### PR TITLE
Provider streaming core: shared SSE framer/driver, PreparedRequest single-build, typed mid-stream failures

### DIFF
--- a/crates/intendant-core/src/error.rs
+++ b/crates/intendant-core/src/error.rs
@@ -3,6 +3,12 @@ use std::fmt;
 #[derive(Debug)]
 pub enum CallerError {
     Provider(String),
+    /// A provider SSE stream failed mid-body, after a successful open.
+    /// Displays with the same "Provider error: Stream error:" shape the
+    /// retry string-match and session logs already carry; the typed
+    /// variant lets the agent loop classify mid-stream failures
+    /// structurally instead of parsing prose.
+    StreamChunk(String),
     Agent(String),
     SubAgent(String),
     Io(std::io::Error),
@@ -25,6 +31,7 @@ impl fmt::Display for CallerError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             CallerError::Provider(msg) => write!(f, "Provider error: {}", msg),
+            CallerError::StreamChunk(msg) => write!(f, "Provider error: Stream error: {}", msg),
             CallerError::Agent(msg) => write!(f, "Agent error: {}", msg),
             CallerError::SubAgent(msg) => write!(f, "Sub-agent error: {}", msg),
             CallerError::Io(e) => write!(f, "IO error: {}", e),
@@ -80,6 +87,18 @@ mod tests {
     fn provider_error_display() {
         let err = CallerError::Provider("rate limited".to_string());
         assert_eq!(format!("{}", err), "Provider error: rate limited");
+    }
+
+    #[test]
+    fn stream_chunk_error_displays_as_legacy_stream_error() {
+        // Session logs and the agent loop's fallback string match carry
+        // the "Provider error: Stream error:" shape from the pre-typed
+        // era; the typed variant must not change the rendered string.
+        let err = CallerError::StreamChunk("connection reset".to_string());
+        assert_eq!(
+            format!("{}", err),
+            "Provider error: Stream error: connection reset"
+        );
     }
 
     #[test]

--- a/src/bin/caller/agent_loop.rs
+++ b/src/bin/caller/agent_loop.rs
@@ -1167,31 +1167,50 @@ pub(crate) async fn run_agent_loop(
         // (the trait default errors — mock and custom providers), the
         // messages dump is the turn's ONLY exact input record, so it is
         // written regardless of the gate.
-        let request_snapshot = provider.request_snapshot(conversation.messages(), true);
-        if messages_json_dump_enabled() || request_snapshot.is_err() {
+        //
+        // ONE build per turn: the prepared request's bytes feed both the
+        // Context-tab snapshot below (parsed back from the same bytes, so
+        // "exact request payload" holds by construction) and every stream
+        // attempt in the retry loop — the old shape built the full request
+        // once for the snapshot and again per chat_stream call.
+        let prepared = provider.prepare_request(conversation.messages(), true);
+        if messages_json_dump_enabled() || prepared.is_err() {
             slog(&session_log, |l| {
                 if let Ok(json) = serde_json::to_string_pretty(conversation.messages()) {
                     l.messages_input(&json);
                 }
             });
         }
-        match request_snapshot {
-            Ok((context_format, raw_context)) => {
-                bus.send(AppEvent::ContextSnapshot {
-                    session_id: local_session_id.clone(),
-                    source: "native".to_string(),
-                    label: "Internal agent request payload".to_string(),
-                    request_id: Some(format!("native-turn-{turn}")),
-                    request_index: Some(turn as u64),
-                    turn: Some(turn),
-                    format: context_format,
-                    token_count: conversation.last_usage().map(|u| u.total_tokens),
-                    token_count_kind: None,
-                    context_window: Some(conversation.context_window()),
-                    hard_context_window: Some(conversation.context_window()),
-                    item_count: provider_request_item_count(&raw_context),
-                    raw: std::sync::Arc::new(raw_context),
-                });
+        let prepared = match prepared {
+            Ok(prepared) => {
+                match prepared.snapshot_value() {
+                    Ok(raw_context) => {
+                        bus.send(AppEvent::ContextSnapshot {
+                            session_id: local_session_id.clone(),
+                            source: "native".to_string(),
+                            label: "Internal agent request payload".to_string(),
+                            request_id: Some(format!("native-turn-{turn}")),
+                            request_index: Some(turn as u64),
+                            turn: Some(turn),
+                            format: prepared.format.clone(),
+                            token_count: conversation.last_usage().map(|u| u.total_tokens),
+                            token_count_kind: None,
+                            context_window: Some(conversation.context_window()),
+                            hard_context_window: Some(conversation.context_window()),
+                            item_count: provider_request_item_count(&raw_context),
+                            raw: std::sync::Arc::new(raw_context),
+                        });
+                    }
+                    Err(e) => {
+                        slog(&session_log, |l| {
+                            l.warn(&format!(
+                                "Failed to build provider request context snapshot: {}",
+                                e
+                            ))
+                        });
+                    }
+                }
+                Some(prepared)
             }
             Err(e) => {
                 slog(&session_log, |l| {
@@ -1200,8 +1219,9 @@ pub(crate) async fn run_agent_loop(
                         e
                     ))
                 });
+                None
             }
-        }
+        };
 
         // Streaming API call — wrapped in select! so an interrupt cancels
         // mid-stream without waiting for the provider to finish. The
@@ -1234,7 +1254,13 @@ pub(crate) async fn run_agent_loop(
                         }
                     }
                 };
-                let stream_fut = provider.chat_stream(conversation.messages(), &on_stream_event);
+                // The prepared bytes ride every attempt (Bytes refcount
+                // bumps); only providers without a prepare path (mock,
+                // custom) fall back to the rebuild-per-call shape.
+                let stream_fut = match prepared.as_ref() {
+                    Some(prepared) => provider.chat_stream_prepared(prepared, &on_stream_event),
+                    None => provider.chat_stream(conversation.messages(), &on_stream_event),
+                };
                 let outcome = tokio::select! {
                     biased;
                     _ = cancel_token.cancelled() => {
@@ -1249,7 +1275,13 @@ pub(crate) async fn run_agent_loop(
                         break;
                     }
                     Err(e) => {
-                        let is_stream_error = e.to_string().contains("Stream error");
+                        // Typed classification first (the driver reports
+                        // mid-stream chunk failures as StreamChunk); the
+                        // string match stays as a compatibility fallback
+                        // for error paths that still stringify, not as
+                        // the contract.
+                        let is_stream_error = matches!(e, CallerError::StreamChunk(_))
+                            || e.to_string().contains("Stream error");
                         if is_stream_error && attempt < STREAM_RETRIES {
                             slog(&session_log, |l| {
                                 l.warn(&format!(

--- a/src/bin/caller/provider/anthropic.rs
+++ b/src/bin/caller/provider/anthropic.rs
@@ -238,11 +238,12 @@ impl AnthropicProvider {
 
     /// Build the messages POST through whichever auth path this instance
     /// carries. `headers` excludes credentials; the relay adds those.
-    /// Takes the request pre-serialized so the body is produced exactly once
-    /// per call (retries memcpy the bytes instead of re-walking the DOM).
+    /// Takes the request pre-serialized as shared `Bytes` so the body is
+    /// produced exactly once per turn and every attempt (first send and
+    /// retries) reuses the same allocation via a refcount bump.
     pub(crate) async fn post_messages(
         &self,
-        request_body: &[u8],
+        request_body: &bytes::Bytes,
         beta_header: &str,
         streaming: bool,
     ) -> Result<ProviderHttpResponse, CallerError> {
@@ -257,7 +258,7 @@ impl AnthropicProvider {
                         .header("anthropic-version", "2023-06-01")
                         .header("anthropic-beta", beta_header)
                         .header("content-type", "application/json")
-                        .body(request_body.to_vec());
+                        .body(request_body.clone());
                     if streaming {
                         request.timeout(STREAM_TIMEOUT)
                     } else {
@@ -277,6 +278,8 @@ impl AnthropicProvider {
                     ("anthropic-beta".to_string(), beta_header.to_string()),
                     ("content-type".to_string(), "application/json".to_string()),
                 ];
+                // The relay ships the request as owned frames — one copy
+                // at this boundary, accepted (egress `fetch` takes Vec).
                 crate::credential_egress::fetch(kind, "POST", &url, headers, request_body.to_vec())
                     .await
                     .map(ProviderHttpResponse::Egress)
@@ -288,11 +291,15 @@ impl AnthropicProvider {
 
 #[async_trait]
 impl ChatProvider for AnthropicProvider {
-    fn request_snapshot(
+    /// The one request build: message conversion, tools, the pre-4.5
+    /// max_tokens clamp, and a single serialization straight to shared
+    /// bytes. The snapshot, the first send, and every retry all derive
+    /// from this build.
+    fn prepare_request(
         &self,
         messages: &[Message],
         stream: bool,
-    ) -> Result<(String, serde_json::Value), CallerError> {
+    ) -> Result<PreparedRequest, CallerError> {
         let (system, api_messages) = build_anthropic_messages(messages);
 
         let mut tools_vec: Vec<serde_json::Value> = Vec::new();
@@ -324,48 +331,14 @@ impl ChatProvider for AnthropicProvider {
             tools,
             stream,
         };
-        Ok((
-            "anthropic.messages.request.v1".to_string(),
-            serde_json::to_value(&request).map_err(CallerError::Json)?,
+        Ok(PreparedRequest::new(
+            "anthropic.messages.request.v1",
+            serde_json::to_vec(&request).map_err(CallerError::Json)?,
         ))
     }
 
     async fn chat(&self, messages: &[Message]) -> Result<ChatResponse, CallerError> {
-        let (system, api_messages) = build_anthropic_messages(messages);
-
-        let mut tools_vec: Vec<serde_json::Value> = Vec::new();
-        if self.use_tools {
-            let defs = self.tools();
-            tools_vec.extend(defs.iter().map(|t| t.to_anthropic()));
-        }
-        if self.cu_enabled {
-            if let Some((w, h)) = self.cu_display {
-                tools_vec.push(serde_json::json!({
-                    "type": "computer_20251124",
-                    "name": "computer",
-                    "display_width_px": w,
-                    "display_height_px": h
-                }));
-            }
-        }
-        let tools = if tools_vec.is_empty() {
-            None
-        } else {
-            Some(tools_vec)
-        };
-
-        let request = AnthropicChatRequest {
-            model: self.model.clone(),
-            system,
-            messages: api_messages,
-            max_tokens: self.effective_max_tokens(messages, tools.as_deref()),
-            tools,
-            stream: false,
-        };
-
-        // Serialize once, straight to bytes — `to_value` + `.json()` walked
-        // the full request (images included) twice per call.
-        let request_body = serde_json::to_vec(&request).map_err(CallerError::Json)?;
+        let prepared = self.prepare_request(messages, false)?;
 
         let beta_header = if self.cu_enabled {
             "prompt-caching-2024-07-31,computer-use-2025-11-24"
@@ -374,7 +347,7 @@ impl ChatProvider for AnthropicProvider {
         };
 
         let response = self
-            .post_messages(&request_body, beta_header, false)
+            .post_messages(&prepared.body, beta_header, false)
             .await?;
 
         if !response.status_success() {
@@ -511,46 +484,24 @@ impl ChatProvider for AnthropicProvider {
         messages: &[Message],
         on_event: &(dyn Fn(StreamEvent) + Send + Sync),
     ) -> Result<ChatResponse, CallerError> {
-        let (system, api_messages) = build_anthropic_messages(messages);
+        let prepared = self.prepare_request(messages, true)?;
+        self.chat_stream_prepared(&prepared, on_event).await
+    }
 
-        let mut tools_vec: Vec<serde_json::Value> = Vec::new();
-        if self.use_tools {
-            let defs = self.tools();
-            tools_vec.extend(defs.iter().map(|t| t.to_anthropic()));
-        }
-        if self.cu_enabled {
-            if let Some((w, h)) = self.cu_display {
-                tools_vec.push(serde_json::json!({
-                    "type": "computer_20251124",
-                    "name": "computer",
-                    "display_width_px": w,
-                    "display_height_px": h
-                }));
-            }
-        }
-        let tools = if tools_vec.is_empty() {
-            None
-        } else {
-            Some(tools_vec)
-        };
-
-        let request = AnthropicChatRequest {
-            model: self.model.clone(),
-            system,
-            messages: api_messages,
-            max_tokens: self.effective_max_tokens(messages, tools.as_deref()),
-            tools,
-            stream: true,
-        };
-        let request_body = serde_json::to_vec(&request).map_err(CallerError::Json)?;
-
+    async fn chat_stream_prepared(
+        &self,
+        prepared: &PreparedRequest,
+        on_event: &(dyn Fn(StreamEvent) + Send + Sync),
+    ) -> Result<ChatResponse, CallerError> {
         let beta_header = if self.cu_enabled {
             "prompt-caching-2024-07-31,computer-use-2025-11-24"
         } else {
             "prompt-caching-2024-07-31"
         };
 
-        let response = self.post_messages(&request_body, beta_header, true).await?;
+        let response = self
+            .post_messages(&prepared.body, beta_header, true)
+            .await?;
 
         if !response.status_success() {
             let status = response.status_line();
@@ -665,8 +616,7 @@ impl streaming::SseFold for AnthropicStreamFold {
                             }
                         }
                         "input_json_delta" => {
-                            if let Some(json) = delta.get("partial_json").and_then(|t| t.as_str())
-                            {
+                            if let Some(json) = delta.get("partial_json").and_then(|t| t.as_str()) {
                                 self.current_tool_json.push_str(json);
                             }
                         }
@@ -1899,6 +1849,69 @@ mod tests {
         assert_eq!(serialized.matches("image elided").count(), 0);
     }
 
+    // --- PreparedRequest: one build feeds wire and snapshot ---
+
+    #[test]
+    fn prepare_request_builds_wire_and_snapshot_once() {
+        // new_plain: deterministic (no env-dependent tool set, no CU).
+        let provider = AnthropicProvider::new_plain(
+            "key".to_string(),
+            "claude-sonnet-4-5-20250929".to_string(),
+            200_000,
+            64_000,
+        );
+        let messages = vec![
+            Message {
+                role: "system".to_string(),
+                content: "sys".to_string(),
+                ..Default::default()
+            },
+            user_text("hello"),
+        ];
+        let prepared = provider.prepare_request(&messages, true).unwrap();
+        assert_eq!(prepared.format, "anthropic.messages.request.v1");
+
+        // Wire pin: the bytes equal a manual build of the exact request
+        // the old snapshot and stream paths each built separately.
+        let (system, api_messages) = build_anthropic_messages(&messages);
+        let manual = AnthropicChatRequest {
+            model: "claude-sonnet-4-5-20250929".to_string(),
+            system,
+            messages: api_messages,
+            max_tokens: 64_000,
+            tools: None,
+            stream: true,
+        };
+        assert_eq!(
+            prepared.body.as_ref(),
+            serde_json::to_vec(&manual).unwrap().as_slice()
+        );
+
+        // Snapshot parity: parsed from the wire bytes (by construction)
+        // and equal to the legacy to_value construction.
+        let snapshot = prepared.snapshot_value().unwrap();
+        assert_eq!(
+            snapshot,
+            serde_json::from_slice::<serde_json::Value>(&prepared.body).unwrap()
+        );
+        assert_eq!(snapshot, serde_json::to_value(&manual).unwrap());
+        assert_eq!(snapshot.get("stream"), Some(&serde_json::Value::Bool(true)));
+
+        // The trait snapshot derives from the same build path.
+        let (format, value) = provider.request_snapshot(&messages, true).unwrap();
+        assert_eq!(format, prepared.format);
+        assert_eq!(value, snapshot);
+
+        // Retries reuse the allocation: a Bytes clone shares the pointer
+        // (each HTTP attempt's `.body(bytes.clone())` is a refcount bump).
+        let retry_view = prepared.body.clone();
+        assert_eq!(retry_view.as_ptr(), prepared.body.as_ptr());
+
+        // Non-streaming build omits the stream field entirely (serde skip).
+        let non_stream = provider.prepare_request(&messages, false).unwrap();
+        assert!(non_stream.snapshot_value().unwrap().get("stream").is_none());
+    }
+
     // --- Stream fold (the Anthropic arm of the shared SSE driver) ---
 
     /// A realistic Messages-API SSE transcript: prompt-side usage in
@@ -1935,12 +1948,8 @@ mod tests {
         // mid-sequence — the framer must never manufacture U+FFFD or
         // fragment an event.
         let mut fold = AnthropicStreamFold::new(false, Vec::new());
-        let deltas = streaming::test_support::drive_transcript(
-            &mut fold,
-            ANTHROPIC_SSE_TRANSCRIPT,
-            7,
-        )
-        .await;
+        let deltas =
+            streaming::test_support::drive_transcript(&mut fold, ANTHROPIC_SSE_TRANSCRIPT, 7).await;
         assert_eq!(deltas, vec!["Hel", "lo é🦀"]);
 
         let response = fold.finish();

--- a/src/bin/caller/provider/anthropic.rs
+++ b/src/bin/caller/provider/anthropic.rs
@@ -562,153 +562,171 @@ impl ChatProvider for AnthropicProvider {
             )));
         }
 
-        // Parse SSE stream
-        let mut text_parts = Vec::new();
-        let mut tool_calls: Vec<ToolCall> = Vec::new();
-        let mut cu_calls: Vec<crate::computer_use::CuToolCall> = Vec::new();
-        let mut current_tool_json = String::new();
-        let mut current_tool_id = String::new();
-        let mut current_tool_name = String::new();
-        let mut usage = TokenUsage {
-            rate_limit_windows: response.anthropic_rate_limit_windows(),
-            ..Default::default()
+        let mut fold =
+            AnthropicStreamFold::new(self.cu_enabled, response.anthropic_rate_limit_windows());
+        streaming::run_sse_stream(response, &mut fold, on_event)
+            .await
+            .map_err(streaming::StreamFailure::into_caller_error)?;
+        let response = fold.finish();
+        on_event(StreamEvent::Complete(response.clone()));
+        Ok(response)
+    }
+}
+
+/// The Anthropic arm of the shared SSE driver: exactly the per-event
+/// mutable state the old hand-rolled loop carried (current tool
+/// assembly, prompt-side usage from `message_start`, output tokens from
+/// `message_delta`), with the mechanics living in `provider::streaming`.
+pub(crate) struct AnthropicStreamFold {
+    cu_enabled: bool,
+    json: streaming::EventJson,
+    text_parts: Vec<String>,
+    tool_calls: Vec<ToolCall>,
+    cu_calls: Vec<crate::computer_use::CuToolCall>,
+    current_tool_json: String,
+    current_tool_id: String,
+    current_tool_name: String,
+    usage: TokenUsage,
+}
+
+impl AnthropicStreamFold {
+    pub(crate) fn new(
+        cu_enabled: bool,
+        rate_limit_windows: Vec<crate::types::SessionLimitWindow>,
+    ) -> Self {
+        Self {
+            cu_enabled,
+            json: streaming::EventJson::new(),
+            text_parts: Vec::new(),
+            tool_calls: Vec::new(),
+            cu_calls: Vec::new(),
+            current_tool_json: String::new(),
+            current_tool_id: String::new(),
+            current_tool_name: String::new(),
+            usage: TokenUsage {
+                rate_limit_windows,
+                ..Default::default()
+            },
+        }
+    }
+
+    /// Assemble the final response after the stream ends.
+    pub(crate) fn finish(mut self) -> ChatResponse {
+        self.usage.total_tokens = self.usage.prompt_tokens + self.usage.completion_tokens;
+        ChatResponse {
+            content: self.text_parts.join(""),
+            usage: self.usage,
+            reasoning_summary: None,
+            reasoning_content: None,
+            tool_calls: self.tool_calls,
+            cu_calls: self.cu_calls,
+            raw_output: None,
+        }
+    }
+}
+
+impl streaming::SseFold for AnthropicStreamFold {
+    fn on_data(
+        &mut self,
+        data: &str,
+        on_event: &(dyn Fn(StreamEvent) + Send + Sync),
+    ) -> Result<(), CallerError> {
+        let Some(event) = self.json.parse(data) else {
+            return Ok(());
         };
-        let mut line_buf = SseLineBuffer::new();
-
-        let mut stream = response.bytes_stream();
-        while let Some(chunk) = stream.next().await {
-            let chunk = chunk.map_err(|e| CallerError::Provider(format!("Stream error: {}", e)))?;
-            line_buf.push_chunk(&chunk);
-
-            // Process complete lines
-            while let Some(line) = line_buf.next_line() {
-                if line.is_empty() {
-                    continue;
-                }
-
-                if let Some(("data", data)) = parse_sse_line(&line) {
-                    if data == "[DONE]" {
-                        continue;
-                    }
-                    if let Ok(event) = serde_json::from_str::<serde_json::Value>(data) {
-                        let event_type = event.get("type").and_then(|t| t.as_str()).unwrap_or("");
-                        match event_type {
-                            "content_block_start" => {
-                                if let Some(cb) = event.get("content_block") {
-                                    let cb_type =
-                                        cb.get("type").and_then(|t| t.as_str()).unwrap_or("");
-                                    if cb_type == "tool_use" {
-                                        current_tool_id = cb
-                                            .get("id")
-                                            .and_then(|v| v.as_str())
-                                            .unwrap_or("")
-                                            .to_string();
-                                        current_tool_name = cb
-                                            .get("name")
-                                            .and_then(|v| v.as_str())
-                                            .unwrap_or("")
-                                            .to_string();
-                                        current_tool_json.clear();
-                                    }
-                                }
-                            }
-                            "content_block_delta" => {
-                                if let Some(delta) = event.get("delta") {
-                                    let delta_type =
-                                        delta.get("type").and_then(|t| t.as_str()).unwrap_or("");
-                                    match delta_type {
-                                        "text_delta" => {
-                                            if let Some(text) =
-                                                delta.get("text").and_then(|t| t.as_str())
-                                            {
-                                                text_parts.push(text.to_string());
-                                                on_event(StreamEvent::Delta(text.to_string()));
-                                            }
-                                        }
-                                        "input_json_delta" => {
-                                            if let Some(json) =
-                                                delta.get("partial_json").and_then(|t| t.as_str())
-                                            {
-                                                current_tool_json.push_str(json);
-                                            }
-                                        }
-                                        _ => {}
-                                    }
-                                }
-                            }
-                            "content_block_stop" => {
-                                if !current_tool_id.is_empty() {
-                                    if current_tool_name == "computer" && self.cu_enabled {
-                                        if let Ok(input) = serde_json::from_str::<serde_json::Value>(
-                                            &current_tool_json,
-                                        ) {
-                                            if let Some(action) = parse_anthropic_cu_action(&input)
-                                            {
-                                                cu_calls.push(crate::computer_use::CuToolCall {
-                                                    call_id: current_tool_id.clone(),
-                                                    actions: vec![action],
-                                                    metadata: crate::computer_use::CuCallMetadata::default(),
-                                                });
-                                            }
-                                        }
-                                    } else {
-                                        tool_calls.push(ToolCall {
-                                            id: current_tool_id.clone(),
-                                            call_id: current_tool_id.clone(),
-                                            name: current_tool_name.clone(),
-                                            arguments: current_tool_json.clone(),
-                                        });
-                                    }
-                                    current_tool_id.clear();
-                                    current_tool_name.clear();
-                                    current_tool_json.clear();
-                                }
-                            }
-                            "message_delta" => {
-                                if let Some(u) = event.get("usage") {
-                                    let output = u
-                                        .get("output_tokens")
-                                        .and_then(|v| v.as_u64())
-                                        .unwrap_or(0);
-                                    usage.completion_tokens = output;
-                                }
-                            }
-                            "message_start" => {
-                                if let Some(msg) = event.get("message") {
-                                    if let Some(parsed) = msg.get("usage").cloned().and_then(|u| {
-                                        serde_json::from_value::<AnthropicUsage>(u).ok()
-                                    }) {
-                                        // Prompt-side counters only; output
-                                        // arrives later via message_delta.
-                                        let prompt_side = parsed.to_token_usage();
-                                        usage.prompt_tokens = prompt_side.prompt_tokens;
-                                        usage.cached_tokens = prompt_side.cached_tokens;
-                                        usage.cache_creation_tokens =
-                                            prompt_side.cache_creation_tokens;
-                                        usage.cache_ttl_seconds = prompt_side.cache_ttl_seconds;
-                                    }
-                                }
-                            }
-                            _ => {}
-                        }
+        let event_type = event.get("type").and_then(|t| t.as_str()).unwrap_or("");
+        match event_type {
+            "content_block_start" => {
+                if let Some(cb) = event.get("content_block") {
+                    let cb_type = cb.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                    if cb_type == "tool_use" {
+                        self.current_tool_id = cb
+                            .get("id")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        self.current_tool_name = cb
+                            .get("name")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        self.current_tool_json.clear();
                     }
                 }
             }
+            "content_block_delta" => {
+                if let Some(delta) = event.get("delta") {
+                    let delta_type = delta.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                    match delta_type {
+                        "text_delta" => {
+                            if let Some(text) = delta.get("text").and_then(|t| t.as_str()) {
+                                self.text_parts.push(text.to_string());
+                                on_event(StreamEvent::Delta(text.to_string()));
+                            }
+                        }
+                        "input_json_delta" => {
+                            if let Some(json) = delta.get("partial_json").and_then(|t| t.as_str())
+                            {
+                                self.current_tool_json.push_str(json);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            "content_block_stop" => {
+                if !self.current_tool_id.is_empty() {
+                    if self.current_tool_name == "computer" && self.cu_enabled {
+                        if let Ok(input) =
+                            serde_json::from_str::<serde_json::Value>(&self.current_tool_json)
+                        {
+                            if let Some(action) = parse_anthropic_cu_action(&input) {
+                                self.cu_calls.push(crate::computer_use::CuToolCall {
+                                    call_id: self.current_tool_id.clone(),
+                                    actions: vec![action],
+                                    metadata: crate::computer_use::CuCallMetadata::default(),
+                                });
+                            }
+                        }
+                    } else {
+                        self.tool_calls.push(ToolCall {
+                            id: self.current_tool_id.clone(),
+                            call_id: self.current_tool_id.clone(),
+                            name: self.current_tool_name.clone(),
+                            arguments: self.current_tool_json.clone(),
+                        });
+                    }
+                    self.current_tool_id.clear();
+                    self.current_tool_name.clear();
+                    self.current_tool_json.clear();
+                }
+            }
+            "message_delta" => {
+                if let Some(u) = event.get("usage") {
+                    let output = u.get("output_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
+                    self.usage.completion_tokens = output;
+                }
+            }
+            "message_start" => {
+                if let Some(msg) = event.get("message") {
+                    if let Some(parsed) = msg
+                        .get("usage")
+                        .cloned()
+                        .and_then(|u| serde_json::from_value::<AnthropicUsage>(u).ok())
+                    {
+                        // Prompt-side counters only; output
+                        // arrives later via message_delta.
+                        let prompt_side = parsed.to_token_usage();
+                        self.usage.prompt_tokens = prompt_side.prompt_tokens;
+                        self.usage.cached_tokens = prompt_side.cached_tokens;
+                        self.usage.cache_creation_tokens = prompt_side.cache_creation_tokens;
+                        self.usage.cache_ttl_seconds = prompt_side.cache_ttl_seconds;
+                    }
+                }
+            }
+            _ => {}
         }
-
-        usage.total_tokens = usage.prompt_tokens + usage.completion_tokens;
-        let content = text_parts.join("");
-        let response = ChatResponse {
-            content,
-            usage,
-            reasoning_summary: None,
-            reasoning_content: None,
-            tool_calls,
-            cu_calls,
-            raw_output: None,
-        };
-        on_event(StreamEvent::Complete(response.clone()));
-        Ok(response)
+        Ok(())
     }
 }
 
@@ -1879,5 +1897,120 @@ mod tests {
         let serialized = serde_json::to_string(&api_msgs).unwrap();
         assert_eq!(serialized.matches("\"type\":\"image\"").count(), 3);
         assert_eq!(serialized.matches("image elided").count(), 0);
+    }
+
+    // --- Stream fold (the Anthropic arm of the shared SSE driver) ---
+
+    /// A realistic Messages-API SSE transcript: prompt-side usage in
+    /// message_start, split text deltas (multibyte content), a tool_use
+    /// block assembled from input_json_delta fragments, and the output
+    /// count in message_delta.
+    const ANTHROPIC_SSE_TRANSCRIPT: &str = concat!(
+        "event: message_start\n",
+        "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":10,\"output_tokens\":1,\"cache_read_input_tokens\":90,\"cache_creation_input_tokens\":20}}}\n",
+        "\n",
+        "event: content_block_delta\n",
+        "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hel\"}}\n",
+        "\n",
+        "event: content_block_delta\n",
+        "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"lo \\u00e9🦀\"}}\n",
+        "\n",
+        "event: content_block_start\n",
+        "data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":\"exec_command\"}}\n",
+        "\n",
+        "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"comm\"}}\n",
+        "\n",
+        "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"and\\\":\\\"ls\\\"}\"}}\n",
+        "\n",
+        "data: {\"type\":\"content_block_stop\",\"index\":1}\n",
+        "\n",
+        "event: message_delta\n",
+        "data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":42}}\n",
+        "\n",
+    );
+
+    #[tokio::test]
+    async fn anthropic_fold_assembles_text_tools_and_usage() {
+        // 7-byte chunks split every line, the multibyte é, and the 🦀
+        // mid-sequence — the framer must never manufacture U+FFFD or
+        // fragment an event.
+        let mut fold = AnthropicStreamFold::new(false, Vec::new());
+        let deltas = streaming::test_support::drive_transcript(
+            &mut fold,
+            ANTHROPIC_SSE_TRANSCRIPT,
+            7,
+        )
+        .await;
+        assert_eq!(deltas, vec!["Hel", "lo é🦀"]);
+
+        let response = fold.finish();
+        assert_eq!(response.content, "Hello é🦀");
+        assert_eq!(response.tool_calls.len(), 1);
+        assert_eq!(response.tool_calls[0].id, "toolu_1");
+        assert_eq!(response.tool_calls[0].call_id, "toolu_1");
+        assert_eq!(response.tool_calls[0].name, "exec_command");
+        assert_eq!(response.tool_calls[0].arguments, "{\"command\":\"ls\"}");
+        assert!(response.cu_calls.is_empty());
+        assert!(response.raw_output.is_none());
+
+        // Usage: prompt side folded from message_start (uncached + reads
+        // + writes), completion from message_delta, total assembled at
+        // finish, TTL from the flat creation counter.
+        assert_eq!(response.usage.prompt_tokens, 120);
+        assert_eq!(response.usage.completion_tokens, 42);
+        assert_eq!(response.usage.total_tokens, 162);
+        assert_eq!(response.usage.cached_tokens, 90);
+        assert_eq!(response.usage.cache_creation_tokens, 20);
+        assert_eq!(response.usage.cache_ttl_seconds, Some(300));
+    }
+
+    #[tokio::test]
+    async fn anthropic_fold_routes_computer_tool_use_to_cu_calls() {
+        let transcript = concat!(
+            "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_cu\",\"name\":\"computer\"}}\n\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"action\\\":\\\"screenshot\\\"}\"}}\n\n",
+            "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+        );
+        // CU-enabled: the computer tool becomes a CU call, not a ToolCall.
+        let mut fold = AnthropicStreamFold::new(true, Vec::new());
+        streaming::test_support::drive_transcript(&mut fold, transcript, 11).await;
+        let response = fold.finish();
+        assert!(response.tool_calls.is_empty());
+        assert_eq!(response.cu_calls.len(), 1);
+        assert_eq!(response.cu_calls[0].call_id, "toolu_cu");
+        assert!(matches!(
+            response.cu_calls[0].actions[..],
+            [crate::computer_use::CuAction::Screenshot]
+        ));
+
+        // CU-disabled: the same block is an ordinary tool call.
+        let mut fold = AnthropicStreamFold::new(false, Vec::new());
+        streaming::test_support::drive_transcript(&mut fold, transcript, 11).await;
+        let response = fold.finish();
+        assert!(response.cu_calls.is_empty());
+        assert_eq!(response.tool_calls.len(), 1);
+        assert_eq!(response.tool_calls[0].name, "computer");
+    }
+
+    #[tokio::test]
+    async fn anthropic_fold_carries_rate_limit_windows_and_drops_garbage() {
+        let windows = vec![crate::types::SessionLimitWindow {
+            label: "req/min".to_string(),
+            used_pct: Some(3),
+            resets_at_epoch: None,
+            status: None,
+        }];
+        let transcript = concat!(
+            "data: not json at all\n\n",
+            "data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":5}}\n\n",
+        );
+        let mut fold = AnthropicStreamFold::new(false, windows);
+        streaming::test_support::drive_transcript(&mut fold, transcript, 64).await;
+        let response = fold.finish();
+        // The unparseable payload degrades to a drop; the stream keeps
+        // folding, and the pre-attached header windows survive.
+        assert_eq!(response.usage.completion_tokens, 5);
+        assert_eq!(response.usage.rate_limit_windows.len(), 1);
+        assert_eq!(response.usage.rate_limit_windows[0].label, "req/min");
     }
 }

--- a/src/bin/caller/provider/gemini.rs
+++ b/src/bin/caller/provider/gemini.rs
@@ -104,11 +104,13 @@ impl GeminiProvider {
     /// POST a generateContent-family request through whichever auth path
     /// this instance carries. Auth never rides an egress request — the
     /// relay attaches `x-goog-api-key` from the vault. Takes the request
-    /// pre-serialized so the body is produced exactly once per call.
+    /// pre-serialized as shared `Bytes` so the body is produced exactly
+    /// once per turn and every attempt (first send and retries) reuses
+    /// the same allocation via a refcount bump.
     pub(crate) async fn post_generate(
         &self,
         url: &str,
-        request_body: &[u8],
+        request_body: &bytes::Bytes,
         streaming: bool,
     ) -> Result<ProviderHttpResponse, CallerError> {
         match &self.auth {
@@ -119,7 +121,7 @@ impl GeminiProvider {
                         .post(url)
                         .header("content-type", "application/json")
                         .header("x-goog-api-key", api_key)
-                        .body(request_body.to_vec());
+                        .body(request_body.clone());
                     if streaming {
                         request.timeout(STREAM_TIMEOUT)
                     } else {
@@ -135,6 +137,8 @@ impl GeminiProvider {
             }
             ProviderAuth::ClientEgress { kind } => {
                 let headers = vec![("content-type".to_string(), "application/json".to_string())];
+                // The relay ships the request as owned frames — one copy
+                // at this boundary, accepted (egress `fetch` takes Vec).
                 crate::credential_egress::fetch(kind, "POST", url, headers, request_body.to_vec())
                     .await
                     .map(ProviderHttpResponse::Egress)
@@ -155,11 +159,16 @@ pub(crate) fn gemini_role(role: &str) -> &str {
 
 #[async_trait]
 impl ChatProvider for GeminiProvider {
-    fn request_snapshot(
+    /// The one request build: contents assembly, systemInstruction, and a
+    /// single serialization straight to shared bytes. The snapshot, the
+    /// first send, and every retry all derive from this build. The
+    /// `stream` flag does not change the body — Gemini selects streaming
+    /// by endpoint (`:streamGenerateContent?alt=sse`), not by a field.
+    fn prepare_request(
         &self,
         messages: &[Message],
         stream: bool,
-    ) -> Result<(String, serde_json::Value), CallerError> {
+    ) -> Result<PreparedRequest, CallerError> {
         let _ = stream;
         let (system_text, mut request_body) = build_gemini_request_parts(messages, self);
 
@@ -169,30 +178,22 @@ impl ChatProvider for GeminiProvider {
             });
         }
 
-        Ok((
-            "gemini.generate-content.request.v1".to_string(),
-            request_body,
+        Ok(PreparedRequest::new(
+            "gemini.generate-content.request.v1",
+            serde_json::to_vec(&request_body).map_err(CallerError::Json)?,
         ))
     }
 
     async fn chat(&self, messages: &[Message]) -> Result<ChatResponse, CallerError> {
-        let (system_text, mut request_body) = build_gemini_request_parts(messages, self);
-
-        if let Some(ref sys) = system_text {
-            request_body["systemInstruction"] = serde_json::json!({
-                "parts": [{"text": sys}]
-            });
-        }
-
         // Note: Gemini API uses implicit context caching. Requests with the same
         // prefix are automatically cached server-side. No explicit API changes needed.
+        let prepared = self.prepare_request(messages, false)?;
         let url = format!(
             "{}/v1beta/models/{}:generateContent",
             self.endpoint, self.model
         );
 
-        let body_bytes = serde_json::to_vec(&request_body).map_err(CallerError::Json)?;
-        let response = self.post_generate(&url, &body_bytes, false).await?;
+        let response = self.post_generate(&url, &prepared.body, false).await?;
 
         if !response.status_success() {
             let status = response.status_line();
@@ -347,22 +348,22 @@ impl ChatProvider for GeminiProvider {
         messages: &[Message],
         on_event: &(dyn Fn(StreamEvent) + Send + Sync),
     ) -> Result<ChatResponse, CallerError> {
-        let (system_text, mut request_body) = build_gemini_request_parts(messages, self);
+        let prepared = self.prepare_request(messages, true)?;
+        self.chat_stream_prepared(&prepared, on_event).await
+    }
 
-        if let Some(ref sys) = system_text {
-            request_body["systemInstruction"] = serde_json::json!({
-                "parts": [{"text": sys}]
-            });
-        }
-
+    async fn chat_stream_prepared(
+        &self,
+        prepared: &PreparedRequest,
+        on_event: &(dyn Fn(StreamEvent) + Send + Sync),
+    ) -> Result<ChatResponse, CallerError> {
         // Use streamGenerateContent endpoint
         let url = format!(
             "{}/v1beta/models/{}:streamGenerateContent?alt=sse",
             self.endpoint, self.model
         );
 
-        let body_bytes = serde_json::to_vec(&request_body).map_err(CallerError::Json)?;
-        let response = self.post_generate(&url, &body_bytes, true).await?;
+        let response = self.post_generate(&url, &prepared.body, true).await?;
 
         if !response.status_success() {
             let status = response.status_line();
@@ -1048,6 +1049,68 @@ mod tests {
         assert_eq!(out[1], serde_json::json!({"text": "bc"}));
     }
 
+    // --- PreparedRequest: one build feeds wire and snapshot ---
+
+    #[test]
+    fn prepare_request_builds_wire_and_snapshot_once() {
+        // new_plain: deterministic (no env-dependent tool set, no CU).
+        let provider = GeminiProvider::new_plain(
+            "key".to_string(),
+            "gemini-2.5-pro".to_string(),
+            1_048_576,
+            65_536,
+        );
+        let messages = vec![
+            Message {
+                role: "system".to_string(),
+                content: "sys".to_string(),
+                ..Default::default()
+            },
+            Message {
+                role: "user".to_string(),
+                content: "hello".to_string(),
+                ..Default::default()
+            },
+        ];
+        let prepared = provider.prepare_request(&messages, true).unwrap();
+        assert_eq!(prepared.format, "gemini.generate-content.request.v1");
+
+        // Wire pin: the bytes equal a manual build of the exact request
+        // the old snapshot and stream paths each built separately.
+        let (system_text, mut manual) = build_gemini_request_parts(&messages, &provider);
+        manual["systemInstruction"] = serde_json::json!({
+            "parts": [{"text": system_text.unwrap()}]
+        });
+        assert_eq!(
+            prepared.body.as_ref(),
+            serde_json::to_vec(&manual).unwrap().as_slice()
+        );
+
+        // Snapshot parity: parsed from the wire bytes (by construction)
+        // and equal to the legacy request body Value.
+        let snapshot = prepared.snapshot_value().unwrap();
+        assert_eq!(
+            snapshot,
+            serde_json::from_slice::<serde_json::Value>(&prepared.body).unwrap()
+        );
+        assert_eq!(snapshot, manual);
+
+        // The trait snapshot derives from the same build path.
+        let (format, value) = provider.request_snapshot(&messages, true).unwrap();
+        assert_eq!(format, prepared.format);
+        assert_eq!(value, snapshot);
+
+        // Retries reuse the allocation: a Bytes clone shares the pointer
+        // (each HTTP attempt's `.body(bytes.clone())` is a refcount bump).
+        let retry_view = prepared.body.clone();
+        assert_eq!(retry_view.as_ptr(), prepared.body.as_ptr());
+
+        // The stream flag never changes the body: Gemini selects
+        // streaming by endpoint, so both builds serialize identically.
+        let non_stream = provider.prepare_request(&messages, false).unwrap();
+        assert_eq!(non_stream.body, prepared.body);
+    }
+
     // --- Stream fold (the Gemini arm of the shared SSE driver) ---
 
     /// A realistic streamGenerateContent alt=sse transcript: split text
@@ -1076,10 +1139,7 @@ mod tests {
         assert_eq!(response.tool_calls[0].id, "gemini_call_0");
         assert_eq!(response.tool_calls[0].call_id, "gemini_call_0");
         assert_eq!(response.tool_calls[0].name, "exec_command");
-        assert_eq!(
-            response.tool_calls[0].arguments,
-            "{\"command\":\"ls\"}"
-        );
+        assert_eq!(response.tool_calls[0].arguments, "{\"command\":\"ls\"}");
 
         // Raw parts coalesce pure-text runs but keep the signed part and
         // the functionCall verbatim as boundaries.

--- a/src/bin/caller/provider/gemini.rs
+++ b/src/bin/caller/provider/gemini.rs
@@ -374,134 +374,153 @@ impl ChatProvider for GeminiProvider {
             )));
         }
 
-        let mut text_parts = Vec::new();
-        let mut tool_calls: Vec<ToolCall> = Vec::new();
-        let mut cu_calls: Vec<crate::computer_use::CuToolCall> = Vec::new();
-        let mut raw_model_parts: Vec<serde_json::Value> = Vec::new();
-        let mut usage = TokenUsage::default();
-        let mut line_buf = SseLineBuffer::new();
+        let mut fold = GeminiStreamFold::new(self.cu_enabled, self.cu_display);
+        streaming::run_sse_stream(response, &mut fold, on_event)
+            .await
+            .map_err(streaming::StreamFailure::into_caller_error)?;
+        let response = fold.finish();
+        on_event(StreamEvent::Complete(response.clone()));
+        Ok(response)
+    }
+}
 
-        let mut stream = response.bytes_stream();
-        while let Some(chunk) = stream.next().await {
-            let chunk = chunk.map_err(|e| CallerError::Provider(format!("Stream error: {}", e)))?;
-            line_buf.push_chunk(&chunk);
+/// The Gemini streamGenerateContent arm of the shared SSE driver: exactly
+/// the per-chunk mutable state the old hand-rolled loop carried
+/// (candidate parts, raw echo-back parts, last-chunk `usageMetadata`),
+/// with the mechanics living in `provider::streaming`.
+pub(crate) struct GeminiStreamFold {
+    cu_enabled: bool,
+    cu_display: Option<(u32, u32)>,
+    json: streaming::EventJson,
+    text_parts: Vec<String>,
+    tool_calls: Vec<ToolCall>,
+    cu_calls: Vec<crate::computer_use::CuToolCall>,
+    raw_model_parts: Vec<serde_json::Value>,
+    usage: TokenUsage,
+}
 
-            while let Some(line) = line_buf.next_line() {
-                if line.is_empty() {
-                    continue;
-                }
-
-                // Gemini streaming with alt=sse returns SSE format
-                let data = if let Some(("data", d)) = parse_sse_line(&line) {
-                    d
-                } else {
-                    continue;
-                };
-
-                if let Ok(resp) = serde_json::from_str::<serde_json::Value>(data) {
-                    // Extract text and function calls from candidates
-                    if let Some(parts) = resp
-                        .pointer("/candidates/0/content/parts")
-                        .and_then(|p| p.as_array())
-                    {
-                        for part in parts {
-                            // Capture raw parts for verbatim echo-back (preserves thoughtSignature)
-                            raw_model_parts.push(part.clone());
-
-                            if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
-                                text_parts.push(text.to_string());
-                                on_event(StreamEvent::Delta(text.to_string()));
-                            }
-                            if let Some(fc) = part.get("functionCall") {
-                                let name = fc
-                                    .get("name")
-                                    .and_then(|n| n.as_str())
-                                    .unwrap_or("")
-                                    .to_string();
-                                let args_val =
-                                    fc.get("args").cloned().unwrap_or(serde_json::json!({}));
-
-                                if self.cu_enabled && GEMINI_CU_FUNCTIONS.contains(&name.as_str()) {
-                                    let (dw, dh) = self.cu_display.unwrap_or((1440, 900));
-                                    if let Some(action) =
-                                        parse_gemini_cu_action(&name, &args_val, dw, dh)
-                                    {
-                                        let id = format!("gemini_cu_{}", cu_calls.len());
-                                        cu_calls.push(crate::computer_use::CuToolCall {
-                                            call_id: id,
-                                            actions: vec![action],
-                                            metadata: crate::computer_use::CuCallMetadata::default(
-                                            ),
-                                        });
-                                    }
-                                } else {
-                                    let args = serde_json::to_string(&args_val)
-                                        .unwrap_or_else(|_| "{}".to_string());
-                                    let id = format!("gemini_call_{}", tool_calls.len());
-                                    tool_calls.push(ToolCall {
-                                        id: id.clone(),
-                                        call_id: id,
-                                        name,
-                                        arguments: args,
-                                    });
-                                }
-                            }
-                        }
-                    }
-
-                    // Extract usage from the last chunk
-                    if let Some(u) = resp.get("usageMetadata") {
-                        let prompt = u
-                            .get("promptTokenCount")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(0);
-                        let completion = u
-                            .get("candidatesTokenCount")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(0);
-                        let total = u
-                            .get("totalTokenCount")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(prompt + completion);
-                        let cached = u
-                            .get("cachedContentTokenCount")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(0);
-                        usage = TokenUsage {
-                            prompt_tokens: prompt,
-                            completion_tokens: completion,
-                            total_tokens: total,
-                            cached_tokens: cached,
-                            ..Default::default()
-                        };
-                    }
-                }
-            }
+impl GeminiStreamFold {
+    pub(crate) fn new(cu_enabled: bool, cu_display: Option<(u32, u32)>) -> Self {
+        Self {
+            cu_enabled,
+            cu_display,
+            json: streaming::EventJson::new(),
+            text_parts: Vec::new(),
+            tool_calls: Vec::new(),
+            cu_calls: Vec::new(),
+            raw_model_parts: Vec::new(),
+            usage: TokenUsage::default(),
         }
+    }
 
-        let content = text_parts.join("");
+    /// Assemble the final response after the stream ends.
+    pub(crate) fn finish(self) -> ChatResponse {
+        let content = self.text_parts.join("");
         // Store raw parts for echo-back (preserves thoughtSignature for
         // Gemini CU). Adjacent pure-text delta parts are coalesced first:
         // streaming produced one `{"text": …}` fragment per delta, and
         // echoing hundreds of them back in every subsequent request body
         // was pure wire/parse bloat.
-        let raw_model_parts = coalesce_adjacent_text_parts(raw_model_parts);
+        let raw_model_parts = coalesce_adjacent_text_parts(self.raw_model_parts);
         let raw_output = if !raw_model_parts.is_empty() {
             Some(raw_model_parts)
         } else {
             None
         };
-        let response = ChatResponse {
+        ChatResponse {
             content,
-            usage,
+            usage: self.usage,
             reasoning_summary: None,
             reasoning_content: None,
-            tool_calls,
-            cu_calls,
+            tool_calls: self.tool_calls,
+            cu_calls: self.cu_calls,
             raw_output,
+        }
+    }
+}
+
+impl streaming::SseFold for GeminiStreamFold {
+    fn on_data(
+        &mut self,
+        data: &str,
+        on_event: &(dyn Fn(StreamEvent) + Send + Sync),
+    ) -> Result<(), CallerError> {
+        let Some(resp) = self.json.parse(data) else {
+            return Ok(());
         };
-        on_event(StreamEvent::Complete(response.clone()));
-        Ok(response)
+        // Extract text and function calls from candidates
+        if let Some(parts) = resp
+            .pointer("/candidates/0/content/parts")
+            .and_then(|p| p.as_array())
+        {
+            for part in parts {
+                // Capture raw parts for verbatim echo-back (preserves thoughtSignature)
+                self.raw_model_parts.push(part.clone());
+
+                if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
+                    self.text_parts.push(text.to_string());
+                    on_event(StreamEvent::Delta(text.to_string()));
+                }
+                if let Some(fc) = part.get("functionCall") {
+                    let name = fc
+                        .get("name")
+                        .and_then(|n| n.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let args_val = fc.get("args").cloned().unwrap_or(serde_json::json!({}));
+
+                    if self.cu_enabled && GEMINI_CU_FUNCTIONS.contains(&name.as_str()) {
+                        let (dw, dh) = self.cu_display.unwrap_or((1440, 900));
+                        if let Some(action) = parse_gemini_cu_action(&name, &args_val, dw, dh) {
+                            let id = format!("gemini_cu_{}", self.cu_calls.len());
+                            self.cu_calls.push(crate::computer_use::CuToolCall {
+                                call_id: id,
+                                actions: vec![action],
+                                metadata: crate::computer_use::CuCallMetadata::default(),
+                            });
+                        }
+                    } else {
+                        let args =
+                            serde_json::to_string(&args_val).unwrap_or_else(|_| "{}".to_string());
+                        let id = format!("gemini_call_{}", self.tool_calls.len());
+                        self.tool_calls.push(ToolCall {
+                            id: id.clone(),
+                            call_id: id,
+                            name,
+                            arguments: args,
+                        });
+                    }
+                }
+            }
+        }
+
+        // Extract usage from the last chunk
+        if let Some(u) = resp.get("usageMetadata") {
+            let prompt = u
+                .get("promptTokenCount")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            let completion = u
+                .get("candidatesTokenCount")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            let total = u
+                .get("totalTokenCount")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(prompt + completion);
+            let cached = u
+                .get("cachedContentTokenCount")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            self.usage = TokenUsage {
+                prompt_tokens: prompt,
+                completion_tokens: completion,
+                total_tokens: total,
+                cached_tokens: cached,
+                ..Default::default()
+            };
+        }
+        Ok(())
     }
 }
 
@@ -1027,5 +1046,80 @@ mod tests {
         assert_eq!(out[0]["thoughtSignature"].as_str(), Some("sig1"));
         assert_eq!(out[0]["text"].as_str(), Some("a"));
         assert_eq!(out[1], serde_json::json!({"text": "bc"}));
+    }
+
+    // --- Stream fold (the Gemini arm of the shared SSE driver) ---
+
+    /// A realistic streamGenerateContent alt=sse transcript: split text
+    /// deltas (multibyte content), a functionCall part, a
+    /// thoughtSignature part that must survive coalescing verbatim, and
+    /// usageMetadata where the last chunk wins.
+    const GEMINI_SSE_TRANSCRIPT: &str = concat!(
+        "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Hel\"}]}}],\"usageMetadata\":{\"promptTokenCount\":1,\"candidatesTokenCount\":1,\"totalTokenCount\":2}}\r\n",
+        "\r\n",
+        "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"lo 🦀\"},{\"text\":\"sig\",\"thoughtSignature\":\"tsig_1\"},{\"functionCall\":{\"name\":\"exec_command\",\"args\":{\"command\":\"ls\"}}}]}}],\"usageMetadata\":{\"promptTokenCount\":50,\"candidatesTokenCount\":10,\"totalTokenCount\":60,\"cachedContentTokenCount\":30}}\r\n",
+        "\r\n",
+    );
+
+    #[tokio::test]
+    async fn gemini_fold_assembles_text_tools_raw_parts_and_usage() {
+        let mut fold = GeminiStreamFold::new(false, None);
+        let deltas =
+            streaming::test_support::drive_transcript(&mut fold, GEMINI_SSE_TRANSCRIPT, 7).await;
+        // The thoughtSignature part's text is a delta too (the old loop
+        // emitted any part with a text field).
+        assert_eq!(deltas, vec!["Hel", "lo 🦀", "sig"]);
+
+        let response = fold.finish();
+        assert_eq!(response.content, "Hello 🦀sig");
+        assert_eq!(response.tool_calls.len(), 1);
+        assert_eq!(response.tool_calls[0].id, "gemini_call_0");
+        assert_eq!(response.tool_calls[0].call_id, "gemini_call_0");
+        assert_eq!(response.tool_calls[0].name, "exec_command");
+        assert_eq!(
+            response.tool_calls[0].arguments,
+            "{\"command\":\"ls\"}"
+        );
+
+        // Raw parts coalesce pure-text runs but keep the signed part and
+        // the functionCall verbatim as boundaries.
+        let raw = response.raw_output.as_ref().unwrap();
+        assert_eq!(raw.len(), 3);
+        assert_eq!(raw[0], serde_json::json!({"text": "Hello 🦀"}));
+        assert_eq!(raw[1]["thoughtSignature"].as_str(), Some("tsig_1"));
+        assert!(raw[2].get("functionCall").is_some());
+
+        // usageMetadata: the last chunk's counters win.
+        assert_eq!(response.usage.prompt_tokens, 50);
+        assert_eq!(response.usage.completion_tokens, 10);
+        assert_eq!(response.usage.total_tokens, 60);
+        assert_eq!(response.usage.cached_tokens, 30);
+    }
+
+    #[tokio::test]
+    async fn gemini_fold_routes_cu_functions_when_cu_enabled() {
+        let transcript = concat!(
+            "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"name\":\"click_at\",\"args\":{\"x\":500,\"y\":500}}}]}}]}\n\n",
+        );
+        // CU-enabled: click_at maps through the normalized-coordinate CU
+        // parser instead of the tool-call lane.
+        let mut fold = GeminiStreamFold::new(true, Some((1000, 1000)));
+        streaming::test_support::drive_transcript(&mut fold, transcript, 64).await;
+        let response = fold.finish();
+        assert!(response.tool_calls.is_empty());
+        assert_eq!(response.cu_calls.len(), 1);
+        assert_eq!(response.cu_calls[0].call_id, "gemini_cu_0");
+        assert!(matches!(
+            response.cu_calls[0].actions[..],
+            [crate::computer_use::CuAction::Click { .. }]
+        ));
+
+        // CU-disabled: the same functionCall is an ordinary tool call.
+        let mut fold = GeminiStreamFold::new(false, None);
+        streaming::test_support::drive_transcript(&mut fold, transcript, 64).await;
+        let response = fold.finish();
+        assert!(response.cu_calls.is_empty());
+        assert_eq!(response.tool_calls.len(), 1);
+        assert_eq!(response.tool_calls[0].name, "click_at");
     }
 }

--- a/src/bin/caller/provider/mod.rs
+++ b/src/bin/caller/provider/mod.rs
@@ -341,6 +341,37 @@ impl ProviderHttpResponse {
     }
 }
 
+/// One provider request, built exactly once per turn: the serialized
+/// wire bytes plus the stable schema label the Context tab keys on. The
+/// same `Bytes` feed every HTTP attempt (first send and retries are
+/// refcount bumps, not copies) and the snapshot view — parsed back from
+/// those bytes by [`PreparedRequest::snapshot_value`], so the Context
+/// tab's "exact request payload" guarantee holds by construction instead
+/// of by parallel rebuild.
+#[derive(Debug, Clone)]
+pub struct PreparedRequest {
+    /// Stable schema label (e.g. `anthropic.messages.request.v1`).
+    pub(crate) format: String,
+    /// The serialized request body — the exact bytes on the wire.
+    pub(crate) body: bytes::Bytes,
+}
+
+impl PreparedRequest {
+    pub(crate) fn new(format: impl Into<String>, body: Vec<u8>) -> Self {
+        Self {
+            format: format.into(),
+            body: body.into(),
+        }
+    }
+
+    /// The snapshot-facing DOM view, parsed from the wire bytes. Costs
+    /// one parse, so only snapshot consumers (the per-turn Context-tab
+    /// event) pay for it — `chat`/`chat_stream` never do.
+    pub(crate) fn snapshot_value(&self) -> Result<serde_json::Value, CallerError> {
+        serde_json::from_slice(&self.body).map_err(CallerError::Json)
+    }
+}
+
 /// Events emitted during streaming responses.
 #[derive(Debug, Clone)]
 pub enum StreamEvent {
@@ -415,18 +446,37 @@ pub trait ChatProvider: Send + Sync {
         vec![]
     }
 
-    /// Build the provider-specific request body that will be sent for this
-    /// message slice. Used by the dashboard Context tab to show the exact
-    /// model request payload after provider role conversion, system/developer
-    /// fields, tools, and native computer-use blocks are applied.
-    fn request_snapshot(
+    /// Build the provider-specific request exactly once: role conversion,
+    /// system/developer fields, tools, native computer-use blocks, and
+    /// serialization. The returned [`PreparedRequest`] carries the exact
+    /// wire bytes; [`ChatProvider::request_snapshot`] and
+    /// [`ChatProvider::chat_stream_prepared`] both derive from it, so the
+    /// agent loop's per-turn Context snapshot and the HTTP body are one
+    /// build instead of two.
+    fn prepare_request(
         &self,
         _messages: &[Message],
         _stream: bool,
-    ) -> Result<(String, serde_json::Value), CallerError> {
+    ) -> Result<PreparedRequest, CallerError> {
         Err(CallerError::Provider(
             "provider does not expose a request payload snapshot".to_string(),
         ))
+    }
+
+    /// The provider request as a `(format, payload)` pair for the
+    /// dashboard Context tab — derived from [`ChatProvider::prepare_request`]
+    /// (the payload is a parse of the exact wire bytes). Kept as a trait
+    /// method for snapshot-only consumers; the agent loop calls
+    /// `prepare_request` directly so the same build also feeds the wire.
+    #[allow(dead_code)]
+    fn request_snapshot(
+        &self,
+        messages: &[Message],
+        stream: bool,
+    ) -> Result<(String, serde_json::Value), CallerError> {
+        let prepared = self.prepare_request(messages, stream)?;
+        let value = prepared.snapshot_value()?;
+        Ok((prepared.format, value))
     }
 
     /// Stream a chat response, emitting deltas via the callback.
@@ -442,6 +492,23 @@ pub trait ChatProvider: Send + Sync {
         }
         on_event(StreamEvent::Complete(response.clone()));
         Ok(response)
+    }
+
+    /// Stream a chat response from an already-built request (`stream:
+    /// true` builds only). The agent loop prepares once per turn and
+    /// hands the same [`PreparedRequest`] to every retry attempt, so
+    /// neither the snapshot nor a retry ever rebuilds or re-serializes
+    /// the request. Providers that implement [`ChatProvider::prepare_request`]
+    /// implement this too; the default mirrors `prepare_request`'s
+    /// absence so callers fall back to [`ChatProvider::chat_stream`].
+    async fn chat_stream_prepared(
+        &self,
+        _prepared: &PreparedRequest,
+        _on_event: &(dyn Fn(StreamEvent) + Send + Sync),
+    ) -> Result<ChatResponse, CallerError> {
+        Err(CallerError::Provider(
+            "provider does not stream prepared requests".to_string(),
+        ))
     }
 }
 
@@ -1583,6 +1650,24 @@ mod tests {
     // (Framing and driver coverage lives in `streaming::tests`; the
     // SseLineBuffer/parse_sse_line scenarios were ported there when
     // SseFramer superseded them.)
+
+    #[test]
+    fn providers_without_prepare_request_keep_the_legacy_snapshot_error() {
+        // The agent loop's mock/custom-provider fallback (messages dump +
+        // warn) keys on this exact error; request_snapshot derives from
+        // prepare_request, so both surface it unchanged.
+        let mock = mock::MockOrchestrationProvider::new();
+        let err = mock.prepare_request(&[], true).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Provider error: provider does not expose a request payload snapshot"
+        );
+        let err = mock.request_snapshot(&[], true).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Provider error: provider does not expose a request payload snapshot"
+        );
+    }
 
     #[test]
     fn stream_event_delta_clone() {

--- a/src/bin/caller/provider/mod.rs
+++ b/src/bin/caller/provider/mod.rs
@@ -14,6 +14,7 @@ mod anthropic;
 pub(crate) use anthropic::*;
 mod gemini;
 pub(crate) use gemini::*;
+pub(crate) mod streaming;
 
 /// HTTP client timeout for API requests (120 seconds).
 const API_TIMEOUT: Duration = Duration::from_secs(120);
@@ -75,60 +76,11 @@ async fn send_with_retry(
         .unwrap_or_else(|| CallerError::Provider("request failed after retries".to_string())))
 }
 
-/// Parse Server-Sent Events from a byte stream. Returns (event_type, data) pairs.
-/// Handles multi-line data fields by joining with newlines.
-fn parse_sse_line(line: &str) -> Option<(&str, &str)> {
-    if let Some(rest) = line.strip_prefix("data: ") {
-        Some(("data", rest))
-    } else if let Some(rest) = line.strip_prefix("event: ") {
-        Some(("event", rest))
-    } else {
-        None
-    }
-}
-
-/// Byte-accurate line framing for SSE streams. Network chunks accumulate as
-/// raw bytes and are converted to text only once a complete line is
-/// available: converting each chunk independently (the old per-chunk
-/// `from_utf8_lossy`) corrupted any multibyte UTF-8 codepoint that a chunk
-/// boundary happened to split — common with CJK/emoji streaming — into
-/// U+FFFD replacement characters.
-pub(crate) struct SseLineBuffer {
-    buf: Vec<u8>,
-}
-
-impl SseLineBuffer {
-    pub(crate) fn new() -> Self {
-        Self { buf: Vec::new() }
-    }
-
-    /// Append a raw network chunk.
-    pub(crate) fn push_chunk(&mut self, chunk: &[u8]) {
-        self.buf.extend_from_slice(chunk);
-    }
-
-    /// Pop the next complete line: everything up to the first `'\n'` (which
-    /// is consumed and excluded), with trailing `'\r'`s stripped — the
-    /// byte-level equivalent of the providers' old `trim_end_matches('\r')`.
-    /// Lossy UTF-8 conversion happens only here, on the complete line, so a
-    /// genuinely invalid byte still degrades to U+FFFD but a chunk boundary
-    /// never manufactures one. Returns `None` when no full line is buffered;
-    /// the partial tail stays buffered for the next chunk. Scanning for
-    /// `b'\n'`/`b'\r'` byte-wise is UTF-8-safe: ASCII bytes never occur
-    /// inside a multibyte sequence.
-    pub(crate) fn next_line(&mut self) -> Option<String> {
-        let newline_pos = self.buf.iter().position(|&b| b == b'\n')?;
-        let mut line_end = newline_pos;
-        while line_end > 0 && self.buf[line_end - 1] == b'\r' {
-            line_end -= 1;
-        }
-        let line = String::from_utf8_lossy(&self.buf[..line_end]).into_owned();
-        // Drain the consumed prefix in place instead of reallocating the
-        // remainder into a fresh buffer per line.
-        self.buf.drain(..=newline_pos);
-        Some(line)
-    }
-}
+// SSE mechanics — chunk→event framing, the stream driver, and the
+// per-provider fold seam — live in [`streaming`]. The line-buffer and
+// `parse_sse_line` helpers the three provider loops used to share were
+// superseded by `streaming::SseFramer` (which also fixes the multi-line
+// `data:` joining those helpers documented but never implemented).
 
 /// Streaming timeout for SSE connections (10 minutes).
 const STREAM_TIMEOUT: Duration = Duration::from_secs(600);
@@ -356,14 +308,24 @@ impl ProviderHttpResponse {
 
     fn bytes_stream(
         self,
-    ) -> std::pin::Pin<Box<dyn futures_util::Stream<Item = Result<Vec<u8>, String>> + Send>> {
+    ) -> std::pin::Pin<Box<dyn futures_util::Stream<Item = Result<bytes::Bytes, String>> + Send>>
+    {
         match self {
+            // reqwest chunks are already refcounted `Bytes` — hand them
+            // through as-is (the old `.to_vec()` copied the entire
+            // response body once per chunk for nothing).
             ProviderHttpResponse::Direct(response) => Box::pin(
                 response
                     .bytes_stream()
-                    .map(|chunk| chunk.map(|bytes| bytes.to_vec()).map_err(|e| e.to_string())),
+                    .map(|chunk| chunk.map_err(|e| e.to_string())),
             ),
-            ProviderHttpResponse::Egress(response) => Box::pin(response.bytes_stream()),
+            // The egress relay assembles owned Vecs from base64 frames;
+            // `Bytes::from(Vec)` takes ownership without copying.
+            ProviderHttpResponse::Egress(response) => Box::pin(
+                response
+                    .bytes_stream()
+                    .map(|chunk| chunk.map(bytes::Bytes::from)),
+            ),
         }
     }
 
@@ -1227,77 +1189,6 @@ pub mod mock {
 mod tests {
     use super::*;
 
-    /// Drain every currently complete line.
-    fn drain_lines(buf: &mut SseLineBuffer) -> Vec<String> {
-        let mut lines = Vec::new();
-        while let Some(line) = buf.next_line() {
-            lines.push(line);
-        }
-        lines
-    }
-
-    #[test]
-    fn sse_line_buffer_multibyte_split_across_two_chunks() {
-        // "…" is E2 80 A6; split it mid-sequence the way a network chunk
-        // boundary can. The old per-chunk from_utf8_lossy turned each half
-        // into U+FFFD.
-        let payload = "data: a…b\n".as_bytes();
-        let mut buf = SseLineBuffer::new();
-        buf.push_chunk(&payload[..9]); // "data: a" + E2 80 (mid-codepoint)
-        assert_eq!(buf.next_line(), None);
-        buf.push_chunk(&payload[9..]); // A6 + "b\n"
-        assert_eq!(buf.next_line().as_deref(), Some("data: a…b"));
-        assert_eq!(buf.next_line(), None);
-    }
-
-    #[test]
-    fn sse_line_buffer_emoji_split_across_three_chunks() {
-        // "🦀" is F0 9F A6 80 — four bytes, split across three pushes.
-        let payload = "data: 🦀!\n".as_bytes();
-        let mut buf = SseLineBuffer::new();
-        buf.push_chunk(&payload[..7]); // "data: " + F0
-        assert_eq!(buf.next_line(), None);
-        buf.push_chunk(&payload[7..9]); // 9F A6
-        assert_eq!(buf.next_line(), None);
-        buf.push_chunk(&payload[9..]); // 80 "!\n"
-        let line = buf.next_line().unwrap();
-        assert_eq!(line, "data: 🦀!");
-        assert!(!line.contains('\u{FFFD}'));
-    }
-
-    #[test]
-    fn sse_line_buffer_crlf_and_heartbeat_lines() {
-        let mut buf = SseLineBuffer::new();
-        buf.push_chunk(b"data: hi\r\n\r\n\ndata: x\r\r\n");
-        assert_eq!(
-            drain_lines(&mut buf),
-            // Trailing '\r's are stripped (all of them — trim_end_matches
-            // parity), and heartbeat blank lines come through as empty
-            // strings for the callers' existing is_empty() skip.
-            vec!["data: hi", "", "", "data: x"]
-        );
-    }
-
-    #[test]
-    fn sse_line_buffer_split_mid_data_prefix() {
-        let mut buf = SseLineBuffer::new();
-        buf.push_chunk(b"da");
-        assert_eq!(buf.next_line(), None);
-        buf.push_chunk(b"ta: {\"k\":1}\n");
-        assert_eq!(buf.next_line().as_deref(), Some("data: {\"k\":1}"));
-    }
-
-    #[test]
-    fn sse_line_buffer_multiple_lines_one_chunk_and_partial_tail() {
-        let mut buf = SseLineBuffer::new();
-        buf.push_chunk(b"event: delta\ndata: one\ndata: tw");
-        assert_eq!(drain_lines(&mut buf), vec!["event: delta", "data: one"]);
-        // The partial tail stays buffered until its newline arrives.
-        buf.push_chunk(b"o\n");
-        assert_eq!(buf.next_line().as_deref(), Some("data: two"));
-        assert_eq!(buf.next_line(), None);
-    }
-
     #[test]
     fn project_env_keys_whitelists_provider_keys_only() {
         let dir = tempfile::tempdir().unwrap();
@@ -1689,27 +1580,9 @@ mod tests {
     }
 
     // --- Streaming tests ---
-
-    #[test]
-    fn parse_sse_line_data() {
-        let (kind, content) = parse_sse_line("data: {\"type\":\"ping\"}").unwrap();
-        assert_eq!(kind, "data");
-        assert_eq!(content, "{\"type\":\"ping\"}");
-    }
-
-    #[test]
-    fn parse_sse_line_event() {
-        let (kind, content) = parse_sse_line("event: message_start").unwrap();
-        assert_eq!(kind, "event");
-        assert_eq!(content, "message_start");
-    }
-
-    #[test]
-    fn parse_sse_line_unknown() {
-        assert!(parse_sse_line("id: 123").is_none());
-        assert!(parse_sse_line("").is_none());
-        assert!(parse_sse_line("random text").is_none());
-    }
+    // (Framing and driver coverage lives in `streaming::tests`; the
+    // SseLineBuffer/parse_sse_line scenarios were ported there when
+    // SseFramer superseded them.)
 
     #[test]
     fn stream_event_delta_clone() {

--- a/src/bin/caller/provider/openai.rs
+++ b/src/bin/caller/provider/openai.rs
@@ -609,236 +609,249 @@ impl ChatProvider for OpenAIProvider {
             )));
         }
 
-        // Parse SSE stream
-        let mut text_parts = Vec::new();
-        let mut tool_calls: Vec<ToolCall> = Vec::new();
-        let mut cu_calls: Vec<crate::computer_use::CuToolCall> = Vec::new();
-        let mut raw_output_items: Vec<serde_json::Value> = Vec::new();
-        let mut usage = TokenUsage::default();
-        let mut reasoning_summary_parts = Vec::new();
-        let reasoning_content_parts: Vec<String> = Vec::new();
-        // Track in-progress function calls by index
-        let mut pending_tools: std::collections::HashMap<usize, ToolCall> =
-            std::collections::HashMap::new();
-        let mut line_buf = SseLineBuffer::new();
+        let mut fold = OpenAIStreamFold::new(self.cu_enabled);
+        streaming::run_sse_stream(ProviderHttpResponse::Direct(response), &mut fold, on_event)
+            .await
+            .map_err(streaming::StreamFailure::into_caller_error)?;
+        let response = fold.finish();
+        on_event(StreamEvent::Complete(response.clone()));
+        Ok(response)
+    }
+}
 
-        let mut stream = response.bytes_stream();
-        while let Some(chunk) = stream.next().await {
-            let chunk = chunk.map_err(|e| CallerError::Provider(format!("Stream error: {}", e)))?;
-            line_buf.push_chunk(&chunk);
+/// The OpenAI Responses-API arm of the shared SSE driver: exactly the
+/// per-event mutable state the old hand-rolled loop carried (pending
+/// function calls by output index, raw echo-back items, usage from
+/// `response.completed`), with the mechanics living in
+/// `provider::streaming`.
+pub(crate) struct OpenAIStreamFold {
+    cu_enabled: bool,
+    json: streaming::EventJson,
+    text_parts: Vec<String>,
+    tool_calls: Vec<ToolCall>,
+    cu_calls: Vec<crate::computer_use::CuToolCall>,
+    raw_output_items: Vec<serde_json::Value>,
+    usage: TokenUsage,
+    reasoning_summary_parts: Vec<String>,
+    /// Never populated by the streaming vocabulary (full reasoning
+    /// content only arrives on the non-streaming path); kept so the final
+    /// assembly matches the old loop field-for-field.
+    reasoning_content_parts: Vec<String>,
+    /// In-progress function calls by output index.
+    pending_tools: std::collections::HashMap<usize, ToolCall>,
+}
 
-            while let Some(line) = line_buf.next_line() {
-                if line.is_empty() {
-                    continue;
+impl OpenAIStreamFold {
+    pub(crate) fn new(cu_enabled: bool) -> Self {
+        Self {
+            cu_enabled,
+            json: streaming::EventJson::new(),
+            text_parts: Vec::new(),
+            tool_calls: Vec::new(),
+            cu_calls: Vec::new(),
+            raw_output_items: Vec::new(),
+            usage: TokenUsage::default(),
+            reasoning_summary_parts: Vec::new(),
+            reasoning_content_parts: Vec::new(),
+            pending_tools: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Assemble the final response after the stream ends.
+    pub(crate) fn finish(mut self) -> ChatResponse {
+        // Flush any remaining pending tool calls
+        let mut remaining_indices: Vec<usize> = self.pending_tools.keys().copied().collect();
+        remaining_indices.sort();
+        for idx in remaining_indices {
+            if let Some(tc) = self.pending_tools.remove(&idx) {
+                self.tool_calls.push(tc);
+            }
+        }
+
+        let content = self.text_parts.join("");
+        let reasoning_summary = if self.reasoning_summary_parts.is_empty() {
+            None
+        } else {
+            Some(self.reasoning_summary_parts.join("\n"))
+        };
+        let reasoning_content = if self.reasoning_content_parts.is_empty() {
+            None
+        } else {
+            Some(self.reasoning_content_parts.join(""))
+        };
+        let raw_output = if self.raw_output_items.is_empty() {
+            None
+        } else {
+            Some(self.raw_output_items)
+        };
+
+        ChatResponse {
+            content,
+            usage: self.usage,
+            reasoning_summary,
+            reasoning_content,
+            tool_calls: self.tool_calls,
+            cu_calls: self.cu_calls,
+            raw_output,
+        }
+    }
+}
+
+impl streaming::SseFold for OpenAIStreamFold {
+    fn on_data(
+        &mut self,
+        data: &str,
+        on_event: &(dyn Fn(StreamEvent) + Send + Sync),
+    ) -> Result<(), CallerError> {
+        let Some(event) = self.json.parse(data) else {
+            return Ok(());
+        };
+        let event_type = event.get("type").and_then(|t| t.as_str()).unwrap_or("");
+        match event_type {
+            "response.output_text.delta" => {
+                if let Some(delta) = event.get("delta").and_then(|d| d.as_str()) {
+                    self.text_parts.push(delta.to_string());
+                    on_event(StreamEvent::Delta(delta.to_string()));
                 }
-                if let Some(("data", data)) = parse_sse_line(&line) {
-                    if data == "[DONE]" {
-                        continue;
+            }
+            "response.output_item.added" => {
+                // Track raw output items
+                if let Some(item) = event.get("item") {
+                    self.raw_output_items.push(item.clone());
+                    let item_type = item.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                    if item_type == "function_call" {
+                        let idx = event
+                            .get("output_index")
+                            .and_then(|v| v.as_u64())
+                            .unwrap_or(0) as usize;
+                        let id = item
+                            .get("id")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let call_id = item
+                            .get("call_id")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let name = item
+                            .get("name")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        self.pending_tools.insert(
+                            idx,
+                            ToolCall {
+                                id,
+                                call_id,
+                                name,
+                                arguments: String::new(),
+                            },
+                        );
                     }
-                    if let Ok(event) = serde_json::from_str::<serde_json::Value>(data) {
-                        let event_type = event.get("type").and_then(|t| t.as_str()).unwrap_or("");
-                        match event_type {
-                            "response.output_text.delta" => {
-                                if let Some(delta) = event.get("delta").and_then(|d| d.as_str()) {
-                                    text_parts.push(delta.to_string());
-                                    on_event(StreamEvent::Delta(delta.to_string()));
+                }
+            }
+            "response.function_call_arguments.delta" => {
+                let idx = event
+                    .get("output_index")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0) as usize;
+                if let Some(delta) = event.get("delta").and_then(|d| d.as_str()) {
+                    if let Some(tc) = self.pending_tools.get_mut(&idx) {
+                        tc.arguments.push_str(delta);
+                    }
+                }
+            }
+            "response.function_call_arguments.done" => {
+                let idx = event
+                    .get("output_index")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0) as usize;
+                if let Some(tc) = self.pending_tools.remove(&idx) {
+                    self.tool_calls.push(tc);
+                }
+            }
+            "response.output_item.done" => {
+                // Update raw output with final item
+                if let Some(item) = event.get("item") {
+                    let idx = event
+                        .get("output_index")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0) as usize;
+                    if idx < self.raw_output_items.len() {
+                        self.raw_output_items[idx] = item.clone();
+                    }
+                    let item_type = item.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                    // Parse computer_call items
+                    if item_type == "computer_call" && self.cu_enabled {
+                        if let Some(call_id) = item.get("call_id").and_then(|v| v.as_str()) {
+                            let actions = item
+                                .get("actions")
+                                .and_then(|a| a.as_array())
+                                .map(|arr| {
+                                    arr.iter().filter_map(parse_openai_cu_action).collect()
+                                })
+                                .unwrap_or_default();
+                            let safety = item
+                                .get("pending_safety_checks")
+                                .and_then(|v| v.as_array())
+                                .cloned()
+                                .unwrap_or_default();
+                            self.cu_calls.push(crate::computer_use::CuToolCall {
+                                call_id: call_id.to_string(),
+                                actions,
+                                metadata: crate::computer_use::CuCallMetadata {
+                                    pending_safety_checks: safety,
+                                    ..Default::default()
+                                },
+                            });
+                        }
+                    }
+                    // Extract reasoning summary
+                    if item_type == "reasoning" {
+                        if let Some(summary) = item.get("summary").and_then(|s| s.as_array()) {
+                            for s in summary {
+                                if let Some(text) = s.get("text").and_then(|t| t.as_str()) {
+                                    self.reasoning_summary_parts.push(text.to_string());
                                 }
                             }
-                            "response.output_item.added" => {
-                                // Track raw output items
-                                if let Some(item) = event.get("item") {
-                                    raw_output_items.push(item.clone());
-                                    let item_type =
-                                        item.get("type").and_then(|t| t.as_str()).unwrap_or("");
-                                    if item_type == "function_call" {
-                                        let idx = event
-                                            .get("output_index")
-                                            .and_then(|v| v.as_u64())
-                                            .unwrap_or(0)
-                                            as usize;
-                                        let id = item
-                                            .get("id")
-                                            .and_then(|v| v.as_str())
-                                            .unwrap_or("")
-                                            .to_string();
-                                        let call_id = item
-                                            .get("call_id")
-                                            .and_then(|v| v.as_str())
-                                            .unwrap_or("")
-                                            .to_string();
-                                        let name = item
-                                            .get("name")
-                                            .and_then(|v| v.as_str())
-                                            .unwrap_or("")
-                                            .to_string();
-                                        pending_tools.insert(
-                                            idx,
-                                            ToolCall {
-                                                id,
-                                                call_id,
-                                                name,
-                                                arguments: String::new(),
-                                            },
-                                        );
-                                    }
-                                }
-                            }
-                            "response.function_call_arguments.delta" => {
-                                let idx = event
-                                    .get("output_index")
-                                    .and_then(|v| v.as_u64())
-                                    .unwrap_or(0)
-                                    as usize;
-                                if let Some(delta) = event.get("delta").and_then(|d| d.as_str()) {
-                                    if let Some(tc) = pending_tools.get_mut(&idx) {
-                                        tc.arguments.push_str(delta);
-                                    }
-                                }
-                            }
-                            "response.function_call_arguments.done" => {
-                                let idx = event
-                                    .get("output_index")
-                                    .and_then(|v| v.as_u64())
-                                    .unwrap_or(0)
-                                    as usize;
-                                if let Some(tc) = pending_tools.remove(&idx) {
-                                    tool_calls.push(tc);
-                                }
-                            }
-                            "response.output_item.done" => {
-                                // Update raw output with final item
-                                if let Some(item) = event.get("item") {
-                                    let idx = event
-                                        .get("output_index")
-                                        .and_then(|v| v.as_u64())
-                                        .unwrap_or(0)
-                                        as usize;
-                                    if idx < raw_output_items.len() {
-                                        raw_output_items[idx] = item.clone();
-                                    }
-                                    let item_type =
-                                        item.get("type").and_then(|t| t.as_str()).unwrap_or("");
-                                    // Parse computer_call items
-                                    if item_type == "computer_call" && self.cu_enabled {
-                                        if let Some(call_id) =
-                                            item.get("call_id").and_then(|v| v.as_str())
-                                        {
-                                            let actions = item
-                                                .get("actions")
-                                                .and_then(|a| a.as_array())
-                                                .map(|arr| {
-                                                    arr.iter()
-                                                        .filter_map(parse_openai_cu_action)
-                                                        .collect()
-                                                })
-                                                .unwrap_or_default();
-                                            let safety = item
-                                                .get("pending_safety_checks")
-                                                .and_then(|v| v.as_array())
-                                                .cloned()
-                                                .unwrap_or_default();
-                                            cu_calls.push(crate::computer_use::CuToolCall {
-                                                call_id: call_id.to_string(),
-                                                actions,
-                                                metadata: crate::computer_use::CuCallMetadata {
-                                                    pending_safety_checks: safety,
-                                                    ..Default::default()
-                                                },
-                                            });
-                                        }
-                                    }
-                                    // Extract reasoning summary
-                                    if item_type == "reasoning" {
-                                        if let Some(summary) =
-                                            item.get("summary").and_then(|s| s.as_array())
-                                        {
-                                            for s in summary {
-                                                if let Some(text) =
-                                                    s.get("text").and_then(|t| t.as_str())
-                                                {
-                                                    reasoning_summary_parts.push(text.to_string());
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            "response.completed" => {
-                                if let Some(resp) = event.get("response") {
-                                    if let Some(u) = resp.get("usage") {
-                                        usage.prompt_tokens = u
-                                            .get("input_tokens")
-                                            .and_then(|v| v.as_u64())
-                                            .unwrap_or(0);
-                                        usage.completion_tokens = u
-                                            .get("output_tokens")
-                                            .and_then(|v| v.as_u64())
-                                            .unwrap_or(0);
-                                        usage.total_tokens = u
-                                            .get("total_tokens")
-                                            .and_then(|v| v.as_u64())
-                                            .unwrap_or(
-                                                usage.prompt_tokens + usage.completion_tokens,
-                                            );
-                                        usage.cached_tokens = u
-                                            .get("input_tokens_details")
-                                            .and_then(|d| d.get("cached_tokens"))
-                                            .and_then(|v| v.as_u64())
-                                            .unwrap_or(0);
-                                        usage.cache_creation_tokens = u
-                                            .get("input_tokens_details")
-                                            .and_then(|d| d.get("cache_write_tokens"))
-                                            .and_then(|v| v.as_u64())
-                                            .unwrap_or(0);
-                                        usage.cache_ttl_seconds =
-                                            (usage.cache_creation_tokens > 0).then_some(30 * 60);
-                                    }
-                                }
-                            }
-                            _ => {}
                         }
                     }
                 }
             }
-        }
-
-        // Flush any remaining pending tool calls
-        let mut remaining_indices: Vec<usize> = pending_tools.keys().copied().collect();
-        remaining_indices.sort();
-        for idx in remaining_indices {
-            if let Some(tc) = pending_tools.remove(&idx) {
-                tool_calls.push(tc);
+            "response.completed" => {
+                if let Some(resp) = event.get("response") {
+                    if let Some(u) = resp.get("usage") {
+                        self.usage.prompt_tokens = u
+                            .get("input_tokens")
+                            .and_then(|v| v.as_u64())
+                            .unwrap_or(0);
+                        self.usage.completion_tokens = u
+                            .get("output_tokens")
+                            .and_then(|v| v.as_u64())
+                            .unwrap_or(0);
+                        self.usage.total_tokens = u
+                            .get("total_tokens")
+                            .and_then(|v| v.as_u64())
+                            .unwrap_or(self.usage.prompt_tokens + self.usage.completion_tokens);
+                        self.usage.cached_tokens = u
+                            .get("input_tokens_details")
+                            .and_then(|d| d.get("cached_tokens"))
+                            .and_then(|v| v.as_u64())
+                            .unwrap_or(0);
+                        self.usage.cache_creation_tokens = u
+                            .get("input_tokens_details")
+                            .and_then(|d| d.get("cache_write_tokens"))
+                            .and_then(|v| v.as_u64())
+                            .unwrap_or(0);
+                        self.usage.cache_ttl_seconds =
+                            (self.usage.cache_creation_tokens > 0).then_some(30 * 60);
+                    }
+                }
             }
+            _ => {}
         }
-
-        let content = text_parts.join("");
-        let reasoning_summary = if reasoning_summary_parts.is_empty() {
-            None
-        } else {
-            Some(reasoning_summary_parts.join("\n"))
-        };
-        let reasoning_content = if reasoning_content_parts.is_empty() {
-            None
-        } else {
-            Some(reasoning_content_parts.join(""))
-        };
-        let raw_output = if raw_output_items.is_empty() {
-            None
-        } else {
-            Some(raw_output_items)
-        };
-
-        let response = ChatResponse {
-            content,
-            usage,
-            reasoning_summary,
-            reasoning_content,
-            tool_calls,
-            cu_calls,
-            raw_output,
-        };
-        on_event(StreamEvent::Complete(response.clone()));
-        Ok(response)
+        Ok(())
     }
 }
 
@@ -1395,5 +1408,116 @@ mod tests {
         // Should have only the function_call_output, no user image message
         assert_eq!(input.len(), 1);
         assert_eq!(input[0]["type"].as_str(), Some("function_call_output"));
+    }
+
+    // --- Stream fold (the OpenAI arm of the shared SSE driver) ---
+
+    /// A realistic Responses-API SSE transcript: a function call assembled
+    /// from argument deltas, split text deltas (multibyte content), the
+    /// done-event overwrite of the raw echo-back item, a reasoning
+    /// summary, usage in `response.completed`, and the trailing `[DONE]`.
+    const OPENAI_SSE_TRANSCRIPT: &str = concat!(
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call_1\",\"name\":\"exec_command\",\"arguments\":\"\"}}\n",
+        "\n",
+        "data: {\"type\":\"response.function_call_arguments.delta\",\"output_index\":0,\"delta\":\"{\\\"command\\\":\"}\n",
+        "\n",
+        "data: {\"type\":\"response.function_call_arguments.delta\",\"output_index\":0,\"delta\":\"\\\"ls\\\"}\"}\n",
+        "\n",
+        "data: {\"type\":\"response.function_call_arguments.done\",\"output_index\":0}\n",
+        "\n",
+        "data: {\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"type\":\"message\"}}\n",
+        "\n",
+        "data: {\"type\":\"response.output_text.delta\",\"delta\":\"Hi \"}\n",
+        "\n",
+        "data: {\"type\":\"response.output_text.delta\",\"delta\":\"🦀\"}\n",
+        "\n",
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call_1\",\"name\":\"exec_command\",\"arguments\":\"{\\\"command\\\":\\\"ls\\\"}\",\"status\":\"completed\"}}\n",
+        "\n",
+        "data: {\"type\":\"response.output_item.done\",\"output_index\":2,\"item\":{\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"thought about it\"}]}}\n",
+        "\n",
+        "data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":100,\"output_tokens\":25,\"total_tokens\":125,\"input_tokens_details\":{\"cached_tokens\":80,\"cache_write_tokens\":10}}}}\n",
+        "\n",
+        "data: [DONE]\n",
+        "\n",
+    );
+
+    #[tokio::test]
+    async fn openai_fold_assembles_tools_text_raw_output_and_usage() {
+        let mut fold = OpenAIStreamFold::new(false);
+        let deltas =
+            streaming::test_support::drive_transcript(&mut fold, OPENAI_SSE_TRANSCRIPT, 7).await;
+        assert_eq!(deltas, vec!["Hi ", "🦀"]);
+
+        let response = fold.finish();
+        assert_eq!(response.content, "Hi 🦀");
+        assert_eq!(response.tool_calls.len(), 1);
+        assert_eq!(response.tool_calls[0].id, "fc_1");
+        assert_eq!(response.tool_calls[0].call_id, "call_1");
+        assert_eq!(response.tool_calls[0].name, "exec_command");
+        assert_eq!(response.tool_calls[0].arguments, "{\"command\":\"ls\"}");
+
+        // Raw echo-back items: the done event replaced index 0 with the
+        // final item; the out-of-range done (index 2) was ignored but its
+        // reasoning summary still extracted.
+        let raw = response.raw_output.as_ref().unwrap();
+        assert_eq!(raw.len(), 2);
+        assert_eq!(raw[0]["status"].as_str(), Some("completed"));
+        assert_eq!(raw[1]["type"].as_str(), Some("message"));
+        assert_eq!(response.reasoning_summary.as_deref(), Some("thought about it"));
+        assert_eq!(response.reasoning_content, None);
+
+        assert_eq!(response.usage.prompt_tokens, 100);
+        assert_eq!(response.usage.completion_tokens, 25);
+        assert_eq!(response.usage.total_tokens, 125);
+        assert_eq!(response.usage.cached_tokens, 80);
+        assert_eq!(response.usage.cache_creation_tokens, 10);
+        assert_eq!(response.usage.cache_ttl_seconds, Some(1800));
+    }
+
+    #[tokio::test]
+    async fn openai_fold_flushes_pending_tools_in_index_order() {
+        // Calls whose arguments.done never arrives flush at finish,
+        // ordered by output index — exactly the old loop's tail flush.
+        let transcript = concat!(
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"type\":\"function_call\",\"id\":\"fc_b\",\"call_id\":\"call_b\",\"name\":\"second\",\"arguments\":\"\"}}\n\n",
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc_a\",\"call_id\":\"call_a\",\"name\":\"first\",\"arguments\":\"\"}}\n\n",
+            "data: {\"type\":\"response.function_call_arguments.delta\",\"output_index\":0,\"delta\":\"{}\"}\n\n",
+        );
+        let mut fold = OpenAIStreamFold::new(false);
+        streaming::test_support::drive_transcript(&mut fold, transcript, 64).await;
+        let response = fold.finish();
+        assert_eq!(response.tool_calls.len(), 2);
+        assert_eq!(response.tool_calls[0].name, "first");
+        assert_eq!(response.tool_calls[0].arguments, "{}");
+        assert_eq!(response.tool_calls[1].name, "second");
+    }
+
+    #[tokio::test]
+    async fn openai_fold_routes_computer_calls_when_cu_enabled() {
+        let transcript = concat!(
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"computer_call\",\"call_id\":\"cu_1\"}}\n\n",
+            "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"computer_call\",\"call_id\":\"cu_1\",\"actions\":[{\"type\":\"click\",\"x\":10,\"y\":20,\"button\":\"left\"}],\"pending_safety_checks\":[{\"id\":\"sc_1\"}]}}\n\n",
+        );
+        let mut fold = OpenAIStreamFold::new(true);
+        streaming::test_support::drive_transcript(&mut fold, transcript, 32).await;
+        let response = fold.finish();
+        assert_eq!(response.cu_calls.len(), 1);
+        assert_eq!(response.cu_calls[0].call_id, "cu_1");
+        assert!(matches!(
+            response.cu_calls[0].actions[..],
+            [crate::computer_use::CuAction::Click { x: 10, y: 20, .. }]
+        ));
+        assert_eq!(
+            response.cu_calls[0].metadata.pending_safety_checks.len(),
+            1
+        );
+
+        // CU-disabled: the computer_call is ignored (no CU lane, no tool
+        // call), matching the old loop's guard.
+        let mut fold = OpenAIStreamFold::new(false);
+        streaming::test_support::drive_transcript(&mut fold, transcript, 32).await;
+        let response = fold.finish();
+        assert!(response.cu_calls.is_empty());
+        assert!(response.tool_calls.is_empty());
     }
 }

--- a/src/bin/caller/provider/openai.rs
+++ b/src/bin/caller/provider/openai.rs
@@ -308,11 +308,14 @@ impl OpenAIProvider {
 
 #[async_trait]
 impl ChatProvider for OpenAIProvider {
-    fn request_snapshot(
+    /// The one request build: part assembly and a single serialization
+    /// straight to shared bytes. The snapshot, the first send, and every
+    /// retry all derive from this build.
+    fn prepare_request(
         &self,
         messages: &[Message],
         stream: bool,
-    ) -> Result<(String, serde_json::Value), CallerError> {
+    ) -> Result<PreparedRequest, CallerError> {
         let (instructions, input, text, tools) = build_openai_request_parts(messages, self);
         let request = OpenAIResponsesRequest {
             model: self.model.clone(),
@@ -324,32 +327,17 @@ impl ChatProvider for OpenAIProvider {
             tools,
             stream,
         };
-        Ok((
-            "openai.responses.request.v1".to_string(),
-            serde_json::to_value(&request).map_err(CallerError::Json)?,
+        Ok(PreparedRequest::new(
+            "openai.responses.request.v1",
+            serde_json::to_vec(&request).map_err(CallerError::Json)?,
         ))
     }
 
     async fn chat(&self, messages: &[Message]) -> Result<ChatResponse, CallerError> {
-        let (instructions, input, text, tools) = build_openai_request_parts(messages, self);
-
-        let request = OpenAIResponsesRequest {
-            model: self.model.clone(),
-            input,
-            instructions,
-            max_output_tokens: Some(self.max_output_tokens),
-            reasoning: self.reasoning.clone(),
-            text,
-            tools,
-            stream: false,
-        };
-
         // Note: OpenAI Responses API uses automatic prompt caching for prompts
         // longer than 1024 tokens. No explicit API changes are needed — caching
         // is applied server-side and reported via usage.prompt_tokens_details.
-        // Serialize once, straight to bytes — `to_value` + `.json()` walked
-        // the full request (images included) twice per call.
-        let request_body = serde_json::to_vec(&request).map_err(CallerError::Json)?;
+        let prepared = self.prepare_request(messages, false)?;
         let client = &self.client;
         let api_key = &self.api_key;
         let response = send_with_retry(
@@ -359,7 +347,8 @@ impl ChatProvider for OpenAIProvider {
                     .post("https://api.openai.com/v1/responses")
                     .header("Authorization", format!("Bearer {}", api_key))
                     .header("content-type", "application/json")
-                    .body(request_body.clone())
+                    // Bytes clone: every attempt reuses the one allocation.
+                    .body(prepared.body.clone())
             },
             MAX_RETRIES,
         )
@@ -567,18 +556,15 @@ impl ChatProvider for OpenAIProvider {
         messages: &[Message],
         on_event: &(dyn Fn(StreamEvent) + Send + Sync),
     ) -> Result<ChatResponse, CallerError> {
-        let (instructions, input, text, tools) = build_openai_request_parts(messages, self);
-        let request = OpenAIResponsesRequest {
-            model: self.model.clone(),
-            input,
-            instructions,
-            max_output_tokens: Some(self.max_output_tokens),
-            reasoning: self.reasoning.clone(),
-            text,
-            tools,
-            stream: true,
-        };
-        let request_body = serde_json::to_vec(&request).map_err(CallerError::Json)?;
+        let prepared = self.prepare_request(messages, true)?;
+        self.chat_stream_prepared(&prepared, on_event).await
+    }
+
+    async fn chat_stream_prepared(
+        &self,
+        prepared: &PreparedRequest,
+        on_event: &(dyn Fn(StreamEvent) + Send + Sync),
+    ) -> Result<ChatResponse, CallerError> {
         let client = &self.client;
         let api_key = &self.api_key;
 
@@ -593,7 +579,8 @@ impl ChatProvider for OpenAIProvider {
                     .header("Authorization", format!("Bearer {}", api_key))
                     .header("content-type", "application/json")
                     .timeout(STREAM_TIMEOUT)
-                    .body(request_body.clone())
+                    // Bytes clone: every attempt reuses the one allocation.
+                    .body(prepared.body.clone())
             },
             MAX_RETRIES,
         )
@@ -788,9 +775,7 @@ impl streaming::SseFold for OpenAIStreamFold {
                             let actions = item
                                 .get("actions")
                                 .and_then(|a| a.as_array())
-                                .map(|arr| {
-                                    arr.iter().filter_map(parse_openai_cu_action).collect()
-                                })
+                                .map(|arr| arr.iter().filter_map(parse_openai_cu_action).collect())
                                 .unwrap_or_default();
                             let safety = item
                                 .get("pending_safety_checks")
@@ -822,14 +807,10 @@ impl streaming::SseFold for OpenAIStreamFold {
             "response.completed" => {
                 if let Some(resp) = event.get("response") {
                     if let Some(u) = resp.get("usage") {
-                        self.usage.prompt_tokens = u
-                            .get("input_tokens")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(0);
-                        self.usage.completion_tokens = u
-                            .get("output_tokens")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(0);
+                        self.usage.prompt_tokens =
+                            u.get("input_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
+                        self.usage.completion_tokens =
+                            u.get("output_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
                         self.usage.total_tokens = u
                             .get("total_tokens")
                             .and_then(|v| v.as_u64())
@@ -1410,6 +1391,75 @@ mod tests {
         assert_eq!(input[0]["type"].as_str(), Some("function_call_output"));
     }
 
+    // --- PreparedRequest: one build feeds wire and snapshot ---
+
+    #[test]
+    fn prepare_request_builds_wire_and_snapshot_once() {
+        // new_plain: deterministic (no structured output, no reasoning,
+        // no env-dependent tool set, no CU).
+        let provider = OpenAIProvider::new_plain(
+            "key".to_string(),
+            "gpt-5.2-codex".to_string(),
+            400_000,
+            16_384,
+        );
+        let messages = vec![
+            Message {
+                role: "system".to_string(),
+                content: "sys".to_string(),
+                ..Default::default()
+            },
+            Message {
+                role: "user".to_string(),
+                content: "hello".to_string(),
+                ..Default::default()
+            },
+        ];
+        let prepared = provider.prepare_request(&messages, true).unwrap();
+        assert_eq!(prepared.format, "openai.responses.request.v1");
+
+        // Wire pin: the bytes equal a manual build of the exact request
+        // the old snapshot and stream paths each built separately.
+        let (instructions, input, text, tools) = build_openai_request_parts(&messages, &provider);
+        let manual = OpenAIResponsesRequest {
+            model: "gpt-5.2-codex".to_string(),
+            input,
+            instructions,
+            max_output_tokens: Some(16_384),
+            reasoning: None,
+            text,
+            tools,
+            stream: true,
+        };
+        assert_eq!(
+            prepared.body.as_ref(),
+            serde_json::to_vec(&manual).unwrap().as_slice()
+        );
+
+        // Snapshot parity: parsed from the wire bytes (by construction)
+        // and equal to the legacy to_value construction.
+        let snapshot = prepared.snapshot_value().unwrap();
+        assert_eq!(
+            snapshot,
+            serde_json::from_slice::<serde_json::Value>(&prepared.body).unwrap()
+        );
+        assert_eq!(snapshot, serde_json::to_value(&manual).unwrap());
+
+        // The trait snapshot derives from the same build path.
+        let (format, value) = provider.request_snapshot(&messages, true).unwrap();
+        assert_eq!(format, prepared.format);
+        assert_eq!(value, snapshot);
+
+        // Retries reuse the allocation: a Bytes clone shares the pointer
+        // (each HTTP attempt's `.body(bytes.clone())` is a refcount bump).
+        let retry_view = prepared.body.clone();
+        assert_eq!(retry_view.as_ptr(), prepared.body.as_ptr());
+
+        // Non-streaming build omits the stream field entirely (serde skip).
+        let non_stream = provider.prepare_request(&messages, false).unwrap();
+        assert!(non_stream.snapshot_value().unwrap().get("stream").is_none());
+    }
+
     // --- Stream fold (the OpenAI arm of the shared SSE driver) ---
 
     /// A realistic Responses-API SSE transcript: a function call assembled
@@ -1463,7 +1513,10 @@ mod tests {
         assert_eq!(raw.len(), 2);
         assert_eq!(raw[0]["status"].as_str(), Some("completed"));
         assert_eq!(raw[1]["type"].as_str(), Some("message"));
-        assert_eq!(response.reasoning_summary.as_deref(), Some("thought about it"));
+        assert_eq!(
+            response.reasoning_summary.as_deref(),
+            Some("thought about it")
+        );
         assert_eq!(response.reasoning_content, None);
 
         assert_eq!(response.usage.prompt_tokens, 100);
@@ -1507,10 +1560,7 @@ mod tests {
             response.cu_calls[0].actions[..],
             [crate::computer_use::CuAction::Click { x: 10, y: 20, .. }]
         ));
-        assert_eq!(
-            response.cu_calls[0].metadata.pending_safety_checks.len(),
-            1
-        );
+        assert_eq!(response.cu_calls[0].metadata.pending_safety_checks.len(), 1);
 
         // CU-disabled: the computer_call is ignored (no CU lane, no tool
         // call), matching the old loop's guard.

--- a/src/bin/caller/provider/streaming.rs
+++ b/src/bin/caller/provider/streaming.rs
@@ -1,0 +1,602 @@
+//! The shared SSE streaming core: byte-accurate chunk→event framing and
+//! the provider-agnostic stream driver. The three providers carried
+//! near-identical hand-rolled SSE loops that had already drifted on
+//! protocol details; the mechanics live here exactly once, and each
+//! provider keeps only its event vocabulary as an [`SseFold`]
+//! implementation (the same seam discipline as the request-build helpers:
+//! behavior differences stay per-provider, never `if provider == …` in
+//! shared code).
+
+use super::{ProviderHttpResponse, StreamEvent};
+use crate::error::CallerError;
+use futures_util::StreamExt;
+
+/// Byte-accurate SSE event framing. Network chunks accumulate as raw
+/// bytes and are drained by offset (`pos`), compacting only when the
+/// consumed prefix outgrows the live tail — no per-line reallocation.
+/// Text conversion happens per complete line, so a chunk boundary that
+/// splits a multibyte UTF-8 codepoint (common with CJK/emoji streaming)
+/// never manufactures U+FFFD replacement characters; a genuinely invalid
+/// byte still degrades to U+FFFD.
+///
+/// Framing follows the SSE wire format: `\n` line endings with trailing
+/// `\r`s stripped (CRLF parity with the old `trim_end_matches('\r')`),
+/// blank-line event boundaries, multi-line `data:` fields joined with
+/// `\n` (the behavior `parse_sse_line` documented but none of the three
+/// loops implemented), and an optional `event:` type. Comment (`:`),
+/// `id:`, `retry:`, and unknown lines are ignored, as the per-line loops
+/// ignored them. Only `data: `/`event: ` with the space are recognized —
+/// the exact acceptance set of the loops this replaces.
+pub(crate) struct SseFramer {
+    /// Raw unconsumed bytes; `pos` is the consumed prefix.
+    buf: Vec<u8>,
+    pos: usize,
+    /// Accumulators for the in-progress event.
+    event_type: Option<String>,
+    data: String,
+    have_data: bool,
+    /// Storage for the event handed out by the last `next_event`/`finish`
+    /// call — [`SseEvent`] borrows from here instead of allocating.
+    out_event: Option<String>,
+    out_data: String,
+}
+
+/// One framed SSE event, borrowed from the framer.
+pub(crate) struct SseEvent<'a> {
+    /// The `event:` field, when the provider sent one (Anthropic does).
+    /// None of the current folds dispatch on it — the payload's own JSON
+    /// `type` field is the vocabulary — but the framer surfaces it so
+    /// they could (framing tests pin it).
+    #[allow(dead_code)]
+    pub(crate) event: Option<&'a str>,
+    /// The joined `data:` payload. Never empty: events without data lines
+    /// dispatch nothing (SSE spec, and the old loops skipped blank and
+    /// non-`data:` lines the same way).
+    pub(crate) data: &'a str,
+}
+
+impl SseFramer {
+    pub(crate) fn new() -> Self {
+        Self {
+            buf: Vec::new(),
+            pos: 0,
+            event_type: None,
+            data: String::new(),
+            have_data: false,
+            out_event: None,
+            out_data: String::new(),
+        }
+    }
+
+    /// Append a raw network chunk.
+    pub(crate) fn push(&mut self, chunk: &[u8]) {
+        // Compact when the dead prefix outgrows the live tail: amortized
+        // O(bytes) total, instead of a per-line memmove of the remainder.
+        if self.pos > 0 && self.pos > self.buf.len() / 2 {
+            self.buf.drain(..self.pos);
+            self.pos = 0;
+        }
+        self.buf.extend_from_slice(chunk);
+    }
+
+    /// Pop the next complete event, if a blank-line boundary has arrived.
+    /// The partial tail (unterminated line or unterminated event) stays
+    /// buffered for the next chunk.
+    pub(crate) fn next_event(&mut self) -> Option<SseEvent<'_>> {
+        loop {
+            let rel_newline = self.buf[self.pos..].iter().position(|&b| b == b'\n')?;
+            let line_start = self.pos;
+            let mut line_end = line_start + rel_newline;
+            self.pos = line_end + 1;
+            while line_end > line_start && self.buf[line_end - 1] == b'\r' {
+                line_end -= 1;
+            }
+            if line_end == line_start {
+                // Blank line: event boundary. Dispatch only when data
+                // accumulated — an event with an empty data buffer
+                // dispatches nothing (SSE spec; heartbeat blank lines and
+                // bare `event:` lines fell through the old loops too).
+                if self.have_data {
+                    self.out_event = self.event_type.take();
+                    self.out_data = std::mem::take(&mut self.data);
+                    self.have_data = false;
+                    return Some(SseEvent {
+                        event: self.out_event.as_deref(),
+                        data: &self.out_data,
+                    });
+                }
+                self.event_type = None;
+                continue;
+            }
+            let line = String::from_utf8_lossy(&self.buf[line_start..line_end]);
+            if let Some(value) = line.strip_prefix("data: ") {
+                if self.have_data {
+                    self.data.push('\n');
+                }
+                self.data.push_str(value);
+                self.have_data = true;
+            } else if let Some(value) = line.strip_prefix("event: ") {
+                self.event_type = Some(value.to_string());
+            }
+        }
+    }
+
+    /// Flush the in-progress event at end-of-stream. The per-line loops
+    /// processed every complete `data:` line immediately, so a stream
+    /// whose final event is not blank-line-terminated must still
+    /// dispatch — spec-pedantic discard here would be silent data loss
+    /// relative to the loops this replaces. A trailing *partial line*
+    /// (no `\n`) stays undelivered, exactly as before.
+    pub(crate) fn finish(&mut self) -> Option<SseEvent<'_>> {
+        if !self.have_data {
+            return None;
+        }
+        self.out_event = self.event_type.take();
+        self.out_data = std::mem::take(&mut self.data);
+        self.have_data = false;
+        Some(SseEvent {
+            event: self.out_event.as_deref(),
+            data: &self.out_data,
+        })
+    }
+}
+
+/// Why a stream died after a successful open. Typed so the agent loop can
+/// classify mid-stream failures structurally; the legacy
+/// `"Stream error"` string match stays as a compatibility fallback, not
+/// the contract.
+pub(crate) enum StreamFailure {
+    /// The chunk stream failed mid-body. Open-side failures never reach
+    /// the driver: request-open status and transport retries live in
+    /// `send_with_retry`, and the callers accept the status before
+    /// handing the response over.
+    Chunk { source: String },
+    /// A fold rejected an event. None of the current folds produce one —
+    /// unparseable payloads degrade to a logged drop (see [`EventJson`])
+    /// exactly as the old loops silently dropped them — but the lane
+    /// exists so a fold can fail typed.
+    Fold(CallerError),
+}
+
+impl StreamFailure {
+    /// Collapse into the caller-facing error, preserving the exact legacy
+    /// message shape (`Provider error: Stream error: …`) that session
+    /// logs carry and the agent loop's fallback string match accepts.
+    pub(crate) fn into_caller_error(self) -> CallerError {
+        match self {
+            StreamFailure::Chunk { source } => CallerError::StreamChunk(source),
+            StreamFailure::Fold(e) => e,
+        }
+    }
+}
+
+/// A provider's arm of the stream driver: folds one SSE `data:` payload
+/// into its in-progress response state. `[DONE]` never reaches a fold —
+/// the driver consumes it.
+pub(crate) trait SseFold {
+    fn on_data(
+        &mut self,
+        data: &str,
+        on_event: &(dyn Fn(StreamEvent) + Send + Sync),
+    ) -> Result<(), CallerError>;
+}
+
+/// Run one SSE response through a provider fold: bytes → [`SseFramer`] →
+/// `[DONE]` filtering → `fold.on_data` per event, with the end-of-stream
+/// flush. The single implementation of the shell the three provider
+/// loops used to mirror.
+pub(crate) async fn run_sse_stream<F: SseFold>(
+    response: ProviderHttpResponse,
+    fold: &mut F,
+    on_event: &(dyn Fn(StreamEvent) + Send + Sync),
+) -> Result<(), StreamFailure> {
+    drive_sse_stream(response.bytes_stream(), fold, on_event).await
+}
+
+/// [`run_sse_stream`]'s transport-generic core, split out so tests can
+/// drive the full framer+fold path from scripted chunk sequences without
+/// an HTTP response.
+pub(crate) async fn drive_sse_stream<F, S>(
+    mut stream: S,
+    fold: &mut F,
+    on_event: &(dyn Fn(StreamEvent) + Send + Sync),
+) -> Result<(), StreamFailure>
+where
+    F: SseFold,
+    S: futures_util::Stream<Item = Result<bytes::Bytes, String>> + Unpin,
+{
+    let mut framer = SseFramer::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|source| StreamFailure::Chunk { source })?;
+        framer.push(&chunk);
+        while let Some(event) = framer.next_event() {
+            if event.data == "[DONE]" {
+                continue;
+            }
+            fold.on_data(event.data, on_event)
+                .map_err(StreamFailure::Fold)?;
+        }
+    }
+    if let Some(event) = framer.finish() {
+        if event.data != "[DONE]" {
+            fold.on_data(event.data, on_event)
+                .map_err(StreamFailure::Fold)?;
+        }
+    }
+    Ok(())
+}
+
+/// The shared `data:` → JSON parse with first-failure observability. The
+/// old loops dropped unparseable payloads silently (`if let Ok(...)`);
+/// the first one per stream now leaves a masked, truncated stderr note so
+/// a protocol break is diagnosable. Each fold owns one — the flag is
+/// per-stream state.
+pub(crate) struct EventJson {
+    logged_unparseable: bool,
+}
+
+impl EventJson {
+    pub(crate) fn new() -> Self {
+        Self {
+            logged_unparseable: false,
+        }
+    }
+
+    pub(crate) fn parse(&mut self, data: &str) -> Option<serde_json::Value> {
+        match serde_json::from_str(data) {
+            Ok(value) => Some(value),
+            Err(e) => {
+                if !self.logged_unparseable {
+                    self.logged_unparseable = true;
+                    let head: String = data.chars().take(120).collect();
+                    eprintln!(
+                        "[provider] dropping unparseable SSE data payload (first this stream): {e}: {}",
+                        super::mask_api_keys(&head)
+                    );
+                }
+                None
+            }
+        }
+    }
+}
+
+/// Fixture plumbing for the per-provider fold tests: drive a fold over a
+/// scripted SSE transcript exactly the way `run_sse_stream` would,
+/// split into fixed-size chunks (small sizes exercise every boundary,
+/// including mid-multibyte and mid-line), returning the Delta events
+/// emitted along the way.
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::*;
+
+    pub(crate) async fn drive_transcript<F: SseFold>(
+        fold: &mut F,
+        transcript: &str,
+        chunk_size: usize,
+    ) -> Vec<String> {
+        let deltas = std::sync::Mutex::new(Vec::new());
+        let on_event = |event: StreamEvent| {
+            if let StreamEvent::Delta(text) = event {
+                deltas.lock().unwrap().push(text);
+            }
+        };
+        let chunks: Vec<Result<bytes::Bytes, String>> = transcript
+            .as_bytes()
+            .chunks(chunk_size.max(1))
+            .map(|c| Ok(bytes::Bytes::copy_from_slice(c)))
+            .collect();
+        drive_sse_stream(futures_util::stream::iter(chunks), fold, &on_event)
+            .await
+            .map_err(|failure| failure.into_caller_error().to_string())
+            .expect("scripted transcript must fold cleanly");
+        deltas.into_inner().unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Drain every currently complete event as owned (type, data) pairs.
+    fn drain_events(framer: &mut SseFramer) -> Vec<(Option<String>, String)> {
+        let mut events = Vec::new();
+        while let Some(ev) = framer.next_event() {
+            events.push((ev.event.map(str::to_string), ev.data.to_string()));
+        }
+        events
+    }
+
+    #[test]
+    fn framer_single_data_event() {
+        let mut framer = SseFramer::new();
+        framer.push(b"data: {\"k\":1}\n\n");
+        let events = drain_events(&mut framer);
+        assert_eq!(events, vec![(None, "{\"k\":1}".to_string())]);
+        assert!(framer.next_event().is_none());
+        assert!(framer.finish().is_none());
+    }
+
+    #[test]
+    fn framer_event_type_and_data() {
+        let mut framer = SseFramer::new();
+        framer.push(b"event: message_start\ndata: {\"type\":\"message_start\"}\n\n");
+        let events = drain_events(&mut framer);
+        assert_eq!(
+            events,
+            vec![(
+                Some("message_start".to_string()),
+                "{\"type\":\"message_start\"}".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn framer_multibyte_split_across_two_chunks() {
+        // "…" is E2 80 A6; split it mid-sequence the way a network chunk
+        // boundary can. Converting per chunk would corrupt each half into
+        // U+FFFD.
+        let payload = "data: a…b\n\n".as_bytes();
+        let mut framer = SseFramer::new();
+        framer.push(&payload[..9]); // "data: a" + E2 80 (mid-codepoint)
+        assert!(framer.next_event().is_none());
+        framer.push(&payload[9..]); // A6 + "b\n\n"
+        let events = drain_events(&mut framer);
+        assert_eq!(events, vec![(None, "a…b".to_string())]);
+    }
+
+    #[test]
+    fn framer_emoji_split_across_three_chunks() {
+        // "🦀" is F0 9F A6 80 — four bytes, split across three pushes.
+        let payload = "data: 🦀!\n\n".as_bytes();
+        let mut framer = SseFramer::new();
+        framer.push(&payload[..7]); // "data: " + F0
+        assert!(framer.next_event().is_none());
+        framer.push(&payload[7..9]); // 9F A6
+        assert!(framer.next_event().is_none());
+        framer.push(&payload[9..]); // 80 "!\n\n"
+        let events = drain_events(&mut framer);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].1, "🦀!");
+        assert!(!events[0].1.contains('\u{FFFD}'));
+    }
+
+    #[test]
+    fn framer_one_byte_chunks() {
+        let payload = b"event: delta\ndata: {\"a\":\"b\"}\n\ndata: [DONE]\n\n";
+        let mut framer = SseFramer::new();
+        let mut events = Vec::new();
+        for byte in payload.iter() {
+            framer.push(std::slice::from_ref(byte));
+            for (ev, data) in drain_events(&mut framer) {
+                events.push((ev, data));
+            }
+        }
+        assert_eq!(
+            events,
+            vec![
+                (Some("delta".to_string()), "{\"a\":\"b\"}".to_string()),
+                (None, "[DONE]".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn framer_crlf_and_heartbeat_blank_lines() {
+        let mut framer = SseFramer::new();
+        // CRLF endings, a stray heartbeat blank pair, and trailing '\r's
+        // stripped in trim_end_matches parity.
+        framer.push(b"data: hi\r\n\r\n\r\ndata: x\r\r\n\n");
+        let events = drain_events(&mut framer);
+        assert_eq!(
+            events,
+            vec![(None, "hi".to_string()), (None, "x".to_string())]
+        );
+    }
+
+    #[test]
+    fn framer_joins_multi_line_data() {
+        // The SSE spec behavior parse_sse_line documented but no loop
+        // implemented: multiple data lines in one event join with '\n'.
+        let mut framer = SseFramer::new();
+        framer.push(b"data: {\"a\":\ndata: 1}\n\n");
+        let events = drain_events(&mut framer);
+        assert_eq!(events, vec![(None, "{\"a\":\n1}".to_string())]);
+    }
+
+    #[test]
+    fn framer_ignores_comments_ids_and_unspaced_prefixes() {
+        let mut framer = SseFramer::new();
+        // Comment, id, retry, and a space-less "data:" line are all
+        // outside the acceptance set of the loops this replaces.
+        framer.push(b": keep-alive\nid: 7\nretry: 100\ndata:nospace\ndata: real\n\n");
+        let events = drain_events(&mut framer);
+        assert_eq!(events, vec![(None, "real".to_string())]);
+    }
+
+    #[test]
+    fn framer_bare_event_line_dispatches_nothing() {
+        let mut framer = SseFramer::new();
+        framer.push(b"event: ping\n\ndata: after\n\n");
+        let events = drain_events(&mut framer);
+        // The dataless ping event vanishes; its type must NOT leak onto
+        // the next event.
+        assert_eq!(events, vec![(None, "after".to_string())]);
+    }
+
+    #[test]
+    fn framer_finish_flushes_unterminated_final_event() {
+        let mut framer = SseFramer::new();
+        framer.push(b"data: {\"done\":true}\n");
+        assert!(framer.next_event().is_none());
+        let ev = framer.finish().expect("final event must flush at EOF");
+        assert_eq!(ev.data, "{\"done\":true}");
+        assert!(framer.finish().is_none());
+    }
+
+    #[test]
+    fn framer_finish_drops_partial_line() {
+        // An unterminated *line* (no '\n') was never processed by the old
+        // loops; only complete data lines flush.
+        let mut framer = SseFramer::new();
+        framer.push(b"data: complete\ndata: partial-tail");
+        assert!(framer.next_event().is_none());
+        let ev = framer.finish().expect("complete line flushes");
+        assert_eq!(ev.data, "complete");
+    }
+
+    #[test]
+    fn framer_partial_tail_survives_compaction() {
+        let mut framer = SseFramer::new();
+        // Many events churn pos forward so push's compaction actually
+        // runs; a split multibyte tail must survive the memmove.
+        for i in 0..200 {
+            framer.push(format!("data: event-{i}\n\n").as_bytes());
+            let events = drain_events(&mut framer);
+            assert_eq!(events, vec![(None, format!("event-{i}"))]);
+        }
+        let payload = "data: a…b\n\n".as_bytes();
+        framer.push(&payload[..9]);
+        assert!(framer.next_event().is_none());
+        framer.push(&payload[9..]);
+        let events = drain_events(&mut framer);
+        assert_eq!(events, vec![(None, "a…b".to_string())]);
+    }
+
+    // --- Driver ---
+
+    /// Records every payload handed to the fold.
+    struct RecordingFold {
+        seen: Vec<String>,
+        fail_on: Option<String>,
+    }
+
+    impl RecordingFold {
+        fn new() -> Self {
+            Self {
+                seen: Vec::new(),
+                fail_on: None,
+            }
+        }
+    }
+
+    impl SseFold for RecordingFold {
+        fn on_data(
+            &mut self,
+            data: &str,
+            on_event: &(dyn Fn(StreamEvent) + Send + Sync),
+        ) -> Result<(), CallerError> {
+            if self.fail_on.as_deref() == Some(data) {
+                return Err(CallerError::Provider("fold rejected".to_string()));
+            }
+            self.seen.push(data.to_string());
+            on_event(StreamEvent::Delta(data.to_string()));
+            Ok(())
+        }
+    }
+
+    fn chunk_stream(
+        chunks: Vec<Result<&'static [u8], &'static str>>,
+    ) -> impl futures_util::Stream<Item = Result<bytes::Bytes, String>> + Unpin {
+        futures_util::stream::iter(chunks.into_iter().map(|c| {
+            c.map(bytes::Bytes::from_static)
+                .map_err(|e| e.to_string())
+        }))
+    }
+
+    #[tokio::test]
+    async fn driver_folds_events_and_filters_done() {
+        let mut fold = RecordingFold::new();
+        let deltas: Mutex<Vec<String>> = Mutex::new(Vec::new());
+        let on_event = |event: StreamEvent| {
+            if let StreamEvent::Delta(text) = event {
+                deltas.lock().unwrap().push(text);
+            }
+        };
+        let stream = chunk_stream(vec![
+            Ok(b"data: one\n\nda"),
+            Ok(b"ta: two\n\ndata: [DONE]\n\n"),
+        ]);
+        drive_sse_stream(stream, &mut fold, &on_event)
+            .await
+            .map_err(|_| "driver failed")
+            .unwrap();
+        assert_eq!(fold.seen, vec!["one", "two"]);
+        assert_eq!(*deltas.lock().unwrap(), vec!["one", "two"]);
+    }
+
+    #[tokio::test]
+    async fn driver_flushes_final_event_without_blank_line() {
+        let mut fold = RecordingFold::new();
+        let stream = chunk_stream(vec![Ok(b"data: a\n\ndata: tail\n")]);
+        drive_sse_stream(stream, &mut fold, &|_| {})
+            .await
+            .map_err(|_| "driver failed")
+            .unwrap();
+        assert_eq!(fold.seen, vec!["a", "tail"]);
+    }
+
+    #[tokio::test]
+    async fn driver_chunk_failure_is_typed_and_preserves_prior_events() {
+        let mut fold = RecordingFold::new();
+        let stream = chunk_stream(vec![Ok(b"data: before\n\n"), Err("connection reset")]);
+        let failure = drive_sse_stream(stream, &mut fold, &|_| {})
+            .await
+            .expect_err("chunk error must surface");
+        match failure {
+            StreamFailure::Chunk { source } => assert_eq!(source, "connection reset"),
+            StreamFailure::Fold(_) => panic!("expected Chunk failure"),
+        }
+        // Deltas already emitted before the failure stand, as they did
+        // when the old loops bubbled the error after processing lines.
+        assert_eq!(fold.seen, vec!["before"]);
+    }
+
+    #[tokio::test]
+    async fn driver_fold_error_surfaces_as_fold_failure() {
+        let mut fold = RecordingFold::new();
+        fold.fail_on = Some("bad".to_string());
+        let stream = chunk_stream(vec![Ok(b"data: ok\n\ndata: bad\n\n")]);
+        let failure = drive_sse_stream(stream, &mut fold, &|_| {})
+            .await
+            .expect_err("fold error must surface");
+        assert!(matches!(failure, StreamFailure::Fold(_)));
+        assert_eq!(fold.seen, vec!["ok"]);
+    }
+
+    #[test]
+    fn stream_failure_maps_to_legacy_error_shape() {
+        // The chunk lane renders exactly the string the session logs and
+        // the agent loop's fallback match have always carried.
+        let err = StreamFailure::Chunk {
+            source: "connection reset".to_string(),
+        }
+        .into_caller_error();
+        assert!(matches!(err, CallerError::StreamChunk(_)));
+        assert_eq!(
+            err.to_string(),
+            "Provider error: Stream error: connection reset"
+        );
+
+        let fold_err = StreamFailure::Fold(CallerError::Provider("x".to_string()));
+        assert!(matches!(
+            fold_err.into_caller_error(),
+            CallerError::Provider(_)
+        ));
+    }
+
+    #[test]
+    fn event_json_parses_and_logs_drop_once() {
+        let mut json = EventJson::new();
+        assert_eq!(
+            json.parse("{\"a\":1}"),
+            Some(serde_json::json!({"a": 1}))
+        );
+        // Unparseable payloads degrade to None (dropped by folds); the
+        // once-per-stream log flag flips on the first one.
+        assert!(json.parse("not json").is_none());
+        assert!(json.logged_unparseable);
+        assert!(json.parse("still not json").is_none());
+        assert_eq!(json.parse("2"), Some(serde_json::json!(2)));
+    }
+}

--- a/src/bin/caller/provider/streaming.rs
+++ b/src/bin/caller/provider/streaming.rs
@@ -498,10 +498,11 @@ mod tests {
     fn chunk_stream(
         chunks: Vec<Result<&'static [u8], &'static str>>,
     ) -> impl futures_util::Stream<Item = Result<bytes::Bytes, String>> + Unpin {
-        futures_util::stream::iter(chunks.into_iter().map(|c| {
-            c.map(bytes::Bytes::from_static)
-                .map_err(|e| e.to_string())
-        }))
+        futures_util::stream::iter(
+            chunks
+                .into_iter()
+                .map(|c| c.map(bytes::Bytes::from_static).map_err(|e| e.to_string())),
+        )
     }
 
     #[tokio::test]
@@ -588,10 +589,7 @@ mod tests {
     #[test]
     fn event_json_parses_and_logs_drop_once() {
         let mut json = EventJson::new();
-        assert_eq!(
-            json.parse("{\"a\":1}"),
-            Some(serde_json::json!({"a": 1}))
-        );
+        assert_eq!(json.parse("{\"a\":1}"), Some(serde_json::json!({"a": 1})));
         // Unparseable payloads degrade to None (dropped by folds); the
         // once-per-stream log flag flips on the first one.
         assert!(json.parse("not json").is_none());


### PR DESCRIPTION
Provider streaming core: shared SSE framer/driver, PreparedRequest single-build, typed mid-stream failures.

Implements the staged L-track design (efficiency audit: shared provider streaming core), plus the F4 request double-build fix.

## Shared SSE streaming core (`provider/streaming.rs`)

- `SseFramer`: byte-accurate chunk-to-event framing, drained by offset with amortized compaction (no per-line realloc/memmove), lossy UTF-8 conversion only on complete lines (a chunk boundary can never manufacture U+FFFD). Handles CRLF, blank-line event boundaries, `[DONE]`, and multi-line `data:` joining -- the behavior `parse_sse_line` documented but none of the three loops implemented. End-of-stream flush keeps parity with the old per-line loops (a final event without a trailing blank line still dispatches).
- `run_sse_stream` / `drive_sse_stream`: the one implementation of the shell the three provider loops used to mirror (bytes -> framer -> `[DONE]` filter -> fold), with a transport-generic core so tests drive the full path from scripted chunk sequences.
- Per-provider `SseFold` impls (`AnthropicStreamFold`, `OpenAIStreamFold`, `GeminiStreamFold`) hold exactly the mutable state each old loop carried; event vocabulary and semantics are moved verbatim (stage-1: the `Value` DOM parse stays inside the fold).
- Unparseable `data:` payloads log once per stream (masked, truncated) instead of vanishing silently.
- `ProviderHttpResponse::bytes_stream` item type `Vec<u8>` -> `bytes::Bytes`: the Direct arm stops copying every reqwest chunk; the egress arm wraps its Vecs zero-copy.

## PreparedRequest: one build per turn (F4)

`provider.request_snapshot(...)` used to build the full converted request for the Context-tab snapshot, then `chat_stream` rebuilt it again for the wire -- two full DOM builds + serializations per turn, growing with context length.

- `PreparedRequest { format, body: Bytes }` + trait methods `prepare_request` / `chat_stream_prepared`. The agent loop builds once per turn; the same bytes feed the ContextSnapshot event (parsed via `snapshot_value()` -- the "exact request payload" guarantee now holds by construction) and every HTTP attempt (first attempt and retries are `Bytes` refcount bumps, not memcpys; the agent-loop stream retries also stop rebuilding the request per attempt).
- `request_snapshot` remains on the trait, derived from `prepare_request` (per-provider overrides deleted).
- `chat`/`chat_stream` share the same single-build path internally; the egress relay arm takes one documented copy at its `Vec<u8>` boundary.

## Typed mid-stream failures

- `CallerError::StreamChunk` renders the exact legacy `Provider error: Stream error: ...` string (session logs and automation unchanged); the agent loop's stream-retry classification is now `matches!(e, CallerError::StreamChunk(_))` with the string match kept as a compatibility fallback.

## Behavior notes

- Deltas, final `ChatResponse` fields, error strings, and retry semantics are pinned byte-identical by per-provider fold fixture tests (synthetic SSE transcripts split at adversarial chunk boundaries, including mid-multibyte).
- Deliberate deltas, all from the ratified design note: multi-line `data:` joining (spec behavior, previously documented-but-missing; single-data-line events -- all real provider traffic -- are unaffected), the once-per-stream unparseable-payload log, and the typed failure lane.
- `SseLineBuffer`/`parse_sse_line` (superseded by the framer) are removed; their test scenarios are ported into `streaming::tests`.
- Mock/e2e paths unchanged: `MockProvider` implements the trait directly and keeps the default-error `prepare_request`, so the agent loop's messages-dump fallback behaves exactly as before.
