### PR TITLE
feat(agenda): serve the occurrence journal — GET /api/agenda/occurrences with since/item/limit cursor

### DIFF
--- a/docs/src/agenda-and-memory.md
+++ b/docs/src/agenda-and-memory.md
@@ -53,6 +53,16 @@ restarts; the v1 contract is not a guarantee against sudden power loss. The
 delivery-critical occurrence journal has a stronger rule: it is synced before
 a notification or session launch is attempted.
 
+The occurrence journal is served the same way, read-only, at
+`GET /api/agenda/occurrences` (`agenda.read`; tunnel twin
+`api_agenda_occurrences`): the per-occurrence delivery and dispatch record
+(`prepared`, `delivered`, `suppressed`, `missed`, `started`, `completed`,
+`failed`, `unknown`), where downtime-skipped instants show up honestly as
+journal silence. The journal is append-only — nothing compacts or rewrites
+it — so the same `since` line cursor, `item_id` filter, and `limit` paging
+apply, with the same honesty rules: records a newer build wrote are served
+verbatim with `known: false`, non-JSON lines as `unparseable: true`.
+
 ### Items and transitions
 
 An item is a `note`, `task`, or `question`. Its lifecycle is derived from the
@@ -637,6 +647,7 @@ routes:
 |---|---|---|
 | `GET /api/agenda` | `agenda.read` | Items, status counts, skipped-line count, and the session-resolution join map |
 | `GET /api/agenda/ops` | `agenda.read` | Raw op-log page: `since` line cursor, `item` filter, unfoldable lines served verbatim |
+| `GET /api/agenda/occurrences` | `agenda.read` | Raw occurrence-journal page: same cursor and verbatim-honesty rules |
 | `POST /api/agenda/op` | `agenda.write` | Apply one validated Agenda command |
 | `POST /api/agenda/reminders/policy` | `settings.manage` | Change owner reminder policy |
 

--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -1885,6 +1885,7 @@ response omits the header.
 | POST | `/api/session/current/rollback` | SessionManage | own origin | bounded | Roll the current session back to a round (optionally reverting files) |
 | GET | `/api/agenda` | AgendaRead | own origin | none | Agenda ledger snapshot: items (oldest first) plus status counts |
 | GET | `/api/agenda/ops` | AgendaRead | own origin | none | Raw agenda op-log page (since/item/limit cursor; unknown ops served verbatim) |
+| GET | `/api/agenda/occurrences` | AgendaRead | own origin | none | Raw occurrence-journal page (since/item/limit cursor; unknown records served verbatim) |
 | POST | `/api/agenda/op` | AgendaWrite | own origin | ≤ 16 MiB | Apply one agenda command (add, ask, answer, patch, transitions, or scheduled-session propose/approve/revoke) |
 | GET | `/api/agenda/blobs/{item_id}/{blob_id}/raw` | AgendaRead | own origin | none | Fetch one parked-ask preview blob's raw bytes (attachment; MIME sniffing disabled) |
 | GET | `/api/agenda/items/{item_id}/refs/drift` | AgendaRead | own origin | none | Re-hash one item's file refs against their attach digests (expand-time drift check) |

--- a/src/bin/caller/agenda/handle.rs
+++ b/src/bin/caller/agenda/handle.rs
@@ -559,6 +559,26 @@ impl AgendaHandle {
         }
     }
 
+    /// Run `f` with the handle's journal reader (lazily opened, its own
+    /// mutex — never nested with the store lock). `None` when the
+    /// journal cannot be opened; callers degrade honestly.
+    fn with_journal<T>(&self, f: impl FnOnce(&mut OccurrenceJournal) -> T) -> Option<T> {
+        let mut guard = match self.decoration_journal.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if guard.is_none() {
+            match OccurrenceJournal::open(&self.dir) {
+                Ok(journal) => *guard = Some(journal),
+                Err(err) => {
+                    eprintln!("[agenda] opening occurrence journal failed: {err}");
+                    return None;
+                }
+            }
+        }
+        guard.as_mut().map(f)
+    }
+
     /// Stamp the display-only planner derivations
     /// (`effects[].next_fire_ms`, `deferred_until`) onto freshly folded
     /// item clones, with the clock of this read — the serving seam for
