### PR TITLE
feat(dashboard): agenda under-the-hood, raw-JSON sheet, ops ledger count, palette entries (redesign slice D)

### DIFF
--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -6166,6 +6166,8 @@ mod tests {
             "api_agenda_op",
             "api_agenda_ref_drift",
             "api_agenda_reminder_policy",
+            "api_agenda_ops",
+            "api_agenda_occurrences",
             "api_memory_search",
             "api_memory_claim",
             "api_memory_propose",

--- a/static/app/32-daemon-api.js
+++ b/static/app/32-daemon-api.js
@@ -182,6 +182,8 @@ const DAEMON_API_HTTP_MAP = Object.freeze({
   api_agenda_op: { verb: 'POST', path: '/api/agenda/op' },
   api_agenda_ref_drift: { verb: 'GET', path: '/api/agenda/items/{item_id}/refs/drift' },
   api_agenda_reminder_policy: { verb: 'POST', path: '/api/agenda/reminders/policy' },
+  api_agenda_ops: { verb: 'GET', path: '/api/agenda/ops', query: ['since', 'item', 'limit'] },
+  api_agenda_occurrences: { verb: 'GET', path: '/api/agenda/occurrences', query: ['since', 'item', 'limit'] },
   api_memory_search: { verb: 'GET', path: '/api/memory/search', query: ['q', 'limit', 'candidates'] },
   api_memory_claim: { verb: 'GET', path: '/api/memory/claim', query: ['id'] },
   api_memory_propose: { verb: 'POST', path: '/api/memory/propose' },

--- a/static/app/manifest.txt
+++ b/static/app/manifest.txt
@@ -87,19 +87,21 @@ ui2-activity.js
 46-recording-replay.js
 47-annotation-clips.js
 # Agenda must evaluate BEFORE the router (48): a #agenda deep link makes the
-# router's eval-time boot call agendaOnTabShown(), which reads these five
+# router's eval-time boot call agendaOnTabShown(), which reads these six
 # fragments' module-level lets/consts — they must be initialized by then
 # (deep-link TDZ rule). Their top levels declare only lets/consts/functions;
 # daemonApi (32), routeTo (48), escapeHtml (52) are reached from inside
-# functions at runtime. Order within the quintet: data layer, then the card
-# surface, then the inspector, then the lens surfaces (graph, plan) — each
-# consumes earlier state; the cards' lens registry reaches the lens
+# functions at runtime. Order within the sextet: data layer, then the card
+# surface, then the inspector, then the lens surfaces (graph, plan), then
+# the under-the-hood internals — each consumes earlier state; the cards'
+# lens registry, the inspector, and the chrome palette reach the later
 # fragments' hoisted functions at runtime only.
 ui2-agenda.js
 ui2-agenda-cards.js
 ui2-agenda-inspector.js
 ui2-agenda-graph.js
 ui2-agenda-plan.js
+ui2-agenda-hood.js
 # Memory: same deep-link TDZ rule as agenda — a #memory deep link makes the
 # router's eval-time boot call memoryOnTabShown(), which reads this fragment's
 # module-level lets. Top level declares only lets/functions.

--- a/static/app/ui2-agenda-cards.js
+++ b/static/app/ui2-agenda-cards.js
@@ -940,7 +940,11 @@ function agendaRenderTab() {
   const skipped = agendaSkippedLines > 0
     ? ` · ${agendaSkippedLines} newer-build line${agendaSkippedLines === 1 ? '' : 's'} preserved unfolded (an older binary never destroys history it can’t read)`
     : '';
-  ledger.textContent = `agenda.jsonl · append-only op log · ${agendaCounts.open || 0} open · ${agendaCounts.done || 0} done · ${agendaCounts.retired || 0} retired${skipped}`;
+  // Real ops truth from GET /api/agenda/ops (slice D, ui2-agenda-hood.js):
+  // the segment renders once fetched; the sync fetches only while this
+  // tab is visible and the data signature moved.
+  ledger.textContent = `agenda.jsonl · append-only op log · ${agendaCounts.open || 0} open · ${agendaCounts.done || 0} done · ${agendaCounts.retired || 0} retired${agendaLedgerOpsSegment()}${skipped}`;
+  agendaLedgerOpsSync();
 
   const lens = AGENDA_LENSES.find((l) => l.id === agendaLens) || AGENDA_LENSES[0];
   agendaLensSurfacesDeactivate(lens.id);

--- a/static/app/ui2-agenda-hood.js
+++ b/static/app/ui2-agenda-hood.js
@@ -45,24 +45,26 @@ function agendaHoodReset() {
 async function agendaHoodFetchPages(method, itemId, key) {
   const entries = [];
   let since = 0;
-  let pageMore = false;
   for (let page = 0; page < 8; page++) {
     const resp = await daemonApi.request(method, { item: itemId, limit: 500, since });
     if (!resp.ok || !resp.body || !Array.isArray(resp.body[key])) {
       const message = (resp.body && resp.body.error) || `unavailable (${resp.status})`;
-      return { error: message, entries, pageMore };
+      return { error: message, entries, pageMore: false };
     }
     entries.push(...resp.body[key]);
-    if (resp.body.next_since >= resp.body.log_len) return { error: '', entries, pageMore };
+    if (resp.body.next_since >= resp.body.log_len) return { error: '', entries, pageMore: false };
     since = resp.body.next_since;
-    pageMore = true; // provisional: cleared by a terminal page above
   }
+  // Page budget exhausted with the cursor still short of the log's end.
   return { error: '', entries, pageMore: true };
 }
 
 function agendaHoodEnsureData(item) {
+  // An errored cache counts as fresh: retry only when the item's
+  // updated_ms moves or the inspector reopens — a persistent failure
+  // must never become a render→fetch→render loop.
   const fresh = (cache) => cache && cache.itemId === item.id
-    && cache.updatedMs === (item.updated_ms || 0) && !cache.error;
+    && cache.updatedMs === (item.updated_ms || 0);
   if (!fresh(agendaHoodOps)) {
     const stamp = { itemId: item.id, updatedMs: item.updated_ms || 0 };
     agendaHoodOps = { ...stamp, loading: true, error: '', entries: [], pageMore: false };
@@ -200,11 +202,16 @@ function agendaHoodBornHtml(item) {
 // The latest journal record for this effect's last occurrence — journal
 // truth first; the fold's last_run fields are the fallback when the
 // journal page has nothing (absence claims nothing).
-function agendaHoodOccurrenceLine(effect) {
+function agendaHoodOccurrenceLine(item, effect) {
   const run = effect.last_run;
   if (!run) return '';
   let state = run.state;
   let source = 'journal synced before dispatch';
+  if (agendaHoodOcc && agendaHoodOcc.itemId !== item.id) {
+    // Cache from a previous selection (only reachable when this item's
+    // fetch is gated): claim nothing from it.
+    return `<div class="ag2-hood-occ">${escapeHtml(`occurrence ${run.occurrence_id} · ${state} · fold view`)}</div>`;
+  }
   if (agendaHoodOcc && !agendaHoodOcc.loading && !agendaHoodOcc.error) {
     const records = agendaHoodOcc.entries
       .filter((entry) => entry && entry.record
@@ -266,7 +273,7 @@ function agendaHoodManifestHtml(item) {
     <div class="ag2-hood-seal t-${sealTone}"><span class="ag2-hood-sealdot"></span>${escapeHtml(sealLine)}</div>
     <div class="ag2-hood-note mono">${escapeHtml(attribution)}</div>
     ${streak}
-    ${agendaHoodOccurrenceLine(effect)}
+    ${agendaHoodOccurrenceLine(item, effect)}
   </div>`;
 }
 
@@ -314,7 +321,7 @@ function agendaHoodAskHtml(item) {
 
 // Presentation verb for one served envelope. Every interpolated field is
 // op-log DATA — the caller escapes the whole verb string.
-function agendaHoodOpVerb(op) {
+function agendaHoodOpVerb(op, envelope) {
   const type = String(op.type || '');
   const titleOf = (id, cap) => {
     const target = agendaFindItem(id);
@@ -329,7 +336,12 @@ function agendaHoodOpVerb(op) {
     case 'retire': return 'retired — hidden, never deleted';
     case 'answer': return 'answered';
     case 'dismiss': return `dismissed${op.action ? ` (${op.action})` : ''} — still open`;
-    case 'annotate': return 'annotated';
+    case 'annotate': {
+      // The self-described label rides the verb (the triage mandate's
+      // annotations read as "annotated · --source triage").
+      const source = envelope.source || op.source || '';
+      return source ? `annotated · --source ${source}` : 'annotated';
+    }
     case 'set_blocker': return 'blocker set';
     case 'clear_blocker': return 'blocker cleared';
     case 'add_ref': return `ref attached · ${op.ref_type || 'file'}`;
@@ -396,7 +408,7 @@ function agendaHoodHistoryHtml(item) {
       }
       const envelope = entry.op || {};
       const op = envelope.op || {};
-      const verb = entry.known ? agendaHoodOpVerb(op) : `op · ${String(op.type || '—')}`;
+      const verb = entry.known ? agendaHoodOpVerb(op, envelope) : `op · ${String(op.type || '—')}`;
       return {
         at: envelope.at_ms || 0,
         verb,
@@ -509,13 +521,20 @@ function agendaLedgerOpsSync() {
   agendaLedgerOpsInFlight = true;
   daemonApi.request('api_agenda_ops', { limit: 1 }).then((resp) => {
     agendaLedgerOpsInFlight = false;
-    if (!resp.ok || !resp.body || typeof resp.body.log_len !== 'number') return;
+    if (!resp.ok || !resp.body || typeof resp.body.log_len !== 'number') {
+      // Unsupported/unavailable: remember the signature so a failing
+      // daemon is not re-asked on every repaint — the next DATA change
+      // retries once. The segment simply stays absent.
+      agendaLedgerOpsSig = sig;
+      return;
+    }
     const changed = agendaLedgerOpsLen !== resp.body.log_len;
     agendaLedgerOpsLen = resp.body.log_len;
     agendaLedgerOpsSig = sig;
     if (changed) agendaRenderTab();
   }).catch(() => {
     agendaLedgerOpsInFlight = false;
+    agendaLedgerOpsSig = sig;
   });
 }
 

--- a/static/app/ui2-agenda-hood.js
+++ b/static/app/ui2-agenda-hood.js
@@ -46,7 +46,14 @@ async function agendaHoodFetchPages(method, itemId, key) {
   const entries = [];
   let since = 0;
   for (let page = 0; page < 8; page++) {
-    const resp = await daemonApi.request(method, { item: itemId, limit: 500, since });
+    let resp;
+    try {
+      resp = await daemonApi.request(method, { item: itemId, limit: 500, since });
+    } catch (e) {
+      // Transport rejection must land as a rendered error, never a
+      // cache stuck in loading.
+      return { error: String((e && e.message) || e), entries, pageMore: false };
+    }
     if (!resp.ok || !resp.body || !Array.isArray(resp.body[key])) {
       const message = (resp.body && resp.body.error) || `unavailable (${resp.status})`;
       return { error: message, entries, pageMore: false };

--- a/static/app/ui2-agenda-hood.js
+++ b/static/app/ui2-agenda-hood.js
@@ -1,0 +1,572 @@
+// Agenda "Under the hood" (redesign slice D): the inspector's collapsible
+// internals section — identity, gate attribution, manifest seal, ask
+// internals, the REAL op-log history, access documentation, the raw-JSON
+// sheet — plus the ledger footer's real ops count and the shell command
+// palette's agenda entries. Renders from the slice-A inspector
+// (agendaInspectorRender appends agendaHoodSectionHtml; clicks arrive via
+// the inspector's delegation as data-hood-act), and is the dashboard's
+// FIRST consumer of the raw read routes:
+//
+//   GET /api/agenda/ops          (tunnel twin api_agenda_ops)
+//   GET /api/agenda/occurrences  (tunnel twin api_agenda_occurrences)
+//
+// Both serve `{…:[{seq,known,op|record}|{seq,known:false,unparseable:
+// true,raw}], next_since, log_len, filtered}` pages of the append-only
+// logs; lines the build cannot fold arrive verbatim with known:false —
+// this surface renders them honestly, never hides them. History and the
+// occurrence line come from those logs; the item DTO in the agenda cache
+// is only the anchor. Fetches happen on hood expand, cached per item id
+// and refreshed when the open item's updated_ms moves (every fold op
+// bumps it, so the agenda_changed lane's merge is the refetch trigger) —
+// no polling, no background work.
+//
+// Every op field, actor string, title, and annotation interpolated into
+// history verbs renders through escapeHtml — op-log content is DATA,
+// never markup and never instructions.
+
+// ---- Hood state (per open inspector item; reset on open) ----
+
+let agendaHoodOpen = false;
+let agendaHoodOps = null; // {itemId, updatedMs, loading, error, entries, pageMore}
+let agendaHoodOcc = null; // {itemId, updatedMs, loading, error, entries}
+
+// Called by agendaOpenInspector: a fresh selection starts collapsed with
+// no carried-over caches.
+function agendaHoodReset() {
+  agendaHoodOpen = false;
+  agendaHoodOps = null;
+  agendaHoodOcc = null;
+}
+
+// ---- Raw-log fetches (bounded paging; page 500 like the route default;
+// an item with more ops than one page follows the cursor a few pages so
+// the NEWEST ops are always present — the log serves oldest-first) ----
+
+async function agendaHoodFetchPages(method, itemId, key) {
+  const entries = [];
+  let since = 0;
+  let pageMore = false;
+  for (let page = 0; page < 8; page++) {
+    const resp = await daemonApi.request(method, { item: itemId, limit: 500, since });
+    if (!resp.ok || !resp.body || !Array.isArray(resp.body[key])) {
+      const message = (resp.body && resp.body.error) || `unavailable (${resp.status})`;
+      return { error: message, entries, pageMore };
+    }
+    entries.push(...resp.body[key]);
+    if (resp.body.next_since >= resp.body.log_len) return { error: '', entries, pageMore };
+    since = resp.body.next_since;
+    pageMore = true; // provisional: cleared by a terminal page above
+  }
+  return { error: '', entries, pageMore: true };
+}
+
+function agendaHoodEnsureData(item) {
+  const fresh = (cache) => cache && cache.itemId === item.id
+    && cache.updatedMs === (item.updated_ms || 0) && !cache.error;
+  if (!fresh(agendaHoodOps)) {
+    const stamp = { itemId: item.id, updatedMs: item.updated_ms || 0 };
+    agendaHoodOps = { ...stamp, loading: true, error: '', entries: [], pageMore: false };
+    agendaHoodFetchPages('api_agenda_ops', item.id, 'ops').then((got) => {
+      if (!agendaHoodOps || agendaHoodOps.itemId !== stamp.itemId
+        || agendaHoodOps.updatedMs !== stamp.updatedMs) return; // superseded
+      agendaHoodOps = { ...stamp, loading: false, ...got };
+      agendaInspectorRender();
+    });
+  }
+  const effect = (item.effects || [])[0];
+  if (effect && effect.last_run && !fresh(agendaHoodOcc)) {
+    const stamp = { itemId: item.id, updatedMs: item.updated_ms || 0 };
+    agendaHoodOcc = { ...stamp, loading: true, error: '', entries: [] };
+    agendaHoodFetchPages('api_agenda_occurrences', item.id, 'occurrences').then((got) => {
+      if (!agendaHoodOcc || agendaHoodOcc.itemId !== stamp.itemId
+        || agendaHoodOcc.updatedMs !== stamp.updatedMs) return;
+      agendaHoodOcc = { itemId: stamp.itemId, updatedMs: stamp.updatedMs, loading: false, error: got.error, entries: got.entries };
+      agendaInspectorRender();
+    });
+  }
+}
+
+// ---- Section ----
+
+function agendaHoodSectionHtml(item) {
+  const head = `<button type="button" class="ag2-hood-toggle" data-hood-act="toggle"
+      aria-expanded="${agendaHoodOpen ? 'true' : 'false'}">
+    <span class="ag2-hood-title">Under the hood</span>
+    <span class="ag2-hood-sub">ids · digests · attribution · raw ops</span>
+    <span class="ag2-spacer"></span>
+    <span class="ag2-hood-chev">${agendaHoodOpen ? '▾' : '▸'}</span>
+  </button>`;
+  if (!agendaHoodOpen) return `<section class="ag2-hood">${head}</section>`;
+  agendaHoodEnsureData(item);
+  return `<section class="ag2-hood">${head}
+    <div class="ag2-hood-body">
+      ${agendaHoodIdentityHtml(item)}
+      ${agendaHoodBornHtml(item)}
+      ${agendaHoodManifestHtml(item)}
+      ${agendaHoodAskHtml(item)}
+      ${agendaHoodHistoryHtml(item)}
+      ${agendaHoodAccessHtml()}
+      ${agendaHoodFooterHtml(item)}
+    </div>
+  </section>`;
+}
+
+// Delegated from agendaInspClick on [data-hood-act].
+function agendaHoodClick(item, el) {
+  switch (el.dataset.hoodAct) {
+    case 'toggle':
+      agendaHoodOpen = !agendaHoodOpen;
+      agendaInspectorRender();
+      break;
+    case 'copy-id':
+      agendaCopyText(item.id, 'the full item id');
+      break;
+    case 'copy-digest': {
+      const effect = (item.effects || [])[0];
+      if (effect) agendaCopyText(effect.digest, 'the manifest digest');
+      break;
+    }
+    case 'raw':
+      agendaSheetState = { kind: 'raw', itemId: item.id };
+      agendaSheetRender();
+      break;
+    case 'copy-ctl':
+      agendaCopyText(`intendant ctl agenda annotate ${item.id.slice(0, 6).toLowerCase()} "…"`,
+        'a ctl handle — any unique id prefix works');
+      break;
+    default:
+      break;
+  }
+}
+
+// ---- Identity ----
+
+function agendaHoodIdentityHtml(item) {
+  const p = item.provenance || {};
+  const times = [['parked', p.created_ms], ['updated', item.updated_ms]];
+  if (item.completed_ms) times.push(['completed', item.completed_ms]);
+  const grid = times.map(([k, v]) => `<div class="ag2-hood-time">
+      <div class="ag2-hood-time-k">${escapeHtml(k)}</div>
+      <div class="ag2-hood-time-v">${escapeHtml(agendaAbsTime(v))}</div>
+    </div>`).join('');
+  return `<div class="ag2-hood-card">
+    <div class="ag2-hood-eyebrow">Identity</div>
+    <button type="button" class="ag2-hood-idbtn" data-hood-act="copy-id" title="Click to copy the full item id">
+      <span class="t-time">${escapeHtml(item.id.slice(0, 10))}</span><span class="t-rand">${escapeHtml(item.id.slice(10))}</span>
+    </button>
+    <div class="ag2-hood-note">ulid — the highlighted 10 chars encode creation time, so sort order is creation order</div>
+    <div class="ag2-hood-times">${grid}</div>
+  </div>`;
+}
+
+// ---- Born as (gate attribution passport) ----
+
+function agendaHoodBornHtml(item) {
+  const p = item.provenance || {};
+  const chips = [];
+  chips.push(agendaChipHtml(p.kind || 'unattributed', 'iris',
+    'actor class as the daemon’s gates resolved it — mapped at the authenticated edge, never parsed from the request'));
+  if (p.principal) {
+    chips.push(`<span class="ag2-hood-vchip" title="IAM principal exactly as the gate named it">${escapeHtml(p.principal)}</span>`);
+  }
+  if (p.source) {
+    chips.push(`<span class="ag2-hood-source" title="self-described --source label — unverified data beside the attribution; never a principal, never a trust input">via “${escapeHtml(p.source)}”</span>`);
+  }
+  let session = '';
+  if (p.session_id) {
+    const s = agendaSessionInfo(p.session_id);
+    if (s && s.key) {
+      session = `<div class="ag2-hood-session"><a class="agenda-session-link ag2-hood-sess" href="#sessions"
+          data-session-key="${escapeHtml(s.key)}">${escapeHtml(`${p.session_id} → “${s.name || String(s.conversation_id || '').slice(0, 8)}”`)}</a></div>`;
+    } else {
+      session = `<div class="ag2-hood-session"><span class="ag2-hood-sess plain">${escapeHtml(`${p.session_id} — unresolved; degrades to the raw id, never an error`)}</span></div>`;
+    }
+  }
+  const bornNote = p.source
+    ? 'the label is data beside the gate attribution — unverified by doctrine'
+    : p.session_id
+      ? 'session-bound by token possession (the injected loopback capability) — never echoed from request fields'
+      : 'attributed as the owner surface at the authenticated edge';
+  return `<div class="ag2-hood-card">
+    <div class="ag2-hood-eyebrow">Born as</div>
+    <div class="ag2-hood-chips">${chips.join('')}</div>
+    ${session}
+    <div class="ag2-hood-note">${escapeHtml(bornNote)}</div>
+  </div>`;
+}
+
+// ---- Manifest seal ----
+
+// The latest journal record for this effect's last occurrence — journal
+// truth first; the fold's last_run fields are the fallback when the
+// journal page has nothing (absence claims nothing).
+function agendaHoodOccurrenceLine(effect) {
+  const run = effect.last_run;
+  if (!run) return '';
+  let state = run.state;
+  let source = 'journal synced before dispatch';
+  if (agendaHoodOcc && !agendaHoodOcc.loading && !agendaHoodOcc.error) {
+    const records = agendaHoodOcc.entries
+      .filter((entry) => entry && entry.record
+        && entry.record.occurrence_id === run.occurrence_id);
+    if (records.length) {
+      state = records[records.length - 1].record.state || state;
+    } else {
+      source = 'fold view — the journal page holds no record for it';
+    }
+  } else if (agendaHoodOcc && agendaHoodOcc.loading) {
+    source = 'reading occurrences.jsonl…';
+  } else if (agendaHoodOcc && agendaHoodOcc.error) {
+    source = 'fold view — journal read unavailable';
+  }
+  const requested = (effect.requested || []).length;
+  const tail = requested ? ` · ${requested} owner run-request${requested > 1 ? 's' : ''}` : '';
+  return `<div class="ag2-hood-occ">${escapeHtml(`occurrence ${run.occurrence_id} · ${state} · ${source}${tail}`)}</div>`;
+}
+
+function agendaHoodManifestHtml(item) {
+  const effect = (item.effects || [])[0];
+  if (!effect || !effect.manifest) return '';
+  const bound = !!effect.approval && effect.approval.digest === effect.digest;
+  const digestGroups = (effect.digest.match(/.{1,4}/g) || [effect.digest]).join(' ');
+  const sealTone = bound ? 'green' : 'amber';
+  const sealLine = bound
+    ? 'approval bound to this exact revision — any edit voids it'
+    : 'no approval binds this revision — nothing fires';
+  let attribution;
+  if (effect.approval) {
+    attribution = `approved ${agendaAbsTime(effect.approval.at_ms)} by ${effect.approval.principal || '—'} (${effect.approval.kind || '—'})`;
+  } else {
+    const proposer = effect.proposed_session_id
+      ? agendaActorLabel({ session_id: effect.proposed_session_id, kind: effect.proposed_kind, principal: effect.proposed_principal })
+      : (effect.proposed_kind || '—');
+    attribution = `proposed ${agendaAbsTime(effect.proposed_ms)} by ${proposer}`;
+  }
+  let streak = '';
+  const rec = effect.manifest.recurrence;
+  if (rec) {
+    const threshold = Math.max(1, rec.suspend_after_failures || 3);
+    const n = Math.min(effect.consecutive_failures || 0, threshold);
+    const dots = Array.from({ length: threshold }, (_, i) =>
+      `<span class="ag2-hood-dot${i < n ? ' filled' : ''}"></span>`).join('');
+    const suspended = (effect.consecutive_failures || 0) >= threshold;
+    const label = suspended
+      ? `suspended — ${n} of ${threshold} non-success outcomes; re-approval resets the streak`
+      : `${n} of ${threshold} non-success outcomes before suspension (missed runs don’t count)`;
+    streak = `<div class="ag2-hood-streak">${dots}<span class="ag2-hood-note">${escapeHtml(label)}</span></div>`;
+  }
+  return `<div class="ag2-hood-card">
+    <div class="ag2-hood-cardhead">
+      <span class="ag2-hood-eyebrow">Manifest seal</span>
+      <span class="ag2-spacer"></span>
+      <span class="ag2-hood-effid">${escapeHtml(effect.effect_id)}</span>
+    </div>
+    <button type="button" class="ag2-hood-idbtn digest" data-hood-act="copy-digest"
+      title="Click to copy the full digest — sha256 over item + effect identity and the manifest’s canonical bytes">${escapeHtml(digestGroups)}</button>
+    <div class="ag2-hood-seal t-${sealTone}"><span class="ag2-hood-sealdot"></span>${escapeHtml(sealLine)}</div>
+    <div class="ag2-hood-note mono">${escapeHtml(attribution)}</div>
+    ${streak}
+    ${agendaHoodOccurrenceLine(effect)}
+  </div>`;
+}
+
+// ---- Ask internals ----
+
+function agendaHoodAskHtml(item) {
+  if (item.kind !== 'question') return '';
+  const chips = [];
+  if (item.ask) {
+    chips.push(`<span class="ag2-hood-vchip" title="question-rail identity from the approval allocator — floored above every persisted ask at fold, so a restarted daemon never re-mints one">ask #${escapeHtml(String(item.ask.ask_id))}</span>`);
+    (item.ask.questions || []).forEach((q) => {
+      (q.previews || []).forEach((pv) => {
+        if (!pv.upload_id) return; // inline text previews carry no blob
+        chips.push(`<span class="ag2-hood-vchip" title="${escapeHtml(`GET ${pv.url || ''} — attachment + nosniff, so a blob never renders by direct navigation; the dashboard fetches it into a sandboxed srcdoc`)}">${escapeHtml(`blob ${pv.upload_id} · ${pv.mime || 'text/html'}`)}</span>`);
+      });
+    });
+  }
+  if (item.dismissed) {
+    chips.push(`<span class="ag2-hood-source" title="${escapeHtml(`rails cleared ${agendaRelTime(item.dismissed.at_ms)} — deliberately excluded from page-load and boot re-announcement`)}">${escapeHtml(`dismissed · ${item.dismissed.action || '—'}`)}</span>`);
+  }
+  if (item.answer) {
+    const delivered = item.answer.delivered;
+    const label = delivered === true ? 'delivered: true'
+      : delivered === false ? 'delivered: false' : 'delivery: unrecorded';
+    const tone = delivered === true ? 'green' : delivered === false ? 'sky' : 'iris';
+    const tip = delivered === true
+      ? 'reached the asking session as a user message at a turn boundary, resolved across its resume lineage'
+      : delivered === false
+        ? 'recorded by a daemon-authored record_ask_delivery op; one info notification raised (title only, never answer text)'
+        : 'absent data claims nothing';
+    chips.push(agendaChipHtml(label, tone, tip));
+  }
+  if (!chips.length) return '';
+  const note = item.status === 'open'
+    ? 'only an answer resolves a question — dismissal is not resolution'
+    : 'the item keeps the durable record: the joined text plus the structured resolution';
+  return `<div class="ag2-hood-card">
+    <div class="ag2-hood-eyebrow">Ask internals</div>
+    <div class="ag2-hood-chips">${chips.join('')}</div>
+    <div class="ag2-hood-note">${escapeHtml(note)}</div>
+  </div>`;
+}
+
+// ---- History (the real op log) ----
+
+// Presentation verb for one served envelope. Every interpolated field is
+// op-log DATA — the caller escapes the whole verb string.
+function agendaHoodOpVerb(op) {
+  const type = String(op.type || '');
+  const titleOf = (id, cap) => {
+    const target = agendaFindItem(id);
+    const title = target ? target.title : '';
+    return title ? `“${title.length > cap ? `${title.slice(0, cap - 1)}…` : title}”` : `“${String(id || '?').slice(0, 8)}…”`;
+  };
+  switch (type) {
+    case 'add': return 'parked';
+    case 'patch': return 'patched';
+    case 'complete': return 'completed';
+    case 'reopen': return 'reopened';
+    case 'retire': return 'retired — hidden, never deleted';
+    case 'answer': return 'answered';
+    case 'dismiss': return `dismissed${op.action ? ` (${op.action})` : ''} — still open`;
+    case 'annotate': return 'annotated';
+    case 'set_blocker': return 'blocker set';
+    case 'clear_blocker': return 'blocker cleared';
+    case 'add_ref': return `ref attached · ${op.ref_type || 'file'}`;
+    case 'remove_ref': return `ref removed · ${op.ref_type || 'file'}`;
+    case 'add_part_of': return `filed under ${titleOf(op.parent_id, 27)}`;
+    case 'remove_part_of': return 'unfiled';
+    case 'add_relates_to': return `related to ${titleOf(op.target_id, 23)}`;
+    case 'remove_relates_to': return `relation removed · ${titleOf(op.target_id, 23)}`;
+    case 'add_relies_on': return `relies on ${titleOf(op.target_id, 23)}`;
+    case 'remove_relies_on': return `dependency removed · ${titleOf(op.target_id, 23)}`;
+    case 'propose_effect': return 'manifest proposed';
+    case 'approve_effect': return 'approved — digest bound';
+    case 'revoke_effect': return 'approval revoked';
+    case 'request_occurrence': return 'run requested';
+    case 'record_occurrence': return `run ${op.state || '—'}`;
+    case 'record_ask_delivery':
+      return op.delivered === false ? 'delivery pending — no live asker' : 'answer delivered';
+    default: return `op · ${type || '—'}`;
+  }
+}
+
+function agendaHoodOpDot(op, known) {
+  if (!known) return 'neutral';
+  switch (String(op.type || '')) {
+    case 'add': case 'reopen': case 'request_occurrence': return 'iris';
+    case 'set_blocker': return 'rose';
+    case 'clear_blocker': case 'approve_effect': case 'answer': case 'complete': return 'green';
+    case 'add_ref': case 'remove_ref': case 'record_ask_delivery': return 'sky';
+    case 'propose_effect': case 'revoke_effect': return 'amber';
+    case 'record_occurrence':
+      return op.state === 'completed' || op.state === 'delivered' ? 'green'
+        : op.state === 'failed' ? 'rose'
+          : op.state === 'started' ? 'iris' : 'amber';
+    default: return 'neutral';
+  }
+}
+
+// Who performed a served op, from the ENVELOPE's gate attribution (the
+// self-described source label supplements, never replaces it).
+function agendaHoodOpWho(envelope) {
+  const actor = envelope.actor || null;
+  const label = actor ? agendaActorLabel(actor) : '';
+  if (label) return label;
+  const source = envelope.source
+    || (envelope.op && envelope.op.source) || '';
+  if (source) return `“${source}”`;
+  const daemonOps = ['record_occurrence', 'record_ask_delivery'];
+  if (envelope.op && daemonOps.includes(String(envelope.op.type || ''))) return 'the daemon';
+  return 'unattributed';
+}
+
+function agendaHoodHistoryHtml(item) {
+  const cache = agendaHoodOps;
+  let body;
+  let label = '';
+  if (!cache || cache.loading) {
+    body = '<div class="ag2-hood-note">reading agenda.jsonl…</div>';
+  } else if (cache.error) {
+    body = `<div class="ag2-hood-note">${escapeHtml(`op log ${cache.error}`)}</div>`;
+  } else {
+    const rows = cache.entries.map((entry) => {
+      if (entry.unparseable) {
+        return { at: 0, verb: 'unreadable line · preserved', who: '', dot: 'neutral' };
+      }
+      const envelope = entry.op || {};
+      const op = envelope.op || {};
+      const verb = entry.known ? agendaHoodOpVerb(op) : `op · ${String(op.type || '—')}`;
+      return {
+        at: envelope.at_ms || 0,
+        verb,
+        who: agendaHoodOpWho(envelope),
+        dot: agendaHoodOpDot(op, !!entry.known),
+      };
+    });
+    rows.reverse(); // newest first (the log serves oldest-first)
+    const shown = rows.slice(0, 9).map((row) => `<div class="ag2-hood-tl-row">
+        <span class="ag2-hood-tl-dot t-${row.dot}"></span>
+        <span class="ag2-hood-tl-verb">${escapeHtml(row.verb)}</span>
+        ${row.who ? `<span class="ag2-hood-tl-who">${escapeHtml(`by ${row.who}`)}</span>` : ''}
+        <span class="ag2-spacer"></span>
+        <span class="ag2-hood-tl-t">${escapeHtml(row.at ? agendaRelTime(row.at) : '—')}</span>
+      </div>`).join('');
+    const more = rows.length > 9
+      ? `<div class="ag2-hood-more">+ ${rows.length - 9}${cache.pageMore ? '+' : ''} earlier ops in the log</div>`
+      : '';
+    body = `<div class="ag2-hood-rail">${shown}</div>${more}`;
+    label = `${rows.length}${cache.pageMore ? '+' : ''} ops · append-only`;
+  }
+  return `<div class="ag2-hood-card">
+    <div class="ag2-hood-cardhead">
+      <span class="ag2-hood-eyebrow">History</span>
+      <span class="ag2-spacer"></span>
+      <span class="ag2-hood-effid">${escapeHtml(label)}</span>
+    </div>
+    ${body}
+  </div>`;
+}
+
+// ---- Access (documentation copy — static, like the prototype) ----
+
+function agendaHoodAccessHtml() {
+  const chips = [
+    ['agenda.read · GET /api/agenda',
+      'the ledger snapshot: items, counts, skipped lines, reminder policy, session join map'],
+    ['agenda.write · POST /api/agenda/op',
+      'one validated command per call — attribution mapped at the authenticated edge, never from the body'],
+    ['owner surface · approve / revoke / start',
+      'the tenant edge refuses agent-session, peer, and unattributed callers with a named denial'],
+    ['settings.manage · reminder policy',
+      'separate authority — an agenda.write grant can’t make its own item louder'],
+  ].map(([label, tip]) =>
+    `<span class="ag2-hood-vchip" title="${escapeHtml(tip)}">${escapeHtml(label)}</span>`).join('');
+  return `<div class="ag2-hood-card">
+    <div class="ag2-hood-eyebrow">Access</div>
+    <div class="ag2-hood-chips">${chips}</div>
+    <div class="ag2-hood-note">approvals, revokes, and start-now are owner-surface acts — an agent session is refused by policy, even on its own manifest</div>
+  </div>`;
+}
+
+function agendaHoodFooterHtml(item) {
+  const handle = `intendant ctl agenda annotate ${item.id.slice(0, 6).toLowerCase()} "…"`;
+  return `<div class="ag2-hood-foot">
+    <button type="button" class="ag2-btn ghost" data-hood-act="raw">View raw item JSON</button>
+    <button type="button" class="ag2-btn ghost" data-hood-act="copy-ctl"
+      title="${escapeHtml(`${handle} — any unique id prefix works in ctl`)}">Copy ctl handle</button>
+    <span class="ag2-hood-footnote">retire hides, nothing deletes — agenda.jsonl keeps every line</span>
+  </div>`;
+}
+
+// ---- Raw-JSON sheet ----
+
+// Presentation strip of nulls and empty arrays (the prototype's toRaw):
+// the served DTO minus visual noise, pretty-printed. The label below the
+// pre names the truth precisely — the served item is the fold product
+// PLUS the planner's display-only decorations (next_fire_ms,
+// deferred_until), so "pure fold product" would be false.
+function agendaHoodStripRaw(value) {
+  return JSON.parse(JSON.stringify(value, (key, v) =>
+    (v === null || (Array.isArray(v) && !v.length) ? undefined : v)));
+}
+
+function agendaRawSheetHtml(item) {
+  const pretty = JSON.stringify(agendaHoodStripRaw(item), null, 2);
+  return `<div class="ag2-sheet-head">
+      <span class="ag2-sheet-title">Raw item JSON</span>
+      <span class="ag2-spacer"></span>
+      <button type="button" class="ag2-x" data-sheet-act="close" title="Close — esc">×</button>
+    </div>
+    <div class="ag2-sheet-item">${escapeHtml(`${item.id.slice(0, 6).toLowerCase()} · ${item.title}`)}</div>
+    <pre class="ag2-sheet-raw">${escapeHtml(pretty)}</pre>
+    <div class="ag2-hood-footnote">Exactly what GET /api/agenda serves — the fold product of agenda.jsonl plus the planner’s display-only decorations (next_fire_ms, deferred_until). Nothing here is stored state beyond the ops.</div>`;
+}
+
+// ---- Ledger footer ops count ----
+// The real log length (one {limit:1} page for its log_len), rendered by
+// the cards fragment between the counts and the skipped-lines segment.
+// Fetch-on-render lifecycle: agendaRenderTab calls the sync on every
+// paint; it fetches only while the tab is visible and only when the data
+// signature moved (the agenda_changed merge bumps updated_ms /counts, so
+// a changed ledger refetches; a parked tab never fetches — no timers to
+// tear down).
+
+let agendaLedgerOpsLen = null;
+let agendaLedgerOpsSig = '';
+let agendaLedgerOpsInFlight = false;
+
+function agendaLedgerOpsSegment() {
+  return agendaLedgerOpsLen === null ? '' : ` · ${agendaLedgerOpsLen} ops in the log`;
+}
+
+function agendaLedgerOpsSync() {
+  if (!agendaTabVisible() || document.hidden || agendaLedgerOpsInFlight) return;
+  if (!Array.isArray(agendaItems)) return;
+  const sig = `${agendaCounts.open}|${agendaCounts.done}|${agendaCounts.retired}|`
+    + agendaItems.reduce((max, it) => Math.max(max, it.updated_ms || 0), 0);
+  if (sig === agendaLedgerOpsSig && agendaLedgerOpsLen !== null) return;
+  agendaLedgerOpsInFlight = true;
+  daemonApi.request('api_agenda_ops', { limit: 1 }).then((resp) => {
+    agendaLedgerOpsInFlight = false;
+    if (!resp.ok || !resp.body || typeof resp.body.log_len !== 'number') return;
+    const changed = agendaLedgerOpsLen !== resp.body.log_len;
+    agendaLedgerOpsLen = resp.body.log_len;
+    agendaLedgerOpsSig = sig;
+    if (changed) agendaRenderTab();
+  }).catch(() => {
+    agendaLedgerOpsInFlight = false;
+  });
+}
+
+// ---- Command palette entries (the shell ⌘K seam) ----
+// ui2PaletteEntries (ui2-chrome.js) concatenates this provider through a
+// typeof guard — the palette's documented convention for cross-fragment
+// state (read by name at event time). Two entry classes: lens
+// destinations derived from AGENDA_LENSES (never a mirrored list), and
+// item-title hits over the loaded agenda cache.
+function agendaPaletteEntries(query) {
+  const q = (query || '').trim().toLowerCase();
+  const entries = [];
+  if (typeof AGENDA_LENSES !== 'undefined') {
+    for (const lens of AGENDA_LENSES) {
+      const label = `Agenda: ${lens.label}`;
+      if (q && !label.toLowerCase().includes(q)) continue;
+      entries.push({
+        section: 'Agenda',
+        icon: 'agenda',
+        label,
+        hint: 'go',
+        run: () => {
+          agendaLens = lens.id;
+          routeTo('agenda');
+          agendaRenderTab();
+        },
+      });
+    }
+  }
+  if (q.length >= 2 && Array.isArray(agendaItems)) {
+    const scored = [];
+    for (const item of agendaItems) {
+      const score = ui2FuzzyScore(q, item.title);
+      if (score < 0) continue;
+      scored.push({ score, item });
+    }
+    scored.sort((a, b) => b.score - a.score);
+    for (const { item } of scored.slice(0, 9)) {
+      const title = String(item.title || '');
+      entries.push({
+        section: 'Agenda',
+        icon: 'agenda',
+        label: title.length > 44 ? `${title.slice(0, 43)}…` : title,
+        hint: `${item.kind} · ${item.status}`,
+        matchless: true,
+        run: () => {
+          routeTo('agenda');
+          agendaOpenInspector(item.id);
+        },
+      });
+    }
+  }
+  return entries;
+}

--- a/static/app/ui2-agenda-inspector.css
+++ b/static/app/ui2-agenda-inspector.css
@@ -1,7 +1,9 @@
-/* Agenda inspector + schedule/preview sheets + reminder-policy popover
-   (redesign slice A). Token palette only; scoped under html.ui-v2. The
-   inspector is an animated-width side panel ≥1180px and a fixed overlay
-   with a backdrop below that — same DOM, media-query switched. */
+/* Agenda inspector + schedule/preview/raw sheets + reminder-policy
+   popover (redesign slices A + D — slice D adds the under-the-hood
+   section and the raw-JSON sheet). Token palette only; scoped under
+   html.ui-v2. The inspector is an animated-width side panel ≥1180px and
+   a fixed overlay with a backdrop below that — same DOM, media-query
+   switched. */
 
 /* ---- Inspector shell ---- */
 
@@ -629,6 +631,267 @@ html.ui-v2 .ag2-insp-notetext {
   white-space: pre-wrap;
   overflow-wrap: anywhere;
   margin-top: 2px;
+}
+
+/* ---- Under the hood (slice D) ---- */
+
+html.ui-v2 .ag2-hood {
+  border-top: 1px solid var(--line);
+  padding-top: 12px;
+}
+html.ui-v2 .ag2-hood-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  padding: 0;
+  text-align: left;
+}
+html.ui-v2 .ag2-hood-title {
+  font-family: var(--mono);
+  font-size: var(--eyebrow-size);
+  font-weight: 700;
+  letter-spacing: var(--eyebrow-track);
+  text-transform: uppercase;
+  color: var(--text-3);
+}
+html.ui-v2 .ag2-hood-sub,
+html.ui-v2 .ag2-hood-chev {
+  font-size: 10.5px;
+  color: var(--text-3);
+}
+html.ui-v2 .ag2-hood-body {
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+html.ui-v2 .ag2-hood-card {
+  border: 1px solid var(--line);
+  border-radius: var(--r-ctl);
+  background: var(--surface);
+  padding: 10px 12px;
+}
+html.ui-v2 .ag2-hood-cardhead {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+html.ui-v2 .ag2-hood-eyebrow {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--text-3);
+}
+html.ui-v2 .ag2-hood-effid {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text-3);
+  overflow-wrap: anywhere;
+}
+html.ui-v2 .ag2-hood-idbtn {
+  display: inline-flex;
+  margin-top: 7px;
+  background: var(--code-bg);
+  border: 1px solid var(--line);
+  border-radius: var(--r-inset);
+  padding: 5px 10px;
+  cursor: pointer;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  overflow-wrap: anywhere;
+  text-align: left;
+}
+html.ui-v2 .ag2-hood-idbtn:hover { border-color: var(--line-2); }
+html.ui-v2 .ag2-hood-idbtn .t-time { color: var(--iris-2); }
+html.ui-v2 .ag2-hood-idbtn .t-rand { color: var(--text-3); }
+html.ui-v2 .ag2-hood-idbtn.digest {
+  color: var(--text-2);
+  letter-spacing: 0.08em;
+}
+html.ui-v2 .ag2-hood-note {
+  font-size: 10px;
+  color: var(--text-3);
+  margin-top: 5px;
+}
+html.ui-v2 .ag2-hood-note.mono {
+  font-family: var(--mono);
+  overflow-wrap: anywhere;
+}
+html.ui-v2 .ag2-hood-times {
+  display: flex;
+  gap: 16px;
+  margin-top: 9px;
+  flex-wrap: wrap;
+}
+html.ui-v2 .ag2-hood-time-k {
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-3);
+}
+html.ui-v2 .ag2-hood-time-v {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--text-2);
+  margin-top: 2px;
+}
+html.ui-v2 .ag2-hood-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 7px;
+  align-items: center;
+}
+html.ui-v2 .ag2-hood-vchip {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text-2);
+  background: var(--surface-3);
+  border-radius: 6px;
+  padding: 2px 7px;
+  white-space: nowrap;
+}
+html.ui-v2 .ag2-hood-source {
+  font-family: var(--mono);
+  font-size: 10px;
+  font-style: italic;
+  color: var(--text-3);
+  border: 1px dashed var(--line-2);
+  border-radius: 6px;
+  padding: 2px 7px;
+}
+html.ui-v2 .ag2-hood-session { margin-top: 6px; }
+html.ui-v2 .ag2-hood-sess {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  overflow-wrap: anywhere;
+}
+html.ui-v2 .ag2-hood-sess.plain { color: var(--text-3); }
+html.ui-v2 .ag2-hood-seal {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-top: 7px;
+  font-size: 11px;
+  font-weight: 700;
+}
+html.ui-v2 .ag2-hood-seal.t-green { color: var(--green); }
+html.ui-v2 .ag2-hood-seal.t-amber { color: var(--amber); }
+html.ui-v2 .ag2-hood-sealdot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
+html.ui-v2 .ag2-hood-streak {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-top: 8px;
+}
+html.ui-v2 .ag2-hood-streak .ag2-hood-note { margin: 0 0 0 4px; }
+html.ui-v2 .ag2-hood-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: 1.5px solid var(--line-2);
+  box-sizing: border-box;
+}
+html.ui-v2 .ag2-hood-dot.filled {
+  border: 0;
+  background: var(--rose);
+}
+html.ui-v2 .ag2-hood-occ {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text-3);
+  margin-top: 6px;
+  border-top: 1px solid var(--line);
+  padding-top: 6px;
+  overflow-wrap: anywhere;
+}
+html.ui-v2 .ag2-hood-rail {
+  margin: 9px 0 0 3px;
+  border-left: 1px solid var(--line);
+}
+html.ui-v2 .ag2-hood-tl-row {
+  position: relative;
+  padding: 0 0 9px 14px;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+html.ui-v2 .ag2-hood-tl-dot {
+  position: absolute;
+  left: -4px;
+  top: 3px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+}
+html.ui-v2 .ag2-hood-tl-dot.t-iris { background: var(--iris); }
+html.ui-v2 .ag2-hood-tl-dot.t-green { background: var(--green); }
+html.ui-v2 .ag2-hood-tl-dot.t-amber { background: var(--amber); }
+html.ui-v2 .ag2-hood-tl-dot.t-rose { background: var(--rose); }
+html.ui-v2 .ag2-hood-tl-dot.t-sky { background: var(--sky); }
+html.ui-v2 .ag2-hood-tl-dot.t-neutral { background: var(--neutral-dot); }
+html.ui-v2 .ag2-hood-tl-verb {
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--text-2);
+  overflow-wrap: anywhere;
+}
+html.ui-v2 .ag2-hood-tl-who {
+  font-size: 10.5px;
+  color: var(--text-3);
+  white-space: nowrap;
+}
+html.ui-v2 .ag2-hood-tl-t {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text-3);
+  white-space: nowrap;
+}
+html.ui-v2 .ag2-hood-more {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text-3);
+  margin-left: 17px;
+}
+html.ui-v2 .ag2-hood-foot {
+  display: flex;
+  gap: 7px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+html.ui-v2 .ag2-hood-footnote {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text-3);
+}
+html.ui-v2 .ag2-sheet-raw {
+  margin: 0;
+  background: var(--code-bg);
+  border: 1px solid var(--line);
+  border-radius: var(--r-ctl);
+  padding: 12px;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  line-height: 1.55;
+  color: var(--text-2);
+  overflow: auto;
+  max-height: 52vh;
 }
 
 /* ---- Modal sheets (schedule + preview) ---- */

--- a/static/app/ui2-agenda-inspector.js
+++ b/static/app/ui2-agenda-inspector.js
@@ -25,6 +25,7 @@ let agendaInspRefMust = false;
 function agendaOpenInspector(id) {
   if (!agendaFindItem(id)) return;
   agendaSelId = id;
+  agendaHoodReset(); // slice D: a fresh selection starts collapsed
   agendaInspEditingTitle = false;
   agendaInspEditingBody = false;
   agendaInspAdds = { blocker: false, dep: false, ref: false };
@@ -81,6 +82,7 @@ function agendaInspectorRender() {
         ${agendaInspOrganizationHtml(item)}
         ${agendaInspRefsHtml(item)}
         ${agendaInspThreadHtml(item)}
+        ${agendaHoodSectionHtml(item)}
       </div>
     </div>`;
   });
@@ -753,6 +755,12 @@ function agendaInspClick(e) {
     }, removeRef);
     return;
   }
+  const hoodAct = e.target.closest('[data-hood-act]');
+  if (hoodAct) {
+    // Under-the-hood section (slice D, ui2-agenda-hood.js).
+    agendaHoodClick(item, hoodAct);
+    return;
+  }
   const act = e.target.closest('[data-act]');
   if (!act) return;
   switch (act.dataset.act) {
@@ -1059,7 +1067,9 @@ function agendaSheetRender() {
   agendaRenderPreservingFocus(panel, () => {
     panel.innerHTML = agendaSheetState.kind === 'prev'
       ? agendaPrevSheetHtml(item)
-      : agendaSchedSheetHtml(item);
+      : agendaSheetState.kind === 'raw'
+        ? agendaRawSheetHtml(item) // slice D (ui2-agenda-hood.js)
+        : agendaSchedSheetHtml(item);
   });
   agendaHydratePreviewFrames(panel);
 }

--- a/static/app/ui2-chrome.js
+++ b/static/app/ui2-chrome.js
@@ -732,7 +732,12 @@ function ui2PaletteEntries(q) {
   const filtered = entries.filter((item) => !query || item.label.toLowerCase().includes(query));
   const actions = ui2PaletteActionEntries(q)
     .filter((item) => item.matchless || !query || item.label.toLowerCase().includes(query));
-  return [...filtered, ...ui2PaletteSessionEntries(query), ...ui2PaletteMessageEntries(query), ...actions];
+  // Agenda section (lens destinations + item hits): provided by
+  // ui2-agenda-hood.js under this fragment's convention — cross-fragment
+  // state is read by name at event time with a typeof guard, so the
+  // palette never depends on the agenda fragments being present.
+  const agenda = typeof agendaPaletteEntries === 'function' ? agendaPaletteEntries(query) : [];
+  return [...filtered, ...ui2PaletteSessionEntries(query), ...agenda, ...ui2PaletteMessageEntries(query), ...actions];
 }
 
 const ui2Palette = { open: false, selected: 0, entries: [] };


### PR DESCRIPTION
Final implementation slice of the owner-greenlit Agenda dashboard redesign: the inspector's Under-the-hood section, the raw-JSON sheet, the ledger's real ops count, and the shell palette's agenda entries — the dashboard's first consumer of the raw read routes `GET /api/agenda/ops` and `GET /api/agenda/occurrences` (tunnel twins `api_agenda_ops` / `api_agenda_occurrences`).

## Under the hood (inspector bottom, collapsible)

- **Identity** — the ULID as a copy button with the 10-char time prefix highlighted, the sort-order hint, and an absolute times grid (parked/updated/completed).
- **Born as** — the gate-attribution passport: actor class chip (mapped at the authenticated edge, never parsed from the request), verbatim principal chip, self-described `--source` rendered AS unverified (italic dashed, "via …"), the session line resolved through the sessions join map into a Sessions-tab link (unresolved ids degrade to the raw id, never an error), and the three-variant born note.
- **Manifest seal** (when an effect exists) — the digest in 4-char groups (click-copies), the green bound / amber unbound seal line, approval/proposal attribution, failure-streak dots against the manifest threshold, and the occurrence line read from the JOURNAL: the hood fetches `api_agenda_occurrences` filtered to the item, finds the latest record for the effect's `last_run.occurrence_id`, and falls back to fold fields with an honest label when the journal page holds nothing.
- **Ask internals** (questions) — ask id chip, per-preview blob chips with the attachment+nosniff route tooltip, dismissed chip, and the delivered true/false/unrecorded variants.
- **History** — the headline: the REAL op timeline from `api_agenda_ops` (item-filtered, bounded paging so the newest ops are always present), newest-first, latest 9 + "+ N earlier ops in the log". Verbs map the full 24-op vocabulary (`annotated · --source X`, `filed under "…"`, `approved — digest bound`, `run <state>`, `retired — hidden, never deleted`, …); `known:false` ops render honestly as `op · <type>` and unparseable lines as `unreadable line · preserved`. Who comes from the ENVELOPE's gate attribution via the shared actor-label helper; daemon-authored ops say "the daemon". Cached per item and refreshed when the open item's `updated_ms` moves (the agenda_changed merge is the trigger) — no polling; an errored cache never becomes a render→fetch loop.
- **Access** — the four static documentation chips (agenda.read / agenda.write / owner surface / settings.manage) with their tooltips.
- **Footer** — View raw item JSON, Copy ctl handle (`intendant ctl agenda annotate <6-char prefix> "…"`, any-unique-prefix tooltip), and the nothing-deletes note.

## Raw-JSON sheet

Modal like the schedule/preview sheets (same host, kind `raw`): the served item DTO with nulls and empty arrays stripped, pretty-printed in a capped mono pre. The footer line applies the truthful-labels correction: "Exactly what GET /api/agenda serves — the fold product of agenda.jsonl plus the planner's display-only decorations (next_fire_ms, deferred_until). Nothing here is stored state beyond the ops."

## Ledger ops count

The tab footer now renders `· N ops in the log` from a `limit:1` ops page's `log_len`, between the counts and the skipped-lines segment. Fetch-on-render lifecycle: only while the tab is visible and only when the data signature (counts + max updated_ms) moved; failures remember the signature so an unsupported daemon is never re-polled per repaint. No timers.

## Palette seam

The shell palette had no provider registry — each section is a hard-wired function concatenated in `ui2PaletteEntries`, and its documented convention is "cross-fragment state is read by name at event time with typeof guards" (the `window.intendantLayouts` contract is the precedent). The smallest honest seam follows exactly that: one typeof-guarded `agendaPaletteEntries(query)` concatenation. The provider (in the hood fragment) serves an Agenda section: lens destinations derived from `AGENDA_LENSES` (never a mirrored list — a future lens lands in the palette automatically) and, when the agenda cache is loaded, fuzzy item-title hits (top 9, `kind · status` meta, open the inspector). No per-tab ⌘K handler was added.

## daemonApi twin rows (the one .rs touch)

The client facade's `DAEMON_API_HTTP_MAP` never carried `api_agenda_ops` / `api_agenda_occurrences` — the routes had no dashboard consumer until this slice, so every hood/ledger fetch failed at the facade. The two GET rows land with their since/item/limit query mapping, and the pinned coverage set in `daemon_api_http_map_mirrors_gateway_routes` (dashboard_control/mod.rs) is extended deliberately, as that test instructs.

## Battery

- `node --check` on all touched fragments; assembler regen committed
- `cargo test -p intendant --bins` green (all three bin suites); `cargo fmt --check` clean; `cargo clippy --workspace -- -D warnings` clean (a .rs file was touched)
- Rig: slice-C's seeded ledger relaunched on the slice-D binary, plus a triage-labeled annotation and a fast-firing approved one-shot so the occurrence journal holds a real record (`run failed` — the mock rig's honest spawn refusal) — screenshots of the expanded hood (real history + seal + journal-backed occurrence line + the ledger's "15 ops in the log"), the raw sheet with the corrected footer line, and the palette's Agenda section (all seven lens rows + the item hit with kind · status meta).
