### PR TITLE
vitals: immediate git-probe locus for resumed external sessions

### DIFF
--- a/crates/intendant-core/src/vitals.rs
+++ b/crates/intendant-core/src/vitals.rs
@@ -28,6 +28,14 @@ pub struct SessionGitVitals {
     /// the primary branch itself.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub primary_unpushed: Option<u32>,
+    /// Basename of the probed checkout's toplevel — names WHERE these
+    /// numbers were measured. A session's probe target can be an activity
+    /// locus (a worktree the backend actually works in) rather than its
+    /// registered project root, and the chip must say so instead of
+    /// letting the numbers pass as the root's. Wire-additive: empty on
+    /// emissions from daemons that predate the field.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub checkout: String,
 }
 
 /// Prompt-cache lifecycle for the vitals chips: `hit_pct` is the share of
@@ -380,6 +388,36 @@ mod tests {
             }
         }
         assert!(PERMISSION_DISPLAY_KINDS.contains(&PERMISSION_KIND_AUTONOMY));
+    }
+
+    /// The git section's `checkout` field is wire-additive: serialized
+    /// when known, absent when empty, and a legacy emission without it
+    /// deserializes to the empty default (frontends then simply don't
+    /// name a checkout).
+    #[test]
+    fn git_vitals_checkout_round_trips_and_stays_wire_additive() {
+        let vitals = SessionGitVitals {
+            branch: "agent/fix".into(),
+            dirty_files: 1,
+            ahead: 2,
+            behind: 3,
+            primary_ref: "origin/main".into(),
+            checkout: "session-fork".into(),
+            ..Default::default()
+        };
+        let wire = serde_json::to_value(&vitals).expect("serializes");
+        assert_eq!(wire["checkout"], "session-fork");
+        let back: SessionGitVitals = serde_json::from_value(wire).expect("deserializes");
+        assert_eq!(back, vitals);
+
+        // Legacy wire without the field: defaults to empty, and an empty
+        // checkout is not serialized (no noise on unknown).
+        let legacy: SessionGitVitals =
+            serde_json::from_str(r#"{"branch":"main","dirtyFiles":0,"ahead":0,"behind":0}"#)
+                .expect("legacy deserializes");
+        assert_eq!(legacy.checkout, "");
+        let rewire = serde_json::to_value(&legacy).expect("serializes");
+        assert!(rewire.get("checkout").is_none());
     }
 
     /// The config section's wire shape: camelCase fields, absent when

--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -1020,6 +1020,18 @@ pub enum AppEvent {
         paths: Vec<String>,
     },
 
+    /// The session's backend stated its effective working directory
+    /// first-hand (Claude Code's `system:init` `cwd` echo, Codex's
+    /// applied thread settings). Seeds the git-vitals activity locus
+    /// authoritatively — unlike `SessionFileActivity`'s write-path
+    /// heuristic, the probe target switches immediately, so the git chip
+    /// measures the checkout the backend says it works in from the next
+    /// tick. Internal event: not broadcast to frontends, not persisted.
+    SessionCwdAnnounced {
+        session_id: Option<String>,
+        cwd: String,
+    },
+
     /// A user-uploaded file was committed to the upload store. Emitted by
     /// the `POST /api/upload` handler after the bytes land on disk. The
     /// dashboard keeps a list of these to let the user attach one or more
@@ -3212,6 +3224,7 @@ pub fn app_event_to_outbound(event: &AppEvent) -> Option<crate::types::OutboundE
         AppEvent::Tick
         | AppEvent::JsonExtracted { .. }
         | AppEvent::SessionFileActivity { .. }
+        | AppEvent::SessionCwdAnnounced { .. }
         | AppEvent::SessionDirChanged { .. }
         | AppEvent::ControlCommand(_)
         | AppEvent::PresenceReady

--- a/src/bin/caller/external_agent/claude_code.rs
+++ b/src/bin/caller/external_agent/claude_code.rs
@@ -1067,6 +1067,10 @@ struct CcReader {
     /// The CLI's last effort echo (2.1.2xx never states one; kept as the
     /// change edge if a future protocol does).
     effort_echo: Option<String>,
+    /// The last `system:init` `cwd` a `CwdAnnounced` was emitted for.
+    /// Init re-fires after every user message, so the git-vitals locus
+    /// seed fires once per distinct working directory, not per init.
+    cwd_echo: Option<String>,
     announced_session_id: Option<String>,
 }
 
@@ -1098,6 +1102,7 @@ impl CcReader {
             init_logged: false,
             permission_mode_warned: None,
             effort_echo: None,
+            cwd_echo: None,
             announced_session_id: None,
         }
     }
@@ -1498,6 +1503,24 @@ impl CcReader {
         }
         if let Some(model) = msg.get("model").and_then(|m| m.as_str()) {
             self.note_model_echo(model, out);
+        }
+        // The CLI's own statement of the directory it operates in — the
+        // authoritative confirmation for the git-vitals locus (a resumed
+        // session can work in a checkout the registered project root
+        // knows nothing about). Emitted once per distinct value: init
+        // re-fires after every user message.
+        if let Some(cwd) = msg
+            .get("cwd")
+            .and_then(|c| c.as_str())
+            .map(str::trim)
+            .filter(|c| !c.is_empty())
+        {
+            if self.cwd_echo.as_deref() != Some(cwd) {
+                self.cwd_echo = Some(cwd.to_string());
+                out.events.push(AgentEvent::CwdAnnounced {
+                    cwd: cwd.to_string(),
+                });
+            }
         }
         // First-hand effort: adopt the CLI's own echo if an init ever
         // states one (2.1.2xx doesn't; the launch `--effort` value seeds
@@ -4195,6 +4218,51 @@ mod tests {
             !background_tasks::session_known(sid),
             "re-adoption clears a previous process's records"
         );
