### PR TITLE
agenda asks: clicking the question opens its panel

### DIFF
--- a/static/app/ui2-agenda.css
+++ b/static/app/ui2-agenda.css
@@ -146,6 +146,9 @@ html.ui-v2 .agenda-glyph.open { color: var(--iris); }
 html.ui-v2 .agenda-glyph.done { color: var(--green); }
 html.ui-v2 .agenda-glyph.retired { color: var(--text-3); }
 html.ui-v2 .agenda-glyph.question { color: var(--amber); font-weight: 700; }
+html.ui-v2 .agenda-item-head-openable { cursor: pointer; border-radius: 8px; }
+html.ui-v2 .agenda-item-head-openable:hover { background: var(--hover-wash); }
+html.ui-v2 .agenda-item-head-openable:hover .agenda-item-title { color: var(--iris-2); }
 html.ui-v2 .agenda-open-ask-btn {
   border-color: rgba(var(--iris-rgb), .4);
   color: var(--iris-2);

--- a/static/app/ui2-agenda.js
+++ b/static/app/ui2-agenda.js
@@ -1165,8 +1165,10 @@ function agendaRenderTab() {
     // live there; the inline input stays as an explicit plain-text path,
     // never the only door.
     let answerBlock = '';
+    const openRichAsk = item.kind === 'question' && item.status === 'open'
+      && item.ask && Array.isArray(item.ask.questions) && item.ask.questions.length;
     if (item.kind === 'question' && item.status === 'open') {
-      const richAsk = item.ask && Array.isArray(item.ask.questions) && item.ask.questions.length;
+      const richAsk = openRichAsk;
       const openBtn = richAsk
         ? `<div class="agenda-answer-row agenda-ask-open-row">
             <button type="button" class="agenda-btn agenda-open-ask-btn" data-id="${escapeHtml(item.id)}">Open question panel</button>
@@ -1194,8 +1196,15 @@ function agendaRenderTab() {
     const dismissedChip = item.status === 'open' && item.dismissed
       ? `<span class="agenda-chip dismissed" title="${escapeHtml(agendaDismissedTip(item.dismissed))}">dismissed · still open</span>`
       : '';
+    // Open rich asks: the whole head is the affordance — clicking the
+    // question opens its panel (the obvious gesture; the explicit button
+    // below remains for discoverability). role/tabindex make it a real
+    // control for keyboard and assistive tech.
+    const headOpenAttrs = openRichAsk
+      ? ` agenda-item-head-openable" data-open-ask="${escapeHtml(item.id)}" role="button" tabindex="0" title="Open the question panel`
+      : '';
     return `<div class="agenda-item" data-status="${escapeHtml(item.status)}">
-      <div class="agenda-item-head">
+      <div class="agenda-item-head${headOpenAttrs}">
         ${agendaGlyph(item.status, item.kind)}
         <span class="agenda-item-kind">${escapeHtml(item.kind)}</span>
         <span class="agenda-item-title">${escapeHtml(item.title)}</span>
@@ -1217,6 +1226,18 @@ function agendaRenderTab() {
   });
   list.querySelectorAll('.agenda-open-ask-btn').forEach((btn) => {
     btn.addEventListener('click', () => agendaOpenParkedAsk(btn.dataset.id));
+  });
+  list.querySelectorAll('.agenda-item-head-openable').forEach((head) => {
+    const open = (e) => {
+      // Chips/links inside the head keep their own behavior.
+      if (e.target.closest('button, a, input, select')) return;
+      e.preventDefault();
+      agendaOpenParkedAsk(head.dataset.openAsk);
+    };
+    head.addEventListener('click', open);
+    head.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') open(e);
+    });
   });
   list.querySelectorAll('button[data-op]').forEach((btn) => {
     btn.addEventListener('click', () => {


### PR DESCRIPTION
The open-panel affordance was a button among five on the item card;
live QA (2026-07-21) showed the obvious gesture is clicking the question
itself. For open rich asks the whole item head becomes the control
(role=button, tabindex, Enter/Space, hover affordance; chips and buttons
inside keep their own behavior). The explicit button stays for
discoverability.
