### PR TITLE
Security: gate arbitrary shell capabilities

### DIFF
--- a/crates/intendant-core/src/autonomy.rs
+++ b/crates/intendant-core/src/autonomy.rs
@@ -8,8 +8,8 @@ use tokio::sync::RwLock;
 pub enum AutonomyLevel {
     /// Ask for every category except file reads; Deny rules still gate.
     Low,
-    /// Default. Apply category rules; default Ask rules cover writes,
-    /// deletes, and destructive actions.
+    /// Default. Apply category rules; arbitrary shell execution inherits
+    /// the strictest rule of every effect the shell can reach.
     #[default]
     Medium,
     /// Auto-approve ordinary Ask rules; Deny rules and hard gates still gate.
@@ -68,15 +68,17 @@ impl ActionCategory {
     pub fn severity(self) -> u8 {
         match self {
             Self::FileRead => 0,
-            Self::CommandExec => 1,
             Self::ToolCall => 1,
             Self::NetworkRequest => 2,
             Self::FileWrite => 3,
             Self::FileDelete => 4,
             Self::Destructive => 5,
-            Self::HumanInput => 6,
-            Self::LiveAudioSpawn => 7,
-            Self::DisplayControl => 8,
+            // A shell can perform every ordinary runtime effect, even when
+            // the best-effort classifier cannot recognize the spelling.
+            Self::CommandExec => 6,
+            Self::HumanInput => 7,
+            Self::LiveAudioSpawn => 8,
+            Self::DisplayControl => 9,
         }
     }
 }
@@ -166,6 +168,14 @@ impl ApprovalRule {
             _ => None,
         }
     }
+
+    fn strictest(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Deny, _) | (_, Self::Deny) => Self::Deny,
+            (Self::Ask, _) | (_, Self::Ask) => Self::Ask,
+            (Self::Auto, Self::Auto) => Self::Auto,
+        }
+    }
 }
 
 /// Category-level approval rules parsed from intendant.toml [approval] section.