@@ -569,36 +589,43 @@ impl AgendaHandle {
     /// undecorated items (absence claims nothing). Never called under
     /// the store lock — the journal reader has its own.
     fn decorate_items(&self, items: &mut [AgendaItem]) {
-        let mut guard = match self.decoration_journal.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => poisoned.into_inner(),
-        };
-        if guard.is_none() {
-            match OccurrenceJournal::open(&self.dir) {
-                Ok(journal) => *guard = Some(journal),
-                Err(err) => {
-                    eprintln!("[agenda] opening journal for decoration failed: {err}");
-                    return;
-                }
+        let policy = self.reminder_policy();
+        let now_ms = now_ms();
+        self.with_journal(|journal| {
+            if let Err(err) = journal.refresh_if_stale() {
+                eprintln!("[agenda] journal refresh for decoration failed: {err}");
             }
-        }
-        let Some(journal) = guard.as_mut() else {
-            return;
-        };
-        if let Err(err) = journal.refresh_if_stale() {
-            eprintln!("[agenda] journal refresh for decoration failed: {err}");
-        }
-        super::reminders::decorate_planner_fields(
-            items,
-            journal,
-            &self.reminder_policy(),
-            now_ms(),
-            &super::scheduler::local_minute_of_day_at,
-        );
+            super::reminders::decorate_planner_fields(
+                items,
+                journal,
+                &policy,
+                now_ms,
+                &super::scheduler::local_minute_of_day_at,
+            );
+        });
     }
 
     fn decorate_item(&self, item: &mut AgendaItem) {
         self.decorate_items(std::slice::from_mut(item));
+    }
+
+    /// One page of the raw occurrence journal (read-only; the
+    /// `GET /api/agenda/occurrences` surface). Runs under the handle's
+    /// journal mutex — see [`OccurrenceJournal::read_page`] for the
+    /// cursor contract and why a page never splits a concurrent
+    /// scheduler append.
+    pub(crate) fn read_occurrences(
+        &self,
+        since: u64,
+        item: Option<&str>,
+        limit: usize,
+    ) -> std::io::Result<super::reminders::AgendaOccurrencesPage> {
+        self.with_journal(|journal| journal.read_page(since, item, limit))
+            .unwrap_or_else(|| {
+                Err(std::io::Error::other(
+                    "occurrence journal unavailable on this daemon",
+                ))
+            })
     }
 }
 
@@ -1821,5 +1848,73 @@ mod tests {
         let store = AgendaStore::open(dir.path()).unwrap();
         let raw = store.snapshot();
         assert_eq!(raw[0].effects[0].next_fire_ms, None);
+    }
+
+    /// The occurrence-journal read surface converges on scheduler writes:
+    /// records appended through a SEPARATE writer instance (the
+    /// production topology) are served by the handle's reader with exact
+    /// cursor math and the item filter, and a foreign non-JSON line is
+    /// surfaced as `unparseable` rather than hidden.
+    #[test]
+    fn read_occurrences_serves_scheduler_writes() {
+        use std::io::Write as _;
+        let dir = tempfile::tempdir().unwrap();
+        let bus = EventBus::new();
+        let handle = AgendaHandle::new(AgendaStore::open(dir.path()).unwrap(), bus, dir.path());
+        // Prime the handle's reader first, so convergence-on-growth is
+        // what this test exercises (not first-open).
+        let page = handle.read_occurrences(0, None, 500).unwrap();
+        assert_eq!(page.log_len, 0);
+
+        let mut writer = super::super::reminders::OccurrenceJournal::open(dir.path()).unwrap();
+        for (round, item) in [(0u64, "01ITEMA"), (1, "01ITEMB"), (2, "01ITEMA")] {
+            writer
+                .append(&super::super::reminders::OccurrenceRecord {
+                    v: 1,
+                    at_ms: round + 1,
+                    occurrence_id: format!("occ-{round}"),
+                    item_id: item.into(),
+                    due_ms: round,
+                    state: super::super::reminders::OccurrenceState::Delivered,
+                    urgency: None,
+                    session_id: None,
+                })
+                .unwrap();
+        }
+
+        let page = handle.read_occurrences(0, None, 500).unwrap();
+        assert_eq!(page.log_len, 3);
+        assert_eq!(page.next_since, 3);
+        assert_eq!(page.occurrences.len(), 3);
+        assert!(page
+            .occurrences
+            .iter()
+            .all(|e| e["known"] == serde_json::Value::Bool(true)));
+
+        let page = handle.read_occurrences(0, Some("01ITEMA"), 500).unwrap();
+        assert!(page.filtered);
+        let seqs: Vec<u64> = page
+            .occurrences
+            .iter()
+            .map(|e| e["seq"].as_u64().unwrap())
+            .collect();
+        assert_eq!(seqs, vec![0, 2]);
+
+        // A foreign non-JSON line (hand edit, torn tail) is served as
+        // unparseable history, never dropped.
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(dir.path().join("occurrences.jsonl"))
+            .unwrap()
+            .write_all(b"garbage tail\n")
+            .unwrap();
+        let page = handle.read_occurrences(3, None, 500).unwrap();
+        assert_eq!(page.log_len, 4);
+        assert_eq!(page.occurrences.len(), 1);
+        assert_eq!(
+            page.occurrences[0]["unparseable"],
+            serde_json::Value::Bool(true)
+        );
+        assert_eq!(page.occurrences[0]["raw"], "garbage tail");
     }
 }

--- a/src/bin/caller/agenda/mod.rs
+++ b/src/bin/caller/agenda/mod.rs
@@ -41,7 +41,9 @@ mod types;
 pub(crate) use ask::{agenda_ask_pending, ask_outcome_delivery_text, spawn_ask_resolver};
 pub(crate) use blobs::find_blob;
 pub(crate) use handle::AgendaHandle;
