### PR TITLE
feat(agenda): serve the raw op log — GET /api/agenda/ops with since/item/limit cursor

### DIFF
--- a/docs/src/agenda-and-memory.md
+++ b/docs/src/agenda-and-memory.md
@@ -37,6 +37,16 @@ newer record versions, and a torn final line are preserved but skipped so an
 older binary does not destroy history it cannot interpret. Multiple daemon
 processes sharing one home detect growth and refold before reads and writes.
 
+The raw log itself is also served, read-only, at `GET /api/agenda/ops`
+(`agenda.read`; tunnel twin `api_agenda_ops`) for per-item history and
+manifest-revision diffs. `since` is a 0-based line cursor into the append-only
+file, `item` filters server-side to one item's operations, and `limit` pages
+the scan (default 500, capped at 2000). The preserve-don't-destroy rule
+extends to this read: a line the serving build cannot fold is returned
+verbatim with `known: false`, and a line that is not JSON at all is returned
+string-escaped with `unparseable: true` — the endpoint never hides history it
+cannot parse.
+
 The item log writes and flushes one complete JSON line per operation, but does
 not `fsync` each item operation. It survives ordinary process and daemon
 restarts; the v1 contract is not a guarantee against sudden power loss. The
@@ -612,6 +622,7 @@ routes:
 | Route | Permission | Purpose |
 |---|---|---|
 | `GET /api/agenda` | `agenda.read` | Items, status counts, skipped-line count, and the session-resolution join map |
+| `GET /api/agenda/ops` | `agenda.read` | Raw op-log page: `since` line cursor, `item` filter, unfoldable lines served verbatim |
 | `POST /api/agenda/op` | `agenda.write` | Apply one validated Agenda command |
 | `POST /api/agenda/reminders/policy` | `settings.manage` | Change owner reminder policy |
 

--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -1884,6 +1884,7 @@ response omits the header.
 | GET | `/api/session/current/history` | SessionManage | own origin | none | Serialized rollback History for the current session |
 | POST | `/api/session/current/rollback` | SessionManage | own origin | bounded | Roll the current session back to a round (optionally reverting files) |
 | GET | `/api/agenda` | AgendaRead | own origin | none | Agenda ledger snapshot: items (oldest first) plus status counts |
+| GET | `/api/agenda/ops` | AgendaRead | own origin | none | Raw agenda op-log page (since/item/limit cursor; unknown ops served verbatim) |
 | POST | `/api/agenda/op` | AgendaWrite | own origin | ≤ 16 MiB | Apply one agenda command (add, ask, answer, patch, transitions, or scheduled-session propose/approve/revoke) |
 | GET | `/api/agenda/blobs/{item_id}/{blob_id}/raw` | AgendaRead | own origin | none | Fetch one parked-ask preview blob's raw bytes (attachment; MIME sniffing disabled) |
 | GET | `/api/agenda/items/{item_id}/refs/drift` | AgendaRead | own origin | none | Re-hash one item's file refs against their attach digests (expand-time drift check) |

--- a/src/bin/caller/agenda/handle.rs
+++ b/src/bin/caller/agenda/handle.rs
@@ -514,6 +514,20 @@ impl AgendaHandle {
         (store.snapshot(), store.counts(), store.skipped_lines())
     }
 
+    /// One page of the raw op log (read-only; the `GET /api/agenda/ops`
+    /// surface). Holds the same store lock every append completes under,
+    /// so a page can never contain a torn in-process line — see
+    /// [`AgendaStore::read_ops`] for the cursor and forward-compat
+    /// contract.
+    pub(crate) fn read_ops(
+        &self,
+        since: u64,
+        item: Option<&str>,
+        limit: usize,
+    ) -> std::io::Result<super::store::AgendaOpsPage> {
+        self.lock().read_ops(since, item, limit)
+    }
+
     fn lock(&self) -> std::sync::MutexGuard<'_, AgendaStore> {
         // Poison recovery is sound here: disk is authoritative, and the
         // staleness check refolds from disk whenever lengths diverge.
