### PR TITLE
polish(dashboard): agenda graph copy says link, not edge (owner vocabulary)

### DIFF
--- a/docs/src/agenda-and-memory.md
+++ b/docs/src/agenda-and-memory.md
@@ -196,8 +196,8 @@ operations in the same append-only log:
   with the clearing actor. Setting and clearing are plain `agenda.write`
   acts; the housekeeping mandate governs agent *conduct* (agents without a
   mandate annotate with evidence instead of clearing), not capability.
-- **Dependencies** (`add_relies_on` / `remove_relies_on`) draw edges to
-  other items. A completed prerequisite satisfies the edge by pure
+- **Dependencies** (`add_relies_on` / `remove_relies_on`) draw links to
+  other items. A completed prerequisite satisfies the link by pure
   recomputation at read time; a **retired** prerequisite does not silently
   satisfy — the dependent renders "prerequisite retired — review"; a target
   missing from the fold renders "prerequisite missing"; cycles simply render
@@ -247,7 +247,7 @@ the preview blob store remains exclusively Ask-v2's (pinned in
 
 ### The graph: placement and adjacency (G2)
 
-Two more edge vocabularies make the agenda navigable, both ordinary
+Two more link vocabularies make the agenda navigable, both ordinary
 attributed ops, both **pure navigation**:
 
 - **`part_of`** (`add_part_of` / `remove_part_of`, plus the atomic `place`
@@ -261,9 +261,9 @@ attributed ops, both **pure navigation**:
   flags are all derived at render from the ordinary snapshot.
 - **`relates_to`** (`add_relates_to` / `remove_relates_to`) — untyped
   see-also adjacency: stored directed (the writer's item carries the
-  edge), rendered as the undirected union, deduped in both directions at
+  link), rendered as the undirected union, deduped in both directions at
   intake; removal names the pair in either order and the daemon resolves
-  the stored side. Capped at 32 stored edges per item.
+  the stored side. Capped at 32 stored links per item.
 
 **Two rules are pinned.** *Anti-hiding:* a `part_of` placement never
 removes an item from the flat recent lens — grouping is an opt-in reorder
@@ -587,7 +587,7 @@ share a project, park ONE hub note titled after the project, place them
 under it, and annotate the hub "triage: hub for <project>" so it leaves
 the frontier too; a singleton with no matching hub stays unplaced —
 annotate it "triage: no placement — standalone" so it leaves the
