### PR TITLE
agenda F2: gates & threads — annotate, blockers, relies_on, derived blocked

### DIFF
--- a/docs/src/agenda-and-memory.md
+++ b/docs/src/agenda-and-memory.md
@@ -62,6 +62,8 @@ The supported commands are:
 
 - `add`, `patch`, `complete`, `reopen`, and `retire`;
 - `answer` for an open question (answering also resolves it);
+- `annotate`, `set_blocker`, `clear_blocker`, `add_relies_on`, and
+  `remove_relies_on` — the item's thread and gates (below);
 - `propose_effect`, `approve_effect`, and `revoke_effect` for a scheduled
   session.
 
@@ -74,6 +76,38 @@ A question is the durable, non-blocking counterpart to `ask_user`. Parking it
 does not stop a session. The owner can answer later, and a future session can
 read the reply from the item. Reopening an answered question clears the
 current reply view but not the historical operation.
+
+### Threads, blockers, and dependencies
+
+Three follow-through vocabularies extend items, all ordinary attributed
+operations in the same append-only log:
+
+- **Annotations** (`annotate`) append an attributed, timestamped note to an
+  item of any status — the thread under it. Full history folds; surfaces cap
+  the render with an expander. Intake caps each note at the body limit and
+  an item at 500 annotations (a pathology rail, not a budget).
+- **Blockers** (`set_blocker` / `clear_blocker`) state a human criterion —
+  "api access granted", "waiting on the vendor" — on an open item. **No
+  machinery evaluates blockers**: no watchers, no pollers, no condition
+  language. The daemon mints the blocker id at intake; clears are
+  operations, never deletions — a cleared blocker stays rendered as history
+  with the clearing actor. Setting and clearing are plain `agenda.write`
+  acts; the housekeeping mandate governs agent *conduct* (agents without a
+  mandate annotate with evidence instead of clearing), not capability.
+- **Dependencies** (`add_relies_on` / `remove_relies_on`) draw edges to
+  other items. A completed prerequisite satisfies the edge by pure
+  recomputation at read time; a **retired** prerequisite does not silently
+  satisfy — the dependent renders "prerequisite retired — review"; a target
+  missing from the fold renders "prerequisite missing"; cycles simply render
+  every member blocked (direct status lookup, nothing walks).
+
+**Blocked is derived presentation, never state.** An open item with any
+uncleared blocker or unsatisfied dependency renders a blocked chip, and
+list surfaces can filter on it (`ctl agenda list --blocked`, the dashboard
+filter) — but the value is computed at render time by each surface (the
+daemon ships the same pure helper for ctl and tests), never stored, never
+put on the wire, and never a notification trigger: the reminder lane
+remains the only thing that fires.
 
 ### Due reminders
 

--- a/src/bin/caller/agenda/reminders.rs
+++ b/src/bin/caller/agenda/reminders.rs
@@ -684,6 +684,9 @@ mod tests {
             effects: Vec::new(),
             ask: None,
             dismissed: None,
+            annotations: Vec::new(),
+            blockers: Vec::new(),
+            relies_on: Vec::new(),
         }
     }
 

--- a/src/bin/caller/agenda/store.rs
+++ b/src/bin/caller/agenda/store.rs
@@ -5,8 +5,9 @@
 
 use super::types::{
     apply_op, counts, AgendaActor, AgendaCommand, AgendaCounts, AgendaItem, AgendaOp,
-    AgendaOpRecord, AgendaPatch, AgendaStatus, AGENDA_LOG_VERSION, MAX_BODY_BYTES,
-    MAX_SOURCE_CHARS, MAX_TAGS, MAX_TAG_CHARS, MAX_TITLE_CHARS,
+    AgendaOpRecord, AgendaPatch, AgendaStatus, AGENDA_LOG_VERSION, MAX_ANNOTATIONS_PER_ITEM,
+    MAX_BODY_BYTES, MAX_CRITERION_CHARS, MAX_RELIES_ON_PER_ITEM, MAX_SOURCE_CHARS, MAX_TAGS,
+    MAX_TAG_CHARS, MAX_TITLE_CHARS, MAX_UNCLEARED_BLOCKERS_PER_ITEM,
 };
 use std::collections::BTreeMap;
 use std::io::Write;
