### PR TITLE
dashboard: Activity-grid bulk pills (header details, Hide done) + minimized dock band

### DIFF
--- a/static/app/12-styles-tasks-log.css
+++ b/static/app/12-styles-tasks-log.css
@@ -809,6 +809,18 @@ body.context-focus-active {
 .session-window-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  /* Universal anti-overlap (ledger finding #4, generalized): whenever the
+     grid's height is definite or clamped (a dragged .resized height, the
+     42vh max-height here, the flexed concurrent-log-minimized state),
+     `auto` rows are sized against the container and compress below their
+     content-sized cards, which then paint across the next row (the
+     minimized-bar-over-neighbor artifact). Pinning rows to max-content
+     keeps every row exactly as tall as its cards and turns surplus into
+     scroll; align-content: start stacks rows from the top. Both are
+     inert under .maximized (display: flex, single line). Mechanism
+     detail: ui2-grid.css (the .resized cure this generalizes). */
+  grid-auto-rows: max-content;
+  align-content: start;
   gap: 10px;
   padding: 8px;
   max-height: 42vh;
@@ -998,6 +1010,26 @@ body.context-focus-active {
 .session-window.minimized {
   min-height: 36px;
   max-height: 36px;
+  /* Dock band: minimized bars flow to the END of the grid (visual order
+     only — DOM order is untouched, so Focus display-gating, activate
+     scrollIntoView, and persistence are unaffected) and pack into dense
+     36px max-content rows below the active cards, taskbar-style. The
+     lineage wires re-render from live rects on the same rAF pass every
+     minimize change already schedules, so they follow the moved bars. */
+  order: 9;
+}
+/* Gentle dock-in when a card collapses to its bar. Opacity only — a
+   transform would skew the rect the wire-render rAF pass reads
+   mid-animation — and no FLIP/measured motion: DOM efficiency is an
+   explicit bar for this band. */
+@media (prefers-reduced-motion: no-preference) {
+  .session-window.minimized {
+    animation: session-window-dock-in .2s ease-out;
+  }
+}
+@keyframes session-window-dock-in {
+  from { opacity: .45; }
+  to { opacity: 1; }
 }
 .session-window.minimized .session-window-log,
 .session-window.minimized .session-window-cwd,

--- a/static/app/20-shell.html
+++ b/static/app/20-shell.html
@@ -146,8 +146,14 @@
                   title="Minimize every finished sub-agent window">
             Minimize done<span class="ui2-minimize-done-count" id="ui2-minimize-done-count">0</span>
           </button>
+          <button type="button" class="ui2-hide-done" id="ui2-hide-done-btn" hidden
+                  title="Hide every finished session card (sessions stay in Sessions)">
+            Hide done<span class="ui2-hide-done-count" id="ui2-hide-done-count">0</span>
+          </button>
           <button type="button" class="ui2-collapse-all" id="ui2-collapse-all-btn" hidden
                   title="Minimize every session window to its header bar">Collapse all</button>
+          <button type="button" class="ui2-header-details" id="ui2-header-details-btn" hidden
+                  title="Expand header details on every session window">Expand details</button>
           <!-- vertical sliders, NOT the Control tab's horizontal pair —
                two adjacent controls must not share a glyph -->
           <button type="button" class="ui2-view-options-btn" id="ui2-view-options-btn"

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -780,14 +780,26 @@ function sessionWindowIsDoneSubagent(sessionId) {
   return sessionWindowIsSubagent(sid) && !sessionRelationshipSubagentIsActive(sid);
 }
 
-// The AUTO rule demands HARD done-evidence — ended, or phase
-// done/interrupted. Bare 'idle' is deliberately NOT enough here: replayed
-// windows are built at 'idle' before their real phase arrives
-// (onSessionStarted during log replay, when update_status_bar is not
-// applied), and waiting_followup normalizes to 'idle' — auto-collapsing
-// either would hide a live window. The bulk pill uses the broader badge
-// predicate above: an explicit click may collapse idle-parked sub-agents
-// too.
+// HARD done-evidence — ended, or phase done/interrupted. Bare 'idle' is
+// deliberately NOT enough: replayed windows are built at 'idle' before
+// their real phase arrives (onSessionStarted during log replay, when
+// update_status_bar is not applied), and waiting_followup normalizes to
+// 'idle' — treating either as done would target a live window. Shared by
+// the sub-agent auto-minimize derivation below and the "Hide done" bulk
+// sweep, which applies it to ANY window (top-level sessions included).
+function sessionWindowHasHardDoneEvidence(sessionId) {
+  const sid = String(sessionId || '').trim();
+  const win = sid ? sessionWindows.get(sid) : null;
+  if (!win) return false;
+  const meta = sessionMetadataById.get(sid) || {};
+  const phase = normalizeSessionPhase(win.phase || meta.phase || '');
+  return !!(win.ended || meta.ended) || phase === 'done' || phase === 'interrupted';
+}
+
+// The AUTO rule demands HARD done-evidence
+// (sessionWindowHasHardDoneEvidence above — never bare 'idle'). The
+// "Minimize done" bulk pill uses the broader badge predicate instead:
+// an explicit click may collapse idle-parked sub-agents too.
 //
 // User intent always wins: a maximized window is never touched, and a
 // window the user explicitly restored while done (userRestoredWhileDone —
@@ -811,11 +823,7 @@ function maybeAutoMinimizeSubagentWindow(sessionId) {
   }
   if (win.minimized || win.userRestoredWhileDone) return;
   if (maximizedSessionWindowId === sid) return;
-  const meta = sessionMetadataById.get(sid) || {};
-  const phase = normalizeSessionPhase(win.phase || meta.phase || '');
-  const hardDone = !!(win.ended || meta.ended)
-    || phase === 'done' || phase === 'interrupted';
-  if (!hardDone) return;
+  if (!sessionWindowHasHardDoneEvidence(sid)) return;
   win.autoMinimized = true;
   setSessionWindowMinimized(sid, true);
 }
@@ -862,6 +870,77 @@ function setAllSessionWindowsMinimized(minimized) {
   }
   return changed;
 }
