### PR TITLE
sessions: claude-code edits branch via anchor-fork

### DIFF
--- a/src/bin/caller/session_fork/fork_points.rs
+++ b/src/bin/caller/session_fork/fork_points.rs
@@ -275,6 +275,125 @@ pub(crate) fn native_fork_points(
     Ok(catalog)
 }
 
+/// Resolve the fork anchor for an edited Claude Code user message by its
+/// exact prose. Claude Code has no in-place rewind on the supervision
+/// wire, so an edit is serviced as an anchor-fork branch — but the live
+/// lane's `user_turn_index` counts THIS supervision run (claude turn
+/// state is not seeded from history), so the turn number cannot address
+/// the transcript chain. The edited row's original text can: match it
+/// against the active chain's user turns and anchor at the unique match's
+/// parent. Ambiguity or absence is a refusal, never a guess — the
+/// transcript's inline fork affordance covers those cases exactly.
+pub(crate) fn claude_edit_branch_anchor(
+    transcript_path: &Path,
+    original_text: &str,
+) -> Result<ForkAnchorSpec, String> {
+    let wanted = original_text.trim();
+    if wanted.is_empty() {
+        return Err("the edited row carried no original text to locate".to_string());
+    }
+    let tree = shared_claude_tree_scan(transcript_path)
+        .map_err(|err| format!("transcript scan failed: {err}"))?;
+    let Some(leaf) = tree.active_leaf.as_deref() else {
+        return Err("the transcript has no active message chain".to_string());
+    };
+    let on_chain: std::collections::HashSet<&str> = tree
+        .ancestor_chain(leaf)
+        .iter()
+        .map(|node| node.uuid.as_str())
+        .collect();
+
+    let file = std::fs::File::open(transcript_path)
+        .map_err(|err| format!("transcript open failed: {err}"))?;
+    let mut matches: Vec<(String, Option<String>)> = Vec::new();
+    for line in std::io::BufRead::lines(std::io::BufReader::new(file)) {
+        let Ok(line) = line else { continue };
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Ok(obj) = serde_json::from_str::<serde_json::Value>(trimmed) else {
+            continue;
+        };
+        if obj.get("type").and_then(serde_json::Value::as_str) != Some("user")
+            || obj.get("isMeta").and_then(serde_json::Value::as_bool) == Some(true)
+            || obj.get("isCompactSummary").and_then(serde_json::Value::as_bool) == Some(true)
+            || obj.get("isSidechain").and_then(serde_json::Value::as_bool) == Some(true)
+        {
+            continue;
+        }
+        let Some(uuid) = obj.get("uuid").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        if !on_chain.contains(uuid) {
+            continue;
+        }
+        let content = obj.get("message").and_then(|m| m.get("content"));
+        let mut prose = String::new();
+        match content {
+            Some(serde_json::Value::String(text)) => prose.push_str(text),
+            Some(serde_json::Value::Array(blocks)) => {
+                for block in blocks {
+                    if block.get("type").and_then(serde_json::Value::as_str) == Some("text") {
+                        if let Some(text) = block.get("text").and_then(serde_json::Value::as_str) {
+                            if !prose.is_empty() {
+                                prose.push('\n');
+                            }
+                            prose.push_str(text);
+                        }
+                    }
+                }
+            }
+            _ => continue,
+        }
+        // The rendered row the user edited had the supervision addendum
+        // trimmed and injected harness lines filtered — apply the same
+        // transforms so prose comparison is apples to apples.
+        let prose = prose
+            .split(crate::external_agent::claude_code::CLAUDE_CODE_BOOTSTRAP_ADDENDUM_MARKER)
+            .next()
+            .unwrap_or("")
+            .trim();
+        if prose.is_empty()
+            || crate::external_agent::transcript_text::is_injected_external_user_text(prose)
+        {
+            continue;
+        }
+        if prose == wanted {
+            matches.push((
+                uuid.to_string(),
+                obj.get("parentUuid")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string),
+            ));
+        }
+    }
+
+    match matches.as_slice() {
+        [] => Err(
+            "this message was not found on the session's active chain (it may sit on an \
+             abandoned branch or behind a compaction) — use the transcript row's fork button"
+                .to_string(),
+        ),
+        [(_, parent)] => match parent {
+            Some(parent) => Ok(ForkAnchorSpec {
+                kind: "message".to_string(),
+                turn: None,
+                item_id: None,
+                position: None,
+                seq: None,
+                message_uuid: Some(parent.clone()),
+            }),
+            None => Err("cannot branch from before the session's first message".to_string()),
+        },
+        many => Err(format!(
+            "this prompt appears {} times in the session — use the transcript row's fork \
+             button to pick the exact occurrence",
+            many.len()
+        )),
+    }
+}
+
 /// Fork points for a Claude Code session, derived from its transcript
 /// tree: the active head, inactive sibling branch tips, and user-turn
 /// boundaries on the active chain. Every anchor is a chain-slice target
