### PR TITLE
Instant vitals hydration: disk-recovered chips, context section, persisted limit windows

### DIFF
--- a/crates/intendant-core/src/vitals.rs
+++ b/crates/intendant-core/src/vitals.rs
@@ -53,6 +53,41 @@ pub struct SessionCacheVitals {
     /// is unknown (the countdown is hidden, the hit receipt still shows).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ttl_seconds: Option<u32>,
+    /// Present when this section was hydrated from the session's on-disk
+    /// records (a resumed/restored session's transcript) rather than a
+    /// live wire report; the value is the as-of epoch of the record it
+    /// came from. Frontends caveat the claim ("from the session log as
+    /// of …"); every live usage fold overwrites the section with the
+    /// stamp absent. Wire-additive.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recovered_at_epoch: Option<u64>,
+}
+
+/// Live context-footprint snapshot — the vitals `context` section behind
+/// the dashboard's context meter. `tokens_used` is the last model call's
+/// prompt+output footprint (input + cache reads + cache writes + output),
+/// `usage_pct` its share of `context_window` (producers clamp via the
+/// effective window, so it never exceeds 100). Live `UsageSnapshot`s fill
+/// it turn by turn; the restore hydrator seeds it from a resumed
+/// transcript's last usage record with `recovered_at_epoch` set, so an
+/// idle or freshly restored session states its footprint instead of `--`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionContextVitals {
+    /// Context footprint of the latest call, in tokens.
+    pub tokens_used: u64,
+    /// Context window the footprint is measured against.
+    pub context_window: u64,
+    /// `tokens_used` as a percentage of the window (≤ 100 by producer
+    /// clamping).
+    pub usage_pct: f64,
+    /// Unix seconds when these numbers were current: emission time for
+    /// live fills, the source record's timestamp for recovered ones.
+    pub observed_at_epoch: u64,
+    /// Present when hydrated from on-disk records (see
+    /// [`SessionCacheVitals::recovered_at_epoch`]); live fills clear it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recovered_at_epoch: Option<u64>,
 }
 
 /// One provider rate-limit window (subscription 5h/7d, per-minute API
@@ -204,6 +239,18 @@ pub struct SessionConfigVitals {
     /// the backend has not yet confirmed.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub permission_echoed: bool,
+    /// Present when `model` (and its decorating `effort`) was hydrated
+    /// from the session's on-disk records — recorded launch config or the
+    /// transcript — rather than reported live this daemon lifetime; the
+    /// value is the as-of epoch of the source. Frontends caveat the chip;
+    /// any live fold that states a model clears it. Wire-additive.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_recovered_at_epoch: Option<u64>,
+    /// Present when the permission fields were hydrated from on-disk
+    /// records (which also keep `permission_echoed` false); cleared by
+    /// any live fold that states a mode. Wire-additive.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permission_recovered_at_epoch: Option<u64>,
 }
 
 /// The backend-agnostic permission display classes — the one catalog
@@ -275,10 +322,11 @@ pub fn codex_permission_kind(approval_policy: &str, sandbox: &str) -> Option<&'s
 }
 
 /// Per-session vitals (git / prompt-cache / rate limits / live activity /
-/// config facts) shown by the dashboard and Station — the port of the
-/// operator statusline. Sections are independent: producers fill what
-/// they know, frontends hide what is absent.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+/// config facts / context footprint) shown by the dashboard and Station —
+/// the port of the operator statusline. Sections are independent:
+/// producers fill what they know, frontends hide what is absent.
+/// (`PartialEq` only: the context section carries an `f64`.)
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionVitals {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -292,6 +340,10 @@ pub struct SessionVitals {
     /// Session configuration facts (model / effort / permission mode).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub config: Option<SessionConfigVitals>,
+    /// Context-footprint snapshot behind the dashboard's context meter.
+    /// Wire-additive.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context: Option<SessionContextVitals>,
 }
 
 #[cfg(test)]
@@ -473,6 +525,7 @@ mod tests {
             permission_mode: Some("bypassPermissions".into()),
             permission_kind: Some(PERMISSION_KIND_BYPASS.into()),
             permission_echoed: true,
+            ..Default::default()
         };
         let wire = serde_json::to_value(&full).expect("serializes");
         assert_eq!(wire["model"], "claude-fable-5");
@@ -488,5 +541,93 @@ mod tests {
             serde_json::json!({}),
             "absent facts serialize to nothing"
         );
+    }
+
+    /// The recovered-provenance stamps are wire-additive: serialized
+    /// camelCase when present, absent otherwise, and legacy emissions
+    /// without them deserialize to `None` (a live claim, no caveat).
+    #[test]
+    fn recovered_stamps_round_trip_and_stay_wire_additive() {
+        let config = SessionConfigVitals {
+            model: Some("claude-fable-5".into()),
+            permission_mode: Some("plan".into()),
+            permission_kind: Some(PERMISSION_KIND_PLAN.into()),
+            model_recovered_at_epoch: Some(1_784_500_000),
+            permission_recovered_at_epoch: Some(1_784_500_000),
+            ..Default::default()
+        };
+        let wire = serde_json::to_value(&config).expect("serializes");
+        assert_eq!(wire["modelRecoveredAtEpoch"], 1_784_500_000u64);
+        assert_eq!(wire["permissionRecoveredAtEpoch"], 1_784_500_000u64);
+        let back: SessionConfigVitals = serde_json::from_value(wire).expect("deserializes");
+        assert_eq!(back, config);
+
+        let legacy: SessionConfigVitals =
+            serde_json::from_str(r#"{"model":"claude-fable-5"}"#).expect("legacy deserializes");
+        assert_eq!(legacy.model_recovered_at_epoch, None);
+        assert_eq!(legacy.permission_recovered_at_epoch, None);
+        let rewire = serde_json::to_value(&legacy).expect("serializes");
+        assert!(rewire.get("modelRecoveredAtEpoch").is_none());
+        assert!(rewire.get("permissionRecoveredAtEpoch").is_none());
+
+        let cache = SessionCacheVitals {
+            hit_pct: Some(97),
+            last_activity_epoch: 1_784_500_000,
+            ttl_seconds: Some(3600),
+            recovered_at_epoch: Some(1_784_500_000),
+        };
+        let wire = serde_json::to_value(&cache).expect("serializes");
+        assert_eq!(wire["recoveredAtEpoch"], 1_784_500_000u64);
+        let legacy: SessionCacheVitals =
+            serde_json::from_str(r#"{"hitPct":40,"lastActivityEpoch":1}"#)
+                .expect("legacy deserializes");
+        assert_eq!(legacy.recovered_at_epoch, None);
+        assert!(serde_json::to_value(&legacy)
+            .expect("serializes")
+            .get("recoveredAtEpoch")
+            .is_none());
+    }
+
+    /// The context section's wire shape: camelCase, the recovered stamp
+    /// only when present, and the whole section wire-additive on
+    /// `SessionVitals` (legacy emissions without it deserialize to
+    /// `None`, and an absent section serializes to nothing).
+    #[test]
+    fn context_vitals_wire_shape_and_additivity() {
+        let context = SessionContextVitals {
+            tokens_used: 442_000,
+            context_window: 1_000_000,
+            usage_pct: 44.2,
+            observed_at_epoch: 1_784_500_000,
+            recovered_at_epoch: None,
+        };
+        let wire = serde_json::to_value(&context).expect("serializes");
+        assert_eq!(wire["tokensUsed"], 442_000u64);
+        assert_eq!(wire["contextWindow"], 1_000_000u64);
+        assert_eq!(wire["usagePct"], 44.2);
+        assert_eq!(wire["observedAtEpoch"], 1_784_500_000u64);
+        assert!(wire.get("recoveredAtEpoch").is_none());
+        let back: SessionContextVitals = serde_json::from_value(wire).expect("deserializes");
+        assert_eq!(back, context);
+
+        let vitals = SessionVitals {
+            context: Some(SessionContextVitals {
+                recovered_at_epoch: Some(1_784_400_000),
+                ..context
+            }),
+            ..Default::default()
+        };
+        let wire = serde_json::to_value(&vitals).expect("serializes");
+        assert_eq!(wire["context"]["recoveredAtEpoch"], 1_784_400_000u64);
+
+        let legacy: SessionVitals = serde_json::from_str(
+            r#"{"git":{"branch":"main","dirtyFiles":0,"ahead":0,"behind":0}}"#,
+        )
+        .expect("legacy deserializes");
+        assert!(legacy.context.is_none());
+        assert!(serde_json::to_value(&legacy)
+            .expect("serializes")
+            .get("context")
+            .is_none());
     }
 }

--- a/src/bin/caller/agenda/scheduler.rs
+++ b/src/bin/caller/agenda/scheduler.rs
@@ -28,6 +28,28 @@ const SAFETY_TICK: std::time::Duration = std::time::Duration::from_secs(300);
 /// is exactly the RFC's "session creation is idempotent by occurrence id".
 const DELEGATION_PREFIX: &str = "agenda-occ-";
 
+/// Cap on remembered pre-receipt session outcomes. Terminal events are
+/// rare (one per session end), and most remembered entries belong to
+/// non-scheduled sessions whose receipts never come — the cap simply
+/// bounds that residue; eviction is oldest-first.
+const EARLY_OUTCOME_CAP: usize = 64;
+
+/// A session's terminal event observed BEFORE its `TaskReceived` receipt
+/// — the fast-spawn inversion: `start_new_session` dispatches the child
+/// loop and returns before the supervisor's executor emits the receipt,
+/// so a fast first turn (mock-speed sessions; a loaded box descheduling
+/// the executor) can land `DoneSignal` on the bus first. Dropping such a
+/// completion strands the occurrence as running-forever (supervised
+/// sessions park after done — no `SessionEnded` ever follows to resolve
+/// it); remembering it lets the receipt complete the arc in order
+/// (started → terminal) whichever event wins the race.
+struct EarlyOutcome {
+    /// `None` = completed normally (note carries the done message);
+    /// `Some(reason)` = the session ended without finishing.
+    failed: Option<String>,
+    note: String,
+}
+
 /// In-flight scheduled-session bookkeeping (in-memory; the journal is the
 /// durable truth, and a restart resolves both maps fail-closed).
 #[derive(Default)]
@@ -37,6 +59,11 @@ struct SchedulerState {
     awaiting: HashMap<String, SpawnOccurrence>,
     /// Receipt seen, session running: session id → spawn facts.
     running: HashMap<String, SpawnOccurrence>,
+    /// Terminal events that arrived before their receipt, session id →
+    /// outcome, insertion-ordered for the cap eviction (see
+    /// [`EarlyOutcome`]). First terminal per session wins; consumed by
+    /// the receipt.
+    early_outcomes: Vec<(String, EarlyOutcome)>,
 }
 
 impl SchedulerState {
@@ -46,6 +73,27 @@ impl SchedulerState {
             .cloned()
             .chain(self.running.values().map(|s| s.occurrence_id.clone()))
             .collect()
+    }
+
+    /// Remember a terminal event no running entry claimed (first one per
+    /// session wins — a `DoneSignal` must not be downgraded by the
+    /// parked session's eventual `SessionEnded`).
+    fn remember_early_outcome(&mut self, session_id: &str, outcome: EarlyOutcome) {
+        if self.early_outcomes.iter().any(|(id, _)| id == session_id) {
+            return;
+        }
+        self.early_outcomes.push((session_id.to_string(), outcome));
+        if self.early_outcomes.len() > EARLY_OUTCOME_CAP {
+            self.early_outcomes.remove(0);
+        }
+    }
+
+    fn take_early_outcome(&mut self, session_id: &str) -> Option<EarlyOutcome> {
+        let index = self
+            .early_outcomes
+            .iter()
+            .position(|(id, _)| id == session_id)?;
+        Some(self.early_outcomes.remove(index).1)
     }
 }
 
@@ -369,6 +417,16 @@ fn observe_event(
             );
             record_on_item(handle, &spawn, "started", Some(session_id.clone()), None);
             state.running.insert(session_id.clone(), spawn);
+            // The session's terminal event can beat this receipt onto the
+            // bus (the fast-spawn inversion — see [`EarlyOutcome`]): a
+            // remembered outcome resolves the occurrence now, keeping the
+            // journal arc in order (started, then the terminal).
+            if let Some(early) = state.take_early_outcome(session_id) {
+                match early.failed {
+                    None => complete_running(handle, journal, state, session_id, early.note),
+                    Some(reason) => fail_running(handle, journal, state, session_id, &reason),
+                }
+            }
         }
         // The two normal-completion shapes: `signal_done` exits emit
         // DoneSignal (the common case — proven live), while no-commands
@@ -378,7 +436,11 @@ fn observe_event(
             message,
         } => {
             let note = message.clone().unwrap_or_else(|| "done".to_string());
-            complete_running(handle, journal, state, session_id, note);
+            if state.running.contains_key(session_id) {
+                complete_running(handle, journal, state, session_id, note);
+            } else {
+                state.remember_early_outcome(session_id, EarlyOutcome { failed: None, note });
+            }
         }
         AppEvent::TaskComplete {
             session_id: Some(session_id),
@@ -386,34 +448,63 @@ fn observe_event(
             summary,
         } => {
             let note = summary.clone().unwrap_or_else(|| reason.clone());
-            complete_running(handle, journal, state, session_id, note);
+            if state.running.contains_key(session_id) {
+                complete_running(handle, journal, state, session_id, note);
+            } else {
+                state.remember_early_outcome(session_id, EarlyOutcome { failed: None, note });
+            }
         }
         AppEvent::SessionEnded {
             session_id, reason, ..
         } => {
             // Normal completion removes the entry first (supervised
-            // sessions park after done); reaching here running means the
-            // session stopped or errored before finishing.
-            let Some(spawn) = state.running.remove(session_id) else {
-                return;
-            };
-            session_record(
-                journal,
-                &spawn,
-                now_ms(),
-                OccurrenceState::Failed,
-                Some(session_id.clone()),
-            );
-            record_on_item(
-                handle,
-                &spawn,
-                "failed",
-                Some(session_id.clone()),
-                Some(reason.clone()),
-            );
+            // sessions park after done); a RUNNING session reaching here
+            // stopped or errored before finishing — and pre-receipt the
+            // same end is remembered as a failed outcome (first terminal
+            // per session wins, so a done session's later end never
+            // downgrades its completion).
+            if state.running.contains_key(session_id) {
+                fail_running(handle, journal, state, session_id, reason);
+            } else {
+                state.remember_early_outcome(
+                    session_id,
+                    EarlyOutcome {
+                        failed: Some(reason.clone()),
+                        note: reason.clone(),
+                    },
+                );
+            }
         }
         _ => {}
     }
+}
+
+/// A running scheduled session ended without finishing: journal `failed`
+/// and write the reason back to the item.
+fn fail_running(
+    handle: &AgendaHandle,
+    journal: &mut OccurrenceJournal,
+    state: &mut SchedulerState,
+    session_id: &str,
+    reason: &str,
+) {
+    let Some(spawn) = state.running.remove(session_id) else {
+        return;
+    };
+    session_record(
+        journal,
+        &spawn,
+        now_ms(),
+        OccurrenceState::Failed,
+        Some(session_id.to_string()),
+    );
+    record_on_item(
+        handle,
+        &spawn,
+        "failed",
+        Some(session_id.to_string()),
+        Some(reason.to_string()),
+    );
 }
 
 /// A running scheduled session finished normally: journal `completed` and
@@ -1237,6 +1328,238 @@ mod tests {
                 "spent start-now occurrence must not re-dispatch"
             );
         }
