### PR TITLE
ask rail: tuck wins the cascade, full-pane previews, honest chips

### DIFF
--- a/static/app/12-styles-tasks-log.css
+++ b/static/app/12-styles-tasks-log.css
@@ -3106,7 +3106,25 @@ body.context-focus-active {
   cursor: pointer;
 }
 .question-tuck:hover { background: var(--surface1); color: var(--text); }
-#question-panel.question-minimized { display: none; }
+/* !important on purpose (router-hide precedent): the dock geometry rule
+   `#activity-log-pane .bottom-panel.visible { display:flex }` outranks any
+   id+class selector, and a tuck that silently loses the cascade is exactly
+   the "minimize does nothing" bug shipped once already. */
+#question-panel.question-minimized { display: none !important; }
+/* Preview-bearing questions own the WHOLE pane — the comparison is the
+   content, and the tuck chip is the escape hatch. On narrow (mobile)
+   viewports every question panel takes the full pane: the bottom-dock
+   sliver layout is too cramped there. */
+#activity-log-pane #question-panel.has-previews.visible {
+  top: 0;
+  max-height: none;
+}
+@media (max-width: 900px) {
+  #activity-log-pane #question-panel.visible {
+    top: 0;
+    max-height: none;
+  }
+}
 #question-restore-chip {
   position: fixed;
   right: 20px;

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -3900,9 +3900,11 @@ function updateQuestionProgress() {
     const followup = (block?.querySelector('.question-followup-input')?.value || '').trim();
     const { min } = questionPickBounds(q);
     const picked = block ? block.querySelectorAll('.question-option.selected').length : 0;
-    // Satisfied = typed free text, enough picks, a follow-up standing in,
-    // or nothing required.
-    const done = !!(block && (typed || followup || picked >= Math.max(min, 1) || min === 0));
+    // Ticked = ENGAGED (typed, enough picks, or a follow-up standing in).
+    // An untouched optional question stays untucked — a pre-ticked "✓" on
+    // something the user never looked at reads as a lie (min 0 only means
+    // Submit won't block on it).
+    const done = !!(block && (typed || followup || (picked > 0 && picked >= min)));
     if (done) answered++;
     const chip = content.querySelector(`.question-index-chip[data-q="${i}"]`);
     if (chip) {
@@ -4278,10 +4280,12 @@ function showUserQuestion(id, questions, sessionId, expiresAtMs, held) {
   title.appendChild(tuck);
   content.appendChild(title);
 
-  // Pinned index (2+ questions): one chip per header, kept above the
+  // Pinned index (3+ questions): one chip per header, kept above the
   // scroll region; tapping a chip jumps to its question, and
-  // updateQuestionProgress ticks chips as answers land.
-  if (multi) {
+  // updateQuestionProgress ticks chips as answers land. With only two
+  // questions both are on screen anyway — the chips read as dead
+  // buttons (live finding 2026-07-20), so they don't render.
+  if (list.length > 2) {
     const index = document.createElement('div');
     index.className = 'question-index';
     list.forEach((q, qIndex) => {

--- a/static/app/ui2-activity.css
+++ b/static/app/ui2-activity.css
@@ -1667,15 +1667,19 @@ html.ui-v2 #question-panel .question-preview-note-btn.open {
   background: var(--surface-2);
   color: var(--text);
 }
+/* Block header = a quiet eyebrow LABEL. It must not share the index
+   chips' pill styling — a pill that ignores clicks reads as a broken
+   button (live finding 2026-07-20). */
 html.ui-v2 #question-panel .question-header-chip {
   font-family: var(--mono);
   font-size: 9px;
   font-weight: 700;
-  letter-spacing: .12em;
+  letter-spacing: .14em;
   text-transform: uppercase;
-  color: var(--sky);
-  background: rgba(var(--sky-rgb), .1);
-  border: 1px solid rgba(var(--sky-rgb), .24);
+  color: var(--text-3);
+  background: transparent;
+  border: 0;
+  padding: 0;
 }
 html.ui-v2 #question-panel .question-option {
   border: 1px solid var(--line);


### PR DESCRIPTION
Live QA findings on the Ask v2 panel:

- The tuck 'did nothing': the dock geometry rule
  (#activity-log-pane .bottom-panel.visible, display:flex) outranks the
  id+class minimized rule, so the panel never actually hid — the PR
  #515 re-show fix addressed a real stomp but not this cascade loss.
  question-minimized now carries !important (router-hide precedent).
- Preview-bearing questions own the whole pane (top:0), and on narrow
  viewports every question panel does — the bottom-dock sliver is too
  cramped on mobile; the tuck chip is the escape hatch.
- The question-index chips render only for 3+ questions (with two, both
  are on screen and the chips read as dead buttons), and the per-block
  header chip restyles as a quiet eyebrow label instead of a
  pill-that-looks-clickable.
- Progress ticks mean engagement: an untouched optional question no
  longer shows a pre-ticked ✓ (min 0 only means Submit won't block).