-pub(crate) use reminders::ReminderPolicyPatch;
+pub(crate) use reminders::{
+    AgendaOccurrencesPage, ReminderPolicyPatch, AGENDA_OCCURRENCES_DEFAULT_LIMIT,
+};
 pub(crate) use scheduler::spawn_reminder_scheduler;
 pub(crate) use spawn_project::{recorded_session_project_root, SessionSpawnContext};
 pub(crate) use store::{

--- a/src/bin/caller/agenda/reminders.rs
+++ b/src/bin/caller/agenda/reminders.rs
@@ -437,6 +437,131 @@ impl OccurrenceJournal {
         }
         Ok(())
     }
+
+    /// One page of the raw journal (read-only; `GET /api/agenda/occurrences`).
+    ///
+    /// `since` is a 0-based line cursor into `occurrences.jsonl`. The
+    /// journal is append-only — nothing in the daemon compacts, truncates,
+    /// or rewrites it (the writers are [`Self::append`]'s single
+    /// whole-line `write_all` and the torn-tail `\n` terminators in
+    /// [`Self::open`]/[`Self::refresh_if_stale`], which never add a line)
+    /// — so a line index is a stable sequence number, and external
+    /// tampering that shrinks the file surfaces as `log_len` dropping
+    /// below the cursor.
+    ///
+    /// The fold's skip-don't-brick rule extends to reads: a line
+    /// [`fold_journal`] cannot fold (a newer build's record shape) is
+    /// still served VERBATIM with `known:false` — this build never hides
+    /// delivery history it cannot parse; a line that is not JSON at all
+    /// is served as `{"seq":N,"known":false,"unparseable":true,"raw":…}`.
+    /// `item` filters on the raw line's `item_id` field (unknown shapes
+    /// included); lines without one are excluded under the filter.
+    /// Whitespace-only lines keep their seq slot but are never served.
+    ///
+    /// Torn reads: the in-process writer (the scheduler's own journal
+    /// instance) appends each record as ONE `write_all` of a complete
+    /// line on an `O_APPEND` handle, so a concurrent read observes whole
+    /// lines — the exact guarantee [`Self::refresh_if_stale`]'s own fold
+    /// (and the co-homed-daemons convergence it exists for) already
+    /// rests on; a crash-torn tail is permanently torn and served as
+    /// `unparseable` history. The caller's lock (`AgendaHandle`'s
+    /// journal mutex) additionally serializes this read against our own
+    /// terminator writes.
+    pub(crate) fn read_page(
+        &mut self,
+        since: u64,
+        item: Option<&str>,
+        limit: usize,
+    ) -> std::io::Result<AgendaOccurrencesPage> {
+        // Converge first (terminates a foreign torn tail), like every
+        // other read through this instance.
+        self.refresh_if_stale()?;
+        let limit = limit.clamp(1, AGENDA_OCCURRENCES_MAX_LIMIT);
+        let bytes = match std::fs::read(&self.path) {
+            Ok(bytes) => bytes,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+            Err(err) => return Err(err),
+        };
+        let text = String::from_utf8_lossy(&bytes);
+        let mut occurrences: Vec<serde_json::Value> = Vec::new();
+        let mut log_len = 0u64;
+        // The first seq the scan did not consume; log_len unless the
+        // page filled mid-log.
+        let mut next_since: Option<u64> = None;
+        for (index, raw_line) in text.lines().enumerate() {
+            let seq = index as u64;
+            log_len = seq + 1;
+            if next_since.is_some() || seq < since {
+                continue;
+            }
+            let line = raw_line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            let entry = match serde_json::from_str::<serde_json::Value>(line) {
+                Ok(value) => {
+                    if let Some(want) = item {
+                        let referenced = value.get("item_id").and_then(serde_json::Value::as_str);
+                        if referenced != Some(want) {
+                            continue;
+                        }
+                    }
+                    // Known = this build's fold parses it — exactly the
+                    // predicate `fold_journal` folds with.
+                    let known = serde_json::from_str::<OccurrenceRecord>(line).is_ok();
+                    serde_json::json!({ "seq": seq, "known": known, "record": value })
+                }
+                Err(_) => {
+                    if item.is_some() {
+                        continue; // no item_id — excluded under the filter
+                    }
+                    serde_json::json!({
+                        "seq": seq,
+                        "known": false,
+                        "unparseable": true,
+                        "raw": line,
+                    })
+                }
+            };
+            occurrences.push(entry);
+            if occurrences.len() >= limit {
+                next_since = Some(seq + 1);
+            }
+        }
+        Ok(AgendaOccurrencesPage {
+            occurrences,
+            next_since: next_since.unwrap_or(log_len),
+            log_len,
+            filtered: item.is_some(),
+        })
+    }
+}
+
+/// Default page size for [`OccurrenceJournal::read_page`] when the caller
+/// names none; the clamp ceiling is [`AGENDA_OCCURRENCES_MAX_LIMIT`].
+pub(crate) const AGENDA_OCCURRENCES_DEFAULT_LIMIT: usize = 500;
+/// Hard page-size ceiling for [`OccurrenceJournal::read_page`].
+pub(crate) const AGENDA_OCCURRENCES_MAX_LIMIT: usize = 2000;
+
+/// One page of the raw occurrence journal, as
+/// `GET /api/agenda/occurrences` serves it. Serializes to exactly the
+/// response body:
+/// `{"occurrences":[…],"next_since":…,"log_len":…,"filtered":…}`.
+#[derive(Debug, serde::Serialize)]
+pub(crate) struct AgendaOccurrencesPage {
+    /// Served entries, in journal order. Each is
+    /// `{"seq":N,"known":bool,"record":<the line's JSON, verbatim>}`, or
+    /// `{"seq":N,"known":false,"unparseable":true,"raw":"<line>"}` for a
+    /// line that is not JSON at all.
+    pub(crate) occurrences: Vec<serde_json::Value>,
+    /// Resume cursor: the first seq this scan did not consume — last
+    /// returned seq + 1 when the page filled, otherwise `log_len`.
+    pub(crate) next_since: u64,
+    /// Total lines in the journal right now. A value below a client's
+    /// cursor means the append-only contract was broken externally.
+    pub(crate) log_len: u64,
+    /// True when an `item` filter was applied to this page.
+    pub(crate) filtered: bool,
 }
 
 fn fold_record_into(entry: &mut OccurrenceProgress, record: &OccurrenceRecord) {
@@ -2099,5 +2224,226 @@ mod tests {
         decorate_planner_fields(&mut done, &journal, &policy, now, &at_23);
         assert_eq!(done[0].deferred_until, None);
         assert_eq!(done[0].effects[0].next_fire_ms, None);
+    }
+
+    // ---- The occurrence-journal read page (GET /api/agenda/occurrences) ----
+
+    /// Seed a journal through the REAL append path with the writer's own
+    /// record shapes: one reminder delivery (prepared → delivered, as
+    /// `deliver_one` writes) for item A and one scheduled-session run
+    /// (prepared → started → completed, as `dispatch_session` + the
+    /// write-back write) for item B — five lines, seqs 0..=4. Then three
+    /// foreign lines appended directly, as a newer build or hand edit
+    /// would: an unknown-shape record still carrying A's `item_id` (5),
+    /// an item-less unknown record (6), and a non-JSON line (7).
+    fn seeded_occurrences(dir: &Path) -> OccurrenceJournal {
+        let mut journal = OccurrenceJournal::open(dir).unwrap();
+        for (state, urgency) in [
+            (OccurrenceState::Prepared, None),
+            (OccurrenceState::Delivered, Some(ReminderUrgency::Attention)),
+        ] {
+            journal
+                .append(&OccurrenceRecord {
+                    v: 1,
+                    at_ms: 1_000,
+                    occurrence_id: "occ-reminder-a".into(),
+                    item_id: "01ITEMA".into(),
+                    due_ms: 900,
+                    state,
+                    urgency,
+                    session_id: None,
+                })
+                .unwrap();
+        }
+        for (state, session) in [
+            (OccurrenceState::Prepared, None),
+            (OccurrenceState::Started, Some("sess-run-1".to_string())),
+            (OccurrenceState::Completed, Some("sess-run-1".to_string())),
+        ] {
+            journal
+                .append(&OccurrenceRecord {
+                    v: 1,
+                    at_ms: 2_000,
+                    occurrence_id: "occ-session-b".into(),
+                    item_id: "01ITEMB".into(),
+                    due_ms: 1_900,
+                    state,
+                    urgency: None,
+                    session_id: session,
+                })
+                .unwrap();
+        }
+        let foreign = "{\"v\":1,\"at_ms\":3000,\"occurrence_id\":\"occ-future\",\"item_id\":\"01ITEMA\",\"due_ms\":2900,\"state\":\"rescheduled\"}\n\
+             {\"v\":2,\"kind\":\"journal_note\"}\n\
+             this line is not JSON at all\n";
+        let mut file = std::fs::File::options()
+            .append(true)
+            .open(&journal.path)
+            .unwrap();
+        file.write_all(foreign.as_bytes()).unwrap();
+        journal
+    }
+
+    fn page_seqs(page: &AgendaOccurrencesPage) -> Vec<u64> {
+        page.occurrences
+            .iter()
+            .map(|e| e["seq"].as_u64().unwrap())
+            .collect()
+    }
+
+    /// Full-page service and window math: real-writer lines round-trip as
+    /// `known` records, a newer build's record is served verbatim with
+    /// `known:false`, a non-JSON line as `unparseable` — and
+    /// since/limit/next_since/log_len behave exactly like the op-log
+    /// cursor.
+    #[test]
+    fn occurrences_page_windows_and_serves_verbatim() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut journal = seeded_occurrences(dir.path());
+
+        let page = journal.read_page(0, None, 500).unwrap();
+        assert_eq!(page.log_len, 8);
+        assert_eq!(page.next_since, 8);
+        assert!(!page.filtered);
+        assert_eq!(page_seqs(&page), (0..8).collect::<Vec<u64>>());
+        // The five real-writer lines: known, and each round-trips through
+        // the typed record — nothing partial, nothing reshaped.
+        for entry in &page.occurrences[..5] {
+            assert_eq!(entry["known"], serde_json::Value::Bool(true));
+            let record: OccurrenceRecord = serde_json::from_value(entry["record"].clone()).unwrap();
+            assert!(record.at_ms > 0);
+        }
+        assert_eq!(page.occurrences[1]["record"]["state"], "delivered");
+        assert_eq!(page.occurrences[4]["record"]["state"], "completed");
+        assert_eq!(page.occurrences[4]["record"]["session_id"], "sess-run-1");
+        // A newer build's vocabulary: served verbatim, marked unknown.
+        assert_eq!(page.occurrences[5]["known"], serde_json::Value::Bool(false));
+        assert_eq!(page.occurrences[5]["record"]["state"], "rescheduled");
+        assert_eq!(page.occurrences[5]["record"]["item_id"], "01ITEMA");
+        assert_eq!(page.occurrences[6]["known"], serde_json::Value::Bool(false));
+        assert_eq!(page.occurrences[6]["record"]["kind"], "journal_note");
+        // Non-JSON: unparseable, raw preserved string-escaped.
+        assert_eq!(
+            page.occurrences[7]["unparseable"],
+            serde_json::Value::Bool(true)
+        );
+        assert_eq!(page.occurrences[7]["raw"], "this line is not JSON at all");
+
+        // Window math: a mid-log page fills and resumes exactly.
+        let page = journal.read_page(2, None, 3).unwrap();
+        assert_eq!(page_seqs(&page), vec![2, 3, 4]);
+        assert_eq!(page.next_since, 5);
+        assert_eq!(page.log_len, 8);
+        let page = journal.read_page(page.next_since, None, 500).unwrap();
+        assert_eq!(page_seqs(&page), vec![5, 6, 7]);
+        assert_eq!(page.next_since, 8);
+        // At (or past) the tail: empty page still pointing at the tail.
+        let page = journal.read_page(8, None, 500).unwrap();
+        assert!(page.occurrences.is_empty());
+        assert_eq!(page.next_since, 8);
+        let page = journal.read_page(100, None, 500).unwrap();
+        assert!(page.occurrences.is_empty());
+        assert_eq!(page.next_since, 8);
+        // The limit clamp floor: 0 is not "unbounded" and not "nothing".
+        let page = journal.read_page(0, None, 0).unwrap();
+        assert_eq!(page.occurrences.len(), 1);
+        assert_eq!(page.next_since, 1);
+    }
+
+    /// The `item` filter serves exactly the lines whose `item_id` is the
+    /// requested item — unknown-shape records included — and excludes
+    /// item-less and unparseable lines; a truncated filtered page resumes
+    /// without re-serving.
+    #[test]
+    fn occurrences_item_filter_includes_only_that_items_records() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut journal = seeded_occurrences(dir.path());
+
+        let page = journal.read_page(0, Some("01ITEMA"), 500).unwrap();
+        assert!(page.filtered);
+        assert_eq!(page.log_len, 8);
+        assert_eq!(page.next_since, 8);
+        // A's reminder pair (0, 1) and the unknown-shape record on A (5);
+        // never B's lines, the item-less record (6), or non-JSON (7).
+        assert_eq!(page_seqs(&page), vec![0, 1, 5]);
+        for entry in &page.occurrences {
+            assert_eq!(entry["record"]["item_id"], "01ITEMA");
+        }
+        assert_eq!(page.occurrences[2]["known"], serde_json::Value::Bool(false));
+
+        let page = journal.read_page(0, Some("01ITEMB"), 500).unwrap();
+        assert_eq!(page_seqs(&page), vec![2, 3, 4]);
+
+        // Truncated filtered page: resume serves the rest exactly once.
+        let page = journal.read_page(0, Some("01ITEMA"), 2).unwrap();
+        assert_eq!(page_seqs(&page), vec![0, 1]);
+        assert_eq!(page.next_since, 2);
+        let page = journal
+            .read_page(page.next_since, Some("01ITEMA"), 500)
+            .unwrap();
+        assert_eq!(page_seqs(&page), vec![5]);
+        assert_eq!(page.next_since, 8);
+
+        // An id nothing references filters to an empty (honest) page.
+        let page = journal.read_page(0, Some("01NOSUCH"), 500).unwrap();
+        assert!(page.occurrences.is_empty());
+        assert!(page.filtered);
+        assert_eq!(page.next_since, 8);
+    }
+
+    /// The production topology's torn-read canary: the scheduler writes
+    /// through its OWN journal instance while a reader instance pages —
+    /// every served entry is a complete record (whole-line `O_APPEND`
+    /// visibility), never an `unparseable` artifact of an in-flight
+    /// append.
+    #[test]
+    fn occurrences_reads_never_split_writer_appends() {
+        let dir = tempfile::tempdir().unwrap();
+        const APPENDS: u64 = 40;
+        let writer = {
+            let dir = dir.path().to_path_buf();
+            std::thread::spawn(move || {
+                let mut journal = OccurrenceJournal::open(&dir).unwrap();
+                for round in 0..APPENDS {
+                    journal
+                        .append(&OccurrenceRecord {
+                            v: 1,
+                            at_ms: round + 1,
+                            occurrence_id: format!("occ-{round}"),
+                            item_id: "01ITEMC".into(),
+                            due_ms: round,
+                            state: OccurrenceState::Delivered,
+                            urgency: Some(ReminderUrgency::Info),
+                            // Padding so a torn line would be visible.
+                            session_id: Some("x".repeat(200)),
+                        })
+                        .unwrap();
+                }
+            })
+        };
+        let mut reader = OccurrenceJournal::open(dir.path()).unwrap();
+        let assert_complete = |page: &AgendaOccurrencesPage| {
+            for entry in &page.occurrences {
+                assert_eq!(
+                    entry["known"],
+                    serde_json::Value::Bool(true),
+                    "a concurrent read must never surface a torn line: {entry}"
+                );
+                assert!(
+                    serde_json::from_value::<OccurrenceRecord>(entry["record"].clone()).is_ok(),
+                    "served line must be a complete record: {entry}"
+                );
+            }
+        };
+        while !writer.is_finished() {
+            let page = reader.read_page(0, None, 2000).unwrap();
+            assert_complete(&page);
+        }
+        writer.join().unwrap();
+        let page = reader.read_page(0, None, 2000).unwrap();
+        assert_complete(&page);
+        assert_eq!(page.log_len, APPENDS);
+        assert_eq!(page.occurrences.len(), APPENDS as usize);
+        assert_eq!(page.next_since, page.log_len);
     }
 }

