### PR TITLE
feat(dashboard): agenda Upcoming lens — the 14-day plan timeline (redesign slice C)

### DIFF
--- a/static/app/manifest.txt
+++ b/static/app/manifest.txt
@@ -87,18 +87,19 @@ ui2-activity.js
 46-recording-replay.js
 47-annotation-clips.js
 # Agenda must evaluate BEFORE the router (48): a #agenda deep link makes the
-# router's eval-time boot call agendaOnTabShown(), which reads these four
+# router's eval-time boot call agendaOnTabShown(), which reads these five
 # fragments' module-level lets/consts — they must be initialized by then
 # (deep-link TDZ rule). Their top levels declare only lets/consts/functions;
 # daemonApi (32), routeTo (48), escapeHtml (52) are reached from inside
-# functions at runtime. Order within the quartet: data layer, then the card
-# surface, then the inspector, then the graph lens (each consumes earlier
-# state; the cards' lens registry reaches the graph's hoisted functions at
-# runtime only).
+# functions at runtime. Order within the quintet: data layer, then the card
+# surface, then the inspector, then the lens surfaces (graph, plan) — each
+# consumes earlier state; the cards' lens registry reaches the lens
+# fragments' hoisted functions at runtime only.
 ui2-agenda.js
 ui2-agenda-cards.js
 ui2-agenda-inspector.js
 ui2-agenda-graph.js
+ui2-agenda-plan.js
 # Memory: same deep-link TDZ rule as agenda — a #memory deep link makes the
 # router's eval-time boot call memoryOnTabShown(), which reads this fragment's
 # module-level lets. Top level declares only lets/functions.

--- a/static/app/ui2-agenda-cards.js
+++ b/static/app/ui2-agenda-cards.js
@@ -10,13 +10,14 @@
 // renders only inside sandboxed srcdoc iframes (agendaHydratePreviewFrames).
 
 // ---- Lens registry ----
-// The extensible seam for later slices: a lens is {id, label} plus either
-// groups() (the shared card-list surface) or render(host) (a custom
-// surface that owns #ag2-groups entirely — the graph lens's canvas,
-// slice B in ui2-agenda-graph.js), with an optional deactivate() the
-// render pass calls on every lens that is NOT about to paint (the graph
-// lens stops its rAF loop there). The plan (Upcoming horizon) lens lands
-// as a follow-up slice by ADDING an entry here — nothing else changes.
+// The extensible seam: a lens is {id, label} plus either groups() (the
+// shared card-list surface) or render(host) (a custom surface that owns
+// #ag2-groups entirely — the graph lens's canvas in ui2-agenda-graph.js,
+// the Upcoming timeline in ui2-agenda-plan.js), with an optional
+// deactivate() the render pass calls on every lens that is NOT about to
+// paint (the graph lens stops its rAF loop there; the plan lens its
+// refresh timer). Later lenses land by ADDING entries here — nothing
+// else changes.
 const AGENDA_LENSES = [
   { id: 'now', label: 'Needs you', groups: () => agendaLensGroupsNow() },
   { id: 'open', label: 'Open', groups: () => agendaLensGroupsOpen() },
@@ -26,6 +27,12 @@ const AGENDA_LENSES = [
     label: 'Graph',
     render: (host) => agendaGraphRenderLens(host),
     deactivate: () => agendaGraphTeardown(),
+  },
+  {
+    id: 'plan',
+    label: 'Upcoming',
+    render: (host) => agendaPlanRenderLens(host),
+    deactivate: () => agendaPlanTeardown(),
   },
   { id: 'questions', label: 'Questions', groups: () => agendaLensGroupsQuestions() },
   { id: 'archive', label: 'Archive', groups: () => agendaLensGroupsArchive() },
@@ -1094,6 +1101,14 @@ function agendaGroupsKeydown(e) {
     if (card && e.target === card) {
       e.preventDefault();
       agendaOpenInspector(card.dataset.itemId);
+      return;
+    }
+    // Focusable non-card openers (the Upcoming lens's timeline rows):
+    // Enter mirrors their click-delegation open.
+    const opener = e.target.closest('[data-open-item]');
+    if (opener && e.target === opener) {
+      e.preventDefault();
+      agendaOpenInspector(opener.dataset.openItem);
     }
   }
 }

