### PR TITLE
skills: surface compatibility to the model; distribution:global installs builtins machine-wide

### DIFF
--- a/crates/intendant-core/src/skills.rs
+++ b/crates/intendant-core/src/skills.rs
@@ -34,6 +34,25 @@ pub struct SkillConfig {
     #[serde(default)]
     #[allow(dead_code)]
     pub sandbox: Option<bool>,
+    /// Free-text environment requirements (Agent Skills standard
+    /// `compatibility`). Surfaced verbatim in the injected catalog so the
+    /// model can pre-filter — deliberately ahead of other harnesses,
+    /// which drop the field before the model ever sees it (verified
+    /// 2026-07-19 on claude 2.1.215 / codex 0.144.6).
+    #[serde(default)]
+    pub compatibility: Option<String>,
+    /// Intendant extension: `distribution: global` marks a skill the
+    /// daemon installs machine-wide into `~/.agents/skills/` at startup.
+    /// Unknown values are kept verbatim and treated as not-global.
+    #[serde(default)]
+    pub distribution: Option<String>,
+}
+
+impl SkillConfig {
+    /// Whether the daemon should install this skill machine-wide.
+    pub fn is_global(&self) -> bool {
+        self.distribution.as_deref() == Some("global")
+    }
 }
 
 /// Where a skill was discovered.
@@ -70,7 +89,7 @@ pub struct Skill {
 ///
 /// The file must start with `---`, followed by YAML frontmatter, closed by
 /// another `---` line. Everything after is the body.
-fn parse_skill_md(content: &str, source_path: &Path) -> Result<(SkillConfig, String), String> {
+pub fn parse_skill_md(content: &str, source_path: &Path) -> Result<(SkillConfig, String), String> {
     let trimmed = content.trim_start();
     if !trimmed.starts_with("---") {
         return Err(format!(
@@ -114,6 +133,8 @@ fn parse_frontmatter(yaml: &str) -> Result<SkillConfig, String> {
     let mut autonomy: Option<String> = None;
     let mut disable_auto_invocation = false;
     let mut sandbox: Option<bool> = None;
+    let mut compatibility: Option<String> = None;
+    let mut distribution: Option<String> = None;
 
     let lines: Vec<&str> = yaml.lines().collect();
     let mut i = 0;
@@ -172,6 +193,8 @@ fn parse_frontmatter(yaml: &str) -> Result<SkillConfig, String> {
                 disable_auto_invocation = value == "true";
             }
             "sandbox" => sandbox = Some(value == "true"),
+            "compatibility" => compatibility = Some(value),
+            "distribution" => distribution = Some(value),
             _ => {} // Ignore unknown fields for forward compatibility
         }
     }
@@ -185,6 +208,8 @@ fn parse_frontmatter(yaml: &str) -> Result<SkillConfig, String> {
         autonomy,
         disable_auto_invocation,
         sandbox,
+        compatibility: compatibility.filter(|c| !c.is_empty()),
+        distribution: distribution.filter(|d| !d.is_empty()),
     })
 }
 
@@ -333,10 +358,7 @@ pub fn format_skill_catalog(skills: &[Skill]) -> String {
     if !auto_skills.is_empty() {
         out.push_str("**Auto-invocable** (use when the task matches):\n");
         for s in &auto_skills {
-            out.push_str(&format!(
-                "- **{}**: {}\n",
-                s.config.name, s.config.description
-            ));
+            push_catalog_line(&mut out, s);
         }
         out.push('\n');
     }
@@ -344,15 +366,26 @@ pub fn format_skill_catalog(skills: &[Skill]) -> String {
     if !manual_skills.is_empty() {
         out.push_str("**Manual only** (only invoke when explicitly requested):\n");
         for s in &manual_skills {
-            out.push_str(&format!(
-                "- **{}**: {}\n",
-                s.config.name, s.config.description
-            ));
+            push_catalog_line(&mut out, s);
         }
         out.push('\n');
     }
 
     out
+}
+
+/// One catalog entry. `compatibility` rides after the description so the
+/// model can rule a skill out before invoking it (the field's intent per
+/// the Agent Skills standard — description stays purpose-only).
+fn push_catalog_line(out: &mut String, s: &Skill) {
+    out.push_str(&format!(
+        "- **{}**: {}",
+        s.config.name, s.config.description
+    ));
+    if let Some(compat) = s.config.compatibility.as_deref() {
+        out.push_str(&format!(" (compatibility: {compat})"));
+    }
+    out.push('\n');
 }
 
 /// Load a skill body with `$ARGUMENTS` substitution.
@@ -457,6 +490,65 @@ Instructions here.
         assert!(config.description.contains("Deploy the current branch"));
         assert!(config.description.contains("integration test suite"));
         assert_eq!(config.autonomy, Some("low".to_string()));
+    }
+
+    #[test]
+    fn parse_compatibility_and_distribution() {
+        let content = "---\nname: caller\ndescription: Operate the daemon\ncompatibility: >\n  Requires a reachable Intendant daemon.\n  Supervised sessions have $INTENDANT injected.\ndistribution: global\n---\nbody\n";
+        let (config, _) = parse_skill_md(content, Path::new("test/SKILL.md")).unwrap();
+        assert_eq!(
+            config.compatibility.as_deref(),
+            Some("Requires a reachable Intendant daemon. Supervised sessions have $INTENDANT injected.")
+        );
+        assert!(config.is_global());
+
+        // Absent / empty fields normalize to None; unknown distribution
+        // values are kept but are not global.
+        let (config, _) = parse_skill_md(
+            "---\nname: a\ndescription: b\ncompatibility:\n---\nbody\n",
+            Path::new("test/SKILL.md"),
+        )
+        .unwrap();
+        assert_eq!(config.compatibility, None);
+        assert!(!config.is_global());
+        let (config, _) = parse_skill_md(
+            "---\nname: a\ndescription: b\ndistribution: project\n---\nbody\n",
+            Path::new("test/SKILL.md"),
+        )
+        .unwrap();
+        assert_eq!(config.distribution.as_deref(), Some("project"));
+        assert!(!config.is_global());
+    }
+
+    #[test]
+    fn catalog_surfaces_compatibility_after_description() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let dir = root.join("skills").join("gated");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("SKILL.md"),
+            "---\nname: gated\ndescription: Do the thing.\ncompatibility: macOS only.\n---\nbody\n",
+        )
+        .unwrap();
+        let plain = root.join("skills").join("plain");
+        std::fs::create_dir_all(&plain).unwrap();
+        std::fs::write(
+            plain.join("SKILL.md"),
+            "---\nname: plain\ndescription: No requirements.\n---\nbody\n",
+        )
+        .unwrap();
+
+        let skills = discover_skills_in(Some(root), None);
+        let catalog = format_skill_catalog(&skills);
+        assert!(
+            catalog.contains("- **gated**: Do the thing. (compatibility: macOS only.)"),
+            "{catalog}"
+        );
+        assert!(
+            catalog.contains("- **plain**: No requirements.\n"),
+            "{catalog}"
+        );
     }
 
     #[test]
@@ -627,6 +719,8 @@ Instructions here.
                     autonomy: None,
                     disable_auto_invocation: false,
                     sandbox: None,
+                    compatibility: None,
+                    distribution: None,
                 },
                 body: String::new(),
                 source_path: PathBuf::new(),
