### PR TITLE
Codex Cloud attach slice 1: mTLS enrollment ceremony (broker, cloud-worker ceiling, attachment socket)

### DIFF
--- a/docs/src/codex-cloud-workers.md
+++ b/docs/src/codex-cloud-workers.md
@@ -125,6 +125,9 @@ intendant codex-cloud probe --task task_e_...
 # Continue a finished task with a new turn (see "Follow-ups" below).
 intendant codex-cloud followup task_e_... -m "Now also fix the tests"
 
+# Attach the live worker to this daemon over mTLS (see "Attaching" below).
+intendant codex-cloud attach task_e_... --home-url wss://your-host:8765 --send
+
 # Drop terminal leases with no live attachment (default: older than 7 days).
 intendant codex-cloud prune
 intendant codex-cloud prune --all
@@ -208,9 +211,54 @@ intendant codex-cloud followup task_e_... --json < prompt.txt   # stdin keeps pr
 `INTENDANT_CODEX_CLOUD_BACKEND` overrides the backend base URL (tests point
 it at a local stub; the default is the production web backend).
 
+## Attaching a worker to home (mTLS enrollment ceremony)
+
+A worker has no inbound reachability and no durable identity, so attaching
+it inverts the usual peer pairing. Home runs the whole ceremony:
+
+```bash
+# Mint a single-use token bound to the task and deliver the attach prompt
+# as a follow-up turn into the warm worker:
+intendant codex-cloud attach task_e_... --home-url wss://your-host:8765 --send
+
+# Or print the prompt to deliver by hand (task page, initial submit):
+intendant codex-cloud attach task_e_... --home-url wss://your-host:8765
+```
+
+The composed prompt tells the worker to run `intendant codex-cloud agent`
+through `run-worker.sh` (task-local state), with the token on stdin — never
+argv. The agent then:
+
+1. generates a keypair in its task-local state root (the private key never
+   leaves the worker; the daemon signs a public key, never mints one);
+2. redeems `{token, public key}` at home's public
+   `POST /api/codex-cloud/enroll` route and receives a client certificate
+   whose identity record carries the system-issued **`cloud-worker`**
+   profile and a hard expiry (`--identity-ttl-s`, default 3600);
+3. dials home's gateway over mTLS, pinned to the fingerprint baked into
+   the prompt, and holds the socket in the foreground. The accepted socket
+   *is* the attachment: the lease flips `connected` while it lives and
+   `disconnected` when it dies.
+
+Security shape: the enrollment token is stored hashed, minutes-TTL
+(`--token-ttl-s`, default 900), bound to one task, and burned atomically on
+first redemption — an unknown, used, or expired token refuses identically,
+and the public doorbell is rate-limited. The `cloud-worker` profile is
+recognized by every enforcement path but grants **no** operation at all
+(strictly less than presence-only) and is never operator-assignable; the
+gateway routes an attaching cloud-worker socket to the attachment lane
+before any dashboard grant exists, so the certificate authenticates exactly
+one thing: this heartbeat. Authority over the worker flows home→worker in
+later slices; the worker's inbound authority on home stays nothing.
+
+The worker's egress must be able to reach `--home-url`: in a
+network-restricted Codex Cloud environment, add the home host to the
+environment's allowlist or the dial is refused before TLS.
+
 ## Attachment lifecycle
 