--- a/static/app/ui2-agenda-plan.js
+++ b/static/app/ui2-agenda-plan.js
@@ -1,0 +1,322 @@
+// Agenda tab Upcoming lens (redesign slice C): a 14-day day-grouped
+// timeline of what will actually happen — reminder deliveries and
+// scheduled-session fires. Registered in AGENDA_LENSES
+// (ui2-agenda-cards.js) between "Graph" and "Questions" as a
+// custom-surface lens: render() owns #ag2-groups, deactivate() stops the
+// refresh timer. Data and derivations come from ui2-agenda.js
+// (agendaItems, agendaEffectState, agendaReminderPolicy); rows carry
+// data-open-item, so the cards fragment's existing #ag2-groups click
+// delegation opens the slice-A inspector with no listeners of our own.
+//
+// Instants are SERVED, never recomputed (the whole point of PR #576's
+// display fields): `effects[].next_fire_ms` is the planner's next real
+// fire instant (absent when nothing will fire — unapproved, suspended,
+// spent, exhausted) and item-level `deferred_until` is the planner's
+// quiet-hours deferral instant (absent when nothing defers). The only
+// client arithmetic is presentation: projecting up to two further
+// standing instants by pure period addition anchored on the served
+// instant, and a wall-clock quiet-window chip on fire rows — both
+// annotated at their sites.
+//
+// Item-authored text (titles) renders through escapeHtml; every other
+// string here is static vocabulary, a number, or a daemon-minted digest
+// prefix (escaped anyway). No pulsing dots under prefers-reduced-motion:
+// the dots pulse via the shared ui2-pulse keyframes, which the global
+// reduced-motion rule in 16-styles-v2-tokens.css already collapses.
+//
+// Lifecycle: static DOM (no rAF), but relative correctness drifts — a
+// 60s re-render keeps Today/now rows honest. The timer is armed only
+// while this lens is the active surface and the document is visible:
+// deactivate() (the render pass's sweep) and visibilitychange → hidden
+// tear it down, and a tick that finds the agenda tab hidden disarms
+// itself (at most one no-op tick after a tab switch; the render path
+// re-arms on re-entry). No background timers persist.
+
+const AGENDA_PLAN_DAY_MS = 24 * 60 * 60 * 1000;
+const AGENDA_PLAN_HORIZON_DAYS = 14;
+// The served instant plus at most this many projected future instants
+// per standing series.
+const AGENDA_PLAN_STANDING_INSTANTS = 3;
+
+let agendaPlanTimer = null;
+
+// ---- Lens surface (the AGENDA_LENSES render/deactivate pair) ----
+
+function agendaPlanRenderLens(host) {
+  const days = agendaPlanDays();
+  const foot = '<div class="ag2-plan-foot">Fire instants come from the daemon’s planner (served on the item DTO); day grouping and cadence projection rendered at view time — quiet hours defer reminders, never approved sessions.</div>';
+  if (!days.length) {
+    host.innerHTML = `<div class="ag2-plan">
+      <div class="ag2-empty">
+        <div class="ag2-empty-glyph">◍</div>
+        <div class="ag2-empty-title">Nothing on the horizon</div>
+        <div class="ag2-empty-hint">No armed fires and no future reminders in the next ${AGENDA_PLAN_HORIZON_DAYS} days.</div>
+      </div>
+      ${foot}
+    </div>`;
+  } else {
+    host.innerHTML = `<div class="ag2-plan">
+      ${days.map(agendaPlanDayHtml).join('')}
+      ${foot}
+    </div>`;
+  }
+  agendaPlanEnsureTimer();
+}
+
+function agendaPlanTeardown() {
+  if (agendaPlanTimer !== null) {
+    clearInterval(agendaPlanTimer);
+    agendaPlanTimer = null;
+  }
+}
+
+function agendaPlanShouldRun() {
+  return agendaLens === 'plan' && !document.hidden && agendaTabVisible();
+}
+
+function agendaPlanEnsureTimer() {
+  if (agendaPlanTimer !== null || !agendaPlanShouldRun()) return;
+  agendaPlanTimer = setInterval(() => {
+    if (!agendaPlanShouldRun()) {
+      // Lens switched under us, tab hidden, or document hidden: disarm
+      // entirely — the render path re-arms on the next paint.
+      agendaPlanTeardown();
+      return;
+    }
+    agendaRenderTab();
+  }, 60000);
+}
+
+// ---- Time presentation ----
+
+// Fixed-width 24h clock text for the mono time column (locale AM/PM
+// would break the column alignment the design's 44px slot assumes).
+function agendaPlanHm(ms) {
+  const d = new Date(ms);
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function agendaPlanDayLabel(ms) {
+  const d = new Date(ms);
+  const today = new Date();
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  if (d.toDateString() === today.toDateString()) return 'Today';
+  if (d.toDateString() === tomorrow.toDateString()) return 'Tomorrow';
+  return d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
+}
+
+// Whether a fire instant falls inside the owner's quiet window — a
+// DISPLAY ANNOTATION ONLY on session rows (the "in quiet hours" chip),
+// never a deferral computation: approved sessions are never deferred
+// (the A3 ruling), so there is no served deferral instant to read and a
+// local wall-clock membership check is the honest annotation. Client
+// twin of QuietHours::contains (minutes since local midnight, window may
+// cross it).
+function agendaPlanInQuietAt(ms) {
+  const quiet = agendaReminderPolicy && agendaReminderPolicy.quiet_hours;
+  if (!quiet || quiet.start_min === quiet.end_min) return false;
+  const d = new Date(ms);
+  const minute = d.getHours() * 60 + d.getMinutes();
+  if (quiet.start_min < quiet.end_min) {
+    return minute >= quiet.start_min && minute < quiet.end_min;
+  }
+  return minute >= quiet.start_min || minute < quiet.end_min;
+}
+
+// ---- Row composition ----
+
+// The effective delivery loudness for an item's reminder: the owner's
+// per-item override, else the policy default (mirrors
+// ReminderPolicy::urgency_for).
+function agendaPlanUrgency(item) {
+  const policy = agendaReminderPolicy || {};
+  const overrides = policy.item_urgency || {};
+  return overrides[item.id] || policy.default_urgency || 'attention';
+}
+
+const AGENDA_PLAN_URGENCY_TONES = {
+  urgent: 'rose',
+  attention: 'amber',
+  info: 'sky',
+  mute: 'neutral',
+};
+
+// Every event on the horizon: {at, item, what, tone, pulse, chips, note}.
+// Deliberately unfiltered (like the graph lens): the timeline shows the
+// whole open ledger's future; search and the lens-bar filter chips keep
+// applying to the card lenses only.
+function agendaPlanEvents() {
+  const now = Date.now();
+  const horizon = now + AGENDA_PLAN_HORIZON_DAYS * AGENDA_PLAN_DAY_MS;
+  const policy = agendaReminderPolicy || {};
+  const remindersOff = policy.enabled === false;
+  const events = [];
+  (agendaItems || []).forEach((item) => {
+    if (item.status !== 'open') return;
+    // Reminder delivery. Overdue reminders (due before now) are the
+    // Needs-you lens's business; this lens shows the future only.
+    if (item.due_ms && item.due_ms > now && item.due_ms <= horizon) {
+      const urgency = agendaPlanUrgency(item);
+      const chips = [agendaChipHtml(urgency,
+        AGENDA_PLAN_URGENCY_TONES[urgency] || 'amber',
+        'Delivery loudness — owner policy')];
+      // Served planner derivation: when quiet hours would defer this
+      // delivery, the instant it would actually happen. Absent = nothing
+      // defers (including reminders disabled) — absence claims nothing.
+      if (item.deferred_until) {
+        chips.push(agendaChipHtml(`deferred → ${agendaPlanHm(item.deferred_until)}`,
+          'amber', 'Quiet hours defer every reminder — urgent included', true));
+      }
+      events.push({
+        at: item.due_ms, item, what: 'reminder', tone: 'sky', pulse: '',
+        chips,
+        note: remindersOff ? 'reminders are globally off — this will not fire' : null,
+      });
+    }
+    const st = agendaEffectState(item);
+    if (!st) return;
+    const digest8 = String(st.effect.digest || '').slice(0, 8);
+    if (st.kind === 'running') {
+      events.push({
+        at: now, item, what: 'session running now', tone: 'iris',
+        pulse: 'fast', chips: [], note: null,
+      });
+    } else if (st.kind === 'pending') {
+      events.push({
+        at: Math.max(st.manifest.fire_at_ms, now), item,
+        what: 'proposed session — will not fire', tone: 'amber', pulse: 'slow',
+        chips: [agendaChipHtml('needs approval', 'amber',
+          `Approval binds digest ${digest8}… exactly`)],
+        note: `waiting on your approval of digest ${digest8}… — proposing carries no authority`,
+      });
+    } else if (st.kind === 'suspended') {
+      events.push({
+        at: now, item, what: 'standing series suspended', tone: 'amber',
+        pulse: 'slow',
+        chips: [agendaChipHtml(`${st.effect.consecutive_failures} failures`, 'rose',
+          'Consecutive non-success outcomes since the last approval')],
+        note: 'nothing fires while suspended — re-approving the unchanged digest re-arms the series',
+      });
+    }
+    // Fire rows ride the SERVED planner instant exclusively: absent
+    // means nothing will fire (unapproved, suspended, spent, exhausted),
+    // so these compose correctly with the states above by construction —
+    // a running standing series still shows its next instants.
+    const nextFire = st.effect.next_fire_ms;
+    if (nextFire == null || nextFire > horizon) return;
+    const quietChip = (at) => (agendaPlanInQuietAt(at)
+      ? [agendaChipHtml('in quiet hours', 'sky',
+        'Approved sessions are never deferred — approving an off-hours run was the explicit decision', true)]
+      : []);
+    if (!st.rec) {
+      events.push({
+        at: nextFire, item, what: 'session fires — one-shot', tone: 'green',
+        pulse: '', chips: quietChip(nextFire), note: null,
+      });
+      return;
+    }
+    // Standing series: the served instant, then up to two further
+    // instants by pure period addition — arithmetic projections of the
+    // approved cadence anchored on the daemon's served instant, NOT
+    // planner logic (the planner's own judgments — suspension, spend,
+    // exhaustion — are already baked into next_fire_ms's presence).
+    // until_ms/max_occurrences are manifest bounds applied to the
+    // projection; the occurrence index of an instant is its offset from
+    // fire_at_ms on the cadence grid.
+    const every = st.rec.every_ms > 0 ? st.rec.every_ms : 0;
+    const requested = (st.effect.requested || []).length;
+    const what = `standing run · every ${agendaCadenceLabel(st.rec.every_ms)}`;
+    for (let i = 0, at = nextFire; i < AGENDA_PLAN_STANDING_INSTANTS; i++, at += every) {
+      if (at > horizon) break;
+      if (st.rec.until_ms && at > st.rec.until_ms) break;
+      if (st.rec.max_occurrences) {
+        const index = Math.round((at - st.manifest.fire_at_ms) / (every || 1));
+        if (index >= st.rec.max_occurrences) break;
+      }
+      events.push({
+        at, item, what, tone: 'green', pulse: '', chips: quietChip(at),
+        note: i === 0 && requested
+          ? `plus ${requested} owner-requested extra occurrence${requested === 1 ? '' : 's'} pending`
+          : null,
+      });
+      if (!every) break;
+    }
+    if (st.rec.until_ms && st.rec.until_ms <= horizon) {
+      events.push({
+        at: st.rec.until_ms, item, what: 'standing series ends',
+        tone: 'neutral', pulse: '', chips: [], note: null,
+      });
+    }
+  });
+  events.sort((a, b) => a.at - b.at);
+  return events;
+}
+
+// Events grouped into day buckets: {key, label, hint, rows}.
+function agendaPlanDays() {
+  const days = [];
+  agendaPlanEvents().forEach((event) => {
+    const key = new Date(event.at).toDateString();
+    let day = days.find((d) => d.key === key);
+    if (!day) {
+      day = { key, label: agendaPlanDayLabel(event.at), rows: [] };
+      days.push(day);
+    }
+    day.rows.push(event);
+  });
+  days.forEach((day) => {
+    day.hint = `${day.rows.length} event${day.rows.length === 1 ? '' : 's'}`;
+  });
+  return days;
+}
+
+// ---- Render ----
+
+function agendaPlanRowHtml(row) {
+  const title = String(row.item.title || '');
+  const shown = title.length > 44 ? `${title.slice(0, 43)}…` : title;
+  const dotClasses = ['ag2-plan-dot', `t-${row.tone}`];
+  if (row.pulse) dotClasses.push('pulse', row.pulse);
+  return `<div class="ag2-plan-row" data-open-item="${escapeHtml(row.item.id)}" role="button" tabindex="0">
+    <span class="${dotClasses.join(' ')}" aria-hidden="true"></span>
+    <div class="ag2-plan-line">
+      <span class="ag2-plan-time">${agendaPlanHm(row.at)}</span>
+      <span class="ag2-plan-title">${escapeHtml(shown)}</span>
+      <span class="ag2-plan-what">${escapeHtml(row.what)}</span>
+      ${row.chips.join('')}
+    </div>
+    ${row.note ? `<div class="ag2-plan-note">${escapeHtml(row.note)}</div>` : ''}
+  </div>`;
+}
+
+function agendaPlanDayHtml(day) {
+  return `<div class="ag2-plan-day">
+    <div class="ag2-plan-day-head">
+      <span class="ag2-plan-day-label">${escapeHtml(day.label)}</span>
+      <span class="ag2-plan-day-hint">${escapeHtml(day.hint)}</span>
+    </div>
+    <div class="ag2-plan-rail">${day.rows.map(agendaPlanRowHtml).join('')}</div>
+  </div>`;
+}
+
+// ---- Wire (the stop/resume conduit; see the fragment header) ----
+
+{
+  const wire = () => {
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) {
+        agendaPlanTeardown();
+        return;
+      }
+      if (agendaLens === 'plan' && agendaTabVisible()) {
+        // Resume through the render pass: repaint the drifted relative
+        // rows immediately and re-arm the timer.
+        agendaRenderTab();
+      }
+    });
+  };
+  if (document.readyState === 'complete') wire();
+  else document.addEventListener('DOMContentLoaded', wire, { once: true });
+}