+    }
+
+    /// The fast-spawn inversion: `start_new_session` dispatches the child
+    /// loop and returns before the executor emits `TaskReceived`, so a
+    /// fast first turn (mock-speed; a loaded box) can land its terminal
+    /// event on the bus FIRST. The scheduler must resolve the occurrence
+    /// whichever order the receipt and the terminal arrive — dropping the
+    /// early completion stranded the occurrence as running-forever (the
+    /// parked session never emits `SessionEnded`; observed live on the
+    /// #552 Linux e2e leg, 180s write-back timeout).
+    #[tokio::test]
+    async fn completion_before_receipt_still_writes_back() {
+        let dir = tempfile::tempdir().unwrap();
+        let default_project = tempfile::tempdir().unwrap();
+        let handle = handle_with_default_project(dir.path(), default_project.path());
+        let mut journal = OccurrenceJournal::open(handle.dir()).unwrap();
+        let mut state = SchedulerState::default();
+        let item = handle
+            .apply(
+                AgendaCommand::Add {
+                    kind: AgendaKind::Task,
+                    title: "race me".into(),
+                    body: String::new(),
+                    tags: Vec::new(),
+                    due_ms: None,
+                    source: None,
+                },
+                None,
+            )
+            .unwrap();
+        handle
+            .apply(
+                AgendaCommand::StartNow {
+                    id: item.id.clone(),
+                    goal: None,
+                    project_root: None,
+                    interactive: None,
+                    agent_config: None,
+                },
+                owner(),
+            )
+            .unwrap();
+        let mut rx = handle.bus().subscribe();
+        run_pass(&handle, &mut journal, &mut state).await;
+        let mut delegation_id = None;
+        while let Ok(event) = rx.try_recv() {
+            if let AppEvent::ControlCommand(ControlMsg::StartTask {
+                delegation_id: Some(id),
+                ..
+            }) = event
+            {
+                delegation_id = Some(id);
+            }
+        }
+        let delegation_id = delegation_id.expect("occurrence dispatched");
+        let occurrence_id = delegation_id
+            .strip_prefix(DELEGATION_PREFIX)
+            .unwrap()
+            .to_string();
+
+        // The terminal beats the receipt onto the bus. A later
+        // SessionEnded (a parked-then-stopped session) must not
+        // downgrade it: first terminal per session wins.
+        observe_event(
+            &handle,
+            &mut journal,
+            &mut state,
+            &AppEvent::DoneSignal {
+                session_id: Some("sess-fast".into()),
+                message: Some("won the race".into()),
+            },
+        );
+        observe_event(
+            &handle,
+            &mut journal,
+            &mut state,
+            &AppEvent::SessionEnded {
+                session_id: "sess-fast".into(),
+                reason: "stopped".into(),
+                error_kind: None,
+            },
+        );
+        assert!(
+            journal.progress(&occurrence_id).started.is_none(),
+            "no receipt yet — nothing journaled"
+        );
+
+        observe_event(
+            &handle,
+            &mut journal,
+            &mut state,
+            &AppEvent::TaskReceived {
+                delegation_id,
+                session_id: "sess-fast".into(),
+            },
+        );
+        // The receipt drains the remembered outcome: the journal arc stays
+        // in order (started, then the terminal) and the item completes.
+        let progress = journal.progress(&occurrence_id);
+        assert_eq!(progress.started.as_deref(), Some("sess-fast"));
+        assert_eq!(progress.terminal, Some(OccurrenceState::Completed));
+        let (items, _, _) = handle.snapshot();
+        let run = items.iter().find(|i| i.id == item.id).unwrap().effects[0]
+            .last_run
+            .clone()
+            .unwrap();
+        assert_eq!(run.state, "completed");
+        assert_eq!(run.note.as_deref(), Some("won the race"));
+        assert!(state.running.is_empty(), "occurrence fully resolved");
+        assert!(
+            state.take_early_outcome("sess-fast").is_none(),
+            "the remembered outcome is consumed by the receipt"
+        );
+    }
+
+    /// The same inversion with a failure shape: a session that dies
+    /// before its receipt resolves the occurrence `failed` instead of
+    /// stranding it. Unrelated sessions' terminals stay bounded residue.
+    #[tokio::test]
+    async fn early_session_end_before_receipt_fails_the_occurrence() {
+        let dir = tempfile::tempdir().unwrap();
+        let default_project = tempfile::tempdir().unwrap();
+        let handle = handle_with_default_project(dir.path(), default_project.path());
+        let mut journal = OccurrenceJournal::open(handle.dir()).unwrap();
+        let mut state = SchedulerState::default();
+        let item = handle
+            .apply(
+                AgendaCommand::Add {
+                    kind: AgendaKind::Task,
+                    title: "die fast".into(),
+                    body: String::new(),
+                    tags: Vec::new(),
+                    due_ms: None,
+                    source: None,
+                },
+                None,
+            )
+            .unwrap();
+        handle
+            .apply(
+                AgendaCommand::StartNow {
+                    id: item.id.clone(),
+                    goal: None,
+                    project_root: None,
+                    interactive: None,
+                    agent_config: None,
+                },
+                owner(),
+            )
+            .unwrap();
+        let mut rx = handle.bus().subscribe();
+        run_pass(&handle, &mut journal, &mut state).await;
+        let mut delegation_id = None;
+        while let Ok(event) = rx.try_recv() {
+            if let AppEvent::ControlCommand(ControlMsg::StartTask {
+                delegation_id: Some(id),
+                ..
+            }) = event
+            {
+                delegation_id = Some(id);
+            }
+        }
+        let delegation_id = delegation_id.expect("occurrence dispatched");
+        let occurrence_id = delegation_id
+            .strip_prefix(DELEGATION_PREFIX)
+            .unwrap()
+            .to_string();
+
+        observe_event(
+            &handle,
+            &mut journal,
+            &mut state,
+            &AppEvent::SessionEnded {
+                session_id: "sess-dead".into(),
+                reason: "error: exploded".into(),
+                error_kind: None,
+            },
+        );
+        // Bystander terminals (every session in the daemon ends
+        // eventually) stay bounded residue and — under the cap — never
+        // evict the entry the receipt is about to claim.
+        for index in 0..(EARLY_OUTCOME_CAP - 1) {
+            observe_event(
+                &handle,
+                &mut journal,
+                &mut state,
+                &AppEvent::DoneSignal {
+                    session_id: Some(format!("bystander-{index}")),
+                    message: None,
+                },
+            );
+        }
+        assert_eq!(state.early_outcomes.len(), EARLY_OUTCOME_CAP);
+
+        observe_event(
+            &handle,
+            &mut journal,
+            &mut state,
+            &AppEvent::TaskReceived {
+                delegation_id,
+                session_id: "sess-dead".into(),
+            },
+        );
+        let progress = journal.progress(&occurrence_id);
+        assert_eq!(progress.started.as_deref(), Some("sess-dead"));
+        assert_eq!(progress.terminal, Some(OccurrenceState::Failed));
+        let (items, _, _) = handle.snapshot();
+        let run = items.iter().find(|i| i.id == item.id).unwrap().effects[0]
+            .last_run
+            .clone()
+            .unwrap();
+        assert_eq!(run.state, "failed");
+        assert_eq!(run.note.as_deref(), Some("error: exploded"));
+
+        // Overflow past the cap drops the OLDEST remembered outcome
+        // (sess-dead was consumed by the receipt: CAP-1 remain; two more
+        // pushes cross the cap once).
+        for extra in ["one-more", "two-more"] {
+            state.remember_early_outcome(
+                extra,
+                EarlyOutcome {
+                    failed: None,
+                    note: "n".into(),
+                },
+            );
+        }
+        assert_eq!(state.early_outcomes.len(), EARLY_OUTCOME_CAP);
+        assert!(
+            state.take_early_outcome("bystander-0").is_none(),
+            "oldest entry evicted at the cap"
+        );
+        assert!(state.take_early_outcome("two-more").is_some());
     }
 
     /// A start-now carrying the confirm sheet's launch pins records them on

--- a/src/bin/caller/agent_loop.rs
+++ b/src/bin/caller/agent_loop.rs
@@ -1168,6 +1168,7 @@ pub(crate) async fn run_agent_loop(
                 permission_mode: Some(autonomy_level),
                 permission_kind: Some(intendant_core::vitals::PERMISSION_KIND_AUTONOMY.to_string()),
                 permission_echoed: true,
+                ..Default::default()
             },
         });
     }

--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -469,6 +469,18 @@ pub enum AppEvent {
         session_id: Option<String>,
         facts: crate::types::SessionConfigVitals,
     },
+    /// Disk-recovered session facts from the boot/resume vitals hydrator
+    /// (`session_vitals_restore`): recorded launch config + backend
+    /// transcript tail, provenance-stamped. Hub-internal like
+    /// `SessionConfigFacts` — the hub folds it fill-if-absent (live
+    /// producers always win) into `SessionVitals`, the outbound and
+    /// session-logged carrier; this event itself has no outbound twin
+    /// and is never persisted. Boxed: the payload carries several vitals
+    /// sections and rides a clone-per-subscriber broadcast.
+    SessionRecoveredFacts {
+        session_id: Option<String>,
+        facts: Box<crate::session_vitals_restore::RecoveredSessionFacts>,
+    },
     SessionAttached {
         session_id: String,
         source: String,
@@ -2972,6 +2984,7 @@ pub fn app_event_to_outbound(event: &AppEvent) -> Option<crate::types::OutboundE
         AppEvent::SessionActivity { .. } => None,
         AppEvent::SessionRateLimits { .. } => None,
         AppEvent::SessionConfigFacts { .. } => None,
+        AppEvent::SessionRecoveredFacts { .. } => None,
         AppEvent::SessionAttached { session_id, source } => Some(OutboundEvent::SessionAttached {
             session_id: session_id.clone(),
             source: source.clone(),

--- a/src/bin/caller/external_agent/claude_code.rs
+++ b/src/bin/caller/external_agent/claude_code.rs
@@ -51,7 +51,7 @@ pub const CLAUDE_CODE_BOOTSTRAP_ADDENDUM_MARKER: &str = "### Intendant Supervisi
 /// session whose model has a larger window (1M-beta) and >200k tokens on
 /// board, the FIRST turn's mid-turn meter divides by this default and can
 /// read >100% until that first result corrects it.
-const DEFAULT_CONTEXT_WINDOW: u64 = 200_000;
+pub(crate) const DEFAULT_CONTEXT_WINDOW: u64 = 200_000;
 
 /// Placeholder thread id used until Claude Code reveals the native session
 /// id (it stamps one on every stdout message once the first turn begins).
@@ -729,7 +729,11 @@ fn context_window_from_model_usage(model_usage: &serde_json::Value, model: &str)
 /// divided by the 200k default — the footprint/window clamp then pins the
 /// context meter at exactly 100% for the whole session (observed live on a
 /// claude-fable-5 session at 442k real footprint).
-fn claude_model_context_window(model: &str) -> Option<u64> {
+///
+/// `pub(crate)`: the vitals restore hydrator
+/// (`session_vitals_restore.rs`) sizes a recovered transcript footprint
+/// against this same table.
+pub(crate) fn claude_model_context_window(model: &str) -> Option<u64> {
     const ONE_M: u64 = 1_000_000;
     let model = model.trim();
     for (prefix, window) in [
@@ -1285,6 +1289,30 @@ impl CcReader {
         }
     }
 
+    /// First-hand effort echo: adopt the CLI's own statement of the
+    /// session's effort level and surface it as config facts when it
+    /// actually changed. Probed on `system:init` (`effort` /
+    /// `reasoningEffort`) and on assistant envelopes' top-level `effort`
+    /// — the transcript records the latter on every assistant line, but
+    /// the LIVE stream envelope does not carry it as of 2.1.217 (probed
+    /// live: assistant envelope keys are message / parent_tool_use_id /
+    /// request_id / session_id / timestamp / type / uuid), so the
+    /// assistant arm is defensive future-proofing. Until a CLI states
+    /// one, the launch `--effort` value seeds the config facts at spawn —
+    /// effort is never inferred from output.
+    fn note_effort_echo(&mut self, effort: &str, out: &mut CcLineOutcome) {
+        if self.effort_echo.as_deref() == Some(effort) {
+            return;
+        }
+        self.effort_echo = Some(effort.to_string());
+        out.events.push(AgentEvent::ConfigFacts {
+            facts: crate::types::SessionConfigVitals {
+                effort: Some(effort.to_string()),
+                ..Default::default()
+            },
+        });
+    }
+
     /// Route one wire observation through the shared activity machine and
     /// queue the resulting vitals snapshot (if any) for the drain.
     fn observe_activity(&self, obs: ActivityObs, out: &mut CcLineOutcome) {
@@ -1709,9 +1737,7 @@ impl CcReader {
             }
         }
         // First-hand effort: adopt the CLI's own echo if an init ever
-        // states one (2.1.2xx doesn't; the launch `--effort` value seeds
-        // the config facts at spawn — effort is never inferred from
-        // output).
+        // states one (2.1.2xx doesn't — see `note_effort_echo`).
         if let Some(effort) = msg
             .get("effort")
             .or_else(|| msg.get("reasoningEffort"))
@@ -1719,15 +1745,7 @@ impl CcReader {
             .map(str::trim)
             .filter(|e| !e.is_empty())
         {
-            if self.effort_echo.as_deref() != Some(effort) {
-                self.effort_echo = Some(effort.to_string());
-                out.events.push(AgentEvent::ConfigFacts {
-                    facts: crate::types::SessionConfigVitals {
-                        effort: Some(effort.to_string()),
-                        ..Default::default()
-                    },
-                });
-            }
+            self.note_effort_echo(effort, out);
         }
         if !self.init_logged {
             self.init_logged = true;
@@ -2060,6 +2078,20 @@ impl CcReader {
         // `message_delta`/`result` usage the snapshots are built from.
         if let Some(usage) = msg.get("message").and_then(|m| m.get("usage")) {
             self.note_cache_ttl_flavor(usage);
+        }
+        // Top-level `effort` on the envelope, main thread only (a Task
+        // child can run its own settings): first-hand echo when a CLI
+        // ever states it — 2.1.217's live envelopes don't (transcript
+        // records do); see `note_effort_echo`.
+        if child_scope.is_none() {
+            if let Some(effort) = msg
+                .get("effort")
+                .and_then(|e| e.as_str())
+                .map(str::trim)
+                .filter(|e| !e.is_empty())
+            {
+                self.note_effort_echo(effort, out);
+            }
         }
         let Some(content) = msg
             .get("message")
@@ -3782,6 +3814,7 @@ impl ExternalAgent for ClaudeCodeAgent {
                 permission_kind: intendant_core::vitals::claude_permission_kind(&permission_mode)
                     .map(str::to_string),
                 permission_echoed: false,
+                ..Default::default()
             },
         });
 
@@ -4849,6 +4882,45 @@ mod tests {
         let facts = config_facts_of(&out);
         assert_eq!(facts.len(), 1, "model switch emits");
         assert_eq!(facts[0].model.as_deref(), Some("claude-opus-4-6"));
+    }
+
+    /// The defensive assistant-envelope effort arm: a top-level `effort`
+    /// on a main-thread assistant envelope becomes a first-hand effort
+    /// echo (change-edged), while sidechain (Task-child) envelopes and
+    /// effort-less envelopes — the live 2.1.217 shape, probed — claim
+    /// nothing.
+    #[test]
+    fn assistant_envelope_effort_echo_is_defensive_and_change_edged() {
+        let mut reader = test_reader();
+        // The live 2.1.217 shape: no top-level effort → no claim.
+        let out = reader.process_line(
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]},"session_id":"s1"}"#,
+        );
+        assert!(
+            config_facts_of(&out).is_empty(),
+            "absent effort claims nothing"
+        );
+
+        // A future CLI mirroring its transcript record: adopt the echo.
+        let envelope = r#"{"type":"assistant","effort":"xhigh","message":{"content":[{"type":"text","text":"hi"}]},"session_id":"s1"}"#;
+        let out = reader.process_line(envelope);
+        let facts = config_facts_of(&out);
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].effort.as_deref(), Some("xhigh"));
+
+        // Change edge: the same value stays quiet.
+        let out = reader.process_line(envelope);
+        assert!(config_facts_of(&out).is_empty(), "re-echo stays quiet");
+
+        // Sidechain envelopes (Task children run their own settings)
+        // never claim the session's effort.
+        let out = reader.process_line(
+            r#"{"type":"assistant","effort":"low","parent_tool_use_id":"toolu_child","message":{"content":[{"type":"text","text":"hi"}]},"session_id":"s1"}"#,
+        );
+        assert!(
+            config_facts_of(&out).is_empty(),
+            "sidechain effort is the child's, not the session's"
+        );
     }
 
     /// The 2.1.201 status channel echoes the live permission mode after an

--- a/src/bin/caller/external_agent/codex/mod.rs
+++ b/src/bin/caller/external_agent/codex/mod.rs
@@ -388,6 +388,7 @@ impl CodexAgent {
                     .map(str::to_string),
                 permission_mode,
                 permission_echoed: true,
+                ..Default::default()
             },
         });
     }

--- a/src/bin/caller/external_agent/codex/reader.rs
+++ b/src/bin/caller/external_agent/codex/reader.rs
@@ -1029,6 +1029,7 @@ pub(crate) fn codex_thread_settings_config_facts(
         permission_mode,
         permission_kind,
         permission_echoed,
+        ..Default::default()
     };
     (facts != crate::types::SessionConfigVitals::default()).then_some(facts)
 }

--- a/src/bin/caller/external_agent/kimi_code/events.rs
+++ b/src/bin/caller/external_agent/kimi_code/events.rs
@@ -1031,6 +1031,7 @@ impl EventTranslator {
                 permission_mode: permission,
                 permission_kind,
                 permission_echoed: echoed,
+                ..Default::default()
             },
         }]
     }

--- a/src/bin/caller/external_agent/kimi_code/mod.rs
+++ b/src/bin/caller/external_agent/kimi_code/mod.rs
@@ -1069,6 +1069,7 @@ impl KimiCodeAgent {
                 permission_kind: kimi_permission_kind(&self.launch.permission_mode)
                     .map(str::to_string),
                 permission_echoed: echoed,
+                ..Default::default()
             },
         });
     }
@@ -2502,7 +2503,10 @@ fn validate_permission_mode(mode: &str) -> Result<(), CallerError> {
     }
 }
 
