### PR TITLE
fix(dashboard): Changes cold deep link — re-arm activation refetch, honest loading state

### DIFF
--- a/static/app/20-shell.html
+++ b/static/app/20-shell.html
@@ -600,7 +600,7 @@
           </div>
           <div class="changes-container">
             <div class="changes-sidebar" id="changes-file-list">
-              <div class="changes-empty">No file changes yet</div>
+              <div class="changes-empty">Loading changes...</div>
             </div>
             <div class="changes-diff-viewer" id="changes-diff-viewer">
               <div class="changes-diff-header" id="changes-diff-header">Select a file to view changes</div>

--- a/static/app/36-voice-wasm-init.js
+++ b/static/app/36-voice-wasm-init.js
@@ -633,7 +633,20 @@ async function main() {
           // Historical replay can emit lifecycle commands such as session_ended
           // that move the live dashboard to Sessions. The URL remains the
           // navigation source of truth, so re-apply it after replay settles.
+          const changesWasActive = isChangesSubtabActive();
           applyCurrentRoute();
+          // The replay reset the Changes pane (resetChangesPane above) and
+          // the route re-apply early-returns for an already-active subtab,
+          // so a dashboard parked on Changes — an #activity/changes deep
+          // link at cold boot, or a live reconnect — would keep the loading
+          // placeholder until some unrelated trigger refetched. Re-run the
+          // activation fetch now that the replayed session context is in
+          // place; when the route apply itself just switched onto Changes,
+          // switchActivitySubtab already fetched and this stays out of its
+          // way.
+          if (changesWasActive && isChangesSubtabActive()) {
+            refreshChangesForActivation();
+          }
           reconcileRecordingStreams();
         });
         return;

--- a/static/app/37-uicommand-changes-control.js
+++ b/static/app/37-uicommand-changes-control.js
@@ -312,6 +312,17 @@ let changesRefreshTimer = null;
 let changesRefreshSeq = 0;
 let changesRenderFrame = null;
 let pendingChangesAutoSelect = null;
+// Whether the pane's content states a real answer — a parsed list
+// response, a delivered daemon error, or the target-mismatch notice.
+// False until the FIRST fetch resolves (and again after a bare
+// resetChangesPane), so the empty state reads as loading instead of
+// claiming "No file changes yet" before anything was actually asked.
+let changesListResolved = false;
+// One-shot re-arm for a boot whose first fetch failed on the transport
+// lane (tunnel not up yet, and no HTTP twin in Connect mode) — the
+// refreshControlPane deep-link pattern: poll for a usable tunnel, then
+// re-run the activation fetch if the pane still has no answer.
+let changesWaitingForTransport = false;
 
 // Split the changed-files map into the session-edit rows and the
 // working-tree rows (records the daemon's git lane tagged
@@ -326,11 +337,14 @@ function changesEntriesByOrigin() {
   return { session, workingTree };
 }
 
-// The list pane's honest empty-state line: only claim "no changes" when
-// BOTH the session sources and the working tree are empty — and say the
-// working tree is clean when that is affirmatively known (total 0 from
-// the same status parse the dirty chip counts).
+// The list pane's honest empty-state line: before the first fetch has
+// resolved the pane has no answer to state, so it says loading; after
+// that, only claim "no changes" when BOTH the session sources and the
+// working tree are empty — and say the working tree is clean when that
+// is affirmatively known (total 0 from the same status parse the dirty
+// chip counts).
 function changesEmptyStateMessage() {
+  if (!changesListResolved) return 'Loading changes...';
   if (changesWorkingTree && Number(changesWorkingTree.total) === 0) {
     return 'No file changes yet — the working tree is clean.';
   }
@@ -490,7 +504,7 @@ function renderChangesFileList(emptyMessage = null) {
   });
 }
 
