### PR TITLE
Track C C1: coordination bus glue — declaration lifecycle, env binds, daemon GC, sandbox grant

### DIFF
--- a/src/bin/caller/agent_loop.rs
+++ b/src/bin/caller/agent_loop.rs
@@ -1128,6 +1128,10 @@ pub(crate) async fn run_agent_loop(
     // Session-scoped MCP bootstrap for the runtime child's env: `ctl` run
     // by shell commands inside this session then auto-attributes to it.
     runtime_mcp_env: Option<&agent_runner::RuntimeMcpEnv>,
+    // The session's coordination-bus declaration (owned by the enclosing
+    // round loop): each turn boundary is a heartbeat tick (§1.5 cadence —
+    // throttled internally, no timers here).
+    coordination_declaration: Option<&coordination::lifecycle::SessionDeclarationGuard>,
 ) -> Result<(LoopStats, LoopExitReason), CallerError> {
     let mut budget_warning_shown = false;
     let mut empty_command_streak = 0usize;
@@ -1394,6 +1398,13 @@ pub(crate) async fn run_agent_loop(
                     });
                 }
             }
+        }
+
+        // Turn boundary = the native declaration's heartbeat tick
+        // (§1.5): an mtime touch at most once a minute, keeping the
+        // radar's staleness clock honest while the session works.
+        if let Some(declaration) = coordination_declaration {
+            declaration.heartbeat_now();
         }
 
         conversation.increment_turn();
@@ -3463,6 +3474,70 @@ fn steer_follow_up(
         .for_target(local_session_id.clone())
 }
 
+/// The declaration's `## intent` source for a native session: the most
+/// recent task-bearing user message (initial task, resume task, or the
+/// follow-up that started the current round). Free text — normalized
+/// and bounded by `declaration_intent` at write time.
+fn native_session_intent(conversation: &Conversation) -> String {
+    conversation
+        .messages()
+        .iter()
+        .rev()
+        .find(|m| {
+            matches!(
+                m.provenance,
+                MessageProvenance::Task
+                    | MessageProvenance::ResumeTask
+                    | MessageProvenance::FollowUp
+            )
+        })
+        .map(|m| m.content.clone())
+        .unwrap_or_default()
+}
+
+/// Coordination-bus declaration for a native supervised session (Track C
+/// §1.5): written at session start, heartbeat at turn boundaries, removed
+/// by the guard's Drop on any orderly loop exit — a crash-abandoned copy
+/// ages out by TTL. Space resolution follows the B1 seam (env override →
+/// derived worktree-normalized key), so a sub-agent session in an
+/// isolated worktree lands in its main repo's space. Advisory: bus
+/// trouble logs and the session runs undeclared; a session without an id
+/// has no writer identity and declares nothing.
+fn declare_native_session_on_bus(
+    local_session_id: &Option<String>,
+    project: &Project,
+    conversation: &Conversation,
+    session_log: &SharedSessionLog,
+) -> Option<coordination::lifecycle::SessionDeclarationGuard> {
+    let session_id = local_session_id.as_deref()?;
+    let (space_dir, space_key) = coordination::paths::resolve_space_dir(
+        coordination::paths::env_override().as_deref(),
+        &crate::platform::intendant_home(),
+        &project.root,
+    );
+    let intent = native_session_intent(conversation);
+    match coordination::lifecycle::SessionDeclarationGuard::declare(
+        coordination::lifecycle::DeclareParams {
+            space_dir: &space_dir,
+            space_key: &space_key,
+            session_id,
+            backend: "native",
+            project_root: &project.root,
+            branch: crate::worktree::current_branch(&project.root),
+            intent: &intent,
+        },
+        coordination::now_ms(),
+    ) {
+        Ok(guard) => Some(guard),
+        Err(e) => {
+            slog(session_log, |l| {
+                l.debug(&format!("Coordination declaration skipped: {e}"))
+            });
+            None
+        }
+    }
+}
+
 /// Wraps `run_agent_loop` in a multi-round loop that waits for follow-up messages
 /// between rounds. The session continues until the user closes the channel,
 /// budget is exhausted, safety cap is reached, or a non-recoverable exit occurs.
