### PR TITLE
Attachment delivery: stored-path reference on every lane; steers are steers

### DIFF
--- a/docs/src/external-agent-orchestration.md
+++ b/docs/src/external-agent-orchestration.md
@@ -56,7 +56,7 @@ pub trait ExternalAgent: Send + Sync {
     // Turns
     async fn send_message(&mut self, thread: &AgentThread, message: &str) -> Result<(), CallerError>;
     async fn send_message_with_images(/* … */) -> Result<(), CallerError>;          // default: text-only
-    async fn send_message_with_attachments(/* … */) -> Result<(), CallerError>;     // default: stage files + prelude
+    async fn send_message_with_attachments(/* … */) -> Result<(), CallerError>;     // default: stored-path prelude + image blocks
 
     // Oversight
     async fn resolve_approval(&mut self, request_id: &str, decision: ApprovalDecision)
@@ -103,6 +103,40 @@ dropdown's `<option value>`.
 
 Gemini CLI was previously supported as a backend and was retired in July 2026;
 persisted sessions from it remain readable but cannot be resumed.
+
+### Attachment delivery
+
+User attachments (dashboard uploads, pasted screenshots) follow one contract
+on every delivery lane — new task, queued follow-up, mid-turn steer, and
+native sessions alike:
+
+- **Stored-path reference.** Every delivered user message names each
+  attachment that exists on disk with a stable, greppable line ending in
+  `[attachment stored: <absolute path>]`
+  (`external_agent::ATTACHMENT_STORED_MARKER`), composed once by
+  `external_agent::text_with_attachments_prelude` — prelude before the
+  user's text. The receiving agent can act on the stored file immediately
+  (read it, relay it to a sub-agent) without hunting the store.
+  Image-capable backends get the inline image block *and* the path line
+  tying those pixels to their disk path; backends without image input get
+  the path line as the whole image delivery (no silent drop). Backend
+  overrides of `send_message_with_attachments` must keep the prelude so
+  the reference contract holds everywhere.
+- **Durable stores.** Dashboard uploads land in the project-local
+  `.intendant/uploads/` store (never pruned; explicit delete only) or, for
+  projectless daemons, the daemon-global store (pruned after 14 days of
+  inactivity) — the referenced path outlives the turn that delivered it.
+- **Steers are steers.** An attachment-bearing steer takes the native
+  mid-turn injection lane like any text steer — it is never parked for the
+  turn boundary just because it carries files. The mid-turn lane is
+  text-only, so the stored-path line *is* the image delivery there; if no
+  lane acks the steer, the standard fallback queues it as the session's
+  next turn, where the pixels additionally ride as content blocks (the
+  boundary send site re-derives the same prelude). A natively acked steer
+  never double-delivers at the boundary. (Until 2026-07-22 attachment
+  steers were routed straight to the boundary follow-up lane — arriving
+  minutes late and out of order relative to later text steers; that
+  routing is gone.)
 
 ## Per-Backend Reference
 

--- a/src/bin/caller/agent_loop.rs
+++ b/src/bin/caller/agent_loop.rs
@@ -132,21 +132,14 @@ impl UserAttachments {
             .collect()
     }
 
-    pub(crate) fn text_with_file_prelude(&self, text: &str) -> String {
-        let files: Vec<&external_agent::AgentFileAttachment> = self
-            .items
-            .iter()
-            .filter_map(|att| match att {
-                external_agent::AgentAttachment::File(file) => Some(file),
-                external_agent::AgentAttachment::Image(_) => None,
-            })
-            .collect();
-        let prelude = external_agent::format_file_attachments_prelude(&files);
-        if prelude.is_empty() {
-            text.to_string()
-        } else {
-            format!("{}{}", prelude, text)
-        }
+    /// The native-session spelling of the delivery contract: the same
+    /// stored-path prelude every external lane uses
+    /// ([`external_agent::text_with_attachments_prelude`]), covering files
+    /// AND images with on-disk paths. Pixels still ride separately via
+    /// [`Self::conversation_images`]; the path lines make the stored files
+    /// referenceable.
+    pub(crate) fn text_with_attachments_prelude(&self, text: &str) -> String {
+        external_agent::text_with_attachments_prelude(text, &self.items)
     }
 }
 
@@ -3787,7 +3780,9 @@ pub(crate) async fn run_round_loop(
                     break;
                 };
                 round += 1;
-                let followup_text = message.attachments.text_with_file_prelude(&message.text);
+                let followup_text = message
+                    .attachments
+                    .text_with_attachments_prelude(&message.text);
                 let followup_images = message.attachments.conversation_images();
                 slog(&session_log, |l| {
                     l.info(&format!(
@@ -4251,6 +4246,56 @@ mod budget_tail {
             .into_iter()
             .collect();
         assert_eq!(budget_tail_index(&batch, &handled), None);
+    }
+}
+
+#[cfg(test)]
+mod user_attachments {
+    use super::UserAttachments;
+    use crate::external_agent;
+    use std::path::PathBuf;
+
+    /// Native-session seam: the composed text names stored images (not just
+    /// files — the pre-unification helper skipped them) while the pixels
+    /// still ride separately as conversation images.
+    #[test]
+    fn native_prelude_names_stored_images_and_keeps_pixels() {
+        let attachments = UserAttachments::from_items(vec![
+            external_agent::AgentAttachment::Image(
+                external_agent::AgentImageAttachment::from_frame_path(
+                    PathBuf::from("/store/uploads/s1/cd34__shot.png"),
+                    "aGk=".to_string(),
+                    "image/png".to_string(),
+                ),
+            ),
+            external_agent::AgentAttachment::File(external_agent::AgentFileAttachment {
+                local_path: PathBuf::from("/store/uploads/s1/ab12__report.pdf"),
+                name: "report.pdf".to_string(),
+                mime_type: "application/pdf".to_string(),
+                size: 9,
+            }),
+        ]);
+        let composed = attachments.text_with_attachments_prelude("check these");
+        assert!(
+            composed.contains(&format!(
+                "{}/store/uploads/s1/cd34__shot.png]",
+                external_agent::ATTACHMENT_STORED_MARKER
+            )),
+            "image path line missing: {composed}"
+        );
+        assert!(
+            composed.contains(&format!(
+                "{}/store/uploads/s1/ab12__report.pdf]",
+                external_agent::ATTACHMENT_STORED_MARKER
+            )),
+            "file path line missing: {composed}"
+        );
+        assert!(composed.ends_with("check these"));
+        assert_eq!(
+            attachments.conversation_images().len(),
+            1,
+            "the image block lane is unchanged by the path line"
+        );
     }
 }
 

--- a/src/bin/caller/external_agent/kimi_code/mod.rs
+++ b/src/bin/caller/external_agent/kimi_code/mod.rs
@@ -1799,7 +1799,10 @@ impl ExternalAgent for KimiCodeAgent {
             .cloned()
             .map(AgentAttachment::Image)
             .collect::<Vec<_>>();
-        let content = self.attachment_content(message, &attachments).await?;
+        // Same stored-path prelude as the trait default: Kimi delivers the
+        // content natively AND the model can reference the on-disk file.
+        let augmented = super::text_with_attachments_prelude(message, &attachments);
+        let content = self.attachment_content(&augmented, &attachments).await?;
         self.submit_content(thread, content).await?;
         Ok(())
     }
@@ -1810,7 +1813,12 @@ impl ExternalAgent for KimiCodeAgent {
         message: &str,
         attachments: &[AgentAttachment],
     ) -> Result<(), CallerError> {
-        let content = self.attachment_content(message, attachments).await?;
+        // Native file upload + inline images carry the bytes; the
+        // stored-path prelude keeps the delivered message shape (and the
+        // greppable `[attachment stored: …]` reference) identical to every
+        // other backend.
+        let augmented = super::text_with_attachments_prelude(message, attachments);
+        let content = self.attachment_content(&augmented, attachments).await?;
         self.submit_content(thread, content).await?;
         Ok(())
     }

--- a/src/bin/caller/external_agent/mod.rs
+++ b/src/bin/caller/external_agent/mod.rs
@@ -888,45 +888,85 @@ pub enum AgentAttachment {
     File(AgentFileAttachment),
 }
 
-impl AgentAttachment {
-    /// Images flow through each backend's native image path; files need
-    /// the "stage + point" workaround. Exposed as a method so call sites
-    /// reading a heterogeneous `&[AgentAttachment]` can split into two
-    /// buckets cleanly.
-    pub fn is_image(&self) -> bool {
-        matches!(self, AgentAttachment::Image(_))
-    }
-}
-
-/// Build the short prelude that precedes a user's message when the task
-/// carries one or more non-image file attachments. Tells the model what
-/// files are available and where to find them, without pretending the
-/// backend has a real "document" content block.
+/// Stable, greppable marker that opens every stored-attachment path line in
+/// a delivered user message: `[attachment stored: <absolute path>]`.
 ///
-/// Empty string when there are no file attachments — callers can
-/// concatenate unconditionally.
-pub fn format_file_attachments_prelude(files: &[&AgentFileAttachment]) -> String {
-    if files.is_empty() {
+/// This is the reference half of the attachment contract: the pixels/bytes
+/// may or may not ride a given lane, but the stored path always does, so the
+/// receiving agent can act on the file (read it, relay it to a sub-agent)
+/// without hunting the store. Keep the marker identical across every
+/// delivery lane — task, follow-up, steer, native — and treat its exact
+/// spelling as an interface (tests pin it).
+pub const ATTACHMENT_STORED_MARKER: &str = "[attachment stored: ";
+
+/// Build the prelude that precedes a user's message when it carries
+/// attachments. One line per attachment that exists on disk — non-image
+/// files always, images when their store path is known (an in-memory
+/// screenshot has no stored file and gets no line). Each line ends with the
+/// stable `[attachment stored: <absolute path>]` marker so the model can
+/// reference the stored file directly; for backends that also deliver the
+/// image content block, the line ties the inline pixels to their disk path.
+///
+/// Retention note: dashboard uploads live in the project-local
+/// `.intendant/uploads/` store (never pruned) or, for projectless daemons,
+/// the daemon-global store (pruned after
+/// [`crate::global_store::GLOBAL_STORE_RETENTION_DAYS`] days of
+/// inactivity) — durable either way, not session-lifetime temp files.
+///
+/// Empty string when nothing has a stored path — callers can concatenate
+/// unconditionally.
+pub fn format_attachments_prelude(attachments: &[AgentAttachment]) -> String {
+    let mut lines = String::new();
+    for attachment in attachments {
+        match attachment {
+            AgentAttachment::File(f) => {
+                // Humanised size: "123 B" / "1.2 KB" / "4.3 MB". Nothing
+                // fancy — just avoids raw byte counts for multi-MB PDFs.
+                lines.push_str(&format!(
+                    "- `{}` ({}, {}) — {}{}]\n",
+                    f.name,
+                    f.mime_type,
+                    human_bytes(f.size),
+                    ATTACHMENT_STORED_MARKER,
+                    f.local_path.display(),
+                ));
+            }
+            AgentAttachment::Image(img) => {
+                let Some(path) = img.local_path.as_ref() else {
+                    continue;
+                };
+                let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("image");
+                lines.push_str(&format!(
+                    "- `{}` ({}) — {}{}]\n",
+                    name,
+                    img.mime_type,
+                    ATTACHMENT_STORED_MARKER,
+                    path.display(),
+                ));
+            }
+        }
+    }
+    if lines.is_empty() {
         return String::new();
     }
-    let mut out = String::from(
+    format!(
         "The user attached the following file(s). Read them with your file \
-         tools when relevant; paths are absolute.\n\n",
-    );
-    for f in files {
-        // Humanised size: "123 B" / "1.2 KB" / "4.3 MB". Nothing fancy —
-        // just avoids showing raw byte counts for multi-MB PDFs.
-        let size = human_bytes(f.size);
-        out.push_str(&format!(
-            "- `{}` ({}, {}) — path: {}\n",
-            f.name,
-            f.mime_type,
-            size,
-            f.local_path.display(),
-        ));
+         tools when relevant; paths are absolute.\n\n{lines}\n"
+    )
+}
+
+/// The one concatenation convention for [`format_attachments_prelude`]:
+/// prelude BEFORE the user's text (the model reads the attachment list
+/// first, then the instruction), text unchanged when no line applies.
+/// Every lane that composes a deliverable message from text + attachments
+/// goes through here so the delivered shape stays identical across lanes.
+pub fn text_with_attachments_prelude(text: &str, attachments: &[AgentAttachment]) -> String {
+    let prelude = format_attachments_prelude(attachments);
+    if prelude.is_empty() {
+        text.to_string()
+    } else {
+        format!("{prelude}{text}")
     }
-    out.push('\n');
-    out
 }
 
 fn human_bytes(n: u64) -> String {
@@ -1826,11 +1866,20 @@ pub trait ExternalAgent: Send + Sync {
     }
 
     /// Send a user message with a heterogeneous list of attachments
-    /// (images + files). Default implementation routes images through
-    /// `send_message_with_images` and prepends a prelude describing any
-    /// file attachments at stable paths. Backends that grow a native
+    /// (images + files). Default implementation prepends the stored-path
+    /// prelude for EVERY attachment with an on-disk file — images included
+    /// (`[attachment stored: …]` lines, see
+    /// [`format_attachments_prelude`]) — then routes images through
+    /// `send_message_with_images`. On backends without image input the
+    /// path line is therefore the whole image delivery (the
+    /// `send_message_with_images` default forwards text only); on
+    /// image-capable backends the model gets the content block AND the
+    /// stored path it can reference. Backends that grow a native
     /// "document" content block later can override this to pass files
-    /// through the wire protocol instead of staging + pointing.
+    /// through the wire protocol instead of staging + pointing — overrides
+    /// must keep the stored-path prelude (compose via
+    /// [`text_with_attachments_prelude`]) so the reference contract holds
+    /// on every backend.
     async fn send_message_with_attachments(
         &mut self,
         thread: &AgentThread,
@@ -1844,21 +1893,7 @@ pub trait ExternalAgent: Send + Sync {
                 AgentAttachment::File(_) => None,
             })
             .collect();
-        let files: Vec<&AgentFileAttachment> = attachments
-            .iter()
-            .filter_map(|a| match a {
-                AgentAttachment::File(f) => Some(f),
-                AgentAttachment::Image(_) => None,
-            })
-            .collect();
-        let prelude = format_file_attachments_prelude(&files);
-        // Prelude comes BEFORE the user's message so the model reads the
-        // attachment list first, then the actual instruction.
-        let augmented = if prelude.is_empty() {
-            message.to_string()
-        } else {
-            format!("{}{}", prelude, message)
-        };
+        let augmented = text_with_attachments_prelude(message, attachments);
         self.send_message_with_images(thread, &augmented, &images)
             .await
     }
@@ -2868,5 +2903,234 @@ mod tests {
             }
             other => panic!("expected ExternalAgent error, got {other:?}"),
         }
+    }
+
+    fn stored_image(path: &str) -> AgentAttachment {
+        AgentAttachment::Image(AgentImageAttachment::from_frame_path(
+            PathBuf::from(path),
+            "aGk=".to_string(),
+            "image/png".to_string(),
+        ))
+    }
+
+    fn stored_file(name: &str, path: &str, size: u64) -> AgentAttachment {
+        AgentAttachment::File(AgentFileAttachment {
+            local_path: PathBuf::from(path),
+            name: name.to_string(),
+            mime_type: "application/pdf".to_string(),
+            size,
+        })
+    }
+
+    /// The stored-path prelude names every attachment with an on-disk file
+    /// — images included — via the stable `[attachment stored: …]` marker;
+    /// an in-memory image (no stored file) gets no line.
+    #[test]
+    fn attachments_prelude_names_stored_files_and_images() {
+        let attachments = vec![
+            stored_file("report.pdf", "/store/uploads/s1/ab12__report.pdf", 2048),
+            stored_image("/store/uploads/s1/cd34__shot.png"),
+            AgentAttachment::Image(AgentImageAttachment::from_image_data(&ImageData {
+                media_type: "image/jpeg".to_string(),
+                data: "aGk=".to_string(),
+            })),
+        ];
+        let prelude = format_attachments_prelude(&attachments);
+        assert!(
+            prelude.contains(&format!(
+                "{ATTACHMENT_STORED_MARKER}/store/uploads/s1/ab12__report.pdf]"
+            )),
+            "file line missing: {prelude}"
+        );
+        assert!(
+            prelude.contains(&format!(
+                "{ATTACHMENT_STORED_MARKER}/store/uploads/s1/cd34__shot.png]"
+            )),
+            "image line missing: {prelude}"
+        );
+        assert!(
+            prelude.contains("`cd34__shot.png` (image/png)"),
+            "image line should carry the on-disk name and mime: {prelude}"
+        );
+        assert!(
+            prelude.contains("`report.pdf` (application/pdf, 2.0 KB)"),
+            "file line should keep name/mime/size: {prelude}"
+        );
+        assert_eq!(
+            prelude.matches(ATTACHMENT_STORED_MARKER).count(),
+            2,
+            "the pathless in-memory image must not mint a stored line: {prelude}"
+        );
+
+        // Nothing stored → empty prelude, text passes through unchanged.
+        let pathless = vec![AgentAttachment::Image(
+            AgentImageAttachment::from_image_data(&ImageData {
+                media_type: "image/png".to_string(),
+                data: "aGk=".to_string(),
+            }),
+        )];
+        assert_eq!(format_attachments_prelude(&pathless), "");
+        assert_eq!(format_attachments_prelude(&[]), "");
+        assert_eq!(
+            text_with_attachments_prelude("do the thing", &pathless),
+            "do the thing"
+        );
+
+        // Composition convention: prelude BEFORE the user's text.
+        let composed = text_with_attachments_prelude("do the thing", &attachments);
+        assert!(composed.ends_with("do the thing"), "got: {composed}");
+        assert!(composed.starts_with("The user attached the following file(s)."));
+    }
+
+    /// Recorder for the delivery seam: captures the final wire text and how
+    /// many images were forwarded alongside it.
+    #[derive(Default, Clone)]
+    struct SentRecord {
+        text: String,
+        images: usize,
+    }
+
+    struct RecordingBackend {
+        image_capable: bool,
+        sent: std::sync::Arc<std::sync::Mutex<Vec<SentRecord>>>,
+    }
+
+    #[async_trait]
+    impl ExternalAgent for RecordingBackend {
+        fn name(&self) -> &str {
+            "recording"
+        }
+
+        async fn initialize(
+            &mut self,
+            _config: AgentConfig,
+        ) -> Result<mpsc::UnboundedReceiver<AgentEvent>, CallerError> {
+            Err(CallerError::ExternalAgent("not used in this test".into()))
+        }
+
+        async fn start_thread(&mut self) -> Result<AgentThread, CallerError> {
+            Err(CallerError::ExternalAgent("not used in this test".into()))
+        }
+
+        async fn send_message(
+            &mut self,
+            _thread: &AgentThread,
+            message: &str,
+        ) -> Result<(), CallerError> {
+            self.sent.lock().unwrap().push(SentRecord {
+                text: message.to_string(),
+                images: 0,
+            });
+            Ok(())
+        }
+
+        async fn send_message_with_images(
+            &mut self,
+            thread: &AgentThread,
+            message: &str,
+            images: &[AgentImageAttachment],
+        ) -> Result<(), CallerError> {
+            if !self.image_capable {
+                // Mirror the trait default: text only.
+                return self.send_message(thread, message).await;
+            }
+            self.sent.lock().unwrap().push(SentRecord {
+                text: message.to_string(),
+                images: images.len(),
+            });
+            Ok(())
+        }
+
+        fn supports_image_input(&self) -> bool {
+            self.image_capable
+        }
+
+        async fn resolve_approval(
+            &mut self,
+            _request_id: &str,
+            _decision: ApprovalDecision,
+        ) -> Result<(), CallerError> {
+            Err(CallerError::ExternalAgent("not used in this test".into()))
+        }
+
+        async fn shutdown(&mut self) -> Result<(), CallerError> {
+            Ok(())
+        }
+    }
+
+    /// Image-capable backend: the delivered message carries BOTH the image
+    /// content block and the stored-path line naming the same file.
+    #[tokio::test]
+    async fn attachment_delivery_image_backend_gets_block_and_path_line() {
+        let sent = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut backend = RecordingBackend {
+            image_capable: true,
+            sent: sent.clone(),
+        };
+        let thread = AgentThread {
+            thread_id: "t1".to_string(),
+        };
+        backend
+            .send_message_with_attachments(
+                &thread,
+                "look at this",
+                &[stored_image("/store/uploads/s1/cd34__shot.png")],
+            )
+            .await
+            .unwrap();
+        let records = sent.lock().unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].images, 1, "image block must still be forwarded");
+        assert!(
+            records[0].text.contains(&format!(
+                "{ATTACHMENT_STORED_MARKER}/store/uploads/s1/cd34__shot.png]"
+            )),
+            "delivered text must name the stored path: {}",
+            records[0].text
+        );
+        assert!(records[0].text.ends_with("look at this"));
+    }
+
+    /// Backend without image input: the stored-path line is the whole image
+    /// delivery — no silent drop.
+    #[tokio::test]
+    async fn attachment_delivery_text_backend_gets_path_line_as_whole_delivery() {
+        let sent = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut backend = RecordingBackend {
+            image_capable: false,
+            sent: sent.clone(),
+        };
+        let thread = AgentThread {
+            thread_id: "t1".to_string(),
+        };
+        backend
+            .send_message_with_attachments(
+                &thread,
+                "look at this",
+                &[
+                    stored_image("/store/uploads/s1/cd34__shot.png"),
+                    stored_file("report.pdf", "/store/uploads/s1/ab12__report.pdf", 2048),
+                ],
+            )
+            .await
+            .unwrap();
+        let records = sent.lock().unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].images, 0, "text-only lane forwards no blocks");
+        assert!(
+            records[0].text.contains(&format!(
+                "{ATTACHMENT_STORED_MARKER}/store/uploads/s1/cd34__shot.png]"
+            )),
+            "the image's stored path must survive on a text-only backend: {}",
+            records[0].text
+        );
+        assert!(
+            records[0].text.contains(&format!(
+                "{ATTACHMENT_STORED_MARKER}/store/uploads/s1/ab12__report.pdf]"
+            )),
+            "file attachments keep their stored-path line: {}",
+            records[0].text
+        );
+        assert!(records[0].text.ends_with("look at this"));
     }
 }