--- a/static/app/ui2-agenda.css
+++ b/static/app/ui2-agenda.css
@@ -1,8 +1,9 @@
 /* Agenda tab (redesign slice A: lenses, compose bar, cards; slice B: the
-   Graph lens's constellation panel) + the compact activity-pane card +
-   the start-now confirm sheet. Token palette only (16-styles-v2-tokens);
-   scoped under html.ui-v2 like every v2 sheet. The inspector,
-   schedule/preview sheets, and the reminder-policy popover live in
+   Graph lens's constellation panel; slice C: the Upcoming lens's day
+   timeline) + the compact activity-pane card + the start-now confirm
+   sheet. Token palette only (16-styles-v2-tokens); scoped under
+   html.ui-v2 like every v2 sheet. The inspector, schedule/preview
+   sheets, and the reminder-policy popover live in
    ui2-agenda-inspector.css. */
 
 /* ---- Tab layout: main column + animated inspector ---- */
@@ -823,6 +824,94 @@ html.ui-v2 .ag2-graph-swatch.s-line { width: 14px; }
 html.ui-v2 .ag2-graph-swatch.s-line.t-place { border-top: 2px solid rgba(var(--iris-rgb), 0.55); }
 html.ui-v2 .ag2-graph-swatch.s-line.t-rel { border-top: 2px dashed var(--text-3); }
 html.ui-v2 .ag2-graph-swatch.s-line.t-dep { border-top: 2px solid rgba(var(--rose-rgb), 0.6); }