+
+// Bulk header-details sweep behind the "Expand details / Collapse
+// details" pill (ui2-activity.js owns the button): flips every window's
+// click-to-expand header strip — vitals chips, git indicators, PROJ/CWD
+// paths, goal, tier, relationship strip — in one click. The OTHER axis
+// from its "Collapse all" neighbor: windows stay put, only their header
+// details open or close. Minimized windows are swept too — the class
+// flip is visually inert under .minimized and simply applies when the
+// window is restored (restore re-runs the path labels, and the vitals
+// ticker re-renders chips). Like minimized, headerCollapsed is
+// per-page-load and never persisted. Each per-window set schedules the
+// rAF-deduped relationship render, so a sweep costs one render pass.
+// Returns how many windows changed state.
+function setAllSessionWindowHeadersCollapsed(collapsed) {
+  const target = !!collapsed;
+  let changed = 0;
+  for (const [sid, win] of sessionWindows) {
+    if (!win || !!win.headerCollapsed === target) continue;
+    setSessionWindowHeaderCollapsed(sid, target);
+    changed += 1;
+  }
+  return changed;
+}
+
+// Bulk close behind the "Hide done" pill (ui2-activity.js owns the
+// button + live count): remove every hard-done window's card from this
+// dashboard through the SAME path as the × button's "Hide card" choice
+// (hideSessionWindowAction → removeSessionWindow), so side-relationship
+// cleanup, the sessionWindows map, persistence, and DOM teardown all
+// ride the existing code. Closing a card neither ends nor deletes the
+// session — it stays in the Sessions list, reopenable and replayable.
+// Scope is ANY window with hard done evidence — sub-agent or top-level —
+// and deliberately NOT bare 'idle' (an idle-parked session may still
+// continue; the "Minimize done" pill's broader idle-parked boundary
+// does not apply here). Key snapshot up front: each hide deletes from
+// sessionWindows mid-walk. Returns how many cards it closed.
+function hideDoneSessionWindows() {
+  let changed = 0;
+  for (const sid of [...sessionWindows.keys()]) {
+    if (!sessionWindowHasHardDoneEvidence(sid)) continue;
+    hideSessionWindowAction(sid);
+    changed += 1;
+  }
+  return changed;
+}
+
+// QA facade (window.qa convention): the dashboard validator's grid-pill
+// probe builds throwaway windows and reads per-window sweep state — the
+// bulk sweeps above are otherwise unreachable from the page's global
+// scope (every fragment shares one module scope). build/setMinimized
+// route through the same ensureSessionWindow / setSessionWindowMinimized
+// paths live sessions use; the readbacks are serializable snapshots.
+window.qa = Object.assign(window.qa || {}, {
+  sessionWindowSweeps: {
+    build: (sessionId, meta) => !!ensureSessionWindow(sessionId, meta || {}),
+    setMinimized: (sessionId, minimized) => setSessionWindowMinimized(sessionId, !!minimized),
+    windowIds: () => [...sessionWindows.keys()],
+    windowState: (sessionId) => {
+      const sid = String(sessionId || '').trim();
+      const win = sid ? sessionWindows.get(sid) : null;
+      if (!win) return null;
+      return {
+        minimized: !!win.minimized,
+        headerCollapsed: !!win.headerCollapsed,
+        minimizedClass: win.el.classList.contains('minimized'),
+        headerCollapsedClass: win.el.classList.contains('header-collapsed'),
+        hardDone: sessionWindowHasHardDoneEvidence(sid),
+      };
+    },
+  },
+});
 
 function updateSessionWindowMaximizeState() {
   const grid = document.getElementById('session-window-grid');

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -926,6 +926,7 @@ window.qa = Object.assign(window.qa || {}, {
   sessionWindowSweeps: {
     build: (sessionId, meta) => !!ensureSessionWindow(sessionId, meta || {}),
     setMinimized: (sessionId, minimized) => setSessionWindowMinimized(sessionId, !!minimized),
+    relate: (evt) => applySessionRelationship(evt || {}),
     windowIds: () => [...sessionWindows.keys()],
     windowState: (sessionId) => {
       const sid = String(sessionId || '').trim();

--- a/static/app/ui2-activity.css
+++ b/static/app/ui2-activity.css
@@ -194,8 +194,13 @@ html.ui-v2 #activity-subtabs .ui2-layout-toggle button[aria-pressed="true"] {
   box-shadow: var(--ui2-shadow-seg), inset 0 0 0 1px var(--line);
 }
 
-/* minimize-done: a small amber hygiene pill */
-html.ui-v2 #activity-subtabs .ui2-minimize-done {
+/* minimize-done + hide-done: small amber hygiene pills (minimize drops
+   finished sub-agents to header bars; hide closes every hard-done
+   window's card — the sessions stay in Sessions). hide-done is
+   grid-only like the sweep pills below: Focus hides the cards it acts
+   on. */
+html.ui-v2 #activity-subtabs .ui2-minimize-done,
+html.ui-v2 #activity-subtabs .ui2-hide-done {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -211,9 +216,13 @@ html.ui-v2 #activity-subtabs .ui2-minimize-done {
   cursor: pointer;
   transition: background var(--t-fast);
 }
-html.ui-v2 #activity-subtabs .ui2-minimize-done[hidden] { display: none; }
-html.ui-v2 #activity-subtabs .ui2-minimize-done:hover { background: rgba(var(--amber-rgb), .14); }
-html.ui-v2 #activity-subtabs .ui2-minimize-done-count {
+html.ui-v2 #activity-subtabs .ui2-minimize-done[hidden],
+html.ui-v2 #activity-subtabs .ui2-hide-done[hidden],
+html.ui-v2:not([data-ui2-layout="grid"]) #activity-subtabs .ui2-hide-done { display: none; }
+html.ui-v2 #activity-subtabs .ui2-minimize-done:hover,
+html.ui-v2 #activity-subtabs .ui2-hide-done:hover { background: rgba(var(--amber-rgb), .14); }
+html.ui-v2 #activity-subtabs .ui2-minimize-done-count,
+html.ui-v2 #activity-subtabs .ui2-hide-done-count {
   min-width: 16px; height: 16px;
   display: inline-flex; align-items: center; justify-content: center;
   padding: 0 4px;
@@ -223,11 +232,14 @@ html.ui-v2 #activity-subtabs .ui2-minimize-done-count {
   font-size: 9.5px;
 }
 
-/* collapse/expand-all: the grid sweep twin of the hygiene pill — neutral
-   ink (a layout action, not an attention nudge), and grid-only: Focus
-   hides the session windows the sweep acts on (ui2-activity.js keeps the
-   label naming the direction one click will act) */
-html.ui-v2 #activity-subtabs .ui2-collapse-all {
+/* collapse/expand-all + its header-details twin: the grid sweep pills —
+   neutral ink (layout actions, not attention nudges), and grid-only:
+   Focus hides the session windows the sweeps act on (ui2-activity.js
+   keeps each label naming the direction one click will act).
+   .ui2-collapse-all drives the window axis (minimized);
+   .ui2-header-details drives the header-details axis (headerCollapsed). */
+html.ui-v2 #activity-subtabs .ui2-collapse-all,
+html.ui-v2 #activity-subtabs .ui2-header-details {
   display: inline-flex;
   align-items: center;
   height: 28px;
@@ -242,9 +254,12 @@ html.ui-v2 #activity-subtabs .ui2-collapse-all {
   cursor: pointer;
   transition: background var(--t-fast), color var(--t-fast);
 }
-html.ui-v2 #activity-subtabs .ui2-collapse-all:hover { color: var(--text); background: var(--hover-wash); }
+html.ui-v2 #activity-subtabs .ui2-collapse-all:hover,
+html.ui-v2 #activity-subtabs .ui2-header-details:hover { color: var(--text); background: var(--hover-wash); }
 html.ui-v2 #activity-subtabs .ui2-collapse-all[hidden],
-html.ui-v2:not([data-ui2-layout="grid"]) #activity-subtabs .ui2-collapse-all { display: none; }
+html.ui-v2 #activity-subtabs .ui2-header-details[hidden],
+html.ui-v2:not([data-ui2-layout="grid"]) #activity-subtabs .ui2-collapse-all,
+html.ui-v2:not([data-ui2-layout="grid"]) #activity-subtabs .ui2-header-details { display: none; }
 
 /* Options trigger */
 html.ui-v2 #activity-subtabs .ui2-view-options-btn {

--- a/static/app/ui2-activity.js
+++ b/static/app/ui2-activity.js
@@ -135,9 +135,43 @@ function ui2RefreshMinimizeDoneControl() {
   btn.title = count === 1
     ? 'Minimize the finished sub-agent window'
     : `Minimize all ${count} finished sub-agent windows`;
-  // The collapse-all pill rides the same freshness passes (badge refresh,
-  // relationship render, every minimize state change routes here).
+  // The hide-done, collapse-all, and header-details pills ride the same
+  // freshness passes (badge refresh, relationship render, every minimize
+  // state change routes here).
+  ui2RefreshHideDoneControl();
   ui2RefreshCollapseAllControl();
+  ui2RefreshHeaderDetailsControl();
+}
+
+// ── "Hide done" close sweep pill ───────────────────────────────────────
+// Beside "Minimize done" but the stronger hygiene action: CLOSE every
+// hard-done window's card (41's hideDoneSessionWindows — the same path
+// as the × button's "Hide card" choice), sub-agent or top-level alike.
+// Hard done evidence only (ended / phase done|interrupted — never bare
+// idle), so idle-parked and live windows always survive, and the closed
+// cards' sessions stay in the Sessions list, reopenable and replayable.
+// Hidden while nothing qualifies; grid-only via the stylesheet layout
+// gate like the sweep pills.
+function ui2CountHardDoneWindows() {
+  if (typeof sessionWindows === 'undefined'
+      || typeof sessionWindowHasHardDoneEvidence !== 'function') return 0;
+  let count = 0;
+  for (const sid of sessionWindows.keys()) {
+    if (sessionWindowHasHardDoneEvidence(sid)) count += 1;
+  }
+  return count;
+}
+
+function ui2RefreshHideDoneControl() {
+  const btn = document.getElementById('ui2-hide-done-btn');
+  if (!btn) return;
+  const count = ui2CountHardDoneWindows();
+  const countEl = document.getElementById('ui2-hide-done-count');
+  if (countEl) countEl.textContent = String(count);
+  btn.hidden = count === 0;
+  btn.title = count === 1
+    ? 'Hide the finished session card (its session stays in Sessions)'
+    : `Hide all ${count} finished session cards (their sessions stay in Sessions)`;
 }
 
 // ── "Collapse all / Expand all" grid sweep pill ────────────────────────
@@ -184,6 +218,51 @@ function ui2WireCollapseAllControl() {
   });
 }
 
