### PR TITLE
security: bind approval decisions to exact prompts

### DIFF
--- a/src/bin/caller/agent_loop.rs
+++ b/src/bin/caller/agent_loop.rs
@@ -834,17 +834,6 @@ pub(crate) async fn handle_peer_tool_call(
     }
 }
 
-/// Approval ids for controller-tool gates (outbound MCP calls,
-/// `invoke_skill`, `spawn_sub_agent`, `workflow_checkpoint`). Own base keeps
-/// them disjoint from the turn-numbered runtime approval ids and the
-/// live-audio consent range (`1 << 41`).
-const CONTROLLER_TOOL_APPROVAL_ID_BASE: u64 = 1 << 42;
-static CONTROLLER_TOOL_APPROVAL_ID: std::sync::atomic::AtomicU64 =
-    std::sync::atomic::AtomicU64::new(CONTROLLER_TOOL_APPROVAL_ID_BASE);
-fn next_controller_tool_approval_id() -> u64 {
-    CONTROLLER_TOOL_APPROVAL_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-}
-
 /// Outcome of the controller-tool approval gate.
 enum ControllerToolGate {
     /// Dispatch the call.
@@ -919,7 +908,7 @@ async fn gate_controller_tool_call(
     slog(session_log, |l| {
         l.approval(&category.to_string(), preview, "waiting")
     });
-    let id = next_controller_tool_approval_id();
+    let id = event::next_approval_id();
 
     // (response, via_json): on the JSON stdin lane this waiter emits
     // ApprovalResolved itself; on the registry lane the resolver
@@ -2298,7 +2287,7 @@ pub(crate) async fn run_agent_loop(
                     .clone()
                     .unwrap_or_else(|| "The agent asked for your input.".to_string());
                 slog(&session_log, |l| l.human_question(&question));
-                let question_id = turn as u64;
+                let question_id = event::next_approval_id();
                 let (tx, rx) = tokio::sync::oneshot::channel();
                 approval_registry.lock().unwrap().insert(question_id, tx);
                 bus.send(AppEvent::UserQuestionRequired {
@@ -2425,18 +2414,19 @@ pub(crate) async fn run_agent_loop(
                         return Ok((loop_stats, LoopExitReason::Denied));
                     }
 
+                    let approval_id = event::next_approval_id();
                     if let Some(slot) = json_approval {
                         // JSON mode: emit approval event and wait for stdin response
                         bus.send(AppEvent::ApprovalRequired {
                             session_id: local_session_id.clone(),
-                            id: turn as u64,
+                            id: approval_id,
                             command_preview: preview.clone(),
                             category: cat,
                         });
                         let (tx, rx) = tokio::sync::oneshot::channel();
                         {
                             let mut guard = slot.lock().unwrap();
-                            *guard = Some((turn as u64, tx));
+                            *guard = Some((approval_id, tx));
                         }
                         match rx.await {
                             Ok(event::ApprovalResponse::Approve) => {
@@ -2445,7 +2435,7 @@ pub(crate) async fn run_agent_loop(
                                 });
                                 bus.send(AppEvent::ApprovalResolved {
                                     session_id: local_session_id.clone(),
-                                    id: turn as u64,
+                                    id: approval_id,
                                     action: "approve".to_string(),
                                 });
                                 apply_user_approval(
@@ -2464,7 +2454,7 @@ pub(crate) async fn run_agent_loop(
                                 });
                                 bus.send(AppEvent::ApprovalResolved {
                                     session_id: local_session_id.clone(),
-                                    id: turn as u64,
+                                    id: approval_id,
                                     action: "approve_all".to_string(),
                                 });
                                 apply_user_approval(
@@ -2483,7 +2473,7 @@ pub(crate) async fn run_agent_loop(
                                 });
                                 bus.send(AppEvent::ApprovalResolved {
                                     session_id: local_session_id.clone(),
-                                    id: turn as u64,
+                                    id: approval_id,
                                     action: "skip".to_string(),
                                 });
                                 should_skip = true;
@@ -2500,7 +2490,7 @@ pub(crate) async fn run_agent_loop(
                                 });
                                 bus.send(AppEvent::ApprovalResolved {
                                     session_id: local_session_id.clone(),
-                                    id: turn as u64,
+                                    id: approval_id,
                                     action: "deny".to_string(),
                                 });
                                 bus.send(AppEvent::TaskComplete {
@@ -2524,10 +2514,10 @@ pub(crate) async fn run_agent_loop(
                     } else {
                         // Interactive mode (TUI/MCP): approval via registry
                         let (tx, rx) = tokio::sync::oneshot::channel();
-                        approval_registry.lock().unwrap().insert(turn as u64, tx);
+                        approval_registry.lock().unwrap().insert(approval_id, tx);
                         bus.send(AppEvent::ApprovalRequired {
                             session_id: local_session_id.clone(),
-                            id: turn as u64,
+                            id: approval_id,
                             command_preview: preview.clone(),
                             category: cat,
                         });
@@ -2897,7 +2887,7 @@ Proceed with explicit assumptions and continue without additional questions."
                     .clone()
                     .unwrap_or_else(|| "The agent asked for your input.".to_string());
                 slog(&session_log, |l| l.human_question(&question));
-                let question_id = turn as u64;
+                let question_id = event::next_approval_id();
                 let (tx, rx) = tokio::sync::oneshot::channel();
                 approval_registry.lock().unwrap().insert(question_id, tx);
                 bus.send(AppEvent::UserQuestionRequired {
@@ -3008,18 +2998,19 @@ Proceed with explicit assumptions and continue without additional questions."
                         return Ok((loop_stats, LoopExitReason::Denied));
                     }
 
+                    let approval_id = event::next_approval_id();
                     if let Some(slot) = json_approval {
                         // JSON mode: emit approval event and wait for stdin response
                         bus.send(AppEvent::ApprovalRequired {
                             session_id: local_session_id.clone(),
-                            id: turn as u64,
+                            id: approval_id,
                             command_preview: preview.clone(),
                             category: cat,
                         });
                         let (tx, rx) = tokio::sync::oneshot::channel();
                         {
                             let mut guard = slot.lock().unwrap();
-                            *guard = Some((turn as u64, tx));
+                            *guard = Some((approval_id, tx));
                         }
                         match rx.await {
                             Ok(event::ApprovalResponse::Approve) => {
@@ -3028,7 +3019,7 @@ Proceed with explicit assumptions and continue without additional questions."
                                 });
                                 bus.send(AppEvent::ApprovalResolved {
                                     session_id: local_session_id.clone(),
-                                    id: turn as u64,
+                                    id: approval_id,
                                     action: "approve".to_string(),
                                 });
                                 apply_user_approval(
@@ -3047,7 +3038,7 @@ Proceed with explicit assumptions and continue without additional questions."
                                 });
                                 bus.send(AppEvent::ApprovalResolved {
                                     session_id: local_session_id.clone(),
-                                    id: turn as u64,
+                                    id: approval_id,
                                     action: "approve_all".to_string(),
                                 });
                                 apply_user_approval(
@@ -3066,7 +3057,7 @@ Proceed with explicit assumptions and continue without additional questions."
                                 });
                                 bus.send(AppEvent::ApprovalResolved {
                                     session_id: local_session_id.clone(),
-                                    id: turn as u64,
+                                    id: approval_id,
                                     action: "skip".to_string(),
                                 });
                                 should_skip = true;
@@ -3083,7 +3074,7 @@ Proceed with explicit assumptions and continue without additional questions."
                                 });
                                 bus.send(AppEvent::ApprovalResolved {
                                     session_id: local_session_id.clone(),
-                                    id: turn as u64,
+                                    id: approval_id,
                                     action: "deny".to_string(),
                                 });
                                 bus.send(AppEvent::TaskComplete {
@@ -3107,10 +3098,10 @@ Proceed with explicit assumptions and continue without additional questions."
                     } else {
                         // Interactive mode (TUI/MCP): approval via registry
                         let (tx, rx) = tokio::sync::oneshot::channel();
-                        approval_registry.lock().unwrap().insert(turn as u64, tx);
+                        approval_registry.lock().unwrap().insert(approval_id, tx);
                         bus.send(AppEvent::ApprovalRequired {
                             session_id: local_session_id.clone(),
-                            id: turn as u64,
+                            id: approval_id,
                             command_preview: preview.clone(),
                             category: cat,
                         });
@@ -3818,12 +3809,6 @@ fn messages_json_dump_enabled() -> bool {
     *ENABLED
 }
 
-/// Distinct id space for sandbox-consent question prompts (turn ids count
-/// up from zero, live-audio consent uses 1<<41, controller-tool gates
-/// 1<<42).
-const SANDBOX_CONSENT_ID_BASE: u64 = 1 << 43;
-static SANDBOX_CONSENT_ID_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-
 /// One sandbox write denial worth offering a grant for.
 struct SandboxDenial {
     /// The path the runtime was refused on, as reported.
@@ -4006,8 +3991,7 @@ fn raise_sandbox_consent_cards(
                 continue;
             }
         }
-        let id = SANDBOX_CONSENT_ID_BASE
-            + SANDBOX_CONSENT_ID_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let id = event::next_approval_id();
         let (tx, rx) = tokio::sync::oneshot::channel();
         approval_registry
             .lock()

--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -11,6 +11,14 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 static NEXT_AGENT_OUTPUT_ID: AtomicU64 = AtomicU64::new(1);
+/// Process-wide allocator for every approval and structured-question rail.
+///
+/// Approval registries are session-scoped, but events and frontend state are
+/// daemon-wide. A single allocator keeps their numeric wire ids unambiguous
+/// even when several sessions block concurrently. The base leaves all legacy
+/// turn/range ids below it and remains exactly representable by JavaScript.
+static NEXT_APPROVAL_ID: AtomicU64 = AtomicU64::new(1 << 44);
+const MAX_SAFE_WIRE_ID: u64 = (1 << 53) - 1;
 const OUTBOUND_CONTEXT_SNAPSHOT_RAW_INLINE_LIMIT: usize = 128 * 1024;
 
 pub fn next_agent_output_id() -> String {
@@ -20,6 +28,15 @@ pub fn next_agent_output_id() -> String {
         .map(|d| d.as_millis())
         .unwrap_or_default();
     format!("ao-{millis:x}-{seq:x}")
+}
+
+pub(crate) fn next_approval_id() -> u64 {
+    let id = NEXT_APPROVAL_ID.fetch_add(1, Ordering::Relaxed);
+    assert!(
+        id <= MAX_SAFE_WIRE_ID,
+        "process exhausted the JavaScript-safe approval id space"
+    );
+    id
 }
 
 /// Source of a context injection item.
@@ -4017,6 +4034,14 @@ pub fn spawn_human_question_monitor(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn approval_ids_are_process_wide_monotonic_and_wire_safe() {
+        let first = next_approval_id();
+        let second = next_approval_id();
+        assert!(second > first);
+        assert!(second <= MAX_SAFE_WIRE_ID);
+    }
 
     #[test]
     fn event_bus_send_receive() {

--- a/src/bin/caller/external_events.rs
+++ b/src/bin/caller/external_events.rs
@@ -147,9 +147,6 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
     managed_context_density_handoff: bool,
     managed_context_density_handoff_completed: bool,
 ) -> DrainOutcome {
-    use std::sync::atomic::Ordering;
-
-    let approval_counter = std::sync::atomic::AtomicU64::new(1);
     let mut turns_in_round = 0usize;
     let local_session_id = config.session_id.clone();
     let alias_session_id = config.alias_session_id.clone();
@@ -1816,7 +1813,7 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                         });
                     }
                 } else {
-                    let id = approval_counter.fetch_add(1, Ordering::Relaxed);
+                    let id = event::next_approval_id();
                     // Arm the responder BEFORE announcing the approval: a
                     // frontend that reacts to the event instantly (scripted
                     // control-socket clients) must find the registry entry,
@@ -1963,7 +1960,7 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                         });
                     }
                 } else {
-                    let id = approval_counter.fetch_add(1, Ordering::Relaxed);
+                    let id = event::next_approval_id();
                     // Arm the responder BEFORE announcing the question (same
                     // race as approvals: an instant answer must find the
                     // registry entry).
@@ -2163,7 +2160,7 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                         });
                     }
                 } else {
-                    let id = approval_counter.fetch_add(1, Ordering::Relaxed);
+                    let id = event::next_approval_id();
                     // Arm the responder BEFORE announcing (same race as the
                     // command-approval arm above).
                     let rx = if let Some(slot) = config.json_approval {

--- a/src/bin/caller/live_audio.rs
+++ b/src/bin/caller/live_audio.rs
@@ -2055,23 +2055,10 @@ async fn whisper_inbound_loop<T>(
 // dispatch path's approval registry (popped directly by the MCP
 // approve/deny tools) against the event bus's `ControlCommand` approval
 // verbs (how the web dashboard, tunnel, and control socket resolve), so it
-// works uniformly across daemon shapes. Ids come from a dedicated high
-// range so they can never collide with per-session turn-keyed approvals or
-// the ask range, and the session supervisor's approval routing consults
+// works uniformly across daemon shapes. Ids come from the process-wide
+// approval allocator, and the session supervisor's approval routing consults
 // [`spawn_consent_pending`] so a gate id is not misreported as an unknown
 // approval.
-
-/// Base of the live-audio consent id range. Per-session loops key approvals
-/// by small turn counters and `ask_user` draws from `1 << 40`; this range is
-/// disjoint from both while staying below JS's `Number.MAX_SAFE_INTEGER`.
-const SPAWN_CONSENT_ID_BASE: u64 = 1 << 41;
-
-static SPAWN_CONSENT_ID: std::sync::atomic::AtomicU64 =
-    std::sync::atomic::AtomicU64::new(SPAWN_CONSENT_ID_BASE);
-
-fn next_spawn_consent_id() -> u64 {
-    SPAWN_CONSENT_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-}
 
 /// Default blocking wait for the consent prompt (same as `ask_user`).
 pub(crate) const SPAWN_CONSENT_WAIT: Duration = Duration::from_secs(300);
@@ -2220,7 +2207,7 @@ pub(crate) async fn request_spawn_consent(
 ) -> Result<SpawnConsent, String> {
     use crate::event::{AppEvent, ApprovalResponse, ControlMsg};
 
-    let id = next_spawn_consent_id();
+    let id = crate::event::next_approval_id();
 
     // Native JSON mode: the stdin loop owns the response channel. Arm the
     // slot before announcing so an instant response cannot miss it.
@@ -2329,8 +2316,8 @@ pub(crate) async fn request_spawn_consent(
                         );
                     }
                     Ok(Ok(AppEvent::ControlCommand(msg))) => match msg {
-                        // Ids from the dedicated consent range are globally
-                        // unique — match on id alone (same as `ask_user`).
+                        // Approval ids are process-wide — match on id alone
+                        // (same as `ask_user`).
                         ControlMsg::Approve { id: verb_id, .. }
                         | ControlMsg::ApproveAll { id: verb_id, .. }
                             if verb_id == id =>
@@ -4212,8 +4199,8 @@ mod tests {
     }
 
     /// Wait for the gate's ApprovalRequired and return its id, asserting the
-    /// prompt rides the approval rail with the live-audio category and an id
-    /// from the dedicated consent range.
+    /// prompt rides the approval rail with the live-audio category and a
+    /// JavaScript-safe id from the process-wide allocator.
     async fn wait_for_consent_prompt(rx: &mut tokio::sync::broadcast::Receiver<AppEvent>) -> u64 {
         loop {
             match tokio::time::timeout(Duration::from_secs(5), rx.recv())
@@ -4228,10 +4215,7 @@ mod tests {
                     ..
                 } => {
                     assert_eq!(category, crate::autonomy::ActionCategory::LiveAudioSpawn);
-                    assert!(
-                        id >= SPAWN_CONSENT_ID_BASE,
-                        "consent ids come from the dedicated range: {id}"
-                    );
+                    assert!(id <= (1_u64 << 53) - 1, "consent id is not wire-safe: {id}");
                     assert!(
                         command_preview.contains("spawn_live_audio"),
                         "{command_preview}"

--- a/src/bin/caller/mcp/commands.rs
+++ b/src/bin/caller/mcp/commands.rs
@@ -105,7 +105,7 @@ pub(crate) async fn start_task_with_state(
     s.session_cached_tokens = 0;
     s.session_cache_creation_tokens = 0;
     s.set_phase(Phase::Thinking);
-    s.pending_approval = None;
+    s.pending_approvals.clear();
     s.human_question = None;
     s.should_quit = false;
     s.next_task_orchestrate = orchestrate;
@@ -155,6 +155,7 @@ pub(crate) async fn handle_control_command_mcp(
             let mut s = state.write().await;
             let outcome = resolve_pending_approval(
                 &mut s,
+                id,
                 ApprovalResponse::Approve,
                 McpToolScope::Unrestricted,
             );
@@ -178,6 +179,7 @@ pub(crate) async fn handle_control_command_mcp(
             let mut s = state.write().await;
             let outcome = resolve_pending_approval(
                 &mut s,
+                id,
                 ApprovalResponse::Deny,
                 McpToolScope::Unrestricted,
             );
@@ -202,23 +204,29 @@ pub(crate) async fn handle_control_command_mcp(
             // structured answers straight to whichever waiter registered
             // this id (question prompts share the approval registry).
             let mut s = state.write().await;
-            resolve_approval(
+            let resolved = resolve_approval(
                 &s.approval_registry,
                 id,
                 ApprovalResponse::Answer { answers },
             );
-            s.set_phase(Phase::RunningAgent);
-            s.push_log(LogLevel::Info, "Question answered by MCP agent".to_string());
-            bus.send(AppEvent::ApprovalResolved {
-                session_id: None,
-                id,
-                action: "answer".to_string(),
-            });
+            if resolved {
+                s.set_phase(Phase::RunningAgent);
+                s.push_log(LogLevel::Info, "Question answered by MCP agent".to_string());
+                bus.send(AppEvent::ApprovalResolved {
+                    session_id: None,
+                    id,
+                    action: "answer".to_string(),
+                });
+            }
             emit_control_result(
                 control_tx,
                 "answer_question",
-                true,
-                "answers delivered".to_string(),
+                resolved,
+                if resolved {
+                    "answers delivered".to_string()
+                } else {
+                    format!("question {id} is not pending")
+                },
                 None,
             );
             Some(RESOURCE_APPROVAL_URI)
@@ -239,6 +247,7 @@ pub(crate) async fn handle_control_command_mcp(
             let mut s = state.write().await;
             let outcome = resolve_pending_approval(
                 &mut s,
+                id,
                 ApprovalResponse::Skip,
                 McpToolScope::Unrestricted,
             );
@@ -262,6 +271,7 @@ pub(crate) async fn handle_control_command_mcp(
             let mut s = state.write().await;
             let outcome = resolve_pending_approval(
                 &mut s,
+                id,
                 ApprovalResponse::ApproveAll,
                 McpToolScope::Unrestricted,
             );

--- a/src/bin/caller/mcp/events.rs
+++ b/src/bin/caller/mcp/events.rs
@@ -630,12 +630,15 @@ pub fn spawn_event_listener(
                             LogLevel::Info,
                             format!("Approval required [{}]: {}", category, command_preview),
                         );
-                        s.pending_approval = Some(PendingApprovalState {
+                        s.pending_approvals.insert(
                             id,
-                            command_preview,
-                            category: category.to_string(),
-                            session_id: session_id.clone(),
-                        });
+                            PendingApprovalState {
+                                id,
+                                command_preview,
+                                category: category.to_string(),
+                                session_id: session_id.clone(),
+                            },
+                        );
                         resource_changed = Some("intendant://pending-approval");
                     }
 
@@ -758,8 +761,10 @@ pub fn spawn_event_listener(
                     }
 
                     AppEvent::ApprovalResolved { id, ref action, .. } => {
-                        s.pending_approval = None;
-                        if action == "deny" {
+                        s.pending_approvals.remove(&id);
+                        if !s.pending_approvals.is_empty() {
+                            s.set_phase(Phase::WaitingApproval);
+                        } else if action == "deny" {
                             s.set_phase(Phase::Done);
                         } else {
                             s.set_phase(Phase::RunningAgent);
@@ -1622,7 +1627,7 @@ pub(crate) fn hydrate_requested_session_status_from_logs(
     // (presence_*, external_agent, configured_codex_managed_context,
     // log_dir) — re-audit when the replay converter grows a producer; and
     // fields with replayable producers that the hydration applier never
-    // writes (pending_approval, human_question — ApprovalRequired's arm
+    // writes (pending_approvals, human_question — ApprovalRequired's arm
     // writes only phase state, HumanQuestionDetected has no applier arm) —
     // re-audit when the applier grows a write to them.
     let provider_name = s.provider_name.clone();

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -452,7 +452,10 @@ impl IntendantServer {
                     self.get_logs_for_session(params, session_id).await,
                 ))
             }
-            "get_pending_approval" => Ok(text_tool_result(self.get_pending_approval().await)),
+            "get_pending_approval" => Ok(text_tool_result(
+                self.get_pending_approval_scoped(McpToolScope::from_actor(&actor))
+                    .await,
+            )),
             "get_pending_input" => Ok(text_tool_result(self.get_pending_input().await)),
             "approve" => {
                 let Parameters(params) = parse_params::<ApproveParams>(args)?;
@@ -852,11 +855,11 @@ enum ActionOutcome {
 /// behavior; a supervised agent session — bound by MCP token possession —
 /// is contained even though its transport-default principal is
 /// root-compatible for IAM: it may not rewrite the daemon-global shared
-/// autonomy (`set_autonomy`, `approve_all`) and may only resolve approvals
-/// raised by its own session. The same idea as `grant_user_display`'s
-/// owner-surface gate, keyed on actor provenance instead of trust posture
-/// so deliberately granted scoped humans and federated peers are not
-/// caught by it.
+/// autonomy (`set_autonomy`, `approve_all`) or resolve any approval,
+/// including one raised by its own session. The same idea as
+/// `grant_user_display`'s owner-surface gate, keyed on actor provenance
+/// instead of trust posture so deliberately granted scoped humans and
+/// federated peers are not caught by it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum McpToolScope<'a> {
     /// Full historical behavior.
@@ -883,50 +886,29 @@ impl<'a> McpToolScope<'a> {
 }
 
 /// Send `response` to the registry waiter registered under `id`.
-fn resolve_approval(registry: &ApprovalRegistry, id: u64, response: ApprovalResponse) {
+///
+/// `true` means the exact responder existed and was consumed. Callers must
+/// not retire frontend state merely because some other approval is pending.
+fn resolve_approval(registry: &ApprovalRegistry, id: u64, response: ApprovalResponse) -> bool {
     if let Ok(mut reg) = registry.lock() {
         if let Some(responder) = reg.remove(&id) {
             let _ = responder.send(response);
+            return true;
         }
     }
+    false
 }
 
-/// Denial message when `scope` may not resolve the currently pending
-/// approval, or None when resolution may proceed. Own-session resolution
-/// compares the approval's recorded owning session against the caller's
-/// token-bound session id (alias-aware); unknown ownership on either side
-/// fails closed. Must run under the same state borrow as the resolution so
-/// the decision and the `take()` cannot interleave with a pending swap.
-fn scope_denies_pending_approval(state: &McpAppState, scope: McpToolScope<'_>) -> Option<String> {
-    let McpToolScope::AgentSession { session_id } = scope else {
+/// Approval decisions are owner acts. A supervised agent may raise a prompt,
+/// but possession of its session-scoped MCP token must never let it answer
+/// that prompt itself (including always-ask live-audio consent).
+fn scope_denies_approval_resolution(scope: McpToolScope<'_>) -> Option<String> {
+    let McpToolScope::AgentSession { .. } = scope else {
         return None;
     };
-    let Some(pending) = state.pending_approval.as_ref() else {
-        // Nothing pending: fall through to the ordinary no-op.
-        return None;
-    };
-    let owner = pending
-        .session_id
-        .as_deref()
-        .map(str::trim)
-        .filter(|id| !id.is_empty());
-    let own = session_id.map(str::trim).filter(|id| !id.is_empty());
-    let owned = match (owner, own) {
-        (Some(owner), Some(own)) => {
-            owner == own
-                || state
-                    .session_related_ids(own)
-                    .iter()
-                    .any(|related| related == owner)
-        }
-        _ => false,
-    };
-    if owned {
-        return None;
-    }
     Some(
-        "the pending approval was not raised by your session. A supervised agent session may \
-         only resolve its own session's approvals; the daemon owner resolves others from the \
+        "approval decisions require an owner surface. A supervised agent session cannot resolve \
+         approval prompts, including prompts raised by itself; ask the user to decide from the \
          dashboard or `intendant ctl`."
             .to_string(),
     )
@@ -951,36 +933,34 @@ fn scope_denies_daemon_lifecycle(scope: McpToolScope<'_>, tool: &str) -> Option<
     }
 }
 
-/// Resolve the pending approval prompt with `response` — the single handler
+/// Resolve exactly `requested_id` with `response` — the single handler
 /// behind the approve/deny/skip/approve_all tools and their `ControlMsg`
 /// twins. Phase transition and log line derive from the response kind.
-/// `scope` contains agent-session callers to their own session's approvals
-/// (and refuses ApproveAll outright — it widens daemon-global autonomy);
-/// the check and the `take()` share one `&mut state`, so they are atomic.
+/// Supervised agent sessions are refused outright: approval is an owner act.
+/// The exact-id lookup, responder removal, and pending-state removal share
+/// one `&mut state`, so another prompt cannot be substituted between them.
 fn resolve_pending_approval(
     state: &mut McpAppState,
+    requested_id: u64,
     response: ApprovalResponse,
     scope: McpToolScope<'_>,
 ) -> ActionOutcome {
-    if matches!(scope, McpToolScope::AgentSession { .. })
-        && matches!(response, ApprovalResponse::ApproveAll)
-    {
-        return ActionOutcome::Denied {
-            reason: "approve_all raises daemon-wide autonomy to Full and is not available to \
-                     supervised agent sessions; approve your own session's approvals one at a \
-                     time, or ask the user (ask_user)"
-                .to_string(),
-        };
-    }
-    if let Some(reason) = scope_denies_pending_approval(state, scope) {
+    if let Some(reason) = scope_denies_approval_resolution(scope) {
         return ActionOutcome::Denied { reason };
     }
-    let Some(pending) = state.pending_approval.take() else {
+    let Some(pending) = state.pending_approvals.get(&requested_id) else {
         return ActionOutcome::NoOp {
-            reason: "No pending approval".to_string(),
+            reason: format!("No pending approval with id {requested_id}"),
         };
     };
-    let (phase, log) = match &response {
+    debug_assert_eq!(pending.id, requested_id);
+    if !resolve_approval(&state.approval_registry, requested_id, response.clone()) {
+        return ActionOutcome::NoOp {
+            reason: format!("Approval {requested_id} no longer has a pending responder"),
+        };
+    }
+    state.pending_approvals.remove(&requested_id);
+    let (resolved_phase, log) = match &response {
         ApprovalResponse::Approve => (Phase::RunningAgent, "Approved by MCP agent"),
         ApprovalResponse::Skip => (Phase::RunningAgent, "Skipped by MCP agent"),
         ApprovalResponse::Deny => (Phase::Done, "Denied by MCP agent"),
@@ -990,7 +970,11 @@ fn resolve_pending_approval(
         ),
         ApprovalResponse::Answer { .. } => (Phase::RunningAgent, "Question answered by MCP agent"),
     };
-    resolve_approval(&state.approval_registry, pending.id, response);
+    let phase = if state.pending_approvals.is_empty() {
+        resolved_phase
+    } else {
+        Phase::WaitingApproval
+    };
     state.set_phase(phase);
     state.push_log(LogLevel::Info, log.to_string());
     ActionOutcome::Ok
@@ -1589,8 +1573,19 @@ impl IntendantServer {
         description = "Get the current pending approval request, if any. Returns null if no approval is pending."
     )]
     async fn get_pending_approval(&self) -> String {
+        self.get_pending_approval_scoped(McpToolScope::Unrestricted)
+            .await
+    }
+
+    async fn get_pending_approval_scoped(&self, scope: McpToolScope<'_>) -> String {
         let s = self.state.read().await;
-        match s.approval_snapshot() {
+        let snapshot = match scope {
+            McpToolScope::Unrestricted => s.approval_snapshot(),
+            McpToolScope::AgentSession { session_id } => {
+                s.approval_snapshot_for_session(session_id)
+            }
+        };
+        match snapshot {
             Some(snap) => {
                 serde_json::to_string_pretty(&snap).unwrap_or_else(|_| "null".to_string())
             }
@@ -1624,7 +1619,7 @@ impl IntendantServer {
         scope: McpToolScope<'_>,
     ) -> String {
         let mut s = self.state.write().await;
-        let outcome = resolve_pending_approval(&mut s, ApprovalResponse::Approve, scope);
+        let outcome = resolve_pending_approval(&mut s, params.id, ApprovalResponse::Approve, scope);
         if outcome == ActionOutcome::Ok {
             self.bus.send(AppEvent::ApprovalResolved {
                 session_id: None,
@@ -1643,7 +1638,7 @@ impl IntendantServer {
 
     pub(crate) async fn deny_scoped(&self, params: DenyParams, scope: McpToolScope<'_>) -> String {
         let mut s = self.state.write().await;
-        let outcome = resolve_pending_approval(&mut s, ApprovalResponse::Deny, scope);
+        let outcome = resolve_pending_approval(&mut s, params.id, ApprovalResponse::Deny, scope);
         if outcome == ActionOutcome::Ok {
             self.bus.send(AppEvent::ApprovalResolved {
                 session_id: None,
@@ -1664,7 +1659,7 @@ impl IntendantServer {
 
     pub(crate) async fn skip_scoped(&self, params: SkipParams, scope: McpToolScope<'_>) -> String {
         let mut s = self.state.write().await;
-        let outcome = resolve_pending_approval(&mut s, ApprovalResponse::Skip, scope);
+        let outcome = resolve_pending_approval(&mut s, params.id, ApprovalResponse::Skip, scope);
         if outcome == ActionOutcome::Ok {
             self.bus.send(AppEvent::ApprovalResolved {
                 session_id: None,
@@ -1688,7 +1683,8 @@ impl IntendantServer {
         scope: McpToolScope<'_>,
     ) -> String {
         let mut s = self.state.write().await;
-        let outcome = resolve_pending_approval(&mut s, ApprovalResponse::ApproveAll, scope);
+        let outcome =
+            resolve_pending_approval(&mut s, params.id, ApprovalResponse::ApproveAll, scope);
         if outcome == ActionOutcome::Ok {
             self.bus.send(AppEvent::ApprovalResolved {
                 session_id: None,
@@ -2783,12 +2779,15 @@ pub(crate) mod tests {
     ) -> tokio::sync::oneshot::Receiver<ApprovalResponse> {
         let (tx, rx) = tokio::sync::oneshot::channel();
         state.approval_registry.lock().unwrap().insert(id, tx);
-        state.pending_approval = Some(PendingApprovalState {
+        state.pending_approvals.insert(
             id,
-            command_preview: "echo hi".to_string(),
-            category: "exec".to_string(),
-            session_id: session_id.map(str::to_string),
-        });
+            PendingApprovalState {
+                id,
+                command_preview: "echo hi".to_string(),
+                category: "exec".to_string(),
+                session_id: session_id.map(str::to_string),
+            },
+        );
         rx
     }
 
@@ -2843,7 +2842,7 @@ pub(crate) mod tests {
         assert!(dispatch_result_text(&result).contains("Denied"));
         assert_eq!(autonomy.read().await.level, initial_level);
         assert!(
-            state.read().await.pending_approval.is_some(),
+            state.read().await.pending_approvals.contains_key(&7),
             "denied approve_all must leave the approval pending"
         );
         assert!(rx.try_recv().is_err(), "no response reached the waiter");
@@ -2946,42 +2945,31 @@ pub(crate) mod tests {
         assert!(state.read().await.should_quit);
     }
 
-    /// H5 containment: agent-session callers resolve only approvals raised
-    /// by their own session; the owner surface still resolves anything.
+    /// H4 containment: approval is an owner act, caller ids bind exactly,
+    /// and concurrent prompts cannot replace or consume one another.
     #[tokio::test]
-    async fn agent_sessions_resolve_only_their_own_approvals() {
+    async fn approval_resolution_is_owner_only_and_exactly_bound() {
         let bus = EventBus::new();
         let state = test_state();
         let server = IntendantServer::new(state.clone(), bus);
 
-        // Cross-session: the pending approval belongs to another session.
+        // Arm two concurrent sessions in the daemon-wide observable state.
         let mut other_rx = {
             let mut s = state.write().await;
             arm_pending_approval(&mut s, 11, Some("sess-other"))
         };
-        let result = server
-            .call_tool_by_name_as_caller(
-                "approve",
-                serde_json::json!({ "id": 11 }),
-                Some("sess-a"),
-                None,
-                agent_session_caller("sess-a"),
-            )
-            .await
-            .expect("dispatch");
-        assert!(
-            dispatch_result_text(&result).contains("Denied"),
-            "cross-session approval resolution must be denied"
-        );
-        assert!(state.read().await.pending_approval.is_some());
-        assert!(other_rx.try_recv().is_err());
+        let mut own_rx = {
+            let mut s = state.write().await;
+            arm_pending_approval(&mut s, 13, Some("sess-a"))
+        };
 
-        // deny/skip are contained the same way (they also resolve).
-        for tool in ["deny", "skip"] {
+        // A supervised agent cannot approve either another session or its
+        // own prompt, and deny/skip are the same owner-only decision.
+        for (tool, id) in [("approve", 11), ("approve", 13), ("deny", 13), ("skip", 13)] {
             let result = server
                 .call_tool_by_name_as_caller(
                     tool,
-                    serde_json::json!({ "id": 11 }),
+                    serde_json::json!({ "id": id }),
                     Some("sess-a"),
                     None,
                     agent_session_caller("sess-a"),
@@ -2990,72 +2978,73 @@ pub(crate) mod tests {
                 .expect("dispatch");
             assert!(
                 dispatch_result_text(&result).contains("Denied"),
-                "{tool} must be denied cross-session"
+                "{tool}({id}) must be denied to an agent session"
             );
-            assert!(state.read().await.pending_approval.is_some());
         }
+        assert_eq!(state.read().await.pending_approvals.len(), 2);
+        assert!(other_rx.try_recv().is_err());
+        assert!(own_rx.try_recv().is_err());
 
-        // An approval whose owning session was never recorded fails closed
-        // for agent callers.
-        state.write().await.pending_approval = Some(PendingApprovalState {
-            id: 12,
-            command_preview: "echo hi".to_string(),
-            category: "exec".to_string(),
-            session_id: None,
-        });
+        let owner = || {
+            ToolCaller::from_gate(
+                &crate::access::iam::AccessPrincipal::root_dashboard_session("test", "https"),
+                None,
+            )
+        };
+
+        // An owner-supplied id that is not pending is a no-op. It must not
+        // fall back to whichever prompt most recently arrived.
         let result = server
             .call_tool_by_name_as_caller(
                 "approve",
                 serde_json::json!({ "id": 12 }),
-                Some("sess-a"),
                 None,
-                agent_session_caller("sess-a"),
+                None,
+                owner(),
             )
             .await
             .expect("dispatch");
-        assert!(dispatch_result_text(&result).contains("Denied"));
+        assert!(dispatch_result_text(&result).contains("No pending approval with id 12"));
+        assert_eq!(state.read().await.pending_approvals.len(), 2);
+        assert!(other_rx.try_recv().is_err());
+        assert!(own_rx.try_recv().is_err());
 
-        // Own-session resolution works — including through a linked
-        // backend alias.
-        let own_rx = {
-            let mut s = state.write().await;
-            s.link_session_aliases("sess-a", "backend-a");
-            arm_pending_approval(&mut s, 13, Some("backend-a"))
-        };
+        // Exact owner resolution consumes only id 13; id 11 and its waiter
+        // survive, and the global phase remains waiting for that prompt.
         let result = server
             .call_tool_by_name_as_caller(
                 "approve",
                 serde_json::json!({ "id": 13 }),
-                Some("sess-a"),
                 None,
-                agent_session_caller("sess-a"),
+                None,
+                owner(),
             )
             .await
             .expect("dispatch");
         assert_eq!(dispatch_result_text(&result), "ok");
-        assert!(state.read().await.pending_approval.is_none());
         assert_eq!(own_rx.await.unwrap(), ApprovalResponse::Approve);
+        {
+            let s = state.read().await;
+            assert!(!s.pending_approvals.contains_key(&13));
+            assert!(s.pending_approvals.contains_key(&11));
+            assert_eq!(s.phase, Phase::WaitingApproval);
+        }
+        assert!(other_rx.try_recv().is_err());
 
-        // The owner surface still resolves another session's approval.
-        let owner_rx = {
-            let mut s = state.write().await;
-            arm_pending_approval(&mut s, 14, Some("sess-other"))
-        };
+        // The remaining exact id can then be resolved independently.
         let result = server
             .call_tool_by_name_as_caller(
                 "approve",
-                serde_json::json!({ "id": 14 }),
+                serde_json::json!({ "id": 11 }),
                 None,
                 None,
-                ToolCaller::from_gate(
-                    &crate::access::iam::AccessPrincipal::root_dashboard_session("test", "https"),
-                    None,
-                ),
+                owner(),
             )
             .await
             .expect("dispatch");
         assert_eq!(dispatch_result_text(&result), "ok");
-        assert_eq!(owner_rx.await.unwrap(), ApprovalResponse::Approve);
+        assert_eq!(other_rx.await.unwrap(), ApprovalResponse::Approve);
+        assert!(state.read().await.pending_approvals.is_empty());
     }
 
     #[test]
@@ -3222,7 +3211,7 @@ pub(crate) mod tests {
             assert_eq!(s.budget_pct, 0.0);
             assert_eq!(s.phase, Phase::Idle);
             assert!(s.log_entries.is_empty());
-            assert!(s.pending_approval.is_none());
+            assert!(s.pending_approvals.is_empty());
             assert!(s.human_question.is_none());
             assert!(!s.should_quit);
         });
@@ -4468,6 +4457,7 @@ pub(crate) mod tests {
             let mut s = state.write().await;
             let outcome = resolve_pending_approval(
                 &mut s,
+                999,
                 ApprovalResponse::Approve,
                 McpToolScope::Unrestricted,
             );

--- a/src/bin/caller/mcp/state.rs
+++ b/src/bin/caller/mcp/state.rs
@@ -41,7 +41,12 @@ pub struct McpAppState {
     pub task_description: String,
     pub log_entries: std::collections::VecDeque<LogEntrySnapshot>,
     next_log_id: u64,
-    pub pending_approval: Option<PendingApprovalState>,
+    /// Daemon-observed approvals keyed by their process-wide wire id.
+    ///
+    /// Several managed sessions may block at once. Keeping one slot here
+    /// allowed a later prompt to replace an unrelated earlier one and made
+    /// resolution depend on arrival order instead of the caller-supplied id.
+    pub pending_approvals: std::collections::BTreeMap<u64, PendingApprovalState>,
     pub approval_registry: ApprovalRegistry,
     pub human_question: Option<String>,
     pub should_quit: bool,
@@ -292,7 +297,7 @@ impl McpAppState {
             task_description: String::new(),
             log_entries: std::collections::VecDeque::new(),
             next_log_id: 0,
-            pending_approval: None,
+            pending_approvals: std::collections::BTreeMap::new(),
             approval_registry: ApprovalRegistry::default(),
             human_question: None,
             should_quit: false,
@@ -1529,11 +1534,38 @@ impl McpAppState {
     }
 
     pub(crate) fn approval_snapshot(&self) -> Option<ApprovalSnapshot> {
-        self.pending_approval.as_ref().map(|p| ApprovalSnapshot {
-            id: p.id,
-            command_preview: p.command_preview.clone(),
-            category: p.category.clone(),
-        })
+        self.pending_approvals
+            .last_key_value()
+            .map(|(_, p)| ApprovalSnapshot {
+                id: p.id,
+                command_preview: p.command_preview.clone(),
+                category: p.category.clone(),
+            })
+    }
+
+    pub(crate) fn approval_snapshot_for_session(
+        &self,
+        session_id: Option<&str>,
+    ) -> Option<ApprovalSnapshot> {
+        let session_id = session_id?.trim();
+        if session_id.is_empty() {
+            return None;
+        }
+        let related = self.session_related_ids(session_id);
+        self.pending_approvals
+            .values()
+            .rev()
+            .find(|pending| {
+                pending
+                    .session_id
+                    .as_deref()
+                    .is_some_and(|owner| related.iter().any(|id| id == owner))
+            })
+            .map(|pending| ApprovalSnapshot {
+                id: pending.id,
+                command_preview: pending.command_preview.clone(),
+                category: pending.category.clone(),
+            })
     }
 
     pub(crate) fn human_question_snapshot(&self) -> Option<HumanQuestionSnapshot> {
@@ -1714,20 +1746,24 @@ mod tests {
             let mut s = state.write().await;
             let (tx, rx) = tokio::sync::oneshot::channel();
             s.approval_registry.lock().unwrap().insert(1, tx);
-            s.pending_approval = Some(PendingApprovalState {
-                id: 1,
-                command_preview: "rm -rf /tmp".to_string(),
-                category: "destructive".to_string(),
-                session_id: None,
-            });
+            s.pending_approvals.insert(
+                1,
+                PendingApprovalState {
+                    id: 1,
+                    command_preview: "rm -rf /tmp".to_string(),
+                    category: "destructive".to_string(),
+                    session_id: None,
+                },
+            );
 
             let outcome = resolve_pending_approval(
                 &mut s,
+                1,
                 ApprovalResponse::Approve,
                 McpToolScope::Unrestricted,
             );
             assert_eq!(outcome, ActionOutcome::Ok);
-            assert!(s.pending_approval.is_none());
+            assert!(s.pending_approvals.is_empty());
             assert_eq!(s.phase, Phase::RunningAgent);
 
             // Check the oneshot received the response
@@ -1747,15 +1783,19 @@ mod tests {
             let mut s = state.write().await;
             let (tx, rx) = tokio::sync::oneshot::channel();
             s.approval_registry.lock().unwrap().insert(2, tx);
-            s.pending_approval = Some(PendingApprovalState {
-                id: 2,
-                command_preview: "curl evil.com".to_string(),
-                category: "network".to_string(),
-                session_id: None,
-            });
+            s.pending_approvals.insert(
+                2,
+                PendingApprovalState {
+                    id: 2,
+                    command_preview: "curl evil.com".to_string(),
+                    category: "network".to_string(),
+                    session_id: None,
+                },
+            );
 
             let outcome = resolve_pending_approval(
                 &mut s,
+                2,
                 ApprovalResponse::Deny,
                 McpToolScope::Unrestricted,
             );
@@ -1778,15 +1818,19 @@ mod tests {
             let mut s = state.write().await;
             let (tx, rx) = tokio::sync::oneshot::channel();
             s.approval_registry.lock().unwrap().insert(3, tx);
-            s.pending_approval = Some(PendingApprovalState {
-                id: 3,
-                command_preview: "test".to_string(),
-                category: "exec".to_string(),
-                session_id: None,
-            });
+            s.pending_approvals.insert(
+                3,
+                PendingApprovalState {
+                    id: 3,
+                    command_preview: "test".to_string(),
+                    category: "exec".to_string(),
+                    session_id: None,
+                },
+            );
 
             let outcome = resolve_pending_approval(
                 &mut s,
+                3,
                 ApprovalResponse::Skip,
                 McpToolScope::Unrestricted,
             );
@@ -1809,15 +1853,19 @@ mod tests {
             let mut s = state.write().await;
             let (tx, rx) = tokio::sync::oneshot::channel();
             s.approval_registry.lock().unwrap().insert(4, tx);
-            s.pending_approval = Some(PendingApprovalState {
-                id: 4,
-                command_preview: "ls".to_string(),
-                category: "exec".to_string(),
-                session_id: None,
-            });
+            s.pending_approvals.insert(
+                4,
+                PendingApprovalState {
+                    id: 4,
+                    command_preview: "ls".to_string(),
+                    category: "exec".to_string(),
+                    session_id: None,
+                },
+            );
 
             let outcome = resolve_pending_approval(
                 &mut s,
+                4,
                 ApprovalResponse::ApproveAll,
                 McpToolScope::Unrestricted,
             );
@@ -1861,15 +1909,55 @@ mod tests {
         rt.block_on(async {
             let state = test_state();
             let mut s = state.write().await;
-            s.pending_approval = Some(PendingApprovalState {
-                id: 42,
-                command_preview: "rm -rf /".to_string(),
-                category: "destructive".to_string(),
-                session_id: None,
-            });
+            s.pending_approvals.insert(
+                42,
+                PendingApprovalState {
+                    id: 42,
+                    command_preview: "rm -rf /".to_string(),
+                    category: "destructive".to_string(),
+                    session_id: None,
+                },
+            );
             let snap = s.approval_snapshot().unwrap();
             assert_eq!(snap.id, 42);
             assert_eq!(snap.category, "destructive");
+        });
+    }
+
+    #[test]
+    fn approval_snapshot_for_session_never_leaks_another_sessions_prompt() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let state = test_state();
+            let mut s = state.write().await;
+            s.link_session_aliases("session-a", "backend-a");
+            for (id, session_id) in [(40, "backend-a"), (41, "session-b")] {
+                s.pending_approvals.insert(
+                    id,
+                    PendingApprovalState {
+                        id,
+                        command_preview: format!("prompt {id}"),
+                        category: "exec".to_string(),
+                        session_id: Some(session_id.to_string()),
+                    },
+                );
+            }
+
+            assert_eq!(
+                s.approval_snapshot_for_session(Some("session-a"))
+                    .map(|snapshot| snapshot.id),
+                Some(40)
+            );
+            assert_eq!(
+                s.approval_snapshot_for_session(Some("session-b"))
+                    .map(|snapshot| snapshot.id),
+                Some(41)
+            );
+            assert!(s.approval_snapshot_for_session(Some("session-c")).is_none());
+            assert!(s.approval_snapshot_for_session(None).is_none());
         });
     }
 

--- a/src/bin/caller/mcp/tools_ask.rs
+++ b/src/bin/caller/mcp/tools_ask.rs
@@ -12,10 +12,8 @@
 //! Resolution rides the same wire as every other frontend intent: the
 //! waiter subscribes to the event bus and reacts to the
 //! `ControlMsg::AnswerQuestion` / approval-verb `ControlCommand`s that name
-//! its id. Ask ids are allocated from [`ASK_USER_ID_BASE`], a range
-//! disjoint from the per-session loop counters (which count turns/approvals
-//! from 1), so an MCP-armed ask can never collide with a session's own
-//! pending approvals in the shared id space.
+//! its id. Ask ids use the same process-wide allocator as every approval and
+//! structured-question rail, so concurrent sessions cannot collide.
 //!
 //! `notify_user` is the opposite shape: it broadcasts
 //! [`AppEvent::UserNotification`] and returns immediately. Urgency levels
@@ -37,20 +35,6 @@ pub(crate) const ASK_USER_DEFAULT_WAIT_SECS: u64 = 300;
 pub(crate) const ASK_USER_MAX_WAIT_SECS: u64 = 900;
 /// Maximum notification text size. Notifications are alerts, not documents.
 pub(crate) const NOTIFY_USER_MAX_TEXT_BYTES: usize = 4096;
-
-/// Base of the MCP ask id range. Per-session agent loops allocate approval
-/// and question ids from small local counters (turn numbers, counters from
-/// 1); MCP-armed asks share the same `u64` id space on the wire, so they
-/// draw from a disjoint high range instead. Still well below JS's
-/// `Number.MAX_SAFE_INTEGER` (2^53) — dashboards handle the id as a number.
-pub(crate) const ASK_USER_ID_BASE: u64 = 1 << 40;
-
-static ASK_ID_COUNTER: std::sync::atomic::AtomicU64 =
-    std::sync::atomic::AtomicU64::new(ASK_USER_ID_BASE);
-
-fn next_ask_id() -> u64 {
-    ASK_ID_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-}
 
 /// Ids of `ask_user` questions currently blocked on an answer. Advisory
 /// registry: resolution happens in the waiter (via the bus), but other
@@ -294,7 +278,7 @@ impl IntendantServer {
             );
         };
 
-        let id = next_ask_id();
+        let id = crate::event::next_approval_id();
 
         // No frontend can ever answer in this shape (headless without a web
         // gateway): tell the model to proceed instead of blocking on nobody
@@ -365,8 +349,8 @@ impl IntendantServer {
             // Every frontend intent rides the bus as a ControlCommand
             // (web /ws, dashboard tunnel, control socket, MCP twins), so
             // matching here resolves uniformly across daemon shapes. Ids
-            // from the dedicated ask range are globally unique — match on
-            // id alone.
+            // from the process-wide allocator are globally unique — match
+            // on id alone.
             let AppEvent::ControlCommand(msg) = event else {
                 continue;
             };
@@ -555,10 +539,11 @@ mod tests {
     }
 
     #[test]
-    fn ask_ids_come_from_the_disjoint_range() {
-        // Loop-local approval counters count from 1; the shared id space
-        // only stays collision-free if MCP asks never dip below the base.
-        assert!(next_ask_id() >= ASK_USER_ID_BASE);
+    fn ask_ids_use_the_process_wide_wire_allocator() {
+        let first = crate::event::next_approval_id();
+        let second = crate::event::next_approval_id();
+        assert!(second > first);
+        assert!(second <= (1_u64 << 53) - 1);
     }
 
     #[test]
@@ -640,7 +625,7 @@ mod tests {
             }
             other => panic!("expected UserQuestionRequired, got {other:?}"),
         };
-        assert!(id >= ASK_USER_ID_BASE, "ask id {id} below the MCP range");
+        assert!(id <= (1_u64 << 53) - 1, "ask id is not wire-safe: {id}");
         assert_eq!(questions.len(), 1);
         assert_eq!(questions[0].question, "Which color?");
         assert!(ask_user_question_pending(id));

--- a/src/bin/caller/presence.rs
+++ b/src/bin/caller/presence.rs
@@ -1307,13 +1307,29 @@ pub fn update_agent_state(event: &AppEvent, state: &Arc<Mutex<AgentStateSnapshot
                 category: category.to_string(),
             });
         }
-        AppEvent::ApprovalResolved { action, .. } => {
-            s.pending_approval = None;
-            s.pending_question = None;
-            if action == "deny" {
-                s.phase = "done".to_string();
-            } else {
-                s.phase = "running_agent".to_string();
+        AppEvent::ApprovalResolved { id, action, .. } => {
+            let approval_matched = s
+                .pending_approval
+                .as_ref()
+                .is_some_and(|pending| pending.id == *id);
+            let question_matched = s
+                .pending_question
+                .as_ref()
+                .is_some_and(|pending| pending.id == *id);
+            if approval_matched {
+                s.pending_approval = None;
+            }
+            if question_matched {
+                s.pending_question = None;
+            }
+            // A daemon-wide event stream may carry another session's
+            // resolution. Never let it clear or advance this session's rail.
+            if approval_matched || question_matched {
+                if action == "deny" {
+                    s.phase = "done".to_string();
+                } else {
+                    s.phase = "running_agent".to_string();
+                }
             }
         }
         AppEvent::HumanQuestionDetected { .. } => {
@@ -1667,6 +1683,42 @@ mod tests {
                 s.last_output_summary,
                 "Orchestrator completed: analyzed project structure"
             );
+        }
+
+        update_agent_state(
+            &AppEvent::ApprovalRequired {
+                session_id: Some("session-a".to_string()),
+                id: 100,
+                command_preview: "sensitive action".to_string(),
+                category: crate::autonomy::ActionCategory::CommandExec,
+            },
+            &state,
+        );
+        update_agent_state(
+            &AppEvent::ApprovalResolved {
+                session_id: Some("session-b".to_string()),
+                id: 101,
+                action: "approve".to_string(),
+            },
+            &state,
+        );
+        {
+            let s = state.lock().unwrap();
+            assert_eq!(s.pending_approval.as_ref().map(|p| p.id), Some(100));
+            assert_eq!(s.phase, "waiting_approval");
+        }
+        update_agent_state(
+            &AppEvent::ApprovalResolved {
+                session_id: Some("session-a".to_string()),
+                id: 100,
+                action: "approve".to_string(),
+            },
+            &state,
+        );
+        {
+            let s = state.lock().unwrap();
+            assert!(s.pending_approval.is_none());
+            assert_eq!(s.phase, "running_agent");
         }
 
         update_agent_state(


### PR DESCRIPTION
## Summary

- allocate every approval and structured-question wire id from one process-wide JavaScript-safe sequence
- retain concurrent pending approvals by exact id and scope agent-session visibility to related session aliases
- require the caller-supplied id to match an active responder before changing state
- refuse approval resolution from supervised agent sessions, including their own live-audio consent prompts
- prevent unrelated resolution events and unknown question ids from clearing or advancing frontend state

## Validation

- cargo check --bin intendant
- cargo test --bin intendant approval -- --nocapture
- cargo test --bin intendant approval_snapshot_for_session_never_leaks_another_sessions_prompt -- --nocapture
- cargo clippy --bins -- -D warnings
- cargo test --bins: one full green run (3982 controller, 121 connect, 91 runtime); later stress reruns hit rotating authority-store lock timeouts unrelated to this patch, and every reported failure passed when rerun in isolation
