### PR TITLE
tests: model cross-boot watcher resume as a store clone, not a same-path reopen

### DIFF
--- a/src/bin/caller/file_watcher.rs
+++ b/src/bin/caller/file_watcher.rs
@@ -1842,6 +1842,45 @@ impl FileWatcher {
         self.racy_window_nanos = nanos;
     }
 
+    /// Test support: materialize "the next boot resumes this store" as a
+    /// fresh directory carrying the previous boot's bytes.
+    ///
+    /// Cross-boot resume tests must NOT drop a watcher and reopen the
+    /// same store path in-process: the advisory store lock is a `flock`
+    /// owned by the open file description, and under a parallel
+    /// `cargo test` run any concurrently forked subprocess (the
+    /// git-driving tests) briefly inherits that description between
+    /// `fork` and `exec` — pinning the lock past the drop, so the
+    /// resumed instance loses `try_lock` and silently degrades to
+    /// read-only (`live_index_disabled`, `changes_index_snapshot` =
+    /// `None`; observed ejecting the merge queue on the busier CI Mac,
+    /// where the fork→exec window is routinely wide enough to lose the
+    /// race). Production never reacquires in-process — one watcher per
+    /// daemon run — so the deterministic model of "same store, next
+    /// boot" is the same bytes at a fresh path, sharing no lock
+    /// identity with the previous instance. Plant between-boot
+    /// leftovers AFTER cloning; the clone copies regular files and
+    /// directories only (all a store the previous boot wrote can hold).
+    #[cfg(test)]
+    pub(crate) fn clone_store_for_resume(store: &Path) -> tempfile::TempDir {
+        fn copy_dir(src: &Path, dst: &Path) {
+            std::fs::create_dir_all(dst).expect("create resumed-store dir");
+            for entry in std::fs::read_dir(src).expect("read store dir").flatten() {
+                let from = entry.path();
+                let to = dst.join(entry.file_name());
+                let ft = entry.file_type().expect("store entry type");
+                if ft.is_dir() {
+                    copy_dir(&from, &to);
+                } else if ft.is_file() {
+                    std::fs::copy(&from, &to).expect("copy store file");
+                }
+            }
+        }
+        let resumed = tempfile::TempDir::new().expect("resumed store dir");
+        copy_dir(store, resumed.path());
+        resumed
+    }
+
     /// Wrap `self` in an async-mutex-backed shared handle and spawn the
     /// filesystem watcher loop + round-complete listener. Returns the handle
     /// plus the two join handles so callers can keep them alive.

--- a/src/bin/caller/web_gateway/routes_sessions.rs
+++ b/src/bin/caller/web_gateway/routes_sessions.rs
@@ -6562,6 +6562,12 @@ mod tests {
     /// before this one must not surface as a phantom "deleted" row — the
     /// stale `baseline/` copy is reconciled away at watcher construction,
     /// keeping the full scan and the watcher-index fast path in agreement.
+    ///
+    /// The resumed instance opens a CLONE of the store (same bytes,
+    /// fresh path — `clone_store_for_resume`): reopening the same path
+    /// in-process races concurrently forked subprocesses pinning the
+    /// dropped store flock, which degraded this test's resumed watcher
+    /// to read-only on the CI Mac and ejected the merge queue.
     #[test]
     fn resume_after_delete_reconciles_stale_baselines() {
         let project = tempfile::TempDir::new().unwrap();
@@ -6580,15 +6586,17 @@ mod tests {
         // The file disappears between runs.
         std::fs::remove_file(root.join("stale.rs")).unwrap();
 
+        let resumed_store =
+            crate::file_watcher::FileWatcher::clone_store_for_resume(snapshot.path());
         let mut resumed = crate::file_watcher::FileWatcher::new(
             root.to_path_buf(),
-            snapshot.path().to_path_buf(),
+            resumed_store.path().to_path_buf(),
             crate::event::EventBus::new(),
         )
         .expect("resumed watcher");
         resumed.mark_live_index_healthy_for_tests();
 
-        let baseline_dir = snapshot.path().join("baseline");
+        let baseline_dir = resumed_store.path().join("baseline");
         let full = changes_list_summaries_full_scan(&baseline_dir, root);
         let index = resumed.changes_index_snapshot().expect("healthy index");
         let fast = changes_list_summaries_from_index(&baseline_dir, root, &index);


### PR DESCRIPTION
resume_after_delete_reconciles_stale_baselines ejected the merge queue
twice from the macOS leg: the resumed FileWatcher lost the store lock
and degraded to read-only, so changes_index_snapshot() was None and the
'healthy index' expect panicked.

Mechanism (test-only race, not a production one): the store lock is a
flock owned by the open file description. Under plain cargo test — one
process, tests parallel on threads, several of them spawning git
subprocesses — a concurrent fork briefly inherits the descriptor
between fork and exec, pinning the just-dropped lock. The resumed
instance's try_lock then loses and read-only sets the sticky
live_index_disabled. Fast machines win the drop race; the busier CI Mac
does not. Production constructs one watcher per daemon run (boot-time
wiring) and never reacquires a store lock in-process, so this seam does
not exist there.

Fix: a test-support clone_store_for_resume copies the store's bytes to
a fresh path — the honest model of 'same store, next boot' — so the
resumed instance shares no lock identity with the first. The sibling
drop-then-reopen resume tests in file_watcher.rs remain to be converted
in a follow-up; this lands the queue-blocking one.
