### PR TITLE
security: keep supervised MCP tokens off argv

### DIFF
--- a/docs/src/external-agent-orchestration.md
+++ b/docs/src/external-agent-orchestration.md
@@ -107,7 +107,7 @@ adapter from `[agent.<backend>]` config, then `run_external_agent_mode()`
 | Module | `external_agent/codex/` (mod, threads, wire, context_trace, reader) | `external_agent/claude_code.rs` |
 | Spawn command | `codex app-server` | `claude -p --output-format stream-json --input-format stream-json --verbose --include-partial-messages --permission-prompt-tool stdio --permission-mode <mode>` |
 | Wire protocol | JSON-RPC over JSONL (`app-server`) | stream-json over stdio |
-| MCP injection | Per-process `-c mcp_servers.intendant.{type,url}` overrides plus scoped env; no workspace config file | Inline `--mcp-config '{…}'` JSON string |
+| MCP injection | Per-process `-c mcp_servers.intendant.{type,url,bearer_token_env_var}` overrides plus scoped env; no workspace config file | Inline `--mcp-config '{…}'` JSON with an environment-expanded Authorization header |
 | Multi-thread | Yes — many threads per process | No |
 | Native thread id | Yes | Yes — announced via `AgentEvent::NativeSessionId` on the first turn (placeholder `claude-code-session` until then; `--resume` keeps the id stable so resumed threads are canonical immediately) |
 | Mid-turn steer | Yes (`turn/steer`) | No — 2.1.2xx discards stdin user messages mid-turn (2.1.200's absorb was a CLI bug, since removed); `steer_turn` reports queue semantics and the steer delivers at the turn boundary (or immediately as its own turn when idle) |
@@ -182,7 +182,7 @@ What each supervised backend actually receives:
 | | **Codex** | **Claude Code** |
 |---|---|---|
 | MCP tool exposure | `tool_profile=core` (bootstrap set) | `tool_profile=core` (bootstrap set) |
-| Loopback `mcp_token` in URL | yes | yes |
+| Session-scoped MCP bearer | child env → Authorization header | child env → environment-expanded Authorization header |
 | `session_id` scope in URL | yes | yes |
 | `$INTENDANT` + `INTENDANT_MCP_URL` env (`ctl` bootstrap) | yes (+ `INTENDANT_MANAGED_CONTEXT`) | yes |
 | Guidance channel | managed-context developer message | first-prompt bootstrap addendum |
@@ -235,8 +235,13 @@ features it lacks.
   server exclusively through command-line `-c` overrides on the app-server
   process; Intendant does not write, back up, or restore
   `<workspace>/.codex/config.toml`. The command line includes
-  `-c mcp_servers.intendant.type="http" -c mcp_servers.intendant.url="…"`, plus the
-  user's toggles as further `-c` overrides:
+  `-c mcp_servers.intendant.type="http"`,
+  `-c mcp_servers.intendant.url="…"`, and
+  `-c mcp_servers.intendant.bearer_token_env_var="INTENDANT_MCP_BEARER_TOKEN"`.
+  The URL on argv carries session/profile routing but no credential; the
+  session-derived bearer exists only in the explicitly injected child
+  environment and Codex sends it as `Authorization: Bearer`. The user's
+  toggles ride as further `-c` overrides:
   `tools.web_search=true`, `model_reasoning_effort="…"`,
   `sandbox_workspace_write.network_access=true` (only in `workspace-write`), and
   `sandbox_workspace_write.writable_roots=[…]`.
@@ -262,10 +267,13 @@ features it lacks.
   `INTENDANT=/absolute/path/to/intendant`, `INTENDANT_MCP_URL`,
   `INTENDANT_SESSION_ID`, and `INTENDANT_MANAGED_CONTEXT`, so agent shells can
   run `"$INTENDANT" ctl ...` without relying on user PATH setup. Claude Code
-  gets the same treatment (scoped URL with `tool_profile=core` + `mcp_token` +
-  `session_id`, the `$INTENDANT`/`INTENDANT_MCP_URL`/`INTENDANT_SESSION_ID`
-  env, and a first-prompt bootstrap addendum naming the bootstrap tools and
-  the `ctl` discovery flow).
+  gets the same treatment: its inline MCP JSON contains a token-free scoped URL
+  and an `Authorization` header that expands
+  `${INTENDANT_MCP_BEARER_TOKEN}` inside the child. Both backends also receive
+  the token-bearing `$INTENDANT_MCP_URL` for `ctl` through their private
+  environment, plus `$INTENDANT`/`INTENDANT_SESSION_ID`; no bearer value rides
+  either process's argv. Claude's first-prompt bootstrap addendum names the
+  bootstrap tools and the `ctl` discovery flow.
 
   For dashboard/browser validation against an already-running Intendant web port,
   managed agents should use the repository helper instead of generating ad-hoc
@@ -672,10 +680,12 @@ through Claude Code 2.1.210):
   visible from frontends instead of silently running without CU tools.
 
 The Intendant MCP server is passed **inline** as a JSON string to