-frontier. Add relates_to edges only where reading the items shows a
+frontier. Add relates_to links only where reading the items shows a
 real working relation. Attach refs you can substantiate (the brief file
 an item's body names, the PR its title cites) — never guess a locator.
 

--- a/skills/intendant-agenda/SKILL.md
+++ b/skills/intendant-agenda/SKILL.md
@@ -52,13 +52,13 @@ dashboard, attributed to your session.
 "$INTENDANT" ctl agenda schedule 01KX --goal "Weekly housekeeping pass" --at "+1d" --every 7d   # STANDING: one approval covers the series
 "$INTENDANT" ctl agenda annotate 01KX "Tried the vendor API — still 403; evidence in run 88."
 "$INTENDANT" ctl agenda block 01KX "gpt-live-1 available on the API (currently app-only)"
-"$INTENDANT" ctl agenda relies-on 01KX 01KY    # 01KX waits on 01KY (--remove drops the edge)
+"$INTENDANT" ctl agenda relies-on 01KX 01KY    # 01KX waits on 01KY (--remove drops the link)
 "$INTENDANT" ctl agenda list --blocked         # open items with uncleared blockers / unmet deps
 "$INTENDANT" ctl agenda ref 01KX ~/brief.md --must-read --label "kickoff brief"   # typed pointer, never content
 "$INTENDANT" ctl agenda ref 01KX https://github.com/org/repo/pull/42              # url ref (type inferred)
 "$INTENDANT" ctl agenda add "Finish the soak review" --ref ~/soak-notes.md --must-read   # attach at park time
 "$INTENDANT" ctl agenda place 01KX --under 01KH   # file under a hub (re-parents atomically; --remove unplaces)
-"$INTENDANT" ctl agenda relates 01KX 01KY         # untyped see-also edge (--remove drops it)
+"$INTENDANT" ctl agenda relates 01KX 01KY         # untyped see-also link (--remove drops it)
 "$INTENDANT" ctl agenda list --under 01KH         # the hub's placed subtree
 ```
 
@@ -108,7 +108,7 @@ dashboard, attributed to your session.
   note to any item (the thread under it — progress, evidence, context for
   whoever picks it up). `block` states a human criterion on an open item;
   **nothing evaluates it** — it renders a blocked chip until cleared.
-  `relies-on` draws an edge to a prerequisite item; a completed
+  `relies-on` draws a link to a prerequisite item; a completed
   prerequisite satisfies it automatically at read time, a retired one
   flags the dependent for review. `list --blocked` filters the gated set.
 
@@ -122,7 +122,7 @@ dashboard, attributed to your session.
 
 - **The graph is navigation, never semantics**: `place` files an item
   under a hub (a hub is just an item with children — the program/project
-  item you'd naturally park anyway), `relates` draws a see-also edge.
+  item you'd naturally park anyway), `relates` draws a see-also link.
   One live parent; placement never hides an item from the flat list,
   never blocks a hub when a child is blocked, never completes anything.
   Filing your item under the program hub you're working helps the owner

--- a/src/bin/caller/agenda/store.rs
+++ b/src/bin/caller/agenda/store.rs
@@ -1310,7 +1310,7 @@ impl AgendaStore {
                     return Err(AgendaError::Invalid("an item cannot rely on itself".into()));
                 }
                 // The target must exist NOW (intake strictness); the fold
-                // stays tolerant of dangling edges in foreign logs.
+                // stays tolerant of dangling links in foreign logs.
                 self.require(&target_id)?;
                 if item.relies_on.iter().any(|e| e.target_id == target_id) {
                     return Err(AgendaError::Transition(format!(
@@ -1417,7 +1417,7 @@ impl AgendaStore {
             } => {
                 let target_id = target_id.trim().to_string();
                 let item = self.require(&id)?;
-                // Resolve which side stores the edge — callers name the
+                // Resolve which side stores the link — callers name the
                 // pair in either order; the op names the storing item.
                 if item.relates_to.iter().any(|e| e.target_id == target_id) {
                     Ok(AgendaOp::RemoveRelatesTo { id, target_id })
@@ -2603,7 +2603,7 @@ mod tests {
 
     /// F2 intake strictness + persistence: the five thread/gate verbs
     /// validate at intake (empty/oversized text, non-open items for
-    /// set_blocker/add_relies_on, duplicates, self-edges, missing targets,
+    /// set_blocker/add_relies_on, duplicates, self-links, missing targets,
     /// caps), mint blocker ids server-side, and the folded state survives
     /// a store reopen. The forward-compat property (older builds
     /// skip-and-preserve unknown vocabulary) keeps holding for whatever
@@ -2700,7 +2700,7 @@ mod tests {
             Err(AgendaError::Invalid(_))
         ));
 
-        // AddReliesOn: self-edge, missing target, duplicate all refused.
+        // AddReliesOn: self-link, missing target, duplicate all refused.
         assert!(matches!(
             store.apply_command(
                 AgendaCommand::AddReliesOn {
@@ -2751,7 +2751,7 @@ mod tests {
 
         // ClearBlocker resolves a unique prefix to the full id at intake
         // (the durable op carries the exact id); RemoveReliesOn needs a
-        // live edge.
+        // live link.
         let cleared = store
             .apply_command(
                 AgendaCommand::ClearBlocker {
@@ -2838,7 +2838,7 @@ mod tests {
             .unwrap();
 
         // Reopen the store: thread, blocker history (cleared entry kept),
-        // and the removed edge all replay exactly.
+        // and the removed link all replay exactly.
         drop(store);
         let store = AgendaStore::open(dir.path()).unwrap();
         let a_re = store.get(&a.id).unwrap();
@@ -3607,7 +3607,7 @@ mod tests {
             .unwrap_err();
         assert!(err.to_string().contains("already related"));
         // Removal named in the OPPOSITE order still resolves the stored
-        // side; the view edge disappears from the storing item.
+        // side; the view link disappears from the storing item.
         store
             .apply_command(
                 AgendaCommand::RemoveRelatesTo {

--- a/src/bin/caller/agenda/types.rs
+++ b/src/bin/caller/agenda/types.rs
@@ -1958,9 +1958,9 @@ pub(crate) fn apply_op(
 #[cfg(test)]
 pub(crate) fn dependency_state(
     items: &BTreeMap<String, AgendaItem>,
-    edge: &AgendaDependency,
+    link: &AgendaDependency,
 ) -> (bool, Option<&'static str>) {
-    match items.get(&edge.target_id) {
+    match items.get(&link.target_id) {
         None => (false, Some("target_missing")),
         Some(target) => match target.status {
             AgendaStatus::Done => (true, None),
@@ -1980,7 +1980,7 @@ pub(crate) fn is_blocked(items: &BTreeMap<String, AgendaItem>, item: &AgendaItem
             || item
                 .relies_on
                 .iter()
-                .any(|edge| !dependency_state(items, edge).0))
+                .any(|link| !dependency_state(items, link).0))
 }
 
 pub(crate) fn counts(items: &BTreeMap<String, AgendaItem>) -> AgendaCounts {
@@ -2621,7 +2621,7 @@ mod tests {
     /// clear-is-an-op history, links with add/remove, and full tolerance
     /// for out-of-order or foreign lines.
     #[test]
-    fn f2_fold_annotations_blockers_edges() {
+    fn f2_fold_annotations_blockers_links() {
         let mut items = BTreeMap::new();
         apply_op(&mut items, &rec(1, add("a", "dependent")));
         apply_op(&mut items, &rec(2, add("b", "prerequisite")));

--- a/src/bin/caller/agenda/types.rs
+++ b/src/bin/caller/agenda/types.rs
@@ -18,7 +18,7 @@ pub(crate) const MAX_ANNOTATIONS_PER_ITEM: usize = 500;
 pub(crate) const MAX_UNCLEARED_BLOCKERS_PER_ITEM: usize = 32;
 pub(crate) const MAX_RELIES_ON_PER_ITEM: usize = 32;
 pub(crate) const MAX_CRITERION_CHARS: usize = 1000;
-/// G2 caps (steward-ruled 2026-07-22). Adjacency follows the edges idiom;
+/// G2 caps (steward-ruled 2026-07-22). Adjacency follows the links idiom;
 /// the children cap is a pathology rail like annotations (project hubs
 /// legitimately accrue hundreds of children — 32 would strangle the
 /// primary intended use), and the depth cap keeps the tree a working
@@ -26,7 +26,7 @@ pub(crate) const MAX_CRITERION_CHARS: usize = 1000;
 pub(crate) const MAX_RELATES_TO_PER_ITEM: usize = 32;
 pub(crate) const MAX_PART_OF_DEPTH: usize = 16;
 pub(crate) const MAX_CHILDREN_PER_HUB: usize = 500;
-/// G1 caps (steward-ruled 2026-07-22). Refs follow the blockers/edges
+/// G1 caps (steward-ruled 2026-07-22). Refs follow the blockers/links
 /// idiom; locator bounds are per-type (paths, opaque ids, urls).
 pub(crate) const MAX_REFS_PER_ITEM: usize = 32;
 pub(crate) const MAX_REF_LABEL_CHARS: usize = 100;
@@ -509,7 +509,7 @@ pub struct AgendaItem {
     /// Cleared entries STAY as the evidence trail — clears are ops.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(crate) blockers: Vec<AgendaBlocker>,
-    /// Live dependency edges (F2 `relies_on`). Removal drops the edge from
+    /// Live dependency links (F2 `relies_on`). Removal drops the link from
     /// this view; the log keeps the full add/remove history. Satisfaction
     /// and the blocked chip are derived at RENDER time, never stored or
     /// wired.
@@ -527,7 +527,7 @@ pub struct AgendaItem {
     /// never hides an item from the flat recent lens (anti-hiding rule).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) part_of: Option<AgendaPlacement>,
-    /// Stored adjacency edges (G2 `add_relates_to`), this item's side
+    /// Stored adjacency links (G2 `add_relates_to`), this item's side
     /// only — surfaces render the undirected union.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(crate) relates_to: Vec<AgendaRelation>,
@@ -604,7 +604,7 @@ pub struct AgendaBlockerClear {
     pub(crate) source: Option<String>,
 }
 
-/// One live dependency edge (F2 `relies_on` fold view). Satisfaction is
+/// One live dependency link (F2 `relies_on` fold view). Satisfaction is
 /// derived at render time from the target's status — a completed target
 /// satisfies; a retired target does NOT silently satisfy (renders a
 /// "prerequisite retired — review" marker); cycles simply render every
@@ -644,7 +644,7 @@ pub struct AgendaPlacement {
     pub(crate) source: Option<String>,
 }
 
-/// One stored adjacency edge (G2 `add_relates_to` fold view): untyped,
+/// One stored adjacency link (G2 `add_relates_to` fold view): untyped,
 /// purely navigational — nothing derives, evaluates, blocks, or fires
 /// from adjacency, ever. Stored directed (the writer's item carries it),
 /// rendered undirected and deduped by every surface.
@@ -692,11 +692,11 @@ impl AgendaRefType {
 /// One live typed reference (G1 `add_ref` fold view): a TYPED POINTER,
 /// never content — no blobs, no copies, no uploads; the agenda points, it
 /// does not store. Addressed by `(ref_type, locator)` — no minted id,
-/// exactly as `relies_on` edges are addressed by `target_id`; changing
+/// exactly as `relies_on` links are addressed by `target_id`; changing
 /// `must_read` or `label` is remove+add (history honest). Locators and
 /// labels are data, never instructions to whoever reads them; a
 /// `must_read` is a pointer the reading agent weighs, not a standing
-/// order. Item-to-item links are NOT refs — that is G2's edge vocabulary.
+/// order. Item-to-item links are NOT refs — that is G2's link vocabulary.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AgendaRef {
     pub(crate) ref_type: AgendaRefType,
@@ -918,7 +918,7 @@ pub enum AgendaCommand {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         source: Option<String>,
     },
-    /// Add a dependency edge: this item relies on `target_id`.
+    /// Add a dependency link: this item relies on `target_id`.
     /// Satisfaction is derived at render time from the target's status —
     /// nothing evaluates, nothing fires.
     AddReliesOn {
@@ -927,7 +927,7 @@ pub enum AgendaCommand {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         source: Option<String>,
     },
-    /// Remove a live dependency edge (an op; the log keeps history).
+    /// Remove a live dependency link (an op; the log keeps history).
     RemoveReliesOn {
         id: String,
         target_id: String,
@@ -962,7 +962,7 @@ pub enum AgendaCommand {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         source: Option<String>,
     },
-    /// Add an undirected adjacency edge (stored on this item). Purely
+    /// Add an undirected adjacency link (stored on this item). Purely
     /// navigational.
     AddRelatesTo {
         id: String,
@@ -970,7 +970,7 @@ pub enum AgendaCommand {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         source: Option<String>,
     },
-    /// Remove an adjacency edge. The daemon resolves which side stores
+    /// Remove an adjacency link. The daemon resolves which side stores
     /// it — callers name the pair in either order.
     RemoveRelatesTo {
         id: String,
@@ -1178,12 +1178,12 @@ pub(crate) enum AgendaOp {
         id: String,
         blocker_id: String,
     },
-    /// Dependency edge added (F2).
+    /// Dependency link added (F2).
     AddReliesOn {
         id: String,
         target_id: String,
     },
-    /// Dependency edge removed (F2): drops the view edge; history stays.
+    /// Dependency link removed (F2): drops the view link; history stays.
     RemoveReliesOn {
         id: String,
         target_id: String,
@@ -1200,12 +1200,12 @@ pub(crate) enum AgendaOp {
         id: String,
         parent_id: String,
     },
-    /// Adjacency edge added (G2), stored on `id`'s side.
+    /// Adjacency link added (G2), stored on `id`'s side.
     AddRelatesTo {
         id: String,
         target_id: String,
     },
-    /// Adjacency edge removed (G2).
+    /// Adjacency link removed (G2).
     RemoveRelatesTo {
         id: String,
         target_id: String,
@@ -1476,13 +1476,13 @@ pub(crate) fn apply_op(
                 return Some(format!("add_relies_on for unknown {id} ignored"));
             };
             if target_id == id {
-                return Some(format!("self-edge on {id} ignored"));
+                return Some(format!("self-link on {id} ignored"));
             }
             if item.relies_on.iter().any(|e| e.target_id == *target_id) {
-                return Some(format!("duplicate edge {id}→{target_id} ignored"));
+                return Some(format!("duplicate link {id}→{target_id} ignored"));
             }
             // A target missing from this fold (partial/foreign replay) is
-            // tolerated — the render marks the edge "prerequisite missing".
+            // tolerated — the render marks the link "prerequisite missing".
             let actor = rec.actor.clone().unwrap_or_default();
             item.relies_on.push(AgendaDependency {
                 target_id: target_id.clone(),
@@ -1503,7 +1503,7 @@ pub(crate) fn apply_op(
             item.relies_on.retain(|e| e.target_id != *target_id);
             if item.relies_on.len() == before {
                 return Some(format!(
-                    "remove_relies_on for absent edge {id}→{target_id} ignored"
+                    "remove_relies_on for absent link {id}→{target_id} ignored"
                 ));
             }
             item.updated_ms = at_ms;
@@ -1942,7 +1942,7 @@ pub(crate) fn apply_op(
     }
 }
 
-/// Render-time judgment of one dependency edge: `(satisfied, review)`.
+/// Render-time judgment of one dependency link: `(satisfied, review)`.
 /// A completed target satisfies; a retired target does NOT silently
 /// satisfy (review `"target_retired"`); a target absent from the fold —
 /// foreign/partial replay — is review `"target_missing"`. Direct status
@@ -2618,7 +2618,7 @@ mod tests {
     }
 
     /// F2 fold: annotations thread (any status), blockers with
-    /// clear-is-an-op history, edges with add/remove, and full tolerance
+    /// clear-is-an-op history, links with add/remove, and full tolerance
     /// for out-of-order or foreign lines.
     #[test]
     fn f2_fold_annotations_blockers_edges() {
@@ -2717,7 +2717,7 @@ mod tests {
         assert!(apply_op(&mut items, &clear).is_some(), "double clear warns");
         assert_eq!(items["a"].blockers.len(), 1, "history is never deleted");
 
-        // Edges: add, self-edge warn, duplicate warn, remove drops the
+        // Links: add, self-link warn, duplicate warn, remove drops the
         // view (log history is the caller's record).
         assert!(apply_op(
             &mut items,
@@ -2788,7 +2788,7 @@ mod tests {
                 )
             )
             .is_some(),
-            "removing an absent edge warns"
+            "removing an absent link warns"
         );
         assert_eq!(items["a"].relies_on.len(), 1);
         assert_eq!(items["a"].relies_on[0].target_id, "b");
@@ -2960,7 +2960,7 @@ mod tests {
         );
         assert!(is_blocked(&items, &items["a"]));
 
-        // Dangling edge (foreign/partial log): review, blocked, no error.
+        // Dangling link (foreign/partial log): review, blocked, no error.
         apply_op(
             &mut items,
             &rec(

--- a/static/app/ui2-agenda-graph.js
+++ b/static/app/ui2-agenda-graph.js
@@ -39,7 +39,7 @@ const AGENDA_GRAPH_SETTLE_ITERATIONS = 260;
 // level so re-renders (inspector open, event-lane merges) never reset
 // the orbit or re-scatter surviving nodes.
 let agendaGraphNodes = [];
-let agendaGraphEdges = [];
+let agendaGraphLinks = [];
 let agendaGraphKey = '';
 let agendaGraphSettleLeft = 0;
 let agendaGraphRaf = null;
@@ -272,7 +272,7 @@ function agendaGraphTeardown() {
 
 // ---- Layout (topology-keyed force relaxation) ----
 
-// Rebuild nodes/edges only when the topology key changes; surviving
+// Rebuild nodes/links only when the topology key changes; surviving
 // nodes keep their positions and the settle budget re-arms so the new
 // shape relaxes in over the following frames.
 function agendaGraphBuild() {
@@ -298,27 +298,27 @@ function agendaGraphBuild() {
     };
   });
   const idx = new Map(agendaGraphNodes.map((n, i) => [n.id, i]));
-  const edges = [];
+  const links = [];
   const seenRel = new Set();
   items.forEach((x) => {
     if (x.part_of && idx.has(x.part_of.parent_id)) {
-      edges.push({ a: idx.get(x.id), b: idx.get(x.part_of.parent_id), t: 'place' });
+      links.push({ a: idx.get(x.id), b: idx.get(x.part_of.parent_id), t: 'place' });
     }
-    (x.relies_on || []).forEach((edge) => {
-      if (idx.has(edge.target_id)) {
-        edges.push({ a: idx.get(x.id), b: idx.get(edge.target_id), t: 'dep' });
+    (x.relies_on || []).forEach((link) => {
+      if (idx.has(link.target_id)) {
+        links.push({ a: idx.get(x.id), b: idx.get(link.target_id), t: 'dep' });
       }
     });
     // relates_to renders undirected: dedupe the two stored directions.
-    (x.relates_to || []).forEach((edge) => {
-      if (!idx.has(edge.target_id)) return;
-      const pair = [x.id, edge.target_id].sort().join(':');
+    (x.relates_to || []).forEach((link) => {
+      if (!idx.has(link.target_id)) return;
+      const pair = [x.id, link.target_id].sort().join(':');
       if (seenRel.has(pair)) return;
       seenRel.add(pair);
-      edges.push({ a: idx.get(x.id), b: idx.get(edge.target_id), t: 'rel' });
+      links.push({ a: idx.get(x.id), b: idx.get(link.target_id), t: 'rel' });
     });
   });
-  agendaGraphEdges = edges;
+  agendaGraphLinks = links;
   agendaGraphSettleLeft = AGENDA_GRAPH_SETTLE_ITERATIONS;
   return items;
 }
@@ -333,7 +333,7 @@ function agendaGraphSettleBudget(count) {
 
 function agendaGraphRelax(iterations) {
   const nodes = agendaGraphNodes;
-  const edges = agendaGraphEdges;
+  const links = agendaGraphLinks;
   for (let it = 0; it < iterations; it++) {
     for (let i = 0; i < nodes.length; i++) {
       for (let j = i + 1; j < nodes.length; j++) {
@@ -350,11 +350,11 @@ function agendaGraphRelax(iterations) {
         B[0] -= dx * f; B[1] -= dy * f; B[2] -= dz * f;
       }
     }
-    edges.forEach((edge) => {
-      const A = nodes[edge.a].p;
-      const B = nodes[edge.b].p;
-      const rest = edge.t === 'place' ? 74 : edge.t === 'dep' ? 96 : 116;
-      const k = edge.t === 'place' ? 0.014 : 0.007;
+    links.forEach((link) => {
+      const A = nodes[link.a].p;
+      const B = nodes[link.b].p;
+      const rest = link.t === 'place' ? 74 : link.t === 'dep' ? 96 : 116;
+      const k = link.t === 'place' ? 0.014 : 0.007;
       const dx = B[0] - A[0];
       const dy = B[1] - A[1];
       const dz = B[2] - A[2];
@@ -470,21 +470,21 @@ function agendaGraphDraw(ts) {
       childCount.set(x.part_of.parent_id, (childCount.get(x.part_of.parent_id) || 0) + 1);
     }
   });
-  // Edges under nodes: placement solid iris, see-also dashed neutral,
+  // Links under nodes: placement solid iris, see-also dashed neutral,
   // waits-on rose with the animated dash (static under reduced motion).
-  agendaGraphEdges.forEach((edge) => {
-    const a = pts[edge.a];
-    const b = pts[edge.b];
+  agendaGraphLinks.forEach((link) => {
+    const a = pts[link.a];
+    const b = pts[link.b];
     const depth = Math.max(0.25, Math.min(1, ((a.s + b.s) / 2) * 1.1 - 0.18));
-    const hot = hover && (nodes[edge.a].id === hover || nodes[edge.b].id === hover);
+    const hot = hover && (nodes[link.a].id === hover || nodes[link.b].id === hover);
     g.beginPath();
     g.moveTo(a.x, a.y);
     g.lineTo(b.x, b.y);
-    if (edge.t === 'place') {
+    if (link.t === 'place') {
       g.setLineDash([]);
       g.strokeStyle = `rgba(${pal.iris},${depth * (hot ? 0.75 : 0.38)})`;
       g.lineWidth = hot ? 1.6 : 1.1;
-    } else if (edge.t === 'rel') {
+    } else if (link.t === 'rel') {
       g.setLineDash([3, 5]);
       g.lineDashOffset = 0;
       g.strokeStyle = `rgba(${pal.text},${depth * (hot ? 0.5 : 0.16)})`;

--- a/static/app/ui2-agenda-inspector.js
+++ b/static/app/ui2-agenda-inspector.js
@@ -452,12 +452,12 @@ function agendaInspGatesHtml(item) {
       ${target
     ? `<a class="ag2-insp-deplink" data-open-item="${escapeHtml(target.id)}">waits on “${escapeHtml(title)}”</a>`
     : `<span class="ag2-insp-deplink">waits on ${escapeHtml(title)}</span>`}
-      <button type="button" class="ag2-x" data-remove-dep="${escapeHtml(d.target_id)}" title="Drop the edge (the log keeps history)">×</button>
+      <button type="button" class="ag2-x" data-remove-dep="${escapeHtml(d.target_id)}" title="Drop the link (the log keeps history)">×</button>
     </div>`;
   });
   const empty = !blockers.length && !deps.length
     ? '<div class="ag2-hint">Nothing gates this item.</div>' : '';