@@ -1591,5 +1605,80 @@ mod tests {
         let run = recorded.effects[0].last_run.as_ref().unwrap();
         assert_eq!(run.state, "completed");
         assert_eq!(run.session_id.as_deref(), Some("sess-run-1"));
+    }
+
+    /// The op-log read shares the append lock: pages taken WHILE another
+    /// thread appends through the same handle only ever hold complete
+    /// envelopes — never a torn or partial line, never an `unparseable`
+    /// artifact of an in-flight write.
+    #[test]
+    fn read_ops_under_concurrent_appends_never_serves_torn_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        let bus = EventBus::new();
+        let handle = std::sync::Arc::new(AgendaHandle::new(
+            AgendaStore::open(dir.path()).unwrap(),
+            bus,
+            dir.path(),
+        ));
+        let item = handle
+            .apply(
+                AgendaCommand::Add {
+                    refs: Vec::new(),
+                    kind: AgendaKind::Task,
+                    title: "torn-read canary".into(),
+                    body: String::new(),
+                    tags: Vec::new(),
+                    due_ms: None,
+                    source: None,
+                },
+                None,
+            )
+            .unwrap();
+
+        const APPENDS: u64 = 40;
+        let writer = {
+            let handle = handle.clone();
+            let id = item.id.clone();
+            std::thread::spawn(move || {
+                for round in 0..APPENDS {
+                    handle
+                        .apply(
+                            AgendaCommand::Annotate {
+                                id: id.clone(),
+                                text: format!("note {round} — {}", "x".repeat(200)),
+                                source: None,
+                            },
+                            None,
+                        )
+                        .unwrap();
+                }
+            })
+        };
+        let assert_complete = |page: &crate::agenda::AgendaOpsPage| {
+            for entry in &page.ops {
+                assert_eq!(
+                    entry["known"],
+                    serde_json::Value::Bool(true),
+                    "a concurrent read must never surface a torn line: {entry}"
+                );
+                assert!(
+                    serde_json::from_value::<super::super::types::AgendaOpRecord>(
+                        entry["op"].clone()
+                    )
+                    .is_ok(),
+                    "served line must be a complete envelope: {entry}"
+                );
+            }
+        };
+        while !writer.is_finished() {
+            let page = handle.read_ops(0, None, 2000).unwrap();
+            assert_complete(&page);
+        }
+        writer.join().unwrap();
+        let page = handle.read_ops(0, None, 2000).unwrap();
+        assert_complete(&page);
+        assert_eq!(page.log_len, APPENDS + 1);
+        assert_eq!(page.ops.len(), (APPENDS + 1) as usize);
+        assert_eq!(page.next_since, page.log_len);
     }
 }

--- a/src/bin/caller/agenda/mod.rs
+++ b/src/bin/caller/agenda/mod.rs
@@ -44,7 +44,9 @@ pub(crate) use handle::AgendaHandle;
 pub(crate) use reminders::ReminderPolicyPatch;
 pub(crate) use scheduler::spawn_reminder_scheduler;
 pub(crate) use spawn_project::{recorded_session_project_root, SessionSpawnContext};
-pub(crate) use store::{file_ref_drift, AgendaError, AgendaStore};
+pub(crate) use store::{
+    file_ref_drift, AgendaError, AgendaOpsPage, AgendaStore, AGENDA_OPS_DEFAULT_LIMIT,
+};
 pub(crate) use types::{
     AgendaActor, AgendaAnswer, AgendaCommand, AgendaCounts, AgendaItem, AgendaStatus,
 };