-`--mcp-config` (not a file path); the URL is the scoped bootstrap endpoint
-(`session_id` + `tool_profile=core` + `mcp_token`), and the child gets
-`$INTENDANT`, `INTENDANT_MCP_URL`, and `INTENDANT_SESSION_ID` so
-`"$INTENDANT" ctl ...` works from its shell. The first user message carries a
+`--mcp-config` (not a file path). Its argv-visible URL carries `session_id` +
+`tool_profile=core` but no token; the Authorization header expands
+`${INTENDANT_MCP_BEARER_TOKEN}` from the child environment. The child also gets
+the token-bearing `INTENDANT_MCP_URL` plus `$INTENDANT` and
+`INTENDANT_SESSION_ID` so `"$INTENDANT" ctl ...` works from its shell. The
+first user message carries a
 bootstrap addendum naming the MCP bootstrap tools
 (`read_screen`/`take_screenshot`/`execute_cu_actions`, shared-view), the lazy
 `ctl --help` discovery flow, and the dashboard-validation helper.
@@ -905,8 +915,9 @@ shared state (when driven over MCP) → config default → native.
 ## Gotchas and Caveats
 
 - **No workspace config mutation.** Codex MCP injection is per-process:
-  Intendant passes `-c` overrides and scoped env to the app-server process. It
-  does not write `<workspace>/.codex/config.toml`, create
+  Intendant passes token-free `-c` overrides and a session-scoped bearer in the
+  child environment to the app-server process. It does not write
+  `<workspace>/.codex/config.toml`, create
   `config.toml.intendant-backup`, or restore files on shutdown.
 - **Settings latch at thread/process start.** Codex latches sandbox, approval
   policy, model, reasoning effort, tool set, and writable roots at `thread/start`.

