### PR TITLE
steers: confirm delivery on tool-call checkpoints; waiting rows show elapsed

### DIFF
--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -265,8 +265,9 @@ pub enum AppEvent {
     SteerAccepted {
         session_id: Option<String>,
         id: String,
-        /// Short human-readable detail for UI display, e.g. "Codex accepted
-        /// the steer; waiting for the next runtime checkpoint".
+        /// Short human-readable detail for UI display, e.g. "Codex injected
+        /// the message into the running turn — awaiting the model's next
+        /// activity".
         reason: String,
     },
     /// Mid-turn steering could not be delivered natively by the current

--- a/src/bin/caller/external_events.rs
+++ b/src/bin/caller/external_events.rs
@@ -632,7 +632,7 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                                     text: text.clone(),
                                 });
                                 let reason = format!(
-                                    "{} accepted the steer; waiting for the next runtime checkpoint",
+                                    "{} injected the message into the running turn — awaiting the model's next activity",
                                     agent.name()
                                 );
                                 slog(config.session_log, |l| {
@@ -1529,6 +1529,17 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                 tool_name,
                 message_uuid,
             } => {
+                // A model-issued tool call is a fresh API response — the same
+                // checkpoint evidence as streamed text, and often the ONLY
+                // signal for minutes when the model chains tool calls without
+                // emitting text (observed live: a 5-minute "waiting" row on an
+                // already-absorbed steer). The helper's session filter keeps a
+                // child sub-agent's tool calls from confirming parent steers.
+                mark_pending_runtime_steers_delivered_at_model_checkpoint(
+                    config,
+                    pending_runtime_steers,
+                    agent.name(),
+                );
                 if event_is_primary
                     && agent.supports_item_anchor_rewind()
                     && managed_codex_foreground_dashboard_command(&tool_name, &preview)

--- a/static/app/12-styles-tasks-log.css
+++ b/static/app/12-styles-tasks-log.css
@@ -702,6 +702,14 @@ body.context-focus-active {
   overflow-wrap: anywhere;
   white-space: normal;
 }
+.steer-elapsed {
+  grid-column: 2;
+  color: var(--overlay1);
+  font-size: 11px;
+  font-style: normal;
+  font-variant-numeric: tabular-nums;
+}
+.steer-elapsed:empty { display: none; }
 .steer-cancel {
   grid-column: 3;
   grid-row: 1 / span 2;

--- a/static/app/54-session-lifecycle.js
+++ b/static/app/54-session-lifecycle.js
@@ -987,6 +987,50 @@ function cancelSteerRow(id) {
   removeSteerRowSoon(key, 700);
 }
 
+// Waiting steer rows show how long they have been waiting (a mid-turn steer
+// can honestly sit minutes before the model's next checkpoint confirms it —
+// without a clock the row reads as stuck). One shared 1s ticker, started only
+// while a waiting row exists and self-stopping when none remain.
+const STEER_WAITING_STATUSES = ['pending', 'accepted', 'queued'];
+let steerElapsedTimer = null;
+
+function steerElapsedLabel(ms) {
+  const s = Math.max(0, Math.floor(ms / 1000));
+  if (s < 60) return s + 's';
+  const m = Math.floor(s / 60);
+  if (m < 60) return m + 'm ' + (s % 60) + 's';
+  const h = Math.floor(m / 60);
+  return h + 'h ' + (m % 60) + 'm';
+}
+
+function steerElapsedTick() {
+  const now = Date.now();
+  let waitingRows = 0;
+  steerRows.forEach((entry) => {
+    const el = entry.el;
+    if (!el || !el.isConnected) return;
+    const node = el.querySelector('.steer-elapsed');
+    if (!node) return;
+    const waiting = STEER_WAITING_STATUSES.some((cls) => el.classList.contains(cls));
+    if (!waiting || !entry.waitingSince) {
+      if (node.textContent) node.textContent = '';
+      return;
+    }
+    waitingRows++;
+    const label = '· ' + steerElapsedLabel(now - entry.waitingSince);
+    if (node.textContent !== label) node.textContent = label;
+  });
+  if (waitingRows === 0 && steerElapsedTimer) {
+    clearInterval(steerElapsedTimer);
+    steerElapsedTimer = null;
+  }
+}
+
+function ensureSteerElapsedTicker() {
+  if (!steerElapsedTimer) steerElapsedTimer = setInterval(steerElapsedTick, 1000);
+  steerElapsedTick();
+}
+
 function onSteerStatusUpdate(id, text, status, reason, options = {}) {
   const key = String(id || '').trim();
   if (!key) return;
@@ -1002,9 +1046,10 @@ function onSteerStatusUpdate(id, text, status, reason, options = {}) {
       '<span class="steer-icon"></span>'
       + '<span class="steer-text"></span>'
       + '<span class="steer-reason"></span>'
+      + '<span class="steer-elapsed"></span>'
       + '<button type="button" class="steer-cancel" title="Clear queued steer" aria-label="Clear queued steer">&#10005;</button>';
     strip.appendChild(el);
-    entry = { el, timeout: null, text: '', sessionId: '' };
+    entry = { el, timeout: null, text: '', sessionId: '', waitingSince: Date.now() };
     steerRows.set(key, entry);
     el.querySelector('.steer-cancel')?.addEventListener('click', () => cancelSteerRow(key));
   }
@@ -1031,6 +1076,13 @@ function onSteerStatusUpdate(id, text, status, reason, options = {}) {
   el.title = [entry.text || text, reason].filter(Boolean).join('\n\n');
   strip.classList.remove('empty');
   stationScheduleUpdate();
+
+  if (STEER_WAITING_STATUSES.includes(status)) {
+    ensureSteerElapsedTicker();
+  } else {
+    const elapsedNode = el.querySelector('.steer-elapsed');
+    if (elapsedNode) elapsedNode.textContent = '';
+  }
 
   // Clear any in-flight fade timer — a fresh status update preempts it.
   if (entry.timeout) { clearTimeout(entry.timeout); entry.timeout = null; }


### PR DESCRIPTION
Follow-up to #512, from live e2e: a mid-turn steer to a Claude Code session sat in "waiting for the next runtime checkpoint" for 5 minutes while the model chained tool calls without emitting text — the steer was already absorbed (it produced an agenda item mid-turn), but delivery confirmation only fires on model text, so the row read as stuck.

1. **Delivery confirms on tool-call checkpoints** (`external_events.rs`): the `ToolStarted` arm now calls `mark_pending_runtime_steers_delivered_at_model_checkpoint` — a model-issued tool call is the same fresh-API-response evidence as streamed text. The helper's existing session filter keeps a Task sub-agent's tool calls from confirming parent steers.
2. **Honest accepted wording**: `SteerAccepted` reason becomes "<agent> injected the message into the running turn — awaiting the model's next activity".
3. **Elapsed clock on waiting rows** (`54-session-lifecycle.js` + CSS): pending/accepted/queued steer rows show `· 1m 23s`, driven by a single shared 1s ticker that starts with the first waiting row and self-stops with the last; cleared on terminal statuses. `static/app.html` regenerated via the assembler.

## Verification
- `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`
- `cargo nextest run -p intendant --bins` (4516 passed), lib crates, `--test e2e` (24 passed)
- `node --check` on the fragment; live `tests/skills/claude-code-e2e` driver run: see PR comment