### PR TITLE
Serve completed Task-subagent terminals so reloads read DONE

### DIFF
--- a/src/bin/caller/web_gateway/session_catalog/task_threads.rs
+++ b/src/bin/caller/web_gateway/session_catalog/task_threads.rs
@@ -33,21 +33,45 @@ pub(crate) fn is_claude_task_child_id(session_id: &str) -> bool {
     })
 }
 
+/// What a synthetic `task-*` id resolves to in the Claude Code store: the
+/// subagent transcript itself, the spawning `toolUseId` the id was minted
+/// from, and — when the same project alias carries it — the PARENT
+/// thread's transcript, the only file Claude Code persists the child's
+/// terminal status into (`<task-notification>` records; the subagent
+/// transcript just ends at its final assistant message).
+pub(crate) struct ClaudeTaskSubagentArtifacts {
+    pub(crate) transcript: PathBuf,
+    pub(crate) tool_use_id: String,
+    pub(crate) parent_transcript: Option<PathBuf>,
+}
+
 /// Resolve a synthetic `task-*` id to its `agent-<agentId>.jsonl`
-/// transcript: scan `projects/*/*/subagents/*.meta.json`, matching each
-/// sidecar's `toolUseId` through the SAME minting function the wrapper
-/// used, and return the first match whose sibling transcript exists. A
-/// relocated store can carry the parent dir under several project
-/// aliases (S0b Q1); the copies describe the same thread, so any match
-/// serves.
+/// transcript (see [`find_claude_task_subagent_artifacts`]).
 pub(crate) fn find_claude_task_subagent_transcript(
     home: &Path,
     session_id: &str,
 ) -> Option<PathBuf> {
+    find_claude_task_subagent_artifacts(home, session_id).map(|artifacts| artifacts.transcript)
+}
+
+/// Resolve a synthetic `task-*` id to its subagent-store artifacts: scan
+/// `projects/*/*/subagents/*.meta.json`, matching each sidecar's
+/// `toolUseId` through the SAME minting function the wrapper used, and
+/// return the first match whose sibling transcript exists. A relocated
+/// store can carry the parent dir under several project aliases (S0b Q1);
+/// the copies describe the same thread, so any match serves — but prefer
+/// an alias that also carries the parent transcript (the terminal-status
+/// source), falling back to the first transcript-only match so
+/// resolution never regresses to a miss.
+pub(crate) fn find_claude_task_subagent_artifacts(
+    home: &Path,
+    session_id: &str,
+) -> Option<ClaudeTaskSubagentArtifacts> {
     if !is_claude_task_child_id(session_id) {
         return None;
     }
     let projects = home.join(".claude").join("projects");
+    let mut transcript_only: Option<ClaudeTaskSubagentArtifacts> = None;
     for project in std::fs::read_dir(&projects).ok()?.flatten() {
         if !project.file_type().map(|t| t.is_dir()).unwrap_or(false) {
             continue;
@@ -80,32 +104,262 @@ pub(crate) fn find_claude_task_subagent_transcript(
                 {
                     continue;
                 }
-                if !subagent_meta_matches_task_id(&meta_path, session_id) {
+                let Some(tool_use_id) = subagent_meta_task_tool_use_id(&meta_path, session_id)
+                else {
+                    continue;
+                };
+                let transcript = subagents.join(format!("{agent_stem}.jsonl"));
+                if !transcript.is_file() {
                     continue;
                 }
-                let transcript = subagents.join(format!("{agent_stem}.jsonl"));
-                if transcript.is_file() {
-                    return Some(transcript);
+                // The parent transcript is the child dir's sibling
+                // `<parent-uuid>.jsonl` in the same project alias.
+                let parent_transcript = child
+                    .path()
+                    .parent()
+                    .map(|dir| dir.join(format!("{}.jsonl", child.file_name().to_string_lossy())))
+                    .filter(|path| path.is_file());
+                let artifacts = ClaudeTaskSubagentArtifacts {
+                    transcript,
+                    tool_use_id,
+                    parent_transcript,
+                };
+                if artifacts.parent_transcript.is_some() {
+                    return Some(artifacts);
+                }
+                if transcript_only.is_none() {
+                    transcript_only = Some(artifacts);
                 }
             }
         }
     }
-    None
+    transcript_only
 }
 
-/// One sidecar read: does this meta's `toolUseId` mint the requested id?
-fn subagent_meta_matches_task_id(meta_path: &Path, session_id: &str) -> bool {
-    let Ok(contents) = std::fs::read_to_string(meta_path) else {
-        return false;
-    };
-    let Ok(meta) = serde_json::from_str::<serde_json::Value>(&contents) else {
-        return false;
-    };
+/// One sidecar read: when this meta's `toolUseId` mints the requested id,
+/// return that `toolUseId` (the parent-transcript correlation key).
+fn subagent_meta_task_tool_use_id(meta_path: &Path, session_id: &str) -> Option<String> {
+    let contents = std::fs::read_to_string(meta_path).ok()?;
+    let meta = serde_json::from_str::<serde_json::Value>(&contents).ok()?;
     meta.get("toolUseId")
         .and_then(|value| value.as_str())
-        .is_some_and(|tool_use_id| {
+        .filter(|tool_use_id| {
             crate::external_agent::claude_code::task_tool_child_id(tool_use_id) == session_id
         })
+        .map(str::to_string)
+}
+
+// ---------------------------------------------------------------------
+// Completed-terminal synthesis
+//
+// The live "Task complete" LogEntry for a Task child is bus-only (never
+// persisted into any session log), and the subagent transcript carries
+// no terminal marker — so after a tab reload or daemon restart a
+// completed child rehydrated from this store read IDLE forever. Claude
+// Code itself DOES persist the completion: the parent transcript records
+// each `system:task_notification` as a `<task-notification>` XML block
+// (a `queue-operation` record plus the injected `user` delivery, both
+// carrying `<tool-use-id>` and `<status>`). Derive a synthetic terminal
+// row from that evidence so every hydration/replay lane serves the same
+// DONE the live window showed.
+// ---------------------------------------------------------------------
+
+/// `kind` marker of the synthesized completed-terminal row. The dashboard
+/// counts it as done-evidence during hydration and dedupes it against the
+/// live "Task complete" log line (which carries a different timestamp and
+/// event id, so signature dedupe never pairs them).
+pub(crate) const CLAUDE_TASK_TERMINAL_KIND: &str = "subagent_terminal";
+
+const TASK_NOTIFICATION_OPEN: &str = "<task-notification>";
+const TASK_NOTIFICATION_CLOSE: &str = "</task-notification>";
+
+/// One `<task-notification>` block's terminal facts as persisted in the
+/// parent transcript, stamped with the carrying record's timestamp.
+struct ClaudeTaskNotification {
+    status: String,
+    summary: Option<String>,
+    ts: Option<String>,
+    ts_ms: Option<i64>,
+}
+
+/// The LAST `<task-notification>` for this `tool_use_id` in the parent
+/// transcript ("the same task-id may notify more than once" — a resumed
+/// child re-notifies, so recency wins). One bounded pass: lines are only
+/// JSON-parsed when they contain the correlation needle, and only the
+/// two record shapes Claude Code writes the block into are accepted — an
+/// assistant message QUOTING the block must not count as evidence.
+fn last_claude_task_notification(
+    parent_transcript: &Path,
+    tool_use_id: &str,
+) -> Option<ClaudeTaskNotification> {
+    use std::io::BufRead as _;
+    let needle = format!("<tool-use-id>{tool_use_id}</tool-use-id>");
+    let file = std::fs::File::open(parent_transcript).ok()?;
+    let reader = std::io::BufReader::new(file);
+    let mut last = None;
+    for line in reader.lines() {
+        let Ok(line) = line else {
+            continue;
+        };
+        if !line.contains(&needle) {
+            continue;
+        }
+        let Ok(record) = serde_json::from_str::<serde_json::Value>(&line) else {
+            continue;
+        };
+        let text = match record.get("type").and_then(|v| v.as_str()).unwrap_or("") {
+            "queue-operation" => record
+                .get("content")
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
+            "user" => claude_user_record_text(&record),
+            _ => None,
+        };
+        let Some(text) = text else {
+            continue;
+        };
+        let Some((status, summary)) = task_notification_facts(&text, &needle) else {
+            continue;
+        };
+        let ts = record
+            .get("timestamp")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        let ts_ms = ts
+            .as_deref()
+            .and_then(|ts| chrono::DateTime::parse_from_rfc3339(ts).ok())
+            .map(|dt| dt.timestamp_millis());
+        last = Some(ClaudeTaskNotification {
+            status,
+            summary,
+            ts,
+            ts_ms,
+        });
+    }
+    last
+}
+
+/// A `user` record's textual content: the injected notification delivery
+/// uses a plain string, but tolerate the block form too.
+fn claude_user_record_text(record: &serde_json::Value) -> Option<String> {
+    let content = record.get("message")?.get("content")?;
+    if let Some(text) = content.as_str() {
+        return Some(text.to_string());
+    }
+    let blocks = content.as_array()?;
+    let mut text = String::new();
+    for block in blocks {
+        if block.get("type").and_then(|v| v.as_str()) == Some("text") {
+            if let Some(t) = block.get("text").and_then(|v| v.as_str()) {
+                text.push_str(t);
+                text.push('\n');
+            }
+        }
+    }
+    (!text.is_empty()).then_some(text)
+}
+
+/// `<status>` / `<summary>` from the notification block that contains
+/// `needle`, tolerating unrelated blocks on the same record.
+fn task_notification_facts(text: &str, needle: &str) -> Option<(String, Option<String>)> {
+    let needle_at = text.find(needle)?;
+    let block_start = text[..needle_at].rfind(TASK_NOTIFICATION_OPEN)?;
+    let block_end = text[needle_at..]
+        .find(TASK_NOTIFICATION_CLOSE)
+        .map(|offset| needle_at + offset)
+        .unwrap_or(text.len());
+    let block = &text[block_start..block_end];
+    let status = xml_tag_text(block, "status")?;
+    let summary = xml_tag_text(block, "summary");
+    Some((status, summary))
+}
+
+fn xml_tag_text(block: &str, tag: &str) -> Option<String> {
+    let open = format!("<{tag}>");
+    let close = format!("</{tag}>");
+    let start = block.find(&open)? + open.len();
+    let end = block[start..].find(&close)? + start;
+    let text = block[start..end].trim();
+    (!text.is_empty()).then(|| text.to_string())
+}
+
+/// One-line, bounded summary — the same shaping the live emit applies
+/// (`claude_code::task_summary_snippet`), so hydrated rows read like the
+/// live "Task complete" line byte-for-byte.
+fn task_terminal_summary_snippet(text: &str) -> Option<String> {
+    let joined = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    let trimmed = joined.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed.chars().count() > 240 {
+        Some(format!(
+            "{}…",
+            trimmed.chars().take(240).collect::<String>()
+        ))
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+/// The synthesized completed-terminal row for a Task child, or None when
+/// the durable evidence doesn't support one:
+///
+/// - no parent transcript at the resolved alias (conservative miss);
+/// - the last notification is not a completion — errored / stopped
+///   children keep today's behavior (their live path already emits a
+///   persisted `SessionEnded`); only completion is starved of durable
+///   evidence;
+/// - the subagent transcript has rows NEWER than the notification (a
+///   resumed child) — completion evidence older than the transcript tail
+///   is stale, and the resumed run's own terminal will re-derive.
+pub(crate) fn claude_task_terminal_entry(
+    artifacts: &ClaudeTaskSubagentArtifacts,
+    entries: &[serde_json::Value],
+) -> Option<serde_json::Value> {
+    let parent = artifacts.parent_transcript.as_deref()?;
+    let notification = last_claude_task_notification(parent, &artifacts.tool_use_id)?;
+    // The wire statuses the live path folds into "completed"
+    // (claude_code::handle_task_notification).
+    if !matches!(notification.status.as_str(), "completed" | "success") {
+        return None;
+    }
+    if let (Some(terminal_ms), Some(last_ms)) = (notification.ts_ms, last_entry_ts_ms(entries)) {
+        if terminal_ms < last_ms {
+            return None;
+        }
+    }
+    // Live grammar: `emit_external_subagent_state`'s completed arm with
+    // the backend source as the label.
+    let label = crate::external_agent::AgentBackend::ClaudeCode.to_string();
+    let content = match notification
+        .summary
+        .as_deref()
+        .and_then(task_terminal_summary_snippet)
+    {
+        Some(summary) => format!("Task complete: {label} subagent completed: {summary}"),
+        None => format!("Task complete: {label} subagent completed"),
+    };
+    let mut entry = serde_json::json!({
+        "level": "info",
+        "source": label,
+        "kind": CLAUDE_TASK_TERMINAL_KIND,
+        "content": content,
+    });
+    if let Some(ts) = notification.ts {
+        entry["ts"] = serde_json::Value::String(ts);
+    }
+    if let Some(ts_ms) = notification.ts_ms {
+        entry["ts_ms"] = serde_json::Value::from(ts_ms);
+    }
+    Some(entry)
+}
+
+fn last_entry_ts_ms(entries: &[serde_json::Value]) -> Option<i64> {
+    entries
+        .iter()
+        .rev()
+        .find_map(|entry| entry.get("ts_ms").and_then(|v| v.as_i64()))
 }
 
 #[cfg(test)]
@@ -345,5 +599,437 @@ mod tests {
             ),
             None
         );
+    }
+
+    // ---- Completed-terminal synthesis ----
+
+    /// The block Claude Code persists into the parent transcript for a
+    /// `system:task_notification` (fields in observed live order; the
+    /// multi-line `<result>` proves summary extraction doesn't bleed).
+    fn notification_block(tool_use_id: &str, status: &str, summary: &str) -> String {
+        format!(
+            "<task-notification>\n<task-id>a0343c7095a040965</task-id>\n\
+             <tool-use-id>{tool_use_id}</tool-use-id>\n\
+             <output-file>/tmp/tasks/a0343c7095a040965.output</output-file>\n\
+             <status>{status}</status>\n<summary>{summary}</summary>\n\
+             <note>A task-notification fires each time this agent stops.</note>\n\
+             <result>Full report:\n\n## Details\n\nline two</result>\n\
+             </task-notification>"
+        )
+    }
+
+    /// Append the two record shapes a real notification lands as — the
+    /// `queue-operation` copy and the injected `user` delivery — to the
+    /// parent transcript in the given project alias.
+    fn append_parent_notification(
+        home: &Path,
+        project: &str,
+        parent: &str,
+        tool_use_id: &str,
+        status: &str,
+        summary: &str,
+        ts: &str,
+    ) {
+        let block = notification_block(tool_use_id, status, summary);
+        let path = home
+            .join(".claude")
+            .join("projects")
+            .join(project)
+            .join(format!("{parent}.jsonl"));
+        let mut body = std::fs::read_to_string(&path).unwrap_or_default();
+        body.push_str(
+            &serde_json::json!({
+                "type": "queue-operation",
+                "operation": "enqueue",
+                "timestamp": ts,
+                "sessionId": parent,
+                "content": block,
+            })
+            .to_string(),
+        );
+        body.push('\n');
+        body.push_str(
+            &serde_json::json!({
+                "parentUuid": "u-parent",
+                "isSidechain": false,
+                "type": "user",
+                "message": { "role": "user", "content": block },
+                "timestamp": ts,
+                "sessionId": parent,
+            })
+            .to_string(),
+        );
+        body.push('\n');
+        std::fs::write(&path, body).unwrap();
+    }
+
+    const COMPLETED_ROW: &str =
+        "Task complete: Claude Code subagent completed: Agent \"turn alignment\" finished";
+
+    #[test]
+    fn completed_notification_serves_synthetic_terminal_row() {
+        let home = tempfile::tempdir().unwrap();
+        write_subagent(
+            home.path(),
+            "-repo-project",
+            PARENT,
+            "a0343c7095a040965",
+            TOOL_USE_ID,
+            &fixture_lines(),
+        );
+        append_parent_notification(
+            home.path(),
+            "-repo-project",
+            PARENT,
+            TOOL_USE_ID,
+            "completed",
+            "Agent \"turn alignment\" finished",
+            "2026-07-17T10:00:30.000Z",
+        );
+        let entries = external_session_entries_from_home(home.path(), "claude-code", TASK_ID)
+            .expect("task child entries");
+        // Exactly ONE terminal row, even though the parent carries the
+        // block twice (queue-operation + user delivery).
+        let terminals: Vec<_> = entries
+            .iter()
+            .filter(|entry| {
+                entry.get("kind").and_then(|v| v.as_str()) == Some(CLAUDE_TASK_TERMINAL_KIND)
+            })
+            .collect();
+        assert_eq!(terminals.len(), 1);
+        let terminal = entries.last().expect("entries end with the terminal row");
+        assert_eq!(
+            terminal.get("kind").and_then(|v| v.as_str()),
+            Some(CLAUDE_TASK_TERMINAL_KIND)
+        );
+        assert_eq!(
+            terminal.get("content").and_then(|v| v.as_str()),
+            Some(COMPLETED_ROW)
+        );
+        assert_eq!(terminal.get("level").and_then(|v| v.as_str()), Some("info"));
+        assert_eq!(
+            terminal.get("source").and_then(|v| v.as_str()),
+            Some("Claude Code")
+        );
+        // Annotated like every served entry: stable id, delivery, ts.
+        assert!(terminal
+            .get("event_id")
+            .and_then(|v| v.as_str())
+            .is_some_and(|id| !id.is_empty()));
+        assert_eq!(
+            terminal.get("ts").and_then(|v| v.as_str()),
+            Some("2026-07-17T10:00:30.000Z")
+        );
+        assert!(terminal.get("ts_ms").and_then(|v| v.as_i64()).is_some());
+
+        // The detail page (the hydration fetch) serves the same row.
+        let body = external_session_detail_from_home_with_page(
+            home.path(),
+            "claude-code",
+            TASK_ID,
+            None,
+            None,
+        )
+        .expect("detail body");
+        let value: serde_json::Value = serde_json::from_str(&body).unwrap();
+        let detail_entries = value.get("entries").and_then(|v| v.as_array()).unwrap();
+        let last = detail_entries.last().expect("detail entries");
+        assert_eq!(
+            last.get("content").and_then(|v| v.as_str()),
+            Some(COMPLETED_ROW)
+        );
+        assert_eq!(
+            last.get("kind").and_then(|v| v.as_str()),
+            Some(CLAUDE_TASK_TERMINAL_KIND)
+        );
+    }
+
+    #[test]
+    fn non_completed_notifications_add_no_terminal_row() {
+        // Errored / stopped children keep today's behavior: no synthetic
+        // row (their live path already persists a SessionEnded).
+        for status in ["failed", "stopped", "killed"] {
+            let home = tempfile::tempdir().unwrap();
+            write_subagent(
+                home.path(),
+                "-repo-project",
+                PARENT,
+                "a0343c7095a040965",
+                TOOL_USE_ID,
+                &fixture_lines(),
+            );
+            append_parent_notification(
+                home.path(),
+                "-repo-project",
+                PARENT,
+                TOOL_USE_ID,
+                status,
+                "Agent \"turn alignment\" ended",
+                "2026-07-17T10:00:30.000Z",
+            );
+            let entries = external_session_entries_from_home(home.path(), "claude-code", TASK_ID)
+                .expect("task child entries");
+            assert_eq!(entries.len(), 2, "status {status} must not add a row");
+            assert_eq!(
+                entries[1].get("content").and_then(|v| v.as_str()),
+                Some("Starting on the alignment.")
+            );
+        }
+    }
+
+    #[test]
+    fn last_notification_wins_across_reruns() {
+        // failed then completed (a resumed child finishing cleanly):
+        // recency wins, the terminal row appears.
+        let home = tempfile::tempdir().unwrap();
+        write_subagent(
+            home.path(),
+            "-repo-project",
+            PARENT,
+            "a0343c7095a040965",
+            TOOL_USE_ID,
+            &fixture_lines(),
+        );
+        append_parent_notification(
+            home.path(),
+            "-repo-project",
+            PARENT,
+            TOOL_USE_ID,
+            "failed",
+            "boom",
+            "2026-07-17T10:00:30.000Z",
+        );
+        append_parent_notification(
+            home.path(),
+            "-repo-project",
+            PARENT,
+            TOOL_USE_ID,
+            "completed",
+            "second run done",
+            "2026-07-17T10:05:00.000Z",
+        );
+        let entries = external_session_entries_from_home(home.path(), "claude-code", TASK_ID)
+            .expect("task child entries");
+        assert_eq!(
+            entries
+                .last()
+                .and_then(|e| e.get("content"))
+                .and_then(|v| v.as_str()),
+            Some("Task complete: Claude Code subagent completed: second run done")
+        );
+
+        // completed then failed: the stale completion must NOT resurface.
+        let home = tempfile::tempdir().unwrap();
+        write_subagent(
+            home.path(),
+            "-repo-project",
+            PARENT,
+            "a0343c7095a040965",
+            TOOL_USE_ID,
+            &fixture_lines(),
+        );
+        append_parent_notification(
+            home.path(),
+            "-repo-project",
+            PARENT,
+            TOOL_USE_ID,
+            "completed",
+            "first run done",
+            "2026-07-17T10:00:30.000Z",
+        );
+        append_parent_notification(
+            home.path(),
+            "-repo-project",
+            PARENT,
+            TOOL_USE_ID,
+            "failed",
+            "rerun boom",
+            "2026-07-17T10:05:00.000Z",
+        );
+        let entries = external_session_entries_from_home(home.path(), "claude-code", TASK_ID)
+            .expect("task child entries");
+        assert_eq!(entries.len(), 2);
+    }
+
+    #[test]
+    fn transcript_rows_newer_than_notification_suppress_stale_terminal() {
+        // A resumed child streams rows after the old completion — the
+        // stale evidence must not paint the live-again child as done.
+        let home = tempfile::tempdir().unwrap();
+        let mut lines = fixture_lines();
+        lines.push(sidechain_line(
+            "assistant",
+            "a-2",
+            "2026-07-17T10:10:00.000Z",
+            serde_json::json!([{ "type": "text", "text": "Resumed and working again." }]),
+        ));
+        write_subagent(
+            home.path(),
+            "-repo-project",
+            PARENT,
+            "a0343c7095a040965",
+            TOOL_USE_ID,
+            &lines,
+        );
+        append_parent_notification(
+            home.path(),
+            "-repo-project",
+            PARENT,
+            TOOL_USE_ID,
+            "completed",
+            "Agent \"turn alignment\" finished",
+            "2026-07-17T10:00:30.000Z",
+        );
+        let entries = external_session_entries_from_home(home.path(), "claude-code", TASK_ID)
+            .expect("task child entries");
+        assert!(!entries.iter().any(|entry| {
+            entry.get("kind").and_then(|v| v.as_str()) == Some(CLAUDE_TASK_TERMINAL_KIND)
+        }));
+    }
+
+    #[test]
+    fn quoted_notification_in_assistant_row_is_not_evidence() {
+        // The parent model quoting the block in an assistant message must
+        // not count — only the queue-operation / user record shapes do.
+        let home = tempfile::tempdir().unwrap();
+        write_subagent(
+            home.path(),
+            "-repo-project",
+            PARENT,
+            "a0343c7095a040965",
+            TOOL_USE_ID,
+            &fixture_lines(),
+        );
+        let block = notification_block(TOOL_USE_ID, "completed", "quoted");
+        let path = home
+            .path()
+            .join(".claude")
+            .join("projects")
+            .join("-repo-project")
+            .join(format!("{PARENT}.jsonl"));
+        std::fs::write(
+            &path,
+            format!(
+                "{}\n",
+                serde_json::json!({
+                    "type": "assistant",
+                    "message": { "role": "assistant",
+                        "content": [{ "type": "text", "text": block }] },
+                    "timestamp": "2026-07-17T10:00:30.000Z",
+                    "sessionId": PARENT,
+                })
+            ),
+        )
+        .unwrap();
+        let entries = external_session_entries_from_home(home.path(), "claude-code", TASK_ID)
+            .expect("task child entries");
+        assert_eq!(entries.len(), 2);
+    }
+
+    #[test]
+    fn late_notification_upgrades_cached_no_terminal_entries() {
+        // The completion lands in the PARENT file after the subagent's
+        // last write: a parse cached in that gap must not pin IDLE
+        // forever. No-terminal cache hits re-derive; terminal entries
+        // are final and re-serve the same Arc.
+        let home = tempfile::tempdir().unwrap();
+        write_subagent(
+            home.path(),
+            "-repo-project",
+            PARENT,
+            "a0343c7095a040965",
+            TOOL_USE_ID,
+            &fixture_lines(),
+        );
+        // Parent transcript exists (so the artifacts resolve with it) but
+        // carries no notification yet.
+        let parent_path = home
+            .path()
+            .join(".claude")
+            .join("projects")
+            .join("-repo-project")
+            .join(format!("{PARENT}.jsonl"));
+        std::fs::write(&parent_path, "").unwrap();
+
+        let first = external_session_entries_from_home_arc(home.path(), "claude-code", TASK_ID)
+            .expect("pre-notification entries");
+        assert_eq!(first.len(), 2);
+
+        append_parent_notification(
+            home.path(),
+            "-repo-project",
+            PARENT,
+            TOOL_USE_ID,
+            "completed",
+            "Agent \"turn alignment\" finished",
+            "2026-07-17T10:00:30.000Z",
+        );
+        // The subagent transcript is untouched — only the parent grew.
+        let second = external_session_entries_from_home_arc(home.path(), "claude-code", TASK_ID)
+            .expect("post-notification entries");
+        assert_eq!(second.len(), 3);
+        assert_eq!(
+            second
+                .last()
+                .and_then(|e| e.get("content"))
+                .and_then(|v| v.as_str()),
+            Some(COMPLETED_ROW)
+        );
+        // Terminal entries are final: later parent growth (the thread
+        // moving on) neither drops the row nor doubles it, whether the
+        // request is served from the cache or re-derived.
+        let mut body = std::fs::read_to_string(&parent_path).unwrap();
+        body.push_str("{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"parent moved on\"}]},\"timestamp\":\"2026-07-17T11:00:00.000Z\"}\n");
+        std::fs::write(&parent_path, body).unwrap();
+        let third = external_session_entries_from_home_arc(home.path(), "claude-code", TASK_ID)
+            .expect("entries after parent growth");
+        let terminals = third
+            .iter()
+            .filter(|entry| {
+                entry.get("kind").and_then(|v| v.as_str()) == Some(CLAUDE_TASK_TERMINAL_KIND)
+            })
+            .count();
+        assert_eq!(terminals, 1);
+    }
+
+    /// The dashboard fragment carries the one unavoidable mirror of the
+    /// terminal-row contract (the merge-dedupe guard's kind check and the
+    /// phase derivation's content prefix); pin both to the Rust source so
+    /// a rename here fails the suite instead of shipping as drift.
+    #[test]
+    fn terminal_row_contract_is_pinned_in_dashboard_fragment() {
+        let fragment = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("static/app/39-session-windows.js"),
+        )
+        .expect("dashboard fragment 39-session-windows.js");
+        assert!(
+            fragment.contains(&format!("'{CLAUDE_TASK_TERMINAL_KIND}'")),
+            "the merge guard must key on kind '{CLAUDE_TASK_TERMINAL_KIND}'"
+        );
+        assert!(
+            fragment.contains("startsWith('Task complete:')"),
+            "the restored-phase derivation must key on the 'Task complete:' prefix"
+        );
+    }
+
+    #[test]
+    fn missing_parent_transcript_serves_entries_without_terminal() {
+        let home = tempfile::tempdir().unwrap();
+        write_subagent(
+            home.path(),
+            "-repo-project",
+            PARENT,
+            "a0343c7095a040965",
+            TOOL_USE_ID,
+            &fixture_lines(),
+        );
+        let artifacts = find_claude_task_subagent_artifacts(home.path(), TASK_ID)
+            .expect("artifacts resolve without a parent transcript");
+        assert_eq!(artifacts.tool_use_id, TOOL_USE_ID);
+        assert!(artifacts.parent_transcript.is_none());
+        let entries = external_session_entries_from_home(home.path(), "claude-code", TASK_ID)
+            .expect("task child entries");
+        assert_eq!(entries.len(), 2);
     }
 }

--- a/src/bin/caller/web_gateway/session_catalog/transcripts.rs
+++ b/src/bin/caller/web_gateway/session_catalog/transcripts.rs
@@ -1299,16 +1299,66 @@ pub(crate) fn external_session_entries_from_home_arc(
         "codex" => find_codex_session_file(home, session_id),
         // Task-tool sub-threads have no transcript keyed by their
         // synthetic `task-*` id; after the ordinary lookup misses, fall
-        // back to the parent's persisted subagent artifacts (Codex
-        // sub-threads need no fallback — they get first-class rollouts
-        // under their own thread ids).
-        "claude-code" => find_claude_session_file_for_transcript(home, session_id)
-            .or_else(|| find_claude_task_subagent_transcript(home, session_id)),
+        // back to the parent's persisted subagent artifacts through the
+        // task-aware lane, which also appends the completed-terminal row
+        // the subagent file itself never carries (Codex sub-threads need
+        // no fallback — they get first-class rollouts under their own
+        // thread ids).
+        "claude-code" => match find_claude_session_file_for_transcript(home, session_id) {
+            Some(path) => Some(path),
+            None => {
+                let artifacts = find_claude_task_subagent_artifacts(home, session_id)?;
+                return claude_task_child_entries_arc(home, session_id, &artifacts);
+            }
+        },
         "gemini" => find_gemini_session_file_for_transcript(home, session_id),
         _ => None,
     }?;
 
     external_session_entries_from_file_arc(home, &source, session_id, &path)
+}
+
+/// Task-child serving: the subagent transcript's rows plus — once the
+/// PARENT transcript carries the child's completed `<task-notification>`
+/// — a synthesized terminal row, so hydration and replay read DONE the
+/// way the live window did. The live "Task complete" LogEntry is
+/// bus-only and the subagent transcript just ends, so after a tab reload
+/// or daemon restart this lane is the only completion evidence
+/// (see `claude_task_terminal_entry`).
+///
+/// Cache rule: entries WITH the terminal row are final — a completed
+/// child's transcript only changes on a resume, which re-keys the
+/// (len, mtime) cache entry — so they cache like any other transcript.
+/// Entries WITHOUT it stay suspect: the notification lands in the
+/// PARENT file strictly after the subagent's last write, so a cached
+/// no-terminal parse is re-derived on every hit until the terminal
+/// appears (a still-running child churns its cache key anyway, so this
+/// forgoes no real reuse).
+fn claude_task_child_entries_arc(
+    home: &Path,
+    session_id: &str,
+    artifacts: &ClaudeTaskSubagentArtifacts,
+) -> Option<std::sync::Arc<Vec<serde_json::Value>>> {
+    let source = "claude-code";
+    let key = external_transcript_cache_key(source, session_id, &artifacts.transcript)?;
+    if let Some(entries) = cached_external_transcript_entries(&key) {
+        let has_terminal = entries.iter().any(|entry| {
+            entry.get("kind").and_then(|v| v.as_str()) == Some(CLAUDE_TASK_TERMINAL_KIND)
+        });
+        if has_terminal {
+            return Some(entries);
+        }
+    }
+
+    let steers = external_mid_turn_steer_ledger(home, source, session_id);
+    let mut entries = parse_claude_session_entries(&artifacts.transcript, &steers)?;
+    if let Some(terminal) = claude_task_terminal_entry(artifacts, &entries) {
+        entries.push(terminal);
+    }
+    annotate_external_transcript_entries(source, session_id, &mut entries);
+    let entries = std::sync::Arc::new(entries);
+    store_external_transcript_entries(key, &entries);
+    Some(entries)
 }
 
 pub(crate) fn external_session_entries_from_home(

--- a/static/app/39-session-windows.js
+++ b/static/app/39-session-windows.js
@@ -3627,6 +3627,17 @@ function sessionWindowRecordFromReplayEntry(entry = {}, fallbackSessionId = '') 
     content = content ? `Done signal: ${content}` : 'Done signal';
     return { ...base, level: 'detail', source: source || 'worker', content, kind };
   }
+  if (event === 'task_complete') {
+    // Live grammar (the WASM task_complete handler): reason, em-dash,
+    // summary — so a replay-served completion reads (and derives phase)
+    // like the live row did.
+    const reason = String(entry.reason || '').trim() || 'done';
+    const summary = String(entry.summary || '').trim();
+    content = summary
+      ? `Task complete: ${reason} — ${summary}`
+      : `Task complete: ${reason}`;
+    return { ...base, level: 'info', source: source || 'worker', content, kind };
+  }
   if (event === 'session_started') {
     return { ...base, level: 'info', source: 'system', content: `Session started: ${sessionId}`, kind };
   }
@@ -4079,6 +4090,16 @@ function appendMissingRestoredSessionWindowEntries(win, entries, fallbackSession
   for (const record of records) {
     const signatures = sessionWindowTranscriptSignaturesForRecord(record, fallbackSessionId);
     if (signatures.length > 0 && signatures.some(signature => existing.has(signature))) continue;
+    // The synthesized completed-terminal row (kind subagent_terminal,
+    // served by the task-child hydration lane) and the live "Task
+    // complete" LogEntry describe the same completion with different
+    // timestamps and event ids, so signatures never pair them — content
+    // is the identity here. A window that already shows a terminal row
+    // must not gain a second one from a merge fetch.
+    if (
+      record.kind === 'subagent_terminal' &&
+      sessionWindowHistoryHasTaskCompleteRow(win)
+    ) continue;
     missing.push(record);
     for (const signature of signatures) {
       existing.add(signature);
@@ -4087,6 +4108,21 @@ function appendMissingRestoredSessionWindowEntries(win, entries, fallbackSession
   if (!missing.length) return removedDuplicates;
   insertSessionWindowHistoryRecords(win, missing, sessionWindowShouldFollowNextOutput(win));
   return missing.length + removedDuplicates;
+}
+
+// Does this window already render a "Task complete" line (live LogEntry
+// or a previously merged terminal row)? Content-prefix identity — the
+// only stable key both copies share (see the merge guard above).
+function sessionWindowHistoryHasTaskCompleteRow(win) {
+  return ensureSessionWindowHistory(win).some(item => {
+    const node = sessionWindowHistoryNode(item);
+    if (node) {
+      const content = node.querySelector?.('.log-content');
+      return String((content || node).textContent || '').startsWith('Task complete:');
+    }
+    const record = sessionWindowHistoryRecord(item);
+    return String(record?.content || '').startsWith('Task complete:');
+  });
 }
 
 function externalSessionWindowSyncRecord(sessionId) {
@@ -4237,7 +4273,10 @@ async function hydrateRestoredSessionWindow(win, record) {
     const rendered = renderRestoredSessionWindowEntries(targetWin, entries, targetSid);
     clearSessionWindowHydrateError(targetWin || win);
     if (rendered > 0) {
-      updateSessionWindow(targetSid, { phase: 'idle', ended: false });
+      updateSessionWindow(targetSid, {
+        phase: restoredSessionWindowPhaseFromEntries(entries, targetSid),
+        ended: false,
+      });
       stationScheduleUpdate();
     }
   } catch (err) {
@@ -4249,6 +4288,40 @@ async function hydrateRestoredSessionWindow(win, record) {
   } finally {
     clearTimeout(timeout);
   }
+}
+
+// Hydration phase from the restored transcript's own evidence, mirroring
+// inferSessionPhaseFromLog's terminal prefixes: the LAST phase-relevant
+// row decides, so a completed Task child (whose hydration lane serves the
+// synthesized terminal row) or an ended session rehydrates as done, while
+// anything with activity after its last terminal — a resumed child —
+// stays the historical blanket 'idle' and lets live events drive.
+// Active states are deliberately NOT restored: a fetched transcript
+// cannot prove a live turn or a live approval.
+function restoredSessionWindowPhaseFromEntries(entries, fallbackSessionId) {
+  if (!Array.isArray(entries)) return 'idle';
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const record = sessionWindowRecordFromReplayEntry(entries[i], fallbackSessionId);
+    if (!record) continue;
+    const content = String(record.content || '');
+    if (content.startsWith('Task complete:') || content.startsWith('Session ended:')) {
+      return 'done';
+    }
+    if (content.startsWith('Agent interrupted:')) return 'interrupted';
+    const level = String(record.level || '').toLowerCase();
+    if (
+      level === 'model' ||
+      level === 'agent' ||
+      content.startsWith('Turn ') ||
+      content.startsWith('Running on display') ||
+      content.startsWith('Approval required') ||
+      content.startsWith('Question:') ||
+      (content.startsWith('Round ') && content.includes(' complete'))
+    ) {
+      return 'idle';
+    }
+  }
+  return 'idle';
 }
 
 function sessionWindowHydrationRecord(sessionId) {


### PR DESCRIPTION
## Problem

Completed Claude Code Task sub-agent windows (`task-*`) show IDLE — not DONE — after any tab reload or daemon restart, forever, and accumulate as stale relic windows (the "Hide done" pill's hard done-evidence predicate correctly refuses them).

Mechanism (verified): on a completed `task_notification`, `emit_external_subagent_state` emits a **bus-only** `AppEvent::LogEntry` ("Task complete: …") — `LogEntry` is not in `app_event_writes_to_session_log`, so nothing daemon-side records the completion durably — and `external_subagent_terminal_reason` deliberately returns `None` for `"completed"`, so no `SessionEnded` is emitted either. The post-#466 hydration lane serves the CC-side `subagents/agent-*.jsonl`, which carries **no terminal marker** (it just ends at the final assistant message), and `hydrateRestoredSessionWindow` hard-set `phase: 'idle'` after rendering regardless of content.

## Mechanism chosen: derive the terminal read-side from the parent transcript's task-notification

The brief offered two directions (persist the sub-scoped row into the wrapper log vs. synthesize from the parent transcript). Verified both against the real store and picked the **parent-transcript derivation** — it is smaller in blast radius and the only one that is truthful for every case:

- Claude Code itself already persists the completion durably: the parent transcript records each `system:task_notification` as a `<task-notification>` XML block (`<tool-use-id>`, `<status>completed</status>`, `<summary>`), twice — a `queue-operation` record plus the injected `user` delivery. The subagent JSONL never carries a terminal (verified on a live store).
- A daemon-persisted row (e.g. switching the completed arm to the persisted `AppEvent::TaskComplete`) only reaches the *current boot's* daemon-main log: it would fix reload-within-boot until the bootstrap replay entry limit ages it out, but **not daemon restart**, and would help no already-completed session. The read-side derivation fixes reload, restart, and every existing relic window retroactively — and changes **no live emit**, so there is no new live double-emit surface.

## Changes

**`session_catalog/task_threads.rs`** — the resolver now returns artifacts (subagent transcript + spawning `toolUseId` + parent transcript when the same project alias carries it; aliases with a parent transcript are preferred, transcript-only matches remain the fallback). `find_claude_task_subagent_transcript` stays as a thin wrapper. New completed-terminal derivation:
- the **last** `<task-notification>` for the toolUseId wins (children can re-notify across resumes);
- only `completed|success` synthesizes — errored/stopped children keep today's behavior (their live path already emits a persisted `SessionEnded`);
- completion evidence older than the subagent transcript's tail (a resumed child) is discarded;
- only the two record shapes CC writes the block into count — an assistant message *quoting* the block is not evidence;
- the row mirrors the live grammar byte-for-byte (`Task complete: Claude Code subagent completed: <summary snippet>`, level `info`, source `Claude Code`), tagged `kind: "subagent_terminal"`.

**`session_catalog/transcripts.rs`** — task-child serving lane appends the synthesized row before annotation (stable `event_id`/`ts_ms`/`delivery` like any served entry) with a staleness-proof cache rule: entries **with** the terminal are final and cache normally; entries **without** it re-derive on cache hits — the notification lands in the *parent* file strictly after the subagent's last write, so a parse cached in that gap must not pin IDLE forever (a running child churns its cache key anyway, so nothing real is forgone).

**`static/app/39-session-windows.js`** (fragment; regenerated `app.html` committed) —
- hydration derives phase from the served entries (last phase-relevant row wins, mirroring `inferSessionPhaseFromLog`'s prefixes) instead of hard-setting `'idle'`; active states are deliberately not restored;
- merge-lane dupe guard: a served `subagent_terminal` record is skipped when the window already renders a "Task complete" line — the live bus row and the synthetic row share no timestamp or event id, so signatures can never pair them; content prefix is the identity;
- replayed `task_complete` events now map to a rendered row (live WASM grammar: `Task complete: {reason} — {summary}`) instead of being dropped, giving native sessions the same restored-done derivation.

## Invariants kept

- Live lanes untouched: the completed live emit stays the bus LogEntry; exactly one terminal row renders live (guard covers the later merge fetch).
- Errored/interrupted/killed subs: behavior unchanged.
- Codex sub-threads share the IDLE-after-reload gap conceptually, but their rollouts carry no equivalent durable terminal evidence to derive from — not covered here; noted for follow-up.
- The one unavoidable frontend mirror (the `subagent_terminal` kind + `Task complete:` prefix) is pinned by a daemon-side parity test against the fragment.

## Tests

- completed notification → served entries end with the synthesized terminal row (content/kind/level/source/ts/event_id), and the detail page (the hydration fetch) serves it;
- `failed`/`stopped`/`killed` notifications add no row;
- last notification wins across reruns (failed→completed appears; completed→failed does not);
- subagent rows newer than the notification suppress the stale terminal (resumed child);
- a quoted block in an assistant record is not evidence;
- a notification landing after a no-terminal parse upgrades the cached entries (and later parent growth neither drops nor doubles the row);
- missing parent transcript still serves entries, no row;
- fragment parity test pins the kind marker and content prefix.

Battery: `cargo fmt --check` clean; `cargo check` clean; `cargo test -p intendant --bins` 4193+147+97 passed, 0 failed; the five lib crates 217+571+26+88+39 passed, 0 failed; `cargo clippy --workspace -- -D warnings` clean; `node --check` on the fragment; `app.html` regenerated via the assembler.