+    }
+
+    /// The `system:init` `cwd` echo emits ONE `CwdAnnounced` per distinct
+    /// value — the authoritative git-vitals locus confirmation. Init
+    /// re-fires after every user message, so an unchanged re-echo stays
+    /// silent until the directory actually changes.
+    #[test]
+    fn init_cwd_echo_announces_once_per_distinct_value() {
+        let mut reader = test_reader();
+        fn announced(out: &CcLineOutcome) -> Vec<String> {
+            out.events
+                .iter()
+                .filter_map(|e| match e {
+                    AgentEvent::CwdAnnounced { cwd } => Some(cwd.clone()),
+                    _ => None,
+                })
+                .collect()
+        }
+
+        let out = reader.process_line(
+            r#"{"type":"system","subtype":"init","cwd":"/repo/.claude/worktrees/wt","session_id":"s1","model":"claude-fable-5"}"#,
+        );
+        assert_eq!(
+            announced(&out),
+            vec!["/repo/.claude/worktrees/wt".to_string()]
+        );
+
+        // The next init re-states the same cwd: silence.
+        let out = reader.process_line(
+            r#"{"type":"system","subtype":"init","cwd":"/repo/.claude/worktrees/wt","session_id":"s1"}"#,
+        );
+        assert!(
+            announced(&out).is_empty(),
+            "unchanged cwd re-echo stays silent"
+        );
+
+        // A changed cwd announces again; blank or absent cwd never does.
+        let out = reader
+            .process_line(r#"{"type":"system","subtype":"init","cwd":"/repo","session_id":"s1"}"#);
+        assert_eq!(announced(&out), vec!["/repo".to_string()]);
+        let out = reader
+            .process_line(r#"{"type":"system","subtype":"init","cwd":"  ","session_id":"s1"}"#);
+        assert!(announced(&out).is_empty());
+        let out = reader.process_line(r#"{"type":"system","subtype":"init","session_id":"s1"}"#);
+        assert!(announced(&out).is_empty());
     }
 
     /// Write-ish tool_use blocks emit their structured paths alongside

--- a/src/bin/caller/external_agent/codex/reader.rs
+++ b/src/bin/caller/external_agent/codex/reader.rs
@@ -2966,6 +2966,18 @@ pub(crate) fn translate_notification_with_scope(
                         message: format!("Codex thread settings applied: cwd {cwd}"),
                     },
                 );
+                // The server's own statement of the thread's effective
+                // working directory — the authoritative git-vitals locus
+                // confirmation (mirrors Claude Code's `system:init` cwd
+                // echo).
+                send_scoped_agent_event(
+                    event_tx,
+                    thread_id,
+                    turn_id,
+                    AgentEvent::CwdAnnounced {
+                        cwd: cwd.to_string(),
+                    },
+                );
             }
             // The applied settings are the server's own config echo —
             // model / reasoning effort / approval+sandbox ride the
@@ -6240,6 +6252,14 @@ error: build failed
                 );
             }
             other => panic!("expected Log, got {:?}", other),
+        }
+        // The applied cwd also rides the authoritative git-vitals locus
+        // lane (the Claude Code `system:init` echo's Codex twin).
+        match rx.try_recv().unwrap() {
+            AgentEvent::CwdAnnounced { cwd } => {
+                assert_eq!(cwd, "/home/user/projects/intendant-original");
+            }
+            other => panic!("expected CwdAnnounced, got {:?}", other),
         }
     }
 }

--- a/src/bin/caller/external_agent/mod.rs
+++ b/src/bin/caller/external_agent/mod.rs
@@ -1256,6 +1256,14 @@ pub enum AgentEvent {
     /// drain forwards it as `AppEvent::SessionFileActivity` for the
     /// git-vitals activity-locus tracker.
     FileActivity { paths: Vec<String> },
+    /// The backend's own first-hand statement of the working directory it
+    /// operates in (Claude Code's `system:init` `cwd` field, Codex's
+    /// `thread/settings/updated` effective settings). The drain forwards
+    /// it as `AppEvent::SessionCwdAnnounced`, which seeds the git-vitals
+    /// probe locus immediately — authoritative, unlike the
+    /// [`AgentEvent::FileActivity`] write-path heuristic. Ambient
+    /// bookkeeping: implies no turn.
+    CwdAnnounced { cwd: String },
     /// Incremental output from a running tool.
     ToolOutputDelta { item_id: String, text: String },
     /// A tool execution completed.

--- a/src/bin/caller/external_events.rs
+++ b/src/bin/caller/external_events.rs
@@ -2107,6 +2107,19 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                     });
                 }
             }
