### PR TITLE
Fix governor linker-phase serialization and fairness

### DIFF
--- a/crates/rustc-governor/src/config.rs
+++ b/crates/rustc-governor/src/config.rs
@@ -44,18 +44,25 @@ pub struct Config {
     /// grown past the installer-minted files in a root-owned dir) — link
     /// gating may degrade, ordinary governance never rides with it.
     pub link_slots: u32,
+    /// Number of pre-created, writable `link-waiter-<i>` files available
+    /// to the crash-safe FIFO queue in front of the link slots. `0`
+    /// disables queue ordering while keeping the link gate itself. If no
+    /// waiter file is usable (for example, a new binary is installed
+    /// before its root-owned assets), link serialization remains active
+    /// but degrades to unordered polling.
+    pub link_queue_slots: u32,
     /// Usernames whose invocations are classed `ci`; everyone else is
     /// `local`.
     pub ci_users: Vec<String>,
-    /// Front of the compile chain for governed *and* fail-open
+    /// Front of the cacheable compile chain for governed and fail-open
     /// invocations: `wrap_with <real-compiler> <args…>` — in production
-    /// the sccache client, whose blocking round-trip is what carries the
-    /// permit's ceiling to server-side compiles (governed runs spawn it
-    /// and wait, permit parent-held; fail-open runs exec it). Unset (or
-    /// written as `""`, which the parser normalizes to unset) means "run
-    /// the compiler directly": the governor works without sccache. The
-    /// real compiler itself is never configured here — cargo passes it
-    /// as argv[1] (the RUSTC_WRAPPER contract).
+    /// the sccache client, whose blocking round-trip carries the permit's
+    /// ceiling to server-side compiles. Governed heavyweight bin/test
+    /// invocations are non-cacheable and run rustc directly so their
+    /// invocation-private linker shim is reliable. Unset (or `""`) means
+    /// "run the compiler directly": the governor works without sccache.
+    /// The real compiler itself is never configured here — cargo passes
+    /// it as argv[1] (the RUSTC_WRAPPER contract).
     pub wrap_with: Option<PathBuf>,
 }
 
@@ -71,6 +78,7 @@ impl Default for Config {
             // keys are ignored, so pre-gate configs stay parseable while
             // this default carries the policy).
             link_slots: 1,
+            link_queue_slots: 64,
             ci_users: vec!["_intendant-ci".to_string(), "ci".to_string()],
             wrap_with: None,
         }
@@ -116,6 +124,7 @@ pub fn parse(text: &str) -> Result<Config, String> {
             "local_reserved" => cfg.local_reserved = parse_u32(value).map_err(|e| err(&e))?,
             "ci_reserved" => cfg.ci_reserved = parse_u32(value).map_err(|e| err(&e))?,
             "link_slots" => cfg.link_slots = parse_u32(value).map_err(|e| err(&e))?,
+            "link_queue_slots" => cfg.link_queue_slots = parse_u32(value).map_err(|e| err(&e))?,
             "ci_users" => cfg.ci_users = parse_string_array(value).map_err(|e| err(&e))?,
             "wrap_with" => {
                 // Empty means unset: the installer's here-doc always writes
@@ -261,6 +270,7 @@ permit_dir = "/usr/local/var/intendant-governor"
 local_reserved = 1
 ci_reserved = 2   # per-box sizing
 link_slots = 1
+link_queue_slots = 64
 ci_users = ["_intendant-ci", "ci"]
 wrap_with = "/opt/homebrew/bin/sccache"
 "#;
@@ -287,6 +297,7 @@ wrap_with = "/opt/homebrew/bin/sccache"
             "local_reserved = 3\n",
             "ci_reserved = 0\n",
             "link_slots = 4\n",
+            "link_queue_slots = 12\n",
             "ci_users = [\"a\", \"b\",]\n",
             "wrap_with = \"/opt/sccache\"\n",
         );
@@ -296,6 +307,7 @@ wrap_with = "/opt/homebrew/bin/sccache"
         assert_eq!(cfg.local_reserved, 3);
         assert_eq!(cfg.ci_reserved, 0);
         assert_eq!(cfg.link_slots, 4);
+        assert_eq!(cfg.link_queue_slots, 12);
         assert_eq!(cfg.ci_users, vec!["a".to_string(), "b".to_string()]);
         assert_eq!(cfg.wrap_with, Some(PathBuf::from("/opt/sccache")));
     }
@@ -310,6 +322,13 @@ wrap_with = "/opt/homebrew/bin/sccache"
         assert_eq!(parse("link_slots = 0\n").unwrap().link_slots, 0);
         assert!(parse("link_slots = -1\n").is_err());
         assert!(parse("link_slots = many\n").is_err());
+    }
+
+    #[test]
+    fn link_queue_defaults_to_a_bounded_fifo_and_zero_disables_ordering() {
+        assert_eq!(parse("enabled = true\n").unwrap().link_queue_slots, 64);
+        assert_eq!(parse("link_queue_slots = 0\n").unwrap().link_queue_slots, 0);
+        assert!(parse("link_queue_slots = -1\n").is_err());
     }
 
     #[test]

--- a/crates/rustc-governor/src/govlog.rs
+++ b/crates/rustc-governor/src/govlog.rs
@@ -1,10 +1,8 @@
-//! `<permit_dir>/governor.log`: one acquisition line per governed
-//! invocation, plus one `kind=link-done` completion line per heavyweight
-//! link (bypasses, probes, and fail-open runs are deliberately silent —
-//! the log answers "who waited how long on which permit", and the probe
-//! fast path must not pay even a log write). The link fields — crate,
-//! classification, both waits, runtime — are the soak telemetry the
-//! link-gate sizing (and any future allowlist/weighting) is justified by.
+//! `<permit_dir>/governor.log`: one compile-permit acquisition line per
+//! governed invocation, plus linker acquisition/completion lines for each
+//! heavyweight final artifact. Bypasses, probes, and fail-open runs are
+//! deliberately silent — the log answers which phase waited, for how long,
+//! and on which resource. The probe fast path must not pay even a log write.
 //!
 //! Best-effort end to end: logging must never fail the build, so every I/O
 //! error here is swallowed. Rotation is truncate-in-place at 1MB keeping
@@ -30,45 +28,77 @@ const KEEP_BYTES: u64 = 256 * 1024;
 /// carry `None` and log `kind=compile`).
 pub(crate) enum LinkDisposition<'a> {
     /// Serialized through a held slot.
-    Gated { slot: &'a str, link_wait_ms: u64 },
+    Gated {
+        slot: &'a str,
+        link_wait_ms: u64,
+        queue: &'a str,
+        scope: &'a str,
+    },
     /// `link_slots = 0`: gated off by configuration.
     Off,
     /// No usable slot file: gating degraded, ordinary governance kept.
     Degraded,
 }
 