@@ -717,5 +836,79 @@ mod tests {
             .find(|point| point.id == "msg:b1")
             .expect("post-compact turn boundary listed");
         assert!(!post.pre_compaction);
+    }
+
+    fn edit_fixture_line(uuid: &str, parent: Option<&str>, kind: &str, text: &str) -> String {
+        serde_json::json!({
+            "uuid": uuid,
+            "parentUuid": parent,
+            "type": kind,
+            "timestamp": "2026-07-19T00:00:00.000Z",
+            "message": {"role": kind, "content": [{"type": "text", "text": text}]},
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn claude_edit_branch_anchor_unique_match_anchors_at_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("edit.jsonl");
+        // u1 → a1 → u2a (abandoned, same text as u2b) → and u2b → a2 (active).
+        let lines = [
+            edit_fixture_line("u1", None, "user", "first prompt"),
+            edit_fixture_line("a1", Some("u1"), "assistant", "reply one"),
+            edit_fixture_line("u2a", Some("a1"), "user", "do the thing"),
+            edit_fixture_line("u2b", Some("a1"), "user", "do the thing"),
+            edit_fixture_line("a2", Some("u2b"), "assistant", "done"),
+        ];
+        std::fs::write(&path, lines.join("\n")).unwrap();
+
+        // The abandoned duplicate is off-chain and must not create
+        // ambiguity: the unique on-chain match anchors at its parent.
+        let anchor = claude_edit_branch_anchor(&path, "do the thing").expect("anchor");
+        assert_eq!(anchor.kind, "message");
+        assert_eq!(anchor.message_uuid.as_deref(), Some("a1"));
+    }
+
+    #[test]
+    fn claude_edit_branch_anchor_trims_supervision_addendum() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("edit.jsonl");
+        let addendum_suffixed = format!(
+            "run the tests\n\n{}\nharness plumbing",
+            crate::external_agent::claude_code::CLAUDE_CODE_BOOTSTRAP_ADDENDUM_MARKER
+        );
+        let lines = [
+            edit_fixture_line("u1", None, "user", "first prompt"),
+            edit_fixture_line("a1", Some("u1"), "assistant", "ok"),
+            edit_fixture_line("u2", Some("a1"), "user", &addendum_suffixed),
+            edit_fixture_line("a2", Some("u2"), "assistant", "ran"),
+        ];
+        std::fs::write(&path, lines.join("\n")).unwrap();
+
+        let anchor = claude_edit_branch_anchor(&path, "run the tests").expect("anchor");
+        assert_eq!(anchor.message_uuid.as_deref(), Some("a1"));
+    }
+
+    #[test]
+    fn claude_edit_branch_anchor_refuses_ambiguity_absence_and_first_turn() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("edit.jsonl");
+        let lines = [
+            edit_fixture_line("u1", None, "user", "first prompt"),
+            edit_fixture_line("a1", Some("u1"), "assistant", "ok"),
+            edit_fixture_line("u2", Some("a1"), "user", "continue"),
+            edit_fixture_line("a2", Some("u2"), "assistant", "more"),
+            edit_fixture_line("u3", Some("a2"), "user", "continue"),
+            edit_fixture_line("a3", Some("u3"), "assistant", "done"),
+        ];
+        std::fs::write(&path, lines.join("\n")).unwrap();
+
+        let ambiguous = claude_edit_branch_anchor(&path, "continue").expect_err("ambiguous");
+        assert!(ambiguous.contains("2 times"), "{ambiguous}");
+        let missing = claude_edit_branch_anchor(&path, "never said this").expect_err("missing");
+        assert!(missing.contains("not found"), "{missing}");
+        let first = claude_edit_branch_anchor(&path, "first prompt").expect_err("first turn");
+        assert!(first.contains("first message"), "{first}");
     }
 }

