### PR TITLE
leases: per-request provider auth re-validation + custody cleanup events

### DIFF
--- a/src/bin/caller/credential_audit.rs
+++ b/src/bin/caller/credential_audit.rs
@@ -30,6 +30,14 @@ pub const EVENT_CUSTODY_RESET: &str = "custody_reset";
 /// CredentialsManage-gated save surface (`POST /api/api-keys` or its
 /// tunnel twin). The label carries key *names* only.
 pub const EVENT_PROVIDER_KEYS_WRITTEN: &str = "provider_keys_written";
+/// A dead lease's materialized auth home could not be deleted yet — a
+/// leased CLI session still runs against it, a provisional startup holds
+/// it, or the reap itself failed. Cleanup is queued;
+/// [`EVENT_LEASE_HOME_REMOVED`] records the eventual deletion.
+pub const EVENT_LEASE_CLEANUP_DEFERRED: &str = "lease_cleanup_deferred";
+/// A materialized leased auth home was deleted from disk (sweep, session
+/// end, revocation, or the startup sweep).
+pub const EVENT_LEASE_HOME_REMOVED: &str = "lease_home_removed";
 
 /// How many events the in-memory tail keeps (and the file is trimmed
 /// to on rewrite).

--- a/src/bin/caller/credential_leases.rs
+++ b/src/bin/caller/credential_leases.rs
@@ -79,11 +79,12 @@ impl Drop for CredentialLease {
     fn drop(&mut self) {
         // Zeroize the store's own long-lived copy. Copies already served
         // out of the store are NOT reclaimed here: `leased_secret` returns
-        // plain Strings, and the native providers capture the key at
-        // provider construction — a session started under this lease keeps
-        // (and keeps using) its captured copy until that session ends.
-        // Expiry and revocation stop the store from serving new copies;
-        // they cannot claw back served ones.
+        // plain Strings. The native providers re-resolve through the store
+        // at every request boundary (`ProviderAuth::request_key`), so
+        // expiry and revocation take effect at the next request — but a
+        // copy inside an in-flight request, and a materialized
+        // external-CLI auth home until its session exits, remain beyond
+        // the store's reach.
         self.material.fill(0);
     }
 }
@@ -742,14 +743,14 @@ fn sweep_locked(
             continue;
         }
         if defer_home_cleanup {
-            queue_materialization_cleanup(&kind);
+            queue_materialization_cleanup(&kind, "expired: leased session still running");
             continue;
         }
         match reap_materialization(root, &kind) {
             Ok(reaped) => cleanup.push(MaterializationCleanup { kind, reaped }),
             Err(err) => {
                 eprintln!("[credential-leases] expired lease cleanup for {kind} failed: {err}");
-                queue_materialization_cleanup(&kind);
+                queue_materialization_cleanup(&kind, &format!("expired: reap failed: {err}"));
             }
         }
     }
