### PR TITLE
external: turn ordinals from prompt state; CC resume seed; near-time straddle fix

### DIFF
--- a/src/bin/caller/claude_history.rs
+++ b/src/bin/caller/claude_history.rs
@@ -78,7 +78,8 @@ mod tests {
         let state = user_turn_state_from_transcript_entries(entries.iter());
         assert_eq!(state.active_count(), 2);
 
-        let empty = user_turn_state_from_transcript_entries(std::iter::empty::<&serde_json::Value>());
+        let empty =
+            user_turn_state_from_transcript_entries(std::iter::empty::<&serde_json::Value>());
         assert_eq!(empty.active_count(), 0);
     }
 

--- a/src/bin/caller/claude_history.rs
+++ b/src/bin/caller/claude_history.rs
@@ -1,0 +1,222 @@
+//! Resume seeding for supervised Claude Code sessions: derive the live
+//! loop's `UserTurnRevisionState` from the resumed thread's own
+//! transcript.
+//!
+//! The transcript's prompt ordinal is the turn authority for external
+//! sessions: the dashboard's replay/hydration lane
+//! (`session_catalog::transcripts::parse_claude_session_entries`) counts
+//! non-injected, non-steer user prompts positionally over the WHOLE
+//! resumed JSONL, and the reload annotator
+//! (`annotate_replay_user_turns_from_external_transcript`) overwrites
+//! persisted rows with those ordinals. A resumed live lane that restarts
+//! counting at turn 1 therefore disagrees with every hydrated row — the
+//! same prompt renders twice under different turn badges, and edits are
+//! rejected as "no longer active context" because the daemon validates
+//! the transcript-numbered index against its own restarted state.
+//!
+//! Seeding reuses the catalog's own parser + mid-turn steer ledger via
+//! `external_session_entries_from_home_arc` (derive, don't mirror), so
+//! the live lane continues at exactly the ordinal the transcript lane
+//! will serve for the resumed history.
+
+use std::path::Path;
+
+use crate::codex_history::UserTurnRevisionState;
+
+/// User-turn state for a resumed Claude Code thread, counted from the
+/// same parsed transcript snapshot the session catalog serves (warming
+/// the catalog's shared cache as a side effect). `None` when no
+/// transcript resolves for `session_id` under `home`.
+pub(crate) fn claude_user_turn_state_from_history(
+    home: &Path,
+    session_id: &str,
+) -> Option<UserTurnRevisionState> {
+    let entries = crate::web_gateway::external_session_entries_from_home_arc(
+        home,
+        crate::external_agent::AgentBackend::ClaudeCode.as_short_str(),
+        session_id,
+    )?;
+    Some(user_turn_state_from_transcript_entries(entries.iter()))
+}
+
+/// Seed a fresh state to the highest `user_turn_index` any transcript
+/// entry carries. Max — not row count — so turnless user rows (mid-turn
+/// steers) and non-user rows can never skew the seed off the transcript
+/// lane's numbering.
+pub(crate) fn user_turn_state_from_transcript_entries<'a>(
+    entries: impl IntoIterator<Item = &'a serde_json::Value>,
+) -> UserTurnRevisionState {
+    let max_user_turn = entries
+        .into_iter()
+        .filter_map(|entry| entry.get("user_turn_index").and_then(|v| v.as_u64()))
+        .max()
+        .unwrap_or(0)
+        .min(u64::from(u32::MAX)) as u32;
+    let mut state = UserTurnRevisionState::default();
+    state.seed_active_turns_to(max_user_turn);
+    state
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transcript_entry_seed_uses_max_turn_index_and_ignores_turnless_rows() {
+        let entries = vec![
+            serde_json::json!({
+                "source": "User", "content": "first prompt",
+                "user_turn_index": 1, "user_turn_revision": 1,
+            }),
+            serde_json::json!({ "source": "Claude Code", "content": "a reply" }),
+            serde_json::json!({ "source": "User", "content": "a mid-turn steer" }),
+            serde_json::json!({
+                "source": "User", "content": "second prompt",
+                "user_turn_index": 2, "user_turn_revision": 1,
+            }),
+        ];
+        let state = user_turn_state_from_transcript_entries(entries.iter());
+        assert_eq!(state.active_count(), 2);
+
+        let empty = user_turn_state_from_transcript_entries(std::iter::empty::<&serde_json::Value>());
+        assert_eq!(empty.active_count(), 0);
+    }
+
+    fn rfc3339_ms(value: &str) -> i64 {
+        chrono::DateTime::parse_from_rfc3339(value)
+            .expect("fixture timestamp")
+            .timestamp_millis()
+    }
+
+    /// The resume-seed ⇄ replay-lane parity oracle: over one fixture JSONL
+    /// containing normal prompts, harness-injected shapes
+    /// (`is_injected_external_user_text`: task notifications, interrupt
+    /// markers), tool_result/meta plumbing, and a ledger-proven mid-turn
+    /// steer, the seed equals the hydration lane's highest prompt ordinal
+    /// — so a resumed live lane's next prompt continues the transcript's
+    /// numbering instead of restarting at 1 (the double-row T1-vs-T14
+    /// class). Exercises the full pipeline the daemon runs at resume:
+    /// transcript discovery → wrapper-index steer-ledger build → parse.
+    #[test]
+    fn claude_resume_seed_matches_replay_lane_prompt_ordinals() {
+        let home = tempfile::tempdir().unwrap();
+        let session_id = "0197feed-aaaa-bbbb-cccc-turnseed0001";
+        let wrapper_id = "wrapper-cc-turn-seed";
+        let steer_text = "also update the changelog";
+
+        // Wrapper session log carrying the mid-turn steer arc (request +
+        // accepted), discovered through the wrapper index like the live
+        // catalog's ledger build.
+        let wrapper_dir = home.path().join(".intendant").join("logs").join(wrapper_id);
+        std::fs::create_dir_all(&wrapper_dir).unwrap();
+        let requested_ts_ms = rfc3339_ms("2026-07-15T10:00:29Z");
+        std::fs::write(
+            wrapper_dir.join("session.jsonl"),
+            [
+                serde_json::json!({
+                    "ts": "10:00:29", "ts_ms": requested_ts_ms,
+                    "event": "steer_requested", "level": "info",
+                    "message": format!("Steer requested: {steer_text}"),
+                    "data": { "session_id": session_id, "id": "steer-1", "status": "pending", "text": steer_text },
+                }),
+                serde_json::json!({
+                    "ts": "10:00:29", "ts_ms": requested_ts_ms + 150,
+                    "event": "steer_accepted", "level": "info",
+                    "message": "Steer accepted",
+                    "data": { "session_id": session_id, "id": "steer-1", "status": "accepted" },
+                }),
+            ]
+            .into_iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<_>>()
+            .join("\n"),
+        )
+        .unwrap();
+        crate::external_wrapper_index::upsert(
+            home.path(),
+            "claude-code",
+            session_id,
+            wrapper_id,
+            &wrapper_dir,
+            None,
+        )
+        .unwrap();
+
+        // The resumed thread's own transcript, under the store layout the
+        // catalog's fast path resolves (`projects/<project>/<id>.jsonl`).
+        let project_dir = home
+            .path()
+            .join(".claude")
+            .join("projects")
+            .join("-tmp-turn-seed-project");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let lines = [
+            r#"{"type":"user","timestamp":"2026-07-15T10:00:00.000Z","message":{"role":"user","content":"fix the flaky test"}}"#.to_string(),
+            r#"{"type":"assistant","timestamp":"2026-07-15T10:00:05.000Z","message":{"role":"assistant","content":[{"type":"text","text":"On it."}]}}"#.to_string(),
+            // Harness-injected shapes: no row, no index.
+            r#"{"type":"user","timestamp":"2026-07-15T10:00:20.000Z","message":{"role":"user","content":"<task-notification>build finished</task-notification>"}}"#.to_string(),
+            // The mid-turn steer, echoed after its wrapper-log request:
+            // renders turnless and burns no index.
+            format!(
+                r#"{{"type":"user","timestamp":"2026-07-15T10:00:30.000Z","message":{{"role":"user","content":"{steer_text}"}}}}"#
+            ),
+            r#"{"type":"user","timestamp":"2026-07-15T10:00:40.000Z","message":{"role":"user","content":"[Request interrupted by user]"}}"#.to_string(),
+            r#"{"type":"user","timestamp":"2026-07-15T10:00:50.000Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01","content":"ok"}]}}"#.to_string(),
+            r#"{"type":"user","isMeta":true,"timestamp":"2026-07-15T10:00:55.000Z","message":{"role":"user","content":"Caveat: harness-generated"}}"#.to_string(),
+            // Block-form follow-up (image rides along): one turn.
+            r#"{"type":"user","timestamp":"2026-07-15T10:01:00.000Z","message":{"role":"user","content":[{"type":"image","source":{"type":"base64","media_type":"image/png","data":"aGk="}},{"type":"text","text":"now fix the docs"}]}}"#.to_string(),
+            r#"{"type":"user","timestamp":"2026-07-15T10:02:00.000Z","message":{"role":"user","content":"ship it"}}"#.to_string(),
+        ];
+        std::fs::write(
+            project_dir.join(format!("{session_id}.jsonl")),
+            lines.join("\n"),
+        )
+        .unwrap();
+
+        let seed = claude_user_turn_state_from_history(home.path(), session_id)
+            .expect("resumed transcript should seed");
+        let entries = crate::web_gateway::external_session_entries_from_home(
+            home.path(),
+            "claude-code",
+            session_id,
+        )
+        .expect("replay lane should parse the same transcript");
+
+        let user_rows: Vec<(&str, Option<u64>, Option<u64>)> = entries
+            .iter()
+            .filter(|e| e["source"] == "User")
+            .map(|e| {
+                (
+                    e["content"].as_str().unwrap_or(""),
+                    e.get("user_turn_index").and_then(|v| v.as_u64()),
+                    e.get("user_turn_revision").and_then(|v| v.as_u64()),
+                )
+            })
+            .collect();
+        assert_eq!(
+            user_rows,
+            vec![
+                ("fix the flaky test", Some(1), Some(1)),
+                (steer_text, None, None),
+                ("now fix the docs", Some(2), Some(1)),
+                ("ship it", Some(3), Some(1)),
+            ],
+            "replay lane counts prompt ordinals; injected/steer rows burn no index"
+        );
+        let replay_max = user_rows
+            .iter()
+            .filter_map(|(_, turn, _)| *turn)
+            .max()
+            .unwrap_or(0);
+        assert_eq!(
+            u64::from(seed.active_count()),
+            replay_max,
+            "resume seed must equal the replay lane's highest prompt ordinal"
+        );
+        assert_eq!(seed.active_count(), 3);
+
+        // The live lane's next prompt continues the transcript numbering.
+        let mut live = seed;
+        assert_eq!(live.record_next_turn(), (4, 1));
+    }
+}

