### PR TITLE
session config discoverability: menu item names model/effort/permissions; model-chip explainer links the launch-config sheet

### DIFF
--- a/static/app/12-styles-tasks-log.css
+++ b/static/app/12-styles-tasks-log.css
@@ -1619,6 +1619,10 @@ body.context-focus-active {
   cursor: pointer;
 }
 .vx-action:hover { background: var(--surface1); }
+/* A row may carry several actions (the model row's "Change for this
+   session" + "Copy model id"): siblings breathe apart and wrap cleanly
+   on the narrow bottom sheet. */
+.vx-action + .vx-action { margin-left: 8px; }
 /* — The facts card: each fact is an atomic token (a real <button>) that
    never wraps internally (white-space: nowrap); lines wrap BETWEEN
    tokens. Family groups sit a wide gap apart; facts within a group read

--- a/static/app/39-session-windows.js
+++ b/static/app/39-session-windows.js
@@ -1256,7 +1256,24 @@ const VITALS_SYMBOLS = {
       if (caveat) lines.push(caveat);
       return lines;
     },
-    action: (v) => (v.model ? { label: 'Copy model id', run: () => vitalsCopyText(v.model) } : null),
+    // Model and reasoning effort (with permissions and tools) are
+    // per-session settings, editable through the launch-config sheet for
+    // external-agent sessions — surface that entry point right where a
+    // reader inspecting the model facts goes looking for it. Native
+    // sessions have no sheet, so they get no dead button.
+    action: (v, sessionId) => {
+      const actions = [];
+      const sid = String(sessionId || '').trim();
+      if (sid && sessionConfigSource(sessionConfigMetadata(sid))
+          && typeof window.openSessionConfigModal === 'function') {
+        actions.push({
+          label: 'Change for this session — Launch config...',
+          run: () => window.openSessionConfigModal(sid),
+        });
+      }
+      if (v.model) actions.push({ label: 'Copy model id', run: () => vitalsCopyText(v.model) });
+      return actions.length ? actions : null;
+    },
   },
   permissions: {
     label: 'Permissions',
@@ -2653,7 +2670,12 @@ function vxExplainerRow(spec) {
     }
     body.appendChild(desc);
   }
-  if (spec.action) body.appendChild(vxActionButton(spec.action));
+  // A symbol may carry one action or several (the model row pairs
+  // "Change for this session" with "Copy model id") — each renders as
+  // its own button.
+  for (const action of Array.isArray(spec.action) ? spec.action : (spec.action ? [spec.action] : [])) {
+    body.appendChild(vxActionButton(action));
+  }
   row.appendChild(body);
   if (spec.onTap && !spec.absent) {
     row.setAttribute('role', 'button');

--- a/static/app/40-session-launch.js
+++ b/static/app/40-session-launch.js
@@ -93,7 +93,7 @@ function openSessionConfigModal(sessionOrId) {
   if (title) title.textContent = `${prettyAgentName(source)} launch config`;
   const description = document.getElementById('session-config-description');
   if (description) {
-    description.textContent = 'Save changes for future attaches, or save and immediately restart this external backend with the new binary and mode.';
+    description.textContent = 'Per-session agent settings — model, reasoning effort, permissions, tools, and binary, depending on the agent. Saved settings apply on the next attach or resume; Save & restart applies them now.';
   }
   const sessionInput = document.getElementById('session-config-session');
   if (sessionInput) {
@@ -913,7 +913,7 @@ const SESSION_WINDOW_GENERIC_ACTIONS = [
   { op: 'copy-session-id', label: 'Copy full session ID', title: 'Copy the full session ID' },
   { op: 'rename-session', label: 'Rename session...', title: 'Rename this session' },
   { op: 'delegate-sub-agent', label: 'Delegate...', title: 'Spawn a supervised sub-agent under this session' },
-  { op: 'configure-launch', label: 'Launch config...', title: 'Configure the binary and managed-context mode used on next attach/resume' },
+  { op: 'configure-launch', label: 'Launch config: model, effort, permissions...', title: 'Change this session’s agent settings — model, reasoning effort, permission mode, tools, managed context, or binary (options vary by agent). Saved settings apply on the next attach, resume, or restart.' },
   { op: 'attach-session', label: 'Attach session', title: 'Attach this backend without sending a prompt' },
   { op: 'restart-session', label: 'Restart with saved config', title: 'Stop this backend and resume it with saved launch config' },
   { op: 'stop-session', label: 'Stop session...', title: 'Stop the live backend and remove it from active dashboards', danger: true },


### PR DESCRIPTION
The 'Launch config...' session-window menu item's label and tooltip
predated the sheet gaining model, reasoning effort, permission, and
tool pins — a user hunting 'change this session's effort' couldn't
find it. Name the goods in the label and tooltip, refresh the modal
description the same way, and add a 'Change for this session — Launch
config...' action inside the Model chip's vitals explainer that closes
the pane and opens the sheet (external-agent sessions only; native
sessions get no dead button). Explainer rows can now carry one action
or several; sibling action buttons get a small gap and wrap cleanly on
the bottom sheet.