@@ -38,7 +39,7 @@ pub(crate) enum AgendaError {
 /// preserved on disk but skipped at load (forward compatibility: a newer
 /// build's vocabulary — effects, journal curation — must not brick an older
 /// daemon's ledger).
-const KNOWN_OPS: [&str; 11] = [
+const KNOWN_OPS: [&str; 16] = [
     "add",
     "patch",
     "complete",
@@ -46,6 +47,11 @@ const KNOWN_OPS: [&str; 11] = [
     "retire",
     "answer",
     "dismiss",
+    "annotate",
+    "set_blocker",
+    "clear_blocker",
+    "add_relies_on",
+    "remove_relies_on",
     "propose_effect",
     "approve_effect",
     "revoke_effect",
@@ -234,7 +240,7 @@ impl AgendaStore {
             return self.apply_ask(questions, actor, now_ms);
         }
         let deletes_blobs = matches!(&cmd, AgendaCommand::Retire { .. });
-        let op = self.command_to_op(cmd)?;
+        let op = self.command_to_op(cmd, now_ms)?;
         let item = self.append_op(op, actor, source, now_ms)?;
         // Retention is tied to the item lifecycle: preview blobs die with
         // RETIREMENT — not completion, because answered questions remain
@@ -452,7 +458,7 @@ impl AgendaStore {
             .ok_or_else(|| AgendaError::Invalid("internal: item missing after fold".into()))
     }
 
-    fn command_to_op(&mut self, cmd: AgendaCommand) -> Result<AgendaOp, AgendaError> {
+    fn command_to_op(&mut self, cmd: AgendaCommand, now_ms: u64) -> Result<AgendaOp, AgendaError> {
         // `source` is detached (and validated) in `apply_command` before the
         // translation — the remaining fields are the op's.
         match cmd {
@@ -592,6 +598,153 @@ impl AgendaStore {
                         orchestrate,
                     },
                 })
+            }
+            AgendaCommand::Annotate {
+                id,
+                text,
+                source: _,
+            } => {
+                let item = self.require(&id)?;
+                let text = text.trim();
+                if text.is_empty() {
+                    return Err(AgendaError::Invalid("annotation must not be empty".into()));
+                }
+                if text.len() > MAX_BODY_BYTES {
+                    return Err(AgendaError::Invalid(format!(
+                        "annotation exceeds {MAX_BODY_BYTES} bytes"
+                    )));
+                }
+                // The steward-ruled pathology rail — not a budget (weekly
+                // housekeeping ≈ 52/item/year).
+                if item.annotations.len() >= MAX_ANNOTATIONS_PER_ITEM {
+                    return Err(AgendaError::Invalid(format!(
+                        "item has {MAX_ANNOTATIONS_PER_ITEM} annotations — retire it or start \
+                         a successor item"
+                    )));
+                }
+                Ok(AgendaOp::Annotate {
+                    id,
+                    text: text.to_string(),
+                })
+            }
+            AgendaCommand::SetBlocker {
+                id,
+                criterion,
+                source: _,
+            } => {
+                let item = self.require(&id)?;
+                if item.status != AgendaStatus::Open {
+                    return Err(AgendaError::Transition(format!(
+                        "{id} is not open — blockers describe open work"
+                    )));
+                }
+                let criterion = criterion.trim();
+                if criterion.is_empty() {
+                    return Err(AgendaError::Invalid("criterion must not be empty".into()));
+                }
+                if criterion.chars().count() > MAX_CRITERION_CHARS {
+                    return Err(AgendaError::Invalid(format!(
+                        "criterion exceeds {MAX_CRITERION_CHARS} characters"
+                    )));
+                }
+                let uncleared = item.blockers.iter().filter(|b| b.cleared.is_none());
+                if uncleared.clone().any(|b| b.criterion == criterion) {
+                    return Err(AgendaError::Transition(format!(
+                        "{id} is already blocked on exactly this criterion"
+                    )));
+                }
+                if uncleared.count() >= MAX_UNCLEARED_BLOCKERS_PER_ITEM {
+                    return Err(AgendaError::Invalid(format!(
+                        "more than {MAX_UNCLEARED_BLOCKERS_PER_ITEM} uncleared blockers"
+                    )));
+                }
+                // Intake-minted, recorded in the op — replay never mints
+                // (§7 purity). The at_ms preimage makes same-criterion
+                // re-blocks (after a clear) distinct; a same-millisecond
+                // duplicate is refused above as an identical criterion.
+                let blocker_id = mint_blocker_id(&id, criterion, now_ms);
+                if item.blockers.iter().any(|b| b.blocker_id == blocker_id) {
+                    return Err(AgendaError::Invalid(
+                        "blocker id collision — retry the command".into(),
+                    ));
+                }
+                Ok(AgendaOp::SetBlocker {
+                    id,
+                    blocker_id,
+                    criterion: criterion.to_string(),
+                })
+            }
+            AgendaCommand::ClearBlocker {
+                id,
+                blocker_id,
+                source: _,
+            } => {
+                let item = self.require(&id)?;
+                // Any item status: clearing history on a done item is a
+                // legitimate bookkeeping act.
+                let needle = blocker_id.trim();
+                let mut matches = item
+                    .blockers
+                    .iter()
+                    .filter(|b| b.cleared.is_none() && b.blocker_id.starts_with(needle));
+                let Some(blocker) = matches.next() else {
+                    return Err(AgendaError::NotFound(format!(
+                        "no uncleared blocker matching {needle:?} on {id}"
+                    )));
+                };
+                if matches.next().is_some() {
+                    return Err(AgendaError::Invalid(format!(
+                        "blocker prefix {needle:?} is ambiguous on {id}"
+                    )));
+                }
+                Ok(AgendaOp::ClearBlocker {
+                    id: id.clone(),
+                    blocker_id: blocker.blocker_id.clone(),
+                })
+            }
+            AgendaCommand::AddReliesOn {
+                id,
+                target_id,
+                source: _,
+            } => {
+                let item = self.require(&id)?;
+                if item.status != AgendaStatus::Open {
+                    return Err(AgendaError::Transition(format!(
+                        "{id} is not open — dependencies describe open work"
+                    )));
+                }
+                let target_id = target_id.trim().to_string();
+                if target_id == id {
+                    return Err(AgendaError::Invalid("an item cannot rely on itself".into()));
+                }
+                // The target must exist NOW (intake strictness); the fold
+                // stays tolerant of dangling edges in foreign logs.
+                self.require(&target_id)?;
+                if item.relies_on.iter().any(|e| e.target_id == target_id) {
+                    return Err(AgendaError::Transition(format!(
+                        "{id} already relies on {target_id}"
+                    )));
+                }
+                if item.relies_on.len() >= MAX_RELIES_ON_PER_ITEM {
+                    return Err(AgendaError::Invalid(format!(
+                        "more than {MAX_RELIES_ON_PER_ITEM} dependencies"
+                    )));
+                }
+                Ok(AgendaOp::AddReliesOn { id, target_id })
+            }
+            AgendaCommand::RemoveReliesOn {
+                id,
+                target_id,
+                source: _,
+            } => {
+                let item = self.require(&id)?;
+                let target_id = target_id.trim().to_string();
+                if !item.relies_on.iter().any(|e| e.target_id == target_id) {
+                    return Err(AgendaError::NotFound(format!(
+                        "{id} has no live dependency on {target_id}"
+                    )));
+                }
+                Ok(AgendaOp::RemoveReliesOn { id, target_id })
             }
             AgendaCommand::ApproveEffect { id, digest } => {
                 let item = self.require(&id)?;
@@ -753,6 +906,29 @@ fn parse_record(line: &str) -> Result<AgendaOpRecord, String> {
         return Err(format!("unknown op type {op_type:?}"));
     }
     serde_json::from_value(value).map_err(|err| format!("malformed {op_type} op: {err}"))
+}
+
+/// The ruled blocker-id shape (F2 vocabulary):
+/// `"bk-" + first 12 hex of sha256("agenda-blocker\0" item "\0" criterion
+/// "\0" at_ms)`. Minted once at intake and recorded in the op — replay
+/// never mints (§7 purity, same discipline as `effect_id`).
+fn mint_blocker_id(item_id: &str, criterion: &str, at_ms: u64) -> String {
+    use sha2::Digest;
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(b"agenda-blocker\0");
+    hasher.update(item_id.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(criterion.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(at_ms.to_string().as_bytes());
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(15);
+    hex.push_str("bk-");
+    for byte in digest.iter().take(6) {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{byte:02x}");
+    }
+    hex
 }
 
 /// The self-described `--source` label: trimmed, bounded, present-or-absent
@@ -1370,6 +1546,258 @@ mod tests {
         assert_eq!(store.snapshot().len(), 1);
         assert_eq!(store.ops(), 1);
         assert_eq!(store.skipped_lines(), 3);
+        // The skipped lines are preserved on disk verbatim, not repaired
+        // away — a newer build folds them later.
+        let raw = std::fs::read_to_string(store.log_path()).unwrap();
+        assert!(raw.contains(r#""type":"propose_effect""#));
+    }
+
+    /// F2 intake strictness + persistence: the five thread/gate verbs
+    /// validate at intake (empty/oversized text, non-open items for
+    /// set_blocker/add_relies_on, duplicates, self-edges, missing targets,
+    /// caps), mint blocker ids server-side, and the folded state survives
+    /// a store reopen. The forward-compat property (older builds
+    /// skip-and-preserve unknown vocabulary) keeps holding for whatever
+    /// comes after F2.
+    #[test]
+    fn f2_verbs_are_strict_at_intake_and_persist() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = AgendaStore::open(dir.path()).unwrap();
+        let a = store.apply_command(add_cmd("dependent"), None, 1).unwrap();
+        let b = store
+            .apply_command(add_cmd("prerequisite"), None, 2)
+            .unwrap();
+
+        // Annotate: empty and unknown-item rejected; a real one lands with
+        // the envelope source.
+        assert!(matches!(
+            store.apply_command(
+                AgendaCommand::Annotate {
+                    id: a.id.clone(),
+                    text: "   ".into(),
+                    source: None,
+                },
+                None,
+                3,
+            ),
+            Err(AgendaError::Invalid(_))
+        ));
+        assert!(matches!(
+            store.apply_command(
+                AgendaCommand::Annotate {
+                    id: "01UNKNOWN".into(),
+                    text: "x".into(),
+                    source: None,
+                },
+                None,
+                3,
+            ),
+            Err(AgendaError::NotFound(_))
+        ));
+        let annotated = store
+            .apply_command(
+                AgendaCommand::Annotate {
+                    id: a.id.clone(),
+                    text: "waiting on the API rollout".into(),
+                    source: Some("deploy-hook".into()),
+                },
+                None,
+                4,
+            )
+            .unwrap();
+        assert_eq!(annotated.annotations.len(), 1);
+        assert_eq!(
+            annotated.annotations[0].source.as_deref(),
+            Some("deploy-hook")
+        );
+
+        // SetBlocker: open-only, bounded criterion, duplicate criterion
+        // refused, id minted server-side (bk- prefix).
+        let blocked = store
+            .apply_command(
+                AgendaCommand::SetBlocker {
+                    id: a.id.clone(),
+                    criterion: "gpt-live-1 available on the API".into(),
+                    source: None,
+                },
+                None,
+                5,
+            )
+            .unwrap();
+        let blocker_id = blocked.blockers[0].blocker_id.clone();
+        assert!(blocker_id.starts_with("bk-") && blocker_id.len() == 15);
+        assert!(matches!(
+            store.apply_command(
+                AgendaCommand::SetBlocker {
+                    id: a.id.clone(),
+                    criterion: "gpt-live-1 available on the API".into(),
+                    source: None,
+                },
+                None,
+                6,
+            ),
+            Err(AgendaError::Transition(_))
+        ));
+        assert!(matches!(
+            store.apply_command(
+                AgendaCommand::SetBlocker {
+                    id: a.id.clone(),
+                    criterion: "c".repeat(MAX_CRITERION_CHARS + 1),
+                    source: None,
+                },
+                None,
+                6,
+            ),
+            Err(AgendaError::Invalid(_))
+        ));
+
+        // AddReliesOn: self-edge, missing target, duplicate all refused.
+        assert!(matches!(
+            store.apply_command(
+                AgendaCommand::AddReliesOn {
+                    id: a.id.clone(),
+                    target_id: a.id.clone(),
+                    source: None,
+                },
+                None,
+                7,
+            ),
+            Err(AgendaError::Invalid(_))
+        ));
+        assert!(matches!(
+            store.apply_command(
+                AgendaCommand::AddReliesOn {
+                    id: a.id.clone(),
+                    target_id: "01UNKNOWN".into(),
+                    source: None,
+                },
+                None,
+                7,
+            ),
+            Err(AgendaError::NotFound(_))
+        ));
+        store
+            .apply_command(
+                AgendaCommand::AddReliesOn {
+                    id: a.id.clone(),
+                    target_id: b.id.clone(),
+                    source: None,
+                },
+                None,
+                8,
+            )
+            .unwrap();
+        assert!(matches!(
+            store.apply_command(
+                AgendaCommand::AddReliesOn {
+                    id: a.id.clone(),
+                    target_id: b.id.clone(),
+                    source: None,
+                },
+                None,
+                9,
+            ),
+            Err(AgendaError::Transition(_))
+        ));
+
+        // ClearBlocker resolves a unique prefix to the full id at intake
+        // (the durable op carries the exact id); RemoveReliesOn needs a
+        // live edge.
+        let cleared = store
+            .apply_command(
+                AgendaCommand::ClearBlocker {
+                    id: a.id.clone(),
+                    blocker_id: blocker_id[..6].to_string(),
+                    source: None,
+                },
+                None,
+                10,
+            )
+            .unwrap();
+        assert!(cleared.blockers[0].cleared.is_some());
+        assert!(matches!(
+            store.apply_command(
+                AgendaCommand::ClearBlocker {
+                    id: a.id.clone(),
+                    blocker_id,
+                    source: None,
+                },
+                None,
+                11,
+            ),
+            Err(AgendaError::NotFound(_)),
+        ));
+        store
+            .apply_command(
+                AgendaCommand::RemoveReliesOn {
+                    id: a.id.clone(),
+                    target_id: b.id.clone(),
+                    source: None,
+                },
+                None,
+                12,
+            )
+            .unwrap();
+        assert!(matches!(
+            store.apply_command(
+                AgendaCommand::RemoveReliesOn {
+                    id: a.id.clone(),
+                    target_id: b.id.clone(),
+                    source: None,
+                },
+                None,
+                13,
+            ),
+            Err(AgendaError::NotFound(_))
+        ));
+
+        // Blocking a completed item is a transition error.
+        store
+            .apply_command(
+                AgendaCommand::Complete {
+                    id: b.id.clone(),
+                    source: None,
+                },
+                None,
+                14,
+            )
+            .unwrap();
+        assert!(matches!(
+            store.apply_command(
+                AgendaCommand::SetBlocker {
+                    id: b.id.clone(),
+                    criterion: "too late".into(),
+                    source: None,
+                },
+                None,
+                15,
+            ),
+            Err(AgendaError::Transition(_))
+        ));
+        // …but annotating it is fine (housekeeping annotates without
+        // disposing).
+        store
+            .apply_command(
+                AgendaCommand::Annotate {
+                    id: b.id.clone(),
+                    text: "post-completion evidence".into(),
+                    source: None,
+                },
+                None,
+                16,
+            )
+            .unwrap();
+
+        // Reopen the store: thread, blocker history (cleared entry kept),
+        // and the removed edge all replay exactly.
+        drop(store);
+        let store = AgendaStore::open(dir.path()).unwrap();
+        let a_re = store.get(&a.id).unwrap();
+        assert_eq!(a_re.annotations.len(), 1);
+        assert_eq!(a_re.blockers.len(), 1);
+        assert!(a_re.blockers[0].cleared.is_some());
+        assert!(a_re.relies_on.is_empty());
+        assert_eq!(store.get(&b.id).unwrap().annotations.len(), 1);
     }
 
     fn ask_question(text: &str) -> crate::mcp::AskUserQuestionParams {

--- a/src/bin/caller/agenda/types.rs
+++ b/src/bin/caller/agenda/types.rs
@@ -11,6 +11,13 @@ pub(crate) const MAX_BODY_BYTES: usize = 64 * 1024;
 pub(crate) const MAX_TAGS: usize = 32;
 pub(crate) const MAX_TAG_CHARS: usize = 100;
 pub(crate) const MAX_SOURCE_CHARS: usize = 100;
+/// F2 caps (steward-ruled 2026-07-20): annotations got an explicit intake
+/// cap — the one otherwise-unbounded DTO surface (weekly housekeeping ≈
+/// 52/item/year; 500 is a pathology rail, not a budget).
+pub(crate) const MAX_ANNOTATIONS_PER_ITEM: usize = 500;
+pub(crate) const MAX_UNCLEARED_BLOCKERS_PER_ITEM: usize = 32;
+pub(crate) const MAX_RELIES_ON_PER_ITEM: usize = 32;
+pub(crate) const MAX_CRITERION_CHARS: usize = 1000;
 
 /// What an agenda entry is. Kinds and effects are orthogonal: no kind
 /// implies any delivery or execution behavior. `Question` (slice A4) is a
@@ -326,6 +333,100 @@ pub struct AgendaItem {
     /// by `answer` and `reopen`; never a lifecycle transition.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) dismissed: Option<AgendaDismissal>,
+    /// Attributed note thread (F2 `annotate`), full history in fold order —
+    /// render caps with an expander. Notes are data, never instructions.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) annotations: Vec<AgendaAnnotation>,
+    /// Blockers (F2): human-stated criteria, never evaluated by machinery.
+    /// Cleared entries STAY as the evidence trail — clears are ops.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) blockers: Vec<AgendaBlocker>,
+    /// Live dependency edges (F2 `relies_on`). Removal drops the edge from
+    /// this view; the log keeps the full add/remove history. Satisfaction
+    /// and the blocked chip are derived at RENDER time, never stored or
+    /// wired.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) relies_on: Vec<AgendaDependency>,
+}
+
+/// One attributed note on an item (F2 `annotate` fold view). Attribution
+/// mirrors [`AgendaActor`] + the envelope's self-described `source` label
+/// (which supplements, never replaces, gate attribution — steward ruling
+/// Q2).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgendaAnnotation {
+    /// The note — data, never instructions (bodies doctrine).
+    pub(crate) text: String,
+    pub(crate) at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) principal: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) source: Option<String>,
+}
+
+/// One blocker (F2 fold view): criterion text stated by whoever set it,
+/// with set/cleared attribution. NO evaluation machinery exists — the
+/// owner clears from the card; agents clear only under an explicit
+/// mandate (conduct doctrine, not an IAM gate — steward ruling Q3).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgendaBlocker {
+    /// Intake-minted stable id (`bk-…`), recorded in the op — replay never
+    /// mints.
+    pub(crate) blocker_id: String,
+    /// The blocking criterion — data describing the world, never a
+    /// condition any component evaluates.
+    pub(crate) criterion: String,
+    pub(crate) set_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) principal: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) source: Option<String>,
+    /// Set by `clear_blocker` — the cleared entry remains rendered
+    /// history (clears are ops, never deletions).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) cleared: Option<AgendaBlockerClear>,
+}
+
+/// The clearing act's attribution (F2 `clear_blocker` fold view).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgendaBlockerClear {
+    pub(crate) at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) principal: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) source: Option<String>,
+}
+
+/// One live dependency edge (F2 `relies_on` fold view). Satisfaction is
+/// derived at render time from the target's status — a completed target
+/// satisfies; a retired target does NOT silently satisfy (renders a
+/// "prerequisite retired — review" marker); cycles simply render every
+/// member blocked. Nothing evaluates, nothing fires.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgendaDependency {
+    /// The prerequisite item's id.
+    pub(crate) target_id: String,
+    pub(crate) added_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) principal: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) source: Option<String>,
 }
 
 /// Field-level patch of presentation state (umbrella RFC §7.2: `Patch`