--- a/src/bin/caller/external_mode.rs
+++ b/src/bin/caller/external_mode.rs
@@ -7,11 +7,15 @@
 // is the deferred cosmetic pass (see the god-file split design).
 use crate::*;
 
-/// Surface a visible warning when an outbound message carries image
+/// Surface a visible notice when an outbound message carries image
 /// attachments the backend cannot deliver natively (the
-/// `send_message_with_images` default forwards text only). Non-image files
-/// always travel via the staged-path prelude, so images are the only
-/// attachment kind that can silently vanish on an unsupporting backend.
+/// `send_message_with_images` default forwards text only). The stored-path
+/// prelude (`[attachment stored: …]` — see
+/// `external_agent::format_attachments_prelude`) still names every stored
+/// attachment in the delivered text, so the agent can read the file with
+/// its own tools — the pixels just don't arrive inline. An image with no
+/// stored file (in-memory only) gets no path line either, so that corner
+/// stays an honest "will not reach the agent" warning.
 fn warn_undeliverable_images(
     session_log: &SharedSessionLog,
     agent_name: &str,
@@ -21,11 +25,29 @@ fn warn_undeliverable_images(
     if supports_images {
         return;
     }
-    let dropped = attachments.iter().filter(|a| a.is_image()).count();
-    if dropped > 0 {
+    let stored_path = |a: &&external_agent::AgentAttachment| match a {
+        external_agent::AgentAttachment::Image(img) => Some(img.local_path.is_some()),
+        external_agent::AgentAttachment::File(_) => None,
+    };
+    let referenced = attachments
+        .iter()
+        .filter(|a| stored_path(a) == Some(true))
+        .count();
+    let vanishing = attachments
+        .iter()
+        .filter(|a| stored_path(a) == Some(false))
+        .count();
+    if referenced > 0 {
         slog(session_log, |l| {
             l.warn(&format!(
-                "{agent_name} backend does not deliver image attachments; {dropped} image(s) will not reach the agent (text and staged file paths still sent)"
+                "{agent_name} backend does not take inline image input; {referenced} image attachment(s) delivered as stored-file path reference(s) only"
+            ));
+        });
+    }
+    if vanishing > 0 {
+        slog(session_log, |l| {
+            l.warn(&format!(
+                "{agent_name} backend does not take inline image input; {vanishing} image attachment(s) have no stored file and will not reach the agent"
             ));
         });
     }

--- a/src/bin/caller/run_modes.rs
+++ b/src/bin/caller/run_modes.rs
@@ -3851,8 +3851,10 @@ pub(crate) async fn run_direct_mode(
                     ))
                 });
                 // Append the new task as a continuation message
