### PR TITLE
governor: queue fairness, compile-done telemetry, longer log window

### DIFF
--- a/crates/rustc-governor/src/govlog.rs
+++ b/crates/rustc-governor/src/govlog.rs
@@ -1,12 +1,14 @@
 //! `<permit_dir>/governor.log`: one compile-permit acquisition line per
-//! governed invocation, plus linker acquisition/completion lines for each
-//! heavyweight final artifact. Bypasses, probes, and fail-open runs are
-//! deliberately silent — the log answers which phase waited, for how long,
-//! and on which resource. The probe fast path must not pay even a log write.
+//! governed invocation and one `compile-done` hold-time line at its reap,
+//! plus linker acquisition/completion lines for each heavyweight final
+//! artifact. Bypasses, probes, and fail-open runs are deliberately silent
+//! — the log answers which phase waited, for how long, and on which
+//! resource, and (via `compile-done`) how long each permit was actually
+//! held. The probe fast path must not pay even a log write.
 //!
 //! Best-effort end to end: logging must never fail the build, so every I/O
-//! error here is swallowed. Rotation is truncate-in-place at 1MB keeping
-//! the last 256KB — the scripts/ci hooks/watchdog doctrine: governed
+//! error here is swallowed. Rotation is truncate-in-place at 8MB keeping
+//! the last 2MB — the scripts/ci hooks/watchdog doctrine: governed
 //! accounts can write the pre-created 0666 file but cannot create siblings
 //! in the root-owned permit dir, so tmp+rename is off the table. Racing
 //! rotators are serialized by a non-blocking flock on the log itself
@@ -21,8 +23,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use crate::flock;
 
 pub(crate) const LOG_NAME: &str = "governor.log";
-const MAX_LOG_BYTES: u64 = 1024 * 1024;
-const KEEP_BYTES: u64 = 256 * 1024;
+// Sized for sizing decisions: permit/link tuning wants about a week of
+// history, and a busy agent box burns just under 1MB of governed lines a
+// day (measured 2026-07-21) — 8MB caps the file, 2MB is the floor a
+// rotation leaves behind.
+const MAX_LOG_BYTES: u64 = 8 * 1024 * 1024;
+const KEEP_BYTES: u64 = 2 * 1024 * 1024;
 
 /// How the link gate treated a heavyweight invocation (ordinary compiles
 /// carry `None` and log `kind=compile`).
