### PR TITLE
Track C C2: radar core — zero-LLM detection, §2.2 renderer, radar notes

### DIFF
--- a/src/bin/caller/coordination/declarations.rs
+++ b/src/bin/caller/coordination/declarations.rs
@@ -11,7 +11,8 @@ use std::io::Write as IoWrite;
 use std::path::{Path, PathBuf};
 
 use super::scan::{
-    self, DefensiveRead, LivenessScan, ScanReject, REJECT_GRAMMAR, REJECT_NOT_REGULAR,
+    self, DefensiveRead, LivenessScan, ReadBudget, ScanReject, REJECT_GRAMMAR, REJECT_NOT_REGULAR,
+    REJECT_READ_BUDGET,
 };
 use super::{io_err, restrict_dir_modes, sanitize_key, CoordinationError};
 
@@ -286,10 +287,28 @@ pub(crate) fn scan_dir(
     dir: &Path,
     now_ms: u64,
 ) -> Result<LivenessScan<SessionDeclaration>, CoordinationError> {
+    scan_dir_budgeted(dir, now_ms, &mut ReadBudget::unbounded())
+}
+
+/// [`scan_dir`] under a §1.6 whole-space read budget (the radar's
+/// entry): entries the budget refuses are surfaced as
+/// `read-budget` rejections without ever being opened.
+pub(crate) fn scan_dir_budgeted(
+    dir: &Path,
+    now_ms: u64,
+    budget: &mut ReadBudget,
+) -> Result<LivenessScan<SessionDeclaration>, CoordinationError> {
     let (found, mut rejected) = scan::scan_liveness_dir(dir)?;
     let mut entries = Vec::with_capacity(found.len());
     for entry in found {
         let name = format!("{}.md", entry.stem);
+        if !budget.admit(entry.meta.len()) {
+            rejected.push(ScanReject {
+                name,
+                reason: REJECT_READ_BUDGET,
+            });
+            continue;
+        }
         let bytes = match scan::open_liveness(&entry.path)? {
             DefensiveRead::Ok(bytes) => bytes,
             DefensiveRead::Vanished => continue,
@@ -531,6 +550,30 @@ mod tests {
         let d = &scan.entries[0];
         assert_eq!(d.dirty, vec!["src/ok.rs".to_string()]);
         assert_eq!(d.dirty_dropped, 3, "hostile paths counted, never kept");
+    }
+
+    #[test]
+    fn budgeted_scan_skips_unread_entries_loudly() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ds = space(&tmp);
+        for id in ["s-a", "s-b", "s-c"] {
+            ds.write_own(&input(id, "x", &[])).unwrap();
+        }
+        let dir = tmp.path().join("space/sessions");
+        let mut budget = ReadBudget::new(2, u64::MAX);
+        let scan = scan_dir_budgeted(&dir, super::super::now_ms(), &mut budget).unwrap();
+        assert_eq!(scan.entries.len(), 2, "budgeted prefix parses");
+        assert_eq!(scan.rejected.len(), 1);
+        assert_eq!(scan.rejected[0].reason, REJECT_READ_BUDGET);
+        assert_eq!(
+            scan.rejected[0].name, "s-c.md",
+            "deterministic (sorted) drop order"
+        );
+        // Byte budget bites the same way.
+        let mut tight = ReadBudget::new(usize::MAX, 1);
+        let scan = scan_dir_budgeted(&dir, super::super::now_ms(), &mut tight).unwrap();
+        assert!(scan.entries.is_empty());
+        assert_eq!(scan.rejected.len(), 3);
     }
 
     #[test]

--- a/src/bin/caller/coordination/messages.rs
+++ b/src/bin/caller/coordination/messages.rs
@@ -10,7 +10,10 @@
 use std::io::Write as IoWrite;
 use std::path::{Path, PathBuf};
 
-use super::scan::{self, DefensiveRead, LivenessScan, ScanReject, REJECT_FOREIGN_ENTRY};
+use super::scan::{
+    self, DefensiveRead, LivenessScan, ReadBudget, ScanReject, REJECT_FOREIGN_ENTRY,
+    REJECT_READ_BUDGET,
+};
 use super::{io_err, restrict_dir_modes, sanitize_key, CoordinationError};
 
 pub(crate) const KIND_MESSAGE: &str = "message";
@@ -26,6 +29,14 @@ pub(crate) const MESSAGE_TTL_MIN_S: u32 = 60;
 pub(crate) const MESSAGE_TTL_MAX_S: u32 = 604_800;
 /// Reserved for the daemon's C2 lanes.
 pub(crate) const RESERVED_DAEMON_WRITER: &str = "daemon";
+/// Radar-note spam guard (the §2.8 cooldown precedent applied to the
+/// bus lane): at most one radar note lands on a recipient per window,
+/// on top of the per-overlap-set dedup by note id.
+pub(crate) const RADAR_NOTE_COOLDOWN_MS: u64 = 10 * 60 * 1000;
+/// Overlap paths listed in one radar-note body; the remainder is
+/// counted in the note's fixed template line (bounds are write-side
+/// too — rule 6 — and the §1.5 dirty-cap spirit applies here).
+pub(crate) const RADAR_NOTE_MAX_PATHS: usize = 64;
 
 /// Frontmatter-only view (listing/radar); `body` costs a `read`.
 #[derive(Debug, Clone, serde::Serialize)]
@@ -50,6 +61,25 @@ pub(crate) struct MessageInput<'a> {
     pub to: Option<&'a str>,
     pub ttl_s: Option<u32>,
     pub body: &'a str,
+}
+
+/// Input for [`MessageSpace::write_radar_note`] — every field is a
+/// machine value the writer re-validates (§2.3): grammar ids, the
+/// closed source flags, a u32 PR number, repo-relative paths.
+pub(crate) struct RadarNoteInput<'a> {
+    /// The flagged party this note is addressed to (`to:`).
+    pub to: &'a str,
+    /// All flagged parties (`parties:`), recipient included.
+    pub parties: &'a [&'a str],
+    /// Overlap evidence: declared working sets / observed git status.
+    pub declared: bool,
+    pub git: bool,
+    /// Open-PR overlap, when the counterpart is a PR's file set.
+    pub pr: Option<u32>,
+    /// The overlapping repo-relative paths (full parse grammar, not
+    /// the renderer's display bound — the note body is exact).
+    pub paths: &'a [String],
+    pub ttl_s: Option<u32>,
 }
 
 /// The `messages/` store for one coordination space (resolved dir in,
@@ -174,6 +204,218 @@ impl MessageSpace {
         })
     }
 
+    /// The daemon's privileged radar-note lane (§2.8, R9): writes
+    /// `kind: radar-note` under the reserved `daemon` writer dir to the
+    /// flagged party. The public [`Self::write`] keeps refusing the
+    /// `daemon` writer — this entry point is the only path in, and its
+    /// body is schema-rendered from validated tokens only (§2.3
+    /// grammars; no free text): an `## overlap` section of
+    /// grammar-valid repo-relative paths plus a fixed template
+    /// paragraph whose only variable tokens are validated ids, the
+    /// closed `sources` enum, and decimal counts.
+    ///
+    /// Spam discipline, both layers tested:
+    /// - one live note per distinct overlap set per flagged pair — the
+    ///   note id is `rn-<hash>` over (recipient, parties, pr, full
+    ///   path set), so an existing file (even expired, until GC) means
+    ///   this exact situation was already delivered → `Ok(None)`;
+    /// - at most one note per recipient per
+    ///   [`RADAR_NOTE_COOLDOWN_MS`] regardless of set — a churning
+    ///   working set must not mint a note stream → `Ok(None)`.
+    ///
+    /// TTL takes the normal clamp (default when `None`); the per-writer
+    /// live cap applies to the daemon dir like any other writer.
+    pub(crate) fn write_radar_note(
+        &self,
+        input: &RadarNoteInput<'_>,
+    ) -> Result<Option<MessageMeta>, CoordinationError> {
+        let to = input.to;
+        if to.is_empty() || sanitize_key(to) != to {
+            return Err(CoordinationError::WriteRefused(format!(
+                "radar-note recipient {to:?} is outside the filename grammar"
+            )));
+        }
+        if input.parties.is_empty() || input.parties.len() > 8 {
+            return Err(CoordinationError::WriteRefused(format!(
+                "radar-note parties count {} is outside 1..=8",
+                input.parties.len()
+            )));
+        }
+        for p in input.parties {
+            if p.is_empty() || sanitize_key(p) != *p {
+                return Err(CoordinationError::WriteRefused(format!(
+                    "radar-note party {p:?} is outside the filename grammar"
+                )));
+            }
+        }
+        if !input.parties.contains(&to) {
+            return Err(CoordinationError::WriteRefused(
+                "radar-note recipient must be one of its parties".into(),
+            ));
+        }
+        if !input.declared && !input.git && input.pr.is_none() {
+            return Err(CoordinationError::WriteRefused(
+                "radar-note needs at least one source (declared/git/pr)".into(),
+            ));
+        }
+        if input.paths.is_empty() {
+            return Err(CoordinationError::WriteRefused(
+                "radar-note needs at least one overlapping path".into(),
+            ));
+        }
+        for p in input.paths {
+            if !scan::valid_rel_path(p) {
+                return Err(CoordinationError::WriteRefused(format!(
+                    "radar-note path {p:?} is outside the repo-relative grammar"
+                )));
+            }
+        }
+        let ttl_s = input
+            .ttl_s
+            .unwrap_or(MESSAGE_TTL_DEFAULT_S)
+            .clamp(MESSAGE_TTL_MIN_S, MESSAGE_TTL_MAX_S);
+
+        // Canonical identity of this overlap situation → the note id.
+        // Sorted, deduplicated paths make the hash order-independent;
+        // sources are deliberately excluded so an evidence shift alone
+        // (declared → declared+git) does not mint a new note.
+        let mut paths: Vec<&str> = input.paths.iter().map(String::as_str).collect();
+        paths.sort_unstable();
+        paths.dedup();
+        let mut parties: Vec<&str> = input.parties.to_vec();
+        parties.sort_unstable();
+        let canonical = format!(
+            "to={to};parties={};pr={};paths={}",
+            parties.join(","),
+            input.pr.map(|n| n.to_string()).unwrap_or_default(),
+            paths.join(",")
+        );
+        let id = format!("rn-{:016x}", super::fnv1a_64(canonical.as_bytes()));
+
+        let writer_dir = self.dir.join(RESERVED_DAEMON_WRITER);
+        if writer_dir.join(format!("{id}.md")).exists() {
+            return Ok(None); // this exact overlap set was already delivered
+        }
+        let now_ms = super::now_ms();
+        if !writer_dir.is_dir() {
+            let (dirs, _) = writer_dirs(&self.dir)?;
+            if dirs.len() >= MAX_WRITER_DIRS {
+                return Err(CoordinationError::WriteRefused(format!(
+                    "space holds {} writer dirs; the bound is {MAX_WRITER_DIRS}",
+                    dirs.len()
+                )));
+            }
+        }
+        std::fs::create_dir_all(&writer_dir).map_err(io_err)?;
+        restrict_dir_modes(&writer_dir)?;
+        let (live, _) = scan::scan_liveness_dir(&writer_dir)?;
+        if live.len() >= MAX_MESSAGES_PER_WRITER {
+            return Err(CoordinationError::WriteRefused(format!(
+                "writer {RESERVED_DAEMON_WRITER:?} holds {} messages; the bound is \
+                 {MAX_MESSAGES_PER_WRITER} — expiry GC must catch up first",
+                live.len()
+            )));
+        }
+        // Recipient cooldown over the daemon dir's live notes.
+        for entry in &live {
+            let meta = match scan::open_liveness(&entry.path)? {
+                DefensiveRead::Ok(bytes) => scan::parse_doc(bytes, &entry.stem, MESSAGE_KINDS)
+                    .ok()
+                    .and_then(|doc| {
+                        meta_from_doc(&doc, &entry.stem, RESERVED_DAEMON_WRITER, now_ms)
+                    }),
+                _ => None,
+            };
+            let Some(meta) = meta else { continue };
+            if meta.kind == KIND_RADAR_NOTE
+                && !meta.expired
+                && meta.to.as_deref() == Some(to)
+                && now_ms.saturating_sub(meta.created_ms) < RADAR_NOTE_COOLDOWN_MS
+            {
+                return Ok(None); // recipient was noted moments ago — don't spam
+            }
+        }
+
+        let mut sources: Vec<&str> = Vec::new();
+        if input.declared {
+            sources.push("declared");
+        }
+        if input.git {
+            sources.push("git");
+        }
+        if input.pr.is_some() {
+            sources.push("pr");
+        }
+        let sources = sources.join(",");
+
+        let mut doc = String::new();
+        doc.push_str("---\n");
+        doc.push_str("v: 1\n");
+        doc.push_str(&format!("kind: {KIND_RADAR_NOTE}\n"));
+        doc.push_str(&format!("id: {id}\n"));
+        doc.push_str(&format!("space: {}\n", self.space));
+        doc.push_str(&format!("from: {RESERVED_DAEMON_WRITER}\n"));
+        doc.push_str(&format!("to: {to}\n"));
+        doc.push_str(&format!("parties: {}\n", parties.join(",")));
+        doc.push_str(&format!("sources: {sources}\n"));
+        if let Some(pr) = input.pr {
+            doc.push_str(&format!("pr: {pr}\n"));
+        }
+        doc.push_str(&format!("created_ms: {now_ms}\n"));
+        doc.push_str(&format!("ttl_s: {ttl_s}\n"));
+        doc.push_str("attribution: unverified-same-uid\n");
+        doc.push_str("---\n");
+        doc.push_str("## overlap\n");
+        let listed = paths.len().min(RADAR_NOTE_MAX_PATHS);
+        for p in &paths[..listed] {
+            doc.push_str(p);
+            doc.push('\n');
+        }
+        doc.push('\n');
+        let mut who = parties.join(" and ");
+        if let Some(pr) = input.pr {
+            who.push_str(&format!(" and open pr#{pr}"));
+        }
+        doc.push_str(&format!(
+            "Working-set overlap between {who} (sources: {sources}). \
+             Coordinate in this space before touching the paths above."
+        ));
+        if paths.len() > listed {
+            doc.push_str(&format!(
+                " {} further paths were not listed.",
+                paths.len() - listed
+            ));
+        }
+        doc.push('\n');
+        if doc.len() > super::MAX_DOC_BYTES {
+            return Err(CoordinationError::WriteRefused(format!(
+                "radar-note document is {} bytes; the §9 bound is {}",
+                doc.len(),
+                super::MAX_DOC_BYTES
+            )));
+        }
+
+        let path = writer_dir.join(format!("{id}.md"));
+        let tmp = writer_dir.join(format!(".{id}.tmp"));
+        {
+            let mut f = std::fs::File::create(&tmp).map_err(io_err)?;
+            f.write_all(doc.as_bytes()).map_err(io_err)?;
+            f.sync_all().map_err(io_err)?;
+        }
+        super::restrict_file_modes(&tmp)?;
+        std::fs::rename(&tmp, &path).map_err(io_err)?;
+
+        Ok(Some(MessageMeta {
+            id,
+            writer: RESERVED_DAEMON_WRITER.to_string(),
+            kind: KIND_RADAR_NOTE.to_string(),
+            to: Some(to.to_string()),
+            created_ms: now_ms,
+            ttl_s,
+            expired: false,
+        }))
+    }
+
     /// Every message's frontmatter across all writers, rule-5 liveness
     /// posture. Expired entries are returned flagged — GC removes,
     /// radar decides.