--- a/src/bin/caller/agenda/store.rs
+++ b/src/bin/caller/agenda/store.rs
@@ -71,6 +71,33 @@ const KNOWN_OPS: [&str; 24] = [
 
 const LOG_FILE: &str = "agenda.jsonl";
 
+/// Default page size for [`AgendaStore::read_ops`] when the caller names
+/// none; the clamp ceiling is [`AGENDA_OPS_MAX_LIMIT`].
+pub(crate) const AGENDA_OPS_DEFAULT_LIMIT: usize = 500;
+/// Hard page-size ceiling for [`AgendaStore::read_ops`].
+pub(crate) const AGENDA_OPS_MAX_LIMIT: usize = 2000;
+
+/// One page of the raw op log, as `GET /api/agenda/ops` serves it.
+/// Serializes to exactly the response body:
+/// `{"ops":[…],"next_since":…,"log_len":…,"filtered":…}`.
+#[derive(Debug, serde::Serialize)]
+pub(crate) struct AgendaOpsPage {
+    /// Served entries, in log order. Each is
+    /// `{"seq":N,"known":bool,"op":<the line's JSON, verbatim>}`, or
+    /// `{"seq":N,"known":false,"unparseable":true,"raw":"<line>"}` for a
+    /// line that is not JSON at all.
+    pub(crate) ops: Vec<serde_json::Value>,
+    /// Resume cursor: the first seq this scan did not consume — last
+    /// returned seq + 1 when the page filled, otherwise `log_len`.
+    pub(crate) next_since: u64,
+    /// Total lines in the log right now. A value below a client's cursor
+    /// means the append-only contract was broken externally (the same
+    /// shrink [`AgendaStore::refresh_if_stale`] refolds through).
+    pub(crate) log_len: u64,
+    /// True when an `item` filter was applied to this page.
+    pub(crate) filtered: bool,
+}
+
 /// Start-now's default goal statement: the item quoted as data with its id
 /// so the spawned session's own (attributed) `ctl` can act on it. The
 /// confirm sheet's editable text replaces exactly this part; the mode coda
@@ -1607,6 +1634,111 @@ impl AgendaStore {
 
     pub(crate) fn counts(&self) -> AgendaCounts {
         counts(&self.items)
+    }
+
+    /// One page of the raw op log (read-only; `GET /api/agenda/ops`).
+    ///
+    /// `since` is a 0-based line cursor into `agenda.jsonl`. The log is
+    /// append-only — the daemon never truncates or rewrites it — so a
+    /// line index is a stable sequence number: line N today is line N
+    /// forever, and a cursor survives restarts and refolds. (External
+    /// tampering that shrinks the file surfaces as `log_len` dropping
+    /// below the cursor.)
+    ///
+    /// The fold's forward-compatibility rule extends to reads: a line
+    /// whose op vocabulary this build does not fold (`op.type` outside
+    /// [`KNOWN_OPS`], a newer line version) is still served VERBATIM,
+    /// marked `known:false` — an older server never HIDES history it
+    /// cannot parse, just as an older binary never destroys history it
+    /// cannot read. A line that is not JSON at all (crash-torn tail,
+    /// hand edit) is served as
+    /// `{"seq":N,"known":false,"unparseable":true,"raw":"<line>"}`.
+    ///
+    /// `item` filters to lines whose `op.id` equals it; lines carrying
+    /// no `op.id` (unparseable lines, foreign envelopes) are excluded
+    /// under the filter — they reference no item. `limit` is clamped to
+    /// [1, [`AGENDA_OPS_MAX_LIMIT`]]. Whitespace-only lines keep their
+    /// seq slot but are never served (fold parity: they are padding,
+    /// not history).
+    ///
+    /// Torn reads: the caller ([`super::AgendaHandle`]) holds the same
+    /// store lock every append completes under (`write_all` + flush
+    /// before release), so an in-process line can never be observed
+    /// half-written; cross-process appends are whole-line `O_APPEND`
+    /// writes — exactly the exposure [`Self::refresh_if_stale`]'s own
+    /// read path already carries.
+    pub(crate) fn read_ops(
+        &mut self,
+        since: u64,
+        item: Option<&str>,
+        limit: usize,
+    ) -> std::io::Result<AgendaOpsPage> {
+        // Converge with disk first (terminates a foreign torn tail and
+        // refreshes the fold), like every other read through the handle.
+        self.refresh_if_stale()?;
+        let limit = limit.clamp(1, AGENDA_OPS_MAX_LIMIT);
+        let bytes = match std::fs::read(&self.log_path) {
+            Ok(bytes) => bytes,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+            Err(err) => return Err(err),
+        };
+        let text = String::from_utf8_lossy(&bytes);
+        let mut ops: Vec<serde_json::Value> = Vec::new();
+        let mut log_len = 0u64;
+        // The first seq the scan did not consume; log_len unless the
+        // page filled mid-log.
+        let mut next_since: Option<u64> = None;
+        for (index, raw_line) in text.lines().enumerate() {
+            let seq = index as u64;
+            log_len = seq + 1;
+            if next_since.is_some() || seq < since {
+                continue;
+            }
+            let line = raw_line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            let entry = match serde_json::from_str::<serde_json::Value>(line) {
+                Ok(value) => {
+                    if let Some(want) = item {
+                        let referenced = value
+                            .get("op")
+                            .and_then(|op| op.get("id"))
+                            .and_then(serde_json::Value::as_str);
+                        if referenced != Some(want) {
+                            continue;
+                        }
+                    }
+                    let known = value
+                        .get("op")
+                        .and_then(|op| op.get("type"))
+                        .and_then(serde_json::Value::as_str)
+                        .is_some_and(|tag| KNOWN_OPS.contains(&tag));
+                    serde_json::json!({ "seq": seq, "known": known, "op": value })
+                }
+                Err(_) => {
+                    if item.is_some() {
+                        continue; // no op.id — excluded under the filter
+                    }
+                    serde_json::json!({
+                        "seq": seq,
+                        "known": false,
+                        "unparseable": true,
+                        "raw": line,
+                    })
+                }
+            };
+            ops.push(entry);
+            if ops.len() >= limit {
+                next_since = Some(seq + 1);
+            }
+        }
+        Ok(AgendaOpsPage {
+            ops,
+            next_since: next_since.unwrap_or(log_len),
+            log_len,
+            filtered: item.is_some(),
+        })
     }
 
     #[cfg(test)]
@@ -3887,5 +4019,225 @@ mod tests {
         // The foreign line survives on disk verbatim.
         let text = std::fs::read_to_string(dir.path().join(LOG_FILE)).unwrap();
         assert!(text.contains("sigil"));
+    }
+
+    /// Seed the read_ops fixture through the real command path (two
+    /// parks, one annotate, one complete — lines 0..=3), then append a
+    /// newer build's op referencing item A (4), an item-less foreign op
+    /// (5), and a non-JSON line (6) directly, as another binary or a
+    /// hand edit would. Returns `(store, item_a_id, item_b_id)`.
+    fn seeded_ops_store(dir: &Path) -> (AgendaStore, String, String) {
+        let mut store = AgendaStore::open(dir).unwrap();
+        let a = store
+            .apply_command(add_cmd("first"), owner(), 1000)
+            .unwrap();
+        let b = store.apply_command(add_cmd("second"), None, 2000).unwrap();
+        store
+            .apply_command(
+                AgendaCommand::Annotate {
+                    id: a.id.clone(),
+                    text: "progress note".into(),
+                    source: None,
+                },
+                None,
+                3000,
+            )
+            .unwrap();
+        store
+            .apply_command(
+                AgendaCommand::Complete {
+                    id: b.id.clone(),
+                    source: None,
+                },
+                None,
+                4000,
+            )
+            .unwrap();
+        let foreign = format!(
+            "{{\"v\":1,\"at_ms\":5000,\"op\":{{\"type\":\"journal_curate\",\"id\":\"{}\",\"note\":\"from a newer build\"}}}}\n\
+             {{\"v\":1,\"at_ms\":6000,\"op\":{{\"type\":\"compact_marker\"}}}}\n\
+             this line is not JSON at all\n",
+            a.id
+        );
+        let mut log = std::fs::File::options()
+            .append(true)
+            .open(store.log_path())
+            .unwrap();
+        log.write_all(foreign.as_bytes()).unwrap();
+        (store, a.id, b.id)
+    }
+
+    /// `GET /api/agenda/ops` mechanics (a, c, d): the full page serves
+    /// every line — known ops as full envelopes, unknown vocabulary
+    /// verbatim with `known:false`, non-JSON as `unparseable` — and the
+    /// since/limit window keeps `next_since`/`log_len` exact.
+    #[test]
+    fn read_ops_serves_every_line_and_windows_exactly() {
+        let dir = tempfile::tempdir().unwrap();
+        let (mut store, a, _b) = seeded_ops_store(dir.path());
+
+        let page = store.read_ops(0, None, 500).unwrap();
+        assert_eq!(page.log_len, 7);
+        assert_eq!(page.next_since, 7);
+        assert!(!page.filtered);
+        assert_eq!(page.ops.len(), 7);
+        for (index, entry) in page.ops.iter().enumerate() {
+            assert_eq!(entry["seq"].as_u64(), Some(index as u64));
+        }
+        // The four command-path lines are full envelopes this build
+        // folds: they round-trip through the typed record, so nothing
+        // partial was served.
+        for entry in &page.ops[..4] {
+            assert_eq!(entry["known"], serde_json::Value::Bool(true));
+            let record: AgendaOpRecord = serde_json::from_value(entry["op"].clone()).unwrap();
+            assert!(record.at_ms > 0);
+        }
+        assert_eq!(page.ops[0]["op"]["op"]["type"], "add");
+        assert_eq!(page.ops[2]["op"]["op"]["type"], "annotate");
+        assert_eq!(page.ops[3]["op"]["op"]["type"], "complete");
+        // (c) Unknown vocabulary: served VERBATIM, marked unknown.
+        assert_eq!(page.ops[4]["known"], serde_json::Value::Bool(false));
+        assert_eq!(page.ops[4]["op"]["op"]["type"], "journal_curate");
+        assert_eq!(page.ops[4]["op"]["op"]["id"], a.as_str());
+        assert_eq!(page.ops[4]["op"]["op"]["note"], "from a newer build");
+        assert_eq!(page.ops[5]["known"], serde_json::Value::Bool(false));
+        assert_eq!(page.ops[5]["op"]["op"]["type"], "compact_marker");
+        // (d) Non-JSON: unparseable, raw text preserved string-escaped.
+        assert_eq!(page.ops[6]["known"], serde_json::Value::Bool(false));
+        assert_eq!(page.ops[6]["unparseable"], serde_json::Value::Bool(true));
+        assert_eq!(page.ops[6]["raw"], "this line is not JSON at all");
+
+        // (a) Window math: a mid-log page fills and resumes exactly.
+        let page = store.read_ops(2, None, 3).unwrap();
+        let seqs: Vec<u64> = page
+            .ops
+            .iter()
+            .map(|e| e["seq"].as_u64().unwrap())
+            .collect();
+        assert_eq!(seqs, vec![2, 3, 4]);
+        assert_eq!(page.next_since, 5);
+        assert_eq!(page.log_len, 7);
+        let page = store.read_ops(page.next_since, None, 500).unwrap();
+        let seqs: Vec<u64> = page
+            .ops
+            .iter()
+            .map(|e| e["seq"].as_u64().unwrap())
+            .collect();
+        assert_eq!(seqs, vec![5, 6]);
+        assert_eq!(page.next_since, 7);
+        // A cursor at (or past) the tail returns an empty page that
+        // keeps pointing at the tail.
+        let page = store.read_ops(7, None, 500).unwrap();
+        assert!(page.ops.is_empty());
+        assert_eq!(page.next_since, 7);
+        let page = store.read_ops(100, None, 500).unwrap();
+        assert!(page.ops.is_empty());
+        assert_eq!(page.next_since, 7);
+        // The limit clamp floor: 0 is not "unbounded" and not "nothing".
+        let page = store.read_ops(0, None, 0).unwrap();
+        assert_eq!(page.ops.len(), 1);
+        assert_eq!(page.next_since, 1);
+    }
+
+    /// (b) The `item` filter serves exactly the lines whose `op.id` is
+    /// the requested item — unknown vocabulary included — and excludes
+    /// lines carrying no item reference (foreign item-less ops,
+    /// unparseable lines). The cursor stays a LINE cursor under the
+    /// filter, so a truncated filtered page resumes without re-serving.
+    #[test]
+    fn read_ops_item_filter_includes_only_that_items_ops() {
+        let dir = tempfile::tempdir().unwrap();
+        let (mut store, a, b) = seeded_ops_store(dir.path());
+
+        let page = store.read_ops(0, Some(&a), 500).unwrap();
+        assert!(page.filtered);
+        assert_eq!(page.log_len, 7);
+        assert_eq!(page.next_since, 7);
+        let seqs: Vec<u64> = page
+            .ops
+            .iter()
+            .map(|e| e["seq"].as_u64().unwrap())
+            .collect();
+        // A's add (0), A's annotate (2), the newer build's op on A (4);
+        // never B's lines, the item-less op (5), or the non-JSON line (6).
+        assert_eq!(seqs, vec![0, 2, 4]);
+        for entry in &page.ops {
+            assert_eq!(entry["op"]["op"]["id"], a.as_str());
+        }
+        assert_eq!(page.ops[2]["known"], serde_json::Value::Bool(false));
+
+        let page = store.read_ops(0, Some(&b), 500).unwrap();
+        let seqs: Vec<u64> = page
+            .ops
+            .iter()
+            .map(|e| e["seq"].as_u64().unwrap())
+            .collect();
+        assert_eq!(seqs, vec![1, 3]);
+
+        // Truncated filtered page: next_since is the line after the last
+        // served line, and resuming there serves the rest exactly once.
+        let page = store.read_ops(0, Some(&a), 2).unwrap();
+        let seqs: Vec<u64> = page
+            .ops
+            .iter()
+            .map(|e| e["seq"].as_u64().unwrap())
+            .collect();
+        assert_eq!(seqs, vec![0, 2]);
+        assert_eq!(page.next_since, 3);
+        let page = store.read_ops(page.next_since, Some(&a), 500).unwrap();
+        let seqs: Vec<u64> = page
+            .ops
+            .iter()
+            .map(|e| e["seq"].as_u64().unwrap())
+            .collect();
+        assert_eq!(seqs, vec![4]);
+        assert_eq!(page.next_since, 7);
+
+        // An id nothing references filters to an empty (but honest) page.
+        let page = store
+            .read_ops(0, Some("01NOSUCHITEMEVERPARKED0000"), 500)
+            .unwrap();
+        assert!(page.ops.is_empty());
+        assert!(page.filtered);
+        assert_eq!(page.next_since, 7);
+    }
+
+    /// (e) Reads interleaved with appends never serve a torn line: every
+    /// page taken between appends holds only complete envelopes, and the
+    /// tail advances by exactly one line per op. (The lock discipline
+    /// this relies on — reads and appends under one store mutex — is
+    /// exercised cross-thread in `handle.rs`.)
+    #[test]
+    fn read_ops_between_appends_never_serves_a_torn_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = AgendaStore::open(dir.path()).unwrap();
+        let id = store.apply_command(add_cmd("host"), None, 1).unwrap().id;
+        let mut last_len = store.read_ops(0, None, 500).unwrap().log_len;
+        assert_eq!(last_len, 1);
+        for round in 0..20u64 {
+            store
+                .apply_command(
+                    AgendaCommand::Annotate {
+                        id: id.clone(),
+                        text: format!("note {round}"),
+                        source: None,
+                    },
+                    None,
+                    2 + round,
+                )
+                .unwrap();
+            let page = store.read_ops(0, None, 2000).unwrap();
+            assert_eq!(page.log_len, last_len + 1);
+            assert_eq!(page.next_since, page.log_len);
+            assert_eq!(page.ops.len(), page.log_len as usize);
+            for entry in &page.ops {
+                // Complete lines only: every one parses as the typed
+                // record — a torn/partial line could not.
+                assert_eq!(entry["known"], serde_json::Value::Bool(true));
+                let record: AgendaOpRecord = serde_json::from_value(entry["op"].clone()).unwrap();
+                assert_eq!(record.op.item_id(), id);
+            }
+            last_len = page.log_len;
+        }
     }
 }