--- a/src/bin/caller/external_mode.rs
+++ b/src/bin/caller/external_mode.rs
@@ -330,6 +330,13 @@ pub(crate) async fn run_external_agent_mode(
     }
 
     // Event loop
+    //
+    // Resumed threads seed their user-turn state from the backend's own
+    // history: the transcript's prompt ordinal is the turn authority (the
+    // catalog's hydration lane and the reload annotator both count the
+    // WHOLE resumed transcript), so a live lane restarting at turn 1
+    // would double-render every prompt under disagreeing badges and
+    // reject edits of transcript-numbered turns.
     let mut user_turn_revisions = match (
         &backend,
         resumed_external_session.as_deref(),
@@ -337,6 +344,15 @@ pub(crate) async fn run_external_agent_mode(
     ) {
         (external_agent::AgentBackend::Codex, Some(_), session_id) => {
             codex_user_turn_state_from_history(session_id).unwrap_or_default()
+        }
+        // A `--fork-session` resume starts on the placeholder id (the
+        // forked child announces its own id mid-turn), so only a
+        // canonical id — a plain resume, whose id stays stable — seeds.
+        (external_agent::AgentBackend::ClaudeCode, Some(_), session_id)
+            if backend.thread_id_is_canonical(session_id) =>
+        {
+            claude_user_turn_state_from_history(&platform::home_dir(), session_id)
+                .unwrap_or_default()
         }
         _ => UserTurnRevisionState::default(),
     };
@@ -1495,15 +1511,18 @@ pub(crate) async fn run_external_agent_mode(
 
             let side_round = side_rounds.entry(side_thread_id.clone()).or_insert(0);
             *side_round += 1;
-            let user_turn_revision = side_turn_revisions
+            // Prompt ordinal from the revision state (side rounds track it
+            // 1:1 today, but the ordinal is the emitted authority — see
+            // the primary emit site).
+            let (side_user_turn_index, user_turn_revision) = side_turn_revisions
                 .entry(side_thread_id.clone())
                 .or_default()
-                .record_active_turn(*side_round as u32);
+                .record_next_turn();
             emit_user_message_log(
                 &bus,
                 &session_log,
                 Some(&side_thread_id),
-                Some(*side_round as u32),
+                Some(side_user_turn_index),
                 Some(user_turn_revision),
                 replacement_for_user_turn_index,
                 &attachments.refs,
@@ -1930,7 +1949,7 @@ pub(crate) async fn run_external_agent_mode(
                 );
                 continue;
             }
-            let active_edit_revision_ok = user_turn_index as usize <= round
+            let active_edit_revision_ok = user_turn_index <= user_turn_revisions.active_count()
                 && user_turn_revisions
                     .validate_expected_revision(user_turn_index, edit_user_turn_revision)
                     .is_ok();
@@ -1993,7 +2012,7 @@ pub(crate) async fn run_external_agent_mode(
                     }
                 }
             }