+
+/* ---- Upcoming lens (slice C): the 14-day day-grouped timeline. Rows
+   ride the shared .ag2-chip family; dots pulse via the shared ui2-pulse
+   keyframes, which the global reduced-motion rule collapses. ---- */
+
+html.ui-v2 .ag2-plan {
+  margin-bottom: 22px;
+}
+html.ui-v2 .ag2-plan-day {
+  margin-bottom: 18px;
+}
+html.ui-v2 .ag2-plan-day-head {
+  display: flex;
+  align-items: baseline;
+  gap: 9px;
+  margin: 0 0 8px 2px;
+}
+html.ui-v2 .ag2-plan-day-label {
+  font-family: var(--mono);
+  font-size: var(--eyebrow-size);
+  font-weight: 700;
+  letter-spacing: var(--eyebrow-track);
+  text-transform: uppercase;
+  color: var(--text-3);
+}
+html.ui-v2 .ag2-plan-day-hint {
+  font-size: 11px;
+  color: var(--text-3);
+}
+html.ui-v2 .ag2-plan-rail {
+  margin-left: 3px;
+  border-left: 1px solid var(--line);
+}
+html.ui-v2 .ag2-plan-row {
+  position: relative;
+  padding: 0 0 13px 16px;
+  cursor: pointer;
+}
+html.ui-v2 .ag2-plan-dot {
+  position: absolute;
+  left: -4px;
+  top: 4px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+}
+html.ui-v2 .ag2-plan-dot.t-sky { background: var(--sky); }
+html.ui-v2 .ag2-plan-dot.t-iris { background: var(--iris); }
+html.ui-v2 .ag2-plan-dot.t-amber { background: var(--amber); }
+html.ui-v2 .ag2-plan-dot.t-green { background: var(--green); }
+html.ui-v2 .ag2-plan-dot.t-neutral { background: var(--neutral-dot); }
+html.ui-v2 .ag2-plan-dot.pulse.slow { animation: ui2-pulse 2s ease-in-out infinite; }
+html.ui-v2 .ag2-plan-dot.pulse.fast { animation: ui2-pulse 1.3s ease-in-out infinite; }
+html.ui-v2 .ag2-plan-line {
+  display: flex;
+  align-items: baseline;
+  gap: 9px;
+  flex-wrap: wrap;
+}
+html.ui-v2 .ag2-plan-time {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text-3);
+  width: 44px;
+  flex-shrink: 0;
+}
+html.ui-v2 .ag2-plan-title {
+  font-size: 12.5px;
+  font-weight: 650;
+  color: var(--text);
+  overflow-wrap: anywhere;
+}
+html.ui-v2 .ag2-plan-row:hover .ag2-plan-title {
+  color: var(--iris-2);
+}
+html.ui-v2 .ag2-plan-what {
+  font-size: 11.5px;
+  color: var(--text-3);
+}
+html.ui-v2 .ag2-plan-note {
+  font-size: 10.5px;
+  color: var(--text-3);
+  margin: 3px 0 0 53px;
+}
+html.ui-v2 .ag2-plan-foot {
+  font-size: 10.5px;
+  color: var(--text-3);
+}
 
 /* ---- Empty state + footer ledger ---- */
 