@@ -1506,15 +1507,25 @@ fn run_cleanup_item(
     }
     if let Some(path) = &item.reaped {
         let removed = match symlink_metadata_if_present(path) {
-            Ok(None) => Ok(()),
+            Ok(None) => Ok(false),
             Ok(Some(_)) => {
                 validate_reaped_directory(path, Some(&format!(".reap-{}-", plan.dir_name)))
                     .and_then(|(boundary, canonical)| remove_tree_no_follow(&canonical, &boundary))
+                    .map(|()| true)
             }
             Err(error) => Err(error),
         };
         match removed {
-            Ok(()) => {}
+            Ok(true) => {
+                crate::credential_audit::record(
+                    crate::credential_audit::EVENT_LEASE_HOME_REMOVED,
+                    &item.kind,
+                    plan.dir_name,
+                    "daemon",
+                    "reaped leased auth home deleted".to_string(),
+                );
+            }
+            Ok(false) => {}
             Err(err) => {
                 eprintln!(
                     "[credential-leases] cleanup of {} for {} failed: {err}",
@@ -1555,13 +1566,25 @@ fn run_deferred_cleanup_in(
     }
     for path in parked {
         let cleanup_result = match symlink_metadata_if_present(&path) {
-            Ok(None) => Ok(()),
+            Ok(None) => Ok(false),
             Ok(Some(_)) => validate_reaped_directory(&path, None)
-                .and_then(|(boundary, canonical)| remove_tree_no_follow(&canonical, &boundary)),
+                .and_then(|(boundary, canonical)| remove_tree_no_follow(&canonical, &boundary))
+                .map(|()| true),
             Err(error) => Err(error),
         };
-        let removed = match cleanup_result {
-            Ok(()) => true,
+        let resolved = match cleanup_result {
+            Ok(deleted) => {
+                if deleted {
+                    crate::credential_audit::record(
+                        crate::credential_audit::EVENT_LEASE_HOME_REMOVED,
+                        kind_for_reaped_path(&path).unwrap_or(""),
+                        "",
+                        "daemon",
+                        "parked reaped home deleted on retry".to_string(),
+                    );
+                }
+                true
+            }
             Err(err) => {
                 eprintln!(
                     "[credential-leases] retry cleanup of {} failed: {err}",
@@ -1570,7 +1593,7 @@ fn run_deferred_cleanup_in(
                 false
             }
         };
-        if removed {
+        if resolved {
             pending_reaped_paths()
                 .write()
                 .expect("pending reaped paths poisoned")
@@ -1579,12 +1602,40 @@ fn run_deferred_cleanup_in(
     }
 }
 
-fn queue_materialization_cleanup(kind: &str) {
-    if materialization_plan(kind).is_some() {
-        pending_materialization_cleanup()
-            .write()
-            .expect("pending materialization cleanup poisoned")
-            .insert(kind.to_string());
+/// The lease kind whose reaped-home name (`.reap-<dir>-<nonce>`) this
+/// path carries — audit attribution for retried deletions, where only
+/// the path survives.
+fn kind_for_reaped_path(path: &Path) -> Option<&'static str> {
+    let name = path.file_name()?.to_str()?;
+    ["oauth:codex", "oauth:claude-code", "oauth:kimi"]
+        .into_iter()
+        .find(|kind| {
+            materialization_plan(kind)
+                .is_some_and(|plan| name.starts_with(&format!(".reap-{}-", plan.dir_name)))
+        })
+}
+
+/// Park a kind's home deletion for a later sweep, recording WHY in the
+/// custody trail. The event fires only on the transition into the queue —
+/// re-parking an already-parked kind (every later sweep pass that still
+/// finds the blocker) stays silent, so the trail shows decisions, not
+/// polling.
+fn queue_materialization_cleanup(kind: &str, reason: &str) {
+    if materialization_plan(kind).is_none() {
+        return;
+    }
+    let newly_queued = pending_materialization_cleanup()
+        .write()
+        .expect("pending materialization cleanup poisoned")
+        .insert(kind.to_string());
+    if newly_queued {
+        crate::credential_audit::record(
+            crate::credential_audit::EVENT_LEASE_CLEANUP_DEFERRED,
+            kind,
+            "",
+            "daemon",
+            reason.to_string(),
+        );
     }
 }
 
@@ -1741,7 +1792,10 @@ pub fn startup_materialization_sweep() {
                     root.display()
                 );
                 for kind in ["oauth:codex", "oauth:claude-code", "oauth:kimi"] {
-                    queue_materialization_cleanup(kind);
+                    queue_materialization_cleanup(
+                        kind,
+                        "startup sweep refused unsafe materialization root",
+                    );
                 }
                 crate::lease_transcript_staging::gc_staging(&staging.staging, now_unix_ms() as i64);
                 crate::credential_audit::record_reset();
@@ -1751,6 +1805,7 @@ pub fn startup_materialization_sweep() {
         // Crash leftovers can hold transcripts from the previous process's
         // leased sessions — stage them before the sweep deletes the root
         // (works with no indexer running; the drainer picks them up later).
+        let mut swept_kinds: Vec<&str> = Vec::new();
         for kind in ["oauth:codex", "oauth:claude-code", "oauth:kimi"] {
             if let Some(plan) = materialization_plan(kind) {
                 let home = canonical_root.join(plan.dir_name);
@@ -1759,6 +1814,7 @@ pub fn startup_materialization_sweep() {
                     .is_some_and(|canonical| canonical.parent() == Some(canonical_root.as_path()))
                 {
                     stage_before_removal(&plan, &home, &staging);
+                    swept_kinds.push(kind);
                 }
             }
         }
@@ -1783,13 +1839,29 @@ pub fn startup_materialization_sweep() {
                 }
             }
         }
-        if let Err(err) = remove_tree_no_follow(&canonical_root, &canonical_root) {
-            eprintln!(
-                "[credential-leases] startup sweep of {} failed: {err}",
-                canonical_root.display()
-            );
-            for kind in ["oauth:codex", "oauth:claude-code", "oauth:kimi"] {
-                queue_materialization_cleanup(kind);
+        match remove_tree_no_follow(&canonical_root, &canonical_root) {
+            Ok(()) => {
+                for kind in swept_kinds {
+                    crate::credential_audit::record(
+                        crate::credential_audit::EVENT_LEASE_HOME_REMOVED,
+                        kind,
+                        "",
+                        "daemon",
+                        "startup sweep: no lease survives a restart".to_string(),
+                    );
+                }
+            }
+            Err(err) => {
+                eprintln!(
+                    "[credential-leases] startup sweep of {} failed: {err}",
+                    canonical_root.display()
+                );
+                for kind in ["oauth:codex", "oauth:claude-code", "oauth:kimi"] {
+                    queue_materialization_cleanup(
+                        kind,
+                        "startup sweep failed to delete materialization root",
+                    );
+                }
             }
         }
     }
@@ -2052,7 +2124,10 @@ pub fn revoke(selector: Option<&str>, actor: &str, via: &str) -> usize {
                 continue;
             }
             if kind_has_provisional_leased_startup(kind) && !final_shutdown {
-                queue_materialization_cleanup(kind);
+                queue_materialization_cleanup(
+                    kind,
+                    "revoked: provisional leased startup still in flight",
+                );
                 continue;
             }
             match reap_materialization(&root, kind) {
@@ -2065,7 +2140,7 @@ pub fn revoke(selector: Option<&str>, actor: &str, via: &str) -> usize {
                 }
                 Err(err) => {
                     eprintln!("[credential-leases] revoked lease cleanup for {kind} failed: {err}");
-                    queue_materialization_cleanup(kind);
+                    queue_materialization_cleanup(kind, &format!("revoked: reap failed: {err}"));
                 }
             }
         }
@@ -2213,6 +2288,148 @@ mod tests {
         *child_dns_credential_scrub_state().write().unwrap() =
             DnsCredentialChildScrubState::default();
         leased_home_sessions().write().unwrap().clear();
+    }
+
+    #[test]
+    fn per_request_auth_follows_lease_lifecycle() {
+        // Env lock first (scrubbing the ambient provider vars this test's
+        // dry-path assertions depend on), then the module store lock — the
+        // one ordering used for both, so no cycle can form.
+        let _env = crate::test_support::TEST_ENV_LOCK.blocking_lock();
+        let saved: Vec<(&str, Option<String>)> = ["ANTHROPIC_API_KEY", "ANTHROPIC"]
+            .into_iter()
+            .map(|name| (name, std::env::var(name).ok()))
+            .collect();
+        for (name, _) in &saved {
+            std::env::remove_var(name);
+        }
+        let _guard = lock();
+        reset();
+        grant(
+            "api_key:anthropic",
+            "vault",
+            "sk-lease-material-1",
+            None,
+            "owner",
+            "test",
+            Some(MIN_TTL_MS),
+            Some(0),
+        )
+        .unwrap();
+        let auth = crate::provider::ProviderAuth::PerRequest {
+            env_name: "ANTHROPIC_API_KEY",
+            project_key: None,
+        };
+        assert_eq!(auth.request_key().unwrap(), "sk-lease-material-1");
+        // A mid-session re-grant serves fresh material at the next request.
+        grant(
+            "api_key:anthropic",
+            "vault",
+            "sk-lease-material-2",
+            None,
+            "owner",
+            "test",
+            Some(MIN_TTL_MS),
+            Some(0),
+        )
+        .unwrap();
+        assert_eq!(auth.request_key().unwrap(), "sk-lease-material-2");
+        // Revocation goes dry at the next request boundary — the running
+        // session keeps no captured copy (the per-request re-validation fix).
+        revoke(Some("api_key:anthropic"), "test", "local");
+        let err = auth.request_key().unwrap_err().to_string();
+        assert!(err.contains("went dry mid-session"), "{err}");
+        // With a project overlay present, the request falls back instead.
+        let overlaid = crate::provider::ProviderAuth::PerRequest {
+            env_name: "ANTHROPIC_API_KEY",
+            project_key: Some("sk-project".to_string()),
+        };
+        assert_eq!(overlaid.request_key().unwrap(), "sk-project");
+        reset();
+        for (name, value) in saved {
+            match value {
+                Some(value) => std::env::set_var(name, value),
+                None => std::env::remove_var(name),
+            }
+        }
+    }
+
+    #[test]
+    fn deferred_cleanup_and_home_removal_reach_custody_trail() {
+        let _guard = lock();
+        reset();
+        let started = now_unix_ms();
+        let case = tempfile::tempdir().unwrap();
+        let root = case.path().join("leased-auth");
+        let staging = crate::lease_transcript_staging::StagingPaths {
+            staging: case.path().join("staging"),
+            active: case.path().join("active"),
+        };
+        materialize_kind(
+            &root,
+            &staging,
+            "oauth:codex",
+            r#"{"tokens":{"access_token":"at"}}"#,
+        )
+        .unwrap();
+        // An expired lease whose CLI session is still running: register the
+        // session while the lease is live, then backdate it to expiry.
+        grant(
+            "oauth:codex",
+            "Codex",
+            r#"{"tokens":{"access_token":"at"}}"#,
+            Some("access_token"),
+            "owner",
+            "test",
+            Some(MIN_TTL_MS),
+            Some(0),
+        )
+        .unwrap();
+        note_leased_session_running("codex", &["k1-defer-session"]);
+        store()
+            .write()
+            .unwrap()
+            .get_mut("oauth:codex")
+            .unwrap()
+            .renewed_at_unix_ms = 1;
+        sweep_now_in(&root, &staging);
+        assert!(
+            pending_materialization_cleanup()
+                .read()
+                .unwrap()
+                .contains("oauth:codex"),
+            "expired home must be parked while its session runs"
+        );
+        assert!(
+            root.join("codex-home").exists(),
+            "parked home must remain on disk"
+        );
+        let deferred = crate::credential_audit::recent(200)
+            .into_iter()
+            .any(|event| {
+                event.event == crate::credential_audit::EVENT_LEASE_CLEANUP_DEFERRED
+                    && event.kind == "oauth:codex"
+                    && event.at_unix_ms >= started
+                    && event.detail.contains("leased session still running")
+            });
+        assert!(deferred, "deferral must reach the custody trail");
+        // The session ends: the next sweep reaps, deletes, and records it.
+        leased_home_sessions().write().unwrap().clear();
+        sweep_now_in(&root, &staging);
+        assert!(
+            !root.join("codex-home").exists(),
+            "home must be deleted once the session is gone"
+        );
+        let removed = crate::credential_audit::recent(200)
+            .into_iter()
+            .any(|event| {
+                event.event == crate::credential_audit::EVENT_LEASE_HOME_REMOVED
+                    && event.kind == "oauth:codex"
+                    && event.at_unix_ms >= started
+                    && event.detail.contains("reaped leased auth home deleted")
+            });
+        assert!(removed, "deletion must reach the custody trail");
+        reset();
     }
 
     #[test]
@@ -2604,7 +2821,7 @@ mod tests {
         let home = tmp.path().join("codex-home");
         std::fs::create_dir_all(&home).unwrap();
         std::fs::write(home.join("auth.json"), "LEFTOVER").unwrap();
-        queue_materialization_cleanup("oauth:codex");
+        queue_materialization_cleanup("oauth:codex", "test");
 
         let now = now_unix_ms();
         let mut leases: HashMap<String, CredentialLease> = HashMap::new();
@@ -3450,7 +3667,7 @@ mod tests {
         // active material is removed with no expiry tombstone, and cleanup
         // parks because the provisional process could otherwise recreate it.
         store().write().unwrap().remove("oauth:claude-code");
-        queue_materialization_cleanup("oauth:claude-code");
+        queue_materialization_cleanup("oauth:claude-code", "test");
         assert!(reap_parked_kinds(&HashMap::new(), &root, Some("oauth:claude-code")).is_empty());
 
         let error = startup.promote(&["wrapper", "backend"]).unwrap_err();
@@ -3496,7 +3713,7 @@ mod tests {
         .unwrap()
         .expect("hold");
         store().write().unwrap().remove("oauth:codex");
-        queue_materialization_cleanup("oauth:codex");
+        queue_materialization_cleanup("oauth:codex", "test");
 
         let cleanup =
             reap_parked_kinds_with_policy(&HashMap::new(), &root, Some("oauth:codex"), false);
@@ -3591,7 +3808,7 @@ mod tests {
             .write()
             .unwrap()
             .insert("sess-live".to_string(), "oauth:codex".to_string());
-        queue_materialization_cleanup("oauth:codex");
+        queue_materialization_cleanup("oauth:codex", "test");
 
         // A selector for a different kind leaves the parked home alone.
         let leases: HashMap<String, CredentialLease> = HashMap::new();
@@ -3614,7 +3831,7 @@ mod tests {
         // home belongs to the new lease.
         std::fs::create_dir_all(&home).unwrap();
         std::fs::write(home.join("auth.json"), "FRESH").unwrap();
-        queue_materialization_cleanup("oauth:codex");
+        queue_materialization_cleanup("oauth:codex", "test");
         let now = now_unix_ms();
         let mut active: HashMap<String, CredentialLease> = HashMap::new();
         active.insert(

--- a/src/bin/caller/provider/anthropic.rs
+++ b/src/bin/caller/provider/anthropic.rs
@@ -249,12 +249,13 @@ impl AnthropicProvider {
     ) -> Result<ProviderHttpResponse, CallerError> {
         let url = format!("{}/v1/messages", self.endpoint);
         match &self.auth {
-            ProviderAuth::Key(api_key) => {
+            auth @ (ProviderAuth::Key(_) | ProviderAuth::PerRequest { .. }) => {
+                let api_key = auth.request_key()?;
                 let builder = || {
                     let request = self
                         .client
                         .post(&url)
-                        .header("x-api-key", api_key)
+                        .header("x-api-key", api_key.as_ref())
                         .header("anthropic-version", "2023-06-01")
                         .header("anthropic-beta", beta_header)
                         .header("content-type", "application/json")

--- a/src/bin/caller/provider/gemini.rs
+++ b/src/bin/caller/provider/gemini.rs
@@ -114,13 +114,14 @@ impl GeminiProvider {
         streaming: bool,
     ) -> Result<ProviderHttpResponse, CallerError> {
         match &self.auth {
-            ProviderAuth::Key(api_key) => {
+            auth @ (ProviderAuth::Key(_) | ProviderAuth::PerRequest { .. }) => {
+                let api_key = auth.request_key()?;
                 let builder = || {
                     let request = self
                         .client
                         .post(url)
                         .header("content-type", "application/json")
-                        .header("x-goog-api-key", api_key)
+                        .header("x-goog-api-key", api_key.as_ref())
                         .body(request_body.clone());
                     if streaming {
                         request.timeout(STREAM_TIMEOUT)

--- a/src/bin/caller/provider/mod.rs
+++ b/src/bin/caller/provider/mod.rs
@@ -159,16 +159,27 @@ pub struct ChatResponse {
     pub raw_output: Option<Vec<serde_json::Value>>,
 }
 
-/// How a provider instance authenticates its requests: a real key
-/// (lease or environment) attached daemon-side, or the client-egress
-/// marker — a registered browser relay holds the credential, the daemon
-/// ships auth-less requests to it, and the browser attaches the key
+/// How a provider instance authenticates its requests: a fixed key
+/// captured at construction, the per-request marker that re-resolves the
+/// lease/env chain on every request, or the client-egress marker — a
+/// registered browser relay holds the credential, the daemon ships
+/// auth-less requests to it, and the browser attaches the key
 /// (credential custody, rollout step 5). `From<String>` keeps every
 /// existing key-shaped construction site source-compatible.
 #[derive(Debug, Clone)]
 pub enum ProviderAuth {
     Key(String),
-    ClientEgress { kind: &'static str },
+    /// Re-resolved through `credential_leases::provider_api_key` at every
+    /// request boundary, with the session project's `.env` overlay as the
+    /// last layer — so lease revocation, expiry, re-grant, and dashboard
+    /// key saves take effect at the next request instead of session end.
+    PerRequest {
+        env_name: &'static str,
+        project_key: Option<String>,
+    },
+    ClientEgress {
+        kind: &'static str,
+    },
 }
 
 impl From<String> for ProviderAuth {
@@ -177,16 +188,80 @@ impl From<String> for ProviderAuth {
     }
 }
 
-/// The credential a selector binds for a provider: a real key first
-/// (lease shadows env, as everywhere), else the egress marker when a
-/// browser relay is attached for the kind.
-fn provider_auth_for(env_name: &str, egress_kind: &'static str) -> Option<ProviderAuth> {
-    crate::credential_leases::provider_api_key(env_name)
-        .map(ProviderAuth::Key)
-        .or_else(|| {
-            crate::credential_egress::available(egress_kind)
-                .then_some(ProviderAuth::ClientEgress { kind: egress_kind })
-        })
+impl ProviderAuth {
+    /// The credential for the request being built *now*. `Key` is a fixed
+    /// capture; `PerRequest` re-resolves so a revoked or expired lease
+    /// stops fueling at the next request boundary, failing closed with a
+    /// named error when nothing replaces it. The egress marker carries no
+    /// daemon-side key by design — callers route it before asking.
+    pub(crate) fn request_key(&self) -> Result<std::borrow::Cow<'_, str>, CallerError> {
+        match self {
+            ProviderAuth::Key(key) => Ok(std::borrow::Cow::Borrowed(key.as_str())),
+            ProviderAuth::PerRequest {
+                env_name,
+                project_key,
+            } => {
+                if let Some(key) = crate::credential_leases::provider_api_key(env_name) {
+                    return Ok(std::borrow::Cow::Owned(key));
+                }
+                if let Some(key) = project_key {
+                    return Ok(std::borrow::Cow::Borrowed(key.as_str()));
+                }
+                let note = crate::credential_leases::expired_lease_note()
+                    .map(|note| format!(" — {note}"))
+                    .unwrap_or_default();
+                Err(CallerError::Config(format!(
+                    "{env_name} went dry mid-session: no credential lease, environment \
+                     key, or project key currently serves it{note}"
+                )))
+            }
+            ProviderAuth::ClientEgress { kind } => Err(CallerError::Config(format!(
+                "client-egress auth for {kind} carries no daemon-side key; \
+                 this request path requires a direct credential"
+            ))),
+        }
+    }
+}
+
+/// The credential a selector binds for a provider: available iff the
+/// lease/env chain (or the project overlay) serves a key right now, but
+/// bound as `PerRequest` so every request re-resolves. Precedence matches
+/// the pre-per-request selectors: key sources first (lease shadows env,
+/// as everywhere), else the egress marker when a browser relay is
+/// attached, else the project overlay alone.
+fn provider_auth_with_project(
+    env_name: &'static str,
+    egress_kind: Option<&'static str>,
+    project_keys: &ProjectEnvKeys,
+) -> Option<ProviderAuth> {
+    let project_key = project_keys.get(env_name);
+    if crate::credential_leases::provider_api_key(env_name).is_some() {
+        return Some(ProviderAuth::PerRequest {
+            env_name,
+            project_key,
+        });
+    }
+    if let Some(kind) = egress_kind {
+        if crate::credential_egress::available(kind) {
+            return Some(ProviderAuth::ClientEgress { kind });
+        }
+    }
+    project_key.map(|key| ProviderAuth::PerRequest {
+        env_name,
+        project_key: Some(key),
+    })
+}
+
+/// [`provider_auth_with_project`] for the selectors that carry no session
+/// project overlay.
+fn provider_auth_for(env_name: &'static str, egress_kind: &'static str) -> Option<ProviderAuth> {
+    provider_auth_with_project(env_name, Some(egress_kind), &ProjectEnvKeys::none())
+}
+
+/// Per-request OpenAI auth for the selectors that carry no session
+/// project overlay (OpenAI has no egress lane today).
+fn openai_auth() -> Option<ProviderAuth> {
+    provider_auth_with_project("OPENAI_API_KEY", None, &ProjectEnvKeys::none())
 }
 
 /// The provider API-key environment variables — the single authoritative
@@ -664,15 +739,17 @@ pub fn select_provider_for_project(
 fn select_provider_with_project_keys(
     project_keys: &ProjectEnvKeys,
 ) -> Result<Box<dyn ChatProvider>, CallerError> {
-    let openai_key = crate::credential_leases::provider_api_key("OPENAI_API_KEY")
-        .or_else(|| project_keys.get("OPENAI_API_KEY"));
-    let anthropic_key = provider_auth_for(
+    let openai_key = provider_auth_with_project("OPENAI_API_KEY", None, project_keys);
+    let anthropic_key = provider_auth_with_project(
         "ANTHROPIC_API_KEY",
-        crate::credential_egress::KIND_ANTHROPIC,
-    )
-    .or_else(|| project_keys.get("ANTHROPIC_API_KEY").map(ProviderAuth::Key));
-    let gemini_key = provider_auth_for("GEMINI_API_KEY", crate::credential_egress::KIND_GEMINI)
-        .or_else(|| project_keys.get("GEMINI_API_KEY").map(ProviderAuth::Key));
+        Some(crate::credential_egress::KIND_ANTHROPIC),
+        project_keys,
+    );
+    let gemini_key = provider_auth_with_project(
+        "GEMINI_API_KEY",
+        Some(crate::credential_egress::KIND_GEMINI),
+        project_keys,
+    );
 
     let preferred = env::var("PROVIDER").ok();
 
@@ -816,7 +893,7 @@ pub fn select_provider_with_overrides(
         .map(|s| s.to_string())
         .or_else(|| env::var("PRESENCE_MODEL").ok());
 
-    let openai_key = crate::credential_leases::provider_api_key("OPENAI_API_KEY");
+    let openai_key = openai_auth();
     let anthropic_key = provider_auth_for(
         "ANTHROPIC_API_KEY",
         crate::credential_egress::KIND_ANTHROPIC,
@@ -893,7 +970,7 @@ pub fn select_cu_provider(
         .map(String::from)
         .or_else(|| env::var("CU_MODEL").ok());
 
-    let openai_key = crate::credential_leases::provider_api_key("OPENAI_API_KEY");
+    let openai_key = openai_auth();
     let anthropic_key = provider_auth_for(
         "ANTHROPIC_API_KEY",
         crate::credential_egress::KIND_ANTHROPIC,
@@ -1013,7 +1090,7 @@ pub fn select_presence_provider(
         .map(|s| s.to_string())
         .or_else(|| env::var("PRESENCE_MODEL").ok());
 
-    let openai_key = crate::credential_leases::provider_api_key("OPENAI_API_KEY");
+    let openai_key = openai_auth();
     let anthropic_key = provider_auth_for(
         "ANTHROPIC_API_KEY",
         crate::credential_egress::KIND_ANTHROPIC,
@@ -1262,6 +1339,45 @@ pub mod mock {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn request_key_static_and_egress_shapes() {
+        let auth = ProviderAuth::Key("sk-static".to_string());
+        assert_eq!(auth.request_key().unwrap(), "sk-static");
+        let egress = ProviderAuth::ClientEgress {
+            kind: crate::credential_egress::KIND_ANTHROPIC,
+        };
+        let err = egress.request_key().unwrap_err().to_string();
+        assert!(err.contains("client-egress"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn per_request_auth_re_resolves_every_request() {
+        let _env = crate::test_support::TEST_ENV_LOCK.lock().await;
+        const NAME: &str = "INTENDANT_TEST_PER_REQUEST_KEY";
+        std::env::remove_var(NAME);
+        let auth = ProviderAuth::PerRequest {
+            env_name: NAME,
+            project_key: Some("sk-project".to_string()),
+        };
+        // No env key: the project overlay is the last layer.
+        assert_eq!(auth.request_key().unwrap(), "sk-project");
+        // A key appearing mid-session is served at the next request…
+        std::env::set_var(NAME, "sk-env-1");
+        assert_eq!(auth.request_key().unwrap(), "sk-env-1");
+        // …and so is a replacement: nothing is captured at construction.
+        std::env::set_var(NAME, "sk-env-2");
+        assert_eq!(auth.request_key().unwrap(), "sk-env-2");
+        std::env::remove_var(NAME);
+        // Fully dry: fail closed with a named error.
+        let dry = ProviderAuth::PerRequest {
+            env_name: NAME,
+            project_key: None,
+        };
+        let err = dry.request_key().unwrap_err().to_string();
+        assert!(err.contains("went dry mid-session"), "{err}");
+        assert!(err.contains(NAME), "{err}");
+    }
 
     #[test]
     fn project_env_keys_whitelists_provider_keys_only() {

--- a/src/bin/caller/provider/openai.rs
+++ b/src/bin/caller/provider/openai.rs
@@ -221,7 +221,7 @@ impl ResponsesUsage {
 
 pub struct OpenAIProvider {
     client: Client,
-    api_key: String,
+    auth: ProviderAuth,
     model: String,
     context_window: u64,
     max_output_tokens: u64,
@@ -237,7 +237,7 @@ pub struct OpenAIProvider {
 
 impl OpenAIProvider {
     pub fn new(
-        api_key: String,
+        api_key: impl Into<ProviderAuth>,
         model: String,
         context_window: u64,
         max_output_tokens: u64,
@@ -248,7 +248,7 @@ impl OpenAIProvider {
 
         Self {
             client: api_client(),
-            api_key,
+            auth: api_key.into(),
             model,
             context_window,
             max_output_tokens,
@@ -263,14 +263,14 @@ impl OpenAIProvider {
 
     #[allow(dead_code)]
     pub fn new_plain(
-        api_key: String,
+        api_key: impl Into<ProviderAuth>,
         model: String,
         context_window: u64,
         max_output_tokens: u64,
     ) -> Self {
         Self {
             client: api_client(),
-            api_key,
+            auth: api_key.into(),
             model,
             context_window,
             max_output_tokens,
@@ -284,7 +284,7 @@ impl OpenAIProvider {
     }
 
     pub fn new_with_tools(
-        api_key: String,
+        api_key: impl Into<ProviderAuth>,
         model: String,
         context_window: u64,
         max_output_tokens: u64,
@@ -292,7 +292,7 @@ impl OpenAIProvider {
     ) -> Self {
         Self {
             client: api_client(),
-            api_key,
+            auth: api_key.into(),
             model,
             context_window,
             max_output_tokens,
@@ -339,7 +339,7 @@ impl ChatProvider for OpenAIProvider {
         // is applied server-side and reported via usage.prompt_tokens_details.
         let prepared = self.prepare_request(messages, false)?;
         let client = &self.client;
-        let api_key = &self.api_key;
+        let api_key = self.auth.request_key()?;
         let response = send_with_retry(
             client,
             || {
@@ -566,7 +566,7 @@ impl ChatProvider for OpenAIProvider {
         on_event: &(dyn Fn(StreamEvent) + Send + Sync),
     ) -> Result<ChatResponse, CallerError> {
         let client = &self.client;
-        let api_key = &self.api_key;
+        let api_key = self.auth.request_key()?;
 
         // Same retry policy as non-streaming: the status is known before any
         // body bytes stream, so a 429/5xx at request-open retries with


### PR DESCRIPTION
Track K (credential-custody migration), slice K1 — the ratified first slice, non-custodial, landed while the K0 intake awaits its ruling.

**Per-request lease re-validation.** `ProviderAuth::Key` captured the resolved key at provider construction, so a revoked or expired lease kept fueling every running native session until session end. Native selectors now bind `ProviderAuth::PerRequest`, which re-runs the lease → env chain (project-`.env` overlay as the last layer) at every request boundary. Revocation, expiry, re-grant, and dashboard key saves take effect at the next request; a fully dry source fails closed with a named error that carries the expired-lease note. OpenAI joins `ProviderAuth` (previously a bare `String` field); `From<String>` keeps every existing construction site compiling.

**Companion custody-trail events** (`credential_audit.rs`): `lease_cleanup_deferred` fires once per transition that parks a dead lease's materialized auth home (live leased session, provisional startup, failed reap, unsafe startup root — reason recorded); `lease_home_removed` records every actual deletion (sweep reap, parked-path retry, startup sweep).

**Tests**: per-request re-resolution across env/project/dry states; lease lifecycle (grant → re-grant → revoke → project fallback) proving no captured copy survives revocation; a hermetic tempdir rig driving defer → session-end → reap and asserting both events reach the trail. Battery: bins 4555+148+97, lib crates, fmt, clippy `-D warnings`, mock e2e 30/30 — all green.