@@ -639,6 +733,8 @@ Instructions here.
                     autonomy: None,
                     disable_auto_invocation: true,
                     sandbox: None,
+                    compatibility: None,
+                    distribution: None,
                 },
                 body: String::new(),
                 source_path: PathBuf::new(),
@@ -662,6 +758,8 @@ Instructions here.
                 autonomy: None,
                 disable_auto_invocation: false,
                 sandbox: None,
+                compatibility: None,
+                distribution: None,
             },
             body: "Deploy $ARGUMENTS to staging.".to_string(),
             source_path: PathBuf::new(),
@@ -683,6 +781,8 @@ Instructions here.
                 autonomy: None,
                 disable_auto_invocation: false,
                 sandbox: None,
+                compatibility: None,
+                distribution: None,
             },
             body: "Just run clippy.".to_string(),
             source_path: PathBuf::new(),
@@ -701,6 +801,8 @@ Instructions here.
                 autonomy: None,
                 disable_auto_invocation: false,
                 sandbox: None,
+                compatibility: None,
+                distribution: None,
             },
             body: "Deploy $ARGUMENTS now.".to_string(),
             source_path: PathBuf::new(),
@@ -723,6 +825,8 @@ Instructions here.
                 autonomy: None,
                 disable_auto_invocation: false,
                 sandbox: None,
