### PR TITLE
feat(dashboard): Agenda redesign slice A — lenses, cards, inspector

### DIFF
--- a/src/bin/caller/agenda/types.rs
+++ b/src/bin/caller/agenda/types.rs
@@ -2529,7 +2529,7 @@ mod tests {
             "item.status === 'done' && item.ask && item.answer",
             "item.answer.delivered === false",
             "answered · awaiting pickup",
-            "agenda-chip pickup",
+            "agendaChipHtml('answered · awaiting pickup', 'sky'",
         ] {
             assert!(
                 app.contains(marker),

--- a/static/app/31-ui2-foundation.js
+++ b/static/app/31-ui2-foundation.js
@@ -52,6 +52,7 @@ const UI2_ICON_PATHS = {
   branch: '<circle cx="6" cy="6" r="2.4"/><circle cx="6" cy="18" r="2.4"/><circle cx="18" cy="8" r="2.4"/><path d="M6 8.4v7.2"/><path d="M18 10.4c0 4.2-6 1.8-6 5.6"/>',
 
   // — production glyphs the prototype lacked (drawn to the same grid) —
+  bell: '<path d="M6 15.5V11a6 6 0 0 1 12 0v4.5l1.6 2.6H4.4z"/><path d="M10 20.6a2.2 2.2 0 0 0 4 0"/>',
   close: '<path d="M6 6l12 12"/><path d="M18 6L6 18"/>',
   back: '<path d="M15 6l-6 6 6 6"/>',
   copy: '<rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h10"/>',

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -4119,6 +4119,41 @@ function updateQuestionProgress() {
 // Grid stays — zooming a preview is part of reading the record. A deleted
 // blob (retire prunes them) degrades to the same named "unavailable"
 // placeholder, never a broken card.
+
+// The ONE iframe factory and the ONE srcdoc writer for agent-authored
+// preview HTML, shared by every consumer (this question rail and the
+// Agenda tab's preview thumbnails/sheet). Centralizing them keeps the
+// pinned invariant checkable: the sandbox attribute is set in exactly one
+// place and the document is written in exactly one place, bundle-wide
+// (question_preview_iframe_sandbox_is_pinned counts both).
+function createSandboxedPreviewFrame(className, title) {
+  const frame = document.createElement('iframe');
+  frame.className = className;
+  frame.setAttribute('sandbox', 'allow-scripts');
+  frame.setAttribute('referrerpolicy', 'no-referrer');
+  frame.title = title || 'preview';
+  frame.tabIndex = -1;
+  return frame;
+}
+// Blob bytes are immutable per upload id, so fetched documents cache by
+// URL — re-renders re-hydrate without a round trip.
+const sandboxedPreviewHtmlCache = new Map();
+function fetchSandboxedPreviewInto(frame, url, onMissing) {
+  const cached = sandboxedPreviewHtmlCache.get(url);
+  const write = (html) => { frame.srcdoc = html; };
+  if (cached !== undefined) {
+    write(cached);
+    return;
+  }
+  fetch(url)
+    .then((r) => (r.ok ? r.text() : Promise.reject(new Error(`HTTP ${r.status}`))))
+    .then((html) => {
+      sandboxedPreviewHtmlCache.set(url, html);
+      write(html);
+    })
+    .catch(() => { if (onMissing) onMissing(); });
+}
+
 function appendQuestionPreviews(block, q, qIndex, archive) {
   const previews = Array.isArray(q.previews) ? q.previews : [];
   if (!previews.length) return;
@@ -4250,16 +4285,9 @@ function appendQuestionPreviews(block, q, qIndex, archive) {
       });
 
     if (p.kind === 'html' && p.url) {
-      const frame = document.createElement('iframe');
-      frame.className = 'question-preview-frame';
-      frame.setAttribute('sandbox', 'allow-scripts');
-      frame.setAttribute('referrerpolicy', 'no-referrer');
-      frame.title = p.label || 'preview';
+      const frame = createSandboxedPreviewFrame('question-preview-frame', p.label || 'preview');
       card.appendChild(frame);
-      fetch(p.url)
-        .then((r) => (r.ok ? r.text() : Promise.reject(new Error(`HTTP ${r.status}`))))
-        .then((html) => { frame.srcdoc = html; })
-        .catch(() => { frame.replaceWith(missingChip(p)); });
+      fetchSandboxedPreviewInto(frame, p.url, () => { frame.replaceWith(missingChip(p)); });
     } else if (p.kind === 'image' && p.url) {
       const img = document.createElement('img');
       img.className = 'question-preview-image';

--- a/static/app/manifest.txt
+++ b/static/app/manifest.txt
@@ -27,6 +27,7 @@ ui2-sessions.css
 ui2-activity.css
 ui2-activity-panes.css
 ui2-agenda.css
+ui2-agenda-inspector.css
 ui2-memory.css
 ui2-grid.css
 ui2-live.css
@@ -86,11 +87,15 @@ ui2-activity.js
 46-recording-replay.js
 47-annotation-clips.js
 # Agenda must evaluate BEFORE the router (48): a #agenda deep link makes the
-# router's eval-time boot call agendaOnTabShown(), which reads this fragment's
-# module-level lets — they must be initialized by then (deep-link TDZ rule).
-# Its own top level declares only lets/functions; daemonApi (32), routeTo (48),
-# escapeHtml (52) are reached from inside functions at runtime.
+# router's eval-time boot call agendaOnTabShown(), which reads these three
+# fragments' module-level lets/consts — they must be initialized by then
+# (deep-link TDZ rule). Their top levels declare only lets/consts/functions;
+# daemonApi (32), routeTo (48), escapeHtml (52) are reached from inside
+# functions at runtime. Order within the trio: data layer, then the card
+# surface, then the inspector (each consumes the previous one's state).
 ui2-agenda.js
+ui2-agenda-cards.js
+ui2-agenda-inspector.js
 # Memory: same deep-link TDZ rule as agenda — a #memory deep link makes the
 # router's eval-time boot call memoryOnTabShown(), which reads this fragment's
 # module-level lets. Top level declares only lets/functions.

--- a/static/app/ui2-agenda-cards.js
+++ b/static/app/ui2-agenda-cards.js
@@ -461,7 +461,10 @@ function agendaCardChips(item) {
     chips.push(agendaChipHtml('dismissed · still open', 'neutral',
       agendaDismissedTip(item.dismissed), true));
   }
-  if (item.answer && item.answer.delivered === false) {
+  // Answered ask whose delivery reached no session (the daemon-recorded
+  // `delivered: false` marker; absent data claims nothing).
+  if (item.status === 'done' && item.ask && item.answer
+    && item.answer.delivered === false) {
     chips.push(agendaChipHtml('answered · awaiting pickup', 'sky',
       'No live session heard the answer — the asker’s successor reads it at session start', true));
   }
@@ -636,10 +639,11 @@ function agendaQaPillsHtml(item, qi) {
 
 // Preview thumbnails for one question — the "show, then ask" cards.
 // SECURITY INVARIANT (same as the question rail): agent-authored html
-// renders ONLY inside `<iframe sandbox="allow-scripts">` populated via
-// srcdoc from an authenticated fetch — opaque origin, never same-origin,
-// never blob:/createObjectURL. Bytes come from the agenda blob store
-// route the payload names.
+// renders ONLY inside a sandboxed srcdoc iframe with an opaque origin —
+// built exclusively by the shared createSandboxedPreviewFrame factory and
+// filled by the shared fetchSandboxedPreviewInto writer (fragment 41; the
+// pinned single-writer invariant). This renderer emits placeholder slots;
+// agendaHydratePreviewFrames swaps them for real frames.
 function agendaPreviewStripHtml(item, qi, ctx) {
   const q = item.ask && item.ask.questions[qi];
   const previews = (q && q.previews) || [];
@@ -654,8 +658,8 @@ function agendaPreviewStripHtml(item, qi, ctx) {
     const tone = answered ? 'green' : 'iris';
     let media;
     if (p.kind === 'html' && p.url) {
-      media = `<iframe class="ag2-prev-frame" sandbox="allow-scripts" referrerpolicy="no-referrer"
-        title="${escapeHtml(p.label || 'preview')}" data-preview-url="${escapeHtml(p.url)}" tabindex="-1"></iframe>`;
+      media = `<span class="ag2-prev-slot" data-preview-url="${escapeHtml(p.url)}"
+        data-preview-title="${escapeHtml(p.label || 'preview')}"></span>`;
     } else if (p.kind === 'image' && p.url) {
       media = `<img class="ag2-prev-img" loading="lazy" src="${escapeHtml(p.url)}" alt="${escapeHtml(p.label || 'preview')}" />`;
     } else if (p.kind === 'text' && p.content) {
@@ -682,32 +686,24 @@ function agendaPreviewStripHtml(item, qi, ctx) {
   return `<div class="ag2-prevs${ctx === 'insp' ? ' insp' : ''}">${cards.join('')}</div>`;
 }
 
-// Hydrate sandboxed preview frames after an innerHTML render: fetch the
-// blob once (cached per url) and hand it to srcdoc. A failed fetch
-// degrades to a named unavailable chip, never a broken card.
-const agendaPreviewHtmlCache = new Map();
+// Hydrate preview slots after an innerHTML render: each slot becomes a
+// sandboxed frame from the shared factory (fragment 41 — the pinned
+// single-factory/single-writer pattern), filled from the blob store. A
+// failed fetch degrades to a named unavailable chip, never a broken card.
 function agendaHydratePreviewFrames(root) {
-  root.querySelectorAll('iframe.ag2-prev-frame[data-preview-url]').forEach((frame) => {
-    const url = frame.dataset.previewUrl;
-    if (!url || frame.dataset.loaded) return;
-    frame.dataset.loaded = '1';
-    const cached = agendaPreviewHtmlCache.get(url);
-    if (cached !== undefined) {
-      frame.srcdoc = cached;
-      return;
-    }
-    fetch(url)
-      .then((r) => (r.ok ? r.text() : Promise.reject(new Error(`HTTP ${r.status}`))))
-      .then((html) => {
-        agendaPreviewHtmlCache.set(url, html);
-        frame.srcdoc = html;
-      })
-      .catch(() => {
-        const chip = document.createElement('span');
-        chip.className = 'ag2-prev-missing';
-        chip.textContent = 'preview unavailable (blob deleted from the store)';
-        frame.replaceWith(chip);
-      });
+  root.querySelectorAll('.ag2-prev-slot[data-preview-url]').forEach((slot) => {
+    const url = slot.dataset.previewUrl;
+    if (!url) return;
+    const full = slot.dataset.previewFull === '1';
+    const frame = createSandboxedPreviewFrame(
+      full ? 'ag2-prev-frame full' : 'ag2-prev-frame', slot.dataset.previewTitle);
+    slot.replaceWith(frame);
+    fetchSandboxedPreviewInto(frame, url, () => {
+      const chip = document.createElement('span');
+      chip.className = 'ag2-prev-missing';
+      chip.textContent = 'preview unavailable (blob deleted from the store)';
+      frame.replaceWith(chip);
+    });
   });
 }
 

--- a/static/app/ui2-agenda-cards.js
+++ b/static/app/ui2-agenda-cards.js
@@ -1,0 +1,1075 @@
+// Agenda tab surface (redesign slice A): the lens bar, compose bar, card
+// list, and footer ledger. Builds its DOM inside the existing #tab-agenda
+// container (the shell fragment stays untouched; the legacy static markup
+// is replaced at boot). Data + derivations live in ui2-agenda.js; the
+// inspector, sheets, and reminder-policy popover in
+// ui2-agenda-inspector.js. Same module, so cross-fragment function calls
+// are plain hoisted calls; module-level lets stay within their fragment.
+//
+// Every item-authored string renders through escapeHtml; ask preview HTML
+// renders only inside sandboxed srcdoc iframes (agendaHydratePreviewFrames).
+
+// ---- Lens registry ----
+// The extensible seam for later slices: a lens is {id, label, groups()}.
+// The graph (constellation) and plan (Upcoming horizon) lenses land as
+// follow-up slices by ADDING entries here — nothing else changes.
+const AGENDA_LENSES = [
+  { id: 'now', label: 'Needs you', groups: () => agendaLensGroupsNow() },
+  { id: 'open', label: 'Open', groups: () => agendaLensGroupsOpen() },
+  { id: 'hubs', label: 'By hub', groups: () => agendaLensGroupsHubs() },
+  { id: 'questions', label: 'Questions', groups: () => agendaLensGroupsQuestions() },
+  { id: 'archive', label: 'Archive', groups: () => agendaLensGroupsArchive() },
+];
+
+const AGENDA_COMPOSE_PLACEHOLDERS = {
+  task: 'Park a task — one actionable line; details can follow in the item…',
+  note: 'Park a note — an idea, a decision, anything worth keeping…',
+  question: 'Park a question — non-blocking; answer it whenever…',
+};
+
+let agendaComposeKind = 'task';
+
+// ---- Scaffold ----
+
+function agendaEnsureScaffold() {
+  const pane = document.getElementById('tab-agenda');
+  if (!pane || document.getElementById('ag2-root')) return;
+  pane.innerHTML = `
+  <div class="ag2" id="ag2-root">
+    <main class="ag2-main" id="ag2-main">
+      <div class="ag2-inner">
+        <div class="ag2-head">
+          <div>
+            <h2 class="ag2-title">Agenda</h2>
+            <p class="ag2-sub">Parked intent that outlives any one session — one ledger for this daemon, every project.</p>
+          </div>
+          <button type="button" class="ag2-bell" id="ag2-bell" title="Reminder delivery policy — owner authority (settings.manage)">
+            ${typeof ui2Icon === 'function' ? ui2Icon('bell', 14) : ''}<span>Reminders</span><span class="ag2-bell-dot" id="ag2-bell-dot" hidden title="Quiet hours are active now"></span>
+          </button>
+        </div>
+        <div class="ag2-compose">
+          <div class="ag2-seg" id="ag2-kind-seg" role="group" aria-label="Kind">
+            <button type="button" data-kind="task" class="active">Task</button>
+            <button type="button" data-kind="note">Note</button>
+            <button type="button" data-kind="question">Question</button>
+          </div>
+          <input id="ag2-compose-title" type="text" maxlength="500" autocomplete="off"
+                 placeholder="${escapeHtml(AGENDA_COMPOSE_PLACEHOLDERS.task)}" aria-label="New agenda item title" />
+          <select id="ag2-compose-due" aria-label="Reminder"
+                  title="A due time delivers a reminder to you — it never authorizes work">
+            <option value="">No reminder</option>
+            <option value="3h">Remind in 3 hours</option>
+            <option value="eve">This evening 18:00</option>
+            <option value="tom">Tomorrow 09:00</option>
+            <option value="mon">Next Monday 09:00</option>
+          </select>
+          <button type="button" class="ag2-park" id="ag2-park">Park</button>
+        </div>
+        <div class="ag2-lensbar">
+          <div class="ag2-seg ag2-lenses" id="ag2-lenses" role="tablist" aria-label="Agenda lens"></div>
+          <span class="ag2-spacer"></span>
+          <button type="button" class="ag2-fchip" id="ag2-f-blocked"
+                  title="Open items with an uncleared blocker or unmet prerequisite — derived at render, never stored"></button>
+          <button type="button" class="ag2-fchip" id="ag2-f-frontier"
+                  title="The un-triaged frontier: open items newer than the last triage summary, or unplaced with no triage note — the triage mandate’s scope">frontier</button>
+          <input id="ag2-search" class="ag2-search" type="text" autocomplete="off"
+                 placeholder="Search the ledger — press /" aria-label="Search the agenda" />
+        </div>
+        <div class="ag2-notice" id="ag2-notice" hidden></div>
+        <div id="ag2-groups"></div>
+        <div class="ag2-ledger" id="ag2-ledger"></div>
+      </div>
+    </main>
+    <div class="ag2-inspector-backdrop" id="ag2-inspector-backdrop" hidden></div>
+    <aside class="ag2-inspector" id="ag2-inspector" aria-label="Agenda item inspector"></aside>
+  </div>`;
+  agendaWireScaffold();
+}
+
+function agendaWireScaffold() {
+  const kindSeg = document.getElementById('ag2-kind-seg');
+  const title = document.getElementById('ag2-compose-title');
+  kindSeg.querySelectorAll('button[data-kind]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      agendaComposeKind = btn.dataset.kind;
+      kindSeg.querySelectorAll('button').forEach((b) =>
+        b.classList.toggle('active', b === btn));
+      title.placeholder = AGENDA_COMPOSE_PLACEHOLDERS[agendaComposeKind]
+        || AGENDA_COMPOSE_PLACEHOLDERS.task;
+    });
+  });
+  document.getElementById('ag2-park').addEventListener('click', agendaComposePark);
+  title.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      agendaComposePark();
+    }
+  });
+  document.getElementById('ag2-search').addEventListener('input', (e) => {
+    agendaSearch = e.target.value;
+    agendaRenderTab();
+  });
+  document.getElementById('ag2-f-blocked').addEventListener('click', () => {
+    agendaFilterBlocked = !agendaFilterBlocked;
+    agendaRenderTab();
+  });
+  document.getElementById('ag2-f-frontier').addEventListener('click', () => {
+    agendaFilterFrontier = !agendaFilterFrontier;
+    agendaRenderTab();
+  });
+  document.getElementById('ag2-bell').addEventListener('click', (e) => {
+    e.stopPropagation();
+    agendaBellToggle();
+  });
+  const groups = document.getElementById('ag2-groups');
+  groups.addEventListener('click', agendaGroupsClick);
+  groups.addEventListener('input', agendaGroupsInput);
+  groups.addEventListener('keydown', agendaGroupsKeydown);
+  // Tab-scoped keyboard: '/' focuses search, 'n' the composer, Escape
+  // closes overlays inspector-last. Skips typing contexts; the approval
+  // rail's y/n shortcuts live on the Activity tab so there is no overlap.
+  document.addEventListener('keydown', (e) => {
+    if (!agendaTabVisible()) return;
+    if (e.key === 'Escape') {
+      // The start-now sheet owns its own Escape handler — never chain past
+      // it into the inspector on the same keypress.
+      const startSheet = document.getElementById('agenda-start-sheet');
+      if (startSheet && !startSheet.hidden) return;
+      if (agendaSheetClose() || agendaBellClose() || agendaCloseInspector()) {
+        e.preventDefault();
+      }
+      return;
+    }
+    const t = e.target;
+    const tag = (t && t.tagName) || '';
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT'
+      || (t && t.isContentEditable)) return;
+    if (e.metaKey || e.ctrlKey || e.altKey) return;
+    if (e.key === '/') {
+      e.preventDefault();
+      document.getElementById('ag2-search')?.focus();
+    } else if (e.key === 'n') {
+      e.preventDefault();
+      document.getElementById('ag2-compose-title')?.focus();
+    }
+  });
+}
+
+// Compose-bar reminder presets → an absolute due instant (ms).
+function agendaDuePresetMs(value) {
+  const now = new Date();
+  if (value === '3h') return Date.now() + 3 * 36e5;
+  if (value === 'eve') {
+    const d = new Date();
+    d.setHours(18, 0, 0, 0);
+    if (d.getTime() <= Date.now()) d.setDate(d.getDate() + 1);
+    return d.getTime();
+  }
+  if (value === 'tom') {
+    const d = new Date(now);
+    d.setDate(d.getDate() + 1);
+    d.setHours(9, 0, 0, 0);
+    return d.getTime();
+  }
+  if (value === 'mon') {
+    const d = new Date(now);
+    d.setHours(9, 0, 0, 0);
+    do { d.setDate(d.getDate() + 1); } while (d.getDay() !== 1);
+    return d.getTime();
+  }
+  return null;
+}
+
+async function agendaComposePark() {
+  const title = document.getElementById('ag2-compose-title');
+  const due = document.getElementById('ag2-compose-due');
+  const btn = document.getElementById('ag2-park');
+  const text = (title.value || '').trim();
+  if (!text) {
+    agendaFlashError('Give it a one-line title first.');
+    title.focus();
+    return;
+  }
+  const params = { op: 'add', kind: agendaComposeKind, title: text };
+  const dueMs = agendaDuePresetMs(due.value);
+  if (dueMs) params.due_ms = dueMs;
+  const ok = await agendaSendOp(params, btn);
+  if (ok) {
+    title.value = '';
+    due.value = '';
+    title.focus();
+    if (typeof showControlToast === 'function') {
+      showControlToast('success', `Parked${dueMs ? ' — reminder set' : ''}.`);
+    }
+  }
+}
+
+// ---- Lens group computation ----
+
+function agendaSearchMatch(item, q) {
+  if (!q) return true;
+  return String(item.title || '').toLowerCase().includes(q)
+    || String(item.body || '').toLowerCase().includes(q)
+    || (item.tags || []).some((t) => String(t).toLowerCase().includes(q))
+    || String(item.id || '').toLowerCase().includes(q);
+}
+
+// The un-triaged frontier — the triage mandate's declared scope: open
+// items newer than the newest triage summary (`triage:summary` tag), or
+// unplaced with no triage annotation; summaries themselves excluded. A
+// render-side convention over ordinary data, like the rank parse.
+function agendaFrontierPredicate() {
+  const newestSummary = Math.max(0, ...(agendaItems || [])
+    .filter((x) => (x.tags || []).includes('triage:summary'))
+    .map((x) => (x.provenance && x.provenance.created_ms) || 0));
+  return (x) => x.status === 'open'
+    && !(x.tags || []).includes('triage:summary')
+    && (((x.provenance && x.provenance.created_ms) || 0) > newestSummary
+      || (!x.part_of && !(x.annotations || []).some((a) => a.source === 'triage')));
+}
+
+function agendaFilteredPool() {
+  const q = agendaSearch.trim().toLowerCase();
+  let pool = (agendaItems || []).filter((item) => agendaSearchMatch(item, q));
+  if (agendaFilterBlocked) pool = pool.filter((item) => agendaItemIsBlocked(item));
+  if (agendaFilterFrontier) pool = pool.filter(agendaFrontierPredicate());
+  return pool;
+}
+
+function agendaByNew(a, b) {
+  const am = (a.provenance && a.provenance.created_ms) || 0;
+  const bm = (b.provenance && b.provenance.created_ms) || 0;
+  if (bm !== am) return bm - am;
+  return a.id < b.id ? 1 : -1;
+}
+
+// The Attend ordering: ranked ascending first (the triage mandate's
+// declared "rank N" convention, parsed in agendaTriageInfo), unranked
+// after, ties newest-updated first.
+function agendaAttendOrder(a, b) {
+  const ra = agendaTriageInfo(a);
+  const rb = agendaTriageInfo(b);
+  const ka = ra && ra.rank !== null ? ra.rank : Infinity;
+  const kb = rb && rb.rank !== null ? rb.rank : Infinity;
+  if (ka !== kb) return ka - kb;
+  return (b.updated_ms || 0) - (a.updated_ms || 0);
+}
+
+function agendaLensGroupsNow() {
+  const pool = agendaFilteredPool();
+  const seen = new Set();
+  const take = (arr) => arr.filter((x) => !seen.has(x.id) && (seen.add(x.id), true));
+  const answer = take(pool
+    .filter((x) => x.kind === 'question' && x.status === 'open' && !x.dismissed)
+    .sort(agendaByNew));
+  const approve = take(pool.filter((x) => {
+    const st = agendaEffectState(x);
+    return x.status === 'open' && st && st.kind === 'pending';
+  }));
+  const suspended = take(pool.filter((x) => {
+    const st = agendaEffectState(x);
+    return st && st.kind === 'suspended';
+  }));
+  const overdue = take(pool.filter((x) =>
+    x.status === 'open' && x.due_ms && x.due_ms < Date.now()));
+  const attend = take(pool
+    .filter((x) => x.status === 'open' && agendaTriageInfo(x))
+    .sort(agendaAttendOrder));
+  const groups = [];
+  if (answer.length) {
+    groups.push({
+      label: 'Answer',
+      hint: 'parked questions — nothing blocks, nothing expires; answering resolves them everywhere',
+      rows: answer.map((x) => ({ item: x, composer: true })),
+    });
+  }
+  if (approve.length) {
+    groups.push({
+      label: 'Approve',
+      hint: 'proposed session manifests — nothing fires without you; approval binds the exact digest',
+      rows: approve.map((x) => ({ item: x })),
+    });
+  }
+  if (suspended.length) {
+    groups.push({
+      label: 'Suspended',
+      hint: 'standing runs stopped after repeated failures — surfaced, never silently re-fired',
+      rows: suspended.map((x) => ({ item: x })),
+    });
+  }
+  if (overdue.length) {
+    groups.push({
+      label: 'Overdue',
+      hint: 'reminders that already fired — still just notifications, never work orders',
+      rows: overdue.map((x) => ({ item: x })),
+    });
+  }
+  if (attend.length) {
+    groups.push({
+      label: 'Attend',
+      hint: 'triage-flagged items, ranked — ordinary annotations from the triage mandate; ranking gates nothing',
+      rows: attend.map((x) => ({ item: x })),
+    });
+  }
+  return groups;
+}
+
+function agendaLensGroupsOpen() {
+  const items = agendaFilteredPool()
+    .filter((x) => x.status === 'open')
+    .sort(agendaByNew);
+  if (!items.length) return [];
+  return [{
+    label: 'Open items',
+    hint: 'newest first — the flat lens; filing under hubs never hides anything here',
+    rows: items.map((x) => ({ item: x, composer: true })),
+  }];
+}
+
+function agendaLensGroupsHubs() {
+  const q = agendaSearch.trim().toLowerCase();
+  const frontier = agendaFrontierPredicate();
+  const hubs = (agendaItems || [])
+    .filter((x) => x.status !== 'retired' && agendaChildrenOf(x.id).length)
+    .sort((a, b) => agendaChildrenOf(b.id).length - agendaChildrenOf(a.id).length);
+  const groups = hubs.map((hub) => {
+    const kids = agendaChildrenOf(hub.id)
+      .filter((x) => x.status !== 'retired' && agendaSearchMatch(x, q))
+      .filter((x) => !agendaFilterBlocked || agendaItemIsBlocked(x))
+      .filter((x) => !agendaFilterFrontier || frontier(x))
+      .sort((a, b) =>
+        (a.status === 'open' ? -1 : 1) - (b.status === 'open' ? -1 : 1)
+        || agendaByNew(a, b));
+    const open = kids.filter((k) => k.status === 'open').length;
+    return {
+      label: hub.title,
+      hint: `${open} open · ${kids.length - open} done — roll-ups derived at render`,
+      hubId: hub.id,
+      rows: kids.map((x) => ({ item: x, noHub: true, composer: true })),
+    };
+  }).filter((g) => g.rows.length);
+  const unfiled = agendaFilteredPool()
+    .filter((x) => x.status === 'open' && !x.part_of && !agendaChildrenOf(x.id).length)
+    .sort(agendaByNew);
+  if (unfiled.length) {
+    groups.push({
+      label: 'Not filed',
+      hint: 'no placement yet — file from an item’s Organization section, or let the triage mandate do it',
+      rows: unfiled.map((x) => ({ item: x, composer: true })),
+    });
+  }
+  return groups;
+}
+
+function agendaLensGroupsQuestions() {
+  const pool = agendaFilteredPool();
+  const open = pool
+    .filter((x) => x.kind === 'question' && x.status === 'open')
+    .sort(agendaByNew);
+  const answered = pool
+    .filter((x) => x.kind === 'question' && x.status === 'done')
+    .sort(agendaByNew);
+  const groups = [];
+  if (open.length) {
+    groups.push({
+      label: 'Open questions',
+      hint: 'dismissed ones stay here — only an answer resolves a question',
+      rows: open.map((x) => ({ item: x, composer: true })),
+    });
+  }
+  if (answered.length) {
+    groups.push({
+      label: 'Answered',
+      hint: 'resolved questions — structured breakdowns live in each item’s panel',
+      rows: answered.map((x) => ({ item: x, showAnswer: true })),
+    });
+  }
+  return groups;
+}
+
+function agendaLensGroupsArchive() {
+  const pool = agendaFilteredPool();
+  const done = pool
+    .filter((x) => x.status === 'done')
+    .sort((a, b) => (b.completed_ms || 0) - (a.completed_ms || 0));
+  const retired = pool.filter((x) => x.status === 'retired').sort(agendaByNew);
+  const groups = [];
+  if (done.length) {
+    groups.push({
+      label: 'Done',
+      hint: 'reopen resurrects — completing cancelled any pending reminder',
+      rows: done.map((x) => ({ item: x, showAnswer: true })),
+    });
+  }
+  if (retired.length) {
+    groups.push({
+      label: 'Retired',
+      hint: 'hidden, never deleted — there is no destructive delete on this ledger',
+      rows: retired.map((x) => ({ item: x })),
+    });
+  }
+  return groups;
+}
+
+// Distinct items the "Needs you" lens would show — the lens badge.
+function agendaNeedsYouCount() {
+  const needs = new Set();
+  (agendaItems || []).forEach((x) => {
+    const st = agendaEffectState(x);
+    if (x.kind === 'question' && x.status === 'open' && !x.dismissed) needs.add(x.id);
+    if (x.status === 'open' && st && st.kind === 'pending') needs.add(x.id);
+    if (st && st.kind === 'suspended') needs.add(x.id);
+    if (x.status === 'open' && x.due_ms && x.due_ms < Date.now()) needs.add(x.id);
+    if (x.status === 'open' && agendaTriageInfo(x)) needs.add(x.id);
+  });
+  return needs.size;
+}
+
+// ---- Chips ----
+
+// One presentation chip. `tone` maps to the token families (green, amber,
+// rose, sky, iris, neutral); `dashed` renders the outline-only variant.
+function agendaChipHtml(label, tone, tip, dashed) {
+  const cls = ['ag2-chip'];
+  if (tone) cls.push(`t-${tone}`);
+  if (dashed) cls.push('dashed');
+  return `<span class="${cls.join(' ')}"${tip ? ` title="${escapeHtml(tip)}"` : ''}>${escapeHtml(label)}</span>`;
+}
+
+function agendaCardChips(item) {
+  const chips = [];
+  const st = agendaEffectState(item);
+  if (item.status === 'done') {
+    chips.push(agendaChipHtml(`done ${agendaRelTime(item.completed_ms || item.updated_ms)}`,
+      'green', 'Completed — reopen any time'));
+  }
+  if (item.status === 'retired') {
+    chips.push(agendaChipHtml('retired', 'neutral', 'Hidden from open lenses; history preserved'));
+  }
+  if (item.status === 'open' && item.due_ms) {
+    const overdue = item.due_ms < Date.now();
+    chips.push(agendaChipHtml(
+      overdue ? `overdue ${agendaRelTime(item.due_ms).replace(' ago', '')}` : `due ${agendaRelTime(item.due_ms)}`,
+      overdue ? 'amber' : 'sky',
+      `Reminder ${agendaAbsTime(item.due_ms)} — delivery follows your policy`));
+  }
+  if (agendaItemIsBlocked(item)) {
+    chips.push(agendaChipHtml('blocked', 'rose',
+      'Derived at render — an uncleared blocker or unmet prerequisite'));
+  }
+  if (item.kind === 'question' && item.status === 'open' && item.dismissed) {
+    chips.push(agendaChipHtml('dismissed · still open', 'neutral',
+      agendaDismissedTip(item.dismissed), true));
+  }
+  if (item.answer && item.answer.delivered === false) {
+    chips.push(agendaChipHtml('answered · awaiting pickup', 'sky',
+      'No live session heard the answer — the asker’s successor reads it at session start', true));
+  }
+  if (st) {
+    if (st.kind === 'running') {
+      chips.push(agendaChipHtml('running', 'iris', 'An occurrence is in flight'));
+    } else if (st.kind === 'pending') {
+      chips.push(agendaChipHtml('needs approval', 'amber',
+        'A proposed manifest — nothing fires without an owner approval of its exact digest'));
+    } else if (st.kind === 'suspended') {
+      chips.push(agendaChipHtml('suspended', 'amber',
+        `${st.effect.consecutive_failures} failures in a row — re-approve to re-arm`));
+    } else if (st.kind === 'standing') {
+      chips.push(agendaChipHtml(`standing · every ${agendaCadenceLabel(st.rec.every_ms)}`, 'green',
+        `One approval covers the series · next ${agendaAbsTime(st.next)}`));
+    } else if (st.kind === 'armed') {
+      chips.push(agendaChipHtml('armed', 'sky', `Fires ${agendaAbsTime(st.next)}`));
+    }
+  }
+  const kids = agendaChildrenOf(item.id);
+  if (kids.length) {
+    const open = kids.filter((k) => k.status === 'open').length;
+    const blocked = kids.filter((k) => agendaItemIsBlocked(k)).length;
+    chips.push(agendaChipHtml(
+      `hub · ${open} open${blocked ? ` · ${blocked} blocked` : ''}`,
+      'neutral',
+      'A hub is just an item with children — grouping never hides or blocks anything'));
+    if (item.status === 'done' && open) {
+      chips.push(agendaChipHtml('done over open children', 'amber',
+        'Render-level flag only — completion never cascades'));
+    }
+  }
+  const triage = agendaTriageInfo(item);
+  if (triage) {
+    chips.push(agendaChipHtml(
+      triage.rank !== null ? `triage #${triage.rank}` : 'triage',
+      'iris', triage.text, true));
+  }
+  const mustReads = (item.refs || []).filter((r) => r.must_read).length;
+  if (mustReads) {
+    chips.push(agendaChipHtml(`${mustReads} must-read`, 'iris',
+      'Typed pointers the reading agent weighs — never orders'));
+  }
+  return chips.join('');
+}
+
+// ---- Attribution line ----
+
+function agendaCardByline(item, opts) {
+  const p = item.provenance || {};
+  const s = agendaSessionInfo(p.session_id);
+  const tip = [
+    p.principal ? `principal ${p.principal}` : 'principal —',
+    p.kind || 'unattributed',
+    p.session_id ? `session ${p.session_id}` : '',
+  ].filter(Boolean).join(' · ');
+  let by;
+  if (s && s.key) {
+    const label = s.name || `session ${String(s.conversation_id || p.session_id).slice(0, 8)}`;
+    by = `by <a href="#sessions" class="agenda-session-link" data-session-key="${escapeHtml(s.key)}" title="${escapeHtml(tip)}">${escapeHtml(label)}</a>`;
+  } else if (p.session_id) {
+    by = `by <span title="${escapeHtml(tip)}">${escapeHtml(`session ${p.session_id.slice(0, 12)}…`)}</span>`;
+  } else {
+    const label = p.kind === 'dashboard' ? 'you'
+      : p.source ? p.source
+        : p.kind === 'local_process' ? 'local shell'
+          : p.kind === 'peer' ? 'a peer daemon' : (p.kind || 'unattributed');
+    by = `by <span title="${escapeHtml(tip)}">${escapeHtml(label)}</span>`;
+  }
+  const selfDesc = p.source
+    ? '<span class="agenda-self-described" title="Self-described label — unverified, never an identity">· self-described</span>'
+    : '';
+  const bits = [
+    `<span class="ag2-kind">${escapeHtml(item.kind)}</span>`,
+    by,
+    selfDesc,
+    `<span>· ${escapeHtml(agendaRelTime(p.created_ms))}</span>`,
+  ];
+  const hub = item.part_of && agendaFindItem(item.part_of.parent_id);
+  if (hub && !opts.noHub) {
+    bits.push(`<span>· in</span> <a class="ag2-hub-link" data-open-item="${escapeHtml(hub.id)}">${escapeHtml(hub.title.length > 34 ? `${hub.title.slice(0, 33)}…` : hub.title)}</a>`);
+  }
+  (item.tags || []).slice(0, 3).forEach((tag) => {
+    bits.push(`<span class="ag2-tag">${escapeHtml(tag)}</span>`);
+  });
+  return bits.filter(Boolean).join(' ');
+}
+
+// ---- Inline effect strip (pending / suspended / running, open items) ----
+
+function agendaCardEffectStrip(item) {
+  const st = agendaEffectState(item);
+  if (!st || item.status !== 'open') return '';
+  if (!['pending', 'suspended', 'running'].includes(st.kind)) return '';
+  const e = st.effect;
+  let line = '';
+  let tone = 'amber';
+  let actions = '';
+  const id = escapeHtml(item.id);
+  if (st.kind === 'pending') {
+    const proposer = e.proposed_kind === 'dashboard'
+      ? 'You proposed'
+      : `“${agendaActorLabel({ session_id: e.proposed_session_id, kind: e.proposed_kind, principal: e.proposed_principal }) || 'a session'}” proposes`;
+    line = `${proposer}: runs ${agendaAbsTime(st.manifest.fire_at_ms)}`
+      + (st.rec ? ` · every ${agendaCadenceLabel(st.rec.every_ms)}` : ' · once')
+      + ' — needs your approval';
+    actions = `<button type="button" class="ag2-btn prim" data-op-btn="approve_effect" data-id="${id}" data-digest="${escapeHtml(e.digest || '')}" title="Binds this exact manifest digest — any edit voids it">Approve</button>`
+      + `<button type="button" class="ag2-btn ghost" data-open-item="${id}">Review</button>`;
+  } else if (st.kind === 'suspended') {
+    line = `Standing run suspended after ${e.consecutive_failures} failures — never silently re-fired`;
+    actions = `<button type="button" class="ag2-btn prim" data-op-btn="approve_effect" data-id="${id}" data-digest="${escapeHtml(e.digest || '')}" title="Re-approve the unchanged digest — resets the streak">Re-arm</button>`
+      + `<button type="button" class="ag2-btn ghost" data-open-item="${id}">Review</button>`;
+  } else {
+    tone = 'iris';
+    line = `Running now — started ${agendaRelTime(e.last_run.at_ms)}`;
+    const run = e.last_run;
+    const s = run.session_id && agendaSessionInfo(run.session_id);
+    actions = s && s.key
+      ? `<button type="button" class="ag2-btn ghost" data-jump-session="${escapeHtml(s.key)}">Watch</button>`
+      : '';
+  }
+  return `<div class="ag2-eff t-${tone}">
+    <span class="ag2-eff-line">${escapeHtml(line)}</span>
+    <span class="ag2-spacer"></span>${actions}
+  </div>`;
+}
+
+// ---- Inline question answering ----
+
+function agendaQaPicks(itemId, qi) {
+  const per = agendaQaSel[itemId];
+  return (per && per[qi]) || [];
+}
+
+function agendaQaTogglePick(item, qi, label) {
+  if (item.status !== 'open') return;
+  const q = item.ask && item.ask.questions[qi];
+  if (!q) return;
+  // Real pick bounds (UserQuestion::pick_bounds): explicit pick_min/max
+  // win; otherwise one, or any-number under multi_select.
+  const optionCount = (q.options || []).length;
+  const defaultMax = q.multi_select ? Math.max(1, optionCount) : 1;
+  let max = Math.max(1, q.pick_max || defaultMax);
+  if (optionCount > 0) max = Math.min(max, optionCount);
+  const per = agendaQaSel[item.id] || (agendaQaSel[item.id] = {});
+  const picks = per[qi] ? [...per[qi]] : [];
+  const at = picks.indexOf(label);
+  if (at >= 0) picks.splice(at, 1);
+  else if (max === 1) { picks.length = 0; picks.push(label); }
+  else if (picks.length < max) picks.push(label);
+  else return; // at the bound — an explicit deselect must come first
+  per[qi] = picks;
+  agendaRenderTab();
+  agendaInspectorRender();
+}
+
+function agendaQaPillsHtml(item, qi) {
+  const q = item.ask && item.ask.questions[qi];
+  if (!q || !(q.options || []).length) return '';
+  const picks = agendaQaPicks(item.id, qi);
+  const answered = item.answer && item.answer.structured
+    ? (item.answer.structured.selections || {})[q.question] || null
+    : null;
+  const pills = (q.options || []).map((o) => {
+    const on = answered ? answered.includes(o.label) : picks.includes(o.label);
+    return `<button type="button" class="ag2-pill${on ? ' on' : ''}${answered ? ' recorded' : ''}"
+      data-pill-item="${escapeHtml(item.id)}" data-pill-q="${qi}" data-pill-label="${escapeHtml(o.label)}"
+      ${o.description ? ` title="${escapeHtml(o.description)}"` : ''}>${escapeHtml(o.label)}</button>`;
+  });
+  return `<div class="ag2-pills">${pills.join('')}</div>`;
+}
+
+// Preview thumbnails for one question — the "show, then ask" cards.
+// SECURITY INVARIANT (same as the question rail): agent-authored html
+// renders ONLY inside `<iframe sandbox="allow-scripts">` populated via
+// srcdoc from an authenticated fetch — opaque origin, never same-origin,
+// never blob:/createObjectURL. Bytes come from the agenda blob store
+// route the payload names.
+function agendaPreviewStripHtml(item, qi, ctx) {
+  const q = item.ask && item.ask.questions[qi];
+  const previews = (q && q.previews) || [];
+  if (!previews.length) return '';
+  const picks = agendaQaPicks(item.id, qi);
+  const answered = item.answer && item.answer.structured
+    ? (item.answer.structured.selections || {})[q.question] || null
+    : null;
+  const cards = previews.map((p, pi) => {
+    const isOption = (q.options || []).some((o) => o.label === p.label);
+    const selected = isOption && (answered ? answered.includes(p.label) : picks.includes(p.label));
+    const tone = answered ? 'green' : 'iris';
+    let media;
+    if (p.kind === 'html' && p.url) {
+      media = `<iframe class="ag2-prev-frame" sandbox="allow-scripts" referrerpolicy="no-referrer"
+        title="${escapeHtml(p.label || 'preview')}" data-preview-url="${escapeHtml(p.url)}" tabindex="-1"></iframe>`;
+    } else if (p.kind === 'image' && p.url) {
+      media = `<img class="ag2-prev-img" loading="lazy" src="${escapeHtml(p.url)}" alt="${escapeHtml(p.label || 'preview')}" />`;
+    } else if (p.kind === 'text' && p.content) {
+      media = `<pre class="ag2-prev-text">${escapeHtml(p.content)}</pre>`;
+    } else {
+      media = `<span class="ag2-prev-missing">${escapeHtml(p.label || 'preview')} unavailable</span>`;
+    }
+    const state = selected ? (answered ? 'picked' : 'selected') : '';
+    const tip = isOption
+      ? (item.status === 'open' ? 'Click to pick this option — expand for the full render'
+        : 'The rendered prototype this option shipped with')
+      : 'A reference render, for contrast';
+    return `<div class="ag2-prev${selected ? ` sel t-${tone}` : ''}" data-prev-item="${escapeHtml(item.id)}" data-prev-q="${qi}" data-prev-i="${pi}" title="${escapeHtml(tip)}">
+      <div class="ag2-prev-media">${media}</div>
+      <div class="ag2-prev-cap">
+        <span class="ag2-prev-label${selected ? ' sel' : ''}">${escapeHtml(p.label || `#${pi + 1}`)}</span>
+        ${state ? `<span class="ag2-prev-state">· ${state}</span>` : ''}
+        <span class="ag2-spacer"></span>
+        <button type="button" class="ag2-prev-expand" data-prev-expand="${pi}"
+          title="Full size, in a sheet">expand ›</button>
+      </div>
+    </div>`;
+  });
+  return `<div class="ag2-prevs${ctx === 'insp' ? ' insp' : ''}">${cards.join('')}</div>`;
+}
+
+// Hydrate sandboxed preview frames after an innerHTML render: fetch the
+// blob once (cached per url) and hand it to srcdoc. A failed fetch
+// degrades to a named unavailable chip, never a broken card.
+const agendaPreviewHtmlCache = new Map();
+function agendaHydratePreviewFrames(root) {
+  root.querySelectorAll('iframe.ag2-prev-frame[data-preview-url]').forEach((frame) => {
+    const url = frame.dataset.previewUrl;
+    if (!url || frame.dataset.loaded) return;
+    frame.dataset.loaded = '1';
+    const cached = agendaPreviewHtmlCache.get(url);
+    if (cached !== undefined) {
+      frame.srcdoc = cached;
+      return;
+    }
+    fetch(url)
+      .then((r) => (r.ok ? r.text() : Promise.reject(new Error(`HTTP ${r.status}`))))
+      .then((html) => {
+        agendaPreviewHtmlCache.set(url, html);
+        frame.srcdoc = html;
+      })
+      .catch(() => {
+        const chip = document.createElement('span');
+        chip.className = 'ag2-prev-missing';
+        chip.textContent = 'preview unavailable (blob deleted from the store)';
+        frame.replaceWith(chip);
+      });
+  });
+}
+
+// The card composer for open questions: pills + previews (first question
+// inline — the inspector carries the full multi-question form), one
+// note/answer input, Answer + Later.
+function agendaCardQaHtml(item) {
+  if (item.kind !== 'question' || item.status !== 'open') return '';
+  const id = escapeHtml(item.id);
+  const hasAsk = !!(item.ask && Array.isArray(item.ask.questions) && item.ask.questions.length);
+  const pills = hasAsk ? agendaQaPillsHtml(item, 0) : '';
+  const previews = hasAsk ? agendaPreviewStripHtml(item, 0, 'card') : '';
+  const more = hasAsk && item.ask.questions.length > 1
+    ? `<div class="ag2-qa-more">+ ${item.ask.questions.length - 1} more question${item.ask.questions.length > 2 ? 's' : ''} in the panel — open the item</div>`
+    : '';
+  const draft = agendaQaDrafts[item.id] || '';
+  const placeholder = hasAsk
+    ? 'Add a note with your pick (optional)…'
+    : 'Type your answer — it lands on the item and reaches the asking session…';
+  const later = hasAsk && !item.dismissed
+    ? `<button type="button" class="ag2-btn ghost" data-later="${id}" title="Clears it from every rail now — the question stays open here; only an answer resolves it">Later</button>`
+    : '';
+  return `<div class="ag2-qa">
+    ${pills}${previews}${more}
+    <div class="ag2-qa-row">
+      <input type="text" class="ag2-qa-input" maxlength="4000" data-qa-draft="${id}" data-fkey="qa:${id}"
+             placeholder="${escapeHtml(placeholder)}" aria-label="Answer" value="${escapeHtml(draft)}" />
+      <button type="button" class="ag2-btn prim" data-answer="${id}">Answer</button>
+      ${later}
+    </div>
+  </div>`;
+}
+
+// Build the structured resolution from the shared pick/note/draft state —
+// the same wire shapes the question rail records (AgendaAskResolution:
+// answers/selections/followups keyed by question text, annotations as
+// {preview, note} anchored to a picked card's label).
+function agendaBuildStructuredAnswer(item) {
+  const questions = (item.ask && item.ask.questions) || [];
+  const draft = (agendaQaDrafts[item.id] || '').trim();
+  if (!questions.length) {
+    if (!draft) return { error: 'Type an answer first.' };
+    return { text: draft, structured: null };
+  }
+  const answers = {};
+  const selections = {};
+  const followups = {};
+  const annotations = {};
+  const parts = [];
+  questions.forEach((q, qi) => {
+    const picks = agendaQaPicks(item.id, qi);
+    if (picks.length) {
+      selections[q.question] = [...picks];
+      answers[q.question] = picks.join(', ');
+      parts.push((q.header ? `${q.header}: ` : '') + picks.join(', '));
+    }
+    const note = (agendaQaNotes[`${item.id}:${qi}`] || '').trim();
+    if (note && picks.length) {
+      annotations[q.question] = [{ preview: picks[0], note }];
+      parts.push(`note on “${picks[0]}”: ${note}`);
+    }
+  });
+  if (draft) {
+    followups[questions[0].question] = draft;
+    parts.push(draft);
+  }
+  if (!parts.length) return { error: 'Pick an option or type an answer first.' };
+  const structured = { answers, selections, followups };
+  if (Object.keys(annotations).length) structured.annotations = annotations;
+  return { text: parts.join(' — '), structured };
+}
+
+async function agendaSubmitAnswer(item, button) {
+  const built = agendaBuildStructuredAnswer(item);
+  if (built.error) {
+    agendaFlashError(built.error);
+    return false;
+  }
+  const params = { op: 'answer', id: item.id, text: built.text };
+  if (built.structured) params.structured = built.structured;
+  const ok = await agendaSendOp(params, button);
+  if (ok) {
+    delete agendaQaSel[item.id];
+    delete agendaQaDrafts[item.id];
+    Object.keys(agendaQaNotes).forEach((k) => {
+      if (k.startsWith(`${item.id}:`)) delete agendaQaNotes[k];
+    });
+    if (typeof showControlToast === 'function') {
+      showControlToast('success', 'Answer recorded on the item.');
+    }
+    agendaRenderAll();
+  }
+  return ok;
+}
+
+// "Later" on an ask-backed question: the rail's own skip verb — the
+// daemon records the dismissal (the item stays open; only an answer
+// resolves it). Plain questions have no rail card, so no Later.
+function agendaDismissAsk(item) {
+  if (!item.ask || !item.ask.ask_id) return;
+  if (typeof dispatchControlMsg !== 'function') return;
+  dispatchControlMsg({ action: 'skip', id: item.ask.ask_id });
+  // If the rail panel is currently showing this ask, clear it like its
+  // own Skip button would — the daemon-side dismissal is the record.
+  if (typeof pendingQuestion !== 'undefined' && pendingQuestion
+    && pendingQuestion.id === item.ask.ask_id) {
+    if (typeof clearPendingQuestion === 'function') clearPendingQuestion();
+    if (typeof hidePanel === 'function') hidePanel('question-panel');
+  }
+  if (typeof showControlToast === 'function') {
+    showControlToast('info', 'Cleared from the rails — the question stays open here.');
+  }
+}
+
+// ---- Card ----
+
+function agendaCtlHtml(item) {
+  const id = escapeHtml(item.id);
+  if (item.kind === 'question' && item.status === 'open') {
+    return `<button type="button" class="ag2-ctl q" data-ctl="${id}" title="Open question — answering resolves it">?</button>`;
+  }
+  if (item.status === 'open') {
+    return `<button type="button" class="ag2-ctl open" data-ctl="${id}" title="Mark done"></button>`;
+  }
+  if (item.status === 'done') {
+    return `<button type="button" class="ag2-ctl done" data-ctl="${id}" title="Reopen">✓</button>`;
+  }
+  return `<button type="button" class="ag2-ctl retired" data-ctl="${id}" title="Reopen (retired)"></button>`;
+}
+
+function agendaCardHtml(row) {
+  const item = row.item;
+  const opts = row;
+  const id = escapeHtml(item.id);
+  const blockedLine = agendaBlockedLine(item);
+  const answerLine = opts.showAnswer && item.answer && item.answer.text
+    ? `<div class="ag2-ansline">${escapeHtml(item.answer.text.length > 180 ? `${item.answer.text.slice(0, 180)}…` : item.answer.text)}</div>`
+    : '';
+  const qa = opts.composer ? agendaCardQaHtml(item) : '';
+  const classes = ['ag2-card'];
+  if (agendaSelId === item.id) classes.push('selected');
+  if (item.status === 'retired') classes.push('retired');
+  return `<div class="${classes.join(' ')}" data-item-id="${id}" role="button" tabindex="0">
+    ${agendaCtlHtml(item)}
+    <div class="ag2-card-main">
+      <div class="ag2-card-titlerow">
+        <span class="ag2-card-title${item.status === 'done' ? ' done' : ''}${item.status !== 'open' ? ' dim' : ''}">${escapeHtml(item.title)}</span>
+        ${agendaCardChips(item)}
+      </div>
+      <div class="ag2-card-meta">${agendaCardByline(item, opts)}</div>
+      ${blockedLine ? `<div class="ag2-blocked-line">${escapeHtml(blockedLine)}</div>` : ''}
+      ${agendaCardEffectStrip(item)}
+      ${qa}${answerLine}
+    </div>
+    <span class="ag2-card-chev" aria-hidden="true">›</span>
+  </div>`;
+}
+
+// ---- Tab render ----
+
+function agendaRenderTab() {
+  const pane = document.getElementById('tab-agenda');
+  if (!pane) return;
+  agendaEnsureScaffold();
+  const groupsHost = document.getElementById('ag2-groups');
+  if (!groupsHost) return;
+
+  // Lens tabs + filter chips reflect state.
+  const lensesHost = document.getElementById('ag2-lenses');
+  const needs = agendaNeedsYouCount();
+  lensesHost.innerHTML = AGENDA_LENSES.map((lens) => {
+    const label = lens.id === 'now' && needs
+      ? `${lens.label} · ${needs}` : lens.label;
+    return `<button type="button" role="tab" data-lens="${lens.id}"
+      aria-selected="${agendaLens === lens.id}" class="${agendaLens === lens.id ? 'active' : ''}">${escapeHtml(label)}</button>`;
+  }).join('');
+  lensesHost.querySelectorAll('button[data-lens]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      agendaLens = btn.dataset.lens;
+      agendaRenderTab();
+    });
+  });
+  const blockedBtn = document.getElementById('ag2-f-blocked');
+  const nBlocked = (agendaItems || []).filter((x) => agendaItemIsBlocked(x)).length;
+  blockedBtn.textContent = `blocked · ${nBlocked}`;
+  blockedBtn.classList.toggle('on-rose', agendaFilterBlocked);
+  const frontierBtn = document.getElementById('ag2-f-frontier');
+  frontierBtn.classList.toggle('on-iris', agendaFilterFrontier);
+  const searchBox = document.getElementById('ag2-search');
+  if (searchBox.value !== agendaSearch) searchBox.value = agendaSearch;
+  const bellDot = document.getElementById('ag2-bell-dot');
+  if (bellDot) bellDot.hidden = !agendaQuietNow();
+
+  // Ledger + load/loading states.
+  const ledger = document.getElementById('ag2-ledger');
+  if (agendaLoadError) {
+    groupsHost.innerHTML = `<div class="ui-empty">${escapeHtml(agendaLoadError)}</div>`;
+    ledger.textContent = '';
+    return;
+  }
+  if (agendaItems === null) {
+    groupsHost.innerHTML = '<div class="ui-empty">Loading…</div>';
+    ledger.textContent = '';
+    return;
+  }
+  const skipped = agendaSkippedLines > 0
+    ? ` · ${agendaSkippedLines} newer-build line${agendaSkippedLines === 1 ? '' : 's'} preserved unfolded (an older binary never destroys history it can’t read)`
+    : '';
+  ledger.textContent = `agenda.jsonl · append-only op log · ${agendaCounts.open || 0} open · ${agendaCounts.done || 0} done · ${agendaCounts.retired || 0} retired${skipped}`;
+
+  const lens = AGENDA_LENSES.find((l) => l.id === agendaLens) || AGENDA_LENSES[0];
+  const groups = lens.groups();
+  if (!groups.length) {
+    const filtered = agendaSearch.trim() || agendaFilterBlocked || agendaFilterFrontier;
+    const title = filtered ? 'Nothing matches'
+      : agendaLens === 'now' ? 'Nothing needs you' : 'Nothing here yet';
+    const hint = filtered
+      ? 'Loosen the search or filters — retire hides nothing from them.'
+      : agendaLens === 'now'
+        ? 'The agenda is quiet — everything parked is either moving or waiting politely.'
+        : 'Park something above, or let your sessions park as they work.';
+    groupsHost.innerHTML = `<div class="ag2-empty">
+      <div class="ag2-empty-glyph">◍</div>
+      <div class="ag2-empty-title">${escapeHtml(title)}</div>
+      <div class="ag2-empty-hint">${escapeHtml(hint)}</div>
+    </div>`;
+    return;
+  }
+  agendaRenderPreservingFocus(groupsHost, () => {
+    groupsHost.innerHTML = groups.map((group) => {
+      const hubLink = group.hubId
+        ? `<a class="ag2-hub-open" data-open-item="${escapeHtml(group.hubId)}">open the hub ›</a>`
+        : '';
+      return `<div class="ag2-group">
+        <div class="ag2-group-head">
+          <span class="ag2-group-label">${escapeHtml(group.label)}</span>
+          <span class="ag2-group-hint">${escapeHtml(group.hint)}</span>
+          ${hubLink}
+        </div>
+        <div class="ag2-cards">${group.rows.map(agendaCardHtml).join('')}</div>
+      </div>`;
+    }).join('');
+  });
+  agendaHydratePreviewFrames(groupsHost);
+}
+
+// ---- List event delegation (wired once on #ag2-groups) ----
+
+function agendaGroupsClick(e) {
+  const sessionLink = e.target.closest('a.agenda-session-link');
+  if (sessionLink) {
+    e.preventDefault();
+    agendaJumpToSession(sessionLink.dataset.sessionKey);
+    return;
+  }
+  const ctl = e.target.closest('[data-ctl]');
+  if (ctl) {
+    const item = agendaFindItem(ctl.dataset.ctl);
+    if (!item) return;
+    if (item.kind === 'question' && item.status === 'open') {
+      agendaOpenInspector(item.id);
+    } else if (item.status === 'open') {
+      agendaSendOp({ op: 'complete', id: item.id }, ctl);
+    } else {
+      agendaSendOp({ op: 'reopen', id: item.id }, ctl);
+    }
+    return;
+  }
+  const opBtn = e.target.closest('[data-op-btn]');
+  if (opBtn) {
+    const params = { op: opBtn.dataset.opBtn, id: opBtn.dataset.id };
+    // Approve binds the digest of the revision this render showed.
+    if (opBtn.dataset.digest) params.digest = opBtn.dataset.digest;
+    agendaSendOp(params, opBtn);
+    return;
+  }
+  const jump = e.target.closest('[data-jump-session]');
+  if (jump) {
+    agendaJumpToSession(jump.dataset.jumpSession);
+    return;
+  }
+  const pill = e.target.closest('.ag2-pill');
+  if (pill) {
+    const item = agendaFindItem(pill.dataset.pillItem);
+    if (item && !(item.answer && item.answer.structured)) {
+      agendaQaTogglePick(item, Number(pill.dataset.pillQ), pill.dataset.pillLabel);
+    }
+    return;
+  }
+  const expand = e.target.closest('[data-prev-expand]');
+  if (expand) {
+    const card = expand.closest('[data-prev-item]');
+    if (card) {
+      agendaOpenPreviewSheet(card.dataset.prevItem,
+        Number(card.dataset.prevQ), Number(expand.dataset.prevExpand));
+    }
+    return;
+  }
+  const prev = e.target.closest('[data-prev-item]');
+  if (prev) {
+    agendaPreviewCardClick(prev);
+    return;
+  }
+  const answerBtn = e.target.closest('[data-answer]');
+  if (answerBtn) {
+    const item = agendaFindItem(answerBtn.dataset.answer);
+    if (item) agendaSubmitAnswer(item, answerBtn);
+    return;
+  }
+  const laterBtn = e.target.closest('[data-later]');
+  if (laterBtn) {
+    const item = agendaFindItem(laterBtn.dataset.later);
+    if (item) agendaDismissAsk(item);
+    return;
+  }
+  const openItem = e.target.closest('[data-open-item]');
+  if (openItem) {
+    agendaOpenInspector(openItem.dataset.openItem);
+    return;
+  }
+  const card = e.target.closest('.ag2-card');
+  if (card && !e.target.closest('button, a, input, select, iframe')) {
+    agendaOpenInspector(card.dataset.itemId);
+  }
+}
+
+// A preview card body click: picking when the card mirrors an option and
+// the question is open, expanding otherwise (matches the rail).
+function agendaPreviewCardClick(cardEl) {
+  const item = agendaFindItem(cardEl.dataset.prevItem);
+  const qi = Number(cardEl.dataset.prevQ);
+  const pi = Number(cardEl.dataset.prevI);
+  if (!item || !item.ask) return;
+  const q = item.ask.questions[qi];
+  const p = q && (q.previews || [])[pi];
+  if (!p) return;
+  const isOption = (q.options || []).some((o) => o.label === p.label);
+  if (isOption && item.status === 'open' && !(item.answer && item.answer.structured)) {
+    agendaQaTogglePick(item, qi, p.label);
+  } else {
+    agendaOpenPreviewSheet(item.id, qi, pi);
+  }
+}
+
+function agendaGroupsInput(e) {
+  const draft = e.target.closest('[data-qa-draft]');
+  if (draft) agendaQaDrafts[draft.dataset.qaDraft] = draft.value;
+}
+
+function agendaGroupsKeydown(e) {
+  if (e.key === 'Enter') {
+    const draft = e.target.closest('[data-qa-draft]');
+    if (draft) {
+      e.preventDefault();
+      const item = agendaFindItem(draft.dataset.qaDraft);
+      if (item) agendaSubmitAnswer(item);
+      return;
+    }
+    const card = e.target.closest('.ag2-card');
+    if (card && e.target === card) {
+      e.preventDefault();
+      agendaOpenInspector(card.dataset.itemId);
+    }
+  }
+}

--- a/static/app/ui2-agenda-inspector.css
+++ b/static/app/ui2-agenda-inspector.css
@@ -1,0 +1,910 @@
+/* Agenda inspector + schedule/preview sheets + reminder-policy popover
+   (redesign slice A). Token palette only; scoped under html.ui-v2. The
+   inspector is an animated-width side panel ≥1180px and a fixed overlay
+   with a backdrop below that — same DOM, media-query switched. */
+
+/* ---- Inspector shell ---- */
+
+html.ui-v2 .ag2-inspector {
+  width: 0;
+  flex-shrink: 0;
+  overflow: hidden;
+  background: var(--bg-1);
+  transition: width var(--t-slow) ease;
+}
+html.ui-v2 .ag2-inspector.open {
+  width: clamp(340px, calc(100vw - 850px), 478px);
+}
+html.ui-v2 .ag2-inspector-backdrop { display: none; }
+@media (max-width: 1179px) {
+  html.ui-v2 .ag2-inspector {
+    position: fixed;
+    top: var(--ui2-ovs-h, 48px);
+    right: 0;
+    bottom: 0;
+    width: 0;
+    z-index: 57;
+    box-shadow: var(--shadow-overlay);
+    transition: none;
+  }
+  html.ui-v2 .ag2-inspector.open {
+    width: min(478px, calc(100vw - 40px));
+  }
+  html.ui-v2 .ag2-inspector-backdrop:not([hidden]) {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 56;
+    background: rgba(4, 5, 8, 0.45);
+  }
+}
+html.ui-v2 .ag2-insp-col {
+  width: 100%;
+  min-width: 280px;
+  height: 100%;
+  border-left: 1px solid var(--line);
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+}
+html.ui-v2 .ag2-insp-scroll {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 16px 18px 44px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+/* ---- Inspector header ---- */
+
+html.ui-v2 .ag2-insp-head {
+  padding: 14px 18px 12px;
+  border-bottom: 1px solid var(--line);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+html.ui-v2 .ag2-insp-chips {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+html.ui-v2 .ag2-idbtn {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--text-3);
+  background: var(--surface-2);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 1px 7px;
+  cursor: pointer;
+}
+html.ui-v2 .ag2-idbtn:hover {
+  color: var(--text-2);
+  border-color: var(--line-2);
+}
+html.ui-v2 .ag2-insp-title {
+  font-size: 17px;
+  font-weight: 800;
+  color: var(--text);
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+  cursor: text;
+}
+html.ui-v2 .ag2-insp-titleedit {
+  display: flex;
+  gap: 7px;
+}
+html.ui-v2 .ag2-insp-titleedit input {
+  flex: 1;
+  min-width: 0;
+  background: var(--surface-2);
+  border: 1px solid var(--line-2);
+  border-radius: 9px;
+  color: var(--text);
+  font-size: 14px;
+  font-weight: 700;
+  padding: 6px 9px;
+}
+html.ui-v2 .ag2-insp-titleedit input:focus {
+  outline: none;
+  border-color: var(--iris);
+}
+html.ui-v2 .ag2-insp-ctx {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11.5px;
+  color: var(--text-3);
+  flex-wrap: wrap;
+}
+html.ui-v2 .ag2-insp-actions {
+  display: flex;
+  gap: 7px;
+  flex-wrap: wrap;
+}
+
+/* ---- Sections ---- */
+
+html.ui-v2 .ag2-sec {
+  border-top: 1px solid var(--line);
+  padding-top: 14px;
+}
+html.ui-v2 .ag2-sec:first-child {
+  border-top: 0;
+  padding-top: 0;
+}
+html.ui-v2 .ag2-sec-head {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 8px;
+  flex-wrap: wrap;
+}
+html.ui-v2 .ag2-sec-label {
+  font-family: var(--mono);
+  font-size: var(--eyebrow-size);
+  font-weight: 700;
+  letter-spacing: var(--eyebrow-track);
+  text-transform: uppercase;
+  color: var(--text-3);
+}
+html.ui-v2 .ag2-sec-hint {
+  font-size: 10.5px;
+  color: var(--text-3);
+}
+html.ui-v2 .ag2-sec-body {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+
+/* ---- Question section ---- */
+
+html.ui-v2 .ag2-insp-q {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+html.ui-v2 .ag2-insp-qtext {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  overflow-wrap: anywhere;
+}
+html.ui-v2 .ag2-insp-notein,
+html.ui-v2 .ag2-insp-addrow input[type="text"] {
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--surface-2);
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  color: var(--text);
+  font-size: 11.5px;
+  padding: 5px 9px;
+}
+html.ui-v2 .ag2-insp-notein:focus,
+html.ui-v2 .ag2-insp-addrow input[type="text"]:focus {
+  outline: none;
+  border-color: var(--iris);
+}
+html.ui-v2 .ag2-insp-resolved {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border-left: 2px solid var(--green);
+  padding-left: 10px;
+}
+html.ui-v2 .ag2-insp-resq {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+html.ui-v2 .ag2-insp-resq-q {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--text-3);
+  overflow-wrap: anywhere;
+}
+html.ui-v2 .ag2-insp-resq-picks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: center;
+}
+html.ui-v2 .ag2-respick {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--green);
+  background: rgba(var(--green-rgb), 0.12);
+  border-radius: 6px;
+  padding: 1px 7px;
+  overflow-wrap: anywhere;
+}
+html.ui-v2 .ag2-restext {
+  font-size: 12.5px;
+  color: var(--text-2);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+html.ui-v2 .ag2-resnote {
+  font-size: 11px;
+  color: var(--text-3);
+  overflow-wrap: anywhere;
+}
+
+/* ---- Details ---- */
+
+html.ui-v2 .ag2-insp-body {
+  font-size: 12.5px;
+  line-height: 1.6;
+  color: var(--text-2);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  border-left: 2px solid var(--line);
+  padding-left: 10px;
+}
+html.ui-v2 .ag2-insp-bodyedit {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+html.ui-v2 .ag2-insp-bodyedit textarea {
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--surface-2);
+  border: 1px solid var(--line-2);
+  border-radius: 9px;
+  color: var(--text);
+  font-size: 12.5px;
+  line-height: 1.55;
+  padding: 8px 10px;
+  resize: vertical;
+}
+html.ui-v2 .ag2-insp-bodyedit textarea:focus {
+  outline: none;
+  border-color: var(--iris);
+}
+
+/* ---- Scheduled-session card ---- */
+
+html.ui-v2 .ag2-effcard {
+  border: 1px solid var(--line);
+  background: var(--surface-2);
+  border-radius: 11px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+html.ui-v2 .ag2-effcard.t-amber {
+  border-color: rgba(var(--amber-rgb), 0.3);
+  background: rgba(var(--amber-rgb), 0.07);
+}
+html.ui-v2 .ag2-effcard.t-sky {
+  border-color: rgba(var(--sky-rgb), 0.28);
+  background: rgba(var(--sky-rgb), 0.06);
+}
+html.ui-v2 .ag2-effcard.t-green {
+  border-color: rgba(var(--green-rgb), 0.28);
+  background: rgba(var(--green-rgb), 0.06);
+}
+html.ui-v2 .ag2-effcard.t-iris {
+  border-color: rgba(var(--iris-rgb), 0.3);
+  background: rgba(var(--iris-rgb), 0.07);
+}
+html.ui-v2 .ag2-effcard-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+html.ui-v2 .ag2-eff-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--neutral-dot);
+  flex-shrink: 0;
+}
+html.ui-v2 .ag2-effcard.t-amber .ag2-eff-dot { background: var(--amber); animation: ui2-pulse 2s infinite; }
+html.ui-v2 .ag2-effcard.t-sky .ag2-eff-dot { background: var(--sky); }
+html.ui-v2 .ag2-effcard.t-green .ag2-eff-dot { background: var(--green); }
+html.ui-v2 .ag2-effcard.t-iris .ag2-eff-dot { background: var(--iris); animation: ui2-pulse 1.3s infinite; }
+html.ui-v2 .ag2-eff-state {
+  font-size: 12.5px;
+  font-weight: 700;
+  color: var(--text-2);
+}
+html.ui-v2 .ag2-effcard.t-amber .ag2-eff-state { color: var(--amber); }
+html.ui-v2 .ag2-effcard.t-sky .ag2-eff-state { color: var(--sky); }
+html.ui-v2 .ag2-effcard.t-green .ag2-eff-state { color: var(--green); }
+html.ui-v2 .ag2-effcard.t-iris .ag2-eff-state { color: var(--iris-2); }
+html.ui-v2 .ag2-eff-grid {
+  display: grid;
+  grid-template-columns: 92px 1fr;
+  row-gap: 5px;
+  column-gap: 10px;
+}
+html.ui-v2 .ag2-eff-k {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text-3);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding-top: 2px;
+}
+html.ui-v2 .ag2-eff-v {
+  font-size: 12px;
+  color: var(--text-2);
+  overflow-wrap: anywhere;
+}
+html.ui-v2 .ag2-eff-v.mono { font-family: var(--mono); font-size: 11px; }
+html.ui-v2 .ag2-eff-goal {
+  font-size: 12px;
+  color: var(--text-2);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  border-left: 2px solid rgba(var(--iris-rgb), 0.5);
+  padding-left: 9px;
+  max-height: 120px;
+  overflow-y: auto;
+}
+html.ui-v2 .ag2-eff-lastrun {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  border-top: 1px solid var(--line);
+  padding-top: 8px;
+}
+html.ui-v2 .ag2-eff-lastrun-head {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  flex-wrap: wrap;
+}
+html.ui-v2 .ag2-eff-note {
+  font-size: 12px;
+  color: var(--text-2);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  border-left: 2px solid var(--line);
+  padding-left: 9px;
+}
+html.ui-v2 .ag2-insp-noeff {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border: 1px dashed var(--line-2);
+  border-radius: 11px;
+  padding: 10px 12px;
+}
+html.ui-v2 .ag2-insp-noeff .ag2-hint { flex: 1; font-size: 12px; }
+
+/* ---- Reminder row ---- */
+
+html.ui-v2 .ag2-insp-remrow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+html.ui-v2 .ag2-insp-remrow select,
+html.ui-v2 .ag2-insp-orgrow select,
+html.ui-v2 .ag2-insp-addrow select {
+  background: var(--surface-2);
+  border: 1px solid var(--line-2);
+  border-radius: 9px;
+  color: var(--text-2);
+  font-size: 11.5px;
+  padding: 5px 7px;
+  min-width: 0;
+  max-width: 100%;
+}
+
+/* ---- Blocked on ---- */
+
+html.ui-v2 .ag2-insp-blocker {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+html.ui-v2 .ag2-insp-blocker.cleared { opacity: 0.55; }
+html.ui-v2 .ag2-insp-bdot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--rose);
+  flex-shrink: 0;
+  align-self: center;
+}
+html.ui-v2 .ag2-insp-blocker.cleared .ag2-insp-bdot { background: var(--text-3); }
+html.ui-v2 .ag2-insp-bmain {
+  flex: 1;
+  min-width: 0;
+}
+html.ui-v2 .ag2-insp-btext {
+  font-size: 12.5px;
+  color: var(--text);
+  overflow-wrap: anywhere;
+}
+html.ui-v2 .ag2-insp-blocker.cleared .ag2-insp-btext { text-decoration: line-through; }
+html.ui-v2 .ag2-insp-dep {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+html.ui-v2 .ag2-insp-deplink {
+  flex: 1;
+  min-width: 0;
+  font-size: 12.5px;
+  color: var(--text-2);
+  cursor: pointer;
+  overflow-wrap: anywhere;
+}
+html.ui-v2 a.ag2-insp-deplink:hover { color: var(--iris-2); }
+html.ui-v2 .ag2-insp-addbtns {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+html.ui-v2 .ag2-insp-addrow {
+  display: flex;
+  gap: 7px;
+  align-items: center;
+}
+html.ui-v2 .ag2-insp-addrow input[type="text"] { flex: 1; min-width: 0; }
+html.ui-v2 .ag2-insp-addrow input[type="text"].mono {
+  font-family: var(--mono);
+  font-size: 11px;
+}
+html.ui-v2 .ag2-insp-addrow select { flex: 1; }
+html.ui-v2 .ag2-check {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--text-3);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+html.ui-v2 .ag2-check.top { align-items: flex-start; font-size: 12px; color: var(--text-2); }
+html.ui-v2 .ag2-check.top input { margin-top: 2px; }
+
+/* ---- Organization ---- */
+
+html.ui-v2 .ag2-insp-orgrow {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+html.ui-v2 .ag2-insp-orgrow > select { flex: 1; }
+html.ui-v2 .ag2-orgk {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--text-3);
+  width: 76px;
+  flex-shrink: 0;
+  padding-top: 5px;
+}
+html.ui-v2 .ag2-orgv {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  align-items: center;
+}
+html.ui-v2 .ag2-relchip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10.5px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-pill);
+  padding: 1px 8px;
+  color: var(--text-2);
+  max-width: 100%;
+}
+html.ui-v2 .ag2-relchip a {
+  color: inherit;
+  cursor: pointer;
+  overflow-wrap: anywhere;
+}
+html.ui-v2 .ag2-relchip a:hover { color: var(--iris-2); }
+html.ui-v2 .ag2-reladd {
+  border-radius: var(--r-pill) !important;
+  max-width: 150px;
+  font-size: 10.5px !important;
+  padding: 2px 6px !important;
+}
+html.ui-v2 .ag2-tagchip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--text-2);
+  background: var(--surface-3);
+  border-radius: 6px;
+  padding: 1px 7px;
+}
+html.ui-v2 .ag2-tagin {
+  width: 76px;
+  background: var(--surface-2);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 10.5px;
+  padding: 2px 7px;
+}
+html.ui-v2 .ag2-tagin:focus {
+  outline: none;
+  border-color: var(--iris);
+}
+
+/* ---- References ---- */
+
+html.ui-v2 .ag2-ref {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  padding: 5px 9px;
+}
+html.ui-v2 .ag2-ref.must { border-color: rgba(var(--iris-rgb), 0.45); }
+html.ui-v2 .ag2-ref-type {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-3);
+  flex-shrink: 0;
+}
+html.ui-v2 .ag2-ref-loc {
+  flex: 1;
+  min-width: 0;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text-2);
+  overflow-wrap: anywhere;
+}
+html.ui-v2 a.ag2-ref-loc {
+  color: var(--iris-2);
+  cursor: pointer;
+  text-decoration: none;
+}
+html.ui-v2 a.ag2-ref-loc:hover { text-decoration: underline; }
+html.ui-v2 .ag2-ref-must {
+  font-size: 9.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--iris);
+  flex-shrink: 0;
+}
+html.ui-v2 .agenda-ref-drift {
+  font-family: var(--mono);
+  font-size: 10px;
+  flex-shrink: 0;
+}
+html.ui-v2 .agenda-ref-drift[data-status="unchanged"] { color: var(--green); }
+html.ui-v2 .agenda-ref-drift[data-status="changed"] { color: var(--amber); }
+html.ui-v2 .agenda-ref-drift[data-status="missing"] { color: var(--rose); }
+
+/* ---- Thread ---- */
+
+html.ui-v2 .ag2-insp-thread {
+  margin-left: 3px;
+  border-left: 1px solid var(--line);
+}
+html.ui-v2 .ag2-insp-note {
+  position: relative;
+  padding: 0 0 10px 14px;
+}
+html.ui-v2 .ag2-insp-notedot {
+  position: absolute;
+  left: -4px;
+  top: 3px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--neutral-dot);
+}
+html.ui-v2 .ag2-insp-notedot.t-iris { background: var(--iris); }
+html.ui-v2 .ag2-insp-notedot.t-sky { background: var(--sky); }
+html.ui-v2 .ag2-insp-notemeta {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text-3);
+}
+html.ui-v2 .ag2-insp-notetext {
+  font-size: 12.5px;
+  color: var(--text-2);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  margin-top: 2px;
+}
+
+/* ---- Modal sheets (schedule + preview) ---- */
+
+#ag2-sheet[hidden] { display: none; }
+html.ui-v2 .ag2-sheet-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  background: rgba(4, 5, 8, 0.55);
+  backdrop-filter: blur(5px);
+}
+html.ui-v2 .ag2-sheet-panel {
+  position: fixed;
+  z-index: 61;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(540px, calc(100vw - 32px));
+  max-height: min(82vh, 720px);
+  overflow-y: auto;
+  overflow-x: hidden;
+  border-radius: 17px;
+  border: 1px solid var(--line-2);
+  background: linear-gradient(180deg, var(--surface-2), var(--surface));
+  box-shadow: var(--shadow-overlay);
+  padding: 18px 20px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+html.ui-v2 .ag2-sheet-head {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+html.ui-v2 .ag2-sheet-title {
+  font-size: 15px;
+  font-weight: 800;
+  color: var(--text);
+}
+html.ui-v2 .ag2-sheet-sub {
+  font-size: 12px;
+  color: var(--text-2);
+  margin-top: -6px;
+}
+html.ui-v2 .ag2-sheet-item {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--text-3);
+  border-left: 2px solid var(--iris);
+  padding-left: 9px;
+  overflow-wrap: anywhere;
+}
+html.ui-v2 .ag2-sheet-k {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-3);
+  margin-bottom: 5px;
+}
+html.ui-v2 .ag2-sheet-panel textarea {
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--surface-2);
+  border: 1px solid var(--line-2);
+  border-radius: 9px;
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 11.5px;
+  line-height: 1.5;
+  padding: 8px 10px;
+  resize: vertical;
+}
+html.ui-v2 .ag2-sheet-panel textarea:focus {
+  outline: none;
+  border-color: var(--iris);
+  box-shadow: 0 0 0 3px rgba(var(--iris-rgb), 0.22);
+}
+html.ui-v2 .ag2-sheet-grid {
+  display: grid;
+  grid-template-columns: 96px 1fr;
+  align-items: center;
+  row-gap: 8px;
+  column-gap: 10px;
+}
+html.ui-v2 .ag2-sheet-grid .ag2-sheet-k { margin-bottom: 0; }
+html.ui-v2 .ag2-sheet-grid input,
+html.ui-v2 .ag2-sheet-grid select,
+html.ui-v2 .ag2-sheet-inline input {
+  background: var(--surface-2);
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 11.5px;
+  padding: 5px 7px;
+  min-width: 0;
+}
+html.ui-v2 .ag2-sheet-grid select { font-family: var(--sans); }
+html.ui-v2 .ag2-sheet-inline {
+  display: flex;
+  gap: 7px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+html.ui-v2 .ag2-sheet-num {
+  width: 52px;
+  text-align: right;
+  background: var(--surface-2);
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 11.5px;
+  padding: 4px 7px;
+}
+html.ui-v2 .ag2-sheet-callout {
+  font-size: 11.5px;
+  color: var(--text-2);
+  border-radius: 9px;
+  padding: 7px 10px;
+}
+html.ui-v2 .ag2-sheet-callout.t-green {
+  background: rgba(var(--green-rgb), 0.08);
+  border: 1px solid rgba(var(--green-rgb), 0.26);
+}
+html.ui-v2 .ag2-sheet-callout.t-amber {
+  color: var(--amber);
+  background: rgba(var(--amber-rgb), 0.1);
+  border: 1px solid rgba(var(--amber-rgb), 0.26);
+}
+html.ui-v2 .ag2-sheet-error {
+  color: var(--rose);
+  font-size: 11.5px;
+  border-left: 2px solid var(--rose);
+  padding-left: 8px;
+  overflow-wrap: anywhere;
+}
+html.ui-v2 .ag2-sheet-prevwrap {
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  overflow: hidden;
+  background: var(--code-bg);
+  height: 50vh;
+}
+html.ui-v2 .ag2-prev-frame.full,
+html.ui-v2 .ag2-prev-text.full {
+  width: 100%;
+  height: 100%;
+  transform: none;
+  border: 0;
+  display: block;
+  box-sizing: border-box;
+}
+html.ui-v2 .ag2-prev-img.full {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
+}
+html.ui-v2 .ag2-sheet-prevfoot {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+/* ---- Reminder-policy popover ---- */
+
+#ag2-bell-pop[hidden] { display: none; }
+html.ui-v2 .ag2-bell-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 54;
+}
+html.ui-v2 .ag2-bell-panel {
+  position: fixed;
+  z-index: 55;
+  width: 344px;
+  max-width: calc(100vw - 24px);
+  border: 1px solid var(--line-2);
+  border-radius: 15px;
+  background: linear-gradient(180deg, var(--surface-2), var(--surface));
+  box-shadow: var(--shadow-menu);
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 11px;
+}
+html.ui-v2 .ag2-bell-head {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+html.ui-v2 .ag2-bell-title {
+  font-size: 13.5px;
+  font-weight: 800;
+  color: var(--text);
+}
+html.ui-v2 .ag2-bell-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+html.ui-v2 .ag2-bell-rowmain { flex: 1; min-width: 0; }
+html.ui-v2 .ag2-bell-k {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 2px;
+}
+html.ui-v2 .ag2-bell-times {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-left: 2px;
+}
+html.ui-v2 .ag2-bell-times input {
+  background: var(--surface-2);
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 11.5px;
+  padding: 4px 7px;
+}
+html.ui-v2 .ag2-bell-foot {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  color: var(--text-3);
+  border-top: 1px solid var(--line);
+  padding-top: 9px;
+  line-height: 1.6;
+}
+html.ui-v2 .ag2-seg-btn.u-info.active {
+  background: rgba(var(--sky-rgb), 0.14);
+  color: var(--sky);
+  box-shadow: inset 0 0 0 1px rgba(var(--sky-rgb), 0.4);
+}
+html.ui-v2 .ag2-seg-btn.u-attention.active {
+  background: rgba(var(--amber-rgb), 0.14);
+  color: var(--amber);
+  box-shadow: inset 0 0 0 1px rgba(var(--amber-rgb), 0.4);
+}
+html.ui-v2 .ag2-seg-btn.u-urgent.active {
+  background: rgba(var(--rose-rgb), 0.14);
+  color: var(--rose);
+  box-shadow: inset 0 0 0 1px rgba(var(--rose-rgb), 0.4);
+}
+
+/* ---- Toggle switch ---- */
+
+html.ui-v2 .ag2-tog {
+  width: 42px;
+  height: 24px;
+  border-radius: var(--r-pill);
+  border: 0;
+  cursor: pointer;
+  position: relative;
+  flex-shrink: 0;
+  transition: background var(--t-slow);
+  padding: 0;
+  background: var(--surface-3);
+}
+html.ui-v2 .ag2-tog.on { background: var(--iris); }
+html.ui-v2 .ag2-tog-knob {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+  transition: left var(--t-slow);
+}
+html.ui-v2 .ag2-tog.on .ag2-tog-knob { left: 21px; }

--- a/static/app/ui2-agenda-inspector.js
+++ b/static/app/ui2-agenda-inspector.js
@@ -455,6 +455,17 @@ function agendaInspGatesHtml(item) {
   });
   const empty = !blockers.length && !deps.length
     ? '<div class="ag2-hint">Nothing gates this item.</div>' : '';
+  // Blockers and dependency edges describe OPEN work — the daemon refuses
+  // them elsewhere, so the affordances only exist there.
+  if (item.status !== 'open') {
+    return `<section class="ag2-sec">
+      <div class="ag2-sec-head">
+        <span class="ag2-sec-label">Blocked on</span>
+        <span class="ag2-sec-hint">stated criteria &amp; prerequisites — nothing evaluates them; people do</span>
+      </div>
+      <div class="ag2-sec-body">${blockers.join('')}${deps.join('')}${empty}</div>
+    </section>`;
+  }
   const desc = agendaDescendantIds(item.id);
   const depOptions = (agendaItems || [])
     .filter((x) => x.id !== item.id && x.status === 'open' && !desc.has(x.id)
@@ -747,12 +758,11 @@ function agendaInspClick(e) {
     case 'close': agendaCloseInspector(); break;
     case 'copy-id': agendaCopyText(item.id, 'the full item id'); break;
     case 'title-edit':
-      if (item.status !== 'retired') {
-        agendaInspEditingTitle = true;
-        agendaInspTitleDraft = item.title;
-        agendaInspectorRender();
-        document.getElementById('ag2-insp-title-input')?.focus();
-      }
+      // Patch is presentation state and works on any status.
+      agendaInspEditingTitle = true;
+      agendaInspTitleDraft = item.title;
+      agendaInspectorRender();
+      document.getElementById('ag2-insp-title-input')?.focus();
       break;
     case 'title-save': agendaInspSaveTitle(item); break;
     case 'start': agendaOpenStartSheet(item.id, act); break;
@@ -1216,8 +1226,8 @@ function agendaPrevSheetHtml(item) {
     `<button type="button" class="ag2-seg-btn${i === s.pi ? ' active' : ''}" data-sheet-act="prev-view" data-view="${i}">${escapeHtml((pv.label || `#${i + 1}`).split(' — ')[0])}</button>`).join('');
   let media;
   if (p.kind === 'html' && p.url) {
-    media = `<iframe class="ag2-prev-frame full" sandbox="allow-scripts" referrerpolicy="no-referrer"
-      title="${escapeHtml(p.label || 'preview')}" data-preview-url="${escapeHtml(p.url)}"></iframe>`;
+    media = `<span class="ag2-prev-slot" data-preview-url="${escapeHtml(p.url)}"
+      data-preview-title="${escapeHtml(p.label || 'preview')}" data-preview-full="1"></span>`;
   } else if (p.kind === 'image' && p.url) {
     media = `<img class="ag2-prev-img full" src="${escapeHtml(p.url)}" alt="${escapeHtml(p.label || 'preview')}" />`;
   } else if (p.kind === 'text' && p.content) {

--- a/static/app/ui2-agenda-inspector.js
+++ b/static/app/ui2-agenda-inspector.js
@@ -1,0 +1,1422 @@
+// Agenda item inspector (redesign slice A): the right-side panel with the
+// full item anatomy — question answering, details, the scheduled-session
+// manifest, reminder, gates, organization, references, and the thread —
+// plus the schedule sheet, the preview sheet, and the reminder-policy
+// popover. Renders into #ag2-inspector (built by ui2-agenda-cards.js's
+// scaffold); ≥1180px it is an animated-width side panel, below that a
+// fixed overlay with a backdrop (pure CSS media query — same DOM).
+//
+// Everything item-authored renders escaped; ask preview HTML only inside
+// sandboxed srcdoc iframes (agendaHydratePreviewFrames). Ops are the
+// AgendaCommand vocabulary verbatim — nothing invented.
+
+let agendaInspWired = false;
+let agendaInspEditingTitle = false;
+let agendaInspTitleDraft = '';
+let agendaInspEditingBody = false;
+let agendaInspBodyDraft = '';
+let agendaInspAdds = { blocker: false, dep: false, ref: false };
+let agendaInspBlockerDraft = '';
+let agendaInspAnnDraft = '';
+let agendaInspTagDraft = '';
+let agendaInspRefDraft = '';
+let agendaInspRefMust = false;
+
+function agendaOpenInspector(id) {
+  if (!agendaFindItem(id)) return;
+  agendaSelId = id;
+  agendaInspEditingTitle = false;
+  agendaInspEditingBody = false;
+  agendaInspAdds = { blocker: false, dep: false, ref: false };
+  agendaInspBlockerDraft = '';
+  agendaInspAnnDraft = '';
+  agendaInspTagDraft = '';
+  agendaInspRefDraft = '';
+  agendaInspRefMust = false;
+  agendaRenderTab();
+  agendaInspectorRender();
+}
+
+// Returns true when it actually closed something (the Escape chain).
+function agendaCloseInspector() {
+  if (!agendaSelId) return false;
+  agendaSelId = null;
+  agendaRenderTab();
+  agendaInspectorRender();
+  return true;
+}
+
+function agendaInspectorRender() {
+  const host = document.getElementById('ag2-inspector');
+  const backdrop = document.getElementById('ag2-inspector-backdrop');
+  if (!host) return;
+  if (!agendaInspWired) {
+    agendaInspWired = true;
+    host.addEventListener('click', agendaInspClick);
+    host.addEventListener('input', agendaInspInput);
+    host.addEventListener('change', agendaInspChange);
+    host.addEventListener('keydown', agendaInspKeydown);
+    if (backdrop) backdrop.addEventListener('click', () => agendaCloseInspector());
+  }
+  const item = agendaSelId ? agendaFindItem(agendaSelId) : null;
+  if (!item) {
+    // Selection gone (retired elsewhere, fold moved): close honestly.
+    agendaSelId = null;
+    host.classList.remove('open');
+    if (backdrop) backdrop.hidden = true;
+    host.innerHTML = '';
+    return;
+  }
+  host.classList.add('open');
+  if (backdrop) backdrop.hidden = false;
+  agendaRenderPreservingFocus(host, () => {
+    host.innerHTML = `<div class="ag2-insp-col">
+      ${agendaInspHeaderHtml(item)}
+      <div class="ag2-insp-scroll">
+        ${agendaInspQuestionHtml(item)}
+        ${agendaInspDetailsHtml(item)}
+        ${agendaInspEffectHtml(item)}
+        ${agendaInspReminderHtml(item)}
+        ${agendaInspGatesHtml(item)}
+        ${agendaInspOrganizationHtml(item)}
+        ${agendaInspRefsHtml(item)}
+        ${agendaInspThreadHtml(item)}
+      </div>
+    </div>`;
+  });
+  agendaHydratePreviewFrames(host);
+}
+
+// ---- Header ----
+
+function agendaInspHeaderHtml(item) {
+  const statusTone = item.status === 'open' ? 'iris' : item.status === 'done' ? 'green' : 'neutral';
+  const p = item.provenance || {};
+  const s = agendaSessionInfo(p.session_id);
+  const byHtml = agendaActorHtml(p);
+  const title = agendaInspEditingTitle
+    ? `<div class="ag2-insp-titleedit">
+        <input type="text" id="ag2-insp-title-input" data-fkey="insp-title" maxlength="500"
+               value="${escapeHtml(agendaInspTitleDraft)}" aria-label="Title" />
+        <button type="button" class="ag2-btn" data-act="title-save">Save</button>
+      </div>`
+    : `<div class="ag2-insp-title" data-act="title-edit" title="Click to edit the title">${escapeHtml(item.title)}</div>`;
+  const acts = [];
+  const A = (label, act, cls, tip) =>
+    acts.push(`<button type="button" class="ag2-btn ${cls || ''}" data-act="${act}"${tip ? ` title="${escapeHtml(tip)}"` : ''}>${escapeHtml(label)}</button>`);
+  if (item.status === 'open') {
+    A('Start a session', 'start', 'prim',
+      'Opens the confirm sheet — review exactly what the spawn runs with');
+    const sid = agendaFollowUpSid(item);
+    if (sid) {
+      A('Follow up', 'follow-live', '',
+        'The origin conversation is live — open the composer targeted at it with this item quoted');
+    } else if (agendaFollowUpResumable(item)) {
+      A('Follow up (resumes session)', 'follow-resume', '',
+        'The origin conversation has ended — resume it (same conversation, its recorded project) with this item quoted');
+    }
+    if (item.kind === 'question') {
+      A('Close unanswered', 'complete', 'ghost',
+        'Completes without an answer — the asker is told the outcome');
+    } else {
+      A('Mark done', 'complete');
+    }
+    A('Retire', 'retire', 'danger',
+      'Hides from open lenses — never deletes; history is append-only');
+  } else {
+    A('Reopen', 'reopen', '',
+      item.kind === 'question'
+        ? 'Re-asks — clears the current reply view; the log keeps every reply' : '');
+    if (item.status === 'done') A('Retire', 'retire', 'danger');
+  }
+  return `<div class="ag2-insp-head">
+    <div class="ag2-insp-chips">
+      <span class="ag2-kind">${escapeHtml(item.kind)}</span>
+      ${agendaChipHtml(item.status, statusTone)}
+      <button type="button" class="ag2-idbtn" data-act="copy-id" title="Copy the full item id">${escapeHtml(item.id.slice(0, 6).toLowerCase())}</button>
+      <span class="ag2-spacer"></span>
+      <button type="button" class="ag2-x" data-act="close" title="Close — esc">×</button>
+    </div>
+    ${title}
+    <div class="ag2-insp-ctx">
+      <span>parked ${escapeHtml(agendaRelTime(p.created_ms))}${byHtml ? ' by' : ''}</span>
+      ${byHtml}
+      <span>· updated ${escapeHtml(agendaRelTime(item.updated_ms))}</span>
+    </div>
+    <div class="ag2-insp-actions">${acts.join('')}</div>
+  </div>`;
+}
+
+// ---- Question section ----
+
+function agendaInspQuestionHtml(item) {
+  if (item.kind !== 'question') return '';
+  const id = escapeHtml(item.id);
+  const questions = (item.ask && item.ask.questions) || [];
+  const blocks = questions.map((q, qi) => {
+    const picks = agendaQaPicks(item.id, qi);
+    const noteKey = `${item.id}:${qi}`;
+    const noteRow = item.status === 'open' && picks.length && (q.previews || []).length
+      ? `<input type="text" class="ag2-insp-notein" data-qa-note="${escapeHtml(noteKey)}" data-fkey="note-${qi}"
+           placeholder="Note anchored to “${escapeHtml(picks[0])}” — travels with the structured answer (optional)…"
+           value="${escapeHtml(agendaQaNotes[noteKey] || '')}" />`
+      : '';
+    return `<div class="ag2-insp-q">
+      <div class="ag2-insp-qtext">${escapeHtml(q.question)}</div>
+      ${agendaQaPillsHtml(item, qi)}
+      ${agendaPreviewStripHtml(item, qi, 'insp')}
+      ${(q.previews || []).length ? '<div class="ag2-hint">rendered previews from the ask’s blob store — sandboxed, quoted; the blobs are the agent’s renders, never live pages</div>' : ''}
+      ${noteRow}
+    </div>`;
+  }).join('');
+  let composer = '';
+  if (item.status === 'open') {
+    const hasAsk = questions.length > 0;
+    const draft = agendaQaDrafts[item.id] || '';
+    const railDoor = hasAsk
+      ? `<button type="button" class="ag2-linkbtn" data-act="rail-open">Open on the question rail ›</button>`
+      : '';
+    const note = hasAsk
+      ? `Rich ask #${item.ask.ask_id} — parked on every dashboard’s question rail; answering here resolves it everywhere. Nothing blocks, nothing expires.`
+      : `Parked ${agendaRelTime((item.provenance || {}).created_ms)} — the answer lands on the item; a live asking session hears it, and an ended one’s successor reads it at session start.`;
+    composer = `${hasAsk ? '' : `<div class="ag2-insp-qtext">${escapeHtml(item.title)}</div>`}
+      <div class="ag2-qa-row">
+        <input type="text" class="ag2-qa-input" maxlength="4000" data-qa-draft="${id}" data-fkey="insp-qa"
+               placeholder="${hasAsk ? 'Add a note with your pick (optional)…' : 'Type your answer…'}"
+               aria-label="Answer" value="${escapeHtml(draft)}" />
+        <button type="button" class="ag2-btn prim" data-answer="${id}">Answer</button>
+      </div>
+      <div class="ag2-hint">${escapeHtml(note)} ${railDoor}</div>`;
+  }
+  let resolved = '';
+  if (item.answer) {
+    const a = item.answer;
+    const rows = [];
+    if (a.structured) {
+      const sByQ = a.structured;
+      questions.forEach((q) => {
+        const picks = (sByQ.selections || {})[q.question] || [];
+        const followup = (sByQ.followups || {})[q.question];
+        const notes = ((sByQ.annotations || {})[q.question] || []);
+        if (!picks.length && followup === undefined && !notes.length
+          && !((sByQ.answers || {})[q.question])) return;
+        rows.push(`<div class="ag2-insp-resq">
+          <div class="ag2-insp-resq-q">${escapeHtml(q.question)}</div>
+          <div class="ag2-insp-resq-picks">
+            ${picks.map((p) => `<span class="ag2-respick">${escapeHtml(p)}</span>`).join('')}
+            ${followup !== undefined ? `<span class="ag2-restext">${escapeHtml(followup)}</span>` : ''}
+          </div>
+          ${notes.map((n) => `<div class="ag2-resnote">anchored to “${escapeHtml(n.preview)}”: ${escapeHtml(n.note)}</div>`).join('')}
+        </div>`);
+      });
+    }
+    if (!rows.length && a.text) {
+      rows.push(`<div class="ag2-insp-resq"><span class="ag2-restext">${escapeHtml(a.text)}</span></div>`);
+    }
+    const who = agendaActorLabel(a) || 'unattributed';
+    const delivery = a.delivered === false
+      ? ' · awaiting pickup — no live session heard it'
+      : a.delivered === true ? ' · delivered into the asking session' : '';
+    const railView = item.status === 'done' && questions.length
+      ? ` <button type="button" class="ag2-linkbtn" data-act="rail-view">View the rail record ›</button>`
+      : '';
+    resolved = `<div class="ag2-insp-resolved">
+      ${rows.join('')}
+      <div class="ag2-hint">answered by ${escapeHtml(who)} · ${escapeHtml(agendaRelTime(a.at_ms))}${escapeHtml(delivery)}${railView}</div>
+    </div>`;
+  }
+  const stateChip = item.status === 'open' && item.dismissed
+    ? `<div>${agendaChipHtml('dismissed · still open', 'neutral', agendaDismissedTip(item.dismissed), true)}</div>`
+    : '';
+  return `<section class="ag2-sec">
+    <div class="ag2-sec-head"><span class="ag2-sec-label">Question</span></div>
+    <div class="ag2-sec-body">${blocks}${composer}${resolved}${stateChip}</div>
+  </section>`;
+}
+
+// ---- Details (body) ----
+
+function agendaInspDetailsHtml(item) {
+  let body;
+  if (agendaInspEditingBody) {
+    body = `<div class="ag2-insp-bodyedit">
+      <textarea rows="6" id="ag2-insp-body-input" data-fkey="insp-body" aria-label="Body">${escapeHtml(agendaInspBodyDraft)}</textarea>
+      <div class="ag2-row-end">
+        <button type="button" class="ag2-btn ghost" data-act="body-cancel">Cancel</button>
+        <button type="button" class="ag2-btn prim" data-act="body-save">Save</button>
+      </div>
+    </div>`;
+  } else if (item.body) {
+    body = `<div class="ag2-insp-body">${escapeHtml(item.body)}</div>`;
+  } else {
+    body = '<div class="ag2-hint">No body — the title is the whole note.</div>';
+  }
+  return `<section class="ag2-sec">
+    <div class="ag2-sec-head">
+      <span class="ag2-sec-label">Details</span>
+      <span class="ag2-sec-hint">quoted data — never instructions</span>
+      <span class="ag2-spacer"></span>
+      ${agendaInspEditingBody ? '' : '<button type="button" class="ag2-linkbtn" data-act="body-edit">edit</button>'}
+    </div>
+    <div class="ag2-sec-body">${body}</div>
+  </section>`;
+}
+
+// ---- Scheduled session ----
+
+function agendaInspEffectHtml(item) {
+  const st = agendaEffectState(item);
+  let body;
+  if (!st) {
+    body = `<div class="ag2-insp-noeff">
+      <div class="ag2-hint">No session is scheduled on this item.</div>
+      <button type="button" class="ag2-btn" data-act="sched">Schedule one…</button>
+    </div>`;
+  } else {
+    const e = st.effect;
+    const m = st.manifest;
+    const states = {
+      pending: ['amber', 'Waiting on your approval'],
+      armed: ['sky', `Armed — fires ${agendaRelTime(st.next)}`],
+      standing: ['green', `Standing — every ${agendaCadenceLabel(st.rec ? st.rec.every_ms : 0)}`],
+      suspended: ['amber', `Suspended — ${e.consecutive_failures} failures in a row`],
+      running: ['iris', 'Running now'],
+      finished: ['neutral', 'Ran — outcome below'],
+    };
+    const [tone, stateLabel] = states[st.kind] || states.finished;
+    const rows = [];
+    const R = (k, v, mono) =>
+      rows.push(`<div class="ag2-eff-k">${escapeHtml(k)}</div><div class="ag2-eff-v${mono ? ' mono' : ''}">${escapeHtml(v)}</div>`);
+    R('when', st.rec
+      ? `every ${agendaCadenceLabel(st.rec.every_ms)} · next ${agendaAbsTime(st.next)}`
+      : `${agendaAbsTime(m.fire_at_ms)} (${agendaRelTime(m.fire_at_ms)})`);
+    if (st.rec && (st.rec.until_ms || st.rec.max_occurrences)) {
+      R('ends', `${st.rec.until_ms ? agendaAbsTime(st.rec.until_ms) : ''}${st.rec.max_occurrences ? `${st.rec.until_ms ? ' or ' : ''}after ${st.rec.max_occurrences} runs` : ''}`);
+    }
+    R('shape', `${m.interactive ? 'interactive — opens and waits for you' : 'goal run — autonomous, writes back'} · ${m.orchestrate ? 'orchestrated' : 'direct'}`);
+    R('project', m.project_root || 'inherited at fire time: parking session’s root, else daemon default', !!m.project_root);
+    const cfg = m.agent_config || null;
+    R('config', cfg
+      ? `${[cfg.agent, ...Object.entries(cfg).filter(([k]) => k !== 'agent').map(([, v]) => v)].filter(Boolean).join(' · ')} — explicit, recorded on the manifest`
+      : 'inherits daemon defaults (Settings → reasoning)', !!cfg);
+    if (st.rec) {
+      R('on failure', `suspend after ${st.threshold} failed runs in a row — surfaced, never silently re-fired`);
+    }
+    let lastRun = '';
+    if (e.last_run) {
+      const run = e.last_run;
+      const runTone = run.state === 'completed' ? 'green'
+        : run.state === 'failed' ? 'rose'
+          : run.state === 'started' ? 'iris' : 'amber';
+      const s = run.session_id && agendaSessionInfo(run.session_id);
+      const sessionLink = s && s.key
+        ? ` <a class="ag2-linkbtn" data-jump-session="${escapeHtml(s.key)}">view session ›</a>`
+        : '';
+      lastRun = `<div class="ag2-eff-lastrun">
+        <div class="ag2-eff-lastrun-head">
+          ${agendaChipHtml(`last run · ${run.state}`, runTone)}
+          <span class="ag2-hint">${escapeHtml(`${agendaRelTime(run.at_ms)} · occurrence ${run.occurrence_id}`)}</span>
+          ${sessionLink}
+        </div>
+        ${run.note ? `<div class="ag2-eff-note">${escapeHtml(run.note)}</div>` : ''}
+      </div>`;
+    }
+    const acts = [];
+    const A = (label, act, cls, tip) =>
+      acts.push(`<button type="button" class="ag2-btn ${cls || ''}" data-act="${act}"${tip ? ` title="${escapeHtml(tip)}"` : ''}>${escapeHtml(label)}</button>`);
+    if (st.kind === 'pending') {
+      A('Approve this exact plan', 'eff-approve', 'prim',
+        `Binds digest ${String(e.digest || '').slice(0, 8)}… — any edit voids it`);
+      A('Edit schedule…', 'sched');
+    } else if (st.kind === 'armed') {
+      A('Edit (voids approval)', 'sched');
+      A('Revoke approval', 'eff-revoke', 'danger', 'Instant, owner-surface only');
+    } else if (st.kind === 'standing') {
+      A('Run now', 'eff-run-now', '',
+        'One extra occurrence of the approved digest — within the reviewed decision, no new ceremony');
+      A('Edit (voids approval)', 'sched');
+      A('Revoke', 'eff-revoke', 'danger');
+    } else if (st.kind === 'suspended') {
+      A('Re-approve to re-arm', 'eff-approve', 'prim',
+        'Same digest, one click — resets the failure streak');
+      A('Revoke', 'eff-revoke', 'danger');
+    } else if (st.kind === 'running') {
+      // In-flight: nothing to arm or edit mid-run; the last-run row links
+      // the session.
+    } else {
+      A('Schedule again…', 'sched');
+    }
+    body = `<div class="ag2-effcard t-${tone}">
+      <div class="ag2-effcard-head">
+        <span class="ag2-eff-dot"></span>
+        <span class="ag2-eff-state">${escapeHtml(stateLabel)}</span>
+        <span class="ag2-spacer"></span>
+        <span class="ag2-hint mono">digest ${escapeHtml(String(e.digest || '').slice(0, 10))}…${e.approval ? ' · approved' : ' · unapproved'}</span>
+      </div>
+      <div class="ag2-eff-grid">${rows.join('')}</div>
+      <div class="ag2-eff-goal">${escapeHtml(m.goal || '')}</div>
+      ${lastRun}
+      ${acts.length ? `<div class="ag2-insp-actions">${acts.join('')}</div>` : ''}
+    </div>`;
+  }
+  return `<section class="ag2-sec">
+    <div class="ag2-sec-head">
+      <span class="ag2-sec-label">Scheduled session</span>
+      <span class="ag2-sec-hint">nothing fires without your approval of the exact plan</span>
+    </div>
+    <div class="ag2-sec-body">${body}</div>
+  </section>`;
+}
+
+// ---- Reminder ----
+
+function agendaInspReminderHtml(item) {
+  const overdue = item.due_ms && item.due_ms < Date.now();
+  const dueChip = item.due_ms
+    ? agendaChipHtml(`${overdue ? 'overdue — was ' : ''}${agendaAbsTime(item.due_ms)} · ${agendaRelTime(item.due_ms)}`,
+      overdue ? 'amber' : 'sky')
+    : agendaChipHtml('no reminder', 'neutral');
+  const policy = agendaReminderPolicy;
+  const urgency = agendaItemUrgency(item.id);
+  const defaultUrgency = (policy && policy.default_urgency) || 'attention';
+  const options = ['default', 'mute', 'info', 'attention', 'urgent'].map((v) => {
+    const label = v === 'default' ? `default (${defaultUrgency})` : v;
+    return `<option value="${v}"${v === urgency ? ' selected' : ''}>${label}</option>`;
+  }).join('');
+  const minToHhmm = (min) =>
+    `${String(Math.floor(min / 60)).padStart(2, '0')}:${String(min % 60).padStart(2, '0')}`;
+  const note = !policy ? ''
+    : !policy.enabled
+      ? 'Reminders are globally off — nothing fires until you re-enable them.'
+      : `Delivery follows your policy: ${policy.quiet_hours ? `quiet hours ${minToHhmm(policy.quiet_hours.start_min)}–${minToHhmm(policy.quiet_hours.end_min)} defer everything; ` : ''}anything staler than ${policy.staleness_hours}h folds into a digest. Completing or retiring cancels the pending reminder.`;
+  return `<section class="ag2-sec">
+    <div class="ag2-sec-head">
+      <span class="ag2-sec-label">Reminder</span>
+      <span class="ag2-sec-hint">a reminder notifies you — it never authorizes work</span>
+    </div>
+    <div class="ag2-sec-body">
+      <div class="ag2-insp-remrow">
+        ${dueChip}
+        <select data-act-change="due-preset" aria-label="Change the reminder">
+          <option value="">Change…</option>
+          <option value="3h">In 3 hours</option>
+          <option value="eve">This evening 18:00</option>
+          <option value="tom">Tomorrow 09:00</option>
+          <option value="mon">Next Monday 09:00</option>
+          <option value="clear">No reminder</option>
+        </select>
+        <span class="ag2-spacer"></span>
+        <span class="ag2-hint">loudness</span>
+        <select data-act-change="urgency" aria-label="Reminder loudness"
+                title="Per-item override on your reminder policy (settings.manage — an agenda.write grant can’t raise its own loudness)">${options}</select>
+      </div>
+      ${note ? `<div class="ag2-hint">${escapeHtml(note)}</div>` : ''}
+    </div>
+  </section>`;
+}
+
+// ---- Blocked on (blockers + prerequisites) ----
+
+function agendaInspGatesHtml(item) {
+  const id = escapeHtml(item.id);
+  const blockers = (item.blockers || []).map((b) => {
+    const meta = [
+      b.cleared ? `cleared ${agendaRelTime(b.cleared.at_ms)} by ${agendaActorLabel(b.cleared) || 'unattributed'}` : '',
+      `set ${agendaRelTime(b.set_ms)} by ${agendaActorLabel(b) || 'unattributed'}`,
+      'nothing evaluates this; people do',
+    ].filter(Boolean).join(' · ');
+    const clear = !b.cleared && item.status === 'open'
+      ? `<button type="button" class="ag2-btn" data-clear-blocker="${escapeHtml(b.blocker_id)}"
+           title="Clearing is an op, never a deletion — the entry stays as history">Clear</button>`
+      : '';
+    return `<div class="ag2-insp-blocker${b.cleared ? ' cleared' : ''}">
+      <span class="ag2-insp-bdot"></span>
+      <div class="ag2-insp-bmain">
+        <div class="ag2-insp-btext">${escapeHtml(b.criterion)}</div>
+        <div class="ag2-hint">${escapeHtml(meta)}</div>
+      </div>
+      ${clear}
+    </div>`;
+  });
+  const deps = (item.relies_on || []).map((d) => {
+    const target = agendaFindItem(d.target_id);
+    const state = !target ? ['missing', 'rose']
+      : target.status === 'done' ? ['satisfied', 'green']
+        : target.status === 'retired' ? ['retired — review', 'amber']
+          : ['open', 'neutral'];
+    const title = target ? target.title : `${d.target_id.slice(0, 10)}…`;
+    return `<div class="ag2-insp-dep">
+      ${agendaChipHtml(state[0], state[1])}
+      ${target
+    ? `<a class="ag2-insp-deplink" data-open-item="${escapeHtml(target.id)}">waits on “${escapeHtml(title)}”</a>`
+    : `<span class="ag2-insp-deplink">waits on ${escapeHtml(title)}</span>`}
+      <button type="button" class="ag2-x" data-remove-dep="${escapeHtml(d.target_id)}" title="Drop the edge (the log keeps history)">×</button>
+    </div>`;
+  });
+  const empty = !blockers.length && !deps.length
+    ? '<div class="ag2-hint">Nothing gates this item.</div>' : '';
+  const desc = agendaDescendantIds(item.id);
+  const depOptions = (agendaItems || [])
+    .filter((x) => x.id !== item.id && x.status === 'open' && !desc.has(x.id)
+      && !(item.relies_on || []).some((d) => d.target_id === x.id))
+    .map((x) => `<option value="${escapeHtml(x.id)}">${escapeHtml(x.title.slice(0, 46))}</option>`)
+    .join('');
+  const blockerAdd = agendaInspAdds.blocker
+    ? `<div class="ag2-insp-addrow">
+        <input type="text" data-fkey="blocker-add" data-draft="blocker" maxlength="4000"
+               placeholder="A human criterion — e.g. “api access granted”; nothing will evaluate it"
+               value="${escapeHtml(agendaInspBlockerDraft)}" aria-label="Blocker criterion" />
+        <button type="button" class="ag2-btn" data-act="blocker-add">Set blocker</button>
+      </div>` : '';
+  const depAdd = agendaInspAdds.dep
+    ? `<div class="ag2-insp-addrow">
+        <select data-act-change="dep-add" aria-label="This item waits on">
+          <option value="">This item waits on…</option>${depOptions}
+        </select>
+      </div>` : '';
+  return `<section class="ag2-sec">
+    <div class="ag2-sec-head">
+      <span class="ag2-sec-label">Blocked on</span>
+      <span class="ag2-sec-hint">stated criteria &amp; prerequisites — nothing evaluates them; people do</span>
+    </div>
+    <div class="ag2-sec-body">
+      ${blockers.join('')}${deps.join('')}${empty}
+      <div class="ag2-insp-addbtns">
+        <button type="button" class="ag2-dashbtn" data-act="toggle-blocker-add">+ state a blocker</button>
+        <button type="button" class="ag2-dashbtn" data-act="toggle-dep-add">+ add a prerequisite</button>
+      </div>
+      ${blockerAdd}${depAdd}
+    </div>
+  </section>`;
+}
+
+// ---- Organization (placement, see-also, tags) ----
+
+function agendaInspOrganizationHtml(item) {
+  const desc = agendaDescendantIds(item.id);
+  const others = (agendaItems || []).filter((x) => x.id !== item.id && x.status !== 'retired');
+  const placeOptions = others
+    .filter((x) => !desc.has(x.id))
+    .sort((a, b) => agendaChildrenOf(b.id).length - agendaChildrenOf(a.id).length)
+    .map((x) => {
+      const hub = agendaChildrenOf(x.id).length ? '▣ ' : '';
+      const selected = item.part_of && item.part_of.parent_id === x.id ? ' selected' : '';
+      return `<option value="${escapeHtml(x.id)}"${selected}>${hub}${escapeHtml(x.title.slice(0, 46))}</option>`;
+    }).join('');
+  const partners = agendaRelationPartners(item);
+  const rels = [...partners].map((pid) => {
+    const target = agendaFindItem(pid);
+    if (!target) return '';
+    return `<span class="ag2-relchip">
+      <a data-open-item="${escapeHtml(pid)}">${escapeHtml(target.title.slice(0, 34))}</a>
+      <button type="button" class="ag2-x" data-remove-rel="${escapeHtml(pid)}" title="Remove the see-also edge (the log keeps history)">×</button>
+    </span>`;
+  }).join('');
+  const relOptions = others
+    .filter((x) => !partners.has(x.id))
+    .map((x) => `<option value="${escapeHtml(x.id)}">${escapeHtml(x.title.slice(0, 46))}</option>`)
+    .join('');
+  const tags = (item.tags || []).map((t) =>
+    `<span class="ag2-tagchip">${escapeHtml(t)}<button type="button" class="ag2-x" data-remove-tag="${escapeHtml(t)}" title="Remove tag">×</button></span>`).join('');
+  return `<section class="ag2-sec">
+    <div class="ag2-sec-head">
+      <span class="ag2-sec-label">Organization</span>
+      <span class="ag2-sec-hint">pure navigation — grouping never hides, blocks, or completes anything</span>
+    </div>
+    <div class="ag2-sec-body">
+      <div class="ag2-insp-orgrow">
+        <span class="ag2-orgk">Filed under</span>
+        <select data-act-change="place" aria-label="Filed under">
+          <option value="">— not filed (stays in every lens either way)</option>
+          ${placeOptions}
+        </select>
+      </div>
+      <div class="ag2-insp-orgrow">
+        <span class="ag2-orgk">See also</span>
+        <div class="ag2-orgv">
+          ${rels}
+          <select class="ag2-reladd" data-act-change="rel-add" aria-label="Relate to">
+            <option value="">+ relate…</option>${relOptions}
+          </select>
+        </div>
+      </div>
+      <div class="ag2-insp-orgrow">
+        <span class="ag2-orgk">Tags</span>
+        <div class="ag2-orgv">
+          ${tags}
+          <input type="text" class="ag2-tagin" data-fkey="tag-add" data-draft="tag" maxlength="60"
+                 placeholder="+ tag" aria-label="Add a tag" value="${escapeHtml(agendaInspTagDraft)}" />
+        </div>
+      </div>
+    </div>
+  </section>`;
+}
+
+// ---- References ----
+
+function agendaInspRefsHtml(item) {
+  const refs = item.refs || [];
+  let hasFileDigest = false;
+  const rows = refs.map((r) => {
+    const label = r.label ? `${r.label} — ` : '';
+    let target;
+    if (r.ref_type === 'url') {
+      target = `<a class="ag2-ref-loc" href="${escapeHtml(r.locator)}" target="_blank" rel="noopener noreferrer nofollow">${escapeHtml(label + r.locator)}</a>`;
+    } else if (r.ref_type === 'session') {
+      const s = agendaSessionInfo(r.locator);
+      const text = label + ((s && s.name) || `session ${String(r.locator).slice(0, 12)}`);
+      target = s && s.key
+        ? `<a class="ag2-ref-loc" data-jump-session="${escapeHtml(s.key)}" title="${escapeHtml(r.locator)}">${escapeHtml(text)}</a>`
+        : `<span class="ag2-ref-loc" title="${escapeHtml(r.locator)}">${escapeHtml(text)}</span>`;
+    } else if (r.ref_type === 'memory') {
+      target = `<a class="ag2-ref-loc" data-open-claim="${escapeHtml(r.locator)}" title="${escapeHtml(r.locator)}">${escapeHtml(label || 'claim ')}${escapeHtml(label ? '' : String(r.locator).slice(0, 12))}</a>`;
+    } else {
+      if (r.digest) hasFileDigest = true;
+      target = `<span class="ag2-ref-loc" title="${escapeHtml(r.digest ? `sha256 ${r.digest.slice(0, 16)}… recorded at attach — the digest travels; blobs never do` : r.locator)}">${escapeHtml(label + r.locator)}</span>`;
+    }
+    const must = r.must_read
+      ? '<span class="ag2-ref-must" title="A pointer the reading agent weighs — not a standing order">must-read</span>'
+      : '';
+    const drift = r.ref_type === 'file' && r.digest
+      ? `<span class="agenda-ref-drift" data-item="${escapeHtml(item.id)}" data-locator="${escapeHtml(r.locator)}"></span>`
+      : '';
+    return `<div class="ag2-ref${r.must_read ? ' must' : ''}">
+      <span class="ag2-ref-type">${escapeHtml(r.ref_type)}</span>
+      ${target}${must}${drift}
+      <button type="button" class="ag2-x" data-remove-ref-type="${escapeHtml(r.ref_type)}" data-remove-ref-loc="${escapeHtml(r.locator)}"
+              title="Remove the pointer (an op — the log keeps history)">×</button>
+    </div>`;
+  }).join('');
+  const empty = refs.length ? '' : '<div class="ag2-hint">No pointers yet — park the brief’s path, not its text.</div>';
+  const verify = hasFileDigest
+    ? '<button type="button" class="ag2-linkbtn" data-act="verify-refs" title="Re-hash file refs against their attach-time sha256 — on demand, never on list render">Verify files</button>'
+    : '';
+  const addRow = agendaInspAdds.ref
+    ? `<div class="ag2-insp-addrow">
+        <input type="text" class="mono" data-fkey="ref-add" data-draft="ref" maxlength="2000"
+               placeholder="A path, URL, claim id, or session id — the type is inferred"
+               value="${escapeHtml(agendaInspRefDraft)}" aria-label="Pointer locator" />
+        <label class="ag2-check"><input type="checkbox" data-act-change="ref-must"${agendaInspRefMust ? ' checked' : ''}>must-read</label>
+        <button type="button" class="ag2-btn" data-act="ref-add">Attach</button>
+      </div>` : '';
+  return `<section class="ag2-sec">
+    <div class="ag2-sec-head">
+      <span class="ag2-sec-label">References</span>
+      <span class="ag2-sec-hint">typed pointers, never content — bodies go stale, pointers don’t</span>
+      <span class="ag2-spacer"></span>
+      ${verify}
+    </div>
+    <div class="ag2-sec-body">
+      ${rows}${empty}
+      <div class="ag2-insp-addbtns">
+        <button type="button" class="ag2-dashbtn" data-act="toggle-ref-add">+ attach a pointer</button>
+      </div>
+      ${addRow}
+    </div>
+  </section>`;
+}
+
+// ---- Thread ----
+
+function agendaInspThreadHtml(item) {
+  const notes = item.annotations || [];
+  const all = agendaExpandedThreads.has(item.id);
+  const shown = all ? notes : notes.slice(-3);
+  const rail = shown.map((n) => {
+    const who = n.kind === 'dashboard' ? 'you'
+      : (agendaActorLabel(n) || n.source || 'unattributed');
+    const meta = `${who}${n.source ? ` · --source ${n.source}` : ''} · ${agendaRelTime(n.at_ms)}`;
+    const dot = n.kind === 'dashboard' ? 'iris' : n.source === 'triage' ? 'sky' : 'neutral';
+    return `<div class="ag2-insp-note">
+      <span class="ag2-insp-notedot t-${dot}"></span>
+      <div class="ag2-insp-notemeta">${escapeHtml(meta)}</div>
+      <div class="ag2-insp-notetext">${escapeHtml(n.text)}</div>
+    </div>`;
+  }).join('');
+  const more = notes.length > 3
+    ? `<button type="button" class="ag2-linkbtn" data-act="thread-all">${all ? 'collapse' : `show all ${notes.length}`}</button>`
+    : '';
+  const empty = notes.length ? '' : '<div class="ag2-hint">No notes yet — the thread is the handoff trail.</div>';
+  return `<section class="ag2-sec">
+    <div class="ag2-sec-head">
+      <span class="ag2-sec-label">Thread</span>
+      <span class="ag2-sec-hint">${escapeHtml(`${notes.length} note${notes.length === 1 ? '' : 's'} — attributed, append-only`)}</span>
+    </div>
+    <div class="ag2-sec-body">
+      ${empty}${rail ? `<div class="ag2-insp-thread">${rail}</div>` : ''}${more}
+      <div class="ag2-insp-addrow">
+        <input type="text" data-fkey="ann-add" data-draft="ann" maxlength="4000"
+               placeholder="Add a note to the thread — attributed to you" aria-label="Annotation"
+               value="${escapeHtml(agendaInspAnnDraft)}" />
+        <button type="button" class="ag2-btn" data-act="ann-add">Annotate</button>
+      </div>
+    </div>
+  </section>`;
+}
+
+// ---- Inspector event delegation ----
+
+function agendaInspItem() {
+  return agendaSelId ? agendaFindItem(agendaSelId) : null;
+}
+
+function agendaInspClick(e) {
+  const item = agendaInspItem();
+  if (!item) return;
+  const sessionLink = e.target.closest('a.agenda-session-link');
+  if (sessionLink) {
+    e.preventDefault();
+    agendaJumpToSession(sessionLink.dataset.sessionKey);
+    return;
+  }
+  const jump = e.target.closest('[data-jump-session]');
+  if (jump) {
+    agendaJumpToSession(jump.dataset.jumpSession);
+    return;
+  }
+  const claim = e.target.closest('[data-open-claim]');
+  if (claim) {
+    routeTo('memory');
+    if (typeof memoryGotoClaim === 'function') memoryGotoClaim(claim.dataset.openClaim);
+    return;
+  }
+  const openItem = e.target.closest('[data-open-item]');
+  if (openItem) {
+    agendaOpenInspector(openItem.dataset.openItem);
+    return;
+  }
+  const pill = e.target.closest('.ag2-pill');
+  if (pill) {
+    if (!(item.answer && item.answer.structured)) {
+      agendaQaTogglePick(item, Number(pill.dataset.pillQ), pill.dataset.pillLabel);
+    }
+    return;
+  }
+  const expand = e.target.closest('[data-prev-expand]');
+  if (expand) {
+    const card = expand.closest('[data-prev-item]');
+    if (card) {
+      agendaOpenPreviewSheet(card.dataset.prevItem,
+        Number(card.dataset.prevQ), Number(expand.dataset.prevExpand));
+    }
+    return;
+  }
+  const prev = e.target.closest('[data-prev-item]');
+  if (prev) {
+    agendaPreviewCardClick(prev);
+    return;
+  }
+  const answerBtn = e.target.closest('[data-answer]');
+  if (answerBtn) {
+    agendaSubmitAnswer(item, answerBtn);
+    return;
+  }
+  const clearBlocker = e.target.closest('[data-clear-blocker]');
+  if (clearBlocker) {
+    agendaSendOp({ op: 'clear_blocker', id: item.id, blocker_id: clearBlocker.dataset.clearBlocker }, clearBlocker);
+    return;
+  }
+  const removeDep = e.target.closest('[data-remove-dep]');
+  if (removeDep) {
+    agendaSendOp({ op: 'remove_relies_on', id: item.id, target_id: removeDep.dataset.removeDep }, removeDep);
+    return;
+  }
+  const removeRel = e.target.closest('[data-remove-rel]');
+  if (removeRel) {
+    // Either order works — the daemon resolves which side stores the edge.
+    agendaSendOp({ op: 'remove_relates_to', id: item.id, target_id: removeRel.dataset.removeRel }, removeRel);
+    return;
+  }
+  const removeTag = e.target.closest('[data-remove-tag]');
+  if (removeTag) {
+    const tags = (item.tags || []).filter((t) => t !== removeTag.dataset.removeTag);
+    agendaSendOp({ op: 'patch', id: item.id, patch: { tags } }, removeTag);
+    return;
+  }
+  const removeRef = e.target.closest('[data-remove-ref-type]');
+  if (removeRef) {
+    agendaSendOp({
+      op: 'remove_ref', id: item.id,
+      ref_type: removeRef.dataset.removeRefType, locator: removeRef.dataset.removeRefLoc,
+    }, removeRef);
+    return;
+  }
+  const act = e.target.closest('[data-act]');
+  if (!act) return;
+  switch (act.dataset.act) {
+    case 'close': agendaCloseInspector(); break;
+    case 'copy-id': agendaCopyText(item.id, 'the full item id'); break;
+    case 'title-edit':
+      if (item.status !== 'retired') {
+        agendaInspEditingTitle = true;
+        agendaInspTitleDraft = item.title;
+        agendaInspectorRender();
+        document.getElementById('ag2-insp-title-input')?.focus();
+      }
+      break;
+    case 'title-save': agendaInspSaveTitle(item); break;
+    case 'start': agendaOpenStartSheet(item.id, act); break;
+    case 'follow-live': {
+      const sid = agendaFollowUpSid(item);
+      if (sid) agendaFollowUpWithRecorder(item, sid);
+      break;
+    }
+    case 'follow-resume': agendaFollowUpResume(item); break;
+    case 'complete': agendaSendOp({ op: 'complete', id: item.id }, act); break;
+    case 'reopen': agendaSendOp({ op: 'reopen', id: item.id }, act); break;
+    case 'retire': agendaSendOp({ op: 'retire', id: item.id }, act); break;
+    case 'rail-open': agendaOpenParkedAsk(item.id); break;
+    case 'rail-view': agendaViewAnsweredAsk(item.id); break;
+    case 'body-edit':
+      agendaInspEditingBody = true;
+      agendaInspBodyDraft = item.body || '';
+      agendaInspectorRender();
+      document.getElementById('ag2-insp-body-input')?.focus();
+      break;
+    case 'body-cancel':
+      agendaInspEditingBody = false;
+      agendaInspectorRender();
+      break;
+    case 'body-save':
+      agendaInspEditingBody = false;
+      agendaSendOp({ op: 'patch', id: item.id, patch: { body: agendaInspBodyDraft } }, act);
+      break;
+    case 'sched': agendaOpenSchedSheet(item.id); break;
+    case 'eff-approve': {
+      const st = agendaEffectState(item);
+      if (st) {
+        // Approve binds the digest of exactly the revision rendered.
+        agendaSendOp({ op: 'approve_effect', id: item.id, digest: st.effect.digest }, act);
+      }
+      break;
+    }
+    case 'eff-revoke': agendaSendOp({ op: 'revoke_effect', id: item.id }, act); break;
+    case 'eff-run-now':
+      // One extra occurrence of the approved standing manifest — the
+      // daemon refuses (named) outside its rules: recurring + approved,
+      // not suspended, no run in flight, no earlier request pending.
+      agendaSendOp({ op: 'request_occurrence', id: item.id }, act);
+      break;
+    case 'toggle-blocker-add':
+      agendaInspAdds.blocker = !agendaInspAdds.blocker;
+      agendaInspectorRender();
+      break;
+    case 'toggle-dep-add':
+      agendaInspAdds.dep = !agendaInspAdds.dep;
+      agendaInspectorRender();
+      break;
+    case 'toggle-ref-add':
+      agendaInspAdds.ref = !agendaInspAdds.ref;
+      agendaInspectorRender();
+      break;
+    case 'blocker-add': agendaInspAddBlocker(item, act); break;
+    case 'ref-add': agendaInspAddRef(item, act); break;
+    case 'ann-add': agendaInspAddAnnotation(item, act); break;
+    case 'verify-refs': agendaVerifyRefs(item.id, act); break;
+    case 'thread-all':
+      if (agendaExpandedThreads.has(item.id)) agendaExpandedThreads.delete(item.id);
+      else agendaExpandedThreads.add(item.id);
+      agendaInspectorRender();
+      break;
+    default: break;
+  }
+}
+
+function agendaInspInput(e) {
+  const t = e.target;
+  if (t.id === 'ag2-insp-title-input') agendaInspTitleDraft = t.value;
+  else if (t.id === 'ag2-insp-body-input') agendaInspBodyDraft = t.value;
+  else if (t.dataset.qaDraft) agendaQaDrafts[t.dataset.qaDraft] = t.value;
+  else if (t.dataset.qaNote) agendaQaNotes[t.dataset.qaNote] = t.value;
+  else if (t.dataset.draft === 'blocker') agendaInspBlockerDraft = t.value;
+  else if (t.dataset.draft === 'ann') agendaInspAnnDraft = t.value;
+  else if (t.dataset.draft === 'tag') agendaInspTagDraft = t.value;
+  else if (t.dataset.draft === 'ref') agendaInspRefDraft = t.value;
+}
+
+function agendaInspKeydown(e) {
+  if (e.key !== 'Enter') return;
+  const t = e.target;
+  const item = agendaInspItem();
+  if (!item) return;
+  if (t.id === 'ag2-insp-title-input') {
+    e.preventDefault();
+    agendaInspSaveTitle(item);
+  } else if (t.dataset && t.dataset.qaDraft) {
+    e.preventDefault();
+    agendaSubmitAnswer(item);
+  } else if (t.dataset && t.dataset.draft === 'blocker') {
+    e.preventDefault();
+    agendaInspAddBlocker(item);
+  } else if (t.dataset && t.dataset.draft === 'ann') {
+    e.preventDefault();
+    agendaInspAddAnnotation(item);
+  } else if (t.dataset && t.dataset.draft === 'tag') {
+    e.preventDefault();
+    agendaInspAddTag(item);
+  } else if (t.dataset && t.dataset.draft === 'ref') {
+    e.preventDefault();
+    agendaInspAddRef(item);
+  }
+}
+
+function agendaInspChange(e) {
+  const t = e.target;
+  const item = agendaInspItem();
+  if (!item) return;
+  if (t.dataset.actChange === 'due-preset') {
+    const v = t.value;
+    t.value = '';
+    if (!v) return;
+    // Merge-patch semantics: `null` clears, a value sets (AgendaPatch
+    // double_option).
+    const ms = v === 'clear' ? null : agendaDuePresetMs(v);
+    agendaSendOp({ op: 'patch', id: item.id, patch: { due_ms: ms } }, t);
+  } else if (t.dataset.actChange === 'urgency') {
+    agendaSetItemUrgency(item.id, t.value, t);
+  } else if (t.dataset.actChange === 'place') {
+    agendaInspPlace(item, t.value, t);
+  } else if (t.dataset.actChange === 'rel-add') {
+    const v = t.value;
+    t.value = '';
+    if (v) agendaSendOp({ op: 'add_relates_to', id: item.id, target_id: v }, t);
+  } else if (t.dataset.actChange === 'dep-add') {
+    const v = t.value;
+    if (v) {
+      agendaInspAdds.dep = false;
+      agendaSendOp({ op: 'add_relies_on', id: item.id, target_id: v }, t);
+    }
+  } else if (t.dataset.actChange === 'ref-must') {
+    agendaInspRefMust = !!t.checked;
+  }
+}
+
+function agendaInspSaveTitle(item) {
+  const text = agendaInspTitleDraft.trim();
+  agendaInspEditingTitle = false;
+  if (text && text !== item.title) {
+    agendaSendOp({ op: 'patch', id: item.id, patch: { title: text } });
+  } else {
+    agendaInspectorRender();
+  }
+}
+
+// Placement changes ride the real vocabulary: none→parent = add_part_of;
+// parent→none = remove_part_of; parent→parent = the atomic `place`
+// (validate-new-first re-parent, steward override 2026-07-22).
+function agendaInspPlace(item, value, control) {
+  const current = item.part_of ? item.part_of.parent_id : '';
+  if (value === current) return;
+  if (!value && current) {
+    agendaSendOp({ op: 'remove_part_of', id: item.id, parent_id: current }, control);
+  } else if (value && !current) {
+    agendaSendOp({ op: 'add_part_of', id: item.id, parent_id: value }, control);
+  } else if (value && current) {
+    agendaSendOp({ op: 'place', id: item.id, under: value }, control);
+  }
+}
+
+function agendaInspAddBlocker(item, button) {
+  const text = agendaInspBlockerDraft.trim();
+  if (!text) return;
+  agendaInspBlockerDraft = '';
+  agendaInspAdds.blocker = false;
+  agendaSendOp({ op: 'set_blocker', id: item.id, criterion: text }, button);
+}
+
+function agendaInspAddAnnotation(item, button) {
+  const text = agendaInspAnnDraft.trim();
+  if (!text) return;
+  agendaInspAnnDraft = '';
+  agendaSendOp({ op: 'annotate', id: item.id, text }, button);
+}
+
+function agendaInspAddTag(item) {
+  const tag = agendaInspTagDraft.trim();
+  if (!tag) return;
+  agendaInspTagDraft = '';
+  if ((item.tags || []).includes(tag)) {
+    agendaInspectorRender();
+    return;
+  }
+  agendaSendOp({ op: 'patch', id: item.id, patch: { tags: [...(item.tags || []), tag] } });
+}
+
+// Pointer type inference for the add row (the daemon validates the typed
+// command either way — this only picks the claimed type): http(s) → url,
+// a 12+-hex run → memory claim id, an id the sessions join knows → session,
+// anything else → file path.
+function agendaInspInferRefType(locator) {
+  if (/^https?:\/\//i.test(locator)) return 'url';
+  if (/^[0-9a-f]{12,}$/i.test(locator)) return 'memory';
+  if (agendaSessions && agendaSessions[locator]) return 'session';
+  if (/^sess-/.test(locator)) return 'session';
+  return 'file';
+}
+
+function agendaInspAddRef(item, button) {
+  const locator = agendaInspRefDraft.trim();
+  if (!locator) return;
+  const refType = agendaInspInferRefType(locator);
+  const params = { op: 'add_ref', id: item.id, ref_type: refType, locator };
+  if (agendaInspRefMust) params.must_read = true;
+  agendaInspRefDraft = '';
+  agendaInspRefMust = false;
+  agendaInspAdds.ref = false;
+  agendaSendOp(params, button).then((ok) => {
+    if (ok && typeof showControlToast === 'function') {
+      showControlToast('success', refType === 'file'
+        ? 'Attached — the file was hashed at intake; the digest travels, blobs never do.'
+        : `Attached a ${refType} pointer.`);
+    }
+  });
+}
+
+function agendaCopyText(text, what) {
+  const done = () => {
+    if (typeof showControlToast === 'function') {
+      showControlToast('info', `${`Copied ${what || ''}`.trim()}.`);
+    }
+  };
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(text).then(done,
+      () => agendaFlashError('Clipboard unavailable in this context.'));
+  } else {
+    agendaFlashError('Clipboard unavailable in this context.');
+  }
+}
+
+// Re-render helper that keeps the focused input (by data-fkey) focused
+// across an innerHTML replace — event-lane repaints otherwise steal the
+// caret mid-typing.
+function agendaRenderPreservingFocus(host, render) {
+  const active = document.activeElement;
+  const key = active && host.contains(active) ? active.getAttribute('data-fkey') : null;
+  const selStart = key && active.selectionStart != null ? active.selectionStart : null;
+  render();
+  if (!key) return;
+  const next = host.querySelector(`[data-fkey="${CSS.escape(key)}"]`);
+  if (!next) return;
+  next.focus();
+  if (selStart != null && next.setSelectionRange) {
+    try { next.setSelectionRange(selStart, selStart); } catch (err) { /* non-text inputs */ }
+  }
+}
+
+// ---- Sheets (schedule + preview) ----
+
+let agendaSheetState = null;
+
+function agendaEnsureSheetHost() {
+  let host = document.getElementById('ag2-sheet');
+  if (host) return host;
+  host = document.createElement('div');
+  host.id = 'ag2-sheet';
+  host.hidden = true;
+  host.innerHTML = '<div class="ag2-sheet-backdrop"></div><div class="ag2-sheet-panel" role="dialog" aria-modal="true"></div>';
+  document.body.appendChild(host);
+  host.querySelector('.ag2-sheet-backdrop').addEventListener('click', () => agendaSheetClose());
+  const panel = host.querySelector('.ag2-sheet-panel');
+  panel.addEventListener('click', agendaSheetClick);
+  panel.addEventListener('input', agendaSheetInput);
+  panel.addEventListener('change', agendaSheetInput);
+  return host;
+}
+
+// Returns true when a sheet was open (the Escape chain).
+function agendaSheetClose() {
+  const host = document.getElementById('ag2-sheet');
+  const wasOpen = !!(host && !host.hidden);
+  if (host) host.hidden = true;
+  agendaSheetState = null;
+  return wasOpen;
+}
+
+function agendaSheetRender() {
+  const host = agendaEnsureSheetHost();
+  const panel = host.querySelector('.ag2-sheet-panel');
+  if (!agendaSheetState) {
+    host.hidden = true;
+    return;
+  }
+  const item = agendaFindItem(agendaSheetState.itemId);
+  if (!item) {
+    agendaSheetClose();
+    return;
+  }
+  host.hidden = false;
+  agendaRenderPreservingFocus(panel, () => {
+    panel.innerHTML = agendaSheetState.kind === 'prev'
+      ? agendaPrevSheetHtml(item)
+      : agendaSchedSheetHtml(item);
+  });
+  agendaHydratePreviewFrames(panel);
+}
+
+// -- Schedule sheet --
+
+function agendaOpenSchedSheet(itemId) {
+  const item = agendaFindItem(itemId);
+  if (!item) return;
+  const st = agendaEffectState(item);
+  const m = st && st.manifest;
+  const toLocal = (ms) => {
+    const d = new Date(ms);
+    const p = (n) => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}T${p(d.getHours())}:${p(d.getMinutes())}`;
+  };
+  const rec = m && m.recurrence;
+  agendaSheetState = {
+    kind: 'sched',
+    itemId,
+    goal: m ? m.goal : agendaStartGoalStatement(item),
+    when: toLocal(st && st.next > Date.now() ? st.next : Date.now() + 864e5),
+    repeat: rec ? String(Math.round(rec.every_ms / 864e5)) : '',
+    until: '',
+    maxRuns: rec && rec.max_occurrences ? String(rec.max_occurrences) : '',
+    suspend: rec && rec.suspend_after_failures ? String(rec.suspend_after_failures) : '3',
+    orchestrate: !!(m && m.orchestrate),
+    approveNow: true,
+    voids: !!(st && st.effect.approval),
+    error: '',
+  };
+  agendaSheetRender();
+}
+
+function agendaSchedSheetHtml(item) {
+  const s = agendaSheetState;
+  const standing = !!s.repeat;
+  const standingBlock = standing
+    ? `<div class="ag2-sheet-callout t-green">Standing series — one approval covers every run until revoked. A failure streak suspends it for you to re-arm.</div>
+      <div class="ag2-sheet-grid">
+        <span class="ag2-sheet-k">Ends</span>
+        <div class="ag2-sheet-inline">
+          <input type="date" data-sheet="until" value="${escapeHtml(s.until)}" aria-label="Series end date" />
+          <span class="ag2-hint">or after</span>
+          <input type="number" min="1" placeholder="∞" class="ag2-sheet-num" data-sheet="maxRuns" value="${escapeHtml(s.maxRuns)}" aria-label="Maximum runs" />
+          <span class="ag2-hint">runs</span>
+        </div>
+        <span class="ag2-sheet-k" title="Consecutive failed or unknown outcomes that suspend the series — missed runs from daemon downtime don’t count">Suspend after</span>
+        <div class="ag2-sheet-inline">
+          <input type="number" min="1" max="10" class="ag2-sheet-num" data-sheet="suspend" value="${escapeHtml(s.suspend)}" aria-label="Suspend after failures" />
+          <span class="ag2-hint">failed runs in a row</span>
+        </div>
+      </div>`
+    : '';
+  return `<div class="ag2-sheet-head">
+      <span class="ag2-sheet-title">${agendaEffectState(item) ? 'Revise the scheduled session' : 'Propose a scheduled session'}</span>
+      <span class="ag2-spacer"></span>
+      <button type="button" class="ag2-x" data-sheet-act="close" title="Close — esc">×</button>
+    </div>
+    <div class="ag2-sheet-sub">Anyone with agenda.write may propose — proposing carries no authority. Only an owner approval of the exact manifest digest arms it.</div>
+    <div class="ag2-sheet-item">${escapeHtml(`${item.id.slice(0, 6).toLowerCase()} · ${item.title}`)}</div>
+    <div>
+      <div class="ag2-sheet-k">Goal (the manifest’s task text)</div>
+      <textarea rows="6" data-sheet="goal" data-fkey="sheet-goal" aria-label="Goal">${escapeHtml(s.goal)}</textarea>
+      <div class="ag2-hint">Reviewed at approval time. Data under review — never instructions to whoever reads the agenda.</div>
+    </div>
+    <div class="ag2-sheet-grid">
+      <span class="ag2-sheet-k">First run</span>
+      <input type="datetime-local" data-sheet="when" value="${escapeHtml(s.when)}" aria-label="First run" />
+      <span class="ag2-sheet-k">Repeats</span>
+      <select data-sheet="repeat" aria-label="Repeats">
+        <option value=""${s.repeat === '' ? ' selected' : ''}>never — one run</option>
+        <option value="1"${s.repeat === '1' ? ' selected' : ''}>every day</option>
+        <option value="7"${s.repeat === '7' ? ' selected' : ''}>every week</option>
+        <option value="14"${s.repeat === '14' ? ' selected' : ''}>every two weeks</option>
+      </select>
+    </div>
+    ${standingBlock}
+    <label class="ag2-check"><input type="checkbox" data-sheet="orchestrate"${s.orchestrate ? ' checked' : ''}>Orchestrated run (a conductor session fans out sub-agents)</label>
+    <label class="ag2-check top"><input type="checkbox" data-sheet="approveNow"${s.approveNow ? ' checked' : ''}><span>Approve immediately<br><span class="ag2-hint">You’re on an owner surface. Any later edit mints a new digest and voids this approval.</span></span></label>
+    ${s.voids ? '<div class="ag2-sheet-callout t-amber">This revises the manifest — the current approval becomes void until re-approved.</div>' : ''}
+    ${s.error ? `<div class="ag2-sheet-error">${escapeHtml(s.error)}</div>` : ''}
+    <div class="ag2-row-end">
+      <button type="button" class="ag2-btn ghost" data-sheet-act="close">Cancel</button>
+      <button type="button" class="ag2-btn prim" data-sheet-act="sched-confirm">${s.approveNow ? 'Propose & approve' : 'Propose schedule'}</button>
+    </div>`;
+}
+
+async function agendaSchedConfirm(button) {
+  const s = agendaSheetState;
+  if (!s) return;
+  const item = agendaFindItem(s.itemId);
+  if (!item) {
+    agendaSheetClose();
+    return;
+  }
+  const fail = (message) => {
+    s.error = message;
+    agendaSheetRender();
+  };
+  const goal = s.goal.trim();
+  if (!goal) return fail('The manifest needs a goal.');
+  const fire = new Date(s.when).getTime();
+  if (!fire || Number.isNaN(fire)) return fail('Pick a first-run time.');
+  const params = {
+    op: 'propose_effect', id: item.id, goal, fire_at_ms: fire,
+    orchestrate: !!s.orchestrate,
+  };
+  if (s.repeat) {
+    const rec = { every_ms: Number(s.repeat) * 864e5 };
+    if (s.until) {
+      const until = new Date(`${s.until}T23:59`).getTime();
+      if (until && !Number.isNaN(until)) rec.until_ms = until;
+    }
+    if (s.maxRuns && Number(s.maxRuns) > 0) rec.max_occurrences = Number(s.maxRuns);
+    rec.suspend_after_failures = Math.max(1, Number(s.suspend) || 3);
+    params.recurrence = rec;
+  }
+  if (button) button.disabled = true;
+  try {
+    const resp = await daemonApi.request('api_agenda_op', params);
+    if (!(resp.ok && resp.body && resp.body.item)) {
+      return fail((resp.body && resp.body.error) || `propose failed (${resp.status})`);
+    }
+    agendaObserveServerMessage({ item: resp.body.item });
+    let approved = false;
+    if (s.approveNow) {
+      // Approve exactly the revision the daemon just minted from this
+      // sheet — its digest comes back on the proposed item.
+      const effect = (resp.body.item.effects || [])[0];
+      if (effect && effect.digest) {
+        approved = await agendaSendOp({ op: 'approve_effect', id: item.id, digest: effect.digest });
+      }
+    }
+    agendaSheetClose();
+    agendaSheetRender();
+    if (typeof showControlToast === 'function') {
+      showControlToast(approved ? 'success' : 'info', approved
+        ? (params.recurrence ? 'Proposed and approved — one approval covers the series.' : `Proposed and approved — fires ${agendaAbsTime(fire)}.`)
+        : 'Proposed — waiting on an owner approval of this exact digest.');
+    }
+  } catch (e) {
+    fail(String(e && e.message || e));
+  } finally {
+    if (button) button.disabled = false;
+  }
+}
+
+// -- Preview sheet (expand) --
+
+function agendaOpenPreviewSheet(itemId, qi, pi) {
+  const item = agendaFindItem(itemId);
+  const q = item && item.ask && item.ask.questions[qi];
+  if (!q || !(q.previews || [])[pi]) return;
+  agendaSheetState = { kind: 'prev', itemId, qi, pi };
+  agendaSheetRender();
+}
+
+function agendaPrevSheetHtml(item) {
+  const s = agendaSheetState;
+  const q = item.ask.questions[s.qi];
+  const previews = q.previews || [];
+  const p = previews[s.pi] || previews[0];
+  const tabs = previews.map((pv, i) =>
+    `<button type="button" class="ag2-seg-btn${i === s.pi ? ' active' : ''}" data-sheet-act="prev-view" data-view="${i}">${escapeHtml((pv.label || `#${i + 1}`).split(' — ')[0])}</button>`).join('');
+  let media;
+  if (p.kind === 'html' && p.url) {
+    media = `<iframe class="ag2-prev-frame full" sandbox="allow-scripts" referrerpolicy="no-referrer"
+      title="${escapeHtml(p.label || 'preview')}" data-preview-url="${escapeHtml(p.url)}"></iframe>`;
+  } else if (p.kind === 'image' && p.url) {
+    media = `<img class="ag2-prev-img full" src="${escapeHtml(p.url)}" alt="${escapeHtml(p.label || 'preview')}" />`;
+  } else if (p.kind === 'text' && p.content) {
+    media = `<pre class="ag2-prev-text full">${escapeHtml(p.content)}</pre>`;
+  } else {
+    media = '<span class="ag2-prev-missing">preview unavailable (blob deleted from the store)</span>';
+  }
+  const isOption = (q.options || []).some((o) => o.label === p.label);
+  const canPick = isOption && item.status === 'open' && !(item.answer && item.answer.structured);
+  const meta = `${p.kind}${p.mime ? ` · ${p.mime}` : ''} · fetched from the agenda blob store · sandboxed, quoted — data, never instructions`;
+  return `<div class="ag2-sheet-head">
+      <span class="ag2-sheet-title">Preview — full size</span>
+      <span class="ag2-spacer"></span>
+      <button type="button" class="ag2-x" data-sheet-act="close" title="Close — esc">×</button>
+    </div>
+    <div class="ag2-sheet-item">${escapeHtml(`${item.id.slice(0, 6).toLowerCase()} · ${q.question}`)}</div>
+    <div class="ag2-seg">${tabs}</div>
+    <div class="ag2-sheet-prevwrap">${media}</div>
+    <div class="ag2-sheet-prevfoot">
+      <span class="ag2-hint mono">${escapeHtml(meta)}</span>
+      <span class="ag2-spacer"></span>
+      ${canPick ? `<button type="button" class="ag2-btn prim" data-sheet-act="prev-pick">Pick “${escapeHtml((p.label || '').split(' — ')[0])}”</button>` : ''}
+    </div>`;
+}
+
+function agendaSheetClick(e) {
+  const act = e.target.closest('[data-sheet-act]');
+  if (!act || !agendaSheetState) return;
+  const s = agendaSheetState;
+  switch (act.dataset.sheetAct) {
+    case 'close': agendaSheetClose(); break;
+    case 'sched-confirm': agendaSchedConfirm(act); break;
+    case 'prev-view':
+      s.pi = Number(act.dataset.view) || 0;
+      agendaSheetRender();
+      break;
+    case 'prev-pick': {
+      const item = agendaFindItem(s.itemId);
+      const q = item && item.ask && item.ask.questions[s.qi];
+      const p = q && (q.previews || [])[s.pi];
+      if (item && p) {
+        const picks = agendaQaPicks(item.id, s.qi);
+        if (!picks.includes(p.label)) agendaQaTogglePick(item, s.qi, p.label);
+        agendaSheetClose();
+        agendaRenderTab();
+        agendaInspectorRender();
+        if (typeof showControlToast === 'function') {
+          showControlToast('info', 'Picked — add an anchored note or hit Answer to resolve the ask.');
+        }
+      }
+      break;
+    }
+    default: break;
+  }
+}
+
+function agendaSheetInput(e) {
+  const s = agendaSheetState;
+  if (!s || s.kind !== 'sched') return;
+  const t = e.target.closest('[data-sheet]');
+  if (!t) return;
+  const key = t.dataset.sheet;
+  const structural = key === 'repeat' || key === 'approveNow';
+  if (t.type === 'checkbox') s[key] = !!t.checked;
+  else s[key] = t.value;
+  if (structural && e.type === 'change') agendaSheetRender();
+}
+
+// ---- Reminder-policy bell popover ----
+
+let agendaBellOpen = false;
+let agendaBellWired = false;
+
+function agendaBellToggle() {
+  agendaBellOpen = !agendaBellOpen;
+  agendaBellRender();
+}
+
+// Returns true when it actually closed (the Escape chain).
+function agendaBellClose() {
+  if (!agendaBellOpen) return false;
+  agendaBellOpen = false;
+  agendaBellRender();
+  return true;
+}
+
+function agendaEnsureBellHost() {
+  let host = document.getElementById('ag2-bell-pop');
+  if (host) return host;
+  host = document.createElement('div');
+  host.id = 'ag2-bell-pop';
+  host.hidden = true;
+  host.innerHTML = '<div class="ag2-bell-overlay"></div><div class="ag2-bell-panel" role="dialog" aria-label="Reminder delivery policy"></div>';
+  document.body.appendChild(host);
+  host.querySelector('.ag2-bell-overlay').addEventListener('click', () => agendaBellClose());
+  return host;
+}
+
+function agendaBellRender() {
+  const host = agendaEnsureBellHost();
+  const panel = host.querySelector('.ag2-bell-panel');
+  if (!agendaBellOpen) {
+    host.hidden = true;
+    return;
+  }
+  host.hidden = false;
+  // Anchor under the bell button (fixed positioning).
+  const bell = document.getElementById('ag2-bell');
+  if (bell) {
+    const rect = bell.getBoundingClientRect();
+    panel.style.top = `${Math.round(rect.bottom + 8)}px`;
+    panel.style.right = `${Math.round(Math.max(12, window.innerWidth - rect.right))}px`;
+  }
+  const policy = agendaReminderPolicy;
+  if (!policy) {
+    panel.innerHTML = '<div class="ag2-hint">Reminder policy unavailable — the daemon has not served one yet.</div>';
+    return;
+  }
+  const minToHhmm = (min) =>
+    `${String(Math.floor(min / 60)).padStart(2, '0')}:${String(min % 60).padStart(2, '0')}`;
+  const quiet = policy.quiet_hours || null;
+  const seg = ['info', 'attention', 'urgent'].map((v) =>
+    `<button type="button" class="ag2-seg-btn u-${v}${policy.default_urgency === v ? ' active' : ''}" data-bell-urg="${v}">${v}</button>`).join('');
+  panel.innerHTML = `
+    <div class="ag2-bell-head">
+      <span class="ag2-bell-title">Reminder delivery</span>
+      <span class="ag2-spacer"></span>
+      <span class="ag2-hint mono">owner policy</span>
+    </div>
+    <div class="ag2-bell-row">
+      <div class="ag2-bell-rowmain">
+        <div class="ag2-bell-k">Deliver reminders</div>
+        <div class="ag2-hint">Due times notify you at their instant.</div>
+      </div>
+      <button type="button" class="ag2-tog${policy.enabled ? ' on' : ''}" data-bell-act="enabled" role="switch" aria-checked="${policy.enabled}" aria-label="Deliver reminders"><span class="ag2-tog-knob"></span></button>
+    </div>
+    <div>
+      <div class="ag2-bell-k">Default loudness</div>
+      <div class="ag2-seg">${seg}</div>
+    </div>
+    <div class="ag2-bell-row">
+      <div class="ag2-bell-rowmain">
+        <div class="ag2-bell-k">Quiet hours</div>
+        <div class="ag2-hint">Defers every reminder — urgent included. Approved scheduled sessions still fire.</div>
+      </div>
+      <button type="button" class="ag2-tog${quiet ? ' on' : ''}" data-bell-act="quiet" role="switch" aria-checked="${!!quiet}" aria-label="Quiet hours"><span class="ag2-tog-knob"></span></button>
+    </div>
+    ${quiet ? `<div class="ag2-bell-times">
+      <input type="time" data-bell-time="start" value="${minToHhmm(quiet.start_min)}" aria-label="Quiet hours start" />
+      <span class="ag2-hint">to</span>
+      <input type="time" data-bell-time="end" value="${minToHhmm(quiet.end_min)}" aria-label="Quiet hours end" />
+      <span class="ag2-hint">${agendaQuietNow() ? 'quiet now' : ''}</span>
+    </div>` : ''}
+    <div class="ag2-bell-row">
+      <div class="ag2-bell-rowmain">
+        <div class="ag2-bell-k">Fold stale reminders into a digest</div>
+        <div class="ag2-hint">Anything older than this arrives summarized, not one by one.</div>
+      </div>
+      <input type="number" min="1" max="336" class="ag2-sheet-num" data-bell-act="stale" value="${policy.staleness_hours}" aria-label="Staleness hours" />
+      <span class="ag2-hint">hours</span>
+    </div>
+    <div class="ag2-bell-foot">settings.manage · POST /api/agenda/reminders/policy — an agenda.write grant can’t make its own item louder.</div>`;
+  if (!agendaBellWired) {
+    agendaBellWired = true;
+    panel.addEventListener('click', (e) => {
+      const urg = e.target.closest('[data-bell-urg]');
+      if (urg) {
+        agendaSendPolicyPatch({ default_urgency: urg.dataset.bellUrg }, urg).then(() => agendaBellRender());
+        return;
+      }
+      const act = e.target.closest('[data-bell-act]');
+      if (!act) return;
+      const current = agendaReminderPolicy || {};
+      if (act.dataset.bellAct === 'enabled') {
+        agendaSendPolicyPatch({ enabled: !current.enabled }, act).then(() => agendaBellRender());
+      } else if (act.dataset.bellAct === 'quiet') {
+        agendaSendPolicyPatch({
+          quiet_hours: current.quiet_hours ? null : { start_min: 22 * 60, end_min: 7 * 60 + 30 },
+        }, act).then(() => agendaBellRender());
+      }
+    });
+    panel.addEventListener('change', (e) => {
+      const time = e.target.closest('[data-bell-time]');
+      const current = agendaReminderPolicy || {};
+      if (time && current.quiet_hours) {
+        const [h, m] = String(time.value || '').split(':').map(Number);
+        if (Number.isNaN(h) || Number.isNaN(m)) return;
+        const next = { ...current.quiet_hours };
+        next[time.dataset.bellTime === 'start' ? 'start_min' : 'end_min'] = h * 60 + m;
+        agendaSendPolicyPatch({ quiet_hours: next }, time).then(() => agendaBellRender());
+        return;
+      }
+      const stale = e.target.closest('[data-bell-act="stale"]');
+      if (stale) {
+        const hours = Math.max(1, Math.min(336, Number(stale.value) || 0));
+        if (hours) {
+          agendaSendPolicyPatch({ staleness_hours: hours }, stale).then(() => agendaBellRender());
+        }
+      }
+    });
+  }
+}

--- a/static/app/ui2-agenda-inspector.js
+++ b/static/app/ui2-agenda-inspector.js
@@ -580,7 +580,8 @@ function agendaInspRefsHtml(item) {
         ? `<a class="ag2-ref-loc" data-jump-session="${escapeHtml(s.key)}" title="${escapeHtml(r.locator)}">${escapeHtml(text)}</a>`
         : `<span class="ag2-ref-loc" title="${escapeHtml(r.locator)}">${escapeHtml(text)}</span>`;
     } else if (r.ref_type === 'memory') {
-      target = `<a class="ag2-ref-loc" data-open-claim="${escapeHtml(r.locator)}" title="${escapeHtml(r.locator)}">${escapeHtml(label || 'claim ')}${escapeHtml(label ? '' : String(r.locator).slice(0, 12))}</a>`;
+      const text = label ? label + r.locator : `claim ${String(r.locator).slice(0, 12)}`;
+      target = `<a class="ag2-ref-loc" data-open-claim="${escapeHtml(r.locator)}" title="${escapeHtml(r.locator)}">${escapeHtml(text)}</a>`;
     } else {
       if (r.digest) hasFileDigest = true;
       target = `<span class="ag2-ref-loc" title="${escapeHtml(r.digest ? `sha256 ${r.digest.slice(0, 16)}… recorded at attach — the digest travels; blobs never do` : r.locator)}">${escapeHtml(label + r.locator)}</span>`;

--- a/static/app/ui2-agenda.css
+++ b/static/app/ui2-agenda.css
@@ -1,398 +1,798 @@
-/* Agenda tab + the compact activity-pane card. Token palette only
-   (16-styles-v2-tokens); scoped under html.ui-v2 like every v2 sheet. */
+/* Agenda tab (redesign slice A: lenses, compose bar, cards) + the compact
+   activity-pane card + the start-now confirm sheet. Token palette only
+   (16-styles-v2-tokens); scoped under html.ui-v2 like every v2 sheet.
+   The inspector, schedule/preview sheets, and the reminder-policy popover
+   live in ui2-agenda-inspector.css. */
 
-/* ---- Tab ---- */
+/* ---- Tab layout: main column + animated inspector ---- */
 
 html.ui-v2 #tab-agenda {
-  overflow-y: auto;
+  overflow: hidden;
 }
-html.ui-v2 .agenda-wrap {
-  max-width: 860px;
-  margin: 0 auto;
-  padding: 18px 20px 40px;
+html.ui-v2 .ag2 {
+  flex: 1;
+  min-height: 0;
   display: flex;
-  flex-direction: column;
-  gap: 12px;
 }
-html.ui-v2 .agenda-head {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 12px;
-}
-html.ui-v2 .agenda-title {
-  margin: 0;
-  font-size: 17px;
-  font-weight: 650;
-  color: var(--text);
-}
-html.ui-v2 .agenda-counts {
-  font-family: var(--mono);
-  font-size: 11px;
-  color: var(--text-3);
-}
-html.ui-v2 .agenda-compose {
-  display: flex;
-  gap: 8px;
-}
-html.ui-v2 .agenda-compose select,
-html.ui-v2 .agenda-compose input,
-html.ui-v2 .agenda-compose button {
-  background: var(--surface);
-  color: var(--text);
-  border: 1px solid var(--line);
-  border-radius: 9px;
-  padding: 7px 10px;
-  font-size: 13px;
-}
-html.ui-v2 .agenda-compose input {
+html.ui-v2 .ag2-main {
   flex: 1;
   min-width: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 22px 26px 60px;
+  box-sizing: border-box;
 }
-html.ui-v2 .agenda-compose input:focus {
-  outline: none;
-  border-color: var(--iris);
-}
-html.ui-v2 .agenda-compose button {
-  cursor: pointer;
-  font-weight: 600;
-}
-html.ui-v2 .agenda-compose button:hover {
-  border-color: var(--iris);
-  color: var(--iris);
-}
-html.ui-v2 .agenda-reminders-bar {
+html.ui-v2 .ag2-inner {
+  max-width: 920px;
+  margin: 0 auto;
   display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
+  flex-direction: column;
 }
-html.ui-v2 .agenda-reminders-bar:empty {
-  display: none;
-}
-html.ui-v2 .agenda-rem-label {
-  font-family: var(--mono);
-  font-size: 9.5px;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--text-3);
-}
-html.ui-v2 .agenda-reminders-bar select,
-html.ui-v2 .agenda-bell {
-  background: var(--surface);
-  color: var(--text-2);
-  border: 1px solid var(--line);
-  border-radius: 7px;
-  font-size: 11.5px;
-  padding: 3px 6px;
-}
-html.ui-v2 .agenda-filters {
+
+/* ---- Header ---- */
+
+html.ui-v2 .ag2-head {
   display: flex;
-  gap: 6px;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
 }
-html.ui-v2 .agenda-filter {
-  background: none;
-  border: 1px solid transparent;
-  border-radius: 999px;
-  color: var(--text-3);
-  font-size: 12px;
-  padding: 3px 11px;
-  cursor: pointer;
-}
-html.ui-v2 .agenda-filter:hover {
-  color: var(--text-2);
-}
-html.ui-v2 .agenda-filter.active {
-  border-color: var(--line);
-  background: var(--surface);
+html.ui-v2 .ag2-title {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
   color: var(--text);
 }
-html.ui-v2 .agenda-note {
-  font-size: 12px;
-  color: var(--amber);
+html.ui-v2 .ag2-sub {
+  margin: 5px 0 0;
+  font-size: 13px;
+  color: var(--text-2);
 }
-html.ui-v2 .agenda-list {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-html.ui-v2 .agenda-item {
+html.ui-v2 .ag2-bell {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  background: none;
   border: 1px solid var(--line);
-  border-radius: var(--r-card, 12px);
-  background: var(--surface);
-  padding: 10px 12px;
+  border-radius: 9px;
+  color: var(--text-2);
+  font-size: 12px;
+  font-weight: 600;
+  padding: 6px 11px;
+  cursor: pointer;
+  flex-shrink: 0;
+  margin-top: 4px;
+}
+html.ui-v2 .ag2-bell:hover {
+  border-color: var(--line-2);
+  background: var(--surface-2);
+  color: var(--text);
+}
+html.ui-v2 .ag2-bell-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--amber);
+}
+
+/* ---- Compose bar ---- */
+
+html.ui-v2 .ag2-compose {
   display: flex;
-  flex-direction: column;
-  gap: 6px;
+  gap: 8px;
+  align-items: center;
+  padding: 10px;
+  border: 1px solid var(--line);
+  border-radius: 13px;
+  background: var(--surface);
+  margin: 16px 0 12px;
 }
-html.ui-v2 .agenda-item[data-status="done"] .agenda-item-title {
+html.ui-v2 .ag2-compose input {
+  flex: 1;
+  min-width: 0;
+  background: var(--surface-2);
+  border: 1px solid var(--line-2);
+  border-radius: 9px;
+  color: var(--text);
+  font-size: 13px;
+  padding: 7px 10px;
+}
+html.ui-v2 .ag2-compose input:focus {
+  outline: none;
+  border-color: var(--iris);
+  box-shadow: 0 0 0 3px rgba(var(--iris-rgb), 0.22);
+}
+html.ui-v2 .ag2-compose select {
+  background: var(--surface-2);
+  border: 1px solid var(--line-2);
+  border-radius: 9px;
+  color: var(--text-2);
+  font-size: 12px;
+  padding: 7px 8px;
+  flex-shrink: 0;
+}
+html.ui-v2 .ag2-park {
+  background: linear-gradient(180deg, var(--iris), var(--iris-deep));
+  border: 0;
+  border-radius: 9px;
+  color: var(--on-accent);
+  font-size: 12.5px;
+  font-weight: 800;
+  padding: 8px 16px;
+  cursor: pointer;
+  box-shadow: var(--shadow-primary);
+  flex-shrink: 0;
+}
+html.ui-v2 .ag2-park:hover { filter: brightness(1.08); }
+html.ui-v2 .ag2-park:disabled { opacity: 0.5; cursor: default; }
+
+/* ---- Segmented controls (kind + lenses + sheet view tabs) ---- */
+
+html.ui-v2 .ag2-seg {
+  display: inline-flex;
+  gap: 2px;
+  padding: 3px;
+  background: var(--surface-2);
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  flex-shrink: 0;
+}
+html.ui-v2 .ag2-seg > button,
+html.ui-v2 .ag2-seg-btn {
+  background: none;
+  border: 0;
+  border-radius: 8px;
+  padding: 5px 12px;
+  font-size: 12px;
+  font-weight: 600;
   color: var(--text-3);
-  text-decoration: line-through;
+  cursor: pointer;
+  white-space: nowrap;
 }
-html.ui-v2 .agenda-item[data-status="retired"] {
-  opacity: 0.62;
+html.ui-v2 .ag2-seg > button.active,
+html.ui-v2 .ag2-seg-btn.active {
+  background: linear-gradient(180deg, rgba(var(--iris-rgb), 0.22), rgba(var(--iris-rgb), 0.12));
+  color: var(--iris-2);
+  box-shadow: inset 0 0 0 1px rgba(var(--iris-rgb), 0.4);
+  font-weight: 700;
 }
-html.ui-v2 .agenda-item-head {
+html.ui-v2 .ag2-lenses { overflow-x: auto; }
+html.ui-v2 .ag2-lenses > button.active {
+  background: var(--surface-3);
+  color: var(--text);
+  box-shadow: none;
+}
+
+/* ---- Lens bar (lenses + filter chips + search) ---- */
+
+html.ui-v2 .ag2-lensbar {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
+  margin-bottom: 14px;
   flex-wrap: wrap;
 }
-html.ui-v2 .agenda-glyph {
-  font-size: 13px;
-  line-height: 1;
+html.ui-v2 .ag2-spacer { flex: 1; }
+html.ui-v2 .ag2-fchip {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  border-radius: var(--r-pill);
+  padding: 3px 10px;
+  cursor: pointer;
+  color: var(--text-3);
+  background: none;
+  border: 1px solid var(--line);
 }
-html.ui-v2 .agenda-glyph.open { color: var(--iris); }
-html.ui-v2 .agenda-glyph.done { color: var(--green); }
-html.ui-v2 .agenda-glyph.retired { color: var(--text-3); }
-html.ui-v2 .agenda-glyph.question { color: var(--amber); font-weight: 700; }
-html.ui-v2 .agenda-item-head-openable { cursor: pointer; border-radius: 8px; }
-html.ui-v2 .agenda-item-head-openable:hover { background: var(--hover-wash); }
-html.ui-v2 .agenda-item-head-openable:hover .agenda-item-title { color: var(--iris-2); }
-html.ui-v2 .agenda-open-ask-btn {
-  border-color: rgba(var(--iris-rgb), .4);
+html.ui-v2 .ag2-fchip.on-rose {
+  color: var(--rose);
+  background: rgba(var(--rose-rgb), 0.12);
+  border-color: rgba(var(--rose-rgb), 0.4);
+}
+html.ui-v2 .ag2-fchip.on-iris {
   color: var(--iris-2);
-  font-weight: 650;
+  background: rgba(var(--iris-rgb), 0.12);
+  border-color: rgba(var(--iris-rgb), 0.4);
 }
-html.ui-v2 .agenda-open-ask-btn:hover {
-  background: rgba(var(--iris-rgb), .1);
-  border-color: rgba(var(--iris-rgb), .55);
+html.ui-v2 .ag2-search {
+  width: 190px;
+  background: var(--surface-2);
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  color: var(--text);
+  font-size: 12px;
+  padding: 6px 9px;
 }
-html.ui-v2 .agenda-ask-hint {
+html.ui-v2 .ag2-search:focus {
+  outline: none;
+  border-color: var(--iris);
+  box-shadow: 0 0 0 3px rgba(var(--iris-rgb), 0.22);
+}
+html.ui-v2 .ag2-notice {
+  font-size: 12px;
+  color: var(--amber);
+  border-left: 2px solid var(--amber);
+  padding-left: 9px;
+  margin-bottom: 10px;
+  overflow-wrap: anywhere;
+}
+
+/* ---- Groups ---- */
+
+html.ui-v2 .ag2-group { margin-bottom: 22px; }
+html.ui-v2 .ag2-group-head {
+  display: flex;
+  align-items: baseline;
+  gap: 9px;
+  margin: 0 0 8px 2px;
+  flex-wrap: wrap;
+}
+html.ui-v2 .ag2-group-label {
+  font-family: var(--mono);
+  font-size: var(--eyebrow-size);
+  font-weight: 700;
+  letter-spacing: var(--eyebrow-track);
+  text-transform: uppercase;
+  color: var(--text-3);
+}
+html.ui-v2 .ag2-group-hint {
   font-size: 11px;
   color: var(--text-3);
 }
-html.ui-v2 .agenda-ask-open-row { margin-bottom: 4px; }
-html.ui-v2 .agenda-item-kind {
+html.ui-v2 .ag2-hub-open {
+  font-size: 11px;
+  color: var(--iris-2);
+  cursor: pointer;
+}
+html.ui-v2 .ag2-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* ---- Cards ---- */
+
+html.ui-v2 .ag2-card {
+  border: 1px solid var(--line);
+  border-radius: 13px;
+  background: var(--surface);
+  padding: 11px 14px 11px 12px;
+  display: flex;
+  gap: 11px;
+  align-items: flex-start;
+  cursor: pointer;
+  transition: border-color var(--t-fast), background var(--t-fast);
+}
+html.ui-v2 .ag2-card:hover { border-color: var(--line-2); }
+html.ui-v2 .ag2-card.selected {
+  border-color: rgba(var(--iris-rgb), 0.5);
+  background: var(--surface-2);
+}
+html.ui-v2 .ag2-card.retired { opacity: 0.62; }
+html.ui-v2 .ag2-card:focus-visible {
+  outline: 2px solid rgba(var(--iris-rgb), 0.5);
+  outline-offset: 1px;
+}
+html.ui-v2 .ag2-card-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+html.ui-v2 .ag2-card-chev {
+  color: var(--text-3);
+  font-size: 15px;
+  line-height: 1.3;
+  flex-shrink: 0;
+}
+html.ui-v2 .ag2-card-titlerow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+html.ui-v2 .ag2-card-title {
+  font-size: 13.5px;
+  font-weight: 650;
+  color: var(--text);
+  overflow-wrap: anywhere;
+}
+html.ui-v2 .ag2-card-title.dim { color: var(--text-3); }
+html.ui-v2 .ag2-card-title.done { text-decoration: line-through; }
+html.ui-v2 .ag2-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11.5px;
+  color: var(--text-3);
+  flex-wrap: wrap;
+}
+html.ui-v2 .ag2-kind {
   font-family: var(--mono);
   font-size: 9.5px;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--text-3);
   border: 1px solid var(--line);
   border-radius: 5px;
   padding: 1px 5px;
+  color: var(--text-3);
 }
-html.ui-v2 .agenda-item-title {
-  font-size: 13.5px;
-  font-weight: 600;
-  color: var(--text);
+html.ui-v2 .ag2-tag {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text-3);
+  background: var(--surface-3);
+  border-radius: 6px;
+  padding: 1px 6px;
+}
+html.ui-v2 .ag2-hub-link {
+  color: var(--text-2);
+  cursor: pointer;
+}
+html.ui-v2 .ag2-hub-link:hover { color: var(--iris-2); }
+html.ui-v2 .ag2-blocked-line {
+  font-size: 12px;
+  color: var(--text-2);
+  border-left: 2px solid rgba(var(--rose-rgb), 0.55);
+  padding-left: 9px;
+  margin-top: 1px;
   overflow-wrap: anywhere;
 }
-html.ui-v2 .agenda-chip {
-  font-family: var(--mono);
-  font-size: 10.5px;
+html.ui-v2 .ag2-ansline {
+  font-size: 12px;
   color: var(--text-2);
-  background: var(--surface-2);
-  border-radius: 999px;
-  padding: 1px 8px;
-}
-html.ui-v2 .agenda-chip.due { color: var(--sky); }
-html.ui-v2 .agenda-chip.due.overdue { color: var(--amber); }
-/* Bodies are quoted data: plain text, whitespace preserved, never HTML. */
-html.ui-v2 .agenda-item-body {
-  font-size: 12.5px;
-  color: var(--text-2);
+  border-left: 2px solid var(--green);
+  padding-left: 9px;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
-  max-height: 180px;
-  overflow-y: auto;
-  border-left: 2px solid var(--line);
-  padding-left: 9px;
 }
-html.ui-v2 .agenda-answer-row {
+
+/* ---- Status control glyph ---- */
+
+html.ui-v2 .ag2-ctl {
+  width: 19px;
+  height: 19px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  margin-top: 1px;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 800;
+  line-height: 1;
   display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  background: none;
+}
+html.ui-v2 .ag2-ctl.open {
+  border: 1.5px solid var(--text-3);
+  color: transparent;
+}
+html.ui-v2 .ag2-ctl.open:hover {
+  border-color: var(--green);
+  color: var(--green);
+}
+html.ui-v2 .ag2-ctl.open:hover::after { content: '✓'; }
+html.ui-v2 .ag2-ctl.q {
+  border: 1.5px solid rgba(var(--amber-rgb), 0.7);
+  background: rgba(var(--amber-rgb), 0.1);
+  color: var(--amber);
+}
+html.ui-v2 .ag2-ctl.done {
+  border: 1.5px solid rgba(var(--green-rgb), 0.7);
+  background: rgba(var(--green-rgb), 0.14);
+  color: var(--green);
+}
+html.ui-v2 .ag2-ctl.retired {
+  border: 1.5px dashed var(--line-2);
+  color: var(--text-3);
+}
+
+/* ---- Chips (tinted token families; rgba(var(--x-rgb), a) formula) ---- */
+
+html.ui-v2 .ag2-chip {
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 700;
+  white-space: nowrap;
+  border-radius: var(--r-pill);
+  padding: 1px 8px;
+  color: var(--text-2);
+  background: var(--surface-3);
+  border: 1px solid transparent;
+}
+html.ui-v2 .ag2-chip.t-green {
+  color: var(--green);
+  background: rgba(var(--green-rgb), 0.12);
+  border-color: rgba(var(--green-rgb), 0.26);
+}
+html.ui-v2 .ag2-chip.t-amber {
+  color: var(--amber);
+  background: rgba(var(--amber-rgb), 0.12);
+  border-color: rgba(var(--amber-rgb), 0.26);
+}
+html.ui-v2 .ag2-chip.t-rose {
+  color: var(--rose);
+  background: rgba(var(--rose-rgb), 0.12);
+  border-color: rgba(var(--rose-rgb), 0.26);
+}
+html.ui-v2 .ag2-chip.t-sky {
+  color: var(--sky);
+  background: rgba(var(--sky-rgb), 0.12);
+  border-color: rgba(var(--sky-rgb), 0.26);
+}
+html.ui-v2 .ag2-chip.t-iris {
+  color: var(--iris-2);
+  background: rgba(var(--iris-rgb), 0.12);
+  border-color: rgba(var(--iris-rgb), 0.26);
+}
+html.ui-v2 .ag2-chip.t-neutral {
+  color: var(--text-2);
+  background: var(--surface-3);
+}
+html.ui-v2 .ag2-chip.dashed {
+  background: none;
+  border-style: dashed;
+}
+html.ui-v2 .ag2-chip.t-green.dashed { border-color: rgba(var(--green-rgb), 0.45); }
+html.ui-v2 .ag2-chip.t-amber.dashed { border-color: rgba(var(--amber-rgb), 0.45); }
+html.ui-v2 .ag2-chip.t-rose.dashed { border-color: rgba(var(--rose-rgb), 0.45); }
+html.ui-v2 .ag2-chip.t-sky.dashed { border-color: rgba(var(--sky-rgb), 0.45); }
+html.ui-v2 .ag2-chip.t-iris.dashed { border-color: rgba(var(--iris-rgb), 0.45); }
+html.ui-v2 .ag2-chip.t-neutral.dashed {
+  border-color: var(--line-2);
+  color: var(--text-3);
+}
+
+/* ---- Buttons ---- */
+
+html.ui-v2 .ag2-btn {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  color: var(--text-2);
+  font-size: 11.5px;
+  font-weight: 700;
+  padding: 5px 12px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+html.ui-v2 .ag2-btn:hover {
+  background: var(--surface-2);
+  border-color: var(--line-2);
+  color: var(--text);
+}
+html.ui-v2 .ag2-btn:disabled { opacity: 0.5; cursor: default; }
+html.ui-v2 .ag2-btn.prim {
+  background: linear-gradient(180deg, var(--iris), var(--iris-deep));
+  border-color: transparent;
+  color: var(--on-accent);
+  font-weight: 800;
+  box-shadow: 0 4px 12px rgba(var(--iris-rgb), 0.25);
+}
+html.ui-v2 .ag2-btn.prim:hover { filter: brightness(1.08); }
+html.ui-v2 .ag2-btn.ghost {
+  background: none;
+  color: var(--text-3);
+  font-weight: 600;
+}
+html.ui-v2 .ag2-btn.ghost:hover {
+  color: var(--text-2);
+  border-color: var(--line-2);
+  background: none;
+}
+html.ui-v2 .ag2-btn.danger {
+  background: none;
+  border-color: rgba(var(--rose-rgb), 0.4);
+  color: var(--rose);
+  font-weight: 600;
+}
+html.ui-v2 .ag2-btn.danger:hover { background: rgba(var(--rose-rgb), 0.1); }
+html.ui-v2 .ag2-linkbtn {
+  background: none;
+  border: 0;
+  color: var(--iris-2);
+  font-size: 11px;
+  cursor: pointer;
+  padding: 0;
+}
+html.ui-v2 .ag2-linkbtn:hover { text-decoration: underline; }
+html.ui-v2 .ag2-x {
+  background: none;
+  border: 0;
+  color: var(--text-3);
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 3px;
+  flex-shrink: 0;
+}
+html.ui-v2 .ag2-x:hover { color: var(--rose); }
+html.ui-v2 .ag2-dashbtn {
+  background: none;
+  border: 1px dashed var(--line-2);
+  border-radius: var(--r-pill);
+  color: var(--text-3);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 3px 11px;
+  cursor: pointer;
+}
+html.ui-v2 .ag2-dashbtn:hover {
+  border-color: rgba(var(--iris-rgb), 0.5);
+  color: var(--iris-2);
+}
+html.ui-v2 .ag2-hint {
+  font-size: 10.5px;
+  color: var(--text-3);
+  overflow-wrap: anywhere;
+}
+html.ui-v2 .ag2-hint.mono { font-family: var(--mono); font-size: 10px; }
+html.ui-v2 .ag2-row-end {
+  display: flex;
+  justify-content: flex-end;
   gap: 8px;
 }
-html.ui-v2 .agenda-answer-input {
+
+/* ---- Inline effect strip on cards ---- */
+
+html.ui-v2 .ag2-eff {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  flex-wrap: wrap;
+  margin-top: 3px;
+  padding: 7px 10px;
+  border-radius: 9px;
+}
+html.ui-v2 .ag2-eff.t-amber {
+  background: rgba(var(--amber-rgb), 0.08);
+  border: 1px solid rgba(var(--amber-rgb), 0.26);
+}
+html.ui-v2 .ag2-eff.t-amber .ag2-eff-line { color: var(--amber); }
+html.ui-v2 .ag2-eff.t-iris {
+  background: rgba(var(--iris-rgb), 0.08);
+  border: 1px solid rgba(var(--iris-rgb), 0.26);
+}
+html.ui-v2 .ag2-eff.t-iris .ag2-eff-line { color: var(--iris-2); }
+html.ui-v2 .ag2-eff-line {
+  font-size: 12px;
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+
+/* ---- Inline question answering ---- */
+
+html.ui-v2 .ag2-qa {
+  margin-top: 3px;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+html.ui-v2 .ag2-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+html.ui-v2 .ag2-pill {
+  border: 1px solid var(--line);
+  background: var(--surface-2);
+  color: var(--text-2);
+  border-radius: var(--r-pill);
+  padding: 4px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  overflow-wrap: anywhere;
+}
+html.ui-v2 .ag2-pill.on {
+  border-color: transparent;
+  background: linear-gradient(180deg, rgba(var(--iris-rgb), 0.24), rgba(var(--iris-rgb), 0.13));
+  color: var(--iris-2);
+  box-shadow: inset 0 0 0 1px rgba(var(--iris-rgb), 0.45);
+  font-weight: 700;
+}
+html.ui-v2 .ag2-pill.recorded { cursor: default; }
+html.ui-v2 .ag2-pill.recorded.on {
+  background: rgba(var(--green-rgb), 0.13);
+  color: var(--green);
+  box-shadow: inset 0 0 0 1px rgba(var(--green-rgb), 0.45);
+}
+html.ui-v2 .ag2-qa-row {
+  display: flex;
+  gap: 7px;
+}
+html.ui-v2 .ag2-qa-input {
   flex: 1;
   min-width: 0;
   background: var(--surface-2);
-  border: 1px solid var(--line);
-  border-radius: 8px;
+  border: 1px solid var(--line-2);
+  border-radius: 9px;
   color: var(--text);
-  font-size: 12.5px;
+  font-size: 12px;
   padding: 5px 9px;
 }
-html.ui-v2 .agenda-answer-input:focus {
+html.ui-v2 .ag2-qa-input:focus {
   outline: none;
   border-color: var(--amber);
+  box-shadow: 0 0 0 3px rgba(var(--amber-rgb), 0.18);
 }
-/* Replies are quoted data, like bodies. */
-html.ui-v2 .agenda-item-answer {
-  font-size: 12.5px;
-  color: var(--text-2);
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
-  border-left: 2px solid var(--green);
-  padding-left: 9px;
+html.ui-v2 .ag2-qa-more {
+  font-size: 10.5px;
+  color: var(--text-3);
 }
-/* Structured rich-ask archive: per-question "Header: answer" rows, the
-   picked option labels, follow-ups, and anchored preview notes — all
-   quoted data, in the item's question order. */
-html.ui-v2 .agenda-answer-structured {
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
-  white-space: normal;
+
+/* ---- Ask preview thumbnails (sandboxed srcdoc renders) ---- */
+
+html.ui-v2 .ag2-prevs {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
 }
-html.ui-v2 .agenda-answer-q {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
+html.ui-v2 .ag2-prev {
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  overflow: hidden;
+  cursor: pointer;
+  background: var(--code-bg);
+  transition: border-color var(--t-fast);
 }
-html.ui-v2 .agenda-answer-line {
-  color: var(--text-2);
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
+html.ui-v2 .ag2-prev:hover { border-color: var(--line-2); }
+html.ui-v2 .ag2-prev.sel.t-iris {
+  border-color: rgba(var(--iris-rgb), 0.55);
+  box-shadow: inset 0 0 0 1px rgba(var(--iris-rgb), 0.55);
 }
-html.ui-v2 .agenda-answer-qname {
+html.ui-v2 .ag2-prev.sel.t-green {
+  border-color: rgba(var(--green-rgb), 0.55);
+  box-shadow: inset 0 0 0 1px rgba(var(--green-rgb), 0.55);
+}
+html.ui-v2 .ag2-prev-media {
+  height: 112px;
+  pointer-events: none;
+  overflow: hidden;
+  background: var(--code-bg);
+}
+html.ui-v2 .ag2-prevs.insp .ag2-prev-media { height: 132px; }
+html.ui-v2 .ag2-prev-frame {
+  width: 200%;
+  height: 224px;
+  border: 0;
+  transform: scale(0.5);
+  transform-origin: 0 0;
+  display: block;
+  background: var(--code-bg);
+}
+html.ui-v2 .ag2-prevs.insp .ag2-prev-frame { height: 264px; }
+html.ui-v2 .ag2-prev-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+html.ui-v2 .ag2-prev-text {
+  margin: 0;
+  padding: 8px;
   font-family: var(--mono);
-  font-size: 11px;
+  font-size: 10px;
+  color: var(--text-2);
+  overflow: hidden;
+  height: 100%;
+  box-sizing: border-box;
+}
+html.ui-v2 .ag2-prev-missing {
+  display: inline-block;
+  padding: 8px;
+  font-size: 10.5px;
   color: var(--text-3);
 }
-html.ui-v2 .agenda-answer-picks {
+html.ui-v2 .ag2-prev-cap {
   display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 9px;
+  border-top: 1px solid var(--line);
+  background: var(--surface);
 }
-html.ui-v2 .agenda-chip.pick {
-  color: var(--green);
-  background: color-mix(in srgb, var(--green, #98c379) 12%, transparent);
-}
-html.ui-v2 .agenda-answer-extra {
-  font-size: 11.5px;
-  color: var(--text-3);
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
-}
-/* Dismissed-but-open questions: a quiet state marker, never an alarm —
-   the rails were cleared deliberately; the item stays open here. */
-html.ui-v2 .agenda-chip.dismissed {
-  color: var(--text-3);
-  background: none;
-  border: 1px dashed var(--line);
-}
-/* Answered ask nobody heard (answer.delivered === false on a done item):
-   quiet like the dismissal marker, tinted so an unread reply stands out
-   from plain history. */
-html.ui-v2 .agenda-chip.pickup {
-  color: var(--sky);
-  background: none;
-  border: 1px dashed color-mix(in srgb, var(--sky, #7dcfff) 45%, transparent);
-}
-html.ui-v2 .agenda-card-q {
-  font-family: var(--mono);
-  font-size: 11px;
+html.ui-v2 .ag2-prev-label {
+  font-size: 10.5px;
   font-weight: 700;
-  color: var(--amber);
+  color: var(--text-2);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+html.ui-v2 .ag2-prev-label.sel { color: var(--iris-2); }
+html.ui-v2 .ag2-prev.sel.t-green .ag2-prev-label { color: var(--green); }
+html.ui-v2 .ag2-prev-state {
+  font-family: var(--mono);
+  font-size: 9px;
+  color: var(--text-3);
+  white-space: nowrap;
+}
+html.ui-v2 .ag2-prev-expand {
+  background: none;
+  border: 0;
+  color: var(--text-3);
+  font-size: 10px;
+  font-family: var(--mono);
+  cursor: pointer;
+  padding: 0;
   flex-shrink: 0;
 }
-html.ui-v2 .agenda-item-foot {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-}
-html.ui-v2 .agenda-item-meta {
-  font-family: var(--mono);
-  font-size: 10.5px;
-  color: var(--text-3);
-}
-html.ui-v2 .agenda-item-actions {
-  display: flex;
-  gap: 6px;
-}
-html.ui-v2 .agenda-btn {
-  background: none;
-  border: 1px solid var(--line);
-  border-radius: 7px;
-  color: var(--text-2);
-  font-size: 11.5px;
-  padding: 3px 9px;
-  cursor: pointer;
-}
-html.ui-v2 .agenda-btn:hover {
-  border-color: var(--iris);
-  color: var(--iris);
-}
-html.ui-v2 .agenda-btn:disabled {
-  opacity: 0.5;
-  cursor: default;
-}
+html.ui-v2 .ag2-prev-expand:hover { color: var(--iris-2); }
 
-/* Scheduled-session effect: the manifest under review, its digest, and the
-   digest-bound approval state (A5). */
-html.ui-v2 .agenda-effect {
-  border: 1px solid var(--line);
-  border-radius: 9px;
-  background: var(--surface-2);
-  padding: 8px 10px;
+/* ---- Empty state + footer ledger ---- */
+
+html.ui-v2 .ag2-empty {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  align-items: center;
+  gap: 9px;
+  padding: 60px 20px;
+  text-align: center;
 }
-html.ui-v2 .agenda-effect-head {
+html.ui-v2 .ag2-empty-glyph {
+  width: 40px;
+  height: 40px;
+  border-radius: 11px;
+  background: var(--surface-2);
+  border: 1px solid var(--line-2);
   display: flex;
   align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
+  justify-content: center;
+  color: var(--text-3);
+  font-size: 16px;
 }
-html.ui-v2 .agenda-effect-icon {
+html.ui-v2 .ag2-empty-title {
+  font-size: 13.5px;
+  font-weight: 700;
+  color: var(--text);
+}
+html.ui-v2 .ag2-empty-hint {
+  font-size: 11.5px;
+  color: var(--text-3);
+}
+html.ui-v2 .ag2-ledger {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text-3);
+  margin-top: 26px;
+  padding-top: 12px;
+  border-top: 1px solid var(--line);
+}
+html.ui-v2 .ag2-ledger:empty { display: none; }
+
+/* ---- Shared attribution atoms (cards + inspector + twin) ---- */
+
+html.ui-v2 .agenda-session-link {
   color: var(--iris);
-  font-size: 12px;
-  line-height: 1;
+  text-decoration: none;
+  border-bottom: 1px dotted color-mix(in srgb, var(--iris) 55%, transparent);
+  cursor: pointer;
 }
-html.ui-v2 .agenda-effect-label {
-  font-family: var(--mono);
-  font-size: 9.5px;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
+html.ui-v2 .agenda-session-link:hover {
+  color: var(--text);
+  border-bottom-color: var(--text);
+}
+html.ui-v2 .agenda-self-described {
   color: var(--text-3);
+  font-style: italic;
 }
-html.ui-v2 .agenda-effect-state {
-  font-family: var(--mono);
-  font-size: 10.5px;
-  margin-left: auto;
+/* Flash highlight on the Sessions-tab card an agenda jump lands on.
+   Defined here because the agenda owns the jump gesture. */
+.agenda-jump-flash {
+  animation: agenda-jump-flash-pulse 0.8s ease-in-out 3;
 }
-html.ui-v2 .agenda-effect-state.pending { color: var(--amber); }
-html.ui-v2 .agenda-effect-state.armed { color: var(--sky); }
-html.ui-v2 .agenda-effect-state.completed { color: var(--green); }
-html.ui-v2 .agenda-effect-state.failed { color: var(--red); }
-html.ui-v2 .agenda-effect-state.attention { color: var(--amber); }
-/* The goal is the task text under review — quoted data, never instructions. */
-html.ui-v2 .agenda-effect-goal {
-  font-size: 12.5px;
-  color: var(--text-2);
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
-  max-height: 140px;
-  overflow-y: auto;
-  border-left: 2px solid var(--iris);
-  padding-left: 9px;
-}
-/* Run outcomes (session summaries, failure reasons) are quoted data too. */
-html.ui-v2 .agenda-effect-note {
-  font-size: 12px;
-  color: var(--text-3);
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
-  max-height: 120px;
-  overflow-y: auto;
-  border-left: 2px solid var(--line);
-  padding-left: 9px;
-}
-html.ui-v2 .agenda-btn.approve {
-  border-color: var(--green);
-  color: var(--green);
-}
-html.ui-v2 .agenda-btn.approve:hover {
-  background: rgba(var(--green-rgb), 0.12);
-  border-color: var(--green);
-  color: var(--green);
+@keyframes agenda-jump-flash-pulse {
+  0%, 100% { outline: 2px solid transparent; outline-offset: 2px; }
+  50% { outline: 2px solid var(--iris, #7c7cf0); outline-offset: 2px; }
 }
 
-/* ---- Activity-pane card (stacks under #ui2-vitals-rail) ---- */
+/* ---- Compact activity-pane card twin (unchanged by the redesign — it
+   keeps rendering from the shared cache) ---- */
 
 html.ui-v2 #ui2-agenda-card {
   display: none;
@@ -481,6 +881,13 @@ html.ui-v2 .agenda-card-empty {
   color: var(--text-3);
 }
 html.ui-v2 .agenda-card-more { cursor: pointer; }
+html.ui-v2 .agenda-card-q {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--amber);
+  flex-shrink: 0;
+}
 html.ui-v2 .agenda-card-add input {
   width: 100%;
   background: var(--surface-2);
@@ -493,261 +900,6 @@ html.ui-v2 .agenda-card-add input {
 html.ui-v2 .agenda-card-add input:focus {
   outline: none;
   border-color: var(--iris);
-}
-
-/* F1 provenance: resolved session names link to the conversation row on
-   the Sessions tab; self-described labels are visibly labeled data. */
-html.ui-v2 .agenda-session-link {
-  color: var(--iris);
-  text-decoration: none;
-  border-bottom: 1px dotted color-mix(in srgb, var(--iris) 55%, transparent);
-  cursor: pointer;
-}
-html.ui-v2 .agenda-session-link:hover {
-  color: var(--text);
-  border-bottom-color: var(--text);
-}
-html.ui-v2 .agenda-self-described {
-  color: var(--text-3);
-  font-style: italic;
-}
-/* Flash highlight on the Sessions-tab card an agenda jump lands on.
-   Defined here because the agenda owns the jump gesture. */
-.agenda-jump-flash {
-  animation: agenda-jump-flash-pulse 0.8s ease-in-out 3;
-}
-@keyframes agenda-jump-flash-pulse {
-  0%, 100% { outline: 2px solid transparent; outline-offset: 2px; }
-  50% { outline: 2px solid var(--iris, #7c7cf0); outline-offset: 2px; }
-}
-
-/* F2 gates & threads: annotations, blockers, dependency edges, blocked
-   chip. All content is escaped data. */
-html.ui-v2 .agenda-chip.blocked {
-  background: color-mix(in srgb, var(--red, #e06c75) 18%, transparent);
-  color: var(--red, #e06c75);
-  border: 1px solid color-mix(in srgb, var(--red, #e06c75) 45%, transparent);
-}
-html.ui-v2 .agenda-item-thread {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  margin: 4px 0 2px 22px;
-}
-html.ui-v2 .agenda-note {
-  font-size: 11.5px;
-  color: var(--text-2);
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
-}
-html.ui-v2 .agenda-thread-more {
-  align-self: flex-start;
-  background: none;
-  border: none;
-  padding: 0;
-  font-size: 11px;
-  color: var(--iris);
-  cursor: pointer;
-}
-html.ui-v2 .agenda-blocker {
-  display: flex;
-  align-items: baseline;
-  gap: 6px;
-  font-size: 11.5px;
-  color: var(--text);
-}
-html.ui-v2 .agenda-blocker.cleared { color: var(--text-3); }
-html.ui-v2 .agenda-blocker-text { overflow-wrap: anywhere; }
-html.ui-v2 .agenda-blocker .agenda-btn { margin-left: auto; flex-shrink: 0; }
-html.ui-v2 .agenda-edges {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-}
-html.ui-v2 .agenda-edge {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 10.5px;
-  border-radius: 999px;
-  padding: 1px 8px;
-  border: 1px solid var(--line);
-  color: var(--text-2);
-  max-width: 100%;
-}
-html.ui-v2 .agenda-edge.satisfied {
-  color: var(--green, #98c379);
-  border-color: color-mix(in srgb, var(--green, #98c379) 45%, transparent);
-}
-html.ui-v2 .agenda-edge.review {
-  color: var(--peach, #e5a06c);
-  border-color: color-mix(in srgb, var(--peach, #e5a06c) 45%, transparent);
-}
-html.ui-v2 .agenda-edge-remove {
-  background: none;
-  border: none;
-  padding: 0 0 0 2px;
-  color: var(--text-3);
-  cursor: pointer;
-  font-size: 12px;
-  line-height: 1;
-}
-html.ui-v2 .agenda-edge-remove:hover { color: var(--red, #e06c75); }
-html.ui-v2 .agenda-thread-add {
-  display: flex;
-  gap: 6px;
-  align-items: center;
-}
-html.ui-v2 .agenda-thread-add .agenda-thread-input {
-  flex: 1;
-  min-width: 0;
-  background: var(--surface-2);
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  color: var(--text);
-  font-size: 11.5px;
-  padding: 4px 8px;
-}
-html.ui-v2 .agenda-thread-add .agenda-thread-input:focus {
-  outline: none;
-  border-color: var(--iris);
-}
-
-/* G1 typed references: pointer chips + rows. Locators and labels are
-   escaped data; must-reads render prominent (a pointer to weigh, not an
-   order); drift badges land only after the on-demand Verify fetch. */
-html.ui-v2 .agenda-chip.refs { color: var(--text-2); }
-html.ui-v2 .agenda-chip.refs.must {
-  color: var(--iris);
-  border: 1px solid color-mix(in srgb, var(--iris) 45%, transparent);
-}
-html.ui-v2 .agenda-refs {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 4px;
-  margin: 4px 0 2px 22px;
-}
-html.ui-v2 .agenda-ref {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  font-size: 10.5px;
-  border-radius: 999px;
-  padding: 1px 8px;
-  border: 1px solid var(--line);
-  color: var(--text-2);
-  max-width: 100%;
-}
-html.ui-v2 .agenda-ref.must {
-  border-color: color-mix(in srgb, var(--iris) 55%, transparent);
-}
-html.ui-v2 .agenda-ref a {
-  color: var(--iris);
-  text-decoration: none;
-  overflow-wrap: anywhere;
-}
-html.ui-v2 .agenda-ref a:hover { text-decoration: underline; }
-html.ui-v2 .agenda-ref-type {
-  font-size: 9.5px;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--text-3);
-}
-html.ui-v2 .agenda-ref-must {
-  font-size: 9.5px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--iris);
-}
-html.ui-v2 .agenda-ref-drift[data-status="unchanged"] { color: var(--green, #98c379); }
-html.ui-v2 .agenda-ref-drift[data-status="changed"] { color: var(--peach, #e5a06c); }
-html.ui-v2 .agenda-ref-drift[data-status="missing"] { color: var(--red, #e06c75); }
-html.ui-v2 .agenda-ref-remove {
-  background: none;
-  border: none;
-  padding: 0 0 0 2px;
-  color: var(--text-3);
-  cursor: pointer;
-  font-size: 12px;
-  line-height: 1;
-}
-html.ui-v2 .agenda-ref-remove:hover { color: var(--red, #e06c75); }
-html.ui-v2 .agenda-refs-verify { flex-shrink: 0; }
-
-/* G2 graph: hub roll-ups, placement, adjacency, the by-hub lens. All
-   derived at render; nesting is an opt-in reorder of the same cards. */
-html.ui-v2 .agenda-chip.hub { color: var(--text-2); }
-html.ui-v2 .agenda-hub-open-flag {
-  font-size: 10px;
-  color: var(--peach, #e5a06c);
-}
-html.ui-v2 .agenda-chip.placement {
-  display: inline-flex;
-  align-items: center;
-  gap: 3px;
-  color: var(--text-2);
-}
-html.ui-v2 .agenda-chip.placement a,
-html.ui-v2 .agenda-relation a {
-  color: inherit;
-  text-decoration: none;
-}
-html.ui-v2 .agenda-chip.placement a:hover,
-html.ui-v2 .agenda-relation a:hover { color: var(--iris); }
-html.ui-v2 .agenda-place-remove,
-html.ui-v2 .agenda-relation-remove {
-  background: none;
-  border: none;
-  padding: 0 0 0 2px;
-  color: var(--text-3);
-  cursor: pointer;
-  font-size: 12px;
-  line-height: 1;
-}
-html.ui-v2 .agenda-place-remove:hover,
-html.ui-v2 .agenda-relation-remove:hover { color: var(--red, #e06c75); }
-html.ui-v2 .agenda-relations {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-  margin: 4px 0 2px 22px;
-}
-html.ui-v2 .agenda-relation {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 10.5px;
-  border-radius: 999px;
-  padding: 1px 8px;
-  border: 1px solid var(--line);
-  color: var(--text-2);
-  max-width: 100%;
-}
-html.ui-v2 .agenda-item-nested {
-  margin-left: calc(var(--agenda-nest-depth, 1) * 18px);
-  border-left: 2px solid color-mix(in srgb, var(--iris) 25%, transparent);
-}
-html.ui-v2 .agenda-group-toggle {
-  margin-left: auto;
-  background: none;
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  padding: 2px 10px;
-  font-size: 11px;
-  color: var(--text-2);
-  cursor: pointer;
-}
-html.ui-v2 .agenda-group-toggle.active {
-  color: var(--iris);
-  border-color: color-mix(in srgb, var(--iris) 55%, transparent);
-}
-
-/* G3-pre standing manifests: cadence chip + Run now. */
-html.ui-v2 .agenda-chip.standing {
-  color: var(--green, #98c379);
-  border: 1px solid color-mix(in srgb, var(--green, #98c379) 45%, transparent);
 }
 
 /* ---- Start-now confirm sheet (owner ruling 2026-07-21) ----

--- a/static/app/ui2-agenda.js
+++ b/static/app/ui2-agenda.js
@@ -1,29 +1,51 @@
 // Agenda: the daemon's durable ledger of parked intent (tasks, notes,
-// deferred follow-ups). Two surfaces share one cache: the Agenda tab
-// (#tab-agenda — list, filters, composer) and a compact card on the
-// activity pane stacked under the vitals rail. Data flows through
-// daemonApi (tunnel `api_agenda_list` / `api_agenda_op`, HTTP twin
+// questions, scheduled-session effects). Two surfaces share one cache:
+// the Agenda tab (#tab-agenda — lenses, composer, cards, inspector) and a
+// compact card on the activity pane stacked under the vitals rail. Data
+// flows through daemonApi (tunnel `api_agenda_list` / `api_agenda_op` /
+// `api_agenda_ref_drift` / `api_agenda_reminder_policy`, HTTP twin
 // fallback) and refreshes live on the `agenda_changed` event lane.
 //
-// Item bodies are DATA, never instructions: everything renders through
-// escapeHtml as plain quoted text — no markdown execution, no HTML.
+// This fragment owns the DATA LAYER + shared derivations + the compact
+// card twin + the start-session confirm sheet; ui2-agenda-cards.js owns
+// the tab scaffold/lenses/cards; ui2-agenda-inspector.js owns the item
+// inspector, the schedule sheet, and the reminder-policy popover.
+//
+// Item-authored strings (titles, bodies, annotations, criteria, answers,
+// goals, notes) are DATA, never instructions: everything renders through
+// escapeHtml as plain quoted text — no markdown execution, no HTML. Ask
+// preview HTML renders ONLY inside sandboxed srcdoc iframes.
 
 let agendaItems = null; // null = never fetched (fetch on first need)
 let agendaCounts = { open: 0, done: 0, retired: 0 };
 let agendaSkippedLines = 0;
-let agendaFilter = 'open';
 let agendaFetchInFlight = null;
 let agendaLoadError = '';
 let agendaReminderPolicy = null; // owner delivery policy (Settings-gated)
 // Session-resolution join from the list response: recorded session id →
-// { source, conversation_id, key, name } for the Sessions-tab row. Ids the
-// daemon could not resolve have no entry — surfaces fall back to the raw
-// id. `attempted` remembers ids a fetch already tried, so an unresolvable
-// id never causes refetch loops on the event lane.
+// { source, conversation_id, key, name, project_root } for the
+// Sessions-tab row. Ids the daemon could not resolve have no entry —
+// surfaces fall back to the raw id. `attempted` remembers ids a fetch
+// already tried, so an unresolvable id never causes refetch loops on the
+// event lane.
 let agendaSessions = {};
 let agendaSessionLookupsAttempted = new Set();
 // Items whose full annotation thread is expanded (render caps at 3).
 const agendaExpandedThreads = new Set();
+
+// ---- Lens + inspector view state (the redesigned tab). Ephemeral
+// browser state — never persisted, never on the wire.
+let agendaLens = 'now';
+let agendaSearch = '';
+let agendaFilterBlocked = false;
+let agendaFilterFrontier = false;
+let agendaSelId = null; // inspector selection (item id) or null
+// Inline structured-answer state, shared by the card composer and the
+// inspector question section: picks per question index, one free-text
+// draft per item, anchored notes per `${itemId}:${qi}`.
+const agendaQaSel = {};
+const agendaQaDrafts = {};
+const agendaQaNotes = {};
 
 async function agendaRefresh() {
   if (agendaFetchInFlight) return agendaFetchInFlight;
@@ -61,9 +83,9 @@ async function agendaRefresh() {
 // this) harmless. Once per page load per ask id — and never for a
 // DISMISSED item (`item.dismissed`, still open): the owner cleared it
 // from the rails deliberately, so it stays cleared across loads; the
-// card's "Open question panel" button is the deliberate way back, and
-// answering or reopening clears the marker (the log keeps the dismissal
-// as history).
+// inspector's question section is the deliberate way back, and answering
+// or reopening clears the marker (the log keeps the dismissal as
+// history).
 const agendaAnnouncedAsks = new Set();
 function agendaAnnounceParkedAsks() {
   if (!Array.isArray(agendaItems)) return;
@@ -89,11 +111,10 @@ function agendaAnnounceParkedAsks() {
   }
 }
 
-// Explicit "open the question panel" from an agenda item card. Unlike the
-// once-per-load announce this is a user act: it re-surfaces even a tucked
-// or previously-dismissed panel, and it navigates to the Activity tab
-// where the panel lives (opening invisibly confused live QA 2026-07-20 —
-// the item card only offered the blind plain-text input).
+// Explicit "open the question panel" (the rail door in the inspector's
+// question section). Unlike the once-per-load announce this is a user
+// act: it re-surfaces even a tucked or previously-dismissed panel, and it
+// navigates to the Activity tab where the panel lives.
 function agendaOpenParkedAsk(itemId) {
   const item = (agendaItems || []).find((candidate) => candidate.id === itemId);
   if (!item || !item.ask || !Array.isArray(item.ask.questions) || !item.ask.questions.length) {
@@ -115,11 +136,11 @@ function agendaOpenParkedAsk(itemId) {
   if (typeof setQuestionMinimized === 'function') setQuestionMinimized(false);
 }
 
-// "View question" on a DONE ask-backed item: the same panel, rendered
-// READ-ONLY from the retained payload — the record stays fully viewable
-// (recorded picks selected, follow-ups and anchored notes as content,
-// preview cards from the retained blobs; blobs are deleted only on
-// retire, and a missing one degrades to a named placeholder). Close
+// "View the rail record" on a DONE ask-backed item: the same panel,
+// rendered READ-ONLY from the retained payload — the record stays fully
+// viewable (recorded picks selected, follow-ups and anchored notes as
+// content, preview cards from the retained blobs; blobs are deleted only
+// on retire, and a missing one degrades to a named placeholder). Close
 // returns here; "Reopen to change answer" rides the existing reopen op.
 function agendaViewAnsweredAsk(itemId) {
   const item = agendaFindItem(itemId);
@@ -153,15 +174,6 @@ async function agendaReopenAnsweredAsk(itemId) {
   if (!ok) return false;
   agendaOpenParkedAsk(itemId);
   return true;
-}
-
-// Head-click router for ask-backed items: an OPEN item's head opens the
-// live panel, a DONE item's head opens the read-only record.
-function agendaOpenAskPanel(itemId) {
-  const item = agendaFindItem(itemId);
-  if (!item) return;
-  if (item.status === 'open') agendaOpenParkedAsk(itemId);
-  else if (item.status === 'done') agendaViewAnsweredAsk(itemId);
 }
 
 // Live update from the event lane: merge the changed item, adopt counts.
@@ -230,42 +242,29 @@ async function agendaSendOp(params, button) {
   }
 }
 
+// Refused ops surface inline on the tab's notice line (and the ledger
+// keeps rendering under it). The daemon's named refusal is the message.
 function agendaFlashError(message) {
-  const note = document.getElementById('agenda-tab-skipped');
-  if (!note) return;
-  note.style.display = '';
+  const note = document.getElementById('ag2-notice');
+  if (!note) {
+    if (typeof showControlToast === 'function') showControlToast('error', message);
+    return;
+  }
+  note.hidden = false;
   note.textContent = message;
   setTimeout(() => {
     note.textContent = '';
-    agendaRenderAll(); // restores the skipped-lines note if one applies
+    note.hidden = true;
   }, 6000);
-}
-
-function agendaGlyph(status, kind) {
-  if (status === 'done') return '<span class="agenda-glyph done" aria-label="done">✓</span>';
-  if (status === 'retired') return '<span class="agenda-glyph retired" aria-label="retired">⊘</span>';
-  if (kind === 'question') return '<span class="agenda-glyph question" aria-label="open question">?</span>';
-  return '<span class="agenda-glyph open" aria-label="open">○</span>';
-}
-
-function agendaDueChip(item) {
-  if (!item.due_ms) return '';
-  const due = new Date(item.due_ms);
-  const overdue = item.status === 'open' && item.due_ms < Date.now();
-  const label = due.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
-    + (due.getHours() || due.getMinutes()
-      ? ' ' + due.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
-      : '');
-  return `<span class="agenda-chip due${overdue ? ' overdue' : ''}">due ${escapeHtml(label)}</span>`;
 }
 
 function agendaSessionInfo(id) {
   return (id && agendaSessions && agendaSessions[id]) || null;
 }
 
-// ---- F2 derived presentation (client twin of the daemon's is_blocked /
-// dependency_state — like the overdue chip, derived at render time from
-// facts the tab already holds; never stored, never on the wire).
+// ---- Derived presentation (client twin of the daemon's render-time
+// judgments — like the overdue chip, derived at render time from facts
+// the tab already holds; never stored, never on the wire).
 
 function agendaFindItem(id) {
   return (agendaItems || []).find((item) => item.id === id) || null;
@@ -285,6 +284,95 @@ function agendaItemIsBlocked(item) {
   if (item.status !== 'open') return false;
   if ((item.blockers || []).some((b) => !b.cleared)) return true;
   return (item.relies_on || []).some((edge) => !agendaEdgeState(edge).satisfied);
+}
+
+// The card's one-line blocked statement (first gate wins). Plain TEXT —
+// callers escape.
+function agendaBlockedLine(item) {
+  if (item.status !== 'open') return null;
+  const blocker = (item.blockers || []).find((b) => !b.cleared);
+  if (blocker) return `Blocked — waiting on: “${blocker.criterion}”`;
+  for (const edge of item.relies_on || []) {
+    const target = agendaFindItem(edge.target_id);
+    if (!target) return 'Prerequisite missing from the fold — review';
+    if (target.status === 'retired') return `Prerequisite “${target.title}” was retired — review`;
+    if (target.status === 'open') return `Waits on “${target.title}” — still open`;
+  }
+  return null;
+}
+
+// The item's scheduled-session effect, judged for render: kind is one of
+// running | suspended | pending | standing | armed | finished. Mirrors
+// the daemon's fold judgments (AgendaEffect::suspended, the scheduler's
+// next-instant derivation) — derived here every paint, never stored.
+function agendaEffectState(item) {
+  const effect = (item.effects || [])[0];
+  if (!effect || !effect.manifest) return null;
+  const manifest = effect.manifest;
+  const rec = manifest.recurrence || null;
+  const threshold = rec ? Math.max(1, rec.suspend_after_failures || 3) : 0;
+  const suspended = !!rec && (effect.consecutive_failures || 0) >= threshold;
+  const running = !!(effect.last_run && effect.last_run.state === 'started');
+  let next = manifest.fire_at_ms;
+  if (rec && rec.every_ms > 0) {
+    const behind = Math.max(0, Math.ceil((Date.now() - manifest.fire_at_ms) / rec.every_ms));
+    next = manifest.fire_at_ms + behind * rec.every_ms;
+  }
+  const kind = running ? 'running'
+    : suspended ? 'suspended'
+      : !effect.approval ? 'pending'
+        : rec ? 'standing'
+          : next > Date.now() ? 'armed' : 'finished';
+  return { effect, manifest, rec, threshold, suspended, running, next, kind };
+}
+
+function agendaChildrenOf(id) {
+  return (agendaItems || []).filter(
+    (it) => it.part_of && it.part_of.parent_id === id
+  );
+}
+
+// Transitive descendant set (cycle-safe) — the exclusion set for the
+// Filed-under and prerequisite pickers.
+function agendaDescendantIds(id, seen) {
+  seen = seen || new Set();
+  for (const child of agendaChildrenOf(id)) {
+    if (!seen.has(child.id)) {
+      seen.add(child.id);
+      agendaDescendantIds(child.id, seen);
+    }
+  }
+  return seen;
+}
+
+// The undirected adjacency union: edges stored on this item plus edges
+// other items store pointing here, deduped.
+function agendaRelationPartners(item) {
+  const partners = new Set((item.relates_to || []).map((e) => e.target_id));
+  (agendaItems || []).forEach((other) => {
+    if ((other.relates_to || []).some((e) => e.target_id === item.id)) {
+      partners.add(other.id);
+    }
+  });
+  partners.delete(item.id);
+  return partners;
+}
+
+// Triage-rank convention: the triage mandate writes ordinary annotations
+// with the self-described `triage` source, and a "rank N" phrase in the
+// text is its DECLARED ranking convention. The /rank (\d+)/ parse here is
+// a render-side bridge until a typed rank ships — it orders the Attend
+// group and labels the chip, and gates nothing (annotations are data).
+// The newest ranked triage note wins; an unranked one still marks the
+// item as triage-flagged.
+function agendaTriageInfo(item) {
+  const notes = (item.annotations || []).filter((a) => a.source === 'triage');
+  if (!notes.length) return null;
+  for (let i = notes.length - 1; i >= 0; i--) {
+    const m = /rank (\d+)/.exec(notes[i].text || '');
+    if (m) return { rank: Number(m[1]), text: notes[i].text || '' };
+  }
+  return { rank: null, text: notes[notes.length - 1].text || '' };
 }
 
 function agendaActorLabel(p) {
@@ -343,21 +431,48 @@ function agendaActorHtml(p) {
   return bits.join(' ');
 }
 
-function agendaProvenanceLine(item) {
-  const p = item.provenance || {};
-  const created = p.created_ms
-    ? new Date(p.created_ms).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
-    : '';
-  const who = agendaActorHtml(p);
-  const parts = [];
-  if (created) parts.push(escapeHtml(`parked ${created}`));
-  if (who) parts.push(`by ${who}`);
-  return parts.join(' · ');
+// Relative instant ("in 3h" / "2d ago" / "just now"). Plain TEXT.
+function agendaRelTime(ms) {
+  if (!ms) return '';
+  const delta = ms - Date.now();
+  const abs = Math.abs(delta);
+  if (abs < 45e3) return 'just now';
+  const unit = abs < 36e5 ? `${Math.round(abs / 6e4)}m`
+    : abs < 864e5 ? `${Math.round(abs / 36e5)}h`
+      : `${Math.round(abs / 864e5)}d`;
+  return delta > 0 ? `in ${unit}` : `${unit} ago`;
+}
+
+// Absolute instant ("Tue Jul 21, 09:00", locale-aware). Plain TEXT.
+function agendaAbsTime(ms) {
+  if (!ms) return '';
+  const d = new Date(ms);
+  return `${d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' })}, `
+    + d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+}
+
+// Human cadence label for a recurrence interval (plain TEXT — callers
+// escape).
+function agendaCadenceLabel(everyMs) {
+  const minutes = Math.round((everyMs || 0) / 60000);
+  if (minutes % (7 * 24 * 60) === 0) return `${minutes / (7 * 24 * 60)}w`;
+  if (minutes % (24 * 60) === 0) return `${minutes / (24 * 60)}d`;
+  if (minutes % 60 === 0) return `${minutes / 60}h`;
+  return `${minutes}m`;
+}
+
+// The dismissal chip's tooltip (marker on a still-open question whose
+// rail card was skipped/denied). Plain TEXT — the caller escapes.
+function agendaDismissedTip(dismissed) {
+  const when = dismissed.at_ms ? agendaRelTime(dismissed.at_ms) : '';
+  const verb = dismissed.action ? `(${dismissed.action}) ` : '';
+  return `Rails cleared ${verb}${when ? `${when} ` : ''}— the question stays open `
+    + 'and answerable here; only an answer resolves it.';
 }
 
 // Jump to the conversation's row on the Sessions tab: switch tabs, then
 // focus/flash the card once the list renders it (rows are keyed by
-// sessionListRowKey = source<conversation id>). If the row is not in
+// sessionListRowKey = source<conversation id>). If the row is not in
 // the loaded window the jump degrades to just opening the tab.
 function agendaJumpToSession(key) {
   if (!key) return;
@@ -377,442 +492,9 @@ function agendaJumpToSession(key) {
   seek();
 }
 
-// Scheduled-session effect (A5): render the manifest under review, its
-// digest, and the approval state. Approval is an owner-surface act — the
-// dashboard is one, so the Approve button lives here; it carries the digest
-// of exactly the revision rendered, so what you approve is what you read
-// (a concurrent re-propose makes the click fail with "digest mismatch").
-function agendaEffectBlock(item) {
-  const effect = (item.effects || [])[0];
-  if (!effect || !effect.manifest) return '';
-  const manifest = effect.manifest;
-  const when = manifest.fire_at_ms ? new Date(manifest.fire_at_ms) : null;
-  const whenLabel = when
-    ? when.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
-      + ' ' + when.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
-    : '';
-  // Standing cadence (G3-pre): the recurrence lives INSIDE the digest-
-  // bound manifest — one approval covers the series; any edit voids it.
-  const rec = manifest.recurrence || null;
-  const recLabel = rec ? agendaCadenceLabel(rec.every_ms) : '';
-  const suspendThreshold = rec ? (rec.suspend_after_failures || 3) : 0;
-  const suspended = !!rec && (effect.consecutive_failures || 0) >= suspendThreshold;
-  const chips =
-    (whenLabel ? `<span class="agenda-chip due">${rec ? 'from' : 'at'} ${escapeHtml(whenLabel)}</span>` : '')
-    + (rec ? `<span class="agenda-chip standing" title="Standing manifest: one approval covers every occurrence${rec.until_ms ? `; ends ${new Date(rec.until_ms).toLocaleDateString()}` : ''}${rec.max_occurrences ? `; at most ${rec.max_occurrences} runs` : ''}">every ${escapeHtml(recLabel)}</span>` : '')
-    + (suspended ? `<span class="agenda-chip blocked" title="${escapeHtml(`${effect.consecutive_failures} consecutive failed runs — re-approve the unchanged manifest to re-arm, or revoke`)}">suspended</span>` : '')
-    + (manifest.orchestrate ? '<span class="agenda-chip">orchestrate</span>' : '')
-    + (manifest.interactive ? '<span class="agenda-chip" title="Opens the session with the goal as its first message, then waits for you">interactive</span>' : '')
-    + (manifest.project_root
-      ? `<span class="agenda-chip" title="${escapeHtml(`project: ${manifest.project_root}`)}">${escapeHtml(agendaShortPath(manifest.project_root))}</span>`
-      : '');
-  const proposer = agendaActorLabel({
-    kind: effect.proposed_kind,
-    session_id: effect.proposed_session_id,
-    principal: effect.proposed_principal,
-  });
-  const digestShort = escapeHtml(String(effect.digest || '').slice(0, 12));
-  const run = effect.last_run;
-  let stateHtml = '';
-  let noteHtml = '';
-  let actions = '';
-  if (run) {
-    const glyphs = { completed: '✓', failed: '✗', missed: '⊘', unknown: '?', started: '▶' };
-    const classes = { completed: 'completed', failed: 'failed', started: 'armed' };
-    const bits = [`${glyphs[run.state] || '·'} ${run.state}`];
-    if (run.session_id) bits.push(agendaActorLabel({ session_id: run.session_id }));
-    stateHtml = `<span class="agenda-effect-state ${classes[run.state] || 'attention'}">${escapeHtml(bits.join(' · '))}</span>`;
-    if (run.note) {
-      // Session summaries / failure reasons are quoted data, like bodies.
-      noteHtml = `<div class="agenda-effect-note">${escapeHtml(run.note)}</div>`;
-    }
-  } else if (effect.approval) {
-    const who = agendaActorLabel(effect.approval);
-    stateHtml = `<span class="agenda-effect-state armed">approved${who ? ` by ${escapeHtml(who)}` : ''}</span>`;
-    if (item.status === 'open') {
-      actions = `<button type="button" class="agenda-btn" data-op="revoke_effect" data-id="${escapeHtml(item.id)}">Revoke</button>`;
-    }
-  } else {
-    stateHtml = '<span class="agenda-effect-state pending">awaiting your approval</span>';
-    if (item.status === 'open') {
-      actions = `<button type="button" class="agenda-btn approve" data-op="approve_effect" data-id="${escapeHtml(item.id)}" data-digest="${escapeHtml(effect.digest || '')}">Approve</button>`;
-    }
-  }
-  // Standing-effect actions (G3-pre). Suspended + still approved: the
-  // one-click re-arm re-approves the UNCHANGED digest. Approved + armed:
-  // "Run now" fires one extra occurrence of the approved bytes (bare
-  // start_now — the daemon routes it to request_occurrence, approval
-  // untouched).
-  if (rec && item.status === 'open' && effect.approval) {
-    if (suspended) {
-      actions = `<button type="button" class="agenda-btn approve" data-op="approve_effect" data-id="${escapeHtml(item.id)}" data-digest="${escapeHtml(effect.digest || '')}" title="Re-approve the unchanged manifest — resets the failure streak and re-arms the series">Re-arm</button>${actions}`;
-    } else if (!run || run.state !== 'started') {
-      actions = `<button type="button" class="agenda-btn agenda-run-now" data-id="${escapeHtml(item.id)}" title="Fire one extra occurrence of the approved manifest now — the standing approval is untouched">Run now</button>${actions}`;
-    }
-  }
-  return `<div class="agenda-effect">
-    <div class="agenda-effect-head">
-      <span class="agenda-effect-icon" aria-hidden="true">⏵</span>
-      <span class="agenda-effect-label">Scheduled session</span>
-      ${chips}${stateHtml}
-    </div>
-    <div class="agenda-effect-goal">${escapeHtml(manifest.goal || '')}</div>
-    ${noteHtml}
-    <div class="agenda-item-foot">
-      <span class="agenda-item-meta">digest ${digestShort}${proposer ? ` · proposed by ${escapeHtml(proposer)}` : ''}</span>
-      <span class="agenda-item-actions">${actions}</span>
-    </div>
-  </div>`;
-}
-
-// Human cadence label for a recurrence interval (plain TEXT — callers
-// escape).
-function agendaCadenceLabel(everyMs) {
-  const minutes = Math.round((everyMs || 0) / 60000);
-  if (minutes % (7 * 24 * 60) === 0) return `${minutes / (7 * 24 * 60)}w`;
-  if (minutes % (24 * 60) === 0) return `${minutes / (24 * 60)}d`;
-  if (minutes % 60 === 0) return `${minutes / 60}h`;
-  return `${minutes}m`;
-}
-
-// The dismissal chip's tooltip (marker on a still-open question whose
-// rail card was skipped/denied). Plain TEXT — the caller escapes.
-function agendaDismissedTip(dismissed) {
-  const when = dismissed.at_ms
-    ? new Date(dismissed.at_ms).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
-    : '';
-  const verb = dismissed.action ? `(${dismissed.action}) ` : '';
-  return `Dismissed ${verb}${when ? `on ${when} ` : ''}from the question rail — it stays open `
-    + 'and answerable here, but is not auto-announced again; Open question panel brings it back.';
-}
-
-// The recorded reply on a resolved question. Plain answers render the
-// joined text; rich (ask-backed) answers render the STRUCTURED breakdown
-// (`item.answer.structured` — maps keyed by question text), walked in the
-// ITEM's question order exactly like the daemon's text summary: a
-// "Header: answer" line per engaged question, the picked option labels,
-// follow-ups, and anchored preview notes. All of it is quoted data —
-// escaped, never executed, never instructions.
-function agendaAnswerBlock(item) {
-  const answer = item.answer;
-  const who = agendaActorLabel(answer);
-  const when = answer.at_ms
-    ? new Date(answer.at_ms).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
-    : '';
-  const meta = `<span class="agenda-item-meta">— ${escapeHtml([who && `by ${who}`, when].filter(Boolean).join(' · '))}</span>`;
-  const questions = (item.ask && Array.isArray(item.ask.questions)) ? item.ask.questions : [];
-  const rows = answer.structured
-    ? agendaStructuredAnswerRows(questions, answer.structured)
-    : [];
-  if (!rows.length) {
-    return `<div class="agenda-item-answer">↳ ${escapeHtml(answer.text || '')}
-      ${meta}</div>`;
-  }
-  return `<div class="agenda-item-answer agenda-answer-structured">${rows.join('')}
-    <div>${meta}</div></div>`;
-}
-
-// One row per engaged question of a structured resolution. A question is
-// engaged when any of the maps mention it; a follow-up may stand in for
-// an answer, so the answer text is optional on the line.
-function agendaStructuredAnswerRows(questions, s) {
-  const answers = s.answers || {};
-  const selections = s.selections || {};
-  const followups = s.followups || {};
-  const annotations = s.annotations || {};
-  const engaged = questions.filter((q) =>
-    q.question in answers || q.question in selections
-    || q.question in followups || q.question in annotations);
-  return engaged.map((q) => {
-    const name = q.header || q.question;
-    const answerText = answers[q.question];
-    const head = answerText !== undefined
-      ? `<span class="agenda-answer-qname" title="${escapeHtml(q.question)}">${escapeHtml(name)}:</span> ${escapeHtml(answerText)}`
-      : `<span class="agenda-answer-qname" title="${escapeHtml(q.question)}">${escapeHtml(name)}</span>`;
-    const picks = (selections[q.question] || [])
-      .map((label) => `<span class="agenda-chip pick">✓ ${escapeHtml(label)}</span>`)
-      .join(' ');
-    const extras = [];
-    if (followups[q.question] !== undefined) {
-      extras.push(`<div class="agenda-answer-extra">follow-up: ${escapeHtml(followups[q.question])}</div>`);
-    }
-    for (const note of annotations[q.question] || []) {
-      extras.push(`<div class="agenda-answer-extra">note on ${escapeHtml(note.preview)}: ${escapeHtml(note.note)}</div>`);
-    }
-    return `<div class="agenda-answer-q">
-      <div class="agenda-answer-line">${head}</div>
-      ${picks ? `<div class="agenda-answer-picks">${picks}</div>` : ''}
-      ${extras.join('')}
-    </div>`;
-  });
-}
-
-// The item's thread + gates (F2): annotations (capped with an expander),
-// blockers with their clear affordance and cleared history, dependency
-// chips with satisfied/review markers, and the note/block composer.
-// Everything is data rendered escaped; nothing here executes or obeys.
-function agendaThreadBlock(item) {
-  const parts = [];
-  const notes = item.annotations || [];
-  if (notes.length) {
-    const cap = 3;
-    const shown = agendaExpandedThreads.has(item.id) ? notes : notes.slice(-cap);
-    const rows = shown.map((note) => {
-      const when = note.at_ms
-        ? new Date(note.at_ms).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
-        : '';
-      const who = agendaActorHtml(note);
-      const meta = [who, escapeHtml(when)].filter(Boolean).join(' · ');
-      return `<div class="agenda-note">↳ ${escapeHtml(note.text)}
-        <span class="agenda-item-meta">— ${meta}</span></div>`;
-    });
-    const more = notes.length > shown.length
-      ? `<button type="button" class="agenda-thread-more" data-id="${escapeHtml(item.id)}">show all ${notes.length} notes</button>`
-      : '';
-    parts.push(`<div class="agenda-thread">${rows.join('')}${more}</div>`);
-  }
-  const blockers = item.blockers || [];
-  if (blockers.length) {
-    const rows = blockers.map((blocker) => {
-      const who = agendaActorHtml(blocker);
-      if (blocker.cleared) {
-        const clearedBy = agendaActorHtml(blocker.cleared);
-        return `<div class="agenda-blocker cleared">✓ <s>${escapeHtml(blocker.criterion)}</s>
-          <span class="agenda-item-meta">— cleared${clearedBy ? ` by ${clearedBy}` : ''}</span></div>`;
-      }
-      const clear = item.status === 'open'
-        ? `<button type="button" class="agenda-btn agenda-clear-blocker" data-id="${escapeHtml(item.id)}" data-blocker="${escapeHtml(blocker.blocker_id)}">Clear</button>`
-        : '';
-      return `<div class="agenda-blocker">
-        <span class="agenda-blocker-text" title="${escapeHtml(blocker.blocker_id)}">⛔ ${escapeHtml(blocker.criterion)}</span>
-        <span class="agenda-item-meta">${who ? `— set by ${who}` : ''}</span>${clear}
-      </div>`;
-    });
-    parts.push(`<div class="agenda-blockers">${rows.join('')}</div>`);
-  }
-  const edges = item.relies_on || [];
-  if (edges.length) {
-    const chips = edges.map((edge) => {
-      const state = agendaEdgeState(edge);
-      const target = agendaFindItem(edge.target_id);
-      const label = target ? target.title : edge.target_id.slice(0, 10);
-      const marker = state.review === 'target_retired'
-        ? ' · prerequisite retired — review'
-        : state.review === 'target_missing'
-          ? ' · prerequisite missing'
-          : '';
-      const cls = state.satisfied ? 'satisfied' : state.review ? 'review' : 'waiting';
-      const remove = item.status === 'open'
-        ? `<button type="button" class="agenda-edge-remove" data-id="${escapeHtml(item.id)}" data-target="${escapeHtml(edge.target_id)}" aria-label="Remove dependency" title="Remove dependency">×</button>`
-        : '';
-      return `<span class="agenda-edge ${cls}" title="${escapeHtml(edge.target_id)}">
-        ${state.satisfied ? '✓' : '…'} needs ${escapeHtml(label)}${escapeHtml(marker)}${remove}</span>`;
-    });
-    parts.push(`<div class="agenda-edges">${chips.join('')}</div>`);
-  }
-  // Composer: annotate any non-retired item; block only open ones.
-  if (item.status !== 'retired') {
-    const blockBtn = item.status === 'open'
-      ? `<button type="button" class="agenda-btn agenda-thread-block" data-id="${escapeHtml(item.id)}">Block</button>`
-      : '';
-    parts.push(`<div class="agenda-thread-add">
-      <input type="text" class="agenda-thread-input" maxlength="4000"
-             placeholder="Add a note — or state a blocker…" aria-label="Note or blocker" data-id="${escapeHtml(item.id)}" />
-      <button type="button" class="agenda-btn agenda-thread-note" data-id="${escapeHtml(item.id)}">Note</button>
-      ${blockBtn}
-    </div>`);
-  }
-  return parts.length ? `<div class="agenda-item-thread">${parts.join('')}</div>` : '';
-}
-
-// ---- G2 graph presentation: hub roll-ups, placement, adjacency. ALL
-// derived at render from the ordinary snapshot — never stored, never on
-// the wire — and placement NEVER hides an item: the flat lens stays the
-// default, grouping is an opt-in reorder of the same cards (anti-hiding
-// rule). No transitive semantics: a hub completing over open children
-// wears a render-level flag only.
-
-let agendaGroupByHub = false;
-let agendaAttentionOrderOn = false;
-
-function agendaChildrenOf(id) {
-  return (agendaItems || []).filter(
-    (it) => it.part_of && it.part_of.parent_id === id
-  );
-}
-
-function agendaHubChip(item) {
-  const children = agendaChildrenOf(item.id);
-  if (!children.length) return '';
-  const open = children.filter((c) => c.status === 'open').length;
-  const doneOverOpen = item.status === 'done' && open > 0;
-  const flag = doneOverOpen
-    ? `<span class="agenda-hub-open-flag" title="This hub is done but ${open} of its children are still open — completion never cascades">· open children</span>`
-    : '';
-  return `<span class="agenda-chip hub" title="${children.length} item(s) placed under this one">⌂ ${open}/${children.length} open</span>${flag}`;
-}
-
-function agendaPlacementChip(item) {
-  if (!item.part_of) return '';
-  const parent = agendaFindItem(item.part_of.parent_id);
-  const label = parent ? parent.title : `${item.part_of.parent_id.slice(0, 10)}… (missing)`;
-  const short = label.length > 28 ? `${label.slice(0, 28)}…` : label;
-  return `<span class="agenda-chip placement">
-    <a href="#agenda" class="agenda-item-jump" data-jump="${escapeHtml(item.part_of.parent_id)}" title="Placed under: ${escapeHtml(label)}">in ${escapeHtml(short)}</a>
-    <button type="button" class="agenda-place-remove" data-id="${escapeHtml(item.id)}" data-parent="${escapeHtml(item.part_of.parent_id)}" aria-label="Remove placement" title="Un-place (history stays in the log)">×</button>
-  </span>`;
-}
-
-// The undirected adjacency union: edges stored on this item plus edges
-// other items store pointing here, deduped.
-function agendaRelationsBlock(item) {
-  const partners = new Set((item.relates_to || []).map((e) => e.target_id));
-  (agendaItems || []).forEach((other) => {
-    if ((other.relates_to || []).some((e) => e.target_id === item.id)) {
-      partners.add(other.id);
-    }
-  });
-  if (!partners.size) return '';
-  const chips = [...partners].map((pid) => {
-    const target = agendaFindItem(pid);
-    const label = target ? target.title : `${pid.slice(0, 10)}…`;
-    const short = label.length > 30 ? `${label.slice(0, 30)}…` : label;
-    return `<span class="agenda-relation">
-      <a href="#agenda" class="agenda-item-jump" data-jump="${escapeHtml(pid)}" title="${escapeHtml(label)}">↔ ${escapeHtml(short)}</a>
-      <button type="button" class="agenda-relation-remove" data-id="${escapeHtml(item.id)}" data-target="${escapeHtml(pid)}" aria-label="Remove relation" title="Remove relation (either side may — the daemon resolves the stored edge)">×</button>
-    </span>`;
-  });
-  return `<div class="agenda-relations">${chips.join('')}</div>`;
-}
-
-// Scroll-and-flash navigation to another item's card in this tab.
-function agendaJumpToItem(id) {
-  const selector = `.agenda-item[data-item-id="${window.CSS && CSS.escape ? CSS.escape(id) : id}"]`;
-  let card = document.querySelector(selector);
-  if (!card) {
-    // The target sits outside the current filter — widen to All.
-    agendaFilter = 'all';
-    document.querySelectorAll('#agenda-filters .agenda-filter').forEach((b) =>
-      b.classList.toggle('active', b.dataset.filter === 'all'));
-    agendaRenderTab();
-    card = document.querySelector(selector);
-  }
-  if (!card) return;
-  card.scrollIntoView({ block: 'center', behavior: 'smooth' });
-  card.classList.add('agenda-jump-flash');
-  setTimeout(() => card.classList.remove('agenda-jump-flash'), 2400);
-}
-
-// The Attention lens (G3): the SAME open cards ordered by what needs the
-// owner — blocking questions, approval-pending manifests, suspended
-// standing effects, triage-recommended items, then recency. A pure
-// reorder over data the tab already holds (triage recommendations are
-// ordinary annotations with the self-described `triage` source — data,
-// gating nothing); the attention queue is a VIEW, never a second inbox.
-function agendaAttentionClass(item) {
-  if (item.kind === 'question' && item.status === 'open') return 0;
-  const effect = (item.effects || [])[0];
-  if (effect && !effect.approval && item.status === 'open') return 1;
-  if (effect && effect.manifest && effect.manifest.recurrence) {
-    const threshold = (effect.manifest.recurrence.suspend_after_failures || 3);
-    if ((effect.consecutive_failures || 0) >= threshold) return 2;
-  }
-  if ((item.annotations || []).some((n) => n.source === 'triage')) return 3;
-  return 4;
-}
-
-function agendaAttentionOrder(filtered) {
-  return filtered
-    .slice()
-    .sort((a, b) => {
-      const ca = agendaAttentionClass(a);
-      const cb = agendaAttentionClass(b);
-      if (ca !== cb) return ca - cb;
-      return (b.updated_ms || 0) - (a.updated_ms || 0);
-    })
-    .map((item) => ({ item, depth: 0 }));
-}
-
-// Grouped ordering (the by-hub lens): the SAME filtered cards, reordered
-// so children follow their parent (depth-indented). Roots keep the
-// newest-first order; an item whose parent is outside the filtered set
-// renders as a root — everything filtered stays visible, always.
-function agendaGroupedOrder(filtered) {
-  const inSet = new Map(filtered.map((item) => [item.id, item]));
-  const roots = filtered
-    .filter((item) => !(item.part_of && inSet.has(item.part_of.parent_id)))
-    .sort((a, b) => (a.id < b.id ? 1 : -1));
-  const out = [];
-  const emit = (item, depth) => {
-    out.push({ item, depth });
-    agendaChildrenOf(item.id)
-      .filter((child) => inSet.has(child.id))
-      .sort((a, b) => (a.id < b.id ? 1 : -1))
-      .forEach((child) => emit(child, Math.min(depth + 1, 6)));
-  };
-  roots.forEach((root) => emit(root, 0));
-  return out;
-}
-
-// ---- G1 typed references: chips + per-ref rows. Refs are POINTERS —
-// labels and locators are data, rendered escaped, never followed by
-// machinery. A must-read is rendered prominent for whoever picks the item
-// up (a pointer they weigh, not an order). File drift is fetched ON
-// DEMAND per item (the Verify button) — never on list render.
-
-function agendaRefsChip(item) {
-  const refs = item.refs || [];
-  if (!refs.length) return '';
-  const must = refs.filter((r) => r.must_read).length;
-  const label = refs.length === 1 ? '1 ref' : `${refs.length} refs`;
-  return `<span class="agenda-chip refs${must ? ' must' : ''}"${must ? ` title="${must} must-read"` : ''}>⛉ ${label}</span>`;
-}
-
-function agendaRefFileName(locator) {
-  const parts = String(locator).split(/[\\/]/).filter(Boolean);
-  return parts.length ? parts[parts.length - 1] : locator;
-}
-
-function agendaRefsBlock(item) {
-  const refs = item.refs || [];
-  if (!refs.length) return '';
-  let hasFile = false;
-  const rows = refs.map((ref) => {
-    const label = ref.label || '';
-    let target = '';
-    if (ref.ref_type === 'url') {
-      target = `<a href="${escapeHtml(ref.locator)}" target="_blank" rel="noopener noreferrer nofollow">${escapeHtml(label || ref.locator)}</a>`;
-    } else if (ref.ref_type === 'session') {
-      const s = agendaSessionInfo(ref.locator);
-      const text = label || (s && s.name) || `session ${String(ref.locator).slice(0, 12)}`;
-      target = s && s.key
-        ? `<a href="#sessions" class="agenda-session-link" data-session-key="${escapeHtml(s.key)}" title="${escapeHtml(ref.locator)}">${escapeHtml(text)}</a>`
-        : `<span title="${escapeHtml(ref.locator)}">${escapeHtml(text)}</span>`;
-    } else if (ref.ref_type === 'memory') {
-      target = `<a href="#memory" class="agenda-ref-claim" data-claim="${escapeHtml(ref.locator)}" title="${escapeHtml(ref.locator)}">${escapeHtml(label || `claim ${String(ref.locator).slice(0, 12)}`)}</a>`;
-    } else {
-      hasFile = true;
-      const drift = ref.digest
-        ? `<span class="agenda-ref-drift" data-item="${escapeHtml(item.id)}" data-locator="${escapeHtml(ref.locator)}"></span>`
-        : '';
-      target = `<span title="${escapeHtml(ref.locator)}">${escapeHtml(label || agendaRefFileName(ref.locator))}</span>${drift}`;
-    }
-    const must = ref.must_read
-      ? '<span class="agenda-ref-must" title="Marked must-read by whoever attached it — weigh it before working the item">must-read</span>'
-      : '';
-    const remove = `<button type="button" class="agenda-ref-remove" data-id="${escapeHtml(item.id)}" data-type="${escapeHtml(ref.ref_type)}" data-locator="${escapeHtml(ref.locator)}" aria-label="Remove reference" title="Remove reference (history stays in the log)">×</button>`;
-    return `<span class="agenda-ref ${escapeHtml(ref.ref_type)}${ref.must_read ? ' must' : ''}">
-      <span class="agenda-ref-type">${escapeHtml(ref.ref_type)}</span>${must}${target}${remove}</span>`;
-  });
-  const verify = hasFile
-    ? `<button type="button" class="agenda-btn agenda-refs-verify" data-id="${escapeHtml(item.id)}" title="Re-hash the attached files against their attach-time digests">Verify files</button>`
-    : '';
-  return `<div class="agenda-refs">${rows.join('')}${verify}</div>`;
-}
-
 // On-demand drift check (G1): one fetch per gesture, per item — the
-// expand-time rehash lane. Badges land on the matching rows; a missing
-// file renders as missing, never an error.
+// expand-time rehash lane. Badges land on the matching inspector rows; a
+// missing file renders as missing, never an error.
 async function agendaVerifyRefs(itemId, button) {
   if (button) button.disabled = true;
   try {
@@ -826,7 +508,7 @@ async function agendaVerifyRefs(itemId, button) {
       el.dataset.status = row.status;
       el.textContent = row.status === 'unchanged' ? '✓ unchanged'
         : row.status === 'missing' ? 'missing'
-          : 'changed since attached';
+          : 'changed since attach';
     });
   } catch (err) {
     console.warn('agenda ref drift check failed', err);
@@ -918,6 +600,53 @@ function agendaShortPath(path) {
   }
   const raw = String(path || '');
   return raw.length > 28 ? `…${raw.slice(-27)}` : raw;
+}
+
+// ---- Reminder policy writes (Settings-gated: the owner's delivery
+// policy; an agenda.write grant can't raise its own item's loudness).
+
+function agendaItemUrgency(id) {
+  const overrides = (agendaReminderPolicy && agendaReminderPolicy.item_urgency) || {};
+  return overrides[id] || 'default';
+}
+
+async function agendaSetItemUrgency(id, value, control) {
+  const patch = { item_urgency: { [id]: value === 'default' ? null : value } };
+  await agendaSendPolicyPatch(patch, control);
+}
+
+async function agendaSendPolicyPatch(patch, control) {
+  if (control) control.disabled = true;
+  try {
+    const resp = await daemonApi.request('api_agenda_reminder_policy', patch);
+    if (resp.ok && resp.body && resp.body.reminder_policy) {
+      agendaReminderPolicy = resp.body.reminder_policy;
+      agendaRenderAll();
+      return true;
+    }
+    agendaFlashError((resp.body && resp.body.error) || `policy update failed (${resp.status})`);
+    agendaRenderAll(); // restore the controls to the effective policy
+    return false;
+  } catch (e) {
+    agendaFlashError(String(e && e.message || e));
+    return false;
+  } finally {
+    if (control) control.disabled = false;
+  }
+}
+
+// Whether the owner's quiet-hours window covers this instant (client twin
+// of QuietHours::contains — minutes since local midnight, may cross it).
+function agendaQuietNow() {
+  const quiet = agendaReminderPolicy && agendaReminderPolicy.quiet_hours;
+  if (!quiet) return false;
+  const now = new Date();
+  const minute = now.getHours() * 60 + now.getMinutes();
+  if (quiet.start_min === quiet.end_min) return false;
+  if (quiet.start_min < quiet.end_min) {
+    return minute >= quiet.start_min && minute < quiet.end_min;
+  }
+  return minute >= quiet.start_min || minute < quiet.end_min;
 }
 
 // ---- Start-now confirm sheet ----
@@ -1052,11 +781,14 @@ function agendaStartExecutionSummary(mode) {
 // settings (derive-don't-mirror: models and efforts come from the settings
 // payload where the daemon serves them; the static kimi/claude-alias lists
 // mirror the pinned settings-pane markup). `model`/`effort` are the daemon
-// DEFAULTS the selects inherit when left untouched.
-function agendaStartBackendConfig(settings) {
+// DEFAULTS the selects inherit when left untouched. `backend` may override
+// the daemon default (the sheet's Backend select) — the same
+// AgentLaunchConfig vocabulary CreateSession uses.
+function agendaStartBackendConfig(settings, backendOverride) {
   const d = settings || {};
-  const backend = (typeof normalizeAgentId === 'function')
+  const dflt = (typeof normalizeAgentId === 'function')
     ? normalizeAgentId(d.external_agent) : (d.external_agent || '');
+  const backend = backendOverride === undefined || backendOverride === '' ? dflt : backendOverride;
   if (backend === 'claude-code') {
     return {
       backend,
@@ -1064,9 +796,9 @@ function agendaStartBackendConfig(settings) {
       modelKey: 'claude_model',
       effortKey: 'claude_effort',
       effortLabel: 'Reasoning',
-      model: String(d.claude_model || ''),
+      model: backend === dflt ? String(d.claude_model || '') : '',
       models: ['fable', 'opus', 'sonnet', 'haiku'],
-      effort: String(d.claude_effort || ''),
+      effort: backend === dflt ? String(d.claude_effort || '') : '',
       efforts: Array.isArray(d.claude_efforts) ? d.claude_efforts : [],
     };
   }
@@ -1078,9 +810,9 @@ function agendaStartBackendConfig(settings) {
       modelKey: 'codex_model',
       effortKey: 'codex_reasoning_effort',
       effortLabel: 'Reasoning',
-      model: String(d.codex_model || ''),
+      model: backend === dflt ? String(d.codex_model || '') : '',
       models,
-      effort: String(d.codex_reasoning_effort || ''),
+      effort: backend === dflt ? String(d.codex_reasoning_effort || '') : '',
       efforts: Array.isArray(d.codex_reasoning_efforts) ? d.codex_reasoning_efforts : [],
     };
   }
@@ -1091,11 +823,14 @@ function agendaStartBackendConfig(settings) {
       modelKey: 'kimi_model',
       effortKey: 'kimi_thinking',
       effortLabel: 'Thinking',
-      model: String(d.kimi_model || ''),
+      model: backend === dflt ? String(d.kimi_model || '') : '',
       models: ['kimi-code/kimi-for-coding', 'kimi-code/kimi-for-coding-highspeed', 'kimi-code/k3'],
-      effort: String(d.kimi_thinking || ''),
+      effort: backend === dflt ? String(d.kimi_thinking || '') : '',
       efforts: ['off', 'low', 'medium', 'high', 'xhigh', 'max'],
     };
+  }
+  if (backend === 'internal') {
+    return { backend: 'internal', label: 'Internal agent' };
   }
   return { backend: '', label: 'Internal agent' };
 }
@@ -1205,51 +940,43 @@ function agendaOpenStartSheet(itemId, anchor) {
   // DAEMON defaults (fetched fresh on open), with honest provenance —
   // an untouched select inherits ("daemon default (max)") and sends
   // nothing; an explicit pick is recorded on the manifest and applied.
+  // The Backend select uses the AgentLaunchConfig vocabulary the daemon
+  // documents ("internal", "codex", "claude-code", "kimi"); picking one
+  // explicitly pins the reviewed backend on the manifest. Pi is launchable
+  // as the daemon default but has no model catalog wired here yet.
   const config = agendaStartSheetEl('div', 'ags-config');
   panel.appendChild(config);
-  const configState = { spec: null, modelSel: null, effortSel: null };
+  const configState = { spec: null, backendSel: null, modelSel: null, effortSel: null, backendOverride: '' };
   const renderConfigControls = () => {
     config.textContent = '';
     configState.modelSel = null;
     configState.effortSel = null;
+    configState.backendSel = null;
     if (agendaStartSheetSettings === null) {
       config.appendChild(agendaStartSheetEl('div', 'ags-config-line',
         'Loading the daemon’s launch defaults…'));
       return;
     }
-    const spec = agendaStartBackendConfig(agendaStartSheetSettings);
+    const dfltSpec = agendaStartBackendConfig(agendaStartSheetSettings);
+    const spec = agendaStartBackendConfig(agendaStartSheetSettings, configState.backendOverride);
     configState.spec = spec;
-    const backendLine = agendaStartSheetEl('div', 'ags-config-line',
-      `${spec.label} · daemon default backend`);
-    config.appendChild(backendLine);
-    if (!spec.backend) {
-      config.appendChild(agendaStartSheetEl('div', 'ags-hint',
-        'Model and provider follow the daemon’s native configuration.'));
-      return;
-    }
-    const addSelect = (labelText, id, defaultValue, options) => {
+    const addSelect = (labelText, id, options, selected) => {
       const row = agendaStartSheetEl('div', 'ags-config-row');
       const label = agendaStartSheetEl('label', 'ags-label', labelText);
       label.setAttribute('for', id);
       row.appendChild(label);
       const select = document.createElement('select');
       select.id = id;
-      const inherit = document.createElement('option');
-      inherit.value = '';
-      inherit.textContent = defaultValue
-        ? `Daemon default (${defaultValue})`
-        : 'Daemon default (backend default)';
-      select.appendChild(inherit);
-      const values = [...options];
-      if (defaultValue && !values.includes(defaultValue)) values.push(defaultValue);
-      for (const value of values) {
+      for (const [value, text] of options) {
         const option = document.createElement('option');
         option.value = value;
-        option.textContent = value;
+        option.textContent = text;
+        if (value === selected) option.selected = true;
         select.appendChild(option);
       }
       row.appendChild(select);
-      const hint = agendaStartSheetEl('div', 'ags-hint', 'daemon default');
+      const hint = agendaStartSheetEl('div', 'ags-hint',
+        selected ? 'explicit — recorded on the manifest' : 'daemon default');
       row.appendChild(hint);
       select.addEventListener('change', () => {
         hint.textContent = select.value
@@ -1259,9 +986,35 @@ function agendaOpenStartSheet(itemId, anchor) {
       config.appendChild(row);
       return select;
     };
-    configState.modelSel = addSelect('Model', 'ags-config-model', spec.model, spec.models);
-    configState.effortSel = addSelect(
-      spec.effortLabel, 'ags-config-effort', spec.effort, spec.efforts);
+    const backendOptions = [['', `Daemon default (${dfltSpec.label})`]];
+    for (const [value, text] of [
+      ['internal', 'Internal agent'], ['codex', 'Codex'],
+      ['claude-code', 'Claude Code'], ['kimi', 'Kimi Code'],
+    ]) {
+      backendOptions.push([value, text]);
+    }
+    configState.backendSel = addSelect('Backend', 'ags-config-backend',
+      backendOptions, configState.backendOverride);
+    configState.backendSel.addEventListener('change', () => {
+      configState.backendOverride = configState.backendSel.value;
+      renderConfigControls();
+    });
+    if (!spec.backend || spec.backend === 'internal') {
+      config.appendChild(agendaStartSheetEl('div', 'ags-hint',
+        'Model and provider follow the daemon’s native configuration.'));
+      return;
+    }
+    if (!spec.modelKey) return;
+    const inheritLabel = (dflt) => dflt
+      ? `Daemon default (${dflt})` : 'Daemon default (backend default)';
+    const modelValues = [...spec.models];
+    if (spec.model && !modelValues.includes(spec.model)) modelValues.push(spec.model);
+    configState.modelSel = addSelect('Model', 'ags-config-model',
+      [['', inheritLabel(spec.model)], ...modelValues.map((v) => [v, v])], '');
+    const effortValues = [...spec.efforts];
+    if (spec.effort && !effortValues.includes(spec.effort)) effortValues.push(spec.effort);
+    configState.effortSel = addSelect(spec.effortLabel, 'ags-config-effort',
+      [['', inheritLabel(spec.effort)], ...effortValues.map((v) => [v, v])], '');
   };
   renderConfigControls();
   // Fetch fresh daemon defaults on every open (the settings snapshot ages
@@ -1363,17 +1116,18 @@ async function agendaStartSheetSubmit(item, goal, project, error, startBtn, conf
   // An explicit pick also pins the reviewed backend — the approved config
   // must not silently re-target if the daemon default changes.
   const spec = configState && configState.spec;
-  if (spec && spec.backend) {
-    const agentConfig = {};
+  const agentConfig = {};
+  if (configState && configState.backendOverride) {
+    agentConfig.agent = configState.backendOverride;
+  }
+  if (spec && spec.backend && spec.backend !== 'internal') {
     const model = configState.modelSel ? configState.modelSel.value : '';
     const effort = configState.effortSel ? configState.effortSel.value : '';
     if (model) agentConfig[spec.modelKey] = model;
     if (effort) agentConfig[spec.effortKey] = effort;
-    if (Object.keys(agentConfig).length) {
-      agentConfig.agent = spec.backend;
-      params.agent_config = agentConfig;
-    }
+    if ((model || effort) && !agentConfig.agent) agentConfig.agent = spec.backend;
   }
+  if (Object.keys(agentConfig).length) params.agent_config = agentConfig;
   startBtn.disabled = true;
   try {
     const resp = await daemonApi.request('api_agenda_op', params);
@@ -1395,444 +1149,10 @@ async function agendaStartSheetSubmit(item, goal, project, error, startBtn, conf
   }
 }
 
-function agendaActionButtons(item) {
-  const actions = [];
-  if (item.status === 'open') actions.push(['complete', 'Complete'], ['retire', 'Retire']);
-  else if (item.status === 'done') actions.push(['reopen', 'Reopen'], ['retire', 'Retire']);
-  else actions.push(['reopen', 'Reopen']);
-  let extra = '';
-  if (item.status === 'open') {
-    // Owner start-now: opens the CONFIRM SHEET (bottom sheet on coarse
-    // pointers, popover on desktop) — what will run (goal, project,
-    // config, Interactive/Goal-run) is reviewed there; the daemon mints
-    // + approves the manifest from the confirmed parameters and fires
-    // through the ordinary scheduled lane. The one-click instant fire is
-    // retired on dashboard surfaces (owner ruling, 2026-07-21). Owner
-    // surface = this dashboard; agents get NotPermitted.
-    // NOT on rich parked asks: those await the owner's ANSWER — spawning
-    // a follow-through session on one just re-reads the question at the
-    // owner (live-QA footgun 2026-07-20). Answering is the primary act;
-    // Open question panel is the affordance.
-    const richAsk = item.kind === 'question'
-      && item.ask && Array.isArray(item.ask.questions) && item.ask.questions.length;
-    if (!richAsk) {
-      extra += `<button type="button" class="agenda-btn agenda-start-now" data-id="${escapeHtml(item.id)}" title="Review and start a supervised session from this item">Start now</button>`;
-    }
-    // Follow-up targets the ORIGIN conversation: live window → composer;
-    // ended but resumable → the existing resume path. Never a silent
-    // unrelated new session.
-    const sid = agendaFollowUpSid(item);
-    if (sid) {
-      extra += `<button type="button" class="agenda-btn agenda-follow-up" data-id="${escapeHtml(item.id)}" data-sid="${escapeHtml(sid)}" title="The recording conversation is live — open the composer targeted at it with this item quoted">Follow up</button>`;
-    } else if (agendaFollowUpResumable(item)) {
-      extra += `<button type="button" class="agenda-btn agenda-follow-up-resume" data-id="${escapeHtml(item.id)}" title="The recording conversation has ended — resume it (same conversation, its recorded project) and open the composer with this item quoted">Follow up (resumes session)</button>`;
-    }
-  }
-  const buttons = extra + actions
-    .map(([op, label]) =>
-      `<button type="button" class="agenda-btn" data-op="${op}" data-id="${escapeHtml(item.id)}">${label}</button>`)
-    .join('');
-  // The per-item reminder loudness control (owner policy) — only where a
-  // reminder can still fire.
-  if (item.status !== 'open' || !item.due_ms) return buttons;
-  const level = agendaItemUrgency(item.id);
-  const options = ['default', 'mute', 'info', 'attention', 'urgent']
-    .map((value) => {
-      const label = value === 'default'
-        ? `default (${(agendaReminderPolicy && agendaReminderPolicy.default_urgency) || 'attention'})`
-        : value;
-      return `<option value="${value}"${value === level ? ' selected' : ''}>${label}</option>`;
-    })
-    .join('');
-  return `<select class="agenda-bell" data-id="${escapeHtml(item.id)}" title="Reminder loudness for this item (owner policy)" aria-label="Reminder loudness">${options}</select>${buttons}`;
-}
-
-function agendaItemUrgency(id) {
-  const overrides = (agendaReminderPolicy && agendaReminderPolicy.item_urgency) || {};
-  return overrides[id] || 'default';
-}
-
-async function agendaSetItemUrgency(id, value, control) {
-  const patch = { item_urgency: { [id]: value === 'default' ? null : value } };
-  await agendaSendPolicyPatch(patch, control);
-}
-
-async function agendaSendPolicyPatch(patch, control) {
-  if (control) control.disabled = true;
-  try {
-    const resp = await daemonApi.request('api_agenda_reminder_policy', patch);
-    if (resp.ok && resp.body && resp.body.reminder_policy) {
-      agendaReminderPolicy = resp.body.reminder_policy;
-      agendaRenderAll();
-      return true;
-    }
-    agendaFlashError((resp.body && resp.body.error) || `policy update failed (${resp.status})`);
-    agendaRenderAll(); // restore the control to the effective policy
-    return false;
-  } catch (e) {
-    agendaFlashError(String(e && e.message || e));
-    return false;
-  } finally {
-    if (control) control.disabled = false;
-  }
-}
-
-function agendaRenderReminderBar() {
-  const bar = document.getElementById('agenda-reminders-bar');
-  if (!bar) return;
-  const policy = agendaReminderPolicy;
-  if (!policy) {
-    bar.innerHTML = '';
-    return;
-  }
-  const quiet = policy.quiet_hours;
-  const minToHhmm = (min) =>
-    `${String(Math.floor(min / 60)).padStart(2, '0')}:${String(min % 60).padStart(2, '0')}`;
-  const quietLabel = quiet
-    ? `${minToHhmm(quiet.start_min)}–${minToHhmm(quiet.end_min)}`
-    : 'off';
-  bar.innerHTML = `
-    <span class="agenda-rem-label">Reminders</span>
-    <button type="button" class="agenda-btn" id="agenda-rem-toggle">${policy.enabled ? 'on' : 'off'}</button>
-    <span class="agenda-rem-label">quiet hours</span>
-    <button type="button" class="agenda-btn" id="agenda-rem-quiet" title="Deliveries inside the window wait for its end">${escapeHtml(quietLabel)}</button>
-    <span class="agenda-rem-label">default</span>
-    <select id="agenda-rem-default" aria-label="Default reminder urgency">
-      ${['info', 'attention', 'urgent'].map((value) =>
-        `<option value="${value}"${value === policy.default_urgency ? ' selected' : ''}>${value}</option>`).join('')}
-    </select>`;
-  const toggle = document.getElementById('agenda-rem-toggle');
-  if (toggle) toggle.addEventListener('click', () =>
-    agendaSendPolicyPatch({ enabled: !policy.enabled }, toggle));
-  const dflt = document.getElementById('agenda-rem-default');
-  if (dflt) dflt.addEventListener('change', () =>
-    agendaSendPolicyPatch({ default_urgency: dflt.value }, dflt));
-  const quietBtn = document.getElementById('agenda-rem-quiet');
-  if (quietBtn) quietBtn.addEventListener('click', () => {
-    const current = quiet ? `${minToHhmm(quiet.start_min)}-${minToHhmm(quiet.end_min)}` : '';
-    const raw = prompt('Quiet hours (HH:MM-HH:MM local; may cross midnight; empty = off)', current);
-    if (raw === null) return;
-    const trimmed = raw.trim();
-    if (!trimmed) {
-      agendaSendPolicyPatch({ quiet_hours: null }, quietBtn);
-      return;
-    }
-    const m = trimmed.match(/^(\d{1,2}):(\d{2})\s*-\s*(\d{1,2}):(\d{2})$/);
-    if (!m) {
-      agendaFlashError('quiet hours must look like 22:00-08:00');
-      return;
-    }
-    const start = Number(m[1]) * 60 + Number(m[2]);
-    const end = Number(m[3]) * 60 + Number(m[4]);
-    if (start > 23 * 60 + 59 || end > 23 * 60 + 59) {
-      agendaFlashError('quiet hours must use 00:00–23:59');
-      return;
-    }
-    agendaSendPolicyPatch({ quiet_hours: { start_min: start, end_min: end } }, quietBtn);
-  });
-}
-
 function agendaRenderAll() {
   agendaRenderTab();
   agendaRenderCard();
-  agendaRenderReminderBar();
-}
-
-function agendaRenderTab() {
-  const list = document.getElementById('agenda-tab-list');
-  if (!list) return;
-  const counts = document.getElementById('agenda-tab-counts');
-  if (counts) {
-    counts.textContent =
-      `${agendaCounts.open || 0} open · ${agendaCounts.done || 0} done · ${agendaCounts.retired || 0} retired`;
-  }
-  const note = document.getElementById('agenda-tab-skipped');
-  if (note && !note.textContent) {
-    if (agendaSkippedLines > 0) {
-      note.style.display = '';
-      note.textContent =
-        `${agendaSkippedLines} history line(s) from another build are preserved but not shown.`;
-    } else {
-      note.style.display = 'none';
-    }
-  }
-  if (agendaLoadError) {
-    list.innerHTML = `<div class="ui-empty">${escapeHtml(agendaLoadError)}</div>`;
-    return;
-  }
-  if (agendaItems === null) {
-    list.innerHTML = '<div class="ui-empty">Loading…</div>';
-    return;
-  }
-  // Questions is a KIND view, not a status: the open questions (rich
-  // parked asks lead with their panel button) plus the answered archive.
-  // Retired questions stay reachable under Retired / All.
-  const filtered = agendaItems.filter((item) =>
-    agendaFilter === 'all' ? true
-      : agendaFilter === 'blocked' ? agendaItemIsBlocked(item)
-        : agendaFilter === 'questions'
-          ? item.kind === 'question' && item.status !== 'retired'
-          : item.status === agendaFilter);
-  if (!filtered.length) {
-    list.innerHTML = agendaFilter === 'questions'
-      ? '<div class="ui-empty">No open or answered questions — park one with <code>intendant ctl ask --park</code>.</div>'
-      : `<div class="ui-empty">No ${agendaFilter === 'all' ? '' : `${agendaFilter} `}items — park one above, or run <code>intendant ctl agenda add</code>.</div>`;
-    return;
-  }
-  // Newest first reads best in a review list; ULIDs sort by creation.
-  // The by-hub lens reorders the SAME cards (children nested under
-  // parents) — the flat order stays the default and the guarantee.
-  const ordered = agendaAttentionOrderOn
-    ? agendaAttentionOrder(filtered)
-    : agendaGroupByHub
-    ? agendaGroupedOrder(filtered)
-    : filtered
-        .slice()
-        .sort((a, b) => (a.id < b.id ? 1 : -1))
-        .map((item) => ({ item, depth: 0 }));
-  const rows = ordered.map(({ item, depth }) => {
-    const tags = (item.tags || [])
-      .map((tag) => `<span class="agenda-chip">#${escapeHtml(tag)}</span>`)
-      .join('');
-    const body = item.body
-      ? `<div class="agenda-item-body">${escapeHtml(item.body)}</div>`
-      : '';
-    // The ask-seam reply affordance: open questions take a durable reply
-    // right here; answered ones show it (data, rendered escaped). Rich
-    // (ask-backed) questions lead with the panel — options and previews
-    // live there; the inline input stays as an explicit plain-text path,
-    // never the only door. Done rich asks keep a "View question" door to
-    // the same panel rendered read-only — the record stays fully viewable.
-    let answerBlock = '';
-    const openRichAsk = item.kind === 'question' && item.status === 'open'
-      && item.ask && Array.isArray(item.ask.questions) && item.ask.questions.length;
-    const doneRichAsk = item.kind === 'question' && item.status === 'done'
-      && item.ask && Array.isArray(item.ask.questions) && item.ask.questions.length;
-    if (item.kind === 'question' && item.status === 'open') {
-      const richAsk = openRichAsk;
-      const openBtn = richAsk
-        ? `<div class="agenda-answer-row agenda-ask-open-row">
-            <button type="button" class="agenda-btn agenda-open-ask-btn" data-id="${escapeHtml(item.id)}">Open question panel</button>
-            <span class="agenda-ask-hint">${item.ask.questions.length > 1
-    ? `${item.ask.questions.length} structured questions`
-    : 'structured question'} with options${item.ask.questions.some((q) => (q.previews || []).length) ? ' + previews' : ''}</span>
-          </div>`
-        : '';
-      answerBlock = `${openBtn}<div class="agenda-answer-row">
-        <input type="text" class="agenda-answer-input" maxlength="4000"
-               placeholder="${richAsk ? 'Or type a plain-text answer…' : 'Answer this question…'}" aria-label="Answer" data-id="${escapeHtml(item.id)}" />
-        <button type="button" class="agenda-btn agenda-answer-btn" data-id="${escapeHtml(item.id)}">Answer</button>
-      </div>`;
-    } else if (item.answer && (item.answer.text || item.answer.structured)) {
-      // Answered: the archive keeps the full structured breakdown for
-      // rich asks, the joined text otherwise (agendaAnswerBlock).
-      answerBlock = agendaAnswerBlock(item);
-    }
-    if (doneRichAsk) {
-      answerBlock = `<div class="agenda-answer-row agenda-ask-open-row">
-          <button type="button" class="agenda-btn agenda-view-ask-btn" data-id="${escapeHtml(item.id)}">View question</button>
-          <span class="agenda-ask-hint">the full question as asked${item.ask.questions.some((q) => (q.previews || []).length) ? ' — previews included' : ''}, with the recorded answer</span>
-        </div>${answerBlock}`;
-    }
-    const blockedChip = agendaItemIsBlocked(item)
-      ? '<span class="agenda-chip blocked">blocked</span>'
-      : '';
-    // Dismissed-but-open questions wear a quiet marker: the rails were
-    // cleared deliberately and stay cleared (no auto re-announce); the
-    // item itself remains open and answerable right here.
-    const dismissedChip = item.status === 'open' && item.dismissed
-      ? `<span class="agenda-chip dismissed" title="${escapeHtml(agendaDismissedTip(item.dismissed))}">dismissed · still open</span>`
-      : '';
-    // Answered ask whose delivery reached no session (the daemon recorded
-    // `answer.delivered: false`): a quiet marker that the reply sits here
-    // unheard — the next session's agenda check is the pickup path.
-    // Pre-marker history (no `delivered` field) claims nothing.
-    const pickupChip = item.status === 'done' && item.ask && item.answer
-      && item.answer.delivered === false
-      ? '<span class="agenda-chip pickup" title="The answer was recorded, but the asking session was gone and no successor was live. The next session’s agenda check picks it up.">answered · awaiting pickup</span>'
-      : '';
-    // Rich asks: the whole head is the affordance — clicking the question
-    // opens its panel (live for open items, the read-only record for done
-    // ones; the explicit button below remains for discoverability).
-    // role/tabindex make it a real control for keyboard and assistive tech.
-    const headOpenAttrs = openRichAsk || doneRichAsk
-      ? ` agenda-item-head-openable" data-open-ask="${escapeHtml(item.id)}" role="button" tabindex="0" title="${openRichAsk ? 'Open the question panel' : 'View the answered question'}`
-      : '';
-    const indent = depth > 0 ? ` agenda-item-nested` : '';
-    const indentStyle = depth > 0 ? ` style="--agenda-nest-depth:${depth}"` : '';
-    return `<div class="agenda-item${indent}" data-status="${escapeHtml(item.status)}" data-item-id="${escapeHtml(item.id)}"${indentStyle}>
-      <div class="agenda-item-head${headOpenAttrs}">
-        ${agendaGlyph(item.status, item.kind)}
-        <span class="agenda-item-kind">${escapeHtml(item.kind)}</span>
-        <span class="agenda-item-title">${escapeHtml(item.title)}</span>
-        ${blockedChip}${dismissedChip}${pickupChip}${agendaDueChip(item)}${agendaHubChip(item)}${agendaPlacementChip(item)}${agendaRefsChip(item)}${tags}
-      </div>
-      ${body}${answerBlock}${agendaRefsBlock(item)}${agendaRelationsBlock(item)}${agendaThreadBlock(item)}${agendaEffectBlock(item)}
-      <div class="agenda-item-foot">
-        <span class="agenda-item-meta">${agendaProvenanceLine(item)}</span>
-        <span class="agenda-item-actions">${agendaActionButtons(item)}</span>
-      </div>
-    </div>`;
-  });
-  list.innerHTML = rows.join('');
-  list.querySelectorAll('a.agenda-session-link').forEach((link) => {
-    link.addEventListener('click', (e) => {
-      e.preventDefault();
-      agendaJumpToSession(link.dataset.sessionKey);
-    });
-  });
-  list.querySelectorAll('.agenda-open-ask-btn').forEach((btn) => {
-    btn.addEventListener('click', () => agendaOpenParkedAsk(btn.dataset.id));
-  });
-  list.querySelectorAll('.agenda-view-ask-btn').forEach((btn) => {
-    btn.addEventListener('click', () => agendaViewAnsweredAsk(btn.dataset.id));
-  });
-  list.querySelectorAll('.agenda-item-head-openable').forEach((head) => {
-    const open = (e) => {
-      // Chips/links inside the head keep their own behavior.
-      if (e.target.closest('button, a, input, select')) return;
-      e.preventDefault();
-      agendaOpenAskPanel(head.dataset.openAsk);
-    };
-    head.addEventListener('click', open);
-    head.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter' || e.key === ' ') open(e);
-    });
-  });
-  list.querySelectorAll('button[data-op]').forEach((btn) => {
-    btn.addEventListener('click', () => {
-      const params = { op: btn.dataset.op, id: btn.dataset.id };
-      // Approve binds the digest of the revision this render showed.
-      if (btn.dataset.digest) params.digest = btn.dataset.digest;
-      agendaSendOp(params, btn);
-    });
-  });
-  list.querySelectorAll('select.agenda-bell').forEach((sel) => {
-    sel.addEventListener('change', () =>
-      agendaSetItemUrgency(sel.dataset.id, sel.value, sel));
-  });
-  // F3 act-on-item wiring: Start now opens the confirm sheet (never an
-  // instant fire); follow-up routes to the origin conversation.
-  list.querySelectorAll('button.agenda-start-now').forEach((btn) => {
-    btn.addEventListener('click', () => agendaOpenStartSheet(btn.dataset.id, btn));
-  });
-  // G3-pre: Run now fires one extra occurrence of the APPROVED standing
-  // manifest (bare start_now — the daemon routes it to request_occurrence;
-  // the manifest shown in this block is exactly what runs, so no sheet).
-  list.querySelectorAll('button.agenda-run-now').forEach((btn) => {
-    btn.addEventListener('click', () =>
-      agendaSendOp({ op: 'start_now', id: btn.dataset.id }, btn));
-  });
-  list.querySelectorAll('button.agenda-follow-up').forEach((btn) => {
-    btn.addEventListener('click', () => {
-      const item = agendaFindItem(btn.dataset.id);
-      if (item) agendaFollowUpWithRecorder(item, btn.dataset.sid);
-    });
-  });
-  list.querySelectorAll('button.agenda-follow-up-resume').forEach((btn) => {
-    btn.addEventListener('click', () => {
-      const item = agendaFindItem(btn.dataset.id);
-      if (item) agendaFollowUpResume(item);
-    });
-  });
-  // F2 thread + gates wiring.
-  list.querySelectorAll('button.agenda-thread-more').forEach((btn) => {
-    btn.addEventListener('click', () => {
-      agendaExpandedThreads.add(btn.dataset.id);
-      agendaRenderTab();
-    });
-  });
-  list.querySelectorAll('button.agenda-clear-blocker').forEach((btn) => {
-    btn.addEventListener('click', () =>
-      agendaSendOp({ op: 'clear_blocker', id: btn.dataset.id, blocker_id: btn.dataset.blocker }, btn));
-  });
-  list.querySelectorAll('button.agenda-edge-remove').forEach((btn) => {
-    btn.addEventListener('click', () =>
-      agendaSendOp({ op: 'remove_relies_on', id: btn.dataset.id, target_id: btn.dataset.target }, btn));
-  });
-  // G2 graph wiring: item jumps, un-place, relation removal.
-  list.querySelectorAll('a.agenda-item-jump').forEach((link) => {
-    link.addEventListener('click', (e) => {
-      e.preventDefault();
-      agendaJumpToItem(link.dataset.jump);
-    });
-  });
-  list.querySelectorAll('button.agenda-place-remove').forEach((btn) => {
-    btn.addEventListener('click', () =>
-      agendaSendOp({
-        op: 'remove_part_of', id: btn.dataset.id, parent_id: btn.dataset.parent,
-      }, btn));
-  });
-  list.querySelectorAll('button.agenda-relation-remove').forEach((btn) => {
-    btn.addEventListener('click', () =>
-      agendaSendOp({
-        op: 'remove_relates_to', id: btn.dataset.id, target_id: btn.dataset.target,
-      }, btn));
-  });
-  // G1 refs wiring: remove, on-demand drift verify, Memory claim jumps.
-  list.querySelectorAll('button.agenda-ref-remove').forEach((btn) => {
-    btn.addEventListener('click', () =>
-      agendaSendOp({
-        op: 'remove_ref', id: btn.dataset.id,
-        ref_type: btn.dataset.type, locator: btn.dataset.locator,
-      }, btn));
-  });
-  list.querySelectorAll('button.agenda-refs-verify').forEach((btn) => {
-    btn.addEventListener('click', () => agendaVerifyRefs(btn.dataset.id, btn));
-  });
-  list.querySelectorAll('a.agenda-ref-claim').forEach((link) => {
-    link.addEventListener('click', (e) => {
-      e.preventDefault();
-      routeTo('memory');
-      if (typeof memoryGotoClaim === 'function') memoryGotoClaim(link.dataset.claim);
-    });
-  });
-  const submitThread = async (id, input, op, control) => {
-    const text = (input.value || '').trim();
-    if (!text) return;
-    input.disabled = true;
-    const params = op === 'set_blocker'
-      ? { op, id, criterion: text }
-      : { op, id, text };
-    const ok = await agendaSendOp(params, control);
-    input.disabled = false;
-    if (!ok) input.focus();
-  };
-  list.querySelectorAll('button.agenda-thread-note').forEach((btn) => {
-    const input = list.querySelector(`input.agenda-thread-input[data-id="${btn.dataset.id}"]`);
-    if (!input) return;
-    btn.addEventListener('click', () => submitThread(btn.dataset.id, input, 'annotate', btn));
-    input.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter') {
-        e.preventDefault();
-        submitThread(btn.dataset.id, input, 'annotate', btn);
-      }
-    });
-  });
-  list.querySelectorAll('button.agenda-thread-block').forEach((btn) => {
-    const input = list.querySelector(`input.agenda-thread-input[data-id="${btn.dataset.id}"]`);
-    if (!input) return;
-    btn.addEventListener('click', () => submitThread(btn.dataset.id, input, 'set_blocker', btn));
-  });
-  const submitAnswer = async (id, input, control) => {
-    const text = (input.value || '').trim();
-    if (!text) return;
-    input.disabled = true;
-    const ok = await agendaSendOp({ op: 'answer', id, text }, control);
-    input.disabled = false;
-    if (!ok) input.focus();
-  };
-  list.querySelectorAll('button.agenda-answer-btn').forEach((btn) => {
-    const input = list.querySelector(`input.agenda-answer-input[data-id="${btn.dataset.id}"]`);
-    if (!input) return;
-    btn.addEventListener('click', () => submitAnswer(btn.dataset.id, input, btn));
-    input.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter') {
-        e.preventDefault();
-        submitAnswer(btn.dataset.id, input, btn);
-      }
-    });
-  });
+  agendaInspectorRender();
 }
 
 // ---- Compact card on the activity pane (stacked under the vitals rail).
@@ -1943,73 +1263,14 @@ function agendaPositionCard() {
 
 {
   const wire = () => {
-    const filters = document.getElementById('agenda-filters');
-    if (filters) {
-      filters.querySelectorAll('.agenda-filter').forEach((btn) => {
-        btn.addEventListener('click', () => {
-          agendaFilter = btn.dataset.filter || 'open';
-          filters.querySelectorAll('.agenda-filter').forEach((b) =>
-            b.classList.toggle('active', b === btn));
-          agendaRenderTab();
-        });
-      });
-      const group = document.getElementById('agenda-group-toggle');
-      const attention = document.getElementById('agenda-attention-toggle');
-      const syncLenses = () => {
-        if (group) {
-          group.classList.toggle('active', agendaGroupByHub);
-          group.setAttribute('aria-pressed', agendaGroupByHub ? 'true' : 'false');
-        }
-        if (attention) {
-          attention.classList.toggle('active', agendaAttentionOrderOn);
-          attention.setAttribute('aria-pressed', agendaAttentionOrderOn ? 'true' : 'false');
-        }
-        agendaRenderTab();
-      };
-      if (group) {
-        group.addEventListener('click', () => {
-          agendaGroupByHub = !agendaGroupByHub;
-          if (agendaGroupByHub) agendaAttentionOrderOn = false;
-          syncLenses();
-        });
-      }
-      if (attention) {
-        attention.addEventListener('click', () => {
-          agendaAttentionOrderOn = !agendaAttentionOrderOn;
-          if (agendaAttentionOrderOn) agendaGroupByHub = false;
-          syncLenses();
-        });
-      }
-    }
-    const addBtn = document.getElementById('agenda-add-btn');
-    const addTitle = document.getElementById('agenda-add-title');
-    const addKind = document.getElementById('agenda-add-kind');
-    const submitAdd = async () => {
-      const title = (addTitle && addTitle.value || '').trim();
-      if (!title) return;
-      const picked = (addKind && addKind.value) || 'task';
-      const kind = ['task', 'note', 'question'].includes(picked) ? picked : 'task';
-      const ok = await agendaSendOp({ op: 'add', kind, title }, addBtn);
-      if (ok && addTitle) {
-        addTitle.value = '';
-        addTitle.focus();
-      }
-    };
-    if (addBtn) addBtn.addEventListener('click', submitAdd);
-    if (addTitle) {
-      addTitle.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter') {
-          e.preventDefault();
-          submitAdd();
-        }
-      });
-    }
+    agendaEnsureScaffold();
     agendaBuildCard();
     agendaRefresh();
-    // Follow-up affordance liveness: the button is derived at render time
-    // from session-window state the agenda has no event lane for, so a
-    // visible tab re-renders when (and only when) the eligibility
-    // signature changes — the target-switch poll idiom, write-guarded.
+    // Follow-up affordance liveness: the inspector's follow-up action is
+    // derived at render time from session-window state the agenda has no
+    // event lane for, so a visible tab re-renders when (and only when) the
+    // eligibility signature changes — the target-switch poll idiom,
+    // write-guarded.
     let followUpSig = '';
     setInterval(() => {
       if (!agendaTabVisible() || !Array.isArray(agendaItems)) return;
@@ -2020,6 +1281,7 @@ function agendaPositionCard() {
       if (sig !== followUpSig) {
         followUpSig = sig;
         agendaRenderTab();
+        agendaInspectorRender();
       }
     }, 2000);
     // Pane-gated: the card lives in #activity-log-pane, so with the

--- a/static/app/ui2-agenda.js
+++ b/static/app/ui2-agenda.js
@@ -217,8 +217,14 @@ function agendaTabVisible() {
 }
 
 function agendaOnTabShown() {
-  if (agendaItems === null) agendaRefresh();
-  else agendaRenderAll();
+  if (agendaItems === null) {
+    // Build the scaffold immediately (replacing the legacy static markup
+    // with the Loading state) — the fetch fills it in when it lands.
+    agendaRenderTab();
+    agendaRefresh();
+  } else {
+    agendaRenderAll();
+  }
 }
 
 async function agendaSendOp(params, button) {
@@ -1005,8 +1011,8 @@ function agendaOpenStartSheet(itemId, anchor) {
       return;
     }
     if (!spec.modelKey) return;
-    const inheritLabel = (dflt) => dflt
-      ? `Daemon default (${dflt})` : 'Daemon default (backend default)';
+    const inheritLabel = (defaultValue) => defaultValue
+      ? `Daemon default (${defaultValue})` : 'Daemon default (backend default)';
     const modelValues = [...spec.models];
     if (spec.model && !modelValues.includes(spec.model)) modelValues.push(spec.model);
     configState.modelSel = addSelect('Model', 'ags-config-model',


### PR DESCRIPTION
Slice A of the Agenda dashboard redesign: the designer's Agenda screen translated into the fragment conventions (ui2 classes + tokens, escaped-data rendering, event-lane refresh), against the existing daemon API only.

## What changed

**Lens restructure** (`ui2-agenda-cards.js`, new) — the filter row becomes lens tabs: **Needs you** (default; Answer / Approve / Suspended / Overdue / Attend groups, deduped in that order), **Open** (the flat newest-first lens), **By hub** (hubs = non-retired items with children, per-hub roll-up hints derived at render, plus a Not-filed group), **Questions** (open + answered), **Archive** (done + retired). Filter chips `blocked · N` and `frontier`, ledger search (`/` focuses it, `n` focuses the composer, `Esc` closes overlays inspector-last). The lens registry is an explicit seam — the graph and Upcoming lenses of later slices are new entries, nothing else.

**Cards** — status control glyph, chip row (done/retired/due/overdue/blocked/dismissed-still-open/answered-awaiting-pickup/running/needs-approval/suspended/standing·every-N/armed/hub roll-up/done-over-open-children/triage #N/N must-read), kind label, attribution with Sessions-tab jump links and visibly self-described `--source` labels, relative time, hub membership link, tags, a blocked line, an inline effect strip (pending: Approve + Review; suspended: Re-arm + Review; running: Watch), and inline question answering — option pills honoring the real pick bounds, sandboxed preview thumbnails, note/answer input, Answer + Later (Later rides the rail's skip verb, so the dismissal is the daemon's own record).

**Inspector** (`ui2-agenda-inspector.js` + `.css`, new) — side panel ≥1180px (animated width), overlay + backdrop below. Header (kind/status chips, copyable id prefix, click-to-edit title via `patch`, context line, action row: Start a session / Follow up / Mark done / Close unanswered / Retire / Reopen), Question section (per-question pills, preview grid with expand-to-sheet and pick, per-pick anchored note, structured resolved view, dismissed-still-open chip, and a door to the existing rail panel/record viewer), Details (body view/edit via `patch`), Scheduled session (state card pending/armed/standing/suspended/running/finished with when/ends/shape/project/config/on-failure rows, goal quote, last run + View session, actions per state: Approve this exact plan / Edit schedule / Revoke / Run now via `request_occurrence` / Re-approve to re-arm / Schedule one…), Reminder (due presets via `patch.due_ms`, per-item loudness via the policy route), Blocked on (blockers + Clear, relies_on with derived satisfied/open/retired-review/missing chips, add affordances gated to open items as the daemon requires), Organization (Filed under with descendant exclusion — `add_part_of`/`remove_part_of`/atomic `place`; undirected see-also chips; tags via `patch.tags`), References (typed rows, must-read badge, on-demand drift via `api_agenda_ref_drift`, add pointer with type inference, remove), Thread (attributed annotation rail, cap 3 + show-all, add note).

**Sheets + popover** — schedule sheet (`propose_effect` with first-run/repeats/ends/max-runs/suspend-after/orchestrate; Approve immediately sends `approve_effect` bound to the digest the propose response minted; voids-approval warning when revising an approved manifest), full-size preview sheet with view tabs and Pick, and the reminder-policy bell popover (enabled toggle, default loudness, quiet hours with time inputs, staleness digest hours — the existing Settings-gated route and write shapes).

**Data layer** (`ui2-agenda.js`) — fetch/cache/event-lane/ops unchanged in shape; new render-side derivations (effect state, blocked line, triage rank, descendants, quiet-now). The compact `#ui2-agenda-card` activity twin is untouched and keeps rendering from the shared cache. The start-now confirm sheet keeps its flow and gains a Backend select over the settings-served catalogs (an explicit pick pins `agent_config.agent`; untouched selects still inherit).

**Shared preview security seam** (`41-session-window-actions.js`) — every agent-authored preview render (question rail + agenda) now goes through ONE sandboxed-iframe factory and ONE srcdoc writer, so the pinned single-writer invariant (`question_preview_iframe_sandbox_is_pinned`) covers both consumers; fetched blob documents cache by URL.

**Daemon-side pin updated** (`agenda/types.rs`) — `awaiting_pickup_chip_condition_is_pinned_in_app_html` now points at the new chip emitter (the condition markers are unchanged and the new code adopts the pinned condition verbatim).

The tab scaffold is built by the agenda fragments inside the existing `#tab-agenda` container; the shell fragment is untouched (its static block is replaced at boot — the deep-link path builds the scaffold immediately).

## Deliberate divergences from the design

- No per-tab theme toggle (foundation `ui2SetTheme` owns theming) and no per-tab command palette (the global palette owns the chord; palette integration is a later slice).
- The old `all` filter is dropped deliberately: Open ∪ Archive covers every status.
- **Attend** is our addition to "Needs you": items carrying a triage annotation, ordered by the declared `rank N` convention (`/rank (\d+)/`, commented as a bridge until a typed rank ships), each with a `triage #N` chip — preserves the existing G3 attention-lens semantics.
- Graph (constellation) and Upcoming lenses, the "Under the hood" section, the raw-JSON sheet, and palette integration are later slices; the lens registry and section layout leave the seams, and no dead buttons ship.
- The footer ledger line reports the real payload only (counts + preserved-unfolded skipped lines); the design's "ops folded" count has no wire source today, so it is omitted rather than invented.
- The Questions lens's Answered group is `done` only; retired questions live in Archive → Retired (the design mixed retired into Answered).
- Later (dismiss) appears only on ask-backed questions — plain questions have no rail card to clear; the dismissal lane is the resolver's.

## Preservation honored

- `#ui2-agenda-card` compact twin untouched (markup, CSS, behavior).
- Rail announce of parked asks, the ask panel door, and the read-only answered-record viewer all kept (now reached from the inspector).
- Follow-up routing (live composer target / resume the origin conversation), the start-now confirm sheet semantics (owner ruling 2026-07-21), approve-binds-rendered-digest, G3 triage attention semantics, blob sandbox posture, and the deep-link TDZ rule (both new fragments sit before the router in the manifest).

## Battery

- `node --check` on every edited/added JS fragment: pass.
- `cargo run -p app-html-assembler` + committed regen: pass (95 fragments).
- `cargo test -p intendant --bins`: **4824 + 148 + 97 passed, 0 failed** (includes the app.html parity gate and the three agenda/preview pins).
- `cargo fmt --check`: pass.
- `cargo clippy --workspace -- -D warnings`: pass (run because one .rs test marker changed).
- Visual acceptance on a scratch mock-provider daemon (state root isolated via `INTENDANT_HOME`, items seeded through `ctl agenda` — park/ask/block/place/relies-on/triage annotations/ref/schedule/approve/complete/retire): every lens, the inspector, the schedule sheet, and the bell popover render to spec with zero page errors, and the write paths were exercised through the real UI — the inline card composer answered the open question (`answer` recorded, Answered group + toast confirmed) and the card strip's Approve armed the pending manifest digest-bound (chip flipped to `armed`, Needs-you badge and ledger counts repainted live off the event lane). Screenshots (untracked, worktree `tmp-artifacts/`): 01-needs-you, 02-open, 03-by-hub, 04-questions, 05-archive, 06-inspector, 07-schedule-sheet, 08-bell-popover, 09-after-answer-approve, 10-questions-answered.
