### PR TITLE
dashboard: consolidate Timeline bulk sweeps into one Arrange menu

### DIFF
--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -165,8 +165,8 @@ JSON-serializable snapshot. Current probes: `qa.sessionsHydration()`
 `qa.sessionsFuel()` (new-session credential preflight,
 `55b-session-launch.js`), `qa.newSessionAgentPrefs()` (last-used
 launch-option prefill state, same fragment), `qa.focusSurface()` (Activity
-Focus target/promotion state), `qa.minimizeDone()` (sub-agent auto-minimize
-and bulk-control state), and `qa.station()` — a pointer to
+Focus target/promotion state), `qa.arrangeMenu()` (the Arrange menu's
+bulk-sweep rows, counts, and sub-agent auto-minimize state), and `qa.station()` — a pointer to
 `window.stationProbe`, which predates the namespace and keeps its legacy name
 (the validator's `--station-*` probes and smoke skills depend on it).
 `window.__intendantPaneDiag` above is the other legacy surface.

--- a/static/app/20-shell.html
+++ b/static/app/20-shell.html
@@ -120,9 +120,10 @@
     <div id="tab-activity" class="tab-pane active">
       <!-- Activity v3 view header: the five views as one segmented switch
            on the left; the Log view's tools on the right (session switcher,
-           Focus/Grid, minimize-done, and the Options popover holding
-           verbosity + host filter). The tools are CSS-gated to the log
-           sub-tab (#activity-subtabs:has([data-activity-tab="log"].active))
+           Focus/Grid, the Arrange menu holding the bulk window sweeps, and
+           the Options popover holding verbosity + host filter). The tools
+           are CSS-gated to the log sub-tab
+           (#activity-subtabs:has([data-activity-tab="log"].active))
            — every element keeps its id, so ui2-chrome.js / ui2-activity.js
            wiring is untouched by the move out of the oversight bar. -->
       <div class="subtabs" id="activity-subtabs">
@@ -142,23 +143,55 @@
             <button type="button" id="ui2-layout-grid-btn" data-layout="grid"
                     title="Grid — session windows with the concurrent stream below">Grid</button>
           </div>
-          <button type="button" class="ui2-minimize-done" id="ui2-minimize-done-btn" hidden
-                  title="Minimize every finished sub-agent window">
-            Minimize done<span class="ui2-minimize-done-count" id="ui2-minimize-done-count">0</span>
+          <!-- One compact menu button consolidating the bulk window sweeps
+               (it replaced five standalone pills: Minimize done, Hide done,
+               Collapse all/Expand all, Expand/Collapse details).
+               ui2-activity.js unhides it while session windows exist and
+               derives every menu row in one pass (ui2RefreshArrangeMenu). -->
+          <button type="button" class="ui2-arrange-btn" id="ui2-arrange-btn" hidden
+                  aria-haspopup="true" aria-expanded="false"
+                  title="Arrange session windows — bulk expand, collapse, and cleanup sweeps">
+            Arrange<svg viewBox="0 0 24 24" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>
           </button>
-          <button type="button" class="ui2-hide-done" id="ui2-hide-done-btn" hidden
-                  title="Hide every finished session card (sessions stay in Sessions)">
-            Hide done<span class="ui2-hide-done-count" id="ui2-hide-done-count">0</span>
-          </button>
-          <button type="button" class="ui2-collapse-all" id="ui2-collapse-all-btn" hidden
-                  title="Minimize every session window to its header bar">Collapse all</button>
-          <button type="button" class="ui2-header-details" id="ui2-header-details-btn" hidden
-                  title="Expand header details on every session window">Expand details</button>
           <!-- vertical sliders, NOT the Control tab's horizontal pair —
                two adjacent controls must not share a glyph -->
           <button type="button" class="ui2-view-options-btn" id="ui2-view-options-btn"
                   aria-haspopup="true" aria-expanded="false" title="Timeline display options">
             <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 4v6"/><path d="M6 14v6"/><circle cx="6" cy="12" r="2"/><path d="M12 4v2"/><path d="M12 10v10"/><circle cx="12" cy="8" r="2"/><path d="M18 4v8"/><path d="M18 16v4"/><circle cx="18" cy="14" r="2"/></svg>Options
+          </button>
+        </div>
+        <!-- The Arrange menu panel: the bulk session-window sweeps as menu
+             rows, every action reusing 41-session-window-actions.js's sweep
+             functions verbatim. Same popover mechanics as the Options panel
+             below (position:fixed stamped from the trigger; .open toggled by
+             ui2WireArrangeMenu), but the display gate lives in the
+             stylesheet: the menu can only render under grid layout with the
+             log sub-tab active — the same conditions its trigger lives
+             under — so a stale .open can never surface it elsewhere. -->
+        <div class="ui2-arrange-menu" id="ui2-arrange-menu" role="group" aria-label="Arrange session windows">
+          <button type="button" class="ui2-arrange-item" id="ui2-arrange-expand-all" data-arrange-action="expand-all"
+                  title="Restore every minimized session window">
+            <span class="ui2-arrange-item-label">Expand all windows</span><span class="ui2-arrange-count" hidden>0</span>
+          </button>
+          <button type="button" class="ui2-arrange-item" id="ui2-arrange-collapse-all" data-arrange-action="collapse-all"
+                  title="Minimize every session window to its header bar">
+            <span class="ui2-arrange-item-label">Collapse all windows</span><span class="ui2-arrange-count" hidden>0</span>
+          </button>
+          <button type="button" class="ui2-arrange-item" id="ui2-arrange-collapse-subs" data-arrange-action="collapse-subs" hidden
+                  title="Minimize every sub-agent window — working or finished — leaving top-level sessions in place">
+            <span class="ui2-arrange-item-label">Collapse sub-agents</span><span class="ui2-arrange-count" hidden>0</span>
+          </button>
+          <button type="button" class="ui2-arrange-item" id="ui2-arrange-minimize-done" data-arrange-action="minimize-done" hidden
+                  title="Minimize every finished sub-agent window">
+            <span class="ui2-arrange-item-label">Minimize finished sub-agents</span><span class="ui2-arrange-count" hidden>0</span>
+          </button>
+          <button type="button" class="ui2-arrange-item" id="ui2-arrange-hide-done" data-arrange-action="hide-done" hidden
+                  title="Hide every finished session card (their sessions stay in Sessions)">
+            <span class="ui2-arrange-item-label">Hide finished</span><span class="ui2-arrange-count" hidden>0</span>
+          </button>
+          <button type="button" class="ui2-arrange-item" id="ui2-arrange-details" data-arrange-action="details" data-direction="expand"
+                  title="Expand header details on every session window">
+            <span class="ui2-arrange-item-label">Expand all details</span>
           </button>
         </div>
         <!-- The Options popover panel: still #activity-log-controls, still

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -871,6 +871,31 @@ function setAllSessionWindowsMinimized(minimized) {
   return changed;
 }
 
+// Bulk sweep behind the Arrange menu's "Collapse sub-agents" row
+// (ui2-activity.js owns the menu): minimize EVERY sub-agent window —
+// working or finished alike (predicate: sessionWindowIsSubagent, the
+// same relationship boundary the badges and the done-sub sweeps share) —
+// leaving top-level windows untouched. The middle ground between
+// "Collapse all" (everything) and "Minimize done" (finished subs only):
+// a parent fanning out work keeps its own transcript on screen while the
+// whole fan-out drops to header bars. Manual-sweep semantics exactly
+// like setAllSessionWindowsMinimized's collapse direction: autoMinimized
+// stays false so the done→active crossing never pops open a window the
+// user swept closed, and userRestoredWhileDone re-arms false. Returns
+// how many windows changed state.
+function minimizeSubagentWindows() {
+  let changed = 0;
+  for (const [sid, win] of sessionWindows) {
+    if (!win || win.minimized) continue;
+    if (!sessionWindowIsSubagent(sid)) continue;
+    win.autoMinimized = false;
+    win.userRestoredWhileDone = false;
+    setSessionWindowMinimized(sid, true);
+    changed += 1;
+  }
+  return changed;
+}
+
 // Bulk header-details sweep behind the "Expand details / Collapse
 // details" pill (ui2-activity.js owns the button): flips every window's
 // click-to-expand header strip — vitals chips, git indicators, PROJ/CWD

--- a/static/app/ui2-activity.css
+++ b/static/app/ui2-activity.css
@@ -194,54 +194,16 @@ html.ui-v2 #activity-subtabs .ui2-layout-toggle button[aria-pressed="true"] {
   box-shadow: var(--ui2-shadow-seg), inset 0 0 0 1px var(--line);
 }
 