-            if user_turn_index as usize > round {
+            if user_turn_index > user_turn_revisions.active_count() {
                 let message = format!(
                     "Cannot edit user turn {} in {} session {}; current user turn count is {}",
                     user_turn_index,
@@ -2002,7 +2021,7 @@ pub(crate) async fn run_external_agent_mode(
                         .as_deref()
                         .map(|sid| sid.chars().take(8).collect::<String>())
                         .unwrap_or_else(|| "unknown".to_string()),
-                    round
+                    user_turn_revisions.active_count()
                 );
                 bus.send(AppEvent::UserMessageEditStatus {
                     session_id: live_session_id.clone(),
@@ -2044,7 +2063,10 @@ pub(crate) async fn run_external_agent_mode(
                 );
                 continue;
             }
-            let turns_to_drop = round as u32 - user_turn_index + 1;
+            // Rollback depth is counted in USER turns from the prompt
+            // ordinal state — `round` can exceed it (spontaneous backend
+            // rounds), and a round-based count over-rolls the backend.
+            let turns_to_drop = user_turn_revisions.active_count() - user_turn_index + 1;
             let mut rollback_result = agent.rollback_turns(turns_to_drop).await;
             if let Err(err) = rollback_result.as_ref() {
                 if backend == external_agent::AgentBackend::Codex
@@ -2312,7 +2334,15 @@ pub(crate) async fn run_external_agent_mode(
         }
 
         round += 1;
-        let user_turn_revision = user_turn_revisions.record_active_turn(round as u32);
+        // The emitted turn index is the PROMPT ORDINAL from the revision
+        // state — never `round`, which also counts spontaneous backend
+        // rounds (and restarts on resume for backends without a seed), so
+        // it drifts off the transcript lane's positional numbering.
+        // `round` stays the round counter for status lines/RoundComplete.
+        // After an edit rollback (`rewind_from_turn` above) this yields
+        // the edited index with a bumped revision, exactly like the old
+        // round-aligned bookkeeping.
+        let (user_turn_index, user_turn_revision) = user_turn_revisions.record_next_turn();
         stats.turns = 0;
         let attachment_count = attachments.len();
         let merged = drain_steer_queue_as_followup(
@@ -2332,7 +2362,7 @@ pub(crate) async fn run_external_agent_mode(
             &bus,
             &session_log,
             live_session_id.as_deref(),
-            Some(round as u32),
+            Some(user_turn_index),
             Some(user_turn_revision),
             replacement_for_user_turn_index,
             &attachments.refs,

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -116,6 +116,8 @@ pub(crate) use intendant_display::x11_input;
 // God-file split (see CLAUDE.md "File size budget"): regions extracted from
 // this file live in the modules below; the glob re-exports keep existing
 // crate:: and unqualified references resolving unchanged.
+mod claude_history;
+pub(crate) use claude_history::*;
 mod codex_history;
 pub(crate) use codex_history::*;
 mod external_output;

--- a/src/bin/caller/managed_context_ops/apply.rs
+++ b/src/bin/caller/managed_context_ops/apply.rs
@@ -438,19 +438,22 @@ pub(crate) async fn start_external_side_followup_turn(
         if state.has_side_thread(&session_id) {
             let side_round = state.side_rounds.entry(session_id.clone()).or_insert(0);
             *side_round += 1;
-            let user_turn_revision = state
+            // Prompt ordinal from the revision state (side rounds track
+            // it 1:1 today, but the ordinal is the emitted authority —
+            // see external_mode's primary emit site).
+            let (side_user_turn_index, user_turn_revision) = state
                 .side_turn_revisions
                 .entry(session_id.clone())
                 .or_default()
-                .record_active_turn(*side_round as u32);
-            Some((*side_round, user_turn_revision))
+                .record_next_turn();
+            Some((*side_round, side_user_turn_index, user_turn_revision))
         } else {
             None
         }
     } else {
         None
     };
-    let Some((side_round, user_turn_revision)) = side_turn else {
+    let Some((side_round, side_user_turn_index, user_turn_revision)) = side_turn else {
         return false;
     };
 
@@ -458,7 +461,7 @@ pub(crate) async fn start_external_side_followup_turn(
         config.bus,
         config.session_log,
         Some(&session_id),
-        Some(side_round as u32),
+        Some(side_user_turn_index),
         Some(user_turn_revision),
         None,
         &[],

--- a/src/bin/caller/session_fork/fork_points.rs
+++ b/src/bin/caller/session_fork/fork_points.rs
@@ -277,12 +277,15 @@ pub(crate) fn native_fork_points(
 
 /// Resolve the fork anchor for an edited Claude Code user message by its
 /// exact prose. Claude Code has no in-place rewind on the supervision
-/// wire, so an edit is serviced as an anchor-fork branch — but the live
-/// lane's `user_turn_index` counts THIS supervision run (claude turn
-/// state is not seeded from history), so the turn number cannot address
-/// the transcript chain. The edited row's original text can: match it
-/// against the active chain's user turns and anchor at the unique match's
-/// parent. Ambiguity or absence is a refusal, never a guess — the
+/// wire, so an edit is serviced as an anchor-fork branch — and the
+/// edited row's original text is the address: match it against the
+/// active chain's user turns and anchor at the unique match's parent.
+/// Text stays the anchor key even though plain resumes now seed the
+/// live lane's `user_turn_index` from the transcript
+/// (`claude_user_turn_state_from_history`): the seed is best-effort
+/// (`--fork-session` resumes start on the placeholder id and re-count
+/// this supervision run), while prose matching addresses the chain
+/// regardless. Ambiguity or absence is a refusal, never a guess — the
 /// transcript's inline fork affordance covers those cases exactly.
 pub(crate) fn claude_edit_branch_anchor(
     transcript_path: &Path,

--- a/src/bin/caller/thread_actions.rs
+++ b/src/bin/caller/thread_actions.rs
@@ -2113,14 +2113,19 @@ pub(crate) async fn rollback_parent_thread_from_turn(
     if first_user_turn_index == 0 {
         return Err("Cannot rewind user turn 0".to_string());
     }
-    if first_user_turn_index as usize > *round {
+    // Bounds and rollback depth come from the prompt-ordinal state, not
+    // `round`: rounds also count spontaneous backend turns (and restart on
+    // resume for unseeded backends), so a round-based depth over-rolls
+    // the backend. `round` is reset below purely as the round counter.
+    let active_user_turns = user_turn_revisions.active_count();
+    if first_user_turn_index > active_user_turns {
         return Err(format!(
             "Cannot rewind to user turn {}; current user turn count is {}",
-            first_user_turn_index, *round
+            first_user_turn_index, active_user_turns
         ));
     }
 
-    let turns_to_drop = *round as u32 - first_user_turn_index + 1;
+    let turns_to_drop = active_user_turns - first_user_turn_index + 1;
     agent
         .rollback_turns(turns_to_drop)
         .await
@@ -2144,7 +2149,10 @@ pub(crate) async fn handle_parent_undo_thread_action(
     config: &DrainConfig<'_>,
 ) {
     let turns = undo_turns_from_params(&params);
-    let result = match parent_rewind_first_turn_for_undo(*round, turns) {
+    let result = match parent_rewind_first_turn_for_undo(
+        user_turn_revisions.active_count() as usize,
+        turns,
+    ) {
         Ok(first_user_turn_index) => rollback_parent_thread_from_turn(
             agent,
             round,

--- a/src/bin/caller/thread_actions.rs
+++ b/src/bin/caller/thread_actions.rs
@@ -2149,21 +2149,20 @@ pub(crate) async fn handle_parent_undo_thread_action(
     config: &DrainConfig<'_>,
 ) {
     let turns = undo_turns_from_params(&params);
-    let result = match parent_rewind_first_turn_for_undo(
-        user_turn_revisions.active_count() as usize,
-        turns,
-    ) {
-        Ok(first_user_turn_index) => rollback_parent_thread_from_turn(
-            agent,
-            round,
-            user_turn_revisions,
-            first_user_turn_index,
-            config,
-        )
-        .await
-        .map(|turns_removed| format!("rolled back {} turn(s)", turns_removed)),
-        Err(message) => Err(message),
-    };
+    let result =
+        match parent_rewind_first_turn_for_undo(user_turn_revisions.active_count() as usize, turns)
+        {
+            Ok(first_user_turn_index) => rollback_parent_thread_from_turn(
+                agent,
+                round,
+                user_turn_revisions,
+                first_user_turn_index,
+                config,
+            )
+            .await
+            .map(|turns_removed| format!("rolled back {} turn(s)", turns_removed)),
+            Err(message) => Err(message),
+        };
 
     let (success, message) = match result {
         Ok(message) => (true, message),

--- a/static/app/39-session-windows.js
+++ b/static/app/39-session-windows.js
@@ -3813,8 +3813,7 @@ function sessionWindowTranscriptSignaturesFromParts(parts, options = {}) {
       signatures.push(['exact-ms', String(parts.tsMs), ...textParts].join('\u001f'));
     }
     if (isUserMessage && options.includeUserNearTime) {
-      const timeBucket = sessionWindowTranscriptTimeBucket(parts.ts);
-      if (timeBucket) {
+      for (const timeBucket of sessionWindowTranscriptTimeBuckets(parts.ts)) {
         signatures.push([
           'user-near-time-text',
           parts.sessionId,
@@ -3982,10 +3981,21 @@ function sessionWindowTranscriptTimestampForHistoryItem(item) {
   return sessionWindowTranscriptTimestampMs(record?.ts_ms ?? record?.tsMs ?? record?.ts ?? record?.timestamp ?? '');
 }
 
-function sessionWindowTranscriptTimeBucket(value) {
+// Near-time buckets for the turn-agnostic user-row bridge: the primary 5s
+// floor lattice PLUS a half-offset (2.5s) lattice, so two copies of one
+// prompt that straddle a primary floor boundary (observed live: live-lane
+// dispatch ts vs transcript-lane backend ts, 2s apart across a boundary)
+// still share the offset bucket — any pair within 2.5s provably shares at
+// least one bucket. The lattices are namespaced ('a'/'b') so a primary
+// bucket number never collides with an offset bucket number: matches stay
+// within one lattice, which caps the pairable spread at <5s exactly like
+// the single-bucket window did (deliberately NOT ±1-neighbor probing,
+// which would let identical-text prompts up to ~15s apart collapse — the
+// distinct-repeated-prompts safety bar).
+function sessionWindowTranscriptTimeBuckets(value) {
   const ms = sessionWindowTranscriptTimestampMs(value);
-  if (ms === null) return '';
-  return String(Math.floor(ms / 5000));
+  if (ms === null) return [];
+  return ['a' + Math.floor(ms / 5000), 'b' + Math.floor((ms + 2500) / 5000)];
 }
 
 // Timestamp lookups for the insert-position scan cost a querySelector +


### PR DESCRIPTION
## Problem
Resumed external Claude Code sessions render every user message TWICE with disagreeing turn badges (observed T1 vs T14), and editing a message on a resumed session fails with "no longer active context".

Mechanism: (a) the live lane had no resume seed for CC — only Codex seeded `user_turn_revisions` from history, so post-resume live rows restart at index 1 while the CC transcript lane counts prompt ordinals positionally over the WHOLE resumed JSONL; (b) the live index was a ROUND counter (`round += 1; record_active_turn(round)`), and spontaneous backend rounds consume indices with no user emit → non-constant skew; (c) the turn-keyed text signature can't pair the copies, and the turn-agnostic near-time bridge used floor-aligned 5s buckets that the observed 2s-apart copies straddled.

The transcript's prompt ordinal is the correct authority (navigator + reload annotator already agree with it).

## Fix (three parts)
1. **ClaudeCode resume seed** — new `claude_history::claude_user_turn_state_from_history(home, session_id)` reuses the catalog's own parser + mid-turn steer ledger (`external_session_entries_from_home_arc` → `parse_claude_session_entries`; derive, don't mirror) and seeds `UserTurnRevisionState` to the transcript's max prompt ordinal. Gated to canonical ids (a `--fork-session` resume starts on the placeholder id and keeps today's behavior). Parity oracle test: seed == replay-lane count over one fixture JSONL with normal prompts, injected task-notification shapes, interrupt markers, tool_result/meta plumbing, and a ledger-proven mid-turn steer.
2. **Emit prompt ordinals, not rounds** — the primary emit site derives `user_turn_index` from `user_turn_revisions.record_next_turn()`; `round` remains the round counter for status lines/RoundComplete. Edit/undo bounds and rollback depth (`turns_to_drop`) now come from `active_count()` instead of `round` (also fixes the latent Codex round-vs-prompt skew, where a round-based depth could over-roll the backend after spontaneous rounds). Side-thread emit sites switch to the same ordinal form (numerically identical today; side rounds track ordinals 1:1).
3. **Straddle-proof near-time bridge** (frontend backstop) — fragment 39's near-time user-row signature emits a dual half-offset bucket lattice ('a' + floor(ms/5000), 'b' + floor((ms+2500)/5000)): any pair within 2.5s provably shares a bucket, pairable spread stays <5s (no window widening — deliberately not ±1-neighbor probing, which would collapse legitimately distinct identical prompts up to ~15s apart). app.html regenerated via the assembler.

## Backward compat
Old wrapper logs whose `[user]` lines carry no turn fields keep today's untagged replay behavior (pinned by the existing `rt_user_message_row_without_metadata_replays_untagged_like_legacy` test; the record shape is unchanged — only the emitted index value changes).

Live confirmation of the resumed-CC arc happens on the next real resumed session (a real CC resume can't be driven headless).