### PR TITLE
fix(claude-code): terminate resumed Task sub-agent windows (notification re-keying)

### DIFF
--- a/src/bin/caller/external_agent/claude_code.rs
+++ b/src/bin/caller/external_agent/claude_code.rs
@@ -734,9 +734,11 @@ struct CcTaskChild {
     /// see it as an ephemeral child session wired to the parent via a
     /// `session_relationship` — it is not resumable or addressable.
     child_id: String,
-    /// A terminal state was already emitted; late envelopes (e.g. the main
-    /// agent continuing the child via SendMessage) still scope to the
-    /// child window, but no second terminal event fires.
+    /// A terminal state was already emitted. The latch guards against a
+    /// duplicate terminal for the same run segment only: envelopes routed
+    /// back into a terminal child (the main agent resuming the task — the
+    /// stream re-enters tagged with the same spawn tool_use id) clear it
+    /// again in `task_scope_for`, so the resumed run's own end can emit.
     terminal: bool,
 }
 
@@ -989,8 +991,16 @@ struct CcReader {
     /// In-band sub-agents by spawning tool_use id (the value child
     /// envelopes carry as `parent_tool_use_id`).
     task_children: HashMap<String, CcTaskChild>,
-    /// `task_id` (the key `system:task_*` events use) → spawning
-    /// tool_use id.
+    /// `task_id` (the key `system:task_*` events use) → the SPAWN
+    /// tool_use id, first-write-wins. Claude Code keys each
+    /// `system:task_notification` by whichever tool_use initiated THAT
+    /// run segment — the spawn for run #1, the resume message for a
+    /// resumed run — while the task_id stays stable across runs and
+    /// children stay keyed by the spawn id (the value child envelopes
+    /// carry as `parent_tool_use_id`). The first binding for a task_id is
+    /// therefore the spawn binding, and later `task_started`s for the
+    /// same task must never overwrite it: this map is how a resumed
+    /// run's notification finds its child again.
     task_ids: HashMap<String, String>,
     /// tool_use ids of plan-shaped calls (`TodoWrite`, `TaskUpdate`) already
     /// rendered as `PlanUpdate`, mapped to the tool name for failure logs, so
@@ -1248,9 +1258,26 @@ impl CcReader {
             };
             self.register_task_child(&ptid, None, spawn, out);
         }
-        self.task_children
-            .get(&ptid)
-            .map(|child| child.child_id.clone())
+        let child = self.task_children.get_mut(&ptid)?;
+        if child.terminal {
+            // The stream flowing into a terminal child proves the agent
+            // lives again: a resumed Task run re-enters the same child
+            // window (same spawn tool_use id), and its own end must be
+            // able to emit — re-arm the once-guard. Deliberately no fresh
+            // `SubAgentToolCall { inProgress }` rides the re-arm: the
+            // frontend derives the window's active look from the scoped
+            // stream itself and its end from the terminal's log line, not
+            // from the inProgress state, while a re-registration event
+            // would add parent-turn bookkeeping (AgentStarted/turn
+            // counters) — and, arriving while the parent sits idle, would
+            // open a spurious observe-drain round on it. The drain re-arms
+            // its SessionEnded dedupe from the same scoped stream
+            // (`thread_actions::note_external_subagent_liveness`). Side
+            // effect, intended: a re-armed child is non-terminal again,
+            // so shutdown (`close_open_task_children`) properly closes it.
+            child.terminal = false;
+        }
+        Some(child.child_id.clone())
     }
 
     /// Register an in-band sub-agent and announce it as a synthetic child
