### PR TITLE
dashboard: expand conversational prose by default, assistant prose bubbles, peek unclamp, centered chapter jumps, grid collapse-all, switcher wiring fix

### DIFF
--- a/static/app/20-shell.html
+++ b/static/app/20-shell.html
@@ -146,6 +146,8 @@
                   title="Minimize every finished sub-agent window">
             Minimize done<span class="ui2-minimize-done-count" id="ui2-minimize-done-count">0</span>
           </button>
+          <button type="button" class="ui2-collapse-all" id="ui2-collapse-all-btn" hidden
+                  title="Minimize every session window to its header bar">Collapse all</button>
           <!-- vertical sliders, NOT the Control tab's horizontal pair —
                two adjacent controls must not share a glyph -->
           <button type="button" class="ui2-view-options-btn" id="ui2-view-options-btn"

--- a/static/app/40-session-launch.js
+++ b/static/app/40-session-launch.js
@@ -1046,7 +1046,10 @@ function buildSessionWindowLogEntry(c) {
   appendCopyLogEntryButton(entry, c.content ?? '');
   appendEditUserMessageButton(entry, c);
   if (c.collapsible || content.split('\n').length > 3 || content.length > 300) {
-    makeSessionWindowLogEntryCollapsible(entry, cnt);
+    // Conversational prose (user/steer/model text) starts expanded — only
+    // tool/system payloads keep the compact collapsed default (41's
+    // isConversationalProseLog, the chapter-nav vocabulary).
+    makeSessionWindowLogEntryCollapsible(entry, cnt, isConversationalProseLog(c));
   }
   return entry;
 }

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -793,6 +793,30 @@ function minimizeDoneSubagentWindows() {
   return changed;
 }
 