@@ -3503,6 +3578,11 @@ pub(crate) async fn run_round_loop(
     // so a dying watcher's late push cannot resurrect a delivered steer as
     // an extra round. Grows one small id per steer, like round_ledger.
     let mut delivered_steer_ids: HashSet<String> = HashSet::new();
+    // This loop IS the native session: declare on the coordination bus
+    // for its whole span (all rounds + parked waits); the guard's Drop
+    // removes the declaration on any orderly exit.
+    let coordination_declaration =
+        declare_native_session_on_bus(&local_session_id, project, conversation, &session_log);
 
     loop {
         let (stats, exit_reason) = run_agent_loop(
@@ -3524,6 +3604,7 @@ pub(crate) async fn run_round_loop(
             headless,
             orchestration,
             runtime_mcp_env,
+            coordination_declaration.as_ref(),
         )
         .await?;
 
@@ -4195,6 +4276,32 @@ fn budget_tail_index(
     tool_results
         .iter()
         .rposition(|(call_id, _, _)| !handled_call_ids.contains(call_id))
+}
+
+#[cfg(test)]
+mod coordination_intent {
+    use super::native_session_intent;
+    use crate::conversation::{Conversation, MessageProvenance};
+
+    #[test]
+    fn latest_task_bearing_message_wins_and_injections_never_do() {
+        let mut conv = Conversation::new("system".into(), 100_000);
+        assert_eq!(
+            native_session_intent(&conv),
+            "",
+            "no task yet → empty (declare falls back)"
+        );
+        conv.add_user(MessageProvenance::Task, "initial task".into());
+        conv.add_user(MessageProvenance::SystemInjection, "[System] nudge".into());
+        assert_eq!(native_session_intent(&conv), "initial task");
+        conv.add_user(MessageProvenance::FollowUp, "[New Task] pivot".into());
+        conv.add_user(MessageProvenance::Steer, "steer text".into());
+        assert_eq!(
+            native_session_intent(&conv),
+            "[New Task] pivot",
+            "latest task-bearing message is the session's current goal"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src/bin/caller/agent_loop.rs
+++ b/src/bin/caller/agent_loop.rs
@@ -287,10 +287,12 @@ pub(crate) fn handle_workflow_checkpoint_call(
     project: &Project,
     local_session_id: &Option<String>,
 ) -> String {
-    let Some(home) = dirs::home_dir() else {
-        return "Error: workflow_checkpoint needs a resolvable home directory.".to_string();
-    };
-    let space = match crate::coordination::CheckpointSpace::open(&home, &project.root) {
+    let (space_dir, space_key) = crate::coordination::paths::resolve_space_dir(
+        crate::coordination::paths::env_override().as_deref(),
+        &crate::platform::intendant_home(),
+        &project.root,
+    );
+    let space = match crate::coordination::CheckpointSpace::open_at(&space_dir, space_key) {
         Ok(space) => space,
         Err(e) => return format!("Error: {e}"),
     };

--- a/src/bin/caller/agent_loop.rs
+++ b/src/bin/caller/agent_loop.rs
@@ -4283,6 +4283,14 @@ mod coordination_intent {
     use super::native_session_intent;
     use crate::conversation::{Conversation, MessageProvenance};
 
+    /// UFCS on purpose: the provenance-parity pin below censuses this
+    /// file's production conversation entry points by their method-call
+    /// spelling; a test fixture is not an emission site and must not
+    /// join (or force a re-pin of) that count.
+    fn append(conv: &mut Conversation, provenance: MessageProvenance, text: &str) {
+        Conversation::add_user(conv, provenance, text.to_string());
+    }
+
     #[test]
     fn latest_task_bearing_message_wins_and_injections_never_do() {
         let mut conv = Conversation::new("system".into(), 100_000);
@@ -4291,11 +4299,15 @@ mod coordination_intent {
             "",
             "no task yet → empty (declare falls back)"
         );
-        conv.add_user(MessageProvenance::Task, "initial task".into());
-        conv.add_user(MessageProvenance::SystemInjection, "[System] nudge".into());
+        append(&mut conv, MessageProvenance::Task, "initial task");
+        append(
+            &mut conv,
+            MessageProvenance::SystemInjection,
+            "[System] nudge",
+        );
         assert_eq!(native_session_intent(&conv), "initial task");
-        conv.add_user(MessageProvenance::FollowUp, "[New Task] pivot".into());
-        conv.add_user(MessageProvenance::Steer, "steer text".into());
+        append(&mut conv, MessageProvenance::FollowUp, "[New Task] pivot");
+        append(&mut conv, MessageProvenance::Steer, "steer text");
         assert_eq!(
             native_session_intent(&conv),
             "[New Task] pivot",

--- a/src/bin/caller/agent_runner.rs
+++ b/src/bin/caller/agent_runner.rs
@@ -358,6 +358,9 @@ const RUNTIME_CHILD_BASE_ENV: &[&str] = &[
     // Exact controller→runtime path control; all other INTENDANT_* names
     // default-deny and the spawn site injects its live controls explicitly.
     "INTENDANT_HOME",
+    // Coordination-space bind (Track C): shell children resolve the
+    // session's bus space through this; carries no authority.
+    "INTENDANT_COORDINATION_DIR",
 ];
 
 /// Whether a controller env name may be copied into the runtime's cleared
@@ -768,6 +771,20 @@ async fn run_agent_inner(
     // pipeline got this via `cd <dir> &&` in its spawn shell string.)
     if let Some(workdir) = workdir.filter(|dir| dir.is_dir()) {
         cmd.current_dir(workdir);
+    }
+
+    // Coordination-space bind (Track C): the runtime's shell children
+    // read and write bus files (declarations, messages) via the
+    // coordination skill, so export the session's resolved space dir.
+    // An isolated worktree child thereby lands in its main repo's
+    // space; an inherited override wins (sub-agent seam).
+    if let Some(root) = workdir.filter(|dir| dir.is_dir()) {
+        let (space_dir, _) = crate::coordination::paths::resolve_space_dir(
+            crate::coordination::paths::env_override().as_deref(),
+            &crate::platform::intendant_home(),
+            root,
+        );
+        cmd.env(crate::coordination::paths::COORDINATION_DIR_ENV, &space_dir);
     }
 
     // If sandbox config is provided, serialize it as an env var. The

--- a/src/bin/caller/coordination/checkpoint.rs
+++ b/src/bin/caller/coordination/checkpoint.rs
@@ -26,7 +26,11 @@ pub(crate) struct CheckpointSpace {
 impl CheckpointSpace {
     /// Root a space under `<home>/.intendant/coordination/`. `home` is
     /// a parameter (hermetic tests inject tempdirs; the tool edge
-    /// resolves the real home — the repo's hermeticity rule).
+    /// resolves the real home — the repo's hermeticity rule). Production
+    /// edges resolve through `paths::resolve_space_dir` + [`Self::open_at`]
+    /// (the B1 seam), leaving this derivation-included shape to the
+    /// checkpoint tests, which pin it unmodified.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn open(
         home: &Path,
         project_root: &Path,

--- a/src/bin/caller/coordination/checkpoint.rs
+++ b/src/bin/caller/coordination/checkpoint.rs
@@ -32,11 +32,18 @@ impl CheckpointSpace {
         project_root: &Path,
     ) -> Result<CheckpointSpace, CoordinationError> {
         let space = space_key(project_root);
-        let dir = home
-            .join(".intendant")
-            .join("coordination")
-            .join(&space)
-            .join("checkpoints");
+        let space_dir = home.join(".intendant").join("coordination").join(&space);
+        Self::open_at(&space_dir, space)
+    }
+
+    /// Root a space at an already-resolved space dir (the
+    /// `paths::resolve_space_dir` seam — env is read at the caller's
+    /// edge, never here).
+    pub(crate) fn open_at(
+        space_dir: &Path,
+        space: String,
+    ) -> Result<CheckpointSpace, CoordinationError> {
+        let dir = space_dir.join("checkpoints");
         std::fs::create_dir_all(&dir).map_err(io_err)?;
         restrict_dir_modes(&dir)?;
         Ok(CheckpointSpace { dir, space })

--- a/src/bin/caller/coordination/declarations.rs
+++ b/src/bin/caller/coordination/declarations.rs
@@ -6,7 +6,6 @@
 //! (45 min), garbage collection is time-based (24 h — the ruled §9
 //! rule-8 amendment for liveness kinds), and a reader treats every
 //! field as unverified same-UID input.
-#![cfg_attr(not(test), allow(dead_code))] // C1 PR A: consumed by the PR-B glue; allow dropped as wiring lands.
 
 use std::io::Write as IoWrite;
 use std::path::{Path, PathBuf};
@@ -273,6 +272,7 @@ impl DeclarationSpace {
 
     /// The radar's read: every declaration in the space, with the
     /// rule-5 liveness amendment — malformed entries surface by name.
+    #[cfg_attr(not(test), allow(dead_code))] // C2 radar's entry point; write/GC paths are live (C1 PR B).
     pub(crate) fn scan(
         &self,
         now_ms: u64,
@@ -308,7 +308,10 @@ pub(crate) fn scan_dir(
 
 /// Branch names render in radar summaries: printable, bounded, no
 /// control bytes, no leading dash (option-injection hygiene).
-fn valid_branch(s: &str) -> bool {
+/// `pub(crate)`: the lifecycle glue pre-filters its optional branch
+/// hint through the same grammar rather than sinking a declaration on
+/// an exotic branch name.
+pub(crate) fn valid_branch(s: &str) -> bool {
     !s.is_empty()
         && s.len() <= 256
         && !s.starts_with('-')

--- a/src/bin/caller/coordination/gc.rs
+++ b/src/bin/caller/coordination/gc.rs
@@ -10,8 +10,6 @@
 //! eligible inside `checkpoints/`). Malformed liveness entries are
 //! KEPT and reported — GC deletes only what it can positively
 //! attribute to an expired lifetime, never what it cannot parse.
-#![cfg_attr(not(test), allow(dead_code))] // C1 PR A: consumed by the PR-B daemon wiring; allow dropped as wiring lands.
-
 use std::path::Path;
 
 use super::{declarations, messages, scan, MAX_SCAN_ENTRIES};
@@ -314,5 +312,32 @@ mod tests {
         assert_eq!(report.spaces, 2);
         assert_eq!(report.declarations_removed, 2);
         assert!(report.errors.is_empty(), "{:?}", report.errors);
+    }
+}
+
+/// Daemon-startup sweep (the `global_store::prune_at_daemon_startup`
+/// pattern): resolve the real state root at the edge, sweep every
+/// space, log one line when anything happened.
+pub(crate) fn sweep_at_daemon_startup() {
+    let root = super::paths::coordination_root(&crate::platform::intendant_home());
+    let report = sweep_all(&root, super::now_ms());
+    if report.removed_anything() || !report.errors.is_empty() || !report.malformed_kept.is_empty() {
+        eprintln!(
+            "[coordination] gc: {} declarations, {} messages, {} temp orphans removed across {} spaces{}{}",
+            report.declarations_removed,
+            report.messages_removed,
+            report.tmp_removed,
+            report.spaces,
+            if report.malformed_kept.is_empty() {
+                String::new()
+            } else {
+                format!("; kept malformed: {}", report.malformed_kept.join(", "))
+            },
+            if report.errors.is_empty() {
+                String::new()
+            } else {
+                format!("; errors: {}", report.errors.join("; "))
+            },
+        );
     }
 }

--- a/src/bin/caller/coordination/lifecycle.rs
+++ b/src/bin/caller/coordination/lifecycle.rs
@@ -1,0 +1,310 @@
+//! Declaration lifecycle glue (Track C, C1): the supervised-session
+//! writer for the `sessions/` liveness lane.
+//!
+//! One guard per live supervised session, owned by the session's loop:
+//! the loop declares at session start, heartbeats at its natural
+//! boundaries (native glue: turn boundaries; wrapper glue: event-drain
+//! ticks — ruled §1.5 cadence, no new timers), and the guard removes
+//! the declaration on Drop (any orderly loop exit). A crash that skips
+//! Drop is exactly the abandoned-declaration case the TTL sweep exists
+//! for. Every operation is advisory liveness DATA for the radar —
+//! declare errors are surfaced to the caller's session log and the
+//! session proceeds undeclared; heartbeat trouble is swallowed (the
+//! next beat retries, staleness stays honest by mtime).
+//!
+//! The guard is also where the writer-identity mapping lives:
+//! [`writer_id_for_session`] is the single session-id → bus-writer-id
+//! rule, shared by every kind so the C3 message lane cannot drift from
+//! the declaration filename.
+
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use super::declarations::{DeclarationInput, DeclarationSpace};
+use super::{sanitize_key, scan, CoordinationError};
+
+/// Minimum interval between heartbeat writes (§1.5): refreshes ride
+/// natural boundaries, which for a busy wrapper can tick sub-second —
+/// the throttle keeps the cost at one `utimes` a minute, plenty to
+/// resolve the 45-minute staleness threshold.
+pub(crate) const HEARTBEAT_MIN_INTERVAL_MS: u64 = 60 * 1000;
+
+/// Intent truncation bound: §1.5 wants "one short paragraph" (advisory
+/// body ≤ 8 KiB); a session goal is often a full task prompt, so the
+/// glue keeps the head and marks the cut.
+pub(crate) const MAX_INTENT_BYTES: usize = 1024;
+
+/// Written when a session has no stated task text (attached externals,
+/// resumed shells) — `write_own` refuses empty intent, and an honest
+/// placeholder beats an invented one.
+pub(crate) const FALLBACK_INTENT: &str = "(session started without a stated task)";
+
+/// The one session-id → writer-id mapping for the bus (declaration
+/// filename stem today; the C3 `messages/<writer>/` dir must reuse it).
+/// `s-` marks supervised sessions apart from `guest-<ulid>` writers and
+/// keeps the stem clear of the reserved `daemon` name by construction;
+/// sanitizing the composed string keeps the result inside the §1.3
+/// grammar (and its 64-char clamp) for any session id.
+pub(crate) fn writer_id_for_session(session_id: &str) -> String {
+    sanitize_key(&format!("s-{session_id}"))
+}
+
+/// Collapse a session goal into the declaration's `## intent` paragraph:
+/// whitespace runs (newlines included) become single spaces — the body
+/// section markers are line-anchored, so a one-line paragraph can never
+/// open a `## dirty` section — then truncate at a char boundary with an
+/// ellipsis. Empty input gets the honest fallback.
+pub(crate) fn declaration_intent(raw: &str) -> String {
+    let mut collapsed = String::with_capacity(raw.len().min(MAX_INTENT_BYTES + 8));
+    let mut gap_pending = false;
+    for c in raw.chars() {
+        if c.is_whitespace() {
+            gap_pending = !collapsed.is_empty();
+            continue;
+        }
+        if gap_pending {
+            collapsed.push(' ');
+            gap_pending = false;
+        }
+        collapsed.push(c);
+        if collapsed.len() > MAX_INTENT_BYTES {
+            break;
+        }
+    }
+    if collapsed.is_empty() {
+        return FALLBACK_INTENT.to_string();
+    }
+    if collapsed.len() > MAX_INTENT_BYTES {
+        let mut cut = MAX_INTENT_BYTES;
+        while !collapsed.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        collapsed.truncate(cut);
+        collapsed.push('…');
+    }
+    collapsed
+}
+
+/// Everything a session loop knows at declare time. Paths and the space
+/// key arrive RESOLVED (see `paths::resolve_space_dir`) — the guard
+/// never reads env or a home dir, so tests inject tempdir spaces.
+pub(crate) struct DeclareParams<'a> {
+    pub space_dir: &'a Path,
+    pub space_key: &'a str,
+    /// The supervised session's id, verbatim (mapped through
+    /// [`writer_id_for_session`] for the filename; recorded sanitized in
+    /// the `session:` field).
+    pub session_id: &'a str,
+    /// One of the closed §1.5 backend set (`native`, `codex`,
+    /// `claude-code`, `kimi`, `pi`).
+    pub backend: &'a str,
+    /// The session's checkout root; recorded as `root:` when it passes
+    /// the absolute-path grammar, silently omitted otherwise (optional
+    /// hint fields never sink the whole declaration).
+    pub project_root: &'a Path,
+    /// Checked-out branch when known; same optional-hint treatment.
+    pub branch: Option<String>,
+    /// Raw session goal/title; normalized via [`declaration_intent`].
+    pub intent: &'a str,
+}
+
+/// RAII holder for one session's own declaration. Heartbeats take
+/// `&self` (interior-mutable throttle clock) so shared drain contexts
+/// can tick without a `&mut` thread through their call stacks.
+pub(crate) struct SessionDeclarationGuard {
+    space: DeclarationSpace,
+    id: String,
+    session_id: String,
+    backend: String,
+    root: Option<String>,
+    branch: Option<String>,
+    intent: String,
+    last_beat_ms: AtomicU64,
+}
+
+impl SessionDeclarationGuard {
+    /// Open the space's `sessions/` store and write this session's
+    /// declaration. Errors are the caller's to log — the session runs
+    /// undeclared rather than failing over bus trouble.
+    pub(crate) fn declare(
+        params: DeclareParams<'_>,
+        now_ms: u64,
+    ) -> Result<Self, CoordinationError> {
+        let root_str = params.project_root.to_string_lossy();
+        let guard = SessionDeclarationGuard {
+            space: DeclarationSpace::open(params.space_dir, params.space_key)?,
+            id: writer_id_for_session(params.session_id),
+            session_id: params.session_id.to_string(),
+            backend: params.backend.to_string(),
+            root: scan::valid_abs_path(&root_str).then(|| root_str.into_owned()),
+            branch: params
+                .branch
+                .filter(|b| super::declarations::valid_branch(b)),
+            intent: declaration_intent(params.intent),
+            last_beat_ms: AtomicU64::new(now_ms),
+        };
+        guard.space.write_own(&guard.input())?;
+        Ok(guard)
+    }
+
+    /// Piggybacked liveness beat: an mtime touch, at most once per
+    /// [`HEARTBEAT_MIN_INTERVAL_MS`]. A declaration that vanished under
+    /// the guard (GC'd past TTL, tidied by hand) is re-declared — the
+    /// session is demonstrably still live. Failures are swallowed: the
+    /// beat window is claimed first, so trouble retries a minute later
+    /// instead of on every tick.
+    pub(crate) fn heartbeat(&self, now_ms: u64) {
+        let last = self.last_beat_ms.load(Ordering::Relaxed);
+        if now_ms.saturating_sub(last) < HEARTBEAT_MIN_INTERVAL_MS {
+            return;
+        }
+        self.last_beat_ms.store(now_ms, Ordering::Relaxed);
+        match self.space.touch_own(&self.id) {
+            Ok(true) => {}
+            Ok(false) => {
+                let _ = self.space.write_own(&self.input());
+            }
+            Err(_) => {}
+        }
+    }
+
+    /// [`Self::heartbeat`] on the process clock (the loop edges' form).
+    pub(crate) fn heartbeat_now(&self) {
+        self.heartbeat(super::now_ms());
+    }
+
+    /// The parsed view of what this guard last wrote (re-declare input).
+    fn input(&self) -> DeclarationInput<'_> {
+        DeclarationInput {
+            id: &self.id,
+            session: Some(&self.session_id),
+            backend: Some(&self.backend),
+            root: self.root.as_deref(),
+            branch: self.branch.as_deref(),
+            intent: &self.intent,
+            dirty: &[],
+        }
+    }
+
+    /// Read back the own declaration (tests + diagnostics).
+    #[cfg(test)]
+    pub(crate) fn read_back(&self) -> Option<super::declarations::SessionDeclaration> {
+        self.space.read_own(&self.id).ok().flatten()
+    }
+}
+
+impl Drop for SessionDeclarationGuard {
+    fn drop(&mut self) {
+        // Clean-end removal (§1.5). Best-effort: a failure here leaves
+        // an abandoned declaration for the TTL sweep, never a panic in
+        // an unwinding session.
+        let _ = self.space.remove_own(&self.id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn params<'a>(space_dir: &'a Path, intent: &'a str) -> DeclareParams<'a> {
+        DeclareParams {
+            space_dir,
+            space_key: "test-space",
+            session_id: "Sess_01ABC",
+            backend: "native",
+            project_root: Path::new("/tmp/proj"),
+            branch: Some("feat/x".to_string()),
+            intent,
+        }
+    }
+
+    #[test]
+    fn writer_id_mapping_is_grammar_safe_and_bounded() {
+        assert_eq!(writer_id_for_session("abc"), "s-abc");
+        assert_eq!(writer_id_for_session("Sess_01ABC"), "s-sess-01abc");
+        let long = writer_id_for_session(&"x".repeat(200));
+        assert!(long.len() <= 64);
+        assert_eq!(sanitize_key(&long), long, "idempotent under the grammar");
+        // The supervised prefix keeps the stem off the reserved name.
+        assert_ne!(writer_id_for_session("daemon"), "daemon");
+    }
+
+    #[test]
+    fn intent_normalization_collapses_truncates_and_falls_back() {
+        assert_eq!(declaration_intent("  fix\nthe\tbus  "), "fix the bus");
+        assert_eq!(declaration_intent("   \n\t  "), FALLBACK_INTENT);
+        // A multi-line goal can never smuggle a line-anchored section
+        // marker into the body.
+        assert!(!declaration_intent("x\n## dirty\n- evil").contains('\n'));
+        let long = declaration_intent(&"é".repeat(2 * MAX_INTENT_BYTES));
+        assert!(long.len() <= MAX_INTENT_BYTES + '…'.len_utf8());
+        assert!(long.ends_with('…'), "cut is marked");
+    }
+
+    #[test]
+    fn declare_heartbeat_drop_lifecycle() {
+        let tmp = tempfile::tempdir().unwrap();
+        let space = tmp.path().join("space");
+        let now = super::super::now_ms();
+        let guard =
+            SessionDeclarationGuard::declare(params(&space, "carve the glue"), now).unwrap();
+        let file = tmp.path().join("space/sessions/s-sess-01abc.md");
+        assert!(file.is_file());
+
+        let decl = guard.read_back().expect("own declaration parses");
+        assert_eq!(decl.backend.as_deref(), Some("native"));
+        assert_eq!(decl.session.as_deref(), Some("sess-01abc"));
+        assert_eq!(decl.root.as_deref(), Some("/tmp/proj"));
+        assert_eq!(decl.branch.as_deref(), Some("feat/x"));
+        assert_eq!(decl.intent, "carve the glue");
+        assert!(
+            decl.dirty.is_empty(),
+            "glue declares no dirty paths (C2 radar unions git status)"
+        );
+
+        // Inside the throttle window: no write happens (removing the
+        // file makes any write observable).
+        std::fs::remove_file(&file).unwrap();
+        guard.heartbeat(now + HEARTBEAT_MIN_INTERVAL_MS - 1);
+        assert!(!file.exists(), "throttled beat writes nothing");
+
+        // Past the window: the vanished declaration is re-declared.
+        guard.heartbeat(now + HEARTBEAT_MIN_INTERVAL_MS + 1);
+        assert!(file.is_file(), "vanished declaration re-declared");
+
+        drop(guard);
+        assert!(!file.exists(), "clean end removes the declaration");
+    }
+
+    #[test]
+    fn invalid_hint_fields_are_omitted_not_fatal() {
+        let tmp = tempfile::tempdir().unwrap();
+        let space = tmp.path().join("space");
+        let mut p = params(&space, "x");
+        p.project_root = Path::new("relative/not/abs");
+        p.branch = Some("-rf".to_string());
+        let guard = SessionDeclarationGuard::declare(p, super::super::now_ms()).unwrap();
+        let decl = guard.read_back().unwrap();
+        assert_eq!(decl.root, None, "non-grammar root omitted");
+        assert_eq!(decl.branch, None, "non-grammar branch omitted");
+    }
+
+    #[test]
+    fn declare_refuses_only_on_real_write_trouble() {
+        // A session id that sanitizes to a usable stem never fails; the
+        // error path is the store's own (e.g. an unwritable space dir).
+        let tmp = tempfile::tempdir().unwrap();
+        let file_in_the_way = tmp.path().join("blocked");
+        std::fs::write(&file_in_the_way, "x").unwrap();
+        let p = DeclareParams {
+            space_dir: &file_in_the_way,
+            space_key: "blocked",
+            session_id: "s1",
+            backend: "native",
+            project_root: Path::new("/p"),
+            branch: None,
+            intent: "x",
+        };
+        assert!(SessionDeclarationGuard::declare(p, 0).is_err());
+    }
+}

--- a/src/bin/caller/coordination/messages.rs
+++ b/src/bin/caller/coordination/messages.rs
@@ -5,7 +5,7 @@
 //! weighs, and expiry is advisory until GC removes the file. The
 //! `daemon` writer name is reserved for the daemon's own lanes
 //! (C2 radar notes); plain writers are refused it here.
-#![cfg_attr(not(test), allow(dead_code))] // C1 PR A: consumed by the C2/C3 lanes + skill; allow dropped as wiring lands.
+#![cfg_attr(not(test), allow(dead_code))] // C1 staging: GC already consumes the scan side; the write/read lanes are C2 (radar notes) / C3 (messages + skill). Drop as that wiring lands.
 
 use std::io::Write as IoWrite;
 use std::path::{Path, PathBuf};

--- a/src/bin/caller/coordination/mod.rs
+++ b/src/bin/caller/coordination/mod.rs
@@ -64,9 +64,12 @@
 //! sessions; the `daemon` writer name is reserved for the daemon's
 //! lanes). `scan.rs` carries the shared rule-5 liveness machinery and
 //! field grammars, `paths.rs` the space-dir resolution seam
-//! (`INTENDANT_COORDINATION_DIR` override → derived key), and `gc.rs`
-//! the rule-8 liveness sweep. The consumers — collision radar,
-//! daemon-rendered prompt lanes, the CLI — are C2/C3.
+//! (`INTENDANT_COORDINATION_DIR` override → derived key), `gc.rs` the
+//! rule-8 liveness sweep, and `lifecycle.rs` the supervised-session
+//! declaration glue (declare at start / heartbeat at loop boundaries /
+//! remove on clean end) the native and wrapper loops own. The
+//! consumers — collision radar, daemon-rendered prompt lanes, the
+//! CLI — are C2/C3.
 
 use std::path::{Path, PathBuf};
 
@@ -74,6 +77,7 @@ mod checkpoint;
 pub(crate) use checkpoint::*;
 pub(crate) mod declarations;
 pub(crate) mod gc;
+pub(crate) mod lifecycle;
 pub(crate) mod messages;
 pub(crate) mod paths;
 pub(crate) mod scan;
@@ -249,7 +253,9 @@ fn ulid_like() -> String {
     out
 }
 
-fn now_ms() -> u64 {
+/// Process clock in epoch ms — `pub(crate)` so the loop edges can pass
+/// the same clock the stores use into declare/heartbeat calls.
+pub(crate) fn now_ms() -> u64 {
     use std::time::{SystemTime, UNIX_EPOCH};
     SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/src/bin/caller/coordination/paths.rs
+++ b/src/bin/caller/coordination/paths.rs
@@ -10,8 +10,6 @@
 //! covers detached temp clones and deliberate space grouping). Env is
 //! read only at the process edge (`env_override`); everything below
 //! takes explicit paths (the repo's hermeticity rule).
-#![cfg_attr(not(test), allow(dead_code))] // C1 PR A: consumed by the PR-B glue; allow dropped as wiring lands.
-
 use std::path::{Path, PathBuf};
 
 pub(crate) const COORDINATION_DIR_ENV: &str = "INTENDANT_COORDINATION_DIR";

--- a/src/bin/caller/coordination/scan.rs
+++ b/src/bin/caller/coordination/scan.rs
@@ -263,11 +263,18 @@ pub(crate) fn valid_rel_path(s: &str) -> bool {
 
 /// Absolute box-local path field (`root:`): printable, bounded, no
 /// control bytes — machine value, never rendered into summaries.
+/// "Absolute" is judged for every platform's spelling (all three are
+/// first-class): unix `/…`, Windows drive (`C:\…` / `C:/…`) and UNC
+/// (`\\server\…`) forms — a Windows daemon's declarations must carry
+/// their roots too.
 pub(crate) fn valid_abs_path(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    let windows_abs = matches!(bytes, [drive, b':', b'\\' | b'/', ..] if drive.is_ascii_alphabetic())
+        || s.starts_with("\\\\");
     !s.is_empty()
         && s.len() <= 1024
-        && s.starts_with('/')
-        && !s.bytes().any(|b| b.is_ascii_control())
+        && (s.starts_with('/') || windows_abs)
+        && !bytes.iter().any(|b| b.is_ascii_control())
 }
 
 /// Closed backend enum for declaration frontmatter.
@@ -313,6 +320,29 @@ mod tests {
             assert!(!valid_rel_path(bad), "{bad:?} must be rejected");
         }
         assert!(!valid_rel_path(&"x".repeat(513)), "length bound");
+    }
+
+    #[test]
+    fn abs_path_grammar_accepts_every_platform_spelling() {
+        for good in [
+            "/Users/u/projects/x",
+            "/tmp",
+            "C:\\Users\\ci\\repo",
+            "c:/work/repo",
+            "\\\\server\\share\\repo",
+        ] {
+            assert!(valid_abs_path(good), "{good:?} must be accepted");
+        }
+        for bad in [
+            "",
+            "relative/path",
+            "C:no-separator",
+            "1:\\not-a-drive",
+            "has\x1bcontrol/",
+            &format!("/{}", "x".repeat(1024)),
+        ] {
+            assert!(!valid_abs_path(bad), "{bad:?} must be rejected");
+        }
     }
 
     #[test]

--- a/src/bin/caller/external_agent/claude_code.rs
+++ b/src/bin/caller/external_agent/claude_code.rs
@@ -3756,6 +3756,7 @@ impl ExternalAgent for ClaudeCodeAgent {
                 &self.intendant_mcp_url(port),
                 self.mcp_session_id.as_deref(),
                 self.mcp_auth_token.as_deref(),
+                Some(&config.working_dir),
             );
         }
         // An active oauth:claude-code lease materializes a synthesized

--- a/src/bin/caller/external_agent/codex/mod.rs
+++ b/src/bin/caller/external_agent/codex/mod.rs
@@ -617,6 +617,10 @@ impl CodexAgent {
             &self.intendant_mcp_url(port),
             self.mcp_session_id.as_deref(),
             self.mcp_auth_token.as_deref(),
+            // The spawn assigns `working_dir` from the launch config
+            // before building the child env, so the coordination-space
+            // bind rides the same call (None in unit tests → no bind).
+            self.working_dir.as_deref(),
         );
         command.env(
             "INTENDANT_MANAGED_CONTEXT",

--- a/src/bin/caller/external_agent/kimi_code/mod.rs
+++ b/src/bin/caller/external_agent/kimi_code/mod.rs
@@ -1520,6 +1520,7 @@ impl ExternalAgent for KimiCodeAgent {
                     url,
                     self.mcp_session_id.as_deref(),
                     self.mcp_auth_token.as_deref(),
+                    Some(&config.working_dir),
                 );
             }
             crate::platform::die_with_parent(&mut command);

--- a/src/bin/caller/external_agent/mod.rs
+++ b/src/bin/caller/external_agent/mod.rs
@@ -170,11 +170,21 @@ pub(crate) fn intendant_bootstrap_mcp_url_at(
 /// without putting the secret on argv. With these set,
 /// `"$INTENDANT" ctl ...` works from any backend's shell without further
 /// configuration.
+///
+/// `project_root` (the backend's working dir) additionally binds the
+/// session's coordination space (Track C §3.6): this is the ruled
+/// plumbing site for all four external backends — the child's shell
+/// resolves the bus through `INTENDANT_COORDINATION_DIR` instead of
+/// re-deriving the space key. An override already on the supervisor's
+/// own env wins (a supervised controller keeps its parent's space);
+/// the var carries no authority. `None` (tests, portless spawns)
+/// skips the bind — and the env read — entirely.
 pub(super) fn add_intendant_bootstrap_env(
     command: &mut tokio::process::Command,
     mcp_url: &str,
     session_id: Option<&str>,
     mcp_token: Option<&str>,
+    project_root: Option<&std::path::Path>,
 ) {
     command.env("INTENDANT_MCP_URL", mcp_url);
     if let Some(session_id) = session_id.map(str::trim).filter(|s| !s.is_empty()) {
@@ -189,6 +199,14 @@ pub(super) fn add_intendant_bootstrap_env(
     }
     if let Ok(current_exe) = std::env::current_exe() {
         command.env("INTENDANT", current_exe);
+    }
+    if let Some(root) = project_root.filter(|dir| dir.is_dir()) {
+        let (space_dir, _) = crate::coordination::paths::resolve_space_dir(
+            crate::coordination::paths::env_override().as_deref(),
+            &crate::platform::intendant_home(),
+            root,
+        );
+        command.env(crate::coordination::paths::COORDINATION_DIR_ENV, space_dir);
     }
 }
 
@@ -2261,6 +2279,7 @@ mod tests {
             "http://localhost:1/mcp?x",
             Some("sess-1"),
             Some("process-token"),
+            None, // no project root → no coordination bind (and no env/home read)
         );
 
         let envs: Vec<(OsString, Option<OsString>)> = command
@@ -2305,6 +2324,52 @@ mod tests {
             Some(OsString::from(
                 crate::web_gateway::session_scoped_mcp_token("process-token", "sess-1")
             ))
+        );
+        assert!(
+            set_value_for(crate::coordination::paths::COORDINATION_DIR_ENV).is_none(),
+            "no project root → no coordination bind"
+        );
+    }
+
+    /// The §3.6 external plumbing site: a project root binds the child's
+    /// `INTENDANT_COORDINATION_DIR`. Hermetic — the supervisor-side
+    /// override is set (under the env lock), so resolution short-circuits
+    /// before any home-dir or git access.
+    #[test]
+    fn bootstrap_env_binds_coordination_space_for_supervised_children() {
+        use std::ffi::{OsStr, OsString};
+
+        let _env = crate::test_support::TEST_ENV_LOCK.blocking_lock();
+        let var = crate::coordination::paths::COORDINATION_DIR_ENV;
+        let saved = std::env::var_os(var);
+        let tmp = tempfile::tempdir().unwrap();
+        let space = tmp.path().join("proj-0011223344556677");
+        std::fs::create_dir_all(&space).unwrap();
+        std::env::set_var(var, &space);
+
+        let mut command = tokio::process::Command::new("true");
+        add_intendant_bootstrap_env(
+            &mut command,
+            "http://localhost:1/mcp?x",
+            Some("sess-1"),
+            None,
+            Some(tmp.path()),
+        );
+
+        match &saved {
+            Some(v) => std::env::set_var(var, v),
+            None => std::env::remove_var(var),
+        }
+
+        let bound = command
+            .as_std()
+            .get_envs()
+            .find(|(k, _)| *k == OsStr::new(var))
+            .and_then(|(_, v)| v.map(OsString::from));
+        assert_eq!(
+            bound,
+            Some(space.as_os_str().to_os_string()),
+            "supervisor override rides through to the child verbatim"
         );
     }
 

--- a/src/bin/caller/external_agent/pi.rs
+++ b/src/bin/caller/external_agent/pi.rs
@@ -524,6 +524,7 @@ impl ExternalAgent for PiAgent {
                 &url,
                 self.mcp_session_id.as_deref(),
                 self.mcp_auth_token.as_deref(),
+                Some(&config.working_dir),
             );
         }
         if let Some(dir) = crate::credential_leases::materialized_pi_agent_dir() {

--- a/src/bin/caller/external_events.rs
+++ b/src/bin/caller/external_events.rs
@@ -1150,6 +1150,13 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
             }
         };
 
+        // Event-drain tick = the wrapper's declaration heartbeat (§1.5):
+        // the backend demonstrably produced work, so the supervisor
+        // refreshes its liveness claim (throttled inside the guard).
+        if let Some(declaration) = config.coordination_declaration {
+            declaration.heartbeat_now();
+        }
+
         let (event_thread_id, event_turn_id, event) = event.into_scope();
         let event_is_primary =
             scoped_event_targets_config(&event_thread_id, &local_session_id, &alias_session_id);
@@ -1200,6 +1207,9 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                 headless: config.headless,
                 context_injection: config.context_injection,
                 reload_credentials: config.reload_credentials,
+                // Child activity is the same supervised session working:
+                // the parent's declaration stays the one liveness claim.
+                coordination_declaration: config.coordination_declaration,
             };
             &child_config_storage
         } else {
@@ -3032,6 +3042,7 @@ mod tests {
             headless: true,
             context_injection: &context_injection,
             reload_credentials: None,
+            coordination_declaration: None,
         };
         let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
         let delayed_bus = bus.clone();
@@ -3114,6 +3125,7 @@ mod tests {
             headless: true,
             context_injection: &context_injection,
             reload_credentials: None,
+            coordination_declaration: None,
         };
         let side_id = "kimi-parent:agent-0";
         let mut open_side_threads = HashMap::new();
@@ -3245,6 +3257,7 @@ mod tests {
             headless: true,
             context_injection: &context_injection,
             reload_credentials: None,
+            coordination_declaration: None,
         };
         let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
         // The steer is already on the bus when the drain starts — the
@@ -3333,6 +3346,7 @@ mod tests {
             headless: true,
             context_injection: &context_injection,
             reload_credentials: None,
+            coordination_declaration: None,
         };
         let child_id = "kimi-parent:agent-1";
         let state = |status: &str, message: Option<&str>| external_agent::SubAgentState {
@@ -3453,6 +3467,7 @@ mod tests {
             headless: true,
             context_injection: &context_injection,
             reload_credentials: None,
+            coordination_declaration: None,
         };
         let side_id = "kimi-parent:side-agent";
         let subagent_id = "kimi-parent:worker-agent";
@@ -3595,6 +3610,7 @@ mod tests {
             headless: true,
             context_injection: &context_injection,
             reload_credentials: None,
+            coordination_declaration: None,
         };
         let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
         event_tx
@@ -3937,6 +3953,7 @@ mod tests {
             headless: true,
             context_injection: &context_injection,
             reload_credentials: None,
+            coordination_declaration: None,
         };
         let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
         event_tx
@@ -4110,6 +4127,7 @@ mod tests {
             headless: true,
             context_injection: &context_injection,
             reload_credentials: None,
+            coordination_declaration: None,
         };
         let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
         event_tx
@@ -4248,6 +4266,7 @@ mod tests {
             headless: true,
             context_injection: &context_injection,
             reload_credentials: None,
+            coordination_declaration: None,
         };
         let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
         event_tx
@@ -4405,6 +4424,7 @@ mod tests {
             headless: true,
             context_injection: &context_injection,
             reload_credentials: None,
+            coordination_declaration: None,
         };
         let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
         event_tx
@@ -4619,6 +4639,7 @@ mod tests {
             headless: true,
             context_injection: &context_injection,
             reload_credentials: None,
+            coordination_declaration: None,
         };
         let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
         event_tx
@@ -4778,6 +4799,7 @@ mod tests {
             headless: true,
             context_injection: &context_injection,
             reload_credentials: None,
+            coordination_declaration: None,
         };
         let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
         event_tx
@@ -4889,6 +4911,7 @@ mod tests {
             headless: true,
             context_injection: &context_injection,
             reload_credentials: None,
+            coordination_declaration: None,
         };
         let (_event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
         let interrupts = Arc::new(std::sync::atomic::AtomicUsize::new(0));

--- a/src/bin/caller/external_mode.rs
+++ b/src/bin/caller/external_mode.rs
@@ -499,6 +499,46 @@ pub(crate) async fn run_external_agent_mode(
         Some(FollowUpMessage::with_attachments(task, attachments))
     };
 
+    // Coordination-bus declaration (Track C §1.5): the supervisor
+    // declares on the backend's behalf (`backend:` set) for the whole
+    // supervised span; the drain's event ticks heartbeat it, and the
+    // guard's Drop removes it on any orderly exit (crash-abandoned
+    // copies age out by TTL). Advisory: bus trouble logs and the
+    // session runs undeclared. Identity note: the declaration keeps the
+    // spawn-time session id even if the primary address later rotates
+    // (fork/native-id upgrades) — the `session:` field is a correlation
+    // hint, not routing state.
+    let coordination_declaration = live_session_id
+        .clone()
+        .or_else(|| session_log_id(&session_log))
+        .and_then(|session_id| {
+            let (space_dir, space_key) = coordination::paths::resolve_space_dir(
+                coordination::paths::env_override().as_deref(),
+                &crate::platform::intendant_home(),
+                &project.root,
+            );
+            match coordination::lifecycle::SessionDeclarationGuard::declare(
+                coordination::lifecycle::DeclareParams {
+                    space_dir: &space_dir,
+                    space_key: &space_key,
+                    session_id: &session_id,
+                    backend: backend.as_short_str(),
+                    project_root: &project.root,
+                    branch: crate::worktree::current_branch(&project.root),
+                    intent: surgical_task_statement.as_deref().unwrap_or(""),
+                },
+                coordination::now_ms(),
+            ) {
+                Ok(guard) => Some(guard),
+                Err(e) => {
+                    slog(&session_log, |l| {
+                        l.debug(&format!("Coordination declaration skipped: {e}"))
+                    });
+                    None
+                }
+            }
+        });
+
     // Reload-credentials handshake: the drain raises this when the request
     // arrives mid-turn (after interrupting the backend); the loop applies
     // the in-place respawn at the next safe point. Idle requests apply
@@ -526,6 +566,7 @@ pub(crate) async fn run_external_agent_mode(
         headless,
         context_injection: &context_injection,
         reload_credentials: Some(&backend_credentials_reload),
+        coordination_declaration: coordination_declaration.as_ref(),
     };
     let mut codex_thread_action_dedupe = CodexThreadActionDedupe::default();
     if let Some(ready_tx) = ready_for_thread_actions {

--- a/src/bin/caller/external_supervision.rs
+++ b/src/bin/caller/external_supervision.rs
@@ -1206,6 +1206,15 @@ pub(crate) struct DrainConfig<'a> {
     /// for lanes without the in-loop respawn (the foreground persistent
     /// loop), where the event is simply not consumable mid-turn.
     pub(crate) reload_credentials: Option<&'a std::sync::atomic::AtomicBool>,
+    /// The supervised session's coordination-bus declaration, owned by
+    /// the supervision loop (Track C §1.5: the supervisor writes for the
+    /// backend). The drain's event ticks are the wrapper's heartbeat
+    /// boundary — internally throttled, so a busy drain costs one mtime
+    /// touch a minute. `None` for lanes without a session declaration
+    /// (child/side drains inherit the parent's guard; the legacy
+    /// persistent presence lane and tests pass `None`).
+    pub(crate) coordination_declaration:
+        Option<&'a crate::coordination::lifecycle::SessionDeclarationGuard>,
 }
 
 impl DrainConfig<'_> {

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -2944,7 +2944,17 @@ fn configure_sandbox_env(
     // the denial-consent flow can recompute the grant env live (the flag
     // lock pins the state for this daemon's lifetime).
     let base_cfg = match project_write_scope {
-        Some(root) => sandbox::SandboxConfig::default_for_project(root, log_dir),
+        Some(root) => {
+            // Coordination-space bind (Track C): env override → derived
+            // worktree-normalized key, resolved here at the edge so the
+            // sandbox constructor stays pure.
+            let (space_dir, _) = crate::coordination::paths::resolve_space_dir(
+                crate::coordination::paths::env_override().as_deref(),
+                &crate::platform::intendant_home(),
+                root,
+            );
+            sandbox::SandboxConfig::default_for_project(root, log_dir, Some(&space_dir))
+        }
         None => sandbox::SandboxConfig::projectless(log_dir),
     };
     sandbox::record_sandbox_startup(sandbox::SandboxRuntimeState {

--- a/src/bin/caller/managed_context_ops/apply.rs
+++ b/src/bin/caller/managed_context_ops/apply.rs
@@ -780,6 +780,7 @@ mod tests {
             headless: true,
             context_injection,
             reload_credentials: None,
+            coordination_declaration: None,
         }
     }
 

--- a/src/bin/caller/managed_context_ops/pressure.rs
+++ b/src/bin/caller/managed_context_ops/pressure.rs
@@ -1240,6 +1240,7 @@ mod tests {
             headless: true,
             context_injection: &context_injection,
             reload_credentials: None,
+            coordination_declaration: None,
         };
         let snapshot = external_agent::AgentContextSnapshot {
             source: "codex".to_string(),
@@ -1337,6 +1338,7 @@ mod tests {
             headless: true,
             context_injection: &context_injection,
             reload_credentials: None,
+            coordination_declaration: None,
         };
 
         let snapshot = latest_external_context_snapshot_from_log(&config).expect("snapshot");

--- a/src/bin/caller/run_modes.rs
+++ b/src/bin/caller/run_modes.rs
@@ -888,6 +888,7 @@ pub(crate) async fn run_with_presence(
                         headless: false,
                         context_injection: &context_injection,
                         reload_credentials: None,
+                        coordination_declaration: None,
                     };
                     match apply_external_context_rewind(
                         agent,
@@ -1291,6 +1292,7 @@ pub(crate) async fn run_with_presence(
                         headless: false,
                         context_injection: &context_injection,
                         reload_credentials: None,
+                        coordination_declaration: None,
                     };
                     apply_context_rewind_backout_action(agent, &op, &action_params, &drain_config)
                         .await
@@ -1339,6 +1341,7 @@ pub(crate) async fn run_with_presence(
                         headless: false,
                         context_injection: &context_injection,
                         reload_credentials: None,
+                        coordination_declaration: None,
                     };
                     if is_fission_spawn_action(&op) {
                         apply_fission_spawn_action(agent, &action_params, &drain_config).await
@@ -1470,6 +1473,7 @@ pub(crate) async fn run_with_presence(
                         headless: false,
                         context_injection: &context_injection,
                         reload_credentials: None,
+                        coordination_declaration: None,
                     };
                     persist_codex_service_tier_for_drain(
                         &drain_config,
@@ -1509,6 +1513,7 @@ pub(crate) async fn run_with_presence(
                             headless: false,
                             context_injection: &context_injection,
                             reload_credentials: None,
+                            coordination_declaration: None,
                         };
                         if let Err(error) = persist_live_external_launch_config(
                             agent.as_ref(),
@@ -1556,6 +1561,7 @@ pub(crate) async fn run_with_presence(
                             headless: false,
                             context_injection: &context_injection,
                             reload_credentials: None,
+                            coordination_declaration: None,
                         };
                         if let Err(error) = persist_live_external_launch_config(
                             agent.as_ref(),
@@ -1614,6 +1620,7 @@ pub(crate) async fn run_with_presence(
                             headless: false,
                             context_injection: &context_injection,
                             reload_credentials: None,
+                            coordination_declaration: None,
                         };
                         match persist_external_fork_child_launch_overlay(
                             agent.as_ref(),
@@ -1683,6 +1690,7 @@ pub(crate) async fn run_with_presence(
                                 headless: false,
                                 context_injection: &context_injection,
                                 reload_credentials: None,
+                                coordination_declaration: None,
                             };
                             emit_side_session_started(
                                 &drain_config,
@@ -1778,6 +1786,7 @@ pub(crate) async fn run_with_presence(
                     headless: false,
                     context_injection: &context_injection,
                     reload_credentials: None,
+                    coordination_declaration: None,
                 };
                 if let Some(child_thread_id) =
                     scoped_event_codex_subagent_thread_id(&event_thread_id, &cumulative_stats)
@@ -2715,6 +2724,7 @@ pub(crate) async fn run_with_presence(
                     headless: false,
                     context_injection: &context_injection,
                     reload_credentials: None,
+                    coordination_declaration: None,
                 };
                 let codex_managed_context_enabled =
                     matches!(backend, external_agent::AgentBackend::Codex)

--- a/src/bin/caller/sandbox.rs
+++ b/src/bin/caller/sandbox.rs
@@ -592,6 +592,17 @@ impl SandboxConfig {
     pub fn default_for_project(project_root: &Path, log_dir: &Path) -> Self {
         let mut config = Self::projectless(log_dir);
         config.write_paths.insert(0, project_root.to_path_buf());
+        // Coordination-space bind (Track C): bus writes (declarations,
+        // messages) from sandboxed runtime shells land under the state
+        // root's `coordination/<space-key>` — grant exactly that
+        // subtree, never the state root wholesale (it holds the trust
+        // store; see the `logs/` rationale above).
+        let (space_dir, _) = crate::coordination::paths::resolve_space_dir(
+            crate::coordination::paths::env_override().as_deref(),
+            &crate::platform::intendant_home(),
+            project_root,
+        );
+        config.write_paths.push(space_dir);
         config
     }
 

--- a/src/bin/caller/sandbox.rs
+++ b/src/bin/caller/sandbox.rs
@@ -589,20 +589,23 @@ impl SandboxConfig {
     /// - Write: project root, the OS scratch dir(s), session-log roots, and
     ///   the Unix toolchain caches
     ///   (`toolchain_cache_write_paths`)
-    pub fn default_for_project(project_root: &Path, log_dir: &Path) -> Self {
+    pub fn default_for_project(
+        project_root: &Path,
+        log_dir: &Path,
+        coordination_space_dir: Option<&Path>,
+    ) -> Self {
         let mut config = Self::projectless(log_dir);
         config.write_paths.insert(0, project_root.to_path_buf());
         // Coordination-space bind (Track C): bus writes (declarations,
-        // messages) from sandboxed runtime shells land under the state
-        // root's `coordination/<space-key>` — grant exactly that
+        // messages) from sandboxed runtime shells land under the
+        // session's `coordination/<space-key>` dir — grant exactly that
         // subtree, never the state root wholesale (it holds the trust
-        // store; see the `logs/` rationale above).
-        let (space_dir, _) = crate::coordination::paths::resolve_space_dir(
-            crate::coordination::paths::env_override().as_deref(),
-            &crate::platform::intendant_home(),
-            project_root,
-        );
-        config.write_paths.push(space_dir);
+        // store; see the `logs/` rationale above). Resolved by the
+        // caller's edge (`paths::resolve_space_dir`) — this constructor
+        // stays pure for hermetic tests.
+        if let Some(space_dir) = coordination_space_dir {
+            config.write_paths.push(space_dir.to_path_buf());
+        }
         config
     }
 
@@ -1281,6 +1284,7 @@ mod tests {
         let config = SandboxConfig::default_for_project(
             Path::new("/home/user/project"),
             Path::new("/tmp/logs"),
+            None,
         );
         assert!(config.enabled);
         assert!(config
@@ -1301,7 +1305,7 @@ mod tests {
         let log_dir = Path::new("/tmp/logs");
         let projectless = SandboxConfig::projectless(log_dir);
         let mut with_project =
-            SandboxConfig::default_for_project(Path::new("/home/user/project"), log_dir);
+            SandboxConfig::default_for_project(Path::new("/home/user/project"), log_dir, None);
         // Exactly one path apart: the project root. No cwd, no widening.
         assert!(!projectless
             .write_paths
@@ -1311,6 +1315,20 @@ mod tests {
             .retain(|p| p != Path::new("/home/user/project"));
         assert_eq!(projectless.write_paths, with_project.write_paths);
         assert!(projectless.enabled);
+    }
+
+    /// The coordination-space grant is exactly the injected dir — the
+    /// caller's edge resolves it; the constructor never reads env.
+    #[test]
+    fn project_config_grants_injected_coordination_space_dir() {
+        let log_dir = Path::new("/tmp/logs");
+        let space = Path::new("/state/coordination/proj-abc123");
+        let config = SandboxConfig::default_for_project(
+            Path::new("/home/user/project"),
+            log_dir,
+            Some(space),
+        );
+        assert!(config.write_paths.contains(&space.to_path_buf()));
     }
 
     /// The write set grants the state root's `logs/` subtree only — never
@@ -1434,8 +1452,11 @@ mod tests {
 
     #[test]
     fn disabled_config_skips_apply() {
-        let mut config =
-            SandboxConfig::default_for_project(Path::new("/tmp/test"), Path::new("/tmp/logs"));
+        let mut config = SandboxConfig::default_for_project(
+            Path::new("/tmp/test"),
+            Path::new("/tmp/logs"),
+            None,
+        );
         config.enabled = false;
         assert_eq!(config.apply_to_current_process().unwrap(), false);
     }
@@ -1445,6 +1466,7 @@ mod tests {
         let config = SandboxConfig::default_for_project(
             Path::new("/home/user/myproject"),
             Path::new("/var/log/intendant"),
+            None,
         );
         assert!(config.write_paths.len() >= 3);
     }

--- a/src/bin/caller/startup/daemon.rs
+++ b/src/bin/caller/startup/daemon.rs
@@ -44,6 +44,10 @@ pub(crate) async fn run_daemon(
     // staged uploads / transfer jobs): prune entries idle past the
     // retention window so the store cannot grow unbounded across restarts.
     tokio::task::spawn_blocking(global_store::prune_at_daemon_startup);
+    // Coordination-space liveness GC (§9 rule-8 liveness amendment):
+    // declarations a day past heartbeat, messages past TTL, orphaned
+    // atomic-write temps. Never touches checkpoint documents.
+    tokio::task::spawn_blocking(crate::coordination::gc::sweep_at_daemon_startup);
     // One-time external-wrapper-index repair (v1 -> v2): recompute each
     // (source, backend session) group's active wrapper from log-dir
     // activity, undoing the inversions written while the session-catalog

--- a/src/bin/caller/thread_actions.rs
+++ b/src/bin/caller/thread_actions.rs
@@ -3428,6 +3428,8 @@ pub(crate) async fn drain_external_child_turn(
         headless: config.headless,
         context_injection: config.context_injection,
         reload_credentials: config.reload_credentials,
+        // Child activity heartbeats the parent session's declaration.
+        coordination_declaration: config.coordination_declaration,
     };
 
     match drain_external_agent_events(
@@ -5140,6 +5142,7 @@ mod tests {
             headless: false,
             context_injection: &context_injection,
             reload_credentials: None,
+            coordination_declaration: None,
         };
         let child = "session_parent:agent-7";
         let mut stats = LoopStats::default();
@@ -5349,6 +5352,7 @@ mod tests {
             headless: false,
             context_injection: &context_injection,
             reload_credentials: None,
+            coordination_declaration: None,
         };
         let child = "session_parent:agent-7";
         let mut stats = LoopStats::default();
@@ -5455,6 +5459,7 @@ mod tests {
             headless: true,
             context_injection: &context_injection,
             reload_credentials: None,
+            coordination_declaration: None,
         };
         let mut stats = LoopStats::default();
 
@@ -5540,6 +5545,7 @@ mod tests {
             headless: true,
             context_injection: &context_injection,
             reload_credentials: None,
+            coordination_declaration: None,
         };
         let mut stats = LoopStats::default();
         let errored = external_agent::SubAgentState {
@@ -5702,6 +5708,7 @@ mod tests {
             headless: true,
             context_injection: &context_injection,
             reload_credentials: None,
+            coordination_declaration: None,
         };
 
         emit_side_session_started(
@@ -5780,6 +5787,7 @@ mod tests {
             headless: true,
             context_injection: &context_injection,
             reload_credentials: None,
+            coordination_declaration: None,
         };
         let mut stats = LoopStats::default();
 
@@ -5900,6 +5908,7 @@ mod tests {
             headless: true,
             context_injection: &context_injection,
             reload_credentials: None,
+            coordination_declaration: None,
         };
         let mut stats = LoopStats::default();
 
@@ -6123,6 +6132,7 @@ mod tests {
             headless: true,
             context_injection,
             reload_credentials: None,
+            coordination_declaration: None,
         }
     }
 

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -104,6 +104,11 @@ impl TestRig {
             // A host shell exporting the Connect rendezvous URL would make
             // the daemon-lane tests dial out; the suite is no-network.
             .env_remove("INTENDANT_CONNECT_RENDEZVOUS_URL")
+            // Supervised shells (native runtime children, external
+            // backends) inherit a coordination-space bind; honoring it
+            // here would write this rig's session declarations into the
+            // HOST's live bus space instead of the fresh HOME below.
+            .env_remove("INTENDANT_COORDINATION_DIR")
             // The suite is display-free by contract, but a host with a live
             // X session at :0 (a self-hosted runner doubling as a desktop)
             // breaks that hermeticity: the caller's vision probe finds the


### PR DESCRIPTION
Second C1 slice (follows #560, the bus core). Wires the liveness kinds into the running system per the ruled protocol (~/coordination-bus-protocol.md §1.5/§3.6):

- **Declaration lifecycle** (`coordination/lifecycle.rs`): `SessionDeclarationGuard` — declare at session start, 60s-throttled mtime heartbeat at natural boundaries (native turn boundaries; wrapper event-drain ticks), re-declare on vanish, remove on clean end (Drop). Native loop owns its guard in `run_round_loop`; external supervisors declare with `backend:` set. Writer-id mapping centralized (`writer_id_for_session`) for C3 reuse.
- **Env binds**: `INTENDANT_COORDINATION_DIR` exported to runtime children (spawn site + allowlist row) and all four external backends via `add_intendant_bootstrap_env` (codex through `add_intendant_ctl_env`; kimi rebuilt per retry). e2e rig scrubs the var so suite runs inside a supervised session can't write into the host's live bus.
- **Daemon GC**: startup sweep (`global_store::prune_at_daemon_startup` pattern) — declarations a day past heartbeat, messages past TTL, orphaned temps; checkpoint documents provably untouched.
- **Checkpoint edge**: `workflow_checkpoint` now resolves through `paths::resolve_space_dir` (env override + `INTENDANT_HOME`-aware) via additive `CheckpointSpace::open_at`; checkpoint tests pinned unmodified.
- **Sandbox**: `default_for_project` grants write on exactly the session's coordination space dir, injected as a parameter (edge resolves env; constructor pure; projectless pin verbatim). Cross-platform `valid_abs_path` (Windows drive/UNC).

Battery: fmt --check, clippy workspace -D warnings, full bins (4723), lib crates, headless e2e (31) — all green.