### PR TITLE
steers: reconcile fallback acks across id aliases; re-enable CC mid-turn injection

### DIFF
--- a/docs/src/external-agent-orchestration.md
+++ b/docs/src/external-agent-orchestration.md
@@ -110,7 +110,7 @@ adapter from `[agent.<backend>]` config, then `run_external_agent_mode()`
 | MCP injection | Per-process `-c mcp_servers.intendant.{type,url,bearer_token_env_var}` overrides plus scoped env; no workspace config file | Inline `--mcp-config '{…}'` JSON with an environment-expanded Authorization header |
 | Multi-thread | Yes — many threads per process | No |
 | Native thread id | Yes | Yes — announced via `AgentEvent::NativeSessionId` on the first turn (placeholder `claude-code-session` until then; `--resume` keeps the id stable so resumed threads are canonical immediately) |
-| Mid-turn steer | Yes (`turn/steer`) | No — 2.1.2xx discards stdin user messages mid-turn (2.1.200's absorb was a CLI bug, since removed); `steer_turn` reports queue semantics and the steer delivers at the turn boundary (or immediately as its own turn when idle) |
+| Mid-turn steer | Yes (`turn/steer`) | Yes — a stdin user message is absorbed into the running turn at the CLI's next checkpoint (verified on 2.1.215; 2.1.207 discarded such lines). No stdout echo, so delivery is inferred at the next model checkpoint; an idle session delivers the steer immediately as its own turn |
 | Mid-turn interrupt | Yes (`turn/interrupt`) | Yes (`control_request` `interrupt`; the process survives for follow-up turns) |
 | Token usage / context meter | Yes | Yes (`message_delta` + `result` usage; context window from `modelUsage`) |
 | Reasoning trace | Yes | Yes (`thinking` blocks) |
@@ -603,15 +603,17 @@ through Claude Code 2.1.210):
   `error_during_execution`, mapped to a completed turn rather than a
   backend error when Intendant requested the interrupt); the process stays
   usable for follow-up turns.
-- **Steer**: the CLI **discards** a user message written while a turn runs
-  (probed on 2.1.207; the 2.1.200-era absorb was a CLI bug, since removed,
-  and `system/init.capabilities` advertises no replacement protocol yet).
-  `steer_turn` therefore returns the load-bearing "mid-turn steering not
-  supported" / "no active turn" markers and the drain queues the text onto
-  `context_injection`: it delivers as a `[User]` line when the next turn's
-  message is sent, and an idle session flushes the queue immediately as
-  its own turn. Goal notices queue as next-prompt preludes for the same
-  reason (a mid-turn write would vanish).
+- **Steer**: a user message written while a turn runs is **absorbed into
+  the running turn** at the CLI's next checkpoint (verified live on
+  2.1.215; 2.1.207 was observed discarding such lines, 2.1.200 absorbed
+  them). `steer_turn` writes the stream-json user message and the drain
+  tracks it as a pending runtime steer — the CLI never echoes the injected
+  message on stdout, so delivery is inferred at the next model checkpoint
+  (turn completion at the latest). An idle session keeps the "no active
+  turn" marker and delivers the steer immediately as its own turn. Goal
+  notices still queue as next-prompt preludes: unlike a steer's
+  best-effort injection, a notice must never silently vanish on a
+  discard-era CLI.
 - **Usage**: per-API-call usage from `message_delta` stream events plus the
   turn `result` feed `AgentEvent::Usage`; the context window comes from the
   result's `modelUsage` map (200k default until the first result).
@@ -745,7 +747,7 @@ capability-gated affordances in `app.html`, and `external_wrapper_index`.
 |---|---|---|---|
 | Steer / interrupt / stop affordances | `SessionCapabilities.{follow_up,steer,interrupt}`; the UI gates on capabilities, not backend type | emits all three | **Parity** (emits all three) |
 | Usage / context meter | `AgentEvent::Usage` → `UsageSnapshot` / `ContextSnapshot` | `token_count` notifications | **Parity** (`message_delta` + `result` usage) |
