### PR TITLE
fix(dashboard): add Vault sign-in CTA to the unfueled launch card and New Session banner

### DIFF
--- a/static/app/13-styles-sessions-terminal.css
+++ b/static/app/13-styles-sessions-terminal.css
@@ -666,6 +666,11 @@
 .sessions-spawn-action:hover {
   background: color-mix(in srgb, var(--blue) 28%, var(--surface0));
 }
+/* With peer actions (Add API keys + Sign in an agent) only the first
+   carries the auto margin, so the pair sits together on the right. */
+.sessions-spawn-action ~ .sessions-spawn-action {
+  margin-left: 0;
+}
 .sessions-unfueled-banner {
   display: flex;
   align-items: center;
@@ -682,10 +687,14 @@
 .sessions-unfueled-banner.hidden {
   display: none;
 }
-.sessions-unfueled-add-keys {
+.sessions-unfueled-add-keys,
+.sessions-unfueled-signin {
   flex: none;
-  margin-left: auto;
   white-space: nowrap;
+}
+/* First of the peer pair right-aligns the group. */
+.sessions-unfueled-add-keys {
+  margin-left: auto;
 }
 .sessions-host-strip {
   display: flex;

--- a/static/app/20-shell.html
+++ b/static/app/20-shell.html
@@ -1747,6 +1747,7 @@
                 <div id="new-session-unfueled-banner" class="sessions-unfueled-banner hidden">
                   <span class="sessions-unfueled-text">No model credentials on this daemon &mdash; the internal agent can&rsquo;t start. External agents (Codex, Claude Code, Kimi Code, Pi) sign in with their own accounts and still work.</span>
                   <button type="button" class="ui-btn sessions-unfueled-add-keys" onclick="focusSettingsApiKeys()">Add API keys</button>
+                  <button type="button" class="ui-btn sessions-unfueled-signin" onclick="focusVaultAgentSignin()">Sign in an agent</button>
                 </div>
                 <details class="ui-fold sessions-new-external-fold" id="new-session-external-fold">
                   <summary>External agent options</summary>

--- a/static/app/34-station-panes.js
+++ b/static/app/34-station-panes.js
@@ -312,7 +312,7 @@ async function stationStartSession() {
   const launchAgent = stationEffectiveLaunchAgent();
   if ((launchAgent === 'internal' || !launchAgent) && daemonInternalUnfueled()) {
     showControlToast?.('error', NEW_SESSION_UNFUELED_MESSAGE);
-    setNewSessionSpawnNotice('error', NEW_SESSION_UNFUELED_MESSAGE, newSessionAddKeysAction());
+    setNewSessionSpawnNotice('error', NEW_SESSION_UNFUELED_MESSAGE, newSessionUnfueledActions());
     stationOpenPanel?.('system:controls', 'Internal launch needs credentials');
     return;
   }

--- a/static/app/55b-session-launch.js
+++ b/static/app/55b-session-launch.js
@@ -676,6 +676,17 @@ function newSessionAddKeysAction() {
   return { label: 'Add API keys', onClick: () => focusSettingsApiKeys() };
 }
 
+function newSessionSigninAction() {
+  return { label: 'Sign in an agent', onClick: () => focusVaultAgentSignin() };
+}
+
+// The unfueled remediations, as peers (the Activity empty state's pair):
+// add a provider API key, or sign an external agent into its subscription
+// account in the Vault tab.
+function newSessionUnfueledActions() {
+  return [newSessionAddKeysAction(), newSessionSigninAction()];
+}
+
 // Leads with the immediate fix (the paired newSessionAddKeysAction deep
 // link lands on that card); .env and vault leases stay as secondary paths.
 const NEW_SESSION_UNFUELED_MESSAGE =
@@ -872,20 +883,20 @@ function setNewSessionSpawnNotice(kind, text, action) {
   notice.className = `sessions-spawn-notice ${noticeKind}` + (hasText ? '' : ' hidden');
   textEl.textContent = text || '';
   notice.title = text || '';
-  let actionBtn = document.getElementById('new-session-spawn-action');
-  if (action && hasText) {
-    if (!actionBtn) {
-      actionBtn = document.createElement('button');
-      actionBtn.id = 'new-session-spawn-action';
-      actionBtn.type = 'button';
-      actionBtn.className = 'sessions-spawn-action';
-      notice.appendChild(actionBtn);
-    }
-    actionBtn.textContent = action.label;
-    actionBtn.onclick = action.onClick;
-  } else if (actionBtn) {
-    actionBtn.remove();
-  }
+  // `action` is one {label, onClick} or an array of peers (the unfueled
+  // class pairs Add API keys with Sign in an agent). Buttons are rebuilt
+  // per notice — updates are event-driven, never per-frame.
+  const actions = hasText ? [action].flat().filter(Boolean) : [];
+  notice.querySelectorAll('.sessions-spawn-action').forEach(btn => btn.remove());
+  actions.forEach((entry, index) => {
+    const actionBtn = document.createElement('button');
+    actionBtn.id = index === 0 ? 'new-session-spawn-action' : `new-session-spawn-action-${index + 1}`;
+    actionBtn.type = 'button';
+    actionBtn.className = 'sessions-spawn-action';
+    actionBtn.textContent = entry.label;
+    actionBtn.onclick = entry.onClick;
+    notice.appendChild(actionBtn);
+  });
   stationScheduleUpdate();
 }
 
@@ -945,9 +956,9 @@ function maybeFailRecentNewSessionSpawn(sessionId, reason, errorKind) {
   newSessionSpawnTask = '';
   newSessionSpawnName = '';
   setNewSessionStartButtonPending(false);
-  // Structured failure classes carry an action instead of prose-parsing.
+  // Structured failure classes carry actions instead of prose-parsing.
   const action = errorKind === 'unfueled'
-    ? newSessionAddKeysAction()
+    ? newSessionUnfueledActions()
     : errorKind === 'no_project'
       ? newSessionPickProjectAction()
       : null;
@@ -1074,7 +1085,7 @@ async function startNewSession() {
     // Belt-and-braces behind the banner: the fueled flag may have flipped
     // since the last render.
     updateNewSessionFuelBanner();
-    setNewSessionSpawnNotice('error', NEW_SESSION_UNFUELED_MESSAGE, newSessionAddKeysAction());
+    setNewSessionSpawnNotice('error', NEW_SESSION_UNFUELED_MESSAGE, newSessionUnfueledActions());
     return;
   }
 

--- a/static/app/ui2-sessions.css
+++ b/static/app/ui2-sessions.css
@@ -1094,7 +1094,8 @@ html.ui-v2 #tab-sessions .sessions-unfueled-banner::before {
   box-shadow: 0 0 0 3px rgba(var(--amber-rgb), .14);
   animation: ui2-pulse 2s infinite;
 }
-html.ui-v2 #tab-sessions .sessions-unfueled-add-keys {
+html.ui-v2 #tab-sessions .sessions-unfueled-add-keys,
+html.ui-v2 #tab-sessions .sessions-unfueled-signin {
   border: 0;
   border-radius: 8px;
   padding: 7px 14px;
@@ -1102,7 +1103,8 @@ html.ui-v2 #tab-sessions .sessions-unfueled-add-keys {
   color: var(--on-accent);
   font-weight: 800;
 }
-html.ui-v2 #tab-sessions .sessions-unfueled-add-keys:hover:not(:disabled) {
+html.ui-v2 #tab-sessions .sessions-unfueled-add-keys:hover:not(:disabled),
+html.ui-v2 #tab-sessions .sessions-unfueled-signin:hover:not(:disabled) {
   background: var(--amber);
   border-color: transparent;
   filter: brightness(1.08);


### PR DESCRIPTION
Give the two remaining unfueled surfaces the Activity empty state's peer
pair (#584): alongside 'Add API keys', a 'Sign in an agent' button that
deep-links to the Vault tab's 'Agent accounts — this daemon' section via
focusVaultAgentSignin().

- setNewSessionSpawnNotice now accepts one action or an array of peers,
  rebuilding the .sessions-spawn-action buttons per notice; the unfueled
  class (Sessions preflight, Station launch preflight, and the structured
  launch-failure path) passes both remediations. Single-action callers
  are unchanged.
- The New Session modal's unfueled banner gains the same second button;
  the peer pair right-aligns as a group in both CSS generations.

Neither surface knows per-agent sign-in posture, so no posture copy is
added here — the CTA is the affordance.
