### PR TITLE
access: same-home sibling loopback-token handoff

### DIFF
--- a/docs/src/trust-architecture.md
+++ b/docs/src/trust-architecture.md
@@ -817,6 +817,14 @@ The honest security envelope, per platform:
   the unchanged owner surface: an owner-launched script or unsupervised
   agent on the same account has always been, and remains, the owner.
 
+Multi-daemon homes get a same-home handoff: an owner-posture caller on
+one daemon may ask `GET /api/local-daemons/tokens` for the per-instance
+tokens that daemon's own state root holds (files it could already
+read), so the trusted dashboard opens same-home siblings with their own
+tokened URLs. The route is credential-custody gated, answers
+per-request without persisting anything, never crosses a home boundary,
+and retires naturally when the fleet-identity arc supersedes it.
+
 The same asymmetry applies to the
 state-root secrets: every platform's **default** grant set excludes the trust
 store (`access-certs/`), leased auth, and the custody trail from runtime writes,

--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -1888,6 +1888,7 @@ response omits the header.
 | GET | `/api/settings` | Settings | own origin | none | Current runtime settings |
 | POST | `/api/api-keys` | CredentialsManage | own origin | bounded | Store provider API keys in the daemon-config .env |
 | GET | `/api/api-key-status` | Settings | own origin | none | Which provider keys are configured (presence only) |
+| GET | `/api/local-daemons/tokens` | CredentialsManage | own origin | none | Loopback admission tokens for same-home daemon instances (owner handoff) |
 | POST | `/api/claude-auth/start` | CredentialsManage | own origin | ≤ 4 KiB | Start the Claude sign-in ceremony (`claude auth login` on a daemon-private PTY) |
 | GET | `/api/claude-auth/status` | CredentialsManage | own origin | none | Claude sign-in ceremony state (validated sign-in URL; account info on success) |
 | POST | `/api/claude-auth/code` | CredentialsManage | own origin | ≤ 2 KiB | Submit the pasted authorization code to the Claude sign-in ceremony |

