### PR TITLE
custody: K2b — access-certs estate migration behind custody seams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2921,6 +2921,7 @@ dependencies = [
  "image",
  "instant-acme",
  "intendant-core",
+ "intendant-custody",
  "intendant-display",
  "intendant-platform",
  "landlock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ dirs = "6"
 # Rust, so no setup-script changes are needed.
 which = "8"
 intendant-core = { path = "crates/intendant-core" }
+intendant-custody = { path = "crates/intendant-custody" }
 intendant-display = { path = "crates/intendant-display" }
 intendant-platform = { path = "crates/intendant-platform" }
 rmcp = { version = ">=1.4.0, <1.5.0", features = ["server", "transport-io", "client", "transport-child-process"] }

--- a/crates/intendant-custody/src/bin/custody-probe.rs
+++ b/crates/intendant-custody/src/bin/custody-probe.rs
@@ -1,0 +1,77 @@
+//! Acceptance-rig helper: the UNREGISTERED caller (Track K ruling Q7).
+//!
+//! The acceptance test creates a throwaway keychain and stores a wrapping
+//! key from its own process; this binary is the *other* program — a
+//! different code identity the keychain item's ACL does not trust. It
+//! disables keychain UI (so an ACL confirmation becomes a deterministic
+//! error instead of a prompt), unlocks the keychain with its explicit
+//! password (removing the lock state from the equation), and attempts a
+//! retrieval. Its exit code reports the custody outcome via
+//! [`intendant_custody::probe_exit`].
+//!
+//! Never point this at the login keychain; it exists for rig keychains in
+//! temp dirs.
+
+fn main() {
+    std::process::exit(run());
+}
+
+#[cfg(target_os = "macos")]
+fn run() -> i32 {
+    use intendant_custody::mac_keychain::{disable_keychain_ui, ScopedKeychainKeyProvider};
+    use intendant_custody::{probe_exit, BackendKind, CustodyBackend, CustodyError};
+
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let [keychain_path, keychain_password, blob_dir, entry] = args.as_slice() else {
+        eprintln!("usage: custody-probe <keychain-path> <keychain-password> <blob-dir> <entry>");
+        return probe_exit::USAGE;
+    };
+
+    let _ui_lock = match disable_keychain_ui() {
+        Ok(lock) => lock,
+        Err(error) => {
+            eprintln!("custody-probe: cannot disable keychain UI: {error}");
+            return probe_exit::USAGE;
+        }
+    };
+
+    let provider = ScopedKeychainKeyProvider::open(keychain_path, keychain_password);
+    let backend = match intendant_custody::WrappedBlobBackend::new(
+        blob_dir,
+        BackendKind::MacKeychainWrapped,
+        Box::new(provider),
+    ) {
+        Ok(backend) => backend,
+        Err(error) => {
+            eprintln!("custody-probe: backend setup failed: {error}");
+            return probe_exit::USAGE;
+        }
+    };
+
+    match backend.retrieve(entry) {
+        Ok(secret) => {
+            // Outcome only — material never reaches stdout/stderr.
+            eprintln!(
+                "custody-probe: RETRIEVED {} bytes for {entry}",
+                secret.as_bytes().len()
+            );
+            probe_exit::RETRIEVED
+        }
+        Err(error) => {
+            eprintln!("custody-probe: {error}");
+            match error {
+                CustodyError::DeniedNonInteractive { .. } => probe_exit::DENIED_NON_INTERACTIVE,
+                CustodyError::NotFound { .. } => probe_exit::NOT_FOUND,
+                CustodyError::Unsealable { .. } => probe_exit::UNSEALABLE,
+                CustodyError::BackendUnavailable { .. } => probe_exit::BACKEND_UNAVAILABLE,
+                CustodyError::InvalidName { .. } | CustodyError::Io { .. } => probe_exit::OTHER,
+            }
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn run() -> i32 {
+    eprintln!("custody-probe: the keychain acceptance rig is macOS-only");
+    intendant_custody::probe_exit::USAGE
+}

--- a/crates/intendant-custody/src/lib.rs
+++ b/crates/intendant-custody/src/lib.rs
@@ -25,6 +25,28 @@ pub use file_backend::PlainFileBackend;
 pub use names::validate_entry_name;
 pub use wrapped::{WrappedBlobBackend, WrappingKeyProvider};
 
+/// Exit codes for the `custody-probe` helper binary (the acceptance
+/// rig's unregistered caller). The acceptance test asserts on these, so
+/// the probe's outcome vocabulary is pinned here rather than duplicated.
+pub mod probe_exit {
+    /// The probe retrieved the entry (caller discrimination FAILED —
+    /// an unregistered binary read the wrapping key silently).
+    pub const RETRIEVED: i32 = 0;
+    /// Bad invocation / non-macOS.
+    pub const USAGE: i32 = 2;
+    /// [`crate::CustodyError::DeniedNonInteractive`] — the acceptance
+    /// deny class.
+    pub const DENIED_NON_INTERACTIVE: i32 = 3;
+    /// [`crate::CustodyError::NotFound`].
+    pub const NOT_FOUND: i32 = 4;
+    /// [`crate::CustodyError::Unsealable`].
+    pub const UNSEALABLE: i32 = 5;
+    /// [`crate::CustodyError::BackendUnavailable`].
+    pub const BACKEND_UNAVAILABLE: i32 = 6;
+    /// Any other custody error.
+    pub const OTHER: i32 = 7;
+}
+
 use zeroize::Zeroizing;
 
 /// Retrieved secret material. The buffer is zeroized on drop; callers
@@ -32,7 +54,10 @@ use zeroize::Zeroizing;
 pub struct Secret(Zeroizing<Vec<u8>>);
 
 impl Secret {
-    pub(crate) fn new(bytes: Vec<u8>) -> Self {
+    /// Wrap material in a zeroizing buffer. Public so callers whose
+    /// fallback lane reads plain files can hand both lanes' material to
+    /// consumers under one hygiene type.
+    pub fn new(bytes: Vec<u8>) -> Self {
         Self(Zeroizing::new(bytes))
     }
 

--- a/crates/intendant-custody/src/mac_keychain.rs
+++ b/crates/intendant-custody/src/mac_keychain.rs
@@ -16,6 +16,13 @@ use crate::{BackendKind, CustodyError, WrappedBlobBackend, WrappingKeyProvider};
 
 const ERR_SEC_ITEM_NOT_FOUND: i32 = -25300;
 const ERR_SEC_INTERACTION_NOT_ALLOWED: i32 = -25308;
+/// `errSecAuthFailed`. On modern macOS an item-ACL denial with UI
+/// disabled surfaces as this code, not `errSecInteractionNotAllowed`
+/// (proven live by the acceptance rig on 2026-07-21). It is *also* the
+/// wrong-password code, so it maps to the deny class only on item-access
+/// operations — an explicit unlock has already succeeded by then, which
+/// removes the wrong-password reading.
+const ERR_SEC_AUTH_FAILED: i32 = -25293;
 
 const DEFAULT_SERVICE: &str = "dev.intendant.custody";
 const DEFAULT_ACCOUNT: &str = "wrapping-key-v1";
@@ -69,20 +76,135 @@ impl WrappingKeyProvider for LoginKeychainKeyProvider {
                     &self.account,
                     key.as_ref(),
                 )
-                .map_err(|error| keychain_error(backend, "store wrapping key", &error))?;
+                .map_err(|error| item_access_error(backend, "store wrapping key", &error))?;
                 Ok(key)
             }
-            Err(error) if error.code() == ERR_SEC_INTERACTION_NOT_ALLOWED => {
-                Err(CustodyError::DeniedNonInteractive {
-                    backend,
-                    reason: "keychain requires interaction this context cannot provide".to_string(),
-                })
-            }
-            Err(error) => Err(keychain_error(backend, "read wrapping key", &error)),
+            Err(error) => Err(item_access_error(backend, "read wrapping key", &error)),
         }
     }
 }
 
+/// A wrapping-key provider bound to one file-backed keychain at an
+/// explicit path — never the login keychain. This is the acceptance-rig
+/// provider (Track K ruling Q7): the rig creates a throwaway keychain in
+/// a temp dir, and caller discrimination is exercised against it with
+/// keychain UI disabled, so the deny leg is deterministic on dev Macs and
+/// headless CI listeners alike. The keychain is opened and unlocked with
+/// its explicit password on every use (an explicit-credential unlock has
+/// no UI), leaving the item ACL as the only interaction surface.
+pub struct ScopedKeychainKeyProvider {
+    keychain_path: std::path::PathBuf,
+    keychain_password: String,
+    service: String,
+    account: String,
+}
+
+impl ScopedKeychainKeyProvider {
+    /// Create the file-backed keychain at `path` (no UI, password set
+    /// programmatically) and return a provider bound to it.
+    pub fn create(
+        path: impl Into<std::path::PathBuf>,
+        password: &str,
+    ) -> Result<Self, CustodyError> {
+        let path = path.into();
+        security_framework::os::macos::keychain::CreateOptions::new()
+            .password(password)
+            .prompt_user(false)
+            .create(&path)
+            .map_err(|error| {
+                keychain_error(BackendKind::MacKeychainWrapped, "create keychain", &error)
+            })?;
+        Ok(Self::open(path, password))
+    }
+
+    /// Bind to an existing file-backed keychain without touching it yet.
+    pub fn open(path: impl Into<std::path::PathBuf>, password: &str) -> Self {
+        Self {
+            keychain_path: path.into(),
+            keychain_password: password.to_string(),
+            service: DEFAULT_SERVICE.to_string(),
+            account: DEFAULT_ACCOUNT.to_string(),
+        }
+    }
+
+    fn unlocked_keychain(
+        &self,
+    ) -> Result<security_framework::os::macos::keychain::SecKeychain, CustodyError> {
+        let backend = BackendKind::MacKeychainWrapped;
+        let mut keychain =
+            security_framework::os::macos::keychain::SecKeychain::open(&self.keychain_path)
+                .map_err(|error| keychain_error(backend, "open keychain", &error))?;
+        keychain
+            .unlock(Some(&self.keychain_password))
+            .map_err(|error| keychain_error(backend, "unlock keychain", &error))?;
+        Ok(keychain)
+    }
+}
+
+impl WrappingKeyProvider for ScopedKeychainKeyProvider {
+    fn wrapping_key(&self, create_if_missing: bool) -> Result<Zeroizing<[u8; 32]>, CustodyError> {
+        let backend = BackendKind::MacKeychainWrapped;
+        let keychain = self.unlocked_keychain()?;
+        match keychain.find_generic_password(&self.service, &self.account) {
+            Ok((bytes, _item)) => {
+                if bytes.len() != 32 {
+                    return Err(CustodyError::BackendUnavailable {
+                        backend,
+                        reason: "wrapping-key keychain item is malformed".to_string(),
+                    });
+                }
+                let mut key = Zeroizing::new([0u8; 32]);
+                key.copy_from_slice(&bytes);
+                Ok(key)
+            }
+            Err(error) if error.code() == ERR_SEC_ITEM_NOT_FOUND => {
+                if !create_if_missing {
+                    return Err(CustodyError::BackendUnavailable {
+                        backend,
+                        reason: "wrapping key absent from the keychain".to_string(),
+                    });
+                }
+                let mut key = Zeroizing::new([0u8; 32]);
+                ring::rand::SecureRandom::fill(&ring::rand::SystemRandom::new(), key.as_mut())
+                    .map_err(|_| CustodyError::Io {
+                        context: "mint wrapping key".to_string(),
+                        message: "system randomness unavailable".to_string(),
+                    })?;
+                keychain
+                    .add_generic_password(&self.service, &self.account, key.as_ref())
+                    .map_err(|error| item_access_error(backend, "store wrapping key", &error))?;
+                Ok(key)
+            }
+            Err(error) => Err(item_access_error(backend, "read wrapping key", &error)),
+        }
+    }
+}
+
+/// RAII guard from [`disable_keychain_ui`]; interaction is re-enabled
+/// when it drops.
+pub use security_framework::os::macos::keychain::KeychainUserInteractionLock;
+
+/// Disable keychain user interaction for this process — every operation
+/// that would show a prompt fails with `errSecInteractionNotAllowed`
+/// instead. The acceptance rig runs both its legs under this lock so the
+/// deny assertion is a deterministic error, not a hung prompt, in
+/// headless contexts.
+pub fn disable_keychain_ui() -> Result<KeychainUserInteractionLock, CustodyError> {
+    security_framework::os::macos::keychain::SecKeychain::disable_user_interaction().map_err(
+        |error| {
+            keychain_error(
+                BackendKind::MacKeychainWrapped,
+                "disable keychain interaction",
+                &error,
+            )
+        },
+    )
+}
+
+/// Translate errors from keychain *setup* operations (open, unlock,
+/// create). Only `errSecInteractionNotAllowed` is the deny class here —
+/// `errSecAuthFailed` at this stage means a wrong keychain password, a
+/// backend problem, not caller discrimination.
 fn keychain_error(
     backend: BackendKind,
     action: &str,
@@ -97,6 +219,29 @@ fn keychain_error(
     CustodyError::BackendUnavailable {
         backend,
         reason: format!("{action}: keychain error {}", error.code()),
+    }
+}
+
+/// Translate errors from *item access* (find/read, add/store). Both
+/// `errSecInteractionNotAllowed` and `errSecAuthFailed` are the
+/// non-interactive deny class here: any explicit unlock has already
+/// succeeded, so an authorization failure is the item ACL refusing this
+/// caller without UI.
+fn item_access_error(
+    backend: BackendKind,
+    action: &str,
+    error: &security_framework::base::Error,
+) -> CustodyError {
+    let code = error.code();
+    if code == ERR_SEC_INTERACTION_NOT_ALLOWED || code == ERR_SEC_AUTH_FAILED {
+        return CustodyError::DeniedNonInteractive {
+            backend,
+            reason: format!("keychain refused item access without interaction (OSStatus {code})"),
+        };
+    }
+    CustodyError::BackendUnavailable {
+        backend,
+        reason: format!("{action}: keychain error {code}"),
     }
 }
 

--- a/crates/intendant-custody/tests/mac_acceptance.rs
+++ b/crates/intendant-custody/tests/mac_acceptance.rs
@@ -1,0 +1,103 @@
+//! The Track K acceptance rig (ruling Q7, binding): prove on a real
+//! macOS keychain that custody discriminates callers — the binary that
+//! created the wrapping-key item retrieves silently, and a *different*
+//! binary (the spawned `custody-probe` helper, an unregistered code
+//! identity replaying the incident shape) fails closed with the
+//! non-interactive deny class instead of reading the key or hanging on
+//! a prompt.
+//!
+//! Hermetic by doctrine: a throwaway file-backed keychain inside a temp
+//! dir — never the login keychain — and keychain UI disabled for the
+//! whole process, so both legs are deterministic on dev Macs and on the
+//! headless CI listener alike. The interactive prompt lane (a human
+//! clicking "Always Allow") is deliberately NOT here; it lives in
+//! `tests/skills/` and runs on operator hardware only.
+//!
+//! An integration test (not an inline module) because the rig's whole
+//! point is spawning a second, differently-identified binary — cargo
+//! only exposes `CARGO_BIN_EXE_*` to integration tests.
+
+#![cfg(target_os = "macos")]
+
+use std::process::Command;
+
+use intendant_custody::mac_keychain::{disable_keychain_ui, ScopedKeychainKeyProvider};
+use intendant_custody::{probe_exit, BackendKind, CustodyBackend, WrappedBlobBackend};
+
+const KEYCHAIN_PASSWORD: &str = "intendant-acceptance-rig";
+const ENTRY: &str = "access-certs/client.key";
+const MATERIAL: &[u8] = b"RIG PRIVATE KEY MATERIAL (not a real key)";
+
+#[test]
+fn keychain_custody_discriminates_callers_without_ui() {
+    // Process-global UI disable: a leg that would prompt must error, not
+    // hang. Held for both legs — the silent leg proves it never needed
+    // interaction in the first place.
+    let _ui_lock = disable_keychain_ui().expect("disable keychain UI for the rig");
+
+    let tmp = tempfile::tempdir().expect("rig temp dir");
+    let keychain_path = tmp.path().join("acceptance.keychain");
+    let blob_dir = tmp.path().join("blobs");
+
+    let provider = ScopedKeychainKeyProvider::create(&keychain_path, KEYCHAIN_PASSWORD)
+        .expect("create throwaway rig keychain");
+    let backend = WrappedBlobBackend::new(
+        &blob_dir,
+        BackendKind::MacKeychainWrapped,
+        Box::new(provider),
+    )
+    .expect("assemble rig backend");
+
+    // ── Leg 1: the creating caller stores and retrieves silently. ──
+    // The store mints the wrapping key into the rig keychain; the item's
+    // ACL records this test binary as its trusted application.
+    backend
+        .store(ENTRY, MATERIAL)
+        .expect("creating caller must store without interaction");
+    let retrieved = backend
+        .retrieve(ENTRY)
+        .expect("creating caller must retrieve without interaction");
+    assert_eq!(retrieved.as_bytes(), MATERIAL);
+
+    // ── Leg 2: an unregistered binary fails closed, non-interactively. ──
+    // `custody-probe` is a different executable, so the item ACL does not
+    // trust it; with UI disabled the ACL confirmation must surface as the
+    // named deny class — never the material, never a hang.
+    let denied = probe(&keychain_path, &blob_dir, ENTRY);
+    assert_eq!(
+        denied.status.code(),
+        Some(probe_exit::DENIED_NON_INTERACTIVE),
+        "unregistered caller must land on DeniedNonInteractive; probe stderr:\n{}",
+        String::from_utf8_lossy(&denied.stderr)
+    );
+    let denied_stderr = String::from_utf8_lossy(&denied.stderr);
+    assert!(
+        denied_stderr.contains("denied non-interactively"),
+        "probe stderr must carry the named deny class, got:\n{denied_stderr}"
+    );
+
+    // ── Leg 3: absent entries answer NotFound without touching the
+    // keystore, even for the unregistered caller (no spurious deny/prompt
+    // surface for entries that do not exist).
+    let absent = probe(&keychain_path, &blob_dir, "access-certs/absent.key");
+    assert_eq!(
+        absent.status.code(),
+        Some(probe_exit::NOT_FOUND),
+        "absent entry must answer NotFound before any keystore access; probe stderr:\n{}",
+        String::from_utf8_lossy(&absent.stderr)
+    );
+}
+
+fn probe(
+    keychain_path: &std::path::Path,
+    blob_dir: &std::path::Path,
+    entry: &str,
+) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_custody-probe"))
+        .arg(keychain_path)
+        .arg(KEYCHAIN_PASSWORD)
+        .arg(blob_dir)
+        .arg(entry)
+        .output()
+        .expect("spawn custody-probe")
+}

--- a/src/bin/caller/access/cert_server.rs
+++ b/src/bin/caller/access/cert_server.rs
@@ -502,7 +502,10 @@ where
                 .await;
             }
             let p12 = cert_dir.join("client.p12");
-            match std::fs::read(&p12) {
+            // Custody-routed: a migrated .p12 is served out of the sealed
+            // custody entry; a custody failure is a loud 500, never a
+            // silent 404 that reads like "run setup again".
+            match crate::key_custody::read_key_material(&p12) {
                 Ok(bytes) => {
                     let filename = if path == "/client.pfx" {
                         "client.pfx"
@@ -513,17 +516,28 @@ where
                         &mut stream,
                         "200 OK",
                         "application/x-pkcs12",
-                        &bytes,
+                        bytes.as_bytes(),
                         filename,
                     )
                     .await
                 }
-                Err(_) => {
+                Err(_) if !p12.exists() => {
                     write_response(
                         &mut stream,
                         "404 Not Found",
                         "text/plain",
                         b"not found",
+                        &[],
+                    )
+                    .await
+                }
+                Err(error) => {
+                    eprintln!("!! client.p12 unavailable: {error}");
+                    write_response(
+                        &mut stream,
+                        "500 Internal Server Error",
+                        "text/plain",
+                        b"client identity bundle unavailable; see server log",
                         &[],
                     )
                     .await
@@ -1077,13 +1091,13 @@ fn mobileconfig_profile(
         "client.crt",
         AppleProfileCertRole::ClientIdentity,
     )?;
-    let p12 =
-        std::fs::read(cert_dir.join("client.p12")).map_err(|e| format!("read client.p12: {e}"))?;
+    let p12 = crate::key_custody::read_key_material(&cert_dir.join("client.p12"))
+        .map_err(|e| format!("read client.p12: {e}"))?;
     Ok(mobileconfig_profile_from_bytes(
         host_label,
         p12_password,
         &ca_der,
-        &p12,
+        p12.as_bytes(),
     ))
 }
 

--- a/src/bin/caller/access/certs.rs
+++ b/src/bin/caller/access/certs.rs
@@ -202,8 +202,9 @@ pub fn ensure_certs(
     let p12_bytes =
         build_apple_compatible_p12(&client_key, &client_cert, &[ca_cert], label, &password)?;
     // The .p12 bundles the client private key — same owner-only-from-creation
-    // treatment as the bare key files.
-    intendant_core::state_paths::write_private_file(&cert_dir.join(CLIENT_P12), &p12_bytes)?;
+    // and custody-aware treatment as the bare key files.
+    crate::key_custody::write_key_material(&cert_dir.join(CLIENT_P12), &p12_bytes)
+        .map_err(AccessError)?;
     state::write_p12_password(cert_dir, &password)?;
 
     println!(":: certificates generated in {}", cert_dir.display());
@@ -256,7 +257,7 @@ pub fn issue_client_identity(cert_dir: &Path, label: &str) -> AccessResult<Issue
     }
 
     let ca_pem = std::fs::read_to_string(ca_path)?;
-    let ca_key_pem = std::fs::read_to_string(key_path)?;
+    let ca_key_pem = read_ca_key_pem(&key_path)?;
     let ca_key = KeyPair::from_pem(&ca_key_pem)?;
     let ca_issuer = issuer_from_pem(&ca_pem, ca_key)?;
     let (cert, key) = generate_client_cert(&ca_issuer, label)?;
@@ -298,7 +299,7 @@ pub fn issue_client_certificate_for_public_key(
     }
 
     let ca_pem = std::fs::read_to_string(ca_path)?;
-    let ca_key_pem = std::fs::read_to_string(key_path)?;
+    let ca_key_pem = read_ca_key_pem(&key_path)?;
     let ca_key = KeyPair::from_pem(&ca_key_pem)?;
     let ca_issuer = issuer_from_pem(&ca_pem, ca_key)?;
     let public_key = SubjectPublicKeyInfo::from_pem(public_key_pem)
@@ -310,7 +311,7 @@ pub fn issue_client_certificate_for_public_key(
 
 fn regenerate_server_cert(cert_dir: &Path, server_names: &ServerNames) -> AccessResult<()> {
     let ca_pem = std::fs::read_to_string(cert_dir.join(CA_CRT))?;
-    let ca_key_pem = std::fs::read_to_string(cert_dir.join(CA_KEY))?;
+    let ca_key_pem = read_ca_key_pem(&cert_dir.join(CA_KEY))?;
     let ca_key = KeyPair::from_pem(&ca_key_pem)?;
     let ca_issuer = issuer_from_pem(&ca_pem, ca_key)?;
 
@@ -589,10 +590,22 @@ fn write_pem_cert(path: &Path, cert: &Certificate) -> AccessResult<()> {
 }
 
 /// Private keys are 0600 on Unix from the moment the file exists — never
-/// write-then-chmod (Windows relies on the profile ACL).
+/// write-then-chmod (Windows relies on the profile ACL). Custody-aware:
+/// regenerating a migrated key refreshes its custody entry instead of
+/// regressing it to a plain file.
 fn write_pem_private_key(path: &Path, key: &KeyPair) -> AccessResult<()> {
-    intendant_core::state_paths::write_private_file(path, key.serialize_pem())?;
+    crate::key_custody::write_key_material(path, key.serialize_pem().as_bytes())
+        .map_err(AccessError)?;
     Ok(())
+}
+
+/// Read the CA private key as PEM text through the custody seam — a
+/// plain file serves as-is, a migrated key comes out of custody.
+fn read_ca_key_pem(path: &Path) -> AccessResult<String> {
+    let material = crate::key_custody::read_key_material(path).map_err(AccessError)?;
+    let pem = std::str::from_utf8(material.as_bytes())
+        .map_err(|e| AccessError(format!("CA key {} is not UTF-8 PEM: {e}", path.display())))?;
+    Ok(pem.to_string())
 }
 
 /// Read a PEM-encoded certificate file and return its DER bytes.

--- a/src/bin/caller/credential_audit.rs
+++ b/src/bin/caller/credential_audit.rs
@@ -38,6 +38,24 @@ pub const EVENT_LEASE_CLEANUP_DEFERRED: &str = "lease_cleanup_deferred";
 /// A materialized leased auth home was deleted from disk (sweep, session
 /// end, revocation, or the startup sweep).
 pub const EVENT_LEASE_HOME_REMOVED: &str = "lease_home_removed";
+/// A class-1 private key file was relocated into OS-keystore custody
+/// (`intendant custody migrate`). Relocation, not rotation (Track K
+/// ruling Q6, owner-accepted 2026-07-21): pre-migration copies are
+/// unaffected.
+pub const EVENT_KEY_MIGRATED: &str = "key_custody_migrated";
+/// A custody-held key was returned to a plain file
+/// (`intendant custody restore`).
+pub const EVENT_KEY_RESTORED: &str = "key_custody_restored";
+/// A custody-held entry's material was replaced in place (key
+/// regeneration — recert, forced setup — while the entry is migrated).
+pub const EVENT_KEY_STORED: &str = "key_custody_stored";
+/// A custody operation for a migrated key failed — retrieval or store
+/// denied, backend unavailable, or blob unsealable. Fail-closed: no
+/// material was served and no file fallback occurred. (Pre-migration
+/// plain-file mode is deliberately not a per-read event: reads happen at
+/// every boot and dial, and `intendant custody status` labels the estate
+/// instead.)
+pub const EVENT_KEY_DENIED: &str = "key_custody_denied";
 
 /// How many events the in-memory tail keeps (and the file is trimmed
 /// to on rewrite).

--- a/src/bin/caller/key_custody.rs
+++ b/src/bin/caller/key_custody.rs
@@ -1,0 +1,733 @@
+//! OS-keystore custody for the access-certs private-key estate (Track K).
+//!
+//! The class-1 artifacts — `ca.key`, `server.key`, `client.key`,
+//! `client.p12` — normally live as 0600 files in the access cert dir.
+//! `intendant custody migrate` relocates each into a sealed blob under
+//! `<cert_dir>/custody/` (wrapping key held by the platform keystore via
+//! `intendant-custody`) and replaces the file with a *tombstone* naming
+//! the custody entry. Every consumption seam reads through
+//! [`read_key_material`], which routes by content: a real key serves
+//! as-is (labeled file mode), a tombstone routes to custody and **never**
+//! falls back to a file — after migration, a stale plain copy reappearing
+//! next to a tombstone must not silently win. Key regeneration writes go
+//! through [`write_key_material`], so a recert on a migrated estate
+//! refreshes the custody entry instead of regressing it to a file.
+//!
+//! Binding labels from the Track K ruling:
+//! - Custody before a Developer ID + hardened-runtime binary is
+//!   *bar-raising, not lane-sealing* — it defeats the casual same-uid
+//!   file read, not a patient same-uid attacker.
+//! - Migration is *relocation, not rotation* (Q6, owner-accepted
+//!   2026-07-21): copies made before migration are unaffected.
+
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+use intendant_custody::{BackendKind, CustodyBackend, Secret};
+
+use crate::credential_audit;
+
+/// Sealed blobs live in this subdirectory of the access cert dir — inside
+/// the estate, so the runtime sandbox's `access-certs` read-deny and
+/// write-exclusion cover custody state with no new policy.
+const CUSTODY_SUBDIR: &str = "custody";
+
+/// First line of a migrated key file. Old binaries fail loudly on it
+/// ("no private key found"), current ones route to custody.
+const TOMBSTONE_MAGIC: &[u8] = b"INTENDANT CUSTODY TOMBSTONE v1\n";
+
+/// The class-1 artifacts `intendant custody migrate` relocates: the
+/// access-certs private-key subtree as one unit (ruling Q-S). The .p12
+/// bundles the client key, so leaving it out would make migrating
+/// `client.key` theater.
+const CLASS1_FILES: [&str; 4] = ["ca.key", "server.key", "client.key", "client.p12"];
+
+fn entry_name_for(file_name: &str) -> String {
+    format!("access-certs/{file_name}")
+}
+
+fn is_tombstone(bytes: &[u8]) -> bool {
+    bytes.starts_with(TOMBSTONE_MAGIC)
+}
+
+/// The custody entry named by a tombstone. Only called on bytes that
+/// passed [`is_tombstone`]; a magic-but-no-entry file is corrupt and
+/// fails closed rather than being served as key material.
+fn tombstone_entry(bytes: &[u8]) -> Result<String, String> {
+    std::str::from_utf8(bytes)
+        .ok()
+        .and_then(|text| {
+            text.lines()
+                .find_map(|line| line.strip_prefix("entry: "))
+                .map(|entry| entry.trim().to_string())
+        })
+        .filter(|entry| !entry.is_empty())
+        .ok_or_else(|| "corrupt custody tombstone: no entry line".to_string())
+}
+
+fn tombstone_body(entry: &str, kind: BackendKind) -> Vec<u8> {
+    let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    let mut body = TOMBSTONE_MAGIC.to_vec();
+    body.extend_from_slice(
+        format!(
+            "entry: {entry}\nbackend: {kind}\nmoved: {now}\n\n\
+             The private key that lived here is held in OS-keystore custody: a\n\
+             sealed blob under access-certs/{CUSTODY_SUBDIR}/ whose wrapping key lives in\n\
+             the platform keystore. `intendant custody status` shows the estate;\n\
+             `intendant custody restore` returns keys to plain files.\n"
+        )
+        .as_bytes(),
+    );
+    body
+}
+
+/// The platform custody backend for blobs under `<cert_dir>/custody`, or
+/// `None` where no OS-keystore backend exists yet (Windows DPAPI and
+/// Linux secret-service arrive with a later Track K slice; until then
+/// those platforms stay in labeled file mode).
+fn platform_backend(cert_dir: &Path) -> Option<Result<Box<dyn CustodyBackend>, String>> {
+    #[cfg(target_os = "macos")]
+    {
+        Some(
+            intendant_custody::mac_keychain::mac_wrapped_backend(cert_dir.join(CUSTODY_SUBDIR))
+                .map(|backend| Box::new(backend) as Box<dyn CustodyBackend>)
+                .map_err(|error| format!("custody backend setup: {error}")),
+        )
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = cert_dir;
+        None
+    }
+}
+
+/// Read private-key material from `path`, routing tombstones to custody.
+///
+/// This is the single consumption seam for every class-1 read (TLS
+/// server key, peer mTLS client identity, CA ceremonies, p12 serving) —
+/// and it also serves operator-override key paths, which simply never
+/// contain a tombstone. Missing files and custody failures are named
+/// errors; a migrated key never silently degrades to a file read. A
+/// plain file is the labeled pre-migration default (`intendant custody
+/// status` names it), deliberately not a per-read audit event — reads
+/// happen at every daemon boot and dial, and there is no silent
+/// degradation lane left to audit: the custody lane fails closed.
+pub fn read_key_material(path: &Path) -> Result<Secret, String> {
+    let bytes = std::fs::read(path).map_err(|error| format!("read {}: {error}", path.display()))?;
+    if !is_tombstone(&bytes) {
+        return Ok(Secret::new(bytes));
+    }
+    let entry = tombstone_entry(&bytes).map_err(|error| format!("{}: {error}", path.display()))?;
+    let backend = required_backend(path, &entry)?;
+    retrieve_migrated(backend.as_ref(), path, &entry)
+}
+
+/// Write private-key material to `path`, keeping migrated entries in
+/// custody: if the file is a tombstone, the new material replaces the
+/// custody entry and the tombstone is refreshed; otherwise this is a
+/// plain owner-only-from-creation file write.
+pub fn write_key_material(path: &Path, material: &[u8]) -> Result<(), String> {
+    let existing = std::fs::read(path).ok();
+    match existing.as_deref().filter(|bytes| is_tombstone(bytes)) {
+        Some(bytes) => {
+            let entry =
+                tombstone_entry(bytes).map_err(|error| format!("{}: {error}", path.display()))?;
+            let backend = required_backend(path, &entry)?;
+            store_migrated(backend.as_ref(), path, &entry, material)
+        }
+        None => intendant_core::state_paths::write_private_file(path, material)
+            .map_err(|error| format!("write {}: {error}", path.display())),
+    }
+}
+
+/// Resolve the platform backend for a migrated file, failing closed (and
+/// auditing) when this platform cannot serve the entry.
+fn required_backend(path: &Path, entry: &str) -> Result<Box<dyn CustodyBackend>, String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("{} has no parent directory", path.display()))?;
+    match platform_backend(parent) {
+        Some(Ok(backend)) => Ok(backend),
+        Some(Err(error)) => {
+            audit_denied(entry, path, &error);
+            Err(format!(
+                "custody entry {entry} for {}: {error}; `intendant custody restore` returns keys \
+                 to files (run it from a context the keystore trusts)",
+                path.display()
+            ))
+        }
+        None => {
+            let error = "no custody backend on this platform".to_string();
+            audit_denied(entry, path, &error);
+            Err(format!(
+                "custody entry {entry} for {}: {error} — the key was migrated on a platform with \
+                 an OS keystore; run `intendant custody restore` there, or restore the file from \
+                 backup",
+                path.display()
+            ))
+        }
+    }
+}
+
+/// Retrieve a migrated entry — the fail-closed custody lane. Every
+/// failure is audited and named; there is deliberately no file fallback.
+fn retrieve_migrated(
+    backend: &dyn CustodyBackend,
+    path: &Path,
+    entry: &str,
+) -> Result<Secret, String> {
+    backend.retrieve(entry).map_err(|error| {
+        let error = error.to_string();
+        audit_denied(entry, path, &error);
+        format!(
+            "custody entry {entry} for {}: {error}; `intendant custody restore` returns keys to \
+             files (run it from a context the keystore trusts)",
+            path.display()
+        )
+    })
+}
+
+/// Replace a migrated entry's material and refresh its tombstone.
+fn store_migrated(
+    backend: &dyn CustodyBackend,
+    path: &Path,
+    entry: &str,
+    material: &[u8],
+) -> Result<(), String> {
+    backend.store(entry, material).map_err(|error| {
+        let error = error.to_string();
+        audit_denied(entry, path, &error);
+        format!("custody store {entry} for {}: {error}", path.display())
+    })?;
+    replace_file_atomic(path, &tombstone_body(entry, backend.kind()))?;
+    credential_audit::record(
+        credential_audit::EVENT_KEY_STORED,
+        entry,
+        &path.display().to_string(),
+        "daemon",
+        "custody entry replaced by key regeneration".to_string(),
+    );
+    Ok(())
+}
+
+fn audit_denied(entry: &str, path: &Path, detail: &str) {
+    credential_audit::record(
+        credential_audit::EVENT_KEY_DENIED,
+        entry,
+        &path.display().to_string(),
+        "daemon",
+        detail.to_string(),
+    );
+}
+
+/// Staged sibling used by [`replace_file_atomic`]; a distinct suffix per
+/// full file name so `client.key` and `client.p12` never collide.
+fn staged_path(path: &Path) -> PathBuf {
+    let mut name = path
+        .file_name()
+        .map(|name| name.to_os_string())
+        .unwrap_or_default();
+    name.push(".custody-staged");
+    path.with_file_name(name)
+}
+
+/// Owner-only staged write + rename. Standard library only (the tempfile
+/// crate stays off persist seams), synced before rename, parent synced
+/// after so the swap is durable before any custody blob is deleted.
+fn replace_file_atomic(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    let staged = staged_path(path);
+    let _ = std::fs::remove_file(&staged);
+    let mut file = intendant_core::state_paths::private_file_options()
+        .create_new(true)
+        .open(&staged)
+        .map_err(|error| format!("stage {}: {error}", staged.display()))?;
+    file.write_all(bytes)
+        .map_err(|error| format!("stage {}: {error}", staged.display()))?;
+    file.sync_all()
+        .map_err(|error| format!("sync {}: {error}", staged.display()))?;
+    drop(file);
+    std::fs::rename(&staged, path)
+        .map_err(|error| format!("replace {}: {error}", path.display()))?;
+    #[cfg(unix)]
+    if let Some(parent) = path.parent() {
+        if let Ok(dir) = std::fs::File::open(parent) {
+            let _ = dir.sync_all();
+        }
+    }
+    Ok(())
+}
+
+/// One artifact's outcome in a migrate/restore run.
+enum Outcome {
+    Done,
+    Skipped(&'static str),
+}
+
+/// Relocate every class-1 file in `cert_dir` into `backend`. Per-file
+/// sequence: store → retrieve-and-verify byte-equal → tombstone the
+/// file. Any failure stops the run with the file untouched — a failed or
+/// half migration leaves a working file install (already-migrated files
+/// from earlier in the run stay migrated; the verb is idempotent).
+fn migrate_estate(
+    cert_dir: &Path,
+    backend: &dyn CustodyBackend,
+    mut report: impl FnMut(&str, &Outcome),
+) -> Result<(), String> {
+    for name in CLASS1_FILES {
+        let path = cert_dir.join(name);
+        let bytes = match std::fs::read(&path) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                report(name, &Outcome::Skipped("not present"));
+                continue;
+            }
+            Err(error) => return Err(format!("read {}: {error}", path.display())),
+        };
+        if is_tombstone(&bytes) {
+            report(name, &Outcome::Skipped("already in custody"));
+            continue;
+        }
+        let entry = entry_name_for(name);
+        backend
+            .store(&entry, &bytes)
+            .map_err(|error| format!("store {entry}: {error}"))?;
+        let sealed = backend
+            .retrieve(&entry)
+            .map_err(|error| format!("verify {entry}: {error}"))?;
+        if sealed.as_bytes() != bytes.as_slice() {
+            return Err(format!(
+                "verify {entry}: round-trip mismatch — file left untouched"
+            ));
+        }
+        replace_file_atomic(&path, &tombstone_body(&entry, backend.kind()))?;
+        credential_audit::record(
+            credential_audit::EVENT_KEY_MIGRATED,
+            &entry,
+            &path.display().to_string(),
+            "operator",
+            format!(
+                "relocated into {} custody (relocation, not rotation — pre-migration copies \
+                 unaffected)",
+                backend.kind()
+            ),
+        );
+        report(name, &Outcome::Done);
+    }
+    Ok(())
+}
+
+/// Return every migrated class-1 file to a plain file. Per-file:
+/// retrieve → durable file write over the tombstone → delete the blob
+/// (best-effort; a leftover blob is inert once the file is real again).
+fn restore_estate(
+    cert_dir: &Path,
+    backend: &dyn CustodyBackend,
+    mut report: impl FnMut(&str, &Outcome),
+) -> Result<(), String> {
+    for name in CLASS1_FILES {
+        let path = cert_dir.join(name);
+        let bytes = match std::fs::read(&path) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                report(name, &Outcome::Skipped("not present"));
+                continue;
+            }
+            Err(error) => return Err(format!("read {}: {error}", path.display())),
+        };
+        if !is_tombstone(&bytes) {
+            report(name, &Outcome::Skipped("already a file"));
+            continue;
+        }
+        let entry = tombstone_entry(&bytes).map_err(|error| format!("{name}: {error}"))?;
+        let material = backend
+            .retrieve(&entry)
+            .map_err(|error| format!("retrieve {entry}: {error}"))?;
+        replace_file_atomic(&path, material.as_bytes())?;
+        if let Err(error) = backend.delete(&entry) {
+            eprintln!("!! blob delete for {entry} failed ({error}) — the restored file wins; the leftover sealed blob is inert");
+        }
+        credential_audit::record(
+            credential_audit::EVENT_KEY_RESTORED,
+            &entry,
+            &path.display().to_string(),
+            "operator",
+            "returned from custody to a plain file".to_string(),
+        );
+        report(name, &Outcome::Done);
+    }
+    Ok(())
+}
+
+/// `intendant custody <status|migrate|restore>` — keyless, local, opt-in
+/// (ruling Q2: migration never happens on boot).
+pub fn run_cli(args: Vec<String>) -> Result<(), String> {
+    let action = args.first().map(String::as_str).unwrap_or("");
+    if !matches!(action, "status" | "migrate" | "restore") {
+        return Err("usage: intendant custody <status|migrate|restore>\n\
+             \n\
+             status    Show where each access private key lives (file, custody, missing)\n\
+             migrate   Relocate access private keys into OS-keystore custody (opt-in)\n\
+             restore   Return custody-held access private keys to plain files"
+            .to_string());
+    }
+    let cert_dir = crate::access::backend::select_backend().cert_dir();
+    match action {
+        "status" => print_status(&cert_dir),
+        "migrate" => {
+            let backend = cli_backend(&cert_dir)?;
+            println!(
+                ":: migrating access private keys into {} custody",
+                backend.kind()
+            );
+            migrate_estate(&cert_dir, backend.as_ref(), print_outcome)?;
+            println!();
+            println!(
+                ":: done — sealed blobs live in {}; reads route through custody",
+                cert_dir.join(CUSTODY_SUBDIR).display()
+            );
+            println!(
+                ":: relocation, not rotation: copies made before migration are unaffected\n\
+                 :: (pre-migration copy risk owner-accepted 2026-07-21)"
+            );
+            println!(
+                ":: custody raises the bar against casual same-uid file reads; it is not a\n\
+                 :: sealed lane until the daemon ships as a signed, hardened binary"
+            );
+            Ok(())
+        }
+        "restore" => {
+            let backend = cli_backend(&cert_dir)?;
+            println!(":: returning access private keys to plain files");
+            restore_estate(&cert_dir, backend.as_ref(), print_outcome)?;
+            println!(":: done — keys are plain files again (labeled file mode)");
+            Ok(())
+        }
+        _ => unreachable!("matched above"),
+    }
+}
+
+fn cli_backend(cert_dir: &Path) -> Result<Box<dyn CustodyBackend>, String> {
+    match platform_backend(cert_dir) {
+        Some(Ok(backend)) => Ok(backend),
+        Some(Err(error)) => Err(error),
+        None => Err(
+            "no custody backend on this platform yet (Windows DPAPI and Linux secret-service \
+             backends arrive with a later Track K slice); access keys stay in labeled file mode"
+                .to_string(),
+        ),
+    }
+}
+
+fn print_outcome(name: &str, outcome: &Outcome) {
+    match outcome {
+        Outcome::Done => println!("   {name:<12} done"),
+        Outcome::Skipped(reason) => println!("   {name:<12} skipped ({reason})"),
+    }
+}
+
+fn print_status(cert_dir: &Path) -> Result<(), String> {
+    println!("Custody status (access-certs estate)");
+    println!("   cert dir: {}", cert_dir.display());
+    let backend = match platform_backend(cert_dir) {
+        Some(Ok(backend)) => {
+            println!("   backend:  {} (available)", backend.kind());
+            Some(backend)
+        }
+        Some(Err(error)) => {
+            println!("   backend:  unavailable ({error})");
+            None
+        }
+        None => {
+            println!(
+                "   backend:  none on this platform yet — keys stay in labeled file mode\n\
+                              (Windows DPAPI / Linux secret-service arrive with a later Track K slice)"
+            );
+            None
+        }
+    };
+    println!();
+    for name in CLASS1_FILES {
+        let path = cert_dir.join(name);
+        let line = match std::fs::read(&path) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => "missing".to_string(),
+            Err(error) => format!("unreadable ({error})"),
+            Ok(bytes) if !is_tombstone(&bytes) => "file mode".to_string(),
+            Ok(bytes) => match tombstone_entry(&bytes) {
+                Err(error) => format!("INCONSISTENT: {error}"),
+                Ok(entry) => match backend.as_deref().map(|backend| backend.contains(&entry)) {
+                    Some(Ok(true)) => "custody (sealed blob present)".to_string(),
+                    Some(Ok(false)) => format!(
+                        "INCONSISTENT: tombstone for {entry} but no sealed blob — restore is \
+                         impossible; regenerate via `intendant access setup --force`"
+                    ),
+                    Some(Err(error)) => format!("custody (blob check failed: {error})"),
+                    None => format!("custody entry {entry} (no backend on this platform)"),
+                },
+            },
+        };
+        println!("   {name:<12} {line}");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use intendant_custody::PlainFileBackend;
+
+    fn backend_in(dir: &Path) -> PlainFileBackend {
+        PlainFileBackend::new(dir.join(CUSTODY_SUBDIR)).unwrap()
+    }
+
+    fn seed(dir: &Path, name: &str, bytes: &[u8]) -> PathBuf {
+        let path = dir.join(name);
+        std::fs::write(&path, bytes).unwrap();
+        path
+    }
+
+    #[test]
+    fn tombstone_detection_and_entry_roundtrip() {
+        let body = tombstone_body("access-certs/server.key", BackendKind::PlainFile);
+        assert!(is_tombstone(&body));
+        assert_eq!(tombstone_entry(&body).unwrap(), "access-certs/server.key");
+        assert!(!is_tombstone(b"-----BEGIN PRIVATE KEY-----\nabc\n"));
+        // Magic without an entry line is corrupt, not key material.
+        assert!(tombstone_entry(TOMBSTONE_MAGIC).is_err());
+    }
+
+    #[test]
+    fn plain_files_serve_as_is() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = seed(tmp.path(), "server.key", b"PLAIN PEM");
+        assert_eq!(read_key_material(&path).unwrap().as_bytes(), b"PLAIN PEM");
+        // Operator-override paths outside the estate behave identically.
+        let other = seed(tmp.path(), "operator-override.pem", b"OTHER PEM");
+        assert_eq!(read_key_material(&other).unwrap().as_bytes(), b"OTHER PEM");
+    }
+
+    #[test]
+    fn migrate_tombstones_files_and_custody_serves_them() {
+        let tmp = tempfile::tempdir().unwrap();
+        let backend = backend_in(tmp.path());
+        let key = seed(tmp.path(), "client.key", b"CLIENT KEY");
+        let p12 = seed(tmp.path(), "client.p12", b"\x30\x82P12 BINARY");
+
+        let mut outcomes = Vec::new();
+        migrate_estate(tmp.path(), &backend, |name, outcome| {
+            outcomes.push((name.to_string(), matches!(outcome, Outcome::Done)));
+        })
+        .unwrap();
+        assert_eq!(
+            outcomes
+                .iter()
+                .filter(|(_, done)| *done)
+                .map(|(name, _)| name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["client.key", "client.p12"],
+            "absent ca.key/server.key skip, present files migrate"
+        );
+
+        // Files are tombstones now; the custody lane serves the material.
+        let key_bytes = std::fs::read(&key).unwrap();
+        assert!(is_tombstone(&key_bytes));
+        let entry = tombstone_entry(&key_bytes).unwrap();
+        assert_eq!(entry, "access-certs/client.key");
+        assert_eq!(
+            retrieve_migrated(&backend, &key, &entry)
+                .unwrap()
+                .as_bytes(),
+            b"CLIENT KEY"
+        );
+        assert!(is_tombstone(&std::fs::read(&p12).unwrap()));
+
+        // Idempotent: a second run skips everything.
+        let mut second = Vec::new();
+        migrate_estate(tmp.path(), &backend, |name, outcome| {
+            second.push((name.to_string(), matches!(outcome, Outcome::Done)));
+        })
+        .unwrap();
+        assert!(second.iter().all(|(_, done)| !done));
+
+        // The migrate + custody-read trail reached the audit log.
+        let events = credential_audit::recent(100);
+        assert!(events.iter().any(|event| {
+            event.event == credential_audit::EVENT_KEY_MIGRATED
+                && event.kind == "access-certs/client.key"
+                && event.label == key.display().to_string()
+                && event.detail.contains("relocation, not rotation")
+        }));
+    }
+
+    #[test]
+    fn restore_returns_files_and_deletes_blobs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let backend = backend_in(tmp.path());
+        let key = seed(tmp.path(), "server.key", b"SERVER KEY");
+        migrate_estate(tmp.path(), &backend, |_, _| {}).unwrap();
+        assert!(is_tombstone(&std::fs::read(&key).unwrap()));
+
+        restore_estate(tmp.path(), &backend, |_, _| {}).unwrap();
+        assert_eq!(std::fs::read(&key).unwrap(), b"SERVER KEY");
+        assert!(
+            !backend.contains("access-certs/server.key").unwrap(),
+            "restored entries leave no blob behind"
+        );
+        let events = credential_audit::recent(100);
+        assert!(events.iter().any(|event| {
+            event.event == credential_audit::EVENT_KEY_RESTORED
+                && event.label == key.display().to_string()
+        }));
+    }
+
+    #[test]
+    fn custody_write_refreshes_entry_and_keeps_tombstone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let backend = backend_in(tmp.path());
+        let key = seed(tmp.path(), "server.key", b"OLD SERVER KEY");
+        migrate_estate(tmp.path(), &backend, |_, _| {}).unwrap();
+
+        // The regen path: store through the custody-aware writer.
+        let bytes = std::fs::read(&key).unwrap();
+        let entry = tombstone_entry(&bytes).unwrap();
+        store_migrated(&backend, &key, &entry, b"NEW SERVER KEY").unwrap();
+        assert!(is_tombstone(&std::fs::read(&key).unwrap()));
+        assert_eq!(
+            retrieve_migrated(&backend, &key, &entry)
+                .unwrap()
+                .as_bytes(),
+            b"NEW SERVER KEY"
+        );
+    }
+
+    #[test]
+    fn write_key_material_plain_path_is_owner_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("fresh.key");
+        write_key_material(&path, b"FRESH").unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"FRESH");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600);
+        }
+    }
+
+    /// A backend failure mid-migrate leaves the current file untouched
+    /// (files migrated earlier in the run stay migrated).
+    #[test]
+    fn migrate_failure_leaves_file_intact() {
+        struct FailingStore;
+        impl CustodyBackend for FailingStore {
+            fn kind(&self) -> BackendKind {
+                BackendKind::PlainFile
+            }
+            fn store(
+                &self,
+                name: &str,
+                _material: &[u8],
+            ) -> Result<(), intendant_custody::CustodyError> {
+                Err(intendant_custody::CustodyError::BackendUnavailable {
+                    backend: BackendKind::PlainFile,
+                    reason: format!("simulated outage for {name}"),
+                })
+            }
+            fn retrieve(&self, name: &str) -> Result<Secret, intendant_custody::CustodyError> {
+                Err(intendant_custody::CustodyError::NotFound {
+                    name: name.to_string(),
+                })
+            }
+            fn delete(&self, _name: &str) -> Result<(), intendant_custody::CustodyError> {
+                Ok(())
+            }
+            fn contains(&self, _name: &str) -> Result<bool, intendant_custody::CustodyError> {
+                Ok(false)
+            }
+        }
+
+        let tmp = tempfile::tempdir().unwrap();
+        let key = seed(tmp.path(), "ca.key", b"CA KEY");
+        let error = migrate_estate(tmp.path(), &FailingStore, |_, _| {}).unwrap_err();
+        assert!(error.contains("store access-certs/ca.key"), "{error}");
+        assert_eq!(
+            std::fs::read(&key).unwrap(),
+            b"CA KEY",
+            "a failed store must leave the file untouched"
+        );
+    }
+
+    /// The custody lane never falls back to files: a denied retrieval is
+    /// a named error and lands in the audit trail.
+    #[test]
+    fn denied_retrieval_fails_closed_and_audits() {
+        struct Denying;
+        impl CustodyBackend for Denying {
+            fn kind(&self) -> BackendKind {
+                BackendKind::MacKeychainWrapped
+            }
+            fn store(
+                &self,
+                _name: &str,
+                _material: &[u8],
+            ) -> Result<(), intendant_custody::CustodyError> {
+                Ok(())
+            }
+            fn retrieve(&self, _name: &str) -> Result<Secret, intendant_custody::CustodyError> {
+                Err(intendant_custody::CustodyError::DeniedNonInteractive {
+                    backend: BackendKind::MacKeychainWrapped,
+                    reason: "simulated headless deny".to_string(),
+                })
+            }
+            fn delete(&self, _name: &str) -> Result<(), intendant_custody::CustodyError> {
+                Ok(())
+            }
+            fn contains(&self, _name: &str) -> Result<bool, intendant_custody::CustodyError> {
+                Ok(true)
+            }
+        }
+
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("client.key");
+        replace_file_atomic(
+            &path,
+            &tombstone_body("access-certs/client.key", BackendKind::MacKeychainWrapped),
+        )
+        .unwrap();
+        let error = retrieve_migrated(&Denying, &path, "access-certs/client.key").unwrap_err();
+        assert!(error.contains("denied non-interactively"), "{error}");
+        assert!(error.contains("intendant custody restore"), "{error}");
+        let events = credential_audit::recent(100);
+        assert!(events.iter().any(|event| {
+            event.event == credential_audit::EVENT_KEY_DENIED
+                && event.label == path.display().to_string()
+                && event.detail.contains("simulated headless deny")
+        }));
+    }
+
+    /// On platforms with no custody backend, a tombstoned key is a named
+    /// error pointing at the platform gap — never a silent file serve.
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn tombstone_without_platform_backend_is_a_named_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("client.key");
+        replace_file_atomic(
+            &path,
+            &tombstone_body("access-certs/client.key", BackendKind::MacKeychainWrapped),
+        )
+        .unwrap();
+        let error = read_key_material(&path).unwrap_err();
+        assert!(
+            error.contains("no custody backend on this platform"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn cli_rejects_unknown_actions() {
+        let error = run_cli(vec!["frobnicate".to_string()]).unwrap_err();
+        assert!(error.contains("usage: intendant custody"), "{error}");
+        let error = run_cli(Vec::new()).unwrap_err();
+        assert!(error.contains("usage: intendant custody"), "{error}");
+    }
+}

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -55,6 +55,7 @@ mod frontend;
 mod gateway_routes;
 mod global_store;
 mod hosted_verify;
+mod key_custody;
 mod lease_transcript_staging;
 mod lineage_ledger;
 mod linux_display_env;
@@ -402,6 +403,7 @@ fn print_help() {
     println!("SUBCOMMANDS:");
     println!("    ctl                   Control a running Intendant daemon over MCP");
     println!("    access                Configure dashboard TLS/mTLS access certificates");
+    println!("    custody               Show, migrate, or restore OS-keystore custody of access private keys");
     println!("    hosted-verify         Verify a rendezvous serves the code its transparency log commits to (--releases: app release artifacts)");
     println!("    org                   Create or print a local org root key");
     println!("    peer                  Pair and configure federated Intendant peers");
@@ -3145,6 +3147,21 @@ async fn main() -> Result<(), CallerError> {
                 );
                 Ok(())
             }
+            Err(e) => {
+                eprintln!("error: {e}");
+                std::process::exit(1);
+            }
+        };
+    }
+
+    // Intercept `intendant custody <action>` — show, migrate, or restore
+    // OS-keystore custody of the access private-key estate (Track K).
+    // Keyless and local like `org`; migration is opt-in by ruling, never
+    // an ambient side effect of some other command.
+    if env::args().nth(1).as_deref() == Some("custody") {
+        let argv: Vec<String> = env::args().skip(2).collect();
+        return match key_custody::run_cli(argv) {
+            Ok(()) => Ok(()),
             Err(e) => {
                 eprintln!("error: {e}");
                 std::process::exit(1);

--- a/src/bin/caller/web_tls.rs
+++ b/src/bin/caller/web_tls.rs
@@ -661,18 +661,23 @@ pub fn load_pem_cert_and_key(
         ));
     }
 
-    let key_bytes = std::fs::read(key_path)
-        .map_err(|e| format!("reading TLS key {}: {e}", key_path.display()))?;
+    // Custody-routed: a migrated key file is a tombstone naming a sealed
+    // custody entry; a plain file (including operator overrides) serves
+    // as-is. Fail-closed — no file fallback for migrated keys.
+    let key_bytes =
+        crate::key_custody::read_key_material(key_path).map_err(|e| format!("TLS key: {e}"))?;
     let key: rustls::pki_types::PrivateKeyDer<'static> =
-        rustls::pki_types::PrivateKeyDer::from_pem_slice(&key_bytes).map_err(|e| match e {
-            PemError::NoItemsFound => {
-                format!(
-                    "no private key found in {} (expected PKCS#8/PKCS#1/SEC1 PEM)",
-                    key_path.display()
-                )
-            }
-            err => format!("parsing TLS key {}: {err}", key_path.display()),
-        })?;
+        rustls::pki_types::PrivateKeyDer::from_pem_slice(key_bytes.as_bytes()).map_err(
+            |e| match e {
+                PemError::NoItemsFound => {
+                    format!(
+                        "no private key found in {} (expected PKCS#8/PKCS#1/SEC1 PEM)",
+                        key_path.display()
+                    )
+                }
+                err => format!("parsing TLS key {}: {err}", key_path.display()),
+            },
+        )?;
 
     Ok((cert_chain, key))
 }

