### PR TITLE
sessions: fork from every anchor label; stamp transcript uuids on daemon rows

### DIFF
--- a/src/bin/caller/web_gateway/session_catalog/replay.rs
+++ b/src/bin/caller/web_gateway/session_catalog/replay.rs
@@ -902,16 +902,30 @@ pub(crate) fn annotate_replay_user_turns_from_external_transcript(
     };
     let user_turns: Vec<serde_json::Value> = transcript
         .iter()
-        .filter(|entry| entry.get("source").and_then(|v| v.as_str()) == Some("user"))
         .filter(|entry| {
             entry
+                .get("source")
+                .and_then(|v| v.as_str())
+                .map(|source| source.trim().eq_ignore_ascii_case("user"))
+                .unwrap_or(false)
+        })
+        .filter(|entry| {
+            // Codex turns carry the revision projection; claude turns carry
+            // the transcript message uuid (the inline fork join key). Either
+            // identity makes a transcript user turn worth stamping onto its
+            // daemon-log twin — a fully supervised session's detail view
+            // renders ONLY daemon-log rows, so without this stamp the
+            // claude fork affordances never appear there.
+            let has_revision = entry
                 .get("user_turn_index")
                 .and_then(|v| v.as_u64())
                 .is_some()
                 && entry
                     .get("user_turn_revision")
                     .and_then(|v| v.as_u64())
-                    .is_some()
+                    .is_some();
+            let has_uuid = entry.get("message_uuid").and_then(|v| v.as_str()).is_some();
+            has_revision || has_uuid
         })
         // Clone only the matched user turns; the shared transcript
         // snapshot itself is never deep-cloned on this path anymore.
@@ -969,6 +983,8 @@ pub(crate) fn annotate_replay_user_turns_from_external_transcript(
                 "replacement_for_user_turn_index",
                 "superseded",
                 "superseded_reason",
+                "message_uuid",
+                "off_active_chain",
             ] {
                 if let Some(value) = turn.get(key) {
                     obj.insert(key.to_string(), value.clone());
@@ -1933,5 +1949,44 @@ mod tests {
             context.pointer("/raw/0/role").and_then(|v| v.as_str()),
             Some("user")
         );
+    }
+
+    /// A fully supervised claude session's detail view renders ONLY
+    /// daemon-log rows, which carry no transcript uuids — the inline fork
+    /// join keys on `message_uuid`, so without stamping, those views show
+    /// zero fork affordances (found live 2026-07-19). The annotator maps
+    /// daemon user rows onto transcript user turns in order (duplicate
+    /// prose maps sequentially, never globally) and stamps the uuid.
+    #[test]
+    fn claude_daemon_rows_get_transcript_uuids_stamped() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path();
+        let project = home.join(".claude").join("projects").join("p1");
+        std::fs::create_dir_all(&project).unwrap();
+        let sid = "cc-stamp-test";
+        let lines = [
+            r#"{"uuid":"u1","parentUuid":null,"type":"user","timestamp":"2026-07-19T00:00:01.000Z","message":{"role":"user","content":[{"type":"text","text":"continue"}]}}"#,
+            r#"{"uuid":"a1","parentUuid":"u1","type":"assistant","timestamp":"2026-07-19T00:00:02.000Z","message":{"role":"assistant","content":[{"type":"text","text":"ok one"}]}}"#,
+            r#"{"uuid":"u2","parentUuid":"a1","type":"user","timestamp":"2026-07-19T00:00:03.000Z","message":{"role":"user","content":[{"type":"text","text":"continue"}]}}"#,
+            r#"{"uuid":"a2","parentUuid":"u2","type":"assistant","timestamp":"2026-07-19T00:00:04.000Z","message":{"role":"assistant","content":[{"type":"text","text":"ok two"}]}}"#,
+        ];
+        std::fs::write(project.join(format!("{sid}.jsonl")), lines.join("\n")).unwrap();
+
+        let mut entries = vec![
+            serde_json::json!({"event":"log_entry","session_id":sid,"source":"User","content":"continue"}),
+            serde_json::json!({"event":"log_entry","session_id":sid,"source":"Claude Code","content":"ok one"}),
+            serde_json::json!({"event":"log_entry","session_id":sid,"source":"User","content":"continue"}),
+        ];
+        annotate_replay_user_turns_from_external_transcript(&mut entries, home, "claude-code", sid);
+        assert_eq!(entries[0]["message_uuid"], "u1");
+        assert!(
+            entries[0].get("user_turn_index").is_none(),
+            "claude stamps carry no codex revision fields"
+        );
+        assert_eq!(
+            entries[2]["message_uuid"], "u2",
+            "duplicate prose maps in order, not to the first global match"
+        );
+        assert!(entries[1].get("message_uuid").is_none());
     }
 }

