### PR TITLE
Security quick wins: daemon-lifecycle containment, executable-repoint gate, mixed askHuman rail

### DIFF
--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -292,9 +292,11 @@ surface.
 
 ## askHuman Behavior
 
-- Under the **dashboard**, `askHuman` surfaces as a question card; the answer
-  is written to the session-scoped response file (`--json` accepts an `input`
-  command for the same file).
+- Under the **dashboard**, `askHuman` surfaces as a question card and the
+  question consumes the whole batch: the askHuman call returns the answer,
+  and any other commands in a mixed batch return a not-executed note asking
+  the model to re-issue them. (`--json` instead accepts an `input` command
+  answered through the session-scoped response file.)
 - In **headless mode** (no dashboard, non-interactive stdin), `askHuman` cannot
   be answered interactively, so the loop tells the model to continue with
   explicit assumptions rather than wait.

--- a/docs/src/credential-custody.md
+++ b/docs/src/credential-custody.md
@@ -273,6 +273,17 @@ operation; granting requires a session whose principal holds a new
 `credentials.manage` gate (IAM v2 catalog), so a scoped guest session
 cannot fuel or drain a daemon.
 
+The same gate covers **executable repointing**: the external-agent
+command paths (`codex_command`, `codex_managed_command`,
+`claude_command`) decide which binary runs with the machine's
+credentials and workspace, so changing them — via POST `/api/settings`
+(per-field: everything else on the settings surface stays
+Settings-class, and a full-payload round trip that merely echoes the
+current values saves fine) or via the `SetCodexCommand` /
+`SetCodexManagedCommand` ControlMsg twins — requires
+`credentials.manage`. A federated peer or scoped session holding only
+Settings cannot repoint what the daemon executes.
+
 **Lifetime.** Two knobs, both user-visible:
 
 - **Connected renewal**: while any granting browser session is attached,

--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -123,7 +123,13 @@ session) is refused `set_autonomy` and `approve_all` outright — both rewrite
 the daemon-global shared autonomy, which would let a supervised agent widen
 its own approval policy — and `approve`/`deny`/`skip` resolve only approvals
 raised by the caller's own session (cross-session resolution is denied;