-| Goal chip in the agent-window header (`/goal`) | `SessionGoal` type; `AgentEvent::GoalUpdated/GoalCleared`; `session_goal` outbound + log replay; the window chip renderer is backend-neutral; op semantics + wire conventions (statuses, budget shape, objective limit, notice texts) live in the shared `external_agent::GoalEngine`, which the Claude Code adapter and the native presence loop both run | native `thread/goal/*` RPCs | **Live — wrapper goal engine in the adapter.** The full `goal*` op family is advertised and dispatched; goal state lives in `CcShared`, notices always queue as a prelude on the next prompt (2.1.2xx discards mid-turn stdin writes; consecutive notices coalesce in order, and updates never buy a turn), and budget spend is measured in FRESH tokens (uncached input + cache creation + output — cache reads excluded), flipping `active` → `budgetLimited` at exhaustion. Engine state is per-process: after a resume the chip rehydrates from the log but the engine starts empty (re-set the goal) |
+| Goal chip in the agent-window header (`/goal`) | `SessionGoal` type; `AgentEvent::GoalUpdated/GoalCleared`; `session_goal` outbound + log replay; the window chip renderer is backend-neutral; op semantics + wire conventions (statuses, budget shape, objective limit, notice texts) live in the shared `external_agent::GoalEngine`, which the Claude Code adapter and the native presence loop both run | native `thread/goal/*` RPCs | **Live — wrapper goal engine in the adapter.** The full `goal*` op family is advertised and dispatched; goal state lives in `CcShared`, notices always queue as a prelude on the next prompt (mid-turn stdin delivery is unconfirmable and one CLI era discarded it; consecutive notices coalesce in order, and updates never buy a turn), and budget spend is measured in FRESH tokens (uncached input + cache creation + output — cache reads excluded), flipping `active` → `budgetLimited` at exhaustion. Engine state is per-process: after a resume the chip rehydrates from the log but the engine starts empty (re-set the goal) |
 | Per-window action menu (fork / compact / goals / …) | **Universal (landed):** `SessionCapabilities.thread_actions` op vocabulary + the `thread_action` control message (`codex_thread_action` stays a wire alias); the kebab and Station session actions render from the advertised op list, with the codex heuristic as legacy-replay fallback | full op set | **`compact` + `fork` + `side` live.** `compact` sends the native `/compact` user message (status → `compact_boundary` → free result); `fork` respawns via `ForkHandling::RespawnResume` → `ResumeSession { fork: true }` → `--resume <parent> --fork-session` (the child binds its own native id + the `fork` relationship on its first prompt); `side` (`/btw`) is the same respawn with `relationship_kind: "side"` and the boundary + question as the child's first prompt. No Claude analog planned: fast / review / memory-reset |
 | Relationship wiring (parent/sub/fork header chips + SVG wires; Station edges) | `session_relationship` event + lineage ledger + `/api` serving + both renderers — all backend-neutral | side / subagent / fork / fission / rewind emitters | **`fork` + `side` + `subagent` emitted.** Fork/side on the forked child's first identity announcement (persisted `forked_from` + `fork_relationship` lineage); in-band Task sub-agents ride `SubAgentToolCall` → ephemeral `task-*` child sessions with `subagent` relationships (fission observations stay Codex-only by design) |
 | Per-session persisted launch overlay | `SessionAgentConfig` + `ConfigureSessionAgent` / `Restart` (universal `agent_command` + backend fields, bundled as `LaunchOverrides`). The daemon owns this overlay: implicit resumes (`ResumeSession` from auto-attach or a Resume button) carry NO launch overrides — only the explicit configure/restart flows do — and every config funnel drops (or, for the explicit flows, rejects with an error) an `agent_command` whose executable is a *different* backend's CLI than the session's source, so cross-agent contamination can neither launch nor persist | all `codex_*` fields | **Live.** `claude_model` / `claude_permission_mode` / `claude_allowed_tools` / `claude_effort` pins with inherit-vs-pin sentinels ("default" stays a pinnable permission mode; `all` pins explicitly-unrestricted tools), Launch-config modal rows, and LIVE apply of model + permission on save via the `model` / `permission-mode` thread actions (`set_model` / `set_permission_mode` control requests, verified on 2.1.201) |

--- a/src/bin/caller/external_agent/claude_code.rs
+++ b/src/bin/caller/external_agent/claude_code.rs
@@ -3356,12 +3356,13 @@ impl ClaudeCodeAgent {
     }
 
     /// Deliver an operator-goal notice to the model: queued as a prelude on