--- a/src/bin/caller/web_gateway/session_catalog/replay.rs
+++ b/src/bin/caller/web_gateway/session_catalog/replay.rs
@@ -936,7 +936,7 @@ pub(crate) fn annotate_replay_user_turns_from_external_transcript(
     }
 
     let mut next_user_turn = 0usize;
-    for entry in entries {
+    for entry in entries.iter_mut() {
         if entry.get("event").and_then(|v| v.as_str()) != Some("log_entry") {
             continue;
         }
@@ -989,6 +989,58 @@ pub(crate) fn annotate_replay_user_turns_from_external_transcript(
                 if let Some(value) = turn.get(key) {
                     obj.insert(key.to_string(), value.clone());
                 }
+            }
+        }
+    }
+
+    // Second pass — tool rows. Transcript tool entries carry the exact
+    // `item_id` key plus their line's `message_uuid`; daemon-log tool rows
+    // carry the same item id. Stamping the uuid here is what makes the
+    // anchor-labeled rows of a fully supervised claude session forkable
+    // (their detail view renders only daemon-log rows).
+    let mut uuid_by_item: std::collections::HashMap<&str, &serde_json::Value> =
+        std::collections::HashMap::new();
+    for entry in transcript.iter() {
+        let (Some(item_id), Some(_)) = (
+            entry.get("item_id").and_then(|v| v.as_str()),
+            entry.get("message_uuid").and_then(|v| v.as_str()),
+        ) else {
+            continue;
+        };
+        uuid_by_item.entry(item_id).or_insert(entry);
+    }
+    if uuid_by_item.is_empty() {
+        return;
+    }
+    for entry in entries.iter_mut() {
+        if entry.get("event").and_then(|v| v.as_str()) != Some("log_entry") {
+            continue;
+        }
+        if entry.get("session_id").and_then(|v| v.as_str()) != Some(session_id) {
+            continue;
+        }
+        if entry.get("message_uuid").is_some() {
+            continue;
+        }
+        let stamped = entry
+            .get("item_id")
+            .and_then(|v| v.as_str())
+            .and_then(|item_id| uuid_by_item.get(item_id))
+            .map(|src| {
+                (
+                    src.get("message_uuid").cloned(),
+                    src.get("off_active_chain").cloned(),
+                )
+            });
+        let Some((uuid, off_chain)) = stamped else {
+            continue;
+        };
+        if let Some(obj) = entry.as_object_mut() {
+            if let Some(uuid) = uuid {
+                obj.insert("message_uuid".to_string(), uuid);
+            }
+            if let Some(off_chain) = off_chain {
+                obj.insert("off_active_chain".to_string(), off_chain);
             }
         }
     }
@@ -1966,7 +2018,7 @@ mod tests {
         let sid = "cc-stamp-test";
         let lines = [
             r#"{"uuid":"u1","parentUuid":null,"type":"user","timestamp":"2026-07-19T00:00:01.000Z","message":{"role":"user","content":[{"type":"text","text":"continue"}]}}"#,
-            r#"{"uuid":"a1","parentUuid":"u1","type":"assistant","timestamp":"2026-07-19T00:00:02.000Z","message":{"role":"assistant","content":[{"type":"text","text":"ok one"}]}}"#,
+            r#"{"uuid":"a1","parentUuid":"u1","type":"assistant","timestamp":"2026-07-19T00:00:02.000Z","message":{"role":"assistant","content":[{"type":"text","text":"ok one"},{"type":"tool_use","id":"toolu_9","name":"Bash","input":{"command":"ls"}}]}}"#,
             r#"{"uuid":"u2","parentUuid":"a1","type":"user","timestamp":"2026-07-19T00:00:03.000Z","message":{"role":"user","content":[{"type":"text","text":"continue"}]}}"#,
             r#"{"uuid":"a2","parentUuid":"u2","type":"assistant","timestamp":"2026-07-19T00:00:04.000Z","message":{"role":"assistant","content":[{"type":"text","text":"ok two"}]}}"#,
         ];
@@ -1974,7 +2026,7 @@ mod tests {
 
         let mut entries = vec![
             serde_json::json!({"event":"log_entry","session_id":sid,"source":"User","content":"continue"}),
-            serde_json::json!({"event":"log_entry","session_id":sid,"source":"Claude Code","content":"ok one"}),
+            serde_json::json!({"event":"log_entry","session_id":sid,"source":"Claude Code","kind":"tool_call","item_id":"toolu_9","content":"Bash: ls"}),
             serde_json::json!({"event":"log_entry","session_id":sid,"source":"User","content":"continue"}),
         ];
         annotate_replay_user_turns_from_external_transcript(&mut entries, home, "claude-code", sid);
@@ -1983,6 +2035,9 @@ mod tests {
             entries[2]["message_uuid"], "u2",
             "duplicate prose maps in order, not to the first global match"
         );
-        assert!(entries[1].get("message_uuid").is_none());
+        assert_eq!(
+            entries[1]["message_uuid"], "a1",
+            "tool rows stamp via their exact item_id key (the anchor-labeled rows)"
+        );
     }
 }

