### PR TITLE
skills: keep global catalogs independent

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -1198,25 +1198,27 @@ over personal skills of the same name.
 ### Global distribution
 
 At startup (daemon, headless, and MCP modes), the daemon installs every skill
-shipped inside the Intendant binary into `~/.agents/skills/` — the Agent
-Skills standard personal path that Codex and Intendant read. The setup
-scripts make `~/.claude/skills` an alias of that same directory on macOS,
-Linux, and Windows, so Claude Code sees the identical catalog. Installation
-is machine-scoped and idempotent: content-identical installs are no-ops,
-stale marked copies are swept on upgrade, and an unmarked user-authored
-directory with the same name always wins.
+shipped inside the Intendant binary independently into `~/.agents/skills/`
+for Codex and Intendant and `~/.claude/skills/` for Claude Code. Intendant
+never aliases, replaces, or otherwise takes ownership of either global root.
+If a root is a symlink, junction, file, or other non-directory object, it is
+left untouched and reported. Inside a normal directory, only per-skill
+directories carrying `.intendant-installed` are refreshed or removed;
+content-identical installs are no-ops, stale marked copies are swept on
+upgrade, and an unmarked user-authored directory with the same name always
+wins.
 
 The shipped sources remain tracked under this repository's `skills/` and are
 embedded in the binary (`builtin_skills.rs`, pinned to that directory by
 test). Starting a supervised Claude Code or Codex session performs no skill
 copying and writes nothing into the project.
 
-Personal global skills are installed manually under `~/.agents/skills/`.
-Personal project-scoped skills are installed manually in the backend's project
-path (`<project>/.agents/skills/` for Codex and Intendant, or
-`<project>/.claude/skills/` for Claude Code) and must be covered by that
-project's ignore rules; this repository ignores both. Intendant does not
-mirror private project skills between backend-specific paths.
+Personal global skills are installed manually in the backend's own path
+(`~/.agents/skills/` for Codex and Intendant or `~/.claude/skills/` for
+Claude Code). Personal project-scoped skills likewise stay in the backend's
+project path (`<project>/.agents/skills/` or `<project>/.claude/skills/`) and
+must be covered by that project's ignore rules; this repository ignores both.
+Intendant does not mirror personal skills between backend-specific paths.
 
 ## INTENDANT.md project instructions
 

--- a/docs/src/external-agent-orchestration.md
+++ b/docs/src/external-agent-orchestration.md
@@ -860,20 +860,20 @@ external CLI's own away-from-keyboard fallback.
 
 ## Skills
 
-Intendant installs every shipped skill machine-wide into
-`~/.agents/skills/` at daemon startup. The setup scripts alias
-`~/.claude/skills` to the same directory on every supported platform, so
+Intendant installs every shipped skill machine-wide into the independent
+`~/.agents/skills/` and `~/.claude/skills/` roots at daemon startup, so
 supervised and bare Codex or Claude Code sessions see the shipped catalog
-through their normal personal discovery. Installs are marker-owned and
-idempotent; an unmarked user-authored collision always wins.
+through their normal personal discovery. Intendant manages only marked
+per-skill directories: the roots themselves and unmarked user-authored
+collisions are always left untouched.
 
 Starting an external session never copies skills into its project. Personal
-global skills remain user-owned under `~/.agents/skills/`; personal
-project-scoped skills remain user-owned under the backend's normal project
-path and belong in that project's ignore rules. There is no
-Intendant-specific legacy skill path and no automatic mirroring between
-Claude Code's `.claude/skills/` and the Agent Skills standard
-`.agents/skills/`. See "Global distribution" in the configuration chapter.
+global and project-scoped skills remain user-owned under the backend's normal
+global or project path and belong in that project's ignore rules where
+applicable. There is no Intendant-specific legacy skill path and no automatic
+mirroring between Claude Code's `.claude/skills/` and the Agent Skills
+standard `.agents/skills/`. See "Global distribution" in the configuration
+chapter.
 
 ## Configuration
 

