### PR TITLE
fix(mcp): serve object-typed tool schemas; pin every profile's schemas

### DIFF
--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -343,6 +343,7 @@ impl IntendantServer {
                         let mut schema =
                             serde_json::to_value(&*tool.input_schema).unwrap_or_default();
                         inline_schema_refs(&mut schema);
+                        ensure_object_typed_schema_root(&mut schema);
                         serde_json::json!({
                             "name": tool.name,
                             "description": tool.description,
@@ -2692,6 +2693,74 @@ fn resolve_refs(value: &mut serde_json::Value, defs: &serde_json::Map<String, se
     }
 }
 
+/// Force a served tool `inputSchema` root to be explicitly object-typed.
+///
+/// The MCP spec requires every tool `inputSchema` to be a JSON Schema of
+/// `"type": "object"`, and real clients enforce it: claude-code validates the
+/// whole `tools/list` result client-side and rejects the ENTIRE list when one
+/// tool's schema root is not object-typed — one bad schema costs the session
+/// every Intendant tool. schemars renders internally-tagged enums (e.g.
+/// `agenda_op`'s `AgendaCommand`) as a bare `{"oneOf": [...]}` root with no
+/// top-level `"type"`, even though every variant serializes as a JSON object
+/// by construction.
+///
+/// When the root lacks `"type"` and provably describes an object — it carries
+/// object-vocabulary keywords, or every `oneOf`/`anyOf`/`allOf` branch is
+/// itself object-shaped — inject the top-level `"type": "object"` the spec
+/// requires. Roots that already declare a `"type"`, or whose shape cannot be
+/// proven object-only, are left untouched: the serving-path pin test
+/// (`every_profile_serves_only_object_typed_tool_schemas`) fails on any tool
+/// this cannot fix, so a bad schema breaks the suite instead of shipping.
+fn ensure_object_typed_schema_root(schema: &mut serde_json::Value) {
+    let Some(obj) = schema.as_object_mut() else {
+        return;
+    };
+    if obj.contains_key("type") {
+        return;
+    }
+    if schema_describes_object(obj) {
+        obj.insert(
+            "type".to_string(),
+            serde_json::Value::String("object".to_string()),
+        );
+    }
+}
+
+/// Whether a typeless JSON Schema provably validates only JSON objects.
+fn schema_describes_object(schema: &serde_json::Map<String, serde_json::Value>) -> bool {
+    // Object-vocabulary keywords only constrain (and only make sense on)
+    // object instances.
+    if [
+        "properties",
+        "required",
+        "additionalProperties",
+        "patternProperties",
+    ]
+    .iter()
+    .any(|key| schema.contains_key(*key))
+    {
+        return true;
+    }
+    // A combinator root is object-only when every branch is: schemars renders
+    // internally-tagged enums as `oneOf` over object-typed variants.
+    ["oneOf", "anyOf", "allOf"].iter().any(|key| {
+        schema
+            .get(*key)
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|branches| {
+                !branches.is_empty()
+                    && branches.iter().all(|branch| {
+                        branch.as_object().is_some_and(|branch| {
+                            match branch.get("type").and_then(serde_json::Value::as_str) {
+                                Some(kind) => kind == "object",
+                                None => schema_describes_object(branch),
+                            }
+                        })
+                    })
+            })
+    })
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
@@ -4739,5 +4808,75 @@ pub(crate) mod tests {
         let original = schema.clone();
         inline_schema_refs(&mut schema);
         assert_eq!(schema, original);
+    }
+
+    #[test]
+    fn ensure_object_typed_schema_root_fixes_tagged_enum_one_of() {
+        // The schemars shape for an internally-tagged enum (agenda_op's
+        // AgendaCommand): a bare oneOf root over object variants, no
+        // top-level type — the exact shape MCP clients reject.
+        let mut schema = serde_json::json!({
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": { "op": { "type": "string", "const": "add" } },
+                    "required": ["op"]
+                },
+                {
+                    "type": "object",
+                    "properties": { "op": { "type": "string", "const": "retire" } },
+                    "required": ["op"]
+                }
+            ]
+        });
+        ensure_object_typed_schema_root(&mut schema);
+        assert_eq!(schema["type"], "object");
+        assert_eq!(schema["oneOf"].as_array().map(Vec::len), Some(2));
+    }
+
+    #[test]
+    fn ensure_object_typed_schema_root_accepts_typeless_object_vocabulary() {
+        // A typeless branch that itself carries object vocabulary (nested
+        // combinators do this) still proves the root object-only.
+        let mut schema = serde_json::json!({
+            "anyOf": [
+                { "properties": { "a": { "type": "string" } }, "required": ["a"] },
+                { "type": "object", "properties": { "b": { "type": "number" } } }
+            ]
+        });
+        ensure_object_typed_schema_root(&mut schema);
+        assert_eq!(schema["type"], "object");
+    }
+
+    #[test]
+    fn ensure_object_typed_schema_root_leaves_declared_types_alone() {
+        let mut schema = serde_json::json!({
+            "type": "object",
+            "properties": { "name": { "type": "string" } }
+        });
+        let original = schema.clone();
+        ensure_object_typed_schema_root(&mut schema);
+        assert_eq!(schema, original);
+    }
+
+    #[test]
+    fn ensure_object_typed_schema_root_never_mislabels_non_object_shapes() {
+        // A oneOf with a non-object branch genuinely admits non-object
+        // instances; injecting "type": "object" would silently invalidate
+        // that branch. Leave it for the serving-path pin test to reject.
+        let mut mixed = serde_json::json!({
+            "oneOf": [
+                { "type": "object", "properties": {} },
+                { "type": "string" }
+            ]
+        });
+        let original = mixed.clone();
+        ensure_object_typed_schema_root(&mut mixed);
+        assert_eq!(mixed, original);
+
+        // An unconstrained root proves nothing; leave it untouched.
+        let mut empty = serde_json::json!({});
+        ensure_object_typed_schema_root(&mut empty);
+        assert_eq!(empty, serde_json::json!({}));
     }
 }