@@ -461,6 +562,50 @@ pub enum AgendaCommand {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         source: Option<String>,
     },
+    /// Append an attributed, timestamped note to any item, any status —
+    /// the thread under it (A4's answer op generalized). Notes are data,
+    /// never instructions; history is the full log, render caps with an
+    /// expander.
+    Annotate {
+        id: String,
+        text: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        source: Option<String>,
+    },
+    /// State a blocking criterion on an open item. Plain text about the
+    /// world — NO watcher, poller, or condition language ever evaluates
+    /// it. The daemon mints the blocker id at intake.
+    SetBlocker {
+        id: String,
+        criterion: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        source: Option<String>,
+    },
+    /// Clear one blocker — an op, never a deletion: the entry stays as
+    /// history with the clearing actor. Plain `agenda.write` (the owner
+    /// decision governs agent CONDUCT via mandate text, not capability).
+    ClearBlocker {
+        id: String,
+        blocker_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        source: Option<String>,
+    },
+    /// Add a dependency edge: this item relies on `target_id`.
+    /// Satisfaction is derived at render time from the target's status —
+    /// nothing evaluates, nothing fires.
+    AddReliesOn {
+        id: String,
+        target_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        source: Option<String>,
+    },
+    /// Remove a live dependency edge (an op; the log keeps history).
+    RemoveReliesOn {
+        id: String,
+        target_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        source: Option<String>,
+    },
     /// Approve the current manifest revision by its digest. **An
     /// owner-surface act** — the tenant edge refuses agent-session, peer,
     /// and unattributed actors with a named denial.
@@ -502,7 +647,12 @@ impl AgendaCommand {
             | AgendaCommand::Reopen { source, .. }
             | AgendaCommand::Retire { source, .. }
             | AgendaCommand::Answer { source, .. }
-            | AgendaCommand::ProposeEffect { source, .. } => source.take(),
+            | AgendaCommand::ProposeEffect { source, .. }
+            | AgendaCommand::Annotate { source, .. }
+            | AgendaCommand::SetBlocker { source, .. }
+            | AgendaCommand::ClearBlocker { source, .. }
+            | AgendaCommand::AddReliesOn { source, .. }
+            | AgendaCommand::RemoveReliesOn { source, .. } => source.take(),
             AgendaCommand::Ask { .. }
             | AgendaCommand::ApproveEffect { .. }
             | AgendaCommand::RevokeEffect { .. } => None,
@@ -566,6 +716,33 @@ pub(crate) enum AgendaOp {
         #[serde(default, skip_serializing_if = "String::is_empty")]
         action: String,
     },
+    /// Attributed note (F2). Attribution + `source` ride the envelope.
+    Annotate {
+        id: String,
+        text: String,
+    },
+    /// Blocker set (F2): `blocker_id` was minted at intake and is recorded
+    /// here — replay never mints.
+    SetBlocker {
+        id: String,
+        blocker_id: String,
+        criterion: String,
+    },
+    /// Blocker cleared (F2): an op, never a deletion.
+    ClearBlocker {
+        id: String,
+        blocker_id: String,
+    },
+    /// Dependency edge added (F2).
+    AddReliesOn {
+        id: String,
+        target_id: String,
+    },
+    /// Dependency edge removed (F2): drops the view edge; history stays.
+    RemoveReliesOn {
+        id: String,
+        target_id: String,
+    },
     ProposeEffect {
         id: String,
         effect_id: String,
@@ -605,6 +782,11 @@ impl AgendaOp {
             | AgendaOp::Retire { id }
             | AgendaOp::Answer { id, .. }
             | AgendaOp::Dismiss { id, .. }
+            | AgendaOp::Annotate { id, .. }
+            | AgendaOp::SetBlocker { id, .. }
+            | AgendaOp::ClearBlocker { id, .. }
+            | AgendaOp::AddReliesOn { id, .. }
+            | AgendaOp::RemoveReliesOn { id, .. }
             | AgendaOp::ProposeEffect { id, .. }
             | AgendaOp::ApproveEffect { id, .. }
             | AgendaOp::RevokeEffect { id, .. }
@@ -691,8 +873,117 @@ pub(crate) fn apply_op(
                     effects: Vec::new(),
                     ask: ask.clone(),
                     dismissed: None,
+                    annotations: Vec::new(),
+                    blockers: Vec::new(),
+                    relies_on: Vec::new(),
                 },
             );
+            None
+        }
+        AgendaOp::Annotate { id, text } => {
+            let Some(item) = items.get_mut(id) else {
+                return Some(format!("annotate for unknown {id} ignored"));
+            };
+            let actor = rec.actor.clone().unwrap_or_default();
+            item.annotations.push(AgendaAnnotation {
+                text: text.clone(),
+                at_ms,
+                principal: actor.principal,
+                session_id: actor.session_id,
+                kind: actor.kind,
+                source: rec.source.clone(),
+            });
+            item.updated_ms = at_ms;
+            None
+        }
+        AgendaOp::SetBlocker {
+            id,
+            blocker_id,
+            criterion,
+        } => {
+            let Some(item) = items.get_mut(id) else {
+                return Some(format!("set_blocker for unknown {id} ignored"));
+            };
+            if item.blockers.iter().any(|b| b.blocker_id == *blocker_id) {
+                return Some(format!("duplicate blocker {blocker_id} on {id} ignored"));
+            }
+            let actor = rec.actor.clone().unwrap_or_default();
+            item.blockers.push(AgendaBlocker {
+                blocker_id: blocker_id.clone(),
+                criterion: criterion.clone(),
+                set_ms: at_ms,
+                principal: actor.principal,
+                session_id: actor.session_id,
+                kind: actor.kind,
+                source: rec.source.clone(),
+                cleared: None,
+            });
+            item.updated_ms = at_ms;
+            None
+        }
+        AgendaOp::ClearBlocker { id, blocker_id } => {
+            let Some(item) = items.get_mut(id) else {
+                return Some(format!("clear_blocker for unknown {id} ignored"));
+            };
+            let Some(blocker) = item
+                .blockers
+                .iter_mut()
+                .find(|b| b.blocker_id == *blocker_id)
+            else {
+                return Some(format!(
+                    "clear_blocker for unknown {blocker_id} on {id} ignored"
+                ));
+            };
+            if blocker.cleared.is_some() {
+                return Some(format!("blocker {blocker_id} on {id} already cleared"));
+            }
+            let actor = rec.actor.clone().unwrap_or_default();
+            blocker.cleared = Some(AgendaBlockerClear {
+                at_ms,
+                principal: actor.principal,
+                session_id: actor.session_id,
+                kind: actor.kind,
+                source: rec.source.clone(),
+            });
+            item.updated_ms = at_ms;
+            None
+        }
+        AgendaOp::AddReliesOn { id, target_id } => {
+            let Some(item) = items.get_mut(id) else {
+                return Some(format!("add_relies_on for unknown {id} ignored"));
+            };
+            if target_id == id {
+                return Some(format!("self-edge on {id} ignored"));
+            }
+            if item.relies_on.iter().any(|e| e.target_id == *target_id) {
+                return Some(format!("duplicate edge {id}→{target_id} ignored"));
+            }
+            // A target missing from this fold (partial/foreign replay) is
+            // tolerated — the render marks the edge "prerequisite missing".
+            let actor = rec.actor.clone().unwrap_or_default();
+            item.relies_on.push(AgendaDependency {
+                target_id: target_id.clone(),
+                added_ms: at_ms,
+                principal: actor.principal,
+                session_id: actor.session_id,
+                kind: actor.kind,
+                source: rec.source.clone(),
+            });
+            item.updated_ms = at_ms;
+            None
+        }
+        AgendaOp::RemoveReliesOn { id, target_id } => {
+            let Some(item) = items.get_mut(id) else {
+                return Some(format!("remove_relies_on for unknown {id} ignored"));
+            };
+            let before = item.relies_on.len();
+            item.relies_on.retain(|e| e.target_id != *target_id);
+            if item.relies_on.len() == before {
+                return Some(format!(
+                    "remove_relies_on for absent edge {id}→{target_id} ignored"
+                ));
+            }
+            item.updated_ms = at_ms;
             None
         }
         AgendaOp::Patch { id, patch } => {
@@ -917,6 +1208,47 @@ pub(crate) fn apply_op(
             }
         }
     }
