### PR TITLE
fix(sessions): persist attachment refs on native user rows (external parity)

### DIFF
--- a/src/bin/caller/agent_loop.rs
+++ b/src/bin/caller/agent_loop.rs
@@ -1350,8 +1350,11 @@ pub(crate) async fn run_agent_loop(
                 // not. The record carries the raw steer text, not the
                 // `[User]`-prefixed conversation string.
                 if provenance == MessageProvenance::Steer {
+                    // Injection-lane steers carry raw images only
+                    // (`ContextInjection` mints no upload refs), so there
+                    // are no renderable refs to persist here.
                     slog(&session_log, |l| {
-                        let _ = l.conversation_message_user(seq, provenance, &inj.text, None);
+                        let _ = l.conversation_message_user(seq, provenance, &inj.text, None, &[]);
                     });
                 }
                 slog(&session_log, |l| {
@@ -2366,6 +2369,7 @@ pub(crate) async fn run_agent_loop(
                                 MessageProvenance::AskHumanAnswer,
                                 &reply,
                                 Some(seq),
+                                &[],
                             );
                         });
                     }
@@ -2951,6 +2955,7 @@ Proceed with explicit assumptions and continue without additional questions."
                             MessageProvenance::AskHumanAnswer,
                             &answer,
                             None,
+                            &[],
                         );
                     });
                 }
@@ -3778,12 +3783,16 @@ pub(crate) async fn run_round_loop(
                         followup_images,
                     )
                 };
+                // The canonical record carries the renderable upload refs
+                // delivered with this message (external-lane parity: the
+                // `[user]` rows persist the same array via `user_message`).
                 slog(&session_log, |l| {
                     let _ = l.conversation_message_user(
                         followup_seq,
                         followup_provenance,
                         &message.text,
                         None,
+                        &message.attachments.refs,
                     );
                 });
                 if let Some(id) = message.steer_id {

--- a/src/bin/caller/run_modes.rs
+++ b/src/bin/caller/run_modes.rs
@@ -3250,12 +3250,15 @@ pub(crate) async fn run_with_presence(
                         combined_images,
                     )
                 };
+                // Presence-lane attachments are frame-registry grabs, which
+                // mint no upload refs — nothing renderable to persist.
                 slog(&session_log, |l| {
                     let _ = l.conversation_message_user(
                         task_seq,
                         MessageProvenance::Task,
                         &task_text,
                         None,
+                        &[],
                     );
                 });
 
@@ -3298,6 +3301,7 @@ pub(crate) async fn run_with_presence(
                         MessageProvenance::FollowUp,
                         &task_text,
                         None,
+                        &[],
                     );
                 });
             }
@@ -3528,12 +3532,17 @@ pub(crate) async fn run_direct_mode(
                         attachment_images.clone(),
                     )
                 };
+                // Same dispatch as the fresh-task sites below: the refs for
+                // the delivered attachments ride the canonical record
+                // (external-lane parity — the resumed images entered the
+                // conversation above).
                 slog(&session_log, |l| {
                     let _ = l.conversation_message_user(
                         resume_seq,
                         MessageProvenance::ResumeTask,
                         &task,
                         None,
+                        &attachments.refs,
                     );
                 });
                 conv
@@ -3566,8 +3575,13 @@ pub(crate) async fn run_direct_mode(
                     attachment_images.clone(),
                 );
                 slog(&session_log, |l| {
-                    let _ =
-                        l.conversation_message_user(task_seq, MessageProvenance::Task, &task, None);
+                    let _ = l.conversation_message_user(
+                        task_seq,
+                        MessageProvenance::Task,
+                        &task,
+                        None,
+                        &attachments.refs,
+                    );
                 });
                 conv
             }
@@ -3580,8 +3594,16 @@ pub(crate) async fn run_direct_mode(
             &attachments.text_with_file_prelude(&task),
             attachment_images.clone(),
         );
+        // The canonical record carries the renderable upload refs delivered
+        // with the task (external-lane parity with the `[user]` rows).
         slog(&session_log, |l| {
-            let _ = l.conversation_message_user(task_seq, MessageProvenance::Task, &task, None);
+            let _ = l.conversation_message_user(
+                task_seq,
+                MessageProvenance::Task,
+                &task,
+                None,
+                &attachments.refs,
+            );
         });
         conv
     };