-fn kimi_permission_kind(permission: &str) -> Option<&'static str> {
+/// `pub(crate)`: the vitals restore hydrator
+/// (`session_vitals_restore.rs`) classifies a recovered launch config's
+/// kimi mode through this same catalog.
+pub(crate) fn kimi_permission_kind(permission: &str) -> Option<&'static str> {
     match permission {
         "manual" => Some(intendant_core::vitals::PERMISSION_KIND_ASK),
         "auto" => Some(intendant_core::vitals::PERMISSION_KIND_AUTO_SAFE),

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -88,6 +88,7 @@ mod session_log;
 mod session_names;
 mod session_supervisor;
 mod session_vitals;
+mod session_vitals_restore;
 mod setup;
 mod shared_view_lifecycle;
 mod skill_install;

--- a/src/bin/caller/mcp/events.rs
+++ b/src/bin/caller/mcp/events.rs
@@ -256,6 +256,7 @@ pub fn spawn_event_listener(
                     | AppEvent::SessionActivity { .. }
                     | AppEvent::SessionRateLimits { .. }
                     | AppEvent::SessionConfigFacts { .. }
+                    | AppEvent::SessionRecoveredFacts { .. }
                     | AppEvent::SessionRenameResult { .. }
                     | AppEvent::SessionAgentConfigResult { .. }
                     | AppEvent::ClaudeConfigChanged { .. }

--- a/src/bin/caller/peer/transport/intendant.rs
+++ b/src/bin/caller/peer/transport/intendant.rs
@@ -874,6 +874,7 @@ mod tests {
                     limits: Vec::new(),
                     activity: None,
                     config: None,
+                    context: None,
                 },
             },
             crate::types::OutboundEvent::Status {

--- a/src/bin/caller/peer/upcast.rs
+++ b/src/bin/caller/peer/upcast.rs
@@ -593,6 +593,7 @@ impl AppEventUpcaster {
             | AppEvent::SessionActivity { .. }
             | AppEvent::SessionRateLimits { .. }
             | AppEvent::SessionConfigFacts { .. }
+            | AppEvent::SessionRecoveredFacts { .. }
             | AppEvent::ContextSnapshot { .. }
             | AppEvent::CodexThreadActionRequested { .. }
             | AppEvent::ExternalFollowUpRequested { .. }
@@ -4788,6 +4789,7 @@ mod tests {
             limits: Vec::new(),
             activity: None,
             config: None,
+            context: None,
         }
     }
 

--- a/src/bin/caller/presence.rs
+++ b/src/bin/caller/presence.rs
@@ -1096,6 +1096,7 @@ pub fn filter_event(event: &AppEvent, last_phase: &mut String) -> Option<Presenc
         | AppEvent::SessionActivity { .. }
         | AppEvent::SessionRateLimits { .. }
         | AppEvent::SessionConfigFacts { .. }
+        | AppEvent::SessionRecoveredFacts { .. }
         | AppEvent::SessionRenameResult { .. }
         | AppEvent::SessionAgentConfigResult { .. }
         | AppEvent::ClaudeConfigChanged { .. }

--- a/src/bin/caller/session_supervisor/launch.rs
+++ b/src/bin/caller/session_supervisor/launch.rs
@@ -72,6 +72,34 @@ impl SessionSupervisor {
         }
     }
 
+    /// Instant-vitals hydration for a resumed/attached external session,
+    /// fired beside [`Self::seed_resumed_git_vitals_locus`]: the recorded
+    /// launch config and the backend transcript tail fill the session's
+    /// Model/permissions chips and context meter NOW (fill-if-absent at
+    /// the hub — see `session_vitals_restore`), instead of waiting
+    /// seconds for the spawned backend's first wire echo. Keyed exactly
+    /// like the lane's `register_git_vitals` so the facts land on the
+    /// entry just registered.
+    fn hydrate_resumed_session_vitals(
+        &self,
+        session_id: &str,
+        backend: Option<&external_agent::AgentBackend>,
+        resume_token: &str,
+        launch_config: Option<&crate::session_config::SessionAgentConfig>,
+    ) {
+        let Some(backend) = backend else {
+            return;
+        };
+        crate::session_vitals_restore::hydrate_resumed_session_vitals(
+            self.config.bus.clone(),
+            self.logs_home(),
+            session_id.to_string(),
+            backend.clone(),
+            resume_token.to_string(),
+            launch_config.cloned(),
+        );
+    }
+
     /// Create and dispatch a new managed session. THE shared launch path:
     /// every session-creating lane (`CreateSession`, untargeted
     /// `StartTask` — composer, ctl, peer delegations, the agenda's
@@ -976,6 +1004,12 @@ impl SessionSupervisor {
                     &resume_token,
                     codex_home.as_deref(),
                 );
+                self.hydrate_resumed_session_vitals(
+                    &session_id,
+                    external_backend.as_ref(),
+                    &resume_token,
+                    effective_session_agent_config.as_ref(),
+                );
                 let intendant_session_id = session_log
                     .lock()
                     .map(|log| log.session_id().to_string())
@@ -1121,6 +1155,16 @@ impl SessionSupervisor {
             external_backend.as_ref(),
             &resume_token,
             codex_home.as_deref(),
+        );
+        self.hydrate_resumed_session_vitals(
+            if fork {
+                &intendant_session_id
+            } else {
+                &live_session_id
+            },
+            external_backend.as_ref(),
+            &resume_token,
+            effective_session_agent_config.as_ref(),
         );
         self.activate_shared_session(session_log.clone()).await;
         self.config.bus.send(AppEvent::SessionStarted {

--- a/src/bin/caller/session_vitals.rs
+++ b/src/bin/caller/session_vitals.rs
@@ -966,6 +966,24 @@ fn epoch_seconds() -> u64 {
         .unwrap_or(0)
 }
 
+/// Context-section percentage for one usage snapshot. The snapshot's own
+/// `usage_pct` is authoritative when it says anything — external backends
+/// compute it from this very footprint, and some (Codex managed context)
+/// know better than a naive division. The exception is the
+/// zero-with-tokens shape: the native usage rail's `usage_pct` mirrors
+/// `TurnStarted.budget_pct`, which is 0.0 on a session's FIRST turn while
+/// `tokens_used` is already real (the budget figure lags one turn) — the
+/// context section must not claim an empty window beside a stated
+/// footprint, so that one inconsistent shape derives the percentage from
+/// the section's own tokens/window instead (clamped like every producer).
+fn context_usage_pct(main: &ModelUsageSnapshot) -> f64 {
+    if main.usage_pct > 0.0 || main.tokens_used == 0 || main.context_window == 0 {
+        return main.usage_pct;
+    }
+    let effective_window = main.context_window.max(main.tokens_used);
+    (main.tokens_used as f64 / effective_window as f64) * 100.0
+}
+
 /// Fold one usage snapshot into a session's cache section. Returns `None`
 /// when the snapshot carries no per-request cache sample (nothing to
 /// learn). `previous_ttl` keeps the last known TTL flavor across read-only
@@ -1050,7 +1068,7 @@ pub(crate) fn spawn_cache_vitals_listener(
                             vitals.context = Some(crate::types::SessionContextVitals {
                                 tokens_used: main.tokens_used,
                                 context_window: main.context_window,
-                                usage_pct: main.usage_pct,
+                                usage_pct: context_usage_pct(&main),
                                 observed_at_epoch: now_epoch,
                                 recovered_at_epoch: None,
                             });
@@ -2001,6 +2019,47 @@ mod tests {
             cache_ttl_seconds: ttl,
             ..Default::default()
         }
+    }
+
+    /// The context section's percentage: the snapshot's own figure is
+    /// authoritative whenever it says anything, and the one inconsistent
+    /// shape — the native rail's first-turn `budget_pct` 0.0 beside a
+    /// real `tokens_used` (observed live: 4499 tokens / 200k window
+    /// logged as 0.0%) — derives from the section's own tokens/window
+    /// instead of claiming an empty context.
+    #[test]
+    fn context_usage_pct_derives_only_for_the_zero_with_tokens_shape() {
+        let mut main = ModelUsageSnapshot {
+            tokens_used: 4_499,
+            context_window: 200_000,
+            usage_pct: 0.0,
+            ..Default::default()
+        };
+        let derived = context_usage_pct(&main);
+        assert!(
+            (derived - 2.2495).abs() < 0.001,
+            "zero-with-tokens derives tokens/window, got {derived}"
+        );
+
+        // A stated percentage passes through verbatim — external
+        // backends' own figures (managed context) know better.
+        main.usage_pct = 41.5;
+        assert_eq!(context_usage_pct(&main), 41.5);
+
+        // No tokens (guarded earlier by the caller) and no window both
+        // pass the snapshot's figure through unchanged.
+        main.usage_pct = 0.0;
+        main.tokens_used = 0;
+        assert_eq!(context_usage_pct(&main), 0.0);
+        main.tokens_used = 4_499;
+        main.context_window = 0;
+        assert_eq!(context_usage_pct(&main), 0.0);
+
+        // A footprint past the window clamps via the effective window —
+        // never above 100.
+        main.context_window = 2_000;
+        let clamped = context_usage_pct(&main);
+        assert!((clamped - 100.0).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/src/bin/caller/session_vitals.rs
+++ b/src/bin/caller/session_vitals.rs
@@ -631,37 +631,61 @@ impl GitVitalsProber {
 /// the git family blanks to "not reported" the moment usage wins the
 /// race). The alias map canonicalizes every apply/remove so one entry —
 /// and therefore every emitted snapshot — carries all sections.
-struct SessionVitalsHub {
-    bus: EventBus,
-    sessions: Mutex<HashMap<String, SessionVitals>>,
+pub(crate) struct SessionVitalsHub {
+    pub(crate) bus: EventBus,
+    pub(crate) sessions: Mutex<HashMap<String, SessionVitals>>,
     /// alias id → canonical id, fed by `SessionIdentity` (native →
     /// wrapper). Chains are flattened at link time so `resolve` is one
     /// hop in practice; the hop cap is a cycle guard only.
-    aliases: Mutex<HashMap<String, String>>,
+    pub(crate) aliases: Mutex<HashMap<String, String>>,
     /// canonical id → backend source ("claude-code", "codex"), fed by
     /// `SessionIdentity`. Membership key for the account-scoped limits
     /// fold; native sessions never appear here.
-    session_sources: Mutex<HashMap<String, String>>,
+    pub(crate) session_sources: Mutex<HashMap<String, String>>,
     /// Per backend source: the account's latest known rate-limit windows,
     /// by label, freshest report per window (`observed_at_epoch`). The
     /// account outlives any one session, so a session starting mid-warning
     /// inherits the known state instead of claiming ignorance.
-    account_limits: Mutex<HashMap<String, std::collections::BTreeMap<String, SessionLimitWindow>>>,
+    pub(crate) account_limits:
+        Mutex<HashMap<String, std::collections::BTreeMap<String, SessionLimitWindow>>>,
+    /// Daemon state file the account window store persists to (see
+    /// `session_vitals_restore::account_limit_store`) so a restart keeps
+    /// the account's last known windows; `None` disables persistence
+    /// (unit tests, embedded producers).
+    pub(crate) limit_store: Option<PathBuf>,
 }
 
 impl SessionVitalsHub {
-    fn new(bus: EventBus) -> Arc<Self> {
+    /// Persistence-free hub — the unit-test constructor (production goes
+    /// through [`Self::with_limit_store`]).
+    #[cfg(test)]
+    pub(crate) fn new(bus: EventBus) -> Arc<Self> {
+        Self::with_limit_store(bus, None)
+    }
+
+    /// Hub with rate-limit window persistence: `limit_store` (when set) is
+    /// read once here — restoring the accounts' last known windows — and
+    /// rewritten whenever a report changes an account store. Stale
+    /// restores stay honest downstream: every window keeps its
+    /// `observed_at_epoch`, and the frontends' reset-rollover degradation
+    /// already refuses to present a lapsed window as current.
+    pub(crate) fn with_limit_store(bus: EventBus, limit_store: Option<PathBuf>) -> Arc<Self> {
+        let account_limits = limit_store
+            .as_deref()
+            .map(crate::session_vitals_restore::load_account_limit_store)
+            .unwrap_or_default();
         Arc::new(Self {
             bus,
             sessions: Mutex::new(HashMap::new()),
             aliases: Mutex::new(HashMap::new()),
             session_sources: Mutex::new(HashMap::new()),
-            account_limits: Mutex::new(HashMap::new()),
+            account_limits: Mutex::new(account_limits),
+            limit_store,
         })
     }
 
     /// Canonical id for any member of an identity group.
-    fn resolve(&self, session_id: &str) -> String {
+    pub(crate) fn resolve(&self, session_id: &str) -> String {
         let aliases = self.aliases.lock().expect("vitals alias lock");
         let mut id = session_id.trim();
         for _ in 0..4 {
@@ -715,6 +739,9 @@ impl SessionVitalsHub {
                 if vitals.config.is_none() {
                     vitals.config = orphan.config;
                 }
+                if vitals.context.is_none() {
+                    vitals.context = orphan.context;
+                }
             });
         }
     }
@@ -755,7 +782,11 @@ impl SessionVitalsHub {
     /// session of that source. Sourceless (native) sessions keep
     /// per-session windows. An empty report still mirrors the account
     /// view — that is how a newly linked session inherits known state.
-    fn apply_rate_limit_windows(&self, session_id: &str, windows: Vec<SessionLimitWindow>) {
+    pub(crate) fn apply_rate_limit_windows(
+        &self,
+        session_id: &str,
+        windows: Vec<SessionLimitWindow>,
+    ) {
         let session_id = self.resolve(session_id);
         let source = self
             .session_sources
@@ -769,12 +800,15 @@ impl SessionVitalsHub {
             }
             return;
         };
-        let merged: Vec<SessionLimitWindow> = {
+        let (merged, store_changed): (Vec<SessionLimitWindow>, bool) = {
             let mut accounts = self.account_limits.lock().expect("vitals account lock");
             let store = accounts.entry(source.clone()).or_default();
-            fold_limit_windows(store, &windows);
-            store.values().cloned().collect()
+            let changed = fold_limit_windows(store, &windows);
+            (store.values().cloned().collect(), changed)
         };
+        if store_changed {
+            self.persist_account_limits();
+        }
         if merged.is_empty() {
             return;
         }
@@ -792,7 +826,7 @@ impl SessionVitalsHub {
         }
     }
 
-    fn apply(&self, session_id: &str, update: impl FnOnce(&mut SessionVitals)) {
+    pub(crate) fn apply(&self, session_id: &str, update: impl FnOnce(&mut SessionVitals)) {
         let session_id = self.resolve(session_id);
         let changed = {
             let mut sessions = self.sessions.lock().expect("vitals state lock");
@@ -813,7 +847,13 @@ impl SessionVitalsHub {
     /// switch), and a known value is never blanked by a later partial
     /// that omits it. The permission fields travel as one datum — a mode
     /// update carries its display kind and echo provenance with it.
-    fn apply_config_facts(&self, session_id: &str, update: SessionConfigVitals) {
+    ///
+    /// This is the LIVE fold: a field it states overwrites any
+    /// disk-recovered value and clears that field's recovered stamp, so a
+    /// hydrator/live race settles on the live claim regardless of arrival
+    /// order (`apply_recovered_facts` is fill-if-absent — see
+    /// `session_vitals_restore`).
+    pub(crate) fn apply_config_facts(&self, session_id: &str, update: SessionConfigVitals) {
         if update == SessionConfigVitals::default() {
             return;
         }
@@ -821,6 +861,7 @@ impl SessionVitalsHub {
             let config = vitals.config.get_or_insert_with(Default::default);
             if update.model.is_some() {
                 config.model = update.model;
+                config.model_recovered_at_epoch = None;
             }
             if update.effort.is_some() {
                 config.effort = update.effort;
@@ -829,6 +870,7 @@ impl SessionVitalsHub {
                 config.permission_mode = update.permission_mode;
                 config.permission_kind = update.permission_kind;
                 config.permission_echoed = update.permission_echoed;
+                config.permission_recovered_at_epoch = None;
             }
         });
     }
@@ -890,11 +932,13 @@ impl SessionVitalsHub {
 /// incumbent — legacy emissions predate the stamp — always yields to a
 /// report). Windows the report does not mention persist: providers
 /// announce one window per event (Claude Code), and an unmentioned
-/// window's last known state is still the account's best truth.
+/// window's last known state is still the account's best truth. Returns
+/// whether the store actually changed (the persistence trigger).
 fn fold_limit_windows(
     store: &mut std::collections::BTreeMap<String, SessionLimitWindow>,
     incoming: &[SessionLimitWindow],
-) {
+) -> bool {
+    let mut changed = false;
     for window in incoming {
         let label = window.label.trim();
         if label.is_empty() {
@@ -904,11 +948,14 @@ fn fold_limit_windows(
             Some(existing)
                 if existing.observed_at_epoch.unwrap_or(0)
                     > window.observed_at_epoch.unwrap_or(0) => {}
+            Some(existing) if existing == window => {}
             _ => {
                 store.insert(label.to_string(), window.clone());
+                changed = true;
             }
         }
     }
+    changed
 }
 
 /// Unix seconds now — the cache-countdown anchor.
@@ -949,6 +996,7 @@ fn cache_vitals_from_usage(
         hit_pct: Some(hit_pct),
         last_activity_epoch: now_epoch,
         ttl_seconds,
+        recovered_at_epoch: None,
     })
 }
 
@@ -963,7 +1011,7 @@ fn cache_vitals_from_usage(
 /// each other's chips) — and record each session's backend source, the
 /// membership key of the account-scoped limits fold. Sessions are pruned on
 /// `SessionEnded`.
-fn spawn_cache_vitals_listener(
+pub(crate) fn spawn_cache_vitals_listener(
     bus: EventBus,
     hub: Arc<SessionVitalsHub>,
 ) -> tokio::task::JoinHandle<()> {
@@ -987,10 +1035,25 @@ fn spawn_cache_vitals_listener(
                     }
                     hub.apply(&session_id, |vitals| {
                         let previous_ttl = vitals.cache.as_ref().and_then(|c| c.ttl_seconds);
-                        if let Some(cache) =
-                            cache_vitals_from_usage(&main, previous_ttl, epoch_seconds())
+                        let now_epoch = epoch_seconds();
+                        if let Some(cache) = cache_vitals_from_usage(&main, previous_ttl, now_epoch)
                         {
                             vitals.cache = Some(cache);
+                        }
+                        // Context footprint: every backend's usage rail
+                        // states tokens/window/pct in one vocabulary, so
+                        // this single fill covers them all. A LIVE fold:
+                        // it overwrites any disk-recovered section (the
+                        // absent stamp clears the caveat by construction).
+                        // All-zero snapshots carry no footprint claim.
+                        if main.tokens_used > 0 {
+                            vitals.context = Some(crate::types::SessionContextVitals {
+                                tokens_used: main.tokens_used,
+                                context_window: main.context_window,
+                                usage_pct: main.usage_pct,
+                                observed_at_epoch: now_epoch,
+                                recovered_at_epoch: None,
+                            });
                         }
                     });
                 }
@@ -1013,6 +1076,14 @@ fn spawn_cache_vitals_listener(
                     session_id: Some(session_id),
                     facts,
                 }) => hub.apply_config_facts(&session_id, facts),
+                // Disk-recovered facts from the boot/resume hydrator:
+                // fill-if-absent, so whatever a live producer already
+                // stated wins regardless of arrival order (see
+                // `session_vitals_restore`).
+                Ok(AppEvent::SessionRecoveredFacts {
+                    session_id: Some(session_id),
+                    facts,
+                }) => hub.apply_recovered_facts(&session_id, *facts),
                 // The autonomy level is daemon-global shared state; the
                 // fold updates every autonomy-backed config section so a
                 // Control-tab change shows up mid-session.
@@ -1267,79 +1338,31 @@ impl GitVitalsTargets {
     }
 }
 
-/// Cap on boot-time registration of restored sessions. A long-lived
-/// store accumulates thousands of non-ended session dirs (a real store
-/// measured ~2.1k across ~100 distinct roots), and every registered
-/// target costs a per-tick probe plus an emission — and a session-log
-/// write — for every session sharing a root whenever that root's git
-/// state changes. The newest N by meta mtime cover the session windows
-/// a dashboard realistically shows; older idle sessions regain their
-/// chips the moment they are resumed (launch-time registration, as
-/// before).
-const RESTORED_TARGET_CAP: usize = 64;
-
 /// Register git-probe targets for sessions RESTORED from the on-disk
 /// session store (`<home>/.intendant/logs`) — the daemon-boot
 /// complement to the supervisor's launch/resume registration. Without
 /// it a restart empties the registry, and idle session windows lose
 /// their git/health chips until the next resume touches them.
 ///
-/// Scope mirrors the `SessionEnded` prune: a `completed` meta means the
-/// session ended before the restart (the prune would have dropped it),
-/// so it stays unregistered; `idle` / `interrupted` / stale `running`
-/// sessions were live in a daemon's registry when it died and come
-/// back. Worktree sessions register their CHECKOUT
-/// (`meta.worktree.path`), exactly like launch-time registration.
-/// The newest [`RESTORED_TARGET_CAP`] sessions win (meta-file mtime —
-/// re-stamped on every lifecycle transition — is the recency key), and
-/// registration is insert-if-absent so the primary seed and any
-/// launch/resume racing the scan keep their fresher roots.
+/// The candidate walk (scope, recency cap, worktree-checkout roots)
+/// lives in [`crate::session_vitals_restore::restored_session_candidates`]
+/// — shared with the boot vitals hydrator so both restore lanes cover
+/// exactly the same sessions. Registration is insert-if-absent so the
+/// primary seed and any launch/resume racing the scan keep their
+/// fresher roots.
 ///
 /// Returns how many sessions were registered. Synchronous filesystem
-/// walk — call it from a blocking context.
+/// walk. Production boots through
+/// `session_vitals_restore::restore_session_vitals_at_boot`, which runs
+/// this same registration over one shared walk; this wrapper remains the
+/// registration contract's test seam.
+#[cfg(test)]
 pub(crate) fn register_restored_session_targets(home: &Path, registry: &GitVitalsTargets) -> usize {
-    let logs_dir = crate::platform::intendant_home_in(home).join("logs");
-    let Ok(entries) = std::fs::read_dir(&logs_dir) else {
-        return 0;
-    };
-    // (meta mtime, session id, effective root)
-    let mut restored: Vec<(std::time::SystemTime, String, PathBuf)> = Vec::new();
-    for entry in entries.flatten() {
-        let meta_path = entry.path().join("session_meta.json");
-        let Ok(raw) = std::fs::read_to_string(&meta_path) else {
-            continue;
-        };
-        let Ok(meta) = serde_json::from_str::<crate::session_log::SessionMeta>(&raw) else {
-            continue;
-        };
-        // Parity with the SessionEnded prune: completed = ended.
-        if meta.status.as_deref() == Some("completed") {
-            continue;
-        }
-        let root = meta
-            .worktree
-            .as_ref()
-            .map(|worktree| worktree.path.clone())
-            .or(meta.project_root);
-        let Some(root) = root.filter(|root| !root.trim().is_empty()) else {
-            continue;
-        };
-        let session_id = meta.session_id.trim().to_string();
-        if session_id.is_empty() {
-            continue;
-        }
-        let mtime = meta_path
-            .metadata()
-            .and_then(|m| m.modified())
-            .unwrap_or(std::time::UNIX_EPOCH);
-        restored.push((mtime, session_id, PathBuf::from(root)));
-    }
-    // Newest first; the cap keeps probe work and emission fan-out bounded.
-    restored.sort_by_key(|entry| std::cmp::Reverse(entry.0));
-    restored
+    crate::session_vitals_restore::restored_session_candidates(home)
         .into_iter()
-        .take(RESTORED_TARGET_CAP)
-        .filter(|(_, session_id, root)| registry.register_restored(session_id, root.clone()))
+        .filter(|candidate| {
+            registry.register_restored(&candidate.session_id, candidate.root.clone())
+        })
         .count()
 }
 
@@ -1384,15 +1407,21 @@ async fn probe_cached(
 /// backend-agnostic, so the listener runs wherever a bus exists — a
 /// projectless daemon still reports cache and rate-limit vitals for every
 /// session; only the git segment needs a repo target.
+///
+/// `limit_store` (production:
+/// [`crate::session_vitals_restore::account_limit_store_path`]) makes the
+/// per-account rate-limit window store survive restarts: restored here,
+/// rewritten on change. `None` keeps the store memory-only.
 pub(crate) fn spawn_session_vitals_producer(
     bus: EventBus,
     seed_targets: Vec<(String, PathBuf)>,
+    limit_store: Option<PathBuf>,
 ) -> (GitVitalsTargets, tokio::task::JoinHandle<()>) {
     let registry = GitVitalsTargets::default();
     for (session_id, cwd) in seed_targets {
         registry.register(&session_id, cwd);
     }
-    let hub = SessionVitalsHub::new(bus.clone());
+    let hub = SessionVitalsHub::with_limit_store(bus.clone(), limit_store);
     let wake = Arc::new(tokio::sync::Notify::new());
     let _cache_listener = spawn_cache_vitals_listener(bus.clone(), hub.clone());
     let _target_maintainer =
@@ -1519,6 +1548,7 @@ fn spawn_git_target_maintainer(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::session_vitals_restore::RESTORED_TARGET_CAP;
 
     fn sh(cwd: &Path, args: &[&str]) {
         let status = std::process::Command::new(args[0])
@@ -2071,6 +2101,7 @@ mod tests {
                 hit_pct: Some(90),
                 last_activity_epoch: 1,
                 ttl_seconds: Some(300),
+                recovered_at_epoch: None,
             })
         });
         // Identical rewrite → no emission.
@@ -2134,6 +2165,7 @@ mod tests {
                 permission_mode: Some("bypassPermissions".into()),
                 permission_kind: Some("bypass".into()),
                 permission_echoed: false,
+                ..Default::default()
             },
         });
         let (sid, config) = tokio::time::timeout(deadline, wait_config(&mut rx))
@@ -2565,7 +2597,7 @@ mod tests {
 
         let bus = EventBus::new();
         let mut rx = bus.subscribe();
-        let (targets, _producer) = spawn_session_vitals_producer(bus.clone(), Vec::new());
+        let (targets, _producer) = spawn_session_vitals_producer(bus.clone(), Vec::new(), None);
         assert_eq!(
             register_restored_session_targets(home.path(), &targets),
             1,
@@ -2618,6 +2650,7 @@ mod tests {
         let (_targets, _producer) = spawn_session_vitals_producer(
             bus.clone(),
             vec![("vcs-session".to_string(), repo_a.path().to_path_buf())],
+            None,
         );
 
         let deadline = std::time::Duration::from_secs(20);
@@ -2763,7 +2796,7 @@ mod tests {
 
         let bus = EventBus::new();
         let mut rx = bus.subscribe();
-        let (targets, _producer) = spawn_session_vitals_producer(bus.clone(), Vec::new());
+        let (targets, _producer) = spawn_session_vitals_producer(bus.clone(), Vec::new(), None);
         targets.register("shared-a", repo.path().to_path_buf());
         targets.register("shared-b", repo.path().to_path_buf());
 
@@ -2813,7 +2846,7 @@ mod tests {
         // Subscribed before the producer spawns, so every change-only hub
         // emission is queued here — sequential waits never miss one.
         let mut rx = bus.subscribe();
-        let (targets, _producer) = spawn_session_vitals_producer(bus.clone(), Vec::new());
+        let (targets, _producer) = spawn_session_vitals_producer(bus.clone(), Vec::new(), None);
         targets.register("s-fork", root.to_path_buf());
 
         let deadline = std::time::Duration::from_secs(20);
@@ -2880,7 +2913,7 @@ mod tests {
 
         let bus = EventBus::new();
         let mut rx = bus.subscribe();
-        let (targets, _producer) = spawn_session_vitals_producer(bus.clone(), Vec::new());
+        let (targets, _producer) = spawn_session_vitals_producer(bus.clone(), Vec::new(), None);
         targets.register("s-announce", root.to_path_buf());
 
         let deadline = std::time::Duration::from_secs(20);
@@ -2947,7 +2980,7 @@ mod tests {
 
         let bus = EventBus::new();
         let mut rx = bus.subscribe();
-        let (targets, _producer) = spawn_session_vitals_producer(bus.clone(), Vec::new());
+        let (targets, _producer) = spawn_session_vitals_producer(bus.clone(), Vec::new(), None);
         targets.register("supervised-1", root.to_path_buf());
 
         let deadline = std::time::Duration::from_secs(20);
@@ -2988,7 +3021,7 @@ mod tests {
         // (regression: the listener used to die with the git gating,
         // blanking the dashboard's Prompt cache row daemon-wide).
         let bus = EventBus::new();
-        let _producer = spawn_session_vitals_producer(bus.clone(), Vec::new());
+        let _producer = spawn_session_vitals_producer(bus.clone(), Vec::new(), None);
         let mut rx = bus.subscribe();
         bus.send(AppEvent::UsageSnapshot {
             session_id: Some("cc-session".into()),
@@ -3479,12 +3512,22 @@ mod tests {
             "permissionMode",
             "permissionKind",
             "permissionEchoed",
+            // Recovered-provenance stamps (instant vitals hydration): the
+            // model/permissions/cache chips caveat disk-hydrated values.
+            "modelRecoveredAtEpoch",
+            "permissionRecoveredAtEpoch",
+            "recoveredAtEpoch",
         ] {
             assert!(
                 catalog.contains(field),
                 "catalog stopped consuming wire field {field} — SessionVitals and VITALS_SYMBOLS drifted"
             );
         }
+        // The recovered caveat itself: one sentence pattern, dated.
+        assert!(
+            catalog.contains("From the session log as of"),
+            "catalog lost the recovered-provenance caveat line"
+        );
         // The permission display kinds (the daemon-side catalog in
         // intendant-core vitals.rs) must each have plain-language copy in
         // the frontend catalog — one vocabulary, two responsibilities.
@@ -3508,6 +3551,30 @@ mod tests {
             assert!(
                 catalog.contains(state),
                 "catalog stopped handling activity state {state}"
+            );
+        }
+        // The context section rides the vitals store (normalize + merge
+        // in this fragment) and feeds the header meter's fallback lane in
+        // fragment 41 — pin both consumers so the wire section can't
+        // silently lose its frontend.
+        for marker in [
+            "src.context",
+            "context: incoming.context || existing.context",
+        ] {
+            assert!(
+                fragment.contains(marker),
+                "fragment 39 stopped carrying vitals.context ({marker})"
+            );
+        }
+        let actions_fragment = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("static/app/41-session-window-actions.js"),
+        )
+        .expect("dashboard session-window-actions fragment");
+        for marker in ["contextPctFromVitals", "vitals?.context", "usagePct"] {
+            assert!(
+                actions_fragment.contains(marker),
+                "fragment 41 lost the context-meter vitals fallback ({marker})"
             );
         }
     }

--- a/src/bin/caller/session_vitals_restore.rs
+++ b/src/bin/caller/session_vitals_restore.rs
@@ -1,0 +1,1765 @@
+//! Instant vitals hydration — the disk-recovery side of the session
+//! vitals hub (`session_vitals.rs`, at its size budget, keeps only the
+//! live producers).
+//!
+//! After a resume or daemon restart the Model/effort and permission
+//! chips used to wait on the backend's first wire echo (seconds — or
+//! forever, for restored sessions nobody resumes), and the context
+//! meter waited on the first live usage snapshot. The ground truth
+//! already sits on disk: the wrapper log dir's recorded launch config
+//! (`session_agent_config.json`) and the backend's own transcript
+//! (Claude Code stamps model / top-level effort / permissionMode /
+//! usage / cwd on its `~/.claude/projects` records). This module reads
+//! both and feeds the hub — under a strict precedence:
+//!
+//! **wire echo > launch config > disk snapshot**, per field, by
+//! construction: the hydrator merges its two disk layers itself
+//! (recorded launch config beats the transcript) and the hub folds the
+//! result **fill-if-absent** ([`SessionVitalsHub::apply_recovered_facts`]
+//! never overwrites a field a live producer stated), while every live
+//! fold overwrites recovered values and clears their `recovered_at`
+//! stamps. Races between the hydrator and a spawning backend are
+//! harmless in either order.
+//!
+//! Recovered fields carry provenance stamps (`model_recovered_at_epoch`,
+//! `permission_recovered_at_epoch`, the cache/context sections'
+//! `recovered_at_epoch`) so frontends can caveat the chip ("from the
+//! session log as of …"); disk-sourced permission facts keep
+//! `permission_echoed: false`.
+//!
+//! Two call sites hydrate: the boot restore scan (same candidate walk
+//! and newest-N cap as the git-target restore — [`restored_session_candidates`])
+//! and the resume/attach lanes (`session_supervisor/launch.rs`, beside
+//! `seed_resumed_git_vitals_locus`). Both emit
+//! `AppEvent::SessionRecoveredFacts` — hub-internal, no outbound twin,
+//! never persisted — and everything downstream (session-log vitals
+//! rows, `session_state_lines` bootstrap, tunnel, Station, peers)
+//! inherits from the hub's ordinary `SessionVitals` emission.
+//!
+//! This module also owns the hub's account rate-limit window
+//! persistence: the per-account store (account truth that outlives any
+//! session) survives restarts in a small versioned state file, and the
+//! existing `observed_at_epoch` / reset-rollover degradation keeps a
+//! stale restore honest. Reported percentages persist as reported;
+//! nothing is ever synthesized.
+
+use std::collections::{BTreeMap, HashMap};
+use std::path::{Path, PathBuf};
+
+use crate::event::{AppEvent, EventBus};
+use crate::external_agent::AgentBackend;
+use crate::session_config::SessionAgentConfig;
+use crate::session_vitals::{GitVitalsTargets, SessionVitalsHub};
+use crate::types::{
+    SessionCacheVitals, SessionConfigVitals, SessionContextVitals, SessionLimitWindow,
+};
+
+// ---------------------------------------------------------------------------
+// Recovered facts + the hub's fill-if-absent fold
+// ---------------------------------------------------------------------------
+
+/// One session's disk-recovered vitals facts, pre-merged across the two
+/// disk layers (recorded launch config over transcript snapshot) with
+/// every provenance stamp already baked in. Carried by
+/// `AppEvent::SessionRecoveredFacts`.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct RecoveredSessionFacts {
+    /// Backend source ("claude-code", "codex", "kimi") when known — the
+    /// membership key that lets a restored session inherit the account's
+    /// persisted rate-limit windows.
+    pub source: Option<String>,
+    /// Config-section facts; absent fields claim nothing. Recovered
+    /// stamps ride the fields themselves.
+    pub config: SessionConfigVitals,
+    /// Prompt-cache receipt recovered from the transcript's last usage
+    /// record (`recovered_at_epoch` set; `last_activity_epoch` is the
+    /// record's own time, so the client-side TTL countdown reads
+    /// honestly stale).
+    pub cache: Option<SessionCacheVitals>,
+    /// Context footprint recovered from the transcript's last usage
+    /// record (`recovered_at_epoch` set).
+    pub context: Option<SessionContextVitals>,
+}
+
+impl RecoveredSessionFacts {
+    /// Nothing to state: the hydrator skips the emission entirely.
+    pub fn is_empty(&self) -> bool {
+        self.source.is_none()
+            && self.config == SessionConfigVitals::default()
+            && self.cache.is_none()
+            && self.context.is_none()
+    }
+}
+
+impl SessionVitalsHub {
+    /// Fold disk-recovered facts into a session's vitals, fill-if-absent
+    /// per field: a value any live producer already stated — launch
+    /// emission, wire echo, usage fold — is never overwritten, so the
+    /// hydrator can lose every race safely (live folds conversely
+    /// overwrite recovered values and clear their stamps; see
+    /// `apply_config_facts` and the usage listener).
+    ///
+    /// A known `source` additionally records account membership and
+    /// mirrors the account's known rate-limit windows into the session —
+    /// how a restored session inherits the persisted account state
+    /// without waiting for a live `SessionIdentity`.
+    pub(crate) fn apply_recovered_facts(&self, session_id: &str, facts: RecoveredSessionFacts) {
+        if facts.is_empty() {
+            return;
+        }
+        let RecoveredSessionFacts {
+            source,
+            config,
+            cache,
+            context,
+        } = facts;
+        if config != SessionConfigVitals::default() || cache.is_some() || context.is_some() {
+            self.apply(session_id, |vitals| {
+                if config != SessionConfigVitals::default() {
+                    let section = vitals.config.get_or_insert_with(Default::default);
+                    if section.model.is_none() && config.model.is_some() {
+                        section.model = config.model.clone();
+                        section.model_recovered_at_epoch = config.model_recovered_at_epoch;
+                    }
+                    if section.effort.is_none() && config.effort.is_some() {
+                        section.effort = config.effort.clone();
+                    }
+                    if section.permission_mode.is_none() && config.permission_mode.is_some() {
+                        section.permission_mode = config.permission_mode.clone();
+                        section.permission_kind = config.permission_kind.clone();
+                        // Disk facts are never a backend's own voucher.
+                        section.permission_echoed = false;
+                        section.permission_recovered_at_epoch =
+                            config.permission_recovered_at_epoch;
+                    }
+                }
+                if vitals.cache.is_none() {
+                    vitals.cache = cache.clone();
+                }
+                if vitals.context.is_none() {
+                    vitals.context = context.clone();
+                }
+            });
+        }
+        // Membership last, so the mirrored account-limit emission (if
+        // any) already carries the sections filled above.
+        if let Some(source) = source.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+            let canonical = self.resolve(session_id);
+            if !canonical.is_empty() {
+                self.session_sources
+                    .lock()
+                    .expect("vitals source lock")
+                    .insert(canonical, source.to_string());
+                // An empty report mirrors the account's known windows into
+                // the newly joined member (the `link_identity` pattern).
+                self.apply_rate_limit_windows(session_id, Vec::new());
+            }
+        }
+    }
+
+    /// Persist the account rate-limit window store to the hub's state
+    /// file, if one is configured. Serialization happens under the lock
+    /// (the store is a handful of windows); the write itself is handed to
+    /// the blocking pool when a runtime is present, falling back to an
+    /// inline write in plain-sync callers (tests).
+    pub(crate) fn persist_account_limits(&self) {
+        let Some(path) = self.limit_store.clone() else {
+            return;
+        };
+        let snapshot = self
+            .account_limits
+            .lock()
+            .expect("vitals account lock")
+            .clone();
+        let write = move || {
+            if let Err(err) = persist_account_limit_store(&path, &snapshot) {
+                eprintln!("Session vitals: account limit store write failed: {err}");
+            }
+        };
+        if tokio::runtime::Handle::try_current().is_ok() {
+            tokio::task::spawn_blocking(write);
+        } else {
+            write();
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Account rate-limit window persistence
+// ---------------------------------------------------------------------------
+
+/// Store format version this daemon writes. Readers accept exactly this
+/// major shape; unknown FIELDS anywhere are ignored (additive evolution
+/// needs no bump), while a future breaking shape bumps the version and
+/// this reader fails closed to an empty store (windows re-learn on the
+/// next provider report — honest, never corrupting).
+const ACCOUNT_LIMIT_STORE_VERSION: u32 = 1;
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct AccountLimitStoreFile {
+    version: u32,
+    /// Backend source → that account's windows (label-keyed map flattened
+    /// to a list on disk; labels re-key on load).
+    accounts: BTreeMap<String, Vec<SessionLimitWindow>>,
+}
+
+/// Production location of the account rate-limit window store.
+pub(crate) fn account_limit_store_path() -> PathBuf {
+    crate::platform::intendant_home().join("account-rate-limits.json")
+}
+
+/// Load the persisted per-account window store. Missing file, parse
+/// failures, and future-versioned files all read as empty — the store is
+/// a warm-start convenience, never load-bearing state.
+pub(crate) fn load_account_limit_store(
+    path: &Path,
+) -> HashMap<String, BTreeMap<String, SessionLimitWindow>> {
+    let Ok(raw) = std::fs::read_to_string(path) else {
+        return HashMap::new();
+    };
+    let Ok(file) = serde_json::from_str::<AccountLimitStoreFile>(&raw) else {
+        return HashMap::new();
+    };
+    if file.version != ACCOUNT_LIMIT_STORE_VERSION {
+        return HashMap::new();
+    }
+    file.accounts
+        .into_iter()
+        .map(|(source, windows)| {
+            let store: BTreeMap<String, SessionLimitWindow> = windows
+                .into_iter()
+                .filter(|window| !window.label.trim().is_empty())
+                .map(|window| (window.label.trim().to_string(), window))
+                .collect();
+            (source, store)
+        })
+        .filter(|(source, store)| !source.trim().is_empty() && !store.is_empty())
+        .collect()
+}
+
+/// Atomically write the account window store (temp file + rename via the
+/// shared helper). Windows persist exactly as reported — `used_pct`
+/// stays absent when the provider never stated one.
+pub(crate) fn persist_account_limit_store(
+    path: &Path,
+    accounts: &HashMap<String, BTreeMap<String, SessionLimitWindow>>,
+) -> Result<(), String> {
+    let file = AccountLimitStoreFile {
+        version: ACCOUNT_LIMIT_STORE_VERSION,
+        accounts: accounts
+            .iter()
+            .map(|(source, store)| (source.clone(), store.values().cloned().collect()))
+            .collect(),
+    };
+    let json = serde_json::to_string_pretty(&file).map_err(|e| e.to_string())?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    crate::file_watcher::atomic_write(path, json.as_bytes()).map_err(|e| e.to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Claude Code transcript tail extractor
+// ---------------------------------------------------------------------------
+
+/// The last usage entry a transcript records, in the fields the vitals
+/// sections need (verified live against Claude Code 2.1.215–2.1.217
+/// records: `message.usage` with the per-TTL `cache_creation` split).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct RecordedUsage {
+    pub input_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_creation_tokens: u64,
+    pub output_tokens: u64,
+    /// Per-TTL cache-write split (`cache_creation.ephemeral_{5m,1h}_input_tokens`)
+    /// — the cache chip's TTL flavor.
+    pub ephemeral_5m_tokens: u64,
+    pub ephemeral_1h_tokens: u64,
+    /// Epoch seconds of the record carrying this usage, when it stated a
+    /// parseable `timestamp`.
+    pub observed_at_epoch: Option<u64>,
+}
+
+impl RecordedUsage {
+    fn footprint_tokens(&self) -> u64 {
+        self.input_tokens + self.cache_read_tokens + self.cache_creation_tokens + self.output_tokens
+    }
+}
+
+/// Facts one bounded read of a Claude Code transcript yields — the
+/// last-recorded value per field. Absent fields make no claim.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct RecordedSessionFacts {
+    /// `message.model` of the last main-thread assistant record.
+    pub model: Option<String>,
+    /// Top-level `effort` of the last main-thread assistant record
+    /// (transcript-only in 2.1.217 — live stream envelopes don't carry
+    /// it; absent = no claim, never inferred).
+    pub effort: Option<String>,
+    /// Top-level `permissionMode` (user records and the dedicated
+    /// `permission-mode` records).
+    pub permission_mode: Option<String>,
+    /// Last main-thread usage entry with any tokens in it.
+    pub usage: Option<RecordedUsage>,
+    /// Top-level `cwd` of the last record stating one (any record type —
+    /// identical scope to `latest_recorded_cwd`, which resume-locus
+    /// seeding already trusts).
+    pub cwd: Option<String>,
+    /// Epoch seconds of the newest record that contributed any fact —
+    /// the "as of" the recovered chips are caveated with.
+    pub as_of_epoch: Option<u64>,
+}
+
+impl RecordedSessionFacts {
+    fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
+
+    /// Fold one JSONL record, last-writer-wins per field. Sidechain
+    /// records (in-band Task children) are skipped for the session facts
+    /// — a child can run a different model, and its usage is the child's
+    /// context, not the main thread's — but still count for `cwd`.
+    fn fold_record(&mut self, obj: &serde_json::Value) {
+        let record_epoch = obj
+            .get("timestamp")
+            .and_then(|t| t.as_str())
+            .and_then(parse_record_epoch);
+        if let Some(cwd) = obj
+            .get("cwd")
+            .and_then(|c| c.as_str())
+            .map(str::trim)
+            .filter(|c| !c.is_empty())
+        {
+            self.cwd = Some(cwd.to_string());
+            self.as_of_epoch = record_epoch.or(self.as_of_epoch);
+        }
+        if obj.get("isSidechain").and_then(|v| v.as_bool()) == Some(true) {
+            return;
+        }
+        let mut contributed = false;
+        if let Some(mode) = obj
+            .get("permissionMode")
+            .and_then(|m| m.as_str())
+            .map(str::trim)
+            .filter(|m| !m.is_empty())
+        {
+            self.permission_mode = Some(mode.to_string());
+            contributed = true;
+        }
+        if obj.get("type").and_then(|t| t.as_str()) == Some("assistant") {
+            if let Some(model) = obj
+                .get("message")
+                .and_then(|m| m.get("model"))
+                .and_then(|m| m.as_str())
+                .map(str::trim)
+                .filter(|m| !m.is_empty())
+            {
+                self.model = Some(model.to_string());
+                contributed = true;
+            }
+            if let Some(effort) = obj
+                .get("effort")
+                .and_then(|e| e.as_str())
+                .map(str::trim)
+                .filter(|e| !e.is_empty())
+            {
+                self.effort = Some(effort.to_string());
+                contributed = true;
+            }
+            if let Some(usage) = obj
+                .get("message")
+                .and_then(|m| m.get("usage"))
+                .and_then(|usage| recorded_usage_from_value(usage, record_epoch))
+            {
+                self.usage = Some(usage);
+                contributed = true;
+            }
+        }
+        if contributed {
+            self.as_of_epoch = record_epoch.or(self.as_of_epoch);
+        }
+    }
+
+    /// Whether every field the transcript can state is already known —
+    /// the head-window fallback is only read for the remainder.
+    fn saturated(&self) -> bool {
+        self.model.is_some()
+            && self.effort.is_some()
+            && self.permission_mode.is_some()
+            && self.usage.is_some()
+            && self.cwd.is_some()
+    }
+}
+
+/// A `message.usage` object → the recovered-usage fields. All-zero usage
+/// carries no information (synthetic records) and claims nothing.
+fn recorded_usage_from_value(
+    usage: &serde_json::Value,
+    observed_at_epoch: Option<u64>,
+) -> Option<RecordedUsage> {
+    let read = |key: &str| usage.get(key).and_then(|v| v.as_u64()).unwrap_or(0);
+    let ephemeral = |key: &str| {
+        usage
+            .get("cache_creation")
+            .and_then(|c| c.get(key))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0)
+    };
+    let recorded = RecordedUsage {
+        input_tokens: read("input_tokens"),
+        cache_read_tokens: read("cache_read_input_tokens"),
+        cache_creation_tokens: read("cache_creation_input_tokens"),
+        output_tokens: read("output_tokens"),
+        ephemeral_5m_tokens: ephemeral("ephemeral_5m_input_tokens"),
+        ephemeral_1h_tokens: ephemeral("ephemeral_1h_input_tokens"),
+        observed_at_epoch,
+    };
+    (recorded.footprint_tokens() > 0).then_some(recorded)
+}
+
+/// ISO-8601 record timestamp → epoch seconds.
+fn parse_record_epoch(timestamp: &str) -> Option<u64> {
+    chrono::DateTime::parse_from_rfc3339(timestamp.trim())
+        .ok()
+        .map(|dt| dt.timestamp())
+        .filter(|secs| *secs > 0)
+        .map(|secs| secs as u64)
+}
+
+/// Byte windows for the bounded transcript read — the
+/// `latest_recorded_cwd` shape (tail nearly always answers; the head is
+/// the fallback for facts a tail of cwd-less oversized records missed).
+const FACTS_TAIL_BYTES: u64 = 256 * 1024;
+const FACTS_HEAD_BYTES: u64 = 64 * 1024;
+
+/// The most recent session facts a Claude Code transcript records, in
+/// two bounded reads (tail, then a head fallback for still-unknown
+/// fields) — a resume must not pay a full parse of a multi-megabyte
+/// transcript. `None` when the file can't be read or no scanned window
+/// states any fact.
+pub(crate) fn latest_recorded_session_facts(path: &Path) -> Option<RecordedSessionFacts> {
+    use std::io::{Read, Seek, SeekFrom};
+    let mut file = std::fs::File::open(path).ok()?;
+    let len = file.metadata().ok()?.len();
+    let tail_start = len.saturating_sub(FACTS_TAIL_BYTES);
+    file.seek(SeekFrom::Start(tail_start)).ok()?;
+    let mut tail = Vec::new();
+    file.read_to_end(&mut tail).ok()?;
+    // Lossy: a mid-file seek can split a multi-byte character; the
+    // replacement bytes only ever corrupt the partial line the scan
+    // skips anyway.
+    let tail = String::from_utf8_lossy(&tail);
+    let mut facts = fold_facts_in_lines(&tail, tail_start > 0);
+    if tail_start > 0 && !facts.saturated() {
+        let mut head = vec![0u8; FACTS_HEAD_BYTES.min(tail_start) as usize];
+        file.seek(SeekFrom::Start(0)).ok()?;
+        file.read_exact(&mut head).ok()?;
+        let head = String::from_utf8_lossy(&head);
+        let head_facts = fold_facts_in_lines(&head, false);
+        // The tail is newer: head facts only fill fields the tail left
+        // unknown, and never advance the as-of stamp on their own.
+        if facts.model.is_none() {
+            facts.model = head_facts.model;
+        }
+        if facts.effort.is_none() {
+            facts.effort = head_facts.effort;
+        }
+        if facts.permission_mode.is_none() {
+            facts.permission_mode = head_facts.permission_mode;
+        }
+        if facts.usage.is_none() {
+            facts.usage = head_facts.usage;
+        }
+        if facts.cwd.is_none() {
+            facts.cwd = head_facts.cwd;
+        }
+        if facts.as_of_epoch.is_none() {
+            facts.as_of_epoch = head_facts.as_of_epoch;
+        }
+    }
+    (!facts.is_empty()).then_some(facts)
+}
+
+/// Fold the complete JSONL lines of one chunk. `skip_first_line` drops
+/// the leading partial line of a mid-file read; a trailing partial line
+/// simply fails its JSON parse.
+fn fold_facts_in_lines(chunk: &str, skip_first_line: bool) -> RecordedSessionFacts {
+    let mut facts = RecordedSessionFacts::default();
+    let mut lines = chunk.lines();
+    if skip_first_line {
+        let _ = lines.next();
+    }
+    for line in lines {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if let Ok(obj) = serde_json::from_str::<serde_json::Value>(line) {
+            facts.fold_record(&obj);
+        }
+    }
+    facts
+}
+
+// ---------------------------------------------------------------------------
+// Layer merge: recorded launch config over transcript snapshot
+// ---------------------------------------------------------------------------
+
+/// Merge the two disk layers into one recovered-facts payload for a
+/// session of `backend`. Field precedence inside the hydrator: the
+/// wrapper's recorded launch config (what Intendant asked the backend to
+/// run — the same layer a live spawn emission states) beats the
+/// transcript snapshot; the live-wire layer wins later at the hub by
+/// fill-if-absent. Cache/context only ever come from the transcript's
+/// usage record.
+///
+/// Stamps state where a field's value actually came from:
+/// transcript-sourced fields carry the record's as-of epoch;
+/// launch-config-sourced fields carry `launch_config_as_of_epoch` — the
+/// config file's mtime on the boot lane, and `None` on the resume lane
+/// (the effective config computed this instant is current intent, the
+/// same claim the spawn's own launch emission makes moments later, so
+/// no caveat is owed).
+pub(crate) fn recovered_facts_from_layers(
+    backend: &AgentBackend,
+    launch_config: Option<&SessionAgentConfig>,
+    launch_config_as_of_epoch: Option<u64>,
+    recorded: Option<&RecordedSessionFacts>,
+) -> RecoveredSessionFacts {
+    let recorded_as_of = recorded.and_then(|facts| facts.as_of_epoch);
+    let (config_model, config_effort, config_mode): (
+        Option<&String>,
+        Option<&String>,
+        Option<&String>,
+    ) = match (backend, launch_config) {
+        (AgentBackend::ClaudeCode, Some(config)) => (
+            config.claude_model.as_ref(),
+            config.claude_effort.as_ref(),
+            config.claude_permission_mode.as_ref(),
+        ),
+        (AgentBackend::Codex, Some(config)) => (
+            config.codex_model.as_ref(),
+            config.codex_reasoning_effort.as_ref(),
+            None, // sandbox·approval pair handled below
+        ),
+        (AgentBackend::Kimi, Some(config)) => (
+            config.kimi_model.as_ref(),
+            config.kimi_thinking.as_ref(),
+            config.kimi_permission_mode.as_ref(),
+        ),
+        (_, None) => (None, None, None),
+    };
+
+    let mut config = SessionConfigVitals::default();
+    let stamp_for = |from_config: bool| {
+        if from_config {
+            launch_config_as_of_epoch
+        } else {
+            recorded_as_of
+        }
+    };
+
+    let recorded_model = recorded.and_then(|facts| facts.model.as_ref());
+    if let Some(model) = config_model.or(recorded_model) {
+        config.model = Some(model.clone());
+        config.model_recovered_at_epoch = stamp_for(config_model.is_some());
+    }
+    let recorded_effort = recorded.and_then(|facts| facts.effort.as_ref());
+    if let Some(effort) = config_effort.or(recorded_effort) {
+        config.effort = Some(effort.clone());
+    }
+
+    // Permission mode + display kind, per backend vocabulary.
+    match backend {
+        AgentBackend::ClaudeCode => {
+            let recorded_mode = recorded.and_then(|facts| facts.permission_mode.as_ref());
+            if let Some(mode) = config_mode.or(recorded_mode) {
+                config.permission_mode = Some(mode.clone());
+                config.permission_kind =
+                    intendant_core::vitals::claude_permission_kind(mode).map(str::to_string);
+                config.permission_recovered_at_epoch = stamp_for(config_mode.is_some());
+            }
+        }
+        AgentBackend::Codex => {
+            // The launch pair renders exactly like the live launch-facts
+            // emission ("sandbox · approval"); no transcript layer here
+            // (the Codex rollout extractor is a flagged follow-up).
+            let sandbox = launch_config
+                .and_then(|c| c.codex_sandbox.as_deref())
+                .map(str::trim)
+                .unwrap_or_default();
+            let approval = launch_config
+                .and_then(|c| c.codex_approval_policy.as_deref())
+                .map(str::trim)
+                .unwrap_or_default();
+            let mode = match (sandbox.is_empty(), approval.is_empty()) {
+                (true, true) => None,
+                (false, true) => Some(sandbox.to_string()),
+                (true, false) => Some(approval.to_string()),
+                (false, false) => Some(format!("{sandbox} · {approval}")),
+            };
+            if let Some(mode) = mode {
+                config.permission_mode = Some(mode);
+                config.permission_kind =
+                    intendant_core::vitals::codex_permission_kind(approval, sandbox)
+                        .map(str::to_string);
+                config.permission_recovered_at_epoch = stamp_for(true);
+            }
+        }
+        AgentBackend::Kimi => {
+            if let Some(mode) = config_mode {
+                config.permission_mode = Some(mode.clone());
+                config.permission_kind =
+                    crate::external_agent::kimi_code::kimi_permission_kind(mode)
+                        .map(str::to_string);
+                config.permission_recovered_at_epoch = stamp_for(true);
+            }
+        }
+    }
+
+    // Cache + context from the transcript's last usage record.
+    let usage = recorded.and_then(|facts| facts.usage.as_ref());
+    let (cache, context) = usage
+        .map(|usage| {
+            let model = config.model.as_deref().unwrap_or_default();
+            (
+                recovered_cache_vitals(usage),
+                recovered_context_vitals(usage, model),
+            )
+        })
+        .unwrap_or((None, None));
+
+    RecoveredSessionFacts {
+        source: Some(backend_source_name(backend).to_string()),
+        config,
+        cache,
+        context,
+    }
+}
+
+fn backend_source_name(backend: &AgentBackend) -> &'static str {
+    match backend {
+        AgentBackend::ClaudeCode => "claude-code",
+        AgentBackend::Codex => "codex",
+        AgentBackend::Kimi => "kimi",
+    }
+}
+
+/// Cache receipt from a recorded usage entry — the
+/// `cache_vitals_from_usage` formula over transcript fields. The TTL
+/// flavor comes from the per-TTL split when it states one; a flat write
+/// or a bare read falls back to the Anthropic 5-minute default (the
+/// transcript is always an Anthropic backend). `last_activity_epoch` is
+/// the record's own time — the client countdown then reads honestly
+/// stale/cold instead of restarting.
+fn recovered_cache_vitals(usage: &RecordedUsage) -> Option<SessionCacheVitals> {
+    let sample_total = usage.cache_read_tokens + usage.cache_creation_tokens + usage.input_tokens;
+    if sample_total == 0 {
+        return None;
+    }
+    // Floor, never round — 100 must mean fully cache-served.
+    let hit_pct = ((usage.cache_read_tokens * 100) / sample_total).min(100) as u8;
+    let ttl_seconds = if usage.ephemeral_1h_tokens > 0 {
+        Some(3600)
+    } else if usage.ephemeral_5m_tokens > 0
+        || usage.cache_creation_tokens > 0
+        || usage.cache_read_tokens > 0
+    {
+        // A stated 5m split, a flat write, and a bare read all resolve to
+        // the Anthropic 5-minute default.
+        Some(300)
+    } else {
+        None
+    };
+    let observed = usage.observed_at_epoch?;
+    Some(SessionCacheVitals {
+        hit_pct: Some(hit_pct),
+        last_activity_epoch: observed,
+        ttl_seconds,
+        recovered_at_epoch: Some(observed),
+    })
+}
+
+/// Context footprint from a recorded usage entry — the live formula
+/// (tokens = input + cache reads + cache writes + output; pct clamped by
+/// the effective window) against the model family's known window, so a
+/// 1M-window session never reads >100% against the 200k default.
+fn recovered_context_vitals(usage: &RecordedUsage, model: &str) -> Option<SessionContextVitals> {
+    let tokens_used = usage.footprint_tokens();
+    if tokens_used == 0 {
+        return None;
+    }
+    let window = crate::external_agent::claude_code::claude_model_context_window(model)
+        .unwrap_or(crate::external_agent::claude_code::DEFAULT_CONTEXT_WINDOW);
+    let effective_window = window.max(tokens_used);
+    let usage_pct = (tokens_used as f64 / effective_window as f64) * 100.0;
+    let observed = usage.observed_at_epoch?;
+    Some(SessionContextVitals {
+        tokens_used,
+        context_window: effective_window,
+        usage_pct,
+        observed_at_epoch: observed,
+        recovered_at_epoch: Some(observed),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Hydration call sites
+// ---------------------------------------------------------------------------
+
+/// One restored-session candidate from the on-disk session store.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RestoredSessionCandidate {
+    pub session_id: String,
+    /// Effective probe root: the worktree checkout for worktree
+    /// sessions, else the recorded project root.
+    pub root: PathBuf,
+}
+
+/// Cap on boot-time restoration. A long-lived store accumulates
+/// thousands of non-ended session dirs (a real store measured ~2.1k
+/// across ~100 distinct roots); the newest N by meta mtime cover the
+/// session windows a dashboard realistically shows, and older idle
+/// sessions regain their chips the moment they are resumed. Both boot
+/// restore lanes — git-target registration and vitals hydration — run
+/// over exactly this candidate list, so their coverage can't drift.
+pub(crate) const RESTORED_TARGET_CAP: usize = 64;
+
+/// Walk the session store for restore candidates: non-ended sessions
+/// (scope mirrors the `SessionEnded` prune — a `completed` meta ended
+/// before the restart), newest [`RESTORED_TARGET_CAP`] by meta mtime
+/// (re-stamped on every lifecycle transition), worktree sessions keyed
+/// by their checkout. Synchronous filesystem walk — call it from a
+/// blocking context.
+pub(crate) fn restored_session_candidates(home: &Path) -> Vec<RestoredSessionCandidate> {
+    let logs_dir = crate::platform::intendant_home_in(home).join("logs");
+    let Ok(entries) = std::fs::read_dir(&logs_dir) else {
+        return Vec::new();
+    };
+    let mut restored: Vec<(std::time::SystemTime, RestoredSessionCandidate)> = Vec::new();
+    for entry in entries.flatten() {
+        let meta_path = entry.path().join("session_meta.json");
+        let Ok(raw) = std::fs::read_to_string(&meta_path) else {
+            continue;
+        };
+        let Ok(meta) = serde_json::from_str::<crate::session_log::SessionMeta>(&raw) else {
+            continue;
+        };
+        // Parity with the SessionEnded prune: completed = ended.
+        if meta.status.as_deref() == Some("completed") {
+            continue;
+        }
+        let root = meta
+            .worktree
+            .as_ref()
+            .map(|worktree| worktree.path.clone())
+            .or(meta.project_root);
+        let Some(root) = root.filter(|root| !root.trim().is_empty()) else {
+            continue;
+        };
+        let session_id = meta.session_id.trim().to_string();
+        if session_id.is_empty() {
+            continue;
+        }
+        let mtime = meta_path
+            .metadata()
+            .and_then(|m| m.modified())
+            .unwrap_or(std::time::UNIX_EPOCH);
+        restored.push((
+            mtime,
+            RestoredSessionCandidate {
+                session_id,
+                root: PathBuf::from(root),
+            },
+        ));
+    }
+    // Newest first; the cap keeps probe work and emission fan-out bounded.
+    restored.sort_by_key(|entry| std::cmp::Reverse(entry.0));
+    restored
+        .into_iter()
+        .take(RESTORED_TARGET_CAP)
+        .map(|(_, candidate)| candidate)
+        .collect()
+}
+
+/// The boot restore pass: one candidate walk feeding both restore lanes
+/// — git-target registration (insert-if-absent, exactly
+/// `register_restored_session_targets`) and vitals hydration for each
+/// candidate's wrapper dir. Returns (targets registered, sessions
+/// hydrated). Synchronous — the boot call sites run it on the blocking
+/// pool.
+pub(crate) fn restore_session_vitals_at_boot(
+    home: &Path,
+    registry: &GitVitalsTargets,
+    bus: &EventBus,
+) -> (usize, usize) {
+    let candidates = restored_session_candidates(home);
+    let registered = candidates
+        .iter()
+        .filter(|candidate| {
+            registry.register_restored(&candidate.session_id, candidate.root.clone())
+        })
+        .count();
+    let mut hydrated = 0usize;
+    for candidate in &candidates {
+        let facts = recover_wrapper_session_facts(home, &candidate.session_id);
+        let Some((facts, cwd)) = facts else {
+            continue;
+        };
+        // First-hand locus seed, exactly like the resume lane: the
+        // transcript's recorded cwd is where the session actually works
+        // (a worktree the registered root knows nothing about).
+        if let Some(cwd) = cwd.as_deref() {
+            registry.seed_locus(&candidate.session_id, Path::new(cwd));
+        }
+        if !facts.is_empty() {
+            hydrated += 1;
+            bus.send(AppEvent::SessionRecoveredFacts {
+                session_id: Some(candidate.session_id.clone()),
+                facts: Box::new(facts),
+            });
+        }
+    }
+    (registered, hydrated)
+}
+
+/// Disk recovery for one wrapper session dir: the recorded launch config
+/// (`session_agent_config.json`), the wrapper-index mapping to the
+/// backend conversation, and — for Claude Code — the transcript tail.
+/// Returns the merged facts plus the transcript's recorded cwd (the
+/// boot locus seed). `None` when the wrapper resolves to no external
+/// backend (native sessions have no disk layer beyond what the daemon
+/// already replays).
+fn recover_wrapper_session_facts(
+    home: &Path,
+    wrapper_session_id: &str,
+) -> Option<(RecoveredSessionFacts, Option<String>)> {
+    let log_dir = crate::platform::intendant_home_in(home)
+        .join("logs")
+        .join(wrapper_session_id);
+    let launch_config = crate::session_config::read_log_dir_config(&log_dir);
+    let config_as_of = launch_config.as_ref().and_then(|_| {
+        log_dir
+            .join(crate::session_config::SESSION_AGENT_CONFIG_FILE)
+            .metadata()
+            .ok()
+            .and_then(|meta| meta.modified().ok())
+            .and_then(|mtime| mtime.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|age| age.as_secs())
+    });
+    let conversation =
+        crate::external_wrapper_index::conversation_for_wrapper(home, wrapper_session_id);
+    let source = conversation
+        .as_ref()
+        .map(|(source, _)| source.clone())
+        .or_else(|| {
+            launch_config
+                .as_ref()
+                .and_then(|config| config.source.clone())
+        });
+    let backend = crate::external_agent::AgentBackend::from_str_loose(source.as_deref()?)?;
+    let recorded = match (&backend, conversation.as_ref()) {
+        (AgentBackend::ClaudeCode, Some((_, backend_session_id))) => {
+            crate::web_gateway::find_claude_session_file(home, backend_session_id)
+                .and_then(|transcript| latest_recorded_session_facts(&transcript))
+        }
+        _ => None,
+    };
+    let cwd = recorded.as_ref().and_then(|facts| facts.cwd.clone());
+    let facts = recovered_facts_from_layers(
+        &backend,
+        launch_config.as_ref(),
+        config_as_of,
+        recorded.as_ref(),
+    );
+    Some((facts, cwd))
+}
+
+/// The resume/attach hydration lane, called beside
+/// `seed_resumed_git_vitals_locus` with the just-computed effective
+/// launch config: reads the backend transcript tail (Claude Code) off
+/// the blocking pool and emits the merged recovered facts keyed exactly
+/// like the lane's git-vitals registration. Fire-and-forget — the live
+/// spawn's own launch emission and echoes win any race by construction.
+pub(crate) fn hydrate_resumed_session_vitals(
+    bus: EventBus,
+    home: PathBuf,
+    vitals_session_id: String,
+    backend: AgentBackend,
+    resume_token: String,
+    launch_config: Option<SessionAgentConfig>,
+) {
+    if vitals_session_id.trim().is_empty() {
+        return;
+    }
+    let work = move || {
+        let recorded = match &backend {
+            AgentBackend::ClaudeCode => {
+                let token = resume_token.trim();
+                if token.is_empty() {
+                    None
+                } else {
+                    crate::web_gateway::find_claude_session_file(&home, token)
+                        .and_then(|transcript| latest_recorded_session_facts(&transcript))
+                }
+            }
+            // Codex/Kimi: launch-config layer only (transcript extractors
+            // are a flagged follow-up).
+            _ => None,
+        };
+        let facts = recovered_facts_from_layers(
+            &backend,
+            launch_config.as_ref(),
+            // The effective config was computed this instant — current
+            // intent, not a disk snapshot: no stamp (see
+            // `recovered_facts_from_layers`).
+            None,
+            recorded.as_ref(),
+        );
+        if !facts.is_empty() {
+            bus.send(AppEvent::SessionRecoveredFacts {
+                session_id: Some(vitals_session_id),
+                facts: Box::new(facts),
+            });
+        }
+    };
+    if tokio::runtime::Handle::try_current().is_ok() {
+        tokio::task::spawn_blocking(work);
+    } else {
+        work();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session_vitals::spawn_cache_vitals_listener;
+
+    // Fixture lines shaped from live Claude Code 2.1.215–2.1.217 records
+    // (synthetic values — no real transcript bytes committed).
+    fn assistant_line(model: &str, effort: &str, ts: &str, sidechain: bool) -> String {
+        format!(
+            concat!(
+                r#"{{"parentUuid":"p1","isSidechain":{sidechain},"type":"assistant","effort":"{effort}","#,
+                r#""cwd":"/repo","sessionId":"cc-1","version":"2.1.217","gitBranch":"main","#,
+                r#""uuid":"u1","timestamp":"{ts}","requestId":"req_1","#,
+                r#""message":{{"id":"msg_1","type":"message","role":"assistant","model":"{model}","#,
+                r#""content":[{{"type":"text","text":"ok"}}],"stop_reason":"end_turn","#,
+                r#""usage":{{"input_tokens":2,"cache_creation_input_tokens":3240,"cache_read_input_tokens":55796,"#,
+                r#""output_tokens":521,"cache_creation":{{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":3240}}}}}}}}"#,
+            ),
+            sidechain = sidechain,
+            effort = effort,
+            ts = ts,
+            model = model,
+        )
+    }
+
+    fn user_line(mode: &str, cwd: &str, ts: &str) -> String {
+        format!(
+            concat!(
+                r#"{{"parentUuid":null,"isSidechain":false,"type":"user","permissionMode":"{mode}","#,
+                r#""cwd":"{cwd}","sessionId":"cc-1","version":"2.1.217","timestamp":"{ts}","#,
+                r#""message":{{"role":"user","content":"do the thing"}}}}"#,
+            ),
+            mode = mode,
+            cwd = cwd,
+            ts = ts,
+        )
+    }
+
+    /// The extractor folds model / top-level effort / permissionMode /
+    /// last usage (with the per-TTL split) / cwd / record timestamp,
+    /// last-writer-wins, skipping sidechain records for session facts.
+    #[test]
+    fn extractor_reads_the_live_record_shape() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("t.jsonl");
+        let mut lines = Vec::new();
+        lines.push(user_line("default", "/repo", "2026-07-22T07:00:00.000Z"));
+        lines.push(assistant_line(
+            "claude-haiku-4-5",
+            "low",
+            "2026-07-22T07:10:00.000Z",
+            false,
+        ));
+        // Dedicated permission-mode record (no timestamp on the live shape).
+        lines.push(
+            r#"{"type":"permission-mode","permissionMode":"bypassPermissions","sessionId":"cc-1"}"#
+                .to_string(),
+        );
+        // A sidechain Task child on another model must not claim the facts.
+        lines.push(assistant_line(
+            "claude-haiku-4-5-child",
+            "high",
+            "2026-07-22T07:20:00.000Z",
+            true,
+        ));
+        // Malformed line: skipped, never aborts the fold.
+        lines.push("{not json".to_string());
+        lines.push(assistant_line(
+            "claude-fable-5",
+            "xhigh",
+            "2026-07-22T07:53:52.991Z",
+            false,
+        ));
+        std::fs::write(&path, lines.join("\n") + "\n").unwrap();
+
+        let facts = latest_recorded_session_facts(&path).expect("facts");
+        assert_eq!(facts.model.as_deref(), Some("claude-fable-5"));
+        assert_eq!(facts.effort.as_deref(), Some("xhigh"));
+        assert_eq!(facts.permission_mode.as_deref(), Some("bypassPermissions"));
+        assert_eq!(facts.cwd.as_deref(), Some("/repo"));
+        let usage = facts.usage.as_ref().expect("usage");
+        assert_eq!(usage.input_tokens, 2);
+        assert_eq!(usage.cache_read_tokens, 55_796);
+        assert_eq!(usage.cache_creation_tokens, 3_240);
+        assert_eq!(usage.output_tokens, 521);
+        assert_eq!(usage.ephemeral_1h_tokens, 3_240);
+        assert_eq!(usage.ephemeral_5m_tokens, 0);
+        let as_of = facts.as_of_epoch.expect("as-of stamp");
+        assert_eq!(usage.observed_at_epoch, Some(as_of));
+        let parsed = chrono::DateTime::parse_from_rfc3339("2026-07-22T07:53:52.991Z").unwrap();
+        assert_eq!(as_of, parsed.timestamp() as u64);
+    }
+
+    /// Absent fields claim nothing: a transcript with no effort / usage /
+    /// mode yields None for exactly those fields, and an empty or missing
+    /// file yields no facts at all.
+    #[test]
+    fn extractor_absent_fields_make_no_claims() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("t.jsonl");
+        std::fs::write(
+            &path,
+            concat!(
+                // Assistant record without effort/usage (older CLIs).
+                r#"{"type":"assistant","cwd":"/repo","timestamp":"2026-07-22T07:00:00Z","#,
+                r#""message":{"role":"assistant","model":"claude-haiku-4-5","content":[]}}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+        let facts = latest_recorded_session_facts(&path).expect("facts");
+        assert_eq!(facts.model.as_deref(), Some("claude-haiku-4-5"));
+        assert_eq!(facts.effort, None, "no effort recorded — no claim");
+        assert_eq!(facts.permission_mode, None);
+        assert_eq!(facts.usage, None);
+
+        std::fs::write(&path, "").unwrap();
+        assert_eq!(latest_recorded_session_facts(&path), None);
+        assert_eq!(
+            latest_recorded_session_facts(&dir.path().join("gone.jsonl")),
+            None
+        );
+    }
+
+    /// The head window fills only fields a fact-less oversized tail
+    /// missed (the `latest_recorded_cwd` shape).
+    #[test]
+    fn extractor_scans_tail_then_head() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("t.jsonl");
+        let mut contents = user_line("plan", "/repo", "2026-07-22T06:00:00Z");
+        contents.push('\n');
+        contents.push_str(&format!(
+            "{{\"type\":\"attachment\",\"blob\":\"{}\"}}\n",
+            "x".repeat((FACTS_TAIL_BYTES + 4096) as usize)
+        ));
+        std::fs::write(&path, contents).unwrap();
+        let facts = latest_recorded_session_facts(&path).expect("facts");
+        assert_eq!(
+            facts.permission_mode.as_deref(),
+            Some("plan"),
+            "head fallback covers a fact-less tail window"
+        );
+        assert_eq!(facts.cwd.as_deref(), Some("/repo"));
+    }
+
+    /// Layer precedence inside the hydrator: the recorded launch config
+    /// beats the transcript per field; the transcript fills the rest;
+    /// stamps state each field's actual source (config mtime vs record
+    /// time), and cache/context only ever derive from the transcript.
+    #[test]
+    fn layer_merge_config_beats_transcript_per_field() {
+        let recorded = RecordedSessionFacts {
+            model: Some("claude-haiku-4-5".into()),
+            effort: Some("low".into()),
+            permission_mode: Some("default".into()),
+            usage: Some(RecordedUsage {
+                input_tokens: 2,
+                cache_read_tokens: 55_796,
+                cache_creation_tokens: 3_240,
+                output_tokens: 521,
+                ephemeral_5m_tokens: 0,
+                ephemeral_1h_tokens: 3_240,
+                observed_at_epoch: Some(1_000_000),
+            }),
+            cwd: Some("/repo".into()),
+            as_of_epoch: Some(1_000_000),
+        };
+        // Config states model + mode; effort comes from the transcript.
+        let config = SessionAgentConfig {
+            claude_model: Some("claude-fable-5".into()),
+            claude_permission_mode: Some("bypassPermissions".into()),
+            ..Default::default()
+        };
+        let facts = recovered_facts_from_layers(
+            &AgentBackend::ClaudeCode,
+            Some(&config),
+            Some(2_000_000),
+            Some(&recorded),
+        );
+        assert_eq!(facts.source.as_deref(), Some("claude-code"));
+        assert_eq!(facts.config.model.as_deref(), Some("claude-fable-5"));
+        assert_eq!(
+            facts.config.model_recovered_at_epoch,
+            Some(2_000_000),
+            "config-sourced model stamps with the config's as-of"
+        );
+        assert_eq!(facts.config.effort.as_deref(), Some("low"));
+        assert_eq!(
+            facts.config.permission_mode.as_deref(),
+            Some("bypassPermissions")
+        );
+        assert_eq!(
+            facts.config.permission_kind.as_deref(),
+            Some(intendant_core::vitals::PERMISSION_KIND_BYPASS)
+        );
+        assert!(!facts.config.permission_echoed);
+        assert_eq!(facts.config.permission_recovered_at_epoch, Some(2_000_000));
+
+        // Cache: 55796 / (55796+3240+2) floor = 94%; 1h split → 3600.
+        let cache = facts.cache.as_ref().expect("cache");
+        assert_eq!(cache.hit_pct, Some(94));
+        assert_eq!(cache.ttl_seconds, Some(3600));
+        assert_eq!(cache.last_activity_epoch, 1_000_000);
+        assert_eq!(cache.recovered_at_epoch, Some(1_000_000));
+
+        // Context: fable-5 → 1M window from the model-family table.
+        let context = facts.context.as_ref().expect("context");
+        assert_eq!(context.tokens_used, 2 + 55_796 + 3_240 + 521);
+        assert_eq!(context.context_window, 1_000_000);
+        assert!(context.usage_pct > 5.9 && context.usage_pct < 6.0);
+        assert_eq!(context.observed_at_epoch, 1_000_000);
+        assert_eq!(context.recovered_at_epoch, Some(1_000_000));
+
+        // Transcript-only merge (no config): transcript fields stamped
+        // with the record time.
+        let facts =
+            recovered_facts_from_layers(&AgentBackend::ClaudeCode, None, None, Some(&recorded));
+        assert_eq!(facts.config.model.as_deref(), Some("claude-haiku-4-5"));
+        assert_eq!(facts.config.model_recovered_at_epoch, Some(1_000_000));
+        assert_eq!(facts.config.permission_mode.as_deref(), Some("default"));
+        assert_eq!(
+            facts.config.permission_kind.as_deref(),
+            Some(intendant_core::vitals::PERMISSION_KIND_ASK)
+        );
+
+        // Resume lane (config as-of None): config-sourced fields carry no
+        // stamp — current intent, not a disk snapshot.
+        let facts = recovered_facts_from_layers(
+            &AgentBackend::ClaudeCode,
+            Some(&config),
+            None,
+            Some(&recorded),
+        );
+        assert_eq!(facts.config.model_recovered_at_epoch, None);
+        assert_eq!(facts.config.effort.as_deref(), Some("low"));
+    }
+
+    /// A footprint above the family window clamps by widening the
+    /// effective window (the live meter's rule) — never >100%.
+    #[test]
+    fn recovered_context_clamps_against_the_family_window() {
+        let usage = RecordedUsage {
+            input_tokens: 250_000,
+            output_tokens: 1_000,
+            observed_at_epoch: Some(5),
+            ..Default::default()
+        };
+        let context = recovered_context_vitals(&usage, "claude-haiku-4-5").expect("context");
+        assert_eq!(context.context_window, 251_000, "window widened to fit");
+        assert!((context.usage_pct - 100.0).abs() < f64::EPSILON);
+        // Unknown model family: the 200k default applies.
+        let small = RecordedUsage {
+            input_tokens: 50_000,
+            observed_at_epoch: Some(5),
+            ..Default::default()
+        };
+        let context = recovered_context_vitals(&small, "mystery-model").expect("context");
+        assert_eq!(context.context_window, 200_000);
+        assert!((context.usage_pct - 25.0).abs() < 0.01);
+    }
+
+    /// Codex/Kimi launch-config layers map their own vocabulary
+    /// (sandbox·approval join, kimi thinking-as-effort) with recovered
+    /// stamps; no transcript layer exists for them yet.
+    #[test]
+    fn layer_merge_codex_and_kimi_config_layers() {
+        let config = SessionAgentConfig {
+            codex_model: Some("gpt-5.5-codex".into()),
+            codex_reasoning_effort: Some("high".into()),
+            codex_sandbox: Some("workspace-write".into()),
+            codex_approval_policy: Some("on-request".into()),
+            ..Default::default()
+        };
+        let facts = recovered_facts_from_layers(&AgentBackend::Codex, Some(&config), Some(7), None);
+        assert_eq!(facts.source.as_deref(), Some("codex"));
+        assert_eq!(facts.config.model.as_deref(), Some("gpt-5.5-codex"));
+        assert_eq!(facts.config.effort.as_deref(), Some("high"));
+        assert_eq!(
+            facts.config.permission_mode.as_deref(),
+            Some("workspace-write · on-request")
+        );
+        assert_eq!(
+            facts.config.permission_kind.as_deref(),
+            Some(intendant_core::vitals::PERMISSION_KIND_AUTO_SANDBOXED)
+        );
+        assert_eq!(facts.config.permission_recovered_at_epoch, Some(7));
+        assert!(facts.cache.is_none());
+        assert!(facts.context.is_none());
+
+        let config = SessionAgentConfig {
+            kimi_model: Some("kimi-k2.5".into()),
+            kimi_thinking: Some("on".into()),
+            kimi_permission_mode: Some("yolo".into()),
+            ..Default::default()
+        };
+        let facts = recovered_facts_from_layers(&AgentBackend::Kimi, Some(&config), Some(9), None);
+        assert_eq!(facts.source.as_deref(), Some("kimi"));
+        assert_eq!(facts.config.model.as_deref(), Some("kimi-k2.5"));
+        assert_eq!(facts.config.effort.as_deref(), Some("on"));
+        assert_eq!(
+            facts.config.permission_kind.as_deref(),
+            Some(intendant_core::vitals::PERMISSION_KIND_BYPASS)
+        );
+
+        // No layers at all: only the source remains, and the emission is
+        // still useful (account-limit membership).
+        let facts = recovered_facts_from_layers(&AgentBackend::Codex, None, None, None);
+        assert!(!facts.is_empty());
+        assert_eq!(facts.source.as_deref(), Some("codex"));
+        assert_eq!(facts.config, SessionConfigVitals::default());
+    }
+
+    fn recovered_cc_facts(as_of: u64) -> RecoveredSessionFacts {
+        RecoveredSessionFacts {
+            source: Some("claude-code".into()),
+            config: SessionConfigVitals {
+                model: Some("claude-fable-5".into()),
+                effort: Some("xhigh".into()),
+                permission_mode: Some("bypassPermissions".into()),
+                permission_kind: Some(intendant_core::vitals::PERMISSION_KIND_BYPASS.into()),
+                permission_echoed: false,
+                model_recovered_at_epoch: Some(as_of),
+                permission_recovered_at_epoch: Some(as_of),
+            },
+            cache: Some(SessionCacheVitals {
+                hit_pct: Some(94),
+                last_activity_epoch: as_of,
+                ttl_seconds: Some(3600),
+                recovered_at_epoch: Some(as_of),
+            }),
+            context: Some(SessionContextVitals {
+                tokens_used: 59_559,
+                context_window: 1_000_000,
+                usage_pct: 5.9559,
+                observed_at_epoch: as_of,
+                recovered_at_epoch: Some(as_of),
+            }),
+        }
+    }
+
+    /// Recovered-then-live: the hydrator fills empty sections (stamped),
+    /// and every later live fold overwrites its field and clears the
+    /// stamp — the race is harmless in this order.
+    #[tokio::test]
+    async fn recovered_then_live_overwrites_and_clears_stamps() {
+        let bus = EventBus::new();
+        let hub = SessionVitalsHub::new(bus.clone());
+        let _listener = spawn_cache_vitals_listener(bus.clone(), hub.clone());
+        let mut rx = bus.subscribe();
+        let deadline = std::time::Duration::from_secs(5);
+
+        async fn wait_vitals(
+            rx: &mut tokio::sync::broadcast::Receiver<AppEvent>,
+        ) -> crate::types::SessionVitals {
+            loop {
+                if let Ok(AppEvent::SessionVitals { vitals, .. }) = rx.recv().await {
+                    return vitals;
+                }
+            }
+        }
+
+        bus.send(AppEvent::SessionRecoveredFacts {
+            session_id: Some("cc-1".into()),
+            facts: Box::new(recovered_cc_facts(1_000_000)),
+        });
+        let vitals = tokio::time::timeout(deadline, wait_vitals(&mut rx))
+            .await
+            .expect("recovered emission");
+        let config = vitals.config.as_ref().expect("config");
+        assert_eq!(config.model.as_deref(), Some("claude-fable-5"));
+        assert_eq!(config.model_recovered_at_epoch, Some(1_000_000));
+        assert_eq!(config.permission_recovered_at_epoch, Some(1_000_000));
+        assert!(!config.permission_echoed);
+        assert_eq!(
+            vitals.context.as_ref().and_then(|c| c.recovered_at_epoch),
+            Some(1_000_000)
+        );
+
+        // Live model echo: overwrites the model, clears ITS stamp only.
+        bus.send(AppEvent::SessionConfigFacts {
+            session_id: Some("cc-1".into()),
+            facts: SessionConfigVitals {
+                model: Some("claude-mythos-5".into()),
+                ..Default::default()
+            },
+        });
+        let vitals = tokio::time::timeout(deadline, wait_vitals(&mut rx))
+            .await
+            .expect("model echo emission");
+        let config = vitals.config.as_ref().expect("config");
+        assert_eq!(config.model.as_deref(), Some("claude-mythos-5"));
+        assert_eq!(config.model_recovered_at_epoch, None, "live fold clears");
+        assert_eq!(
+            config.permission_recovered_at_epoch,
+            Some(1_000_000),
+            "untouched fields keep their stamps"
+        );
+
+        // Live permission echo: clears the permission stamp and vouches.
+        bus.send(AppEvent::SessionConfigFacts {
+            session_id: Some("cc-1".into()),
+            facts: SessionConfigVitals {
+                permission_mode: Some("bypassPermissions".into()),
+                permission_kind: Some(intendant_core::vitals::PERMISSION_KIND_BYPASS.into()),
+                permission_echoed: true,
+                ..Default::default()
+            },
+        });
+        let vitals = tokio::time::timeout(deadline, wait_vitals(&mut rx))
+            .await
+            .expect("mode echo emission");
+        let config = vitals.config.as_ref().expect("config");
+        assert!(config.permission_echoed);
+        assert_eq!(config.permission_recovered_at_epoch, None);
+
+        // Live usage: overwrites cache AND context, clearing both stamps.
+        bus.send(AppEvent::UsageSnapshot {
+            session_id: Some("cc-1".into()),
+            main: crate::frontend::ModelUsageSnapshot {
+                provider: "anthropic".into(),
+                model: "claude-mythos-5".into(),
+                tokens_used: 70_000,
+                context_window: 1_000_000,
+                hard_context_window: Some(1_000_000),
+                usage_pct: 7.0,
+                prompt_tokens: 69_000,
+                completion_tokens: 1_000,
+                cached_tokens: 60_000,
+                cache_creation_tokens: 2_000,
+                last_cache_read_tokens: 60_000,
+                last_cache_creation_tokens: 2_000,
+                last_uncached_input_tokens: 7_000,
+                cache_ttl_seconds: Some(300),
+                limits: Vec::new(),
+            },
+            presence: None,
+        });
+        let vitals = tokio::time::timeout(deadline, wait_vitals(&mut rx))
+            .await
+            .expect("usage emission");
+        let context = vitals.context.as_ref().expect("context");
+        assert_eq!(context.tokens_used, 70_000);
+        assert_eq!(context.recovered_at_epoch, None, "live usage clears");
+        assert!((context.usage_pct - 7.0).abs() < f64::EPSILON);
+        assert_eq!(
+            vitals.cache.as_ref().and_then(|c| c.recovered_at_epoch),
+            None,
+            "live cache fold clears"
+        );
+    }
+
+    /// Live-then-recovered: everything a live producer stated survives
+    /// the hydrator untouched (fill-if-absent) — the race is harmless in
+    /// this order too. Only genuinely absent fields fill.
+    #[tokio::test]
+    async fn live_then_recovered_fills_only_absent_fields() {
+        let bus = EventBus::new();
+        let hub = SessionVitalsHub::new(bus.clone());
+
+        // Live launch facts: model + mode (no effort — CC 2.1.2xx echoes
+        // none), live usage context.
+        hub.apply_config_facts(
+            "cc-1",
+            SessionConfigVitals {
+                model: Some("claude-mythos-5".into()),
+                permission_mode: Some("plan".into()),
+                permission_kind: Some(intendant_core::vitals::PERMISSION_KIND_PLAN.into()),
+                permission_echoed: true,
+                ..Default::default()
+            },
+        );
+        hub.apply("cc-1", |vitals| {
+            vitals.context = Some(SessionContextVitals {
+                tokens_used: 70_000,
+                context_window: 1_000_000,
+                usage_pct: 7.0,
+                observed_at_epoch: 2_000_000,
+                recovered_at_epoch: None,
+            });
+        });
+
+        hub.apply_recovered_facts("cc-1", recovered_cc_facts(1_000_000));
+
+        let vitals = hub
+            .sessions
+            .lock()
+            .expect("vitals state lock")
+            .get("cc-1")
+            .cloned()
+            .expect("entry");
+        let config = vitals.config.as_ref().expect("config");
+        assert_eq!(
+            config.model.as_deref(),
+            Some("claude-mythos-5"),
+            "live model survives the hydrator"
+        );
+        assert_eq!(config.model_recovered_at_epoch, None);
+        assert_eq!(config.permission_mode.as_deref(), Some("plan"));
+        assert!(config.permission_echoed, "live voucher survives");
+        assert_eq!(config.permission_recovered_at_epoch, None);
+        // Effort was absent live → the recovered value fills.
+        assert_eq!(config.effort.as_deref(), Some("xhigh"));
+        // Context was live → recovered context ignored.
+        let context = vitals.context.as_ref().expect("context");
+        assert_eq!(context.tokens_used, 70_000);
+        assert_eq!(context.recovered_at_epoch, None);
+        // Cache was absent → recovered cache fills, stamped.
+        assert_eq!(
+            vitals.cache.as_ref().and_then(|c| c.recovered_at_epoch),
+            Some(1_000_000)
+        );
+    }
+
+    /// The account limit store round-trips through its state file,
+    /// tolerates unknown fields (additive forward-compat), fails closed
+    /// on a future version, and never invents percentages.
+    #[test]
+    fn limit_store_round_trip_and_forward_compat() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("account-rate-limits.json");
+        let mut accounts: HashMap<String, BTreeMap<String, SessionLimitWindow>> = HashMap::new();
+        let mut store = BTreeMap::new();
+        store.insert(
+            "5h".to_string(),
+            SessionLimitWindow {
+                label: "5h".into(),
+                used_pct: None,
+                resets_at_epoch: Some(1_784_503_200),
+                status: Some("allowed_warning".into()),
+                observed_at_epoch: Some(1_784_499_000),
+            },
+        );
+        accounts.insert("claude-code".to_string(), store);
+        persist_account_limit_store(&path, &accounts).expect("persist");
+
+        let loaded = load_account_limit_store(&path);
+        assert_eq!(loaded, accounts, "round-trip is lossless");
+        let window = &loaded["claude-code"]["5h"];
+        assert_eq!(window.used_pct, None, "unreported percentage stays absent");
+        assert_eq!(window.observed_at_epoch, Some(1_784_499_000));
+
+        // Additive forward-compat: unknown fields anywhere are ignored.
+        let raw = std::fs::read_to_string(&path).unwrap();
+        let mut value: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        value["future_top_level"] = serde_json::json!({"x": 1});
+        value["accounts"]["claude-code"][0]["futureField"] = serde_json::json!(true);
+        std::fs::write(&path, serde_json::to_string(&value).unwrap()).unwrap();
+        let loaded = load_account_limit_store(&path);
+        assert_eq!(loaded["claude-code"]["5h"].label, "5h");
+
+        // A future breaking version fails closed to empty.
+        value["version"] = serde_json::json!(2);
+        std::fs::write(&path, serde_json::to_string(&value).unwrap()).unwrap();
+        assert!(load_account_limit_store(&path).is_empty());
+
+        // Missing / corrupt files read as empty.
+        assert!(load_account_limit_store(&dir.path().join("gone.json")).is_empty());
+        std::fs::write(&path, "{").unwrap();
+        assert!(load_account_limit_store(&path).is_empty());
+    }
+
+    /// End-to-end persistence: a report through one hub lands in the
+    /// state file; a second hub restores it at construction; recovered
+    /// facts with a source mirror the restored account view into the
+    /// session — and the restored windows keep their honest stamps.
+    #[tokio::test]
+    async fn limit_store_survives_a_hub_restart_and_mirrors_to_recovered_sessions() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("account-rate-limits.json");
+        let bus = EventBus::new();
+        let hub = SessionVitalsHub::with_limit_store(bus.clone(), Some(path.clone()));
+        // Session of the claude-code account reports a window.
+        hub.apply_recovered_facts(
+            "cc-1",
+            RecoveredSessionFacts {
+                source: Some("claude-code".into()),
+                ..Default::default()
+            },
+        );
+        let window = SessionLimitWindow {
+            label: "7d".into(),
+            used_pct: None,
+            resets_at_epoch: Some(1_784_900_000),
+            status: Some("allowed".into()),
+            observed_at_epoch: Some(1_784_499_000),
+        };
+        hub.apply_rate_limit_windows("cc-1", vec![window.clone()]);
+        // The persist may ride the blocking pool: wait for the file.
+        for _ in 0..100 {
+            if path.exists() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        assert!(path.exists(), "report persists the store");
+
+        // Restart: a fresh hub restores the account view; a restored
+        // session inherits it via recovered-facts membership.
+        let bus2 = EventBus::new();
+        let hub2 = SessionVitalsHub::with_limit_store(bus2.clone(), Some(path.clone()));
+        hub2.apply_recovered_facts(
+            "cc-restored",
+            RecoveredSessionFacts {
+                source: Some("claude-code".into()),
+                ..Default::default()
+            },
+        );
+        let vitals = hub2
+            .sessions
+            .lock()
+            .expect("vitals state lock")
+            .get("cc-restored")
+            .cloned()
+            .expect("restored entry");
+        assert_eq!(vitals.limits, vec![window]);
+    }
+
+    /// Boot restore: both lanes (git-target registration and vitals
+    /// hydration) run over one candidate walk — identical scope and cap —
+    /// and a Claude Code candidate hydrates from its recorded launch
+    /// config + transcript, seeding the git locus from the recorded cwd.
+    #[tokio::test]
+    async fn boot_restore_registers_and_hydrates_over_one_capped_walk() {
+        let home = tempfile::tempdir().unwrap();
+        let logs = home.path().join(".intendant").join("logs");
+
+        // The transcript the wrapper maps to, in the real store shape.
+        let project_dir = home.path().join(".claude/projects/-repo");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        // Recorded cwd points at a checkout (worktree) the meta root
+        // doesn't know about.
+        let worktree = home.path().join("repo-wt");
+        std::fs::create_dir_all(worktree.join(".git")).unwrap();
+        let transcript = project_dir.join("backend-cc-9.jsonl");
+        std::fs::write(
+            &transcript,
+            [
+                user_line(
+                    "acceptEdits",
+                    worktree.to_str().unwrap(),
+                    "2026-07-22T07:00:00Z",
+                ),
+                assistant_line("claude-fable-5", "max", "2026-07-22T07:10:00Z", false).replace(
+                    "\"cwd\":\"/repo\"",
+                    &format!("\"cwd\":\"{}\"", worktree.display()),
+                ),
+            ]
+            .join("\n")
+                + "\n",
+        )
+        .unwrap();
+
+        // Wrapper session dir: meta + launch config + index mapping.
+        let wrapper_dir = logs.join("wrap-cc");
+        std::fs::create_dir_all(&wrapper_dir).unwrap();
+        std::fs::write(
+            wrapper_dir.join("session_meta.json"),
+            serde_json::json!({
+                "session_id": "wrap-cc",
+                "created_at": "now",
+                "project_root": home.path().join("repo").to_str().unwrap(),
+                "status": "idle",
+            })
+            .to_string(),
+        )
+        .unwrap();
+        crate::session_config::write_log_dir_config(
+            &wrapper_dir,
+            &SessionAgentConfig {
+                source: Some("claude-code".into()),
+                claude_model: Some("claude-fable-5".into()),
+                claude_permission_mode: Some("acceptEdits".into()),
+                ..Default::default()
+            },
+        )
+        .expect("write config");
+        crate::external_wrapper_index::upsert(
+            home.path(),
+            "claude-code",
+            "backend-cc-9",
+            "wrap-cc",
+            &wrapper_dir,
+            None,
+        )
+        .expect("index upsert");
+
+        // A completed session: excluded by both lanes.
+        let done_dir = logs.join("wrap-done");
+        std::fs::create_dir_all(&done_dir).unwrap();
+        std::fs::write(
+            done_dir.join("session_meta.json"),
+            serde_json::json!({
+                "session_id": "wrap-done",
+                "created_at": "now",
+                "project_root": "/x",
+                "status": "completed",
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let bus = EventBus::new();
+        let mut rx = bus.subscribe();
+        let registry = GitVitalsTargets::default();
+        let (registered, hydrated) = restore_session_vitals_at_boot(home.path(), &registry, &bus);
+        assert_eq!(registered, 1, "completed sessions stay out");
+        assert_eq!(hydrated, 1);
+
+        // Parity with the registration-only wrapper over the same walk.
+        let twin = GitVitalsTargets::default();
+        assert_eq!(
+            crate::session_vitals::register_restored_session_targets(home.path(), &twin),
+            registered
+        );
+        let mut ids: Vec<String> = registry.snapshot().into_iter().map(|(id, _)| id).collect();
+        let mut twin_ids: Vec<String> = twin.snapshot().into_iter().map(|(id, _)| id).collect();
+        ids.sort();
+        twin_ids.sort();
+        assert_eq!(ids, twin_ids, "both lanes cover the same sessions");
+        assert_eq!(
+            registry.snapshot()[0].1,
+            worktree,
+            "recorded cwd seeds the probe locus at boot"
+        );
+
+        let event = rx.try_recv().expect("hydration event");
+        let AppEvent::SessionRecoveredFacts { session_id, facts } = event else {
+            panic!("unexpected event: {event:?}");
+        };
+        assert_eq!(session_id.as_deref(), Some("wrap-cc"));
+        assert_eq!(facts.source.as_deref(), Some("claude-code"));
+        assert_eq!(facts.config.model.as_deref(), Some("claude-fable-5"));
+        assert!(
+            facts.config.model_recovered_at_epoch.is_some(),
+            "boot-lane config facts are disk-stamped"
+        );
+        assert_eq!(facts.config.permission_mode.as_deref(), Some("acceptEdits"));
+        assert_eq!(
+            facts.config.effort.as_deref(),
+            Some("max"),
+            "transcript fills effort"
+        );
+        assert!(
+            facts.context.is_some(),
+            "transcript usage recovers the meter"
+        );
+    }
+
+    /// Boot-cap parity: past the cap, both lanes restore exactly the same
+    /// (newest) candidate set.
+    #[test]
+    fn boot_walk_cap_applies_to_both_lanes() {
+        let home = tempfile::tempdir().unwrap();
+        let logs = home.path().join(".intendant").join("logs");
+        let total = RESTORED_TARGET_CAP + 3;
+        for index in 0..total {
+            let dir = logs.join(format!("sess-{index:03}"));
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(
+                dir.join("session_meta.json"),
+                serde_json::json!({
+                    "session_id": format!("sess-{index:03}"),
+                    "created_at": "now",
+                    "project_root": "/x",
+                    "status": "idle",
+                })
+                .to_string(),
+            )
+            .unwrap();
+        }
+        let candidates = restored_session_candidates(home.path());
+        assert_eq!(candidates.len(), RESTORED_TARGET_CAP);
+        let bus = EventBus::new();
+        let registry = GitVitalsTargets::default();
+        let (registered, hydrated) = restore_session_vitals_at_boot(home.path(), &registry, &bus);
+        assert_eq!(registered, RESTORED_TARGET_CAP);
+        assert_eq!(hydrated, 0, "native sessions have no disk layer to hydrate");
+        let twin = GitVitalsTargets::default();
+        assert_eq!(
+            crate::session_vitals::register_restored_session_targets(home.path(), &twin),
+            RESTORED_TARGET_CAP
+        );
+    }
+
+    /// The resume hydration lane: transcript + effective config merge and
+    /// emit under the lane's vitals id (sync context exercises the
+    /// no-runtime fallback path). Config-layer fields arrive unstamped
+    /// (current intent); transcript-sourced fields keep their stamps.
+    #[test]
+    fn resume_hydration_emits_merged_facts_under_the_given_id() {
+        let home = tempfile::tempdir().unwrap();
+        let project_dir = home.path().join(".claude/projects/-repo");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        std::fs::write(
+            project_dir.join("backend-cc-7.jsonl"),
+            assistant_line("claude-fable-5", "xhigh", "2026-07-22T07:00:00Z", false) + "\n",
+        )
+        .unwrap();
+
+        let bus = EventBus::new();
+        let mut rx = bus.subscribe();
+        hydrate_resumed_session_vitals(
+            bus.clone(),
+            home.path().to_path_buf(),
+            "backend-cc-7".into(),
+            AgentBackend::ClaudeCode,
+            "backend-cc-7".into(),
+            Some(SessionAgentConfig {
+                source: Some("claude-code".into()),
+                claude_effort: Some("low".into()),
+                ..Default::default()
+            }),
+        );
+        let event = rx.try_recv().expect("hydration event");
+        let AppEvent::SessionRecoveredFacts { session_id, facts } = event else {
+            panic!("unexpected event: {event:?}");
+        };
+        assert_eq!(session_id.as_deref(), Some("backend-cc-7"));
+        assert_eq!(
+            facts.config.effort.as_deref(),
+            Some("low"),
+            "effective config beats the transcript's effort"
+        );
+        assert_eq!(facts.config.model.as_deref(), Some("claude-fable-5"));
+        assert!(
+            facts.config.model_recovered_at_epoch.is_some(),
+            "transcript-sourced model keeps its record stamp"
+        );
+        assert!(facts.cache.is_some());
+        assert!(facts.context.is_some());
+    }
+}

--- a/src/bin/caller/startup/daemon.rs
+++ b/src/bin/caller/startup/daemon.rs
@@ -144,23 +144,34 @@ pub(crate) async fn run_daemon(
         (Some(session_id), Some(root)) => vec![(session_id, root)],
         _ => Vec::new(),
     };
-    let (vitals_git_targets, _vitals_producer) =
-        session_vitals::spawn_session_vitals_producer(bus.clone(), vitals_git_seed);
+    let (vitals_git_targets, _vitals_producer) = session_vitals::spawn_session_vitals_producer(
+        bus.clone(),
+        vitals_git_seed,
+        Some(crate::session_vitals_restore::account_limit_store_path()),
+    );
     // Restored sessions: a restart empties the target registry, so idle
     // session windows lose their git/health chips until the next resume.
-    // Re-register the store's non-ended sessions (bounded, newest-first,
-    // insert-if-absent — see register_restored_session_targets) off the
-    // startup path; the first probe tick re-emits each session's rows and
-    // the bootstrap caches carry them to later-connecting dashboards.
+    // One bounded walk (newest-first, insert-if-absent — see
+    // restore_session_vitals_at_boot) re-registers the store's non-ended
+    // sessions AND hydrates their vitals from disk (recorded launch
+    // config + backend transcript tails), off the startup path; the
+    // hub's emissions and the first probe tick re-fill each session's
+    // chips, and the bootstrap caches carry them to later-connecting
+    // dashboards.
     {
         let registry = vitals_git_targets.clone();
+        let restore_bus = bus.clone();
         tokio::task::spawn_blocking(move || {
-            let restored = session_vitals::register_restored_session_targets(
-                &crate::platform::home_dir(),
-                &registry,
-            );
-            if restored > 0 {
-                eprintln!("Session vitals: git targets restored for {restored} session(s)");
+            let (restored, hydrated) =
+                crate::session_vitals_restore::restore_session_vitals_at_boot(
+                    &crate::platform::home_dir(),
+                    &registry,
+                    &restore_bus,
+                );
+            if restored > 0 || hydrated > 0 {
+                eprintln!(
+                    "Session vitals: git targets restored for {restored} session(s), vitals hydrated for {hydrated}"
+                );
             }
         });
     }

--- a/src/bin/caller/startup/headless.rs
+++ b/src/bin/caller/startup/headless.rs
@@ -488,6 +488,7 @@ pub(crate) async fn run_headless_mode(
         Some(session_vitals::spawn_session_vitals_producer(
             bus.clone(),
             seed,
+            Some(crate::session_vitals_restore::account_limit_store_path()),
         ))
     } else {
         None
@@ -495,15 +496,21 @@ pub(crate) async fn run_headless_mode(
     let vitals_git_targets = vitals.as_ref().map(|(targets, _)| targets.clone());
     // Restored sessions, mirroring daemon boot: with the dashboard on,
     // the store's idle session windows keep their git/health chips here
-    // too (this shape falls through to run_daemon_loop after the task).
+    // too, and their vitals hydrate from disk (this shape falls through
+    // to run_daemon_loop after the task).
     if let Some(registry) = vitals_git_targets.clone() {
+        let restore_bus = bus.clone();
         tokio::task::spawn_blocking(move || {
-            let restored = session_vitals::register_restored_session_targets(
-                &crate::platform::home_dir(),
-                &registry,
-            );
-            if restored > 0 {
-                eprintln!("Session vitals: git targets restored for {restored} session(s)");
+            let (restored, hydrated) =
+                crate::session_vitals_restore::restore_session_vitals_at_boot(
+                    &crate::platform::home_dir(),
+                    &registry,
+                    &restore_bus,
+                );
+            if restored > 0 || hydrated > 0 {
+                eprintln!(
+                    "Session vitals: git targets restored for {restored} session(s), vitals hydrated for {hydrated}"
+                );
             }
         });
     }

--- a/src/bin/caller/types.rs
+++ b/src/bin/caller/types.rs
@@ -151,7 +151,7 @@ pub struct SessionPublishedPr {
 // existing `crate::types::Session*Vitals` paths keep working.
 pub use intendant_core::vitals::{
     SessionActivityState, SessionActivityVitals, SessionCacheVitals, SessionConfigVitals,
-    SessionGitVitals, SessionLimitWindow, SessionVitals,
+    SessionContextVitals, SessionGitVitals, SessionLimitWindow, SessionVitals,
 };
 
 /// Normalized region in a shared display view.

--- a/static/app/39-session-windows.js
+++ b/static/app/39-session-windows.js
@@ -1118,6 +1118,21 @@ function vitalsChipFactTextFromChip(text) {
   return String(text || '').replace(VITALS_CHIP_GLYPH_PREFIX, '').trim();
 }
 
+// Recovered-provenance caveat (instant vitals hydration): a chip whose
+// value was hydrated from the session's on-disk records — the
+// `modelRecoveredAtEpoch` / `permissionRecoveredAtEpoch` /
+// `recoveredAtEpoch` stamps — says so in its explainer instead of
+// passing disk state off as a live report. The stamp is the source
+// record's epoch; the daemon clears it on every live fold, so the chip
+// renders normally (no extra glyph) and the caveat disappears the
+// moment the backend speaks.
+function vitalsRecoveredCaveat(recoveredAtEpoch) {
+  const epoch = Number(recoveredAtEpoch);
+  if (!Number.isFinite(epoch) || epoch <= 0) return '';
+  const wall = formatLimitResetWallClock(epoch);
+  return `From the session log as of ${wall || 'an earlier run'} — live values arrive with the next turn.`;
+}
+
 const VITALS_SYMBOLS = {
   health: {
     label: 'Session health',
@@ -1236,6 +1251,8 @@ const VITALS_SYMBOLS = {
       if (v.effort) {
         lines.push(`Reasoning effort is set to “${v.effort}” — how hard the model may think before answering. A setting, not a measurement.`);
       }
+      const caveat = vitalsRecoveredCaveat(v.recoveredAtEpoch);
+      if (caveat) lines.push(caveat);
       return lines;
     },
     action: (v) => (v.model ? { label: 'Copy model id', run: () => vitalsCopyText(v.model) } : null),
@@ -1249,7 +1266,12 @@ const VITALS_SYMBOLS = {
     explain: (v) => {
       const lines = [...v.lines];
       lines.push(`In the agent's own vocabulary: “${v.mode}”.`);
-      if (!v.echoed) {
+      const caveat = vitalsRecoveredCaveat(v.recoveredAtEpoch);
+      if (caveat) {
+        // Recovered modes are also unconfirmed (echoed stays false) —
+        // the dated caveat carries both facts in one line.
+        lines.push(caveat);
+      } else if (!v.echoed) {
         lines.push("This is the launch setting — the agent hasn't confirmed it yet.");
       }
       return lines;
@@ -1353,10 +1375,15 @@ const VITALS_SYMBOLS = {
     quiet: 'No cache reading on the last request.',
     icon: 'bolt',
     chip: (v) => `⚡${v.hitPct}%`,
-    explain: (v) => [
-      `${v.hitPct}% of the last request was answered from the provider's prompt cache.`,
-      'Cached input is far cheaper and faster than fresh input.',
-    ],
+    explain: (v) => {
+      const lines = [
+        `${v.hitPct}% of the last request was answered from the provider's prompt cache.`,
+        'Cached input is far cheaper and faster than fresh input.',
+      ];
+      const caveat = vitalsRecoveredCaveat(v.recoveredAtEpoch);
+      if (caveat) lines.push(caveat);
+      return lines;
+    },
   },
   'cache-ttl': {
     label: 'Cache freshness',
@@ -1365,15 +1392,20 @@ const VITALS_SYMBOLS = {
     icon: 'clock',
     chip: (v) => (v.cold ? '✗' : `⏳${v.countdown}`),
     factText: (v) => (v.cold ? 'cache cold' : v.countdown),
-    explain: (v) => (v.cold
-      ? [
-        'The prompt cache went cold — the next request rebuilds it.',
-        'Nothing is broken; the next turn just costs a little more once.',
-      ]
-      : [
-        `The prompt cache stays warm for another ${v.countdown}.`,
-        'If the session idles past that, the next request rebuilds it — slower and pricier.',
-      ]),
+    explain: (v) => {
+      const lines = v.cold
+        ? [
+          'The prompt cache went cold — the next request rebuilds it.',
+          'Nothing is broken; the next turn just costs a little more once.',
+        ]
+        : [
+          `The prompt cache stays warm for another ${v.countdown}.`,
+          'If the session idles past that, the next request rebuilds it — slower and pricier.',
+        ];
+      const caveat = vitalsRecoveredCaveat(v.recoveredAtEpoch);
+      if (caveat) lines.push(caveat);
+      return lines;
+    },
   },
   limit: {
     label: 'Rate limit',
@@ -1610,6 +1642,7 @@ function vitalsChipModels(vitals, meta, sessionId) {
         model,
         shortName: vitalsModelShortName(model),
         effort: factsEffort,
+        recoveredAtEpoch: Number(facts.modelRecoveredAtEpoch) || 0,
       });
     }
     const mode = String(facts.permissionMode || '').trim();
@@ -1620,6 +1653,7 @@ function vitalsChipModels(vitals, meta, sessionId) {
         lines: display.lines,
         mode,
         echoed: facts.permissionEchoed === true,
+        recoveredAtEpoch: Number(facts.permissionRecoveredAtEpoch) || 0,
       }, {
         // Cosmetic tint only: a chosen bypass/ungated configuration is
         // worth noticing, but it is not a failure — no health-dot
@@ -1674,10 +1708,11 @@ function vitalsChipModels(vitals, meta, sessionId) {
 
   const cache = vitals?.cache && typeof vitals.cache === 'object' ? vitals.cache : null;
   if (cache) {
+    const cacheRecoveredAt = Number(cache.recoveredAtEpoch) || 0;
     const hitRaw = Number(cache.hitPct);
     if (Number.isFinite(hitRaw) && cache.hitPct !== null && cache.hitPct !== undefined) {
       const hitPct = Math.max(0, Math.min(100, hitRaw));
-      push('cache-hit', 'cache-hit', { hitPct }, {
+      push('cache-hit', 'cache-hit', { hitPct, recoveredAtEpoch: cacheRecoveredAt }, {
         severity: hitPct >= 90 ? 'ok' : '',
         tone: hitPct >= 90 ? 'ok' : hitPct >= 50 ? 'warn' : 'crit',
       });
@@ -1685,10 +1720,13 @@ function vitalsChipModels(vitals, meta, sessionId) {
     const remaining = sessionCacheCountdownSeconds(cache);
     if (remaining !== null) {
       if (remaining > 0) {
-        push('cache-ttl', 'cache-ttl', { cold: false, countdown: formatCacheCountdown(remaining) },
-          { severity: '', tone: remaining <= 60 ? 'crit' : '', ticking: true });
+        push('cache-ttl', 'cache-ttl', {
+          cold: false,
+          countdown: formatCacheCountdown(remaining),
+          recoveredAtEpoch: cacheRecoveredAt,
+        }, { severity: '', tone: remaining <= 60 ? 'crit' : '', ticking: true });
       } else {
-        push('cache-ttl', 'cache-ttl', { cold: true, countdown: '' });
+        push('cache-ttl', 'cache-ttl', { cold: true, countdown: '', recoveredAtEpoch: cacheRecoveredAt });
       }
     }
   }
@@ -3276,8 +3314,9 @@ function normalizeSessionVitals(raw) {
   const limits = Array.isArray(src.limits) ? src.limits : [];
   const activity = src.activity && typeof src.activity === 'object' ? src.activity : null;
   const config = src.config && typeof src.config === 'object' ? src.config : null;
-  if (!git && !cache && !limits.length && !activity && !config) return null;
-  return { git, cache, limits, activity, config };
+  const context = src.context && typeof src.context === 'object' ? src.context : null;
+  if (!git && !cache && !limits.length && !activity && !config && !context) return null;
+  return { git, cache, limits, activity, config, context };
 }
 
 // Merge an arriving vitals snapshot over what a session already has. A
@@ -3296,6 +3335,7 @@ function mergeSessionVitals(incoming, existing) {
     limits: incoming.limits?.length ? incoming.limits : existing.limits || [],
     activity: incoming.activity || existing.activity || null,
     config: incoming.config || existing.config || null,
+    context: incoming.context || existing.context || null,
   };
 }
 
@@ -3318,6 +3358,12 @@ function applySessionVitals(raw = {}, options = {}) {
   // Once per arrival (not per identity alias), from the incoming limits —
   // transitions are about what the wire just said, not the merged cache.
   maybeAlertLimitTransitions(sid, vitals.limits, options);
+  // The header context meter can be riding this session's vitals.context
+  // fallback (no live update_usage yet — bootstrap, restored sessions);
+  // re-derive it so the recovered figure lands without waiting on usage.
+  if (vitals.context && typeof renderForegroundSessionUsage === 'function') {
+    renderForegroundSessionUsage();
+  }
   refreshSessionVitalsTicker();
 }
 

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -3367,10 +3367,37 @@ function usageForForegroundSession() {
   return latestGlobalUsage;
 }
 
+// Context percentage from a session's vitals `context` section — the
+// fallback lane when no live update_usage has arrived this tab-lifetime
+// (bootstrap after a daemon restart, attaching to an idle session): the
+// daemon persists and replays vitals, so the recovered footprint is
+// available immediately. Looks across the identity group like the
+// update_usage cache does. Null when no session in the group carries one.
+function contextPctFromVitals(sid) {
+  if (!sid || typeof sessionMetadataById === 'undefined') return null;
+  // relatedSessionIdsForSession includes sid itself.
+  const ids = typeof relatedSessionIdsForSession === 'function'
+    ? relatedSessionIdsForSession(sid) : new Set([sid]);
+  for (const id of ids) {
+    const context = sessionMetadataById.get(id)?.vitals?.context;
+    const pct = Number(context?.usagePct);
+    if (context && Number.isFinite(pct)) return pct;
+  }
+  return null;
+}
+
 function renderForegroundSessionUsage() {
   const usageCommand = usageForForegroundSession();
   const main = usageCommand ? parseUsageJson(usageCommand.main_json) : null;
-  setContextUsagePct(main && typeof main.usage_pct === 'number' ? main.usage_pct : null);
+  if (main && typeof main.usage_pct === 'number') {
+    setContextUsagePct(main.usage_pct);
+    return;
+  }
+  // Live usage first; vitals.context second (recovered/replayed footprint).
+  const sid = typeof explicitForegroundSessionId === 'function'
+    ? explicitForegroundSessionId() : '';
+  const fallbackPct = contextPctFromVitals(sid);
+  setContextUsagePct(fallbackPct !== null ? fallbackPct : null);
 }
 
 function applyMainBackendStatus() {


### PR DESCRIPTION
Session vitals stayed empty after resume/daemon-restart until live wire
events arrived: model/permission chips waited on Claude Code's
system:init echo (seconds after spawn; forever for restored sessions
nobody resumes), the context meter waited on the first live usage
snapshot, and the account rate-limit window store died with the process.
The ground truth already sits on disk — the wrapper dir's recorded
launch config and the backend transcript (verified against live CC
2.1.215-2.1.217 records: message.model, top-level effort on assistant
records, message.usage with the ephemeral 5m/1h cache_creation split,
permissionMode, cwd, timestamps).

- session_vitals_restore.rs (hub sibling; the hub file is at its size
  budget): SessionVitalsHub::apply_recovered_facts folds disk facts
  fill-if-absent — precedence wire echo > launch config > disk snapshot
  holds by construction, and every live fold (apply_config_facts, the
  usage/cache listener) overwrites recovered values and clears their
  stamps, so hydrator/live races are harmless in either order (tested
  both ways).
- Provenance stamps, wire-additive on intendant-core vitals types:
  model/permission recovered_at epochs on the config section,
  recovered_at_epoch on cache and the new context section; disk-sourced
  permission facts keep permission_echoed false. The vit-chip explainers
  add the dated "from the session log" caveat line; chips render
  normally otherwise.
- SessionVitals gains a context section (tokens/window/pct/observed_at)
  filled by the existing usage listener from live UsageSnapshots and by
  the hydrator from the transcript's last usage record (same footprint
  formula, pct clamped via the claude_model_context_window family
  table). The dashboard context meter reads live update_usage first and
  falls back to vitals.context — which also fixes the idle-attach gap.
- latest_recorded_session_facts: bounded tail-then-head transcript read
  (the latest_recorded_cwd shape) yielding model, top-level effort
  (absent = no claim), permissionMode, last usage entry with the per-TTL
  split, cwd, and record timestamps; sidechain records never claim
  session facts. Fixtures are synthetic, shaped from live 2.1.21x
  records.
- Hydration call sites: the boot restore scan (one shared candidate
  walk + newest-64 cap with the git-target restore, spawn_blocking, and
  the recorded cwd now seeds the probe locus at boot) and the
  resume/attach lanes beside seed_resumed_git_vitals_locus (effective
  launch config as the config layer, transcript as the recovered
  layer). Both emit hub-internal SessionRecoveredFacts; session-log
  persistence, the bootstrap caches, tunnel, Station, and peers inherit
  from the hub's ordinary emission.
- The per-account rate-limit window store persists to a versioned
  account-rate-limits.json (atomic write on change, additive
  forward-compat, future versions fail closed to empty) and restores at
  hub construction; recovered-facts membership mirrors the account view
  into restored sessions, and the existing observed_at/reset-rollover
  degradation keeps stale restores honest. Percentages persist exactly
  as reported, never synthesized.
- Effort echo probe (live, CC 2.1.217): stream-json assistant envelopes
  carry NO top-level effort — the field is transcript-only. The parser
  arm is implemented defensively anyway (present on a future CLI's main
  thread -> first-hand echo via note_effort_echo; absent -> nothing),
  sharing the change-edge with the init-echo lane.
- Codex/Kimi recover their launch-config layer (model, effort/thinking,
  sandbox-approval / permission-mode kinds); their transcript extractors
  stay a flagged follow-up per the ruling.
