### PR TITLE
explorer: memory curation — judgment actions, history, supersession navigation (Track J J2)

### DIFF
--- a/src/bin/caller/memory/service.rs
+++ b/src/bin/caller/memory/service.rs
@@ -15,7 +15,7 @@ use crate::access::actor::{ActorBinding, ActorKind as GateActorKind};
 use super::plane::EphemeralPlane;
 use super::types::{
     hex32, ClaimProvenance, ClaimView, JudgeArgs, JudgmentView, MemoryError, ProposeArgs,
-    SearchArgs, MAX_REASON_CHARS,
+    SearchArgs, MAX_REASON_CHARS, MINTED_VERDICTS,
 };
 
 /// Search results are hard-capped regardless of the caller's ask
@@ -631,7 +631,7 @@ impl MemoryService {
                 return Err(MemoryError::Vocabulary {
                     what: "verdict",
                     got: other.to_string(),
-                    allowed: "accept, dispute, retire, supersede".into(),
+                    allowed: MINTED_VERDICTS.join(", "),
                 })
             }
         };
@@ -1280,6 +1280,31 @@ mod tests {
             options("memory-add-sensitivity"),
             kernel(&Class::ALL.iter().map(|c| c.as_str()).collect::<Vec<_>>()),
             "memory-add-sensitivity options drifted from Class::ALL"
+        );
+    }
+
+    /// The Explorer's curation buttons are a static mirror of the
+    /// service's MINTED verdict set (the same derive-don't-mirror
+    /// parity pin as the vocab selects): a verdict added or removed
+    /// on either side without the other fails here instead of
+    /// shipping as drift. Order included — the row reads in the
+    /// service's canonical order.
+    #[test]
+    fn explorer_verdict_actions_mirror_the_minted_set() {
+        let app = include_str!("../../../../static/app.html");
+        // The fragment renders the buttons through its `verb(...)`
+        // template helper — extract the literal call arguments in
+        // source order.
+        let mut buttons = Vec::new();
+        for (at, _) in app.match_indices("${verb('") {
+            let rest = &app[at + "${verb('".len()..];
+            let end = rest.find('\'').expect("unterminated verb call");
+            buttons.push(rest[..end].to_string());
+        }
+        assert_eq!(
+            buttons,
+            MINTED_VERDICTS.to_vec(),
+            "Explorer curation buttons drifted from MINTED_VERDICTS"
         );
     }
 

--- a/src/bin/caller/memory/types.rs
+++ b/src/bin/caller/memory/types.rs
@@ -39,6 +39,15 @@ fn default_sensitivity() -> String {
 /// this DTO-edge bound rejects loudly, never truncates.
 pub(crate) const MAX_REASON_CHARS: usize = 2000;
 
+/// The verdict vocabulary this build MINTS — the v1 subset of the
+/// kernel's closed §11.1 set (retract stays author/agent-lane
+/// machinery surfaced read-only; raise_class/declassify are
+/// fail-closed classification arms; pins are fail-closed at the
+/// stamped kernel). Single source: the service's judge match, its
+/// rejection text, and the Explorer's curation buttons (parity test)
+/// all derive from this list.
+pub(crate) const MINTED_VERDICTS: &[&str] = &["accept", "dispute", "retire", "supersede"];
+
 /// Arguments for a judgment (`judge` — the owner curation lane).
 /// `verdict` is the v1-minted subset of the kernel's closed §11.1
 /// vocabulary: `accept`, `dispute`, `retire`, `supersede` (retract is

--- a/static/app/ui2-memory.css
+++ b/static/app/ui2-memory.css
@@ -114,8 +114,9 @@ html.ui-v2 .memory-item-head {
   gap: 8px;
   flex-wrap: wrap;
 }
-/* Derived status chip: candidate is the authoring state; judgments
-   (a later slice) move claims to the other states. */
+/* Derived status chip: candidate is the authoring state; owner
+   judgments (the curation row below) move claims to the other
+   states. */
 html.ui-v2 .memory-status {
   font-family: var(--mono);
   font-size: 9.5px;
@@ -198,4 +199,85 @@ html.ui-v2 .memory-detail-value {
   font-size: 11px;
   color: var(--text-2);
   overflow-wrap: anywhere;
+}
+
+/* ---- Curation (Track J J2): judgment history + owner verdict
+   actions. ---- */
+html.ui-v2 .memory-judgments {
+  border-top: 1px dashed var(--line);
+  margin-top: 5px;
+  padding-top: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+html.ui-v2 .memory-judgment-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 11.5px;
+}
+html.ui-v2 .memory-judgment-verdict {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 1px 8px;
+  color: var(--text-3);
+}
+html.ui-v2 .memory-judgment-verdict[data-verdict="accept"] { color: var(--green); }
+html.ui-v2 .memory-judgment-verdict[data-verdict="dispute"] { color: var(--amber); }
+html.ui-v2 .memory-judgment-verdict[data-verdict="supersede"] { color: var(--iris); }
+html.ui-v2 .memory-judgment-meta {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--text-3);
+}
+/* Reasons are quoted data — rendered as text in quotation marks. */
+html.ui-v2 .memory-judgment-reason {
+  flex-basis: 100%;
+  font-size: 11.5px;
+  color: var(--text-2);
+  padding-left: 12px;
+  overflow-wrap: anywhere;
+}
+html.ui-v2 .memory-judgment-successor {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--iris);
+  text-decoration: none;
+}
+html.ui-v2 .memory-judgment-successor:hover { text-decoration: underline; }
+html.ui-v2 .memory-curation {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 6px;
+}
+html.ui-v2 .memory-judge-btn {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-2);
+  background: var(--surface-2);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 3px 12px;
+  cursor: pointer;
+}
+html.ui-v2 .memory-judge-btn:hover {
+  color: var(--text);
+  border-color: var(--iris);
+}
+html.ui-v2 .memory-judge-strip input[type="text"] {
+  flex: 1 1 200px;
+  min-width: 140px;
+}
+html.ui-v2 .memory-judge-strip select {
+  max-width: 340px;
 }