-function resetChangesPane(message = 'No file changes yet') {
+function resetChangesPane(message = null) {
   if (changesRenderFrame) {
     cancelAnimationFrame(changesRenderFrame);
     changesRenderFrame = null;
@@ -499,10 +513,16 @@ function resetChangesPane(message = 'No file changes yet') {
   changedFiles.clear();
   changesWorkingTree = null;
   activeChangesFile = null;
-  renderChangesFileList(message);
+  // A bare reset (session switch, bootstrap replay) returns the pane to
+  // the pre-answer state — the next default render says loading until a
+  // fetch resolves. An explicit message (load errors, tracking
+  // unavailable) IS the pane's answer and renders verbatim.
+  changesListResolved = !!message;
+  const text = message || changesEmptyStateMessage();
+  renderChangesFileList(text);
   renderChangesDiffHeader(null);
   const content = document.getElementById('changes-diff-content');
-  if (content) content.innerHTML = `<span class="changes-empty">${escapeHtml(message)}</span>`;
+  if (content) content.innerHTML = `<span class="changes-empty">${escapeHtml(text)}</span>`;
   updateChangesBadge();
   stationScheduleUpdate();
 }
@@ -593,6 +613,8 @@ function fetchChangesResponse(path = '') {
 }
 
 function showChangesTargetMismatch(message) {
+  // The mismatch notice is a stated answer, not a pending fetch.
+  changesListResolved = true;
   activeChangesFile = null;
   changedFiles.clear();
   changesWorkingTree = null;
@@ -619,6 +641,7 @@ async function refreshChangesList(options = {}) {
     const resp = await fetchChangesResponse();
     const data = await parseChangesResponse(resp);
     if (seq !== changesRefreshSeq) return;
+    changesListResolved = true;
     changedFiles.clear();
     // List shape: `{files: [...], working_tree: {...}?}` (the envelope);
     // a bare array (the pre-envelope daemon shape) still parses.
@@ -662,12 +685,61 @@ async function refreshChangesList(options = {}) {
     }
     stationScheduleUpdate();
   } catch (e) {
-    if (!quiet) {
+    if (seq !== changesRefreshSeq) return;
+    // A thrown DaemonApiError (any kind but a delivered 'http') is a
+    // transport-lane failure; everything else came out of a delivered
+    // daemon response (parseChangesResponse's structured error / status
+    // shapes).
+    const laneFailure = !!(e && e.name === 'DaemonApiError' && e.kind !== 'http');
+    // Quiet refreshes keep the previous content on failure — but a pane
+    // that has never resolved is only showing the loading placeholder,
+    // so a delivered "no" (e.g. the watcher-absent 503) must land as the
+    // answer rather than park the loading state forever. A lane failure
+    // before the first answer instead arms the tunnel retry: the cold
+    // boot's fetch can precede any usable transport.
+    if (!quiet || (!changesListResolved && !laneFailure)) {
       resetChangesPane(e.message === 'file watcher not active'
         ? 'Change tracking unavailable'
         : `Unable to load changes: ${e.message}`);
+    } else if (!changesListResolved && laneFailure) {
+      armChangesTransportRetry();
     }
   }
+}
+
+// The subtab-activation fetch — one function so every path that "opens"
+// the Changes view (switchActivitySubtab in 48-router-settings.js, the
+// bootstrap-replay re-arm in 36-voice-wasm-init.js, the transport retry
+// below) runs the identical list + timeline refresh instead of
+// hand-rolled copies. refreshHistory is a no-op when the endpoint 404s,
+// so a session resumed mid-flight still shows its existing timeline.
+function refreshChangesForActivation() {
+  refreshChangesList({ selectFirst: true, refreshActive: true, quiet: true });
+  if (typeof refreshHistory === 'function') refreshHistory();
+}
+
+// Deep links (#activity/changes) activate the subtab during initial
+// route apply, before the dashboard tunnel is constructed — and in
+// Connect mode there is no HTTP twin to fall back to, so that first
+// fetch fails on the lane. Poll briefly for a usable tunnel (the
+// refreshControlPane deep-link pattern) and re-run the activation fetch
+// once, unless something else resolved the pane meanwhile.
+function armChangesTransportRetry() {
+  if (changesWaitingForTransport) return;
+  changesWaitingForTransport = true;
+  const retry = () => {
+    if (changesListResolved) {
+      changesWaitingForTransport = false;
+      return;
+    }
+    if (dashboardControlTransport && dashboardControlTransport.canUseRpc()) {
+      changesWaitingForTransport = false;
+      if (isChangesSubtabActive()) refreshChangesForActivation();
+      return;
+    }
+    setTimeout(retry, 250);
+  };
+  setTimeout(retry, 250);
 }
 
 function scheduleChangesRefresh() {

--- a/static/app/48-router-settings.js
+++ b/static/app/48-router-settings.js
@@ -515,11 +515,10 @@ function switchActivitySubtab(name) {
   if (name === 'changes') {
     const badge = document.getElementById('badge-changes');
     if (badge) { badge.style.display = 'none'; badge.textContent = ''; }
-    refreshChangesList({ selectFirst: true, refreshActive: true, quiet: true });
-    // Populate the timeline on first view in case the user opened the
-    // Changes tab after a session had already racked up history
-    // (refreshHistory is a no-op when the endpoint 404s).
-    if (typeof refreshHistory === 'function') refreshHistory();
+    // The shared activation fetch (list + timeline) — the same call the
+    // cold-boot re-arm paths in 37-uicommand-changes-control.js and
+    // 36-voice-wasm-init.js reuse.
+    refreshChangesForActivation();
   }
   if (name === 'control') {
     refreshControlPane();


### PR DESCRIPTION
A #activity/changes deep link at cold boot activated the subtab during
initial route apply, before the tunnel/session context existed; the WS
bootstrap log_replay then resetChangesPane()'d the pane and the post-
replay applyCurrentRoute() early-returned for the already-active subtab,
parking the static 'No file changes yet' copy until an unrelated trigger
refetched. Extract the subtab-activation fetch (list + timeline) into
refreshChangesForActivation(), re-run it after the bootstrap replay
settles (covers cold deep links and live reconnects), and arm a tunnel
retry (the refreshControlPane deep-link pattern) when the first fetch
fails on the transport lane. The pane also no longer claims 'No file
changes yet' before any fetch resolved: empty-state copy reads 'Loading
changes...' until data or a real answer (delivered error, mismatch
notice) arrives — PR #557's three-state resolved copy is unchanged.
