### PR TITLE
transcripts: content-aware user-turn assignment for mid-turn steers

### DIFF
--- a/src/bin/caller/external_agent/transcript_text.rs
+++ b/src/bin/caller/external_agent/transcript_text.rs
@@ -59,6 +59,12 @@ pub(crate) fn is_injected_external_user_text(text: &str) -> bool {
     let trimmed = text.trim_start();
     trimmed.starts_with("# AGENTS.md instructions for ")
         || trimmed.starts_with("<turn_aborted>")
+        // Claude Code's synthetic abort markers ("[Request interrupted by
+        // user]", "…for tool use]") ride user messages; the live adapter
+        // deliberately drops them (`claude_code.rs::handle_user` — the
+        // `result` message carries the outcome), so no transcript surface
+        // may render them as user speech or count them as user turns.
+        || trimmed.starts_with("[Request interrupted by user")
         || trimmed.starts_with("<subagent_notification>")
         || trimmed.starts_with("<environment_context>")
         || trimmed.starts_with("<task-notification>")

--- a/src/bin/caller/web_gateway/session_catalog/mod.rs
+++ b/src/bin/caller/web_gateway/session_catalog/mod.rs
@@ -24,6 +24,8 @@ mod rows_usage;
 pub(crate) use rows_usage::*;
 pub(crate) mod backend_lists;
 pub(crate) use backend_lists::*;
+mod steer_ledger;
+pub(crate) use steer_ledger::*;
 mod transcripts;
 pub(crate) use transcripts::*;
 

--- a/src/bin/caller/web_gateway/session_catalog/steer_ledger.rs
+++ b/src/bin/caller/web_gateway/session_catalog/steer_ledger.rs
@@ -1,0 +1,460 @@
+//! Mid-turn steer ledger: the wrapper session log's record of which steer
+//! texts entered the backend conversation INSIDE an already-running turn.
+//!
+//! Why it exists: a mid-turn steer (Codex `turn/steer`) puts a plain user
+//! message into the backend's own transcript without incrementing the
+//! wrapper's round counter — the live lane logs it via
+//! `emit_user_message_log` with NO `user_turn_index` (see the accept path
+//! in `external_events.rs`). Blind positional counting in the transcript
+//! parsers therefore drifts after every mid-turn steer: hydrated user rows
+//! claim indexes the live lane never emitted, post-steer follow-ups miss
+//! the text-signature dedupe bridge, and edit/rewind affordances target
+//! the wrong turn. The parsers consult this ledger to classify a
+//! transcript user row as a mid-turn steer (rendered WITHOUT turn
+//! metadata, exactly like its live row) instead of burning a turn index
+//! on it.
+//!
+//! Ground truth is the wrapper's own `session.jsonl`: `steer_requested`
+//! carries the steer text, `steer_accepted` marks the runtime accepting a
+//! mid-turn injection (the Codex `turn/steer` OK path), and
+//! `steer_delivered` with `mid_turn: true` marks its checkpoint flush.
+//! Boundary-drained steers (`mid_turn: false`) never enter the ledger:
+//! their text reaches the backend inside a counted follow-up message (the
+//! `[User] …` merge in `drain_steer_queue_as_followup`), so positional
+//! counting already agrees with the wrapper for them.
+//!
+//! Safety bar (matches PR #444's): classification may only WITHHOLD turn
+//! metadata from a row the live lane also showed without metadata — it
+//! never suppresses or merges rows. Each ledger entry is consumed at most
+//! once, so a legitimately repeated identical prompt still mints its own
+//! turn, and consumption is timestamp-guarded so a transcript row that
+//! predates the steer request can never be misclassified.
+
+use super::*;
+
+/// Clock slack for the "a steer's transcript row cannot predate its
+/// request" guard. Both timestamps come from the same host (the daemon
+/// stamps `steer_requested`, the backend CLI stamps its transcript line)
+/// but through different processes and precisions — Codex rollout lines
+/// can carry second-precision timestamps, so the guard must tolerate at
+/// least one second of rounding. Kept small on purpose: the guard is what
+/// makes a cached parse of an unchanged transcript invariant under ledger
+/// growth (new entries can only match rows written after the request).
+pub(crate) const MID_TURN_STEER_ROW_TS_SLACK_MS: i64 = 2_000;
+
+#[derive(Clone, Debug)]
+pub(crate) struct ExternalSteerLedgerEntry {
+    /// Trimmed steer text — the same text the live `UserMessageLog` row
+    /// carried and the backend recorded as a user message.
+    pub(crate) text: String,
+    /// `ts_ms` of the `steer_requested` event, when the log carried one.
+    pub(crate) requested_ts_ms: Option<i64>,
+}
+
+/// Mid-turn steer texts for one external session, in request order.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ExternalSteerLedger {
+    entries: Vec<ExternalSteerLedgerEntry>,
+}
+
+impl ExternalSteerLedger {
+    #[cfg(test)]
+    pub(crate) fn from_entries(entries: Vec<ExternalSteerLedgerEntry>) -> Self {
+        Self { entries }
+    }
+
+    pub(crate) fn cursor(&self) -> ExternalSteerCursor<'_> {
+        ExternalSteerCursor {
+            entries: &self.entries,
+            consumed: vec![false; self.entries.len()],
+        }
+    }
+}
+
+/// Per-parse consumption state over a shared ledger: each entry justifies
+/// AT MOST one turnless user row, so identical repeated prompts keep
+/// minting distinct turns once the matching steer entries are spent.
+pub(crate) struct ExternalSteerCursor<'a> {
+    entries: &'a [ExternalSteerLedgerEntry],
+    consumed: Vec<bool>,
+}
+
+impl ExternalSteerCursor<'_> {
+    /// True iff `text` matches an unconsumed mid-turn steer entry whose
+    /// request does not postdate the row (within clock slack); consumes
+    /// the matched entry. Rows without a parseable timestamp are never
+    /// classified as steers (fail-closed: a phantom turn index is the
+    /// known pre-existing failure mode; misclassifying an unrelated row
+    /// would be a new one).
+    pub(crate) fn try_consume_mid_turn_steer(
+        &mut self,
+        text: &str,
+        row_ts_ms: Option<i64>,
+    ) -> bool {
+        let text = text.trim();
+        if text.is_empty() {
+            return false;
+        }
+        let Some(row_ts_ms) = row_ts_ms else {
+            return false;
+        };
+        for (index, entry) in self.entries.iter().enumerate() {
+            if self.consumed[index] || entry.text != text {
+                continue;
+            }
+            if let Some(requested_ts_ms) = entry.requested_ts_ms {
+                if row_ts_ms.saturating_add(MID_TURN_STEER_ROW_TS_SLACK_MS) < requested_ts_ms {
+                    continue;
+                }
+            }
+            self.consumed[index] = true;
+            return true;
+        }
+        false
+    }
+}
+
+/// Wrapper log dirs consulted for the ledger: the managed-context named
+/// dir, the wrapper-index records, and the session-list cache's observed
+/// dirs. Deliberately NOT the recent-log content scan that
+/// `external_context_snapshot_replay_log_dirs` falls back to — a session
+/// with no known wrapper has no live turn lane to align with (foreign or
+/// imported transcripts), and the content scan reads whole logs per fetch.
+/// Returns each dir with the wrapper session ids that may label its steer
+/// events (`data.session_id` is the LIVE session address at request time,
+/// which can be the wrapper id before the native backend id is announced).
+fn external_steer_ledger_log_dirs(
+    home: &Path,
+    source: &str,
+    session_id: &str,
+) -> Vec<(PathBuf, Vec<String>)> {
+    let mut dirs: Vec<(PathBuf, Vec<String>)> = Vec::new();
+    let mut seen_dirs: HashSet<String> = HashSet::new();
+    let mut push_dir = |dirs: &mut Vec<(PathBuf, Vec<String>)>, path: PathBuf, alias: Option<String>| {
+        let key = std::fs::canonicalize(&path)
+            .unwrap_or_else(|_| path.clone())
+            .to_string_lossy()
+            .to_string();
+        let dir_name_alias = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(str::to_string);
+        if seen_dirs.insert(key) {
+            let mut aliases = Vec::new();
+            aliases.extend(dir_name_alias);
+            aliases.extend(alias);
+            dirs.push((path, aliases));
+        } else if let Some(alias) = alias {
+            if let Some((_, aliases)) = dirs.iter_mut().find(|(existing, _)| *existing == path) {
+                if !aliases.contains(&alias) {
+                    aliases.push(alias);
+                }
+            }
+        }
+    };
+
+    if let Some(path) = managed_context_named_log_dir(home, session_id) {
+        push_dir(&mut dirs, path, None);
+    }
+    for record in crate::external_wrapper_index::wrappers_for(home, source, session_id) {
+        let alias = Some(record.intendant_session_id.clone()).filter(|id| !id.trim().is_empty());
+        push_dir(&mut dirs, PathBuf::from(record.log_path), alias);
+    }
+    for path in cached_intendant_log_dirs_for_session_id(session_id) {
+        push_dir(&mut dirs, path, None);
+    }
+
+    dirs
+}
+
+/// Build the mid-turn steer ledger for `(source, session_id)` from its
+/// wrapper session logs. Requested texts join accepted/mid-turn-delivered
+/// ids across all discovered logs (a resumed session's request and
+/// delivery can land in different wrapper epochs).
+pub(crate) fn external_mid_turn_steer_ledger(
+    home: &Path,
+    source: &str,
+    session_id: &str,
+) -> ExternalSteerLedger {
+    struct RequestedSteer {
+        text: String,
+        ts_ms: Option<i64>,
+        order: usize,
+    }
+    let mut requested: HashMap<String, RequestedSteer> = HashMap::new();
+    let mut injected_ids: HashSet<String> = HashSet::new();
+    let mut order = 0usize;
+
+    for (dir, aliases) in external_steer_ledger_log_dirs(home, source, session_id) {
+        let Ok(file) = std::fs::File::open(dir.join("session.jsonl")) else {
+            continue;
+        };
+        let reader = std::io::BufReader::new(file);
+        for line in std::io::BufRead::lines(reader) {
+            let Ok(line) = line else {
+                continue;
+            };
+            // Substring prefilter keeps the JSON parse off the (vastly
+            // dominant) non-steer lines.
+            if !line.contains("steer_") {
+                continue;
+            }
+            let Ok(event) = serde_json::from_str::<serde_json::Value>(&line) else {
+                continue;
+            };
+            let event_kind = event.get("event").and_then(|v| v.as_str()).unwrap_or("");
+            if !matches!(
+                event_kind,
+                "steer_requested" | "steer_accepted" | "steer_delivered"
+            ) {
+                continue;
+            }
+            let data = event.get("data");
+            // Steers for OTHER sessions sharing this wrapper log (side
+            // threads, Codex subagents) must not leak into this
+            // transcript's ledger; an absent session id means the
+            // wrapper's primary session — this one.
+            let event_session_id = data
+                .and_then(|d| d.get("session_id"))
+                .and_then(|v| v.as_str())
+                .map(str::trim)
+                .unwrap_or("");
+            if !event_session_id.is_empty()
+                && event_session_id != session_id
+                && !aliases.iter().any(|alias| alias == event_session_id)
+            {
+                continue;
+            }
+            let Some(id) = data
+                .and_then(|d| d.get("id"))
+                .and_then(|v| v.as_str())
+                .map(str::trim)
+                .filter(|id| !id.is_empty())
+            else {
+                continue;
+            };
+            match event_kind {
+                "steer_requested" => {
+                    let Some(text) = data
+                        .and_then(|d| d.get("text"))
+                        .and_then(|v| v.as_str())
+                        .map(str::trim)
+                        .filter(|text| !text.is_empty())
+                    else {
+                        continue;
+                    };
+                    requested.entry(id.to_string()).or_insert_with(|| {
+                        order += 1;
+                        RequestedSteer {
+                            text: text.to_string(),
+                            ts_ms: event.get("ts_ms").and_then(|v| v.as_i64()),
+                            order,
+                        }
+                    });
+                }
+                "steer_accepted" => {
+                    injected_ids.insert(id.to_string());
+                }
+                "steer_delivered" => {
+                    if data
+                        .and_then(|d| d.get("mid_turn"))
+                        .and_then(|v| v.as_bool())
+                        == Some(true)
+                    {
+                        injected_ids.insert(id.to_string());
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let mut matched: Vec<RequestedSteer> = requested
+        .into_iter()
+        .filter_map(|(id, entry)| injected_ids.contains(&id).then_some(entry))
+        .collect();
+    matched.sort_by_key(|entry| (entry.ts_ms.unwrap_or(i64::MAX), entry.order));
+    ExternalSteerLedger {
+        entries: matched
+            .into_iter()
+            .map(|entry| ExternalSteerLedgerEntry {
+                text: entry.text,
+                requested_ts_ms: entry.ts_ms,
+            })
+            .collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn steer_line(
+        event: &str,
+        ts_ms: i64,
+        id: &str,
+        session_id: Option<&str>,
+        text: Option<&str>,
+        mid_turn: Option<bool>,
+    ) -> String {
+        let mut data = serde_json::json!({ "id": id, "status": "x" });
+        if let Some(session_id) = session_id {
+            data["session_id"] = serde_json::json!(session_id);
+        }
+        if let Some(text) = text {
+            data["text"] = serde_json::json!(text);
+        }
+        if let Some(mid_turn) = mid_turn {
+            data["mid_turn"] = serde_json::json!(mid_turn);
+        }
+        serde_json::json!({
+            "ts": "12:00:00",
+            "ts_ms": ts_ms,
+            "event": event,
+            "level": "info",
+            "message": format!("Steer {event}"),
+            "data": data,
+        })
+        .to_string()
+    }
+
+    fn write_wrapper_log(home: &Path, wrapper_id: &str, lines: &[String]) -> PathBuf {
+        let dir = home
+            .join(".intendant")
+            .join("logs")
+            .join(wrapper_id);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("session.jsonl"), lines.join("\n")).unwrap();
+        dir
+    }
+
+    /// Requested+accepted (the Codex `turn/steer` OK arc) and
+    /// requested+delivered-mid-turn both enter the ledger; queued
+    /// boundary deliveries (`mid_turn: false`) and requested-only steers
+    /// do not — their texts reach the backend inside counted follow-up
+    /// messages (or never), so classifying them as turnless would
+    /// re-create the drift in the other direction.
+    #[test]
+    fn ledger_admits_only_mid_turn_injected_steers() {
+        let home = tempfile::tempdir().unwrap();
+        let backend_id = "0199aaaa-ledger-admission";
+        let wrapper_id = "wrapper-ledger-admission";
+        let dir = write_wrapper_log(
+            home.path(),
+            wrapper_id,
+            &[
+                steer_line("steer_requested", 1_000, "s-accepted", None, Some("also do B"), None),
+                steer_line("steer_accepted", 1_001, "s-accepted", None, None, None),
+                steer_line("steer_requested", 2_000, "s-boundary", None, Some("queued text"), None),
+                steer_line("steer_delivered", 2_500, "s-boundary", None, None, Some(false)),
+                steer_line("steer_requested", 3_000, "s-pending", None, Some("never landed"), None),
+                steer_line("steer_requested", 4_000, "s-checkpoint", None, Some("mid checkpoint"), None),
+                steer_line("steer_delivered", 4_500, "s-checkpoint", None, None, Some(true)),
+            ],
+        );
+        crate::external_wrapper_index::upsert(
+            home.path(),
+            "codex",
+            backend_id,
+            wrapper_id,
+            &dir,
+            None,
+        )
+        .unwrap();
+
+        let ledger = external_mid_turn_steer_ledger(home.path(), "codex", backend_id);
+        let texts: Vec<&str> = ledger.entries.iter().map(|e| e.text.as_str()).collect();
+        assert_eq!(texts, vec!["also do B", "mid checkpoint"]);
+        assert_eq!(ledger.entries[0].requested_ts_ms, Some(1_000));
+    }
+
+    /// Steer events labeled with ANOTHER session id (side threads and
+    /// Codex subagents share the wrapper log) stay out of this
+    /// transcript's ledger, while events labeled with the wrapper's own
+    /// intendant session id (the live address before the native backend
+    /// id is announced) are admitted.
+    #[test]
+    fn ledger_filters_other_sessions_but_admits_wrapper_alias() {
+        let home = tempfile::tempdir().unwrap();
+        let backend_id = "0199aaaa-ledger-alias";
+        let wrapper_id = "wrapper-ledger-alias";
+        let dir = write_wrapper_log(
+            home.path(),
+            wrapper_id,
+            &[
+                steer_line(
+                    "steer_requested",
+                    1_000,
+                    "s-side",
+                    Some("side-thread-id"),
+                    Some("side steer"),
+                    None,
+                ),
+                steer_line("steer_accepted", 1_001, "s-side", Some("side-thread-id"), None, None),
+                steer_line(
+                    "steer_requested",
+                    2_000,
+                    "s-alias",
+                    Some(wrapper_id),
+                    Some("alias steer"),
+                    None,
+                ),
+                steer_line("steer_accepted", 2_001, "s-alias", Some(wrapper_id), None, None),
+                steer_line(
+                    "steer_requested",
+                    3_000,
+                    "s-backend",
+                    Some(backend_id),
+                    Some("backend steer"),
+                    None,
+                ),
+                steer_line("steer_accepted", 3_001, "s-backend", Some(backend_id), None, None),
+            ],
+        );
+        crate::external_wrapper_index::upsert(
+            home.path(),
+            "codex",
+            backend_id,
+            wrapper_id,
+            &dir,
+            None,
+        )
+        .unwrap();
+
+        let ledger = external_mid_turn_steer_ledger(home.path(), "codex", backend_id);
+        let texts: Vec<&str> = ledger.entries.iter().map(|e| e.text.as_str()).collect();
+        assert_eq!(texts, vec!["alias steer", "backend steer"]);
+    }
+
+    /// Consumption is one-shot and timestamp-guarded: an entry matches at
+    /// most one row, never a row that predates its request (beyond clock
+    /// slack), and never a row without a parseable timestamp. The guard is
+    /// what keeps a cached parse of an unchanged transcript invariant
+    /// under ledger growth.
+    #[test]
+    fn cursor_consumption_is_one_shot_and_ts_guarded() {
+        let ledger = ExternalSteerLedger::from_entries(vec![ExternalSteerLedgerEntry {
+            text: "keep going".to_string(),
+            requested_ts_ms: Some(10_000),
+        }]);
+        let mut cursor = ledger.cursor();
+        assert!(
+            !cursor.try_consume_mid_turn_steer("keep going", Some(10_000 - 5_000)),
+            "a row written before the request cannot be its steer"
+        );
+        assert!(
+            !cursor.try_consume_mid_turn_steer("keep going", None),
+            "rows without timestamps fail closed (stay counted turns)"
+        );
+        assert!(
+            !cursor.try_consume_mid_turn_steer("different text", Some(11_000)),
+            "text must match exactly (trimmed)"
+        );
+        assert!(cursor.try_consume_mid_turn_steer("  keep going  ", Some(11_000)));
+        assert!(
+            !cursor.try_consume_mid_turn_steer("keep going", Some(12_000)),
+            "an entry justifies at most one turnless row — the repeated \
+             identical prompt after it stays a real turn"
+        );
+    }
+}

--- a/src/bin/caller/web_gateway/session_catalog/steer_ledger.rs
+++ b/src/bin/caller/web_gateway/session_catalog/steer_ledger.rs
@@ -130,7 +130,9 @@ fn external_steer_ledger_log_dirs(
 ) -> Vec<(PathBuf, Vec<String>)> {
     let mut dirs: Vec<(PathBuf, Vec<String>)> = Vec::new();
     let mut seen_dirs: HashSet<String> = HashSet::new();
-    let mut push_dir = |dirs: &mut Vec<(PathBuf, Vec<String>)>, path: PathBuf, alias: Option<String>| {
+    let mut push_dir = |dirs: &mut Vec<(PathBuf, Vec<String>)>,
+                        path: PathBuf,
+                        alias: Option<String>| {
         let key = std::fs::canonicalize(&path)
             .unwrap_or_else(|_| path.clone())
             .to_string_lossy()
@@ -255,14 +257,13 @@ pub(crate) fn external_mid_turn_steer_ledger(
                 "steer_accepted" => {
                     injected_ids.insert(id.to_string());
                 }
-                "steer_delivered" => {
+                "steer_delivered"
                     if data
                         .and_then(|d| d.get("mid_turn"))
                         .and_then(|v| v.as_bool())
-                        == Some(true)
-                    {
-                        injected_ids.insert(id.to_string());
-                    }
+                        == Some(true) =>
+                {
+                    injected_ids.insert(id.to_string());
                 }
                 _ => {}
             }
@@ -319,10 +320,7 @@ mod tests {
     }
 
     fn write_wrapper_log(home: &Path, wrapper_id: &str, lines: &[String]) -> PathBuf {
-        let dir = home
-            .join(".intendant")
-            .join("logs")
-            .join(wrapper_id);
+        let dir = home.join(".intendant").join("logs").join(wrapper_id);
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("session.jsonl"), lines.join("\n")).unwrap();
         dir
@@ -343,13 +341,55 @@ mod tests {
             home.path(),
             wrapper_id,
             &[
-                steer_line("steer_requested", 1_000, "s-accepted", None, Some("also do B"), None),
+                steer_line(
+                    "steer_requested",
+                    1_000,
+                    "s-accepted",
+                    None,
+                    Some("also do B"),
+                    None,
+                ),
                 steer_line("steer_accepted", 1_001, "s-accepted", None, None, None),
-                steer_line("steer_requested", 2_000, "s-boundary", None, Some("queued text"), None),
-                steer_line("steer_delivered", 2_500, "s-boundary", None, None, Some(false)),
-                steer_line("steer_requested", 3_000, "s-pending", None, Some("never landed"), None),
-                steer_line("steer_requested", 4_000, "s-checkpoint", None, Some("mid checkpoint"), None),
-                steer_line("steer_delivered", 4_500, "s-checkpoint", None, None, Some(true)),
+                steer_line(
+                    "steer_requested",
+                    2_000,
+                    "s-boundary",
+                    None,
+                    Some("queued text"),
+                    None,
+                ),
+                steer_line(
+                    "steer_delivered",
+                    2_500,
+                    "s-boundary",
+                    None,
+                    None,
+                    Some(false),
+                ),
+                steer_line(
+                    "steer_requested",
+                    3_000,
+                    "s-pending",
+                    None,
+                    Some("never landed"),
+                    None,
+                ),
+                steer_line(
+                    "steer_requested",
+                    4_000,
+                    "s-checkpoint",
+                    None,
+                    Some("mid checkpoint"),
+                    None,
+                ),
+                steer_line(
+                    "steer_delivered",
+                    4_500,
+                    "s-checkpoint",
+                    None,
+                    None,
+                    Some(true),
+                ),
             ],
         );
         crate::external_wrapper_index::upsert(
@@ -390,7 +430,14 @@ mod tests {
                     Some("side steer"),
                     None,
                 ),
-                steer_line("steer_accepted", 1_001, "s-side", Some("side-thread-id"), None, None),
+                steer_line(
+                    "steer_accepted",
+                    1_001,
+                    "s-side",
+                    Some("side-thread-id"),
+                    None,
+                    None,
+                ),
                 steer_line(
                     "steer_requested",
                     2_000,
@@ -399,7 +446,14 @@ mod tests {
                     Some("alias steer"),
                     None,
                 ),
-                steer_line("steer_accepted", 2_001, "s-alias", Some(wrapper_id), None, None),
+                steer_line(
+                    "steer_accepted",
+                    2_001,
+                    "s-alias",
+                    Some(wrapper_id),
+                    None,
+                    None,
+                ),
                 steer_line(
                     "steer_requested",
                     3_000,
@@ -408,7 +462,14 @@ mod tests {
                     Some("backend steer"),
                     None,
                 ),
-                steer_line("steer_accepted", 3_001, "s-backend", Some(backend_id), None, None),
+                steer_line(
+                    "steer_accepted",
+                    3_001,
+                    "s-backend",
+                    Some(backend_id),
+                    None,
+                    None,
+                ),
             ],
         );
         crate::external_wrapper_index::upsert(

--- a/src/bin/caller/web_gateway/session_catalog/transcripts.rs
+++ b/src/bin/caller/web_gateway/session_catalog/transcripts.rs
@@ -331,6 +331,7 @@ pub(crate) fn codex_removed_turn_ids_for_user_turns(
 pub(crate) fn push_codex_transcript_message(
     entries: &mut Vec<serde_json::Value>,
     user_turn_revisions: &mut ReplayUserTurnRevisionState,
+    steer_cursor: &mut ExternalSteerCursor<'_>,
     pending_replacement_for_user_turn: &mut Option<u32>,
     synthetic_item_seq: &mut u64,
     item_id: Option<&str>,
@@ -350,14 +351,31 @@ pub(crate) fn push_codex_transcript_message(
     let mut user_turn_index = None;
     let mut user_turn_revision = None;
     if normalized_role == "user" {
-        let (recorded_turn_index, recorded_turn_revision) = user_turn_revisions.record_next_turn();
-        user_turn_index = Some(recorded_turn_index);
-        user_turn_revision = Some(recorded_turn_revision);
-        if let Some(entry) = entries.last_mut() {
-            entry["user_turn_index"] = serde_json::json!(recorded_turn_index);
-            entry["user_turn_revision"] = serde_json::json!(recorded_turn_revision);
-            if let Some(turn) = pending_replacement_for_user_turn.take() {
-                entry["replacement_for_user_turn_index"] = serde_json::json!(turn);
+        // Mid-turn steers are user rows the wrapper never counted: the
+        // live lane logged them WITHOUT turn metadata (the `turn/steer`
+        // accept path), so hydration must render them the same way and
+        // must not burn a turn index — otherwise every later prompt
+        // drifts out of alignment with the wrapper's round counter (and
+        // the frontend's text-signature dedupe bridge with it).
+        let rendered_content = entries
+            .last()
+            .and_then(|entry| entry.get("content"))
+            .and_then(|value| value.as_str())
+            .unwrap_or("")
+            .to_string();
+        let is_mid_turn_steer = steer_cursor
+            .try_consume_mid_turn_steer(&rendered_content, timestamp_millis_from_str(ts));
+        if !is_mid_turn_steer {
+            let (recorded_turn_index, recorded_turn_revision) =
+                user_turn_revisions.record_next_turn();
+            user_turn_index = Some(recorded_turn_index);
+            user_turn_revision = Some(recorded_turn_revision);
+            if let Some(entry) = entries.last_mut() {
+                entry["user_turn_index"] = serde_json::json!(recorded_turn_index);
+                entry["user_turn_revision"] = serde_json::json!(recorded_turn_revision);
+                if let Some(turn) = pending_replacement_for_user_turn.take() {
+                    entry["replacement_for_user_turn_index"] = serde_json::json!(turn);
+                }
             }
         }
     }
@@ -394,11 +412,15 @@ pub(crate) fn push_codex_transcript_message(
     }
 }
 
-pub(crate) fn parse_codex_session_entries(path: &Path) -> Option<Vec<serde_json::Value>> {
+pub(crate) fn parse_codex_session_entries(
+    path: &Path,
+    steers: &ExternalSteerLedger,
+) -> Option<Vec<serde_json::Value>> {
     let file = std::fs::File::open(path).ok()?;
     let reader = std::io::BufReader::new(file);
     let mut entries: Vec<serde_json::Value> = Vec::new();
     let mut user_turn_revisions = ReplayUserTurnRevisionState::default();
+    let mut steer_cursor = steers.cursor();
     let mut pending_replacement_for_user_turn: Option<u32> = None;
     let mut rollout_session_id: Option<String> = None;
     let mut current_turn_id: Option<String> = None;
@@ -576,6 +598,7 @@ pub(crate) fn parse_codex_session_entries(path: &Path) -> Option<Vec<serde_json:
                 push_codex_transcript_message(
                     &mut entries,
                     &mut user_turn_revisions,
+                    &mut steer_cursor,
                     &mut pending_replacement_for_user_turn,
                     &mut synthetic_item_seq,
                     response_item_id.as_deref(),
@@ -603,6 +626,7 @@ pub(crate) fn parse_codex_session_entries(path: &Path) -> Option<Vec<serde_json:
                 push_codex_transcript_message(
                     &mut entries,
                     &mut user_turn_revisions,
+                    &mut steer_cursor,
                     &mut pending_replacement_for_user_turn,
                     &mut synthetic_item_seq,
                     response_item_id.as_deref(),
@@ -823,12 +847,24 @@ pub(crate) fn codex_session_canonical_lanes(path: &Path) -> (bool, bool) {
 /// initial prompt rendered twice in the Activity log (observed live: a
 /// 6s create→ready gap put the copies in different near-time buckets).
 ///
+/// Counting is content-aware, not blind: user rows whose text the
+/// wrapper's steer ledger proves entered mid-turn (`steers`) render
+/// WITHOUT turn metadata — the live lane logged those with no index —
+/// so post-steer prompts keep the wrapper's numbering. Synthetic
+/// interrupt markers (`[Request interrupted by user…]`) are dropped
+/// entirely, mirroring the live adapter's disposition
+/// (`claude_code.rs::handle_user`): the live feed never rendered them,
+/// and burning indexes on them shifted every later prompt.
+///
 /// The flat predecessor extracted every block's text with
 /// `message_content_text` and stamped user-role envelopes as source
 /// `"user"` — which put tool_result payloads (command output!) in the log
 /// as USER speech, dropped tool-call rows entirely, and used a source
 /// label ("claude") the live rows never carry ("Claude Code").
-pub(crate) fn parse_claude_session_entries(path: &Path) -> Option<Vec<serde_json::Value>> {
+pub(crate) fn parse_claude_session_entries(
+    path: &Path,
+    steers: &ExternalSteerLedger,
+) -> Option<Vec<serde_json::Value>> {
     let file = std::fs::File::open(path).ok()?;
     let reader = std::io::BufReader::new(file);
     let mut entries = Vec::new();
@@ -840,6 +876,7 @@ pub(crate) fn parse_claude_session_entries(path: &Path) -> Option<Vec<serde_json
     // initial prompt hydrates as turn 1 rev 1 — the values the live
     // `UserMessageLog` row carries.
     let mut user_turn_revisions = ReplayUserTurnRevisionState::default();
+    let mut steer_cursor = steers.cursor();
 
     for line in reader.lines() {
         let Ok(line) = line else {
@@ -900,14 +937,21 @@ pub(crate) fn parse_claude_session_entries(path: &Path) -> Option<Vec<serde_json
         if let Some(text) = content.and_then(|c| c.as_str()) {
             let text = user_prose(text);
             if typ == "user" && !text.is_empty() && !is_injected_external_user_text(&text) {
-                let (user_turn_index, user_turn_revision) = user_turn_revisions.record_next_turn();
-                push(serde_json::json!({
+                let mut entry = serde_json::json!({
                     "level": "info",
                     "source": "User",
                     "content": text,
-                    "user_turn_index": user_turn_index,
-                    "user_turn_revision": user_turn_revision,
-                }));
+                });
+                // Mid-turn steer texts render turnless — the live row
+                // carried no metadata, and counting them drifts every
+                // later prompt off the wrapper's numbering.
+                if !steer_cursor.try_consume_mid_turn_steer(&text, ts_ms) {
+                    let (user_turn_index, user_turn_revision) =
+                        user_turn_revisions.record_next_turn();
+                    entry["user_turn_index"] = serde_json::json!(user_turn_index);
+                    entry["user_turn_revision"] = serde_json::json!(user_turn_revision);
+                }
+                push(entry);
             }
             continue;
         }
@@ -915,8 +959,10 @@ pub(crate) fn parse_claude_session_entries(path: &Path) -> Option<Vec<serde_json
             continue;
         };
         // One user turn per transcript line: a multi-block user message is
-        // one live prompt, so its prose blocks share the line's turn.
-        let mut line_user_turn: Option<(u32, u32)> = None;
+        // one live prompt, so its prose blocks share the line's turn — or
+        // the line's steer-ness (`Some(None)` = classified as a mid-turn
+        // steer, rendered without turn metadata).
+        let mut line_user_turn: Option<Option<(u32, u32)>> = None;
         for block in blocks {
             match block.get("type").and_then(|t| t.as_str()).unwrap_or("") {
                 "text" => {
@@ -940,15 +986,24 @@ pub(crate) fn parse_claude_session_entries(path: &Path) -> Option<Vec<serde_json
                         let text = user_prose(text);
                         if !text.is_empty() {
                             // Live shape: UserMessageLog → LogEntry.
-                            let (user_turn_index, user_turn_revision) = *line_user_turn
-                                .get_or_insert_with(|| user_turn_revisions.record_next_turn());
-                            push(serde_json::json!({
+                            let line_turn = *line_user_turn.get_or_insert_with(|| {
+                                if steer_cursor.try_consume_mid_turn_steer(&text, ts_ms) {
+                                    None
+                                } else {
+                                    Some(user_turn_revisions.record_next_turn())
+                                }
+                            });
+                            let mut entry = serde_json::json!({
                                 "level": "info",
                                 "source": "User",
                                 "content": text,
-                                "user_turn_index": user_turn_index,
-                                "user_turn_revision": user_turn_revision,
-                            }));
+                            });
+                            if let Some((user_turn_index, user_turn_revision)) = line_turn {
+                                entry["user_turn_index"] = serde_json::json!(user_turn_index);
+                                entry["user_turn_revision"] =
+                                    serde_json::json!(user_turn_revision);
+                            }
+                            push(entry);
                         }
                     }
                 }
@@ -1194,10 +1249,11 @@ pub(crate) fn parse_external_session_entries_from_file(
     source: &str,
     session_id: &str,
     path: &Path,
+    steers: &ExternalSteerLedger,
 ) -> Option<Vec<serde_json::Value>> {
     match source {
-        "codex" => parse_codex_session_entries(path),
-        "claude-code" => parse_claude_session_entries(path),
+        "codex" => parse_codex_session_entries(path, steers),
+        "claude-code" => parse_claude_session_entries(path, steers),
         "gemini" => parse_gemini_session_entries(path, session_id),
         _ => None,
     }
@@ -1205,7 +1261,15 @@ pub(crate) fn parse_external_session_entries_from_file(
 
 /// Shared-snapshot form: read-only consumers take the cache's Arc
 /// directly instead of deep-cloning the whole parsed transcript per hit.
+///
+/// The steer ledger is built only on a cache MISS: a cached parse of an
+/// unchanged transcript is invariant under ledger growth, because a new
+/// ledger entry's timestamp guard admits only rows written after its
+/// request — rows the keyed snapshot cannot contain (and when the steer's
+/// row does land, the transcript's len/mtime key changes and the parse
+/// reruns with the fresh ledger).
 pub(crate) fn external_session_entries_from_file_arc(
+    home: &Path,
     source: &str,
     session_id: &str,
     path: &Path,
@@ -1215,7 +1279,11 @@ pub(crate) fn external_session_entries_from_file_arc(
         return Some(entries);
     }
 
-    let mut entries = parse_external_session_entries_from_file(source, session_id, path)?;
+    let steers = match source {
+        "codex" | "claude-code" => external_mid_turn_steer_ledger(home, source, session_id),
+        _ => ExternalSteerLedger::default(),
+    };
+    let mut entries = parse_external_session_entries_from_file(source, session_id, path, &steers)?;
     annotate_external_transcript_entries(source, session_id, &mut entries);
     let entries = std::sync::Arc::new(entries);
     store_external_transcript_entries(key, &entries);
@@ -1235,7 +1303,7 @@ pub(crate) fn external_session_entries_from_home_arc(
         _ => None,
     }?;
 
-    external_session_entries_from_file_arc(&source, session_id, &path)
+    external_session_entries_from_file_arc(home, &source, session_id, &path)
 }
 
 pub(crate) fn external_session_entries_from_home(
@@ -2874,7 +2942,7 @@ mod tests {
         ];
         std::fs::write(&path, lines.join("\n")).unwrap();
 
-        let entries = parse_claude_session_entries(&path).expect("parse");
+        let entries = parse_claude_session_entries(&path, &ExternalSteerLedger::default()).expect("parse");
         let rows: Vec<(String, String, String, String, String)> = entries
             .iter()
             .map(|e| {
@@ -2958,7 +3026,7 @@ mod tests {
         ];
         std::fs::write(&path, lines.join("\n")).unwrap();
 
-        let entries = parse_claude_session_entries(&path).expect("parse");
+        let entries = parse_claude_session_entries(&path, &ExternalSteerLedger::default()).expect("parse");
         let contents: Vec<&str> = entries
             .iter()
             .map(|e| e["content"].as_str().unwrap_or(""))
@@ -3011,7 +3079,7 @@ mod tests {
         ];
         std::fs::write(&path, lines.join("\n")).unwrap();
 
-        let entries = parse_claude_session_entries(&path).expect("parse");
+        let entries = parse_claude_session_entries(&path, &ExternalSteerLedger::default()).expect("parse");
         let user_rows: Vec<(&str, u64, u64)> = entries
             .iter()
             .filter(|e| e["source"] == "User")
@@ -3044,6 +3112,279 @@ mod tests {
         assert_eq!(live.record_next_turn(), replay.record_next_turn());
     }
 
+    fn rfc3339_ms(value: &str) -> i64 {
+        chrono::DateTime::parse_from_rfc3339(value)
+            .expect("fixture timestamp")
+            .timestamp_millis()
+    }
+
+    /// End-to-end mid-turn steer alignment for Codex: a steer the wrapper
+    /// log proves entered mid-turn (`steer_requested` + `steer_accepted`,
+    /// the `turn/steer` OK arc) hydrates as a user row WITHOUT turn
+    /// metadata — the live lane logged it with none — and consumes no
+    /// index, so the post-steer follow-up keeps the wrapper's numbering
+    /// (turn 2, matching the live `emit_user_message_log` row) instead of
+    /// drifting to 3 and falling back to the fragile near-time dedupe
+    /// bucket. Exercises the full pipeline: wrapper-index discovery →
+    /// ledger build → parse.
+    #[test]
+    fn codex_transcript_mid_turn_steer_rows_stay_turnless() {
+        let home = tempfile::tempdir().unwrap();
+        let sessions_dir = home.path().join(".codex").join("sessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        let session_id = "019e37b2-steer-alignment";
+        let wrapper_id = "wrapper-steer-alignment";
+        let steer_text = "also update the docs";
+
+        let wrapper_dir = home
+            .path()
+            .join(".intendant")
+            .join("logs")
+            .join(wrapper_id);
+        std::fs::create_dir_all(&wrapper_dir).unwrap();
+        let requested_ts_ms = rfc3339_ms("2026-07-15T10:00:29Z");
+        std::fs::write(
+            wrapper_dir.join("session.jsonl"),
+            [
+                serde_json::json!({
+                    "ts": "10:00:29", "ts_ms": requested_ts_ms,
+                    "event": "steer_requested", "level": "info",
+                    "message": format!("Steer requested: {steer_text}"),
+                    "data": { "session_id": session_id, "id": "steer-1", "status": "pending", "text": steer_text },
+                }),
+                serde_json::json!({
+                    "ts": "10:00:29", "ts_ms": requested_ts_ms + 150,
+                    "event": "steer_accepted", "level": "info",
+                    "message": "Steer accepted",
+                    "data": { "session_id": session_id, "id": "steer-1", "status": "accepted" },
+                }),
+            ]
+            .into_iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<_>>()
+            .join("\n"),
+        )
+        .unwrap();
+        crate::external_wrapper_index::upsert(
+            home.path(),
+            "codex",
+            session_id,
+            wrapper_id,
+            &wrapper_dir,
+            None,
+        )
+        .unwrap();
+
+        std::fs::write(
+            sessions_dir.join(format!("rollout-2026-07-15T10-00-00-{session_id}.jsonl")),
+            [
+                serde_json::json!({
+                    "timestamp": "2026-07-15T10:00:00Z",
+                    "type": "session_meta",
+                    "payload": { "id": session_id }
+                }),
+                serde_json::json!({
+                    "timestamp": "2026-07-15T10:00:01Z",
+                    "type": "event_msg",
+                    "payload": { "type": "task_started", "turn_id": "codex-turn-1" }
+                }),
+                serde_json::json!({
+                    "timestamp": "2026-07-15T10:00:01Z",
+                    "type": "event_msg",
+                    "payload": { "type": "user_message", "message": "fix the flaky auth test" }
+                }),
+                serde_json::json!({
+                    "timestamp": "2026-07-15T10:00:10Z",
+                    "type": "event_msg",
+                    "payload": { "type": "agent_message", "message": "Looking at it." }
+                }),
+                // The mid-turn steer, echoed into the rollout AFTER the
+                // wrapper logged its request.
+                serde_json::json!({
+                    "timestamp": "2026-07-15T10:00:30Z",
+                    "type": "event_msg",
+                    "payload": { "type": "user_message", "message": steer_text }
+                }),
+                serde_json::json!({
+                    "timestamp": "2026-07-15T10:01:00Z",
+                    "type": "event_msg",
+                    "payload": { "type": "user_message", "message": "now ship the fix" }
+                }),
+            ]
+            .into_iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<_>>()
+            .join("\n"),
+        )
+        .unwrap();
+
+        let entries = external_session_entries_from_home(home.path(), "codex", session_id)
+            .expect("codex session should resolve");
+        let user_rows: Vec<(&str, Option<u64>, Option<u64>)> = entries
+            .iter()
+            .filter(|e| e["source"] == "user")
+            .map(|e| {
+                (
+                    e["content"].as_str().unwrap_or(""),
+                    e.get("user_turn_index").and_then(|v| v.as_u64()),
+                    e.get("user_turn_revision").and_then(|v| v.as_u64()),
+                )
+            })
+            .collect();
+        assert_eq!(
+            user_rows,
+            vec![
+                ("fix the flaky auth test", Some(1), Some(1)),
+                (steer_text, None, None),
+                ("now ship the fix", Some(2), Some(1)),
+            ],
+            "the mid-turn steer renders turnless and burns no index"
+        );
+        // The steer row still belongs to the turn it steered — its thread
+        // projection attributes it to the active turn, not a phantom one.
+        let steer_row = entries
+            .iter()
+            .find(|e| e["source"] == "user" && e["content"] == steer_text)
+            .expect("steer row rendered");
+        assert_eq!(steer_row["turn_id"].as_str(), Some("codex-turn-1"));
+    }
+
+    /// Steer classification never collapses or re-classifies repeated
+    /// identical prompts: one ledger entry justifies AT MOST one turnless
+    /// row, and every other occurrence of the same text keeps minting its
+    /// own distinct turn (turn identity is what distinguishes legitimately
+    /// repeated prompts — the #444 safety bar).
+    #[test]
+    fn codex_transcript_repeated_identical_prompts_stay_distinct_after_steer() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rollout-repeat-steer.jsonl");
+        std::fs::write(
+            &path,
+            [
+                serde_json::json!({
+                    "timestamp": "2026-07-15T11:00:00Z",
+                    "type": "session_meta",
+                    "payload": { "id": "019e37b2-repeat-steer" }
+                }),
+                serde_json::json!({
+                    "timestamp": "2026-07-15T11:00:01Z",
+                    "type": "event_msg",
+                    "payload": { "type": "user_message", "message": "start the migration" }
+                }),
+                // Mid-turn steer (in the ledger, echoed after its request).
+                serde_json::json!({
+                    "timestamp": "2026-07-15T11:00:30Z",
+                    "type": "event_msg",
+                    "payload": { "type": "user_message", "message": "keep going" }
+                }),
+                // The user later sends the IDENTICAL text as a real
+                // follow-up: the spent ledger entry must not touch it.
+                serde_json::json!({
+                    "timestamp": "2026-07-15T11:05:00Z",
+                    "type": "event_msg",
+                    "payload": { "type": "user_message", "message": "keep going" }
+                }),
+            ]
+            .into_iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<_>>()
+            .join("\n"),
+        )
+        .unwrap();
+
+        let steers = ExternalSteerLedger::from_entries(vec![ExternalSteerLedgerEntry {
+            text: "keep going".to_string(),
+            requested_ts_ms: Some(rfc3339_ms("2026-07-15T11:00:29Z")),
+        }]);
+        let entries = parse_codex_session_entries(&path, &steers).expect("parse");
+        let user_rows: Vec<(&str, Option<u64>, Option<u64>)> = entries
+            .iter()
+            .filter(|e| e["source"] == "user")
+            .map(|e| {
+                (
+                    e["content"].as_str().unwrap_or(""),
+                    e.get("user_turn_index").and_then(|v| v.as_u64()),
+                    e.get("user_turn_revision").and_then(|v| v.as_u64()),
+                )
+            })
+            .collect();
+        assert_eq!(
+            user_rows,
+            vec![
+                ("start the migration", Some(1), Some(1)),
+                ("keep going", None, None),
+                ("keep going", Some(2), Some(1)),
+            ],
+            "one ledger entry = at most one turnless row; the repeat is a distinct real turn"
+        );
+    }
+
+    /// Claude Code twin of the steer-alignment contract, plus the CC
+    /// synthetic abort marker: a ledger-proven mid-turn steer renders
+    /// turnless (block form — the classification is per transcript line),
+    /// `[Request interrupted by user]` rows disappear entirely (the live
+    /// adapter drops them — `handle_user`; hydration painting them as
+    /// User rows also burned an index and shifted every later prompt),
+    /// the initial prompt keeps the #444 contract (turn 1 rev 1, addendum
+    /// trimmed), and identical repeated prompts keep distinct turns.
+    #[test]
+    fn claude_transcript_steer_and_interrupt_rows_do_not_shift_turns() {
+        let addendum_marker =
+            crate::external_agent::claude_code::CLAUDE_CODE_BOOTSTRAP_ADDENDUM_MARKER;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session.jsonl");
+        let initial_prompt = format!("refactor the parser\\n\\n{addendum_marker}\\nsupervisor plumbing");
+        let lines = [
+            format!(
+                r#"{{"type":"user","timestamp":"2026-07-15T12:00:00.000Z","message":{{"role":"user","content":"{initial_prompt}"}}}}"#
+            ),
+            r#"{"type":"assistant","timestamp":"2026-07-15T12:00:05.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Starting."}]}}"#.to_string(),
+            // CC's synthetic abort marker rides a user message; the live
+            // feed never rendered it and no turn may burn on it.
+            r#"{"type":"user","timestamp":"2026-07-15T12:00:20.000Z","message":{"role":"user","content":[{"type":"text","text":"[Request interrupted by user]"}]}}"#.to_string(),
+            // The mid-turn steer (block form), echoed after its request.
+            r#"{"type":"user","timestamp":"2026-07-15T12:00:30.000Z","message":{"role":"user","content":[{"type":"text","text":"also fix the docs"}]}}"#.to_string(),
+            r#"{"type":"user","timestamp":"2026-07-15T12:01:00.000Z","message":{"role":"user","content":[{"type":"image","source":{"type":"base64","media_type":"image/png","data":"aGk="}},{"type":"text","text":"resume with plan B"}]}}"#.to_string(),
+            // Identical repeated prompt: a distinct real turn.
+            r#"{"type":"user","timestamp":"2026-07-15T12:02:00.000Z","message":{"role":"user","content":"resume with plan B"}}"#.to_string(),
+        ];
+        std::fs::write(&path, lines.join("\n")).unwrap();
+
+        let steers = ExternalSteerLedger::from_entries(vec![ExternalSteerLedgerEntry {
+            text: "also fix the docs".to_string(),
+            requested_ts_ms: Some(rfc3339_ms("2026-07-15T12:00:29Z")),
+        }]);
+        let entries = parse_claude_session_entries(&path, &steers).expect("parse");
+        let user_rows: Vec<(&str, Option<u64>, Option<u64>)> = entries
+            .iter()
+            .filter(|e| e["source"] == "User")
+            .map(|e| {
+                (
+                    e["content"].as_str().unwrap_or(""),
+                    e.get("user_turn_index").and_then(|v| v.as_u64()),
+                    e.get("user_turn_revision").and_then(|v| v.as_u64()),
+                )
+            })
+            .collect();
+        assert_eq!(
+            user_rows,
+            vec![
+                ("refactor the parser", Some(1), Some(1)),
+                ("also fix the docs", None, None),
+                ("resume with plan B", Some(2), Some(1)),
+                ("resume with plan B", Some(3), Some(1)),
+            ],
+            "steer turnless, interrupt marker absent, repeats distinct, initial prompt intact"
+        );
+        assert!(
+            entries.iter().all(|e| !e["content"]
+                .as_str()
+                .unwrap_or("")
+                .contains("Request interrupted")),
+            "synthetic abort markers never render on any row"
+        );
+    }
+
     /// Transcript entries carry the line's `message_uuid`, abandoned sibling
     /// branches are flagged `off_active_chain`, and every Claude fork point's
     /// `at_message_uuid` display anchor resolves to a rendered row with the
@@ -3063,7 +3404,7 @@ mod tests {
         ];
         std::fs::write(&path, lines.join("\n")).unwrap();
 
-        let entries = parse_claude_session_entries(&path).expect("parse");
+        let entries = parse_claude_session_entries(&path, &ExternalSteerLedger::default()).expect("parse");
         let entry_for = |uuid: &str| {
             entries
                 .iter()

--- a/src/bin/caller/web_gateway/session_catalog/transcripts.rs
+++ b/src/bin/caller/web_gateway/session_catalog/transcripts.rs
@@ -1000,8 +1000,7 @@ pub(crate) fn parse_claude_session_entries(
                             });
                             if let Some((user_turn_index, user_turn_revision)) = line_turn {
                                 entry["user_turn_index"] = serde_json::json!(user_turn_index);
-                                entry["user_turn_revision"] =
-                                    serde_json::json!(user_turn_revision);
+                                entry["user_turn_revision"] = serde_json::json!(user_turn_revision);
                             }
                             push(entry);
                         }
@@ -2942,7 +2941,8 @@ mod tests {
         ];
         std::fs::write(&path, lines.join("\n")).unwrap();
 
-        let entries = parse_claude_session_entries(&path, &ExternalSteerLedger::default()).expect("parse");
+        let entries =
+            parse_claude_session_entries(&path, &ExternalSteerLedger::default()).expect("parse");
         let rows: Vec<(String, String, String, String, String)> = entries
             .iter()
             .map(|e| {
@@ -3026,7 +3026,8 @@ mod tests {
         ];
         std::fs::write(&path, lines.join("\n")).unwrap();
 
-        let entries = parse_claude_session_entries(&path, &ExternalSteerLedger::default()).expect("parse");
+        let entries =
+            parse_claude_session_entries(&path, &ExternalSteerLedger::default()).expect("parse");
         let contents: Vec<&str> = entries
             .iter()
             .map(|e| e["content"].as_str().unwrap_or(""))
@@ -3079,7 +3080,8 @@ mod tests {
         ];
         std::fs::write(&path, lines.join("\n")).unwrap();
 
-        let entries = parse_claude_session_entries(&path, &ExternalSteerLedger::default()).expect("parse");
+        let entries =
+            parse_claude_session_entries(&path, &ExternalSteerLedger::default()).expect("parse");
         let user_rows: Vec<(&str, u64, u64)> = entries
             .iter()
             .filter(|e| e["source"] == "User")
@@ -3136,11 +3138,7 @@ mod tests {
         let wrapper_id = "wrapper-steer-alignment";
         let steer_text = "also update the docs";
 
-        let wrapper_dir = home
-            .path()
-            .join(".intendant")
-            .join("logs")
-            .join(wrapper_id);
+        let wrapper_dir = home.path().join(".intendant").join("logs").join(wrapper_id);
         std::fs::create_dir_all(&wrapper_dir).unwrap();
         let requested_ts_ms = rfc3339_ms("2026-07-15T10:00:29Z");
         std::fs::write(
@@ -3182,11 +3180,6 @@ mod tests {
                     "timestamp": "2026-07-15T10:00:00Z",
                     "type": "session_meta",
                     "payload": { "id": session_id }
-                }),
-                serde_json::json!({
-                    "timestamp": "2026-07-15T10:00:01Z",
-                    "type": "event_msg",
-                    "payload": { "type": "task_started", "turn_id": "codex-turn-1" }
                 }),
                 serde_json::json!({
                     "timestamp": "2026-07-15T10:00:01Z",
@@ -3241,12 +3234,20 @@ mod tests {
             "the mid-turn steer renders turnless and burns no index"
         );
         // The steer row still belongs to the turn it steered — its thread
-        // projection attributes it to the active turn, not a phantom one.
-        let steer_row = entries
-            .iter()
-            .find(|e| e["source"] == "user" && e["content"] == steer_text)
-            .expect("steer row rendered");
-        assert_eq!(steer_row["turn_id"].as_str(), Some("codex-turn-1"));
+        // projection shares the enclosing turn's id (the first prompt's),
+        // never a phantom turn of its own.
+        let turn_id_of = |content: &str| {
+            entries
+                .iter()
+                .find(|e| e["source"] == "user" && e["content"] == content)
+                .and_then(|e| e["turn_id"].as_str())
+                .map(str::to_string)
+                .unwrap_or_else(|| panic!("no turn_id on row {content:?}"))
+        };
+        assert_eq!(
+            turn_id_of(steer_text),
+            turn_id_of("fix the flaky auth test")
+        );
     }
 
     /// Steer classification never collapses or re-classifies repeated
@@ -3333,7 +3334,8 @@ mod tests {
             crate::external_agent::claude_code::CLAUDE_CODE_BOOTSTRAP_ADDENDUM_MARKER;
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("session.jsonl");
-        let initial_prompt = format!("refactor the parser\\n\\n{addendum_marker}\\nsupervisor plumbing");
+        let initial_prompt =
+            format!("refactor the parser\\n\\n{addendum_marker}\\nsupervisor plumbing");
         let lines = [
             format!(
                 r#"{{"type":"user","timestamp":"2026-07-15T12:00:00.000Z","message":{{"role":"user","content":"{initial_prompt}"}}}}"#
@@ -3404,7 +3406,8 @@ mod tests {
         ];
         std::fs::write(&path, lines.join("\n")).unwrap();
 
-        let entries = parse_claude_session_entries(&path, &ExternalSteerLedger::default()).expect("parse");
+        let entries =
+            parse_claude_session_entries(&path, &ExternalSteerLedger::default()).expect("parse");
         let entry_for = |uuid: &str| {
             entries
                 .iter()


### PR DESCRIPTION
## Problem

PR #444 gave hydrated external-transcript user rows `user_turn_index`/`user_turn_revision` so the frontend's text-signature dedupe can collapse them against live-emitted rows. Its known residual: **mid-turn steers** appear as plain user messages in the backend's own transcript but do not increment the wrapper's round counter — the live lane logs them with NO turn metadata (`emit_user_message_log` on the `turn/steer` accept path). Blind positional counting in the parsers therefore drifted after every mid-turn steer: post-steer follow-ups hydrated one index high, missed the text-signature bridge, fell back to the 5-second near-time bucket (visible duplicates), and edit/rewind affordances computed against the wrong turn number.

## Fix

User-turn assignment is now **content-aware** in both parsers, driven by daemon-side ground truth:

- New `session_catalog/steer_ledger.rs`: builds a per-session **mid-turn steer ledger** from the wrapper session log — `steer_requested` (carries the text) joined by id to `steer_accepted` / `steer_delivered { mid_turn: true }`. Boundary-drained steers (`mid_turn: false`) never enter the ledger: their text reaches the backend inside a counted follow-up (the `[User] …` merge), where positional counting is already right.
- Both `parse_codex_session_entries` and `parse_claude_session_entries` consult the ledger: a user row whose text the ledger proves entered mid-turn renders **without** turn metadata (exactly like its live row) and consumes no index, so every later prompt keeps the wrapper's numbering. The row itself still renders (and keeps its enclosing `turn_id` in the Codex thread projection).
- Claude Code's synthetic `[Request interrupted by user]` markers join the shared injected-text vocabulary (`is_injected_external_user_text`): the live adapter deliberately drops them (`claude_code.rs::handle_user`), while hydration was both painting them as User rows and burning turn indexes on them.

## Safety bar (the #444 invariants)

- Classification only **withholds** metadata from rows the live lane also showed without metadata — it never suppresses or merges rows by content match.
- Each requested steer justifies **at most one** turnless row (one-shot multiset consumption), so legitimately repeated identical prompts keep minting distinct turns.
- Consumption is **timestamp-guarded**: a transcript row cannot predate its steer request (2s clock slack), which also makes a cached parse of an unchanged transcript invariant under ledger growth — the ledger is built only on transcript-cache miss, and the cache key is untouched.
- Rows without parseable timestamps fail closed (stay counted turns — the pre-existing failure mode, never a new one).

## Tests

- `steer_ledger.rs`: ledger admission (accepted / delivered-mid-turn only), side-thread filtering + wrapper-alias admission, one-shot + ts-guarded cursor consumption.
- `transcripts.rs`: Codex end-to-end steer-then-followup alignment through wrapper-index discovery; Codex repeated-identical-prompt distinctness after a spent ledger entry; Claude Code steer + interrupt-marker + initial-prompt + repeated-prompt contract. The #444 regression test (`claude_transcript_user_rows_carry_live_turn_metadata`) is untouched and stays green.