--- a/src/bin/caller/session_log/bus_events.rs
+++ b/src/bin/caller/session_log/bus_events.rs
@@ -1595,13 +1595,18 @@ impl SessionLog {
     /// the conversation's concern, not the record's. `ref_seq` marks a
     /// projection: the text entered the conversation inside another entry
     /// (the native-tool askHuman answer rides a tool result) whose seq it
-    /// references for rewind-cut semantics.
+    /// references for rewind-cut semantics. `attachments` carries the
+    /// renderable upload-store refs delivered WITH this message (native
+    /// parity with the external lane's `[user]` rows — same array shape as
+    /// `user_message`); the field is omitted when empty, so rows without
+    /// attachments keep the exact pre-field line shape.
     pub fn conversation_message_user(
         &mut self,
         seq: u64,
         provenance: crate::conversation::MessageProvenance,
         text: &str,
         ref_seq: Option<u64>,
+        attachments: &[crate::types::SessionNoteAttachment],
     ) -> String {
         let message_id = Uuid::new_v4().to_string();
         let mut data = serde_json::json!({
@@ -1613,6 +1618,11 @@ impl SessionLog {
         });
         if let Some(ref_seq) = ref_seq {
             data["ref_seq"] = serde_json::Value::from(ref_seq);
+        }
+        if !attachments.is_empty() {
+            if let Ok(refs) = serde_json::to_value(attachments) {
+                data["attachments"] = refs;
+            }
         }
         let preview: String = text.chars().take(200).collect();
         self.emit(LogEvent {

--- a/src/bin/caller/session_log/mod.rs
+++ b/src/bin/caller/session_log/mod.rs
@@ -2118,6 +2118,7 @@ mod tests {
             crate::conversation::MessageProvenance::AskHumanAnswer,
             "the raw answer",
             Some(6),
+            &[],
         );
         drop(log);
         let event = read_last_event(dir.path(), "conversation_message");
@@ -2131,6 +2132,58 @@ mod tests {
         assert_eq!(event["data"]["text"].as_str(), Some("the raw answer"));
         assert_eq!(event["data"]["ref_seq"].as_u64(), Some(6));
         assert!(event["ts_ms"].as_i64().is_some());
+        // BACKWARD COMPAT: an attachment-less record keeps the exact
+        // pre-field data shape — no `attachments` key at all, so the
+        // emitted line is byte-shaped like every legacy row.
+        assert!(event["data"].get("attachments").is_none());
+        let keys: Vec<&str> = event["data"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        let mut expected = vec![
+            "message_id",
+            "message_seq",
+            "provenance",
+            "ref_seq",
+            "role",
+            "text",
+        ];
+        expected.sort_unstable();
+        let mut got = keys.clone();
+        got.sort_unstable();
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn conversation_message_user_persists_attachment_refs() {
+        // Native parity with the external lane's `[user]` rows: the
+        // canonical user record carries the renderable upload refs in
+        // `data.attachments`, in the same array shape `user_message`
+        // persists (SessionNoteAttachment).
+        let dir = tempfile::tempdir().unwrap();
+        let mut log = SessionLog::open(dir.path().to_path_buf()).unwrap();
+        let refs = vec![crate::types::SessionNoteAttachment {
+            upload_id: "u-1".to_string(),
+            name: "shot.png".to_string(),
+            mime: "image/png".to_string(),
+            url: "/api/session/current/uploads/u-1/raw".to_string(),
+        }];
+        log.conversation_message_user(
+            4,
+            crate::conversation::MessageProvenance::FollowUp,
+            "see the screenshot",
+            None,
+            &refs,
+        );
+        drop(log);
+        let event = read_last_event(dir.path(), "conversation_message");
+        assert_eq!(event["data"]["role"].as_str(), Some("user"));
+        assert_eq!(event["data"]["text"].as_str(), Some("see the screenshot"));
+        let replayed: Vec<crate::types::SessionNoteAttachment> =
+            serde_json::from_value(event["data"]["attachments"].clone()).unwrap();
+        assert_eq!(replayed, refs);
     }
 
     #[test]

--- a/src/bin/caller/session_log/replay.rs
+++ b/src/bin/caller/session_log/replay.rs
@@ -1260,6 +1260,53 @@ pub fn session_log_entry_to_app_event(
             })
         }
 
+        // ── Canonical message-lane records (native sessions) ──
+        //
+        // `conversation_message` rows normally render no timeline entry of
+        // their own — their diagnostic twins (the `Round N follow-up:` info
+        // rows, `model_response`) already carry the text, so replaying the
+        // canonical record too would double-serve every message. The ONE
+        // exception is a user row carrying renderable attachment refs
+        // (native parity with the external lane's `[user]` rows): the refs
+        // exist nowhere else in the log, so replay serves that row as
+        // `UserMessageLog` — the exact wire shape the external lane's user
+        // rows use — and the dashboard renders the same thumbnail strip
+        // (`turn: None` and untagged turn metadata, like the live lane's
+        // native rows). Legacy rows (no `attachments` field) keep replaying
+        // to nothing, byte-identical to before.
+        "conversation_message" => {
+            if data.and_then(|d| d.get("role")).and_then(|v| v.as_str()) != Some("user") {
+                return None;
+            }
+            let attachments = data
+                .and_then(|d| d.get("attachments"))
+                .and_then(|value| {
+                    serde_json::from_value::<Vec<crate::types::SessionNoteAttachment>>(
+                        value.clone(),
+                    )
+                    .ok()
+                })
+                .unwrap_or_default();
+            if attachments.is_empty() {
+                return None;
+            }
+            // `data.text` is the full raw user text; `message` is only a
+            // 200-char preview of it.
+            let content = data
+                .and_then(|d| d.get("text"))
+                .and_then(|v| v.as_str())
+                .unwrap_or(message)
+                .to_string();
+            Some(AppEvent::UserMessageLog {
+                session_id: None,
+                content,
+                user_turn_index: None,
+                user_turn_revision: None,
+                replacement_for_user_turn_index: None,
+                attachments,
+            })
+        }
+
         // ── Info / warn / error / debug → LogEntry ──
         //
         // Source and level are derived from message prefixes to match what
@@ -1652,6 +1699,125 @@ mod tests {
                 other => panic!("expected untagged LogEntry, got {:?}", other),
             }
         }
+    }
+
+    #[test]
+    fn rt_conversation_message_user_row_with_attachments_replays_as_user_message_log() {
+        // Native parity with the external lane's `[user]` rows: a canonical
+        // user record carrying renderable upload refs replays as
+        // `UserMessageLog`, the same wire shape (log_entry, source User)
+        // the external lane serves — so the dashboard renders the same
+        // thumbnail strip on native user rows.
+        let dir = tempfile::tempdir().unwrap();
+        let log_dir = dir.path().join("session");
+        let mut log = SessionLog::open(log_dir.clone()).unwrap();
+        let refs = vec![crate::types::SessionNoteAttachment {
+            upload_id: "u-7".to_string(),
+            name: "grab.png".to_string(),
+            mime: "image/png".to_string(),
+            url: "/api/session/current/uploads/u-7/raw".to_string(),
+        }];
+        log.conversation_message_user(
+            9,
+            crate::conversation::MessageProvenance::FollowUp,
+            "look at the attached screenshot",
+            None,
+            &refs,
+        );
+        drop(log);
+
+        let entry = read_last_event(&log_dir, "conversation_message");
+        match session_log_entry_to_app_event(&entry, &log_dir).unwrap() {
+            AppEvent::UserMessageLog {
+                session_id,
+                content,
+                user_turn_index,
+                user_turn_revision,
+                replacement_for_user_turn_index,
+                attachments,
+            } => {
+                // Session id is stamped later by the replay-metadata
+                // injector, exactly like the external `[user]` rows.
+                assert_eq!(session_id, None);
+                assert_eq!(content, "look at the attached screenshot");
+                // Native rows carry no wrapper turn metadata.
+                assert_eq!(user_turn_index, None);
+                assert_eq!(user_turn_revision, None);
+                assert_eq!(replacement_for_user_turn_index, None);
+                assert_eq!(attachments, refs);
+            }
+            other => panic!("expected UserMessageLog, got {:?}", other),
+        }
+
+        // The served wire row matches the external lane's user rows:
+        // log_entry with source User, no turn, attachments carried.
+        let outbound = crate::event::app_event_to_outbound(
+            &session_log_entry_to_app_event(&entry, &log_dir).unwrap(),
+        )
+        .unwrap();
+        let json = serde_json::to_value(&outbound).unwrap();
+        assert_eq!(
+            json.get("event").and_then(|v| v.as_str()),
+            Some("log_entry")
+        );
+        assert_eq!(json.get("source").and_then(|v| v.as_str()), Some("User"));
+        assert_eq!(json.get("turn"), None);
+        assert_eq!(
+            json.pointer("/attachments/0/upload_id")
+                .and_then(|v| v.as_str()),
+            Some("u-7")
+        );
+        assert_eq!(
+            json.pointer("/attachments/0/url").and_then(|v| v.as_str()),
+            Some("/api/session/current/uploads/u-7/raw")
+        );
+    }
+
+    #[test]
+    fn rt_conversation_message_rows_without_attachments_replay_to_nothing_like_legacy() {
+        // BACKWARD COMPAT: canonical records without attachment refs keep
+        // replaying to NO served entry at all — their diagnostic twins
+        // carry the text — so legacy logs (and every attachment-less row a
+        // new binary writes) replay byte-identically to before the field
+        // existed. Assistant records never convert, attachments or not.
+        let dir = tempfile::tempdir().unwrap();
+        let log_dir = dir.path().join("session");
+        let mut log = SessionLog::open(log_dir.clone()).unwrap();
+        log.conversation_message_user(
+            2,
+            crate::conversation::MessageProvenance::Task,
+            "plain task",
+            None,
+            &[],
+        );
+        log.model_response_with_message(3, "assistant reply", 10, 5, 15, 0, 0);
+        drop(log);
+
+        let rows = read_events(&log_dir, "conversation_message");
+        assert_eq!(rows.len(), 2);
+        for row in &rows {
+            assert!(
+                session_log_entry_to_app_event(row, &log_dir).is_none(),
+                "attachment-less conversation_message must not serve an entry: {row}"
+            );
+        }
+
+        // A hand-written legacy line (pre-field binaries) — same verdict.
+        let legacy: serde_json::Value = serde_json::json!({
+            "ts": "10:00:00.000",
+            "ts_ms": 1_752_000_000_000_i64,
+            "event": "conversation_message",
+            "level": "info",
+            "message": "old prompt",
+            "data": {
+                "message_id": "m-1",
+                "message_seq": 1,
+                "role": "user",
+                "provenance": "task",
+                "text": "old prompt",
+            },
+        });
+        assert!(session_log_entry_to_app_event(&legacy, &log_dir).is_none());
     }
 
     /// A failed clear is terminal steer state: without a structured event +


### PR DESCRIPTION
## Problem

Post-#472, EXTERNAL sessions (Claude Code + Codex) persist user-message attachment refs into the session log and live events via `emit_user_message_log` (the canonical `[user]` rows carry `data.attachments`). NATIVE sessions dropped the refs at persistence: the native loop and the initial-task sites persist user rows via `conversation_message_user`, which had no attachments field. The model still received the images — only the persisted record and the replayed timeline lost them.

## Fix (ratified: "same behavior for codex and internal")

1. **Persist**: `conversation_message_user` gains an additive `attachments` parameter (same `SessionNoteAttachment` array shape as the external `[user]` rows' `data.attachments`), omitted when empty — attachment-less rows keep the exact legacy line shape, pinned by test. Refs are passed at the native follow-up site (`agent_loop.rs`) and all three `run_direct_mode` task sites in `run_modes.rs` (fresh, fresh-after-load-error, and the resume-task row — the same dispatch with the same `UserAttachments.refs`, whose images enter the conversation identically). The injection-steer, askHuman-answer, and presence-frame sites mint no upload refs and pass none.
2. **Serve on replay**: `session_log_entry_to_app_event` gains a `conversation_message` arm that serves user records carrying attachments as `AppEvent::UserMessageLog` — the external lane's exact wire shape (`log_entry`, source `User`, `attachments`) — so both the session-window hydration lane and the rehydration lane carry the refs. Records without attachments (all legacy rows and every attachment-less row a new binary writes) keep replaying to nothing — their diagnostic twins carry the text — byte-identical to today, pinned by test.
3. **Frontend**: no fragment change needed. The post-#472 canonical-row preview path (`sessionWindowRecordFromReplayEntry` → `userLogAttachmentPreviews` → `appendLogAttachmentStrip`) is shape-generic over `log_entry` rows with `attachments`; native rows served in the same wire shape render through the identical code path (verified via the dashboard boot probe: native-shaped and external-shaped rows render identical thumbnail strips).

## Out of scope (deliberate)

- The legacy non-supervised `follow_up_tx` fallback persisting empty refs.
- Dashboard-captured FRAMES minting no refs (separate frame registry — deliberate design; presence-lane task sites therefore pass no refs).
- Live-lane bus emission for native user rows (the ratified fix covers persistence + replay + rendering; the live composer echo already covers the sending browser).

## Tests

- Writer round-trip: with attachments (refs serialized), without (no `attachments` key; `data` key set pinned to the legacy set).
- Replay: attachment-carrying user record → `UserMessageLog` + outbound wire shape (`log_entry`/`User`/`attachments`); attachment-less records (writer-emitted + hand-written legacy line) and assistant records → no served entry.