--- a/src/bin/caller/mcp/tool_gate.rs
+++ b/src/bin/caller/mcp/tool_gate.rs
@@ -326,6 +326,7 @@ macro_rules! manual_http_tool_definition {
     ($name:literal, $description:literal, $params:ty) => {{
         let mut schema = serde_json::to_value(schemars::schema_for!($params)).unwrap_or_default();
         inline_schema_refs(&mut schema);
+        ensure_object_typed_schema_root(&mut schema);
         serde_json::json!({
             "name": $name,
             "description": $description,
@@ -1132,5 +1133,169 @@ mod tests {
             mcp_tool_operation("tool_added_without_classification"),
             PeerOperation::CredentialsManage
         );
+    }
+
+    /// Derive-don't-mirror pin for the MCP client constraint: the spec
+    /// requires every tool `inputSchema` to be object-typed, and claude-code
+    /// validates the whole `tools/list` client-side — ONE schema whose root
+    /// lacks `"type": "object"` rejects the ENTIRE list and the session
+    /// registers zero Intendant tools (the live 2026-07 `agenda_op`
+    /// regression). Iterate every profile branch of
+    /// [`tool_allowed_for_profile`] (plus the no-profile and unknown-profile
+    /// fail-open surfaces) x managed-context through the real serving path
+    /// and fail on any served schema that is not explicitly object-typed.
+    #[test]
+    fn every_profile_serves_only_object_typed_tool_schemas() {
+        use crate::event::EventBus;
+        use crate::mcp::tests::{test_server, test_state};
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let (_home, server) = test_server(test_state(), EventBus::new());
+            // Every named arm of `tool_allowed_for_profile`, the profile-less
+            // default, and an unknown profile (which fails open to the full
+            // surface).
+            let profiles = [
+                None,
+                Some("full"),
+                Some("core"),
+                Some("codex-core"),
+                Some("cli"),
+                Some("minimal"),
+                Some("screen"),
+                Some("display"),
+                Some("managed"),
+                Some("managed-context"),
+                Some("unknown-profile-for-schema-pin"),
+            ];
+            for profile in profiles {
+                for managed_context in [false, true] {
+                    let served = server
+                        .list_tools_json_for_session(None, Some(managed_context), profile)
+                        .await;
+                    let tools = served["tools"].as_array().expect("tools array");
+                    assert!(
+                        !tools.is_empty(),
+                        "profile {profile:?} (managed_context={managed_context}) served no tools"
+                    );
+                    for tool in tools {
+                        let name = tool["name"].as_str().expect("tool name");
+                        assert_eq!(
+                            tool.pointer("/inputSchema/type")
+                                .and_then(serde_json::Value::as_str),
+                            Some("object"),
+                            "tool `{name}` served under profile {profile:?} \
+                             (managed_context={managed_context}) must carry a top-level \
+                             `\"type\": \"object\"` inputSchema — one non-object schema \
+                             makes MCP clients reject the whole tools/list"
+                        );
+                    }
+                }
+            }
+        });
+    }
+
+    /// The stdio transport serves the `#[tool]` router's raw schemas without
+    /// the JSON serving path's normalization. Router params are structs
+    /// (object-typed roots) by construction today; pin that at the source so
+    /// a future non-object params type (e.g. an internally-tagged enum used
+    /// directly as `Parameters<T>`) fails here instead of shipping a listing
+    /// stdio clients reject.
+    #[test]
+    fn router_tool_schemas_are_object_typed_at_the_source() {
+        use crate::event::EventBus;
+        use crate::mcp::tests::{test_server, test_state};
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let (_home, server) = test_server(test_state(), EventBus::new());
+            let tools = server.tool_router.list_all();
+            assert!(!tools.is_empty(), "tool router must not be empty");
+            for tool in tools {
+                assert_eq!(
+                    tool.input_schema
+                        .get("type")
+                        .and_then(serde_json::Value::as_str),
+                    Some("object"),
+                    "router tool `{}` must declare a `\"type\": \"object\"` schema root \
+                     — the stdio transport serves it verbatim",
+                    tool.name
+                );
+            }
+        });
+    }
+
+    /// `agenda_op` is the tool that broke supervised claude-code sessions:
+    /// `AgendaCommand` is an internally-tagged enum, schemars renders it as a
+    /// bare `oneOf` root with no top-level `"type"`, and the client rejected
+    /// the entire served tool list. Pin the served shape end-to-end: round-trip
+    /// the core-profile listing (the profile supervised external sessions
+    /// receive) through wire bytes and assert the schema root is object-typed
+    /// with every op variant intact.
+    #[test]
+    fn agenda_op_served_schema_round_trips_object_typed_with_variants_intact() {
+        use crate::event::EventBus;
+        use crate::mcp::tests::{test_server, test_state};
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let (_home, server) = test_server(test_state(), EventBus::new());
+            let served = server
+                .list_tools_json_for_session(None, Some(false), Some("core"))
+                .await;
+            // What a client parses is what we assert on.
+            let wire = serde_json::to_string(&served).expect("serialize tools/list");
+            let parsed: serde_json::Value = serde_json::from_str(&wire).expect("parse tools/list");
+            let agenda_op = parsed["tools"]
+                .as_array()
+                .expect("tools array")
+                .iter()
+                .find(|tool| tool["name"] == "agenda_op")
+                .expect("agenda_op must be served in the core profile");
+            let schema = &agenda_op["inputSchema"];
+            assert_eq!(schema["type"].as_str(), Some("object"));
+            let variants = schema["oneOf"]
+                .as_array()
+                .expect("agenda_op keeps its oneOf variants");
+            let mut ops: Vec<&str> = variants
+                .iter()
+                .map(|variant| {
+                    assert_eq!(
+                        variant["type"].as_str(),
+                        Some("object"),
+                        "every AgendaCommand variant serializes as a JSON object"
+                    );
+                    variant
+                        .pointer("/properties/op/const")
+                        .and_then(serde_json::Value::as_str)
+                        .expect("variant op tag const")
+                })
+                .collect();
+            ops.sort_unstable();
+            assert_eq!(
+                ops,
+                [
+                    "add",
+                    "answer",
+                    "approve_effect",
+                    "complete",
+                    "patch",
+                    "propose_effect",
+                    "reopen",
+                    "retire",
+                    "revoke_effect"
+                ],
+                "agenda_op's served oneOf must keep the full AgendaCommand vocabulary"
+            );
+        });
     }
 }