-/* minimize-done + hide-done: small amber hygiene pills (minimize drops
-   finished sub-agents to header bars; hide closes every hard-done
-   window's card — the sessions stay in Sessions). hide-done is
-   grid-only like the sweep pills below: Focus hides the cards it acts
-   on. */
-html.ui-v2 #activity-subtabs .ui2-minimize-done,
-html.ui-v2 #activity-subtabs .ui2-hide-done {
+/* Arrange ▾ — ONE compact menu trigger consolidating every bulk
+   session-window sweep (it replaced five standalone pills: minimize
+   done, hide done, collapse/expand all, expand/collapse details).
+   Sibling styling to Focus/Grid/Options, and grid-only like the pills
+   it replaced — Focus hides the session windows the sweeps act on —
+   plus hidden by ui2-activity.js while no session window exists. */
+html.ui-v2 #activity-subtabs .ui2-arrange-btn {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  height: 28px;
-  padding: 0 10px;
-  border: 1px solid rgba(var(--amber-rgb), .3);
-  border-radius: 9px;
-  background: rgba(var(--amber-rgb), .08);
-  color: var(--amber);
-  font-family: inherit;
-  font-size: 11px;
-  font-weight: 700;
-  cursor: pointer;
-  transition: background var(--t-fast);
-}
-html.ui-v2 #activity-subtabs .ui2-minimize-done[hidden],
-html.ui-v2 #activity-subtabs .ui2-hide-done[hidden],
-html.ui-v2:not([data-ui2-layout="grid"]) #activity-subtabs .ui2-hide-done { display: none; }
-html.ui-v2 #activity-subtabs .ui2-minimize-done:hover,
-html.ui-v2 #activity-subtabs .ui2-hide-done:hover { background: rgba(var(--amber-rgb), .14); }
-html.ui-v2 #activity-subtabs .ui2-minimize-done-count,
-html.ui-v2 #activity-subtabs .ui2-hide-done-count {
-  min-width: 16px; height: 16px;
-  display: inline-flex; align-items: center; justify-content: center;
-  padding: 0 4px;
-  border-radius: var(--r-pill);
-  background: rgba(var(--amber-rgb), .2);
-  font-family: var(--mono);
-  font-size: 9.5px;
-}
-
-/* collapse/expand-all + its header-details twin: the grid sweep pills —
-   neutral ink (layout actions, not attention nudges), and grid-only:
-   Focus hides the session windows the sweeps act on (ui2-activity.js
-   keeps each label naming the direction one click will act).
-   .ui2-collapse-all drives the window axis (minimized);
-   .ui2-header-details drives the header-details axis (headerCollapsed). */
-html.ui-v2 #activity-subtabs .ui2-collapse-all,
-html.ui-v2 #activity-subtabs .ui2-header-details {
-  display: inline-flex;
-  align-items: center;
+  gap: 5px;
   height: 28px;
   padding: 0 10px;
   border: 1px solid var(--line);
