### PR TITLE
Codex Cloud attach: key enrollment throttling by the listener's source bucket

### DIFF
--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -1192,7 +1192,7 @@ pub(crate) async fn serve_http_request(
                     stream,
                     route_body,
                     cert_dir,
-                    peer_addr,
+                    source_hint.clone(),
                     route.cors,
                     fleet_cors_origin.as_deref(),
                 )

--- a/src/bin/caller/web_gateway/routes_codex_cloud.rs
+++ b/src/bin/caller/web_gateway/routes_codex_cloud.rs
@@ -89,18 +89,18 @@ pub(crate) async fn handle_codex_cloud_enroll(
     stream: DemuxStream,
     body: String,
     cert_dir: PathBuf,
-    peer_addr: std::net::SocketAddr,
+    source_hint: String,
     cors: crate::gateway_routes::CorsPosture,
     fleet_origin: Option<&str>,
 ) {
-    let response = codex_cloud_enroll_response(body, cert_dir, peer_addr).await;
+    let response = codex_cloud_enroll_response(body, cert_dir, source_hint).await;
     write_api_response(stream, response, cors, fleet_origin).await;
 }
 
 async fn codex_cloud_enroll_response(
     body: String,
     cert_dir: PathBuf,
-    peer_addr: std::net::SocketAddr,
+    source_hint: String,
 ) -> ApiResponse {
     // Parse before counting: unparseable spray never consumes the
     // allowance, so it cannot starve well-formed redemptions.
@@ -110,10 +110,11 @@ async fn codex_cloud_enroll_response(
             return ApiResponse::json_error(400, format!("invalid enrollment request: {error}"))
         }
     };
-    if !crate::codex_cloud_attach::enroll_rate_ok(
-        &peer_addr.ip().to_string(),
-        crate::codex_cloud::now_unix_ms(),
-    ) {
+    // The listener's per-client source bucket, like the pairing doorbell:
+    // the peer IP on direct ingress, the relay-preamble bucket on
+    // reachability-relay ingress — never the relay's own dial-back
+    // address, which would fold every relayed worker into one queue.
+    if !crate::codex_cloud_attach::enroll_rate_ok(&source_hint, crate::codex_cloud::now_unix_ms()) {
         return ApiResponse::json_error(429, "enrollment is rate limited; retry shortly");
     }
     let outcome = tokio::task::spawn_blocking(move || {


### PR DESCRIPTION
Follow-up to #595, fixing its review finding (the branch entered the merge queue before the fix could ride along):

On `ReachabilityRelay` ingress the connection's `peer_addr` is the relay's own dial-back socket, so keying the enroll limiter by peer IP folded every relayed worker into one per-source queue — ten valid attempts from any relay client 429'd all relayed enrollments for the rest of the window. The listener already derives the correct throttling identity for exactly this situation (the relay-preamble per-client bucket on relay ingress, the peer IP on direct ingress) and hands it to dispatch as `source_hint`, which the pairing doorbell's limiter already consumes. The enroll handler now takes that same `source_hint` instead of `peer_addr`.

Two-file change; full battery green (5135 bins tests, workspace Clippy `-D warnings`, fmt).