+// Bulk grid sweep behind the "Collapse all / Expand all" pill
+// (ui2-activity.js owns the button): EVERY session window, not just done
+// sub-agents, so the user can drop the grid to a stack of header bars
+// and glance across all of them at once. Explicit intent, per-window
+// MANUAL semantics — exactly toggleSessionWindowMinimized's contract:
+// a collapse leaves autoMinimized false, so the done→active crossing
+// never pops open a window the user swept closed; a restore of a done
+// sub-agent is recorded (userRestoredWhileDone) so the auto-minimize
+// derivation does not immediately re-collapse it. A maximized window is
+// released by setSessionWindowMinimized itself when minimized. Returns
+// how many windows changed state.
+function setAllSessionWindowsMinimized(minimized) {
+  const target = !!minimized;
+  let changed = 0;
+  for (const [sid, win] of sessionWindows) {
+    if (!win || !!win.minimized === target) continue;
+    win.autoMinimized = false;
+    win.userRestoredWhileDone = !target && sessionWindowIsDoneSubagent(sid);
+    setSessionWindowMinimized(sid, target);
+    changed += 1;
+  }
+  return changed;
+}
+
 function updateSessionWindowMaximizeState() {
   const grid = document.getElementById('session-window-grid');
   if (!grid) return;

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -1697,6 +1697,24 @@ function createLogScaffold(c, extraClass) {
   return { entry, hostId };
 }
 
+// Conversational prose vs tool/system payload, for collapse DEFAULTS:
+// prose rows (what someone SAID) start expanded wherever the length/flag
+// collapse rules fire; payload rows keep the compact collapsed default.
+// The classification derives from the same stamped vocabulary the
+// renderers and the chapter-nav classifier key on (57c-chapter-nav.js) —
+// user and steer sources, plus model-level non-reasoning rows — never a
+// parallel kind list. User rows drop tool-shaped payloads riding the
+// user role (external backends' tool results; sessionDetailToolResultShape
+// is the shared predicate — native user rows virtually never match it,
+// and a false positive merely keeps today's collapsed default).
+function isConversationalProseLog(c) {
+  if (!c) return false;
+  const source = String(c.source || '').toLowerCase();
+  if (source === 'steer') return true;
+  if (source === 'user') return !sessionDetailToolResultShape(c);
+  return c.level === 'model' && c.kind !== 'reasoning';
+}
+
 // rAF-coalesced follow for the MAIN stream (finding: interleaved layout
 // read/write per appended entry). Reading scrollHeight right after each
 // append forces a synchronous layout of the 10k-node scroller — N entries
@@ -2883,6 +2901,10 @@ function renderLogEntry(c) {
   if (c.collapsible || hasImages) {
     entry.classList.add('collapsible');
     if (hasImages) _logImageStore.set(entry, c.images);
+    // Flagged long prose stays readable: collapsible (the "less" toggle
+    // remains) but expanded from the start. Image rows keep the collapsed
+    // default — expanding is what materializes the deferred gallery.
+    if (!hasImages && isConversationalProseLog(c)) entry.classList.add('expanded');
     const toggle = document.createElement('span');
     toggle.className = 'collapse-toggle';
     toggle.innerHTML = '<span class="arrow">\u25B8 more</span><span class="arrow-up">\u25BE less</span>';

--- a/static/app/57-sessions-replay.js
+++ b/static/app/57-sessions-replay.js
@@ -1888,6 +1888,7 @@ function rebuildSessionDetailViewRows(view) {
   view.expandableRowCount = countSessionDetailExpandableRows(view.rows);
   view.expandedRows = new Set();
   if (detailExpandAll) setSessionDetailRowsExpanded(view, true);
+  else seedSessionDetailProseExpanded(view);
 }
 
 function updateSessionDetailLogsBadge(view, fallbackCount = 0) {
@@ -2067,6 +2068,35 @@ function setSessionDetailRowsExpanded(view, expanded) {
   if (!expanded) return;
   for (let i = 0; i < view.rows.length; i++) {
     if (sessionDetailRowIsExpandable(view.rows[i])) view.expandedRows.add(i);
+  }
+}
+
+// Conversational prose in the detail lane — the chapter-nav detail
+// vocabulary (57c: the renderer's own displaySource decision for user
+// rows — so the external Tool relabel is already applied — plus
+// model-level non-reasoning records) plus steer rows. Diffs are never
+// prose: they render through the diff branch whatever their level.
+function sessionDetailRowIsProse(row) {
+  if (!row || row.kind !== 'entry') return false;
+  const record = row.record || {};
+  if (isDiffLog(record)) return false;
+  if (row.displaySource === sessionDetailSourceLabels.user) return true;
+  if (String(record.source || '').toLowerCase() === 'steer') return true;
+  return record.level === 'model' && record.kind !== 'reasoning';
+}
+
+// Default expansion for a freshly built row set: prose reads open,
+// payloads read compact. expandedRows keeps its polarity (member =
+// expanded), so the per-row toggle and the Expand/Collapse-all sweep
+// stay untouched; an explicit sweep overrides this default until the
+// next rebuild (rebuilds already reset every per-row toggle — the index
+// Set cannot survive one).
+function seedSessionDetailProseExpanded(view) {
+  for (let i = 0; i < view.rows.length; i++) {
+    const row = view.rows[i];
+    if (sessionDetailRowIsProse(row) && sessionDetailRowIsExpandable(row)) {
+      view.expandedRows.add(i);
+    }
   }
 }
 

--- a/static/app/57c-chapter-nav.js
+++ b/static/app/57c-chapter-nav.js
@@ -254,6 +254,23 @@ function chapterNavHighlightRow(node, mode) {
   setTimeout(clear, 1600);
 }
 
+// ── Jump landing ───────────────────────────────────────────────────────
+// Where a jumped-to row lands: vertically CENTERED in its scroller, so
+// the hit arrives with context on both sides instead of hugging the top
+// edge; a row taller than the viewport instead pins its first line just
+// below the top (CHAPTER_NAV_JUMP_PAD_PX) so the start of the message is
+// always visible. Manual scrollTop math on purpose: scrollIntoView can
+// scroll ancestor containers too, block:'center' buries the head of
+// taller-than-viewport rows, and the cursor bookkeeping needs the
+// resulting scrollTop synchronously.
+function chapterNavJumpScrollTop(scroller, node) {
+  const lead = Math.max(
+    CHAPTER_NAV_JUMP_PAD_PX,
+    Math.floor((scroller.clientHeight - node.offsetHeight) / 2)
+  );
+  return Math.max(0, node.offsetTop - lead);
+}
+
 // ── Pane jumps ─────────────────────────────────────────────────────────
 
 function chapterNavJumpPane(win, mode, dir) {
@@ -284,7 +301,7 @@ function chapterNavJumpPane(win, mode, dir) {
   const node = win.log.querySelector(`[data-history-index="${target}"]`);
   if (!node) return false;
   win.followOutput = false;
-  win.log.scrollTop = Math.max(0, node.offsetTop - CHAPTER_NAV_JUMP_PAD_PX);
+  win.log.scrollTop = chapterNavJumpScrollTop(win.log, node);
   ix.cursor = { mark: target, scrollTop: win.log.scrollTop };
   chapterNavHighlightRow(node, mode);
   const cluster = chapterNavClusterForPane(win);
@@ -321,7 +338,7 @@ function chapterNavPaneHistoryLoaded(win) {
   const node = win.log.querySelector(`[data-history-index="${target}"]`);
   if (!node) return;
   win.followOutput = false;
-  win.log.scrollTop = Math.max(0, node.offsetTop - CHAPTER_NAV_JUMP_PAD_PX);
+  win.log.scrollTop = chapterNavJumpScrollTop(win.log, node);
   ix.cursor = { mark: target, scrollTop: win.log.scrollTop };
   chapterNavHighlightRow(node, pending.mode);
   const cluster = chapterNavClusterForPane(win);
@@ -365,7 +382,7 @@ function chapterNavScrollDetailTo(view, ix, marks, target, mode) {
   }
   const node = view.scroller.querySelector(`[data-detail-row-index="${target}"]`);
   if (!node) return;
-  view.scroller.scrollTop = Math.max(0, node.offsetTop - CHAPTER_NAV_JUMP_PAD_PX);
+  view.scroller.scrollTop = chapterNavJumpScrollTop(view.scroller, node);
   ix.cursor = { mark: target, scrollTop: view.scroller.scrollTop };
   chapterNavHighlightRow(node, mode);
   chapterNavUpdateCount(chapterNavDetailCluster, mode, marks, target);

--- a/static/app/ui2-activity.css
+++ b/static/app/ui2-activity.css
@@ -215,6 +215,29 @@ html.ui-v2 #activity-subtabs .ui2-minimize-done-count {
   font-size: 9.5px;
 }
 
+/* collapse/expand-all: the grid sweep twin of the hygiene pill — neutral
+   ink (a layout action, not an attention nudge), and grid-only: Focus
+   hides the session windows the sweep acts on (ui2-activity.js keeps the
+   label naming the direction one click will act) */
+html.ui-v2 #activity-subtabs .ui2-collapse-all {
+  display: inline-flex;
+  align-items: center;
+  height: 28px;
+  padding: 0 10px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: transparent;
+  color: var(--text-3);
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background var(--t-fast), color var(--t-fast);
+}
+html.ui-v2 #activity-subtabs .ui2-collapse-all:hover { color: var(--text); background: var(--hover-wash); }
+html.ui-v2 #activity-subtabs .ui2-collapse-all[hidden],
+html.ui-v2:not([data-ui2-layout="grid"]) #activity-subtabs .ui2-collapse-all { display: none; }
+
 /* Options trigger */
 html.ui-v2 #activity-subtabs .ui2-view-options-btn {
   display: inline-flex;
@@ -409,6 +432,33 @@ html.ui-v2 .log-entry.source-user .log-content {
   color: var(--text);
 }
 html.ui-v2 .log-entry.source-user { padding-top: 7px; padding-bottom: 7px; }
+/* …and the agent's replies get the same quiet card in the model/iris
+   family — a shade quieter than the user's amber (model prose is the
+   bulk of a transcript), same geometry, so saying reads as cards and
+   doing stays bare work rows. Keyed on the stamped renderer vocabulary
+   exactly like the chapter-nav classifier (57c): level-model minus
+   reasoning; the structural :nots keep entry kinds that ride the model
+   level (thinking rows, diffs, output groups) on their own grammar.
+   Native model rows and external claude-code/codex/gemini prose all
+   stamp level-model, so every surface (grid/Focus, stream, detail,
+   peek) gets the card from this one rule. Steer rows deliberately keep
+   their dimmed meta hairline — not restyled here. */
+html.ui-v2 .log-entry.level-model:not([data-kind="reasoning"]):not(.reasoning-log-entry):not(.diff-log-entry):not(.command-output-group) .log-content {
+  background: rgba(var(--iris-rgb), .05);
+  border: 1px solid rgba(var(--iris-rgb), .12);
+  border-radius: 12px;
+  padding: 7px 12px;
+}
+html.ui-v2 .log-entry.level-model:not([data-kind="reasoning"]):not(.reasoning-log-entry):not(.diff-log-entry):not(.command-output-group) {
+  padding-top: 7px;
+  padding-bottom: 7px;
+}
+/* border-box: a collapsed card's 1.5em clamp would otherwise be eaten by
+   its own padding — keep one text line visible inside collapsed bubbles */
+html.ui-v2 .log-entry.collapsible:not(.expanded).source-user .log-content,
+html.ui-v2 .log-entry.collapsible:not(.expanded).level-model:not([data-kind="reasoning"]):not(.reasoning-log-entry):not(.diff-log-entry):not(.command-output-group) .log-content {
+  max-height: calc(1.5em + 16px);
+}
 
 /* markdown body rhythm */
 html.ui-v2 .log-entry .log-markdown { min-width: 0; }

--- a/static/app/ui2-activity.js
+++ b/static/app/ui2-activity.js
@@ -135,6 +135,53 @@ function ui2RefreshMinimizeDoneControl() {
   btn.title = count === 1
     ? 'Minimize the finished sub-agent window'
     : `Minimize all ${count} finished sub-agent windows`;
+  // The collapse-all pill rides the same freshness passes (badge refresh,
+  // relationship render, every minimize state change routes here).
+  ui2RefreshCollapseAllControl();
+}
+
+// ── "Collapse all / Expand all" grid sweep pill ────────────────────────
+// Beside "Minimize done", acting on EVERY session window (41's
+// setAllSessionWindowsMinimized): one click drops the grid to a stack of
+// header bars for an all-sessions glance, the next restores it. The
+// label always names the direction one click will act — any expanded
+// window means Collapse all, an all-minimized grid means Expand all.
+// Grid-only surface: Focus hides the session windows the sweep acts on,
+// so the stylesheet layout-gates the pill (html[data-ui2-layout]).
+function ui2RefreshCollapseAllControl() {
+  const btn = document.getElementById('ui2-collapse-all-btn');
+  if (!btn) return;
+  const windows = typeof sessionWindows !== 'undefined' ? sessionWindows : null;
+  if (!windows || windows.size === 0) {
+    btn.hidden = true;
+    return;
+  }
+  let expanded = 0;
+  for (const win of windows.values()) {
+    if (win && !win.minimized) expanded += 1;
+  }
+  const collapse = expanded > 0;
+  btn.hidden = false;
+  btn.dataset.direction = collapse ? 'collapse' : 'expand';
+  btn.textContent = collapse ? 'Collapse all' : 'Expand all';
+  btn.title = collapse
+    ? (expanded === 1
+        ? 'Minimize the session window to its header bar'
+        : `Minimize all ${expanded} session windows to their header bars`)
+    : 'Restore every minimized session window';
+  btn.setAttribute('aria-label', btn.title);
+}
+
+function ui2WireCollapseAllControl() {
+  const btn = document.getElementById('ui2-collapse-all-btn');
+  if (!btn) return;
+  btn.addEventListener('click', () => {
+    const collapse = btn.dataset.direction !== 'expand';
+    if (typeof setAllSessionWindowsMinimized === 'function') {
+      setAllSessionWindowsMinimized(collapse);
+    }
+    ui2RefreshMinimizeDoneControl();
+  });
 }
 
 let ui2MinimizeDoneRefreshQueued = false;
@@ -590,6 +637,7 @@ function ui2RailTick(force) {
     ui2AugmentApprovalPanel();
     ui2WireLayoutToggle();
     ui2WireMinimizeDoneControl();
+    ui2WireCollapseAllControl();
     ui2WireViewOptions();
     ui2DressComposer();
     ui2BuildVitalsRail();

--- a/static/app/ui2-chrome.js
+++ b/static/app/ui2-chrome.js
@@ -215,11 +215,12 @@ function ui2WireMirrors() {
   // focusSessionWindow() path as clicking a window. "All sessions" clears
   // the Focus filter back to the combined stream.
   //
-  // Wired strictly on DOMContentLoaded: this block reads `sessionWindows`,
-  // a `let` a later fragment declares in the shared module scope — at
-  // chrome-boot time it is in its TDZ, and even `typeof` on a TDZ binding
-  // THROWS (the module-boot rule's sharpest edge; a throw here kills
-  // every fragment after this one).
+  // Called directly below: ui2WireMirrors itself only runs from the
+  // module's DOMContentLoaded boot, so every fragment has executed and
+  // `sessionWindows` (a later fragment's shared-scope `let`) is out of
+  // its TDZ. The old nested readiness gate here re-registered a
+  // DOMContentLoaded listener DURING DCL dispatch — which per spec never
+  // fires — so the switcher was never wired at all.
   const ui2WireSwitcher = () => {
   const switcher = document.getElementById('ui2-session-switcher');
   const rebuildSwitcher = () => {
@@ -270,8 +271,7 @@ function ui2WireMirrors() {
     rebuildSwitcher();
   }
   };
-  if (document.readyState === 'complete') ui2WireSwitcher();
-  else document.addEventListener('DOMContentLoaded', ui2WireSwitcher, { once: true });
+  ui2WireSwitcher();
 
   // Prominent theme toggle: icon shows the current theme; click flips.
   const themeBtn = document.getElementById('ui2-theme-btn');

--- a/static/app/ui2-composer-peek.css
+++ b/static/app/ui2-composer-peek.css
@@ -161,47 +161,20 @@ html.ui-v2 .ui2-composer-peek .log-entry pre {
   padding: 8px 10px;
 }
 
-/* long payloads clamp; the fade appears only on entries that really clip
-   (JS tags .ui2-peek-clamped — CSS cannot see overflow). The blanket
-   content:none also retires v1's side fade on collapsible entries, whose
-   1.5em clamp the max-height below supersedes inside the peek. */
-html.ui-v2 .ui2-composer-peek .log-entry .log-content {
-  position: relative;
-  max-height: 8.5em;
-  overflow: hidden;
-}
-/* …but never the TAIL entry — the last one that actually clips, marked
-   .ui2-peek-tail-open by JS. :last-child is not enough: completion meta
-   lines (Done / Round complete) trail the final message. Content
-   clipped INSIDE an entry is not in the list's scroll flow, so the tail
-   of a long latest message was unreachable — the list hit scroll-bottom
-   while the fade obscured the end permanently. Opened, the list
-   scroller carries the full text. max-height:none (not a larger cap)
-   so this also keeps superseding the base collapsible 1.5em clamp,
-   exactly like the 8.5em rule it lifts. */
-html.ui-v2 .ui2-composer-peek .log-entry.ui2-peek-tail-open .log-content {
-  max-height: none;
-}
-html.ui-v2 .ui2-composer-peek .log-entry:not(.ui2-peek-clamped) .log-content::after { content: none; }
-html.ui-v2 .ui2-composer-peek .log-entry.ui2-peek-clamped .log-content::after {
-  content: '';
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  top: auto;
-  width: auto;
-  height: 1.8em;
-  background: linear-gradient(to bottom, transparent, var(--surface));
-  pointer-events: none;
-}
-/* diff bodies: same digest clamp, same tail exemption — on the tail
-   entry the body falls back to the base .diff-log-body scroll box
-   (max-height 460px, overflow auto), so a trailing diff stays readable
-   in place instead of hard-clipping. */
-html.ui-v2 .ui2-composer-peek .diff-log-entry:not(.ui2-peek-tail-open) .diff-log-body {
-  max-height: 8.5em;
-  overflow: hidden;
+/* No per-message clamp: conversational prose starts expanded (40/41's
+   collapse defaults) and renders in FULL — the list scroller carries
+   length, with the follow logic and the container-level more-below cue
+   below. Collapsed rows (tool payloads and other long non-prose) keep
+   the base compact 1.5em state instead: command groups and diffs read
+   as their summary lines, generic collapsed rows as one line with the
+   base right-edge fade as the "there's more" cue — retinted to the
+   sheet's surface (the base gradient fades to --base, the page bg).
+   The toggles are hidden here and clones carry no wiring, so drop the
+   pointer cursor they would lie with; the full text is one tap away in
+   Activity. */
+html.ui-v2 .ui2-composer-peek .log-entry.collapsible { cursor: default; }
+html.ui-v2 .ui2-composer-peek .log-entry.collapsible:not(.expanded) .log-content::after {
+  background: linear-gradient(to right, transparent, var(--surface));
 }
 
 /* container-level "more below" cue: pinned to the sheet, not the scroll

--- a/static/app/ui2-composer-peek.js
+++ b/static/app/ui2-composer-peek.js
@@ -87,33 +87,6 @@
     return 'No output yet';
   }
 
-  // CSS cannot see overflow, and "the tail" is not simply :last-child —
-  // completion meta lines (Done / Round complete) trail the final
-  // message. Two-phase pass over every rendered clone: measure each one
-  // under the digest clamp, then open the LAST entry that actually
-  // clips (the newest clipping content is the conversation tail the
-  // user must be able to finish reading — the list scroller carries
-  // it), and fade-tag the earlier clippers, whose full text is one tap
-  // away in Activity. Re-run on every render: appends and in-place
-  // growth both move which entry is the tail.
-  function peekRetagClamped() {
-    for (const r of peekRendered) r.clone.classList.remove('ui2-peek-tail-open');
-    const measured = [];
-    for (const r of peekRendered) {
-      const content = r.clone.querySelector('.log-content');
-      measured.push([r.clone, !!content && content.scrollHeight > content.clientHeight + 1]);
-    }
-    let tailOpen = null;
-    for (let i = measured.length - 1; i >= 0; i--) {
-      if (measured[i][1]) { tailOpen = measured[i][0]; break; }
-    }
-    for (const [clone, clips] of measured) {
-      const isTail = clone === tailOpen;
-      clone.classList.toggle('ui2-peek-tail-open', isTail);
-      clone.classList.toggle('ui2-peek-clamped', clips && !isTail);
-    }
-  }
-
   // The container-level "more below" fade must never obscure the tail:
   // it shows only while unread content sits below the viewport and goes
   // away at scroll-bottom. Re-synced on scroll and after every render
@@ -163,7 +136,6 @@
       if (r.clone === cursor) cursor = cursor.nextElementSibling;
       else peekList.insertBefore(r.clone, cursor);
     }
-    peekRetagClamped();
     peekPendingDirty.clear();
     if (peekFollow) peekList.scrollTop = peekList.scrollHeight;
     peekSyncMoreBelow();
@@ -192,9 +164,6 @@
     }
     peekPendingDirty.clear();
     if (touched) {
-      // Full re-tag, not per-clone: in-place growth (streaming output)
-      // can turn a short entry into the new tail clipper.
-      peekRetagClamped();
       if (peekFollow) peekList.scrollTop = peekList.scrollHeight;
       peekSyncMoreBelow();
     }


### PR DESCRIPTION
Six ratified dashboard presentation changes, fragments-only (app.html regenerated per commit).

**A — conversational prose never default-collapses.** Prose (user and steer rows, plus model-level non-reasoning rows — exactly the chapter-nav vocabulary in 57c) over the collapse threshold now renders collapsible-but-expanded, keeping the manual "less" toggle, in all three renderers: the grid/Focus record builder (40), the live stream (41), and the Sessions detail/replay lane (57, seeded into `expandedRows` at rebuild; the Set keeps its member-means-expanded polarity and the Expand/Collapse-all sweep still overrides everything, with prose defaults re-seeding on the next rows rebuild). Tool/system payloads and image rows (whose expansion materializes the deferred gallery) keep the compact collapsed default. **Collapsible-flag finding:** nothing in the daemon sets `collapsible` — it is computed in the presence-web WASM client (`crates/presence-web/src/app_state.rs`, `is_collapsible` on images/line/char thresholds) and rides `add_log_entry` commands into the live lane, so long live prose really was collapsing today; the fix treats flagged prose as expanded-by-default at the render sites without touching WASM artifacts.

**B — assistant-prose bubble, CSS-only.** Model non-reasoning prose gets a quiet iris-family card with the user bubble's exact geometry (radius 12px, padding 7px 12px, low-alpha `--iris-rgb` wash/border — defined in both light and dark token blocks), a shade quieter than the user's amber since model prose dominates a transcript. Keyed on the stamped `level-model` class + `:not([data-kind="reasoning"])` (class, not `data-level`, because the detail renderer stamps only the class), with structural `:not()`s for entry kinds that ride the model level (reasoning/diff/output-group). Native `source-model` and external claude-code/codex/gemini prose all stamp `level-model`, so one rule covers every surface. Collapsed bubbles get a border-box clamp compensation so one text line stays visible. **Open question:** steer rows deliberately keep their dimmed meta hairline — whether steers should eventually join the card family is left for a separate design decision.

**C — peek unclamp.** The composer peek's per-message clamp model is removed outright (8.5em cap, `peekRetagClamped` JS measurement, `.ui2-peek-clamped`/`.ui2-peek-tail-open`, diff cap — nothing else consumed them): prose arrives expanded from A and renders in full; the list scroller carries length, with the 12-entry tail cap, follow logic, and more-below cue unchanged. **Non-prose decision:** collapsed rows keep their base compact state (command groups and diffs read as summary lines, generic collapsed rows as one 1.5em line) with the base right-edge fade retinted to the sheet surface as the "there's more" cue — toggles stay hidden and clones stay inert (pointer cursor dropped), full text one tap away in Activity.

**D — chapter-jump centering.** Both jump paths (pane cluster incl. the parked-jump seam, Sessions-detail cluster) now land the target at the vertical center of its scroll container; entries taller than the viewport pin their first line just below the top edge with a small pad. Manual scrollTop math rather than `scrollIntoView({block:'center'})`: it cannot scroll ancestor containers, handles the taller-than-viewport head-visibility rule, and the cursor bookkeeping needs the resulting scrollTop synchronously. Jump highlight flash unchanged. Probe-verified: jumped node center within 1px of viewport center.

**E — grid collapse/expand-all pill.** A neutral pill next to "Minimize done" toggling every grid session window between minimized header bars and expanded, for an all-sessions glance. Manual minimize semantics per window (never `autoMinimized`, so reactivating sub-agents don't pop back open a swept-closed window); expand marks done sub-agents `userRestoredWhileDone` exactly like a manual restore so the auto-minimize derivation doesn't fight it; a maximized window is released by the existing minimize path. Label always names the direction one click will act; grid-layout-only (Focus hides the windows the sweep acts on); rides the Minimize-done refresh passes.

**F — focused-session switcher never wired (dead since introduction).** Root cause: a nested readiness gate re-registered a DOMContentLoaded listener during DCL dispatch (the enclosing `ui2WireMirrors` already runs from the module's DCL boot), which per spec never fires — so `#ui2-session-switcher` stayed empty with no wiring. Fixed with a direct call, matching the sibling activity-tools wire calls; boot probe confirms the select now carries options and its data-sig.

**Verification:** `cargo fmt --check`, `cargo check`, `cargo test -p intendant --bins` (3976+121+91 passed), library-crate tests (all green), `cargo clippy --workspace -- -D warnings` clean, static-script parse gate PASS. Dashboard boot probe (validate-dashboard.cjs, launched dashboard + CDP): PASS; live DOM probes confirmed A (prose expanded / payload collapsed at 1.5em), B (iris card on model, amber on user, none on system), C (clamp rules gone, retinted fade present), D (centered within 1px), E (pill appears with correct direction label), F (switcher populated with data-sig).