--- a/tests/skills/custody-keychain-prompt/SKILL.md
+++ b/tests/skills/custody-keychain-prompt/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: custody-keychain-prompt
+description: Operator-hardware prompt lane for Track K custody — verifies the interactive macOS keychain arc (Always Allow on the wrapping key, silent reads after, deny on Deny) that the hermetic acceptance rig deliberately excludes
+---
+
+# Custody keychain prompt lane (macOS, operator hardware only)
+
+The hermetic acceptance rig (`crates/intendant-custody/tests/mac_acceptance.rs`)
+proves caller discrimination with keychain UI **disabled**: the creating binary
+reads silently, an unregistered binary lands on `DeniedNonInteractive`. What it
+deliberately cannot exercise is the interactive third path — SecurityAgent
+showing the wrapping-key prompt and a human ruling on it. That lane needs a GUI
+session and a person, so it lives here (Track K ruling Q7: prompt lane =
+operator hardware, never CI).
+
+**Requires:** a macOS GUI session (SecurityAgent prompts are invisible over
+SSH — they appear on the console), a build of this worktree, and a daemon whose
+access certs exist (`intendant access setup` has been run). Use a scratch
+`$HOME`-adjacent daemon if you don't want to touch your live estate; the flow
+below relocates real keys and restores them at the end.
+
+## Arc
+
+1. **Migrate (silent — creating caller):**
+   `target/release/intendant custody migrate`
+   Expect per-file `done` lines, the *relocation-not-rotation* label, and **no
+   prompt** — the migrating binary mints the wrapping-key item, so the item ACL
+   trusts it from birth. `intendant custody status` shows every artifact as
+   `custody (sealed blob present)`.
+2. **Silent reads (same binary):** restart the daemon from the same build;
+   HTTPS bind (server.key) and any peer dial (client.key) must proceed with no
+   prompt and no new `key_custody_denied` events in the custody trail.
+3. **The prompt (different binary identity):** rebuild the binary (any code
+   change re-signs the ad-hoc identity), run
+   `target/release/intendant custody status`, then trigger a read (restart the
+   daemon or `intendant access serve-certs`). SecurityAgent shows the
+   wrapping-key prompt for `dev.intendant.custody`:
+   - **Always Allow** → this identity joins the item ACL; subsequent reads are
+     silent. (On signed installs the stable "Intendant Dev" identity makes this
+     a once-ever event; ad-hoc dev builds re-prompt per rebuild — the ruled Q2
+     reason custody is recommended-by-default on signed installs only.)
+   - **Deny** → the read fails with the named custody error, and
+     `key_custody_denied` lands in the trail. The daemon must fail closed with
+     the `intendant custody restore` guidance, not hang and not fall back to
+     any file.
+4. **Headless cross-check:** from an SSH session (no GUI), a read by a
+   not-yet-allowed binary must return the `DeniedNonInteractive` class
+   promptly — never park waiting on a prompt nobody can see.
+5. **Restore:** `intendant custody restore` — files return, blobs deleted,
+   `key_custody_restored` events in the trail, daemon boots clean from files.
+
+Record outcomes (prompt shown? silence after Always Allow? deny named?) in the
+session notes; this lane is the human proof behind the docs' custody claims.