+// ── "Expand details / Collapse details" header sweep pill ──────────────
+// Beside "Collapse all", driving the OTHER axis: every window's
+// click-to-expand header-details strip (41's
+// setAllSessionWindowHeadersCollapsed) — vitals chips, git indicators,
+// paths, goal, tier, relationships — while the windows themselves stay
+// put. Direction counts NON-minimized windows only (the same visibility
+// boundary the sibling counts with); the sweep still flips minimized
+// windows so a later restore honors the choice. Grid-only via the same
+// stylesheet layout gate as its neighbor.
+function ui2RefreshHeaderDetailsControl() {
+  const btn = document.getElementById('ui2-header-details-btn');
+  if (!btn) return;
+  const windows = typeof sessionWindows !== 'undefined' ? sessionWindows : null;
+  if (!windows || windows.size === 0) {
+    btn.hidden = true;
+    return;
+  }
+  let expanded = 0;
+  for (const win of windows.values()) {
+    if (win && !win.minimized && !win.headerCollapsed) expanded += 1;
+  }
+  const collapse = expanded > 0;
+  btn.hidden = false;
+  btn.dataset.direction = collapse ? 'collapse' : 'expand';
+  btn.textContent = collapse ? 'Collapse details' : 'Expand details';
+  btn.title = collapse
+    ? (expanded === 1
+        ? 'Collapse header details on the expanded session window'
+        : `Collapse header details on all ${expanded} expanded session windows`)
+    : 'Expand header details on every session window';
+  btn.setAttribute('aria-label', btn.title);
+}
+
+function ui2WireHeaderDetailsControl() {
+  const btn = document.getElementById('ui2-header-details-btn');
+  if (!btn) return;
+  btn.addEventListener('click', () => {
+    const collapse = btn.dataset.direction !== 'expand';
+    if (typeof setAllSessionWindowHeadersCollapsed === 'function') {
+      setAllSessionWindowHeadersCollapsed(collapse);
+    }
+    ui2RefreshMinimizeDoneControl();
+  });
+}
+
 let ui2MinimizeDoneRefreshQueued = false;
 function ui2QueueMinimizeDoneRefresh() {
   if (ui2MinimizeDoneRefreshQueued) return;
@@ -202,6 +281,15 @@ function ui2WireMinimizeDoneControl() {
     ui2RefreshMinimizeDoneControl();
   });
   ui2RefreshMinimizeDoneControl();
