### PR TITLE
Doorbell limiter hardening: per-source org presentation window, bounded pairing limiter map

### DIFF
--- a/src/bin/caller/access/org.rs
+++ b/src/bin/caller/access/org.rs
@@ -1138,14 +1138,17 @@ fn present_org_grant_plan(
 /// subject must later authenticate over peer mTLS; a browser-key subject is
 /// record-only until a real browser-key ingress exists. A peer grant commits its inert IAM audit before the
 /// identity record, so a partial failure can leave audit history but never
-/// usable peer authority whose IAM commit failed.
+/// usable peer authority whose IAM commit failed. `source` is the caller's
+/// doorbell bucket for [`presentation_rate_ok`]; non-listener callers pass a
+/// fixed lane label such as `"local"`.
 pub fn present_org_grant_value(
     cert_dir: &std::path::Path,
+    source: &str,
     doc_value: &serde_json::Value,
     extra_daemon_ids: &[String],
     now_unix_ms: u64,
 ) -> Result<PresentedOrgGrant, String> {
-    if !presentation_rate_ok(now_unix_ms) {
+    if !presentation_rate_ok(source, now_unix_ms) {
         return Err("too many org grant presentations; retry shortly".to_string());
     }
     crate::access::iam::transact_state(cert_dir, |state, transaction| {
@@ -1807,23 +1810,64 @@ pub fn revoke_org(
     Ok(revoked)
 }
 
-/// Fixed-window limiter for the public presentation endpoint.
-pub fn presentation_rate_ok(now_unix_ms: u64) -> bool {
-    use std::sync::{Mutex, OnceLock};
-    const WINDOW_MS: u64 = 60_000;
-    const MAX_PER_WINDOW: u32 = 30;
-    static WINDOW: OnceLock<Mutex<(u64, u32)>> = OnceLock::new();
-    let mut window = WINDOW
-        .get_or_init(|| Mutex::new((0, 0)))
-        .lock()
-        .expect("org presentation limiter poisoned");
-    if now_unix_ms.saturating_sub(window.0) >= WINDOW_MS {
-        *window = (now_unix_ms, 0);
+/// Doorbell limiter for the public org presentation surface, per-source
+/// first (the enroll doorbell's design in
+/// `codex_cloud_attach::enroll_rate_ok`): one cheap scanner must not be
+/// able to hold the public presentation doorbell at its cap for everyone,
+/// so each source gets its own sliding window and the global window is
+/// only the wider backstop. The signed document stays the real
+/// authorization; this only keeps the store from being ground. Emptied
+/// source queues are dropped so the map cannot grow without bound under
+/// rotating sources.
+struct PresentationRateLimiter {
+    global: std::collections::VecDeque<u64>,
+    per_source: std::collections::HashMap<String, std::collections::VecDeque<u64>>,
+}
+
+static PRESENTATION_RATE: std::sync::OnceLock<std::sync::Mutex<PresentationRateLimiter>> =
+    std::sync::OnceLock::new();
+const PRESENTATION_RATE_WINDOW_MS: u64 = 60_000;
+const PRESENTATION_RATE_GLOBAL_MAX: usize = 60;
+const PRESENTATION_RATE_PER_SOURCE_MAX: usize = 10;
+
+fn prune_presentation_window(queue: &mut std::collections::VecDeque<u64>, now_unix_ms: u64) {
+    while let Some(at_ms) = queue.front().copied() {
+        if now_unix_ms.saturating_sub(at_ms) < PRESENTATION_RATE_WINDOW_MS {
+            break;
+        }
+        queue.pop_front();
     }
-    if window.1 >= MAX_PER_WINDOW {
+}
+
+/// `source` is the listener's per-client bucket on the public HTTP door
+/// (the peer IP on direct ingress, the relay-preamble bucket on
+/// reachability-relay ingress) and a fixed lane label on authenticated or
+/// local callers.
+pub fn presentation_rate_ok(source: &str, now_unix_ms: u64) -> bool {
+    let limiter = PRESENTATION_RATE.get_or_init(|| {
+        std::sync::Mutex::new(PresentationRateLimiter {
+            global: std::collections::VecDeque::new(),
+            per_source: std::collections::HashMap::new(),
+        })
+    });
+    let mut limiter = limiter
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    limiter.per_source.retain(|_, queue| {
+        prune_presentation_window(queue, now_unix_ms);
+        !queue.is_empty()
+    });
+    prune_presentation_window(&mut limiter.global, now_unix_ms);
+    if limiter.global.len() >= PRESENTATION_RATE_GLOBAL_MAX {
         return false;
     }
-    window.1 += 1;
+    let source_queue = limiter.per_source.entry(source.to_string()).or_default();
+    prune_presentation_window(source_queue, now_unix_ms);
+    if source_queue.len() >= PRESENTATION_RATE_PER_SOURCE_MAX {
+        return false;
+    }
+    source_queue.push_back(now_unix_ms);
+    limiter.global.push_back(now_unix_ms);
     true
 }
 
@@ -2894,7 +2938,7 @@ mod tests {
         let document_value = serde_json::to_value(&document).unwrap();
         let presentation_thread = std::thread::spawn(move || {
             presentation_started_tx.send(()).unwrap();
-            present_org_grant_value(&presentation_dir, &document_value, &[], test_now())
+            present_org_grant_value(&presentation_dir, "local", &document_value, &[], test_now())
         });
         presentation_started_rx.recv().unwrap();
         release_apply_tx.send(()).unwrap();
@@ -2952,7 +2996,8 @@ mod tests {
         .unwrap();
         crate::access::iam::save_state(directory.path(), &initial).unwrap();
         let document_value = serde_json::to_value(&document).unwrap();
-        present_org_grant_value(directory.path(), &document_value, &[], test_now()).unwrap();
+        present_org_grant_value(directory.path(), "local", &document_value, &[], test_now())
+            .unwrap();
 
         let (revoke_has_lock_tx, revoke_has_lock_rx) = mpsc::channel();
         let (release_revoke_tx, release_revoke_rx) = mpsc::channel();
@@ -2972,7 +3017,7 @@ mod tests {
         let presentation_dir = directory.path().to_path_buf();
         let presentation_thread = std::thread::spawn(move || {
             presentation_started_tx.send(()).unwrap();
-            present_org_grant_value(&presentation_dir, &document_value, &[], test_now())
+            present_org_grant_value(&presentation_dir, "local", &document_value, &[], test_now())
         });
         presentation_started_rx.recv().unwrap();
         release_revoke_tx.send(()).unwrap();
@@ -3031,6 +3076,7 @@ mod tests {
         std::fs::set_permissions(directory.path(), readonly).unwrap();
         let result = present_org_grant_value(
             directory.path(),
+            "local",
             &serde_json::to_value(&document).unwrap(),
             &[],
             test_now(),
@@ -3044,5 +3090,36 @@ mod tests {
                 .is_none(),
             "peer authority must not exist unless its IAM audit committed first"
         );
+    }
+
+    #[test]
+    fn presentation_rate_limit_is_per_source_with_a_global_backstop() {
+        // Far-future epoch in a distinctive range (the enroll limiter
+        // test's trick) so parallel tests sharing the process-wide
+        // limiter cannot interfere inside this window: real-clock
+        // callers use other buckets, and a real-clock prune vantage
+        // never counts future entries as stale.
+        let base = 3_600_000_000_000u64;
+        for i in 0..PRESENTATION_RATE_PER_SOURCE_MAX {
+            assert!(presentation_rate_ok("203.0.113.5", base + i as u64), "{i}");
+        }
+        // The noisy source is throttled…
+        assert!(!presentation_rate_ok("203.0.113.5", base + 50));
+        // …while a different source is untouched.
+        assert!(presentation_rate_ok("203.0.113.6", base + 51));
+        // The noisy source recovers once its window slides…
+        assert!(presentation_rate_ok(
+            "203.0.113.5",
+            base + PRESENTATION_RATE_WINDOW_MS + 100
+        ));
+        // …and that check also dropped every emptied aged-out queue from
+        // the map instead of retaining it forever.
+        let limiter = PRESENTATION_RATE
+            .get()
+            .unwrap()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        assert!(!limiter.per_source.contains_key("203.0.113.6"));
+        assert!(limiter.per_source.contains_key("203.0.113.5"));
     }
 }

--- a/src/bin/caller/peer/access_request.rs
+++ b/src/bin/caller/peer/access_request.rs
@@ -1091,12 +1091,28 @@ fn enforce_create_rate_limits(
     source_hint: Option<&str>,
     config: &PeerAccessRequestConfig,
 ) -> Result<(), CallerError> {
-    let now = unix_timestamp();
+    enforce_create_rate_limits_at(source_hint, config, unix_timestamp())
+}
+
+fn enforce_create_rate_limits_at(
+    source_hint: Option<&str>,
+    config: &PeerAccessRequestConfig,
+    now: i64,
+) -> Result<(), CallerError> {
     let limiter = CREATE_RATE_LIMITER.get_or_init(|| StdMutex::new(CreateRateLimiter::default()));
     let mut limiter = limiter
         .lock()
         .map_err(|_| CallerError::Config("peer access request rate limiter poisoned".into()))?;
     let window_secs = effective_rate_limit_window_secs(config);
+
+    // Prune every source queue and drop the emptied ones (the enroll
+    // doorbell's design in `codex_cloud_attach::enroll_rate_ok`): without
+    // the drop, rotating source hints would grow the map without bound
+    // over the daemon's lifetime.
+    limiter.per_source.retain(|_, queue| {
+        prune_rate_queue(queue, now, window_secs);
+        !queue.is_empty()
+    });
 
     prune_rate_queue(&mut limiter.global, now, window_secs);
     if limiter.global.len() >= config.max_creates_per_window {
@@ -1942,8 +1958,17 @@ mod tests {
         assert_eq!(project.config.peers[0].card_url, result.card_url);
     }
 
+    /// The create limiter is process-global, and the aging test below
+    /// prunes from a far-future vantage that would count every real-clock
+    /// entry as stale — interleaved with this real-clock streak it could
+    /// erase the streak mid-test. Serialize the two limiter tests.
+    static RATE_LIMIT_TEST_SERIALIZER: StdMutex<()> = StdMutex::new(());
+
     #[test]
     fn create_rate_limit_rejects_excess_per_source() {
+        let _serialized = RATE_LIMIT_TEST_SERIALIZER
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let source = format!(
             "test-rate-{}-{:?}",
             unix_timestamp(),
@@ -1964,6 +1989,38 @@ mod tests {
                 .contains("peer access request rate limit exceeded"),
             "err: {err}"
         );
+    }
+
+    #[test]
+    fn create_rate_limit_drops_emptied_source_entries() {
+        let _serialized = RATE_LIMIT_TEST_SERIALIZER
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // Far-future epoch in a distinctive range (same trick as the
+        // enroll limiter's test): parallel tests use the real clock, so
+        // nothing else can land entries inside this window — and a
+        // real-clock prune vantage never counts future entries as stale.
+        let base: i64 = 4_000_000_000;
+        let config = PeerAccessRequestConfig::default();
+        let window_secs = effective_rate_limit_window_secs(&config);
+        let source_a = "test-drop-source-a";
+        let source_b = "test-drop-source-b";
+
+        enforce_create_rate_limits_at(Some(source_a), &config, base).unwrap();
+        {
+            let limiter = CREATE_RATE_LIMITER.get().unwrap().lock().unwrap();
+            assert!(limiter.per_source.contains_key(source_a));
+        }
+
+        // Once its window ages out, any later check drops the emptied
+        // entry from the map instead of retaining it forever.
+        enforce_create_rate_limits_at(Some(source_b), &config, base + window_secs + 1).unwrap();
+        let limiter = CREATE_RATE_LIMITER.get().unwrap().lock().unwrap();
+        assert!(
+            !limiter.per_source.contains_key(source_a),
+            "aged-out source entry must be dropped, not kept as an empty queue"
+        );
+        assert!(limiter.per_source.contains_key(source_b));
     }
 
     #[test]

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -1901,11 +1901,15 @@ pub(crate) async fn serve_http_request(
                 .await;
             }
             RouteHandlerId::AccessOrgGrantPresent => {
+                // The listener's per-client doorbell bucket (peer IP on
+                // direct ingress, relay-preamble bucket on relay ingress)
+                // — an availability hint only, never authority.
                 return handle_access_org_grant_present(
                     stream,
                     route_body,
                     cert_dir,
                     agent_card_value_for_targets,
+                    source_hint,
                     route.cors,
                 )
                 .await;
@@ -1915,7 +1919,12 @@ pub(crate) async fn serve_http_request(
             }
             RouteHandlerId::AccessOrgApplyRenew => {
                 return handle_access_org_apply_renew(
-                    stream, route_body, req_path, cert_dir, route.cors,
+                    stream,
+                    route_body,
+                    req_path,
+                    cert_dir,
+                    source_hint,
+                    route.cors,
                 )
                 .await;
             }

--- a/src/bin/caller/web_gateway/routes_access.rs
+++ b/src/bin/caller/web_gateway/routes_access.rs
@@ -387,6 +387,7 @@ pub(crate) async fn handle_access_org_grant_present(
     body_text: String,
     cert_dir: std::path::PathBuf,
     agent_card_value_for_targets: std::sync::Arc<serde_json::Value>,
+    source_hint: String,
     cors: crate::gateway_routes::CorsPosture,
 ) {
     // Transport-owned body decode; the doorbell's parse-error 400 rides
@@ -395,7 +396,12 @@ pub(crate) async fn handle_access_org_grant_present(
         Ok(params) => {
             // Materializes grants — an authority transaction.
             blocking_access_response(move || {
-                access_org_present_api_response(&cert_dir, params, &agent_card_value_for_targets)
+                access_org_present_api_response_from_source(
+                    &cert_dir,
+                    &source_hint,
+                    params,
+                    &agent_card_value_for_targets,
+                )
             })
             .await
         }
@@ -423,6 +429,7 @@ pub(crate) async fn handle_access_org_apply_renew(
     body_text: String,
     req_path: &str,
     cert_dir: std::path::PathBuf,
+    source_hint: String,
     cors: crate::gateway_routes::CorsPosture,
 ) {
     // The per-path caps (ORL vs grant-doc) live on the two table rows;
@@ -433,9 +440,9 @@ pub(crate) async fn handle_access_org_apply_renew(
             // Both leaves run authority transactions.
             blocking_access_response(move || {
                 if is_orl_apply {
-                    access_org_orl_apply_api_response(&cert_dir, params)
+                    access_org_orl_apply_api_response_from_source(&cert_dir, &source_hint, params)
                 } else {
-                    access_org_renew_api_response(&cert_dir, params)
+                    access_org_renew_api_response_from_source(&cert_dir, &source_hint, params)
                 }
             })
             .await
@@ -1095,16 +1102,41 @@ pub(crate) fn access_org_manage_api_response(
     access_result_api_response(result, 400)
 }
 
-/// POST /api/access/org-grants + the tunnel's `api_access_org_present`
-/// (the doorbell class: the signed document is the authorization).
+/// Doorbell bucket for the dashboard-control tunnel twins of the org
+/// doorbell quartet: tunnel callers are authenticated, IAM-gated
+/// dashboard sessions rather than listener sources, so the whole lane
+/// shares one fixed bucket (distinct from any peer address, which keeps
+/// public-door scanners from starving it past the global backstop).
+const ORG_DOORBELL_TUNNEL_SOURCE: &str = "dashboard-control";
+
+/// POST /api/access/org-grants (the doorbell class: the signed document
+/// is the authorization). `source` is the listener's per-client bucket —
+/// the peer IP on direct ingress, the relay-preamble bucket on
+/// reachability-relay ingress.
+pub(crate) fn access_org_present_api_response_from_source(
+    cert_dir: &std::path::Path,
+    source: &str,
+    params: serde_json::Value,
+    agent_card: &serde_json::Value,
+) -> ApiResponse {
+    access_result_api_response(
+        access_org_present_response_value(cert_dir, source, params, agent_card),
+        400,
+    )
+}
+
+/// The tunnel's `api_access_org_present`, on the fixed tunnel-lane
+/// doorbell bucket.
 pub(crate) fn access_org_present_api_response(
     cert_dir: &std::path::Path,
     params: serde_json::Value,
     agent_card: &serde_json::Value,
 ) -> ApiResponse {
-    access_result_api_response(
-        access_org_present_response_value(cert_dir, params, agent_card),
-        400,
+    access_org_present_api_response_from_source(
+        cert_dir,
+        ORG_DOORBELL_TUNNEL_SOURCE,
+        params,
+        agent_card,
     )
 }
 
@@ -1115,22 +1147,48 @@ pub(crate) fn access_org_orl_api_response(cert_dir: &std::path::Path, handle: &s
     access_result_api_response(access_org_orl_response_value(cert_dir, handle), 404)
 }
 
-/// POST /api/access/orgs/revocations/apply + the tunnel's
-/// `api_access_org_orl_apply`.
+/// POST /api/access/orgs/revocations/apply, with the listener's
+/// per-client doorbell bucket as `source`.
+pub(crate) fn access_org_orl_apply_api_response_from_source(
+    cert_dir: &std::path::Path,
+    source: &str,
+    params: serde_json::Value,
+) -> ApiResponse {
+    access_result_api_response(
+        access_org_orl_apply_response_value(cert_dir, source, params),
+        400,
+    )
+}
+
+/// The tunnel's `api_access_org_orl_apply`, on the fixed tunnel-lane
+/// doorbell bucket.
 pub(crate) fn access_org_orl_apply_api_response(
     cert_dir: &std::path::Path,
     params: serde_json::Value,
 ) -> ApiResponse {
-    access_result_api_response(access_org_orl_apply_response_value(cert_dir, params), 400)
+    access_org_orl_apply_api_response_from_source(cert_dir, ORG_DOORBELL_TUNNEL_SOURCE, params)
 }
 
-/// POST /api/access/org-grants/renew + the tunnel's
-/// `api_access_org_renew`.
+/// POST /api/access/org-grants/renew, with the listener's per-client
+/// doorbell bucket as `source`.
+pub(crate) fn access_org_renew_api_response_from_source(
+    cert_dir: &std::path::Path,
+    source: &str,
+    params: serde_json::Value,
+) -> ApiResponse {
+    access_result_api_response(
+        access_org_renew_response_value(cert_dir, source, params),
+        400,
+    )
+}
+
+/// The tunnel's `api_access_org_renew`, on the fixed tunnel-lane
+/// doorbell bucket.
 pub(crate) fn access_org_renew_api_response(
     cert_dir: &std::path::Path,
     params: serde_json::Value,
 ) -> ApiResponse {
-    access_result_api_response(access_org_renew_response_value(cert_dir, params), 400)
+    access_org_renew_api_response_from_source(cert_dir, ORG_DOORBELL_TUNNEL_SOURCE, params)
 }
 
 /// POST /api/access/fleet-cert/request + the tunnel's
@@ -2208,11 +2266,13 @@ pub(crate) fn is_public_org_grant_path(request_line: &str) -> bool {
 /// — as on the other doorbell fns below.
 pub(crate) fn access_org_present_response_value(
     cert_dir: &std::path::Path,
+    source: &str,
     params: serde_json::Value,
     agent_card: &serde_json::Value,
 ) -> Result<serde_json::Value, String> {
     let outcome = crate::access::org::present_org_grant_value(
         cert_dir,
+        source,
         &params,
         &org_target_agent_card_ids(agent_card),
         crate::access::client_key::now_unix_ms() as u64,
@@ -2496,10 +2556,11 @@ pub(crate) fn access_org_orl_response_value(
 /// a partial failure is therefore fail-closed and remains retryable.
 pub(crate) fn access_org_orl_apply_response_value(
     cert_dir: &std::path::Path,
+    source: &str,
     params: serde_json::Value,
 ) -> Result<serde_json::Value, String> {
     let now = crate::access::client_key::now_unix_ms() as u64;
-    if !crate::access::org::presentation_rate_ok(now) {
+    if !crate::access::org::presentation_rate_ok(source, now) {
         return Err("too many org grant presentations; retry shortly".to_string());
     }
     if serde_json::to_string(&params)
@@ -2637,10 +2698,11 @@ pub(crate) fn access_org_revoke_member_response_value(
 /// revocation list gates it.
 pub(crate) fn access_org_renew_response_value(
     cert_dir: &std::path::Path,
+    source: &str,
     params: serde_json::Value,
 ) -> Result<serde_json::Value, String> {
     let now = crate::access::client_key::now_unix_ms() as u64;
-    if !crate::access::org::presentation_rate_ok(now) {
+    if !crate::access::org::presentation_rate_ok(source, now) {
         return Err("too many org grant presentations; retry shortly".to_string());
     }
     if serde_json::to_string(&params)
@@ -5669,9 +5731,13 @@ mod tests {
         // the shared present core (derived through it over the same
         // tempdir store); 400 under the public tail.
         let card = serde_json::json!({});
-        let expected_error =
-            access_org_present_response_value(&cert_dir, serde_json::json!({}), &card)
-                .expect_err("empty org grant document must not verify");
+        let expected_error = access_org_present_response_value(
+            &cert_dir,
+            "golden-transcript",
+            serde_json::json!({}),
+            &card,
+        )
+        .expect_err("empty org grant document must not verify");
         let expected_body = serde_json::json!({"error": expected_error}).to_string();
         let response = collect_access_handler_response(|stream| {
             handle_access_org_grant_present(
@@ -5679,6 +5745,7 @@ mod tests {
                 "{}".to_string(),
                 cert_dir.clone(),
                 std::sync::Arc::new(card.clone()),
+                "golden-transcript".to_string(),
                 public_cors("POST", "/api/access/org-grants"),
             )
         })
@@ -5699,6 +5766,7 @@ mod tests {
                 invalid.to_string(),
                 cert_dir.clone(),
                 std::sync::Arc::new(card.clone()),
+                "golden-transcript".to_string(),
                 public_cors("POST", "/api/access/org-grants"),
             )
         })
@@ -5742,6 +5810,7 @@ mod tests {
                 "{}".to_string(),
                 "/api/access/orgs/revocations/apply",
                 cert_dir.clone(),
+                "golden-transcript".to_string(),
                 public_cors("POST", "/api/access/orgs/revocations/apply"),
             )
         })
@@ -5764,6 +5833,7 @@ mod tests {
                 "{}".to_string(),
                 "/api/access/org-grants/renew",
                 cert_dir.clone(),
+                "golden-transcript".to_string(),
                 public_cors("POST", "/api/access/org-grants/renew"),
             )
         })


### PR DESCRIPTION
Two pre-existing rate-limiter weaknesses surfaced as follow-ups by the #595 review, both fixed on the exemplar that landed with #595/#596 (`codex_cloud_attach::enroll_rate_ok`): per-source sliding windows with a wider global backstop, plus a prune-then-drop-empty pass so the source map stays bounded.

**Pairing doorbell limiter map growth** (`src/bin/caller/peer/access_request.rs`)

`enforce_create_rate_limits` pruned queue *entries* by window but never removed emptied per-source map entries, so the map grew without bound over daemon lifetime under rotating source hints. Every check now prunes each source queue and drops the emptied ones. Config-driven caps and error strings are unchanged; the limiter core takes an injectable `now` (`enforce_create_rate_limits_at`) so the new test can age a window out deterministically. The new unit test proves an emptied source's map entry is gone once its window ages out (far-future-epoch trick, same as the enroll limiter's test); the two limiter tests are serialized on a test-local mutex because a far-future prune vantage counts every real-clock entry as stale and could otherwise erase the real-clock streak test's window mid-test under plain `cargo test` parallelism.

**Org presentation doorbell was a single global window** (`src/bin/caller/access/org.rs`)

`presentation_rate_ok` was one process-wide fixed window (30/min) with no source partitioning, counted for every caller — a single cheap scanner could hold the public org-grant presentation doorbell at its cap for everyone. Converted to the enroll limiter's design: `presentation_rate_ok(source, now_unix_ms)` with per-source sliding windows (10/min) and a global backstop (60/min), pruning + dropping emptied source queues each check. The gateway threads the listener's per-client source bucket (the peer IP on direct ingress, the relay-preamble bucket on reachability-relay ingress) through all three doorbell consumers — present, orl-apply, and renew — exactly the way #596 did for the enroll route (`http_dispatch` arms -> `routes_access` handlers -> `*_response_value` cores). The dashboard-control tunnel twins keep their existing signatures and run on one fixed authenticated-lane bucket (`dashboard-control`), so public-door scanners can no longer starve the tunnel short of the global backstop; `org.rs` tests and other non-listener callers pass `"local"`. Refusal wording is unchanged on every path. New unit test proves per-source isolation (source A exhausted, source B still admitted) plus the emptied-queue drop, using the far-future-epoch trick.

Battery: `cargo fmt --check` clean; `cargo nextest run -p intendant --bins` green; `cargo clippy --workspace -- -D warnings` clean.