### PR DESCRIPTION
Track K slice K2b: the class-1 private-key estate (`ca.key`, `server.key`, `client.key`, `client.p12`) can relocate into OS-keystore custody, opt-in via the new keyless `intendant custody <status|migrate|restore>` subcommand.

**Migration semantics (ruled):** relocation, not rotation — per file: store into the sealed-blob backend → verify byte-equal round trip → atomically replace the file with a tombstone naming the custody entry. Any failure leaves the file untouched; the verb is idempotent; a failed/half migration leaves a fully working file install. Restore is the inverse (durable file write over the tombstone, then best-effort blob delete). Sealed blobs live at `access-certs/custody/`, inside the existing runtime-sandbox read-deny — no new sandbox policy.

**Consumption seams:** every class-1 read routes by content through `key_custody::read_key_material` — `web_tls::load_pem_cert_and_key` (gateway acceptor, enrollment server, peer mTLS client identity, gateway reload), the three CA ceremony reads in `access/certs.rs`, both `client.p12` serves in `cert_server.rs` (denied custody now 500s loudly instead of a misleading 404). Plain files serve as-is — the labeled pre-migration default, shown by `custody status`; tombstones go to custody and **never** fall back to a file, so a stale plain copy cannot silently win after migration. There is deliberately no per-read "file mode" audit event: the fail-closed lane replaced the silent-degradation lane the audit requirement targeted, and read-side trail writes from real binaries would leak state into the live trail during e2e runs. Key regeneration writes go through `write_key_material`, so recert/`--force` on a migrated estate refreshes the custody entry instead of regressing it to file mode. New trail events: `key_custody_migrated`/`restored`/`stored`/`denied`.

**Acceptance rig (ruling Q7, hermetic):** `crates/intendant-custody/tests/mac_acceptance.rs` — throwaway file-backed keychain in a temp dir (never login), new `ScopedKeychainKeyProvider`, keychain UI disabled process-wide, spawned `custody-probe` helper binary as the unregistered caller. Proven live on real keychain: creating binary silent, second binary lands on `DeniedNonInteractive`, absent entries answer `NotFound` without touching the keystore. Evidence note: the no-UI ACL deny surfaces as `errSecAuthFailed` (-25293) on modern macOS, so item-access errors map it (plus `errSecInteractionNotAllowed`) to the deny class, while setup-stage errors keep -25293 as backend-unavailable (there it means a wrong keychain password). The interactive prompt lane is an operator-hardware skill: `tests/skills/custody-keychain-prompt`.

Battery: fmt, clippy -D warnings (workspace), `cargo test -p intendant --bins` (4810), all lib crates incl. the acceptance rig, headless e2e (30), live smoke of `custody status` + usage + `--help`.