### PR TITLE
V3 "Proscenium" — a second dashboard, opt-in at /v3 (draft, not for merge)

### DIFF
--- a/docs/design/proscenium/README.md
+++ b/docs/design/proscenium/README.md
@@ -1,0 +1,376 @@
+# Proscenium — a design concept for the Intendant dashboard
+
+> **Status:** design concept + interactive prototype, 2026-07-17.
+> Self-contained, no build step: open `prototype/index.html` in any browser.
+> Nothing here touches the shipped dashboard (`static/app/`); this is a
+> proposal to be evaluated on its own terms, then adopted incrementally if it
+> earns it. A sibling concept, **Atrium**, lives at `docs/design/atrium/` in the
+> `design/dashboard-everything-concept` worktree — see *Relationship to Atrium*
+> below for an honest comparison.
+
+The name is already in the codebase: the Intendant brand glyph is annotated
+*Proscenium arch* (`static/logo-glyph.svg`). The proscenium is the frame
+between the audience and the stage — the place the owner sits to watch,
+applaud, and occasionally stand up and say something. The owner never has to
+go backstage. Backstage is fully lit if they want it.
+
+---
+
+## The observation
+
+The product's own thesis (`AGENTS.md`, `docs/src/introduction.md`):
+
+> Agents perform, orchestrators conduct, the Intendant runs the house — and
+> answers to the owner.
+
+The current dashboard is a superb **operator's cockpit**: thirteen tabs named
+after subsystems (Activity, Sessions, Agenda, Memory, Live display, Station,
+Terminal, Files, Usage, Access, Vault, Settings, Debug), every gauge visible,
+every knob one navigation away. It is built for the person who flies the
+plane. But the thesis says the owner doesn't fly the plane — the Intendant
+does. The owner *answers questions, sets policy, and enjoys the show*.
+
+Two people open this app:
+
+- **The owner** (the thesis's human; "grandma" in the brief) wants three
+  things: *talk to the house, answer what needs answering, see that things
+  are going well.* She should never need to know what a "managed-context
+  rewind anchor" is.
+- **The operator** (the power user) wants the full control plane — every
+  route, grant, launch pin, lease, and ledger line — fast, without the calm
+  layer taxing every interaction.
+
+Today both get the cockpit. Proscenium is one app that is a home for the
+first person and a cockpit for the second, mediated by the one character the
+codebase already cast for exactly this role: **presence**.
+
+---
+
+## The concept in one paragraph
+
+The dashboard stops being a console of subsystems and becomes **the owner's
+relationship with their house**: a first-person conversation with the
+Intendant as the home screen; a single *Needs You* queue that collects every
+decision the house cannot make alone; a formal two-register rendering policy
+(*voice* for humans, *instrument* for machinery) with a density dial; and the
+entire control plane — every route, tunnel method, and ControlMsg the daemon
+exposes — organized into intent-named rooms, every one of them one ⌘K search
+away. Calm enough to hand to your grandmother. Nothing deleted, nothing
+dumbed down: power is *folded*, not removed.
+
+---
+
+## The four load-bearing ideas
+
+### 1. The Conversation is the home screen
+
+`docs/src/presence.md` already defines the soul of this surface:
+
+> The user talks to presence, not directly to the worker agent. Presence
+> speaks as Intendant in the first person ("I'm working on that now", not
+> "the agent is working on that").
+
+Proscenium takes that sentence literally and makes the **presence
+conversation the default screen** — not a chat drawer beside the cockpit, the
+home. Presence greets you, narrates ("Three turns into the login fix — the
+tests pass; one thing needs you"), renders **work artifacts inline** (a diff
+summary, a screenshot, a recording clip, a cost figure, a finished file), and
+takes your next wish in the composer. The composer is the same one the
+codebase already ships globally — talk, `@`-aim at a session or machine,
+`/`-command for power grammar, attach, or hold the mic and speak (live voice
+already exists; here it is simply first-class rather than an oversight-bar
+popover).
+
+Crucially, the conversation is **honest about its machinery**: every presence
+milestone carries a *Show work* disclosure that unfolds the underlying
+activity-log lines it summarizes. The voice register is a rendering of the
+truth, never a replacement for it — one unfold, and you're looking at the raw
+turn-by-turn log. (This is the two-register contract of idea 3, applied to
+the thread itself.)
+
+**The briefing.** Because presence mediates, the app gains a daily rhythm no
+console has: open it after time away and the first message is a *briefing* —
+what finished, what failed and was retried, what is waiting on you, what's
+scheduled today. Every input to the briefing already exists daemon-side
+(session events, agenda ledger, scheduler, usage snapshots); rendering it is
+a presence query away. The agenda subsystem's **scheduled sessions** shipped
+daemon-side (`agenda/scheduler.rs`, `propose_scheduled_session`) and were
+never surfaced in the SPA — Proscenium's *Today* ribbon finally gives them a
+home.
+
+### 2. The Queue — *Needs You* is the owner's inbox
+
+The owner's one job in this architecture is to decide what only the owner may
+decide. Today those decisions are scattered across at least seven surfaces:
+the approval panel (Activity), the AskHuman and structured-question panels,
+the display-request doorbell, peer approvals (Access → Daemons), enrollment
+requests (Access → People & Devices), the hosted-control gate, and unfueled /
+dry-lease warnings.
+
+Proscenium unifies every one of them into **the Queue** — one severity-ordered
+inbox, pinned to the top of Home and badged from every screen:
+
+- **Each item is a decision card in plain language**: *"Claude wants to
+  delete 3 files in `~/projects/exports`"* — with the honest consequence
+  stated, the **safe default pre-selected**, a *Details* unfold carrying the
+  raw payload (command, paths, diff, requesting session, expiry), and the
+  provenance line the trust doctrine mandates (*"via Studio Mac · you ·
+  owner"* — every pane states whose authority it spends).
+- **Resolving is one tap or one key** (the existing `y` / `s` / `a` / `n`
+  grammar). Approvals keep their full existing semantics — Approve, Skip,
+  Approve all like this (category rule), Deny — nothing is lost.
+- **Two tiers**: *Decisions* (blocking — approvals, questions, doorbells,
+  enrollments, fuel) and *For your awareness* (budget warnings, finished
+  watched tasks, lease-expiry notices, reminders). Awareness never blocks;
+  it dismisses.
+- **Empty is a feature**: *"You're free."* Inbox zero for your house. The
+  badge disappears; the house hums.
+
+Every Queue item is a renderer over events that already exist
+(`ApprovalRequired`, `UserQuestionRequired`, `DisplayRequestRaised`, peer
+`ApprovalRequested`, enrollment-request routes, hosted-control requests,
+`BudgetWarning`, api-key status). No new backend is required for v1; a
+daemon-side unified attention feed can come later as a derived control-plane
+projection (see `capability-map.md`).
+
+### 3. Two Registers — every surface speaks human first, machine on demand
+
+Proscenium's progressive disclosure is not a mode that hides things; it is a
+**rendering policy** applied everywhere, with a hard contract:
+
+> **Nothing is hidden. Everything unfolds.**
+
+- **Voice register** — plain sentences, stable nouns with short glosses
+  ("Fuel — the API keys the house runs on"), generous type (a serif voice
+  face for prose), safe defaults, words over enums. This is how the house
+  *speaks*.
+- **Instrument register** — the exact machinery: IDs, routes, roles, counts,
+  JSON, mono type. Always one unfold, one ⌘K, or one density notch away —
+  never absent, never requiring a mode flip to *reach*, only to *see first*.
+
+A global **density dial** — **Cozy / Standard / Studio** — retunes which
+register greets you: Cozy is voice-first with folds at rest; Standard is the
+balanced default; Studio is instrument-first (folds open, IDs and routes
+visible inline, dense grids, shortcut hints shown). It persists per browser
+and changes presentation only: every capability exists at every density. A
+power user on a Cozy-configured machine loses nothing — ⌘K searches the full
+instrument vocabulary regardless.
+
+One deliberate rule, differing from the sibling Atrium concept: **nouns are
+never renamed per level.** A session is a session at every density; Cozy adds
+a gloss, it does not swap in a euphemism. Two vocabularies would be two
+languages to learn and would break search, docs, and support. Plain language
+is a *layer over* stable names, not a replacement for them.
+
+### 4. The House — depth organized by intent — and one search that finds everything
+
+Behind the Conversation, the thirteen subsystem tabs become **eight rooms
+plus two vantage points**, named for what you came to do:
+
+| Room | Answers | Absorbs (today) |
+|---|---|---|
+| **Home** | "Talk to the house. What needs me? What's happening today?" | Activity (log), approvals/questions/doorbells, Agenda (today), presence voice |
+| **Work** | "How's the job going? Give it work." | Sessions (Recent/Deep Search/Worktrees/New), Activity subtabs per session (Log/Context/Managed/Changes/Control), sub-agents, forks, lineage |
+| **Screens** | "Show me a machine. Let me touch it." | Live display, recordings/clips, annotations, your-screen sharing, Terminal, browser workspaces, virtual displays |
+| **Files** | "Get me that file. Move these." | Files editor + Transfers |
+| **Machines** | "What machines do I have? Link another. Send work there." | Access → Daemons/Peers (pairing, routes, petnames, delegation, coordinator), multi-host browsing |
+| **People & Keys** | "Who can do what? Hand out a key. See the keys I hold." | Access → Overview/People & Devices/Diagnostics/Advanced, orgs, Vault, leases, custody trail, hosted control |
+| **Books** | "What's it costing? What did it do? What does it remember?" | Usage, Agenda (the List), Memory, session reports/archives |
+| **Settings** | "Change how the house behaves." | Settings (re-sorted as questions), appearance, autonomy & approval rules |
+| **Station** *(vantage)* | "Immerse me." | Station — the WASM constellation stays the war-room view, reached from anywhere |
+| **Studio** *(vantage)* | "Open the machinery." | Debug (observer display, diagnostics), raw state, transport lanes, MCP tool reference, component field guide |
+
+The mapping is a **relocation, never a deletion** — `capability-map.md`
+carries the full route-by-route guarantee, compiled against
+`gateway_routes::ROUTES`, the tunnel method table, and the ControlMsg
+vocabulary.
+
+And because no taxonomy survives contact with a power user: **⌘K is the
+universal index** — rooms, objects (sessions, machines, people, displays,
+files), every individual setting including folded ones ("writable roots" →
+the Codex sandbox row), every action (approve, pair a machine, fuel, stop
+session, flip theme), help explainers, and the session deep-search lane.
+Enter jumps to the exact control — opening its fold and flashing it. If you
+know what you want, you never navigate at all.
+
+---
+
+## A day with Proscenium
+
+**The owner.** Morning push: *"2 things need you."* She opens the app. The
+briefing, in the serif voice: *"Good morning. The photo-book layout finished
+overnight — it's in Files. The backup failed once and I retried it; fine now.
+Claude wants to delete old exports, and a new laptop is asking for access."*
+Two decision cards: she reads the consequence, taps **Allow** on the first,
+**Not now** on the second. *"You're free."* She types *"show me the photo
+book"* — presence opens the Files room at the finished folder. She never saw
+the words *session*, *approval category*, or *enrollment*.
+
+**The operator.** Opens, ⌘K → `codex writable roots`, lands on the folded
+row, flips it. `y` `a` `n` through the Queue without touching the mouse.
+Density to Studio: the Work room becomes a dense grid with IDs, routes, and
+token facts inline. Into a session's rewind composer; out to the
+constellation in Station; a glance at the custody trail; a raw-JSON inspection
+of a grant. The calm layer never taxed a single keystroke — it simply wasn't
+in the way.
+
+Same app. Same routes. Same control plane. Two registers.
+
+---
+
+## Visual language — *"House lights"* (summary; full spec in `visual-language.md`)
+
+The current UI is a blue-black iris dev-tool; Atrium goes to paper and
+botanical green. Proscenium takes the third road the brand itself offers —
+the **theater at night, warmed by lamplight**, with the conductor's baton as
+the accent:
+
+- **Lamplight (dark, default):** warm brown-charcoal surfaces (never
+  blue-black), brass-gold accent drawn from the glyph's baton gradient
+  (`#f9e2af → #a68a5b`), warm off-white ink.
+- **Daylight (light):** warm paper and true ink, brass deepened for contrast.
+- **The color doctrine: warm is yours, cool is the machinery's.** Authority,
+  attention, and the house's own chrome live in the warm family (brass,
+  marigold, brick). Agent/machine state lives in the cool family (sage for
+  healthy work, slate for information). A glance at any screen reads the
+  provenance of its content before a word is read. Chips stay labeled in
+  words, always — color remains garnish, never the message (existing
+  doctrine, kept).
+- **Typography makes the two registers literal:** a serif *voice* face
+  (Iowan Old Style / Palatino / Georgia stack) for greetings, briefings,
+  decision headlines, and empty states; Hanken Grotesk (already self-hosted)
+  for UI; JetBrains Mono (already self-hosted) for the instrument register.
+- **The arch** is the quiet motif: the brand glyph; the *stage cards* of
+  Now Playing, whose header band carries the arch curve; a one-time
+  curtain-lift on first paint (motion-safe, `prefers-reduced-motion`
+  honored). No skeuomorphism beyond that — this is a tool, not a theme park.
+
+---
+
+## A note on time
+
+Consoles show state; relationships happen over time. Proscenium adds the time
+dimension the codebase already has data for: the **briefing** (what happened
+while you were away), the **Today ribbon** (now marker, scheduled sessions
+and reminders from the agenda scheduler, milestones as they land), and
+**history as a first-class citizen** (Books). The daemon already owns
+long-running work, reminders, and a scheduler the SPA never surfaced — the
+design catches the UI up to the backend.
+
+---
+
+## Relationship to Atrium
+
+Atrium (`docs/design/atrium/`, sibling worktree) is a good concept and this
+one borrows none of it accidentally. The honest differences:
+
+| | **Atrium** | **Proscenium** |
+|---|---|---|
+| Center of gravity | The **object model** — everything is a card; cards open Spaces; one Inspector holds details | The **relationship** — presence conversation as home; the Queue as the owner's inbox; objects serve the thread |
+| Daily loop | A dashboard you visit | A house that briefs you; inbox-zero as the goal state; time (Today, schedule) as structure |
+| Disclosure model | Simple/Balanced/Expert dial that renames vocabulary per level ("Screens" vs "Displays") | Two **registers** over **stable nouns** + Cozy/Standard/Studio density; nothing renamed, everything unfolded |
+| Presence | A composer row | The spine — first-person voice, inline artifacts, briefing, voice parity |
+| Prototype depth | Static single page | Fully interactive multi-room build: working ⌘K index, live queue resolution, density + theme engines, simulated event stream |
+
+They agree on the disease (subsystem IA, cockpit-for-everyone) and on several
+remedies (one search, one inspector-like depth container, a level dial that
+is a rendering policy). They are two different cures; if the fleet prefers
+Atrium's object grammar, Proscenium's Queue, briefing, and register contract
+still apply wholesale.
+
+---
+
+## What this does not change (invariants)
+
+- **Frontends are renderers, never a second brain.** Every mutation here is
+  an existing ControlMsg / tunnel method / route; the prototype's data model
+  mirrors daemon snapshot shapes for exactly this reason.
+- **The trust doctrine stands.** Authority badges on every pane, route
+  provenance chips, petnames first, ceilings and ceremonies untouched —
+  presented more quietly, never less truthfully. `role:none` hosted
+  provenance remains `role:none`.
+- **Derive, don't mirror.** The ⌘K settings index, the Queue, and the room
+  catalogs are all derivations over existing declared tables (ROUTES, IAM
+  catalog, settings payload) — the implementation plan keeps them derived
+  with parity tests, in the spirit of `tunnel_method_partition_is_pinned`.
+- **Accessibility floor.** Keyboard-first flows, visible focus, labeled
+  chips, reduced motion, the DOM surface as the a11y floor even as Station
+  grows.
+- **Station stays** the immersive successor surface; Proscenium gives it a
+  place in the IA rather than competing with it.
+
+---
+
+## Adoption path (if the concept earns it)
+
+1. **Tokens + registers** land as a `ui3-*` fragment family beside ui-v2
+   (the alias-layer trick the v2 tokens already use makes this cheap).
+2. **Home + Queue** ship as a new default destination beside the existing
+   rail — no removals — fed from the existing snapshot/event stream; the
+   seven scattered attention surfaces gain a shared item model.
+3. **Rooms** absorb tabs one at a time (Work first — the session Space is
+   the deepest), each behind the hash router, old routes redirecting.
+4. **⌘K universal index** (settings + actions + objects) with jump-and-flash.
+5. **Density dial** last, once Studio demonstrably covers the old surface —
+   pinned by a parity test against the ROUTES/tunnel derivation.
+
+Each step is independently shippable and independently revertable.
+
+---
+
+## The doc suite
+
+- `README.md` — this file: the concept.
+- `surfaces.md` — every room specified: layout, contents, states, data.
+- `power-model.md` — the two registers, density dial, ⌘K spec, keyboard map,
+  the disclosure contract.
+- `visual-language.md` — tokens, color doctrine, type, arch motif, motion,
+  accessibility.
+- `capability-map.md` — the coverage guarantee: every route, tunnel method,
+  and ControlMsg, and its Proscenium home.
+- `prototype/` — the interactive build. Open `prototype/index.html`.
+
+---
+
+## Prototype tour
+
+`prototype/` is a clickable, self-contained build (no server, no build step —
+open `prototype/index.html` in any browser; mock data modeled on the real
+ontology: the fleet machines, the eight approval categories, builtin roles,
+peer profiles, claim codes, leases, custody). Things to try, in an order that
+tells the story:
+
+1. **The owner's morning** — Home opens on the briefing and the Queue. Read
+   a decision card, unfold its *details*, then press `y` (or click) to
+   resolve it. Watch the badge count down to *"You're free."*
+2. **Talk to the house** — in the composer, type `show me the cover`, then
+   `tidy my downloads folder`. The thread answers, and a new stage card
+   appears under Now Playing.
+3. **A live event arrives** — the ✦ button in the top bar injects an event
+   (an approval from another machine, a task finishing, a doorbell). Try it
+   from a room other than Home: the badge and drawer carry it.
+4. **The deep surface** — open Work → the `fix-login` stage card: timeline
+   with steer strip, real diff, context budget, backend controls, approval
+   rules, vitals, lineage, managed-context rewind. This is where power
+   users live.
+5. **⌘K is the index** — press `⌘K` (or `/`) and type `writable roots`.
+   Enter lands on the exact folded row in Settings and flashes it. Try
+   `quiet hours`, `pair a machine`, `approve`, `fix-login`.
+6. **The density dial** — top bar, `standard` → click to cycle Cozy /
+   Standard / Studio (or ⌘K → "cycle density"). Studio opens every fold,
+   shows IDs inline, tightens the grid. Cozy speaks first. Same routes,
+   same capabilities — three depths.
+7. **House lights** — the theme button flips Lamplight ⇄ Daylight.
+8. **The keyboard** — press `?` for the map; `g w` then `g h` to move
+   between rooms without the mouse.
+9. **The rooms** — Screens (a "live" display with the agent's cursor at
+   work, input authority, your-screen grant), Files (the desk, transfers,
+   a grant-denied state), Machines (the fleet, pairing wizard, delegate),
+   People & Keys (grants, the vault, fuel, custody trail), Books (costs,
+   the List, memory, reports), Settings (questions → the raw TOML),
+   Station (the constellation), Studio (the machinery, raw + the component
+   field guide).
+
+Everything resolves, unfolds, searches, and navigates client-side; nothing
+phones home. Resolved queue items persist per browser (clear
+`localStorage['proscenium.queue.resolved']` to reset the morning).

--- a/docs/design/proscenium/capability-map.md
+++ b/docs/design/proscenium/capability-map.md
@@ -1,0 +1,146 @@
+# Proscenium — capability map
+
+The coverage guarantee behind "nothing is deleted." Compiled against the
+daemon's declared surface in this worktree @ `a5081f18`:
+
+- `src/bin/caller/gateway_routes.rs` — the `ROUTES` table (~135 rows: every
+  HTTP route + its tunnel twin),
+- `src/bin/caller/dashboard_control/mod.rs` — `CONTROL_ONLY_METHODS`
+  (tunnel-only residue),
+- `src/bin/caller/event.rs` — the `ControlMsg` intent vocabulary and
+  `AppEvent` stream.
+
+Each entry: the capability → its Proscenium home. *Room* = nav destination;
+*Queue* = the Needs-You inbox; *Space* = an object's deep page; *⌘K* = the
+universal index. **[derived]** = computable client-side from existing
+events; **[new projection]** = a daemon-side addition the design suggests
+(optional, flagged, never assumed by v1).
+
+---
+
+## 1. Sessions & the agent loop
+
+| Capability | Proscenium home |
+|---|---|
+| Catalog (`GET /api/sessions`, `/stream`, `/search`, `/message-search`) | Work → Live/Archive; ⌘K lanes 2 & 4 |
+| Paged replay, agent-output, context-snapshot, report zip | Session Space → Timeline/Context/Vitals; Books → Reports |
+| `CreateSession` / `StartTask` (all launch params: backend, model, sandbox, approval policy, managed context, worktree, project root) | Home composer; Work → New (Options folds) |
+| `ResumeSession`, `StopSession`, `RestartSession`, `RenameSession`, `Interrupt` | Session Space header; stage-card ⋯; ⌘K actions |
+| `FollowUp`/`CancelFollowUp`, `Steer`/`CancelSteer`, `EditUserMessage` | Session Space → Timeline (steer strip, edit chip; gated by `SessionCapabilities`) |
+| `SpawnSubAgent` (delegate), `ForkSessionAtAnchor`, fork-points | Session Space → Vitals & lineage; Work → Live fan view |
+| `ConfigureSessionAgent` + all Codex/Claude pins (`SetCodex*`, `SetClaude*`, `SetExternalAgent`) | Session Space → Controls; Settings → fine print (defaults) |
+| `CodexThreadAction` (new/compact/fast/fork/side/undo/review/rename/goal/init/memory-reset) | Session Space → Controls; `/`-grammar in composer |
+| Approvals (`ApprovalRequired` → approve/skip/deny, `SetApprovalRule` "like this") | **Queue**; inline in the Conversation; Session Space; ⌘K action |
+| Questions (`UserQuestionRequired`, AskHuman, structured) | **Queue**; inline in the Conversation |
+| Managed context (anchors/records/fission routes, rewind composer, backout, lineage) | Session Space → Context fold (rewind/records/fission); Studio raw |
+| Worktrees (`/api/worktrees` inspect/scan/remove/clean/merge) | Work → Worktrees; Machine Space |
+| Background tasks registry | Session Space → Vitals fold |
+| History rollback/redo/prune, conversation rollback | Session Space → Changes |
+| Session data delete (per-kind), `DELETE /api/session/{id}` | Session Space → Vitals & lineage → data |
+| `SessionVitals` (git, cache TTL, rate limits), `UsageSnapshot` | stage-card meters; Session Space → Vitals; Books → Costs |
+| `SessionActivity`/`StatusSnapshot`/`Tick` | the status sentences everywhere (voice register source) |
+| `InvokeSkill` | composer `/`-grammar; ⌘K actions **[surfaces a daemon capability the SPA never exposed]** |
+| Session notes (`post_session_note`/`SessionNote`) | Session Space → Timeline ("pin a note") **[new surface for a shipped tool]** |
+| Controller-loop intents (halt/intervene/restart/status) | Studio → Workbench **[first-class home for MCP-only power]** |
+
+## 2. External agents & fuel
+
+| Capability | Proscenium home |
+|---|---|
+| `GET /api/external-agents` (installed/auth/quota posture) | Work → New (agent picker states); Settings → minds |
+| Sign-in ceremonies (`/api/claude-auth/*`, `/api/codex-auth/*`) | People & Keys → Keys & vault fold; Work → New unfueled CTA |
+| API keys (`POST /api/api-keys`, status) | Settings → minds; Home unfueled card ("Fuel") |
+| Credential leases (grant/renew/revoke/status), custody trail | People & Keys → Keys & vault; **Queue** dry-lease FYI |
+| Daemon vault blobs, deposits | People & Keys → Keys & vault (Studio folds) |
+| Egress relay (register/unregister/probe + frames) | People & Keys → Keys & vault → egress fold |
+| `POST /session` ephemeral live tokens | presence voice (composer mic); People & Keys diagnostics |
+
+## 3. Displays, computer use, recordings
+
+| Capability | Proscenium home |
+|---|---|
+| Inventory, signaling, WebRTC lanes | Screens → Stage |
+| Input authority (request/release/snapshot, force-takeover) | Screens → Stage toolbar + authority card |
+| `TakeDisplay`/`ReleaseDisplay`, virtual displays, debug screen | Screens → Stage / empty state; Studio → Workbench |
+| `GrantUserDisplay`/`RevokeUserDisplay` (durations) | Screens → Your screen; Home shared-view banner |
+| `DisplayRequestRaised` → `ResolveDisplayRequest` | **Queue** (doorbell, never auto-approvable) |
+| Recordings (start/stop/delete, segments, m3u8, frames) | Screens → Recordings & clips; Session Space → Vitals fold |
+| CU overlays (`CuActionExecuted`), shared view/focus | Screens → Stage; presence `inspect_frame(s)` renders in Conversation |
+| Diagnostics visual markers, freshness sink | Studio → Workbench |
+
+## 4. Presence, voice, audio
+
+| Capability | Proscenium home |
+|---|---|
+| `presence_connect`/`make_active`/checkpoints | Home composer mic; voice is the Conversation's spoken register |
+| Live audio (Gemini Live/OpenAI Realtime), `spawn_live_audio` | Home; the call skills' results render as Conversation artifacts |
+| Transcription (`user_audio` → `UserTranscript`) | Conversation thread (voice messages land as text) |
+| Presence tools (submit_task, approve/deny/skip, respond, set_autonomy…) | the Queue + Conversation (voice runs the same items) |
+| Quarantined live-model tool calls | **Queue** FYI tier **[first surface — daemon ships, SPA silent]** |
+| Presence camera frames | Conversation (presence video), Screens → Stage (presence source) |
+
+## 5. Terminal, files, transfers, browser
+
+| Capability | Proscenium home |
+|---|---|
+| PTY (`terminal_open/input/resize/close/share`, scrollback) | Screens → Terminals; Machine Space |
+| Scoped fs (`/api/fs/*`, sha-guarded write, range reads) | Files; grant-denied humane state |
+| Transfers (`/api/transfers/*`, chunks, resume, 206 downloads) | Files → Transfers; ⌘K "resume transfer" |
+| Browser workspaces (create/acquire/release/close, providers) | Screens → Browser workspaces; Studio |
+| Uploads store (`/api/session/current/uploads`) | composer attach; Session Space → Timeline attachments |
+
+## 6. Peers / federation
+
+| Capability | Proscenium home |
+|---|---|
+| Registry, agent card, capabilities, `PeerSnapshot` | Machines → cards & drill-down |
+| Pairing (invite/join/request-access/poll, identities, decisions) | Machines → Link a machine; **Queue** (peer doorbell) |
+| Message / delegate task / `POST /api/coordinator/route` | Machines → Delegate; composer `@machine` |
+| Peer approvals (`/api/peers/{id}/approval`) | **Queue** (per-peer section) |
+| Peer displays/sessions browsing, multi-host (`/api/dashboard/targets`) | Machine Space; Work/Screens host chips |
+| Peer profiles (9) + revocation | Machines → pairing wizard; People & Keys → grants |
+
+## 7. Access / IAM / trust
+
+| Capability | Proscenium home |
+|---|---|
+| Overview, IAM state, user/client grants, grant updates | People & Keys → People & devices (+ full matrix fold) |
+| Enrollment requests + decisions | **Queue**; People & Keys |
+| Orgs (trust/revoke/issue/renew/ORL/issuers) | People & Keys → Organizations (Studio fold) |
+| Connect (status/claim-code/config/unclaim) | People & Keys → Doors |
+| Trust tier (`integrated`/`disposable`) | People & Keys → You |
+| Fleet cert request, hosted anchor decisions | People & Keys → Doors (Studio fold) |
+| Hosted control (bootstrap/requests/presets/leases) | **Queue** (asks); People & Keys → Doors |
+| Tabs registry (`/api/dashboard/tabs`) | People & Keys → You ("your open tabs") |
+| Roles (11 builtin) + 26 permissions | People & Keys, plain-language role previews; Studio matrix |
+| The authority badge doctrine | every pane's authority line (rendering rule, not a route) |
+
+## 8. Agenda, memory, stats, settings, misc
+
+| Capability | Proscenium home |
+|---|---|
+| Agenda (`/api/agenda`, ops, reminders policy) | Home → Today ribbon; Books → The List |
+| **Scheduled sessions** (`propose_scheduled_session`, approve/revoke, occurrences) | Home → Today; Books → The List **[first surface for the shipped scheduler]** |
+| Memory (search/claim/propose, candidates, durability) | Books → What the house remembers |
+| Usage/cost (`UsageSnapshot`, pricing, disk) | Books → Costs & usage; Machine Space |
+| Settings payload (`GET/POST /api/settings`, all families) | Settings, question-sorted; every row in ⌘K lane 3 |
+| `SetAutonomy`, `SetVerbosity`, env overrides | Settings → autonomy; Session Space ⋯; Settings → fine print |
+| `GET /config`, `GET /debug`, stale-build compare | Studio → Workbench; the stale-build banner (kept) |
+| MCP tools (whole list) incl. `api_mcp_tool_call` | Studio → Reference; all are also the presence tool surface |
+| Attention (`UserNotification` urgency, title/favicon, push) | Queue FYI tier + escalation policy (`power-model.md` §6) |
+
+---
+
+## The two deliberate [new projection]s (optional)
+
+1. **Unified attention feed** — v1 derives the Queue client-side from the
+   event stream + polled routes (works today). Worth adding later: a
+   control-plane `attention` projection (single writer, severity-ordered,
+   expiry-aware) so every frontend (dashboard, Station, voice, MCP)
+   inherits one queue instead of re-deriving it.
+2. **Briefing digest** — v1 renders the briefing client-side from snapshot
+   + agenda + recent events. Worth adding later: a presence-side digest
+   query ("brief me") so the prose is presence's own voice on every
+   frontend.
+
+Neither blocks anything in this design.

--- a/docs/design/proscenium/power-model.md
+++ b/docs/design/proscenium/power-model.md
@@ -1,0 +1,155 @@
+# Proscenium — the power model
+
+How one app serves the owner and the operator without compromise. Four
+mechanisms, each simple, together load-bearing.
+
+---
+
+## 1. The disclosure contract
+
+> **Nothing is hidden. Everything unfolds.**
+
+Every summary view carries its machinery exactly one unfold away, and the
+unfold is *the same gesture everywhere*: a `┄ details ┄` / chevron row that
+expands in place. Folds remember their state per user per object kind (a
+power user who always opens Changes finds it open; grandma never sees it
+until she asks). No capability exists only at some density, behind some
+mode, or on some other screen — if you cannot find a thing, the index
+(§4) takes you to its exact folded row.
+
+The contract bans two failure modes the current dashboard and naive
+redesigns both suffer: **clutter** (everything visible for everyone — the
+cockpit) and **burial** (power removed to a separate "advanced" app, or
+renamed per level so search and docs fork). Proscenium folds; it never
+amputates and never renames.
+
+---
+
+## 2. The two registers
+
+A rendering policy applied to every surface:
+
+| | **Voice register** | **Instrument register** |
+|---|---|---|
+| Language | sentences ("Editing the login flow — 12 files changed") | facts (`turn 14 · 12 files · gpt-5.2-codex · $0.83`) |
+| Nouns | stable noun + short gloss: "Fuel — the API keys the house runs on" | the bare noun: "credential lease" |
+| Type | serif voice face, generous measure | mono, compact, tabular |
+| Defaults | safe choice pre-selected, consequence stated | every choice visible, no pre-selection |
+| Truth | a summary *of* the raw | the raw: IDs, routes, JSON |
+
+Rules:
+
+- **Stable nouns, glossed — never renamed per level.** A *session* is a
+  session at Cozy and at Studio. Glosses are a layer over the real
+  vocabulary (the codebase's own words: session, display, peer, lease,
+  grant, vault, anchor, fuel), so docs, search, support, and the two
+  registers all speak one language.
+- **Voice never fabricates.** Every voice-register sentence is a rendering
+  of daemon facts (`SessionActivity`, `StatusSnapshot`, events) and links
+  its source. If the house can't know, it says so — the honest-seams
+  doctrine applied to copy.
+- **Instrument is always one gesture away** (unfold, ⌘K, or density notch)
+  and requires no mode flip to *reach* — only to *see first*.
+
+---
+
+## 3. The density dial — Cozy / Standard / Studio
+
+One global, per-browser preference. A rendering policy, not a feature gate.
+
+| | **Cozy** | **Standard** (default) | **Studio** |
+|---|---|---|---|
+| Register | voice-first | voice summary + instrument folds | instrument-first |
+| Type/spacing | 15px base, generous | 14px base | 13px, compact, tabular |
+| Folds | at rest | first fold open on detail views | all open |
+| Meta lines | hidden (words only) | summary facts | IDs, routes, token detail inline |
+| Home layout | single column, queue → thread → now playing | single column + vitals rail | three-column ops grid |
+| Shortcut hints | hidden | in tooltips | visible inline |
+| Raw JSON | via ⌘K "inspect raw" | one fold | inline where useful |
+| Nav | 6 rooms + overflow | all rooms | all rooms + Studio, section counts |
+
+The dial never gates: ⌘K searches the full instrument vocabulary at every
+density, and a Cozy machine operated by a power user loses nothing but
+keystrokes to unfold. It persists in `localStorage`, is settable from
+Settings → "How should it look and feel?", the header, and ⌘K
+("density studio"), and is purely client-side.
+
+---
+
+## 4. The index — ⌘K
+
+The power user's home row; the owner's polite concierge. One box, four
+lanes, always in this order:
+
+1. **Actions** — verb-first, context-aware: *Approve top queue item*, *Stop
+   'fix-login'*, *New session*, *Pair a machine*, *Fuel from vault*, *Take
+   control of Display 1*, *Flip theme*, *Set density Studio*. Actions know
+   their preconditions (no active session → no *Stop*).
+2. **Go to** — every room and every named object: sessions, machines,
+   people, displays, worktrees, agenda items, files (shallow index), peers.
+3. **Settings** — *every settings row, folded or not*, under plain aliases:
+   "writable roots", "codex sandbox", "quiet hours", "approval rules",
+   "reasoning effort". Enter jumps to the room, opens the fold, flashes the
+   row. This lane is what makes "power users can find every little config"
+   a guarantee rather than a hope.
+4. **Search deeper** — the async lanes: session metadata search and the
+   full-log message search (today's Deep Search), results unioned.
+
+Behavior: fuzzy match (prefix > substring > subsequence), recency boost,
+mouse-free by default (`↑↓` move, `↵` act, `→` peek details, `esc`), and
+**register-blind**: the index always speaks instrument vocabulary even at
+Cozy, because search is where precision belongs. Alias coverage is
+hand-tended where plain words diverge from nouns ("fuel" → API keys +
+leases + vault).
+
+**Derivation, not mirroring:** lane 3's catalog is generated from the same
+settings payload/schema the Settings room renders; lane 1's actions from a
+declared table beside the room registry; object lanes from existing
+snapshots. A settings row added without an index entry fails a parity
+test — the index can never silently drift from the surface (the codebase's
+derive-don't-mirror doctrine, applied to search).
+
+---
+
+## 5. The keyboard map
+
+Global, discoverable (`?` opens the map), consistent with what the
+dashboard already ships:
+
+| Key | Where | Does |
+|---|---|---|
+| `⌘K` / `/` | everywhere | the index |
+| `?` | everywhere | shortcut map |
+| `g` then letter | everywhere | go to room: `h` Home, `w` Work, `s` Screens, `f` Files, `m` Machines, `p` People & Keys, `b` Books, `,` Settings, `t` Station, `u` Studio |
+| `y` `s` `a` `n` | queue / approval | approve / skip / approve-all-like-this / deny (existing grammar) |
+| `j` `k` | queue, lists | next / previous |
+| `x` | queue | dismiss FYI |
+| `↵` | cards | open / primary action |
+| `e` | cards | unfold details |
+| `⌘↵` | composer | send |
+| `esc` | layered | close topmost layer (existing contract) |
+
+Power flows: `⌘K writable roots ↵` (lands on the folded row, flashing);
+`y y a n` (clear four queue items without the mouse); `g w` → `j j ↵`
+(open the third live session).
+
+---
+
+## 6. Attention & escalation policy
+
+The Queue's reach, in escalating order, each step opt-in and honest:
+
+1. **In-app** — header badge (count + severity), Home pin, favicon dot and
+   `(N)` title prefix (today's attention center, kept).
+2. **Browser Notifications** — for hidden tabs, opt-in (existing).
+3. **Web Push** — for closed tabs, via Connect, payloads never carrying
+   work content (existing doctrine). Urgency mapping follows
+   `NotificationUrgency` (Info/Attention/Urgent).
+4. **Voice** — if a live voice session is active, presence *says* the
+   queue item aloud, in the first person, and takes the answer
+   conversationally (`approve_action`/`deny_action` presence tools already
+   exist).
+
+The owner should be able to run the house from the lock screen or the
+garden: the Queue is the same items at every reach, resolving everywhere at
+once.

--- a/docs/design/proscenium/prototype/app.css
+++ b/docs/design/proscenium/prototype/app.css
@@ -1,0 +1,474 @@
+/* ============================================================
+   Proscenium — component library (app.css)
+   ------------------------------------------------------------
+   STYLEGUIDE (the contract — reuse, don't improvise):
+
+   Layout      #rail (.rail-item, .rail-group-label) · #topbar
+               · #main > .page (one per room) · #composer
+   Structure   .card [.card-head .card-title .card-sub .card-actions]
+               .stage-card (arch band — live work) [.stage-band .stage-body]
+               .decision[.sev-attention|.sev-info|.fyi] (queue card)
+               .panel (sunken well) .row .col .wrap .grow
+   Disclosure  <details class="fold"> <summary> … <div class="fold-body">
+               (.fold[data-key] remembers state; studio opens by default)
+   Actions     .btn[.btn-primary|.btn-safe|.btn-danger|.btn-quiet][.btn-xs]
+               .icon-btn · .seg > button[.on]
+   Status      .chip[.chip-sage|.chip-slate|.chip-brass|.chip-attn|
+               .chip-brick|.chip-violet] — always labeled, never color-only
+               .dot[.dot-sage…] + word · .meter > .meter-fill · .badge-count
+   Facts       .fact (inline mono fact) · .kv > .k/.v · .factline
+   Tables      .table (dense, instrument register)
+   Thread      .thread .msg[.msg-you] .msg-body .artifact .milestone
+   Misc        .empty (.empty-glyph .empty-title .empty-hint)
+               .skeleton · .diff(.diff-add/.diff-del/.diff-hunk) · .heat
+               .tree · .authline · .kbd-hint · .flash (jump target)
+   Density     .cozy-only .studio-only .hide-cozy (visibility helpers)
+   ============================================================ */
+
+/* ============ App frame ============ */
+#app { display: flex; height: 100vh; }
+#column { flex: 1; display: flex; flex-direction: column; min-width: 0; }
+
+/* Curtain lift (first paint) */
+#curtain {
+  position: fixed; inset: 0; z-index: 200; display: flex; align-items: center; justify-content: center;
+  background: var(--bg); color: var(--text-2);
+  animation: curtain 900ms var(--ease) forwards; pointer-events: none;
+}
+#curtain svg { animation: curtainGlyph 700ms var(--ease) both; }
+@keyframes curtain { 0%,55% { opacity: 1; } 100% { opacity: 0; visibility: hidden; } }
+@keyframes curtainGlyph { from { opacity: 0; transform: translateY(14px) scale(.96); } to { opacity: 1; transform: none; } }
+
+/* Prototype banner */
+#proto-banner {
+  position: fixed; top: 0; left: 0; right: 0; z-index: 150;
+  display: flex; align-items: center; gap: 10px;
+  padding: 6px 14px; font-size: 12.5px;
+  background: linear-gradient(90deg, rgba(var(--brass-rgb),.14), rgba(var(--brass-rgb),.05));
+  border-bottom: 1px solid var(--line);
+  color: var(--text-2); backdrop-filter: blur(8px);
+}
+#proto-banner a { color: var(--brass); text-decoration: none; border-bottom: 1px solid rgba(var(--brass-rgb),.4); }
+#app { padding-top: 33px; }
+
+/* ============ Rail ============ */
+#rail {
+  width: var(--rail-w); flex: none; display: flex; flex-direction: column;
+  background: var(--bg-1); border-right: 1px solid var(--line);
+  padding: 14px 10px 10px; gap: 2px; overflow-y: auto;
+}
+#rail-brand {
+  display: flex; align-items: center; gap: 10px; padding: 4px 10px 14px;
+  color: var(--text);
+}
+#rail-brand .wordmark { font: 600 16px var(--voice); letter-spacing: .02em; }
+.rail-group-label {
+  font: 600 var(--fs-eyebrow) var(--sans); letter-spacing: .12em; text-transform: uppercase;
+  color: var(--text-3); padding: 14px 12px 5px;
+}
+.rail-item {
+  display: flex; align-items: center; gap: 10px; width: 100%;
+  padding: 7px 12px; border: 0; border-radius: var(--r-ctl);
+  background: none; color: var(--text-2); font: 500 var(--fs-base) var(--sans);
+  cursor: pointer; text-align: left; text-decoration: none;
+  transition: background var(--t-fast), color var(--t-fast);
+}
+.rail-item:hover { background: var(--surface-2); color: var(--text); }
+.rail-item.on { background: rgba(var(--brass-rgb),.13); color: var(--brass-2); }
+html[data-theme="daylight"] .rail-item.on { color: var(--brass); }
+.rail-item .icon { flex: none; }
+.rail-item .rail-sub { margin-left: auto; font-size: 11px; color: var(--text-3); }
+#rail-foot { border-top: 1px solid var(--line); padding-top: 8px; margin-top: 6px; }
+#rail-queue { position: relative; }
+#rail-identity { padding: 8px 12px 2px; font-size: 11.5px; line-height: 1.45; }
+
+/* ============ Topbar ============ */
+#topbar {
+  display: flex; align-items: center; gap: 8px;
+  padding: 10px 20px; border-bottom: 1px solid var(--line);
+  background: color-mix(in srgb, var(--bg) 82%, transparent);
+  backdrop-filter: blur(10px); flex: none;
+}
+#topbar-title { font-size: var(--fs-title); letter-spacing: .01em; }
+#topbar-facts { font-size: 12px; display: flex; gap: 14px; }
+#btn-palette {
+  display: flex; align-items: center; gap: 8px;
+  border: 1px solid var(--line-2); background: var(--surface);
+  color: var(--text-2); border-radius: var(--r-pill); padding: 6px 12px;
+  font: 500 12.5px var(--sans); cursor: pointer;
+  transition: border-color var(--t-fast), box-shadow var(--t-fast);
+}
+#btn-palette:hover { border-color: rgba(var(--brass-rgb),.5); box-shadow: var(--glow-brass); color: var(--text); }
+.kbd-hint {
+  font: 500 11px var(--mono); color: var(--text-3);
+  border: 1px solid var(--line); border-radius: 5px; padding: 1px 6px;
+  background: var(--bg-1);
+}
+
+/* ============ Main ============ */
+#main { flex: 1; overflow-y: auto; scroll-behavior: smooth; }
+.page {
+  max-width: var(--content-max); margin: 0 auto; padding: 26px 26px 40px;
+  display: flex; flex-direction: column; gap: var(--gap);
+  animation: pageIn var(--t-slow) var(--ease);
+}
+@keyframes pageIn { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }
+.page-title { font: 500 var(--fs-display)/1.2 var(--voice); letter-spacing: .01em; margin: 4px 0 0; }
+.page-sub { color: var(--text-2); margin: 2px 0 8px; max-width: 64ch; }
+.eyebrow {
+  font: 600 var(--fs-eyebrow) var(--sans); letter-spacing: .12em;
+  text-transform: uppercase; color: var(--text-3);
+}
+.section-head { display: flex; align-items: baseline; gap: 10px; margin: 14px 0 2px; }
+.section-head .eyebrow { flex: none; }
+.section-head .line { flex: 1; border-top: 1px solid var(--line); }
+html[data-density="studio"] .page-title { font-size: var(--fs-display); }
+
+/* ============ Cards ============ */
+.card {
+  background: var(--surface); border: 1px solid var(--line);
+  border-radius: var(--r-card); padding: var(--pad-card);
+  box-shadow: var(--shadow-card);
+}
+.card-head { display: flex; align-items: flex-start; gap: 12px; margin-bottom: 8px; }
+.card-title { font: 600 15px var(--sans); margin: 0; }
+.card-sub { color: var(--text-2); font-size: 13px; margin-top: 2px; }
+.card-actions { margin-left: auto; display: flex; gap: 8px; flex: none; }
+.grid { display: grid; gap: var(--gap); }
+.grid-2 { grid-template-columns: repeat(2, 1fr); }
+.grid-3 { grid-template-columns: repeat(3, 1fr); }
+html[data-density="studio"] .grid-3 { grid-template-columns: repeat(4, 1fr); }
+@media (max-width: 900px) { .grid-2, .grid-3 { grid-template-columns: 1fr; } }
+
+.panel {
+  background: var(--bg-1); border: 1px solid var(--line);
+  border-radius: var(--r-ctl); padding: 12px 14px;
+}
+.row { display: flex; align-items: center; gap: 8px; }
+.col { display: flex; flex-direction: column; gap: 8px; }
+input[type="radio"], input[type="checkbox"] { accent-color: var(--brass); }
+.input {
+  border: 1px solid var(--line-2); background: var(--bg-1); color: var(--text);
+  border-radius: var(--r-ctl); font: 400 13.5px var(--sans); padding: 7px 11px;
+  outline: none; transition: border-color var(--t-fast), box-shadow var(--t-fast);
+}
+.input:focus { border-color: rgba(var(--brass-rgb),.55); box-shadow: var(--glow-brass); }
+.input::placeholder { color: var(--text-3); }
+
+/* ============ Stage card (the arch — live work) ============ */
+.stage-card {
+  position: relative; display: block; border: 1px solid var(--line); border-radius: var(--r-card);
+  background: var(--surface); overflow: hidden; box-shadow: var(--shadow-card);
+  color: var(--text); text-decoration: none;
+  transition: border-color var(--t-med), transform var(--t-med), box-shadow var(--t-med);
+}
+.stage-card::before { /* the arch band */
+  content: ""; display: block; height: 26px;
+  border-radius: 46% 46% 0 0 / 100% 100% 0 0;
+  background: linear-gradient(180deg, rgba(var(--sage-rgb),.22), rgba(var(--sage-rgb),.03));
+  border-bottom: 1px solid var(--line);
+  margin: 0 8px; transform: translateY(6px);
+}
+.stage-card.attention::before { background: linear-gradient(180deg, rgba(var(--attn-rgb),.26), rgba(var(--attn-rgb),.03)); }
+.stage-card.peer::before { background: linear-gradient(180deg, rgba(var(--violet-rgb),.22), rgba(var(--violet-rgb),.03)); }
+.stage-card.done::before { background: linear-gradient(180deg, rgba(var(--slate-rgb),.18), rgba(var(--slate-rgb),.02)); }
+.stage-card:hover { border-color: var(--line-2); transform: translateY(-1px); box-shadow: var(--shadow-card), 0 6px 20px rgba(0,0,0,.18); }
+.stage-body { padding: 12px 16px 14px; }
+.stage-name { font: 600 15px var(--sans); display: flex; align-items: center; gap: 8px; }
+.stage-sentence { color: var(--text-2); margin: 4px 0 10px; font-size: 13.5px; }
+.stage-facts { display: flex; gap: 12px; flex-wrap: wrap; align-items: center; }
+
+/* ============ Chips, dots, facts ============ */
+.chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  font: 500 12px var(--sans); padding: 2.5px 10px;
+  border-radius: var(--r-pill); border: 1px solid var(--line-2);
+  color: var(--text-2); background: var(--surface-2); white-space: nowrap;
+}
+.chip .dot { margin: 0 -2px 0 -4px; }
+.chip-sage   { color: var(--sage);   border-color: rgba(var(--sage-rgb),.35);  background: rgba(var(--sage-rgb),.10); }
+.chip-slate  { color: var(--slate);  border-color: rgba(var(--slate-rgb),.35); background: rgba(var(--slate-rgb),.10); }
+.chip-brass  { color: var(--brass-2);border-color: rgba(var(--brass-rgb),.4);  background: rgba(var(--brass-rgb),.11); }
+html[data-theme="daylight"] .chip-brass { color: var(--brass); }
+.chip-attn   { color: var(--attn);   border-color: rgba(var(--attn-rgb),.4);   background: rgba(var(--attn-rgb),.10); }
+.chip-brick  { color: var(--brick);  border-color: rgba(var(--brick-rgb),.4);  background: rgba(var(--brick-rgb),.10); }
+.chip-violet { color: var(--violet); border-color: rgba(var(--violet-rgb),.4); background: rgba(var(--violet-rgb),.10); }
+.dot { display: inline-block; width: 7px; height: 7px; border-radius: 50%; background: var(--text-3); flex: none; }
+.dot-sage { background: var(--sage); box-shadow: 0 0 8px rgba(var(--sage-rgb),.6); }
+.dot-attn { background: var(--attn); box-shadow: 0 0 8px rgba(var(--attn-rgb),.6); }
+.dot-brick { background: var(--brick); }
+.dot-slate { background: var(--slate); }
+.dot-pulse { animation: pulse 2s infinite; }
+@keyframes pulse { 50% { opacity: .45; } }
+.fact { font: 400 12px var(--mono); color: var(--text-3); white-space: nowrap; }
+.factline { display: flex; gap: 14px; flex-wrap: wrap; }
+.kv { display: grid; grid-template-columns: minmax(120px, auto) 1fr; gap: 4px 16px; font-size: 13px; }
+.kv .k { color: var(--text-3); }
+.kv .v { color: var(--text); font-family: var(--mono); font-size: 12.5px; overflow-wrap: anywhere; }
+.badge-count {
+  min-width: 19px; height: 19px; padding: 0 6px; border-radius: var(--r-pill);
+  background: var(--attn); color: #241A08; font: 700 11px/19px var(--sans);
+  text-align: center; margin-left: auto;
+}
+.authline { color: var(--text-3); font-size: 11.5px; display: flex; gap: 6px; align-items: center; flex-wrap: wrap; }
+.authline .who { color: var(--brass-2); font-weight: 600; }
+html[data-theme="daylight"] .authline .who { color: var(--brass); }
+
+/* ============ Decision cards (the Queue) ============ */
+.decision {
+  position: relative; border: 1px solid rgba(var(--attn-rgb),.35);
+  border-radius: var(--r-card); background:
+    linear-gradient(180deg, rgba(var(--attn-rgb),.07), transparent 42%), var(--surface);
+  padding: var(--pad-card); box-shadow: var(--shadow-card);
+  animation: decideIn var(--t-slow) var(--ease);
+}
+@keyframes decideIn { from { opacity: 0; transform: translateY(-8px); } to { opacity: 1; transform: none; } }
+.decision.fyi { border-color: var(--line-2); background: var(--surface); }
+.decision-head { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; }
+.decision-title { font: 500 17px var(--voice); margin: 2px 0; }
+.decision-consequence { color: var(--text-2); font-size: 13.5px; margin: 2px 0 10px; }
+.decision-actions { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+.decision .authline { margin-top: 10px; }
+.decision.resolved { opacity: 0; transform: translateY(-6px); transition: opacity .3s, transform .3s; pointer-events: none; }
+.queue-free {
+  text-align: center; padding: 26px 20px; color: var(--text-2);
+  font: 500 16.5px var(--voice);
+}
+.queue-free .big { font-size: 20px; color: var(--sage); display: block; margin-bottom: 4px; }
+
+/* ============ Buttons ============ */
+.btn {
+  display: inline-flex; align-items: center; gap: 7px;
+  border: 1px solid var(--line-2); background: var(--surface-2);
+  color: var(--text); border-radius: var(--r-ctl);
+  font: 500 13px var(--sans); padding: 7px 14px; cursor: pointer;
+  transition: border-color var(--t-fast), background var(--t-fast), box-shadow var(--t-fast), transform var(--t-fast);
+}
+.btn:hover { border-color: var(--text-3); transform: translateY(-.5px); }
+.btn:active { transform: none; }
+.btn-primary {
+  background: linear-gradient(180deg, var(--brass-2), var(--brass));
+  border-color: rgba(var(--brass-rgb),.6); color: var(--on-brass); font-weight: 600;
+}
+.btn-primary:hover { box-shadow: var(--glow-brass); border-color: var(--brass); }
+.btn-safe { border-color: rgba(var(--sage-rgb),.45); color: var(--sage); background: rgba(var(--sage-rgb),.08); }
+.btn-safe:hover { border-color: var(--sage); }
+.btn-danger { border-color: rgba(var(--brick-rgb),.45); color: var(--brick); background: rgba(var(--brick-rgb),.07); }
+.btn-danger:hover { border-color: var(--brick); }
+.btn-quiet { background: none; border-color: transparent; color: var(--text-2); }
+.btn-quiet:hover { background: var(--surface-2); color: var(--text); border-color: transparent; }
+.btn-xs { padding: 3px 9px; font-size: 12px; border-radius: 8px; }
+.btn[disabled] { opacity: .45; pointer-events: none; }
+.icon-btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+  width: 32px; height: 32px; border-radius: var(--r-ctl);
+  border: 1px solid transparent; background: none; color: var(--text-2); cursor: pointer;
+  transition: background var(--t-fast), color var(--t-fast), border-color var(--t-fast);
+}
+.icon-btn:hover { background: var(--surface-2); color: var(--text); }
+.icon-btn.on { color: var(--brass-2); border-color: rgba(var(--brass-rgb),.4); background: rgba(var(--brass-rgb),.1); }
+.icon { display: inline-flex; width: 18px; height: 18px; flex: none; }
+.icon svg { width: 100%; height: 100%; }
+
+/* Segmented */
+.seg { display: inline-flex; border: 1px solid var(--line-2); border-radius: var(--r-ctl); overflow: hidden; background: var(--bg-1); }
+.seg button {
+  border: 0; background: none; color: var(--text-2); font: 500 12.5px var(--sans);
+  padding: 6px 13px; cursor: pointer; border-right: 1px solid var(--line);
+}
+.seg button:last-child { border-right: 0; }
+.seg button.on { background: rgba(var(--brass-rgb),.16); color: var(--brass-2); }
+html[data-theme="daylight"] .seg button.on { color: var(--brass); }
+
+/* Meters */
+.meter { display: inline-block; vertical-align: middle; height: 5px; border-radius: 4px; background: var(--surface-3); overflow: hidden; min-width: 60px; }
+.meter-fill { display: block; height: 100%; border-radius: 4px; background: var(--sage); transition: width .5s var(--ease); }
+.meter-fill.warn { background: var(--attn); }
+.meter-fill.hot { background: var(--brick); }
+
+/* ============ Folds (the disclosure contract) ============ */
+.fold { border: 1px solid var(--line); border-radius: var(--r-card); background: var(--surface); overflow: hidden; }
+.fold > summary {
+  list-style: none; cursor: pointer; display: flex; align-items: center; gap: 10px;
+  padding: 12px 16px; font: 600 13.5px var(--sans); color: var(--text);
+  transition: background var(--t-fast);
+}
+.fold > summary::-webkit-details-marker { display: none; }
+.fold > summary:hover { background: var(--surface-2); }
+.fold > summary .chev { transition: transform var(--t-med) var(--ease); color: var(--text-3); }
+.fold[open] > summary .chev { transform: rotate(90deg); }
+.fold > summary .fold-note { margin-left: auto; font: 400 12px var(--sans); color: var(--text-3); }
+.fold-body { padding: 4px 16px 16px; border-top: 1px solid var(--line); }
+.fold.flash, .flash { animation: flashTarget 1.6s var(--ease); }
+@keyframes flashTarget {
+  0%, 100% { box-shadow: none; }
+  15%, 45% { box-shadow: var(--glow-brass); border-color: rgba(var(--brass-rgb),.6); }
+}
+
+/* ============ Thread (the Conversation) ============ */
+.thread { display: flex; flex-direction: column; gap: 12px; }
+.msg { display: flex; gap: 10px; max-width: 82%; }
+.msg .avatar {
+  flex: none; width: 30px; height: 30px; border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  background: rgba(var(--brass-rgb),.14); color: var(--brass-2); border: 1px solid rgba(var(--brass-rgb),.3);
+}
+html[data-theme="daylight"] .msg .avatar { color: var(--brass); }
+.msg-body {
+  background: var(--surface); border: 1px solid var(--line);
+  border-radius: 4px var(--r-card) var(--r-card) var(--r-card);
+  padding: 10px 14px; box-shadow: var(--shadow-card);
+}
+.msg-body .prose { font: 400 var(--fs-voice)/1.55 var(--voice); }
+.msg-body .prose p { margin: 0 0 8px; } .msg-body .prose p:last-child { margin: 0; }
+.msg-you { align-self: flex-end; flex-direction: row-reverse; }
+.msg-you .msg-body { background: rgba(var(--brass-rgb),.09); border-color: rgba(var(--brass-rgb),.25); border-radius: var(--r-card) 4px var(--r-card) var(--r-card); }
+.msg-you .avatar { background: var(--surface-2); color: var(--text-2); border-color: var(--line-2); }
+.msg-meta { font-size: 11px; color: var(--text-3); margin-top: 6px; display: flex; gap: 8px; }
+.milestone {
+  display: flex; align-items: center; gap: 10px; color: var(--text-3); font-size: 12.5px;
+  padding: 2px 6px;
+}
+.milestone .line { flex: 1; border-top: 1px solid var(--line); }
+.milestone button { font-size: 11.5px; }
+.artifact {
+  margin-top: 10px; border: 1px solid var(--line-2); border-radius: var(--r-ctl);
+  background: var(--bg-1); padding: 10px 12px;
+}
+.artifact-head { display: flex; gap: 8px; align-items: center; font: 600 12.5px var(--sans); color: var(--text-2); margin-bottom: 6px; }
+
+/* Diff */
+.diff { font: 400 12px/1.6 var(--mono); overflow-x: auto; border-radius: var(--r-inset); }
+.diff-hunk { color: var(--slate); padding: 2px 10px; background: rgba(var(--slate-rgb),.07); }
+.diff-add { color: var(--sage); padding: 0 10px; display: block; background: rgba(var(--sage-rgb),.06); }
+.diff-del { color: var(--brick); padding: 0 10px; display: block; background: rgba(var(--brick-rgb),.05); }
+.diff-ctx { color: var(--text-3); padding: 0 10px; display: block; }
+
+/* ============ Today ribbon ============ */
+.ribbon { display: flex; gap: 8px; align-items: stretch; overflow-x: auto; padding: 4px 2px 8px; }
+.ribbon-item {
+  flex: none; display: flex; flex-direction: column; gap: 2px;
+  border: 1px solid var(--line); border-radius: var(--r-ctl);
+  background: var(--surface); padding: 8px 12px; min-width: 130px;
+  font-size: 12.5px; cursor: pointer; transition: border-color var(--t-fast);
+}
+.ribbon-item:hover { border-color: var(--line-2); }
+.ribbon-item .t { font: 500 11.5px var(--mono); color: var(--text-3); }
+.ribbon-item.now { border-color: rgba(var(--brass-rgb),.5); background: rgba(var(--brass-rgb),.07); }
+.ribbon-item.now .t { color: var(--brass-2); }
+
+/* ============ Composer ============ */
+#composer { flex: none; padding: 10px 20px 14px; border-top: 1px solid var(--line); background: color-mix(in srgb, var(--bg) 85%, transparent); backdrop-filter: blur(10px); }
+#composer-target { margin: 0 auto 6px; width: max-content; }
+#composer-box {
+  display: flex; align-items: flex-end; gap: 6px; max-width: var(--content-max); margin: 0 auto;
+  background: var(--surface); border: 1px solid var(--line-2); border-radius: 18px;
+  padding: 8px 10px; box-shadow: var(--shadow-card);
+  transition: border-color var(--t-fast), box-shadow var(--t-fast);
+}
+#composer-box:focus-within { border-color: rgba(var(--brass-rgb),.55); box-shadow: var(--glow-brass); }
+#composer-input {
+  flex: 1; border: 0; background: none; resize: none; color: var(--text);
+  font: 400 15px/1.45 var(--sans); padding: 5px 6px; max-height: 140px; outline: none;
+}
+#composer-hint { max-width: var(--content-max); margin: 5px auto 0; font-size: 11.5px; }
+.btn-send { color: var(--brass-2); }
+html[data-theme="daylight"] .btn-send { color: var(--brass); }
+
+/* ============ Overlays: palette & drawer ============ */
+.overlay { position: fixed; inset: 0; z-index: 100; background: rgba(10,8,6,.5); backdrop-filter: blur(3px); animation: fadeIn var(--t-fast); }
+@keyframes fadeIn { from { opacity: 0; } }
+#palette-panel {
+  width: min(640px, 92vw); margin: 12vh auto 0;
+  background: var(--surface-2); border: 1px solid var(--line-2);
+  border-radius: var(--r-panel); box-shadow: var(--shadow-overlay); overflow: hidden;
+}
+#palette-input-row { display: flex; align-items: center; gap: 10px; padding: 14px 16px; border-bottom: 1px solid var(--line); color: var(--text-3); }
+#palette-input { flex: 1; border: 0; background: none; outline: none; color: var(--text); font: 400 16px var(--sans); }
+#palette-results { max-height: 54vh; overflow-y: auto; padding: 6px; }
+.pal-lane { padding: 8px 12px 3px; font: 600 10.5px var(--sans); letter-spacing: .12em; text-transform: uppercase; color: var(--text-3); }
+.pal-item {
+  display: flex; align-items: center; gap: 10px; padding: 8px 12px; border-radius: var(--r-ctl);
+  cursor: pointer; color: var(--text-2);
+}
+.pal-item .pal-name { color: var(--text); font-weight: 500; }
+.pal-item .pal-hint { margin-left: auto; font-size: 11.5px; color: var(--text-3); }
+.pal-item.sel { background: rgba(var(--brass-rgb),.14); }
+.pal-item.sel .pal-name { color: var(--brass-2); }
+html[data-theme="daylight"] .pal-item.sel .pal-name { color: var(--brass); }
+#palette-foot { padding: 9px 16px; border-top: 1px solid var(--line); font-size: 11.5px; }
+
+#queue-panel {
+  position: absolute; top: 0; right: 0; bottom: 0; width: min(460px, 94vw);
+  background: var(--bg-1); border-left: 1px solid var(--line-2);
+  box-shadow: var(--shadow-overlay); overflow-y: auto; padding: 18px;
+  display: flex; flex-direction: column; gap: 12px;
+  animation: drawerIn var(--t-med) var(--ease);
+}
+@keyframes drawerIn { from { transform: translateX(30px); opacity: 0; } to { transform: none; opacity: 1; } }
+
+/* Toasts */
+#toasts { position: fixed; bottom: 90px; right: 20px; display: flex; flex-direction: column; gap: 8px; z-index: 160; }
+.toast {
+  background: var(--surface-2); border: 1px solid var(--line-2); color: var(--text);
+  border-radius: var(--r-ctl); padding: 10px 14px; font-size: 13px;
+  box-shadow: var(--shadow-overlay); animation: toastIn var(--t-med) var(--ease);
+  display: flex; gap: 8px; align-items: center; max-width: 340px;
+}
+.toast.sage { border-color: rgba(var(--sage-rgb),.4); }
+.toast.brick { border-color: rgba(var(--brick-rgb),.4); }
+@keyframes toastIn { from { opacity: 0; transform: translateY(8px); } }
+
+/* ============ Data display ============ */
+.table { width: 100%; border-collapse: collapse; font-size: 13px; }
+.table th {
+  text-align: left; font: 600 11px var(--sans); letter-spacing: .08em; text-transform: uppercase;
+  color: var(--text-3); padding: 6px 10px; border-bottom: 1px solid var(--line-2);
+}
+.table td { padding: 8px 10px; border-bottom: 1px solid var(--line); color: var(--text-2); }
+.table td:first-child { color: var(--text); font-weight: 500; }
+.table tr:hover td { background: var(--surface-2); }
+.table .mono { font-size: 12px; }
+
+.tree { font: 400 13px var(--mono); }
+.tree-row { display: flex; gap: 8px; align-items: center; padding: 3px 8px; border-radius: 6px; cursor: pointer; color: var(--text-2); }
+.tree-row:hover { background: var(--surface-2); }
+.tree-row.on { background: rgba(var(--brass-rgb),.12); color: var(--brass-2); }
+
+.heat { display: grid; grid-template-rows: repeat(7, 1fr); grid-auto-flow: column; gap: 3px; }
+.heat i { width: 11px; height: 11px; border-radius: 3px; background: var(--surface-3); }
+.heat i.l1 { background: rgba(var(--sage-rgb),.3); } .heat i.l2 { background: rgba(var(--sage-rgb),.5); }
+.heat i.l3 { background: rgba(var(--sage-rgb),.7); } .heat i.l4 { background: var(--sage); }
+
+/* Log lines (instrument register) */
+.log { font: 400 12px/1.65 var(--mono); color: var(--text-2); }
+.log .lt { color: var(--text-3); }
+.log .tool { color: var(--slate); }
+.log .ok { color: var(--sage); }
+.log .err { color: var(--brick); }
+
+/* ============ Empty & skeleton ============ */
+.empty { text-align: center; padding: 44px 20px; color: var(--text-2); }
+.empty-glyph { font-size: 30px; color: var(--text-3); margin-bottom: 10px; display: inline-block; }
+.empty-title { font: 500 19px var(--voice); color: var(--text); margin-bottom: 6px; }
+.empty-hint { font-size: 13.5px; max-width: 46ch; margin: 0 auto 14px; }
+.skeleton { border-radius: var(--r-ctl); background: linear-gradient(100deg, var(--surface) 40%, var(--surface-2) 50%, var(--surface) 60%); background-size: 200% 100%; animation: sk 1.4s infinite linear; }
+@keyframes sk { to { background-position: -200% 0; } }
+
+/* ============ Density visibility helpers ============ */
+html[data-density="cozy"] .hide-cozy, html[data-density="cozy"] .studio-only { display: none !important; }
+html:not([data-density="cozy"]) .cozy-only { display: none !important; }
+html:not([data-density="studio"]) .studio-only { display: none !important; }
+html[data-density="studio"] .fold { border-radius: var(--r-ctl); }
+html[data-density="studio"] .stage-sentence { font-size: 12.5px; }
+html[data-density="cozy"] .stage-facts .fact { display: none; }
+
+/* ============ Responsive ============ */
+@media (max-width: 860px) {
+  #rail { width: 64px; }
+  .rail-label, .rail-group-label, #rail-identity, #rail-brand .wordmark { display: none; }
+  .rail-item { justify-content: center; padding: 9px; }
+  .badge-count { position: absolute; top: 2px; right: 4px; }
+  #topbar-facts { display: none; }
+  .msg { max-width: 100%; }
+}

--- a/docs/design/proscenium/prototype/css/views-a.css
+++ b/docs/design/proscenium/prototype/css/views-a.css
@@ -1,0 +1,170 @@
+/* ============================================================
+   Proscenium — room styles: Screens · Files · Machines
+   (views-a.css). Everything here is prefixed (.scr-*, .file-*,
+   .mach-*) — tokens and shared components stay in app.css.
+   The fake "screens" are pictures of remote displays, so they
+   stay dark under both house themes, like a video would.
+   ============================================================ */
+
+/* ============ Screens room ============ */
+.scr-stagegrid { display: grid; grid-template-columns: minmax(0, 1fr) 300px; gap: var(--gap); align-items: start; }
+@media (max-width: 1120px) { .scr-stagegrid { grid-template-columns: 1fr; } }
+
+.scr-screen {
+  position: relative; overflow: hidden;
+  border: 1px solid var(--line-2); border-radius: var(--r-ctl);
+  aspect-ratio: 16 / 10; background: #100E0C; color: #E9E2D2;
+}
+.scr-cool { background: #0E1218; color: #D7E1EC; }
+
+/* --- fake staging browser (disp-1) --- */
+.scr-browser {
+  position: absolute; inset: 9% 9% 0; display: flex; flex-direction: column;
+  border-radius: 10px 10px 0 0; overflow: hidden;
+  background: #1A1712; border: 1px solid rgba(242,232,213,.10); border-bottom: 0;
+  box-shadow: 0 10px 34px rgba(0,0,0,.5);
+}
+.scr-browser-bar {
+  display: flex; align-items: center; gap: 7px; padding: 7px 10px; flex: none;
+  background: #221E18; border-bottom: 1px solid rgba(242,232,213,.08);
+}
+.scr-stoplight { width: 9px; height: 9px; border-radius: 50%; background: #4A4234; flex: none; }
+.scr-url {
+  flex: 1; min-width: 0; font: 400 11px var(--mono); color: #B9AE95;
+  background: rgba(0,0,0,.30); border: 1px solid rgba(242,232,213,.08);
+  border-radius: var(--r-pill); padding: 3px 10px;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.scr-banner {
+  display: flex; align-items: center; gap: 8px; padding: 8px 14px; flex: none;
+  background: rgba(217,123,102,.16); color: #E5A191;
+  border-bottom: 1px solid rgba(217,123,102,.28); font-size: 12px;
+}
+.scr-banner .icon { width: 14px; height: 14px; }
+.scr-page { padding: 16px 18px; display: flex; flex-direction: column; gap: 10px; }
+.scr-page-title { font: 500 15px var(--voice); color: #EDE5D3; }
+.scr-field { height: 26px; border-radius: 7px; background: #26211A; border: 1px solid rgba(242,232,213,.09); }
+.scr-field.scr-ghost { height: 8px; width: 55%; opacity: .55; }
+.scr-btn { height: 26px; width: 34%; border-radius: 7px; background: linear-gradient(180deg, rgba(210,162,76,.9), rgba(178,132,52,.9)); }
+
+/* --- the agent cursor + click ripple --- */
+.scr-cursor {
+  position: absolute; left: 58%; top: 56%; z-index: 3; pointer-events: none;
+  display: flex; align-items: center; gap: 5px;
+  transition: left 1.15s var(--ease), top 1.15s var(--ease);
+}
+.scr-cursor-dot {
+  width: 11px; height: 11px; border-radius: 50%; background: var(--attn); flex: none;
+  box-shadow: 0 0 0 3px rgba(232,163,61,.25), 0 0 12px rgba(232,163,61,.55);
+}
+.scr-cursor-tag {
+  font: 500 10.5px var(--mono); color: #F4EBD8; background: rgba(20,17,12,.88);
+  border: 1px solid rgba(232,163,61,.45); border-radius: var(--r-pill);
+  padding: 2px 8px; white-space: nowrap;
+}
+.scr-ripple {
+  position: absolute; z-index: 2; width: 8px; height: 8px; border-radius: 50%;
+  border: 2px solid var(--attn); transform: translate(-50%, -50%);
+  pointer-events: none; animation: scrRipple .7s ease-out forwards;
+}
+@keyframes scrRipple {
+  from { opacity: .9; width: 8px; height: 8px; }
+  to   { opacity: 0;  width: 46px; height: 46px; }
+}
+
+/* --- peer terminal-ish screen (disp-2) --- */
+.scr-term-screen { position: absolute; inset: 0; padding: 14px 16px; overflow: hidden; }
+.scr-screen .log { color: #C6CFDB; font-size: 11.5px; }
+.scr-screen .log .lt   { color: #6E7B8C; }
+.scr-screen .log .tool { color: #9DC0E8; }
+.scr-screen .log .ok   { color: #9CD0A6; }
+.scr-screen .log .err  { color: #E5A191; }
+
+/* --- xterm panel --- */
+.scr-xterm {
+  background: #131110; border: 1px solid var(--line-2); border-radius: var(--r-ctl);
+  padding: 12px 14px; font: 400 12.5px/1.7 var(--mono); color: #CFC6B0;
+  overflow-x: auto; white-space: nowrap;
+}
+.scr-xterm .p { color: #8AB894; }  /* prompt */
+.scr-xterm .c { color: #EFE7D4; }  /* command */
+.scr-xterm .o { color: #8D8270; }  /* output */
+.scr-caret {
+  display: inline-block; width: 8px; height: 14px; margin-left: 2px;
+  background: #8AB894; vertical-align: -2px;
+  animation: scrCaret 1.1s steps(1) infinite;
+}
+@keyframes scrCaret { 50% { opacity: 0; } }
+
+/* --- recordings: the fake player --- */
+.scr-poster {
+  position: relative; display: flex; align-items: center; justify-content: center;
+  aspect-ratio: 16 / 8.2; overflow: hidden;
+  border: 1px solid var(--line); border-radius: var(--r-ctl);
+  background:
+    radial-gradient(120% 130% at 20% 0%, rgba(210,162,76,.10), transparent 55%),
+    linear-gradient(150deg, #241E16, #16120F 65%);
+  transition: border-color var(--t-med);
+}
+.scr-player.playing .scr-poster { border-color: rgba(210,162,76,.45); }
+.scr-play {
+  width: 52px; height: 52px; border-radius: 50%; cursor: pointer;
+  border: 1px solid rgba(242,232,213,.25); background: rgba(0,0,0,.42); color: #F1EADC;
+  display: inline-flex; align-items: center; justify-content: center;
+  transition: transform var(--t-fast), box-shadow var(--t-fast);
+}
+.scr-play:hover { transform: scale(1.06); box-shadow: 0 0 18px rgba(210,162,76,.28); }
+.scr-play svg { display: block; }
+.scr-timeline { position: absolute; left: 0; right: 0; bottom: 0; height: 4px; background: rgba(242,232,213,.12); }
+.scr-timeline i { display: block; height: 100%; width: 0; background: var(--brass); }
+.scr-player.playing .scr-timeline i { animation: scrPlay var(--playdur, 14s) linear infinite; }
+@keyframes scrPlay { from { width: 0; } to { width: 100%; } }
+
+/* ============ Files room ============ */
+.file-deskgrid { display: grid; grid-template-columns: 280px minmax(0, 1fr); gap: var(--gap); align-items: start; }
+@media (max-width: 900px) { .file-deskgrid { grid-template-columns: 1fr; } }
+
+/* whose-disk accent — the colored top edge on the viewer panel */
+.file-accent-slate  { border-top: 2px solid var(--slate); }
+.file-accent-violet { border-top: 2px solid var(--violet); }
+
+.file-chev { transition: transform var(--t-med) var(--ease); color: var(--text-3); }
+.file-folder.open > .file-chev { transform: rotate(90deg); }
+
+/* fake PDF page (cream paper under both themes) */
+.file-page {
+  background: #F3EDDD; border-radius: var(--r-ctl); padding: 20px 22px;
+  box-shadow: 0 6px 24px rgba(0,0,0,.28);
+}
+.file-page-line { height: 8px; border-radius: 4px; background: rgba(74,65,50,.16); margin: 9px 0; }
+.file-page-line.w80 { width: 80%; }
+.file-page-line.w60 { width: 60%; }
+.file-page-line.w40 { width: 40%; }
+.file-page-line.file-page-head { height: 14px; width: 46%; background: rgba(74,65,50,.32); }
+
+/* the cover — a warm book jacket, drawn in CSS */
+.file-cover {
+  position: relative; display: flex; flex-direction: column; align-items: center;
+  justify-content: center; gap: 12px; text-align: center;
+  aspect-ratio: 4 / 5; max-width: 320px; margin: 0 auto; padding: 22px;
+  border-radius: 10px; overflow: hidden; color: #F1E7D0;
+  background:
+    radial-gradient(140% 90% at 50% 0%, rgba(210,162,76,.30), transparent 55%),
+    linear-gradient(165deg, #31463A 0%, #24352B 48%, #1A2620 100%);
+  box-shadow: 0 10px 34px rgba(0,0,0,.4), inset 0 0 0 1px rgba(241,231,208,.14);
+}
+.file-cover::before {
+  content: ""; position: absolute; inset: 12px; pointer-events: none;
+  border: 1px solid rgba(210,162,76,.5); border-radius: 7px;
+}
+.file-cover .t { font: 500 30px/1.18 var(--voice); letter-spacing: .02em; text-shadow: 0 2px 10px rgba(0,0,0,.4); }
+.file-cover .s { font: 400 11.5px var(--sans); letter-spacing: .18em; text-transform: uppercase; color: rgba(241,231,208,.78); }
+.file-cover .rule { width: 54px; border-top: 1px solid rgba(210,162,76,.7); }
+
+/* ============ Machines room ============ */
+.mach-petname { font: 500 21px var(--voice); letter-spacing: .01em; }
+.mach-pressure {
+  display: grid; grid-template-columns: 34px 1fr 36px; gap: 5px 8px; align-items: center;
+}
+.mach-pressure .k { font: 400 11px var(--mono); color: var(--text-3); }
+.mach-pressure .p { font: 400 11px var(--mono); color: var(--text-3); text-align: right; }

--- a/docs/design/proscenium/prototype/css/views-b.css
+++ b/docs/design/proscenium/prototype/css/views-b.css
@@ -1,0 +1,108 @@
+/* ============================================================
+   Proscenium — room CSS, set B: People & Keys (.ppl-),
+   Books (.bks-), Station (.stn-), Studio (.std-).
+   Tokens and app.css classes are consumed, never redefined.
+   ============================================================ */
+
+/* ============ People & Keys (.ppl-) ============ */
+.ppl-roles { display: grid; grid-template-columns: repeat(auto-fill, minmax(216px, 1fr)); gap: 8px; }
+.ppl-role { cursor: pointer; display: block; transition: border-color var(--t-fast), box-shadow var(--t-fast); }
+.ppl-role:hover { border-color: var(--line-2); }
+.ppl-role:has(input:checked) { border-color: rgba(var(--brass-rgb),.55); box-shadow: var(--glow-brass); }
+.ppl-role input { accent-color: var(--brass); margin-right: 6px; }
+.ppl-role .dim { font-size: 12px; margin-top: 3px; }
+
+.ppl-claim {
+  text-align: center; font-size: 13px; line-height: 2.1; letter-spacing: .05em;
+  color: var(--brass-2);
+}
+html[data-theme="daylight"] .ppl-claim { color: var(--brass); }
+
+.ppl-trail { position: relative; padding-left: 16px; }
+.ppl-trail::before {
+  content: ""; position: absolute; left: 4px; top: 9px; bottom: 9px;
+  width: 1px; background: var(--line-2);
+}
+.ppl-trail-row { position: relative; display: flex; align-items: baseline; gap: 10px; padding: 4px 0; }
+.ppl-trail-dot {
+  position: absolute; left: -15px; top: 9px; width: 7px; height: 7px;
+  border-radius: 50%; background: var(--bg-1); border: 1px solid var(--line-2);
+}
+
+/* ============ Books (.bks-) ============ */
+.bks-kpis { display: grid; grid-template-columns: repeat(4, 1fr); gap: var(--gap); }
+@media (max-width: 900px) { .bks-kpis { grid-template-columns: repeat(2, 1fr); } }
+.bks-kpi-value { font: 500 26px var(--voice); color: var(--text); }
+.bks-kpi-label { font: 600 12.5px var(--sans); color: var(--text-2); margin-top: 2px; }
+
+.bks-heat { margin: 4px 0 10px; }
+/* app.css leaves .meter-fill inline, so its width% never paints; scoped repair
+   for this room's cost bars only (contract gap, reported). */
+.bks-costbar .meter-fill { display: block; }
+.bks-heat-legend { gap: 4px; }
+.bks-heat-legend i { width: 11px; height: 11px; border-radius: 3px; background: var(--surface-3); flex: none; }
+.bks-heat-legend i.l1 { background: rgba(var(--sage-rgb),.3); }
+.bks-heat-legend i.l2 { background: rgba(var(--sage-rgb),.5); }
+.bks-heat-legend i.l3 { background: rgba(var(--sage-rgb),.7); }
+.bks-heat-legend i.l4 { background: var(--sage); }
+
+.bks-item { padding: 7px 6px; border-radius: 8px; cursor: pointer; transition: background var(--t-fast); }
+.bks-item:hover { background: var(--surface-2); }
+.bks-check {
+  width: 20px; height: 20px; flex: none; display: inline-flex; align-items: center; justify-content: center;
+  border: 1px solid var(--line-2); border-radius: 6px; color: var(--sage);
+}
+.bks-item-title { font-size: 13.5px; }
+.bks-item-title.done { text-decoration: line-through; color: var(--text-3); }
+
+/* ============ Station (.stn-) ============ */
+.stn-scene {
+  position: relative; margin: 0 -26px; min-height: 560px; overflow: hidden;
+  background: radial-gradient(1100px 560px at 50% 42%, #17203A 0%, #0B0E16 68%);
+  border-top: 1px solid var(--line); border-bottom: 1px solid var(--line);
+}
+.stn-svg { position: absolute; inset: 0; width: 100%; height: 100%; }
+.stn-svg text { fill: #C6BAA4; font-family: var(--sans); font-size: 12.5px; }
+.stn-svg .stn-label { text-anchor: middle; }
+.stn-svg .stn-sublabel { fill: #91866F; font-family: var(--mono); font-size: 10px; text-anchor: middle; }
+.stn-star { fill: #F1EADC; }
+.stn-star.tw { animation: stnTw 3.6s ease-in-out infinite; }
+@keyframes stnTw { 50% { opacity: .12; } }
+.stn-ring { fill: none; stroke: rgba(145,134,111,.30); stroke-dasharray: 3 7; }
+.stn-ring-faint { fill: none; stroke: rgba(145,134,111,.16); }
+.stn-spin { transform-origin: 500px 280px; animation: stnSpin 140s linear infinite; }
+.stn-spin-rev { transform-origin: 500px 280px; animation: stnSpinRev 210s linear infinite; }
+@keyframes stnSpin { to { transform: rotate(360deg); } }
+@keyframes stnSpinRev { to { transform: rotate(-360deg); } }
+.stn-link { stroke: rgba(145,134,111,.22); stroke-width: 1; }
+.stn-core path, .stn-core line { stroke: var(--brass); }
+.stn-core .stn-core-accent { stroke: var(--brass-2); }
+.stn-host-dot { fill: #26211A; stroke: var(--sage); stroke-width: 1.6; }
+.stn-host-dot.off { stroke: var(--slate); stroke-dasharray: 2 3; }
+.stn-agent { cursor: pointer; }
+.stn-agent-dot.work { fill: var(--sage); }
+.stn-agent-dot.idle { fill: var(--slate); }
+.stn-agent text { font-size: 11px; fill: #C6BAA4; }
+.stn-agent:hover text { fill: #F1EADC; }
+.stn-glow { fill: rgba(var(--attn-rgb),.08); stroke: var(--attn); stroke-width: 2; animation: stnGlow 2.2s ease-in-out infinite; }
+@keyframes stnGlow { 50% { opacity: .2; } }
+
+.stn-hud { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.stn-note { font-size: 12.5px; max-width: 78ch; }
+
+/* ============ Studio (.std-) ============ */
+.std-json { white-space: pre; font-size: 12px; line-height: 1.65; }
+.std-events { max-height: 300px; overflow-y: auto; }
+.std-guide { display: grid; grid-template-columns: repeat(auto-fill, minmax(310px, 1fr)); gap: 14px; }
+.std-spec {
+  border: 1px solid var(--line); border-radius: var(--r-card);
+  background: var(--surface); padding: 12px 14px;
+}
+.std-wide { grid-column: 1 / -1; }
+.std-spec-label {
+  font: 600 var(--fs-eyebrow) var(--sans); letter-spacing: .12em;
+  text-transform: uppercase; color: var(--text-3); margin-bottom: 10px;
+}
+/* same scoped .meter-fill repair so the guide's meter specimens paint */
+.std-spec .meter-fill { display: block; }
+.std-specimen { border: 1px dashed var(--line-2); border-radius: var(--r-card); padding: 8px; }

--- a/docs/design/proscenium/prototype/index.html
+++ b/docs/design/proscenium/prototype/index.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="lamplight" data-density="standard">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>Proscenium — the Intendant dashboard, reimagined</title>
+<link rel="stylesheet" href="tokens.css">
+<link rel="stylesheet" href="app.css">
+<link rel="stylesheet" href="css/views-a.css">
+<link rel="stylesheet" href="css/views-b.css">
+</head>
+<body>
+
+<!-- Curtain lift: first paint only, skipped under reduced motion -->
+<div id="curtain" aria-hidden="true">
+  <svg viewBox="70 80 372 372" width="72" height="72" aria-hidden="true">
+    <path d="M128 384 L128 240 Q128 128 256 128 Q384 128 384 240 L384 384"
+          fill="none" stroke="currentColor" stroke-width="14" stroke-linecap="round"/>
+    <line x1="256" y1="220" x2="256" y2="330" stroke="currentColor" stroke-width="14" stroke-linecap="round"/>
+    <line x1="236" y1="300" x2="330" y2="180" stroke="var(--brass)" stroke-width="10" stroke-linecap="round"/>
+  </svg>
+</div>
+
+<div id="proto-banner" role="note">
+  <span><strong>Proscenium</strong> — a design concept prototype. Mock data, no daemon attached.
+  Everything you see renders the real control-plane vocabulary.</span>
+  <span class="grow"></span>
+  <a href="../README.md">the concept</a>
+  <button class="btn btn-quiet btn-xs" id="proto-banner-close" aria-label="Dismiss">Dismiss</button>
+</div>
+
+<div id="app">
+  <!-- Left rail -->
+  <nav id="rail" aria-label="Rooms">
+    <div id="rail-brand" title="Proscenium">
+      <svg viewBox="70 80 372 372" width="30" height="30" aria-hidden="true">
+        <path d="M128 384 L128 240 Q128 128 256 128 Q384 128 384 240 L384 384"
+              fill="none" stroke="currentColor" stroke-width="16" stroke-linecap="round"/>
+        <line x1="256" y1="220" x2="256" y2="330" stroke="currentColor" stroke-width="16" stroke-linecap="round"/>
+        <line x1="236" y1="300" x2="330" y2="180" stroke="var(--brass)" stroke-width="11" stroke-linecap="round"/>
+        <circle cx="196" cy="360" r="11" fill="var(--brass)"/>
+        <circle cx="316" cy="360" r="11" fill="var(--brass)" opacity=".55"/>
+      </svg>
+      <span class="rail-label wordmark">Intendant</span>
+    </div>
+    <div id="rail-rooms" role="list"></div>
+    <div class="grow"></div>
+    <div id="rail-vantages"></div>
+    <div id="rail-foot">
+      <button id="rail-queue" class="rail-item" title="Needs you (queue)">
+        <span class="icon" data-icon="doorbell"></span>
+        <span class="rail-label">Needs you</span>
+        <span class="badge-count" id="rail-queue-count" hidden></span>
+      </button>
+      <div id="rail-identity" class="authline"></div>
+    </div>
+  </nav>
+
+  <!-- Main column -->
+  <div id="column">
+    <header id="topbar">
+      <div id="topbar-title" class="voice"></div>
+      <div class="grow"></div>
+      <div id="topbar-facts" class="mono dim"></div>
+      <button class="icon-btn" id="btn-simulate" title="Demo: inject a live event">
+        <span class="icon" data-icon="sparkle"></span>
+      </button>
+      <button class="icon-btn" id="btn-density" title="Density: Cozy / Standard / Studio">
+        <span class="icon" data-icon="density"></span><span id="density-label" class="hide-cozy"></span>
+      </button>
+      <button class="icon-btn" id="btn-theme" title="Theme: Lamplight / Daylight">
+        <span class="icon" data-icon="theme"></span>
+      </button>
+      <button id="btn-palette" title="Search everything (⌘K)">
+        <span class="icon" data-icon="search"></span><span class="kbd-hint">⌘K</span>
+      </button>
+    </header>
+
+    <main id="main" role="main" tabindex="-1"></main>
+
+    <footer id="composer" aria-label="Talk to the house">
+      <div id="composer-target" class="chip chip-brass" hidden></div>
+      <div id="composer-box">
+        <button class="icon-btn" title="Attach" id="composer-attach"><span class="icon" data-icon="attach"></span></button>
+        <textarea id="composer-input" rows="1" placeholder="Ask the house anything…"></textarea>
+        <button class="icon-btn" title="Speak (live voice)" id="composer-mic"><span class="icon" data-icon="mic"></span></button>
+        <button class="icon-btn btn-send" title="Send (⌘↵)" id="composer-send"><span class="icon" data-icon="send"></span></button>
+      </div>
+      <div id="composer-hint" class="dim">@ aims at a session or machine · / for power grammar · the house answers in the thread</div>
+    </footer>
+  </div>
+</div>
+
+<!-- ⌘K palette -->
+<div id="palette" class="overlay" hidden>
+  <div id="palette-panel" role="dialog" aria-label="Search everything">
+    <div id="palette-input-row">
+      <span class="icon" data-icon="search"></span>
+      <input id="palette-input" type="text" placeholder="Search rooms, work, settings, actions…" autocomplete="off" spellcheck="false">
+      <span class="kbd-hint">esc</span>
+    </div>
+    <div id="palette-results" role="listbox"></div>
+    <div id="palette-foot" class="dim">↑↓ move · ↵ open · → peek · every setting, folded or not</div>
+  </div>
+</div>
+
+<!-- Queue drawer -->
+<div id="queue-drawer" class="overlay" hidden>
+  <div id="queue-panel" role="dialog" aria-label="Needs you"></div>
+</div>
+
+<div id="toasts" aria-live="polite"></div>
+
+<script src="js/icons.js"></script>
+<script src="js/data.js"></script>
+<script src="js/ui.js"></script>
+<script src="js/palette.js"></script>
+<script src="js/views/home.js"></script>
+<script src="js/views/work.js"></script>
+<script src="js/views/session.js"></script>
+<script src="js/views/screens.js"></script>
+<script src="js/views/files.js"></script>
+<script src="js/views/machines.js"></script>
+<script src="js/views/people.js"></script>
+<script src="js/views/books.js"></script>
+<script src="js/views/settings.js"></script>
+<script src="js/views/station.js"></script>
+<script src="js/views/studio.js"></script>
+<script src="js/app.js"></script>
+</body>
+</html>

--- a/docs/design/proscenium/prototype/js/app.js
+++ b/docs/design/proscenium/prototype/js/app.js
@@ -1,0 +1,307 @@
+/* Proscenium — app shell: router, rail, topbar, composer, keyboard,
+   theme/density engines, queue drawer, demo event injection. */
+window.P = window.P || {};
+
+/* The rooms (palette + rail derive from this one table) */
+P.ROOMS = [
+  { id: 'home',     title: 'Home',          icon: 'arch',     gloss: 'the conversation · needs you' },
+  { id: 'work',     title: 'Work',          icon: 'stage',    gloss: 'sessions on stage' },
+  { id: 'screens',  title: 'Screens',       icon: 'screens',  gloss: 'see & touch your machines' },
+  { id: 'files',    title: 'Files',         icon: 'files',    gloss: 'the desk · transfers' },
+  { id: 'machines', title: 'Machines',      icon: 'machines', gloss: 'the fleet · pairing · delegation' },
+  { id: 'people',   title: 'People & Keys', icon: 'key',      gloss: 'who may do what · vault' },
+  { id: 'books',    title: 'Books',         icon: 'books',    gloss: 'costs · the list · memory' },
+  { id: 'settings', title: 'Settings',      icon: 'settings', gloss: 'how the house behaves' }
+];
+P.VANTAGES = [
+  { id: 'station', title: 'Station', icon: 'station', gloss: 'the constellation' },
+  { id: 'studio',  title: 'Studio',  icon: 'studio',  gloss: 'the machinery, raw' }
+];
+
+P.current = null;
+
+P.go = function (hash) {
+  if (location.hash === hash) P.route();
+  else location.hash = hash;
+};
+P.rerender = function () { P.route(); };
+
+P.route = function () {
+  const raw = (location.hash || '#/home').replace(/^#\/?/, '');
+  const parts = raw.split('/').filter(Boolean);
+  let viewId = parts[0] || 'home';
+  let params = parts.slice(1);
+
+  /* session space lives under work */
+  if (viewId === 'work' && params[0] === 'session') { viewId = 'session'; params = params.slice(1); }
+  if (!P.views[viewId]) { viewId = 'home'; params = []; }
+
+  P.current = viewId;
+  const view = P.views[viewId];
+  const main = document.getElementById('main');
+  main.innerHTML = '';
+  view.render(main, params);
+  P.mountIcons(main);
+  main.scrollTop = 0;
+
+  /* rail active state */
+  document.querySelectorAll('#rail-rooms .rail-item, #rail-vantages .rail-item').forEach(a => {
+    a.classList.toggle('on', a.dataset.room === viewId || (viewId === 'session' && a.dataset.room === 'work'));
+  });
+
+  /* topbar */
+  const room = P.ROOMS.concat(P.VANTAGES).find(r => r.id === viewId);
+  document.getElementById('topbar-title').textContent =
+    viewId === 'session' ? 'Work' : room ? room.title : '';
+  document.getElementById('topbar-facts').innerHTML =
+    '<span>' + P.data.sessions.filter(s => s.phase === 'working').length + ' working</span>' +
+    '<span>' + P.queueStore.pending().length + ' need you</span>' +
+    '<span class="studio-only">direct mTLS · tunnel live</span>';
+
+  P.renderQueueBadge();
+  P.renderRailIdentity();
+};
+
+/* ---------------- rail ---------------- */
+P.buildRail = function () {
+  const rooms = document.getElementById('rail-rooms');
+  rooms.innerHTML = P.ROOMS.map(r =>
+    '<a class="rail-item" data-room="' + r.id + '" href="#/' + r.id + '" title="' + P.esc(r.gloss) + '">' +
+    '<span class="icon">' + P.icon(r.icon) + '</span><span class="rail-label">' + r.title + '</span>' +
+    (r.id === 'work' ? '<span class="rail-sub">' + P.data.sessions.filter(s => s.phase === 'working').length + '</span>' : '') +
+    '</a>').join('');
+  document.getElementById('rail-vantages').innerHTML =
+    '<div class="rail-group-label">Vantages</div>' +
+    P.VANTAGES.map(r =>
+      '<a class="rail-item" data-room="' + r.id + '" href="#/' + r.id + '" title="' + P.esc(r.gloss) + '">' +
+      '<span class="icon">' + P.icon(r.icon) + '</span><span class="rail-label">' + r.title + '</span></a>').join('');
+  P.mountIcons(document.getElementById('rail'));
+};
+
+P.renderRailIdentity = function () {
+  const you = P.data.you;
+  document.getElementById('rail-identity').innerHTML =
+    '<div class="authline"><span class="who">' + P.esc(you.name) + ' · ' + you.role + '</span>' +
+    P.routeChip(you.route.replace(' mTLS', '')) + '</div>';
+};
+
+/* ---------------- queue badge + drawer ---------------- */
+P.renderQueueBadge = function () {
+  const n = P.queueStore.pending().length;
+  const badge = document.getElementById('rail-queue-count');
+  badge.hidden = n === 0;
+  badge.textContent = n;
+  document.title = (n ? '(' + n + ') ' : '') + 'Proscenium — the Intendant dashboard, reimagined';
+  const facts = document.getElementById('topbar-facts');
+  if (facts) facts.querySelectorAll('span')[1].textContent = n + ' need you';
+};
+
+P.openQueueDrawer = function () {
+  const drawer = document.getElementById('queue-drawer');
+  const panel = document.getElementById('queue-panel');
+  const pending = P.queueStore.pending();
+  const fyis = P.queueStore.fyis();
+  panel.innerHTML =
+    '<div class="row"><h2 class="voice" style="margin:0;font-size:22px">Needs you</h2><span class="grow"></span>' +
+    '<button class="icon-btn" id="queue-close">' + P.icon('x') + '</button></div>' +
+    (pending.length || fyis.length
+      ? pending.map(q => P.decisionCard(q)).join('') +
+        (fyis.length ? '<div class="eyebrow" style="margin-top:8px">for your awareness</div>' + fyis.map(q => P.decisionCard(q)).join('') : '')
+      : '<div class="queue-free"><span class="big">You’re free.</span>Nothing needs you. The house will tap you the moment something does.</div>');
+  drawer.hidden = false;
+  panel.querySelector('#queue-close').onclick = () => drawer.hidden = true;
+  drawer.onclick = e => { if (e.target === drawer) drawer.hidden = true; };
+};
+
+/* ---------------- theme & density ---------------- */
+P.setTheme = function (t) {
+  document.documentElement.dataset.theme = t;
+  P.store.set('theme', t);
+};
+P.cycleTheme = function () {
+  P.setTheme(document.documentElement.dataset.theme === 'lamplight' ? 'daylight' : 'lamplight');
+};
+P.setDensity = function (d) {
+  document.documentElement.dataset.density = d;
+  P.store.set('density', d);
+  document.getElementById('density-label').textContent = d;
+  P.rerender();
+};
+P.cycleDensity = function () {
+  const order = ['cozy', 'standard', 'studio'];
+  const next = order[(order.indexOf(P.density()) + 1) % order.length];
+  P.setDensity(next);
+  P.toast('Density → ' + next, null);
+};
+
+/* ---------------- composer ---------------- */
+P.wireComposer = function () {
+  const ta = document.getElementById('composer-input');
+  const send = () => {
+    const text = ta.value.trim();
+    if (!text) return;
+    ta.value = ''; ta.style.height = 'auto';
+    if (P.current === 'home') P.views.home.onSend(text);
+    else { P.go('#/home'); setTimeout(() => P.views.home.onSend(text), 250); }
+  };
+  ta.addEventListener('keydown', e => {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); send(); }
+    else if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send(); }
+  });
+  ta.addEventListener('input', () => { ta.style.height = 'auto'; ta.style.height = Math.min(ta.scrollHeight, 140) + 'px'; });
+  document.getElementById('composer-send').onclick = send;
+  document.getElementById('composer-mic').onclick = () =>
+    P.toast('Live voice would connect here — the thread is the same one you’re reading', null);
+  document.getElementById('composer-attach').onclick = () =>
+    P.toast('Attachments stage here and ride the next message', null);
+};
+
+/* ---------------- keyboard ---------------- */
+P.showShortcuts = function () {
+  const panel = document.getElementById('queue-panel');
+  const drawer = document.getElementById('queue-drawer');
+  const rows = [
+    ['⌘K or /', 'the index — everything, one box'], ['?', 'this map'],
+    ['g h / w / s / f / m / p / b', 'go: home · work · screens · files · machines · people · books'],
+    ['g ,  ·  g t  ·  g u', 'settings · station · studio'],
+    ['y s a n', 'queue: approve · skip · approve-all · deny'],
+    ['j k', 'move through the queue'], ['x', 'dismiss an FYI'],
+    ['e', 'unfold details'], ['⌘↵', 'send'], ['esc', 'close the top layer']
+  ];
+  panel.innerHTML =
+    '<div class="row"><h2 class="voice" style="margin:0;font-size:22px">The keyboard</h2><span class="grow"></span>' +
+    '<button class="icon-btn" id="queue-close">' + P.icon('x') + '</button></div>' +
+    '<div class="card"><div class="kv">' + rows.map(r =>
+      '<span class="k mono">' + r[0] + '</span><span class="v" style="font-family:var(--sans)">' + r[1] + '</span>').join('') +
+    '</div></div>';
+  drawer.hidden = false;
+  panel.querySelector('#queue-close').onclick = () => drawer.hidden = true;
+  drawer.onclick = e => { if (e.target === drawer) drawer.hidden = true; };
+};
+
+let gPending = false;
+P.wireKeyboard = function () {
+  document.addEventListener('keydown', e => {
+    const typing = /INPUT|TEXTAREA/.test(document.activeElement.tagName);
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') { e.preventDefault(); P.palette.isOpen ? P.palette.close() : P.palette.open(); return; }
+    if (typing) { if (e.key === 'Escape') document.activeElement.blur(); return; }
+    if (P.palette.isOpen) return;
+    const drawerOpen = !document.getElementById('queue-drawer').hidden;
+    if (e.key === 'Escape') { if (drawerOpen) document.getElementById('queue-drawer').hidden = true; return; }
+    if (e.key === '?') { P.showShortcuts(); return; }
+    if (e.key === '/') { e.preventDefault(); P.palette.open(); return; }
+    if (gPending) {
+      gPending = false;
+      const map = { h: 'home', w: 'work', s: 'screens', f: 'files', m: 'machines', p: 'people', b: 'books', ',': 'settings', t: 'station', u: 'studio' };
+      if (map[e.key]) { e.preventDefault(); P.go('#/' + map[e.key]); }
+      return;
+    }
+    if (e.key === 'g') { gPending = true; setTimeout(() => gPending = false, 900); return; }
+    /* queue grammar */
+    if ('ysanx'.includes(e.key) && P.current === 'home') {
+      const top = e.key === 'x' ? P.queueStore.fyis()[0] : P.queueStore.pending()[0];
+      if (!top) return;
+      const act = { y: 'approve', s: 'skip', a: 'always', n: 'deny', x: 'dismiss' }[e.key];
+      const valid = top.actions.find(a => a.id === act) ? act : (e.key === 'y' ? top.actions[0].id : null);
+      if (valid) P.queueStore.resolve(top.id, valid);
+    }
+  });
+};
+
+/* ---------------- demo event injection ---------------- */
+P.wireSimulate = function () {
+  const scenarios = [
+    {
+      label: 'an approval arrives', run() {
+        P.data.queue.unshift({
+          id: 'q-sim-' + Date.now(), kind: 'approval', sev: 'attention', when: 'just now',
+          category: 'command_exec', session: 'docs-sweep', machine: 'dell', backend: 'Codex',
+          title: 'Codex wants to run the link fixer',
+          consequence: 'On Workshop — it rewrites dead links in 41 chapters. Reversible via git; nothing leaves the machine.',
+          details: { command: 'python3 scripts/fix_links.py --apply docs/src/', paths: [], rule: 'Always allowing would set command_exec → Auto for docs work.', raw: '{ "category": "command_exec", "tool": "local_bash" }' },
+          actions: [
+            { id: 'approve', label: 'Allow once', kind: 'safe', key: 'y' },
+            { id: 'always', label: 'Always allow docs fixes', kind: 'quiet', key: 'a' },
+            { id: 'deny', label: 'Deny', kind: 'danger', key: 'n' }
+          ]
+        });
+      }
+    },
+    {
+      label: 'a task finishes', run() {
+        P.data.conversation.push(
+          { kind: 'milestone', text: 'docs-sweep finished · 96 chapters, 3 dead links fixed' },
+          { from: 'presence', at: 'now', prose: ['**docs-sweep** is done — three dead links fixed, one ambiguous one left in the list for you. Workshop is idle again.'] }
+        );
+        const s = P.data.sessions.find(x => x.id === 'docs-sweep');
+        if (s) { s.phase = 'done'; s.sentence = 'Finished — 3 dead links fixed, 1 needs your call'; }
+      }
+    },
+    {
+      label: 'a doorbell rings', run() {
+        P.data.queue.unshift({
+          id: 'q-sim-' + Date.now(), kind: 'display', sev: 'attention', when: 'just now',
+          session: 'photo-book', machine: 'local',
+          title: '“photo-book” wants to show you something',
+          consequence: 'Shared view — it presents the cover full-screen on your display. You can dismiss it any time; it never takes input.',
+          durations: ['Until I dismiss it'],
+          actions: [
+            { id: 'allow', label: 'Show me', kind: 'safe', key: 'y' },
+            { id: 'deny', label: 'Later', kind: 'quiet', key: 'n' }
+          ]
+        });
+      }
+    }
+  ];
+  let i = 0;
+  document.getElementById('btn-simulate').onclick = () => {
+    const sc = scenarios[i++ % scenarios.length];
+    sc.run();
+    P.toast('Demo: ' + sc.label, null);
+    P.renderQueueBadge();
+    if (P.current === 'home') P.rerender();
+    else P.openQueueDrawer();
+  };
+};
+
+/* ---------------- boot ---------------- */
+P.boot = function () {
+  P.setTheme(P.store.get('theme', 'lamplight'));
+  document.documentElement.dataset.density = P.store.get('density', 'standard');
+  document.getElementById('density-label').textContent = P.density();
+
+  P.buildRail();
+  P.wireComposer();
+  P.wireKeyboard();
+  P.wireSimulate();
+
+  document.getElementById('btn-palette').onclick = () => P.palette.open();
+  document.getElementById('btn-theme').onclick = P.cycleTheme;
+  document.getElementById('btn-density').onclick = P.cycleDensity;
+  document.getElementById('rail-queue').onclick = P.openQueueDrawer;
+  document.getElementById('proto-banner-close').onclick = () => {
+    document.getElementById('proto-banner').remove();
+    document.getElementById('app').style.paddingTop = '0';
+  };
+
+  window.addEventListener('hashchange', P.route);
+  if (!location.hash) location.hash = '#/home';
+  P.route();
+  P.mountIcons(document);
+
+  /* first-paint composer greeting rotation */
+  const hints = [
+    'Ask the house anything…',
+    '“tidy my downloads folder”',
+    '“@fix-login try the tests again”',
+    '“/codex review the diff”',
+    '“what did the backup do last night?”'
+  ];
+  let hi = 0;
+  setInterval(() => {
+    const ta = document.getElementById('composer-input');
+    if (ta && !ta.value) ta.placeholder = hints[hi = (hi + 1) % hints.length];
+  }, 4200);
+};
+
+document.addEventListener('DOMContentLoaded', P.boot);

--- a/docs/design/proscenium/prototype/js/data.js
+++ b/docs/design/proscenium/prototype/js/data.js
@@ -1,0 +1,380 @@
+/* Proscenium — mock control-plane state.
+   Shapes mirror the daemon's own vocabulary (StatusSnapshot, SessionVitals,
+   PeerSnapshot, the 8 approval categories, builtin roles, peer profiles,
+   NotificationUrgency). Nothing here is fantasy data: every field has a
+   source in gateway_routes::ROUTES, the AppEvent stream, or the IAM model. */
+window.P = window.P || {};
+
+P.data = {
+
+  you: {
+    name: 'Val', role: 'owner', device: 'This browser · Safari',
+    route: 'direct mTLS', since: 'Mar 2026', keyId: 'k_9f2c…a41e'
+  },
+
+  /* ------------------------------------------------ machines (fleet) --- */
+  machines: [
+    {
+      id: 'local', petname: 'Studio Mac', label: 'macbook-a', thisMachine: true,
+      route: 'direct', role: 'owner', os: 'macOS 15.5', status: 'online',
+      pressure: { cpu: 34, mem: 61 }, fueled: true,
+      capabilities: ['computer-use', 'display', 'voice', 'terminal'],
+      version: '0.42.3 · a5081f18'
+    },
+    {
+      id: 'dell', petname: 'Workshop', label: 'dell-206', thisMachine: false,
+      route: 'fleet name', role: 'operator', os: 'Debian 13', status: 'online',
+      pressure: { cpu: 12, mem: 38 }, fueled: true,
+      capabilities: ['computer-use', 'terminal', 'headless'],
+      version: '0.42.3 · a5081f18', lease: 'fuel lease · 2 days left'
+    },
+    {
+      id: 'samsung', petname: 'Parlor PC', label: 'samsung-win', thisMachine: false,
+      route: 'hosted', role: 'observer', os: 'Windows 11', status: 'away',
+      pressure: { cpu: 0, mem: 0 }, fueled: false,
+      capabilities: ['display'],
+      version: '0.41.0 · 9d65f325', note: 'Away 3 days — fuel expired'
+    }
+  ],
+
+  /* ------------------------------------------------ sessions (work) ---- */
+  sessions: [
+    {
+      id: 'fix-login', name: 'fix-login', backend: 'claude-code', model: 'claude-fable',
+      machine: 'local', phase: 'working', turn: 14,
+      sentence: 'Editing the login flow — 12 files changed so far',
+      task: 'Fix the OAuth redirect loop on staging. Users bounce between /login and /auth/callback when the session cookie is cross-site.',
+      started: '09:41', cost: 0.83, tokens: { used: 184200, ctx: 200000, pct: 82 },
+      branch: 'fix/login-redirect', dirty: 12, ahead: 3,
+      cache: { hit: 94, ttl: '4m 12s' }, limits: { fiveHour: 31, week: 12 },
+      queue: ['q-approve-delete'],
+      caps: { follow_up: true, steer: true, interrupt: true, thread_actions: false },
+      subagents: []
+    },
+    {
+      id: 'docs-sweep', name: 'docs-sweep', backend: 'codex', model: 'gpt-5.2-codex',
+      machine: 'dell', phase: 'working', turn: 8, peer: true,
+      sentence: 'Running the link checker across the mdBook — 41 of 96 chapters scanned',
+      task: 'Sweep docs/src for dead links and stale route references; fix what is safe, list the rest.',
+      started: '10:07', cost: 0.31, tokens: { used: 96400, ctx: 272000, pct: 35 },
+      branch: 'docs/link-sweep', dirty: 6, ahead: 1,
+      cache: { hit: 88, ttl: '1m 3s' }, limits: { fiveHour: 18, week: 9 },
+      queue: [], caps: { follow_up: true, steer: true, interrupt: true, thread_actions: true },
+      subagents: []
+    },
+    {
+      id: 'photo-book', name: 'photo-book', backend: 'internal', model: 'orchestrate',
+      machine: 'local', phase: 'done', turn: 46, finishedAgo: '6:12 this morning',
+      sentence: 'Finished — the photo book is laid out and exported',
+      task: 'Make a printed photo book from last Christmas — pick the best 60 photos, lay them out, export a PDF for the print shop.',
+      cost: 2.41, tokens: { used: 612000, ctx: 200000, pct: 100 },
+      branch: 'main', dirty: 0, cache: { hit: 91 }, limits: {},
+      queue: [], caps: { follow_up: true, steer: false, interrupt: false, thread_actions: false },
+      subagents: [
+        { name: 'photo-cull', role: 'research', result: '62 picks from 1,840 photos' },
+        { name: 'book-layout', role: 'implementation', result: '38-page spread, PDF exported' }
+      ],
+      resultFiles: ['~/Pictures/photo-book/christmas-2025.pdf', '~/Pictures/photo-book/cover.png']
+    },
+    {
+      id: 'nightly-backup', name: 'nightly-backup', backend: 'internal', model: 'direct',
+      machine: 'local', phase: 'done', turn: 3, finishedAgo: '02:00 (scheduled)',
+      sentence: 'Finished — one retry, then clean. 41.2 GB to the NAS.',
+      task: 'Nightly backup of ~/Documents and ~/Pictures to the NAS.', cost: 0.04,
+      tokens: { used: 12400, ctx: 200000, pct: 6 }, branch: '—', dirty: 0,
+      cache: { hit: 0 }, limits: {}, queue: [], scheduled: 'every day · 02:00',
+      caps: { follow_up: true, steer: false, interrupt: false, thread_actions: false },
+      subagents: [], note: 'rsync failed once (NAS asleep) — retried after wake-on-LAN, clean.'
+    },
+    {
+      id: 'q2-invoices', name: 'q2-invoices', backend: 'claude-code', model: 'claude-sonnet',
+      machine: 'local', phase: 'idle', idleSince: 'Tuesday',
+      sentence: 'Idle since Tuesday — waiting for you, whenever',
+      task: 'Reconcile Q2 invoices against the bank export and flag anything over $500 without a PO.',
+      cost: 1.12, tokens: { used: 288000, ctx: 200000, pct: 44 },
+      branch: 'main', dirty: 2, cache: { hit: 76 }, limits: {},
+      queue: [], caps: { follow_up: true, steer: true, interrupt: true, thread_actions: false },
+      subagents: []
+    },
+    {
+      id: 'station-polish', name: 'station-polish', backend: 'internal', model: 'sub-agent',
+      machine: 'local', phase: 'archived', finishedAgo: 'last week',
+      sentence: 'Archived — merged into its parent',
+      task: 'Sub-agent: soften the Station approval-glow ring animation.', cost: 0.19,
+      tokens: { used: 41000, ctx: 200000, pct: 21 }, branch: 'fix/station-glow', dirty: 0,
+      cache: { hit: 85 }, limits: {}, queue: [], parent: 'dashboard-everything-concept',
+      caps: { follow_up: false, steer: false, interrupt: false, thread_actions: false },
+      subagents: []
+    }
+  ],
+
+  /* ------------------------------------------------ the Queue ---------- */
+  queue: [
+    {
+      id: 'q-approve-delete', kind: 'approval', sev: 'attention', when: '2 min ago',
+      category: 'file_delete', session: 'fix-login', machine: 'local', backend: 'Claude Code',
+      title: 'Claude wants to delete 3 files',
+      consequence: 'In ~/projects/shopify-theme/exports — old CSV dumps it says are regenerated each run. This cannot be undone.',
+      details: {
+        command: 'rm exports/2026-05-orders.csv exports/2026-06-orders.csv exports/backup-orders.csv',
+        paths: ['exports/2026-05-orders.csv', 'exports/2026-06-orders.csv', 'exports/backup-orders.csv'],
+        rule: 'Always allowing would set file_delete → Auto for this project.',
+        raw: '{ "category": "file_delete", "tool": "Bash", "command": "rm …", "session": "fix-login", "turn": 14 }'
+      },
+      actions: [
+        { id: 'approve', label: 'Allow once', kind: 'safe', key: 'y' },
+        { id: 'always', label: 'Always allow here', kind: 'quiet', key: 'a' },
+        { id: 'deny', label: 'Deny', kind: 'danger', key: 'n', default: true }
+      ]
+    },
+    {
+      id: 'q-callback-url', kind: 'question', sev: 'attention', when: '6 min ago',
+      session: 'fix-login', machine: 'local',
+      title: 'Which callback URL should win?',
+      consequence: 'The OAuth provider allows exactly one. The redirect loop lives in this choice.',
+      options: ['/auth/callback (keep, register with provider)', '/callback (shorter, update provider)'],
+      freeText: true,
+      actions: [{ id: 'answer', label: 'Answer', kind: 'primary', key: '↵' }, { id: 'skip', label: 'Let Claude decide', kind: 'quiet', key: 's' }]
+    },
+    {
+      id: 'q-doorbell', kind: 'display', sev: 'attention', when: 'just now',
+      session: 'fix-login', machine: 'local',
+      title: '“fix-login” is asking to see this screen',
+      consequence: 'It can look but not touch — to read the staging error page you left open. Never approved automatically.',
+      durations: ['15 minutes', 'This session', 'Until I revoke it'],
+      actions: [
+        { id: 'allow', label: 'Allow 15 min', kind: 'safe', key: 'y' },
+        { id: 'deny', label: 'Not now', kind: 'quiet', key: 'n' },
+        { id: 'deny-session', label: 'Never this session', kind: 'danger' }
+      ]
+    },
+    {
+      id: 'q-ipad', kind: 'enrollment', sev: 'attention', when: '28 min ago',
+      machine: 'local',
+      title: 'A new device wants in: “Val’s iPad”',
+      consequence: 'Approving hands it a key. Spectator can watch; Operator can run work. You can revoke either, any time.',
+      roles: ['spectator', 'operator', 'session-reader'],
+      actions: [
+        { id: 'spectator', label: 'Spectator key', kind: 'safe', key: 'y' },
+        { id: 'operator', label: 'Operator key', kind: 'quiet' },
+        { id: 'deny', label: 'Deny', kind: 'danger', key: 'n', default: true }
+      ]
+    },
+    {
+      id: 'q-context', kind: 'fyi', sev: 'info', when: '12 min ago',
+      session: 'fix-login',
+      title: '“fix-login” has used 82% of its context',
+      consequence: 'It will compact soon, or you can rewind to the anchor at turn 9 if it drifts.',
+      actions: [{ id: 'open', label: 'Open session', kind: 'quiet' }, { id: 'dismiss', label: 'Got it', kind: 'quiet', key: 'x' }]
+    },
+    {
+      id: 'q-lease', kind: 'fyi', sev: 'info', when: '1 h ago',
+      machine: 'dell',
+      title: 'Workshop’s fuel lease runs out in 2 days',
+      consequence: 'It will politely go dry — nothing lost, it just stops thinking until you renew.',
+      actions: [{ id: 'renew', label: 'Renew lease', kind: 'primary' }, { id: 'dismiss', label: 'Later', kind: 'quiet', key: 'x' }]
+    }
+  ],
+
+  /* ------------------------------------------------ the Conversation --- */
+  conversation: [
+    {
+      from: 'presence', kind: 'briefing', at: '07:58',
+      prose: [
+        'Good morning, Val. Two things finished overnight, four things need you, and one machine is thirsty.',
+        'The **photo book** is done — sixty-two picks from your Christmas dump, laid out and exported. The **backup** failed once (the NAS was asleep), woke it, retried, clean. **fix-login** is fourteen turns in and has a question only you can answer.'
+      ],
+      artifacts: [
+        {
+          type: 'changes', title: 'photo-book — finished at 06:12',
+          stat: '+38 pages · 62 photos · $2.41',
+          files: ['christmas-2025.pdf (38 pages, 41 MB)', 'cover.png'],
+          link: 'files'
+        }
+      ]
+    },
+    { from: 'you', at: '08:02', text: 'lovely. show me the cover when i’m done with the queue' },
+    {
+      from: 'presence', at: '08:02',
+      prose: ['It’s waiting in Files, and I’ve pinned the cover to the top of the session. I’ll keep the queue warm for you — the deletion ask is the only one I’d read carefully; the rest are one tap each.']
+    },
+    { kind: 'milestone', text: 'docs-sweep started on Workshop · 10:07', detail: 'log lines 1–214' },
+    {
+      from: 'presence', at: '10:07',
+      prose: ['Workshop is sweeping the docs now — forty-one chapters in, no dead routes so far. It’s on the fleet name route, so it watches; it can’t touch anything here.']
+    }
+  ],
+
+  /* ------------------------------------------------ Today ribbon ------- */
+  today: [
+    { t: '02:00', label: 'nightly-backup ran', kind: 'done', note: '1 retry · clean' },
+    { t: '06:12', label: 'photo-book finished', kind: 'done' },
+    { t: '09:41', label: 'fix-login started', kind: 'done' },
+    { t: 'now', label: '4 things need you', kind: 'now' },
+    { t: '13:30', label: 'reminder: dentist 15:00', kind: 'reminder' },
+    { t: '18:00', label: 'q2-invoices check-in (scheduled)', kind: 'scheduled' },
+    { t: '02:00', label: 'nightly-backup (scheduled)', kind: 'scheduled' }
+  ],
+
+  /* ------------------------------------------------ agenda (The List) -- */
+  agenda: [
+    { id: 'a1', kind: 'task', title: 'Renew Workshop’s fuel lease', status: 'open', added: 'yesterday' },
+    { id: 'a2', kind: 'question', title: 'Should photo-book v2 use the lay-flat binding?', status: 'open', added: '06:15' },
+    { id: 'a3', kind: 'task', title: 'Nightly backup of ~/Documents + ~/Pictures', status: 'open', scheduled: 'every day · 02:00' },
+    { id: 'a4', kind: 'note', title: 'Print shop wants PDF/X-4, not PDF 1.7', status: 'open', added: 'Tue' },
+    { id: 'a5', kind: 'task', title: 'Rotate the fleet claim code after the iPad joins', status: 'done', added: 'Mon' }
+  ],
+
+  /* ------------------------------------------------ memory ------------- */
+  memory: [
+    { kind: 'preference', statement: 'Val prefers plain-language summaries; no jargon in briefings.', sensitivity: 'private', status: 'accepted', by: 'owner' },
+    { kind: 'decision', statement: 'The print shop takes PDF/X-4 only — always export both.', sensitivity: 'internal', status: 'accepted', by: 'photo-book' },
+    { kind: 'observation', statement: 'The NAS sleeps after 20 min; wake it before rsync.', sensitivity: 'internal', status: 'accepted', by: 'nightly-backup' },
+    { kind: 'procedure', statement: 'For OAuth bugs on staging, check the callback registry first.', sensitivity: 'internal', status: 'candidate', by: 'fix-login' },
+    { kind: 'episode', statement: '2026-07-16: the redirect loop turned out to be a SameSite cookie mismatch.', sensitivity: 'private', status: 'candidate', by: 'fix-login' }
+  ],
+
+  /* ------------------------------------------------ usage (Books) ------ */
+  usage: {
+    kpis: [
+      { label: 'This month', value: '$41.20', sub: 'est. across 2 fueled machines' },
+      { label: 'Tokens', value: '18.4M', sub: '61% served from prompt cache' },
+      { label: 'Sessions', value: '126', sub: '9 active today' },
+      { label: 'Cache saved', value: '$63.80', sub: 'what caching didn’t spend' }
+    ],
+    byAgent: [
+      { agent: 'Claude Code · fable', cost: 18.40, sessions: 41 },
+      { agent: 'Codex · gpt-5.2', cost: 12.10, sessions: 33 },
+      { agent: 'Native · orchestrate', cost: 7.90, sessions: 30 },
+      { agent: 'Presence · voice', cost: 2.80, sessions: 22 }
+    ],
+    heat: null, /* generated: 26 weeks × 7 */
+    disk: [
+      { what: 'Recordings', size: '12.4 GB' }, { what: 'Frames', size: '3.1 GB' },
+      { what: 'Session logs', size: '812 MB' }, { what: 'Transfers', size: '240 MB' }
+    ]
+  },
+
+  /* ------------------------------------------------ people & keys ------ */
+  people: [
+    { who: 'Val (you)', key: 'k_9f2c…a41e', role: 'owner', route: 'direct mTLS', lifecycle: 'active', since: 'Mar 2026' },
+    { who: 'Val’s iPhone', key: 'k_77b1…c902', role: 'operator', route: 'fleet name', lifecycle: 'active', since: 'Apr 2026' },
+    { who: 'Sam (partner)', key: 'k_3dd8…0f77', role: 'spectator', route: 'hosted', lifecycle: 'active', since: 'May 2026' },
+    { who: 'old laptop', key: 'k_51aa…9e0b', role: 'operator', route: '—', lifecycle: 'revoked', since: 'revoked Jun 2026' }
+  ],
+  custody: [
+    { at: '09:12', what: 'Fuel lease granted → Workshop (claude · 3 days)', by: 'you' },
+    { at: 'Tue', what: 'Vault unlocked (passkey)', by: 'you' },
+    { at: 'Tue', what: 'Deposit consumed: gemini-live ephemeral token', by: 'presence' },
+    { at: 'Mon', what: 'Lease revoked → Parlor PC (went dry)', by: 'you' },
+    { at: 'Mon', what: 'Egress relay registered: api.anthropic.com via this browser', by: 'this browser' }
+  ],
+  vault: { state: 'Locked', entries: 4, passkeys: 2, recovery: 'BIP39 · written down' },
+
+  /* ------------------------------------------------ screens ------------ */
+  displays: [
+    { id: 'disp-1', name: 'Display 1 · staging browser', machine: 'local', live: true, authority: 'agent (fix-login)', res: '2560×1440', stream: true },
+    { id: 'disp-2', name: 'Virtual display · Xvfb', machine: 'dell', live: true, authority: 'agent (docs-sweep)', res: '1920×1080', peer: true },
+    { id: 'disp-0', name: 'Your screen', machine: 'local', live: false, authority: 'you', private: true, res: '3024×1964' }
+  ],
+  recordings: [
+    { id: 'rec-1', name: 'fix-login — the redirect loop, captured', len: '2:14', when: 'yesterday', size: '88 MB' },
+    { id: 'rec-2', name: 'photo-book — layout timelapse', len: '0:48', when: '06:02', size: '31 MB' }
+  ],
+
+  /* ------------------------------------------------ files -------------- */
+  files: [
+    { path: '~/Pictures/photo-book/', kind: 'folder', children: [
+      { path: 'christmas-2025.pdf', kind: 'file', size: '41 MB', note: 'exported 06:12' },
+      { path: 'cover.png', kind: 'file', size: '3.2 MB' },
+      { path: 'picks/', kind: 'folder', children: [] }
+    ]},
+    { path: '~/projects/shopify-theme/', kind: 'folder', children: [
+      { path: 'exports/', kind: 'folder', note: '3 files pending decision', children: [] },
+      { path: 'src/auth/', kind: 'folder', children: [] }
+    ]},
+    { path: '~/Documents/', kind: 'folder', children: [] }
+  ],
+  transfers: [
+    { id: 't1', what: 'christmas-2025.pdf → Print shop upload', dir: 'up', pct: 100, state: 'done' },
+    { id: 't2', what: 'bank-export-q2.csv ← Workshop', dir: 'down', pct: 62, state: 'resumable' }
+  ],
+
+  /* ------------------------------------------------ settings rows ------ */
+  /* Every row is ⌘K-addressable; `fold` is the jump target. */
+  settings: [
+    { q: 'autonomy', section: 'How much may the house do on its own?', name: 'Autonomy', kind: 'dial',
+      aliases: 'autonomy independence freedom self-driving', value: 'Medium — gate writes',
+      gloss: 'How far the house goes before it asks.' },
+    { q: 'approvals', section: 'How much may the house do on its own?', name: 'Approval rules', kind: 'rules',
+      aliases: 'approval rules gates ask auto deny permissions', fold: 'fold-approvals',
+      rows: [
+        ['Read files', 'auto'], ['Edit & write', 'ask'], ['Delete files', 'ask'],
+        ['Run shell commands', 'ask'], ['Network egress', 'auto'], ['Destructive actions', 'deny'],
+        ['Control your display', 'ask'], ['External-agent tool calls', 'ask']
+      ] },
+    { q: 'providers', section: 'Who provides the minds?', name: 'API keys', kind: 'keys',
+      aliases: 'api keys openai anthropic gemini fuel credentials', fold: 'fold-keys',
+      rows: [['Anthropic', 'set · sk-ant-…3f9'], ['OpenAI', 'set · sk-…k21'], ['Gemini', 'not set']] },
+    { q: 'providers', section: 'Who provides the minds?', name: 'External agent defaults', kind: 'rows',
+      aliases: 'codex claude backend default agent', fold: 'fold-backends',
+      rows: [['Default backend', 'Claude Code'], ['Codex model', 'gpt-5.2-codex'], ['Codex reasoning effort', 'high'], ['Claude model', 'claude-fable']] },
+    { q: 'providers', section: 'Who provides the minds?', name: 'Codex sandbox', kind: 'rows',
+      aliases: 'writable roots sandbox workspace-write codex permissions network access', fold: 'fold-codex-sandbox',
+      rows: [['Sandbox mode', 'workspace-write'], ['Writable roots', '~/projects · /tmp'], ['Network access', 'off'], ['Web search', 'on']] },
+    { q: 'reach', section: 'How does it reach you?', name: 'Presence', kind: 'rows',
+      aliases: 'presence voice model text live', fold: 'fold-presence',
+      rows: [['Text presence', 'on · claude-sonnet'], ['Live voice', 'on · gemini-2.5-flash-live'], ['Idle timeout', '10 min']] },
+    { q: 'reach', section: 'How does it reach you?', name: 'Notifications', kind: 'rows',
+      aliases: 'notifications push badge sounds quiet hours', fold: 'fold-notify',
+      rows: [['Title badge', 'on'], ['Browser notifications', 'on'], ['Web push', 'on'], ['Quiet hours', '22:00 – 07:00']] },
+    { q: 'see', section: 'What may it see and touch?', name: 'Computer use', kind: 'rows',
+      aliases: 'computer use display screenshot recording framerate backend', fold: 'fold-cu',
+      rows: [['Backend', 'auto (SCK)'], ['Recording', 'on · 5 fps · high'], ['Your screen', 'always ask first']] },
+    { q: 'feel', section: 'How should it look and feel?', name: 'Theme & density', kind: 'appearance',
+      aliases: 'theme dark light density cozy studio appearance', fold: 'fold-appearance' },
+    { q: 'fine', section: 'The fine print', name: 'Env overrides', kind: 'rows',
+      aliases: 'env environment variables overrides debug', fold: 'fold-env',
+      rows: [['INTENDANT_MOCK_DISPLAY', '— (unset)'], ['RUST_LOG', 'info']] },
+    { q: 'fine', section: 'The fine print', name: 'Raw intendant.toml', kind: 'toml',
+      aliases: 'toml raw config file edit', fold: 'fold-toml' }
+  ],
+
+  /* ------------------------------------------------ session log sample - */
+  fixLoginLog: [
+    ['09:41:03', 'sys', 'task received — fix the OAuth redirect loop on staging'],
+    ['09:41:31', 'tool', 'Read src/auth/callback.ts (214 lines)'],
+    ['09:42:02', 'tool', 'Grep "SameSite" across src/ — 6 hits'],
+    ['09:44:20', 'note', 'found it: session cookie is SameSite=Lax; provider bounces through a cross-site POST'],
+    ['09:46:11', 'tool', 'Edit src/auth/session.ts — SameSite=None; Secure for the OAuth handshake'],
+    ['09:48:55', 'tool', 'Edit src/middleware/redirect.ts — drop the loop-back on 302 chains'],
+    ['09:52:14', 'ok', 'npm test — auth suite green (41/41)'],
+    ['10:01:37', 'ask', 'wants to delete 3 regenerated CSV dumps in exports/'],
+    ['10:03:12', 'ask', 'which callback URL should win? /auth/callback or /callback'],
+    ['10:07:44', 'doorbell', 'asking to see your screen — the staging error page you left open']
+  ],
+
+  /* ------------------------------------------------ diff sample -------- */
+  sampleDiff: [
+    ['hunk', '@@ src/auth/session.ts:41 @@'],
+    ['ctx', '  export function sessionCookie(req) {'],
+    ['del', '-   return cookie("sid", token, { sameSite: "lax", secure: true })'],
+    ['add', '+   return cookie("sid", token, { sameSite: pickSameSite(req), secure: true })'],
+    ['ctx', '  }'],
+    ['hunk', '@@ src/middleware/redirect.ts:12 @@'],
+    ['del', '-   if (seen.has(url)) return res.redirect("/login")'],
+    ['add', '+   if (seen.has(url)) return next(new LoopDetected(url))'],
+    ['ctx', '   seen.add(url)']
+  ]
+};
+
+/* Generate the 26-week activity heat deterministically */
+(function () {
+  const heat = []; let seed = 42;
+  for (let w = 0; w < 26 * 7; w++) {
+    seed = (seed * 16807) % 2147483647;
+    const r = seed % 100;
+    heat.push(r < 22 ? 0 : r < 50 ? 1 : r < 72 ? 2 : r < 90 ? 3 : 4);
+  }
+  P.data.usage.heat = heat;
+})();

--- a/docs/design/proscenium/prototype/js/icons.js
+++ b/docs/design/proscenium/prototype/js/icons.js
@@ -1,0 +1,67 @@
+/* Proscenium — icon registry. 24×24 stroke grid, 1.7 width, round caps.
+   Usage: P.icon('name') → svg string; P.mountIcons(root) fills [data-icon]. */
+window.P = window.P || {};
+
+P.ICONS = {
+  arch:      '<path d="M4.5 20 V11 Q4.5 4 12 4 Q19.5 4 19.5 11 V20"/><path d="M8 20 V12 Q8 7.5 12 7.5 Q16 7.5 16 12 V20" opacity=".45"/>',
+  stage:     '<path d="M3 17 Q12 13 21 17"/><path d="M5 17 V9 Q5 5 12 5 Q19 5 19 9 V17" opacity=".9"/><circle cx="12" cy="11" r="1.6"/>',
+  screens:   '<rect x="3" y="4.5" width="18" height="12.5" rx="2"/><path d="M9 20.5 h6 M12 17 v3.5"/>',
+  files:     '<path d="M3.5 7 Q3.5 5.5 5 5.5 h4 l2 2.5 h8 Q20.5 8 20.5 9.5 V17 Q20.5 18.5 19 18.5 H5 Q3.5 18.5 3.5 17 Z"/>',
+  machines:  '<rect x="3" y="4" width="8" height="7" rx="1.5"/><rect x="13" y="13" width="8" height="7" rx="1.5"/><path d="M7 11 v4 Q7 16.5 8.5 16.5 H13" opacity=".7"/>',
+  key:       '<circle cx="8" cy="12" r="4"/><path d="M12 12 h9 M17.5 12 v3.5 M20.5 12 v2.5"/>',
+  books:     '<path d="M5 4.5 Q5 3.5 6 3.5 H19 V17 H6.5 Q5 17 5 18.5 Q5 20 6.5 20 H19"/><path d="M5 17.5 V4.5" opacity=".6"/>',
+  settings:  '<path d="M4 7 h8 M17 7 h3 M4 16.5 h3 M12 16.5 h8"/><circle cx="14.5" cy="7" r="2.2"/><circle cx="9.5" cy="16.5" r="2.2"/>',
+  station:   '<circle cx="12" cy="12" r="2.2"/><circle cx="12" cy="12" r="6" opacity=".55"/><circle cx="12" cy="12" r="9.5" opacity=".3"/><circle cx="18.5" cy="7.5" r="1.3"/><circle cx="5.5" cy="15.5" r="1.3"/>',
+  studio:    '<path d="M9 3.5 h6 M10 3.5 V9 L4.8 18 Q4 20 6.5 20 h11 Q20 20 19.2 18 L14 9 V3.5"/><path d="M7.5 14.5 h9" opacity=".6"/>',
+  search:    '<circle cx="11" cy="11" r="6.5"/><path d="M15.8 15.8 L20.5 20.5"/>',
+  mic:       '<rect x="9" y="3" width="6" height="11" rx="3"/><path d="M5.5 11 Q5.5 16.5 12 16.5 Q18.5 16.5 18.5 11 M12 16.5 V20"/>',
+  send:      '<path d="M4.5 12 L20 4.5 L13.5 20 L11 13.5 Z"/><path d="M11 13.5 L20 4.5" opacity=".6"/>',
+  attach:    '<path d="M16 11.5 L9.8 17.7 Q8 19.5 6 17.7 Q4.2 15.9 6 14.1 L13.4 6.7 Q14.9 5.2 16.6 6.7 Q18.3 8.2 16.8 9.7 L9.5 17" />',
+  doorbell:  '<path d="M6 16 V11 Q6 6 12 6 Q18 6 18 11 V16"/><path d="M4.5 16 h15 M10 19 Q12 20.5 14 19"/>',
+  sparkle:   '<path d="M12 4 L13.8 10.2 L20 12 L13.8 13.8 L12 20 L10.2 13.8 L4 12 L10.2 10.2 Z"/>',
+  density:   '<path d="M4 6 h16 M4 12 h16 M4 18 h10" /><circle cx="18" cy="18" r="2" opacity=".7"/>',
+  theme:     '<path d="M12 3.5 A8.5 8.5 0 1 0 20.5 12 A7 7 0 0 1 12 3.5 Z"/>',
+  chev:      '<path d="M9 5.5 L15.5 12 L9 18.5"/>',
+  chevdown:  '<path d="M5.5 9 L12 15.5 L18.5 9"/>',
+  plus:      '<path d="M12 5 V19 M5 12 H19"/>',
+  check:     '<path d="M4.5 12.5 L10 18 L19.5 6.5"/>',
+  x:         '<path d="M6 6 L18 18 M18 6 L6 18"/>',
+  skip:      '<path d="M6 5 L13 12 L6 19 M13 5 L20 12 L13 19" opacity=".9"/>',
+  clock:     '<circle cx="12" cy="12" r="8.5"/><path d="M12 7 V12 L15.5 14"/>',
+  fuel:      '<path d="M12 3.5 Q17 9.5 17 13.5 A5 5 0 0 1 7 13.5 Q7 9.5 12 3.5 Z"/>',
+  shield:    '<path d="M12 3.5 L19.5 6.5 V11 Q19.5 17.5 12 20.5 Q4.5 17.5 4.5 11 V6.5 Z"/>',
+  terminal:  '<rect x="3" y="4.5" width="18" height="15" rx="2"/><path d="M7 9.5 L10.5 12.5 L7 15.5 M12.5 15.5 H17"/>',
+  camera:    '<rect x="3" y="7" width="13" height="11" rx="2"/><path d="M16 11 L21 8 V17 L16 14 Z"/>',
+  record:    '<circle cx="12" cy="12" r="8.5" opacity=".6"/><circle cx="12" cy="12" r="3.5"/>',
+  branch:    '<circle cx="6.5" cy="6" r="2.5"/><circle cx="6.5" cy="18" r="2.5"/><circle cx="17.5" cy="8" r="2.5"/><path d="M6.5 8.5 V15.5 M17.5 10.5 Q17.5 15 12 15.5 L9 15.7" opacity=".8"/>',
+  folder:    '<path d="M3.5 7 Q3.5 5.5 5 5.5 h4 l2 2.5 h8 Q20.5 8 20.5 9.5 V17 Q20.5 18.5 19 18.5 H5 Q3.5 18.5 3.5 17 Z"/>',
+  file:      '<path d="M6 3.5 H14 L18.5 8 V20.5 H6 Z"/><path d="M13.5 3.5 V8.5 H18.5" opacity=".6"/>',
+  external:  '<path d="M10 5.5 H5.5 V18.5 H18.5 V14"/><path d="M13.5 4.5 H19.5 V10.5 M19.5 4.5 L11 13" opacity=".8"/>',
+  pause:     '<path d="M8.5 5.5 V18.5 M15.5 5.5 V18.5"/>',
+  stop:      '<rect x="6.5" y="6.5" width="11" height="11" rx="1.5"/>',
+  play:      '<path d="M8 5.5 L18.5 12 L8 18.5 Z"/>',
+  refresh:   '<path d="M19.5 12 A7.5 7.5 0 1 1 17.2 6.3 M17.5 3.5 V7 H14" />',
+  info:      '<circle cx="12" cy="12" r="8.5" opacity=".7"/><path d="M12 11 V16.5 M12 7.5 V8"/>',
+  warn:      '<path d="M12 4 L21 19.5 H3 Z"/><path d="M12 10 V14.5 M12 16.8 V17.3"/>',
+  question:  '<circle cx="12" cy="12" r="8.5" opacity=".7"/><path d="M9.5 9.5 Q9.5 7.5 12 7.5 Q14.5 7.5 14.5 9.5 Q14.5 11 12.5 11.8 Q12 12.2 12 13.5 M12 16.3 V16.8"/>',
+  trash:     '<path d="M5 7 H19 M9.5 7 V5 Q9.5 4 10.5 4 h3 Q14.5 4 14.5 5 V7 M7 7 L7.8 19 Q7.9 20 9 20 h6 Q16.1 20 16.2 19 L17 7"/>',
+  eye:       '<path d="M3 12 Q7.5 5.5 12 5.5 Q16.5 5.5 21 12 Q16.5 18.5 12 18.5 Q7.5 18.5 3 12 Z"/><circle cx="12" cy="12" r="2.8"/>',
+  hand:      '<path d="M8 11.5 V5.5 Q8 4 9.3 4 Q10.6 4 10.6 5.5 V10 M10.6 10 V3.8 Q10.6 2.6 11.8 2.6 Q13 2.6 13 3.8 V10 M13 10 V5 Q13 3.8 14.2 3.8 Q15.4 3.8 15.4 5 V11 M15.4 11.5 L17 9.8 Q18 8.8 19 9.8 Q20 10.8 19 11.8 L14.5 17 Q12.5 20 9.5 19.5 Q7 19 5.8 16.5 L4.5 13.5 Q4 12 5.2 11.3 Q6.4 10.6 7.3 12 L8 13.5"/>',
+  layers:    '<path d="M12 3.5 L21 8.5 L12 13.5 L3 8.5 Z"/><path d="M4.5 12.5 L12 16.5 L19.5 12.5 M4.5 16.5 L12 20.5 L19.5 16.5" opacity=".55"/>',
+  history:   '<path d="M4 12 A8 8 0 1 1 6 6.5 M4 3.5 V7 H7.5" /><path d="M12 8 V12 L15 14" opacity=".8"/>',
+  download:  '<path d="M12 4 V14.5 M7.5 10.5 L12 15 L16.5 10.5 M4.5 18.5 H19.5"/>',
+  upload:    '<path d="M12 15 V4.5 M7.5 9 L12 4.5 L16.5 9 M4.5 18.5 H19.5"/>',
+};
+
+P.icon = function (name, size) {
+  const d = P.ICONS[name] || P.ICONS.info;
+  const s = size || 18;
+  return '<svg viewBox="0 0 24 24" width="' + s + '" height="' + s + '" fill="none" stroke="currentColor"' +
+    ' stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' + d + '</svg>';
+};
+
+P.mountIcons = function (root) {
+  (root || document).querySelectorAll('[data-icon]').forEach(function (el) {
+    if (!el.dataset.mounted) { el.innerHTML = P.icon(el.dataset.icon); el.dataset.mounted = '1'; }
+  });
+};

--- a/docs/design/proscenium/prototype/js/palette.js
+++ b/docs/design/proscenium/prototype/js/palette.js
@@ -1,0 +1,210 @@
+/* Proscenium — the universal index (⌘K).
+   Lanes: Actions · Go to · Settings · Search deeper. Register-blind: the
+   index always speaks instrument vocabulary regardless of density.
+   Jump-and-flash: settings land on their exact folded row. */
+window.P = window.P || {};
+
+P.palette = (function () {
+  let sel = 0, items = [], deepTimer = null;
+
+  const overlay = () => document.getElementById('palette');
+  const input = () => document.getElementById('palette-input');
+  const results = () => document.getElementById('palette-results');
+
+  /* ---------------- index sources ---------------- */
+  function roomItems() {
+    return P.ROOMS.map(r => ({
+      lane: 'Go to', name: r.title, hint: r.gloss, icon: r.icon,
+      run: () => P.go('#/' + r.id)
+    }));
+  }
+  function objectItems() {
+    const out = [];
+    P.data.sessions.forEach(s => out.push({
+      lane: 'Go to', name: s.name, hint: 'session · ' + s.backend + ' · ' + P.machineName(s.machine),
+      icon: 'stage', run: () => P.go('#/work/session/' + s.id)
+    }));
+    P.data.machines.forEach(m => out.push({
+      lane: 'Go to', name: m.petname, hint: 'machine · ' + m.label + ' · via ' + m.route,
+      icon: 'machines', run: () => P.go('#/machines/' + m.id)
+    }));
+    P.data.people.forEach(p => out.push({
+      lane: 'Go to', name: p.who, hint: 'key · ' + p.role + ' · ' + p.lifecycle,
+      icon: 'key', run: () => P.go('#/people')
+    }));
+    P.data.displays.forEach(d => out.push({
+      lane: 'Go to', name: d.name, hint: 'display · ' + (d.live ? 'live' : 'private'),
+      icon: 'screens', run: () => P.go('#/screens')
+    }));
+    P.data.agenda.forEach(a => out.push({
+      lane: 'Go to', name: a.title, hint: 'the list · ' + a.kind + ' · ' + a.status,
+      icon: 'books', run: () => P.go('#/books')
+    }));
+    return out;
+  }
+  function settingsItems() {
+    const out = [];
+    P.data.settings.forEach(row => {
+      const mk = (name, hint) => ({
+        lane: 'Settings', name: name, hint: hint, icon: 'settings',
+        run: () => { P.go('#/settings'); setTimeout(() => P.flashTarget(row.fold || ''), 60); }
+      });
+      out.push(mk(row.name, row.section));
+      (row.rows || []).forEach(r => out.push(mk(r[0], row.name + ' · ' + row.section)));
+    });
+    return out;
+  }
+  function actionItems() {
+    const top = P.queueStore.pending()[0];
+    const out = [
+      {
+        lane: 'Actions', name: 'New session', hint: 'give the house work', icon: 'plus',
+        run: () => P.go('#/work/new')
+      },
+      {
+        lane: 'Actions', name: 'Pair a machine', hint: 'grow the fleet', icon: 'machines',
+        run: () => { P.go('#/machines'); setTimeout(() => P.flashTarget('fold-pairing'), 60); }
+      },
+      {
+        lane: 'Actions', name: 'Fuel from your vault', hint: 'keys & leases', icon: 'fuel',
+        run: () => { P.go('#/people'); setTimeout(() => P.flashTarget('fold-vault'), 60); }
+      },
+      {
+        lane: 'Actions', name: 'Renew Workshop’s lease', hint: '2 days left', icon: 'fuel',
+        run: () => P.toast('Lease renewed — Workshop stays fueled', 'sage')
+      },
+      {
+        lane: 'Actions', name: 'Take control of Display 1', hint: 'input authority', icon: 'hand',
+        run: () => P.go('#/screens')
+      },
+      {
+        lane: 'Actions', name: 'Stop “fix-login”', hint: 'interrupt the turn', icon: 'stop',
+        run: () => P.toast('Interrupt sent to fix-login', 'brick')
+      },
+      {
+        lane: 'Actions', name: 'Flip theme', hint: 'lamplight ⇄ daylight', icon: 'theme',
+        run: () => P.cycleTheme()
+      },
+      {
+        lane: 'Actions', name: 'Cycle density', hint: 'cozy · standard · studio', icon: 'density',
+        run: () => P.cycleDensity()
+      },
+      {
+        lane: 'Actions', name: 'Show keyboard map', hint: '?', icon: 'question',
+        run: () => P.showShortcuts()
+      }
+    ];
+    if (top) {
+      out.unshift(
+        {
+          lane: 'Actions', name: 'Approve: ' + top.title, hint: 'top of the queue · y', icon: 'check',
+          run: () => P.queueStore.resolve(top.id, top.actions[0].id)
+        },
+        {
+          lane: 'Actions', name: 'Deny: ' + top.title, hint: 'top of the queue · n', icon: 'x',
+          run: () => P.queueStore.resolve(top.id, 'deny')
+        }
+      );
+    }
+    return out;
+  }
+  function deepItems(q) {
+    if (!q || q.length < 3) return [];
+    const hits = [];
+    const needle = q.toLowerCase();
+    P.data.fixLoginLog.forEach(l => {
+      if (l[2].toLowerCase().includes(needle))
+        hits.push({ lane: 'Search deeper', name: l[2], hint: 'fix-login · ' + l[0], icon: 'search', run: () => P.go('#/work/session/fix-login') });
+    });
+    P.data.sessions.forEach(s => {
+      if (s.task.toLowerCase().includes(needle))
+        hits.push({ lane: 'Search deeper', name: s.task.slice(0, 80) + '…', hint: s.name, icon: 'search', run: () => P.go('#/work/session/' + s.id) });
+    });
+    return hits.slice(0, 4);
+  }
+
+  /* ---------------- fuzzy ---------------- */
+  function score(q, item) {
+    const hay = (item.name + ' ' + (item.hint || '') + ' ' + (item.aliases || '')).toLowerCase();
+    const needle = q.toLowerCase().trim();
+    if (!needle) return 1;
+    if (hay.startsWith(needle)) return 100;
+    const nameLow = item.name.toLowerCase();
+    if (nameLow.startsWith(needle)) return 90;
+    if (nameLow.includes(needle)) return 70;
+    if (hay.includes(needle)) return 50;
+    // subsequence
+    let i = 0;
+    for (const c of hay) if (c === needle[i]) i++;
+    return i === needle.length ? 25 : 0;
+  }
+
+  /* alias lookup for settings vocabulary */
+  function withAliases(it) {
+    const row = P.data.settings.find(r => r.name === it.name || (r.rows || []).some(x => x[0] === it.name));
+    if (row) it.aliases = row.aliases || '';
+    return it;
+  }
+
+  /* ---------------- render ---------------- */
+  function render() {
+    const q = input().value;
+    const all = [...actionItems(), ...roomItems(), ...objectItems(), ...settingsItems().map(withAliases)];
+    let matched = all.map(it => ({ it, s: score(q, it) })).filter(x => x.s > 0);
+    matched.sort((a, b) => b.s - a.s);
+    matched = matched.slice(0, 14);
+    const deep = deepItems(q);
+    items = matched.map(x => x.it).concat(deep);
+
+    const lanes = [];
+    let lastLane = null;
+    const html = items.map((it, idx) => {
+      let h = '';
+      if (it.lane !== lastLane) { h += '<div class="pal-lane">' + P.esc(it.lane) + '</div>'; lastLane = it.lane; }
+      h += '<div class="pal-item' + (idx === sel ? ' sel' : '') + '" data-idx="' + idx + '">' +
+        P.ICON(it.icon || 'chev', 15) +
+        '<span class="pal-name">' + P.esc(it.name) + '</span>' +
+        (it.hint ? '<span class="pal-hint">' + P.esc(it.hint) + '</span>' : '') + '</div>';
+      return h;
+    }).join('');
+    results().innerHTML = html || '<div class="pal-lane">No matches — the index covers every room, object, and setting.</div>';
+
+    results().querySelectorAll('.pal-item').forEach(el => {
+      el.addEventListener('click', () => choose(+el.dataset.idx));
+      el.addEventListener('mousemove', () => { sel = +el.dataset.idx; paint(); });
+    });
+  }
+  function paint() {
+    results().querySelectorAll('.pal-item').forEach(el => el.classList.toggle('sel', +el.dataset.idx === sel));
+  }
+  function choose(idx) {
+    const it = items[idx]; if (!it) return;
+    close();
+    setTimeout(() => it.run(), 10);
+  }
+
+  function onKey(e) {
+    if (e.key === 'ArrowDown') { e.preventDefault(); sel = Math.min(sel + 1, items.length - 1); paint(); scrollSel(); }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); sel = Math.max(sel - 1, 0); paint(); scrollSel(); }
+    else if (e.key === 'Enter') { e.preventDefault(); choose(sel); }
+    else if (e.key === 'Escape') { close(); }
+  }
+  function scrollSel() {
+    const el = results().querySelector('.pal-item.sel');
+    if (el) el.scrollIntoView({ block: 'nearest' });
+  }
+
+  function open() {
+    sel = 0;
+    overlay().hidden = false;
+    input().value = '';
+    render();
+    setTimeout(() => input().focus(), 20);
+    input().oninput = () => { sel = 0; render(); };
+    input().onkeydown = onKey;
+    overlay().onclick = e => { if (e.target === overlay()) close(); };
+  }
+  function close() { overlay().hidden = true; }
+
+  return { open, close, get isOpen() { return !overlay().hidden; } };
+})();

--- a/docs/design/proscenium/prototype/js/ui.js
+++ b/docs/design/proscenium/prototype/js/ui.js
@@ -1,0 +1,233 @@
+/* Proscenium — shared UI helpers (the component contract).
+   Every view renders through these; improvise nothing per-room. */
+window.P = window.P || {};
+
+/* ---------- tiny DOM ---------- */
+P.h = function (tag, cls, html) {
+  const e = document.createElement(tag);
+  if (cls) e.className = cls;
+  if (html != null) e.innerHTML = html;
+  return e;
+};
+P.esc = function (s) {
+  return String(s).replace(/[&<>"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+};
+P.ICON = function (name, size) { return '<span class="icon">' + P.icon(name, size) + '</span>'; };
+
+/* ---------- preferences (theme/density handled in app.js) ---------- */
+P.store = {
+  get(k, dflt) { try { const v = localStorage.getItem('proscenium.' + k); return v == null ? dflt : JSON.parse(v); } catch { return dflt; } },
+  set(k, v) { try { localStorage.setItem('proscenium.' + k, JSON.stringify(v)); } catch {} }
+};
+P.density = () => document.documentElement.dataset.density || 'standard';
+
+/* ---------- chips, dots, facts ---------- */
+P.chip = function (label, kind, iconName) {
+  return '<span class="chip' + (kind ? ' chip-' + kind : '') + '">' +
+    (iconName ? P.ICON(iconName, 13) : '') + P.esc(label) + '</span>';
+};
+P.dot = function (kind, pulse) { return '<span class="dot dot-' + kind + (pulse ? ' dot-pulse' : '') + '"></span>'; };
+P.fact = function (s) { return '<span class="fact">' + P.esc(s) + '</span>'; };
+P.meter = function (pct, cls) {
+  const tone = cls || (pct >= 90 ? 'hot' : pct >= 70 ? 'warn' : '');
+  return '<span class="meter" title="' + pct + '%"><span class="meter-fill ' + tone + '" style="width:' + pct + '%"></span></span>';
+};
+P.machineName = function (id) {
+  const m = P.data.machines.find(m => m.id === id);
+  return m ? m.petname : id;
+};
+P.routeChip = function (route) {
+  const kind = route === 'direct' ? 'sage' : route === 'fleet name' ? 'slate' : 'violet';
+  return P.chip('via ' + route, kind);
+};
+P.authline = function (who, role, route) {
+  return '<div class="authline">' + P.ICON('shield', 13) +
+    '<span class="who">' + P.esc(who) + ' · ' + P.esc(role) + '</span>' +
+    (route ? P.routeChip(route) : '') + '</div>';
+};
+
+/* ---------- folds (disclosure contract; remembers state; studio opens) ---------- */
+P.fold = function (opts) {
+  // opts: {key, title, note, body, open}
+  const key = opts.key ? 'fold.' + opts.key : null;
+  const remembered = key ? P.store.get(key, null) : null;
+  const studio = P.density() === 'studio';
+  const open = remembered != null ? remembered : (opts.open != null ? opts.open : studio);
+  const d = P.h('details', 'fold');
+  if (key) d.dataset.key = key;
+  if (opts.id) d.id = opts.id;
+  if (open) d.setAttribute('open', '');
+  d.innerHTML = '<summary>' + P.ICON('chev', 15).replace('class="icon"', 'class="icon chev"') +
+    '<span>' + P.esc(opts.title) + '</span>' +
+    (opts.note ? '<span class="fold-note">' + P.esc(opts.note) + '</span>' : '') + '</summary>' +
+    '<div class="fold-body">' + opts.body + '</div>';
+  d.addEventListener('toggle', function () {
+    if (key) P.store.set(key, d.open);
+  });
+  return d;
+};
+P.foldHtml = function (opts) { const d = P.fold(opts); return d.outerHTML; };
+
+/* jump-and-flash: open a fold by id and flash it (⌘K landing) */
+P.flashTarget = function (id) {
+  requestAnimationFrame(() => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    if (el.tagName === 'DETAILS') el.open = true;
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    el.classList.remove('flash'); void el.offsetWidth; el.classList.add('flash');
+  });
+};
+
+/* ---------- cards ---------- */
+P.card = function (opts) {
+  // {title, sub, actions, body, cls}
+  return '<div class="card ' + (opts.cls || '') + '">' +
+    (opts.title ? '<div class="card-head"><div><h3 class="card-title">' + opts.title + '</h3>' +
+      (opts.sub ? '<div class="card-sub">' + opts.sub + '</div>' : '') + '</div>' +
+      (opts.actions ? '<div class="card-actions">' + opts.actions + '</div>' : '') + '</div>' : '') +
+    (opts.body || '') + '</div>';
+};
+
+/* ---------- stage card (live work) ---------- */
+P.stageCard = function (s) {
+  const tone = s.queue && s.queue.length ? 'attention' : s.peer ? 'peer' : s.phase === 'done' ? 'done' : '';
+  const facts = [];
+  facts.push(P.fact(s.backend + ' · ' + s.model));
+  if (s.turn) facts.push(P.fact('turn ' + s.turn));
+  if (s.tokens) facts.push('<span class="fact">' + s.tokens.pct + '% ctx</span>' + P.meter(s.tokens.pct));
+  if (s.cost != null) facts.push(P.fact('$' + s.cost.toFixed(2)));
+  return '<a class="stage-card ' + tone + '" href="#/work/session/' + s.id + '">' +
+    '<div class="stage-body">' +
+    '<div class="stage-name">' + (s.phase === 'working' ? P.dot('sage', true) : s.phase === 'idle' ? P.dot('slate') : P.dot('slate')) +
+      P.esc(s.name) +
+      (s.peer ? P.chip(P.machineName(s.machine), 'violet') : '') +
+      (s.queue && s.queue.length ? P.chip('needs you', 'attn', 'doorbell') : '') + '</div>' +
+    '<div class="stage-sentence">' + P.esc(s.sentence) + '</div>' +
+    '<div class="stage-facts">' + facts.join('') + '</div>' +
+    '</div></a>';
+};
+
+/* ---------- decision card (the Queue) ---------- */
+P.decisionCard = function (q, opts) {
+  opts = opts || {};
+  if (P.queueStore.isResolved(q.id)) return '';
+  const isFyi = q.kind === 'fyi';
+  let actions = q.actions.map(a =>
+    '<button class="btn ' + (a.kind === 'primary' ? 'btn-primary' : a.kind === 'safe' ? 'btn-safe' : a.kind === 'danger' ? 'btn-danger' : 'btn-quiet') +
+    (a.default && !isFyi ? ' btn-default' : '') + '" data-q="' + q.id + '" data-action="' + a.id + '">' +
+    P.esc(a.label) + (a.key ? ' <span class="kbd-hint">' + a.key + '</span>' : '') + '</button>').join('');
+  let extra = '';
+  if (q.options) {
+    extra += '<div class="col" style="gap:6px;margin:4px 0 10px">' + q.options.map((o, i) =>
+      '<label class="row" style="gap:8px"><input type="radio" name="' + q.id + '-opt" ' + (i === 0 ? 'checked' : '') + '> <span>' + P.esc(o) + '</span></label>').join('') +
+      (q.freeText ? '<input class="input" placeholder="or say it in your own words…" style="margin-top:4px">' : '') + '</div>';
+  }
+  if (q.durations) {
+    extra += '<div class="row" style="gap:6px;margin:2px 0 10px">' + q.durations.map((d, i) =>
+      '<span class="chip' + (i === 0 ? ' chip-sage' : '') + '">' + d + '</span>').join('') + '</div>';
+  }
+  if (q.roles) {
+    extra += '<div class="dim" style="font-size:12.5px;margin:2px 0 8px">' +
+      'A <b>spectator</b> watches. An <b>operator</b> runs work and touches screens, but can’t hand out keys.</div>';
+  }
+  const details = q.details ? '<details class="fold" style="margin:8px 0 10px"><summary>' +
+    '<span class="icon chev">' + P.icon('chev', 15) + '</span><span>details</span>' +
+    '<span class="fold-note">' + P.esc(q.category || q.kind) + '</span></summary><div class="fold-body">' +
+    (q.details.command ? '<div class="panel mono" style="margin-bottom:8px">$ ' + P.esc(q.details.command) + '</div>' : '') +
+    (q.details.paths ? '<div class="col" style="gap:3px;margin-bottom:8px">' + q.details.paths.map(p => '<span class="mono" style="font-size:12px">✕ ' + P.esc(p) + '</span>').join('') + '</div>' : '') +
+    (q.details.rule ? '<div class="dim" style="font-size:12.5px;margin-bottom:8px">' + P.esc(q.details.rule) + '</div>' : '') +
+    '<div class="log dim" style="font-size:11.5px">' + P.esc(q.details.raw) + '</div>' +
+    '</div></details>' : '';
+  return '<div class="decision' + (isFyi ? ' fyi' : '') + '" data-qcard="' + q.id + '">' +
+    '<div class="decision-head">' +
+      (isFyi ? P.chip('for your awareness', 'slate', 'info') : P.chip('needs you · ' + (q.category || q.kind), 'attn', 'doorbell')) +
+      '<span class="grow"></span><span class="fact">' + q.when + '</span></div>' +
+    '<div class="decision-title">' + P.esc(q.title) + '</div>' +
+    '<div class="decision-consequence">' + P.esc(q.consequence) + '</div>' +
+    extra + details +
+    '<div class="decision-actions">' + actions + '</div>' +
+    P.authline('you', 'owner', 'direct') +
+    '</div>';
+};
+
+/* ---------- queue store (shared: Home, drawer, badge) ---------- */
+P.queueStore = {
+  resolved: P.store.get('queue.resolved', {}),
+  isResolved(id) { return !!this.resolved[id]; },
+  resolve(id, action) {
+    this.resolved[id] = { action: action, at: Date.now() };
+    P.store.set('queue.resolved', this.resolved);
+    const q = P.data.queue.find(x => x.id === id);
+    P.toast(this.toastFor(q, action), q && (action === 'deny' || action === 'deny-session') ? 'brick' : 'sage');
+    document.querySelectorAll('[data-qcard="' + id + '"]').forEach(c => {
+      c.classList.add('resolved'); setTimeout(() => c.remove(), 320);
+    });
+    setTimeout(() => P.renderQueueBadge(), 300);
+  },
+  toastFor(q, action) {
+    if (!q) return 'Done';
+    const map = {
+      approve: 'Allowed once — the house carries on', always: 'Rule set: ' + (q.category || '') + ' → Auto for this project',
+      deny: 'Denied — nothing was touched', 'deny-session': 'Denied for this session',
+      answer: 'Answer sent', skip: 'The house will decide', spectator: 'Spectator key issued', operator: 'Operator key issued',
+      dismiss: 'Noted', open: 'Opening…', renew: 'Lease renewed — Workshop stays fueled', allow: 'Screen shared for 15 minutes'
+    };
+    return map[action] || 'Resolved';
+  },
+  pending() { return P.data.queue.filter(q => !this.isResolved(q.id) && q.kind !== 'fyi'); },
+  fyis() { return P.data.queue.filter(q => !this.isResolved(q.id) && q.kind === 'fyi'); }
+};
+
+/* ---------- empty state & skeleton ---------- */
+P.empty = function (glyph, title, hint, actionHtml) {
+  return '<div class="empty"><div class="empty-glyph">' + P.ICON(glyph, 34) + '</div>' +
+    '<div class="empty-title">' + P.esc(title) + '</div>' +
+    '<div class="empty-hint">' + P.esc(hint) + '</div>' + (actionHtml || '') + '</div>';
+};
+P.skeleton = function (h, w) {
+  return '<div class="skeleton" style="height:' + (h || 14) + 'px;width:' + (w || '100%') + '"></div>';
+};
+
+/* ---------- toast ---------- */
+P.toast = function (msg, tone) {
+  const t = P.h('div', 'toast ' + (tone || ''), P.ICON(tone === 'brick' ? 'x' : 'check', 15) + '<span>' + P.esc(msg) + '</span>');
+  document.getElementById('toasts').appendChild(t);
+  setTimeout(() => { t.style.opacity = '0'; t.style.transition = 'opacity .3s'; setTimeout(() => t.remove(), 320); }, 3200);
+};
+
+/* ---------- page scaffold ---------- */
+P.page = function (opts) {
+  // {eyebrow, title, sub, body}
+  return '<div class="page">' +
+    (opts.eyebrow ? '<div class="eyebrow">' + P.esc(opts.eyebrow) + '</div>' : '') +
+    (opts.title ? '<h1 class="page-title">' + opts.title + '</h1>' : '') +
+    (opts.sub ? '<div class="page-sub">' + opts.sub + '</div>' : '') +
+    opts.body + '</div>';
+};
+P.section = function (label) {
+  return '<div class="section-head"><span class="eyebrow">' + P.esc(label) + '</span><span class="line"></span></div>';
+};
+
+/* ---------- global click delegation for queue actions ---------- */
+document.addEventListener('click', function (e) {
+  const b = e.target.closest('[data-q][data-action]');
+  if (!b) return;
+  const qid = b.dataset.q, action = b.dataset.action;
+  if (action === 'open') { location.hash = '#/work/session/fix-login'; return; }
+  P.queueStore.resolve(qid, action);
+});
+
+/* helpers */
+P.row = function (html, gap) { return '<div class="row" style="display:flex;align-items:center;gap:' + (gap || 8) + 'px">' + html + '</div>'; };
+P.col = function (html, gap) { return '<div class="col" style="display:flex;flex-direction:column;gap:' + (gap || 8) + 'px">' + html + '</div>'; };
+P.logLines = function (lines) {
+  return '<div class="log">' + lines.map(l =>
+    '<div><span class="lt">' + l[0] + '</span> <span class="' +
+    (l[1] === 'tool' ? 'tool' : l[1] === 'ok' ? 'ok' : l[1] === 'err' || l[1] === 'ask' ? 'err' : '') + '">' +
+    P.esc(l[2]) + '</span></div>').join('') + '</div>';
+};
+P.diffHtml = function (rows) {
+  return '<div class="diff">' + rows.map(r =>
+    '<span class="diff-' + r[0] + '">' + P.esc(r[1]) + '</span>').join('') + '</div>';
+};

--- a/docs/design/proscenium/prototype/js/views/books.js
+++ b/docs/design/proscenium/prototype/js/views/books.js
@@ -1,0 +1,189 @@
+/* Proscenium — Books: the ledgers.
+   Costs & usage → the List → what the house remembers → reports. */
+window.P = window.P || {};
+P.views = P.views || {};
+
+P.views.books = {
+  title: 'Books',
+
+  render(el) {
+    const u = P.data.usage;
+
+    el.innerHTML = P.page({
+      eyebrow: 'the ledgers',
+      title: 'Books',
+      sub: 'What the house spent, what’s parked for later, and what it remembers. Every number is the daemon’s own bookkeeping — no estimates invented here.',
+      body:
+        /* ---------- Costs & usage ---------- */
+        P.section('Costs & usage') +
+        '<div class="bks-kpis">' +
+          u.kpis.map(k =>
+            '<div class="card bks-kpi">' +
+              '<div class="bks-kpi-value">' + P.esc(k.value) + '</div>' +
+              '<div class="bks-kpi-label">' + P.esc(k.label) + '</div>' +
+              '<div class="dim" style="font-size:12px;margin-top:2px">' + P.esc(k.sub) + '</div>' +
+            '</div>').join('') +
+        '</div>' +
+
+        '<div class="grid grid-2">' +
+          P.card({
+            title: 'By agent — this month', sub: 'estimated cost · sessions', cls: 'bks-costbar',
+            body: '<table class="table"><tbody>' +
+              u.byAgent.map(a => {
+                const max = u.byAgent[0].cost;
+                return '<tr><td>' + P.esc(a.agent) + '</td>' +
+                  '<td class="mono">' + a.sessions + '</td>' +
+                  '<td class="mono">$' + a.cost.toFixed(2) + '</td>' +
+                  '<td style="width:34%">' + P.row(P.meter(Math.round(a.cost / max * 100), 'flat')) + '</td></tr>';
+              }).join('') + '</tbody></table>'
+          }) +
+          P.card({
+            title: 'Disk', sub: 'what the house keeps on this machine',
+            body: '<table class="table"><tbody>' +
+              u.disk.map(d =>
+                '<tr><td>' + P.esc(d.what) + '</td><td class="mono" style="text-align:right">' + P.esc(d.size) + '</td></tr>').join('') +
+              '</tbody></table>' +
+              '<div class="dim" style="font-size:12px;margin-top:8px">Per-kind deletion lives with each session — the report zips below are the audit trail.</div>'
+          }) +
+        '</div>' +
+
+        P.card({
+          title: 'Activity — the last 26 weeks', sub: 'sessions per day, any machine',
+          body:
+            '<div class="heat bks-heat">' +
+              u.heat.map(v => '<i' + (v ? ' class="l' + v + '"' : '') + '></i>').join('') +
+            '</div>' +
+            '<div class="row bks-heat-legend">' +
+              '<span class="fact">less</span><i></i><i class="l1"></i><i class="l2"></i><i class="l3"></i><i class="l4"></i><span class="fact">more</span>' +
+              '<span class="grow"></span>' + P.fact('9 active today · 61% cache-served') +
+            '</div>'
+        }) +
+
+        /* ---------- The List ---------- */
+        P.section('The List — parked for later') +
+        '<div class="card">' +
+          '<div id="bks-list">' + this.listHtml() + '</div>' +
+          '<div class="row" style="margin-top:10px;padding-top:12px;border-top:1px solid var(--line)">' +
+            '<input class="input" id="bks-add" placeholder="Park a task, note, or question — the house will surface it…" style="flex:1;min-width:220px">' +
+            '<button class="btn btn-quiet" id="bks-add-btn">' + P.ICON('plus', 14) + ' Add</button>' +
+          '</div>' +
+        '</div>' +
+
+        P.card({
+          title: 'Scheduled sessions', sub: 'the daemon’s scheduler fires these — Today on Home shows the same',
+          body:
+            '<div class="row" style="flex-wrap:wrap">' +
+              P.ICON('clock', 15) + '<b>nightly-backup</b>' +
+              P.chip('every day · 02:00', 'brass', 'clock') +
+              P.fact('next tonight · ran clean at 02:00') +
+              '<span class="grow"></span>' +
+              '<button class="btn btn-quiet btn-xs" data-sched="pause">pause</button>' +
+              '<button class="btn btn-danger btn-xs" data-sched="revoke">revoke</button>' +
+            '</div>'
+        }) +
+
+        /* ---------- What the house remembers ---------- */
+        P.section('What the house remembers') +
+        '<div class="grid grid-2" id="bks-mem">' + this.memHtml() + '</div>' +
+        '<div class="card">' +
+          '<div class="row" style="gap:8px;flex-wrap:wrap">' +
+            '<select class="input" id="bks-mem-kind">' +
+              ['preference', 'decision', 'observation', 'procedure', 'episode'].map(k => '<option>' + k + '</option>').join('') +
+            '</select>' +
+            '<input class="input" id="bks-mem-text" placeholder="A claim the house should consider…" style="flex:1;min-width:240px">' +
+            '<button class="btn btn-primary" id="bks-mem-btn">Propose</button>' +
+          '</div>' +
+          '<div class="dim" style="margin-top:10px;font-size:12.5px">New claims land as <b>candidates</b> — nothing is accepted until the house argues it through. And the honest caveat: this plane is ephemeral in this build — restart forgets.</div>' +
+        '</div>' +
+
+        /* ---------- Reports & history ---------- */
+        P.section('Reports & history') +
+        P.card({
+          title: 'Session reports', sub: 'the full audit trail, zipped — logs, frames, decisions',
+          body:
+            '<div class="row" style="gap:8px;flex-wrap:wrap">' +
+              P.data.sessions.filter(s => s.phase === 'done' || s.phase === 'archived').map(s =>
+                '<button class="btn btn-quiet btn-xs" data-report="' + P.esc(s.id) + '">' +
+                P.ICON('download', 13) + ' ' + P.esc(s.name) + ' .zip</button>').join('') +
+            '</div>' +
+            '<div class="dim" style="margin-top:10px;font-size:12px">Deep search across full logs lives in ⌘K — three or more characters, under “Search deeper”.</div>'
+        })
+    });
+
+    this.wire(el);
+  },
+
+  listHtml() {
+    return P.data.agenda.map(a =>
+      '<div class="bks-item row" data-ag="' + P.esc(a.id) + '" title="click to ' + (a.status === 'done' ? 'reopen' : 'complete') + '">' +
+        '<span class="bks-check">' + (a.status === 'done' ? P.ICON('check', 12) : '') + '</span>' +
+        P.chip(a.kind, a.kind === 'task' ? 'slate' : a.kind === 'question' ? 'attn' : 'brass') +
+        '<span class="bks-item-title' + (a.status === 'done' ? ' done' : '') + '">' + P.esc(a.title) + '</span>' +
+        (a.scheduled ? P.chip(a.scheduled, 'brass', 'clock') : '') +
+        '<span class="grow"></span>' +
+        P.chip(a.status === 'done' ? 'done' : 'open', a.status === 'done' ? 'sage' : 'slate') +
+        (a.added ? P.fact('added ' + a.added) : '') +
+      '</div>').join('');
+  },
+
+  memHtml() {
+    return P.data.memory.map(m =>
+      '<div class="card">' +
+        '<div class="row" style="gap:6px;flex-wrap:wrap">' +
+          P.chip(m.kind, 'slate') +
+          P.chip(m.sensitivity, m.sensitivity === 'private' ? 'brick' : 'slate') +
+          P.chip(m.status, m.status === 'accepted' ? 'sage' : 'attn') +
+          '<span class="grow"></span>' + P.fact('by ' + m.by) +
+        '</div>' +
+        '<div style="margin-top:8px;font-size:13.5px">' + P.esc(m.statement) + '</div>' +
+      '</div>').join('');
+  },
+
+  wire(el) {
+    const rewiredList = () => {
+      el.querySelector('#bks-list').innerHTML = this.listHtml();
+      wireList();
+    };
+    const wireList = () => {
+      el.querySelectorAll('[data-ag]').forEach(r => r.addEventListener('click', () => {
+        const a = P.data.agenda.find(x => x.id === r.dataset.ag);
+        if (!a) return;
+        a.status = a.status === 'done' ? 'open' : 'done';
+        rewiredList();
+        P.toast(a.status === 'done' ? 'Marked done — the house stops nudging' : 'Reopened — back on the list', a.status === 'done' ? 'sage' : null);
+      }));
+    };
+    wireList();
+
+    const addBtn = el.querySelector('#bks-add-btn');
+    const addInput = el.querySelector('#bks-add');
+    const addItem = () => {
+      const text = (addInput.value || '').trim();
+      if (!text) { addInput.focus(); return; }
+      P.data.agenda.push({ id: 'a' + Date.now(), kind: 'task', title: text, status: 'open', added: 'now' });
+      addInput.value = '';
+      rewiredList();
+      P.toast('On the list — the house will surface it', 'sage');
+    };
+    addBtn.addEventListener('click', addItem);
+    addInput.addEventListener('keydown', e => { if (e.key === 'Enter') addItem(); });
+
+    el.querySelectorAll('[data-sched]').forEach(b => b.addEventListener('click', () => {
+      if (b.dataset.sched === 'pause') P.toast('nightly-backup paused — the scheduler holds its fire', null);
+      else P.toast('Schedule revoked — 02:00 will come and go quietly', 'brick');
+    }));
+
+    el.querySelector('#bks-mem-btn').addEventListener('click', () => {
+      const kind = el.querySelector('#bks-mem-kind').value;
+      const text = (el.querySelector('#bks-mem-text').value || '').trim();
+      if (!text) { el.querySelector('#bks-mem-text').focus(); return; }
+      P.data.memory.unshift({ kind: kind, statement: text, sensitivity: 'private', status: 'candidate', by: 'you' });
+      el.querySelector('#bks-mem').innerHTML = this.memHtml();
+      el.querySelector('#bks-mem-text').value = '';
+      P.toast('Proposed — a candidate now; the house argues it before accepting', 'sage');
+    });
+
+    el.querySelectorAll('[data-report]').forEach(b => b.addEventListener('click', () =>
+      P.toast('The ' + b.dataset.report + ' report zip would download now', 'sage')));
+  }
+};

--- a/docs/design/proscenium/prototype/js/views/files.js
+++ b/docs/design/proscenium/prototype/js/views/files.js
@@ -1,0 +1,219 @@
+/* Proscenium — Files: the desk. Whose-disk accent, an expandable tree
+   and a viewer pane, one humane denial, and resumable transfers. */
+window.P = window.P || {};
+P.views = P.views || {};
+
+P.views.files = {
+  title: 'Files',
+  machine: 'local',
+  sel: 'christmas-2025.pdf',
+  expanded: null,
+
+  /* Workshop's disk — the peer's own tree, seen from here (read-only) */
+  peerTree: [
+    { path: '~/intendant/docs/src/', kind: 'folder', children: [
+      { path: 'SUMMARY.md', kind: 'file', size: '4 KB' },
+      { path: 'architecture.md', kind: 'file', size: '38 KB' },
+      { path: 'peer-federation.md', kind: 'file', size: '21 KB' }
+    ] },
+    { path: '~/intendant/scripts/', kind: 'folder', children: [] }
+  ],
+
+  render(el) {
+    if (!this.expanded) {
+      this.expanded = new Set(['~/Pictures/photo-book/', '~/projects/shopify-theme/', '~/intendant/docs/src/']);
+    }
+    const m = P.data.machines.find(x => x.id === this.machine);
+    const peer = !m.thisMachine;
+    el.innerHTML = P.page({
+      eyebrow: 'the desk',
+      title: 'Files',
+      sub: 'Files across your machines, and what is moving between them.',
+      body:
+        '<div class="row" style="justify-content:space-between;flex-wrap:wrap;gap:8px">' +
+          '<span class="seg" id="file-machines">' +
+            P.data.machines.filter(x => x.status === 'online').map(x =>
+              '<button class="' + (x.id === this.machine ? 'on' : '') + '" data-machine="' + x.id + '">' +
+              '<span class="dot dot-' + (x.thisMachine ? 'slate' : 'violet') + '"></span> ' + P.esc(x.petname) + '</button>').join('') +
+          '</span>' +
+          P.authline('you', 'owner', peer ? m.route : 'direct') +
+        '</div>' +
+        (peer
+          ? '<div class="panel dim" style="font-size:12.5px">Browsing ' + P.esc(m.petname) +
+            '’s disk from here — looking, not touching. Its own IAM decides what you may see.</div>'
+          : '') +
+        '<div class="file-deskgrid">' +
+          '<div class="card" style="padding:10px"><div class="tree">' +
+            this.treeHtml(peer ? this.peerTree : P.data.files) +
+            (peer ? '' :
+              '<div class="tree-row" data-file="~/etc" style="padding-left:8px">' +
+                '<span class="icon">' + P.icon('folder', 12) + '</span>~/etc <span class="fact">locked</span></div>') +
+          '</div></div>' +
+          '<div id="file-viewer-host">' + this.viewerHtml() + '</div>' +
+        '</div>' +
+        P.section('Transfers') +
+        this.transfersHtml()
+    });
+    this.wire(el);
+  },
+
+  /* ---------------- the tree ---------------- */
+  treeHtml(nodes, depth) {
+    depth = depth || 0;
+    return nodes.map(n => {
+      const short = n.path.replace(/\/$/, '').split('/').pop() + (n.kind === 'folder' ? '/' : '');
+      const label = depth === 0 ? n.path : short;
+      const pad = 'padding-left:' + (8 + depth * 16) + 'px';
+      if (n.kind === 'folder') {
+        const open = this.expanded.has(n.path);
+        return '<div class="tree-row file-folder' + (open ? ' open' : '') + '" data-folder="' + P.esc(n.path) + '" style="' + pad + '">' +
+          '<span class="icon file-chev">' + P.icon('chev', 12) + '</span>' +
+          '<span>' + P.esc(label) + '</span>' +
+          (n.note ? ' <a class="chip chip-attn" href="#/home" title="see the queue">' + P.esc(n.note) + '</a>' : '') +
+          '</div>' +
+          (open && n.children && n.children.length ? this.treeHtml(n.children, depth + 1) : '');
+      }
+      return '<div class="tree-row' + (this.sel === n.path ? ' on' : '') + '" data-file="' + P.esc(n.path) + '" style="' + pad + '">' +
+        '<span class="icon">' + P.icon('file', 12) + '</span>' +
+        '<span>' + P.esc(label) + '</span>' +
+        (n.size ? ' <span class="fact">' + P.esc(n.size) + '</span>' : '') +
+        '</div>';
+    }).join('');
+  },
+
+  /* ---------------- the viewer pane ---------------- */
+  viewerHtml() {
+    const m = P.data.machines.find(x => x.id === this.machine);
+    const accent = m.thisMachine ? 'file-accent-slate' : 'file-accent-violet';
+    const sel = this.sel;
+    let inner;
+    if (sel === '~/etc') {
+      inner = P.empty('key', 'The house may look, but not touch, here',
+        'This folder sits outside every grant the house holds — ask for the key. A person can say yes; a rule cannot.',
+        '<button class="btn btn-safe" id="file-request">' + P.ICON('key', 15) + ' Request access</button>');
+    } else if (sel === 'christmas-2025.pdf') {
+      inner =
+        '<div class="row" style="gap:16px;align-items:flex-start;flex-wrap:wrap">' +
+          '<div style="flex:1;min-width:220px">' +
+            '<div class="row" style="gap:8px">' + P.ICON('file', 16) + '<b>christmas-2025.pdf</b></div>' +
+            '<div class="factline" style="margin:10px 0">' +
+              P.fact('41 MB') + P.fact('38 pages') + P.fact('exported 06:12') + P.fact('PDF/X-4') + '</div>' +
+            '<div class="dim" style="font-size:12.5px;margin-bottom:12px">The print-shop export from this morning’s photo-book run.</div>' +
+            '<button class="btn btn-primary btn-xs" id="file-download">' + P.ICON('download', 13) + ' Download</button>' +
+          '</div>' +
+          '<div class="file-page" style="flex:none;width:230px">' +
+            '<div class="file-page-line file-page-head"></div>' +
+            '<div class="file-page-line"></div>' +
+            '<div class="file-page-line w80"></div>' +
+            '<div class="file-page-line"></div>' +
+            '<div class="file-page-line w60"></div>' +
+            '<div class="file-page-line w80"></div>' +
+            '<div class="file-page-line w40"></div>' +
+          '</div>' +
+        '</div>';
+    } else if (sel === 'cover.png') {
+      inner =
+        '<div class="file-cover">' +
+          '<div class="s">the christmas book</div>' +
+          '<div class="rule"></div>' +
+          '<div class="t">Christmas<br>2025</div>' +
+          '<div class="rule"></div>' +
+          '<div class="s">sixty-two photographs</div>' +
+        '</div>' +
+        '<div class="factline" style="justify-content:center;margin-top:12px">' +
+          P.fact('cover.png') + P.fact('3.2 MB') + P.fact('exported 06:12') + '</div>';
+    } else if (sel && sel.indexOf('.md') > -1) {
+      inner =
+        '<div class="row" style="gap:8px">' + P.ICON('file', 15) + '<b>' + P.esc(sel) + '</b></div>' +
+        '<div class="panel mono" style="margin-top:10px;font-size:12px"># ' + P.esc(sel.replace('.md', '')) +
+          '<br><br>…the chapter text renders here — CodeMirror in the real build.</div>' +
+        '<div class="dim" style="margin-top:8px;font-size:12px">Read-only from here — edits happen on ' + P.esc(m.petname) + ' itself.</div>';
+    } else {
+      inner = P.empty('files', 'Pick a file', 'Choose something on the left — I’ll show it here.');
+    }
+    return '<div class="card ' + accent + '" id="file-viewer">' + inner + '</div>';
+  },
+
+  /* ---------------- transfers ---------------- */
+  transfersHtml() {
+    return '<div class="card"><div class="col" style="gap:12px">' +
+      P.data.transfers.map(t => {
+        const done = t.state === 'done';
+        return '<div class="row" style="gap:10px;flex-wrap:wrap">' +
+          P.ICON(t.dir === 'up' ? 'upload' : 'download', 15) +
+          '<span style="flex:1;min-width:200px">' + P.esc(t.what) + '</span>' +
+          '<span class="row" style="gap:6px;min-width:160px;flex:0 0 220px">' +
+            '<span class="meter" style="flex:1"><span class="meter-fill' + (done ? '' : ' warn') +
+              '" id="file-meter-' + t.id + '" style="width:' + t.pct + '%"></span></span>' +
+            '<span class="fact" id="file-pct-' + t.id + '">' + t.pct + '%</span></span>' +
+          '<span id="file-state-' + t.id + '">' +
+            (done ? P.chip('done', 'sage') : P.chip('paused · resumable', 'attn')) + '</span>' +
+          (done ? '' : '<button class="btn btn-safe btn-xs" id="file-resume-' + t.id + '">Resume</button>') +
+        '</div>';
+      }).join('') +
+      '</div>' +
+      '<div class="dim" style="margin-top:10px;font-size:12px">Transfers survive restarts — the house picks up where it left off.</div></div>';
+  },
+
+  /* ---------------- wiring ---------------- */
+  wire(el) {
+    const self = this;
+
+    el.querySelectorAll('[data-machine]').forEach(b => b.addEventListener('click', () => {
+      self.machine = b.dataset.machine;
+      self.sel = self.machine === 'local' ? 'christmas-2025.pdf' : 'SUMMARY.md';
+      P.rerender();
+    }));
+
+    el.querySelectorAll('[data-folder]').forEach(r => r.addEventListener('click', e => {
+      if (e.target.closest('a')) return;
+      const p = r.dataset.folder;
+      if (self.expanded.has(p)) self.expanded.delete(p); else self.expanded.add(p);
+      P.rerender();
+    }));
+
+    el.querySelectorAll('[data-file]').forEach(r => r.addEventListener('click', () => {
+      self.sel = r.dataset.file;
+      el.querySelectorAll('[data-file]').forEach(x => x.classList.toggle('on', x === r));
+      const host = document.getElementById('file-viewer-host');
+      host.innerHTML = self.viewerHtml();
+      self.wireViewer(host);
+    }));
+
+    this.wireViewer(el);
+
+    const resume = el.querySelector('#file-resume-t2');
+    if (resume) resume.addEventListener('click', () => {
+      resume.disabled = true;
+      const fill = document.getElementById('file-meter-t2');
+      const pct = document.getElementById('file-pct-t2');
+      const state = document.getElementById('file-state-t2');
+      const t = P.data.transfers.find(x => x.id === 't2');
+      let p = t.pct;
+      const timer = setInterval(() => {
+        if (!fill.isConnected) { clearInterval(timer); return; }
+        p += 1;
+        if (p >= 100) {
+          p = 100;
+          clearInterval(timer);
+          t.pct = 100; t.state = 'done';
+          fill.classList.remove('warn');
+          state.innerHTML = P.chip('done', 'sage');
+          resume.remove();
+          P.toast('Transfer finished — bank-export-q2.csv is here', 'sage');
+        }
+        fill.style.width = p + '%';
+        pct.textContent = p + '%';
+      }, 55);
+    });
+  },
+
+  wireViewer(root) {
+    const dl = root.querySelector('#file-download');
+    if (dl) dl.addEventListener('click', () =>
+      P.toast('christmas-2025.pdf would download now — 41 MB', 'sage'));
+    const req = root.querySelector('#file-request');
+    if (req) req.addEventListener('click', () =>
+      P.toast('Access requested — you’ll be asked on the machine itself', null));
+  }
+};

--- a/docs/design/proscenium/prototype/js/views/home.js
+++ b/docs/design/proscenium/prototype/js/views/home.js
@@ -1,0 +1,127 @@
+/* Proscenium — Home: the owner's box.
+   Queue → the Conversation → Now Playing → Today. */
+window.P = window.P || {};
+P.views = P.views || {};
+
+P.views.home = {
+  title: 'Home',
+
+  render(el) {
+    const hour = new Date().getHours();
+    const greet = hour < 12 ? 'Good morning' : hour < 18 ? 'Good afternoon' : 'Good evening';
+    const pending = P.queueStore.pending();
+    const fyis = P.queueStore.fyis();
+    const live = P.data.sessions.filter(s => s.phase === 'working');
+
+    el.innerHTML = P.page({
+      title: greet + ', ' + P.data.you.name + '.',
+      sub: pending.length
+        ? '<b>' + pending.length + '</b> thing' + (pending.length > 1 ? 's' : '') + ' need' + (pending.length > 1 ? '' : 's') + ' you — the rest is humming.'
+        : 'Nothing needs you. The house is humming.',
+      body:
+        /* ---------- the Queue ---------- */
+        P.section('Needs you') +
+        '<div id="home-queue" class="col" style="gap:12px">' +
+          (pending.length || fyis.length
+            ? pending.map(q => P.decisionCard(q)).join('') +
+              (fyis.length ? fyis.map(q => P.decisionCard(q)).join('') : '')
+            : '<div class="queue-free"><span class="big">You’re free.</span>' +
+              P.esc(live.length + ' session' + (live.length === 1 ? ' is' : 's are') + ' working — I’ll tap you if anything comes up.') + '</div>') +
+        '</div>' +
+
+        /* ---------- the Conversation ---------- */
+        P.section('The conversation') +
+        '<div class="thread" id="home-thread">' + P.views.home.threadHtml() + '</div>' +
+
+        /* ---------- Now Playing ---------- */
+        P.section('Now playing') +
+        '<div class="grid grid-3" id="now-playing">' +
+          (live.map(P.stageCard).join('') ||
+            P.empty('stage', 'Nothing on stage', 'Give the house something to do — one sentence in the composer is enough.')) +
+        '</div>' +
+
+        /* ---------- Today ---------- */
+        P.section('Today') +
+        '<div class="ribbon">' + P.data.today.map(t =>
+          '<div class="ribbon-item' + (t.kind === 'now' ? ' now' : '') + '">' +
+          '<span class="t">' + P.esc(t.t) + '</span><span>' + P.esc(t.label) + '</span>' +
+          (t.note ? '<span class="dim" style="font-size:11px">' + P.esc(t.note) + '</span>' : '') +
+          '</div>').join('') + '</div>'
+    });
+
+    P.views.home.wireThread(el);
+  },
+
+  threadHtml() {
+    return P.data.conversation.map(m => {
+      if (m.kind === 'milestone') {
+        return '<div class="milestone"><span class="line"></span><span>' + P.esc(m.text) + '</span>' +
+          '<button class="btn btn-quiet btn-xs" data-showwork="' + P.esc(m.detail || '') + '">show work</button>' +
+          '<span class="line"></span></div>';
+      }
+      if (m.from === 'you') {
+        return '<div class="msg msg-you"><div class="avatar">' + P.icon('arch', 15) + '</div>' +
+          '<div class="msg-body"><div class="prose"><p>' + P.esc(m.text) + '</p></div>' +
+          '<div class="msg-meta"><span>' + m.at + '</span><span>you</span></div></div></div>';
+      }
+      const prose = (m.prose || []).map(p =>
+        '<p>' + P.esc(p).replace(/\*\*(.+?)\*\*/g, '<b>$1</b>') + '</p>').join('');
+      const artifacts = (m.artifacts || []).map(a =>
+        '<div class="artifact"><div class="artifact-head">' + P.ICON('branch', 14) + P.esc(a.title) +
+        '<span class="grow"></span><span class="fact">' + P.esc(a.stat) + '</span></div>' +
+        '<div class="col" style="gap:3px">' + a.files.map(f => '<span class="mono" style="font-size:12px">' + P.esc(f) + '</span>').join('') + '</div>' +
+        '<div style="margin-top:8px"><a class="chip chip-slate" href="#/' + a.link + '">open in ' + a.link + ' →</a></div></div>'
+      ).join('');
+      const badge = m.kind === 'briefing' ? P.chip('the briefing', 'brass', 'sparkle') + ' ' : '';
+      return '<div class="msg"><div class="avatar">' + P.icon('arch', 15) + '</div>' +
+        '<div class="msg-body">' + badge + '<div class="prose">' + prose + '</div>' + artifacts +
+        '<div class="msg-meta"><span>' + m.at + '</span><span>presence · the house</span></div></div></div>';
+    }).join('');
+  },
+
+  wireThread(el) {
+    el.querySelectorAll('[data-showwork]').forEach(b => b.addEventListener('click', function () {
+      const ms = this.closest('.milestone');
+      if (ms.nextElementSibling && ms.nextElementSibling.classList.contains('panel')) { ms.nextElementSibling.remove(); this.textContent = 'show work'; return; }
+      const w = P.h('div', 'panel', P.logLines(P.data.fixLoginLog.slice(0, 5)));
+      ms.after(w); this.textContent = 'hide work';
+    }));
+  },
+
+  /* The composer talks here (called by app.js on send) */
+  onSend(text) {
+    const t = text.toLowerCase();
+    P.data.conversation.push({ from: 'you', at: 'now', text: text });
+    let reply;
+    if (t.includes('cover') || t.includes('photo') || t.includes('book')) {
+      reply = {
+        from: 'presence', at: 'now',
+        prose: ['Here it is — the book and the cover, fresh from this morning. The print-ready PDF is the **PDF/X-4** variant, as the shop asked.'],
+        artifacts: [{ type: 'files', title: 'photo-book — exported', stat: '2 files', files: ['christmas-2025.pdf (41 MB)', 'cover.png'], link: 'files' }]
+      };
+    } else if (t.includes('approve') || t.includes('allow') || t.includes('yes')) {
+      const top = P.queueStore.pending()[0];
+      reply = { from: 'presence', at: 'now', prose: top ? ['Done — I’ve resolved “' + top.title + '”. ' + (P.queueStore.pending().length - 1 || 'No') + ' left in the queue.'] : ['Nothing waiting on you — the queue is clear.'] };
+      if (top) setTimeout(() => P.queueStore.resolve(top.id, top.actions[0].id), 400);
+    } else if (t.includes('queue') || t.includes('need')) {
+      const n = P.queueStore.pending().length;
+      reply = { from: 'presence', at: 'now', prose: [n ? n + ' things need you — the deletion ask is the one to read. They’re pinned above.' : 'Nothing needs you. You’re free.'] };
+    } else {
+      /* a new task — the house takes it on */
+      const id = 'task-' + Math.random().toString(36).slice(2, 6);
+      P.data.sessions.unshift({
+        id: id, name: text.split(' ').slice(0, 2).join('-').toLowerCase().replace(/[^a-z-]/g, '') || id,
+        backend: 'internal', model: 'orchestrate', machine: 'local', phase: 'working', turn: 1,
+        sentence: 'Starting up — reading the brief', task: text, started: 'now', cost: 0.00,
+        tokens: { used: 1200, ctx: 200000, pct: 1 }, branch: 'main', dirty: 0,
+        cache: { hit: 0 }, limits: {}, queue: [],
+        caps: { follow_up: true, steer: true, interrupt: true, thread_actions: false }, subagents: []
+      });
+      reply = { from: 'presence', at: 'now', prose: ['I’ll take that on. I’m spinning up a session now — it’s on stage under **Now playing**, and I’ll narrate as it goes. Anything it can’t decide, it’ll raise in the queue.'] };
+      P.data.conversation.push({ kind: 'milestone', text: 'task received — session starting', detail: 'log' });
+      setTimeout(() => { if (P.current === 'home') P.rerender(); }, 1800);
+    }
+    P.data.conversation.push(reply);
+    if (P.current === 'home') P.rerender();
+  }
+};

--- a/docs/design/proscenium/prototype/js/views/machines.js
+++ b/docs/design/proscenium/prototype/js/views/machines.js
@@ -1,0 +1,242 @@
+/* Proscenium — Machines: the fleet. Cards first (this machine, then
+   peers), a drill-down per machine, the pairing fold (⌘K lands on
+   #fold-pairing), and delegation across the fence. */
+window.P = window.P || {};
+P.views = P.views || {};
+
+P.views.machines = {
+  title: 'Machines',
+  cap: 'computer-use',
+
+  render(el, params) {
+    if (params && params[0]) { this.renderMachine(el, params[0]); return; }
+    this.renderFleet(el);
+  },
+
+  /* ---------------- the fleet ---------------- */
+  renderFleet(el) {
+    const ms = P.data.machines.slice().sort((a, b) =>
+      (b.thisMachine ? 1 : 0) - (a.thisMachine ? 1 : 0));
+    const knocks = P.data.queue.filter(q => q.kind === 'enrollment' && !P.queueStore.isResolved(q.id));
+    el.innerHTML = P.page({
+      eyebrow: 'the fleet',
+      title: 'Machines',
+      sub: 'The house’s wings — your machines, the peers it can reach, and how new ones join.',
+      body:
+        (knocks.length
+          ? '<div class="panel row" style="gap:10px">' + P.ICON('doorbell', 15) +
+            '<span style="flex:1">' + P.esc(knocks[0].title) + ' — it’s waiting in the queue.</span>' +
+            '<a class="chip chip-attn" href="#/home">answer it →</a></div>'
+          : '') +
+        '<div class="grid grid-3">' + ms.map(m => this.machineCard(m)).join('') + '</div>' +
+        this.pairingFold() +
+        this.delegateFold()
+    });
+    this.wireFleet(el);
+  },
+
+  machineCard(m) {
+    const online = m.status === 'online';
+    return '<div class="card">' +
+      '<div class="row" style="align-items:baseline;gap:8px">' +
+        '<span class="mach-petname">' + P.esc(m.petname) + '</span>' +
+        '<span class="dim mono" style="font-size:11.5px;white-space:nowrap">' + P.esc(m.label) + '</span>' +
+        '<span class="grow"></span>' +
+        (m.thisMachine ? P.chip('this machine', 'brass') : '') +
+      '</div>' +
+      '<div class="row" style="gap:8px;margin-top:6px;flex-wrap:wrap">' +
+        P.dot(online ? 'sage' : 'slate', online) +
+        '<span style="font-size:13px">' + (online ? 'online' : 'away') + '</span>' +
+        P.routeChip(m.route) +
+        P.chip(m.role, m.role === 'owner' ? 'brass' : 'slate') +
+      '</div>' +
+      '<div class="row" style="gap:6px;margin-top:10px;flex-wrap:wrap">' +
+        m.capabilities.map(c => P.chip(c, null)).join('') +
+      '</div>' +
+      '<div class="mach-pressure" style="margin-top:12px">' +
+        '<span class="k">cpu</span>' + P.meter(m.pressure.cpu) +
+        '<span class="p">' + (online ? m.pressure.cpu + '%' : '—') + '</span>' +
+        '<span class="k">mem</span>' + P.meter(m.pressure.mem) +
+        '<span class="p">' + (online ? m.pressure.mem + '%' : '—') + '</span>' +
+      '</div>' +
+      '<div class="row" style="gap:8px;margin-top:12px;flex-wrap:wrap">' +
+        (m.fueled ? P.chip('fueled', 'sage', 'fuel') : P.chip('dry', 'attn', 'fuel')) +
+        (m.lease ? P.fact(m.lease) : '') +
+        (m.note ? P.fact(m.note) : '') +
+      '</div>' +
+      '<div class="factline" style="margin-top:10px">' + P.fact(m.os) + P.fact(m.version) + '</div>' +
+      '<div class="row" style="margin-top:12px">' +
+        '<a class="btn btn-quiet btn-xs" href="#/machines/' + m.id + '">Open ' + P.ICON('chev', 13) + '</a>' +
+      '</div>' +
+    '</div>';
+  },
+
+  /* ---------------- link a machine (⌘K lands here) ---------------- */
+  pairingFold() {
+    const mode = (title, expl, cons, extra) =>
+      '<div class="panel">' +
+        '<div style="margin-bottom:6px"><b>' + title + '</b></div>' +
+        '<div style="font-size:13px;color:var(--text-2)">' + expl + '</div>' +
+        (extra || '') +
+        '<div class="dim" style="font-size:12px;margin-top:8px;font-style:italic">' + cons + '</div>' +
+      '</div>';
+    return P.foldHtml({
+      key: 'machines.pairing', id: 'fold-pairing', title: 'Link a machine', note: 'four ways in',
+      body:
+        '<div class="grid grid-2">' +
+          mode('Request access',
+            'Knock on another house’s door. You introduce yourself; its owner decides what you may do.',
+            'This creates a route, not authority — its IAM still decides.',
+            '<div style="margin-top:10px"><button class="btn btn-safe btn-xs" data-pair="request">Send a request</button></div>') +
+          mode('Join invite',
+            'Someone handed you twelve words. They name a door — once — and then they are spent.',
+            'A claim code is a name tag, not a key — the other house still decides your role.',
+            '<div class="row" style="margin-top:10px;gap:8px">' +
+              '<input class="input mono" id="mach-claim" placeholder="broom candle harbor … twelve words" style="flex:1;min-width:180px">' +
+              '<button class="btn btn-safe btn-xs" data-pair="join">Join</button></div>') +
+          mode('Grant invite',
+            'Mint twelve words for a machine you want to let in. Single use, and they wilt in a day.',
+            'You stay the authority — revoke the moment you like.',
+            '<div style="margin-top:10px"><button class="btn btn-safe btn-xs" data-pair="grant">Mint a code</button></div>') +
+          mode('Manual add',
+            'Paste an address and a key by hand — for networks that don’t do ceremonies.',
+            'This creates a route, not authority — your IAM still decides.',
+            '<div style="margin-top:10px"><button class="btn btn-quiet btn-xs" data-pair="manual">Add manually</button></div>') +
+        '</div>'
+    });
+  },
+
+  /* ---------------- delegate ---------------- */
+  delegateFold() {
+    return P.foldHtml({
+      key: 'machines.delegate', title: 'Delegate', note: 'send work across the fleet',
+      body:
+        '<div class="dim" style="font-size:12.5px;margin-bottom:10px">Pick what the work needs — I’ll show you who can take it.</div>' +
+        '<div class="row" style="gap:6px;flex-wrap:wrap">' +
+          ['computer-use', 'terminal', 'headless'].map(c =>
+            '<button class="chip' + (c === this.cap ? ' chip-sage' : '') + '" data-cap="' + c + '">' + c + '</button>').join('') +
+        '</div>' +
+        '<div id="mach-eligible" style="margin-top:10px">' + this.eligibleHtml() + '</div>'
+    });
+  },
+
+  eligibleHtml() {
+    const cap = this.cap;
+    const peers = P.data.machines.filter(m =>
+      !m.thisMachine && m.capabilities.indexOf(cap) > -1 && m.status === 'online' && m.fueled);
+    if (!peers.length) {
+      return P.empty('machines', 'Nobody can take that right now',
+        'A peer needs the capability, fuel, and a pulse — Parlor PC is away and dry.');
+    }
+    return peers.map(m =>
+      '<div class="panel">' +
+        '<div class="row" style="gap:8px;flex-wrap:wrap">' +
+          P.dot('sage') + '<b>' + P.esc(m.petname) + '</b>' +
+          P.routeChip(m.route) + P.chip(m.role, 'slate') +
+          '<span class="fact">' + P.esc(m.label) + '</span>' +
+        '</div>' +
+        '<textarea class="input" rows="2" style="width:100%;margin-top:8px" placeholder="What should ' +
+          P.esc(m.petname) + ' do? One sentence is plenty…"></textarea>' +
+        '<div class="row" style="margin-top:8px;gap:8px;flex-wrap:wrap">' +
+          '<button class="btn btn-primary btn-xs" data-route-task="' + m.id + '">' + P.ICON('send', 13) + ' Route the task</button>' +
+          '<span class="dim" style="font-size:12px">Its IAM re-decides everything there — your route is a request, not a skeleton key.</span>' +
+        '</div>' +
+      '</div>').join('');
+  },
+
+  wireFleet(el) {
+    const self = this;
+    el.querySelectorAll('[data-pair]').forEach(b => b.addEventListener('click', () => {
+      const msgs = {
+        request: 'Request sent — the other house’s owner will see it knock',
+        join: 'The twelve words would be checked and spent here — welcome in',
+        grant: 'A fresh claim code would appear here — twelve words, single use',
+        manual: 'The address-and-key form lives here in the real build'
+      };
+      P.toast(msgs[b.dataset.pair], b.dataset.pair === 'manual' ? null : 'sage');
+    }));
+    el.querySelectorAll('[data-cap]').forEach(b => b.addEventListener('click', () => {
+      self.cap = b.dataset.cap;
+      el.querySelectorAll('[data-cap]').forEach(x => x.classList.toggle('chip-sage', x === b));
+      document.getElementById('mach-eligible').innerHTML = self.eligibleHtml();
+      self.wireEligible(el);
+    }));
+    this.wireEligible(el);
+  },
+
+  wireEligible(el) {
+    el.querySelectorAll('[data-route-task]').forEach(b => b.addEventListener('click', () =>
+      P.toast('Task routed to ' + P.machineName(b.dataset.routeTask) + ' — receipt tracked', 'sage')));
+  },
+
+  /* ---------------- the drill-down ---------------- */
+  renderMachine(el, id) {
+    const m = P.data.machines.find(x => x.id === id) || P.data.machines[0];
+    const peer = !m.thisMachine;
+    const online = m.status === 'online';
+    const rank = { working: 0, idle: 1, done: 2, archived: 3 };
+    const sessions = P.data.sessions.filter(s => s.machine === m.id)
+      .sort((a, b) => (rank[a.phase] || 9) - (rank[b.phase] || 9));
+    const displays = P.data.displays.filter(d => d.machine === m.id);
+    el.innerHTML = P.page({
+      body:
+        '<div class="row" style="align-items:flex-start;gap:14px;flex-wrap:wrap">' +
+          '<div style="min-width:280px;flex:1">' +
+            '<div class="eyebrow"><a href="#/machines" style="color:inherit">machines</a> / ' + P.esc(m.petname) + '</div>' +
+            '<h1 class="page-title" style="font-size:26px">' + P.esc(m.petname) + '</h1>' +
+            '<div class="page-sub">' +
+              (m.thisMachine ? 'This machine — where the house lives.'
+                : P.esc(m.note || 'A peer, reached ' + m.route + '.')) + '</div>' +
+            '<div class="row" style="gap:6px;flex-wrap:wrap">' +
+              P.dot(online ? 'sage' : 'slate', online) +
+              '<span style="font-size:13px">' + P.esc(m.status) + '</span>' +
+              P.routeChip(m.route) +
+              P.chip(m.role, 'slate') +
+              (m.fueled ? P.chip('fueled', 'sage', 'fuel') : P.chip('dry', 'attn', 'fuel')) +
+              (m.thisMachine ? P.chip('this machine', 'brass') : '') +
+            '</div>' +
+          '</div>' +
+          '<div class="col" style="gap:8px;align-items:flex-end">' +
+            P.authline(m.thisMachine ? 'you' : m.petname, m.role, m.route) +
+          '</div>' +
+        '</div>' +
+        (peer
+          ? '<div class="panel dim" style="font-size:12.5px">You’re browsing ' + P.esc(m.petname) +
+            ' from across the fence — its sessions and screens are shown display-only, as its IAM allows. Work on it happens from its own dashboard.</div>'
+          : '') +
+        /* stats mini-panel */
+        '<div class="card"><div class="factline" style="gap:22px">' +
+          '<span>' + P.fact(m.os) + '</span>' +
+          '<span>' + P.fact(m.version) + '</span>' +
+          '<span class="row" style="gap:6px">' + P.fact('cpu ' + m.pressure.cpu + '%') + P.meter(m.pressure.cpu) + '</span>' +
+          '<span class="row" style="gap:6px">' + P.fact('mem ' + m.pressure.mem + '%') + P.meter(m.pressure.mem) + '</span>' +
+          (m.lease ? '<span>' + P.fact(m.lease) + '</span>' : '') +
+          '<span class="studio-only">' + P.fact(m.capabilities.join(' · ')) + '</span>' +
+        '</div></div>' +
+        P.section('Its sessions') +
+        (sessions.length
+          ? '<div class="grid grid-3">' + sessions.map(P.stageCard).join('') + '</div>'
+          : P.empty('stage', 'Nothing on stage',
+              m.thisMachine ? 'Give the house something to do — one sentence in the composer is enough.'
+                : 'This machine is idle.')) +
+        P.section('Its screens') +
+        (displays.length
+          ? '<div class="card"><div class="col" style="gap:10px">' +
+            displays.map(d =>
+              '<div class="row" style="gap:10px;flex-wrap:wrap">' +
+                P.ICON('screens', 15) +
+                '<span style="flex:1;min-width:180px">' + P.esc(d.name) + '</span>' +
+                P.fact(d.res) +
+                (d.live ? P.chip('live', 'sage') : P.chip('private', 'slate')) +
+                (d.peer ? P.routeChip('fleet name') : '') +
+                '<a class="chip" href="#/screens">open in screens →</a>' +
+              '</div>').join('') +
+            '</div></div>'
+          : P.empty('screens', 'No screens here',
+              'Screens appear when the house launches something graphical, or its owner shares one.')) +
+        (peer
+          ? '<div class="dim" style="font-size:12.5px">Browsing its files and sessions stays display-only — the trust model gives you a window, not a key.</div>'
+          : '')
+    });
+  }
+};

--- a/docs/design/proscenium/prototype/js/views/people.js
+++ b/docs/design/proscenium/prototype/js/views/people.js
@@ -1,0 +1,256 @@
+/* Proscenium — People & Keys: who may do what.
+   You → people & devices → doors → keys & vault (⌘K lands on #fold-vault)
+   → organizations (studio). Trust doctrine stays literal: petnames first,
+   routes labeled, claiming grants no authority, hosted ceiling role:none. */
+window.P = window.P || {};
+P.views = P.views || {};
+
+P.views.people = {
+  title: 'People & Keys',
+  vaultOpen: false,
+
+  /* the 7 builtin roles, in plain words */
+  ROLES: [
+    ['owner', 'everything, including who else gets keys'],
+    ['operator', 'runs work and touches screens; can’t hand out keys'],
+    ['spectator', 'watches everything, touches nothing'],
+    ['session-reader', 'reads finished work only'],
+    ['terminal', 'a shared shell'],
+    ['files-read', 'reads files, nothing more'],
+    ['files-write', 'drops files in, can’t read them back']
+  ],
+
+  CLAIM: 'witch collapse practice feed harbor lantern orbit meadow velvet paper anchor stone',
+
+  render(el) {
+    const you = P.data.you;
+
+    el.innerHTML = P.page({
+      eyebrow: 'who may do what',
+      title: 'People & Keys',
+      sub: 'Every key the house honors, what it may do, and where the fuel lives. Petnames first — the route is always labeled, and no door mints authority.',
+      body:
+        /* ---------- You ---------- */
+        '<div class="grid grid-2">' +
+          '<div class="card">' +
+            '<div class="row" style="gap:10px;align-items:baseline;flex-wrap:wrap">' +
+              '<span class="voice" style="font-size:23px">' + P.esc(you.name) + '</span>' +
+              P.chip(you.role, 'brass', 'shield') + P.routeChip(you.route.replace(' mTLS', '')) +
+            '</div>' +
+            '<div class="kv" style="margin-top:12px">' +
+              '<span class="k">key</span><span class="v">' + P.esc(you.keyId) + '</span>' +
+              '<span class="k">device</span><span class="v">' + P.esc(you.device) + '</span>' +
+              '<span class="k">route</span><span class="v">' + P.esc(you.route) + '</span>' +
+              '<span class="k">since</span><span class="v">' + P.esc(you.since) + '</span>' +
+            '</div>' +
+            '<div class="factline" style="margin-top:10px">' +
+              P.fact('your open tabs: 2 dashboard · 1 holding voice') +
+            '</div>' +
+          '</div>' +
+          P.card({
+            title: 'Trust tier',
+            sub: 'where this browser stands',
+            body:
+              '<div class="row">' + P.chip('integrated', 'sage', 'shield') + P.fact('the strongest tier') + '</div>' +
+              '<p style="margin:10px 0 8px;font-size:13.5px">This machine is integrated — it holds real keys. ' +
+              'What this key signs, the house trusts; a hosted page can never mint its way here.</p>' +
+              '<div class="dim" style="font-size:12.5px">Lower tiers exist on purpose: a fleet-named device watches and works, a hosted tab only finds the door.</div>'
+          }) +
+        '</div>' +
+
+        /* ---------- People & devices ---------- */
+        P.section('People & devices') +
+        '<div class="card" style="padding:6px"><table class="table"><thead><tr>' +
+        '<th>Who</th><th>Key</th><th>Role</th><th>Route</th><th>Lifecycle</th><th>Since</th></tr></thead><tbody>' +
+        P.data.people.map(p =>
+          '<tr>' +
+          '<td>' + P.esc(p.who) + '</td>' +
+          '<td class="mono">' + P.esc(p.key) + '</td>' +
+          '<td>' + P.chip(p.role, p.role === 'owner' ? 'brass' : 'slate') + '</td>' +
+          '<td>' + (p.route === '—' ? '<span class="dim">—</span>' : P.routeChip(p.route.replace(' mTLS', ''))) + '</td>' +
+          '<td>' + P.chip(p.lifecycle, p.lifecycle === 'active' ? 'sage' : 'brick') + '</td>' +
+          '<td class="mono">' + P.esc(p.since) + '</td>' +
+          '</tr>').join('') +
+        '</tbody></table></div>' +
+
+        P.foldHtml({ key: 'people.grant', title: 'Hand out a key', note: 'a promise you can revoke any time',
+          body:
+          '<div class="dim" style="font-size:13px;margin:4px 0 10px">Pick what the new key may do — plain words up front, the compiled role rides along underneath.</div>' +
+          '<div class="ppl-roles">' +
+            this.ROLES.map((r, i) =>
+              '<label class="panel ppl-role"><input type="radio" name="ppl-role" value="' + r[0] + '"' + (i === 1 ? ' checked' : '') + '>' +
+              '<b>' + P.esc(r[0]) + '</b><div class="dim">' + P.esc(r[1]) + '</div></label>').join('') +
+          '</div>' +
+          '<div class="row" style="margin-top:12px;gap:10px;flex-wrap:wrap">' +
+            '<button class="btn btn-primary" id="ppl-issue">' + P.ICON('key', 15) + ' Issue this key</button>' +
+            '<span class="dim" style="font-size:12.5px">A device that wants in asks first — enrollment requests arrive in <a href="#/home">the Queue</a>, and you decide there.</span>' +
+          '</div>' }) +
+
+        /* ---------- Doors ---------- */
+        P.section('Doors — the ways in') +
+        '<div class="grid grid-3">' +
+          P.card({
+            title: 'Connect', sub: 'the hosted rendezvous',
+            body:
+              '<div class="row">' + P.chip('linked', 'sage') + P.fact('route healthy · 42 ms') + '</div>' +
+              '<div class="kv" style="margin-top:10px">' +
+                '<span class="k">account</span><span class="v">val@example.com</span>' +
+                '<span class="k">trusted for</span><span class="v">discovery & routes</span>' +
+              '</div>' +
+              '<div class="dim" style="margin-top:10px;font-size:12.5px">Connect knows your fleet’s names and where to knock. It can introduce — it mints no authority here, and it holds no keys.</div>'
+          }) +
+          P.card({
+            title: 'Claim code', sub: 'a name tag, not a key — one use, twelve words',
+            body:
+              '<div class="panel mono ppl-claim">witch collapse practice feed<br>harbor lantern orbit meadow<br>velvet paper anchor stone</div>' +
+              '<div class="row" style="margin-top:10px;gap:8px">' +
+                '<button class="btn btn-quiet btn-xs" id="ppl-copy-claim">' + P.ICON('attach', 13) + ' copy</button>' +
+                '<span class="grow"></span>' + P.fact('expires tonight') +
+              '</div>' +
+              '<div class="dim" style="margin-top:8px;font-size:12.5px">Claiming grants no authority. It lets a new browser find the fleet and say its name — then it still asks you for a key.</div>'
+          }) +
+          P.card({
+            title: 'Hosted control', sub: 'reaching this house from anywhere',
+            body:
+              '<div class="seg" id="ppl-hosted">' +
+                '<button class="on" data-hc="View">View</button><button data-hc="Tasks">Tasks</button><button data-hc="Operate">Operate</button>' +
+              '</div>' +
+              '<div class="dim" style="margin-top:10px;font-size:12.5px">The compiled floor: hosted sessions can never exceed <b>role:none</b> without an owner ceremony on this machine. Tasks and Operate mint time-boxed leases you can revoke.</div>' +
+              '<div class="row" style="margin-top:10px">' +
+                '<button class="btn btn-quiet btn-xs" id="ppl-mint">mint a hosted lease</button>' +
+              '</div>'
+          }) +
+        '</div>' +
+
+        /* ---------- Keys & vault (⌘K target) ---------- */
+        P.foldHtml({ key: 'people.vault', id: 'fold-vault', title: 'Keys & vault', note: 'fuel · custody · ceremonies',
+          body:
+          '<div id="ppl-vault-state">' + this.vaultHtml() + '</div>' +
+
+          '<div class="eyebrow" style="margin:18px 0 6px">Fuel — leases the vault feeds</div>' +
+          '<table class="table"><thead><tr><th>Machine</th><th>Fuel</th><th>Standing</th><th></th></tr></thead><tbody>' +
+            '<tr><td>Workshop</td><td class="mono">claude · max</td><td>' + P.chip('2 days left', 'attn') + '</td>' +
+              '<td style="white-space:nowrap;text-align:right">' +
+                '<button class="btn btn-quiet btn-xs" data-lease="renew:Workshop">renew</button> ' +
+                '<button class="btn btn-danger btn-xs" data-lease="revoke:Workshop">revoke</button></td></tr>' +
+            '<tr><td>Parlor PC</td><td class="mono">—</td><td>' + P.chip('dry — expired', 'brick') + '</td>' +
+              '<td style="text-align:right"><button class="btn btn-quiet btn-xs" data-lease="renew:Parlor PC">renew</button></td></tr>' +
+          '</tbody></table>' +
+          '<div class="dim" style="font-size:12px;margin-top:6px">Leases live in memory only — a daemon restart politely goes dry; nothing credential-shaped touches the disk.</div>' +
+
+          '<div class="eyebrow" style="margin:18px 0 6px">Custody trail — where secrets have been</div>' +
+          '<div class="ppl-trail">' +
+            P.data.custody.map(c =>
+              '<div class="ppl-trail-row"><span class="ppl-trail-dot"></span>' +
+              '<span class="fact" style="width:48px;flex:none">' + P.esc(c.at) + '</span>' +
+              '<span style="flex:1;font-size:13px;color:var(--text-2)">' + P.esc(c.what) + '</span>' +
+              '<span class="dim" style="font-size:12px">' + P.esc(c.by) + '</span></div>').join('') +
+          '</div>' +
+
+          '<div class="row" style="margin-top:14px">' + P.ICON('external', 14) +
+            '<span style="font-size:13px">Client egress: <span class="mono" style="font-size:12px">api.anthropic.com</span> rides out through this browser — registered Monday.</span>' +
+            '<span class="grow"></span>' + P.fact('one registration') + '</div>' +
+
+          '<div style="margin-top:14px">' +
+          P.foldHtml({ key: 'people.ceremonies', title: 'Agent sign-in ceremonies', note: 'Claude Code · Codex device auth',
+            body:
+            '<div class="grid grid-2">' +
+              '<div class="panel"><div class="row"><b>Claude Code</b><span class="grow"></span>' + P.chip('not linked', 'slate') + '</div>' +
+                '<div class="dim" style="font-size:12.5px;margin:6px 0 10px">The house runs the device-auth dance in a supervised terminal — you see the URL, the code, and exactly where the token lands.</div>' +
+                '<button class="btn btn-quiet btn-xs" data-ceremony="Claude Code">start ceremony</button></div>' +
+              '<div class="panel"><div class="row"><b>Codex</b><span class="grow"></span>' + P.chip('not linked', 'slate') + '</div>' +
+                '<div class="dim" style="font-size:12.5px;margin:6px 0 10px">Same ceremony, different provider — a device code, your approval in the browser, the token sealed into the vault.</div>' +
+                '<button class="btn btn-quiet btn-xs" data-ceremony="Codex">start ceremony</button></div>' +
+            '</div>' }) +
+          '</div>' }) +
+
+        /* ---------- Organizations (studio) ---------- */
+        '<div class="studio-only">' +
+        P.foldHtml({ key: 'people.orgs', title: 'Organizations', note: 'trusted roots · role caps · revocation lists',
+          body:
+          '<table class="table"><thead><tr><th>Org root</th><th>Role cap</th><th>ORL</th></tr></thead><tbody>' +
+            '<tr><td class="mono">acme-labs</td><td>' + P.chip('operator', 'slate') + '</td><td>' + P.chip('current', 'sage') + '</td></tr>' +
+            '<tr><td class="mono">family</td><td>' + P.chip('spectator', 'slate') + '</td><td>' + P.chip('current', 'sage') + '</td></tr>' +
+          '</tbody></table>' +
+          '<div class="dim" style="font-size:12.5px;margin-top:8px">An org root signs grant documents and revocation lists; no org key can raise a grant above its cap. Joining with an org grant arrives in the Queue like any enrollment.</div>' }) +
+        '</div>'
+    });
+
+    this.wire(el);
+  },
+
+  vaultHtml() {
+    const v = P.data.vault;
+    if (!this.vaultOpen) {
+      return '<div class="row" style="flex-wrap:wrap">' +
+        P.chip(v.state, 'attn', 'shield') +
+        P.fact(v.entries + ' entries · ' + v.passkeys + ' passkeys · ' + v.recovery) +
+        '<span class="grow"></span>' +
+        '<button class="btn btn-safe btn-xs" id="ppl-vault-toggle">' + P.ICON('key', 13) + ' Unlock</button>' +
+      '</div>';
+    }
+    return '<div class="row" style="flex-wrap:wrap">' +
+        P.chip('Unlocked', 'sage', 'shield') +
+        P.fact('locks again on sleep or 10 idle minutes') +
+        '<span class="grow"></span>' +
+        '<button class="btn btn-quiet btn-xs" id="ppl-vault-toggle">Lock</button>' +
+      '</div>' +
+      '<div class="panel" style="margin-top:10px"><div class="kv">' +
+        '<span class="k">Anthropic key</span><span class="v">sk-ant-…3f9</span>' +
+        '<span class="k">OpenAI key</span><span class="v">sk-…k21</span>' +
+        '<span class="k">Gemini key</span><span class="v">AIza-…8qx</span>' +
+        '<span class="k">NAS password</span><span class="v">••••••••••</span>' +
+      '</div></div>';
+  },
+
+  wire(el) {
+    const issue = el.querySelector('#ppl-issue');
+    if (issue) issue.addEventListener('click', () => {
+      const role = (el.querySelector('input[name="ppl-role"]:checked') || {}).value || 'operator';
+      P.toast(role[0].toUpperCase() + role.slice(1) + ' key issued — revoke it here any time', 'sage');
+    });
+
+    const copy = el.querySelector('#ppl-copy-claim');
+    if (copy) copy.addEventListener('click', () => {
+      try { if (navigator.clipboard) navigator.clipboard.writeText(this.CLAIM).catch(() => {}); } catch (e) {}
+      P.toast('Copied — twelve words, one use. It names; it never grants.', 'sage');
+    });
+
+    el.querySelectorAll('[data-hc]').forEach(b => b.addEventListener('click', () => {
+      el.querySelectorAll('[data-hc]').forEach(x => x.classList.remove('on'));
+      b.classList.add('on');
+      const gloss = {
+        View: 'View — watches dashboards and finished work; the floor stays role:none',
+        Tasks: 'Tasks — may start and steer work under a time-boxed lease',
+        Operate: 'Operate — adds screens and input, still under the lease, still revocable'
+      };
+      P.toast(gloss[b.dataset.hc] || 'Preset selected', null);
+    }));
+    const mint = el.querySelector('#ppl-mint');
+    if (mint) mint.addEventListener('click', () =>
+      P.toast('A hosted lease would be minted here — time-boxed, revocable, floored at role:none', null));
+
+    el.querySelectorAll('[data-lease]').forEach(b => b.addEventListener('click', () => {
+      const parts = b.dataset.lease.split(':');
+      const act = parts[0], machine = parts.slice(1).join(':');
+      if (act === 'renew') P.toast('Lease renewed — ' + machine + ' stays fueled', 'sage');
+      else P.toast('Lease revoked — ' + machine + ' politely goes dry', 'brick');
+    }));
+
+    el.querySelectorAll('[data-ceremony]').forEach(b => b.addEventListener('click', () =>
+      P.toast('The ' + b.dataset.ceremony + ' ceremony would open a supervised terminal here', null)));
+
+    this.wireVault(el);
+  },
+
+  wireVault(el) {
+    const t = el.querySelector('#ppl-vault-toggle');
+    if (!t) return;
+    t.addEventListener('click', () => {
+      this.vaultOpen = !this.vaultOpen;
+      el.querySelector('#ppl-vault-state').innerHTML = this.vaultHtml();
+      this.wireVault(el);
+      P.toast(this.vaultOpen ? 'Vault unlocked — entries stay masked until you ask' : 'Vault locked', this.vaultOpen ? 'sage' : null);
+    });
+  }
+};

--- a/docs/design/proscenium/prototype/js/views/screens.js
+++ b/docs/design/proscenium/prototype/js/views/screens.js
@@ -1,0 +1,350 @@
+/* Proscenium — Screens: see and touch your machines.
+   Live displays on stage, input authority in the rail, recordings,
+   a terminal, and browser workspaces. The agent cursor drifts on its
+   own and parks whenever you take the wheel. */
+window.P = window.P || {};
+P.views = P.views || {};
+
+P.views.screens = {
+  title: 'Screens',
+  hands: 'agent',        /* who holds Display 1: 'agent' (fix-login) or 'you' */
+  shared: false,         /* is your screen lent to the house? */
+  shareDur: '15 minutes',
+
+  render(el) {
+    const d = {};
+    P.data.displays.forEach(x => { d[x.id] = x; });
+    el.innerHTML = P.page({
+      eyebrow: 'see and touch your machines',
+      title: 'Screens',
+      sub: 'Every screen the house can see. Watch it work, take the wheel when you want to, or lend it yours.',
+      body:
+        '<div class="scr-stagegrid">' +
+          '<div class="col" style="gap:var(--gap)">' +
+            this.displayCard(d['disp-1']) +
+            this.peerDisplayCard(d['disp-2']) +
+          '</div>' +
+          '<div class="col" style="gap:var(--gap)">' +
+            this.authorityCard() +
+            this.activityCard() +
+            '<button class="btn btn-quiet" id="scr-new-vdisplay">' + P.ICON('plus', 15) + ' New virtual display</button>' +
+          '</div>' +
+        '</div>' +
+        this.yourScreenCard(d['disp-0']) +
+        P.section('Recordings & clips') +
+        '<div class="grid grid-2">' + P.data.recordings.map(r => this.recordingCard(r)).join('') + '</div>' +
+        P.section('Terminals') +
+        this.terminalCard() +
+        P.section('Browser workspaces') +
+        this.workspaceCard()
+    });
+    this.wire(el);
+  },
+
+  /* ---------------- the stage ---------------- */
+  displayCard(d) {
+    const you = this.hands === 'you';
+    return '<div class="card">' +
+      '<div class="card-head"><div>' +
+        '<h3 class="card-title">' + P.esc(d.name) + '</h3>' +
+        '<div class="card-sub">' + P.esc(P.machineName(d.machine)) + ' · ' + P.fact(d.res) +
+          ' · <span id="scr-hands-line">hands: ' + (you ? 'you' : 'agent (fix-login)') + '</span></div>' +
+      '</div>' +
+      '<div class="card-actions">' + P.chip('live', 'sage') + '</div></div>' +
+      '<div class="scr-screen" id="scr-screen-1">' +
+        '<div class="scr-browser">' +
+          '<div class="scr-browser-bar">' +
+            '<span class="scr-stoplight"></span><span class="scr-stoplight"></span><span class="scr-stoplight"></span>' +
+            '<span class="scr-url">https://staging.shopify.example/login</span>' +
+          '</div>' +
+          '<div class="scr-banner">' + P.ICON('warn', 14) + '<span>Too many redirects — the site sent you in a loop</span></div>' +
+          '<div class="scr-page">' +
+            '<div class="scr-page-title">Sign in</div>' +
+            '<div class="scr-field"></div>' +
+            '<div class="scr-field"></div>' +
+            '<div class="scr-btn"></div>' +
+            '<div class="scr-field scr-ghost"></div>' +
+          '</div>' +
+        '</div>' +
+        '<div class="scr-cursor" id="scr-cursor"' + (you ? ' style="display:none"' : '') + '>' +
+          '<span class="scr-cursor-dot"></span><span class="scr-cursor-tag">fix-login</span>' +
+        '</div>' +
+      '</div>' +
+      '<div class="row" style="margin-top:10px;gap:6px;flex-wrap:wrap">' +
+        '<button class="btn ' + (you ? 'btn-danger' : 'btn-safe') + ' btn-xs" id="scr-take-control">' +
+          P.ICON('hand', 13) + ' <span>' + (you ? 'Release' : 'Take control') + '</span></button>' +
+        ['Stream', 'Attach frame', 'Annotate', 'Record', 'Fullscreen'].map(t =>
+          '<button class="btn btn-quiet btn-xs" data-scr-tool="' + t + '">' + t + '</button>').join('') +
+      '</div></div>';
+  },
+
+  peerDisplayCard(d) {
+    return '<div class="card">' +
+      '<div class="card-head"><div>' +
+        '<h3 class="card-title">' + P.esc(d.name) + '</h3>' +
+        '<div class="card-sub">' + P.esc(P.machineName(d.machine)) + ' · ' + P.fact(d.res) + ' · hands: agent (docs-sweep)</div>' +
+      '</div>' +
+      '<div class="card-actions">' + P.chip('live', 'sage') + P.routeChip('fleet name') + '</div></div>' +
+      '<div class="scr-screen scr-cool"><div class="scr-term-screen">' +
+        P.logLines([
+          ['10:07:12', 'tool', 'mdbook-linkcheck docs/src — 96 chapters queued'],
+          ['10:09:31', 'ok', 'chapters 1–41 clean'],
+          ['10:12:44', 'err', 'stale route reference · docs/src/peer-federation.md:41'],
+          ['10:15:20', 'tool', 'grep -r "http://" docs/src — 31 hits'],
+          ['10:18:02', 'ok', '41 of 96 chapters scanned — no dead links yet']
+        ]) +
+        '<div style="margin-top:6px"><span class="scr-caret"></span></div>' +
+      '</div></div>' +
+      '<div class="row" style="margin-top:10px;gap:6px;flex-wrap:wrap">' +
+        ['Stream', 'Attach frame', 'Record'].map(t =>
+          '<button class="btn btn-quiet btn-xs" data-scr-tool="' + t + '">' + t + '</button>').join('') +
+        '<span class="grow"></span>' +
+        '<span class="dim" style="font-size:12px">Watching only — touching Workshop’s screen needs Workshop’s own say-so.</span>' +
+      '</div></div>';
+  },
+
+  /* ---------------- the rail ---------------- */
+  authorityCard() {
+    const row = (what, who, id) =>
+      '<div class="row" style="gap:8px">' +
+        '<span style="flex:1;min-width:0;font-size:13px">' + P.esc(what) + '</span>' +
+        '<span class="fact"' + (id ? ' id="' + id + '"' : '') + '>' + P.esc(who) + '</span></div>';
+    return P.card({
+      title: 'Who may touch what',
+      sub: 'Input authority, with its session',
+      body:
+        '<div class="col" style="gap:8px;margin-top:4px">' +
+          row('Display 1 · staging browser', this.hands === 'you' ? 'you' : 'agent · fix-login', 'scr-auth-disp-1') +
+          row('Virtual display · Xvfb', 'agent · docs-sweep') +
+          row('Your screen', 'you') +
+        '</div>' +
+        '<div class="dim" style="font-size:12px;margin-top:10px">Taking the wheel parks the agent’s hands — it watches until you give them back.</div>'
+    });
+  },
+
+  activityCard() {
+    return P.card({
+      title: 'Display activity',
+      body: P.logLines([
+        ['10:07', 'tool', 'agent clicked the login button'],
+        ['10:04', '', 'screenshot taken — the error banner, read'],
+        ['09:58', 'ok', 'stream started · 15 fps'],
+        ['09:52', '', 'you took the wheel for two minutes'],
+        ['09:41', '', 'display attached to fix-login']
+      ])
+    });
+  },
+
+  /* ---------------- your screen ---------------- */
+  yourScreenCard(d) {
+    const shared = this.shared;
+    return '<div class="card" id="scr-your-screen">' +
+      '<div class="card-head"><div>' +
+        '<h3 class="card-title">' + P.esc(d.name) + '</h3>' +
+        '<div class="card-sub">Private by default — the house may look only when you say so, for as long as you say.</div>' +
+      '</div>' +
+      '<div class="card-actions">' +
+        (shared ? P.chip('shared · ' + this.shareDur, 'attn', 'eye') : P.chip('private', 'slate', 'shield')) +
+      '</div></div>' +
+      '<div class="row" style="gap:8px;flex-wrap:wrap">' +
+        '<button class="btn ' + (shared ? 'btn-danger' : 'btn-safe') + '" id="scr-share-screen">' +
+          P.ICON(shared ? 'x' : 'eye', 15) + ' ' + (shared ? 'Stop sharing' : 'Share with the house…') + '</button>' +
+        '<button class="btn btn-quiet" data-scr-tool="View privately">View privately</button>' +
+        (shared ? '' :
+          '<span class="seg" id="scr-share-dur">' +
+            ['15 minutes', 'this session', 'until revoked'].map((t, i) =>
+              '<button class="' + (i === 0 ? 'on' : '') + '" data-dur="' + t + '">' + t + '</button>').join('') +
+          '</span>') +
+      '</div>' +
+      (shared
+        ? '<div class="dim" style="margin-top:8px;font-size:12.5px">The house can look for ' + P.esc(this.shareDur) +
+          ' — looking only, never touching. Stopping is always one tap away.</div>'
+        : '') +
+    '</div>';
+  },
+
+  /* ---------------- recordings & clips ---------------- */
+  recordingCard(r) {
+    return '<div class="card scr-player" style="--playdur:' + (r.id === 'rec-1' ? 12 : 7) + 's">' +
+      '<div class="card-head"><div>' +
+        '<h3 class="card-title">' + P.esc(r.name) + '</h3>' +
+        '<div class="card-sub">' + P.fact(r.len + ' · ' + r.when + ' · ' + r.size) + '</div>' +
+      '</div></div>' +
+      '<div class="scr-poster">' +
+        '<button class="scr-play" data-play aria-label="Play">' + P.icon('play', 22) + '</button>' +
+        '<div class="scr-timeline"><i></i></div>' +
+      '</div>' +
+      '<div class="row" style="margin-top:10px;gap:6px;flex-wrap:wrap">' +
+        [['in', 'set in'], ['out', 'set out'], ['annotate', 'annotate'], ['save', 'save clip']].map(c =>
+          '<button class="btn btn-quiet btn-xs" data-clip="' + c[0] + '">' + c[1] + '</button>').join('') +
+      '</div></div>';
+  },
+
+  /* ---------------- terminals ---------------- */
+  terminalCard() {
+    return '<div class="card">' +
+      '<div class="card-head"><div>' +
+        '<h3 class="card-title">Terminal</h3>' +
+        '<div class="card-sub">A shell is how you touch a machine — pin one here.</div>' +
+      '</div>' +
+      '<div class="card-actions">' + P.chip('Studio Mac', 'slate') +
+        '<button class="btn btn-quiet btn-xs" id="scr-term-share">share…</button></div></div>' +
+      '<div class="scr-xterm">' +
+        '<div><span class="p">val@studio-mac</span> <span class="o">~/projects/shopify-theme</span> <span class="c">$ npm test</span></div>' +
+        '<div class="o">✓ auth suite — 41 passing · 3.2s</div>' +
+        '<div><span class="p">val@studio-mac</span> <span class="o">~/projects/shopify-theme</span> <span class="c">$ git status --short</span></div>' +
+        '<div class="o"> M src/auth/session.ts · M src/middleware/redirect.ts · +10 more</div>' +
+        '<div><span class="p">val@studio-mac</span> <span class="o">~/projects/shopify-theme</span> <span class="c">$ </span><span class="scr-caret"></span></div>' +
+      '</div>' +
+      '<div class="dim" style="margin-top:8px;font-size:12.5px">Sharing a terminal is a grant — ' +
+        '<span class="mono">terminal.view</span> to watch, <span class="mono">terminal.write</span> to type. Yours to revoke, always.</div>' +
+    '</div>';
+  },
+
+  /* ---------------- browser workspaces ---------------- */
+  workspaceCard() {
+    const providers = ['auto', 'cdp', 'system_cdp', 'playwright', 'agent_browser', 'stream'];
+    return P.card({
+      title: 'Browser workspaces',
+      sub: 'Agent-driven browsers, leased by the session that drives them.',
+      body:
+        '<div class="row" style="gap:10px;flex-wrap:wrap">' +
+          P.ICON('external', 15) +
+          '<div style="flex:1;min-width:200px"><b>docs link-checker</b> <span class="fact">playwright · leased by docs-sweep</span></div>' +
+          P.chip('leased', 'violet') +
+          '<button class="btn btn-quiet btn-xs" data-ws="acquire">Acquire</button>' +
+          '<button class="btn btn-quiet btn-xs" data-ws="release">Release</button>' +
+        '</div>' +
+        P.foldHtml({
+          key: 'screens.workspace', title: 'New workspace', note: 'provider · lease',
+          body:
+            '<div class="row" style="gap:8px;flex-wrap:wrap;align-items:center">' +
+              '<span class="dim" style="font-size:12.5px">Provider</span>' +
+              '<span class="seg">' + providers.map((p, i) =>
+                '<button class="' + (i === 0 ? 'on' : '') + '" data-provider="' + p + '">' + p + '</button>').join('') + '</span>' +
+              '<button class="btn btn-safe btn-xs" id="scr-ws-create">Create workspace</button>' +
+            '</div>' +
+            '<div class="dim" style="margin-top:8px;font-size:12px">“auto” picks what the machine offers; the rest pin it. One workspace, one lease at a time.</div>'
+        })
+    });
+  },
+
+  /* ---------------- wiring ---------------- */
+  wire(el) {
+    const self = this;
+
+    el.querySelectorAll('[data-scr-tool]').forEach(b => b.addEventListener('click', () =>
+      P.toast(b.dataset.scrTool + ' — lives here in the real build', null)));
+
+    const take = el.querySelector('#scr-take-control');
+    if (take) take.addEventListener('click', () => {
+      self.hands = self.hands === 'agent' ? 'you' : 'agent';
+      const you = self.hands === 'you';
+      take.className = 'btn ' + (you ? 'btn-danger' : 'btn-safe') + ' btn-xs';
+      take.innerHTML = P.ICON('hand', 13) + ' <span>' + (you ? 'Release' : 'Take control') + '</span>';
+      const line = document.getElementById('scr-hands-line');
+      if (line) line.textContent = 'hands: ' + (you ? 'you' : 'agent (fix-login)');
+      const rail = document.getElementById('scr-auth-disp-1');
+      if (rail) rail.textContent = you ? 'you' : 'agent · fix-login';
+      const cursor = document.getElementById('scr-cursor');
+      if (cursor) cursor.style.display = you ? 'none' : '';
+      P.toast(you ? 'You’re at the wheel — fix-login’s hands are parked' : 'Released — fix-login has the wheel again', you ? 'sage' : null);
+    });
+
+    this.wireShare(el);
+
+    const newVd = el.querySelector('#scr-new-vdisplay');
+    if (newVd) newVd.addEventListener('click', () =>
+      P.toast('A fresh virtual display would spin up here — Xvfb, 1920×1080', 'sage'));
+
+    el.querySelectorAll('[data-play]').forEach(b => b.addEventListener('click', () => {
+      const player = b.closest('.scr-player');
+      const playing = player.classList.toggle('playing');
+      b.innerHTML = P.icon(playing ? 'pause' : 'play', 22);
+    }));
+    el.querySelectorAll('[data-clip]').forEach(b => b.addEventListener('click', () => {
+      const msgs = {
+        in: 'Clip starts here',
+        out: 'Clip ends here — ready to cut',
+        annotate: 'Pen, rect, and arrow live here in the real build',
+        save: 'Clip saved — find it under Recordings'
+      };
+      P.toast(msgs[b.dataset.clip], b.dataset.clip === 'save' ? 'sage' : null);
+    }));
+
+    const termShare = el.querySelector('#scr-term-share');
+    if (termShare) termShare.addEventListener('click', () =>
+      P.toast('Terminal shared with the house — terminal.view, revocable any time', 'sage'));
+
+    el.querySelectorAll('[data-ws]').forEach(b => b.addEventListener('click', () =>
+      P.toast(b.dataset.ws === 'acquire'
+        ? 'Workspace acquired — your session holds the lease'
+        : 'Lease released — the workspace is free', 'sage')));
+    el.querySelectorAll('[data-provider]').forEach(b => b.addEventListener('click', () => {
+      b.closest('.seg').querySelectorAll('button').forEach(x => x.classList.remove('on'));
+      b.classList.add('on');
+    }));
+    const create = el.querySelector('#scr-ws-create');
+    if (create) create.addEventListener('click', () => {
+      const on = el.querySelector('[data-provider].on');
+      P.toast('Workspace created — provider ' + (on ? on.dataset.provider : 'auto'), 'sage');
+    });
+
+    this.startCursor(el);
+  },
+
+  /* the share card re-renders itself, so it gets its own (re)wiring */
+  wireShare(root) {
+    const self = this;
+    const shareBtn = root.querySelector('#scr-share-screen');
+    if (shareBtn) shareBtn.addEventListener('click', () => {
+      self.shared = !self.shared;
+      if (self.shared) {
+        const on = document.querySelector('#scr-share-dur button.on');
+        self.shareDur = on ? on.dataset.dur : '15 minutes';
+      }
+      P.toast(self.shared
+        ? 'Screen shared for ' + self.shareDur + ' — looking only, never touching'
+        : 'Sharing stopped — your screen is yours again', self.shared ? 'sage' : null);
+      const old = document.getElementById('scr-your-screen');
+      if (old) {
+        const tpl = document.createElement('template');
+        tpl.innerHTML = self.yourScreenCard(P.data.displays.find(x => x.id === 'disp-0')).trim();
+        old.replaceWith(tpl.content.firstElementChild);
+        self.wireShare(document);
+      }
+    });
+    root.querySelectorAll('#scr-share-dur button').forEach(b => b.addEventListener('click', () => {
+      b.closest('.seg').querySelectorAll('button').forEach(x => x.classList.remove('on'));
+      b.classList.add('on');
+    }));
+  },
+
+  /* the agent cursor: drifts, sometimes clicks, parks while you drive,
+     and cleans itself up when the room is left */
+  startCursor(el) {
+    const screen = el.querySelector('#scr-screen-1');
+    const cursor = el.querySelector('#scr-cursor');
+    if (!screen || !cursor) return;
+    const self = this;
+    function drift() {
+      if (!screen.isConnected) { clearInterval(moveT); clearInterval(clickT); return; }
+      if (self.hands === 'you') return;
+      cursor.style.left = (14 + Math.random() * 66) + '%';
+      cursor.style.top = (30 + Math.random() * 52) + '%';
+    }
+    function click() {
+      if (!screen.isConnected) { clearInterval(moveT); clearInterval(clickT); return; }
+      if (self.hands === 'you' || Math.random() < 0.45) return;
+      const r = document.createElement('span');
+      r.className = 'scr-ripple';
+      r.style.left = cursor.style.left;
+      r.style.top = cursor.style.top;
+      screen.appendChild(r);
+      setTimeout(() => r.remove(), 720);
+    }
+    drift();
+    const moveT = setInterval(drift, 2200);
+    const clickT = setInterval(click, 3300);
+  }
+};

--- a/docs/design/proscenium/prototype/js/views/session.js
+++ b/docs/design/proscenium/prototype/js/views/session.js
@@ -1,0 +1,225 @@
+/* Proscenium — the Session Space: one deep page per session.
+   Timeline · Changes · Context · Controls · Vitals & lineage.
+   Folds honor the disclosure contract; Studio density opens them all. */
+window.P = window.P || {};
+P.views = P.views || {};
+
+P.views.session = {
+  title: 'Session',
+
+  render(el, params) {
+    const id = params[0];
+    const s = P.data.sessions.find(x => x.id === id) || P.data.sessions[0];
+    const q = P.data.queue.filter(x => x.session === s.id && !P.queueStore.isResolved(x.id));
+
+    el.innerHTML = P.page({
+      body:
+        /* header */
+        '<div class="row" style="align-items:flex-start;gap:14px;flex-wrap:wrap">' +
+          '<div style="min-width:280px;flex:1">' +
+            '<div class="eyebrow"><a href="#/work" style="color:inherit">work</a> / ' + P.esc(s.name) + '</div>' +
+            '<h1 class="page-title" style="font-size:26px">' + P.esc(s.name) + '</h1>' +
+            '<div class="page-sub">' + P.esc(s.sentence) + '</div>' +
+            '<div class="row" style="gap:6px;flex-wrap:wrap">' +
+              P.chip(s.phase === 'working' ? 'working' : s.phase, s.phase === 'working' ? 'sage' : 'slate') +
+              P.chip(s.backend, 'slate') + P.chip(s.model, 'slate') +
+              P.chip(P.machineName(s.machine), s.peer ? 'violet' : null) +
+              (s.queue && s.queue.length ? P.chip('needs you', 'attn', 'doorbell') : '') +
+            '</div>' +
+          '</div>' +
+          '<div class="col" style="gap:8px;align-items:flex-end">' +
+            '<div class="row" style="gap:6px">' +
+              (s.phase === 'working' ? '<button class="btn btn-quiet" data-act="pause">' + P.ICON('pause', 15) + ' Pause</button>' : '') +
+              '<button class="btn btn-danger" data-act="stop">' + P.ICON('stop', 15) + ' Stop</button>' +
+              '<button class="btn btn-quiet" data-act="rename">Rename</button>' +
+            '</div>' + P.authline('you', 'owner', 'direct') +
+          '</div>' +
+        '</div>' +
+
+        /* vitals strip */
+        '<div class="card"><div class="factline" style="gap:22px">' +
+          '<span>' + P.fact('turn ' + s.turn) + '</span>' +
+          '<span class="row" style="gap:6px">' + P.fact('context ' + s.tokens.pct + '%') + P.meter(s.tokens.pct) + '</span>' +
+          '<span>' + P.fact('$' + s.cost.toFixed(2)) + '</span>' +
+          '<span>' + P.fact('cache ' + s.cache.hit + '%' + (s.cache.ttl ? ' · ttl ' + s.cache.ttl : '')) + '</span>' +
+          (s.limits.fiveHour != null ? '<span class="row" style="gap:6px">' + P.fact('5h ' + s.limits.fiveHour + '%') + P.meter(s.limits.fiveHour) + '</span>' : '') +
+          '<span class="studio-only">' + P.fact('branch ' + s.branch + ' · ' + s.dirty + ' dirty · ' + (s.ahead || 0) + ' ahead') + '</span>' +
+        '</div></div>' +
+
+        /* its queue items */
+        (q.length ? P.section('Waiting on you, here') + q.map(x => P.decisionCard(x)).join('') : '') +
+
+        /* the folds */
+        P.foldHtml({ key: 'session.timeline', title: 'Timeline', note: 'turns · tools · reasoning', open: true,
+          body: this.timeline(s) }) +
+        P.foldHtml({ key: 'session.changes', title: 'Changes', note: s.dirty + ' files · history & rollback',
+          body: this.changes(s) }) +
+        P.foldHtml({ key: 'session.context', title: 'Context', note: s.tokens.pct + '% of ' + Math.round(s.tokens.ctx / 1000) + 'k',
+          body: this.context(s) }) +
+        P.foldHtml({ key: 'session.controls', title: 'Controls', note: s.backend + ' knobs · approval rules',
+          body: this.controls(s) }) +
+        P.foldHtml({ key: 'session.vitals', title: 'Vitals & lineage', note: 'git · recordings · forks · data',
+          body: this.vitals(s) })
+    });
+
+    this.wire(el, s);
+  },
+
+  timeline(s) {
+    const steer = s.phase === 'working'
+      ? '<div class="panel row" style="margin-bottom:12px">' + P.ICON('send', 14) +
+        '<input class="input" placeholder="Steer mid-turn — it lands at the next safe point…" style="flex:1;border:0;background:none">' +
+        '<button class="btn btn-quiet btn-xs" data-act="steer">steer</button></div>'
+      : '';
+    const log = s.id === 'fix-login' ? P.data.fixLoginLog : [
+      ['10:07:00', 'sys', 'task received — ' + s.task.slice(0, 60)],
+      ['10:07:12', 'tool', 'Read AGENTS.md (241 lines)'],
+      ['10:09:31', 'tool', 'Grep "http://" across docs/src — 31 hits'],
+      ['10:12:44', 'note', 'chapter map built; checking links in file order'],
+      ['10:18:02', 'ok', '41 of 96 chapters clean so far']
+    ];
+    return steer + P.logLines(log) +
+      '<div class="row" style="margin-top:10px;gap:8px">' +
+        '<span class="dim" style="font-size:12px">Verbosity</span>' +
+        '<span class="seg"><button class="on">normal</button><button>verbose</button><button>debug</button></span>' +
+        '<span class="grow"></span>' +
+        '<span class="fact">live · replays on reconnect</span>' +
+      '</div>';
+  },
+
+  changes(s) {
+    if (!s.dirty) return P.empty('check', 'A clean tree', 'This session left no uncommitted changes.');
+    const files = ['src/auth/session.ts (+4 −1)', 'src/middleware/redirect.ts (+2 −1)', 'src/auth/callback.ts (+18 −6)', 'src/routes/login.ts (+9 −2)'];
+    return '<div class="grid" style="grid-template-columns:200px 1fr;gap:12px">' +
+      '<div class="col" style="gap:2px">' + files.map((f, i) =>
+        '<div class="tree-row' + (i === 0 ? ' on' : '') + '">' + P.ICON('file', 13) + P.esc(f) + '</div>').join('') +
+        '<div class="row" style="margin-top:10px;gap:6px;flex-wrap:wrap">' +
+          '<button class="btn btn-quiet btn-xs" data-act="rollback">' + P.ICON('history', 13) + ' rollback…</button>' +
+          '<button class="btn btn-quiet btn-xs">history</button>' +
+        '</div></div>' +
+      '<div>' + P.diffHtml(P.data.sampleDiff) + '</div>' +
+      '</div>';
+  },
+
+  context(s) {
+    const cats = [
+      ['conversation', 41, 'slate'], ['code read', 26, 'sage'], ['tool output', 17, 'violet'],
+      ['system + prompts', 9, 'brass'], ['free', 100 - s.tokens.pct, null]
+    ];
+    const bar = '<div class="row" style="gap:2px;height:22px;border-radius:6px;overflow:hidden">' +
+      cats.filter(c => c[1] > 0).map(c =>
+        '<span style="width:' + c[1] + '%;background:' + (c[2] ? 'rgba(var(--' + c[2] + '-rgb),.5)' : 'var(--surface-3)') + '" title="' + c[0] + ' ' + c[1] + '%"></span>').join('') + '</div>';
+    const legend = '<div class="factline" style="margin-top:8px">' +
+      cats.filter(c => c[2]).map(c => '<span class="fact"><span class="dot dot-' + c[2] + '"></span> ' + c[0] + ' ' + c[1] + '%</span>').join('') + '</div>';
+    return bar + legend +
+      '<div class="dim" style="margin:10px 0;font-size:12.5px">Largest consumers: the auth module read (turn 3), the test run output (turn 12), the system prompt. The 3D scene lives in Station — this is the quiet version.</div>' +
+      P.foldHtml({ key: 'session.managed', title: 'Managed context', note: 'density · anchors · rewind · fission',
+        body:
+        '<div class="grid grid-2">' +
+          '<div class="panel"><div class="eyebrow" style="margin-bottom:6px">Density</div>' +
+            '<div class="kv"><span class="k">compaction pressure</span><span class="v">' + s.tokens.pct + '%</span>' +
+            '<span class="k">anchors</span><span class="v">3 — latest at turn 9</span>' +
+            '<span class="k">last compaction</span><span class="v">turn 11 · kept 62%</span></div></div>' +
+          '<div class="panel"><div class="eyebrow" style="margin-bottom:6px">Rewind</div>' +
+            '<div class="dim" style="font-size:12.5px;margin-bottom:8px">Roll the conversation back to an anchor; carry forward only what you name.</div>' +
+            '<div class="row" style="gap:6px"><span class="chip">turn 9 · cookie fix found</span><span class="chip">turn 4 · map built</span></div>' +
+            '<div class="row" style="margin-top:8px;gap:6px">' +
+              '<button class="btn btn-quiet btn-xs" data-act="rewind">compose rewind…</button>' +
+              '<button class="btn btn-quiet btn-xs">records & backout</button>' +
+              '<button class="btn btn-quiet btn-xs">fission…</button></div></div>' +
+        '</div>' });
+  },
+
+  controls(s) {
+    const isCodex = s.backend === 'codex';
+    const isClaude = s.backend === 'claude-code';
+    let body = '';
+    if (isClaude) {
+      body = '<div class="kv">' +
+        '<span class="k">Model</span><span class="v">claude-fable (override: off)</span>' +
+        '<span class="k">Permission mode</span><span class="v">acceptEdits</span>' +
+        '<span class="k">Allowed tools</span><span class="v">Read, Edit, Bash(npm test:*), Grep, Glob</span>' +
+        '<span class="k">Managed context</span><span class="v">managed</span></div>';
+    } else if (isCodex) {
+      body = '<div class="kv">' +
+        '<span class="k">Model</span><span class="v">gpt-5.2-codex · effort high</span>' +
+        '<span class="k">Sandbox</span><span class="v">workspace-write · network off</span>' +
+        '<span class="k">Writable roots</span><span class="v">~/projects · /tmp</span>' +
+        '<span class="k">Service tier</span><span class="v">default</span></div>' +
+        '<div class="row" style="margin:10px 0;gap:6px;flex-wrap:wrap">' +
+        ['new', 'compact', 'fast', 'fork', 'side', 'undo', 'review', 'goal'].map(a =>
+          '<button class="btn btn-quiet btn-xs" data-thread="' + a + '">/' + a + '</button>').join('') + '</div>';
+    } else {
+      body = '<div class="kv">' +
+        '<span class="k">Execution</span><span class="v">' + s.model + '</span>' +
+        '<span class="k">Sub-agents</span><span class="v">' + s.subagents.length + '</span></div>';
+    }
+    body += '<div class="eyebrow" style="margin:14px 0 6px">Approval rules — this session’s project</div>' +
+      '<div class="col" style="gap:4px">' +
+      [['Read files', 'auto'], ['Edit & write', 'ask'], ['Delete files', 'ask'], ['Run shell commands', 'ask'],
+       ['Network egress', 'auto'], ['Destructive actions', 'deny'], ['Control your display', 'ask'], ['External-agent tool calls', 'ask']
+      ].map(r => '<div class="row"><span style="width:190px">' + r[0] + '</span>' +
+        '<span class="seg">' + ['auto', 'ask', 'deny'].map(v =>
+          '<button class="' + (r[1] === v ? 'on' : '') + '" data-rule="' + r[0] + ':' + v + '">' + v + '</button>').join('') + '</span></div>').join('') +
+      '</div>' +
+      '<div class="dim" style="margin-top:8px;font-size:12px">Rules apply live and save to intendant.toml — “approve all like this” in the queue lands here.</div>';
+    return body;
+  },
+
+  vitals(s) {
+    return '<div class="grid grid-2">' +
+      '<div class="panel"><div class="eyebrow" style="margin-bottom:6px">Git</div>' +
+        '<div class="kv"><span class="k">branch</span><span class="v">' + s.branch + '</span>' +
+        '<span class="k">working tree</span><span class="v">' + (s.dirty ? s.dirty + ' dirty files' : 'clean') + '</span>' +
+        '<span class="k">ahead</span><span class="v">' + (s.ahead || 0) + ' commits</span>' +
+        '<span class="k">merge parity</span><span class="v">with main · clean</span></div></div>' +
+      '<div class="panel"><div class="eyebrow" style="margin-bottom:6px">Lineage</div>' +
+        (s.subagents.length
+          ? '<div class="col" style="gap:6px">' + s.subagents.map(sa =>
+              '<div class="row">' + P.ICON('branch', 13) + '<b>' + P.esc(sa.name) + '</b>' + P.chip(sa.role, 'slate') + '</div>').join('') + '</div>'
+          : '<div class="dim" style="font-size:12.5px">No sub-agents or forks. Fork points appear here when the backend offers them.</div>') +
+        '<div class="row" style="margin-top:8px;gap:6px"><button class="btn btn-quiet btn-xs" data-act="fork">fork from anchor…</button>' +
+        '<button class="btn btn-quiet btn-xs" data-act="delegate">delegate to sub-agent…</button></div></div>' +
+      '<div class="panel"><div class="eyebrow" style="margin-bottom:6px">Recordings & frames</div>' +
+        '<div class="col" style="gap:6px">' +
+        (s.id === 'fix-login'
+          ? '<div class="row">' + P.ICON('record', 14) + '<span>the redirect loop, captured</span><span class="fact">2:14 · 88 MB</span></div>'
+          : '<div class="dim" style="font-size:12.5px">No recordings yet — the house records when you ask, or when a turn goes sideways.</div>') +
+        '</div></div>' +
+      '<div class="panel"><div class="eyebrow" style="margin-bottom:6px">Data</div>' +
+        '<div class="row" style="gap:6px;flex-wrap:wrap">' +
+          '<button class="btn btn-quiet btn-xs" data-act="report">download report (.zip)</button>' +
+          '<button class="btn btn-danger btn-xs" data-act="delete">delete session data…</button>' +
+        '</div>' +
+        '<div class="dim" style="margin-top:8px;font-size:12px">Per-kind deletion: logs, frames, recordings — or everything. The report is the full audit trail.</div></div>' +
+    '</div>';
+  },
+
+  wire(el, s) {
+    el.querySelectorAll('[data-act]').forEach(b => b.addEventListener('click', () => {
+      const act = b.dataset.act;
+      const msgs = {
+        stop: ['Interrupt sent — the turn stops at the next safe point', 'brick'],
+        pause: ['Paused — the session holds its place', 'sage'],
+        rename: ['Rename lives here in the real build', null],
+        steer: ['Steer queued — lands at the next safe point', 'sage'],
+        rollback: ['Rollback would open its confirm dialog — files and/or conversation', null],
+        rewind: ['The rewind composer opens here — anchor, reason, carry-forward', null],
+        fork: ['Fork from an anchor — a sibling session branches off', null],
+        delegate: ['Delegate — spawn a sub-agent with its own brief and worktree', null],
+        report: ['The report zip would download now', 'sage'],
+        delete: ['Deletion is a typed-confirm in the real build — nothing happens here', 'brick']
+      };
+      const m = msgs[act] || ['Done', null];
+      P.toast(m[0], m[1]);
+    }));
+    el.querySelectorAll('[data-thread]').forEach(b => b.addEventListener('click', () =>
+      P.toast('/' + b.dataset.thread + ' sent to ' + s.name, 'sage')));
+    el.querySelectorAll('[data-rule]').forEach(b => b.addEventListener('click', () => {
+      const [rule, v] = b.dataset.rule.split(':');
+      b.closest('.seg').querySelectorAll('button').forEach(x => x.classList.remove('on'));
+      b.classList.add('on');
+      P.toast(rule + ' → ' + v + ' — live, saved to intendant.toml', 'sage');
+    }));
+  }
+};

--- a/docs/design/proscenium/prototype/js/views/settings.js
+++ b/docs/design/proscenium/prototype/js/views/settings.js
@@ -1,0 +1,127 @@
+/* Proscenium — Settings: questions, not subsystems.
+   Every row is ⌘K-addressable (fold ids match data.js); the fine print
+   unfolds to the raw intendant.toml. */
+window.P = window.P || {};
+P.views = P.views || {};
+
+P.views.settings = {
+  title: 'Settings',
+
+  render(el) {
+    const sections = {};
+    P.data.settings.forEach(row => { (sections[row.section] = sections[row.section] || []).push(row); });
+
+    el.innerHTML = P.page({
+      eyebrow: 'how the house behaves',
+      title: 'Settings',
+      sub: 'Plain questions up front. Every knob the daemon honors is here — folded, findable, and one ⌘K away by its plain name (“writable roots”, “quiet hours”…).',
+      body: Object.keys(sections).map(sec =>
+        P.section(sec) + sections[sec].map(row => this.rowHtml(row)).join('')
+      ).join('') +
+      '<div class="row" style="margin-top:16px;gap:8px">' +
+        '<button class="btn btn-primary" id="settings-save">Save</button>' +
+        '<button class="btn btn-quiet">Reset to the daemon’s defaults</button>' +
+        '<span class="grow"></span>' +
+        '<span class="fact">writes intendant.toml · project first, daemon-wide as fallback</span>' +
+      '</div>'
+    });
+
+    this.wire(el);
+  },
+
+  rowHtml(row) {
+    switch (row.kind) {
+      case 'dial': {
+        const levels = [
+          ['Low', 'reads only — it asks before it touches'],
+          ['Medium', 'gate writes — the everyday default'],
+          ['High', 'auto unless a rule says deny'],
+          ['Full', 'ungated — you watch the log, not the queue']
+        ];
+        return '<div class="card"><div class="card-head"><div><h3 class="card-title">Autonomy</h3>' +
+          '<div class="card-sub">' + row.gloss + ' Currently: <b>' + row.value + '</b>.</div></div></div>' +
+          '<div class="grid" style="grid-template-columns:repeat(4,1fr);gap:8px">' +
+          levels.map((l, i) =>
+            '<button class="panel' + (i === 1 ? ' autonomy-on' : '') + '" data-autonomy="' + l[0] + '" style="text-align:left;cursor:pointer;border-color:' + (i === 1 ? 'rgba(var(--brass-rgb),.5)' : 'var(--line)') + '">' +
+            '<b>' + l[0] + '</b><div class="dim" style="font-size:12px;margin-top:2px">' + l[1] + '</div></button>').join('') +
+          '</div></div>';
+      }
+      case 'rules': {
+        return P.foldHtml({ key: 'settings.rules', id: row.fold, title: row.name, note: 'live-applied · saves to intendant.toml',
+          body: '<div class="col" style="gap:4px">' +
+            row.rows.map(r => '<div class="row"><span style="width:210px">' + r[0] + '</span>' +
+              '<span class="seg">' + ['auto', 'ask', 'deny'].map(v =>
+                '<button class="' + (r[1] === v ? 'on' : '') + '" data-srule="' + r[0] + ':' + v + '">' + v + '</button>').join('') + '</span></div>').join('') +
+          '</div>' });
+      }
+      case 'keys': {
+        return P.foldHtml({ key: 'settings.keys', id: row.fold, title: row.name, note: 'presence checked, never shown',
+          body: '<div class="col" style="gap:8px">' +
+            row.rows.map(r => '<div class="row"><span style="width:110px">' + r[0] + '</span>' +
+              '<input class="input mono" type="password" placeholder="••••••••" style="flex:1">' +
+              P.chip(r[1].startsWith('set') ? 'set' : 'not set', r[1].startsWith('set') ? 'sage' : 'attn') + '</div>').join('') +
+            '<div class="dim" style="font-size:12px">Saved to ~/.config/intendant/.env — or skip keys entirely and fuel from the vault (People & Keys).</div>' +
+          '</div>' });
+      }
+      case 'rows': {
+        return P.foldHtml({ key: 'settings.' + row.name, id: row.fold, title: row.name, note: row.rows.length + ' rows',
+          body: '<div class="kv">' + row.rows.map(r =>
+            '<span class="k">' + P.esc(r[0]) + '</span><span class="v">' + P.esc(r[1]) + '</span>').join('') + '</div>' });
+      }
+      case 'appearance': {
+        return P.foldHtml({ key: 'settings.appearance', id: row.fold, title: row.name, note: 'applies instantly, this browser', open: true,
+          body:
+          '<div class="row" style="gap:20px;flex-wrap:wrap">' +
+            '<div><div class="eyebrow" style="margin-bottom:6px">Theme</div>' +
+              '<span class="seg" id="seg-theme">' +
+                '<button data-theme-val="lamplight" class="' + (document.documentElement.dataset.theme === 'lamplight' ? 'on' : '') + '">Lamplight</button>' +
+                '<button data-theme-val="daylight" class="' + (document.documentElement.dataset.theme === 'daylight' ? 'on' : '') + '">Daylight</button>' +
+              '</span></div>' +
+            '<div><div class="eyebrow" style="margin-bottom:6px">Density</div>' +
+              '<span class="seg" id="seg-density">' +
+                ['cozy', 'standard', 'studio'].map(d =>
+                  '<button data-density-val="' + d + '" class="' + (P.density() === d ? 'on' : '') + '">' + d[0].toUpperCase() + d.slice(1) + '</button>').join('') +
+              '</span></div>' +
+            '<div class="dim" style="font-size:12px;max-width:36ch">Cozy speaks first. Studio shows the machinery first. Nothing is hidden at any density — only unfolded.</div>' +
+          '</div>' });
+      }
+      case 'toml': {
+        return P.foldHtml({ key: 'settings.toml', id: row.fold, title: row.name, note: 'the truth is a text file',
+          body:
+          '<div class="panel mono" style="font-size:12px;line-height:1.7;white-space:pre">[agent]\nautonomy = "medium"\napproval_rules = { file_read = "auto", file_write = "ask",\n  file_delete = "ask", command_exec = "ask", network = "auto",\n  destructive = "deny", display_control = "ask", tool_call = "ask" }\n\n[presence]\nenabled = true\ntext_model = "claude-sonnet"\nlive_model = "gemini-2.5-flash-live"\n\n[recording]\nframerate = 5\nquality = "high"</div>' +
+          '<div class="row" style="margin-top:8px;gap:8px">' +
+            '<button class="btn btn-quiet btn-xs" data-act="toml-validate">validate</button>' +
+            '<span class="fact" id="toml-status">valid · matches what the daemon is running</span>' +
+          '</div>' });
+      }
+    }
+    return '';
+  },
+
+  wire(el) {
+    el.querySelectorAll('[data-autonomy]').forEach(b => b.addEventListener('click', () => {
+      el.querySelectorAll('[data-autonomy]').forEach(x => x.style.borderColor = 'var(--line)');
+      b.style.borderColor = 'rgba(var(--brass-rgb),.5)';
+      P.toast('Autonomy → ' + b.dataset.autonomy + ' — takes effect on the next task', 'sage');
+    }));
+    el.querySelectorAll('[data-srule]').forEach(b => b.addEventListener('click', () => {
+      b.closest('.seg').querySelectorAll('button').forEach(x => x.classList.remove('on'));
+      b.classList.add('on');
+      const [rule, v] = b.dataset.srule.split(':');
+      P.toast(rule + ' → ' + v + ' — live', 'sage');
+    }));
+    el.querySelectorAll('[data-theme-val]').forEach(b => b.addEventListener('click', () => {
+      P.setTheme(b.dataset.themeVal);
+      el.querySelectorAll('[data-theme-val]').forEach(x => x.classList.toggle('on', x === b));
+    }));
+    el.querySelectorAll('[data-density-val]').forEach(b => b.addEventListener('click', () => {
+      P.setDensity(b.dataset.densityVal);
+      el.querySelectorAll('[data-density-val]').forEach(x => x.classList.toggle('on', x === b));
+    }));
+    el.querySelector('#settings-save').addEventListener('click', () =>
+      P.toast('Saved to intendant.toml — the daemon picked it up live', 'sage'));
+    const v = el.querySelector('[data-act="toml-validate"]');
+    if (v) v.addEventListener('click', () =>
+      P.toast('Valid TOML — no drift from the running daemon', 'sage'));
+  }
+};

--- a/docs/design/proscenium/prototype/js/views/station.js
+++ b/docs/design/proscenium/prototype/js/views/station.js
@@ -1,0 +1,115 @@
+/* Proscenium — Station: the constellation vantage.
+   A mock of the WebGPU scene, drawn from the same P.data the DOM rooms use —
+   its place in the house, not a second brain. Click a session node to open
+   its space. No timers: all motion is CSS. */
+window.P = window.P || {};
+P.views = P.views || {};
+
+P.views.station = {
+  title: 'Station',
+
+  CX: 500, CY: 280, R: 175, AR: 52,
+
+  render(el) {
+    const working = P.data.sessions.filter(s => s.phase === 'working');
+    const needsYou = P.data.sessions.filter(s => s.queue && s.queue.length);
+
+    el.innerHTML = P.page({
+      eyebrow: 'vantage',
+      title: 'Station',
+      sub: 'The whole house at one glance — every machine, every session, and the one thing glowing for you.',
+      body:
+        '<div class="stn-scene">' + this.scene() + '</div>' +
+        '<div class="stn-hud">' +
+          P.chip(P.data.machines.length + ' hosts', 'slate', 'machines') +
+          P.chip(working.length + ' working', 'sage') +
+          (needsYou.length ? P.chip(needsYou.length + ' needs you', 'attn', 'doorbell') : P.chip('nothing needs you', 'sage')) +
+          P.chip('tunnel live', 'violet') +
+          '<span class="grow"></span>' +
+          '<span class="factline">' +
+            '<span class="fact">' + P.dot('sage') + ' working</span>' +
+            '<span class="fact">' + P.dot('slate') + ' idle / away</span>' +
+            '<span class="fact">' + P.dot('attn') + ' needs you</span>' +
+          '</span>' +
+        '</div>' +
+        '<div class="dim stn-note">The real Station renders this scene in WebGPU and routes every interaction through the same control plane — this is its place in the house, not a second brain. Click a session to open its space.</div>'
+    });
+
+    this.wire(el);
+  },
+
+  /* deterministic PRNG so the starfield doesn't jump between renders */
+  rnd: (function () { let seed = 99; return function () { seed = (seed * 16807) % 2147483647; return seed / 2147483647; }; })(),
+
+  scene() {
+    const cx = this.CX, cy = this.CY, R = this.R;
+    const hostAngles = { local: -90, dell: 30, samsung: 150 };
+    const at = (ox, oy, r, deg) => {
+      const a = deg * Math.PI / 180;
+      return [ox + r * Math.cos(a), oy + r * Math.sin(a)];
+    };
+
+    /* starfield */
+    let stars = '';
+    for (let i = 0; i < 130; i++) {
+      const x = (this.rnd() * 1000).toFixed(1), y = (this.rnd() * 560).toFixed(1);
+      const r = (0.4 + this.rnd() * 0.9).toFixed(2), o = (0.1 + this.rnd() * 0.5).toFixed(2);
+      stars += '<circle class="stn-star' + (i % 9 === 0 ? ' tw' : '') + '" cx="' + x + '" cy="' + y + '" r="' + r + '" opacity="' + o + '"/>';
+    }
+
+    /* orbit rings — the two dashed ones rotate, slowly */
+    const rings =
+      '<g class="stn-spin"><circle class="stn-ring" cx="' + cx + '" cy="' + cy + '" r="' + R + '"/></g>' +
+      '<g class="stn-spin-rev"><circle class="stn-ring" cx="' + cx + '" cy="' + cy + '" r="' + (R + 74) + '"/></g>' +
+      '<circle class="stn-ring-faint" cx="' + cx + '" cy="' + cy + '" r="' + (R - 74) + '"/>';
+
+    /* the operator core — the brass arch */
+    const core =
+      '<g transform="translate(' + cx + ',' + cy + ') scale(0.22) translate(-256,-256)" class="stn-core">' +
+        '<path d="M128 384 L128 240 Q128 128 256 128 Q384 128 384 240 L384 384" fill="none" stroke-width="30" stroke-linecap="round"/>' +
+        '<line x1="256" y1="220" x2="256" y2="330" stroke-width="30" stroke-linecap="round"/>' +
+        '<line x1="236" y1="300" x2="330" y2="180" stroke-width="22" stroke-linecap="round" class="stn-core-accent"/>' +
+      '</g>' +
+      '<text x="' + cx + '" y="' + (cy + 44) + '" class="stn-label">the house</text>' +
+      '<text x="' + cx + '" y="' + (cy + 59) + '" class="stn-sublabel">operator core · you</text>';
+
+    /* hosts + their agents */
+    let hosts = '';
+    P.data.machines.forEach(m => {
+      const pos = at(cx, cy, R, hostAngles[m.id] != null ? hostAngles[m.id] : 0);
+      const hx = pos[0].toFixed(1), hy = pos[1].toFixed(1);
+      const agents = P.data.sessions.filter(s => s.machine === m.id && (s.phase === 'working' || s.phase === 'idle'));
+      hosts += '<line class="stn-link" x1="' + cx + '" y1="' + cy + '" x2="' + hx + '" y2="' + hy + '"/>' +
+        '<circle class="stn-ring-faint" cx="' + hx + '" cy="' + hy + '" r="' + this.AR + '"/>';
+      agents.forEach((s, i) => {
+        const ang = 160 + i * 140;
+        const ap = at(+hx, +hy, this.AR, ang);
+        const ax = ap[0].toFixed(1), ay = ap[1].toFixed(1);
+        /* label rides radially outward from the host so it never crosses the host's own name */
+        const rad = ang * Math.PI / 180, cos = Math.cos(rad), sin = Math.sin(rad);
+        const anchor = cos > 0.3 ? 'start' : cos < -0.3 ? 'end' : 'middle';
+        const lx = (+ax + 11 * cos).toFixed(1), ly = (+ay + 11 * sin + 4).toFixed(1);
+        const needs = s.queue && s.queue.length;
+        hosts += '<g class="stn-agent" data-sess="' + P.esc(s.id) + '">' +
+          '<title>' + P.esc(s.name + ' — ' + s.sentence) + '</title>' +
+          (needs ? '<circle class="stn-glow" cx="' + ax + '" cy="' + ay + '" r="13"/>' : '') +
+          '<circle class="stn-agent-dot ' + (s.phase === 'working' ? 'work' : 'idle') + '" cx="' + ax + '" cy="' + ay + '" r="5.5"/>' +
+          '<text x="' + lx + '" y="' + ly + '" text-anchor="' + anchor + '">' + P.esc(s.name) + '</text>' +
+        '</g>';
+      });
+      hosts += '<g class="stn-host">' +
+        '<circle class="stn-host-dot' + (m.status === 'online' ? '' : ' off') + '" cx="' + hx + '" cy="' + hy + '" r="9"/>' +
+        '<text x="' + hx + '" y="' + (+hy + 28) + '" class="stn-label">' + P.esc(m.petname) + '</text>' +
+        '<text x="' + hx + '" y="' + (+hy + 42) + '" class="stn-sublabel">' + P.esc(m.label + ' · via ' + m.route) + '</text>' +
+      '</g>';
+    });
+
+    return '<svg class="stn-svg" viewBox="0 0 1000 560" preserveAspectRatio="xMidYMid slice" role="img" aria-label="The house constellation">' +
+      stars + rings + core + hosts + '</svg>';
+  },
+
+  wire(el) {
+    el.querySelectorAll('.stn-agent').forEach(g =>
+      g.addEventListener('click', () => P.go('#/work/session/' + g.dataset.sess)));
+  }
+};

--- a/docs/design/proscenium/prototype/js/views/studio.js
+++ b/docs/design/proscenium/prototype/js/views/studio.js
@@ -1,0 +1,356 @@
+/* Proscenium — Studio: the machinery, raw.
+   Workbench (lanes, observer screen, self-test) → raw state (snapshot +
+   live event stream) → reference (keyboard, MCP tools) → the component
+   field guide: every shared component, every state, labeled.
+   Every timer is cleared at the top of render and self-clears when its
+   node leaves the DOM. */
+window.P = window.P || {};
+P.views = P.views || {};
+
+P.views.studio = {
+  title: 'Studio',
+  obsUp: false,
+
+  render(el) {
+    /* timer hygiene — re-render starts clean */
+    if (this._evt) { clearInterval(this._evt); this._evt = null; }
+    if (this._diag) { this._diag.forEach(clearTimeout); this._diag = null; }
+
+    const snapshot = {
+      sessions: P.data.sessions.length,
+      queue: P.data.queue.length,
+      machines: P.data.machines.length,
+      you: P.data.you.name + ' · ' + P.data.you.role + ' · ' + P.data.you.route
+    };
+
+    el.innerHTML = P.page({
+      eyebrow: 'vantage · the machinery, raw',
+      title: 'Studio',
+      sub: 'Everything the friendly rooms polish away: the lanes, the snapshot, the event stream — and the component contract itself, made visible.',
+      body:
+        /* ---------- Workbench ---------- */
+        P.section('Workbench') +
+        '<div class="grid grid-2">' +
+          P.card({
+            title: 'Transport lanes', sub: 'three lanes, one control plane — each labeled by what it carries',
+            body: '<div class="col" style="gap:12px">' +
+              this.lane('HTTP', '/api', '12 ms', 'JSON routes — sessions, files, people, the ledgers') +
+              this.lane('WebSocket', '/ws', '8 ms · 2 clients', 'the event stream — vitals, queue, presence') +
+              this.lane('WebRTC', 'tunnel', '31 ms · DTLS', 'display frames & input — the Screens room rides this') +
+            '</div>'
+          }) +
+          P.card({
+            title: 'Observer debug screen', sub: 'a throwaway virtual display the pipeline can capture while you watch',
+            body:
+              '<div class="row" id="std-obs-row">' + this.obsChip() +
+                '<span class="grow"></span>' +
+                '<button class="btn btn-quiet btn-xs" id="std-obs-up"' + (this.obsUp ? ' disabled' : '') + '>set up</button>' +
+                '<button class="btn btn-quiet btn-xs" id="std-obs-down"' + (this.obsUp ? '' : ' disabled') + '>tear down</button>' +
+              '</div>' +
+              '<div class="dim" style="font-size:12px;margin-top:10px">Xvfb :99 · 1280×720 · captured by the tile encoder — the observer sees exactly what the agent would.</div>'
+          }) +
+        '</div>' +
+        P.card({
+          title: 'Diagnostics', sub: 'the self-test walks every trust and transport assertion, in order',
+          body:
+            '<div class="row">' +
+              '<button class="btn btn-primary" id="std-diag">Run self-test</button>' +
+              '<span class="fact" id="std-diag-status">idle — last run clean, 9 checks</span>' +
+            '</div>' +
+            '<div class="log panel" id="std-diag-log" style="margin-top:12px;min-height:22px"></div>'
+        }) +
+
+        /* ---------- Raw state ---------- */
+        P.foldHtml({ key: 'studio.raw', title: 'Raw state', note: 'the snapshot · live event stream', open: true,
+          body:
+          '<div class="eyebrow" style="margin-bottom:6px">StatusSnapshot (trimmed)</div>' +
+          '<div class="panel mono std-json">' + P.esc(JSON.stringify(snapshot, null, 2)) + '</div>' +
+          '<div class="row" style="margin:16px 0 6px">' +
+            '<span class="eyebrow">AppEvent stream</span>' +
+            '<span class="fact">live · mock fan-out</span>' +
+            '<span class="grow"></span>' +
+            '<button class="btn btn-quiet btn-xs" id="std-evt-pause">pause</button>' +
+          '</div>' +
+          '<div class="log panel std-events" id="std-events"></div>' }) +
+
+        /* ---------- Reference ---------- */
+        P.section('Reference') +
+        '<div class="grid grid-2">' +
+          P.card({
+            title: 'The keyboard', sub: 'the same map the ? overlay shows',
+            body: '<div class="kv">' + this.KEYS.map(r =>
+              '<span class="k mono">' + P.esc(r[0]) + '</span><span class="v" style="font-family:var(--sans)">' + P.esc(r[1]) + '</span>').join('') + '</div>'
+          }) +
+          P.card({
+            title: 'MCP tools', sub: 'the same tools power presence — voice and text call these',
+            body: '<div class="col" style="gap:5px">' + this.TOOLS.map(t =>
+              '<div class="row"><span class="mono" style="width:170px;font-size:12px;flex:none">' + P.esc(t[0]) + '</span>' +
+              '<span class="dim" style="font-size:12.5px">' + P.esc(t[1]) + '</span></div>').join('') + '</div>'
+          }) +
+        '</div>' +
+
+        /* ---------- The component field guide ---------- */
+        P.section('The component field guide — every state, labeled') +
+        '<div class="dim" style="font-size:12.5px;margin-top:-6px">The contract made visible. Specimens marked inert don’t act; everything else behaves.</div>' +
+        '<div class="std-guide">' + this.guide() + '</div>'
+    });
+
+    this.wire(el);
+    this.startEvents(el);
+  },
+
+  lane(name, path, latency, carries) {
+    return '<div class="row">' + P.dot('sage', true) +
+      '<span class="mono" style="width:150px;flex:none">' + P.esc(name) + ' <span class="dim">' + P.esc(path) + '</span></span>' +
+      P.fact(latency) +
+      '<span class="dim" style="font-size:12.5px">' + P.esc(carries) + '</span></div>';
+  },
+
+  obsChip() {
+    return this.obsUp ? P.chip('up · streaming', 'sage') : P.chip('down', 'slate');
+  },
+
+  KEYS: [
+    ['⌘K or /', 'the index — everything, one box'], ['?', 'the keyboard map'],
+    ['g h / w / s / f / m / p / b', 'go: home · work · screens · files · machines · people · books'],
+    ['g ,  ·  g t  ·  g u', 'settings · station · studio'],
+    ['y s a n', 'queue: approve · skip · approve-all · deny'],
+    ['j k', 'move through the queue'], ['x', 'dismiss an FYI'],
+    ['e', 'unfold details'], ['⌘↵', 'send'], ['esc', 'close the top layer']
+  ],
+
+  TOOLS: [
+    ['start_task', 'give the house work'],
+    ['approve', 'allow a queued action'],
+    ['deny', 'refuse it — nothing was touched'],
+    ['take_screenshot', 'see a display, one frame'],
+    ['list_peers', 'who is federated'],
+    ['send_input', 'type or click on a display'],
+    ['rewind_context', 'compose a rewind to an anchor'],
+    ['agenda_op', 'add, complete, reopen on the List'],
+    ['memory_propose', 'offer a claim to the house'],
+    ['spawn_live_audio', 'open a live voice session'],
+    ['get_status', 'the trimmed snapshot'],
+    ['list_sessions', 'what is on stage']
+  ],
+
+  /* ---------------- event stream ---------------- */
+  startEvents(el) {
+    const kinds = [
+      () => 'SessionVitals fix-login cache_ttl=4m12s ctx=82%',
+      () => 'QueueDepth pending=' + P.queueStore.pending().length,
+      () => 'PeerHeartbeat Workshop rtt=88ms route=fleet',
+      () => 'DisplayFrames disp-1 fps=5 tiles=3',
+      () => 'LeaseTick Workshop fuel=2d',
+      () => 'GatewayConn tabs=2 voice=1',
+      () => 'CacheStats claude hit=94%',
+      () => 'SchedulerTick nightly-backup next=02:00',
+      () => 'SessionVitals docs-sweep ctx=35% turn=8',
+      () => 'VaultState sealed entries=4'
+    ];
+    let i = 0;
+    const stamp = () => {
+      const d = new Date();
+      const p = n => String(n).padStart(2, '0');
+      return p(d.getHours()) + ':' + p(d.getMinutes()) + ':' + p(d.getSeconds());
+    };
+    const push = () => {
+      const log = document.getElementById('std-events');
+      if (!log) { clearInterval(this._evt); this._evt = null; return; }
+      const line = P.h('div', null,
+        '<span class="lt">' + stamp() + '</span> ' + P.esc(kinds[i++ % kinds.length]()));
+      log.appendChild(line);
+      while (log.children.length > 28) log.removeChild(log.firstChild);
+      log.scrollTop = log.scrollHeight;
+    };
+    for (let k = 0; k < 6; k++) push();
+    this._evt = setInterval(push, 1600);
+  },
+
+  /* ---------------- field guide ---------------- */
+  guide() {
+    const spec = (label, html, wide) =>
+      '<div class="std-spec' + (wide ? ' std-wide' : '') + '"><div class="std-spec-label">' + P.esc(label) + '</div>' + html + '</div>';
+
+    const demoQ = {
+      id: 'demo-approve', kind: 'approval', sev: 'attention', when: 'now',
+      category: 'file_delete', session: 'demo', machine: 'local', backend: 'Claude Code',
+      title: 'Claude wants to delete 3 files',
+      consequence: 'A specimen of the decision card — the real ones live in the Queue. These buttons are inert.',
+      details: { command: 'rm exports/old.csv', paths: ['exports/old.csv'], rule: 'Always allowing would set file_delete → Auto.', raw: '{ "category": "file_delete", "specimen": true }' },
+      actions: [
+        { id: 'approve', label: 'Allow once', kind: 'safe', key: 'y' },
+        { id: 'always', label: 'Always allow here', kind: 'quiet', key: 'a' },
+        { id: 'deny', label: 'Deny', kind: 'danger', key: 'n', default: true }
+      ]
+    };
+    const demoStage = {
+      id: 'demo-stage', name: 'demo-working', backend: 'claude-code', model: 'claude-fable',
+      machine: 'local', phase: 'working', turn: 5,
+      sentence: 'A specimen stage card — working, with its facts and meter',
+      tokens: { used: 82000, ctx: 200000, pct: 41 }, cost: 0.42, queue: []
+    };
+    const demoStageAttn = {
+      id: 'demo-stage-attn', name: 'demo-needs-you', backend: 'codex', model: 'gpt-5.2-codex',
+      machine: 'dell', phase: 'working', turn: 2, peer: true,
+      sentence: 'The same card, attention tone — the queue chip glows',
+      tokens: { used: 40000, ctx: 272000, pct: 15 }, cost: 0.11, queue: ['demo']
+    };
+
+    return [
+      spec('chips — every kind', '<div class="row" style="flex-wrap:wrap">' +
+        P.chip('default') + P.chip('sage', 'sage') + P.chip('slate', 'slate') +
+        P.chip('brass', 'brass') + P.chip('attn', 'attn') + P.chip('brick', 'brick') +
+        P.chip('violet', 'violet') + P.chip('with icon', 'attn', 'doorbell') + '</div>'),
+
+      spec('dots — always with a word', '<div class="factline">' +
+        '<span class="fact">' + P.dot('sage') + ' sage</span>' +
+        '<span class="fact">' + P.dot('sage', true) + ' pulsing</span>' +
+        '<span class="fact">' + P.dot('attn') + ' attn</span>' +
+        '<span class="fact">' + P.dot('brick') + ' brick</span>' +
+        '<span class="fact">' + P.dot('slate') + ' slate</span></div>'),
+
+      spec('facts & meters', '<div class="col" style="gap:8px">' +
+        '<div>' + P.fact('12 ms · the instrument register') + '</div>' +
+        '<div class="row">' + P.fact('34%') + P.meter(34) + '</div>' +
+        '<div class="row">' + P.fact('74% warn') + P.meter(74) + '</div>' +
+        '<div class="row">' + P.fact('92% hot') + P.meter(92) + '</div></div>'),
+
+      spec('buttons', '<div class="row" style="flex-wrap:wrap">' +
+        '<button class="btn">default</button>' +
+        '<button class="btn btn-primary">primary</button>' +
+        '<button class="btn btn-safe">safe</button>' +
+        '<button class="btn btn-danger">danger</button>' +
+        '<button class="btn btn-quiet">quiet</button>' +
+        '<button class="btn btn-xs">xs</button>' +
+        '<button class="btn" disabled>disabled</button>' +
+        '<button class="icon-btn">' + P.ICON('sparkle', 15) + '</button></div>'),
+
+      spec('segmented control', '<span class="seg"><button class="on">auto</button><button>ask</button><button>deny</button></span>' +
+        '<div class="dim" style="font-size:12px;margin-top:6px">approval rules use these — live-applied</div>'),
+
+      spec('badge & kbd hint', '<div class="row">' +
+        '<span class="badge-count">4</span><span class="dim" style="font-size:12.5px">unread queue depth</span>' +
+        '<span class="grow"></span><span class="kbd-hint">⌘K</span><span class="kbd-hint">y</span></div>'),
+
+      spec('fold — closed & open', '<div class="col" style="gap:8px">' +
+        P.foldHtml({ title: 'A closed fold', note: 'remembers state', open: false, body: '<div class="dim" style="font-size:13px">Power unfolds where you look for it.</div>' }) +
+        P.foldHtml({ title: 'An open fold', note: 'studio opens by default', open: true, body: '<div class="dim" style="font-size:13px">Same contract, opened.</div>' }) +
+        '</div>'),
+
+      spec('decision card — specimen, inert',
+        '<div class="std-specimen" id="std-specimen">' + P.decisionCard(demoQ) + '</div>' +
+        '<div class="dim" style="font-size:12px;margin-top:6px">Wrapped so its buttons toast instead of resolving.</div>', true),
+
+      spec('stage cards — working & needs-you', '<div class="grid grid-2">' +
+        P.stageCard(demoStage) + P.stageCard(demoStageAttn) + '</div>', true),
+
+      spec('empty state', P.empty('stage', 'Nothing on stage', 'Every room ships its empty state — a serif line and one honest next action.')),
+
+      spec('skeleton — loading, never a lone spinner', '<div class="col" style="gap:8px">' +
+        P.skeleton(14, '72%') + P.skeleton(14, '100%') + P.skeleton(14, '45%') + '</div>'),
+
+      spec('diff block', P.diffHtml(P.data.sampleDiff), true),
+
+      spec('kv grid', '<div class="kv">' +
+        '<span class="k">branch</span><span class="v">fix/login-redirect</span>' +
+        '<span class="k">working tree</span><span class="v">12 dirty files</span>' +
+        '<span class="k">cache</span><span class="v">94% · ttl 4m 12s</span></div>'),
+
+      spec('panel — the sunken well', '<div class="panel mono" style="font-size:12px">$ intendant ctl sessions --working</div>'),
+
+      spec('table', '<table class="table"><thead><tr><th>Session</th><th>Cost</th><th>State</th></tr></thead><tbody>' +
+        '<tr><td>fix-login</td><td class="mono">$0.83</td><td>' + P.chip('working', 'sage') + '</td></tr>' +
+        '<tr><td>docs-sweep</td><td class="mono">$0.31</td><td>' + P.chip('working', 'sage') + '</td></tr>' +
+        '<tr><td>q2-invoices</td><td class="mono">$1.12</td><td>' + P.chip('idle', 'slate') + '</td></tr>' +
+        '</tbody></table>', true),
+
+      spec('log lines', P.logLines(P.data.fixLoginLog.slice(0, 5))),
+
+      spec('tree rows', '<div class="tree">' +
+        '<div class="tree-row on">' + P.ICON('folder', 13) + ' ~/projects/shopify-theme/</div>' +
+        '<div class="tree-row">' + P.ICON('file', 13) + ' exports/</div>' +
+        '<div class="tree-row">' + P.ICON('file', 13) + ' src/auth/</div></div>'),
+
+      spec('authline — who acted, by what route', '<div class="col" style="gap:6px">' +
+        P.authline('you', 'owner', 'direct') +
+        P.authline('Workshop', 'operator', 'fleet name') +
+        P.authline('a hosted tab', 'role:none', 'hosted') + '</div>'),
+
+      spec('toast', '<button class="btn btn-quiet" id="std-toast-demo">fire a toast</button>' +
+        '<span class="dim" style="font-size:12px;margin-left:8px">bottom-right · 3.2 s · sage or brick</span>'),
+
+      spec('today ribbon', '<div class="ribbon">' +
+        P.data.today.map(t =>
+          '<div class="ribbon-item' + (t.kind === 'now' ? ' now' : '') + '">' +
+          '<span class="t">' + P.esc(t.t) + '</span><span>' + P.esc(t.label) + '</span></div>').join('') + '</div>', true),
+
+      spec('queue-free — the resolved queue', '<div class="queue-free"><span class="big">You’re free.</span>Nothing needs you. The house will tap you the moment something does.</div>', true)
+    ].join('');
+  },
+
+  /* ---------------- wiring ---------------- */
+  wire(el) {
+    /* observer debug screen */
+    const obsUp = el.querySelector('#std-obs-up'), obsDown = el.querySelector('#std-obs-down');
+    const obsPaint = () => {
+      el.querySelector('#std-obs-row').querySelector('.chip').outerHTML = this.obsChip();
+      obsUp.disabled = this.obsUp; obsDown.disabled = !this.obsUp;
+    };
+    obsUp.addEventListener('click', () => { this.obsUp = true; obsPaint(); P.toast('Observer screen up — Xvfb :99 feeding the tile encoder', 'sage'); });
+    obsDown.addEventListener('click', () => { this.obsUp = false; obsPaint(); P.toast('Observer screen torn down', null); });
+
+    /* diagnostics self-test */
+    el.querySelector('#std-diag').addEventListener('click', () => this.runDiag(el));
+
+    /* event stream pause */
+    const pauseBtn = el.querySelector('#std-evt-pause');
+    pauseBtn.addEventListener('click', () => {
+      if (this._evt) { clearInterval(this._evt); this._evt = null; pauseBtn.textContent = 'resume'; }
+      else { this.startEvents(el); pauseBtn.textContent = 'pause'; }
+    });
+
+    /* field guide: toast demo */
+    const td = el.querySelector('#std-toast-demo');
+    if (td) td.addEventListener('click', () => P.toast('The toast — brief, warm, and gone', 'sage'));
+
+    /* field guide: decision specimen stays inert */
+    const specimen = el.querySelector('#std-specimen');
+    if (specimen) specimen.addEventListener('click', e => {
+      if (e.target.closest('[data-q][data-action]')) {
+        e.stopPropagation();
+        P.toast('A specimen — its buttons are inert. The real ones live in the Queue.', null);
+      }
+    });
+  },
+
+  runDiag(el) {
+    if (this._diag) { this._diag.forEach(clearTimeout); this._diag = null; }
+    const log = el.querySelector('#std-diag-log');
+    const status = el.querySelector('#std-diag-status');
+    log.innerHTML = '';
+    status.textContent = 'running…';
+    const steps = [
+      'route direct mTLS ✓ 12 ms',
+      'route fleet name (Workshop) ✓ 88 ms',
+      'tunnel ICE/DTLS ✓ 204 ms',
+      'vault sealed & reachable ✓',
+      'IAM model compile ✓ 14 ops',
+      'encoder pool vp8 ✓ warm',
+      'hosted provenance pin ✓ role:none',
+      'event bus fan-out ✓ 2 clients',
+      'scheduler tick ✓ next 02:00'
+    ];
+    this._diag = steps.map((s, i) => setTimeout(() => {
+      const target = document.getElementById('std-diag-log');
+      if (!target) return;
+      target.appendChild(P.h('div', null,
+        '<span class="lt">check ' + (i + 1) + '/9</span> <span class="ok">' + P.esc(s) + '</span>'));
+      if (i === steps.length - 1) {
+        const st = document.getElementById('std-diag-status');
+        if (st) st.textContent = 'clean — 9/9 · ' + new Date().toLocaleTimeString();
+        P.toast('Self-test clean — 9 of 9', 'sage');
+      }
+    }, 320 * (i + 1)));
+  }
+};

--- a/docs/design/proscenium/prototype/js/views/work.js
+++ b/docs/design/proscenium/prototype/js/views/work.js
@@ -1,0 +1,160 @@
+/* Proscenium — Work (the Stage): Live · Archive · New · Worktrees. */
+window.P = window.P || {};
+P.views = P.views || {};
+
+P.views.work = {
+  title: 'Work',
+  lane: 'live',
+
+  render(el, params) {
+    const lane = params[0] && ['live', 'archive', 'new', 'worktrees'].includes(params[0]) ? params[0] : this.lane;
+    this.lane = lane;
+    const lanes = [['live', 'Live'], ['archive', 'Archive'], ['new', 'New'], ['worktrees', 'Worktrees']];
+    el.innerHTML = P.page({
+      eyebrow: 'the stage',
+      title: 'Work',
+      sub: 'Everything the house is doing, has done, or could start. One deep page per session — power unfolds where you look for it.',
+      body:
+        '<div class="row" style="justify-content:space-between">' +
+          '<div class="seg">' + lanes.map(l =>
+            '<button class="' + (l[0] === lane ? 'on' : '') + '" data-lane="' + l[0] + '">' + l[1] + '</button>').join('') + '</div>' +
+          P.authline('you', 'owner', 'direct') +
+        '</div>' +
+        '<div id="work-lane">' + this['lane_' + lane]() + '</div>'
+    });
+    el.querySelectorAll('[data-lane]').forEach(b => b.addEventListener('click', () => {
+      P.go('#/work/' + b.dataset.lane);
+    }));
+    this.wire(el, lane);
+  },
+
+  /* ---------------- Live ---------------- */
+  lane_live() {
+    const live = P.data.sessions.filter(s => s.phase === 'working');
+    const idle = P.data.sessions.filter(s => s.phase === 'idle');
+    const machines = P.data.machines.filter(m => live.some(s => s.machine === m.id));
+    const pb = P.data.sessions.find(s => s.id === 'photo-book');
+    return '<div class="row" style="gap:6px;flex-wrap:wrap">' +
+        P.chip('all machines', 'brass') + machines.map(m => P.chip(m.petname, m.id === 'local' ? 'slate' : 'violet')).join('') +
+      '</div>' +
+      '<div class="grid grid-3">' + live.map(P.stageCard).join('') + '</div>' +
+      (pb ? P.section('Just finished — and its sub-agents') +
+        '<div class="grid grid-3">' + P.stageCard(pb) +
+          pb.subagents.map(sa =>
+            '<div class="card"><div class="row">' + P.dot('slate') + '<b>' + P.esc(sa.name) + '</b>' +
+            '<span class="grow"></span>' + P.chip(sa.role, 'slate') + '</div>' +
+            '<div class="card-sub" style="margin-top:6px">' + P.esc(sa.result) + '</div>' +
+            '<div class="factline" style="margin-top:8px">' + P.fact('sub-agent of photo-book') + P.fact('merged') + '</div></div>').join('') +
+        '</div>' : '') +
+      (idle.length ? P.section('Idle — waiting whenever you are') +
+        '<div class="grid grid-3">' + idle.map(P.stageCard).join('') + '</div>' : '');
+  },
+
+  /* ---------------- Archive ---------------- */
+  lane_archive() {
+    const rows = P.data.sessions.filter(s => s.phase !== 'working');
+    return '<div class="row" style="gap:8px;flex-wrap:wrap">' +
+        '<input class="input" id="archive-q" placeholder="Search sessions and their logs…" style="flex:1;min-width:220px">' +
+        P.chip('project: all', null, 'chevdown') + P.chip('source: all', null, 'chevdown') +
+        P.chip('status: all', null, 'chevdown') + P.chip('sort: recent', null, 'chevdown') +
+      '</div>' +
+      '<div class="card" style="padding:6px"><table class="table"><thead><tr>' +
+      '<th>Session</th><th>Source</th><th>Machine</th><th>Status</th><th>Cost</th><th></th></tr></thead><tbody>' +
+      rows.map(s => '<tr data-open-session="' + s.id + '" style="cursor:pointer">' +
+        '<td>' + P.esc(s.name) + '<div class="dim" style="font-weight:400;font-size:12px">' + P.esc(s.sentence) + '</div></td>' +
+        '<td class="mono">' + s.backend + '</td><td>' + P.machineName(s.machine) + '</td>' +
+        '<td>' + P.chip(s.phase === 'done' ? 'finished' : s.phase, s.phase === 'done' ? 'sage' : s.phase === 'idle' ? 'slate' : null) + '</td>' +
+        '<td class="mono">$' + s.cost.toFixed(2) + '</td>' +
+        '<td>' + P.chip('open', null, 'chev') + '</td></tr>').join('') +
+      '</tbody></table></div>' +
+      '<div class="dim" style="font-size:12px">Deep search across full logs lives in ⌘K — type three or more characters and look under “Search deeper”.</div>';
+  },
+
+  /* ---------------- New ---------------- */
+  lane_new() {
+    const fueled = P.data.machines.find(m => m.id === 'local').fueled;
+    return '<div class="card"><div class="card-head"><div>' +
+        '<h3 class="card-title">What should the house do?</h3>' +
+        '<div class="card-sub">One sentence is enough. The house asks if it needs more.</div></div></div>' +
+      '<textarea class="input" id="new-task" rows="3" placeholder="e.g. Tidy my downloads folder — keep anything from this month, archive the rest by year" style="width:100%;font-size:15px"></textarea>' +
+      '<div class="row" style="margin-top:10px;gap:8px;flex-wrap:wrap">' +
+        (fueled ? P.chip('fueled — model credentials active', 'sage', 'fuel')
+                : P.chip('no fuel yet — add API keys', 'attn', 'fuel')) +
+        P.chip('on Studio Mac', 'slate', 'machines') +
+      '</div>' +
+      '<div class="row" style="margin-top:14px;gap:8px">' +
+        '<button class="btn btn-primary" id="new-start">' + P.ICON('send', 15) + ' Start</button>' +
+        '<span class="dim" style="font-size:12.5px">@ aims it at a machine · options unfold below</span>' +
+      '</div></div>' +
+
+      P.foldHtml({ key: 'new.options', title: 'Options', note: 'the full launch panel — nothing removed',
+        body:
+        '<div class="grid grid-2">' +
+          '<div class="panel"><div class="eyebrow" style="margin-bottom:8px">Where</div>' +
+            '<div class="kv"><span class="k">Project</span><span class="v">~/projects/shopify-theme</span>' +
+            '<span class="k">Worktree</span><span class="v">off — work in place</span></div>' +
+            '<div class="row" style="margin-top:8px"><button class="btn btn-quiet btn-xs">browse…</button>' +
+            '<button class="btn btn-quiet btn-xs">run in a git worktree</button></div></div>' +
+          '<div class="panel"><div class="eyebrow" style="margin-bottom:8px">Who does it</div>' +
+            '<div class="col" style="gap:6px">' +
+            ['Internal (orchestrate)', 'Claude Code · claude-fable', 'Codex · gpt-5.2-codex'].map((a, i) =>
+              '<label class="row" style="gap:8px"><input type="radio" name="new-agent" ' + (i === 0 ? 'checked' : '') + '><span>' + a + '</span></label>').join('') +
+            '</div></div>' +
+          '<div class="panel"><div class="eyebrow" style="margin-bottom:8px">Execution</div>' +
+            '<div class="kv"><span class="k">Mode</span><span class="v">auto — the house decides</span>' +
+            '<span class="k">Sandbox</span><span class="v">workspace-write</span>' +
+            '<span class="k">Approval policy</span><span class="v">medium — gate writes</span></div></div>' +
+          '<div class="panel"><div class="eyebrow" style="margin-bottom:8px">Backend pins</div>' +
+            '<div class="kv"><span class="k">Codex effort</span><span class="v">high</span>' +
+            '<span class="k">Managed context</span><span class="v">managed</span>' +
+            '<span class="k">Context replay</span><span class="v">summary</span></div>' +
+            '<div class="dim" style="margin-top:8px;font-size:12px">Every pin the daemon honors — one fold deeper per backend.</div></div>' +
+        '</div>' });
+  },
+
+  /* ---------------- Worktrees ---------------- */
+  lane_worktrees() {
+    const wts = [
+      { name: 'fix/login-redirect', session: 'fix-login', dirty: 12, ahead: 3, risk: 'review', note: '12 files changed — matches the OAuth scope' },
+      { name: 'docs/link-sweep', session: 'docs-sweep', dirty: 6, ahead: 1, risk: 'low', note: 'docs only, no code paths' },
+      { name: 'fix/station-glow', session: 'station-polish', dirty: 0, ahead: 0, risk: 'done', note: 'merged into parent — safe to remove' },
+      { name: 'spike/webgpu-fallback', session: '—', dirty: 31, ahead: 9, risk: 'stale', note: '2 weeks untouched, unmerged commits' }
+    ];
+    return '<div class="row" style="gap:8px;flex-wrap:wrap">' +
+        '<button class="btn btn-quiet btn-xs">' + P.ICON('refresh', 13) + ' scan</button>' +
+        P.chip('active', 'sage') + P.chip('dirty', null) + P.chip('unmerged', null) + P.chip('risk first', 'attn') +
+      '</div>' +
+      '<div class="col" style="gap:10px">' + wts.map(w =>
+        '<div class="card"><div class="row">' + P.ICON('branch', 15) + '<b class="mono">' + w.name + '</b>' +
+          '<span class="grow"></span>' +
+          P.chip(w.risk === 'review' ? 'worth a look' : w.risk === 'low' ? 'low risk' : w.risk === 'done' ? 'merged' : 'stale',
+                 w.risk === 'low' || w.risk === 'done' ? 'sage' : w.risk === 'review' ? 'attn' : 'brick') +
+        '</div>' +
+        '<div class="card-sub" style="margin-top:6px">' + P.esc(w.note) + '</div>' +
+        '<div class="factline" style="margin-top:8px">' + P.fact(w.dirty + ' dirty') + P.fact(w.ahead + ' ahead') +
+          P.fact('session: ' + w.session) + '</div>' +
+        '<div class="row" style="margin-top:10px;gap:6px">' +
+          '<button class="btn btn-quiet btn-xs">inspect</button>' +
+          '<button class="btn btn-quiet btn-xs">open shell</button>' +
+          '<button class="btn btn-quiet btn-xs">open files</button>' +
+          (w.risk === 'done' ? '<button class="btn btn-danger btn-xs">remove</button>' : '') +
+        '</div></div>').join('') + '</div>';
+  },
+
+  wire(el, lane) {
+    if (lane === 'archive') {
+      el.querySelectorAll('[data-open-session]').forEach(r =>
+        r.addEventListener('click', () => P.go('#/work/session/' + r.dataset.openSession)));
+    }
+    if (lane === 'new') {
+      const start = el.querySelector('#new-start');
+      const ta = el.querySelector('#new-task');
+      start.addEventListener('click', () => {
+        const text = (ta.value || '').trim() || 'Tidy my downloads folder';
+        P.toast('The house takes it on', 'sage');
+        P.go('#/home');
+        setTimeout(() => P.views.home.onSend(text), 300);
+      });
+    }
+  }
+};

--- a/docs/design/proscenium/prototype/tokens.css
+++ b/docs/design/proscenium/prototype/tokens.css
@@ -1,0 +1,143 @@
+/* ============================================================
+   Proscenium — design tokens ("House lights")
+   Lamplight (dark, default) · Daylight (light)
+   Density: cozy · standard · studio
+   Doctrine: warm is yours (brass/attn/brick) — cool is the
+   machinery's (sage/slate/violet). Chips always carry words.
+   ============================================================ */
+
+@font-face {
+  font-family: 'Hanken Grotesk';
+  src: url('../../../../static/fonts/hanken-grotesk-latin.woff2') format('woff2');
+  font-weight: 100 900; font-style: normal; font-display: swap;
+}
+@font-face {
+  font-family: 'JetBrains Mono';
+  src: url('../../../../static/fonts/jetbrains-mono-latin.woff2') format('woff2');
+  font-weight: 100 800; font-style: normal; font-display: swap;
+}
+
+:root {
+  /* --- Lamplight (dark) ------------------------------------ */
+  --bg:        #14120F;
+  --bg-1:      #191612;
+  --surface:   #1E1A15;
+  --surface-2: #26211A;
+  --surface-3: #2F2920;
+  --line:      rgba(242,232,213,.09);
+  --line-2:    rgba(242,232,213,.16);
+  --text:      #F1EADC;
+  --text-2:    #C6BAA4;
+  --text-3:    #91866F;
+
+  --brass:     #D2A24C;  --brass-rgb: 210,162,76;
+  --brass-2:   #E4BC72;
+  --on-brass:  #241A08;
+  --attn:      #E8A33D;  --attn-rgb: 232,163,61;
+  --brick:     #D97B66;  --brick-rgb: 217,123,102;
+  --sage:      #8AB894;  --sage-rgb: 138,184,148;
+  --slate:     #7FA6C9;  --slate-rgb: 127,166,201;
+  --violet:    #A58BD4;  --violet-rgb: 165,139,212;
+
+  --shadow-card:    0 1px 0 rgba(255,240,214,.03) inset, 0 2px 10px rgba(0,0,0,.25);
+  --shadow-overlay: 0 12px 40px rgba(0,0,0,.5), 0 2px 8px rgba(0,0,0,.4);
+  --glow-brass: 0 0 0 1px rgba(var(--brass-rgb),.35), 0 0 24px rgba(var(--brass-rgb),.12);
+
+  /* --- Type ------------------------------------------------- */
+  --voice: 'Iowan Old Style', 'Palatino Linotype', Palatino, Georgia, 'Times New Roman', serif;
+  --sans:  'Hanken Grotesk', -apple-system, 'Segoe UI', system-ui, sans-serif;
+  --mono:  'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+
+  --fs-base: 14px;
+  --fs-voice: 16.5px;
+  --fs-display: 30px;
+  --fs-title: 19px;
+  --fs-eyebrow: 11px;
+  --lh: 1.5;
+
+  /* --- Shape & spacing -------------------------------------- */
+  --r-inset: 8px; --r-ctl: 10px; --r-card: 14px; --r-panel: 20px; --r-pill: 999px;
+  --pad-card: 16px 18px;
+  --gap: 14px;
+  --rail-w: 216px;
+  --content-max: 1060px;
+
+  /* --- Motion ------------------------------------------------ */
+  --t-fast: .13s; --t-med: .18s; --t-slow: .24s;
+  --ease: cubic-bezier(.2,.7,.3,1);
+}
+
+html[data-theme="daylight"] {
+  --bg:        #F4EFE4;
+  --bg-1:      #EDE7D8;
+  --surface:   #FFFCF4;
+  --surface-2: #F7F1E3;
+  --surface-3: #EFE7D4;
+  --line:      rgba(58,46,28,.13);
+  --line-2:    rgba(58,46,28,.22);
+  --text:      #262018;
+  --text-2:    #5F574A;
+  --text-3:    #8B8170;
+
+  --brass:     #A67C1F;  --brass-rgb: 166,124,31;
+  --brass-2:   #8F6A15;
+  --on-brass:  #FFF8E6;
+  --attn:      #B97F0F;  --attn-rgb: 185,127,15;
+  --brick:     #B84B39;  --brick-rgb: 184,75,57;
+  --sage:      #3F7D4E;  --sage-rgb: 63,125,78;
+  --slate:     #33608F;  --slate-rgb: 51,96,143;
+  --violet:    #6D52A8;  --violet-rgb: 109,82,168;
+
+  --shadow-card:    0 1px 0 rgba(255,255,255,.6) inset, 0 2px 8px rgba(84,64,30,.10);
+  --shadow-overlay: 0 14px 44px rgba(84,64,30,.22), 0 2px 8px rgba(84,64,30,.14);
+  --glow-brass: 0 0 0 1px rgba(var(--brass-rgb),.4), 0 0 20px rgba(var(--brass-rgb),.14);
+}
+
+/* --- Density ------------------------------------------------- */
+html[data-density="cozy"] {
+  --fs-base: 15px; --fs-voice: 17.5px; --fs-display: 33px; --fs-title: 21px;
+  --gap: 18px; --pad-card: 20px 22px; --content-max: 880px;
+}
+html[data-density="studio"] {
+  --fs-base: 13px; --fs-voice: 15px; --fs-display: 24px; --fs-title: 16px;
+  --gap: 10px; --pad-card: 12px 14px; --content-max: 1280px;
+  --rail-w: 232px;
+}
+
+/* --- Base ---------------------------------------------------- */
+* { box-sizing: border-box; }
+html, body { height: 100%; }
+body {
+  margin: 0;
+  font: 400 var(--fs-base)/var(--lh) var(--sans);
+  background:
+    radial-gradient(1200px 500px at 85% -10%, rgba(var(--brass-rgb),.06), transparent 60%),
+    var(--bg);
+  color: var(--text);
+  -webkit-font-smoothing: antialiased;
+  overflow: hidden;
+}
+::selection { background: rgba(var(--brass-rgb),.32); }
+.voice { font-family: var(--voice); }
+.mono  { font-family: var(--mono); font-size: .92em; }
+.dim   { color: var(--text-3); }
+.grow  { flex: 1 1 auto; }
+[hidden] { display: none !important; }
+
+:focus-visible {
+  outline: 2px solid var(--brass);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+a { color: var(--slate); text-decoration: none; }
+a:hover { text-decoration: underline; }
+a.chip:hover, a.stage-card:hover { text-decoration: none; }
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { animation-duration: .001s !important; transition-duration: .001s !important; }
+}
+
+/* Scrollbars */
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-thumb { background: var(--surface-3); border-radius: 8px; border: 2px solid var(--bg); }
+::-webkit-scrollbar-track { background: transparent; }

--- a/docs/design/proscenium/surfaces.md
+++ b/docs/design/proscenium/surfaces.md
@@ -1,0 +1,366 @@
+# Proscenium — surfaces, specified
+
+Every room of the house: its purpose, layout, components, states, the daemon
+data it renders, and its interactions. Names in `code` are real routes,
+events, methods, and vocabulary from the daemon (see `capability-map.md` for
+the full derivation). Nothing in this file invents a backend capability;
+where a surface would benefit from a projection the daemon doesn't publish
+yet, it is marked **[derived]** (computable client-side from existing events)
+or **[new projection]** (a daemon-side addition worth making, flagged as
+such).
+
+Conventions used below:
+
+- *Decision card* — the Queue's unit (see §1.2).
+- *Stage card* — the arch-topped live-work card (see §1.3).
+- *Fold* — the system-wide disclosure contract (`power-model.md`): every
+  summary carries its machinery one unfold away.
+- *Authority line* — the trust-doctrine badge every pane carries:
+  `you · owner` / `via dell-206 · operator`, plus route chip
+  (`direct` / `fleet name` / `hosted`).
+
+---
+
+## 1. Home
+
+The default screen. The owner's box. Three movements, top to bottom:
+**Needs You → the Conversation → Now Playing & Today.** At Studio density the
+same screen re-flows to a denser grid (queue left, thread center, vitals
+right) — same content, instrument-first.
+
+### 1.1 The briefing
+
+First paint after >1h away (persisted per browser), presence opens the thread
+with the briefing: 3–6 plain sentences covering *finished / failed & retried /
+waiting on you / today*. **[derived]** from `StatusSnapshot`, session events
+(`TaskComplete`, `LoopError`, `DoneSignal`), `AgendaChanged`, and the agenda
+scheduler. A *"Tell me more"* affordance on any sentence drills into the
+session Space or Books entry behind it. Dismissible; never repeated; Studio
+density replaces prose with a compact fact table (same content).
+
+### 1.2 Needs You — the Queue
+
+Pinned above the thread whenever non-empty; a persistent header badge
+(count + highest severity) reachable from every room.
+
+**Item sources (all existing):**
+
+| Queue item | Daemon source | Resolution |
+|---|---|---|
+| Command/tool approval | `ApprovalRequired` (+ category from the 8 shipped categories: `file_read`, `file_write`, `file_delete`, `command_exec`, `network`, `destructive`, `display_control`, `tool_call`) | Approve `y` / Skip `s` / Approve all like this `a` (category rule → `SetApprovalRule`) / Deny `n` |
+| Agent question (free text) | `UserQuestionRequired` / AskHuman panel | Inline answer → respond intent |
+| Structured question (external agents) | `UserQuestionRequired` (multi-question form) | Option buttons + free text → Submit/Skip |
+| Display doorbell | `DisplayRequestRaised` (never auto-approvable) | Allow (15m / this session / until revoked → `ResolveDisplayRequest`) / Deny / Deny for session |
+| Peer doorbell | `/api/peers/pairing/requests` (public knock) | Approve with profile picker (9 real profiles) / Deny |
+| Peer session approvals | `POST /api/peers/{id}/approval` | Approve/Deny/Skip, per-peer |
+| Enrollment request | `/api/access/enrollment-requests` | Grant role (plain-language role picker) / Deny |
+| Hosted-control ask | `/api/hosted-control/requests` | Review ceremony link (presets view/tasks/operate, compiled floor) |
+| Fuel (unfueled / lease dry) | `/api/api-key-status`, lease status events | "Fuel from your vault" → vault lease flow |
+
+**FYI tier** (dismissible, never blocking): `BudgetWarning/Exhausted`,
+watched-task completion, lease-expiry-soon, agenda reminders, stale-build
+nudge, `UserNotification` by `NotificationUrgency` (Info/Attention/Urgent).
+
+**Anatomy of a decision card:**
+
+```
+╭────────────────────────────────────────────────────────────╮
+│ ● ATTENTION · approval                        2 min ago     │
+│ Claude wants to delete 3 files                              │
+│ In ~/projects/exports — this cannot be undone.              │
+│ ┄┄ details ┄┄ (unfolds: exact paths, requesting session,    │
+│    raw command, category, the rule it would set)            │
+│ [Allow once]  [Always allow deletions here]  [Deny]         │
+│ via Studio Mac · you · owner                                │
+╰────────────────────────────────────────────────────────────╯
+```
+
+Safe default is visually primary and stated in words; destructive categories
+(`file_delete`, `destructive`) default-select **Deny**, not Allow — the card
+makes the safe path the easy path, per category policy shipped in Settings.
+Keyboard: `y s a n` act on the top card; `j/k` move through the queue;
+`x` dismisses an FYI; `enter` opens details.
+
+**Empty state** (a feature, not an absence): serif line — *"You're free.
+Three sessions are working; I'll tap you if anything comes up."*
+
+### 1.3 The Conversation
+
+The spine. A single ongoing thread with presence, rendered voice-register
+first:
+
+- **Presence messages** — prose, first person, in the voice face. May carry
+  **inline artifacts**: a changes summary (files + diffstat, unfolds to the
+  real diff), a frame/screenshot, a recording clip, a stat block, a file
+  link, a mini table (e.g. cost of the finished task).
+- **Milestone rows** — task started/steered/completed/failed, rendered as
+  quiet one-liners with a *Show work* unfold that reveals the underlying
+  activity-log lines (the same `AgentOutput`/`ModelResponse` stream Activity
+  shows today). This is the register contract inside the thread.
+- **Decision cards inline** — Queue items also land in the thread at the
+  moment they arise (mirrored, not duplicated: resolving in one place
+  resolves everywhere).
+- **Owner messages** — right-aligned, quiet. `@` autocomplete aims at a
+  session or machine (target chip shown above the composer, same resolution
+  rules as today's prompt-target); `/` surfaces power grammar (real skills,
+  thread actions, `/goal` for Codex); attach stages uploads
+  (`/api/session/current/uploads`); the mic button starts live voice
+  (`presence_connect` / `make_active`) with the transcript landing in the
+  same thread (`UserTranscript`, `PresenceLog` — checkpoint continuity means
+  voice and text share one conversation).
+- **Composer placeholder** rotates honest examples: *"Ask the house
+  anything… e.g. 'tidy my downloads folder', '@fix-login try the tests
+  again', '/codex review the diff'."*
+
+### 1.4 Now Playing & Today
+
+- **Now Playing** — one *stage card* per active session (arch-headed):
+  status **sentence** (from `SessionActivity` + `StatusSnapshot`, rendered
+  as words: "Editing the login flow — turn 14, 12 files changed"), phase,
+  model, a thin token/context meter, needs-you badge if it has Queue items.
+  Primary action: **Open**. Hover/Studio: pause/stop/steer shortcuts. Peer
+  sessions appear as cool-tinted, display-only cards (display-only per the
+  trust model) with the peer's petname and route chip.
+- **Today ribbon** — a horizontal day line: now marker; scheduled sessions
+  (the agenda scheduler's `propose_scheduled_session` occurrences — the SPA's
+  first surface for them **[fills a shipped-daemon gap]**); reminders;
+  milestones as they land. Click an occurrence → its agenda item; the
+  scheduler's approve/revoke owner actions live here.
+
+---
+
+## 2. Work — *the Stage*
+
+Everything about sessions. Four lanes, one row of quiet tabs: **Live ·
+Archive · New · Worktrees** (Deep Search folds into ⌘K and the Archive's
+search field).
+
+### 2.1 Live
+
+The stage grid: stage cards for every active session (any host — the host
+strip pattern from today's Sessions tab, now a *machine filter chip row*
+with petnames). Orchestrations show their sub-agent fan as nested mini-cards
+(parent edges, relationship kind: subagent/fork/side — `SessionRelationship`).
+Sort: attention-first, then activity. Each card → the session Space.
+
+### 2.2 Session Space (the deep surface — the heart of Work)
+
+One page per session. Header: name (rename inline), status sentence, machine
++ route chips, model, cost so far, phase, Stop/Pause. Then five folds —
+first three open at Standard, all open at Studio:
+
+1. **Timeline** — the conversation/log (verbosity switch Normal/Verbose/Debug
+   lives here, folded into the header's ⋯). Turns, tool calls with output
+   previews, reasoning rows (one grammar across Claude thinking / Codex
+   reasoning / native summaries), steer strip, follow-up queue, edit-user-
+   message chip where `SessionCapabilities` allows. Infinite scroll +
+   windowing, as today.
+2. **Changes** — file list + full diff viewer; history timeline with
+   Redo/Prune; rollback modal (files and/or conversation); abandoned-branch
+   fold. (Today's Changes subtab, unchanged in capability.)
+3. **Context** — the token-mass view. The Three.js scene remains available
+   (Studio); Standard renders a quiet 2D category bar + "largest consumers"
+   list (same snapshot data) — the 3D scene is a vantage, not a gate.
+   Managed-context fold beneath: density stats, pressure meter, anchors,
+   the rewind composer, records & backout, fission/lineage ledgers — the
+   full Managed subtab, one unfold deeper.
+4. **Controls** — launch config and backend knobs exactly as today's Control
+   subtab (Codex: thread actions, sandbox, approval policy, model, effort,
+   service tier, tools, writable roots; Claude: model, permission mode,
+   allowed tools; native: approval rules per category). Gated by
+   `SessionCapabilities` — never by backend identity.
+5. **Vitals & lineage** — git branch/dirty/ahead-behind, prompt-cache
+   receipt + TTL, rate-limit windows (`SessionVitals`); lineage fan
+   (parent/children, fork points panel); recordings & frames; logs;
+   background tasks; the report zip; delete-data modal.
+
+Empty/idle/completed states each get real designs (archive resume card;
+interrupted session with Resume/Rollback/Fork actions; abandoned with
+why-it-was-abandoned).
+
+### 2.3 Archive
+
+The session list, calmer: search-first (quick search + message-search union,
+as today), filter *tray* (Project / Source / Status / subagents / superseded)
+collapsed into one control with active-filter chips, 10-way sort behind a
+single "Sort" menu, windowed card list. Session detail overlay is replaced by
+the session Space (2.2) — one deep surface, not two.
+
+### 2.4 New
+
+The launch form, voice-first: one big box ("What should the house do?") with
+the full power folded behind **Options**: project path + Browse, worktree,
+agent picker (Internal/Codex/Claude Code — with fueled/unfueled state inline:
+*"Fueled — model credentials active"* / *"No model credentials — Add API
+keys"*), execution mode, backend pins (per-backend folds), attachments.
+Everything today's New Session form does; the calm version is one sentence.
+
+### 2.5 Worktrees
+
+Today's worktrees panel, re-carded: scan/cached, search, toggles
+(Active/Dirty/Unmerged/Main), risk-first sort, inspect modal (metrics, review
+reasons, dirty files, Open shell / Open files), remove, the session-linked
+finish card. Same verbs, quieter room.
+
+---
+
+## 3. Screens — *see and touch your machines*
+
+The stage-first workspace today's Live display tab built, rounded out with
+the machine's other touch-surfaces:
+
+- **Stage** — live display tiles (WebRTC), per-display toolbar (Take
+  control / Release, Stream to voice, Attach frame, Annotate, Callout,
+  Record, Fullscreen, Close), input-authority badge, CU overlays (agent
+  cursor, ripples, key chips, screenshot flash — the honesty theater of
+  watching it work). Empty state: *"No screens are live — screens appear
+  when the house launches something graphical, or you share yours"* +
+  New virtual display.
+- **Your screen** — the private-view vs share-with-agent grant card
+  (`GrantUserDisplay`/`RevokeUserDisplay`), duration-phrased.
+- **Rail** — displays list, input-authority card with session attribution,
+  display activity feed, peer displays.
+- **Recordings & clips** — the player (MP4 segments + m3u8), annotation
+  toolbar (pen/rect/circle/arrow/text), clip extraction (in/out, FPS,
+  keyframes), Save/Attach/Send.
+- **Terminals** — the PTY (xterm), target machine chip, share (terminal.view/
+  write grants), mobile keybar. Lives here because a shell is how you *touch*
+  a machine; power users pin it.
+- **Browser workspaces** — the agent-driven browser: create (provider:
+  auto/cdp/system_cdp/playwright/agent_browser/stream), lease
+  (Acquire/Release), live view. (Today's Debug-tab surface, promoted to
+  where an owner would look for it.)
+
+---
+
+## 4. Files
+
+The mini-IDE, unchanged in capability, re-skinned: target machine chip
+(blue = this daemon, mauve = peer — the existing whose-disk accent rule),
+tree, tabs, CodeMirror, find-in-file, sha-guarded save, filesystem-grant
+checks with a humane denial state ("The house may read here but not write —
+ask for the key" + request affordance). **Transfers** beside it: downloads,
+uploads (staged, conflict policy), resumable history.
+
+---
+
+## 5. Machines — *the house's wings*
+
+The fleet, first-class:
+
+- **Machine cards** — petname first, self-reported label muted (trust
+  doctrine), status dot + words, route chip (`direct`/`fleet name`/`hosted`),
+  role chip (`operator`, …), capability badges, pressure (CPU/mem from
+  Station's host model), live sessions/displays fold (`PeerSnapshot`).
+  This machine first, then peers.
+- **Link a machine** — the pairing wizard, four modes (Request access /
+  Join invite / Grant invite / Manual), plain-language steps, the honest
+  consequence of each ("This creates a route, not authority — your IAM
+  still decides").
+- **Delegate** — message / delegate task / coordinator route (capability
+  picker → eligible peers → route with instructions): the fleet's real
+  superpower, today buried three folds deep in Access → Daemons.
+- **Machine drill-down** — a machine opens its own Space: its sessions
+  (browse-in-place), its screens, its files, its stats — the multi-host
+  pattern today's host strips invented, given a room.
+
+---
+
+## 6. People & Keys — *who may do what*
+
+Trust administration, humanized without lying:
+
+- **You** — the identity hero: this browser's key, role, route, expiry;
+  the trust-tier card with a one-line honest gloss.
+- **People & devices** — who has access: grants with lifecycle chips
+  (active/draft/revoked/expired), plain-language role previews ("An
+  *operator* can run work and touch screens, but can't change who has
+  keys"), enrollment requests (also in the Queue), join-with-org-grant fold.
+- **Doors** — Connect status & account link, claim-code card (twelve words,
+  one-time, "a name tag, not a key"), hosted-control leases (presets
+  view/tasks/operate + the compiled floor, stated).
+- **Keys & vault** — the vault (unlock/passkeys/entries), **fuel** (leases:
+  grant/renew/revoke, memory-only stated), custody trail as a quiet ledger,
+  client-egress registration, agent-account sign-in ceremonies
+  (Claude/Codex PTY ceremonies, folded deep).
+- **Organizations** — trusted roots, role caps, ORL. Studio-only fold.
+- **Diagnostics** — route health grid, self-test. (The full IAM model —
+  permission matrix, all-grants grid, model inspector — lives one fold down;
+  Studio density opens here directly.)
+
+---
+
+## 7. Books — *the ledgers*
+
+- **Costs & usage** — today's Usage tab, any machine: KPIs, estimated-cost
+  grid, tokens-per-turn, activity skyline + month heatmap, disk usage.
+- **The List** (agenda) — parked tasks/notes/questions, reminders policy
+  (quiet hours), scheduled sessions + their occurrences (second home for the
+  scheduler, with Today on Home), `ctl` hint for power users.
+- **What the house remembers** (memory) — the claims explorer: kinds,
+  sensitivity, candidate lane, durability honesty ("this plane is ephemeral
+  in this build"), propose-a-claim.
+- **Reports & history** — session report zips, the deep-search lane,
+  per-session archives.
+
+---
+
+## 8. Settings — *how the house behaves*
+
+Re-sorted from subsystems to **questions**:
+
+1. **How much may the house do on its own?** — the autonomy dial (4 honest
+   levels) + the 8 approval-rule rows (Auto/Ask/Deny, live-applied).
+2. **Who provides the minds?** — API keys + status, provider/model mirrors,
+   external-agent defaults.
+3. **How does it reach you?** — presence (text/live providers), voice,
+   transcription, notifications (title badge, browser notifications, push),
+   quiet hours.
+4. **What may it see and touch?** — computer use (backend, provider),
+   recording (framerate/quality), display policy.
+5. **How should it look and feel?** — theme, density, composer behavior.
+6. **The fine print** — every remaining row, grouped, folded: env overrides,
+   session report, advanced.
+
+Every row — including folded ones — is in the ⌘K index under plain aliases.
+At the very bottom, Studio density: **the raw file** — `intendant.toml`
+rendered, validated on save, with a "what changed" diff line. The ultimate
+power feature is admitting the truth is a text file.
+
+---
+
+## 9. Station *(vantage)*
+
+The WASM constellation, framed as the house's war room: reached from the nav
+(special glyph) and from any "constellation" link (session → see it in
+Station). Proscenium chrome stays out of its canvas; the composer and Queue
+badge overlay it. The DOM surfaces remain the accessibility floor — Station
+is a presentation of the same control plane, as its own chapter demands.
+
+---
+
+## 10. Studio *(vantage)*
+
+The expert layer, density Studio by default:
+
+- **Workbench** — observer debug screen, diagnostics self-test, module/
+  transport health (the three lanes: HTTP/WS/tunnel, with live status),
+  `GET /debug` internals, visual-freshness rigs.
+- **Raw state** — the control-plane snapshot, event stream (pauseable,
+  filterable), IAM model inspector.
+- **Reference** — the MCP tool list, the route table (derived from
+  `gateway_routes::ROUTES`), keyboard map, the component field guide (every
+  Proscenium component in every state — the prototype ships this as a real
+  page).
+
+---
+
+## Cross-cutting states
+
+Every room ships designed states, not afterthoughts: **loading** (skeleton
+rows, never spinners alone), **empty** (serif line + one honest next action
+— see the copy deck in `visual-language.md`), **denied** (IAM denial: what
+you asked, whose key it needs, how to request it), **offline/reconnecting**
+(the connection chip's story, per lane), **stale build** (the daemon
+updated — reload), **module death** (the canary banner, kept). The
+prototype's field guide renders each.

--- a/docs/design/proscenium/v3-plan.md
+++ b/docs/design/proscenium/v3-plan.md
@@ -1,0 +1,77 @@
+# V3 implementation plan — Proscenium becomes the dashboard
+
+> Status: **landed as a draft** on branch `design/dashboard-north-star`
+> (2026-07-17) — `/v3` serves the full room set, verified end-to-end
+> against a mock-provider daemon (composer task → approval in the Queue →
+> approve in-page → completion milestone, plus every room rendered
+> error-free). Decisions taken with the owner on 2026-07-17:
+>
+> - **Architecture: full replacement trajectory.** V3 is a *new, standalone
+>   front-end codebase* — not a re-skin of the ui-v2 DOM and not a wrapper
+>   around its JS. It talks to the daemon directly (HTTP routes + `/ws`
+>   events; the datachannel tunnel only where HTTP/WS genuinely can't go).
+>   When it proves itself, `static/app.html` gets replaced; until then the
+>   two coexist.
+> - **Default: opt-in.** V2 stays the default at `/`. V3 lives at `/v3`
+>   (embedded like app.html, with an `INTENDANT_V3_HTML_PATH` dev override
+>   mirroring `INTENDANT_APP_HTML_PATH`), linked from V2 ("Try V3"). One
+>   line flips the default when the time comes.
+> - **Depth: deep core + every room re-presented.** Home/Queue/Conversation,
+>   ⌘K, Work/Session Space, Settings, density/theme engines at full depth;
+>   Screens, Files, Machines, People & Keys, Books, Station, Studio as real
+>   V3 rooms over the same routes — plus beyond-parity surfaces the daemon
+>   already supports but the SPA never exposed (the agenda scheduler,
+>   quarantine, invoke_skill, unified doorbells).
+>
+> The concept and its design language: `README.md`, `surfaces.md`,
+> `power-model.md`, `visual-language.md`, `capability-map.md` in this
+> directory. The interactive concept prototype (mock data):
+> `prototype/index.html`.
+
+## Why a clean-room front-end (and what we still borrow)
+
+The ui-v2 chrome re-presents v1's DOM; V3's information architecture
+(conversation-first Home, the unified Queue, intent-named rooms, two
+registers, density) is a different *shape*, not a different skin — re-
+presentation would fight the old DOM at every turn. So V3 is clean-room:
+
+- **No build step, like the target it replaces.** `static/v3/` is plain
+  HTML/CSS/JS (classic scripts, one `V3` namespace), embedded into the
+  binary via the existing `static_assets.rs` table and served at `/v3/*`.
+  No bundler, no framework, no new dependencies.
+- **Everything mutating rides the existing rails.** Tasks, approvals,
+  questions, display grants, autonomy, approval rules, agenda ops — all go
+  out as the same ControlMsgs over `/ws` and the same HTTP routes the V2
+  SPA and MCP use. V3 is a renderer, never a second brain (the control-
+  plane invariant, unchanged).
+- **Derive, don't mirror.** The ⌘K settings index derives from
+  `GET /api/settings`; the queue derives from the event stream + polled
+  routes; the rooms catalog is one declared table. Parity tests pin what
+  must not drift.
+
+## The work, in phases
+
+| # | Phase | Proof |
+|---|---|---|
+| 1 | Wire-protocol recon (auth, WS frames, JSON shapes, serving) | this plan's appendix |
+| 2 | Rust plumbing: embed `static/v3/*`, serve `/v3` + `/v3/*`, dev override, asset-table tests, "Try V3" link in V2 | `cargo test --bins` |
+| 3 | V3 shell: tokens, chrome (rail/topbar/composer), density+theme engines, boot/auth, transport (WS + HTTP + reconnect) | boots against mock daemon |
+| 4 | Home: unified Queue (approvals, questions, display doorbells, enrollment, peer approvals, fuel, FYI), Conversation (presence + milestones + show-work), Now Playing, Today (agenda + **scheduler — first UI**) | Playwright flows vs mock |
+| 5 | ⌘K universal index: rooms/objects/actions/**every settings row** + deep search, jump-and-flash | flows |
+| 6 | Work + Session Space (timeline, changes, context, controls, vitals/lineage) over the real catalog + replay routes | flows |
+| 7 | Settings V3: question-sorted, real GET/POST round-trip, raw TOML view | flows |
+| 8 | Rooms re-presented: Screens, Files, Machines, People & Keys, Books, Station (link to the WASM canvas), Studio | flows |
+| 9 | Beyond-parity: scheduler card, quarantine FYI, invoke_skill in ⌘K, unified peer/hosted doorbells | flows |
+| 10 | Narrative coherence: `docs/src/web-dashboard.md` V3 chapter, this plan's status, CLAUDE.md/AGENTS.md sync (byte parity) | docs gate |
+| 11 | Battery: `cargo test --bins`, `cargo clippy`, mock-daemon E2E, `scripts/validate-dashboard.cjs` boot probe unaffected | green |
+| 12 | **Draft PR** (`gh pr create --draft`), no auto-merge | URL |
+
+## Guardrails
+
+- V2 (`static/app/`, `static/app.html`) is **untouched** except the "Try
+  V3" link; the app-html regen gate stays green.
+- No `unsafe`, no new crates, no changes to the IAM/trust model — V3 is a
+  client of it, badges and all.
+- The V3 page never ships secrets; auth is exactly what the daemon grants
+  the serving context (same as app.html today).
+- File-size budget and code conventions per the repo's AGENTS.md.

--- a/docs/design/proscenium/visual-language.md
+++ b/docs/design/proscenium/visual-language.md
@@ -1,0 +1,164 @@
+# Proscenium — visual language: *House lights*
+
+The current dashboard is a blue-black iris dev-tool. Proscenium is the
+**theater at night, warmed by lamplight** — the owner's side of the
+proscenium arch — with the glyph's golden baton as the accent. Two themes,
+one token system, two type registers, one motif.
+
+---
+
+## 1. The color doctrine
+
+> **Warm is yours. Cool is the machinery's.**
+
+The house, the owner, authority, and anything needing a human decision live
+in the **warm family** (brass, marigold, brick). Agents, machines, and
+informational state live in the **cool family** (sage, slate). Provenance is
+legible before a word is read. Chips stay labeled in words — color is
+garnish, never the message (existing doctrine, kept verbatim).
+
+### Lamplight (dark — default)
+
+| Token | Value | Use |
+|---|---|---|
+| `--bg` | `#14120F` | app ground, warm near-black |
+| `--bg-1` | `#191612` | sunken wells (composer, log) |
+| `--surface` | `#1E1A15` | cards |
+| `--surface-2` | `#26211A` | raised cards, popovers |
+| `--surface-3` | `#2F2920` | hover, active wells |
+| `--line` | `rgba(242,232,213,.09)` | hairlines |
+| `--line-2` | `rgba(242,232,213,.16)` | stronger seams |
+| `--text` | `#F1EADC` | warm off-white ink |
+| `--text-2` | `#C6BAA4` | secondary |
+| `--text-3` | `#91866F` | tertiary, timestamps |
+| `--brass` | `#D2A24C` | primary accent — the baton; primary actions, focus rings, brand |
+| `--brass-2` | `#E4BC72` | hover/highlight |
+| `--on-brass` | `#241A08` | text on brass |
+| `--attn` | `#E8A33D` | *needs you* — queue badges, decision accents |
+| `--brick` | `#D97B66` | danger/deny/destructive |
+| `--sage` | `#8AB894` | healthy work, success, *working* state |
+| `--slate` | `#7FA6C9` | machine/agent information, links to instruments |
+| `--violet` | `#A58BD4` | peer/federation provenance (kept from ui-v2's mauve peer rule) |
+
+Each semantic ships an `-rgb` triplet for alpha tints (fill 8–14%, border
+~25%, text full) — the ui-v2 pattern, kept.
+
+### Daylight (light)
+
+Ground `#F7F3EA` (warm paper), surface `#FFFDF7`, ink `#262018`,
+secondary `#5F574A`, brass deepened to `#A67C1F` for contrast
+(AA on paper), attn `#B97F0F`, brick `#B84B39`, sage `#3F7D4E`, slate
+`#33608F`. Same tokens, remapped — the flip is pure CSS variables, as
+today.
+
+Both themes meet WCAG AA for body text (4.5:1) and UI chrome (3:1); the
+brass/on-brass and sage/text pairings were chosen against both grounds.
+
+---
+
+## 2. Typography — the registers made literal
+
+| Register | Face | Where |
+|---|---|---|
+| **Voice** | `Iowan Old Style, Palatino Linotype, Palatino, Georgia, serif` | greetings, briefing prose, decision-card headlines, space titles, empty states, quoted results |
+| **UI** | `Hanken Grotesk` (self-hosted, as today) | chrome, labels, buttons, forms, chips |
+| **Instrument** | `JetBrains Mono` (self-hosted) | logs, diffs, IDs, paths, JSON, metrics, token counts |
+
+Scale (Standard density): 14px base / 1.5; voice prose 16–18px; display
+(greeting) 28–34px; eyebrow 11px small-caps with .12em tracking (one recipe,
+everywhere). Cozy +1px and +air; Studio −1px and −air, tabular numerals for
+fact columns. Inputs 16px on touch devices (iOS zoom rule, kept).
+
+---
+
+## 3. Shape, elevation, the arch
+
+- **Radii ladder:** 8 inset / 10 control / 14 card / 20 panel / 999 pill.
+- **The arch** — the one motif, used three ways only:
+  1. the brand glyph (already a proscenium arch with the baton),
+  2. **stage cards** (Now Playing / Live work): the header band's top edge
+     carries the arch curve (`border-radius: 46% 46% 0 0 / 18px 18px 0 0`
+     on the band; a card that reads as a lit stage),
+  3. the first-paint **curtain lift** (below).
+  Nothing else arches. Restraint is what keeps it a signature.
+- **Elevation:** warm-tinted shadows (`0 1px 0 rgba(255,240,214,.03)` inset
+  + `0 8px 24px rgba(0,0,0,.35)` on overlays); no blur theatrics on
+  persistent surfaces (the WebGPU recomposite rule, kept); glass reserved
+  for floating chrome over the stage.
+- **Hairlines over fills** for structure; fills reserved for state.
+
+---
+
+## 4. Motion
+
+- **Curtain lift** — first paint only: a 500ms warm fade from `--bg` with
+  the arch glyph settling; once per session, never on navigation.
+- **Decisions arrive** — queue cards slide-settle from the top with a
+  gentle 220ms ease; resolving one lifts it away and slides the rest up
+  (the *you're free* moment should feel like a breath).
+- **Spotlight** — stage cards carry a soft radial highlight that follows
+  the pointer (8% brass tint); off at Cozy, off under
+  `prefers-reduced-motion`.
+- Everything else: 120–180ms ease-out transforms + opacity; no springs, no
+  bounce, no parallax. `prefers-reduced-motion` collapses all of it to
+  instant (existing global rule, kept).
+
+---
+
+## 5. Iconography
+
+Inline 24×24 stroke SVGs, 1.7 stroke, round caps — the ui-v2 registry
+pattern (`ui2Icon`), re-drawn where the house metaphor offers a better
+glyph (doorbell for the queue, baton for actions, wings for machines, key
+for People & Keys, ledger for Books, arch for Home). **No emoji** in chrome
+(the v2 rule, kept). Status dots always paired with words.
+
+---
+
+## 6. The copy deck — how the house speaks
+
+Voice-register copy rules: first person ("I'm working on it"), contractions
+welcome, no exclamation marks, no robot apology, numbers in words under
+ten, and *the honest consequence in every ask*. Samples the prototype
+ships:
+
+- Greeting: *"Good morning. Two things need you; the rest is humming."*
+- Queue empty: *"You're free. Three sessions are working — I'll tap you if
+  anything comes up."*
+- Unfueled: *"This daemon has no fuel yet — the API keys it runs on. Fuel
+  it from your vault and it's off."*
+- Doorbell: *"The session 'fix-login' is asking to see this screen. It can
+  look but not touch, for 15 minutes."*
+- Denied (IAM): *"You asked as a spectator. That needs an operator key —
+  ask the owner, or request it here."*
+- Empty archive: *"Nothing finished yet. Give the house something to do —
+  one sentence is enough."*
+- Offline: *"The line to Studio Mac went quiet. Reconnecting…"*
+
+---
+
+## 7. Accessibility contract
+
+- Keyboard-first: every flow in `power-model.md` §5 works without a
+  pointer; visible `:focus-visible` brass ring (2px, offset 2).
+- ARIA: rooms are `role=main` landmarks; the Queue is `role=log`
+  `aria-live=polite`; decision cards expose their actions as a group with
+  the safe default first in tab order; folds are real `<button>`
+  disclosures with `aria-expanded`.
+- Contrast: AA everywhere (§1); never color-only status (chips labeled,
+  dots paired with words).
+- Reduced motion honored (§4); the curtain lift is skipped.
+- The DOM surface remains the accessibility floor as Station grows —
+  Station's hotspot-mirror pattern stays canonical.
+- Touch: 44px targets, safe-area insets, the composer above the keyboard,
+  no hover-only affordances (folds are taps, not reveals).
+
+---
+
+## 8. Token implementation note
+
+The prototype implements these as `tokens.css` (custom properties under
+`html[data-theme]` + `html[data-density]`), the same alias-layer trick
+ui-v2 uses — so if the concept is adopted, the token file drops into a
+`ui3-tokens` fragment beside `16-styles-v2-tokens.css` and the two systems
+can coexist during migration.

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -114,6 +114,18 @@ needs a normal build. A read failure serves a loud 500 naming the override
 rather than silently falling back to the embedded copy, and the gateway
 logs the active override at startup.
 
+### V3 dashboard dev override
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `INTENDANT_V3_HTML_PATH` | unset | Serve the V3 dashboard (`/v3` and `/v3/*`) from this directory, re-read on every request, instead of the embedded copy |
+
+Development-only, same contract as the app.html override: point it at a
+checkout's `static/v3/` and every browser refresh picks up front-end edits
+with no daemon rebuild. A read failure serves a loud 500 naming the
+override (without echoing the configured path), and the gateway logs the
+active override at startup.
+
 ### Session-log retention variables
 
 | Variable | Default | Description |

--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -18,6 +18,61 @@ the gateway re-read a disk copy of app.html on every request instead of
 serving the embedded one (see [Configuration](./configuration.md)) — edit a
 fragment, run the assembler, refresh.
 
+## V3 — Proscenium (in development; opt-in)
+
+A **second, standalone dashboard** ships alongside the classic SPA at
+**`/v3`** — the implementation of the *Proscenium* design concept (full
+design docs and the clickable concept prototype live in
+`docs/design/proscenium/`). V3 is a clean-room front-end codebase
+(`static/v3/`, plain HTML/CSS/JS, no build step, embedded like every other
+static asset) that talks to the daemon over the same public rails the
+classic SPA uses — the `/ws` event stream + ControlMsg intents + the
+declared HTTP routes. It is a renderer over the one control plane, never a
+second brain, and it changes nothing about IAM, mTLS, or the classic
+dashboard: **`/` stays the default**, and V3 is one click away via the
+"Try V3 ✦" link in the classic nav (a "Classic (V2)" link rides the V3
+rail for the way back). When V3 proves itself, replacing app.html becomes
+a one-line flip; until then both are shipped.
+
+Where the classic dashboard is an operator's cockpit organized by
+subsystem, V3 is organized around the **owner–house relationship**:
+
+- **Home is a conversation, not a log.** Presence speaks first-person
+  (briefing, milestones, "show work" unfolding to the raw lines), the
+  composer takes tasks (with `@`-aiming and `/` grammar), and finished
+  work lands as artifacts in the thread.
+- **The Queue** unifies every decision the daemon can't make alone —
+  command approvals, agent questions, display doorbells, enrollment
+  requests, peer pairing knocks, federated peer approvals, hosted-control
+  asks, fuel — as plain-language cards with the safe default stated, all
+  resolvable inline or by keyboard (`y`/`s`/`a`/`n`).
+- **Eight intent-named rooms** (Home, Work, Screens, Files, Machines,
+  People & Keys, Books, Settings) plus two vantages (Station, Studio),
+  each calm on top with the machinery one unfold away.
+- **Two registers and a density dial** (Cozy / Standard / Studio): plain
+  sentences first, instrument truth (IDs, JSON, routes) always one gesture
+  away. Nothing is renamed per level; everything unfolds.
+- **One universal ⌘K index** — rooms, sessions, machines, people,
+  displays, agenda items, every settings row (derived from the same
+  catalog the Settings room renders), and every action — with
+  jump-and-flash onto the exact folded control.
+
+Beyond parity, V3 surfaces things the daemon already does but no frontend
+had ever shown: the **agenda scheduler** (propose/approve/revoke scheduled
+sessions, in Books → The List and Home's Today ribbon) and the **unified
+doorbells** (pairing requests, hosted-control asks, federated peer
+approvals) collected into the Queue.
+
+Honest gaps in this draft — V3 links to the classic dashboard rather than
+rebuilding these yet: the WebRTC live display stream and input authority,
+the PTY terminal, the tunnel-only vault/egress/custody surfaces, the
+managed-context rewind/fission composer, and the WebGPU Station canvas
+(V3 renders its own small constellation and links the real one).
+
+For iteration, `INTENDANT_V3_HTML_PATH=<dir>` mirrors
+`INTENDANT_APP_HTML_PATH`: the gateway re-reads `static/v3/` from disk on
+every request, so front-end edits need only a browser refresh.
+
 ## On by default
 
 There is no opt-in: the gateway starts automatically unless you pass `--no-web`,

--- a/src/bin/caller/web_gateway/access_gates.rs
+++ b/src/bin/caller/web_gateway/access_gates.rs
@@ -261,8 +261,10 @@ pub(crate) fn has_reverse_proxy_provenance(header_text: &str) -> bool {
 /// ICE/TURN configuration) and every state/action route stays behind IAM.
 pub(crate) fn is_public_dashboard_shell_or_asset(method: &str, path: &str) -> bool {
     matches!(method, "GET" | "HEAD")
-        && (matches!(path, "/" | "/index.html" | "/app" | "/access")
-            || path == "/.well-known/agent-card.json"
+        && (matches!(
+            path,
+            "/" | "/index.html" | "/app" | "/access" | "/v3" | "/v3/"
+        ) || path == "/.well-known/agent-card.json"
             || embedded_static_asset(path).is_some())
 }
 
@@ -834,6 +836,7 @@ mod tests {
             "/index.html",
             "/app",
             "/access",
+            "/v3",
             "/.well-known/agent-card.json",
             "/wasm-web/presence_web.js",
             "/icon-128.png",

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -26,6 +26,11 @@ pub(crate) struct HttpRequestCtx {
     pub(crate) app_html: Arc<String>,
     pub(crate) app_html_override: Option<Arc<std::path::Path>>,
     pub(crate) app_html_cache: Arc<OnceLock<(String, Vec<u8>)>>,
+    /// The V3 dashboard's `INTENDANT_V3_HTML_PATH` dev override (a whole
+    /// directory) and its entry point's per-spawn ETag/gzip cache — the
+    /// app.html pair's exact counterpart for the /v3 serving arms.
+    pub(crate) v3_override_dir: Option<Arc<std::path::Path>>,
+    pub(crate) v3_html_cache: Arc<OnceLock<(String, Vec<u8>)>>,
     pub(crate) worktree_inventory_cache: Arc<Mutex<Option<String>>>,
     pub(crate) mcp_server: Option<Arc<crate::mcp::IntendantServer>>,
     pub(crate) peer_registry: Option<crate::peer::PeerRegistry>,
@@ -94,6 +99,8 @@ pub(crate) async fn serve_http_request(
         app_html,
         app_html_override,
         app_html_cache,
+        v3_override_dir,
+        v3_html_cache,
         worktree_inventory_cache,
         mcp_server,
         peer_registry,
@@ -2123,6 +2130,68 @@ pub(crate) async fn serve_http_request(
             .into_string();
         use tokio::io::AsyncWriteExt;
         let write_ok = stream.write_all(response.as_bytes()).await.is_ok();
+        parked_ok = reuse && write_ok;
+    } else if req_path == "/v3" || req_path == "/v3/" {
+        // The V3 dashboard's entry point — a standalone shell alongside
+        // the classic app.html, on the same serving policy: no-cache,
+        // ETag, gzip, deny-framing. ETag + gzip are computed once per
+        // gateway spawn, on first load (the app_html_cache pattern).
+        // Under INTENDANT_V3_HTML_PATH the override dir's v3.html is
+        // re-read (and re-tagged) on every request instead.
+        let reuse = stream.exchange_reusable();
+        let response = if let Some(dir) = v3_override_dir.as_deref() {
+            v3_override_response(req_method, header_text, req_query, dir, "", reuse)
+        } else {
+            let (etag, gzip) = v3_html_cache.get_or_init(|| {
+                (
+                    asset_etag(V3_HTML.as_bytes()),
+                    gzip_compress(V3_HTML.as_bytes()),
+                )
+            });
+            build_static_asset_response(
+                req_method,
+                header_text,
+                req_query,
+                asset_version(),
+                StaticAssetView {
+                    content_type: "text/html; charset=utf-8",
+                    body: V3_HTML.as_bytes(),
+                    etag,
+                    gzip: Some(gzip),
+                    cache_control: Some("no-cache"),
+                },
+                reuse,
+            )
+        };
+        use tokio::io::AsyncWriteExt;
+        let write_ok = stream.write_all(&response).await.is_ok();
+        parked_ok = reuse && write_ok;
+    } else if let (Some(dir), Some(rest)) =
+        (v3_override_dir.as_deref(), req_path.strip_prefix("/v3/"))
+    {
+        // V3 assets under the override dir: fresh disk read per request,
+        // loud failure — serving the embedded copy would silently mask
+        // the file the developer is iterating on.
+        let reuse = stream.exchange_reusable();
+        let response = v3_override_response(req_method, header_text, req_query, dir, rest, reuse);
+        use tokio::io::AsyncWriteExt;
+        let write_ok = stream.write_all(&response).await.is_ok();
+        parked_ok = reuse && write_ok;
+    } else if let Some(asset) = static_asset_arm(req_method, req_path, v3_asset_paths()) {
+        // The embedded V3 assets, restricted to the declared V3_ASSETS
+        // set — an unregistered /v3/* path falls through to the default
+        // arm like any other unknown path.
+        let reuse = stream.exchange_reusable();
+        let response = build_static_asset_response(
+            req_method,
+            header_text,
+            req_query,
+            asset_version(),
+            asset.view(),
+            reuse,
+        );
+        use tokio::io::AsyncWriteExt;
+        let write_ok = stream.write_all(&response).await.is_ok();
         parked_ok = reuse && write_ok;
     } else if req_method == "GET" || req_method == "HEAD" {
         // Default: serve app.html (also matches /app for

--- a/src/bin/caller/web_gateway/listener.rs
+++ b/src/bin/caller/web_gateway/listener.rs
@@ -1184,6 +1184,26 @@ fn spawn_web_gateway_from_cert_dir_with_relay_listener(
     // rewritten HTML is gateway-scoped (unlike the `include_*!` constants
     // behind `embedded_static_asset`), so its cache lives here.
     let app_html_cache: Arc<OnceLock<(String, Vec<u8>)>> = Arc::new(OnceLock::new());
+    // INTENDANT_V3_HTML_PATH (dev override): read once at spawn; when
+    // set, every /v3 request re-reads that directory instead of serving
+    // the embedded V3 dashboard and its assets.
+    let v3_override_dir: Option<Arc<std::path::Path>> = v3_html_override_dir().map(Arc::from);
+    if let Some(dir) = &v3_override_dir {
+        eprintln!(
+            "[web_gateway] INTENDANT_V3_HTML_PATH: serving the V3 dashboard from {} \
+             (re-read per request; the embedded copy is ignored)",
+            dir.display()
+        );
+        if let Err(err) = std::fs::metadata(dir) {
+            eprintln!(
+                "[web_gateway] WARNING: INTENDANT_V3_HTML_PATH is not readable right now: {err}"
+            );
+        }
+    }
+    // The V3 entry point's per-spawn (ETag token, gzipped body) — the
+    // app_html_cache pattern; V3_HTML is unrewritten, so this is pure
+    // first-load amortization.
+    let v3_html_cache: Arc<OnceLock<(String, Vec<u8>)>> = Arc::new(OnceLock::new());
     let tls_failure_log_state: TlsFailureLogState = Arc::new(Mutex::new(HashMap::new()));
     let lifecycle_shared_session = shared_session.clone();
     let lifecycle_authority = Arc::clone(&display_input_authority);
@@ -1345,6 +1365,8 @@ fn spawn_web_gateway_from_cert_dir_with_relay_listener(
             let app_html = app_html.clone();
             let app_html_cache = app_html_cache.clone();
             let app_html_override = app_html_override.clone();
+            let v3_override_dir = v3_override_dir.clone();
+            let v3_html_cache = v3_html_cache.clone();
             let transcriber = transcriber.clone();
             let active_presence = active_presence.clone();
             let display_input_authority = display_input_authority.clone();
@@ -1757,6 +1779,8 @@ fn spawn_web_gateway_from_cert_dir_with_relay_listener(
                         app_html: app_html.clone(),
                         app_html_override: app_html_override.clone(),
                         app_html_cache: app_html_cache.clone(),
+                        v3_override_dir: v3_override_dir.clone(),
+                        v3_html_cache: v3_html_cache.clone(),
                         worktree_inventory_cache: worktree_inventory_cache.clone(),
                         mcp_server: mcp_server.clone(),
                         peer_registry: peer_registry.clone(),

--- a/src/bin/caller/web_gateway/static_assets.rs
+++ b/src/bin/caller/web_gateway/static_assets.rs
@@ -103,6 +103,182 @@ pub(crate) const FONT_JBMONO_LATIN: &[u8] =
 pub(crate) const FONT_JBMONO_LATIN_EXT: &[u8] =
     include_bytes!("../../../../static/fonts/jetbrains-mono-latin-ext.woff2");
 
+// The standalone V3 dashboard (static/v3/): a second, self-contained
+// shell served at /v3 alongside the classic app.html. Its assets are
+// unversioned — no `?v=` rewrite — so the entry point is served by its
+// own no-cache arm (like app.html) and only the assets in [`V3_ASSETS`]
+// live in the embedded map.
+pub(crate) const V3_HTML: &str = include_str!("../../../../static/v3/v3.html");
+
+pub(crate) const V3_TOKENS_CSS: &str = include_str!("../../../../static/v3/v3-tokens.css");
+
+pub(crate) const V3_APP_CSS: &str = include_str!("../../../../static/v3/v3-app.css");
+
+pub(crate) const V3_ROOMS_CSS: &str = include_str!("../../../../static/v3/v3-rooms.css");
+
+pub(crate) const V3_ICONS_JS: &str = include_str!("../../../../static/v3/js/v3-icons.js");
+
+pub(crate) const V3_TRANSPORT_JS: &str = include_str!("../../../../static/v3/js/v3-transport.js");
+
+pub(crate) const V3_DATA_JS: &str = include_str!("../../../../static/v3/js/v3-data.js");
+
+pub(crate) const V3_UI_JS: &str = include_str!("../../../../static/v3/js/v3-ui.js");
+
+pub(crate) const V3_PALETTE_JS: &str = include_str!("../../../../static/v3/js/v3-palette.js");
+
+pub(crate) const V3_APP_JS: &str = include_str!("../../../../static/v3/js/v3-app.js");
+
+pub(crate) const V3_VIEW_HOME_JS: &str = include_str!("../../../../static/v3/js/views/home.js");
+
+pub(crate) const V3_VIEW_WORK_JS: &str = include_str!("../../../../static/v3/js/views/work.js");
+
+pub(crate) const V3_VIEW_SESSION_JS: &str =
+    include_str!("../../../../static/v3/js/views/session.js");
+
+pub(crate) const V3_VIEW_SCREENS_JS: &str =
+    include_str!("../../../../static/v3/js/views/screens.js");
+
+pub(crate) const V3_VIEW_FILES_JS: &str = include_str!("../../../../static/v3/js/views/files.js");
+
+pub(crate) const V3_VIEW_MACHINES_JS: &str =
+    include_str!("../../../../static/v3/js/views/machines.js");
+
+pub(crate) const V3_VIEW_PEOPLE_JS: &str = include_str!("../../../../static/v3/js/views/people.js");
+
+pub(crate) const V3_VIEW_BOOKS_JS: &str = include_str!("../../../../static/v3/js/views/books.js");
+
+pub(crate) const V3_VIEW_SETTINGS_JS: &str =
+    include_str!("../../../../static/v3/js/views/settings.js");
+
+pub(crate) const V3_VIEW_STATION_JS: &str =
+    include_str!("../../../../static/v3/js/views/station.js");
+
+pub(crate) const V3_VIEW_STUDIO_JS: &str = include_str!("../../../../static/v3/js/views/studio.js");
+
+/// The V3 dashboard's embedded assets — (request path, content type,
+/// body, compressible). One declaration drives both the embedded-asset
+/// map and the `/v3/*` routing arm's path set ([`v3_asset_paths`]), so
+/// the HTML's `<link>`/`<script>` URLs, the map, and the arm can never
+/// drift. v3.html itself is deliberately absent: it is served by its own
+/// no-cache arm (like app.html), never from this table.
+pub(crate) const V3_ASSETS: [(&str, &str, &[u8], bool); 20] = [
+    (
+        "/v3/v3-tokens.css",
+        "text/css",
+        V3_TOKENS_CSS.as_bytes(),
+        true,
+    ),
+    ("/v3/v3-app.css", "text/css", V3_APP_CSS.as_bytes(), true),
+    (
+        "/v3/v3-rooms.css",
+        "text/css",
+        V3_ROOMS_CSS.as_bytes(),
+        true,
+    ),
+    (
+        "/v3/js/v3-icons.js",
+        "application/javascript",
+        V3_ICONS_JS.as_bytes(),
+        true,
+    ),
+    (
+        "/v3/js/v3-transport.js",
+        "application/javascript",
+        V3_TRANSPORT_JS.as_bytes(),
+        true,
+    ),
+    (
+        "/v3/js/v3-data.js",
+        "application/javascript",
+        V3_DATA_JS.as_bytes(),
+        true,
+    ),
+    (
+        "/v3/js/v3-ui.js",
+        "application/javascript",
+        V3_UI_JS.as_bytes(),
+        true,
+    ),
+    (
+        "/v3/js/v3-palette.js",
+        "application/javascript",
+        V3_PALETTE_JS.as_bytes(),
+        true,
+    ),
+    (
+        "/v3/js/v3-app.js",
+        "application/javascript",
+        V3_APP_JS.as_bytes(),
+        true,
+    ),
+    (
+        "/v3/js/views/home.js",
+        "application/javascript",
+        V3_VIEW_HOME_JS.as_bytes(),
+        true,
+    ),
+    (
+        "/v3/js/views/work.js",
+        "application/javascript",
+        V3_VIEW_WORK_JS.as_bytes(),
+        true,
+    ),
+    (
+        "/v3/js/views/session.js",
+        "application/javascript",
+        V3_VIEW_SESSION_JS.as_bytes(),
+        true,
+    ),
+    (
+        "/v3/js/views/screens.js",
+        "application/javascript",
+        V3_VIEW_SCREENS_JS.as_bytes(),
+        true,
+    ),
+    (
+        "/v3/js/views/files.js",
+        "application/javascript",
+        V3_VIEW_FILES_JS.as_bytes(),
+        true,
+    ),
+    (
+        "/v3/js/views/machines.js",
+        "application/javascript",
+        V3_VIEW_MACHINES_JS.as_bytes(),
+        true,
+    ),
+    (
+        "/v3/js/views/people.js",
+        "application/javascript",
+        V3_VIEW_PEOPLE_JS.as_bytes(),
+        true,
+    ),
+    (
+        "/v3/js/views/books.js",
+        "application/javascript",
+        V3_VIEW_BOOKS_JS.as_bytes(),
+        true,
+    ),
+    (
+        "/v3/js/views/settings.js",
+        "application/javascript",
+        V3_VIEW_SETTINGS_JS.as_bytes(),
+        true,
+    ),
+    (
+        "/v3/js/views/station.js",
+        "application/javascript",
+        V3_VIEW_STATION_JS.as_bytes(),
+        true,
+    ),
+    (
+        "/v3/js/views/studio.js",
+        "application/javascript",
+        V3_VIEW_STUDIO_JS.as_bytes(),
+        true,
+    ),
+];
+
 /// Compute a short content hash for cache-busting embedded static assets.
 /// When the WASM, JS, or favicon changes (i.e. a new build), the hash changes,
 /// the URL changes, and browsers fetch the new version.
@@ -300,6 +476,11 @@ pub(crate) fn embedded_static_asset(path: &str) -> Option<&'static EmbeddedStati
             MANIFEST_WEBMANIFEST.as_bytes(),
             false,
         );
+        // The V3 dashboard's assets (the shell itself is served by its
+        // own no-cache arm, like app.html — never from this map).
+        for (path, content_type, body, compressible) in V3_ASSETS {
+            insert(path, content_type, body, compressible);
+        }
         map
     });
     assets.get(path)
@@ -589,6 +770,128 @@ pub(crate) fn vault_kernel_override_response(
         },
         keep_alive,
     ))
+}
+
+/// The request paths of the V3 dashboard's assets, derived once from
+/// [`V3_ASSETS`] — the `/v3/*` routing arm's exact-path allowlist, so a
+/// declared asset is routable by construction (and nothing else is).
+pub(crate) fn v3_asset_paths() -> &'static [&'static str] {
+    static PATHS: OnceLock<Vec<&'static str>> = OnceLock::new();
+    PATHS.get_or_init(|| V3_ASSETS.iter().map(|(path, ..)| *path).collect())
+}
+
+/// The `INTENDANT_V3_HTML_PATH` dev override: serve the V3 dashboard and
+/// its assets from this disk *directory* instead of the embedded copies,
+/// re-reading on every request — a static/v3/ edit shows up on browser
+/// refresh with no daemon rebuild or restart. Read once at gateway
+/// spawn; a whitespace-only value counts as unset.
+pub(crate) fn v3_html_override_dir() -> Option<std::path::PathBuf> {
+    v3_html_override_dir_from(std::env::var("INTENDANT_V3_HTML_PATH").ok())
+}
+
+fn v3_html_override_dir_from(raw: Option<String>) -> Option<std::path::PathBuf> {
+    let raw = raw?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(std::path::PathBuf::from(trimmed))
+}
+
+/// Content type for a file served from the V3 override directory, by
+/// extension; anything unrecognized is opaque bytes.
+fn v3_override_content_type(rest: &str) -> &'static str {
+    match rest.rsplit('.').next() {
+        Some("html") => "text/html; charset=utf-8",
+        Some("css") => "text/css",
+        Some("js") => "application/javascript",
+        Some("png") => "image/png",
+        Some("svg") => "image/svg+xml",
+        Some("woff2") => "font/woff2",
+        Some("json") => "application/json",
+        _ => "application/octet-stream",
+    }
+}
+
+/// Serve one V3 dashboard request under the `INTENDANT_V3_HTML_PATH`
+/// override: `<dir>/v3.html` for the entry point (empty `rest`), else
+/// `<dir>/<rest>` — a fresh disk read either way, a fresh strong ETag
+/// (an unchanged file still revalidates to 304), no-cache, no gzip, and
+/// deny-framing on HTML via [`build_static_asset_response`]. Any `..` in
+/// `rest` is rejected outright: the override dir is the root this lane
+/// may read from. A read failure is a loud 500 naming the override —
+/// falling back to the embedded copy would silently mask the broken path
+/// the developer is trying to iterate on.
+pub(crate) fn v3_override_response(
+    method: &str,
+    header_text: &str,
+    query: &str,
+    dir: &std::path::Path,
+    rest: &str,
+    keep_alive: bool,
+) -> Vec<u8> {
+    if rest.contains("..") {
+        let body = "V3 asset paths may not contain '..'.\n";
+        let mut response = HttpResponse::new("400 Bad Request")
+            .header("Content-Type", "text/plain; charset=utf-8")
+            .header("Content-Length", body.len().to_string())
+            .header("Cache-Control", "no-store")
+            .header("Access-Control-Allow-Origin", "*")
+            .connection_reuse(keep_alive)
+            .into_bytes();
+        if method != "HEAD" {
+            response.extend_from_slice(body.as_bytes());
+        }
+        return response;
+    }
+    let file_rel = if rest.is_empty() { "v3.html" } else { rest };
+    let target = dir.join(file_rel);
+    match std::fs::read(&target) {
+        Ok(body) => {
+            let etag = asset_etag(&body);
+            build_static_asset_response(
+                method,
+                header_text,
+                query,
+                asset_version(),
+                StaticAssetView {
+                    content_type: v3_override_content_type(file_rel),
+                    body: &body,
+                    etag: &etag,
+                    gzip: None,
+                    cache_control: Some("no-cache"),
+                },
+                keep_alive,
+            )
+        }
+        Err(err) => {
+            // The configured path and the OS error stay server-side
+            // (the app.html override's rationale: this response is
+            // served certificate-free from the shell lane, so a body
+            // echoing the absolute override path would hand any
+            // reachable page a local username/project layout whenever
+            // the dev override is broken).
+            eprintln!(
+                "[web_gateway] INTENDANT_V3_HTML_PATH read failed ({}): {err}",
+                target.display()
+            );
+            let body = "INTENDANT_V3_HTML_PATH override is active but the requested \
+                 V3 file could not be read. Check the daemon log for the path and \
+                 error, then fix the override directory (or unset \
+                 INTENDANT_V3_HTML_PATH) and refresh.\n";
+            let mut response = HttpResponse::new("500 Internal Server Error")
+                .header("Content-Type", "text/plain; charset=utf-8")
+                .header("Content-Length", body.len().to_string())
+                .header("Cache-Control", "no-store")
+                .header("Access-Control-Allow-Origin", "*")
+                .connection_reuse(keep_alive)
+                .into_bytes();
+            if method != "HEAD" {
+                response.extend_from_slice(body.as_bytes());
+            }
+            response
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1212,6 +1515,164 @@ mod tests {
         assert!(!text.contains(&dir.path().display().to_string()));
         // HEAD keeps the status but sends headers only.
         let head = app_html_override_response("HEAD", "", "", &path, false);
+        let head = String::from_utf8_lossy(&head);
+        assert!(head.starts_with("HTTP/1.1 500"));
+        assert!(head.ends_with("\r\n\r\n"));
+    }
+
+    /// The V3 catalog: every declared asset is embedded with its declared
+    /// content type and body, and the shell references every declared
+    /// asset — a declared path v3.html never fetches is drift between the
+    /// catalog and the page.
+    #[test]
+    fn v3_assets_are_embedded_and_referenced_by_the_shell() {
+        assert!(!V3_HTML.is_empty());
+        assert!(V3_HTML.contains("<!DOCTYPE html>"));
+        for (path, content_type, body, _compressible) in V3_ASSETS {
+            assert!(path.starts_with("/v3/"), "{path} must live under /v3/");
+            let asset = embedded_static_asset(path).expect(path);
+            assert_eq!(asset.content_type, content_type, "{path}");
+            assert_eq!(asset.body, body, "{path}");
+            assert!(!body.is_empty(), "{path} must not embed an empty file");
+            assert!(V3_HTML.contains(path), "v3.html must reference {path}");
+        }
+        // The entry point itself is NOT in the embedded map: it is served
+        // by its own no-cache arm, like app.html.
+        assert!(embedded_static_asset("/v3").is_none());
+        assert!(embedded_static_asset("/v3/v3.html").is_none());
+    }
+
+    /// The `/v3/*` arm's allowlist is derived from the declared assets and
+    /// keeps the arm's GET/HEAD + exact-path semantics.
+    #[test]
+    fn v3_asset_paths_match_the_declared_assets() {
+        let paths = v3_asset_paths();
+        assert_eq!(paths.len(), V3_ASSETS.len());
+        for (path, ..) in V3_ASSETS {
+            assert!(paths.contains(&path), "{path} must be routable");
+        }
+        let asset = static_asset_arm("GET", "/v3/v3-app.css", paths).expect("declared css");
+        assert_eq!(asset.content_type, "text/css");
+        assert_eq!(asset.body, V3_APP_CSS.as_bytes());
+        assert!(static_asset_arm("HEAD", "/v3/js/v3-app.js", paths).is_some());
+        // Non-GET/HEAD and undeclared paths (including the shell itself)
+        // fall through to later arms.
+        assert!(static_asset_arm("POST", "/v3/v3-app.css", paths).is_none());
+        assert!(static_asset_arm("GET", "/v3/v3.html", paths).is_none());
+        assert!(static_asset_arm("GET", "/v3/js/views/nope.js", paths).is_none());
+    }
+
+    #[test]
+    fn v3_override_dir_blank_values_count_as_unset() {
+        assert_eq!(v3_html_override_dir_from(None), None);
+        assert_eq!(v3_html_override_dir_from(Some(String::new())), None);
+        assert_eq!(v3_html_override_dir_from(Some("   ".into())), None);
+        assert_eq!(
+            v3_html_override_dir_from(Some(" /tmp/v3 ".into())),
+            Some(std::path::PathBuf::from("/tmp/v3"))
+        );
+    }
+
+    #[test]
+    fn v3_override_content_type_by_extension() {
+        assert_eq!(
+            v3_override_content_type("v3.html"),
+            "text/html; charset=utf-8"
+        );
+        assert_eq!(v3_override_content_type("v3-app.css"), "text/css");
+        assert_eq!(
+            v3_override_content_type("js/v3-app.js"),
+            "application/javascript"
+        );
+        assert_eq!(v3_override_content_type("icon.png"), "image/png");
+        assert_eq!(v3_override_content_type("icon.svg"), "image/svg+xml");
+        assert_eq!(v3_override_content_type("font.woff2"), "font/woff2");
+        assert_eq!(v3_override_content_type("data.json"), "application/json");
+        assert_eq!(
+            v3_override_content_type("README"),
+            "application/octet-stream"
+        );
+        assert_eq!(
+            v3_override_content_type("archive.bin"),
+            "application/octet-stream"
+        );
+    }
+
+    #[test]
+    fn v3_override_rejects_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        for rest in ["../app.html", "js/../../secret", "v3..html"] {
+            let resp = v3_override_response("GET", "", "", dir.path(), rest, false);
+            let text = String::from_utf8_lossy(&resp);
+            assert!(text.starts_with("HTTP/1.1 400"), "{rest} must be rejected");
+        }
+        // HEAD on a rejected path keeps the status but sends headers only.
+        let head = v3_override_response("HEAD", "", "", dir.path(), "../x", false);
+        let head = String::from_utf8_lossy(&head);
+        assert!(head.starts_with("HTTP/1.1 400"));
+        assert!(head.ends_with("\r\n\r\n"));
+    }
+
+    #[test]
+    fn v3_override_serves_html_at_empty_rest_and_rereads() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("v3.html"), "<!DOCTYPE html>v3-one").unwrap();
+        let first = v3_override_response("GET", "", "", dir.path(), "", false);
+        let first = String::from_utf8_lossy(&first);
+        assert!(first.starts_with("HTTP/1.1 200 OK\r\n"));
+        assert!(first.contains("Content-Type: text/html"));
+        assert!(first.contains("Cache-Control: no-cache"));
+        // HTML is deny-framed, like every dashboard response.
+        assert!(first.contains("X-Frame-Options: DENY"));
+        assert!(first.ends_with("v3-one"));
+
+        // An edit is visible on the very next request — nothing caches it.
+        std::fs::write(dir.path().join("v3.html"), "<!DOCTYPE html>v3-two").unwrap();
+        let second = v3_override_response("GET", "", "", dir.path(), "", false);
+        let second = String::from_utf8_lossy(&second);
+        assert!(second.ends_with("v3-two"));
+
+        // Unchanged content still revalidates to a 304 via its fresh ETag.
+        let etag = second
+            .split("ETag: \"")
+            .nth(1)
+            .and_then(|rest| rest.split('"').next())
+            .expect("override response carries an ETag")
+            .to_string();
+        let third = v3_override_response(
+            "GET",
+            &format!("If-None-Match: \"{etag}\"\r\n"),
+            "",
+            dir.path(),
+            "",
+            false,
+        );
+        assert!(String::from_utf8_lossy(&third).starts_with("HTTP/1.1 304"));
+    }
+
+    #[test]
+    fn v3_override_serves_assets_and_missing_is_a_loud_500() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("js")).unwrap();
+        std::fs::write(dir.path().join("js/v3-app.js"), "window.V3={};").unwrap();
+        let resp = v3_override_response("GET", "", "", dir.path(), "js/v3-app.js", false);
+        let text = String::from_utf8_lossy(&resp);
+        assert!(text.starts_with("HTTP/1.1 200 OK\r\n"));
+        assert!(text.contains("Content-Type: application/javascript"));
+        assert!(text.contains("Cache-Control: no-cache"));
+        assert!(text.ends_with("window.V3={};"));
+
+        let resp = v3_override_response("GET", "", "", dir.path(), "js/missing.js", false);
+        let text = String::from_utf8_lossy(&resp);
+        assert!(text.starts_with("HTTP/1.1 500"));
+        assert!(text.contains("INTENDANT_V3_HTML_PATH"));
+        // The absolute path (and the OS error) must never reach the body —
+        // this page is readable certificate-free, and the path leaks a
+        // local username/project layout. It is logged server-side instead.
+        assert!(!text.contains("missing.js"));
+        assert!(!text.contains(&dir.path().display().to_string()));
+        // HEAD keeps the status but sends headers only.
+        let head = v3_override_response("HEAD", "", "", dir.path(), "js/missing.js", false);
         let head = String::from_utf8_lossy(&head);
         assert!(head.starts_with("HTTP/1.1 500"));
         assert!(head.ends_with("\r\n\r\n"));

--- a/static/app/ui2-chrome.css
+++ b/static/app/ui2-chrome.css
@@ -118,6 +118,13 @@ html.ui-v2 .ui2-nav-bottom {
   padding: 10px; border-top: 1px solid var(--line);
   display: flex; flex-direction: column; gap: 8px;
 }
+html.ui-v2 .ui2-v3-link {
+  display: block; padding: 6px 10px; border: 1px solid rgba(var(--iris-rgb), .35);
+  border-radius: var(--r-ctl); color: var(--iris); text-decoration: none;
+  font: 600 12px var(--sans); text-align: center; letter-spacing: .02em;
+  background: rgba(var(--iris-rgb), .08);
+}
+html.ui-v2 .ui2-v3-link:hover { background: rgba(var(--iris-rgb), .16); }
 html.ui-v2 .ui2-autonomy {
   display: flex; align-items: center; gap: 10px; width: 100%;
   padding: 8px 10px; border: 1px solid var(--line); border-radius: var(--r-ctl);

--- a/static/app/ui2-shell.html
+++ b/static/app/ui2-shell.html
@@ -45,6 +45,7 @@
   <div class="ui2-nav-groups" id="ui2-nav-groups"><!-- built by ui2-chrome.js --></div>
 
   <div class="ui2-nav-bottom">
+    <a href="/v3" class="ui2-v3-link ui2-nav-label" title="Try the V3 concept dashboard (Proscenium) — the classic dashboard stays right here">Try V3 ✦</a>
     <button type="button" class="ui2-autonomy" id="ui2-autonomy-btn"
             title="Autonomy level — opens Settings">
       <span class="ui2-autonomy-icon" id="ui2-autonomy-icon"></span>

--- a/static/v3/js/v3-app.js
+++ b/static/v3/js/v3-app.js
@@ -1,0 +1,256 @@
+/* V3 — app shell: router, rail, topbar, composer, keyboard, theme/density,
+   queue drawer. Boot order: transport → data → subscribe → route.
+   V3 is a renderer over the one control plane, never a second brain. */
+window.V3 = window.V3 || {};
+
+V3.ROOMS = [
+  { id: 'home',     title: 'Home',          icon: 'arch',     gloss: 'the conversation · needs you' },
+  { id: 'work',     title: 'Work',          icon: 'stage',    gloss: 'sessions on stage' },
+  { id: 'screens',  title: 'Screens',       icon: 'screens',  gloss: 'see & touch your machines' },
+  { id: 'files',    title: 'Files',         icon: 'files',    gloss: 'the desk · transfers' },
+  { id: 'machines', title: 'Machines',      icon: 'machines', gloss: 'the fleet · pairing · delegation' },
+  { id: 'people',   title: 'People & Keys', icon: 'key',      gloss: 'who may do what · vault' },
+  { id: 'books',    title: 'Books',         icon: 'books',    gloss: 'costs · the list · memory' },
+  { id: 'settings', title: 'Settings',      icon: 'settings', gloss: 'how the house behaves' }
+];
+V3.VANTAGES = [
+  { id: 'station', title: 'Station', icon: 'station', gloss: 'the constellation' },
+  { id: 'studio',  title: 'Studio',  icon: 'studio',  gloss: 'the machinery, raw' }
+];
+
+V3.current = null;
+V3._subs = [];
+
+/* tiny state bus: views and chrome subscribe to store changes */
+V3.bus = {
+  sub(fn) { V3._subs.push(fn); },
+  emit(what) {
+    for (const fn of V3._subs) { try { fn(what); } catch (e) { console.error('[v3] bus listener', e); } }
+  }
+};
+
+V3.go = function (hash) {
+  if (location.hash === hash) V3.route();
+  else location.hash = hash;
+};
+V3.rerender = function () { V3.route(); };
+
+V3.route = function () {
+  const raw = (location.hash || '#/home').replace(/^#\/?/, '');
+  const parts = raw.split('/').filter(Boolean);
+  let viewId = parts[0] || 'home';
+  let params = parts.slice(1);
+
+  if (viewId === 'work' && params[0] === 'session') { viewId = 'session'; params = params.slice(1); }
+  if (!V3.views[viewId]) { viewId = 'home'; params = []; }
+
+  V3.current = viewId;
+  const view = V3.views[viewId];
+  const main = document.getElementById('main');
+  main.innerHTML = '';
+  view.render(main, params);
+  V3.mountIcons(main);
+  main.scrollTop = 0;
+
+  document.querySelectorAll('#rail-rooms .rail-item, #rail-vantages .rail-item').forEach(a => {
+    a.classList.toggle('on', a.dataset.room === viewId || (viewId === 'session' && a.dataset.room === 'work'));
+  });
+
+  const room = V3.ROOMS.concat(V3.VANTAGES).find(r => r.id === viewId);
+  document.getElementById('topbar-title').textContent =
+    viewId === 'session' ? 'Work' : room ? room.title : '';
+
+  V3.renderTopFacts();
+  V3.renderQueueBadge();
+  V3.renderRailIdentity();
+};
+
+V3.renderTopFacts = function () {
+  const d = V3.data;
+  const working = d.sessions.filter(s => s.active).length;
+  const conn = V3.transport.state; // 'connecting' | 'live' | 'offline'
+  const facts = [
+    '<span>' + working + ' working</span>',
+    '<span>' + V3.queueStore.pending().length + ' need you</span>'
+  ];
+  if (conn !== 'live') facts.push('<span class="chip chip-attn">reconnecting…</span>');
+  else facts.push('<span class="studio-only">' + V3.esc(d.connFact || 'live') + '</span>');
+  document.getElementById('topbar-facts').innerHTML = facts.join('');
+};
+
+/* ---------------- rail ---------------- */
+V3.buildRail = function () {
+  document.getElementById('rail-rooms').innerHTML = V3.ROOMS.map(r =>
+    '<a class="rail-item" data-room="' + r.id + '" href="#/' + r.id + '" title="' + V3.esc(r.gloss) + '">' +
+    '<span class="icon">' + V3.icon(r.icon) + '</span><span class="rail-label">' + r.title + '</span></a>').join('');
+  document.getElementById('rail-vantages').innerHTML =
+    '<div class="rail-group-label">Vantages</div>' +
+    V3.VANTAGES.map(r =>
+      '<a class="rail-item" data-room="' + r.id + '" href="#/' + r.id + '" title="' + V3.esc(r.gloss) + '">' +
+      '<span class="icon">' + V3.icon(r.icon) + '</span><span class="rail-label">' + r.title + '</span></a>').join('');
+  V3.mountIcons(document.getElementById('rail'));
+};
+
+V3.renderRailIdentity = function () {
+  const you = V3.data.you || {};
+  document.getElementById('rail-identity').innerHTML =
+    '<div class="authline"><span class="who">' + V3.esc(you.name || 'you') + ' · ' + V3.esc(you.role || 'owner') + '</span>' +
+    (you.route ? V3.routeChip(you.route) : '') + '</div>';
+};
+
+/* ---------------- queue badge + drawer ---------------- */
+V3.renderQueueBadge = function () {
+  const n = V3.queueStore.pending().length;
+  const badge = document.getElementById('rail-queue-count');
+  badge.hidden = n === 0;
+  badge.textContent = n;
+  document.title = (n ? '(' + n + ') ' : '') + 'Intendant';
+  V3.renderTopFacts();
+};
+
+V3.openQueueDrawer = function () {
+  const drawer = document.getElementById('queue-drawer');
+  const panel = document.getElementById('queue-panel');
+  const pending = V3.queueStore.pending();
+  const fyis = V3.queueStore.fyis();
+  panel.innerHTML =
+    '<div class="row"><h2 class="voice" style="margin:0;font-size:22px">Needs you</h2><span class="grow"></span>' +
+    '<button class="icon-btn" id="queue-close">' + V3.icon('x') + '</button></div>' +
+    (pending.length || fyis.length
+      ? pending.map(q => V3.decisionCard(q)).join('') +
+        (fyis.length ? '<div class="eyebrow" style="margin-top:8px">for your awareness</div>' + fyis.map(q => V3.decisionCard(q)).join('') : '')
+      : '<div class="queue-free"><span class="big">You’re free.</span>Nothing needs you. The house will tap you the moment something does.</div>');
+  drawer.hidden = false;
+  panel.querySelector('#queue-close').onclick = () => drawer.hidden = true;
+  drawer.onclick = e => { if (e.target === drawer) drawer.hidden = true; };
+};
+
+/* ---------------- theme & density ---------------- */
+V3.setTheme = function (t) {
+  document.documentElement.dataset.theme = t;
+  V3.store.set('theme', t);
+};
+V3.cycleTheme = function () {
+  V3.setTheme(document.documentElement.dataset.theme === 'lamplight' ? 'daylight' : 'lamplight');
+};
+V3.setDensity = function (d) {
+  document.documentElement.dataset.density = d;
+  V3.store.set('density', d);
+  document.getElementById('density-label').textContent = d;
+  V3.rerender();
+};
+V3.cycleDensity = function () {
+  const order = ['cozy', 'standard', 'studio'];
+  V3.setDensity(order[(order.indexOf(V3.density()) + 1) % order.length]);
+};
+
+/* ---------------- composer ---------------- */
+V3.wireComposer = function () {
+  const ta = document.getElementById('composer-input');
+  const target = document.getElementById('composer-target');
+  const syncTarget = () => {
+    const t = V3.data.composerTarget;
+    target.hidden = !t;
+    if (t) target.textContent = 'to: ' + t;
+  };
+  V3.bus.sub(syncTarget);
+  const send = () => {
+    const text = ta.value.trim();
+    if (!text) return;
+    ta.value = ''; ta.style.height = 'auto';
+    V3.actions.sendMessage(text);
+  };
+  ta.addEventListener('keydown', e => {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); send(); }
+    else if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send(); }
+  });
+  ta.addEventListener('input', () => { ta.style.height = 'auto'; ta.style.height = Math.min(ta.scrollHeight, 140) + 'px'; });
+  document.getElementById('composer-send').onclick = send;
+  document.getElementById('composer-mic').onclick = () => V3.actions.toggleVoice();
+  document.getElementById('composer-attach').onclick = () => V3.actions.attach();
+  syncTarget();
+};
+
+/* ---------------- keyboard ---------------- */
+V3.showShortcuts = function () {
+  const panel = document.getElementById('queue-panel');
+  const drawer = document.getElementById('queue-drawer');
+  const rows = [
+    ['⌘K or /', 'the index — everything, one box'], ['?', 'this map'],
+    ['g h / w / s / f / m / p / b', 'go: home · work · screens · files · machines · people · books'],
+    ['g ,  ·  g t  ·  g u', 'settings · station · studio'],
+    ['y s a n', 'queue: approve · skip · approve-all · deny'],
+    ['x', 'dismiss an FYI'], ['e', 'unfold details'], ['⌘↵', 'send'], ['esc', 'close the top layer']
+  ];
+  panel.innerHTML =
+    '<div class="row"><h2 class="voice" style="margin:0;font-size:22px">The keyboard</h2><span class="grow"></span>' +
+    '<button class="icon-btn" id="queue-close">' + V3.icon('x') + '</button></div>' +
+    '<div class="card"><div class="kv">' + rows.map(r =>
+      '<span class="k mono">' + r[0] + '</span><span class="v" style="font-family:var(--sans)">' + r[1] + '</span>').join('') +
+    '</div></div>';
+  drawer.hidden = false;
+  panel.querySelector('#queue-close').onclick = () => drawer.hidden = true;
+  drawer.onclick = e => { if (e.target === drawer) drawer.hidden = true; };
+};
+
+let gPending = false;
+V3.wireKeyboard = function () {
+  document.addEventListener('keydown', e => {
+    const typing = /INPUT|TEXTAREA|SELECT/.test(document.activeElement.tagName);
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') { e.preventDefault(); V3.palette.isOpen ? V3.palette.close() : V3.palette.open(); return; }
+    if (typing) { if (e.key === 'Escape') document.activeElement.blur(); return; }
+    if (V3.palette.isOpen) return;
+    const drawerOpen = !document.getElementById('queue-drawer').hidden;
+    if (e.key === 'Escape') { if (drawerOpen) document.getElementById('queue-drawer').hidden = true; return; }
+    if (e.key === '?') { V3.showShortcuts(); return; }
+    if (e.key === '/') { e.preventDefault(); V3.palette.open(); return; }
+    if (gPending) {
+      gPending = false;
+      const map = { h: 'home', w: 'work', s: 'screens', f: 'files', m: 'machines', p: 'people', b: 'books', ',': 'settings', t: 'station', u: 'studio' };
+      if (map[e.key]) { e.preventDefault(); V3.go('#/' + map[e.key]); }
+      return;
+    }
+    if (e.key === 'g') { gPending = true; setTimeout(() => gPending = false, 900); return; }
+    if ('ysanx'.includes(e.key)) {
+      const top = e.key === 'x' ? V3.queueStore.fyis()[0] : V3.queueStore.pending()[0];
+      if (!top) return;
+      const act = { y: 'approve', s: 'skip', a: 'always', n: 'deny', x: 'dismiss' }[e.key];
+      V3.actions.resolveQueueItem(top, act);
+    }
+  });
+};
+
+/* ---------------- boot ---------------- */
+V3.boot = function () {
+  V3.setTheme(V3.store.get('theme', 'lamplight'));
+  document.documentElement.dataset.density = V3.store.get('density', 'standard');
+  document.getElementById('density-label').textContent = V3.density();
+
+  V3.buildRail();
+  V3.wireComposer();
+  V3.wireKeyboard();
+
+  document.getElementById('btn-palette').onclick = () => V3.palette.open();
+  document.getElementById('btn-theme').onclick = V3.cycleTheme;
+  document.getElementById('btn-density').onclick = V3.cycleDensity;
+  document.getElementById('rail-queue').onclick = V3.openQueueDrawer;
+
+  window.addEventListener('hashchange', V3.route);
+  if (!location.hash) location.hash = '#/home';
+
+  /* transport → data → first paint; every store change re-renders chrome
+     and, when the visible room asked for live updates, the view itself */
+  V3.bus.sub(what => {
+    if (what === 'queue') V3.renderQueueBadge();
+    if (what === 'conn') V3.renderTopFacts();
+    const view = V3.views[V3.current];
+    if (view && view.live) { try { view.live(what); } catch (e) { console.error('[v3] live render', e); } }
+  });
+
+  V3.transport.boot().then(() => V3.data.init()).catch(err => {
+    console.error('[v3] boot failed', err);
+    V3.data.bootError = String(err && err.message || err);
+  }).finally(() => V3.route());
+};
+
+document.addEventListener('DOMContentLoaded', V3.boot);

--- a/static/v3/js/v3-data.js
+++ b/static/v3/js/v3-data.js
@@ -1,0 +1,634 @@
+/* V3 — data: the normalized store + every intent.
+   Views consume V3.data.* (never raw wire shapes); mutations go through
+   V3.actions.* (never a fetch from a view). One control plane — this file
+   is a renderer and an intent emitter, never a second writer.
+
+   Queue model keys on (kind, session, id), following the SPA's proven
+   attention-center pattern; resolution is optimistic with server events
+   (approval_resolved / display_request_resolved / poll refresh) as truth. */
+window.V3 = window.V3 || {};
+
+V3.data = {
+  config: null,
+  you: { name: 'you', role: 'owner', route: 'direct' },
+  connFact: 'live',
+  sessions: [],            // normalized session rows (live first)
+  queue: [],               // normalized attention items
+  conversation: [],        // {from:'presence'|'you'|'milestone', ...}
+  logs: {},                // session_id → rolling log lines [{t, kind, text}]
+  machines: [],            // this daemon first, then peers
+  agenda: [], agendaCounts: { open: 0, done: 0, retired: 0 }, reminderPolicy: null,
+  settings: null,
+  people: [], grants: [], accessOverview: null,
+  usage: {},               // session_id → ModelUsageSnapshot (+ 'main')
+  fuel: null,              // {openai, anthropic, gemini} → all false = dry
+  externalAgents: [],
+  displays: [],
+  composerTarget: null,    // session id the composer is aimed at (null = new work)
+  bootError: null
+};
+
+/* ============================== normalization ============================== */
+
+V3.norm = {
+  phase(status) {
+    return { running: 'working', in_progress: 'working', idle: 'idle', resident: 'idle', completed: 'done',
+             failed: 'failed', abandoned: 'abandoned', interrupted: 'interrupted' }[status] || status || 'idle';
+  },
+  sessionName(row) {
+    if (row.name) return row.name;
+    if (row.task) {
+      const words = String(row.task).replace(/[^\w\s-]/g, '').trim().split(/\s+/).slice(0, 3).join('-').toLowerCase();
+      return words || String(row.session_id || '').slice(0, 8);
+    }
+    return String(row.session_id || '').slice(0, 8);
+  },
+  session(row) {
+    const id = row.session_id;
+    const existing = V3.data.sessions.find(s => s.id === id) || {};
+    return Object.assign(existing, {
+      id,
+      name: V3.norm.sessionName(row),
+      backend: row.backend_source || row.source || 'intendant',
+      model: row.model || row.provider || '',
+      phase: V3.norm.phase(row.status),
+      active: row.status === 'running',
+      turn: row.turns || 0,
+      cost: row.estimated_cost || 0,
+      costKnown: row.pricing_known !== false,
+      tokens: Object.assign(existing.tokens || {}, { used: row.total_tokens || 0 }),
+      task: row.task || '',
+      cwd: row.project_root || row.cwd || '',
+      worktree: row.worktree || null,
+      recordings: row.recordings || 0,
+      canResume: row.can_resume !== false,
+      relationships: row.relationships || [],
+      machine: 'local',
+      updatedAt: row.updated_at || null,
+      sentence: existing.sentence || (row.status === 'running' ? 'Working…' : V3.norm.phase(row.status))
+    });
+  },
+  ago(ts) {
+    const s = Math.max(0, (Date.now() - ts) / 1000);
+    if (s < 60) return 'just now';
+    if (s < 3600) return Math.round(s / 60) + ' min ago';
+    if (s < 86400) return Math.round(s / 3600) + ' h ago';
+    return Math.round(s / 86400) + ' d ago';
+  },
+  commandTitle(command, actor) {
+    const c = String(command || '').trim();
+    const who = actor || 'The house';
+    /* tool display names arrive as e.g. "editFile: /path" or "execAsAgent: …" */
+    const tool = c.match(/^([A-Za-z_]+)\s*:/)?.[1] || '';
+    if (/^edit_?file$/i.test(tool) || /^editFile$/.test(tool)) return who + ' wants to edit a file';
+    if (/^write/i.test(tool)) return who + ' wants to write a file';
+    if (/^delete/i.test(tool)) return who + ' wants to delete a file';
+    if (/^exec(AsAgent|_command)?$/i.test(tool) || /^execAsAgent$/.test(tool)) {
+      const rest = c.slice(c.indexOf(':') + 1).trim();
+      return who + ' wants to run “' + (rest.split(/\s+/)[0] || 'a command') + '”';
+    }
+    const first = c.split(/\s+/)[0] || 'run';
+    const verbs = { rm: 'delete files', mv: 'move files', cp: 'copy files', mkdir: 'create folders',
+                    git: 'run git', npm: 'run npm', cargo: 'run cargo', curl: 'reach the network',
+                    sudo: 'run with elevated rights', python3: 'run a script', python: 'run a script' };
+    const what = verbs[first] || 'run “' + first + '”';
+    return who + ' wants to ' + what;
+  }
+};
+
+/* ============================== the queue ============================== */
+
+V3.queueStore = {
+  pending() { return V3.data.queue.filter(q => q.kind !== 'fyi'); },
+  fyis() { return V3.data.queue.filter(q => q.kind === 'fyi'); },
+  isResolved(id) { return !V3.data.queue.find(q => q.id === id); },
+  resolve(id, action) {
+    const q = V3.data.queue.find(x => x.id === id);
+    if (q) V3.actions.resolveQueueItem(q, action);
+  },
+  upsert(item) {
+    const i = V3.data.queue.findIndex(q => q.id === item.id);
+    if (i >= 0) V3.data.queue[i] = Object.assign(V3.data.queue[i], item);
+    else V3.data.queue.unshift(item);
+    V3.bus.emit('queue');
+  },
+  remove(id) {
+    const i = V3.data.queue.findIndex(q => q.id === id);
+    if (i >= 0) { V3.data.queue.splice(i, 1); V3.bus.emit('queue'); }
+  },
+  removeRef(pred) {
+    const before = V3.data.queue.length;
+    V3.data.queue = V3.data.queue.filter(q => !pred(q));
+    if (V3.data.queue.length !== before) V3.bus.emit('queue');
+  }
+};
+
+V3.queueDerive = {
+  approval(msg) {
+    const s = V3.data.sessions.find(x => x.id === msg.session_id);
+    const actor = s ? (s.backend === 'claude-code' ? 'Claude' : s.backend === 'codex' ? 'Codex' : 'The house') : 'The house';
+    const cmd = String(msg.command || '');
+    V3.queueStore.upsert({
+      id: 'approval-' + (msg.session_id || 'main') + '-' + msg.id,
+      kind: 'approval', sev: 'attention', ts: Date.now(), when: 'just now',
+      category: msg.category || 'command', session: msg.session_id, machine: 'local',
+      title: V3.norm.commandTitle(cmd, actor),
+      consequence: 'In ' + (s && s.cwd || 'the project') + ' — approve once is the safe default; “always” writes a rule.',
+      details: { command: cmd, paths: [], rule: '“Always” sets this category → Auto for the project.', raw: JSON.stringify(msg) },
+      actions: [
+        { id: 'approve', label: 'Allow once', kind: 'safe', key: 'y' },
+        { id: 'always', label: 'Always allow', kind: 'quiet', key: 'a' },
+        { id: 'skip', label: 'Skip', kind: 'quiet', key: 's' },
+        { id: 'deny', label: 'Deny', kind: 'danger', key: 'n' }
+      ],
+      ref: { id: msg.id, sessionId: msg.session_id }
+    });
+  },
+  question(msg) {
+    const qs = msg.questions || [];
+    const first = qs[0] || {};
+    const opts = (first.options || []).map(o => typeof o === 'string' ? o : (o.label + (o.description ? ' — ' + o.description : '')));
+    V3.queueStore.upsert({
+      id: 'question-' + (msg.session_id || 'main') + '-' + msg.id,
+      kind: 'question', sev: 'attention', ts: Date.now(), when: 'just now',
+      session: msg.session_id, machine: 'local',
+      title: first.question || 'The house has a question',
+      consequence: qs.length > 1 ? (qs.length + ' questions — answer what you can; it fills in the rest.') : 'It can’t decide this one for you.',
+      options: opts.length ? opts : null,
+      freeText: true,
+      questions: qs,
+      actions: [
+        { id: 'answer', label: 'Answer', kind: 'primary', key: '↵' },
+        { id: 'skip', label: 'Let it decide', kind: 'quiet', key: 's' }
+      ],
+      ref: { id: msg.id, sessionId: msg.session_id }
+    });
+  },
+  displayRequest(msg) {
+    const s = V3.data.sessions.find(x => x.id === msg.session_id);
+    const name = s ? '“' + s.name + '”' : 'A session';
+    const touch = msg.access === 'view_and_control';
+    V3.queueStore.upsert({
+      id: 'display-' + (msg.session_id || 'main') + '-' + msg.id,
+      kind: 'display', sev: 'attention', ts: Date.now(), when: 'just now',
+      session: msg.session_id, machine: 'local',
+      title: name + ' is asking to ' + (touch ? 'see and touch' : 'see') + ' this screen',
+      consequence: (msg.reason ? '“' + msg.reason + '”. ' : '') + (touch ? 'It could click and type while you watch.' : 'It can look but not touch.') + ' Never approved automatically.',
+      durations: ['15 minutes', 'This session', 'Until I revoke it'],
+      durationMap: ['15m', 'this_session', 'until_revoked'],
+      actions: [
+        { id: 'allow', label: 'Allow 15 min', kind: 'safe', key: 'y' },
+        { id: 'deny', label: 'Not now', kind: 'quiet', key: 'n' },
+        { id: 'deny-session', label: 'Never this session', kind: 'danger' }
+      ],
+      ref: { id: msg.id, sessionId: msg.session_id, access: msg.access }
+    });
+  },
+  notify(msg) {
+    if (!msg.urgency || msg.urgency === 'info') return;
+    V3.queueStore.upsert({
+      id: 'notify-' + (msg.id || msg.ts || Date.now()),
+      kind: 'fyi', sev: msg.urgency === 'urgent' ? 'attention' : 'info', ts: msg.ts || Date.now(), when: 'just now',
+      session: msg.session_id,
+      title: msg.title || 'The house says',
+      consequence: msg.text || '',
+      actions: [{ id: 'dismiss', label: 'Got it', kind: 'quiet', key: 'x' }],
+      ref: {}
+    });
+  },
+  budget(msg, exhausted) {
+    V3.queueStore.upsert({
+      id: 'budget', kind: 'fyi', sev: exhausted ? 'attention' : 'info', ts: Date.now(), when: 'just now',
+      title: exhausted ? 'The budget is spent' : 'The budget is at ' + Math.round(msg.pct || 0) + '%',
+      consequence: exhausted ? 'The house stops mid-thought until you top up.' : 'It will stop when it runs out — Settings → fine print holds the dial.',
+      actions: [{ id: 'dismiss', label: 'Got it', kind: 'quiet', key: 'x' }],
+      ref: {}
+    });
+  },
+  fuel(status) {
+    const dry = status && !status.openai && !status.anthropic && !status.gemini;
+    V3.queueStore.removeRef(q => q.id === 'fuel');
+    if (dry) {
+      V3.queueStore.upsert({
+        id: 'fuel', kind: 'fyi', sev: 'attention', ts: Date.now(), when: 'now',
+        title: 'This daemon has no fuel yet',
+        consequence: 'The API keys it runs on. Add one and it’s off — Settings → Who provides the minds?',
+        actions: [{ id: 'fuel', label: 'Add API keys', kind: 'primary' }, { id: 'dismiss', label: 'Later', kind: 'quiet', key: 'x' }],
+        ref: {}
+      });
+    }
+  }
+};
+
+/* ============================== the store init ============================== */
+
+V3.data.init = function () {
+  const T = V3.transport;
+  const D = V3.data;
+
+  /* ----- wire subscriptions ----- */
+  T.on('t:state_snapshot', msg => {
+    D.connFact = 'live · ' + (msg.state && msg.state.phase || 'idle');
+    const st = msg.state || {};
+    if (st.pending_approval) V3.queueDerive.approval({ id: st.pending_approval.id, command: st.pending_approval.command_preview || st.pending_approval.command, session_id: msg.session_id, category: st.pending_approval.category });
+    if (st.pending_question) V3.queueDerive.question({ id: st.pending_question.id, questions: st.pending_question.questions, session_id: msg.session_id });
+    V3.bus.emit('conn');
+  });
+  T.on('t:log_replay', msg => {
+    (msg.entries || []).forEach(e => V3.data.ingestLog(e));
+    V3.bus.emit('conversation');
+  });
+  T.on('event:approval_required', V3.queueDerive.approval);
+  T.on('event:user_question', V3.queueDerive.question);
+  T.on('event:display_request_raised', V3.queueDerive.displayRequest);
+  T.on('event:approval_resolved', msg => V3.queueStore.removeRef(q => q.ref && q.ref.id === msg.id && (q.kind === 'approval' || q.kind === 'question')));
+  T.on('event:display_request_resolved', msg => V3.queueStore.removeRef(q => q.ref && q.ref.id === msg.id && q.kind === 'display'));
+  T.on('event:user_notification', V3.queueDerive.notify);
+  T.on('event:budget_warning', m => V3.queueDerive.budget(m, false));
+  T.on('event:budget_exhausted', m => V3.queueDerive.budget(m, true));
+
+  T.on('event:session_started', msg => {
+    D.sessions.unshift({
+      id: msg.session_id, name: V3.norm.sessionName(msg), backend: msg.backend || 'intendant',
+      model: '', phase: 'working', active: true, turn: 0, cost: 0, costKnown: true,
+      tokens: { used: 0, pct: 0 }, task: msg.task || '', cwd: '', relationships: [],
+      machine: 'local', sentence: 'Starting up…'
+    });
+    D.conversation.push({ kind: 'milestone', text: '“' + V3.norm.sessionName(msg) + '” started', ts: Date.now() });
+    V3.bus.emit('sessions'); V3.bus.emit('conversation');
+  });
+  T.on('event:session_ended', msg => {
+    const s = D.sessions.find(x => x.id === msg.session_id);
+    if (s) { s.active = false; s.phase = msg.error_kind ? 'failed' : 'done'; s.sentence = msg.reason || 'Finished'; }
+    V3.queueStore.removeRef(q => q.session === msg.session_id && q.kind !== 'fyi');
+    V3.bus.emit('sessions'); V3.bus.emit('queue');
+  });
+  T.on('event:status', msg => {
+    if (msg.session_id) {
+      const s = D.sessions.find(x => x.id === msg.session_id);
+      if (s) {
+        s.turn = msg.turn || s.turn;
+        s.phase = msg.phase === 'idle' ? 'idle' : 'working';
+        s.active = msg.phase !== 'idle';
+        if (msg.task) s.task = msg.task;
+      }
+    }
+    if (msg.autonomy) D.autonomy = msg.autonomy;
+    D.connFact = (msg.provider || '') + (msg.model ? ' · ' + msg.model : '') || 'live';
+    V3.bus.emit('sessions'); V3.bus.emit('conn');
+  });
+  T.on('event:autonomy_changed', msg => { if (msg.level || msg.autonomy) D.autonomy = msg.level || msg.autonomy; });
+  T.on('event:model_response', msg => {
+    const s = D.sessions.find(x => x.id === msg.session_id);
+    if (s && msg.summary) { s.sentence = msg.summary; s.turn = msg.turn || s.turn; V3.bus.emit('sessions'); }
+    V3.data.appendLog(msg.session_id, msg.turn, 'model', msg.summary || msg.reasoning_summary || '');
+  });
+  T.on('event:agent_output', msg => {
+    V3.data.appendLog(msg.session_id, null, 'tool', (msg.stdout || msg.stderr || '').slice(0, 400));
+  });
+  T.on('event:log_entry', msg => {
+    V3.data.appendLog(msg.session_id, msg.turn, msg.level || 'info', msg.content || '');
+  });
+  T.on('event:task_received', msg => {
+    D.conversation.push({ kind: 'milestone', text: 'task received — ' + (msg.task || '').slice(0, 60), ts: Date.now(), session: msg.session_id });
+    V3.bus.emit('conversation');
+  });
+  T.on('event:task_complete', msg => {
+    D.conversation.push({ kind: 'milestone', text: 'finished — ' + (msg.summary || msg.reason || '').slice(0, 80), ts: Date.now(), session: msg.session_id });
+    const s = D.sessions.find(x => x.id === msg.session_id);
+    if (s) { s.phase = 'done'; s.active = false; s.sentence = 'Finished — ' + (msg.summary || msg.reason || ''); }
+    V3.bus.emit('conversation'); V3.bus.emit('sessions');
+  });
+  T.on('event:done_signal', msg => {
+    /* the loop's own completion fact — task_complete may not follow */
+    const text = 'finished — ' + (msg.message || msg.reason || 'done').slice(0, 80);
+    D.conversation.push({ kind: 'milestone', text, ts: Date.now(), session: msg.session_id });
+    const s = D.sessions.find(x => x.id === msg.session_id);
+    if (s) { s.phase = 'done'; s.active = false; s.sentence = 'Finished — ' + (msg.message || ''); }
+    V3.bus.emit('conversation'); V3.bus.emit('sessions');
+  });
+  T.on('event:presence_log', msg => {
+    const text = msg.message || '';
+    /* internal wire chatter is not the house's voice */
+    if (text.startsWith('[ws]') || text.includes('ControlMsg')) return;
+    D.conversation.push({ from: 'presence', prose: [text], level: msg.level, at: V3.now(), ts: Date.now() });
+    V3.bus.emit('conversation');
+  });
+  T.on('event:usage_update', msg => {
+    if (msg.session_id && msg.main) {
+      D.usage[msg.session_id] = msg.main;
+      const s = D.sessions.find(x => x.id === msg.session_id);
+      if (s) { s.tokens.pct = Math.round(msg.main.usage_pct || 0); if (msg.main.model) s.model = msg.main.model; }
+      V3.bus.emit('sessions');
+    } else if (msg.main) { D.usage.main = msg.main; }
+  });
+  T.on('event:session_vitals', msg => {
+    const s = D.sessions.find(x => x.id === msg.session_id);
+    if (s) {
+      s.vitals = Object.assign(s.vitals || {}, msg.vitals || msg);
+      V3.bus.emit('sessions');
+    }
+  });
+  T.on('event:session_identity', msg => {
+    const s = D.sessions.find(x => x.id === msg.session_id);
+    if (s && msg.name) { s.name = msg.name; V3.bus.emit('sessions'); }
+  });
+  T.on('event:agenda_changed', () => V3.data.refresh.agenda());
+  T.on('event:display_ready', msg => {
+    if (!D.displays.find(d => d.id === msg.display_id)) D.displays.push({ id: msg.display_id, w: msg.width, h: msg.height, live: true });
+    V3.bus.emit('displays');
+  });
+  T.on('event:peer_event_forwarded', msg => {
+    const inner = msg.event || msg.peer_event || {};
+    if (inner.approval_required || inner.event === 'approval_required') {
+      const a = inner.approval_required || inner;
+      V3.queueStore.upsert({
+        id: 'peer-approval-' + msg.peer_id + '-' + a.id,
+        kind: 'peer-approval', sev: 'attention', ts: Date.now(), when: 'just now',
+        machine: msg.peer_id,
+        title: V3.norm.commandTitle(a.command, 'A peer session'),
+        consequence: 'On ' + (V3.machineName(msg.peer_id) || msg.peer_id) + ' — its IAM asked you to decide.',
+        details: { command: a.command || '', raw: JSON.stringify(a) },
+        actions: [
+          { id: 'approve', label: 'Allow', kind: 'safe', key: 'y' },
+          { id: 'deny', label: 'Decline', kind: 'danger', key: 'n' }
+        ],
+        ref: { id: a.id, peerId: msg.peer_id }
+      });
+    }
+  });
+
+  /* ----- initial polls ----- */
+  const polls = [
+    ['sessions', '/api/sessions', rows => {
+      D.sessions = (Array.isArray(rows) ? rows : []).map(r => V3.norm.session(r));
+      V3.bus.emit('sessions');
+    }],
+    ['agenda', '/api/agenda', r => {
+      D.agenda = r.items || []; D.agendaCounts = r.counts || D.agendaCounts; D.reminderPolicy = r.reminder_policy || null;
+      V3.bus.emit('agenda');
+    }],
+    ['peers', '/api/peers', r => {
+      const peers = (r.peers || []).map(p => ({
+        id: p.id, petname: p.label || p.id, label: p.id, route: p.browser_tcp_via_url ? 'fleet name' : 'direct',
+        role: p.role || 'peer', status: p.connection_state === 'connected' ? 'online' : 'away',
+        capabilities: (p.capabilities || []).map(c => c.kind === 'computer-use' ? 'computer-use' : (c.name || c.kind)),
+        sessions: p.sessions || [], displays: p.displays || [], version: p.version || ''
+      }));
+      D.machines = [{
+        id: 'local', petname: 'This machine', label: 'this daemon', route: 'direct', role: 'owner',
+        status: 'online', capabilities: ['computer-use', 'display', 'voice', 'terminal'],
+        version: (T.config && T.config.app_build) || '', pressure: null, fueled: true
+      }].concat(peers);
+      V3.bus.emit('machines');
+    }],
+    ['fuel', '/api/api-key-status', r => { D.fuel = r; V3.queueDerive.fuel(r); }],
+    ['settings', '/api/settings', r => { D.settings = r; V3.bus.emit('settings'); }],
+    ['external-agents', '/api/external-agents', r => { D.externalAgents = r.external_agents || []; V3.bus.emit('agents'); }],
+    ['access', '/api/access/overview', r => {
+      D.accessOverview = r;
+      D.people = (r.principals || []).map(p => ({
+        who: p.label || p.id, key: p.key_id || p.id, role: p.role_id || p.role || '—',
+        route: p.route || '—', lifecycle: p.revoked ? 'revoked' : 'active', since: p.created || ''
+      }));
+      D.grants = r.grants || [];
+      V3.bus.emit('people');
+    }],
+    ['enrollment', '/api/access/enrollment-requests', r => {
+      (r.requests || []).forEach(req => {
+        V3.queueStore.upsert({
+          id: 'enroll-' + (req.fingerprint || req.id || req.label),
+          kind: 'enrollment', sev: 'attention', ts: Date.now(), when: 'just now',
+          title: 'A new device wants in: “' + (req.label || 'unnamed') + '”',
+          consequence: 'Approving hands it a key. Spectator watches; Operator runs work. Revoke any time.',
+          roles: ['spectator', 'operator', 'session-reader'],
+          actions: [
+            { id: 'spectator', label: 'Spectator key', kind: 'safe', key: 'y' },
+            { id: 'operator', label: 'Operator key', kind: 'quiet' },
+            { id: 'deny', label: 'Deny', kind: 'danger', key: 'n', default: true }
+          ],
+          ref: { fingerprint: req.fingerprint || req.id }
+        });
+      });
+    }],
+    ['pairing', '/api/peers/pairing/requests', r => {
+      (r.requests || []).filter(x => x.status === 'pending').forEach(req => {
+        V3.queueStore.upsert({
+          id: 'pair-' + req.code,
+          kind: 'peer-pair', sev: 'attention', ts: (req.created_at_unix || 0) * 1000 || Date.now(), when: 'just now',
+          title: '“' + (req.requester_label || 'A daemon') + '” wants to pair',
+          consequence: 'It asks for the “' + (req.requested_profile || 'peer') + '” profile. Pairing creates a route — your IAM still decides what it may do.',
+          actions: [
+            { id: 'approve', label: 'Pair', kind: 'safe', key: 'y' },
+            { id: 'deny', label: 'Decline', kind: 'danger', key: 'n', default: true }
+          ],
+          ref: { code: req.code }
+        });
+      });
+    }],
+    ['hosted', '/api/access/hosted-control', r => {
+      (r.pending_requests || []).forEach(req => {
+        V3.queueStore.upsert({
+          id: 'hosted-' + req.request_id,
+          kind: 'hosted', sev: 'attention', ts: Date.now(), when: 'just now',
+          title: '“' + (req.requester_label || 'Someone') + '” asks to borrow this daemon',
+          consequence: 'A hosted lease — preset “' + (req.requested_preset || 'view') + '”, time-boxed, revocable. The compiled floor stands.',
+          actions: [
+            { id: 'approve', label: 'Grant lease', kind: 'safe', key: 'y' },
+            { id: 'deny', label: 'Decline', kind: 'danger', key: 'n', default: true }
+          ],
+          ref: { requestId: req.request_id }
+        });
+      });
+    }]
+  ];
+
+  /* polls are best-effort: a 403/404 marks the lane gated, never fatal */
+  const results = polls.map(([name, path, ok]) =>
+    V3.transport.get(path).then(ok).catch(e => console.warn('[v3] poll ' + name + ' gated: ' + e.message)));
+
+  /* periodic refresh of the poll-only queue lanes + fuel */
+  V3.data._pollTimer = setInterval(() => {
+    if (document.hidden) return;
+    ['fuel', 'enrollment', 'pairing', 'hosted'].forEach((name, i) => {
+      const p = polls.find(x => x[0] === name);
+      if (p) V3.transport.get(p[1]).then(p[2]).catch(() => {});
+    });
+  }, 30000);
+
+  return Promise.allSettled(results).then(() => V3.bus.emit('ready'));
+};
+
+V3.now = function () {
+  const d = new Date();
+  return String(d.getHours()).padStart(2, '0') + ':' + String(d.getMinutes()).padStart(2, '0');
+};
+
+V3.data.refresh = {
+  agenda() {
+    V3.transport.get('/api/agenda').then(r => {
+      V3.data.agenda = r.items || []; V3.data.agendaCounts = r.counts || V3.data.agendaCounts;
+      V3.bus.emit('agenda');
+    }).catch(() => {});
+  },
+  sessions() {
+    V3.transport.get('/api/sessions').then(rows => {
+      V3.data.sessions = (Array.isArray(rows) ? rows : []).map(r => V3.norm.session(r));
+      V3.bus.emit('sessions');
+    }).catch(() => {});
+  }
+};
+
+/* rolling per-session log buffer (timeline + show-work) */
+V3.data.appendLog = function (sessionId, turn, kind, text) {
+  if (!text) return;
+  const key = sessionId || 'main';
+  const buf = V3.data.logs[key] = V3.data.logs[key] || [];
+  buf.push({ t: V3.now(), turn, kind, text: String(text) });
+  if (buf.length > 300) buf.splice(0, buf.length - 300);
+  V3.bus.emit('logs:' + key);
+};
+V3.data.ingestLog = function (e) {
+  const sessionId = e.session_id || (e.data && e.data.session_id) || 'main';
+  V3.data.appendLog(sessionId, e.turn, e.level || e.event || 'info', e.message || e.summary || (e.data && e.data.message) || '');
+};
+
+/* ============================== actions (intents out) ============================== */
+
+V3.actions = {
+  sendMessage(text) {
+    const target = V3.data.composerTarget;
+    const msg = target
+      ? { action: 'start_task', task: text, session_id: target }
+      : { action: 'create_session', task: text };
+    msg.follow_up_id = 'v3-' + Date.now().toString(36);
+    if (V3.transport.send(msg)) {
+      V3.data.conversation.push({ from: 'you', text, at: V3.now(), ts: Date.now() });
+      V3.bus.emit('conversation');
+    }
+  },
+
+  resolveQueueItem(item, act) {
+    const T = V3.transport, ref = item.ref || {};
+    let sent = false;
+    switch (item.kind) {
+      case 'approval': {
+        const map = { approve: 'approve', skip: 'skip', always: 'approve_all', deny: 'deny' };
+        if (!map[act]) return;
+        sent = T.send({ action: map[act], id: ref.id, session_id: ref.sessionId });
+        break;
+      }
+      case 'question': {
+        if (act === 'answer') {
+          const answers = V3.actions._collectAnswers(item);
+          sent = T.send({ action: 'answer_question', id: ref.id, session_id: ref.sessionId, answers });
+        } else {
+          sent = T.send({ action: 'skip', id: ref.id });
+        }
+        break;
+      }
+      case 'display': {
+        const map = { allow: 'approve', deny: 'deny', 'deny-session': 'deny_session' };
+        if (!map[act]) return;
+        const dur = act === 'allow' ? '15m' : undefined;
+        sent = T.send({ action: 'resolve_display_request', id: ref.id, decision: map[act], duration: dur, session_id: ref.sessionId });
+        break;
+      }
+      case 'enrollment': {
+        if (act === 'deny') { V3.transport.post('/api/access/enrollment-requests/decide', { fingerprint: ref.fingerprint, approve: false }).catch(V3.actions._err); }
+        else { V3.transport.post('/api/access/enrollment-requests/decide', { fingerprint: ref.fingerprint, approve: true, role_id: 'role:' + act }).catch(V3.actions._err); }
+        sent = true;
+        break;
+      }
+      case 'peer-pair': {
+        V3.transport.post('/api/peers/pairing/requests/' + encodeURIComponent(ref.code) + '/' + (act === 'approve' ? 'approve' : 'deny'), {}).catch(V3.actions._err);
+        sent = true;
+        break;
+      }
+      case 'peer-approval': {
+        V3.transport.post('/api/peers/' + encodeURIComponent(ref.peerId) + '/approval', { request_id: ref.id, decision: act === 'approve' ? 'accept' : 'decline' }).catch(V3.actions._err);
+        sent = true;
+        break;
+      }
+      case 'hosted': {
+        V3.transport.post('/api/access/hosted-control/requests/decide', { request_id: ref.requestId, approve: act === 'approve' }).catch(V3.actions._err);
+        sent = true;
+        break;
+      }
+      case 'fyi': {
+        if (act === 'fuel') { V3.go('#/settings'); return; }
+        sent = true; // dismiss
+        break;
+      }
+    }
+    if (sent) {
+      V3.queueStore.remove(item.id);
+      V3.toast(act === 'deny' || act === 'deny-session' ? 'Denied — nothing was touched' : 'Done — the house carries on',
+               act === 'deny' || act === 'deny-session' ? 'brick' : 'sage');
+    }
+  },
+
+  _collectAnswers(item) {
+    const answers = {};
+    const card = document.querySelector('[data-qcard="' + item.id + '"]');
+    (item.questions || []).forEach((q, i) => {
+      const qt = q.question || String(i);
+      if (card) {
+        const radio = card.querySelector('input[name="' + item.id + '-opt-' + i + '"]:checked');
+        const free = card.querySelector('input[data-free="' + i + '"]');
+        if (free && free.value.trim()) { answers[qt] = free.value.trim(); return; }
+        if (radio) { answers[qt] = radio.value; return; }
+      }
+      answers[qt] = '';
+    });
+    return answers;
+  },
+
+  interrupt(sessionId) { V3.transport.send({ action: 'interrupt', session_id: sessionId }); },
+  stopSession(sessionId) { V3.transport.send({ action: 'stop_session', session_id: sessionId }); },
+  resumeSession(sessionId) { V3.transport.send({ action: 'resume_session', session_id: sessionId }); },
+  steer(sessionId, text) { V3.transport.send({ action: 'steer', session_id: sessionId, text, id: 'v3s-' + Date.now().toString(36) }); },
+  followUp(sessionId, text) { V3.transport.send({ action: 'follow_up', session_id: sessionId, text, follow_up_id: 'v3f-' + Date.now().toString(36) }); },
+
+  setApprovalRule(category, rule) {
+    V3.transport.send({ action: 'set_approval_rule', category, rule });
+    V3.toast(category + ' → ' + rule + ' — live', 'sage');
+  },
+  setAutonomy(level) {
+    V3.transport.send({ action: 'set_autonomy', level });
+    V3.toast('Autonomy → ' + level + ' — next task onward', 'sage');
+  },
+  saveSettings(patch) {
+    /* merge-then-POST: the daemon expects the full payload, and a partial
+       POST must never reset a neighbor */
+    return V3.transport.get('/api/settings')
+      .then(cur => V3.transport.post('/api/settings', Object.assign({}, cur, patch)))
+      .then(() => {
+        V3.toast('Saved — the daemon picked it up live', 'sage');
+        Object.assign(V3.data.settings || {}, patch);
+      })
+      .catch(V3.actions._err);
+  },
+  agendaOp(cmd) {
+    return V3.transport.post('/api/agenda/op', cmd)
+      .then(() => { V3.data.refresh.agenda(); return true; })
+      .catch(e => { V3.actions._err(e); return false; });
+  },
+  grantUserDisplay(duration) { V3.transport.send({ action: 'grant_user_display', duration }); },
+  revokeUserDisplay() { V3.transport.send({ action: 'revoke_user_display' }); },
+  takeDisplay(id) { V3.transport.send({ action: 'take_display', display_id: id }); },
+  releaseDisplay(id) { V3.transport.send({ action: 'release_display', display_id: id }); },
+
+  toggleVoice() {
+    V3.transport.send({ t: 'presence_connect' });
+    V3.toast('Asking the house to pick up… (live voice connects when fueled)', null);
+  },
+  attach() { V3.toast('Attachments stage here and ride the next message', null); },
+
+  setTarget(sessionId) {
+    V3.data.composerTarget = sessionId || null;
+    V3.bus.emit('target');
+  },
+
+  _err(e) { V3.toast('The daemon said no: ' + e.message, 'brick'); console.warn('[v3] action failed', e); }
+};

--- a/static/v3/js/v3-icons.js
+++ b/static/v3/js/v3-icons.js
@@ -1,0 +1,67 @@
+/* Proscenium — icon registry. 24×24 stroke grid, 1.7 width, round caps.
+   Usage: V3.icon('name') → svg string; V3.mountIcons(root) fills [data-icon]. */
+window.V3 = window.V3 || {};
+
+V3.ICONS = {
+  arch:      '<path d="M4.5 20 V11 Q4.5 4 12 4 Q19.5 4 19.5 11 V20"/><path d="M8 20 V12 Q8 7.5 12 7.5 Q16 7.5 16 12 V20" opacity=".45"/>',
+  stage:     '<path d="M3 17 Q12 13 21 17"/><path d="M5 17 V9 Q5 5 12 5 Q19 5 19 9 V17" opacity=".9"/><circle cx="12" cy="11" r="1.6"/>',
+  screens:   '<rect x="3" y="4.5" width="18" height="12.5" rx="2"/><path d="M9 20.5 h6 M12 17 v3.5"/>',
+  files:     '<path d="M3.5 7 Q3.5 5.5 5 5.5 h4 l2 2.5 h8 Q20.5 8 20.5 9.5 V17 Q20.5 18.5 19 18.5 H5 Q3.5 18.5 3.5 17 Z"/>',
+  machines:  '<rect x="3" y="4" width="8" height="7" rx="1.5"/><rect x="13" y="13" width="8" height="7" rx="1.5"/><path d="M7 11 v4 Q7 16.5 8.5 16.5 H13" opacity=".7"/>',
+  key:       '<circle cx="8" cy="12" r="4"/><path d="M12 12 h9 M17.5 12 v3.5 M20.5 12 v2.5"/>',
+  books:     '<path d="M5 4.5 Q5 3.5 6 3.5 H19 V17 H6.5 Q5 17 5 18.5 Q5 20 6.5 20 H19"/><path d="M5 17.5 V4.5" opacity=".6"/>',
+  settings:  '<path d="M4 7 h8 M17 7 h3 M4 16.5 h3 M12 16.5 h8"/><circle cx="14.5" cy="7" r="2.2"/><circle cx="9.5" cy="16.5" r="2.2"/>',
+  station:   '<circle cx="12" cy="12" r="2.2"/><circle cx="12" cy="12" r="6" opacity=".55"/><circle cx="12" cy="12" r="9.5" opacity=".3"/><circle cx="18.5" cy="7.5" r="1.3"/><circle cx="5.5" cy="15.5" r="1.3"/>',
+  studio:    '<path d="M9 3.5 h6 M10 3.5 V9 L4.8 18 Q4 20 6.5 20 h11 Q20 20 19.2 18 L14 9 V3.5"/><path d="M7.5 14.5 h9" opacity=".6"/>',
+  search:    '<circle cx="11" cy="11" r="6.5"/><path d="M15.8 15.8 L20.5 20.5"/>',
+  mic:       '<rect x="9" y="3" width="6" height="11" rx="3"/><path d="M5.5 11 Q5.5 16.5 12 16.5 Q18.5 16.5 18.5 11 M12 16.5 V20"/>',
+  send:      '<path d="M4.5 12 L20 4.5 L13.5 20 L11 13.5 Z"/><path d="M11 13.5 L20 4.5" opacity=".6"/>',
+  attach:    '<path d="M16 11.5 L9.8 17.7 Q8 19.5 6 17.7 Q4.2 15.9 6 14.1 L13.4 6.7 Q14.9 5.2 16.6 6.7 Q18.3 8.2 16.8 9.7 L9.5 17" />',
+  doorbell:  '<path d="M6 16 V11 Q6 6 12 6 Q18 6 18 11 V16"/><path d="M4.5 16 h15 M10 19 Q12 20.5 14 19"/>',
+  sparkle:   '<path d="M12 4 L13.8 10.2 L20 12 L13.8 13.8 L12 20 L10.2 13.8 L4 12 L10.2 10.2 Z"/>',
+  density:   '<path d="M4 6 h16 M4 12 h16 M4 18 h10" /><circle cx="18" cy="18" r="2" opacity=".7"/>',
+  theme:     '<path d="M12 3.5 A8.5 8.5 0 1 0 20.5 12 A7 7 0 0 1 12 3.5 Z"/>',
+  chev:      '<path d="M9 5.5 L15.5 12 L9 18.5"/>',
+  chevdown:  '<path d="M5.5 9 L12 15.5 L18.5 9"/>',
+  plus:      '<path d="M12 5 V19 M5 12 H19"/>',
+  check:     '<path d="M4.5 12.5 L10 18 L19.5 6.5"/>',
+  x:         '<path d="M6 6 L18 18 M18 6 L6 18"/>',
+  skip:      '<path d="M6 5 L13 12 L6 19 M13 5 L20 12 L13 19" opacity=".9"/>',
+  clock:     '<circle cx="12" cy="12" r="8.5"/><path d="M12 7 V12 L15.5 14"/>',
+  fuel:      '<path d="M12 3.5 Q17 9.5 17 13.5 A5 5 0 0 1 7 13.5 Q7 9.5 12 3.5 Z"/>',
+  shield:    '<path d="M12 3.5 L19.5 6.5 V11 Q19.5 17.5 12 20.5 Q4.5 17.5 4.5 11 V6.5 Z"/>',
+  terminal:  '<rect x="3" y="4.5" width="18" height="15" rx="2"/><path d="M7 9.5 L10.5 12.5 L7 15.5 M12.5 15.5 H17"/>',
+  camera:    '<rect x="3" y="7" width="13" height="11" rx="2"/><path d="M16 11 L21 8 V17 L16 14 Z"/>',
+  record:    '<circle cx="12" cy="12" r="8.5" opacity=".6"/><circle cx="12" cy="12" r="3.5"/>',
+  branch:    '<circle cx="6.5" cy="6" r="2.5"/><circle cx="6.5" cy="18" r="2.5"/><circle cx="17.5" cy="8" r="2.5"/><path d="M6.5 8.5 V15.5 M17.5 10.5 Q17.5 15 12 15.5 L9 15.7" opacity=".8"/>',
+  folder:    '<path d="M3.5 7 Q3.5 5.5 5 5.5 h4 l2 2.5 h8 Q20.5 8 20.5 9.5 V17 Q20.5 18.5 19 18.5 H5 Q3.5 18.5 3.5 17 Z"/>',
+  file:      '<path d="M6 3.5 H14 L18.5 8 V20.5 H6 Z"/><path d="M13.5 3.5 V8.5 H18.5" opacity=".6"/>',
+  external:  '<path d="M10 5.5 H5.5 V18.5 H18.5 V14"/><path d="M13.5 4.5 H19.5 V10.5 M19.5 4.5 L11 13" opacity=".8"/>',
+  pause:     '<path d="M8.5 5.5 V18.5 M15.5 5.5 V18.5"/>',
+  stop:      '<rect x="6.5" y="6.5" width="11" height="11" rx="1.5"/>',
+  play:      '<path d="M8 5.5 L18.5 12 L8 18.5 Z"/>',
+  refresh:   '<path d="M19.5 12 A7.5 7.5 0 1 1 17.2 6.3 M17.5 3.5 V7 H14" />',
+  info:      '<circle cx="12" cy="12" r="8.5" opacity=".7"/><path d="M12 11 V16.5 M12 7.5 V8"/>',
+  warn:      '<path d="M12 4 L21 19.5 H3 Z"/><path d="M12 10 V14.5 M12 16.8 V17.3"/>',
+  question:  '<circle cx="12" cy="12" r="8.5" opacity=".7"/><path d="M9.5 9.5 Q9.5 7.5 12 7.5 Q14.5 7.5 14.5 9.5 Q14.5 11 12.5 11.8 Q12 12.2 12 13.5 M12 16.3 V16.8"/>',
+  trash:     '<path d="M5 7 H19 M9.5 7 V5 Q9.5 4 10.5 4 h3 Q14.5 4 14.5 5 V7 M7 7 L7.8 19 Q7.9 20 9 20 h6 Q16.1 20 16.2 19 L17 7"/>',
+  eye:       '<path d="M3 12 Q7.5 5.5 12 5.5 Q16.5 5.5 21 12 Q16.5 18.5 12 18.5 Q7.5 18.5 3 12 Z"/><circle cx="12" cy="12" r="2.8"/>',
+  hand:      '<path d="M8 11.5 V5.5 Q8 4 9.3 4 Q10.6 4 10.6 5.5 V10 M10.6 10 V3.8 Q10.6 2.6 11.8 2.6 Q13 2.6 13 3.8 V10 M13 10 V5 Q13 3.8 14.2 3.8 Q15.4 3.8 15.4 5 V11 M15.4 11.5 L17 9.8 Q18 8.8 19 9.8 Q20 10.8 19 11.8 L14.5 17 Q12.5 20 9.5 19.5 Q7 19 5.8 16.5 L4.5 13.5 Q4 12 5.2 11.3 Q6.4 10.6 7.3 12 L8 13.5"/>',
+  layers:    '<path d="M12 3.5 L21 8.5 L12 13.5 L3 8.5 Z"/><path d="M4.5 12.5 L12 16.5 L19.5 12.5 M4.5 16.5 L12 20.5 L19.5 16.5" opacity=".55"/>',
+  history:   '<path d="M4 12 A8 8 0 1 1 6 6.5 M4 3.5 V7 H7.5" /><path d="M12 8 V12 L15 14" opacity=".8"/>',
+  download:  '<path d="M12 4 V14.5 M7.5 10.5 L12 15 L16.5 10.5 M4.5 18.5 H19.5"/>',
+  upload:    '<path d="M12 15 V4.5 M7.5 9 L12 4.5 L16.5 9 M4.5 18.5 H19.5"/>',
+};
+
+V3.icon = function (name, size) {
+  const d = V3.ICONS[name] || V3.ICONS.info;
+  const s = size || 18;
+  return '<svg viewBox="0 0 24 24" width="' + s + '" height="' + s + '" fill="none" stroke="currentColor"' +
+    ' stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' + d + '</svg>';
+};
+
+V3.mountIcons = function (root) {
+  (root || document).querySelectorAll('[data-icon]').forEach(function (el) {
+    if (!el.dataset.mounted) { el.innerHTML = V3.icon(el.dataset.icon); el.dataset.mounted = '1'; }
+  });
+};

--- a/static/v3/js/v3-palette.js
+++ b/static/v3/js/v3-palette.js
@@ -1,0 +1,173 @@
+/* V3 — the universal index (⌘K).
+   Lanes: Actions · Go to · Settings · Search deeper. Register-blind: the
+   index always speaks instrument vocabulary regardless of density.
+   Settings derive from V3.settingsCatalog — the same table the Settings
+   room renders, so a row added there is searchable here, automatically.
+   Jump-and-flash: settings land on their exact folded row. */
+window.V3 = window.V3 || {};
+
+V3.palette = (function () {
+  let sel = 0, items = [];
+
+  const overlay = () => document.getElementById('palette');
+  const input = () => document.getElementById('palette-input');
+  const results = () => document.getElementById('palette-results');
+
+  /* ---------------- index sources ---------------- */
+  function roomItems() {
+    return V3.ROOMS.concat(V3.VANTAGES).map(r => ({
+      lane: 'Go to', name: r.title, hint: r.gloss, icon: r.icon,
+      run: () => V3.go('#/' + r.id)
+    }));
+  }
+  function objectItems() {
+    const out = [];
+    V3.data.sessions.forEach(s => out.push({
+      lane: 'Go to', name: s.name, hint: 'session · ' + (s.backend || '') + (s.active ? ' · working' : ' · ' + s.phase),
+      icon: 'stage', run: () => V3.go('#/work/session/' + s.id)
+    }));
+    V3.data.machines.forEach(m => out.push({
+      lane: 'Go to', name: m.petname, hint: 'machine · ' + m.label + ' · via ' + m.route,
+      icon: 'machines', run: () => V3.go('#/machines/' + m.id)
+    }));
+    V3.data.people.forEach(p => out.push({
+      lane: 'Go to', name: p.who, hint: 'key · ' + p.role + ' · ' + p.lifecycle,
+      icon: 'key', run: () => V3.go('#/people')
+    }));
+    V3.data.displays.forEach(d => out.push({
+      lane: 'Go to', name: 'Display ' + d.id, hint: 'display · ' + (d.live ? 'live' : 'off'),
+      icon: 'screens', run: () => V3.go('#/screens')
+    }));
+    V3.data.agenda.forEach(a => out.push({
+      lane: 'Go to', name: a.title, hint: 'the list · ' + a.kind + ' · ' + a.status,
+      icon: 'books', run: () => V3.go('#/books')
+    }));
+    return out;
+  }
+  function settingsItems() {
+    return V3.settingsCatalog.map(row => ({
+      lane: 'Settings', name: row.name, hint: row.section, icon: 'settings',
+      aliases: row.aliases || '',
+      run: () => { V3.go('#/settings'); setTimeout(() => V3.flashTarget(row.fold || ('set-' + row.key)), 80); }
+    }));
+  }
+  function actionItems() {
+    const top = V3.queueStore.pending()[0];
+    const live = V3.data.sessions.filter(s => s.active);
+    const out = [
+      { lane: 'Actions', name: 'New session', hint: 'give the house work', icon: 'plus', run: () => V3.go('#/work/new') },
+      { lane: 'Actions', name: 'Pair a machine', hint: 'grow the fleet', icon: 'machines',
+        run: () => { V3.go('#/machines'); setTimeout(() => V3.flashTarget('fold-pairing'), 80); } },
+      { lane: 'Actions', name: 'Add API keys', hint: V3.data.fuel && !V3.data.fuel.openai && !V3.data.fuel.anthropic && !V3.data.fuel.gemini ? 'the daemon is dry' : 'fuel',
+        icon: 'fuel', run: () => { V3.go('#/settings'); setTimeout(() => V3.flashTarget('fold-keys'), 80); } },
+      { lane: 'Actions', name: 'Speak to the house', hint: 'live voice', icon: 'mic', run: () => V3.actions.toggleVoice() },
+      { lane: 'Actions', name: 'Flip theme', hint: 'lamplight ⇄ daylight', icon: 'theme', run: () => V3.cycleTheme() },
+      { lane: 'Actions', name: 'Cycle density', hint: 'cozy · standard · studio', icon: 'density', run: () => V3.cycleDensity() },
+      { lane: 'Actions', name: 'Show keyboard map', hint: '?', icon: 'question', run: () => V3.showShortcuts() },
+      { lane: 'Actions', name: 'Open the classic dashboard', hint: 'V2, right here', icon: 'external', run: () => { location.href = '/'; } }
+    ];
+    live.forEach(s => out.push({
+      lane: 'Actions', name: 'Stop “' + s.name + '”', hint: 'interrupt the turn', icon: 'stop',
+      run: () => { V3.actions.interrupt(s.id); V3.toast('Interrupt sent to ' + s.name, 'brick'); }
+    }));
+    if (top) {
+      out.unshift(
+        { lane: 'Actions', name: 'Approve: ' + top.title, hint: 'top of the queue · y', icon: 'check',
+          run: () => V3.actions.resolveQueueItem(top, 'approve') },
+        { lane: 'Actions', name: 'Deny: ' + top.title, hint: 'top of the queue · n', icon: 'x',
+          run: () => V3.actions.resolveQueueItem(top, 'deny') }
+      );
+    }
+    return out;
+  }
+  function deepItems(q) {
+    if (!q || q.length < 3) return [];
+    const needle = q.toLowerCase();
+    const hits = [];
+    Object.keys(V3.data.logs).forEach(sid => {
+      V3.data.logs[sid].forEach(l => {
+        if (hits.length < 4 && l.text.toLowerCase().includes(needle))
+          hits.push({ lane: 'Search deeper', name: l.text.slice(0, 72), hint: sid + ' · ' + l.t, icon: 'search', run: () => V3.go('#/work/session/' + sid) });
+      });
+    });
+    V3.data.sessions.forEach(s => {
+      if (hits.length < 6 && (s.task || '').toLowerCase().includes(needle))
+        hits.push({ lane: 'Search deeper', name: s.task.slice(0, 72) + (s.task.length > 72 ? '…' : ''), hint: s.name, icon: 'search', run: () => V3.go('#/work/session/' + s.id) });
+    });
+    return hits;
+  }
+
+  /* ---------------- fuzzy ---------------- */
+  function score(q, item) {
+    const hay = (item.name + ' ' + (item.hint || '') + ' ' + (item.aliases || '')).toLowerCase();
+    const needle = q.toLowerCase().trim();
+    if (!needle) return 1;
+    if (hay.startsWith(needle)) return 100;
+    const nameLow = item.name.toLowerCase();
+    if (nameLow.startsWith(needle)) return 90;
+    if (nameLow.includes(needle)) return 70;
+    if (hay.includes(needle)) return 50;
+    let i = 0;
+    for (const c of hay) if (c === needle[i]) i++;
+    return i === needle.length ? 25 : 0;
+  }
+
+  /* ---------------- render ---------------- */
+  function render() {
+    const q = input().value;
+    const all = [...actionItems(), ...roomItems(), ...objectItems(), ...settingsItems()];
+    let matched = all.map(it => ({ it, s: score(q, it) })).filter(x => x.s > 0);
+    matched.sort((a, b) => b.s - a.s);
+    matched = matched.slice(0, 14);
+    const deep = deepItems(q);
+    items = matched.map(x => x.it).concat(deep);
+
+    let lastLane = null;
+    results().innerHTML = items.map((it, idx) => {
+      let h = '';
+      if (it.lane !== lastLane) { h += '<div class="pal-lane">' + V3.esc(it.lane) + '</div>'; lastLane = it.lane; }
+      h += '<div class="pal-item' + (idx === sel ? ' sel' : '') + '" data-idx="' + idx + '">' +
+        V3.ICON(it.icon || 'chev', 15) +
+        '<span class="pal-name">' + V3.esc(it.name) + '</span>' +
+        (it.hint ? '<span class="pal-hint">' + V3.esc(it.hint) + '</span>' : '') + '</div>';
+      return h;
+    }).join('') || '<div class="pal-lane">No matches — the index covers every room, object, and setting.</div>';
+
+    results().querySelectorAll('.pal-item').forEach(el => {
+      el.addEventListener('click', () => choose(+el.dataset.idx));
+      el.addEventListener('mousemove', () => { sel = +el.dataset.idx; paint(); });
+    });
+  }
+  function paint() {
+    results().querySelectorAll('.pal-item').forEach(el => el.classList.toggle('sel', +el.dataset.idx === sel));
+  }
+  function choose(idx) {
+    const it = items[idx]; if (!it) return;
+    close();
+    setTimeout(() => it.run(), 10);
+  }
+  function onKey(e) {
+    if (e.key === 'ArrowDown') { e.preventDefault(); sel = Math.min(sel + 1, items.length - 1); paint(); scrollSel(); }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); sel = Math.max(sel - 1, 0); paint(); scrollSel(); }
+    else if (e.key === 'Enter') { e.preventDefault(); choose(sel); }
+    else if (e.key === 'Escape') { close(); }
+  }
+  function scrollSel() {
+    const el = results().querySelector('.pal-item.sel');
+    if (el) el.scrollIntoView({ block: 'nearest' });
+  }
+
+  function open() {
+    sel = 0;
+    overlay().hidden = false;
+    input().value = '';
+    render();
+    setTimeout(() => input().focus(), 20);
+    input().oninput = () => { sel = 0; render(); };
+    input().onkeydown = onKey;
+    overlay().onclick = e => { if (e.target === overlay()) close(); };
+  }
+  function close() { overlay().hidden = true; }
+
+  return { open, close, get isOpen() { return !overlay().hidden; } };
+})();

--- a/static/v3/js/v3-transport.js
+++ b/static/v3/js/v3-transport.js
@@ -1,0 +1,125 @@
+/* V3 — transport: the two lanes a plain page needs.
+   HTTP JSON via fetch, events + ControlMsgs over one /ws text socket.
+   Auth is transport-contextual (loopback/mTLS root session) — no token
+   handling here beyond the optional federation bearer the V2 SPA also
+   honors (localStorage["intendantFederationBearerToken"], appended as
+   ?token= on the WS URL when present).
+   Wire facts (verified against the daemon):
+   - server→client: {"event":"<snake>", ...} OutboundEvents plus
+     {"t":"<type>", ...} frames (state_snapshot, log_replay, ws_denied…)
+   - client→server: flat ControlMsg JSON, {"action":"<snake>", ...}
+   - no subscribe handshake: a fresh socket gets the full bootstrap
+     (state_snapshot → cached events → session replays → log_replay)
+     before live events flow. */
+window.V3 = window.V3 || {};
+
+V3.transport = (function () {
+  const handlers = {};   // '<event|t>:<tag>' → [fn]; '*' wildcard on 'event:*'
+  let ws = null;
+  let booted = false;
+  let reconnectDelay = 800;
+  let tabId = null;
+
+  const T = {
+    state: 'connecting',           // connecting | live | offline
+    config: null,
+    connectionId: null,
+    bootstrapped: false,
+
+    on(tag, fn) { (handlers[tag] = handlers[tag] || []).push(fn); },
+    emit(tag, msg) {
+      (handlers[tag] || []).forEach(fn => { try { fn(msg); } catch (e) { console.error('[v3] handler ' + tag, e); } });
+    },
+
+    async boot() {
+      tabId = sessionStorage.getItem('intendant.v3.tab') ||
+        (() => { const id = 'v3-' + Math.random().toString(36).slice(2, 10); sessionStorage.setItem('intendant.v3.tab', id); return id; })();
+      try { T.config = await T.get('/config'); } catch (e) { T.config = {}; }
+      T.connect();
+      /* resolve once bootstrapped, or after 4s — never trap first paint */
+      return new Promise(resolve => {
+        const t0 = Date.now();
+        const check = setInterval(() => {
+          if (T.bootstrapped || Date.now() - t0 > 4000) { clearInterval(check); resolve(); }
+        }, 120);
+      });
+    },
+
+    wsUrl() {
+      const proto = location.protocol === 'https:' ? 'wss://' : 'ws://';
+      let url = proto + location.host + '/ws?tab=' + encodeURIComponent(tabId);
+      const bearer = localStorage.getItem('intendantFederationBearerToken');
+      if (bearer) url += '&token=' + encodeURIComponent(bearer);
+      return url;
+    },
+
+    connect() {
+      T.setState('connecting');
+      try { ws = new WebSocket(T.wsUrl()); } catch (e) { T.setState('offline'); return; }
+      ws.onopen = () => { T.setState('live'); reconnectDelay = 800; };
+      ws.onmessage = ev => T.dispatch(ev.data);
+      ws.onclose = () => {
+        T.setState('offline');
+        setTimeout(T.connect, reconnectDelay);
+        reconnectDelay = Math.min(reconnectDelay * 1.6, 10000);
+      };
+      ws.onerror = () => { try { ws.close(); } catch (e) {} };
+    },
+
+    setState(s) {
+      if (T.state === s) return;
+      T.state = s;
+      V3.bus.emit('conn');
+    },
+
+    dispatch(raw) {
+      let msg;
+      try { msg = JSON.parse(raw); } catch (e) { return; }
+      if (msg.t === 'state_snapshot') {
+        T.connectionId = msg.connection_id || null;
+        if (msg.config && !T.config) T.config = msg.config;
+      }
+      if (msg.t) T.emit('t:' + msg.t, msg);
+      if (msg.event) {
+        T.emit('event:' + msg.event, msg);
+        T.emit('event:*', msg);
+      }
+      /* bootstrap_flushed marks the end of replay — live lane is open */
+      if (msg.t === 'bootstrap_flushed' || (msg.event && !T.bootstrapped)) {
+        /* the first live/replayed event also counts: the daemon stamps
+           replayed events, but any traffic proves the pipe works */
+        T.bootstrapped = true;
+      }
+    },
+
+    send(obj) {
+      if (ws && ws.readyState === 1) { ws.send(JSON.stringify(obj)); return true; }
+      V3.toast('The line to the house is down — reconnecting…', 'brick');
+      return false;
+    },
+
+    async get(path) {
+      const r = await fetch(path, { headers: T.authHeaders() });
+      if (!r.ok) throw new Error('GET ' + path + ' → ' + r.status);
+      return r.json();
+    },
+    async post(path, body) {
+      const r = await fetch(path, {
+        method: 'POST',
+        headers: Object.assign({ 'Content-Type': 'application/json' }, T.authHeaders()),
+        body: JSON.stringify(body)
+      });
+      if (!r.ok) {
+        const text = await r.text().catch(() => '');
+        throw new Error('POST ' + path + ' → ' + r.status + (text ? ' · ' + text.slice(0, 160) : ''));
+      }
+      const ct = r.headers.get('content-type') || '';
+      return ct.includes('json') ? r.json() : r.text();
+    },
+    authHeaders() {
+      const bearer = localStorage.getItem('intendantFederationBearerToken');
+      return bearer ? { 'Authorization': 'Bearer ' + bearer } : {};
+    }
+  };
+  return T;
+})();

--- a/static/v3/js/v3-ui.js
+++ b/static/v3/js/v3-ui.js
@@ -1,0 +1,212 @@
+/* Proscenium — shared UI helpers (the component contract).
+   Every view renders through these; improvise nothing per-room. */
+window.P = window.P || {};
+
+/* ---------- tiny DOM ---------- */
+V3.h = function (tag, cls, html) {
+  const e = document.createElement(tag);
+  if (cls) e.className = cls;
+  if (html != null) e.innerHTML = html;
+  return e;
+};
+V3.esc = function (s) {
+  return String(s).replace(/[&<>"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+};
+V3.ICON = function (name, size) { return '<span class="icon">' + V3.icon(name, size) + '</span>'; };
+
+/* ---------- preferences (theme/density handled in app.js) ---------- */
+V3.store = {
+  get(k, dflt) { try { const v = localStorage.getItem('intendant.v3.' + k); return v == null ? dflt : JSON.parse(v); } catch { return dflt; } },
+  set(k, v) { try { localStorage.setItem('intendant.v3.' + k, JSON.stringify(v)); } catch {} }
+};
+V3.density = () => document.documentElement.dataset.density || 'standard';
+
+/* ---------- chips, dots, facts ---------- */
+V3.chip = function (label, kind, iconName) {
+  return '<span class="chip' + (kind ? ' chip-' + kind : '') + '">' +
+    (iconName ? V3.ICON(iconName, 13) : '') + V3.esc(label) + '</span>';
+};
+V3.dot = function (kind, pulse) { return '<span class="dot dot-' + kind + (pulse ? ' dot-pulse' : '') + '"></span>'; };
+V3.fact = function (s) { return '<span class="fact">' + V3.esc(s) + '</span>'; };
+V3.meter = function (pct, cls) {
+  const tone = cls || (pct >= 90 ? 'hot' : pct >= 70 ? 'warn' : '');
+  return '<span class="meter" title="' + pct + '%"><span class="meter-fill ' + tone + '" style="width:' + pct + '%"></span></span>';
+};
+V3.machineName = function (id) {
+  const m = V3.data.machines.find(m => m.id === id);
+  return m ? m.petname : id;
+};
+V3.routeChip = function (route) {
+  const kind = route === 'direct' ? 'sage' : route === 'fleet name' ? 'slate' : 'violet';
+  return V3.chip('via ' + route, kind);
+};
+V3.authline = function (who, role, route) {
+  return '<div class="authline">' + V3.ICON('shield', 13) +
+    '<span class="who">' + V3.esc(who) + ' · ' + V3.esc(role) + '</span>' +
+    (route ? V3.routeChip(route) : '') + '</div>';
+};
+
+/* ---------- folds (disclosure contract; remembers state; studio opens) ---------- */
+V3.fold = function (opts) {
+  // opts: {key, title, note, body, open}
+  const key = opts.key ? 'fold.' + opts.key : null;
+  const remembered = key ? V3.store.get(key, null) : null;
+  const studio = V3.density() === 'studio';
+  const open = remembered != null ? remembered : (opts.open != null ? opts.open : studio);
+  const d = V3.h('details', 'fold');
+  if (key) d.dataset.key = key;
+  if (opts.id) d.id = opts.id;
+  if (open) d.setAttribute('open', '');
+  d.innerHTML = '<summary>' + V3.ICON('chev', 15).replace('class="icon"', 'class="icon chev"') +
+    '<span>' + V3.esc(opts.title) + '</span>' +
+    (opts.note ? '<span class="fold-note">' + V3.esc(opts.note) + '</span>' : '') + '</summary>' +
+    '<div class="fold-body">' + opts.body + '</div>';
+  d.addEventListener('toggle', function () {
+    if (key) V3.store.set(key, d.open);
+  });
+  return d;
+};
+V3.foldHtml = function (opts) { const d = V3.fold(opts); return d.outerHTML; };
+
+/* jump-and-flash: open a fold by id and flash it (⌘K landing) */
+V3.flashTarget = function (id) {
+  requestAnimationFrame(() => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    if (el.tagName === 'DETAILS') el.open = true;
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    el.classList.remove('flash'); void el.offsetWidth; el.classList.add('flash');
+  });
+};
+
+/* ---------- cards ---------- */
+V3.card = function (opts) {
+  // {title, sub, actions, body, cls}
+  return '<div class="card ' + (opts.cls || '') + '">' +
+    (opts.title ? '<div class="card-head"><div><h3 class="card-title">' + opts.title + '</h3>' +
+      (opts.sub ? '<div class="card-sub">' + opts.sub + '</div>' : '') + '</div>' +
+      (opts.actions ? '<div class="card-actions">' + opts.actions + '</div>' : '') + '</div>' : '') +
+    (opts.body || '') + '</div>';
+};
+
+/* ---------- stage card (live work) ---------- */
+V3.stageCard = function (s) {
+  const needsYou = V3.data.queue.some(q => q.kind !== 'fyi' && q.session === s.id);
+  const isPeer = s.machine && s.machine !== 'local';
+  const tone = needsYou ? 'attention' : isPeer ? 'peer' : s.phase === 'done' ? 'done' : '';
+  const facts = [];
+  facts.push(V3.fact((s.backend || '') + (s.model ? ' · ' + s.model : '')));
+  if (s.turn) facts.push(V3.fact('turn ' + s.turn));
+  if (s.tokens && s.tokens.pct != null && s.tokens.pct > 0) facts.push('<span class="fact">' + s.tokens.pct + '% ctx</span>' + V3.meter(s.tokens.pct));
+  if (s.cost != null && s.cost > 0) facts.push(V3.fact('$' + s.cost.toFixed(2)));
+  return '<a class="stage-card ' + tone + '" href="#/work/session/' + s.id + '">' +
+    '<div class="stage-body">' +
+    '<div class="stage-name">' + (s.phase === 'working' ? V3.dot('sage', true) : V3.dot('slate')) +
+      V3.esc(s.name) +
+      (isPeer ? V3.chip(V3.machineName(s.machine), 'violet') : '') +
+      (needsYou ? V3.chip('needs you', 'attn', 'doorbell') : '') + '</div>' +
+    '<div class="stage-sentence">' + V3.esc(s.sentence || '') + '</div>' +
+    '<div class="stage-facts">' + facts.join('') + '</div>' +
+    '</div></a>';
+};
+
+/* ---------- decision card (the Queue) ---------- */
+V3.decisionCard = function (q, opts) {
+  opts = opts || {};
+  if (V3.queueStore.isResolved(q.id)) return '';
+  const isFyi = q.kind === 'fyi';
+  let actions = q.actions.map(a =>
+    '<button class="btn ' + (a.kind === 'primary' ? 'btn-primary' : a.kind === 'safe' ? 'btn-safe' : a.kind === 'danger' ? 'btn-danger' : 'btn-quiet') +
+    (a.default && !isFyi ? ' btn-default' : '') + '" data-q="' + q.id + '" data-action="' + a.id + '">' +
+    V3.esc(a.label) + (a.key ? ' <span class="kbd-hint">' + a.key + '</span>' : '') + '</button>').join('');
+  let extra = '';
+  if (q.options) {
+    extra += '<div class="col" style="gap:6px;margin:4px 0 10px">' + q.options.map((o, i) =>
+      '<label class="row" style="gap:8px"><input type="radio" name="' + q.id + '-opt-0" value="' + V3.esc(o) + '" ' + (i === 0 ? 'checked' : '') + '> <span>' + V3.esc(o) + '</span></label>').join('') +
+      (q.freeText ? '<input class="input" data-free="0" placeholder="or say it in your own words…" style="margin-top:4px">' : '') + '</div>';
+  } else if (q.freeText) {
+    extra += '<div class="col" style="gap:6px;margin:4px 0 10px"><input class="input" data-free="0" placeholder="your answer…"></div>';
+  }
+  if (q.durations) {
+    extra += '<div class="row" style="gap:6px;margin:2px 0 10px">' + q.durations.map((d, i) =>
+      '<span class="chip' + (i === 0 ? ' chip-sage' : '') + '">' + d + '</span>').join('') + '</div>';
+  }
+  if (q.roles) {
+    extra += '<div class="dim" style="font-size:12.5px;margin:2px 0 8px">' +
+      'A <b>spectator</b> watches. An <b>operator</b> runs work and touches screens, but can’t hand out keys.</div>';
+  }
+  const details = q.details ? '<details class="fold" style="margin:8px 0 10px"><summary>' +
+    '<span class="icon chev">' + V3.icon('chev', 15) + '</span><span>details</span>' +
+    '<span class="fold-note">' + V3.esc(q.category || q.kind) + '</span></summary><div class="fold-body">' +
+    (q.details.command ? '<div class="panel mono" style="margin-bottom:8px">$ ' + V3.esc(q.details.command) + '</div>' : '') +
+    (q.details.paths ? '<div class="col" style="gap:3px;margin-bottom:8px">' + q.details.paths.map(p => '<span class="mono" style="font-size:12px">✕ ' + V3.esc(p) + '</span>').join('') + '</div>' : '') +
+    (q.details.rule ? '<div class="dim" style="font-size:12.5px;margin-bottom:8px">' + V3.esc(q.details.rule) + '</div>' : '') +
+    '<div class="log dim" style="font-size:11.5px">' + V3.esc(q.details.raw) + '</div>' +
+    '</div></details>' : '';
+  return '<div class="decision' + (isFyi ? ' fyi' : '') + '" data-qcard="' + q.id + '">' +
+    '<div class="decision-head">' +
+      (isFyi ? V3.chip('for your awareness', 'slate', 'info') : V3.chip('needs you · ' + (q.category || q.kind), 'attn', 'doorbell')) +
+      '<span class="grow"></span><span class="fact">' + q.when + '</span></div>' +
+    '<div class="decision-title">' + V3.esc(q.title) + '</div>' +
+    '<div class="decision-consequence">' + V3.esc(q.consequence) + '</div>' +
+    extra + details +
+    '<div class="decision-actions">' + actions + '</div>' +
+    (q.machine && q.machine !== 'local'
+      ? V3.authline('via ' + V3.machineName(q.machine), q.role || 'peer', 'fleet name')
+      : V3.authline(V3.data.you.name, V3.data.you.role, V3.data.you.route)) +
+    '</div>';
+};
+
+/* ---------- queue store lives in v3-data.js (server-truth + actions) ---------- */
+
+/* ---------- empty state & skeleton ---------- */
+V3.empty = function (glyph, title, hint, actionHtml) {
+  return '<div class="empty"><div class="empty-glyph">' + V3.ICON(glyph, 34) + '</div>' +
+    '<div class="empty-title">' + V3.esc(title) + '</div>' +
+    '<div class="empty-hint">' + V3.esc(hint) + '</div>' + (actionHtml || '') + '</div>';
+};
+V3.skeleton = function (h, w) {
+  return '<div class="skeleton" style="height:' + (h || 14) + 'px;width:' + (w || '100%') + '"></div>';
+};
+
+/* ---------- toast ---------- */
+V3.toast = function (msg, tone) {
+  const t = V3.h('div', 'toast ' + (tone || ''), V3.ICON(tone === 'brick' ? 'x' : 'check', 15) + '<span>' + V3.esc(msg) + '</span>');
+  document.getElementById('toasts').appendChild(t);
+  setTimeout(() => { t.style.opacity = '0'; t.style.transition = 'opacity .3s'; setTimeout(() => t.remove(), 320); }, 3200);
+};
+
+/* ---------- page scaffold ---------- */
+V3.page = function (opts) {
+  // {eyebrow, title, sub, body}
+  return '<div class="page">' +
+    (opts.eyebrow ? '<div class="eyebrow">' + V3.esc(opts.eyebrow) + '</div>' : '') +
+    (opts.title ? '<h1 class="page-title">' + opts.title + '</h1>' : '') +
+    (opts.sub ? '<div class="page-sub">' + opts.sub + '</div>' : '') +
+    opts.body + '</div>';
+};
+V3.section = function (label) {
+  return '<div class="section-head"><span class="eyebrow">' + V3.esc(label) + '</span><span class="line"></span></div>';
+};
+
+/* ---------- global click delegation for queue actions ---------- */
+document.addEventListener('click', function (e) {
+  const b = e.target.closest('[data-q][data-action]');
+  if (!b) return;
+  const q = V3.data.queue.find(x => x.id === b.dataset.q);
+  if (q) V3.actions.resolveQueueItem(q, b.dataset.action);
+});
+
+/* helpers */
+V3.row = function (html, gap) { return '<div class="row" style="display:flex;align-items:center;gap:' + (gap || 8) + 'px">' + html + '</div>'; };
+V3.col = function (html, gap) { return '<div class="col" style="display:flex;flex-direction:column;gap:' + (gap || 8) + 'px">' + html + '</div>'; };
+V3.logLines = function (lines) {
+  return '<div class="log">' + lines.map(l =>
+    '<div><span class="lt">' + l[0] + '</span> <span class="' +
+    (l[1] === 'tool' ? 'tool' : l[1] === 'ok' ? 'ok' : l[1] === 'err' || l[1] === 'ask' ? 'err' : '') + '">' +
+    V3.esc(l[2]) + '</span></div>').join('') + '</div>';
+};
+V3.diffHtml = function (rows) {
+  return '<div class="diff">' + rows.map(r =>
+    '<span class="diff-' + r[0] + '">' + V3.esc(r[1]) + '</span>').join('') + '</div>';
+};

--- a/static/v3/js/views/books.js
+++ b/static/v3/js/views/books.js
@@ -1,0 +1,380 @@
+/* V3 — Books: the ledgers.
+   Costs & usage → the List → scheduled sessions → what the house remembers
+   → reports. Every number derives from V3.data (the sessions catalog, the
+   agenda poll, provider usage snapshots) — nothing estimated here that the
+   daemon didn't already book. The scheduled-sessions card is the first UI
+   for the daemon's scheduler: propose is an agenda op, approve is an
+   owner-surface act bound to the manifest digest. */
+window.V3 = window.V3 || {};
+V3.views = V3.views || {};
+
+V3.views.books = {
+  title: 'Books',
+
+  _mem: null,   /* last memory search: {q, results, durability, error} */
+
+  clock(ms) { return V3.clock ? V3.clock(ms) : new Date(ms).toLocaleString(); },
+  ago(ms) { return V3.norm && V3.norm.ago ? V3.norm.ago(ms) : ''; },
+
+  fmtTokens(n) {
+    if (!n) return '0';
+    if (n >= 1e6) return (n / 1e6).toFixed(1) + 'M';
+    if (n >= 1e3) return (n / 1e3).toFixed(1) + 'k';
+    return String(n);
+  },
+
+  render(el) {
+    const D = V3.data;
+    const sessions = D.sessions || [];
+
+    el.innerHTML = V3.page({
+      eyebrow: 'the ledgers',
+      title: 'Books',
+      sub: 'What the house spent, what’s parked for later, and what it remembers. Every number is the daemon’s own bookkeeping — read off the sessions catalog, never invented here.',
+      body:
+        V3.section('Costs & usage') +
+        this.kpisHtml() +
+        '<div class="grid grid-2">' +
+          this.byBackendHtml() +
+          this.topSessionsHtml() +
+        '</div>' +
+
+        V3.section('The List — parked for later') +
+        '<div class="card">' +
+          '<div id="bks-list">' + this.listHtml() + '</div>' +
+          '<div class="row" style="margin-top:10px;padding-top:12px;border-top:1px solid var(--line);flex-wrap:wrap">' +
+            '<input class="input" id="bks-add" placeholder="Park a task, note, or question — the house will surface it…" style="flex:1;min-width:220px">' +
+            '<select class="input" id="bks-add-kind">' +
+              ['task', 'note', 'question'].map(k => '<option value="' + k + '">' + k + '</option>').join('') +
+            '</select>' +
+            '<button class="btn btn-quiet" id="bks-add-btn">' + V3.ICON('plus', 14) + ' Add</button>' +
+          '</div>' +
+        '</div>' +
+
+        this.scheduledHtml() +
+
+        V3.section('What the house remembers') +
+        '<div class="card">' +
+          '<div class="row" style="flex-wrap:wrap">' +
+            '<input class="input" id="bks-mem-q" placeholder="Search the memory plane — a word, a name, a decision…" style="flex:1;min-width:240px" value="' + V3.esc(this._mem ? this._mem.q : '') + '">' +
+            '<button class="btn btn-primary" id="bks-mem-btn">' + V3.ICON('search', 14) + ' Search</button>' +
+          '</div>' +
+          '<div id="bks-mem-results" style="margin-top:12px">' + this.memHtml() + '</div>' +
+          '<div class="dim" style="margin-top:10px;font-size:12.5px">New claims are proposed through the agent in this draft — tell the house what to remember in the composer, and it lands as a candidate for the house to argue through.</div>' +
+        '</div>' +
+
+        V3.section('Reports & history') +
+        this.reportsHtml()
+    });
+
+    this.wire(el);
+  },
+
+  /* ---------- costs & usage ---------- */
+  kpisHtml() {
+    const D = V3.data;
+    const S = D.sessions || [];
+    const cost = S.reduce((a, s) => a + (s.cost || 0), 0);
+    const unknown = S.filter(s => s.costKnown === false).length;
+    const tokens = Object.values(D.usage || {}).reduce((a, u) => a + ((u && u.tokens_used) || 0), 0);
+    const working = S.filter(s => s.active).length;
+    const kpi = (value, label, sub) =>
+      '<div class="card"><div class="bks-kpi-value">' + V3.esc(value) + '</div>' +
+      '<div class="bks-kpi-label">' + V3.esc(label) + '</div>' +
+      '<div class="dim" style="font-size:12px;margin-top:2px">' + V3.esc(sub) + '</div></div>';
+    return '<div class="bks-kpis">' +
+      kpi('$' + cost.toFixed(2), 'estimated spend',
+        unknown ? 'summed from the sessions catalog · ' + unknown + ' unpriced' : 'summed from the sessions catalog') +
+      kpi(String(S.length), 'sessions', 'every session the catalog tracks') +
+      kpi(this.fmtTokens(tokens), 'tokens', 'as the providers reported them') +
+      kpi(String(working), 'working now', 'live on stage') +
+    '</div>';
+  },
+
+  byBackendHtml() {
+    const S = V3.data.sessions || [];
+    const by = {};
+    S.forEach(s => {
+      const b = s.backend || 'intendant';
+      by[b] = by[b] || { cost: 0, n: 0 };
+      by[b].cost += s.cost || 0; by[b].n++;
+    });
+    const rows = Object.keys(by).sort((a, b) => by[b].cost - by[a].cost);
+    return V3.card({
+      title: 'By backend', sub: 'estimated cost · sessions — derived from the catalog',
+      body: rows.length
+        ? '<table class="table"><tbody>' + rows.map(b => {
+            const max = by[rows[0]].cost || 1;
+            return '<tr><td class="mono">' + V3.esc(b) + '</td>' +
+              '<td class="mono">' + by[b].n + '</td>' +
+              '<td class="mono">$' + by[b].cost.toFixed(2) + '</td>' +
+              '<td style="width:34%">' + V3.meter(Math.round(by[b].cost / max * 100), '') + '</td></tr>';
+          }).join('') + '</tbody></table>'
+        : '<div class="dim" style="font-size:12.5px">No sessions yet — the ledger fills in as the house works.</div>'
+    });
+  },
+
+  topSessionsHtml() {
+    const S = (V3.data.sessions || []).filter(s => (s.cost || 0) > 0)
+      .sort((a, b) => b.cost - a.cost).slice(0, 5);
+    return V3.card({
+      title: 'Priciest sessions', sub: 'top five · tap through to the session space',
+      body: S.length
+        ? '<table class="table"><tbody>' + S.map(s =>
+            '<tr data-open-session="' + V3.esc(s.id) + '" style="cursor:pointer">' +
+            '<td>' + V3.esc(s.name) + '<div class="dim" style="font-weight:400;font-size:12px">' + V3.esc((s.task || '').slice(0, 60)) + '</div></td>' +
+            '<td>' + V3.chip(s.phase, s.active ? 'sage' : s.phase === 'failed' ? 'brick' : 'slate') + '</td>' +
+            '<td class="mono">$' + s.cost.toFixed(2) + '</td>' +
+            '<td>' + V3.chip('open', null, 'chev') + '</td></tr>').join('') + '</tbody></table>'
+        : '<div class="dim" style="font-size:12.5px">No priced sessions yet — cost shows up once a provider reports usage.</div>'
+    });
+  },
+
+  /* ---------- the List ---------- */
+  listHtml() {
+    const D = V3.data;
+    const items = (D.agenda || []).filter(a => a.status !== 'retired');
+    const counts = D.agendaCounts || {};
+    if (!items.length) {
+      return V3.empty('books', 'Nothing parked', 'Park a task, note, or question below — the house surfaces it when it’s due.') +
+        (counts.retired ? '<div class="dim" style="font-size:12px;margin-top:6px">' + counts.retired + ' retired — hidden here.</div>' : '');
+    }
+    const open = items.filter(a => a.status !== 'done');
+    const done = items.filter(a => a.status === 'done');
+    const rows = open.concat(done).map(a => this.itemHtml(a)).join('');
+    return rows +
+      '<div class="dim" style="font-size:12px;margin-top:8px">' +
+        V3.esc((counts.open != null ? counts.open : open.length) + ' open · ' + (counts.done != null ? counts.done : done.length) + ' done' +
+        (counts.retired ? ' · ' + counts.retired + ' retired (hidden here)' : '')) + '</div>';
+  },
+
+  itemHtml(a) {
+    const isDone = a.status === 'done';
+    const hasFx = (a.effects || []).length > 0;
+    const answer = a.answer && (typeof a.answer === 'string' ? a.answer : (a.answer.text || a.answer.answer || ''));
+    return '<div class="bks-item" data-ag="' + V3.esc(a.id) + '">' +
+      '<div class="row" data-ag-toggle="' + V3.esc(a.id) + '" title="click to ' + (isDone ? 'reopen' : 'complete') + '" style="cursor:pointer">' +
+        '<span class="bks-check">' + (isDone ? V3.ICON('check', 12) : '') + '</span>' +
+        V3.chip(a.kind, a.kind === 'task' ? 'slate' : a.kind === 'question' ? 'attn' : 'brass') +
+        '<span class="bks-item-title' + (isDone ? ' done' : '') + '">' + V3.esc(a.title) + '</span>' +
+        (a.due_ms ? V3.chip(this.clock(a.due_ms), 'brass', 'clock') : '') +
+        (hasFx ? V3.chip('scheduled', 'brass', 'clock') : '') +
+        '<span class="grow"></span>' +
+        V3.chip(isDone ? 'done' : 'open', isDone ? 'sage' : 'slate') +
+        (a.updated_ms ? V3.fact(this.ago(a.updated_ms)) : '') +
+      '</div>' +
+      (a.body ? '<div class="dim" style="font-size:12.5px;margin:2px 0 2px 28px">' + V3.esc(String(a.body).slice(0, 200)) + '</div>' : '') +
+      ((a.tags || []).length ? '<div class="factline" style="margin-left:28px">' + a.tags.map(t => V3.fact('#' + t)).join('') + '</div>' : '') +
+      (a.kind === 'question' && !isDone
+        ? '<div class="row" style="margin:6px 0 2px 28px">' +
+          '<input class="input" data-ag-answer="' + V3.esc(a.id) + '" placeholder="Answer the house…" style="flex:1;max-width:420px">' +
+          '<button class="btn btn-quiet btn-xs" data-ag-answer-btn="' + V3.esc(a.id) + '">answer</button></div>'
+        : '') +
+      (a.kind === 'question' && isDone && answer
+        ? '<div class="dim" style="font-size:12.5px;margin:2px 0 2px 28px">answered: “' + V3.esc(String(answer).slice(0, 160)) + '”</div>'
+        : '') +
+    '</div>';
+  },
+
+  /* ---------- scheduled sessions (the daemon's scheduler) ---------- */
+  scheduledHtml() {
+    const D = V3.data;
+    const withFx = (D.agenda || []).filter(a => (a.effects || []).length);
+    const openItems = (D.agenda || []).filter(a => a.status !== 'retired' && !(a.effects || []).length);
+
+    const rows = withFx.map(a => (a.effects || []).map(fx => {
+      const m = fx.manifest || {};
+      const approved = !!(fx.approval && fx.approval.digest && fx.approval.digest === fx.digest);
+      const last = fx.last_run || null;
+      return '<div class="row" style="flex-wrap:wrap;padding:8px 0;border-bottom:1px solid var(--line)">' +
+        V3.ICON('clock', 15) +
+        '<b>' + V3.esc(m.goal || a.title || 'scheduled session') + '</b>' +
+        (m.fire_at_ms ? V3.chip(this.clock(m.fire_at_ms), 'brass', 'clock') : V3.chip('no fire time', 'slate')) +
+        (approved ? V3.chip('approved — will fire', 'sage', 'check') : V3.chip('proposed — needs your approval', 'attn')) +
+        (last ? V3.fact('last run: ' + (last.state || '?') + (last.at_ms ? ' · ' + this.ago(last.at_ms) : '')) : '') +
+        '<span class="grow"></span>' +
+        (approved
+          ? '<button class="btn btn-danger btn-xs" data-fx-revoke="' + V3.esc(a.id) + '">revoke</button>'
+          : '<button class="btn btn-safe btn-xs" data-fx-approve="' + V3.esc(a.id) + '" data-fx-digest="' + V3.esc(fx.digest || '') + '">approve</button>') +
+      '</div>';
+    }).join('')).join('');
+
+    return V3.card({
+      title: 'Scheduled sessions', sub: 'the daemon’s scheduler fires these — an approval binds the exact manifest, byte for byte',
+      body:
+        (rows || '<div class="dim" style="font-size:12.5px;padding:4px 0 8px">Nothing scheduled. Pick a parked item below, give it a goal and a time — the house proposes it, you approve it, the daemon fires it.</div>') +
+        '<div class="eyebrow" style="margin:14px 0 8px">Propose one</div>' +
+        '<div class="row" style="flex-wrap:wrap;gap:8px">' +
+          '<select class="input" id="bks-fx-item">' +
+            (openItems.length
+              ? openItems.map(a => '<option value="' + V3.esc(a.id) + '">' + V3.esc(a.title.slice(0, 48)) + '</option>').join('')
+              : '<option value="">— park an item on the List first —</option>') +
+          '</select>' +
+          '<input class="input" id="bks-fx-goal" placeholder="What the session should do…" style="flex:1;min-width:200px">' +
+          '<input class="input" type="datetime-local" id="bks-fx-when">' +
+          '<button class="btn btn-primary" id="bks-fx-btn" ' + (openItems.length ? '' : 'disabled') + '>Propose</button>' +
+        '</div>' +
+        '<div class="dim" style="font-size:12px;margin-top:8px">A proposal is data until you approve it — the daemon fires nothing unapproved, and re-proposing voids the old approval.</div>'
+    });
+  },
+
+  /* ---------- what the house remembers ---------- */
+  memHtml() {
+    const mem = this._mem;
+    if (!mem) {
+      return '<div class="dim" style="font-size:12.5px">Search the plane — claims come back with their kind, sensitivity, and standing. Nothing is shown unprompted.</div>';
+    }
+    if (mem.error) {
+      return '<div class="dim" style="font-size:12.5px">The memory plane said no: <b>' + V3.esc(mem.error) + '</b>' +
+        (mem.error.includes('503') ? ' — it’s unavailable on this daemon.' : '') + '</div>';
+    }
+    const claims = mem.results || [];
+    const durability = mem.durability ? '<div class="factline" style="margin-top:10px">' + V3.fact(mem.durability) + V3.fact('this plane is ephemeral in this build — a restart forgets') + '</div>' : '';
+    if (!claims.length) {
+      return '<div class="dim" style="font-size:12.5px">No claims match “' + V3.esc(mem.q) + '”.</div>' + durability;
+    }
+    return '<div class="grid grid-2">' + claims.map(c =>
+      '<div class="card">' +
+        '<div class="row" style="gap:6px;flex-wrap:wrap">' +
+          V3.chip(c.kind || 'claim', 'slate') +
+          V3.chip(c.sensitivity || '—', c.sensitivity === 'private' ? 'brick' : 'slate') +
+          V3.chip(c.status || '—', c.status === 'accepted' ? 'sage' : c.status === 'candidate' ? 'attn' : 'slate') +
+          '<span class="grow"></span>' +
+          (c.id ? V3.fact(String(c.id).slice(0, 8)) : '') +
+        '</div>' +
+        '<div style="margin-top:8px;font-size:13.5px">' + V3.esc(c.statement || '') + '</div>' +
+        ((c.session || (c.proposed_by && c.proposed_by.kind)) ? '<div class="factline" style="margin-top:8px">' +
+          (c.session ? V3.fact('session: ' + c.session) : '') +
+          (c.proposed_by && c.proposed_by.kind ? V3.fact('by: ' + c.proposed_by.kind) : '') + '</div>' : '') +
+      '</div>').join('') + '</div>' + durability;
+  },
+
+  memSearch(el) {
+    const input = el.querySelector('#bks-mem-q');
+    const q = (input && input.value || '').trim();
+    if (!q) { V3.toast('Type something to search for first', 'brick'); if (input) input.focus(); return; }
+    const node = el.querySelector('#bks-mem-results');
+    if (node) node.innerHTML = '<div class="col" style="gap:8px">' + V3.skeleton(14, '70%') + V3.skeleton(14, '100%') + V3.skeleton(14, '45%') + '</div>';
+    V3.transport.get('/api/memory/search?q=' + encodeURIComponent(q) + '&limit=12&candidates=1').then(r => {
+      this._mem = { q, results: r.results || r.claims || [], durability: r.durability || '' };
+    }).catch(e => {
+      this._mem = { q, results: [], durability: '', error: e.message };
+    }).then(() => {
+      const n = document.getElementById('bks-mem-results');
+      if (n && V3.current === 'books') n.innerHTML = this.memHtml();
+    });
+  },
+
+  /* ---------- reports & history ---------- */
+  reportsHtml() {
+    const S = (V3.data.sessions || []).filter(s => s.phase === 'done' || s.phase === 'failed');
+    if (!S.length) {
+      return V3.card({ title: 'Session reports', sub: 'the full audit trail, zipped — logs, frames, decisions',
+        body: '<div class="dim" style="font-size:12.5px">Nothing finished yet — once a session wraps, its report zip lands here.</div>' });
+    }
+    return V3.card({
+      title: 'Session reports', sub: 'the full audit trail, zipped — logs, frames, decisions',
+      body: '<table class="table"><tbody>' +
+        S.slice(0, 12).map(s =>
+          '<tr>' +
+          '<td><a href="#/work/session/' + V3.esc(s.id) + '" style="color:inherit">' + V3.esc(s.name) + '</a>' +
+            '<div class="dim" style="font-weight:400;font-size:12px">' + V3.esc((s.task || '').slice(0, 60)) + '</div></td>' +
+          '<td>' + V3.chip(s.phase, s.phase === 'done' ? 'sage' : 'brick') + '</td>' +
+          '<td class="mono">' + V3.esc(s.backend || '') + '</td>' +
+          '<td class="mono">' + (s.cost ? '$' + s.cost.toFixed(2) : '—') + '</td>' +
+          '<td style="text-align:right"><a class="btn btn-quiet btn-xs" href="/api/session/' + encodeURIComponent(s.id) + '/report">' +
+            V3.ICON('download', 13) + ' report .zip</a></td>' +
+          '</tr>').join('') + '</tbody></table>'
+    });
+  },
+
+  /* ---------- wiring ---------- */
+  wire(el) {
+    /* per-session cost rows → session space */
+    el.querySelectorAll('[data-open-session]').forEach(r =>
+      r.addEventListener('click', () => V3.go('#/work/session/' + r.dataset.openSession)));
+
+    /* the List: complete / reopen */
+    el.querySelectorAll('[data-ag-toggle]').forEach(row => row.addEventListener('click', () => {
+      const a = (V3.data.agenda || []).find(x => x.id === row.dataset.agToggle);
+      if (!a) return;
+      const done = a.status === 'done';
+      V3.actions.agendaOp({ op: done ? 'reopen' : 'complete', id: a.id })
+        .then(() => V3.toast(done ? 'Reopened — back on the list' : 'Marked done — the house stops nudging', done ? null : 'sage'));
+    }));
+
+    /* add to the List */
+    const addBtn = el.querySelector('#bks-add-btn');
+    const addInput = el.querySelector('#bks-add');
+    const addKind = el.querySelector('#bks-add-kind');
+    const addItem = () => {
+      const text = (addInput.value || '').trim();
+      if (!text) { addInput.focus(); return; }
+      const kind = addKind.value || 'task';
+      addInput.value = '';
+      V3.actions.agendaOp({ op: 'add', kind, title: text })
+        .then(() => V3.toast('On the list — the house will surface it', 'sage'));
+    };
+    if (addBtn) addBtn.addEventListener('click', addItem);
+    if (addInput) addInput.addEventListener('keydown', e => { if (e.key === 'Enter') addItem(); });
+
+    /* answer a question */
+    el.querySelectorAll('[data-ag-answer-btn]').forEach(btn => btn.addEventListener('click', () => {
+      const id = btn.dataset.agAnswerBtn;
+      const input = el.querySelector('[data-ag-answer="' + CSS.escape(id) + '"]');
+      const text = (input && input.value || '').trim();
+      if (!text) { if (input) input.focus(); return; }
+      V3.actions.agendaOp({ op: 'answer', id, text })
+        .then(() => V3.toast('Answered — the question resolves', 'sage'));
+    }));
+    el.querySelectorAll('[data-ag-answer]').forEach(input => input.addEventListener('keydown', e => {
+      if (e.key === 'Enter') {
+        const id = input.dataset.agAnswer;
+        const text = (input.value || '').trim();
+        if (!text) return;
+        V3.actions.agendaOp({ op: 'answer', id, text })
+          .then(() => V3.toast('Answered — the question resolves', 'sage'));
+      }
+    }));
+
+    /* scheduled sessions: approve / revoke / propose */
+    el.querySelectorAll('[data-fx-approve]').forEach(btn => btn.addEventListener('click', () => {
+      V3.actions.agendaOp({ op: 'approve_effect', id: btn.dataset.fxApprove, digest: btn.dataset.fxDigest })
+        .then(() => V3.toast('Approved — the daemon fires it at its time', 'sage'));
+    }));
+    el.querySelectorAll('[data-fx-revoke]').forEach(btn => btn.addEventListener('click', () => {
+      V3.actions.agendaOp({ op: 'revoke_effect', id: btn.dataset.fxRevoke })
+        .then(() => V3.toast('Approval revoked — it will not fire', 'brick'));
+    }));
+    const fxBtn = el.querySelector('#bks-fx-btn');
+    if (fxBtn) fxBtn.addEventListener('click', () => {
+      const itemSel = el.querySelector('#bks-fx-item');
+      const goalIn = el.querySelector('#bks-fx-goal');
+      const whenIn = el.querySelector('#bks-fx-when');
+      const id = itemSel && itemSel.value;
+      const goal = (goalIn.value || '').trim();
+      const fire = whenIn.value ? new Date(whenIn.value).getTime() : NaN;
+      if (!id) { V3.toast('Park an item on the List first', 'brick'); return; }
+      if (!goal) { V3.toast('Say what the session should do', 'brick'); goalIn.focus(); return; }
+      if (!isFinite(fire)) { V3.toast('Pick a fire time', 'brick'); whenIn.focus(); return; }
+      V3.actions.agendaOp({ op: 'propose_effect', id, goal, fire_at_ms: Math.round(fire) })
+        .then(() => V3.toast('Proposed — approve it here and the scheduler takes it', 'sage'));
+    });
+
+    /* memory search */
+    const memBtn = el.querySelector('#bks-mem-btn');
+    const memQ = el.querySelector('#bks-mem-q');
+    if (memBtn) memBtn.addEventListener('click', () => this.memSearch(el));
+    if (memQ) memQ.addEventListener('keydown', e => { if (e.key === 'Enter') this.memSearch(el); });
+  },
+
+  live(what) {
+    if (!['agenda', 'sessions', 'ready'].includes(what)) return;
+    const active = document.activeElement;
+    if (active && document.getElementById('main').contains(active) && /INPUT|TEXTAREA|SELECT/.test(active.tagName)) return;
+    const main = document.getElementById('main');
+    const y = main.scrollTop;
+    this.render(main);
+    main.scrollTop = y;
+  }
+};

--- a/static/v3/js/views/files.js
+++ b/static/v3/js/views/files.js
@@ -1,0 +1,324 @@
+/* V3 — Files: the desk. This daemon's scoped filesystem as a lazy tree,
+   an 8 KB peek pane, humane denials, and the resumable-transfer shelf.
+   Everything rides V3.transport — with one documented exception: file
+   previews need the byte lane (GET /api/fs/read answers raw bytes, not
+   JSON), taken in peekBytes() with the transport's own auth headers. */
+window.V3 = window.V3 || {};
+V3.views = V3.views || {};
+
+V3.views.files = {
+  title: 'Files',
+  rootState: 'loading',   /* loading | ok | denied | error */
+  rootError: '',
+  rootPath: null,         /* canonical path the daemon resolved '~' to */
+  home: null,             /* the daemon's home, from the first listing */
+  dirs: {},               /* path → {entries, state, error} */
+  expanded: {},           /* path → true */
+  sel: null,              /* selected file path */
+  preview: null,          /* {path, state, text, total, size, modified, error} */
+  transfers: null,        /* null = loading · 'denied' · 'error' · [jobs] */
+  transfersError: '',
+  _rootRequested: false,
+  _transfersRequested: false,
+
+  PREVIEW_BYTES: 8191,    /* first 8 KB, zero-based range */
+
+  render(el) {
+    this.ensureRoot();
+    this.ensureTransfers();
+    el.innerHTML = V3.page({
+      eyebrow: 'the desk',
+      title: 'Files',
+      sub: 'Files on this daemon’s disk, and what is moving under them.',
+      body:
+        '<div class="row" style="justify-content:space-between;flex-wrap:wrap;gap:8px">' +
+          '<span class="fact">' + V3.esc(this.home ? 'this daemon’s disk · ' + this.home : 'this daemon’s disk') + '</span>' +
+          V3.authline(V3.data.you.name, V3.data.you.role, V3.data.you.route) +
+        '</div>' +
+        '<div class="file-deskgrid">' +
+          '<div class="card" style="padding:10px" id="file-tree-host"><div class="tree">' +
+            this.treeHtml() +
+          '</div></div>' +
+          '<div id="file-viewer-host">' + this.viewerHtml() + '</div>' +
+        '</div>' +
+        V3.section('Transfers') +
+        '<div id="file-transfers-host">' + this.transfersHtml() + '</div>'
+    });
+    this.wire(el);
+  },
+
+  /* ---------------- the tree (lazy) ---------------- */
+  ensureRoot() {
+    if (this._rootRequested) return;
+    this._rootRequested = true;
+    V3.transport.get('/api/fs/list?path=~').then(r => {
+      this.home = r.home || null;
+      this.rootPath = r.path;
+      this.dirs[r.path] = { entries: r.entries || [], state: 'ok' };
+      this.rootState = 'ok';
+      this.refreshTree();
+    }).catch(e => {
+      this.rootState = /403/.test(e.message) ? 'denied' : 'error';
+      this.rootError = e.message;
+      this.refreshTree();
+    });
+  },
+
+  treeHtml() {
+    if (this.rootState === 'loading') {
+      return V3.skeleton(18) + '<div style="height:6px"></div>' + V3.skeleton(18, '70%') +
+        '<div style="height:6px"></div>' + V3.skeleton(18, '45%');
+    }
+    if (this.rootState === 'denied') {
+      return '<div class="dim" style="font-size:12.5px;padding:8px 4px">The house may not read here yet — ' +
+        'filesystem grants live in Access on the <a href="/">classic dashboard</a>.</div>';
+    }
+    if (this.rootState === 'error') {
+      return '<div class="dim" style="font-size:12.5px;padding:8px 4px">The listing failed: ' +
+        V3.esc(this.rootError) + '</div>';
+    }
+    return this.dirHtml(this.rootPath, 0, '~');
+  },
+
+  dirHtml(path, depth, label) {
+    const open = !!this.expanded[path];
+    const pad = 'padding-left:' + (8 + depth * 16) + 'px';
+    let html = '<div class="tree-row file-folder' + (open ? ' open' : '') + '" data-folder="' + V3.esc(path) + '" style="' + pad + '">' +
+      '<span class="icon file-chev">' + V3.icon('chev', 12) + '</span>' +
+      '<span>' + V3.esc(label) + '</span></div>';
+    if (!open) return html;
+    const d = this.dirs[path];
+    const childPad = 'padding-left:' + (8 + (depth + 1) * 16) + 'px';
+    if (!d || d.state === 'loading') {
+      return html + '<div class="tree-row" style="' + childPad + '"><span class="dim" style="font-size:12px">reading…</span></div>';
+    }
+    if (d.state === 'denied') {
+      return html + '<div class="tree-row" style="' + childPad + '"><span class="dim" style="font-size:12px">locked — no grant here</span></div>';
+    }
+    if (d.state === 'error') {
+      return html + '<div class="tree-row" style="' + childPad + '"><span class="dim" style="font-size:12px">' + V3.esc(d.error || 'unreadable') + '</span></div>';
+    }
+    const visible = (d.entries || []).filter(e => !e.hidden);
+    if (!visible.length) {
+      return html + '<div class="tree-row" style="' + childPad + '"><span class="dim" style="font-size:12px">empty</span></div>';
+    }
+    return html + visible.map(e => this.entryHtml(e, depth + 1)).join('');
+  },
+
+  entryHtml(e, depth) {
+    if (e.is_dir) return this.dirHtml(e.path, depth, e.name + '/');
+    const pad = 'padding-left:' + (8 + depth * 16) + 'px';
+    return '<div class="tree-row' + (this.sel === e.path ? ' on' : '') + '" data-file="' + V3.esc(e.path) + '" style="' + pad + '">' +
+      '<span class="icon">' + V3.icon('file', 12) + '</span>' +
+      '<span>' + V3.esc(e.name) + '</span>' +
+      (e.is_symlink ? ' <span class="fact">link</span>' : '') +
+    '</div>';
+  },
+
+  refreshTree() {
+    const host = document.getElementById('file-tree-host');
+    if (!host) return;
+    host.innerHTML = '<div class="tree">' + this.treeHtml() + '</div>';
+    this.wireTree(host);
+  },
+
+  /* ---------------- the viewer pane ---------------- */
+  loadPreview(path) {
+    this.preview = { path, state: 'loading' };
+    this.paintViewer();
+    V3.transport.get('/api/fs/stat?path=' + encodeURIComponent(path)).then(st => {
+      if (!st.exists) { this.preview = { path, state: 'note', note: 'It isn’t there anymore.' }; return this.paintViewer(); }
+      if (!st.is_file) { this.preview = { path, state: 'note', note: 'Not a regular file — nothing to print.' }; return this.paintViewer(); }
+      if (st.readable === false) { this.preview = { path, state: 'denied', size: st.size, modified: st.modified_ms }; return this.paintViewer(); }
+      this.peekBytes(path, st);
+    }).catch(e => {
+      this.preview = { path, state: /403/.test(e.message) ? 'denied' : 'error', error: e.message };
+      this.paintViewer();
+    });
+  },
+
+  /* The byte lane: GET /api/fs/read answers raw bytes (200/206), not
+     JSON, so V3.transport.get can't carry it. One fetch, same origin,
+     the same bearer the transport would send, capped at the first 8 KB
+     with a Range header. Every other call in this view rides transport. */
+  peekBytes(path, st) {
+    fetch('/api/fs/read?path=' + encodeURIComponent(path), {
+      headers: Object.assign({ 'Range': 'bytes=0-' + this.PREVIEW_BYTES }, V3.transport.authHeaders())
+    }).then(r => {
+      if (!r.ok && r.status !== 206) throw new Error('GET /api/fs/read → ' + r.status);
+      const total = this.rangeTotal(r.headers.get('Content-Range'));
+      const ctype = r.headers.get('Content-Type') || '';
+      return r.text().then(text => ({ total, ctype, text, status: r.status }));
+    }).then(res => {
+      if (/^image\//.test(res.ctype)) {
+        this.preview = { path, state: 'image', size: st.size, modified: st.modified_ms };
+      } else if (/[\x00-\x08\x0E-\x1F]/.test(res.text)) {
+        this.preview = { path, state: 'binary', size: st.size, modified: st.modified_ms };
+      } else {
+        this.preview = {
+          path, state: 'text', text: res.text,
+          total: res.total != null ? res.total : st.size,
+          truncated: res.status === 206 || (st.size != null && st.size > this.PREVIEW_BYTES + 1),
+          size: st.size, modified: st.modified_ms
+        };
+      }
+      this.paintViewer();
+    }).catch(e => {
+      this.preview = { path, state: /403/.test(e.message) ? 'denied' : 'error', error: e.message, size: st.size, modified: st.modified_ms };
+      this.paintViewer();
+    });
+  },
+
+  rangeTotal(cr) {
+    const m = /\/(\d+)\s*$/.exec(cr || '');
+    return m ? +m[1] : null;
+  },
+
+  paintViewer() {
+    const host = document.getElementById('file-viewer-host');
+    if (host) host.innerHTML = this.viewerHtml();
+  },
+
+  viewerHtml() {
+    const p = this.preview;
+    let inner;
+    if (!p) {
+      inner = V3.empty('files', 'Pick a file', 'Choose something on the left — I’ll show the first page of it here.');
+    } else if (p.state === 'loading') {
+      inner = '<div class="col" style="gap:8px">' + V3.skeleton(16, '60%') + V3.skeleton(120) + '</div>';
+    } else if (p.state === 'denied') {
+      inner = V3.empty('key', 'The house may not read here yet',
+        'Filesystem grants live in Access on the classic dashboard — a person can say yes there; a rule cannot.',
+        '<a class="btn btn-safe" href="/">' + V3.ICON('key', 15) + ' open Access →</a>');
+    } else if (p.state === 'image') {
+      inner = this.previewHead(p) +
+        V3.empty('camera', 'A picture — not rendered in this draft',
+          'The classic dashboard draws images; this room reads text.' + this.sizeWords(p));
+    } else if (p.state === 'binary') {
+      inner = this.previewHead(p) +
+        V3.empty('file', 'Binary — nothing honest to print',
+          'It isn’t text, so I won’t dump it.' + this.sizeWords(p));
+    } else if (p.state === 'text') {
+      inner = this.previewHead(p) +
+        '<pre class="file-pre">' + V3.esc(p.text) + '</pre>' +
+        (p.truncated
+          ? '<div class="dim" style="margin-top:8px;font-size:12px">the first 8 KB' +
+            (p.total != null ? ' of ' + this.fmtSize(p.total) : '') + ' — the rest stays on disk.</div>'
+          : '');
+    } else if (p.state === 'note') {
+      inner = V3.empty('file', 'Nothing to show', p.note || '');
+    } else {
+      inner = V3.empty('warn', 'The read failed', p.error || 'the daemon said no');
+    }
+    return '<div class="card file-accent-slate" id="file-viewer">' + inner + '</div>';
+  },
+
+  previewHead(p) {
+    const name = String(p.path).split('/').pop();
+    return '<div class="row" style="gap:8px;margin-bottom:10px">' +
+      V3.ICON('file', 15) + '<b>' + V3.esc(name) + '</b><span class="grow"></span>' +
+      (p.size != null ? V3.fact(this.fmtSize(p.size)) : '') +
+      (p.modified ? V3.fact('modified ' + V3.norm.ago(p.modified)) : '') +
+    '</div>';
+  },
+
+  sizeWords(p) {
+    return p.size != null ? ' It’s ' + this.fmtSize(p.size) + ' on disk.' : '';
+  },
+
+  fmtSize(bytes) {
+    const b = +bytes;
+    if (!(b >= 0)) return '—';
+    if (b < 1024) return b + ' B';
+    if (b < 1024 * 1024) return (b / 1024).toFixed(b < 10240 ? 1 : 0) + ' KB';
+    if (b < 1024 * 1024 * 1024) return (b / (1024 * 1024)).toFixed(1) + ' MB';
+    return (b / (1024 * 1024 * 1024)).toFixed(2) + ' GB';
+  },
+
+  /* ---------------- transfers ---------------- */
+  ensureTransfers() {
+    if (this._transfersRequested) return;
+    this._transfersRequested = true;
+    V3.transport.get('/api/transfers').then(r => {
+      this.transfers = (r && r.jobs) || [];
+    }).catch(e => {
+      this.transfers = /403/.test(e.message) ? 'denied' : 'error';
+      this.transfersError = e.message;
+    }).finally(() => {
+      const host = document.getElementById('file-transfers-host');
+      if (host) host.innerHTML = this.transfersHtml();
+    });
+  },
+
+  transfersHtml() {
+    if (this.transfers === null) {
+      return '<div class="card">' + V3.skeleton(18) + '<div style="height:8px"></div>' + V3.skeleton(18, '65%') + '</div>';
+    }
+    if (this.transfers === 'denied') {
+      return V3.card({ title: 'Transfers',
+        body: '<div class="dim" style="font-size:12.5px">The daemon keeps this shelf closed to you — its IAM gates the transfer list.</div>' });
+    }
+    if (this.transfers === 'error') {
+      return V3.card({ title: 'Transfers',
+        body: '<div class="dim" style="font-size:12.5px">The shelf didn’t answer: ' + V3.esc(this.transfersError) + '</div>' });
+    }
+    if (!this.transfers.length) {
+      return V3.empty('upload', 'Nothing moving right now',
+        'When files move between you, the house, and peers, they land here — and they’re resumable: the house picks up where it left off after a restart.');
+    }
+    return '<div class="card"><div class="col" style="gap:12px">' +
+        this.transfers.map(t => this.transferRow(t)).join('') +
+      '</div>' +
+      '<div class="dim" style="margin-top:10px;font-size:12px">Transfers survive restarts — the house picks up where it left off.</div></div>';
+  },
+
+  transferRow(t) {
+    const done = t.status === 'completed';
+    const total = t.total_size || 0;
+    const pct = total ? Math.min(100, Math.round(100 * (t.completed_bytes || 0) / total)) : (done ? 100 : 0);
+    const leaf = p => p ? String(p).split('/').filter(Boolean).pop() : null;
+    const name = t.original_name || t.filename || t.source_label || leaf(t.final_path) || leaf(t.destination_path) || leaf(t.source_path) || t.id;
+    const chipFor = {
+      completed: ['done', 'sage'], running: ['moving', 'slate'], queued: ['queued', 'slate'],
+      paused: ['paused · resumable', 'attn'], ready: ['ready', 'sage'],
+      failed: ['failed', 'brick'], cancelled: ['cancelled', 'slate']
+    }[t.status] || [t.status || '—', 'slate'];
+    return '<div class="row" style="gap:10px;flex-wrap:wrap">' +
+      V3.ICON(t.kind === 'upload' ? 'upload' : 'download', 15) +
+      '<span style="flex:1;min-width:200px">' + V3.esc(name) + '</span>' +
+      '<span class="row" style="gap:6px;min-width:160px;flex:0 0 220px">' +
+        V3.meter(pct, done ? '' : 'warn') +
+        '<span class="fact">' + pct + '%</span></span>' +
+      V3.chip(chipFor[0], chipFor[1]) +
+      (t.status === 'failed' && t.error ? '<span class="fact" title="' + V3.esc(t.error) + '">why</span>' : '') +
+    '</div>';
+  },
+
+  /* ---------------- wiring ---------------- */
+  wire(el) {
+    this.wireTree(el);
+  },
+
+  wireTree(root) {
+    const self = this;
+    root.querySelectorAll('[data-folder]').forEach(r => r.addEventListener('click', () => {
+      const p = r.dataset.folder;
+      if (self.expanded[p]) { delete self.expanded[p]; self.refreshTree(); return; }
+      self.expanded[p] = true;
+      if (!self.dirs[p]) {
+        self.dirs[p] = { entries: [], state: 'loading' };
+        V3.transport.get('/api/fs/list?path=' + encodeURIComponent(p)).then(res => {
+          self.dirs[p] = { entries: res.entries || [], state: 'ok' };
+        }).catch(err => {
+          self.dirs[p] = { entries: [], state: /403/.test(err.message) ? 'denied' : 'error', error: err.message };
+        }).finally(() => self.refreshTree());
+      }
+      self.refreshTree();
+    }));
+    root.querySelectorAll('[data-file]').forEach(r => r.addEventListener('click', () => {
+      self.sel = r.dataset.file;
+      document.querySelectorAll('#file-tree-host [data-file]').forEach(x => x.classList.toggle('on', x === r));
+      self.loadPreview(self.sel);
+    }));
+  }
+};

--- a/static/v3/js/views/home.js
+++ b/static/v3/js/views/home.js
@@ -1,0 +1,155 @@
+/* V3 — Home: the owner's box.
+   Queue → the Conversation → Now Playing → Today.
+   Every section renders from V3.data; `live(what)` re-renders on store
+   events without clobbering an in-progress answer or scroll position. */
+window.V3 = window.V3 || {};
+V3.views = V3.views || {};
+
+V3.views.home = {
+  title: 'Home',
+
+  render(el) {
+    const D = V3.data;
+    const hour = new Date().getHours();
+    const greet = hour < 12 ? 'Good morning' : hour < 18 ? 'Good afternoon' : 'Good evening';
+    const pending = V3.queueStore.pending();
+    const fyis = V3.queueStore.fyis();
+    const live = D.sessions.filter(s => s.active);
+    const done = D.sessions.filter(s => !s.active && (s.phase === 'done' || s.phase === 'failed')).slice(0, 3);
+
+    el.innerHTML = V3.page({
+      title: greet + (D.you.name !== 'you' ? ', ' + D.you.name : '') + '.',
+      sub: D.bootError
+        ? 'The line to the house failed to open: <b>' + V3.esc(D.bootError) + '</b> — retrying in the background.'
+        : pending.length
+          ? '<b>' + pending.length + '</b> thing' + (pending.length > 1 ? 's' : '') + ' need' + (pending.length > 1 ? '' : 's') + ' you — the rest is humming.'
+          : 'Nothing needs you. The house is humming.',
+      body:
+        V3.section('Needs you') +
+        '<div id="home-queue" class="col" style="gap:12px">' +
+          (pending.length || fyis.length
+            ? pending.map(q => V3.decisionCard(q)).join('') + fyis.map(q => V3.decisionCard(q)).join('')
+            : '<div class="queue-free"><span class="big">You’re free.</span>' +
+              V3.esc(live.length ? live.length + ' session' + (live.length === 1 ? ' is' : 's are') + ' working — I’ll tap you if anything comes up.'
+                                  : 'Nothing on stage either — give the house something to do below.') + '</div>') +
+        '</div>' +
+
+        V3.section('The conversation') +
+        '<div class="thread" id="home-thread">' + this.threadHtml() + '</div>' +
+
+        V3.section('Now playing') +
+        '<div class="grid grid-3">' +
+          (live.map(V3.stageCard).join('') ||
+            V3.empty('stage', 'Nothing on stage', 'Give the house something to do — one sentence in the composer is enough.')) +
+        '</div>' +
+        (done.length ? '<div class="eyebrow" style="margin-top:10px">just finished</div>' +
+          '<div class="grid grid-3">' + done.map(V3.stageCard).join('') + '</div>' : '') +
+
+        V3.section('Today') +
+        this.todayHtml()
+    });
+    V3.mountIcons(el);
+    this.wire(el);
+  },
+
+  threadHtml() {
+    const conv = V3.data.conversation;
+    if (!conv.length) {
+      return '<div class="queue-free" style="padding:18px"><span class="big">Say something to the house.</span>' +
+        'It answers in the first person, and shows its work when you ask.</div>';
+    }
+    return conv.slice(-60).map(m => {
+      if (m.kind === 'milestone') {
+        return '<div class="milestone"><span class="line"></span><span>' + V3.esc(m.text) + '</span>' +
+          (m.session ? '<button class="btn btn-quiet btn-xs" data-showwork="' + V3.esc(m.session) + '">show work</button>' : '') +
+          '<span class="line"></span></div>';
+      }
+      if (m.from === 'you') {
+        return '<div class="msg msg-you"><div class="avatar">' + V3.icon('arch', 15) + '</div>' +
+          '<div class="msg-body"><div class="prose"><p>' + V3.esc(m.text) + '</p></div>' +
+          '<div class="msg-meta"><span>' + (m.at || '') + '</span><span>you</span></div></div></div>';
+      }
+      const prose = (m.prose || []).map(p => '<p>' + V3.esc(p) + '</p>').join('');
+      return '<div class="msg"><div class="avatar">' + V3.icon('arch', 15) + '</div>' +
+        '<div class="msg-body"><div class="prose">' + prose + '</div>' +
+        '<div class="msg-meta"><span>' + (m.at || '') + '</span><span>presence · the house</span></div></div></div>';
+    }).join('');
+  },
+
+  todayHtml() {
+    const D = V3.data;
+    const items = [];
+    const now = Date.now();
+    const day = 86400000;
+    /* agenda items with due times + scheduled-session effects (the
+       daemon's scheduler, surfaced here for the first time) */
+    D.agenda.forEach(a => {
+      (a.effects || []).forEach(fx => {
+        const when = (fx.manifest && (fx.manifest.fire_at_ms || fx.manifest.next_ms)) || fx.proposed_ms;
+        /* approval state = presence of a matching approval digest (AgendaApproval) */
+        const approved = !!(fx.approval && fx.approval.digest && fx.approval.digest === fx.digest);
+        items.push({
+          t: when, kind: approved ? 'scheduled' : 'proposed',
+          label: (fx.manifest && fx.manifest.goal) || a.title || 'scheduled session',
+          fxId: fx.effect_id, digest: fx.digest, approved, itemId: a.id
+        });
+      });
+      if (a.due_ms) items.push({ t: a.due_ms, kind: 'reminder', label: a.title, itemId: a.id });
+    });
+    items.sort((a, b) => (a.t || now) - (b.t || now));
+    const upcoming = items.filter(i => !i.t || i.t > now - day).slice(0, 10);
+
+    let html = '<div class="ribbon">';
+    html += '<div class="ribbon-item now"><span class="t">now</span><span>' +
+      (V3.queueStore.pending().length ? V3.queueStore.pending().length + ' things need you' : 'all clear') + '</span></div>';
+    html += upcoming.map(i =>
+      '<div class="ribbon-item' + (i.kind === 'proposed' ? ' attn' : '') + '" ' + (i.fxId ? 'data-fx="' + i.itemId + ':' + i.fxId + ':' + (i.digest || '') + ':' + i.approved + '"' : '') + '>' +
+      '<span class="t">' + (i.t ? V3.esc(V3.clock(i.t)) : '—') + '</span><span>' + V3.esc(i.label) + '</span>' +
+      (i.kind === 'proposed' ? '<span class="dim" style="font-size:11px">scheduled session — tap to approve</span>'
+        : i.kind === 'scheduled' ? '<span class="dim" style="font-size:11px">scheduled</span>' : '') +
+      '</div>').join('');
+    html += '</div>';
+    if (!upcoming.length) {
+      html += '<div class="dim" style="font-size:12.5px;margin-top:-4px">Nothing scheduled. Park something in Books → The List and give it a time — the daemon’s scheduler fires it.</div>';
+    }
+    return html;
+  },
+
+  wire(el) {
+    el.querySelectorAll('[data-showwork]').forEach(b => b.addEventListener('click', function () {
+      const ms = this.closest('.milestone');
+      if (ms.nextElementSibling && ms.nextElementSibling.classList.contains('panel')) { ms.nextElementSibling.remove(); this.textContent = 'show work'; return; }
+      const lines = (V3.data.logs[this.dataset.showwork] || []).slice(-8);
+      const w = V3.h('div', 'panel', lines.length
+        ? V3.logLines(lines.map(l => [l.t, l.kind, l.text]))
+        : '<div class="dim" style="font-size:12px">No work lines replayed for this session yet.</div>');
+      ms.after(w); this.textContent = 'hide work';
+    }));
+    el.querySelectorAll('[data-fx]').forEach(card => card.addEventListener('click', () => {
+      const [itemId, fxId, digest, approved] = card.dataset.fx.split(':');
+      if (approved === 'true') return;
+      V3.actions.agendaOp({ op: 'approve_effect', id: itemId, digest })
+        .then(ok => { if (ok) V3.toast('Scheduled — the daemon fires it', 'sage'); });
+    }));
+  },
+
+  live(what) {
+    if (!['queue', 'sessions', 'conversation', 'agenda', 'ready', 'conn', 'logs:main'].includes(what)) return;
+    const active = document.activeElement;
+    if (active && document.getElementById('main').contains(active) && /INPUT|TEXTAREA/.test(active.tagName)) return;
+    const main = document.getElementById('main');
+    const y = main.scrollTop;
+    this.render(main);
+    main.scrollTop = y;
+    if (what === 'conversation') main.scrollTop = main.scrollHeight;
+  }
+};
+
+V3.clock = function (ms) {
+  const d = new Date(ms);
+  const today = new Date();
+  const sameDay = d.toDateString() === today.toDateString();
+  const hm = String(d.getHours()).padStart(2, '0') + ':' + String(d.getMinutes()).padStart(2, '0');
+  if (sameDay) return hm;
+  return d.toLocaleDateString(undefined, { weekday: 'short' }) + ' ' + hm;
+};

--- a/static/v3/js/views/machines.js
+++ b/static/v3/js/views/machines.js
@@ -1,0 +1,290 @@
+/* V3 — Machines: the fleet. Cards first (this machine, then peers),
+   a drill-down per machine, the pairing fold (⌘K lands on
+   #fold-pairing), and delegation across the fence. Everything renders
+   from V3.data.machines (this daemon first, then /api/peers); what the
+   daemon doesn't publish shows as an honest dash, never a made-up number. */
+window.V3 = window.V3 || {};
+V3.views = V3.views || {};
+
+V3.views.machines = {
+  title: 'Machines',
+  cap: 'computer-use',
+
+  render(el, params) {
+    if (params && params[0]) { this.renderMachine(el, params[0]); return; }
+    this.renderFleet(el);
+  },
+
+  /* ---------------- the fleet ---------------- */
+  renderFleet(el) {
+    const ms = V3.data.machines;
+    const knocks = V3.data.queue.filter(q =>
+      (q.kind === 'enrollment' || q.kind === 'peer-pair') && !V3.queueStore.isResolved(q.id));
+    el.innerHTML = V3.page({
+      eyebrow: 'the fleet',
+      title: 'Machines',
+      sub: 'The house’s wings — your machines, the peers it can reach, and how new ones join.',
+      body:
+        (knocks.length
+          ? '<div class="panel row" style="gap:10px">' + V3.ICON('doorbell', 15) +
+            '<span style="flex:1">' + V3.esc(knocks[0].title) + ' — it’s waiting in the queue.</span>' +
+            '<a class="chip chip-attn" href="#/home">answer it →</a></div>'
+          : '') +
+        (ms.length
+          ? '<div class="grid grid-3">' + ms.map(m => this.machineCard(m)).join('') + '</div>'
+          : V3.empty('machines', 'No machines yet', 'This daemon hasn’t checked in, and no peers are linked.')) +
+        this.pairingFold() +
+        this.delegateFold()
+    });
+    this.wireFleet(el);
+  },
+
+  /* local fuel comes from /api/api-key-status; peers don't publish
+     theirs to this daemon — an honest dash, not a guess */
+  fueledChip(m) {
+    if (m.id === 'local') {
+      const f = V3.data.fuel || {};
+      return (f.openai || f.anthropic || f.gemini)
+        ? V3.chip('fueled', 'sage', 'fuel')
+        : V3.chip('dry — no API keys', 'attn', 'fuel');
+    }
+    return V3.fact('fuel: —');
+  },
+
+  machineCard(m) {
+    const online = m.status === 'online';
+    const local = m.id === 'local';
+    return '<div class="card">' +
+      '<div class="row" style="align-items:baseline;gap:8px">' +
+        '<span class="mach-petname">' + V3.esc(m.petname) + '</span>' +
+        '<span class="dim mono" style="font-size:11.5px;white-space:nowrap">' + V3.esc(m.label) + '</span>' +
+        '<span class="grow"></span>' +
+        (local ? V3.chip('this machine', 'brass') : '') +
+      '</div>' +
+      '<div class="row" style="gap:8px;margin-top:6px;flex-wrap:wrap">' +
+        V3.dot(online ? 'sage' : 'slate', online) +
+        '<span style="font-size:13px">' + (online ? 'online' : 'away') + '</span>' +
+        V3.routeChip(m.route) +
+        V3.chip(m.role || 'peer', m.role === 'owner' ? 'brass' : 'slate') +
+      '</div>' +
+      ((m.capabilities || []).length
+        ? '<div class="row" style="gap:6px;margin-top:10px;flex-wrap:wrap">' +
+          m.capabilities.map(c => V3.chip(c, null)).join('') + '</div>'
+        : '') +
+      '<div class="row" style="gap:8px;margin-top:12px;flex-wrap:wrap">' + this.fueledChip(m) + '</div>' +
+      '<div class="factline" style="margin-top:10px">' + V3.fact(m.version ? 'v' + m.version : 'version —') + '</div>' +
+      '<div class="row" style="margin-top:12px">' +
+        '<a class="btn btn-quiet btn-xs" href="#/machines/' + encodeURIComponent(m.id) + '">Open ' + V3.ICON('chev', 13) + '</a>' +
+      '</div>' +
+    '</div>';
+  },
+
+  /* ---------------- link a machine (⌘K lands here) ---------------- */
+  pairingFold() {
+    const mode = (title, expl, cons) =>
+      '<div class="panel">' +
+        '<div style="margin-bottom:6px"><b>' + V3.esc(title) + '</b></div>' +
+        '<div style="font-size:13px;color:var(--text-2)">' + V3.esc(expl) + '</div>' +
+        '<div class="dim" style="font-size:12px;margin-top:8px;font-style:italic">' + V3.esc(cons) + '</div>' +
+      '</div>';
+    return V3.foldHtml({
+      key: 'machines.pairing', id: 'fold-pairing', title: 'Link a machine', note: 'four ways in',
+      body:
+        '<div class="grid grid-2">' +
+          mode('Request access',
+            'Knock on another house’s door. You introduce yourself; its owner decides what you may do.',
+            'Pairing creates a route, not authority — its IAM still decides.') +
+          mode('Join invite',
+            'Someone handed you twelve words. They name a door — once — and then they are spent.',
+            'A claim code is a name tag, not a key — the other house still decides your role.') +
+          mode('Grant invite',
+            'Mint twelve words for a machine you want to let in. Single use, and they wilt in a day.',
+            'You stay the authority — revoke the moment you like.') +
+          mode('Manual add',
+            'Paste an address and a key by hand — for networks that don’t do ceremonies.',
+            'Pairing creates a route, not authority — your IAM still decides.') +
+        '</div>' +
+        '<div class="dim" style="font-size:12.5px;margin-top:10px">The full pairing wizard lives in the classic dashboard for this draft — <a href="/">open it there →</a></div>'
+    });
+  },
+
+  /* ---------------- delegate ---------------- */
+  delegateFold() {
+    const peers = V3.data.machines.filter(m => m.id !== 'local');
+    const caps = [];
+    peers.forEach(m => (m.capabilities || []).forEach(c => { if (caps.indexOf(c) === -1) caps.push(c); }));
+    if (!caps.length) caps.push('computer-use', 'terminal', 'headless');
+    if (caps.indexOf(this.cap) === -1) this.cap = caps[0];
+    return V3.foldHtml({
+      key: 'machines.delegate', title: 'Delegate', note: 'send work across the fleet',
+      body:
+        '<div class="dim" style="font-size:12.5px;margin-bottom:10px">Pick what the work needs — I’ll show you who can take it.</div>' +
+        '<div class="row" style="gap:6px;flex-wrap:wrap">' +
+          caps.map(c =>
+            '<button class="chip' + (c === this.cap ? ' chip-sage' : '') + '" data-cap="' + V3.esc(c) + '">' + V3.esc(c) + '</button>').join('') +
+        '</div>' +
+        '<div id="mach-eligible" style="margin-top:10px">' + this.eligibleHtml() + '</div>'
+    });
+  },
+
+  eligibleHtml() {
+    const cap = this.cap;
+    const peers = V3.data.machines.filter(m => m.id !== 'local');
+    if (!peers.length) {
+      return V3.empty('machines', 'No peers linked yet',
+        'Pair a machine above and it can take work from here — its own IAM re-decides everything there.');
+    }
+    const eligible = peers.filter(m => m.status === 'online' && (m.capabilities || []).indexOf(cap) > -1);
+    if (!eligible.length) {
+      return V3.empty('machines', 'Nobody can take that right now',
+        'A peer needs the capability and a pulse — nothing online advertises “' + cap + '”.');
+    }
+    return eligible.map(m =>
+      '<div class="panel">' +
+        '<div class="row" style="gap:8px;flex-wrap:wrap">' +
+          V3.dot('sage') + '<b>' + V3.esc(m.petname) + '</b>' +
+          V3.routeChip(m.route) + V3.chip(m.role || 'peer', 'slate') +
+          '<span class="fact">' + V3.esc(m.label) + '</span>' +
+        '</div>' +
+        '<textarea class="input" rows="2" style="width:100%;margin-top:8px" placeholder="What should ' +
+          V3.esc(m.petname) + ' do? One sentence is plenty…"></textarea>' +
+        '<div class="row" style="margin-top:8px;gap:8px;flex-wrap:wrap">' +
+          '<button class="btn btn-primary btn-xs" data-route-task="' + V3.esc(m.id) + '">' + V3.ICON('send', 13) + ' Route the task</button>' +
+          '<span class="dim" style="font-size:12px">Its IAM re-decides everything there — your route is a request, not a skeleton key.</span>' +
+        '</div>' +
+      '</div>').join('');
+  },
+
+  wireFleet(el) {
+    const self = this;
+    el.querySelectorAll('[data-cap]').forEach(b => b.addEventListener('click', () => {
+      self.cap = b.dataset.cap;
+      el.querySelectorAll('[data-cap]').forEach(x => x.classList.toggle('chip-sage', x === b));
+      const host = document.getElementById('mach-eligible');
+      if (host) { host.innerHTML = self.eligibleHtml(); self.wireEligible(host); }
+    }));
+    this.wireEligible(el);
+  },
+
+  wireEligible(root) {
+    root.querySelectorAll('[data-route-task]').forEach(b => b.addEventListener('click', () => {
+      const id = b.dataset.routeTask;
+      const ta = b.closest('.panel').querySelector('textarea');
+      const text = (ta && ta.value || '').trim();
+      if (!text) { V3.toast('Give the task a sentence first', 'brick'); return; }
+      b.disabled = true;
+      /* the daemon's DelegateTaskRequest keys on `instructions` */
+      V3.transport.post('/api/peers/' + encodeURIComponent(id) + '/task', {
+        instructions: text,
+        client_correlation_id: 'v3-' + Date.now().toString(36)
+      }).then(r => {
+        if (ta) ta.value = '';
+        V3.toast('Routed to ' + V3.machineName(id) +
+          (r && r.delivery === 'acknowledged' ? ' — acknowledged' : ' — sent, unconfirmed'), 'sage');
+      }).catch(V3.actions._err).finally(() => { b.disabled = false; });
+    }));
+  },
+
+  /* ---------------- the drill-down ---------------- */
+  renderMachine(el, rawId) {
+    let id = rawId;
+    try { id = decodeURIComponent(rawId); } catch (e) {}
+    const m = V3.data.machines.find(x => String(x.id) === String(id));
+    if (!m) {
+      el.innerHTML = V3.page({
+        body:
+          '<div class="eyebrow"><a href="#/machines" style="color:inherit">machines</a></div>' +
+          V3.empty('machines', 'No such machine', 'It may have unpaired — the fleet list is one tap back.')
+      });
+      return;
+    }
+    const local = m.id === 'local';
+    const online = m.status === 'online';
+    const sessions = local ? V3.data.sessions.filter(s => (s.machine || 'local') === 'local') : [];
+    el.innerHTML = V3.page({
+      body:
+        '<div class="row" style="align-items:flex-start;gap:14px;flex-wrap:wrap">' +
+          '<div style="min-width:280px;flex:1">' +
+            '<div class="eyebrow"><a href="#/machines" style="color:inherit">machines</a> / ' + V3.esc(m.petname) + '</div>' +
+            '<h1 class="page-title" style="font-size:26px">' + V3.esc(m.petname) + '</h1>' +
+            '<div class="page-sub">' +
+              (local ? 'This machine — where the house lives.'
+                     : 'A peer, reached ' + V3.esc(m.route) + '.') + '</div>' +
+            '<div class="row" style="gap:6px;flex-wrap:wrap">' +
+              V3.dot(online ? 'sage' : 'slate', online) +
+              '<span style="font-size:13px">' + V3.esc(m.status) + '</span>' +
+              V3.routeChip(m.route) +
+              V3.chip(m.role || 'peer', m.role === 'owner' ? 'brass' : 'slate') +
+              this.fueledChip(m) +
+              (local ? V3.chip('this machine', 'brass') : '') +
+            '</div>' +
+          '</div>' +
+          '<div class="col" style="gap:8px;align-items:flex-end">' +
+            (local ? V3.authline(V3.data.you.name, V3.data.you.role, V3.data.you.route)
+                   : V3.authline('via ' + m.petname, m.role || 'peer', m.route)) +
+          '</div>' +
+        '</div>' +
+        (!local
+          ? '<div class="panel dim" style="font-size:12.5px">You’re browsing ' + V3.esc(m.petname) +
+            ' from across the fence — its sessions and screens show here display-only, as its IAM allows.</div>'
+          : '') +
+        '<div class="card"><div class="factline" style="gap:22px">' +
+          '<span>' + V3.fact(m.version ? 'v' + m.version : 'version —') + '</span>' +
+          '<span>' + V3.fact((m.capabilities || []).join(' · ') || 'no capabilities advertised') + '</span>' +
+          '<span class="studio-only">' + V3.fact('via ' + m.route) + '</span>' +
+        '</div></div>' +
+        V3.section('Its sessions') +
+        (local
+          ? (sessions.length
+            ? '<div class="grid grid-3">' + sessions.map(V3.stageCard).join('') + '</div>'
+            : V3.empty('stage', 'Nothing on stage', 'Give the house something to do — one sentence in the composer is enough.'))
+          : '<div class="card"><div class="row" style="gap:10px;flex-wrap:wrap">' +
+            V3.ICON('stage', 15) +
+            '<span style="flex:1;min-width:220px;font-size:13px">A peer’s sessions browse in the classic dashboard in this draft — nothing is hidden, just not rebuilt here yet.</span>' +
+            '<a class="btn btn-quiet btn-xs" href="/">open the classic dashboard →</a></div></div>') +
+        V3.section('Its screens') +
+        this.machineDisplaysHtml(m, local) +
+        (!local
+          ? '<div class="dim" style="font-size:12.5px">Work on ' + V3.esc(m.petname) +
+            ' happens from its own dashboard — the trust model gives you a window, not a key.</div>'
+          : '')
+    });
+  },
+
+  machineDisplaysHtml(m, local) {
+    if (local) {
+      const displays = V3.data.displays;
+      if (!displays.length) {
+        return V3.empty('screens', 'No screens here',
+          'Screens appear when the house launches something graphical, or its owner shares one.');
+      }
+      return '<div class="card"><div class="col" style="gap:10px">' +
+        displays.map(d =>
+          '<div class="row" style="gap:10px;flex-wrap:wrap">' +
+            V3.ICON('screens', 15) +
+            '<span style="flex:1;min-width:180px">Display ' + V3.esc(d.id) + '</span>' +
+            V3.fact(d.w + '×' + d.h) +
+            (d.live ? V3.chip('live', 'sage') : V3.chip('off', 'slate')) +
+            '<a class="chip" href="#/screens">open in screens →</a>' +
+          '</div>').join('') +
+        '</div></div>';
+    }
+    const reported = (m.displays || []).length;
+    if (!reported) {
+      return V3.empty('screens', 'No screens here', 'Nothing ' + m.petname + ' has shared right now.');
+    }
+    return '<div class="card"><div class="dim" style="font-size:12.5px">' +
+      V3.esc(m.petname) + ' reports ' + reported + ' display' + (reported === 1 ? '' : 's') +
+      ' — watching them lives in the classic dashboard in this draft. <a href="/">open it →</a></div></div>';
+  },
+
+  live(what) {
+    if (!['machines', 'sessions', 'queue', 'ready', 'displays'].includes(what)) return;
+    const active = document.activeElement;
+    if (active && document.getElementById('main').contains(active) && /INPUT|TEXTAREA/.test(active.tagName)) return;
+    const main = document.getElementById('main');
+    const y = main.scrollTop;
+    V3.route();
+    main.scrollTop = y;
+  }
+};

--- a/static/v3/js/views/people.js
+++ b/static/v3/js/views/people.js
@@ -1,0 +1,198 @@
+/* V3 — People & Keys: who may do what.
+   You → people & devices → doors → keys & vault (⌘K lands on #fold-vault).
+   Everything renders from V3.data (the /api/access/* polls); the only fetch
+   the room makes itself is the hosted-control snapshot, cached per visit.
+   Trust doctrine stays literal: petnames first, routes labeled, no door
+   mints authority, and the hosted ceiling stands without an owner ceremony. */
+window.V3 = window.V3 || {};
+V3.views = V3.views || {};
+
+V3.views.people = {
+  title: 'People & Keys',
+
+  /* the four keys the house hands out, in plain words */
+  ROLES: [
+    ['owner', 'everything, including who else gets keys — hand this one out like a spare house key'],
+    ['operator', 'runs work and touches screens; can’t hand out keys'],
+    ['spectator', 'watches everything, touches nothing'],
+    ['session-reader', 'reads finished work only']
+  ],
+
+  _hc: undefined,   /* hosted-control snapshot: undefined = not fetched, null = gated/absent */
+
+  render(el) {
+    const D = V3.data;
+    const you = D.you || { name: 'you', role: 'owner', route: 'direct' };
+    const ov = D.accessOverview || {};
+    const fuel = D.fuel || {};
+    const agents = D.externalAgents || [];
+
+    el.innerHTML = V3.page({
+      eyebrow: 'who may do what',
+      title: 'People & Keys',
+      sub: 'Every key the house honors, what it may do, and where the fuel lives. Petnames first — the route is always labeled, and no door mints authority.',
+      body:
+        /* ---------- You ---------- */
+        '<div class="card">' +
+          '<div class="row" style="gap:10px;align-items:baseline;flex-wrap:wrap">' +
+            '<span class="voice" style="font-size:23px">' + V3.esc(you.name) + '</span>' +
+            V3.chip(you.role, 'brass', 'shield') + V3.routeChip(you.route) +
+          '</div>' +
+          '<p style="margin:10px 0 0;font-size:13.5px;max-width:64ch">This page is served by the daemon itself, and it treats whoever reached it as <b>' +
+            V3.esc(you.role) + '</b> — on loopback, that’s the owner. Your identity here is the serving context, not a login: the day you open this page through a key of your own, the house will name it here.</p>' +
+        '</div>' +
+
+        /* ---------- People & devices ---------- */
+        V3.section('People & devices') +
+        (D.people.length
+          ? '<div class="card" style="padding:6px"><table class="table"><thead><tr>' +
+            '<th>Who</th><th>Key</th><th>Role</th><th>Route</th><th>Lifecycle</th><th>Since</th></tr></thead><tbody>' +
+            D.people.map(p =>
+              '<tr>' +
+              '<td>' + V3.esc(p.who) + '</td>' +
+              '<td class="mono">' + V3.esc(p.key || '—') + '</td>' +
+              '<td>' + V3.chip(p.role, p.role === 'owner' ? 'brass' : 'slate') + '</td>' +
+              '<td>' + (!p.route || p.route === '—' ? '<span class="dim">—</span>' : V3.routeChip(p.route)) + '</td>' +
+              '<td>' + V3.chip(p.lifecycle, p.lifecycle === 'active' ? 'sage' : 'brick') + '</td>' +
+              '<td class="mono">' + V3.esc(p.since || '—') + '</td>' +
+              '</tr>').join('') +
+            '</tbody></table></div>' +
+            '<div class="factline" style="margin-top:-4px">' +
+              V3.fact((ov.principals || []).length + ' principals · ' + (ov.grants || []).length + ' grants · ' + (ov.permissions || []).length + ' permissions in the IAM model') +
+              (ov.scope ? V3.fact('scope: ' + (ov.scope.label || ov.scope.kind || 'daemon')) : '') +
+            '</div>'
+          : V3.empty('key', 'No other keys yet', 'This daemon honors only the identity that served this page. When you enroll another device or hand out a key, it appears here.')) +
+
+        V3.foldHtml({ key: 'people.grant', title: 'Hand out a key', note: 'a promise you can revoke any time',
+          body:
+          '<div class="dim" style="font-size:13px;margin:4px 0 10px">What a new key may do — plain words up front, the compiled role rides along underneath.</div>' +
+          '<div class="ppl-roles">' +
+            this.ROLES.map(r =>
+              '<div class="panel ppl-role"><b>' + V3.esc(r[0]) + '</b><div class="dim">' + V3.esc(r[1]) + '</div></div>').join('') +
+          '</div>' +
+          '<div class="dim" style="font-size:12.5px;margin-top:12px">A device that wants in asks first — enrollment requests arrive in <a href="#/home">the Queue</a>, and you decide there. The deep grant forms (custom roles, org grants, ORLs) stay on <a href="/">the classic dashboard</a> for this draft.</div>' }) +
+
+        /* ---------- Doors ---------- */
+        V3.section('Doors — the ways in') +
+        '<div class="grid grid-2">' +
+          '<div id="ppl-hc">' + this.hostedHtml() + '</div>' +
+          V3.card({
+            title: 'Connect & claim codes', sub: 'the hosted rendezvous',
+            body:
+              '<div class="row">' + V3.chip('a name tag, not a key', 'slate', 'info') + '</div>' +
+              '<p style="margin:10px 0 8px;font-size:13.5px">Connect introduces: it knows the fleet’s names and where to knock. A twelve-word claim code lets a new browser find this daemon and say its name — <b>claiming grants no authority</b>; the newcomer still asks you for a key.</p>' +
+              '<div class="dim" style="font-size:12.5px">The claim ceremony — minting and redeeming codes — lives in <a href="/">the classic dashboard</a> in this draft.</div>'
+          }) +
+        '</div>' +
+
+        /* ---------- Keys & vault (⌘K target) ---------- */
+        V3.foldHtml({ key: 'people.vault', id: 'fold-vault', title: 'Keys & vault', note: 'fuel · sign-ins · custody',
+          body:
+          '<div class="eyebrow" style="margin:4px 0 8px">Fuel — the API keys the house runs on</div>' +
+          '<div class="row" style="flex-wrap:wrap">' +
+            [['Anthropic', 'anthropic'], ['OpenAI', 'openai'], ['Gemini', 'gemini']].map(([label, k]) =>
+              V3.chip(label + ': ' + (fuel[k] ? 'set' : 'not set'), fuel[k] ? 'sage' : 'attn', 'fuel')).join('') +
+            '<span class="grow"></span>' +
+            '<button class="btn btn-primary btn-xs" id="ppl-add-keys">' + V3.ICON('key', 13) + ' Add API keys</button>' +
+          '</div>' +
+          '<div class="dim" style="font-size:12px;margin-top:6px">Presence checked, never shown — the daemon holds them in its .env and the page never reads them back.</div>' +
+
+          '<div class="eyebrow" style="margin:18px 0 8px">Agent sign-ins — who’s logged in locally</div>' +
+          (agents.length
+            ? '<div class="col" style="gap:6px">' + agents.map(a =>
+                '<div class="row" style="flex-wrap:wrap">' +
+                  '<b style="min-width:130px">' + V3.esc(a.label || a.id) + '</b>' +
+                  (a.installed === false ? V3.chip('not installed', 'slate')
+                    : V3.chip('installed', 'sage')) +
+                  (a.local_login ? V3.chip('signed in locally', 'sage') : V3.chip('not signed in', 'slate')) +
+                  (a.leased ? V3.chip('leased', 'violet') : '') +
+                '</div>').join('') + '</div>'
+            : '<div class="dim" style="font-size:12.5px">No external agents reported — install Codex or Claude Code and the house can supervise them.</div>') +
+          '<div class="dim" style="font-size:12px;margin-top:6px">Sign-in ceremonies (device auth, tokens) run on <a href="/">the classic dashboard</a>, where you watch exactly where a token lands.</div>' +
+
+          '<div class="eyebrow" style="margin:18px 0 8px">Custody trail — where secrets have been</div>' +
+          '<div class="dim" style="font-size:12.5px;max-width:64ch">The trail — vault leases, egress registrations, token landings — rides the dashboard-control tunnel in this build, so it renders on <a href="/">the classic dashboard</a>. Nothing credential-shaped is ever shown here; presence and state are all a page may say.</div>'
+        })
+    });
+
+    this.wire(el);
+    if (this._hc === undefined) this.fetchHosted();
+  },
+
+  /* ---------- hosted control (the one honest door the room fetches itself) ---------- */
+  hostedHtml() {
+    const hc = this._hc;
+    if (hc === undefined) {
+      return V3.card({ title: 'Hosted control', sub: 'reaching this house from anywhere',
+        body: '<div class="col" style="gap:8px">' + V3.skeleton(14, '60%') + V3.skeleton(14, '90%') + '</div>' });
+    }
+    if (hc === null || hc.configured === false) {
+      return V3.card({ title: 'Hosted control', sub: 'reaching this house from anywhere',
+        body:
+          '<div class="row">' + V3.chip('not configured', 'slate') + '</div>' +
+          '<p style="margin:10px 0 0;font-size:13.5px">This daemon isn’t enrolled with a hosted rendezvous, so nobody can borrow it from a browser. The compiled floor would still apply if it were: hosted sessions can never exceed the preset ceiling without an owner ceremony on this machine.</p>' });
+    }
+    const pol = hc.policy || {};
+    const leases = (hc.active_leases || []).length;
+    const pending = (hc.pending_requests || []).length;
+    const ttl = this.fmtTtl(pol.max_ttl_secs);
+    return V3.card({ title: 'Hosted control', sub: 'reaching this house from anywhere',
+      actions: '<button class="icon-btn" id="ppl-hc-refresh" title="Refresh">' + V3.ICON('refresh', 14) + '</button>',
+      body:
+        '<div class="row" style="flex-wrap:wrap">' +
+          V3.chip(hc.enabled === false ? 'paused' : 'enabled', hc.enabled === false ? 'slate' : 'sage') +
+          V3.chip('ceiling: ' + (pol.ceiling || '—'), 'brass', 'shield') +
+          V3.fact('leases live: ' + leases) +
+          (pending ? V3.chip(pending + ' asking in the Queue', 'attn', 'doorbell') : '') +
+        '</div>' +
+        '<div class="kv" style="margin-top:10px">' +
+          '<span class="k">max lease</span><span class="v">' + V3.esc(ttl) + '</span>' +
+          '<span class="k">floor</span><span class="v">the ceiling stands without an owner ceremony</span>' +
+        '</div>' +
+        '<div class="dim" style="margin-top:10px;font-size:12.5px">Hosted sessions are time-boxed leases you can revoke, and they can never exceed the preset ceiling — a hosted page mints nothing on its own.</div>' });
+  },
+
+  fmtTtl(secs) {
+    const s = Number(secs) || 0;
+    if (!s) return '—';
+    if (s % 86400 === 0) return (s / 86400) + ' day' + (s / 86400 > 1 ? 's' : '');
+    if (s % 3600 === 0) return (s / 3600) + ' h';
+    if (s % 60 === 0) return (s / 60) + ' min';
+    return s + ' s';
+  },
+
+  fetchHosted() {
+    V3.transport.get('/api/access/hosted-control').then(r => {
+      this._hc = r || null;
+    }).catch(() => {
+      this._hc = null;   /* 404 = not configured, 403 = gated — both render the same honest card */
+    }).then(() => {
+      const node = document.getElementById('ppl-hc');
+      if (node && V3.current === 'people') { node.innerHTML = this.hostedHtml(); this.wireHosted(node); }
+    });
+  },
+
+  wireHosted(node) {
+    const btn = (node || document).querySelector('#ppl-hc-refresh');
+    if (btn) btn.addEventListener('click', () => { this._hc = undefined; this.fetchHosted(); const n = document.getElementById('ppl-hc'); if (n) n.innerHTML = this.hostedHtml(); });
+  },
+
+  wire(el) {
+    const add = el.querySelector('#ppl-add-keys');
+    if (add) add.addEventListener('click', () => {
+      V3.go('#/settings');
+      setTimeout(() => V3.flashTarget('fold-keys'), 80);
+    });
+    this.wireHosted(el);
+  },
+
+  live(what) {
+    if (!['people', 'agents', 'ready'].includes(what)) return;
+    const active = document.activeElement;
+    if (active && document.getElementById('main').contains(active) && /INPUT|TEXTAREA|SELECT/.test(active.tagName)) return;
+    const main = document.getElementById('main');
+    const y = main.scrollTop;
+    this.render(main);
+    main.scrollTop = y;
+  }
+};

--- a/static/v3/js/views/screens.js
+++ b/static/v3/js/views/screens.js
@@ -1,0 +1,308 @@
+/* V3 — Screens: see and touch your machines.
+   Real daemon displays render as honest placeholder tiles (the WebRTC
+   stream stays in the classic dashboard in this draft); input authority
+   is wired to take_display/release_display, your-screen grants ride
+   grant/revoke_user_display, and the activity feed is seeded from the
+   store's rolling logs and fed live by cu_action / display_* events.
+   Terminals and the agent browser are honest link cards, not fakes. */
+window.V3 = window.V3 || {};
+V3.views = V3.views || {};
+
+V3.views.screens = {
+  title: 'Screens',
+  hands: {},            /* displayId → 'agent' | 'you' — who holds the wheel */
+  shared: false,        /* is your screen lent to the house? */
+  shareDur: '15m',
+  activity: [],         /* rolling feed: {t, kind, text} */
+  _subscribed: false,
+
+  DURS: [['15m', '15 minutes'], ['this_session', 'this session'], ['until_revoked', 'until revoked']],
+  DUR_WORDS: { '15m': '15 minutes', 'this_session': 'this session', 'until_revoked': 'until I revoke it' },
+
+  render(el) {
+    this.subscribe();
+    const displays = V3.data.displays;
+    el.innerHTML = V3.page({
+      eyebrow: 'see and touch your machines',
+      title: 'Screens',
+      sub: 'Every screen the house can see. Watch it work, take the wheel when you want to, or lend it yours.',
+      body:
+        '<div class="scr-stagegrid">' +
+          '<div class="col" style="gap:var(--gap)">' +
+            (displays.length ? displays.map(d => this.displayCard(d)).join('') : this.noDisplaysCard()) +
+          '</div>' +
+          '<div class="col" style="gap:var(--gap)">' +
+            this.authorityCard() +
+            this.activityCard() +
+            '<button class="btn btn-quiet" id="scr-new-vdisplay">' + V3.ICON('plus', 15) + ' New virtual display</button>' +
+          '</div>' +
+        '</div>' +
+        this.yourScreenCard() +
+        V3.section('Recordings & clips') +
+        this.recordingsHtml() +
+        V3.section('Terminals') +
+        this.terminalCard() +
+        V3.section('Browser workspaces') +
+        this.workspaceCard()
+    });
+    this.wire(el);
+  },
+
+  /* ---------------- the stage ---------------- */
+  displayCard(d) {
+    const you = (this.hands[d.id] || 'agent') === 'you';
+    return '<div class="card">' +
+      '<div class="card-head"><div>' +
+        '<h3 class="card-title">Display ' + V3.esc(d.id) + '</h3>' +
+        '<div class="card-sub">this machine · ' + V3.fact(d.w + '×' + d.h) +
+          ' · hands: ' + (you ? 'you' : 'the house') + '</div>' +
+      '</div>' +
+      '<div class="card-actions">' + V3.chip('live', 'sage') + '</div></div>' +
+      '<div class="scr-screen"><div class="scr-placeholder">' +
+        V3.ICON('screens', 30) +
+        '<span class="scr-res">' + V3.esc(d.w + ' × ' + d.h) + '</span>' +
+        '<span class="scr-note">The live stream lives in the classic dashboard for now — <a href="/">watch it there →</a></span>' +
+      '</div></div>' +
+      '<div class="row" style="margin-top:10px;gap:6px;flex-wrap:wrap">' +
+        '<button class="btn ' + (you ? 'btn-danger' : 'btn-safe') + ' btn-xs" data-hands="' + V3.esc(d.id) + '">' +
+          V3.ICON('hand', 13) + ' <span>' + (you ? 'Release' : 'Take control') + '</span></button>' +
+        '<span class="dim" style="font-size:12px">Taking the wheel parks the house’s hands — it watches until you give them back.</span>' +
+      '</div></div>';
+  },
+
+  noDisplaysCard() {
+    return '<div class="card">' + V3.empty('screens', 'No live displays',
+      'They appear when the house opens something graphical — or spin up a fresh virtual one from the rail.') + '</div>';
+  },
+
+  /* ---------------- the rail ---------------- */
+  authorityCard() {
+    const rows = V3.data.displays.map(d =>
+      ['Display ' + d.id + ' · ' + d.w + '×' + d.h,
+       (this.hands[d.id] || 'agent') === 'you' ? 'you' : 'the house']);
+    rows.push(['Your screen', this.shared ? 'lent to the house · looking only' : 'you']);
+    const row = (what, who) =>
+      '<div class="row" style="gap:8px">' +
+        '<span style="flex:1;min-width:0;font-size:13px">' + V3.esc(what) + '</span>' +
+        '<span class="fact">' + V3.esc(who) + '</span></div>';
+    return V3.card({
+      title: 'Who may touch what',
+      sub: 'Input authority, live from the daemon',
+      body:
+        '<div class="col" style="gap:8px;margin-top:4px">' +
+          rows.map(r => row(r[0], r[1])).join('') +
+        '</div>' +
+        '<div class="dim" style="font-size:12px;margin-top:10px">Taking the wheel parks the house’s hands on that screen until you release it.</div>'
+    });
+  },
+
+  activityInner() {
+    return this.activity.length
+      ? V3.logLines(this.activity.slice(-8).map(l => [l.t, l.kind, l.text]))
+      : '<div class="dim" style="font-size:12.5px;padding:6px 0">No display activity yet — when the house clicks, types, or reads a screen, it streams here.</div>';
+  },
+  activityCard() {
+    return V3.card({
+      title: 'Display activity',
+      body: '<div id="scr-activity-body">' + this.activityInner() + '</div>'
+    });
+  },
+
+  /* ---------------- your screen ---------------- */
+  yourScreenCard() {
+    const shared = this.shared;
+    return '<div class="card" id="scr-your-screen">' +
+      '<div class="card-head"><div>' +
+        '<h3 class="card-title">Your screen</h3>' +
+        '<div class="card-sub">Private by default — the house may look only when you say so, for as long as you say.</div>' +
+      '</div>' +
+      '<div class="card-actions">' +
+        (shared ? V3.chip('shared · ' + this.DUR_WORDS[this.shareDur], 'attn', 'eye')
+                : V3.chip('private', 'slate', 'shield')) +
+      '</div></div>' +
+      '<div class="row" style="gap:8px;flex-wrap:wrap">' +
+        (shared
+          ? '<button class="btn btn-danger" id="scr-share-stop">' + V3.ICON('x', 15) + ' Stop sharing</button>'
+          : '<button class="btn btn-safe" id="scr-share-start">' + V3.ICON('eye', 15) + ' Share with the house</button>' +
+            '<span class="seg" id="scr-share-dur">' +
+              this.DURS.map(d =>
+                '<button class="' + (d[0] === this.shareDur ? 'on' : '') + '" data-dur="' + d[0] + '">' + d[1] + '</button>').join('') +
+            '</span>') +
+      '</div>' +
+      (shared
+        ? '<div class="dim" style="margin-top:8px;font-size:12.5px">The house can look — ' + V3.esc(this.DUR_WORDS[this.shareDur]) +
+          '. Looking only, never touching; stopping is always one tap away.</div>'
+        : '<div class="dim" style="margin-top:8px;font-size:12.5px">When the house asks to see your screen, the doorbell rings in the ' +
+          '<a href="#/home">Queue</a> — nothing is ever shared silently.</div>') +
+    '</div>';
+  },
+
+  /* ---------------- recordings & clips ---------------- */
+  recordingsHtml() {
+    const recs = V3.data.sessions.filter(s => (s.recordings || 0) > 0);
+    if (!recs.length) {
+      return V3.empty('record', 'No recordings yet',
+        'When a session records its screen, the shelf fills in here.');
+    }
+    return '<div class="grid grid-2">' + recs.map(s =>
+      '<div class="card">' +
+        '<div class="card-head"><div>' +
+          '<h3 class="card-title">' + V3.esc(s.name) + '</h3>' +
+          '<div class="card-sub">' + V3.fact(s.recordings + ' recording' + (s.recordings === 1 ? '' : 's')) +
+            (s.task ? ' · ' + V3.esc(String(s.task).slice(0, 60)) : '') + '</div>' +
+        '</div></div>' +
+        '<a class="scr-poster" href="/" title="The player lives in the classic dashboard for now">' +
+          '<span class="scr-play">' + V3.icon('play', 22) + '</span>' +
+        '</a>' +
+        '<div class="row" style="margin-top:10px;gap:6px;flex-wrap:wrap">' +
+          '<a class="btn btn-quiet btn-xs" href="/">' + V3.ICON('play', 13) + ' play in the classic dashboard</a>' +
+          '<a class="btn btn-quiet btn-xs" href="/api/session/' + encodeURIComponent(s.id) + '/report" download>' +
+            V3.ICON('download', 13) + ' report (.zip)</a>' +
+        '</div>' +
+        '<div class="dim" style="margin-top:6px;font-size:12px">The in-page player isn’t rebuilt in this draft — the classic dashboard plays these today.</div>' +
+      '</div>').join('') + '</div>';
+  },
+
+  /* ---------------- honest link cards ---------------- */
+  terminalCard() {
+    return V3.card({
+      title: 'Terminals',
+      sub: 'A shell is how you touch a machine.',
+      body:
+        '<div class="row" style="gap:10px;flex-wrap:wrap">' +
+          V3.ICON('terminal', 16) +
+          '<span style="flex:1;min-width:220px;font-size:13px">The PTY rides the classic dashboard in this draft — pin one, share it, and type there.</span>' +
+          '<a class="btn btn-quiet btn-xs" href="/">open terminals →</a>' +
+        '</div>'
+    });
+  },
+  workspaceCard() {
+    return V3.card({
+      title: 'Browser workspaces',
+      sub: 'Agent-driven browsers, leased by the session that drives them.',
+      body:
+        '<div class="row" style="gap:10px;flex-wrap:wrap">' +
+          V3.ICON('external', 16) +
+          '<span style="flex:1;min-width:220px;font-size:13px">The agent browser rides the classic dashboard in this draft — leases and providers live there.</span>' +
+          '<a class="btn btn-quiet btn-xs" href="/">open workspaces →</a>' +
+        '</div>'
+    });
+  },
+
+  /* ---------------- live subscriptions ----------------
+     These events aren't normalized into V3.data (it's the shared store
+     and stays lean), so the room listens on the transport itself and
+     keeps the state view-local. */
+  subscribe() {
+    if (this._subscribed) return;
+    this._subscribed = true;
+    this.seedActivity();
+    const self = this;
+
+    this.push = function (kind, text) {
+      self.activity.push({ t: V3.now(), kind, text });
+      if (self.activity.length > 60) self.activity.splice(0, self.activity.length - 60);
+      if (V3.current === 'screens') {
+        const host = document.getElementById('scr-activity-body');
+        if (host) host.innerHTML = self.activityInner();
+      }
+    };
+    const rerender = function () { if (V3.current === 'screens') V3.rerender(); };
+
+    V3.transport.on('event:cu_action', msg => {
+      const s = V3.data.sessions.find(x => x.id === msg.session_id);
+      const who = s ? '“' + s.name + '”' : 'the house';
+      const at = (msg.x != null && msg.y != null) ? ' at (' + msg.x + ', ' + msg.y + ')' : '';
+      self.push('tool', who + ' · ' + (msg.kind || 'act') + at + ' · display ' + msg.display_id);
+    });
+    V3.transport.on('event:display_taken', msg => {
+      self.hands[msg.display_id] = 'you';
+      self.push('ok', 'you took the wheel · display ' + msg.display_id);
+      rerender();
+    });
+    V3.transport.on('event:display_released', msg => {
+      self.hands[msg.display_id] = 'agent';
+      self.push('', 'the house has the wheel again · display ' + msg.display_id);
+      rerender();
+    });
+    V3.transport.on('event:display_ready', msg => {
+      self.push('ok', 'display ' + msg.display_id + ' ready · ' + msg.width + '×' + msg.height);
+    });
+    V3.transport.on('event:user_display_granted', () => {
+      self.shared = true;
+      self.push('ok', 'your screen is lent — looking only');
+      rerender();
+    });
+    V3.transport.on('event:user_display_revoked', () => {
+      self.shared = false;
+      self.push('', 'your screen is yours again');
+      rerender();
+    });
+  },
+
+  seedActivity() {
+    const cuish = /click|typed|keystroke|scroll|screenshot|screen|display|cursor|computer.use/i;
+    const lines = [];
+    Object.keys(V3.data.logs).forEach(sid => {
+      (V3.data.logs[sid] || []).forEach(l => {
+        if (cuish.test(l.text || '')) {
+          lines.push({ t: l.t, kind: l.kind === 'err' ? 'err' : 'tool', text: String(l.text).slice(0, 140) });
+        }
+      });
+    });
+    this.activity = lines.slice(-40);
+  },
+
+  /* ---------------- wiring ---------------- */
+  wire(el) {
+    const self = this;
+
+    el.querySelectorAll('[data-hands]').forEach(b => b.addEventListener('click', () => {
+      const raw = b.dataset.hands;
+      const id = /^\d+$/.test(raw) ? +raw : raw;
+      const you = (self.hands[raw] || 'agent') === 'you';
+      if (you) V3.actions.releaseDisplay(id);
+      else V3.actions.takeDisplay(id);
+      self.hands[raw] = you ? 'agent' : 'you';
+      V3.toast(you ? 'Released — the house has the wheel again'
+                   : 'You’re at the wheel — the house’s hands are parked', you ? null : 'sage');
+      V3.rerender();
+    }));
+
+    const newVd = el.querySelector('#scr-new-vdisplay');
+    if (newVd) newVd.addEventListener('click', () => {
+      V3.transport.send({ action: 'create_virtual_display' });
+      V3.toast('Asking the house for a fresh virtual display…', 'sage');
+    });
+
+    const start = el.querySelector('#scr-share-start');
+    if (start) start.addEventListener('click', () => {
+      V3.actions.grantUserDisplay(self.shareDur);
+      self.shared = true;
+      V3.toast('Screen shared — ' + self.DUR_WORDS[self.shareDur] + ', looking only', 'sage');
+      V3.rerender();
+    });
+    const stop = el.querySelector('#scr-share-stop');
+    if (stop) stop.addEventListener('click', () => {
+      V3.actions.revokeUserDisplay();
+      self.shared = false;
+      V3.toast('Sharing stopped — your screen is yours again', null);
+      V3.rerender();
+    });
+    el.querySelectorAll('#scr-share-dur button').forEach(b => b.addEventListener('click', () => {
+      b.closest('.seg').querySelectorAll('button').forEach(x => x.classList.remove('on'));
+      b.classList.add('on');
+      self.shareDur = b.dataset.dur;
+    }));
+  },
+
+  live(what) {
+    if (!['displays', 'sessions', 'ready'].includes(what)) return;
+    const active = document.activeElement;
+    if (active && document.getElementById('main').contains(active) && /INPUT|TEXTAREA/.test(active.tagName)) return;
+    const main = document.getElementById('main');
+    const y = main.scrollTop;
+    this.render(main);
+    main.scrollTop = y;
+  }
+};

--- a/static/v3/js/views/session.js
+++ b/static/v3/js/views/session.js
@@ -1,0 +1,184 @@
+/* V3 — the Session Space: one deep page per session.
+   Timeline · Context · Controls · Vitals & lineage. Live via the store's
+   rolling log buffer + session events; history paged in from
+   GET /api/session/{id}. */
+window.V3 = window.V3 || {};
+V3.views = V3.views || {};
+
+V3.views.session = {
+  title: 'Session',
+  historyLoaded: {},
+
+  render(el, params) {
+    const id = params[0];
+    const s = V3.data.sessions.find(x => x.id === id) || { id, name: id, phase: 'idle', sentence: 'Loading…', backend: '', model: '', tokens: {} };
+    this.current = s;
+    const q = V3.data.queue.filter(x => x.session === id);
+    const usage = V3.data.usage[id] || {};
+    this.loadHistory(id);
+
+    el.innerHTML = V3.page({
+      body:
+        '<div class="row" style="align-items:flex-start;gap:14px;flex-wrap:wrap">' +
+          '<div style="min-width:280px;flex:1">' +
+            '<div class="eyebrow"><a href="#/work" style="color:inherit">work</a> / ' + V3.esc(s.name) + '</div>' +
+            '<h1 class="page-title" style="font-size:26px">' + V3.esc(s.name) + '</h1>' +
+            '<div class="page-sub">' + V3.esc(s.sentence || s.task || '') + '</div>' +
+            '<div class="row" style="gap:6px;flex-wrap:wrap">' +
+              V3.chip(s.phase, s.active ? 'sage' : 'slate') +
+              (s.backend ? V3.chip(s.backend, 'slate') : '') +
+              (s.model ? V3.chip(s.model, 'slate') : '') +
+              V3.chip(V3.machineName(s.machine || 'local'), s.machine && s.machine !== 'local' ? 'violet' : null) +
+            '</div>' +
+          '</div>' +
+          '<div class="col" style="gap:8px;align-items:flex-end">' +
+            '<div class="row" style="gap:6px">' +
+              '<button class="btn btn-quiet" data-act="target">' + V3.ICON('send', 15) + ' Aim composer</button>' +
+              (s.active ? '<button class="btn btn-danger" data-act="interrupt">' + V3.ICON('stop', 15) + ' Stop</button>' : '') +
+              (!s.active && s.canResume !== false ? '<button class="btn btn-safe" data-act="resume">Resume</button>' : '') +
+            '</div>' + V3.authline(V3.data.you.name, V3.data.you.role, V3.data.you.route) +
+          '</div>' +
+        '</div>' +
+
+        '<div class="card"><div class="factline" style="gap:22px">' +
+          '<span>' + V3.fact('turn ' + (s.turn || 0)) + '</span>' +
+          (s.tokens && s.tokens.pct ? '<span class="row" style="gap:6px">' + V3.fact('context ' + s.tokens.pct + '%') + V3.meter(s.tokens.pct) + '</span>' : '') +
+          (s.cost ? '<span>' + V3.fact('$' + s.cost.toFixed(2)) + '</span>' : '') +
+          (usage.cached_tokens ? '<span>' + V3.fact('cache ' + Math.round(100 * usage.cached_tokens / Math.max(1, usage.prompt_tokens || 1)) + '%') + '</span>' : '') +
+          (s.cwd ? '<span class="studio-only">' + V3.fact(s.cwd) + '</span>' : '') +
+        '</div></div>' +
+
+        (q.length ? V3.section('Waiting on you, here') + q.map(x => V3.decisionCard(x)).join('') : '') +
+
+        V3.foldHtml({ key: 'session.timeline', title: 'Timeline', note: 'live · replayed on reload', open: true,
+          body: this.timelineHtml(s) }) +
+        V3.foldHtml({ key: 'session.context', title: 'Context', note: (s.tokens && s.tokens.pct ? s.tokens.pct + '%' : '—'),
+          body: this.contextHtml(s, usage) }) +
+        V3.foldHtml({ key: 'session.controls', title: 'Controls', note: 'approval rules · steering',
+          body: this.controlsHtml(s) }) +
+        V3.foldHtml({ key: 'session.vitals', title: 'Vitals & lineage', note: 'git · relationships · data',
+          body: this.vitalsHtml(s) })
+    });
+    this.wire(el, s);
+  },
+
+  loadHistory(id) {
+    if (this.historyLoaded[id]) return;
+    this.historyLoaded[id] = true;
+    V3.transport.get('/api/session/' + encodeURIComponent(id) + '?limit=80').then(r => {
+      (r.entries || []).forEach(e => V3.data.ingestLog(Object.assign({ session_id: id }, e)));
+      if (V3.current === 'session') V3.rerender();
+    }).catch(() => {});
+  },
+
+  timelineHtml(s) {
+    const lines = (V3.data.logs[s.id] || []).slice(-120);
+    const composer = s.active
+      ? '<div class="panel row" style="margin-bottom:12px">' + V3.ICON('send', 14) +
+        '<input class="input" id="steer-input" placeholder="Steer mid-turn — it lands at the next safe point…" style="flex:1">' +
+        '<button class="btn btn-quiet btn-xs" data-act="steer">steer</button>' +
+        '<button class="btn btn-quiet btn-xs" data-act="followup">queue follow-up</button></div>'
+      : '';
+    return composer +
+      (lines.length
+        ? V3.logLines(lines.map(l => [l.t, l.kind, (l.text || '').slice(0, 300)]))
+        : '<div class="dim" style="font-size:12.5px;padding:8px 0">No work lines yet — they stream in as the house works, and replay when you return.</div>');
+  },
+
+  contextHtml(s, usage) {
+    const pct = s.tokens && s.tokens.pct || (usage.usage_pct ? Math.round(usage.usage_pct) : 0);
+    return '<div class="grid grid-2">' +
+      '<div class="panel"><div class="eyebrow" style="margin-bottom:6px">Budget</div>' +
+        '<div class="row" style="gap:10px">' + V3.meter(pct) + '<span class="fact">' + pct + '% of the window</span></div>' +
+        '<div class="kv" style="margin-top:10px">' +
+          (usage.prompt_tokens ? '<span class="k">prompt tokens</span><span class="v">' + usage.prompt_tokens.toLocaleString() + '</span>' : '') +
+          (usage.cached_tokens ? '<span class="k">served from cache</span><span class="v">' + usage.cached_tokens.toLocaleString() + '</span>' : '') +
+        '</div></div>' +
+      '<div class="panel"><div class="eyebrow" style="margin-bottom:6px">Managed context</div>' +
+        '<div class="dim" style="font-size:12.5px">Anchors, rewinds, and fission for this session live in the daemon’s managed-context plane — the deep composer is on the V2 roadmap for this room; nothing here is hidden, it’s just not rebuilt yet.</div>' +
+        '<div style="margin-top:8px"><a class="chip chip-slate" href="/">open it in the classic dashboard →</a></div></div>' +
+    '</div>';
+  },
+
+  controlsHtml(s) {
+    const cats = [
+      ['file_read', 'Read files'], ['file_write', 'Edit & write'], ['file_delete', 'Delete files'],
+      ['command_exec', 'Run shell commands'], ['network', 'Network egress'], ['destructive', 'Destructive actions'],
+      ['display_control', 'Control your display'], ['tool_call', 'External-agent tool calls']
+    ];
+    const payload = V3.data.settings || {};
+    return '<div class="eyebrow" style="margin-bottom:6px">Approval rules — applied live, saved by the daemon</div>' +
+      '<div class="col" style="gap:4px">' +
+      cats.map(([k, label]) => {
+        const cur = payload['approval_' + k] || 'ask';
+        return '<div class="row"><span style="width:190px">' + label + '</span>' +
+          '<span class="seg">' + ['auto', 'ask', 'deny'].map(v =>
+            '<button class="' + (cur === v ? 'on' : '') + '" data-rule="' + k + ':' + v + '">' + v + '</button>').join('') + '</span></div>';
+      }).join('') + '</div>' +
+      '<div class="dim" style="margin-top:8px;font-size:12px">Per-backend launch pins (sandbox, model, effort, writable roots) ride along on the next resume — set the defaults in Settings → The fine print.</div>';
+  },
+
+  vitalsHtml(s) {
+    const v = s.vitals || {};
+    const rel = s.relationships || [];
+    return '<div class="grid grid-2">' +
+      '<div class="panel"><div class="eyebrow" style="margin-bottom:6px">Git</div>' +
+        (v.branch || s.worktree
+          ? '<div class="kv"><span class="k">branch</span><span class="v">' + V3.esc(v.branch || s.worktree || '—') + '</span>' +
+            (v.dirty != null ? '<span class="k">working tree</span><span class="v">' + (v.dirty ? v.dirty + ' dirty' : 'clean') + '</span>' : '') +
+            (v.ahead != null ? '<span class="k">ahead</span><span class="v">' + v.ahead + '</span>' : '') + '</div>'
+          : '<div class="dim" style="font-size:12.5px">No git facts reported for this session.</div>') + '</div>' +
+      '<div class="panel"><div class="eyebrow" style="margin-bottom:6px">Lineage</div>' +
+        (rel.length
+          ? '<div class="col" style="gap:6px">' + rel.map(r =>
+              '<div class="row">' + V3.ICON('branch', 13) + '<span class="mono" style="font-size:12px">' + V3.esc(r.session_id || r.id || r.kind || JSON.stringify(r)) + '</span>' +
+              (r.kind ? V3.chip(r.kind, 'slate') : '') + '</div>').join('') + '</div>'
+          : '<div class="dim" style="font-size:12.5px">No sub-agents or forks on record.</div>') + '</div>' +
+      '<div class="panel"><div class="eyebrow" style="margin-bottom:6px">Recordings & data</div>' +
+        '<div class="factline">' + V3.fact((s.recordings || 0) + ' recordings') + '</div>' +
+        '<div class="row" style="margin-top:8px;gap:6px">' +
+          '<a class="btn btn-quiet btn-xs" href="/api/session/' + encodeURIComponent(s.id) + '/report" download>' + V3.ICON('download', 13) + ' report (.zip)</a>' +
+        '</div></div>' +
+    '</div>';
+  },
+
+  wire(el, s) {
+    el.querySelectorAll('[data-act]').forEach(b => b.addEventListener('click', () => {
+      const act = b.dataset.act;
+      if (act === 'interrupt') { V3.actions.interrupt(s.id); V3.toast('Interrupt sent — the turn stops at the next safe point', 'brick'); }
+      if (act === 'resume') { V3.actions.resumeSession(s.id); V3.toast('Resuming…', 'sage'); }
+      if (act === 'target') {
+        V3.actions.setTarget(s.id);
+        V3.toast('Composer aimed at ' + s.name, 'sage');
+        document.getElementById('composer-input').focus();
+      }
+      if (act === 'steer' || act === 'followup') {
+        const inp = el.querySelector('#steer-input');
+        const text = (inp && inp.value || '').trim();
+        if (!text) return;
+        if (act === 'steer') { V3.actions.steer(s.id, text); V3.toast('Steer queued', 'sage'); }
+        else { V3.actions.followUp(s.id, text); V3.toast('Follow-up queued', 'sage'); }
+        inp.value = '';
+      }
+    }));
+    el.querySelectorAll('[data-rule]').forEach(b => b.addEventListener('click', () => {
+      b.closest('.seg').querySelectorAll('button').forEach(x => x.classList.remove('on'));
+      b.classList.add('on');
+      const [cat, rule] = b.dataset.rule.split(':');
+      V3.actions.setApprovalRule(cat, rule);
+    }));
+  },
+
+  live(what) {
+    const s = this.current;
+    if (!s) return;
+    if (what === 'sessions' || what === 'queue' || what === 'logs:' + s.id) {
+      const active = document.activeElement;
+      if (active && document.getElementById('main').contains(active) && /INPUT|TEXTAREA/.test(active.tagName)) return;
+      const main = document.getElementById('main');
+      const y = main.scrollTop;
+      this.render(main, [s.id]);
+      main.scrollTop = y;
+    }
+  }
+};

--- a/static/v3/js/views/settings.js
+++ b/static/v3/js/views/settings.js
@@ -1,0 +1,232 @@
+/* V3 — Settings: questions, not subsystems.
+   The catalog below is THE one table: this view renders from it and the
+   ⌘K palette indexes from it (derive, don't mirror — a row added here is
+   searchable there, automatically). Save is merge-then-POST. */
+window.V3 = window.V3 || {};
+V3.views = V3.views || {};
+
+/* key = SettingsPayload field; fold = jump target id; kind drives the row UI */
+V3.settingsCatalog = [
+  { key: '_autonomy', section: 'How much may the house do on its own?', name: 'Autonomy', kind: 'dial',
+    aliases: 'autonomy independence freedom self-driving', gloss: 'How far the house goes before it asks.' },
+  { key: '_approvals', section: 'How much may the house do on its own?', name: 'Approval rules', kind: 'rules', fold: 'fold-approvals',
+    aliases: 'approval rules gates ask auto deny permissions' },
+
+  { key: '_keys', section: 'Who provides the minds?', name: 'API keys', kind: 'keys', fold: 'fold-keys',
+    aliases: 'api keys openai anthropic gemini fuel credentials' },
+  { key: 'external_agent', section: 'Who provides the minds?', name: 'Default external agent', kind: 'select',
+    options: ['', 'codex', 'claude-code'], aliases: 'codex claude backend default agent' },
+  { key: 'codex_model', section: 'Who provides the minds?', name: 'Codex model', kind: 'text', aliases: 'codex model gpt' },
+  { key: 'codex_reasoning_effort', section: 'Who provides the minds?', name: 'Codex reasoning effort', kind: 'select',
+    options: ['minimal', 'low', 'medium', 'high', 'xhigh'], aliases: 'codex reasoning effort thinking' },
+  { key: 'claude_model', section: 'Who provides the minds?', name: 'Claude model', kind: 'text', aliases: 'claude model fable opus sonnet haiku' },
+
+  { key: 'presence_enabled', section: 'How does it reach you?', name: 'Presence', kind: 'toggle', fold: 'fold-presence',
+    aliases: 'presence voice text live' },
+  { key: 'presence_model', section: 'How does it reach you?', name: 'Presence text model', kind: 'text', aliases: 'presence text model' },
+  { key: 'presence_live_model', section: 'How does it reach you?', name: 'Live voice model', kind: 'text', aliases: 'live voice model gemini realtime' },
+  { key: 'transcription_enabled', section: 'How does it reach you?', name: 'Transcription', kind: 'toggle', aliases: 'transcription whisper speech' },
+  { key: 'live_audio_timeout_secs', section: 'How does it reach you?', name: 'Live audio idle timeout (s)', kind: 'number', aliases: 'live audio timeout idle' },
+
+  { key: 'cu_backend', section: 'What may it see and touch?', name: 'Computer-use backend', kind: 'select', fold: 'fold-cu',
+    options: ['auto', 'x11', 'wayland', 'macos'], aliases: 'computer use display screenshot backend' },
+  { key: 'recording_enabled', section: 'What may it see and touch?', name: 'Recording', kind: 'toggle', aliases: 'recording video capture' },
+  { key: 'recording_framerate', section: 'What may it see and touch?', name: 'Recording framerate', kind: 'number', aliases: 'framerate fps recording' },
+  { key: 'recording_quality', section: 'What may it see and touch?', name: 'Recording quality', kind: 'select',
+    options: ['low', 'medium', 'high'], aliases: 'recording quality' },
+
+  { key: '_appearance', section: 'How should it look and feel?', name: 'Theme & density', kind: 'appearance', fold: 'fold-appearance',
+    aliases: 'theme dark light density cozy studio appearance' },
+
+  { key: 'codex_sandbox', section: 'The fine print', name: 'Codex sandbox', kind: 'select', fold: 'fold-codex-sandbox',
+    options: ['read-only', 'workspace-write', 'danger-full-access'], aliases: 'codex sandbox permissions' },
+  { key: 'codex_writable_roots', section: 'The fine print', name: 'Codex writable roots', kind: 'text',
+    aliases: 'writable roots sandbox workspace-write paths' },
+  { key: 'codex_network_access', section: 'The fine print', name: 'Codex network access', kind: 'toggle', aliases: 'codex network internet egress' },
+  { key: 'codex_web_search', section: 'The fine print', name: 'Codex web search', kind: 'toggle', aliases: 'codex web search tool' },
+  { key: 'codex_service_tier', section: 'The fine print', name: 'Codex service tier', kind: 'text', aliases: 'codex service tier priority' },
+  { key: 'codex_managed_context', section: 'The fine print', name: 'Codex managed context', kind: 'select',
+    options: ['off', 'vanilla', 'managed'], aliases: 'codex managed context rewind' },
+  { key: 'claude_permission_mode', section: 'The fine print', name: 'Claude permission mode', kind: 'select',
+    options: ['default', 'acceptEdits', 'plan', 'bypassPermissions'], aliases: 'claude permission mode acceptEdits' },
+  { key: 'claude_allowed_tools', section: 'The fine print', name: 'Claude allowed tools', kind: 'text', aliases: 'claude allowed tools' },
+  { key: '_env', section: 'The fine print', name: 'Env overrides', kind: 'ro', aliases: 'env environment variables overrides debug' },
+  { key: '_raw', section: 'The fine print', name: 'Raw settings payload', kind: 'toml', fold: 'fold-toml', aliases: 'raw json toml config file' }
+];
+
+V3.views.settings = {
+  title: 'Settings',
+
+  render(el) {
+    const D = V3.data;
+    const payload = D.settings || {};
+    const sections = {};
+    V3.settingsCatalog.forEach(row => { (sections[row.section] = sections[row.section] || []).push(row); });
+
+    el.innerHTML = V3.page({
+      eyebrow: 'how the house behaves',
+      title: 'Settings',
+      sub: 'Plain questions up front. Every knob the daemon honors is here — folded, findable, and one ⌘K away by its plain name. Changes save to the daemon, not the browser.',
+      body: Object.keys(sections).map(sec =>
+        V3.section(sec) + sections[sec].map(row => this.rowHtml(row, payload)).join('')
+      ).join('') +
+      '<div class="row" style="margin-top:16px;gap:8px">' +
+        '<button class="btn btn-primary" id="settings-save">Save</button>' +
+        '<span class="dim" id="settings-dirty" style="font-size:12.5px">no unsaved changes</span>' +
+        '<span class="grow"></span>' +
+        '<span class="fact">writes through the daemon — approval rules apply live</span>' +
+      '</div>'
+    });
+    this.wire(el);
+  },
+
+  rowHtml(row, payload) {
+    const val = payload[row.key];
+    switch (row.kind) {
+      case 'dial': {
+        const cur = V3.data.autonomy || 'medium';
+        const levels = [
+          ['low', 'reads only — it asks before it touches'],
+          ['medium', 'gate writes — the everyday default'],
+          ['high', 'auto unless a rule says deny'],
+          ['full', 'ungated — you watch the log, not the queue']
+        ];
+        return '<div class="card" id="set-_autonomy"><div class="card-head"><div><h3 class="card-title">Autonomy</h3>' +
+          '<div class="card-sub">' + row.gloss + ' Currently: <b>' + V3.esc(cur) + '</b>.</div></div></div>' +
+          '<div class="grid" style="grid-template-columns:repeat(4,1fr);gap:8px">' +
+          levels.map(l =>
+            '<button class="panel" data-autonomy="' + l[0] + '" style="text-align:left;cursor:pointer;border-color:' + (l[0] === cur ? 'rgba(var(--brass-rgb),.5)' : 'var(--line)') + '">' +
+            '<b style="text-transform:capitalize">' + l[0] + '</b><div class="dim" style="font-size:12px;margin-top:2px">' + l[1] + '</div></button>').join('') +
+          '</div></div>';
+      }
+      case 'rules': {
+        const cats = [
+          ['file_read', 'Read files'], ['file_write', 'Edit & write'], ['file_delete', 'Delete files'],
+          ['command_exec', 'Run shell commands'], ['network', 'Network egress'], ['destructive', 'Destructive actions'],
+          ['display_control', 'Control your display'], ['tool_call', 'External-agent tool calls']
+        ];
+        return V3.foldHtml({ key: 'settings.rules', id: row.fold, title: row.name, note: 'live-applied, saved by the daemon',
+          body: '<div class="col" style="gap:4px">' +
+            cats.map(([k, label]) => {
+              const cur = payload['approval_' + k] || 'ask';
+              return '<div class="row"><span style="width:210px">' + label + '</span>' +
+                '<span class="seg">' + ['auto', 'ask', 'deny'].map(v =>
+                  '<button class="' + (cur === v ? 'on' : '') + '" data-srule="' + k + ':' + v + '">' + v + '</button>').join('') + '</span></div>';
+            }).join('') +
+          '</div>' });
+      }
+      case 'keys': {
+        const fuel = V3.data.fuel || {};
+        const rows = [['Anthropic', 'anthropic'], ['OpenAI', 'openai'], ['Gemini', 'gemini']];
+        return V3.foldHtml({ key: 'settings.keys', id: row.fold, title: row.name, note: 'presence checked, never shown',
+          body: '<div class="col" style="gap:8px">' +
+            rows.map(([label, k]) => '<div class="row"><span style="width:110px">' + label + '</span>' +
+              '<input class="input mono" type="password" data-key="' + k + '" placeholder="••••••••" style="flex:1">' +
+              V3.chip(fuel[k] ? 'set' : 'not set', fuel[k] ? 'sage' : 'attn') + '</div>').join('') +
+            '<div class="dim" style="font-size:12px">Saved by the daemon to its .env — the page never reads existing keys back.</div>' +
+          '</div>' });
+      }
+      case 'appearance': {
+        return V3.foldHtml({ key: 'settings.appearance', id: row.fold, title: row.name, note: 'this browser, instant', open: true,
+          body:
+          '<div class="row" style="gap:20px;flex-wrap:wrap">' +
+            '<div><div class="eyebrow" style="margin-bottom:6px">Theme</div>' +
+              '<span class="seg" id="seg-theme">' +
+                '<button data-theme-val="lamplight" class="' + (document.documentElement.dataset.theme === 'lamplight' ? 'on' : '') + '">Lamplight</button>' +
+                '<button data-theme-val="daylight" class="' + (document.documentElement.dataset.theme === 'daylight' ? 'on' : '') + '">Daylight</button>' +
+              '</span></div>' +
+            '<div><div class="eyebrow" style="margin-bottom:6px">Density</div>' +
+              '<span class="seg" id="seg-density">' +
+                ['cozy', 'standard', 'studio'].map(d =>
+                  '<button data-density-val="' + d + '" class="' + (V3.density() === d ? 'on' : '') + '">' + d[0].toUpperCase() + d.slice(1) + '</button>').join('') +
+              '</span></div>' +
+            '<div class="dim" style="font-size:12px;max-width:36ch">Cozy speaks first. Studio shows the machinery first. Nothing is hidden at any density — only unfolded.</div>' +
+          '</div>' });
+      }
+      case 'toggle': {
+        return this.setRow(row, '<label class="row" style="gap:8px;justify-content:flex-start">' +
+          '<input type="checkbox" data-set="' + row.key + '" ' + (val ? 'checked' : '') + '>' +
+          '<span>' + (val ? 'on' : 'off') + '</span></label>');
+      }
+      case 'select': {
+        return this.setRow(row, '<span class="seg">' + row.options.map(o =>
+          '<button data-set="' + row.key + '" data-val="' + o + '" class="' + ((val || '') === o ? 'on' : '') + '">' + (o || 'none') + '</button>').join('') + '</span>');
+      }
+      case 'number': {
+        return this.setRow(row, '<input class="input mono" type="number" data-set="' + row.key + '" value="' + V3.esc(val == null ? '' : val) + '" style="width:110px">');
+      }
+      case 'text': {
+        return this.setRow(row, '<input class="input mono" data-set="' + row.key + '" value="' + V3.esc(val == null ? '' : val) + '" style="flex:1">');
+      }
+      case 'ro': {
+        const env = payload.env_overrides || {};
+        const keys = Object.keys(env);
+        return this.setRow(row, keys.length
+          ? '<div class="kv">' + keys.map(k => '<span class="k">' + V3.esc(k) + '</span><span class="v">' + V3.esc(env[k]) + '</span>').join('') + '</div>'
+          : '<span class="dim" style="font-size:12.5px">none set — the daemon runs its defaults</span>');
+      }
+      case 'toml': {
+        return V3.foldHtml({ key: 'settings.toml', id: row.fold, title: row.name, note: 'the truth, unstyled',
+          body: '<div class="panel mono" style="font-size:12px;line-height:1.7;white-space:pre;max-height:320px;overflow:auto">' +
+            V3.esc(JSON.stringify(payload, null, 2)) + '</div>' });
+      }
+    }
+    return '';
+  },
+
+  setRow(row, controlHtml) {
+    return '<div class="card" id="set-' + row.key + '" style="padding:12px 16px"><div class="row">' +
+      '<span style="min-width:240px">' + row.name + '</span>' + controlHtml + '</div></div>';
+  },
+
+  wire(el) {
+    const dirty = el.querySelector('#settings-dirty');
+    const patch = {};
+    const mark = () => { dirty.textContent = Object.keys(patch).length ? Object.keys(patch).length + ' unsaved change' + (Object.keys(patch).length > 1 ? 's' : '') : 'no unsaved changes'; };
+
+    el.querySelectorAll('[data-autonomy]').forEach(b => b.addEventListener('click', () => {
+      el.querySelectorAll('[data-autonomy]').forEach(x => x.style.borderColor = 'var(--line)');
+      b.style.borderColor = 'rgba(var(--brass-rgb),.5)';
+      V3.actions.setAutonomy(b.dataset.autonomy);
+      V3.data.autonomy = b.dataset.autonomy;
+    }));
+    el.querySelectorAll('[data-srule]').forEach(b => b.addEventListener('click', () => {
+      b.closest('.seg').querySelectorAll('button').forEach(x => x.classList.remove('on'));
+      b.classList.add('on');
+      const [cat, rule] = b.dataset.srule.split(':');
+      V3.actions.setApprovalRule(cat, rule);
+    }));
+    el.querySelectorAll('[data-set]').forEach(inp => {
+      if (inp.type === 'checkbox') inp.addEventListener('change', () => { patch[inp.dataset.set] = inp.checked; mark(); });
+      else if (inp.tagName === 'BUTTON') inp.addEventListener('click', () => {
+        inp.closest('.seg').querySelectorAll('button').forEach(x => x.classList.remove('on'));
+        inp.classList.add('on');
+        patch[inp.dataset.set] = inp.dataset.val; mark();
+      });
+      else inp.addEventListener('change', () => {
+        patch[inp.dataset.set] = inp.type === 'number' ? Number(inp.value) : inp.value; mark();
+      });
+    });
+    el.querySelectorAll('[data-key]').forEach(inp => inp.addEventListener('change', () => {
+      if (!inp.value.trim()) return;
+      V3.transport.post('/api/api-keys', { [inp.dataset.key]: inp.value.trim() })
+        .then(() => V3.toast('Key saved by the daemon', 'sage'))
+        .catch(e => V3.toast('Key save failed: ' + e.message, 'brick'));
+      inp.value = '';
+    }));
+    el.querySelectorAll('[data-theme-val]').forEach(b => b.addEventListener('click', () => {
+      V3.setTheme(b.dataset.themeVal);
+      el.querySelectorAll('[data-theme-val]').forEach(x => x.classList.toggle('on', x === b));
+    }));
+    el.querySelectorAll('[data-density-val]').forEach(b => b.addEventListener('click', () => {
+      V3.setDensity(b.dataset.densityVal);
+      el.querySelectorAll('[data-density-val]').forEach(x => x.classList.toggle('on', x === b));
+    }));
+    el.querySelector('#settings-save').addEventListener('click', () => {
+      if (!Object.keys(patch).length) { V3.toast('Nothing to save', null); return; }
+      V3.actions.saveSettings(patch).then(() => {
+        Object.keys(patch).forEach(k => delete patch[k]); mark();
+      });
+    });
+  }
+};

--- a/static/v3/js/views/station.js
+++ b/static/v3/js/views/station.js
@@ -1,0 +1,139 @@
+/* V3 — Station: the constellation vantage.
+   The whole house at one glance, drawn from V3.data — machines on the ring,
+   sessions as their satellites, attention glowing. All motion is CSS (the
+   rings and glow are animations), so no timer ever outlives the view; the
+   store events re-render the scene through live(). Click an agent node to
+   open its space. The real WebGPU canvas renders on the classic dashboard. */
+window.V3 = window.V3 || {};
+V3.views = V3.views || {};
+
+V3.views.station = {
+  title: 'Station',
+
+  CX: 500, CY: 280, R: 175, AR: 52,
+
+  render(el) {
+    /* timer hygiene — this view holds none by design; keep the invariant explicit */
+    if (this._timer) { clearInterval(this._timer); this._timer = null; }
+
+    const D = V3.data;
+    const working = D.sessions.filter(s => s.active);
+    const needsYou = D.sessions.filter(s =>
+      V3.data.queue.some(q => q.kind !== 'fyi' && q.session === s.id));
+    const conn = V3.transport.state;
+
+    el.innerHTML = V3.page({
+      eyebrow: 'vantage',
+      title: 'Station',
+      sub: 'The whole house at one glance — every machine, every session, and the one thing glowing for you.',
+      body:
+        '<div class="stn-scene">' + this.scene() + '</div>' +
+        '<div class="stn-hud">' +
+          V3.chip(D.machines.length + ' host' + (D.machines.length === 1 ? '' : 's'), 'slate', 'machines') +
+          V3.chip(working.length + ' working', 'sage') +
+          (needsYou.length ? V3.chip(needsYou.length + ' need' + (needsYou.length === 1 ? 's' : '') + ' you', 'attn', 'doorbell')
+                           : V3.chip('nothing needs you', 'sage')) +
+          V3.chip(conn === 'live' ? 'ws live' : conn === 'connecting' ? 'connecting…' : 'offline',
+                  conn === 'live' ? 'sage' : conn === 'connecting' ? 'attn' : 'brick') +
+          '<span class="grow"></span>' +
+          '<span class="factline">' +
+            '<span class="fact">' + V3.dot('sage') + ' working</span>' +
+            '<span class="fact">' + V3.dot('slate') + ' idle / away</span>' +
+            '<span class="fact">' + V3.dot('attn') + ' needs you</span>' +
+          '</span>' +
+        '</div>' +
+        V3.card({
+          title: 'The full canvas', sub: 'WebGPU, on the classic dashboard',
+          body:
+            '<p style="margin:0 0 10px;font-size:13.5px">The real Station renders this scene in WebGPU — free camera, tile streams, the works. It lives on <a href="/">the classic dashboard</a> for now: same control plane, same trust, nothing here is a second brain.</p>' +
+            '<a class="btn btn-quiet btn-xs" href="/">' + V3.ICON('external', 13) + ' open the classic Station</a>'
+        })
+    });
+
+    this.wire(el);
+  },
+
+  scene() {
+    const cx = this.CX, cy = this.CY, R = this.R;
+    const at = (ox, oy, r, deg) => {
+      const a = deg * Math.PI / 180;
+      return [ox + r * Math.cos(a), oy + r * Math.sin(a)];
+    };
+
+    /* starfield — seeded per render so re-renders don't reshuffle the sky */
+    let seed = 99;
+    const rnd = () => { seed = (seed * 16807) % 2147483647; return seed / 2147483647; };
+    let stars = '';
+    for (let i = 0; i < 130; i++) {
+      const x = (rnd() * 1000).toFixed(1), y = (rnd() * 560).toFixed(1);
+      const r = (0.4 + rnd() * 0.9).toFixed(2), o = (0.1 + rnd() * 0.5).toFixed(2);
+      stars += '<circle class="stn-star' + (i % 9 === 0 ? ' tw' : '') + '" cx="' + x + '" cy="' + y + '" r="' + r + '" opacity="' + o + '"/>';
+    }
+
+    const rings =
+      '<g class="stn-spin"><circle class="stn-ring" cx="' + cx + '" cy="' + cy + '" r="' + R + '"/></g>' +
+      '<g class="stn-spin-rev"><circle class="stn-ring" cx="' + cx + '" cy="' + cy + '" r="' + (R + 74) + '"/></g>' +
+      '<circle class="stn-ring-faint" cx="' + cx + '" cy="' + cy + '" r="' + (R - 74) + '"/>';
+
+    /* the operator core — the brass arch */
+    const core =
+      '<g transform="translate(' + cx + ',' + cy + ') scale(0.22) translate(-256,-256)" class="stn-core">' +
+        '<path d="M128 384 L128 240 Q128 128 256 128 Q384 128 384 240 L384 384" fill="none" stroke-width="30" stroke-linecap="round"/>' +
+        '<line x1="256" y1="220" x2="256" y2="330" stroke-width="30" stroke-linecap="round"/>' +
+        '<line x1="236" y1="300" x2="330" y2="180" stroke-width="22" stroke-linecap="round" class="stn-core-accent"/>' +
+      '</g>' +
+      '<text x="' + cx + '" y="' + (cy + 44) + '" class="stn-label">the house</text>' +
+      '<text x="' + cx + '" y="' + (cy + 59) + '" class="stn-sublabel">operator core · you</text>';
+
+    /* hosts evenly spaced on the ring, this daemon at the top */
+    const machines = V3.data.machines || [];
+    let hosts = '';
+    machines.forEach((m, mi) => {
+      const deg = machines.length === 1 ? -90 : -90 + mi * (360 / machines.length);
+      const pos = at(cx, cy, R, deg);
+      const hx = pos[0].toFixed(1), hy = pos[1].toFixed(1);
+      const agents = (V3.data.sessions || []).filter(s =>
+        (s.machine || 'local') === m.id && (s.active || s.phase === 'working' || s.phase === 'idle'));
+      hosts += '<line class="stn-link" x1="' + cx + '" y1="' + cy + '" x2="' + hx + '" y2="' + hy + '"/>' +
+        '<circle class="stn-ring-faint" cx="' + hx + '" cy="' + hy + '" r="' + this.AR + '"/>';
+      agents.forEach((s, i) => {
+        const ang = 160 + i * 140;
+        const ap = at(+hx, +hy, this.AR, ang);
+        const ax = ap[0].toFixed(1), ay = ap[1].toFixed(1);
+        /* label rides radially outward from the host so it never crosses the host's own name */
+        const rad = ang * Math.PI / 180, cos = Math.cos(rad), sin = Math.sin(rad);
+        const anchor = cos > 0.3 ? 'start' : cos < -0.3 ? 'end' : 'middle';
+        const lx = (+ax + 11 * cos).toFixed(1), ly = (+ay + 11 * sin + 4).toFixed(1);
+        const needs = V3.data.queue.some(q => q.kind !== 'fyi' && q.session === s.id);
+        const tone = needs ? 'attn' : (s.active || s.phase === 'working') ? 'work' : 'idle';
+        hosts += '<g class="stn-agent" data-sess="' + V3.esc(s.id) + '">' +
+          '<title>' + V3.esc(s.name + ' — ' + (s.sentence || s.phase)) + '</title>' +
+          (needs ? '<circle class="stn-glow" cx="' + ax + '" cy="' + ay + '" r="13"/>' : '') +
+          '<circle class="stn-agent-dot ' + tone + '" cx="' + ax + '" cy="' + ay + '" r="5.5"/>' +
+          '<text x="' + lx + '" y="' + ly + '" text-anchor="' + anchor + '">' + V3.esc(s.name) + '</text>' +
+        '</g>';
+      });
+      hosts += '<g class="stn-host">' +
+        '<circle class="stn-host-dot' + (m.status === 'online' ? '' : ' off') + '" cx="' + hx + '" cy="' + hy + '" r="9"/>' +
+        '<text x="' + hx + '" y="' + (+hy + 28) + '" class="stn-label">' + V3.esc(m.petname) + '</text>' +
+        '<text x="' + hx + '" y="' + (+hy + 42) + '" class="stn-sublabel">' + V3.esc((m.label || '') + ' · via ' + (m.route || '?')) + '</text>' +
+      '</g>';
+    });
+
+    return '<svg class="stn-svg" viewBox="0 0 1000 560" preserveAspectRatio="xMidYMid slice" role="img" aria-label="The house constellation">' +
+      stars + rings + core + hosts + '</svg>';
+  },
+
+  wire(el) {
+    el.querySelectorAll('.stn-agent').forEach(g =>
+      g.addEventListener('click', () => V3.go('#/work/session/' + g.dataset.sess)));
+  },
+
+  live(what) {
+    if (!['sessions', 'queue', 'machines', 'conn', 'ready'].includes(what)) return;
+    const main = document.getElementById('main');
+    const y = main.scrollTop;
+    this.render(main);
+    main.scrollTop = y;
+  }
+};

--- a/static/v3/js/views/studio.js
+++ b/static/v3/js/views/studio.js
@@ -1,0 +1,339 @@
+/* V3 — Studio: the machinery, raw.
+   Workbench (transport lanes, ping) → raw state → live event stream →
+   reference (keyboard, what V3 doesn't rebuild yet) → the component field
+   guide: every shared component, every state, labeled and inert.
+   The transport has no off(), so the event tap registers ONCE and writes
+   only while its DOM node is mounted — nothing outlives the view. */
+window.V3 = window.V3 || {};
+V3.views = V3.views || {};
+
+V3.views.studio = {
+  title: 'Studio',
+
+  _events: [],        /* ring buffer, last 30 bus events */
+  _seen: 0,
+  _paused: false,
+  _tapped: false,
+  _ping: null,        /* {ms, ok, at, error} */
+
+  KEYS: [
+    ['⌘K or /', 'the index — everything, one box'], ['?', 'this map'],
+    ['g h / w / s / f / m / p / b', 'go: home · work · screens · files · machines · people · books'],
+    ['g ,  ·  g t  ·  g u', 'settings · station · studio'],
+    ['y s a n', 'queue: approve · skip · approve-all · deny'],
+    ['x', 'dismiss an FYI'], ['e', 'unfold details'], ['⌘↵', 'send'], ['esc', 'close the top layer']
+  ],
+
+  MISSING: [
+    ['Managed-context composer', 'anchors, rewinds, and fission for a session’s context'],
+    ['Credential custody', 'vault leases, egress registrations, the custody trail — tunnel-only in this build'],
+    ['WebRTC display stream', 'live frames and input — Screens shows state, not the video'],
+    ['PTY terminal', 'the supervised shell runs on the classic dashboard'],
+    ['Station WebGPU canvas', 'the free-camera constellation renders there, not here']
+  ],
+
+  render(el) {
+    /* hygiene: no timers are owned by this view; keep the invariant explicit */
+    if (this._timer) { clearInterval(this._timer); this._timer = null; }
+    this._paused = false;
+
+    const D = V3.data;
+    const T = V3.transport;
+    const snapshot = {
+      sessions: (D.sessions || []).length,
+      queue: (D.queue || []).length,
+      machines: (D.machines || []).length,
+      config: T.config || null
+    };
+
+    el.innerHTML = V3.page({
+      eyebrow: 'vantage · the machinery, raw',
+      title: 'Studio',
+      sub: 'Everything the friendly rooms polish away: the lanes, the snapshot, the event stream — and the component contract itself, made visible.',
+      body:
+        /* ---------- Workbench ---------- */
+        V3.section('Workbench') +
+        '<div class="grid grid-2">' +
+          V3.card({
+            title: 'Transport lanes', sub: 'two lanes carry V3 in this draft — each labeled by what it carries',
+            body: '<div class="col" style="gap:12px">' +
+              this.lane('HTTP', '/api', T.config ? 'sage' : 'attn', T.config ? 'config loaded' : 'config not loaded yet',
+                'JSON routes — sessions, agenda, people, the ledgers') +
+              this.lane('WebSocket', '/ws',
+                T.state === 'live' ? 'sage' : T.state === 'connecting' ? 'attn' : 'brick',
+                T.state + (T.connectionId ? ' · conn ' + T.connectionId.slice(0, 8) : ''),
+                'the event stream — vitals, queue, presence, ControlMsgs out') +
+              this.lane('WebRTC', 'tunnel', 'slate', 'unused by V3 in this draft',
+                'display frames & input travel the classic dashboard’s tunnel') +
+            '</div>'
+          }) +
+          V3.card({
+            title: 'Diagnostics', sub: 'a ping against the daemon’s own HTTP lane',
+            body:
+              '<div class="row">' +
+                '<button class="btn btn-primary" id="std-ping">Ping /config</button>' +
+                '<span class="fact" id="std-ping-result">' + this.pingFact() + '</span>' +
+              '</div>' +
+              '<div class="dim" style="font-size:12px;margin-top:10px">One GET, timed in the browser. The daemon’s deeper self-tests stay on the classic dashboard; this proves the lane this page actually rides.</div>'
+          }) +
+        '</div>' +
+
+        /* ---------- Raw state ---------- */
+        V3.foldHtml({ key: 'studio.raw', title: 'Raw state', note: 'the snapshot · live event stream', open: true,
+          body:
+          '<div class="eyebrow" style="margin-bottom:6px">Store snapshot (trimmed)</div>' +
+          '<div class="panel mono std-json">' + V3.esc(JSON.stringify(snapshot, null, 2)) + '</div>' +
+          '<div class="row" style="margin:16px 0 6px">' +
+            '<span class="eyebrow">Event stream</span>' +
+            '<span class="fact" id="std-evt-count">live · ' + this._seen + ' seen</span>' +
+            '<span class="grow"></span>' +
+            '<button class="btn btn-quiet btn-xs" id="std-evt-pause">pause</button>' +
+          '</div>' +
+          '<div class="log panel std-events" id="std-events">' + this.eventsHtml() + '</div>' }) +
+
+        /* ---------- Reference ---------- */
+        V3.section('Reference') +
+        '<div class="grid grid-2">' +
+          V3.card({
+            title: 'The keyboard', sub: 'the same map the ? overlay shows',
+            body: '<div class="kv">' + this.KEYS.map(r =>
+              '<span class="k mono">' + V3.esc(r[0]) + '</span><span class="v" style="font-family:var(--sans)">' + V3.esc(r[1]) + '</span>').join('') + '</div>'
+          }) +
+          V3.card({
+            title: 'What V3 doesn’t rebuild yet', sub: 'honest gaps — each opens the classic dashboard, where it lives',
+            body: '<div class="col" style="gap:8px">' + this.MISSING.map(m =>
+              '<div class="row" style="align-items:flex-start">' + V3.ICON('external', 13) +
+                '<span style="font-size:13px"><b>' + V3.esc(m[0]) + '</b> — <span class="dim">' + V3.esc(m[1]) + '</span></span>' +
+                '<span class="grow"></span><a class="chip chip-slate" href="/">classic →</a></div>').join('') + '</div>'
+          }) +
+        '</div>' +
+
+        /* ---------- The component field guide ---------- */
+        V3.section('The component field guide — every state, labeled') +
+        '<div class="dim" style="font-size:12.5px;margin-top:-6px">The contract made visible. Specimens marked inert don’t act; everything else behaves.</div>' +
+        '<div class="std-guide">' + this.guide() + '</div>'
+    });
+
+    this.wire(el);
+    this.ensureTap();
+  },
+
+  lane(name, path, tone, state, carries) {
+    return '<div class="row">' + V3.dot(tone, tone === 'sage') +
+      '<span class="mono" style="width:150px;flex:none">' + V3.esc(name) + ' <span class="dim">' + V3.esc(path) + '</span></span>' +
+      V3.chip(state, tone) +
+      '<span class="dim" style="font-size:12.5px">' + V3.esc(carries) + '</span></div>';
+  },
+
+  pingFact() {
+    const p = this._ping;
+    if (!p) return 'idle — never pinged';
+    if (!p.ok) return 'failed · ' + (p.error || '') + ' · ' + p.at;
+    return p.ms + ' ms · ' + p.at;
+  },
+
+  /* ---------------- event stream ---------------- */
+  ensureTap() {
+    if (this._tapped) return;
+    this._tapped = true;
+    V3.transport.on('event:*', msg => {
+      if (V3.views.studio._paused) return;
+      const self = V3.views.studio;
+      self._seen++;
+      const brief = msg.session_id ? ' · ' + String(msg.session_id).slice(0, 8)
+        : msg.phase ? ' · ' + msg.phase : '';
+      self._events.push([self.stamp(), msg.event || '?', brief]);
+      if (self._events.length > 30) self._events.splice(0, self._events.length - 30);
+      const log = document.getElementById('std-events');
+      if (log) { log.innerHTML = self.eventsHtml(); log.scrollTop = log.scrollHeight; }
+      const count = document.getElementById('std-evt-count');
+      if (count) count.textContent = 'live · ' + self._seen + ' seen';
+    });
+  },
+
+  eventsHtml() {
+    if (!this._events.length) {
+      return '<div class="dim" style="font-size:12px">Quiet so far — the daemon’s events land here as they stream.</div>';
+    }
+    return this._events.map(l =>
+      '<div><span class="lt">' + l[0] + '</span> <span>' + V3.esc(l[1]) + '</span><span class="dim">' + V3.esc(l[2]) + '</span></div>').join('');
+  },
+
+  stamp() {
+    const d = new Date();
+    const p = n => String(n).padStart(2, '0');
+    return p(d.getHours()) + ':' + p(d.getMinutes()) + ':' + p(d.getSeconds());
+  },
+
+  /* ---------------- field guide ---------------- */
+  guide() {
+    const spec = (label, html, wide) =>
+      '<div class="std-spec' + (wide ? ' std-wide' : '') + '"><div class="std-spec-label">' + V3.esc(label) + '</div>' + html + '</div>';
+
+    /* the live component returns '' for anything not in the queue (it hides
+       resolved items), so the guide ships a static specimen in the same
+       classes — a labeled mirror of the markup, never a component call.
+       data-q/data-action stay on the buttons so the inert wrapper can
+       demonstrate the guard; the id is never in the real queue, so the
+       global delegation in v3-ui.js no-ops even if the wrapper is bypassed. */
+    const decisionSpecimen =
+      '<div class="decision">' +
+        '<div class="decision-head">' + V3.chip('needs you · file_delete', 'attn', 'doorbell') +
+          '<span class="grow"></span><span class="fact">now</span></div>' +
+        '<div class="decision-title">Claude wants to delete 3 files</div>' +
+        '<div class="decision-consequence">A static specimen of the decision card — the real ones live in the Queue. These buttons are inert.</div>' +
+        '<div class="panel mono" style="margin-bottom:10px">$ rm exports/old.csv</div>' +
+        '<div class="decision-actions">' +
+          '<button class="btn btn-safe" data-q="demo-approve" data-action="approve">Allow once <span class="kbd-hint">y</span></button>' +
+          '<button class="btn btn-quiet" data-q="demo-approve" data-action="always">Always allow <span class="kbd-hint">a</span></button>' +
+          '<button class="btn btn-danger btn-default" data-q="demo-approve" data-action="deny">Deny <span class="kbd-hint">n</span></button>' +
+        '</div>' +
+        V3.authline('you', 'owner', 'direct') +
+      '</div>';
+    const demoStage = {
+      id: 'demo-stage', name: 'demo-working', backend: 'claude-code', model: 'claude-fable',
+      machine: 'local', phase: 'working', active: true, turn: 5,
+      sentence: 'A specimen stage card — working, with its facts and meter',
+      tokens: { used: 82000, pct: 41 }, cost: 0.42
+    };
+    const demoStagePeer = {
+      id: 'demo-stage-peer', name: 'demo-peer', backend: 'codex', model: 'gpt-5.2-codex',
+      machine: 'workshop', phase: 'working', active: true, turn: 2,
+      sentence: 'The peer tone — a session reported by another machine',
+      tokens: { used: 40000, pct: 15 }, cost: 0.11
+    };
+
+    return [
+      spec('chips — every kind', '<div class="row" style="flex-wrap:wrap">' +
+        V3.chip('default') + V3.chip('sage', 'sage') + V3.chip('slate', 'slate') +
+        V3.chip('brass', 'brass') + V3.chip('attn', 'attn') + V3.chip('brick', 'brick') +
+        V3.chip('violet', 'violet') + V3.chip('with icon', 'attn', 'doorbell') + '</div>'),
+
+      spec('dots — always with a word', '<div class="factline">' +
+        '<span class="fact">' + V3.dot('sage') + ' sage</span>' +
+        '<span class="fact">' + V3.dot('sage', true) + ' pulsing</span>' +
+        '<span class="fact">' + V3.dot('attn') + ' attn</span>' +
+        '<span class="fact">' + V3.dot('brick') + ' brick</span>' +
+        '<span class="fact">' + V3.dot('slate') + ' slate</span></div>'),
+
+      spec('facts & meters — incl. warn / hot', '<div class="col" style="gap:8px">' +
+        '<div>' + V3.fact('12 ms · the instrument register') + '</div>' +
+        '<div class="row">' + V3.fact('34%') + V3.meter(34) + '</div>' +
+        '<div class="row">' + V3.fact('74% warn') + V3.meter(74) + '</div>' +
+        '<div class="row">' + V3.fact('92% hot') + V3.meter(92) + '</div></div>'),
+
+      spec('buttons', '<div class="row" style="flex-wrap:wrap">' +
+        '<button class="btn">default</button>' +
+        '<button class="btn btn-primary">primary</button>' +
+        '<button class="btn btn-safe">safe</button>' +
+        '<button class="btn btn-danger">danger</button>' +
+        '<button class="btn btn-quiet">quiet</button>' +
+        '<button class="btn btn-xs">xs</button>' +
+        '<button class="btn" disabled>disabled</button>' +
+        '<button class="icon-btn">' + V3.ICON('sparkle', 15) + '</button></div>'),
+
+      spec('segmented control', '<span class="seg"><button class="on">auto</button><button>ask</button><button>deny</button></span>' +
+        '<div class="dim" style="font-size:12px;margin-top:6px">approval rules use these — live-applied; the specimen is unwired</div>'),
+
+      spec('fold — closed & open', '<div class="col" style="gap:8px">' +
+        V3.foldHtml({ title: 'A closed fold', note: 'keyless, forgets itself', open: false, body: '<div class="dim" style="font-size:13px">Power unfolds where you look for it.</div>' }) +
+        V3.foldHtml({ title: 'An open fold', note: 'studio opens by default', open: true, body: '<div class="dim" style="font-size:13px">Same contract, opened. Keyless specimens don’t remember state.</div>' }) +
+        '</div>'),
+
+      spec('decision card — specimen, inert',
+        '<div class="std-specimen" id="std-specimen">' + decisionSpecimen + '</div>' +
+        '<div class="dim" style="font-size:12px;margin-top:6px">A static markup specimen — V3.decisionCard renders only live queue items. Wrapped so its buttons toast instead of resolving.</div>', true),
+
+      spec('stage cards — working & peer tones', '<div class="std-specimen" data-inert-links="1"><div class="grid grid-2">' +
+        V3.stageCard(demoStage) + V3.stageCard(demoStagePeer) + '</div></div>' +
+        '<div class="dim" style="font-size:12px;margin-top:6px">The attention tone isn’t staged — it glows when the real queue holds an item for the session. Links are inert here.</div>', true),
+
+      spec('empty state', V3.empty('stage', 'Nothing on stage', 'Every room ships its empty state — a serif line and one honest next action.')),
+
+      spec('skeleton — loading, never a lone spinner', '<div class="col" style="gap:8px">' +
+        V3.skeleton(14, '72%') + V3.skeleton(14, '100%') + V3.skeleton(14, '45%') + '</div>'),
+
+      spec('kv grid', '<div class="kv">' +
+        '<span class="k">branch</span><span class="v">fix/login-redirect</span>' +
+        '<span class="k">working tree</span><span class="v">12 dirty files</span>' +
+        '<span class="k">cache</span><span class="v">94% · ttl 4m 12s</span></div>'),
+
+      spec('table', '<table class="table"><thead><tr><th>Session</th><th>Cost</th><th>State</th></tr></thead><tbody>' +
+        '<tr><td>fix-login</td><td class="mono">$0.83</td><td>' + V3.chip('working', 'sage') + '</td></tr>' +
+        '<tr><td>docs-sweep</td><td class="mono">$0.31</td><td>' + V3.chip('working', 'sage') + '</td></tr>' +
+        '<tr><td>q2-invoices</td><td class="mono">$1.12</td><td>' + V3.chip('idle', 'slate') + '</td></tr>' +
+        '</tbody></table>', true),
+
+      spec('log lines', V3.logLines([
+        ['21:04', 'model', 'Reading src/auth/session.rs'],
+        ['21:04', 'tool', '$ cargo test --bins'],
+        ['21:05', 'ok', '42 passed · 0 failed'],
+        ['21:05', 'err', 'warning: unused import'],
+        ['21:06', 'info', 'turn 6 complete']
+      ])),
+
+      spec('authline — who acted, by what route', '<div class="col" style="gap:6px">' +
+        V3.authline('you', 'owner', 'direct') +
+        V3.authline('Workshop', 'operator', 'fleet name') +
+        V3.authline('a hosted tab', 'role:none', 'hosted') + '</div>'),
+
+      spec('toast', '<button class="btn btn-quiet" id="std-toast-demo">fire a toast</button>' +
+        '<span class="dim" style="font-size:12px;margin-left:8px">bottom-right · 3.2 s · sage or brick</span>')
+    ].join('');
+  },
+
+  /* ---------------- wiring ---------------- */
+  wire(el) {
+    /* ping */
+    const pingBtn = el.querySelector('#std-ping');
+    if (pingBtn) pingBtn.addEventListener('click', () => {
+      const t0 = performance.now();
+      const node = el.querySelector('#std-ping-result');
+      if (node) node.textContent = 'pinging…';
+      V3.transport.get('/config').then(() => {
+        this._ping = { ok: true, ms: Math.round(performance.now() - t0), at: this.stamp() };
+      }).catch(e => {
+        this._ping = { ok: false, error: e.message, at: this.stamp() };
+      }).then(() => {
+        const n = document.getElementById('std-ping-result');
+        if (n && V3.current === 'studio') n.textContent = this.pingFact();
+        if (this._ping.ok) V3.toast('The house answered in ' + this._ping.ms + ' ms', 'sage');
+      });
+    });
+
+    /* event stream pause */
+    const pauseBtn = el.querySelector('#std-evt-pause');
+    if (pauseBtn) pauseBtn.addEventListener('click', () => {
+      this._paused = !this._paused;
+      pauseBtn.textContent = this._paused ? 'resume' : 'pause';
+    });
+
+    /* field guide: toast demo */
+    const td = el.querySelector('#std-toast-demo');
+    if (td) td.addEventListener('click', () => V3.toast('The toast — brief, warm, and gone', 'sage'));
+
+    /* field guide: specimens stay inert — no queue resolution, no navigation */
+    const specimen = el.querySelector('#std-specimen');
+    if (specimen) specimen.addEventListener('click', e => {
+      if (e.target.closest('[data-q][data-action]')) {
+        e.stopPropagation();
+        e.preventDefault();
+        V3.toast('A specimen — its buttons are inert. The real ones live in the Queue.', null);
+      }
+    });
+    const links = el.querySelector('[data-inert-links]');
+    if (links) links.addEventListener('click', e => {
+      if (e.target.closest('a')) { e.preventDefault(); V3.toast('A specimen — the real cards navigate to their session.', null); }
+    });
+  },
+
+  live(what) {
+    if (!['conn', 'sessions', 'queue', 'machines', 'ready'].includes(what)) return;
+    const active = document.activeElement;
+    if (active && document.getElementById('main').contains(active) && /INPUT|TEXTAREA|SELECT/.test(active.tagName)) return;
+    const main = document.getElementById('main');
+    const y = main.scrollTop;
+    this.render(main);
+    main.scrollTop = y;
+  }
+};

--- a/static/v3/js/views/work.js
+++ b/static/v3/js/views/work.js
@@ -1,0 +1,153 @@
+/* V3 — Work (the Stage): Live · Archive · New · Worktrees. */
+window.V3 = window.V3 || {};
+V3.views = V3.views || {};
+
+V3.views.work = {
+  title: 'Work',
+  lane: 'live',
+  worktrees: null,
+
+  render(el, params) {
+    const lane = params[0] && ['live', 'archive', 'new', 'worktrees'].includes(params[0]) ? params[0] : this.lane;
+    this.lane = lane;
+    const lanes = [['live', 'Live'], ['archive', 'Archive'], ['new', 'New'], ['worktrees', 'Worktrees']];
+    el.innerHTML = V3.page({
+      eyebrow: 'the stage',
+      title: 'Work',
+      sub: 'Everything the house is doing, has done, or could start. One deep page per session — power unfolds where you look for it.',
+      body:
+        '<div class="row" style="justify-content:space-between">' +
+          '<div class="seg">' + lanes.map(l =>
+            '<button class="' + (l[0] === lane ? 'on' : '') + '" data-lane="' + l[0] + '">' + l[1] + '</button>').join('') + '</div>' +
+          V3.authline(V3.data.you.name, V3.data.you.role, V3.data.you.route) +
+        '</div>' +
+        '<div id="work-lane">' + this['lane_' + lane]() + '</div>'
+    });
+    el.querySelectorAll('[data-lane]').forEach(b => b.addEventListener('click', () => V3.go('#/work/' + b.dataset.lane)));
+    this.wire(el, lane);
+  },
+
+  lane_live() {
+    const S = V3.data.sessions;
+    const live = S.filter(s => s.active);
+    const done = S.filter(s => !s.active && ['done', 'failed'].includes(s.phase)).slice(0, 3);
+    const idle = S.filter(s => !s.active && s.phase === 'idle').slice(0, 3);
+    return '<div class="grid grid-3">' +
+        (live.map(V3.stageCard).join('') || V3.empty('stage', 'Nothing on stage', 'Give the house something to do — the composer below, or Work → New.')) +
+      '</div>' +
+      (done.length ? V3.section('Just finished') + '<div class="grid grid-3">' + done.map(V3.stageCard).join('') + '</div>' : '') +
+      (idle.length ? V3.section('Idle — waiting whenever you are') + '<div class="grid grid-3">' + idle.map(V3.stageCard).join('') + '</div>' : '');
+  },
+
+  lane_archive() {
+    const rows = V3.data.sessions;
+    if (!rows.length) return V3.empty('stage', 'Nothing finished yet', 'The archive fills in as the house works.');
+    return '<div class="row" style="gap:8px;flex-wrap:wrap">' +
+        '<input class="input" id="archive-q" placeholder="Filter sessions…" style="flex:1;min-width:220px">' +
+        '<span class="fact">' + rows.length + ' sessions</span>' +
+      '</div>' +
+      '<div class="card" style="padding:6px"><table class="table"><thead><tr>' +
+      '<th>Session</th><th>Source</th><th>Status</th><th>Turns</th><th>Cost</th><th></th></tr></thead><tbody id="archive-rows">' +
+      rows.map(s => '<tr data-open-session="' + s.id + '" data-search="' + V3.esc((s.name + ' ' + s.task).toLowerCase()) + '" style="cursor:pointer">' +
+        '<td>' + V3.esc(s.name) + '<div class="dim" style="font-weight:400;font-size:12px">' + V3.esc((s.task || '').slice(0, 70)) + '</div></td>' +
+        '<td class="mono">' + V3.esc(s.backend) + '</td>' +
+        '<td>' + V3.chip(s.phase, s.phase === 'done' ? 'sage' : s.phase === 'failed' ? 'brick' : s.active ? 'sage' : 'slate') + '</td>' +
+        '<td class="mono">' + (s.turn || 0) + '</td>' +
+        '<td class="mono">' + (s.cost ? '$' + s.cost.toFixed(2) : '—') + '</td>' +
+        '<td>' + V3.chip('open', null, 'chev') + '</td></tr>').join('') +
+      '</tbody></table></div>';
+  },
+
+  lane_new() {
+    const fuel = V3.data.fuel || {};
+    const fueled = fuel.openai || fuel.anthropic || fuel.gemini;
+    const agents = V3.data.externalAgents || [];
+    const agentOpts = [['', 'Internal (the house itself)']].concat(
+      agents.map(a => [a.id, a.label + (a.installed === false ? ' — not installed' : '')]));
+    return '<div class="card"><div class="card-head"><div>' +
+        '<h3 class="card-title">What should the house do?</h3>' +
+        '<div class="card-sub">One sentence is enough. The house asks if it needs more.</div></div></div>' +
+      '<textarea class="input" id="new-task" rows="3" placeholder="e.g. Tidy my downloads folder — keep anything from this month, archive the rest by year" style="width:100%;font-size:15px"></textarea>' +
+      '<div class="row" style="margin-top:10px;gap:8px;flex-wrap:wrap">' +
+        (fueled ? V3.chip('fueled — model credentials active', 'sage', 'fuel')
+                : V3.chip('no fuel yet — add API keys in Settings', 'attn', 'fuel')) +
+      '</div>' +
+      '<div class="row" style="margin-top:14px;gap:8px;align-items:center">' +
+        '<button class="btn btn-primary" id="new-start">' + V3.ICON('send', 15) + ' Start</button>' +
+        '<label class="row" style="gap:6px"><input type="checkbox" id="new-direct"> <span class="dim" style="font-size:12.5px">direct — skip the orchestrator</span></label>' +
+      '</div></div>' +
+      V3.foldHtml({ key: 'new.options', title: 'Options', note: 'the full launch panel — nothing removed',
+        body:
+        '<div class="grid grid-2">' +
+          '<div class="panel"><div class="eyebrow" style="margin-bottom:8px">Who does it</div>' +
+            '<div class="col" style="gap:6px">' +
+            agentOpts.map(([v, label], i) =>
+              '<label class="row" style="gap:8px"><input type="radio" name="new-agent" value="' + v + '" ' + (i === 0 ? 'checked' : '') + '><span>' + V3.esc(label) + '</span></label>').join('') +
+            '</div></div>' +
+          '<div class="panel"><div class="eyebrow" style="margin-bottom:8px">Where</div>' +
+            '<div class="kv"><span class="k">Project</span><span class="v">' + V3.esc(V3.data.sessions[0] && V3.data.sessions[0].cwd || 'the daemon’s project') + '</span>' +
+            '<span class="k">Worktree</span><span class="v">off — work in place</span></div></div>' +
+        '</div>' });
+  },
+
+  lane_worktrees() {
+    if (!this.worktrees) {
+      V3.transport.get('/api/worktrees').then(r => {
+        this.worktrees = r.worktrees || r || [];
+        if (this.lane === 'worktrees') V3.rerender();
+      }).catch(() => { this.worktrees = []; });
+      return '<div class="col" style="gap:8px">' + V3.skeleton(18) + V3.skeleton(18, '70%') + V3.skeleton(18, '45%') + '</div>';
+    }
+    if (!this.worktrees.length) return V3.empty('branch', 'No worktrees', 'Sessions that ask for an isolated checkout appear here.');
+    return '<div class="col" style="gap:10px">' + this.worktrees.map(w =>
+      '<div class="card"><div class="row">' + V3.ICON('branch', 15) + '<b class="mono">' + V3.esc(w.branch || w.name || w.path || '?') + '</b>' +
+        '<span class="grow"></span>' +
+        (w.dirty ? V3.chip(w.dirty + ' dirty', 'attn') : V3.chip('clean', 'sage')) +
+      '</div>' +
+      '<div class="factline" style="margin-top:8px">' +
+        (w.session_id ? V3.fact('session: ' + w.session_id) : '') +
+        (w.ahead != null ? V3.fact(w.ahead + ' ahead') : '') +
+        (w.path ? V3.fact(w.path) : '') +
+      '</div></div>').join('') + '</div>';
+  },
+
+  wire(el, lane) {
+    if (lane === 'archive') {
+      el.querySelectorAll('[data-open-session]').forEach(r =>
+        r.addEventListener('click', () => V3.go('#/work/session/' + r.dataset.openSession)));
+      const q = el.querySelector('#archive-q');
+      if (q) q.addEventListener('input', () => {
+        const needle = q.value.toLowerCase();
+        el.querySelectorAll('#archive-rows tr').forEach(r => {
+          r.style.display = !needle || r.dataset.search.includes(needle) ? '' : 'none';
+        });
+      });
+    }
+    if (lane === 'new') {
+      el.querySelector('#new-start').addEventListener('click', () => {
+        const text = (el.querySelector('#new-task').value || '').trim();
+        if (!text) { V3.toast('Give the house a sentence first', 'brick'); return; }
+        const agent = (el.querySelector('input[name="new-agent"]:checked') || {}).value || null;
+        const direct = el.querySelector('#new-direct').checked;
+        const msg = { action: 'create_session', task: text, follow_up_id: 'v3-' + Date.now().toString(36) };
+        if (agent) msg.agent = agent;
+        if (direct) msg.direct = true;
+        V3.transport.send(msg);
+        V3.data.conversation.push({ from: 'you', text, at: V3.now(), ts: Date.now() });
+        V3.toast('The house takes it on', 'sage');
+        V3.go('#/home');
+      });
+      const ta = el.querySelector('#new-task');
+      if (ta) ta.focus();
+    }
+  },
+
+  live(what) {
+    if (what === 'sessions' && V3.current === 'work' && (this.lane === 'live' || this.lane === 'archive')) {
+      const main = document.getElementById('main');
+      const lane = main.querySelector('#work-lane');
+      if (lane) lane.innerHTML = this['lane_' + this.lane]();
+      this.wire(main, this.lane);
+    }
+  }
+};

--- a/static/v3/v3-app.css
+++ b/static/v3/v3-app.css
@@ -1,0 +1,474 @@
+/* ============================================================
+   Proscenium — component library (app.css)
+   ------------------------------------------------------------
+   STYLEGUIDE (the contract — reuse, don't improvise):
+
+   Layout      #rail (.rail-item, .rail-group-label) · #topbar
+               · #main > .page (one per room) · #composer
+   Structure   .card [.card-head .card-title .card-sub .card-actions]
+               .stage-card (arch band — live work) [.stage-band .stage-body]
+               .decision[.sev-attention|.sev-info|.fyi] (queue card)
+               .panel (sunken well) .row .col .wrap .grow
+   Disclosure  <details class="fold"> <summary> … <div class="fold-body">
+               (.fold[data-key] remembers state; studio opens by default)
+   Actions     .btn[.btn-primary|.btn-safe|.btn-danger|.btn-quiet][.btn-xs]
+               .icon-btn · .seg > button[.on]
+   Status      .chip[.chip-sage|.chip-slate|.chip-brass|.chip-attn|
+               .chip-brick|.chip-violet] — always labeled, never color-only
+               .dot[.dot-sage…] + word · .meter > .meter-fill · .badge-count
+   Facts       .fact (inline mono fact) · .kv > .k/.v · .factline
+   Tables      .table (dense, instrument register)
+   Thread      .thread .msg[.msg-you] .msg-body .artifact .milestone
+   Misc        .empty (.empty-glyph .empty-title .empty-hint)
+               .skeleton · .diff(.diff-add/.diff-del/.diff-hunk) · .heat
+               .tree · .authline · .kbd-hint · .flash (jump target)
+   Density     .cozy-only .studio-only .hide-cozy (visibility helpers)
+   ============================================================ */
+
+/* ============ App frame ============ */
+#app { display: flex; height: 100vh; }
+#column { flex: 1; display: flex; flex-direction: column; min-width: 0; }
+
+/* Curtain lift (first paint) */
+#curtain {
+  position: fixed; inset: 0; z-index: 200; display: flex; align-items: center; justify-content: center;
+  background: var(--bg); color: var(--text-2);
+  animation: curtain 900ms var(--ease) forwards; pointer-events: none;
+}
+#curtain svg { animation: curtainGlyph 700ms var(--ease) both; }
+@keyframes curtain { 0%,55% { opacity: 1; } 100% { opacity: 0; visibility: hidden; } }
+@keyframes curtainGlyph { from { opacity: 0; transform: translateY(14px) scale(.96); } to { opacity: 1; transform: none; } }
+
+/* Prototype banner */
+#proto-banner {
+  position: fixed; top: 0; left: 0; right: 0; z-index: 150;
+  display: flex; align-items: center; gap: 10px;
+  padding: 6px 14px; font-size: 12.5px;
+  background: linear-gradient(90deg, rgba(var(--brass-rgb),.14), rgba(var(--brass-rgb),.05));
+  border-bottom: 1px solid var(--line);
+  color: var(--text-2); backdrop-filter: blur(8px);
+}
+#proto-banner a { color: var(--brass); text-decoration: none; border-bottom: 1px solid rgba(var(--brass-rgb),.4); }
+#app { padding-top: 33px; }
+
+/* ============ Rail ============ */
+#rail {
+  width: var(--rail-w); flex: none; display: flex; flex-direction: column;
+  background: var(--bg-1); border-right: 1px solid var(--line);
+  padding: 14px 10px 10px; gap: 2px; overflow-y: auto;
+}
+#rail-brand {
+  display: flex; align-items: center; gap: 10px; padding: 4px 10px 14px;
+  color: var(--text);
+}
+#rail-brand .wordmark { font: 600 16px var(--voice); letter-spacing: .02em; }
+.rail-group-label {
+  font: 600 var(--fs-eyebrow) var(--sans); letter-spacing: .12em; text-transform: uppercase;
+  color: var(--text-3); padding: 14px 12px 5px;
+}
+.rail-item {
+  display: flex; align-items: center; gap: 10px; width: 100%;
+  padding: 7px 12px; border: 0; border-radius: var(--r-ctl);
+  background: none; color: var(--text-2); font: 500 var(--fs-base) var(--sans);
+  cursor: pointer; text-align: left; text-decoration: none;
+  transition: background var(--t-fast), color var(--t-fast);
+}
+.rail-item:hover { background: var(--surface-2); color: var(--text); }
+.rail-item.on { background: rgba(var(--brass-rgb),.13); color: var(--brass-2); }
+html[data-theme="daylight"] .rail-item.on { color: var(--brass); }
+.rail-item .icon { flex: none; }
+.rail-item .rail-sub { margin-left: auto; font-size: 11px; color: var(--text-3); }
+#rail-foot { border-top: 1px solid var(--line); padding-top: 8px; margin-top: 6px; }
+#rail-queue { position: relative; }
+#rail-identity { padding: 8px 12px 2px; font-size: 11.5px; line-height: 1.45; }
+
+/* ============ Topbar ============ */
+#topbar {
+  display: flex; align-items: center; gap: 8px;
+  padding: 10px 20px; border-bottom: 1px solid var(--line);
+  background: color-mix(in srgb, var(--bg) 82%, transparent);
+  backdrop-filter: blur(10px); flex: none;
+}
+#topbar-title { font-size: var(--fs-title); letter-spacing: .01em; }
+#topbar-facts { font-size: 12px; display: flex; gap: 14px; }
+#btn-palette {
+  display: flex; align-items: center; gap: 8px;
+  border: 1px solid var(--line-2); background: var(--surface);
+  color: var(--text-2); border-radius: var(--r-pill); padding: 6px 12px;
+  font: 500 12.5px var(--sans); cursor: pointer;
+  transition: border-color var(--t-fast), box-shadow var(--t-fast);
+}
+#btn-palette:hover { border-color: rgba(var(--brass-rgb),.5); box-shadow: var(--glow-brass); color: var(--text); }
+.kbd-hint {
+  font: 500 11px var(--mono); color: var(--text-3);
+  border: 1px solid var(--line); border-radius: 5px; padding: 1px 6px;
+  background: var(--bg-1);
+}
+
+/* ============ Main ============ */
+#main { flex: 1; overflow-y: auto; scroll-behavior: smooth; }
+.page {
+  max-width: var(--content-max); margin: 0 auto; padding: 26px 26px 40px;
+  display: flex; flex-direction: column; gap: var(--gap);
+  animation: pageIn var(--t-slow) var(--ease);
+}
+@keyframes pageIn { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }
+.page-title { font: 500 var(--fs-display)/1.2 var(--voice); letter-spacing: .01em; margin: 4px 0 0; }
+.page-sub { color: var(--text-2); margin: 2px 0 8px; max-width: 64ch; }
+.eyebrow {
+  font: 600 var(--fs-eyebrow) var(--sans); letter-spacing: .12em;
+  text-transform: uppercase; color: var(--text-3);
+}
+.section-head { display: flex; align-items: baseline; gap: 10px; margin: 14px 0 2px; }
+.section-head .eyebrow { flex: none; }
+.section-head .line { flex: 1; border-top: 1px solid var(--line); }
+html[data-density="studio"] .page-title { font-size: var(--fs-display); }
+
+/* ============ Cards ============ */
+.card {
+  background: var(--surface); border: 1px solid var(--line);
+  border-radius: var(--r-card); padding: var(--pad-card);
+  box-shadow: var(--shadow-card);
+}
+.card-head { display: flex; align-items: flex-start; gap: 12px; margin-bottom: 8px; }
+.card-title { font: 600 15px var(--sans); margin: 0; }
+.card-sub { color: var(--text-2); font-size: 13px; margin-top: 2px; }
+.card-actions { margin-left: auto; display: flex; gap: 8px; flex: none; }
+.grid { display: grid; gap: var(--gap); }
+.grid-2 { grid-template-columns: repeat(2, 1fr); }
+.grid-3 { grid-template-columns: repeat(3, 1fr); }
+html[data-density="studio"] .grid-3 { grid-template-columns: repeat(4, 1fr); }
+@media (max-width: 900px) { .grid-2, .grid-3 { grid-template-columns: 1fr; } }
+
+.panel {
+  background: var(--bg-1); border: 1px solid var(--line);
+  border-radius: var(--r-ctl); padding: 12px 14px;
+}
+.row { display: flex; align-items: center; gap: 8px; }
+.col { display: flex; flex-direction: column; gap: 8px; }
+input[type="radio"], input[type="checkbox"] { accent-color: var(--brass); }
+.input {
+  border: 1px solid var(--line-2); background: var(--bg-1); color: var(--text);
+  border-radius: var(--r-ctl); font: 400 13.5px var(--sans); padding: 7px 11px;
+  outline: none; transition: border-color var(--t-fast), box-shadow var(--t-fast);
+}
+.input:focus { border-color: rgba(var(--brass-rgb),.55); box-shadow: var(--glow-brass); }
+.input::placeholder { color: var(--text-3); }
+
+/* ============ Stage card (the arch — live work) ============ */
+.stage-card {
+  position: relative; display: block; border: 1px solid var(--line); border-radius: var(--r-card);
+  background: var(--surface); overflow: hidden; box-shadow: var(--shadow-card);
+  color: var(--text); text-decoration: none;
+  transition: border-color var(--t-med), transform var(--t-med), box-shadow var(--t-med);
+}
+.stage-card::before { /* the arch band */
+  content: ""; display: block; height: 26px;
+  border-radius: 46% 46% 0 0 / 100% 100% 0 0;
+  background: linear-gradient(180deg, rgba(var(--sage-rgb),.22), rgba(var(--sage-rgb),.03));
+  border-bottom: 1px solid var(--line);
+  margin: 0 8px; transform: translateY(6px);
+}
+.stage-card.attention::before { background: linear-gradient(180deg, rgba(var(--attn-rgb),.26), rgba(var(--attn-rgb),.03)); }
+.stage-card.peer::before { background: linear-gradient(180deg, rgba(var(--violet-rgb),.22), rgba(var(--violet-rgb),.03)); }
+.stage-card.done::before { background: linear-gradient(180deg, rgba(var(--slate-rgb),.18), rgba(var(--slate-rgb),.02)); }
+.stage-card:hover { border-color: var(--line-2); transform: translateY(-1px); box-shadow: var(--shadow-card), 0 6px 20px rgba(0,0,0,.18); }
+.stage-body { padding: 12px 16px 14px; }
+.stage-name { font: 600 15px var(--sans); display: flex; align-items: center; gap: 8px; }
+.stage-sentence { color: var(--text-2); margin: 4px 0 10px; font-size: 13.5px; }
+.stage-facts { display: flex; gap: 12px; flex-wrap: wrap; align-items: center; }
+
+/* ============ Chips, dots, facts ============ */
+.chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  font: 500 12px var(--sans); padding: 2.5px 10px;
+  border-radius: var(--r-pill); border: 1px solid var(--line-2);
+  color: var(--text-2); background: var(--surface-2); white-space: nowrap;
+}
+.chip .dot { margin: 0 -2px 0 -4px; }
+.chip-sage   { color: var(--sage);   border-color: rgba(var(--sage-rgb),.35);  background: rgba(var(--sage-rgb),.10); }
+.chip-slate  { color: var(--slate);  border-color: rgba(var(--slate-rgb),.35); background: rgba(var(--slate-rgb),.10); }
+.chip-brass  { color: var(--brass-2);border-color: rgba(var(--brass-rgb),.4);  background: rgba(var(--brass-rgb),.11); }
+html[data-theme="daylight"] .chip-brass { color: var(--brass); }
+.chip-attn   { color: var(--attn);   border-color: rgba(var(--attn-rgb),.4);   background: rgba(var(--attn-rgb),.10); }
+.chip-brick  { color: var(--brick);  border-color: rgba(var(--brick-rgb),.4);  background: rgba(var(--brick-rgb),.10); }
+.chip-violet { color: var(--violet); border-color: rgba(var(--violet-rgb),.4); background: rgba(var(--violet-rgb),.10); }
+.dot { display: inline-block; width: 7px; height: 7px; border-radius: 50%; background: var(--text-3); flex: none; }
+.dot-sage { background: var(--sage); box-shadow: 0 0 8px rgba(var(--sage-rgb),.6); }
+.dot-attn { background: var(--attn); box-shadow: 0 0 8px rgba(var(--attn-rgb),.6); }
+.dot-brick { background: var(--brick); }
+.dot-slate { background: var(--slate); }
+.dot-pulse { animation: pulse 2s infinite; }
+@keyframes pulse { 50% { opacity: .45; } }
+.fact { font: 400 12px var(--mono); color: var(--text-3); white-space: nowrap; }
+.factline { display: flex; gap: 14px; flex-wrap: wrap; }
+.kv { display: grid; grid-template-columns: minmax(120px, auto) 1fr; gap: 4px 16px; font-size: 13px; }
+.kv .k { color: var(--text-3); }
+.kv .v { color: var(--text); font-family: var(--mono); font-size: 12.5px; overflow-wrap: anywhere; }
+.badge-count {
+  min-width: 19px; height: 19px; padding: 0 6px; border-radius: var(--r-pill);
+  background: var(--attn); color: #241A08; font: 700 11px/19px var(--sans);
+  text-align: center; margin-left: auto;
+}
+.authline { color: var(--text-3); font-size: 11.5px; display: flex; gap: 6px; align-items: center; flex-wrap: wrap; }
+.authline .who { color: var(--brass-2); font-weight: 600; }
+html[data-theme="daylight"] .authline .who { color: var(--brass); }
+
+/* ============ Decision cards (the Queue) ============ */
+.decision {
+  position: relative; border: 1px solid rgba(var(--attn-rgb),.35);
+  border-radius: var(--r-card); background:
+    linear-gradient(180deg, rgba(var(--attn-rgb),.07), transparent 42%), var(--surface);
+  padding: var(--pad-card); box-shadow: var(--shadow-card);
+  animation: decideIn var(--t-slow) var(--ease);
+}
+@keyframes decideIn { from { opacity: 0; transform: translateY(-8px); } to { opacity: 1; transform: none; } }
+.decision.fyi { border-color: var(--line-2); background: var(--surface); }
+.decision-head { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; }
+.decision-title { font: 500 17px var(--voice); margin: 2px 0; }
+.decision-consequence { color: var(--text-2); font-size: 13.5px; margin: 2px 0 10px; }
+.decision-actions { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+.decision .authline { margin-top: 10px; }
+.decision.resolved { opacity: 0; transform: translateY(-6px); transition: opacity .3s, transform .3s; pointer-events: none; }
+.queue-free {
+  text-align: center; padding: 26px 20px; color: var(--text-2);
+  font: 500 16.5px var(--voice);
+}
+.queue-free .big { font-size: 20px; color: var(--sage); display: block; margin-bottom: 4px; }
+
+/* ============ Buttons ============ */
+.btn {
+  display: inline-flex; align-items: center; gap: 7px;
+  border: 1px solid var(--line-2); background: var(--surface-2);
+  color: var(--text); border-radius: var(--r-ctl);
+  font: 500 13px var(--sans); padding: 7px 14px; cursor: pointer;
+  transition: border-color var(--t-fast), background var(--t-fast), box-shadow var(--t-fast), transform var(--t-fast);
+}
+.btn:hover { border-color: var(--text-3); transform: translateY(-.5px); }
+.btn:active { transform: none; }
+.btn-primary {
+  background: linear-gradient(180deg, var(--brass-2), var(--brass));
+  border-color: rgba(var(--brass-rgb),.6); color: var(--on-brass); font-weight: 600;
+}
+.btn-primary:hover { box-shadow: var(--glow-brass); border-color: var(--brass); }
+.btn-safe { border-color: rgba(var(--sage-rgb),.45); color: var(--sage); background: rgba(var(--sage-rgb),.08); }
+.btn-safe:hover { border-color: var(--sage); }
+.btn-danger { border-color: rgba(var(--brick-rgb),.45); color: var(--brick); background: rgba(var(--brick-rgb),.07); }
+.btn-danger:hover { border-color: var(--brick); }
+.btn-quiet { background: none; border-color: transparent; color: var(--text-2); }
+.btn-quiet:hover { background: var(--surface-2); color: var(--text); border-color: transparent; }
+.btn-xs { padding: 3px 9px; font-size: 12px; border-radius: 8px; }
+.btn[disabled] { opacity: .45; pointer-events: none; }
+.icon-btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+  width: 32px; height: 32px; border-radius: var(--r-ctl);
+  border: 1px solid transparent; background: none; color: var(--text-2); cursor: pointer;
+  transition: background var(--t-fast), color var(--t-fast), border-color var(--t-fast);
+}
+.icon-btn:hover { background: var(--surface-2); color: var(--text); }
+.icon-btn.on { color: var(--brass-2); border-color: rgba(var(--brass-rgb),.4); background: rgba(var(--brass-rgb),.1); }
+.icon { display: inline-flex; width: 18px; height: 18px; flex: none; }
+.icon svg { width: 100%; height: 100%; }
+
+/* Segmented */
+.seg { display: inline-flex; border: 1px solid var(--line-2); border-radius: var(--r-ctl); overflow: hidden; background: var(--bg-1); }
+.seg button {
+  border: 0; background: none; color: var(--text-2); font: 500 12.5px var(--sans);
+  padding: 6px 13px; cursor: pointer; border-right: 1px solid var(--line);
+}
+.seg button:last-child { border-right: 0; }
+.seg button.on { background: rgba(var(--brass-rgb),.16); color: var(--brass-2); }
+html[data-theme="daylight"] .seg button.on { color: var(--brass); }
+
+/* Meters */
+.meter { display: inline-block; vertical-align: middle; height: 5px; border-radius: 4px; background: var(--surface-3); overflow: hidden; min-width: 60px; }
+.meter-fill { display: block; height: 100%; border-radius: 4px; background: var(--sage); transition: width .5s var(--ease); }
+.meter-fill.warn { background: var(--attn); }
+.meter-fill.hot { background: var(--brick); }
+
+/* ============ Folds (the disclosure contract) ============ */
+.fold { border: 1px solid var(--line); border-radius: var(--r-card); background: var(--surface); overflow: hidden; }
+.fold > summary {
+  list-style: none; cursor: pointer; display: flex; align-items: center; gap: 10px;
+  padding: 12px 16px; font: 600 13.5px var(--sans); color: var(--text);
+  transition: background var(--t-fast);
+}
+.fold > summary::-webkit-details-marker { display: none; }
+.fold > summary:hover { background: var(--surface-2); }
+.fold > summary .chev { transition: transform var(--t-med) var(--ease); color: var(--text-3); }
+.fold[open] > summary .chev { transform: rotate(90deg); }
+.fold > summary .fold-note { margin-left: auto; font: 400 12px var(--sans); color: var(--text-3); }
+.fold-body { padding: 4px 16px 16px; border-top: 1px solid var(--line); }
+.fold.flash, .flash { animation: flashTarget 1.6s var(--ease); }
+@keyframes flashTarget {
+  0%, 100% { box-shadow: none; }
+  15%, 45% { box-shadow: var(--glow-brass); border-color: rgba(var(--brass-rgb),.6); }
+}
+
+/* ============ Thread (the Conversation) ============ */
+.thread { display: flex; flex-direction: column; gap: 12px; }
+.msg { display: flex; gap: 10px; max-width: 82%; }
+.msg .avatar {
+  flex: none; width: 30px; height: 30px; border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  background: rgba(var(--brass-rgb),.14); color: var(--brass-2); border: 1px solid rgba(var(--brass-rgb),.3);
+}
+html[data-theme="daylight"] .msg .avatar { color: var(--brass); }
+.msg-body {
+  background: var(--surface); border: 1px solid var(--line);
+  border-radius: 4px var(--r-card) var(--r-card) var(--r-card);
+  padding: 10px 14px; box-shadow: var(--shadow-card);
+}
+.msg-body .prose { font: 400 var(--fs-voice)/1.55 var(--voice); }
+.msg-body .prose p { margin: 0 0 8px; } .msg-body .prose p:last-child { margin: 0; }
+.msg-you { align-self: flex-end; flex-direction: row-reverse; }
+.msg-you .msg-body { background: rgba(var(--brass-rgb),.09); border-color: rgba(var(--brass-rgb),.25); border-radius: var(--r-card) 4px var(--r-card) var(--r-card); }
+.msg-you .avatar { background: var(--surface-2); color: var(--text-2); border-color: var(--line-2); }
+.msg-meta { font-size: 11px; color: var(--text-3); margin-top: 6px; display: flex; gap: 8px; }
+.milestone {
+  display: flex; align-items: center; gap: 10px; color: var(--text-3); font-size: 12.5px;
+  padding: 2px 6px;
+}
+.milestone .line { flex: 1; border-top: 1px solid var(--line); }
+.milestone button { font-size: 11.5px; }
+.artifact {
+  margin-top: 10px; border: 1px solid var(--line-2); border-radius: var(--r-ctl);
+  background: var(--bg-1); padding: 10px 12px;
+}
+.artifact-head { display: flex; gap: 8px; align-items: center; font: 600 12.5px var(--sans); color: var(--text-2); margin-bottom: 6px; }
+
+/* Diff */
+.diff { font: 400 12px/1.6 var(--mono); overflow-x: auto; border-radius: var(--r-inset); }
+.diff-hunk { color: var(--slate); padding: 2px 10px; background: rgba(var(--slate-rgb),.07); }
+.diff-add { color: var(--sage); padding: 0 10px; display: block; background: rgba(var(--sage-rgb),.06); }
+.diff-del { color: var(--brick); padding: 0 10px; display: block; background: rgba(var(--brick-rgb),.05); }
+.diff-ctx { color: var(--text-3); padding: 0 10px; display: block; }
+
+/* ============ Today ribbon ============ */
+.ribbon { display: flex; gap: 8px; align-items: stretch; overflow-x: auto; padding: 4px 2px 8px; }
+.ribbon-item {
+  flex: none; display: flex; flex-direction: column; gap: 2px;
+  border: 1px solid var(--line); border-radius: var(--r-ctl);
+  background: var(--surface); padding: 8px 12px; min-width: 130px;
+  font-size: 12.5px; cursor: pointer; transition: border-color var(--t-fast);
+}
+.ribbon-item:hover { border-color: var(--line-2); }
+.ribbon-item .t { font: 500 11.5px var(--mono); color: var(--text-3); }
+.ribbon-item.now { border-color: rgba(var(--brass-rgb),.5); background: rgba(var(--brass-rgb),.07); }
+.ribbon-item.now .t { color: var(--brass-2); }
+
+/* ============ Composer ============ */
+#composer { flex: none; padding: 10px 20px 14px; border-top: 1px solid var(--line); background: color-mix(in srgb, var(--bg) 85%, transparent); backdrop-filter: blur(10px); }
+#composer-target { margin: 0 auto 6px; width: max-content; }
+#composer-box {
+  display: flex; align-items: flex-end; gap: 6px; max-width: var(--content-max); margin: 0 auto;
+  background: var(--surface); border: 1px solid var(--line-2); border-radius: 18px;
+  padding: 8px 10px; box-shadow: var(--shadow-card);
+  transition: border-color var(--t-fast), box-shadow var(--t-fast);
+}
+#composer-box:focus-within { border-color: rgba(var(--brass-rgb),.55); box-shadow: var(--glow-brass); }
+#composer-input {
+  flex: 1; border: 0; background: none; resize: none; color: var(--text);
+  font: 400 15px/1.45 var(--sans); padding: 5px 6px; max-height: 140px; outline: none;
+}
+#composer-hint { max-width: var(--content-max); margin: 5px auto 0; font-size: 11.5px; }
+.btn-send { color: var(--brass-2); }
+html[data-theme="daylight"] .btn-send { color: var(--brass); }
+
+/* ============ Overlays: palette & drawer ============ */
+.overlay { position: fixed; inset: 0; z-index: 100; background: rgba(10,8,6,.5); backdrop-filter: blur(3px); animation: fadeIn var(--t-fast); }
+@keyframes fadeIn { from { opacity: 0; } }
+#palette-panel {
+  width: min(640px, 92vw); margin: 12vh auto 0;
+  background: var(--surface-2); border: 1px solid var(--line-2);
+  border-radius: var(--r-panel); box-shadow: var(--shadow-overlay); overflow: hidden;
+}
+#palette-input-row { display: flex; align-items: center; gap: 10px; padding: 14px 16px; border-bottom: 1px solid var(--line); color: var(--text-3); }
+#palette-input { flex: 1; border: 0; background: none; outline: none; color: var(--text); font: 400 16px var(--sans); }
+#palette-results { max-height: 54vh; overflow-y: auto; padding: 6px; }
+.pal-lane { padding: 8px 12px 3px; font: 600 10.5px var(--sans); letter-spacing: .12em; text-transform: uppercase; color: var(--text-3); }
+.pal-item {
+  display: flex; align-items: center; gap: 10px; padding: 8px 12px; border-radius: var(--r-ctl);
+  cursor: pointer; color: var(--text-2);
+}
+.pal-item .pal-name { color: var(--text); font-weight: 500; }
+.pal-item .pal-hint { margin-left: auto; font-size: 11.5px; color: var(--text-3); }
+.pal-item.sel { background: rgba(var(--brass-rgb),.14); }
+.pal-item.sel .pal-name { color: var(--brass-2); }
+html[data-theme="daylight"] .pal-item.sel .pal-name { color: var(--brass); }
+#palette-foot { padding: 9px 16px; border-top: 1px solid var(--line); font-size: 11.5px; }
+
+#queue-panel {
+  position: absolute; top: 0; right: 0; bottom: 0; width: min(460px, 94vw);
+  background: var(--bg-1); border-left: 1px solid var(--line-2);
+  box-shadow: var(--shadow-overlay); overflow-y: auto; padding: 18px;
+  display: flex; flex-direction: column; gap: 12px;
+  animation: drawerIn var(--t-med) var(--ease);
+}
+@keyframes drawerIn { from { transform: translateX(30px); opacity: 0; } to { transform: none; opacity: 1; } }
+
+/* Toasts */
+#toasts { position: fixed; bottom: 90px; right: 20px; display: flex; flex-direction: column; gap: 8px; z-index: 160; }
+.toast {
+  background: var(--surface-2); border: 1px solid var(--line-2); color: var(--text);
+  border-radius: var(--r-ctl); padding: 10px 14px; font-size: 13px;
+  box-shadow: var(--shadow-overlay); animation: toastIn var(--t-med) var(--ease);
+  display: flex; gap: 8px; align-items: center; max-width: 340px;
+}
+.toast.sage { border-color: rgba(var(--sage-rgb),.4); }
+.toast.brick { border-color: rgba(var(--brick-rgb),.4); }
+@keyframes toastIn { from { opacity: 0; transform: translateY(8px); } }
+
+/* ============ Data display ============ */
+.table { width: 100%; border-collapse: collapse; font-size: 13px; }
+.table th {
+  text-align: left; font: 600 11px var(--sans); letter-spacing: .08em; text-transform: uppercase;
+  color: var(--text-3); padding: 6px 10px; border-bottom: 1px solid var(--line-2);
+}
+.table td { padding: 8px 10px; border-bottom: 1px solid var(--line); color: var(--text-2); }
+.table td:first-child { color: var(--text); font-weight: 500; }
+.table tr:hover td { background: var(--surface-2); }
+.table .mono { font-size: 12px; }
+
+.tree { font: 400 13px var(--mono); }
+.tree-row { display: flex; gap: 8px; align-items: center; padding: 3px 8px; border-radius: 6px; cursor: pointer; color: var(--text-2); }
+.tree-row:hover { background: var(--surface-2); }
+.tree-row.on { background: rgba(var(--brass-rgb),.12); color: var(--brass-2); }
+
+.heat { display: grid; grid-template-rows: repeat(7, 1fr); grid-auto-flow: column; gap: 3px; }
+.heat i { width: 11px; height: 11px; border-radius: 3px; background: var(--surface-3); }
+.heat i.l1 { background: rgba(var(--sage-rgb),.3); } .heat i.l2 { background: rgba(var(--sage-rgb),.5); }
+.heat i.l3 { background: rgba(var(--sage-rgb),.7); } .heat i.l4 { background: var(--sage); }
+
+/* Log lines (instrument register) */
+.log { font: 400 12px/1.65 var(--mono); color: var(--text-2); }
+.log .lt { color: var(--text-3); }
+.log .tool { color: var(--slate); }
+.log .ok { color: var(--sage); }
+.log .err { color: var(--brick); }
+
+/* ============ Empty & skeleton ============ */
+.empty { text-align: center; padding: 44px 20px; color: var(--text-2); }
+.empty-glyph { font-size: 30px; color: var(--text-3); margin-bottom: 10px; display: inline-block; }
+.empty-title { font: 500 19px var(--voice); color: var(--text); margin-bottom: 6px; }
+.empty-hint { font-size: 13.5px; max-width: 46ch; margin: 0 auto 14px; }
+.skeleton { border-radius: var(--r-ctl); background: linear-gradient(100deg, var(--surface) 40%, var(--surface-2) 50%, var(--surface) 60%); background-size: 200% 100%; animation: sk 1.4s infinite linear; }
+@keyframes sk { to { background-position: -200% 0; } }
+
+/* ============ Density visibility helpers ============ */
+html[data-density="cozy"] .hide-cozy, html[data-density="cozy"] .studio-only { display: none !important; }
+html:not([data-density="cozy"]) .cozy-only { display: none !important; }
+html:not([data-density="studio"]) .studio-only { display: none !important; }
+html[data-density="studio"] .fold { border-radius: var(--r-ctl); }
+html[data-density="studio"] .stage-sentence { font-size: 12.5px; }
+html[data-density="cozy"] .stage-facts .fact { display: none; }
+
+/* ============ Responsive ============ */
+@media (max-width: 860px) {
+  #rail { width: 64px; }
+  .rail-label, .rail-group-label, #rail-identity, #rail-brand .wordmark { display: none; }
+  .rail-item { justify-content: center; padding: 9px; }
+  .badge-count { position: absolute; top: 2px; right: 4px; }
+  #topbar-facts { display: none; }
+  .msg { max-width: 100%; }
+}

--- a/static/v3/v3-rooms.css
+++ b/static/v3/v3-rooms.css
@@ -1,0 +1,143 @@
+/* V3 — room-specific styles. Shared chrome lives in v3-app.css and the
+   palette/tokens in v3-tokens.css; everything here is prefixed per room
+   (.ppl- People & Keys · .bks- Books · .stn- Station · .std- Studio) and
+   consumes tokens, never redefines them. Adapted from the Proscenium
+   prototype's views-b.css — the meter-fill repairs are dropped because
+   v3-app.css already paints .meter-fill as a block. */
+
+/* ============ People & Keys (.ppl-) ============ */
+.ppl-roles { display: grid; grid-template-columns: repeat(auto-fill, minmax(216px, 1fr)); gap: 8px; }
+.ppl-role { cursor: default; }
+.ppl-role b { text-transform: capitalize; }
+.ppl-role .dim { font-size: 12px; margin-top: 3px; }
+
+/* ============ Books (.bks-) ============ */
+.bks-kpis { display: grid; grid-template-columns: repeat(4, 1fr); gap: var(--gap); }
+@media (max-width: 900px) { .bks-kpis { grid-template-columns: repeat(2, 1fr); } }
+.bks-kpi-value { font: 500 26px var(--voice); color: var(--text); }
+.bks-kpi-label { font: 600 12.5px var(--sans); color: var(--text-2); margin-top: 2px; }
+
+.bks-item { padding: 7px 6px; border-radius: 8px; cursor: pointer; transition: background var(--t-fast); }
+.bks-item:hover { background: var(--surface-2); }
+.bks-check {
+  width: 20px; height: 20px; flex: none; display: inline-flex; align-items: center; justify-content: center;
+  border: 1px solid var(--line-2); border-radius: 6px; color: var(--sage);
+}
+.bks-item-title { font-size: 13.5px; }
+.bks-item-title.done { text-decoration: line-through; color: var(--text-3); }
+
+/* ============ Station (.stn-) ============ */
+.stn-scene {
+  position: relative; margin: 0 -26px; min-height: 560px; overflow: hidden;
+  background: radial-gradient(1100px 560px at 50% 42%, #17203A 0%, #0B0E16 68%);
+  border-top: 1px solid var(--line); border-bottom: 1px solid var(--line);
+}
+.stn-svg { position: absolute; inset: 0; width: 100%; height: 100%; }
+.stn-svg text { fill: #C6BAA4; font-family: var(--sans); font-size: 12.5px; }
+.stn-svg .stn-label { text-anchor: middle; }
+.stn-svg .stn-sublabel { fill: #91866F; font-family: var(--mono); font-size: 10px; text-anchor: middle; }
+.stn-star { fill: #F1EADC; }
+.stn-star.tw { animation: stnTw 3.6s ease-in-out infinite; }
+@keyframes stnTw { 50% { opacity: .12; } }
+.stn-ring { fill: none; stroke: rgba(145,134,111,.30); stroke-dasharray: 3 7; }
+.stn-ring-faint { fill: none; stroke: rgba(145,134,111,.16); }
+.stn-spin { transform-origin: 500px 280px; animation: stnSpin 140s linear infinite; }
+.stn-spin-rev { transform-origin: 500px 280px; animation: stnSpinRev 210s linear infinite; }
+@keyframes stnSpin { to { transform: rotate(360deg); } }
+@keyframes stnSpinRev { to { transform: rotate(-360deg); } }
+.stn-link { stroke: rgba(145,134,111,.22); stroke-width: 1; }
+.stn-core path, .stn-core line { stroke: var(--brass); }
+.stn-core .stn-core-accent { stroke: var(--brass-2); }
+.stn-host-dot { fill: #26211A; stroke: var(--sage); stroke-width: 1.6; }
+.stn-host-dot.off { stroke: var(--slate); stroke-dasharray: 2 3; }
+.stn-agent { cursor: pointer; }
+.stn-agent-dot.work { fill: var(--sage); }
+.stn-agent-dot.idle { fill: var(--slate); }
+.stn-agent-dot.attn { fill: var(--attn); }
+.stn-agent text { font-size: 11px; fill: #C6BAA4; }
+.stn-agent:hover text { fill: #F1EADC; }
+.stn-glow { fill: rgba(var(--attn-rgb),.08); stroke: var(--attn); stroke-width: 2; animation: stnGlow 2.2s ease-in-out infinite; }
+@keyframes stnGlow { 50% { opacity: .2; } }
+
+.stn-hud { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.stn-note { font-size: 12.5px; max-width: 78ch; }
+
+/* ============ Studio (.std-) ============ */
+.std-json { white-space: pre; font-size: 12px; line-height: 1.65; max-height: 340px; overflow: auto; }
+.std-events { max-height: 300px; overflow-y: auto; min-height: 60px; }
+.std-guide { display: grid; grid-template-columns: repeat(auto-fill, minmax(310px, 1fr)); gap: 14px; }
+.std-spec {
+  border: 1px solid var(--line); border-radius: var(--r-card);
+  background: var(--surface); padding: 12px 14px;
+}
+.std-wide { grid-column: 1 / -1; }
+.std-spec-label {
+  font: 600 var(--fs-eyebrow) var(--sans); letter-spacing: .12em;
+  text-transform: uppercase; color: var(--text-3); margin-bottom: 10px;
+}
+.std-specimen { border: 1px dashed var(--line-2); border-radius: var(--r-card); padding: 8px; }
+
+/* ============ Screens (.scr-) ============ */
+/* Adapted from the Proscenium prototype's views-a.css, trimmed to what
+   the real room renders: no fake browsers, agent cursors, or pretend
+   players — those were mock props. The "screens" are pictures of remote
+   displays, so they stay dark under both house themes, like a video
+   would. */
+.scr-stagegrid { display: grid; grid-template-columns: minmax(0, 1fr) 300px; gap: var(--gap); align-items: start; }
+@media (max-width: 1120px) { .scr-stagegrid { grid-template-columns: 1fr; } }
+
+.scr-screen {
+  position: relative; overflow: hidden;
+  border: 1px solid var(--line-2); border-radius: var(--r-ctl);
+  aspect-ratio: 16 / 10; background: #100E0C; color: #E9E2D2;
+}
+
+/* the placeholder tile: stands where the WebRTC stream will, until this
+   draft learns to render it */
+.scr-placeholder {
+  position: absolute; inset: 0; display: flex; flex-direction: column;
+  align-items: center; justify-content: center; gap: 8px; text-align: center;
+  padding: 18px; color: #B9AE95;
+}
+.scr-placeholder .icon { color: #6E6350; }
+.scr-placeholder .scr-res { font: 400 12px var(--mono); color: #8D8270; }
+.scr-placeholder .scr-note { font-size: 12.5px; max-width: 340px; }
+.scr-placeholder a { color: #9DC0E8; }
+
+/* recordings poster — a link to the classic dashboard's player, not a
+   player itself */
+.scr-poster {
+  position: relative; display: flex; align-items: center; justify-content: center;
+  aspect-ratio: 16 / 8.2; overflow: hidden;
+  border: 1px solid var(--line); border-radius: var(--r-ctl);
+  background:
+    radial-gradient(120% 130% at 20% 0%, rgba(210,162,76,.10), transparent 55%),
+    linear-gradient(150deg, #241E16, #16120F 65%);
+  transition: border-color var(--t-med);
+}
+.scr-poster:hover { border-color: rgba(210,162,76,.45); text-decoration: none; }
+.scr-play {
+  width: 52px; height: 52px; border-radius: 50%;
+  border: 1px solid rgba(242,232,213,.25); background: rgba(0,0,0,.42); color: #F1EADC;
+  display: inline-flex; align-items: center; justify-content: center;
+}
+
+/* ============ Files (.file-) ============ */
+.file-deskgrid { display: grid; grid-template-columns: 280px minmax(0, 1fr); gap: var(--gap); align-items: start; }
+@media (max-width: 900px) { .file-deskgrid { grid-template-columns: 1fr; } }
+
+/* whose-disk accent — the colored top edge on the viewer panel */
+.file-accent-slate { border-top: 2px solid var(--slate); }
+
+.file-chev { transition: transform var(--t-med) var(--ease); color: var(--text-3); }
+.file-folder.open > .file-chev { transform: rotate(90deg); }
+
+/* the 8 KB text peek */
+.file-pre {
+  margin: 0; white-space: pre-wrap; word-break: break-word;
+  font: 400 12px/1.65 var(--mono); color: var(--text-2);
+  max-height: 380px; overflow: auto;
+}
+
+/* ============ Machines (.mach-) ============ */
+.mach-petname { font: 500 21px var(--voice); letter-spacing: .01em; }

--- a/static/v3/v3-tokens.css
+++ b/static/v3/v3-tokens.css
@@ -1,0 +1,143 @@
+/* ============================================================
+   Proscenium — design tokens ("House lights")
+   Lamplight (dark, default) · Daylight (light)
+   Density: cozy · standard · studio
+   Doctrine: warm is yours (brass/attn/brick) — cool is the
+   machinery's (sage/slate/violet). Chips always carry words.
+   ============================================================ */
+
+@font-face {
+  font-family: 'Hanken Grotesk';
+  src: url('/fonts/hanken-grotesk-latin.woff2') format('woff2');
+  font-weight: 100 900; font-style: normal; font-display: swap;
+}
+@font-face {
+  font-family: 'JetBrains Mono';
+  src: url('/fonts/jetbrains-mono-latin.woff2') format('woff2');
+  font-weight: 100 800; font-style: normal; font-display: swap;
+}
+
+:root {
+  /* --- Lamplight (dark) ------------------------------------ */
+  --bg:        #14120F;
+  --bg-1:      #191612;
+  --surface:   #1E1A15;
+  --surface-2: #26211A;
+  --surface-3: #2F2920;
+  --line:      rgba(242,232,213,.09);
+  --line-2:    rgba(242,232,213,.16);
+  --text:      #F1EADC;
+  --text-2:    #C6BAA4;
+  --text-3:    #91866F;
+
+  --brass:     #D2A24C;  --brass-rgb: 210,162,76;
+  --brass-2:   #E4BC72;
+  --on-brass:  #241A08;
+  --attn:      #E8A33D;  --attn-rgb: 232,163,61;
+  --brick:     #D97B66;  --brick-rgb: 217,123,102;
+  --sage:      #8AB894;  --sage-rgb: 138,184,148;
+  --slate:     #7FA6C9;  --slate-rgb: 127,166,201;
+  --violet:    #A58BD4;  --violet-rgb: 165,139,212;
+
+  --shadow-card:    0 1px 0 rgba(255,240,214,.03) inset, 0 2px 10px rgba(0,0,0,.25);
+  --shadow-overlay: 0 12px 40px rgba(0,0,0,.5), 0 2px 8px rgba(0,0,0,.4);
+  --glow-brass: 0 0 0 1px rgba(var(--brass-rgb),.35), 0 0 24px rgba(var(--brass-rgb),.12);
+
+  /* --- Type ------------------------------------------------- */
+  --voice: 'Iowan Old Style', 'Palatino Linotype', Palatino, Georgia, 'Times New Roman', serif;
+  --sans:  'Hanken Grotesk', -apple-system, 'Segoe UI', system-ui, sans-serif;
+  --mono:  'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+
+  --fs-base: 14px;
+  --fs-voice: 16.5px;
+  --fs-display: 30px;
+  --fs-title: 19px;
+  --fs-eyebrow: 11px;
+  --lh: 1.5;
+
+  /* --- Shape & spacing -------------------------------------- */
+  --r-inset: 8px; --r-ctl: 10px; --r-card: 14px; --r-panel: 20px; --r-pill: 999px;
+  --pad-card: 16px 18px;
+  --gap: 14px;
+  --rail-w: 216px;
+  --content-max: 1060px;
+
+  /* --- Motion ------------------------------------------------ */
+  --t-fast: .13s; --t-med: .18s; --t-slow: .24s;
+  --ease: cubic-bezier(.2,.7,.3,1);
+}
+
+html[data-theme="daylight"] {
+  --bg:        #F4EFE4;
+  --bg-1:      #EDE7D8;
+  --surface:   #FFFCF4;
+  --surface-2: #F7F1E3;
+  --surface-3: #EFE7D4;
+  --line:      rgba(58,46,28,.13);
+  --line-2:    rgba(58,46,28,.22);
+  --text:      #262018;
+  --text-2:    #5F574A;
+  --text-3:    #8B8170;
+
+  --brass:     #A67C1F;  --brass-rgb: 166,124,31;
+  --brass-2:   #8F6A15;
+  --on-brass:  #FFF8E6;
+  --attn:      #B97F0F;  --attn-rgb: 185,127,15;
+  --brick:     #B84B39;  --brick-rgb: 184,75,57;
+  --sage:      #3F7D4E;  --sage-rgb: 63,125,78;
+  --slate:     #33608F;  --slate-rgb: 51,96,143;
+  --violet:    #6D52A8;  --violet-rgb: 109,82,168;
+
+  --shadow-card:    0 1px 0 rgba(255,255,255,.6) inset, 0 2px 8px rgba(84,64,30,.10);
+  --shadow-overlay: 0 14px 44px rgba(84,64,30,.22), 0 2px 8px rgba(84,64,30,.14);
+  --glow-brass: 0 0 0 1px rgba(var(--brass-rgb),.4), 0 0 20px rgba(var(--brass-rgb),.14);
+}
+
+/* --- Density ------------------------------------------------- */
+html[data-density="cozy"] {
+  --fs-base: 15px; --fs-voice: 17.5px; --fs-display: 33px; --fs-title: 21px;
+  --gap: 18px; --pad-card: 20px 22px; --content-max: 880px;
+}
+html[data-density="studio"] {
+  --fs-base: 13px; --fs-voice: 15px; --fs-display: 24px; --fs-title: 16px;
+  --gap: 10px; --pad-card: 12px 14px; --content-max: 1280px;
+  --rail-w: 232px;
+}
+
+/* --- Base ---------------------------------------------------- */
+* { box-sizing: border-box; }
+html, body { height: 100%; }
+body {
+  margin: 0;
+  font: 400 var(--fs-base)/var(--lh) var(--sans);
+  background:
+    radial-gradient(1200px 500px at 85% -10%, rgba(var(--brass-rgb),.06), transparent 60%),
+    var(--bg);
+  color: var(--text);
+  -webkit-font-smoothing: antialiased;
+  overflow: hidden;
+}
+::selection { background: rgba(var(--brass-rgb),.32); }
+.voice { font-family: var(--voice); }
+.mono  { font-family: var(--mono); font-size: .92em; }
+.dim   { color: var(--text-3); }
+.grow  { flex: 1 1 auto; }
+[hidden] { display: none !important; }
+
+:focus-visible {
+  outline: 2px solid var(--brass);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+a { color: var(--slate); text-decoration: none; }
+a:hover { text-decoration: underline; }
+a.chip:hover, a.stage-card:hover { text-decoration: none; }
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { animation-duration: .001s !important; transition-duration: .001s !important; }
+}
+
+/* Scrollbars */
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-thumb { background: var(--surface-3); border-radius: 8px; border: 2px solid var(--bg); }
+::-webkit-scrollbar-track { background: transparent; }

--- a/static/v3/v3.html
+++ b/static/v3/v3.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="lamplight" data-density="standard">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>Intendant</title>
+<meta name="description" content="The Intendant dashboard — the owner's box for the agentic house.">
+<link rel="icon" href="/icon-128.png">
+<link rel="stylesheet" href="/v3/v3-tokens.css">
+<link rel="stylesheet" href="/v3/v3-app.css">
+<link rel="stylesheet" href="/v3/v3-rooms.css">
+</head>
+<body>
+
+<!-- Curtain lift: first paint per tab, skipped under reduced motion -->
+<div id="curtain" aria-hidden="true">
+  <svg viewBox="70 80 372 372" width="72" height="72" aria-hidden="true">
+    <path d="M128 384 L128 240 Q128 128 256 128 Q384 128 384 240 L384 384"
+          fill="none" stroke="currentColor" stroke-width="14" stroke-linecap="round"/>
+    <line x1="256" y1="220" x2="256" y2="330" stroke="currentColor" stroke-width="14" stroke-linecap="round"/>
+    <line x1="236" y1="300" x2="330" y2="180" stroke="var(--brass)" stroke-width="10" stroke-linecap="round"/>
+  </svg>
+</div>
+
+<div id="app">
+  <nav id="rail" aria-label="Rooms">
+    <div id="rail-brand" title="Intendant">
+      <svg viewBox="70 80 372 372" width="30" height="30" aria-hidden="true">
+        <path d="M128 384 L128 240 Q128 128 256 128 Q384 128 384 240 L384 384"
+              fill="none" stroke="currentColor" stroke-width="16" stroke-linecap="round"/>
+        <line x1="256" y1="220" x2="256" y2="330" stroke="currentColor" stroke-width="16" stroke-linecap="round"/>
+        <line x1="236" y1="300" x2="330" y2="180" stroke="var(--brass)" stroke-width="11" stroke-linecap="round"/>
+        <circle cx="196" cy="360" r="11" fill="var(--brass)"/>
+        <circle cx="316" cy="360" r="11" fill="var(--brass)" opacity=".55"/>
+      </svg>
+      <span class="rail-label wordmark">Intendant</span>
+    </div>
+    <div id="rail-rooms" role="list"></div>
+    <div class="grow"></div>
+    <div id="rail-vantages"></div>
+    <a class="rail-item" id="rail-v2" href="/" title="Back to the classic dashboard">
+      <span class="icon" data-icon="external"></span>
+      <span class="rail-label">Classic (V2)</span>
+    </a>
+    <div id="rail-foot">
+      <button id="rail-queue" class="rail-item" title="Needs you (queue)">
+        <span class="icon" data-icon="doorbell"></span>
+        <span class="rail-label">Needs you</span>
+        <span class="badge-count" id="rail-queue-count" hidden></span>
+      </button>
+      <div id="rail-identity" class="authline"></div>
+    </div>
+  </nav>
+
+  <div id="column">
+    <header id="topbar">
+      <div id="topbar-title" class="voice"></div>
+      <div class="grow"></div>
+      <div id="topbar-facts" class="mono dim"></div>
+      <button class="icon-btn" id="btn-density" title="Density: Cozy / Standard / Studio">
+        <span class="icon" data-icon="density"></span><span id="density-label" class="hide-cozy"></span>
+      </button>
+      <button class="icon-btn" id="btn-theme" title="Theme: Lamplight / Daylight">
+        <span class="icon" data-icon="theme"></span>
+      </button>
+      <button id="btn-palette" title="Search everything (⌘K)">
+        <span class="icon" data-icon="search"></span><span class="kbd-hint">⌘K</span>
+      </button>
+    </header>
+
+    <main id="main" role="main" tabindex="-1"></main>
+
+    <footer id="composer" aria-label="Talk to the house">
+      <div id="composer-target" class="chip chip-brass" hidden></div>
+      <div id="composer-box">
+        <button class="icon-btn" title="Attach" id="composer-attach"><span class="icon" data-icon="attach"></span></button>
+        <textarea id="composer-input" rows="1" placeholder="Ask the house anything…"></textarea>
+        <button class="icon-btn" title="Speak (live voice)" id="composer-mic"><span class="icon" data-icon="mic"></span></button>
+        <button class="icon-btn btn-send" title="Send (⌘↵)" id="composer-send"><span class="icon" data-icon="send"></span></button>
+      </div>
+      <div id="composer-hint" class="dim">@ aims at a session · / for power grammar · the house answers in the thread</div>
+    </footer>
+  </div>
+</div>
+
+<div id="palette" class="overlay" hidden>
+  <div id="palette-panel" role="dialog" aria-label="Search everything">
+    <div id="palette-input-row">
+      <span class="icon" data-icon="search"></span>
+      <input id="palette-input" type="text" placeholder="Search rooms, work, settings, actions…" autocomplete="off" spellcheck="false">
+      <span class="kbd-hint">esc</span>
+    </div>
+    <div id="palette-results" role="listbox"></div>
+    <div id="palette-foot" class="dim">↑↓ move · ↵ open · every setting, folded or not</div>
+  </div>
+</div>
+
+<div id="queue-drawer" class="overlay" hidden>
+  <div id="queue-panel" role="dialog" aria-label="Needs you"></div>
+</div>
+
+<div id="toasts" aria-live="polite"></div>
+
+<script src="/v3/js/v3-icons.js"></script>
+<script src="/v3/js/v3-transport.js"></script>
+<script src="/v3/js/v3-data.js"></script>
+<script src="/v3/js/v3-ui.js"></script>
+<script src="/v3/js/v3-palette.js"></script>
+<script src="/v3/js/views/home.js"></script>
+<script src="/v3/js/views/work.js"></script>
+<script src="/v3/js/views/session.js"></script>
+<script src="/v3/js/views/screens.js"></script>
+<script src="/v3/js/views/files.js"></script>
+<script src="/v3/js/views/machines.js"></script>
+<script src="/v3/js/views/people.js"></script>
+<script src="/v3/js/views/books.js"></script>
+<script src="/v3/js/views/settings.js"></script>
+<script src="/v3/js/views/station.js"></script>
+<script src="/v3/js/views/studio.js"></script>
+<script src="/v3/js/v3-app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
# V3 "Proscenium" — a second dashboard, opt-in at `/v3` (draft, not for merge)

**Draft — do not merge.** This is the V3 dashboard concept, implemented end-to-end and verified against a mock-provider daemon, opened as a draft so the fleet can live with it. The classic dashboard is untouched as the default at `/`; V3 is one click away via the "Try V3 ✦" nav link.

## What it is

The full design story is in **`docs/design/proscenium/`** (concept, per-room specs, power model, visual language, route-by-route capability map, and a self-contained interactive concept prototype). The one-paragraph version: the current dashboard is a superb operator's cockpit organized by subsystem; V3 is organized around the owner–house relationship from the product's own thesis — a first-person **conversation with the house** as Home, a unified **Needs-You queue** for every decision the daemon can't make alone, **two registers** (voice first, instrument one unfold away) with a Cozy/Standard/Studio density dial, **eight intent-named rooms** plus Station/Studio vantages, and **one universal ⌘K index** that lands on any folded setting by plain name.

- `docs/design/proscenium/README.md` — the concept
- `docs/design/proscenium/v3-plan.md` — the build contract and decisions
- `docs/design/proscenium/prototype/` — the clickable mock prototype (open `index.html`)

## What's in the box

**Rust (pure additions, +tests):**
- `web_gateway/static_assets.rs` — embed `static/v3/*` (single declared `V3_ASSETS` table driving both the embedded map and the dispatch allowlist — derive, don't mirror); `INTENDANT_V3_HTML_PATH` dev override (whole-dir, re-read per request, traversal-safe, loud-500 without path echo, content-type by extension).
- `web_gateway/http_dispatch.rs` — `/v3` entry arm (override-aware, ETag+gzip per spawn, no-cache, deny-framing) + `/v3/*` asset arm; undeclared paths fall through like any unknown path.
- `web_gateway/listener.rs` — spawn wiring for the override + cache.
- `web_gateway/access_gates.rs` — `/v3` joins the public shell paths (remote certless browsers get the shell at `role:none`, exactly like `/`); pinned test updated.
- 7 new hermetic `v3_*` tests.

**Front-end (`static/v3/`):** plain HTML/CSS/JS, no build step, one `V3` namespace, classic scripts — a clean-room implementation over the daemon's public rails (`/ws` events + ControlMsgs + declared HTTP routes; no tunnel dependency, no IAM change). All ten destinations: Home (Queue + Conversation + Now Playing + Today ribbon), Work + Session Space, Screens, Files, Machines, People & Keys, Books, Settings (question-sorted, one catalog driving the room *and* the ⌘K settings lane), Station (constellation), Studio (workbench + component field guide).

**Classic (`static/app/`):** the "Try V3 ✦" nav link (fragments edited; `static/app.html` regenerated via the assembler — regen gate green).

**Docs:** `web-dashboard.md` V3 chapter, `configuration.md` override entry.

## Beyond parity (daemon-capable, never-before-surfaced)

- **Agenda scheduler UI** — propose/approve/revoke scheduled sessions (Books → The List; Home's Today ribbon). First frontend for `agenda/scheduler.rs`.
- **Unified doorbells in the Queue** — peer pairing requests, hosted-control asks, federated peer approvals (`POST /api/peers/{id}/approval`), enrollment requests, fuel status — one severity-ordered inbox instead of five hidden corners.

## Honest gaps (linked, not hidden)

V3 links to the classic dashboard rather than rebuilding: the WebRTC live display stream + input authority, the PTY terminal, the tunnel-only vault/egress/custody surfaces, the managed-context rewind/fission composer, and the WebGPU Station canvas (V3 renders its own small constellation and links the real one). Each gap is stated in the room itself and in the Studio's "what V3 doesn't rebuild yet" card.

## Verification

- **End-to-end against a mock-provider daemon** (`PROVIDER=mock`, `edit_file` gated by the default `file_write=ask` rule): composer task → session starts → approval lands in the Queue → approved in-page → edit executes → "finished" milestone in the thread. Playwright-driven, screenshots reviewed for every room, both themes, all three densities.
- Wire-flow traced event-by-event (session_started → approval_required → approval_resolved → done_signal) — plus the fixes it forced: `done_signal` completion handling, tool-display-name queue titles, presence-noise filtering, `in_progress` phase mapping.
- `cargo test --bins v3` → 8 passed; full `cargo test --bins` + clippy + rustfmt in the local battery before this PR.
- No new dependencies, no unsafe, no gateway_routes edits, no behavior change to existing serving arms (0 removed Rust lines outside access_gates' one match arm).

## Try it

```bash
cargo build --bin intendant --bin intendant-runtime
./target/debug/intendant --tls --web 8791
# open https://localhost:8791/v3  (or click "Try V3 ✦" in the classic nav)
# iterate: INTENDANT_V3_HTML_PATH=$PWD/static/v3 ./target/debug/intendant --tls --web 8791
```