+}
+
+/// Render-time judgment of one dependency edge: `(satisfied, review)`.
+/// A completed target satisfies; a retired target does NOT silently
+/// satisfy (review `"target_retired"`); a target absent from the fold —
+/// foreign/partial replay — is review `"target_missing"`. Direct status
+/// lookup only: cycles need no machinery (every member of a cycle has a
+/// non-Done target and simply derives blocked), nothing walks, nothing
+/// evaluates, nothing fires.
+///
+/// This is presentation, deliberately NOT a stored or wire field (the DTO
+/// stays the pure fold product — the D0-Agenda-Data migration replays the
+/// log verbatim). The dashboard and ctl derive the same judgment from the
+/// serialized items like the overdue chip; this typed twin exists to PIN
+/// the semantics in unit tests (the retire-review and cycle rules).
+#[cfg(test)]
+pub(crate) fn dependency_state(
+    items: &BTreeMap<String, AgendaItem>,
+    edge: &AgendaDependency,
+) -> (bool, Option<&'static str>) {
+    match items.get(&edge.target_id) {
+        None => (false, Some("target_missing")),
+        Some(target) => match target.status {
+            AgendaStatus::Done => (true, None),
+            AgendaStatus::Retired => (false, Some("target_retired")),
+            AgendaStatus::Open => (false, None),
+        },
+    }
+}
+
+/// Render-time blocked judgment: an open item with any uncleared blocker
+/// or any unsatisfied live dependency. Never stored, never on the wire,
+/// never notifies — A3's time lane remains the only thing that fires.
+#[cfg(test)]
+pub(crate) fn is_blocked(items: &BTreeMap<String, AgendaItem>, item: &AgendaItem) -> bool {
+    item.status == AgendaStatus::Open
+        && (item.blockers.iter().any(|b| b.cleared.is_none())
+            || item
+                .relies_on
+                .iter()
+                .any(|edge| !dependency_state(items, edge).0))
 }
 
 pub(crate) fn counts(items: &BTreeMap<String, AgendaItem>) -> AgendaCounts {
@@ -1326,6 +1658,433 @@ mod tests {
         let answer: AgendaCommand =
             serde_json::from_str(r#"{"op":"answer","id":"01X","text":"yes"}"#).unwrap();
         assert!(matches!(answer, AgendaCommand::Answer { .. }));
+    }
+
+    /// F2 fold: annotations thread (any status), blockers with
+    /// clear-is-an-op history, edges with add/remove, and full tolerance
+    /// for out-of-order or foreign lines.
+    #[test]
+    fn f2_fold_annotations_blockers_edges() {
+        let mut items = BTreeMap::new();
+        apply_op(&mut items, &rec(1, add("a", "dependent")));
+        apply_op(&mut items, &rec(2, add("b", "prerequisite")));
+
+        // Annotations: attributed thread, allowed on done items too.
+        let mut note = rec(
+            3,
+            AgendaOp::Annotate {
+                id: "a".into(),
+                text: "evidence: still waiting on the API".into(),
+            },
+        );
+        note.actor = Some(AgendaActor {
+            principal: None,
+            session_id: Some("sess-1".into()),
+            kind: Some("agent_session".into()),
+        });
+        note.source = Some("housekeeper".into());
+        assert!(apply_op(&mut items, &note).is_none());
+        apply_op(&mut items, &rec(4, AgendaOp::Complete { id: "b".into() }));
+        assert!(apply_op(
+            &mut items,
+            &rec(
+                5,
+                AgendaOp::Annotate {
+                    id: "b".into(),
+                    text: "post-completion note".into()
+                }
+            )
+        )
+        .is_none());
+        let a = &items["a"];
+        assert_eq!(a.annotations.len(), 1);
+        assert_eq!(a.annotations[0].session_id.as_deref(), Some("sess-1"));
+        assert_eq!(a.annotations[0].source.as_deref(), Some("housekeeper"));
+        assert_eq!(items["b"].annotations.len(), 1);
+        // Unknown item: warn, keep going.
+        assert!(apply_op(
+            &mut items,
+            &rec(
+                6,
+                AgendaOp::Annotate {
+                    id: "nope".into(),
+                    text: "x".into()
+                }
+            )
+        )
+        .is_some());
+
+        // Blockers: set, duplicate-id warn, clear-is-an-op (entry stays),
+        // double-clear warn.
+        assert!(apply_op(
+            &mut items,
+            &rec(
+                7,
+                AgendaOp::SetBlocker {
+                    id: "a".into(),
+                    blocker_id: "bk-000000000001".into(),
+                    criterion: "gpt-live-1 available on the API".into(),
+                }
+            )
+        )
+        .is_none());
+        assert!(apply_op(
+            &mut items,
+            &rec(
+                8,
+                AgendaOp::SetBlocker {
+                    id: "a".into(),
+                    blocker_id: "bk-000000000001".into(),
+                    criterion: "duplicate".into(),
+                }
+            )
+        )
+        .is_some());
+        let mut clear = rec(
+            9,
+            AgendaOp::ClearBlocker {
+                id: "a".into(),
+                blocker_id: "bk-000000000001".into(),
+            },
+        );
+        clear.actor = Some(AgendaActor {
+            principal: Some("principal:root:dashboard".into()),
+            session_id: None,
+            kind: Some("dashboard".into()),
+        });
+        assert!(apply_op(&mut items, &clear).is_none());
+        let blocker = &items["a"].blockers[0];
+        assert_eq!(blocker.criterion, "gpt-live-1 available on the API");
+        let cleared = blocker.cleared.as_ref().expect("clear recorded");
+        assert_eq!(cleared.kind.as_deref(), Some("dashboard"));
+        assert!(apply_op(&mut items, &clear).is_some(), "double clear warns");
+        assert_eq!(items["a"].blockers.len(), 1, "history is never deleted");
+
+        // Edges: add, self-edge warn, duplicate warn, remove drops the
+        // view (log history is the caller's record).
+        assert!(apply_op(
+            &mut items,
+            &rec(
+                10,
+                AgendaOp::AddReliesOn {
+                    id: "a".into(),
+                    target_id: "b".into()
+                }
+            )
+        )
+        .is_none());
+        assert!(apply_op(
+            &mut items,
+            &rec(
+                11,
+                AgendaOp::AddReliesOn {
+                    id: "a".into(),
+                    target_id: "a".into()
+                }
+            )
+        )
+        .is_some());
+        assert!(apply_op(
+            &mut items,
+            &rec(
+                12,
+                AgendaOp::AddReliesOn {
+                    id: "a".into(),
+                    target_id: "b".into()
+                }
+            )
+        )
+        .is_some());
+        assert_eq!(items["a"].relies_on.len(), 1);
+        // Dangling target tolerated (foreign/partial log).
+        assert!(apply_op(
+            &mut items,
+            &rec(
+                13,
+                AgendaOp::AddReliesOn {
+                    id: "a".into(),
+                    target_id: "01GONE".into()
+                }
+            )
+        )
+        .is_none());
+        assert!(apply_op(
+            &mut items,
+            &rec(
+                14,
+                AgendaOp::RemoveReliesOn {
+                    id: "a".into(),
+                    target_id: "01GONE".into()
+                }
+            )
+        )
+        .is_none());
+        assert!(
+            apply_op(
+                &mut items,
+                &rec(
+                    15,
+                    AgendaOp::RemoveReliesOn {
+                        id: "a".into(),
+                        target_id: "01GONE".into()
+                    }
+                )
+            )
+            .is_some(),
+            "removing an absent edge warns"
+        );
+        assert_eq!(items["a"].relies_on.len(), 1);
+        assert_eq!(items["a"].relies_on[0].target_id, "b");
+    }
+
+    /// Pins the five F2 durable line formats (additive to v1) and their
+    /// round-trips — the migration story is "these exact bytes replay".
+    #[test]
+    fn f2_op_line_formats_are_pinned() {
+        let annotate = AgendaOpRecord {
+            v: 1,
+            at_ms: 20,
+            actor: Some(AgendaActor {
+                principal: None,
+                session_id: Some("sess-9".into()),
+                kind: Some("agent_session".into()),
+            }),
+            source: None,
+            op: AgendaOp::Annotate {
+                id: "01X".into(),
+                text: "note".into(),
+            },
+        };
+        let line = serde_json::to_string(&annotate).unwrap();
+        assert_eq!(
+            line,
+            r#"{"v":1,"at_ms":20,"actor":{"session_id":"sess-9","kind":"agent_session"},"op":{"type":"annotate","id":"01X","text":"note"}}"#
+        );
+        assert_eq!(
+            serde_json::from_str::<AgendaOpRecord>(&line).unwrap(),
+            annotate
+        );
+
+        for (record, expected) in [
+            (
+                AgendaOpRecord {
+                    v: 1,
+                    at_ms: 21,
+                    actor: None,
+                    source: Some("deploy-hook".into()),
+                    op: AgendaOp::SetBlocker {
+                        id: "01X".into(),
+                        blocker_id: "bk-0a1b2c3d4e5f".into(),
+                        criterion: "api access granted".into(),
+                    },
+                },
+                r#"{"v":1,"at_ms":21,"source":"deploy-hook","op":{"type":"set_blocker","id":"01X","blocker_id":"bk-0a1b2c3d4e5f","criterion":"api access granted"}}"#,
+            ),
+            (
+                AgendaOpRecord {
+                    v: 1,
+                    at_ms: 22,
+                    actor: None,
+                    source: None,
+                    op: AgendaOp::ClearBlocker {
+                        id: "01X".into(),
+                        blocker_id: "bk-0a1b2c3d4e5f".into(),
+                    },
+                },
+                r#"{"v":1,"at_ms":22,"op":{"type":"clear_blocker","id":"01X","blocker_id":"bk-0a1b2c3d4e5f"}}"#,
+            ),
+            (
+                AgendaOpRecord {
+                    v: 1,
+                    at_ms: 23,
+                    actor: None,
+                    source: None,
+                    op: AgendaOp::AddReliesOn {
+                        id: "01X".into(),
+                        target_id: "01Y".into(),
+                    },
+                },
+                r#"{"v":1,"at_ms":23,"op":{"type":"add_relies_on","id":"01X","target_id":"01Y"}}"#,
+            ),
+            (
+                AgendaOpRecord {
+                    v: 1,
+                    at_ms: 24,
+                    actor: None,
+                    source: None,
+                    op: AgendaOp::RemoveReliesOn {
+                        id: "01X".into(),
+                        target_id: "01Y".into(),
+                    },
+                },
+                r#"{"v":1,"at_ms":24,"op":{"type":"remove_relies_on","id":"01X","target_id":"01Y"}}"#,
+            ),
+        ] {
+            let line = serde_json::to_string(&record).unwrap();
+            assert_eq!(line, expected);
+            assert_eq!(
+                serde_json::from_str::<AgendaOpRecord>(&line).unwrap(),
+                record
+            );
+        }
+    }
+
+    #[test]
+    fn f2_command_wire_shapes_parse() {
+        for (json, ok) in [
+            (r#"{"op":"annotate","id":"01X","text":"n"}"#, true),
+            (
+                r#"{"op":"annotate","id":"01X","text":"n","source":"hook"}"#,
+                true,
+            ),
+            (r#"{"op":"set_blocker","id":"01X","criterion":"c"}"#, true),
+            (
+                r#"{"op":"clear_blocker","id":"01X","blocker_id":"bk-1"}"#,
+                true,
+            ),
+            (
+                r#"{"op":"add_relies_on","id":"01X","target_id":"01Y"}"#,
+                true,
+            ),
+            (
+                r#"{"op":"remove_relies_on","id":"01X","target_id":"01Y"}"#,
+                true,
+            ),
+            // Clients never mint blocker ids on set.
+            (
+                r#"{"op":"set_blocker","id":"01X","criterion":"c","blocker_id":"bk-forged"}"#,
+                false,
+            ),
+        ] {
+            assert_eq!(
+                serde_json::from_str::<AgendaCommand>(json).is_ok(),
+                ok,
+                "{json}"
+            );
+        }
+    }
+
+    /// The ruled derivation semantics: done satisfies; RETIRED does not
+    /// silently satisfy (review marker); missing target marks for review;
+    /// cycles derive blocked on every member without any walk; clearing
+    /// the last blocker unblocks; everything is pure recomputation.
+    #[test]
+    fn derived_blocked_retire_review_and_cycle_tolerance() {
+        let mut items = BTreeMap::new();
+        apply_op(&mut items, &rec(1, add("a", "dependent")));
+        apply_op(&mut items, &rec(2, add("b", "prerequisite")));
+        apply_op(
+            &mut items,
+            &rec(
+                3,
+                AgendaOp::AddReliesOn {
+                    id: "a".into(),
+                    target_id: "b".into(),
+                },
+            ),
+        );
+        assert!(is_blocked(&items, &items["a"]), "open target blocks");
+        assert!(!is_blocked(&items, &items["b"]));
+
+        // Completion satisfies by pure recomputation — no event fired.
+        apply_op(&mut items, &rec(4, AgendaOp::Complete { id: "b".into() }));
+        assert_eq!(
+            dependency_state(&items, &items["a"].relies_on[0]),
+            (true, None)
+        );
+        assert!(!is_blocked(&items, &items["a"]));
+
+        // Retire does NOT silently satisfy: review marker + blocked again.
+        apply_op(&mut items, &rec(5, AgendaOp::Reopen { id: "b".into() }));
+        apply_op(&mut items, &rec(6, AgendaOp::Retire { id: "b".into() }));
+        assert_eq!(
+            dependency_state(&items, &items["a"].relies_on[0]),
+            (false, Some("target_retired"))
+        );
+        assert!(is_blocked(&items, &items["a"]));
+
+        // Dangling edge (foreign/partial log): review, blocked, no error.
+        apply_op(
+            &mut items,
+            &rec(
+                7,
+                AgendaOp::AddReliesOn {
+                    id: "b".into(),
+                    target_id: "01GONE".into(),
+                },
+            ),
+        );
+        apply_op(&mut items, &rec(8, AgendaOp::Reopen { id: "b".into() }));
+        assert_eq!(
+            dependency_state(&items, &items["b"].relies_on[0]),
+            (false, Some("target_missing"))
+        );
+
+        // Cycle: c→d, d→c — both derive blocked, nothing recurses.
+        apply_op(&mut items, &rec(9, add("c", "one")));
+        apply_op(&mut items, &rec(10, add("d", "other")));
+        apply_op(
+            &mut items,
+            &rec(
+                11,
+                AgendaOp::AddReliesOn {
+                    id: "c".into(),
+                    target_id: "d".into(),
+                },
+            ),
+        );
+        apply_op(
+            &mut items,
+            &rec(
+                12,
+                AgendaOp::AddReliesOn {
+                    id: "d".into(),
+                    target_id: "c".into(),
+                },
+            ),
+        );
+        assert!(is_blocked(&items, &items["c"]));
+        assert!(is_blocked(&items, &items["d"]));
+
+        // Blockers: uncleared blocks, clearing the last one unblocks.
+        apply_op(&mut items, &rec(13, add("e", "solo")));
+        apply_op(
+            &mut items,
+            &rec(
+                14,
+                AgendaOp::SetBlocker {
+                    id: "e".into(),
+                    blocker_id: "bk-1".into(),
+                    criterion: "wait".into(),
+                },
+            ),
+        );
+        assert!(is_blocked(&items, &items["e"]));
+        apply_op(
+            &mut items,
+            &rec(
+                15,
+                AgendaOp::ClearBlocker {
+                    id: "e".into(),
+                    blocker_id: "bk-1".into(),
+                },
+            ),
+        );
+        assert!(!is_blocked(&items, &items["e"]));
+        // A done item is never "blocked" regardless of blockers.
+        apply_op(
+            &mut items,
+            &rec(
+                16,
+                AgendaOp::SetBlocker {
+                    id: "e".into(),
+                    blocker_id: "bk-2".into(),
+                    criterion: "wait more".into(),
+                },
+            ),
+        );
+        apply_op(&mut items, &rec(17, AgendaOp::Complete { id: "e".into() }));
+        assert!(!is_blocked(&items, &items["e"]));
     }
 
     #[test]

--- a/src/bin/caller/ctl.rs
+++ b/src/bin/caller/ctl.rs
@@ -2159,6 +2159,94 @@ async fn run_agenda(
         "complete" | "done" => agenda_transition(client, config, "complete", &raw[1..]).await?,
         "reopen" => agenda_transition(client, config, "reopen", &raw[1..]).await?,
         "retire" => agenda_transition(client, config, "retire", &raw[1..]).await?,
+        "annotate" => {
+            let args = parse_command_args(&raw[1..], &["--source"], &[])?;
+            let id = agenda_resolve_id(
+                client,
+                config,
+                &args,
+                "agenda annotate requires an item id (a unique prefix is enough)",
+            )
+            .await?;
+            let text = args.positional[1..].join(" ");
+            if text.trim().is_empty() {
+                return Err("agenda annotate requires the note text after the id".to_string());
+            }
+            let mut map = Map::new();
+            map.insert("op".to_string(), Value::String("annotate".to_string()));
+            map.insert("id".to_string(), Value::String(id));
+            map.insert("text".to_string(), Value::String(text));
+            insert_string(&mut map, "source", args.one("--source"));
+            let response = call_tool(client, config, "agenda_op", Value::Object(map)).await?;
+            print_tool_response(response, config, None)?;
+        }
+        "block" => {
+            let args = parse_command_args(&raw[1..], &["--source"], &[])?;
+            let id = agenda_resolve_id(
+                client,
+                config,
+                &args,
+                "agenda block requires an item id (a unique prefix is enough)",
+            )
+            .await?;
+            let criterion = args.positional[1..].join(" ");
+            if criterion.trim().is_empty() {
+                return Err("agenda block requires the blocking criterion after the id".to_string());
+            }
+            let mut map = Map::new();
+            map.insert("op".to_string(), Value::String("set_blocker".to_string()));
+            map.insert("id".to_string(), Value::String(id));
+            map.insert("criterion".to_string(), Value::String(criterion));
+            insert_string(&mut map, "source", args.one("--source"));
+            let response = call_tool(client, config, "agenda_op", Value::Object(map)).await?;
+            print_tool_response(response, config, None)?;
+        }
+        "unblock" => {
+            let args = parse_command_args(&raw[1..], &["--source"], &[])?;
+            let id = agenda_resolve_id(
+                client,
+                config,
+                &args,
+                "agenda unblock requires an item id (a unique prefix is enough)",
+            )
+            .await?;
+            // Blocker id prefix; with exactly one uncleared blocker the
+            // daemon accepts the empty prefix (matches everything).
+            let blocker = args.positional.get(1).cloned().unwrap_or_default();
+            let mut map = Map::new();
+            map.insert("op".to_string(), Value::String("clear_blocker".to_string()));
+            map.insert("id".to_string(), Value::String(id));
+            map.insert("blocker_id".to_string(), Value::String(blocker));
+            insert_string(&mut map, "source", args.one("--source"));
+            let response = call_tool(client, config, "agenda_op", Value::Object(map)).await?;
+            print_tool_response(response, config, None)?;
+        }
+        "relies-on" | "needs" => {
+            let args = parse_command_args(&raw[1..], &["--source"], &["--remove"])?;
+            let id = agenda_resolve_id(
+                client,
+                config,
+                &args,
+                "agenda relies-on requires the dependent item id first",
+            )
+            .await?;
+            let Some(target_raw) = args.positional.get(1) else {
+                return Err("agenda relies-on requires the prerequisite item id second".to_string());
+            };
+            let target = agenda_resolve_id_str(client, config, target_raw).await?;
+            let op = if args.has("--remove") {
+                "remove_relies_on"
+            } else {
+                "add_relies_on"
+            };
+            let mut map = Map::new();
+            map.insert("op".to_string(), Value::String(op.to_string()));
+            map.insert("id".to_string(), Value::String(id));
+            map.insert("target_id".to_string(), Value::String(target));
+            insert_string(&mut map, "source", args.one("--source"));
+            let response = call_tool(client, config, "agenda_op", Value::Object(map)).await?;
+            print_tool_response(response, config, None)?;
+        }
         "patch" | "edit" => {
             let args = parse_command_args(
                 &raw[1..],
@@ -2243,7 +2331,12 @@ async fn run_agenda_list(
     config: &Config,
     raw: &[String],
 ) -> Result<(), String> {
-    let args = parse_command_args(raw, &[], &["--all", "--open", "--done", "--retired"])?;
+    let args = parse_command_args(
+        raw,
+        &[],
+        &["--all", "--open", "--done", "--retired", "--blocked"],
+    )?;
+    let blocked_only = args.has("--blocked");
     let status = if args.has("--all") {
         None
     } else if args.has("--done") {
@@ -2252,6 +2345,7 @@ async fn run_agenda_list(
         Some("retired")
     } else {
         // Default to the working set; --open is accepted for symmetry.
+        // --blocked implies open (blocked is derived only on open items).
         Some("open")
     };
     let mut tool_args = Map::new();
@@ -2260,15 +2354,28 @@ async fn run_agenda_list(
         let response = call_tool(client, config, "agenda_list", Value::Object(tool_args)).await?;
         return print_tool_response(response, config, None);
     }
-    let (items, counts) = agenda_fetch(client, config, Value::Object(tool_args)).await?;
+    // Human rendering always fetches the full ledger: the blocked chip is
+    // derived at print time (never stored, never wired) and judging a
+    // dependency needs its target's status whatever the display filter.
+    let (all_items, counts) = agenda_fetch(client, config, Value::Object(Map::new())).await?;
+    let items: Vec<&Value> = all_items
+        .iter()
+        .filter(|item| {
+            let item_status = item.get("status").and_then(Value::as_str).unwrap_or("");
+            status.is_none_or(|s| item_status == s)
+                && (!blocked_only || agenda_item_is_blocked(&all_items, item))
+        })
+        .collect();
     if items.is_empty() {
-        match status {
-            Some(status) => println!("no {status} agenda items"),
-            None => println!("agenda is empty"),
+        match (blocked_only, status) {
+            (true, _) => println!("no blocked agenda items"),
+            (false, Some(status)) => println!("no {status} agenda items"),
+            (false, None) => println!("agenda is empty"),
         }
     }
     for item in &items {
-        println!("{}", agenda_render_row(item));
+        let blocked = agenda_item_is_blocked(&all_items, item);
+        println!("{}", agenda_render_row(item, blocked));
     }
     let open = counts.get("open").and_then(Value::as_u64).unwrap_or(0);
     let done = counts.get("done").and_then(Value::as_u64).unwrap_or(0);
@@ -2277,7 +2384,39 @@ async fn run_agenda_list(
     Ok(())
 }
 
-fn agenda_render_row(item: &Value) -> String {
+/// Print-time twin of the daemon's `agenda::is_blocked` derivation (the
+/// dashboard derives the same way): open + (uncleared blocker OR any live
+/// edge whose target is not done — missing and retired targets both count
+/// as unsatisfied).
+fn agenda_item_is_blocked(all_items: &[Value], item: &Value) -> bool {
+    if item.get("status").and_then(Value::as_str) != Some("open") {
+        return false;
+    }
+    let uncleared_blocker = item
+        .get("blockers")
+        .and_then(Value::as_array)
+        .is_some_and(|blockers| blockers.iter().any(|b| b.get("cleared").is_none()));
+    if uncleared_blocker {
+        return true;
+    }
+    item.get("relies_on")
+        .and_then(Value::as_array)
+        .is_some_and(|edges| {
+            edges.iter().any(|edge| {
+                let target_id = edge.get("target_id").and_then(Value::as_str).unwrap_or("");
+                let target_status = all_items
+                    .iter()
+                    .find(|candidate| {
+                        candidate.get("id").and_then(Value::as_str) == Some(target_id)
+                    })
+                    .and_then(|t| t.get("status"))
+                    .and_then(Value::as_str);
+                target_status != Some("done")
+            })
+        })
+}
+
+fn agenda_render_row(item: &Value, blocked: bool) -> String {
     let field = |key: &str| item.get(key).and_then(Value::as_str).unwrap_or("");
     let glyph = match (field("status"), field("kind")) {
         ("open", "question") => "?",
@@ -2291,6 +2430,9 @@ fn agenda_render_row(item: &Value) -> String {
         field("kind"),
         field("title")
     );
+    if blocked {
+        row.push_str("  [blocked]");
+    }
     if let Some(answer) = item
         .get("answer")
         .and_then(|a| a.get("text"))
@@ -2384,9 +2526,23 @@ async fn agenda_resolve_id(
     let raw = args
         .positional
         .first()
-        .map(|id| id.trim().to_ascii_uppercase())
+        .map(|id| id.trim())
         .filter(|id| !id.is_empty())
         .ok_or_else(|| message.to_string())?;
+    agenda_resolve_id_str(client, config, raw).await
+}
+
+/// [`agenda_resolve_id`]'s core for call sites holding the raw prefix
+/// directly (e.g. the second positional of `relies-on`).
+async fn agenda_resolve_id_str(
+    client: &reqwest::Client,
+    config: &Config,
+    raw: &str,
+) -> Result<String, String> {
+    let raw = raw.trim().to_ascii_uppercase();
+    if raw.is_empty() {
+        return Err("empty agenda item id".to_string());
+    }
     let (items, _) = agenda_fetch(client, config, Value::Object(Map::new())).await?;
     let matches: Vec<(&str, &str)> = items
         .iter()
@@ -3798,7 +3954,11 @@ fn help_agenda() {
   intendant ctl agenda add TITLE... [--note|--task|--kind question] [--body TEXT] [--tag TAG]... [--due WHEN] [--source LABEL]\n\
   intendant ctl agenda ask QUESTION... [--body TEXT] [--tag TAG]... [--due WHEN] [--source LABEL]\n\
   intendant ctl agenda answer ID_PREFIX REPLY... [--source LABEL]\n\
-  intendant ctl agenda list [--all|--open|--done|--retired] [--json]\n\
+  intendant ctl agenda list [--all|--open|--done|--retired] [--blocked] [--json]\n\
+  intendant ctl agenda annotate ID_PREFIX NOTE... [--source LABEL]\n\
+  intendant ctl agenda block ID_PREFIX CRITERION... [--source LABEL]\n\
+  intendant ctl agenda unblock ID_PREFIX [BLOCKER_PREFIX] [--source LABEL]\n\
+  intendant ctl agenda relies-on ID_PREFIX TARGET_PREFIX [--remove] [--source LABEL]\n\
   intendant ctl agenda complete ID_PREFIX [--source LABEL]\n\
   intendant ctl agenda reopen ID_PREFIX [--source LABEL]\n\
   intendant ctl agenda retire ID_PREFIX [--source LABEL]\n\
@@ -3821,6 +3981,17 @@ instructions to follow. --source LABEL is a self-described, UNVERIFIED\n\
 label for unsupervised callers (cron jobs, hooks) — it renders visibly\n\
 as self-described and never becomes attribution; supervised sessions\n\
 are attributed automatically and don't need it.\n\
+\n\
+`annotate` appends an attributed note (any status — the item's thread).\n\
+`block` states a human criterion (e.g. \"api access granted\") on an open\n\
+item; NOTHING evaluates it — the owner clears from the dashboard, or\n\
+`unblock` clears by blocker-id prefix (omit the prefix when only one is\n\
+uncleared); clears are recorded history, never deletions. `relies-on`\n\
+adds a dependency edge (--remove drops it): a completed prerequisite\n\
+satisfies the edge by pure recomputation; a RETIRED one does not — the\n\
+dependent shows \"prerequisite retired — review\". `list --blocked` shows\n\
+open items with an uncleared blocker or unsatisfied dependency; blocked\n\
+is derived at read time, never stored, and never notifies.\n\
 \n\
 `schedule` proposes a session manifest on an item: at WHEN, spawn a normal\n\
 supervised session with that goal (never raw actions). Nothing fires until\n\

--- a/src/bin/caller/mcp/tool_gate.rs
+++ b/src/bin/caller/mcp/tool_gate.rs
@@ -443,7 +443,7 @@ fn build_manual_http_tool_definitions() -> Vec<serde_json::Value> {
         "agenda_op",
         manual_http_tool_definition!(
             "agenda_op",
-            "Apply one agenda operation, keyed by op: add (park a note, task, or question: kind, title, body?, tags?, due_ms?), ask (park a RICH multi-question ask as a durable question item: questions is the ask_user vocabulary — up to 4 of {question, header?, options?, pick_min?, pick_max?, free_text?, previews?} with the same preview kinds and caps; it renders on the dashboard question rail exactly like a live ask, returns immediately with the item and its rail ask_id, and the structured reply lands on the item), answer (id + text — reply to an open question; resolves it; structured? carries a rich-ask breakdown), patch (id + {title?, body?, tags?, due_ms? — null due_ms clears}), complete (id), reopen (id — resurrects done or retired; re-asking a question clears its reply view and re-surfaces a rich ask on the rail), retire (id — also deletes a rich ask's preview blobs), propose_effect (id + goal + fire_at_ms + orchestrate? — propose a scheduled session on the item: at that instant the daemon spawns a normal supervised session with that goal; NOTHING fires until the owner approves, so propose and move on), approve_effect (id + digest), or revoke_effect (id). Approval is the owner's act alone — dashboard and owner-shell surfaces only; agent and peer callers may propose but are refused approval by policy, so never attempt to approve (or revoke) a manifest, including your own. Approval binds the exact manifest digest: re-proposing revises the manifest and voids any approval. Session outcomes write back to the item (effects[].last_run). A question is a durable non-blocking ask: it badges the owner's attention rail and the reply is readable in a later session. due_ms delivers a reminder at that instant (owner policy controls loudness). Non-owner ops accept source? — a self-described, UNVERIFIED caller label for unsupervised processes; it renders visibly as self-described and never becomes attribution (supervised sessions are attributed automatically; omit it). Returns the item as it now stands; add returns its minted id. History is append-only — nothing is ever destroyed.",
+            "Apply one agenda operation, keyed by op: add (park a note, task, or question: kind, title, body?, tags?, due_ms?), ask (park a RICH multi-question ask as a durable question item: questions is the ask_user vocabulary — up to 4 of {question, header?, options?, pick_min?, pick_max?, free_text?, previews?} with the same preview kinds and caps; it renders on the dashboard question rail exactly like a live ask, returns immediately with the item and its rail ask_id, and the structured reply lands on the item), answer (id + text — reply to an open question; resolves it; structured? carries a rich-ask breakdown), patch (id + {title?, body?, tags?, due_ms? — null due_ms clears}), complete (id), reopen (id — resurrects done or retired; re-asking a question clears its reply view and re-surfaces a rich ask on the rail), retire (id — also deletes a rich ask's preview blobs), annotate (id + text — append an attributed note to the item's thread, any status), set_blocker (id + criterion — state a human blocking criterion on an open item; NOTHING evaluates it, no watcher exists; the daemon mints the blocker id), clear_blocker (id + blocker_id — an op recorded as history, never a deletion; you have no duty to review blockers and clear only when the owner asks or your mandate says so — otherwise annotate with evidence instead), add_relies_on / remove_relies_on (id + target_id — dependency edges; a done prerequisite satisfies by pure recomputation, a retired one flags the dependent for review; blocked is derived at read time and never notifies), propose_effect (id + goal + fire_at_ms + orchestrate? — propose a scheduled session on the item: at that instant the daemon spawns a normal supervised session with that goal; NOTHING fires until the owner approves, so propose and move on), approve_effect (id + digest), or revoke_effect (id). Approval is the owner's act alone — dashboard and owner-shell surfaces only; agent and peer callers may propose but are refused approval by policy, so never attempt to approve (or revoke) a manifest, including your own. Approval binds the exact manifest digest: re-proposing revises the manifest and voids any approval. Session outcomes write back to the item (effects[].last_run). A question is a durable non-blocking ask: it badges the owner's attention rail and the reply is readable in a later session. due_ms delivers a reminder at that instant (owner policy controls loudness). Non-owner ops accept source? — a self-described, UNVERIFIED caller label for unsupervised processes; it renders visibly as self-described and never becomes attribution (supervised sessions are attributed automatically; omit it). Returns the item as it now stands; add returns its minted id. History is append-only — nothing is ever destroyed.",
             crate::agenda::AgendaCommand
         ),
     );
@@ -1313,15 +1313,20 @@ mod tests {
                 ops,
                 [
                     "add",
+                    "add_relies_on",
+                    "annotate",
                     "answer",
                     "approve_effect",
                     "ask",
+                    "clear_blocker",
                     "complete",
                     "patch",
                     "propose_effect",
+                    "remove_relies_on",
                     "reopen",
                     "retire",
-                    "revoke_effect"
+                    "revoke_effect",
+                    "set_blocker"
                 ],
                 "agenda_op's served oneOf must keep the full AgendaCommand vocabulary"
             );

--- a/static/app/20-shell.html
+++ b/static/app/20-shell.html
@@ -881,6 +881,7 @@
         <div class="agenda-reminders-bar" id="agenda-reminders-bar"></div>
         <div class="agenda-filters" id="agenda-filters" role="tablist" aria-label="Agenda filter">
           <button type="button" class="agenda-filter active" data-filter="open">Open</button>
+          <button type="button" class="agenda-filter" data-filter="blocked">Blocked</button>
           <button type="button" class="agenda-filter" data-filter="done">Done</button>
           <button type="button" class="agenda-filter" data-filter="retired">Retired</button>
           <button type="button" class="agenda-filter" data-filter="all">All</button>

--- a/static/app/ui2-agenda.css
+++ b/static/app/ui2-agenda.css
@@ -449,3 +449,95 @@ html.ui-v2 .agenda-self-described {
   0%, 100% { outline: 2px solid transparent; outline-offset: 2px; }
   50% { outline: 2px solid var(--iris, #7c7cf0); outline-offset: 2px; }
 }
+
+/* F2 gates & threads: annotations, blockers, dependency edges, blocked
+   chip. All content is escaped data. */
+html.ui-v2 .agenda-chip.blocked {
+  background: color-mix(in srgb, var(--red, #e06c75) 18%, transparent);
+  color: var(--red, #e06c75);
+  border: 1px solid color-mix(in srgb, var(--red, #e06c75) 45%, transparent);
+}
+html.ui-v2 .agenda-item-thread {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 4px 0 2px 22px;
+}
+html.ui-v2 .agenda-note {
+  font-size: 11.5px;
+  color: var(--text-2);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+html.ui-v2 .agenda-thread-more {
+  align-self: flex-start;
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 11px;
+  color: var(--iris);
+  cursor: pointer;
+}
+html.ui-v2 .agenda-blocker {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: 11.5px;
+  color: var(--text);
+}
+html.ui-v2 .agenda-blocker.cleared { color: var(--text-3); }
+html.ui-v2 .agenda-blocker-text { overflow-wrap: anywhere; }
+html.ui-v2 .agenda-blocker .agenda-btn { margin-left: auto; flex-shrink: 0; }
+html.ui-v2 .agenda-edges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+html.ui-v2 .agenda-edge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10.5px;
+  border-radius: 999px;
+  padding: 1px 8px;
+  border: 1px solid var(--line);
+  color: var(--text-2);
+  max-width: 100%;
+}
+html.ui-v2 .agenda-edge.satisfied {
+  color: var(--green, #98c379);
+  border-color: color-mix(in srgb, var(--green, #98c379) 45%, transparent);
+}
+html.ui-v2 .agenda-edge.review {
+  color: var(--peach, #e5a06c);
+  border-color: color-mix(in srgb, var(--peach, #e5a06c) 45%, transparent);
+}
+html.ui-v2 .agenda-edge-remove {
+  background: none;
+  border: none;
+  padding: 0 0 0 2px;
+  color: var(--text-3);
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 1;
+}
+html.ui-v2 .agenda-edge-remove:hover { color: var(--red, #e06c75); }
+html.ui-v2 .agenda-thread-add {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+html.ui-v2 .agenda-thread-add .agenda-thread-input {
+  flex: 1;
+  min-width: 0;
+  background: var(--surface-2);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--text);
+  font-size: 11.5px;
+  padding: 4px 8px;
+}
+html.ui-v2 .agenda-thread-add .agenda-thread-input:focus {
+  outline: none;
+  border-color: var(--iris);
+}

--- a/static/app/ui2-agenda.js
+++ b/static/app/ui2-agenda.js
@@ -22,6 +22,8 @@ let agendaReminderPolicy = null; // owner delivery policy (Settings-gated)
 // id never causes refetch loops on the event lane.
 let agendaSessions = {};
 let agendaSessionLookupsAttempted = new Set();
+// Items whose full annotation thread is expanded (render caps at 3).
+const agendaExpandedThreads = new Set();
 
 async function agendaRefresh() {
   if (agendaFetchInFlight) return agendaFetchInFlight;
@@ -183,6 +185,30 @@ function agendaSessionInfo(id) {
   return (id && agendaSessions && agendaSessions[id]) || null;
 }
 
+// ---- F2 derived presentation (client twin of the daemon's is_blocked /
+// dependency_state — like the overdue chip, derived at render time from
+// facts the tab already holds; never stored, never on the wire).
+
+function agendaFindItem(id) {
+  return (agendaItems || []).find((item) => item.id === id) || null;
+}
+
+// One edge's render judgment: { satisfied, review } where review is
+// '' | 'target_retired' | 'target_missing'.
+function agendaEdgeState(edge) {
+  const target = agendaFindItem(edge.target_id);
+  if (!target) return { satisfied: false, review: 'target_missing' };
+  if (target.status === 'done') return { satisfied: true, review: '' };
+  if (target.status === 'retired') return { satisfied: false, review: 'target_retired' };
+  return { satisfied: false, review: '' };
+}
+
+function agendaItemIsBlocked(item) {
+  if (item.status !== 'open') return false;
+  if ((item.blockers || []).some((b) => !b.cleared)) return true;
+  return (item.relies_on || []).some((edge) => !agendaEdgeState(edge).satisfied);
+}
+
 function agendaActorLabel(p) {
   // Gate-attributed actor (A2), rendered for humans. Session ids resolve
   // through the join map to the conversation's human name; unresolved ids
@@ -337,6 +363,84 @@ function agendaEffectBlock(item) {
   </div>`;
 }
 
+// The item's thread + gates (F2): annotations (capped with an expander),
+// blockers with their clear affordance and cleared history, dependency
+// chips with satisfied/review markers, and the note/block composer.
+// Everything is data rendered escaped; nothing here executes or obeys.
+function agendaThreadBlock(item) {
+  const parts = [];
+  const notes = item.annotations || [];
+  if (notes.length) {
+    const cap = 3;
+    const shown = agendaExpandedThreads.has(item.id) ? notes : notes.slice(-cap);
+    const rows = shown.map((note) => {
+      const when = note.at_ms
+        ? new Date(note.at_ms).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+        : '';
+      const who = agendaActorHtml(note);
+      const meta = [who, escapeHtml(when)].filter(Boolean).join(' · ');
+      return `<div class="agenda-note">↳ ${escapeHtml(note.text)}
+        <span class="agenda-item-meta">— ${meta}</span></div>`;
+    });
+    const more = notes.length > shown.length
+      ? `<button type="button" class="agenda-thread-more" data-id="${escapeHtml(item.id)}">show all ${notes.length} notes</button>`
+      : '';
+    parts.push(`<div class="agenda-thread">${rows.join('')}${more}</div>`);
+  }
+  const blockers = item.blockers || [];
+  if (blockers.length) {
+    const rows = blockers.map((blocker) => {
+      const who = agendaActorHtml(blocker);
+      if (blocker.cleared) {
+        const clearedBy = agendaActorHtml(blocker.cleared);
+        return `<div class="agenda-blocker cleared">✓ <s>${escapeHtml(blocker.criterion)}</s>
+          <span class="agenda-item-meta">— cleared${clearedBy ? ` by ${clearedBy}` : ''}</span></div>`;
+      }
+      const clear = item.status === 'open'
+        ? `<button type="button" class="agenda-btn agenda-clear-blocker" data-id="${escapeHtml(item.id)}" data-blocker="${escapeHtml(blocker.blocker_id)}">Clear</button>`
+        : '';
+      return `<div class="agenda-blocker">
+        <span class="agenda-blocker-text" title="${escapeHtml(blocker.blocker_id)}">⛔ ${escapeHtml(blocker.criterion)}</span>
+        <span class="agenda-item-meta">${who ? `— set by ${who}` : ''}</span>${clear}
+      </div>`;
+    });
+    parts.push(`<div class="agenda-blockers">${rows.join('')}</div>`);
+  }
+  const edges = item.relies_on || [];
+  if (edges.length) {
+    const chips = edges.map((edge) => {
+      const state = agendaEdgeState(edge);
+      const target = agendaFindItem(edge.target_id);
+      const label = target ? target.title : edge.target_id.slice(0, 10);
+      const marker = state.review === 'target_retired'
+        ? ' · prerequisite retired — review'
+        : state.review === 'target_missing'
+          ? ' · prerequisite missing'
+          : '';
+      const cls = state.satisfied ? 'satisfied' : state.review ? 'review' : 'waiting';
+      const remove = item.status === 'open'
+        ? `<button type="button" class="agenda-edge-remove" data-id="${escapeHtml(item.id)}" data-target="${escapeHtml(edge.target_id)}" aria-label="Remove dependency" title="Remove dependency">×</button>`
+        : '';
+      return `<span class="agenda-edge ${cls}" title="${escapeHtml(edge.target_id)}">
+        ${state.satisfied ? '✓' : '…'} needs ${escapeHtml(label)}${escapeHtml(marker)}${remove}</span>`;
+    });
+    parts.push(`<div class="agenda-edges">${chips.join('')}</div>`);
+  }
+  // Composer: annotate any non-retired item; block only open ones.
+  if (item.status !== 'retired') {
+    const blockBtn = item.status === 'open'
+      ? `<button type="button" class="agenda-btn agenda-thread-block" data-id="${escapeHtml(item.id)}">Block</button>`
+      : '';
+    parts.push(`<div class="agenda-thread-add">
+      <input type="text" class="agenda-thread-input" maxlength="4000"
+             placeholder="Add a note — or state a blocker…" aria-label="Note or blocker" data-id="${escapeHtml(item.id)}" />
+      <button type="button" class="agenda-btn agenda-thread-note" data-id="${escapeHtml(item.id)}">Note</button>
+      ${blockBtn}
+    </div>`);
+  }
+  return parts.length ? `<div class="agenda-item-thread">${parts.join('')}</div>` : '';
+}
+
 function agendaActionButtons(item) {
   const actions = [];
   if (item.status === 'open') actions.push(['complete', 'Complete'], ['retire', 'Retire']);
@@ -479,7 +583,9 @@ function agendaRenderTab() {
     return;
   }
   const filtered = agendaItems.filter((item) =>
-    agendaFilter === 'all' ? true : item.status === agendaFilter);
+    agendaFilter === 'all' ? true
+      : agendaFilter === 'blocked' ? agendaItemIsBlocked(item)
+        : item.status === agendaFilter);
   if (!filtered.length) {
     const what = agendaFilter === 'all' ? '' : `${agendaFilter} `;
     list.innerHTML =
@@ -512,14 +618,17 @@ function agendaRenderTab() {
         <span class="agenda-item-meta">— ${escapeHtml([who && `by ${who}`, when].filter(Boolean).join(' · '))}</span>
       </div>`;
     }
+    const blockedChip = agendaItemIsBlocked(item)
+      ? '<span class="agenda-chip blocked">blocked</span>'
+      : '';
     return `<div class="agenda-item" data-status="${escapeHtml(item.status)}">
       <div class="agenda-item-head">
         ${agendaGlyph(item.status, item.kind)}
         <span class="agenda-item-kind">${escapeHtml(item.kind)}</span>
         <span class="agenda-item-title">${escapeHtml(item.title)}</span>
-        ${agendaDueChip(item)}${tags}
+        ${blockedChip}${agendaDueChip(item)}${tags}
       </div>
-      ${body}${answerBlock}${agendaEffectBlock(item)}
+      ${body}${answerBlock}${agendaThreadBlock(item)}${agendaEffectBlock(item)}
       <div class="agenda-item-foot">
         <span class="agenda-item-meta">${agendaProvenanceLine(item)}</span>
         <span class="agenda-item-actions">${agendaActionButtons(item)}</span>
@@ -544,6 +653,48 @@ function agendaRenderTab() {
   list.querySelectorAll('select.agenda-bell').forEach((sel) => {
     sel.addEventListener('change', () =>
       agendaSetItemUrgency(sel.dataset.id, sel.value, sel));
+  });
+  // F2 thread + gates wiring.
+  list.querySelectorAll('button.agenda-thread-more').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      agendaExpandedThreads.add(btn.dataset.id);
+      agendaRenderTab();
+    });
+  });
+  list.querySelectorAll('button.agenda-clear-blocker').forEach((btn) => {
+    btn.addEventListener('click', () =>
+      agendaSendOp({ op: 'clear_blocker', id: btn.dataset.id, blocker_id: btn.dataset.blocker }, btn));
+  });
+  list.querySelectorAll('button.agenda-edge-remove').forEach((btn) => {
+    btn.addEventListener('click', () =>
+      agendaSendOp({ op: 'remove_relies_on', id: btn.dataset.id, target_id: btn.dataset.target }, btn));
+  });
+  const submitThread = async (id, input, op, control) => {
+    const text = (input.value || '').trim();
+    if (!text) return;
+    input.disabled = true;
+    const params = op === 'set_blocker'
+      ? { op, id, criterion: text }
+      : { op, id, text };
+    const ok = await agendaSendOp(params, control);
+    input.disabled = false;
+    if (!ok) input.focus();
+  };
+  list.querySelectorAll('button.agenda-thread-note').forEach((btn) => {
+    const input = list.querySelector(`input.agenda-thread-input[data-id="${btn.dataset.id}"]`);
+    if (!input) return;
+    btn.addEventListener('click', () => submitThread(btn.dataset.id, input, 'annotate', btn));
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        submitThread(btn.dataset.id, input, 'annotate', btn);
+      }
+    });
+  });
+  list.querySelectorAll('button.agenda-thread-block').forEach((btn) => {
+    const input = list.querySelector(`input.agenda-thread-input[data-id="${btn.dataset.id}"]`);
+    if (!input) return;
+    btn.addEventListener('click', () => submitThread(btn.dataset.id, input, 'set_blocker', btn));
   });
   const submitAnswer = async (id, input, control) => {
     const text = (input.value || '').trim();

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -1384,9 +1384,13 @@ async fn native_session_ctl_agenda_add_attributes_to_the_session() {
                                        "echo INJECTED %INTENDANT_MCP_URL%$INTENDANT_MCP_URL" } }] },
                 { "expect_transcript_contains": "/mcp?session_id=",
                   "content": "Parking the follow-up on the agenda.",
+                  // Unquoted binary path: cmd mishandles a quote-leading
+                  // command string (`'"C:\…\intendant.exe"' is not
+                  // recognized` — the second queue failure), and every CI
+                  // and fleet target path is space-free.
                   "tool_calls": [{ "name": "exec_command",
                                    "arguments": { "nonce": 2, "command": format!(
-                                       "\"{intendant}\" ctl --json agenda add parked-from-inside --task"
+                                       "{intendant} ctl --json agenda add parked-from-inside --task"
                                    ) } }] },
                 { "expect_transcript_contains": "parked-from-inside",
                   "content": "Parked.",

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -1366,16 +1366,30 @@ async fn ctl_session_note_posts_a_display_only_note_with_image() {
 #[tokio::test]
 async fn native_session_ctl_agenda_add_attributes_to_the_session() {
     let intendant = intendant_bin();
+    // Three steps, portable across sh and cmd (no POSIX-only syntax — the
+    // Windows runtime shells through cmd, where `[`/`{` broke this test in
+    // the merge queue). Step 1 echoes the injected URL: `%VAR%` expands on
+    // cmd while `$VAR` expands on sh, so EITHER platform puts
+    // `/mcp?session_id=` in the transcript iff the injection reached the
+    // runtime env. Step 2's expectation gates the actual ctl write on that
+    // proof (an unmet expectation is a loud provider error), so a broken
+    // injection can never fall back onto some other daemon's default port.
+    // Step 3 gates completion on ctl echoing the minted item back.
     let script = serde_json::json!({
         "profiles": [{
             "steps": [
-                { "content": "Parking the follow-up on the agenda.",
+                { "content": "Probing the injected bootstrap.",
                   "tool_calls": [{ "name": "exec_command",
-                                   "arguments": { "nonce": 1, "command": format!(
-                                       "[ -n \"$INTENDANT_MCP_URL\" ] || {{ echo NO_INJECTED_MCP_URL >&2; exit 1; }}; \
-                                        \"{intendant}\" ctl agenda add parked-from-inside --task"
+                                   "arguments": { "nonce": 1, "command":
+                                       "echo INJECTED %INTENDANT_MCP_URL%$INTENDANT_MCP_URL" } }] },
+                { "expect_transcript_contains": "/mcp?session_id=",
+                  "content": "Parking the follow-up on the agenda.",
+                  "tool_calls": [{ "name": "exec_command",
+                                   "arguments": { "nonce": 2, "command": format!(
+                                       "\"{intendant}\" ctl --json agenda add parked-from-inside --task"
                                    ) } }] },
-                { "content": "Parked.",
+                { "expect_transcript_contains": "parked-from-inside",
+                  "content": "Parked.",
                   "tool_calls": [{ "name": "signal_done",
                                    "arguments": { "message": "agenda write done" } }] }
             ]


### PR DESCRIPTION
Track F slice 2, built on the steward's F2 vocabulary ruling (2026-07-20, in the coordination file). Stacked on #523 (F1) — the diff shrinks to F2-only once that merges. Draft until then.

## What

Five new single-line attributed ops in the existing JSONL log, riding the existing `agenda_op` route/tunnel/MCP/ctl lanes — no new routes, no new IAM (`agenda.write` covers all five):

- **`annotate`** — attributed, timestamped note thread on items of any status (housekeeping annotates done/retired items without disposing). Render caps with an expander; intake caps one note at the body limit and an item at **500 annotations** (the steward-ruled pathology rail).
- **`set_blocker` / `clear_blocker`** — human criterion text on open items. **No evaluation machinery**: no watchers, no pollers, no condition language. Blocker ids are minted at intake (`bk-` + 12 hex of the ruled preimage) and recorded in the op — replay never mints. **Clears are ops, never deletions**: the cleared entry stays rendered as history with the clearing actor. Per ruling Q3, both stay plain `agenda.write` — the owner decision governs agent *conduct* (mandate text; agents without one annotate with evidence instead of clearing), not capability.
- **`add_relies_on` / `remove_relies_on`** — dependency edges (target must exist at intake, self-edges/duplicates refused, 32-edge cap). Removal drops the view edge; the log keeps history (ruling Q4's deliberate asymmetry with blocker history).
- **Derived `blocked` is presentation only** — computed at render time by each surface (dashboard JS twin, ctl print-time twin over the served items, and a `cfg(test)` typed twin that pins the semantics), never stored, never on the wire, never a notification. A completed prerequisite satisfies by pure recomputation; a **retired** one renders "prerequisite retired — review"; a missing target renders "prerequisite missing"; cycles derive blocked on every member with no walk.
- `--source` rides all five per the F1 placement (envelope sibling of the actor); the ruling's Q2 clarification (label **supplements** gate attribution when both exist) matches the shipped renderer.

Surfaces: `ctl agenda annotate/block/unblock/relies-on` + `list --blocked`; the dashboard thread block (notes, blockers with a Clear affordance, edge chips with satisfied/review markers), blocked chip + Blocked filter, and a per-item note/block composer; MCP `agenda_op` description + served-schema pin extended.

## Acceptance (per the commissioning brief)

- Fold unit tests: the **retire-flags-for-review** rule, **cycle tolerance**, and **clear-is-an-op history** (`derived_blocked_retire_review_and_cycle_tolerance`, `f2_fold_annotations_blockers_edges`).
- Pinned durable line formats for all five ops (round-tripped); forward-compat skip-and-preserve extended with an on-disk preservation assert.
- Intake strictness suite (`f2_verbs_are_strict_at_intake_and_persist`): empty/oversized text, non-open targets, duplicates, self-edges, caps, prefix-resolved clears, reopen-persistence.
- **Live dashboard probe** (validate-dashboard.cjs against a mock-provider rig): adds an annotation and a blocker through the real UI, sees the blocked chip appear **live** on the event lane, clears from the card, verifies the chip clears and the history stays, and checks the durable fold via ctl. All green on this Mac.
- Everything renders escaped; bodies/notes/criteria stay data, never instructions.