### PR TITLE
dashboard: composer peek dismissal is real state; the WebKit close-then-reopen dies

### DIFF
--- a/static/app/ui2-composer-peek.js
+++ b/static/app/ui2-composer-peek.js
@@ -30,9 +30,13 @@
   let peekBoundLog = null;
   let peekRendered = []; // [{ source, clone }] in list order
   let peekFollow = true;
-  // Explicit close suppresses auto-open until the working streak ends or
-  // the target changes — otherwise the next phase mutation would fight
-  // the user's dismissal.
+  // Explicit close is real state, not a render artifact: every automatic
+  // open stays suppressed until a deliberate trigger clears it — the
+  // working streak ending (so a NEW turn may auto-open), the prompt
+  // target changing, or the user re-entering the dock from outside via a
+  // gesture off the peek (the focusin entry in peekWire). Renders and
+  // live events for the target must never resurrect a dismissed peek —
+  // otherwise the next phase mutation would fight the user's dismissal.
   let peekDismissed = false;
   let peekLastTarget = '';
   let peekLastPhaseCat = null;
@@ -335,6 +339,19 @@
     peekOpen();
   }
 
+  // Every explicit dismissal — the ✕, Esc, outside-click, the QA hook —
+  // funnels through here so the surfaces cannot drift apart again: latch
+  // plus close, plus the ✕'s keep-typing refocus when asked. That refocus
+  // is safe against the open-on-focus entry rule only because of the
+  // gesture guard in peekWire's focusin handler — add dismissal
+  // side-effects here, never at the call sites.
+  function peekDismiss(refocus) {
+    peekClose(true);
+    if (!refocus) return;
+    const input = document.getElementById('activity-task-input');
+    if (input) input.focus({ preventScroll: true });
+  }
+
   function peekBuild(root) {
     const icon = (name, size) => (typeof ui2Icon === 'function' ? ui2Icon(name, size) : '');
     root.setAttribute('role', 'region');
@@ -400,9 +417,7 @@
     });
     closeBtn.addEventListener('click', (e) => {
       e.stopPropagation();
-      peekClose(true);
-      const input = document.getElementById('activity-task-input');
-      if (input) input.focus({ preventScroll: true });
+      peekDismiss(true);
     });
     peekList.addEventListener('scroll', () => {
       peekFollow = peekList.scrollTop + peekList.clientHeight >= peekList.scrollHeight - 24;
@@ -414,6 +429,11 @@
   // content on every load of a dashboard with history is a surprise, not
   // an affordance. Focus counts as intent only after a real gesture.
   let peekSawUserGesture = false;
+  // Target of the most recent pointerdown/keydown: gesture state the
+  // focus-entry rule can trust when focus-event bookkeeping cannot be —
+  // WebKit never mouse-focuses buttons, so a focusin caused by clicking
+  // the peek's own chrome arrives with a null/outside relatedTarget.
+  let peekGestureTarget = null;
 
   const peekWire = () => {
     const root = document.getElementById('ui2-composer-peek');
@@ -423,16 +443,28 @@
     peekBarEl = bar;
     peekBuild(root);
 
-    document.addEventListener('pointerdown', () => { peekSawUserGesture = true; }, { capture: true, passive: true });
-    document.addEventListener('keydown', () => { peekSawUserGesture = true; }, { capture: true });
+    const noteGesture = (e) => {
+      peekSawUserGesture = true;
+      peekGestureTarget = e.target instanceof Node ? e.target : null;
+    };
+    document.addEventListener('pointerdown', noteGesture, { capture: true, passive: true });
+    document.addEventListener('keydown', noteGesture, { capture: true });
 
     bar.addEventListener('focusin', (e) => {
       if (!peekSawUserGesture) return;
       if (peekIsOpen() || peekComposerPill()) return;
-      // Focus moving WITHIN the dock (input → Send, the close button's
-      // refocus) is not an entry — reopening there would undo an Esc/×
-      // dismissal the user just made.
+      // Focus moving WITHIN the dock (Tab from input to Send, engines
+      // that focus buttons on click) is not an entry — reopening there
+      // would undo an Esc/× dismissal the user just made.
       if (e.relatedTarget instanceof Node && bar.contains(e.relatedTarget)) return;
+      // relatedTarget alone cannot carry that rule on WebKit: Safari
+      // never mouse-focuses buttons, so the ✕ handler's keep-typing
+      // refocus of the input lands here with a null/body relatedTarget —
+      // and used to reopen the sheet in the very click that dismissed it.
+      // Gesture state instead of focus-event timing: a focus produced by
+      // interacting with the peek itself is peek interaction, never an
+      // entry into the composer.
+      if (peekGestureTarget && peekRoot.contains(peekGestureTarget)) return;
       // Focus landing on the target-switch chrome is retargeting intent,
       // not composition — opening the peek under that popover just stacks
       // two overlays (and made Esc close the hidden one first).
@@ -459,16 +491,16 @@
       if (e.target instanceof Node && peekBarEl.contains(e.target)) {
         e.preventDefault();
         e.stopImmediatePropagation();
-        peekClose(true);
+        peekDismiss(false);
         return;
       }
-      peekClose(true);
+      peekDismiss(false);
     }, true);
 
     document.addEventListener('pointerdown', (e) => {
       if (!peekIsOpen()) return;
       if (e.target instanceof Node && peekBarEl.contains(e.target)) return;
-      peekClose(true);
+      peekDismiss(false);
     }, true);
 
     window.addEventListener('ui2:composer-state', (e) => {
@@ -500,7 +532,7 @@
     window.__ui2Peek = {
       isOpen: peekIsOpen,
       open: peekOpen,
-      close: () => peekClose(true),
+      close: () => peekDismiss(false),
       sessionId: () => peekBoundSid,
     };
   };


### PR DESCRIPTION
The composer conversation peek's close button closed the sheet and then reopened it in the same click on Safari, while clicking outside the dock dismissed it durably — so the button read as a no-op (live user report).

Root cause: the button handler refocuses the composer input as a keep-typing nicety, and the dock's `focusin` open-on-entry rule relied on `relatedTarget` to recognize intra-dock focus moves. WebKit never mouse-focuses buttons (the mousedown blurs the input toward body instead), so that refocus arrives with a null/body `relatedTarget`, the intra-dock guard misses, and the entry rule clears the dismissal latch and reopens the peek synchronously inside the dismissing click. Chromium focuses buttons on mousedown, so `relatedTarget` lands inside the bar there — which is why the guard held on the engine it was written against.

Fix — state over focus-event timing (WebKit-safe by construction):

- Track the target of the most recent pointerdown/keydown (the existing gesture listeners) and teach the focus-entry rule that a focus produced by a gesture on the peek itself is peek interaction, never an entry into the composer. Engine-independent: no reliance on whether or when the button took focus.
- Funnel every explicit dismissal (close button, Esc, outside-click, the QA hook) through one `peekDismiss(refocus)` path so the surfaces cannot drift apart again; the button keeps its refocus, now safe behind the gesture guard.
- Codify the deliberate re-open triggers at the latch declaration: working-streak end (a new turn may auto-open), prompt-target change, or a genuine gesture-backed focus re-entry into the dock. Renders and live events for the target never resurrect a dismissed peek.

Verification (mock-provider daemon + headless Chromium over the validate-dashboard harness, isolated state root, worktree binary pinned): headless pages move `activeElement` without delivering focus events, so the rig dispatches each engine's documented stream itself — Safari's (button never focused, refocus focusin with null relatedTarget) and Chromium's (button focused on mousedown, refocus focusin carrying the button). A/B on the same base commit:

- pre-fix: close button closes then instantly reopens, both idle and mid-working-streak (the reported bug); typing after it shows the peek still open; outside-click closes durably (the user's workaround); Chromium-stream close works.
- post-fix: close button dismisses durably in the WebKit stream, idle and mid-streak, with the input refocused; stays closed across continued typing and a full follow-up turn of live target-session events; new-turn auto-open after the dismissed streak ends still fires; gesture-backed focus re-entry still reopens; outside-click parity; Chromium stream unregressed.

Battery: cargo fmt --check, cargo clippy, cargo test --bins (full green pass; one earlier pass had 3 load-flakes in freshly-landed hosted_control tests, all pass in isolation, no overlap with this JS-only diff), app.html regenerated byte-identical from fragments, dashboard-boot probe PASS.