--- a/src/bin/caller/web_gateway/session_catalog/replay.rs
+++ b/src/bin/caller/web_gateway/session_catalog/replay.rs
@@ -1979,10 +1979,6 @@ mod tests {
         ];
         annotate_replay_user_turns_from_external_transcript(&mut entries, home, "claude-code", sid);
         assert_eq!(entries[0]["message_uuid"], "u1");
-        assert!(
-            entries[0].get("user_turn_index").is_none(),
-            "claude stamps carry no codex revision fields"
-        );
         assert_eq!(
             entries[2]["message_uuid"], "u2",
             "duplicate prose maps in order, not to the first global match"

--- a/static/app/13-styles-sessions-terminal.css
+++ b/static/app/13-styles-sessions-terminal.css
@@ -3434,6 +3434,12 @@ html.ui-v2[data-theme="light"] .control-toast {
 @media (pointer: coarse) {
   .log-entry .log-fork-entry { opacity: 1; pointer-events: auto; }
 }
+/* The anchor-label companion is always visible — it rides a label that is
+   itself always visible, in the live lane and detail alike. */
+.log-entry .log-fork-entry.log-fork-inline {
+  opacity: 1;
+  pointer-events: auto;
+}
 .log-entry.has-fork-form { flex-wrap: wrap; }
 .log-fork-form-host {
   flex: 1 1 100%;

--- a/static/app/38-managed-context.js
+++ b/static/app/38-managed-context.js
@@ -510,6 +510,15 @@ function renderManagedContextAnchors() {
     btn.textContent = 'Use';
     btn.addEventListener('click', () => fillManagedContextAnchor(itemId, rowInfo.sessionId || sid));
     row.appendChild(btn);
+    const forkBtn = document.createElement('button');
+    forkBtn.type = 'button';
+    forkBtn.className = 'managed-context-btn';
+    forkBtn.textContent = 'Fork';
+    forkBtn.title = 'Fork the session at this anchor into a new session (the parent is untouched)';
+    forkBtn.addEventListener('click', () =>
+      managedContextForkFromAnchor(row, itemId, rowInfo.sessionId || sid)
+    );
+    row.appendChild(forkBtn);
     host.appendChild(row);
   }
   if (!host.childElementCount) {

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -1843,6 +1843,8 @@ function createLogScaffold(c, extraClass) {
       fillManagedContextAnchor(c.item_id, sid);
     });
     entry.appendChild(anchor);
+    // Everything labeled anchor forks: the ⑂ rides the label itself.
+    appendAnchorForkAffordance(entry, c, sid);
   }
   return { entry, hostId };
 }

--- a/static/app/57b-session-fork.js
+++ b/static/app/57b-session-fork.js
@@ -439,8 +439,15 @@ function anchorForkPointForRecord(source, record) {
 function appendAnchorForkAffordance(entry, record, sessionId) {
   const sid = String(sessionId || (record && record.session_id) || '').trim();
   if (!sid || !entry) return;
+  // Source resolution: the fork index (loaded eagerly when the detail
+  // opened) is authoritative and present even when the sessions-list
+  // metadata has not hydrated (a directly opened detail); the metadata
+  // row is the live-lane fallback.
+  const idx = _sessionForkInlineIndexes.get(sid);
   const meta = typeof sessionConfigMetadata === 'function' ? sessionConfigMetadata(sid) : null;
-  const source = typeof sessionConfigSource === 'function' ? sessionConfigSource(meta) : '';
+  const source =
+    (idx && idx.source) ||
+    (typeof sessionConfigSource === 'function' ? sessionConfigSource(meta) : '');
   const point = anchorForkPointForRecord(source, record);
   if (!point) return;
   const btn = document.createElement('button');

--- a/static/app/57b-session-fork.js
+++ b/static/app/57b-session-fork.js
@@ -338,6 +338,12 @@ function sessionForkRowHint(point) {
   if (point.kind === 'head') {
     return 'Fork at the current head (the child keeps the full history).';
   }
+  if (point.kind === 'item-anchor') {
+    return 'Fork at this anchor: the child keeps history through this item (vanilla codex rounds to the containing turn).';
+  }
+  if (point.kind === 'message' && point.message_uuid && !point.at_message_uuid) {
+    return 'Fork here: the child keeps history through this row and continues fresh from it.';
+  }
   return 'Fork from before this message: the child keeps everything above and redoes from here.';
 }
 
@@ -408,6 +414,71 @@ function sessionForkToggleRowForm(entry, btn, source, sessionId, point) {
     sessionForkDispatch(source, sessionId, point, nameInput.value.trim(), taskInput.value.trim(), status);
   });
   entry.appendChild(host);
+}
+
+// ── "Anything labeled anchor forks" ──
+// The ⑂ that rides every minted anchor label (the `log-anchor-btn` on
+// item rows, live lane and detail alike, plus the Managed pane's Recent
+// anchors list). Codex rows fork at the item anchor itself (the managed
+// binary cuts exactly; vanilla rounds down to the containing turn — the
+// engine labels the rounding); claude-code rows fork at the row's
+// transcript message uuid (hydrated detail rows carry it; live rows
+// without one get no button — a cut is never guessed).
+
+function anchorForkPointForRecord(source, record) {
+  if (!record) return null;
+  if (source === 'codex' && record.item_id) {
+    return { kind: 'item-anchor', item_id: record.item_id, position: 'after' };
+  }
+  if (source === 'claude-code' && record.message_uuid) {
+    return { kind: 'message', message_uuid: record.message_uuid };
+  }
+  return null;
+}
+
+function appendAnchorForkAffordance(entry, record, sessionId) {
+  const sid = String(sessionId || (record && record.session_id) || '').trim();
+  if (!sid || !entry) return;
+  const meta = typeof sessionConfigMetadata === 'function' ? sessionConfigMetadata(sid) : null;
+  const source = typeof sessionConfigSource === 'function' ? sessionConfigSource(meta) : '';
+  const point = anchorForkPointForRecord(source, record);
+  if (!point) return;
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'log-fork-entry log-fork-inline';
+  btn.textContent = '⑂';
+  btn.title =
+    source === 'codex'
+      ? 'Fork the session at this anchor (the vanilla codex binary rounds to the containing turn)'
+      : 'Fork the session: the child keeps history through this row';
+  btn.setAttribute('aria-label', 'Fork the session at this anchor');
+  btn.addEventListener('click', (ev) => {
+    ev.stopPropagation();
+    sessionForkToggleRowForm(entry, btn, source, sid, point);
+  });
+  entry.appendChild(btn);
+}
+
+// Managed pane Recent-anchors rows: same rule, list-shaped. Only codex
+// anchors dispatch (item ids from other backends' tool rows are not fork
+// keys); the status lands inline in the row.
+function managedContextForkFromAnchor(row, itemId, sessionId) {
+  const sid = String(sessionId || '').trim();
+  if (!sid || !itemId || !row) return;
+  const meta = typeof sessionConfigMetadata === 'function' ? sessionConfigMetadata(sid) : null;
+  // Item anchors are codex vocabulary — when the metadata row has not
+  // hydrated yet, codex is the only source this list can belong to.
+  const source =
+    (typeof sessionConfigSource === 'function' ? sessionConfigSource(meta) : '') || 'codex';
+  const point = anchorForkPointForRecord(source, { item_id: itemId });
+  if (!point) return;
+  let status = row.querySelector('.sd-fork-status');
+  if (!status) {
+    status = document.createElement('span');
+    status.className = 'sd-fork-status';
+    row.appendChild(status);
+  }
+  sessionForkDispatch(source, sid, point, '', '', status);
 }
 
 function anchorSummaryForUi(anchor) {


### PR DESCRIPTION
The rule this lands: **anything the UI labels an anchor forks** — the user-facing contract the fork program promised from its first brief.

- The `anchor` chips on item rows (live lane and detail, minted in createLogScaffold) get a ⑂ companion: codex rows dispatch an item-anchor fork (the managed binary cuts exactly; vanilla rounds down to the containing turn — the engine labels the rounding), claude rows dispatch a message fork at the row's transcript uuid. The Managed pane's Recent-anchors rows gain a **Fork** button beside **Use** (codex vocabulary; non-codex ids never dispatch).
- **The bug a user screenshot exposed:** a fully supervised claude session's detail view renders ONLY daemon-log rows — no transcript uuids — so the claude inline fork join (`message_uuid`) matched nothing and such sessions showed zero fork buttons on message rows, while hydration-dominated sessions showed them. The replay annotator that already correlates daemon user rows to transcript turns (in order, duplicate prose maps sequentially) now also stamps `message_uuid` + `off_active_chain`; its transcript-side source filter is case-insensitive (claude transcript rows say `User`; the filter matched `user`, so claude never annotated at all).
- Known residual, deliberately out: live-lane claude rows have no uuid until the wrapper stamps one at event time — their anchor chips stay fork-less; codex chips fork in every lane.

Tests: in-order uuid stamping with duplicate prose + no codex fields on claude stamps; full suite green; app.html regenerated from fragments.