+            external_agent::AgentEvent::CwdAnnounced { cwd } => {
+                // The backend's first-hand working-directory statement —
+                // seeds the git-vitals locus immediately. Same
+                // primary-conversation gate as FileActivity: a side
+                // thread's cwd must not retarget the supervising
+                // session's git chip.
+                if event_is_primary && !cwd.trim().is_empty() {
+                    config.bus.send(AppEvent::SessionCwdAnnounced {
+                        session_id: config.session_id.clone(),
+                        cwd,
+                    });
+                }
+            }
             external_agent::AgentEvent::FileApprovalRequest {
                 request_id,
                 path,

--- a/src/bin/caller/mcp/events.rs
+++ b/src/bin/caller/mcp/events.rs
@@ -1010,8 +1010,8 @@ pub fn spawn_event_listener(
                     | AppEvent::ConversationRolledBack { .. } => {
                         // Broadcast-only — handled by outbound event converter.
                     }
-                    AppEvent::SessionFileActivity { .. } => {
-                        // Internal git-vitals activity-locus signal — no
+                    AppEvent::SessionFileActivity { .. } | AppEvent::SessionCwdAnnounced { .. } => {
+                        // Internal git-vitals activity-locus signals — no
                         // MCP surface.
                     }
                     AppEvent::DisplayCaptureLost {

--- a/src/bin/caller/peer/transport/intendant.rs
+++ b/src/bin/caller/peer/transport/intendant.rs
@@ -860,6 +860,7 @@ mod tests {
                         merge_parity: String::new(),
                         unpushed: None,
                         primary_unpushed: None,
+                        checkout: String::new(),
                     }),
                     cache: None,
                     limits: Vec::new(),

--- a/src/bin/caller/peer/upcast.rs
+++ b/src/bin/caller/peer/upcast.rs
@@ -594,6 +594,7 @@ impl AppEventUpcaster {
             | AppEvent::SessionAgentConfigResult { .. }
             | AppEvent::FileChanged { .. }
             | AppEvent::SessionFileActivity { .. }
+            | AppEvent::SessionCwdAnnounced { .. }
             | AppEvent::UploadReady { .. }
             | AppEvent::UploadDeleted { .. }
             | AppEvent::SnapshotCreated { .. }
@@ -4618,6 +4619,7 @@ mod tests {
                 merge_parity: "clean".into(),
                 unpushed: Some(0),
                 primary_unpushed: None,
+                checkout: String::new(),
             }),
             cache: None,
             limits: Vec::new(),

--- a/src/bin/caller/presence.rs
+++ b/src/bin/caller/presence.rs
@@ -1053,6 +1053,7 @@ pub fn filter_event(event: &AppEvent, last_phase: &mut String) -> Option<Presenc
         | AppEvent::DisplayReleased { .. }
         | AppEvent::SessionDirChanged { .. }
         | AppEvent::SessionFileActivity { .. }
+        | AppEvent::SessionCwdAnnounced { .. }
         | AppEvent::PresenceUsageUpdate { .. }
         | AppEvent::PresenceLog { .. }
         | AppEvent::PresenceReady

--- a/src/bin/caller/session_supervisor/launch.rs
+++ b/src/bin/caller/session_supervisor/launch.rs
@@ -30,9 +30,45 @@ impl SessionSupervisor {
     /// Register a launched session's effective project root as its
     /// git-vitals probe target (worktree sessions pass their checkout).
     /// No-op when the daemon runs without the vitals producer.
+    ///
+    /// Fresh launches need nothing more: the backend is spawned with the
+    /// registered root as its working directory, so registration IS the
+    /// launch-time cwd seed. Resumes additionally seed the activity locus
+    /// from the resumed transcript (see
+    /// [`Self::seed_resumed_git_vitals_locus`]).
     fn register_git_vitals(&self, session_id: &str, root: &std::path::Path) {
         if let Some(targets) = self.config.git_vitals_targets.as_ref() {
             targets.register(session_id, root.to_path_buf());
+        }
+    }
+
+    /// Seed a just-registered git-vitals target with the working directory
+    /// the resumed backend session records ([`resumed_transcript_cwd`]),
+    /// BEFORE the backend spawns: the first probe tick then measures the
+    /// checkout the session actually works in instead of waiting on
+    /// write-activity heuristics (or affirming the registered root's
+    /// state). The backend's own live cwd echo (`system:init`, applied
+    /// thread settings) confirms or corrects the seed once it speaks.
+    fn seed_resumed_git_vitals_locus(
+        &self,
+        session_id: &str,
+        backend: Option<&external_agent::AgentBackend>,
+        resume_token: &str,
+        codex_home: Option<&str>,
+    ) {
+        let Some(backend) = backend else {
+            return;
+        };
+        let Some(targets) = self.config.git_vitals_targets.as_ref() else {
+            return;
+        };
+        if let Some(cwd) = resumed_transcript_cwd(
+            &self.logs_home(),
+            backend,
+            resume_token,
+            codex_home.map(std::path::Path::new),
+        ) {
+            targets.seed_locus(session_id, &cwd);
         }
     }
 
@@ -838,6 +874,12 @@ impl SessionSupervisor {
                 let codex_home = effective_session_agent_config
                     .as_ref()
                     .and_then(|config| config.codex_home.clone());
+                self.seed_resumed_git_vitals_locus(
+                    &session_id,
+                    external_backend.as_ref(),
+                    &resume_token,
+                    codex_home.as_deref(),
+                );
                 let intendant_session_id = session_log
                     .lock()
                     .map(|log| log.session_id().to_string())
@@ -972,6 +1014,18 @@ impl SessionSupervisor {
         let codex_home = effective_session_agent_config
             .as_ref()
             .and_then(|config| config.codex_home.clone());
+        // Same id keying as the registration above: the seed must land on
+        // the entry just registered.
+        self.seed_resumed_git_vitals_locus(
+            if fork {
+                &intendant_session_id
+            } else {
+                &live_session_id
+            },
+            external_backend.as_ref(),
+            &resume_token,
+            codex_home.as_deref(),
+        );
         self.activate_shared_session(session_log.clone()).await;
         self.config.bus.send(AppEvent::SessionStarted {
             // A fork materializes a NEW wrapper session: announce it under
@@ -1784,6 +1838,138 @@ pub(crate) fn external_attach_dedupe_keys(
         ids.push(id.to_string());
     }
     ids.into_iter().map(|id| format!("{source}:{id}")).collect()
+}
+
+/// Byte windows for the resumed-transcript cwd scan. The latest recorded
+/// cwd is nearly always inside the tail window (Claude Code stamps `cwd`
+/// on every record; Codex re-states it per `turn_context`); the head
+/// window is the fallback for a tail filled by cwd-less oversized records
+/// (one huge tool result) — short openers (Codex `session_meta`, a
+/// transcript's first records) live there.
+const TRANSCRIPT_CWD_TAIL_BYTES: u64 = 256 * 1024;
+const TRANSCRIPT_CWD_HEAD_BYTES: u64 = 64 * 1024;
+
+/// The LAST cwd `extract` finds among the complete JSONL lines of one
+/// chunk. `skip_first_line` drops the leading partial line of a
+/// mid-file read; a trailing partial line simply fails its JSON parse.
+fn latest_cwd_in_lines(
+    chunk: &str,
+    skip_first_line: bool,
+    extract: &impl Fn(&serde_json::Value) -> Option<String>,
+) -> Option<String> {
+    let mut lines = chunk.lines();
+    if skip_first_line {
+        let _ = lines.next();
+    }
+    let mut latest = None;
+    for line in lines {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(obj) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        if let Some(cwd) = extract(&obj) {
+            latest = Some(cwd);
+        }
+    }
+    latest
+}
+
+/// The most recent working directory a backend transcript records,
+/// through per-format `extract`, in two bounded reads (tail, then head
+/// fallback) — a resume must not pay a full parse of a multi-megabyte
+/// transcript for one field. `None` when no scanned window states a cwd.
+pub(crate) fn latest_recorded_cwd(
+    path: &Path,
+    extract: impl Fn(&serde_json::Value) -> Option<String>,
+) -> Option<PathBuf> {
+    use std::io::{Read, Seek, SeekFrom};
+    let mut file = std::fs::File::open(path).ok()?;
+    let len = file.metadata().ok()?.len();
+    let tail_start = len.saturating_sub(TRANSCRIPT_CWD_TAIL_BYTES);
+    file.seek(SeekFrom::Start(tail_start)).ok()?;
+    let mut tail = Vec::new();
+    file.read_to_end(&mut tail).ok()?;
+    // Lossy: a mid-file seek can split a multi-byte character; the
+    // replacement bytes only ever corrupt the partial line the scan
+    // skips anyway.
+    let tail = String::from_utf8_lossy(&tail);
+    if let Some(cwd) = latest_cwd_in_lines(&tail, tail_start > 0, &extract) {
+        return Some(PathBuf::from(cwd));
+    }
+    if tail_start == 0 {
+        // The tail window covered the whole file — nothing else to scan.
+        return None;
+    }
+    let mut head = vec![0u8; TRANSCRIPT_CWD_HEAD_BYTES.min(tail_start) as usize];
+    file.seek(SeekFrom::Start(0)).ok()?;
+    file.read_exact(&mut head).ok()?;
+    let head = String::from_utf8_lossy(&head);
+    latest_cwd_in_lines(&head, false, &extract).map(PathBuf::from)
+}
+
+fn non_empty_json_str(value: Option<&serde_json::Value>) -> Option<String> {
+    value
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+/// `cwd` as a Claude Code transcript line records it: a top-level field
+/// stamped on (nearly) every record — the field the session catalog's
+/// row fold reads (`ClaudeRowAccumulator`).
+pub(crate) fn claude_line_cwd(obj: &serde_json::Value) -> Option<String> {
+    non_empty_json_str(obj.get("cwd"))
+}
+
+/// `cwd` as a Codex rollout line records it: `session_meta` states the
+/// thread's launch cwd and each `turn_context` the turn's effective cwd
+/// — the fields the session catalog's accumulator reads
+/// (`CodexSessionListAccumulator`).
+pub(crate) fn codex_line_cwd(obj: &serde_json::Value) -> Option<String> {
+    match obj.get("type").and_then(|v| v.as_str())? {
+        "session_meta" | "turn_context" => non_empty_json_str(obj.get("payload")?.get("cwd")),
+        _ => None,
+    }
+}
+
+/// The working directory the resumed backend session actually RECORDS —
+/// the registration-time git-vitals locus seed. A session resumed by id
+/// can live in a checkout the registered project root knows nothing
+/// about (the observed shape: an externally created Claude Code session
+/// working in a worktree while the daemon registers the project root, so
+/// its git chip affirmed the wrong checkout's `+0/−0`). The transcript
+/// finders are the session catalog's own (`find_claude_session_file`,
+/// `find_codex_session_file_in`). `None` — no seed, the registered root
+/// stands — when the transcript can't be located or states no cwd.
+pub(crate) fn resumed_transcript_cwd(
+    home: &Path,
+    backend: &external_agent::AgentBackend,
+    resume_token: &str,
+    codex_home: Option<&Path>,
+) -> Option<PathBuf> {
+    let token = resume_token.trim();
+    if token.is_empty() {
+        return None;
+    }
+    match backend {
+        external_agent::AgentBackend::ClaudeCode => {
+            let transcript = crate::web_gateway::find_claude_session_file(home, token)?;
+            latest_recorded_cwd(&transcript, claude_line_cwd)
+        }
+        external_agent::AgentBackend::Codex => {
+            let rollout = match codex_home {
+                Some(codex_root) => {
+                    crate::codex_history::find_codex_session_file_in(codex_root, home, token)
+                }
+                None => crate::codex_history::find_codex_session_file_for_main(home, token),
+            }?;
+            latest_recorded_cwd(&rollout, codex_line_cwd)
+        }
+    }
 }
 
 #[cfg(test)]
@@ -2652,5 +2838,165 @@ mod tests {
             }
             other => panic!("expected file attachment, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn latest_recorded_cwd_scans_tail_then_head() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("t.jsonl");
+
+        // Claude shape: cwd stamped per record — the LAST one wins.
+        std::fs::write(
+            &path,
+            concat!(
+                "{\"type\":\"user\",\"cwd\":\"/repo\"}\n",
+                "{\"type\":\"assistant\",\"cwd\":\"/repo\"}\n",
+                "{\"type\":\"user\",\"cwd\":\"/repo/.claude/worktrees/wt\"}\n",
+            ),
+        )
+        .unwrap();
+        assert_eq!(
+            latest_recorded_cwd(&path, claude_line_cwd),
+            Some(PathBuf::from("/repo/.claude/worktrees/wt"))
+        );
+
+        // A tail window filled by one huge cwd-less record (the oversized
+        // tool-result shape): the head window still yields the early cwd.
+        let mut contents = String::from("{\"type\":\"user\",\"cwd\":\"/repo\"}\n");
+        contents.push_str(&format!(
+            "{{\"type\":\"assistant\",\"blob\":\"{}\"}}\n",
+            "x".repeat((TRANSCRIPT_CWD_TAIL_BYTES + 4096) as usize)
+        ));
+        std::fs::write(&path, contents).unwrap();
+        assert_eq!(
+            latest_recorded_cwd(&path, claude_line_cwd),
+            Some(PathBuf::from("/repo")),
+            "head fallback covers a cwd-less tail window"
+        );
+
+        // No cwd anywhere / no file: no seed.
+        std::fs::write(&path, "{\"type\":\"user\"}\n").unwrap();
+        assert_eq!(latest_recorded_cwd(&path, claude_line_cwd), None);
+        assert_eq!(
+            latest_recorded_cwd(&dir.path().join("gone.jsonl"), claude_line_cwd),
+            None
+        );
+    }
+
+    #[test]
+    fn codex_line_cwd_takes_turn_context_over_session_meta() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rollout.jsonl");
+        // `turn_context` re-states the effective cwd per turn and comes
+        // later, so it wins; a cwd inside an unrelated payload type (an
+        // exec command's workdir) must not.
+        std::fs::write(
+            &path,
+            concat!(
+                "{\"type\":\"session_meta\",\"payload\":{\"id\":\"t1\",\"cwd\":\"/launch\"}}\n",
+                "{\"type\":\"event_msg\",\"payload\":{\"type\":\"exec_command_begin\",\"cwd\":\"/decoy\"}}\n",
+                "{\"type\":\"turn_context\",\"payload\":{\"cwd\":\"/effective\"}}\n",
+            ),
+        )
+        .unwrap();
+        assert_eq!(
+            latest_recorded_cwd(&path, codex_line_cwd),
+            Some(PathBuf::from("/effective"))
+        );
+        // `session_meta` alone still states the launch cwd.
+        std::fs::write(
+            &path,
+            "{\"type\":\"session_meta\",\"payload\":{\"id\":\"t1\",\"cwd\":\"/launch\"}}\n",
+        )
+        .unwrap();
+        assert_eq!(
+            latest_recorded_cwd(&path, codex_line_cwd),
+            Some(PathBuf::from("/launch"))
+        );
+    }
+
+    /// The registration-time seed end-to-end: a resumed Claude Code
+    /// session whose transcript records a worktree cwd retargets the
+    /// git-vitals probe to that worktree — immediately, via
+    /// [`crate::session_vitals::GitVitalsTargets::seed_locus`], not via
+    /// write-activity heuristics.
+    #[test]
+    fn resumed_claude_transcript_cwd_seeds_the_vitals_locus() {
+        let home = tempfile::tempdir().unwrap();
+        // A real checkout shape in the temp home: repo (.git dir) with a
+        // nested linked worktree (.git file).
+        let repo = home.path().join("repo");
+        std::fs::create_dir_all(repo.join(".git")).unwrap();
+        let worktree = repo.join(".claude/worktrees/session-fork");
+        std::fs::create_dir_all(&worktree).unwrap();
+        std::fs::write(worktree.join(".git"), "gitdir: elsewhere\n").unwrap();
+
+        let token = "0caf4660-7345-4f3b-b8e7-407e59aefa5d";
+        let project_dir = home.path().join(".claude").join("projects").join("-repo");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let record = |cwd: &Path| {
+            serde_json::json!({"type": "user", "cwd": cwd.to_string_lossy()}).to_string()
+        };
+        std::fs::write(
+            project_dir.join(format!("{token}.jsonl")),
+            format!("{}\n{}\n", record(&repo), record(&worktree)),
+        )
+        .unwrap();
+
+        let recorded = resumed_transcript_cwd(
+            home.path(),
+            &external_agent::AgentBackend::ClaudeCode,
+            token,
+            None,
+        )
+        .expect("transcript states the worktree cwd");
+        assert_eq!(recorded, worktree);
+
+        // Registered at the project root (what resume registration does),
+        // then seeded with the recorded cwd: the effective probe target is
+        // the worktree from the first tick.
+        let targets = crate::session_vitals::GitVitalsTargets::default();
+        targets.register(token, repo.clone());
+        targets.seed_locus(token, &recorded);
+        assert_eq!(targets.snapshot()[0].1, worktree);
+
+        // Unknown token: no transcript, no seed.
+        assert_eq!(
+            resumed_transcript_cwd(
+                home.path(),
+                &external_agent::AgentBackend::ClaudeCode,
+                "11111111-2222-3333-4444-555555555555",
+                None,
+            ),
+            None
+        );
+    }
+
+    /// Codex parity for the seed source: the rollout's recorded cwd
+    /// resolves through the catalog's finder under an explicit codex home
+    /// (the per-session `codex_home` lane — env-free).
+    #[test]
+    fn resumed_codex_rollout_cwd_resolves_under_explicit_codex_home() {
+        let home = tempfile::tempdir().unwrap();
+        let token = "019a4c2e-77aa-4bb0-9c11-2f5e8d3a6b41";
+        let codex_root = home.path().join("custom-codex");
+        let day_dir = codex_root.join("sessions").join("2026").join("07");
+        std::fs::create_dir_all(&day_dir).unwrap();
+        std::fs::write(
+            day_dir.join(format!("rollout-2026-07-18T10-00-00-{token}.jsonl")),
+            format!(
+                "{{\"type\":\"session_meta\",\"payload\":{{\"id\":\"{token}\",\"cwd\":\"/work/thread\"}}}}\n"
+            ),
+        )
+        .unwrap();
+        assert_eq!(
+            resumed_transcript_cwd(
+                home.path(),
+                &external_agent::AgentBackend::Codex,
+                token,
+                Some(&codex_root),
+            ),
+            Some(PathBuf::from("/work/thread"))
+        );
     }
 }

--- a/src/bin/caller/session_vitals.rs
+++ b/src/bin/caller/session_vitals.rs
@@ -422,45 +422,49 @@ impl GitVitalsProber {
         let mut merge_parity = String::new();
         let mut primary_unpushed = None;
         if let Some((primary_branch, resolved_ref)) = self.primary_for(toplevel).await {
-            primary_ref = resolved_ref;
-            match self.ahead_behind(toplevel, &primary_ref).await {
+            match self.ahead_behind(toplevel, &resolved_ref).await {
                 Some((a, b)) => {
                     ahead = a;
                     behind = b;
+                    primary_ref = resolved_ref;
+
+                    merge_parity = if (ahead > 0) != (behind > 0) {
+                        // Fast-forward in one direction: trivially clean.
+                        "clean".to_string()
+                    } else if ahead > 0 && behind > 0 && merge_tree_supported() {
+                        match facts.head_oid.as_deref() {
+                            Some(head_oid) => self
+                                .merge_parity(toplevel, &primary_ref, head_oid)
+                                .await
+                                .unwrap_or_default(),
+                            None => String::new(),
+                        }
+                    } else {
+                        String::new()
+                    };
+
+                    if facts.branch != primary_branch {
+                        // No `rev-parse --verify` gate on `@{upstream}`
+                        // first: the `rev-list --count` fails to `None`
+                        // identically when the upstream doesn't resolve, so
+                        // the verify subprocess added no information.
+                        let primary_upstream = format!("{primary_branch}@{{upstream}}");
+                        primary_unpushed = self
+                            .git_count(toplevel, &format!("{primary_upstream}..{primary_branch}"))
+                            .await;
+                    }
                 }
                 // The cached primary stopped resolving (remote-tracking
-                // ref pruned, branch deleted): degrade to 0/0 for this
-                // tick — the old chain's per-call `unwrap_or(0)` — and
-                // drop the cache entry so the next tick rediscovers.
+                // ref pruned, branch deleted): drop the cache entry so the
+                // next tick rediscovers, and state NO primary-relative
+                // claims this tick — `primary_ref` stays empty, so the
+                // frontend shows its quiet "no primary to compare with"
+                // state. The old degrade-to-0/0 read as an affirmative
+                // "in sync with the primary", which a failed probe must
+                // never claim (fail open, not fail affirming).
                 None => {
                     self.primary_cache.remove(toplevel);
                 }
-            }
-
-            merge_parity = if (ahead > 0) != (behind > 0) {
-                // Fast-forward in one direction: trivially clean.
-                "clean".to_string()
-            } else if ahead > 0 && behind > 0 && merge_tree_supported() {
-                match facts.head_oid.as_deref() {
-                    Some(head_oid) => self
-                        .merge_parity(toplevel, &primary_ref, head_oid)
-                        .await
-                        .unwrap_or_default(),
-                    None => String::new(),
-                }
-            } else {
-                String::new()
-            };
-
-            if facts.branch != primary_branch {
-                // No `rev-parse --verify` gate on `@{upstream}` first: the
-                // `rev-list --count` fails to `None` identically when the
-                // upstream doesn't resolve, so the verify subprocess added
-                // no information.
-                let primary_upstream = format!("{primary_branch}@{{upstream}}");
-                primary_unpushed = self
-                    .git_count(toplevel, &format!("{primary_upstream}..{primary_branch}"))
-                    .await;
             }
         }
 
@@ -473,6 +477,10 @@ impl GitVitalsProber {
             merge_parity,
             unpushed,
             primary_unpushed,
+            checkout: toplevel
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+                .unwrap_or_default(),
         })
     }
 
@@ -969,6 +977,27 @@ impl GitTarget {
             }
         }
     }
+
+    /// Seed the locus from a FIRST-HAND statement of the session's working
+    /// directory — a resumed transcript's recorded cwd, the backend's own
+    /// init echo. Unlike [`Self::observe_write_activity`] this is not a
+    /// heuristic over tool traffic, so it applies immediately: no
+    /// sightings threshold, and a statement matching the registered root's
+    /// checkout clears any override the same way. A cwd outside any git
+    /// checkout says nothing about where to probe and changes nothing
+    /// (the registered root remains the fallback identity).
+    fn seed_locus(&mut self, cwd: &Path) {
+        let Some(checkout) = resolve_git_checkout_root(cwd) else {
+            return;
+        };
+        let home_checkout = resolve_git_checkout_root(&self.registered_root);
+        self.candidate = None;
+        self.active_locus = if Some(&checkout) == home_checkout.as_ref() {
+            None
+        } else {
+            Some(checkout)
+        };
+    }
 }
 
 /// Live registry of (session id → working dir) git-probe targets. The
@@ -1041,7 +1070,7 @@ impl GitVitalsTargets {
 
     /// Effective probe targets: the activity locus where one is active,
     /// the registered root otherwise.
-    fn snapshot(&self) -> Vec<(String, PathBuf)> {
+    pub(crate) fn snapshot(&self) -> Vec<(String, PathBuf)> {
         self.targets
             .lock()
             .expect("git vitals targets lock")
@@ -1056,6 +1085,19 @@ impl GitVitalsTargets {
         let mut targets = self.targets.lock().expect("git vitals targets lock");
         if let Some(target) = targets.get_mut(session_id.trim()) {
             target.observe_write_activity(paths);
+        }
+    }
+
+    /// Seed a session's activity locus from a first-hand working-directory
+    /// statement (see [`GitTarget::seed_locus`]) — the launch/resume path
+    /// calls this right after [`Self::register`] so the FIRST probe tick
+    /// already measures the checkout the backend actually works in, and
+    /// the backend's own cwd echo re-seeds it live. No-op for
+    /// unregistered ids.
+    pub(crate) fn seed_locus(&self, session_id: &str, cwd: &Path) {
+        let mut targets = self.targets.lock().expect("git vitals targets lock");
+        if let Some(target) = targets.get_mut(session_id.trim()) {
+            target.seed_locus(cwd);
         }
     }
 
@@ -1234,6 +1276,10 @@ pub(crate) fn spawn_session_vitals_producer(
 /// - `SessionFileActivity` folds a session's structured write paths into
 ///   its activity-locus state, retargeting the probe when the work moved
 ///   into a different checkout (see [`GitTarget::observe_write_activity`]).
+/// - `SessionCwdAnnounced` seeds the locus from the backend's own
+///   working-directory statement (Claude Code's `system:init` echo, Codex
+///   applied thread settings) — authoritative, so it retargets
+///   immediately (see [`GitTarget::seed_locus`]).
 ///
 /// Resolution runs through the hub's alias map both ways: resume lanes
 /// register the live (backend-native) id while events may carry the
@@ -1264,6 +1310,17 @@ fn spawn_git_target_maintainer(
                     for (id, _) in registry.snapshot() {
                         if hub.resolve(&id) == canonical {
                             registry.observe_write_activity(&id, &paths);
+                        }
+                    }
+                }
+                Ok(AppEvent::SessionCwdAnnounced {
+                    session_id: Some(session_id),
+                    cwd,
+                }) => {
+                    let canonical = hub.resolve(&session_id);
+                    for (id, _) in registry.snapshot() {
+                        if hub.resolve(&id) == canonical {
+                            registry.seed_locus(&id, Path::new(&cwd));
                         }
                     }
                 }
@@ -1445,6 +1502,10 @@ mod tests {
         assert_eq!((vitals.ahead, vitals.behind), (0, 0));
         assert_eq!(vitals.merge_parity, "");
         assert_eq!(vitals.primary_unpushed, None, "on the primary itself");
+        assert_eq!(
+            vitals.checkout, "work",
+            "vitals name the probed checkout's toplevel basename"
+        );
 
         // A local commit: ahead of the upstream (unpushed) and of the
         // remote primary (ahead) by the same one commit.
@@ -1474,6 +1535,47 @@ mod tests {
         let vitals = prober.probe(&work).await.expect("repo probes");
         assert_eq!(vitals.branch, "HEAD");
         assert_eq!(vitals.unpushed, None);
+    }
+
+    #[tokio::test]
+    async fn probe_fails_open_when_the_cached_primary_stops_resolving() {
+        // A cached primary whose comparison ref no longer resolves
+        // (remote-tracking ref pruned, branch deleted) must not degrade to
+        // an affirmative `+0/−0` against a dead ref: the tick states NO
+        // primary-relative claims (empty primary_ref → the frontend's
+        // quiet "no primary" state) and drops the cache entry so the next
+        // tick rediscovers honestly.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let work = repo_with_origin(dir.path());
+
+        let mut prober = GitVitalsProber::default();
+        let toplevel = prober.toplevel_for(&work).await.expect("toplevel");
+        prober.primary_cache.insert(
+            toplevel.clone(),
+            ("main".to_string(), "origin/pruned-away".to_string()),
+        );
+
+        let vitals = prober.probe(&work).await.expect("repo still probes");
+        assert_eq!(
+            vitals.primary_ref, "",
+            "no affirmative divergence against a dead comparison ref"
+        );
+        assert_eq!((vitals.ahead, vitals.behind), (0, 0));
+        assert_eq!(vitals.merge_parity, "");
+        assert_eq!(
+            vitals.primary_unpushed, None,
+            "primary-relative counts stay silent on the failed tick"
+        );
+        assert_eq!(vitals.branch, "main", "checkout-local facts still report");
+        assert!(
+            !prober.primary_cache.contains_key(&toplevel),
+            "the dead primary entry is dropped for rediscovery"
+        );
+
+        // The next tick rediscovers the real primary and the divergence
+        // claims return.
+        let vitals = prober.probe(&work).await.expect("repo probes");
+        assert_eq!(vitals.primary_ref, "origin/main");
     }
 
     #[tokio::test]
@@ -2167,6 +2269,52 @@ mod tests {
         assert_eq!(targets.demote_locus("nope", &worktree), None);
     }
 
+    #[test]
+    fn seed_locus_is_immediate_and_authoritative() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(repo.join(".git")).unwrap();
+        let worktree = repo.join(".claude/worktrees/wt");
+        std::fs::create_dir_all(&worktree).unwrap();
+        std::fs::write(worktree.join(".git"), "gitdir: elsewhere\n").unwrap();
+
+        let targets = GitVitalsTargets::default();
+        targets.register("s1", repo.clone());
+        let effective = |targets: &GitVitalsTargets| targets.snapshot()[0].1.clone();
+
+        // One first-hand statement retargets immediately — no sightings
+        // threshold (the launch/resume seed and the backend's own cwd
+        // echo are statements, not write-path heuristics).
+        targets.seed_locus("s1", &worktree.join("src"));
+        assert_eq!(effective(&targets), worktree, "one seed switches");
+
+        // A cwd outside any checkout says nothing — the locus stands.
+        let outside = temp.path().join("no-repo/deep");
+        std::fs::create_dir_all(&outside).unwrap();
+        targets.seed_locus("s1", &outside);
+        assert_eq!(effective(&targets), worktree, "checkout-less seed is inert");
+
+        // A seed pending write-activity candidate is superseded: the
+        // statement wins and clears it (repo sighting below starts over).
+        targets.observe_write_activity("s1", &[repo.join("x.rs").to_string_lossy().into_owned()]);
+        targets.seed_locus("s1", &worktree);
+        targets.observe_write_activity("s1", &[repo.join("x.rs").to_string_lossy().into_owned()]);
+        assert_eq!(
+            effective(&targets),
+            worktree,
+            "seed cleared the stale candidate — one sighting cannot switch"
+        );
+
+        // A statement matching the registered root's checkout clears the
+        // override the same way (immediately).
+        targets.seed_locus("s1", &repo.join("src"));
+        assert_eq!(effective(&targets), repo, "home statement clears the locus");
+
+        // Unregistered ids are a calm no-op.
+        targets.seed_locus("nope", &worktree);
+        assert_eq!(targets.snapshot().len(), 1);
+    }
+
     /// Seed one restored-session record (`session_meta.json`) under
     /// `<home>/.intendant/logs/<id>/`, the store layout the boot scan
     /// walks. Returns the meta path (tests stagger its mtime).
@@ -2446,6 +2594,88 @@ mod tests {
         tokio::time::timeout(deadline, wait_for_branch(&mut rx, "main"))
             .await
             .expect("dead locus falls back to the registered root");
+    }
+
+    #[tokio::test]
+    async fn announced_cwd_retargets_the_probe_immediately() {
+        // End-to-end through the producer: the backend STATES its working
+        // directory (`AppEvent::SessionCwdAnnounced` — a system:init echo
+        // or the registration-time transcript seed re-announced) and the
+        // git chip must measure that checkout from the next tick — ONE
+        // event, no write-activity sightings, and the emitted vitals name
+        // the checkout they were measured at.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        git_cmd(root, &["init", "-q", "-b", "main"]);
+        std::fs::write(root.join("a.txt"), "one\n").unwrap();
+        git_cmd(root, &["add", "."]);
+        git_cmd(root, &["commit", "-qm", "base"]);
+        let worktree = root.join(".claude/worktrees/session-fork");
+        std::fs::create_dir_all(worktree.parent().unwrap()).unwrap();
+        git_cmd(
+            root,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "worktree-announced",
+                worktree.to_str().unwrap(),
+            ],
+        );
+
+        let bus = EventBus::new();
+        let mut rx = bus.subscribe();
+        let (targets, _producer) = spawn_session_vitals_producer(bus.clone(), Vec::new());
+        targets.register("s-announce", root.to_path_buf());
+
+        let deadline = std::time::Duration::from_secs(20);
+        async fn wait_for_branch(
+            rx: &mut tokio::sync::broadcast::Receiver<AppEvent>,
+            want_branch: &str,
+            want_checkout: &str,
+        ) {
+            loop {
+                if let Ok(AppEvent::SessionVitals { session_id, vitals }) = rx.recv().await {
+                    assert_eq!(session_id, "s-announce");
+                    if let Some(git) = vitals.git.as_ref() {
+                        if git.branch == want_branch {
+                            assert_eq!(
+                                git.checkout, want_checkout,
+                                "vitals must name the measured checkout"
+                            );
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+        // The registered root probes first (its checkout basename is the
+        // tempdir's name).
+        let root_name = root.file_name().unwrap().to_string_lossy().into_owned();
+        tokio::time::timeout(deadline, wait_for_branch(&mut rx, "main", &root_name))
+            .await
+            .expect("registered root probes before any announcement");
+
+        // ONE first-hand statement — no hysteresis.
+        bus.send(AppEvent::SessionCwdAnnounced {
+            session_id: Some("s-announce".into()),
+            cwd: worktree.to_string_lossy().into_owned(),
+        });
+        tokio::time::timeout(
+            deadline,
+            wait_for_branch(&mut rx, "worktree-announced", "session-fork"),
+        )
+        .await
+        .expect("one announced cwd retargets the probe");
+
+        // Announcing the registered root clears the override immediately.
+        bus.send(AppEvent::SessionCwdAnnounced {
+            session_id: Some("s-announce".into()),
+            cwd: root.to_string_lossy().into_owned(),
+        });
+        tokio::time::timeout(deadline, wait_for_branch(&mut rx, "main", &root_name))
+            .await
+            .expect("announcing the home checkout switches back");
     }
 
     #[tokio::test]

--- a/src/bin/caller/session_vitals.rs
+++ b/src/bin/caller/session_vitals.rs
@@ -1674,11 +1674,13 @@ mod tests {
         assert_eq!(prober.primary_cache.len(), 1, "discovery cached");
 
         // The remote-tracking ref vanishes (remote pruned): the cached
-        // primary stops resolving. The failing tick degrades to 0/0 —
-        // the old chain's unwrap_or(0) — and invalidates the entry...
+        // primary stops resolving. The failing tick states NO
+        // primary-relative claims (fail open — an affirmative +0/−0
+        // against a dead ref would read as "in sync") and invalidates
+        // the entry...
         git_cmd(&work, &["update-ref", "-d", "refs/remotes/origin/main"]);
         let vitals = prober.probe(&work).await.expect("repo probes");
-        assert_eq!(vitals.primary_ref, "origin/main", "stale name for one tick");
+        assert_eq!(vitals.primary_ref, "", "no stale claim on the failed tick");
         assert_eq!((vitals.ahead, vitals.behind), (0, 0));
         assert!(
             prober.primary_cache.is_empty(),

--- a/src/bin/caller/thread_actions.rs
+++ b/src/bin/caller/thread_actions.rs
@@ -3342,6 +3342,10 @@ pub(crate) fn handle_idle_codex_subagent_event(
             // writes must not retarget any supervising session's git chip
             // (mirrors the drain's primary-conversation-only gating).
         }
+        external_agent::AgentEvent::CwdAnnounced { .. } => {
+            // Same gating as FileActivity: a subagent thread's working
+            // directory is not the supervising session's locus.
+        }
         external_agent::AgentEvent::ToolOutputDelta { item_id, text } => {
             let tool_output_limiter = stats
                 .codex_subagent_tool_output_limiters

--- a/static/app/39-session-windows.js
+++ b/static/app/39-session-windows.js
@@ -1149,9 +1149,16 @@ const VITALS_SYMBOLS = {
     priority: 40,
     quiet: 'No primary branch to compare with.',
     chip: (v) => `+${v.ahead}/−${v.behind}`,
-    explain: (v) => [
-      `Compared with ${v.primaryRef}: this branch has ${v.ahead} commit${v.ahead === 1 ? '' : 's'} of its own and is missing ${v.behind} from there.`,
-    ],
+    explain: (v) => {
+      const lines = [
+        `Compared with ${v.primaryRef}: this branch has ${v.ahead} commit${v.ahead === 1 ? '' : 's'} of its own and is missing ${v.behind} from there.`,
+      ];
+      // Honesty line: WHERE the numbers were measured. The probe follows
+      // the checkout the agent actually works in (which can be a worktree,
+      // not the registered project root), and the popover says so.
+      if (v.checkout) lines.push(`vs ${v.primaryRef} · at ${v.checkout}`);
+      return lines;
+    },
   },
   parity: {
     label: 'Merge readiness',
@@ -1407,6 +1414,7 @@ function vitalsChipModels(vitals, meta, sessionId) {
         ahead: Number(git.ahead) || 0,
         behind: Number(git.behind) || 0,
         primaryRef,
+        checkout: String(git.checkout || '').trim(),
       });
     }
     const parity = String(git.mergeParity || '').trim();


### PR DESCRIPTION
## Problem

Git vitals chips (branch / divergence) for external sessions probe the session's REGISTERED project root, not the checkout the backend actually works in. A Claude Code session resumed by id can work in a worktree the registration knows nothing about: its chip affirmed the root's clean `+0/−0` while the real checkout sat hundreds of commits behind. The existing activity-locus follow needs two structural write sightings (Write/Edit only — Bash and reads never emit), and registration resets the locus on every resume, so the chip could stay wrong indefinitely.

## Mechanism

**Seed at registration, before spawn.** On external resume (both the attach lane and the task lane), the supervisor derives the backend's actual cwd from the resumed transcript's recorded cwd — Claude Code transcripts stamp `cwd` on their records; Codex rollouts state it in `session_meta` / `turn_context` — located through the session catalog's own finders (`find_claude_session_file`, `find_codex_session_file_in`, honoring a per-session codex home) and read in two bounded windows (256 KiB tail, 64 KiB head fallback), never a full transcript parse. The cwd seeds the probe target as an **activity locus** (`GitVitalsTargets::seed_locus`): immediate, no sightings threshold, while the registered root remains the fallback identity — the demote ladder is unchanged, so a stale seed degrades to the root on its first failed probe. Fresh launches need no seed: the backend spawns with the registered root as its working directory.

**Live confirmation.** Claude Code's `system:init` message carries `cwd`; the adapter (which previously ignored it) now emits `AgentEvent::CwdAnnounced` once per distinct value (init re-fires every user message). Codex parity was cheap: `thread/settings/updated` already states the applied `cwd` (previously only logged) — it now rides the same lane. The drain forwards both as `AppEvent::SessionCwdAnnounced` (primary conversation only — side threads and subagents never retarget the supervising chip), and the git-target maintainer folds it as an authoritative locus seed through the identity alias map.

**Honesty layer.** `SessionGitVitals` gains a wire-additive `checkout` field (probed toplevel's basename). The dashboard divergence popover names where the numbers were measured: `vs origin/main · at <checkout>`.

**Fail-open hardening.** When the cached primary's comparison ref stops resolving, the tick no longer degrades to an affirmative `+0/−0`: `primary_ref` stays empty (the frontend's existing quiet "no primary" state), no merge-parity or primary-unpushed claims are made, and the dropped cache entry rediscovers next tick.

## Tests

- seed-from-transcript: fixture CC JSONL with cwd entries → locus target (end-to-end through the finder + registry); Codex rollout under an explicit codex home
- tail/head window scan behavior incl. the oversized-record head fallback
- `seed_locus` semantics: immediate switch, home statement clears, checkout-less cwd inert, candidate superseded
- CC init cwd parse: once per distinct value, silent re-echo, blank/absent never emits
- Codex `thread/settings/updated` emits the announce alongside its log
- producer end-to-end: one `SessionCwdAnnounced` retargets the probe (vs two sightings for write activity) and emitted vitals name the checkout
- fail-open arm: no `primary_ref` on the failed tick, cache dropped, rediscovery next tick
- `checkout` wire round-trip + legacy-emission default

## Notes

Frontend change is minimal (divergence popover values + one explain line); `static/app.html` regenerated from fragments.