### PR TITLE
dashboard: session-window jump-to-bottom button derives from scroll state

### DIFF
--- a/scripts/smoke-dashboard-boot.cjs
+++ b/scripts/smoke-dashboard-boot.cjs
@@ -23,6 +23,17 @@
 //       20-shell.html).
 //   (bonus) if `window.__intendantModuleAlive` exists it must be truthy;
 //       its absence is fine — assertion (a) stands alone.
+//   (d) the session-window jump-to-bottom button is state-derived: on a
+//       synthetic window it must appear whenever the reader is scrolled
+//       off the tail (including on a QUIET window with no appends in
+//       flight), stay put without flicker while output streams in, and
+//       hide at the tail / while minimized / after a restore-from-minimize
+//       rebuild. This is the one interaction-state assertion in the smoke:
+//       the visibility predicate regressed silently in production
+//       (2026-07-19 — event-starved by an append-only flag) because no CI
+//       harness executes SPA interaction paths; the probe is keyless,
+//       deterministic (synthetic DOM only, no daemon sessions), and adds
+//       one Runtime.evaluate.
 //
 // This script builds and launches NOTHING but the browser: point it at a
 // running daemon. Keyless local recipe:
@@ -520,6 +531,115 @@ class BootLedger {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Session-window jump-button behavior probe (assertion (d)).
+//
+// Runs entirely inside the page against a synthetic session window built
+// through the SPA's own creation/append paths — no daemon session exists on
+// the keyless smoke daemon, and none is needed: the probe pins the
+// client-side visibility state machine (scroll → follow recompute → button)
+// that broke silently when it was keyed on an append-only flag. Module-scope
+// SPA functions are unreachable from page evals (one shared module scope),
+// so state mutations go through the window.qa.sessionWindowSweeps facade
+// (41-session-window-actions.js) and everything else is plain DOM. Every
+// wait is a double-rAF settle (scroll events from programmatic scrollTop
+// writes and the SPA's rAF-coalesced follow scroll both land within one
+// frame).
+const JUMP_BUTTON_PROBE_EXPRESSION = `(async () => {
+  const out = { failures: [], steps: [] };
+  const check = (cond, label) => {
+    out.steps.push((cond ? 'pass' : 'FAIL') + ' ' + label);
+    if (!cond) out.failures.push(label);
+  };
+  const settle = () => new Promise((resolve) => {
+    requestAnimationFrame(() => requestAnimationFrame(resolve));
+  });
+  const sid = 'boot-smoke-jump-probe';
+  const qa = window.qa && window.qa.sessionWindowSweeps;
+  for (const name of ['build', 'append', 'remove', 'setMinimized', 'windowState']) {
+    if (!qa || typeof qa[name] !== 'function') {
+      out.failures.push('window.qa.sessionWindowSweeps.' + name + ' missing');
+      return out;
+    }
+  }
+  try {
+    if (!qa.build(sid, { task: 'jump-button smoke probe' })) {
+      out.failures.push('synthetic session window did not materialize');
+      return out;
+    }
+    const root = document.querySelector('.session-window[data-session-id="' + sid + '"]');
+    const log = root && root.querySelector('.session-window-log');
+    const button = root && root.querySelector('.session-window-jump-bottom');
+    if (!root || !log || !button) {
+      out.failures.push('probe window DOM (log / jump button) missing');
+      return out;
+    }
+    // Deterministic scroll geometry regardless of grid auto-fit sizing.
+    log.style.height = '120px';
+    log.style.minHeight = '120px';
+    log.style.overflowY = 'auto';
+    const visible = () => !button.classList.contains('hidden');
+    const atTail = () => {
+      const state = qa.windowState(sid);
+      return !!(state && state.logAtBottom);
+    };
+    for (let i = 0; i < 40; i += 1) qa.append(sid, 'probe seed ' + i + ' ' + 'x'.repeat(48));
+    await settle();
+    check(log.scrollHeight > log.clientHeight + 60, 'probe window is scrollable');
+    check(!visible(), 'seeded at tail: button hidden');
+    // (1) QUIET window scrolled up: nothing appends afterwards — the scroll
+    // recompute alone must reveal the button.
+    log.scrollTop = 0;
+    await settle();
+    check(visible(), 'scrolled-up quiet window: button visible');
+    // (4) streaming appends while scrolled up: stays visible with no
+    // hidden-flicker (any class mutation whose OLD value contains "hidden"
+    // means the button was hidden at some point mid-burst) and no follow
+    // steal of the reader's scroll position.
+    let flickered = false;
+    const observer = new MutationObserver((records) => {
+      for (const record of records) {
+        if (/(^|\\s)hidden(\\s|$)/.test(record.oldValue || '')) flickered = true;
+      }
+    });
+    observer.observe(button, { attributes: true, attributeFilter: ['class'], attributeOldValue: true });
+    const heldScrollTop = log.scrollTop;
+    for (let i = 0; i < 12; i += 1) qa.append(sid, 'probe stream ' + i + ' ' + 'y'.repeat(48));
+    await settle();
+    observer.disconnect();
+    check(visible(), 'streaming append while scrolled up: button still visible');
+    check(!flickered, 'no hidden-flicker during streamed appends');
+    check(Math.abs(log.scrollTop - heldScrollTop) < 1, 'no follow steal while scrolled up');
+    // (2) the button's own click path returns to the tail and hides it.
+    button.click();
+    await settle();
+    check(atTail(), 'jump click landed at the tail');
+    check(!visible(), 'at tail after jump click: button hidden');
+    // (3) restore-from-minimize: minimize unmounts the transcript; restore
+    // re-materializes the tail and lands at the bottom by design, so the
+    // button must be hidden after the rebuild — and a fresh scroll-up on the
+    // rebuilt DOM must reveal it again.
+    log.scrollTop = 0;
+    await settle();
+    check(visible(), 'scrolled up before minimize: button visible');
+    qa.setMinimized(sid, true);
+    await settle();
+    check(!visible(), 'minimized: button hidden');
+    qa.setMinimized(sid, false);
+    await settle();
+    check(atTail(), 'restore-from-minimize landed at the tail');
+    check(!visible(), 'restored at tail: button hidden');
+    log.scrollTop = 0;
+    await settle();
+    check(visible(), 'scrolled up after restore rebuild: button visible');
+  } catch (error) {
+    out.failures.push('probe threw: ' + (error && error.message ? error.message : String(error)));
+  } finally {
+    try { qa.remove(sid); } catch (_) {}
+  }
+  return out;
+})()`;
+
 function remoteObjectText(arg) {
   if (!arg || typeof arg !== 'object') return '';
   if (arg.value !== undefined) {
@@ -612,8 +732,8 @@ async function main() {
     const nav = await cdp.send('Page.navigate', { url: opts.url }, sessionId);
     if (nav.errorText) throw new Error(`navigation failed: ${nav.errorText}`);
 
-    const evaluate = async (expression) => {
-      const result = await cdp.send('Runtime.evaluate', { expression, returnByValue: true }, sessionId);
+    const evaluate = async (expression, { awaitPromise = false } = {}) => {
+      const result = await cdp.send('Runtime.evaluate', { expression, returnByValue: true, awaitPromise }, sessionId);
       if (result.exceptionDetails) throw new Error(`evaluate failed: ${exceptionText(result.exceptionDetails)}`);
       return result.result ? result.result.value : undefined;
     };
@@ -679,6 +799,19 @@ async function main() {
     }
 
     await delay(POST_BOOT_SETTLE_MS);
+
+    // Assertion (d): drive the jump-button state machine on a synthetic
+    // window. Runs before the ledger verdict so any page error the probe
+    // provokes also fails the smoke.
+    const jump = await evaluate(JUMP_BUTTON_PROBE_EXPRESSION, { awaitPromise: true });
+    const jumpSteps = Array.isArray(jump && jump.steps) ? jump.steps : [];
+    const jumpFailures = Array.isArray(jump && jump.failures) ? jump.failures : ['probe returned no result'];
+    console.log(`jump-button probe: ${jumpSteps.length} steps, ${jumpFailures.length} failures`);
+    for (const line of jumpSteps.slice(0, MAX_REPORT_LINES)) console.log(`  ${line}`);
+    if (jumpFailures.length > 0) {
+      for (const line of jumpFailures) ledger.record('jump-button', line, { fatal: true });
+      throw new Error(`jump-button probe failed ${jumpFailures.length} assertion(s)`);
+    }
 
     if (ledger.allowed.length > 0) {
       console.log(`allowed network-level noise (${ledger.allowed.length} entries):`);

--- a/scripts/smoke-dashboard-boot.cjs
+++ b/scripts/smoke-dashboard-boot.cjs
@@ -574,9 +574,10 @@ const JUMP_BUTTON_PROBE_EXPRESSION = `(async () => {
       out.failures.push('probe window DOM (log / jump button) missing');
       return out;
     }
-    // Deterministic scroll geometry regardless of grid auto-fit sizing.
-    log.style.height = '120px';
-    log.style.minHeight = '120px';
+    // Deterministic scroll geometry: max-height caps the flex-stretched log
+    // (header-collapsed windows have no stylesheet max-height), so 40 seed
+    // entries always overflow.
+    log.style.maxHeight = '120px';
     log.style.overflowY = 'auto';
     const visible = () => !button.classList.contains('hidden');
     const atTail = () => {
@@ -586,7 +587,15 @@ const JUMP_BUTTON_PROBE_EXPRESSION = `(async () => {
     for (let i = 0; i < 40; i += 1) qa.append(sid, 'probe seed ' + i + ' ' + 'x'.repeat(48));
     await settle();
     check(log.scrollHeight > log.clientHeight + 60, 'probe window is scrollable');
-    check(!visible(), 'seeded at tail: button hidden');
+    // Anchor at the tail through the scroller itself (a user drag to the
+    // bottom). The seed burst compresses create+append into one task, so
+    // the SPA's follow flush can race the grid-fit rAF that first gives the
+    // log its overflow — live sessions re-arm the flush on every later
+    // append, but the probe must not depend on that ordering.
+    log.scrollTop = log.scrollHeight;
+    await settle();
+    check(atTail(), 'seeded and anchored at the tail');
+    check(!visible(), 'at tail: button hidden');
     // (1) QUIET window scrolled up: nothing appends afterwards — the scroll
     // recompute alone must reveal the button.
     log.scrollTop = 0;
@@ -802,15 +811,23 @@ async function main() {
 
     // Assertion (d): drive the jump-button state machine on a synthetic
     // window. Runs before the ledger verdict so any page error the probe
-    // provokes also fails the smoke.
-    const jump = await evaluate(JUMP_BUTTON_PROBE_EXPRESSION, { awaitPromise: true });
-    const jumpSteps = Array.isArray(jump && jump.steps) ? jump.steps : [];
-    const jumpFailures = Array.isArray(jump && jump.failures) ? jump.failures : ['probe returned no result'];
-    console.log(`jump-button probe: ${jumpSteps.length} steps, ${jumpFailures.length} failures`);
-    for (const line of jumpSteps.slice(0, MAX_REPORT_LINES)) console.log(`  ${line}`);
-    if (jumpFailures.length > 0) {
-      for (const line of jumpFailures) ledger.record('jump-button', line, { fatal: true });
-      throw new Error(`jump-button probe failed ${jumpFailures.length} assertion(s)`);
+    // provokes also fails the smoke. Plain boots only: the probe needs real
+    // scroll geometry from the Activity pane, and a deep-link boot
+    // (#stats / #files legs) routes to a tab that leaves that pane
+    // display:none — the hash-less leg hard-asserts the geometry, so an
+    // activity-pane regression still fails loudly there.
+    if (new URL(opts.url).hash) {
+      console.log('jump-button probe: skipped (deep-link boot, activity pane not routed)');
+    } else {
+      const jump = await evaluate(JUMP_BUTTON_PROBE_EXPRESSION, { awaitPromise: true });
+      const jumpSteps = Array.isArray(jump && jump.steps) ? jump.steps : [];
+      const jumpFailures = Array.isArray(jump && jump.failures) ? jump.failures : ['probe returned no result'];
+      console.log(`jump-button probe: ${jumpSteps.length} steps, ${jumpFailures.length} failures`);
+      for (const line of jumpSteps.slice(0, MAX_REPORT_LINES)) console.log(`  ${line}`);
+      if (jumpFailures.length > 0) {
+        for (const line of jumpFailures) ledger.record('jump-button', line, { fatal: true });
+        throw new Error(`jump-button probe failed ${jumpFailures.length} assertion(s)`);
+      }
     }
 
     if (ledger.allowed.length > 0) {

--- a/static/app/38-managed-context.js
+++ b/static/app/38-managed-context.js
@@ -1789,7 +1789,6 @@ function resetSessionWindowLog(win) {
     win.log.innerHTML = '<div class="session-window-empty">Waiting for events...</div>';
   }
   win.followOutput = true;
-  win.pendingOutput = false;
   updateSessionWindowJumpButton(win);
   scheduleSessionWindowGridFit();
 }

--- a/static/app/40-session-launch.js
+++ b/static/app/40-session-launch.js
@@ -1540,9 +1540,20 @@ function loadNewerSessionWindowEntries(win) {
   return true;
 }
 
+// State-derived visibility: the button shows whenever the reader is off
+// the tail. win.followOutput is the maintained at-tail state — recomputed
+// from real geometry on every scroll (updateSessionWindowFollowFromScroll),
+// set true by every follow/jump/restore path, cleared by scroll-away,
+// append-while-scrolled-up, and chapter jumps. The retired predicate
+// additionally required the old win.pendingOutput "new output arrived
+// below" flag, which only the append paths set — so scrolling up in a
+// quiet session never revealed the button until output happened to stream
+// in (intermittently-missing jump button, fixed 2026-07-19). Deliberately
+// NO layout reads here: this runs per appended chunk per window (see the
+// rAF-coalescing note below for why that path must not force layout).
 function updateSessionWindowJumpButton(win) {
   if (!win || !win.jumpBottom) return;
-  const show = !!win.pendingOutput && !win.followOutput && !win.minimized;
+  const show = !win.followOutput && !win.minimized;
   win.jumpBottom.classList.toggle('hidden', !show);
   win.jumpBottom.setAttribute('aria-hidden', show ? 'false' : 'true');
 }
@@ -1572,7 +1583,6 @@ function scrollSessionWindowToBottom(win) {
     renderSessionWindowTail(win);
   }
   win.followOutput = true;
-  win.pendingOutput = false;
   updateSessionWindowJumpButton(win);
   scheduleSessionWindowScrollToBottom(win);
 }
@@ -1583,7 +1593,6 @@ function applySessionWindowOutputScroll(win, shouldFollow) {
     scrollSessionWindowToBottom(win);
   } else {
     win.followOutput = false;
-    win.pendingOutput = true;
     updateSessionWindowJumpButton(win);
   }
 }
@@ -1592,12 +1601,7 @@ function updateSessionWindowFollowFromScroll(win) {
   if (!win || !win.log) return;
   loadOlderSessionWindowEntries(win);
   loadNewerSessionWindowEntries(win);
-  if (sessionWindowIsRenderingTail(win) && sessionWindowLogIsAtBottom(win.log)) {
-    win.followOutput = true;
-    win.pendingOutput = false;
-  } else {
-    win.followOutput = false;
-  }
+  win.followOutput = sessionWindowIsRenderingTail(win) && sessionWindowLogIsAtBottom(win.log);
   updateSessionWindowJumpButton(win);
 }
 

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -322,7 +322,7 @@ function ensureSessionWindow(sessionId, meta = {}) {
   el.appendChild(jumpBottom);
   el.addEventListener('mousedown', () => focusSessionWindow(sid));
   el.addEventListener('focus', () => focusSessionWindow(sid));
-  log.addEventListener('scroll', () => updateSessionWindowFollowFromScroll(sessionWindows.get(sid)));
+  log.addEventListener('scroll', () => updateSessionWindowFollowFromScroll(sessionWindows.get(sid)), { passive: true });
   jumpBottom.addEventListener('click', (e) => {
     e.preventDefault();
     e.stopPropagation();
@@ -421,7 +421,6 @@ function ensureSessionWindow(sessionId, meta = {}) {
     autoMinimized: false,
     userRestoredWhileDone: false,
     followOutput: true,
-    pendingOutput: false,
     logHistory: [],
     renderStart: 0,
     renderEnd: 0,
@@ -719,7 +718,6 @@ function restoreSessionWindowTranscript(win) {
   const history = ensureSessionWindowHistory(win);
   renderSessionWindowRange(win, sessionWindowTailStart(history.length));
   win.followOutput = true;
-  win.pendingOutput = false;
   updateSessionWindowJumpButton(win);
   scheduleSessionWindowScrollToBottom(win);
 }
@@ -917,17 +915,33 @@ function hideDoneSessionWindows() {
 }
 
 // QA facade (window.qa convention): the dashboard validator's grid-pill
-// probe builds throwaway windows and reads per-window sweep state — the
-// bulk sweeps above are otherwise unreachable from the page's global
-// scope (every fragment shares one module scope). build/setMinimized
-// route through the same ensureSessionWindow / setSessionWindowMinimized
-// paths live sessions use; the readbacks are serializable snapshots.
+// probe builds throwaway windows and reads per-window sweep state, and the
+// boot smoke's jump-button probe drives the transcript state machine — the
+// bulk sweeps above and the append/remove paths are otherwise unreachable
+// from the page's global scope (every fragment shares one module scope).
+// build/setMinimized/append/remove route through the same
+// ensureSessionWindow / setSessionWindowMinimized /
+// appendSessionWindowHistory / removeSessionWindow paths live sessions
+// use; the readbacks are serializable snapshots (windowState's
+// followOutput/logAtBottom expose the jump-button state machine — QA-only
+// layout read, never on a hot path).
 window.qa = Object.assign(window.qa || {}, {
   sessionWindowSweeps: {
     build: (sessionId, meta) => !!ensureSessionWindow(sessionId, meta || {}),
     setMinimized: (sessionId, minimized) => setSessionWindowMinimized(sessionId, !!minimized),
     relate: (evt) => applySessionRelationship(evt || {}),
     windowIds: () => [...sessionWindows.keys()],
+    append: (sessionId, text) => {
+      const sid = String(sessionId || '').trim();
+      const win = sid ? sessionWindows.get(sid) : null;
+      if (!win) return -1;
+      const div = document.createElement('div');
+      div.className = 'log-entry';
+      div.textContent = String(text || '');
+      appendSessionWindowHistory(win, div, sessionWindowShouldFollowNextOutput(win));
+      return ensureSessionWindowHistory(win).length;
+    },
+    remove: (sessionId) => removeSessionWindow(sessionId),
     windowState: (sessionId) => {
       const sid = String(sessionId || '').trim();
       const win = sid ? sessionWindows.get(sid) : null;
@@ -938,6 +952,9 @@ window.qa = Object.assign(window.qa || {}, {
         minimizedClass: win.el.classList.contains('minimized'),
         headerCollapsedClass: win.el.classList.contains('header-collapsed'),
         hardDone: sessionWindowHasHardDoneEvidence(sid),
+        followOutput: !!win.followOutput,
+        logAtBottom: sessionWindowIsRenderingTail(win) && sessionWindowLogIsAtBottom(win.log),
+        jumpHidden: !win.jumpBottom || win.jumpBottom.classList.contains('hidden'),
       };
     },
   },

--- a/static/app/48-router-settings.js
+++ b/static/app/48-router-settings.js
@@ -440,6 +440,9 @@ new MutationObserver(() => {
 const contextViz = {
   canvas: null,
   renderer: null,
+  // Sticky WebGL2-unavailable latch: contextInitThree probes getContext
+  // once, degrades to the empty-state note, and never retries (48b).
+  webglUnavailable: false,
   scene: null,
   camera: null,
   root: null,

--- a/static/app/48b-context-viz.js
+++ b/static/app/48b-context-viz.js
@@ -964,15 +964,47 @@ function contextResetPointerState() {
   contextViz.canvas?.classList.remove('dragging');
 }
 
+// WebGL-less degrade note (headless/GPU-less browsers, some remote
+// desktops). contextBuildThree re-hides #context-scene-empty on every
+// call before init, so the unavailable path must re-show it every time.
+function contextShowWebglUnavailableNote() {
+  const empty = document.getElementById('context-scene-empty');
+  if (!empty) return;
+  empty.textContent = '3D context view is unavailable: this browser could not create a WebGL context. The context details, legend, and raw views still work.';
+  empty.style.display = 'flex';
+}
+
 function contextInitThree() {
   const canvas = document.getElementById('context-scene');
   if (!canvas) return false;
   if (contextViz.renderer) return true;
+  if (contextViz.webglUnavailable) {
+    contextShowWebglUnavailableNote();
+    return false;
+  }
+  // Probe the context BEFORE handing the canvas to THREE: WebGLRenderer
+  // console.error()s and then THROWS when WebGL is unavailable, and that
+  // throw used to escape renderContextPane into whatever UI action focused
+  // the session (e.g. a transcript jump-to-bottom click died before it
+  // scrolled). A null getContext is silent — degrade to the empty-state
+  // note and keep the rest of the pane working. WebGL2 only: the vendored
+  // THREE (r165) no longer accepts WebGL1 contexts.
+  let gl = null;
+  try {
+    gl = canvas.getContext('webgl2', { antialias: true, alpha: true });
+  } catch (_) {
+    gl = null;
+  }
+  if (!gl) {
+    contextViz.webglUnavailable = true;
+    contextShowWebglUnavailableNote();
+    return false;
+  }
   contextViz.canvas = canvas;
   contextViz.scene = new THREE.Scene();
   contextViz.camera = new THREE.PerspectiveCamera(42, 1, 0.1, 1000);
   contextViz.camera.position.set(0, 18, contextViz.zoom);
-  contextViz.renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: true });
+  contextViz.renderer = new THREE.WebGLRenderer({ canvas, context: gl, antialias: true, alpha: true });
   contextViz.renderer.setPixelRatio(Math.min(2, window.devicePixelRatio || 1));
   contextViz.root = new THREE.Group();
   contextViz.scene.add(contextViz.root);

--- a/static/app/57c-chapter-nav.js
+++ b/static/app/57c-chapter-nav.js
@@ -303,6 +303,10 @@ function chapterNavJumpPane(win, mode, dir) {
   win.followOutput = false;
   win.log.scrollTop = chapterNavJumpScrollTop(win.log, node);
   ix.cursor = { mark: target, scrollTop: win.log.scrollTop };
+  // Deterministic jump-button recompute: the scrollTop write above fires a
+  // scroll event only when the position actually changed, so a jump onto
+  // the current position would otherwise leave the button stale.
+  updateSessionWindowJumpButton(win);
   chapterNavHighlightRow(node, mode);
   const cluster = chapterNavClusterForPane(win);
   chapterNavUpdateCount(cluster, mode, marks, target);
@@ -340,6 +344,7 @@ function chapterNavPaneHistoryLoaded(win) {
   win.followOutput = false;
   win.log.scrollTop = chapterNavJumpScrollTop(win.log, node);
   ix.cursor = { mark: target, scrollTop: win.log.scrollTop };
+  updateSessionWindowJumpButton(win);
   chapterNavHighlightRow(node, pending.mode);
   const cluster = chapterNavClusterForPane(win);
   chapterNavUpdateCount(cluster, pending.mode, marks, target);


### PR DESCRIPTION
## Symptom

The session-window scroll-to-bottom button (`.session-window-jump-bottom`) was intermittently missing when scrolled up off the tail — sometimes it showed, sometimes not, forcing manual scrolling.

## Root cause

`updateSessionWindowJumpButton` (static/app/40-session-launch.js) gated visibility on `win.pendingOutput`:

```js
const show = !!win.pendingOutput && !win.followOutput && !win.minimized;
```

`pendingOutput` is set in exactly one place — `applySessionWindowOutputScroll(win, false)`, the append path, which runs only when new output arrives while the reader is not following. The scroll listener (41-session-window-actions.js → `updateSessionWindowFollowFromScroll`) runs a recompute on every scroll, but it only clears `followOutput` — it never sets `pendingOutput` — so the recompute always evaluated to hidden on a quiet session. The button therefore appeared only if output streamed in *after* the user scrolled up: busy sessions revealed it within a beat, idle/between-turns sessions never did. Visibility was event-starved by data (the append-only flag), not by listener wiring. The predicate dates to 2026-05-24 ("Preserve session window scroll position"), when the button was a new-output-below indicator predating the windowed transcript; the product expectation today is "off the tail → button shows".

Same class, secondary: chapter-nav jumps (57c) set `followOutput = false` and reposition the scroller with no recompute (and a jump onto the current position fires no scroll event at all).

**Second defect found by the new probe:** on WebGL-less browsers (headless, GPU-less VMs, some remote desktops) clicking the jump button did nothing at all — the click handler runs `focusSessionWindow` → `renderContextPane` → `contextBuildThree` → `contextInitThree`, where `new THREE.WebGLRenderer(...)` console.error()s and **throws**, killing the handler before `scrollSessionWindowToBottom` ran.

Not shared: the flat Activity `#scroll-bottom` pill is already scroll-derived (58-shortcuts-boot.js, passive listener), and the session detail/replay view uses always-visible pager controls (First/Prev/Next/Latest + entry jump) — no conditional affordance to starve. Neither was touched.

## Fix

- `updateSessionWindowJumpButton` keys on `win.followOutput` alone: `show = !followOutput && !minimized`. `followOutput` is the maintained at-tail state — recomputed from real geometry on every scroll (rendering-tail && the existing 28px distance-from-bottom threshold, unchanged), set true by every follow/jump/restore path, cleared by scroll-away, append-while-scrolled-up, and chapter jumps. Measurement-free on the per-chunk append path (the rAF-coalescing note in 40 documents why that path must not force layout); reuses the existing rAF follow idiom — no ResizeObserver, no per-frame loops.
- `pendingOutput` had no remaining readers — removed everywhere (init, restore-from-minimize, managed-context reset, follow paths).
- Chapter-nav jumps call the recompute deterministically after `followOutput = false`.
- The session-window scroll listener is `{ passive: true }` (matches the main-log idiom).
- Minimized windows keep hiding the button (existing JS guard + CSS).
- `contextInitThree` probes `canvas.getContext('webgl2')` itself before constructing THREE (silent on failure; vendored THREE r165 is WebGL2-only), latches a sticky `webglUnavailable` flag, re-shows the scene empty-state with a clear note, and hands the pre-created context to THREE on success. `contextBuildThree` already tolerated the false return; render/animation paths were already null-safe.

## Probe assertions (boot smoke, assertion (d))

`scripts/smoke-dashboard-boot.cjs` gains a synthetic-window jump-button probe: seeded + anchored at tail → hidden; **scrolled-up quiet window → visible** (the regression class); streamed appends while scrolled up → still visible, zero hidden-flicker (MutationObserver, attributeOldValue), no follow steal; jump click → lands at tail, hidden (exercises the real click path incl. the WebGL-less focus chain); minimize → hidden; restore-from-minimize → lands at tail, hidden; fresh scroll-up on the rebuilt DOM → visible again. State mutations route through a small extension of the existing `window.qa.sessionWindowSweeps` facade (`append`/`remove` + `followOutput`/`logAtBottom`/`jumpHidden` readbacks) since module-scope SPA functions are unreachable from page evals. The probe runs on hash-less boots only — the CI deep-link legs (#stats/#files) route away from the Activity pane (no geometry) and print an explicit skip. Charter note: the smoke's header says feature assertions belong in the deep battery — this block is deliberately the one interaction-state assertion, because the predicate regressed silently in production and no CI harness executes SPA interaction paths; it is keyless, synthetic-DOM-only, one Runtime.evaluate.

Generated `static/app.html` regenerated via `cargo run -p app-html-assembler` (fragments are the source). origin/main merged twice mid-flight (#486-#489, #493, #495, #496); both times only the generated artifact conflicted — resolved via the fragments+regen ritual.