### PR TITLE
Track C C2: delivery lanes — native seam injection, ALERT steers, radar attention kind, prefix e2e

### DIFF
--- a/src/bin/caller/agent_loop.rs
+++ b/src/bin/caller/agent_loop.rs
@@ -1125,6 +1125,10 @@ pub(crate) async fn run_agent_loop(
     // round loop): each turn boundary is a heartbeat tick (§1.5 cadence —
     // throttled internally, no timers here).
     coordination_declaration: Option<&coordination::lifecycle::SessionDeclarationGuard>,
+    // The radar injection seam's per-session state (§2.1/§2.5), owned by
+    // the round loop so dedup survives round boundaries. `None` when the
+    // session has no id (no bus identity → no space to consult).
+    mut radar_seam: Option<&mut CoordinationRadarSeam>,
 ) -> Result<(LoopStats, LoopExitReason), CallerError> {
     let mut budget_warning_shown = false;
     let mut empty_command_streak = 0usize;
@@ -1391,6 +1395,16 @@ pub(crate) async fn run_agent_loop(
                     });
                 }
             }
+        }
+
+        // Coordination radar (Track C §2.1, R6): the FRESH-READ sibling
+        // consult at the same seam — each turn reads the published radar
+        // state and appends at most one `[System] coordination v1` block
+        // as a tail user message (same provenance, same logging shape as
+        // the drain above). Fresh-read, not queued: the task-start purge
+        // above can never drop it, and dedup (§2.5) self-paces it.
+        if let Some(seam) = radar_seam.as_deref_mut() {
+            inject_coordination_radar_block(seam, conversation, &session_log);
         }
 
         // Turn boundary = the native declaration's heartbeat tick