--- a/scripts/setup-linux.sh
+++ b/scripts/setup-linux.sh
@@ -687,21 +687,6 @@ run_check() {
 
 # ── Install mode ──────────────────────────────────────────────────────────
 
-
-# Claude Code reads ~/.claude/skills; point it at the Agent Skills
-# standard dir (~/.agents/skills) so personal and daemon-installed
-# skills reach it too. Never replaces a real user directory.
-link_claude_skills() {
-    mkdir -p "$HOME/.agents/skills"
-    if [ -e "$HOME/.claude/skills" ] && [ ! -L "$HOME/.claude/skills" ]; then
-        warn "~/.claude/skills is a real directory — leaving it; merge it into ~/.agents/skills to unify"
-        return 0
-    fi
-    mkdir -p "$HOME/.claude"
-    ln -sfn "$HOME/.agents/skills" "$HOME/.claude/skills"
-    ok "~/.claude/skills -> ~/.agents/skills"
-}
-
 run_install() {
     echo ""
     echo "================================================================"
@@ -742,9 +727,6 @@ run_install() {
 
     # Phase 7: disable screen lock so the agent isn't interrupted
     disable_screen_lock
-
-    # Phase 7.5: unified skills dir for Claude Code
-    link_claude_skills
 
     # Phase 8: build
     if $SKIP_BUILD; then

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -474,21 +474,6 @@ run_check() {
     echo ""
 }
 
-
-# Claude Code reads ~/.claude/skills; point it at the Agent Skills
-# standard dir (~/.agents/skills) so personal and daemon-installed
-# skills reach it too. Never replaces a real user directory.
-link_claude_skills() {
-    mkdir -p "$HOME/.agents/skills"
-    if [ -e "$HOME/.claude/skills" ] && [ ! -L "$HOME/.claude/skills" ]; then
-        warn "~/.claude/skills is a real directory — leaving it; merge it into ~/.agents/skills to unify"
-        return 0
-    fi
-    mkdir -p "$HOME/.claude"
-    ln -sfn "$HOME/.agents/skills" "$HOME/.claude/skills"
-    ok "~/.claude/skills -> ~/.agents/skills"
-}
-
 run_install() {
     echo ""
     echo "════════════════════════════════════════════════════════"
@@ -525,9 +510,6 @@ run_install() {
 
     # Phase 6: Disable screensaver so the agent isn't interrupted
     disable_screen_lock
-
-    # Phase 6.5: unified skills dir for Claude Code
-    link_claude_skills
 
     # Phase 7: App bundle
     echo ""

--- a/scripts/setup-windows.ps1
+++ b/scripts/setup-windows.ps1
@@ -933,26 +933,8 @@ if (-not ([System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win3
     Die "this script is for Windows"
 }
 
-
-# Claude Code reads ~\.claude\skills; junction it to the Agent Skills
-# standard dir so personal and daemon-installed skills reach it too.
-function Link-ClaudeSkills {
-    $agents = Join-Path $env:USERPROFILE ".agents\skills"
-    $claude = Join-Path $env:USERPROFILE ".claude\skills"
-    New-Item -ItemType Directory -Force -Path $agents | Out-Null
-    if ((Test-Path $claude) -and -not ((Get-Item $claude -Force).LinkType)) {
-        Warn "~\.claude\skills is a real directory -- leaving it; merge it into ~\.agents\skills to unify"
-        return
-    }
-    New-Item -ItemType Directory -Force -Path (Split-Path $claude) | Out-Null
-    if (Test-Path $claude) { (Get-Item $claude -Force).Delete() }
-    New-Item -ItemType Junction -Path $claude -Target $agents | Out-Null
-    Ok "~\.claude\skills -> ~\.agents\skills"
-}
-
 if ($Check) {
     Run-Check
 } else {
     Run-Install
-    Link-ClaudeSkills
 }

--- a/src/bin/caller/builtin_skills.rs
+++ b/src/bin/caller/builtin_skills.rs
@@ -1,10 +1,10 @@
 //! Skills shipped inside the Intendant binary.
 //!
-//! The daemon installs this complete manifest machine-wide under
-//! `~/.agents/skills/`, so packaged installs do not need a repository checkout.
-//! The parity test pins every embedded byte to `skills/` on disk: adding,
-//! removing, or renaming a support file without updating this table fails the
-//! suite instead of shipping a partial skill.
+//! The daemon installs this complete manifest machine-wide under the independent
+//! `~/.agents/skills/` and `~/.claude/skills/` roots, so packaged installs do
+//! not need a repository checkout. The parity test pins every embedded byte to
+//! `skills/` on disk: adding, removing, or renaming a support file without
+//! updating this table fails the suite instead of shipping a partial skill.
 
 /// One skill embedded in the binary.
 pub(crate) struct BuiltinSkill {

--- a/src/bin/caller/skill_install.rs
+++ b/src/bin/caller/skill_install.rs
@@ -1,14 +1,15 @@
-//! Install the skills shipped inside the Intendant binary into the Agent
-//! Skills standard personal directory.
+//! Install the skills shipped inside the Intendant binary into the global
+//! skill directories read by Intendant's supported coding agents.
 //!
 //! This is deliberately a machine-scoped install, never a per-session
 //! project materialization. Project-scoped personal skills remain owned by
 //! the user in the external backend's project directory; starting an
 //! external agent must not write skill copies into its checkout.
 //!
-//! Every daemon-installed directory carries [`INSTALL_MARKER`].
-//! Content-identical installs are no-ops, stale marked copies are removed,
-//! and an unmarked user-owned directory with the same name always wins.
+//! The two roots are independent: Intendant never aliases or replaces either
+//! root. Every daemon-installed skill directory carries [`INSTALL_MARKER`].
+//! Content-identical installs are no-ops, stale marked copies are removed, and
+//! an unmarked user-owned directory with the same name always wins.
 
 use std::collections::BTreeSet;
 use std::io;
@@ -17,41 +18,100 @@ use std::path::{Path, PathBuf};
 /// Ownership marker for a directory created by this installer.
 const INSTALL_MARKER: &str = ".intendant-installed";
 
-/// Report from one global-install pass.
+/// Report from one directly managed skill root.
 #[derive(Debug, Default)]
-pub(crate) struct GlobalInstallReport {
-    pub(crate) installed: Vec<String>,
-    pub(crate) unchanged: usize,
-    pub(crate) skipped_user_owned: Vec<String>,
-    pub(crate) removed_stale: Vec<String>,
+struct SkillInstallReport {
+    installed: Vec<String>,
+    unchanged: usize,
+    skipped_user_owned: Vec<String>,
+    removed_stale: Vec<String>,
 }
 
-/// Install every shipped skill into `~/.agents/skills/` — the Agent Skills
-/// standard personal path that Codex, Intendant itself, and (through the
-/// setup-script `~/.claude/skills` alias) Claude Code all read.
-fn install_global_skills() -> io::Result<GlobalInstallReport> {
+#[derive(Debug)]
+enum SkillRootInstallOutcome {
+    Installed(SkillInstallReport),
+    SkippedUserOwnedRoot,
+    Failed(String),
+}
+
+#[derive(Debug)]
+struct SkillRootInstallReport {
+    display_path: &'static str,
+    outcome: SkillRootInstallOutcome,
+}
+
+/// Report from one global-install pass across both independent roots.
+#[derive(Debug, Default)]
+struct GlobalInstallReport {
+    roots: Vec<SkillRootInstallReport>,
+}
+
+/// Install every shipped skill independently for Agent Skills consumers
+/// (`~/.agents/skills/`) and Claude Code (`~/.claude/skills/`).
+fn install_global_skills() -> GlobalInstallReport {
     let Some(home) = dirs::home_dir() else {
-        return Ok(GlobalInstallReport::default());
+        return GlobalInstallReport::default();
     };
     install_global_skills_in(&home)
 }
 
 /// Home-injectable core of [`install_global_skills`].
-fn install_global_skills_in(home: &Path) -> io::Result<GlobalInstallReport> {
-    let mut report = GlobalInstallReport::default();
-    let target_dir = home.join(".agents").join("skills");
+fn install_global_skills_in(home: &Path) -> GlobalInstallReport {
+    let targets = [
+        ("~/.agents/skills", home.join(".agents").join("skills")),
+        ("~/.claude/skills", home.join(".claude").join("skills")),
+    ];
+    let roots = targets
+        .into_iter()
+        .map(|(display_path, target_dir)| {
+            let outcome = match install_skills_in_root(&target_dir) {
+                Ok(Some(report)) => SkillRootInstallOutcome::Installed(report),
+                Ok(None) => SkillRootInstallOutcome::SkippedUserOwnedRoot,
+                Err(error) => SkillRootInstallOutcome::Failed(error.to_string()),
+            };
+            SkillRootInstallReport {
+                display_path,
+                outcome,
+            }
+        })
+        .collect();
+    GlobalInstallReport { roots }
+}
 
+/// Install the shipped catalog below one normal directory.
+///
+/// A link, junction, file, or other object at the root is user-owned and is
+/// never followed or replaced. `read_link` recognizes Windows junctions as
+/// well as symbolic links, while `symlink_metadata` keeps broken links visible.
+fn install_skills_in_root(target_dir: &Path) -> io::Result<Option<SkillInstallReport>> {
+    match std::fs::symlink_metadata(target_dir) {
+        Ok(metadata) if !is_direct_directory(target_dir, &metadata) => return Ok(None),
+        Ok(_) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
+    }
+
+    let mut report = SkillInstallReport::default();
     let shipped = crate::builtin_skills::BUILTIN_SKILLS;
 
-    // Sweep marked dirs that are no longer shipped globally. Renames and
-    // removals clean up on the next daemon start.
-    if let Ok(entries) = std::fs::read_dir(&target_dir) {
+    // Sweep marked dirs that are no longer shipped. Renames and removals
+    // clean up on the next daemon start.
+    if let Ok(entries) = std::fs::read_dir(target_dir) {
         for entry in entries.flatten() {
             let path = entry.path();
             let Ok(file_type) = entry.file_type() else {
                 continue;
             };
-            if !file_type.is_dir() || !path.join(INSTALL_MARKER).is_file() {
+            if !file_type.is_dir()
+                || !is_direct_directory(
+                    &path,
+                    &match std::fs::symlink_metadata(&path) {
+                        Ok(metadata) => metadata,
+                        Err(_) => continue,
+                    },
+                )
+                || !path.join(INSTALL_MARKER).is_file()
+            {
                 continue;
             }
             let name = entry.file_name().to_string_lossy().into_owned();
@@ -68,7 +128,7 @@ fn install_global_skills_in(home: &Path) -> io::Result<GlobalInstallReport> {
         let dest_metadata = std::fs::symlink_metadata(&dest).ok();
         let dest_is_directory = dest_metadata
             .as_ref()
-            .is_some_and(|metadata| metadata.is_dir() && !metadata.file_type().is_symlink());
+            .is_some_and(|metadata| is_direct_directory(&dest, metadata));
         if dest_metadata.is_some() && (!dest_is_directory || !marker.is_file()) {
             report.skipped_user_owned.push(skill.name.to_string());
             continue;
@@ -92,7 +152,11 @@ fn install_global_skills_in(home: &Path) -> io::Result<GlobalInstallReport> {
         }
         report.installed.push(skill.name.to_string());
     }
-    Ok(report)
+    Ok(Some(report))
+}
+
+fn is_direct_directory(path: &Path, metadata: &std::fs::Metadata) -> bool {
+    metadata.is_dir() && !metadata.file_type().is_symlink() && std::fs::read_link(path).is_err()
 }
 
 fn installed_skill_is_current(dest: &Path, skill: &crate::builtin_skills::BuiltinSkill) -> bool {
@@ -145,25 +209,37 @@ fn collect_installed_files(
 }
 
 /// Startup wrapper for session-serving modes: run the install and log one
-/// line when it changed anything.
+/// line for changes, collisions, skipped roots, or failures.
 pub(crate) fn install_global_skills_at_startup() {
-    match install_global_skills() {
-        Ok(report) => {
-            if !report.installed.is_empty() || !report.removed_stale.is_empty() {
+    for root in install_global_skills().roots {
+        match root.outcome {
+            SkillRootInstallOutcome::Installed(report)
+                if !report.installed.is_empty()
+                    || !report.removed_stale.is_empty()
+                    || !report.skipped_user_owned.is_empty() =>
+            {
                 let kept = if report.skipped_user_owned.is_empty() {
                     String::new()
                 } else {
                     format!(", {} user-owned kept", report.skipped_user_owned.len())
                 };
                 eprintln!(
-                    "[skills] global install: {} installed, {} unchanged, {} stale removed{kept}",
+                    "[skills] {}: {} installed, {} unchanged, {} stale removed{kept}",
+                    root.display_path,
                     report.installed.len(),
                     report.unchanged,
                     report.removed_stale.len(),
                 );
             }
+            SkillRootInstallOutcome::Installed(_) => {}
+            SkillRootInstallOutcome::SkippedUserOwnedRoot => eprintln!(
+                "[skills] {} is a link or non-directory; left untouched",
+                root.display_path
+            ),
+            SkillRootInstallOutcome::Failed(error) => {
+                eprintln!("[skills] {} install failed: {error}", root.display_path)
+            }
         }
-        Err(error) => eprintln!("[skills] global install failed: {error}"),
     }
 }
 
@@ -177,56 +253,75 @@ mod tests {
         let home = tmp.path();
         let expected = crate::builtin_skills::BUILTIN_SKILLS;
 
-        // A user-authored dir colliding with one shipped skill, plus a
-        // stale marked leftover from an older daemon.
-        let target = home.join(".agents").join("skills");
-        let user_owned = target.join(expected[0].name);
+        // A user-authored Agent Skills collision must not suppress the
+        // independent Claude copy. Both roots also sweep stale marked skills.
+        let agents_target = home.join(".agents").join("skills");
+        let claude_target = home.join(".claude").join("skills");
+        let user_owned = agents_target.join(expected[0].name);
         std::fs::create_dir_all(&user_owned).unwrap();
         std::fs::write(user_owned.join("SKILL.md"), "user copy").unwrap();
-        let stale = target.join("retired-builtin");
-        std::fs::create_dir_all(&stale).unwrap();
-        std::fs::write(stale.join(INSTALL_MARKER), "old").unwrap();
+        for target in [&agents_target, &claude_target] {
+            let stale = target.join("retired-builtin");
+            std::fs::create_dir_all(&stale).unwrap();
+            std::fs::write(stale.join(INSTALL_MARKER), "old").unwrap();
+        }
 
-        let first = install_global_skills_in(home).unwrap();
-        assert_eq!(first.installed.len(), expected.len() - 1);
-        assert_eq!(first.skipped_user_owned, vec![expected[0].name.to_string()]);
-        assert_eq!(first.removed_stale, vec!["retired-builtin".to_string()]);
-        assert!(!stale.exists());
+        let first = install_global_skills_in(home);
+        let agents = installed_report(&first, "~/.agents/skills");
+        let claude = installed_report(&first, "~/.claude/skills");
+        assert_eq!(agents.installed.len(), expected.len() - 1);
+        assert_eq!(
+            agents.skipped_user_owned,
+            vec![expected[0].name.to_string()]
+        );
+        assert_eq!(agents.removed_stale, vec!["retired-builtin".to_string()]);
+        assert_eq!(claude.installed.len(), expected.len());
+        assert!(claude.skipped_user_owned.is_empty());
+        assert_eq!(claude.removed_stale, vec!["retired-builtin".to_string()]);
+        assert!(!agents_target.join("retired-builtin").exists());
+        assert!(!claude_target.join("retired-builtin").exists());
         assert_eq!(
             std::fs::read_to_string(user_owned.join("SKILL.md")).unwrap(),
             "user copy"
         );
-        for skill in expected.iter().skip(1) {
-            let dest = target.join(skill.name);
-            assert!(dest.join("SKILL.md").exists(), "{} missing", skill.name);
-            assert!(
-                dest.join(INSTALL_MARKER).exists(),
-                "{} unmarked",
-                skill.name
-            );
-            for (relative, bytes) in skill.support_files {
-                assert_eq!(
-                    std::fs::read(dest.join(relative)).unwrap(),
-                    *bytes,
-                    "{}/{} missing or stale",
-                    skill.name,
-                    relative
+        for (target, skip_first) in [(&agents_target, true), (&claude_target, false)] {
+            for skill in expected.iter().skip(usize::from(skip_first)) {
+                let dest = target.join(skill.name);
+                assert!(dest.join("SKILL.md").exists(), "{} missing", skill.name);
+                assert!(
+                    dest.join(INSTALL_MARKER).exists(),
+                    "{} unmarked",
+                    skill.name
                 );
+                for (relative, bytes) in skill.support_files {
+                    assert_eq!(
+                        std::fs::read(dest.join(relative)).unwrap(),
+                        *bytes,
+                        "{}/{} missing or stale",
+                        skill.name,
+                        relative
+                    );
+                }
             }
         }
 
-        // A changed support file or extra file refreshes the whole managed
-        // directory from the embedded manifest.
+        // Changing one Claude copy refreshes only that root.
         let with_support = expected
             .iter()
             .find(|skill| !skill.support_files.is_empty())
             .expect("at least one shipped skill has support files");
-        let managed = target.join(with_support.name);
+        let managed = claude_target.join(with_support.name);
         let (support_path, support_bytes) = with_support.support_files[0];
         std::fs::write(managed.join(support_path), "stale").unwrap();
         std::fs::write(managed.join("unexpected.txt"), "stale").unwrap();
-        let refreshed = install_global_skills_in(home).unwrap();
-        assert_eq!(refreshed.installed, vec![with_support.name.to_string()]);
+        let refreshed = install_global_skills_in(home);
+        assert!(installed_report(&refreshed, "~/.agents/skills")
+            .installed
+            .is_empty());
+        assert_eq!(
+            installed_report(&refreshed, "~/.claude/skills").installed,
+            vec![with_support.name.to_string()]
+        );
         assert_eq!(
             std::fs::read(managed.join(support_path)).unwrap(),
             support_bytes
@@ -234,9 +329,78 @@ mod tests {
         assert!(!managed.join("unexpected.txt").exists());
 
         // The following run is a pure no-op.
-        let unchanged = install_global_skills_in(home).unwrap();
-        assert!(unchanged.installed.is_empty(), "{unchanged:?}");
-        assert!(unchanged.removed_stale.is_empty(), "{unchanged:?}");
-        assert_eq!(unchanged.unchanged, expected.len() - 1);
+        let unchanged = install_global_skills_in(home);
+        let agents = installed_report(&unchanged, "~/.agents/skills");
+        let claude = installed_report(&unchanged, "~/.claude/skills");
+        assert!(agents.installed.is_empty(), "{unchanged:?}");
+        assert!(claude.installed.is_empty(), "{unchanged:?}");
+        assert!(agents.removed_stale.is_empty(), "{unchanged:?}");
+        assert!(claude.removed_stale.is_empty(), "{unchanged:?}");
+        assert_eq!(agents.unchanged, expected.len() - 1);
+        assert_eq!(claude.unchanged, expected.len());
+    }
+
+    #[test]
+    fn non_directory_global_root_is_left_untouched() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let claude_root = home.join(".claude").join("skills");
+        std::fs::create_dir_all(claude_root.parent().unwrap()).unwrap();
+        std::fs::write(&claude_root, "user-owned").unwrap();
+
+        let report = install_global_skills_in(home);
+        assert!(matches!(
+            outcome(&report, "~/.claude/skills"),
+            SkillRootInstallOutcome::SkippedUserOwnedRoot
+        ));
+        assert_eq!(std::fs::read_to_string(&claude_root).unwrap(), "user-owned");
+        assert_eq!(
+            installed_report(&report, "~/.agents/skills")
+                .installed
+                .len(),
+            crate::builtin_skills::BUILTIN_SKILLS.len()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn global_root_symlink_is_never_followed_or_replaced() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let linked_target = home.join("user-catalog");
+        let claude_root = home.join(".claude").join("skills");
+        std::fs::create_dir_all(&linked_target).unwrap();
+        std::fs::create_dir_all(claude_root.parent().unwrap()).unwrap();
+        std::os::unix::fs::symlink(&linked_target, &claude_root).unwrap();
+
+        let report = install_global_skills_in(home);
+        assert!(matches!(
+            outcome(&report, "~/.claude/skills"),
+            SkillRootInstallOutcome::SkippedUserOwnedRoot
+        ));
+        assert_eq!(std::fs::read_link(&claude_root).unwrap(), linked_target);
+        assert_eq!(std::fs::read_dir(&linked_target).unwrap().count(), 0);
+    }
+
+    fn outcome<'a>(
+        report: &'a GlobalInstallReport,
+        display_path: &str,
+    ) -> &'a SkillRootInstallOutcome {
+        &report
+            .roots
+            .iter()
+            .find(|root| root.display_path == display_path)
+            .unwrap()
+            .outcome
+    }
+
+    fn installed_report<'a>(
+        report: &'a GlobalInstallReport,
+        display_path: &str,
+    ) -> &'a SkillInstallReport {
+        match outcome(report, display_path) {
+            SkillRootInstallOutcome::Installed(report) => report,
+            other => panic!("{display_path} was not installed: {other:?}"),
+        }
     }
 }

--- a/src/bin/caller/startup/daemon.rs
+++ b/src/bin/caller/startup/daemon.rs
@@ -92,9 +92,8 @@ pub(crate) async fn run_daemon(
     daemon_startup_resume_dir: Option<PathBuf>,
     provider_identity: crate::usage_rail::ProviderIdentity,
 ) -> Result<(), CallerError> {
-    // Install every shipped builtin skill into ~/.agents/skills
-    // (marker-owned, no-op when unchanged) so every agent on this machine —
-    // supervised or not — can discover them.
+    // Install every shipped builtin skill independently for Agent Skills
+    // consumers and Claude Code (marker-owned, no-op when unchanged).
     crate::skill_install::install_global_skills_at_startup();
 
     // Retention guard for the daemon-global fallback store (projectless


### PR DESCRIPTION
## Summary
- install shipped skills independently into the Agent Skills and Claude Code global roots
- remove setup-script symlink and junction creation
- leave linked, non-directory, and unmarked user-owned paths untouched

## Validation
- `cargo test -p intendant --bins`
- `cargo test -p intendant-core -p intendant-display -p intendant-platform -p owner-plane-core -p owner-plane-reducer`
- `cargo clippy --workspace -- -D warnings`
- `cargo test -p intendant --test e2e`
- `bash -n scripts/setup-macos.sh`
- `bash -n scripts/setup-linux.sh`
- GitHub Actions: macOS, Linux, and Windows test jobs