### PR TITLE
custody: K3a — class-3 identity keys join the custody estate

### DIFF
--- a/crates/intendant-custody/src/lib.rs
+++ b/crates/intendant-custody/src/lib.rs
@@ -22,7 +22,7 @@ mod wrapped;
 pub mod mac_keychain;
 
 pub use file_backend::PlainFileBackend;
-pub use names::validate_entry_name;
+pub use names::{sealed_blob_file_name, validate_entry_name};
 pub use wrapped::{WrappedBlobBackend, WrappingKeyProvider};
 
 /// Exit codes for the `custody-probe` helper binary (the acceptance

--- a/crates/intendant-custody/src/names.rs
+++ b/crates/intendant-custody/src/names.rs
@@ -46,6 +46,15 @@ pub(crate) fn file_stem_for(name: &str) -> String {
     name.replace('/', "__")
 }
 
+/// File name of a [`crate::WrappedBlobBackend`] entry's sealed blob.
+/// Exported so callers can *observe* custody state (status listings)
+/// with pure path math — constructing a backend would create its blob
+/// directory as a side effect.
+pub fn sealed_blob_file_name(name: &str) -> Result<String, CustodyError> {
+    validate_entry_name(name)?;
+    Ok(format!("{}.sealed", file_stem_for(name)))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/intendant-custody/src/wrapped.rs
+++ b/crates/intendant-custody/src/wrapped.rs
@@ -12,7 +12,7 @@ use ring::rand::SystemRandom;
 use zeroize::Zeroizing;
 
 use crate::file_backend::{create_private_dir_all, write_private_file};
-use crate::names::{file_stem_for, validate_entry_name};
+use crate::names::sealed_blob_file_name;
 use crate::seal::{seal, unseal};
 use crate::{BackendKind, CustodyBackend, CustodyError, Secret};
 
@@ -53,8 +53,7 @@ impl WrappedBlobBackend {
     }
 
     fn blob_path(&self, name: &str) -> Result<PathBuf, CustodyError> {
-        validate_entry_name(name)?;
-        Ok(self.dir.join(format!("{}.sealed", file_stem_for(name))))
+        Ok(self.dir.join(sealed_blob_file_name(name)?))
     }
 }
 