@@ -3491,28 +3505,26 @@ fn native_session_intent(conversation: &Conversation) -> String {
 /// Coordination-bus declaration for a native supervised session (Track C
 /// §1.5): written at session start, heartbeat at turn boundaries, removed
 /// by the guard's Drop on any orderly loop exit — a crash-abandoned copy
-/// ages out by TTL. Space resolution follows the B1 seam (env override →
-/// derived worktree-normalized key), so a sub-agent session in an
-/// isolated worktree lands in its main repo's space. Advisory: bus
-/// trouble logs and the session runs undeclared; a session without an id
-/// has no writer identity and declares nothing.
+/// ages out by TTL. The space arrives resolved (the B1 seam: env override
+/// → derived worktree-normalized key — `run_round_loop` resolves once and
+/// shares it with the radar seam), so a sub-agent session in an isolated
+/// worktree lands in its main repo's space. Advisory: bus trouble logs
+/// and the session runs undeclared; a session without an id has no
+/// writer identity and declares nothing.
 fn declare_native_session_on_bus(
     local_session_id: &Option<String>,
+    space_dir: &std::path::Path,
+    space_key: &str,
     project: &Project,
     conversation: &Conversation,
     session_log: &SharedSessionLog,
 ) -> Option<coordination::lifecycle::SessionDeclarationGuard> {
     let session_id = local_session_id.as_deref()?;
-    let (space_dir, space_key) = coordination::paths::resolve_space_dir(
-        coordination::paths::env_override().as_deref(),
-        &crate::platform::intendant_home(),
-        &project.root,
-    );
     let intent = native_session_intent(conversation);
     match coordination::lifecycle::SessionDeclarationGuard::declare(
         coordination::lifecycle::DeclareParams {
-            space_dir: &space_dir,
-            space_key: &space_key,
+            space_dir,
+            space_key,
             session_id,
             backend: "native",
             project_root: &project.root,
@@ -3529,6 +3541,83 @@ fn declare_native_session_on_bus(
             None
         }
     }
+}
+
+/// Per-session state for the coordination-radar injection seam (Track C
+/// §2.1, R6): the session's resolved space + bus writer identity plus
+/// the §2.5 dedup pair (hash of the last block injected, when it was).
+/// Owned by the round loop and threaded into `run_agent_loop` like the
+/// loop's other per-session state — dedup and the 30-minute reminder
+/// floor are per SESSION, so this must survive round boundaries (a
+/// per-round reset would re-inject an unchanged block at every
+/// follow-up).
+pub(crate) struct CoordinationRadarSeam {
+    space_key: String,
+    writer_id: String,
+    last_hash: Option<u64>,
+    last_injected_ms: u64,
+}
+
+impl CoordinationRadarSeam {
+    fn new(session_id: &str, space_key: String) -> Self {
+        CoordinationRadarSeam {
+            space_key,
+            writer_id: coordination::lifecycle::writer_id_for_session(session_id),
+            last_hash: None,
+            last_injected_ms: 0,
+        }
+    }
+}
+
+/// The §2.1 FRESH-READ consult, one call per turn at the injection seam:
+/// read the daemon-published radar state for this session's space and,
+/// when the ruled renderer has something new to say, append exactly ONE
+/// `[System] coordination v1` block as a tail user message with
+/// `SystemInjection` provenance — the same `add_user` path the drain
+/// above uses, so every prefix-cache proof of §2.6 holds (no earlier
+/// message is touched; quiet turns append nothing). Degrades to a
+/// silent no-op wherever no daemon published radar state (direct /
+/// headless shapes — ruled). §2.9: the block also logs the steer-shaped
+/// `conversation_message_user` record so replay and acceptance can
+/// assert the schema in the turn record.
+fn inject_coordination_radar_block(
+    seam: &mut CoordinationRadarSeam,
+    conversation: &mut Conversation,
+    session_log: &SharedSessionLog,
+) {
+    let Some(state) = coordination::radar::published_radar_state() else {
+        return;
+    };
+    let Some(snapshot) = state.space(&seam.space_key) else {
+        return;
+    };
+    let now_ms = coordination::now_ms();
+    let Some(block) = coordination::render::render_block(
+        &snapshot,
+        &seam.writer_id,
+        seam.last_hash,
+        seam.last_injected_ms,
+        now_ms,
+    ) else {
+        return;
+    };
+    let seq = conversation.add_user(MessageProvenance::SystemInjection, block.text.clone());
+    slog(session_log, |l| {
+        let _ = l.conversation_message_user(
+            seq,
+            MessageProvenance::SystemInjection,
+            &block.text,
+            None,
+            &[],
+        );
+        l.info(&format!(
+            "Coordination radar block injected ({} bytes{})",
+            block.text.len(),
+            if block.has_alert { ", ALERT" } else { "" }
+        ));
+    });
+    seam.last_hash = Some(block.hash);
+    seam.last_injected_ms = now_ms;
 }
 
 /// Wraps `run_agent_loop` in a multi-round loop that waits for follow-up messages
@@ -3573,9 +3662,32 @@ pub(crate) async fn run_round_loop(
     let mut delivered_steer_ids: HashSet<String> = HashSet::new();
     // This loop IS the native session: declare on the coordination bus
     // for its whole span (all rounds + parked waits); the guard's Drop
-    // removes the declaration on any orderly exit.
-    let coordination_declaration =
-        declare_native_session_on_bus(&local_session_id, project, conversation, &session_log);
+    // removes the declaration on any orderly exit. The space resolution
+    // (B1 seam) happens once here and feeds both the declaration and the
+    // radar injection seam's per-session state.
+    let coordination_space = local_session_id.as_ref().map(|_| {
+        coordination::paths::resolve_space_dir(
+            coordination::paths::env_override().as_deref(),
+            &crate::platform::intendant_home(),
+            &project.root,
+        )
+    });
+    let coordination_declaration = coordination_space.as_ref().and_then(|(space_dir, space_key)| {
+        declare_native_session_on_bus(
+            &local_session_id,
+            space_dir,
+            space_key,
+            project,
+            conversation,
+            &session_log,
+        )
+    });
+    let mut radar_seam = match (&local_session_id, &coordination_space) {
+        (Some(session_id), Some((_, space_key))) => {
+            Some(CoordinationRadarSeam::new(session_id, space_key.clone()))
+        }
+        _ => None,
+    };
 
     loop {
         let (stats, exit_reason) = run_agent_loop(
@@ -3598,6 +3710,7 @@ pub(crate) async fn run_round_loop(
             orchestration,
             runtime_mcp_env,
             coordination_declaration.as_ref(),
+            radar_seam.as_mut(),
         )
         .await?;
 

--- a/src/bin/caller/agent_loop.rs
+++ b/src/bin/caller/agent_loop.rs
@@ -4910,7 +4910,9 @@ mod provenance_parity {
         let add_user = concat!(".add_", "user(");
         let add_user_with_images = concat!(".add_", "user_with_images(");
         for (file, users, with_images) in [
-            ("agent_loop.rs", 9usize, 2usize),
+            // agent_loop's 10th site is the coordination radar block
+            // (§2.1 seam, SystemInjection — consciously added, C2).
+            ("agent_loop.rs", 10usize, 2usize),
             ("main.rs", 16, 1),
             ("run_modes.rs", 4, 3),
             ("display_glue.rs", 1, 2),

--- a/src/bin/caller/agent_loop.rs
+++ b/src/bin/caller/agent_loop.rs
@@ -3672,16 +3672,19 @@ pub(crate) async fn run_round_loop(
             &project.root,
         )
     });
-    let coordination_declaration = coordination_space.as_ref().and_then(|(space_dir, space_key)| {
-        declare_native_session_on_bus(
-            &local_session_id,
-            space_dir,
-            space_key,
-            project,
-            conversation,
-            &session_log,
-        )
-    });
+    let coordination_declaration =
+        coordination_space
+            .as_ref()
+            .and_then(|(space_dir, space_key)| {
+                declare_native_session_on_bus(
+                    &local_session_id,
+                    space_dir,
+                    space_key,
+                    project,
+                    conversation,
+                    &session_log,
+                )
+            });
     let mut radar_seam = match (&local_session_id, &coordination_space) {
         (Some(session_id), Some((_, space_key))) => {
             Some(CoordinationRadarSeam::new(session_id, space_key.clone()))

--- a/src/bin/caller/coordination/radar.rs
+++ b/src/bin/caller/coordination/radar.rs
@@ -1499,8 +1499,7 @@ mod tests {
         // A space move mid-raise resolves the old id before raising the
         // new one, so raise/resolve always pair by id.
         tracker.observe_tick(&obs(true));
-        let moved =
-            tracker.observe_tick(&[("sess-1".to_string(), "space-b".to_string(), true)]);
+        let moved = tracker.observe_tick(&[("sess-1".to_string(), "space-b".to_string(), true)]);
         assert_eq!(
             moved
                 .iter()
@@ -1518,7 +1517,10 @@ mod tests {
         let ledger = ExternalSteerLedger::default();
         let t0: u64 = 1_000_000;
         assert!(ledger.admit("sess-1", 11, t0), "first set admits");
-        assert!(!ledger.admit("sess-1", 11, t0 + 1), "same set never repeats");
+        assert!(
+            !ledger.admit("sess-1", 11, t0 + 1),
+            "same set never repeats"
+        );
         assert!(
             !ledger.admit("sess-1", 22, t0 + 1),
             "different set cools down"
@@ -1598,7 +1600,10 @@ mod tests {
                 Err(e) => panic!("no CoordinationRadar after the alerting tick: {e:?}"),
             }
         };
-        assert_eq!(raised, ("sess-radar-a".to_string(), key.clone(), State::Raised));
+        assert_eq!(
+            raised,
+            ("sess-radar-a".to_string(), key.clone(), State::Raised)
+        );
         // The same tick published the snapshot the delivery lanes read.
         assert!(task.state.space_with_alerts_for(&writer).is_some());
 

--- a/src/bin/caller/coordination/radar.rs
+++ b/src/bin/caller/coordination/radar.rs
@@ -423,7 +423,6 @@ impl RadarState {
 
     /// One space's latest snapshot — the injection seam's read
     /// (`render::render_block` consumes it per session).
-    #[cfg_attr(not(test), allow(dead_code))] // consumed by the C2 injection wiring (PR E)
     pub(crate) fn space(&self, space_key: &str) -> Option<Arc<SpaceRadarSnapshot>> {
         self.spaces
             .read()
@@ -431,6 +430,197 @@ impl RadarState {
             .get(space_key)
             .cloned()
     }
+
+    /// Delivery-lane read (§2.8): the snapshot of the space whose ALERT
+    /// overlaps name this writer. A session lives in exactly one space,
+    /// so the first hit wins (iteration over the handful of live
+    /// spaces); `None` means nothing is alerting on this writer
+    /// anywhere — the external steer lane's cheap no-op.
+    pub(crate) fn space_with_alerts_for(&self, writer_id: &str) -> Option<Arc<SpaceRadarSnapshot>> {
+        self.spaces
+            .read()
+            .expect("radar state lock")
+            .values()
+            .find(|snapshot| session_has_alerts(snapshot, writer_id))
+            .cloned()
+    }
+}
+
+/// Whether any ALERT overlap in the snapshot names this writer — the
+/// raise/resolve predicate for the §2.8 rail-badge flag and the
+/// external lane's "anything to say at all" gate. Ambient content
+/// (presence, messages, invalid counts) is invisible here by
+/// construction.
+pub(crate) fn session_has_alerts(snapshot: &SpaceRadarSnapshot, writer_id: &str) -> bool {
+    snapshot
+        .pair_overlaps
+        .iter()
+        .any(|o| o.a == writer_id || o.b == writer_id)
+        || snapshot.pr_overlaps.iter().any(|o| o.writer == writer_id)
+}
+
+/// One §2.8 rail-badge transition to broadcast as
+/// [`crate::event::AppEvent::CoordinationRadar`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RadarFlagTransition {
+    pub session_id: String,
+    /// The flag's stable identity: the session's space key at raise
+    /// time, so a resolve always retracts the raise it pairs with.
+    pub id: String,
+    pub state: crate::types::CoordinationRadarState,
+}
+
+/// Raise/resolve bookkeeping for the §2.8 rail badge: one retractable
+/// flag per supervised session, raised while any ALERT overlap names
+/// the session, resolved when none does — including when the session
+/// disappears from the tick (ended, registry pruned, space GC'd), so a
+/// gone session can never hold a raised flag. A pure state machine the
+/// task feeds full-tick observations; it returns the transitions to
+/// broadcast (raise once, resolve once — no re-raise chatter while a
+/// flag stays up).
+#[derive(Default)]
+pub(crate) struct RadarFlagTracker {
+    /// session id → flag id of the outstanding raise.
+    raised: HashMap<String, String>,
+}
+
+impl RadarFlagTracker {
+    /// Fold one tick's complete observation set — every supervised
+    /// session the radar saw, with its space key and whether that
+    /// space's snapshot names it in an ALERT — and return the
+    /// transitions. A session moving spaces mid-raise resolves the old
+    /// flag before raising the new one (ids must pair exactly).
+    pub(crate) fn observe_tick(
+        &mut self,
+        observed: &[(String, String, bool)],
+    ) -> Vec<RadarFlagTransition> {
+        use crate::types::CoordinationRadarState as State;
+        let mut transitions = Vec::new();
+        let mut seen: HashSet<&str> = HashSet::new();
+        for (session_id, space_key, alerted) in observed {
+            seen.insert(session_id.as_str());
+            let outstanding = self.raised.get(session_id).cloned();
+            match (outstanding, alerted) {
+                (None, true) => {
+                    self.raised.insert(session_id.clone(), space_key.clone());
+                    transitions.push(RadarFlagTransition {
+                        session_id: session_id.clone(),
+                        id: space_key.clone(),
+                        state: State::Raised,
+                    });
+                }
+                (Some(id), false) => {
+                    self.raised.remove(session_id);
+                    transitions.push(RadarFlagTransition {
+                        session_id: session_id.clone(),
+                        id,
+                        state: State::Resolved,
+                    });
+                }
+                (Some(id), true) if id != *space_key => {
+                    self.raised.insert(session_id.clone(), space_key.clone());
+                    transitions.push(RadarFlagTransition {
+                        session_id: session_id.clone(),
+                        id,
+                        state: State::Resolved,
+                    });
+                    transitions.push(RadarFlagTransition {
+                        session_id: session_id.clone(),
+                        id: space_key.clone(),
+                        state: State::Raised,
+                    });
+                }
+                _ => {}
+            }
+        }
+        // Sessions that vanished from the tick resolve, in stable order.
+        let mut gone: Vec<(String, String)> = self
+            .raised
+            .iter()
+            .filter(|(session_id, _)| !seen.contains(session_id.as_str()))
+            .map(|(session_id, id)| (session_id.clone(), id.clone()))
+            .collect();
+        gone.sort();
+        for (session_id, id) in gone {
+            self.raised.remove(&session_id);
+            transitions.push(RadarFlagTransition {
+                session_id,
+                id,
+                state: State::Resolved,
+            });
+        }
+        transitions
+    }
+}
+
+/// §2.8: the external ALERT steer lane's cooldown window — at most one
+/// steer per recipient session per window, regardless of overlap set.
+pub(crate) const EXTERNAL_STEER_COOLDOWN_MS: u64 = 10 * 60 * 1000;
+/// Delivered-set entries kept per session / sessions kept in the ledger
+/// before the cheap clear (the radar task's own cache-cap shape). A
+/// clear's worst case is one repeat steer per pair, still cooldown-paced.
+const STEER_LEDGER_MAX_SETS: usize = 256;
+const STEER_LEDGER_MAX_SESSIONS: usize = 512;
+
+#[derive(Default)]
+struct SessionSteerLedger {
+    last_steer_ms: u64,
+    delivered_sets: HashSet<u64>,
+}
+
+/// Spam discipline for the external ALERT steer lane (§2.8), mirroring
+/// the radar-note lane's two layers (`messages::write_radar_note`):
+/// one steer per **distinct overlap set** per session pair —
+/// `set_hash` is the steer's canonical set identity from
+/// [`super::render::render_alert_steers`] — plus at most one steer per
+/// recipient session per [`EXTERNAL_STEER_COOLDOWN_MS`] regardless of
+/// set. A cooldown-suppressed set stays unrecorded, so the periodic
+/// consult retries it once the window clears (the note lane's
+/// tick-retry shape — deferred, not dropped). Daemon-side state beside
+/// the radar task's published snapshots (the ruled altitude); ambient
+/// content never reaches this ledger because only ALERT steers carry a
+/// set hash at all.
+#[derive(Default)]
+pub(crate) struct ExternalSteerLedger {
+    sessions: std::sync::Mutex<HashMap<String, SessionSteerLedger>>,
+}
+
+impl ExternalSteerLedger {
+    /// True ADMITS the steer now and records it (set marked delivered,
+    /// cooldown restarted) — the caller must then deliver it, mid-turn
+    /// via `steer_turn` or queued as the between-turns
+    /// `ContextInjection` fallback. False: this exact set was already
+    /// delivered, or the session's cooldown is still running.
+    pub(crate) fn admit(&self, session_id: &str, set_hash: u64, now_ms: u64) -> bool {
+        let mut sessions = self.sessions.lock().expect("steer ledger lock");
+        if sessions.len() >= STEER_LEDGER_MAX_SESSIONS && !sessions.contains_key(session_id) {
+            sessions.clear();
+        }
+        let entry = sessions.entry(session_id.to_string()).or_default();
+        if entry.delivered_sets.contains(&set_hash) {
+            return false;
+        }
+        if entry.last_steer_ms != 0
+            && now_ms.saturating_sub(entry.last_steer_ms) < EXTERNAL_STEER_COOLDOWN_MS
+        {
+            return false; // cooling down; the set stays unrecorded and retries later
+        }
+        if entry.delivered_sets.len() >= STEER_LEDGER_MAX_SETS {
+            entry.delivered_sets.clear();
+        }
+        entry.delivered_sets.insert(set_hash);
+        entry.last_steer_ms = now_ms;
+        true
+    }
+}
+
+/// The daemon's steer-cooldown ledger (process-wide like the published
+/// radar state: both external drain halves — mid-turn and idle — must
+/// share one view of what was already delivered).
+static EXTERNAL_STEER_LEDGER: OnceLock<ExternalSteerLedger> = OnceLock::new();
+
+pub(crate) fn external_steer_ledger() -> &'static ExternalSteerLedger {
+    EXTERNAL_STEER_LEDGER.get_or_init(ExternalSteerLedger::default)
 }
 
 /// The daemon's live radar state, published once at startup. Tests
@@ -442,8 +632,10 @@ pub(crate) fn publish_radar_state(state: &RadarState) {
 }
 
 /// The published state, when a daemon startup path wired one — where
-/// the injection seam (PR E) reads each session's space snapshot from.
-#[cfg_attr(not(test), allow(dead_code))] // consumed by the C2 injection wiring (PR E)
+/// the native injection seam reads each session's space snapshot from
+/// (`agent_loop`), and the external ALERT steer lane its alert view
+/// (`external_supervision`). `None` in every non-daemon shape, which is
+/// exactly the ruled degrade-to-no-op.
 pub(crate) fn published_radar_state() -> Option<&'static RadarState> {
     PUBLISHED_RADAR_STATE.get()
 }
@@ -573,6 +765,10 @@ struct RadarTask {
     coordination_root: PathBuf,
     state: RadarState,
     targets: GitVitalsTargets,
+    /// The daemon event bus, for the §2.8 rail-badge transitions
+    /// ([`RadarFlagTracker`] → `AppEvent::CoordinationRadar`).
+    bus: crate::event::EventBus,
+    flags: RadarFlagTracker,
     git_program: std::ffi::OsString,
     /// `gh` participation — disabled only in tests via [`RadarTask`]
     /// construction (unit tests never spawn the task at all).
@@ -681,13 +877,17 @@ impl RadarTask {
         let now_ms = super::now_ms();
         // Registry members grouped by space: every supervised session
         // participates in git-scan detection, declared or not (§2.8).
-        let mut members_by_space: BTreeMap<String, Vec<(String, PathBuf)>> = BTreeMap::new();
+        // Session ids ride along for the rail-badge flags — the bus
+        // works in writer ids, the dashboard in session ids.
+        let mut members_by_space: BTreeMap<String, Vec<(String, String, PathBuf)>> =
+            BTreeMap::new();
         for (session_id, root) in self.targets.snapshot() {
             let key = self.space_key_for(&root);
+            let writer_id = writer_id_for_session(&session_id);
             members_by_space
                 .entry(key)
                 .or_default()
-                .push((writer_id_for_session(&session_id), root));
+                .push((session_id, writer_id, root));
         }
         for members in members_by_space.values_mut() {
             members.sort();
@@ -697,24 +897,40 @@ impl RadarTask {
         keys.extend(self.disk_spaces());
 
         let mut live: HashSet<String> = HashSet::new();
+        // (session id, space key, alerted) per supervised session — the
+        // full-tick observation set the flag tracker folds at the end.
+        let mut flag_observations: Vec<(String, String, bool)> = Vec::new();
         for key in keys {
             let space_dir = self.coordination_root.join(&key);
+            let members = members_by_space.remove(&key).unwrap_or_default();
             let bus = match read_space_bus(&space_dir, now_ms) {
                 Ok(bus) => bus,
                 Err(e) => {
                     // Corruption-grade trouble: keep the last snapshot
                     // (don't blind consumers on a transient) and log on
-                    // change.
+                    // change. Flags follow the retained view for the
+                    // same reason — a transient must not flap them.
                     self.note_trouble(format!("{key}/bus"), Some(e.to_string()));
+                    let retained = self.state.space(&key);
+                    for (session_id, writer_id, _) in &members {
+                        let alerted = retained
+                            .as_deref()
+                            .is_some_and(|s| session_has_alerts(s, writer_id));
+                        flag_observations.push((session_id.clone(), key.clone(), alerted));
+                    }
                     live.insert(key);
                     continue;
                 }
             };
             self.note_trouble(format!("{key}/bus"), None);
-            let members = members_by_space.remove(&key).unwrap_or_default();
-            let roots: Vec<PathBuf> = members.iter().map(|(_, root)| root.clone()).collect();
+            let roots: Vec<PathBuf> = members.iter().map(|(_, _, root)| root.clone()).collect();
+            let writer_members: Vec<(String, PathBuf)> = members
+                .iter()
+                .map(|(_, writer_id, root)| (writer_id.clone(), root.clone()))
+                .collect();
             let observed =
-                collect_observed(&self.git_program, &members, &mut self.toplevel_cache).await;
+                collect_observed(&self.git_program, &writer_members, &mut self.toplevel_cache)
+                    .await;
             let pr_sets = self.pr_sets(&key, &roots, now_ms).await;
             let snapshot = compute_space_snapshot(
                 &RadarSpaceInputs {
@@ -732,24 +948,46 @@ impl RadarTask {
                 format!("{key}/notes"),
                 (!note_errors.is_empty()).then(|| note_errors.join("; ")),
             );
+            for (session_id, writer_id, _) in &members {
+                flag_observations.push((
+                    session_id.clone(),
+                    key.clone(),
+                    session_has_alerts(&snapshot, writer_id),
+                ));
+            }
             self.state.publish_space(snapshot);
             live.insert(key);
         }
         self.state.retain_spaces(&live);
+        // Rail-badge transitions (§2.8, R8) — after the publishes, so a
+        // consumer woken by a raise reads the fresh snapshots.
+        for transition in self.flags.observe_tick(&flag_observations) {
+            self.bus.send(crate::event::AppEvent::CoordinationRadar {
+                session_id: transition.session_id,
+                id: transition.id,
+                state: transition.state,
+            });
+        }
     }
 }
 
 /// Spawn the periodic radar task (daemon startup). Resolves the real
 /// coordination root at this edge — everything below takes explicit
 /// paths — publishes the state handle for the read side, and ticks
-/// forever on [`RADAR_TICK`].
-pub(crate) fn spawn_radar_task(targets: GitVitalsTargets) -> tokio::task::JoinHandle<()> {
+/// forever on [`RADAR_TICK`]. `bus` carries the §2.8 rail-badge
+/// transitions to the normal outbound broadcaster path.
+pub(crate) fn spawn_radar_task(
+    targets: GitVitalsTargets,
+    bus: crate::event::EventBus,
+) -> tokio::task::JoinHandle<()> {
     let state = RadarState::default();
     publish_radar_state(&state);
     let mut task = RadarTask {
         coordination_root: super::paths::coordination_root(&crate::platform::intendant_home()),
         state,
         targets,
+        bus,
+        flags: RadarFlagTracker::default(),
         git_program: "git".into(),
         gh_enabled: true,
         space_key_cache: HashMap::new(),
@@ -1181,5 +1419,209 @@ mod tests {
         assert!(state.space("alpha-1").is_none());
         assert!(state.space("beta-2").is_some());
         assert!(state.space("never").is_none());
+    }
+
+    #[test]
+    fn space_with_alerts_finds_only_alerting_writers() {
+        let state = RadarState::default();
+        let mut s = SpaceRadarSnapshot {
+            space_key: "gamma-3".into(),
+            ..Default::default()
+        };
+        s.sessions.push(RadarSessionPresence {
+            writer_id: "s-ambient".into(),
+            backend: None,
+            stale: false,
+        });
+        s.pair_overlaps.push(RadarPairOverlap {
+            path: "src/x.rs".into(),
+            a: "s-hot".into(),
+            b: "s-warm".into(),
+            declared: true,
+            git: false,
+        });
+        s.pr_overlaps.push(RadarPrOverlap {
+            path: "docs/y.md".into(),
+            writer: "s-pr".into(),
+            pr: 4,
+        });
+        state.publish_space(s);
+        for alerted in ["s-hot", "s-warm", "s-pr"] {
+            assert!(
+                state.space_with_alerts_for(alerted).is_some(),
+                "{alerted} alerts"
+            );
+        }
+        // Present but ambient-only, or absent entirely: no alert view —
+        // the external lane sees nothing to say.
+        assert!(state.space_with_alerts_for("s-ambient").is_none());
+        assert!(state.space_with_alerts_for("s-elsewhere").is_none());
+    }
+
+    /// RULED (R8): the rail-badge flag raises once while ALERTs name a
+    /// session, retracts when they clear, retracts when the session
+    /// disappears, and re-pairs correctly across a space move.
+    #[test]
+    fn flag_tracker_raises_and_resolves_per_session() {
+        use crate::types::CoordinationRadarState as State;
+        let mut tracker = RadarFlagTracker::default();
+        let obs = |alerted: bool| vec![("sess-1".to_string(), "space-a".to_string(), alerted)];
+
+        assert!(tracker.observe_tick(&obs(false)).is_empty(), "quiet start");
+        let raised = tracker.observe_tick(&obs(true));
+        assert_eq!(raised.len(), 1);
+        assert_eq!(
+            (
+                raised[0].session_id.as_str(),
+                raised[0].id.as_str(),
+                raised[0].state
+            ),
+            ("sess-1", "space-a", State::Raised)
+        );
+        // Still alerting: NO re-raise chatter.
+        assert!(tracker.observe_tick(&obs(true)).is_empty());
+        // Cleared: exactly one resolve, same flag id.
+        let resolved = tracker.observe_tick(&obs(false));
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(
+            (resolved[0].id.as_str(), resolved[0].state),
+            ("space-a", State::Resolved)
+        );
+        assert!(tracker.observe_tick(&obs(false)).is_empty(), "no double");
+
+        // Raise again, then the session VANISHES from the tick — the
+        // sweep retracts (a gone session never holds a raised flag).
+        tracker.observe_tick(&obs(true));
+        let swept = tracker.observe_tick(&[]);
+        assert_eq!(swept.len(), 1);
+        assert_eq!(swept[0].state, State::Resolved);
+
+        // A space move mid-raise resolves the old id before raising the
+        // new one, so raise/resolve always pair by id.
+        tracker.observe_tick(&obs(true));
+        let moved =
+            tracker.observe_tick(&[("sess-1".to_string(), "space-b".to_string(), true)]);
+        assert_eq!(
+            moved
+                .iter()
+                .map(|t| (t.id.as_str(), t.state))
+                .collect::<Vec<_>>(),
+            vec![("space-a", State::Resolved), ("space-b", State::Raised)]
+        );
+    }
+
+    /// §2.8 spam discipline for the external steer lane: one steer per
+    /// distinct set, a 10-minute per-session cooldown that DEFERS (not
+    /// drops) newer sets, and per-session isolation.
+    #[test]
+    fn external_steer_ledger_dedups_and_cools_down() {
+        let ledger = ExternalSteerLedger::default();
+        let t0: u64 = 1_000_000;
+        assert!(ledger.admit("sess-1", 11, t0), "first set admits");
+        assert!(!ledger.admit("sess-1", 11, t0 + 1), "same set never repeats");
+        assert!(
+            !ledger.admit("sess-1", 22, t0 + 1),
+            "different set cools down"
+        );
+        assert!(
+            !ledger.admit("sess-1", 22, t0 + EXTERNAL_STEER_COOLDOWN_MS - 1),
+            "still cooling"
+        );
+        assert!(
+            ledger.admit("sess-1", 22, t0 + EXTERNAL_STEER_COOLDOWN_MS),
+            "deferred set admits once the window clears"
+        );
+        assert!(
+            !ledger.admit("sess-1", 11, t0 + 10 * EXTERNAL_STEER_COOLDOWN_MS),
+            "delivered sets stay delivered across windows"
+        );
+        // Sessions are independent.
+        assert!(ledger.admit("sess-2", 11, t0));
+    }
+
+    /// The real task tick end to end (hermetic paths, no gh): a bus
+    /// overlap raises the session's flag on the daemon bus; removing
+    /// the neighbor's declaration resolves it. This is the Rust-side
+    /// emission proof for the retractable `radar` attention kind.
+    #[tokio::test]
+    async fn radar_task_tick_emits_raise_then_resolve_on_the_bus() {
+        use crate::types::CoordinationRadarState as State;
+        let tmp = tempfile::tempdir().unwrap();
+        let coordination_root = tmp.path().join("coordination");
+        let proj = tmp.path().join("proj");
+        std::fs::create_dir_all(&proj).unwrap();
+        let key = crate::coordination::space_key(&proj);
+        let space_dir = coordination_root.join(&key);
+        let writer = writer_id_for_session("sess-radar-a");
+        let ds = DeclarationSpace::open(&space_dir, &key).unwrap();
+        let dirty = ["src/hot.rs".to_string()];
+        for id in [writer.as_str(), "s-nbr"] {
+            ds.write_own(&DeclarationInput {
+                id,
+                session: None,
+                backend: Some("native"),
+                root: None,
+                branch: None,
+                intent: "overlap fixture",
+                dirty: &dirty,
+            })
+            .unwrap();
+        }
+
+        let targets = GitVitalsTargets::default();
+        targets.register("sess-radar-a", proj.clone());
+        let bus = crate::event::EventBus::new();
+        let mut bus_rx = bus.subscribe();
+        let mut task = RadarTask {
+            coordination_root,
+            state: RadarState::default(),
+            targets,
+            bus,
+            flags: RadarFlagTracker::default(),
+            git_program: "git".into(),
+            gh_enabled: false,
+            space_key_cache: HashMap::new(),
+            toplevel_cache: HashMap::new(),
+            pr_cache: HashMap::new(),
+            last_trouble: HashMap::new(),
+        };
+
+        task.tick().await;
+        let raised = loop {
+            match bus_rx.try_recv() {
+                Ok(crate::event::AppEvent::CoordinationRadar {
+                    session_id,
+                    id,
+                    state,
+                }) => break (session_id, id, state),
+                Ok(_) => continue,
+                Err(e) => panic!("no CoordinationRadar after the alerting tick: {e:?}"),
+            }
+        };
+        assert_eq!(raised, ("sess-radar-a".to_string(), key.clone(), State::Raised));
+        // The same tick published the snapshot the delivery lanes read.
+        assert!(task.state.space_with_alerts_for(&writer).is_some());
+
+        // Quiet ticks: no chatter.
+        task.tick().await;
+        // Neighbor leaves; the overlap clears; the flag retracts.
+        std::fs::remove_file(space_dir.join("sessions/s-nbr.md")).unwrap();
+        task.tick().await;
+        let mut transitions = Vec::new();
+        while let Ok(event) = bus_rx.try_recv() {
+            if let crate::event::AppEvent::CoordinationRadar {
+                session_id,
+                id,
+                state,
+            } = event
+            {
+                transitions.push((session_id, id, state));
+            }
+        }
+        assert_eq!(
+            transitions,
+            vec![("sess-radar-a".to_string(), key, State::Resolved)],
+            "exactly one retraction, nothing between"
+        );
     }
 }

--- a/src/bin/caller/coordination/render.rs
+++ b/src/bin/caller/coordination/render.rs
@@ -1163,7 +1163,8 @@ mod tests {
     #[test]
     fn steer_lines_group_sets_per_pair_and_pr() {
         let mut s = base_snapshot();
-        s.sessions.push(presence("s-other-one", Some("codex"), false));
+        s.sessions
+            .push(presence("s-other-one", Some("codex"), false));
         s.messages.push(message("s-peer", "m-0123456789ab", None));
         s.pair_overlaps
             .push(pair("src/b.rs", OWN, "s-other-one", true, false));
@@ -1186,7 +1187,9 @@ mod tests {
         );
         assert_eq!(
             steers[1].text,
-            format!("[System] coordination v1 space={SPACE} ! overlap src/c.rs — with s-second (git)")
+            format!(
+                "[System] coordination v1 space={SPACE} ! overlap src/c.rs — with s-second (git)"
+            )
         );
         assert_eq!(
             steers[2].text,

--- a/src/bin/caller/coordination/render.rs
+++ b/src/bin/caller/coordination/render.rs
@@ -32,7 +32,14 @@
 //!
 //! Zero-LLM and deterministic: identical inputs render byte-identical
 //! blocks; every collection consumed is pre-sorted by the radar.
-#![cfg_attr(not(test), allow(dead_code))] // C2 staging: consumed by the per-turn injection seam + delivery lanes (PR E). Drop as that wiring lands.
+//!
+//! The second product here is the **external ALERT steer line** (§2.8):
+//! [`render_alert_steers`] renders one schema-rendered single line per
+//! distinct overlap set per session pair (or per open PR) for the
+//! supervised-external delivery lane. Ambient content — presence,
+//! messages, invalid counts — has no path into that lane by
+//! construction: the function consumes the snapshot's overlap
+//! collections only (R8: ambient is never pushed at externals).
 
 use std::collections::BTreeMap;
 
@@ -389,6 +396,154 @@ fn assemble(c: &Candidates) -> Option<(String, bool)> {
     }
     text.push_str(MARKER);
     Some((text, take_overlaps > 0))
+}
+
+/// §2.8: byte bound for one external ALERT steer line (self-enforced —
+/// nothing downstream truncates steer text either).
+pub(crate) const STEER_LINE_MAX_BYTES: usize = 512;
+/// Overlap paths listed on one steer line; the remainder renders as the
+/// fixed `(+<n> more)` template token.
+pub(crate) const STEER_MAX_PATHS_LISTED: usize = 4;
+
+/// One external ALERT steer (§2.8): a schema-rendered single line for
+/// one distinct overlap set, plus the set's canonical hash — the
+/// identity the daemon-side [`super::radar::ExternalSteerLedger`] keys
+/// its one-steer-per-set dedup on. The hash covers the counterparty and
+/// the sorted path set, deliberately NOT the evidence sources, so a
+/// declared→declared+git shift alone does not remint a steer (the
+/// radar-note lane's canon, `messages::write_radar_note`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AlertSteer {
+    pub text: String,
+    pub set_hash: u64,
+}
+
+/// Render the §2.8 external ALERT steer lines for one session: one per
+/// counterparty session pair (paths grouped into the pair's set) and
+/// one per open PR. Every token passes its §2.3 validator; invalid
+/// tokens are skipped (a set with no valid path renders nothing — the
+/// external lane has no `invalid:` channel, and the native block
+/// already surfaces the counts). Empty when the session has no ALERT
+/// overlaps — ambient snapshot content cannot reach this lane because
+/// nothing here reads it.
+pub(crate) fn render_alert_steers(
+    snapshot: &SpaceRadarSnapshot,
+    own_writer_id: &str,
+) -> Vec<AlertSteer> {
+    if !valid_space_key_label(&snapshot.space_key) {
+        return Vec::new(); // nothing safe to say at all (§2.3)
+    }
+    let mut steers = Vec::new();
+
+    // Pair sets: group this session's pair overlaps per counterparty.
+    #[derive(Default)]
+    struct PairSet<'a> {
+        paths: std::collections::BTreeSet<&'a str>,
+        declared: bool,
+        git: bool,
+    }
+    let mut pairs: BTreeMap<&str, PairSet<'_>> = BTreeMap::new();
+    for o in &snapshot.pair_overlaps {
+        let other = if o.a == own_writer_id {
+            &o.b
+        } else if o.b == own_writer_id {
+            &o.a
+        } else {
+            continue; // someone else's collision (§2.7 own-scope)
+        };
+        if !valid_id(other) || !scan::valid_rel_path(&o.path) {
+            continue;
+        }
+        let entry = pairs.entry(other.as_str()).or_default();
+        entry.paths.insert(o.path.as_str());
+        entry.declared |= o.declared;
+        entry.git |= o.git;
+    }
+    for (other, set) in &pairs {
+        let sources = match (set.declared, set.git) {
+            (true, true) => "declared+git",
+            (true, false) => "declared",
+            (false, true) => "git",
+            (false, false) => continue, // sourceless set: nothing to claim
+        };
+        let tail = format!(" — with {} ({sources})", id8(other));
+        if let Some(text) = assemble_steer_line(&snapshot.space_key, &set.paths, &tail) {
+            steers.push(AlertSteer {
+                text,
+                set_hash: steer_set_hash(&format!("pair:{other}"), &set.paths),
+            });
+        }
+    }
+
+    // PR sets: group this session's PR overlaps per PR number.
+    let mut prs: BTreeMap<u32, std::collections::BTreeSet<&str>> = BTreeMap::new();
+    for o in &snapshot.pr_overlaps {
+        if o.writer != own_writer_id || !scan::valid_rel_path(&o.path) {
+            continue;
+        }
+        prs.entry(o.pr).or_default().insert(o.path.as_str());
+    }
+    for (pr, paths) in &prs {
+        let tail = format!(" — pr#{pr}");
+        if let Some(text) = assemble_steer_line(&snapshot.space_key, paths, &tail) {
+            steers.push(AlertSteer {
+                text,
+                set_hash: steer_set_hash(&format!("pr:{pr}"), paths),
+            });
+        }
+    }
+    steers
+}
+
+/// Canonical overlap-set identity for the ledger: counterparty (or PR)
+/// plus the sorted path set; sources excluded (see [`AlertSteer`]).
+fn steer_set_hash(counterparty: &str, paths: &std::collections::BTreeSet<&str>) -> u64 {
+    let canonical = format!(
+        "steer:{counterparty};paths={}",
+        paths.iter().copied().collect::<Vec<_>>().join(",")
+    );
+    super::fnv1a_64(canonical.as_bytes())
+}
+
+/// Assemble one steer line under [`STEER_LINE_MAX_BYTES`]: the §2.2
+/// header vocabulary + the ALERT marker + up to
+/// [`STEER_MAX_PATHS_LISTED`] display-bounded paths + the fixed
+/// `(+<n> more)` count for the rest + the pair/PR tail. Paths drop from
+/// the back (into the count) under byte pressure; `None` only when no
+/// path in the set survives its validator.
+fn assemble_steer_line(
+    space_key: &str,
+    paths: &std::collections::BTreeSet<&str>,
+    tail: &str,
+) -> Option<String> {
+    let displayed: Vec<String> = paths.iter().filter_map(|p| display_path(p)).collect();
+    if displayed.is_empty() {
+        return None;
+    }
+    let total = displayed.len();
+    let mut listed = displayed.len().min(STEER_MAX_PATHS_LISTED);
+    loop {
+        let mut line = format!(
+            "[System] coordination v1 space={space_key} ! overlap {}",
+            displayed[..listed].join(", ")
+        );
+        if total > listed {
+            line.push_str(&format!(" (+{} more)", total - listed));
+        }
+        line.push_str(tail);
+        if line.len() <= STEER_LINE_MAX_BYTES {
+            debug_assert!(!line.contains('\n'), "steer lines are single-line");
+            return Some(line);
+        }
+        if listed == 1 {
+            // A single display-bounded path always fits: header ≤ ~130
+            // bytes, path ≤ 120 chars, tail ≤ ~40. Defensive fallback
+            // rather than an unreachable!: drop the line, never emit an
+            // over-bound steer.
+            return None;
+        }
+        listed -= 1;
+    }
 }
 
 #[cfg(test)]
@@ -962,5 +1117,186 @@ mod tests {
             render_block(&snapshot, OWN, None, 0, 7).unwrap().text
         };
         assert_eq!(make(&observed_a), make(&observed_b));
+    }
+
+    // ── §2.8 external ALERT steer lines ──
+
+    /// RULED binding (R8): ambient content cannot reach the external
+    /// steer lane. A snapshot rich in every ambient signal — presence,
+    /// broadcast and addressed messages, invalid counts — but with no
+    /// ALERT overlap renders ZERO steers; the native block for the same
+    /// snapshot happily renders the ambient lines. Type-level backstop:
+    /// `render_alert_steers` reads only the overlap collections, so
+    /// there is no code path from ambient fields into a steer.
+    #[test]
+    fn ambient_content_never_reaches_the_steer_lane() {
+        let mut s = base_snapshot();
+        s.sessions.push(presence("s-other", Some("codex"), false));
+        s.sessions.push(presence("s-tired", None, true));
+        s.messages.push(message("s-peer", "m-0123456789ab", None));
+        s.messages
+            .push(message("s-peer", "m-0123456789ac", Some(OWN)));
+        s.invalid = 7;
+        assert!(
+            render_block(&s, OWN, None, 0, 0).is_some(),
+            "the native block DOES carry this ambient signal"
+        );
+        assert!(
+            render_alert_steers(&s, OWN).is_empty(),
+            "no ALERT ⇒ no steer, ever"
+        );
+
+        // Foreign pairs and foreign PR overlaps are someone else's
+        // alerts — still nothing for this session's lane.
+        s.pair_overlaps
+            .push(pair("src/foreign.rs", "s-xx", "s-yy", true, false));
+        s.pr_overlaps.push(RadarPrOverlap {
+            path: "docs/theirs.md".to_string(),
+            writer: "s-other".to_string(),
+            pr: 9,
+        });
+        assert!(render_alert_steers(&s, OWN).is_empty());
+    }
+
+    /// One steer per distinct overlap set per session pair / per PR,
+    /// schema-shaped, paths grouped and sorted, ambient tokens absent.
+    #[test]
+    fn steer_lines_group_sets_per_pair_and_pr() {
+        let mut s = base_snapshot();
+        s.sessions.push(presence("s-other-one", Some("codex"), false));
+        s.messages.push(message("s-peer", "m-0123456789ab", None));
+        s.pair_overlaps
+            .push(pair("src/b.rs", OWN, "s-other-one", true, false));
+        s.pair_overlaps
+            .push(pair("src/a.rs", "s-other-one", OWN, false, true));
+        s.pair_overlaps
+            .push(pair("src/c.rs", OWN, "s-second", false, true));
+        s.pr_overlaps.push(RadarPrOverlap {
+            path: "docs/mine.md".to_string(),
+            writer: OWN.to_string(),
+            pr: 566,
+        });
+        let steers = render_alert_steers(&s, OWN);
+        assert_eq!(steers.len(), 3, "{steers:?}");
+        assert_eq!(
+            steers[0].text,
+            format!(
+                "[System] coordination v1 space={SPACE} ! overlap src/a.rs, src/b.rs — with s-other- (declared+git)"
+            )
+        );
+        assert_eq!(
+            steers[1].text,
+            format!("[System] coordination v1 space={SPACE} ! overlap src/c.rs — with s-second (git)")
+        );
+        assert_eq!(
+            steers[2].text,
+            format!("[System] coordination v1 space={SPACE} ! overlap docs/mine.md — pr#566")
+        );
+        for steer in &steers {
+            assert!(!steer.text.contains('\n'), "single line");
+            assert!(
+                !steer.text.contains("messages:") && !steer.text.contains("sessions:"),
+                "ambient vocabulary never rides a steer: {}",
+                steer.text
+            );
+        }
+        // Distinct sets ⇒ distinct hashes; a pure evidence shift on the
+        // same set ⇒ the SAME hash (radar-note canon).
+        assert_ne!(steers[0].set_hash, steers[1].set_hash);
+        let mut shifted = base_snapshot();
+        shifted
+            .pair_overlaps
+            .push(pair("src/b.rs", OWN, "s-other-one", false, true));
+        shifted
+            .pair_overlaps
+            .push(pair("src/a.rs", "s-other-one", OWN, false, true));
+        let shifted = render_alert_steers(&shifted, OWN);
+        assert_eq!(shifted[0].set_hash, steers[0].set_hash);
+        assert_ne!(shifted[0].text, steers[0].text, "sources still render");
+        assert!(shifted[0].text.ends_with("(git)"), "{}", shifted[0].text);
+    }
+
+    /// Hostile tokens are skipped, never rendered; a set with no valid
+    /// path renders nothing at all.
+    #[test]
+    fn steer_lines_drop_hostile_tokens() {
+        let mut s = base_snapshot();
+        s.pair_overlaps
+            .push(pair("evil path.rs", OWN, "s-other", true, false));
+        s.pair_overlaps
+            .push(pair("ansi\u{1b}[31m.rs", OWN, "s-other", true, false));
+        s.pair_overlaps
+            .push(pair("src/fine.rs", OWN, "UPPER ID", true, false));
+        s.pr_overlaps.push(RadarPrOverlap {
+            path: "-dash.rs".to_string(),
+            writer: OWN.to_string(),
+            pr: 3,
+        });
+        assert!(
+            render_alert_steers(&s, OWN).is_empty(),
+            "nothing valid to say"
+        );
+
+        s.pair_overlaps
+            .push(pair("src/ok.rs", OWN, "s-other", false, true));
+        let steers = render_alert_steers(&s, OWN);
+        assert_eq!(steers.len(), 1);
+        assert!(steers[0].text.contains("src/ok.rs"));
+        for hostile in ["evil path", "\u{1b}", "UPPER", "-dash.rs"] {
+            assert!(!steers[0].text.contains(hostile), "{hostile:?} leaked");
+        }
+
+        let mut hostile_key = base_snapshot();
+        hostile_key.space_key = "Bad Key!".to_string();
+        hostile_key
+            .pair_overlaps
+            .push(pair("src/ok.rs", OWN, "s-other", true, true));
+        assert!(render_alert_steers(&hostile_key, OWN).is_empty());
+    }
+
+    /// The steer line holds its own byte wall: many long paths list at
+    /// most [`STEER_MAX_PATHS_LISTED`], the rest fold into the fixed
+    /// `(+<n> more)` token, and byte pressure drops listed paths from
+    /// the back rather than overflowing.
+    #[test]
+    fn steer_lines_hold_the_byte_cap() {
+        let mut s = base_snapshot();
+        let long_paths: Vec<String> = (0..12)
+            .map(|i| format!("src/{i:02}{}", "p".repeat(110)))
+            .collect();
+        for p in &long_paths {
+            s.pair_overlaps.push(pair(p, OWN, "s-other", true, true));
+        }
+        let steers = render_alert_steers(&s, OWN);
+        assert_eq!(steers.len(), 1);
+        let text = &steers[0].text;
+        assert!(
+            text.len() <= STEER_LINE_MAX_BYTES,
+            "{} bytes: {text}",
+            text.len()
+        );
+        assert!(text.contains(" more)"), "{text}");
+        let listed = text.matches("src/").count();
+        assert!(listed >= 1 && listed <= STEER_MAX_PATHS_LISTED, "{text}");
+        assert!(
+            text.contains(&format!("(+{} more)", 12 - listed)),
+            "count stays exact: {text}"
+        );
+        assert!(text.ends_with("— with s-other (declared+git)"), "{text}");
+    }
+
+    /// Determinism: same snapshot, same steer bytes and hashes.
+    #[test]
+    fn steer_rendering_is_deterministic() {
+        let mut s = base_snapshot();
+        s.pair_overlaps
+            .push(pair("src/y.rs", OWN, "s-other", true, false));
+        s.pair_overlaps
+            .push(pair("src/x.rs", OWN, "s-other", false, true));
+        let a = render_alert_steers(&s, OWN);
+        let b = render_alert_steers(&s, OWN);
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 1);
+        assert!(a[0].text.contains("src/x.rs, src/y.rs"), "{}", a[0].text);
     }
 }

--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -553,6 +553,20 @@ pub enum AppEvent {
     /// the session log for replay, never injected into any model context,
     /// and never blocking. `urgency` escalates delivery (attention center,
     /// Connect nudge) — see [`crate::types::NotificationUrgency`].
+    /// Collision-radar flag transition for a supervised session (Track C
+    /// §2.8, R8), emitted by the daemon radar task when the session's
+    /// ALERT overlap set first appears (`raised`) and when it clears or
+    /// the session goes away (`resolved`). `id` is the flag's stable
+    /// identity — the session's coordination space key — so a resolve
+    /// always retracts the raise it pairs with. Display-only: frontends
+    /// map it to the retractable `radar` attention kind; the external
+    /// ALERT steer lane polls radar state on its own cooldown-gated
+    /// cadence and never keys deliveries off this event.
+    CoordinationRadar {
+        session_id: String,
+        id: String,
+        state: crate::types::CoordinationRadarState,
+    },
     UserNotification {
         session_id: Option<String>,
         id: String,
@@ -3077,6 +3091,15 @@ pub fn app_event_to_outbound(event: &AppEvent) -> Option<crate::types::OutboundE
             text: text.clone(),
             urgency: *urgency,
             ts: *ts,
+        }),
+        AppEvent::CoordinationRadar {
+            session_id,
+            id,
+            state,
+        } => Some(OutboundEvent::CoordinationRadar {
+            session_id: session_id.clone(),
+            id: id.clone(),
+            state: *state,
         }),
         AppEvent::AutoApproved { preview } => Some(OutboundEvent::AutoApproved {
             preview: preview.clone(),

--- a/src/bin/caller/external_events.rs
+++ b/src/bin/caller/external_events.rs
@@ -1117,7 +1117,7 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                 // (the density-steer precedent), and the cooldown ledger
                 // inside keeps quiet consults free.
                 if coordination_consult_at
-                    .map_or(true, |t| t.elapsed() >= EXTERNAL_COORDINATION_CONSULT_INTERVAL)
+                    .is_none_or(|t| t.elapsed() >= EXTERNAL_COORDINATION_CONSULT_INTERVAL)
                 {
                     coordination_consult_at = Some(tokio::time::Instant::now());
                     steer_external_coordination_alerts(agent, config).await;

--- a/src/bin/caller/external_events.rs
+++ b/src/bin/caller/external_events.rs
@@ -254,6 +254,9 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
         EXTERNAL_CONTEXT_SNAPSHOT_INTERVAL,
     );
     context_snapshot_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    // §2.8 ALERT steer consult spacing: rides the snapshot tick but at
+    // the radar's own cadence (`None` = consult on the first tick).
+    let mut coordination_consult_at: Option<tokio::time::Instant> = None;
     let post_turn_sleep = tokio::time::sleep(EXTERNAL_POST_TURN_DRAIN_GRACE);
     tokio::pin!(post_turn_sleep);
     let mut post_turn_sleep_active = false;
@@ -1108,6 +1111,17 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                     &mut context_snapshot_state,
                 )
                 .await;
+                // Coordination radar, external ALERT lane (§2.8): poll
+                // the published radar state on the radar's own cadence —
+                // mid-turn deliveries ride the backend's `steer_turn`
+                // (the density-steer precedent), and the cooldown ledger
+                // inside keeps quiet consults free.
+                if coordination_consult_at
+                    .map_or(true, |t| t.elapsed() >= EXTERNAL_COORDINATION_CONSULT_INTERVAL)
+                {
+                    coordination_consult_at = Some(tokio::time::Instant::now());
+                    steer_external_coordination_alerts(agent, config).await;
+                }
                 continue;
             }
             maybe_event = event_rx.recv() => {

--- a/src/bin/caller/external_mode.rs
+++ b/src/bin/caller/external_mode.rs
@@ -1383,6 +1383,30 @@ pub(crate) async fn run_external_agent_mode(
                                 );
                                 continue;
                             }
+                            Ok(AppEvent::CoordinationRadar {
+                                session_id,
+                                state: crate::types::CoordinationRadarState::Raised,
+                                ..
+                            }) if event_targets_session_or_alias(
+                                &Some(session_id.clone()),
+                                &live_session_id,
+                                &drain_config.alias_session_id,
+                            ) => {
+                                // Coordination radar, external ALERT lane
+                                // (§2.8): an alert raised while this
+                                // session parks queues the schema line as
+                                // the targeted-ContextInjection fallback —
+                                // merged into the NEXT turn's prompt, never
+                                // an immediate turn of its own. The ledger
+                                // inside dedups sets and holds the 10-min
+                                // cooldown.
+                                queue_external_coordination_alert_steers(
+                                    &context_injection,
+                                    live_session_id.as_deref(),
+                                    &session_log,
+                                );
+                                continue;
+                            }
                             Ok(AppEvent::SteerRequested {
                                 session_id,
                                 text,

--- a/src/bin/caller/external_supervision.rs
+++ b/src/bin/caller/external_supervision.rs
@@ -1235,6 +1235,134 @@ impl DrainConfig<'_> {
 
 pub(crate) const EXTERNAL_CONTEXT_SNAPSHOT_INTERVAL: Duration = Duration::from_secs(1);
 
+/// How often the turn drain consults the radar for §2.8 ALERT steers —
+/// the radar itself republishes on `coordination::radar::RADAR_TICK`,
+/// so a faster consult would only re-read identical snapshots.
+pub(crate) const EXTERNAL_COORDINATION_CONSULT_INTERVAL: Duration = Duration::from_secs(5);
+
+/// The external ALERT-only delivery lane's gate (Track C §2.8, R8):
+/// consult the daemon-published radar state for this session's alerts,
+/// render the schema-rendered single-line steers for its distinct
+/// overlap sets ([`coordination::render::render_alert_steers`] — ALERT
+/// overlaps only; ambient content has no path in), and admit them
+/// through the daemon-side cooldown ledger (one steer per set per pair,
+/// 10-minute per-session cooldown; suppressed sets retry on a later
+/// consult). Admitted steers are RECORDED — the caller must deliver
+/// each: mid-turn through the backend's `steer_turn` lane, otherwise as
+/// the targeted-`ContextInjection` between-turns fallback
+/// ([`queue_external_coordination_alert_steers`], merged into the next
+/// outgoing prompt by `drain_steer_queue_as_followup`). Returns nothing
+/// outside a radar-publishing daemon (foreground `--agent` shapes) —
+/// the ruled degrade-to-no-op.
+pub(crate) fn admit_external_coordination_alert_steers(
+    session_id: Option<&str>,
+) -> Vec<coordination::render::AlertSteer> {
+    let Some(session_id) = session_id else {
+        return Vec::new();
+    };
+    let Some(state) = coordination::radar::published_radar_state() else {
+        return Vec::new();
+    };
+    let writer_id = coordination::lifecycle::writer_id_for_session(session_id);
+    let Some(snapshot) = state.space_with_alerts_for(&writer_id) else {
+        return Vec::new();
+    };
+    let steers = coordination::render::render_alert_steers(&snapshot, &writer_id);
+    if steers.is_empty() {
+        return steers;
+    }
+    let now_ms = coordination::now_ms();
+    let ledger = coordination::radar::external_steer_ledger();
+    steers
+        .into_iter()
+        .filter(|steer| ledger.admit(session_id, steer.set_hash, now_ms))
+        .collect()
+}
+
+/// Between-turns half of the §2.8 lane: queue admitted steers as
+/// session-TARGETED system context injections; the external follow-up
+/// path (`drain_steer_queue_as_followup`) merges them verbatim above
+/// the next outgoing prompt. Deliberately NO steer lifecycle events —
+/// a supervisor-originated radar line is not a user steer (the
+/// managed-context density steer's altitude); the session log carries
+/// the delivery fact instead. Returns how many lines were queued.
+pub(crate) fn queue_external_coordination_alert_steers(
+    context_injection: &event::ContextInjectionQueue,
+    session_id: Option<&str>,
+    session_log: &SharedSessionLog,
+) -> usize {
+    let steers = admit_external_coordination_alert_steers(session_id);
+    if steers.is_empty() {
+        return 0;
+    }
+    let queued = steers.len();
+    if let Ok(mut queue) = context_injection.lock() {
+        for steer in steers {
+            slog(session_log, |l| {
+                l.info(&format!(
+                    "Coordination radar ALERT queued for the next turn: {}",
+                    steer.text
+                ))
+            });
+            queue.push(event::ContextInjection {
+                text: steer.text,
+                images: Vec::new(),
+                source: event::InjectionSource::System,
+                target_session_id: session_id.map(str::to_string),
+                steer_id: None,
+            });
+        }
+    }
+    queued
+}
+
+/// Mid-turn half of the §2.8 lane, called from the turn drain on its
+/// consult cadence: admitted steers go through the backend's native
+/// `steer_turn`; a backend that cannot take one right now (turn just
+/// ended, RPC trouble) falls back to the queued between-turns shape so
+/// the line still reaches the model exactly once.
+pub(crate) async fn steer_external_coordination_alerts(
+    agent: &mut Box<dyn external_agent::ExternalAgent>,
+    config: &DrainConfig<'_>,
+) {
+    let steers = admit_external_coordination_alert_steers(config.session_id.as_deref());
+    for steer in steers {
+        match agent.steer_turn(&steer.text).await {
+            Ok(()) => {
+                let content = format!(
+                    "Coordination radar ALERT steered into the running {} turn: {}",
+                    agent.name(),
+                    steer.text
+                );
+                slog(config.session_log, |l| l.info(&content));
+                config.bus.send(AppEvent::LogEntry {
+                    session_id: config.session_id.clone(),
+                    level: "info".to_string(),
+                    source: "Intendant".to_string(),
+                    content,
+                    turn: None,
+                });
+            }
+            Err(e) => {
+                slog(config.session_log, |l| {
+                    l.debug(&format!(
+                        "Coordination radar steer fell back to the next-turn queue ({e})"
+                    ))
+                });
+                if let Ok(mut queue) = config.context_injection.lock() {
+                    queue.push(event::ContextInjection {
+                        text: steer.text,
+                        images: Vec::new(),
+                        source: event::InjectionSource::System,
+                        target_session_id: config.session_id.clone(),
+                        steer_id: None,
+                    });
+                }
+            }
+        }
+    }
+}
+
 #[derive(Default)]
 pub(crate) struct ExternalContextSnapshotState {
     pub(crate) emitted_keys: std::collections::HashSet<u64>,

--- a/src/bin/caller/mcp/events.rs
+++ b/src/bin/caller/mcp/events.rs
@@ -267,7 +267,8 @@ pub fn spawn_event_listener(
                     | AppEvent::BrowserWorkspaceChanged { .. }
                     | AppEvent::AgendaChanged { .. }
                     | AppEvent::AgendaAskOutcome { .. }
-                    | AppEvent::MemoryChanged { .. } => {} // Derived events — handled by outbound broadcaster
+                    | AppEvent::MemoryChanged { .. }
+                    | AppEvent::CoordinationRadar { .. } => {} // Derived events — handled by outbound broadcaster
                     AppEvent::CodexConfigChanged {
                         managed_context, ..
                     } => {

--- a/src/bin/caller/peer/upcast.rs
+++ b/src/bin/caller/peer/upcast.rs
@@ -632,7 +632,10 @@ impl AppEventUpcaster {
             // nor its ask outcomes (delivery is a local-supervisor act).
             | AppEvent::AgendaChanged { .. }
             | AppEvent::AgendaAskOutcome { .. }
-            | AppEvent::MemoryChanged { .. } => vec![],
+            | AppEvent::MemoryChanged { .. }
+            // Coordination-radar flags are box-local attention state
+            // (the bus never leaves the box).
+            | AppEvent::CoordinationRadar { .. } => vec![],
 
             AppEvent::UserMessageEditStatus {
                 user_turn_index,
@@ -2109,6 +2112,9 @@ impl WireEventUpcaster {
             | OutboundEvent::BrowserWorkspaceChanged { .. }
             | OutboundEvent::SessionRenameResult { .. }
             | OutboundEvent::SessionAgentConfigResult { .. }
+            // A peer's coordination-radar flags are its own box-local
+            // attention state (same class as the AppEvent twin above).
+            | OutboundEvent::CoordinationRadar { .. }
             | OutboundEvent::PeerAdded { .. }
             | OutboundEvent::PeerRemoved { .. }
             | OutboundEvent::PeerStateChanged { .. }

--- a/src/bin/caller/presence.rs
+++ b/src/bin/caller/presence.rs
@@ -1146,7 +1146,10 @@ pub fn filter_event(event: &AppEvent, last_phase: &mut String) -> Option<Presenc
         // Peer-delegation delivery receipts are wire-facing correlation
         // events (OutboundEvent::TaskReceived); the accepted task
         // narrates itself through its own session lifecycle.
-        | AppEvent::TaskReceived { .. } => None,
+        | AppEvent::TaskReceived { .. }
+        // Radar flags are dashboard attention items; the flagged
+        // session's own injected block is what the model narrates from.
+        | AppEvent::CoordinationRadar { .. } => None,
     }
 }
 

--- a/src/bin/caller/provider_mock.rs
+++ b/src/bin/caller/provider_mock.rs
@@ -47,6 +47,14 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
 
 pub const MOCK_SCRIPT_ENV: &str = "INTENDANT_MOCK_SCRIPT";
+/// Opt-in request tap for prefix-stability e2es (coordination §2.6):
+/// when set to a path, every chat call appends one JSONL record
+/// `{"n":…,"messages_json":"…"}` whose `messages_json` field is the
+/// exact serde serialization of the request's message Vec — so two
+/// consecutive requests can be byte-compared for the tail-append-only
+/// property. Test-only and off by default; requests are recorded as
+/// received, before any script bookkeeping.
+pub const MOCK_REQUEST_DUMP_ENV: &str = "INTENDANT_MOCK_REQUEST_DUMP";
 const MOCK_FILE_BARRIER_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 #[derive(Debug, Deserialize)]
@@ -118,6 +126,8 @@ pub struct MockProvider {
     script: MockScript,
     /// (selected profile, next step) — chosen on first chat() call.
     cursor: Mutex<Option<(usize, usize)>>,
+    /// Per-instance request ordinal for the [`MOCK_REQUEST_DUMP_ENV`] tap.
+    dump_seq: AtomicUsize,
 }
 
 impl MockProvider {
@@ -147,7 +157,38 @@ impl MockProvider {
             model: script.model.clone().unwrap_or_else(|| "mock-1".to_string()),
             script,
             cursor: Mutex::new(None),
+            dump_seq: AtomicUsize::new(0),
         })
+    }
+
+    /// The [`MOCK_REQUEST_DUMP_ENV`] tap: append one JSONL record for a
+    /// request as received. The env read lives at this transport edge;
+    /// tests exercise [`Self::dump_request_to`] with an injected path
+    /// (hermetic — no process-global env mutation).
+    fn dump_request_if_enabled(&self, messages: &[Message]) -> Result<(), CallerError> {
+        match std::env::var(MOCK_REQUEST_DUMP_ENV) {
+            Ok(path) if !path.is_empty() => self.dump_request_to(&path, messages),
+            _ => Ok(()),
+        }
+    }
+
+    /// Append one `{"n":…,"model":…,"messages_json":…}` JSONL record.
+    /// Failures are loud config errors — the tap only exists inside
+    /// tests, where a silent miss would fake a pass.
+    fn dump_request_to(&self, path: &str, messages: &[Message]) -> Result<(), CallerError> {
+        use std::io::Write;
+        let n = self.dump_seq.fetch_add(1, Ordering::Relaxed) + 1;
+        let messages_json = serde_json::to_string(messages)
+            .map_err(|e| CallerError::Config(format!("mock request dump serialize: {e}")))?;
+        let record =
+            serde_json::json!({ "n": n, "model": self.model, "messages_json": messages_json });
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .map_err(|e| CallerError::Config(format!("mock request dump {path}: {e}")))?;
+        writeln!(file, "{record}")
+            .map_err(|e| CallerError::Config(format!("mock request dump {path}: {e}")))
     }
 
     /// First profile whose `match` appears in the conversation, else the
@@ -182,6 +223,7 @@ impl MockProvider {
 #[async_trait]
 impl ChatProvider for MockProvider {
     async fn chat(&self, messages: &[Message]) -> Result<ChatResponse, CallerError> {
+        self.dump_request_if_enabled(messages)?;
         let transcript: String = messages
             .iter()
             .map(|m| m.content.as_str())
@@ -447,6 +489,56 @@ mod tests {
             .expect("chat task should not panic")
             .expect("released step should answer");
         assert_eq!(response.content, "released");
+    }
+
+    /// The §2.6 request tap: consecutive requests dump their exact
+    /// message-Vec serialization, and a pure tail append shows up as a
+    /// byte-identical prefix (the same mechanism the coordination
+    /// prefix e2e asserts through the real binaries, which set
+    /// [`MOCK_REQUEST_DUMP_ENV`] on the child daemon's environment).
+    #[test]
+    fn request_dump_records_byte_comparable_serializations() {
+        let dir = tempfile::tempdir().expect("dump dir");
+        let dump = dir.path().join("requests.jsonl");
+        let dump_path = dump.to_str().expect("utf-8 temp path");
+        let provider = MockProvider::from_json(
+            r#"{ "profiles": [{ "steps": [ { "content": "one" }, { "content": "two" } ] }] }"#,
+        )
+        .expect("valid script");
+
+        let mut conversation = vec![message("system", "prompt"), message("user", "task")];
+        provider
+            .dump_request_to(dump_path, &conversation)
+            .expect("first dump");
+        conversation.push(message("assistant", "one"));
+        conversation.push(message("user", "[System] coordination v1 space=test tail"));
+        provider
+            .dump_request_to(dump_path, &conversation)
+            .expect("second dump");
+
+        let dumped = std::fs::read_to_string(&dump).expect("dump file");
+        let records: Vec<serde_json::Value> = dumped
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("dump line parses"))
+            .collect();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0]["n"], 1);
+        assert_eq!(records[1]["n"], 2);
+        let first = records[0]["messages_json"].as_str().expect("first json");
+        let second = records[1]["messages_json"].as_str().expect("second json");
+        let first_open = first.strip_suffix(']').expect("array serialization");
+        assert!(
+            second.starts_with(first_open),
+            "prior request must be a byte prefix:\n{first}\n{second}"
+        );
+        assert_eq!(second.as_bytes()[first_open.len()], b',', "pure append");
+        let second_messages: Vec<serde_json::Value> =
+            serde_json::from_str(second).expect("second parses");
+        assert_eq!(
+            second_messages.last().and_then(|m| m["content"].as_str()),
+            Some("[System] coordination v1 space=test tail"),
+            "the appended tail is the last message"
+        );
     }
 
     #[test]

--- a/src/bin/caller/session_log/bus_events.rs
+++ b/src/bin/caller/session_log/bus_events.rs
@@ -1626,7 +1626,10 @@ impl SessionLog {
     /// (task / resume task / follow-up / delivered steer / askHuman answer).
     /// Emitted only where text genuinely enters the worker conversation;
     /// system injections, tool output, and context summaries are
-    /// deliberately absent. `text` is the RAW user text — attachment
+    /// deliberately absent — with one RULED exception: the coordination
+    /// radar block (Track C §2.9) logs here with `SystemInjection`
+    /// provenance so dashboard replay and the C2 acceptance can assert
+    /// its schema in the turn record. `text` is the RAW user text — attachment
     /// preludes and `[Session resumed]`/`[New Task]`/`[User]` wrappers are
     /// the conversation's concern, not the record's. `ref_seq` marks a
     /// projection: the text entered the conversation inside another entry

--- a/src/bin/caller/startup/daemon.rs
+++ b/src/bin/caller/startup/daemon.rs
@@ -161,9 +161,11 @@ pub(crate) async fn run_daemon(
     // Collision radar (Track C, C2 — ruled §2.1): periodic zero-LLM
     // detection over bus declarations ∪ observed git status (the same
     // registry the vitals prober probes) ∪ open-PR file sets; publishes
-    // per-space snapshots for the injection seam and writes deduplicated
-    // radar notes to flagged parties.
-    let _radar_task = crate::coordination::radar::spawn_radar_task(vitals_git_targets.clone());
+    // per-space snapshots for the injection seam, writes deduplicated
+    // radar notes to flagged parties, and broadcasts the §2.8 rail-badge
+    // raise/resolve transitions on the bus.
+    let _radar_task =
+        crate::coordination::radar::spawn_radar_task(vitals_git_targets.clone(), bus.clone());
     // Restored sessions: a restart empties the target registry, so idle
     // session windows lose their git/health chips until the next resume.
     // One bounded walk (newest-first, insert-if-absent — see

--- a/src/bin/caller/steering.rs
+++ b/src/bin/caller/steering.rs
@@ -112,6 +112,31 @@ pub(crate) fn queued_steer_targets_session(
     session_id == Some(target) || alias_session_id == Some(target)
 }
 
+/// A system injection explicitly TARGETED at this external session —
+/// today only the coordination radar's §2.8 between-turns ALERT
+/// fallback pushes these. Only explicitly targeted entries qualify:
+/// untargeted system injections (display take/release, presence
+/// annotations) belong to the native drain path and stay queued. These
+/// entries merge verbatim (their text carries its own `[System] …`
+/// provenance marker) and never trigger empty flush turns
+/// ([`has_queued_steers_for_session`] deliberately ignores them — an
+/// advisory radar line waits for the next real turn).
+pub(crate) fn queued_system_injection_targets_session(
+    injection: &event::ContextInjection,
+    session_id: Option<&str>,
+    alias_session_id: Option<&str>,
+) -> bool {
+    if injection.steer_id.is_some() || injection.source != event::InjectionSource::System {
+        return false;
+    }
+    injection
+        .target_session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|target| !target.is_empty())
+        .is_some_and(|target| session_id == Some(target) || alias_session_id == Some(target))
+}
+
 pub(crate) fn has_queued_steers_for_session(
     context_injection: &event::ContextInjectionQueue,
     session_id: Option<&str>,
@@ -343,19 +368,28 @@ pub(crate) fn mark_pending_runtime_steers_delivered_at_model_checkpoint(
 /// Drain queued steer items from `context_injection` and merge them into a
 /// follow-up user message bound for an external agent.
 ///
-/// Only drains items whose `steer_id` is `Some(_)` — those are the entries
-/// that the steer fallback path pushed. Other queue sources (display
-/// takeover, presence annotations) are left in place for the native
-/// drain-between-turns path used by the internal agent loop.
+/// Two entry classes drain here:
+/// - items whose `steer_id` is `Some(_)` — the entries the steer fallback
+///   path pushed. Each emits `AppEvent::SteerDelivered { mid_turn: false }`
+///   so the dashboard can retire its pending-steer UI row, and merges
+///   prefixed with `[User]`;
+/// - system items explicitly TARGETED at this session
+///   ([`queued_system_injection_targets_session`] — today the coordination
+///   radar's §2.8 between-turns ALERT fallback). These merge VERBATIM
+///   (their text carries its own `[System] …` provenance marker) and emit
+///   no steer lifecycle events — a supervisor-originated radar line is not
+///   a user steer.
 ///
-/// For each drained item, emits `AppEvent::SteerDelivered { mid_turn: false }`
-/// so the dashboard can retire its pending-steer UI row. The returned
-/// string interleaves queued steers (prefixed with `[User]`) above the
-/// caller's `followup` text — the result is sent as a single external agent
+/// Untargeted non-steer entries (display takeover, presence annotations)
+/// are left in place for the native drain-between-turns path used by the
+/// internal agent loop.
+///
+/// The returned string interleaves the drained lines above the caller's
+/// `followup` text — the result is sent as a single external agent
 /// message so the agent sees both in the same turn's input.
 ///
-/// When `followup` is empty and queued steer text exists, the queued steer
-/// text becomes the whole follow-up. When both are empty, the return is
+/// When `followup` is empty and queued text exists, the queued text
+/// becomes the whole follow-up. When both are empty, the return is
 /// `None`, meaning "nothing to send".
 pub(crate) fn drain_steer_queue_as_followup(
     context_injection: &event::ContextInjectionQueue,
@@ -366,8 +400,8 @@ pub(crate) fn drain_steer_queue_as_followup(
 ) -> Option<String> {
     let mut prefix_lines: Vec<String> = Vec::new();
     if let Ok(mut q) = context_injection.lock() {
-        // Partition: keep non-steer entries and steers for other sessions,
-        // pull out steer entries for this session.
+        // Partition: keep foreign/untargeted entries, pull out this
+        // session's steers and targeted system injections.
         let mut kept = Vec::with_capacity(q.len());
         for inj in q.drain(..) {
             if queued_steer_targets_session(&inj, session_id, alias_session_id) {
@@ -382,6 +416,8 @@ pub(crate) fn drain_steer_queue_as_followup(
                     id,
                     mid_turn: false,
                 });
+            } else if queued_system_injection_targets_session(&inj, session_id, alias_session_id) {
+                prefix_lines.push(inj.text.clone());
             } else {
                 kept.push(inj);
             }
@@ -612,6 +648,56 @@ mod tests {
             .expect("should produce a message");
         assert_eq!(merged, "follow-up");
         assert_eq!(queue.lock().unwrap().len(), 1, "non-steer entry preserved");
+    }
+
+    #[tokio::test]
+    async fn drain_steer_queue_merges_targeted_system_injections_verbatim() {
+        // The coordination radar's §2.8 between-turns fallback: a
+        // session-TARGETED system injection merges verbatim (its text
+        // carries its own [System] marker), emits NO steer lifecycle
+        // events, and never counts as a queued steer (no empty flush
+        // turn). Untargeted system entries stay for the native drain.
+        let bus = EventBus::new();
+        let mut rx = bus.subscribe();
+        let queue = event::ContextInjectionQueue::default();
+        {
+            let mut q = queue.lock().unwrap();
+            q.push(event::ContextInjection {
+                text: "[System] coordination v1 space=s-1 ! overlap src/a.rs — with s-peer (git)"
+                    .into(),
+                images: vec![],
+                source: event::InjectionSource::System,
+                target_session_id: Some("session-b".into()),
+                steer_id: None,
+            });
+            q.push(event::ContextInjection {
+                text: "[System] coordination v1 space=s-1 ! overlap src/b.rs — pr#7".into(),
+                images: vec![],
+                source: event::InjectionSource::System,
+                target_session_id: Some("session-other".into()),
+                steer_id: None,
+            });
+            q.push(event::ContextInjection::text("display grant".into()));
+        }
+        assert!(
+            !has_queued_steers_for_session(&queue, Some("session-b"), None),
+            "targeted system injections must not arm the empty flush turn"
+        );
+
+        let merged = drain_steer_queue_as_followup(&queue, "main", &bus, Some("session-b"), None)
+            .expect("merged");
+        assert_eq!(
+            merged,
+            "[System] coordination v1 space=s-1 ! overlap src/a.rs — with s-peer (git)\nmain"
+        );
+        let remaining = queue.lock().unwrap();
+        assert_eq!(remaining.len(), 2, "foreign + untargeted entries stay");
+        assert!(remaining.iter().any(|inj| inj.text == "display grant"));
+        drop(remaining);
+        assert!(
+            rx.try_recv().is_err(),
+            "no steer lifecycle events for radar lines"
+        );
     }
 
     #[tokio::test]

--- a/src/bin/caller/types.rs
+++ b/src/bin/caller/types.rs
@@ -314,6 +314,17 @@ pub enum NotificationUrgency {
     Urgent,
 }
 
+/// Collision-radar flag lifecycle (Track C §2.8, R8). `raised` adds the
+/// dashboard's retractable `radar` attention item; `resolved` retracts
+/// it — the retraction is why the radar has its own attention kind
+/// instead of riding fire-and-forget `user_notification`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CoordinationRadarState {
+    Raised,
+    Resolved,
+}
+
 impl NotificationUrgency {
     pub fn as_str(self) -> &'static str {
         match self {
@@ -490,6 +501,17 @@ pub enum OutboundEvent {
         #[serde(default)]
         urgency: NotificationUrgency,
         ts: u64,
+    },
+    /// Collision-radar flag for one session (Track C §2.8, R8): the
+    /// daemon radar task raises it while ALERT overlaps name the
+    /// session and resolves it when they clear. `id` is the flag's
+    /// stable identity (the session's coordination space key), so a
+    /// resolve always retracts the raise it pairs with; the dashboard
+    /// maps the pair to the retractable `radar` attention kind.
+    CoordinationRadar {
+        session_id: String,
+        id: String,
+        state: CoordinationRadarState,
     },
     TaskComplete {
         #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/static/app/57-attention-notifications.js
+++ b/static/app/57-attention-notifications.js
@@ -4,7 +4,8 @@
 // on the human — fed from the same server events the panels render
 // (approval_required / user_question / approval_resolved, plus session
 // terminations), keyed by (kind, session, id) so future kinds (display
-// requests, agent notify) drop in cheaply.
+// requests, agent notify, the coordination radar's retractable overlap
+// flag) drop in cheaply.
 //
 // Surfaces, in escalation order:
 //   1. document-title prefix `(N)` + favicon count badge — default ON
@@ -131,6 +132,18 @@ function attentionApplyEvent(d, live) {
     if ((urgency === 'attention' || urgency === 'urgent') && live && document.hidden) {
       attentionAdd('notify', d.session_id, d.id, live);
     }
+  } else if (ev === 'coordination_radar') {
+    // Collision-radar flag (Track C §2.8): retractable BY DESIGN —
+    // 'raised' adds, 'resolved' retracts the same (session, id) item,
+    // which is why the radar has its own kind instead of riding
+    // fire-and-forget notifications. Like 'display', the flag's
+    // lifecycle is the radar's, not the turn's.
+    if (d.state === 'raised') {
+      attentionAdd('radar', d.session_id, d.id, live);
+    } else if (d.state === 'resolved') {
+      attentionRemove('radar', d.session_id, d.id);
+      attentionRepaint();
+    }
   } else if (ev === 'approval_resolved') {
     // Approvals and questions share the id space; resolve either.
     attentionRemove('approval', d.session_id, d.id);
@@ -140,10 +153,13 @@ function attentionApplyEvent(d, live) {
     // The blocked loop returned — approvals/questions in that session no
     // longer wait (some exit paths skip approval_resolved). A display
     // request survives: its waiter is the blocked MCP call, not the turn;
-    // it clears via display_request_resolved or session_ended.
+    // it clears via display_request_resolved or session_ended. A radar
+    // flag survives for the same reason: the files still overlap until
+    // the radar says 'resolved' (or session_ended).
     const sessionKey = attentionSessionKey(d.session_id);
     for (const [key, item] of [...attentionItems]) {
-      if (attentionSessionKey(item.sessionId) === sessionKey && item.kind !== 'display') {
+      if (attentionSessionKey(item.sessionId) === sessionKey
+          && item.kind !== 'display' && item.kind !== 'radar') {
         attentionItems.delete(key);
       }
     }
@@ -239,11 +255,13 @@ function attentionShowNotification(items) {
   const questions = items.filter((i) => i.kind === 'question').length;
   const displayRequests = items.filter((i) => i.kind === 'display').length;
   const notifies = items.filter((i) => i.kind === 'notify').length;
+  const radars = items.filter((i) => i.kind === 'radar').length;
   let title;
   if (items.length === 1) {
     title = questions ? 'Intendant: the agent has a question'
       : displayRequests ? 'Intendant: agent asks to view your screen'
       : notifies ? 'Intendant: the agent sent a notification'
+      : radars ? 'Intendant: sessions are overlapping on files'
       : 'Intendant: approval needed';
   } else {
     const parts = [];
@@ -251,6 +269,7 @@ function attentionShowNotification(items) {
     if (questions) parts.push(`${questions} question${questions > 1 ? 's' : ''}`);
     if (displayRequests) parts.push(`${displayRequests} display request${displayRequests > 1 ? 's' : ''}`);
     if (notifies) parts.push(`${notifies} notification${notifies > 1 ? 's' : ''}`);
+    if (radars) parts.push(`${radars} overlap alert${radars > 1 ? 's' : ''}`);
     title = `Intendant: ${parts.join(' and ')} waiting`;
   }
   const total = attentionItems.size;

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -109,6 +109,11 @@ impl TestRig {
             // here would write this rig's session declarations into the
             // HOST's live bus space instead of the fresh HOME below.
             .env_remove("INTENDANT_COORDINATION_DIR")
+            // The mock provider's request tap is per-test opt-in (the
+            // coordination prefix e2e sets it on its own daemon); an
+            // inherited path would make unrelated rigs cross-write one
+            // dump file.
+            .env_remove("INTENDANT_MOCK_REQUEST_DUMP")
             // The suite is display-free by contract, but a host with a live
             // X session at :0 (a self-hosted runner doubling as a desktop)
             // breaks that hermeticity: the caller's vision probe finds the
@@ -4769,6 +4774,276 @@ async fn supervised_session_writes_task_ask_human_and_steer_message_rows() {
             "Round one done, payload chosen.",
             "Steered round two.",
         ],
+    );
+}
+
+/// Track C C2, RULED binding (§2.6/R6): the coordination radar block
+/// arrives as a NEW tail message and the prior request's serialized
+/// message prefix stays byte-identical — the prefix-cache proof
+/// enacted through the real binaries. Round 1 runs before any bus
+/// signal exists; two fixture declarations sharing a dirty path then
+/// hand the daemon radar a §2.7 overlap, whose radar-note file on disk
+/// is the observable "a tick saw it" gate (the same tick publishes the
+/// snapshot right after writing notes); the steered round 2's first
+/// turn injects the block, gated a second time by the mock script's
+/// own transcript expectation. Request payloads come from the mock
+/// provider's opt-in tap (INTENDANT_MOCK_REQUEST_DUMP): each record's
+/// `messages_json` is the exact serde serialization of that request's
+/// message Vec, so "nothing before the tail changed" is a literal
+/// `starts_with` over bytes.
+#[tokio::test]
+async fn coordination_radar_block_injects_as_a_pure_tail_append() {
+    use futures_util::SinkExt;
+
+    let rig = TestRig::new();
+    let script = rig.write_script(&serde_json::json!({
+        "profiles": [{
+            "steps": [
+                { "content": "Radar round one.",
+                  "tool_calls": [{ "name": "signal_done",
+                                   "arguments": { "message": "round one" } }] },
+                { "expect_transcript_contains": "[System] coordination v1",
+                  "content": "Radar block received.",
+                  "tool_calls": [{ "name": "signal_done",
+                                   "arguments": { "message": "round two" } }] }
+            ]
+        }]
+    }));
+    let session_project = tempfile::tempdir().expect("session project dir");
+    let dump_path = rig.home.path().join("mock-requests.jsonl");
+
+    let mut cmd = rig.command();
+    cmd.env("INTENDANT_MOCK_SCRIPT", &script)
+        .env("INTENDANT_MOCK_REQUEST_DUMP", &dump_path)
+        .args(["--no-tls", "--web", "0"]);
+    let mut child = cmd.spawn().expect("spawn intendant daemon");
+    let stderr_buf = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    let stdout_buf = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    let _stderr_drain = drain_pipe_into(child.stderr.take().expect("stderr"), stderr_buf.clone());
+    let _stdout_drain = drain_pipe_into(child.stdout.take().expect("stdout"), stdout_buf.clone());
+    let daemon_log = {
+        let stderr_buf = stderr_buf.clone();
+        move || stderr_buf.lock().map(|b| tail(&b, 4000)).unwrap_or_default()
+    };
+
+    let stderr_so_far = wait_for_output(&stderr_buf, "Dashboard: http://", RUN_TIMEOUT).await;
+    let port: u16 = stderr_so_far
+        .lines()
+        .find_map(|line| {
+            let url = line.strip_prefix("Dashboard: http://")?;
+            url.rsplit(':').next()?.trim().parse().ok()
+        })
+        .expect("parse the dashboard port from the startup line");
+    // Gateway readiness (the hand-spawn twin of spawn_daemon's poll), so
+    // a single create_session suffices.
+    let client = reqwest::Client::new();
+    let card_url = format!("http://127.0.0.1:{port}/.well-known/agent-card.json");
+    poll_until(
+        "the gateway to serve the agent card",
+        DAEMON_START_TIMEOUT,
+        || {
+            let client = client.clone();
+            let card_url = card_url.clone();
+            async move { http_get_json(&client, &card_url).await }
+        },
+        &daemon_log,
+    )
+    .await;
+
+    let (mut ws, _) = tokio_tungstenite::connect_async(format!(
+        "ws://127.0.0.1:{port}/ws?token={}",
+        rig_loopback_token(&rig, port)
+    ))
+    .await
+    .expect("connect /ws");
+    ws.send(tokio_tungstenite::tungstenite::Message::Text(
+        serde_json::json!({
+            "action": "create_session",
+            "task": "coordinate the radar prefix run",
+            "project_root": session_project.path().to_string_lossy(),
+            "direct": true,
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .expect("send create_session");
+    let started = next_matching_ws_event(&mut ws, RUN_TIMEOUT, |json| {
+        json.get("event").and_then(|v| v.as_str()) == Some("session_started")
+            && json.get("task").and_then(|v| v.as_str())
+                == Some("coordinate the radar prefix run")
+    })
+    .await
+    .unwrap_or_else(|| panic!("session never started:\n{}", daemon_log()));
+    let session_id = started
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .expect("started session id")
+        .to_string();
+    next_matching_ws_event(&mut ws, RUN_TIMEOUT, |json| {
+        json.get("event").and_then(|v| v.as_str()) == Some("round_complete")
+            && json.get("session_id").and_then(|v| v.as_str()) == Some(session_id.as_str())
+    })
+    .await
+    .unwrap_or_else(|| panic!("round 1 never completed:\n{}", daemon_log()));
+
+    // The parked session's own §1.5 declaration marks the live space.
+    let coordination_root = rig.home.path().join(".intendant").join("coordination");
+    let space_dir = poll_until(
+        "the session's coordination space to appear",
+        RUN_TIMEOUT,
+        || {
+            let root = coordination_root.clone();
+            async move {
+                std::fs::read_dir(&root).ok()?.flatten().map(|e| e.path()).find(|p| {
+                    std::fs::read_dir(p.join("sessions"))
+                        .is_ok_and(|mut entries| entries.next().is_some())
+                })
+            }
+        },
+        &daemon_log,
+    )
+    .await;
+    let space_key = space_dir
+        .file_name()
+        .expect("space dir basename")
+        .to_string_lossy()
+        .to_string();
+
+    // Two fixture declarations sharing a dirty path: the §2.7 pair
+    // overlap the radar flags. Written AFTER round 1, so round 1's
+    // request predates any coordination signal by construction.
+    for id in ["s-fake-a", "s-fake-b"] {
+        let doc = format!(
+            "---\nv: 1\nkind: session-declaration\nid: {id}\nbackend: native\ncreated_ms: 1\n---\n\
+             ## intent\noccupying the same space\n\n## dirty\n- shared/hot.rs\n"
+        );
+        std::fs::write(space_dir.join("sessions").join(format!("{id}.md")), doc)
+            .expect("write fixture declaration");
+    }
+    // The radar's deduplicated note write is the tick-completion proof:
+    // once an rn-* note exists, the same tick's snapshot publish (which
+    // follows the note writes) is microseconds behind — long past by
+    // the time the steer round-trips below.
+    poll_until(
+        "a radar note for the fixture overlap",
+        RUN_TIMEOUT,
+        || {
+            let notes_dir = space_dir.join("messages").join("daemon");
+            async move {
+                std::fs::read_dir(&notes_dir)
+                    .ok()?
+                    .flatten()
+                    .find(|e| e.file_name().to_string_lossy().starts_with("rn-"))
+                    .map(|_| ())
+            }
+        },
+        &daemon_log,
+    )
+    .await;
+
+    // Round 2 via the parked-steer fallback; the mock's own transcript
+    // expectation gates on the injected block.
+    ws.send(tokio_tungstenite::tungstenite::Message::Text(
+        serde_json::json!({
+            "action": "steer",
+            "session_id": session_id,
+            "id": "steer-radar-1",
+            "text": "continue with round two",
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .expect("send steer");
+    next_matching_ws_event(&mut ws, RUN_TIMEOUT, |json| {
+        json.get("event").and_then(|v| v.as_str()) == Some("round_complete")
+            && json.get("session_id").and_then(|v| v.as_str()) == Some(session_id.as_str())
+    })
+    .await
+    .unwrap_or_else(|| {
+        panic!(
+            "steered round 2 never completed:\n{}\nsession logs:\n{}",
+            daemon_log(),
+            tail(&rig.session_logs(), 6000)
+        )
+    });
+    ws.send(tokio_tungstenite::tungstenite::Message::Text(
+        serde_json::json!({ "action": "stop_session", "session_id": session_id })
+            .to_string()
+            .into(),
+    ))
+    .await
+    .expect("send stop_session");
+    next_matching_ws_event(&mut ws, RUN_TIMEOUT, |json| {
+        json.get("event").and_then(|v| v.as_str()) == Some("session_ended")
+            && json.get("session_id").and_then(|v| v.as_str()) == Some(session_id.as_str())
+    })
+    .await
+    .unwrap_or_else(|| panic!("stopped session never ended:\n{}", daemon_log()));
+    let _ = child.kill().await;
+
+    // ---- The §2.6 byte proof, from the provider-side request tap ----
+    let dumped = std::fs::read_to_string(&dump_path).expect("request dump exists");
+    let records: Vec<serde_json::Value> = dumped
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("dump line parses"))
+        .collect();
+    assert_eq!(
+        records.len(),
+        2,
+        "one request per round, nothing else:\n{dumped}"
+    );
+    let first = records[0]["messages_json"].as_str().expect("first request");
+    let second = records[1]["messages_json"].as_str().expect("second request");
+    let first_open = first.strip_suffix(']').expect("array serialization");
+    assert!(
+        second.starts_with(first_open),
+        "round 2's request must extend round 1's byte-for-byte:\n{first}\n{second}"
+    );
+    assert_eq!(
+        second.as_bytes()[first_open.len()],
+        b',',
+        "the extension is a pure append after the prior tail"
+    );
+
+    let first_messages: Vec<serde_json::Value> =
+        serde_json::from_str(first).expect("first request parses");
+    let second_messages: Vec<serde_json::Value> =
+        serde_json::from_str(second).expect("second request parses");
+    assert!(second_messages.len() > first_messages.len());
+    let expected_block = format!(
+        "[System] coordination v1 space={space_key}\n\
+         sessions: 2 active, 0 stale — s-fake-a(native), s-fake-b(native)"
+    );
+    let tail_message = second_messages.last().expect("non-empty request");
+    assert_eq!(tail_message["role"].as_str(), Some("user"));
+    assert_eq!(
+        tail_message["content"].as_str(),
+        Some(expected_block.as_str()),
+        "the §2.2 block is the NEW tail message"
+    );
+    assert!(
+        !first_messages.iter().any(|m| m["content"]
+            .as_str()
+            .is_some_and(|c| c.starts_with("[System] coordination v1 space="))),
+        "round 1 predates the signal — no block before the tail append"
+    );
+
+    // ---- §2.9: the block's conversation row in the turn record ----
+    let log_dir = rig
+        .home
+        .path()
+        .join(".intendant")
+        .join("logs")
+        .join(&session_id);
+    let rows = parsed_session_rows(&log_dir);
+    let messages = canonical_message_rows(&rows);
+    let block_row = user_message_row(&messages, &expected_block);
+    assert_eq!(
+        msg_field(block_row, "provenance").as_str(),
+        Some("system_injection"),
+        "the ruled steer-shaped record carries the injection provenance"
     );
 }
 

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -4823,7 +4823,12 @@ async fn coordination_radar_block_injects_as_a_pure_tail_append() {
     let _stdout_drain = drain_pipe_into(child.stdout.take().expect("stdout"), stdout_buf.clone());
     let daemon_log = {
         let stderr_buf = stderr_buf.clone();
-        move || stderr_buf.lock().map(|b| tail(&b, 4000)).unwrap_or_default()
+        move || {
+            stderr_buf
+                .lock()
+                .map(|b| tail(&b, 4000))
+                .unwrap_or_default()
+        }
     };
 
     let stderr_so_far = wait_for_output(&stderr_buf, "Dashboard: http://", RUN_TIMEOUT).await;
@@ -4870,8 +4875,7 @@ async fn coordination_radar_block_injects_as_a_pure_tail_append() {
     .expect("send create_session");
     let started = next_matching_ws_event(&mut ws, RUN_TIMEOUT, |json| {
         json.get("event").and_then(|v| v.as_str()) == Some("session_started")
-            && json.get("task").and_then(|v| v.as_str())
-                == Some("coordinate the radar prefix run")
+            && json.get("task").and_then(|v| v.as_str()) == Some("coordinate the radar prefix run")
     })
     .await
     .unwrap_or_else(|| panic!("session never started:\n{}", daemon_log()));
@@ -4895,10 +4899,14 @@ async fn coordination_radar_block_injects_as_a_pure_tail_append() {
         || {
             let root = coordination_root.clone();
             async move {
-                std::fs::read_dir(&root).ok()?.flatten().map(|e| e.path()).find(|p| {
-                    std::fs::read_dir(p.join("sessions"))
-                        .is_ok_and(|mut entries| entries.next().is_some())
-                })
+                std::fs::read_dir(&root)
+                    .ok()?
+                    .flatten()
+                    .map(|e| e.path())
+                    .find(|p| {
+                        std::fs::read_dir(p.join("sessions"))
+                            .is_ok_and(|mut entries| entries.next().is_some())
+                    })
             }
         },
         &daemon_log,
@@ -4995,7 +5003,9 @@ async fn coordination_radar_block_injects_as_a_pure_tail_append() {
         "one request per round, nothing else:\n{dumped}"
     );
     let first = records[0]["messages_json"].as_str().expect("first request");
-    let second = records[1]["messages_json"].as_str().expect("second request");
+    let second = records[1]["messages_json"]
+        .as_str()
+        .expect("second request");
     let first_open = first.strip_suffix(']').expect("array serialization");
     assert!(
         second.starts_with(first_open),


### PR DESCRIPTION
Second and final C2 slice (radar core = #571). The §2.8 delivery matrix, wired end to end:

- **Native seam** (§2.1, R6): per-turn fresh-read consult at the context-injection drain — one bounded `[System] coordination v1` tail append via the existing SystemInjection path, per-session dedup state threaded from `run_round_loop`, §2.9 `conversation_message_user` logging. Both severities; silent no-op without a daemon-published snapshot.
- **External ALERT-only steers** (§2.8): schema-rendered single lines through the per-backend `steer_turn` lane with targeted ContextInjection between-turns fallback (density-steer precedent; anchor now `external_events.rs:1397-1448`). Once-ever per distinct overlap set + 10-min per-recipient cooldown (`ExternalSteerLedger`, daemon-side beside the published state). No steer lifecycle events — matching the precedent and §2.8's queue-fallback semantics; ambient content provably never pushed at externals.
- **Rail badge** (§2.8, R8): `CoordinationRadar` AppEvent/OutboundEvent with `raised|resolved`, emitted by the radar task via a flag tracker keyed on the space (stable id ⇒ resolve always retracts its raise); new retractable `radar` attention kind in `attentionApplyEvent` (fragment edit; `app.html` regenerated).
- **Byte-identical-prefix e2e** (§2.6, RULED): opt-in mock request tap (`INTENDANT_MOCK_REQUEST_DUMP`, child-env only, rig-scrubbed) records exact serialized message Vecs; the test proves request N+1 = request N + `,<new tail>` (pure array append), the block is the new tail user message, absent from request N, and the session log row carries `system_injection` provenance.

The agent_loop provenance-parity pin tripped on the new seam exactly as designed and is re-pinned (9 → 10 add_user sites). PR D's staging markers consumed by this wiring are dropped.

Battery: fmt --check, clippy workspace -D warnings, full bins (4810), lib crates, headless e2e (32, incl. the new prefix test) — all green.