### PR TITLE
gateway: stamp every response with x-intendant-app-build for stale-tab nudge

### DIFF
--- a/src/bin/caller/dashboard_control/api_sessions.rs
+++ b/src/bin/caller/dashboard_control/api_sessions.rs
@@ -3268,14 +3268,24 @@ mod tests {
         }
         let text = String::from_utf8(raw).unwrap();
         let head_end = text.find("\r\n\r\n").expect("head/body split") + 4;
+        // The build stamp is an HTTP-lane-only header (the serialization
+        // seam prepends it to every rendered head); the tunnel lane below
+        // has no HTTP head at all — its frames are datachannel JSON, and
+        // its stale-build signal is the tunnel handshake's own
+        // `app_build` check — so the lanes' parity contract stays the
+        // event-line sequence, unaffected by the header.
         assert_eq!(
             &text[..head_end],
-            "HTTP/1.1 200 OK\r\n\
-             Content-Type: application/x-ndjson\r\n\
-             Cache-Control: no-cache\r\n\
-             Connection: close\r\n\
-             Vary: Origin\r\n\
-             \r\n"
+            format!(
+                "HTTP/1.1 200 OK\r\n\
+                 x-intendant-app-build: {}\r\n\
+                 Content-Type: application/x-ndjson\r\n\
+                 Cache-Control: no-cache\r\n\
+                 Connection: close\r\n\
+                 Vary: Origin\r\n\
+                 \r\n",
+                crate::web_gateway::app_build()
+            )
         );
         assert_eq!(&text[head_end..], lines.concat());
 

