### PR TITLE
custody hardening: private identity dir, std-only connect store persist, legacy pem retirement

### DIFF
--- a/src/bin/caller/custom_domain/cert.rs
+++ b/src/bin/caller/custom_domain/cert.rs
@@ -9,8 +9,12 @@ use serde::{Deserialize, Serialize};
 
 use super::CertificateStatus;
 
-const CERT_FILE: &str = "custom-domain-cert.pem";
-const KEY_FILE: &str = "custom-domain-key.pem";
+/// The two-file layout that predated the atomic pair record. No writer has
+/// existed for it in the current tree and the read fallback is retired
+/// (Track K Q8): a successful generation write deletes any leftover copy so
+/// superseded key material does not linger on disk.
+const LEGACY_CERT_FILE: &str = "custom-domain-cert.pem";
+const LEGACY_KEY_FILE: &str = "custom-domain-key.pem";
 const CERT_PAIR_FILE: &str = "custom-domain-certificate-pair.json";
 const CERT_PAIR_SCHEMA_VERSION: u32 = 1;
 const CERT_PAIR_MAX_BYTES: u64 = 512 * 1024;
@@ -120,46 +124,9 @@ fn read_stored_certificate_pair(cert_dir: &Path) -> Result<Option<(String, Strin
     crate::access::authority_store::with_lock(cert_dir, || {
         let pair_path = cert_dir.join(CERT_PAIR_FILE);
         match read_certificate_pair_record_locked(&pair_path) {
-            Ok(Some(record)) => {
-                return Ok(Some((record.certificate_chain_pem, record.private_key_pem)));
-            }
-            Ok(None) => {}
-            Err(error) => return Err(crate::access::AccessError(error)),
-        }
-
-        // Compatibility with the original two-file layout. Every new commit
-        // uses the single atomic record above; a valid legacy pair is still
-        // accepted until the next issuance writes a generation record.
-        let cert_path = cert_dir.join(CERT_FILE);
-        let key_path = cert_dir.join(KEY_FILE);
-        match (
-            std::fs::read_to_string(&cert_path),
-            std::fs::read_to_string(&key_path),
-        ) {
-            (Ok(cert), Ok(key)) => Ok(Some((cert, key))),
-            (Err(cert_error), Err(key_error))
-                if cert_error.kind() == std::io::ErrorKind::NotFound
-                    && key_error.kind() == std::io::ErrorKind::NotFound =>
-            {
-                Ok(None)
-            }
-            (Ok(_), Err(error)) | (Err(error), Ok(_))
-                if error.kind() == std::io::ErrorKind::NotFound =>
-            {
-                // The original layout committed key and certificate as two
-                // independent replacements. A missing sibling is an
-                // incomplete legacy generation, not durable authority; the
-                // guarded issuance path may atomically replace it.
-                Ok(None)
-            }
-            (Err(error), _) => Err(crate::access::AccessError(format!(
-                "read {}: {error}",
-                cert_path.display()
-            ))),
-            (_, Err(error)) => Err(crate::access::AccessError(format!(
-                "read {}: {error}",
-                key_path.display()
-            ))),
+            Ok(Some(record)) => Ok(Some((record.certificate_chain_pem, record.private_key_pem))),
+            Ok(None) => Ok(None),
+            Err(error) => Err(crate::access::AccessError(error)),
         }
     })
     .map_err(|error| error.to_string())
@@ -201,7 +168,7 @@ fn read_certificate_pair_record_locked(
     Ok(Some(record))
 }
 
-fn write_certificate_pair_locked(
+pub(super) fn write_certificate_pair_locked(
     cert_dir: &Path,
     domain: &ValidatedCustomDomain,
     certificate_chain_pem: &str,
@@ -224,7 +191,14 @@ fn write_certificate_pair_locked(
     crate::access::authority_store::atomic_write_private_locked(
         &cert_dir.join(CERT_PAIR_FILE),
         &bytes,
-    )
+    )?;
+    // Best-effort retirement of the pre-record two-file layout: the read
+    // path no longer accepts it, so a leftover key file is only a stale
+    // copy of superseded material.
+    for legacy in [LEGACY_CERT_FILE, LEGACY_KEY_FILE] {
+        let _ = std::fs::remove_file(cert_dir.join(legacy));
+    }
+    Ok(())
 }
 
 fn issuance_lease_path(cert_dir: &Path) -> PathBuf {
@@ -1090,13 +1064,20 @@ mod tests {
             rcgen::generate_simple_self_signed(vec!["box.example.test".to_string()]).unwrap();
         let other =
             rcgen::generate_simple_self_signed(vec!["other.example.test".to_string()]).unwrap();
-        std::fs::write(dir.path().join(CERT_FILE), certificate.cert.pem()).unwrap();
-        std::fs::write(dir.path().join(KEY_FILE), other.signing_key.serialize_pem()).unwrap();
         let domain = ValidatedCustomDomain {
             name: "box.example.test".to_string(),
             rp_id: "box.example.test".to_string(),
             origin: "https://box.example.test".to_string(),
         };
+        crate::access::authority_store::with_lock(dir.path(), || {
+            write_certificate_pair_locked(
+                dir.path(),
+                &domain,
+                &certificate.cert.pem(),
+                &other.signing_key.serialize_pem(),
+            )
+        })
+        .unwrap();
         let status = Arc::new(RwLock::new(CertificateStatus::default()));
 
         let error = restore(&domain, dir.path(), &status).unwrap_err();
@@ -1114,13 +1095,15 @@ mod tests {
     #[test]
     fn stored_pair_read_waits_for_the_atomic_writer_transaction() {
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join(CERT_FILE), b"old certificate").unwrap();
-        std::fs::write(dir.path().join(KEY_FILE), b"old key").unwrap();
         let domain = ValidatedCustomDomain {
             name: "box.example.test".to_string(),
             rp_id: "box.example.test".to_string(),
             origin: "https://box.example.test".to_string(),
         };
+        crate::access::authority_store::with_lock(dir.path(), || {
+            write_certificate_pair_locked(dir.path(), &domain, "old certificate", "old key")
+        })
+        .unwrap();
 
         let (writer_locked_tx, writer_locked_rx) = std::sync::mpsc::channel();
         let (finish_tx, finish_rx) = std::sync::mpsc::channel();
@@ -1166,7 +1149,7 @@ mod tests {
     }
 
     #[test]
-    fn atomic_pair_repairs_a_mismatched_legacy_generation() {
+    fn refresh_repairs_a_mismatched_stored_pair() {
         let dir = tempfile::tempdir().unwrap();
         let domain = ValidatedCustomDomain {
             name: "box.example.test".to_string(),
@@ -1176,8 +1159,15 @@ mod tests {
         let certificate = rcgen::generate_simple_self_signed(vec![domain.name.clone()]).unwrap();
         let other =
             rcgen::generate_simple_self_signed(vec!["other.example.test".to_string()]).unwrap();
-        std::fs::write(dir.path().join(CERT_FILE), certificate.cert.pem()).unwrap();
-        std::fs::write(dir.path().join(KEY_FILE), other.signing_key.serialize_pem()).unwrap();
+        crate::access::authority_store::with_lock(dir.path(), || {
+            write_certificate_pair_locked(
+                dir.path(),
+                &domain,
+                &certificate.cert.pem(),
+                &other.signing_key.serialize_pem(),
+            )
+        })
+        .unwrap();
         let status = Arc::new(RwLock::new(CertificateStatus::default()));
 
         assert_eq!(
@@ -1239,7 +1229,7 @@ mod tests {
     }
 
     #[test]
-    fn partial_legacy_pair_is_repairable() {
+    fn leftover_legacy_two_file_layout_is_ignored_and_retired() {
         let dir = tempfile::tempdir().unwrap();
         let domain = ValidatedCustomDomain {
             name: "box.example.test".to_string(),
@@ -1247,32 +1237,15 @@ mod tests {
             origin: "https://box.example.test".to_string(),
         };
         let certificate = rcgen::generate_simple_self_signed(vec![domain.name.clone()]).unwrap();
+        std::fs::write(dir.path().join(LEGACY_CERT_FILE), certificate.cert.pem()).unwrap();
         std::fs::write(
-            dir.path().join(KEY_FILE),
+            dir.path().join(LEGACY_KEY_FILE),
             certificate.signing_key.serialize_pem(),
         )
         .unwrap();
-        let status = Arc::new(RwLock::new(CertificateStatus {
-            state: "valid".to_string(),
-            not_after_unix_ms: Some(u64::MAX),
-            restore_error: Some("stale restore error".to_string()),
-            ..Default::default()
-        }));
-
-        assert_eq!(
-            refresh_shared_certificate_status(&domain, dir.path(), &status).unwrap(),
-            None
-        );
-        {
-            let status = status.read().unwrap();
-            assert_eq!(status.state, "pending");
-            assert_eq!(status.not_after_unix_ms, None);
-            assert_eq!(status.restore_error, None);
-        }
-        let guard = match IssuanceLeaseGuard::begin(&domain, dir.path()).unwrap() {
-            IssuanceClaim::Acquired(guard) => *guard,
-            IssuanceClaim::CertificateCurrent => panic!("the legacy pair is incomplete"),
-        };
+        // The retired layout confers nothing, even complete and valid.
+        assert_eq!(read_stored_certificate_pair(dir.path()).unwrap(), None);
+        // The next generation write deletes the leftover key material.
         crate::access::authority_store::with_lock(dir.path(), || {
             write_certificate_pair_locked(
                 dir.path(),
@@ -1282,12 +1255,9 @@ mod tests {
             )
         })
         .unwrap();
-        guard.finish().unwrap();
-        assert!(
-            refresh_shared_certificate_status(&domain, dir.path(), &status)
-                .unwrap()
-                .is_some()
-        );
+        assert!(!dir.path().join(LEGACY_CERT_FILE).exists());
+        assert!(!dir.path().join(LEGACY_KEY_FILE).exists());
+        assert!(read_stored_certificate_pair(dir.path()).unwrap().is_some());
     }
 
     #[test]

--- a/src/bin/caller/custom_domain/mod.rs
+++ b/src/bin/caller/custom_domain/mod.rs
@@ -534,15 +534,19 @@ mod tests {
         };
         let certificate =
             rcgen::generate_simple_self_signed(vec!["box.fleet.example.test".to_string()]).unwrap();
-        std::fs::write(
-            dir.path().join("custom-domain-cert.pem"),
-            certificate.cert.pem(),
-        )
-        .unwrap();
-        std::fs::write(
-            dir.path().join("custom-domain-key.pem"),
-            certificate.signing_key.serialize_pem(),
-        )
+        let seeded_domain = ValidatedCustomDomain {
+            name: "box.fleet.example.test".to_string(),
+            rp_id: "box.fleet.example.test".to_string(),
+            origin: "https://box.fleet.example.test".to_string(),
+        };
+        crate::access::authority_store::with_lock(dir.path(), || {
+            cert::write_certificate_pair_locked(
+                dir.path(),
+                &seeded_domain,
+                &certificate.cert.pem(),
+                &certificate.signing_key.serialize_pem(),
+            )
+        })
         .unwrap();
         let hosted = || {
             Arc::new(HostedControlRuntime::new(

--- a/src/bin/caller/daemon_identity.rs
+++ b/src/bin/caller/daemon_identity.rs
@@ -26,12 +26,15 @@ impl DaemonIdentity {
     pub fn load_or_create(path: impl AsRef<Path>) -> Result<Self, String> {
         let path = path.as_ref();
         let bytes = match std::fs::read(path) {
-            Ok(bytes) => bytes,
+            Ok(bytes) => {
+                tighten_identity_dir(path);
+                bytes
+            }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 let parent = path
                     .parent()
                     .ok_or_else(|| format!("identity path has no parent: {}", path.display()))?;
-                std::fs::create_dir_all(parent)
+                intendant_core::state_paths::create_private_dir_all(parent)
                     .map_err(|e| format!("create identity dir {}: {e}", parent.display()))?;
                 let rng = ring::rand::SystemRandom::new();
                 let pkcs8 = Ed25519KeyPair::generate_pkcs8(&rng)
@@ -86,6 +89,25 @@ pub fn b64u(bytes: &[u8]) -> String {
 
 fn b64u_decode(s: &str) -> Result<Vec<u8>, base64::DecodeError> {
     base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(s)
+}
+
+/// Installs that predate the private-dir convention created the identity
+/// directory with umask defaults (0755 — group/other-listable, unlike the
+/// state-root convention). The key file itself has always been 0600; this
+/// tightens the existing directory on load so listings stop leaking.
+/// Best-effort: a failure never blocks identity load.
+fn tighten_identity_dir(key_path: &Path) {
+    #[cfg(unix)]
+    if let Some(parent) = key_path.parent() {
+        use std::os::unix::fs::PermissionsExt as _;
+        if let Ok(metadata) = std::fs::metadata(parent) {
+            if metadata.permissions().mode() & 0o077 != 0 {
+                let _ = std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700));
+            }
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = key_path;
 }
 
 /// The daemon-identity state directory — also home to small identity-

--- a/src/bin/connect/main.rs
+++ b/src/bin/connect/main.rs
@@ -1511,20 +1511,36 @@ fn write_store_bytes(path: &Path, bytes: &[u8]) -> Result<(), String> {
         .parent()
         .filter(|parent| !parent.as_os_str().is_empty())
         .unwrap_or_else(|| Path::new("."));
-    std::fs::create_dir_all(parent)
+    intendant_core::state_paths::create_private_dir_all(parent)
         .map_err(|e| format!("create Connect state dir {}: {e}", parent.display()))?;
-    let mut tmp = tempfile::Builder::new()
-        .prefix(".intendant-connect-state-")
-        .suffix(".tmp")
-        .tempfile_in(parent)
-        .map_err(|e| format!("create Connect state tempfile in {}: {e}", parent.display()))?;
-    tmp.write_all(bytes)
-        .map_err(|e| format!("write Connect state tempfile {}: {e}", tmp.path().display()))?;
-    tmp.as_file_mut()
-        .sync_all()
-        .map_err(|e| format!("sync Connect state tempfile {}: {e}", tmp.path().display()))?;
-    tmp.persist(path)
-        .map_err(|e| format!("replace Connect state {}: {}", path.display(), e.error))?;
+    // Std-only staged replace — never the tempfile crate on a persist seam.
+    // The store carries the service's VAPID and transparency-log signing
+    // keys, so the staged file is 0600 on Unix from the moment it exists,
+    // then atomically renamed over the live store. Every save runs under
+    // the global store lock, so the fixed stage name cannot collide; a
+    // stale stage from a crashed run is cleared first.
+    let staged = path.with_extension("staged");
+    match std::fs::remove_file(&staged) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            return Err(format!(
+                "clear stale Connect state stage {}: {e}",
+                staged.display()
+            ))
+        }
+    }
+    let mut file = intendant_core::state_paths::private_file_options()
+        .create_new(true)
+        .open(&staged)
+        .map_err(|e| format!("create Connect state stage {}: {e}", staged.display()))?;
+    file.write_all(bytes)
+        .map_err(|e| format!("write Connect state stage {}: {e}", staged.display()))?;
+    file.sync_all()
+        .map_err(|e| format!("sync Connect state stage {}: {e}", staged.display()))?;
+    drop(file);
+    std::fs::rename(&staged, path)
+        .map_err(|e| format!("replace Connect state {}: {e}", path.display()))?;
     fsync_parent_dir(parent)
 }
 
@@ -1551,7 +1567,7 @@ fn fsync_parent_dir(parent: &Path) -> Result<(), String> {
 /// dirty flag is cleared on success (marks only ever happen under the same
 /// lock, so none can slip between the write and the clear).
 ///
-/// The serialize happens under the lock; the blocking file I/O (tempfile
+/// The serialize happens under the lock; the blocking file I/O (staged
 /// write + fsync + rename + parent-dir fsync) runs on `spawn_blocking` so
 /// it never parks an async worker — with the store lock still HELD across
 /// the await. That lock-across-write is deliberate, not an oversight: as


### PR DESCRIPTION
Track K, the ruled pre-K2 hardening slice (intake Q8, adjudicated + ratified 2026-07-21). Three census flags, each independent of the custody backend:

1. **daemon-identity dir**: key file was always 0600, but the directory was created with umask defaults (0755, group/other-listable — unlike the state-root 0700 convention). Created private going forward; a pre-existing loose dir is tightened best-effort on identity load (Unix only; never blocks load).
2. **Connect store persist**: `write_store_bytes` used the tempfile crate on a persist seam (the banned Windows MAX_PATH class) and relied on the crate's default mode while the store carries the service's VAPID + transparency-STH signing keys. Replaced with a std-only staged write — 0600 at creation via `state_paths::private_file_options`, fsync, atomic rename, parent-dir fsync — under the existing single-writer store lock; the store dir is created private.
3. **Custom-domain legacy pem fallback**: the pre-record two-file layout has no writer in-tree; any install that ever renewed holds the atomic JSON pair, so the fallback only ever served an expired cert. Read path retired; a successful generation write now deletes leftover legacy files so superseded key material stops lingering on disk. Legacy-seeded tests reseed through the atomic writer; `leftover_legacy_two_file_layout_is_ignored_and_retired` pins both behaviors.

Battery: bins 4555+148+97 green, clippy `-D warnings` clean, mock e2e 30/30, fmt clean.