--- a/src/bin/caller/dashboard_control/api_sessions.rs
+++ b/src/bin/caller/dashboard_control/api_sessions.rs
@@ -249,6 +249,9 @@ pub(crate) async fn control_request_frame(
         }
         "api_agenda_list" => api_agenda_list_response(id, &runtime).await,
         "api_agenda_ops" => api_agenda_ops_response(id, params.as_ref(), &runtime).await,
+        "api_agenda_occurrences" => {
+            api_agenda_occurrences_response(id, params.as_ref(), &runtime).await
+        }
         "api_agenda_op" => api_agenda_op_response(id, params.as_ref(), &runtime).await,
         "api_agenda_ref_drift" => {
             api_agenda_ref_drift_response(id, params.as_ref(), &runtime).await
@@ -1330,6 +1333,39 @@ pub(crate) async fn api_agenda_ops_response(
         )
         .await,
         "agenda ops",
+    )
+}
+
+/// Tunnel twin of `GET /api/agenda/occurrences` — `{since, item, limit}`
+/// ride `params` (all optional, same semantics as the query string);
+/// reuses the transport-neutral core.
+pub(crate) async fn api_agenda_occurrences_response(
+    id: String,
+    params: Option<&serde_json::Value>,
+    runtime: &ControlRuntime,
+) -> serde_json::Value {
+    let since = params
+        .and_then(|p| p.get("since"))
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    let item = params
+        .and_then(|p| p.get("item"))
+        .and_then(serde_json::Value::as_str)
+        .filter(|v| !v.is_empty())
+        .map(str::to_string);
+    let limit = params
+        .and_then(|p| p.get("limit"))
+        .and_then(serde_json::Value::as_u64);
+    frame_api_response(
+        id,
+        crate::web_gateway::agenda_occurrences_api_response(
+            since,
+            item.as_deref(),
+            limit,
+            runtime.mcp_server.as_ref(),
+        )
+        .await,
+        "agenda occurrences",
     )
 }
 

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -5837,6 +5837,7 @@ mod tests {
             ("api_session_current_rollback", Row, Some(Op::SessionManage)),
             ("api_agenda_list", Row, Some(Op::AgendaRead)),
             ("api_agenda_ops", Row, Some(Op::AgendaRead)),
+            ("api_agenda_occurrences", Row, Some(Op::AgendaRead)),
             ("api_agenda_op", Row, Some(Op::AgendaWrite)),
             ("api_agenda_ref_drift", Row, Some(Op::AgendaRead)),
             ("api_agenda_reminder_policy", Row, Some(Op::Settings)),

--- a/src/bin/caller/gateway_routes.rs
+++ b/src/bin/caller/gateway_routes.rs
@@ -368,6 +368,9 @@ pub(crate) enum RouteHandlerId {
     AgendaList,
     /// Raw op-log page (since/item/limit cursor; unknown ops verbatim).
     AgendaOps,
+    /// Raw occurrence-journal page (delivery/dispatch history; same
+    /// cursor semantics as the op log).
+    AgendaOccurrences,
     /// Apply one agenda command (add/ask/answer/patch/transitions/effects).
     AgendaOp,
     /// Raw bytes of one parked-ask preview blob (agenda blob store).
@@ -925,6 +928,20 @@ pub(crate) static ROUTES: &[Route] = &[
         "Raw agenda op-log page (since/item/limit cursor; unknown ops served verbatim)",
     )
     .with_tunnel(tunnel_method("api_agenda_ops")),
+    // The occurrence journal behind the scheduler, read-only: per-item
+    // delivery/dispatch history (prepared/delivered/suppressed/missed/
+    // started/completed/failed/unknown), with journal silence for
+    // downtime-skipped instants honestly visible. Same cursor and
+    // unknown-lines-verbatim posture as the op-log route.
+    op_route(
+        RouteMethod::Get,
+        PathPattern::Exact("/api/agenda/occurrences"),
+        PeerOperation::AgendaRead,
+        BodyPolicy::None,
+        RouteHandlerId::AgendaOccurrences,
+        "Raw occurrence-journal page (since/item/limit cursor; unknown records served verbatim)",
+    )
+    .with_tunnel(tunnel_method("api_agenda_occurrences")),
     // Capped above Default: the rich-ask park command (`op:"ask"`)
     // legitimately carries the ≤8 MB preview budget as base64 JSON.
     op_route(

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -1196,6 +1196,16 @@ pub(crate) async fn serve_http_request(
                 )
                 .await;
             }
+            RouteHandlerId::AgendaOccurrences => {
+                return handle_agenda_occurrences(
+                    stream,
+                    request_line,
+                    mcp_server,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
+            }
             RouteHandlerId::AgendaOp => {
                 // The authenticated edge: the pre-dispatch IAM gate bound
                 // this principal; no token names a session on this lane.

--- a/src/bin/caller/web_gateway/routes_agenda.rs
+++ b/src/bin/caller/web_gateway/routes_agenda.rs
@@ -1,5 +1,6 @@
 //! The agenda's HTTP surface: `GET /api/agenda` (ledger snapshot),
-//! `GET /api/agenda/ops` (raw op-log page), and `POST /api/agenda/op`
+//! `GET /api/agenda/ops` (raw op-log page), `GET /api/agenda/occurrences`
+//! (raw occurrence-journal page), and `POST /api/agenda/op`
 //! (apply one command), plus the transport-neutral cores their
 //! dashboard-control tunnel twins reuse. The IAM gate (`agenda.read` /
 //! `agenda.write`) runs pre-dispatch off the route rows; mutations
@@ -232,6 +233,54 @@ pub(crate) async fn handle_agenda_ops(
     let limit = query_param(request_line, "limit").and_then(|v| v.parse().ok());
     let response =
         agenda_ops_api_response(since, item.as_deref(), limit, mcp_server.as_ref()).await;
+    write_api_response(stream, response, cors, fleet_origin).await;
+}
+
+/// Transport-neutral core of `GET /api/agenda/occurrences` (tunnel twin
+/// `api_agenda_occurrences`): one page of the raw occurrence journal —
+/// the delivery/dispatch truth behind reminders and scheduled sessions.
+/// Same cursor semantics as the op-log route; records this build cannot
+/// fold are served verbatim with `known:false` — never hidden (see
+/// [`crate::agenda::AgendaHandle::read_occurrences`]).
+pub(crate) async fn agenda_occurrences_api_response(
+    since: u64,
+    item: Option<&str>,
+    limit: Option<u64>,
+    mcp_server: Option<&Arc<crate::mcp::IntendantServer>>,
+) -> ApiResponse {
+    let Some(agenda) = agenda_handle(mcp_server).await else {
+        return ApiResponse::json_error(503, "agenda unavailable on this daemon");
+    };
+    let limit = limit
+        .map(|v| usize::try_from(v).unwrap_or(usize::MAX))
+        .unwrap_or(crate::agenda::AGENDA_OCCURRENCES_DEFAULT_LIMIT);
+    let page: crate::agenda::AgendaOccurrencesPage =
+        match agenda.read_occurrences(since, item, limit) {
+            Ok(page) => page,
+            Err(err) => {
+                return ApiResponse::json_error(500, format!("reading occurrence journal: {err}"));
+            }
+        };
+    match serde_json::to_value(&page) {
+        Ok(value) => ApiResponse::json(200, JsonBody::Value(value)),
+        Err(err) => ApiResponse::json_error(500, format!("encoding occurrence page: {err}")),
+    }
+}
+
+pub(crate) async fn handle_agenda_occurrences(
+    stream: DemuxStream,
+    request_line: &str,
+    mcp_server: Option<Arc<crate::mcp::IntendantServer>>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
+) {
+    let since = query_param(request_line, "since")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    let item = query_param(request_line, "item").filter(|v| !v.is_empty());
+    let limit = query_param(request_line, "limit").and_then(|v| v.parse().ok());
+    let response =
+        agenda_occurrences_api_response(since, item.as_deref(), limit, mcp_server.as_ref()).await;
     write_api_response(stream, response, cors, fleet_origin).await;
 }
 


### PR DESCRIPTION
Daemon slice 3 (final) of the Agenda redesign program: read-only paging over the occurrence journal (`agenda/occurrences.jsonl` — the delivery/dispatch truth behind reminders and scheduled sessions), so the dashboard can render per-occurrence delivery history and honest journal silence for downtime-skipped instants. Mirrors the `/api/agenda/ops` design wholesale.

## Append-only finding (verified before writing code)

The journal is append-only: its only writers are `OccurrenceJournal::append` (one whole-line `write_all` per record on an `O_APPEND` handle, fsync'd for `prepared`, flushed for terminals) and the torn-tail `\n` terminators in `open`/`refresh_if_stale` (which never add a line — terminating an unterminated tail changes no line count). Every call site was audited (scheduler: `run_pass`, `deliver_one`, `deliver_digest`, `dispatch_session`, `resolve_spawnless`, `resolve_lost_sessions`; the handle's decoration reader: open/refresh only). Nothing compacts, truncates, rewrites, or prunes the file — the `rename` in reminders.rs belongs to the policy file's atomic tmp-swap, not the journal. So a 0-based line cursor is stable, with the same external-shrink signal the ops endpoint documents: `log_len` dropping below a client's cursor means the contract was broken outside the daemon.

## Endpoint

`GET /api/agenda/occurrences?since=<u64>&item=<id>&limit=<u32>` (all optional) — `agenda.read`, own-origin CORS, `BodyPolicy::None`; tunnel twin `api_agenda_occurrences` (params `{since?, item?, limit?}`), IAM derived from the row.

Response:

```json
{
  "occurrences": [
    {"seq": 0, "known": true,  "record": {"v":1, "at_ms": …, "occurrence_id": "…", "item_id": "01…", "due_ms": …, "state": "delivered", …}},
    {"seq": 5, "known": false, "record": {"v":1, …, "state": "rescheduled"}},
    {"seq": 7, "known": false, "unparseable": true, "raw": "<the line, string-escaped>"}
  ],
  "next_since": 8,
  "log_len": 8,
  "filtered": false
}
```

- `seq` = 0-based physical line index; `next_since` = resume cursor (last served seq + 1 when the page filled, else `log_len`); `limit` default 500, clamped [1, 2000] in the journal.
- `known` = the line parses as this build's `OccurrenceRecord` — exactly the predicate `fold_journal` folds with, so "known" and "what this build's scheduler state sees" can never disagree. Unknown shapes (a newer build's state vocabulary) are served **verbatim** with `known:false`; non-JSON lines as `unparseable` — never hidden.
- `item=` filters on the raw line's `item_id` field (the field `OccurrenceRecord` carries — plain serde name, no rename), unknown shapes included when they carry it; lines without one are excluded under the filter.

## Read path / locking

`AgendaHandle::read_occurrences` runs under the handle's journal mutex (the decoration reader's, refactored into a shared `with_journal` acquisition). Why a page never splits a line, stated in the doc-comment: the in-process writer is the scheduler's **separate** journal instance, and each append is ONE `write_all` of a complete line on an `O_APPEND` handle — the same whole-line-visibility guarantee the journal's own cross-instance `refresh_if_stale` convergence (co-homed daemons) already rests on; the mutex additionally serializes the read against our own terminator writes; a crash-torn tail is permanently torn and served as `unparseable` history. `refresh_if_stale` runs first, like every other read through the instance.

## Table/docs plumbing

Route row + `RouteHandlerId::AgendaOccurrences` arm (never the dispatch chain); tunnel twin on the row; `tunnel_method_partition_is_pinned` updated; generated endpoint table regenerated (docs pin green); `agenda-and-memory.md` storage paragraph + surfaces-table row. The SPA `DAEMON_API_HTTP_MAP` descriptor entry rides the UI slice, as with ops.

## Tests (hermetic)

- `agenda::reminders::tests::occurrences_page_windows_and_serves_verbatim` — fixture seeded through the REAL writer (`OccurrenceJournal::append`, the exact fn `deliver_one`/`dispatch_session` call, with their record shapes: prepared→delivered reminder, prepared→started→completed session run), plus foreign lines appended directly; asserts known-record round-trips, verbatim unknowns, unparseable, and the full since/limit/next_since/log_len math incl. the clamp floor.
- `agenda::reminders::tests::occurrences_item_filter_includes_only_that_items_records` — filter includes unknown-shape records carrying the item's `item_id`, excludes item-less/unparseable; truncated filtered pages resume exactly.
- `agenda::reminders::tests::occurrences_reads_never_split_writer_appends` — the production topology's torn-read canary: a writer thread appending through its own journal instance while a reader instance pages; every entry must be a complete record.
- `agenda::handle::tests::read_occurrences_serves_scheduler_writes` — the handle's reader converges on a separate writer instance's appends (growth after first open), cursor + filter through the handle, and a foreign non-JSON tail served as `unparseable`.
- Existing pins updated/passing: partition pin, `endpoint_docs_match_chapter`, `daemon_api_http_map_mirrors_gateway_routes`, table invariants.

## Battery (local, on the final tree)

- `cargo fmt --check` — clean
- `cargo clippy --workspace -- -D warnings` — clean
- `cargo test -p intendant --bins` — caller `4836 passed; 0 failed; 10 ignored`, connect `148 passed`, runtime `97 passed`

## Program status / follow-ups

This closes the daemon side of the Agenda redesign program (ops endpoint #574, planner fields #576, occurrences endpoint here). Named follow-up: `ctl` and MCP read surfaces for the ops + occurrences pages (the UI slice consumes the HTTP/tunnel lanes directly).