### PR DESCRIPTION
UI slice C of the owner-greenlit Agenda dashboard redesign: the Upcoming (plan) lens, translated from the design prototype into the fragment conventions on top of slices A (#575) and B (#577), riding PR #576's served planner fields.

## What it adds

An `Upcoming` entry in `AGENDA_LENSES` between Graph and Questions — a custom-surface lens (the slice-B render/deactivate registry shape) that owns `#ag2-groups` with a 14-day day-grouped timeline: eyebrow day labels (Today / Tomorrow / locale short date) with event-count hints, a left-border rail, mono HH:MM time column, escaped title, what-text, chips, and note lines. Rows carry `data-open-item`, so the existing groups click delegation opens the slice-A inspector with no new listeners; an Enter-key branch in `agendaGroupsKeydown` mirrors the click for focused rows.

## Instants are served, never recomputed

The lens's whole premise is PR #576's display fields: `effects[].next_fire_ms` (the planner's next real fire instant; absent when nothing will fire — unapproved, suspended, spent, exhausted) and item-level `deferred_until` (the planner's quiet-hours deferral instant; absent when nothing defers). The only client arithmetic is presentation, annotated at both sites: up to two further standing instants projected by pure period addition anchored on the served instant (until_ms/max_occurrences applied as manifest bounds on the cadence grid), and a wall-clock quiet-window membership check that feeds the "in quiet hours" display chip on session rows only (approved sessions are never deferred — the chip annotates, it never computes deferral).

## Row sources

- **Reminders** (due in (now, now+14d]): sky dot, effective-loudness chip (`item_urgency[id] || default_urgency`; urgent rose / attention amber / info sky / mute neutral), served `deferred_until` as an amber dashed "deferred → HH:MM" chip, and a "reminders are globally off — this will not fire" note when the policy is disabled.
- **Effects** from fold truths (slice A's `agendaEffectState` precedence) plus the served instant: running now (iris, fast pulse); proposed-will-not-fire at max(fire_at, now) (amber pulse, digest-prefix approval chip + "proposing carries no authority" note); standing-suspended (failures chip, re-arm note); one-shot fire (green); standing fires ("standing run · every N" via `agendaCadenceLabel`) with the first row carrying the owner-requested-extras note, plus a neutral "standing series ends" row when until_ms is inside the horizon.

## Lifecycle

No rAF — static DOM whose relative correctness drifts, so a 60s re-render keeps Today/now rows honest. The timer is armed only while the lens is the active surface and the document is visible: the registry deactivate sweep (lens switch, error/loading paths) and visibilitychange → hidden tear it down; a tick that finds the agenda tab hidden disarms itself (at most one no-op tick after a tab switch, re-armed by the render path on re-entry). Pulsing dots ride the shared `ui2-pulse` keyframes, which the global reduced-motion rule collapses — no pulsing under prefers-reduced-motion.

## Battery

- `node --check` on all touched fragments; assembler regen committed
- `cargo test -p intendant --bins` green (4832 + 148 + 97 passed)
- `cargo fmt --check` clean; no .rs touched
- Visual acceptance on a scratch mock-provider daemon: empty state, then a seeded horizon (deferred urgent reminder under 22:00–08:00 quiet hours set via the policy route, attention-loudness reminder, pending proposal with digest note, approved standing series with until bound — three instants + ends row — and an approved one-shot landing inside quiet hours). DOM audit confirmed day labels, chips, and notes verbatim.