+}
+
+function ui2WireHideDoneControl() {
+  const btn = document.getElementById('ui2-hide-done-btn');
+  if (!btn) return;
+  btn.addEventListener('click', () => {
+    if (typeof hideDoneSessionWindows === 'function') hideDoneSessionWindows();
+    ui2RefreshMinimizeDoneControl();
+  });
 }
 
 // Composer dressing: placeholder copy + the attach glyph. The send
@@ -685,7 +773,9 @@ function ui2RailTick(force) {
     ui2AugmentApprovalPanel();
     ui2WireLayoutToggle();
     ui2WireMinimizeDoneControl();
+    ui2WireHideDoneControl();
     ui2WireCollapseAllControl();
+    ui2WireHeaderDetailsControl();
     ui2WireViewOptions();
     ui2DressComposer();
     ui2BuildVitalsRail();

--- a/static/app/ui2-grid.css
+++ b/static/app/ui2-grid.css
@@ -20,33 +20,29 @@ html.ui-v2 .session-window-grid {
    the grid claims exactly the share the user dragged, and the concurrent
    view gets the rest.
 
-   grid-auto-rows is the load-bearing declaration. The row-overlap that
-   ledger finding #4 recorded (5-6 windows: row 1's cards painted over
-   row 2 — "320px cards in 298px tracks") is a TRACK-SIZING effect: `auto`
-   rows in a definite-height grid have that height distributed across
-   them, so two rows in a 620px grid size to ~292px each while the cards
-   — which are content-sized, since
-   `.session-window:not(.header-collapsed):not(.minimized)` clears the
-   320px cap — stay ~320px and spill out of their track onto the next row.
-   Pinning the rows to max-content takes the container height out of track
-   sizing entirely: every row is exactly as tall as its cards, the surplus
-   becomes scrollable overflow, and rows can never collide.
-   (align-content does NOT help here — it distributes leftover space after
-   tracks are sized, so it never sees the compression. Measured.)
+   The row-overlap cure that used to live here (grid-auto-rows:
+   max-content + align-content: start) moved to the BASE
+   .session-window-grid rule in 12-styles-tasks-log.css: the ledger
+   finding #4 track-sizing artifact — `auto` rows in a definite-height
+   grid compress below their content-sized cards, which then paint over
+   the next row ("320px cards in 298px tracks") — was not specific to
+   .resized. Any clamped height reproduces it (the base 42vh max-height,
+   the flexed concurrent-log-minimized state, transient non-.resized
+   frames), so the pin is now universal and this rule keeps only the
+   definite-height + overflow mechanics.
 
-   The earlier fix — height:auto + the dragged size as a max-height cap —
-   did dodge the overlap, but only by making the height indefinite, which
-   silently removed drag-to-grow: an auto-height grid can never exceed its
-   content, so dragging the handle down just moved a cap nothing was
-   pressing against, and in fit mode (where the cap IS the content height)
-   the drag was a pure no-op. It also outranked v1's `.maximized` and
-   `.concurrent-log-minimized` geometry, so neither state could resize the
-   grid — hence the :not() scoping here. */
+   History, still binding: the earlier fix — height:auto + the dragged
+   size as a max-height cap — did dodge the overlap, but only by making
+   the height indefinite, which silently removed drag-to-grow: an
+   auto-height grid can never exceed its content, so dragging the handle
+   down just moved a cap nothing was pressing against, and in fit mode
+   (where the cap IS the content height) the drag was a pure no-op. It
+   also outranked v1's `.maximized` and `.concurrent-log-minimized`
+   geometry, so neither state could resize the grid — hence the :not()
+   scoping here. */
 html.ui-v2 .subtab-pane:not(.concurrent-log-minimized) .session-window-grid.resized:not(.maximized) {
   height: var(--session-window-grid-height);
   max-height: none;
-  grid-auto-rows: max-content;
-  align-content: start;
   overflow-y: auto;
   overflow-x: hidden;
 }


### PR DESCRIPTION
Three user-ratified Activity-grid improvements — fragments + regenerated app.html only (no Rust changes).

## Item 1 — Expand/Collapse details pill
One control that expands or collapses every session window's header-details strip (model/effort/permission chips, git indicators, PROJ/CWD paths, goal, tier, relationship strip) — the `headerCollapsed` axis. Complements the existing window-level Collapse all pill (`minimized` axis, unchanged).

- Direction derives from non-minimized windows with expanded details (sibling idiom); label pair Expand details / Collapse details.
- Sweep includes minimized windows: the class flip is inert under `.minimized` and applies on restore.
- The one-shot late-sub-agent re-collapse is deliberately not fought (manual-sweep semantics precedent).
- Per-page-load state (same contract as `minimized`); grid-only via the sibling CSS gate.

## Item 2 — Hide done pill
Closes (removes from the grid) every hard-done window's card, sub-agent or top-level. Complements — does not replace — Minimize done.

- Predicate = hard done evidence only (`ended` or phase `done`/`interrupted`; never bare `idle` — idle-parked sessions may continue), extracted into `sessionWindowHasHardDoneEvidence` and shared with the auto-minimize derivation.
- Action reuses the x button's Hide card path (`hideSessionWindowAction` → `removeSessionWindow`) verbatim per window, so persistence, the window map, relationship state, and DOM cleanup ride existing code. **Closing a card neither ends nor deletes the session — it stays in the Sessions list, reopenable and replayable.**
- Live count chip in the Minimize done idiom; hidden at zero; grid-only.

## Item 3 — universal anti-overlap + minimized dock band (CSS-only)
- The `grid-auto-rows: max-content; align-content: start` cure for the ledger-finding-#4 track-compression overlap (auto rows in a clamped grid compress below their content-sized cards, which then paint over the next row — the minimized-bar-over-neighbor screenshot) moves from the `.resized`-scoped ui2 rule to the base `.session-window-grid` rule, covering every non-maximized state (default 42vh clamp, transient non-`.resized`, concurrent-log-minimized). `.maximized` flex mode untouched; no z-index changes.
- `.session-window.minimized { order: 9 }` — minimized bars flow to the end of the grid and pack into dense 36px rows below active cards, taskbar-style. Visual order only: DOM order untouched (Focus gating, activate scrollIntoView, wires, persistence unaffected). Gentle opacity-only dock-in animation, motion-pref gated; no FLIP/measure/observers.

Both pills refresh in the existing `ui2RefreshMinimizeDoneControl` chain (badge refresh + rAF-deduped relationship render), and a `window.qa.sessionWindowSweeps` facade exposes synthetic-window build + state readback for the dashboard validator probe.