### PR DESCRIPTION
## Problem

Every supervised Claude Code session since ~2026-07-16 registers zero Intendant MCP tools. The MCP spec requires tool `inputSchema`s to be object-typed, and claude-code 2.1.x validates the entire `tools/list` result client-side — **one bad schema makes the client reject the whole list** (4 retries, then a permanent "Failed to fetch tools").

The offender is `agenda_op`: its params type `AgendaCommand` is an internally-tagged enum (`#[serde(tag = "op")]`), which schemars renders as a bare `{"oneOf": [...]}` root with **no top-level `"type": "object"`** — even though every variant serializes as a JSON object by construction. `inline_schema_refs` inlines refs but did no shape normalization, so the invalid root shipped on every JSON transport that lists tools.

## Fix

`ensure_object_typed_schema_root` runs after ref inlining in **both** tool-definition builders — the router definitions in `list_tools_json_for_session` and the `manual_http_tool_definition!` macro — so every JSON serving path (HTTP `/mcp` gate, the external-agent bridge) is covered and no caller can bypass it. It injects a top-level `"type": "object"` only when a typeless root *provably* describes an object: it carries object-vocabulary keywords, or every `oneOf`/`anyOf`/`allOf` branch is itself object-shaped. Roots it cannot prove are left untouched — for the pin test to reject, never to ship silently.

No tool names, semantics, or profile composition change — schema shape only.

## Regression pins (derive-don't-mirror for the client constraint)

- `every_profile_serves_only_object_typed_tool_schemas` — iterates every profile branch of `tool_allowed_for_profile` (plus the no-profile and unknown-profile fail-open surfaces) x managed-context through the real serving path, asserting every served `inputSchema` has top-level `"type": "object"`. One bad tool schema now fails the suite instead of nuking every client's tool list.
- `router_tool_schemas_are_object_typed_at_the_source` — pins the raw `#[tool]` router schemas the stdio transport serves verbatim (structs today; a future non-object params type fails here).
- `agenda_op_served_schema_round_trips_object_typed_with_variants_intact` — round-trips the core-profile listing (what supervised external sessions receive) through wire bytes and asserts the root type plus the full 9-variant op vocabulary intact.
- Unit tests for the normalizer: tagged-enum oneOf fixed, declared types untouched, mixed/unprovable shapes never mislabeled.