### PR TITLE
dashboard: user-turn dedupe across lanes, minimize unmounts DOM, switcher focus UX, visible transcript errors

### DIFF
--- a/src/bin/caller/agent_loop.rs
+++ b/src/bin/caller/agent_loop.rs
@@ -63,14 +63,36 @@ pub(crate) struct LoopStats {
     pub(crate) announced_native_session_id: Option<String>,
 }
 
+// `pub` (not `pub(crate)`): this rides the `pub` `AppEvent` enum
+// (`ExternalFollowUpRequested`), and in a bin crate the wider visibility
+// only exists to keep the field/type visibilities consistent — exactly
+// like `external_agent::AgentAttachment`, which the field carried before.
 #[derive(Debug, Clone, Default)]
-pub(crate) struct UserAttachments {
-    pub(crate) items: Vec<external_agent::AgentAttachment>,
+pub struct UserAttachments {
+    pub items: Vec<external_agent::AgentAttachment>,
+    /// Renderable upload-store refs for the SAME user message, minted at
+    /// attachment-resolution time (`resolve_attachments_with_scopes`) for
+    /// the upload-backed entries. These ride the canonical
+    /// `UserMessageLog` row (live wire + session-log persistence) so
+    /// replayed transcripts can show the user's attachments; frame grabs
+    /// have no upload blob and mint no ref. Never consumed by backends —
+    /// display metadata only.
+    pub refs: Vec<crate::types::SessionNoteAttachment>,
 }
 
 impl UserAttachments {
-    pub(crate) fn from_items(items: Vec<external_agent::AgentAttachment>) -> Self {
-        Self { items }
+    pub fn from_items(items: Vec<external_agent::AgentAttachment>) -> Self {
+        Self {
+            items,
+            refs: Vec::new(),
+        }
+    }
+
+    pub fn from_resolved(
+        items: Vec<external_agent::AgentAttachment>,
+        refs: Vec<crate::types::SessionNoteAttachment>,
+    ) -> Self {
+        Self { items, refs }
     }
 
     pub(crate) fn is_empty(&self) -> bool {

--- a/src/bin/caller/display_glue.rs
+++ b/src/bin/caller/display_glue.rs
@@ -148,12 +148,19 @@ pub(crate) async fn resolve_frame_attachments(
 ///
 /// Order is preserved from the input list so the prelude reads the files
 /// in the order the user selected them.
+///
+/// The returned [`UserAttachments`] additionally carries renderable
+/// upload refs (`refs`) for the upload-backed entries — the same
+/// `{upload_id, name, mime, url}` shape session notes use, pointing at
+/// the gateway's `/raw` route — so the canonical `UserMessageLog` row can
+/// persist and replay what the user attached. Frame entries mint no ref
+/// (no upload blob to serve).
 pub(crate) async fn resolve_attachments(
     ids: &[String],
     registry: &Arc<tokio::sync::RwLock<frames::FrameRegistry>>,
     session_dir: &std::path::Path,
     project_root: &std::path::Path,
-) -> Vec<external_agent::AgentAttachment> {
+) -> UserAttachments {
     resolve_attachments_with_scopes(
         ids,
         registry,
@@ -170,11 +177,12 @@ pub(crate) async fn resolve_attachments_with_scopes(
     registry: &Arc<tokio::sync::RwLock<frames::FrameRegistry>>,
     session_dir: &std::path::Path,
     scopes: &[crate::global_store::StoreScope],
-) -> Vec<external_agent::AgentAttachment> {
+) -> UserAttachments {
     if ids.is_empty() {
-        return Vec::new();
+        return UserAttachments::default();
     }
     let mut out: Vec<external_agent::AgentAttachment> = Vec::with_capacity(ids.len());
+    let mut refs: Vec<crate::types::SessionNoteAttachment> = Vec::new();
     for raw in ids {
         if let Some(upload_id) = raw.strip_prefix("upload:") {
             let Some(d) = scopes
@@ -213,6 +221,16 @@ pub(crate) async fn resolve_attachments_with_scopes(
                     },
                 ));
             }
+            // Same URL convention as session-note attachments
+            // (`mcp/tools_notes.rs`): the gateway's raw route resolves the
+            // id against the current-session upload scopes, in every
+            // browser, now and after replay.
+            refs.push(crate::types::SessionNoteAttachment {
+                url: format!("/api/session/current/uploads/{}/raw", d.id),
+                upload_id: d.id.clone(),
+                name: d.original_name.clone().unwrap_or_else(|| d.name.clone()),
+                mime: d.mime.clone(),
+            });
             continue;
         }
         // Frame resolution: accept both "frame:<id>" and bare ids for
@@ -239,7 +257,7 @@ pub(crate) async fn resolve_attachments_with_scopes(
             ),
         ));
     }
-    out
+    UserAttachments::from_resolved(out, refs)
 }
 
 /// Auto-attach the latest display frame(s) from the frame registry.
@@ -1856,7 +1874,7 @@ mod tests {
         let attachments = resolve_attachments(&ids, &registry, &session_dir, &project_root).await;
 
         assert_eq!(attachments.len(), 2);
-        match &attachments[0] {
+        match &attachments.items[0] {
             external_agent::AgentAttachment::File(file) => {
                 assert_eq!(file.name, "data.csv");
                 assert_eq!(file.mime_type, "text/csv");
@@ -1870,7 +1888,7 @@ mod tests {
             }
             other => panic!("expected file upload attachment, got {other:?}"),
         }
-        match &attachments[1] {
+        match &attachments.items[1] {
             external_agent::AgentAttachment::Image(image) => {
                 assert_eq!(image.mime_type, "image/png");
                 assert_eq!(image.local_path.as_ref(), Some(&image_upload.path));
@@ -1878,6 +1896,18 @@ mod tests {
             }
             other => panic!("expected image upload attachment, got {other:?}"),
         }
+        // Upload-backed entries mint renderable refs alongside the backend
+        // items — the canonical user row's replayable attachment metadata.
+        assert_eq!(attachments.refs.len(), 2);
+        assert_eq!(attachments.refs[0].upload_id, file_upload.id);
+        assert_eq!(attachments.refs[0].name, "data.csv");
+        assert_eq!(attachments.refs[0].mime, "text/csv");
+        assert_eq!(
+            attachments.refs[0].url,
+            format!("/api/session/current/uploads/{}/raw", file_upload.id)
+        );
+        assert_eq!(attachments.refs[1].upload_id, image_upload.id);
+        assert_eq!(attachments.refs[1].mime, "image/png");
     }
 
     #[tokio::test]
@@ -1927,7 +1957,7 @@ mod tests {
             resolve_attachments_with_scopes(&ids, &registry, &session_dir, &scopes).await;
 
         assert_eq!(attachments.len(), 1);
-        match &attachments[0] {
+        match &attachments.items[0] {
             external_agent::AgentAttachment::File(file) => {
                 assert_eq!(file.name, "pending.txt");
                 assert_eq!(file.local_path, upload.path);

--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -324,7 +324,7 @@ pub enum AppEvent {
     ExternalFollowUpRequested {
         session_id: String,
         text: String,
-        attachments: Vec<crate::external_agent::AgentAttachment>,
+        attachments: crate::agent_loop::UserAttachments,
         follow_up_id: Option<String>,
     },
     SessionStarted {
@@ -968,6 +968,10 @@ pub enum AppEvent {
         user_turn_index: Option<u32>,
         user_turn_revision: Option<u32>,
         replacement_for_user_turn_index: Option<u32>,
+        /// Renderable upload refs for attachments delivered with this
+        /// message (upload-backed only; frame grabs mint no ref). Display
+        /// metadata: the dashboard shows a thumbnail strip on the row.
+        attachments: Vec<crate::types::SessionNoteAttachment>,
     },
 
     /// Display transport pipeline metrics snapshot.
@@ -3000,6 +3004,7 @@ pub fn app_event_to_outbound(event: &AppEvent) -> Option<crate::types::OutboundE
             user_turn_index: None,
             user_turn_revision: None,
             replacement_for_user_turn_index: None,
+            attachments: Vec::new(),
         }),
         AppEvent::SessionNote {
             session_id,
@@ -3031,6 +3036,7 @@ pub fn app_event_to_outbound(event: &AppEvent) -> Option<crate::types::OutboundE
             user_turn_index,
             user_turn_revision,
             replacement_for_user_turn_index,
+            attachments,
         } => Some(OutboundEvent::LogEntry {
             level: "info".to_string(),
             source: "User".to_string(),
@@ -3040,6 +3046,7 @@ pub fn app_event_to_outbound(event: &AppEvent) -> Option<crate::types::OutboundE
             user_turn_index: *user_turn_index,
             user_turn_revision: *user_turn_revision,
             replacement_for_user_turn_index: *replacement_for_user_turn_index,
+            attachments: attachments.clone(),
         }),
         AppEvent::RecordingStarted { stream_name } => Some(OutboundEvent::RecordingStarted {
             stream_name: stream_name.clone(),
@@ -6076,6 +6083,7 @@ mod tests {
             user_turn_index: Some(4),
             user_turn_revision: Some(2),
             replacement_for_user_turn_index: Some(4),
+            attachments: Vec::new(),
         };
         let outbound = app_event_to_outbound(&event).unwrap();
         let json = serde_json::to_string(&outbound).unwrap();
@@ -6083,6 +6091,30 @@ mod tests {
         assert!(json.contains("\"user_turn_index\":4"));
         assert!(json.contains("\"user_turn_revision\":2"));
         assert!(json.contains("\"replacement_for_user_turn_index\":4"));
+        // Empty attachments stay OFF the wire — the pre-field wire format.
+        assert!(!json.contains("\"attachments\""));
+    }
+
+    #[test]
+    fn outbound_user_message_log_carries_attachment_refs() {
+        let event = AppEvent::UserMessageLog {
+            session_id: Some("sess-1".to_string()),
+            content: "See the screenshot".to_string(),
+            user_turn_index: Some(2),
+            user_turn_revision: Some(1),
+            replacement_for_user_turn_index: None,
+            attachments: vec![crate::types::SessionNoteAttachment {
+                upload_id: "u-77".to_string(),
+                name: "screen.png".to_string(),
+                mime: "image/png".to_string(),
+                url: "/api/session/current/uploads/u-77/raw".to_string(),
+            }],
+        };
+        let outbound = app_event_to_outbound(&event).unwrap();
+        let json = serde_json::to_string(&outbound).unwrap();
+        assert!(json.contains("\"event\":\"log_entry\""));
+        assert!(json.contains("\"upload_id\":\"u-77\""));
+        assert!(json.contains("\"url\":\"/api/session/current/uploads/u-77/raw\""));
     }
 
     #[test]

--- a/src/bin/caller/external_events.rs
+++ b/src/bin/caller/external_events.rs
@@ -618,6 +618,7 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                                     None,
                                     None,
                                     None,
+                                    &[],
                                     &text,
                                 );
                                 pending_runtime_steers.push_back(PendingRuntimeSteer {
@@ -736,7 +737,7 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                             &mut active_side_turns,
                             session_id,
                             text,
-                            UserAttachments::from_items(attachments),
+                            attachments,
                             follow_up_id,
                             None,
                         )

--- a/src/bin/caller/external_mode.rs
+++ b/src/bin/caller/external_mode.rs
@@ -1122,12 +1122,9 @@ pub(crate) async fn run_external_agent_mode(
                                 &drain_config.alias_session_id,
                                 &open_side_threads,
                             ) => {
-                                let followup = FollowUpMessage::with_attachments(
-                                    text,
-                                    UserAttachments::from_items(attachments),
-                                )
-                                .for_target(Some(session_id))
-                                .with_follow_up_id(follow_up_id);
+                                let followup = FollowUpMessage::with_attachments(text, attachments)
+                                    .for_target(Some(session_id))
+                                    .with_follow_up_id(follow_up_id);
                                 if follow_up_message_was_cancelled(
                                     &mut cancelled_follow_ups,
                                     &followup,
@@ -1509,6 +1506,7 @@ pub(crate) async fn run_external_agent_mode(
                 Some(*side_round as u32),
                 Some(user_turn_revision),
                 replacement_for_user_turn_index,
+                &attachments.refs,
                 &turn_text,
             );
             let merged = drain_steer_queue_as_followup(
@@ -1627,6 +1625,7 @@ pub(crate) async fn run_external_agent_mode(
                 Some(*subagent_round as u32),
                 None,
                 None,
+                &attachments.refs,
                 &turn_text,
             );
             let merged = drain_steer_queue_as_followup(
@@ -2336,6 +2335,7 @@ pub(crate) async fn run_external_agent_mode(
             Some(round as u32),
             Some(user_turn_revision),
             replacement_for_user_turn_index,
+            &attachments.refs,
             user_log_text,
         );
         slog(&session_log, |l| {

--- a/src/bin/caller/external_supervision.rs
+++ b/src/bin/caller/external_supervision.rs
@@ -261,6 +261,7 @@ pub(crate) fn try_buffered_idle_agent_event(
 /// the live `UserMessageLog` bus event carrying the same fields — so the
 /// live wire row and its replayed copy are identically tagged and the
 /// dashboard's transcript-signature dedupe collapses them across lanes.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn emit_user_message_log(
     bus: &EventBus,
     session_log: &SharedSessionLog,

--- a/src/bin/caller/external_supervision.rs
+++ b/src/bin/caller/external_supervision.rs
@@ -256,6 +256,11 @@ pub(crate) fn try_buffered_idle_agent_event(
     }
 }
 
+/// Emit one canonical user-message row: a session-log `[user]` line that
+/// persists the turn metadata + renderable attachment refs in `data`, and
+/// the live `UserMessageLog` bus event carrying the same fields — so the
+/// live wire row and its replayed copy are identically tagged and the
+/// dashboard's transcript-signature dedupe collapses them across lanes.
 pub(crate) fn emit_user_message_log(
     bus: &EventBus,
     session_log: &SharedSessionLog,
@@ -263,19 +268,29 @@ pub(crate) fn emit_user_message_log(
     user_turn_index: Option<u32>,
     user_turn_revision: Option<u32>,
     replacement_for_user_turn_index: Option<u32>,
+    attachments: &[crate::types::SessionNoteAttachment],
     text: &str,
 ) {
     let text = text.trim();
     if text.is_empty() {
         return;
     }
-    slog(session_log, |l| l.info(&format!("[user] {}", text)));
+    slog(session_log, |l| {
+        l.user_message(
+            text,
+            user_turn_index,
+            user_turn_revision,
+            replacement_for_user_turn_index,
+            attachments,
+        )
+    });
     bus.send(AppEvent::UserMessageLog {
         session_id: session_id.map(str::to_string),
         content: text.to_string(),
         user_turn_index,
         user_turn_revision,
         replacement_for_user_turn_index,
+        attachments: attachments.to_vec(),
     });
 }
 

--- a/src/bin/caller/managed_context_ops/apply.rs
+++ b/src/bin/caller/managed_context_ops/apply.rs
@@ -461,6 +461,7 @@ pub(crate) async fn start_external_side_followup_turn(
         Some(side_round as u32),
         Some(user_turn_revision),
         None,
+        &[],
         &text,
     );
     let merged = drain_steer_queue_as_followup(
@@ -545,6 +546,7 @@ pub(crate) async fn start_external_primary_steer_followup_turn(
                 None,
                 None,
                 None,
+                &[],
                 &text,
             );
             slog(config.session_log, |l| l.info(&reason));

--- a/src/bin/caller/peer/upcast.rs
+++ b/src/bin/caller/peer/upcast.rs
@@ -2997,6 +2997,7 @@ impl WireEventUpcaster {
                 user_turn_index: _,
                 user_turn_revision: _,
                 replacement_for_user_turn_index: _,
+                attachments: _,
             } => {
                 vec![log_event(wire_log_level(level), source, content.clone())]
             }

--- a/src/bin/caller/run_modes.rs
+++ b/src/bin/caller/run_modes.rs
@@ -2321,15 +2321,13 @@ pub(crate) async fn run_with_presence(
             let initial_attachments = if envelope.attachment_frame_ids.is_empty() {
                 UserAttachments::default()
             } else {
-                UserAttachments::from_items(
-                    resolve_attachments(
-                        &envelope.attachment_frame_ids,
-                        &frame_registry,
-                        &session_dir,
-                        &project.root,
-                    )
-                    .await,
+                resolve_attachments(
+                    &envelope.attachment_frame_ids,
+                    &frame_registry,
+                    &session_dir,
+                    &project.root,
                 )
+                .await
             };
             let mut initial_followup =
                 FollowUpMessage::with_attachments(task_text.clone(), initial_attachments);

--- a/src/bin/caller/session_log/mod.rs
+++ b/src/bin/caller/session_log/mod.rs
@@ -1280,7 +1280,7 @@ impl SessionLog {
             event: "info".to_string(),
             level: Some("info".to_string()),
             message: Some(format!("[user] {}", msg)),
-            data: (!data.is_empty()).then(|| serde_json::Value::Object(data)),
+            data: (!data.is_empty()).then_some(serde_json::Value::Object(data)),
             file: None,
             file2: None,
         });

--- a/src/bin/caller/session_log/mod.rs
+++ b/src/bin/caller/session_log/mod.rs
@@ -1236,6 +1236,56 @@ impl SessionLog {
         });
     }
 
+    /// Log a user message row (`[user] …`) with the live lane's turn
+    /// metadata and renderable attachment refs in `data`, so replay can
+    /// serve the row tagged exactly like the live `UserMessageLog` wire
+    /// row (the cross-lane dedupe key). Stays an ordinary `info` event —
+    /// old readers that ignore `data` render it exactly as before — and
+    /// when there is no metadata at all the emitted line is byte-shaped
+    /// like a plain `info(&format!("[user] {msg}"))`.
+    pub fn user_message(
+        &mut self,
+        msg: &str,
+        user_turn_index: Option<u32>,
+        user_turn_revision: Option<u32>,
+        replacement_for_user_turn_index: Option<u32>,
+        attachments: &[crate::types::SessionNoteAttachment],
+    ) {
+        let mut data = serde_json::Map::new();
+        if let Some(index) = user_turn_index {
+            data.insert("user_turn_index".to_string(), index.into());
+        }
+        if let Some(revision) = user_turn_revision {
+            data.insert("user_turn_revision".to_string(), revision.into());
+        }
+        if let Some(replaced) = replacement_for_user_turn_index {
+            data.insert(
+                "replacement_for_user_turn_index".to_string(),
+                replaced.into(),
+            );
+        }
+        if !attachments.is_empty() {
+            if let Ok(refs) = serde_json::to_value(attachments) {
+                data.insert("attachments".to_string(), refs);
+            }
+        }
+        self.emit(LogEvent {
+            ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
+            turn: if self.current_turn > 0 {
+                Some(self.current_turn)
+            } else {
+                None
+            },
+            event: "info".to_string(),
+            level: Some("info".to_string()),
+            message: Some(format!("[user] {}", msg)),
+            data: (!data.is_empty()).then(|| serde_json::Value::Object(data)),
+            file: None,
+            file2: None,
+        });
+    }
+
     /// Log a voice transcript from the browser presence model.
     pub fn voice_log(&mut self, text: &str, seq: u64, tool_context: Option<&str>) {
         self.emit(LogEvent {

--- a/src/bin/caller/session_log/replay.rs
+++ b/src/bin/caller/session_log/replay.rs
@@ -1272,6 +1272,44 @@ pub fn session_log_entry_to_app_event(
                 if let Some((session_id, source)) = parse_session_attached_message(message) {
                     return Some(AppEvent::SessionAttached { session_id, source });
                 }
+                // User rows written by `SessionLog::user_message` carry the
+                // live lane's turn metadata (and renderable attachment
+                // refs) in `data`. Replay them as `UserMessageLog` so the
+                // served row is identically tagged to the live wire row —
+                // the frontend's transcript-signature dedupe then pairs
+                // the copies (`turn: None` on purpose: the live row never
+                // carried a turn). Legacy `[user]` rows without any of
+                // these fields fall through to the untagged `LogEntry`
+                // below and render exactly as before.
+                if let Some(rest) = message.strip_prefix("[user] ") {
+                    let user_turn_index = u32_from_data(data, "user_turn_index");
+                    let user_turn_revision = u32_from_data(data, "user_turn_revision");
+                    let replacement_for_user_turn_index =
+                        u32_from_data(data, "replacement_for_user_turn_index");
+                    let attachments = data
+                        .and_then(|d| d.get("attachments"))
+                        .and_then(|value| {
+                            serde_json::from_value::<Vec<crate::types::SessionNoteAttachment>>(
+                                value.clone(),
+                            )
+                            .ok()
+                        })
+                        .unwrap_or_default();
+                    if user_turn_index.is_some()
+                        || user_turn_revision.is_some()
+                        || replacement_for_user_turn_index.is_some()
+                        || !attachments.is_empty()
+                    {
+                        return Some(AppEvent::UserMessageLog {
+                            session_id: None,
+                            content: rest.to_string(),
+                            user_turn_index,
+                            user_turn_revision,
+                            replacement_for_user_turn_index,
+                            attachments,
+                        });
+                    }
+                }
             }
             let (source, content) = if let Some(rest) = message.strip_prefix("[user] ") {
                 ("User", rest.to_string())
@@ -1474,6 +1512,145 @@ mod tests {
                 assert_eq!(replayed, text);
             }
             other => panic!("expected SteerRequested, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn rt_user_message_row_replays_turn_metadata_and_attachments() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_dir = dir.path().join("session");
+        let mut log = SessionLog::open(log_dir.clone()).unwrap();
+        let refs = vec![crate::types::SessionNoteAttachment {
+            upload_id: "u-9".to_string(),
+            name: "shot.png".to_string(),
+            mime: "image/png".to_string(),
+            url: "/api/session/current/uploads/u-9/raw".to_string(),
+        }];
+        log.user_message("Look at this", Some(3), Some(2), Some(3), &refs);
+        drop(log);
+
+        let entry = read_last_event(&log_dir, "info");
+        match session_log_entry_to_app_event(&entry, &log_dir).unwrap() {
+            AppEvent::UserMessageLog {
+                session_id,
+                content,
+                user_turn_index,
+                user_turn_revision,
+                replacement_for_user_turn_index,
+                attachments,
+            } => {
+                // Session id is stamped later by the replay-metadata
+                // injector, exactly like untagged log rows.
+                assert_eq!(session_id, None);
+                assert_eq!(content, "Look at this");
+                assert_eq!(user_turn_index, Some(3));
+                assert_eq!(user_turn_revision, Some(2));
+                assert_eq!(replacement_for_user_turn_index, Some(3));
+                assert_eq!(attachments, refs);
+            }
+            other => panic!("expected UserMessageLog, got {:?}", other),
+        }
+
+        // The served wire row matches the live lane's shape: log_entry with
+        // source User, no turn, tagged with the same turn metadata.
+        let outbound = crate::event::app_event_to_outbound(
+            &session_log_entry_to_app_event(&entry, &log_dir).unwrap(),
+        )
+        .unwrap();
+        let json = serde_json::to_value(&outbound).unwrap();
+        assert_eq!(
+            json.get("event").and_then(|v| v.as_str()),
+            Some("log_entry")
+        );
+        assert_eq!(json.get("source").and_then(|v| v.as_str()), Some("User"));
+        assert_eq!(json.get("turn"), None);
+        assert_eq!(
+            json.get("user_turn_index").and_then(|v| v.as_u64()),
+            Some(3)
+        );
+        assert_eq!(
+            json.pointer("/attachments/0/upload_id")
+                .and_then(|v| v.as_str()),
+            Some("u-9")
+        );
+    }
+
+    #[test]
+    fn rt_user_message_row_partial_metadata_still_replays_tagged() {
+        // The mid-turn-steer shape: index/revision absent, but a written
+        // attachment ref must still tag the row (and vice versa — turn
+        // metadata without attachments, the subagent shape).
+        let dir = tempfile::tempdir().unwrap();
+        let log_dir = dir.path().join("session");
+        let mut log = SessionLog::open(log_dir.clone()).unwrap();
+        log.user_message("subagent prompt", Some(2), None, None, &[]);
+        drop(log);
+
+        let entry = read_last_event(&log_dir, "info");
+        match session_log_entry_to_app_event(&entry, &log_dir).unwrap() {
+            AppEvent::UserMessageLog {
+                user_turn_index,
+                user_turn_revision,
+                attachments,
+                ..
+            } => {
+                assert_eq!(user_turn_index, Some(2));
+                assert_eq!(user_turn_revision, None);
+                assert!(attachments.is_empty());
+            }
+            other => panic!("expected UserMessageLog, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn rt_user_message_row_without_metadata_replays_untagged_like_legacy() {
+        // BACKWARD COMPAT: a metadata-less user_message write emits the
+        // same line shape as the historical `info("[user] …")` write (no
+        // `data` key), and BOTH replay as the untagged `LogEntry` old
+        // logs always produced — no tags, turn preserved.
+        let dir = tempfile::tempdir().unwrap();
+        let log_dir = dir.path().join("session");
+        let mut log = SessionLog::open(log_dir.clone()).unwrap();
+        log.turn_start(2, 0.0, 200_000);
+        log.user_message("bare prompt", None, None, None, &[]);
+        log.info("[user] legacy prompt");
+        drop(log);
+
+        let contents = fs::read_to_string(log_dir.join("session.jsonl")).unwrap();
+        let rows: Vec<serde_json::Value> = contents
+            .lines()
+            .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+            .filter(|entry| {
+                entry
+                    .get("message")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|m| m.starts_with("[user] "))
+            })
+            .collect();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(
+            rows[0].get("data"),
+            None,
+            "metadata-less user_message must keep the legacy line shape"
+        );
+
+        for (row, expected) in rows.iter().zip(["bare prompt", "legacy prompt"]) {
+            match session_log_entry_to_app_event(row, &log_dir).unwrap() {
+                AppEvent::LogEntry {
+                    session_id,
+                    level,
+                    source,
+                    content,
+                    turn,
+                } => {
+                    assert_eq!(session_id, None);
+                    assert_eq!(level, "info");
+                    assert_eq!(source, "User");
+                    assert_eq!(content, expected);
+                    assert_eq!(turn, Some(2));
+                }
+                other => panic!("expected untagged LogEntry, got {:?}", other),
+            }
         }
     }
 

--- a/src/bin/caller/session_supervisor/launch.rs
+++ b/src/bin/caller/session_supervisor/launch.rs
@@ -471,7 +471,7 @@ impl SessionSupervisor {
                 attachments.len()
             ));
         }
-        let attachments_for_agent = UserAttachments::from_items(resolved_attachments);
+        let attachments_for_agent = resolved_attachments;
 
         let source = backend
             .as_ref()
@@ -1027,7 +1027,7 @@ impl SessionSupervisor {
             log_dir,
             external_backend.clone(),
             direct.unwrap_or(true),
-            UserAttachments::from_items(resolved_attachments),
+            resolved_attachments,
             None,
             Some(resume_token.clone()),
             (external_backend.is_some() && !force_new).then_some(resume_token),

--- a/src/bin/caller/session_supervisor/mod.rs
+++ b/src/bin/caller/session_supervisor/mod.rs
@@ -676,9 +676,9 @@ impl SessionSupervisor {
         attachments: &[String],
         session_dir: &Path,
         primary_project_root: &Path,
-    ) -> Vec<external_agent::AgentAttachment> {
+    ) -> UserAttachments {
         if attachments.is_empty() {
-            return Vec::new();
+            return UserAttachments::default();
         }
         let scopes = self.attachment_store_scopes(primary_project_root);
         resolve_attachments_with_scopes(

--- a/src/bin/caller/session_supervisor/routing.rs
+++ b/src/bin/caller/session_supervisor/routing.rs
@@ -164,12 +164,9 @@ impl SessionSupervisor {
                     }
                     return;
                 }
-                let msg = FollowUpMessage::with_attachments(
-                    text.clone(),
-                    UserAttachments::from_items(resolved_attachments),
-                )
-                .for_target(Some(requested_id.clone()))
-                .with_follow_up_id(follow_up_id.clone());
+                let msg = FollowUpMessage::with_attachments(text.clone(), resolved_attachments)
+                    .for_target(Some(requested_id.clone()))
+                    .with_follow_up_id(follow_up_id.clone());
                 if tx.send(msg).await.is_err() {
                     emit_follow_up_status(
                         &self.config.bus,
@@ -536,7 +533,7 @@ impl SessionSupervisor {
             .map(|_| request.requested_id.clone());
         let msg = FollowUpMessage::edit_user_message(
             request.text,
-            UserAttachments::from_items(resolved_attachments),
+            resolved_attachments,
             request.user_turn_index,
             user_turn_revision,
             request.original_text,
@@ -1103,12 +1100,8 @@ impl SessionSupervisor {
                 short_session(&managed_id)
             ));
         }
-        let msg = FollowUpMessage::steer(
-            text,
-            UserAttachments::from_items(resolved_attachments),
-            steer_id.clone(),
-        )
-        .for_target(requested_id.clone().or(Some(managed_id.clone())));
+        let msg = FollowUpMessage::steer(text, resolved_attachments, steer_id.clone())
+            .for_target(requested_id.clone().or(Some(managed_id.clone())));
         if tx.send(msg).await.is_err() {
             self.warn(&format!(
                 "Steer dropped: {} session {} in {} is not accepting input",

--- a/src/bin/caller/thread_actions.rs
+++ b/src/bin/caller/thread_actions.rs
@@ -2622,6 +2622,7 @@ pub(crate) fn emit_codex_subagent_transcript_entry(
                 entry,
                 "replacement_for_user_turn_index",
             ),
+            attachments: Vec::new(),
         });
         return;
     }
@@ -3220,6 +3221,7 @@ pub(crate) fn handle_idle_codex_subagent_event(
                 user_turn_index: None,
                 user_turn_revision: None,
                 replacement_for_user_turn_index: None,
+                attachments: Vec::new(),
             });
         }
         external_agent::AgentEvent::Reasoning { text } => {

--- a/src/bin/caller/types.rs
+++ b/src/bin/caller/types.rs
@@ -879,6 +879,13 @@ pub enum OutboundEvent {
         user_turn_revision: Option<u32>,
         #[serde(skip_serializing_if = "Option::is_none")]
         replacement_for_user_turn_index: Option<u32>,
+        /// Renderable upload refs for a user row's delivered attachments
+        /// (`UserMessageLog` lane). Same reference shape session notes use
+        /// — never inline bytes. Additive: absent when empty, so rows
+        /// without attachments serialize byte-identically to the
+        /// pre-field wire format.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        attachments: Vec<SessionNoteAttachment>,
     },
     /// Display-only note an agent posted into its session transcript
     /// (`post_session_note` MCP tool / `intendant ctl session note`).

--- a/static/app/39-session-windows.js
+++ b/static/app/39-session-windows.js
@@ -4051,6 +4051,7 @@ function insertSessionWindowHistoryRecords(win, records, shouldFollow) {
     renderSessionWindowRange(win, win.renderStart);
   }
   applySessionWindowOutputScroll(win, shouldFollow);
+  notifyMinimizedSessionWindowHistoryAppend(win);
 }
 
 function appendMissingRestoredSessionWindowEntries(win, entries, fallbackSessionId) {

--- a/static/app/39-session-windows.js
+++ b/static/app/39-session-windows.js
@@ -3557,7 +3557,18 @@ function sessionWindowRecordFromReplayEntry(entry = {}, fallbackSessionId = '') 
   if (event === 'replay_start' || event === 'context_snapshot') return null;
   if (event === 'log_entry' || !event) {
     if (!content) return null;
-    return { ...base, level: level || 'info', source: source || 'system', content, kind, output_id: entry.output_id || entry.outputId || '' };
+    return {
+      ...base,
+      level: level || 'info',
+      source: source || 'system',
+      content,
+      kind,
+      output_id: entry.output_id || entry.outputId || '',
+      // User rows served by the daemon can carry renderable upload refs
+      // (the UserMessageLog lane) — map them onto the same preview shape
+      // the record builders render as a thumbnail strip.
+      attachment_previews: userLogAttachmentPreviews(entry),
+    };
   }
   if (event === 'session_note') {
     const noteText = String(entry.text || content || '').trim();
@@ -3841,7 +3852,7 @@ function sessionWindowTranscriptContentForNode(node) {
   return sessionWindowTranscriptContentForElement(contentEl);
 }
 
-function sessionWindowTranscriptSignaturesForNode(node, fallbackSessionId = '') {
+function sessionWindowTranscriptSignaturesForNode(node, fallbackSessionId = '', options = {}) {
   if (!node) return [];
   const isCommandOutput = !!node.dataset?.outputId || node.dataset?.kind === 'agent_output';
   // Reasoning rows render a label + elided summary and defer their body,
@@ -3869,7 +3880,7 @@ function sessionWindowTranscriptSignaturesForNode(node, fallbackSessionId = '') 
     replacement_for_user_turn_index: node.dataset?.replacementForUserTurnIndex,
     content,
   }, fallbackSessionId);
-  return sessionWindowTranscriptSignaturesFromParts(parts);
+  return sessionWindowTranscriptSignaturesFromParts(parts, options);
 }
 
 // Per-item signature cache (log-append hot path). Computing a node item's
@@ -3878,12 +3889,15 @@ function sessionWindowTranscriptSignaturesForNode(node, fallbackSessionId = '') 
 // the full-history signature scans. Signatures are stable for an item's
 // lifetime except for its session id, which retargets rewrite in place —
 // so entries are keyed by the effective session id and recomputed when it
-// changes. Node signatures ignore options (as before); record signatures
-// cache per options variant ('near' = includeUserNearTime dedup passes).
-// Item content mutations (live command-output summaries) intentionally do
-// not invalidate: their identity signatures (event/output/item ids) are
-// immutable and their summary-text signatures never matched replayed
-// records in the first place.
+// changes. Both lanes cache per options variant ('near' =
+// includeUserNearTime dedup passes): node-backed items honor options too,
+// so a LIVE user node emits the near-time/turn signatures during
+// hydration dedupe and pairs with its replayed copy (node signatures used
+// to ignore options, which left live user rows invisible to the
+// near-time bridge). Item content mutations (live command-output
+// summaries) intentionally do not invalidate: their identity signatures
+// (event/output/item ids) are immutable and their summary-text signatures
+// never matched replayed records in the first place.
 const _sessionWindowItemSignatureCache = new WeakMap();
 
 function sessionWindowTranscriptSignaturesForHistoryItem(item, fallbackSessionId = '', options = {}) {
@@ -3895,9 +3909,10 @@ function sessionWindowTranscriptSignaturesForHistoryItem(item, fallbackSessionId
     ? String(node.dataset?.sessionId || '').trim()
     : String(record.session_id || record.sessionId || '').trim();
   const sid = ownSid || String(fallbackSessionId || '').trim();
-  const variant = node
-    ? 'node'
-    : (options.includeUserNearTime ? 'near' : (options.includeText === false ? 'noText' : 'def'));
+  const optionsVariant = options.includeUserNearTime
+    ? 'near'
+    : (options.includeText === false ? 'noText' : 'def');
+  const variant = (node ? 'node-' : 'record-') + optionsVariant;
   let cached = _sessionWindowItemSignatureCache.get(item);
   if (cached && cached.sid === sid && cached[variant]) return cached[variant];
   if (!cached || cached.sid !== sid) {
@@ -3905,7 +3920,7 @@ function sessionWindowTranscriptSignaturesForHistoryItem(item, fallbackSessionId
     _sessionWindowItemSignatureCache.set(item, cached);
   }
   const signatures = node
-    ? sessionWindowTranscriptSignaturesForNode(node, fallbackSessionId)
+    ? sessionWindowTranscriptSignaturesForNode(node, fallbackSessionId, options)
     : sessionWindowTranscriptSignaturesForRecord(record, fallbackSessionId, options);
   cached[variant] = signatures;
   return signatures;

--- a/static/app/40-session-launch.js
+++ b/static/app/40-session-launch.js
@@ -739,11 +739,14 @@ function ensureSessionWindowHistory(win) {
 // indices and the rendered nodes' data-history-index. Skipped while the
 // reader is paging inside the region that would be dropped (they can only
 // be there after deep back-paging; the trim resumes when they move on).
+// A minimized window has NO reader (transcript unmounted, renderStart
+// pinned to 0) — trim regardless, or a long-running minimized session
+// would grow logHistory unboundedly.
 function trimSessionWindowHistoryIfNeeded(win) {
   const history = ensureSessionWindowHistory(win);
   if (history.length <= SESSION_WINDOW_HISTORY_LIMIT) return;
   const drop = history.length - SESSION_WINDOW_HISTORY_RETAIN;
-  if (win.renderStart < drop) return;
+  if (win.renderStart < drop && !win.minimized) return;
   // Dropped entries stay in the replay-dedup set as bare signatures, so a
   // reconnect replay can't re-append them as fresh content.
   if (!(win.trimmedHistorySignatures instanceof Set)) win.trimmedHistorySignatures = new Set();
@@ -762,8 +765,10 @@ function trimSessionWindowHistoryIfNeeded(win) {
   // explicitly so the stale Set (with the trimmed items' signatures)
   // frees instead of lingering behind the ref check.
   invalidateSessionWindowHistorySignatureCache(win);
-  win.renderStart -= drop;
-  win.renderEnd -= drop;
+  // Minimized windows sit at renderStart 0 with nothing mounted; clamp
+  // instead of going negative (the children loop below no-ops there).
+  win.renderStart = Math.max(0, win.renderStart - drop);
+  win.renderEnd = Math.max(win.renderStart, win.renderEnd - drop);
   if (win.log) {
     for (const child of win.log.children) {
       const idx = Number(child.dataset?.historyIndex);
@@ -1087,6 +1092,10 @@ function sessionWindowIsRenderingTail(win, historyLength = null) {
 
 function renderSessionWindowRange(win, start) {
   if (!win || !win.log) return;
+  // Minimized: the transcript is unmounted and appends are DATA-ONLY —
+  // every render request no-ops until restore re-renders the tail
+  // (setSessionWindowMinimized → restoreSessionWindowTranscript).
+  if (win.minimized) return;
   const history = ensureSessionWindowHistory(win);
   if (history.length === 0) {
     win.renderStart = 0;
@@ -1113,7 +1122,7 @@ function renderSessionWindowRange(win, start) {
 }
 
 function renderSessionWindowTail(win) {
-  if (!win) return;
+  if (!win || win.minimized) return;
   const history = ensureSessionWindowHistory(win);
   const start = sessionWindowTailStart(history.length);
   if (
@@ -1149,7 +1158,7 @@ function renderSessionWindowTail(win) {
 }
 
 function appendSessionWindowRenderedTailItem(win, item, index, historyLength) {
-  if (!win || !win.log || win.renderEnd !== index) return false;
+  if (!win || !win.log || win.minimized || win.renderEnd !== index) return false;
   const node = materializeSessionWindowHistoryItem(win, item, index);
   if (!node) return false;
   if (win.log.firstElementChild?.classList?.contains('session-window-empty')) {
@@ -1169,7 +1178,7 @@ function appendSessionWindowRenderedTailItem(win, item, index, historyLength) {
 }
 
 function appendSessionWindowRenderedTailItems(win, items, startIndex, historyLength) {
-  if (!win || !win.log || !Array.isArray(items) || items.length === 0) return false;
+  if (!win || !win.log || win.minimized || !Array.isArray(items) || items.length === 0) return false;
   if (win.renderEnd !== startIndex) return false;
   if (win.log.firstElementChild?.classList?.contains('session-window-empty')) {
     win.log.replaceChildren();
@@ -1348,6 +1357,20 @@ function deduplicateSessionWindowHistory(win, shouldFollow = null) {
   return removed;
 }
 
+// While a window is minimized its transcript appends are DATA-ONLY — no
+// DOM mutations — so DOM observers (the composer peek clone-mirrors the
+// log element) never fire. This event is the substitute signal: the peek
+// re-materializes its tail from win.logHistory when the bound window's
+// history grows under it.
+function notifyMinimizedSessionWindowHistoryAppend(win) {
+  if (!win || !win.minimized || !win.sessionId) return;
+  try {
+    window.dispatchEvent(new CustomEvent('ui2:session-window-history-append', {
+      detail: { sessionId: win.sessionId },
+    }));
+  } catch (_) { /* CustomEvent unavailable — the peek stays static until restore */ }
+}
+
 function appendSessionWindowHistory(win, entry, shouldFollow) {
   if (!win || !entry) return;
   const history = ensureSessionWindowHistory(win);
@@ -1372,6 +1395,7 @@ function appendSessionWindowHistory(win, entry, shouldFollow) {
   }
   applySessionWindowOutputScroll(win, shouldFollow);
   trimSessionWindowHistoryIfNeeded(win);
+  notifyMinimizedSessionWindowHistoryAppend(win);
 }
 
 function appendSessionWindowHistoryBatch(win, entries, shouldFollow) {
@@ -1406,6 +1430,7 @@ function appendSessionWindowHistoryBatch(win, entries, shouldFollow) {
   }
   applySessionWindowOutputScroll(win, shouldFollow);
   trimSessionWindowHistoryIfNeeded(win);
+  notifyMinimizedSessionWindowHistoryAppend(win);
 }
 
 function loadOlderSessionWindowEntries(win) {

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -114,6 +114,9 @@ function appendSessionWindowActionMenuItem(parent, action, codex = false) {
 // fields; a no-op once real entries exist.
 function renderSessionWindowLogPlaceholder(win) {
   if (!win || !win.log) return;
+  // Minimized windows keep their transcript unmounted (data-only appends;
+  // see setSessionWindowMinimized) — the placeholder is transcript DOM too.
+  if (win.minimized) return;
   const existing = win.log.querySelector('.session-window-empty');
   // Real entries present: never stomp them (placeholder is gone already).
   if (win.log.childElementCount > (existing ? 1 : 0)) return;
@@ -683,16 +686,51 @@ function toggleSessionWindowHeaderCollapsed(sessionId) {
   setSessionWindowHeaderCollapsed(sid, !win.headerCollapsed);
 }
 
+// Minimize UNMOUNTS the transcript children — a minimized card used to
+// keep its whole rendered window (up to SESSION_WINDOW_RENDER_LIMIT
+// entries) mounted under display:none, so auto-minimized done sub-agents
+// and the Collapse-all sweep saved nothing. The data plane is untouched:
+// win.logHistory keeps accumulating through the ordinary append paths
+// (which go data-only via the win.minimized guards in
+// renderSessionWindowRange / renderSessionWindowTail /
+// appendSessionWindowRenderedTailItem(s)), so restore loses nothing —
+// it re-materializes the visible tail from the history records and lands
+// at the bottom (the existing jump-bottom behavior).
+function unmountSessionWindowTranscript(win) {
+  if (!win || !win.log) return;
+  win.log.replaceChildren();
+  // Nothing is mounted: an empty range at the head is the honest render
+  // state (restore re-renders via renderSessionWindowRange, which has no
+  // early-out, so there is no stale-match hazard).
+  win.renderStart = 0;
+  win.renderEnd = 0;
+}
+
+function restoreSessionWindowTranscript(win) {
+  if (!win || !win.log) return;
+  const history = ensureSessionWindowHistory(win);
+  renderSessionWindowRange(win, sessionWindowTailStart(history.length));
+  win.followOutput = true;
+  win.pendingOutput = false;
+  updateSessionWindowJumpButton(win);
+  scheduleSessionWindowScrollToBottom(win);
+}
+
 function setSessionWindowMinimized(sessionId, minimized) {
   const sid = String(sessionId || '').trim();
   const win = sid ? sessionWindows.get(sid) : null;
   if (!win) return;
+  const wasMinimized = !!win.minimized;
   win.minimized = !!minimized;
   if (win.minimized && maximizedSessionWindowId === sid) {
     maximizedSessionWindowId = '';
     updateSessionWindowMaximizeState();
   }
   updateSessionWindowMinimizeState(sid);
+  if (win.minimized !== wasMinimized) {
+    if (win.minimized) unmountSessionWindowTranscript(win);
+    else restoreSessionWindowTranscript(win);
+  }
   refreshSessionWindowPathLabels(win);
   applySessionWindowGridHeight();
   scheduleSessionRelationshipRender();

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -2739,6 +2739,25 @@ function sessionNoteAttachmentPreviews(d) {
   }));
 }
 
+// User log_entry rows can carry the same upload-ref shape
+// ({upload_id, name, mime, url}) on `attachments` — the daemon's
+// UserMessageLog lane persists what the user attached. Same strip
+// renderer as session notes, but only image refs get a thumbnail src;
+// non-image files degrade straight to the named chip instead of an
+// <img> that errors into one.
+function userLogAttachmentPreviews(d) {
+  const attachments = Array.isArray(d?.attachments) ? d.attachments : [];
+  return attachments.map(att => {
+    const image = String(att?.mime || '').toLowerCase().startsWith('image/');
+    return {
+      dataUrl: image ? (att?.url || '') : '',
+      url: att?.url || '',
+      name: att?.name || 'attachment',
+      mime: att?.mime || '',
+    };
+  });
+}
+
 // Normalize a session_note wire event (live WS or a raw replay/session-
 // detail entry) into the log-command shape renderLogEntry consumes.
 function sessionNoteLogCommand(d) {
@@ -2899,7 +2918,6 @@ function renderLogEntry(c) {
     return;
   }
   finalizeSessionCommandOutputGroups(c);
-  if (shouldSuppressAttachmentReceiptDuplicate(c)) return;
   inferSessionPhaseFromLog(c);
 
   const { entry } = createLogScaffold(c, '');

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -153,6 +153,14 @@ function renderSessionWindowLogPlaceholder(win) {
       }
     });
     box.appendChild(retry);
+    // The reason itself, visible — "session not found (404)" beats a
+    // generic line whose cause hides in a tooltip nobody hovers. Quiet
+    // full-width secondary line; the tooltip keeps the untruncated text.
+    const reason = document.createElement('span');
+    reason.className = 'session-window-empty-reason';
+    reason.textContent = errorText;
+    reason.title = errorText;
+    box.appendChild(reason);
   } else if (hydrating) {
     box.classList.add('session-window-empty-loading');
     box.textContent = 'Loading transcript…';

--- a/static/app/47-annotation-clips.js
+++ b/static/app/47-annotation-clips.js
@@ -976,43 +976,19 @@ function formatSessionDetailTimestamp(value) {
   return formatLogTimestampLabel(raw);
 }
 
-const pendingAttachmentLogReceipts = [];
-const ATTACHMENT_RECEIPT_DEDUPE_MS = 30000;
-
-function normalizeAttachmentReceiptText(text) {
-  return String(text || '').trim().replace(/\s+/g, ' ');
-}
-
-function pruneAttachmentReceiptDedupe(now = Date.now()) {
-  for (let i = pendingAttachmentLogReceipts.length - 1; i >= 0; i--) {
-    if (now - pendingAttachmentLogReceipts[i].createdAt > ATTACHMENT_RECEIPT_DEDUPE_MS) {
-      pendingAttachmentLogReceipts.splice(i, 1);
-    }
-  }
-  while (pendingAttachmentLogReceipts.length > 20) pendingAttachmentLogReceipts.shift();
-}
-
-function rememberAttachmentReceipt(text) {
-  const normalized = normalizeAttachmentReceiptText(text);
-  if (!normalized) return;
-  pruneAttachmentReceiptDedupe();
-  pendingAttachmentLogReceipts.push({ text: normalized, createdAt: Date.now() });
-}
-
-function shouldSuppressAttachmentReceiptDuplicate(c) {
-  const source = String(c && c.source || '').toLowerCase();
-  if (source !== 'user') return false;
-  if (Array.isArray(c.attachment_previews) && c.attachment_previews.length > 0) return false;
-  const text = normalizeAttachmentReceiptText(c.content);
-  if (!text) return false;
-  const now = Date.now();
-  pruneAttachmentReceiptDedupe(now);
-  const idx = pendingAttachmentLogReceipts.findIndex(receipt => receipt.text === text);
-  if (idx < 0) return false;
-  pendingAttachmentLogReceipts.splice(idx, 1);
-  return true;
-}
-
+// Local attachment echo: a STATUS row (source 'attach', never
+// 'user'), so it drops out of YOU semantics — the source-user renderer
+// card, the chapter-nav user classification, and the transcript-signature
+// user pairing all key on source 'user' and ignore it. The canonical YOU
+// row for the same message is the daemon's UserMessageLog log_entry; the
+// old approach (an echo styled AS the user row plus a one-shot live-row
+// suppression) ate the canonical live row and then hydration re-introduced
+// it as a duplicate. The echo deliberately KEEPS the local thumbnails:
+// the live event lane (WASM AddLogEntry) does not carry attachment refs,
+// so this is the instant preview at send time — the canonical row gains
+// its own thumbnail strip from the record lane (session-detail hydration
+// / transcript sync) via the persisted upload refs. The echo itself is
+// local-only and never persisted, so replays show only the canonical row.
 function renderAttachmentReceipt(text, attachments, verb, sessionId) {
   if (!attachments || attachments.length === 0 || typeof renderLogEntry !== 'function') return;
   const previews = attachments.map((att) => ({
@@ -1027,12 +1003,11 @@ function renderAttachmentReceipt(text, attachments, verb, sessionId) {
   renderLogEntry({
     ts: currentLogTime(),
     level: 'info',
-    source: 'user',
+    source: 'attach',
     content,
     session_id: sessionId || undefined,
     attachment_previews: previews,
   });
-  rememberAttachmentReceipt(text);
 }
 
 function uploadAttachButtons() {

--- a/static/app/ui2-activity.css
+++ b/static/app/ui2-activity.css
@@ -130,13 +130,19 @@ html.ui-v2 #activity-subtabs:has(.subtab-btn[data-activity-tab="log"].active) .u
   display: inline-flex;
 }
 
-/* session switcher: a quiet ghost select. appearance:none suppresses the
-   UA arrow, so the data-URI chevron IS the dropdown affordance — it rides
+/* session switcher: a quiet ghost select showing the CURRENT selection's
+   label beside the chevron. appearance:none suppresses the UA arrow, so
+   the data-URI chevron IS the dropdown affordance — it rides
    background-image; keep it when touching `background` (the shorthand
-   would erase it). #6C7482 is the mid-gray that reads on both themes. */
+   would erase it). #6C7482 is the mid-gray that reads on both themes.
+   Width is FIXED, not intrinsic: a select sizes to its widest option, so
+   the control used to jump on every option rebuild (and collapsed to a
+   bare ~40px chevron while option-less); long labels ellipsize inside
+   the stable box instead. */
 html.ui-v2 #activity-subtabs .ui2-session-switcher {
   appearance: none;
   -webkit-appearance: none;
+  width: 156px;
   max-width: 210px;
   height: 28px;
   padding: 0 24px 0 9px;
@@ -150,6 +156,8 @@ html.ui-v2 #activity-subtabs .ui2-session-switcher {
   font-size: 12px;
   font-weight: 550;
   cursor: pointer;
+  overflow: hidden;
+  white-space: nowrap;
   text-overflow: ellipsis;
 }
 html.ui-v2 #activity-subtabs .ui2-session-switcher:hover { border-color: var(--line-2); color: var(--text); }

--- a/static/app/ui2-activity.css
+++ b/static/app/ui2-activity.css
@@ -398,6 +398,12 @@ html.ui-v2 .log-entry.source-prsnc .log-level { color: var(--green); }
 html.ui-v2 .log-entry.source-prsnc .log-level::after { content: 'PRESENCE'; }
 html.ui-v2 .log-entry.source-live .log-level { color: var(--sky); }
 html.ui-v2 .log-entry.source-live .log-level::after { content: 'VOICE'; }
+/* local attachment echo (47's renderAttachmentReceipt): a status row, not
+   user speech — quiet eyebrow, and deliberately NOT source-user, so it
+   never reads as (or dedupes against) the canonical YOU row */
+html.ui-v2 .log-entry.source-attach .log-level { font-size: 0; letter-spacing: 0; color: var(--text-3); }
+html.ui-v2 .log-entry.source-attach .log-level::after { content: 'ATTACH'; }
+html.ui-v2 .log-entry.source-attach .log-content { color: var(--text-3); }
 /* role dot tints */
 html.ui-v2 .log-entry.level-model .log-icon { background: var(--iris); }
 html.ui-v2 .log-entry.level-agent .log-icon { background: var(--green); }

--- a/static/app/ui2-activity.js
+++ b/static/app/ui2-activity.js
@@ -284,6 +284,54 @@ function ui2ApplyFocusSurface() {
   }
 }
 
+// QA drive hooks (window.qa convention): the dashboard validator runs
+// outside the module scope, so the timeline probes need window-visible
+// seams onto the transcript machinery — synthetic entries through the
+// REAL pipelines (processCommands / renderRestoredSessionWindowEntries),
+// plus the minimize/layout/placeholder controls the boot probe asserts.
+// Side-effect-free readback in windowState; the drive hooks mutate only
+// the session windows the probe itself seeds.
+window.qa = Object.assign(window.qa || {}, {
+  timeline: {
+    seedLog: (c) => { processCommands([{ cmd: 'add_log_entry', ...c }]); return true; },
+    seedReplay: (sid, entries) => {
+      const win = sessionWindows.get(sid) || ensureSessionWindow(sid);
+      if (!win) return -1;
+      return renderRestoredSessionWindowEntries(win, entries, sid);
+    },
+    ensureWindow: (sid) => !!ensureSessionWindow(sid),
+    windowState: (sid) => {
+      const win = sessionWindows.get(sid);
+      if (!win) return null;
+      return {
+        mounted: win.log ? win.log.childElementCount : -1,
+        history: Array.isArray(win.logHistory) ? win.logHistory.length : 0,
+        minimized: !!win.minimized,
+        text: win.log ? (win.log.textContent || '') : '',
+        rows: win.log
+          ? [...win.log.querySelectorAll('.log-entry')].map(r => ({
+              text: (r.textContent || '').slice(0, 160),
+              userTurnIndex: r.dataset.userTurnIndex || '',
+            }))
+          : [],
+      };
+    },
+    setMinimized: (sid, minimized) => { setSessionWindowMinimized(sid, minimized); return true; },
+    // try/catch: focus repaints the Context pane, whose three.js renderer
+    // throws in WebGL-less validator browsers — the focus/foreground state
+    // this hook exists for is set before that repaint.
+    focusSession: (sid) => { try { focusSessionWindow(sid); } catch (_) {} return true; },
+    applyLayout: (mode) => { ui2ApplyLayout(mode); return true; },
+    setHydrateError: (sid, message) => {
+      const win = sessionWindows.get(sid);
+      if (!win) return false;
+      win.hydrateError = String(message || '');
+      renderSessionWindowLogPlaceholder(win);
+      return true;
+    },
+  },
+});
+
 // QA readback (window.qa convention): the Focus surface's inputs and its
 // verdict. The interesting regression is silent — Focus renders an empty
 // page — so the probe exposes what it resolved and what it promoted.

--- a/static/app/ui2-chrome.js
+++ b/static/app/ui2-chrome.js
@@ -266,6 +266,18 @@ function ui2WireMirrors() {
     switcher.addEventListener('change', () => {
       const sid = switcher.value;
       const gridLayout = document.documentElement.dataset.ui2Layout === 'grid';
+      // Picking a SESSION while on Grid means "show me that one" — enter
+      // Focus through the same path the Focus button takes (ui2ApplyLayout
+      // keeps the toggle's aria-pressed pair correct); picking
+      // "all sessions" is the inverse gesture and returns to Grid. Within
+      // Focus, picking a session just promotes it (today's behavior).
+      // Layout FIRST: it is the declared intent, and the focus call below
+      // repaints session panes whose renderers can throw in degraded
+      // environments — the layout flip must not ride on their success.
+      if (typeof ui2ApplyLayout === 'function') {
+        if (sid && gridLayout) ui2ApplyLayout('focus');
+        else if (!sid) ui2ApplyLayout('grid');
+      }
       if (sid && typeof focusSessionWindow === 'function') focusSessionWindow(sid);
       else if (!sid && typeof discardPromptTargetReference === 'function') {
         const current = typeof resolvePromptTargetSessionId === 'function'
@@ -273,17 +285,8 @@ function ui2WireMirrors() {
         if (current) discardPromptTargetReference(current);
         if (typeof updatePromptTargetSessionHighlight === 'function') updatePromptTargetSessionHighlight();
       }
-      // Picking a SESSION while on Grid means "show me that one" — enter
-      // Focus through the same path the Focus button takes (ui2ApplyLayout
-      // keeps the toggle's aria-pressed pair correct); picking
-      // "all sessions" is the inverse gesture and returns to Grid. Within
-      // Focus, picking a session just promotes it (today's behavior);
-      // ui2ApplyLayout already ends with ui2ApplyFocusSurface, so the
-      // explicit call below only covers the no-layout-change paths.
-      if (typeof ui2ApplyLayout === 'function') {
-        if (sid && gridLayout) ui2ApplyLayout('focus');
-        else if (!sid) ui2ApplyLayout('grid');
-      }
+      // ui2ApplyLayout already ends with ui2ApplyFocusSurface; this
+      // explicit call covers the no-layout-change paths (Focus→promote).
       if (typeof ui2ApplyFocusSurface === 'function') ui2ApplyFocusSurface();
       // Change feedback: the target-chip brightness-pulse idiom
       // (39's updatePromptTargetChip), sized for a form control.

--- a/static/app/ui2-chrome.js
+++ b/static/app/ui2-chrome.js
@@ -224,7 +224,7 @@ function ui2WireMirrors() {
   const ui2WireSwitcher = () => {
   const switcher = document.getElementById('ui2-session-switcher');
   const rebuildSwitcher = () => {
-    if (!switcher || typeof sessionWindows === 'undefined') return;
+    if (!switcher) return;
     // Must be the SAME selector Focus promotes with (ui2ApplyFocusSurface),
     // or the switcher reads "all sessions" while Focus is showing exactly one
     // session's transcript.
@@ -232,14 +232,19 @@ function ui2WireMirrors() {
       ? (ui2FocusSessionId() || '')
       : (typeof resolvePromptTargetSessionId === 'function'
         ? (resolvePromptTargetSessionId() || '') : '');
+    // Always at least the "all sessions" option: an option-less select
+    // renders as a bare ~40px chevron with no label at all (the pre-wire
+    // boot state), and the control's whole job is showing the selection.
     const options = [['', 'all sessions']];
-    for (const [sid] of sessionWindows) {
-      let label = sid.slice(0, 8);
-      if (typeof sessionIdentityParts === 'function') {
-        const parts = sessionIdentityParts(sid) || {};
-        label = parts.name || parts.shortId || label;
+    if (typeof sessionWindows !== 'undefined') {
+      for (const [sid] of sessionWindows) {
+        let label = sid.slice(0, 8);
+        if (typeof sessionIdentityParts === 'function') {
+          const parts = sessionIdentityParts(sid) || {};
+          label = parts.name || parts.shortId || label;
+        }
+        options.push([sid, label]);
       }
-      options.push([sid, label]);
     }
     const sig = options.map((o) => o[0]).join(',') + '|' + target;
     if (switcher.dataset.sig === sig) return;
@@ -252,10 +257,15 @@ function ui2WireMirrors() {
     }));
     switcher.value = target;
     if (switcher.value !== target) switcher.value = '';
+    // The visible label doubles as the tooltip once it ellipsizes.
+    const selected = switcher.selectedOptions && switcher.selectedOptions[0];
+    switcher.title = 'Focused session — Focus shows this session’s timeline; the composer targets it'
+      + (selected && selected.value ? ` (${selected.textContent})` : '');
   };
   if (switcher) {
     switcher.addEventListener('change', () => {
       const sid = switcher.value;
+      const gridLayout = document.documentElement.dataset.ui2Layout === 'grid';
       if (sid && typeof focusSessionWindow === 'function') focusSessionWindow(sid);
       else if (!sid && typeof discardPromptTargetReference === 'function') {
         const current = typeof resolvePromptTargetSessionId === 'function'
@@ -263,7 +273,27 @@ function ui2WireMirrors() {
         if (current) discardPromptTargetReference(current);
         if (typeof updatePromptTargetSessionHighlight === 'function') updatePromptTargetSessionHighlight();
       }
+      // Picking a SESSION while on Grid means "show me that one" — enter
+      // Focus through the same path the Focus button takes (ui2ApplyLayout
+      // keeps the toggle's aria-pressed pair correct); picking
+      // "all sessions" is the inverse gesture and returns to Grid. Within
+      // Focus, picking a session just promotes it (today's behavior);
+      // ui2ApplyLayout already ends with ui2ApplyFocusSurface, so the
+      // explicit call below only covers the no-layout-change paths.
+      if (typeof ui2ApplyLayout === 'function') {
+        if (sid && gridLayout) ui2ApplyLayout('focus');
+        else if (!sid) ui2ApplyLayout('grid');
+      }
       if (typeof ui2ApplyFocusSurface === 'function') ui2ApplyFocusSurface();
+      // Change feedback: the target-chip brightness-pulse idiom
+      // (39's updatePromptTargetChip), sized for a form control.
+      try {
+        switcher.animate([
+          { transform: 'scale(1)', filter: 'brightness(1)' },
+          { transform: 'scale(1.06)', filter: 'brightness(1.45)', offset: 0.35 },
+          { transform: 'scale(1)', filter: 'brightness(1)' },
+        ], { duration: 450, easing: 'ease-in-out' });
+      } catch (_) { /* Web Animations unavailable — selection change stays silent */ }
     });
     ui2Mirror('task-target-chip', rebuildSwitcher);
     const grid = document.getElementById('session-window-grid');

--- a/static/app/ui2-composer-peek.js
+++ b/static/app/ui2-composer-peek.js
@@ -123,7 +123,16 @@
     if (!peekBoundLog) return 'No transcript yet — send a message below.';
     const ph = peekBoundLog.querySelector('.session-window-empty');
     if (ph && ph.classList.contains('session-window-empty-loading')) return 'Loading transcript…';
-    if (ph && ph.classList.contains('session-window-empty-error')) return 'Transcript failed to load — open Activity to retry.';
+    if (ph && ph.classList.contains('session-window-empty-error')) {
+      // Same visibility rule as the window placeholder: name the reason
+      // (win.hydrateError, the source the placeholder rendered from)
+      // instead of a generic line.
+      const win = peekTargetWindow(peekBoundSid);
+      const reason = String((win && win.hydrateError) || '').trim();
+      return reason
+        ? `Transcript failed to load — ${reason} (open Activity to retry)`
+        : 'Transcript failed to load — open Activity to retry.';
+    }
     return 'No output yet';
   }
 

--- a/static/app/ui2-composer-peek.js
+++ b/static/app/ui2-composer-peek.js
@@ -6,6 +6,15 @@
 // ids), so it never mutates session state; interactive affordances that
 // need the live wiring (collapse, copy, retry) are hidden by the peek
 // stylesheet in favor of "Open in Activity".
+// MINIMIZED target: a minimized window keeps its transcript UNMOUNTED
+// (data-only appends; 41's setSessionWindowMinimized), so the clone
+// mirror has nothing to mirror. The peek then materializes its tail
+// straight from win.logHistory via the record builder — the same nodes
+// restore would mount — and re-renders on the
+// 'ui2:session-window-history-append' signal the data-only append paths
+// dispatch (no DOM mutations means the MutationObserver never fires).
+// Chosen over "restore the window for the peek": peeking must not undo
+// the user's (or the auto-rule's) minimize.
 // Boot follows the ui2-chrome single-boot idiom; every entry point is a
 // no-op when the mount is missing so a stub build stays inert.
 {
@@ -79,6 +88,37 @@
     return out.reverse();
   }
 
+  // Minimized-target fallback: the bound log is unmounted, so build the
+  // tail from win.logHistory records — node-backed items clone their
+  // retained node, record-backed items go through the same record
+  // builder restore uses. Fresh nodes every render (no reconcile): the
+  // tail is ≤ PEEK_TAIL_CAP entries behind a 120ms throttle, and the
+  // surgical reconcile exists for aria-live continuity on the LIVE
+  // mirror, which this lane is not.
+  function peekMaterializedTail() {
+    const win = peekTargetWindow(peekBoundSid);
+    if (!win || !win.minimized || !Array.isArray(win.logHistory) || win.logHistory.length === 0) {
+      return [];
+    }
+    if (typeof buildSessionWindowLogEntry !== 'function') return [];
+    const out = [];
+    for (let i = win.logHistory.length - 1; i >= 0 && out.length < PEEK_TAIL_CAP; i--) {
+      const item = win.logHistory[i];
+      let node = null;
+      try {
+        if (typeof sessionWindowHistoryNode === 'function' && sessionWindowHistoryNode(item)) {
+          node = peekCloneEntry(sessionWindowHistoryNode(item));
+        } else {
+          const record = typeof sessionWindowHistoryRecord === 'function'
+            ? sessionWindowHistoryRecord(item) : null;
+          if (record) node = buildSessionWindowLogEntry(record);
+        }
+      } catch (_) { node = null; }
+      if (node) out.push(node);
+    }
+    return out.reverse();
+  }
+
   function peekEmptyText() {
     if (!peekBoundLog) return 'No transcript yet — send a message below.';
     const ph = peekBoundLog.querySelector('.session-window-empty');
@@ -103,6 +143,13 @@
     if (sources.length === 0) {
       peekRendered = [];
       peekPendingDirty.clear();
+      const materialized = peekMaterializedTail();
+      if (materialized.length > 0) {
+        peekList.replaceChildren(...materialized);
+        if (peekFollow) peekList.scrollTop = peekList.scrollHeight;
+        peekSyncMoreBelow();
+        return;
+      }
       const empty = document.createElement('div');
       empty.className = 'ui2-peek-empty';
       empty.textContent = peekEmptyText();
@@ -515,6 +562,16 @@
     // Open-in-Activity label honest for wherever the user now is.
     window.addEventListener('ui2:tab-changed', () => {
       if (peekIsOpen()) peekSyncOpenLabel();
+    });
+
+    // Minimized-target appends are data-only (no DOM mutations for the
+    // log observer to see) — the append paths dispatch this instead;
+    // re-render the materialized tail through the same throttle.
+    window.addEventListener('ui2:session-window-history-append', (e) => {
+      const sid = (e && e.detail && e.detail.sessionId) || '';
+      if (!peekIsOpen() || !sid || sid !== peekBoundSid) return;
+      peekPendingStructural = true;
+      peekSchedule();
     });
 
     if (typeof ui2Mirror === 'function') {

--- a/static/app/ui2-sessions.css
+++ b/static/app/ui2-sessions.css
@@ -1692,9 +1692,20 @@ html.ui-v2 #tab-sessions .session-card .sc-id { font-family: var(--mono); }
 /* ── Session-window log placeholder states (three-state contract) ── */
 .session-window-empty.session-window-empty-error {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 8px;
   color: var(--red, #f38ba8);
+}
+/* the visible reason line: full-width, quiet, clipped to one line (the
+   tooltip keeps the untruncated text) */
+.session-window-empty-reason {
+  flex-basis: 100%;
+  font-size: 11px;
+  color: var(--text-3, var(--overlay0));
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 .session-window-empty-retry {
   border: 1px solid var(--line, rgba(127,127,127,.35));


### PR DESCRIPTION
Four ratified timeline follow-ups building on #467's presentation changes. One branch, logical commits per item; boot-probe live-DOM assertions for each.

## Item 2 — duplicate user-message bubbles in external-agent sessions

The daemon logs each user turn once, but four frontend lanes produce YOU rows and could not dedupe across live and replay: the live `UserMessageLog` wire row carries `user_turn_index`/`user_turn_revision`, while the session-log replay served the same `[user]` line untagged — no signature bridged the copies, and hydration re-introduced the duplicate.

- **Daemon (a):** `SessionLog::user_message` persists the live lane's turn metadata and renderable upload attachment refs in the `[user]` row's `data`; replay serves tagged rows as `UserMessageLog`, so the served wire row is byte-shaped like the live one (source `User`, `turn: None`, same tags). **Backward compat:** legacy rows without the fields keep today's untagged `LogEntry` path exactly (unit-tested: old-format rows, new-format rows, and the metadata-less write emitting the legacy line shape). The CC-transcript turn annotator is untouched — it overwrites with the same ground truth where the transcript exists; the persisted tags cover the lanes it cannot see.
- **Frontend (b):** the local "Sent/Steered N attachment(s)" echo is now a **status row** (source `attach`, never `source-user`) — it drops out of YOU semantics, chapter-nav user classification, and user signature pairing automatically. `shouldSuppressAttachmentReceiptDuplicate` and its consult site are deleted (the one-shot suppression ate the canonical live T-row; hydration then re-introduced it).
- **Backstop (c):** node-backed history items no longer ignore signature options — live user nodes emit near-time/turn signatures during hydration dedupe, cached per options variant like records.

**Attachment-preview decision:** the canonical user event now carries renderable upload refs (`{upload_id, name, mime, url}`, the session-note shape) minted at attachment-resolution time, persisted and replayed; the record lane (session-detail hydration / transcript sync) renders a thumbnail strip on the canonical row. The **live** WASM `AddLogEntry` lane does not carry attachments — extending it means regenerating the pinned wasm artifacts, which this change deliberately avoids — so the echo status row keeps its local thumbnails as the instant preview at send time. Dupes die either way; frame grabs have no upload blob and mint no ref (count-only). A real supervised-CC live confirmation is deferred to the next live session.

## Item 4 — minimize actually unmounts transcript DOM

Minimize previously toggled a CSS class; a minimized card kept up to 5000 windowed transcript entries mounted under `display:none`. Now minimize unmounts the transcript children (header/vitals untouched); restore re-materializes the visible tail from `win.logHistory` via the existing record builders and lands at the bottom. While minimized, appends are **data-only** (render/append paths guard on `win.minimized`; history, signatures, and dedupe run unchanged, so restore loses nothing), and history trims no longer skip minimized windows. All transitions route through `setSessionWindowMinimized`, so auto-minimized done sub-agents and #467's Collapse-all pill benefit identically.

**Peek-on-minimized decision:** the composer peek clone-mirrors the log element, which is now empty for a minimized target — it falls back to materializing its 12-entry tail from `logHistory` records via the record builder, and re-renders on the `ui2:session-window-history-append` signal the data-only append paths dispatch (no DOM mutations means its MutationObserver never fires). Chosen over restoring the window, which would undo the user's minimize; documented in the fragment header.

## Item 5 — focused-session switcher UX layer

Picking a session while the layout is Grid focuses it **and** enters Focus through `ui2ApplyLayout` (the Focus button's path, so the toggle's `aria-pressed` pair stays correct); picking "all sessions" returns to Grid; within Focus a pick promotes as before. The layout flip runs before the focus call so it cannot be lost to a session-pane repaint throw in degraded environments. The control now always has at least the "all sessions" option (an option-less select rendered as a bare ~40px chevron), holds a fixed width so option rebuilds stop resizing it, ellipsizes long labels (tooltip carries the full label), and pulses on change with the target-chip brightness idiom.

## Micro — visible error kinds on transcript-load failure

The empty-log error placeholder renders the underlying error text as a quiet full-width secondary line (ellipsized; tooltip keeps the untruncated text); the composer peek's mirrored error state names the same reason from `win.hydrateError`.

## Verification

- `cargo fmt --check`, `cargo check`, `cargo test -p intendant --bins` (4005 + 121 + 97 passed), the five lib crates (213 + 571 + 26 + 88 + 39 passed), `cargo clippy --workspace -- -D warnings`, `node --check` on every edited fragment, `validate-dashboard --check-static-scripts` — all green.
- Boot probe (`validate-dashboard --launch-dashboard --require-current-static`) with live-DOM assertions, all passing: item-2 tagged live+replay collapse to one row with legacy rows untagged; item-2c near-time pairing for live nodes; item-4 minimized window has zero transcript children, data-only appends, peek shows the minimized tail, restore re-renders; item-5 Grid pick flips layout with correct aria-pressed and a stable labeled control; micro placeholder shows the reason text with tooltip kept. Driven through a new `window.qa.timeline` namespace (the established validator convention), since the dashboard module scope is unreachable from the harness.