--- a/static/app/ui2-memory.js
+++ b/static/app/ui2-memory.js
@@ -1,7 +1,11 @@
-// Memory Explorer: browse/search the daemon's P1 Memory plane and
-// propose claims (#tab-memory). Data flows through daemonApi (tunnel
-// `api_memory_search` / `api_memory_propose`, HTTP twin fallback) and
-// refreshes live on the `memory_changed` event lane. The plane is
+// Memory Explorer: browse/search the daemon's Memory plane, propose
+// claims, and CURATE them (#tab-memory). Data flows through daemonApi
+// (tunnel `api_memory_search` / `api_memory_propose` /
+// `api_memory_judge` / `api_memory_claim`, HTTP twin fallback) and
+// refreshes live on the `memory_changed` event lane. Judgments are
+// owner acts sealed as attributed append-only plane ops — status is
+// re-derived by the kernel fold, never edited; the verdict actions
+// here mirror exactly the service's minted set (parity-pinned). The plane is
 // durable or ephemeral according to daemon custody support, and the
 // pane renders the effective mode reported by the service.
 //
@@ -22,6 +26,15 @@ let memoryLoadError = '';
 let memoryQuery = '';
 let memoryExpandedId = '';
 let memoryDurability = 'ephemeral';
+// Full view of the expanded claim (api_memory_claim read — search rows
+// are lean by §6.5, so judgment HISTORY only exists on the read view).
+let memoryDetail = null; // { id, claim } | null
+let memoryDetailInFlight = '';
+// Curation state: which verdict's confirm strip is open on the
+// expanded card ('' = none). Judgments are owner acts; this surface
+// is the owner's dashboard.
+let memoryJudgePick = '';
+let memoryJudgeBusy = false;
 
 async function memoryRefresh() {
   if (memoryFetchInFlight) {
@@ -64,6 +77,12 @@ async function memoryRefresh() {
 // filter — refetch (bounded + coalesced) when any surface holds data.
 function memoryObserveServerMessage(d) {
   if (!d || !d.claim || !d.claim.id) return;
+  // Judgment broadcasts carry the full view (history included): a
+  // change to the expanded claim updates its detail pane in place —
+  // curation from another surface (ctl, a second tab) repaints live.
+  if (memoryExpandedId && d.claim.id === memoryExpandedId && Array.isArray(d.claim.judgments)) {
+    memoryDetail = { id: d.claim.id, claim: d.claim };
+  }
   if (memoryClaims === null) {
     if (memoryTabVisible()) memoryRefresh();
     return;
@@ -116,23 +135,196 @@ function memoryProvenanceLine(claim) {
   return escapeHtml(parts.join(' · '));
 }
 
+// Judgment provenance renders the DURABLE identity vocabulary the
+// service records (ruling R2: owner / session / peer / unattributed —
+// a dashboard-vs-ctl surface distinction cannot survive restart, so
+// none is pretended here).
+function memoryJudgeActorLabel(p) {
+  if (!p) return 'unattributed';
+  if (p.actor === 'owner') return 'you';
+  if (p.actor === 'session') return p.principal ? `session ${p.principal.slice(-12)}` : 'an attested session';
+  if (p.actor === 'peer') return 'a peer daemon';
+  return 'unattributed';
+}
+
+// One judgment history row: who judged what, when — the provenance is
+// the product. reason is quoted DATA (escaped, never markup); a
+// supersede row links its successor for navigation.
+function memoryJudgmentRow(j) {
+  const when = j.at_ms
+    ? new Date(j.at_ms).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+    : '';
+  const parts = [
+    `<span class="memory-judgment-verdict" data-verdict="${escapeHtml(j.verdict)}">${escapeHtml(j.verdict)}</span>`,
+    `<span class="memory-judgment-meta">by ${escapeHtml(memoryJudgeActorLabel(j.judged_by))}${when ? ` · ${escapeHtml(when)}` : ''}</span>`,
+  ];
+  if (j.replacement) {
+    parts.push(`<a class="memory-judgment-successor" data-goto="${escapeHtml(j.replacement)}" href="#memory" title="Open the superseding claim">→ ${escapeHtml(j.replacement.slice(0, 12))}</a>`);
+  }
+  const reason = j.reason
+    ? `<div class="memory-judgment-reason">“${escapeHtml(j.reason)}”</div>`
+    : '';
+  return `<div class="memory-judgment-row">${parts.join(' ')}${reason}</div>`;
+}
+
+// The curation row (owner surface): verdict actions with a CONFIRM
+// affordance — picking a verdict opens a strip with an optional
+// reason (DTO cap 2000) and, for supersede, the replacement picker;
+// nothing seals until Confirm. Pins are deliberately absent (they are
+// fail-closed at the stamped kernel — Track J finding #1).
+function memoryCurationBlock(claim) {
+  if (memoryJudgeBusy) {
+    return '<div class="memory-curation"><span class="memory-judgment-meta">judging…</span></div>';
+  }
+  if (!memoryJudgePick) {
+    const verb = (v) => `<button type="button" class="memory-judge-btn" data-judge="${v}">${v}</button>`;
+    return `<div class="memory-curation">
+      ${verb('accept')}${verb('dispute')}${verb('retire')}${verb('supersede')}
+    </div>`;
+  }
+  const others = (memoryClaims || []).filter((c) => c.id !== claim.id);
+  const replacementPicker = memoryJudgePick === 'supersede'
+    ? (others.length
+      ? `<select id="memory-judge-replacement" aria-label="Superseding claim">
+          ${others.map((c) => `<option value="${escapeHtml(c.id)}">${escapeHtml(c.id.slice(0, 12))} · ${escapeHtml(c.statement.slice(0, 60))} (${escapeHtml(c.status)})</option>`).join('')}
+        </select>
+        <span class="memory-judgment-meta">supersession takes effect once the replacement is accepted</span>`
+      : '<span class="memory-judgment-meta">no other claim to supersede with — propose the replacement first</span>')
+    : '';
+  const canConfirm = memoryJudgePick !== 'supersede' || others.length;
+  return `<div class="memory-curation memory-judge-strip">
+    <span class="memory-judgment-verdict" data-verdict="${escapeHtml(memoryJudgePick)}">${escapeHtml(memoryJudgePick)}</span>
+    ${replacementPicker}
+    <input id="memory-judge-reason" type="text" maxlength="2000"
+           placeholder="Reason (optional, recorded verbatim)" aria-label="Judgment reason" />
+    ${canConfirm ? '<button type="button" id="memory-judge-confirm">Confirm</button>' : ''}
+    <button type="button" id="memory-judge-cancel">Cancel</button>
+  </div>`;
+}
+
 function memoryDetailBlock(claim) {
-  const p = claim.proposed_by || {};
+  // The expanded card upgrades to the READ view (with judgment
+  // history) once its fetch lands; until then the lean search row
+  // renders with a loading note.
+  const full = memoryDetail && memoryDetail.id === claim.id ? memoryDetail.claim : null;
+  const c = full || claim;
+  const p = c.proposed_by || {};
   const row = (label, value) => value
     ? `<div class="memory-detail-row"><span class="memory-detail-label">${label}</span><span class="memory-detail-value">${escapeHtml(String(value))}</span></div>`
     : '';
-  const created = claim.created_ms ? new Date(claim.created_ms).toLocaleString() : '';
+  const created = c.created_ms ? new Date(c.created_ms).toLocaleString() : '';
+  const judgments = full
+    ? `<div class="memory-judgments">
+        <div class="memory-detail-label">judgments</div>
+        ${(full.judgments || []).length
+          ? full.judgments.map(memoryJudgmentRow).join('')
+          : '<div class="memory-judgment-meta">none — every claim starts as a candidate; judging it is your act</div>'}
+      </div>`
+    : '<div class="memory-judgment-meta">loading history…</div>';
   return `<div class="memory-item-detail">
-    ${row('claim id', claim.id)}
+    ${row('claim id', c.id)}
     ${row('created', created)}
     ${row('actor', p.actor)}
     ${row('principal', p.principal)}
     ${row('actor session', p.session)}
-    ${row('session context', claim.session)}
-    ${row('project', claim.project)}
-    ${row('model', claim.model)}
-    ${row('durability', claim.durability)}
+    ${row('session context', c.session)}
+    ${row('project', c.project)}
+    ${row('model', c.model)}
+    ${row('durability', c.durability)}
+    ${judgments}
+    ${memoryCurationBlock(c)}
   </div>`;
+}
+
+// Fetch the expanded claim's full read view (judgment history rides
+// only single-claim views). Coalesced per id; stale ids are dropped.
+async function memoryFetchDetail(id) {
+  if (!id || memoryDetailInFlight === id) return;
+  if (memoryDetail && memoryDetail.id === id) return;
+  memoryDetailInFlight = id;
+  try {
+    const resp = await daemonApi.request('api_memory_claim', { id });
+    if (memoryExpandedId !== id) return; // user moved on
+    if (resp.ok && resp.body && resp.body.claim) {
+      memoryDetail = { id, claim: resp.body.claim };
+    } else {
+      memoryDetail = null;
+      memoryFlashNote((resp.body && resp.body.error) || `claim read failed (${resp.status})`);
+    }
+  } catch (e) {
+    memoryFlashNote(String(e && e.message || e));
+  } finally {
+    if (memoryDetailInFlight === id) memoryDetailInFlight = '';
+    memoryRenderTab();
+  }
+}
+
+// Seal one judgment via the owner lane and report the HONEST outcome:
+// a supersede whose replacement is not yet accepted is recorded but
+// moves nothing (§11.2 rule 2) — the note says so instead of faking
+// atomicity (ruling R4).
+async function memoryJudgeConfirm(claimId) {
+  const verdict = memoryJudgePick;
+  if (!verdict) return;
+  const reasonEl = document.getElementById('memory-judge-reason');
+  const reason = reasonEl && reasonEl.value.trim() ? reasonEl.value.trim() : null;
+  const replacementEl = document.getElementById('memory-judge-replacement');
+  const replacement = verdict === 'supersede' && replacementEl ? replacementEl.value : null;
+  memoryJudgeBusy = true;
+  memoryRenderTab();
+  try {
+    const args = { verdict, id: claimId };
+    if (reason) args.reason = reason;
+    if (replacement) args.replacement = replacement;
+    const resp = await daemonApi.request('api_memory_judge', args);
+    if (resp.ok && resp.body && resp.body.claim) {
+      const after = resp.body.claim;
+      memoryDetail = { id: claimId, claim: after };
+      memoryJudgePick = '';
+      if (verdict === 'supersede' && after.status !== 'superseded') {
+        memoryFlashNote(`supersede recorded — takes effect once ${String(replacement || '').slice(0, 12)} is accepted (status: ${after.status})`);
+      } else {
+        memoryFlashNote(`${verdict} recorded — status: ${after.status}`);
+      }
+      memoryRefresh();
+    } else {
+      // Named outcomes (actor-not-permitted, policy-missing, the
+      // reason cap…) surface verbatim.
+      memoryFlashNote((resp.body && resp.body.error) || `judge failed (${resp.status})`);
+    }
+  } catch (e) {
+    memoryFlashNote(String(e && e.message || e));
+  } finally {
+    memoryJudgeBusy = false;
+    memoryRenderTab();
+  }
+}
+
+// Superseded → successor navigation: expand the linked claim. When
+// the current filter hides it, fall back to a direct read (the detail
+// pane renders from the read view, so navigation still works — the
+// list highlight just has nothing to scroll to).
+async function memoryGotoClaim(id) {
+  memoryExpandedId = id;
+  memoryDetail = null;
+  memoryJudgePick = '';
+  memoryFetchDetail(id);
+  const present = () => document.querySelector(`.memory-item[data-id="${CSS.escape(id)}"]`);
+  if (!present()) {
+    // The successor sits outside the current filter — widen to the
+    // unfiltered view (candidates on) so the card can render.
+    memoryQuery = '';
+    const search = document.getElementById('memory-search-input');
+    if (search) search.value = '';
+    const toggle = document.getElementById('memory-show-candidates');
+    if (toggle) toggle.checked = true;
+    await memoryRefresh();
+  } else {
+    memoryRenderTab();
+  }
+  const el = present();
+  if (el) el.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+  else memoryFlashNote(`claim ${id.slice(0, 12)} is not in the first 50 results — find it via search`);
 }
 
 function memoryRenderTab() {
@@ -185,11 +377,48 @@ function memoryRenderTab() {
   });
   list.innerHTML = rows.join('');
   // Whole-row toggle (no hover-only affordance): click/keyboard opens
-  // the full provenance detail.
+  // the full provenance detail. Clicks on the card's interactive
+  // curation controls must not collapse it.
   list.querySelectorAll('.memory-item').forEach((el) => {
-    el.addEventListener('click', () => {
-      memoryExpandedId = memoryExpandedId === el.dataset.id ? '' : el.dataset.id;
+    el.addEventListener('click', (e) => {
+      if (e.target.closest('button, input, select, a, .memory-curation')) return;
+      const next = memoryExpandedId === el.dataset.id ? '' : el.dataset.id;
+      memoryExpandedId = next;
+      memoryDetail = null;
+      memoryJudgePick = '';
       memoryRenderTab();
+      if (next) memoryFetchDetail(next);
+    });
+  });
+  const expanded = memoryExpandedId && list.querySelector(`.memory-item[data-id="${CSS.escape(memoryExpandedId)}"]`);
+  if (expanded) {
+    expanded.querySelectorAll('[data-judge]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        memoryJudgePick = btn.dataset.judge;
+        memoryRenderTab();
+        const reason = document.getElementById('memory-judge-reason');
+        if (reason) reason.focus();
+      });
+    });
+    const confirm = expanded.querySelector('#memory-judge-confirm');
+    if (confirm) confirm.addEventListener('click', () => memoryJudgeConfirm(memoryExpandedId));
+    const cancel = expanded.querySelector('#memory-judge-cancel');
+    if (cancel) cancel.addEventListener('click', () => {
+      memoryJudgePick = '';
+      memoryRenderTab();
+    });
+    const reason = expanded.querySelector('#memory-judge-reason');
+    if (reason) reason.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        memoryJudgeConfirm(memoryExpandedId);
+      }
+    });
+  }
+  list.querySelectorAll('[data-goto]').forEach((link) => {
+    link.addEventListener('click', (e) => {
+      e.preventDefault();
+      memoryGotoClaim(link.dataset.goto);
     });
   });
 }


### PR DESCRIPTION
Judge from the dashboard: verdict actions on the expanded claim card with a confirm affordance, judgment history rendering (durable-identity provenance per R2, reasons as quoted data), superseded → successor navigation, honest supersede-pending messaging (R4). Verdict buttons parity-pinned to the service's MINTED_VERDICTS. No pin UI (kernel fail-closed, Track J finding #1). Live verification via the validate-dashboard rig to follow in this PR.