@@ -282,6 +524,17 @@ pub(crate) fn scan_meta_dir(
     dir: &Path,
     now_ms: u64,
 ) -> Result<LivenessScan<MessageMeta>, CoordinationError> {
+    scan_meta_dir_budgeted(dir, now_ms, &mut ReadBudget::unbounded())
+}
+
+/// [`scan_meta_dir`] under a §1.6 whole-space read budget (the radar's
+/// entry — one budget spans the declarations and messages of a pass):
+/// budget-refused entries surface as `read-budget` rejections, unread.
+pub(crate) fn scan_meta_dir_budgeted(
+    dir: &Path,
+    now_ms: u64,
+    budget: &mut ReadBudget,
+) -> Result<LivenessScan<MessageMeta>, CoordinationError> {
     let (dirs, mut rejected) = writer_dirs(dir)?;
     let mut entries = Vec::new();
     for WriterDir {
@@ -296,6 +549,13 @@ pub(crate) fn scan_meta_dir(
         }));
         for entry in found {
             let name = format!("{writer}/{}.md", entry.stem);
+            if !budget.admit(entry.meta.len()) {
+                rejected.push(ScanReject {
+                    name,
+                    reason: REJECT_READ_BUDGET,
+                });
+                continue;
+            }
             let bytes = match scan::open_liveness(&entry.path)? {
                 DefensiveRead::Ok(bytes) => bytes,
                 DefensiveRead::Vanished => continue,
@@ -489,6 +749,189 @@ mod tests {
         assert_eq!(scan.entries.len(), 1, "forged copy rejected");
         assert_eq!(scan.rejected.len(), 1);
         assert!(scan.rejected[0].name.starts_with("s-forger/"));
+    }
+
+    fn note<'a>(to: &'a str, parties: &'a [&'a str], paths: &'a [String]) -> RadarNoteInput<'a> {
+        RadarNoteInput {
+            to,
+            parties,
+            declared: true,
+            git: true,
+            pr: None,
+            paths,
+            ttl_s: None,
+        }
+    }
+
+    #[test]
+    fn radar_note_writes_under_daemon_and_reads_back() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ms = space(&tmp);
+        let paths = vec!["src/a.rs".to_string(), "src/b.rs".to_string()];
+        let meta = ms
+            .write_radar_note(&note("s-alpha", &["s-alpha", "s-beta"], &paths))
+            .unwrap()
+            .expect("first note lands");
+        assert_eq!(meta.writer, RESERVED_DAEMON_WRITER);
+        assert_eq!(meta.kind, KIND_RADAR_NOTE);
+        assert_eq!(meta.to.as_deref(), Some("s-alpha"));
+        assert_eq!(meta.ttl_s, MESSAGE_TTL_DEFAULT_S, "normal TTL clamp");
+        assert!(meta.id.starts_with("rn-"), "{}", meta.id);
+        assert_eq!(sanitize_key(&meta.id), meta.id, "id obeys the grammar");
+
+        // The scan lists it like any message; the full read shows the
+        // schema-rendered body: `## overlap` paths + template line.
+        let now = super::super::now_ms();
+        let scan = ms.scan_meta(now).unwrap();
+        assert!(scan.rejected.is_empty(), "{:?}", scan.rejected);
+        assert_eq!(scan.entries.len(), 1);
+        let full = ms
+            .read(RESERVED_DAEMON_WRITER, &meta.id, now)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            full.body,
+            "## overlap\nsrc/a.rs\nsrc/b.rs\n\nWorking-set overlap between s-alpha and s-beta \
+             (sources: declared,git). Coordinate in this space before touching the paths above."
+        );
+        let raw = std::fs::read_to_string(
+            tmp.path()
+                .join("space/messages/daemon")
+                .join(format!("{}.md", meta.id)),
+        )
+        .unwrap();
+        assert!(raw.contains("from: daemon\n"), "{raw}");
+        assert!(raw.contains("parties: s-alpha,s-beta\n"), "{raw}");
+        assert!(raw.contains("sources: declared,git\n"), "{raw}");
+        assert!(raw.contains("attribution: unverified-same-uid\n"));
+    }
+
+    #[test]
+    fn radar_note_pr_variant_carries_pr_and_source() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ms = space(&tmp);
+        let paths = vec!["docs/x.md".to_string()];
+        let meta = ms
+            .write_radar_note(&RadarNoteInput {
+                to: "s-alpha",
+                parties: &["s-alpha"],
+                declared: false,
+                git: true,
+                pr: Some(566),
+                paths: &paths,
+                ttl_s: Some(3600),
+            })
+            .unwrap()
+            .unwrap();
+        assert_eq!(meta.ttl_s, 3600);
+        let now = super::super::now_ms();
+        let full = ms
+            .read(RESERVED_DAEMON_WRITER, &meta.id, now)
+            .unwrap()
+            .unwrap();
+        assert!(
+            full.body.contains("s-alpha and open pr#566"),
+            "{}",
+            full.body
+        );
+        assert!(full.body.contains("(sources: git,pr)"), "{}", full.body);
+        let raw = std::fs::read_to_string(
+            tmp.path()
+                .join("space/messages/daemon")
+                .join(format!("{}.md", meta.id)),
+        )
+        .unwrap();
+        assert!(raw.contains("pr: 566\n"), "{raw}");
+    }
+
+    #[test]
+    fn radar_note_dedups_by_overlap_set_and_cools_down_per_recipient() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ms = space(&tmp);
+        let paths = vec!["src/a.rs".to_string()];
+        let parties = ["s-alpha", "s-beta"];
+        let first = ms
+            .write_radar_note(&note("s-alpha", &parties, &paths))
+            .unwrap();
+        assert!(first.is_some());
+        // Same set again (paths in any order): deduped by id.
+        let again = ms
+            .write_radar_note(&note("s-alpha", &parties, &paths))
+            .unwrap();
+        assert!(again.is_none(), "identical overlap set never re-notes");
+        // A different set for the same recipient: suppressed by the
+        // 10-minute recipient cooldown, not written.
+        let other_paths = vec!["src/z.rs".to_string()];
+        let cooled = ms
+            .write_radar_note(&note("s-alpha", &parties, &other_paths))
+            .unwrap();
+        assert!(cooled.is_none(), "recipient cooldown holds");
+        // The OTHER flagged party is a distinct recipient: lands.
+        let beta = ms
+            .write_radar_note(&note("s-beta", &parties, &paths))
+            .unwrap();
+        assert!(beta.is_some(), "each flagged party gets its own note");
+        let scan = ms.scan_meta(super::super::now_ms()).unwrap();
+        assert_eq!(scan.entries.len(), 2, "one per recipient, no spam");
+    }
+
+    #[test]
+    fn radar_note_refusals_are_named() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ms = space(&tmp);
+        let good = vec!["src/a.rs".to_string()];
+        let hostile = vec!["../etc/passwd".to_string()];
+        for (input, needle) in [
+            (note("Bad Id", &["Bad Id"], &good), "grammar"),
+            (note("s-a", &["s-b"], &good), "one of its parties"),
+            (note("s-a", &[], &good), "1..=8"),
+            (note("s-a", &["s-a"], &hostile), "repo-relative"),
+            (
+                RadarNoteInput {
+                    to: "s-a",
+                    parties: &["s-a"],
+                    declared: false,
+                    git: false,
+                    pr: None,
+                    paths: &good,
+                    ttl_s: None,
+                },
+                "at least one source",
+            ),
+            (
+                RadarNoteInput {
+                    to: "s-a",
+                    parties: &["s-a"],
+                    declared: true,
+                    git: false,
+                    pr: None,
+                    paths: &[],
+                    ttl_s: None,
+                },
+                "at least one overlapping path",
+            ),
+        ] {
+            let err = ms.write_radar_note(&input).unwrap_err().to_string();
+            assert!(err.contains(needle), "{err}");
+        }
+    }
+
+    #[test]
+    fn budgeted_meta_scan_skips_unread_messages_loudly() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ms = space(&tmp);
+        for body in ["one", "two", "three"] {
+            ms.write("s-a", &msg(body)).unwrap();
+        }
+        let dir = tmp.path().join("space/messages");
+        let mut budget = ReadBudget::new(1, u64::MAX);
+        let scan = scan_meta_dir_budgeted(&dir, super::super::now_ms(), &mut budget).unwrap();
+        assert_eq!(scan.entries.len(), 1);
+        assert_eq!(scan.rejected.len(), 2);
+        assert!(scan
+            .rejected
+            .iter()
+            .all(|r| r.reason == REJECT_READ_BUDGET && r.name.starts_with("s-a/")));
     }
 
     #[test]

--- a/src/bin/caller/coordination/mod.rs
+++ b/src/bin/caller/coordination/mod.rs
@@ -70,6 +70,14 @@
 //! remove on clean end) the native and wrapper loops own. The
 //! consumers — collision radar, daemon-rendered prompt lanes, the
 //! CLI — are C2/C3.
+//!
+//! Track C (C2) adds the radar's detection half: `radar.rs` (the
+//! daemon's periodic zero-LLM overlap detection over declared sets ∪
+//! observed git status ∪ open-PR file sets, published per space) and
+//! `render.rs` (the pure per-session renderer of the ruled §2.2
+//! `[System] coordination v1` block, byte-capped and deduplicated).
+//! The per-turn injection wiring and the dashboard/external delivery
+//! lanes consume them next.
 
 use std::path::{Path, PathBuf};
 
@@ -80,6 +88,8 @@ pub(crate) mod gc;
 pub(crate) mod lifecycle;
 pub(crate) mod messages;
 pub(crate) mod paths;
+pub(crate) mod radar;
+pub(crate) mod render;
 pub(crate) mod scan;
 
 /// Per-document byte cap (frontmatter + body).
@@ -261,6 +271,21 @@ pub(crate) fn now_ms() -> u64 {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
         .unwrap_or(0)
+}
+
+/// FNV-1a-64 with the STANDARD constants — the radar's render-dedup
+/// hash and radar-note id hash (deterministic, non-cryptographic; a
+/// collision is a dedup nuisance, never a boundary). Deliberately NOT
+/// shared with [`space_key`], whose nonstandard multiplier is pinned
+/// forever by C1 erratum 3 (on-disk spaces key by it — do-not-fix);
+/// new hashing uses the textbook prime.
+pub(crate) fn fnv1a_64(bytes: &[u8]) -> u64 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in bytes {
+        hash ^= *b as u64;
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
 }
 
 /// R5 rider (ruled): the `intendant-coordination` skill ships a python3