--- a/src/bin/caller/web_gateway/http.rs
+++ b/src/bin/caller/web_gateway/http.rs
@@ -904,6 +904,23 @@ impl HttpResponse {
 
     pub(crate) fn into_bytes(self) -> Vec<u8> {
         let mut head = format!("HTTP/1.1 {}\r\n", self.status);
+        // Every buffered gateway response carries the served-bundle build
+        // stamp. The /ws reconnect and control-tunnel handshakes already
+        // re-check `/config`'s `app_build`, but a tab with neither event
+        // lane alive (e.g. WebKit + mTLS hangs client-cert WebSockets and
+        // the tunnel can be down) still makes plain HTTP API calls
+        // constantly — this header is the lane that reaches it, so
+        // `maybeNudgeStaleBuild` can fire after a daemon upgrade instead
+        // of the tab running stale code indefinitely. Emitted here at
+        // serialization time — not as a `headers` entry — so no posture
+        // helper can strip or reorder it; empty stamp (pre-stamp
+        // artifact) emits nothing, which the SPA treats as "no signal".
+        let app_build = super::static_assets::app_build();
+        if !app_build.is_empty() {
+            head.push_str("x-intendant-app-build: ");
+            head.push_str(app_build);
+            head.push_str("\r\n");
+        }
         for (name, value) in &self.headers {
             head.push_str(name);
             head.push_str(": ");
@@ -1471,29 +1488,38 @@ mod tests {
     #[test]
     fn http_response_builder_reproduces_legacy_framing_byte_for_byte() {
         // The five string helpers now serialize through HttpResponse; pin
-        // the exact historical bytes so the rebase stays byte-identical.
+        // the exact historical bytes (plus the serialization-time build
+        // stamp, minted from the embedded artifact) so the rebase stays
+        // byte-identical.
+        let stamp = crate::web_gateway::static_assets::app_build();
         assert_eq!(
             json_response("200 OK", "{\"ok\":true}".to_string()),
-            "HTTP/1.1 200 OK\r\n\
-             Content-Type: application/json\r\n\
-             Content-Length: 11\r\n\
-             Cache-Control: no-cache\r\n\
-             Connection: close\r\n\
-             \r\n\
-             {\"ok\":true}"
+            format!(
+                "HTTP/1.1 200 OK\r\n\
+                 x-intendant-app-build: {stamp}\r\n\
+                 Content-Type: application/json\r\n\
+                 Content-Length: 11\r\n\
+                 Cache-Control: no-cache\r\n\
+                 Connection: close\r\n\
+                 \r\n\
+                 {{\"ok\":true}}"
+            )
         );
         assert_eq!(
             html_response("404 Not Found", "<h1>gone</h1>".to_string()),
-            "HTTP/1.1 404 Not Found\r\n\
-             Content-Type: text/html; charset=utf-8\r\n\
-             Content-Length: 13\r\n\
-             Cache-Control: no-cache\r\n\
-             Access-Control-Allow-Origin: *\r\n\
-             Content-Security-Policy: frame-ancestors 'none'\r\n\
-             X-Frame-Options: DENY\r\n\
-             Connection: close\r\n\
-             \r\n\
-             <h1>gone</h1>"
+            format!(
+                "HTTP/1.1 404 Not Found\r\n\
+                 x-intendant-app-build: {stamp}\r\n\
+                 Content-Type: text/html; charset=utf-8\r\n\
+                 Content-Length: 13\r\n\
+                 Cache-Control: no-cache\r\n\
+                 Access-Control-Allow-Origin: *\r\n\
+                 Content-Security-Policy: frame-ancestors 'none'\r\n\
+                 X-Frame-Options: DENY\r\n\
+                 Connection: close\r\n\
+                 \r\n\
+                 <h1>gone</h1>"
+            )
         );
         // The builder's CORS postures match the historical
         // post-processor bytes (the string-form fleet helper is gone —
@@ -1509,29 +1535,74 @@ mod tests {
             HttpResponse::json("200 OK", "{}")
                 .fleet_cors(Some("https://fleet.example"))
                 .into_string(),
-            "HTTP/1.1 200 OK\r\n\
-             Content-Type: application/json\r\n\
-             Content-Length: 2\r\n\
-             Cache-Control: no-cache\r\n\
-             Connection: close\r\n\
-             Access-Control-Allow-Origin: https://fleet.example\r\n\
-             Vary: Origin\r\n\
-             \r\n\
-             {}"
+            format!(
+                "HTTP/1.1 200 OK\r\n\
+                 x-intendant-app-build: {stamp}\r\n\
+                 Content-Type: application/json\r\n\
+                 Content-Length: 2\r\n\
+                 Cache-Control: no-cache\r\n\
+                 Connection: close\r\n\
+                 Access-Control-Allow-Origin: https://fleet.example\r\n\
+                 Vary: Origin\r\n\
+                 \r\n\
+                 {{}}"
+            )
         );
         assert_eq!(
             HttpResponse::json("200 OK", "{}")
                 .fleet_cors(None)
                 .into_string(),
-            "HTTP/1.1 200 OK\r\n\
-             Content-Type: application/json\r\n\
-             Content-Length: 2\r\n\
-             Cache-Control: no-cache\r\n\
-             Connection: close\r\n\
-             Vary: Origin\r\n\
-             \r\n\
-             {}"
+            format!(
+                "HTTP/1.1 200 OK\r\n\
+                 x-intendant-app-build: {stamp}\r\n\
+                 Content-Type: application/json\r\n\
+                 Content-Length: 2\r\n\
+                 Cache-Control: no-cache\r\n\
+                 Connection: close\r\n\
+                 Vary: Origin\r\n\
+                 \r\n\
+                 {{}}"
+            )
         );
+    }
+
+    #[test]
+    fn every_buffered_response_carries_the_app_build_header() {
+        // The stale-tab reload nudge's HTTP lane: a tab with neither
+        // event lane alive (WebKit + mTLS, tunnel down) only hears a new
+        // daemon build through response headers on its plain API calls.
+        // The stamp is emitted at the single serialization seam, so every
+        // buffered shape carries it — exactly once, right after the
+        // status line, with the same value `/config` serves as
+        // `app_build`.
+        let stamp = crate::web_gateway::static_assets::app_build();
+        assert!(
+            !stamp.is_empty(),
+            "embedded app.html must carry a minted build stamp"
+        );
+        let expected = format!("x-intendant-app-build: {stamp}\r\n");
+        for response in [
+            json_response("200 OK", "{}".to_string()),
+            html_response("200 OK", "<p>hi</p>".to_string()),
+            HttpResponse::with_content("200 OK", "text/plain", "x").into_string(),
+            HttpResponse::json("404 Not Found", "{}")
+                .connection_reuse(true)
+                .into_string(),
+        ] {
+            assert_eq!(
+                response.matches("x-intendant-app-build:").count(),
+                1,
+                "exactly one build-stamp header: {response}"
+            );
+            let after_status = response
+                .split_once("\r\n")
+                .map(|(_, rest)| rest)
+                .unwrap_or_default();
+            assert!(
+                after_status.starts_with(&expected),
+                "build stamp must lead the header block: {response}"
+            );
+        }
     }
 
     #[test]

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -3074,13 +3074,20 @@ mod tests {
     // exactly like `/api/sessions`.
 
     /// The posture-rendered head with no validated cross-origin caller,
-    /// byte for byte.
-    pub(super) const SESSIONS_STREAM_HEAD_GOLDEN: &str = "HTTP/1.1 200 OK\r\n\
-         Content-Type: application/x-ndjson\r\n\
-         Cache-Control: no-cache\r\n\
-         Connection: close\r\n\
-         Vary: Origin\r\n\
-         \r\n";
+    /// byte for byte (the serialization seam prepends the build stamp of
+    /// the embedded dashboard bundle to every rendered head).
+    pub(super) fn sessions_stream_head_golden() -> String {
+        format!(
+            "HTTP/1.1 200 OK\r\n\
+             x-intendant-app-build: {}\r\n\
+             Content-Type: application/x-ndjson\r\n\
+             Cache-Control: no-cache\r\n\
+             Connection: close\r\n\
+             Vary: Origin\r\n\
+             \r\n",
+            crate::web_gateway::static_assets::app_build()
+        )
+    }
 
     #[tokio::test]
     async fn golden_sessions_stream_http_head_is_pinned() {
@@ -3109,7 +3116,7 @@ mod tests {
         let head = stream_response_http_head(status, &content_type, headers, row_cors, None);
         assert_eq!(
             String::from_utf8(head).unwrap(),
-            SESSIONS_STREAM_HEAD_GOLDEN
+            sessions_stream_head_golden()
         );
     }
 

--- a/src/bin/caller/web_gateway/mod.rs
+++ b/src/bin/caller/web_gateway/mod.rs
@@ -555,10 +555,12 @@ mod tests {
     /// The sink's bare JSON framing (`Connection` tail only, NO
     /// `Cache-Control`), spelled out literally — the shape's historical
     /// wildcard ACAO is retired (the own-origin row posture emits no
-    /// CORS header).
+    /// CORS header). The serialization seam prepends the embedded
+    /// bundle's build stamp.
     fn golden_diagnostics_transcript(status_line: &str, body: &str) -> String {
         format!(
-            "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            "HTTP/1.1 {status_line}\r\nx-intendant-app-build: {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            crate::web_gateway::static_assets::app_build(),
             body.len()
         )
     }

--- a/src/bin/caller/web_gateway/routes_access.rs
+++ b/src/bin/caller/web_gateway/routes_access.rs
@@ -4533,10 +4533,12 @@ mod tests {
     }
 
     /// The canonical JSON framing (`Cache-Control` + `Connection` tail),
-    /// spelled out literally.
+    /// spelled out literally (the serialization seam prepends the
+    /// embedded bundle's build stamp).
     fn golden_access_canonical_json_transcript(status_line: &str, body: &str) -> String {
         format!(
-            "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n{body}",
+            "HTTP/1.1 {status_line}\r\nx-intendant-app-build: {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n{body}",
+            crate::web_gateway::static_assets::app_build(),
             body.len()
         )
     }
@@ -4554,7 +4556,8 @@ mod tests {
             None => String::new(),
         };
         format!(
-            "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\n{echo}Vary: Origin\r\n\r\n{body}",
+            "HTTP/1.1 {status_line}\r\nx-intendant-app-build: {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\n{echo}Vary: Origin\r\n\r\n{body}",
+            crate::web_gateway::static_assets::app_build(),
             body.len()
         )
     }
@@ -4572,7 +4575,8 @@ mod tests {
             None => String::new(),
         };
         format!(
-            "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-store\r\nConnection: close\r\n{echo}Vary: Origin\r\n\r\n{body}",
+            "HTTP/1.1 {status_line}\r\nx-intendant-app-build: {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-store\r\nConnection: close\r\n{echo}Vary: Origin\r\n\r\n{body}",
+            crate::web_gateway::static_assets::app_build(),
             body.len()
         )
     }
@@ -5425,7 +5429,8 @@ mod tests {
     /// The public-CORS JSON framing: canonical tail, wildcard ACAO last.
     fn golden_access_public_json_transcript(status_line: &str, body: &str) -> String {
         format!(
-            "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\nAccess-Control-Allow-Origin: *\r\n\r\n{body}",
+            "HTTP/1.1 {status_line}\r\nx-intendant-app-build: {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\nAccess-Control-Allow-Origin: *\r\n\r\n{body}",
+            crate::web_gateway::static_assets::app_build(),
             body.len()
         )
     }

--- a/src/bin/caller/web_gateway/routes_files.rs
+++ b/src/bin/caller/web_gateway/routes_files.rs
@@ -3575,10 +3575,12 @@ mod tests {
         response
     }
 
-    /// The historical `json_response` framing, spelled out literally.
+    /// The historical `json_response` framing, spelled out literally (the
+    /// serialization seam prepends the embedded bundle's build stamp).
     fn golden_json_transcript(status_line: &str, body: &str) -> String {
         format!(
-            "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n{body}",
+            "HTTP/1.1 {status_line}\r\nx-intendant-app-build: {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n{body}",
+            crate::web_gateway::static_assets::app_build(),
             body.len()
         )
     }
@@ -3696,7 +3698,8 @@ mod tests {
         })
         .await;
         let mut expected = format!(
-            "HTTP/1.1 200 OK\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: {}\r\nAccept-Ranges: bytes\r\nX-Content-Sha256: {}\r\nContent-Disposition: attachment; filename=\"golden.txt\"\r\nCache-Control: no-cache\r\nAccess-Control-Expose-Headers: X-Content-Sha256\r\nConnection: close\r\n\r\n",
+            "HTTP/1.1 200 OK\r\nx-intendant-app-build: {}\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: {}\r\nAccept-Ranges: bytes\r\nX-Content-Sha256: {}\r\nContent-Disposition: attachment; filename=\"golden.txt\"\r\nCache-Control: no-cache\r\nAccess-Control-Expose-Headers: X-Content-Sha256\r\nConnection: close\r\n\r\n",
+            crate::web_gateway::static_assets::app_build(),
             GOLDEN_READ_CONTENT.len(),
             fs_sha256_hex(GOLDEN_READ_CONTENT),
         )
@@ -3721,9 +3724,11 @@ mod tests {
         })
         .await;
         // A partial read carries Content-Range instead of the sha header.
-        let mut expected = "HTTP/1.1 206 Partial Content\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: 10\r\nAccept-Ranges: bytes\r\nContent-Range: bytes 7-16/26\r\nContent-Disposition: attachment; filename=\"golden.txt\"\r\nCache-Control: no-cache\r\nAccess-Control-Expose-Headers: X-Content-Sha256\r\nConnection: close\r\n\r\n"
-            .to_string()
-            .into_bytes();
+        let mut expected = format!(
+            "HTTP/1.1 206 Partial Content\r\nx-intendant-app-build: {}\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: 10\r\nAccept-Ranges: bytes\r\nContent-Range: bytes 7-16/26\r\nContent-Disposition: attachment; filename=\"golden.txt\"\r\nCache-Control: no-cache\r\nAccess-Control-Expose-Headers: X-Content-Sha256\r\nConnection: close\r\n\r\n",
+            crate::web_gateway::static_assets::app_build(),
+        )
+        .into_bytes();
         expected.extend_from_slice(&GOLDEN_READ_CONTENT[7..17]);
         assert_eq!(transcript(&response), transcript(&expected));
     }
@@ -3745,7 +3750,8 @@ mod tests {
         .await;
         let body = r#"{"error":"range is not satisfiable"}"#;
         let expected = format!(
-            "HTTP/1.1 416 Range Not Satisfiable\r\nContent-Type: application/json\r\nContent-Length: {}\r\nContent-Range: bytes */26\r\nAccept-Ranges: bytes\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n{body}",
+            "HTTP/1.1 416 Range Not Satisfiable\r\nx-intendant-app-build: {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nContent-Range: bytes */26\r\nAccept-Ranges: bytes\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n{body}",
+            crate::web_gateway::static_assets::app_build(),
             body.len()
         );
         assert_eq!(transcript(&response), expected);
@@ -4271,9 +4277,10 @@ mod tests {
         let text = String::from_utf8_lossy(&response);
         let (head, resp_body) = text.split_once("\r\n\r\n").expect("split");
         assert!(
-            head.starts_with(
-                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: "
-            ),
+            head.starts_with(&format!(
+                "HTTP/1.1 200 OK\r\nx-intendant-app-build: {}\r\nContent-Type: application/json\r\nContent-Length: ",
+                crate::web_gateway::static_assets::app_build()
+            )),
             "{text}"
         );
         assert!(text.contains(upload_golden_tail()), "{head}");
@@ -4320,9 +4327,10 @@ mod tests {
         let text = String::from_utf8_lossy(&response);
         let (head, resp_body) = text.split_once("\r\n\r\n").expect("split");
         assert!(
-            head.starts_with(
-                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: "
-            ),
+            head.starts_with(&format!(
+                "HTTP/1.1 200 OK\r\nx-intendant-app-build: {}\r\nContent-Type: application/json\r\nContent-Length: ",
+                crate::web_gateway::static_assets::app_build()
+            )),
             "{text}"
         );
         assert!(text.contains(upload_golden_tail()), "{head}");
@@ -4410,7 +4418,8 @@ mod tests {
         })
         .await;
         let expected = format!(
-            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 2\r\n{}[]",
+            "HTTP/1.1 200 OK\r\nx-intendant-app-build: {}\r\nContent-Type: application/json\r\nContent-Length: 2\r\n{}[]",
+            crate::web_gateway::static_assets::app_build(),
             upload_golden_tail()
         );
         assert_eq!(String::from_utf8_lossy(&response), expected);
@@ -4430,7 +4439,8 @@ mod tests {
         .await;
         let body = r#"{"error":"upload not found"}"#;
         let expected = format!(
-            "HTTP/1.1 404 Not Found\r\nContent-Type: application/json\r\nContent-Length: {}\r\n{}{}",
+            "HTTP/1.1 404 Not Found\r\nx-intendant-app-build: {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n{}{}",
+            crate::web_gateway::static_assets::app_build(),
             body.len(),
             upload_golden_tail(),
             body
@@ -4455,7 +4465,8 @@ mod tests {
         .await;
         let body = r#"{"ok":true}"#;
         let expected = format!(
-            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n{}",
+            "HTTP/1.1 200 OK\r\nx-intendant-app-build: {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n{}",
+            crate::web_gateway::static_assets::app_build(),
             body.len(),
             body
         );

--- a/src/bin/caller/web_gateway/routes_peers.rs
+++ b/src/bin/caller/web_gateway/routes_peers.rs
@@ -2929,10 +2929,12 @@ mod tests {
     }
 
     /// The peers sub-router's historical JSON framing, spelled out
-    /// literally.
+    /// literally (the serialization seam prepends the embedded bundle's
+    /// build stamp).
     fn golden_peers_transcript(status_line: &str, body: &str) -> String {
         format!(
-            "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nAccess-Control-Allow-Methods: GET, POST, DELETE, OPTIONS\r\nAccess-Control-Allow-Headers: Content-Type\r\nConnection: close\r\n\r\n{body}",
+            "HTTP/1.1 {status_line}\r\nx-intendant-app-build: {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nAccess-Control-Allow-Methods: GET, POST, DELETE, OPTIONS\r\nAccess-Control-Allow-Headers: Content-Type\r\nConnection: close\r\n\r\n{body}",
+            crate::web_gateway::static_assets::app_build(),
             body.len()
         )
     }
@@ -2941,7 +2943,8 @@ mod tests {
     /// methods list.
     fn golden_coordinator_transcript(status_line: &str, body: &str) -> String {
         format!(
-            "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nAccess-Control-Allow-Methods: POST, OPTIONS\r\nAccess-Control-Allow-Headers: Content-Type\r\nConnection: close\r\n\r\n{body}",
+            "HTTP/1.1 {status_line}\r\nx-intendant-app-build: {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nAccess-Control-Allow-Methods: POST, OPTIONS\r\nAccess-Control-Allow-Headers: Content-Type\r\nConnection: close\r\n\r\n{body}",
+            crate::web_gateway::static_assets::app_build(),
             body.len()
         )
     }

--- a/src/bin/caller/web_gateway/routes_sessions.rs
+++ b/src/bin/caller/web_gateway/routes_sessions.rs
@@ -6791,10 +6791,12 @@ mod tests {
     }
 
     /// The canonical JSON framing (`Cache-Control` + `Connection` tail):
-    /// detail and context-snapshot responses, spelled out literally.
+    /// detail and context-snapshot responses, spelled out literally (the
+    /// serialization seam prepends the embedded bundle's build stamp).
     fn golden_session_json_transcript(status_line: &str, body: &str) -> String {
         format!(
-            "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n{body}",
+            "HTTP/1.1 {status_line}\r\nx-intendant-app-build: {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n{body}",
+            crate::web_gateway::static_assets::app_build(),
             body.len()
         )
     }
@@ -6807,7 +6809,8 @@ mod tests {
     /// pinned separately below).
     fn golden_session_fleet_json_transcript(status_line: &str, body: &str) -> String {
         format!(
-            "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\nVary: Origin\r\n\r\n{body}",
+            "HTTP/1.1 {status_line}\r\nx-intendant-app-build: {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\nVary: Origin\r\n\r\n{body}",
+            crate::web_gateway::static_assets::app_build(),
             body.len()
         )
     }
@@ -7396,7 +7399,8 @@ mod tests {
     /// The text/plain framing (report/asset error bodies), spelled out.
     fn golden_text_plain_transcript(status_line: &str, body: &str) -> String {
         format!(
-            "HTTP/1.1 {status_line}\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            "HTTP/1.1 {status_line}\r\nx-intendant-app-build: {}\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            crate::web_gateway::static_assets::app_build(),
             body.len()
         )
     }
@@ -7404,7 +7408,8 @@ mod tests {
     /// The immutable-asset framing (recording segments, frame images).
     fn golden_public_asset_transcript(content_type: &str, bytes: &[u8]) -> Vec<u8> {
         let mut expected = format!(
-            "HTTP/1.1 200 OK\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nCache-Control: public, max-age=3600\r\nConnection: close\r\n\r\n",
+            "HTTP/1.1 200 OK\r\nx-intendant-app-build: {}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nCache-Control: public, max-age=3600\r\nConnection: close\r\n\r\n",
+            crate::web_gateway::static_assets::app_build(),
             bytes.len()
         )
         .into_bytes();
@@ -7565,7 +7570,8 @@ mod tests {
         // builds byte-identical); the framing around them is the pin.
         let bytes = build_session_report_zip(&log_dir).unwrap();
         let mut expected = format!(
-            "HTTP/1.1 200 OK\r\nContent-Type: application/zip\r\nContent-Length: {}\r\nContent-Disposition: attachment; filename=\"intendant-session-{session_id}.zip\"\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n",
+            "HTTP/1.1 200 OK\r\nx-intendant-app-build: {}\r\nContent-Type: application/zip\r\nContent-Length: {}\r\nContent-Disposition: attachment; filename=\"intendant-session-{session_id}.zip\"\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n",
+            crate::web_gateway::static_assets::app_build(),
             bytes.len()
         )
         .into_bytes();
@@ -7696,7 +7702,8 @@ mod tests {
         .await;
         let m3u8 = "#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-MEDIA-SEQUENCE:0\n#EXT-X-TARGETDURATION:2\n#EXTINF:2.000,\nseg_00001.mp4\n#EXT-X-ENDLIST\n";
         let expected = format!(
-            "HTTP/1.1 200 OK\r\nContent-Type: application/vnd.apple.mpegurl\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n{m3u8}",
+            "HTTP/1.1 200 OK\r\nx-intendant-app-build: {}\r\nContent-Type: application/vnd.apple.mpegurl\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n{m3u8}",
+            crate::web_gateway::static_assets::app_build(),
             m3u8.len()
         );
         assert_eq!(golden_transcript(&response), expected);

--- a/src/bin/caller/web_gateway/routes_transfers.rs
+++ b/src/bin/caller/web_gateway/routes_transfers.rs
@@ -1673,6 +1673,9 @@ mod tests {
     /// dispatch arms use.
     #[tokio::test]
     async fn golden_http_transcripts_pin_download_and_commit_shapes() {
+        // The serialization seam prepends the embedded bundle's build
+        // stamp to every rendered head.
+        let stamp = crate::web_gateway::static_assets::app_build();
         let dir = tempfile::tempdir().unwrap();
         let project = dir.path().join("project");
         let dest_dir = dir.path().join("dest");
@@ -1708,6 +1711,7 @@ mod tests {
         let sha = fs_sha256_hex(b"hello transfer");
         let expected_full = format!(
             "HTTP/1.1 200 OK\r\n\
+             x-intendant-app-build: {stamp}\r\n\
              Content-Type: text/plain; charset=utf-8\r\n\
              Content-Length: 14\r\n\
              Accept-Ranges: bytes\r\n\
@@ -1733,7 +1737,9 @@ mod tests {
             )
             .await,
         );
-        let expected_partial = "HTTP/1.1 206 Partial Content\r\n\
+        let expected_partial = format!(
+            "HTTP/1.1 206 Partial Content\r\n\
+             x-intendant-app-build: {stamp}\r\n\
              Content-Type: text/plain; charset=utf-8\r\n\
              Content-Length: 8\r\n\
              Accept-Ranges: bytes\r\n\
@@ -1746,7 +1752,8 @@ mod tests {
              Cache-Control: no-cache\r\n\
              Connection: close\r\n\
              \r\n\
-             transfer";
+             transfer"
+        );
         assert_eq!(partial, expected_partial);
 
         // Unsatisfiable header: 416 with the probing Content-Range tail.
@@ -1758,7 +1765,9 @@ mod tests {
             )
             .await,
         );
-        let expected_416 = "HTTP/1.1 416 Range Not Satisfiable\r\n\
+        let expected_416 = format!(
+            "HTTP/1.1 416 Range Not Satisfiable\r\n\
+             x-intendant-app-build: {stamp}\r\n\
              Content-Type: application/json\r\n\
              Content-Length: 51\r\n\
              Content-Range: bytes */14\r\n\
@@ -1766,7 +1775,8 @@ mod tests {
              Cache-Control: no-cache\r\n\
              Connection: close\r\n\
              \r\n\
-             {\"error\":\"range is not satisfiable\",\"ok\":false}";
+             {{\"error\":\"range is not satisfiable\",\"ok\":false}}"
+        );
         // serde_json object key order is alphabetical for json! literals
         // built in one shot; compute the length from the actual body to
         // keep the pin honest.
@@ -1807,13 +1817,16 @@ mod tests {
         );
         assert_eq!(
             mismatch,
-            "HTTP/1.1 409 Conflict\r\n\
-             Content-Type: application/json\r\n\
-             Content-Length: 45\r\n\
-             Cache-Control: no-cache\r\n\
-             Connection: close\r\n\
-             \r\n\
-             {\"error\":\"upload sha256 mismatch\",\"ok\":false}"
+            format!(
+                "HTTP/1.1 409 Conflict\r\n\
+                 x-intendant-app-build: {stamp}\r\n\
+                 Content-Type: application/json\r\n\
+                 Content-Length: 45\r\n\
+                 Cache-Control: no-cache\r\n\
+                 Connection: close\r\n\
+                 \r\n\
+                 {{\"error\":\"upload sha256 mismatch\",\"ok\":false}}"
+            )
         );
     }
 

--- a/src/bin/caller/web_gateway/session_catalog/external_rows.rs
+++ b/src/bin/caller/web_gateway/session_catalog/external_rows.rs
@@ -1304,9 +1304,12 @@ mod tests {
         .unwrap();
     }
 
+    /// The serialization seam prepends the embedded bundle's build stamp
+    /// to every rendered head.
     fn golden_live_text_plain_transcript(status_line: &str, body: &str) -> String {
         format!(
-            "HTTP/1.1 {status_line}\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            "HTTP/1.1 {status_line}\r\nx-intendant-app-build: {}\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            crate::web_gateway::static_assets::app_build(),
             body.len()
         )
     }
@@ -1344,7 +1347,8 @@ mod tests {
         assert_eq!(
             transcript,
             format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n{body}",
+                "HTTP/1.1 200 OK\r\nx-intendant-app-build: {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n{body}",
+                crate::web_gateway::static_assets::app_build(),
                 body.len()
             )
         );
@@ -1392,7 +1396,8 @@ mod tests {
         assert_eq!(
             transcript,
             format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n{expected_body}",
+                "HTTP/1.1 200 OK\r\nx-intendant-app-build: {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n{expected_body}",
+                crate::web_gateway::static_assets::app_build(),
                 expected_body.len()
             )
         );
@@ -1414,7 +1419,8 @@ mod tests {
         assert_eq!(
             transcript,
             format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: application/vnd.apple.mpegurl\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n{expected_playlist}",
+                "HTTP/1.1 200 OK\r\nx-intendant-app-build: {}\r\nContent-Type: application/vnd.apple.mpegurl\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n{expected_playlist}",
+                crate::web_gateway::static_assets::app_build(),
                 expected_playlist.len()
             )
         );
@@ -1456,7 +1462,8 @@ mod tests {
             .await,
         );
         let mut expected = format!(
-            "HTTP/1.1 200 OK\r\nContent-Type: video/mp4\r\nContent-Length: {}\r\nCache-Control: public, max-age=3600\r\nConnection: close\r\n\r\n",
+            "HTTP/1.1 200 OK\r\nx-intendant-app-build: {}\r\nContent-Type: video/mp4\r\nContent-Length: {}\r\nCache-Control: public, max-age=3600\r\nConnection: close\r\n\r\n",
+            crate::web_gateway::static_assets::app_build(),
             session_bytes.len()
         );
         expected.push_str(&String::from_utf8(session_bytes).unwrap());
@@ -1471,9 +1478,10 @@ mod tests {
             .await,
         );
         assert!(
-            transcript.starts_with(
-                "HTTP/1.1 200 OK\r\nContent-Type: video/mp2t\r\nContent-Length: 22\r\nCache-Control: public, max-age=3600\r\nConnection: close\r\n\r\n"
-            ),
+            transcript.starts_with(&format!(
+                "HTTP/1.1 200 OK\r\nx-intendant-app-build: {}\r\nContent-Type: video/mp2t\r\nContent-Length: 22\r\nCache-Control: public, max-age=3600\r\nConnection: close\r\n\r\n",
+                crate::web_gateway::static_assets::app_build()
+            )),
             "{transcript}"
         );
         assert!(
@@ -1557,7 +1565,8 @@ mod tests {
         let jpeg = b"hq frame jpeg bytes".to_vec();
         let transcript = golden_live_transcript(frame_hq_api_response(Some(jpeg.clone())));
         let mut expected = format!(
-            "HTTP/1.1 200 OK\r\nContent-Type: image/jpeg\r\nContent-Length: {}\r\nCache-Control: public, max-age=31536000, immutable\r\nConnection: close\r\n\r\n",
+            "HTTP/1.1 200 OK\r\nx-intendant-app-build: {}\r\nContent-Type: image/jpeg\r\nContent-Length: {}\r\nCache-Control: public, max-age=31536000, immutable\r\nConnection: close\r\n\r\n",
+            crate::web_gateway::static_assets::app_build(),
             jpeg.len()
         );
         expected.push_str(&String::from_utf8(jpeg).unwrap());

--- a/src/bin/caller/web_gateway/settings.rs
+++ b/src/bin/caller/web_gateway/settings.rs
@@ -1669,10 +1669,12 @@ mod tests {
 
     /// The canonical JSON framing (`Cache-Control` + `Connection` tail):
     /// settings GET/POST, key-status, and project-root, spelled out
-    /// literally.
+    /// literally (the serialization seam prepends the embedded bundle's
+    /// build stamp).
     fn golden_settings_json_transcript(status_line: &str, body: &str) -> String {
         format!(
-            "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n{body}",
+            "HTTP/1.1 {status_line}\r\nx-intendant-app-build: {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n{body}",
+            crate::web_gateway::static_assets::app_build(),
             body.len()
         )
     }
@@ -1683,7 +1685,8 @@ mod tests {
     /// posture emits no CORS header).
     fn golden_settings_bare_json_transcript(status_line: &str, body: &str) -> String {
         format!(
-            "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            "HTTP/1.1 {status_line}\r\nx-intendant-app-build: {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            crate::web_gateway::static_assets::app_build(),
             body.len()
         )
     }

--- a/static/app/32-daemon-api.js
+++ b/static/app/32-daemon-api.js
@@ -613,6 +613,21 @@ async function daemonApiHttpRequest(method, params, opts) {
   } catch (err) {
     throw daemonApiHttpError(err, method);
   }
+  // Stale-tab nudge on the plain-HTTP lane: the /ws reconnect and tunnel
+  // handshakes re-check /config's app_build, but a tab with neither event
+  // lane alive (e.g. WebKit + mTLS hangs client-cert WebSockets and the
+  // tunnel can be down) would otherwise never hear a new daemon build.
+  // Every gateway response carries the served-bundle stamp as a header;
+  // compare at this one chokepoint. Guarded end to end — a missing header
+  // (older daemon, cross-origin) is a no-op and must never break the call.
+  try {
+    const servedBuild = resp.headers && typeof resp.headers.get === 'function'
+      ? resp.headers.get('x-intendant-app-build')
+      : '';
+    if (servedBuild && typeof maybeNudgeStaleBuild === 'function') {
+      maybeNudgeStaleBuild(servedBuild);
+    }
+  } catch (_err) { /* the nudge is best-effort */ }
   const body = await resp.json().catch(() => ({}));
   return { ok: resp.ok, status: resp.status, body: body ?? {} };
 }


### PR DESCRIPTION
A dashboard tab with neither event lane alive (WebKit + mTLS hangs client-cert WebSockets forever; the control tunnel can be down) never re-reads /config after a daemon upgrade, so it runs stale code indefinitely — the reload nudge machinery exists but had no lane to reach such tabs.

- Every buffered gateway HTTP response now carries `x-intendant-app-build: <stamp>` — emitted inside `HttpResponse::into_bytes` (single serialization seam, right after the status line; the same value `/config` serves as `app_build`; an unstamped artifact emits nothing).
- The SPA's daemonApi HTTP facade reads the header at its one chokepoint and feeds `maybeNudgeStaleBuild` — any plain HTTP activity now heals a stale tab (banner when visible, auto-reload when hidden with an empty composer). Fully guarded: a missing header is a no-op.
- Byte-for-byte golden transcript tests across the gateway modules updated to expect the header; a dedicated test pins exactly-one occurrence, leading position, and a non-empty stamp.

Found live: a Safari+mTLS tab kept running a pre-upgrade SPA through two daemon restarts with zero indication.