-  // Blockers and dependency edges describe OPEN work — the daemon refuses
+  // Blockers and dependency links describe OPEN work — the daemon refuses
   // them elsewhere, so the affordances only exist there.
   if (item.status !== 'open') {
     return `<section class="ag2-sec">
@@ -522,7 +522,7 @@ function agendaInspOrganizationHtml(item) {
     if (!target) return '';
     return `<span class="ag2-relchip">
       <a data-open-item="${escapeHtml(pid)}">${escapeHtml(target.title.slice(0, 34))}</a>
-      <button type="button" class="ag2-x" data-remove-rel="${escapeHtml(pid)}" title="Remove the see-also edge (the log keeps history)">×</button>
+      <button type="button" class="ag2-x" data-remove-rel="${escapeHtml(pid)}" title="Remove the see-also link (the log keeps history)">×</button>
     </span>`;
   }).join('');
   const relOptions = others
@@ -737,7 +737,7 @@ function agendaInspClick(e) {
   }
   const removeRel = e.target.closest('[data-remove-rel]');
   if (removeRel) {
-    // Either order works — the daemon resolves which side stores the edge.
+    // Either order works — the daemon resolves which side stores the link.
     agendaSendOp({ op: 'remove_relates_to', id: item.id, target_id: removeRel.dataset.removeRel }, removeRel);
     return;
   }

--- a/static/app/ui2-agenda.js
+++ b/static/app/ui2-agenda.js
@@ -276,10 +276,10 @@ function agendaFindItem(id) {
   return (agendaItems || []).find((item) => item.id === id) || null;
 }
 
-// One edge's render judgment: { satisfied, review } where review is
+// One link's render judgment: { satisfied, review } where review is
 // '' | 'target_retired' | 'target_missing'.
-function agendaEdgeState(edge) {
-  const target = agendaFindItem(edge.target_id);
+function agendaLinkState(link) {
+  const target = agendaFindItem(link.target_id);
   if (!target) return { satisfied: false, review: 'target_missing' };
   if (target.status === 'done') return { satisfied: true, review: '' };
   if (target.status === 'retired') return { satisfied: false, review: 'target_retired' };
@@ -289,7 +289,7 @@ function agendaEdgeState(edge) {
 function agendaItemIsBlocked(item) {
   if (item.status !== 'open') return false;
   if ((item.blockers || []).some((b) => !b.cleared)) return true;
-  return (item.relies_on || []).some((edge) => !agendaEdgeState(edge).satisfied);
+  return (item.relies_on || []).some((link) => !agendaLinkState(link).satisfied);
 }
 
 // The card's one-line blocked statement (first gate wins). Plain TEXT —
@@ -298,8 +298,8 @@ function agendaBlockedLine(item) {
   if (item.status !== 'open') return null;
   const blocker = (item.blockers || []).find((b) => !b.cleared);
   if (blocker) return `Blocked — waiting on: “${blocker.criterion}”`;
-  for (const edge of item.relies_on || []) {
-    const target = agendaFindItem(edge.target_id);
+  for (const link of item.relies_on || []) {
+    const target = agendaFindItem(link.target_id);
     if (!target) return 'Prerequisite missing from the fold — review';
     if (target.status === 'retired') return `Prerequisite “${target.title}” was retired — review`;
     if (target.status === 'open') return `Waits on “${target.title}” — still open`;
@@ -351,7 +351,7 @@ function agendaDescendantIds(id, seen) {
   return seen;
 }
 
-// The undirected adjacency union: edges stored on this item plus edges
+// The undirected adjacency union: links stored on this item plus links
 // other items store pointing here, deduped.
 function agendaRelationPartners(item) {
   const partners = new Set((item.relates_to || []).map((e) => e.target_id));


### PR DESCRIPTION
The owner's graph vocabulary is nodes and links. Rename the graph-relation
sense of "edge" across the Agenda surfaces — user-visible copy (inspector
tooltips), fragment-internal identifiers and comments (agendaGraphEdges ->
agendaGraphLinks, agendaEdgeState -> agendaLinkState, edge locals -> link),
and the docs chapter's graph prose. System-boundary senses (authenticated
edge, tenant edge, hard edges, the canvas's right edge) and the semantic
relation names (filed under, see-also, waits on) are deliberately unchanged.
Wire vocabulary is untouched — relations were already part_of / relates_to /
relies_on; no Rust changes.