-unknown ownership fails closed). This mirrors `grant_user_display`'s
+unknown ownership fails closed). The same containment covers daemon
+lifecycle: `quit`, `schedule_controller_restart`, and
+`cancel_controller_restart` are refused to agent-session callers (a
+supervised agent must not stop or bounce its supervisor), while
+`controller_turn_complete` (the session's own completion signal inside an
+owner-scheduled restart) and the controller-loop halt tools (the autonomous
+loop's self-stop verbs) stay open. This mirrors `grant_user_display`'s
 owner-surface rule: owner surfaces (dashboard, `intendant ctl` on loopback,
 enrolled root mTLS clients, the stdio transport) and deliberately granted
 non-agent principals keep the full surface. The point of the

--- a/src/bin/caller/access/access_policy.rs
+++ b/src/bin/caller/access/access_policy.rs
@@ -942,11 +942,19 @@ pub fn control_msg_operation(ctrl: &ControlMsg) -> PeerOperation {
         | ControlMsg::Skip { .. }
         | ControlMsg::ApproveAll { .. }
         | ControlMsg::AnswerQuestion { .. } => PeerOperation::Approval,
+        // Executable repointing is credential-adjacent, not Settings: the
+        // command path decides WHICH binary external-agent sessions run
+        // with the owner's credentials and workspace, so it takes the same
+        // credentials.manage authority as /api/api-keys (an operation no
+        // peer profile grants). POST /api/settings enforces the same rule
+        // per-field (`executable_repoint_denials`); `claude_command` has no
+        // ControlMsg twin and is covered there alone.
+        ControlMsg::SetCodexCommand { .. } | ControlMsg::SetCodexManagedCommand { .. } => {
+            PeerOperation::CredentialsManage
+        }
         ControlMsg::SetAutonomy { .. }
         | ControlMsg::SetApprovalRule { .. }
         | ControlMsg::SetExternalAgent { .. }
-        | ControlMsg::SetCodexCommand { .. }
-        | ControlMsg::SetCodexManagedCommand { .. }
         | ControlMsg::SetCodexSandbox { .. }
         | ControlMsg::SetCodexApprovalPolicy { .. }
         | ControlMsg::SetCodexModel { .. }

--- a/src/bin/caller/agent_loop.rs
+++ b/src/bin/caller/agent_loop.rs
@@ -2287,79 +2287,79 @@ pub(crate) async fn run_agent_loop(
             // AnswerQuestion into this session's approval registry) instead
             // of dispatching to the runtime, which would park on the
             // human_question file no frontend watches under the daemon.
-            // Scope: batches that are entirely askHuman (the shape models
-            // emit — a blocking question stands alone); a mixed batch keeps
-            // the legacy path and logs why.
+            // ANY batch containing askHuman is consumed by the question (the
+            // text loop's ratified semantics): the askHuman call gets the
+            // answer, and the other calls of a mixed batch get a not-executed
+            // note asking the model to re-issue them. (A mixed batch
+            // previously fell to the runtime file prompt nothing watched.)
             if !headless && json_approval.is_none() && batch_facts.has_ask_human {
-                if batch_facts.all_ask_human {
-                    let question = batch_facts
-                        .ask_human_question
-                        .clone()
-                        .unwrap_or_else(|| "The agent asked for your input.".to_string());
-                    slog(&session_log, |l| l.human_question(&question));
-                    let question_id = turn as u64;
-                    let (tx, rx) = tokio::sync::oneshot::channel();
-                    approval_registry.lock().unwrap().insert(question_id, tx);
-                    bus.send(AppEvent::UserQuestionRequired {
-                        session_id: local_session_id.clone(),
-                        id: question_id,
-                        questions: vec![crate::types::UserQuestion {
-                            question: question.clone(),
-                            header: String::new(),
-                            options: Vec::new(),
-                            multi_select: false,
-                        }],
-                    });
-                    let answer = match rx.await {
-                        Ok(event::ApprovalResponse::Answer { answers }) => answers
-                            .get(&question)
-                            .cloned()
-                            .or_else(|| answers.values().next().cloned())
-                            .unwrap_or_default(),
-                        Ok(_) | Err(_) => String::new(),
-                    };
-                    let answered = !answer.trim().is_empty();
-                    let reply = if answered {
-                        slog(&session_log, |l| l.human_response_sent());
-                        answer
-                    } else {
-                        "The user dismissed the question without answering. Proceed with \
-                         your best judgment; you can re-ask later if it is still relevant."
-                            .to_string()
-                    };
-                    let mut first_result_seq: Option<u64> = None;
-                    for (call_id, tool_name) in &batch.call_id_names {
-                        if handled_call_ids.contains(call_id) {
-                            continue;
-                        }
-                        let seq = conversation.add_tool_result(call_id, tool_name, &reply);
+                let question = batch_facts
+                    .ask_human_question
+                    .clone()
+                    .unwrap_or_else(|| "The agent asked for your input.".to_string());
+                slog(&session_log, |l| l.human_question(&question));
+                let question_id = turn as u64;
+                let (tx, rx) = tokio::sync::oneshot::channel();
+                approval_registry.lock().unwrap().insert(question_id, tx);
+                bus.send(AppEvent::UserQuestionRequired {
+                    session_id: local_session_id.clone(),
+                    id: question_id,
+                    questions: vec![crate::types::UserQuestion {
+                        question: question.clone(),
+                        header: String::new(),
+                        options: Vec::new(),
+                        multi_select: false,
+                    }],
+                });
+                let answer = match rx.await {
+                    Ok(event::ApprovalResponse::Answer { answers }) => answers
+                        .get(&question)
+                        .cloned()
+                        .or_else(|| answers.values().next().cloned())
+                        .unwrap_or_default(),
+                    Ok(_) | Err(_) => String::new(),
+                };
+                let answered = !answer.trim().is_empty();
+                let reply = if answered {
+                    slog(&session_log, |l| l.human_response_sent());
+                    answer
+                } else {
+                    "The user dismissed the question without answering. Proceed with \
+                     your best judgment; you can re-ask later if it is still relevant."
+                        .to_string()
+                };
+                const NOT_EXECUTED: &str = "Not executed: this batch paused for the \
+                     user's answer to askHuman. Read the answer from the askHuman \
+                     result and re-issue this command if it is still needed.";
+                let mut first_result_seq: Option<u64> = None;
+                for (call_id, tool_name) in &batch.call_id_names {
+                    if handled_call_ids.contains(call_id) {
+                        continue;
+                    }
+                    let is_ask = tool_name == "ask_human";
+                    let text = if is_ask { reply.as_str() } else { NOT_EXECUTED };
+                    let seq = conversation.add_tool_result(call_id, tool_name, text);
+                    if is_ask {
                         first_result_seq.get_or_insert(seq);
                     }
-                    // Native-tool askHuman answers enter the conversation as
-                    // tool results; project the raw answer into the message
-                    // lane referencing that result's seq (rewind cuts cover
-                    // it through ref_seq).
-                    if answered {
-                        if let Some(seq) = first_result_seq {
-                            slog(&session_log, |l| {
-                                let _ = l.conversation_message_user(
-                                    seq,
-                                    MessageProvenance::AskHumanAnswer,
-                                    &reply,
-                                    Some(seq),
-                                );
-                            });
-                        }
-                    }
-                    continue;
                 }
-                slog(&session_log, |l| {
-                    l.warn(
-                        "askHuman arrived mixed into a command batch; the runtime file \
-                         prompt handles it, which no dashboard surfaces — answer via MCP \
-                         or expect the model to re-ask",
-                    )
-                });
+                // Native-tool askHuman answers enter the conversation as
+                // tool results; project the raw answer into the message
+                // lane referencing the first askHuman result's seq (rewind
+                // cuts cover it through ref_seq).
+                if answered {
+                    if let Some(seq) = first_result_seq {
+                        slog(&session_log, |l| {
+                            let _ = l.conversation_message_user(
+                                seq,
+                                MessageProvenance::AskHumanAnswer,
+                                &reply,
+                                Some(seq),
+                            );
+                        });
+                    }
+                }
+                continue;
             }
 
             // Autonomy / approval check (same as text path)

--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -1331,12 +1331,20 @@ pub(crate) async fn api_settings_save_response(
         session.runtime_settings.settings_root.clone()
     }
     .or_else(|| runtime.project_root.clone());
+    // Same per-field escalation as the HTTP twin: executable repointing
+    // requires credentials.manage; everything else rides the row's
+    // Settings authorization.
+    let caller_may_manage_credentials = runtime
+        .grant
+        .access_decision(crate::peer::access_policy::PeerOperation::CredentialsManage)
+        .allowed;
     frame_api_response(
         id,
         crate::web_gateway::settings_post_api_response(
             &body_text,
             settings_root.as_deref(),
             &runtime.bus,
+            caller_may_manage_credentials,
         ),
         "settings save",
     )
@@ -2663,7 +2671,7 @@ mod tests {
         let payload = parity_settings_payload();
         let body_text = params_body_text(Some(&payload));
         let (status, http_body) = parity_http_status_and_body(
-            crate::web_gateway::settings_post_api_response(&body_text, None, &rt.bus),
+            crate::web_gateway::settings_post_api_response(&body_text, None, &rt.bus, true),
         );
         assert_eq!(status, 400);
         let frame =
@@ -2683,6 +2691,7 @@ mod tests {
                 &body_text,
                 Some(http_dir.path()),
                 &rt.bus,
+                true,
             ));
         assert_eq!(status, 200);
         assert_eq!(http_body, serde_json::json!({"ok": true, "applied": true}));
@@ -3805,6 +3814,36 @@ mod tests {
             crate::access::access_policy::control_msg_operation(&msg),
             crate::peer::access_policy::PeerOperation::SessionManage,
         );
+    }
+
+    /// Executable repointing rides the settings carry allowlist but
+    /// classifies as credentials.manage: the command path decides which
+    /// binary runs with the owner's credentials, so a Settings-only caller
+    /// (peer profiles; scoped humans without the grant) cannot repoint it
+    /// through the ControlMsg lane any more than through POST /api/settings.
+    #[test]
+    fn executable_repoint_control_msgs_classify_as_credentials_manage() {
+        for (probe, action) in [
+            (
+                serde_json::json!({ "action": "set_codex_command", "command": "x" }),
+                "set_codex_command",
+            ),
+            (
+                serde_json::json!({ "action": "set_codex_managed_command", "command": "x" }),
+                "set_codex_managed_command",
+            ),
+        ] {
+            let msg: ControlMsg = serde_json::from_value(probe).expect("parses");
+            assert_eq!(dashboard_control_msg_action(&msg), action);
+            assert!(
+                dashboard_control_msg_allowed(&msg),
+                "stays on the carry allowlist (root dashboard still saves)"
+            );
+            assert_eq!(
+                crate::access::access_policy::control_msg_operation(&msg),
+                crate::peer::access_policy::PeerOperation::CredentialsManage,
+            );
+        }
     }
 
     /// Every allowlisted action name must be a real `ControlMsg` wire name —

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -618,8 +618,11 @@ impl IntendantServer {
             "schedule_controller_restart" => {
                 let Parameters(params) = parse_params::<ScheduleControllerRestartParams>(args)?;
                 Ok(text_tool_result(
-                    self.schedule_controller_restart_scoped(params, McpToolScope::from_actor(&actor))
-                        .await,
+                    self.schedule_controller_restart_scoped(
+                        params,
+                        McpToolScope::from_actor(&actor),
+                    )
+                    .await,
                 ))
             }
             "controller_turn_complete" => {

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -564,7 +564,9 @@ impl IntendantServer {
                 let params = parse_params::<SetVerbosityParams>(args)?;
                 Ok(text_tool_result(self.set_verbosity(params).await))
             }
-            "quit" => Ok(text_tool_result(self.quit().await)),
+            "quit" => Ok(text_tool_result(
+                self.quit_scoped(McpToolScope::from_actor(&actor)).await,
+            )),
             "start_task" => {
                 let params =
                     parse_params::<StartTaskParams>(with_default_mcp_session_id(args, session_id))?;
@@ -614,9 +616,10 @@ impl IntendantServer {
                 Ok(text_tool_result(self.fission_control(params).await))
             }
             "schedule_controller_restart" => {
-                let params = parse_params::<ScheduleControllerRestartParams>(args)?;
+                let Parameters(params) = parse_params::<ScheduleControllerRestartParams>(args)?;
                 Ok(text_tool_result(
-                    self.schedule_controller_restart(params).await,
+                    self.schedule_controller_restart_scoped(params, McpToolScope::from_actor(&actor))
+                        .await,
                 ))
             }
             "controller_turn_complete" => {
@@ -627,9 +630,10 @@ impl IntendantServer {
             }
             "get_restart_status" => Ok(text_tool_result(self.get_restart_status().await)),
             "cancel_controller_restart" => {
-                let params = parse_params::<CancelControllerRestartParams>(args)?;
+                let Parameters(params) = parse_params::<CancelControllerRestartParams>(args)?;
                 Ok(text_tool_result(
-                    self.cancel_controller_restart(params).await,
+                    self.cancel_controller_restart_scoped(params, McpToolScope::from_actor(&actor))
+                        .await,
                 ))
             }
             "request_controller_loop_halt" => {
@@ -923,6 +927,25 @@ fn scope_denies_pending_approval(state: &McpAppState, scope: McpToolScope<'_>) -
          dashboard or `intendant ctl`."
             .to_string(),
     )
+}
+
+/// Denial when `scope` may not drive daemon lifecycle (`quit`, scheduling
+/// or cancelling controller restarts): a supervised agent session must not
+/// stop or bounce the daemon that supervises it — the same H5 class as
+/// `set_autonomy`/`approve_all`. `controller_turn_complete` (the session's
+/// own completion signal inside an owner-scheduled restart) and the
+/// controller-loop halt tools (the autonomous loop's self-stop verbs) stay
+/// open.
+fn scope_denies_daemon_lifecycle(scope: McpToolScope<'_>, tool: &str) -> Option<String> {
+    if matches!(scope, McpToolScope::AgentSession { .. }) {
+        Some(format!(
+            "{tool} stops or restarts the daemon that supervises you (and every other \
+             session it runs) and is not available to supervised agent sessions; ask the \
+             user (ask_user) if you believe the daemon should stop or restart."
+        ))
+    } else {
+        None
+    }
 }
 
 /// Resolve the pending approval prompt with `response` — the single handler
@@ -1739,6 +1762,14 @@ impl IntendantServer {
 
     #[tool(description = "Shut down the Intendant agent.")]
     async fn quit(&self) -> String {
+        // Stdio MCP transport: owner surface (the owner's own client config).
+        self.quit_scoped(McpToolScope::Unrestricted).await
+    }
+
+    pub(crate) async fn quit_scoped(&self, scope: McpToolScope<'_>) -> String {
+        if let Some(reason) = scope_denies_daemon_lifecycle(scope, "quit") {
+            return format_outcome(ActionOutcome::Denied { reason });
+        }
         let mut s = self.state.write().await;
         let outcome = request_quit(&mut s);
         format_outcome(outcome)
@@ -2830,6 +2861,86 @@ pub(crate) mod tests {
             .expect("dispatch");
         assert!(dispatch_result_text(&result).contains("Autonomy set to"));
         assert_eq!(autonomy.read().await.level, AutonomyLevel::Full);
+    }
+
+    /// H5 containment: daemon-lifecycle tools — a supervised agent session
+    /// cannot stop the daemon (`quit`) or schedule/cancel controller
+    /// restarts; the owner surface keeps the full surface.
+    #[tokio::test]
+    async fn agent_sessions_cannot_stop_or_restart_the_daemon() {
+        let bus = EventBus::new();
+        let state = test_state();
+        let server = IntendantServer::new(state.clone(), bus);
+
+        let result = server
+            .call_tool_by_name_as_caller(
+                "quit",
+                serde_json::json!({}),
+                Some("sess-a"),
+                None,
+                agent_session_caller("sess-a"),
+            )
+            .await
+            .expect("dispatch");
+        assert!(
+            dispatch_result_text(&result).contains("Denied"),
+            "quit must be denied to agent sessions"
+        );
+        assert!(
+            !state.read().await.should_quit,
+            "denied quit must not set the shutdown flag"
+        );
+
+        let result = server
+            .call_tool_by_name_as_caller(
+                "schedule_controller_restart",
+                serde_json::json!({ "controller_id": "loop-a", "north_star_goal": "goal" }),
+                Some("sess-a"),
+                None,
+                agent_session_caller("sess-a"),
+            )
+            .await
+            .expect("dispatch");
+        assert!(
+            dispatch_result_text(&result).contains("Denied"),
+            "schedule_controller_restart must be denied to agent sessions"
+        );
+        assert!(
+            state.read().await.controller_restart.is_none(),
+            "denied scheduling must not arm a restart"
+        );
+
+        let result = server
+            .call_tool_by_name_as_caller(
+                "cancel_controller_restart",
+                serde_json::json!({}),
+                Some("sess-a"),
+                None,
+                agent_session_caller("sess-a"),
+            )
+            .await
+            .expect("dispatch");
+        assert!(
+            dispatch_result_text(&result).contains("Denied"),
+            "cancel_controller_restart must be denied to agent sessions"
+        );
+
+        // The owner surface (stdio / dashboard lanes) still quits.
+        let result = server
+            .call_tool_by_name_as_caller(
+                "quit",
+                serde_json::json!({}),
+                None,
+                None,
+                ToolCaller::from_gate(
+                    &crate::access::iam::AccessPrincipal::root_dashboard_session("test", "https"),
+                    None,
+                ),
+            )
+            .await
+            .expect("dispatch");
+        assert!(!dispatch_result_text(&result).contains("Denied"));
+        assert!(state.read().await.should_quit);
     }
 
     /// H5 containment: agent-session callers resolve only approvals raised

--- a/src/bin/caller/mcp/tools_managed.rs
+++ b/src/bin/caller/mcp/tools_managed.rs
@@ -715,8 +715,21 @@ impl IntendantServer {
     )]
     pub(crate) async fn schedule_controller_restart(
         &self,
-        Parameters(mut params): Parameters<ScheduleControllerRestartParams>,
+        Parameters(params): Parameters<ScheduleControllerRestartParams>,
     ) -> String {
+        // Stdio MCP transport: owner surface (the owner's own client config).
+        self.schedule_controller_restart_scoped(params, McpToolScope::Unrestricted)
+            .await
+    }
+
+    pub(crate) async fn schedule_controller_restart_scoped(
+        &self,
+        mut params: ScheduleControllerRestartParams,
+        scope: McpToolScope<'_>,
+    ) -> String {
+        if let Some(reason) = scope_denies_daemon_lifecycle(scope, "schedule_controller_restart") {
+            return schedule_error_response(format!("Denied: {reason}"), None, None);
+        }
         normalize_schedule_controller_restart_params(&mut params);
         if let Err(e) = validate_schedule_controller_restart_params(&params) {
             return schedule_error_response(e, None, None);
@@ -898,8 +911,21 @@ impl IntendantServer {
     #[tool(description = "Cancel a scheduled controller restart.")]
     pub(crate) async fn cancel_controller_restart(
         &self,
-        Parameters(mut params): Parameters<CancelControllerRestartParams>,
+        Parameters(params): Parameters<CancelControllerRestartParams>,
     ) -> String {
+        // Stdio MCP transport: owner surface (the owner's own client config).
+        self.cancel_controller_restart_scoped(params, McpToolScope::Unrestricted)
+            .await
+    }
+
+    pub(crate) async fn cancel_controller_restart_scoped(
+        &self,
+        mut params: CancelControllerRestartParams,
+        scope: McpToolScope<'_>,
+    ) -> String {
+        if let Some(reason) = scope_denies_daemon_lifecycle(scope, "cancel_controller_restart") {
+            return schedule_error_response(format!("Denied: {reason}"), None, None);
+        }
         normalize_cancel_controller_restart_params(&mut params);
         let mut s = self.state.write().await;
         let log_dir = s.log_dir.clone();

--- a/src/bin/caller/tool_batch.rs
+++ b/src/bin/caller/tool_batch.rs
@@ -12,13 +12,11 @@ use crate::{mcp_client, provider, tools};
 /// runtime spawn on the hottest controller path.
 #[derive(Debug, Clone, Default)]
 pub struct BatchFacts {
-    /// Any command is `askHuman` (selects the runtime's no-timeout path).
+    /// Any command is `askHuman` (selects the runtime's no-timeout path;
+    /// under the daemon, the question rail consumes the whole batch —
+    /// mixed batches included, whose other commands answer with a
+    /// re-issue note).
     pub has_ask_human: bool,
-    /// The batch consists ENTIRELY of `askHuman` commands — the shape models
-    /// actually emit for a blocking question. The question-rail interception
-    /// only fires for this shape; a mixed batch would need the controller to
-    /// reorder execution around the runtime. `false` for an empty batch.
-    pub all_ask_human: bool,
     /// Question text of the first `askHuman` command that carries one.
     pub ask_human_question: Option<String>,
     /// Any command is `captureScreen` (Xvfb auto-launch trigger).
@@ -45,10 +43,7 @@ impl BatchFacts {
         let Some(commands) = parsed.get("commands").and_then(|v| v.as_array()) else {
             return Self::opaque(json_str);
         };
-        let mut facts = BatchFacts {
-            all_ask_human: !commands.is_empty(),
-            ..Self::default()
-        };
+        let mut facts = Self::default();
         let mut preview_parts: Vec<String> = Vec::with_capacity(commands.len());
         for cmd in commands {
             let function = cmd.get("function").and_then(|v| v.as_str()).unwrap_or("?");
@@ -70,9 +65,6 @@ impl BatchFacts {
                     }
                 }
                 _ => {}
-            }
-            if function != "askHuman" {
-                facts.all_ask_human = false;
             }
             if let Some(part) = command_preview_part(function, cmd) {
                 preview_parts.push(part);
@@ -431,14 +423,12 @@ mod tests {
             r#"{"commands":[{"function":"askHuman","nonce":1,"question":"Which DB?"}]}"#,
         );
         assert!(solo.has_ask_human);
-        assert!(solo.all_ask_human);
         assert_eq!(solo.ask_human_question.as_deref(), Some("Which DB?"));
 
         let mixed = BatchFacts::from_json(
             r#"{"commands":[{"function":"execAsAgent","nonce":1,"command":"ls"},{"function":"askHuman","nonce":2,"question":"ok?"}]}"#,
         );
-        assert!(mixed.has_ask_human);
-        assert!(!mixed.all_ask_human, "mixed batch is not all-askHuman");
+        assert!(mixed.has_ask_human, "mixed batches detect askHuman too");
         assert_eq!(mixed.ask_human_question.as_deref(), Some("ok?"));
 
         // The question comes from the first askHuman that HAS one (the old
@@ -456,10 +446,9 @@ mod tests {
             r#"{"commands":[{"function":"execAsAgent","nonce":1,"command":"echo \"askHuman\""}]}"#,
         );
         assert!(!embedded.has_ask_human);
-        assert!(!embedded.all_ask_human);
 
         let empty = BatchFacts::from_json(r#"{"commands":[]}"#);
-        assert!(!empty.all_ask_human, "empty batch is not all-askHuman");
+        assert!(!empty.has_ask_human);
     }
 
     #[test]

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -1205,11 +1205,18 @@ pub(crate) async fn serve_http_request(
             }
             RouteHandlerId::SettingsPost => {
                 let settings_root = runtime_settings.settings_root.or(project_root);
+                // Executable-repointing fields escalate per-field to the
+                // /api/api-keys gate (credentials.manage); the route itself
+                // stays Settings-class.
+                let caller_may_manage_credentials = http_access_context
+                    .decision(crate::peer::access_policy::PeerOperation::CredentialsManage)
+                    .allowed;
                 return handle_settings_post(
                     stream,
                     route_body,
                     bus,
                     settings_root,
+                    caller_may_manage_credentials,
                     route.cors,
                     fleet_cors_origin.as_deref(),
                 )

--- a/src/bin/caller/web_gateway/settings.rs
+++ b/src/bin/caller/web_gateway/settings.rs
@@ -643,13 +643,55 @@ pub(crate) fn settings_post_result(
     body_text: &str,
     project_root: Option<&Path>,
     bus: &EventBus,
+    caller_may_manage_credentials: bool,
 ) -> (u16, String) {
     settings_post_result_with_sandbox_apply(
         body_text,
         project_root,
         bus,
+        caller_may_manage_credentials,
         live_apply_sandbox_settings,
     )
+}
+
+/// The executable-repointing fields whose CHANGE `payload` would apply
+/// against the currently persisted `config` — the credential-adjacent
+/// subset of the settings surface (which binary external-agent sessions
+/// spawn with the owner's credentials and workspace). Values compare
+/// post-normalization, so a full-payload round trip that echoes the
+/// current values (the dashboard's save shape) never trips the gate; only
+/// an actual repoint does. The ControlMsg lane enforces the same rule via
+/// `control_msg_operation` (SetCodexCommand / SetCodexManagedCommand
+/// classify as credentials.manage).
+fn executable_repoint_denials(
+    payload: &SettingsPayload,
+    config: &crate::project::ProjectConfig,
+) -> Vec<&'static str> {
+    let mut denied = Vec::new();
+    if payload.codex_command.is_some() {
+        let next = normalize_settings_codex_command(payload.codex_command.as_deref());
+        if next != config.agent.codex.command {
+            denied.push("codex_command");
+        }
+    }
+    if payload.codex_managed_command.is_some() {
+        let next = payload
+            .codex_managed_command
+            .as_deref()
+            .map(str::trim)
+            .filter(|cmd| !cmd.is_empty())
+            .map(str::to_string);
+        if next != config.agent.codex.managed_command {
+            denied.push("codex_managed_command");
+        }
+    }
+    if payload.claude_command.is_some() {
+        let next = normalize_settings_agent_command(payload.claude_command.as_deref(), "claude");
+        if next != config.agent.claude_code.command {
+            denied.push("claude_command");
+        }
+    }
+    denied
 }
 
 /// The write-sandbox live-apply seam `settings_post_result` runs after a
@@ -675,6 +717,7 @@ pub(crate) fn settings_post_result_with_sandbox_apply(
     body_text: &str,
     project_root: Option<&Path>,
     bus: &EventBus,
+    caller_may_manage_credentials: bool,
     sandbox_live_apply: impl FnOnce(&crate::project::SandboxProjectConfig) -> Result<(), String>,
 ) -> (u16, String) {
     let Some(root) = project_root else {
@@ -698,6 +741,25 @@ pub(crate) fn settings_post_result_with_sandbox_apply(
             return (500, serde_json::json!({"error": e.to_string()}).to_string());
         }
     };
+    if !caller_may_manage_credentials {
+        let denied = executable_repoint_denials(&payload, &proj.config);
+        if !denied.is_empty() {
+            return (
+                403,
+                serde_json::json!({
+                    "error": format!(
+                        "changing {} requires credential-management authority \
+                         (credentials.manage, the /api/api-keys gate): the command \
+                         path decides which executable runs with this machine's \
+                         credentials. Save it from an owner surface.",
+                        denied.join(", ")
+                    ),
+                    "denied_fields": denied,
+                })
+                .to_string(),
+            );
+        }
+    }
     apply_settings_payload(&mut proj.config, &payload);
     match proj.save_config() {
         Ok(()) => {
@@ -1036,8 +1098,10 @@ pub(crate) fn settings_post_api_response(
     body_text: &str,
     project_root: Option<&Path>,
     bus: &EventBus,
+    caller_may_manage_credentials: bool,
 ) -> ApiResponse {
-    let (status, body) = settings_post_result(body_text, project_root, bus);
+    let (status, body) =
+        settings_post_result(body_text, project_root, bus, caller_may_manage_credentials);
     ApiResponse::json(status, JsonBody::PreSerialized(body))
 }
 
@@ -1108,10 +1172,16 @@ pub(crate) async fn handle_settings_post(
     body_text: String,
     bus: EventBus,
     project_root: Option<PathBuf>,
+    caller_may_manage_credentials: bool,
     cors: crate::gateway_routes::CorsPosture,
     fleet_origin: Option<&str>,
 ) {
-    let response = settings_post_api_response(&body_text, project_root.as_deref(), &bus);
+    let response = settings_post_api_response(
+        &body_text,
+        project_root.as_deref(),
+        &bus,
+        caller_may_manage_credentials,
+    );
     write_api_response(stream, response, cors, fleet_origin).await;
 }
 
@@ -1427,6 +1497,7 @@ mod tests {
             "{\"external_agent\":",
             Some(Path::new(".")),
             &EventBus::new(),
+            true,
         );
 
         assert_eq!(status, 400);
@@ -1435,7 +1506,7 @@ mod tests {
 
     #[test]
     fn settings_post_result_rejects_missing_project_root_with_bad_request() {
-        let (status, body) = settings_post_result("{}", None, &EventBus::new());
+        let (status, body) = settings_post_result("{}", None, &EventBus::new(), true);
 
         assert_eq!(status, 400);
         assert!(body.contains("No project root"));
@@ -1487,7 +1558,7 @@ mod tests {
         })
         .to_string();
 
-        let (status, _) = settings_post_result(&body, Some(dir.path()), &bus);
+        let (status, _) = settings_post_result(&body, Some(dir.path()), &bus, true);
         assert_eq!(status, 200);
 
         let mut saw_command = false;
@@ -1714,7 +1785,15 @@ mod tests {
         let cors = settings_route_cors("POST", "/api/settings");
         // Missing project root: 400 under the canonical tail.
         let response = collect_settings_handler_response(|stream| {
-            handle_settings_post(stream, "{}".to_string(), EventBus::new(), None, cors, None)
+            handle_settings_post(
+                stream,
+                "{}".to_string(),
+                EventBus::new(),
+                None,
+                true,
+                cors,
+                None,
+            )
         })
         .await;
         assert_eq!(
@@ -1736,6 +1815,7 @@ mod tests {
                 invalid.to_string(),
                 EventBus::new(),
                 Some(parse_dir.path().to_path_buf()),
+                true,
                 cors,
                 None,
             )
@@ -1777,6 +1857,7 @@ mod tests {
                 body,
                 EventBus::new(),
                 Some(root.clone()),
+                true,
                 cors,
                 None,
             )
@@ -1960,7 +2041,7 @@ mod tests {
         })
         .to_string();
 
-        let (status, _) = settings_post_result(&body, Some(dir.path()), &bus);
+        let (status, _) = settings_post_result(&body, Some(dir.path()), &bus, true);
         assert_eq!(status, 200);
 
         while let Ok(event) = rx.try_recv() {
@@ -2066,6 +2147,7 @@ mod tests {
             &body.to_string(),
             Some(dir.path()),
             &EventBus::new(),
+            true,
             |sandbox| {
                 *seen.borrow_mut() = Some((sandbox.enabled, sandbox.extra_write_paths.clone()));
                 Ok(())
@@ -2110,6 +2192,7 @@ mod tests {
             &minimal_settings_body().to_string(),
             Some(dir.path()),
             &EventBus::new(),
+            true,
             |_| panic!("live apply must not run for a payload without sandbox fields"),
         );
 
@@ -2130,6 +2213,7 @@ mod tests {
             &body.to_string(),
             Some(dir.path()),
             &EventBus::new(),
+            true,
             |_| Err("no runtime state".to_string()),
         );
 
@@ -2141,5 +2225,80 @@ mod tests {
             r#"{"applied":false,"apply_error":"no runtime state","ok":true}"#
         );
         assert!(dir.path().join("intendant.toml").exists());
+    }
+
+    #[test]
+    fn executable_repoint_requires_credentials_manage() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut body = minimal_settings_body();
+        body["codex_command"] = serde_json::json!("/tmp/evil-codex");
+        body["claude_command"] = serde_json::json!("/tmp/evil-claude");
+
+        let (status, response) = settings_post_result_with_sandbox_apply(
+            &body.to_string(),
+            Some(dir.path()),
+            &EventBus::new(),
+            false,
+            |_| Ok(()),
+        );
+        assert_eq!(status, 403, "{response}");
+        assert!(response.contains("codex_command"), "{response}");
+        assert!(response.contains("claude_command"), "{response}");
+        assert!(
+            !dir.path().join("intendant.toml").exists(),
+            "denied save must not persist config"
+        );
+
+        // The same save succeeds with credential-management authority.
+        let (status, response) = settings_post_result_with_sandbox_apply(
+            &body.to_string(),
+            Some(dir.path()),
+            &EventBus::new(),
+            true,
+            |_| Ok(()),
+        );
+        assert_eq!(status, 200, "{response}");
+        let reloaded = crate::project::Project::from_root(dir.path().to_path_buf()).unwrap();
+        assert_eq!(reloaded.config.agent.codex.command, "/tmp/evil-codex");
+        assert_eq!(
+            reloaded.config.agent.claude_code.command,
+            "/tmp/evil-claude"
+        );
+    }
+
+    #[test]
+    fn executable_echo_saves_without_credentials_manage() {
+        let dir = tempfile::tempdir().unwrap();
+        // Persist a non-default command first (an owner action).
+        let mut project = crate::project::Project::from_root(dir.path().to_path_buf()).unwrap();
+        project.config.agent.codex.command = "my-codex".to_string();
+        project.save_config().unwrap();
+
+        // A Settings-only caller echoing the current value (the dashboard's
+        // full-payload round trip) is not repointing anything — normalized
+        // comparison, so whitespace never trips the gate.
+        let mut body = minimal_settings_body();
+        body["codex_command"] = serde_json::json!(" my-codex ");
+        let (status, response) = settings_post_result_with_sandbox_apply(
+            &body.to_string(),
+            Some(dir.path()),
+            &EventBus::new(),
+            false,
+            |_| Ok(()),
+        );
+        assert_eq!(status, 200, "{response}");
+
+        // Changing it without the authority is refused and nothing persists.
+        body["codex_command"] = serde_json::json!("other-codex");
+        let (status, response) = settings_post_result_with_sandbox_apply(
+            &body.to_string(),
+            Some(dir.path()),
+            &EventBus::new(),
+            false,
+            |_| Ok(()),
+        );
+        assert_eq!(status, 403, "{response}");
+        let reloaded = crate::project::Project::from_root(dir.path().to_path_buf()).unwrap();
+        assert_eq!(reloaded.config.agent.codex.command, "my-codex");
     }
 }


### PR DESCRIPTION
Three follow-ups from the 2026-07-17 security-review wave (#462/#463), ratified as the quick-wins batch:

- **MCP daemon-lifecycle containment (H5 class):** `quit`, `schedule_controller_restart`, and `cancel_controller_restart` are refused to agent-session-provenance callers via the same actor-provenance containment as `set_autonomy`/`approve_all`. `controller_turn_complete` and the controller-loop halt tools deliberately stay open (the session's own completion signal; the autonomous loop's self-stop verbs).
- **Executable repointing requires credentials.manage:** `codex_command`/`codex_managed_command`/`claude_command` decide which binary runs with the owner's credentials, but were writable by any Settings-holding caller. Both lanes now escalate: the `control_msg_operation` classifier returns CredentialsManage for the SetCodexCommand/SetCodexManagedCommand ControlMsgs, and the settings POST core refuses per-field with 403 using the caller's decision from its transport edge (HTTP route context / tunnel grant). Comparison is post-normalization, so full-payload round trips that echo current values still save.
- **Mixed askHuman batches ride the question rail:** the JSON/native path consumed only all-askHuman batches; mixed batches fell to the runtime file prompt nothing watches under the daemon. Adopt the text loop's semantics: any batch containing askHuman raises the question card, askHuman calls get the answer, other calls get a not-executed re-issue note. `BatchFacts::all_ask_human` loses its last consumer and is removed.

The fourth ratified item (doorbell card rendering `requester_daemon_id`) turned out already complete end-to-end: #462 added the field to `access_request_summary_json` and the approval card has rendered it since the 2026-07-11 petname first-contact cue — no change needed.