### PR TITLE
display: demand propagation — capture pacing, SCK dirty rects default-on, tile-mode encoder standby

### DIFF
--- a/crates/intendant-display/src/aggregator.rs
+++ b/crates/intendant-display/src/aggregator.rs
@@ -68,13 +68,13 @@
 //! wiring at [`crate::DisplaySession::start`] capture the
 //! pool in one place.
 
-use crate::encode::pool::SimulcastRid;
+use crate::encode::pool::{CodecKind, EncoderId, SimulcastRid};
 use crate::webrtc::{PeerLayerHealth, WebRtcPeer};
 use crate::PeerId;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::RwLock;
+use tokio::sync::{Notify, RwLock};
 use tokio::task::JoinHandle;
 use tokio::time::MissedTickBehavior;
 use tokio_util::sync::CancellationToken;
@@ -830,6 +830,78 @@ pub fn compose_effective_wanted(
 /// callers, which would otherwise each spell the boxed-closure type.
 pub type LayerPauseProbe = Box<dyn Fn(&SimulcastRid) -> Option<bool> + Send + Sync>;
 
+/// Injected pool access for the coordinator's **on-demand tile-standby
+/// reconcile** (the on-demand sibling of the `on_action` /
+/// `is_layer_paused` always-on hooks; same closure-injection rationale —
+/// keeps the reconcile pure and testable without a real pool).
+///
+/// The always-on bank's tile standby already falls out of the #48
+/// demanded-layer bound (a standby peer contributes no RIDs). On-demand
+/// slots sit outside that bound — they are lease-refcounted per peer,
+/// keyed `(codec, rid)` — so the coordinator reconciles them separately:
+/// a subscribed slot whose **every** holder is in video standby pauses;
+/// any non-standby holder resumes it (the pool forces a keyframe on the
+/// paused→active edge). Holders are attributed by the peers' frozen
+/// `active_codec` + `active_rids`.
+pub struct OnDemandStandbyHooks {
+    /// Snapshot of on-demand encoder IDs with at least one subscriber.
+    /// Production: [`crate::encode::pool::EncoderPool::subscribed_on_demand_ids`].
+    pub subscribed_ids: Box<dyn Fn() -> Vec<EncoderId> + Send + Sync>,
+    /// Pause-state probe for one slot (`None` = slot gone — e.g. torn
+    /// down between the snapshot and the probe; the reconcile skips it).
+    /// Production: [`crate::encode::pool::EncoderPool::is_layer_paused`].
+    pub is_paused: Box<dyn Fn(&EncoderId) -> Option<bool> + Send + Sync>,
+    /// Apply a pause (`true`) / resume (`false`) to one slot.
+    /// Production: [`crate::encode::pool::EncoderPool::pause_layer`] /
+    /// [`crate::encode::pool::EncoderPool::resume_layer`].
+    pub set_paused: Box<dyn Fn(&EncoderId, bool) + Send + Sync>,
+}
+
+/// Per-peer facts the standby reconcile needs, snapshotted while the
+/// coordinator holds the peers read guard (so the reconcile itself runs
+/// lock-free).
+#[derive(Clone, Debug)]
+pub struct PeerDemandSnapshot {
+    pub video_standby: bool,
+    pub active_codec: CodecKind,
+    pub active_rids: Vec<SimulcastRid>,
+}
+
+/// One reconcile pass over the subscribed on-demand slots (see
+/// [`OnDemandStandbyHooks`]). Pure aside from the injected hooks.
+///
+/// Per slot: holders = peers whose `active_codec` matches the slot's
+/// codec and whose `active_rids` contain the slot's RID. A slot with no
+/// attributable holder is left alone — its lifecycle belongs to the
+/// lease refcount (transient teardown states, or a subscription shape
+/// this attribution cannot see), and pausing an encoder some unseen
+/// consumer relies on would be the starvation bug. Diffed against
+/// actual pool state so an already-converged slot produces no action.
+pub fn reconcile_on_demand_standby(hooks: &OnDemandStandbyHooks, peers: &[PeerDemandSnapshot]) {
+    for id in (hooks.subscribed_ids)() {
+        let mut holders = peers
+            .iter()
+            .filter(|p| p.active_codec == id.codec && p.active_rids.contains(&id.rid))
+            .peekable();
+        if holders.peek().is_none() {
+            continue;
+        }
+        let wanted = holders.any(|p| !p.video_standby);
+        match ((hooks.is_paused)(&id), wanted) {
+            (Some(false), false) => {
+                eprintln!("[layer-policy] PauseOnDemand({id})");
+                (hooks.set_paused)(&id, true);
+            }
+            (Some(true), true) => {
+                eprintln!("[layer-policy] ResumeOnDemand({id})");
+                (hooks.set_paused)(&id, false);
+            }
+            // Converged, or the slot vanished between snapshot and probe.
+            _ => {}
+        }
+    }
+}
+
 /// Spawn the single layer-policy coordinator for one display.
 ///
 /// One task, three policies, one writer. Subscribes to each peer's
@@ -873,6 +945,8 @@ pub fn spawn_layer_policy_coordinator(
     get_current_rids: Box<dyn Fn() -> Vec<SimulcastRid> + Send + Sync>,
     is_layer_paused: LayerPauseProbe,
     on_action: Box<dyn Fn(CapacityAction) + Send + Sync>,
+    on_demand: OnDemandStandbyHooks,
+    demand_kick: Arc<Notify>,
     config: CapacityPolicyConfig,
     shutdown: CancellationToken,
 ) -> JoinHandle<()> {
@@ -910,212 +984,210 @@ pub fn spawn_layer_policy_coordinator(
         loop {
             tokio::select! {
                 _ = shutdown.cancelled() => break,
-                _ = tick.tick() => {
-                    let now = Instant::now();
+                // Interval tick: the steady-state evaluation cadence.
+                _ = tick.tick() => {}
+                // Demand-edge kick from the owning display session
+                // (tile-standby transitions, notably the
+                // `fallback_to_video` edge): run the same evaluation
+                // immediately instead of up to one TICK later, so the
+                // resume (and its forced keyframe) lands before the
+                // browser finishes switching surfaces. Notify has
+                // one-permit semantics, so kick storms coalesce.
+                _ = demand_kick.notified() => {}
+            }
+            let now = Instant::now();
 
-                    // ---- Snapshot peers + advance presence ----
-                    let current_peers = peers.read().await;
-                    let peer_count = current_peers.len();
+            // ---- Snapshot peers + advance presence ----
+            let current_peers = peers.read().await;
+            let peer_count = current_peers.len();
 
-                    presence_state = transition(presence_state, peer_count, now);
-                    let presence_active = !matches!(
-                        presence_state,
-                        AggregatorState::Idle
-                    );
+            presence_state = transition(presence_state, peer_count, now);
+            let presence_active = !matches!(presence_state, AggregatorState::Idle);
 
-                    // ---- Prune per-peer state on zero peers ----
-                    // Reconnects (same PeerId) start fresh: no stale
-                    // TWCC cascade or RR layer state can survive an
-                    // idle window.
-                    if peer_count == 0 {
-                        twcc_subs.clear();
-                        rr_subs.clear();
-                        twcc_state.clear();
-                        rr_state.clear();
-                        prev_measurement_count.clear();
-                    } else {
-                        twcc_subs.retain(|id, _| current_peers.contains_key(id));
-                        rr_subs.retain(|id, _| current_peers.contains_key(id));
-                        for (id, peer) in current_peers.iter() {
-                            twcc_subs
-                                .entry(*id)
-                                .or_insert_with(|| peer.subscribe_twcc_health());
-                            rr_subs
-                                .entry(*id)
-                                .or_insert_with(|| {
-                                    peer.subscribe_remote_inbound_health()
-                                });
-                        }
-                        twcc_state.retain(|pid, _| current_peers.contains_key(pid));
-                        rr_state
-                            .retain(|(pid, _), _| current_peers.contains_key(pid));
-                        prev_measurement_count
-                            .retain(|(pid, _), _| current_peers.contains_key(pid));
-                    }
-
-                    let peer_ids: Vec<PeerId> =
-                        current_peers.keys().cloned().collect();
-                    // #57: per-tick pinned-layer set. Each peer with
-                    // exactly one negotiated RID contributes that RID
-                    // to the pin set, which `compose_effective_wanted`
-                    // unions into the result regardless of TWCC/RR
-                    // loss. Multi-RID peers (`len() > 1`) don't pin —
-                    // they have the floor as fallback. Computed before
-                    // `drop(current_peers)` so we don't re-acquire the
-                    // peers lock just to read this.
-                    let pinned_layers: HashSet<SimulcastRid> = current_peers
-                        .values()
-                        .filter_map(|peer| {
-                            let rids = peer.active_rids();
-                            if rids.len() == 1 {
-                                Some(rids[0].clone())
-                            } else {
-                                None
-                            }
-                        })
-                        .collect();
-                    // #48: per-tick demanded-layer set (union of every
-                    // live peer's negotiated active_rids). The
-                    // composer uses this as a hard upper bound on the
-                    // effective wanted set — layers outside this set
-                    // produce frames no live peer can decode and are
-                    // pure CPU waste. Computed alongside pinned so we
-                    // walk peers once per tick. Zero peers ⇒ empty
-                    // demand ⇒ effective collapses to empty (encoders
-                    // pause immediately).
-                    let demanded_layers: HashSet<SimulcastRid> = current_peers
-                        .values()
-                        .flat_map(|peer| peer.active_rids().iter().cloned())
-                        .collect();
-                    drop(current_peers);
-
-                    // ---- Refresh current_rids; derive floor + upper ----
-                    let current_rids = get_current_rids();
-                    if current_rids.is_empty() {
-                        // No simulcast layers at all — nothing for the
-                        // pool actions to operate on. Per-peer state
-                        // would be meaningless without rids; advance
-                        // presence above and skip the rest.
-                        continue;
-                    }
-                    // Spec order: descending bitrate, last entry is
-                    // floor. Upper = everything before floor.
-                    let floor = current_rids.last().unwrap().clone();
-                    let upper_layers: Vec<SimulcastRid> =
-                        current_rids[..current_rids.len() - 1].to_vec();
-
-                    // ---- Aggregate-TWCC vote ----
-                    // No peers → no restriction (full current set).
-                    // With peers → step each peer's cascade state
-                    // against its current TWCC health, project to
-                    // wanted upper layers, add floor, union across
-                    // peers.
-                    let twcc_union: HashSet<SimulcastRid> = if peer_ids.is_empty() {
-                        current_rids.iter().cloned().collect()
-                    } else {
-                        let mut per_peer: Vec<HashSet<SimulcastRid>> =
-                            Vec::with_capacity(peer_ids.len());
-                        for peer_id in &peer_ids {
-                            let prev = twcc_state
-                                .get(peer_id)
-                                .copied()
-                                .unwrap_or(AggregateLayerCapacity::AllUpperWanted);
-                            // SAFE: peer_subs populated from
-                            // current_peers above; entry exists.
-                            let health =
-                                *twcc_subs.get(peer_id).unwrap().borrow();
-                            let next = step_aggregate_layer_capacity(
-                                prev,
-                                health.as_ref(),
-                                &config,
-                                now,
-                            );
-                            twcc_state.insert(*peer_id, next);
-                            let mut wanted = aggregate_state_wanted_upper_layers(
-                                next,
-                                &upper_layers,
-                            );
-                            wanted.insert(floor.clone());
-                            per_peer.push(wanted);
-                        }
-                        aggregate_wanted_layers(per_peer)
-                    };
-
-                    // ---- Per-RID RR vote ----
-                    // Same shape: no peers → no restriction. Per-peer
-                    // wanted = floor + per-RID Wanted-state-projection
-                    // for non-floor RIDs. Default per-RID state is
-                    // Wanted, so a peer with no RR ever yet votes for
-                    // every layer (no restriction).
-                    let rr_union: HashSet<SimulcastRid> = if peer_ids.is_empty() {
-                        current_rids.iter().cloned().collect()
-                    } else {
-                        let mut per_peer: Vec<HashSet<SimulcastRid>> =
-                            Vec::with_capacity(peer_ids.len());
-                        for peer_id in &peer_ids {
-                            let health_map =
-                                rr_subs.get(peer_id).unwrap().borrow().clone();
-                            let mut peer_wanted: HashSet<SimulcastRid> =
-                                HashSet::new();
-                            peer_wanted.insert(floor.clone());
-                            for rid in &upper_layers {
-                                let key = (*peer_id, rid.clone());
-                                let prev = rr_state
-                                    .get(&key)
-                                    .copied()
-                                    .unwrap_or(LayerCapacityState::Wanted);
-                                let raw_health = health_map.get(rid);
-                                let prev_count = prev_measurement_count
-                                    .get(&key)
-                                    .copied()
-                                    .unwrap_or(0);
-                                let fresh = fresh_health(raw_health, prev_count);
-                                let next = step_layer_capacity_state(
-                                    prev, fresh, &config, now,
-                                );
-                                rr_state.insert(key.clone(), next);
-                                if let Some(h) = raw_health {
-                                    prev_measurement_count.insert(
-                                        key,
-                                        h.round_trip_time_measurements,
-                                    );
-                                }
-                                if layer_state_is_wanted(&next) {
-                                    peer_wanted.insert(rid.clone());
-                                }
-                            }
-                            per_peer.push(peer_wanted);
-                        }
-                        aggregate_wanted_layers(per_peer)
-                    };
-
-                    // ---- Compose + diff + apply ----
-                    let effective_wanted = compose_effective_wanted(
-                        presence_active,
-                        &twcc_union,
-                        &rr_union,
-                        &current_rids,
-                        &pinned_layers,
-                        &demanded_layers,
-                    );
-
-                    let actual_active: HashSet<SimulcastRid> = current_rids
-                        .iter()
-                        .filter(|rid| {
-                            matches!(is_layer_paused(rid), Some(false))
-                        })
-                        .cloned()
-                        .collect();
-
-                    let actions = diff_wanted_aggregate(
-                        &actual_active,
-                        &effective_wanted,
-                        &current_rids,
-                    );
-                    for action in actions {
-                        on_action(action);
-                    }
+            // ---- Prune per-peer state on zero peers ----
+            // Reconnects (same PeerId) start fresh: no stale
+            // TWCC cascade or RR layer state can survive an
+            // idle window.
+            if peer_count == 0 {
+                twcc_subs.clear();
+                rr_subs.clear();
+                twcc_state.clear();
+                rr_state.clear();
+                prev_measurement_count.clear();
+            } else {
+                twcc_subs.retain(|id, _| current_peers.contains_key(id));
+                rr_subs.retain(|id, _| current_peers.contains_key(id));
+                for (id, peer) in current_peers.iter() {
+                    twcc_subs
+                        .entry(*id)
+                        .or_insert_with(|| peer.subscribe_twcc_health());
+                    rr_subs
+                        .entry(*id)
+                        .or_insert_with(|| peer.subscribe_remote_inbound_health());
                 }
+                twcc_state.retain(|pid, _| current_peers.contains_key(pid));
+                rr_state.retain(|(pid, _), _| current_peers.contains_key(pid));
+                prev_measurement_count.retain(|(pid, _), _| current_peers.contains_key(pid));
+            }
+
+            let peer_ids: Vec<PeerId> = current_peers.keys().cloned().collect();
+            // Per-peer demand facts under the read guard: standby
+            // flag + frozen codec/RID identity. Pinned, demanded,
+            // and the on-demand reconcile below all derive from
+            // this one walk.
+            let peer_demand: Vec<PeerDemandSnapshot> = current_peers
+                .values()
+                .map(|peer| PeerDemandSnapshot {
+                    video_standby: peer.video_standby(),
+                    active_codec: peer.active_codec(),
+                    active_rids: peer.active_rids().to_vec(),
+                })
+                .collect();
+            drop(current_peers);
+            // #57: per-tick pinned-layer set. Each peer with
+            // exactly one negotiated RID contributes that RID
+            // to the pin set, which `compose_effective_wanted`
+            // unions into the result regardless of TWCC/RR
+            // loss. Multi-RID peers (`len() > 1`) don't pin —
+            // they have the floor as fallback.
+            //
+            // Tile standby (per-peer video release): a peer whose
+            // client is painting tiles consumes no video encoder
+            // output, so it neither pins nor demands — its layers
+            // pause unless another live, non-standby peer can
+            // consume them, which is exactly the per-peer
+            // isolation the demand bound already provides. It
+            // still counts for presence (the peers map), so the
+            // zero-peer pause semantics are untouched.
+            let pinned_layers: HashSet<SimulcastRid> = peer_demand
+                .iter()
+                .filter(|peer| !peer.video_standby)
+                .filter_map(|peer| {
+                    if peer.active_rids.len() == 1 {
+                        Some(peer.active_rids[0].clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            // #48: per-tick demanded-layer set (union of every
+            // live non-standby peer's negotiated active_rids).
+            // The composer uses this as a hard upper bound on the
+            // effective wanted set — layers outside this set
+            // produce frames no live peer can decode and are
+            // pure CPU waste. Zero peers (or all peers in tile
+            // standby) ⇒ empty demand ⇒ effective collapses to
+            // empty (encoders pause immediately).
+            let demanded_layers: HashSet<SimulcastRid> = peer_demand
+                .iter()
+                .filter(|peer| !peer.video_standby)
+                .flat_map(|peer| peer.active_rids.iter().cloned())
+                .collect();
+
+            // On-demand tile-standby reconcile. Runs before the
+            // `current_rids` empty-bank early-continue: sessions
+            // with an empty always-on bank (synthetic test rigs)
+            // still carry on-demand slots that must pause when
+            // their only holders are on tiles.
+            reconcile_on_demand_standby(&on_demand, &peer_demand);
+
+            // ---- Refresh current_rids; derive floor + upper ----
+            let current_rids = get_current_rids();
+            if current_rids.is_empty() {
+                // No simulcast layers at all — nothing for the
+                // pool actions to operate on. Per-peer state
+                // would be meaningless without rids; advance
+                // presence above and skip the rest.
+                continue;
+            }
+            // Spec order: descending bitrate, last entry is
+            // floor. Upper = everything before floor.
+            let floor = current_rids.last().unwrap().clone();
+            let upper_layers: Vec<SimulcastRid> = current_rids[..current_rids.len() - 1].to_vec();
+
+            // ---- Aggregate-TWCC vote ----
+            // No peers → no restriction (full current set).
+            // With peers → step each peer's cascade state
+            // against its current TWCC health, project to
+            // wanted upper layers, add floor, union across
+            // peers.
+            let twcc_union: HashSet<SimulcastRid> = if peer_ids.is_empty() {
+                current_rids.iter().cloned().collect()
+            } else {
+                let mut per_peer: Vec<HashSet<SimulcastRid>> = Vec::with_capacity(peer_ids.len());
+                for peer_id in &peer_ids {
+                    let prev = twcc_state
+                        .get(peer_id)
+                        .copied()
+                        .unwrap_or(AggregateLayerCapacity::AllUpperWanted);
+                    // SAFE: peer_subs populated from
+                    // current_peers above; entry exists.
+                    let health = *twcc_subs.get(peer_id).unwrap().borrow();
+                    let next = step_aggregate_layer_capacity(prev, health.as_ref(), &config, now);
+                    twcc_state.insert(*peer_id, next);
+                    let mut wanted = aggregate_state_wanted_upper_layers(next, &upper_layers);
+                    wanted.insert(floor.clone());
+                    per_peer.push(wanted);
+                }
+                aggregate_wanted_layers(per_peer)
+            };
+
+            // ---- Per-RID RR vote ----
+            // Same shape: no peers → no restriction. Per-peer
+            // wanted = floor + per-RID Wanted-state-projection
+            // for non-floor RIDs. Default per-RID state is
+            // Wanted, so a peer with no RR ever yet votes for
+            // every layer (no restriction).
+            let rr_union: HashSet<SimulcastRid> = if peer_ids.is_empty() {
+                current_rids.iter().cloned().collect()
+            } else {
+                let mut per_peer: Vec<HashSet<SimulcastRid>> = Vec::with_capacity(peer_ids.len());
+                for peer_id in &peer_ids {
+                    let health_map = rr_subs.get(peer_id).unwrap().borrow().clone();
+                    let mut peer_wanted: HashSet<SimulcastRid> = HashSet::new();
+                    peer_wanted.insert(floor.clone());
+                    for rid in &upper_layers {
+                        let key = (*peer_id, rid.clone());
+                        let prev = rr_state
+                            .get(&key)
+                            .copied()
+                            .unwrap_or(LayerCapacityState::Wanted);
+                        let raw_health = health_map.get(rid);
+                        let prev_count = prev_measurement_count.get(&key).copied().unwrap_or(0);
+                        let fresh = fresh_health(raw_health, prev_count);
+                        let next = step_layer_capacity_state(prev, fresh, &config, now);
+                        rr_state.insert(key.clone(), next);
+                        if let Some(h) = raw_health {
+                            prev_measurement_count.insert(key, h.round_trip_time_measurements);
+                        }
+                        if layer_state_is_wanted(&next) {
+                            peer_wanted.insert(rid.clone());
+                        }
+                    }
+                    per_peer.push(peer_wanted);
+                }
+                aggregate_wanted_layers(per_peer)
+            };
+
+            // ---- Compose + diff + apply ----
+            let effective_wanted = compose_effective_wanted(
+                presence_active,
+                &twcc_union,
+                &rr_union,
+                &current_rids,
+                &pinned_layers,
+                &demanded_layers,
+            );
+
+            let actual_active: HashSet<SimulcastRid> = current_rids
+                .iter()
+                .filter(|rid| matches!(is_layer_paused(rid), Some(false)))
+                .cloned()
+                .collect();
+
+            let actions = diff_wanted_aggregate(&actual_active, &effective_wanted, &current_rids);
+            for action in actions {
+                on_action(action);
             }
         }
     })
@@ -2576,6 +2648,231 @@ mod tests {
 
     // ----- spawn_layer_policy_coordinator -----
 
+    /// Inert on-demand hooks for coordinator tests that only exercise
+    /// the always-on policy surface.
+    fn inert_on_demand_hooks() -> OnDemandStandbyHooks {
+        OnDemandStandbyHooks {
+            subscribed_ids: Box::new(Vec::new),
+            is_paused: Box::new(|_| None),
+            set_paused: Box::new(|_, _| {}),
+        }
+    }
+
+    // ----- tile-standby: on-demand reconcile (pure) -----
+
+    /// Recording hooks over a shared fake pause-state map, so reconcile
+    /// actions converge exactly like they would against the real pool.
+    struct RecordingOnDemand {
+        hooks: OnDemandStandbyHooks,
+        actions: Arc<std::sync::Mutex<Vec<(EncoderId, bool)>>>,
+    }
+
+    fn recording_on_demand_hooks(
+        ids: Vec<EncoderId>,
+        initially_paused: HashSet<EncoderId>,
+    ) -> RecordingOnDemand {
+        let actions: Arc<std::sync::Mutex<Vec<(EncoderId, bool)>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+        let paused = Arc::new(std::sync::Mutex::new(initially_paused));
+        let paused_probe = Arc::clone(&paused);
+        let paused_apply = Arc::clone(&paused);
+        let actions_apply = Arc::clone(&actions);
+        RecordingOnDemand {
+            hooks: OnDemandStandbyHooks {
+                subscribed_ids: Box::new(move || ids.clone()),
+                is_paused: Box::new(move |id| Some(paused_probe.lock().unwrap().contains(id))),
+                set_paused: Box::new(move |id, pause| {
+                    if pause {
+                        paused_apply.lock().unwrap().insert(id.clone());
+                    } else {
+                        paused_apply.lock().unwrap().remove(id);
+                    }
+                    actions_apply.lock().unwrap().push((id.clone(), pause));
+                }),
+            },
+            actions,
+        }
+    }
+
+    fn h264_fed_id() -> EncoderId {
+        EncoderId::new(CodecKind::H264, SimulcastRid::federated())
+    }
+
+    fn snapshot(standby: bool, codec: CodecKind, rids: Vec<SimulcastRid>) -> PeerDemandSnapshot {
+        PeerDemandSnapshot {
+            video_standby: standby,
+            active_codec: codec,
+            active_rids: rids,
+        }
+    }
+
+    /// A subscribed on-demand slot whose only holder is on tiles pauses;
+    /// a second reconcile pass with unchanged inputs is convergent (no
+    /// duplicate action).
+    #[test]
+    fn on_demand_reconcile_pauses_when_all_holders_standby() {
+        let rec = recording_on_demand_hooks(vec![h264_fed_id()], HashSet::new());
+        let peers = vec![snapshot(
+            true,
+            CodecKind::H264,
+            vec![SimulcastRid::federated()],
+        )];
+        reconcile_on_demand_standby(&rec.hooks, &peers);
+        reconcile_on_demand_standby(&rec.hooks, &peers);
+        assert_eq!(
+            rec.actions.lock().unwrap().clone(),
+            vec![(h264_fed_id(), true)],
+            "one pause on the edge, none on the converged pass"
+        );
+    }
+
+    /// Any non-standby holder keeps a shared slot running (peer-level
+    /// isolation: one tile viewer must not starve a video viewer of the
+    /// same on-demand encoder), and resumes it if it was paused.
+    #[test]
+    fn on_demand_reconcile_keeps_slot_for_non_standby_holder() {
+        // Not paused + one active holder → untouched.
+        let rec = recording_on_demand_hooks(vec![h264_fed_id()], HashSet::new());
+        let peers = vec![
+            snapshot(true, CodecKind::H264, vec![SimulcastRid::federated()]),
+            snapshot(false, CodecKind::H264, vec![SimulcastRid::federated()]),
+        ];
+        reconcile_on_demand_standby(&rec.hooks, &peers);
+        assert!(rec.actions.lock().unwrap().is_empty());
+
+        // Paused (standby engaged earlier) + a holder leaves standby →
+        // resume. The pool's paused→active edge forces a keyframe
+        // (pinned by `pool_resume_layer_from_paused_sets_force_keyframe`),
+        // which is what the fallback-to-video SLA rides on.
+        let paused: HashSet<EncoderId> = std::iter::once(h264_fed_id()).collect();
+        let rec = recording_on_demand_hooks(vec![h264_fed_id()], paused);
+        reconcile_on_demand_standby(&rec.hooks, &peers);
+        assert_eq!(
+            rec.actions.lock().unwrap().clone(),
+            vec![(h264_fed_id(), false)],
+        );
+    }
+
+    /// A slot with no attributable holder is left alone — its lifecycle
+    /// belongs to the lease refcount, and pausing an encoder an unseen
+    /// consumer relies on would be the starvation bug. Codec and RID
+    /// must both match for attribution.
+    #[test]
+    fn on_demand_reconcile_skips_unattributed_slots() {
+        let rec = recording_on_demand_hooks(vec![h264_fed_id()], HashSet::new());
+        // Standby peer on a DIFFERENT codec/rid: not a holder.
+        let peers = vec![snapshot(
+            true,
+            CodecKind::Vp8,
+            vec![SimulcastRid::quarter()],
+        )];
+        reconcile_on_demand_standby(&rec.hooks, &peers);
+        // Zero peers at all: also untouched.
+        reconcile_on_demand_standby(&rec.hooks, &[]);
+        assert!(rec.actions.lock().unwrap().is_empty());
+    }
+
+    // ----- tile-standby: coordinator demand mask -----
+
+    /// End-to-end through the spawned coordinator: a tile-standby peer
+    /// contributes nothing to the demanded bound, so its only layer
+    /// pauses while a second (non-standby) peer's layer stays active;
+    /// clearing standby + kicking resumes it. This is the per-peer RTP
+    /// standby seam for the always-on bank.
+    #[tokio::test]
+    async fn spawn_coordinator_standby_peer_releases_only_its_layers() {
+        use std::sync::Mutex as StdMutex;
+
+        let peers: Arc<RwLock<HashMap<PeerId, Arc<WebRtcPeer>>>> =
+            Arc::new(RwLock::new(HashMap::new()));
+        // Peer 1: local viewer on `f`. Peer 2: federated tile viewer on
+        // `q`, starting in video standby.
+        let local = Arc::new(WebRtcPeer::new_for_test(1, vec![SimulcastRid::full()]));
+        let federated = Arc::new(WebRtcPeer::new_for_test(2, vec![SimulcastRid::quarter()]));
+        federated.set_video_standby(true);
+        peers.write().await.insert(1, Arc::clone(&local));
+        peers.write().await.insert(2, Arc::clone(&federated));
+
+        let paused: Arc<StdMutex<HashSet<SimulcastRid>>> = Arc::new(StdMutex::new(HashSet::new()));
+        let paused_for_action = Arc::clone(&paused);
+        let on_action: Box<dyn Fn(CapacityAction) + Send + Sync> = Box::new(move |a| match a {
+            CapacityAction::PauseLayer(rid) => {
+                paused_for_action.lock().unwrap().insert(rid);
+            }
+            CapacityAction::ResumeLayer(rid) => {
+                paused_for_action.lock().unwrap().remove(&rid);
+            }
+        });
+        let get_current_rids: Box<dyn Fn() -> Vec<SimulcastRid> + Send + Sync> =
+            Box::new(vp8_three_layer_set);
+        let paused_for_probe = Arc::clone(&paused);
+        let is_layer_paused: LayerPauseProbe =
+            Box::new(move |rid| Some(paused_for_probe.lock().unwrap().contains(rid)));
+
+        let kick = Arc::new(Notify::new());
+        let shutdown = CancellationToken::new();
+        let handle = spawn_layer_policy_coordinator(
+            Arc::clone(&peers),
+            get_current_rids,
+            is_layer_paused,
+            on_action,
+            inert_on_demand_hooks(),
+            Arc::clone(&kick),
+            CapacityPolicyConfig::default(),
+            shutdown.clone(),
+        );
+
+        // Converge: standby q-peer demands nothing, local f-peer keeps
+        // f — so exactly {h, q} pause.
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            {
+                let p = paused.lock().unwrap();
+                if p.contains(&SimulcastRid::quarter())
+                    && p.contains(&SimulcastRid::half())
+                    && !p.contains(&SimulcastRid::full())
+                {
+                    break;
+                }
+            }
+            if Instant::now() >= deadline {
+                let p = paused.lock().unwrap().clone();
+                shutdown.cancel();
+                let _ = handle.await;
+                panic!("standby peer's q (and undemanded h) must pause while f stays: {p:?}");
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        // Fallback edge: standby clears + kick → q resumes (f untouched,
+        // h stays paused — still undemanded).
+        federated.set_video_standby(false);
+        kick.notify_one();
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            {
+                let p = paused.lock().unwrap();
+                if !p.contains(&SimulcastRid::quarter()) && !p.contains(&SimulcastRid::full()) {
+                    assert!(
+                        p.contains(&SimulcastRid::half()),
+                        "h stays paused: no peer demands it"
+                    );
+                    break;
+                }
+            }
+            if Instant::now() >= deadline {
+                let p = paused.lock().unwrap().clone();
+                shutdown.cancel();
+                let _ = handle.await;
+                panic!("clearing standby + kick must resume q: {p:?}");
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        shutdown.cancel();
+        let _ = handle.await;
+    }
+
     /// **Spawn-loop smoke test**: drive the coordinator through one
     /// `PAUSE_DEBOUNCE` window with no peers and verify it emits
     /// the expected `PauseLayer` actions when the presence policy
@@ -2624,6 +2921,8 @@ mod tests {
             get_current_rids,
             is_layer_paused,
             on_action,
+            inert_on_demand_hooks(),
+            Arc::new(Notify::new()),
             CapacityPolicyConfig::default(),
             shutdown.clone(),
         );
@@ -2727,6 +3026,8 @@ mod tests {
             get_current_rids,
             is_layer_paused,
             on_action,
+            inert_on_demand_hooks(),
+            Arc::new(Notify::new()),
             CapacityPolicyConfig::default(),
             shutdown.clone(),
         );

--- a/crates/intendant-display/src/aggregator.rs
+++ b/crates/intendant-display/src/aggregator.rs
@@ -850,12 +850,20 @@ pub struct OnDemandStandbyHooks {
     /// Pause-state probe for one slot (`None` = slot gone — e.g. torn
     /// down between the snapshot and the probe; the reconcile skips it).
     /// Production: [`crate::encode::pool::EncoderPool::is_layer_paused`].
-    pub is_paused: Box<dyn Fn(&EncoderId) -> Option<bool> + Send + Sync>,
+    pub is_paused: OnDemandPauseProbe,
     /// Apply a pause (`true`) / resume (`false`) to one slot.
     /// Production: [`crate::encode::pool::EncoderPool::pause_layer`] /
     /// [`crate::encode::pool::EncoderPool::resume_layer`].
-    pub set_paused: Box<dyn Fn(&EncoderId, bool) + Send + Sync>,
+    pub set_paused: OnDemandPauseAction,
 }
+
+/// Pause-state probe for one on-demand slot — the `(codec, rid)`-keyed
+/// sibling of [`LayerPauseProbe`]. `None` = the pool no longer knows the
+/// slot.
+pub type OnDemandPauseProbe = Box<dyn Fn(&EncoderId) -> Option<bool> + Send + Sync>;
+
+/// Apply a pause (`true`) / resume (`false`) to one on-demand slot.
+pub type OnDemandPauseAction = Box<dyn Fn(&EncoderId, bool) + Send + Sync>;
 
 /// Per-peer facts the standby reconcile needs, snapshotted while the
 /// coordinator holds the peers read guard (so the reconcile itself runs
@@ -940,6 +948,7 @@ pub fn reconcile_on_demand_standby(hooks: &OnDemandStandbyHooks, peers: &[PeerDe
 /// (default 0.05 / 0.02 / 5 s drop / 1 s restore).
 ///
 /// Returned `JoinHandle` exits cleanly on `shutdown.cancelled()`.
+#[allow(clippy::too_many_arguments)] // injected-dependency seam: each param is a distinct policy input, not a bundle
 pub fn spawn_layer_policy_coordinator(
     peers: Arc<RwLock<HashMap<PeerId, Arc<WebRtcPeer>>>>,
     get_current_rids: Box<dyn Fn() -> Vec<SimulcastRid> + Send + Sync>,

--- a/crates/intendant-display/src/capture/mod.rs
+++ b/crates/intendant-display/src/capture/mod.rs
@@ -12,6 +12,7 @@
 
 pub mod damage;
 pub mod frame_diff;
+pub mod pacing;
 
 #[cfg(target_os = "linux")]
 pub mod x11_damage;

--- a/crates/intendant-display/src/capture/pacing.rs
+++ b/crates/intendant-display/src/capture/pacing.rs
@@ -1,0 +1,307 @@
+//! Demand-aware pacing for polling capture backends.
+//!
+//! Polling backends (X11 XShm/XGetImage, the synthetic test card) copy the
+//! entire screen every frame interval whether or not anything downstream
+//! consumes the result — at 1080p30 that is ~249 MB/s of memory traffic
+//! before any conversion or encode happens. The F2 idle gate already stops
+//! the BGRA→I420 conversion when the encoder pool has no active consumer,
+//! but the capture copy itself stayed demand-blind.
+//!
+//! This module gives those backends a **demand probe** and a shared pacing
+//! helper:
+//!
+//! - While the probe reports demand, the capture loop paces at the full
+//!   configured frame interval (unchanged behavior).
+//! - While it reports no demand, the loop drops to a slow **keepalive**
+//!   cadence ([`CAPTURE_KEEPALIVE_INTERVAL`], 1 fps) instead of stopping.
+//!   A stopped capture would have cold-start latency (thread + SHM segment
+//!   re-setup on X11) and would break `latest_frame` consumers outright —
+//!   the 1 Hz keepalive keeps `latest_frame` fresh enough for an instant
+//!   first paint, a ≤1 s-stale screenshot, and the FrameRegistry's 1 Hz
+//!   model-feed sampler, which is exactly why the floor is 1 fps and not
+//!   slower. Rate reduction, never a stop.
+//! - The keepalive sleep is sliced ([`DEMAND_POLL_SLICE`]) and re-checks
+//!   the probe each slice, so the moment demand appears (peer join burst,
+//!   tile subscriber registration, an external frame consumer) the loop
+//!   wakes within one slice and resumes full rate — while still honoring
+//!   the full-rate interval as a floor so a wake edge never captures
+//!   faster than the configured fps.
+//!
+//! The probe itself is composed by [`crate::DisplaySession::start`] from the
+//! session's demand sources; backends only evaluate it. A backend with no
+//! probe installed captures at full rate (fail open — pacing is a CPU
+//! optimization, never a correctness gate).
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
+
+/// Composite demand signal evaluated by a capture loop before each pace.
+/// `true` = capture at full rate; `false` = keepalive cadence. Must be
+/// cheap and non-blocking: it runs on the capture thread up to once per
+/// [`DEMAND_POLL_SLICE`].
+pub type CaptureDemandProbe = Arc<dyn Fn() -> bool + Send + Sync>;
+
+/// Keepalive capture cadence while nothing consumes frames. 1 fps keeps
+/// `latest_frame` at most ~1 s stale — fresh enough for the FrameRegistry's
+/// 1 Hz sampler and an instant first paint on demand restore — while
+/// reducing the idle full-screen copy cost by the configured-fps factor.
+pub const CAPTURE_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(1);
+
+/// How often a keepalive sleep re-checks the demand probe (and the
+/// backend's shutdown flag). Bounds both the demand-restore wake latency
+/// and the added `stop_capture` join latency to one slice.
+pub const DEMAND_POLL_SLICE: Duration = Duration::from_millis(50);
+
+/// Which cadence one [`pace_capture_interval`] call paced at. Returned so
+/// capture loops can adapt side behavior (the X11 loop widens its
+/// geometry re-check to every keepalive frame) and so tests can observe
+/// pacing transitions without wall-clock rate measurements.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PaceMode {
+    /// Demand present: paced at the configured frame interval.
+    Full,
+    /// No demand: paced at the keepalive cadence (possibly cut short by a
+    /// demand wake edge).
+    Keepalive,
+}
+
+/// Per-backend slot holding the installed demand probe plus pace-mode
+/// counters (the observability seam pacing tests assert against).
+///
+/// Shared between the backend handle (which installs/clears probes from
+/// [`crate::DisplayBackend::set_capture_demand_probe`] / `stop_capture`)
+/// and the capture thread (which evaluates it). A `std` `RwLock` is
+/// correct on the capture thread: writes are rare (install/clear), reads
+/// are a cheap uncontended lock per pace slice.
+#[derive(Default)]
+pub struct DemandProbeSlot {
+    probe: RwLock<Option<CaptureDemandProbe>>,
+    /// Paces taken at the full frame interval. Monotonic across capture
+    /// sessions of the owning backend.
+    full_paces: AtomicU64,
+    /// Paces taken at the keepalive cadence (including ones a demand wake
+    /// cut short).
+    keepalive_paces: AtomicU64,
+}
+
+impl DemandProbeSlot {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Install (or replace) the demand probe. Takes effect on the capture
+    /// loop's next pace.
+    pub fn install(&self, probe: CaptureDemandProbe) {
+        *self.probe.write().unwrap_or_else(|e| e.into_inner()) = Some(probe);
+    }
+
+    /// Remove the installed probe; the capture loop reverts to full-rate
+    /// pacing (the fail-open default). Called from `stop_capture` so a
+    /// later `start_capture` never paces a fresh session off a previous
+    /// session's stale demand sources.
+    pub fn clear(&self) {
+        *self.probe.write().unwrap_or_else(|e| e.into_inner()) = None;
+    }
+
+    /// Evaluate demand. No probe installed = demand (full rate).
+    pub fn demanded(&self) -> bool {
+        match self
+            .probe
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .as_ref()
+        {
+            Some(probe) => probe(),
+            None => true,
+        }
+    }
+
+    /// Total paces taken at the full frame interval.
+    pub fn full_paces(&self) -> u64 {
+        self.full_paces.load(Ordering::Relaxed)
+    }
+
+    /// Total paces taken at the keepalive cadence.
+    pub fn keepalive_paces(&self) -> u64 {
+        self.keepalive_paces.load(Ordering::Relaxed)
+    }
+}
+
+/// Sleep out the remainder of one capture interval, demand-aware. Blocking
+/// — call from the dedicated capture thread only.
+///
+/// With demand: sleeps `frame_interval - elapsed` (the pre-pacing
+/// behavior, unchanged). Without demand: sleeps toward
+/// `started + CAPTURE_KEEPALIVE_INTERVAL` in [`DEMAND_POLL_SLICE`] slices,
+/// re-checking `shutdown` and the probe each slice; a demand edge ends the
+/// keepalive early but still honors `frame_interval` as a floor so the
+/// wake-edge capture is never faster than the configured fps.
+///
+/// Returns the [`PaceMode`] used, chosen from the probe **once** at entry
+/// (a mid-sleep demand drop finishes the current full-rate pace; the next
+/// pace goes keepalive — cheap, and avoids mode flapping inside one
+/// interval).
+pub fn pace_capture_interval(
+    slot: &DemandProbeSlot,
+    shutdown: &AtomicBool,
+    started: Instant,
+    frame_interval: Duration,
+) -> PaceMode {
+    if slot.demanded() {
+        slot.full_paces.fetch_add(1, Ordering::Relaxed);
+        let elapsed = started.elapsed();
+        if elapsed < frame_interval {
+            std::thread::sleep(frame_interval - elapsed);
+        }
+        return PaceMode::Full;
+    }
+
+    slot.keepalive_paces.fetch_add(1, Ordering::Relaxed);
+    // Keepalive never paces faster than the configured frame interval
+    // (guards a pathological fps < 1 configuration where the frame
+    // interval exceeds the keepalive interval).
+    let deadline = started + CAPTURE_KEEPALIVE_INTERVAL.max(frame_interval);
+    let full_rate_floor = started + frame_interval;
+    loop {
+        if shutdown.load(Ordering::SeqCst) {
+            return PaceMode::Keepalive;
+        }
+        let now = Instant::now();
+        if now >= deadline {
+            return PaceMode::Keepalive;
+        }
+        // Demand wake edge: resume immediately, but not faster than the
+        // full-rate interval since the last capture.
+        if slot.demanded() {
+            if now < full_rate_floor {
+                std::thread::sleep(full_rate_floor - now);
+            }
+            return PaceMode::Keepalive;
+        }
+        let slice = DEMAND_POLL_SLICE.min(deadline - now);
+        std::thread::sleep(slice);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn probe(value: Arc<AtomicBool>) -> CaptureDemandProbe {
+        Arc::new(move || value.load(Ordering::SeqCst))
+    }
+
+    #[test]
+    fn no_probe_defaults_to_full_rate() {
+        let slot = DemandProbeSlot::new();
+        assert!(slot.demanded(), "missing probe must fail open to demand");
+        let shutdown = AtomicBool::new(false);
+        let started = Instant::now();
+        let mode = pace_capture_interval(&slot, &shutdown, started, Duration::from_millis(5));
+        assert_eq!(mode, PaceMode::Full);
+        assert_eq!(slot.full_paces(), 1);
+        assert_eq!(slot.keepalive_paces(), 0);
+    }
+
+    #[test]
+    fn cleared_probe_reverts_to_full_rate() {
+        let slot = DemandProbeSlot::new();
+        slot.install(Arc::new(|| false));
+        assert!(!slot.demanded());
+        slot.clear();
+        assert!(
+            slot.demanded(),
+            "clear() must restore the fail-open default"
+        );
+    }
+
+    #[test]
+    fn demand_paces_at_frame_interval() {
+        let slot = DemandProbeSlot::new();
+        slot.install(Arc::new(|| true));
+        let shutdown = AtomicBool::new(false);
+        let interval = Duration::from_millis(20);
+        let started = Instant::now();
+        let mode = pace_capture_interval(&slot, &shutdown, started, interval);
+        assert_eq!(mode, PaceMode::Full);
+        assert!(
+            started.elapsed() >= interval,
+            "full-rate pace must sleep out the frame interval"
+        );
+        // Well under the keepalive interval: demand must not slow capture.
+        assert!(started.elapsed() < CAPTURE_KEEPALIVE_INTERVAL / 2);
+    }
+
+    #[test]
+    fn no_demand_paces_at_keepalive_interval() {
+        let slot = DemandProbeSlot::new();
+        slot.install(Arc::new(|| false));
+        let shutdown = AtomicBool::new(false);
+        let interval = Duration::from_millis(10);
+        let started = Instant::now();
+        let mode = pace_capture_interval(&slot, &shutdown, started, interval);
+        assert_eq!(mode, PaceMode::Keepalive);
+        assert_eq!(slot.keepalive_paces(), 1);
+        // The whole keepalive interval elapsed (no demand ever appeared).
+        assert!(
+            started.elapsed() >= CAPTURE_KEEPALIVE_INTERVAL,
+            "idle pace must cover the keepalive interval, got {:?}",
+            started.elapsed()
+        );
+    }
+
+    #[test]
+    fn demand_edge_wakes_keepalive_within_slices() {
+        let slot = Arc::new(DemandProbeSlot::new());
+        let demand = Arc::new(AtomicBool::new(false));
+        slot.install(probe(Arc::clone(&demand)));
+        let shutdown = AtomicBool::new(false);
+        let interval = Duration::from_millis(10);
+
+        // Flip demand on shortly after the pace starts; the sliced sleep
+        // must notice long before the 1 s keepalive deadline.
+        let flipper = {
+            let demand = Arc::clone(&demand);
+            std::thread::spawn(move || {
+                std::thread::sleep(Duration::from_millis(80));
+                demand.store(true, Ordering::SeqCst);
+            })
+        };
+        let started = Instant::now();
+        let mode = pace_capture_interval(&slot, &shutdown, started, interval);
+        flipper.join().unwrap();
+        assert_eq!(mode, PaceMode::Keepalive);
+        let woke_after = started.elapsed();
+        assert!(
+            woke_after < Duration::from_millis(500),
+            "demand edge must cut the keepalive sleep short (woke after {woke_after:?})"
+        );
+        assert!(
+            woke_after >= interval,
+            "wake edge must still honor the full-rate floor"
+        );
+    }
+
+    #[test]
+    fn shutdown_edge_exits_keepalive_promptly() {
+        let slot = Arc::new(DemandProbeSlot::new());
+        slot.install(Arc::new(|| false));
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let stopper = {
+            let shutdown = Arc::clone(&shutdown);
+            std::thread::spawn(move || {
+                std::thread::sleep(Duration::from_millis(60));
+                shutdown.store(true, Ordering::SeqCst);
+            })
+        };
+        let started = Instant::now();
+        let mode = pace_capture_interval(&slot, &shutdown, started, Duration::from_millis(10));
+        stopper.join().unwrap();
+        assert_eq!(mode, PaceMode::Keepalive);
+        assert!(
+            started.elapsed() < Duration::from_millis(500),
+            "shutdown must not wait out the keepalive interval"
+        );
+    }
+}

--- a/crates/intendant-display/src/encode/pool/mod.rs
+++ b/crates/intendant-display/src/encode/pool/mod.rs
@@ -1164,6 +1164,27 @@ impl EncoderPool {
             .collect()
     }
 
+    /// Snapshot the on-demand encoder IDs that currently have at least
+    /// one subscriber (`refcount > 0`) — the same active-encoder
+    /// universe [`Self::request_keyframe_all`] targets on the on-demand
+    /// side. Refcount-zero slots mid-teardown are excluded.
+    ///
+    /// Used by the layer-policy coordinator's tile-standby reconcile:
+    /// unlike the always-on bank (whose pause/resume the coordinator
+    /// already drives via the demanded-layer bound), on-demand slots
+    /// are lifecycle-tied to leases, so the coordinator needs their
+    /// live set to decide which slots every holder has put in video
+    /// standby. Returns a `Vec` (not a borrow) so callers never hold
+    /// the on-demand mutex across their loop body.
+    pub fn subscribed_on_demand_ids(&self) -> Vec<EncoderId> {
+        let on_demand = self.inner.on_demand.lock().unwrap();
+        on_demand
+            .iter()
+            .filter(|(_, slot)| slot.refcount > 0)
+            .map(|(id, _)| id.clone())
+            .collect()
+    }
+
     /// **Phase 4d.0**: pause one encoder slot, identified by
     /// `(codec, rid)`. The slot's encoder thread keeps running and
     /// keeps draining its `i420_rx` broadcast subscription (so the
@@ -3424,6 +3445,46 @@ mod tests {
         assert!(
             pool.has_active_consumer(),
             "a single resumed layer re-establishes demand"
+        );
+    }
+
+    /// Tile-standby contract on the on-demand side: a paused on-demand
+    /// slot with a live subscriber is NOT an active consumer (so the
+    /// pool-feed bridge's F2 gate stops converting for a tile-only
+    /// session), while `subscribed_on_demand_ids` keeps listing it (the
+    /// lease — and therefore the encoder slot — is held through
+    /// standby; resume is a flag flip + forced keyframe, not an
+    /// encoder respawn).
+    #[tokio::test]
+    async fn paused_on_demand_slot_is_not_an_active_consumer_but_stays_subscribed() {
+        let pool = EncoderPool::new(64, 64, 30, |_, _| vec![], None);
+        assert!(pool.subscribed_on_demand_ids().is_empty());
+        assert!(!pool.has_active_consumer());
+
+        let prefs = PeerCodecPreferences::new(vec![CodecKind::Vp8]);
+        let (_subs, lease) = pool.subscribe(&prefs).expect("subscribe");
+        let id = EncoderId::new(CodecKind::Vp8, SimulcastRid::full());
+        assert_eq!(pool.subscribed_on_demand_ids(), vec![id.clone()]);
+        assert!(pool.has_active_consumer());
+
+        assert!(pool.pause_layer(id.codec, id.rid.clone()));
+        assert!(
+            !pool.has_active_consumer(),
+            "a paused on-demand slot must not count as demand"
+        );
+        assert_eq!(
+            pool.subscribed_on_demand_ids(),
+            vec![id.clone()],
+            "standby holds the subscription; only the pause flag flips"
+        );
+
+        assert!(pool.resume_layer(id.codec, id.rid.clone()));
+        assert!(pool.has_active_consumer());
+
+        drop(lease);
+        assert!(
+            pool.subscribed_on_demand_ids().is_empty(),
+            "refcount-zero teardown must drop the slot from the listing"
         );
     }
 

--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -1317,6 +1317,21 @@ const PEER_JOIN_BURST: Duration = Duration::from_millis(1500);
 /// screenshot doesn't hold full-rate capture for long.
 const EXTERNAL_FRAME_DEMAND_WINDOW: Duration = Duration::from_secs(3);
 
+/// Stamp the capture demand probe's burst deadline to
+/// `now + PEER_JOIN_BURST`, expressed as milliseconds since
+/// `session_epoch` (an `Instant` cannot live in an atomic). Shared by
+/// [`DisplaySession::signal_peer_join_burst`] and the tile bridge's
+/// `fallback_to_video` edge so the two burst writers cannot drift.
+fn stamp_capture_burst(burst_until_ms: &AtomicU64, session_epoch: Instant) {
+    let now_ms = Instant::now()
+        .saturating_duration_since(session_epoch)
+        .as_millis() as u64;
+    burst_until_ms.store(
+        now_ms.saturating_add(PEER_JOIN_BURST.as_millis() as u64),
+        Ordering::Relaxed,
+    );
+}
+
 fn tile_delta_min_interval() -> Duration {
     Duration::from_millis(1_000 / TILE_DELTA_TARGET_FPS as u64)
 }
@@ -3005,11 +3020,7 @@ impl DisplaySession {
         // frames need capturing at full rate even before the layer
         // policy's resume lands), and the probe runs on the capture
         // thread where the bridge task's local window is unreachable.
-        self.capture_burst_until_ms.store(
-            self.session_ms_now()
-                .saturating_add(PEER_JOIN_BURST.as_millis() as u64),
-            Ordering::Relaxed,
-        );
+        stamp_capture_burst(&self.capture_burst_until_ms, self.session_epoch);
         if let Some(tx) = self.pool_feed_keyframe_tx.lock().await.as_ref() {
             let _ = tx.send(());
         }
@@ -4645,47 +4656,58 @@ mod tests {
     ) -> (
         Arc<RwLock<HashMap<PeerId, Arc<webrtc::WebRtcPeer>>>>,
         Arc<RwLock<HashSet<PeerId>>>,
+        Arc<AtomicUsize>,
         Arc<DisplayMetricsCounters>,
         Arc<webrtc::WebRtcPeer>,
     ) {
         let peer = Arc::new(webrtc::WebRtcPeer::new_for_test(peer_id, Vec::new()));
         let peers = Arc::new(RwLock::new(HashMap::from([(peer_id, Arc::clone(&peer))])));
         let tile_subscribers = Arc::new(RwLock::new(HashSet::from([peer_id])));
+        let tile_gauge = Arc::new(AtomicUsize::new(1));
         let counters = Arc::new(DisplayMetricsCounters::new());
         counters.peer_count.store(1, Ordering::Relaxed);
-        (peers, tile_subscribers, counters, peer)
+        (peers, tile_subscribers, tile_gauge, counters, peer)
     }
 
     #[tokio::test]
     async fn reap_removes_the_registered_peer_and_decrements_the_gauge() {
-        let (peers, subs, counters, peer) = reaper_fixture(7);
-        assert!(reap_peer_registration(&peers, &subs, &counters, 7, &peer).await);
+        let (peers, subs, tile_gauge, counters, peer) = reaper_fixture(7);
+        assert!(reap_peer_registration(&peers, &subs, &tile_gauge, &counters, 7, &peer).await);
         assert!(peers.read().await.is_empty());
         assert!(subs.read().await.is_empty());
+        assert_eq!(
+            tile_gauge.load(Ordering::Relaxed),
+            0,
+            "reap must keep the tile-subscriber gauge in lockstep with the set"
+        );
         assert_eq!(counters.peer_count.load(Ordering::Relaxed), 0);
     }
 
     #[tokio::test]
     async fn reap_leaves_a_replacement_peer_registered_under_the_same_id() {
-        let (peers, subs, counters, old_peer) = reaper_fixture(7);
+        let (peers, subs, tile_gauge, counters, old_peer) = reaper_fixture(7);
         let replacement = Arc::new(webrtc::WebRtcPeer::new_for_test(7, Vec::new()));
         peers.write().await.insert(7, Arc::clone(&replacement));
-        assert!(!reap_peer_registration(&peers, &subs, &counters, 7, &old_peer).await);
+        assert!(
+            !reap_peer_registration(&peers, &subs, &tile_gauge, &counters, 7, &old_peer).await
+        );
         assert!(Arc::ptr_eq(
             peers.read().await.get(&7).expect("replacement stays"),
             &replacement
         ));
         assert!(subs.read().await.contains(&7));
+        assert_eq!(tile_gauge.load(Ordering::Relaxed), 1);
         assert_eq!(counters.peer_count.load(Ordering::Relaxed), 1);
     }
 
     #[tokio::test]
     async fn reap_is_a_no_op_after_remove_peer_already_deregistered() {
-        let (peers, subs, counters, peer) = reaper_fixture(7);
+        let (peers, subs, tile_gauge, counters, peer) = reaper_fixture(7);
         peers.write().await.remove(&7);
         subs.write().await.remove(&7);
+        tile_gauge.store(0, Ordering::Relaxed);
         counters.peer_count.store(0, Ordering::Relaxed);
-        assert!(!reap_peer_registration(&peers, &subs, &counters, 7, &peer).await);
+        assert!(!reap_peer_registration(&peers, &subs, &tile_gauge, &counters, 7, &peer).await);
         assert_eq!(counters.peer_count.load(Ordering::Relaxed), 0);
     }
 

--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -4688,9 +4688,7 @@ mod tests {
         let (peers, subs, tile_gauge, counters, old_peer) = reaper_fixture(7);
         let replacement = Arc::new(webrtc::WebRtcPeer::new_for_test(7, Vec::new()));
         peers.write().await.insert(7, Arc::clone(&replacement));
-        assert!(
-            !reap_peer_registration(&peers, &subs, &tile_gauge, &counters, 7, &old_peer).await
-        );
+        assert!(!reap_peer_registration(&peers, &subs, &tile_gauge, &counters, 7, &old_peer).await);
         assert!(Arc::ptr_eq(
             peers.read().await.get(&7).expect("replacement stays"),
             &replacement

--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -3413,13 +3413,9 @@ impl DisplaySession {
                                     if let Some(pool) = pool_for_fallback.as_ref() {
                                         pool.request_keyframe_all();
                                     }
-                                    capture_burst_until_ms.store(
-                                        Instant::now()
-                                            .saturating_duration_since(session_epoch)
-                                            .as_millis()
-                                            as u64
-                                            + PEER_JOIN_BURST.as_millis() as u64,
-                                        Ordering::Relaxed,
+                                    stamp_capture_burst(
+                                        &capture_burst_until_ms,
+                                        session_epoch,
                                     );
                                     if let Some(tx) = pool_feed_kf_tx.as_ref() {
                                         let _ = tx.send(());

--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -24,7 +24,7 @@
 //! - `latest_frame`: always overwritten, latest-wins.
 
 use std::collections::{HashMap, HashSet};
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -995,6 +995,25 @@ pub trait DisplayBackend: Send + Sync + 'static {
     /// and a subsequent `start_capture` gets a clean slate.
     async fn stop_capture(&self);
 
+    /// Install a demand probe the backend MAY consult to pace capture
+    /// (see [`capture::pacing`]): full configured fps while the probe
+    /// reports demand, the 1 fps keepalive cadence while it reports
+    /// none, waking within one poll slice when demand returns. A rate
+    /// reduction, never a stop — a stopped capture has cold-start
+    /// latency and breaks `latest_frame` consumers, while the 1 fps
+    /// keepalive keeps `latest_frame` fresh enough for an instant
+    /// first paint and the FrameRegistry's 1 Hz sampler.
+    ///
+    /// Default: ignore the probe (capture at full rate). Only polling
+    /// backends benefit — event-driven backends (ScreenCaptureKit,
+    /// PipeWire, DXGI) already emit nothing while the desktop is idle.
+    /// [`DisplaySession::start`] installs a probe composed from the
+    /// session's demand sources; pacing is a CPU optimization and must
+    /// never become a correctness gate (probe absent = full rate).
+    fn set_capture_demand_probe(&self, probe: capture::pacing::CaptureDemandProbe) {
+        let _ = probe;
+    }
+
     /// Inject a browser input event into the display.
     async fn inject_input(&self, event: InputEvent) -> Result<(), CallerError>;
 
@@ -1104,6 +1123,47 @@ pub struct DisplaySession {
     /// channels yet, so subscribers are registered explicitly by the
     /// federated offer path instead of inferred from `peers`.
     tile_subscribers: Arc<RwLock<HashSet<PeerId>>>,
+    /// Lock-free mirror of `tile_subscribers.len()`, maintained inside
+    /// every mutation's write-lock critical section. Exists so the
+    /// capture demand probe (evaluated on the backend's capture
+    /// thread) can read tile demand without an async lock.
+    tile_subscriber_gauge: Arc<AtomicUsize>,
+    /// Whether the tile bridge is currently in video-fallback mode
+    /// (`true` after a `FallbackToVideo` transition, `false` in tile
+    /// mode). Written only by the tile-stream bridge; read by the
+    /// tile-control `Subscribe` handler to decide whether a newly
+    /// subscribing peer starts in video standby (see
+    /// [`webrtc::WebRtcPeer::set_video_standby`]).
+    tile_video_active: Arc<AtomicBool>,
+    /// Wakes the layer-policy coordinator for an immediate evaluation
+    /// when per-peer video demand changes (tile standby edges). The
+    /// coordinator still owns every pause/resume decision — the kick
+    /// only collapses its up-to-one-tick reaction latency so the
+    /// `fallback_to_video` SLA (prompt first paint) holds.
+    layer_policy_kick: Arc<tokio::sync::Notify>,
+    /// Millisecond deadline (relative to `session_epoch`) until which
+    /// the peer-join burst window counts as capture demand. Written by
+    /// [`Self::signal_peer_join_burst`]; read by the capture demand
+    /// probe. 0 = no burst.
+    capture_burst_until_ms: Arc<AtomicU64>,
+    /// Millisecond deadline (relative to `session_epoch`) until which
+    /// recent *external* frame reads count as capture demand. Public
+    /// frame accessors ([`Self::latest_frame`], [`Self::current_frame`],
+    /// [`Self::fresh_frame`], the screenshot wrappers) and
+    /// [`Self::inject_input`] refresh it, so pull-style consumers —
+    /// the recording bridge's `latest_frame` polling, CU action
+    /// screenshots — hold capture at full rate while they are active.
+    /// Session-internal readers (FrameRegistry sampler, tile snapshot
+    /// senders) deliberately bypass these accessors: the 1 fps
+    /// keepalive already serves them, and marking them would pin
+    /// capture at full rate forever.
+    external_frame_demand_until_ms: Arc<AtomicU64>,
+    /// Count of session-internal `frame_tx` subscriptions (the pool-feed
+    /// and tile-stream bridges). The demand probe treats
+    /// `frame_tx.receiver_count()` above this baseline as external
+    /// frame demand (CU quiesce observation, `fresh_frame` waiters, any
+    /// caller-side [`Self::subscribe_frames`] consumer).
+    internal_frame_subscribers: Arc<AtomicUsize>,
     /// D-3c: capture-damage-to-tile bridge task. Sends initial
     /// snapshots and XDamage-driven tile updates to `tile_subscribers`
     /// over WebRTC data channels while leaving the VP8 video track alive
@@ -1240,6 +1300,22 @@ fn convert_for_pool_feed(
 
 const TILE_STREAM_TILE_SIZE_PX: u16 = 64;
 const TILE_DELTA_TARGET_FPS: u32 = 15;
+
+/// Peer-join burst window. Sized to comfortably exceed one Linux ffmpeg
+/// H.264 GOP at 30fps (`-g 30` → ~1s) so the natural keyframe lands
+/// inside the window even though `force_keyframe` is ignored on the
+/// rawvideo pipe. Shared by the pool-feed bridge's burst arm and the
+/// capture demand probe (the burst also counts as capture demand so a
+/// joining peer's first frames are captured at full rate immediately).
+const PEER_JOIN_BURST: Duration = Duration::from_millis(1500);
+
+/// How long a single external frame read ([`DisplaySession::latest_frame`]
+/// and friends) or an injected input event counts as capture demand.
+/// Long enough that continuous pollers (the recording bridge at its
+/// configured framerate, a CU action sequence) never fall back to the
+/// keepalive cadence between touches; short enough that one stray
+/// screenshot doesn't hold full-rate capture for long.
+const EXTERNAL_FRAME_DEMAND_WINDOW: Duration = Duration::from_secs(3);
 
 fn tile_delta_min_interval() -> Duration {
     Duration::from_millis(1_000 / TILE_DELTA_TARGET_FPS as u64)
@@ -1575,6 +1651,31 @@ async fn send_latest_tile_snapshot_to_peer_id(
     .await;
 }
 
+/// Insert into the tile-subscriber set, refreshing the lock-free gauge
+/// inside the same write critical section so the capture demand probe
+/// never observes a set/gauge mismatch.
+async fn tile_subscribers_insert(
+    subscribers: &Arc<RwLock<HashSet<PeerId>>>,
+    gauge: &Arc<AtomicUsize>,
+    peer_id: PeerId,
+) {
+    let mut set = subscribers.write().await;
+    set.insert(peer_id);
+    gauge.store(set.len(), Ordering::Relaxed);
+}
+
+/// Remove from the tile-subscriber set; same gauge contract as
+/// [`tile_subscribers_insert`].
+async fn tile_subscribers_remove(
+    subscribers: &Arc<RwLock<HashSet<PeerId>>>,
+    gauge: &Arc<AtomicUsize>,
+    peer_id: PeerId,
+) {
+    let mut set = subscribers.write().await;
+    set.remove(&peer_id);
+    gauge.store(set.len(), Ordering::Relaxed);
+}
+
 async fn tile_subscriber_peer_handles(
     peers: &Arc<RwLock<HashMap<PeerId, Arc<webrtc::WebRtcPeer>>>>,
     subscribers: &Arc<RwLock<HashSet<PeerId>>>,
@@ -1597,6 +1698,7 @@ async fn tile_subscriber_peer_handles(
 async fn reap_peer_registration(
     peers: &Arc<RwLock<HashMap<PeerId, Arc<webrtc::WebRtcPeer>>>>,
     tile_subscribers: &Arc<RwLock<HashSet<PeerId>>>,
+    tile_subscriber_gauge: &Arc<AtomicUsize>,
     counters: &Arc<DisplayMetricsCounters>,
     peer_id: PeerId,
     peer: &Arc<webrtc::WebRtcPeer>,
@@ -1612,7 +1714,7 @@ async fn reap_peer_registration(
         }
     };
     if removed {
-        tile_subscribers.write().await.remove(&peer_id);
+        tile_subscribers_remove(tile_subscribers, tile_subscriber_gauge, peer_id).await;
         counters.peer_count.fetch_sub(1, Ordering::Relaxed);
     }
     removed
@@ -1641,6 +1743,12 @@ impl DisplaySession {
             pool: std::sync::OnceLock::new(),
             pool_feed_bridge_handle: Mutex::new(None),
             tile_subscribers: Arc::new(RwLock::new(HashSet::new())),
+            tile_subscriber_gauge: Arc::new(AtomicUsize::new(0)),
+            tile_video_active: Arc::new(AtomicBool::new(false)),
+            layer_policy_kick: Arc::new(tokio::sync::Notify::new()),
+            capture_burst_until_ms: Arc::new(AtomicU64::new(0)),
+            external_frame_demand_until_ms: Arc::new(AtomicU64::new(0)),
+            internal_frame_subscribers: Arc::new(AtomicUsize::new(0)),
             tile_stream_handle: Mutex::new(None),
             tile_replay: Arc::new(RwLock::new(tile::recovery::TileUpdateReplayBuffer::new())),
             tile_epoch: Arc::new(AtomicU32::new(1)),
@@ -1888,6 +1996,13 @@ impl DisplaySession {
             ))
         }));
 
+        // Demand-aware capture pacing: give the backend the composed
+        // demand probe before the bridges spawn. Polling backends (X11,
+        // synthetic) drop to the 1 fps keepalive while nothing consumes
+        // frames; event-driven backends ignore the probe. See
+        // [`Self::install_capture_demand_probe`].
+        self.install_capture_demand_probe(&pool_arc);
+
         // 3c.4d: spawn the pool-feed bridge eagerly. The bridge owns
         // BGRA→I420 conversion and `pool.push_i420_frame`; it pumps
         // every always-on encoder for the lifetime of the session,
@@ -1976,11 +2091,34 @@ impl DisplaySession {
                     }
                 }
             });
+        // Tile-standby reconcile hooks for on-demand slots (the
+        // always-on bank's standby falls out of the demanded-layer
+        // bound; on-demand slots are lease-refcounted per peer and
+        // need their own holder-aware pause/resume). Same
+        // closure-injection shape as the always-on hooks above.
+        let pool_for_od_ids = Arc::clone(&pool_arc);
+        let pool_for_od_probe = Arc::clone(&pool_arc);
+        let pool_for_od_action = Arc::clone(&pool_arc);
+        let on_demand_hooks = aggregator::OnDemandStandbyHooks {
+            subscribed_ids: Box::new(move || pool_for_od_ids.subscribed_on_demand_ids()),
+            is_paused: Box::new(move |id: &encode::pool::EncoderId| {
+                pool_for_od_probe.is_layer_paused(id.codec, id.rid.clone())
+            }),
+            set_paused: Box::new(move |id: &encode::pool::EncoderId, paused: bool| {
+                if paused {
+                    pool_for_od_action.pause_layer(id.codec, id.rid.clone());
+                } else {
+                    pool_for_od_action.resume_layer(id.codec, id.rid.clone());
+                }
+            }),
+        };
         let layer_policy_task = aggregator::spawn_layer_policy_coordinator(
             Arc::clone(&self.peers),
             get_current_rids,
             is_layer_paused,
             on_action,
+            on_demand_hooks,
+            Arc::clone(&self.layer_policy_kick),
             aggregator::CapacityPolicyConfig::default(),
             self.shutdown.clone(),
         );
@@ -2228,7 +2366,14 @@ impl DisplaySession {
     }
 
     /// Get the most recently captured frame, or `None` if no frame yet.
+    ///
+    /// Marks external frame demand: repeated polls (the recording
+    /// bridge, CU screenshot sequences) hold a demand-paced capture
+    /// backend at full rate; a lone read after an idle stretch returns
+    /// the keepalive-fresh frame (≤ ~1 s stale — the
+    /// [`capture::pacing`] floor) and warms capture for the next one.
     pub async fn latest_frame(&self) -> Option<Arc<Frame>> {
+        self.note_external_frame_demand();
         self.latest_frame.read().await.clone()
     }
 
@@ -2243,25 +2388,43 @@ impl DisplaySession {
     /// predate that D-4d2 protocol and encoded/shipped the same
     /// baseline a second time on every federated join.
     pub async fn register_tile_subscriber(&self, peer_id: PeerId) {
-        self.tile_subscribers.write().await.insert(peer_id);
+        tile_subscribers_insert(&self.tile_subscribers, &self.tile_subscriber_gauge, peer_id).await;
         if self.get_peer(peer_id).await.is_none() {
             // Raced with a fast Close: the peer left the map between
             // handle_offer returning and this registration. Drop the
             // just-inserted entry (mirrors the Close arm's unregister)
             // instead of leaving it for the reaper.
-            self.tile_subscribers.write().await.remove(&peer_id);
+            tile_subscribers_remove(&self.tile_subscribers, &self.tile_subscriber_gauge, peer_id)
+                .await;
         }
+        // Registration alone does NOT engage video standby: the
+        // federated offer path registers every tile-capable peer, but
+        // the browser stays on the video surface until its explicit
+        // tile-control `Subscribe` lands (the compositor is created on
+        // the first snapshot). Standby engages there.
     }
 
     /// D-3c: unregister a tile subscriber. Safe to call even when the
     /// peer was never registered.
     pub async fn unregister_tile_subscriber(&self, peer_id: PeerId) {
-        self.tile_subscribers.write().await.remove(&peer_id);
+        tile_subscribers_remove(&self.tile_subscribers, &self.tile_subscriber_gauge, peer_id).await;
+        // A still-connected peer that leaves tile streaming is back on
+        // the video surface: restore its video demand and wake the
+        // layer-policy coordinator so paused layers resume promptly.
+        if let Some(peer) = self.get_peer(peer_id).await {
+            if peer.video_standby() {
+                peer.set_video_standby(false);
+                self.layer_policy_kick.notify_one();
+            }
+        }
     }
 
     fn build_tile_control_handler(&self, peer_id: PeerId) -> self::webrtc::TileControlHandler {
         let peers = Arc::clone(&self.peers);
         let subscribers = Arc::clone(&self.tile_subscribers);
+        let subscriber_gauge = Arc::clone(&self.tile_subscriber_gauge);
+        let tile_video_active = Arc::clone(&self.tile_video_active);
+        let layer_policy_kick = Arc::clone(&self.layer_policy_kick);
         let latest_frame = Arc::clone(&self.latest_frame);
         let tile_epoch = Arc::clone(&self.tile_epoch);
         let tile_snapshot_id = Arc::clone(&self.tile_snapshot_id);
@@ -2273,6 +2436,9 @@ impl DisplaySession {
         Arc::new(move |msg| {
             let peers = Arc::clone(&peers);
             let subscribers = Arc::clone(&subscribers);
+            let subscriber_gauge = Arc::clone(&subscriber_gauge);
+            let tile_video_active = Arc::clone(&tile_video_active);
+            let layer_policy_kick = Arc::clone(&layer_policy_kick);
             let latest_frame = Arc::clone(&latest_frame);
             let tile_epoch = Arc::clone(&tile_epoch);
             let tile_snapshot_id = Arc::clone(&tile_snapshot_id);
@@ -2283,7 +2449,24 @@ impl DisplaySession {
             tokio::spawn(async move {
                 match msg {
                     self::webrtc::TileControlMessage::Subscribe { .. } => {
-                        subscribers.write().await.insert(peer_id);
+                        tile_subscribers_insert(&subscribers, &subscriber_gauge, peer_id).await;
+                        // The browser is now painting tiles (its
+                        // compositor is created on this subscription's
+                        // snapshot), so its demand on the video
+                        // encoders can be released — unless the bridge
+                        // is currently in video-fallback mode, where
+                        // the video surface is what the peer watches.
+                        // The layer-policy coordinator owns the
+                        // resulting pause/resume; the kick just makes
+                        // it react now instead of on its next tick.
+                        if !tile_video_active.load(Ordering::Relaxed) {
+                            if let Some(peer) = peers.read().await.get(&peer_id) {
+                                if !peer.video_standby() {
+                                    peer.set_video_standby(true);
+                                    layer_policy_kick.notify_one();
+                                }
+                            }
+                        }
                         send_latest_tile_snapshot_to_peer_id(
                             peers,
                             latest_frame,
@@ -2817,9 +3000,83 @@ impl DisplaySession {
     /// of a started session — the `if let Some` is defense-in-depth
     /// for a session whose `start()` hasn't run yet.
     async fn signal_peer_join_burst(&self) {
+        // Mirror the burst deadline for the capture demand probe: the
+        // burst must count as capture demand (a joining peer's first
+        // frames need capturing at full rate even before the layer
+        // policy's resume lands), and the probe runs on the capture
+        // thread where the bridge task's local window is unreachable.
+        self.capture_burst_until_ms.store(
+            self.session_ms_now()
+                .saturating_add(PEER_JOIN_BURST.as_millis() as u64),
+            Ordering::Relaxed,
+        );
         if let Some(tx) = self.pool_feed_keyframe_tx.lock().await.as_ref() {
             let _ = tx.send(());
         }
+    }
+
+    /// Milliseconds since `session_epoch` — the time base the capture
+    /// demand deadlines use (an `Instant` cannot live in an atomic).
+    fn session_ms_now(&self) -> u64 {
+        Instant::now()
+            .saturating_duration_since(self.session_epoch)
+            .as_millis() as u64
+    }
+
+    /// Record that an external consumer just pulled (or is about to act
+    /// on) frame content, holding capture at full rate for
+    /// [`EXTERNAL_FRAME_DEMAND_WINDOW`]. See the
+    /// `external_frame_demand_until_ms` field docs for which callers
+    /// mark and which deliberately do not.
+    fn note_external_frame_demand(&self) {
+        self.external_frame_demand_until_ms.store(
+            self.session_ms_now()
+                .saturating_add(EXTERNAL_FRAME_DEMAND_WINDOW.as_millis() as u64),
+            Ordering::Relaxed,
+        );
+    }
+
+    /// Build and install the capture demand probe on the backend (see
+    /// [`capture::pacing`] and [`DisplayBackend::set_capture_demand_probe`]).
+    /// Called from [`Self::start`] once the pool exists. The probe ORs
+    /// every demand class the session knows:
+    ///
+    /// 1. encoder demand — [`encode::pool::EncoderPool::has_active_consumer`]
+    ///    (an unpaused always-on layer or a subscribed, unpaused
+    ///    on-demand encoder);
+    /// 2. an open peer-join burst window (capture must be hot before
+    ///    the layer policy's resume lands);
+    /// 3. tile subscribers (dirty-region streaming consumes raw frames
+    ///    directly, independent of the video encoders);
+    /// 4. external raw-frame broadcast subscribers — receiver count
+    ///    above the session-internal baseline (CU quiesce observation,
+    ///    [`Self::fresh_frame`] waiters, any caller-side
+    ///    [`Self::subscribe_frames`] consumer);
+    /// 5. a recent external frame read or injected input
+    ///    ([`Self::note_external_frame_demand`] — the recording
+    ///    bridge's `latest_frame` polling and CU screenshots).
+    ///
+    /// The FrameRegistry's 1 Hz sampler is deliberately NOT a demand
+    /// class: the keepalive floor is 1 fps precisely so the sampler
+    /// (and instant-first-paint `latest_frame` reads) stay served
+    /// while nothing else consumes frames.
+    fn install_capture_demand_probe(&self, pool: &Arc<encode::pool::EncoderPool>) {
+        let pool = Arc::clone(pool);
+        let frame_tx = self.frame_tx.clone();
+        let internal_subs = Arc::clone(&self.internal_frame_subscribers);
+        let tile_gauge = Arc::clone(&self.tile_subscriber_gauge);
+        let burst_until = Arc::clone(&self.capture_burst_until_ms);
+        let external_until = Arc::clone(&self.external_frame_demand_until_ms);
+        let epoch = self.session_epoch;
+        let probe: capture::pacing::CaptureDemandProbe = Arc::new(move || {
+            let now_ms = Instant::now().saturating_duration_since(epoch).as_millis() as u64;
+            now_ms < burst_until.load(Ordering::Relaxed)
+                || tile_gauge.load(Ordering::Relaxed) > 0
+                || now_ms < external_until.load(Ordering::Relaxed)
+                || frame_tx.receiver_count() > internal_subs.load(Ordering::Relaxed)
+                || pool.has_active_consumer()
+        });
+        self.backend.set_capture_demand_probe(probe);
     }
 
     async fn spawn_tile_stream_bridge(&self, _fps: u32) {
@@ -2828,6 +3085,11 @@ impl DisplaySession {
         }
 
         let mut broadcast_rx = self.frame_tx.subscribe();
+        // Session-internal subscription: raise the baseline the capture
+        // demand probe subtracts, so this bridge's receiver never
+        // counts as external frame demand.
+        self.internal_frame_subscribers
+            .fetch_add(1, Ordering::Relaxed);
         let peers = Arc::clone(&self.peers);
         let subscribers = Arc::clone(&self.tile_subscribers);
         let shutdown = self.shutdown.clone();
@@ -2840,6 +3102,20 @@ impl DisplaySession {
         let session_epoch = self.session_epoch;
         let (initial_w, initial_h) = self.backend.resolution();
         let backend_kind = self.backend.kind();
+        // Tile-standby plumbing (per-peer RTP standby under tile mode):
+        // the bridge owns every standby transition, mirrors the mode
+        // into `tile_video_active` for the Subscribe handler, kicks the
+        // layer-policy coordinator on demand edges, and reuses the
+        // peer-join keyframe + burst machinery on the
+        // `fallback_to_video` edge. `start()` initializes the pool and
+        // the pool-feed keyframe channel before spawning this bridge,
+        // so both captures are `Some` in production; the `Option`s
+        // fail soft for direct-construction tests.
+        let tile_video_active = Arc::clone(&self.tile_video_active);
+        let layer_policy_kick = Arc::clone(&self.layer_policy_kick);
+        let capture_burst_until_ms = Arc::clone(&self.capture_burst_until_ms);
+        let pool_for_fallback = self.pool.get().cloned();
+        let pool_feed_kf_tx = self.pool_feed_keyframe_tx.lock().await.clone();
 
         let task = tokio::spawn(async move {
             let mut damage = make_damage_backend(initial_w, initial_h, backend_kind);
@@ -2882,6 +3158,7 @@ impl DisplaySession {
                             grid = Some(next_grid);
                             tile_policy = tile::policy::TilePolicy::new(Instant::now());
                             tile_mode = tile::policy::TileMode::Tiles;
+                            tile_video_active.store(false, Ordering::Relaxed);
                             next_snapshot_at = Instant::now() + tile_snapshot_period(tile_mode);
                             last_delta_tick_at = None;
                             pending_rects.clear();
@@ -2897,7 +3174,9 @@ impl DisplaySession {
                             seq = 1;
                             grid = Some(next_grid);
                             tile_policy = tile::policy::TilePolicy::new(Instant::now());
+                            let was_video = tile_mode == tile::policy::TileMode::Video;
                             tile_mode = tile::policy::TileMode::Tiles;
+                            tile_video_active.store(false, Ordering::Relaxed);
                             last_delta_tick_at = None;
                             pending_rects.clear();
                             synthetic_dirty.reset_cursor();
@@ -2909,6 +3188,38 @@ impl DisplaySession {
                                 tile_size_px: next_grid.tile_size_px,
                             };
                             send_tile_control_to_peers(&peers_now, resize, "resize").await;
+                            if was_video {
+                                // The resize reset the server to tile
+                                // mode, but browsers that took the
+                                // earlier FallbackToVideo are still on
+                                // the video surface — historically they
+                                // stayed there (deltas applied to a
+                                // hidden canvas) until the next
+                                // fallback round-trip. With encoders
+                                // pausing under tile standby that
+                                // mismatch would freeze their visible
+                                // video, so converge the surface
+                                // explicitly: same epoch as the Resize,
+                                // snapshot follows below.
+                                let fallback = tile::transport::TileFrame::FallbackToTile {
+                                    new_epoch: epoch,
+                                };
+                                send_tile_control_to_peers(
+                                    &peers_now,
+                                    fallback,
+                                    "resize-to-tile",
+                                )
+                                .await;
+                            }
+                            // Every subscriber is (back) on tiles after
+                            // this transition: engage standby so the
+                            // video encoders stop paying for hidden
+                            // surfaces. Peers already in standby are
+                            // untouched.
+                            for peer in &peers_now {
+                                peer.set_video_standby(true);
+                            }
+                            layer_policy_kick.notify_one();
                             let snapshot_id = tile_snapshot_id.fetch_add(1, Ordering::Relaxed);
                             // Encode the snapshot once, fan the wire
                             // frames out refcounted — a full-screen
@@ -3070,6 +3381,38 @@ impl DisplaySession {
                                         "[display/tile] display {display_id} fallback_to_video \
                                          dirty_fraction={dirty_fraction:.3}"
                                     );
+                                    // Re-acquire video demand BEFORE the
+                                    // browsers are told to switch
+                                    // surfaces: clear standby, kick the
+                                    // coordinator for an immediate
+                                    // resume (whose paused→active edge
+                                    // forces a keyframe), and reuse the
+                                    // peer-join keyframe + burst
+                                    // machinery so the pool-feed bridge
+                                    // clocks the encoders through the
+                                    // transition — the fallback SLA is
+                                    // a prompt first paint, and this is
+                                    // the same recipe a joining peer
+                                    // already relies on.
+                                    tile_video_active.store(true, Ordering::Relaxed);
+                                    for peer in &peers_now {
+                                        peer.set_video_standby(false);
+                                    }
+                                    layer_policy_kick.notify_one();
+                                    if let Some(pool) = pool_for_fallback.as_ref() {
+                                        pool.request_keyframe_all();
+                                    }
+                                    capture_burst_until_ms.store(
+                                        Instant::now()
+                                            .saturating_duration_since(session_epoch)
+                                            .as_millis()
+                                            as u64
+                                            + PEER_JOIN_BURST.as_millis() as u64,
+                                        Ordering::Relaxed,
+                                    );
+                                    if let Some(tx) = pool_feed_kf_tx.as_ref() {
+                                        let _ = tx.send(());
+                                    }
                                     let fallback = tile::transport::TileFrame::FallbackToVideo {
                                         new_epoch: epoch,
                                     };
@@ -3084,6 +3427,7 @@ impl DisplaySession {
                                         "[display/tile] display {display_id} fallback_to_tile \
                                          dirty_fraction={dirty_fraction:.3}"
                                     );
+                                    tile_video_active.store(false, Ordering::Relaxed);
                                     let fallback = tile::transport::TileFrame::FallbackToTile {
                                         new_epoch: epoch,
                                     };
@@ -3111,6 +3455,14 @@ impl DisplaySession {
                                             );
                                         }
                                     }
+                                    // Back on tiles with the baseline
+                                    // snapshot queued on the reliable
+                                    // channel: release the subscribers'
+                                    // video demand again.
+                                    for peer in &peers_now {
+                                        peer.set_video_standby(true);
+                                    }
+                                    layer_policy_kick.notify_one();
                                 }
                             }
                             continue;
@@ -3318,6 +3670,11 @@ impl DisplaySession {
         events: Option<DisplayEventSender>,
     ) {
         let mut broadcast_rx = self.frame_tx.subscribe();
+        // Session-internal subscription: raise the baseline the capture
+        // demand probe subtracts, so this bridge's receiver never
+        // counts as external frame demand.
+        self.internal_frame_subscribers
+            .fetch_add(1, Ordering::Relaxed);
         let (initial_w, initial_h) = self.backend.resolution();
         let shutdown = self.shutdown.clone();
         let display_id = self.display_id;
@@ -3794,6 +4151,7 @@ impl DisplaySession {
     fn spawn_peer_reaper(&self, peer_id: PeerId, peer: &Arc<self::webrtc::WebRtcPeer>) {
         let peers = Arc::clone(&self.peers);
         let tile_subscribers = Arc::clone(&self.tile_subscribers);
+        let tile_gauge = Arc::clone(&self.tile_subscriber_gauge);
         let counters = Arc::clone(&self.counters);
         let peer = Arc::clone(peer);
         let closed = peer.closed();
@@ -3803,8 +4161,15 @@ impl DisplaySession {
                 _ = closed => {}
                 _ = shutdown.cancelled() => peer.close().await,
             }
-            let _ =
-                reap_peer_registration(&peers, &tile_subscribers, &counters, peer_id, &peer).await;
+            let _ = reap_peer_registration(
+                &peers,
+                &tile_subscribers,
+                &tile_gauge,
+                &counters,
+                peer_id,
+                &peer,
+            )
+            .await;
         });
     }
 
@@ -3849,6 +4214,11 @@ impl DisplaySession {
     /// from per-event tasks is exactly the ordering race the input queue
     /// exists to fix.
     pub async fn inject_input(&self, event: InputEvent) -> Result<(), CallerError> {
+        // Input is a frame-demand precursor: a CU click is invariably
+        // followed by an observation, so warm a demand-paced capture
+        // backend now — the post-action frame is then captured at full
+        // rate instead of on the keepalive cadence.
+        self.note_external_frame_demand();
         self.backend.inject_input(event).await
     }
 
@@ -6325,6 +6695,165 @@ mod tests {
              leaving the slot empty (parity with capture/encoder/\
              clipboard cleanup at display/mod.rs:792-800)"
         );
+    }
+
+    // ---- Demand propagation: capture pacing + tile video standby ----
+
+    /// Demand-aware capture pacing end-to-end through a real
+    /// `DisplaySession` on the synthetic backend: an agent-only session
+    /// (empty synthetic always-on bank, no viewers, no external
+    /// consumers) paces at the keepalive cadence; an external frame
+    /// consumer restores full-rate pacing; the peer-join burst counts
+    /// as demand on its own. Asserts on the pacing seam's mode counters
+    /// (`DemandProbeSlot`) rather than wall-clock frame rates, so the
+    /// test is load-tolerant.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn capture_pacing_follows_session_demand() {
+        let backend = Arc::new(synthetic::SyntheticBackend::new());
+        let slot = backend.demand_slot();
+        let session = DisplaySession::new(0, backend);
+        session.start(30, None, None).await.expect("start");
+
+        // Phase 1 — no demand: the probe (installed by start()) sees no
+        // pool consumer, no tile subscribers, no burst, no external
+        // reads → keepalive paces accumulate. Generous deadline: each
+        // keepalive pace spans up to 1 s.
+        let deadline = Instant::now() + Duration::from_secs(15);
+        while slot.keepalive_paces() < 2 {
+            assert!(
+                Instant::now() < deadline,
+                "agent-only session must reach keepalive pacing                  (full={} keepalive={})",
+                slot.full_paces(),
+                slot.keepalive_paces(),
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        // Phase 2 — demand restore: an external raw-frame subscriber
+        // (the CU-quiesce / recording shape) must pull pacing back to
+        // full rate within a poll slice.
+        let external_rx = session.subscribe_frames();
+        let full_before = slot.full_paces();
+        let deadline = Instant::now() + Duration::from_secs(15);
+        while slot.full_paces() < full_before + 3 {
+            assert!(
+                Instant::now() < deadline,
+                "external frame subscriber must restore full-rate pacing                  (full={} keepalive={})",
+                slot.full_paces(),
+                slot.keepalive_paces(),
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        drop(external_rx);
+
+        // Phase 3 — burst-as-demand: after external demand decays, a
+        // peer-join burst alone must count. (The external-read window
+        // is 3 s; wait it out at keepalive first.)
+        let keepalive_before = slot.keepalive_paces();
+        let deadline = Instant::now() + Duration::from_secs(20);
+        while slot.keepalive_paces() < keepalive_before + 2 {
+            assert!(
+                Instant::now() < deadline,
+                "dropping the subscriber must return pacing to keepalive"
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        session.signal_peer_join_burst().await;
+        let full_before = slot.full_paces();
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while slot.full_paces() == full_before {
+            assert!(
+                Instant::now() < deadline,
+                "the peer-join burst window must count as capture demand"
+            );
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+
+        session.stop().await;
+    }
+
+    /// The tile-subscriber gauge mirrors the async set through every
+    /// mutation path the capture demand probe depends on: register,
+    /// the register-races-fast-close cleanup, and unregister.
+    #[tokio::test]
+    async fn tile_subscriber_gauge_mirrors_registration() {
+        let backend = Arc::new(StubBackend {
+            width: 64,
+            height: 64,
+        });
+        let session = DisplaySession::new(0, backend);
+        assert_eq!(session.tile_subscriber_gauge.load(Ordering::Relaxed), 0);
+
+        // No such peer in the map → insert is rolled back (fast-close
+        // race path) and the gauge returns to zero.
+        session.register_tile_subscriber(7).await;
+        assert_eq!(
+            session.tile_subscriber_gauge.load(Ordering::Relaxed),
+            0,
+            "rolled-back registration must not leak gauge demand"
+        );
+
+        session.register_test_peer_for_cleanup(7).await;
+        session.register_tile_subscriber(7).await;
+        assert_eq!(session.tile_subscriber_gauge.load(Ordering::Relaxed), 1);
+
+        session.unregister_tile_subscriber(7).await;
+        assert_eq!(session.tile_subscriber_gauge.load(Ordering::Relaxed), 0);
+        session.stop().await;
+    }
+
+    /// Poll until `peer.video_standby()` equals `want` (the tile
+    /// control handler applies standby from a spawned task).
+    async fn wait_for_standby(peer: &Arc<webrtc::WebRtcPeer>, want: bool, context: &str) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while peer.video_standby() != want {
+            assert!(
+                Instant::now() < deadline,
+                "{context}: video_standby must become {want}"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    /// Per-peer RTP standby edges: a tile-control `Subscribe` while the
+    /// bridge is in tile mode releases that peer's video demand;
+    /// unregistering restores it. A `Subscribe` arriving while the
+    /// display is in video-fallback mode must NOT engage standby (the
+    /// video surface is what that client watches until the next
+    /// fallback-to-tile).
+    #[tokio::test]
+    async fn tile_subscribe_toggles_video_standby() {
+        let backend = Arc::new(StubBackend {
+            width: 64,
+            height: 64,
+        });
+        let session = DisplaySession::new(0, backend);
+        session.register_test_peer_for_cleanup(7).await;
+        let peer = session.get_peer(7).await.expect("test peer registered");
+        assert!(!peer.video_standby(), "peers start demanding video");
+
+        let handler = session.build_tile_control_handler(7);
+        handler(webrtc::TileControlMessage::Subscribe { client_id: 1 });
+        wait_for_standby(&peer, true, "subscribe in tile mode").await;
+
+        // Unregister (peer leaves tile streaming, stays connected):
+        // demand restored.
+        session.unregister_tile_subscriber(7).await;
+        wait_for_standby(&peer, false, "unregister").await;
+
+        // Video-fallback active: Subscribe must leave demand in place.
+        session.tile_video_active.store(true, Ordering::Relaxed);
+        handler(webrtc::TileControlMessage::Subscribe { client_id: 1 });
+        // The handler runs on a spawned task; give it time to (not)
+        // engage standby, keyed on the snapshot send completing for a
+        // missing latest_frame (immediate).
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(
+            !peer.video_standby(),
+            "subscribe during video fallback must not release video demand"
+        );
+
+        session.stop().await;
     }
 
     // ---- Phase 5a.1 gated-input-handler tests ------------------------

--- a/crates/intendant-display/src/macos.rs
+++ b/crates/intendant-display/src/macos.rs
@@ -317,10 +317,61 @@ fn sample_dirty_rects(sample: &CMSampleBuffer, frame_w: u32, frame_h: u32) -> Op
     Some(rects)
 }
 
+/// The dirty rects attached to one outgoing [`Frame`] when SCK dirty-rect
+/// extraction is enabled: the sample's native rects when the attachment is
+/// present, otherwise a single **full-frame** rect.
+///
+/// The full-frame fallback (rather than `None`) follows the same
+/// conservative rule Chromium's ScreenCaptureKit capturer applies when the
+/// attachment is missing or malformed (observed around stream
+/// reconfiguration): treat the whole frame as changed. Handing `None`
+/// downstream instead would drop the tile bridge into its frame-diff path
+/// for just those frames, diffing against a baseline that stopped
+/// advancing while native rects were served — content that reverts to a
+/// stale baseline hash would then silently never repaint until the
+/// periodic snapshot. A rare full-frame update is the safe shape.
+fn dirty_rects_for_frame(native: Option<Vec<Rect>>, frame_w: u32, frame_h: u32) -> Vec<Rect> {
+    native.unwrap_or_else(|| vec![Rect::new(0, 0, frame_w, frame_h)])
+}
+
+/// Whether ScreenCaptureKit dirty-rect extraction is enabled. **Default
+/// ON** since the 2026-07 demand-propagation pass; the env var is the
+/// opt-out escape hatch (`INTENDANT_MACOS_SCK_DIRTY_RECTS=0`).
+///
+/// Why the default flipped from the initial opt-in:
+///
+/// - Without native rects, macOS tile streaming hashes **every tile of
+///   every frame** on the blocking pool (the frame-diff fallback, up to
+///   15 Hz full-frame work); with them, per-frame damage costs what SCK
+///   already computed. The full-display WebRTC hot path the opt-in was
+///   guarding has since soaked.
+/// - Both `Frame::dirty_rects` consumers degrade per-frame, not
+///   per-session: the tile bridge takes native rects when a frame
+///   carries them and frame-diffs otherwise, and CU's quiesce settle
+///   fingerprints frames without rects. A frame without the attachment
+///   ships a full-frame rect (see [`dirty_rects_for_frame`]) so neither
+///   consumer ever trusts a stale diff baseline.
+/// - The X11 hazard class ("hardware-cursor moves fire no damage") does
+///   not transfer: SCK composites the cursor into the frame it reports
+///   (`with_shows_cursor(true)`), so cursor motion is content change in
+///   the same pipeline that mints the dirty rects, and production SCK
+///   consumers (Chromium's capturer) drive their updated region from
+///   these rects with the cursor embedded. Residual staleness of any
+///   kind is bounded by the tile protocol's periodic snapshot (30 s in
+///   tile mode).
 fn sck_dirty_rects_enabled() -> bool {
-    std::env::var("INTENDANT_MACOS_SCK_DIRTY_RECTS")
-        .map(|raw| sck_dirty_rects_enabled_value(&raw))
-        .unwrap_or(false)
+    sck_dirty_rects_enabled_env(
+        std::env::var("INTENDANT_MACOS_SCK_DIRTY_RECTS")
+            .ok()
+            .as_deref(),
+    )
+}
+
+/// Pure core of [`sck_dirty_rects_enabled`]: `None` (unset) = enabled;
+/// any set value is parsed by [`sck_dirty_rects_enabled_value`], so `0`
+/// / `false` / `no` / `off` disable and truthy spellings keep it on.
+fn sck_dirty_rects_enabled_env(raw: Option<&str>) -> bool {
+    raw.map(sck_dirty_rects_enabled_value).unwrap_or(true)
 }
 
 fn sck_dirty_rects_enabled_value(raw: &str) -> bool {
@@ -757,7 +808,11 @@ impl DisplayBackend for MacOSBackend {
                     );
                 }
                 let dirty_rects = if dirty_rects_enabled {
-                    sample_dirty_rects(&sample, w, h)
+                    Some(dirty_rects_for_frame(
+                        sample_dirty_rects(&sample, w, h),
+                        w,
+                        h,
+                    ))
                 } else {
                     None
                 };
@@ -1085,6 +1140,52 @@ mod tests {
         for value in ["", "0", "false", "no", "off", "enabled"] {
             assert!(!sck_dirty_rects_enabled_value(value), "{value}");
         }
+    }
+
+    /// SCK dirty-rect extraction defaults ON; the env var is the opt-OUT
+    /// escape hatch. Pins the default flip (see
+    /// [`sck_dirty_rects_enabled`] for the rationale) and the opt-out
+    /// spellings an operator would reach for.
+    #[test]
+    fn dirty_rects_default_on_with_env_opt_out() {
+        assert!(
+            sck_dirty_rects_enabled_env(None),
+            "unset env must enable SCK dirty rects (default ON)"
+        );
+        for off in ["0", "false", "no", "off"] {
+            assert!(
+                !sck_dirty_rects_enabled_env(Some(off)),
+                "{off} must opt out"
+            );
+        }
+        for on in ["1", "true", "yes", "on"] {
+            assert!(
+                sck_dirty_rects_enabled_env(Some(on)),
+                "{on} must keep it on"
+            );
+        }
+    }
+
+    /// A frame whose sample lacks the dirty-rect attachment ships a
+    /// full-frame rect, never `None` — the conservative
+    /// missing-attachment rule that keeps downstream consumers off a
+    /// stale frame-diff baseline. Present attachments pass through
+    /// untouched (empty = SCK's idle "nothing changed" verdict).
+    #[test]
+    fn missing_attachment_becomes_full_frame_rect() {
+        assert_eq!(
+            dirty_rects_for_frame(None, 1280, 720),
+            vec![Rect::new(0, 0, 1280, 720)]
+        );
+        assert_eq!(
+            dirty_rects_for_frame(Some(Vec::new()), 1280, 720),
+            Vec::<Rect>::new()
+        );
+        let native = vec![Rect::new(4, 8, 16, 32)];
+        assert_eq!(
+            dirty_rects_for_frame(Some(native.clone()), 1280, 720),
+            native
+        );
     }
 
     /// Real-ScreenCaptureKit teardown-contract stress: fast start/stop

--- a/crates/intendant-display/src/synthetic.rs
+++ b/crates/intendant-display/src/synthetic.rs
@@ -39,6 +39,7 @@
 //! (`synthetic_backend_survives_start_stop_stress`), because this backend
 //! needs no display hardware.
 
+use super::capture::pacing::{self, DemandProbeSlot};
 use super::{DisplayBackend, DisplayInfo, DisplayInfoKind, Frame, FrameFormat, InputEvent};
 use async_trait::async_trait;
 use intendant_core::error::CallerError;
@@ -112,6 +113,12 @@ struct CaptureState {
 pub struct SyntheticBackend {
     capture: Mutex<Option<CaptureState>>,
     shutdown: Arc<AtomicBool>,
+    /// Demand probe slot shared with the producer thread. The synthetic
+    /// source is a polling backend like X11, so it honors the same
+    /// demand pacing ([`super::capture::pacing`]) — which is also what
+    /// lets CI exercise the pacing contract (keepalive on demand drop,
+    /// full rate + wake on demand restore) without a real display.
+    demand: Arc<DemandProbeSlot>,
 }
 
 impl SyntheticBackend {
@@ -119,7 +126,16 @@ impl SyntheticBackend {
         Self {
             capture: Mutex::new(None),
             shutdown: Arc::new(AtomicBool::new(false)),
+            demand: Arc::new(DemandProbeSlot::new()),
         }
+    }
+
+    /// Test observability: the pacing slot, exposing pace-mode counters
+    /// (see [`DemandProbeSlot::full_paces`] /
+    /// [`DemandProbeSlot::keepalive_paces`]). Pacing tests assert on
+    /// counter transitions instead of wall-clock frame rates.
+    pub fn demand_slot(&self) -> Arc<DemandProbeSlot> {
+        Arc::clone(&self.demand)
     }
 }
 
@@ -211,6 +227,7 @@ impl DisplayBackend for SyntheticBackend {
 
         let (tx, rx) = mpsc::channel::<Frame>(4);
         let shutdown = Arc::clone(&self.shutdown);
+        let demand = Arc::clone(&self.demand);
         let interval = std::time::Duration::from_millis(1000 / u64::from(fps.clamp(1, MAX_FPS)));
 
         // The producer owns `tx` (the channel's only sender): thread exit IS
@@ -223,18 +240,15 @@ impl DisplayBackend for SyntheticBackend {
                 if shutdown.load(Ordering::SeqCst) {
                     break;
                 }
+                let start = Instant::now();
                 // Bounded channel, drop-on-full per the capture contract.
                 let _ = tx.try_send(synthetic_frame(&base, frame_index));
                 frame_index += 1;
-                // Sleep in small slices so `stop_capture`'s join stays
-                // responsive regardless of the requested cadence.
-                let deadline = Instant::now() + interval;
-                while Instant::now() < deadline {
-                    if shutdown.load(Ordering::SeqCst) {
-                        return;
-                    }
-                    std::thread::sleep(std::time::Duration::from_millis(5));
-                }
+                // Demand-aware pacing, same contract as the X11 loops:
+                // full fps with demand, 1 fps keepalive without, and a
+                // sliced sleep that keeps `stop_capture`'s join and
+                // demand wake-edges responsive.
+                let _ = pacing::pace_capture_interval(&demand, &shutdown, start, interval);
             }
         });
 
@@ -244,6 +258,9 @@ impl DisplayBackend for SyntheticBackend {
 
     async fn stop_capture(&self) {
         self.shutdown.store(true, Ordering::SeqCst);
+        // Same probe hygiene as the X11 backend: a fresh session paces
+        // fail-open until its own probe is installed.
+        self.demand.clear();
         // Taking the state makes double-stop / stop-without-start no-ops;
         // the join doubles as the bounded channel-close (the thread owns
         // the only sender). Joined on the blocking pool like the other
@@ -254,6 +271,10 @@ impl DisplayBackend for SyntheticBackend {
             })
             .await;
         }
+    }
+
+    fn set_capture_demand_probe(&self, probe: pacing::CaptureDemandProbe) {
+        self.demand.install(probe);
     }
 
     async fn inject_input(&self, _event: InputEvent) -> Result<(), CallerError> {

--- a/crates/intendant-display/src/webrtc/mod.rs
+++ b/crates/intendant-display/src/webrtc/mod.rs
@@ -81,7 +81,7 @@ use rtc::statistics::stats::RTCStatsType;
 use rtc::statistics::StatsSelector;
 use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::io::AsyncWriteExt;
@@ -321,6 +321,26 @@ pub struct WebRtcPeer {
     /// `active_rids` snapshot is always in lockstep with the
     /// negotiated answer SDP.
     active_rids: Vec<SimulcastRid>,
+    /// The codec this peer's forwarders actually consume, frozen at
+    /// construction alongside `active_rids` (both derive from the same
+    /// initial pool subscription). Lets the layer-policy coordinator
+    /// attribute an **on-demand** encoder slot (keyed `(codec, rid)`)
+    /// to the peers holding it when reconciling tile-mode video
+    /// standby.
+    active_codec: CodecKind,
+    /// Tile-mode video standby: `true` while this peer's client paints
+    /// dirty-region tiles (video element hidden), meaning the peer
+    /// currently demands **no** video encoder output. Read by the
+    /// layer-policy coordinator each evaluation — a standby peer
+    /// contributes nothing to the demanded/pinned layer sets and does
+    /// not hold its on-demand slot active — so a tile-only session's
+    /// encoders pause while any non-standby viewer on the same display
+    /// keeps its layers running untouched. Written by the display
+    /// session's tile bridge at the subscribe / fallback transitions;
+    /// flipped back **before** `FallbackToVideo` is sent so the resume
+    /// (with its forced keyframe) races ahead of the browser's surface
+    /// switch.
+    video_standby: AtomicBool,
     shutdown: CancellationToken,
 }
 
@@ -430,6 +450,26 @@ impl WebRtcPeer {
         &self.active_rids
     }
 
+    /// The codec this peer's forwarders consume, frozen at construction.
+    /// See the `active_codec` field docs.
+    pub fn active_codec(&self) -> CodecKind {
+        self.active_codec
+    }
+
+    /// Enter or leave tile-mode video standby (see the `video_standby`
+    /// field docs). Written by the owning display session's tile
+    /// bridge; the layer-policy coordinator reads it on every
+    /// evaluation, so callers pair a transition with a coordinator
+    /// kick when they need the pause/resume to land immediately.
+    pub fn set_video_standby(&self, standby: bool) {
+        self.video_standby.store(standby, Ordering::Relaxed);
+    }
+
+    /// Whether this peer is in tile-mode video standby.
+    pub fn video_standby(&self) -> bool {
+        self.video_standby.load(Ordering::Relaxed)
+    }
+
     /// Test-only: construct a `WebRtcPeer` with just `active_rids`
     /// populated and dummy values for everything else. The dummy
     /// channels are constructed but their senders are dropped so
@@ -448,6 +488,18 @@ impl WebRtcPeer {
     /// pipeline directly.
     #[cfg(any(test, feature = "test-util"))]
     pub fn new_for_test(peer_id: PeerId, active_rids: Vec<SimulcastRid>) -> Self {
+        Self::new_for_test_with_codec(peer_id, crate::encode::pool::BASELINE_CODEC, active_rids)
+    }
+
+    /// [`Self::new_for_test`] with an explicit `active_codec` — for
+    /// tests exercising the on-demand standby reconcile, which
+    /// attributes `(codec, rid)` slots to peers by this field.
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn new_for_test_with_codec(
+        peer_id: PeerId,
+        active_codec: CodecKind,
+        active_rids: Vec<SimulcastRid>,
+    ) -> Self {
         use std::collections::HashMap;
         let (command_tx, _command_rx) = mpsc::channel(1);
         let (_obs_tx, observed_send_bitrate_rx) = watch::channel(None);
@@ -465,6 +517,8 @@ impl WebRtcPeer {
             remote_inbound_health_rx,
             twcc_health_rx,
             active_rids,
+            active_codec,
+            video_standby: AtomicBool::new(false),
             shutdown: CancellationToken::new(),
         }
     }

--- a/crates/intendant-display/src/webrtc/offer.rs
+++ b/crates/intendant-display/src/webrtc/offer.rs
@@ -1028,6 +1028,11 @@ impl WebRtcPeer {
                 remote_inbound_health_rx,
                 twcc_health_rx,
                 active_rids: active_rids.to_vec(),
+                active_codec,
+                // Every peer starts demanding video; the display
+                // session's tile bridge engages standby only once the
+                // client is actually painting tiles.
+                video_standby: std::sync::atomic::AtomicBool::new(false),
                 shutdown,
             },
             encoded_frame_tx,

--- a/crates/intendant-display/src/x11.rs
+++ b/crates/intendant-display/src/x11.rs
@@ -9,6 +9,7 @@
 //! If the XShm extension is unavailable, the backend falls back to `XGetImage`
 //! (slower but always works).
 
+use super::capture::pacing::{self, DemandProbeSlot, PaceMode};
 use super::{DisplayBackend, Frame, FrameFormat, InputEvent};
 use async_trait::async_trait;
 use intendant_core::error::CallerError;
@@ -33,6 +34,13 @@ pub struct X11Backend {
     height: Arc<AtomicU32>,
     shutdown: Arc<AtomicBool>,
     display: String,
+    /// Demand probe slot shared with the capture thread. X11 capture is
+    /// a full-screen copy at configured fps whether or not anything
+    /// consumes it (~249 MB/s at 1080p30), so this polling backend is
+    /// the primary beneficiary of demand pacing: no demand → the loop
+    /// drops to the 1 fps keepalive; demand restored → full rate within
+    /// one poll slice. See [`pacing`].
+    demand: Arc<DemandProbeSlot>,
 }
 
 impl X11Backend {
@@ -60,6 +68,7 @@ impl X11Backend {
             height: Arc::new(AtomicU32::new(height)),
             shutdown: Arc::new(AtomicBool::new(false)),
             display: display_str,
+            demand: Arc::new(DemandProbeSlot::new()),
         })
     }
 
@@ -81,6 +90,7 @@ impl X11Backend {
             height: Arc::new(AtomicU32::new(height)),
             shutdown: Arc::new(AtomicBool::new(false)),
             display: display_str.to_string(),
+            demand: Arc::new(DemandProbeSlot::new()),
         })
     }
 }
@@ -233,6 +243,7 @@ impl DisplayBackend for X11Backend {
         let height = self.height.load(Ordering::SeqCst);
         let shared_w = Arc::clone(&self.width);
         let shared_h = Arc::clone(&self.height);
+        let demand = Arc::clone(&self.demand);
 
         let thread = std::thread::spawn(move || {
             run_x11_capture(
@@ -244,6 +255,7 @@ impl DisplayBackend for X11Backend {
                 height,
                 shared_w,
                 shared_h,
+                demand,
             );
         });
 
@@ -253,6 +265,11 @@ impl DisplayBackend for X11Backend {
 
     async fn stop_capture(&self) {
         self.shutdown.store(true, Ordering::SeqCst);
+        // Drop the demand probe with the session it was composed for: a
+        // later `start_capture` must pace at the fail-open full rate
+        // until its own session installs a fresh probe, never off a
+        // previous session's stale demand sources.
+        self.demand.clear();
 
         // Teardown contract: the capture thread owns the frame channel's only
         // sender, so the join below doubles as the bounded channel-close —
@@ -339,6 +356,10 @@ impl DisplayBackend for X11Backend {
         Ok(())
     }
 
+    fn set_capture_demand_probe(&self, probe: pacing::CaptureDemandProbe) {
+        self.demand.install(probe);
+    }
+
     fn resolution(&self) -> (u32, u32) {
         (
             self.width.load(Ordering::SeqCst),
@@ -380,6 +401,7 @@ fn run_x11_capture(
     height: u32,
     shared_width: Arc<AtomicU32>,
     shared_height: Arc<AtomicU32>,
+    demand: Arc<DemandProbeSlot>,
 ) {
     use x11rb::connection::Connection;
     use x11rb::protocol::shm;
@@ -423,6 +445,7 @@ fn run_x11_capture(
             frame_interval,
             &shared_width,
             &shared_height,
+            &demand,
         );
     } else {
         eprintln!(
@@ -440,6 +463,7 @@ fn run_x11_capture(
             frame_interval,
             &shared_width,
             &shared_height,
+            &demand,
         );
     }
 }
@@ -472,6 +496,7 @@ fn run_shm_capture(
     frame_interval: std::time::Duration,
     shared_width: &Arc<AtomicU32>,
     shared_height: &Arc<AtomicU32>,
+    demand: &Arc<DemandProbeSlot>,
 ) {
     use x11rb::protocol::shm::ConnectionExt as ShmConnectionExt;
     use x11rb::protocol::xproto::ImageFormat;
@@ -526,6 +551,7 @@ fn run_shm_capture(
             frame_interval,
             shared_width,
             shared_height,
+            demand,
         );
         return;
     }
@@ -536,6 +562,11 @@ fn run_shm_capture(
     const MAX_CONSECUTIVE_ERRORS: u32 = 30;
     // Re-query root window geometry every N frames to detect resolution changes.
     const GEOMETRY_CHECK_INTERVAL: u64 = 60;
+    // Whether the previous iteration paced at the keepalive cadence. At
+    // 1 fps the frame-count geometry cadence would stretch to a minute,
+    // so keepalive iterations re-check geometry every frame instead
+    // (one cheap GetGeometry round-trip per second while idle).
+    let mut idle_paced = false;
 
     loop {
         if shutdown.load(Ordering::SeqCst) {
@@ -544,7 +575,7 @@ fn run_shm_capture(
         let start = std::time::Instant::now();
 
         // Periodically check for root window resize (e.g. xrandr change).
-        if frame_count > 0 && frame_count.is_multiple_of(GEOMETRY_CHECK_INTERVAL) {
+        if frame_count > 0 && (idle_paced || frame_count.is_multiple_of(GEOMETRY_CHECK_INTERVAL)) {
             if let Some((new_w, new_h)) = query_root_geometry(conn, root) {
                 if new_w != width || new_h != height {
                     eprintln!(
@@ -573,6 +604,7 @@ fn run_shm_capture(
                         frame_interval,
                         shared_width,
                         shared_height,
+                        demand,
                     );
                     return;
                 }
@@ -645,10 +677,11 @@ fn run_shm_capture(
             }
         }
 
-        let elapsed = start.elapsed();
-        if elapsed < frame_interval {
-            std::thread::sleep(frame_interval - elapsed);
-        }
+        // Demand-aware pacing: full fps while anything consumes frames,
+        // 1 fps keepalive otherwise, waking within one poll slice when
+        // demand returns. See [`pacing::pace_capture_interval`].
+        idle_paced = pacing::pace_capture_interval(demand, shutdown, start, frame_interval)
+            == PaceMode::Keepalive;
     }
 
     // Cleanup: detach from X server and shared memory.
@@ -670,6 +703,7 @@ fn run_getimage_capture(
     frame_interval: std::time::Duration,
     shared_width: &Arc<AtomicU32>,
     shared_height: &Arc<AtomicU32>,
+    demand: &Arc<DemandProbeSlot>,
 ) {
     use x11rb::protocol::xproto::{ConnectionExt, ImageFormat};
 
@@ -680,6 +714,8 @@ fn run_getimage_capture(
     const MAX_CONSECUTIVE_ERRORS: u32 = 30;
     // Re-query root window geometry every N frames to detect resolution changes.
     const GEOMETRY_CHECK_INTERVAL: u64 = 60;
+    // See the SHM loop: keepalive iterations re-check geometry every frame.
+    let mut idle_paced = false;
 
     loop {
         if shutdown.load(Ordering::SeqCst) {
@@ -688,7 +724,7 @@ fn run_getimage_capture(
         let start = std::time::Instant::now();
 
         // Periodically check for root window resize.
-        if frame_count > 0 && frame_count.is_multiple_of(GEOMETRY_CHECK_INTERVAL) {
+        if frame_count > 0 && (idle_paced || frame_count.is_multiple_of(GEOMETRY_CHECK_INTERVAL)) {
             if let Some((new_w, new_h)) = query_root_geometry(conn, root) {
                 if new_w != width || new_h != height {
                     eprintln!(
@@ -769,10 +805,11 @@ fn run_getimage_capture(
             }
         }
 
-        let elapsed = start.elapsed();
-        if elapsed < frame_interval {
-            std::thread::sleep(frame_interval - elapsed);
-        }
+        // Demand-aware pacing: full fps while anything consumes frames,
+        // 1 fps keepalive otherwise, waking within one poll slice when
+        // demand returns. See [`pacing::pace_capture_interval`].
+        idle_paced = pacing::pace_capture_interval(demand, shutdown, start, frame_interval)
+            == PaceMode::Keepalive;
     }
 }
 

--- a/docs/src/display-pipeline.md
+++ b/docs/src/display-pipeline.md
@@ -144,6 +144,31 @@ requires every active policy to agree**:
   (cheap `Arc` stash) instead of converting at capture rate for a stream
   nobody decodes, and the first tick after a viewer joins converts that
   retained frame on demand.
+
+  Demand also propagates one stage further upstream, into **capture pacing**
+  (`display/capture/pacing.rs`): the session composes a demand probe —
+  encoder-pool consumers, the peer-join burst window, tile subscribers,
+  external raw-frame subscribers, and recent external `latest_frame` reads or
+  injected input — and installs it on the backend. Polling backends (X11,
+  synthetic) then drop the capture copy itself from configured fps to a
+  **1 fps keepalive** while nothing consumes frames, waking within one 50 ms
+  poll slice when demand returns. It is a rate reduction, never a stop: a
+  stopped capture has cold-start latency and breaks `latest_frame` consumers,
+  while the 1 fps floor keeps `latest_frame` fresh enough for an instant
+  first paint, a ≤1 s-stale screenshot, and the FrameRegistry's 1 Hz sampler.
+  Event-driven backends (ScreenCaptureKit, PipeWire, DXGI) ignore the probe —
+  they already emit nothing while the desktop is idle.
+
+  Per-peer demand is released under **tile mode** as well: a federated viewer
+  whose client is painting tiles (video element hidden) enters *video
+  standby* — it stops contributing to the demanded/pinned layer sets, and an
+  on-demand encoder slot pauses once every holder is in standby — so a
+  tile-only session stops paying VP8/H.264 encode while any non-standby
+  viewer on the same display keeps its layers running. The
+  `fallback_to_video` edge restores demand *before* the browser is told to
+  switch surfaces, kicks the coordinator for an immediate resume (whose
+  paused→active edge forces a keyframe), and reuses the peer-join
+  keyframe + burst machinery, so the fallback still paints promptly.
 - **Aggregate-TWCC policy** — per-peer cascaded loss. On sustained packet loss it
   pauses the top layer first, then the middle, reversing on recovery. This is the
   actionable signal source on the current `rtc` 0.9 + WKWebView stack.
@@ -301,19 +326,26 @@ per-tile staleness check.
 - **Damage** comes from platform metadata when possible. On **X11**, XDamage
   (`display/capture/x11_damage.rs`) reports real OS-level dirty rects
   (`ReportLevel::BoundingBox`). On **macOS**, ScreenCaptureKit dirty rect
-  extraction is implemented but opt-in via `INTENDANT_MACOS_SCK_DIRTY_RECTS=1`
-  while the full-display WebRTC hot path is being validated. Other paths use a
-  CPU-bound **frame-diff fallback** (`display/capture/frame_diff.rs`) that hashes
-  every tile and emits the ones whose hash changed; where neither is available
-  the capability reports `None` and the policy forces video mode, so the platform
-  keeps the proven VP8 path until its damage backend lands.
+  extraction is **on by default** (`INTENDANT_MACOS_SCK_DIRTY_RECTS=0` is the
+  opt-out escape hatch): frames carry SCK's native dirty rects, a frame whose
+  sample lacks the attachment ships a conservative full-frame rect (the
+  Chromium missing-attachment rule), and the composited cursor
+  (`shows_cursor(true)`) is content change inside the same pipeline that mints
+  the rects — so the X11 hardware-cursor hazard does not transfer. Other paths
+  use a CPU-bound **frame-diff fallback** (`display/capture/frame_diff.rs`)
+  that hashes every tile and emits the ones whose hash changed; where neither
+  is available the capability reports `None` and the policy forces video mode,
+  so the platform keeps the proven VP8 path until its damage backend lands.
 - **Tile ↔ video fallback policy** (`display/tile/policy.rs`) switches to
   whole-frame video on high-motion content and back to tiles when motion subsides,
   with hysteresis to prevent flapping: **enter video at 25% dirty fraction
   (`ENTER_VIDEO_THRESHOLD`), exit at 15% (`EXIT_VIDEO_THRESHOLD`)**, over a
   rolling window of 8 samples (`HISTORY_K`), with a **500 ms minimum dwell**
-  (`MIN_DWELL`) capping switches at 2/sec. The fallback target is the proven VP8-q
-  video track, which stays up the whole time.
+  (`MIN_DWELL`) capping switches at 2/sec. The fallback target is the proven
+  VP8-q video track, which stays **negotiated** the whole time; while a
+  viewer's tile stream is active its video *encoders* idle in per-peer
+  standby (see the layer-policy section above), and the fallback edge
+  restores demand + forces a keyframe before the surface switch.
 - **Cursor** is sent as a separate `CursorState` frame on the control channel and
   drawn as a browser overlay sprite (Path A). X11 typically renders the cursor as
   a hardware overlay that does *not* fire XDamage, so dirtying tiles for cursor
@@ -520,9 +552,9 @@ Rates are computed over the elapsed window and counters reset on read.
 
 - **Physical-key-only input** breaks non-US keyboard layouts (Phase 1).
 - **Tile streaming still depends on data-channel viewers.** X11 uses XDamage;
-  macOS can use ScreenCaptureKit dirty rects when
-  `INTENDANT_MACOS_SCK_DIRTY_RECTS=1` is set and otherwise falls back to
-  frame-diff; Wayland currently uses the CPU-bound frame-diff path.
+  macOS uses ScreenCaptureKit dirty rects by default
+  (`INTENDANT_MACOS_SCK_DIRTY_RECTS=0` opts out to frame-diff); Wayland
+  currently uses the CPU-bound frame-diff path.
 - **Wayland enumeration is portal-limited** — true multi-monitor identity before
   a session opens is not available.
 - **`rtc` 0.9 doesn't surface TWCC or populate RR stats**, hence the interceptor

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -1776,9 +1776,10 @@ async fn display_request_rail_round_trips_over_ws() {
         .expect("send resolve_display_request");
 
         // The approval minted the real grant through the existing path.
-        // Emission order inside the control plane's approve arm: the grant
-        // event first, then the resolution — and a /ws reader consumes
-        // frames in order, so wait for them in that order.
+        // The grant event is emitted before the resolution inside the
+        // control plane's approve arm, so `user_display_granted` strictly
+        // precedes `display_request_resolved` on the wire — wait for it
+        // first.
         let granted = next_matching_ws_event(&mut ws, RUN_TIMEOUT, |json| {
             json.get("event").and_then(|v| v.as_str()) == Some("user_display_granted")
         })
@@ -1792,20 +1793,6 @@ async fn display_request_rail_round_trips_over_ws() {
         assert_eq!(granted["display_id"], 0, "{granted}");
         assert_eq!(granted["agent_visible"], true, "{granted}");
 
-        let resolved = next_matching_ws_event(&mut ws, RUN_TIMEOUT, |json| {
-            json.get("event").and_then(|v| v.as_str()) == Some("display_request_resolved")
-        })
-        .await
-        .unwrap_or_else(|| {
-            panic!(
-                "display_request_resolved never broadcast:\n{}",
-                daemon.log_tail()
-            )
-        });
-        assert_eq!(resolved["id"], id, "{resolved}");
-        assert_eq!(resolved["outcome"], "approved", "{resolved}");
-        assert_eq!(resolved["duration"], "until_revoked", "{resolved}");
-
         // The grant the approval minted also activated a capture session,
         // and under the suite-wide synthetic display mode that session is
         // the deterministic synthetic source on every platform: 1280×720,
@@ -1814,16 +1801,48 @@ async fn display_request_rail_round_trips_over_ws() {
         // report the host's real resolution (or never come up at all on a
         // headless runner). Any leg-0 display events were consumed by the
         // raised-matcher above, so the next display_ready is this leg's.
-        let ready = next_matching_ws_event(&mut ws, RUN_TIMEOUT, |json| {
-            json.get("event").and_then(|v| v.as_str()) == Some("display_ready")
-        })
-        .await
-        .unwrap_or_else(|| {
-            panic!(
-                "display_ready never broadcast after the approved grant:\n{}",
-                daemon.log_tail()
-            )
-        });
+        //
+        // `display_ready` and `display_request_resolved` are UNORDERED
+        // relative to each other: the resolution is sent by the approve
+        // arm after the grant event, but the activation runs concurrently
+        // on the display-lifecycle listener, so its `display_ready` can
+        // legally land between the grant and the resolution (observed on
+        // a loaded merge-group runner 2026-07-17 — a matcher that waited
+        // for `resolved` first silently consumed the interleaved
+        // `display_ready` and then starved for 180 s). Collect both
+        // order-tolerantly.
+        let mut resolved: Option<serde_json::Value> = None;
+        let mut ready: Option<serde_json::Value> = None;
+        while resolved.is_none() || ready.is_none() {
+            let event = next_matching_ws_event(&mut ws, RUN_TIMEOUT, |json| {
+                matches!(
+                    json.get("event").and_then(|v| v.as_str()),
+                    Some("display_request_resolved") | Some("display_ready")
+                )
+            })
+            .await
+            .unwrap_or_else(|| {
+                panic!(
+                    "approve leg still missing {}{} after the approved grant:\n{}",
+                    if resolved.is_none() {
+                        "display_request_resolved "
+                    } else {
+                        ""
+                    },
+                    if ready.is_none() { "display_ready" } else { "" },
+                    daemon.log_tail()
+                )
+            });
+            match event.get("event").and_then(|v| v.as_str()) {
+                Some("display_request_resolved") => resolved = Some(event),
+                _ => ready = Some(event),
+            }
+        }
+        let resolved = resolved.expect("loop exits only with both events");
+        let ready = ready.expect("loop exits only with both events");
+        assert_eq!(resolved["id"], id, "{resolved}");
+        assert_eq!(resolved["outcome"], "approved", "{resolved}");
+        assert_eq!(resolved["duration"], "until_revoked", "{resolved}");
         assert_eq!(ready["display_id"], 0, "{ready}");
         assert_eq!(ready["width"], 1280, "{ready}");
         assert_eq!(ready["height"], 720, "{ready}");


### PR DESCRIPTION
Propagates consumer demand one stage further upstream at each of three seams: the capture copy itself (X11/synthetic pacing), the damage source that feeds tile streaming (macOS SCK dirty rects), and per-peer video-encoder demand under tile mode. The staged bytes-frame-path buffer-pool work is deliberately **not** in this PR (separate later pass), and `crates/intendant-display/src/windows.rs` is untouched (parked draft #367 owns it — Windows dirty rects out of scope).

## 1. X11 capture demand pacing (`capture/pacing.rs`)

X11 SHM capture copied the entire screen at configured fps regardless of consumers (~249 MB/s at 1080p30 before any downstream work); the F2 idle gate stopped the BGRA→I420 conversion but the capture copy stayed demand-blind. Now `DisplaySession::start` composes a demand probe and installs it via a new default-no-op `DisplayBackend::set_capture_demand_probe` seam; the polling backends (X11, synthetic) pace against it:

- demand → full configured fps (unchanged);
- no demand → **1 fps keepalive**, sleeping in 50 ms slices that re-check the probe, so a demand edge restores full rate within one slice (still honoring the frame interval as a floor);
- keepalive iterations re-check X11 root geometry every frame (the 60-frame cadence would stretch to a minute at 1 fps).

**Rate reduction, never a stop** (doc-commented on the module + trait method): a stopped capture has cold-start latency (thread + SHM segment re-setup) and breaks `latest_frame` consumers outright; the 1 fps floor keeps `latest_frame` fresh enough for an instant first paint, a ≤1 s-stale screenshot, and the FrameRegistry's 1 Hz sampler — which is exactly why the floor is 1 fps and not slower. Event-driven backends (SCK, PipeWire, DXGI) ignore the probe: they already emit nothing while idle. `stop_capture` clears the probe so a restarted session paces fail-open (full rate) until the new session re-installs it.

### Frame-consumer enumeration (every `subscribe_frames` / `latest_frame`-family consumer)

Session-internal readers — served by the 1 fps keepalive **by design**, deliberately not demand classes (marking them would pin capture at full rate forever):

| # | Consumer | Path |
|---|---|---|
| i1 | Pool-feed bridge | `spawn_pool_feed_bridge` broadcast subscriber; conversion already gated by `has_active_consumer` ∪ burst (F2) |
| i2 | Tile-stream bridge | `spawn_tile_stream_bridge` broadcast subscriber; work gated on tile subscribers |
| i3 | FrameRegistry 1 Hz sampler | raw `latest_frame` RwLock reads inside `start()` (model feed; the keepalive floor's sizing rationale) |
| i4 | Tile snapshot senders | `send_latest_tile_snapshot_to_peer_id` raw reads (Subscribe / SnapshotRequest / gap recovery) |

External demand classes — ORed into the probe:

| # | Demand class | Covers |
|---|---|---|
| d1 | `EncoderPool::has_active_consumer()` | any unpaused always-on layer or subscribed, unpaused on-demand encoder (viewers) |
| d2 | Peer-join burst window (atomic deadline mirror of `signal_peer_join_burst`, also stamped at `fallback_to_video`) | joining peers, before the layer policy's resume lands |
| d3 | Tile-subscriber gauge (lock-free mirror of the async set, updated inside every mutation's critical section) | dirty-region streaming consumes raw frames independent of the encoders |
| d4 | External raw-frame subscribers: `frame_tx.receiver_count()` above the session-internal baseline | CU quiesce observation (`cu_observation::settle_via_session`), `fresh_frame`/`screenshot_fresh` waiters (`computer_use.rs` post-action captures), and any future caller-side `subscribe_frames` consumer automatically |
| d5 | Recent external read/input window (3 s, marked by `latest_frame`/`current_frame`/`fresh_frame`/`screenshot`/`screenshot_fresh` and `inject_input`) | recording bridge `latest_frame` polling (`recording.rs`), CU one-shot screenshots + `capture_display_screenshot`, the X11 all-black startup probe (`display_glue.rs::x11_fallback_session_is_all_black`), CU click→observe sequences (input is a frame-demand precursor) |

## 2. macOS SCK dirty rects: default ON (opt-out `INTENDANT_MACOS_SCK_DIRTY_RECTS=0`)

Without native rects, macOS tile streaming full-frame-hashes on the blocking pool at up to 15 Hz (frame-diff fallback). Validation performed before flipping:

- **Consumers.** `Frame::dirty_rects` has exactly two consumers, both verified to degrade per-frame, not per-session: the tile bridge (native rects when a frame carries them, frame-diff otherwise; `SCFrameStatus::Idle → Some([])` is trusted as "no change") and CU's quiesce settle (`cu_observation::frame_is_damage`, which already has the pinned `quiesce_trusts_empty_native_dirty_rects` test and gets cheaper — rects instead of FNV-hashing every frame).
- **Missing-attachment hardening.** A non-idle sample without the attachment now ships a **full-frame rect** instead of `None` (`dirty_rects_for_frame`), mirroring Chromium's conservative rule for the same condition (observed around stream reconfiguration). Handing `None` downstream would drop those frames into frame-diff against a baseline that stopped advancing while native rects were served — content reverting to a stale baseline hash would silently never repaint until the 30 s snapshot.
- **The cursor caveat.** The X11 lesson ("hardware-cursor moves fire no damage") does **not** transfer, but the "cursor ships out-of-band as CursorState" claim is X11-only, so it was verified rather than assumed: `damage.cursor_position()` is implemented only by the X11 damage backend (`capture/damage.rs` trait default `None`; macOS gets `NullDamageBackend`), so macOS sends **no** CursorState and injects no synthetic cursor rects. macOS instead composites the cursor **into** the captured pixels (`with_shows_cursor(true)`, `macos.rs`): cursor motion is content change inside the same pipeline that mints the dirty rects. Prior art agrees — Chromium/WebRTC's ScreenCaptureKit capturer drives its updated region from `SCStreamFrameInfoDirtyRects` with the cursor embedded and no cursor-specific compensation, at Chrome screen-sharing scale. Deliberately **not** adding CursorState on macOS: the browser overlay sprite on top of the composited cursor would render a double cursor.
- **Bound on residual risk.** Any staleness class that slips through is bounded by the tile protocol's periodic snapshot (30 s in tile mode) — the documented recovery bound. Live macOS tile-mode verification (alongside the federated/X11 smoke) is an operator check on real hardware, not CI (SCK is TCC-gated).

## 3. Per-peer RTP standby under tile mode

A federated viewer whose client paints tiles (video element hidden — `TileCompositor._showTileSurface`) now releases its demand on the video encoders instead of paying VP8/H.264 encode for a hidden surface.

**Design: demand-release via the layer-policy coordinator, not lease release.** The seam is `WebRtcPeer::video_standby` (per-peer flag) consumed by the coordinator — the single owner of pause/resume stays single:

- **Always-on bank (the default federated VP8-q case):** a standby peer contributes nothing to the #48 demanded / #57 pinned sets, so its layers pause unless another live, non-standby peer demands them — per-peer isolation falls out of the existing demand bound. Presence still counts standby peers (peers map), so the zero-peer pause semantics are untouched.
- **On-demand slots (H.264):** a new coordinator reconcile (`reconcile_on_demand_standby` + `OnDemandStandbyHooks`) attributes each subscribed slot (`EncoderPool::subscribed_on_demand_ids`) to holders by the peers' frozen `active_codec` + `active_rids`, and pauses a slot only when **every** holder is in standby (any non-standby holder keeps a shared slot running / resumes it). Slots with no attributable holder are left to the lease-refcount lifecycle. The **subscription (lease) is held through standby** — the chosen shape is the brief's "low-rate standby" family (encoder paused, subscription held) rather than lease release/re-subscribe, because a release tears the encoder down at refcount 0 and re-acquiring respawns it (ffmpeg process / VideoToolbox session) with cold-start latency that would eat the fallback budget; a paused slot resumes with an atomic flag flip + forced keyframe instead. No periodic keyframe during standby: with the coordinator kick (below) the fresh keyframe arrives within roughly one bridge tick + encode of the fallback edge, so warming the decoder with stale periodic keyframes buys nothing.
- **Fallback SLA (a):** the tile bridge's `fallback_to_video` edge — *before* sending the control frame that makes browsers switch surfaces — clears standby for every subscriber, **kicks** the coordinator (new `Notify` input; runs the same evaluation as a tick, immediately; storms coalesce) so the resume lands now instead of ≤1 s later, and reuses the peer-join machinery (`request_keyframe_all` + the pool-feed burst window). The resume's paused→active edge forces a keyframe (pre-existing pool contract, pinned by `pool_resume_layer_from_paused_sets_force_keyframe`); the burst clocks the pool-feed bridge through the transition exactly as a peer join does.
- **(b) other viewers unaffected:** per-peer by construction — any non-standby peer's demand keeps its layers/slots running (asserted by `spawn_coordinator_standby_peer_releases_only_its_layers` and `on_demand_reconcile_keeps_slot_for_non_standby_holder`).
- **(c) coordinator coherence:** standby only narrows demanded/pinned and adds the on-demand reconcile; presence, TWCC, and RR policies are untouched, and all-standby demand collapse uses the same immediate-pause path #48 already defined for zero demand.
- **Standby edges:** engaged at tile-control `Subscribe` (when the bridge is in tile mode — registration alone doesn't engage it; the federated offer path registers every tile-capable peer before the browser is actually on tiles) and at `fallback_to_tile` (after the baseline snapshot is queued); cleared at `fallback_to_video`, on `unregister_tile_subscriber` for a still-connected peer, and implicitly by peer teardown.
- **Latent mismatch fixed:** a resize while in video fallback resets the server to tile mode without telling browsers, which historically stayed on the (still-encoding) video surface while deltas applied to a hidden canvas. With standby that would present as frozen video, so the resize path now converges the surface explicitly (`FallbackToTile` alongside the `Resize`, same epoch, snapshot follows) and re-engages standby.

## Tests

- `capture/pacing.rs`: probe fail-open default + clear semantics, full-rate pacing, keepalive interval coverage, demand-edge wake within slices (with the full-rate floor), prompt shutdown exit.
- `lib.rs`: session-level pacing through a real `DisplaySession` on the synthetic backend (keepalive on no demand → full rate on an external subscriber → keepalive again → burst counts as demand), asserted on the pacing seam's mode counters rather than wall-clock rates; tile-subscriber gauge mirrored through every mutation path (incl. the register-races-fast-close rollback and the reaper); standby engage on Subscribe-in-tile-mode / clear on unregister / no-engage during video fallback.
- `aggregator.rs`: pure `reconcile_on_demand_standby` tests (pause on all-holders-standby + convergence, keep/resume with a non-standby holder, skip unattributed slots); spawned-coordinator test with two peers (one tiles/standby on `q`, one video on `f`) asserting exactly `{h,q}` pause and `q` resuming after standby-clear + kick.
- `encode/pool/mod.rs`: a paused on-demand slot is not an active consumer (the F2 conversion gate collapses for tile-only sessions) while `subscribed_on_demand_ids` keeps listing it through standby.
- `macos.rs`: default-ON with env opt-out spellings pinned; missing-attachment → full-frame rect; existing dirty-rect scaling tests unchanged.

## Scope notes / deviations

- `windows.rs` is untouched per the #367 ownership constraint, so **Windows GDI polling keeps its current demand-blind capture cadence** — only the F2 conversion gate (#427) applies there. Wiring the (default-no-op) demand probe into the Windows capture loop is a natural follow-up once #367 lands.
- Wayland/PipeWire and macOS SCK are event-driven and correctly ignore the probe (no idle frames to pace away).

## Merge-queue ejection 2026-07-17: root cause + fix (566b2f18)

The first queue attempt was ejected by `display_request_rail_round_trips_over_ws` on the Linux group leg ("display_ready never broadcast after the approved grant", 180 s starve). Root cause is a **pre-existing ordering race in the test**, not the pacing change: the approve arm emits `user_display_granted` before `display_request_resolved`, but the activation the grant triggers runs concurrently on the display-lifecycle listener — its one-shot `display_ready` can interleave between the two, where the test's resolved-first matcher silently consumed it and the ready-matcher then starved. The failing daemon tail actually shows the pacing working as designed (session alive, `capture=1.0fps` keepalive metrics for 3+ minutes). Proof: widening the grant→resolved window by 150 ms reproduces the exact failure signature deterministically on the Linux fleet box with the unmodified test; the order-tolerant matcher in `566b2f18` passes under the same amplifier and in clean runs (Linux full suite 6x green, single test green, local macOS suite green).

## Verification notes

Live federated/X11 verification (keepalive pacing on the real X11 box, tile-standby encoder pause + fallback re-paint over a federated link) is an operator smoke on the peer-test rig, not CI. macOS live tile-mode dirty-rect verification is likewise operator hardware (SCK is TCC-gated).