--- a/src/bin/caller/gateway_routes.rs
+++ b/src/bin/caller/gateway_routes.rs
@@ -358,6 +358,9 @@ pub(crate) enum RouteHandlerId {
     /// connect status payload).
     AccessFleetCertRequest,
     DashboardTargets,
+    /// Same-home sibling loopback-token handoff (owner surfaces open
+    /// sibling daemons friction-free).
+    LocalDaemonTokens,
     /// Live dashboard connections (tab presence): the tabs registry
     /// snapshot with voice/input-authority ownership joined in.
     DashboardTabs,
@@ -1512,6 +1515,21 @@ pub(crate) static ROUTES: &[Route] = &[
         "Which provider keys are configured (presence only)",
     )
     .with_tunnel(tunnel_method("api_key_status")),
+    // ── Same-home sibling loopback-token handoff (ratified 2026-07-20):
+    //    the response contains per-boot loopback admission tokens, so
+    //    the route rides the credential-custody operation like the
+    //    sign-in ceremonies below — no peer profile (peer-root included)
+    //    and no scoped default carries it. HTTP-only, no tunnel twin:
+    //    the consumer is the trusted dashboard's open-sibling action,
+    //    and the payload must never leave the daemon's own origin.
+    op_route(
+        RouteMethod::Get,
+        PathPattern::Exact("/api/local-daemons/tokens"),
+        PeerOperation::CredentialsManage,
+        BodyPolicy::None,
+        RouteHandlerId::LocalDaemonTokens,
+        "Loopback admission tokens for same-home daemon instances (owner handoff)",
+    ),
     // ── Claude sign-in ceremony (claude_auth_ceremony.rs): the dashboard
     //    walks the owner through `claude auth login` on a daemon-private
     //    PTY. Gated on the credential-custody operation — the same class

--- a/src/bin/caller/web_gateway/access_gates.rs
+++ b/src/bin/caller/web_gateway/access_gates.rs
@@ -1276,6 +1276,12 @@ mod tests {
             dashboard_http_operation("GET", "/api/dashboard/targets"),
             Some(PeerOperation::AccessInspect)
         );
+        // The sibling-token handoff hands out loopback admission tokens:
+        // credential-custody class, owner-posture only.
+        assert_eq!(
+            dashboard_http_operation("GET", "/api/local-daemons/tokens"),
+            Some(PeerOperation::CredentialsManage)
+        );
         assert_eq!(
             dashboard_http_operation("GET", "/api/session/current/uploads"),
             Some(PeerOperation::SessionManage)

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -1921,6 +1921,9 @@ pub(crate) async fn serve_http_request(
                 )
                 .await;
             }
+            RouteHandlerId::LocalDaemonTokens => {
+                return handle_local_daemon_tokens(stream, route.cors).await;
+            }
             RouteHandlerId::DashboardTabs => {
                 let response =
                     crate::web_gateway::dashboard_tabs_api_response(dashboard_control.tabs());

--- a/src/bin/caller/web_gateway/routes_access.rs
+++ b/src/bin/caller/web_gateway/routes_access.rs
@@ -272,6 +272,101 @@ pub(crate) async fn handle_dashboard_targets(
     write_api_response(stream, response, cors, fleet_origin).await;
 }
 
+/// Same-home sibling loopback-token handoff (ratified 2026-07-20).
+/// Enumerates the per-instance loopback admission tokens THIS daemon's
+/// state root holds so an owner surface (the trusted dashboard's
+/// open-sibling action) can hand each sibling its own tokened URL.
+///
+/// Binding guards, per the ruling:
+/// - The route is owner-posture only: gated on `CredentialsManage`
+///   (the credential-custody class no peer profile or scoped default
+///   carries), so the caller is already authenticated to this daemon
+///   at owner level.
+/// - Same-home membership is state-root identity: only files under
+///   this daemon's own `loopback-tokens/` subtree are read — the same
+///   files this process could already read — never across a home
+///   boundary.
+/// - Tokens are read per-request and never persisted into any
+///   server-side store.
+/// - This route relays within one trust class and dies naturally when
+///   the fleet-identity arc supersedes per-home token handoff.
+///
+/// Entries are as-found on disk: a crashed daemon's stale file yields
+/// an entry whose port simply refuses or does not answer.
+pub(crate) fn local_daemon_tokens_response_value(
+    state_root: &std::path::Path,
+    self_port: Option<u16>,
+) -> serde_json::Value {
+    let mut instances = Vec::new();
+    let dir = crate::loopback_token::loopback_token_dir(state_root);
+    let mut ports: Vec<u16> = std::fs::read_dir(&dir)
+        .map(|entries| {
+            entries
+                .filter_map(|entry| {
+                    entry
+                        .ok()?
+                        .file_name()
+                        .to_str()?
+                        .strip_suffix(".token")?
+                        .parse()
+                        .ok()
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    ports.sort_unstable();
+    for port in ports {
+        let Some(token) = crate::loopback_token::discover_client_token(None, state_root, port)
+        else {
+            continue;
+        };
+        let scheme = std::fs::read_to_string(crate::loopback_token::loopback_sidecar_path(
+            state_root, port,
+        ))
+        .ok()
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+        .and_then(|meta| {
+            meta.get("scheme")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| "http".to_string());
+        instances.push(serde_json::json!({
+            "port": port,
+            "scheme": scheme,
+            "self": Some(port) == self_port,
+            "dashboard_url": format!("{scheme}://127.0.0.1:{port}/?token={token}"),
+            "token": token,
+        }));
+    }
+    serde_json::json!({ "schema_version": 1, "instances": instances })
+}
+
+pub(crate) async fn handle_local_daemon_tokens(
+    stream: DemuxStream,
+    cors: crate::gateway_routes::CorsPosture,
+) {
+    // Transport edge resolves the real state root and own port; the
+    // value builder stays hermetic (tests inject temp roots).
+    let payload = local_daemon_tokens_response_value(
+        &crate::platform::intendant_home(),
+        crate::sandbox::gateway_loopback_port(),
+    );
+    // Secrets in the body: never cache (`no-store`, not the envelope's
+    // `no-cache`), never decorate with any cross-origin allowance
+    // (`fleet_origin: None` keeps the bare same-origin tail even on
+    // fleet-decorated deployments).
+    let response = ApiResponse::Json {
+        status: 200,
+        body: JsonBody::Value(payload),
+        headers: vec![
+            ("Cache-Control", "no-store".to_string()),
+            ("Connection", "close".to_string()),
+        ],
+    };
+    write_api_response(stream, response, cors, None).await;
+}
+
 /// Run a synchronous authority-store operation off the async reactor.
 /// `authority_store::with_lock` waits for its process/file locks with
 /// blocking `std::thread::sleep` retries (up to its 2s timeout), so a
@@ -4528,6 +4623,56 @@ mod tests {
             crate::dashboard_control::DashboardControlGrant::UserClient { .. }
         ));
         assert!(!unknown.has_any_effective_operation());
+    }
+
+    /// The sibling-token handoff reads only this state root's
+    /// `loopback-tokens/` subtree (same-home membership by state-root
+    /// identity), returns entries as found, marks self, and stores
+    /// nothing. An empty or absent subtree yields an empty list.
+    #[test]
+    fn local_daemon_tokens_enumerate_own_state_root_only() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let empty = local_daemon_tokens_response_value(tmp.path(), Some(8765));
+        assert_eq!(empty["instances"].as_array().map(Vec::len), Some(0));
+
+        let dir = crate::loopback_token::loopback_token_dir(tmp.path());
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("8765.token"), "tok-self\n").unwrap();
+        std::fs::write(dir.join("8765.json"), "{\"v\":1,\"scheme\":\"https\"}\n").unwrap();
+        std::fs::write(dir.join("8799.token"), "tok-sibling\n").unwrap();
+        // No sidecar for 8799: scheme falls back to http.
+        std::fs::write(dir.join("not-a-port.token"), "junk\n").unwrap();
+
+        let payload = local_daemon_tokens_response_value(tmp.path(), Some(8765));
+        let instances = payload["instances"].as_array().unwrap();
+        assert_eq!(instances.len(), 2, "{payload}");
+        let by_port = |port: u64| {
+            instances
+                .iter()
+                .find(|entry| entry["port"] == port)
+                .unwrap_or_else(|| panic!("port {port} missing: {payload}"))
+        };
+        let own = by_port(8765);
+        assert_eq!(own["self"], true);
+        assert_eq!(own["scheme"], "https");
+        assert_eq!(own["token"], "tok-self");
+        assert_eq!(
+            own["dashboard_url"],
+            "https://127.0.0.1:8765/?token=tok-self"
+        );
+        let sibling = by_port(8799);
+        assert_eq!(sibling["self"], false);
+        assert_eq!(sibling["scheme"], "http");
+        assert_eq!(
+            sibling["dashboard_url"],
+            "http://127.0.0.1:8799/?token=tok-sibling"
+        );
+        // Read-only by contract: the subtree is unchanged afterwards.
+        let names: Vec<_> = std::fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|entry| entry.ok()?.file_name().into_string().ok())
+            .collect();
+        assert_eq!(names.len(), 4, "{names:?}");
     }
 
     /// The certless fallback arms are the trusted-local owner lane; both

--- a/static/app/43-access-panes.js
+++ b/static/app/43-access-panes.js
@@ -3,6 +3,42 @@
    request (never authority), and the target DAEMON decides via its
    local IAM. Roles get warmer colors the more they can do. */
 
+// ── Same-home sibling loopback-token handoff ──
+//
+// Sibling daemons on THIS home refuse tokenless loopback like every
+// daemon, and this page holds only its own daemon's token (per-origin
+// storage). Opening a loopback sibling therefore asks the reached
+// daemon for its same-home instance map (/api/local-daemons/tokens —
+// owner-posture only; served per-request, never persisted) and opens
+// the sibling's own tokened URL so its page seeds its own origin.
+// Non-loopback and mTLS targets pass through untouched. Cached per
+// page load; a stale map (sibling rebooted) degrades to the bare URL
+// and the sibling's named 401 guidance.
+let accessSiblingTokenMapPromise = null;
+
+async function withSiblingLoopbackToken(rawUrl) {
+  try {
+    const url = new URL(rawUrl, location.href);
+    const host = url.hostname.replace(/^\[|\]$/g, '').toLowerCase();
+    const loopback =
+      host === 'localhost' || host === '::1' || /^127(?:\.\d{1,3}){3}$/.test(host);
+    if (!loopback || url.searchParams.has('token')) return rawUrl;
+    if (!accessSiblingTokenMapPromise) {
+      accessSiblingTokenMapPromise = fetch('/api/local-daemons/tokens')
+        .then(resp => (resp.ok ? resp.json() : { instances: [] }))
+        .catch(() => ({ instances: [] }));
+    }
+    const map = await accessSiblingTokenMapPromise;
+    const port = url.port || (url.protocol === 'https:' ? '443' : '80');
+    const entry = (map.instances || []).find(inst => String(inst.port) === String(port));
+    if (!entry || !entry.token) return rawUrl;
+    url.searchParams.set('token', entry.token);
+    return url.toString();
+  } catch {
+    return rawUrl;
+  }
+}
+
 const ACCESS_ROLE_META = {
   'role:root': { cls: 'role-root', warn: true, short: 'Full control of this daemon, including access administration.' },
   'role:operator': { cls: 'role-operator', short: 'Operate sessions, display, shell, and files. No access or settings administration.' },
@@ -824,9 +860,9 @@ function renderAccessFleetStrip() {
       direct.className = 'acc-btn acc-fleet-direct';
       direct.textContent = '↗ direct';
       direct.title = `Open ${directUrl} — this daemon's own dashboard, no rendezvous in the loop. Works when this browser can reach it (same LAN/VPN); a self-signed daemon shows a one-time certificate warning.`;
-      direct.addEventListener('click', event => {
+      direct.addEventListener('click', async event => {
         event.stopPropagation();
-        window.open(directUrl, '_blank', 'noopener');
+        window.open(await withSiblingLoopbackToken(directUrl), '_blank', 'noopener');
       });
       meta.appendChild(direct);
     }

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -674,6 +674,114 @@ async fn tls_daemon_admits_tokened_cleartext_ctl_round_trip() {
     );
 }
 
+/// The same-home sibling-token handoff (ratified follow-up to the
+/// loopback admission token): an owner-posture caller on daemon A asks
+/// `/api/local-daemons/tokens` and receives the per-instance tokens A's
+/// state root holds — including sibling daemon B booted on the SAME
+/// home — and B's returned token admits B's owner surfaces. The route
+/// itself is owner-posture: tokenless callers are refused before it.
+#[tokio::test]
+async fn same_home_sibling_token_handoff_admits_the_sibling() {
+    let client = reqwest::Client::new();
+    let idle_script = serde_json::json!({ "profiles": [] });
+    let daemon_a = spawn_daemon(&client, &idle_script).await;
+    let port_a = daemon_a.port;
+
+    // Daemon B: booted by hand against the SAME rig home (`--web 0`,
+    // its own log file for the port parse).
+    let script_path = daemon_a.rig.write_script(&idle_script);
+    let log_b = daemon_a.rig.home.path().join("daemon-b.log");
+    let log_file = std::fs::File::create(&log_b).expect("daemon-b log");
+    let mut cmd = daemon_a.rig.command();
+    cmd.env("INTENDANT_MOCK_SCRIPT", &script_path)
+        .stdout(log_file.try_clone().expect("clone daemon-b log"))
+        .stderr(log_file)
+        .arg("--web")
+        .arg("0")
+        .args([
+            "--bind",
+            "127.0.0.1",
+            "--no-tui",
+            "--no-tls",
+            "--autonomy",
+            "full",
+        ]);
+    let mut child_b = cmd.spawn().expect("spawn sibling daemon");
+    let deadline = tokio::time::Instant::now() + DAEMON_START_TIMEOUT;
+    let port_b = loop {
+        let contents = std::fs::read_to_string(&log_b).unwrap_or_default();
+        if let Some(port) = dashboard_port(&contents) {
+            break port;
+        }
+        if let Ok(Some(status)) = child_b.try_wait() {
+            panic!("sibling daemon exited during startup ({status}):\n{contents}");
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "sibling daemon never printed its Dashboard line:\n{contents}"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    };
+    assert_ne!(port_a, port_b);
+
+    // Tokenless callers never reach the handoff (owner-posture only).
+    let refused = client
+        .get(format!(
+            "http://127.0.0.1:{port_a}/api/local-daemons/tokens"
+        ))
+        .send()
+        .await
+        .expect("tokenless handoff request completes");
+    assert_eq!(refused.status(), 401);
+
+    // The owner-posture caller receives both same-home instances…
+    let authed = daemon_a.authed_client();
+    let payload: serde_json::Value = authed
+        .get(format!(
+            "http://127.0.0.1:{port_a}/api/local-daemons/tokens"
+        ))
+        .send()
+        .await
+        .expect("handoff request completes")
+        .error_for_status()
+        .expect("handoff must serve the owner")
+        .json()
+        .await
+        .expect("handoff JSON");
+    let instances = payload["instances"].as_array().expect("instances array");
+    let entry = |port: u16| {
+        instances
+            .iter()
+            .find(|inst| inst["port"] == port)
+            .unwrap_or_else(|| panic!("port {port} missing from handoff: {payload}"))
+    };
+    assert_eq!(entry(port_a)["self"], true);
+    let sibling = entry(port_b);
+    assert_eq!(sibling["self"], false);
+    let sibling_token = sibling["token"].as_str().expect("sibling token");
+
+    // …and the sibling's token admits the sibling's owner surface.
+    let admitted = client
+        .get(format!("http://127.0.0.1:{port_b}/api/sessions"))
+        .header("x-intendant-loopback-token", sibling_token)
+        .send()
+        .await
+        .expect("sibling request completes");
+    assert!(
+        admitted.status().is_success(),
+        "sibling token must admit the sibling: {}",
+        admitted.status()
+    );
+    let denied = client
+        .get(format!("http://127.0.0.1:{port_b}/api/sessions"))
+        .send()
+        .await
+        .expect("tokenless sibling request completes");
+    assert_eq!(denied.status(), 401);
+
+    let _ = child_b.start_kill();
+}
+
 /// Parse a ctl run's stdout as the single JSON document the command prints.
 fn stdout_json(output: &std::process::Output) -> serde_json::Value {
     let stdout = String::from_utf8_lossy(&output.stdout);


### PR DESCRIPTION
The ratified follow-up to the loopback admission token (#529): multi-daemon homes get their sibling-open livability back without weakening the gate.

`GET /api/local-daemons/tokens` returns the per-instance loopback admission tokens the reached daemon's own state root holds. The four binding guards from the ruling, as implemented:

- **Owner-posture only** — the route rides `PeerOperation::CredentialsManage` (the credential-custody class no peer profile or scoped default carries), so the caller is already authenticated to the reached daemon at owner level. HTTP-only, no tunnel twin; `Cache-Control: no-store`; no fleet-CORS decoration (the payload never leaves the daemon's own origin).
- **Same-home membership by state-root identity** — only files under the daemon's own `loopback-tokens/` subtree are read (files this process could already read); nothing crosses a home boundary.
- **Per-request, never persisted** — the handler reads the files at request time and stores nothing server-side.
- **Supersession noted** — the handler doc comment records that the route dies naturally when the fleet-identity arc supersedes per-home token handoff.

Consumer: the Access pane's open-sibling (`↗ direct`) action fetches the map lazily (cached per page load) and opens loopback siblings by their own tokened URLs, so each sibling page seeds its own origin's storage. Non-loopback and mTLS targets pass through untouched; a stale map degrades to the bare URL and the sibling's named 401 guidance.

Tests: handler unit test (own-subtree enumeration, self-marking, scheme sidecar fallback, read-only contract), IAM op-mapping pin, docs endpoint-table row (generator-verified), and an e2e that boots two daemons on one home and proves the handoff admits the sibling while tokenless callers are refused before the route.