### PR TITLE
dashboard: preview-question UX — tuck-away, wide layout, focus mode, choose-on-card

### DIFF
--- a/static/app/12-styles-tasks-log.css
+++ b/static/app/12-styles-tasks-log.css
@@ -2864,7 +2864,7 @@ body.context-focus-active {
   margin-bottom: 8px;
 }
 .question-previews.multi {
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
 }
 .question-preview-card {
   margin: 0;
@@ -2885,27 +2885,79 @@ body.context-focus-active {
   color: var(--subtext0);
   border-bottom: 1px solid var(--surface1);
 }
-.question-preview-expand {
-  padding: 1px 8px;
+.question-preview-cap-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.question-preview-focus {
+  padding: 1px 7px;
+  border: 1px solid var(--surface1);
+  border-radius: 6px;
+  background: var(--surface0);
+  color: var(--subtext0);
+  font-family: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+.question-preview-focus:hover { background: var(--surface1); color: var(--text); }
+.question-preview-choose {
+  padding: 1px 10px;
+  border: 1px solid color-mix(in srgb, var(--green) 50%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--green) 14%, transparent);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 11px;
+  cursor: pointer;
+}
+.question-preview-choose:hover { background: color-mix(in srgb, var(--green) 22%, transparent); }
+.question-preview-choose.chosen {
+  border-color: var(--green);
+  background: color-mix(in srgb, var(--green) 30%, transparent);
+  font-weight: 600;
+}
+.question-preview-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 8px;
+  grid-column: 1 / -1;
+}
+/* The hidden attribute must beat the display:flex above. */
+.question-preview-tabs[hidden] { display: none; }
+.question-preview-tab {
+  padding: 3px 12px;
   border: 1px solid var(--surface1);
   border-radius: 999px;
   background: var(--surface0);
   color: var(--subtext0);
   font-family: inherit;
-  font-size: 10px;
+  font-size: 11px;
   cursor: pointer;
 }
-.question-preview-expand:hover { background: var(--surface1); color: var(--text); }
+.question-preview-tab:hover { background: var(--surface1); color: var(--text); }
+.question-preview-tab.active {
+  border-color: var(--blue);
+  color: var(--text);
+  background: color-mix(in srgb, var(--blue) 16%, transparent);
+}
 /* Sandboxed agent HTML; the white backdrop matches the light default
-   most prototype documents assume. */
+   most prototype documents assume. Grid frames scale with the viewport;
+   a focused card takes near-pane height. */
 .question-preview-frame {
   display: block;
   width: 100%;
-  height: 280px;
+  height: clamp(280px, 34vh, 520px);
   border: 0;
   background: #fff;
 }
-.question-preview-card.expanded .question-preview-frame { height: 560px; }
+.question-previews[data-mode='focus'] { grid-template-columns: 1fr; }
+.question-previews[data-mode='focus'] .question-preview-card:not(.focused) { display: none; }
+.question-previews[data-mode='focus'] .question-preview-frame { height: min(66vh, 980px); }
+.question-previews[data-mode='focus'] .question-preview-text {
+  max-height: min(66vh, 980px);
+}
 .question-preview-imagelink { display: block; }
 .question-preview-image { display: block; width: 100%; }
 .question-preview-text {
@@ -2927,6 +2979,42 @@ body.context-focus-active {
   color: var(--subtext0);
   font-size: 11px;
 }
+.question-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.question-tuck {
+  width: 22px;
+  height: 22px;
+  border: 1px solid var(--surface1);
+  border-radius: 6px;
+  background: var(--surface0);
+  color: var(--subtext0);
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+}
+.question-tuck:hover { background: var(--surface1); color: var(--text); }
+#question-panel.question-minimized { display: none; }
+#question-restore-chip {
+  position: fixed;
+  right: 20px;
+  bottom: 96px;
+  z-index: 80;
+  padding: 8px 14px;
+  border: 1px solid color-mix(in srgb, var(--blue) 45%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--blue) 16%, var(--mantle));
+  color: var(--text);
+  font-family: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.25);
+}
+#question-restore-chip:hover { filter: brightness(1.1); }
+#question-restore-chip[hidden] { display: none; }
 .question-options {
   display: flex;
   flex-direction: column;

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -3839,12 +3839,28 @@ function updateQuestionProgress() {
 // authentication is ambient (mTLS client cert → IAM principal), so agent
 // markup executing with dashboard-origin authority could drive the daemon
 // API as the operator. Pinned by question_preview_iframe_sandbox_is_pinned.
-function appendQuestionPreviews(block, q) {
+function appendQuestionPreviews(block, q, qIndex) {
   const previews = Array.isArray(q.previews) ? q.previews : [];
   if (!previews.length) return;
   const strip = document.createElement('div');
   strip.className = 'question-previews';
+  strip.dataset.mode = 'grid';
   if (previews.length > 1) strip.classList.add('multi');
+
+  // Focus mode chrome: tabs flip between candidates while one card owns
+  // the whole strip; Grid returns to side-by-side.
+  const tabs = document.createElement('div');
+  tabs.className = 'question-preview-tabs';
+  tabs.hidden = true;
+  strip.appendChild(tabs);
+  const gridBtn = document.createElement('button');
+  gridBtn.type = 'button';
+  gridBtn.className = 'question-preview-tab question-preview-tab-grid';
+  gridBtn.textContent = 'Grid';
+  gridBtn.title = 'Back to the side-by-side grid';
+  gridBtn.addEventListener('click', () => focusQuestionPreview(strip, null));
+  tabs.appendChild(gridBtn);
+
   const missingChip = (p, why) => {
     const chip = document.createElement('span');
     chip.className = 'question-preview-missing';
@@ -3852,34 +3868,67 @@ function appendQuestionPreviews(block, q) {
     chip.title = why || 'preview unavailable (blob deleted from the upload store)';
     return chip;
   };
-  previews.forEach((p) => {
+  previews.forEach((p, pIndex) => {
     const card = document.createElement('figure');
     card.className = 'question-preview-card';
+    card.dataset.p = String(pIndex);
+
+    const tab = document.createElement('button');
+    tab.type = 'button';
+    tab.className = 'question-preview-tab';
+    tab.dataset.p = String(pIndex);
+    tab.textContent = p.label || `#${pIndex + 1}`;
+    tab.addEventListener('click', () => focusQuestionPreview(strip, pIndex));
+    tabs.insertBefore(tab, gridBtn);
+
     const caption = document.createElement('figcaption');
     caption.className = 'question-preview-label';
     const captionText = document.createElement('span');
     captionText.textContent = p.label || '';
     caption.appendChild(captionText);
+    const capActions = document.createElement('span');
+    capActions.className = 'question-preview-cap-actions';
+    // When an option shares this card's label, offer the pick right where
+    // the user is looking (same selection path as the option buttons).
+    const optIndex = (q.options || []).findIndex((o) => o.label === p.label);
+    if (optIndex >= 0) {
+      const choose = document.createElement('button');
+      choose.type = 'button';
+      choose.className = 'question-preview-choose';
+      choose.textContent = `Choose ${p.label}`;
+      choose.addEventListener('click', () => {
+        questionOptionClicked(qIndex, optIndex);
+        const btns = document.querySelectorAll(
+          `#question-content .question-block[data-q="${qIndex}"] .question-option`
+        );
+        choose.classList.toggle('chosen', !!btns[optIndex]?.classList.contains('selected'));
+      });
+      capActions.appendChild(choose);
+    }
+    const focusBtn = document.createElement('button');
+    focusBtn.type = 'button';
+    focusBtn.className = 'question-preview-focus';
+    focusBtn.textContent = '⛶';
+    focusBtn.title = 'Focus this preview (tabs switch candidates)';
+    focusBtn.addEventListener('click', () => {
+      const focused = strip.dataset.mode === 'focus' && card.classList.contains('focused');
+      focusQuestionPreview(strip, focused ? null : pIndex);
+    });
+    capActions.appendChild(focusBtn);
+    caption.appendChild(capActions);
     card.appendChild(caption);
+
     if (p.kind === 'html' && p.url) {
       const frame = document.createElement('iframe');
       frame.className = 'question-preview-frame';
       frame.setAttribute('sandbox', 'allow-scripts');
       frame.setAttribute('referrerpolicy', 'no-referrer');
       frame.title = p.label || 'preview';
-      const grow = document.createElement('button');
-      grow.type = 'button';
-      grow.className = 'question-preview-expand';
-      grow.textContent = 'Expand';
-      grow.addEventListener('click', () => {
-        grow.textContent = card.classList.toggle('expanded') ? 'Collapse' : 'Expand';
-      });
-      caption.appendChild(grow);
       card.appendChild(frame);
       fetch(p.url)
         .then((r) => (r.ok ? r.text() : Promise.reject(new Error(`HTTP ${r.status}`))))
         .then((html) => { frame.srcdoc = html; })
-        .catch(() => { grow.remove(); frame.replaceWith(missingChip(p)); });
+        .catch(() => { frame.replaceWith(missingChip(p)); });
     } else if (p.kind === 'image' && p.url) {
       const img = document.createElement('img');
       img.className = 'question-preview-image';
@@ -3908,6 +3957,51 @@ function appendQuestionPreviews(block, q) {
   block.appendChild(strip);
 }
 
+// Focus one preview card (by index) or return to the grid (null). Focus
+// mode gives the card the whole strip at near-pane height; the tab row
+// flips between candidates without a round-trip through the grid.
+function focusQuestionPreview(strip, index) {
+  const focus = index !== null && index !== undefined;
+  strip.dataset.mode = focus ? 'focus' : 'grid';
+  const tabs = strip.querySelector('.question-preview-tabs');
+  if (tabs) tabs.hidden = !focus;
+  strip.querySelectorAll('.question-preview-tab').forEach((t) => {
+    t.classList.toggle('active', focus && t.dataset.p === String(index));
+  });
+  strip.querySelectorAll('.question-preview-card').forEach((c) => {
+    c.classList.toggle('focused', focus && c.dataset.p === String(index));
+  });
+}
+
+// Tuck the pending question away without answering: the panel hides, a
+// floating chip restores it, and the asking agent keeps blocking — the
+// question stays pending on the daemon either way.
+function setQuestionMinimized(min) {
+  const panel = document.getElementById('question-panel');
+  if (!panel) return;
+  panel.classList.toggle('question-minimized', min);
+  let chip = document.getElementById('question-restore-chip');
+  if (min) {
+    if (!chip) {
+      chip = document.createElement('button');
+      chip.id = 'question-restore-chip';
+      chip.type = 'button';
+      chip.title = 'Reopen the pending agent question';
+      chip.addEventListener('click', () => setQuestionMinimized(false));
+      document.body.appendChild(chip);
+    }
+    const first = pendingQuestion?.questions?.[0];
+    const extra =
+      (pendingQuestion?.questions?.length || 1) > 1
+        ? ` +${pendingQuestion.questions.length - 1}`
+        : '';
+    chip.textContent = `❓ ${first?.header || 'Agent question'}${extra} — pending`;
+    chip.hidden = false;
+  } else if (chip) {
+    chip.hidden = true;
+  }
+}
+
 function showUserQuestion(id, questions, sessionId) {
   if (processingLogReplay) return;
   const list = Array.isArray(questions) ? questions : [];
@@ -3931,10 +4025,19 @@ function showUserQuestion(id, questions, sessionId) {
   content.innerHTML = '';
   const multi = list.length > 1;
   const title = document.createElement('div');
-  title.className = 'approval-title';
-  title.textContent = multi
+  title.className = 'approval-title question-title-row';
+  const titleText = document.createElement('span');
+  titleText.textContent = multi
     ? `The agent has ${list.length} questions`
     : 'The agent has a question';
+  title.appendChild(titleText);
+  const tuck = document.createElement('button');
+  tuck.type = 'button';
+  tuck.className = 'question-tuck';
+  tuck.textContent = '–';
+  tuck.title = 'Tuck away — the question stays pending; a chip brings it back';
+  tuck.addEventListener('click', () => setQuestionMinimized(true));
+  title.appendChild(tuck);
   content.appendChild(title);
 
   // Pinned index (2+ questions): one chip per header, kept above the
@@ -3978,7 +4081,7 @@ function showUserQuestion(id, questions, sessionId) {
     text.textContent = q.question;
     block.appendChild(text);
 
-    appendQuestionPreviews(block, q);
+    appendQuestionPreviews(block, q, qIndex);
 
     const options = document.createElement('div');
     options.className = 'question-options';
@@ -4043,7 +4146,17 @@ function showUserQuestion(id, questions, sessionId) {
   stationCurrentHumanQuestion = `${list[0].question}${extra}`;
   stationScheduleUpdate();
   revealActivityLogPanel();
-  document.getElementById('question-panel').classList.add('visible');
+  const panel = document.getElementById('question-panel');
+  // Preview-bearing questions escape the reading-column measure — the
+  // comparison is the content, so the card owns the pane width.
+  panel.classList.toggle(
+    'has-previews',
+    list.some((entry) => Array.isArray(entry.previews) && entry.previews.length)
+  );
+  // A new (or re-shown) question always surfaces, even if an earlier one
+  // was tucked away.
+  setQuestionMinimized(false);
+  panel.classList.add('visible');
   setApprovalIndicator(true);
 }
 
@@ -4052,6 +4165,9 @@ function clearPendingQuestion() {
   stationCurrentHumanQuestion = '';
   stationScheduleUpdate();
   setApprovalIndicator(false);
+  // Resolved: drop the tucked-away chip and the wide-panel state.
+  setQuestionMinimized(false);
+  document.getElementById('question-panel')?.classList.remove('has-previews');
 }
 
 function showPanel(id) { hideAllPanels(); document.getElementById(id).classList.add('visible'); }

--- a/static/app/ui2-activity.css
+++ b/static/app/ui2-activity.css
@@ -1581,6 +1581,16 @@ html.ui-v2 #question-panel .approval-card {
   padding: 14px 16px;
 }
 html.ui-v2 #question-panel .approval-icon { display: none; }
+/* Preview-bearing questions escape the reading-column measure: the
+   side-by-side comparison IS the content, so the card owns the pane.
+   Explicit width, not just max-width — the dock is a flex column whose
+   auto inline margins make the body fit-content, and a fit-content
+   container lets the preview grid collapse to one column. */
+html.ui-v2 #activity-log-pane #question-panel.has-previews .panel-body,
+html.ui-v2 #activity-log-pane #question-panel.has-previews .panel-header {
+  width: min(1560px, 96%);
+  max-width: none;
+}
 html.ui-v2 #question-panel .question-text { color: var(--text); font-size: 13px; }
 html.ui-v2 #question-panel .question-header-chip {
   font-family: var(--mono);


### PR DESCRIPTION
Follow-up to #497 from first real-world use: the preview panel was too small, blocked the dashboard, and had no way to examine one candidate properly.

- **Tuck away**: minimize control hides the panel behind a floating "pending" chip (restore on click). The agent-side ask keeps blocking either way; new/replayed questions always resurface.
- **Wide layout**: `has-previews` questions take the pane (`width`, not `max-width` — the dock's `margin-inline: auto` flex body was fit-content, which collapsed the grid to one column at 378px). Grid: 3-up at 320px+ columns, frames `clamp(280px, 34vh, 520px)`.
- **Focus mode**: ⛶ on each card focuses it at `min(66vh, 980px)` with A/B/C/Grid tabs; `[hidden]` now beats the tab row's `display:flex`.
- **Choose-on-card**: matching option labels get a Choose button in the card caption, wired through the existing selection path (multi-select semantics included).

QA (live rig, probes + screenshots): wide grid 3-up at 1117px body; focus 1057×566 frame; tab-switch, choose→selected, minimize→chip→restore all verified; sandbox pin test green; full battery green. The transient "ghosting" seen in one capture was an inspector fade mid-animation, not stacking — element-at-point probes confirm the panel owns its pixels.