--- a/src/bin/caller/session_fork/fork_points.rs
+++ b/src/bin/caller/session_fork/fork_points.rs
@@ -317,7 +317,10 @@ pub(crate) fn claude_edit_branch_anchor(
         };
         if obj.get("type").and_then(serde_json::Value::as_str) != Some("user")
             || obj.get("isMeta").and_then(serde_json::Value::as_bool) == Some(true)
-            || obj.get("isCompactSummary").and_then(serde_json::Value::as_bool) == Some(true)
+            || obj
+                .get("isCompactSummary")
+                .and_then(serde_json::Value::as_bool)
+                == Some(true)
             || obj.get("isSidechain").and_then(serde_json::Value::as_bool) == Some(true)
         {
             continue;

--- a/src/bin/caller/session_supervisor/fork.rs
+++ b/src/bin/caller/session_supervisor/fork.rs
@@ -300,6 +300,123 @@ impl SessionSupervisor {
     /// Chain-slice the parent transcript into a fresh child uuid in the
     /// same project dir. Returns `(parent_backend_id, child_uuid,
     /// kept_lines, parent_project_root)`.
+    /// Service an EDIT of a claude-code user message as an anchor-fork
+    /// branch: Claude Code has no in-place rewind on the supervision wire
+    /// (its /rewind is an interactive TUI feature of the CLI itself), so
+    /// "edit turn N and redo" becomes "fork from before that message and
+    /// run the edited prompt in the child". The live lane's turn numbers
+    /// count this supervision run — not the transcript chain — so the
+    /// edited row is located by its exact original prose
+    /// (`claude_edit_branch_anchor`), refusing ambiguity rather than
+    /// guessing; the transcript's inline fork affordance covers refusals.
+    pub(crate) async fn fork_claude_edit_branch(
+        &self,
+        request: super::EditUserMessageRequest,
+        target: super::EditRouteTarget,
+    ) {
+        let sid = Some(target.managed_id.clone());
+        let turn = request.user_turn_index;
+        let Some(original_text) = request
+            .original_text
+            .as_deref()
+            .map(str::trim)
+            .filter(|text| !text.is_empty())
+            .map(str::to_string)
+        else {
+            self.emit_edit_user_message_status(
+                sid,
+                turn,
+                "failed",
+                "the edited row carried no original text to locate in the transcript",
+            );
+            return;
+        };
+        self.emit_edit_user_message_status(
+            sid.clone(),
+            turn,
+            "running",
+            "Claude Code cannot rewind in place — branching into a new session from before this message",
+        );
+        let token = target.managed_id.clone();
+        let home = self.logs_home();
+        let backend_id = match persisted_external_identity_for_session_in_home(&home, &token) {
+            Some((source, id)) if source == "claude-code" => id,
+            Some((source, _)) => {
+                self.emit_edit_user_message_status(
+                    sid,
+                    turn,
+                    "failed",
+                    format!("session is a {source} session, not claude-code"),
+                );
+                return;
+            }
+            None => token.clone(),
+        };
+        let Some(transcript) = crate::web_gateway::find_claude_session_file(&home, &backend_id)
+        else {
+            self.emit_edit_user_message_status(
+                sid,
+                turn,
+                "failed",
+                format!("transcript for claude-code session {backend_id} not found"),
+            );
+            return;
+        };
+        let anchor = match tokio::task::spawn_blocking(move || {
+            crate::session_fork::claude_edit_branch_anchor(&transcript, &original_text)
+        })
+        .await
+        .unwrap_or_else(|err| Err(format!("anchor resolution task failed: {err}")))
+        {
+            Ok(anchor) => anchor,
+            Err(reason) => {
+                self.emit_edit_user_message_status(sid, turn, "failed", reason);
+                return;
+            }
+        };
+        if !request.attachments.is_empty() {
+            self.emit_edit_user_message_status(
+                sid.clone(),
+                turn,
+                "running",
+                "attachments are not carried into an edit branch yet — the edited text runs without them",
+            );
+        }
+        match self.fork_claude_session(&token, &anchor).await {
+            Ok((resolved_backend_id, child_uuid, kept_lines, parent_project_root)) => {
+                let child_short: String = child_uuid.chars().take(8).collect();
+                self.announce_claude_fork(
+                    "claude-code",
+                    resolved_backend_id,
+                    &anchor,
+                    None,
+                    Some(request.text.clone()),
+                    parent_project_root,
+                    Some(format!("edit-{}", request.requested_id)),
+                    child_uuid,
+                    kept_lines,
+                )
+                .await;
+                self.emit_edit_user_message_status(
+                    sid,
+                    turn,
+                    "ok",
+                    format!(
+                        "branched to {child_short} — the edited prompt runs there ({kept_lines} lines kept)"
+                    ),
+                );
+            }
+            Err(error) => {
+                self.emit_edit_user_message_status(
+                    sid,
+                    turn,
+                    "failed",
+                    format!("edit branch fork failed: {error}"),
+                );
+            }
+        }
+    }
+
     async fn fork_claude_session(
         &self,
         token: &str,

--- a/src/bin/caller/session_supervisor/routing.rs
+++ b/src/bin/caller/session_supervisor/routing.rs
@@ -467,6 +467,14 @@ impl SessionSupervisor {
             );
             return;
         };
+        if backend == external_agent::AgentBackend::ClaudeCode {
+            // No in-place rewind exists on the claude-code supervision
+            // wire — service the edit as an anchor-fork branch instead
+            // (the child keeps everything before the edited message and
+            // the edited prompt becomes its first task).
+            self.fork_claude_edit_branch(request, target).await;
+            return;
+        }
         if !backend.supports_user_message_rewind() {
             self.warn(&format!(
                 "Edit dropped: {} session {} does not support user-message rewind yet",

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -2785,9 +2785,15 @@ function appendEditUserMessageButton(entry, c) {
   const btn = document.createElement('button');
   btn.type = 'button';
   btn.className = 'log-edit-message';
+  const meta = typeof sessionConfigMetadata === 'function'
+    ? sessionConfigMetadata(String(c?.session_id || ''))
+    : null;
+  const editSource = typeof sessionConfigSource === 'function' ? sessionConfigSource(meta) : '';
   btn.title = c.superseded
     ? 'Create a managed branch from this historical message'
-    : 'Edit this user message and rerun from here';
+    : editSource === 'claude-code'
+      ? 'Edit this message and branch: the edited prompt reruns in a new session (Claude Code cannot rewind in place)'
+      : 'Edit this user message and rerun from here';
   btn.innerHTML = '&#9998;';
   btn.dataset.sessionId = c.session_id || '';
   btn.dataset.userTurnIndex = String(c.user_turn_index);

--- a/static/app/54-session-lifecycle.js
+++ b/static/app/54-session-lifecycle.js
@@ -427,10 +427,17 @@ function renderEditMessageChip() {
     return;
   }
   const sid = shortSessionId(editMessageDraft.sessionId);
-  const action = editMessageDraft.historical ? 'Branching' : 'Editing';
+  // Claude Code has no in-place rewind on the supervision wire: an edit
+  // there is serviced as an anchor-fork branch, so label it honestly.
+  const meta = typeof sessionConfigMetadata === 'function'
+    ? sessionConfigMetadata(editMessageDraft.sessionId)
+    : null;
+  const source = typeof sessionConfigSource === 'function' ? sessionConfigSource(meta) : '';
+  const branching = editMessageDraft.historical || source === 'claude-code';
+  const action = branching ? 'Branching' : 'Editing';
   label.textContent = `${action} ${sid} #${editMessageDraft.userTurnIndex}`;
-  chip.title = editMessageDraft.historical
-    ? `Creating a managed branch from user turn ${editMessageDraft.userTurnIndex} in session ${editMessageDraft.sessionId}`
+  chip.title = branching
+    ? `Branching from user turn ${editMessageDraft.userTurnIndex} in session ${editMessageDraft.sessionId} — the edited prompt runs in a new session`
     : `Replacing user turn ${editMessageDraft.userTurnIndex} in session ${editMessageDraft.sessionId}`;
 }
 


### PR DESCRIPTION
Clicking edit on a claude-code user message failed with 'does not
support user-message rewind yet': the supervision wire has no rollback
primitive (the CLI's /rewind is TUI-interactive only). The fork engine
covers the gap: a claude-code edit now resolves its transcript anchor by
the edited row's exact prose on the active chain (live turn numbers
count the supervision run, not the chain, so numbers cannot address the
transcript; ambiguity refuses with a pointer to the row's inline fork
button rather than guessing) and branches — the child keeps everything
before the edited message and the edited prompt runs there. The edit
chip and row tooltip say Branching for claude-code so the semantics are
visible upfront; codex/native in-place rewind is unchanged.