@@ -212,6 +222,28 @@ impl Default for ApprovalConfig {
 }
 
 impl ApprovalConfig {
+    /// Effective rule for arbitrary shell execution.
+    ///
+    /// Shell syntax is an open-ended capability: variable indirection,
+    /// command substitution, interpreters, and newly installed binaries make
+    /// it impossible for substring classification to prove which effects a
+    /// command can reach. Govern the capability by the strictest configured
+    /// rule for its reachable effects instead. The classifier can still add
+    /// useful labels, but an unrecognized spelling cannot weaken policy.
+    fn shell_rule(&self) -> ApprovalRule {
+        [
+            self.command_exec,
+            self.file_read,
+            self.file_write,
+            self.file_delete,
+            self.network,
+            self.destructive,
+            self.display_control,
+        ]
+        .into_iter()
+        .fold(ApprovalRule::Auto, ApprovalRule::strictest)
+    }
+
     /// Set the rule for a category by its snake-case name (the
     /// `ApprovalConfig` field name / `ActionCategory` Display form).
     /// Categories that are always "ask" (`human_input`, `live_audio_spawn`)
@@ -237,7 +269,7 @@ impl ApprovalConfig {
             ActionCategory::FileRead => self.file_read,
             ActionCategory::FileWrite => self.file_write,
             ActionCategory::FileDelete => self.file_delete,
-            ActionCategory::CommandExec => self.command_exec,
+            ActionCategory::CommandExec => self.shell_rule(),
             ActionCategory::NetworkRequest => self.network,
             ActionCategory::Destructive => self.destructive,
             ActionCategory::HumanInput => ApprovalRule::Ask, // always ask
@@ -288,49 +320,15 @@ impl AutonomyState {
         }
     }
 
-    /// Generate a dedup key for a command. Strips nonce and display params
-    /// so retries of the same command with different display/nonce are recognized.
+    /// Generate a dedup key for an action.
+    ///
+    /// Keep the source byte-exact. Display selectors and `$NONCE[...]`
+    /// references affect what a command targets, and trying to erase them
+    /// without a complete shell parser lets executable syntax hide inside the
+    /// ignored span. Structured runtime call nonces are removed earlier by
+    /// [`batch_dedup_source`], where they are data rather than shell syntax.
     pub fn command_dedup_key(command: &str) -> String {
-        let normalized = command.replace(char::is_whitespace, " ");
-        let bytes = normalized.as_bytes();
-        let mut key = String::with_capacity(normalized.len());
-        let mut skip_next = false;
-        let mut i = 0;
-        while i < bytes.len() {
-            if bytes[i] == b' ' {
-                key.push(' ');
-                i += 1;
-                continue;
-            }
-
-            let start = i;
-            while i < bytes.len() && bytes[i] != b' ' {
-                i += 1;
-            }
-            let part = &normalized[start..i];
-
-            if skip_next {
-                skip_next = false;
-                continue;
-            }
-            if part == "--display" || part == "display:" {
-                skip_next = true;
-                continue;
-            }
-            if part.starts_with("--display=") || part.starts_with("display:") {
-                continue;
-            }
-            key.push_str(part);
-        }
-        // Remove nonce references
-        while let Some(start) = key.find("$NONCE[") {
-            if let Some(end) = key[start..].find(']') {
-                key.replace_range(start..start + end + 1, "NONCE");
-            } else {
-                break;
-            }
-        }
-        key
+        command.to_owned()
     }
 
     /// Check if this action signature was already approved in this session.
@@ -386,13 +384,14 @@ impl AutonomyState {
                 // Apply global autonomy level
                 match self.level {
                     AutonomyLevel::Medium => {
-                        // Ask for writes, deletes, destructive, network.
+                        // Ask for shell execution and Ask-ruled effects.
                         // ToolCall is here too, but its default rule is
                         // Auto — this arm is reached only under an
                         // explicit `tool_call = "ask"`.
                         matches!(
                             category,
-                            ActionCategory::FileWrite
+                            ActionCategory::CommandExec
+                                | ActionCategory::FileWrite
                                 | ActionCategory::FileDelete
                                 | ActionCategory::Destructive
                                 | ActionCategory::NetworkRequest
@@ -794,6 +793,19 @@ pub fn classify_batch(json_str: &str) -> Vec<(usize, Vec<ActionCategory>)> {
 mod tests {
     use super::*;
 
+    fn all_shell_rules_auto() -> ApprovalConfig {
+        ApprovalConfig {
+            file_read: ApprovalRule::Auto,
+            file_write: ApprovalRule::Auto,
+            file_delete: ApprovalRule::Auto,
+            command_exec: ApprovalRule::Auto,
+            network: ApprovalRule::Auto,
+            destructive: ApprovalRule::Auto,
+            display_control: ApprovalRule::Auto,
+            tool_call: ApprovalRule::Auto,
+        }
+    }
+
     #[test]
     fn autonomy_level_display() {
         assert_eq!(AutonomyLevel::Low.to_string(), "Low");
@@ -833,6 +845,50 @@ mod tests {
         assert_eq!(config.network, ApprovalRule::Auto);
         assert_eq!(config.destructive, ApprovalRule::Ask);
         assert_eq!(config.tool_call, ApprovalRule::Auto);
+        // The configured command-only field is Auto, but arbitrary shell
+        // execution inherits the stricter reachable-effect defaults.
+        assert_eq!(
+            config.rule_for(ActionCategory::CommandExec),
+            ApprovalRule::Ask
+        );
+    }
+
+    #[test]
+    fn shell_rule_is_the_strictest_reachable_rule() {
+        let reachable = [
+            "file_read",
+            "file_write",
+            "file_delete",
+            "command_exec",
+            "network",
+            "destructive",
+            "display_control",
+        ];
+
+        for category in reachable {
+            let mut rules = all_shell_rules_auto();
+            assert!(rules.set_rule_by_name(category, ApprovalRule::Ask));
+            assert_eq!(
+                rules.rule_for(ActionCategory::CommandExec),
+                ApprovalRule::Ask,
+                "{category} = ask must govern shell execution"
+            );
+
+            assert!(rules.set_rule_by_name(category, ApprovalRule::Deny));
+            assert_eq!(
+                rules.rule_for(ActionCategory::CommandExec),
+                ApprovalRule::Deny,
+                "{category} = deny must govern shell execution"
+            );
+        }
+
+        let mut rules = all_shell_rules_auto();
+        rules.tool_call = ApprovalRule::Deny;
+        assert_eq!(
+            rules.rule_for(ActionCategory::CommandExec),
+            ApprovalRule::Auto,
+            "controller tool policy is not reachable through the runtime shell"
+        );
     }
 
     #[test]
@@ -893,10 +949,10 @@ destructive = "deny"
     }
 
     #[test]
-    fn medium_autonomy_asks_for_writes_and_destructive() {
+    fn medium_autonomy_asks_for_shell_writes_and_destructive() {
         let state = AutonomyState::new(AutonomyLevel::Medium, ApprovalConfig::default());
         assert!(!state.needs_approval(ActionCategory::FileRead));
-        assert!(!state.needs_approval(ActionCategory::CommandExec));
+        assert!(state.needs_approval(ActionCategory::CommandExec));
         assert!(!state.needs_approval(ActionCategory::NetworkRequest));
         assert!(state.needs_approval(ActionCategory::FileWrite));
         assert!(state.needs_approval(ActionCategory::FileDelete));
@@ -932,25 +988,32 @@ destructive = "deny"
     }
 
     #[test]
-    fn command_dedup_key_strips_display_params() {
-        assert_eq!(
+    fn command_dedup_key_keeps_effectful_targets_exact() {
+        assert_ne!(
             AutonomyState::command_dedup_key("xdotool --display=1 key Return"),
             AutonomyState::command_dedup_key("xdotool --display=99 key Return")
         );
-        assert_eq!(
+        assert_ne!(
             AutonomyState::command_dedup_key("xdotool display:1 key Return"),
             AutonomyState::command_dedup_key("xdotool display:99 key Return")
+        );
+        assert_ne!(
+            AutonomyState::command_dedup_key("kill $NONCE[1]"),
+            AutonomyState::command_dedup_key("kill $NONCE[2]")
         );
     }
 
     #[test]
-    fn approved_command_dedups_display_param_variants() {
+    fn dedup_never_erases_executable_shell_syntax() {
         let mut state = AutonomyState::default();
-        state.record_approved_command(None, "xdotool --display=1 key Return");
-        assert!(state.was_command_approved(None, "xdotool --display=99 key Return"));
+        state.record_approved_command(None, "echo $NONCE[$(touch /tmp/approved)]");
+        assert!(!state.was_command_approved(None, "echo $NONCE[$(touch /tmp/changed)]"));
 
-        state.record_approved_command(None, "xdotool display:1 key Escape");
-        assert!(state.was_command_approved(None, "xdotool display:99 key Escape"));
+        state.record_approved_command(None, "xdotool --display=$(printf 1) key Return");
+        assert!(!state.was_command_approved(None, "xdotool --display=$(printf 2) key Return"));
+
+        state.record_approved_command(None, "printf 'one two'");
+        assert!(!state.was_command_approved(None, "printf 'one\ttwo'"));
     }
 
     #[test]
@@ -1175,6 +1238,20 @@ destructive = "deny"
     }
 
     #[test]
+    fn unrecognized_shell_effect_cannot_downgrade_default_policy() {
+        let cmd: serde_json::Value = serde_json::json!({
+            "function": "execAsAgent",
+            "nonce": 1,
+            "command": "python -c \"__import__('os').unlink('/tmp/x')\""
+        });
+        let cats = classify_command(&cmd);
+        assert_eq!(cats, vec![ActionCategory::CommandExec]);
+
+        let state = AutonomyState::new(AutonomyLevel::Medium, ApprovalConfig::default());
+        assert!(state.needs_approval(ActionCategory::CommandExec));
+    }
+
+    #[test]
     fn classify_destructive_rm() {
         let cmd: serde_json::Value = serde_json::json!({
             "function": "execAsAgent",
@@ -1342,17 +1419,18 @@ destructive = "deny"
 
     #[test]
     fn severity_ordering() {
-        // Destructive > FileDelete > FileWrite > NetworkRequest > CommandExec > FileRead
+        // Arbitrary shell execution outranks every ordinary effect because
+        // the shell can reach all of them without a recognizable spelling.
+        assert!(ActionCategory::CommandExec.severity() > ActionCategory::Destructive.severity());
         assert!(ActionCategory::Destructive.severity() > ActionCategory::FileDelete.severity());
         assert!(ActionCategory::FileDelete.severity() > ActionCategory::FileWrite.severity());
         assert!(ActionCategory::FileWrite.severity() > ActionCategory::NetworkRequest.severity());
-        assert!(ActionCategory::NetworkRequest.severity() > ActionCategory::CommandExec.severity());
-        assert!(ActionCategory::CommandExec.severity() > ActionCategory::FileRead.severity());
+        assert!(ActionCategory::NetworkRequest.severity() > ActionCategory::FileRead.severity());
     }
 
     #[test]
     fn human_input_highest_severity() {
-        assert!(ActionCategory::HumanInput.severity() > ActionCategory::Destructive.severity());
+        assert!(ActionCategory::HumanInput.severity() > ActionCategory::CommandExec.severity());
     }
 
     #[test]

--- a/docs/src/autonomy.md
+++ b/docs/src/autonomy.md
@@ -21,7 +21,7 @@ Set with `--autonomy`, from the dashboard, or with
 | Level | Behavior |
 |-------|----------|
 | Low | Ask before every category except `FileRead` |
-| Medium (default) | Apply category rules; defaults ask for writes, deletes, and destructive actions (`network` defaults to auto) |
+| Medium (default) | Apply category rules; defaults ask for arbitrary shell execution, writes, deletes, and destructive actions (`network` defaults to auto for the structured `browse` tool) |
 | High | Auto-approve ordinary `ask` rules; native policy denials and hard gates remain |
 | Full | Native runtime and controller actions auto-approve except policy denials and the `HumanInput` / `LiveAudioSpawn` hard gates; see the external-agent caveat below |
 
@@ -38,6 +38,14 @@ their rule is `auto`, while High and Full auto-approve ordinary `ask` rules.
 None of these rules bypasses the human-input/live-audio hard gates or the
 separate user-display grant. External-agent requests take a separate path,
 described below.
+
+`CommandExec` is capability-composed rather than parser-composed. Its effective
+rule is the strictest of `command_exec`, `file_read`, `file_write`,
+`file_delete`, `network`, `destructive`, and `display_control` (`deny` >
+`ask` > `auto`). A shell can reach all of those effects through interpreters,
+subshells, variable expansion, or binaries the classifier has never seen, so
+setting only `command_exec = "auto"` cannot weaken a stricter effect rule. To
+auto-allow arbitrary shell execution, every reachable category must permit it.
 
 ## Layer 3 — per-action approval
 
@@ -115,8 +123,8 @@ The precise logic (`AutonomyState::needs_approval`) has nuances worth knowing:
   explicit-deny check.
 - **Low** — asks for everything except `FileRead` (a `deny` rule still blocks).
 - **Medium / High** — start from the per-category rule. For an `ask` rule,
-  Medium asks only for `FileWrite` / `FileDelete` / `Destructive` /
-  `NetworkRequest` / `ToolCall` (the last only under an explicit
+  Medium asks only for `CommandExec` / `FileWrite` / `FileDelete` /
+  `Destructive` / `NetworkRequest` / `ToolCall` (the last only under an explicit
   `tool_call = "ask"` — its default rule is `auto`); High asks for none of
   them.
 
@@ -133,8 +141,11 @@ not re-prompt. Two properties bound that memory:
   `writeFile`/`editFile` it includes a digest of the full command (minus the
   per-call `nonce`), so approving one edit of a path never covers different
   content aimed at the same path; controller-dispatched tool calls digest
-  their full arguments the same way. Exec commands keep exact-string matching
-  (with the display/nonce normalization that recognizes benign retries).
+  their full arguments the same way. Exec commands keep byte-exact string
+  matching. In particular, display selectors and `$NONCE[...]` process
+  references remain part of the identity because they change the target and
+  may contain executable shell syntax. Only the structured runtime call's
+  top-level JSON `nonce` is removed before hashing.
 
 ## Controller-dispatched tools
 
@@ -209,12 +220,15 @@ binary paths like `/bin/rm`, and `find … -delete`/`-exec rm`), network
 tools, and file writes (redirects, `tee`, `mv`, `cp`). A `sudo` prefix is
 flagged Destructive *and* the command after `sudo` is classified too. When
 multiple categories apply, the highest-severity one drives the prompt label.
+Every shell command also carries `CommandExec`, whose effective policy is the
+strictest reachable rule described above.
 
-The shell classifier is **best-effort keyword matching for approval
-prompting — UX, not a security boundary**: string matching cannot see
-through variable indirection, subshells, or novel spellings. The runtime's
-filesystem/exec sandbox is what actually confines commands; an evasion
-dodges the prompt, never the sandbox.
+The shell substring classifier is **display enrichment, not an authorization
+parser**: it cannot see through variable indirection, subshells, interpreters,
+or novel spellings. Missing one of those spellings no longer downgrades the
+decision because `CommandExec` governs the whole shell capability. The
+runtime's filesystem/exec sandbox remains an independent hard boundary on
+where an approved command can act.
 
 `ToolCall` is not produced by ordinary runtime `classify_command`; it governs
 [controller-dispatched tools](#controller-dispatched-tools) and

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -202,6 +202,14 @@ Per-category approval rules. Each value is `auto` (run without asking), `ask`
 | `destructive` | rule | `ask` | Destructive |
 | `display_control` | rule | `ask` | DisplayControl |
 
+Arbitrary `CommandExec` is governed by the strictest configured rule among
+`command_exec` and every effect a shell can reach: `file_read`, `file_write`,
+`file_delete`, `network`, `destructive`, and `display_control` (`deny` >
+`ask` > `auto`). Consequently the default effective shell rule is `ask` even
+though the `command_exec` field itself defaults to `auto`. This composition is
+deliberate: shell syntax cannot be classified completely, so effect rules must
+not be bypassable with indirection or a different executable spelling.
+
 The `HumanInput` and `LiveAudioSpawn` categories always require a human and are
 not configurable here.
 
@@ -1105,7 +1113,8 @@ Approval is decided by a three-layer model (full UI details in
    `medium`). `low` asks for everything except file reads; `full` keeps the
    human entirely out of the loop (auto-approve) except for `HumanInput`.
 2. **Category rules** — the `[approval]` section above (`auto`/`ask`/`deny`) per
-   category.
+   category. Arbitrary shell execution inherits the strictest rule of every
+   effect it can reach.
 3. **Per-action approval** — `y` / `s` / `a` / `n` (approve / skip / approve-all
    / deny) prompts in any frontend.
 

--- a/static/app/31-ui2-foundation.js
+++ b/static/app/31-ui2-foundation.js
@@ -69,13 +69,13 @@ const UI2_ICON_PATHS = {
 
 // Truthful short tags per autonomy level (shared by the nav chip and the
 // Settings dial). Sourced from intendant-core autonomy.rs::needs_approval:
-// Low runs only file reads; Medium gates Ask-ruled writes/deletes/
-// destructive/network; High auto-approves every Ask rule (only Deny and
-// the hard gates stop it — NOT "gate network", the prototype's tag was
-// wrong); Full bypasses the rules entirely.
+// Low runs only file reads; Medium reviews arbitrary shell commands because
+// CommandExec inherits the strictest reachable effect rule, as well as gating
+// Ask-ruled structured effects; High auto-approves every Ask rule (only Deny
+// and the hard gates stop it); Full auto-approves ordinary native actions.
 const UI2_AUTONOMY_TAGS = {
   Low: 'reads only',
-  Medium: 'gate writes',
+  Medium: 'review commands',
   High: 'auto unless denied',
   Full: 'ungated',
 };

--- a/static/app/39-session-windows.js
+++ b/static/app/39-session-windows.js
@@ -945,7 +945,7 @@ const PERMISSION_KIND_COPY = {
 
 // Resolve a permission kind + raw mode into display copy. `autonomy` is
 // the native backend: the label reuses the sidebar's autonomy vocabulary
-// ("Medium · gate writes"), and the ungated Full level gets the same
+// ("Medium · review commands"), and the ungated Full level gets the same
 // quiet warning tint as bypass. Unknown kinds show the raw mode verbatim
 // — honest passthrough, never a guessed plain-language claim.
 function permissionDisplay(kind, mode) {
@@ -5167,4 +5167,3 @@ function sessionConfigApprovalPolicy(meta = {}) {
     'on-request'
   );
 }
-


### PR DESCRIPTION
## Summary

- govern arbitrary shell execution by the strictest configured reachable-effect rule
- make approval dedup byte-exact for executable strings, closing nonce and display command-substitution smuggling
- update autonomy documentation and dashboard wording

## Security impact

This closes H3: an unrecognized or obfuscated shell spelling can no longer fall back to an auto-approved CommandExec at the default Medium level. Explicit reachable-effect denials also govern shell execution.

## Validation

- cargo test -p intendant-core autonomy (61 passed)
- cargo check --bin intendant --bin intendant-runtime
- cargo test --bins (4213 passed, 10 ignored)
- cargo clippy --bins -- -D warnings
- macOS, Linux, Windows, app-fragment, and repo-integrity PR checks