### PR TITLE
dashboard: pane-gate per-second tickers; drop hot-path :has() gates

### DIFF
--- a/static/app/20-shell.html
+++ b/static/app/20-shell.html
@@ -122,11 +122,12 @@
            on the left; the Log view's tools on the right (session switcher,
            Focus/Grid, the Arrange menu holding the bulk window sweeps, and
            the Options popover holding verbosity + host filter). The tools
-           are CSS-gated to the log sub-tab
-           (#activity-subtabs:has([data-activity-tab="log"].active))
+           are CSS-gated to the log sub-tab via the stamped
+           data-active-subtab attribute (kept current by
+           switchActivitySubtab; this default matches the .active button)
            — every element keeps its id, so ui2-chrome.js / ui2-activity.js
            wiring is untouched by the move out of the oversight bar. -->
-      <div class="subtabs" id="activity-subtabs">
+      <div class="subtabs" id="activity-subtabs" data-active-subtab="log">
         <div class="ui2-view-switch" role="group" aria-label="Activity views">
           <button class="subtab-btn active" data-activity-tab="log"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 12h4l2.5-6 4 12 2.5-6h5"/></svg>Timeline</button>
           <button class="subtab-btn" data-activity-tab="context"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3 4 7.5l8 4.5 8-4.5Z"/><path d="m4 12 8 4.5 8-4.5"/><path d="m4 16.5 8 4.5 8-4.5"/></svg>Context</button>

--- a/static/app/32-vault-custody.js
+++ b/static/app/32-vault-custody.js
@@ -1709,13 +1709,26 @@ function agentSigninCountdownText(deadlineMs) {
   const seconds = String(totalSec % 60).padStart(2, '0');
   return `code expires in ${minutes}:${seconds}`;
 }
+function agentSigninRenderCountdowns() {
+  for (const el of document.querySelectorAll('[data-signin-countdown]')) {
+    el.textContent = agentSigninCountdownText(Number(el.dataset.signinCountdown));
+  }
+}
 function agentSigninEnsureTicker() {
   const needsTick = agentSigninPhase('codex') === 'awaiting_user';
   if (needsTick && !agentSigninTickTimer) {
     agentSigninTickTimer = window.setInterval(() => {
-      for (const el of document.querySelectorAll('[data-signin-countdown]')) {
-        el.textContent = agentSigninCountdownText(Number(el.dataset.signinCountdown));
+      // Pane gate: the countdown lives in the Access pane
+      // (#agent-signin-section), so with that tab parked (or the page
+      // backgrounded) the per-second textContent write hit a display:none
+      // subtree — and still ran style invalidation. While parked, defer
+      // ONE repaint; flushPaneRenders runs it on pane re-entry, so the
+      // countdown is correct the instant the pane shows.
+      if (!paneIsVisible('access')) {
+        renderOrDefer('access', 'agent-signin-countdown', agentSigninRenderCountdowns);
+        return;
       }
+      agentSigninRenderCountdowns();
     }, 1000);
   } else if (!needsTick && agentSigninTickTimer) {
     window.clearInterval(agentSigninTickTimer);

--- a/static/app/39-session-windows.js
+++ b/static/app/39-session-windows.js
@@ -682,6 +682,31 @@ function renderSessionWindowTier(win) {
 }
 
 function refreshSessionGoalTicker() {
+  // Pane gate: session windows live in the Activity tab, so with the tab
+  // parked (another tab active, or the page backgrounded) the per-second
+  // elapsed-time repaint wrote textContent into a display:none subtree —
+  // and every write still runs style invalidation (the `:has()`
+  // before-mutation walk). While parked, keep only the schedule math (is
+  // any goal still active, so the interval arms/disarms exactly as
+  // before) and defer ONE full repaint; flushPaneRenders runs it
+  // synchronously on pane re-entry, so the pane never shows stale text.
+  if (!paneIsVisible('activity')) {
+    let hasActiveGoal = false;
+    for (const [sid] of sessionWindows) {
+      const goal = (sessionMetadataById.get(sid) || {}).goal || null;
+      // Mirrors renderSessionWindowGoal's return value without its DOM
+      // writes: active means "has an objective and status active".
+      if (goal?.objective && normalizeGoalStatus(goal.status) === 'active') hasActiveGoal = true;
+    }
+    renderOrDefer('activity', 'session-goal-tick', refreshSessionGoalTicker);
+    if (hasActiveGoal && !sessionGoalTicker) {
+      sessionGoalTicker = setInterval(refreshSessionGoalTicker, 1000);
+    } else if (!hasActiveGoal && sessionGoalTicker) {
+      clearInterval(sessionGoalTicker);
+      sessionGoalTicker = null;
+    }
+    return;
+  }
   let hasActiveGoal = false;
   for (const [sid, win] of sessionWindows) {
     const goal = (sessionMetadataById.get(sid) || {}).goal || null;
@@ -1785,6 +1810,12 @@ function startVitalsPanelTicker() {
       stopVitalsPanelTicker();
       return;
     }
+    // Page Visibility gate only (not the pane's): the panel is a
+    // body-level overlay, so it can outlive a keyboard/hash tab switch and
+    // stay legitimately on screen — but a backgrounded page has no reader,
+    // and each 1 Hz text write still ran style invalidation. The
+    // visibilitychange hook below repaints immediately on return.
+    if (document.hidden) return;
     try { host._vxTick(); } catch (_) { /* next tick retries */ }
   }, 1000);
 }
@@ -1794,6 +1825,23 @@ function stopVitalsPanelTicker() {
   clearInterval(vitalsPanelTicker);
   vitalsPanelTicker = null;
 }
+
+// Catch-up for the two body-level overlays whose tickers park on
+// document.hidden (the vitals explainer above, the background-task output
+// viewer below): on return to a visible page, repaint immediately instead
+// of waiting out the current interval — countdown text and output tails
+// must never show parked-era values to a reader who just came back.
+document.addEventListener('visibilitychange', () => {
+  if (document.hidden) return;
+  const vx = document.getElementById('vitals-explainer');
+  if (vx && !vx.hidden && typeof vx._vxTick === 'function') {
+    try { vx._vxTick(); } catch (_) { /* the 1 Hz interval retries */ }
+  }
+  const bgov = document.getElementById('bg-output-viewer');
+  if (bgov && !bgov.hidden && typeof bgov._refresh === 'function') {
+    bgov._refresh();
+  }
+});
 
 // Write-guarded textContent: no-op when the rendered second hasn't
 // rolled over, so ticks never churn text nodes (or observers) idly.
@@ -2357,6 +2405,7 @@ function closeBgOutputViewer() {
   const host = document.getElementById('bg-output-viewer');
   if (!host) return;
   host.hidden = true;
+  host._refresh = null;
   if (host._refreshTimer) {
     clearInterval(host._refreshTimer);
     host._refreshTimer = null;
@@ -2391,6 +2440,12 @@ function openSessionBackgroundTaskOutput(sessionId, task) {
   host.hidden = false;
 
   const refresh = async () => {
+    // Backgrounded page: the 2 s tail poll exists only to paint this
+    // panel, so park the request and the writes together (the interval
+    // stays armed and no-ops). The visibilitychange catch-up near
+    // startVitalsPanelTicker repaints — and re-observes a finished task —
+    // immediately on return.
+    if (document.hidden) return;
     let body = null;
     try {
       const resp = await daemonApi.request(
@@ -2425,6 +2480,7 @@ function openSessionBackgroundTaskOutput(sessionId, task) {
     }
   };
   refresh();
+  host._refresh = refresh;
   host._refreshTimer = setInterval(refresh, 2000);
 }
 
@@ -2879,6 +2935,17 @@ function sessionVitalsNeedsTick(vitals) {
 }
 
 function refreshSessionVitalsTicker() {
+  // Pane gate: with the Activity tab parked (another tab active, or the
+  // page backgrounded) the countdown repaints wrote textContent into a
+  // display:none subtree every second, and each write still ran style
+  // invalidation (the `:has()` before-mutation walk). While parked, the
+  // tick keeps its non-UI duties — the arm/disarm schedule math and the
+  // cache-expiry alert, which matters MOST when the user is not watching
+  // (it posts the toast/Notification) — and skips only the DOM writes,
+  // deferring ONE full repaint that flushPaneRenders runs synchronously
+  // on pane re-entry. win.vitalsNeededTick deliberately stays untouched
+  // while parked so the trailing settle render still happens on re-entry.
+  const visible = paneIsVisible('activity');
   let ticking = false;
   for (const [sid, win] of sessionWindows) {
     const vitals = (sessionMetadataById.get(sid) || {}).vitals || null;
@@ -2888,16 +2955,20 @@ function refreshSessionVitalsTicker() {
     // to its cold glyph and a passed limit-reset drops its "↻~Xm" text —
     // instead of freezing mid-count.
     if (!needsTick && !win.vitalsNeededTick) continue;
-    win.vitalsNeededTick = needsTick;
-    renderSessionWindowVitals(win, vitals);
-    // The stalled degradation is purely time-derived — let the status
-    // pill follow the derived state (no-op unless the state flipped).
-    maybeRefreshSessionWindowActivityPill(sid, win, vitals);
     // Arm from the predicate, not the render result: the render reports
     // only cache-ttl models as ticking, which left percentless limit-reset
     // countdowns frozen because nothing kept the interval alive for them.
     if (needsTick) ticking = true;
     maybeAlertCacheExpiry(sid, win, vitals);
+    if (!visible) continue;
+    win.vitalsNeededTick = needsTick;
+    renderSessionWindowVitals(win, vitals);
+    // The stalled degradation is purely time-derived — let the status
+    // pill follow the derived state (no-op unless the state flipped).
+    maybeRefreshSessionWindowActivityPill(sid, win, vitals);
+  }
+  if (!visible) {
+    renderOrDefer('activity', 'session-vitals-tick', refreshSessionVitalsTicker);
   }
   if (ticking && !sessionVitalsTicker) {
     sessionVitalsTicker = setInterval(refreshSessionVitalsTicker, 1000);

--- a/static/app/48-router-settings.js
+++ b/static/app/48-router-settings.js
@@ -481,6 +481,14 @@ const contextAnalysisBySnapshot = new WeakMap();
 function switchActivitySubtab(name) {
   if (activeActivitySubtab === name) return;
   activeActivitySubtab = name;
+  // Stamped state for CSS: ui2-activity.css gates the Timeline tools and
+  // the Arrange menu on this attribute instead of
+  // `:has(.subtab-btn[data-activity-tab="log"].active)` — the subtabs bar
+  // sits beside the per-second-ticking Activity panes, and `:has()`
+  // registrations there taxed every mutation's style-invalidation walk
+  // (derive from the stamp the switcher already owns, don't make the
+  // engine infer it). The HTML default is data-active-subtab="log".
+  document.getElementById('activity-subtabs')?.setAttribute('data-active-subtab', name);
   document.querySelectorAll('#activity-subtabs .subtab-btn').forEach(btn => {
     btn.classList.toggle('active', btn.dataset.activityTab === name);
   });

--- a/static/app/ui2-activity.css
+++ b/static/app/ui2-activity.css
@@ -126,7 +126,12 @@ html.ui-v2 #activity-subtabs .ui2-activity-tools {
   margin-left: auto;
   flex-shrink: 0;
 }
-html.ui-v2 #activity-subtabs:has(.subtab-btn[data-activity-tab="log"].active) .ui2-activity-tools {
+/* Gated on the switcher's stamped data-active-subtab (48-router-settings.js
+   switchActivitySubtab; HTML default "log") rather than
+   `:has(.subtab-btn[data-activity-tab="log"].active)`: the subtabs bar sits
+   beside the per-second-ticking Activity panes, and a `:has()` registration
+   here taxed every DOM mutation's style-invalidation walk. */
+html.ui-v2 #activity-subtabs[data-active-subtab="log"] .ui2-activity-tools {
   display: inline-flex;
 }
 
@@ -239,7 +244,9 @@ html.ui-v2:not([data-ui2-layout="grid"]) #activity-subtabs .ui2-arrange-btn { di
    the log sub-tab active — so a stale .open can never surface the menu
    in Focus or on another sub-tab. */
 html.ui-v2 #ui2-arrange-menu { display: none; }
-html.ui-v2[data-ui2-layout="grid"] #activity-subtabs:has(.subtab-btn[data-activity-tab="log"].active) #ui2-arrange-menu.open {
+/* data-active-subtab replaces the former `:has(.subtab-btn…)` gate — same
+   condition, derived from the switcher's stamp (see the tools rule above). */
+html.ui-v2[data-ui2-layout="grid"] #activity-subtabs[data-active-subtab="log"] #ui2-arrange-menu.open {
   display: flex;
   flex-direction: column;
   align-items: stretch;

--- a/static/app/ui2-activity.js
+++ b/static/app/ui2-activity.js
@@ -684,11 +684,20 @@ function ui2StampApprovalSession() {
 function ui2RailSetRow(id, text, titleLines, state) {
   const row = document.getElementById(id);
   if (!row) return;
+  // Write-guarded: the 1 Hz tick mostly re-derives identical values, and
+  // unconditional textContent/attribute assignment churns text nodes and
+  // feeds every style-invalidation pass (the `:has()` before-mutation
+  // walk) once per row per second for nothing.
   const value = row.querySelector('.ui2-rail-value');
-  if (value) value.textContent = text || '—';
-  row.title = Array.isArray(titleLines) ? titleLines.join('\n') : '';
-  if (state) row.dataset.state = state;
-  else delete row.dataset.state;
+  const nextText = text || '—';
+  if (value && value.textContent !== nextText) value.textContent = nextText;
+  const nextTitle = Array.isArray(titleLines) ? titleLines.join('\n') : '';
+  if (row.title !== nextTitle) row.title = nextTitle;
+  if (state) {
+    if (row.dataset.state !== state) row.dataset.state = state;
+  } else if ('state' in row.dataset) {
+    delete row.dataset.state;
+  }
 }
 
 function ui2BuildVitalsRail() {
@@ -811,8 +820,8 @@ function ui2RailTick(force) {
         label = parts.name || parts.shortId || label;
       }
     }
-    sessionEl.textContent = label;
-    sessionEl.title = sid;
+    if (sessionEl.textContent !== label) sessionEl.textContent = label;
+    if (sessionEl.title !== sid) sessionEl.title = sid;
   }
 
   const meta = (sid && typeof sessionMetadataById !== 'undefined' && sessionMetadataById.get(sid)) || {};
@@ -841,7 +850,10 @@ function ui2RailTick(force) {
   const pctText = pctSrc ? (pctSrc.textContent || '').trim() : '';
   ui2RailSetRow('ui2-rail-ctx', pctText || '—', null, null);
   const fill = document.getElementById('ui2-rail-ctx-fill');
-  if (fill) fill.style.width = Math.max(0, Math.min(100, parseFloat(pctText) || 0)) + '%';
+  if (fill) {
+    const width = Math.max(0, Math.min(100, parseFloat(pctText) || 0)) + '%';
+    if (fill.style.width !== width) fill.style.width = width;
+  }
 
   // Changes count mirrors the sub-tab badge.
   const badge = document.getElementById('badge-changes');
@@ -858,7 +870,16 @@ function ui2RailTick(force) {
     ui2DressComposer();
     ui2BuildVitalsRail();
     ui2RailTick(true);
-    setInterval(() => ui2RailTick(), 1000);
+    // Pane-gated 1 Hz repaint: the offsetParent check inside ui2RailTick
+    // already skips hidden sub-tab/layout states, but with the Activity
+    // tab parked (another tab active, or the page backgrounded —
+    // document.hidden) the rail kept writing per second into a display:none
+    // subtree. renderOrDefer keeps the visible cadence identical and, while
+    // parked, retains only the LATEST repaint thunk, which flushPaneRenders
+    // runs synchronously on pane re-entry — fresh values with zero hidden
+    // writes. (31-init-identity-fleet.js declares the deferral state, so it
+    // must only be reached from this async callback, never module-eval.)
+    setInterval(() => renderOrDefer('activity', 'ui2-rail-tick', () => ui2RailTick()), 1000);
     // Focus surface: follow stream appends, target changes (the chip
     // re-renders on every change), layout flips, and the session-window
     // grid's own MEMBERSHIP — a session resumed from the Sessions tab

--- a/static/app/ui2-agenda.js
+++ b/static/app/ui2-agenda.js
@@ -510,16 +510,21 @@ function agendaRenderCard() {
 
 // The vitals rail owns the top-right column; stack the card just under
 // its live height (both hide together below 1180px / in grid layout).
+// Write-guarded: the 1 Hz reposition mostly re-derives the same state, and
+// re-stamping data-rail-hidden / style.top with unchanged values fed a
+// style-invalidation pass per second (the `:has()` before-mutation walk)
+// for nothing.
 function agendaPositionCard() {
   const card = document.getElementById('ui2-agenda-card');
   const rail = document.getElementById('ui2-vitals-rail');
   if (!card) return;
   if (!rail || !rail.offsetParent) {
-    card.dataset.railHidden = '1';
+    if (card.dataset.railHidden !== '1') card.dataset.railHidden = '1';
     return;
   }
-  delete card.dataset.railHidden;
-  card.style.top = `${rail.offsetTop + rail.offsetHeight + 12}px`;
+  if ('railHidden' in card.dataset) delete card.dataset.railHidden;
+  const top = `${rail.offsetTop + rail.offsetHeight + 12}px`;
+  if (card.style.top !== top) card.style.top = top;
 }
 
 {
@@ -560,7 +565,12 @@ function agendaPositionCard() {
     }
     agendaBuildCard();
     agendaRefresh();
-    setInterval(agendaPositionCard, 1000);
+    // Pane-gated: the card lives in #activity-log-pane, so with the
+    // Activity tab parked (another tab, or document.hidden) the reposition
+    // tick used to write data-rail-hidden into a display:none subtree once
+    // per second. renderOrDefer keeps only the latest reposition thunk
+    // while parked; flushPaneRenders runs it on pane re-entry.
+    setInterval(() => renderOrDefer('activity', 'ui2-agenda-card', agendaPositionCard), 1000);
     agendaPositionCard();
   };
   if (document.readyState === 'complete') wire();


### PR DESCRIPTION
Fixes the measured Safari main-thread churn: per-second tickers kept firing and writing DOM text on panes the user was not viewing, and each write ran style invalidation against a stylesheet carrying 40+ `:has()` selectors (`timerFired → setJSNode_textContent → Style::Invalidator … invalidateForHasBeforeMutation`, ~3% of a 1s main-thread sample while parked on a different tab).

## Part 1 — pane-gate the tickers

All gating derives from the existing `paneIsVisible(tab)` (`activeTab` + `document.hidden`) and routes deferred repaints through the existing `renderOrDefer`/`flushPaneRenders` infra, which `switchTab` already replays **synchronously on pane re-entry** — so a re-entered pane paints fresh values immediately, not one tick later. Visible-pane cadence is unchanged everywhere; no interval was retimed.

| Ticker | Cadence | Gate | DOM writes skipped while parked | State math kept running while parked |
|---|---|---|---|---|
| Vitals rail tick (`ui2-activity.js`) | 1s | `renderOrDefer('activity', 'ui2-rail-tick', …)` | rail row text/title/`data-state`, session label, ctx fill | none needed (pure repaint; `railTicks` QA counter counts render passes, deferred repaint still increments on re-entry) |
| Session goal ticker (`39-session-windows.js`) | 1s, self-disarming | visible branch renders; parked branch defers one full repaint | per-window goal class/text/title | active-goal predicate (mirrors `renderSessionWindowGoal`'s verdict) still arms/disarms the interval exactly as before |
| Session vitals ticker (`39-session-windows.js`) | 1s, self-disarming | per-window `if (!visible) continue` after non-UI duties; defers one full repaint | `renderSessionWindowVitals`, activity pill | `sessionVitalsNeedsTick` arm/disarm math AND `maybeAlertCacheExpiry` — the expiry toast/`Notification` fires precisely when the user is *not* watching, so it stays on the tick; `win.vitalsNeededTick` deliberately untouched while parked so the trailing settle render still lands on re-entry |
| Agenda card reposition (`ui2-agenda.js`) | 1s | `renderOrDefer('activity', 'ui2-agenda-card', …)` | `data-rail-hidden` stamp, `style.top` (previously re-stamped **unconditionally every second precisely when parked**) | none needed (pure position mirror) |
| Vitals explainer panel ticker (`39-session-windows.js`) | 1s, open-panel only | `document.hidden` only | in-place countdown/elapsed text | none; body-level overlay can legitimately outlive a keyboard/hash tab switch, so the pane gate would freeze a visible panel — visibility is the correct gate; `visibilitychange` hook repaints immediately on return |
| Background-task output viewer (`39-session-windows.js`) | 2s poll, open-panel only | `document.hidden` only (skips the network poll too — it exists only to paint the panel) | status chip, note, output tail | interval stays armed and no-ops; the `visibilitychange` hook re-polls immediately on return and thereby re-observes a task that finished while hidden (which stops the poll as before) |
| Agent sign-in countdown (`32-vault-custody.js`) | 1s, ceremony only | `renderOrDefer('access', 'agent-signin-countdown', …)` | countdown text (lives in `#agent-signin-section`, Access pane) | expiry is derived from the deadline at render time, so nothing else needs to run; deferred repaint is correct the instant the pane shows |

Audited and deliberately left alone: Station metrics/liveness (already gated on `activeTab`/`document.hidden`), access presence poll (already `paneIsVisible('access')`-gated — the pattern precedent), session-window metadata poll (already gated by `shouldPollSessionWindowMetadata`), target-switch popover poll (interval exists only while the popover is open; any outside press closes it), display viewer stats timers (torn down with the viewer on tab exit), vault lease renew + sign-in completion polls (network schedule, must keep running), approval-delivery confirm poll (250ms, 5s-bounded, event-driven), recording segment/staleness/fuel/freshness timers (≥5s cadence, event-guarded).

Write guards were also added where the ticker re-derives identical values (`ui2RailSetRow`, session label, ctx fill, agenda card): unchanged values no longer touch the DOM at all, so even visible idle ticks stop feeding the invalidation walk. Cadence is untouched — the guards only skip no-op writes.

## Part 2 — targeted `:has()` hygiene

Only the two rules whose anchor sits in the Activity tab beside the per-second-mutated panes are restructured (`ui2-activity.css`):

- `#activity-subtabs:has(.subtab-btn[data-activity-tab="log"].active) .ui2-activity-tools`
- `[data-ui2-layout="grid"] #activity-subtabs:has(.subtab-btn[data-activity-tab="log"].active) #ui2-arrange-menu.open`

both become `#activity-subtabs[data-active-subtab="log"] …`, keyed off a `data-active-subtab` attribute stamped by `switchActivitySubtab` — the single place that already toggles the subtab button classes (the codebase's derive-from-stamped-state precedent). The static HTML default (`data-active-subtab="log"` in `20-shell.html`) matches the boot-active button, so CSS is correct before any JS runs. Justification: these two rules registered `:has()` invalidation features (including the ubiquitous `active` class) anchored right next to the subtrees every per-second ticker mutates, and an exact-value attribute selector invalidates only on that attribute of that element.

The remaining `:has()` rules (vault 14, live 9, access 8, activity 3, sessions/chrome/legacy 4) are deliberately left: their anchors are not ancestors of any per-second-mutated subtree, their arguments flip only on discrete user events (checkbox/radio state, `focus-visible`, connection status, structural form presence), and the panes they live on have their tickers gated by Part 1 — restructuring them buys nothing measurable against real regression risk in 39 selectors.

## Verification (live boot probe)

`scripts/validate-dashboard.cjs --launch-dashboard` on a throwaway port with this branch's binary, driving the real SPA over CDP:

- **Parked pane silent**: with Sessions active, a `MutationObserver` (subtree + childList + characterData + attributes) over `#ui2-vitals-rail`, `#ui2-agenda-card`, `#session-window-grid` for 3.2s → `{"targets":3,"mutationsWhileParked":0,"railTicksDuringPark":0,"deferredWhileParked":3,"railTickRanOnReentry":true}` — zero DOM writes while parked, and the deferred repaint ran synchronously inside the tab-switch click.
- **Visible cadence unchanged**: on Activity for 3.2s → `{"railTicksOver3s":3,"railVisible":true,"railMutationsWhileVisible":0}` — 1 Hz render passes intact; zero mutations here is the write guards at work on an idle rail (values unchanged tick-to-tick), not a skipped tick.
- `PASS dashboard-validation` (boot checks) and `PASS dashboard-static-scripts file="static/app.html" scripts=3 classic=2 modules=1`.

## Battery

- `cargo fmt --check` — clean
- `cargo check` — green (pre- and post-merge of origin/main)
- `cargo test -p intendant --bins` — `4222 passed; 0 failed; 10 ignored` / `147 passed; 0 failed` / `97 passed; 0 failed`
- lib crates (`intendant-core`, `intendant-display`, `intendant-platform`, `owner-plane-core`, `owner-plane-reducer`) — `218` / `571` (2 ignored) / `26` (1 ignored) / `88` / `39` passed, 0 failed
- `cargo clippy --workspace -- -D warnings` — clean
- `node --check` on every edited fragment — clean
- `static/app.html` regenerated from fragments via `app-html-assembler` and committed (including the post-merge regen after #494 landed; the only merge conflict was the generated artifact, resolved by regeneration).