--- a/src/bin/caller/coordination/radar.rs
+++ b/src/bin/caller/coordination/radar.rs
@@ -1,0 +1,1185 @@
+//! Collision radar — the detection half (Track C, C2; ruled §2.1/§2.7).
+//!
+//! A periodic daemon task maintains per-space radar state from three
+//! zero-LLM inputs — detection is deterministic and never waits on a
+//! model (§2.1, binding):
+//!
+//! - **declared working sets**: the bus `sessions/` scan (rule-5
+//!   liveness posture, under the §1.6 whole-space read budget). A
+//!   stale declaration (mtime > 45 min) is *marked* in presence and no
+//!   longer trusted as proof of a live session, but its dirty set
+//!   still participates in overlap as `declared` evidence — a claimed
+//!   working set outlives a missed heartbeat (C2 brief, pinned);
+//! - **observed dirty sets**: `git status` over the sessions the
+//!   daemon actually supervises — the published `GitVitalsTargets`
+//!   registry — reusing the vitals prober machinery verbatim
+//!   ([`GIT_STATUS_ARGS`], [`parse_status_v2`], the 10 s [`run_git`]
+//!   anti-wedge ceiling, per-toplevel caching). Sessions are seen by
+//!   git-scan detection whether or not they declared (§2.8);
+//! - **open-PR file sets**: `gh pr list --json number,files`, cached
+//!   at least [`PR_CACHE_MIN_MS`] per space and degraded silently when
+//!   `gh` is absent or fails (§2.1). Never invoked by unit tests —
+//!   the pure computation takes injected sets.
+//!
+//! Severity per §2.7: **ALERT** is a path dirty in two working sets
+//! (declared∪observed × declared∪observed, cross-session) or in one
+//! live set ∩ an open PR's files; everything else — presence, stale
+//! peers, unread messages, invalid counts — is ambient. Snapshots are
+//! plain serializable values computed by a pure function over injected
+//! inputs (hermetic tests) and published per space like the
+//! `publish_git_vitals_targets` precedent; `render.rs` turns one
+//! snapshot into one session's §2.2 block, and the daemon writes
+//! deduplicated radar notes to flagged parties (§2.8, `messages.rs`).
+
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock, RwLock};
+
+use super::declarations::{self, SessionDeclaration};
+use super::lifecycle::writer_id_for_session;
+use super::messages::{self, MessageMeta, MessageSpace, RadarNoteInput};
+use super::scan::{self, ReadBudget};
+use super::{sanitize_key, CoordinationError, MAX_SCAN_ENTRIES};
+use crate::session_vitals::{
+    parse_status_v2, run_git, GitVitalsTargets, GIT_PROBE_TIMEOUT, GIT_STATUS_ARGS,
+};
+
+/// Detection cadence. The protocol names no radar cadence, so the task
+/// rides the same tick as the vitals producer whose git machinery it
+/// reuses (`session_vitals::PROBE_INTERVAL`) — a local ref read per
+/// distinct checkout plus two bounded directory scans per space.
+pub(crate) const RADAR_TICK: std::time::Duration = std::time::Duration::from_secs(5);
+/// §1.6: whole-space read budget per radar pass — 512 files / 8 MiB,
+/// shared across both liveness kinds of one space.
+pub(crate) const RADAR_PASS_FILE_BUDGET: usize = 512;
+pub(crate) const RADAR_PASS_BYTE_BUDGET: u64 = 8 * 1024 * 1024;
+/// §2.1: open-PR file sets are cached at least this long (failures
+/// included, so a broken `gh` is retried at the same gentle pace).
+pub(crate) const PR_CACHE_MIN_MS: u64 = 5 * 60 * 1000;
+/// Open PRs / files-per-PR accepted from `gh` (defensive parse bound).
+const MAX_PRS: usize = 64;
+const MAX_PR_FILES: usize = 1024;
+
+/// One session's presence in a space, from its declaration.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub(crate) struct RadarSessionPresence {
+    pub writer_id: String,
+    pub backend: Option<String>,
+    pub stale: bool,
+}
+
+/// ALERT: `path` is in both `a`'s and `b`'s working set (`a < b`,
+/// cross-session). `declared`/`git` say which evidence kinds back the
+/// overlap across the two sides.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub(crate) struct RadarPairOverlap {
+    pub path: String,
+    pub a: String,
+    pub b: String,
+    pub declared: bool,
+    pub git: bool,
+}
+
+/// ALERT: `path` is in `writer`'s working set and in open PR `pr`'s
+/// file set.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub(crate) struct RadarPrOverlap {
+    pub path: String,
+    pub writer: String,
+    pub pr: u32,
+}
+
+/// Existence-only message metadata (writer + id + recipient — NEVER
+/// body text; §9 verbatim).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub(crate) struct RadarMessageMeta {
+    pub writer: String,
+    pub id: String,
+    pub to: Option<String>,
+}
+
+/// One space's radar state: a plain value the renderer and the
+/// delivery lanes read. Every collection is sorted — identical inputs
+/// produce an identical (byte-identical once rendered) snapshot.
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize)]
+pub(crate) struct SpaceRadarSnapshot {
+    pub space_key: String,
+    /// When the radar computed this snapshot. Never rendered (the
+    /// block must hash identically across quiet ticks) — freshness
+    /// metadata for diagnostics/dashboard lanes.
+    pub computed_ms: u64,
+    pub sessions: Vec<RadarSessionPresence>,
+    pub pair_overlaps: Vec<RadarPairOverlap>,
+    pub pr_overlaps: Vec<RadarPrOverlap>,
+    pub messages: Vec<RadarMessageMeta>,
+    /// Entries ignored loudly across the pass: scan rejections (§1.7
+    /// rule-5 counts, read-budget drops) plus every token that failed
+    /// its §2.3 grammar during computation.
+    pub invalid: u64,
+}
+
+/// One supervised session's observed git-dirty set (toplevel-relative
+/// paths, raw — the computation validates the grammar).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ObservedSet {
+    pub writer_id: String,
+    pub paths: BTreeSet<String>,
+}
+
+/// One open PR's changed-file set (raw paths from `gh`; validated at
+/// computation).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PrFileSet {
+    pub number: u32,
+    pub paths: BTreeSet<String>,
+}
+
+/// Injected inputs for one space's computation — everything the pure
+/// function needs, nothing read from the environment.
+pub(crate) struct RadarSpaceInputs<'a> {
+    pub space_key: &'a str,
+    pub declarations: &'a [SessionDeclaration],
+    pub observed: &'a [ObservedSet],
+    pub messages: &'a [MessageMeta],
+    pub pr_files: &'a [PrFileSet],
+    /// Named rejections the scans already counted (rule-5 liveness
+    /// amendment) — folded into the snapshot's `invalid` total.
+    pub scan_invalid: usize,
+}
+
+/// The §2.7 overlap computation, pure and deterministic: working set =
+/// declared ∪ observed per writer; a path in two writers' sets is a
+/// pair ALERT; a path in one writer's set ∩ an open PR's files is a PR
+/// ALERT. Tokens outside their §2.3 grammar never enter a set — they
+/// are counted into `invalid` (loud, never silent).
+pub(crate) fn compute_space_snapshot(
+    inputs: &RadarSpaceInputs<'_>,
+    now_ms: u64,
+) -> SpaceRadarSnapshot {
+    let mut invalid = inputs.scan_invalid as u64;
+
+    // Presence: declarations only (a registry-only session has no bus
+    // presence to describe; its overlaps still name it below).
+    let mut sessions: Vec<RadarSessionPresence> = inputs
+        .declarations
+        .iter()
+        .map(|d| RadarSessionPresence {
+            writer_id: d.id.clone(),
+            backend: d.backend.clone(),
+            stale: d.stale,
+        })
+        .collect();
+    sessions.sort_by(|x, y| x.writer_id.cmp(&y.writer_id));
+    invalid += inputs
+        .declarations
+        .iter()
+        .map(|d| d.dirty_dropped as u64)
+        .sum::<u64>();
+
+    // Working sets: declared ∪ observed per writer, grammar-gated.
+    #[derive(Default)]
+    struct Sets {
+        declared: BTreeSet<String>,
+        git: BTreeSet<String>,
+    }
+    let mut sets: BTreeMap<String, Sets> = BTreeMap::new();
+    for d in inputs.declarations {
+        let entry = sets.entry(d.id.clone()).or_default();
+        for p in &d.dirty {
+            if scan::valid_rel_path(p) {
+                entry.declared.insert(p.clone());
+            } else {
+                invalid += 1;
+            }
+        }
+    }
+    for o in inputs.observed {
+        if o.writer_id.is_empty() || sanitize_key(&o.writer_id) != o.writer_id {
+            invalid += 1;
+            continue;
+        }
+        let entry = sets.entry(o.writer_id.clone()).or_default();
+        for raw in &o.paths {
+            // git spends one line on a whole untracked directory
+            // (`dir/`); normalize the trailing slash before the
+            // grammar gate.
+            let p = raw.trim_end_matches('/');
+            if scan::valid_rel_path(p) {
+                entry.git.insert(p.to_string());
+            } else {
+                invalid += 1;
+            }
+        }
+    }
+    let alls: BTreeMap<&str, BTreeSet<&str>> = sets
+        .iter()
+        .map(|(w, s)| {
+            let all: BTreeSet<&str> = s
+                .declared
+                .iter()
+                .map(String::as_str)
+                .chain(s.git.iter().map(String::as_str))
+                .collect();
+            (w.as_str(), all)
+        })
+        .collect();
+    let writers: Vec<&str> = alls.keys().copied().collect();
+
+    // Pair overlaps (cross-session — a session is never in conflict
+    // with itself).
+    let mut pair_overlaps = Vec::new();
+    for i in 0..writers.len() {
+        for j in i + 1..writers.len() {
+            let (wa, wb) = (writers[i], writers[j]);
+            for path in alls[wa].intersection(&alls[wb]) {
+                let declared =
+                    sets[wa].declared.contains(*path) || sets[wb].declared.contains(*path);
+                let git = sets[wa].git.contains(*path) || sets[wb].git.contains(*path);
+                pair_overlaps.push(RadarPairOverlap {
+                    path: (*path).to_string(),
+                    a: wa.to_string(),
+                    b: wb.to_string(),
+                    declared,
+                    git,
+                });
+            }
+        }
+    }
+    pair_overlaps.sort_by(|x, y| (&x.path, &x.a, &x.b).cmp(&(&y.path, &y.a, &y.b)));
+
+    // PR overlaps: one live set ∩ an open PR's files.
+    let mut pr_sets: Vec<(u32, BTreeSet<&str>)> = Vec::new();
+    for pr in inputs.pr_files {
+        let mut valid_paths = BTreeSet::new();
+        for p in &pr.paths {
+            if scan::valid_rel_path(p) {
+                valid_paths.insert(p.as_str());
+            } else {
+                invalid += 1;
+            }
+        }
+        pr_sets.push((pr.number, valid_paths));
+    }
+    pr_sets.sort_by_key(|(n, _)| *n);
+    let mut pr_overlaps = Vec::new();
+    for (writer, all) in &alls {
+        for (number, paths) in &pr_sets {
+            for path in all.intersection(paths) {
+                pr_overlaps.push(RadarPrOverlap {
+                    path: (*path).to_string(),
+                    writer: writer.to_string(),
+                    pr: *number,
+                });
+            }
+        }
+    }
+    pr_overlaps.sort_by(|x, y| (&x.path, &x.writer, x.pr).cmp(&(&y.path, &y.writer, y.pr)));
+
+    // Messages: existence-only, live entries only (expiry is advisory
+    // until GC, but the radar stops surfacing an expired note).
+    let mut messages: Vec<RadarMessageMeta> = inputs
+        .messages
+        .iter()
+        .filter(|m| !m.expired)
+        .map(|m| RadarMessageMeta {
+            writer: m.writer.clone(),
+            id: m.id.clone(),
+            to: m.to.clone(),
+        })
+        .collect();
+    messages.sort_by(|x, y| (&x.writer, &x.id).cmp(&(&y.writer, &y.id)));
+
+    SpaceRadarSnapshot {
+        space_key: inputs.space_key.to_string(),
+        computed_ms: now_ms,
+        sessions,
+        pair_overlaps,
+        pr_overlaps,
+        messages,
+        invalid,
+    }
+}
+
+/// One space's bus read for a radar pass: both liveness kinds under
+/// one §1.6 whole-space budget, rejections counted (rule 5). Missing
+/// kind directories are an empty space, never an error; scan-bound
+/// overflow and real I/O trouble stay errors the caller surfaces.
+pub(crate) struct SpaceBusRead {
+    pub declarations: Vec<SessionDeclaration>,
+    pub messages: Vec<MessageMeta>,
+    pub scan_invalid: usize,
+}
+
+pub(crate) fn read_space_bus(
+    space_dir: &Path,
+    now_ms: u64,
+) -> Result<SpaceBusRead, CoordinationError> {
+    let mut budget = ReadBudget::new(RADAR_PASS_FILE_BUDGET, RADAR_PASS_BYTE_BUDGET);
+    let decls = declarations::scan_dir_budgeted(&space_dir.join("sessions"), now_ms, &mut budget)?;
+    let msgs = messages::scan_meta_dir_budgeted(&space_dir.join("messages"), now_ms, &mut budget)?;
+    Ok(SpaceBusRead {
+        scan_invalid: decls.rejected.len() + msgs.rejected.len(),
+        declarations: decls.entries,
+        messages: msgs.entries,
+    })
+}
+
+/// Write the deduplicated radar notes for a snapshot's ALERT overlaps
+/// (§2.8): one note per distinct overlap set per flagged pair, to each
+/// flagged party, under the reserved daemon writer dir. Dedup and the
+/// per-recipient cooldown live in [`MessageSpace::write_radar_note`];
+/// this groups overlaps into per-pair path sets. Returns the trouble
+/// (if any) for the caller's throttled log — a full bus is loud, not
+/// fatal.
+pub(crate) fn write_space_radar_notes(
+    space_dir: &Path,
+    space_key: &str,
+    snapshot: &SpaceRadarSnapshot,
+) -> Vec<String> {
+    if snapshot.pair_overlaps.is_empty() && snapshot.pr_overlaps.is_empty() {
+        return Vec::new();
+    }
+    let mut errors = Vec::new();
+    let space = match MessageSpace::open(space_dir, space_key) {
+        Ok(space) => space,
+        Err(e) => return vec![e.to_string()],
+    };
+
+    // Pair notes: group per (a, b) into one path set + source union.
+    let mut pairs: BTreeMap<(&str, &str), (BTreeSet<&str>, bool, bool)> = BTreeMap::new();
+    for o in &snapshot.pair_overlaps {
+        let entry = pairs.entry((o.a.as_str(), o.b.as_str())).or_default();
+        entry.0.insert(o.path.as_str());
+        entry.1 |= o.declared;
+        entry.2 |= o.git;
+    }
+    for ((a, b), (paths, declared, git)) in &pairs {
+        let paths: Vec<String> = paths.iter().map(|p| (*p).to_string()).collect();
+        for recipient in [a, b] {
+            let result = space.write_radar_note(&RadarNoteInput {
+                to: recipient,
+                parties: &[a, b],
+                declared: *declared,
+                git: *git,
+                pr: None,
+                paths: &paths,
+                ttl_s: None,
+            });
+            if let Err(e) = result {
+                errors.push(e.to_string());
+            }
+        }
+    }
+
+    // PR notes: group per (writer, pr).
+    let mut prs: BTreeMap<(&str, u32), BTreeSet<&str>> = BTreeMap::new();
+    for o in &snapshot.pr_overlaps {
+        prs.entry((o.writer.as_str(), o.pr))
+            .or_default()
+            .insert(o.path.as_str());
+    }
+    for ((writer, pr), paths) in &prs {
+        let paths: Vec<String> = paths.iter().map(|p| (*p).to_string()).collect();
+        let result = space.write_radar_note(&RadarNoteInput {
+            to: writer,
+            parties: &[writer],
+            declared: false,
+            git: false,
+            pr: Some(*pr),
+            paths: &paths,
+            ttl_s: None,
+        });
+        if let Err(e) = result {
+            errors.push(e.to_string());
+        }
+    }
+    errors
+}
+
+/// The published per-space radar state (`publish_git_vitals_targets`
+/// precedent): the daemon task is the single writer; the injection
+/// seam and delivery lanes read.
+#[derive(Clone, Default)]
+pub(crate) struct RadarState {
+    spaces: Arc<RwLock<HashMap<String, Arc<SpaceRadarSnapshot>>>>,
+}
+
+impl RadarState {
+    pub(crate) fn publish_space(&self, snapshot: SpaceRadarSnapshot) {
+        self.spaces
+            .write()
+            .expect("radar state lock")
+            .insert(snapshot.space_key.clone(), Arc::new(snapshot));
+    }
+
+    /// Drop spaces that stopped existing (dir GC'd, no supervised
+    /// members left) so stale overlap state cannot outlive its space.
+    pub(crate) fn retain_spaces(&self, live: &HashSet<String>) {
+        self.spaces
+            .write()
+            .expect("radar state lock")
+            .retain(|key, _| live.contains(key));
+    }
+
+    /// One space's latest snapshot — the injection seam's read
+    /// (`render::render_block` consumes it per session).
+    #[cfg_attr(not(test), allow(dead_code))] // consumed by the C2 injection wiring (PR E)
+    pub(crate) fn space(&self, space_key: &str) -> Option<Arc<SpaceRadarSnapshot>> {
+        self.spaces
+            .read()
+            .expect("radar state lock")
+            .get(space_key)
+            .cloned()
+    }
+}
+
+/// The daemon's live radar state, published once at startup. Tests
+/// never publish — seams take a [`RadarState`] or a snapshot directly.
+static PUBLISHED_RADAR_STATE: OnceLock<RadarState> = OnceLock::new();
+
+pub(crate) fn publish_radar_state(state: &RadarState) {
+    let _ = PUBLISHED_RADAR_STATE.set(state.clone());
+}
+
+/// The published state, when a daemon startup path wired one — where
+/// the injection seam (PR E) reads each session's space snapshot from.
+#[cfg_attr(not(test), allow(dead_code))] // consumed by the C2 injection wiring (PR E)
+pub(crate) fn published_radar_state() -> Option<&'static RadarState> {
+    PUBLISHED_RADAR_STATE.get()
+}
+
+/// Parse `gh pr list --json number,files` output into file sets. Pure
+/// (unit-tested on fixtures); bounds are defensive parse caps, and the
+/// path grammar is enforced later at computation.
+pub(crate) fn parse_pr_list_json(bytes: &[u8]) -> Option<Vec<PrFileSet>> {
+    #[derive(serde::Deserialize)]
+    struct GhFile {
+        path: String,
+    }
+    #[derive(serde::Deserialize)]
+    struct GhPr {
+        number: u32,
+        #[serde(default)]
+        files: Vec<GhFile>,
+    }
+    let prs: Vec<GhPr> = serde_json::from_slice(bytes).ok()?;
+    let mut sets: Vec<PrFileSet> = prs
+        .into_iter()
+        .take(MAX_PRS)
+        .map(|pr| PrFileSet {
+            number: pr.number,
+            paths: pr
+                .files
+                .into_iter()
+                .take(MAX_PR_FILES)
+                .map(|f| f.path)
+                .collect(),
+        })
+        .collect();
+    sets.sort_by_key(|s| s.number);
+    Some(sets)
+}
+
+/// Observed dirty sets for one space's supervised members, one
+/// `git status` per distinct checkout toplevel (the vitals prober's
+/// dedup shape). A member outside any checkout, or a wedged/failed
+/// git, simply contributes no observed set — declarations still cover
+/// it.
+async fn collect_observed(
+    git_program: &std::ffi::OsStr,
+    members: &[(String, PathBuf)],
+    toplevel_cache: &mut HashMap<PathBuf, PathBuf>,
+) -> Vec<ObservedSet> {
+    let mut status_by_toplevel: HashMap<PathBuf, Option<BTreeSet<String>>> = HashMap::new();
+    let mut merged: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for (writer_id, root) in members {
+        let toplevel = match toplevel_cache.get(root) {
+            Some(cached) => cached.clone(),
+            None => {
+                let out = run_git(
+                    git_program,
+                    GIT_PROBE_TIMEOUT,
+                    root,
+                    &["rev-parse", "--show-toplevel"],
+                )
+                .await;
+                let Some(out) = out.filter(|o| o.status.success()) else {
+                    continue; // not a checkout (or git trouble): no observed set
+                };
+                let top = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim().to_string());
+                if top.as_os_str().is_empty() {
+                    continue;
+                }
+                if toplevel_cache.len() > 256 {
+                    toplevel_cache.clear(); // vitals prober's cheap cap
+                }
+                toplevel_cache.insert(root.clone(), top.clone());
+                top
+            }
+        };
+        let dirty = match status_by_toplevel.get(&toplevel) {
+            Some(cached) => cached.clone(),
+            None => {
+                let out =
+                    run_git(git_program, GIT_PROBE_TIMEOUT, &toplevel, &GIT_STATUS_ARGS).await;
+                let dirty = out.filter(|o| o.status.success()).map(|o| {
+                    parse_status_v2(&String::from_utf8_lossy(&o.stdout))
+                        .entries
+                        .into_iter()
+                        .map(|e| e.path)
+                        .collect::<BTreeSet<String>>()
+                });
+                if dirty.is_none() {
+                    // The cached toplevel may be stale (checkout gone):
+                    // drop it so the next tick re-resolves.
+                    toplevel_cache.remove(root);
+                }
+                status_by_toplevel.insert(toplevel.clone(), dirty.clone());
+                dirty
+            }
+        };
+        if let Some(paths) = dirty {
+            merged.entry(writer_id.clone()).or_default().extend(paths);
+        }
+    }
+    merged
+        .into_iter()
+        .map(|(writer_id, paths)| ObservedSet { writer_id, paths })
+        .collect()
+}
+
+/// `gh` under the same anti-wedge guards as [`run_git`] (kill_on_drop
+/// + timeout); `None` on any trouble — the caller degrades silently.
+async fn run_gh(cwd: &Path, args: &[&str]) -> Option<std::process::Output> {
+    let output = tokio::process::Command::new("gh")
+        .current_dir(cwd)
+        .args(args)
+        .kill_on_drop(true)
+        .output();
+    tokio::time::timeout(GIT_PROBE_TIMEOUT, output)
+        .await
+        .ok()?
+        .ok()
+}
+
+struct PrCacheEntry {
+    fetched_ms: u64,
+    sets: Arc<Vec<PrFileSet>>,
+}
+
+/// The periodic detection task's state. Constructed once at spawn with
+/// real paths; every tick reads the bus + registry and publishes.
+struct RadarTask {
+    coordination_root: PathBuf,
+    state: RadarState,
+    targets: GitVitalsTargets,
+    git_program: std::ffi::OsString,
+    /// `gh` participation — disabled only in tests via [`RadarTask`]
+    /// construction (unit tests never spawn the task at all).
+    gh_enabled: bool,
+    space_key_cache: HashMap<PathBuf, String>,
+    toplevel_cache: HashMap<PathBuf, PathBuf>,
+    pr_cache: HashMap<String, PrCacheEntry>,
+    /// Last logged trouble per space — the tick logs on CHANGE, never
+    /// per tick (a broken space must be loud once, not a 5 s drumbeat).
+    last_trouble: HashMap<String, String>,
+}
+
+impl RadarTask {
+    fn space_key_for(&mut self, root: &Path) -> String {
+        if let Some(cached) = self.space_key_cache.get(root) {
+            return cached.clone();
+        }
+        let key = super::space_key(root);
+        if self.space_key_cache.len() > 256 {
+            self.space_key_cache.clear();
+        }
+        self.space_key_cache.insert(root.to_path_buf(), key.clone());
+        key
+    }
+
+    async fn pr_sets(
+        &mut self,
+        space_key: &str,
+        roots: &[PathBuf],
+        now_ms: u64,
+    ) -> Arc<Vec<PrFileSet>> {
+        if !self.gh_enabled {
+            return Arc::new(Vec::new());
+        }
+        if let Some(cached) = self.pr_cache.get(space_key) {
+            if now_ms.saturating_sub(cached.fetched_ms) < PR_CACHE_MIN_MS {
+                return cached.sets.clone();
+            }
+        }
+        let mut sets = Vec::new();
+        if let Some(cwd) = roots.first() {
+            let fetched = run_gh(
+                cwd,
+                &["pr", "list", "--json", "number,files", "--limit", "50"],
+            )
+            .await
+            .filter(|out| out.status.success())
+            .and_then(|out| parse_pr_list_json(&out.stdout));
+            sets = fetched.unwrap_or_default(); // silent degrade (§2.1)
+        }
+        let sets = Arc::new(sets);
+        self.pr_cache.insert(
+            space_key.to_string(),
+            PrCacheEntry {
+                fetched_ms: now_ms,
+                sets: sets.clone(),
+            },
+        );
+        sets
+    }
+
+    fn note_trouble(&mut self, key: String, trouble: Option<String>) {
+        match trouble {
+            Some(msg) => {
+                if self.last_trouble.get(&key) != Some(&msg) {
+                    eprintln!("[coordination] radar {key}: {msg}");
+                    self.last_trouble.insert(key, msg);
+                }
+            }
+            None => {
+                self.last_trouble.remove(&key);
+            }
+        }
+    }
+
+    /// Space dirs present on disk (the GC walk's shape: bounded, dirs
+    /// only, dot entries skipped; names outside the space-key grammar
+    /// are foreign and inert).
+    fn disk_spaces(&self) -> BTreeSet<String> {
+        let mut keys = BTreeSet::new();
+        let Ok(entries) = std::fs::read_dir(&self.coordination_root) else {
+            return keys;
+        };
+        for entry in entries.take(MAX_SCAN_ENTRIES).flatten() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if name.starts_with('.')
+                || name.is_empty()
+                || name.len() > 96
+                || !name
+                    .bytes()
+                    .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+            {
+                continue;
+            }
+            let is_dir = std::fs::symlink_metadata(entry.path())
+                .map(|m| m.is_dir())
+                .unwrap_or(false);
+            if is_dir {
+                keys.insert(name);
+            }
+        }
+        keys
+    }
+
+    async fn tick(&mut self) {
+        let now_ms = super::now_ms();
+        // Registry members grouped by space: every supervised session
+        // participates in git-scan detection, declared or not (§2.8).
+        let mut members_by_space: BTreeMap<String, Vec<(String, PathBuf)>> = BTreeMap::new();
+        for (session_id, root) in self.targets.snapshot() {
+            let key = self.space_key_for(&root);
+            members_by_space
+                .entry(key)
+                .or_default()
+                .push((writer_id_for_session(&session_id), root));
+        }
+        for members in members_by_space.values_mut() {
+            members.sort();
+            members.dedup();
+        }
+        let mut keys: BTreeSet<String> = members_by_space.keys().cloned().collect();
+        keys.extend(self.disk_spaces());
+
+        let mut live: HashSet<String> = HashSet::new();
+        for key in keys {
+            let space_dir = self.coordination_root.join(&key);
+            let bus = match read_space_bus(&space_dir, now_ms) {
+                Ok(bus) => bus,
+                Err(e) => {
+                    // Corruption-grade trouble: keep the last snapshot
+                    // (don't blind consumers on a transient) and log on
+                    // change.
+                    self.note_trouble(format!("{key}/bus"), Some(e.to_string()));
+                    live.insert(key);
+                    continue;
+                }
+            };
+            self.note_trouble(format!("{key}/bus"), None);
+            let members = members_by_space.remove(&key).unwrap_or_default();
+            let roots: Vec<PathBuf> = members.iter().map(|(_, root)| root.clone()).collect();
+            let observed =
+                collect_observed(&self.git_program, &members, &mut self.toplevel_cache).await;
+            let pr_sets = self.pr_sets(&key, &roots, now_ms).await;
+            let snapshot = compute_space_snapshot(
+                &RadarSpaceInputs {
+                    space_key: &key,
+                    declarations: &bus.declarations,
+                    observed: &observed,
+                    messages: &bus.messages,
+                    pr_files: &pr_sets,
+                    scan_invalid: bus.scan_invalid,
+                },
+                now_ms,
+            );
+            let note_errors = write_space_radar_notes(&space_dir, &key, &snapshot);
+            self.note_trouble(
+                format!("{key}/notes"),
+                (!note_errors.is_empty()).then(|| note_errors.join("; ")),
+            );
+            self.state.publish_space(snapshot);
+            live.insert(key);
+        }
+        self.state.retain_spaces(&live);
+    }
+}
+
+/// Spawn the periodic radar task (daemon startup). Resolves the real
+/// coordination root at this edge — everything below takes explicit
+/// paths — publishes the state handle for the read side, and ticks
+/// forever on [`RADAR_TICK`].
+pub(crate) fn spawn_radar_task(targets: GitVitalsTargets) -> tokio::task::JoinHandle<()> {
+    let state = RadarState::default();
+    publish_radar_state(&state);
+    let mut task = RadarTask {
+        coordination_root: super::paths::coordination_root(&crate::platform::intendant_home()),
+        state,
+        targets,
+        git_program: "git".into(),
+        gh_enabled: true,
+        space_key_cache: HashMap::new(),
+        toplevel_cache: HashMap::new(),
+        pr_cache: HashMap::new(),
+        last_trouble: HashMap::new(),
+    };
+    tokio::spawn(async move {
+        loop {
+            task.tick().await;
+            tokio::time::sleep(RADAR_TICK).await;
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::coordination::declarations::{DeclarationInput, DeclarationSpace};
+    use crate::coordination::messages::MessageInput;
+
+    fn declaration(id: &str, dirty: &[&str], stale: bool) -> SessionDeclaration {
+        SessionDeclaration {
+            id: id.to_string(),
+            session: None,
+            backend: Some("native".to_string()),
+            root: None,
+            branch: None,
+            created_ms: 1,
+            intent: "test".to_string(),
+            dirty: dirty.iter().map(|s| s.to_string()).collect(),
+            dirty_dropped: 0,
+            effective_mtime_ms: 1,
+            stale,
+        }
+    }
+
+    fn observed(writer: &str, paths: &[&str]) -> ObservedSet {
+        ObservedSet {
+            writer_id: writer.to_string(),
+            paths: paths.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    fn pr(number: u32, paths: &[&str]) -> PrFileSet {
+        PrFileSet {
+            number,
+            paths: paths.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    fn snap(inputs: &RadarSpaceInputs<'_>) -> SpaceRadarSnapshot {
+        compute_space_snapshot(inputs, 1_000_000)
+    }
+
+    fn inputs<'a>(
+        declarations: &'a [SessionDeclaration],
+        observed: &'a [ObservedSet],
+        messages: &'a [MessageMeta],
+        pr_files: &'a [PrFileSet],
+    ) -> RadarSpaceInputs<'a> {
+        RadarSpaceInputs {
+            space_key: "test-space-0000000000000000",
+            declarations,
+            observed,
+            messages,
+            pr_files,
+            scan_invalid: 0,
+        }
+    }
+
+    /// The §2.7 severity classification table, pinned case by case.
+    #[test]
+    fn severity_classification_table() {
+        // declared × declared → pair ALERT, sources declared only.
+        let decls = [
+            declaration("s-a", &["src/x.rs"], false),
+            declaration("s-b", &["src/x.rs"], false),
+        ];
+        let s = snap(&inputs(&decls, &[], &[], &[]));
+        assert_eq!(s.pair_overlaps.len(), 1);
+        let o = &s.pair_overlaps[0];
+        assert_eq!(
+            (o.path.as_str(), o.a.as_str(), o.b.as_str()),
+            ("src/x.rs", "s-a", "s-b")
+        );
+        assert!(o.declared && !o.git);
+
+        // declared × observed → pair ALERT, both sources.
+        let decls = [declaration("s-a", &["src/x.rs"], false)];
+        let obs = [observed("s-b", &["src/x.rs"])];
+        let s = snap(&inputs(&decls, &obs, &[], &[]));
+        assert_eq!(s.pair_overlaps.len(), 1);
+        assert!(s.pair_overlaps[0].declared && s.pair_overlaps[0].git);
+
+        // observed × observed → pair ALERT, git only.
+        let obs = [
+            observed("s-a", &["src/x.rs"]),
+            observed("s-b", &["src/x.rs"]),
+        ];
+        let s = snap(&inputs(&[], &obs, &[], &[]));
+        assert_eq!(s.pair_overlaps.len(), 1);
+        assert!(!s.pair_overlaps[0].declared && s.pair_overlaps[0].git);
+
+        // one live set ∩ open PR files → PR ALERT (declared or observed).
+        let decls = [declaration("s-a", &["docs/y.md"], false)];
+        let s = snap(&inputs(&decls, &[], &[], &[pr(31, &["docs/y.md"])]));
+        assert_eq!(s.pair_overlaps.len(), 0);
+        assert_eq!(s.pr_overlaps.len(), 1);
+        assert_eq!(
+            (
+                s.pr_overlaps[0].path.as_str(),
+                s.pr_overlaps[0].writer.as_str(),
+                s.pr_overlaps[0].pr
+            ),
+            ("docs/y.md", "s-a", 31)
+        );
+        let obs = [observed("s-a", &["docs/y.md"])];
+        let s = snap(&inputs(&[], &obs, &[], &[pr(31, &["docs/y.md"])]));
+        assert_eq!(s.pr_overlaps.len(), 1);
+
+        // A path in ONE set only, or in two PRs with no live set:
+        // no overlap at all.
+        let decls = [declaration("s-a", &["src/solo.rs"], false)];
+        let s = snap(&inputs(
+            &decls,
+            &[],
+            &[],
+            &[pr(1, &["other/p.rs"]), pr(2, &["other/p.rs"])],
+        ));
+        assert!(s.pair_overlaps.is_empty() && s.pr_overlaps.is_empty());
+
+        // A session's own declared ∩ its own observed set is NOT an
+        // overlap (cross-session only).
+        let decls = [declaration("s-a", &["src/x.rs"], false)];
+        let obs = [observed("s-a", &["src/x.rs"])];
+        let s = snap(&inputs(&decls, &obs, &[], &[]));
+        assert!(s.pair_overlaps.is_empty());
+    }
+
+    /// The C2 brief's pinned staleness rule: a >45 min-stale
+    /// declaration is marked in presence but its dirty set still
+    /// participates in overlap as `declared` evidence.
+    #[test]
+    fn stale_declarations_are_marked_but_still_participate() {
+        let decls = [
+            declaration("s-live", &["src/x.rs"], false),
+            declaration("s-stale", &["src/x.rs"], true),
+        ];
+        let s = snap(&inputs(&decls, &[], &[], &[]));
+        assert_eq!(s.sessions.iter().filter(|p| p.stale).count(), 1);
+        assert_eq!(
+            s.pair_overlaps.len(),
+            1,
+            "stale declared set still overlaps"
+        );
+        assert!(s.pair_overlaps[0].declared);
+    }
+
+    #[test]
+    fn hostile_tokens_are_counted_never_kept() {
+        let mut d = declaration("s-a", &[], false);
+        // Inject paths that bypass the parse gate (hostile snapshot
+        // construction): the computation re-validates.
+        d.dirty = vec![
+            "src/ok.rs".to_string(),
+            "../escape".to_string(),
+            "has space".to_string(),
+            "ansi\u{1b}[31m".to_string(),
+        ];
+        d.dirty_dropped = 2; // parse-side counts fold in too
+        let decls = [d];
+        let obs = [
+            observed("s-b", &["src/ok.rs", "also bad", "x\u{202e}rtl"]),
+            observed("Bad Writer!", &["src/ok.rs"]),
+        ];
+        let prs = [pr(9, &["src/ok.rs", "-leading-dash"])];
+        let s = snap(&inputs(&decls, &obs, &[], &prs));
+        // Only the grammar-valid path overlaps; every hostile token
+        // and the pre-counted parse drops land in `invalid`.
+        assert_eq!(s.pair_overlaps.len(), 1);
+        assert_eq!(s.pair_overlaps[0].path, "src/ok.rs");
+        assert_eq!(s.pr_overlaps.len(), 2, "both writers ∩ pr#9");
+        // 3 hostile declared paths + 2 hostile observed paths + 1
+        // hostile writer id + 1 hostile PR path + 2 pre-counted parse
+        // drops = 9.
+        assert_eq!(s.invalid, 9, "{s:?}");
+    }
+
+    /// Zero-LLM determinism (binding): identical inputs in any order
+    /// produce an identical snapshot, ordering stable.
+    #[test]
+    fn computation_is_deterministic_and_order_independent() {
+        let d1 = declaration("s-b", &["src/x.rs", "src/y.rs"], false);
+        let d2 = declaration("s-a", &["src/x.rs"], false);
+        let o1 = observed("s-c", &["src/y.rs", "src/x.rs"]);
+        let o2 = observed("s-a", &["src/z.rs"]);
+        let m1 = MessageMeta {
+            id: "m-2".into(),
+            writer: "s-b".into(),
+            kind: "message".into(),
+            to: None,
+            created_ms: 1,
+            ttl_s: 60,
+            expired: false,
+        };
+        let m2 = MessageMeta {
+            id: "m-1".into(),
+            writer: "s-a".into(),
+            kind: "message".into(),
+            to: Some("s-b".into()),
+            created_ms: 1,
+            ttl_s: 60,
+            expired: false,
+        };
+        let p1 = pr(7, &["src/x.rs"]);
+        let p2 = pr(3, &["src/y.rs"]);
+
+        let forward = [d1.clone(), d2.clone()];
+        let backward = [d2, d1];
+        let a = snap(&inputs(
+            &forward,
+            &[o1.clone(), o2.clone()],
+            &[m1.clone(), m2.clone()],
+            &[p1.clone(), p2.clone()],
+        ));
+        let b = snap(&inputs(&backward, &[o2, o1], &[m2, m1], &[p2, p1]));
+        assert_eq!(a, b, "input order must not matter");
+        // Ordering is pinned, not incidental.
+        let pair_keys: Vec<(&str, &str, &str)> = a
+            .pair_overlaps
+            .iter()
+            .map(|o| (o.path.as_str(), o.a.as_str(), o.b.as_str()))
+            .collect();
+        let mut sorted = pair_keys.clone();
+        sorted.sort();
+        assert_eq!(pair_keys, sorted);
+        assert!(a
+            .messages
+            .windows(2)
+            .all(|w| (&w[0].writer, &w[0].id) <= (&w[1].writer, &w[1].id)));
+    }
+
+    #[test]
+    fn expired_messages_never_surface() {
+        let m = MessageMeta {
+            id: "m-dead".into(),
+            writer: "s-a".into(),
+            kind: "message".into(),
+            to: None,
+            created_ms: 1,
+            ttl_s: 60,
+            expired: true,
+        };
+        let s = snap(&inputs(&[], &[], &[m], &[]));
+        assert!(s.messages.is_empty());
+    }
+
+    #[test]
+    fn read_space_bus_charges_one_budget_across_both_kinds() {
+        let tmp = tempfile::tempdir().unwrap();
+        let space_dir = tmp.path().join("space");
+        let ds = DeclarationSpace::open(&space_dir, "s").unwrap();
+        for i in 0..3 {
+            ds.write_own(&DeclarationInput {
+                id: &format!("s-{i}"),
+                session: None,
+                backend: None,
+                root: None,
+                branch: None,
+                intent: "x",
+                dirty: &[],
+            })
+            .unwrap();
+        }
+        let ms = MessageSpace::open(&space_dir, "s").unwrap();
+        ms.write(
+            "s-0",
+            &MessageInput {
+                to: None,
+                ttl_s: None,
+                body: "note",
+            },
+        )
+        .unwrap();
+
+        let bus = read_space_bus(&space_dir, super::super::now_ms()).unwrap();
+        assert_eq!(bus.declarations.len(), 3);
+        assert_eq!(bus.messages.len(), 1);
+        assert_eq!(bus.scan_invalid, 0);
+
+        // A malformed neighbor is counted, never fatal (rule 5).
+        std::fs::write(space_dir.join("sessions/s-junk.md"), "not a doc").unwrap();
+        let bus = read_space_bus(&space_dir, super::super::now_ms()).unwrap();
+        assert_eq!(bus.declarations.len(), 3);
+        assert_eq!(bus.scan_invalid, 1);
+    }
+
+    #[test]
+    fn radar_notes_flow_from_snapshot_and_dedup() {
+        let tmp = tempfile::tempdir().unwrap();
+        let space_dir = tmp.path().join("space");
+        let decls = [
+            declaration("s-a", &["src/x.rs"], false),
+            declaration("s-b", &["src/x.rs"], false),
+        ];
+        let obs = [observed("s-a", &["docs/pr-file.md"])];
+        let prs = [pr(42, &["docs/pr-file.md"])];
+        let s = snap(&inputs(&decls, &obs, &[], &prs));
+        let errors = write_space_radar_notes(&space_dir, "test-space", &s);
+        assert!(errors.is_empty(), "{errors:?}");
+
+        let ms = MessageSpace::open(&space_dir, "test-space").unwrap();
+        let scan = ms.scan_meta(super::super::now_ms()).unwrap();
+        assert!(scan.rejected.is_empty(), "{:?}", scan.rejected);
+        // Pair note to each flagged party + one PR note to s-a's set
+        // holder... but the PR-note recipient (s-a) was just noted by
+        // the pair lane: the recipient cooldown holds it. Two notes.
+        assert_eq!(scan.entries.len(), 2, "{:?}", scan.entries);
+        let recipients: Vec<Option<&str>> = scan.entries.iter().map(|m| m.to.as_deref()).collect();
+        assert!(recipients.contains(&Some("s-a")) && recipients.contains(&Some("s-b")));
+        assert!(scan
+            .entries
+            .iter()
+            .all(|m| m.writer == "daemon" && m.kind == "radar-note"));
+
+        // Re-running the same snapshot writes nothing new (set dedup +
+        // cooldown).
+        let errors = write_space_radar_notes(&space_dir, "test-space", &s);
+        assert!(errors.is_empty(), "{errors:?}");
+        assert_eq!(
+            ms.scan_meta(super::super::now_ms()).unwrap().entries.len(),
+            2
+        );
+
+        // No overlaps → no bus dirs are ever created.
+        let empty_dir = tmp.path().join("empty-space");
+        let quiet = snap(&inputs(&[], &[], &[], &[]));
+        assert!(write_space_radar_notes(&empty_dir, "empty", &quiet).is_empty());
+        assert!(!empty_dir.exists(), "quiet spaces stay untouched");
+    }
+
+    #[test]
+    fn pr_list_json_parses_the_gh_shape() {
+        let json = br#"[
+            {"number": 566, "files": [{"path": "src/a.rs", "additions": 1, "deletions": 2}, {"path": "docs/b.md"}]},
+            {"number": 12, "files": []},
+            {"number": 90}
+        ]"#;
+        let sets = parse_pr_list_json(json).unwrap();
+        assert_eq!(sets.len(), 3);
+        assert_eq!(sets[0].number, 12, "sorted by number");
+        assert_eq!(sets[2].number, 566);
+        assert!(sets[2].paths.contains("src/a.rs") && sets[2].paths.contains("docs/b.md"));
+        assert!(parse_pr_list_json(b"not json").is_none());
+        assert!(parse_pr_list_json(b"{}").is_none(), "object, not array");
+    }
+
+    #[tokio::test]
+    async fn observed_sets_come_from_git_status_per_toplevel() {
+        let git_ok = std::process::Command::new("git")
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if !git_ok {
+            eprintln!("SKIPPED: no usable `git` on PATH — observed-set collection DID NOT RUN");
+            return;
+        }
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let git = |args: &[&str]| {
+            let status = std::process::Command::new("git")
+                .arg("-C")
+                .arg(&repo)
+                .args(args)
+                .env("GIT_CONFIG_GLOBAL", "/dev/null")
+                .env("GIT_CONFIG_SYSTEM", "/dev/null")
+                .output()
+                .expect("git spawns");
+            assert!(status.status.success(), "git {args:?}");
+        };
+        git(&["init", "-q", "-b", "main"]);
+        std::fs::write(repo.join("tracked.rs"), "a").unwrap();
+        git(&["add", "tracked.rs"]);
+        git(&[
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "commit",
+            "-q",
+            "-m",
+            "seed",
+        ]);
+        std::fs::write(repo.join("tracked.rs"), "b").unwrap(); // modified
+        std::fs::write(repo.join("untracked.rs"), "c").unwrap(); // untracked
+
+        let members = vec![
+            ("s-one".to_string(), repo.clone()),
+            ("s-two".to_string(), repo.clone()), // same checkout, shared status
+            ("s-none".to_string(), tmp.path().join("not-a-repo")),
+        ];
+        let mut cache = HashMap::new();
+        let observed = collect_observed(std::ffi::OsStr::new("git"), &members, &mut cache).await;
+        assert_eq!(observed.len(), 2, "{observed:?}");
+        for set in &observed {
+            assert!(set.paths.contains("tracked.rs"), "{observed:?}");
+            assert!(set.paths.contains("untracked.rs"), "{observed:?}");
+        }
+        assert!(observed.iter().any(|s| s.writer_id == "s-one"));
+        assert!(observed.iter().any(|s| s.writer_id == "s-two"));
+    }
+
+    #[test]
+    fn radar_state_publishes_and_retains() {
+        let state = RadarState::default();
+        let mut s = SpaceRadarSnapshot {
+            space_key: "alpha-1".into(),
+            ..Default::default()
+        };
+        state.publish_space(s.clone());
+        s.space_key = "beta-2".into();
+        state.publish_space(s);
+        assert!(state.space("alpha-1").is_some());
+        let live: HashSet<String> = ["beta-2".to_string()].into_iter().collect();
+        state.retain_spaces(&live);
+        assert!(state.space("alpha-1").is_none());
+        assert!(state.space("beta-2").is_some());
+        assert!(state.space("never").is_none());
+    }
+}

--- a/src/bin/caller/coordination/render.rs
+++ b/src/bin/caller/coordination/render.rs
@@ -1,0 +1,966 @@
+//! Coordination-block renderer (Track C, C2; ruled §2.2–§2.5, §2.7).
+//!
+//! A pure function turns one space's radar snapshot into the ONE
+//! bounded `[System] coordination v1` block a session may receive per
+//! turn. Everything here is binding, ruled behavior:
+//!
+//! - **§2.2 schema, exactly**: line-oriented, one record per line —
+//!   header, `sessions:` presence, `! overlap` ALERT lines,
+//!   `messages:` existence-only (writer + ids, NEVER text),
+//!   `invalid:`, `[truncated]`. Free text cannot appear.
+//! - **§2.3 string safety**: every token passes its per-type validator
+//!   (path grammar with the ≤120-char DISPLAY bound, middle-ellipsized
+//!   — the parse grammar's 512 stays in `scan.rs`, C1 erratum 4;
+//!   sanitize_key-idempotent ids shown as 8-char prefixes; closed
+//!   backend enum; decimal counts). Failures COUNT into `invalid:` and
+//!   never render. The `messages:` writer and ids render whole — §2.2
+//!   makes them the retrieval coordinates for
+//!   `$INTENDANT_COORDINATION_DIR/messages/<writer>/<id>.md`, so a
+//!   truncated prefix would break the documented lazy read.
+//! - **§2.4 caps**: rendered block ≤ 1536 bytes HARD (the loop
+//!   truncates nothing downstream — the renderer is the only wall,
+//!   R1); ≤ 3 session entries listed (counts stay exact); ≤ 8 overlap
+//!   lines, ALERT lines kept first under byte pressure; ≤ 4 message
+//!   lines; `[truncated]` marks every drop.
+//! - **§2.5 dedup**: the caller keeps (hash, injected-at) per session;
+//!   an identical render inside the 30-minute floor returns `None`; a
+//!   NEW alert changes the hash and bypasses naturally.
+//! - **§2.7 presence**: `None` unless at least one non-header line
+//!   exists; the own session is excluded from its own radar lines (a
+//!   session is not in conflict with itself — messages TO it still
+//!   show).
+//!
+//! Zero-LLM and deterministic: identical inputs render byte-identical
+//! blocks; every collection consumed is pre-sorted by the radar.
+#![cfg_attr(not(test), allow(dead_code))] // C2 staging: consumed by the per-turn injection seam + delivery lanes (PR E). Drop as that wiring lands.
+
+use std::collections::BTreeMap;
+
+use super::radar::SpaceRadarSnapshot;
+use super::scan;
+
+/// §2.4 (R1): the rendered block's HARD byte cap.
+pub(crate) const RENDERED_BLOCK_MAX_BYTES: usize = 1536;
+/// §2.4: session entries listed on the presence line (counts exact).
+pub(crate) const MAX_SESSIONS_LISTED: usize = 3;
+/// §2.4: overlap lines rendered, ALERT first.
+pub(crate) const MAX_OVERLAP_LINES: usize = 8;
+/// §2.4: message lines rendered (one per writer).
+pub(crate) const MAX_MESSAGE_LINES: usize = 4;
+/// Ids listed per message line (the §2.2 example's shape; the line's
+/// count stays exact).
+pub(crate) const MAX_MESSAGE_IDS_LISTED: usize = 2;
+/// §2.5: a never-changing block re-injects at most once per floor.
+pub(crate) const REINJECT_FLOOR_MS: u64 = 30 * 60 * 1000;
+/// §2.3: the path DISPLAY bound (middle-ellipsized; erratum 4).
+pub(crate) const PATH_DISPLAY_MAX_CHARS: usize = 120;
+
+/// One rendered block: the exact bytes to inject, the dedup hash the
+/// caller stores, and whether any ALERT line rendered (the external
+/// lane is ALERT-only, §2.8).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RenderedBlock {
+    pub text: String,
+    pub hash: u64,
+    pub has_alert: bool,
+}
+
+/// Render one session's coordination block from its space snapshot.
+///
+/// `own_writer_id` is the session's bus writer id
+/// (`lifecycle::writer_id_for_session`); `last_hash`/`last_injected_ms`
+/// are the caller's per-session dedup state from the previous `Some`
+/// (pass `None`/`0` when nothing was ever injected). Returns `None`
+/// when there is nothing to say (§2.7), or when the identical block
+/// was already injected inside the §2.5 floor.
+pub(crate) fn render_block(
+    snapshot: &SpaceRadarSnapshot,
+    own_writer_id: &str,
+    last_hash: Option<u64>,
+    last_injected_ms: u64,
+    now_ms: u64,
+) -> Option<RenderedBlock> {
+    let candidates = build_candidates(snapshot, own_writer_id)?;
+    let (text, has_alert) = assemble(&candidates)?;
+    debug_assert!(text.len() <= RENDERED_BLOCK_MAX_BYTES);
+    let hash = super::fnv1a_64(text.as_bytes());
+    if last_hash == Some(hash) && now_ms.saturating_sub(last_injected_ms) < REINJECT_FLOOR_MS {
+        return None; // §2.5: identical render, floor not yet reached
+    }
+    Some(RenderedBlock {
+        text,
+        hash,
+        has_alert,
+    })
+}
+
+/// Space-key labels as rendered in the header: the derived-key /
+/// override-label grammar (`paths::resolve_space_dir`'s rule).
+fn valid_space_key_label(s: &str) -> bool {
+    !s.is_empty()
+        && s.len() <= 96
+        && s.bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+}
+
+/// §2.3 id/writer validator: sanitize_key-idempotent, ≤ 64.
+fn valid_id(s: &str) -> bool {
+    !s.is_empty() && s.len() <= 64 && super::sanitize_key(s) == s
+}
+
+/// §2.3 message-id validator. The ruled grammar says `[a-z0-9]{10,32}`
+/// for ULIDs; C1 landed message ids as `m-<ulid>` (and radar notes are
+/// `rn-<hash>`), so the rendered token is the retrievable filename
+/// stem under the same §1.3 grammar, length-bounded 10..=32 — lex
+/// posterior, reported as an erratum candidate.
+fn valid_message_id(s: &str) -> bool {
+    (10..=32).contains(&s.len()) && super::sanitize_key(s) == s
+}
+
+/// The `<id8>` display prefix (§2.3). Ids are grammar-checked ASCII,
+/// so byte slicing is char-safe.
+fn id8(s: &str) -> &str {
+    &s[..s.len().min(8)]
+}
+
+/// §2.3 path display: grammar-valid, ≤ 120 chars middle-ellipsized.
+fn display_path(p: &str) -> Option<String> {
+    if !scan::valid_rel_path(p) {
+        return None;
+    }
+    if p.len() <= PATH_DISPLAY_MAX_CHARS {
+        return Some(p.to_string());
+    }
+    // Grammar paths are pure ASCII: byte offsets are char boundaries.
+    let head = &p[..60];
+    let tail = &p[p.len() - 59..];
+    Some(format!("{head}…{tail}"))
+}
+
+/// The candidate lines for one session's block, per-kind caps applied,
+/// every token validated. `None` only when the space key itself is
+/// outside its grammar (nothing safe to say at all).
+struct Candidates {
+    header: String,
+    sessions: Option<String>,
+    overlaps: Vec<String>,
+    messages: Vec<String>,
+    invalid_line: Option<String>,
+    /// Lines dropped by the per-kind count caps (before byte pressure).
+    cap_dropped: bool,
+}
+
+fn build_candidates(snapshot: &SpaceRadarSnapshot, own_writer_id: &str) -> Option<Candidates> {
+    if !valid_space_key_label(&snapshot.space_key) {
+        return None;
+    }
+    let header = format!("[System] coordination v1 space={}", snapshot.space_key);
+    let mut invalid: u64 = snapshot.invalid;
+
+    // Presence: everyone but the own session (§2.7 — a space holding
+    // only you says nothing). Actives list before stales; counts are
+    // exact, the listing caps at MAX_SESSIONS_LISTED.
+    let mut active: u64 = 0;
+    let mut stale: u64 = 0;
+    let mut listed: Vec<String> = Vec::new();
+    for list_stale in [false, true] {
+        for s in &snapshot.sessions {
+            if s.stale != list_stale || s.writer_id == own_writer_id {
+                continue;
+            }
+            if !valid_id(&s.writer_id) {
+                invalid += 1;
+                continue;
+            }
+            let backend = match s.backend.as_deref() {
+                // A declaration without a backend field is an
+                // unsupervised-grade writer: the closed enum's floor.
+                None => "guest",
+                Some(b) if scan::valid_backend(b) => b,
+                Some(_) => {
+                    invalid += 1;
+                    continue;
+                }
+            };
+            if s.stale {
+                stale += 1;
+            } else {
+                active += 1;
+            }
+            if listed.len() < MAX_SESSIONS_LISTED {
+                listed.push(format!("{}({backend})", id8(&s.writer_id)));
+            }
+        }
+    }
+    let sessions = (active + stale > 0).then(|| {
+        format!(
+            "sessions: {active} active, {stale} stale — {}",
+            listed.join(", ")
+        )
+    });
+
+    // Overlap ALERT lines involving this session (§2.7 own-exclusion:
+    // the own id never renders; the counterparty does).
+    let mut overlaps: Vec<String> = Vec::new();
+    for o in &snapshot.pair_overlaps {
+        let other = if o.a == own_writer_id {
+            &o.b
+        } else if o.b == own_writer_id {
+            &o.a
+        } else {
+            continue; // someone else's collision — not this block's line
+        };
+        if !valid_id(other) {
+            invalid += 1;
+            continue;
+        }
+        let Some(path) = display_path(&o.path) else {
+            invalid += 1;
+            continue;
+        };
+        let sources = match (o.declared, o.git) {
+            (true, true) => "declared+git",
+            (true, false) => "declared",
+            (false, true) => "git",
+            (false, false) => {
+                invalid += 1;
+                continue;
+            }
+        };
+        overlaps.push(format!(
+            "! overlap {path} — with {} ({sources})",
+            id8(other)
+        ));
+    }
+    for o in &snapshot.pr_overlaps {
+        if o.writer != own_writer_id {
+            continue;
+        }
+        let Some(path) = display_path(&o.path) else {
+            invalid += 1;
+            continue;
+        };
+        overlaps.push(format!("! overlap {path} — pr#{}", o.pr));
+    }
+    let overlap_cap_dropped = overlaps.len() > MAX_OVERLAP_LINES;
+    overlaps.truncate(MAX_OVERLAP_LINES);
+
+    // Messages addressed to this session (or space-wide), grouped per
+    // writer — existence and provenance only, never text (§2.2/§9).
+    let mut per_writer: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    for m in &snapshot.messages {
+        if m.writer == own_writer_id {
+            continue; // own outbox is not news
+        }
+        match m.to.as_deref() {
+            None => {}
+            Some(to) if to == own_writer_id => {}
+            Some(_) => continue, // someone else's mail
+        }
+        if !valid_id(&m.writer) || !valid_message_id(&m.id) {
+            invalid += 1;
+            continue;
+        }
+        per_writer.entry(m.writer.as_str()).or_default().push(&m.id);
+    }
+    let mut messages: Vec<String> = Vec::new();
+    let mut message_cap_dropped = false;
+    for (writer, ids) in &per_writer {
+        if messages.len() >= MAX_MESSAGE_LINES {
+            message_cap_dropped = true;
+            break;
+        }
+        let shown = ids
+            .iter()
+            .take(MAX_MESSAGE_IDS_LISTED)
+            .copied()
+            .collect::<Vec<_>>()
+            .join(", ");
+        messages.push(format!(
+            "messages: {} unread — from {writer}: {shown}",
+            ids.len()
+        ));
+    }
+
+    let invalid_line = (invalid > 0).then(|| format!("invalid: {invalid} entries ignored"));
+    Some(Candidates {
+        header,
+        sessions,
+        overlaps,
+        messages,
+        invalid_line,
+        cap_dropped: overlap_cap_dropped || message_cap_dropped,
+    })
+}
+
+/// Assemble the candidates into the final block under the §2.4 hard
+/// byte cap. Under byte pressure the keep-priority is ALERT overlap
+/// lines first, then presence, then messages, then the invalid count —
+/// output stays in schema order regardless. `None` when no non-header
+/// line exists (§2.7).
+fn assemble(c: &Candidates) -> Option<(String, bool)> {
+    let non_header = usize::from(c.sessions.is_some())
+        + c.overlaps.len()
+        + c.messages.len()
+        + usize::from(c.invalid_line.is_some());
+    if non_header == 0 {
+        return None;
+    }
+
+    // The straightforward assembly first: everything the count caps
+    // admitted, plus the marker when those caps dropped lines.
+    let mut full = c.header.clone();
+    if let Some(s) = &c.sessions {
+        full.push('\n');
+        full.push_str(s);
+    }
+    for line in &c.overlaps {
+        full.push('\n');
+        full.push_str(line);
+    }
+    for line in &c.messages {
+        full.push('\n');
+        full.push_str(line);
+    }
+    if let Some(line) = &c.invalid_line {
+        full.push('\n');
+        full.push_str(line);
+    }
+    if c.cap_dropped {
+        full.push_str("\n[truncated]");
+    }
+    if full.len() <= RENDERED_BLOCK_MAX_BYTES {
+        return Some((full, !c.overlaps.is_empty()));
+    }
+
+    // Over budget: reserve the marker, then admit lines by priority.
+    const MARKER: &str = "\n[truncated]";
+    let mut budget = RENDERED_BLOCK_MAX_BYTES.saturating_sub(c.header.len() + MARKER.len());
+    let admit = |line: &str, budget: &mut usize| -> bool {
+        let cost = 1 + line.len();
+        if cost <= *budget {
+            *budget -= cost;
+            true
+        } else {
+            false
+        }
+    };
+    let mut take_overlaps = 0usize;
+    for line in &c.overlaps {
+        if admit(line, &mut budget) {
+            take_overlaps += 1;
+        } else {
+            break;
+        }
+    }
+    let take_sessions = c.sessions.as_deref().is_some_and(|s| admit(s, &mut budget));
+    let mut take_messages = 0usize;
+    for line in &c.messages {
+        if admit(line, &mut budget) {
+            take_messages += 1;
+        } else {
+            break;
+        }
+    }
+    let take_invalid = c
+        .invalid_line
+        .as_deref()
+        .is_some_and(|s| admit(s, &mut budget));
+    if take_overlaps == 0 && !take_sessions && take_messages == 0 && !take_invalid {
+        return None; // nothing fit — unreachable with bounded lines, but never emit a bare header
+    }
+
+    let mut text = c.header.clone();
+    if take_sessions {
+        text.push('\n');
+        text.push_str(c.sessions.as_deref().unwrap_or_default());
+    }
+    for line in &c.overlaps[..take_overlaps] {
+        text.push('\n');
+        text.push_str(line);
+    }
+    for line in &c.messages[..take_messages] {
+        text.push('\n');
+        text.push_str(line);
+    }
+    if take_invalid {
+        text.push('\n');
+        text.push_str(c.invalid_line.as_deref().unwrap_or_default());
+    }
+    text.push_str(MARKER);
+    Some((text, take_overlaps > 0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::coordination::radar::{
+        compute_space_snapshot, ObservedSet, PrFileSet, RadarMessageMeta, RadarPairOverlap,
+        RadarPrOverlap, RadarSessionPresence, RadarSpaceInputs,
+    };
+
+    const SPACE: &str = "test-space-0123456789abcdef";
+    const OWN: &str = "s-me";
+
+    fn base_snapshot() -> SpaceRadarSnapshot {
+        SpaceRadarSnapshot {
+            space_key: SPACE.to_string(),
+            computed_ms: 0,
+            sessions: Vec::new(),
+            pair_overlaps: Vec::new(),
+            pr_overlaps: Vec::new(),
+            messages: Vec::new(),
+            invalid: 0,
+        }
+    }
+
+    fn presence(id: &str, backend: Option<&str>, stale: bool) -> RadarSessionPresence {
+        RadarSessionPresence {
+            writer_id: id.to_string(),
+            backend: backend.map(str::to_string),
+            stale,
+        }
+    }
+
+    fn pair(path: &str, a: &str, b: &str, declared: bool, git: bool) -> RadarPairOverlap {
+        RadarPairOverlap {
+            path: path.to_string(),
+            a: a.to_string(),
+            b: b.to_string(),
+            declared,
+            git,
+        }
+    }
+
+    fn message(writer: &str, id: &str, to: Option<&str>) -> RadarMessageMeta {
+        RadarMessageMeta {
+            writer: writer.to_string(),
+            id: id.to_string(),
+            to: to.map(str::to_string),
+        }
+    }
+
+    fn render(snapshot: &SpaceRadarSnapshot) -> Option<RenderedBlock> {
+        render_block(snapshot, OWN, None, 0, 0)
+    }
+
+    /// Every byte of a rendered block stays inside the schema: ASCII
+    /// text plus the schema's em-dash and the ellipsis, line shapes
+    /// from the §2.2 grammar only.
+    fn assert_schema_clean(text: &str) {
+        for ch in text.chars() {
+            assert!(
+                ch == '\n' || ch == '—' || ch == '…' || ch == ' ' || ch.is_ascii_graphic(),
+                "byte outside the schema grammar: {ch:?} in {text:?}"
+            );
+        }
+        for (i, line) in text.lines().enumerate() {
+            if i == 0 {
+                let key = line
+                    .strip_prefix("[System] coordination v1 space=")
+                    .unwrap_or_else(|| panic!("bad header: {line:?}"));
+                assert!(super::valid_space_key_label(key), "{key:?}");
+                continue;
+            }
+            assert!(
+                line == "[truncated]"
+                    || line.starts_with("sessions: ")
+                    || line.starts_with("! overlap ")
+                    || line.starts_with("messages: ")
+                    || line.starts_with("invalid: "),
+                "line outside the schema: {line:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn solo_space_renders_nothing() {
+        let mut s = base_snapshot();
+        s.sessions.push(presence(OWN, Some("native"), false));
+        assert!(render(&s).is_none(), "§2.7: one session, nothing to say");
+        assert!(render(&base_snapshot()).is_none(), "empty space");
+    }
+
+    #[test]
+    fn presence_line_excludes_own_and_keeps_counts_exact() {
+        let mut s = base_snapshot();
+        s.sessions.push(presence(OWN, Some("native"), false));
+        for i in 0..5 {
+            s.sessions
+                .push(presence(&format!("s-other-{i}"), Some("codex"), false));
+        }
+        s.sessions.push(presence("s-tired", None, true));
+        let block = render(&s).expect("others exist");
+        assert_schema_clean(&block.text);
+        assert!(!block.has_alert);
+        let sessions_line = block
+            .text
+            .lines()
+            .find(|l| l.starts_with("sessions: "))
+            .unwrap();
+        assert!(
+            sessions_line.starts_with("sessions: 5 active, 1 stale — "),
+            "{sessions_line}"
+        );
+        // ≤3 listed, actives first; the backendless stale peer would
+        // render as guest but the cap keeps it off the list.
+        assert_eq!(sessions_line.matches("s-other-").count(), 3);
+        assert!(!block.text.contains("s-me"), "own session never renders");
+    }
+
+    #[test]
+    fn absent_backend_renders_as_guest() {
+        let mut s = base_snapshot();
+        s.sessions.push(presence("s-anon", None, false));
+        let block = render(&s).unwrap();
+        assert!(block.text.contains("s-anon(guest)"), "{}", block.text);
+    }
+
+    #[test]
+    fn overlap_lines_follow_the_schema_and_exclude_foreign_pairs() {
+        let mut s = base_snapshot();
+        s.pair_overlaps
+            .push(pair("src/hot.rs", OWN, "s-other", true, true));
+        s.pair_overlaps
+            .push(pair("src/mine2.rs", "s-aaa", OWN, false, true));
+        s.pair_overlaps
+            .push(pair("src/foreign.rs", "s-xx", "s-yy", true, false));
+        s.pr_overlaps.push(RadarPrOverlap {
+            path: "docs/mine.md".to_string(),
+            writer: OWN.to_string(),
+            pr: 566,
+        });
+        s.pr_overlaps.push(RadarPrOverlap {
+            path: "docs/theirs.md".to_string(),
+            writer: "s-other".to_string(),
+            pr: 9,
+        });
+        let block = render(&s).unwrap();
+        assert_schema_clean(&block.text);
+        assert!(block.has_alert);
+        let lines: Vec<&str> = block.text.lines().collect();
+        assert_eq!(
+            lines[1], "! overlap src/hot.rs — with s-other (declared+git)",
+            "{lines:?}"
+        );
+        assert_eq!(lines[2], "! overlap src/mine2.rs — with s-aaa (git)");
+        assert_eq!(lines[3], "! overlap docs/mine.md — pr#566");
+        assert!(
+            !block.text.contains("foreign") && !block.text.contains("theirs"),
+            "other sessions' collisions are not this block's lines: {}",
+            block.text
+        );
+    }
+
+    #[test]
+    fn messages_show_recipient_scoped_existence_only() {
+        let mut s = base_snapshot();
+        s.messages.push(message("s-peer", "m-0123456789ab", None));
+        s.messages
+            .push(message("s-peer", "m-0123456789ac", Some(OWN)));
+        s.messages
+            .push(message("s-peer", "m-0123456789ad", Some("s-third")));
+        s.messages.push(message(OWN, "m-0123456789ae", None));
+        s.messages
+            .push(message("daemon", "rn-0011223344556677", Some(OWN)));
+        let block = render(&s).unwrap();
+        assert_schema_clean(&block.text);
+        let lines: Vec<&str> = block.text.lines().collect();
+        assert_eq!(
+            lines[1], "messages: 1 unread — from daemon: rn-0011223344556677",
+            "{lines:?}"
+        );
+        assert_eq!(
+            lines[2],
+            "messages: 2 unread — from s-peer: m-0123456789ab, m-0123456789ac"
+        );
+        assert!(
+            !block.text.contains("m-0123456789ad") && !block.text.contains("m-0123456789ae"),
+            "third-party and own mail never render"
+        );
+    }
+
+    #[test]
+    fn caps_bound_every_line_family_with_truncated_marker() {
+        let mut s = base_snapshot();
+        for i in 0..12 {
+            s.pair_overlaps.push(pair(
+                &format!("src/f{i:02}.rs"),
+                OWN,
+                "s-other",
+                true,
+                false,
+            ));
+        }
+        for w in 0..6 {
+            for k in 0..3 {
+                s.messages.push(message(
+                    &format!("s-writer-{w}"),
+                    &format!("m-{w:06}00{k:04}"),
+                    None,
+                ));
+            }
+        }
+        let block = render(&s).unwrap();
+        assert_schema_clean(&block.text);
+        let overlap_lines = block
+            .text
+            .lines()
+            .filter(|l| l.starts_with("! overlap"))
+            .count();
+        assert_eq!(overlap_lines, MAX_OVERLAP_LINES);
+        let message_lines: Vec<&str> = block
+            .text
+            .lines()
+            .filter(|l| l.starts_with("messages: "))
+            .collect();
+        assert_eq!(message_lines.len(), MAX_MESSAGE_LINES);
+        // Counts exact, ids listed capped.
+        assert!(message_lines[0].starts_with("messages: 3 unread — "));
+        assert_eq!(
+            message_lines[0].matches("m-").count(),
+            MAX_MESSAGE_IDS_LISTED
+        );
+        assert!(block.text.ends_with("\n[truncated]"), "{}", block.text);
+        assert!(block.text.len() <= RENDERED_BLOCK_MAX_BYTES);
+    }
+
+    #[test]
+    fn long_paths_are_middle_ellipsized_to_the_display_bound() {
+        let mut s = base_snapshot();
+        let long = format!("src/{}/deep.rs", "x".repeat(200));
+        s.pair_overlaps
+            .push(pair(&long, OWN, "s-other", true, false));
+        let block = render(&s).unwrap();
+        assert_schema_clean(&block.text);
+        let line = block.text.lines().nth(1).unwrap();
+        let path = line
+            .strip_prefix("! overlap ")
+            .unwrap()
+            .split(" — ")
+            .next()
+            .unwrap();
+        assert_eq!(path.chars().count(), PATH_DISPLAY_MAX_CHARS);
+        assert!(path.contains('…'));
+        assert!(path.starts_with("src/xxx") && path.ends_with("deep.rs"));
+    }
+
+    /// RULED binding (R6): adversarial strings on the rendered block —
+    /// spaces, ANSI, newlines, RTL overrides, 4 KB names — become
+    /// `invalid:` counts; not one hostile byte reaches the block.
+    #[test]
+    fn adversarial_snapshot_fields_render_as_counts_only() {
+        let mut s = base_snapshot();
+        s.sessions
+            .push(presence("Bad Writer", Some("native"), false));
+        s.sessions
+            .push(presence("s-mystery", Some("botnet"), false));
+        s.pair_overlaps
+            .push(pair("evil path/with space.rs", OWN, "s-other", true, false));
+        s.pair_overlaps
+            .push(pair("ansi\u{1b}[31mred.rs", OWN, "s-other", true, false));
+        s.pair_overlaps
+            .push(pair("multi\nline.rs", OWN, "s-other", false, true));
+        s.pair_overlaps
+            .push(pair("rtl\u{202e}gnp.rs", OWN, "s-other", true, true));
+        s.pair_overlaps
+            .push(pair(&"a".repeat(4096), OWN, "s-other", true, false));
+        s.pair_overlaps
+            .push(pair("src/fine.rs", OWN, "UPPER CASE ID", true, false));
+        s.pair_overlaps
+            .push(pair("src/none.rs", OWN, "s-other", false, false));
+        s.pr_overlaps.push(RadarPrOverlap {
+            path: "-leading-dash.rs".to_string(),
+            writer: OWN.to_string(),
+            pr: 1,
+        });
+        s.messages
+            .push(message("s-peer", "SHOUTING-NOT-AN-ID", Some(OWN)));
+        s.messages
+            .push(message("bad writer", "m-0123456789ab", None));
+        s.messages.push(message("s-peer", "x", None)); // too short
+        let block = render(&s).expect("the invalid count is a line");
+        assert_schema_clean(&block.text);
+        for hostile in [
+            "evil path",
+            "with space",
+            "\u{1b}",
+            "multi\nline",
+            "\u{202e}",
+            "aaaa",
+            "UPPER",
+            "SHOUTING",
+            "bad writer",
+            "botnet",
+            "s-mystery",
+            "-leading-dash",
+        ] {
+            assert!(
+                !block.text.contains(hostile),
+                "hostile token {hostile:?} leaked into {:?}",
+                block.text
+            );
+        }
+        assert!(!block.has_alert, "nothing valid to alert on");
+        // 12 hostile tokens counted: 2 sessions + 7 overlap drops + 1
+        // pr path + 3 message drops... the empty-sources line is a
+        // count too. Pin the exact line.
+        assert_eq!(
+            block.text.lines().nth(1).unwrap(),
+            "invalid: 13 entries ignored"
+        );
+    }
+
+    /// RULED binding (R6): the same adversarial classes arriving
+    /// through real bus files — scan → compute → render — become
+    /// counts, never bytes.
+    #[test]
+    fn adversarial_bus_files_render_as_counts_end_to_end() {
+        let tmp = tempfile::tempdir().unwrap();
+        let space_dir = tmp.path().join("space");
+        let sessions = space_dir.join("sessions");
+        std::fs::create_dir_all(&sessions).unwrap();
+        // A well-formed neighbor with hostile dirty lines (spaces,
+        // ANSI, RTL, dot-escape, a 4 KB name) — parse counts them.
+        let hostile_dirty = format!(
+            "---\nv: 1\nkind: session-declaration\nid: s-sly\nbackend: native\ncreated_ms: 1\n---\n\
+             ## intent\nlooks legit\n\n## dirty\n- src/ok.rs\n- has space.rs\n- e\u{1b}[31m.rs\n- r\u{202e}tl.rs\n- ../../etc/passwd\n- {}\n",
+            "k".repeat(4096)
+        );
+        std::fs::write(sessions.join("s-sly.md"), hostile_dirty).unwrap();
+        // A malformed neighbor and a foreign entry: named scan rejects.
+        std::fs::write(sessions.join("s-junk.md"), "not a document").unwrap();
+        std::fs::write(sessions.join("stray.txt"), "x").unwrap();
+        // Own declaration sharing the one valid path → a real ALERT.
+        let own = format!(
+            "---\nv: 1\nkind: session-declaration\nid: {OWN}\nbackend: native\ncreated_ms: 1\n---\n\
+             ## intent\nme\n\n## dirty\n- src/ok.rs\n"
+        );
+        std::fs::write(sessions.join(format!("{OWN}.md")), own).unwrap();
+
+        let now = crate::coordination::now_ms();
+        let bus = crate::coordination::radar::read_space_bus(&space_dir, now).unwrap();
+        let snapshot = compute_space_snapshot(
+            &RadarSpaceInputs {
+                space_key: SPACE,
+                declarations: &bus.declarations,
+                observed: &[],
+                messages: &bus.messages,
+                pr_files: &[],
+                scan_invalid: bus.scan_invalid,
+            },
+            now,
+        );
+        let block = render_block(&snapshot, OWN, None, 0, now).unwrap();
+        assert_schema_clean(&block.text);
+        assert!(block.has_alert, "{}", block.text);
+        assert!(block
+            .text
+            .contains("! overlap src/ok.rs — with s-sly (declared)"));
+        // 5 hostile dirty lines + 2 scan rejects (junk doc, stray file).
+        assert!(
+            block.text.contains("invalid: 7 entries ignored"),
+            "{}",
+            block.text
+        );
+        for hostile in ["has space", "\u{1b}", "\u{202e}", "passwd", "kkkk"] {
+            assert!(!block.text.contains(hostile), "{hostile:?} leaked");
+        }
+    }
+
+    /// RULED binding (R1/R6): the 1536-byte cap AT the boundary —
+    /// pre-cap renders of 1535/1536/1537 bytes prove the invariant.
+    #[test]
+    fn byte_cap_holds_at_the_boundary() {
+        // 7 fixed-length overlap paths + 1 tunable path + presence +
+        // one message line gives fine-grained control of the pre-cap
+        // size; candidates are built by the real builder.
+        let snapshot_for = |tail_len: usize| {
+            let mut s = base_snapshot();
+            s.sessions
+                .push(presence("s-other-1", Some("native"), false));
+            for i in 0..7 {
+                s.pair_overlaps.push(pair(
+                    &format!("src/{i}{}", "f".repeat(114)),
+                    OWN,
+                    "s-other-1",
+                    true,
+                    true,
+                ));
+            }
+            s.pair_overlaps.push(pair(
+                &format!("t/{}", "z".repeat(tail_len)),
+                OWN,
+                "s-other-1",
+                true,
+                true,
+            ));
+            s.messages
+                .push(message("s-other-1", "m-0123456789ab", None));
+            for (w, k) in [
+                ("s-other-2", "ac"),
+                ("s-other-2", "ad"),
+                ("s-other-3", "ae"),
+                ("s-other-3", "af"),
+            ] {
+                s.messages
+                    .push(message(w, &format!("m-0123456789{k}"), None));
+            }
+            s
+        };
+        let precap_len = |tail_len: usize| {
+            let c = build_candidates(&snapshot_for(tail_len), OWN).unwrap();
+            assert!(!c.cap_dropped, "boundary probe must not be count-capped");
+            let mut len = c.header.len();
+            for line in c
+                .sessions
+                .iter()
+                .map(String::as_str)
+                .chain(c.overlaps.iter().map(String::as_str))
+                .chain(c.messages.iter().map(String::as_str))
+                .chain(c.invalid_line.iter().map(String::as_str))
+            {
+                len += 1 + line.len();
+            }
+            len
+        };
+        let base = precap_len(1);
+        for target in [1535usize, 1536, 1537] {
+            let tail_len = 1 + (target - base);
+            assert!(
+                tail_len <= 118,
+                "probe path stays under the display bound (base={base})"
+            );
+            assert_eq!(precap_len(tail_len), target, "probe construction");
+            let block = render_block(&snapshot_for(tail_len), OWN, None, 0, 0).unwrap();
+            assert!(
+                block.text.len() <= RENDERED_BLOCK_MAX_BYTES,
+                "target {target}: rendered {} bytes",
+                block.text.len()
+            );
+            assert_schema_clean(&block.text);
+            assert!(block.has_alert, "alerts kept first under pressure");
+            if target <= RENDERED_BLOCK_MAX_BYTES {
+                assert_eq!(block.text.len(), target, "under the cap nothing is cut");
+                assert!(!block.text.contains("[truncated]"));
+            } else {
+                assert!(block.text.ends_with("\n[truncated]"));
+                assert!(
+                    block
+                        .text
+                        .lines()
+                        .filter(|l| l.starts_with("! overlap"))
+                        .count()
+                        >= 7,
+                    "ALERT lines are the last to go: {}",
+                    block.text
+                );
+            }
+        }
+    }
+
+    /// RULED binding (R6): zero-LLM determinism — same snapshot, same
+    /// bytes, every time.
+    #[test]
+    fn rendering_is_deterministic() {
+        let mut s = base_snapshot();
+        s.sessions.push(presence("s-other", Some("codex"), false));
+        s.pair_overlaps
+            .push(pair("src/a.rs", OWN, "s-other", true, true));
+        s.messages.push(message("s-other", "m-0123456789ab", None));
+        s.invalid = 3;
+        let a = render(&s).unwrap();
+        let b = render(&s).unwrap();
+        assert_eq!(a, b);
+        assert_eq!(a.text, b.text, "byte-identical");
+        assert_eq!(a.hash, super::super::fnv1a_64(a.text.as_bytes()));
+    }
+
+    /// §2.5: dedup by hash, the 30-minute reminder floor, and the
+    /// natural new-alert bypass.
+    #[test]
+    fn dedup_floor_and_alert_bypass() {
+        let mut s = base_snapshot();
+        s.sessions.push(presence("s-other", Some("native"), false));
+        let t0: u64 = 1_000_000;
+        let first = render_block(&s, OWN, None, 0, t0).expect("first render lands");
+
+        // Identical render inside the floor: suppressed.
+        assert!(render_block(&s, OWN, Some(first.hash), t0, t0 + 1_000).is_none());
+        assert!(render_block(&s, OWN, Some(first.hash), t0, t0 + REINJECT_FLOOR_MS - 1).is_none());
+        // At the floor: re-injected as a reminder, identical bytes.
+        let again = render_block(&s, OWN, Some(first.hash), t0, t0 + REINJECT_FLOOR_MS)
+            .expect("reminder floor re-injects");
+        assert_eq!(again.text, first.text);
+
+        // A NEW alert changes the hash and bypasses the floor.
+        s.pair_overlaps
+            .push(pair("src/hot.rs", OWN, "s-other", false, true));
+        let alerted = render_block(&s, OWN, Some(first.hash), t0, t0 + 1_000)
+            .expect("new alert bypasses naturally");
+        assert_ne!(alerted.hash, first.hash);
+        assert!(alerted.has_alert);
+    }
+
+    #[test]
+    fn hostile_space_key_renders_nothing() {
+        let mut s = base_snapshot();
+        s.space_key = "Weird Space!\u{1b}".to_string();
+        s.sessions.push(presence("s-other", Some("native"), false));
+        assert!(render(&s).is_none(), "nothing safe to say");
+    }
+
+    #[test]
+    fn invalid_only_block_is_ambient_signal() {
+        let mut s = base_snapshot();
+        s.invalid = 4;
+        let block = render(&s).unwrap();
+        assert_schema_clean(&block.text);
+        assert_eq!(
+            block.text,
+            format!("[System] coordination v1 space={SPACE}\ninvalid: 4 entries ignored")
+        );
+        assert!(!block.has_alert);
+    }
+
+    /// The compute → render pipeline stays deterministic end to end
+    /// under shuffled inputs (the radar sorts, the renderer preserves).
+    #[test]
+    fn pipeline_is_order_independent() {
+        let declarations = Vec::new();
+        let observed_a = [
+            ObservedSet {
+                writer_id: OWN.to_string(),
+                paths: ["src/x.rs".to_string(), "src/y.rs".to_string()]
+                    .into_iter()
+                    .collect(),
+            },
+            ObservedSet {
+                writer_id: "s-peer".to_string(),
+                paths: ["src/y.rs".to_string(), "src/x.rs".to_string()]
+                    .into_iter()
+                    .collect(),
+            },
+        ];
+        let observed_b = [observed_a[1].clone(), observed_a[0].clone()];
+        let prs = [PrFileSet {
+            number: 5,
+            paths: ["src/x.rs".to_string()].into_iter().collect(),
+        }];
+        let make = |observed: &[ObservedSet]| {
+            let snapshot = compute_space_snapshot(
+                &RadarSpaceInputs {
+                    space_key: SPACE,
+                    declarations: &declarations,
+                    observed,
+                    messages: &[],
+                    pr_files: &prs,
+                    scan_invalid: 0,
+                },
+                7,
+            );
+            render_block(&snapshot, OWN, None, 0, 7).unwrap().text
+        };
+        assert_eq!(make(&observed_a), make(&observed_b));
+    }
+}

--- a/src/bin/caller/coordination/scan.rs
+++ b/src/bin/caller/coordination/scan.rs
@@ -24,6 +24,47 @@ pub(crate) const REJECT_FOREIGN_ENTRY: &str = "foreign-entry";
 pub(crate) const REJECT_NOT_REGULAR: &str = "not-regular-file";
 pub(crate) const REJECT_FOREIGN_OWNER: &str = "foreign-owner";
 pub(crate) const REJECT_OVERSIZE_DOC: &str = "oversize-doc";
+/// C2 addition to the §1.11 vocabulary: an entry skipped unread because
+/// the pass's §1.6 whole-space read budget (512 files / 8 MiB) ran out.
+/// Counted like every other rejection — loud, never silent.
+pub(crate) const REJECT_READ_BUDGET: &str = "read-budget";
+
+/// §1.6's whole-space read budget, charged per document BEFORE it is
+/// opened (the enumeration lstat already knows the size). One budget
+/// spans a whole radar/injection pass over a space — both liveness
+/// kinds draw from the same allowance. Entries refused by the budget
+/// surface as [`REJECT_READ_BUDGET`] rejections and are never read.
+#[derive(Debug)]
+pub(crate) struct ReadBudget {
+    files: usize,
+    bytes: u64,
+}
+
+impl ReadBudget {
+    pub(crate) fn new(files: usize, bytes: u64) -> Self {
+        ReadBudget { files, bytes }
+    }
+
+    /// No-limit budget for callers outside a budgeted pass (GC, the
+    /// per-store scans) — the per-dir scan bound still applies.
+    pub(crate) fn unbounded() -> Self {
+        ReadBudget {
+            files: usize::MAX,
+            bytes: u64::MAX,
+        }
+    }
+
+    /// Charge one file of `bytes` length. `false` leaves the budget
+    /// untouched — the caller must skip the read and count the entry.
+    pub(crate) fn admit(&mut self, bytes: u64) -> bool {
+        if self.files == 0 || self.bytes < bytes {
+            return false;
+        }
+        self.files -= 1;
+        self.bytes -= bytes;
+        true
+    }
+}
 
 /// One surfaced-by-name rejection from a liveness scan.
 #[derive(Debug, Clone)]
@@ -464,6 +505,17 @@ mod tests {
         }
         let err = scan_liveness_dir(&dir).unwrap_err();
         assert!(err.to_string().contains("scan bound"), "{err}");
+    }
+
+    #[test]
+    fn read_budget_charges_files_and_bytes() {
+        let mut b = ReadBudget::new(2, 100);
+        assert!(b.admit(60));
+        assert!(!b.admit(50), "byte budget refuses without charging");
+        assert!(b.admit(40), "refused admit left the budget intact");
+        assert!(!b.admit(0), "file budget exhausted");
+        let mut unlimited = ReadBudget::unbounded();
+        assert!(unlimited.admit(u64::MAX));
     }
 
     #[test]

--- a/src/bin/caller/session_vitals.rs
+++ b/src/bin/caller/session_vitals.rs
@@ -70,13 +70,17 @@ const PROBE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
 /// network filesystem, a wedged lock) must fail its probe — feeding the
 /// existing `demote_locus` fallback — instead of freezing the sequential
 /// producer loop, and with it every session's git chip, forever.
-const GIT_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+/// `pub(crate)`: the coordination radar's observed-dirty scans run under
+/// the same ceiling.
+pub(crate) const GIT_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// Run one git subprocess under the anti-wedge guards: `kill_on_drop` so
 /// a timed-out child is reaped instead of orphaned, and `timeout` so no
 /// single invocation can stall the producer loop. `None` on spawn failure
 /// or timeout — callers treat both like the command failing.
-async fn run_git(
+/// `pub(crate)`: shared with the coordination radar (same guards, same
+/// reasons — its detection tick must survive a wedged checkout).
+pub(crate) async fn run_git(
     program: &std::ffi::OsStr,
     timeout: std::time::Duration,
     cwd: &Path,
@@ -121,11 +125,13 @@ fn git_version_at_least(version_line: &str, want_major: u32, want_minor: u32) ->
 /// on the next tick — cheap insurance against daemon-lifetime growth.
 const PROBER_CACHE_CAP: usize = 256;
 
-/// The one `git status` invocation both dirty-state surfaces run: the
-/// vitals prober (async, per-tick) and the Changes tab's working-tree
-/// lane (sync, per request) spawn exactly these arguments and feed
-/// the output to [`parse_status_v2`], so "what counts as dirty" — the
-/// chip's count and the tab's file list — is a single definition.
+/// The one `git status` invocation every dirty-state surface runs: the
+/// vitals prober (async, per-tick), the Changes tab's working-tree
+/// lane (sync, per request), and the coordination radar's observed
+/// working sets spawn exactly these arguments and feed the output to
+/// [`parse_status_v2`], so "what counts as dirty" — the chip's count,
+/// the tab's file list, and the radar's overlap domain — is a single
+/// definition.
 pub(crate) const GIT_STATUS_ARGS: [&str; 4] = [
     "--no-optional-locks",
     "status",

--- a/src/bin/caller/startup/daemon.rs
+++ b/src/bin/caller/startup/daemon.rs
@@ -158,6 +158,12 @@ pub(crate) async fn run_daemon(
     // effective target the dirty chip probes (activity locus included),
     // so the chip and the tab can never state different checkouts.
     session_vitals::publish_git_vitals_targets(&vitals_git_targets);
+    // Collision radar (Track C, C2 — ruled §2.1): periodic zero-LLM
+    // detection over bus declarations ∪ observed git status (the same
+    // registry the vitals prober probes) ∪ open-PR file sets; publishes
+    // per-space snapshots for the injection seam and writes deduplicated
+    // radar notes to flagged parties.
+    let _radar_task = crate::coordination::radar::spawn_radar_task(vitals_git_targets.clone());
     // Restored sessions: a restart empties the target registry, so idle
     // session windows lose their git/health chips until the next resume.
     // One bounded walk (newest-first, insert-if-absent — see


### PR DESCRIPTION
First C2 slice (C1 = #560/#563/#566, steward-PASSED). The collision radar's detection and rendering halves, per the ruled protocol §2 — no per-session injection wiring yet (that lands next, stacked).

- **Detection** (`coordination/radar.rs`, zero-LLM binding): per-space snapshots from declared sets (bus scan under the §1.6 whole-space budget), observed dirty sets (reusing the session_vitals prober machinery over the published GitVitalsTargets roots), and open-PR file sets (`gh` cached ≥5 min, silent degrade). §2.7 severity: ALERT = cross-session dirty∩dirty or dirty∩PR-files. Periodic daemon task publishes per-space state (vitals-registry precedent); spawned at daemon startup.
- **Renderer** (`coordination/render.rs`, pure): the fixed §2.2 line schema — header, presence with 8-char id prefixes, `!`-marked overlap lines, existence-only message lines, `invalid:` counts, `[truncated]`. §2.3 per-type validators (failures count, never render), §2.4 caps with the **1536-byte hard wall + boundary unit test** (R6 binding), §2.5 dedup-by-hash + 30-min reminder floor, §2.7 own-session exclusion and no-signal ⇒ no block.
- **Radar notes**: privileged `write_radar_note` daemon lane (public `write()` still refuses the reserved writer) — fixed template, validated tokens only, per-recipient 10-min cooldown + per-overlap-set dedup.
- **§1.6 read budget**: new `ReadBudget` (512 files / 8 MiB per pass) with the additive `read-budget` rejection token — the whole-space budget's first consumer.
- **Binding tests** (R6): byte-cap boundary, adversarial rendered-block fixtures (spaces/ANSI/newlines/RTL/4KB names → counts, zero out-of-grammar bytes), zero-LLM determinism, dedup/floor, severity table. 76 coordination tests total.

Battery: fmt --check, clippy workspace -D warnings, full bins (4799), lib crates, headless e2e (31) — all green.

Next (stacked): native seam injection, external ALERT steers, `coordination_radar` attention kind, byte-identical-prefix e2e.