@@ -250,16 +212,81 @@ html.ui-v2 #activity-subtabs .ui2-header-details {
   color: var(--text-3);
   font-family: inherit;
   font-size: 11px;
-  font-weight: 700;
+  font-weight: 650;
   cursor: pointer;
-  transition: background var(--t-fast), color var(--t-fast);
+  transition: color var(--t-fast), background var(--t-fast), border-color var(--t-fast);
 }
-html.ui-v2 #activity-subtabs .ui2-collapse-all:hover,
-html.ui-v2 #activity-subtabs .ui2-header-details:hover { color: var(--text); background: var(--hover-wash); }
-html.ui-v2 #activity-subtabs .ui2-collapse-all[hidden],
-html.ui-v2 #activity-subtabs .ui2-header-details[hidden],
-html.ui-v2:not([data-ui2-layout="grid"]) #activity-subtabs .ui2-collapse-all,
-html.ui-v2:not([data-ui2-layout="grid"]) #activity-subtabs .ui2-header-details { display: none; }
+html.ui-v2 #activity-subtabs .ui2-arrange-btn svg {
+  width: 12px; height: 12px;
+  fill: none; stroke: currentColor; stroke-width: 2;
+  stroke-linecap: round; stroke-linejoin: round;
+  transition: transform var(--t-fast);
+}
+html.ui-v2 #activity-subtabs .ui2-arrange-btn:hover { color: var(--text); background: var(--hover-wash); }
+html.ui-v2 #activity-subtabs .ui2-arrange-btn[aria-expanded="true"] {
+  color: var(--text);
+  background: var(--surface-2);
+  border-color: var(--line-2);
+}
+html.ui-v2 #activity-subtabs .ui2-arrange-btn[aria-expanded="true"] svg { transform: rotate(180deg); }
+html.ui-v2 #activity-subtabs .ui2-arrange-btn[hidden],
+html.ui-v2:not([data-ui2-layout="grid"]) #activity-subtabs .ui2-arrange-btn { display: none; }
+
+/* The Arrange menu popover: same mechanics as the Options popover below
+   (display:none base, .open shows, position:fixed against the subtab
+   row's overflow-x clipping, JS stamps top/right from the trigger). The
+   display gate carries the trigger's own conditions — grid layout AND
+   the log sub-tab active — so a stale .open can never surface the menu
+   in Focus or on another sub-tab. */
+html.ui-v2 #ui2-arrange-menu { display: none; }
+html.ui-v2[data-ui2-layout="grid"] #activity-subtabs:has(.subtab-btn[data-activity-tab="log"].active) #ui2-arrange-menu.open {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 2px;
+  position: fixed;
+  z-index: 80;
+  min-width: 232px;
+  margin: 0;
+  padding: 6px;
+  border: 1px solid var(--line-2);
+  border-radius: 12px;
+  background: var(--surface);
+  box-shadow: var(--shadow-menu);
+}
+html.ui-v2 #ui2-arrange-menu .ui2-arrange-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  height: 30px;
+  padding: 0 9px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-2);
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 550;
+  text-align: left;
+  cursor: pointer;
+  transition: color var(--t-fast), background var(--t-fast);
+}
+html.ui-v2 #ui2-arrange-menu .ui2-arrange-item:hover:not([disabled]) { color: var(--text); background: var(--hover-wash); }
+html.ui-v2 #ui2-arrange-menu .ui2-arrange-item[disabled] { color: var(--text-3); opacity: .55; cursor: default; }
+html.ui-v2 #ui2-arrange-menu .ui2-arrange-item[hidden] { display: none; }
+html.ui-v2 #ui2-arrange-menu .ui2-arrange-count {
+  min-width: 16px; height: 16px;
+  display: inline-flex; align-items: center; justify-content: center;
+  padding: 0 4px;
+  border-radius: var(--r-pill);
+  background: rgba(var(--iris-rgb), .16);
+  color: var(--iris-2);
+  font-family: var(--mono);
+  font-size: 9.5px;
+  font-weight: 700;
+}
+html.ui-v2 #ui2-arrange-menu .ui2-arrange-count[hidden] { display: none; }
 
 /* Options trigger */
 html.ui-v2 #activity-subtabs .ui2-view-options-btn {