--- a/src/bin/caller/dashboard_control/api_sessions.rs
+++ b/src/bin/caller/dashboard_control/api_sessions.rs
@@ -248,6 +248,7 @@ pub(crate) async fn control_request_frame(
             api_session_context_snapshot_response(id, params.as_ref()).await
         }
         "api_agenda_list" => api_agenda_list_response(id, &runtime).await,
+        "api_agenda_ops" => api_agenda_ops_response(id, params.as_ref(), &runtime).await,
         "api_agenda_op" => api_agenda_op_response(id, params.as_ref(), &runtime).await,
         "api_agenda_ref_drift" => {
             api_agenda_ref_drift_response(id, params.as_ref(), &runtime).await
@@ -1296,6 +1297,39 @@ pub(crate) async fn api_agenda_list_response(
         id,
         crate::web_gateway::agenda_list_api_response(runtime.mcp_server.as_ref()).await,
         "agenda list",
+    )
+}
+
+/// Tunnel twin of `GET /api/agenda/ops` — `{since, item, limit}` ride
+/// `params` (all optional, same semantics as the query string); reuses
+/// the transport-neutral core.
+pub(crate) async fn api_agenda_ops_response(
+    id: String,
+    params: Option<&serde_json::Value>,
+    runtime: &ControlRuntime,
+) -> serde_json::Value {
+    let since = params
+        .and_then(|p| p.get("since"))
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    let item = params
+        .and_then(|p| p.get("item"))
+        .and_then(serde_json::Value::as_str)
+        .filter(|v| !v.is_empty())
+        .map(str::to_string);
+    let limit = params
+        .and_then(|p| p.get("limit"))
+        .and_then(serde_json::Value::as_u64);
+    frame_api_response(
+        id,
+        crate::web_gateway::agenda_ops_api_response(
+            since,
+            item.as_deref(),
+            limit,
+            runtime.mcp_server.as_ref(),
+        )
+        .await,
+        "agenda ops",
     )
 }
 

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -5836,6 +5836,7 @@ mod tests {
             ("api_session_current_history", Row, Some(Op::SessionManage)),
             ("api_session_current_rollback", Row, Some(Op::SessionManage)),
             ("api_agenda_list", Row, Some(Op::AgendaRead)),
+            ("api_agenda_ops", Row, Some(Op::AgendaRead)),
             ("api_agenda_op", Row, Some(Op::AgendaWrite)),
             ("api_agenda_ref_drift", Row, Some(Op::AgendaRead)),
             ("api_agenda_reminder_policy", Row, Some(Op::Settings)),

--- a/src/bin/caller/gateway_routes.rs
+++ b/src/bin/caller/gateway_routes.rs
@@ -366,6 +366,8 @@ pub(crate) enum RouteHandlerId {
     DashboardTabs,
     /// Agenda ledger snapshot (items + counts).
     AgendaList,
+    /// Raw op-log page (since/item/limit cursor; unknown ops verbatim).
+    AgendaOps,
     /// Apply one agenda command (add/ask/answer/patch/transitions/effects).
     AgendaOp,
     /// Raw bytes of one parked-ask preview blob (agenda blob store).
@@ -909,6 +911,20 @@ pub(crate) static ROUTES: &[Route] = &[
         "Agenda ledger snapshot: items (oldest first) plus status counts",
     )
     .with_tunnel(tunnel_method("api_agenda_list")),
+    // The raw append-only op log behind the fold, read-only: per-item
+    // history and manifest-revision diffs need the ops themselves, not
+    // the fold product. Lines this build cannot fold are served verbatim
+    // with known:false — an older server never hides history it cannot
+    // parse (the fold's preserve-don't-destroy rule, extended to reads).
+    op_route(
+        RouteMethod::Get,
+        PathPattern::Exact("/api/agenda/ops"),
+        PeerOperation::AgendaRead,
+        BodyPolicy::None,
+        RouteHandlerId::AgendaOps,
+        "Raw agenda op-log page (since/item/limit cursor; unknown ops served verbatim)",
+    )
+    .with_tunnel(tunnel_method("api_agenda_ops")),
     // Capped above Default: the rich-ask park command (`op:"ask"`)
     // legitimately carries the ≤8 MB preview budget as base64 JSON.
     op_route(

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -1186,6 +1186,16 @@ pub(crate) async fn serve_http_request(
                 )
                 .await;
             }
+            RouteHandlerId::AgendaOps => {
+                return handle_agenda_ops(
+                    stream,
+                    request_line,
+                    mcp_server,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
+            }
             RouteHandlerId::AgendaOp => {
                 // The authenticated edge: the pre-dispatch IAM gate bound
                 // this principal; no token names a session on this lane.

--- a/src/bin/caller/web_gateway/routes_agenda.rs
+++ b/src/bin/caller/web_gateway/routes_agenda.rs
@@ -1,8 +1,9 @@
-//! The agenda's HTTP surface: `GET /api/agenda` (ledger snapshot) and
-//! `POST /api/agenda/op` (apply one command), plus the transport-neutral
-//! cores their dashboard-control tunnel twins reuse. The IAM gate
-//! (`agenda.read` / `agenda.write`) runs pre-dispatch off the route rows;
-//! mutations funnel through the daemon's single-writer
+//! The agenda's HTTP surface: `GET /api/agenda` (ledger snapshot),
+//! `GET /api/agenda/ops` (raw op-log page), and `POST /api/agenda/op`
+//! (apply one command), plus the transport-neutral cores their
+//! dashboard-control tunnel twins reuse. The IAM gate (`agenda.read` /
+//! `agenda.write`) runs pre-dispatch off the route rows; mutations
+//! funnel through the daemon's single-writer
 //! [`crate::agenda::AgendaHandle`], which broadcasts `agenda_changed`.
 
 use super::*;

--- a/src/bin/caller/web_gateway/routes_agenda.rs
+++ b/src/bin/caller/web_gateway/routes_agenda.rs
@@ -186,6 +186,54 @@ pub(crate) async fn handle_agenda_list(
     write_api_response(stream, response, cors, fleet_origin).await;
 }
 
+/// Transport-neutral core of `GET /api/agenda/ops` (tunnel twin
+/// `api_agenda_ops`): one page of the raw append-only op log, for honest
+/// per-item history and manifest-revision diffs. `since` is a 0-based
+/// line cursor, `item` filters to one item's ops, `limit` defaults to
+/// [`crate::agenda::AGENDA_OPS_DEFAULT_LIMIT`] and is clamped by the
+/// store. Lines this build cannot fold are served verbatim with
+/// `known:false` — never hidden (see [`crate::agenda::AgendaStore::read_ops`]).
+pub(crate) async fn agenda_ops_api_response(
+    since: u64,
+    item: Option<&str>,
+    limit: Option<u64>,
+    mcp_server: Option<&Arc<crate::mcp::IntendantServer>>,
+) -> ApiResponse {
+    let Some(agenda) = agenda_handle(mcp_server).await else {
+        return ApiResponse::json_error(503, "agenda unavailable on this daemon");
+    };
+    let limit = limit
+        .map(|v| usize::try_from(v).unwrap_or(usize::MAX))
+        .unwrap_or(crate::agenda::AGENDA_OPS_DEFAULT_LIMIT);
+    let page: crate::agenda::AgendaOpsPage = match agenda.read_ops(since, item, limit) {
+        Ok(page) => page,
+        Err(err) => {
+            return ApiResponse::json_error(500, format!("reading agenda op log: {err}"));
+        }
+    };
+    match serde_json::to_value(&page) {
+        Ok(value) => ApiResponse::json(200, JsonBody::Value(value)),
+        Err(err) => ApiResponse::json_error(500, format!("encoding agenda op page: {err}")),
+    }
+}
+
+pub(crate) async fn handle_agenda_ops(
+    stream: DemuxStream,
+    request_line: &str,
+    mcp_server: Option<Arc<crate::mcp::IntendantServer>>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
+) {
+    let since = query_param(request_line, "since")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    let item = query_param(request_line, "item").filter(|v| !v.is_empty());
+    let limit = query_param(request_line, "limit").and_then(|v| v.parse().ok());
+    let response =
+        agenda_ops_api_response(since, item.as_deref(), limit, mcp_server.as_ref()).await;
+    write_api_response(stream, response, cors, fleet_origin).await;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Daemon slice 1 of the Agenda redesign program: serve the agenda's raw append-only op log over the gateway, read-only. Today only the fold product ships (`GET /api/agenda`); an honest per-item history and manifest-revision diffs need the ops themselves.

## Endpoint

`GET /api/agenda/ops?since=<u64>&item=<id>&limit=<u32>` — `agenda.read`, own-origin CORS, no body; tunnel twin `api_agenda_ops` (params `{since?, item?, limit?}`), IAM derived from the row.

- **`since`** is a 0-based line cursor into `agenda.jsonl`. The log is append-only — the daemon never truncates or rewrites it — so a line index is a stable sequence number across restarts and refolds. External tampering that shrinks the file surfaces as `log_len` dropping below the cursor.
- **`item`** filters server-side to lines whose `op.id` equals it (the field every op variant carries; unknown-vocabulary ops referencing the item are included). Lines with no `op.id` — item-less foreign ops, unparseable lines — are excluded under the filter.
- **`limit`** defaults to 500, clamped to [1, 2000] in the store (uniform for any future caller).

Response:

```json
{
  "ops": [
    {"seq": 0, "known": true,  "op": {"v":1, "at_ms": …, "actor": …, "op": {"type": "add", "id": "01…", …}}},
    {"seq": 7, "known": false, "op": {"v":1, "at_ms": …, "op": {"type": "journal_curate", …}}},
    {"seq": 9, "known": false, "unparseable": true, "raw": "<the line, string-escaped>"}
  ],
  "next_since": 10,
  "log_len": 10,
  "filtered": false
}
```

`op` is the whole log line parsed as raw JSON (envelope included — the UI needs `at_ms`/`actor` for history). `next_since` is the resume cursor: last served seq + 1 when the page filled, otherwise `log_len`. Whitespace-only lines keep their seq slot but are never served (fold parity: padding, not history).

## Unknown-ops-verbatim rationale

The fold's forward-compatibility rule — an older binary never destroys history it can't read — extends to reads: an older server never **hides** history it can't parse. A line whose op vocabulary this build does not fold (`op.type` outside `KNOWN_OPS`, newer line version) is served verbatim with `known: false`, never dropped or partially parsed; a line that is not JSON at all is served as `{"seq":N,"known":false,"unparseable":true,"raw":…}`.

## Read path / locking

`AgendaStore::read_ops` runs under the same store mutex every append completes under (`write_all` + flush before release), so a page can never contain a torn in-process line; cross-process appends are whole-line `O_APPEND` writes — exactly the exposure `refresh_if_stale`'s own read path already carries (and the read converges with disk through it first, like every other read via the handle).

## Table/docs plumbing

Route declared as a `ROUTES` row + `RouteHandlerId::AgendaOps` arm (never the dispatch chain); tunnel twin on the row's `tunnel:` column; `tunnel_method_partition_is_pinned` updated; generated endpoint table in `docs/src/web-dashboard.md` regenerated (docs pin green); a storage-area paragraph + surfaces-table row in `docs/src/agenda-and-memory.md`. The SPA's `DAEMON_API_HTTP_MAP` descriptor entry deliberately rides the UI slice (its coverage pin is a frozen set; no daemon-side test requires the entry).

## Tests

- `agenda::store::tests::read_ops_serves_every_line_and_windows_exactly` — full-page service (known envelopes round-trip through the typed record), unknown-verbatim, unparseable, since/limit windowing, `next_since`/`log_len` math, limit clamp floor.
- `agenda::store::tests::read_ops_item_filter_includes_only_that_items_ops` — filter includes exactly that item's lines (unknown vocabulary included), excludes item-less and unparseable lines; truncated filtered pages resume without re-serving.
- `agenda::store::tests::read_ops_between_appends_never_serves_a_torn_line` — interleaved append/read: complete envelopes only, tail advances one line per op.
- `agenda::handle::tests::read_ops_under_concurrent_appends_never_serves_torn_lines` — cross-thread canary: pages read while another thread appends through the handle hold only complete envelopes.
- Existing pins updated/passing: `tunnel_method_partition_is_pinned`, `endpoint_docs_match_chapter`, `daemon_api_http_map_mirrors_gateway_routes`, table invariants, body-cap pins.

## Follow-ups (deferred by design)

- Dashboard UI wiring (per-item history panel, revision diffs) + the SPA `DAEMON_API_HTTP_MAP` entry — the UI slice.
- `ctl` verb and MCP tool surfaces for the op log.
- Occurrences endpoint (journal read) and fold-derived next-fire fields.

## Battery (local, on the final tree)

- `cargo fmt --check` — clean
- `cargo clippy --workspace -- -D warnings` — clean
- `cargo test -p intendant --bins` — caller `4828 passed; 0 failed; 10 ignored`, connect `148 passed`, runtime `97 passed`