+                compatibility: None,
+                distribution: None,
             },
             body: String::new(),
             source_path: PathBuf::new(),

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -1189,10 +1189,30 @@ disable-auto-invocation: true
 Frontmatter fields: `name` (required), `description` (required), `autonomy`
 and `sandbox` (parsed, reserved — not yet enforced), `disable-auto-invocation`
 (only the user can trigger it; splits the injected catalog's auto vs manual
-sections). `disable-model-invocation`, `compatibility`, and `allowed-tools`
-are accepted in frontmatter for forward compatibility but are **not yet
-interpreted** by the parser. Project skills take precedence over personal
-skills of the same name.
+sections), `compatibility` (free-text environment requirements, surfaced
+verbatim in the injected catalog after the description so the model can rule
+a skill out *before* invoking it — descriptions stay purpose-only; other
+harnesses currently drop this field before the model sees it, so a one-line
+guard at the top of the body remains the late gate for them), and
+`distribution` (Intendant extension: `global` marks a skill the daemon
+installs machine-wide — see below). `disable-model-invocation` and
+`allowed-tools` are accepted for forward compatibility but are **not yet
+interpreted**. Project skills take precedence over personal skills of the
+same name.
+
+### Global distribution
+
+At startup (daemon, headless, and MCP modes), the daemon installs every
+builtin skill marked `distribution: global` into `~/.agents/skills/` — the
+Agent Skills standard personal path that Codex, Intendant itself, and (via
+the setup scripts' `~/.claude/skills` symlink) Claude Code all read, so the
+skills reach every agent on the machine, supervised or not. The skills are
+embedded in the binary (`builtin_skills.rs`, pinned to `skills/` by test),
+must be single-file, and follow the same ownership contract as project
+materialization: marker-owned copies, content-identical installs are no-ops,
+stale marked copies are swept on upgrade, and a user-authored directory with
+the same name always wins. `INTENDANT_SKIP_SKILL_PROVISION=1` disables this
+along with project materialization.
 
 ### Materialization for supervised external agents
 

--- a/docs/src/external-agent-orchestration.md
+++ b/docs/src/external-agent-orchestration.md
@@ -882,6 +882,13 @@ checkout's shared `.git/info/exclude` (one block covers all worktrees).
 Caps and the `INTENDANT_SKIP_SKILL_PROVISION` kill switch are documented
 in the configuration chapter's Skills section.
 
+Separately from per-project materialization, daemon startup installs the
+builtin `distribution: global` skills into `~/.agents/skills/` (same
+ownership contract), so they reach every agent on the machine — including
+unsupervised ones, whose actual authority over the daemon remains whatever
+IAM grants their principal. See "Global distribution" in the configuration
+chapter.
+
 ## Configuration
 
 External-agent settings live under `[agent]` in `intendant.toml`

--- a/scripts/setup-linux.sh
+++ b/scripts/setup-linux.sh
@@ -687,6 +687,21 @@ run_check() {
 
 # ── Install mode ──────────────────────────────────────────────────────────
 
+
+# Claude Code reads ~/.claude/skills; point it at the Agent Skills
+# standard dir (~/.agents/skills) so personal and daemon-installed
+# skills reach it too. Never replaces a real user directory.
+link_claude_skills() {
+    mkdir -p "$HOME/.agents/skills"
+    if [ -e "$HOME/.claude/skills" ] && [ ! -L "$HOME/.claude/skills" ]; then
+        warn "~/.claude/skills is a real directory — leaving it; merge it into ~/.agents/skills to unify"
+        return 0
+    fi
+    mkdir -p "$HOME/.claude"
+    ln -sfn "$HOME/.agents/skills" "$HOME/.claude/skills"
+    ok "~/.claude/skills -> ~/.agents/skills"
+}
+
 run_install() {
     echo ""
     echo "================================================================"
@@ -727,6 +742,9 @@ run_install() {
 
     # Phase 7: disable screen lock so the agent isn't interrupted
     disable_screen_lock
+
+    # Phase 7.5: unified skills dir for Claude Code
+    link_claude_skills
 
     # Phase 8: build
     if $SKIP_BUILD; then

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -474,6 +474,21 @@ run_check() {
     echo ""
 }
 
+
+# Claude Code reads ~/.claude/skills; point it at the Agent Skills
+# standard dir (~/.agents/skills) so personal and daemon-installed
+# skills reach it too. Never replaces a real user directory.
+link_claude_skills() {
+    mkdir -p "$HOME/.agents/skills"
+    if [ -e "$HOME/.claude/skills" ] && [ ! -L "$HOME/.claude/skills" ]; then
+        warn "~/.claude/skills is a real directory — leaving it; merge it into ~/.agents/skills to unify"
+        return 0
+    fi
+    mkdir -p "$HOME/.claude"
+    ln -sfn "$HOME/.agents/skills" "$HOME/.claude/skills"
+    ok "~/.claude/skills -> ~/.agents/skills"
+}
+
 run_install() {
     echo ""
     echo "════════════════════════════════════════════════════════"
@@ -510,6 +525,9 @@ run_install() {
 
     # Phase 6: Disable screensaver so the agent isn't interrupted
     disable_screen_lock
+
+    # Phase 6.5: unified skills dir for Claude Code
+    link_claude_skills
 
     # Phase 7: App bundle
     echo ""

--- a/scripts/setup-windows.ps1
+++ b/scripts/setup-windows.ps1
@@ -933,8 +933,26 @@ if (-not ([System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win3
     Die "this script is for Windows"
 }
 
+
+# Claude Code reads ~\.claude\skills; junction it to the Agent Skills
+# standard dir so personal and daemon-installed skills reach it too.
+function Link-ClaudeSkills {
+    $agents = Join-Path $env:USERPROFILE ".agents\skills"
+    $claude = Join-Path $env:USERPROFILE ".claude\skills"
+    New-Item -ItemType Directory -Force -Path $agents | Out-Null
+    if ((Test-Path $claude) -and -not ((Get-Item $claude -Force).LinkType)) {
+        Warn "~\.claude\skills is a real directory -- leaving it; merge it into ~\.agents\skills to unify"
+        return
+    }
+    New-Item -ItemType Directory -Force -Path (Split-Path $claude) | Out-Null
+    if (Test-Path $claude) { (Get-Item $claude -Force).Delete() }
+    New-Item -ItemType Junction -Path $claude -Target $agents | Out-Null
+    Ok "~\.claude\skills -> ~\.agents\skills"
+}
+
 if ($Check) {
     Run-Check
 } else {
     Run-Install
+    Link-ClaudeSkills
 }

--- a/skills/intendant-agenda/SKILL.md
+++ b/skills/intendant-agenda/SKILL.md
@@ -1,7 +1,11 @@
 ---
 name: intendant-agenda
 description: When you defer work, promise a follow-up ("I'll also…", "later we should…", "worth revisiting"), hit something out of scope, have a question only the owner can answer but don't need to block on it, or want the owner to see a note that must survive your context window — park it on the daemon's agenda instead of losing it. Also use at session start to check what's parked and whether earlier questions got answered.
+compatibility: Requires a reachable Intendant daemon (supervised sessions have $INTENDANT and INTENDANT_MCP_URL injected).
+distribution: global
 ---
+
+> If `$INTENDANT`/`INTENDANT_MCP_URL` is unset and no local Intendant daemon answers, this skill does not apply — say so and stop.
 
 # The Agenda: park intent that must outlive your context
 

--- a/skills/intendant-cli/SKILL.md
+++ b/skills/intendant-cli/SKILL.md
@@ -1,7 +1,11 @@
 ---
 name: intendant-cli
 description: Use to operate a running Intendant daemon from the CLI — sessions, approvals, displays and screenshots, computer-use input, browser workspaces, audio, and federated peers (message or delegate to another machine's agent, or drive its screen directly with --peer). Prefer `intendant ctl` over broad MCP tools to keep model context small.
+compatibility: Requires a reachable Intendant daemon (supervised sessions have $INTENDANT and INTENDANT_MCP_URL injected).
+distribution: global
 ---
+
+> If `$INTENDANT`/`INTENDANT_MCP_URL` is unset and no local Intendant daemon answers, this skill does not apply — say so and stop.
 
 # Intendant CLI
 

--- a/skills/intendant-memory/SKILL.md
+++ b/skills/intendant-memory/SKILL.md
@@ -1,7 +1,11 @@
 ---
 name: intendant-memory
 description: When you learn something durable about this machine, its owner, or its projects — a fact observed, a decision made, a procedure that works, a preference stated, an episode worth remembering — propose it as a claim on the daemon's Memory plane. Also use at task start when earlier sessions may have learned something relevant; search before re-deriving or assuming a machine-wide fact.
+compatibility: Requires a reachable Intendant daemon (supervised sessions have $INTENDANT and INTENDANT_MCP_URL injected).
+distribution: global
 ---
+
+> If `$INTENDANT`/`INTENDANT_MCP_URL` is unset and no local Intendant daemon answers, this skill does not apply — say so and stop.
 
 # Memory: the daemon's shared claim plane
 

--- a/skills/phone-call/SKILL.md
+++ b/skills/phone-call/SKILL.md
@@ -5,8 +5,11 @@ description: >
   using spawn_live_audio. The AI model talks through the Vortex Audio
   virtual device, which pjsua routes to the SIP call. Returns typed
   structured data from the conversation.
-compatibility: macOS only. Requires Vortex Audio HAL plugin, pjsua, and a GUI session with TCC mic permission.
+compatibility: Requires a reachable Intendant daemon. macOS only. Requires Vortex Audio HAL plugin, pjsua, and a GUI session with TCC mic permission.
+distribution: global
 ---
+
+> If `$INTENDANT`/`INTENDANT_MCP_URL` is unset and no local Intendant daemon answers, this skill does not apply — say so and stop.
 
 # Phone Call via SIP + Live Audio
 

--- a/skills/show-then-ask/SKILL.md
+++ b/skills/show-then-ask/SKILL.md
@@ -1,7 +1,11 @@
 ---
 name: show-then-ask
 description: Use when asking the user to choose between design or implementation variants, judge a before/after, or approve a visual change — show rendered previews on the dashboard question rail instead of describing them. Attach prototype HTML pages (interactive, sandboxed), images, or text snippets to a blocking `intendant ctl ask`; the user's choice or free-text reply returns as the command's stdout.
+compatibility: Requires a reachable Intendant daemon (supervised sessions have $INTENDANT and INTENDANT_MCP_URL injected).
+distribution: global
 ---
+
+> If `$INTENDANT`/`INTENDANT_MCP_URL` is unset and no local Intendant daemon answers, this skill does not apply — say so and stop.
 
 # Show, then ask
 

--- a/skills/visual-collaboration/SKILL.md
+++ b/skills/visual-collaboration/SKILL.md
@@ -1,7 +1,11 @@
 ---
 name: visual-collaboration
 description: "Use when the user should see an agent-owned display through Intendant's shared view: demoing a finished result, letting the user watch live GUI/browser work, focusing attention on a region, capturing a display frame, or asking the user to take input authority."
+compatibility: Requires a reachable Intendant daemon (supervised sessions have $INTENDANT and INTENDANT_MCP_URL injected).
+distribution: global
 ---
+
+> If `$INTENDANT`/`INTENDANT_MCP_URL` is unset and no local Intendant daemon answers, this skill does not apply — say so and stop.
 
 # Visual Collaboration
 

--- a/skills/voice-call-app/SKILL.md
+++ b/skills/voice-call-app/SKILL.md
@@ -4,8 +4,11 @@ description: >
   Make a voice call through any app (Element, FaceTime, WhatsApp, etc.)
   using computer use to navigate the UI and spawn_live_audio for the
   AI voice conversation. Returns typed structured data.
-compatibility: macOS or Linux with a display and supported virtual-audio bridge; macOS needs a GUI session with TCC mic permission.
+compatibility: Requires a reachable Intendant daemon. macOS or Linux with a display and supported virtual-audio bridge; macOS needs a GUI session with TCC mic permission.
+distribution: global
 ---
+
+> If `$INTENDANT`/`INTENDANT_MCP_URL` is unset and no local Intendant daemon answers, this skill does not apply — say so and stop.
 
 # Voice Call via App + Live Audio
 

--- a/src/bin/caller/builtin_skills.rs
+++ b/src/bin/caller/builtin_skills.rs
@@ -1,0 +1,108 @@
+//! The repository's own skills, embedded at compile time so the daemon
+//! can install `distribution: global` ones machine-wide (into
+//! `~/.agents/skills/`) without a checkout on disk — the packaged app
+//! ships them inside the binary exactly like the dashboard's static
+//! assets.
+//!
+//! The table is a manual mirror of `skills/*/SKILL.md`; the parity test
+//! below pins it to the filesystem so adding or renaming a skill without
+//! updating this list fails the suite instead of silently shipping a
+//! daemon that cannot distribute it. Global skills must be single-file
+//! (SKILL.md only): the installer writes exactly one file per skill, and
+//! the parity test enforces the constraint at the source.
+
+/// `(directory name, SKILL.md contents)` for every skill the repo ships.
+pub(crate) const BUILTIN_SKILLS: &[(&str, &str)] = &[
+    (
+        "intendant-agenda",
+        include_str!("../../../skills/intendant-agenda/SKILL.md"),
+    ),
+    (
+        "intendant-cli",
+        include_str!("../../../skills/intendant-cli/SKILL.md"),
+    ),
+    (
+        "intendant-log-search",
+        include_str!("../../../skills/intendant-log-search/SKILL.md"),
+    ),
+    (
+        "intendant-memory",
+        include_str!("../../../skills/intendant-memory/SKILL.md"),
+    ),
+    (
+        "phone-call",
+        include_str!("../../../skills/phone-call/SKILL.md"),
+    ),
+    (
+        "show-then-ask",
+        include_str!("../../../skills/show-then-ask/SKILL.md"),
+    ),
+    (
+        "station-e2e-qa",
+        include_str!("../../../skills/station-e2e-qa/SKILL.md"),
+    ),
+    (
+        "visual-collaboration",
+        include_str!("../../../skills/visual-collaboration/SKILL.md"),
+    ),
+    (
+        "voice-call-app",
+        include_str!("../../../skills/voice-call-app/SKILL.md"),
+    ),
+    (
+        "wayland-portal-e2e",
+        include_str!("../../../skills/wayland-portal-e2e/SKILL.md"),
+    ),
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    /// Pins the embedded table to `skills/` on disk: same directory set,
+    /// same bytes, and every `distribution: global` skill is single-file.
+    #[test]
+    fn builtin_table_matches_the_skills_directory() {
+        let skills_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("skills");
+        let mut on_disk: Vec<String> = std::fs::read_dir(&skills_root)
+            .expect("skills/ readable")
+            .flatten()
+            .filter(|e| e.path().join("SKILL.md").exists())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        on_disk.sort();
+        let mut embedded: Vec<String> = BUILTIN_SKILLS
+            .iter()
+            .map(|(name, _)| name.to_string())
+            .collect();
+        embedded.sort();
+        assert_eq!(
+            embedded, on_disk,
+            "builtin_skills.rs table drifted from skills/ — update the include list"
+        );
+
+        for (name, content) in BUILTIN_SKILLS {
+            let disk = std::fs::read_to_string(skills_root.join(name).join("SKILL.md"))
+                .unwrap_or_else(|e| panic!("read skills/{name}/SKILL.md: {e}"));
+            assert_eq!(&disk, content, "embedded bytes for {name} are stale");
+
+            let (config, _) = intendant_core::skills::parse_skill_md(content, Path::new(name))
+                .unwrap_or_else(|e| panic!("skills/{name}/SKILL.md does not parse: {e}"));
+            assert_eq!(&config.name, name, "frontmatter name must match the dir");
+            if config.is_global() {
+                let extra: Vec<String> = std::fs::read_dir(skills_root.join(name))
+                    .unwrap()
+                    .flatten()
+                    .map(|e| e.file_name().to_string_lossy().into_owned())
+                    .filter(|f| f != "SKILL.md")
+                    .collect();
+                assert!(
+                    extra.is_empty(),
+                    "global skill {name} must be single-file (installer writes SKILL.md \
+                     only); found support files: {extra:?}"
+                );
+            }
+        }
+    }
+}

--- a/src/bin/caller/external_agent/skills_sync.rs
+++ b/src/bin/caller/external_agent/skills_sync.rs
@@ -279,6 +279,115 @@ fn git_common_dir(project_root: &Path) -> Option<PathBuf> {
     })
 }
 
+/// Report from one global-install pass.
+#[derive(Debug, Default)]
+pub(crate) struct GlobalInstallReport {
+    pub(crate) installed: Vec<String>,
+    pub(crate) unchanged: usize,
+    pub(crate) skipped_user_owned: Vec<String>,
+    pub(crate) removed_stale: Vec<String>,
+}
+
+/// Install every `distribution: global` builtin skill into
+/// `~/.agents/skills/` — the Agent Skills standard personal path that
+/// Codex, Intendant itself, and (via the setup-script symlink) Claude
+/// Code all read. Same ownership contract as project materialization:
+/// marker-first writes, marked-only sweeps, user-authored directories
+/// always win. Content-identical installs are no-ops, so restarts and
+/// concurrent daemons do not churn the folder; sweeps remove only marked
+/// dirs, which are derived copies that regenerate from their sources.
+/// Honors [`SKIP_ENV`].
+pub(crate) fn install_global_skills() -> io::Result<GlobalInstallReport> {
+    if std::env::var_os(SKIP_ENV).is_some_and(|v| !v.is_empty()) {
+        return Ok(GlobalInstallReport::default());
+    }
+    let Some(home) = dirs::home_dir() else {
+        return Ok(GlobalInstallReport::default());
+    };
+    install_global_skills_in(&home)
+}
+
+/// Home-injectable core of [`install_global_skills`].
+fn install_global_skills_in(home: &Path) -> io::Result<GlobalInstallReport> {
+    let mut report = GlobalInstallReport::default();
+    let target_dir = home.join(".agents").join("skills");
+
+    let globals: Vec<(&str, &str)> = crate::builtin_skills::BUILTIN_SKILLS
+        .iter()
+        .filter(|(name, content)| {
+            intendant_core::skills::parse_skill_md(content, Path::new(name))
+                .map(|(config, _)| config.is_global())
+                .unwrap_or(false)
+        })
+        .copied()
+        .collect();
+
+    // Sweep marked dirs that are no longer (or never were) in the global
+    // set — renames and demotions clean up on the next daemon start.
+    if let Ok(entries) = std::fs::read_dir(&target_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() || !path.join(MATERIALIZED_MARKER).exists() {
+                continue;
+            }
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if !globals.iter().any(|(n, _)| *n == name) {
+                std::fs::remove_dir_all(&path)?;
+                report.removed_stale.push(name);
+            }
+        }
+    }
+
+    for (name, content) in globals {
+        let dest = target_dir.join(name);
+        let marker = dest.join(MATERIALIZED_MARKER);
+        let skill_md = dest.join("SKILL.md");
+        if dest.exists() && !marker.exists() {
+            // User-authored (possibly via a symlinked personal skills
+            // setup) — the user's copy always wins.
+            report.skipped_user_owned.push(name.to_string());
+            continue;
+        }
+        if marker.exists()
+            && std::fs::read_to_string(&skill_md).is_ok_and(|current| current == content)
+        {
+            report.unchanged += 1;
+            continue;
+        }
+        if dest.exists() {
+            std::fs::remove_dir_all(&dest)?;
+        }
+        std::fs::create_dir_all(&dest)?;
+        std::fs::write(&marker, "source: builtin (daemon-installed)\n")?;
+        std::fs::write(&skill_md, content)?;
+        report.installed.push(name.to_string());
+    }
+    Ok(report)
+}
+
+/// Startup wrapper for the session-serving modes: run the install and
+/// log one line when it changed anything.
+pub(crate) fn install_global_skills_at_startup() {
+    match install_global_skills() {
+        Ok(report) => {
+            if !report.installed.is_empty() || !report.removed_stale.is_empty() {
+                let kept = if report.skipped_user_owned.is_empty() {
+                    String::new()
+                } else {
+                    format!(", {} user-owned kept", report.skipped_user_owned.len())
+                };
+                eprintln!(
+                    "[skills] global install: {} installed, {} unchanged, {} stale removed{kept}",
+                    report.installed.len(),
+                    report.unchanged,
+                    report.removed_stale.len(),
+                );
+            }
+        }
+        Err(e) => eprintln!("[skills] global install failed: {e}"),
+    }
+}
+
 /// Log-friendly one-line summary used by the spawn sites.
 pub(crate) fn describe_report(report: &ProvisionReport) -> Option<String> {
     if report.materialized.is_empty()
@@ -446,6 +555,59 @@ mod tests {
             listing.contains(".claude/"),
             "user-owned dir vanished from git status: {listing}"
         );
+    }
+
+    #[test]
+    fn global_install_is_idempotent_and_ownership_safe() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let expected_globals: Vec<&str> = crate::builtin_skills::BUILTIN_SKILLS
+            .iter()
+            .filter(|(name, content)| {
+                intendant_core::skills::parse_skill_md(content, Path::new(name))
+                    .map(|(config, _)| config.is_global())
+                    .unwrap_or(false)
+            })
+            .map(|(name, _)| *name)
+            .collect();
+        assert!(
+            !expected_globals.is_empty(),
+            "at least one builtin skill must be distribution: global"
+        );
+
+        // A user-authored dir colliding with one global, and a stale
+        // marked leftover from an older daemon.
+        let target = home.join(".agents").join("skills");
+        let user_owned = target.join(expected_globals[0]);
+        std::fs::create_dir_all(&user_owned).unwrap();
+        std::fs::write(user_owned.join("SKILL.md"), "user copy").unwrap();
+        let stale = target.join("retired-builtin");
+        std::fs::create_dir_all(&stale).unwrap();
+        std::fs::write(stale.join(MATERIALIZED_MARKER), "old").unwrap();
+
+        let first = install_global_skills_in(home).unwrap();
+        assert_eq!(first.installed.len(), expected_globals.len() - 1);
+        assert_eq!(
+            first.skipped_user_owned,
+            vec![expected_globals[0].to_string()]
+        );
+        assert_eq!(first.removed_stale, vec!["retired-builtin".to_string()]);
+        assert!(!stale.exists());
+        assert_eq!(
+            std::fs::read_to_string(user_owned.join("SKILL.md")).unwrap(),
+            "user copy"
+        );
+        for name in expected_globals.iter().skip(1) {
+            let dest = target.join(name);
+            assert!(dest.join("SKILL.md").exists(), "{name} missing");
+            assert!(dest.join(MATERIALIZED_MARKER).exists(), "{name} unmarked");
+        }
+
+        // Second run: pure no-op.
+        let second = install_global_skills_in(home).unwrap();
+        assert!(second.installed.is_empty(), "{second:?}");
+        assert!(second.removed_stale.is_empty(), "{second:?}");
+        assert_eq!(second.unchanged, expected_globals.len() - 1);
     }
 
     #[test]

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -14,6 +14,7 @@ mod background_tasks;
 mod browser_workspace;
 #[path = "../../build_info.rs"]
 mod build_info;
+mod builtin_skills;
 mod claude_auth_ceremony;
 mod codex_auth_ceremony;
 mod computer_use;

--- a/src/bin/caller/startup/daemon.rs
+++ b/src/bin/caller/startup/daemon.rs
@@ -92,6 +92,11 @@ pub(crate) async fn run_daemon(
     daemon_startup_resume_dir: Option<PathBuf>,
     provider_identity: crate::usage_rail::ProviderIdentity,
 ) -> Result<(), CallerError> {
+    // Install `distribution: global` builtin skills into ~/.agents/skills
+    // (marker-owned, no-op when unchanged) so every agent on this machine
+    // — supervised or not — can discover them.
+    crate::external_agent::skills_sync::install_global_skills_at_startup();
+
     // Retention guard for the daemon-global fallback store (projectless
     // staged uploads / transfer jobs): prune entries idle past the
     // retention window so the store cannot grow unbounded across restarts.

--- a/src/bin/caller/startup/headless.rs
+++ b/src/bin/caller/startup/headless.rs
@@ -34,6 +34,9 @@ pub(crate) async fn run_headless_mode(
     recording_registry: Arc<tokio::sync::RwLock<recording::RecordingRegistry>>,
     startup_external_resume_session: Option<String>,
 ) -> Result<(), CallerError> {
+    // Install `distribution: global` builtin skills (see run_daemon).
+    crate::external_agent::skills_sync::install_global_skills_at_startup();
+
     // This mode always has a task (enforced by task resolution in main).
     let task = task.unwrap();
 

--- a/src/bin/caller/startup/mcp_mode.rs
+++ b/src/bin/caller/startup/mcp_mode.rs
@@ -30,6 +30,9 @@ pub(crate) async fn run_mcp_mode(
     session_registry: display::SharedSessionRegistry,
     recording_registry: Arc<tokio::sync::RwLock<recording::RecordingRegistry>>,
 ) -> Result<(), CallerError> {
+    // Install `distribution: global` builtin skills (see run_daemon).
+    crate::external_agent::skills_sync::install_global_skills_at_startup();
+
     // MCP mode — speaks Model Context Protocol on stdio.
     // Architecturally a frontend peer of the dashboard: same EventBus,
     // same ControlMsg vocabulary.


### PR DESCRIPTION
Second half of the teaching-via-skills program (ratified: standard dirs, spec-pure frontmatter, no description cramming):

- **`compatibility` reaches the model** in Intendant's injected catalog — rendered after the description so skills self-filter pre-invocation. Both external harnesses currently drop the field before the model sees it (probe-verified), so distributable skills also carry a one-line body guard as the late gate there.
- **`distribution: global`** (Intendant frontmatter extension): the daemon installs marked builtin skills into `~/.agents/skills/` at startup. Embedded in the binary (`builtin_skills.rs`, parity test pins the table to `skills/` byte-for-byte and enforces single-file for globals), marker-owned with the #509 contract (content-identical = no-op, stale marked swept, user-authored always wins), same kill switch.
- **Seven skills marked global**: intendant-cli, show-then-ask, intendant-agenda, intendant-memory, visual-collaboration, phone-call, voice-call-app — the call skills' `compatibility` declares their platform constraints instead of hiding them from other machines.
- **Setup scripts** create the `~/.claude/skills → ~/.agents/skills` symlink (Windows junction), never replacing a real user directory.
- Docs: configuration.md Skills section (field semantics + Global distribution), external-agent-orchestration.md note. Live-proven under a fake `$HOME`: startup printed `global install: 7 installed`, all marker-owned.