-An attachment broker or operator records the independent attachment state:
+The enrollment broker above records the attachment state for its workers;
+an external broker or operator can also record it manually:
 
 ```bash
 intendant codex-cloud attachment task_e_... awaiting
@@ -224,9 +272,8 @@ Refreshes age attachments by three rules:
   broker is gone or will never arrive.
 - `connected` carries `attached_at_unix_ms` and expires after a staleness TTL
   (`INTENDANT_CODEX_CLOUD_ATTACH_TTL_S`, default 3600) unless re-asserted:
-  recording `connected` again restarts the clock. This is the stopgap until a
-  broker owns liveness — a crashed broker cannot leave a lease `connected`
-  forever.
+  recording `connected` again restarts the clock — a crashed broker cannot
+  leave a lease `connected` forever.
 - `connected` within the TTL survives even a terminal provider task, because
   reachability must be checked independently of provider state.
 
@@ -365,9 +412,11 @@ attachment lane instead of pretending each Cloud task is a static `[[peer]]`.
 
 ## Current boundary
 
-This integration covers the reliable job/control plane and the safe
-setup/maintenance contract. The attachment state is ready for a broker to own,
-but Intendant does not yet mint one-time enrollment credentials or allocate
-multi-tenant relay routes. Until that broker exists, live attachment remains an
-explicit deployment-specific command rather than pretending each Cloud task is
-a static `[[peer]]`.
+This integration covers the reliable job/control plane, the safe
+setup/maintenance contract, and the enrollment ceremony that attaches a live
+worker to home over mTLS. The attachment is deliberately just a heartbeat so
+far: the socket carries a hello frame and liveness, nothing else — no
+terminal, no display, no home→worker command channel yet. Workers are
+ephemeral enrollments with zero-authority expiring identities, not static
+`[[peer]]` registry entries, and home must be reachable from the worker's
+egress allowlist (there is no relay tier).

--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -1884,6 +1884,7 @@ response omits the header.
 | GET | `/api/session/current/history` | SessionManage | own origin | none | Serialized rollback History for the current session |
 | POST | `/api/session/current/rollback` | SessionManage | own origin | bounded | Roll the current session back to a round (optionally reverting files) |
 | GET | `/api/codex-cloud/workers` | StatsRead | own origin | none | Codex Cloud worker leases from the cached store (`?refresh=1` re-syncs via the Codex CLI) |
+| POST | `/api/codex-cloud/enroll` | public | public | ≤ 8 KiB | Redeem a single-use Codex Cloud attach token (public key in, zero-authority cloud-worker certificate out) |
 | GET | `/api/agenda` | AgendaRead | own origin | none | Agenda ledger snapshot: items (oldest first) plus status counts |
 | GET | `/api/agenda/ops` | AgendaRead | own origin | none | Raw agenda op-log page (since/item/limit cursor; unknown ops served verbatim) |
 | GET | `/api/agenda/occurrences` | AgendaRead | own origin | none | Raw occurrence-journal page (since/item/limit cursor; unknown records served verbatim) |

--- a/src/bin/caller/access/access_policy.rs
+++ b/src/bin/caller/access/access_policy.rs
@@ -236,6 +236,12 @@ pub enum ProfileClass {
     TaskRunner,
     Operator,
     AdminPeer,
+    /// Authenticate-only ceiling for enrolled ephemeral cloud workers:
+    /// grants no operation at all — strictly less than `PresenceOnly`.
+    /// The identity exists so the gateway can recognize the connection
+    /// and route it to the attachment lane; authority over the worker
+    /// flows the other way (home drives the worker), never inbound.
+    CloudWorker,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -370,6 +376,18 @@ pub(crate) const PROFILES: &[(&str, ProfileClass)] = &[
     ("peer-root", ProfileClass::AdminPeer),
 ];
 
+/// The Codex Cloud attachment broker's system profile name — the single
+/// declaration every mint, enforcement, and routing site derives from.
+pub(crate) const CLOUD_WORKER_PROFILE: &str = "cloud-worker";
+
+/// System-issued profiles: recognized by every enforcement path but never
+/// operator-assignable — [`require_known_profile`] rejects them, and the
+/// dashboard picker (whose parity test mirrors [`PROFILES`] alone) never
+/// lists them. Minted only by dedicated ceremonies; today that is the
+/// Codex Cloud enrollment broker's `cloud-worker` identity.
+pub(crate) const SYSTEM_PROFILES: &[(&str, ProfileClass)] =
+    &[(CLOUD_WORKER_PROFILE, ProfileClass::CloudWorker)];
+
 /// Accepted alternate spellings, each canonicalizing to a [`PROFILES`] name.
 pub(crate) const PROFILE_ALIASES: &[(&str, &str)] = &[
     ("presence", "presence-only"),
@@ -411,6 +429,12 @@ pub fn profile_class(profile: &str) -> ProfileClass {
     let normalized = profile.trim().to_ascii_lowercase();
     canonical_profile_entry(&normalized)
         .map(|(_, class)| class)
+        .or_else(|| {
+            SYSTEM_PROFILES
+                .iter()
+                .find(|(name, _)| *name == normalized)
+                .map(|(_, class)| *class)
+        })
         // Unknown profiles degrade to the least-capable class. This is the
         // wire-side contract: a profile string this daemon does not know
         // (stored by an older build, minted by a newer one) fails closed
@@ -454,6 +478,10 @@ pub fn profile_allows_operation(profile: &str, op: PeerOperation) -> bool {
     use ProfileClass::*;
 
     match profile_class(profile) {
+        // Authenticate-only: an enrolled cloud worker may hold its
+        // attachment socket and nothing else — strictly below
+        // PresenceOnly.
+        CloudWorker => false,
         PresenceOnly => matches!(op, PresenceRead),
         Stats => matches!(op, PresenceRead | StatsRead),
         SessionReader => matches!(op, PresenceRead | StatsRead | SessionInspect),
@@ -1204,6 +1232,31 @@ pub fn write_approved_identity(
     card_url: Option<&str>,
     request_id: Option<&str>,
 ) -> Result<PeerIdentityRecord, CallerError> {
+    write_approved_identity_expiring(
+        cert_dir,
+        fingerprint,
+        label,
+        profile,
+        card_url,
+        request_id,
+        None,
+    )
+}
+
+/// [`write_approved_identity`] with an expiry: past `expires_at_unix` the
+/// record fails [`PeerIdentityRecord::is_active`] and the gateway refuses
+/// the certificate — the enforcement lane for short-lived identities
+/// (cloud-worker enrollments), independent of the certificate's own
+/// validity window.
+pub fn write_approved_identity_expiring(
+    cert_dir: &Path,
+    fingerprint: &str,
+    label: &str,
+    profile: &str,
+    card_url: Option<&str>,
+    request_id: Option<&str>,
+    expires_at_unix: Option<i64>,
+) -> Result<PeerIdentityRecord, CallerError> {
     with_identity_store_lock(cert_dir, || {
         let fingerprint = normalize_fingerprint(fingerprint)?;
         let profile = normalize_profile(profile)?;
@@ -1218,7 +1271,7 @@ pub fn write_approved_identity(
             filesystem: FilesystemAccessPolicy::default(),
             created_at_unix: unix_timestamp(),
             revoked_at_unix: None,
-            expires_at_unix: None,
+            expires_at_unix,
             source: None,
             org_grant_id: None,
             issued_via: None,

--- a/src/bin/caller/codex_cloud.rs
+++ b/src/bin/caller/codex_cloud.rs
@@ -316,6 +316,8 @@ pub async fn run(args: Vec<String>) -> Result<(), String> {
         "pull" => run_pull(&args[1..]).await,
         "probe" => run_probe(&args[1..]).await,
         "followup" | "follow-up" | "message" => run_followup(&args[1..]).await,
+        "attach" => crate::codex_cloud_attach::run_attach(&args[1..]).await,
+        "agent" => crate::codex_cloud_attach::run_agent(&args[1..]).await,
         "bootstrap" => run_bootstrap(&args[1..]),
         "attachment" => run_attachment(&args[1..]),
         "prune" => run_prune(&args[1..]),
@@ -996,7 +998,11 @@ fn mark_probe(store_path: &Path, task_id: &str) -> Result<(), String> {
 /// it into `worker_history` and counts a cold replacement — replacing
 /// silently would discard exactly the evidence the probe exists to
 /// gather.
-fn record_worker_fingerprint(store_path: &Path, task_id: &str, fingerprint: WorkerFingerprint) {
+pub(crate) fn record_worker_fingerprint(
+    store_path: &Path,
+    task_id: &str,
+    fingerprint: WorkerFingerprint,
+) {
     let Ok(_lock) = StoreLock::acquire(store_path) else {
         return;
     };
@@ -1855,15 +1861,24 @@ fn run_attachment(args: &[String]) -> Result<(), String> {
         "none" | "not-requested" => AttachmentState::NotRequested,
         other => return Err(format!("unknown attachment state {other:?}")),
     };
-    let store_path = state_path();
-    let _lock = StoreLock::acquire(&store_path)?;
-    let mut store = load_store(&store_path)?;
+    let label = record_attachment_state(&state_path(), &args[0], state)?;
+    println!("{} attachment={label}", args[0]);
+    Ok(())
+}
+
+/// Record an attachment-lane state on a tracked lease (the CLI verb, the
+/// enrollment broker, and the gateway's attachment socket all converge
+/// here — the store lock keeps them serialized).
+pub(crate) fn record_attachment_state(
+    store_path: &Path,
+    task_id: &str,
+    state: AttachmentState,
+) -> Result<&'static str, String> {
+    let _lock = StoreLock::acquire(store_path)?;
+    let mut store = load_store(store_path)?;
     let label = {
-        let lease = store.leases.get_mut(&args[0]).ok_or_else(|| {
-            format!(
-                "unknown worker lease {}; run `intendant codex-cloud list`",
-                args[0]
-            )
+        let lease = store.leases.get_mut(task_id).ok_or_else(|| {
+            format!("unknown worker lease {task_id}; run `intendant codex-cloud list`")
         })?;
         lease.attachment_state = state;
         // `connected` (re-)starts the staleness clock; `none` resets the
@@ -1876,9 +1891,8 @@ fn run_attachment(args: &[String]) -> Result<(), String> {
         lease.last_observed_unix_ms = now_unix_ms();
         attachment_label(&lease.attachment_state)
     };
-    save_store(&store_path, &store)?;
-    println!("{} attachment={label}", args[0]);
-    Ok(())
+    save_store(store_path, &store)?;
+    Ok(label)
 }
 
 fn run_prune(args: &[String]) -> Result<(), String> {
@@ -2419,7 +2433,7 @@ fn save_store(path: &Path, store: &LeaseStore) -> Result<(), String> {
 /// `<store>.lock` — never the store itself, whose inode `atomic_write`
 /// replaces (and whose reads Windows' LockFileEx would block). The OS
 /// releases the lock if the holder dies.
-struct StoreLock {
+pub(crate) struct StoreLock {
     file: std::fs::File,
 }
 
@@ -2430,7 +2444,7 @@ impl StoreLock {
 
     /// Lock an arbitrary sidecar path with the same semantics (the
     /// per-task follow-up serialization lock rides here too).
-    fn acquire_path(lock_path: &Path) -> Result<Self, String> {
+    pub(crate) fn acquire_path(lock_path: &Path) -> Result<Self, String> {
         if let Some(parent) = lock_path.parent() {
             std::fs::create_dir_all(parent)
                 .map_err(|e| format!("create lease store directory {}: {e}", parent.display()))?;
@@ -2600,7 +2614,7 @@ fn reject_args(args: &[String], command: &str) -> Result<(), String> {
     }
 }
 
-fn now_unix_ms() -> u64 {
+pub(crate) fn now_unix_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_millis() as u64)
@@ -2664,7 +2678,7 @@ internet allowlist must include every exact relay/download domain used by the wo
 
 fn print_help() {
     println!(
-        "Usage:\n  intendant codex-cloud <command> [options]\n\nCommands:\n  doctor       Verify the local Codex CLI and Cloud authentication\n  exec         Submit a task and create a provider-owned worker lease\n  list         Refresh and list Cloud tasks/leases (window + live tracked)\n  status       Show one tracked lease\n  diff         Show a task diff through the Codex CLI\n  pull         Apply a task's diff onto a fresh branch in a new worktree\n  probe        Submit a diagnostic task that fingerprints its worker\n  followup     Send a follow-up turn into an existing task (private backend)\n  attachment   Record the independent live-attachment state\n  prune        Drop terminal leases with no live attachment\n  bootstrap    Generate setup, maintenance, and task-time worker scripts\n\nCodex Cloud containers are ephemeral worker leases, not permanent peers."
+        "Usage:\n  intendant codex-cloud <command> [options]\n\nCommands:\n  doctor       Verify the local Codex CLI and Cloud authentication\n  exec         Submit a task and create a provider-owned worker lease\n  list         Refresh and list Cloud tasks/leases (window + live tracked)\n  status       Show one tracked lease\n  diff         Show a task diff through the Codex CLI\n  pull         Apply a task's diff onto a fresh branch in a new worktree\n  probe        Submit a diagnostic task that fingerprints its worker\n  followup     Send a follow-up turn into an existing task (private backend)\n  attach       Mint a one-time enrollment token + attach prompt for a task's worker\n  agent        (runs inside the worker) redeem a token and hold the attachment socket\n  attachment   Record the independent live-attachment state\n  prune        Drop terminal leases with no live attachment\n  bootstrap    Generate setup, maintenance, and task-time worker scripts\n\nCodex Cloud containers are ephemeral worker leases, not permanent peers."
     );
 }
 

--- a/src/bin/caller/codex_cloud_attach.rs
+++ b/src/bin/caller/codex_cloud_attach.rs
@@ -1,0 +1,969 @@
+//! Codex Cloud attachment broker and worker-side agent (attach slice 1).
+//!
+//! A Codex Cloud worker has no inbound reachability and no durable
+//! identity, so attaching it to home inverts the usual pairing: home
+//! mints a **single-use, minutes-TTL enrollment token** bound to one
+//! task; the token travels to the worker through the only per-task
+//! channel that exists (the task prompt — normally a follow-up into the
+//! warm worker); the worker generates a keypair in its task-local state
+//! root, redeems `{token, public key}` at a public gateway route, and
+//! receives a client certificate whose identity record carries the
+//! zero-authority `cloud-worker` system profile and a hard expiry. It
+//! then dials home's gateway over mTLS and the accepted socket *is* the
+//! attachment: the lease flips `connected` while it lives, `disconnected`
+//! when it dies. Authority over the worker flows home→worker in later
+//! slices; the worker's inbound authority on home stays nothing.
+//!
+//! Private keys never transit (the daemon signs a public key, never
+//! mints one for the worker), tokens are stored hashed and burned
+//! atomically on first redemption, and an unknown, used, or expired
+//! token is indistinguishable in the error surface.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use crate::codex_cloud::{record_attachment_state, state_path, AttachmentState, StoreLock};
+
+const BROKER_VERSION: u32 = 1;
+/// Enrollment tokens are delivery secrets for one attach ceremony:
+/// minutes, not hours.
+const DEFAULT_TOKEN_TTL_S: u64 = 900;
+/// The issued identity's record expiry (independent of cert validity —
+/// the record is what the gateway enforces on every connection).
+const DEFAULT_IDENTITY_TTL_S: u64 = 3600;
+/// The public redemption doorbell's path — the one spelling shared by the
+/// route table, the certless carve-out predicate, and the worker's dial.
+pub(crate) const ENROLL_PATH: &str = "/api/codex-cloud/enroll";
+/// The worker's first frame after the socket opens. Informational — the
+/// identity was already established by the client certificate.
+const HELLO_KIND: &str = "cloud-worker-hello";
+
+// ── Broker store ───────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize)]
+struct BrokerStore {
+    #[serde(default = "broker_version")]
+    version: u32,
+    /// Pending enrollments keyed by SHA-256(token) hex — the plaintext
+    /// token exists only in the mint response and the task prompt.
+    #[serde(default)]
+    pending: BTreeMap<String, PendingEnrollment>,
+    /// Issued identities keyed by client-cert fingerprint. The listener
+    /// resolves an attaching socket to its task through this map.
+    #[serde(default)]
+    bindings: BTreeMap<String, WorkerBinding>,
+}
+
+fn broker_version() -> u32 {
+    BROKER_VERSION
+}
+
+impl Default for BrokerStore {
+    fn default() -> Self {
+        Self {
+            version: BROKER_VERSION,
+            pending: BTreeMap::new(),
+            bindings: BTreeMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingEnrollment {
+    pub task_id: String,
+    pub created_at_unix_ms: u64,
+    pub expires_at_unix_ms: u64,
+    /// TTL for the identity record minted at redemption.
+    pub identity_ttl_s: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkerBinding {
+    pub task_id: String,
+    pub label: String,
+    pub issued_at_unix_ms: u64,
+    pub identity_expires_at_unix: i64,
+}
+
+/// The broker store lives beside the lease store and follows the same
+/// sidecar-lock discipline (CLI, daemon route, and listener share it).
+pub(crate) fn broker_path(lease_store_path: &Path) -> PathBuf {
+    lease_store_path.with_file_name("attach-broker.json")
+}
+
+fn load_broker(path: &Path) -> Result<BrokerStore, String> {
+    match std::fs::read(path) {
+        Ok(bytes) => {
+            let store: BrokerStore = serde_json::from_slice(&bytes)
+                .map_err(|e| format!("parse attach broker store {}: {e}", path.display()))?;
+            if store.version != BROKER_VERSION {
+                return Err(format!(
+                    "unsupported attach broker store version {} in {}",
+                    store.version,
+                    path.display()
+                ));
+            }
+            Ok(store)
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(BrokerStore::default()),
+        Err(e) => Err(format!("read attach broker store {}: {e}", path.display())),
+    }
+}
+
+fn save_broker(path: &Path, store: &BrokerStore) -> Result<(), String> {
+    let bytes = serde_json::to_vec_pretty(store)
+        .map_err(|e| format!("serialize attach broker store: {e}"))?;
+    crate::file_watcher::atomic_write(path, &bytes)
+        .map_err(|e| format!("write attach broker store {}: {e}", path.display()))
+}
+
+fn broker_lock(path: &Path) -> Result<StoreLock, String> {
+    let mut name = path.file_name().unwrap_or_default().to_os_string();
+    name.push(".lock");
+    StoreLock::acquire_path(&path.with_file_name(name))
+}
+
+fn token_hash(token: &str) -> String {
+    use sha2::Digest as _;
+    let digest = sha2::Sha256::digest(token.trim().as_bytes());
+    digest.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+fn random_token() -> Result<String, String> {
+    use base64::Engine as _;
+    use ring::rand::SecureRandom as _;
+    let mut bytes = [0u8; 32];
+    ring::rand::SystemRandom::new()
+        .fill(&mut bytes)
+        .map_err(|_| "generate enrollment token".to_string())?;
+    Ok(base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes))
+}
+
+fn prune_expired(store: &mut BrokerStore, now_ms: u64) {
+    store
+        .pending
+        .retain(|_, pending| pending.expires_at_unix_ms > now_ms);
+}
+
+/// Mint a single-use enrollment token for a task. Returns the plaintext
+/// token — the only time it exists outside the caller's delivery path.
+pub fn mint_enrollment(
+    broker_store_path: &Path,
+    task_id: &str,
+    token_ttl_s: u64,
+    identity_ttl_s: u64,
+    now_ms: u64,
+) -> Result<(String, PendingEnrollment), String> {
+    let token = random_token()?;
+    let pending = PendingEnrollment {
+        task_id: task_id.to_string(),
+        created_at_unix_ms: now_ms,
+        expires_at_unix_ms: now_ms.saturating_add(token_ttl_s.saturating_mul(1000)),
+        identity_ttl_s,
+    };
+    let _lock = broker_lock(broker_store_path)?;
+    let mut store = load_broker(broker_store_path)?;
+    prune_expired(&mut store, now_ms);
+    store.pending.insert(token_hash(&token), pending.clone());
+    save_broker(broker_store_path, &store)?;
+    Ok((token, pending))
+}
+
+/// Atomically burn a token. Unknown, already-used, and expired tokens are
+/// deliberately indistinguishable.
+fn consume_enrollment(
+    broker_store_path: &Path,
+    token: &str,
+    now_ms: u64,
+) -> Result<PendingEnrollment, String> {
+    const REFUSED: &str = "enrollment token was not found, already used, or expired";
+    let _lock = broker_lock(broker_store_path)?;
+    let mut store = load_broker(broker_store_path)?;
+    prune_expired(&mut store, now_ms);
+    let pending = store
+        .pending
+        .remove(&token_hash(token))
+        .ok_or_else(|| REFUSED.to_string())?;
+    save_broker(broker_store_path, &store)?;
+    if pending.expires_at_unix_ms <= now_ms {
+        return Err(REFUSED.to_string());
+    }
+    Ok(pending)
+}
+
+fn record_binding(
+    broker_store_path: &Path,
+    fingerprint: &str,
+    binding: WorkerBinding,
+) -> Result<(), String> {
+    let _lock = broker_lock(broker_store_path)?;
+    let mut store = load_broker(broker_store_path)?;
+    store.bindings.insert(fingerprint.to_string(), binding);
+    save_broker(broker_store_path, &store)
+}
+
+/// The listener's fingerprint → task resolution for an attaching socket.
+pub(crate) fn binding_for_fingerprint(
+    broker_store_path: &Path,
+    fingerprint: &str,
+) -> Option<WorkerBinding> {
+    load_broker(broker_store_path)
+        .ok()?
+        .bindings
+        .get(fingerprint)
+        .cloned()
+}
+
+// ── Redemption (the public enroll route's core) ────────────────────────
+
+/// Light global limiter on the public doorbell. The single-use token is
+/// the real gate; this just keeps a scanner from grinding the store.
+static ENROLL_RATE: std::sync::Mutex<(u64, u32)> = std::sync::Mutex::new((0, 0));
+const ENROLL_RATE_WINDOW_MS: u64 = 60_000;
+const ENROLL_RATE_MAX: u32 = 30;
+
+pub(crate) fn enroll_rate_ok(now_ms: u64) -> bool {
+    let mut state = ENROLL_RATE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if now_ms.saturating_sub(state.0) > ENROLL_RATE_WINDOW_MS {
+        *state = (now_ms, 0);
+    }
+    if state.1 >= ENROLL_RATE_MAX {
+        return false;
+    }
+    state.1 += 1;
+    true
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EnrollRequest {
+    pub version: u32,
+    pub token: String,
+    /// SPKI public key PEM. The daemon signs it — a private key never
+    /// rides this request in either direction.
+    pub public_key_pem: String,
+    /// Optional worker-authored runtime fingerprint (hostname/boot id),
+    /// recorded on the lease like a probe's.
+    #[serde(default)]
+    pub worker: Option<serde_json::Value>,
+}
+
+/// Same hygiene as the follow-up lane's `CodexAuth`: the token is a live
+/// secret until burned, so no derive may ever print it.
+impl std::fmt::Debug for EnrollRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EnrollRequest")
+            .field("version", &self.version)
+            .field("token", &"[redacted]")
+            .field("public_key_pem_len", &self.public_key_pem.len())
+            .field("worker", &self.worker.is_some())
+            .finish()
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct EnrollResponse {
+    pub version: u32,
+    pub task_id: String,
+    pub profile: String,
+    pub client_cert_pem: String,
+    pub identity_expires_at_unix: i64,
+    pub hello_kind: String,
+}
+
+/// Redeem a token for a `cloud-worker` identity. Pure of environment:
+/// every root arrives as a parameter (the route/CLI edges resolve them).
+pub fn redeem_enrollment(
+    cert_dir: &Path,
+    lease_store_path: &Path,
+    request: &EnrollRequest,
+    now_ms: u64,
+) -> Result<EnrollResponse, String> {
+    if request.version != 1 {
+        return Err(format!(
+            "unsupported enrollment request version {}",
+            request.version
+        ));
+    }
+    let token = request.token.trim();
+    if token.is_empty() || token.len() > 128 {
+        return Err("enrollment token has an invalid shape".to_string());
+    }
+    let public_key_pem = request.public_key_pem.trim();
+    if public_key_pem.len() > 4096 {
+        return Err("public key PEM is too large".to_string());
+    }
+    rcgen::SubjectPublicKeyInfo::from_pem(public_key_pem)
+        .map_err(|e| format!("public_key_pem is not a valid SPKI public key: {e}"))?;
+
+    let broker = broker_path(lease_store_path);
+    let pending = consume_enrollment(&broker, token, now_ms)?;
+
+    let profile = crate::access::access_policy::CLOUD_WORKER_PROFILE;
+    let label = format!("{profile} {}", pending.task_id);
+    let cert_pem = crate::access::certs::issue_client_certificate_for_public_key(
+        cert_dir,
+        &label,
+        public_key_pem,
+    )
+    .map_err(|e| format!("issue cloud-worker certificate: {e}"))?;
+    let fingerprint = crate::access::access_policy::fingerprint_pem(&cert_pem)
+        .map_err(|e| format!("fingerprint issued certificate: {e}"))?;
+    let identity_expires_at_unix =
+        ((now_ms / 1000) as i64).saturating_add(pending.identity_ttl_s as i64);
+    crate::access::access_policy::write_approved_identity_expiring(
+        cert_dir,
+        &fingerprint,
+        &label,
+        profile,
+        None,
+        None,
+        Some(identity_expires_at_unix),
+    )
+    .map_err(|e| format!("record cloud-worker identity: {e}"))?;
+    record_binding(
+        &broker,
+        &fingerprint,
+        WorkerBinding {
+            task_id: pending.task_id.clone(),
+            label,
+            issued_at_unix_ms: now_ms,
+            identity_expires_at_unix,
+        },
+    )?;
+    // The ceremony is under way: the lease shows `awaiting` until the
+    // socket actually opens. Best-effort — an untracked task still
+    // enrolls (the lease may live on another store generation).
+    let _ = record_attachment_state(
+        lease_store_path,
+        &pending.task_id,
+        AttachmentState::Awaiting,
+    );
+    if let Some(worker) = &request.worker {
+        record_worker_json(lease_store_path, &pending.task_id, worker);
+    }
+    Ok(EnrollResponse {
+        version: 1,
+        task_id: pending.task_id,
+        profile: profile.to_string(),
+        client_cert_pem: cert_pem,
+        identity_expires_at_unix,
+        hello_kind: HELLO_KIND.to_string(),
+    })
+}
+
+/// Best-effort: fold a worker-authored fingerprint JSON into the lease
+/// (same semantics as a probe collection).
+fn record_worker_json(lease_store_path: &Path, task_id: &str, value: &serde_json::Value) {
+    let Ok(fingerprint) =
+        serde_json::from_value::<crate::codex_cloud::WorkerFingerprint>(value.clone())
+    else {
+        return;
+    };
+    crate::codex_cloud::record_worker_fingerprint(lease_store_path, task_id, fingerprint);
+}
+
+// ── The attachment socket (listener lane) ──────────────────────────────
+
+/// Serve one accepted cloud-worker WebSocket: resolve its task binding,
+/// flip the lease `connected`, hold until the socket ends, flip
+/// `disconnected`. The socket is the heartbeat — no frames are required
+/// beyond the hello, and tungstenite answers pings during the read loop.
+pub(crate) async fn serve_attachment_socket<S>(
+    ws_stream: tokio_tungstenite::WebSocketStream<S>,
+    fingerprint: &str,
+) where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    use futures_util::StreamExt as _;
+
+    let lease_store = state_path();
+    let broker = broker_path(&lease_store);
+    let Some(binding) = binding_for_fingerprint(&broker, fingerprint) else {
+        eprintln!(
+            "[codex-cloud] refusing attachment from unbound cloud-worker certificate {}",
+            &fingerprint[..fingerprint.len().min(12)]
+        );
+        return;
+    };
+    let task_id = binding.task_id;
+    match record_attachment_state(&lease_store, &task_id, AttachmentState::Connected) {
+        Ok(_) => eprintln!("[codex-cloud] worker attached for {task_id}"),
+        Err(error) => eprintln!("[codex-cloud] attachment connect for {task_id}: {error}"),
+    }
+    let (_write, mut read) = ws_stream.split();
+    while let Some(frame) = read.next().await {
+        match frame {
+            Ok(message) if message.is_close() => break,
+            Ok(_) => {}
+            Err(_) => break,
+        }
+    }
+    match record_attachment_state(&lease_store, &task_id, AttachmentState::Disconnected) {
+        Ok(_) => eprintln!("[codex-cloud] worker detached for {task_id}"),
+        Err(error) => eprintln!("[codex-cloud] attachment disconnect for {task_id}: {error}"),
+    }
+}
+
+// ── Attach verb (home side) ────────────────────────────────────────────
+
+fn home_url_from(args_value: Option<String>) -> Result<String, String> {
+    let url = args_value
+        .or_else(|| std::env::var("INTENDANT_CODEX_CLOUD_HOME_URL").ok())
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            "attach needs the daemon's reachable WSS URL: pass --home-url wss://host:port or set INTENDANT_CODEX_CLOUD_HOME_URL"
+                .to_string()
+        })?;
+    if !(url.starts_with("wss://") || url.starts_with("ws://")) {
+        return Err(format!("home URL must be ws(s)://…, got '{url}'"));
+    }
+    Ok(url)
+}
+
+/// The attach follow-up prompt: everything in it is public except the
+/// single-use token, which is the point of the ceremony.
+pub fn attach_prompt(
+    task_id: &str,
+    home_url: &str,
+    server_fingerprint: &str,
+    token: &str,
+) -> String {
+    format!(
+        "Run this exact command in the repository root and keep it running in the foreground until this turn is cancelled. Do not modify any files, do not run builds, and do not print the token back:\n\n\
+```bash\n\
+\"${{INTENDANT_CLOUD_INSTALL_ROOT:-$HOME/.local}}/libexec/intendant-cloud/run-worker.sh\" -- \\\n\
+  \"${{INTENDANT_CLOUD_INSTALL_ROOT:-$HOME/.local}}/bin/intendant\" codex-cloud agent \\\n\
+  --home {home_url} --home-fingerprint {server_fingerprint} --task {task_id} --token-stdin <<'INTENDANT_ATTACH_TOKEN'\n\
+{token}\n\
+INTENDANT_ATTACH_TOKEN\n\
+```\n\n\
+If the command fails because a destination is blocked by the environment's network allowlist, report the blocked host and stop."
+    )
+}
+
+pub async fn run_attach(args: &[String]) -> Result<(), String> {
+    if args.is_empty()
+        || args
+            .iter()
+            .any(|arg| matches!(arg.as_str(), "-h" | "--help" | "help"))
+    {
+        println!(
+            "Usage:\n  intendant codex-cloud attach TASK_ID [--home-url wss://host:port] [--token-ttl-s {DEFAULT_TOKEN_TTL_S}] [--identity-ttl-s {DEFAULT_IDENTITY_TTL_S}] [--send] [--json]"
+        );
+        println!(
+            "Mints a single-use enrollment token bound to the task and composes the attach prompt (printed by default; --send delivers it as a follow-up turn into the warm worker). The worker redeems the token for a zero-authority cloud-worker certificate and dials back; the lease's attachment lane tracks the socket."
+        );
+        return Ok(());
+    }
+    let mut task_id: Option<String> = None;
+    let mut home_url_arg: Option<String> = None;
+    let mut token_ttl_s = DEFAULT_TOKEN_TTL_S;
+    let mut identity_ttl_s = DEFAULT_IDENTITY_TTL_S;
+    let mut send = false;
+    let mut json = false;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--home-url" => {
+                i += 1;
+                home_url_arg = Some(
+                    args.get(i)
+                        .cloned()
+                        .ok_or("--home-url requires a ws(s):// URL")?,
+                );
+            }
+            "--token-ttl-s" => {
+                i += 1;
+                token_ttl_s = args
+                    .get(i)
+                    .and_then(|value| value.parse().ok())
+                    .filter(|value| *value > 0)
+                    .ok_or("--token-ttl-s requires a positive number of seconds")?;
+            }
+            "--identity-ttl-s" => {
+                i += 1;
+                identity_ttl_s = args
+                    .get(i)
+                    .and_then(|value| value.parse().ok())
+                    .filter(|value| *value > 0)
+                    .ok_or("--identity-ttl-s requires a positive number of seconds")?;
+            }
+            "--send" => send = true,
+            "--json" => json = true,
+            other if task_id.is_none() && !other.starts_with('-') => {
+                task_id = Some(other.to_string());
+            }
+            other => return Err(format!("unknown attach argument {other}")),
+        }
+        i += 1;
+    }
+    let task_id = task_id.ok_or("attach requires a Codex Cloud task id")?;
+    let home_url = home_url_from(home_url_arg)?;
+    let lease_store = state_path();
+    let tracked = crate::codex_cloud::cached_leases(&lease_store)?
+        .iter()
+        .any(|lease| lease.task_id == task_id);
+    if !tracked {
+        return Err(format!(
+            "task {task_id} is not in the local lease store — `intendant codex-cloud list` (or `status {task_id}`) tracks it first"
+        ));
+    }
+    let cert_dir = crate::access::backend::select_backend().cert_dir();
+    let server_fingerprint = crate::access::certs::read_server_cert_fingerprint(&cert_dir)
+        .ok_or_else(|| {
+            "no gateway server certificate found — start the daemon once (it mints the TLS identity workers must pin), then retry"
+                .to_string()
+        })?;
+
+    let broker = broker_path(&lease_store);
+    let (token, pending) = mint_enrollment(
+        &broker,
+        &task_id,
+        token_ttl_s,
+        identity_ttl_s,
+        crate::codex_cloud::now_unix_ms(),
+    )?;
+    let _ = record_attachment_state(&lease_store, &task_id, AttachmentState::Awaiting);
+    let prompt = attach_prompt(&task_id, &home_url, &server_fingerprint, &token);
+
+    if send {
+        let receipt = crate::codex_cloud::follow_up_task(&lease_store, &task_id, &prompt).await?;
+        if json {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "task_id": task_id,
+                    "token_expires_at_unix_ms": pending.expires_at_unix_ms,
+                    "identity_ttl_s": identity_ttl_s,
+                    "delivered": true,
+                    "parent_turn_id": receipt.parent_turn_id,
+                })
+            );
+        } else {
+            println!("attach ceremony delivered as a follow-up into {task_id}");
+            println!("  token expires: {}s from mint", token_ttl_s);
+            println!("  watch: intendant codex-cloud status {task_id}");
+        }
+        return Ok(());
+    }
+
+    if json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "task_id": task_id,
+                "token_expires_at_unix_ms": pending.expires_at_unix_ms,
+                "identity_ttl_s": identity_ttl_s,
+                "delivered": false,
+                "prompt": prompt,
+            })
+        );
+    } else {
+        println!(
+            "Deliver this prompt to the task (single-use token inside, expires in {token_ttl_s}s):"
+        );
+        println!();
+        println!("{prompt}");
+    }
+    Ok(())
+}
+
+// ── Worker-side agent ──────────────────────────────────────────────────
+
+pub async fn run_agent(args: &[String]) -> Result<(), String> {
+    if args.is_empty()
+        || args
+            .iter()
+            .any(|arg| matches!(arg.as_str(), "-h" | "--help" | "help"))
+    {
+        println!(
+            "Usage:\n  intendant codex-cloud agent --home wss://host:port --home-fingerprint SHA256 --task TASK_ID --token-stdin [--state-dir DIR]"
+        );
+        println!(
+            "Runs inside a Codex Cloud worker: generates a task-local keypair, redeems the enrollment token at the home daemon's public enroll route, then dials home over mTLS and holds the attachment socket in the foreground. Launch it through run-worker.sh so all state stays task-local."
+        );
+        return Ok(());
+    }
+    let mut home: Option<String> = None;
+    let mut home_fingerprint: Option<String> = None;
+    let mut task: Option<String> = None;
+    let mut token_stdin = false;
+    let mut state_dir: Option<PathBuf> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--home" => {
+                i += 1;
+                home = Some(
+                    args.get(i)
+                        .cloned()
+                        .ok_or("--home requires a ws(s):// URL")?,
+                );
+            }
+            "--home-fingerprint" => {
+                i += 1;
+                home_fingerprint = Some(
+                    args.get(i)
+                        .cloned()
+                        .ok_or("--home-fingerprint requires a SHA-256 hex fingerprint")?,
+                );
+            }
+            "--task" => {
+                i += 1;
+                task = Some(args.get(i).cloned().ok_or("--task requires a task id")?);
+            }
+            "--token-stdin" => token_stdin = true,
+            "--state-dir" => {
+                i += 1;
+                state_dir = Some(PathBuf::from(
+                    args.get(i).cloned().ok_or("--state-dir requires a path")?,
+                ));
+            }
+            other => return Err(format!("unknown agent argument {other}")),
+        }
+        i += 1;
+    }
+    let home = home.ok_or("agent requires --home wss://host:port")?;
+    if !(home.starts_with("wss://") || home.starts_with("ws://")) {
+        return Err(format!("--home must be ws(s)://…, got '{home}'"));
+    }
+    let home_fingerprint = home_fingerprint
+        .ok_or("agent requires --home-fingerprint (pin the daemon's TLS identity)")?;
+    let task = task.ok_or("agent requires --task TASK_ID")?;
+    if !token_stdin {
+        return Err("agent requires --token-stdin (the token never rides argv)".to_string());
+    }
+    let token = tokio::task::spawn_blocking(|| std::io::read_to_string(std::io::stdin()))
+        .await
+        .map_err(|e| format!("read stdin: {e}"))?
+        .map_err(|e| format!("read stdin: {e}"))?
+        .trim()
+        .to_string();
+    if token.is_empty() {
+        return Err("no enrollment token arrived on stdin".to_string());
+    }
+
+    // `run-worker.sh` exports `INTENDANT_HOME` at a task-local root
+    // precisely so identity-bearing state stays out of the worker's
+    // cached directories — follow it into a `cloud-agent/` subdirectory
+    // rather than inventing a second state knob.
+    let state_dir = state_dir
+        .or_else(|| {
+            std::env::var_os("INTENDANT_HOME").map(|root| PathBuf::from(root).join("cloud-agent"))
+        })
+        .unwrap_or_else(|| PathBuf::from(".intendant-cloud-agent"));
+    std::fs::create_dir_all(&state_dir)
+        .map_err(|e| format!("create agent state dir {}: {e}", state_dir.display()))?;
+
+    let pinned = vec![crate::access::pinning::parse_fingerprint(&home_fingerprint)
+        .map_err(|e| format!("--home-fingerprint: {e}"))?];
+
+    // 1. Task-local keypair; the private key never leaves this directory.
+    let key_pair = rcgen::KeyPair::generate().map_err(|e| format!("generate keypair: {e}"))?;
+    let key_path = state_dir.join("client.key");
+    let cert_path = state_dir.join("client.crt");
+    write_private(&key_path, key_pair.serialize_pem().as_bytes())?;
+
+    // 2. Redeem the token for a certificate at the public enroll route.
+    let http_base = crate::peer::transport::ws_url_to_http_base(&home);
+    let enroll_url = format!("{http_base}{ENROLL_PATH}");
+    let client = crate::peer::transport::tls_client::reqwest_client(
+        std::time::Duration::from_secs(20),
+        &pinned,
+        None,
+    )
+    .map_err(|e| format!("build enroll HTTP client: {e}"))?;
+    let worker_fingerprint = collect_worker_fingerprint(crate::codex_cloud::now_unix_ms());
+    let response = client
+        .post(&enroll_url)
+        .json(&serde_json::json!({
+            "version": 1,
+            "token": token,
+            "public_key_pem": key_pair.public_key_pem(),
+            "worker": worker_fingerprint,
+        }))
+        .send()
+        .await
+        .map_err(|e| format!("POST {enroll_url}: {e}"))?;
+    let status = response.status();
+    let text = response.text().await.unwrap_or_default();
+    if !status.is_success() {
+        let snippet: String = text.trim().chars().take(200).collect();
+        return Err(format!("enrollment refused (HTTP {status}): {snippet}"));
+    }
+    let enrolled: serde_json::Value =
+        serde_json::from_str(&text).map_err(|e| format!("parse enrollment response: {e}"))?;
+    let cert_pem = enrolled
+        .get("client_cert_pem")
+        .and_then(serde_json::Value::as_str)
+        .ok_or("enrollment response carried no client_cert_pem")?;
+    std::fs::write(&cert_path, cert_pem)
+        .map_err(|e| format!("write {}: {e}", cert_path.display()))?;
+    eprintln!(
+        "[cloud-agent] enrolled for {task}; identity expires at unix {}",
+        enrolled
+            .get("identity_expires_at_unix")
+            .and_then(serde_json::Value::as_i64)
+            .unwrap_or_default()
+    );
+
+    // 3. Dial home and hold the attachment. The socket is the heartbeat;
+    //    losing it and failing to re-establish is the exit condition.
+    let identity = crate::peer::transport::tls_client::ClientIdentityPaths {
+        cert_path,
+        key_path,
+    };
+    let mut attempt: u32 = 0;
+    loop {
+        match hold_attachment(&home, &pinned, &identity, &task).await {
+            Ok(()) => {
+                attempt = 0;
+                eprintln!("[cloud-agent] attachment closed by home; reconnecting");
+            }
+            Err(error) => {
+                attempt += 1;
+                if attempt > 5 {
+                    return Err(format!(
+                        "attachment failed after {attempt} attempts: {error}"
+                    ));
+                }
+                eprintln!("[cloud-agent] attachment attempt {attempt} failed: {error}");
+            }
+        }
+        let backoff = std::time::Duration::from_secs(2u64.saturating_pow(attempt.min(4)));
+        tokio::time::sleep(backoff).await;
+    }
+}
+
+/// Collect the boot-identity fields the probe prompt measures, in the same
+/// format (`/proc` reads, whitespace-split stat field 22 — PID 1's comm
+/// never contains spaces), so `same_boot` comparisons across the probe and
+/// enroll lanes are meaningful. Best-effort by construction: on a non-Linux
+/// host the `/proc` reads simply come back `None`.
+fn collect_worker_fingerprint(now_ms: u64) -> crate::codex_cloud::WorkerFingerprint {
+    let read_trim = |path: &str| {
+        std::fs::read_to_string(path)
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+    };
+    let pid1_start = read_trim("/proc/1/stat")
+        .and_then(|stat| stat.split_whitespace().nth(21).map(str::to_string));
+    crate::codex_cloud::WorkerFingerprint {
+        hostname: read_trim("/proc/sys/kernel/hostname"),
+        boot_id: read_trim("/proc/sys/kernel/random/boot_id"),
+        pid1_start,
+        unix_ms: Some(now_ms),
+        git_rev: None,
+        rustc: None,
+        cpus: std::thread::available_parallelism()
+            .ok()
+            .map(|count| count.get() as u64),
+        mem_kb: None,
+        collected_at_unix_ms: now_ms,
+    }
+}
+
+fn write_private(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    std::fs::write(path, bytes).map_err(|e| format!("write {}: {e}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+            .map_err(|e| format!("chmod {}: {e}", path.display()))?;
+    }
+    Ok(())
+}
+
+async fn hold_attachment(
+    home: &str,
+    pinned: &[crate::access::pinning::Fingerprint],
+    identity: &crate::peer::transport::tls_client::ClientIdentityPaths,
+    task: &str,
+) -> Result<(), String> {
+    use futures_util::{SinkExt as _, StreamExt as _};
+    use tokio_tungstenite::tungstenite::client::IntoClientRequest as _;
+
+    let mut request = home
+        .into_client_request()
+        .map_err(|e| format!("bad home URL: {e}"))?;
+    request.headers_mut().insert(
+        "x-intendant-cloud-worker",
+        tokio_tungstenite::tungstenite::http::HeaderValue::from_static("1"),
+    );
+    let connector =
+        crate::peer::transport::tls_client::rustls_client_config(pinned, Some(identity))
+            .map_err(|e| format!("build TLS config: {e}"))?
+            .map(|config| tokio_tungstenite::Connector::Rustls(std::sync::Arc::new(config)));
+    let (mut ws, _resp) =
+        tokio_tungstenite::connect_async_tls_with_config(request, None, false, connector)
+            .await
+            .map_err(|e| format!("dial {home}: {e}"))?;
+    ws.send(tokio_tungstenite::tungstenite::Message::Text(
+        serde_json::json!({ "v": 1, "kind": HELLO_KIND, "task_id": task })
+            .to_string()
+            .into(),
+    ))
+    .await
+    .map_err(|e| format!("send hello: {e}"))?;
+    eprintln!("[cloud-agent] attached; holding the socket");
+    while let Some(frame) = ws.next().await {
+        match frame {
+            Ok(message) if message.is_close() => break,
+            Ok(_) => {}
+            Err(error) => return Err(format!("attachment socket: {error}")),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tokens_are_single_use_and_expiring() {
+        let dir = tempfile::tempdir().unwrap();
+        let broker = dir.path().join("attach-broker.json");
+        let (token, pending) = mint_enrollment(&broker, "task_e_att", 900, 3600, 1_000).unwrap();
+        assert_eq!(pending.task_id, "task_e_att");
+        assert!(!broker_contains_plaintext(&broker, &token));
+
+        let consumed = consume_enrollment(&broker, &token, 2_000).unwrap();
+        assert_eq!(consumed.task_id, "task_e_att");
+        // Burned: the same token never redeems twice.
+        let again = consume_enrollment(&broker, &token, 2_000).unwrap_err();
+        assert!(
+            again.contains("already used") || again.contains("not found"),
+            "{again}"
+        );
+
+        // Expired tokens refuse with the identical message.
+        let (token, _) = mint_enrollment(&broker, "task_e_att", 1, 3600, 1_000).unwrap();
+        let expired = consume_enrollment(&broker, &token, 10_000).unwrap_err();
+        assert_eq!(expired, again);
+    }
+
+    fn broker_contains_plaintext(path: &Path, token: &str) -> bool {
+        std::fs::read_to_string(path)
+            .map(|text| text.contains(token))
+            .unwrap_or(false)
+    }
+
+    #[test]
+    fn redemption_issues_a_zero_authority_expiring_identity() {
+        let dir = tempfile::tempdir().unwrap();
+        let cert_dir = dir.path().join("access");
+        std::fs::create_dir_all(&cert_dir).unwrap();
+        let names = crate::access::certs::ServerNames::new(
+            "127.0.0.1".parse().unwrap(),
+            Vec::<std::net::IpAddr>::new(),
+            Vec::<String>::new(),
+        )
+        .unwrap();
+        crate::access::certs::ensure_certs(&cert_dir, &names, "cloud-attach-test", false).unwrap();
+        let lease_store = dir.path().join("leases.json");
+        let broker = broker_path(&lease_store);
+        let (token, _) = mint_enrollment(&broker, "task_e_enroll", 900, 60, 1_000).unwrap();
+
+        let key = rcgen::KeyPair::generate().unwrap();
+        let response = redeem_enrollment(
+            &cert_dir,
+            &lease_store,
+            &EnrollRequest {
+                version: 1,
+                token,
+                public_key_pem: key.public_key_pem(),
+                worker: None,
+            },
+            5_000,
+        )
+        .unwrap();
+        assert_eq!(response.task_id, "task_e_enroll");
+        assert_eq!(response.profile, "cloud-worker");
+
+        let fingerprint =
+            crate::access::access_policy::fingerprint_pem(&response.client_cert_pem).unwrap();
+        let record = crate::access::access_policy::lookup_identity(&cert_dir, &fingerprint)
+            .unwrap()
+            .expect("identity record written");
+        assert_eq!(record.profile, "cloud-worker");
+        assert_eq!(record.expires_at_unix, Some(65));
+        assert!(record.is_active(64));
+        assert!(
+            !record.is_active(66),
+            "identity must expire on its record clock"
+        );
+
+        // The ceiling grants nothing at all.
+        use crate::access::access_policy::{profile_allows_operation, PeerOperation};
+        for op in [
+            PeerOperation::PresenceRead,
+            PeerOperation::StatsRead,
+            PeerOperation::Message,
+            PeerOperation::Task,
+        ] {
+            assert!(!profile_allows_operation("cloud-worker", op));
+        }
+
+        // The binding lets the listener resolve the socket to its task.
+        let binding = binding_for_fingerprint(&broker, &fingerprint).expect("binding recorded");
+        assert_eq!(binding.task_id, "task_e_enroll");
+
+        // A second redemption with the burned token fails.
+        let err = redeem_enrollment(
+            &cert_dir,
+            &lease_store,
+            &EnrollRequest {
+                version: 1,
+                token: "wrong".into(),
+                public_key_pem: key.public_key_pem(),
+                worker: None,
+            },
+            5_000,
+        )
+        .unwrap_err();
+        assert!(err.contains("not found"), "{err}");
+    }
+
+    #[test]
+    fn attach_prompt_carries_the_ceremony_and_nothing_extra() {
+        let prompt = attach_prompt(
+            "task_e_p",
+            "wss://home.example:8443/ws",
+            "ab".repeat(32).as_str(),
+            "tok-secret",
+        );
+        assert!(prompt.contains("codex-cloud agent"));
+        assert!(prompt.contains("--home wss://home.example:8443/ws"));
+        assert!(prompt.contains("--task task_e_p"));
+        assert!(prompt.contains("tok-secret"));
+        assert!(prompt.contains("run-worker.sh"));
+        assert!(prompt.contains("foreground"));
+    }
+
+    #[test]
+    fn enroll_request_debug_never_prints_the_token() {
+        let request = EnrollRequest {
+            version: 1,
+            token: "attach-secret-1".into(),
+            public_key_pem: "-----BEGIN PUBLIC KEY-----".into(),
+            worker: None,
+        };
+        let debug = format!("{request:?}");
+        assert!(!debug.contains("secret-1"), "{debug}");
+        assert!(debug.contains("[redacted]"), "{debug}");
+    }
+
+    #[test]
+    fn system_profile_is_recognized_but_never_operator_assignable() {
+        use crate::access::access_policy::{profile_class, require_known_profile, ProfileClass};
+        assert_eq!(profile_class("cloud-worker"), ProfileClass::CloudWorker);
+        assert!(require_known_profile("cloud-worker").is_err());
+    }
+}

--- a/src/bin/caller/gateway_routes.rs
+++ b/src/bin/caller/gateway_routes.rs
@@ -367,6 +367,7 @@ pub(crate) enum RouteHandlerId {
     /// Codex Cloud worker leases (cached store; `?refresh=1` re-syncs via
     /// the daemon host's Codex CLI and parks transition notes).
     CodexCloudWorkers,
+    CodexCloudEnroll,
     /// Agenda ledger snapshot (items + counts).
     AgendaList,
     /// Raw op-log page (since/item/limit cursor; unknown ops verbatim).
@@ -921,6 +922,17 @@ pub(crate) static ROUTES: &[Route] = &[
         "Codex Cloud worker leases from the cached store (`?refresh=1` re-syncs via the Codex CLI)",
     )
     .with_tunnel(tunnel_method("api_codex_cloud_workers")),
+    // The attachment broker's redemption doorbell: an enrolling worker has
+    // no identity yet, so the route is public and the single-use minted
+    // token is the entire authorization (burned atomically; rate-limited;
+    // grants only the zero-authority cloud-worker profile).
+    public_route(
+        RouteMethod::Post,
+        PathPattern::Exact(crate::codex_cloud_attach::ENROLL_PATH),
+        BodyPolicy::Capped(8 * 1024),
+        RouteHandlerId::CodexCloudEnroll,
+        "Redeem a single-use Codex Cloud attach token (public key in, zero-authority cloud-worker certificate out)",
+    ),
     op_route(
         RouteMethod::Get,
         PathPattern::Exact("/api/agenda"),

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -18,6 +18,7 @@ mod builtin_skills;
 mod claude_auth_ceremony;
 mod codex_auth_ceremony;
 mod codex_cloud;
+mod codex_cloud_attach;
 mod computer_use;
 mod connect_rendezvous;
 mod context_rewind;

--- a/src/bin/caller/web_gateway/access_gates.rs
+++ b/src/bin/caller/web_gateway/access_gates.rs
@@ -349,6 +349,7 @@ pub(crate) fn allows_remote_certless_http(request_line: &str, method: &str, path
     is_public_peer_access_request_path(request_line)
         || is_public_org_grant_path(request_line)
         || is_public_connect_bootstrap_path(request_line)
+        || is_public_codex_cloud_enroll_path(request_line)
         || is_public_dashboard_shell_or_asset(method, path)
 }
 
@@ -1240,6 +1241,17 @@ mod tests {
                 "{method} {path} is authority-free discovery"
             );
         }
+        // The Codex Cloud enroll doorbell is certless by design (the
+        // single-use token in the body is the authorization) — and only
+        // as the exact POST.
+        {
+            let line = "POST /api/codex-cloud/enroll HTTP/1.1";
+            assert!(allows_remote_certless_http(
+                line,
+                "POST",
+                "/api/codex-cloud/enroll"
+            ));
+        }
         for (method, path) in [
             ("POST", "/connect/dashboard/offer"),
             ("POST", "/connect/dashboard/ice"),
@@ -1248,6 +1260,8 @@ mod tests {
             ("GET", "/frames/frame-1"),
             ("GET", "/recordings"),
             ("GET", "/recordings/run-1/segment"),
+            ("GET", "/api/codex-cloud/enroll"),
+            ("GET", "/api/codex-cloud/workers"),
             ("GET", "/debug"),
             ("GET", "/tmp/arbitrary-source.rs"),
             ("GET", "/ws"),

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -1187,6 +1187,16 @@ pub(crate) async fn serve_http_request(
                 )
                 .await;
             }
+            RouteHandlerId::CodexCloudEnroll => {
+                return handle_codex_cloud_enroll(
+                    stream,
+                    route_body,
+                    cert_dir,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
+            }
             RouteHandlerId::AgendaList => {
                 return handle_agenda_list(
                     stream,

--- a/src/bin/caller/web_gateway/listener.rs
+++ b/src/bin/caller/web_gateway/listener.rs
@@ -2278,6 +2278,29 @@ fn spawn_web_gateway_from_cert_dir_with_relay_listener(
                         finalize_http_stream(&mut stream).await;
                         return;
                     }
+                    // Enrolled Codex Cloud workers never reach the dashboard
+                    // stream: their zero-authority `cloud-worker` profile
+                    // exists only to authenticate this socket, which becomes
+                    // the lease's attachment heartbeat and nothing else. The
+                    // profile is an authenticated fact from the identity
+                    // store (never a client header), so route on it before
+                    // the bearer gate — the mTLS identity is strictly
+                    // stronger auth than a federation bearer — and before
+                    // any dashboard grant is minted for it.
+                    if let Some(worker_identity) =
+                        peer_connection_identity.as_ref().filter(|identity| {
+                            identity.profile == crate::access::access_policy::CLOUD_WORKER_PROFILE
+                        })
+                    {
+                        let fingerprint = worker_identity.fingerprint.clone();
+                        let ws_stream = match tokio_tungstenite::accept_async(stream).await {
+                            Ok(ws) => ws,
+                            Err(_) => return,
+                        };
+                        crate::codex_cloud_attach::serve_attachment_socket(ws_stream, &fingerprint)
+                            .await;
+                        return;
+                    }
                     // Bearer enforcement on /ws — dual-mode (Authorization
                     // header from daemons, ?token= query param from
                     // browsers). Reject with a plain HTTP 401 *before*

--- a/src/bin/caller/web_gateway/routes_codex_cloud.rs
+++ b/src/bin/caller/web_gateway/routes_codex_cloud.rs
@@ -64,3 +64,68 @@ pub(crate) async fn handle_codex_cloud_workers(
     let response = codex_cloud_workers_api_response(refresh, mcp_server.as_ref()).await;
     write_api_response(stream, response, cors, fleet_origin).await;
 }
+
+/// Method-exact membership test for the certless carve-out
+/// ([`super::access_gates::allows_remote_certless_http`]): a Codex Cloud
+/// worker redeeming its enrollment token has no client certificate yet —
+/// the single-use token in the body is the entire authorization, so this
+/// one POST sits in the doorbell class beside peer pairing and org
+/// grants.
+pub(crate) fn is_public_codex_cloud_enroll_path(request_line: &str) -> bool {
+    let mut parts = request_line.split_whitespace();
+    let (Some(method), Some(path)) = (parts.next(), parts.next()) else {
+        return false;
+    };
+    let path = path.split('?').next().unwrap_or(path);
+    method == "POST" && path == crate::codex_cloud_attach::ENROLL_PATH
+}
+
+/// The attachment broker's public redemption doorbell
+/// (`POST /api/codex-cloud/enroll`): the single-use minted token is the
+/// entire authorization. Refusals are uniform (an unknown, used, or
+/// expired token reads identically) and the store I/O runs off the
+/// reactor thread.
+pub(crate) async fn handle_codex_cloud_enroll(
+    stream: DemuxStream,
+    body: String,
+    cert_dir: PathBuf,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
+) {
+    let response = codex_cloud_enroll_response(body, cert_dir).await;
+    write_api_response(stream, response, cors, fleet_origin).await;
+}
+
+async fn codex_cloud_enroll_response(body: String, cert_dir: PathBuf) -> ApiResponse {
+    if !crate::codex_cloud_attach::enroll_rate_ok(crate::codex_cloud::now_unix_ms()) {
+        return ApiResponse::json_error(429, "enrollment is rate limited; retry shortly");
+    }
+    let request: crate::codex_cloud_attach::EnrollRequest = match serde_json::from_str(&body) {
+        Ok(request) => request,
+        Err(error) => {
+            return ApiResponse::json_error(400, format!("invalid enrollment request: {error}"))
+        }
+    };
+    let outcome = tokio::task::spawn_blocking(move || {
+        crate::codex_cloud_attach::redeem_enrollment(
+            &cert_dir,
+            &crate::codex_cloud::state_path(),
+            &request,
+            crate::codex_cloud::now_unix_ms(),
+        )
+    })
+    .await;
+    match outcome {
+        Ok(Ok(enrolled)) => match serde_json::to_value(&enrolled) {
+            Ok(value) => ApiResponse::json(200, JsonBody::Value(value)),
+            Err(error) => ApiResponse::json_error(500, format!("serialize enrollment: {error}")),
+        },
+        Ok(Err(error)) => {
+            // Uniform refusal class: token problems and validation
+            // problems both land 403 without distinguishing detail beyond
+            // the message the broker chose to surface.
+            ApiResponse::json_error(403, &error)
+        }
+        Err(error) => ApiResponse::json_error(500, format!("enrollment task: {error}")),
+    }
+}


### PR DESCRIPTION
Attach slice 1 from the Codex Cloud attach track (kickoff brief 2026-07-24): the mTLS enrollment ceremony that turns a live cloud worker into an authenticated, zero-authority attachment on its lease.

## The ceremony

A worker has no inbound reachability and no durable identity, so attachment inverts the usual pairing — home runs everything:

1. **Mint (home):** `codex-cloud attach TASK_ID --home-url wss://… [--send]` requires a tracked lease, mints a single-use token (32 B random; stored **hashed**; minutes TTL, default 900 s), sets the lease `awaiting`, and composes the attach prompt (`--send` delivers it through the follow-up lane into the warm worker). The token is the only secret in the prompt and it is single-use + task-bound by construction.
2. **Redeem (worker):** `codex-cloud agent` (launched through `run-worker.sh`, token on **stdin only**) generates a keypair in the task-local state root and POSTs `{token, public key, worker fingerprint}` to the new public doorbell `POST /api/codex-cloud/enroll`. Private keys never transit in either direction — the daemon signs an SPKI public key.
3. **Issue (home):** the token is burned atomically under the broker's sidecar lock (unknown / used / expired refuse **identically**; the doorbell is rate-limited), a client certificate is issued from the access CA, and the identity record is written with the system-issued **`cloud-worker`** profile and a hard `expires_at` (default 3600 s). The worker's boot fingerprint (probe format) folds onto the lease like a probe's — a stolen-token redemption from foreign hardware displaces the recorded fingerprint and shows up as a counted replacement.
4. **Connect:** the worker dials home's gateway over mTLS pinned to the server fingerprint baked into the prompt. The gateway's WS admission path routes an authenticated `cloud-worker` socket to the attachment lane **before any dashboard grant is minted or bearer checked** — the socket *is* the attachment: lease `connected` while it lives, `disconnected` when it dies. Home's daemon stays the store's single writer.

## The `cloud-worker` ceiling

`ProfileClass::CloudWorker` joins the vocabulary via a new `SYSTEM_PROFILES` table: recognized by every enforcement path, **never operator-assignable** (`require_known_profile` rejects it; the dashboard picker's parity test mirrors `PROFILES` alone), and `profile_allows_operation` returns `false` for every operation — strictly less than presence-only. The identity record's expiry is the enforced lane: `resolve_peer_connection_identity_from_cert_dir` refuses expired records on every connection, so a leaked identity dies on its own clock (the x509 validity is deliberately not the enforcement surface — nothing but this gateway trusts the access CA).

## Open question #1 (operation direction) — answered

Slice 1 deliberately does **not** register the accepted socket as a peer transport: `serve_attachment_socket` holds it as a pure heartbeat. The home→worker operation inversion over the worker→home dial is slice 2's first task, with two candidate paths: (a) register the accepted WS as an outbound-equivalent transport for a synthetic, non-persisted peer — the relay lane already decouples dial direction from operation direction (`peer/transport/multi.rs`), so the machinery exists to imitate on direct-inbound; or (b) route slice 2 through the relay lane (both sides dial out). The broker/identity work here is unchanged under either.

## Verification

- Full keyless battery green: `cargo test -p intendant --bins` (5132), library crates, `cargo test -p intendant --test e2e` (33), workspace Clippy `-D warnings`, fmt.
- Unit tests: token single-use/expiry with identical refusals + no plaintext at rest, redemption issuing an expiring zero-authority identity (real temp CA), prompt content, system-profile recognition/assignability, redacted `Debug` pins.
- **Live loopback rig** (isolated `HOME`, mock provider, real daemon on an ephemeral TLS port; agent run against it exactly as the prompt spells): enroll → pinned mTLS dial → daemon logs `worker attached` → lease `connected` with fingerprint recorded → agent killed → lease `disconnected` → burned-token replay refused with the uniform message → the issued cert probed against real API routes answers 403 `peer profile cloud-worker does not allow …` on every operation.

Slices 2 (terminal on the Cloud card) and 3 (Xvfb display + CU) follow per the brief.