-    /// the next user message, always. Mid-turn stdin writes were the old
-    /// delivery for running turns, but 2.1.2xx discards user lines while a
-    /// turn runs (see `steer_turn`) — the notice would silently vanish. A
-    /// standalone user message is no better: it would start — and pay for —
-    /// a whole turn. The prelude path costs nothing and cannot be dropped;
-    /// a notice raced by an in-flight turn reaches the model one turn later.
+    /// the next user message, always. Mid-turn stdin absorption exists again
+    /// on current CLIs (see `steer_turn`), but its delivery is unconfirmable
+    /// (no stdout echo) and one CLI era (2.1.207) was observed discarding
+    /// such lines — a goal notice must never silently vanish, and a
+    /// standalone user message would start (and pay for) a whole turn. The
+    /// prelude path costs nothing and cannot be dropped; a notice raced by
+    /// an in-flight turn reaches the model one turn later.
     async fn deliver_goal_notice(&mut self, notice: String) -> Result<(), CallerError> {
         self.pending_goal_notice = match self.pending_goal_notice.take() {
             // Coalesce an undelivered notice instead of overwriting it —
@@ -3878,26 +3879,26 @@ impl ExternalAgent for ClaudeCodeAgent {
     }
 
     async fn steer_turn(&mut self, text: &str) -> Result<(), CallerError> {
-        // 2.1.200 absorbed a user message written mid-turn into the running
-        // turn; that was a bug, and 2.1.2xx removed it — the CLI silently
-        // DISCARDS stdin user lines while a turn is running (probed live on
-        // 2.1.207: the text never enters the conversation, no ack, no next
-        // turn; init capabilities advertise no replacement protocol yet).
-        // Writing the bytes anyway produced phantom "delivered" steers. So:
-        // report the truth and let the drain queue the steer for the turn
-        // boundary (the load-bearing "mid-turn steering not supported"
-        // wording — see external_steer_queue_reason), or, when no turn is
-        // running, hand it back as an immediate follow-up ("no active
-        // turn" marker).
-        let _ = text;
+        // A stdin user message written mid-turn is absorbed into the RUNNING
+        // turn at the CLI's next checkpoint (probed live on 2.1.215: a
+        // message injected during a tool call shaped that same turn's final
+        // reply; 2.1.207 was observed discarding such lines, 2.1.200
+        // absorbed them). The CLI never echoes the injected message on
+        // stream-json stdout, so delivery is inferred at the next model
+        // checkpoint via the drain's pending-runtime-steer tracking, and a
+        // line a discarding CLI eats would still be marked delivered at turn
+        // completion — accepted imprecision; the alternative is refusing
+        // native steering entirely and parking every steer until turn end.
         if !self.shared.turn_active.load(Ordering::SeqCst) {
             return Err(CallerError::ExternalAgent(
                 "claude-code has no active turn to steer".into(),
             ));
         }
-        Err(CallerError::ExternalAgent(
-            "mid-turn steering not supported by Claude Code 2.1.x — stream-json input applies user messages only at turn boundaries".into(),
-        ))
+        // Benign race: if the turn ends between the check above and this
+        // write, the CLI treats the line as the next turn's prompt — a
+        // spontaneous round the drain already supervises (same shape as a
+        // task-notification turn).
+        self.write_user_message(text).await
     }
 
     async fn interrupt_turn(&mut self) -> Result<(), CallerError> {
@@ -4877,12 +4878,13 @@ mod tests {
     }
 
     /// The steer contract the drain keys on: idle → "no active turn"
-    /// (immediate follow-up path); running → "mid-turn steering not
-    /// supported" (queue-for-turn-boundary path). CC 2.1.2xx discards
-    /// stdin user lines mid-turn, so steer_turn never writes — writing
-    /// produced phantom "delivered" steers the model never saw.
+    /// (immediate follow-up path); running → write the user message onto
+    /// stdin (the CLI absorbs it into the running turn at its next
+    /// checkpoint — verified live on 2.1.215). Uninitialized here, so the
+    /// running case must fail on the WRITE (no writer yet), never with the
+    /// old "steering not supported" refusal.
     #[tokio::test]
-    async fn steer_reports_queue_semantics_instead_of_writing() {
+    async fn steer_writes_mid_turn_and_requires_active_turn() {
         let mut agent =
             ClaudeCodeAgent::new("claude".into(), None, "default".into(), None, vec![], None);
         let idle_err = agent.steer_turn("more context").await.unwrap_err();
@@ -4893,16 +4895,19 @@ mod tests {
         agent.shared.turn_active.store(true, Ordering::SeqCst);
         let running_err = agent.steer_turn("more context").await.unwrap_err();
         assert!(
-            running_err
-                .to_string()
-                .contains("mid-turn steering not supported"),
-            "got: {running_err}"
+            running_err.to_string().contains("Not initialized"),
+            "running steer should reach the stdin write path, got: {running_err}"
+        );
+        assert!(
+            !running_err.to_string().contains("not supported"),
+            "steering must no longer be refused as unsupported: {running_err}"
         );
     }
 
     /// Goal notices always queue as the next prompt's prelude — a mid-turn
-    /// stdin write would be discarded by the CLI, and consecutive notices
-    /// coalesce in order instead of overwriting each other.
+    /// stdin write is unconfirmable (and one CLI era discarded them), and
+    /// consecutive notices coalesce in order instead of overwriting each
+    /// other.
     #[tokio::test]
     async fn goal_notices_queue_and_coalesce() {
         let mut agent =

--- a/src/bin/caller/session_supervisor/routing.rs
+++ b/src/bin/caller/session_supervisor/routing.rs
@@ -1091,6 +1091,7 @@ impl SessionSupervisor {
                     text,
                     steer_id,
                     event_session_id,
+                    Some(managed_id.clone()),
                 );
             }
             return;
@@ -1514,6 +1515,7 @@ pub(crate) fn spawn_text_steer_fallback(
     text: String,
     steer_id: String,
     target_session_id: Option<String>,
+    resolved_session_id: Option<String>,
 ) {
     tokio::spawn(async move {
         let timeout = tokio::time::sleep(TEXT_STEER_FALLBACK_TIMEOUT);
@@ -1528,9 +1530,10 @@ pub(crate) fn spawn_text_steer_fallback(
                         | Ok(AppEvent::SteerDelivered { session_id, id, .. })
                         | Ok(AppEvent::SteerCancelled { session_id, id, .. })
                             if id == steer_id
-                                && steer_ack_targets_session(
+                                && steer_ack_targets_session_or_resolved(
                                     &session_id,
                                     &target_session_id,
+                                    &resolved_session_id,
                                 ) =>
                         {
                             return;
@@ -1540,9 +1543,10 @@ pub(crate) fn spawn_text_steer_fallback(
                                 .as_deref()
                                 .map(|id| id == steer_id.as_str())
                                 .unwrap_or(true)
-                                && steer_ack_targets_session(
+                                && steer_ack_targets_session_or_resolved(
                                     &session_id,
                                     &target_session_id,
+                                    &resolved_session_id,
                                 ) =>
                         {
                             return;
@@ -1585,6 +1589,25 @@ pub(crate) fn steer_ack_targets_session(
         (Some(actual), Some(expected)) => actual == expected,
         (None, _) | (_, None) => true,
     }
+}
+
+/// Ack matcher for the text-steer fallback. A steer can be requested under a
+/// session's backend-native alias, but the loop that takes it acks under its
+/// primary id (drains normalize alias targets before matching, and the
+/// resolver returns the primary — see `normalize_native_session_target` and
+/// `resolve_external_steer_target_session`). The fallback must therefore
+/// accept an ack under either name; matching only the requested form parked a
+/// duplicate follow-up for every alias-addressed steer and overwrote the
+/// honest queue status with "not acknowledged".
+pub(crate) fn steer_ack_targets_session_or_resolved(
+    actual: &Option<String>,
+    requested: &Option<String>,
+    resolved: &Option<String>,
+) -> bool {
+    steer_ack_targets_session(actual, requested)
+        || resolved
+            .as_deref()
+            .is_some_and(|resolved| actual.as_deref() == Some(resolved))
 }
 
 #[cfg(test)]
@@ -2335,6 +2358,48 @@ mod tests {
         while let Ok(event) = bus_rx.try_recv() {
             if let AppEvent::SteerQueued { id, .. } = event {
                 assert_ne!(id, "steer-2", "acknowledged steer should not queue");
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn text_steer_ack_under_resolved_primary_id_prevents_fallback() {
+        // A steer addressed by a backend-native alias is acked by the owning
+        // loop under its primary id (drains normalize alias targets before
+        // matching). The fallback must treat that ack as this steer's — the
+        // regression was a parked duplicate plus a false "not acknowledged"
+        // status for every alias-addressed steer.
+        let bus = EventBus::new();
+        let mut bus_rx = bus.subscribe();
+        let (tx, mut rx) = mpsc::channel(1);
+
+        spawn_text_steer_fallback(
+            bus.clone(),
+            bus.subscribe(),
+            tx,
+            "check the usage chips".to_string(),
+            "steer-alias-1".to_string(),
+            Some("backend-native-id".to_string()),
+            Some("wrapper-id".to_string()),
+        );
+
+        bus.send(AppEvent::SteerQueued {
+            session_id: Some("wrapper-id".to_string()),
+            id: "steer-alias-1".to_string(),
+            reason: "claude-code accepted the steer".to_string(),
+        });
+
+        tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+        assert!(
+            rx.try_recv().is_err(),
+            "primary-id ack should satisfy an alias-addressed steer's fallback"
+        );
+        while let Ok(event) = bus_rx.try_recv() {
+            if let AppEvent::SteerQueued { id, reason, .. } = event {
+                assert!(
+                    !(id == "steer-alias-1" && reason.contains("not acknowledged")),
+                    "fallback parked despite a primary-id ack: {reason}"
+                );
             }
         }
     }

--- a/tests/skills/claude-code-e2e/SKILL.md
+++ b/tests/skills/claude-code-e2e/SKILL.md
@@ -117,9 +117,10 @@ table and exits non-zero on any failure; the full event log lands in
 - `native-session-id` timeout → the reader stopped capturing `session_id`
   from stdout messages, or `AgentEvent::NativeSessionId` lost its drain arm
   in `main.rs`.
-- `steer-absorbed-in-turn` failing → steering fell back to the queue path
-  (check `steer_turn` and the load-bearing "not supported" error strings) or
-  the CLI stopped absorbing queued user messages mid-turn.
+- `steer-absorbed-in-turn` failing → `steer_turn`'s stdin write regressed
+  (it must write the stream-json user message while `turn_active`), or the
+  installed CLI is from a discard era (2.1.207 was observed dropping
+  mid-turn stdin lines; 2.1.215 absorbs them at the next checkpoint).
 - `interrupt-aborts-turn` failing → the `control_request`/`interrupt`
   round-trip broke; `process-survives-interrupt` failing → the abort is
   killing the whole CLI process rather than the turn.


### PR DESCRIPTION
## What

Two fixes from the live e2e report "native steer was not acknowledged; queued as follow-up" (steer to a Claude Code session addressed by its backend id):

1. **Fallback ack reconciliation** (`session_supervisor/routing.rs`): drains normalize backend-native steer targets and ack under their primary wrapper id (`normalize_native_session_target` → `resolve_external_steer_target_session`), but the 2s text-steer fallback only matched acks against the requested id form. Every alias-addressed steer was therefore parked as a duplicate follow-up and its honest queue status overwritten by a false "not acknowledged". The fallback now accepts an ack under either the requested alias or the resolved managed id (new `steer_ack_targets_session_or_resolved`), with a regression test.

2. **Claude Code mid-turn injection re-enabled** (`external_agent/claude_code.rs`): `steer_turn` writes the stream-json user message onto stdin instead of refusing with "mid-turn steering not supported". Verified live on CC 2.1.215 (twice, haiku): a message written during a running turn is absorbed into that same turn at the CLI's next checkpoint; the CLI never echoes it on stdout, so delivery is inferred via the existing pending-runtime-steer checkpoint tracking (turn completion at the latest). The 2.1.207-era discard behavior is documented as history; the idle path ("no active turn" → immediate follow-up) is unchanged.

Docs/comments refreshed to the verified behavior: capability table + steer section in `docs/src/external-agent-orchestration.md`, goal-notice rationale (prelude path deliberately kept — notices must never vanish on a discard-era CLI), and the live-e2e SKILL troubleshooting notes.

## Verification

- `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`
- `cargo nextest run -p intendant --bins` (4503 passed)
- lib crates + `cargo test -p intendant --test e2e` (24 passed)
- Live raw-CLI probes on 2.1.215 (haiku): mid-turn stdin message absorbed into the running turn's final reply; no stdout echo of the injected message
- Live `tests/skills/claude-code-e2e` driver run: see PR comment