-                let resume_msg = attachments
-                    .text_with_file_prelude(&format!("[Session resumed] Continue with: {}", task));
+                let resume_msg = attachments.text_with_attachments_prelude(&format!(
+                    "[Session resumed] Continue with: {}",
+                    task
+                ));
                 let resume_seq = if attachment_images.is_empty() {
                     conv.add_user(MessageProvenance::ResumeTask, resume_msg)
                 } else {
@@ -3901,7 +3903,7 @@ pub(crate) async fn run_direct_mode(
                 let task_seq = setup_fresh_conversation_with_attachments(
                     &mut conv,
                     &project,
-                    &attachments.text_with_file_prelude(&task),
+                    &attachments.text_with_attachments_prelude(&task),
                     attachment_images.clone(),
                 );
                 slog(&session_log, |l| {
@@ -3921,7 +3923,7 @@ pub(crate) async fn run_direct_mode(
         let task_seq = setup_fresh_conversation_with_attachments(
             &mut conv,
             &project,
-            &attachments.text_with_file_prelude(&task),
+            &attachments.text_with_attachments_prelude(&task),
             attachment_images.clone(),
         );
         // The canonical record carries the renderable upload refs delivered

--- a/src/bin/caller/session_supervisor/routing.rs
+++ b/src/bin/caller/session_supervisor/routing.rs
@@ -1145,55 +1145,84 @@ impl SessionSupervisor {
             }
             return;
         }
-        if attachments.is_empty() {
-            let ack_rx = self.config.bus.subscribe();
-            self.config.bus.send(AppEvent::SteerRequested {
-                session_id: event_session_id.clone(),
-                text: text.clone(),
-                id: steer_id.clone(),
-            });
-            if !steer_id.trim().is_empty() {
-                spawn_text_steer_fallback(
-                    self.config.bus.clone(),
-                    ack_rx,
-                    tx,
-                    text,
-                    steer_id,
-                    event_session_id,
-                    Some(managed_id.clone()),
-                );
+        let resolved_attachments = if attachments.is_empty() {
+            UserAttachments::default()
+        } else {
+            let resolved = self
+                .resolve_session_attachments(&attachments, &session_dir, &project_root)
+                .await;
+            if resolved.len() < attachments.len() {
+                self.warn(&format!(
+                    "Only resolved {} of {} steer attachment(s) for {} session {}",
+                    resolved.len(),
+                    attachments.len(),
+                    source,
+                    short_session(&managed_id)
+                ));
             }
+            resolved
+        };
+
+        // Attachment-bearing steer without a correlation id: the native
+        // mid-turn lane's ack protocol can't be tracked without an id, so
+        // the one lane that needs no ack — queue as the next turn — is the
+        // only safe carrier for the attachment payload. (Frontends always
+        // mint ids; this is the conservative corner.)
+        if !resolved_attachments.is_empty() && steer_id.trim().is_empty() {
+            let msg = FollowUpMessage::steer(text, resolved_attachments, steer_id.clone())
+                .for_target(requested_id.clone().or(Some(managed_id.clone())));
+            if tx.send(msg).await.is_err() {
+                self.warn(&format!(
+                    "Steer dropped: {} session {} in {} is not accepting input",
+                    source,
+                    short_session(&managed_id),
+                    project_root.display()
+                ));
+                return;
+            }
+            self.config.bus.send(AppEvent::SteerQueued {
+                session_id: requested_id.or(Some(managed_id)),
+                id: steer_id,
+                reason: "attachments are queued for the next turn".to_string(),
+            });
             return;
         }
 
-        let resolved_attachments = self
-            .resolve_session_attachments(&attachments, &session_dir, &project_root)
-            .await;
-        if resolved_attachments.len() < attachments.len() {
-            self.warn(&format!(
-                "Only resolved {} of {} steer attachment(s) for {} session {}",
-                resolved_attachments.len(),
-                attachments.len(),
-                source,
-                short_session(&managed_id)
-            ));
-        }
-        let msg = FollowUpMessage::steer(text, resolved_attachments, steer_id.clone())
-            .for_target(requested_id.clone().or(Some(managed_id.clone())));
-        if tx.send(msg).await.is_err() {
-            self.warn(&format!(
-                "Steer dropped: {} session {} in {} is not accepting input",
-                source,
-                short_session(&managed_id),
-                project_root.display()
-            ));
-            return;
-        }
-        self.config.bus.send(AppEvent::SteerQueued {
-            session_id: requested_id.or(Some(managed_id)),
-            id: steer_id,
-            reason: "attachments are queued for the next turn".to_string(),
+        // The attachment-bearing steer rule (deliberate, keep coherent with
+        // `docs/src/external-agent-orchestration.md` "Attachment delivery"):
+        // a steer is a steer — it goes down the native mid-turn lane like
+        // any text steer, never parked for the turn boundary just because
+        // it carries files. The deliverable text is composed ONCE here —
+        // stored-path prelude (`[attachment stored: …]` per file) + the
+        // user's text — and every downstream lane carries it verbatim: the
+        // native mid-turn injection (text-only wire, so the stored path IS
+        // the image delivery mid-turn), the context-injection queue, and
+        // the no-active-turn immediate follow-up. Only if no lane acks
+        // does the fallback below queue the steer as the next turn, where
+        // the resolved attachments additionally ride as content blocks
+        // (the boundary lane can carry pixels; the send site re-derives
+        // the same prelude from the attachments, so the fallback passes
+        // the ORIGINAL text to avoid doubling it).
+        let steer_text =
+            external_agent::text_with_attachments_prelude(&text, &resolved_attachments.items);
+        let ack_rx = self.config.bus.subscribe();
+        self.config.bus.send(AppEvent::SteerRequested {
+            session_id: event_session_id.clone(),
+            text: steer_text,
+            id: steer_id.clone(),
         });
+        if !steer_id.trim().is_empty() {
+            spawn_steer_fallback(
+                self.config.bus.clone(),
+                ack_rx,
+                tx,
+                text,
+                resolved_attachments,
+                steer_id,
+                event_session_id,
+                Some(managed_id.clone()),
+            );
+        }
     }
 
     pub(crate) async fn route_cancel_steer(
@@ -1917,11 +1946,22 @@ pub(crate) fn emit_follow_up_status(
     });
 }
 
-pub(crate) fn spawn_text_steer_fallback(
+/// Arm the steer's queue-as-follow-up fallback: if no delivery lane acks
+/// the steer within [`TEXT_STEER_FALLBACK_TIMEOUT`], it becomes the target
+/// session's next turn. `text` is the user's ORIGINAL text and
+/// `attachments` the resolved attachment payload — the boundary send site
+/// derives the stored-path prelude from the attachments itself, so passing
+/// the composed steer text here would double the prelude. For a steer that
+/// carried attachments, this fallback is also where the pixels ride: the
+/// native mid-turn lane is text-only (stored-path lines), the boundary
+/// lane delivers the content blocks too.
+#[allow(clippy::too_many_arguments)] // established internal signature: the params are distinct dependencies, not a bundle
+pub(crate) fn spawn_steer_fallback(
     bus: EventBus,
     mut ack_rx: tokio::sync::broadcast::Receiver<AppEvent>,
     follow_up_tx: mpsc::Sender<FollowUpMessage>,
     text: String,
+    attachments: UserAttachments,
     steer_id: String,
     target_session_id: Option<String>,
     resolved_session_id: Option<String>,
@@ -1969,7 +2009,7 @@ pub(crate) fn spawn_text_steer_fallback(
             }
         }
 
-        let msg = FollowUpMessage::steer(text, UserAttachments::default(), steer_id.clone())
+        let msg = FollowUpMessage::steer(text, attachments, steer_id.clone())
             .for_target(target_session_id.clone());
         match follow_up_tx.send(msg).await {
             Ok(()) => bus.send(AppEvent::SteerQueued {
@@ -3378,6 +3418,173 @@ mod tests {
         }
     }
 
+    /// Scaffolding for the attachment-steer tests: a temp project store
+    /// with one committed image upload, and a supervisor managing one
+    /// session rooted there. Returns everything a route_steer call needs.
+    async fn attachment_steer_rig(
+        tmp: &tempfile::TempDir,
+        bus: EventBus,
+    ) -> (
+        SessionSupervisor,
+        mpsc::Receiver<FollowUpMessage>,
+        crate::upload_store::UploadDescriptor,
+    ) {
+        use std::io::Write as _;
+        let project_root = tmp.path().join("project");
+        let session_dir = tmp.path().join("session");
+        std::fs::create_dir_all(&project_root).unwrap();
+        std::fs::create_dir_all(&session_dir).unwrap();
+        let mut blob = tempfile::NamedTempFile::new().unwrap();
+        blob.write_all(b"png bytes").unwrap();
+        blob.flush().unwrap();
+        let descriptor = crate::upload_store::commit_upload(
+            blob,
+            "shot.png",
+            "image/png",
+            9,
+            crate::upload_store::UploadDestination::Task,
+            &session_dir,
+            "sess-1",
+            &crate::global_store::StoreScope::Project(project_root.clone()),
+        )
+        .unwrap();
+
+        let supervisor = test_supervisor(project_root.clone(), bus);
+        let (tx, rx) = mpsc::channel(1);
+        {
+            let mut state = supervisor.state.lock().await;
+            state.sessions.insert(
+                "parent-thread".to_string(),
+                ManagedSession {
+                    session_id: "parent-thread".to_string(),
+                    source: "claude-code".to_string(),
+                    name: None,
+                    phase: "thinking".to_string(),
+                    project_root,
+                    session_dir,
+                    follow_up_tx: tx,
+                    approval_registry: event::ApprovalRegistry::default(),
+                    instance_id: 0,
+                    finished_rx: None,
+                    depth: 0,
+                    sub_agent_children: None,
+                },
+            );
+        }
+        (supervisor, rx, descriptor)
+    }
+
+    /// An attachment-bearing steer takes the native mid-turn lane like any
+    /// text steer — parked-for-boundary is no longer its fate — and the
+    /// requested text is the SAME composition every other lane produces:
+    /// stored-path prelude (greppable `[attachment stored: …]` line naming
+    /// the upload-store file) followed by the user's text.
+    #[tokio::test]
+    async fn attachment_steer_takes_native_lane_with_stored_path_text() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bus = EventBus::new();
+        let mut bus_rx = bus.subscribe();
+        let (supervisor, mut rx, descriptor) = attachment_steer_rig(&tmp, bus.clone()).await;
+
+        supervisor
+            .route_steer(
+                Some("parent-thread".to_string()),
+                "PS: forgot to attach the screenshot".to_string(),
+                Some("steer-att-1".to_string()),
+                vec![format!("upload:{}", descriptor.id)],
+            )
+            .await;
+
+        // Lane parity pin: the steer text equals the one composition every
+        // delivery lane derives from the same attachment (built here from
+        // the store descriptor via the same builder).
+        let expected = external_agent::text_with_attachments_prelude(
+            "PS: forgot to attach the screenshot",
+            &[external_agent::AgentAttachment::Image(
+                external_agent::AgentImageAttachment::from_frame_path(
+                    descriptor.path.clone(),
+                    String::new(),
+                    "image/png".to_string(),
+                ),
+            )],
+        );
+        match bus_rx.recv().await.expect("steer requested event") {
+            AppEvent::SteerRequested {
+                session_id,
+                text,
+                id,
+            } => {
+                assert_eq!(session_id.as_deref(), Some("parent-thread"));
+                assert_eq!(id, "steer-att-1");
+                assert_eq!(text, expected, "steer text must be the shared composition");
+                assert!(
+                    text.contains(&format!(
+                        "{}{}]",
+                        external_agent::ATTACHMENT_STORED_MARKER,
+                        descriptor.path.display()
+                    )),
+                    "steer text must name the stored path: {text}"
+                );
+                assert!(text.ends_with("PS: forgot to attach the screenshot"));
+            }
+            other => panic!("expected steer requested event, got {other:?}"),
+        }
+
+        // No lane acked: the fallback queues the steer as the next turn,
+        // carrying the ORIGINAL text (the boundary send site re-derives the
+        // prelude) plus the resolved attachment so the pixels ride the
+        // boundary lane.
+        let msg = tokio::time::timeout(std::time::Duration::from_millis(300), rx.recv())
+            .await
+            .expect("unacknowledged attachment steer should queue as follow-up")
+            .expect("follow-up channel should stay open");
+        assert_eq!(msg.text, "PS: forgot to attach the screenshot");
+        assert_eq!(msg.steer_id.as_deref(), Some("steer-att-1"));
+        assert_eq!(msg.attachments.items.len(), 1);
+        match &msg.attachments.items[0] {
+            external_agent::AgentAttachment::Image(img) => {
+                assert_eq!(img.local_path.as_deref(), Some(descriptor.path.as_path()));
+            }
+            other => panic!("expected resolved image attachment, got {other:?}"),
+        }
+    }
+
+    /// A natively acked attachment steer must not also queue a boundary
+    /// follow-up — mid-turn text+path delivery IS the delivery (the stored
+    /// file is the pixel source), same dedup contract as text steers.
+    #[tokio::test]
+    async fn attachment_steer_native_ack_prevents_follow_up_fallback() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bus = EventBus::new();
+        let mut bus_rx = bus.subscribe();
+        let (supervisor, mut rx, descriptor) = attachment_steer_rig(&tmp, bus.clone()).await;
+
+        supervisor
+            .route_steer(
+                Some("parent-thread".to_string()),
+                "see the attached screenshot".to_string(),
+                Some("steer-att-2".to_string()),
+                vec![format!("upload:{}", descriptor.id)],
+            )
+            .await;
+
+        match bus_rx.recv().await.expect("steer requested event") {
+            AppEvent::SteerRequested { id, .. } => assert_eq!(id, "steer-att-2"),
+            other => panic!("expected steer requested event, got {other:?}"),
+        }
+        bus.send(AppEvent::SteerAccepted {
+            session_id: Some("parent-thread".to_string()),
+            id: "steer-att-2".to_string(),
+            reason: "claude-code accepted the steer".to_string(),
+        });
+
+        tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+        assert!(
+            rx.try_recv().is_err(),
+            "acknowledged attachment steer should not also queue a follow-up"
+        );
+    }
+
     #[tokio::test]
     async fn kimi_child_steer_slash_never_targets_parent_session() {
         let bus = EventBus::new();
@@ -3491,11 +3698,12 @@ mod tests {
         let mut bus_rx = bus.subscribe();
         let (tx, mut rx) = mpsc::channel(1);
 
-        spawn_text_steer_fallback(
+        spawn_steer_fallback(
             bus.clone(),
             bus.subscribe(),
             tx,
             "check the usage chips".to_string(),
+            UserAttachments::default(),
             "steer-alias-1".to_string(),
             Some("backend-native-id".to_string()),
             Some("wrapper-id".to_string()),


### PR DESCRIPTION
Dashboard attachments now reach every session as both the inline image
block (image-capable backends, unchanged) and a stable, greppable
stored-path line — "[attachment stored: <absolute path>]" — composed once
by external_agent::text_with_attachments_prelude and delivered verbatim on
every lane: new task, queued follow-up, mid-turn steer, and native
sessions. Backends without image input get the path line as the whole
image delivery instead of a silent drop; Kimi's native-upload overrides
compose the same prelude so the delivered shape is identical across
backends. The receiving agent can act on the stored file immediately
(read it, relay it to a sub-agent) without hunting the upload store.

Attachment-bearing steers no longer park at the turn boundary: route_steer
sends them down the native mid-turn injection lane like any text steer
(the lane is text-only, so the stored-path line IS the image delivery
mid-turn), and the ack-tracked fallback — spawn_steer_fallback, formerly
spawn_text_steer_fallback — queues the steer as the next turn with the
pixels riding as content blocks only when no lane acks. A natively acked
steer never double-delivers. Previously any steer with attachments
skipped the native lane entirely and was held for the boundary follow-up
lane, arriving minutes late and out of order relative to later text
steers (observed live: later text steers were injected mid-turn and
delivered first, so the model was asked about a screenshot before the
screenshot message had arrived).

The undeliverable-image warning now distinguishes stored images
(reference-delivered) from in-memory ones (truly undeliverable), and the
contract is documented in external-agent-orchestration.md ("Attachment
delivery").