@@ -82,6 +88,27 @@ pub(crate) fn log_link(
         permit_dir,
         &format!(
             "class={class} crate={} {kind} permit={permit_name} wait_ms={permit_wait_ms}",
+            printable_crate(crate_name),
+        ),
+    );
+}
+
+/// Completion line for every governed compile: `runtime_ms` is the permit
+/// HOLD time, spawn through reap — for a heavyweight that spans compile,
+/// codegen, link-slot wait, and the link itself. Paired with the
+/// acquisition line's `wait_ms`, it is the utilization datum permit-count
+/// sizing divides by wall clock.
+pub(crate) fn log_compile_done(
+    permit_dir: &Path,
+    class: &str,
+    crate_name: Option<&str>,
+    permit_name: &str,
+    runtime_ms: u64,
+) {
+    append_line(
+        permit_dir,
+        &format!(
+            "class={class} crate={} kind=compile-done permit={permit_name} runtime_ms={runtime_ms}",
             printable_crate(crate_name),
         ),
     );
@@ -301,6 +328,25 @@ mod tests {
     }
 
     #[test]
+    fn compile_done_carries_the_hold_runtime() {
+        let dir = tempfile::tempdir().unwrap();
+        log_compile_done(
+            dir.path(),
+            "local",
+            Some("intendant"),
+            "permit-local-0",
+            61_500,
+        );
+        let text = std::fs::read_to_string(dir.path().join(LOG_NAME)).unwrap();
+        assert!(
+            text.trim_end().ends_with(
+                "class=local crate=intendant kind=compile-done permit=permit-local-0 runtime_ms=61500"
+            ),
+            "{text}"
+        );
+    }
+
+    #[test]
     fn crate_names_stay_single_line_and_bounded() {
         assert_eq!(printable_crate(None), "-");
         assert_eq!(printable_crate(Some("")), "-");
@@ -314,8 +360,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join(LOG_NAME);
         {
-            let mut f = std::fs::File::create(&path).unwrap();
-            for i in 0..40_000 {
+            let mut f = std::io::BufWriter::new(std::fs::File::create(&path).unwrap());
+            for i in 0..220_000 {
                 writeln!(f, "line {i:07} padding-padding-padding-padding").unwrap();
             }
         }

--- a/crates/rustc-governor/src/main.rs
+++ b/crates/rustc-governor/src/main.rs
@@ -313,6 +313,10 @@ fn run_governed(
         &permit.name,
         permit.wait_ms,
     );
+    // Permit hold time for the compile-done line: acquisition (a moment
+    // ago) through the child's reap.
+    let held = std::time::Instant::now();
+    let permit_name = permit.name.clone();
 
     if classified.heavy {
         match linker::prepare_rustc(args) {
@@ -341,6 +345,13 @@ fn run_governed(
                 };
                 let status = wait_for_child(child);
                 drop(permit);
+                govlog::log_compile_done(
+                    &cfg.permit_dir,
+                    class.as_str(),
+                    classified.crate_name.as_deref(),
+                    &permit_name,
+                    held.elapsed().as_millis() as u64,
+                );
                 match status {
                     Ok(status) => exit_like_child(status),
                     Err(err) => {
@@ -365,6 +376,7 @@ fn run_governed(
                     &cfg,
                     class,
                     classified.crate_name.as_deref(),
+                    held,
                 );
             }
         }
@@ -376,6 +388,13 @@ fn run_governed(
     };
     let status = wait_for_child(child);
     drop(permit);
+    govlog::log_compile_done(
+        &cfg.permit_dir,
+        class.as_str(),
+        classified.crate_name.as_deref(),
+        &permit_name,
+        held.elapsed().as_millis() as u64,
+    );
     match status {
         Ok(status) => exit_like_child(status),
         Err(err) => {
@@ -400,7 +419,9 @@ fn run_whole_rustc_link(
     cfg: &config::Config,
     class: permits::Class,
     crate_name: Option<&str>,
+    held: std::time::Instant,
 ) -> ! {
+    let permit_name = permit.name.clone();
     let link_gate = permits::acquire_link_slot(cfg, config_path, crate_name);
     let disposition = match &link_gate {
         permits::LinkGate::Held(slot) => govlog::LinkDisposition::Gated {
@@ -438,6 +459,13 @@ fn run_whole_rustc_link(
         crate_name,
         started.elapsed().as_millis() as u64,
         "whole-rustc",
+    );
+    govlog::log_compile_done(
+        &cfg.permit_dir,
+        class.as_str(),
+        crate_name,
+        &permit_name,
+        held.elapsed().as_millis() as u64,
     );
     match status {
         Ok(status) => exit_like_child(status),
@@ -628,7 +656,7 @@ fn acquire_governed(
     }
     let classified = link::classify(lossy);
     let class = permits::classify(permits::current_username().as_deref(), &cfg);
-    let permit = permits::acquire(&cfg, class, config_path)?;
+    let permit = permits::acquire(&cfg, class, config_path, classified.crate_name.as_deref())?;
     Some(Governed {
         permit,
         cfg,

--- a/crates/rustc-governor/src/permits.rs
+++ b/crates/rustc-governor/src/permits.rs
@@ -30,6 +30,12 @@
 //!   the class has waiters ⇒ its reservation is honored. A failed probe can
 //!   also mean another borrower's probe won the same instant — a transient,
 //!   conservative false "has waiters" (we skip borrowing for one poll tick).
+//! - A fresh arrival runs the same probe against its OWN class's demand
+//!   file before its first grab: registered waiters mean it joins the
+//!   queue — register, then poll sleeping-first — instead of racing the
+//!   sleepers for a freed permit. Without it, a cargo's back-to-back
+//!   compile stream regrabs the permit within milliseconds of each
+//!   release and can starve a parked waiter for minutes.
 //! - Waiting is a 100ms LOCK_EX|LOCK_NB poll over every eligible permit —
 //!   never a blocking flock on a permit: blocking flock has no timeout, and
 //!   parking inside the kernel on a foreign permit would bypass the demand
@@ -66,6 +72,7 @@ use crate::flock;
 
 pub(crate) const POLL_INTERVAL: Duration = Duration::from_millis(100);
 const LINK_WAIT_NOTICE: Duration = Duration::from_secs(5);
+const COMPILE_WAIT_NOTICE: Duration = Duration::from_secs(10);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Class {
@@ -268,9 +275,12 @@ fn try_take(pool: &mut Vec<(String, File)>) -> Option<(String, File)> {
     Some(pool.swap_remove(idx))
 }
 
-/// Probe the foreign class's demand gate. Success ⇒ no registered waiters
-/// ⇒ borrowing its spare permits is allowed right now.
-fn foreign_has_no_waiters(demand: &File) -> bool {
+/// Probe a class's demand gate. Success ⇒ no waiters are registered on
+/// that class right now — a foreign borrower may take its spare permits,
+/// and a fresh own-class arrival may grab ahead of the (empty) queue. A
+/// failed probe can also mean another probe won the same instant — a
+/// transient, conservative false "has waiters" costing one poll tick.
+fn no_registered_waiters(demand: &File) -> bool {
     if flock::try_lock_exclusive(demand) {
         flock::unlock(demand);
         true
@@ -422,6 +432,22 @@ fn live_config_enabled(config_path: &Path) -> bool {
     matches!(config::load(config_path), Some(live) if live.enabled)
 }
 
+/// Crate names come from argv: bound and sanitize them before the
+/// one-line stderr diagnostics (`-` when absent or unusable).
+fn stderr_crate(crate_name: Option<&str>) -> String {
+    let name: String = crate_name
+        .unwrap_or("-")
+        .chars()
+        .filter(|c| c.is_ascii_graphic())
+        .take(64)
+        .collect();
+    if name.is_empty() {
+        "-".to_string()
+    } else {
+        name
+    }
+}
+
 fn maybe_report_link_wait(
     start: Instant,
     reported: &mut bool,
@@ -429,16 +455,32 @@ fn maybe_report_link_wait(
     queue: &str,
 ) {
     if !*reported && start.elapsed() >= LINK_WAIT_NOTICE {
-        let name: String = crate_name
-            .unwrap_or("-")
-            .chars()
-            .filter(|c| c.is_ascii_graphic())
-            .take(64)
-            .collect();
         eprintln!(
             "rustc-governor: {} waiting for the machine-wide linker slot ({:.1}s, queue={queue})",
-            if name.is_empty() { "-" } else { &name },
+            stderr_crate(crate_name),
             start.elapsed().as_secs_f64(),
+        );
+        *reported = true;
+    }
+}
+
+/// One concise stderr line after ten seconds parked in the compile-permit
+/// queue. The threshold sits above the link notice's five: multi-second
+/// permit waits are routine under concurrent agent builds, and the notice
+/// exists for the starved outlier — a build that looks hung should
+/// explain itself.
+fn maybe_report_compile_wait(
+    start: Instant,
+    reported: &mut bool,
+    crate_name: Option<&str>,
+    class: Class,
+) {
+    if !*reported && start.elapsed() >= COMPILE_WAIT_NOTICE {
+        eprintln!(
+            "rustc-governor: {} waiting for a machine-wide compile permit ({:.1}s, class={})",
+            stderr_crate(crate_name),
+            start.elapsed().as_secs_f64(),
+            class.as_str(),
         );
         *reported = true;
     }
@@ -517,8 +559,14 @@ pub(crate) fn acquire_link_slot(
 /// Acquire one machine-wide compile permit for `class`, waiting as long as
 /// it takes. `None` always means FAIL OPEN (run ungoverned): zero configured
 /// permits, an unusable permit dir, an unregisterable wait, or the kill
-/// switch flipping mid-wait — never "denied".
-pub(crate) fn acquire(cfg: &Config, class: Class, config_path: &Path) -> Option<AcquiredPermit> {
+/// switch flipping mid-wait — never "denied". `crate_name` feeds the
+/// long-wait stderr notice only.
+pub(crate) fn acquire(
+    cfg: &Config,
+    class: Class,
+    config_path: &Path,
+    crate_name: Option<&str>,
+) -> Option<AcquiredPermit> {
     if cfg.local_reserved == 0 && cfg.ci_reserved == 0 {
         return None;
     }
@@ -548,42 +596,65 @@ pub(crate) fn acquire(cfg: &Config, class: Class, config_path: &Path) -> Option<
         })
     };
 
-    // Own-class reservation first.
-    if let Some(p) = try_take(&mut own) {
-        return acquired(start, p);
-    }
+    // A registered queue outranks a fresh arrival: probe the own-class
+    // demand gate — the same probe foreign borrowers use — and skip the
+    // immediate grabs when waiters are parked on it. Without this, a
+    // cargo's compile stream regrabbing the permit within milliseconds of
+    // each release starves sleeping pollers (a waiter measured 194s parked
+    // behind 20 overtakes, 2026-07-21). A failed probe can also be a
+    // colliding probe: transient, conservative, costs one poll tick. An
+    // unopenable own demand file cannot be probed — grab-first then,
+    // matching the fail-open registration below.
+    let own_demand = open_lock_file(&dir.join(demand_name(class)));
+    let join_queue = own_demand
+        .as_ref()
+        .is_some_and(|gate| !no_registered_waiters(gate));
 
-    // Borrow the other class's spare capacity — but only through its demand
-    // gate. An unopenable foreign demand file means the gate cannot be
-    // probed: never borrow blind.
+    // The other class's gate, opened up front: the immediate borrow and
+    // the poll loop both consult it. An unopenable foreign demand file
+    // means the gate cannot be probed: never borrow blind.
     let foreign_demand = open_lock_file(&dir.join(demand_name(class.other())));
-    if !foreign.is_empty() {
-        if let Some(gate) = &foreign_demand {
-            if foreign_has_no_waiters(gate) {
-                if let Some(p) = try_take(&mut foreign) {
-                    return acquired(start, p);
+
+    if !join_queue {
+        // Own-class reservation first.
+        if let Some(p) = try_take(&mut own) {
+            return acquired(start, p);
+        }
+        // Then the other class's spare capacity, through its demand gate.
+        if !foreign.is_empty() {
+            if let Some(gate) = &foreign_demand {
+                if no_registered_waiters(gate) {
+                    if let Some(p) = try_take(&mut foreign) {
+                        return acquired(start, p);
+                    }
                 }
             }
         }
     }
 
-    // Nothing free: register demand — LOCK_SH held for the entire wait so
-    // foreign borrowers keep their hands off this class's reservation —
-    // then poll. If demand can't be registered, fail open rather than wait
-    // unregistered: borrowers couldn't see us, and we could starve behind
-    // them indefinitely.
-    let own_demand = open_lock_file(&dir.join(demand_name(class)))?;
+    // Nothing free (or the class has a queue this arrival must join):
+    // register demand — LOCK_SH held for the entire wait so foreign
+    // borrowers keep their hands off this class's reservation — then poll,
+    // sleeping BEFORE each round: an immediate first retry would hand a
+    // just-freed permit to the newest arrival ahead of every sleeping
+    // waiter, reopening the overtake the demand probe above closes. If
+    // demand can't be registered, fail open rather than wait unregistered:
+    // borrowers couldn't see us, and we could starve behind them
+    // indefinitely.
+    let own_demand = own_demand?;
     if !flock::lock_shared_blocking(&own_demand) {
         return None;
     }
+    let mut reported = false;
     loop {
+        std::thread::sleep(POLL_INTERVAL);
         if let Some(p) = try_take(&mut own) {
             flock::unlock(&own_demand);
             return acquired(start, p);
         }
         if !foreign.is_empty() {
             if let Some(gate) = &foreign_demand {
-                if foreign_has_no_waiters(gate) {
+                if no_registered_waiters(gate) {
                     if let Some(p) = try_take(&mut foreign) {
                         flock::unlock(&own_demand);
                         return acquired(start, p);
@@ -602,7 +673,7 @@ pub(crate) fn acquire(cfg: &Config, class: Class, config_path: &Path) -> Option<
                 return None;
             }
         }
-        std::thread::sleep(POLL_INTERVAL);
+        maybe_report_compile_wait(start, &mut reported, crate_name, class);
     }
 }
 
@@ -654,21 +725,21 @@ mod tests {
     #[test]
     fn acquire_prefers_own_class_then_borrows_idle_foreign() {
         let (_tmp, cfg, path) = rig(1, 1);
-        let a = acquire(&cfg, Class::Local, &path).unwrap();
+        let a = acquire(&cfg, Class::Local, &path, None).unwrap();
         assert_eq!(a.name, "permit-local-0");
         // Own class exhausted, no CI demand registered: borrow.
-        let b = acquire(&cfg, Class::Local, &path).unwrap();
+        let b = acquire(&cfg, Class::Local, &path, None).unwrap();
         assert_eq!(b.name, "permit-ci-0");
         drop(a);
         // Own reservation is free again and preferred.
-        let c = acquire(&cfg, Class::Local, &path).unwrap();
+        let c = acquire(&cfg, Class::Local, &path, None).unwrap();
         assert_eq!(c.name, "permit-local-0");
     }
 
     #[test]
     fn zero_permits_fails_open() {
         let (_tmp, cfg, path) = rig(0, 0);
-        assert!(acquire(&cfg, Class::Local, &path).is_none());
+        assert!(acquire(&cfg, Class::Local, &path, None).is_none());
     }
 
     #[test]
@@ -730,14 +801,14 @@ mod tests {
     #[test]
     fn waiter_respects_foreign_demand_then_takes_own_release() {
         let (_tmp, cfg, path) = rig(1, 1);
-        let held = acquire(&cfg, Class::Local, &path).unwrap();
+        let held = acquire(&cfg, Class::Local, &path, None).unwrap();
         assert_eq!(held.name, "permit-local-0");
         // Register CI demand so Local may not borrow the idle CI permit.
         let demand_ci = open_lock_file(&cfg.permit_dir.join("demand-ci")).unwrap();
         assert!(flock::lock_shared_blocking(&demand_ci));
 
         let (cfg2, path2) = (cfg.clone(), path.clone());
-        let waiter = std::thread::spawn(move || acquire(&cfg2, Class::Local, &path2));
+        let waiter = std::thread::spawn(move || acquire(&cfg2, Class::Local, &path2, None));
         // Generous settle time; the waiter must still be polling (the CI
         // permit is free but demand-gated).
         std::thread::sleep(Duration::from_millis(400));
@@ -753,5 +824,42 @@ mod tests {
             .expect("waiter must acquire after release");
         assert_eq!(got.name, "permit-local-0");
         flock::unlock(&demand_ci);
+    }
+
+    /// The 2026-07-21 starvation shape: the permit is FREE but the class
+    /// has a registered waiter — the pre-fix governor handed the permit
+    /// to the newcomer instantly (wait_ms=0) while the waiter slept out
+    /// its poll tick. A newcomer must join the queue instead: it
+    /// registers and sleeps at least one tick before its first take.
+    #[test]
+    fn newcomer_joins_a_registered_queue_instead_of_overtaking() {
+        let (_tmp, cfg, path) = rig(1, 0);
+        std::fs::create_dir_all(&cfg.permit_dir).unwrap();
+        let waiter = open_lock_file(&cfg.permit_dir.join("demand-local")).unwrap();
+        assert!(flock::lock_shared_blocking(&waiter));
+        let got = acquire(&cfg, Class::Local, &path, Some("newcomer")).unwrap();
+        assert_eq!(got.name, "permit-local-0");
+        assert!(
+            got.wait_ms >= POLL_INTERVAL.as_millis() as u64,
+            "a newcomer must queue behind registered demand, not overtake \
+             (waited {}ms)",
+            got.wait_ms
+        );
+        flock::unlock(&waiter);
+    }
+
+    /// The queue probe must not tax the uncontended path: no registered
+    /// demand ⇒ a free permit is still taken immediately, no poll tick.
+    #[test]
+    fn empty_queue_keeps_the_grab_first_fast_path() {
+        let (_tmp, cfg, path) = rig(1, 0);
+        let got = acquire(&cfg, Class::Local, &path, None).unwrap();
+        assert_eq!(got.name, "permit-local-0");
+        assert!(
+            got.wait_ms < POLL_INTERVAL.as_millis() as u64,
+            "no registered demand: the free permit is taken immediately \
+             (waited {}ms)",
+            got.wait_ms
+        );
     }
 }

--- a/crates/rustc-governor/tests/acceptance.rs
+++ b/crates/rustc-governor/tests/acceptance.rs
@@ -477,10 +477,21 @@ fn waiter_acquires_promptly_after_release() {
     let status = wait_deadline(&mut child, GENEROUS).expect("waiter starved");
     assert!(status.success());
     let log = rig.log();
-    let line = log.lines().last().unwrap_or_default();
+    let compile = log
+        .lines()
+        .rfind(|line| line.contains("kind=compile "))
+        .unwrap_or_default();
     assert!(
-        line.contains("wait_ms="),
-        "log must carry the wait: {line:?}"
+        compile.contains("wait_ms="),
+        "log must carry the wait: {compile:?}"
+    );
+    let done = log
+        .lines()
+        .rfind(|line| line.contains("kind=compile-done "))
+        .unwrap_or_default();
+    assert!(
+        done.contains("runtime_ms="),
+        "reap must log the permit hold time: {done:?}"
     );
 }
 

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -228,9 +228,18 @@ file for the whole wait and poll every eligible permit at 100ms
 Borrowing: before touching a foreign-class permit, probe that class's
 demand file with LOCK_EX|LOCK_NB — success (released immediately)
 means no waiters, so idle capacity is never wasted; failure means the
-class has waiters and its reservation is honored. Nothing is ever
-killed or signalled; borrowed permits return naturally when their
-holder exits.
+class has waiters and its reservation is honored. The same probe
+guards a class's own queue: a fresh arrival probes its OWN demand file
+before its first grab and, when waiters are registered, joins the
+queue (register, then poll sleeping-first) instead of racing the
+sleepers for a freed permit — without this, a cargo's back-to-back
+compile stream regrabs the permit within milliseconds of each release
+and can starve a parked waiter for minutes (measured at 194s,
+2026-07-21). A compile-permit waiter parked past ten seconds emits one
+concise stderr notice (crate, elapsed, class), the link queue's
+five-second diagnostic tuned for a queue where multi-second waits are
+routine. Nothing is ever killed or signalled; borrowed permits return
+naturally when their holder exits.
 
 ### The linker-phase gate: heavyweight final links serialize
 
@@ -313,20 +322,29 @@ deliberately isolated diagnostic invocation. Observability: one
 compile-permit acquisition line per governed invocation in
 `<permit_dir>/governor.log` — timestamp, pid, class, crate,
 `kind=compile` (plus `link=deferred` for a heavyweight), permit, and
-`wait_ms`. The linker shim adds
+`wait_ms` — and one `kind=compile-done runtime_ms=…` line at its reap:
+the permit HOLD time, which next to `wait_ms` is the utilization datum
+permit-count sizing divides by wall clock. The linker shim adds
 `kind=link link_slot=… link_wait_ms=… queue=… scope=linker` (or
 `kind=link-ungated reason=off|degraded`) and
 `kind=link-done runtime_ms=… scope=linker`. That runtime is actual linker
 wall time, no longer compile+codegen+link. Truncate-in-place rotation at
-1MB keeps the last 256K — the hooks-log doctrine, because governed
-accounts can write the pre-created log/ticket files but cannot create
-siblings in the root-owned dir.
+8MB keeps the last 2MB (about a week and a day-plus respectively at a
+busy agent box's measured burn) — the hooks-log doctrine, because
+governed accounts can write the pre-created log/ticket files but cannot
+create siblings in the root-owned dir.
 
 ### Sizing, install, rollout
 
 Per box: `local_reserved + ci_reserved` = the machine-wide ceiling of
 concurrent rustc processes; the per-account jobs cap still bounds any
 single cargo underneath it. The 24GB two-listener Mac runs 1 + 2.
+Ceilings sized before the link gate existed deserve a revisit: with
+heavyweight final links serialized separately, the ordinary ceiling no
+longer carries the link-RSS risk it originally defended against, and
+the `kind=compile-done` hold times against wall clock are the
+utilization data for that call (a 16GB box's single permit measured
+2.8h of cumulative queue wait in one 8.5h window, 2026-07-21).
 Don't set a class to 0 unless it truly never compiles — its members
 would then depend entirely on borrowing. `link_slots` (default 1 in the
 binary, so a binary upgrade turns the gate on with pre-gate configs)

--- a/scripts/ci/install-governor-macos.sh
+++ b/scripts/ci/install-governor-macos.sh
@@ -197,6 +197,7 @@ Notes:
   heavyweight-link gate; `link_queue_slots = 0` keeps the gate but turns
   off FIFO ordering.
 - Watch it: tail -f /usr/local/var/intendant-governor/governor.log
-  (kind=link lines carry link_wait_ms + queue; kind=link-done is actual
-  linker runtime — the link-gate soak data.)
+  (kind=compile/compile-done pair wait_ms with permit hold runtime_ms —
+  the permit-sizing data; kind=link lines carry link_wait_ms + queue;
+  kind=link-done is actual linker runtime — the link-gate soak data.)
 NEXT_EOF


### PR DESCRIPTION
Fresh arrivals now probe their own class's demand gate before the first
grab and join a registered queue (register, then poll sleeping-first)
instead of racing sleeping waiters for a freed permit — a cargo compile
stream regrabbing the permit within milliseconds of each release
measured a waiter parked 194s behind 20 overtakes (2026-07-21). A
compile-permit waiter parked past 10s now emits the link queue's
one-line stderr notice (crate, elapsed, class).

Every governed compile also logs kind=compile-done with its permit hold
runtime at reap — next to wait_ms, the utilization datum permit-count
sizing needs — and the governor.log rotation window grows 1MB/256KB to
8MB/2MB (about a week at a busy agent box's measured burn).