@@ -1613,14 +1640,27 @@ impl CcReader {
         // The correlation key is recorded for every task kind: it only
         // feeds task_notification's id resolution, and a stray entry for a
         // Bash task resolves to an id with no registered child (no-op).
+        // First-write-wins: the first tool_use seen for a task_id is the
+        // spawn segment's (see the `task_ids` field docs).
         let task_id = msg
             .get("task_id")
             .and_then(|v| v.as_str())
             .map(str::trim)
             .filter(|s| !s.is_empty());
         if let Some(task_id) = task_id {
-            self.task_ids
-                .insert(task_id.to_string(), tool_use_id.to_string());
+            let spawn_tool_use_id = self
+                .task_ids
+                .entry(task_id.to_string())
+                .or_insert_with(|| tool_use_id.to_string());
+            // A task_started re-announcing a known task under a NEW
+            // tool_use id describes a later run segment of the same task
+            // (a resume), never a second spawn. Registering or arming
+            // under the segment id would ghost a second child that then
+            // captures the run's task_notification away from the real
+            // child window.
+            if spawn_tool_use_id.as_str() != tool_use_id {
+                return;
+            }
         }
         // Background command announced (`run_in_background` Bash and
         // auto-backgrounded commands alike, live-probed on 2.1.211): arm
@@ -1709,17 +1749,18 @@ impl CcReader {
     /// `system:task_notification`: the async sub-agent's authoritative end
     /// (status + final summary).
     fn handle_task_notification(&mut self, msg: &serde_json::Value, out: &mut CcLineOutcome) {
+        let task_id = msg
+            .get("task_id")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
         let tool_use_id = msg
             .get("tool_use_id")
             .and_then(|v| v.as_str())
             .map(str::trim)
             .filter(|s| !s.is_empty())
             .map(str::to_string)
-            .or_else(|| {
-                msg.get("task_id")
-                    .and_then(|v| v.as_str())
-                    .and_then(|task_id| self.task_ids.get(task_id.trim()).cloned())
-            });
+            .or_else(|| task_id.and_then(|task_id| self.task_ids.get(task_id).cloned()));
         let Some(tool_use_id) = tool_use_id else {
             return;
         };
@@ -1771,6 +1812,21 @@ impl CcReader {
             self.observe_bg_tasks(out);
             return;
         }
+        // Segment re-keying: Claude Code keys a resumed run's notification
+        // by the tool_use that initiated THAT run segment (the resume
+        // message's id), while the child stays keyed by the spawn tool_use
+        // and the task_id stays stable across runs. When the notification's
+        // id misses the children, resolve through the first-write spawn
+        // binding so the resumed run terminates the original child window.
+        // Unknown tool_use AND unknown task_id stays a silent no-op
+        // (`emit_task_terminal` drops ids it never registered).
+        let tool_use_id = if self.task_children.contains_key(&tool_use_id) {
+            tool_use_id
+        } else {
+            task_id
+                .and_then(|task_id| self.task_ids.get(task_id).cloned())
+                .unwrap_or(tool_use_id)
+        };
         let (outer_status, state_status) = match status {
             "completed" | "success" => ("completed", "completed"),
             "failed" | "error" | "errored" => ("failed", "errored"),
@@ -5293,6 +5349,212 @@ mod tests {
                     AgentEvent::SubAgentToolCall { status, agents, .. }
                         if status == "failed" && agents[0].status == "errored"
                 )
+        )));
+    }
+
+    #[test]
+    fn resumed_task_stream_rearms_and_notification_rekeys_via_task_id() {
+        // Claude Code keys each task_notification by the tool_use that
+        // initiated THAT run segment — the Agent spawn for run #1, the
+        // resume message for a resumed run — while the task_id stays
+        // stable and child envelopes keep carrying the spawn id as
+        // parent_tool_use_id. Observed live: without re-keying, a resumed
+        // run re-activates the child window but can never re-terminate
+        // it.
+        let mut reader = test_reader();
+        spawn_task(&mut reader);
+        reader.process_line(
+            r#"{"type":"system","subtype":"task_started","task_id":"aa440","tool_use_id":"toolu_01AAABBBCCCDDDEEE","description":"probe echo","subagent_type":"general-purpose","task_type":"local_agent","session_id":"s1"}"#,
+        );
+        // Run #1 ends under the spawn tool_use id.
+        reader.process_line(
+            r#"{"type":"system","subtype":"task_notification","task_id":"aa440","tool_use_id":"toolu_01AAABBBCCCDDDEEE","status":"completed","summary":"first run done","session_id":"s1"}"#,
+        );
+        assert!(reader.task_children["toolu_01AAABBBCCCDDDEEE"].terminal);
+
+        // Resume: the stream re-enters the child, tagged with the SPAWN id.
+        let out = reader.process_line(
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"back to work"}]},"parent_tool_use_id":"toolu_01AAABBBCCCDDDEEE","session_id":"s1"}"#,
+        );
+        assert!(
+            !reader.task_children["toolu_01AAABBBCCCDDDEEE"].terminal,
+            "stream re-entry must re-arm the terminal once-guard"
+        );
+        // Deliberately no re-registration event rides the re-arm: the
+        // window's active look derives from the scoped stream itself.
+        assert!(
+            !out.events
+                .iter()
+                .any(|e| matches!(e, AgentEvent::SubAgentToolCall { .. })),
+            "re-arm must not re-register: {:?}",
+            out.events
+        );
+        assert!(out.events.iter().any(|e| matches!(
+            e,
+            AgentEvent::Scoped { thread_id, event, .. }
+                if thread_id.as_deref() == Some(TASK_CHILD)
+                    && matches!(event.as_ref(), AgentEvent::Message { text } if text == "back to work")
+        )));
+
+        // Run #2 ends under the RESUME segment's tool_use id + the stable
+        // task_id: the notification must resolve back to the spawn child.
+        let out = reader.process_line(
+            r#"{"type":"system","subtype":"task_notification","task_id":"aa440","tool_use_id":"toolu_01RESUMESEGMENT000","status":"completed","summary":"second run done","session_id":"s1"}"#,
+        );
+        assert!(out.events.iter().any(|e| matches!(
+            e,
+            AgentEvent::Scoped { thread_id, event, .. }
+                if thread_id.as_deref() == Some(TASK_CHILD)
+                    && matches!(
+                        event.as_ref(),
+                        AgentEvent::SubAgentToolCall { item_id, status, agents, .. }
+                            if item_id == "toolu_01AAABBBCCCDDDEEE"
+                                && status == "completed"
+                                && agents[0].status == "completed"
+                                && agents[0].message.as_deref() == Some("second run done")
+                    )
+        )));
+        assert!(reader.task_children["toolu_01AAABBBCCCDDDEEE"].terminal);
+        // A duplicate of run #2's notification stays silent — the
+        // once-guard is latched again.
+        let out = reader.process_line(
+            r#"{"type":"system","subtype":"task_notification","task_id":"aa440","tool_use_id":"toolu_01RESUMESEGMENT000","status":"completed","summary":"second run done","session_id":"s1"}"#,
+        );
+        assert!(out.events.is_empty());
+    }
+
+    #[test]
+    fn task_id_spawn_binding_survives_later_task_started() {
+        // A resumed run may re-announce the same task_id under the new
+        // segment's tool_use id: the spawn binding is first-write-wins,
+        // and the segment id must not register a second (ghost) child
+        // that would capture the run's notification away from the real
+        // child window.
+        let mut reader = test_reader();
+        spawn_task(&mut reader);
+        reader.process_line(
+            r#"{"type":"system","subtype":"task_started","task_id":"aa440","tool_use_id":"toolu_01AAABBBCCCDDDEEE","description":"probe echo","subagent_type":"general-purpose","task_type":"local_agent","session_id":"s1"}"#,
+        );
+        let out = reader.process_line(
+            r#"{"type":"system","subtype":"task_started","task_id":"aa440","tool_use_id":"toolu_01RESUMESEGMENT000","description":"probe echo","subagent_type":"general-purpose","task_type":"local_agent","session_id":"s1"}"#,
+        );
+        assert_eq!(
+            reader.task_ids.get("aa440").map(String::as_str),
+            Some("toolu_01AAABBBCCCDDDEEE"),
+            "spawn binding must survive later task_starteds"
+        );
+        assert!(
+            !reader
+                .task_children
+                .contains_key("toolu_01RESUMESEGMENT000"),
+            "segment id must not ghost a second child"
+        );
+        assert!(
+            out.events.is_empty(),
+            "segment re-announce is silent: {:?}",
+            out.events
+        );
+        // A notification correlating only by task_id still resolves to
+        // the spawn child.
+        let out = reader.process_line(
+            r#"{"type":"system","subtype":"task_notification","task_id":"aa440","status":"completed","summary":"done","session_id":"s1"}"#,
+        );
+        assert!(out.events.iter().any(|e| matches!(
+            e,
+            AgentEvent::Scoped { thread_id, event, .. }
+                if thread_id.as_deref() == Some(TASK_CHILD)
+                    && matches!(
+                        event.as_ref(),
+                        AgentEvent::SubAgentToolCall { item_id, status, .. }
+                            if item_id == "toolu_01AAABBBCCCDDDEEE" && status == "completed"
+                    )
+        )));
+    }
+
+    #[test]
+    fn unknown_notification_ids_stay_silent() {
+        // Neither the tool_use id nor the task_id is known: silent no-op —
+        // no spurious terminal, no panic, the real child untouched.
+        let mut reader = test_reader();
+        spawn_task(&mut reader);
+        let out = reader.process_line(
+            r#"{"type":"system","subtype":"task_notification","task_id":"zz404","tool_use_id":"toolu_01NEVERSEEN0000000","status":"failed","summary":"whose task is this","session_id":"s1"}"#,
+        );
+        assert!(
+            out.events.is_empty(),
+            "unknown ids must no-op: {:?}",
+            out.events
+        );
+        assert!(!reader.task_children["toolu_01AAABBBCCCDDDEEE"].terminal);
+    }
+
+    #[test]
+    fn midrun_continuation_keeps_spawn_keying() {
+        // Steering a RUNNING task does not open a new run segment: child
+        // activity keeps flowing and the notification stays keyed by the
+        // spawn tool_use id. Pinned so the segment re-keying never
+        // disturbs the normal single-run flow.
+        let mut reader = test_reader();
+        spawn_task(&mut reader);
+        reader.process_line(
+            r#"{"type":"system","subtype":"task_started","task_id":"aa440","tool_use_id":"toolu_01AAABBBCCCDDDEEE","description":"probe echo","subagent_type":"general-purpose","task_type":"local_agent","session_id":"s1"}"#,
+        );
+        // Mid-run child activity (never terminal): no re-arm, no
+        // re-register.
+        let out = reader.process_line(
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"still working"}]},"parent_tool_use_id":"toolu_01AAABBBCCCDDDEEE","session_id":"s1"}"#,
+        );
+        assert!(!out
+            .events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::SubAgentToolCall { .. })));
+        assert!(!reader.task_children["toolu_01AAABBBCCCDDDEEE"].terminal);
+        // The run's end still arrives under the spawn id and terminates
+        // exactly once.
+        let out = reader.process_line(
+            r#"{"type":"system","subtype":"task_notification","task_id":"aa440","tool_use_id":"toolu_01AAABBBCCCDDDEEE","status":"completed","summary":"done","session_id":"s1"}"#,
+        );
+        let terminals = out
+            .events
+            .iter()
+            .filter(|e| {
+                matches!(
+                    e,
+                    AgentEvent::Scoped { event, .. }
+                        if matches!(
+                            event.as_ref(),
+                            AgentEvent::SubAgentToolCall { status, .. } if status == "completed"
+                        )
+                )
+            })
+            .count();
+        assert_eq!(terminals, 1);
+    }
+
+    #[test]
+    fn rearmed_child_is_closeable_at_shutdown_again() {
+        // Intended side effect of the re-arm: a resumed child that never
+        // re-terminates is open again, so shutdown closes it instead of
+        // skipping it as already-terminal.
+        let mut reader = test_reader();
+        spawn_task(&mut reader);
+        reader.process_line(
+            r#"{"type":"system","subtype":"task_notification","tool_use_id":"toolu_01AAABBBCCCDDDEEE","status":"completed","session_id":"s1"}"#,
+        );
+        reader.process_line(
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"resumed"}]},"parent_tool_use_id":"toolu_01AAABBBCCCDDDEEE","session_id":"s1"}"#,
+        );
+        let mut out = CcLineOutcome::default();
+        reader.close_open_task_children(&mut out);
+        assert!(out.events.iter().any(|e| matches!(
+            e,
+            AgentEvent::Scoped { thread_id, event, .. }
+                if thread_id.as_deref() == Some(TASK_CHILD)
+                    && matches!(
+                        event.as_ref(),
+                        AgentEvent::SubAgentToolCall { status, agents, .. }
+                            if status == "interrupted" && agents[0].status == "shutdown"
+                    )
         )));
     }
 