-pub(crate) fn log_governed(
+pub(crate) fn log_compile(
     permit_dir: &Path,
     class: &str,
     crate_name: Option<&str>,
-    link: Option<&LinkDisposition>,
+    link_deferred: bool,
     permit_name: &str,
     wait_ms: u64,
 ) {
-    let kind = match link {
-        None => " kind=compile".to_string(),
-        Some(LinkDisposition::Gated { slot, link_wait_ms }) => {
-            format!(" kind=link link_slot={slot} link_wait_ms={link_wait_ms}")
-        }
-        Some(LinkDisposition::Off) => " kind=link-ungated reason=off".to_string(),
-        Some(LinkDisposition::Degraded) => " kind=link-ungated reason=degraded".to_string(),
-    };
+    let deferred = if link_deferred { " link=deferred" } else { "" };
     append_line(
         permit_dir,
         &format!(
-            "class={class} crate={}{kind} permit={permit_name} wait_ms={wait_ms}",
+            "class={class} crate={} kind=compile{deferred} permit={permit_name} wait_ms={wait_ms}",
             printable_crate(crate_name),
         ),
     );
 }
 
-/// Completion line for every heavyweight link (gated or not): the runtime
-/// is the number that sizes the gate post-soak.
-pub(crate) fn log_link_done(permit_dir: &Path, crate_name: Option<&str>, runtime_ms: u64) {
+pub(crate) fn log_link(
+    permit_dir: &Path,
+    class: &str,
+    crate_name: Option<&str>,
+    disposition: &LinkDisposition<'_>,
+    permit_name: &str,
+    permit_wait_ms: u64,
+) {
+    let kind = match disposition {
+        LinkDisposition::Gated {
+            slot,
+            link_wait_ms,
+            queue,
+            scope,
+        } => format!(
+            "kind=link link_slot={slot} link_wait_ms={link_wait_ms} queue={queue} scope={scope}"
+        ),
+        LinkDisposition::Off => "kind=link-ungated reason=off".to_string(),
+        LinkDisposition::Degraded => "kind=link-ungated reason=degraded".to_string(),
+    };
     append_line(
         permit_dir,
         &format!(
-            "crate={} kind=link-done runtime_ms={runtime_ms}",
+            "class={class} crate={} {kind} permit={permit_name} wait_ms={permit_wait_ms}",
+            printable_crate(crate_name),
+        ),
+    );
+}
+
+/// Completion line for every heavyweight link (gated or not). In normal
+/// shim operation this is actual linker wall time, not rustc compile time.
+pub(crate) fn log_link_done(
+    permit_dir: &Path,
+    crate_name: Option<&str>,
+    runtime_ms: u64,
+    scope: &str,
+) {
+    append_line(
+        permit_dir,
+        &format!(
+            "crate={} kind=link-done runtime_ms={runtime_ms} scope={scope}",
             printable_crate(crate_name),
         ),
     );
@@ -180,7 +210,14 @@ mod tests {
     #[test]
     fn log_line_appends_and_parses() {
         let dir = tempfile::tempdir().unwrap();
-        log_governed(dir.path(), "local", Some("serde"), None, "permit-ci-1", 230);
+        log_compile(
+            dir.path(),
+            "local",
+            Some("serde"),
+            false,
+            "permit-ci-1",
+            230,
+        );
         let text = std::fs::read_to_string(dir.path().join(LOG_NAME)).unwrap();
         let line = text.trim_end();
         assert!(
@@ -194,57 +231,72 @@ mod tests {
     #[test]
     fn link_lines_carry_the_soak_fields() {
         let dir = tempfile::tempdir().unwrap();
-        log_governed(
+        log_compile(
             dir.path(),
             "local",
             Some("intendant"),
-            Some(&LinkDisposition::Gated {
-                slot: "link-0",
-                link_wait_ms: 1200,
-            }),
+            true,
             "permit-local-0",
             5,
         );
-        log_governed(
+        log_link(
+            dir.path(),
+            "local",
+            Some("intendant"),
+            &LinkDisposition::Gated {
+                slot: "link-0",
+                link_wait_ms: 1200,
+                queue: "fifo",
+                scope: "linker",
+            },
+            "permit-local-0",
+            5,
+        );
+        log_link(
             dir.path(),
             "ci",
             Some("intendant_connect"),
-            Some(&LinkDisposition::Off),
+            &LinkDisposition::Off,
             "permit-ci-0",
             0,
         );
-        log_governed(
+        log_link(
             dir.path(),
             "ci",
             None,
-            Some(&LinkDisposition::Degraded),
+            &LinkDisposition::Degraded,
             "permit-ci-1",
             0,
         );
-        log_link_done(dir.path(), Some("intendant"), 48_000);
+        log_link_done(dir.path(), Some("intendant"), 48_000, "linker");
         let text = std::fs::read_to_string(dir.path().join(LOG_NAME)).unwrap();
         let lines: Vec<&str> = text.lines().collect();
         assert!(
-            lines[0].contains(
-                "crate=intendant kind=link link_slot=link-0 link_wait_ms=1200 permit=permit-local-0 wait_ms=5"
-            ),
+            lines[0].contains("crate=intendant kind=compile link=deferred"),
             "{}",
             lines[0]
         );
         assert!(
-            lines[1].contains("kind=link-ungated reason=off permit=permit-ci-0"),
+            lines[1].contains(
+                "crate=intendant kind=link link_slot=link-0 link_wait_ms=1200 queue=fifo scope=linker permit=permit-local-0 wait_ms=5"
+            ),
             "{}",
             lines[1]
         );
         assert!(
-            lines[2].contains("crate=- kind=link-ungated reason=degraded"),
+            lines[2].contains("kind=link-ungated reason=off permit=permit-ci-0"),
             "{}",
             lines[2]
         );
         assert!(
-            lines[3].contains("crate=intendant kind=link-done runtime_ms=48000"),
+            lines[3].contains("crate=- kind=link-ungated reason=degraded"),
             "{}",
             lines[3]
+        );
+        assert!(
+            lines[4].contains("crate=intendant kind=link-done runtime_ms=48000 scope=linker"),
+            "{}",
+            lines[4]
         );
     }
 
@@ -268,7 +320,7 @@ mod tests {
             }
         }
         assert!(std::fs::metadata(&path).unwrap().len() > MAX_LOG_BYTES);
-        log_governed(dir.path(), "ci", None, None, "permit-ci-0", 7);
+        log_compile(dir.path(), "ci", None, false, "permit-ci-0", 7);
         let text = std::fs::read_to_string(&path).unwrap();
         assert!(
             (text.len() as u64) <= KEEP_BYTES + 128,
@@ -288,7 +340,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join(LOG_NAME);
         std::fs::write(&path, "existing line\n").unwrap();
-        log_governed(dir.path(), "local", None, None, "permit-local-0", 0);
+        log_compile(dir.path(), "local", None, false, "permit-local-0", 0);
         let text = std::fs::read_to_string(&path).unwrap();
         assert!(text.starts_with("existing line\n"));
         assert_eq!(text.lines().count(), 2);

--- a/crates/rustc-governor/src/linker.rs
+++ b/crates/rustc-governor/src/linker.rs
@@ -1,0 +1,351 @@
+//! The heavyweight-link phase shim.
+//!
+//! Cargo invokes the governor as a rustc wrapper. For a governed bin/test
+//! invocation, the outer governor rewrites rustc's `-C linker=...` to point
+//! back at this same executable and passes the real linker plus log context
+//! in private environment variables. Rustc performs parsing, compilation,
+//! and codegen under its ordinary compile permit; only when it invokes the
+//! linker does this mode acquire the machine-wide link slot.
+//!
+//! Heavy final-artifact invocations are deliberately sent straight to
+//! rustc rather than through `wrap_with`: sccache documents/observably
+//! treats these link-producing bin/test shapes as non-cacheable, and a
+//! long-lived sccache server is not a sound carrier for invocation-private
+//! linker environment. Cacheable library invocations keep the normal
+//! sccache chain.
+
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command};
+use std::time::Instant;
+
+use std::os::unix::ffi::{OsStrExt as _, OsStringExt as _};
+use std::os::unix::process::CommandExt as _;
+
+use crate::{config, govlog, permits};
+
+const MODE_ENV: &str = "INTENDANT_GOVERNOR_LINKER_MODE_V1";
+const REAL_LINKER_ENV: &str = "INTENDANT_GOVERNOR_REAL_LINKER_V1";
+const CLASS_ENV: &str = "INTENDANT_GOVERNOR_LINK_CLASS_V1";
+const CRATE_ENV: &str = "INTENDANT_GOVERNOR_LINK_CRATE_V1";
+const PERMIT_ENV: &str = "INTENDANT_GOVERNOR_LINK_PERMIT_V1";
+const PERMIT_WAIT_ENV: &str = "INTENDANT_GOVERNOR_LINK_PERMIT_WAIT_MS_V1";
+
+const PRIVATE_ENVS: &[&str] = &[
+    MODE_ENV,
+    REAL_LINKER_ENV,
+    CLASS_ENV,
+    CRATE_ENV,
+    PERMIT_ENV,
+    PERMIT_WAIT_ENV,
+];
+
+pub(crate) fn is_linker_mode() -> bool {
+    std::env::var_os(MODE_ENV).is_some_and(|value| value == "1")
+}
+
+pub(crate) struct PreparedRustc {
+    pub(crate) args: Vec<OsString>,
+    real_linker: OsString,
+}
+
+/// Preserve an explicitly configured linker, or the native Unix default
+/// (`cc`) when rustc has no explicit `--target` or linker-flavor override.
+/// Otherwise rustc's target/configuration may select `rust-lld`, `wasm-ld`,
+/// `link.exe`, or another driver that cannot be recovered after overriding
+/// `-C linker`; the caller keeps the safe whole-rustc gate for that
+/// uncommon shape.
+pub(crate) fn prepare_rustc(args: &[OsString]) -> Result<PreparedRustc, &'static str> {
+    let mut rewritten = Vec::with_capacity(args.len() + 2);
+    let mut real_linker: Option<OsString> = None;
+    let mut explicit_target = false;
+    let mut explicit_linker_flavor = false;
+    let mut i = 0;
+    while i < args.len() {
+        let bytes = args[i].as_os_str().as_bytes();
+        if bytes == b"-C" || bytes == b"--codegen" {
+            if let Some(next) = args.get(i + 1) {
+                let option = next.as_os_str().as_bytes();
+                if let Some(linker) = option.strip_prefix(b"linker=") {
+                    real_linker = Some(OsString::from_vec(linker.to_vec()));
+                    i += 2;
+                    continue;
+                }
+                explicit_linker_flavor |= option.starts_with(b"linker-flavor=");
+            }
+        } else if let Some(linker) = bytes
+            .strip_prefix(b"-Clinker=")
+            .or_else(|| bytes.strip_prefix(b"--codegen=linker="))
+        {
+            real_linker = Some(OsString::from_vec(linker.to_vec()));
+            i += 1;
+            continue;
+        } else if bytes.starts_with(b"-Clinker-flavor=")
+            || bytes.starts_with(b"--codegen=linker-flavor=")
+        {
+            explicit_linker_flavor = true;
+        } else if bytes == b"--target" || bytes.starts_with(b"--target=") {
+            explicit_target = true;
+        }
+        rewritten.push(args[i].clone());
+        i += 1;
+    }
+
+    let real_linker = match real_linker {
+        Some(linker) if !linker.is_empty() => linker,
+        Some(_) => return Err("empty explicit linker"),
+        None if explicit_target || explicit_linker_flavor => {
+            return Err("configured default linker is unknown")
+        }
+        None => OsString::from("cc"),
+    };
+    let governor = std::env::current_exe().map_err(|_| "cannot resolve the governor executable")?;
+    if paths_name_same(&real_linker, &governor) {
+        return Err("the configured real linker points at rustc-governor");
+    }
+    rewritten.push(OsString::from("-C"));
+    let mut linker_arg = OsString::from("linker=");
+    linker_arg.push(&governor);
+    rewritten.push(linker_arg);
+    Ok(PreparedRustc {
+        args: rewritten,
+        real_linker,
+    })
+}
+
+fn paths_name_same(candidate: &OsStr, governor: &Path) -> bool {
+    let candidate_path = Path::new(candidate);
+    if std::fs::canonicalize(candidate_path)
+        .ok()
+        .is_some_and(|path| std::fs::canonicalize(governor).ok().as_ref() == Some(&path))
+    {
+        return true;
+    }
+    candidate_path == governor
+}
+
+pub(crate) struct CompileContext<'a> {
+    pub(crate) config_path: &'a Path,
+    pub(crate) class: &'a str,
+    pub(crate) crate_name: Option<&'a str>,
+    pub(crate) permit_name: &'a str,
+    pub(crate) permit_wait_ms: u64,
+}
+
+pub(crate) fn spawn_rustc(
+    real_rustc: &Path,
+    prepared: &PreparedRustc,
+    context: CompileContext<'_>,
+) -> std::io::Result<Child> {
+    let mut command = Command::new(real_rustc);
+    command
+        .args(&prepared.args)
+        .env(MODE_ENV, "1")
+        .env(REAL_LINKER_ENV, &prepared.real_linker)
+        .env("INTENDANT_GOVERNOR_CONFIG", context.config_path)
+        .env(CLASS_ENV, context.class)
+        .env(CRATE_ENV, context.crate_name.unwrap_or("-"))
+        .env(PERMIT_ENV, context.permit_name)
+        .env(PERMIT_WAIT_ENV, context.permit_wait_ms.to_string());
+    command.spawn()
+}
+
+fn private_context() -> (String, Option<String>, String, u64) {
+    let class = std::env::var(CLASS_ENV).unwrap_or_else(|_| "-".to_string());
+    let crate_name = std::env::var(CRATE_ENV).ok().filter(|name| name != "-");
+    let permit = std::env::var(PERMIT_ENV).unwrap_or_else(|_| "-".to_string());
+    let permit_wait_ms = std::env::var(PERMIT_WAIT_ENV)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(0);
+    (class, crate_name, permit, permit_wait_ms)
+}
+
+fn real_linker_command(real_linker: &OsStr, args: &[OsString]) -> Command {
+    let mut command = Command::new(real_linker);
+    command.args(args);
+    for key in PRIVATE_ENVS {
+        command.env_remove(key);
+    }
+    command
+}
+
+fn exec_real_linker(real_linker: &OsStr, args: &[OsString]) -> ! {
+    let err = real_linker_command(real_linker, args).exec();
+    eprintln!(
+        "rustc-governor: failed to exec real linker {}: {err}",
+        Path::new(real_linker).display()
+    );
+    std::process::exit(127);
+}
+
+/// Entry point when rustc invokes this binary as its linker.
+pub(crate) fn run() -> ! {
+    let Some(real_linker) = std::env::var_os(REAL_LINKER_ENV) else {
+        eprintln!("rustc-governor: linker mode is missing its real-linker handoff");
+        std::process::exit(127);
+    };
+    let args: Vec<OsString> = std::env::args_os().skip(1).collect();
+    let governor = std::env::current_exe().ok();
+    if governor
+        .as_deref()
+        .is_some_and(|path| paths_name_same(&real_linker, path))
+    {
+        eprintln!("rustc-governor: refusing recursive linker-shim execution");
+        std::process::exit(127);
+    }
+
+    let config_path = config::config_path();
+    let Some(cfg) = config::load(&config_path) else {
+        exec_real_linker(&real_linker, &args);
+    };
+    if !cfg.enabled || std::env::var_os("INTENDANT_GOVERNOR").is_some_and(|value| value == "off") {
+        exec_real_linker(&real_linker, &args);
+    }
+
+    let (class, crate_name, permit, permit_wait_ms) = private_context();
+    let link_gate = permits::acquire_link_slot(&cfg, &config_path, crate_name.as_deref());
+    let disposition = match &link_gate {
+        permits::LinkGate::Held(slot) => govlog::LinkDisposition::Gated {
+            slot: &slot.name,
+            link_wait_ms: slot.wait_ms,
+            queue: slot.queue.as_str(),
+            scope: "linker",
+        },
+        permits::LinkGate::Off => govlog::LinkDisposition::Off,
+        permits::LinkGate::Degraded => govlog::LinkDisposition::Degraded,
+        permits::LinkGate::FailOpen => exec_real_linker(&real_linker, &args),
+    };
+    govlog::log_link(
+        &cfg.permit_dir,
+        &class,
+        crate_name.as_deref(),
+        &disposition,
+        &permit,
+        permit_wait_ms,
+    );
+
+    let started = Instant::now();
+    let child = match real_linker_command(&real_linker, &args).spawn() {
+        Ok(child) => child,
+        Err(err) => {
+            drop(link_gate);
+            eprintln!(
+                "rustc-governor: failed to run real linker {}: {err}",
+                PathBuf::from(&real_linker).display()
+            );
+            std::process::exit(127);
+        }
+    };
+    let status = crate::wait_for_child(child);
+    // Release the high-RSS slot immediately when the linker is reaped,
+    // before best-effort telemetry I/O.
+    drop(link_gate);
+    govlog::log_link_done(
+        &cfg.permit_dir,
+        crate_name.as_deref(),
+        started.elapsed().as_millis() as u64,
+        "linker",
+    );
+    match status {
+        Ok(status) => crate::exit_like_child(status),
+        Err(err) => {
+            eprintln!("rustc-governor: failed to wait for the real linker: {err}");
+            std::process::exit(127);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(values: &[&str]) -> Vec<OsString> {
+        values.iter().map(OsString::from).collect()
+    }
+
+    fn strings(values: &[OsString]) -> Vec<String> {
+        values
+            .iter()
+            .map(|value| value.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn split_linker_is_preserved_and_replaced_by_the_shim() {
+        let prepared = prepare_rustc(&args(&[
+            "--crate-name",
+            "x",
+            "-C",
+            "linker=/opt/toolchain/cc",
+            "-C",
+            "opt-level=3",
+        ]))
+        .unwrap();
+        assert_eq!(prepared.real_linker, OsString::from("/opt/toolchain/cc"));
+        let rewritten = strings(&prepared.args);
+        assert!(!rewritten
+            .iter()
+            .any(|arg| arg == "linker=/opt/toolchain/cc"));
+        assert!(rewritten.iter().any(|arg| arg == "opt-level=3"));
+        assert!(rewritten.last().unwrap().starts_with("linker="));
+    }
+
+    #[test]
+    fn compact_linkers_use_the_last_rustc_value() {
+        let prepared = prepare_rustc(&args(&[
+            "-Clinker=first",
+            "--codegen=linker=second",
+            "--test",
+        ]))
+        .unwrap();
+        assert_eq!(prepared.real_linker, OsString::from("second"));
+        assert_eq!(
+            strings(&prepared.args)
+                .iter()
+                .filter(|arg| arg.contains("linker="))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn native_default_is_cc_but_unknown_target_defaults_are_not_guessed() {
+        assert_eq!(
+            prepare_rustc(&args(&["--test"])).unwrap().real_linker,
+            OsString::from("cc")
+        );
+        assert_eq!(
+            prepare_rustc(&args(&["--test", "--target", "wasm32-wasip2"]))
+                .err()
+                .unwrap(),
+            "configured default linker is unknown"
+        );
+        assert_eq!(
+            prepare_rustc(&args(&["--target=x86_64-unknown-linux-gnu", "--test"]))
+                .err()
+                .unwrap(),
+            "configured default linker is unknown"
+        );
+        assert_eq!(
+            prepare_rustc(&args(&["--test", "--codegen", "linker-flavor=ld.lld"]))
+                .err()
+                .unwrap(),
+            "configured default linker is unknown"
+        );
+    }
+
+    #[test]
+    fn long_codegen_linker_form_is_preserved_and_rewritten() {
+        let prepared =
+            prepare_rustc(&args(&["--test", "--codegen", "linker=/opt/cross/clang"])).unwrap();
+        assert_eq!(prepared.real_linker, OsString::from("/opt/cross/clang"));
+        assert_eq!(
+            strings(&prepared.args)
+                .iter()
+                .filter(|arg| arg.contains("linker="))
+                .count(),
+            1
+        );
+    }
+}

--- a/crates/rustc-governor/src/main.rs
+++ b/crates/rustc-governor/src/main.rs
@@ -4,10 +4,14 @@
 //! invokes it as `rustc-governor <real-rustc> <args…>` and the chain is:
 //!
 //! ```text
-//! cargo → THIS BINARY (acquires + HOLDS the flock(2) permit, waits) →
-//!   spawn of `wrap_with <real-rustc> <args…>` (the blocking sccache
-//!   client) → sccache server: hits answered from cache, misses
-//!   compiled server-side
+//! cacheable library:
+//!   cargo → THIS BINARY (holds compile permit) →
+//!     `wrap_with <real-rustc> <args…>` (blocking sccache client)
+//!
+//! heavyweight bin/test:
+//!   cargo → THIS BINARY (holds compile permit) → real rustc directly,
+//!     with `-C linker=THIS BINARY` → THIS BINARY in linker mode
+//!       (crash-safe FIFO + link slot) → real linker
 //! ```
 //!
 //! The permit is held by the governor itself, which stays alive as the
@@ -26,7 +30,10 @@
 //! waits. A cache hit occupies its permit only for the client
 //! round-trip (~tens of ms); hits queueing head-of-line behind
 //! miss-saturated permits is an accepted trade (ceiling correctness over
-//! warm-path latency).
+//! warm-path latency). Final bin/test invocations are non-cacheable in
+//! sccache, so they bypass `wrap_with`; this also guarantees that the
+//! invocation-private linker handoff reaches rustc rather than a
+//! long-lived cache server.
 //!
 //! Why wrapper-side: the previous wiring (`[build] rustc = governor`,
 //! `rustc-wrapper = sccache`) made sccache treat the governor as the
@@ -58,19 +65,24 @@
 //!      class). Classification runs over argv[2..]; see `probe.rs`.
 //!   3. **Class detection.** The euid's username, matched against the
 //!      config's `ci_users`, splits invocations into `ci` and `local`.
-//!   4. **The link gate.** A heavyweight final link (bin / `--test` target
-//!      emitting `link` — see `link.rs`) first takes one of the
-//!      machine-global `link_slots` flock slots, BEFORE its ordinary
-//!      permit: a waiter on the link gate holds nothing (no
-//!      ordinary-permit hoarding), and no permit holder ever waits on the
-//!      link slot, so the wait graph is acyclic. Gate failure degrades
-//!      (logged, ordinary governance kept); only the global fail-open
-//!      paths drop governance entirely.
-//!   5. **Permits.** Own-class reservation first, then borrow the other
+//!   4. **Permits.** Own-class reservation first, then borrow the other
 //!      class's spare permits iff that class has no registered waiters,
 //!      else register demand and poll — see `permits.rs` for the demand-gate
 //!      protocol. Nothing is ever killed or signalled; borrowed permits
 //!      return naturally when their holder exits.
+//!   5. **The actual-linker gate.** A heavyweight final artifact (bin /
+//!      `--test` target emitting `link` — see `link.rs`) runs compile and
+//!      codegen under its ordinary permit, then rustc invokes this binary
+//!      as its linker shim. Only that shim enters a bounded crash-safe FIFO
+//!      and takes one of the machine-global `link_slots` flock slots. All
+//!      new processes acquire permit then link, so the wait graph remains
+//!      acyclic; queued linkers can occupy their rustc permits, but only
+//!      for real linker work ahead of them rather than another crate's
+//!      compile/codegen. Missing FIFO assets degrade ordering only; missing
+//!      link-slot assets degrade gating (logged, ordinary governance kept).
+//!      The installer refuses a binary swap while old governors are alive:
+//!      mixing the former link-then-permit generation with this order could
+//!      form a cross-generation cycle.
 //!
 //! Config: `/usr/local/etc/intendant-governor.toml`
 //! (`INTENDANT_GOVERNOR_CONFIG` overrides — how the acceptance tests point
@@ -98,10 +110,20 @@ mod govlog;
 #[cfg_attr(not(unix), allow(dead_code))]
 mod link;
 #[cfg(unix)]
+mod linker;
+#[cfg(unix)]
 mod permits;
 mod probe;
 
 fn main() {
+    // The same executable is also rustc's heavyweight-linker shim. Detect
+    // that private handoff before interpreting argv through cargo's
+    // RUSTC_WRAPPER contract: linker argv[1] is an object/flag, not rustc.
+    #[cfg(unix)]
+    if linker::is_linker_mode() {
+        linker::run();
+    }
+
     let mut argv = std::env::args_os().skip(1);
     // cargo's RUSTC_WRAPPER contract: argv[1] is the real compiler.
     let Some(real) = argv.next().map(PathBuf::from) else {
@@ -215,7 +237,7 @@ fn run_unix(
     config_path: &Path,
     lossy: &[String],
 ) -> ! {
-    match governed_guards(cfg, config_path, lossy) {
+    match acquire_governed(cfg, config_path, lossy) {
         // Fail-open: nothing is held, so there is no fd whose lifetime
         // must outlast the chain — exec(2) keeps the zero-overhead shape
         // (this process image simply BECOMES the chain, and a disabled
@@ -223,7 +245,7 @@ fn run_unix(
         // rustc-wrapper).
         None => exec_wrap_chain(real, args, wrap.as_deref()),
         // Governed: every lock is parent-held — see `run_governed`.
-        Some(guards) => run_governed(real, args, wrap.as_deref(), guards),
+        Some(governed) => run_governed(real, args, wrap.as_deref(), config_path, governed),
     }
 }
 
@@ -265,44 +287,95 @@ fn exec_wrap_chain(real: &Path, args: &[OsString], wrap: Option<&Path>) -> ! {
 /// any-exit-releases story): SIGKILL on the governor releases the
 /// permit in the kernel the instant the process dies (its fds close),
 /// and the child orphans and finishes its current compile momentarily
-/// ungoverned.
+/// outside the compile ceiling. If that child has already become the
+/// linker shim, its independently held link slot remains locked until the
+/// real linker ends — high-RSS link safety is not dropped with the outer
+/// parent.
 #[cfg(unix)]
-fn run_governed(real: &Path, args: &[OsString], wrap: Option<&Path>, guards: Guards) -> ! {
-    let Guards {
+fn run_governed(
+    real: &Path,
+    args: &[OsString],
+    wrap: Option<&Path>,
+    config_path: &Path,
+    governed: Governed,
+) -> ! {
+    let Governed {
         permit,
-        link,
-        link_done,
-    } = guards;
-    let started = std::time::Instant::now();
-    let Some(mut child) = spawn_chain(real, args, wrap) else {
-        // Neither the wrap chain nor the compiler would spawn (messages
-        // already printed by spawn_chain).
-        drop(link);
+        cfg,
+        class,
+        classified,
+    } = governed;
+    govlog::log_compile(
+        &cfg.permit_dir,
+        class.as_str(),
+        classified.crate_name.as_deref(),
+        classified.heavy,
+        &permit.name,
+        permit.wait_ms,
+    );
+
+    if classified.heavy {
+        match linker::prepare_rustc(args) {
+            Ok(prepared) => {
+                let child = linker::spawn_rustc(
+                    real,
+                    &prepared,
+                    linker::CompileContext {
+                        config_path,
+                        class: class.as_str(),
+                        crate_name: classified.crate_name.as_deref(),
+                        permit_name: &permit.name,
+                        permit_wait_ms: permit.wait_ms,
+                    },
+                );
+                let child = match child {
+                    Ok(child) => child,
+                    Err(err) => {
+                        drop(permit);
+                        eprintln!(
+                            "rustc-governor: failed to run {} with the linker shim: {err}",
+                            real.display()
+                        );
+                        std::process::exit(127);
+                    }
+                };
+                let status = wait_for_child(child);
+                drop(permit);
+                match status {
+                    Ok(status) => exit_like_child(status),
+                    Err(err) => {
+                        eprintln!(
+                            "rustc-governor: failed to wait for the governed compiler: {err}"
+                        );
+                        std::process::exit(127);
+                    }
+                }
+            }
+            Err(reason) => {
+                eprintln!(
+                    "rustc-governor: cannot isolate this final link ({reason}); \
+                     serializing the whole rustc invocation"
+                );
+                run_whole_rustc_link(
+                    real,
+                    args,
+                    wrap,
+                    config_path,
+                    permit,
+                    &cfg,
+                    class,
+                    classified.crate_name.as_deref(),
+                );
+            }
+        }
+    }
+
+    let Some(child) = spawn_chain(real, args, wrap) else {
         drop(permit);
         std::process::exit(127);
     };
-    // Between spawn and handler install, TERM/INT/HUP still hits the
-    // default disposition: the governor dies, the kernel releases every
-    // lock, the child orphans — the documented crash semantics, for a
-    // few-instruction window.
-    CHILD_PID.store(child.id() as i32, Ordering::Release);
-    install_signal_forwarders();
-    let status = child.wait();
-    // The child is reaped: its pid is free for reuse, so the forwarders
-    // must stop aiming at it before this process does anything else.
-    CHILD_PID.store(0, Ordering::Release);
-    // Both locks were held for the child's whole run (the fds kept
-    // O_CLOEXEC, so the child never saw them); releasing them now —
-    // before the log write below — is release-on-exit made explicit.
-    drop(link);
+    let status = wait_for_child(child);
     drop(permit);
-    if let Some((permit_dir, crate_name)) = link_done {
-        govlog::log_link_done(
-            &permit_dir,
-            crate_name.as_deref(),
-            started.elapsed().as_millis() as u64,
-        );
-    }
     match status {
         Ok(status) => exit_like_child(status),
         Err(err) => {
@@ -310,6 +383,84 @@ fn run_governed(real: &Path, args: &[OsString], wrap: Option<&Path>, guards: Gua
             std::process::exit(127);
         }
     }
+}
+
+/// Compatibility fallback for an explicit cross target whose implicit
+/// linker rustc knows but the shim cannot safely guess. All new governors
+/// acquire in permit-then-link order, so this remains deadlock-free; the
+/// telemetry's scope marks that its runtime includes compilation/codegen.
+#[cfg(unix)]
+#[allow(clippy::too_many_arguments)]
+fn run_whole_rustc_link(
+    real: &Path,
+    args: &[OsString],
+    wrap: Option<&Path>,
+    config_path: &Path,
+    permit: permits::AcquiredPermit,
+    cfg: &config::Config,
+    class: permits::Class,
+    crate_name: Option<&str>,
+) -> ! {
+    let link_gate = permits::acquire_link_slot(cfg, config_path, crate_name);
+    let disposition = match &link_gate {
+        permits::LinkGate::Held(slot) => govlog::LinkDisposition::Gated {
+            slot: &slot.name,
+            link_wait_ms: slot.wait_ms,
+            queue: slot.queue.as_str(),
+            scope: "whole-rustc",
+        },
+        permits::LinkGate::Off => govlog::LinkDisposition::Off,
+        permits::LinkGate::Degraded => govlog::LinkDisposition::Degraded,
+        permits::LinkGate::FailOpen => {
+            drop(permit);
+            exec_wrap_chain(real, args, wrap);
+        }
+    };
+    govlog::log_link(
+        &cfg.permit_dir,
+        class.as_str(),
+        crate_name,
+        &disposition,
+        &permit.name,
+        permit.wait_ms,
+    );
+    let started = std::time::Instant::now();
+    let Some(child) = spawn_chain(real, args, wrap) else {
+        drop(link_gate);
+        drop(permit);
+        std::process::exit(127);
+    };
+    let status = wait_for_child(child);
+    drop(link_gate);
+    drop(permit);
+    govlog::log_link_done(
+        &cfg.permit_dir,
+        crate_name,
+        started.elapsed().as_millis() as u64,
+        "whole-rustc",
+    );
+    match status {
+        Ok(status) => exit_like_child(status),
+        Err(err) => {
+            eprintln!("rustc-governor: failed to wait for the governed compiler: {err}");
+            std::process::exit(127);
+        }
+    }
+}
+
+#[cfg(unix)]
+pub(crate) fn wait_for_child(mut child: Child) -> std::io::Result<std::process::ExitStatus> {
+    // Between spawn and handler install, TERM/INT/HUP still hits the
+    // default disposition: the governor dies, the kernel releases every
+    // lock, and the child orphans — the documented crash semantics, for a
+    // few-instruction window.
+    CHILD_PID.store(child.id() as i32, Ordering::Release);
+    install_signal_forwarders();
+    let status = child.wait();
+    // The child is reaped: its pid is free for reuse, so the forwarders
+    // must stop aiming at it before this process does anything else.
+    CHILD_PID.store(0, Ordering::Release);
+    status
 }
 
 /// Spawn `wrap_with <real> <args…>` — the real compiler directly when
@@ -433,35 +584,31 @@ fn exit_like_child(status: std::process::ExitStatus) -> ! {
     std::process::exit(status.code().unwrap_or(1));
 }
 
-/// Everything a governed invocation holds, parent-side, for the chain's
-/// whole run. Every fd keeps std's FD_CLOEXEC and must stay invisible to
-/// every child — a leaked fd in a long-lived child (in production: the
-/// sccache server the client daemonizes on demand) keeps its flock held
-/// long after the compile.
+/// Everything the outer governor retains for a governed rustc invocation.
+/// The compile permit is parent-held for the chain's whole run. A heavy
+/// invocation's linker shim separately holds the link slot only while the
+/// real linker runs.
 #[cfg(unix)]
-struct Guards {
+struct Governed {
     permit: permits::AcquiredPermit,
-    /// The held slot for a GATED heavyweight link; `None` for ordinary
-    /// compiles and for heavyweights running with the gate off/degraded.
-    link: Option<permits::AcquiredLinkSlot>,
-    /// `(permit_dir, crate name)` for every heavyweight link, gated or
-    /// not: drives the `kind=link-done` runtime line the soak data needs.
-    link_done: Option<(PathBuf, Option<String>)>,
+    cfg: config::Config,
+    class: permits::Class,
+    classified: link::Classified,
 }
 
 /// Decide whether this invocation is governed, and if so acquire what it
-/// holds: the machine-global link slot first for heavyweight links (the
-/// no-hoarding order — a link-gate waiter owns nothing), then the ordinary
-/// class permit. `None` always means "run ungoverned" — every fail-open
-/// path funnels here, and the caller execs the same `wrap_with` chain,
-/// lockless: a disabled governor must be indistinguishable from a plain
-/// sccache rustc-wrapper.
+/// holds: its ordinary class permit. Heavy invocations do not touch the
+/// link queue here; rustc reaches it later by invoking the linker shim.
+/// `None` always means "run ungoverned" — every fail-open path funnels
+/// here, and the caller execs the same `wrap_with` chain lockless: a
+/// disabled governor must be indistinguishable from a plain sccache
+/// rustc-wrapper.
 #[cfg(unix)]
-fn governed_guards(
+fn acquire_governed(
     cfg: Option<config::Config>,
     config_path: &Path,
     lossy: &[String],
-) -> Option<Guards> {
+) -> Option<Governed> {
     // Secondary, per-invocation kill switch (the config file is the primary
     // one). Any value other than "off" is ignored.
     if std::env::var_os("INTENDANT_GOVERNOR").is_some_and(|v| v == "off") {
@@ -480,46 +627,13 @@ fn governed_guards(
         return None;
     }
     let classified = link::classify(lossy);
-    let (link_slot, link_disposition) = if classified.heavy {
-        match permits::acquire_link_slot(&cfg, config_path) {
-            permits::LinkGate::Held(slot) => (Some(slot), None),
-            permits::LinkGate::Off => (None, Some(govlog::LinkDisposition::Off)),
-            permits::LinkGate::Degraded => (None, Some(govlog::LinkDisposition::Degraded)),
-            permits::LinkGate::FailOpen => return None,
-        }
-    } else {
-        (None, None)
-    };
     let class = permits::classify(permits::current_username().as_deref(), &cfg);
-    let Some(permit) = permits::acquire(&cfg, class, config_path) else {
-        // Mid-wait kill switch or an unusable ordinary pool: the whole
-        // invocation fails open. The link guard is dropped HERE, before
-        // the caller execs — never carried into a fail-open chain.
-        drop(link_slot);
-        return None;
-    };
-    let disposition = match &link_slot {
-        Some(slot) => Some(govlog::LinkDisposition::Gated {
-            slot: &slot.name,
-            link_wait_ms: slot.wait_ms,
-        }),
-        None => link_disposition,
-    };
-    govlog::log_governed(
-        &cfg.permit_dir,
-        class.as_str(),
-        classified.crate_name.as_deref(),
-        disposition.as_ref(),
-        &permit.name,
-        permit.wait_ms,
-    );
-    let link_done = classified
-        .heavy
-        .then(|| (cfg.permit_dir.clone(), classified.crate_name.clone()));
-    Some(Guards {
+    let permit = permits::acquire(&cfg, class, config_path)?;
+    Some(Governed {
         permit,
-        link: link_slot,
-        link_done,
+        cfg,
+        class,
+        classified,
     })
 }
 

--- a/crates/rustc-governor/src/permits.rs
+++ b/crates/rustc-governor/src/permits.rs
@@ -13,6 +13,8 @@
 //! - `link-<i>`,         i < link_slots      — the heavyweight-link slots
 //!   (machine-global, classless: host memory doesn't care whose link it
 //!   is, so there is no reservation split and no demand gate)
+//! - `link-waiter-<i>`,  i < link_queue_slots — writable ticket files for
+//!   the bounded, crash-safe FIFO in front of the link slots
 //!
 //! Protocol:
 //! - Holding a permit = holding LOCK_EX on its file. The governor holds
@@ -35,29 +37,35 @@
 //! - Nothing is ever killed or signalled; borrowed permits return naturally
 //!   when their holder exits.
 //!
-//! Link-slot ordering invariant (load-bearing — see `acquire_link_slot`):
-//! a heavyweight invocation takes its LINK SLOT FIRST, and only then its
-//! ordinary permit. **No ordinary-permit hoarding**: an invocation queued
-//! on the link gate holds zero ordinary permits, so however many
-//! heavyweights pile up, ordinary compiles keep the rest of the pool
-//! (three simultaneous final links — the observed cargo behavior — pin
-//! one slot and zero permits, not three permits). **Deadlock-free**: an
-//! ordinary-permit holder never waits on the link slot (only heavyweights
-//! do, and they acquired it first), so the wait graph has no cycle. The
-//! cost — a held slot idling while its owner queues for an ordinary
-//! permit — delays other *links* only, which is the acceptable direction.
-//! No FIFO/fairness guarantee exists in the flock+poll design; soak
-//! telemetry (govlog's wait fields) decides whether one is ever needed.
+//! The link slot is acquired by the linker shim, after rustc has completed
+//! compilation and codegen. The outer governor continues to hold that
+//! rustc's ordinary permit while the linker waits and runs. This cannot
+//! form a cycle: every heavyweight takes resources in the same
+//! permit-then-link order, and the process holding a link slot needs no
+//! further governor resource before it can finish. It also means a queued
+//! link may occupy a compile permit, but only for the duration of the
+//! actual links ahead of it — not for another crate's entire compile and
+//! codegen phase.
+//!
+//! FIFO is a fixed pool of root-minted, world-writable ticket files. A
+//! waiter exclusively flocks one file, writes its monotonic arrival tuple,
+//! and keeps the flock until it acquires a link slot. Scanners treat
+//! unlocked files as free/stale, so SIGKILL releases a ticket structurally
+//! with no cleanup daemon. The first `usable link slots` active tickets may
+//! compete for slots. If no ticket file is usable (old install, bad
+//! permissions), serialization remains active but ordering degrades to the
+//! old unordered poll; `link_queue_slots = 0` explicitly chooses that mode.
 
 use std::fs::{self, File, OpenOptions};
-use std::io;
+use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::Path;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use crate::config::{self, Config};
 use crate::flock;
 
 pub(crate) const POLL_INTERVAL: Duration = Duration::from_millis(100);
+const LINK_WAIT_NOTICE: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Class {
@@ -150,6 +158,24 @@ pub(crate) struct AcquiredLinkSlot {
     pub(crate) _file: File,
     pub(crate) name: String,
     pub(crate) wait_ms: u64,
+    pub(crate) queue: LinkQueueKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LinkQueueKind {
+    Fifo,
+    Disabled,
+    Degraded,
+}
+
+impl LinkQueueKind {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            LinkQueueKind::Fifo => "fifo",
+            LinkQueueKind::Disabled => "disabled",
+            LinkQueueKind::Degraded => "degraded",
+        }
+    }
 }
 
 /// Outcome of gating a heavyweight link.
@@ -181,6 +207,10 @@ fn link_slot_name(i: u32) -> String {
     format!("link-{i}")
 }
 
+fn link_waiter_name(i: u32) -> String {
+    format!("link-waiter-{i}")
+}
+
 /// Open (or, where the directory allows it, create) a lock file. flock(2)
 /// only needs an open fd — read-only is enough against the root-owned 0644
 /// files of a production install; the create fallback serves tempdir rigs
@@ -188,6 +218,24 @@ fn link_slot_name(i: u32) -> String {
 /// (O_CREAT without O_EXCL), so their locks contend correctly.
 fn open_lock_file(path: &Path) -> Option<File> {
     match OpenOptions::new().read(true).open(path) {
+        Ok(f) => Some(f),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(path)
+            .ok(),
+        Err(_) => None,
+    }
+}
+
+/// Queue tickets carry a small arrival record, so unlike ordinary lock
+/// files they must be writable by every governed account. Production
+/// assets are pre-created 0666 by the installer; creation is only a
+/// convenience for user-writable test/diagnostic rigs.
+fn open_queue_file(path: &Path) -> Option<File> {
+    match OpenOptions::new().read(true).write(true).open(path) {
         Ok(f) => Some(f),
         Err(e) if e.kind() == io::ErrorKind::NotFound => OpenOptions::new()
             .read(true)
@@ -231,14 +279,181 @@ fn foreign_has_no_waiters(demand: &File) -> bool {
     }
 }
 
-/// Acquire one machine-global link slot for a heavyweight link, waiting as
-/// long as it takes. Called BEFORE `acquire` — the ordering invariant in
-/// the module doc: a waiter here holds nothing, so it can hoard no
-/// ordinary capacity and can complete no deadlock cycle. No demand gate:
-/// the slots are classless, and the only takers are heavyweights in this
-/// same single queue. The live kill switch is honored mid-wait exactly
-/// like the permit poll.
-pub(crate) fn acquire_link_slot(cfg: &Config, config_path: &Path) -> LinkGate {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct TicketOrder {
+    monotonic_ns: u128,
+    pid: u32,
+    index: u32,
+}
+
+struct QueueTicket {
+    file: File,
+    order: TicketOrder,
+}
+
+impl Drop for QueueTicket {
+    fn drop(&mut self) {
+        // Stale bytes are harmless (an unlocked file is inactive), but
+        // truncating keeps diagnostics human-readable on graceful exits.
+        let _ = self.file.set_len(0);
+        flock::unlock(&self.file);
+    }
+}
+
+enum QueueClaim {
+    Claimed(QueueTicket),
+    Full,
+    Unusable,
+}
+
+enum QueueState {
+    Fifo(QueueTicket),
+    Disabled,
+    Degraded,
+}
+
+impl QueueState {
+    fn kind(&self) -> LinkQueueKind {
+        match self {
+            QueueState::Fifo(_) => LinkQueueKind::Fifo,
+            QueueState::Disabled => LinkQueueKind::Disabled,
+            QueueState::Degraded => LinkQueueKind::Degraded,
+        }
+    }
+}
+
+fn monotonic_ns() -> u128 {
+    // CLOCK_MONOTONIC is machine-wide on both supported Unix families, so
+    // independently spawned waiters can order their arrivals without a
+    // mutable counter file. Fall back to wall time only if the OS call
+    // unexpectedly fails.
+    // SAFETY: `ts` is a live, writable timespec and clock_gettime writes
+    // exactly that value; CLOCK_MONOTONIC needs no other precondition.
+    let mut ts: libc::timespec = unsafe { std::mem::zeroed() };
+    let rc = unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts) };
+    if rc == 0 {
+        (ts.tv_sec.max(0) as u128) * 1_000_000_000 + ts.tv_nsec.max(0) as u128
+    } else {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    }
+}
+
+fn try_claim_queue_ticket(dir: &Path, count: u32) -> QueueClaim {
+    let mut occupied = false;
+    for index in 0..count {
+        let Some(mut file) = open_queue_file(&dir.join(link_waiter_name(index))) else {
+            continue;
+        };
+        if !flock::try_lock_exclusive(&file) {
+            occupied = true;
+            continue;
+        }
+        let order = TicketOrder {
+            monotonic_ns: monotonic_ns(),
+            pid: std::process::id(),
+            index,
+        };
+        let record = format!("{} {} {}\n", order.monotonic_ns, order.pid, order.index);
+        let wrote = file.set_len(0).is_ok()
+            && file.seek(SeekFrom::Start(0)).is_ok()
+            && file.write_all(record.as_bytes()).is_ok();
+        if wrote {
+            return QueueClaim::Claimed(QueueTicket { file, order });
+        }
+        flock::unlock(&file);
+    }
+    if occupied {
+        QueueClaim::Full
+    } else {
+        QueueClaim::Unusable
+    }
+}
+
+fn parse_ticket_record(text: &str, index: u32) -> TicketOrder {
+    let mut fields = text.split_whitespace();
+    let parsed = (|| {
+        Some(TicketOrder {
+            monotonic_ns: fields.next()?.parse().ok()?,
+            pid: fields.next()?.parse().ok()?,
+            index: fields.next()?.parse().ok()?,
+        })
+    })();
+    // An active owner may be observed in the few instructions between its
+    // flock and record write. Treat an empty/partial active record as the
+    // oldest waiter, conservatively preventing a newcomer from overtaking.
+    parsed.unwrap_or(TicketOrder {
+        monotonic_ns: 0,
+        pid: 0,
+        index,
+    })
+}
+
+fn active_ticket_rank(dir: &Path, count: u32, mine: TicketOrder) -> usize {
+    let mut active = Vec::new();
+    for index in 0..count {
+        let Some(mut file) = open_queue_file(&dir.join(link_waiter_name(index))) else {
+            continue;
+        };
+        if flock::try_lock_exclusive(&file) {
+            // Free or crash-stale: it is not an active queue member.
+            flock::unlock(&file);
+            continue;
+        }
+        let mut record = String::new();
+        let _ = file.seek(SeekFrom::Start(0));
+        let _ = file.read_to_string(&mut record);
+        active.push(parse_ticket_record(&record, index));
+    }
+    active.sort_unstable();
+    active
+        .iter()
+        .position(|ticket| *ticket == mine)
+        // Never let a missing/partially observed own record jump to the
+        // front. A normal claimant writes before this scan, so MAX is only
+        // a conservative one-tick response to a race (or external file
+        // removal/corruption).
+        .unwrap_or(usize::MAX)
+}
+
+fn live_config_enabled(config_path: &Path) -> bool {
+    matches!(config::load(config_path), Some(live) if live.enabled)
+}
+
+fn maybe_report_link_wait(
+    start: Instant,
+    reported: &mut bool,
+    crate_name: Option<&str>,
+    queue: &str,
+) {
+    if !*reported && start.elapsed() >= LINK_WAIT_NOTICE {
+        let name: String = crate_name
+            .unwrap_or("-")
+            .chars()
+            .filter(|c| c.is_ascii_graphic())
+            .take(64)
+            .collect();
+        eprintln!(
+            "rustc-governor: {} waiting for the machine-wide linker slot ({:.1}s, queue={queue})",
+            if name.is_empty() { "-" } else { &name },
+            start.elapsed().as_secs_f64(),
+        );
+        *reported = true;
+    }
+}
+
+/// Acquire one machine-global link slot for the actual linker process,
+/// waiting as long as it takes. The outer governor already holds this
+/// rustc invocation's ordinary permit; see the module-level ordering
+/// proof. No class demand gate applies: link slots are machine-global.
+/// The live kill switch is honored mid-wait exactly like the permit poll.
+pub(crate) fn acquire_link_slot(
+    cfg: &Config,
+    config_path: &Path,
+    crate_name: Option<&str>,
+) -> LinkGate {
     if cfg.link_slots == 0 {
         return LinkGate::Off;
     }
@@ -254,21 +469,47 @@ pub(crate) fn acquire_link_slot(cfg: &Config, config_path: &Path) -> LinkGate {
         return LinkGate::Degraded;
     }
     let start = Instant::now();
+    let mut reported = false;
+    let queue = if cfg.link_queue_slots == 0 {
+        QueueState::Disabled
+    } else {
+        loop {
+            match try_claim_queue_ticket(dir, cfg.link_queue_slots) {
+                QueueClaim::Claimed(ticket) => break QueueState::Fifo(ticket),
+                QueueClaim::Unusable => break QueueState::Degraded,
+                QueueClaim::Full => {
+                    if !live_config_enabled(config_path) {
+                        return LinkGate::FailOpen;
+                    }
+                    maybe_report_link_wait(start, &mut reported, crate_name, "full");
+                    std::thread::sleep(POLL_INTERVAL);
+                }
+            }
+        }
+    };
     loop {
-        if let Some((name, file)) = try_take(&mut slots) {
-            return LinkGate::Held(AcquiredLinkSlot {
-                _file: file,
-                name,
-                wait_ms: start.elapsed().as_millis() as u64,
-            });
+        let may_take = match &queue {
+            QueueState::Fifo(ticket) => {
+                active_ticket_rank(dir, cfg.link_queue_slots, ticket.order) < slots.len()
+            }
+            QueueState::Disabled | QueueState::Degraded => true,
+        };
+        if may_take {
+            if let Some((name, file)) = try_take(&mut slots) {
+                let queue_kind = queue.kind();
+                drop(queue);
+                return LinkGate::Held(AcquiredLinkSlot {
+                    _file: file,
+                    name,
+                    wait_ms: start.elapsed().as_millis() as u64,
+                    queue: queue_kind,
+                });
+            }
         }
-        // Same live kill switch as the permit poll below: a flipped
-        // `enabled = false` or a deleted config unwedges link waiters
-        // within one poll tick, fail-open.
-        match config::load(config_path) {
-            Some(live) if live.enabled => {}
-            _ => return LinkGate::FailOpen,
+        if !live_config_enabled(config_path) {
+            return LinkGate::FailOpen;
         }
+        maybe_report_link_wait(start, &mut reported, crate_name, queue.kind().as_str());
         std::thread::sleep(POLL_INTERVAL);
     }
 }
@@ -379,6 +620,7 @@ mod tests {
             local_reserved: local,
             ci_reserved: ci,
             link_slots: 1,
+            link_queue_slots: 8,
             ci_users: vec!["_intendant-ci".into(), "ci".into()],
             wrap_with: None,
         };
@@ -433,19 +675,25 @@ mod tests {
     fn link_gate_off_and_degraded_never_block() {
         let (_tmp, mut cfg, path) = rig(1, 0);
         cfg.link_slots = 0;
-        assert!(matches!(acquire_link_slot(&cfg, &path), LinkGate::Off));
+        assert!(matches!(
+            acquire_link_slot(&cfg, &path, None),
+            LinkGate::Off
+        ));
         // An unusable permit dir (here: a plain file where the dir should
         // be) means no slot file can be opened or created: Degraded, so
         // the caller keeps ordinary governance instead of failing open.
         cfg.link_slots = 1;
         cfg.permit_dir = path.clone();
-        assert!(matches!(acquire_link_slot(&cfg, &path), LinkGate::Degraded));
+        assert!(matches!(
+            acquire_link_slot(&cfg, &path, None),
+            LinkGate::Degraded
+        ));
     }
 
     #[test]
     fn link_slots_serialize_and_release() {
         let (_tmp, cfg, path) = rig(2, 0);
-        let a = match acquire_link_slot(&cfg, &path) {
+        let a = match acquire_link_slot(&cfg, &path, Some("first")) {
             LinkGate::Held(slot) => slot,
             _ => panic!("first heavyweight must take the slot"),
         };
@@ -453,7 +701,7 @@ mod tests {
         // The single slot is held: a second taker polls. Prove it waits
         // by watching a thread not finish, then release and join.
         let (cfg2, path2) = (cfg.clone(), path.clone());
-        let waiter = std::thread::spawn(move || acquire_link_slot(&cfg2, &path2));
+        let waiter = std::thread::spawn(move || acquire_link_slot(&cfg2, &path2, Some("second")));
         std::thread::sleep(Duration::from_millis(400));
         assert!(
             !waiter.is_finished(),
@@ -470,8 +718,8 @@ mod tests {
     fn multiple_link_slots_admit_that_many() {
         let (_tmp, mut cfg, path) = rig(2, 0);
         cfg.link_slots = 2;
-        let a = acquire_link_slot(&cfg, &path);
-        let b = acquire_link_slot(&cfg, &path);
+        let a = acquire_link_slot(&cfg, &path, Some("a"));
+        let b = acquire_link_slot(&cfg, &path, Some("b"));
         let (a, b) = match (a, b) {
             (LinkGate::Held(a), LinkGate::Held(b)) => (a, b),
             _ => panic!("two slots must admit two links"),

--- a/crates/rustc-governor/tests/acceptance.rs
+++ b/crates/rustc-governor/tests/acceptance.rs
@@ -136,6 +136,33 @@ impl Rig {
         path
     }
 
+    /// A tiny rustc stand-in that honors the `-C linker=...` rewrite. Its
+    /// optional prologue represents compilation/codegen work; afterward it
+    /// execs the linker selected by the governor. The exec preserves the
+    /// child pid, which makes signal/crash assertions deterministic.
+    fn linking_rustc(&self, name: &str, prologue: &str) -> PathBuf {
+        self.script(
+            name,
+            &format!(
+                "{prologue}\n\
+                 linker=\n\
+                 while [ \"$#\" -gt 0 ]; do\n\
+                 \u{20} case \"$1\" in\n\
+                 \u{20}\u{20} -C)\n\
+                 \u{20}\u{20}\u{20} shift\n\
+                 \u{20}\u{20}\u{20} [ \"$#\" -gt 0 ] || break\n\
+                 \u{20}\u{20}\u{20} case \"$1\" in linker=*) linker=${{1#linker=}} ;; esac\n\
+                 \u{20}\u{20}\u{20} ;;\n\
+                 \u{20}\u{20} -Clinker=*) linker=${{1#-Clinker=}} ;;\n\
+                 \u{20} esac\n\
+                 \u{20} shift\n\
+                 done\n\
+                 [ -n \"$linker\" ] || {{ echo 'fake rustc: no linker supplied' >&2; exit 90; }}\n\
+                 exec \"$linker\""
+            ),
+        )
+    }
+
     fn permit(&self, name: &str) -> PathBuf {
         self.permit_dir.join(name)
     }
@@ -165,6 +192,27 @@ fn spawn_governor(config: &Path, real: &Path, args: &[&str], envs: &[(&str, &str
         cmd.env(k, v);
     }
     cmd.spawn().unwrap()
+}
+
+/// Spawn a cargo-shaped heavyweight bin compile with an explicit real
+/// linker. The governor removes this `-C linker=...`, gives rustc its own
+/// shim path, then the fake rustc above invokes the shim.
+fn spawn_heavy(config: &Path, rustc: &Path, real_linker: &Path, envs: &[(&str, &str)]) -> Child {
+    let linker = format!("linker={}", real_linker.display());
+    spawn_governor(
+        config,
+        rustc,
+        &[
+            "--crate-name",
+            "x",
+            "--crate-type",
+            "bin",
+            "--emit=dep-info,link",
+            "-C",
+            &linker,
+        ],
+        envs,
+    )
 }
 
 // ------------------------------------------------------- flock helpers ----
@@ -253,15 +301,14 @@ fn kill_and_reap(mut child: Child) {
     let _ = child.wait();
 }
 
-/// The cargo bin-link argv shape (trimmed): classifies heavyweight, so a
-/// spawn with these args must also hold a link slot.
-const HEAVY_ARGS: &[&str] = &[
-    "--crate-name",
-    "x",
-    "--crate-type",
-    "bin",
-    "--emit=dep-info,link",
-];
+fn locked_queue_tickets(rig: &Rig) -> usize {
+    (0..64)
+        .filter(|index| {
+            let path = rig.permit(&format!("link-waiter-{index}"));
+            path.exists() && is_exclusively_locked(&path)
+        })
+        .count()
+}
 
 // ------------------------------------------------------------- tests ----
 
@@ -565,17 +612,18 @@ fn exit_status_propagates() {
 fn sigterm_forwards_to_child_and_signal_death_propagates() {
     let rig = Rig::new();
     let ticks = rig.root.join("ticks");
-    let script = rig.script(
-        "tick.sh",
+    let linker = rig.script(
+        "linker.sh",
         &format!(
             "i=0\nwhile [ $i -lt 600 ]; do echo tick >> {}; i=$((i+1)); sleep 0.05; done",
             ticks.display()
         ),
     );
+    let rustc = rig.linking_rustc("rustc.sh", "");
     let config = rig.config("gov.toml", 1, 0, false, true);
-    // Heavyweight argv: the signal-death path must release the link slot
-    // exactly like the permit.
-    let mut child = spawn_governor(&config, &script, HEAVY_ARGS, &[]);
+    // The fake rustc execs the linker shim, so the signal-death path
+    // exercises both parent-held locks and both forwarding hops.
+    let mut child = spawn_heavy(&config, &rustc, &linker, &[]);
     wait_for(|| ticks.exists(), GENEROUS, "fixture to start ticking");
     assert!(is_exclusively_locked(&rig.permit("link-0")));
     // SAFETY: pid was spawned by this test and not yet reaped; kill(2)
@@ -918,209 +966,331 @@ fn zero_permits_fails_open() {
 
 // ----------------------------------------------------- the link gate ----
 
-/// Serialization: three heavyweight links against link_slots = 1 (the
-/// default — no key in the config) and THREE ordinary permits, so any
-/// serialization observed comes from the link gate alone, never the
-/// permit pool. Concurrency is measured from the fixture's own event
-/// stream, exactly like the global-ceiling test. All three completing is
-/// also the no-deadlock property for slot-then-permit acquisition.
+/// The regression that matters: all three rustcs finish their compile
+/// prologues while the slot is externally held, then their real linker
+/// phases run one-at-a-time in arrival order. The old governor failed the
+/// first half because it held `link-0` around the entire rustc invocation;
+/// its unordered polling also failed the FIFO half under contention.
 #[test]
-fn heavyweight_links_serialize_on_the_link_slot() {
+fn linker_phase_is_serialized_in_fifo_order_after_compilation() {
     let rig = Rig::new();
     let events = rig.root.join("events");
-    let script = rig.script(
-        "link.sh",
+    let rustc = rig.linking_rustc(
+        "rustc.sh",
+        &format!("echo compile-$TEST_ID >> {}", events.display()),
+    );
+    let linker = rig.script(
+        "linker.sh",
         &format!(
-            "echo start >> {ev}\nsleep 0.4\necho end >> {ev}",
-            ev = events.display()
+            "echo link-start-$TEST_ID >> {events}\n\
+             sleep 0.3\n\
+             echo link-end-$TEST_ID >> {events}",
+            events = events.display(),
         ),
     );
     let config = rig.config("gov.toml", 3, 0, false, true);
+    let slot_held = hold_exclusive(&rig.permit("link-0"));
 
-    let mut kids: Vec<Child> = (0..3)
-        .map(|_| spawn_governor(&config, &script, HEAVY_ARGS, &[]))
-        .collect();
-    let overall = Instant::now();
-    for child in &mut kids {
-        let left = Duration::from_secs(45)
-            .checked_sub(overall.elapsed())
-            .unwrap_or_default();
-        let status = wait_deadline(child, left).expect("heavyweight link must finish");
-        assert!(status.success());
+    let mut kids = Vec::new();
+    for id in ["1", "2", "3"] {
+        kids.push(spawn_heavy(&config, &rustc, &linker, &[("TEST_ID", id)]));
+        wait_for(
+            || {
+                std::fs::read_to_string(&events)
+                    .map(|text| text.lines().any(|line| line == format!("compile-{id}")))
+                    .unwrap_or(false)
+            },
+            GENEROUS,
+            "fake rustc to finish its compile phase",
+        );
+        let expected = kids.len();
+        wait_for(
+            || locked_queue_tickets(&rig) == expected,
+            GENEROUS,
+            "linker shim to claim its FIFO ticket",
+        );
     }
-
-    let text = std::fs::read_to_string(&events).unwrap();
-    let (mut current, mut max, mut starts) = (0_i32, 0_i32, 0);
-    for line in text.lines() {
-        match line {
-            "start" => {
-                current += 1;
-                starts += 1;
-                max = max.max(current);
-            }
-            "end" => current -= 1,
-            other => panic!("unexpected event line {other:?}"),
-        }
-    }
-    assert_eq!(starts, 3);
-    assert_eq!(
-        max, 1,
-        "link gate violated: {max} concurrent heavyweight links (link_slots = 1)"
+    assert!(
+        !std::fs::read_to_string(&events)
+            .unwrap()
+            .contains("link-start"),
+        "no real linker may start while link-0 is held"
     );
-    // Every run logged as a gated link, and the completion lines carry
-    // the runtime soak data.
+    drop(slot_held);
+
+    for child in &mut kids {
+        assert!(wait_deadline(child, GENEROUS).unwrap().success());
+    }
+    let text = std::fs::read_to_string(&events).unwrap();
+    let links: Vec<&str> = text
+        .lines()
+        .filter(|line| line.starts_with("link-"))
+        .collect();
+    assert_eq!(
+        links,
+        [
+            "link-start-1",
+            "link-end-1",
+            "link-start-2",
+            "link-end-2",
+            "link-start-3",
+            "link-end-3",
+        ],
+        "link phases must be serialized FIFO: {text:?}"
+    );
     let log = rig.log();
     assert_eq!(
         log.matches("kind=link link_slot=link-0").count(),
         3,
-        "all three must serialize through the one slot: {log:?}"
+        "{log:?}"
     );
-    assert_eq!(log.matches("kind=link-done runtime_ms=").count(), 3);
-    // Normal exits released everything.
+    assert_eq!(log.matches("queue=fifo scope=linker").count(), 3, "{log:?}");
+    assert_eq!(
+        log.matches("kind=link-done").count(),
+        3,
+        "actual linker runtimes must be logged: {log:?}"
+    );
+    assert_eq!(locked_queue_tickets(&rig), 0);
     assert!(!is_exclusively_locked(&rig.permit("link-0")));
 }
 
-/// No ordinary-permit hoarding (the acquisition-order invariant): an
-/// invocation queued on the link gate holds ZERO ordinary permits, so
-/// ordinary compiles keep the pool, and a probe that superficially
-/// resembles a bin invocation (cargo's startup probe carries
-/// `--crate-type bin`) still bypasses everything.
+/// Exercise the handoff with the real toolchain, not only the shell
+/// fixtures: rustc must preserve the private environment, invoke this
+/// binary as `-C linker`, and receive the real linker's status/output.
 #[test]
-fn queued_heavyweight_hoards_no_ordinary_permit() {
+fn real_rustc_binary_links_through_the_phase_shim() {
     let rig = Rig::new();
-    let marker = rig.root.join("marker");
-    let script = rig.script("done.sh", &format!("echo done >> {}", marker.display()));
+    let source = rig.root.join("tiny.rs");
+    let binary = rig.root.join("tiny");
+    std::fs::write(&source, "fn main() { println!(\"shim-ok\"); }\n").unwrap();
+    let config = rig.config("gov.toml", 1, 0, false, true);
+    let linker = "linker=cc";
+    let output = Command::new(GOVERNOR)
+        .arg("rustc")
+        .args([
+            source.to_str().unwrap(),
+            "--crate-name",
+            "tiny",
+            "--crate-type",
+            "bin",
+            "--emit=link",
+            "-o",
+            binary.to_str().unwrap(),
+            "-C",
+            linker,
+        ])
+        .env("INTENDANT_GOVERNOR_CONFIG", &config)
+        .env_remove("INTENDANT_GOVERNOR")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "real rustc through the shim failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let ran = Command::new(&binary).output().unwrap();
+    assert!(ran.status.success());
+    assert_eq!(String::from_utf8_lossy(&ran.stdout), "shim-ok\n");
+    let log = rig.log();
+    assert!(
+        log.contains("crate=tiny kind=compile link=deferred"),
+        "{log:?}"
+    );
+    assert!(
+        log.contains("crate=tiny kind=link link_slot=link-0")
+            && log.contains("queue=fifo scope=linker"),
+        "{log:?}"
+    );
+}
+
+/// A link waiter has already consumed its own rustc compile permit, but
+/// does not take any additional capacity. With two compile permits, an
+/// ordinary rustc still proceeds while the first final linker is queued.
+#[test]
+fn queued_linker_holds_only_its_own_compile_permit() {
+    let rig = Rig::new();
+    let compiled = rig.root.join("compiled");
+    let linked = rig.root.join("linked");
+    let ordinary_done = rig.root.join("ordinary");
+    let rustc = rig.linking_rustc(
+        "rustc.sh",
+        &format!("echo compiled >> {}", compiled.display()),
+    );
+    let linker = rig.script("linker.sh", &format!("echo linked >> {}", linked.display()));
+    let ordinary = rig.script(
+        "ordinary.sh",
+        &format!("echo ordinary >> {}", ordinary_done.display()),
+    );
     let config = rig.config("gov.toml", 2, 0, false, true);
 
     let slot_held = hold_exclusive(&rig.permit("link-0"));
-    let mut heavy = spawn_governor(&config, &script, HEAVY_ARGS, &[]);
-    assert_still_running_for(&mut heavy, BLOCKED_OBSERVATION);
-    assert!(!marker.exists(), "heavyweight ran while the slot was held");
+    let mut heavy = spawn_heavy(&config, &rustc, &linker, &[]);
+    wait_for(|| compiled.exists(), GENEROUS, "heavy compile phase");
+    wait_for(
+        || locked_queue_tickets(&rig) == 1,
+        GENEROUS,
+        "heavy linker to queue",
+    );
+    assert!(!linked.exists());
     assert!(
-        !is_exclusively_locked(&rig.permit("permit-local-0"))
-            && !is_exclusively_locked(&rig.permit("permit-local-1")),
-        "a link-gate waiter must hold no ordinary permit"
+        is_exclusively_locked(&rig.permit("permit-local-0"))
+            ^ is_exclusively_locked(&rig.permit("permit-local-1")),
+        "one and only one compile permit belongs to the queued rustc"
     );
 
-    // Ordinary compiles proceed through the un-hoarded pool…
-    let mut ordinary = spawn_governor(&config, &script, &[], &[]);
-    assert!(wait_deadline(&mut ordinary, GENEROUS).unwrap().success());
-    assert_eq!(
-        std::fs::read_to_string(&marker).unwrap().lines().count(),
-        1,
-        "the ordinary compile must complete while the heavyweight queues"
-    );
-    // …and a probe-shaped invocation carrying --crate-type bin execs
-    // directly (probe classification runs BEFORE link classification).
-    let mut probe = spawn_governor(
-        &config,
-        &script,
-        &[
-            "-",
-            "--crate-name",
-            "___",
-            "--print=file-names",
-            "--crate-type",
-            "bin",
-            "--emit=dep-info",
-            "--print=cfg",
-        ],
-        &[],
-    );
-    assert!(wait_deadline(&mut probe, GENEROUS).unwrap().success());
-
+    let mut ordinary_child = spawn_governor(&config, &ordinary, &[], &[]);
+    assert!(wait_deadline(&mut ordinary_child, GENEROUS)
+        .unwrap()
+        .success());
+    assert!(ordinary_done.exists());
     drop(slot_held);
-    let status = wait_deadline(&mut heavy, GENEROUS).expect("heavyweight must acquire the slot");
-    assert!(status.success());
-    let log = rig.log();
-    let heavy_line = log
-        .lines()
-        .find(|l| l.contains("kind=link "))
-        .expect("gated heavyweight must log");
-    assert!(
-        heavy_line.contains("crate=x")
-            && heavy_line.contains("link_slot=link-0")
-            && heavy_line.contains("link_wait_ms="),
-        "link line must carry the soak fields: {heavy_line:?}"
-    );
-    assert!(
-        !is_exclusively_locked(&rig.permit("link-0")),
-        "normal exit must release the slot"
-    );
+    assert!(wait_deadline(&mut heavy, GENEROUS).unwrap().success());
+    assert!(linked.exists());
 }
 
-/// While a heavyweight holds the slot and waits for an ordinary permit,
-/// borrowing still works: the composed gate never deadlocks against the
-/// class machinery. (Local reservation held; the idle CI reservation is
-/// borrowable because no CI demand is registered.)
+/// Cacheable ordinary compiles retain the configured wrap chain. Final
+/// bin/test rustcs bypass it because that sccache shape is non-cacheable
+/// and the linker handoff must remain invocation-local.
 #[test]
-fn slot_holder_borrows_idle_foreign_permit() {
+fn heavyweight_bypasses_wrap_but_ordinary_compile_keeps_it() {
+    let rig = Rig::new();
+    let wrap_marker = rig.root.join("wrap");
+    let compile_marker = rig.root.join("compile");
+    let link_marker = rig.root.join("link");
+    let wrap = rig.script(
+        "wrap.sh",
+        &format!("echo wrap >> {}\nexec \"$@\"", wrap_marker.display()),
+    );
+    let rustc = rig.linking_rustc(
+        "rustc.sh",
+        &format!("echo compile >> {}", compile_marker.display()),
+    );
+    let linker = rig.script(
+        "linker.sh",
+        &format!("echo link >> {}", link_marker.display()),
+    );
+    let config = rig.config_with_wrap("gov.toml", 1, 0, false, true, &wrap);
+
+    let mut heavy = spawn_heavy(&config, &rustc, &linker, &[]);
+    assert!(wait_deadline(&mut heavy, GENEROUS).unwrap().success());
+    assert!(compile_marker.exists() && link_marker.exists());
+    assert!(
+        !wrap_marker.exists(),
+        "non-cacheable final rustc must not pass through wrap_with"
+    );
+
+    let ordinary_marker = rig.root.join("ordinary");
+    let ordinary = rig.script(
+        "ordinary.sh",
+        &format!("echo ordinary >> {}", ordinary_marker.display()),
+    );
+    let mut child = spawn_governor(&config, &ordinary, &[], &[]);
+    assert!(wait_deadline(&mut child, GENEROUS).unwrap().success());
+    assert!(ordinary_marker.exists() && wrap_marker.exists());
+}
+
+/// Permit borrowing happens before the linker phase: with Local's own
+/// reservation held and no CI demand, a heavyweight rustc borrows the idle
+/// CI permit, then its linker acquires the classless global slot.
+#[test]
+fn linker_waiter_borrows_idle_foreign_permit() {
     let rig = Rig::new();
     let marker = rig.root.join("marker");
-    let script = rig.script("done.sh", &format!("echo done >> {}", marker.display()));
+    let rustc = rig.linking_rustc("rustc.sh", "");
+    let linker = rig.script("linker.sh", &format!("echo done >> {}", marker.display()));
     let config = rig.config("gov.toml", 1, 1, false, true);
 
     let _local_held = hold_exclusive(&rig.permit("permit-local-0"));
-    let mut heavy = spawn_governor(&config, &script, HEAVY_ARGS, &[]);
-    let status = wait_deadline(&mut heavy, GENEROUS)
-        .expect("slot holder must borrow the idle CI permit, not deadlock");
-    assert!(status.success());
+    let mut heavy = spawn_heavy(&config, &rustc, &linker, &[]);
+    assert!(wait_deadline(&mut heavy, GENEROUS).unwrap().success());
     let log = rig.log();
-    let line = log.lines().find(|l| l.contains("kind=link ")).unwrap();
+    let compile = log
+        .lines()
+        .find(|line| line.contains("kind=compile link=deferred"))
+        .unwrap();
     assert!(
-        line.contains("permit=permit-ci-0"),
-        "must have borrowed the idle CI permit: {line:?}"
+        compile.contains("permit=permit-ci-0"),
+        "must borrow the idle CI permit before linking: {compile:?}"
     );
 }
 
-/// `link_slots = 0` is the per-box opt-out: heavyweights run ungated
-/// (logged as such) but stay ordinary-governed.
+/// `link_slots = 0` disables only link serialization. The actual linker
+/// still runs through the shim so its disposition/runtime are observable,
+/// and the ordinary compile ceiling remains active.
 #[test]
 fn zero_link_slots_disables_the_gate_only() {
     let rig = Rig::new();
     let marker = rig.root.join("marker");
-    let script = rig.script("done.sh", &format!("echo done >> {}", marker.display()));
+    let rustc = rig.linking_rustc("rustc.sh", "");
+    let linker = rig.script("linker.sh", &format!("echo done >> {}", marker.display()));
     let config = rig.config_with_links("gov.toml", 1, 0, 0);
 
-    let mut heavy = spawn_governor(&config, &script, HEAVY_ARGS, &[]);
+    let mut heavy = spawn_heavy(&config, &rustc, &linker, &[]);
     assert!(wait_deadline(&mut heavy, GENEROUS).unwrap().success());
     let log = rig.log();
     let line = log
         .lines()
-        .find(|l| l.contains("kind=link-ungated"))
-        .expect("gate-off heavyweight must log its disposition");
+        .find(|line| line.contains("kind=link-ungated"))
+        .unwrap();
     assert!(
         line.contains("reason=off") && line.contains("permit=permit-local-0"),
         "{line:?}"
     );
-    assert!(
-        log.contains("kind=link-done"),
-        "runtime soak line is wanted even ungated: {log:?}"
-    );
+    assert!(log.contains("kind=link-done"));
 
-    // And the ordinary ceiling still binds: hold the only permit, the
-    // heavyweight queues.
     let _held = hold_exclusive(&rig.permit("permit-local-0"));
-    let mut queued = spawn_governor(&config, &script, HEAVY_ARGS, &[]);
+    let mut queued = spawn_heavy(&config, &rustc, &linker, &[]);
     assert_still_running_for(&mut queued, BLOCKED_OBSERVATION);
     kill_and_reap(queued);
 }
 
-/// Degraded link gating: the permit dir denies creating the slot files
-/// (the production shape: root-owned dir, config grown past the
-/// installer-minted files). The link gate degrades — logged — but
-/// ordinary governance is KEPT: reviewer contract, "link-gate failure
-/// must not discard ordinary governance".
+/// Queue ordering and link serialization degrade independently. During an
+/// old-install/new-binary transition, `link-0` may exist before the new
+/// writable waiter files: the link must remain gated, merely unordered.
+#[test]
+fn missing_fifo_assets_preserve_link_serialization() {
+    let rig = Rig::new();
+    let marker = rig.root.join("marker");
+    let rustc = rig.linking_rustc("rustc.sh", "");
+    let linker = rig.script("linker.sh", &format!("echo done >> {}", marker.display()));
+    let config = rig.config("gov.toml", 1, 0, false, true);
+    for name in [
+        "permit-local-0",
+        "demand-local",
+        "demand-ci",
+        "link-0",
+        "governor.log",
+    ] {
+        drop(open_rw(&rig.permit(name)));
+    }
+    let mut ro = std::fs::metadata(&rig.permit_dir).unwrap().permissions();
+    ro.set_mode(0o555);
+    std::fs::set_permissions(&rig.permit_dir, ro).unwrap();
+    let mut heavy = spawn_heavy(&config, &rustc, &linker, &[]);
+    let status = wait_deadline(&mut heavy, GENEROUS);
+    let mut rw = std::fs::metadata(&rig.permit_dir).unwrap().permissions();
+    rw.set_mode(0o755);
+    std::fs::set_permissions(&rig.permit_dir, rw).unwrap();
+
+    assert!(status.unwrap().success());
+    assert!(marker.exists());
+    let log = rig.log();
+    assert!(
+        log.contains("kind=link link_slot=link-0") && log.contains("queue=degraded scope=linker"),
+        "missing FIFO files must not disable the link gate: {log:?}"
+    );
+}
+
+/// Missing root-minted slot files degrade link gating without discarding
+/// the already-acquired ordinary compile permit.
 #[test]
 fn degraded_link_gate_keeps_ordinary_governance() {
     let rig = Rig::new();
     let marker = rig.root.join("marker");
-    let script = rig.script("done.sh", &format!("echo done >> {}", marker.display()));
+    let rustc = rig.linking_rustc("rustc.sh", "");
+    let linker = rig.script("linker.sh", &format!("echo done >> {}", marker.display()));
     let config = rig.config("gov.toml", 1, 0, false, true);
 
-    // Pre-create everything the ordinary path needs (the installer's
-    // job in production), plus the log file — then make the dir
-    // read-only so link-0 cannot be created.
     for name in [
         "permit-local-0",
         "demand-local",
@@ -1132,91 +1302,146 @@ fn degraded_link_gate_keeps_ordinary_governance() {
     let mut ro = std::fs::metadata(&rig.permit_dir).unwrap().permissions();
     ro.set_mode(0o555);
     std::fs::set_permissions(&rig.permit_dir, ro).unwrap();
-
-    let mut heavy = spawn_governor(&config, &script, HEAVY_ARGS, &[]);
+    let mut heavy = spawn_heavy(&config, &rustc, &linker, &[]);
     let status = wait_deadline(&mut heavy, GENEROUS);
-
-    // Restore permissions FIRST (tempdir cleanup + rig.log both need the
-    // dir readable-writable), then assert.
     let mut rw = std::fs::metadata(&rig.permit_dir).unwrap().permissions();
     rw.set_mode(0o755);
     std::fs::set_permissions(&rig.permit_dir, rw).unwrap();
 
-    assert!(status.expect("degraded gate must not block").success());
+    assert!(status.unwrap().success());
     assert!(marker.exists());
     let log = rig.log();
     let line = log
         .lines()
-        .find(|l| l.contains("kind=link-ungated"))
-        .expect("degraded heavyweight must log its disposition");
+        .find(|line| line.contains("kind=link-ungated"))
+        .unwrap();
     assert!(
         line.contains("reason=degraded") && line.contains("permit=permit-local-0"),
-        "ordinary governance must be kept through link-gate degradation: {line:?}"
+        "{line:?}"
     );
 }
 
-/// SIGKILL on a slot-holding governor releases BOTH locks through kernel
-/// semantics (the fds close with the process), exactly like the
-/// permit-only crash test above.
+/// Killing a queued linker shim releases its FIFO ticket in the kernel.
+/// The next ticket then advances; no stale pid/timestamp cleanup daemon is
+/// required.
 #[test]
-fn sigkilled_heavy_governor_releases_both_locks() {
+fn sigkilled_queue_waiter_cannot_block_the_fifo() {
     let rig = Rig::new();
-    let ready = rig.root.join("ready");
-    let script = rig.script(
-        "hold.sh",
+    let shim_pids = rig.root.join("shim-pids");
+    let linked = rig.root.join("linked");
+    let rustc = rig.linking_rustc(
+        "rustc.sh",
+        &format!("echo \"$TEST_ID $$\" >> {}", shim_pids.display()),
+    );
+    let linker = rig.script(
+        "linker.sh",
+        &format!("echo \"$TEST_ID\" >> {}", linked.display()),
+    );
+    let config = rig.config("gov.toml", 2, 0, false, true);
+    let slot_held = hold_exclusive(&rig.permit("link-0"));
+
+    let mut first = spawn_heavy(&config, &rustc, &linker, &[("TEST_ID", "1")]);
+    wait_for(
+        || locked_queue_tickets(&rig) == 1,
+        GENEROUS,
+        "first FIFO ticket",
+    );
+    let mut second = spawn_heavy(&config, &rustc, &linker, &[("TEST_ID", "2")]);
+    wait_for(
+        || locked_queue_tickets(&rig) == 2,
+        GENEROUS,
+        "second FIFO ticket",
+    );
+    let first_shim: libc::pid_t = std::fs::read_to_string(&shim_pids)
+        .unwrap()
+        .lines()
+        .find_map(|line| {
+            let (id, pid) = line.split_once(' ')?;
+            (id == "1").then(|| pid.parse().unwrap())
+        })
+        .unwrap();
+    // SAFETY: this pid was written by the fake rustc this test spawned and
+    // has exec'd the queued linker shim; it has not been reaped.
+    assert_eq!(unsafe { libc::kill(first_shim, libc::SIGKILL) }, 0);
+    assert!(wait_deadline(&mut first, GENEROUS)
+        .unwrap()
+        .signal()
+        .is_some());
+    wait_for(
+        || locked_queue_tickets(&rig) == 1,
+        GENEROUS,
+        "killed ticket to evaporate",
+    );
+
+    drop(slot_held);
+    assert!(wait_deadline(&mut second, GENEROUS).unwrap().success());
+    assert_eq!(std::fs::read_to_string(&linked).unwrap().trim(), "2");
+}
+
+/// If the outer compile-governor is SIGKILLed after its linker starts, its
+/// ordinary permit is released immediately, but the independently alive
+/// linker shim correctly keeps the high-RSS link slot until the real
+/// linker ends.
+#[test]
+fn sigkilled_outer_releases_compile_permit_but_not_a_live_link_slot() {
+    let rig = Rig::new();
+    let shim_pid = rig.root.join("shim-pid");
+    let linker_pid = rig.root.join("linker-pid");
+    let rustc = rig.linking_rustc("rustc.sh", &format!("echo $$ > {}", shim_pid.display()));
+    let linker = rig.script(
+        "linker.sh",
         &format!(
-            "echo $$ >> {}\nwhile :; do sleep 0.05; done",
-            ready.display()
+            "echo $$ > {}\nwhile :; do sleep 0.05; done",
+            linker_pid.display()
         ),
     );
     let config = rig.config("gov.toml", 1, 0, false, true);
 
-    let mut child = spawn_governor(&config, &script, HEAVY_ARGS, &[]);
-    wait_for(
-        || {
-            std::fs::read_to_string(&ready)
-                .map(|s| s.ends_with('\n'))
-                .unwrap_or(false)
-        },
-        GENEROUS,
-        "holder to start",
-    );
-    assert!(is_exclusively_locked(&rig.permit("link-0")));
+    let mut outer = spawn_heavy(&config, &rustc, &linker, &[]);
+    wait_for(|| linker_pid.exists(), GENEROUS, "real linker to start");
     assert!(is_exclusively_locked(&rig.permit("permit-local-0")));
-    child.kill().unwrap();
-    child.wait().unwrap();
+    assert!(is_exclusively_locked(&rig.permit("link-0")));
+    outer.kill().unwrap();
+    outer.wait().unwrap();
     wait_for(
-        || {
-            !is_exclusively_locked(&rig.permit("link-0"))
-                && !is_exclusively_locked(&rig.permit("permit-local-0"))
-        },
+        || !is_exclusively_locked(&rig.permit("permit-local-0")),
         GENEROUS,
-        "both locks to release after SIGKILL",
+        "compile permit release",
     );
-    let orphan: libc::pid_t = std::fs::read_to_string(&ready)
+    assert!(
+        is_exclusively_locked(&rig.permit("link-0")),
+        "a still-running real linker must remain serialized"
+    );
+
+    let real_linker: libc::pid_t = std::fs::read_to_string(&linker_pid)
         .unwrap()
         .trim()
         .parse()
-        .expect("fixture wrote its pid");
-    // SAFETY: the pid was reported by the fixture this test (transitively)
-    // spawned; kill(2) takes only the pid and signal number.
+        .unwrap();
+    // SAFETY: the pid was reported by the real-linker fixture this test
+    // spawned; kill(2) takes only that pid and signal number.
     unsafe {
-        libc::kill(orphan, libc::SIGKILL);
+        libc::kill(real_linker, libc::SIGKILL);
     }
+    wait_for(
+        || !is_exclusively_locked(&rig.permit("link-0")),
+        GENEROUS,
+        "link slot release after the real linker dies",
+    );
+    // The shim pid file also proves fake rustc exec'd the shim rather than
+    // merely exiting before the link phase.
+    assert!(shim_pid.exists());
 }
 
-/// Neither lock fd is inheritable: a long-lived grandchild the chain
-/// leaves behind (the daemonized-sccache-server shape, minus sccache)
-/// must not keep either flock alive past the governor's exit. This is
-/// the general CLOEXEC + parent-held property; the real-sccache
-/// daemonization variant lives in tests/sccache_chain.rs (heavy bin
-/// shapes are non-cacheable there, so the rlib test carries it).
+/// Neither parent-held lock fd is inheritable by a grandchild the real
+/// linker leaves behind.
 #[test]
 fn long_lived_grandchild_inherits_neither_lock() {
     let rig = Rig::new();
     let marker = rig.root.join("marker");
-    let script = rig.script(
-        "daemonish.sh",
+    let rustc = rig.linking_rustc("rustc.sh", "");
+    let linker = rig.script(
+        "linker.sh",
         &format!(
             "sleep 3 >/dev/null 2>&1 &\necho spawned >> {}",
             marker.display()
@@ -1224,40 +1449,33 @@ fn long_lived_grandchild_inherits_neither_lock() {
     );
     let config = rig.config("gov.toml", 1, 0, false, true);
 
-    let mut child = spawn_governor(&config, &script, HEAVY_ARGS, &[]);
+    let mut child = spawn_heavy(&config, &rustc, &linker, &[]);
     assert!(wait_deadline(&mut child, GENEROUS).unwrap().success());
     assert!(marker.exists());
-    // The governor exited; the backgrounded sleep (reparented, still
-    // alive for ~3s) must hold neither lock.
-    assert!(
-        !is_exclusively_locked(&rig.permit("link-0")),
-        "a grandchild inherited the link-slot fd"
-    );
-    assert!(
-        !is_exclusively_locked(&rig.permit("permit-local-0")),
-        "a grandchild inherited the permit fd"
-    );
+    assert!(!is_exclusively_locked(&rig.permit("link-0")));
+    assert!(!is_exclusively_locked(&rig.permit("permit-local-0")));
 }
 
-/// The live kill switch unwedges LINK-slot waiters exactly like permit
-/// waiters, for every way the config can die: flipped off, deleted, or
-/// replaced with garbage. Fail-open runs are silent in the log, and the
-/// waiter never touched an ordinary permit.
+/// The live kill switch unwedges FIFO link waiters for every way the
+/// config can become unusable. The compile acquisition remains logged;
+/// the fail-open linker itself adds no gated/ungated line.
 #[test]
 fn dying_config_unwedges_link_waiters_fail_open() {
     for way in ["disable", "delete", "garbage"] {
         let rig = Rig::new();
         let marker = rig.root.join("marker");
-        let script = rig.script("done.sh", &format!("echo done >> {}", marker.display()));
+        let rustc = rig.linking_rustc("rustc.sh", "");
+        let linker = rig.script("linker.sh", &format!("echo done >> {}", marker.display()));
         let config = rig.config("gov.toml", 1, 0, false, true);
 
         let _slot_held = hold_exclusive(&rig.permit("link-0"));
-        let mut heavy = spawn_governor(&config, &script, HEAVY_ARGS, &[]);
-        assert_still_running_for(&mut heavy, Duration::from_millis(600));
-        assert!(
-            !is_exclusively_locked(&rig.permit("permit-local-0")),
-            "[{way}] a link-gate waiter must hold no ordinary permit"
+        let mut heavy = spawn_heavy(&config, &rustc, &linker, &[]);
+        wait_for(
+            || locked_queue_tickets(&rig) == 1,
+            GENEROUS,
+            "linker to queue",
         );
+        assert!(is_exclusively_locked(&rig.permit("permit-local-0")));
 
         match way {
             "disable" => {
@@ -1267,45 +1485,14 @@ fn dying_config_unwedges_link_waiters_fail_open() {
             "garbage" => std::fs::write(&config, "enabled = maybe\n").unwrap(),
             _ => unreachable!(),
         }
-        let status = wait_deadline(&mut heavy, GENEROUS)
-            .unwrap_or_else(|| panic!("[{way}] link waiter must unwedge, fail-open"));
-        assert!(status.success(), "[{way}]");
+        assert!(wait_deadline(&mut heavy, GENEROUS).unwrap().success());
         assert!(marker.exists(), "[{way}]");
-        assert_eq!(rig.log(), "", "[{way}] fail-open must not log");
+        let log = rig.log();
+        assert_eq!(log.matches("kind=compile link=deferred").count(), 1);
+        assert!(!log.contains("kind=link "), "[{way}] {log:?}");
+        assert!(!log.contains("kind=link-ungated"), "[{way}] {log:?}");
+        assert_eq!(locked_queue_tickets(&rig), 0);
     }
-}
-
-/// The config dying while a heavyweight HOLDS the slot but waits for an
-/// ordinary permit: the invocation fails open and the slot is dropped
-/// before the exec — never carried into an ungoverned chain.
-#[test]
-fn dying_config_drops_a_held_slot_before_fail_open() {
-    let rig = Rig::new();
-    let marker = rig.root.join("marker");
-    let script = rig.script("done.sh", &format!("echo done >> {}", marker.display()));
-    let config = rig.config("gov.toml", 1, 0, false, true);
-
-    // The only ordinary permit is held forever; the link slot is free.
-    let _permit_held = hold_exclusive(&rig.permit("permit-local-0"));
-    let mut heavy = spawn_governor(&config, &script, HEAVY_ARGS, &[]);
-    // The heavyweight takes the slot, then queues on the permit.
-    wait_for(
-        || is_exclusively_locked(&rig.permit("link-0")),
-        GENEROUS,
-        "heavyweight to take the link slot",
-    );
-    assert_still_running_for(&mut heavy, Duration::from_millis(600));
-
-    std::fs::remove_file(&config).unwrap();
-    let status =
-        wait_deadline(&mut heavy, GENEROUS).expect("permit waiter must unwedge, fail-open");
-    assert!(status.success());
-    assert!(marker.exists());
-    assert!(
-        !is_exclusively_locked(&rig.permit("link-0")),
-        "the slot must be dropped when its holder fails open"
-    );
-    assert_eq!(rig.log(), "", "fail-open must not log");
 }
 
 // ---------------------------------------------------- wiring guards ----

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -133,17 +133,20 @@ considered and deliberately skipped as disproportionate.
 cargo ──[build] rustc-wrapper=governor──▶ rustc-governor <real rustc> <args…>
                     │  probe (-vV / pure --print):
                     │    exec(2) real rustc directly — no permit, no sccache
-                    ▼  compile: acquire flock(2) permit
+                    ▼  acquire flock(2) compile permit
               governor (HOLDS the permit, waits)
-                    │  spawns; the permit fd keeps FD_CLOEXEC —
-                    ▼  no child ever sees it
-              sccache <real rustc> <args…>   (the blocking sccache CLIENT)
-                    ▼
-              sccache server ── hit: answer from cache (client exits in
-                    │                ~tens of ms, permit released)
-                    ▼  miss / non-cacheable
-              real rustc runs; the client — and so the waiting governor,
-              and so the permit — blocks until it finishes
+                    │
+                    ├─ cacheable library ─▶ sccache <rustc> <args…>
+                    │                         │ hit: answer in ~tens of ms
+                    │                         └ miss: server-side rustc
+                    │
+                    └─ final bin/test ─────▶ real rustc directly
+                                              │ compile + codegen
+                                              ▼
+                                    rustc-governor (linker shim)
+                                              │ FIFO ticket + link slot
+                                              ▼
+                                           real linker
 ```
 
 The governor is cargo's `rustc-wrapper`; sccache is no longer the
@@ -156,6 +159,13 @@ governed but uncached):
   governor, whose spawned sccache *client* blocks until the server
   answers: at most N outstanding clients ⇒ at most N server-side
   compiles, no matter which rustc binary the server resolves and runs.
+- **Final bin/test rustcs bypass sccache.** Those link-producing shapes
+  are non-cacheable (the real-sccache regression tests deliberately use
+  an rlib because a bin would test the wrong path). Running them directly
+  also guarantees that the invocation-private `-C linker=…` handoff
+  reaches rustc rather than a long-lived cache server. Their compile and
+  codegen remain covered by the ordinary permit; only their real linker
+  phase takes the separate link slot.
 - **Probes never wait and never touch sccache** — `-vV` / `--version` /
   pure `--print` queries (cargo fires them at every startup) exec the
   real compiler directly: snappy under a full pool, and cargo startup no
@@ -222,7 +232,7 @@ class has waiters and its reservation is honored. Nothing is ever
 killed or signalled; borrowed permits return naturally when their
 holder exits.
 
-### The link gate: heavyweight final links serialize
+### The linker-phase gate: heavyweight final links serialize
 
 The count ceiling alone proved insufficient the day every slot held a
 LINK (2026-07-15, with the governor verified correct — no bypass, no
@@ -231,7 +241,7 @@ concurrently drove the host compressor to 10–11GB with sustained
 two-way swap; a plain `cargo build` then launched three final links at
 once and pushed swap-out to ~124MiB/s. The causal probe was clean (two
 links = severe churn, one = recovering, zero = idle), so the gate
-matches it: ordinary compiles keep the permit pool, heavyweight links
+matches it: ordinary compiles keep the permit pool, heavyweight linkers
 additionally serialize through `link_slots` machine-GLOBAL flock slots
 (`link-<i>` in the permit dir — classless on purpose: host memory does
 not care whose link it is).
@@ -247,19 +257,41 @@ future allowlist or weighting must earn itself with. Full
 classification contract + pinned argv matrix:
 `crates/rustc-governor/src/link.rs`.
 
-Acquisition order is load-bearing: **link slot first, ordinary permit
-second**. A link-gate waiter holds NOTHING — no ordinary-permit
-hoarding (cargo really does launch three links at once; under the
-reverse order they would pin three permits and starve every ordinary
-compile) — and no permit holder ever waits on the link slot, so the
-wait graph is acyclic. The cost, a held slot idling while its owner
-queues for a permit, delays other links only. There is deliberately no
-FIFO/fairness machinery in the flock+poll design; the soak telemetry
-decides whether any is ever needed. Gate failure DEGRADES instead of
-failing open: if no slot file is usable (config grown past the
-installer-minted files), the link runs ungated but still takes its
-ordinary permit — only the global kill-switch paths drop governance
-entirely. `link_slots = 0` is the per-box opt-out.
+The phase boundary is load-bearing. The first link gate wrapped the
+entire heavyweight rustc invocation: a test rustc held `link-0` through
+compile and codegen for 796 seconds while later release binaries waited
+about 14 minutes without starting. The current governor instead replaces
+rustc's linker with the same binary in a private shim mode. Rustc compiles
+and performs codegen under its ordinary permit; only when it invokes the
+shim does that process queue for `link-<i>`, spawn the real linker, and
+hold the slot until the linker is reaped. An explicit target whose
+implicit linker cannot be recovered safely uses a logged
+`scope=whole-rustc` compatibility fallback rather than guessing a
+target-specific linker.
+
+All current-generation heavyweights acquire **ordinary permit, then link
+slot**, so the wait graph is acyclic: a slot holder needs no further
+governor resource before its linker can finish. A queued linker still
+occupies its rustc's compile permit, but only for actual links ahead of it
+rather than another crate's whole compile/codegen phase. The installer
+refuses to swap binaries while any governor is alive because mixing the
+former link-then-permit generation with this order could create a
+cross-generation cycle.
+
+Link waiters are FIFO. The installer pre-creates
+`link-waiter-<i>` (`link_queue_slots`, default 64) mode 0666. A waiter
+exclusively flocks one ticket, writes its monotonic arrival tuple, and
+holds the flock until it acquires a link slot. The first N active tickets
+may compete for N usable slots. SIGKILL closes the ticket fd, so scanners
+recognize it as free/stale without pid polling or a cleanup daemon. After
+five seconds the waiter emits one concise stderr diagnostic naming the
+crate, elapsed wait, and queue mode.
+
+Degradation is split deliberately: if no waiter file is usable, link
+serialization remains active with `queue=degraded` unordered polling; if
+no link slot itself is usable, the linker runs ungated but ordinary
+governance remains. `link_queue_slots = 0` disables FIFO only;
+`link_slots = 0` disables the link gate.
 
 ### Fail-open doctrine + live kill switch
 
@@ -277,16 +309,18 @@ waiters — link-slot waiters included), so
 `enabled = false` drains the governor within ~100ms, no listener
 restarts. `INTENDANT_GOVERNOR_CONFIG` overrides that path; acceptance tests use
 it to point the wrapper at a tempdir rig, and operators can use it for a
-deliberately isolated diagnostic invocation. Observability: one acquisition
-line per *governed* invocation
-in `<permit_dir>/governor.log` — timestamp, pid, class, crate,
-`kind=compile` / `kind=link link_slot=… link_wait_ms=…` /
-`kind=link-ungated reason=off|degraded`, permit, wait_ms — plus one
-`kind=link-done runtime_ms=…` completion line per heavyweight link
-(gated or not): crate, both waits, and runtime are the soak data that
-size the link gate. Truncate-in-place rotation at 1MB keeping the last
-256K — the hooks-log doctrine, because governed accounts can write the
-pre-created file but not create siblings in the root-owned dir.
+deliberately isolated diagnostic invocation. Observability: one
+compile-permit acquisition line per governed invocation in
+`<permit_dir>/governor.log` — timestamp, pid, class, crate,
+`kind=compile` (plus `link=deferred` for a heavyweight), permit, and
+`wait_ms`. The linker shim adds
+`kind=link link_slot=… link_wait_ms=… queue=… scope=linker` (or
+`kind=link-ungated reason=off|degraded`) and
+`kind=link-done runtime_ms=… scope=linker`. That runtime is actual linker
+wall time, no longer compile+codegen+link. Truncate-in-place rotation at
+1MB keeps the last 256K — the hooks-log doctrine, because governed
+accounts can write the pre-created log/ticket files but cannot create
+siblings in the root-owned dir.
 
 ### Sizing, install, rollout
 
@@ -299,17 +333,19 @@ binary, so a binary upgrade turns the gate on with pre-gate configs)
 sizes the heavyweight-link gate per box: keep 1 on small-memory hosts;
 a big-RAM box can raise it — after the installer re-run that mints the
 extra `link-<i>` files — or set 0 to opt out of link gating alone.
+`link_queue_slots` (default 64) bounds FIFO waiters; set 0 only to retain
+serialization with unordered polling.
 
 ```bash
 cargo build --release -p rustc-governor
 sudo scripts/ci/install-governor-macos.sh   # binary + permit dir + conf
 ```
 
-The installer mints config and lock assets BEFORE swapping the binary
-(old binaries ignore the new key and files; a new binary must never run
-ahead of the root-minted slot files it gates on), and upgrades deploy
-during a quiescent no-link interval — an already-running old governor
-cannot retroactively acquire a gate it never knew about. It never edits
+The installer mints config and lock/ticket assets BEFORE swapping the
+binary (old binaries ignore the new key and files; a new binary must
+never run ahead of its root-minted assets), then refuses the binary swap
+while any `rustc-governor` process is alive. Retry after builds drain;
+this enforces the required quiescent generation transition. It never edits
 account cargo configs; it prints the
 `[build] rustc-wrapper = ".../rustc-governor"` line to set per account
 (replacing sccache as the wrapper — the governor runs sccache itself as

--- a/scripts/ci/install-governor-macos.sh
+++ b/scripts/ci/install-governor-macos.sh
@@ -14,8 +14,11 @@
 # binary must never run ahead of the root-minted files it gates on (a
 # heavyweight link would degrade to ungated on a box that wanted the
 # gate). Upgrades land during a quiescent interval anyway: an
-# already-running old governor cannot retroactively acquire a gate it
-# never knew about.
+# already-running old governor cannot change acquisition order. This
+# installer refuses the final binary swap while any governor is alive:
+# mixing the old link-then-permit generation with the new
+# permit-then-linker-shim generation could form a cross-generation wait
+# cycle even though each generation is deadlock-free by itself.
 #
 # Deliberately does NOT touch any account's ~/.cargo/config.toml: the
 # governor stays inert until an account's cargo points at it (as
@@ -62,12 +65,16 @@ ci_reserved = 2
 # final links are what melt a small box, not ordinary rustc concurrency.
 # 0 disables the link gate; absent, the binary defaults it to 1.
 link_slots = 1
+# Crash-safe FIFO capacity in front of the link slots. These writable
+# ticket files are fixed/root-minted; 0 keeps serialization but disables
+# ordering. Absent, the binary defaults to 64.
+link_queue_slots = 64
 ci_users = ["_intendant-ci", "ci"]
-# Governed invocations spawn `wrap_with <rustc> <args…>` (the sccache
-# client) as a CHILD while the governor itself holds its locks until the
-# child exits — the fds are close-on-exec, so no child (crucially, no
-# daemonized sccache server) can inherit a flock. Unset, empty, or a
-# missing path: the compiler runs directly (correct, just uncached).
+# Cacheable governed invocations spawn `wrap_with <rustc> <args…>` (the
+# sccache client) as a CHILD while the governor holds its compile permit.
+# Final bin/test rustcs are non-cacheable and run directly so the same
+# binary can gate only their real linker phase. Lock fds remain
+# close-on-exec. Unset/empty/missing: rustc runs directly (uncached).
 wrap_with = "/opt/homebrew/bin/sccache"
 CONF_EOF
     chmod 0644 "$CONF"
@@ -89,6 +96,10 @@ WRAP_EOF
         echo "  NOTE: no link_slots key — the binary defaults to 1 (heavyweight final"
         echo "  links serialize machine-wide). Add 'link_slots = N' to resize, 0 to disable."
     fi
+    if ! grep -q '^[[:space:]]*link_queue_slots[[:space:]]*=' "$CONF"; then
+        echo "  NOTE: no link_queue_slots key — the binary defaults to 64 FIFO tickets."
+        echo "  Add 'link_queue_slots = N' to resize, 0 to keep gating without ordering."
+    fi
 fi
 
 # Pre-create the flock files for the *effective* config (an existing conf
@@ -101,16 +112,24 @@ permit_dir=$(sed -n 's/^permit_dir[[:space:]]*=[[:space:]]*"\(.*\)".*$/\1/p' "$C
 local_n=$(sed -n 's/^local_reserved[[:space:]]*=[[:space:]]*\([0-9][0-9]*\).*$/\1/p' "$CONF" | tail -n 1)
 ci_n=$(sed -n 's/^ci_reserved[[:space:]]*=[[:space:]]*\([0-9][0-9]*\).*$/\1/p' "$CONF" | tail -n 1)
 link_n=$(sed -n 's/^link_slots[[:space:]]*=[[:space:]]*\([0-9][0-9]*\).*$/\1/p' "$CONF" | tail -n 1)
+link_queue_n=$(sed -n 's/^link_queue_slots[[:space:]]*=[[:space:]]*\([0-9][0-9]*\).*$/\1/p' "$CONF" | tail -n 1)
 permit_dir="${permit_dir:-$PERMIT_DIR_DEFAULT}"
 local_n="${local_n:-1}"
 ci_n="${ci_n:-2}"
 link_n="${link_n:-1}"   # the binary's default when the key is absent
+link_queue_n="${link_queue_n:-64}"   # the binary's default when absent
 
 install -d -m 0755 "$permit_dir"
 create_lock_file() {
     [ -f "$1" ] || : > "$1"
     chown root:wheel "$1"
     chmod 0644 "$1"
+}
+create_queue_file() {
+    [ -f "$1" ] || : > "$1"
+    chown root:wheel "$1"
+    # Every governed account must write its arrival tuple while flocking.
+    chmod 0666 "$1"
 }
 i=0
 while [ "$i" -lt "$local_n" ]; do
@@ -127,15 +146,25 @@ while [ "$i" -lt "$link_n" ]; do
     create_lock_file "$permit_dir/link-$i"
     i=$((i + 1))
 done
+i=0
+while [ "$i" -lt "$link_queue_n" ]; do
+    create_queue_file "$permit_dir/link-waiter-$i"
+    i=$((i + 1))
+done
 create_lock_file "$permit_dir/demand-local"
 create_lock_file "$permit_dir/demand-ci"
 # Every governed account appends to (and rotates) the log: world-writable.
 [ -f "$permit_dir/governor.log" ] || : > "$permit_dir/governor.log"
 chown root:wheel "$permit_dir/governor.log"
 chmod 0666 "$permit_dir/governor.log"
-echo "permit dir ready: $permit_dir (local=$local_n ci=$ci_n link=$link_n)"
+echo "permit dir ready: $permit_dir (local=$local_n ci=$ci_n link=$link_n queue=$link_queue_n)"
 
 # Binary last (see the ordering note up top).
+if pgrep -x rustc-governor >/dev/null 2>&1; then
+    echo "refusing to swap governor generations while rustc-governor processes are active" >&2
+    echo "wait for builds to drain (or use enabled=false to drain waiters), then re-run" >&2
+    exit 1
+fi
 install -m 0755 "$BIN_SRC" "$LIB_BIN_DIR/rustc-governor"
 echo "installed $LIB_BIN_DIR/rustc-governor"
 
@@ -165,8 +194,9 @@ Notes:
   (immediate, machine-wide); a disabled governor still execs the wrap_with
   chain, so caching survives the kill switch. Removing the rustc-wrapper=
   line fully unwires an account. `link_slots = 0` turns off only the
-  heavyweight-link gate.
+  heavyweight-link gate; `link_queue_slots = 0` keeps the gate but turns
+  off FIFO ordering.
 - Watch it: tail -f /usr/local/var/intendant-governor/governor.log
-  (kind=link lines carry link_wait_ms; kind=link-done carries runtime_ms —
-  the link-gate soak data.)
+  (kind=link lines carry link_wait_ms + queue; kind=link-done is actual
+  linker runtime — the link-gate soak data.)
 NEXT_EOF


### PR DESCRIPTION
## Summary

- move heavyweight bin/test serialization from the whole rustc invocation to a linker shim, while retaining the ordinary compile permit
- add a bounded crash-safe FIFO in front of machine-wide link slots, plus a one-shot wait diagnostic and phase-specific telemetry
- preserve sccache for cacheable library compiles; bypass it only for non-cacheable final artifacts so the linker handoff is invocation-local
- pre-create FIFO ticket assets and refuse mixed-generation binary swaps in the macOS installer
- replace whole-rustc gate assumptions with process-level phase, FIFO, crash, fail-open, and real-rustc acceptance coverage

## Validation

- `cargo test -p rustc-governor` (Linux fleet box: 47 unit, 34 acceptance, 2 sccache-chain tests)
- `cargo clippy -p rustc-governor --all-targets -- -D warnings` (Linux fleet box)
- `cargo test -p intendant --bins` (Linux fleet box: controller 4234 passed / 10 ignored, connect 147 passed, runtime 97 passed)
- `cargo test -p intendant-core -p intendant-display -p intendant-platform -p owner-plane-core -p owner-plane-reducer` (Linux fleet box)
- `cargo clippy --workspace -- -D warnings` (Linux fleet box)
- `bash -n scripts/ci/install-governor-macos.sh`
- GitHub Actions: check, artifact parity, and Linux/macOS/Windows test matrix green