--- a/static/app/ui2-activity.js
+++ b/static/app/ui2-activity.js
@@ -81,6 +81,10 @@ function ui2ApplyLayout(mode) {
   const grid = mode === 'grid';
   document.documentElement.dataset.ui2Layout = grid ? 'grid' : 'focus';
   try { localStorage.setItem('intendant.ui2.layout', grid ? 'grid' : 'focus'); } catch (e) { /* private mode */ }
+  // A layout flip moves the Arrange trigger (and leaving Grid hides the
+  // whole Arrange surface) — fully close the menu so its stamped anchor
+  // and aria-expanded never go stale (no-op while closed).
+  ui2CloseArrangeMenu();
   const fBtn = document.getElementById('ui2-layout-focus-btn');
   const gBtn = document.getElementById('ui2-layout-grid-btn');
   if (fBtn) fBtn.setAttribute('aria-pressed', String(!grid));
@@ -106,161 +110,146 @@ function ui2WireLayoutToggle() {
   }
 }
 
-// ── "Minimize done" bulk pill ──────────────────────────────────────────
-// Sits beside the layout toggle; visible only while at least one done
-// sub-agent window is still expanded, with the count of what one click
-// will collapse. The predicate is 41's sessionWindowIsDoneSubagent — the
-// same active boundary the parent "N sub" badge counts with — and the
-// click delegates to minimizeDoneSubagentWindows. Freshness: 40's badge
-// refreshes and the relationship render pass both call the rAF-deduped
-// refresher below.
-function ui2CollectExpandedDoneSubagents() {
-  const out = [];
-  if (typeof sessionWindows === 'undefined'
-      || typeof sessionWindowIsDoneSubagent !== 'function') return out;
+// ── The "Arrange ▾" menu: every bulk session-window sweep ──────────────
+// One compact toolbar button replacing the five standalone pills that had
+// accumulated beside the layout toggle (Minimize done, Hide done,
+// Collapse all/Expand all, Expand/Collapse details), plus the new
+// "Collapse sub-agents" sweep. Chrome consolidation only: every row
+// delegates to 41-session-window-actions.js's existing sweeps —
+//   expand-all / collapse-all → setAllSessionWindowsMinimized
+//   collapse-subs             → minimizeSubagentWindows (every sub-agent
+//                               window, working or finished; top-level
+//                               windows untouched)
+//   minimize-done             → minimizeDoneSubagentWindows
+//   hide-done                 → hideDoneSessionWindows
+//   details                   → setAllSessionWindowHeadersCollapsed
+// Grid-only like the pills it replaces (Focus hides the windows the
+// sweeps act on) via the stylesheet layout gate, and hidden while no
+// session window exists. Freshness: 40's badge refreshes and the
+// relationship render pass call the same (rAF-deduped) refresher the
+// pills rode, which now derives every row in one pass.
+
+// One walk over sessionWindows for every count the menu renders (each
+// retired pill used to run its own walk on the same freshness ticks).
+// Predicates are 41/40's shared boundaries: sessionWindowIsSubagent (the
+// relationship kind the badges use), sessionWindowIsDoneSubagent (the
+// "N sub" active boundary), sessionWindowHasHardDoneEvidence (ended /
+// done / interrupted — never bare idle).
+function ui2ArrangeMenuModel() {
+  const model = {
+    windows: 0, expanded: 0, minimized: 0,
+    subs: 0, subsExpanded: 0, doneSubsExpanded: 0,
+    hardDone: 0, detailsExpanded: 0,
+  };
+  if (typeof sessionWindows === 'undefined') return model;
+  const isSub = typeof sessionWindowIsSubagent === 'function' ? sessionWindowIsSubagent : null;
+  const isDoneSub = typeof sessionWindowIsDoneSubagent === 'function' ? sessionWindowIsDoneSubagent : null;
+  const isHardDone = typeof sessionWindowHasHardDoneEvidence === 'function' ? sessionWindowHasHardDoneEvidence : null;
   for (const [sid, win] of sessionWindows) {
-    if (!win || win.minimized) continue;
-    if (sessionWindowIsDoneSubagent(sid)) out.push(sid);
+    if (!win) continue;
+    model.windows += 1;
+    if (win.minimized) model.minimized += 1;
+    else {
+      model.expanded += 1;
+      if (!win.headerCollapsed) model.detailsExpanded += 1;
+    }
+    if (isSub && isSub(sid)) {
+      model.subs += 1;
+      if (!win.minimized) {
+        model.subsExpanded += 1;
+        if (isDoneSub && isDoneSub(sid)) model.doneSubsExpanded += 1;
+      }
+    }
+    if (isHardDone && isHardDone(sid)) model.hardDone += 1;
   }
-  return out;
+  return model;
 }
 
+function ui2ArrangeSetRow(id, spec) {
+  const row = document.getElementById(id);
+  if (!row) return;
+  row.hidden = !!spec.hidden;
+  row.disabled = !!spec.disabled;
+  if (spec.title) row.title = spec.title;
+  if (spec.label) {
+    const labelEl = row.querySelector('.ui2-arrange-item-label');
+    if (labelEl) labelEl.textContent = spec.label;
+  }
+  if (spec.direction) row.dataset.direction = spec.direction;
+  const countEl = row.querySelector('.ui2-arrange-count');
+  if (countEl) {
+    const show = typeof spec.count === 'number' && spec.count > 0;
+    countEl.hidden = !show;
+    countEl.textContent = String(show ? spec.count : 0);
+  }
+}
+
+// The single-pass refresh behind every freshness tick. Row policy: the
+// universal axes (windows, details) stay visible and disable when their
+// direction has nothing to act on, so the menu never jumps around; the
+// situational sweeps (sub-agents, finished-window hygiene) hide outright
+// while their concept is absent — a no-sub-agent, nothing-finished
+// session shows a three-row menu, not three dead rows.
+function ui2RefreshArrangeMenu() {
+  const btn = document.getElementById('ui2-arrange-btn');
+  if (!btn) return;
+  const m = ui2ArrangeMenuModel();
+  btn.hidden = m.windows === 0;
+  // A sweep can empty the grid under an open menu (Hide finished closes
+  // every card) — retire the popover with its trigger.
+  if (btn.hidden) ui2CloseArrangeMenu();
+  ui2ArrangeSetRow('ui2-arrange-expand-all', {
+    count: m.minimized,
+    disabled: m.minimized === 0,
+    title: 'Restore every minimized session window',
+  });
+  ui2ArrangeSetRow('ui2-arrange-collapse-all', {
+    count: m.expanded,
+    disabled: m.expanded === 0,
+    title: m.expanded === 1
+      ? 'Minimize the session window to its header bar'
+      : `Minimize all ${m.expanded} session windows to their header bars`,
+  });
+  ui2ArrangeSetRow('ui2-arrange-collapse-subs', {
+    count: m.subsExpanded,
+    hidden: m.subs === 0,
+    disabled: m.subsExpanded === 0,
+    title: m.subsExpanded === 1
+      ? 'Minimize the sub-agent window — top-level sessions stay in place'
+      : `Minimize all ${m.subsExpanded} sub-agent windows — working or finished — leaving top-level sessions in place`,
+  });
+  ui2ArrangeSetRow('ui2-arrange-minimize-done', {
+    count: m.doneSubsExpanded,
+    hidden: m.doneSubsExpanded === 0,
+    title: m.doneSubsExpanded === 1
+      ? 'Minimize the finished sub-agent window'
+      : `Minimize all ${m.doneSubsExpanded} finished sub-agent windows`,
+  });
+  ui2ArrangeSetRow('ui2-arrange-hide-done', {
+    count: m.hardDone,
+    hidden: m.hardDone === 0,
+    title: m.hardDone === 1
+      ? 'Hide the finished session card (its session stays in Sessions)'
+      : `Hide all ${m.hardDone} finished session cards (their sessions stay in Sessions)`,
+  });
+  const collapseDetails = m.detailsExpanded > 0;
+  ui2ArrangeSetRow('ui2-arrange-details', {
+    label: collapseDetails ? 'Collapse all details' : 'Expand all details',
+    direction: collapseDetails ? 'collapse' : 'expand',
+    title: collapseDetails
+      ? (m.detailsExpanded === 1
+          ? 'Collapse header details on the expanded session window'
+          : `Collapse header details on all ${m.detailsExpanded} expanded session windows`)
+      : 'Expand header details on every session window',
+  });
+}
+
+// Legacy seam: 40-session-launch.js's relationship-render pass still
+// calls the refresher by its pill-era name (directly at the render pass,
+// rAF-deduped from the badge refreshes) — keep both names routing into
+// the single-pass menu refresh.
 function ui2RefreshMinimizeDoneControl() {
-  const btn = document.getElementById('ui2-minimize-done-btn');
-  if (!btn) return;
-  const count = ui2CollectExpandedDoneSubagents().length;
-  const countEl = document.getElementById('ui2-minimize-done-count');
-  if (countEl) countEl.textContent = String(count);
-  btn.hidden = count === 0;
-  btn.title = count === 1
-    ? 'Minimize the finished sub-agent window'
-    : `Minimize all ${count} finished sub-agent windows`;
-  // The hide-done, collapse-all, and header-details pills ride the same
-  // freshness passes (badge refresh, relationship render, every minimize
-  // state change routes here).
-  ui2RefreshHideDoneControl();
-  ui2RefreshCollapseAllControl();
-  ui2RefreshHeaderDetailsControl();
-}
-
-// ── "Hide done" close sweep pill ───────────────────────────────────────
-// Beside "Minimize done" but the stronger hygiene action: CLOSE every
-// hard-done window's card (41's hideDoneSessionWindows — the same path
-// as the × button's "Hide card" choice), sub-agent or top-level alike.
-// Hard done evidence only (ended / phase done|interrupted — never bare
-// idle), so idle-parked and live windows always survive, and the closed
-// cards' sessions stay in the Sessions list, reopenable and replayable.
-// Hidden while nothing qualifies; grid-only via the stylesheet layout
-// gate like the sweep pills.
-function ui2CountHardDoneWindows() {
-  if (typeof sessionWindows === 'undefined'
-      || typeof sessionWindowHasHardDoneEvidence !== 'function') return 0;
-  let count = 0;
-  for (const sid of sessionWindows.keys()) {
-    if (sessionWindowHasHardDoneEvidence(sid)) count += 1;
-  }
-  return count;
-}
-
-function ui2RefreshHideDoneControl() {
-  const btn = document.getElementById('ui2-hide-done-btn');
-  if (!btn) return;
-  const count = ui2CountHardDoneWindows();
-  const countEl = document.getElementById('ui2-hide-done-count');
-  if (countEl) countEl.textContent = String(count);
-  btn.hidden = count === 0;
-  btn.title = count === 1
-    ? 'Hide the finished session card (its session stays in Sessions)'
-    : `Hide all ${count} finished session cards (their sessions stay in Sessions)`;
-}
-
-// ── "Collapse all / Expand all" grid sweep pill ────────────────────────
-// Beside "Minimize done", acting on EVERY session window (41's
-// setAllSessionWindowsMinimized): one click drops the grid to a stack of
-// header bars for an all-sessions glance, the next restores it. The
-// label always names the direction one click will act — any expanded
-// window means Collapse all, an all-minimized grid means Expand all.
-// Grid-only surface: Focus hides the session windows the sweep acts on,
-// so the stylesheet layout-gates the pill (html[data-ui2-layout]).
-function ui2RefreshCollapseAllControl() {
-  const btn = document.getElementById('ui2-collapse-all-btn');
-  if (!btn) return;
-  const windows = typeof sessionWindows !== 'undefined' ? sessionWindows : null;
-  if (!windows || windows.size === 0) {
-    btn.hidden = true;
-    return;
-  }
-  let expanded = 0;
-  for (const win of windows.values()) {
-    if (win && !win.minimized) expanded += 1;
-  }
-  const collapse = expanded > 0;
-  btn.hidden = false;
-  btn.dataset.direction = collapse ? 'collapse' : 'expand';
-  btn.textContent = collapse ? 'Collapse all' : 'Expand all';
-  btn.title = collapse
-    ? (expanded === 1
-        ? 'Minimize the session window to its header bar'
-        : `Minimize all ${expanded} session windows to their header bars`)
-    : 'Restore every minimized session window';
-  btn.setAttribute('aria-label', btn.title);
-}
-
-function ui2WireCollapseAllControl() {
-  const btn = document.getElementById('ui2-collapse-all-btn');
-  if (!btn) return;
-  btn.addEventListener('click', () => {
-    const collapse = btn.dataset.direction !== 'expand';
-    if (typeof setAllSessionWindowsMinimized === 'function') {
-      setAllSessionWindowsMinimized(collapse);
-    }
-    ui2RefreshMinimizeDoneControl();
-  });
-}
-
-// ── "Expand details / Collapse details" header sweep pill ──────────────
-// Beside "Collapse all", driving the OTHER axis: every window's
-// click-to-expand header-details strip (41's
-// setAllSessionWindowHeadersCollapsed) — vitals chips, git indicators,
-// paths, goal, tier, relationships — while the windows themselves stay
-// put. Direction counts NON-minimized windows only (the same visibility
-// boundary the sibling counts with); the sweep still flips minimized
-// windows so a later restore honors the choice. Grid-only via the same
-// stylesheet layout gate as its neighbor.
-function ui2RefreshHeaderDetailsControl() {
-  const btn = document.getElementById('ui2-header-details-btn');
-  if (!btn) return;
-  const windows = typeof sessionWindows !== 'undefined' ? sessionWindows : null;
-  if (!windows || windows.size === 0) {
-    btn.hidden = true;
-    return;
-  }
-  let expanded = 0;
-  for (const win of windows.values()) {
-    if (win && !win.minimized && !win.headerCollapsed) expanded += 1;
-  }
-  const collapse = expanded > 0;
-  btn.hidden = false;
-  btn.dataset.direction = collapse ? 'collapse' : 'expand';
-  btn.textContent = collapse ? 'Collapse details' : 'Expand details';
-  btn.title = collapse
-    ? (expanded === 1
-        ? 'Collapse header details on the expanded session window'
-        : `Collapse header details on all ${expanded} expanded session windows`)
-    : 'Expand header details on every session window';
-  btn.setAttribute('aria-label', btn.title);
-}
-
-function ui2WireHeaderDetailsControl() {
-  const btn = document.getElementById('ui2-header-details-btn');
-  if (!btn) return;
-  btn.addEventListener('click', () => {
-    const collapse = btn.dataset.direction !== 'expand';
-    if (typeof setAllSessionWindowHeadersCollapsed === 'function') {
-      setAllSessionWindowHeadersCollapsed(collapse);
-    }
-    ui2RefreshMinimizeDoneControl();
-  });
+  ui2RefreshArrangeMenu();
 }
 
 let ui2MinimizeDoneRefreshQueued = false;
@@ -269,27 +258,107 @@ function ui2QueueMinimizeDoneRefresh() {
   ui2MinimizeDoneRefreshQueued = true;
   requestAnimationFrame(() => {
     ui2MinimizeDoneRefreshQueued = false;
-    ui2RefreshMinimizeDoneControl();
+    ui2RefreshArrangeMenu();
   });
 }
 
-function ui2WireMinimizeDoneControl() {
-  const btn = document.getElementById('ui2-minimize-done-btn');
-  if (!btn) return;
-  btn.addEventListener('click', () => {
-    if (typeof minimizeDoneSubagentWindows === 'function') minimizeDoneSubagentWindows();
-    ui2RefreshMinimizeDoneControl();
-  });
-  ui2RefreshMinimizeDoneControl();
+// Menu close is callable from anywhere (ui2ApplyLayout runs it on every
+// layout flip), so it re-queries the DOM instead of riding the wire
+// closure. No-op while closed.
+function ui2CloseArrangeMenu() {
+  const menu = document.getElementById('ui2-arrange-menu');
+  const btn = document.getElementById('ui2-arrange-btn');
+  if (menu) menu.classList.remove('open');
+  if (btn) btn.setAttribute('aria-expanded', 'false');
 }
 
-function ui2WireHideDoneControl() {
-  const btn = document.getElementById('ui2-hide-done-btn');
-  if (!btn) return;
-  btn.addEventListener('click', () => {
-    if (typeof hideDoneSessionWindows === 'function') hideDoneSessionWindows();
-    ui2RefreshMinimizeDoneControl();
+function ui2RunArrangeAction(action, row) {
+  switch (action) {
+    case 'expand-all':
+    case 'collapse-all':
+      if (typeof setAllSessionWindowsMinimized === 'function') {
+        setAllSessionWindowsMinimized(action === 'collapse-all');
+      }
+      break;
+    case 'collapse-subs':
+      if (typeof minimizeSubagentWindows === 'function') minimizeSubagentWindows();
+      break;
+    case 'minimize-done':
+      if (typeof minimizeDoneSubagentWindows === 'function') minimizeDoneSubagentWindows();
+      break;
+    case 'hide-done':
+      if (typeof hideDoneSessionWindows === 'function') hideDoneSessionWindows();
+      break;
+    case 'details':
+      // Direction rides the row's data-direction so the label the user
+      // clicked and the sweep it runs can never disagree.
+      if (typeof setAllSessionWindowHeadersCollapsed === 'function') {
+        setAllSessionWindowHeadersCollapsed(row?.dataset.direction !== 'expand');
+      }
+      break;
+    default:
+      break;
+  }
+  ui2RefreshArrangeMenu();
+}
+
+// Popover mechanics copied from the Options wiring below: fixed-position
+// anchor stamped at open, outside-pointerdown + Escape close, resize
+// re-anchor. The off-log guard differs — the router only stamps .hidden
+// on the Options panel — so leaving the Timeline is observed on the log
+// sub-tab button's class instead (the stylesheet display gate already
+// keeps a stale .open invisible; this keeps aria in step).
+function ui2WireArrangeMenu() {
+  const btn = document.getElementById('ui2-arrange-btn');
+  const menu = document.getElementById('ui2-arrange-menu');
+  if (!btn || !menu) return;
+  const setOpen = (open) => {
+    if (!open) {
+      ui2CloseArrangeMenu();
+      return;
+    }
+    const r = btn.getBoundingClientRect();
+    menu.style.top = `${Math.round(r.bottom + 6)}px`;
+    menu.style.left = '';
+    menu.style.right = `${Math.max(8, Math.round(window.innerWidth - r.right))}px`;
+    // Counts are fresh at the moment the menu opens, whatever tick last
+    // painted them.
+    ui2RefreshArrangeMenu();
+    menu.classList.add('open');
+    btn.setAttribute('aria-expanded', 'true');
+  };
+  btn.addEventListener('click', () => setOpen(!menu.classList.contains('open')));
+  for (const row of menu.querySelectorAll('.ui2-arrange-item')) {
+    row.addEventListener('click', () => {
+      if (row.disabled) return;
+      ui2RunArrangeAction(row.dataset.arrangeAction, row);
+      // Menu semantics: an action dismisses the menu (counts re-derive on
+      // the next open; the sweep's own render pass keeps the grid live).
+      setOpen(false);
+      btn.focus();
+    });
+  }
+  document.addEventListener('pointerdown', (e) => {
+    if (!menu.classList.contains('open')) return;
+    if (menu.contains(e.target) || btn.contains(e.target)) return;
+    setOpen(false);
   });
+  document.addEventListener('keydown', (e) => {
+    if (e.key !== 'Escape' || !menu.classList.contains('open')) return;
+    setOpen(false);
+    btn.focus();
+  });
+  const logBtn = document.querySelector('#activity-subtabs .subtab-btn[data-activity-tab="log"]');
+  if (logBtn) {
+    new MutationObserver(() => {
+      if (!logBtn.classList.contains('active') && menu.classList.contains('open')) setOpen(false);
+    }).observe(logBtn, { attributes: true, attributeFilter: ['class'] });
+  }
+  // position:fixed captures the anchor at open time — track resizes.
+  window.addEventListener('resize', () => {
+    if (menu.classList.contains('open')) setOpen(true);
+  });
+  ui2RefreshArrangeMenu();
 }
 
 // Composer dressing: placeholder copy + the attach glyph. The send
@@ -441,13 +510,25 @@ window.qa = Object.assign(window.qa || {}, {
       return log ? log.querySelectorAll('.log-entry').length : 0;
     })(),
   }),
-  // Sub-agent auto-minimize + the "Minimize done" pill: the count the
-  // pill shows, its visibility, and the per-subagent-window flag state
-  // the derivation runs on (the failure modes — a live window collapsed,
-  // a user-restored window re-collapsed — are silent without this).
-  minimizeDone: () => ({
-    count: ui2CollectExpandedDoneSubagents().length,
-    visible: !(document.getElementById('ui2-minimize-done-btn')?.hidden ?? true),
+  // The Arrange menu (successor of the pill-era qa.minimizeDone): the
+  // one-pass model every row derives from, the trigger/menu open state,
+  // each row's rendered label/count/state, and the per-subagent-window
+  // flag state the sweeps mutate (the failure modes — a live window
+  // collapsed, a user-restored window re-collapsed — are silent without
+  // this).
+  arrangeMenu: () => ({
+    model: ui2ArrangeMenuModel(),
+    buttonHidden: document.getElementById('ui2-arrange-btn')?.hidden ?? true,
+    expanded: document.getElementById('ui2-arrange-btn')?.getAttribute('aria-expanded') === 'true',
+    open: document.getElementById('ui2-arrange-menu')?.classList.contains('open') ?? false,
+    rows: [...document.querySelectorAll('#ui2-arrange-menu .ui2-arrange-item')].map((row) => ({
+      action: row.dataset.arrangeAction || '',
+      label: row.querySelector('.ui2-arrange-item-label')?.textContent || '',
+      count: row.querySelector('.ui2-arrange-count:not([hidden])')?.textContent || '',
+      hidden: !!row.hidden,
+      disabled: !!row.disabled,
+      direction: row.dataset.direction || '',
+    })),
     subagents: (typeof sessionWindows !== 'undefined'
       && typeof sessionWindowIsSubagent === 'function')
       ? [...sessionWindows.entries()]
@@ -772,10 +853,7 @@ function ui2RailTick(force) {
   const wire = () => {
     ui2AugmentApprovalPanel();
     ui2WireLayoutToggle();
-    ui2WireMinimizeDoneControl();
-    ui2WireHideDoneControl();
-    ui2WireCollapseAllControl();
-    ui2WireHeaderDetailsControl();
+    ui2WireArrangeMenu();
     ui2WireViewOptions();
     ui2DressComposer();
     ui2BuildVitalsRail();


### PR DESCRIPTION
The Activity Timeline toolbar had accumulated five bulk pills beside the
layout toggle (Minimize done, Hide done, Collapse all/Expand all,
Expand/Collapse details). Replace them with one compact "Arrange" menu
button — sibling styling to Focus/Grid/Options, grid-layout-only like
the sweep pills it replaces — whose popover lists every bulk sweep as a
row with a live count, disabled or hidden while it has nothing to act
on.

New sweep: "Collapse sub-agents" (minimizeSubagentWindows) minimizes
every sub-agent window — working or finished — leaving top-level
windows untouched, with the manual-sweep intent flags of
setAllSessionWindowsMinimized's collapse direction. The other five rows
reuse the existing sweeps verbatim; the per-pill refresh chain collapses
into one single-pass deriver (ui2RefreshArrangeMenu), with the pill-era
names kept as delegates for 40-session-launch.js's freshness callers.
Popover follows the Options idiom (fixed anchor, outside-click/Escape
close, aria-expanded), and the stylesheet display gate carries the
trigger's own grid + log-sub-tab conditions so a stale open state can
never surface elsewhere. qa.minimizeDone becomes qa.arrangeMenu.
