### PR TITLE
Sub-agent terminal evidence: task-id rekey (CC), rollout-derived DONE (Codex), restored-window task text

### DIFF
--- a/src/bin/caller/external_agent/codex/rollout.rs
+++ b/src/bin/caller/external_agent/codex/rollout.rs
@@ -75,6 +75,16 @@ pub(crate) fn codex_line_may_affect_replay(line: &str) -> bool {
         // their anchor — including non-message items (function_call, reasoning) that
         // render no transcript entry but are the usual targets of a noise-trim rewind.
         (Some("response_item"), _) => true,
+        // Turn-boundary event_msgs are subagent-terminal evidence: a child
+        // thread's rollout ends at `task_complete` (with the final message
+        // in `last_agent_message`) and the catalog parser synthesizes the
+        // completed-terminal row from the LAST such boundary
+        // (`parse_codex_session_entries`); `turn_aborted` retracts it.
+        // `task_started` stays filtered: the parser's turn-id branch for
+        // it has never received lines through this filter, and admitting
+        // it would silently swap hydrated turn ids from the user-row
+        // synthetic ones to rollout turn ids — a separate decision.
+        (Some("event_msg"), Some("task_complete" | "turn_aborted")) => true,
         (Some("event_msg"), None) => true,
         (None, _) => true,
         _ => false,

--- a/src/bin/caller/web_gateway/session_catalog/task_threads.rs
+++ b/src/bin/caller/web_gateway/session_catalog/task_threads.rs
@@ -14,7 +14,8 @@
 //! walks plus one tiny JSON read per meta — transcripts are never opened
 //! here. Codex sub-threads need no counterpart: they get first-class
 //! rollout files under their own thread ids, so the ordinary finder
-//! already resolves them.
+//! already resolves them (their completed-terminal synthesis lives in
+//! the ordinary codex parse — see `parse_codex_session_entries`).
 
 use super::*;
 
@@ -174,11 +175,13 @@ fn subagent_meta_task_tool_use_id(meta_path: &Path, session_id: &str) -> Option<
 // DONE the live window showed.
 // ---------------------------------------------------------------------
 
-/// `kind` marker of the synthesized completed-terminal row. The dashboard
+/// `kind` marker of the synthesized completed-terminal row — shared by
+/// this Claude Code lane and the Codex twin
+/// (`codex_subagent_terminal_entry` in `transcripts.rs`). The dashboard
 /// counts it as done-evidence during hydration and dedupes it against the
 /// live "Task complete" log line (which carries a different timestamp and
 /// event id, so signature dedupe never pairs them).
-pub(crate) const CLAUDE_TASK_TERMINAL_KIND: &str = "subagent_terminal";
+pub(crate) const SUBAGENT_TERMINAL_KIND: &str = "subagent_terminal";
 
 const TASK_NOTIFICATION_OPEN: &str = "<task-notification>";
 const TASK_NOTIFICATION_CLOSE: &str = "</task-notification>";
@@ -310,8 +313,10 @@ fn xml_tag_text(block: &str, tag: &str) -> Option<String> {
 
 /// One-line, bounded summary — the same shaping the live emit applies
 /// (`claude_code::task_summary_snippet`), so hydrated rows read like the
-/// live "Task complete" line byte-for-byte.
-fn task_terminal_summary_snippet(text: &str) -> Option<String> {
+/// live "Task complete" line byte-for-byte. Shared with the Codex
+/// terminal synthesis (`codex_subagent_terminal_entry`), which bounds the
+/// child's full `last_agent_message` the same way.
+pub(crate) fn task_terminal_summary_snippet(text: &str) -> Option<String> {
     let joined = text.split_whitespace().collect::<Vec<_>>().join(" ");
     let trimmed = joined.trim();
     if trimmed.is_empty() {
@@ -369,7 +374,7 @@ pub(crate) fn claude_task_terminal_entry(
     let mut entry = serde_json::json!({
         "level": "info",
         "source": label,
-        "kind": CLAUDE_TASK_TERMINAL_KIND,
+        "kind": SUBAGENT_TERMINAL_KIND,
         "content": content,
     });
     if let Some(ts) = notification.ts {
@@ -753,14 +758,14 @@ mod tests {
         let terminals: Vec<_> = entries
             .iter()
             .filter(|entry| {
-                entry.get("kind").and_then(|v| v.as_str()) == Some(CLAUDE_TASK_TERMINAL_KIND)
+                entry.get("kind").and_then(|v| v.as_str()) == Some(SUBAGENT_TERMINAL_KIND)
             })
             .collect();
         assert_eq!(terminals.len(), 1);
         let terminal = entries.last().expect("entries end with the terminal row");
         assert_eq!(
             terminal.get("kind").and_then(|v| v.as_str()),
-            Some(CLAUDE_TASK_TERMINAL_KIND)
+            Some(SUBAGENT_TERMINAL_KIND)
         );
         assert_eq!(
             terminal.get("content").and_then(|v| v.as_str()),
@@ -800,7 +805,7 @@ mod tests {
         );
         assert_eq!(
             last.get("kind").and_then(|v| v.as_str()),
-            Some(CLAUDE_TASK_TERMINAL_KIND)
+            Some(SUBAGENT_TERMINAL_KIND)
         );
     }
 
@@ -947,7 +952,7 @@ mod tests {
         let terminal = entries.last().expect("terminal row");
         assert_eq!(
             terminal.get("kind").and_then(|v| v.as_str()),
-            Some(CLAUDE_TASK_TERMINAL_KIND)
+            Some(SUBAGENT_TERMINAL_KIND)
         );
         assert_eq!(
             terminal.get("content").and_then(|v| v.as_str()),
@@ -1020,7 +1025,7 @@ mod tests {
             .expect("task child entries");
         assert_eq!(entries.len(), 2);
         assert!(!entries.iter().any(|entry| {
-            entry.get("kind").and_then(|v| v.as_str()) == Some(CLAUDE_TASK_TERMINAL_KIND)
+            entry.get("kind").and_then(|v| v.as_str()) == Some(SUBAGENT_TERMINAL_KIND)
         }));
     }
 
@@ -1056,7 +1061,7 @@ mod tests {
         let entries = external_session_entries_from_home(home.path(), "claude-code", TASK_ID)
             .expect("task child entries");
         assert!(!entries.iter().any(|entry| {
-            entry.get("kind").and_then(|v| v.as_str()) == Some(CLAUDE_TASK_TERMINAL_KIND)
+            entry.get("kind").and_then(|v| v.as_str()) == Some(SUBAGENT_TERMINAL_KIND)
         }));
     }
 
@@ -1159,7 +1164,7 @@ mod tests {
         let terminals = third
             .iter()
             .filter(|entry| {
-                entry.get("kind").and_then(|v| v.as_str()) == Some(CLAUDE_TASK_TERMINAL_KIND)
+                entry.get("kind").and_then(|v| v.as_str()) == Some(SUBAGENT_TERMINAL_KIND)
             })
             .count();
         assert_eq!(terminals, 1);
@@ -1177,8 +1182,8 @@ mod tests {
         )
         .expect("dashboard fragment 39-session-windows.js");
         assert!(
-            fragment.contains(&format!("'{CLAUDE_TASK_TERMINAL_KIND}'")),
-            "the merge guard must key on kind '{CLAUDE_TASK_TERMINAL_KIND}'"
+            fragment.contains(&format!("'{SUBAGENT_TERMINAL_KIND}'")),
+            "the merge guard must key on kind '{SUBAGENT_TERMINAL_KIND}'"
         );
         assert!(
             fragment.contains("startsWith('Task complete:')"),

--- a/src/bin/caller/web_gateway/session_catalog/task_threads.rs
+++ b/src/bin/caller/web_gateway/session_catalog/task_threads.rs
@@ -42,6 +42,12 @@ pub(crate) fn is_claude_task_child_id(session_id: &str) -> bool {
 pub(crate) struct ClaudeTaskSubagentArtifacts {
     pub(crate) transcript: PathBuf,
     pub(crate) tool_use_id: String,
+    /// The subagent's `agentId` — the `agent-<id>` file stem without its
+    /// prefix. Every `<task-notification>` vintage carries it as
+    /// `<task-id>` (the spawn `<tool-use-id>` is newer and, for a child
+    /// interrupted and re-run, each later run notifies under a NEW
+    /// tool_use id), so this is the stable terminal-evidence key.
+    pub(crate) agent_id: String,
     pub(crate) parent_transcript: Option<PathBuf>,
 }
 
@@ -122,6 +128,10 @@ pub(crate) fn find_claude_task_subagent_artifacts(
                 let artifacts = ClaudeTaskSubagentArtifacts {
                     transcript,
                     tool_use_id,
+                    agent_id: agent_stem
+                        .strip_prefix("agent-")
+                        .unwrap_or(agent_stem)
+                        .to_string(),
                     parent_transcript,
                 };
                 if artifacts.parent_transcript.is_some() {
@@ -182,18 +192,27 @@ struct ClaudeTaskNotification {
     ts_ms: Option<i64>,
 }
 
-/// The LAST `<task-notification>` for this `tool_use_id` in the parent
-/// transcript ("the same task-id may notify more than once" — a resumed
-/// child re-notifies, so recency wins). One bounded pass: lines are only
-/// JSON-parsed when they contain the correlation needle, and only the
-/// two record shapes Claude Code writes the block into are accepted — an
-/// assistant message QUOTING the block must not count as evidence.
+/// The LAST `<task-notification>` for this child in the parent transcript
+/// ("the same task-id may notify more than once" — a resumed child
+/// re-notifies, so recency wins). A block counts when it carries EITHER
+/// correlation key: the spawn `<tool-use-id>` needle, or the
+/// `<task-id>{agent_id}</task-id>` needle — a child interrupted and
+/// re-run notifies each later run under a NEW tool_use id (and an
+/// earlier-segment spawn's toolu may not be in this file at all), while
+/// the `<task-id>` = agentId is present in every notification vintage.
+/// Prose mentions of the raw ids never match the full-tag needles. One
+/// bounded pass: lines are only JSON-parsed when they contain a needle,
+/// and only the two record shapes Claude Code writes the block into are
+/// accepted — an assistant message QUOTING the block must not count as
+/// evidence.
 fn last_claude_task_notification(
     parent_transcript: &Path,
     tool_use_id: &str,
+    agent_id: &str,
 ) -> Option<ClaudeTaskNotification> {
     use std::io::BufRead as _;
-    let needle = format!("<tool-use-id>{tool_use_id}</tool-use-id>");
+    let spawn_needle = format!("<tool-use-id>{tool_use_id}</tool-use-id>");
+    let task_needle = format!("<task-id>{agent_id}</task-id>");
     let file = std::fs::File::open(parent_transcript).ok()?;
     let reader = std::io::BufReader::new(file);
     let mut last = None;
@@ -201,7 +220,7 @@ fn last_claude_task_notification(
         let Ok(line) = line else {
             continue;
         };
-        if !line.contains(&needle) {
+        if !line.contains(&spawn_needle) && !line.contains(&task_needle) {
             continue;
         }
         let Ok(record) = serde_json::from_str::<serde_json::Value>(&line) else {
@@ -218,7 +237,13 @@ fn last_claude_task_notification(
         let Some(text) = text else {
             continue;
         };
-        let Some((status, summary)) = task_notification_facts(&text, &needle) else {
+        // Either needle locates the block; the spawn toolu is tried first
+        // (the exact-vintage key), and a needle present in the text but
+        // outside any `<task-notification>` block yields no facts, so the
+        // fallback still lands on the tagged block when one exists.
+        let Some((status, summary)) = task_notification_facts(&text, &spawn_needle)
+            .or_else(|| task_notification_facts(&text, &task_needle))
+        else {
             continue;
         };
         let ts = record
@@ -318,7 +343,8 @@ pub(crate) fn claude_task_terminal_entry(
     entries: &[serde_json::Value],
 ) -> Option<serde_json::Value> {
     let parent = artifacts.parent_transcript.as_deref()?;
-    let notification = last_claude_task_notification(parent, &artifacts.tool_use_id)?;
+    let notification =
+        last_claude_task_notification(parent, &artifacts.tool_use_id, &artifacts.agent_id)?;
     // The wire statuses the live path folds into "completed"
     // (claude_code::handle_task_notification).
     if !matches!(notification.status.as_str(), "completed" | "success") {
@@ -618,6 +644,27 @@ mod tests {
         )
     }
 
+    /// A `<task-notification>` block as persisted for a RE-RUN of an
+    /// interrupted child: Claude Code stamps it with the re-run turn's
+    /// NEW tool_use id — the spawn toolu appears nowhere in it — while
+    /// the `<task-id>` stays the stable agentId (live specimen class:
+    /// task-KCC, 2026-07-18).
+    fn rerun_notification_block(rerun_tool_use_id: &str, status: &str, summary: &str) -> String {
+        notification_block(rerun_tool_use_id, status, summary)
+    }
+
+    /// The `<task-id>`-only vintage (also the earlier-segment shape,
+    /// where the spawn toolu is not in the current parent segment at
+    /// all): no `<tool-use-id>` line ever existed in these blocks.
+    fn task_id_only_notification_block(status: &str, summary: &str) -> String {
+        format!(
+            "<task-notification>\n<task-id>a0343c7095a040965</task-id>\n\
+             <output-file>/tmp/tasks/a0343c7095a040965.output</output-file>\n\
+             <status>{status}</status>\n<summary>{summary}</summary>\n\
+             </task-notification>"
+        )
+    }
+
     /// Append the two record shapes a real notification lands as — the
     /// `queue-operation` copy and the injected `user` delivery — to the
     /// parent transcript in the given project alias.
@@ -631,6 +678,19 @@ mod tests {
         ts: &str,
     ) {
         let block = notification_block(tool_use_id, status, summary);
+        append_parent_notification_block(home, project, parent, &block, ts);
+    }
+
+    /// Low-level form of [`append_parent_notification`] for tests that
+    /// exercise non-default block shapes (re-run toolu, task-id-only
+    /// vintage, untagged recaps).
+    fn append_parent_notification_block(
+        home: &Path,
+        project: &str,
+        parent: &str,
+        block: &str,
+        ts: &str,
+    ) {
         let path = home
             .join(".claude")
             .join("projects")
@@ -852,6 +912,119 @@ mod tests {
     }
 
     #[test]
+    fn rerun_completion_under_new_tool_use_heals_by_task_id() {
+        // The relic class: a background sub interrupted and re-run
+        // notifies each later run under a NEW tool_use id, so the final
+        // completed block never carries the spawn toolu. The `<task-id>`
+        // (= agentId = the subagent file stem) is the stable key.
+        let home = tempfile::tempdir().unwrap();
+        write_subagent(
+            home.path(),
+            "-repo-project",
+            PARENT,
+            "a0343c7095a040965",
+            TOOL_USE_ID,
+            &fixture_lines(),
+        );
+        let block = rerun_notification_block(
+            "toolu_01RERUNRUNRUNRUN9",
+            "completed",
+            "second run finished clean",
+        );
+        assert!(
+            !block.contains(TOOL_USE_ID),
+            "the re-run block must not carry the spawn toolu"
+        );
+        append_parent_notification_block(
+            home.path(),
+            "-repo-project",
+            PARENT,
+            &block,
+            "2026-07-17T10:20:00.000Z",
+        );
+        let entries = external_session_entries_from_home(home.path(), "claude-code", TASK_ID)
+            .expect("task child entries");
+        let terminal = entries.last().expect("terminal row");
+        assert_eq!(
+            terminal.get("kind").and_then(|v| v.as_str()),
+            Some(CLAUDE_TASK_TERMINAL_KIND)
+        );
+        assert_eq!(
+            terminal.get("content").and_then(|v| v.as_str()),
+            Some("Task complete: Claude Code subagent completed: second run finished clean")
+        );
+    }
+
+    #[test]
+    fn task_id_only_vintage_completion_derives_terminal() {
+        // Older notification vintages (and earlier-segment spawns, where
+        // the spawn toolu is not in this parent segment at all) carry no
+        // `<tool-use-id>` line — `<task-id>` alone must resolve.
+        let home = tempfile::tempdir().unwrap();
+        write_subagent(
+            home.path(),
+            "-repo-project",
+            PARENT,
+            "a0343c7095a040965",
+            TOOL_USE_ID,
+            &fixture_lines(),
+        );
+        let block = task_id_only_notification_block("completed", "untagged vintage done");
+        append_parent_notification_block(
+            home.path(),
+            "-repo-project",
+            PARENT,
+            &block,
+            "2026-07-17T10:21:00.000Z",
+        );
+        let entries = external_session_entries_from_home(home.path(), "claude-code", TASK_ID)
+            .expect("task child entries");
+        assert_eq!(
+            entries
+                .last()
+                .and_then(|e| e.get("content"))
+                .and_then(|v| v.as_str()),
+            Some("Task complete: Claude Code subagent completed: untagged vintage done")
+        );
+    }
+
+    #[test]
+    fn untagged_multi_task_stop_recap_is_not_terminal_evidence() {
+        // A multi-task "stopped recap" block carries NO `<task-id>` /
+        // `<tool-use-id>` tags — the ids appear only in prose, which must
+        // not match the full-tag needles (and its status would fail the
+        // completed gate regardless). No terminal row may derive from it.
+        let home = tempfile::tempdir().unwrap();
+        write_subagent(
+            home.path(),
+            "-repo-project",
+            PARENT,
+            "a0343c7095a040965",
+            TOOL_USE_ID,
+            &fixture_lines(),
+        );
+        let recap = format!(
+            "<task-notification>\n<status>stopped</status>\n\
+             <summary>2 background tasks stopped</summary>\n\
+             <note>Agents a0343c7095a040965 ({TOOL_USE_ID}) and zfff0123456789abc \
+             were stopped before completion.</note>\n</task-notification>"
+        );
+        append_parent_notification_block(
+            home.path(),
+            "-repo-project",
+            PARENT,
+            &recap,
+            "2026-07-17T10:22:00.000Z",
+        );
+        let entries = external_session_entries_from_home(home.path(), "claude-code", TASK_ID)
+            .expect("task child entries");
+        assert_eq!(entries.len(), 2);
+        assert!(!entries.iter().any(|entry| {
+            entry.get("kind").and_then(|v| v.as_str()) == Some(CLAUDE_TASK_TERMINAL_KIND)
+        }));
+    }
+
+    #[test]
     fn transcript_rows_newer_than_notification_suppress_stale_terminal() {
         // A resumed child streams rows after the old completion — the
         // stale evidence must not paint the live-again child as done.
@@ -1027,6 +1200,9 @@ mod tests {
         let artifacts = find_claude_task_subagent_artifacts(home.path(), TASK_ID)
             .expect("artifacts resolve without a parent transcript");
         assert_eq!(artifacts.tool_use_id, TOOL_USE_ID);
+        // The stem's `agent-` prefix is stripped: the field is the raw
+        // agentId, exactly what `<task-id>` carries.
+        assert_eq!(artifacts.agent_id, "a0343c7095a040965");
         assert!(artifacts.parent_transcript.is_none());
         let entries = external_session_entries_from_home(home.path(), "claude-code", TASK_ID)
             .expect("task child entries");

--- a/src/bin/caller/web_gateway/session_catalog/transcripts.rs
+++ b/src/bin/caller/web_gateway/session_catalog/transcripts.rs
@@ -426,6 +426,17 @@ pub(crate) fn parse_codex_session_entries(
     let mut current_turn_id: Option<String> = None;
     let mut synthetic_item_seq = 0_u64;
     let mut command_calls: HashMap<String, serde_json::Value> = HashMap::new();
+    // Subagent completed-terminal evidence (the Codex twin of the Claude
+    // Code task-notification synthesis in `task_threads.rs`): whether the
+    // FILE'S OWN session_meta (the first one — later metas describe the
+    // fork source) marks this rollout a subagent thread, and the last
+    // `task_complete` boundary seen — its row timestamp, its
+    // `last_agent_message`, and the entry count at that point, so
+    // anything rendered after it (a resumed child) suppresses the stale
+    // completion. `turn_aborted` (an interrupt) retracts it outright.
+    let mut session_meta_seen = false;
+    let mut is_subagent_rollout = false;
+    let mut subagent_completed: Option<(String, Option<String>, usize)> = None;
     // One combined probe pass (early-exits once both lanes are proven)
     // instead of two independent full-file scans before the main parse.
     let (canonical_user_message_events, canonical_assistant_response_items) =
@@ -448,6 +459,11 @@ pub(crate) fn parse_codex_session_entries(
         };
         if obj.get("type").and_then(|v| v.as_str()) == Some("session_meta") {
             if let Some(payload) = obj.get("payload") {
+                if !session_meta_seen {
+                    session_meta_seen = true;
+                    is_subagent_rollout =
+                        codex_thread_source_from_payload(payload).as_deref() == Some("subagent");
+                }
                 rollout_session_id = rollout_session_id.or_else(|| value_str(payload, "id"));
             }
         }
@@ -458,6 +474,19 @@ pub(crate) fn parse_codex_session_entries(
                     current_turn_id = value_str(payload, "turn_id")
                         .or_else(|| value_str(payload, "turnId"))
                         .or(current_turn_id);
+                    continue;
+                }
+                if payload_type == "task_complete" {
+                    subagent_completed = Some((
+                        value_str(&obj, "timestamp").unwrap_or_default(),
+                        value_str(payload, "last_agent_message")
+                            .or_else(|| value_str(payload, "lastAgentMessage")),
+                        entries.len(),
+                    ));
+                    continue;
+                }
+                if payload_type == "turn_aborted" {
+                    subagent_completed = None;
                     continue;
                 }
                 if payload_type == "thread_goal_updated" {
@@ -769,7 +798,54 @@ pub(crate) fn parse_codex_session_entries(
         }
     }
 
+    // A subagent rollout whose LAST turn-boundary event is `task_complete`
+    // — nothing rendered after it, no later abort — is a completed child:
+    // synthesize the terminal row the live drain emitted
+    // (`emit_external_subagent_state`'s completed arm), so hydration and
+    // replay read DONE the way the live window did. The live "Task
+    // complete" LogEntry is bus-only, and unlike the Claude Code lane the
+    // evidence here lives in the SAME file as the transcript, so the
+    // ordinary (len, mtime) cache key already re-derives on change and
+    // ordering doubles as the staleness guard: a resumed child's rows (or
+    // its interrupt's `turn_aborted`) land after the stale completion and
+    // suppress it. Top-level rollouts never synthesize — completion of a
+    // turn is not completion of a session.
+    if is_subagent_rollout {
+        if let Some((ts, message, entries_len_at_boundary)) = subagent_completed {
+            if entries_len_at_boundary == entries.len() {
+                entries.push(codex_subagent_terminal_entry(&ts, message.as_deref()));
+            }
+        }
+    }
+
     Some(entries)
+}
+
+/// The synthesized completed-terminal row for a Codex subagent thread —
+/// the same grammar as the live emit (`emit_external_subagent_state`,
+/// completed arm, backend label "Codex") and the same row contract as the
+/// Claude Code synthesis (`claude_task_terminal_entry`): the dashboard
+/// merge guard keys on the shared kind, and its restored-phase derivation
+/// keys on the "Task complete:" prefix.
+fn codex_subagent_terminal_entry(ts: &str, message: Option<&str>) -> serde_json::Value {
+    let label = crate::external_agent::AgentBackend::Codex.to_string();
+    let content = match message.and_then(task_terminal_summary_snippet) {
+        Some(summary) => format!("Task complete: {label} subagent completed: {summary}"),
+        None => format!("Task complete: {label} subagent completed"),
+    };
+    let mut entry = serde_json::json!({
+        "level": "info",
+        "source": label,
+        "kind": SUBAGENT_TERMINAL_KIND,
+        "content": content,
+    });
+    if !ts.is_empty() {
+        entry["ts"] = serde_json::Value::String(ts.to_string());
+        if let Some(ts_ms) = timestamp_millis_from_str(ts) {
+            entry["ts_ms"] = serde_json::Value::from(ts_ms);
+        }
+    }
+    entry
 }
 
 /// Whole-file facts the codex projection needs before line 1:
@@ -1303,7 +1379,9 @@ pub(crate) fn external_session_entries_from_home_arc(
         // task-aware lane, which also appends the completed-terminal row
         // the subagent file itself never carries (Codex sub-threads need
         // no fallback — they get first-class rollouts under their own
-        // thread ids).
+        // thread ids, and their completed-terminal row is synthesized
+        // inside the ordinary parse from the rollout's own
+        // `task_complete` boundary).
         "claude-code" => match find_claude_session_file_for_transcript(home, session_id) {
             Some(path) => Some(path),
             None => {
@@ -1343,7 +1421,7 @@ fn claude_task_child_entries_arc(
     let key = external_transcript_cache_key(source, session_id, &artifacts.transcript)?;
     if let Some(entries) = cached_external_transcript_entries(&key) {
         let has_terminal = entries.iter().any(|entry| {
-            entry.get("kind").and_then(|v| v.as_str()) == Some(CLAUDE_TASK_TERMINAL_KIND)
+            entry.get("kind").and_then(|v| v.as_str()) == Some(SUBAGENT_TERMINAL_KIND)
         });
         if has_terminal {
             return Some(entries);
@@ -2062,6 +2140,271 @@ mod tests {
         );
         assert_eq!(row["item_id"].as_str(), Some("rs_1"));
         assert_eq!(row["session_id"].as_str(), Some(session_id));
+    }
+
+    // ---- Codex subagent completed-terminal synthesis ----
+
+    /// The file's own session_meta for a Codex subagent thread rollout
+    /// (observed shape: `thread_source: "subagent"` plus the
+    /// `source.subagent.thread_spawn` record).
+    fn codex_subagent_session_meta(session_id: &str) -> serde_json::Value {
+        serde_json::json!({
+            "timestamp": "2026-05-17T16:48:52Z",
+            "type": "session_meta",
+            "payload": {
+                "id": session_id,
+                "parent_thread_id": "019e37b2-0000-7000-8000-parentthread",
+                "thread_source": "subagent",
+                "agent_path": "/root/doc_audit",
+                "agent_nickname": "Synthia",
+                "source": { "subagent": { "thread_spawn": {
+                    "parent_thread_id": "019e37b2-0000-7000-8000-parentthread",
+                    "depth": 1,
+                    "agent_path": "/root/doc_audit",
+                    "agent_nickname": "Synthia",
+                } } },
+            }
+        })
+    }
+
+    fn codex_event(ts: &str, payload: serde_json::Value) -> serde_json::Value {
+        serde_json::json!({ "timestamp": ts, "type": "event_msg", "payload": payload })
+    }
+
+    fn write_codex_rollout(home: &Path, session_id: &str, lines: &[serde_json::Value]) {
+        let sessions_dir = home.join(".codex").join("sessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        std::fs::write(
+            sessions_dir.join(format!("rollout-2026-05-17T16-48-52-{session_id}.jsonl")),
+            lines
+                .iter()
+                .map(serde_json::Value::to_string)
+                .collect::<Vec<_>>()
+                .join("\n"),
+        )
+        .unwrap();
+    }
+
+    const CODEX_CHILD_COMPLETED_ROW: &str =
+        "Task complete: Codex subagent completed: Docs audited; two links fixed.";
+
+    fn codex_subagent_fixture_head(session_id: &str) -> Vec<serde_json::Value> {
+        vec![
+            codex_subagent_session_meta(session_id),
+            codex_event(
+                "2026-05-17T16:49:00Z",
+                serde_json::json!({ "type": "user_message", "message": "Audit the demo docs" }),
+            ),
+            codex_event(
+                "2026-05-17T16:49:20Z",
+                serde_json::json!({ "type": "agent_message",
+                    "message": "Docs audited; two links fixed." }),
+            ),
+        ]
+    }
+
+    #[test]
+    fn codex_subagent_completion_serves_synthetic_terminal_row() {
+        let dir = tempfile::tempdir().unwrap();
+        let session_id = "019e37b2-subagent-completed";
+        let mut lines = codex_subagent_fixture_head(session_id);
+        lines.push(codex_event(
+            "2026-05-17T16:49:21Z",
+            serde_json::json!({ "type": "task_complete",
+                "turn_id": "019e37b2-turn-0000-8000-000000000001",
+                "last_agent_message": "Docs audited; two links fixed." }),
+        ));
+        write_codex_rollout(dir.path(), session_id, &lines);
+
+        let entries = external_session_entries_from_home(dir.path(), "codex", session_id)
+            .expect("codex child entries");
+        let terminal = entries.last().expect("entries end with the terminal row");
+        assert_eq!(
+            terminal["kind"].as_str(),
+            Some(SUBAGENT_TERMINAL_KIND),
+            "terminal row carries the shared subagent-terminal kind"
+        );
+        assert_eq!(
+            terminal["content"].as_str(),
+            Some(CODEX_CHILD_COMPLETED_ROW)
+        );
+        assert_eq!(terminal["level"].as_str(), Some("info"));
+        assert_eq!(terminal["source"].as_str(), Some("Codex"));
+        assert_eq!(terminal["ts"].as_str(), Some("2026-05-17T16:49:21Z"));
+        assert!(terminal["ts_ms"].as_i64().is_some());
+        // Annotated like every served entry: stable id + delivery.
+        assert!(terminal["event_id"]
+            .as_str()
+            .is_some_and(|id| !id.is_empty()));
+        // Exactly one terminal row.
+        assert_eq!(
+            entries
+                .iter()
+                .filter(|entry| entry["kind"].as_str() == Some(SUBAGENT_TERMINAL_KIND))
+                .count(),
+            1
+        );
+
+        // The detail page (the hydration fetch) serves the same row.
+        let body = external_session_detail_from_home_with_page(
+            dir.path(),
+            "codex",
+            session_id,
+            None,
+            None,
+        )
+        .expect("detail body");
+        let value: serde_json::Value = serde_json::from_str(&body).unwrap();
+        let detail_entries = value["entries"].as_array().expect("entries array");
+        assert_eq!(
+            detail_entries.last().and_then(|e| e["content"].as_str()),
+            Some(CODEX_CHILD_COMPLETED_ROW)
+        );
+    }
+
+    #[test]
+    fn codex_subagent_resumed_rows_suppress_stale_completion() {
+        // A follow-up re-tasks the child: rows land AFTER the old
+        // task_complete and no new boundary has settled yet — the stale
+        // completion must not paint the live-again child as done.
+        let dir = tempfile::tempdir().unwrap();
+        let session_id = "019e37b2-subagent-resumed";
+        let mut lines = codex_subagent_fixture_head(session_id);
+        lines.push(codex_event(
+            "2026-05-17T16:49:21Z",
+            serde_json::json!({ "type": "task_complete",
+                "turn_id": "019e37b2-turn-0000-8000-000000000001",
+                "last_agent_message": "Docs audited; two links fixed." }),
+        ));
+        lines.push(codex_event(
+            "2026-05-17T16:55:00Z",
+            serde_json::json!({ "type": "user_message", "message": "Now audit the guides too" }),
+        ));
+        lines.push(codex_event(
+            "2026-05-17T16:55:10Z",
+            serde_json::json!({ "type": "agent_message", "message": "Working through the guides." }),
+        ));
+        write_codex_rollout(dir.path(), session_id, &lines);
+
+        let entries = external_session_entries_from_home(dir.path(), "codex", session_id)
+            .expect("codex child entries");
+        assert!(!entries
+            .iter()
+            .any(|entry| entry["kind"].as_str() == Some(SUBAGENT_TERMINAL_KIND)));
+    }
+
+    #[test]
+    fn codex_subagent_turn_abort_retracts_completion_evidence() {
+        // An interrupt lands as `turn_aborted` — even with no rendered
+        // rows after the old completion, the abort retracts it (the live
+        // path emitted Interrupted, not completed).
+        let dir = tempfile::tempdir().unwrap();
+        let session_id = "019e37b2-subagent-aborted";
+        let mut lines = codex_subagent_fixture_head(session_id);
+        lines.push(codex_event(
+            "2026-05-17T16:49:21Z",
+            serde_json::json!({ "type": "task_complete",
+                "turn_id": "019e37b2-turn-0000-8000-000000000001",
+                "last_agent_message": "Docs audited; two links fixed." }),
+        ));
+        lines.push(codex_event(
+            "2026-05-17T16:56:00Z",
+            serde_json::json!({ "type": "turn_aborted",
+                "turn_id": "019e37b2-turn-0000-8000-000000000002",
+                "reason": "interrupted" }),
+        ));
+        write_codex_rollout(dir.path(), session_id, &lines);
+
+        let entries = external_session_entries_from_home(dir.path(), "codex", session_id)
+            .expect("codex child entries");
+        assert!(!entries
+            .iter()
+            .any(|entry| entry["kind"].as_str() == Some(SUBAGENT_TERMINAL_KIND)));
+    }
+
+    #[test]
+    fn codex_subagent_last_completion_wins_across_reruns() {
+        // Re-tasked child that settles again: the LAST task_complete is
+        // the terminal, exactly one row, with the newest message.
+        let dir = tempfile::tempdir().unwrap();
+        let session_id = "019e37b2-subagent-rerun";
+        let mut lines = codex_subagent_fixture_head(session_id);
+        lines.push(codex_event(
+            "2026-05-17T16:49:21Z",
+            serde_json::json!({ "type": "task_complete",
+                "turn_id": "019e37b2-turn-0000-8000-000000000001",
+                "last_agent_message": "Docs audited; two links fixed." }),
+        ));
+        lines.push(codex_event(
+            "2026-05-17T16:55:00Z",
+            serde_json::json!({ "type": "user_message", "message": "Now audit the guides too" }),
+        ));
+        lines.push(codex_event(
+            "2026-05-17T16:58:00Z",
+            serde_json::json!({ "type": "agent_message", "message": "Guides audited as well." }),
+        ));
+        lines.push(codex_event(
+            "2026-05-17T16:58:01Z",
+            serde_json::json!({ "type": "task_complete",
+                "turn_id": "019e37b2-turn-0000-8000-000000000002",
+                "last_agent_message": "Guides audited as well." }),
+        ));
+        write_codex_rollout(dir.path(), session_id, &lines);
+
+        let entries = external_session_entries_from_home(dir.path(), "codex", session_id)
+            .expect("codex child entries");
+        let terminals: Vec<_> = entries
+            .iter()
+            .filter(|entry| entry["kind"].as_str() == Some(SUBAGENT_TERMINAL_KIND))
+            .collect();
+        assert_eq!(terminals.len(), 1);
+        assert_eq!(
+            terminals[0]["content"].as_str(),
+            Some("Task complete: Codex subagent completed: Guides audited as well.")
+        );
+        assert_eq!(terminals[0]["ts"].as_str(), Some("2026-05-17T16:58:01Z"));
+    }
+
+    #[test]
+    fn codex_top_level_rollout_never_synthesizes_terminal() {
+        // Every top-level turn also ends in task_complete — completion of
+        // a turn is not completion of a session, so only rollouts whose
+        // own session_meta marks a subagent thread synthesize.
+        let dir = tempfile::tempdir().unwrap();
+        let session_id = "019e37b2-toplevel-turns";
+        write_codex_rollout(
+            dir.path(),
+            session_id,
+            &[
+                serde_json::json!({
+                    "timestamp": "2026-05-17T16:48:52Z",
+                    "type": "session_meta",
+                    "payload": { "id": session_id, "thread_source": "user" }
+                }),
+                codex_event(
+                    "2026-05-17T16:49:00Z",
+                    serde_json::json!({ "type": "user_message", "message": "Audit the demo docs" }),
+                ),
+                codex_event(
+                    "2026-05-17T16:49:20Z",
+                    serde_json::json!({ "type": "agent_message",
+                        "message": "Docs audited; two links fixed." }),
+                ),
+                codex_event(
+                    "2026-05-17T16:49:21Z",
+                    serde_json::json!({ "type": "task_complete",
+                        "turn_id": "019e37b2-turn-0000-8000-000000000001",
+                        "last_agent_message": "Docs audited; two links fixed." }),
+                ),
+            ],
+        );
+
+        let entries = external_session_entries_from_home(dir.path(), "codex", session_id)
+            .expect("codex entries");
+        assert_eq!(entries.len(), 2, "user + assistant rows only");
+        assert!(!entries
+            .iter()
+            .any(|entry| entry["kind"].as_str() == Some(SUBAGENT_TERMINAL_KIND)));
     }
 
     #[test]

--- a/static/app/39-session-windows.js
+++ b/static/app/39-session-windows.js
@@ -4361,6 +4361,7 @@ async function hydrateRestoredSessionWindow(win, record) {
     updateSessionWindowRemotePageState(targetWin, data, source, sid);
     const rendered = renderRestoredSessionWindowEntries(targetWin, entries, targetSid);
     clearSessionWindowHydrateError(targetWin || win);
+    fillRestoredSessionWindowTaskFromEntries(targetSid, entries);
     if (rendered > 0) {
       updateSessionWindow(targetSid, {
         phase: restoredSessionWindowPhaseFromEntries(entries, targetSid),
@@ -4411,6 +4412,37 @@ function restoredSessionWindowPhaseFromEntries(entries, fallbackSessionId) {
     }
   }
   return 'idle';
+}
+
+// Restored windows can show "initial message pending" forever: the
+// persisted record is identity/topology only (no task text), and a dead
+// task child is absent from the session registry, so nothing ever fills
+// the header. The hydrated transcript knows better — its first live user
+// prompt IS the task — so once hydration succeeds, fill the metadata
+// through the ordinary update path (normalize → merge → header render).
+// Anything already present wins: live SessionStarted metadata, registry
+// rows, and later fills all outrank this backstop, which only writes
+// into a blank.
+const SESSION_WINDOW_RESTORED_TASK_CHAR_LIMIT = 240;
+function fillRestoredSessionWindowTaskFromEntries(sessionId, entries) {
+  const sid = String(sessionId || '').trim();
+  if (!sid || !Array.isArray(entries) || !entries.length) return;
+  const meta = sessionMetadataById.get(sid) || {};
+  if (compactSessionText(meta.task)) return;
+  for (const entry of entries) {
+    const record = sessionWindowRecordFromReplayEntry(entry, sid);
+    if (!record || record.superseded) continue;
+    const source = String(record.source || '').trim().toLowerCase();
+    const level = String(record.level || '').trim().toLowerCase();
+    if (source !== 'user' && level !== 'user') continue;
+    const task = compactSessionTextBounded(
+      record.content,
+      SESSION_WINDOW_RESTORED_TASK_CHAR_LIMIT
+    );
+    if (!task) continue;
+    updateSessionWindow(sid, { task });
+    return;
+  }
 }
 
 function sessionWindowHydrationRecord(sessionId) {


### PR DESCRIPTION
Three fixes for the same complaint family: relic sub-agent windows that never heal to DONE, and restored task windows with placeholder text.

## Part A — relic Claude Code task sub windows heal via the stable task-id key
#493 derived the synthetic \`Task complete\` terminal by needling the parent transcript for the spawn \`<tool-use-id>\`. A background sub interrupted and re-run notifies each later run under a NEW tool_use id (and an earlier-segment spawn's toolu may not be in the current parent segment at all), so re-run children relapsed to IDLE forever. The stable key is the \`<task-id>\` = agentId — present in every notification vintage and equal to the subagent file stem — so \`ClaudeTaskSubagentArtifacts\` now carries \`agent_id\` and \`last_claude_task_notification\` accepts a block matching EITHER the spawn tool-use needle OR \`<task-id>{agent_id}</task-id>\`. Last-wins, the completed/success status gate, and the staleness guard are unchanged.

Fixtures: re-run vintage (completed under a new toolu, spawn toolu absent from the block), the task-id-only vintage (no \`<tool-use-id>\` line at all — the older on-disk shape), the untagged multi-task stop recap (ids in prose must not match the full-tag needles), plus the existing single-run suite untouched and green.

## Part B — Codex sub-thread windows rehydrate DONE from durable rollout evidence
**Evidence-source decision: read-side derivation from the child's own rollout; no write-side marker needed.** #493 assumed Codex rollouts carry no durable terminal evidence. Investigation of live rollouts (including \`originator: "intendant"\` supervised children) shows they do:

- a child rollout's \`session_meta\` marks it \`thread_source: "subagent"\` (+ \`source.subagent.thread_spawn\`), and
- every turn boundary is persisted as \`event_msg\` \`task_complete\` (with the final message in \`last_agent_message\`) / \`turn_aborted\` — the child's own file ends at its completion boundary.

The live \`Task complete\` LogEntry from the drain (\`emit_external_subagent_state\`) is bus-only, and the wrapper session log persists no child-scoped terminal — so \`parse_codex_session_entries\` now synthesizes the completed-terminal row from that in-file evidence: the LAST \`task_complete\` wins; anything rendered after it (a resumed child) suppresses the stale completion; \`turn_aborted\` (an interrupt) retracts it; top-level rollouts never synthesize (completion of a turn is not completion of a session). Because evidence and transcript share one file, the ordinary (len, mtime) transcript cache key already re-derives on change — none of the CC lane's special no-terminal cache rule is needed.

The replay line filter admits the two boundary kinds. \`task_started\` deliberately stays filtered: the parser's turn-id branch for it has never received lines through the filter, and admitting it would silently swap hydrated turn ids from user-row synthetics to rollout turn ids — a separate decision, documented at the filter. The synthesized row reuses the shared \`subagent_terminal\` kind and \`Task complete:\` grammar, so the dashboard merge guard and restored-phase derivation cover both backends unchanged; the kind constant is renamed backend-neutral (\`SUBAGENT_TERMINAL_KIND\`). Scope mirrors #493: completed-only (interrupted/errored keep today's behavior).

## Part C — restored task windows show their real task text
Restored task-* windows rendered \`initial message pending\` because the persisted window record is identity/topology only and dead task children are absent from the registry. When transcript hydration succeeds, the window's task metadata is backfilled from the first live user prompt row (bounded via \`compactSessionTextBounded\`, 240 chars) through the ordinary \`updateSessionWindow\` merge path; anything already present wins over the backfill. Fragments edited, \`app.html\` regenerated through the assembler.

## Tests
- \`task_threads\`: 16/16 (4 new — re-run vintage, task-id-only vintage, untagged stop recap, agent-id stem assert)
- \`transcripts\`: 5 new codex-subagent tests (completion row + detail-page serve, resumed-rows suppression, turn_aborted retraction, last-completion-wins, top-level never synthesizes)
- Full local battery in the PR checks section.