--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -90,12 +90,15 @@ wired up by the owner's own client config, always counts as an owner surface. Se
 [Computer Use](./computer-use-and-audio.md#display-targets). Binding order:
 
 1. **Peer daemons** (mTLS peer identity) use their peer-profile principal.
-2. **Supervised backends** present the token in their injected
-   `INTENDANT_MCP_URL`. It is *session-scoped* — derived from the daemon's
-   per-process token and the `session_id` — so it authenticates exactly that
-   agent session (`principal:agent-session:<id>`). Possession of the raw
-   per-process token remains root-equivalent. Explicit-but-wrong tokens are
-   refused with 401. A session whose binding is known but whose grant has
+2. **Supervised backends** receive a bearer only in their cleared child
+   environment and send it in the `Authorization` header. Their argv-visible
+   MCP config contains the environment-variable name, never the value.
+   `INTENDANT_MCP_URL` remains the private environment bootstrap for `ctl`.
+   The bearer is *session-scoped* — derived from the daemon's per-process token
+   and the `session_id` — so it authenticates exactly that agent session
+   (`principal:agent-session:<id>`). Possession of the raw per-process token
+   remains root-equivalent. Explicit-but-wrong tokens are refused with 401. A
+   session whose binding is known but whose grant has
    *lapsed* (expired or revoked) binds the scoped principal and is denied
    with the real reason — it does not fall back to default trust; only
    sessions with no binding at all do.

--- a/src/bin/caller/external_agent/claude_code.rs
+++ b/src/bin/caller/external_agent/claude_code.rs
@@ -2836,7 +2836,9 @@ pub struct ClaudeCodeAgent {
     /// an idle goal update never burns a turn of its own (a mid-turn update
     /// is written immediately instead — the running turn absorbs it).
     pending_goal_notice: Option<String>,
-    /// Loopback MCP auth token from the daemon, baked into the injected URL.
+    /// Loopback MCP auth token from the daemon. The ctl URL carries it in
+    /// the child environment; Claude's argv contains only an environment
+    /// placeholder for the equivalent Authorization header.
     mcp_auth_token: Option<String>,
     /// Intendant session id scoping the injected MCP URL and ctl env.
     mcp_session_id: Option<String>,
@@ -2898,10 +2900,10 @@ impl ClaudeCodeAgent {
         self.max_budget_usd.filter(|b| !(b.is_finite() && *b > 0.0))
     }
 
-    /// The scoped loopback MCP URL injected into `--mcp-config` and the ctl
-    /// env. Claude Code has no managed-context mode, so the server treats the
-    /// session as vanilla; `tool_profile=core` keeps the advertised tool list
-    /// to the bootstrap set (full surface stays callable via `ctl tools`).
+    /// The scoped loopback MCP URL injected into the ctl env. Claude Code has
+    /// no managed-context mode, so the server treats the session as vanilla;
+    /// `tool_profile=core` keeps the advertised tool list to the bootstrap set
+    /// (full surface stays callable via `ctl tools`).
     fn intendant_mcp_url(&self, port: u16) -> String {
         super::intendant_bootstrap_mcp_url(
             port,
@@ -2909,6 +2911,39 @@ impl ClaudeCodeAgent {
             None,
             self.mcp_auth_token.as_deref(),
         )
+    }
+
+    /// Token-free endpoint placed in the inline MCP JSON on argv.
+    fn intendant_mcp_config_url(&self, port: u16) -> String {
+        super::intendant_bootstrap_mcp_url(port, self.mcp_session_id.as_deref(), None, None)
+    }
+
+    /// Inline Claude MCP config whose Authorization header expands from the
+    /// explicitly injected child environment. The serialized argv contains
+    /// `${INTENDANT_MCP_BEARER_TOKEN}`, never the credential value.
+    fn intendant_mcp_config(&self, port: u16) -> serde_json::Value {
+        let mut server = serde_json::json!({
+            "type": "http",
+            "url": self.intendant_mcp_config_url(port),
+        });
+        if super::intendant_mcp_bearer_token(
+            self.mcp_auth_token.as_deref(),
+            self.mcp_session_id.as_deref(),
+        )
+        .is_some()
+        {
+            server["headers"] = serde_json::json!({
+                "Authorization": format!(
+                    "Bearer ${{{}}}",
+                    super::INTENDANT_MCP_BEARER_TOKEN_ENV
+                )
+            });
+        }
+        serde_json::json!({
+            "mcpServers": {
+                "intendant": server
+            }
+        })
     }
 
     async fn write_line(&self, line: &str) -> Result<(), CallerError> {
@@ -3197,22 +3232,15 @@ impl ExternalAgent for ClaudeCodeAgent {
             args.push(self.allowed_tools.join(","));
         }
 
-        // MCP config for Intendant display/CU tools: the scoped bootstrap URL
-        // (session id + tool_profile=core + loopback auth token), same
-        // treatment as managed Codex.
+        // MCP config for Intendant display/CU tools: argv carries the scoped,
+        // token-free bootstrap URL and a header placeholder. The
+        // session-derived bearer itself is injected into the child env after
+        // the clear below, so local process listings cannot scrape it.
         let web_port = config.web_port.or(self.web_port);
         self.web_port = web_port;
         if let Some(port) = web_port {
-            let mcp_config = serde_json::json!({
-                "mcpServers": {
-                    "intendant": {
-                        "type": "http",
-                        "url": self.intendant_mcp_url(port)
-                    }
-                }
-            });
             args.push("--mcp-config".into());
-            args.push(mcp_config.to_string());
+            args.push(self.intendant_mcp_config(port).to_string());
         }
 
         // Spawn the process
@@ -3234,6 +3262,7 @@ impl ExternalAgent for ClaudeCodeAgent {
                 &mut command,
                 &self.intendant_mcp_url(port),
                 self.mcp_session_id.as_deref(),
+                self.mcp_auth_token.as_deref(),
             );
         }
         // An active oauth:claude-code lease materializes a synthesized
@@ -6503,6 +6532,35 @@ mod tests {
             format!(
                 "http://localhost:8765/mcp?session_id=session%20with%20spaces&tool_profile=core&mcp_token={expected_token}"
             )
+        );
+    }
+
+    #[test]
+    fn inline_mcp_config_uses_env_placeholder_not_bearer_value() {
+        let mut agent = ClaudeCodeAgent::new(
+            "claude".into(),
+            None,
+            "default".into(),
+            None,
+            vec![],
+            Some(8765),
+        );
+        agent.mcp_session_id = Some("session-a".to_string());
+        agent.mcp_auth_token = Some("raw-process-secret".to_string());
+        let derived =
+            crate::web_gateway::session_scoped_mcp_token("raw-process-secret", "session-a");
+
+        let config = agent.intendant_mcp_config(8765);
+        let argv_value = config.to_string();
+        assert!(!argv_value.contains("raw-process-secret"));
+        assert!(!argv_value.contains(&derived));
+        assert_eq!(
+            config["mcpServers"]["intendant"]["url"],
+            "http://localhost:8765/mcp?session_id=session-a&tool_profile=core"
+        );
+        assert_eq!(
+            config["mcpServers"]["intendant"]["headers"]["Authorization"],
+            "Bearer ${INTENDANT_MCP_BEARER_TOKEN}"
         );
     }
 

--- a/src/bin/caller/external_agent/codex/mod.rs
+++ b/src/bin/caller/external_agent/codex/mod.rs
@@ -585,6 +585,18 @@ impl CodexAgent {
         )
     }
 
+    /// Token-free URL placed in Codex's `-c` MCP config override. Codex
+    /// reads the bearer from [`super::INTENDANT_MCP_BEARER_TOKEN_ENV`], so
+    /// `ps` exposes only a variable name and never the session credential.
+    fn intendant_mcp_config_url(&self, port: u16) -> String {
+        super::intendant_bootstrap_mcp_url(
+            port,
+            self.mcp_session_id.as_deref(),
+            Some(self.intendant_managed_context_mode()),
+            None,
+        )
+    }
+
     #[allow(dead_code)]
     fn intendant_mcp_base_url(port: u16) -> String {
         format!("http://localhost:{port}/mcp")
@@ -603,6 +615,7 @@ impl CodexAgent {
             command,
             &self.intendant_mcp_url(port),
             self.mcp_session_id.as_deref(),
+            self.mcp_auth_token.as_deref(),
         );
         command.env(
             "INTENDANT_MANAGED_CONTEXT",
@@ -628,7 +641,7 @@ impl CodexAgent {
         effective_web_port: u16,
         inherit_configured_mcp_servers: bool,
     ) -> Vec<String> {
-        let mcp_url = self.intendant_mcp_url(effective_web_port);
+        let mcp_url = self.intendant_mcp_config_url(effective_web_port);
         let mut args: Vec<String> = Vec::new();
         if self.sandbox.trim() == CODEX_DANGER_FULL_ACCESS_SANDBOX {
             args.push("--dangerously-bypass-approvals-and-sandbox".to_string());
@@ -648,6 +661,18 @@ impl CodexAgent {
             "-c".to_string(),
             format!("mcp_servers.intendant.url=\"{}\"", mcp_url),
         ]);
+        if super::intendant_mcp_bearer_token(
+            self.mcp_auth_token.as_deref(),
+            self.mcp_session_id.as_deref(),
+        )
+        .is_some()
+        {
+            args.push("-c".to_string());
+            args.push(format!(
+                "mcp_servers.intendant.bearer_token_env_var=\"{}\"",
+                super::INTENDANT_MCP_BEARER_TOKEN_ENV
+            ));
+        }
         if self.sandbox.trim() == CODEX_DANGER_FULL_ACCESS_SANDBOX {
             args.push("-c".to_string());
             args.push(format!(
@@ -1267,9 +1292,10 @@ impl ExternalAgent for CodexAgent {
         self.protocol_watch = protocol_watch.clone();
 
         // The Intendant MCP server is wired exclusively via per-process
-        // `-c mcp_servers.intendant.{type,url}` overrides (see
-        // app_server_args): each spawned Codex carries its own
-        // session-scoped URL on its command line. A legacy code path also
+        // `-c mcp_servers.intendant.{type,url,bearer_token_env_var}`
+        // overrides (see app_server_args). The URL on argv carries only
+        // session/profile routing; the session-scoped bearer rides an
+        // explicitly injected child env var. A legacy code path also
         // wrote `<working_dir>/.codex/config.toml` — a location Codex does
         // not read config from — which stomped the user's real
         // `~/.codex/config.toml` whenever a session's working dir was
@@ -3466,6 +3492,68 @@ enabled = true
             format!(
                 "http://localhost:8765/mcp?session_id=session%20with%20spaces&managed_context=managed&tool_profile=core&mcp_token={expected_token}"
             )
+        );
+    }
+
+    #[test]
+    fn mcp_bearer_is_in_child_env_never_codex_argv() {
+        use std::ffi::{OsStr, OsString};
+
+        let mut agent = CodexAgent::with_options(
+            "codex".to_string(),
+            None,
+            "never".to_string(),
+            "workspace-write".to_string(),
+            Some(8765),
+            CodexAgentOptions {
+                managed_context: true,
+                ..CodexAgentOptions::default()
+            },
+        );
+        agent.mcp_session_id = Some("session-a".to_string());
+        agent.mcp_auth_token = Some("raw-process-secret".to_string());
+        let expected =
+            crate::web_gateway::session_scoped_mcp_token("raw-process-secret", "session-a");
+
+        let args = agent.app_server_args_with_mcp_inheritance(8765, true);
+        let argv = args.join("\0");
+        assert!(!argv.contains("raw-process-secret"));
+        assert!(!argv.contains(&expected));
+        assert!(args_have_config_override(
+            &args,
+            "mcp_servers.intendant.url=\"http://localhost:8765/mcp?session_id=session-a&managed_context=managed&tool_profile=core\""
+        ));
+        assert!(args_have_config_override(
+            &args,
+            "mcp_servers.intendant.bearer_token_env_var=\"INTENDANT_MCP_BEARER_TOKEN\""
+        ));
+
+        let mut command = crate::platform::spawn_command("codex");
+        super::super::apply_external_child_env_policy_from(
+            &mut command,
+            std::iter::empty::<(OsString, OsString)>(),
+            &std::collections::HashSet::new(),
+        );
+        agent.add_intendant_ctl_env(&mut command, 8765);
+        let envs: Vec<(OsString, Option<OsString>)> = command
+            .as_std()
+            .get_envs()
+            .map(|(key, value)| (key.to_os_string(), value.map(OsString::from)))
+            .collect();
+        let value_for = |name: &str| {
+            envs.iter()
+                .find(|(key, _)| key == OsStr::new(name))
+                .and_then(|(_, value)| value.clone())
+        };
+        assert_eq!(
+            value_for(super::super::INTENDANT_MCP_BEARER_TOKEN_ENV),
+            Some(OsString::from(expected.clone()))
+        );
+        assert_eq!(
+            value_for("INTENDANT_MCP_URL"),
+            Some(OsString::from(format!(
+                "http://localhost:8765/mcp?session_id=session-a&managed_context=managed&tool_profile=core&mcp_token={expected}"
+            )))
         );
     }
 

--- a/src/bin/caller/external_agent/mod.rs
+++ b/src/bin/caller/external_agent/mod.rs
@@ -80,16 +80,44 @@ pub(super) fn encode_mcp_query_value(value: &str) -> String {
     encoded
 }
 
+/// Secret-bearing environment variable read by supervised MCP clients.
+///
+/// The value is injected after the external-child `env_clear()` boundary and
+/// is never copied from the controller's ambient environment. Client config
+/// placed on argv names this variable; it never contains the token itself.
+pub(super) const INTENDANT_MCP_BEARER_TOKEN_ENV: &str = "INTENDANT_MCP_BEARER_TOKEN";
+
+/// Resolve the bearer value a supervised MCP client should send. A session
+/// id derives a token bound to that exact agent principal; without one, the
+/// raw per-process token remains the transport fallback.
+pub(super) fn intendant_mcp_bearer_token(
+    mcp_token: Option<&str>,
+    session_id: Option<&str>,
+) -> Option<String> {
+    let token = mcp_token.map(str::trim).filter(|token| !token.is_empty())?;
+    Some(
+        match session_id
+            .map(str::trim)
+            .filter(|session| !session.is_empty())
+        {
+            Some(session_id) => crate::web_gateway::session_scoped_mcp_token(token, session_id),
+            None => token.to_string(),
+        },
+    )
+}
+
 /// Build the loopback MCP URL Intendant injects into a supervised backend.
 ///
-/// Carries the auth token, the Intendant session id (so tool calls are
-/// scoped to the calling backend), the `core` tool profile (the small
-/// bootstrap set — the broad surface is discovered lazily through
-/// `intendant ctl`), and, for Codex, the managed-context mode. When a
-/// session id is present the injected token is *session-scoped* (derived
-/// from the per-process token and the session id), so the backend
-/// authenticates as exactly that supervised agent session to the daemon's
-/// IAM layer and cannot present another session's identity.
+/// Carries the Intendant session id (so tool calls are scoped to the calling
+/// backend), the `core` tool profile (the small bootstrap set — the broad
+/// surface is discovered lazily through `intendant ctl`), and, for Codex, the
+/// managed-context mode. `mcp_token` is optional: the private
+/// `INTENDANT_MCP_URL` ctl bootstrap includes it, while argv-visible backend
+/// config omits it and authenticates with the bearer env instead. When a
+/// session id is present the token is *session-scoped* (derived from the
+/// per-process token and the session id), so the backend authenticates as
+/// exactly that supervised agent session to the daemon's IAM layer and cannot
+/// present another session's identity.
 pub(super) fn intendant_bootstrap_mcp_url(
     port: u16,
     session_id: Option<&str>,
@@ -105,11 +133,7 @@ pub(super) fn intendant_bootstrap_mcp_url(
         params.push(("managed_context", mode.to_string()));
     }
     params.push(("tool_profile", "core".to_string()));
-    if let Some(token) = mcp_token.map(str::trim).filter(|s| !s.is_empty()) {
-        let value = match session_id {
-            Some(session_id) => crate::web_gateway::session_scoped_mcp_token(token, session_id),
-            None => token.to_string(),
-        };
+    if let Some(value) = intendant_mcp_bearer_token(mcp_token, session_id) {
         params.push(("mcp_token", encode_mcp_query_value(&value)));
     }
     let query = params
@@ -123,16 +147,27 @@ pub(super) fn intendant_bootstrap_mcp_url(
 /// Inject the `intendant ctl` bootstrap environment into a supervised child:
 /// `INTENDANT` (absolute controller binary path), `INTENDANT_MCP_URL`
 /// (loopback endpoint with auth token + session scope baked in), and
-/// `INTENDANT_SESSION_ID`. With these set, `"$INTENDANT" ctl ...` works from
-/// any backend's shell without further configuration.
+/// `INTENDANT_SESSION_ID`. The separately injected
+/// `INTENDANT_MCP_BEARER_TOKEN` lets the backend's MCP client authenticate
+/// without putting the secret on argv. With these set,
+/// `"$INTENDANT" ctl ...` works from any backend's shell without further
+/// configuration.
 pub(super) fn add_intendant_bootstrap_env(
     command: &mut tokio::process::Command,
     mcp_url: &str,
     session_id: Option<&str>,
+    mcp_token: Option<&str>,
 ) {
     command.env("INTENDANT_MCP_URL", mcp_url);
     if let Some(session_id) = session_id.map(str::trim).filter(|s| !s.is_empty()) {
         command.env("INTENDANT_SESSION_ID", session_id);
+    } else {
+        command.env_remove("INTENDANT_SESSION_ID");
+    }
+    if let Some(token) = intendant_mcp_bearer_token(mcp_token, session_id) {
+        command.env(INTENDANT_MCP_BEARER_TOKEN_ENV, token);
+    } else {
+        command.env_remove(INTENDANT_MCP_BEARER_TOKEN_ENV);
     }
     if let Ok(current_exe) = std::env::current_exe() {
         command.env("INTENDANT", current_exe);
@@ -212,6 +247,15 @@ const EXTERNAL_CHILD_BASE_ENV: &[&str] = &[
 /// user extension of the allowlist that can never re-admit provider keys.
 fn external_child_env_allowed(name: &str, passthrough: &HashSet<String>) -> bool {
     let upper = name.to_ascii_uppercase();
+    // Token-bearing MCP bootstrap values are injected explicitly after the
+    // clear. Never copy a stale value from a controller that is itself
+    // running as a supervised child of another daemon.
+    if matches!(
+        upper.as_str(),
+        "INTENDANT_MCP_URL" | "INTENDANT_MCP_BEARER_TOKEN" | "INTENDANT_SESSION_ID"
+    ) {
+        return false;
+    }
     // Controller→child control channel: `INTENDANT` + `INTENDANT_*`
     // bootstrap vars and the mock-provider rig's `PROVIDER` always ride.
     if upper == "INTENDANT" || upper.starts_with("INTENDANT_") || upper == "PROVIDER" {
@@ -1937,8 +1981,6 @@ mod tests {
             // rides PROVIDER + INTENDANT_MOCK_* into children).
             "PROVIDER",
             "INTENDANT",
-            "INTENDANT_MCP_URL",
-            "INTENDANT_SESSION_ID",
             "INTENDANT_MOCK_SCRIPT",
             "INTENDANT_MOCK_DISPLAY",
             "INTENDANT_ENV_PASSTHROUGH",
@@ -1973,6 +2015,11 @@ mod tests {
             "DOCKER_CONFIG",
             "DBUS_SESSION_BUS_ADDRESS",
             "MY_APP_SECRET",
+            // Bootstrap identity/credentials are spawn-injected, never
+            // inherited from an ambient parent session.
+            "INTENDANT_MCP_URL",
+            "INTENDANT_MCP_BEARER_TOKEN",
+            "INTENDANT_SESSION_ID",
             // Injection vectors and plain unknowns default-deny.
             "NODE_OPTIONS",
             "LD_PRELOAD",
@@ -1989,7 +2036,8 @@ mod tests {
     #[test]
     fn external_child_env_passthrough_extends_but_never_admits_provider_keys() {
         let passthrough = intendant_core::env_scrub::env_passthrough_set(Some(
-            "ssh_auth_sock, CARGO_TARGET_DIR, ANTHROPIC_API_KEY",
+            "ssh_auth_sock, CARGO_TARGET_DIR, ANTHROPIC_API_KEY, \
+             INTENDANT_MCP_URL, INTENDANT_MCP_BEARER_TOKEN",
         ));
         assert!(external_child_env_allowed("SSH_AUTH_SOCK", &passthrough));
         assert!(external_child_env_allowed("CARGO_TARGET_DIR", &passthrough));
@@ -2001,6 +2049,12 @@ mod tests {
             !external_child_env_allowed("GH_TOKEN", &passthrough),
             "non-named ambient credentials stay dropped"
         );
+        for name in ["INTENDANT_MCP_URL", "INTENDANT_MCP_BEARER_TOKEN"] {
+            assert!(
+                !external_child_env_allowed(name, &passthrough),
+                "{name} must only come from the explicit spawn injection"
+            );
+        }
     }
 
     /// The applier copies exactly the allowed inherited names onto the
@@ -2026,7 +2080,12 @@ mod tests {
 
         let mut command = tokio::process::Command::new("true");
         apply_external_child_env_policy_from(&mut command, inherited, &HashSet::new());
-        add_intendant_bootstrap_env(&mut command, "http://localhost:1/mcp?x", Some("sess-1"));
+        add_intendant_bootstrap_env(
+            &mut command,
+            "http://localhost:1/mcp?x",
+            Some("sess-1"),
+            Some("process-token"),
+        );
 
         let envs: Vec<(OsString, Option<OsString>)> = command
             .as_std()
@@ -2064,6 +2123,12 @@ mod tests {
         assert_eq!(
             set_value_for("INTENDANT_SESSION_ID"),
             Some(OsString::from("sess-1"))
+        );
+        assert_eq!(
+            set_value_for(INTENDANT_MCP_BEARER_TOKEN_ENV),
+            Some(OsString::from(
+                crate::web_gateway::session_scoped_mcp_token("process-token", "sess-1")
+            ))
         );
     }
 


### PR DESCRIPTION
## What changed

- keep supervised Codex and Claude MCP bearer values out of process arguments
- inject a session-scoped bearer through the cleared child environment
- configure Codex with `bearer_token_env_var` and Claude with an environment-expanded Authorization header
- refuse ambient inheritance of MCP URL, bearer, and session bootstrap variables
- document the new bootstrap boundary

## Why

The root-equivalent MCP credential was embedded in child argv and could be scraped from process listings by another local account. The MCP clients support environment-backed authentication, so argv only needs routing metadata and an environment-variable reference.

## Impact

Supervised backends retain the same session-scoped MCP identity and `intendant ctl` bootstrap behavior. Their process arguments no longer contain the raw or derived bearer value.

## Validation

- `cargo fmt -- --check`
- `cargo check --bin intendant`
- `cargo clippy --bins -- -D warnings`
- `cargo test --bin intendant`: 3,999 passed, 10 ignored
- `cargo test --bin intendant-connect --bin intendant-runtime`: 218 passed
- focused Codex token-off-argv regression test
- focused Claude header-placeholder regression test
- external-child environment allowlist/isolation tests