--- a/src/bin/caller/external_events.rs
+++ b/src/bin/caller/external_events.rs
@@ -1013,6 +1013,14 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
         let event_is_side = side_thread_id.is_some() && !event_is_primary;
         let event_is_codex_subagent =
             codex_subagent_thread_id.is_some() && !event_is_primary && !event_is_side;
+        if event_is_codex_subagent {
+            if let Some(child_thread_id) = codex_subagent_thread_id.as_deref() {
+                // A terminal-marked child that streams again is alive again
+                // (Claude Code Task resume): re-arm the SessionEnded dedupe
+                // so the resumed run's own terminal can emit.
+                note_external_subagent_liveness(stats, child_thread_id, &event);
+            }
+        }
         let child_thread_id = side_thread_id
             .as_ref()
             .or(codex_subagent_thread_id.as_ref());

--- a/src/bin/caller/thread_actions.rs
+++ b/src/bin/caller/thread_actions.rs
@@ -2588,6 +2588,37 @@ pub(crate) fn emit_external_subagent_terminal(
     }
 }
 
+/// A substantive scoped event from a child thread already marked terminal
+/// proves the thread is alive again — a Claude Code Task resume streams new
+/// envelopes into the same child window — so clear the terminal dedupe and
+/// let the resumed run's own terminal emit `SessionEnded`/`Interrupted`
+/// again. Only fresh-conversation kinds (and an explicit `inProgress`
+/// sub-agent state) count: state-carrying `SubAgentToolCall` events must
+/// NOT clear it, because a repeated terminal state is exactly what the
+/// dedupe suppresses, and trailing bookkeeping (tool results, logs, usage)
+/// after a terminal is a straggler, not a resurrection.
+pub(crate) fn note_external_subagent_liveness(
+    stats: &mut LoopStats,
+    child_thread_id: &str,
+    event: &external_agent::AgentEvent,
+) {
+    let alive = match event {
+        external_agent::AgentEvent::Message { .. }
+        | external_agent::AgentEvent::MessageDelta { .. }
+        | external_agent::AgentEvent::Reasoning { .. }
+        | external_agent::AgentEvent::UserMessage { .. }
+        | external_agent::AgentEvent::ToolStarted { .. }
+        | external_agent::AgentEvent::PlanUpdate { .. } => true,
+        external_agent::AgentEvent::SubAgentToolCall { status, .. } => status == "inProgress",
+        _ => false,
+    };
+    if alive {
+        stats
+            .codex_subagent_terminal_sessions
+            .remove(child_thread_id.trim());
+    }
+}
+
 pub(crate) fn json_u32_field(value: &serde_json::Value, key: &str) -> Option<u32> {
     value
         .get(key)
@@ -3182,6 +3213,7 @@ pub(crate) fn handle_idle_codex_subagent_event(
     child_thread_id: String,
     event: external_agent::AgentEvent,
 ) {
+    note_external_subagent_liveness(stats, &child_thread_id, &event);
     let session_id = Some(child_thread_id.clone());
     match event {
         external_agent::AgentEvent::NativeSessionId { .. } => {
@@ -3941,6 +3973,171 @@ mod tests {
                 );
             }
             other => panic!("expected child completion LogEntry, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn reactivated_subagent_can_end_again() {
+        // A Claude Code Task resume streams into a child whose errored
+        // end already emitted SessionEnded: the scoped stream clears the
+        // terminal dedupe so the resumed run's own errored end reaches
+        // SessionEnded again — while a repeated terminal state without
+        // fresh activity stays suppressed.
+        let bus = EventBus::new();
+        let mut rx = bus.subscribe();
+        let dir = tempfile::tempdir().unwrap();
+        let log_dir = dir.path().join("session");
+        let session_log: SharedSessionLog = Arc::new(Mutex::new(
+            session_log::SessionLog::open(log_dir.clone()).unwrap(),
+        ));
+        let approval_registry: event::ApprovalRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let context_injection: event::ContextInjectionQueue = Arc::new(Mutex::new(Vec::new()));
+        let autonomy = autonomy::shared_autonomy(AutonomyState::default());
+        let config = DrainConfig {
+            bus: &bus,
+            web_port: None,
+            session_id: Some("parent-thread".to_string()),
+            alias_session_id: None,
+            backend_thread_id: None,
+            autonomy,
+            session_log: &session_log,
+            project_root: dir.path(),
+            log_dir: &log_dir,
+            approval_registry: &approval_registry,
+            json_approval: None,
+            agent_source: Some("claude-code".to_string()),
+            suppress_agent_started: false,
+            persist_model_responses_inline: true,
+            headless: true,
+            context_injection: &context_injection,
+            reload_credentials: None,
+        };
+        let mut stats = LoopStats::default();
+        let errored = external_agent::SubAgentState {
+            thread_id: "task-child".to_string(),
+            status: "errored".to_string(),
+            message: Some("run failed".to_string()),
+        };
+        fn session_ended_count(rx: &mut tokio::sync::broadcast::Receiver<AppEvent>) -> usize {
+            let mut count = 0;
+            while let Ok(event) = rx.try_recv() {
+                if matches!(
+                    &event,
+                    AppEvent::SessionEnded { session_id, .. } if session_id == "task-child"
+                ) {
+                    count += 1;
+                }
+            }
+            count
+        }
+
+        emit_external_subagent_terminal(&config, &mut stats, &errored);
+        assert_eq!(session_ended_count(&mut rx), 1, "first errored end emits");
+
+        // The same terminal state again, with no fresh activity in
+        // between: suppressed.
+        emit_external_subagent_terminal(&config, &mut stats, &errored);
+        assert_eq!(
+            session_ended_count(&mut rx),
+            0,
+            "repeat without liveness stays deduped"
+        );
+
+        // Resumed-run activity streams into the child while the session
+        // idles.
+        handle_idle_codex_subagent_event(
+            &config,
+            &mut stats,
+            "task-child".to_string(),
+            external_agent::AgentEvent::Message {
+                text: "resumed and working".to_string(),
+            },
+        );
+        let _ = session_ended_count(&mut rx); // drain the forwarding noise
+
+        emit_external_subagent_terminal(&config, &mut stats, &errored);
+        assert_eq!(
+            session_ended_count(&mut rx),
+            1,
+            "re-terminal after reactivation emits again"
+        );
+    }
+
+    #[test]
+    fn subagent_liveness_kinds_are_selective() {
+        // Fresh conversation from a terminal-marked child clears the
+        // SessionEnded dedupe; a repeated terminal state or trailing
+        // bookkeeping never does — that repetition is exactly what the
+        // dedupe suppresses.
+        let mut stats = LoopStats::default();
+        let seed = |stats: &mut LoopStats| {
+            stats
+                .codex_subagent_terminal_sessions
+                .insert("task-child".to_string());
+        };
+
+        for event in [
+            external_agent::AgentEvent::Message { text: "hi".into() },
+            external_agent::AgentEvent::Reasoning {
+                text: "planning".into(),
+            },
+            external_agent::AgentEvent::ToolStarted {
+                item_id: "t1".into(),
+                preview: "ls".into(),
+                tool_name: "Bash".into(),
+            },
+            external_agent::AgentEvent::SubAgentToolCall {
+                item_id: "t2".into(),
+                tool: "Agent".into(),
+                status: "inProgress".into(),
+                sender_thread_id: "task-child".into(),
+                receiver_thread_ids: vec!["task-grandchild".into()],
+                prompt: None,
+                model: None,
+                reasoning_effort: None,
+                agents: Vec::new(),
+            },
+        ] {
+            seed(&mut stats);
+            note_external_subagent_liveness(&mut stats, "task-child", &event);
+            assert!(
+                !stats
+                    .codex_subagent_terminal_sessions
+                    .contains("task-child"),
+                "{event:?} must clear the terminal mark"
+            );
+        }
+
+        for event in [
+            external_agent::AgentEvent::SubAgentToolCall {
+                item_id: "t3".into(),
+                tool: "Agent".into(),
+                status: "failed".into(),
+                sender_thread_id: "parent-thread".into(),
+                receiver_thread_ids: vec!["task-child".into()],
+                prompt: None,
+                model: None,
+                reasoning_effort: None,
+                agents: Vec::new(),
+            },
+            external_agent::AgentEvent::ToolCompleted {
+                item_id: "t1".into(),
+                status: external_agent::ToolCompletionStatus::Cancelled,
+            },
+            external_agent::AgentEvent::Log {
+                level: "info".into(),
+                message: "straggler".into(),
+            },
+            external_agent::AgentEvent::TurnCompleted { message: None },
+        ] {
+            seed(&mut stats);
+            note_external_subagent_liveness(&mut stats, "task-child", &event);
+            assert!(
+                stats
+                    .codex_subagent_terminal_sessions
+                    .contains("task-child"),
+                "{event:?} must not clear the terminal mark"
+            );
         }
     }
 


### PR DESCRIPTION
## Problem

Claude Code keys each `system:task_notification` by whichever tool_use initiated **that run segment**: the `Agent` spawn tool_use for run #1, but the resume message's tool_use for a resumed run #N. The CC-side `task_id` stays stable across runs, and child envelopes keep carrying the **spawn** tool_use as `parent_tool_use_id`. Intendant keyed children by spawn tool_use only, so a resumed run re-activated its child window but could never re-terminate it — the window stranded in "awaiting model" forever, surviving daemon restart.

Three latches held the strand in place:

1. **Reader keying** — `handle_task_notification` used the notification's `tool_use_id` verbatim; a resumed segment's id missed `task_children`, and `emit_task_terminal` silently no-ops on unknown ids. The `task_ids` fallback ran only when `tool_use_id` was absent, and was overwritten by later `task_started`s.
2. **Reader once-guard** — `CcTaskChild.terminal` latched after run #1's end; even a correctly-keyed second terminal would have been swallowed, and `close_open_task_children` skipped terminal children at shutdown.
3. **Drain dedupe** — `codex_subagent_terminal_sessions` suppresses a second `SessionEnded`/`Interrupted` for the same child thread, so an errored re-terminal would not have reached the lifecycle path.

## Fix

- **(a) Notification re-keying**: `task_ids` is now the first-write-wins `task_id -> spawn tool_use` binding (a later `task_started` for a known task announces a new run segment, never a second spawn — it neither overwrites the binding nor ghost-registers a child under the segment id). When a notification's `tool_use_id` misses `task_children`, it re-keys through that binding; unknown tool_use + unknown task_id stays a silent no-op.
- **(b) Re-arm on resume**: `task_scope_for` clears the `terminal` latch when the stream routes back into a terminal child — the agent demonstrably lives again — so the resumed run's own end can emit. **No fresh `SubAgentToolCall{inProgress}` rides the re-arm**: the frontend derives the child window's active look from the scoped stream itself and its end from the terminal's log line (`inferSessionPhaseFromLog`), not from the inProgress state; a re-registration would only add parent-turn bookkeeping (AgentStarted/turn counters) and, arriving while the parent sits idle, would open a spurious observe-drain round on it. Intended side effect: a re-armed child is non-terminal again, so shutdown (`close_open_task_children`) properly closes it instead of skipping it.
- **(c) Drain hygiene**: new `note_external_subagent_liveness` (wired into the active drain's scoped-event routing and the idle listener) removes a child from `codex_subagent_terminal_sessions` when fresh scoped conversation (Message/Reasoning/ToolStarted/PlanUpdate/UserMessage, or an explicit `inProgress` sub-agent state) arrives from a terminal-marked thread — so an errored re-terminal emits `SessionEnded` again. Repeated terminal states and trailing bookkeeping (tool results, logs, usage) never clear it: that repetition is exactly what the dedupe suppresses.

No sweep of children at parent-turn end — background agents legitimately span turns.

## Tests

Fixtures follow the observed wire shapes (spawn envelope → notification #1 under the spawn tool_use → resume → stream envelope routed by `parent_tool_use_id` → notification #2 under a different tool_use, same task_id), with fully synthetic ids:

- `resumed_task_stream_rearms_and_notification_rekeys_via_task_id` — the full resume cycle: re-arm on stream re-entry (pinning that no re-registration event rides it), re-keyed terminal under the spawn id, once-guard re-latched after.
- `task_id_spawn_binding_survives_later_task_started` — first-write binding immune to overwrite; segment id never ghosts a second child; task_id-only notification still resolves.
- `unknown_notification_ids_stay_silent` — unknown tool_use + unknown task_id: no-op, no spurious terminal.
- `midrun_continuation_keeps_spawn_keying` — mid-run child activity does not re-key; single-run flow terminates exactly once (non-regression).
- `rearmed_child_is_closeable_at_shutdown_again` — the intended shutdown side effect.
- `reactivated_subagent_can_end_again` + `subagent_liveness_kinds_are_selective` (thread_actions) — errored re-terminal reaches `SessionEnded` after reactivation; dedupe boundary pinned kind-by-kind.

Existing task-child suite untouched and green.

## Overlap note

Draft #454 (`agent/hosted-control-wp4-wp5`) touches `src/bin/caller/external_agent/claude_code.rs` (+8/-1). This diff stays surgical in that file (task-child keying paths only) to keep any future reconcile trivial.
