### PR TITLE
security: authenticate runtime result streams

### DIFF
--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -30,7 +30,7 @@ every session launched at runtime.
 $INTENDANT_LOG_DIR/           │             ▼            ▼             ▼        │
  (per-session dir:            │      ┌────────────┐ ┌──────────┐ ┌──────────┐  │
   session.jsonl, turns/,      │      │  Control   │ │ Session  │ │   Task   │  │
-  <nonce>_stdout.log, …)      │      │   Plane    │ │Supervisor│ │ Dispatch │  │
+  random command logs, …)    │      │   Plane    │ │Supervisor│ │ Dispatch │  │
                               │      │(single     │ │(owns     │ │(presence/│  │
                               │      │ writer of  │ │ session  │ │ task/    │  │
                               │      │ shared     │ │ graph +  │ │ follow-up│  │
@@ -91,10 +91,14 @@ The runtime/controller split is a deliberate security boundary:
   `INTENDANT_*` control namespace), together with ambient host credentials such
   as agent sockets, forge/cloud/registry tokens, and credential-store pointers.
   Both runtime shell handlers independently repeat the provider and ambient
-  scrub as defense in depth. It
-  reads JSON commands from stdin, executes them sequentially, and writes results
-  to stdout. The write sandbox is **on by default on macOS/Linux and opt-in
-  on Windows** (`--sandbox` forces it on, `--no-sandbox` forces it off, and
+  scrub as defense in depth. It reads JSON commands from stdin, executes them
+  sequentially, and writes results
+  to stdout. Each controller spawn authenticates those result envelopes with a
+  fresh secret delivered over stdin and stripped after verification, so a
+  model-driven descendant cannot spoof controller results by finding another
+  writable path to the stdout pipe. The write sandbox is **on by default on
+  macOS/Linux and opt-in on Windows** (`--sandbox` forces it on,
+  `--no-sandbox` forces it off, and
   `[sandbox] enabled` overrides the platform default): reads stay open, writes
   are confined to the project root, scratch/log dirs, the daemon state root's
   `logs/` subtree, and — on Unix — the toolchain caches. On macOS the Seatbelt
@@ -136,9 +140,9 @@ survive a runtime restart, and each runtime invocation starts with an empty map.
 Commands are processed **sequentially**. Each blocks until completion and
 returns its result directly (exit code, stdout tail, stderr tail). The runtime
 exits after processing the batch. Daemons backgrounded in a shell continue after
-the tool returns. Per-nonce stdout/stderr go to `<nonce>_stdout.log` /
-`<nonce>_stderr.log` inside the session directory the controller passes via
-`INTENDANT_LOG_DIR`.
+the tool returns. Per-command stdout/stderr go to atomically-created
+`<nonce>_<random>_stdout.log` / `<nonce>_<random>_stderr.log` files inside the
+session directory the controller passes via `INTENDANT_LOG_DIR`.
 
 ## Execution Shapes
 

--- a/docs/src/runtime-protocol.md
+++ b/docs/src/runtime-protocol.md
@@ -38,6 +38,14 @@ Each command produces one stdout line wrapped as:
 etc.) serialized into a string. The controller parses the outer envelope, matches
 on `nonce`, then parses `data`.
 
+For controller-launched batches, the controller also overwrites an internal
+`runtime_protocol_token` field with a fresh per-spawn secret. The runtime copies
+that token into every result envelope; the controller accepts only matching
+envelopes and strips the field before result mapping or logging. This prevents a
+model-driven descendant that finds an alias for the controller's stdout pipe from
+fabricating results. Direct command-line invocations such as the examples here
+omit the internal field and retain the tokenless envelope shown above.
+
 More examples:
 
 ```bash
@@ -56,14 +64,19 @@ echo '{"commands":[{"function":"execPty","nonce":1,"command":"cd /tmp"},{"functi
 
 ## The `AgentInput` Shape
 
-The entire stdin payload deserializes into `AgentInput` (`src/models.rs`), which
-has exactly one field:
+The entire stdin payload deserializes into `AgentInput` (`src/models.rs`). Its
+user-visible payload has one field:
 
 ```jsonc
 {
   "commands": [ /* array of Command objects, executed in order */ ]
 }
 ```
+
+The controller may add two optional internal fields before spawn:
+`runtime_protocol_token` authenticates result envelopes, and
+`human_response_token` authenticates the filesystem answer channel used by
+`askHuman`. Any model-supplied values are overwritten.
 
 There is no top-level `context` field at the runtime layer — conversation/context
 management is handled entirely on the controller side (see
@@ -173,9 +186,12 @@ one. `replace_lines` errors if `end_line < line_number`.
 - **Shell**: `crate::utils::agent_shell_command()` picks `bash -c <cmd>` on Unix
   and `cmd.exe /C <cmd>` on Windows; the whole command is one argument so the
   shell does word-splitting. Exit semantics are identical across platforms.
-- **stdout/stderr** are streamed to `<log_dir>/<nonce>_stdout.log` /
-  `_stderr.log`; the result carries only the **last 10 KB** of each
-  (`LOG_TAIL_BYTES`).
+- **stdout/stderr** are streamed to unpredictable
+  `<log_dir>/<nonce>_<random>_stdout.log` /
+  `<nonce>_<random>_stderr.log` artifacts; the result carries only the
+  **last 10 KB** of each (`LOG_TAIL_BYTES`). Each artifact is atomically
+  created as a new file, and the runtime reads its tail through the original
+  open handle, so an existing or later-replaced symlink is never followed.
 - **Credentials are stripped at two boundaries.** The controller removes
   canonical provider names, inherited `*_API_KEY` / `*_API_TOKEN` names, and
   ambient host-credential names (agent sockets, forge/cloud/registry tokens,
@@ -206,8 +222,9 @@ A 30 s per-command deadline guarantees a quiet shell can't wedge the loop. (The
 reader thread also answers ConPTY's startup cursor-position query so Windows
 shells don't hang at launch.) The result carries at most the last 10 KiB and a
 `truncated` boolean. When output is larger, the runtime attempts to preserve the
-full transcript as `<nonce>_pty.log`; the returned truncation marker says where
-it was written or reports that preservation failed.
+full transcript as an atomically-created
+`<nonce>_<random>_pty.log`; the returned truncation marker says where it was
+written or reports that preservation failed.
 
 ### `askHuman`
 
@@ -271,10 +288,12 @@ Linux/X11) the merged `session.Xauthority` cookie file.
 
 On the controller side, stdout and stderr from the runtime process are each
 buffer-capped at 64 MiB while excess bytes are still drained to avoid pipe
-deadlock. An honest truncation note is appended when bytes were discarded. If
-the 120-second batch hard timeout fires, the controller kills the runtime but
-salvages every complete JSONL protocol line already flushed by commands that
-finished; an incomplete trailing line is discarded.
+deadlock. An honest truncation note is appended when bytes were discarded.
+Controller-launched batches discard every stdout line that lacks the per-spawn
+protocol token, then strip that token from accepted lines. If the 120-second
+batch hard timeout fires, the controller kills the runtime but salvages every
+complete, authenticated JSONL protocol line already flushed by commands that
+finished; an incomplete or unauthenticated trailing line is discarded.
 
 ## Filesystem Sandboxing
 

--- a/docs/src/session-logging.md
+++ b/docs/src/session-logging.md
@@ -58,9 +58,9 @@ land in the same place.
 ├── model-request-traces/    # exact Codex request archive (exact mode only)
 ├── human_question           # askHuman IPC: question file (session-scoped)
 ├── human_response           # askHuman IPC: response file (session-scoped)
-├── <nonce>_stdout.log       # runtime stdout for command nonce N  (e.g. 1_stdout.log)
-├── <nonce>_stderr.log       # runtime stderr for command nonce N
-├── <nonce>_pty.log          # full over-cap execPty transcript (only when needed)
+├── <nonce>_<random>_stdout.log # runtime stdout for command nonce N
+├── <nonce>_<random>_stderr.log # runtime stderr for command nonce N
+├── <nonce>_<random>_pty.log    # full over-cap execPty transcript (only when needed)
 ├── frames/                  # display & camera frame captures
 │   ├── frames.jsonl         #   frame manifest (id, stream, timestamp, sent_to_live)
 │   └── *.jpg                #   HQ JPEG frames
@@ -100,10 +100,12 @@ full-context dumps measured ~47% of a real fleet log store):
   restores the archive-everything behavior.
 
 Turn files are named `turn_{NNN}_{suffix}` with `NNN` zero-padded to three digits
-(`write_turn_file` / `append_turn_file`). Per-nonce runtime logs are named
-`{nonce}_stdout.log` / `{nonce}_stderr.log`; an `execPty` result larger than
-10 KiB additionally attempts to preserve its full text in `{nonce}_pty.log`
-(`agent.rs`).
+(`write_turn_file` / `append_turn_file`). Per-command runtime logs are named
+`{nonce}_{random}_stdout.log` / `{nonce}_{random}_stderr.log`; an `execPty`
+result larger than 10 KiB additionally attempts to preserve its full text in
+`{nonce}_{random}_pty.log` (`agent.rs`). The random component is a 32-hex-digit
+UUID. Each file is atomically created as new so a model-chosen nonce cannot
+target a pre-planted symlink.
 
 ### `session_meta.json`
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -9,8 +9,8 @@ use std::os::unix::fs::MetadataExt;
 
 use std::{
     collections::HashMap,
-    fs::{self, OpenOptions},
-    io::{Read as _, Seek, SeekFrom},
+    fs::{self, File, OpenOptions},
+    io::{Read as _, Seek, SeekFrom, Write as _},
     path::{Path, PathBuf},
     process::Stdio,
     sync::{Arc, LazyLock, RwLock},
@@ -72,6 +72,45 @@ const DSR_CPR_REPLY: &[u8] = b"\x1b[1;1R";
 
 const HUMAN_POLL_MS: u64 = 500;
 const LOG_TAIL_BYTES: u64 = 10 * 1024; // 10KB
+const COMMAND_LOG_CREATE_ATTEMPTS: usize = 16;
+
+/// Atomically create a new runtime artifact. `create_new` is the portable
+/// O_CREAT|O_EXCL equivalent: an existing regular file, device, or symlink
+/// is refused instead of followed.
+fn open_new_log_file(path: &Path) -> std::io::Result<File> {
+    OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create_new(true)
+        .open(path)
+}
+
+/// Create an unpredictable per-command artifact inside `log_dir`.
+///
+/// The model controls `nonce`, and an earlier/background command can write
+/// in the session log directory. A random suffix plus atomic creation keeps
+/// it from pre-planting a symlink or other file at the path the runtime will
+/// open. The already-open handle remains authoritative even if the directory
+/// entry is later replaced.
+fn create_command_log(
+    log_dir: &Path,
+    nonce: u64,
+    stream: &str,
+) -> std::io::Result<(PathBuf, File)> {
+    for _ in 0..COMMAND_LOG_CREATE_ATTEMPTS {
+        let suffix = uuid::Uuid::new_v4().simple();
+        let path = log_dir.join(format!("{nonce}_{suffix}_{stream}.log"));
+        match open_new_log_file(&path) {
+            Ok(file) => return Ok((path, file)),
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(err) => return Err(err),
+        }
+    }
+    Err(std::io::Error::new(
+        std::io::ErrorKind::AlreadyExists,
+        "could not allocate a unique runtime log file",
+    ))
+}
 
 // exec_pty sentinel marker pieces. The assembled per-command markers are
 // `{prefix}_{nonce}__`; the typed input only ever carries a *split* form
@@ -205,6 +244,8 @@ pub struct Agent {
     session_xauthority: Option<PathBuf>,
     /// See [`crate::models::AgentInput::human_response_token`].
     human_response_token: Option<String>,
+    /// See [`crate::models::AgentInput::runtime_protocol_token`].
+    runtime_protocol_token: Option<String>,
 }
 
 impl Agent {
@@ -222,6 +263,7 @@ impl Agent {
             available_displays: vec![],
             session_xauthority: None,
             human_response_token: None,
+            runtime_protocol_token: None,
         })
     }
 
@@ -242,6 +284,7 @@ impl Agent {
             available_displays,
             session_xauthority,
             human_response_token: None,
+            runtime_protocol_token: None,
         })
     }
 
@@ -249,6 +292,12 @@ impl Agent {
     /// [`crate::models::AgentInput::human_response_token`]).
     pub fn with_human_response_token(mut self, token: Option<String>) -> Self {
         self.human_response_token = token;
+        self
+    }
+
+    /// Adopt the controller-minted result-stream authentication token.
+    pub fn with_runtime_protocol_token(mut self, token: Option<String>) -> Self {
+        self.runtime_protocol_token = token;
         self
     }
 
@@ -584,14 +633,7 @@ impl Agent {
     }
 
     /// Read the tail of a log file (up to max_bytes from the end).
-    fn read_log_tail(path: &Path, max_bytes: u64) -> String {
-        if !path.exists() {
-            return String::new();
-        }
-        let mut file = match std::fs::File::open(path) {
-            Ok(f) => f,
-            Err(_) => return String::new(),
-        };
+    fn read_open_log_tail(file: &mut File, max_bytes: u64) -> String {
         let total_size = file.metadata().map(|m| m.len()).unwrap_or(0);
         let offset = total_size.saturating_sub(max_bytes);
         let _ = file.seek(SeekFrom::Start(offset));
@@ -600,6 +642,15 @@ impl Agent {
         let bytes_read = file.read(&mut buf).unwrap_or(0);
         buf.truncate(bytes_read);
         String::from_utf8_lossy(&buf).to_string()
+    }
+
+    #[cfg(test)]
+    fn read_log_tail(path: &Path, max_bytes: u64) -> String {
+        let mut file = match File::open(path) {
+            Ok(f) => f,
+            Err(_) => return String::new(),
+        };
+        Self::read_open_log_tail(&mut file, max_bytes)
     }
 
     async fn exec_as_agent(&self, cmd: &AgentCommand) -> Result<String, AgentError> {
@@ -625,19 +676,13 @@ impl Agent {
         let command = self.replace_nonce_refs(command)?;
 
         // Setup output files for this command
-        let stdout_path = self.log_dir.join(format!("{}_stdout.log", cmd.nonce));
-        let stderr_path = self.log_dir.join(format!("{}_stderr.log", cmd.nonce));
-
-        let stdout_file = OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .open(&stdout_path)?;
-        let stderr_file = OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .open(&stderr_path)?;
+        let (_stdout_path, stdout_file) = create_command_log(&self.log_dir, cmd.nonce, "stdout")?;
+        let (_stderr_path, stderr_file) = create_command_log(&self.log_dir, cmd.nonce, "stderr")?;
+        // Read tails through clones of the handles that were atomically
+        // opened above. Reopening by pathname after the shell exits would
+        // reintroduce a replacement/symlink race.
+        let mut stdout_reader = stdout_file.try_clone()?;
+        let mut stderr_reader = stderr_file.try_clone()?;
 
         // Execute command
         let display_id = cmd.display.unwrap_or_else(|| {
@@ -715,8 +760,8 @@ impl Agent {
         self.update_process_info(cmd.nonce, pid, status, exit_code)?;
 
         // Read stdout/stderr tails
-        let stdout_tail = Self::read_log_tail(&stdout_path, LOG_TAIL_BYTES);
-        let stderr_tail = Self::read_log_tail(&stderr_path, LOG_TAIL_BYTES);
+        let stdout_tail = Self::read_open_log_tail(&mut stdout_reader, LOG_TAIL_BYTES);
+        let stderr_tail = Self::read_open_log_tail(&mut stderr_reader, LOG_TAIL_BYTES);
 
         Ok(serde_json::json!({
             "nonce": cmd.nonce,
@@ -1206,10 +1251,7 @@ impl Agent {
 
         let final_output = lines.join("\n");
 
-        let (final_output, truncated) = cap_pty_output(
-            final_output,
-            &self.log_dir.join(format!("{}_pty.log", cmd.nonce)),
-        );
+        let (final_output, truncated) = cap_pty_output(final_output, &self.log_dir, cmd.nonce);
 
         Ok(serde_json::json!({
             "success": true,
@@ -1590,19 +1632,28 @@ impl Agent {
         }
     }
 
-    fn result_json(nonce: u64, data: &str) -> String {
-        serde_json::json!({
+    fn result_json(&self, nonce: u64, data: &str) -> String {
+        let mut result = serde_json::json!({
             "type": "result",
             "nonce": nonce,
             "data": data
-        })
-        .to_string()
+        });
+        if let Some(token) = &self.runtime_protocol_token {
+            result
+                .as_object_mut()
+                .expect("result envelope is an object")
+                .insert(
+                    "runtime_protocol_token".to_string(),
+                    serde_json::Value::String(token.clone()),
+                );
+        }
+        result.to_string()
     }
 
-    fn result_or_error(nonce: u64, result: Result<String, AgentError>) -> String {
+    fn result_or_error(&self, nonce: u64, result: Result<String, AgentError>) -> String {
         match result {
-            Ok(result) => Self::result_json(nonce, &result),
-            Err(e) => Self::result_json(nonce, &format!("Error: {}", e)),
+            Ok(result) => self.result_json(nonce, &result),
+            Err(e) => self.result_json(nonce, &format!("Error: {}", e)),
         }
     }
 
@@ -1621,14 +1672,14 @@ impl Agent {
             let line = match cmd.function.as_str() {
                 "execAsAgent" => {
                     let result = self.exec_as_agent(&cmd).await?;
-                    Self::result_json(cmd.nonce, &result)
+                    self.result_json(cmd.nonce, &result)
                 }
                 "captureScreen" => {
                     let result = self.capture_screen(&cmd).await?;
-                    Self::result_json(cmd.nonce, &result)
+                    self.result_json(cmd.nonce, &result)
                 }
-                "inspectPath" => Self::result_or_error(cmd.nonce, self.inspect_path(&cmd)),
-                "editFile" => Self::result_or_error(cmd.nonce, self.edit_file(&cmd)),
+                "inspectPath" => self.result_or_error(cmd.nonce, self.inspect_path(&cmd)),
+                "editFile" => self.result_or_error(cmd.nonce, self.edit_file(&cmd)),
                 "writeFile" => {
                     // writeFile is editFile with the operation defaulted to
                     // "write"; rewrite the owned command in place (cloning it
@@ -1637,11 +1688,11 @@ impl Agent {
                     if cmd.operation.is_none() {
                         cmd.operation = Some("write".to_string());
                     }
-                    Self::result_or_error(cmd.nonce, self.edit_file(&cmd))
+                    self.result_or_error(cmd.nonce, self.edit_file(&cmd))
                 }
-                "browse" => Self::result_or_error(cmd.nonce, self.browse(&cmd).await),
-                "askHuman" => Self::result_or_error(cmd.nonce, self.ask_human(&cmd).await),
-                "execPty" => Self::result_or_error(cmd.nonce, self.exec_pty(&cmd).await),
+                "browse" => self.result_or_error(cmd.nonce, self.browse(&cmd).await),
+                "askHuman" => self.result_or_error(cmd.nonce, self.ask_human(&cmd).await),
+                "execPty" => self.result_or_error(cmd.nonce, self.exec_pty(&cmd).await),
                 _ => {
                     return Err(AgentError::Process(format!(
                         "Unknown function: {}",
@@ -1773,8 +1824,9 @@ fn incremental_marker_scan(
 /// conversation, mirroring exec_as_agent's 10 KB stdout/stderr tails — an
 /// uncapped PTY transcript (a cargo build, a full test suite) otherwise
 /// rides in the context for the rest of the session. Over-cap output is
-/// preserved in full at `full_log_path` and the truncation marker names it.
-fn cap_pty_output(final_output: String, full_log_path: &Path) -> (String, bool) {
+/// preserved in a random, atomically-created file in `log_dir` and the
+/// truncation marker names it.
+fn cap_pty_output(final_output: String, log_dir: &Path, nonce: u64) -> (String, bool) {
     let tail_cap = LOG_TAIL_BYTES as usize;
     if final_output.len() <= tail_cap {
         return (final_output, false);
@@ -1782,9 +1834,12 @@ fn cap_pty_output(final_output: String, full_log_path: &Path) -> (String, bool) 
     // Be honest about data loss: if the full transcript can't be preserved
     // (disk full, unwritable log dir), the result must say so rather than
     // silently truncating the only copy.
-    let log_note = match fs::write(full_log_path, &final_output) {
-        Ok(()) => format!("; full output: {}", full_log_path.display()),
-        Err(e) => format!("; full transcript unavailable: {}", e),
+    let log_note = match create_command_log(log_dir, nonce, "pty").and_then(|(path, mut file)| {
+        file.write_all(final_output.as_bytes())?;
+        Ok(path)
+    }) {
+        Ok(path) => format!("; full output: {}", path.display()),
+        Err(e) => format!("; full transcript unavailable: {e}"),
     };
     let tail = tail_utf8_by_bytes(&final_output, tail_cap);
     let capped = format!(
@@ -1911,10 +1966,45 @@ mod tests {
         (agent, log_dir)
     }
 
+    fn command_log_paths(log_dir: &Path, nonce: u64, stream: &str) -> Vec<PathBuf> {
+        let prefix = format!("{nonce}_");
+        let suffix = format!("_{stream}.log");
+        let mut paths: Vec<PathBuf> = fs::read_dir(log_dir)
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .and_then(|name| name.strip_prefix(&prefix))
+                    .and_then(|name| name.strip_suffix(&suffix))
+                    .is_some_and(|random| {
+                        random.len() == 32 && random.bytes().all(|byte| byte.is_ascii_hexdigit())
+                    })
+            })
+            .collect();
+        paths.sort();
+        paths
+    }
+
     #[test]
     fn truncate_utf8_by_bytes_stops_at_char_boundary() {
         let text = format!("{}{}", "a".repeat(199), "\u{00e9}");
         assert_eq!(truncate_utf8_by_bytes(&text, 200), "a".repeat(199));
+    }
+
+    #[test]
+    fn result_envelope_carries_runtime_protocol_token_when_armed() {
+        let (agent, _log) = create_test_agent();
+        let agent = agent.with_runtime_protocol_token(Some("controller-secret".to_string()));
+        let parsed: serde_json::Value = serde_json::from_str(&agent.result_json(7, "ok")).unwrap();
+        assert_eq!(parsed["type"], "result");
+        assert_eq!(parsed["nonce"], 7);
+        assert_eq!(parsed["data"], "ok");
+        assert_eq!(
+            parsed["runtime_protocol_token"],
+            serde_json::Value::String("controller-secret".to_string())
+        );
     }
 
     #[tokio::test]
@@ -2063,11 +2153,64 @@ mod tests {
             .unwrap()
             .contains("test_output"));
 
-        // Log files should exist
-        let stdout_path = log_dir.path().join("10_stdout.log");
-        let stderr_path = log_dir.path().join("10_stderr.log");
-        assert!(stdout_path.exists(), "stdout log should be created");
-        assert!(stderr_path.exists(), "stderr log should be created");
+        // Each stream gets one unpredictable, atomically-created log.
+        let stdout_paths = command_log_paths(log_dir.path(), 10, "stdout");
+        let stderr_paths = command_log_paths(log_dir.path(), 10, "stderr");
+        assert_eq!(stdout_paths.len(), 1, "stdout log should be created");
+        assert_eq!(stderr_paths.len(), 1, "stderr log should be created");
+        assert_ne!(stdout_paths[0], log_dir.path().join("10_stdout.log"));
+        assert_ne!(stderr_paths[0], log_dir.path().join("10_stderr.log"));
+        assert!(fs::read_to_string(&stdout_paths[0])
+            .unwrap()
+            .contains("test_output"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_log_creation_refuses_preplanted_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("target");
+        let link = dir.path().join("stdout.log");
+        fs::write(&target, "sentinel").unwrap();
+        symlink(&target, &link).unwrap();
+
+        let error = open_new_log_file(&link).unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+        assert_eq!(fs::read_to_string(target).unwrap(), "sentinel");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn exec_as_agent_ignores_legacy_log_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let (agent, log_dir) = create_test_agent();
+        let target = log_dir.path().join("symlink-target");
+        let legacy_path = log_dir.path().join("10_stdout.log");
+        fs::write(&target, "sentinel").unwrap();
+        symlink(&target, &legacy_path).unwrap();
+        let cmd = AgentCommand {
+            function: "execAsAgent".to_string(),
+            command: Some("printf legitimate".to_string()),
+            nonce: 10,
+            display: Some(1),
+            ..Default::default()
+        };
+
+        let result = agent.exec_as_agent(&cmd).await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["stdout_tail"], "legitimate");
+        assert_eq!(fs::read_to_string(&target).unwrap(), "sentinel");
+        assert!(
+            fs::symlink_metadata(&legacy_path)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "the attacker-planted path must never be opened or replaced"
+        );
+        assert_eq!(command_log_paths(log_dir.path(), 10, "stdout").len(), 1);
     }
 
     #[tokio::test]
@@ -2116,6 +2259,7 @@ mod tests {
     async fn process_input_exec_returns_result() {
         let (agent, _log) = create_test_agent();
         let input = AgentInput {
+            runtime_protocol_token: None,
             human_response_token: None,
             commands: vec![AgentCommand {
                 function: "execAsAgent".to_string(),
@@ -2130,6 +2274,7 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&results[0]).unwrap();
         assert_eq!(parsed["type"], "result");
         assert_eq!(parsed["nonce"], 1);
+        assert!(parsed.get("runtime_protocol_token").is_none());
         // Data contains the exec result with exit_code
         let data: serde_json::Value =
             serde_json::from_str(parsed["data"].as_str().unwrap()).unwrap();
@@ -2140,6 +2285,7 @@ mod tests {
     async fn process_input_unknown_function() {
         let (agent, _log) = create_test_agent();
         let input = AgentInput {
+            runtime_protocol_token: None,
             human_response_token: None,
             commands: vec![AgentCommand {
                 function: "unknownFunc".to_string(),
@@ -2157,6 +2303,7 @@ mod tests {
         let dir = tmp.path().to_str().unwrap().to_string();
         let (agent, _log) = create_test_agent();
         let input = AgentInput {
+            runtime_protocol_token: None,
             human_response_token: None,
             commands: vec![AgentCommand {
                 function: "inspectPath".to_string(),
@@ -2183,6 +2330,7 @@ mod tests {
         let dir = tmp.path().to_str().unwrap().to_string();
         let (agent, _log) = create_test_agent();
         let input = AgentInput {
+            runtime_protocol_token: None,
             human_response_token: None,
             commands: vec![
                 AgentCommand {
@@ -2477,6 +2625,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let fp = tmp.path().join("integration.txt");
         let input = AgentInput {
+            runtime_protocol_token: None,
             human_response_token: None,
             commands: vec![AgentCommand {
                 function: "editFile".to_string(),
@@ -3128,8 +3277,11 @@ mod tests {
         );
         // Marker line + 10 KB tail, nowhere near the full transcript.
         assert!(output.len() < 11 * 1024, "output len {}", output.len());
-        // The full transcript is preserved on disk.
-        let full = fs::read_to_string(log_dir.path().join("77_pty.log")).unwrap();
+        // The full transcript is preserved in one random, atomic artifact.
+        let paths = command_log_paths(log_dir.path(), 77, "pty");
+        assert_eq!(paths.len(), 1);
+        assert_ne!(paths[0], log_dir.path().join("77_pty.log"));
+        let full = fs::read_to_string(&paths[0]).unwrap();
         assert!(
             full.len() > LOG_TAIL_BYTES as usize,
             "full log should exceed the cap, got {}",
@@ -3201,24 +3353,25 @@ mod tests {
     #[test]
     fn cap_pty_output_caps_and_preserves_full_log() {
         let tmp = TempDir::new().unwrap();
-        let log_path = tmp.path().join("1_pty.log");
 
         // Under the cap: untouched, no log file.
         let small = "small output".to_string();
-        let (out, truncated) = cap_pty_output(small.clone(), &log_path);
+        let (out, truncated) = cap_pty_output(small.clone(), tmp.path(), 1);
         assert_eq!(out, small);
         assert!(!truncated);
-        assert!(!log_path.exists());
+        assert!(command_log_paths(tmp.path(), 1, "pty").is_empty());
 
         // Over the cap: marker + tail, full transcript on disk.
         let big = "z".repeat(20_000);
-        let (out, truncated) = cap_pty_output(big.clone(), &log_path);
+        let (out, truncated) = cap_pty_output(big.clone(), tmp.path(), 1);
+        let paths = command_log_paths(tmp.path(), 1, "pty");
+        assert_eq!(paths.len(), 1);
         assert!(truncated);
         assert!(out.starts_with("[execPty output truncated: showing last "));
-        assert!(out.contains(&log_path.display().to_string()));
+        assert!(out.contains(&paths[0].display().to_string()));
         assert!(out.ends_with(&"z".repeat(LOG_TAIL_BYTES as usize)));
         assert!(out.len() < 11 * 1024, "capped len {}", out.len());
-        assert_eq!(fs::read_to_string(&log_path).unwrap(), big);
+        assert_eq!(fs::read_to_string(&paths[0]).unwrap(), big);
 
         // Preservation failure is surfaced, not silently swallowed: the
         // capped result must say the untruncated copy is gone.
@@ -3228,7 +3381,7 @@ mod tests {
             let ro_dir = tmp.path().join("ro");
             fs::create_dir(&ro_dir).unwrap();
             fs::set_permissions(&ro_dir, fs::Permissions::from_mode(0o555)).unwrap();
-            let (out, truncated) = cap_pty_output("w".repeat(20_000), &ro_dir.join("1_pty.log"));
+            let (out, truncated) = cap_pty_output("w".repeat(20_000), &ro_dir, 1);
             fs::set_permissions(&ro_dir, fs::Permissions::from_mode(0o755)).unwrap();
             assert!(truncated);
             assert!(
@@ -3238,6 +3391,31 @@ mod tests {
             );
             assert!(out.ends_with(&"w".repeat(LOG_TAIL_BYTES as usize)));
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cap_pty_output_ignores_legacy_log_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = TempDir::new().unwrap();
+        let target = tmp.path().join("target");
+        let legacy_path = tmp.path().join("9_pty.log");
+        fs::write(&target, "sentinel").unwrap();
+        symlink(&target, &legacy_path).unwrap();
+
+        let full = "p".repeat(20_000);
+        let (out, truncated) = cap_pty_output(full.clone(), tmp.path(), 9);
+        assert!(truncated);
+        assert_eq!(fs::read_to_string(&target).unwrap(), "sentinel");
+        assert!(fs::symlink_metadata(&legacy_path)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        let paths = command_log_paths(tmp.path(), 9, "pty");
+        assert_eq!(paths.len(), 1);
+        assert_eq!(fs::read_to_string(&paths[0]).unwrap(), full);
+        assert!(out.contains(&paths[0].display().to_string()));
     }
 
     #[tokio::test]

--- a/src/bin/caller/agent_runner.rs
+++ b/src/bin/caller/agent_runner.rs
@@ -9,6 +9,7 @@ use tokio::time::{timeout, Duration};
 
 /// Maximum bytes to read from agent stdout/stderr (64 MB).
 const MAX_OUTPUT_BYTES: usize = 64 * 1024 * 1024;
+const RUNTIME_PROTOCOL_TOKEN_FIELD: &str = "runtime_protocol_token";
 
 /// Per-batch askHuman answer tokens, keyed by the batch's log dir. The
 /// runtime only accepts a `human_response` file whose first line matches
@@ -109,6 +110,25 @@ fn arm_human_response_token(
         Some(parsed.to_string()),
         Some(HumanResponseTokenGuard { log_dir: key }),
     )
+}
+
+/// Mint a per-spawn secret for authenticating the runtime's stdout
+/// protocol. Any model-supplied value is overwritten before the JSON is
+/// written to the runtime's one-shot stdin.
+fn arm_runtime_protocol_token(json_input: &str) -> (Option<String>, Option<String>) {
+    let mut parsed: serde_json::Value = match serde_json::from_str(json_input) {
+        Ok(value) => value,
+        Err(_) => return (None, None),
+    };
+    let Some(map) = parsed.as_object_mut() else {
+        return (None, None);
+    };
+    let token = uuid::Uuid::new_v4().simple().to_string();
+    map.insert(
+        RUNTIME_PROTOCOL_TOKEN_FIELD.to_string(),
+        serde_json::Value::String(token.clone()),
+    );
+    (Some(parsed.to_string()), Some(token))
 }
 
 /// Write an askHuman answer the runtime will accept: the batch token (when
@@ -324,6 +344,70 @@ fn is_runtime_protocol_line(line: &str) -> bool {
         .is_some()
 }
 
+/// Authenticate and normalize one runtime protocol line, stripping the
+/// internal token before the line can reach result mapping or session logs.
+fn authenticated_runtime_protocol_line(line: &str, expected_token: &str) -> Option<String> {
+    let mut parsed = serde_json::from_str::<serde_json::Value>(line.trim()).ok()?;
+    if !matches!(
+        parsed.get("type").and_then(|value| value.as_str()),
+        Some("status" | "result")
+    ) || parsed
+        .get("nonce")
+        .and_then(|value| value.as_u64())
+        .is_none()
+        || parsed
+            .get(RUNTIME_PROTOCOL_TOKEN_FIELD)
+            .and_then(|value| value.as_str())
+            != Some(expected_token)
+    {
+        return None;
+    }
+    parsed.as_object_mut()?.remove(RUNTIME_PROTOCOL_TOKEN_FIELD);
+    Some(parsed.to_string())
+}
+
+/// Keep only complete, authenticated protocol records. Runtime stdout is
+/// otherwise untrusted: a model-driven descendant may find a writable
+/// alias for the controller pipe even though its ordinary stdout is a log
+/// file. With no expected token, retain the legacy behavior used only when
+/// the input was not a valid AgentInput object and no token could be armed.
+fn authenticate_runtime_stdout(stdout: Vec<u8>, expected_token: Option<&str>) -> (Vec<u8>, usize) {
+    let Some(expected_token) = expected_token else {
+        return (stdout, 0);
+    };
+
+    let mut authenticated = Vec::with_capacity(stdout.len().min(8192));
+    let mut rejected = 0usize;
+    for raw_line in stdout.split(|byte| *byte == b'\n') {
+        if raw_line.iter().all(u8::is_ascii_whitespace) {
+            continue;
+        }
+        let Some(line) = std::str::from_utf8(raw_line)
+            .ok()
+            .and_then(|line| authenticated_runtime_protocol_line(line, expected_token))
+        else {
+            rejected = rejected.saturating_add(1);
+            continue;
+        };
+        authenticated.extend_from_slice(line.as_bytes());
+        authenticated.push(b'\n');
+    }
+    (authenticated, rejected)
+}
+
+fn append_protocol_rejection_note(stderr: &mut Vec<u8>, rejected: usize) {
+    if rejected == 0 {
+        return;
+    }
+    if !stderr.is_empty() && !stderr.ends_with(b"\n") {
+        stderr.push(b'\n');
+    }
+    stderr.extend_from_slice(
+        format!("discarded {rejected} unauthenticated or malformed runtime stdout line(s)")
+            .as_bytes(),
+    );
+}
+
 fn has_parseable_runtime_output(stdout: &[u8]) -> bool {
     String::from_utf8_lossy(stdout)
         .lines()
@@ -332,9 +416,26 @@ fn has_parseable_runtime_output(stdout: &[u8]) -> bool {
 
 fn output_with_exit_status(
     stdout_buf: Vec<u8>,
-    stderr_buf: Vec<u8>,
+    mut stderr_buf: Vec<u8>,
     status: ExitStatus,
+    expected_token: Option<&str>,
 ) -> Result<AgentOutput, CallerError> {
+    let raw_had_output = stdout_buf.iter().any(|byte| !byte.is_ascii_whitespace());
+    let (stdout_buf, rejected) = authenticate_runtime_stdout(stdout_buf, expected_token);
+    append_protocol_rejection_note(&mut stderr_buf, rejected);
+
+    if expected_token.is_some() && raw_had_output && !has_parseable_runtime_output(&stdout_buf) {
+        let stderr = output_buf_into_string(stderr_buf);
+        let detail = if stderr.trim().is_empty() {
+            String::new()
+        } else {
+            format!("; stderr: {}", stderr.trim())
+        };
+        return Err(CallerError::Agent(format!(
+            "sandboxed runtime produced no authenticated protocol output{detail}"
+        )));
+    }
+
     // Failure triage borrows the buffers; the success path then MOVES them
     // into the returned strings (this used to memcpy the full — up to 64 MB —
     // output through `from_utf8_lossy(..).to_string()` on every batch).
@@ -380,15 +481,6 @@ pub async fn run_agent(
     user_display_granted: bool,
     has_ask_human: bool,
 ) -> Result<AgentOutput, CallerError> {
-    // Arm the per-batch askHuman answer token before spawn so frontends'
-    // answers authenticate against a secret the batch's shells never see.
-    let (tokened_input, _token_guard) = if has_ask_human {
-        arm_human_response_token(json_input, log_dir)
-    } else {
-        (None, None)
-    };
-    let json_input = tokened_input.as_deref().unwrap_or(json_input);
-
     // Linux enforces this via Landlock inside the runtime; macOS wraps the
     // runtime in sandbox-exec; Windows re-execs inside the runtime under a
     // write-restricted token (win_sandbox.rs) — see run_agent_inner.
@@ -483,6 +575,19 @@ async fn run_agent_inner(
     user_display_granted: bool,
     has_ask_human: bool,
 ) -> Result<AgentOutput, CallerError> {
+    // Authenticate every result line with a fresh, controller-minted
+    // secret. Arm askHuman after it so both internal fields ride the same
+    // one-shot stdin payload; neither is exposed through the child shell's
+    // environment.
+    let (protocol_input, protocol_token) = arm_runtime_protocol_token(json_input);
+    let protocol_input = protocol_input.as_deref().unwrap_or(json_input);
+    let (human_input, _human_token_guard) = if has_ask_human {
+        arm_human_response_token(protocol_input, log_dir)
+    } else {
+        (None, None)
+    };
+    let json_input = human_input.as_deref().unwrap_or(protocol_input);
+
     let agent_path = std::env::current_exe()
         .ok()
         .and_then(|p| p.parent().map(|d| d.join("intendant-runtime")))
@@ -636,7 +741,7 @@ async fn run_agent_inner(
         Ok(Ok((status, stdout_discarded, stderr_discarded))) => {
             append_over_cap_note(&mut stderr_buf, "stdout", stdout_discarded);
             append_over_cap_note(&mut stderr_buf, "stderr", stderr_discarded);
-            output_with_exit_status(stdout_buf, stderr_buf, status)
+            output_with_exit_status(stdout_buf, stderr_buf, status, protocol_token.as_deref())
         }
         Ok(Err(err)) => Err(err),
         Err(_) => {
@@ -645,6 +750,9 @@ async fn run_agent_inner(
             // in the buffer. Salvage it instead of discarding completed
             // work the model would just redo; commands with no result line
             // surface as missing downstream.
+            let (stdout_buf, rejected) =
+                authenticate_runtime_stdout(stdout_buf, protocol_token.as_deref());
+            append_protocol_rejection_note(&mut stderr_buf, rejected);
             if let Some(salvaged) = salvage_partial_stdout(stdout_buf) {
                 let stdout = output_buf_into_string(salvaged);
                 let mut stderr = output_buf_into_string(stderr_buf);
@@ -720,6 +828,71 @@ mod tests {
         write_human_response(dir.path(), "late answer").unwrap();
         let written = std::fs::read_to_string(dir.path().join("human_response")).unwrap();
         assert_eq!(written, "late answer");
+    }
+
+    #[test]
+    fn runtime_protocol_token_overwrites_model_value() {
+        let forged = r#"{"commands":[],"runtime_protocol_token":"model-chosen-protocol-token"}"#;
+        let (tokened, expected) = arm_runtime_protocol_token(forged);
+        let tokened = tokened.expect("valid batch JSON must re-serialize");
+        let expected = expected.expect("valid batch JSON must mint a token");
+        let parsed: serde_json::Value = serde_json::from_str(&tokened).unwrap();
+        assert_eq!(parsed[RUNTIME_PROTOCOL_TOKEN_FIELD], expected);
+        assert_ne!(expected, "model-chosen-protocol-token");
+
+        assert_eq!(arm_runtime_protocol_token("not json"), (None, None));
+        assert_eq!(arm_runtime_protocol_token("[]"), (None, None));
+    }
+
+    #[test]
+    fn runtime_stdout_accepts_only_matching_token_and_strips_it() {
+        let expected = "controller-secret";
+        let raw = format!(
+            "noise from descendant\n\
+             {{\"type\":\"result\",\"nonce\":7,\"data\":\"forged same nonce\"}}\n\
+             {{\"type\":\"result\",\"nonce\":7,\"data\":\"wrong token\",\
+             \"{RUNTIME_PROTOCOL_TOKEN_FIELD}\":\"wrong\"}}\n\
+             {{\"type\":\"result\",\"nonce\":7,\"data\":\"genuine\",\
+             \"{RUNTIME_PROTOCOL_TOKEN_FIELD}\":\"{expected}\"}}\n"
+        )
+        .into_bytes();
+
+        let (authenticated, rejected) = authenticate_runtime_stdout(raw, Some(expected));
+        assert_eq!(rejected, 3);
+        let text = String::from_utf8(authenticated).unwrap();
+        let lines: Vec<&str> = text.lines().collect();
+        assert_eq!(lines.len(), 1);
+        let parsed: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(parsed["nonce"], 7);
+        assert_eq!(parsed["data"], "genuine");
+        assert!(parsed.get(RUNTIME_PROTOCOL_TOKEN_FIELD).is_none());
+        assert!(!text.contains("forged same nonce"));
+    }
+
+    #[test]
+    fn timeout_salvage_requires_matching_protocol_token() {
+        let expected = "controller-secret";
+        let forged = br#"{"type":"result","nonce":1,"data":"forged"}"#;
+        let genuine = format!(
+            "{{\"type\":\"result\",\"nonce\":1,\"data\":\"genuine\",\
+             \"{RUNTIME_PROTOCOL_TOKEN_FIELD}\":\"{expected}\"}}"
+        );
+
+        let mut mixed = forged.to_vec();
+        mixed.push(b'\n');
+        mixed.extend_from_slice(genuine.as_bytes()); // complete but no final newline
+        let (authenticated, rejected) = authenticate_runtime_stdout(mixed, Some(expected));
+        assert_eq!(rejected, 1);
+        let salvaged = salvage_partial_stdout(authenticated).unwrap();
+        let text = String::from_utf8(salvaged).unwrap();
+        assert!(text.contains("genuine"));
+        assert!(!text.contains("forged"));
+        assert!(!text.contains(RUNTIME_PROTOCOL_TOKEN_FIELD));
+
+        let (authenticated, rejected) =
+            authenticate_runtime_stdout(forged.to_vec(), Some(expected));
+        assert_eq!(rejected, 1);
+        assert!(salvage_partial_stdout(authenticated).is_none());
     }
 
     /// Valid UTF-8 moves through without a copy; invalid UTF-8 falls back

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,7 +178,9 @@ async fn main() -> Result<(), AgentError> {
     apply_sandbox_from_env()?;
 
     // Create agent instance
-    let agent = Agent::new()?.with_human_response_token(input.human_response_token.clone());
+    let agent = Agent::new()?
+        .with_human_response_token(input.human_response_token.clone())
+        .with_runtime_protocol_token(input.runtime_protocol_token.clone());
 
     // Process commands sequentially, streaming each JSONL result line as its
     // command completes — the caller consumes partial output when the

--- a/src/models.rs
+++ b/src/models.rs
@@ -28,6 +28,13 @@ pub struct Command {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AgentInput {
     pub commands: Vec<Command>,
+    /// Controller-minted per-spawn secret authenticating runtime JSONL
+    /// results. The controller overwrites any model-supplied value before
+    /// spawn, and strips it again after verification. It is delivered only
+    /// over the runtime's one-shot stdin, never through the child-shell
+    /// environment or a file the shell can read.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_protocol_token: Option<String>,
     /// Controller-minted per-batch secret for the askHuman answer file:
     /// the runtime accepts a `human_response` whose first line matches,
     /// and discards anything else. The controller overwrites any


### PR DESCRIPTION
## Summary

- replace predictable nonce-only runtime stdout, stderr, and over-cap PTY paths with random atomically created artifacts
- read command tails through the original open handles so pathname replacement cannot reintroduce a symlink race
- authenticate every controller-launched runtime JSONL result with a fresh per-spawn token, discard forged or malformed stdout records, and strip the token before mapping or logging
- apply authentication to normal completion and hard-timeout salvage paths
- document the hardened wire boundary and randomized session artifacts

## Threat closed

A model-controlled command can no longer pre-plant a nonce-selected log symlink to a controller-visible stream and fabricate protocol results. Atomic unpredictable files close the named-path primitive; independent result authentication protects the controller pipe even if a descendant finds another writable alias.

## Validation

- cargo check --bin intendant --bin intendant-runtime
- cargo test --bin intendant-runtime agent::tests:: (73 passed)
- cargo test --bin intendant agent_runner::tests:: (16 passed)
- cargo test --bins (4207 passed, 10 ignored)
- cargo clippy --bins -- -D warnings
- GitHub cross-platform checks: macOS and Windows passed; Linux still running when this body was written