--- a/src/bin/caller/daemon_identity.rs
+++ b/src/bin/caller/daemon_identity.rs
@@ -25,12 +25,18 @@ impl DaemonIdentity {
 
     pub fn load_or_create(path: impl AsRef<Path>) -> Result<Self, String> {
         let path = path.as_ref();
-        let bytes = match std::fs::read(path) {
-            Ok(bytes) => {
+        // Custody-routed (class 3): a migrated key file is a tombstone
+        // naming a sealed custody entry; a plain file serves as-is. The
+        // create branch always writes a plain file — custody is entered
+        // only through the opt-in `intendant custody migrate` verb.
+        match crate::key_custody::read_key_material_opt(path)
+            .map_err(|e| format!("daemon identity: {e}"))?
+        {
+            Some(material) => {
                 tighten_identity_dir(path);
-                bytes
+                Self::from_pkcs8(material.as_bytes())
             }
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            None => {
                 let parent = path
                     .parent()
                     .ok_or_else(|| format!("identity path has no parent: {}", path.display()))?;
@@ -40,11 +46,9 @@ impl DaemonIdentity {
                 let pkcs8 = Ed25519KeyPair::generate_pkcs8(&rng)
                     .map_err(|_| "generate daemon identity key".to_string())?;
                 write_private_key(path, pkcs8.as_ref())?;
-                pkcs8.as_ref().to_vec()
+                Self::from_pkcs8(pkcs8.as_ref())
             }
-            Err(e) => return Err(format!("read daemon identity {}: {e}", path.display())),
-        };
-        Self::from_pkcs8(&bytes)
+        }
     }
 
     pub fn from_pkcs8(pkcs8: &[u8]) -> Result<Self, String> {

--- a/src/bin/caller/key_custody.rs
+++ b/src/bin/caller/key_custody.rs
@@ -1,17 +1,20 @@
-//! OS-keystore custody for the access-certs private-key estate (Track K).
+//! OS-keystore custody for the daemon's private-key estates (Track K).
 //!
-//! The class-1 artifacts — `ca.key`, `server.key`, `client.key`,
-//! `client.p12` — normally live as 0600 files in the access cert dir.
-//! `intendant custody migrate` relocates each into a sealed blob under
-//! `<cert_dir>/custody/` (wrapping key held by the platform keystore via
-//! `intendant-custody`) and replaces the file with a *tombstone* naming
-//! the custody entry. Every consumption seam reads through
-//! [`read_key_material`], which routes by content: a real key serves
-//! as-is (labeled file mode), a tombstone routes to custody and **never**
-//! falls back to a file — after migration, a stale plain copy reappearing
-//! next to a tombstone must not silently win. Key regeneration writes go
-//! through [`write_key_material`], so a recert on a migrated estate
-//! refreshes the custody entry instead of regressing it to a file.
+//! Two ruled classes migrate through this module. Class 1 — `ca.key`,
+//! `server.key`, `client.key`, `client.p12` in the access cert dir — and
+//! class 3, the Ed25519 identity keys: `daemon-identity/ed25519.pk8` and
+//! every org `root.pk8`/`issuer.pk8` under `<cert_dir>/org/<handle>/`.
+//! `intendant custody migrate` relocates each file into a sealed blob
+//! under its estate's `custody/` subdirectory (wrapping key held by the
+//! platform keystore via `intendant-custody`) and replaces the file with
+//! a *tombstone* naming the custody entry. Every consumption seam reads
+//! through [`read_key_material`]/[`read_key_material_opt`], which route
+//! by content: a real key serves as-is (labeled file mode), a tombstone
+//! routes to custody and **never** falls back to a file — after
+//! migration, a stale plain copy reappearing next to a tombstone must
+//! not silently win. Key regeneration writes go through
+//! [`write_key_material`], so a recert on a migrated estate refreshes
+//! the custody entry instead of regressing it to a file.
 //!
 //! Binding labels from the Track K ruling:
 //! - Custody before a Developer ID + hardened-runtime binary is
@@ -27,23 +30,101 @@ use intendant_custody::{BackendKind, CustodyBackend, Secret};
 
 use crate::credential_audit;
 
-/// Sealed blobs live in this subdirectory of the access cert dir — inside
-/// the estate, so the runtime sandbox's `access-certs` read-deny and
-/// write-exclusion cover custody state with no new policy.
+/// Sealed blobs live in this subdirectory of each estate root — inside
+/// the subtree the runtime sandbox already read-denies, so custody state
+/// needs no new policy.
 const CUSTODY_SUBDIR: &str = "custody";
 
 /// First line of a migrated key file. Old binaries fail loudly on it
 /// ("no private key found"), current ones route to custody.
 const TOMBSTONE_MAGIC: &[u8] = b"INTENDANT CUSTODY TOMBSTONE v1\n";
 
-/// The class-1 artifacts `intendant custody migrate` relocates: the
-/// access-certs private-key subtree as one unit (ruling Q-S). The .p12
-/// bundles the client key, so leaving it out would make migrating
-/// `client.key` theater.
+/// The class-1 artifacts: the access-certs private-key subtree as one
+/// unit (ruling Q-S). The .p12 bundles the client key, so leaving it out
+/// would make migrating `client.key` theater.
 const CLASS1_FILES: [&str; 4] = ["ca.key", "server.key", "client.key", "client.p12"];
 
-fn entry_name_for(file_name: &str) -> String {
-    format!("access-certs/{file_name}")
+/// The class-3 per-org key files under `<cert_dir>/org/<handle>/`.
+const ORG_KEY_FILES: [&str; 2] = ["root.pk8", "issuer.pk8"];
+
+/// The class-3 daemon identity key file.
+const IDENTITY_KEY_FILE: &str = "ed25519.pk8";
+
+/// One custody-managed file: where it lives and the custody entry name
+/// its tombstone carries (which is also the seal AAD).
+struct EstateFile {
+    name: String,
+    path: PathBuf,
+    entry: String,
+}
+
+/// A group of custody-managed files sharing one directory; sealed blobs
+/// live at `<root>/custody/`.
+struct Estate {
+    label: String,
+    root: PathBuf,
+    files: Vec<EstateFile>,
+}
+
+fn access_estate(cert_dir: &Path) -> Estate {
+    Estate {
+        label: "access-certs".to_string(),
+        root: cert_dir.to_path_buf(),
+        files: CLASS1_FILES
+            .iter()
+            .map(|name| EstateFile {
+                name: (*name).to_string(),
+                path: cert_dir.join(name),
+                entry: format!("access-certs/{name}"),
+            })
+            .collect(),
+    }
+}
+
+/// The default daemon-identity estate. An operator-configured
+/// hosted-control `identity_path` outside this directory still routes
+/// through the read seam if hand-migrated, but the verbs only enumerate
+/// the default location in v1.
+fn identity_estate(identity_dir: &Path) -> Estate {
+    Estate {
+        label: "daemon-identity".to_string(),
+        root: identity_dir.to_path_buf(),
+        files: vec![EstateFile {
+            name: IDENTITY_KEY_FILE.to_string(),
+            path: identity_dir.join(IDENTITY_KEY_FILE),
+            entry: format!("daemon-identity/{IDENTITY_KEY_FILE}"),
+        }],
+    }
+}
+
+/// One estate per org key directory on disk (root key required by the
+/// handle lister; the issuer key is optional and skips when absent).
+fn org_estates(cert_dir: &Path) -> Vec<Estate> {
+    crate::access::org::local_org_handles(cert_dir)
+        .into_iter()
+        .map(|handle| {
+            let root = cert_dir.join("org").join(&handle);
+            Estate {
+                label: format!("org {handle}"),
+                files: ORG_KEY_FILES
+                    .iter()
+                    .map(|name| EstateFile {
+                        name: (*name).to_string(),
+                        path: root.join(name),
+                        entry: format!("org/{handle}/{name}"),
+                    })
+                    .collect(),
+                root,
+            }
+        })
+        .collect()
+}
+
+/// Every custody-managed estate for the given roots, in status order.
+fn all_estates(cert_dir: &Path, identity_dir: &Path) -> Vec<Estate> {
+    let mut estates = vec![access_estate(cert_dir), identity_estate(identity_dir)];
+    estates.extend(org_estates(cert_dir));
+    estates
 }
 
 fn is_tombstone(bytes: &[u8]) -> bool {
@@ -72,9 +153,9 @@ fn tombstone_body(entry: &str, kind: BackendKind) -> Vec<u8> {
         format!(
             "entry: {entry}\nbackend: {kind}\nmoved: {now}\n\n\
              The private key that lived here is held in OS-keystore custody: a\n\
-             sealed blob under access-certs/{CUSTODY_SUBDIR}/ whose wrapping key lives in\n\
-             the platform keystore. `intendant custody status` shows the estate;\n\
-             `intendant custody restore` returns keys to plain files.\n"
+             sealed blob in the {CUSTODY_SUBDIR}/ directory beside this file, whose\n\
+             wrapping key lives in the platform keystore. `intendant custody status`\n\
+             shows the estate; `intendant custody restore` returns keys to plain files.\n"
         )
         .as_bytes(),
     );
@@ -113,13 +194,26 @@ fn platform_backend(cert_dir: &Path) -> Option<Result<Box<dyn CustodyBackend>, S
 /// happen at every daemon boot and dial, and there is no silent
 /// degradation lane left to audit: the custody lane fails closed.
 pub fn read_key_material(path: &Path) -> Result<Secret, String> {
-    let bytes = std::fs::read(path).map_err(|error| format!("read {}: {error}", path.display()))?;
+    read_key_material_opt(path)?.ok_or_else(|| format!("read {}: no such file", path.display()))
+}
+
+/// [`read_key_material`] for load-or-create callers: an absent file is
+/// `Ok(None)` (the caller's create branch), every other outcome —
+/// including custody failures for a tombstoned file — stays a named
+/// error. Absence discrimination lives here so callers never parse
+/// error strings for it.
+pub fn read_key_material_opt(path: &Path) -> Result<Option<Secret>, String> {
+    let bytes = match std::fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(format!("read {}: {error}", path.display())),
+    };
     if !is_tombstone(&bytes) {
-        return Ok(Secret::new(bytes));
+        return Ok(Some(Secret::new(bytes)));
     }
     let entry = tombstone_entry(&bytes).map_err(|error| format!("{}: {error}", path.display()))?;
     let backend = required_backend(path, &entry)?;
-    retrieve_migrated(backend.as_ref(), path, &entry)
+    retrieve_migrated(backend.as_ref(), path, &entry).map(Some)
 }
 
 /// Write private-key material to `path`, keeping migrated entries in
@@ -263,47 +357,46 @@ enum Outcome {
     Skipped(&'static str),
 }
 
-/// Relocate every class-1 file in `cert_dir` into `backend`. Per-file
-/// sequence: store → retrieve-and-verify byte-equal → tombstone the
-/// file. Any failure stops the run with the file untouched — a failed or
-/// half migration leaves a working file install (already-migrated files
-/// from earlier in the run stay migrated; the verb is idempotent).
+/// Relocate every file of one estate into `backend`. Per-file sequence:
+/// store → retrieve-and-verify byte-equal → tombstone the file. Any
+/// failure stops the run with the file untouched — a failed or half
+/// migration leaves a working file install (files migrated earlier in
+/// the run stay migrated; the verb is idempotent).
 fn migrate_estate(
-    cert_dir: &Path,
+    estate: &Estate,
     backend: &dyn CustodyBackend,
     mut report: impl FnMut(&str, &Outcome),
 ) -> Result<(), String> {
-    for name in CLASS1_FILES {
-        let path = cert_dir.join(name);
-        let bytes = match std::fs::read(&path) {
+    for file in &estate.files {
+        let bytes = match std::fs::read(&file.path) {
             Ok(bytes) => bytes,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                report(name, &Outcome::Skipped("not present"));
+                report(&file.name, &Outcome::Skipped("not present"));
                 continue;
             }
-            Err(error) => return Err(format!("read {}: {error}", path.display())),
+            Err(error) => return Err(format!("read {}: {error}", file.path.display())),
         };
         if is_tombstone(&bytes) {
-            report(name, &Outcome::Skipped("already in custody"));
+            report(&file.name, &Outcome::Skipped("already in custody"));
             continue;
         }
-        let entry = entry_name_for(name);
+        let entry = &file.entry;
         backend
-            .store(&entry, &bytes)
+            .store(entry, &bytes)
             .map_err(|error| format!("store {entry}: {error}"))?;
         let sealed = backend
-            .retrieve(&entry)
+            .retrieve(entry)
             .map_err(|error| format!("verify {entry}: {error}"))?;
         if sealed.as_bytes() != bytes.as_slice() {
             return Err(format!(
                 "verify {entry}: round-trip mismatch — file left untouched"
             ));
         }
-        replace_file_atomic(&path, &tombstone_body(&entry, backend.kind()))?;
+        replace_file_atomic(&file.path, &tombstone_body(entry, backend.kind()))?;
         credential_audit::record(
             credential_audit::EVENT_KEY_MIGRATED,
-            &entry,
-            &path.display().to_string(),
+            entry,
+            &file.path.display().to_string(),
             "operator",
             format!(
                 "relocated into {} custody (relocation, not rotation — pre-migration copies \
@@ -311,80 +404,104 @@ fn migrate_estate(
                 backend.kind()
             ),
         );
-        report(name, &Outcome::Done);
+        report(&file.name, &Outcome::Done);
     }
     Ok(())
 }
 
-/// Return every migrated class-1 file to a plain file. Per-file:
+/// Return every migrated file of one estate to a plain file. Per-file:
 /// retrieve → durable file write over the tombstone → delete the blob
 /// (best-effort; a leftover blob is inert once the file is real again).
 fn restore_estate(
-    cert_dir: &Path,
+    estate: &Estate,
     backend: &dyn CustodyBackend,
     mut report: impl FnMut(&str, &Outcome),
 ) -> Result<(), String> {
-    for name in CLASS1_FILES {
-        let path = cert_dir.join(name);
-        let bytes = match std::fs::read(&path) {
+    for file in &estate.files {
+        let bytes = match std::fs::read(&file.path) {
             Ok(bytes) => bytes,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                report(name, &Outcome::Skipped("not present"));
+                report(&file.name, &Outcome::Skipped("not present"));
                 continue;
             }
-            Err(error) => return Err(format!("read {}: {error}", path.display())),
+            Err(error) => return Err(format!("read {}: {error}", file.path.display())),
         };
         if !is_tombstone(&bytes) {
-            report(name, &Outcome::Skipped("already a file"));
+            report(&file.name, &Outcome::Skipped("already a file"));
             continue;
         }
-        let entry = tombstone_entry(&bytes).map_err(|error| format!("{name}: {error}"))?;
+        let entry = tombstone_entry(&bytes).map_err(|error| format!("{}: {error}", file.name))?;
         let material = backend
             .retrieve(&entry)
             .map_err(|error| format!("retrieve {entry}: {error}"))?;
-        replace_file_atomic(&path, material.as_bytes())?;
+        replace_file_atomic(&file.path, material.as_bytes())?;
         if let Err(error) = backend.delete(&entry) {
             eprintln!("!! blob delete for {entry} failed ({error}) — the restored file wins; the leftover sealed blob is inert");
         }
         credential_audit::record(
             credential_audit::EVENT_KEY_RESTORED,
             &entry,
-            &path.display().to_string(),
+            &file.path.display().to_string(),
             "operator",
             "returned from custody to a plain file".to_string(),
         );
-        report(name, &Outcome::Done);
+        report(&file.name, &Outcome::Done);
     }
     Ok(())
 }
 
+/// The platform backend kind, without constructing anything — pure
+/// availability for status labeling.
+fn platform_backend_kind() -> Option<BackendKind> {
+    #[cfg(target_os = "macos")]
+    {
+        Some(BackendKind::MacKeychainWrapped)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        None
+    }
+}
+
+const NO_BACKEND_MESSAGE: &str =
+    "no custody backend on this platform yet (Windows DPAPI and Linux secret-service backends \
+     arrive with a later Track K slice); private keys stay in labeled file mode";
+
 /// `intendant custody <status|migrate|restore>` — keyless, local, opt-in
-/// (ruling Q2: migration never happens on boot).
+/// (ruling Q2: migration never happens on boot). Covers the class-1
+/// access estate and the class-3 identity estates in one pass.
 pub fn run_cli(args: Vec<String>) -> Result<(), String> {
     let action = args.first().map(String::as_str).unwrap_or("");
     if !matches!(action, "status" | "migrate" | "restore") {
         return Err("usage: intendant custody <status|migrate|restore>\n\
              \n\
-             status    Show where each access private key lives (file, custody, missing)\n\
-             migrate   Relocate access private keys into OS-keystore custody (opt-in)\n\
-             restore   Return custody-held access private keys to plain files"
+             status    Show where each daemon private key lives (file, custody, missing)\n\
+             migrate   Relocate daemon private keys into OS-keystore custody (opt-in)\n\
+             restore   Return custody-held private keys to plain files"
             .to_string());
     }
     let cert_dir = crate::access::backend::select_backend().cert_dir();
+    let identity_dir = crate::daemon_identity::default_identity_dir();
+    let estates = all_estates(&cert_dir, &identity_dir);
     match action {
-        "status" => print_status(&cert_dir),
+        "status" => {
+            print_status(&estates);
+            Ok(())
+        }
         "migrate" => {
-            let backend = cli_backend(&cert_dir)?;
-            println!(
-                ":: migrating access private keys into {} custody",
-                backend.kind()
-            );
-            migrate_estate(&cert_dir, backend.as_ref(), print_outcome)?;
+            let kind = platform_backend_kind().ok_or(NO_BACKEND_MESSAGE.to_string())?;
+            println!(":: migrating daemon private keys into {kind} custody");
+            for estate in &estates {
+                println!("   {} ({})", estate.label, estate.root.display());
+                if !estate.root.exists() {
+                    println!("      (not present)");
+                    continue;
+                }
+                let backend = cli_backend(&estate.root)?;
+                migrate_estate(estate, backend.as_ref(), print_outcome)?;
+            }
             println!();
-            println!(
-                ":: done — sealed blobs live in {}; reads route through custody",
-                cert_dir.join(CUSTODY_SUBDIR).display()
-            );
+            println!(":: done — sealed blobs live beside each estate; reads route through custody");
             println!(
                 ":: relocation, not rotation: copies made before migration are unaffected\n\
                  :: (pre-migration copy risk owner-accepted 2026-07-21)"
@@ -396,9 +513,17 @@ pub fn run_cli(args: Vec<String>) -> Result<(), String> {
             Ok(())
         }
         "restore" => {
-            let backend = cli_backend(&cert_dir)?;
-            println!(":: returning access private keys to plain files");
-            restore_estate(&cert_dir, backend.as_ref(), print_outcome)?;
+            platform_backend_kind().ok_or(NO_BACKEND_MESSAGE.to_string())?;
+            println!(":: returning daemon private keys to plain files");
+            for estate in &estates {
+                println!("   {} ({})", estate.label, estate.root.display());
+                if !estate.root.exists() {
+                    println!("      (not present)");
+                    continue;
+                }
+                let backend = cli_backend(&estate.root)?;
+                restore_estate(estate, backend.as_ref(), print_outcome)?;
+            }
             println!(":: done — keys are plain files again (labeled file mode)");
             Ok(())
         }
@@ -406,68 +531,64 @@ pub fn run_cli(args: Vec<String>) -> Result<(), String> {
     }
 }
 
-fn cli_backend(cert_dir: &Path) -> Result<Box<dyn CustodyBackend>, String> {
-    match platform_backend(cert_dir) {
+fn cli_backend(estate_root: &Path) -> Result<Box<dyn CustodyBackend>, String> {
+    match platform_backend(estate_root) {
         Some(Ok(backend)) => Ok(backend),
         Some(Err(error)) => Err(error),
-        None => Err(
-            "no custody backend on this platform yet (Windows DPAPI and Linux secret-service \
-             backends arrive with a later Track K slice); access keys stay in labeled file mode"
-                .to_string(),
-        ),
+        None => Err(NO_BACKEND_MESSAGE.to_string()),
     }
 }
 
 fn print_outcome(name: &str, outcome: &Outcome) {
     match outcome {
-        Outcome::Done => println!("   {name:<12} done"),
-        Outcome::Skipped(reason) => println!("   {name:<12} skipped ({reason})"),
+        Outcome::Done => println!("      {name:<12} done"),
+        Outcome::Skipped(reason) => println!("      {name:<12} skipped ({reason})"),
     }
 }
 
-fn print_status(cert_dir: &Path) -> Result<(), String> {
-    println!("Custody status (access-certs estate)");
-    println!("   cert dir: {}", cert_dir.display());
-    let backend = match platform_backend(cert_dir) {
-        Some(Ok(backend)) => {
-            println!("   backend:  {} (available)", backend.kind());
-            Some(backend)
-        }
-        Some(Err(error)) => {
-            println!("   backend:  unavailable ({error})");
-            None
-        }
-        None => {
-            println!(
-                "   backend:  none on this platform yet — keys stay in labeled file mode\n\
-                              (Windows DPAPI / Linux secret-service arrive with a later Track K slice)"
-            );
-            None
-        }
-    };
-    println!();
-    for name in CLASS1_FILES {
-        let path = cert_dir.join(name);
-        let line = match std::fs::read(&path) {
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => "missing".to_string(),
-            Err(error) => format!("unreadable ({error})"),
-            Ok(bytes) if !is_tombstone(&bytes) => "file mode".to_string(),
-            Ok(bytes) => match tombstone_entry(&bytes) {
-                Err(error) => format!("INCONSISTENT: {error}"),
-                Ok(entry) => match backend.as_deref().map(|backend| backend.contains(&entry)) {
-                    Some(Ok(true)) => "custody (sealed blob present)".to_string(),
-                    Some(Ok(false)) => format!(
-                        "INCONSISTENT: tombstone for {entry} but no sealed blob — restore is \
-                         impossible; regenerate via `intendant access setup --force`"
-                    ),
-                    Some(Err(error)) => format!("custody (blob check failed: {error})"),
-                    None => format!("custody entry {entry} (no backend on this platform)"),
-                },
-            },
-        };
-        println!("   {name:<12} {line}");
+/// Observation only: pure path math, no backend construction (which
+/// would create custody directories), no keystore access (no prompt or
+/// deny surface from a status listing).
+fn print_status(estates: &[Estate]) {
+    println!("Custody status");
+    match platform_backend_kind() {
+        Some(kind) => println!("   backend: {kind} (available)"),
+        None => println!(
+            "   backend: none on this platform yet — keys stay in labeled file mode\n\
+             \x20           (Windows DPAPI / Linux secret-service arrive with a later Track K slice)"
+        ),
     }
-    Ok(())
+    for estate in estates {
+        println!();
+        println!("   {} ({})", estate.label, estate.root.display());
+        for file in &estate.files {
+            let line = status_line(estate, file);
+            println!("      {:<12} {line}", file.name);
+        }
+    }
+}
+
+fn status_line(estate: &Estate, file: &EstateFile) -> String {
+    match std::fs::read(&file.path) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => "missing".to_string(),
+        Err(error) => format!("unreadable ({error})"),
+        Ok(bytes) if !is_tombstone(&bytes) => "file mode".to_string(),
+        Ok(bytes) => match tombstone_entry(&bytes) {
+            Err(error) => format!("INCONSISTENT: {error}"),
+            Ok(entry) => {
+                let blob = intendant_custody::sealed_blob_file_name(&entry)
+                    .map(|name| estate.root.join(CUSTODY_SUBDIR).join(name));
+                match blob {
+                    Err(error) => format!("INCONSISTENT: tombstone entry invalid: {error}"),
+                    Ok(blob) if blob.is_file() => "custody (sealed blob present)".to_string(),
+                    Ok(_) => format!(
+                        "INCONSISTENT: tombstone for {entry} but no sealed blob — restore is \
+                         impossible; regenerate this key"
+                    ),
+                }
+            }
+        },
+    }
 }
 
 #[cfg(test)]
@@ -513,7 +634,7 @@ mod tests {
         let p12 = seed(tmp.path(), "client.p12", b"\x30\x82P12 BINARY");
 
         let mut outcomes = Vec::new();
-        migrate_estate(tmp.path(), &backend, |name, outcome| {
+        migrate_estate(&access_estate(tmp.path()), &backend, |name, outcome| {
             outcomes.push((name.to_string(), matches!(outcome, Outcome::Done)));
         })
         .unwrap();
@@ -542,7 +663,7 @@ mod tests {
 
         // Idempotent: a second run skips everything.
         let mut second = Vec::new();
-        migrate_estate(tmp.path(), &backend, |name, outcome| {
+        migrate_estate(&access_estate(tmp.path()), &backend, |name, outcome| {
             second.push((name.to_string(), matches!(outcome, Outcome::Done)));
         })
         .unwrap();
@@ -563,10 +684,10 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let backend = backend_in(tmp.path());
         let key = seed(tmp.path(), "server.key", b"SERVER KEY");
-        migrate_estate(tmp.path(), &backend, |_, _| {}).unwrap();
+        migrate_estate(&access_estate(tmp.path()), &backend, |_, _| {}).unwrap();
         assert!(is_tombstone(&std::fs::read(&key).unwrap()));
 
-        restore_estate(tmp.path(), &backend, |_, _| {}).unwrap();
+        restore_estate(&access_estate(tmp.path()), &backend, |_, _| {}).unwrap();
         assert_eq!(std::fs::read(&key).unwrap(), b"SERVER KEY");
         assert!(
             !backend.contains("access-certs/server.key").unwrap(),
@@ -584,7 +705,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let backend = backend_in(tmp.path());
         let key = seed(tmp.path(), "server.key", b"OLD SERVER KEY");
-        migrate_estate(tmp.path(), &backend, |_, _| {}).unwrap();
+        migrate_estate(&access_estate(tmp.path()), &backend, |_, _| {}).unwrap();
 
         // The regen path: store through the custody-aware writer.
         let bytes = std::fs::read(&key).unwrap();
@@ -647,7 +768,8 @@ mod tests {
 
         let tmp = tempfile::tempdir().unwrap();
         let key = seed(tmp.path(), "ca.key", b"CA KEY");
-        let error = migrate_estate(tmp.path(), &FailingStore, |_, _| {}).unwrap_err();
+        let error =
+            migrate_estate(&access_estate(tmp.path()), &FailingStore, |_, _| {}).unwrap_err();
         assert!(error.contains("store access-certs/ca.key"), "{error}");
         assert_eq!(
             std::fs::read(&key).unwrap(),
@@ -729,5 +851,128 @@ mod tests {
         assert!(error.contains("usage: intendant custody"), "{error}");
         let error = run_cli(Vec::new()).unwrap_err();
         assert!(error.contains("usage: intendant custody"), "{error}");
+    }
+
+    /// Estate enumeration covers class 1 plus every class-3 location:
+    /// the daemon identity key and each org's key directory, with entry
+    /// names carrying the estate namespace.
+    #[test]
+    fn estate_enumeration_covers_identity_and_orgs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cert_dir = tmp.path().join("access-certs");
+        let identity_dir = tmp.path().join("daemon-identity");
+        std::fs::create_dir_all(cert_dir.join("org/acme")).unwrap();
+        std::fs::create_dir_all(cert_dir.join("org/zeta")).unwrap();
+        std::fs::write(cert_dir.join("org/acme/root.pk8"), b"ROOT").unwrap();
+        std::fs::write(cert_dir.join("org/zeta/root.pk8"), b"ROOT").unwrap();
+        // A directory without a root key is not an org estate.
+        std::fs::create_dir_all(cert_dir.join("org/empty")).unwrap();
+
+        let estates = all_estates(&cert_dir, &identity_dir);
+        let labels: Vec<&str> = estates.iter().map(|estate| estate.label.as_str()).collect();
+        assert_eq!(
+            labels,
+            vec!["access-certs", "daemon-identity", "org acme", "org zeta"]
+        );
+
+        let identity = &estates[1];
+        assert_eq!(identity.files.len(), 1);
+        assert_eq!(identity.files[0].entry, "daemon-identity/ed25519.pk8");
+        assert_eq!(identity.files[0].path, identity_dir.join("ed25519.pk8"));
+
+        let acme = &estates[2];
+        let entries: Vec<&str> = acme.files.iter().map(|file| file.entry.as_str()).collect();
+        assert_eq!(entries, vec!["org/acme/root.pk8", "org/acme/issuer.pk8"]);
+        // Every generated entry name is valid custody vocabulary.
+        for estate in &estates {
+            for file in &estate.files {
+                intendant_custody::validate_entry_name(&file.entry).unwrap();
+            }
+        }
+    }
+
+    /// A migrated org estate round-trips: root key tombstoned, custody
+    /// serves it, restore returns the file. The absent issuer key skips.
+    #[test]
+    fn org_estate_migrates_and_restores() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cert_dir = tmp.path().to_path_buf();
+        let org_dir = cert_dir.join("org/acme");
+        std::fs::create_dir_all(&org_dir).unwrap();
+        std::fs::write(org_dir.join("root.pk8"), b"ORG ROOT PKCS8").unwrap();
+
+        let estates = org_estates(&cert_dir);
+        assert_eq!(estates.len(), 1);
+        let estate = &estates[0];
+        let backend = backend_in(&estate.root);
+
+        let mut outcomes = Vec::new();
+        migrate_estate(estate, &backend, |name, outcome| {
+            outcomes.push((name.to_string(), matches!(outcome, Outcome::Done)));
+        })
+        .unwrap();
+        assert_eq!(
+            outcomes,
+            vec![
+                ("root.pk8".to_string(), true),
+                ("issuer.pk8".to_string(), false)
+            ]
+        );
+
+        let bytes = std::fs::read(org_dir.join("root.pk8")).unwrap();
+        assert!(is_tombstone(&bytes));
+        assert_eq!(tombstone_entry(&bytes).unwrap(), "org/acme/root.pk8");
+        assert_eq!(
+            retrieve_migrated(&backend, &org_dir.join("root.pk8"), "org/acme/root.pk8")
+                .unwrap()
+                .as_bytes(),
+            b"ORG ROOT PKCS8"
+        );
+        // The handle lister still sees the org (the tombstone is a file).
+        assert_eq!(
+            crate::access::org::local_org_handles(&cert_dir),
+            vec!["acme".to_string()]
+        );
+
+        restore_estate(estate, &backend, |_, _| {}).unwrap();
+        assert_eq!(
+            std::fs::read(org_dir.join("root.pk8")).unwrap(),
+            b"ORG ROOT PKCS8"
+        );
+    }
+
+    /// The load-or-create seam: absent is `Ok(None)` (create branch),
+    /// plain files serve, and a real identity key round-trips through a
+    /// migrated estate via the custody lane.
+    #[test]
+    fn read_opt_discriminates_absence_and_identity_key_survives_migration() {
+        let tmp = tempfile::tempdir().unwrap();
+        let identity_dir = tmp.path().join("daemon-identity");
+        std::fs::create_dir_all(&identity_dir).unwrap();
+        let key_path = identity_dir.join("ed25519.pk8");
+
+        assert!(read_key_material_opt(&key_path).unwrap().is_none());
+
+        // A real key pair, created through the daemon-identity module.
+        let identity = crate::daemon_identity::DaemonIdentity::load_or_create(&key_path).unwrap();
+        assert_eq!(
+            read_key_material_opt(&key_path)
+                .unwrap()
+                .expect("plain file serves")
+                .as_bytes(),
+            std::fs::read(&key_path).unwrap().as_slice()
+        );
+
+        // Migrate the identity estate; the custody lane serves bytes that
+        // parse back into the same signing identity.
+        let estate = identity_estate(&identity_dir);
+        let backend = backend_in(&identity_dir);
+        migrate_estate(&estate, &backend, |_, _| {}).unwrap();
+        assert!(is_tombstone(&std::fs::read(&key_path).unwrap()));
+        let material =
+            retrieve_migrated(&backend, &key_path, "daemon-identity/ed25519.pk8").unwrap();
+        let reloaded = crate::daemon_identity::DaemonIdentity::from_pkcs8(material.as_bytes())
+            .expect("custody-served bytes parse as the identity key");
+        assert_eq!(reloaded.public_key_b64u(), identity.public_key_b64u());
     }
 }

--- a/src/bin/caller/sandbox.rs
+++ b/src/bin/caller/sandbox.rs
@@ -142,6 +142,12 @@ pub(crate) fn seatbelt_credential_deny_clause() -> Result<String, String> {
     // shell would re-open the loopback owner surface the port guard
     // closes (loopback_token.rs documents the envelope).
     deny_dirs.push(state_root.join(crate::loopback_token::LOOPBACK_TOKEN_DIR));
+    // The daemon-identity signing key (class 3: browser-control,
+    // hosted-control, doorbell caller-ID) lives outside the state root;
+    // it deserves the same read wall as the trust store.
+    deny_dirs.push(canonicalize_for_profile(
+        &crate::daemon_identity::default_identity_dir(),
+    ));
     let mut deny_files: Vec<PathBuf> = vec![
         state_root.join("custody-audit.jsonl"),
         state_root.join("connect.toml"),


### PR DESCRIPTION
Track K slice K3a: the class-3 Ed25519 identity keys — `daemon-identity/ed25519.pk8` (browser control, hosted control, doorbell caller-ID) and every org `root.pk8`/`issuer.pk8` under `<cert_dir>/org/<handle>/` — now migrate, restore, and report through the same tombstone machinery K2b shipped for the access estate.

**Estate model:** `key_custody` generalizes from the fixed class-1 list to named estates (one `custody/` blob dir beside each estate root); the CLI walks access-certs + daemon-identity + each org estate in one pass. Org entries carry the handle in the custody entry name (`org/<handle>/root.pk8`), which is also the seal AAD. Ruled shape: class 3 **relocates** (Q6 — no rotation), storage is sealed bytes + in-process signer (no consumer needs exportable seed bytes; SecKey doesn't speak Ed25519).

**Consumption seam:** `DaemonIdentity::load_or_create` reads through the new `read_key_material_opt` — tombstones route to custody fail-closed, plain files serve as-is, absence is `Ok(None)` so the create branch never string-matches errors; creation always writes a plain file (custody stays opt-in, ruling Q2). This single chokepoint covers the daemon identity, org identities, and hosted-control's `identity_path` (custom paths outside the default dir aren't enumerated by the verbs in v1; hand-migrated tombstones still route — labeled in the module docs).

**Status purity fix (K2b follow-through):** `custody status` is now pure observation — a new `intendant_custody::sealed_blob_file_name` helper (which `WrappedBlobBackend::blob_path` now derives from) checks blob presence with path math instead of constructing backends, which had been creating empty `custody/` dirs as a side effect and would have scattered them across estates.

**Sandbox:** the seatbelt read-deny gains the daemon-identity directory — the signing key deserved the same read wall as the trust store, and it lives outside the state root the existing deny entries cover.

Battery: fmt, clippy -D warnings (workspace), `cargo test -p intendant --bins` (4813), lib crates incl. the custody acceptance rig, headless e2e (30), live smoke of the estate-wide `custody status` (read-only, no dirs created).