### PR TITLE
feat(github): one-click GitHub connect — App Manifest ceremony (Track GC, GC1)

### DIFF
--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -1945,6 +1945,8 @@ response omits the header.
 | POST | `/api/integrations/github` | CredentialsManage | own origin | ≤ 64 KiB | Configure the GitHub App integration (seal credentials into custody, set the watch list) |
 | GET | `/api/integrations/github/status` | Settings | own origin | none | GitHub App integration status (presence + last exchange; never unseals) |
 | DELETE | `/api/integrations/github` | CredentialsManage | own origin | none | Remove the GitHub App integration credentials from custody |
+| POST | `/api/integrations/github/manifest-start` | CredentialsManage | own origin | ≤ 4 KiB | Begin the one-click GitHub App Manifest ceremony (mints the single-use state; refuses without a custody backend) |
+| GET | `/api/integrations/github/callback` | public | own origin | none | GitHub App Manifest redirect landing (single-use state is the authorization; renders a return-to-dashboard page) |
 | GET | `/api/local-daemons/tokens` | CredentialsManage | own origin | none | Loopback admission tokens for same-home daemon instances (owner handoff) |
 | POST | `/api/claude-auth/start` | CredentialsManage | own origin | ≤ 4 KiB | Start the Claude sign-in ceremony (`claude auth login` on a daemon-private PTY) |
 | GET | `/api/claude-auth/status` | CredentialsManage | own origin | none | Claude sign-in ceremony state (validated sign-in URL; account info on success) |

--- a/src/bin/caller/gateway_routes.rs
+++ b/src/bin/caller/gateway_routes.rs
@@ -208,6 +208,10 @@ pub(crate) const AGENDA_OP_BODY_CAP_BYTES: usize = 16 * 1024 * 1024;
 /// list. Anything near this cap is not a legitimate configure gesture.
 pub(crate) const GITHUB_INTEGRATION_BODY_CAP_BYTES: usize = 64 * 1024;
 
+/// The manifest-start payload: at most an org handle in a small JSON
+/// object. Anything bigger is not a legitimate connect gesture.
+pub(crate) const GITHUB_MANIFEST_START_BODY_CAP_BYTES: usize = 4 * 1024;
+
 /// Body cap for the visual-freshness diagnostics sink (NDJSON transcript
 /// batches).
 pub(crate) const DIAGNOSTICS_BODY_CAP_BYTES: usize = 16 * 1024 * 1024;
@@ -309,6 +313,13 @@ pub(crate) enum RouteHandlerId {
     GithubIntegrationStatus,
     /// Delete the sealed credentials (idempotent, audited).
     GithubIntegrationRemove,
+    /// Begin the one-click App Manifest ceremony: mint the single-use
+    /// state, compose the manifest + form target (custody precheck
+    /// refuses up front where no backend can seal).
+    GithubManifestStart,
+    /// GitHub's redirect landing (browser navigation): burn the state,
+    /// convert the code server-side, seal pending-install.
+    GithubManifestCallback,
     /// Claude sign-in ceremony: start `claude auth login` on a private PTY.
     ClaudeAuthStart,
     /// Ceremony state + validated sign-in URL + account info on success.
@@ -1639,13 +1650,17 @@ pub(crate) static ROUTES: &[Route] = &[
         "Which provider keys are configured (presence only)",
     )
     .with_tunnel(tunnel_method("api_key_status")),
-    // ── GitHub App integration (Track PR): credentials seal into
+    // ── GitHub App integration (Track PR + GC): credentials seal into
     //    OS-keystore custody (`github-app/credentials`, born in custody —
     //    no env/file lane), the watch list is non-secret config. Write
     //    and remove ride the provider-key gate (CredentialsManage);
     //    status is presence + last-exchange state and never unseals.
-    //    Capped tight: an App key PEM is ~3 KB; 64 KiB leaves room for
-    //    ids + a watch list, and nothing legitimate is bigger.
+    //    Family principle (Track GC ruling): any route that unseals the
+    //    key gates at CredentialsManage — "never unseals" is the
+    //    Settings tier's defining property, so credential *use* is
+    //    never a Settings-tier read. Capped tight: an App key PEM is
+    //    ~3 KB; 64 KiB leaves room for ids + a watch list, and nothing
+    //    legitimate is bigger.
     op_route(
         RouteMethod::Post,
         PathPattern::Exact("/api/integrations/github"),
@@ -1673,6 +1688,40 @@ pub(crate) static ROUTES: &[Route] = &[
         "Remove the GitHub App integration credentials from custody",
     )
     .with_tunnel(tunnel_method("api_github_integration_remove")),
+    // ── One-click connect (Track GC), the App Manifest ceremony.
+    //    Manifest-start is HTTP-only like the loopback-token row below:
+    //    its payload (form target + state) is only meaningful to a
+    //    browser co-located with this origin — the redirect must land
+    //    back HERE — so a tunnel twin would mint states for ceremonies
+    //    that cannot complete (the peer-dashboard leg is deferred; the
+    //    manual form is its documented path).
+    op_route(
+        RouteMethod::Post,
+        PathPattern::Exact("/api/integrations/github/manifest-start"),
+        PeerOperation::CredentialsManage,
+        BodyPolicy::Capped(GITHUB_MANIFEST_START_BODY_CAP_BYTES),
+        RouteHandlerId::GithubManifestStart,
+        "Begin the one-click GitHub App Manifest ceremony (mints the single-use state; refuses without a custody backend)",
+    ),
+    //    The callback is GitHub's redirect: a top-level browser
+    //    navigation carrying no daemon credential, so the row is
+    //    authority-free BY NAME and the daemon-minted single-use state
+    //    is the handler's entire authorization (the doorbell doctrine;
+    //    without a valid state the code is never exchanged). Own-origin
+    //    CORS like the passkey ceremonies: a navigation needs no ACAO,
+    //    and foreign pages get nothing to read from a drive-by fetch.
+    //    No tunnel twin: the only legitimate caller is GitHub's
+    //    redirect landing in a browser — a datachannel method can never
+    //    be that. The path must also sit in the certless carve-out
+    //    (`access_gates::allows_remote_certless_http`) or the origin
+    //    and client-auth gates refuse the navigation before dispatch.
+    public_own_origin_route(
+        RouteMethod::Get,
+        PathPattern::Exact(crate::github_pr::manifest_ceremony::CALLBACK_PATH),
+        BodyPolicy::None,
+        RouteHandlerId::GithubManifestCallback,
+        "GitHub App Manifest redirect landing (single-use state is the authorization; renders a return-to-dashboard page)",
+    ),
     // ── Same-home sibling loopback-token handoff (ratified 2026-07-20):
     //    the response contains per-boot loopback admission tokens, so
     //    the route rides the credential-custody operation like the

--- a/src/bin/caller/github_pr/client.rs
+++ b/src/bin/caller/github_pr/client.rs
@@ -572,12 +572,17 @@ pub(crate) async fn convert_manifest_code(
         .header("X-GitHub-Api-Version", API_VERSION)
         .send()
         .await
-        .map_err(|error| ApiError::Unreachable(error.to_string()))?;
+        // `without_url`: reqwest's Display embeds the request URL, and
+        // this one carries the still-live single-use code — it must
+        // never reach an error page or a log line.
+        .map_err(|error| ApiError::Unreachable(error.without_url().to_string()))?;
     let response = classify(response).await?;
     response
         .json::<ManifestConversion>()
         .await
-        .map_err(|error| ApiError::Unreachable(format!("conversion response: {error}")))
+        .map_err(|error| {
+            ApiError::Unreachable(format!("conversion response: {}", error.without_url()))
+        })
 }
 
 /// Map a non-2xx response onto the named failure classes. 304 never

--- a/src/bin/caller/github_pr/client.rs
+++ b/src/bin/caller/github_pr/client.rs
@@ -256,10 +256,19 @@ impl GithubAppClient {
                 return Ok(cached.token.clone());
             }
         }
+        // A pending-install document has no installation to mint against;
+        // the named refusal keeps the ceremony phase honest (Denied stays
+        // until the install completes the document).
+        let Some(installation_id) = self.credentials.installation_id else {
+            return Err(ApiError::Denied(
+                "installation pending — install the App on GitHub and finish discovery"
+                    .to_string(),
+            ));
+        };
         let jwt = mint_app_jwt(&self.credentials, now).map_err(ApiError::Denied)?;
         let url = format!(
             "{}/app/installations/{}/access_tokens",
-            self.api_base, self.credentials.installation_id
+            self.api_base, installation_id
         );
         let response = self
             .http
@@ -525,6 +534,53 @@ fn next_page_url(response: &reqwest::Response) -> Option<String> {
     None
 }
 
+/// What the manifest ceremony keeps from GitHub's conversion response.
+/// Deliberately three fields: `client_secret` and `webhook_secret` are
+/// in the response but **never materialize as retained values** — the
+/// narrow parse is the discard (serde ignores the rest of the body).
+#[derive(serde::Deserialize)]
+pub(crate) struct ManifestConversion {
+    pub(crate) id: u64,
+    pub(crate) slug: String,
+    pub(crate) pem: String,
+}
+
+/// Exchange a manifest-flow `code` for the created App's identity:
+/// `POST {api_base}/app-manifests/{code}/conversions`. Credential-less
+/// by design — the single-use code GitHub minted at the owner's Create
+/// click is the entire authorization, so this is a free function, not a
+/// `GithubAppClient` method (no key exists until this call returns).
+/// GitHub answers 201 with the full App object; 404 for an
+/// invalid/expired/used code lands in the `Denied` class via
+/// [`classify`].
+pub(crate) async fn convert_manifest_code(
+    api_base: &str,
+    code: &str,
+) -> Result<ManifestConversion, ApiError> {
+    let http = reqwest::Client::builder()
+        .user_agent("intendant")
+        .timeout(HTTP_TIMEOUT)
+        .build()
+        .map_err(|error| ApiError::Unreachable(format!("http client: {error}")))?;
+    let url = format!(
+        "{}/app-manifests/{}/conversions",
+        api_base.trim_end_matches('/'),
+        code
+    );
+    let response = http
+        .post(&url)
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", API_VERSION)
+        .send()
+        .await
+        .map_err(|error| ApiError::Unreachable(error.to_string()))?;
+    let response = classify(response).await?;
+    response
+        .json::<ManifestConversion>()
+        .await
+        .map_err(|error| ApiError::Unreachable(format!("conversion response: {error}")))
+}
+
 /// Map a non-2xx response onto the named failure classes. 304 never
 /// reaches here (handled at the call site).
 async fn classify(response: reqwest::Response) -> Result<reqwest::Response, ApiError> {
@@ -655,7 +711,8 @@ pub(crate) mod test_fixture {
         GithubAppCredentials {
             v: 1,
             app_id: "123456".to_string(),
-            installation_id: 987,
+            installation_id: Some(987),
+            slug: None,
             private_key_pem: TEST_RSA_PKCS1_PEM.to_string(),
         }
     }

--- a/src/bin/caller/github_pr/client.rs
+++ b/src/bin/caller/github_pr/client.rs
@@ -261,8 +261,7 @@ impl GithubAppClient {
         // until the install completes the document).
         let Some(installation_id) = self.credentials.installation_id else {
             return Err(ApiError::Denied(
-                "installation pending — install the App on GitHub and finish discovery"
-                    .to_string(),
+                "installation pending — install the App on GitHub and finish discovery".to_string(),
             ));
         };
         let jwt = mint_app_jwt(&self.credentials, now).map_err(ApiError::Denied)?;

--- a/src/bin/caller/github_pr/credentials.rs
+++ b/src/bin/caller/github_pr/credentials.rs
@@ -133,7 +133,10 @@ mod tests {
         let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         let map = json.as_object().unwrap();
         assert!(!map.contains_key("slug"), "absent slug must not serialize");
-        assert_eq!(map["installation_id"], 987, "completed id stays a plain number");
+        assert_eq!(
+            map["installation_id"], 987,
+            "completed id stays a plain number"
+        );
 
         let legacy = serde_json::json!({
             "v": 1,

--- a/src/bin/caller/github_pr/credentials.rs
+++ b/src/bin/caller/github_pr/credentials.rs
@@ -21,12 +21,25 @@ fn default_doc_version() -> u32 {
 pub(crate) struct GithubAppCredentials {
     /// Document version; bump only on a breaking shape change. A newer
     /// version fails the parse by name rather than being half-read.
+    /// (The pending-install and `slug` fields below are additive within
+    /// v1: completed documents stay byte-compatible with older builds,
+    /// and a pending document read by an older build fails its parse by
+    /// name — the named pause lane — never a mis-read.)
     #[serde(default = "default_doc_version")]
     pub(crate) v: u32,
     /// The App ID (numeric) or client ID — either is a valid JWT `iss`.
     pub(crate) app_id: String,
-    /// The installation of the App on the watched org/repos.
-    pub(crate) installation_id: u64,
+    /// The installation of the App on the watched org/repos. Absent =
+    /// sealed-pending-install: the manifest ceremony created the App
+    /// and sealed its key, but the owner has not installed it yet, so
+    /// no installation token can be minted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) installation_id: Option<u64>,
+    /// The App's slug (the `github.com/apps/{slug}` segment), recorded
+    /// by the manifest ceremony for the install link. Navigation only —
+    /// never authority.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) slug: Option<String>,
     /// The App's RS256 private key, PEM (PKCS#1 or PKCS#8), normalized
     /// at intake by [`GithubAppCredentials::validate`].
     pub(crate) private_key_pem: String,
@@ -56,14 +69,22 @@ impl GithubAppCredentials {
 
     /// Intake validation: non-empty identity fields and a private key
     /// that actually parses as an RSA signing key. Trims stray
-    /// whitespace so a pasted PEM round-trips byte-stable.
+    /// whitespace so a pasted PEM round-trips byte-stable. An absent
+    /// installation_id is valid (sealed-pending-install); a present one
+    /// must be positive.
     pub(crate) fn validate(&mut self) -> Result<(), String> {
         self.app_id = self.app_id.trim().to_string();
         if self.app_id.is_empty() {
             return Err("app_id must not be empty".to_string());
         }
-        if self.installation_id == 0 {
+        if self.installation_id == Some(0) {
             return Err("installation_id must be a positive integer".to_string());
+        }
+        if let Some(slug) = self.slug.as_mut() {
+            *slug = slug.trim().to_string();
+            if slug.is_empty() {
+                self.slug = None;
+            }
         }
         let trimmed = self.private_key_pem.trim();
         if trimmed.is_empty() {
@@ -83,13 +104,81 @@ mod tests {
         let doc = GithubAppCredentials {
             v: SEALED_DOC_VERSION,
             app_id: "123456".to_string(),
-            installation_id: 987,
+            installation_id: Some(987),
+            slug: None,
             private_key_pem: "irrelevant".to_string(),
         };
         let bytes = doc.sealed_bytes().unwrap();
         let back = GithubAppCredentials::from_sealed_bytes(&bytes).unwrap();
         assert_eq!(back.app_id, "123456");
-        assert_eq!(back.installation_id, 987);
+        assert_eq!(back.installation_id, Some(987));
+        assert_eq!(back.slug, None);
+    }
+
+    /// A completed document serializes without the pending-only fields,
+    /// staying byte-compatible with pre-slug builds (which reject
+    /// unknown fields never — this struct has no `deny_unknown_fields`),
+    /// and a legacy document (no slug, numeric installation_id) parses
+    /// into the evolved shape unchanged.
+    #[test]
+    fn completed_documents_stay_compatible_across_the_shape_evolution() {
+        let doc = GithubAppCredentials {
+            v: SEALED_DOC_VERSION,
+            app_id: "123456".to_string(),
+            installation_id: Some(987),
+            slug: None,
+            private_key_pem: "irrelevant".to_string(),
+        };
+        let bytes = doc.sealed_bytes().unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let map = json.as_object().unwrap();
+        assert!(!map.contains_key("slug"), "absent slug must not serialize");
+        assert_eq!(map["installation_id"], 987, "completed id stays a plain number");
+
+        let legacy = serde_json::json!({
+            "v": 1,
+            "app_id": "77",
+            "installation_id": 42,
+            "private_key_pem": "x",
+        })
+        .to_string();
+        let back = GithubAppCredentials::from_sealed_bytes(legacy.as_bytes()).unwrap();
+        assert_eq!(back.installation_id, Some(42));
+        assert_eq!(back.slug, None);
+    }
+
+    /// The pending shape (no installation_id) round-trips in this build;
+    /// the same bytes fed to the pre-evolution shape fail by the named
+    /// missing field — the fail-closed lane older builds land in.
+    #[test]
+    fn pending_documents_round_trip_here_and_fail_closed_on_old_shapes() {
+        let doc = GithubAppCredentials {
+            v: SEALED_DOC_VERSION,
+            app_id: "123456".to_string(),
+            installation_id: None,
+            slug: Some("intendant-example".to_string()),
+            private_key_pem: "irrelevant".to_string(),
+        };
+        let bytes = doc.sealed_bytes().unwrap();
+        let back = GithubAppCredentials::from_sealed_bytes(&bytes).unwrap();
+        assert_eq!(back.installation_id, None);
+        assert_eq!(back.slug.as_deref(), Some("intendant-example"));
+
+        // The pre-evolution document shape, verbatim from the v1 struct
+        // this build replaced: installation_id was a required u64.
+        #[derive(Debug, serde::Deserialize)]
+        #[allow(dead_code)]
+        struct LegacyShape {
+            v: u32,
+            app_id: String,
+            installation_id: u64,
+            private_key_pem: String,
+        }
+        let error = serde_json::from_slice::<LegacyShape>(&bytes).unwrap_err();
+        assert!(
+            error.to_string().contains("installation_id"),
+            "old builds must fail the pending shape by the named field, got: {error}"
+        );
     }
 
     #[test]
@@ -110,14 +199,16 @@ mod tests {
         let mut doc = GithubAppCredentials {
             v: SEALED_DOC_VERSION,
             app_id: "  ".to_string(),
-            installation_id: 1,
+            installation_id: Some(1),
+            slug: None,
             private_key_pem: "x".to_string(),
         };
         assert!(doc.validate().unwrap_err().contains("app_id"));
         let mut doc = GithubAppCredentials {
             v: SEALED_DOC_VERSION,
             app_id: "1".to_string(),
-            installation_id: 0,
+            installation_id: Some(0),
+            slug: None,
             private_key_pem: "x".to_string(),
         };
         assert!(doc.validate().unwrap_err().contains("installation_id"));
@@ -128,11 +219,25 @@ mod tests {
         let mut doc = GithubAppCredentials {
             v: SEALED_DOC_VERSION,
             app_id: "123".to_string(),
-            installation_id: 7,
+            installation_id: Some(7),
+            slug: Some("  intendant-example  ".to_string()),
             private_key_pem: format!("\n  {}  \n\n", super::super::client::test_rsa_pem()),
         };
         doc.validate().expect("test key must validate");
         assert!(doc.private_key_pem.starts_with("-----BEGIN"));
         assert!(doc.private_key_pem.ends_with("-----\n"));
+        assert_eq!(doc.slug.as_deref(), Some("intendant-example"));
+
+        // The pending shape validates too: absent installation_id is a
+        // legal state, and a whitespace slug normalizes to absent.
+        let mut pending = GithubAppCredentials {
+            v: SEALED_DOC_VERSION,
+            app_id: "123".to_string(),
+            installation_id: None,
+            slug: Some("   ".to_string()),
+            private_key_pem: super::super::client::test_rsa_pem().to_string(),
+        };
+        pending.validate().expect("pending shape must validate");
+        assert_eq!(pending.slug, None);
     }
 }

--- a/src/bin/caller/github_pr/manifest_ceremony.rs
+++ b/src/bin/caller/github_pr/manifest_ceremony.rs
@@ -1,0 +1,431 @@
+//! The one-click connect ceremony (Track GC): daemon-minted single-use
+//! `state` for GitHub's App Manifest flow, plus the manifest the
+//! browser form-POSTs to GitHub.
+//!
+//! The ceremony is **single-flight by replacement**: one pending slot,
+//! and a new manifest-start overwrites (invalidates) the previous one.
+//! This deliberately diverges from `auth_ceremony`'s refuse-second
+//! discipline because the resource here is a slot, not a PTY — there is
+//! no spawned process to orphan, so the newest owner gesture simply
+//! wins. The state token is the callback's **entire** authorization
+//! (the callback route is authority-free by necessity — GitHub's
+//! redirect carries no daemon credential): 32 random bytes, stored
+//! hashed, compared by digest in constant time, burned atomically
+//! **before** the conversion call so a replayed or raced callback can
+//! never reach GitHub. A conversion that then fails ends the ceremony —
+//! fail-closed over convenient; the owner restarts it.
+//!
+//! Core operations live on [`ManifestCeremonySlot`] so tests drive
+//! local instances; the thin free functions at the bottom are the only
+//! thing touching the process global (the status.rs testability split).
+
+use base64::Engine as _;
+use ring::rand::SecureRandom as _;
+
+/// How long a minted state stays redeemable. Inside GitHub's one-hour
+/// code window, generous for a human reading GitHub's create page,
+/// short enough that a forgotten tab is not a standing door.
+pub(crate) const MANIFEST_STATE_TTL_MS: u64 = 30 * 60 * 1000;
+
+/// The uniform refusal: unknown, replayed, expired, and absent states
+/// are deliberately indistinguishable to the caller.
+pub(crate) const STATE_REFUSED: &str =
+    "this connect link is invalid, already used, or expired — start the ceremony again \
+     from the dashboard";
+
+/// One pending ceremony, minted at manifest-start and burned at the
+/// callback. Everything here is non-secret except `state_hash` (a
+/// digest, not the token).
+#[derive(Debug, Clone)]
+pub(crate) struct PendingManifest {
+    /// SHA-256 of the state token, hex — the plaintext never rests.
+    state_hash: String,
+    pub(crate) started_at_unix_ms: u64,
+    pub(crate) expires_at_unix_ms: u64,
+    /// The validated origin (`scheme://authority`) the ceremony started
+    /// from; the redirect returns here and the callback page links back.
+    pub(crate) origin: String,
+    /// Org handle for an org-owned App; `None` = personal account.
+    pub(crate) target_org: Option<String>,
+    /// The principal whose CredentialsManage gesture opened the
+    /// ceremony. The authority-free callback merely completes that
+    /// authorized act, so this is the custody-audit actor at seal time
+    /// (the general attribution rule for authority-free completion
+    /// legs).
+    pub(crate) starter_principal: String,
+}
+
+fn token_hash(token: &str) -> String {
+    let digest = ring::digest::digest(&ring::digest::SHA256, token.as_bytes());
+    digest.as_ref().iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Constant-time byte equality (length gate, then an OR-fold over XOR).
+/// ring deprecated its public helper with no side-channel promises, so
+/// the ruled primitive lives here; it runs on digests anyway
+/// (compare-after-hash), so this is belt and braces.
+fn ct_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter().zip(b).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
+}
+
+fn random_state() -> Result<String, String> {
+    let mut bytes = [0u8; 32];
+    ring::rand::SystemRandom::new()
+        .fill(&mut bytes)
+        .map_err(|_| "generate ceremony state".to_string())?;
+    Ok(base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes))
+}
+
+/// The single-flight pending slot. One per daemon process.
+#[derive(Default)]
+pub(crate) struct ManifestCeremonySlot {
+    pending: std::sync::Mutex<Option<PendingManifest>>,
+}
+
+impl ManifestCeremonySlot {
+    /// Begin a ceremony, replacing (invalidating) any pending one.
+    /// Returns the plaintext state token — the only time it exists
+    /// outside the browser's form action.
+    pub(crate) fn begin(
+        &self,
+        origin: String,
+        target_org: Option<String>,
+        starter_principal: String,
+        now_ms: u64,
+    ) -> Result<String, String> {
+        let token = random_state()?;
+        let pending = PendingManifest {
+            state_hash: token_hash(&token),
+            started_at_unix_ms: now_ms,
+            expires_at_unix_ms: now_ms.saturating_add(MANIFEST_STATE_TTL_MS),
+            origin,
+            target_org,
+            starter_principal,
+        };
+        *self.pending.lock().unwrap_or_else(|p| p.into_inner()) = Some(pending);
+        Ok(token)
+    }
+
+    /// Atomically burn the pending ceremony against a presented state.
+    /// The slot is taken **before** any comparison completes, so two
+    /// raced callbacks cannot both pass, and a mismatch restores
+    /// nothing (a wrong guess costs the attacker the owner's pending
+    /// ceremony, never a second try at it — and costs the owner one
+    /// restart). Unknown, replayed, expired, and absent states are
+    /// indistinguishable ([`STATE_REFUSED`]).
+    pub(crate) fn consume(&self, presented_state: &str, now_ms: u64) -> Result<PendingManifest, String> {
+        let pending = self
+            .pending
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .take()
+            .ok_or_else(|| STATE_REFUSED.to_string())?;
+        let presented_hash = token_hash(presented_state);
+        if !ct_eq(presented_hash.as_bytes(), pending.state_hash.as_bytes()) {
+            return Err(STATE_REFUSED.to_string());
+        }
+        if pending.expires_at_unix_ms <= now_ms {
+            return Err(STATE_REFUSED.to_string());
+        }
+        Ok(pending)
+    }
+
+    /// Whether a live (unexpired) ceremony is pending — status surface
+    /// only; never reveals the hash.
+    pub(crate) fn active(&self, now_ms: u64) -> bool {
+        self.pending
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .as_ref()
+            .is_some_and(|p| p.expires_at_unix_ms > now_ms)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Manifest composition (pure; unit-tested)
+// ---------------------------------------------------------------------------
+
+/// GitHub caps App names at 34 characters; names are globally unique.
+const APP_NAME_MAX: usize = 34;
+
+/// `Intendant (<host>)`, truncated to GitHub's 34-char cap with the
+/// closing paren kept. Collisions surface on GitHub's own create page,
+/// where the name is owner-editable.
+pub(crate) fn manifest_app_name(hostname: &str) -> String {
+    const PREFIX: &str = "Intendant (";
+    const SUFFIX: &str = ")";
+    let budget = APP_NAME_MAX - PREFIX.len() - SUFFIX.len();
+    let host: String = hostname.trim().chars().take(budget).collect();
+    if host.is_empty() {
+        return "Intendant".to_string();
+    }
+    format!("{PREFIX}{host}{SUFFIX}")
+}
+
+/// The GitHub form target for a ceremony: the personal or org create
+/// page, with the state token in the query (GitHub echoes it beside
+/// `code` on the redirect). The org handle is path-escaped — it came
+/// from owner input, not from a trusted vocabulary.
+pub(crate) fn manifest_form_action(target_org: Option<&str>, state: &str) -> String {
+    let encoded_state: String = url::form_urlencoded::byte_serialize(state.as_bytes()).collect();
+    match target_org {
+        Some(org) => {
+            let encoded_org: String = url::form_urlencoded::byte_serialize(org.as_bytes()).collect();
+            format!(
+                "https://github.com/organizations/{encoded_org}/settings/apps/new?state={encoded_state}"
+            )
+        }
+        None => format!("https://github.com/settings/apps/new?state={encoded_state}"),
+    }
+}
+
+/// The manifest document the browser form-POSTs. Read-only permissions
+/// exactly matching the scanner's needs, a private App, and **no
+/// webhook** — `hook_attributes` is omitted entirely (polling is the
+/// only lane this track ships).
+pub(crate) fn manifest_document(origin: &str, hostname: &str) -> serde_json::Value {
+    serde_json::json!({
+        "name": manifest_app_name(hostname),
+        "url": "https://github.com/intendant-dev/Intendant",
+        "redirect_url": format!("{origin}{CALLBACK_PATH}"),
+        "public": false,
+        "default_permissions": {
+            "metadata": "read",
+            "pull_requests": "read",
+            "checks": "read",
+        },
+    })
+}
+
+/// The callback route's path — declared here so the route row, the
+/// carve-out predicate, and the manifest's redirect_url all read one
+/// constant.
+pub(crate) const CALLBACK_PATH: &str = "/api/integrations/github/callback";
+
+/// A manifest-flow `code` as GitHub mints it: short, URL-safe. Anything
+/// else never reaches the conversion URL builder.
+pub(crate) fn code_shape_ok(code: &str) -> bool {
+    !code.is_empty()
+        && code.len() <= 128
+        && code
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+}
+
+// ---------------------------------------------------------------------------
+// Callback doorbell limiter (the enroll limiter's shape: per-source
+// sliding window first, global backstop second; the burned slot is the
+// real gate — this keeps grinding out of the logs)
+// ---------------------------------------------------------------------------
+
+const CALLBACK_RATE_WINDOW_MS: u64 = 60_000;
+const CALLBACK_RATE_GLOBAL_MAX: usize = 60;
+const CALLBACK_RATE_PER_SOURCE_MAX: usize = 10;
+
+#[derive(Default)]
+pub(crate) struct CallbackRateLimiter {
+    global: std::collections::VecDeque<u64>,
+    per_source: std::collections::HashMap<String, std::collections::VecDeque<u64>>,
+}
+
+impl CallbackRateLimiter {
+    pub(crate) fn allow(&mut self, source: &str, now_ms: u64) -> bool {
+        let prune = |queue: &mut std::collections::VecDeque<u64>| {
+            while let Some(at_ms) = queue.front().copied() {
+                if now_ms.saturating_sub(at_ms) < CALLBACK_RATE_WINDOW_MS {
+                    break;
+                }
+                queue.pop_front();
+            }
+        };
+        self.per_source.retain(|_, queue| {
+            prune(queue);
+            !queue.is_empty()
+        });
+        prune(&mut self.global);
+        if self.global.len() >= CALLBACK_RATE_GLOBAL_MAX {
+            return false;
+        }
+        let queue = self.per_source.entry(source.to_string()).or_default();
+        if queue.len() >= CALLBACK_RATE_PER_SOURCE_MAX {
+            return false;
+        }
+        queue.push_back(now_ms);
+        self.global.push_back(now_ms);
+        true
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Process globals — transport edges only; cores take the structs.
+// ---------------------------------------------------------------------------
+
+pub(crate) fn slot() -> &'static ManifestCeremonySlot {
+    static SLOT: std::sync::OnceLock<ManifestCeremonySlot> = std::sync::OnceLock::new();
+    SLOT.get_or_init(ManifestCeremonySlot::default)
+}
+
+pub(crate) fn callback_rate_ok(source: &str, now_ms: u64) -> bool {
+    static LIMITER: std::sync::OnceLock<std::sync::Mutex<CallbackRateLimiter>> =
+        std::sync::OnceLock::new();
+    LIMITER
+        .get_or_init(|| std::sync::Mutex::new(CallbackRateLimiter::default()))
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .allow(source, now_ms)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const NOW: u64 = 1_700_000_000_000;
+
+    fn begin(slot: &ManifestCeremonySlot) -> String {
+        slot.begin(
+            "http://127.0.0.1:8765".to_string(),
+            None,
+            "principal:test".to_string(),
+            NOW,
+        )
+        .expect("begin")
+    }
+
+    #[test]
+    fn state_burns_once_and_uniformly_refuses_replay_and_garbage() {
+        let slot = ManifestCeremonySlot::default();
+        let token = begin(&slot);
+        assert!(slot.active(NOW));
+        let pending = slot.consume(&token, NOW + 1).expect("first consume");
+        assert_eq!(pending.starter_principal, "principal:test");
+        assert_eq!(pending.origin, "http://127.0.0.1:8765");
+        // Replay: the slot is empty — same refusal as a garbage state.
+        let replay = slot.consume(&token, NOW + 2).unwrap_err();
+        let garbage = ManifestCeremonySlot::default()
+            .consume("nonsense", NOW)
+            .unwrap_err();
+        assert_eq!(replay, STATE_REFUSED);
+        assert_eq!(garbage, STATE_REFUSED);
+        assert!(!slot.active(NOW));
+    }
+
+    #[test]
+    fn wrong_state_burns_the_pending_ceremony_without_matching() {
+        let slot = ManifestCeremonySlot::default();
+        let token = begin(&slot);
+        assert_eq!(slot.consume("wrong-guess", NOW).unwrap_err(), STATE_REFUSED);
+        // The guess consumed the slot: the honest token is now refused
+        // too (fail-closed; the owner restarts the ceremony).
+        assert_eq!(slot.consume(&token, NOW).unwrap_err(), STATE_REFUSED);
+    }
+
+    #[test]
+    fn expiry_refuses_and_replacement_invalidates_the_first_ceremony() {
+        let slot = ManifestCeremonySlot::default();
+        let token = begin(&slot);
+        assert_eq!(
+            slot.consume(&token, NOW + MANIFEST_STATE_TTL_MS).unwrap_err(),
+            STATE_REFUSED,
+            "an expired state must refuse uniformly"
+        );
+        let _first = begin(&slot);
+        let second = slot
+            .begin(
+                "http://127.0.0.1:8765".to_string(),
+                Some("example-org".to_string()),
+                "principal:test".to_string(),
+                NOW,
+            )
+            .expect("second begin");
+        // Replacement single-flight: only the live (second) token
+        // redeems, and it carries the second ceremony's parameters.
+        let pending = slot.consume(&second, NOW + 1).expect("live token redeems");
+        assert_eq!(pending.target_org.as_deref(), Some("example-org"));
+
+        // The voided first token: refused — and per burn-on-mismatch,
+        // the attempt costs whatever ceremony is pending at the time
+        // (here: none), never a retry.
+        let first_again = begin(&slot);
+        assert_eq!(
+            slot.consume(&first_again[..first_again.len() - 1], NOW + 1).unwrap_err(),
+            STATE_REFUSED,
+            "a near-miss token is refused"
+        );
+        assert_eq!(
+            slot.consume(&first_again, NOW + 1).unwrap_err(),
+            STATE_REFUSED,
+            "and the mismatch burned the pending ceremony (fail-closed)"
+        );
+    }
+
+    #[test]
+    fn app_name_fits_githubs_cap_and_keeps_the_paren() {
+        assert_eq!(manifest_app_name("macbook-a"), "Intendant (macbook-a)");
+        let long = manifest_app_name("a-very-long-hostname-that-exceeds-github-limits");
+        assert!(long.chars().count() <= 34, "{long:?} must fit 34 chars");
+        assert!(long.ends_with(')'), "{long:?} must keep the closing paren");
+        assert_eq!(manifest_app_name("   "), "Intendant");
+    }
+
+    #[test]
+    fn form_action_targets_personal_or_org_and_escapes_both_inputs() {
+        let personal = manifest_form_action(None, "tok_en-1");
+        assert_eq!(
+            personal,
+            "https://github.com/settings/apps/new?state=tok_en-1"
+        );
+        let org = manifest_form_action(Some("example-org"), "t");
+        assert_eq!(
+            org,
+            "https://github.com/organizations/example-org/settings/apps/new?state=t"
+        );
+        let hostile = manifest_form_action(Some("a/b?c"), "s&t");
+        assert!(!hostile.contains("a/b?c"), "org handle must be escaped");
+        assert!(!hostile.contains("s&t"), "state must be escaped");
+    }
+
+    #[test]
+    fn manifest_document_is_private_readonly_and_webhookless() {
+        let doc = manifest_document("http://127.0.0.1:8765", "box");
+        assert_eq!(doc["public"], false);
+        assert_eq!(
+            doc["redirect_url"],
+            "http://127.0.0.1:8765/api/integrations/github/callback"
+        );
+        assert_eq!(doc["default_permissions"]["metadata"], "read");
+        assert_eq!(doc["default_permissions"]["pull_requests"], "read");
+        assert_eq!(doc["default_permissions"]["checks"], "read");
+        assert_eq!(doc["default_permissions"].as_object().unwrap().len(), 3);
+        let map = doc.as_object().unwrap();
+        assert!(
+            !map.contains_key("hook_attributes"),
+            "no webhook: hook_attributes stays omitted"
+        );
+        assert!(!map.contains_key("default_events"));
+    }
+
+    #[test]
+    fn code_shape_gate_admits_github_codes_and_refuses_url_metacharacters() {
+        assert!(code_shape_ok("a1B2-c3_d4.e5"));
+        for bad in ["", "a/b", "a?b", "a#b", "a b", &"x".repeat(129)] {
+            assert!(!code_shape_ok(bad), "{bad:?} must be refused");
+        }
+    }
+
+    #[test]
+    fn limiter_bounds_per_source_then_globally_and_slides_its_window() {
+        let mut limiter = CallbackRateLimiter::default();
+        for i in 0..CALLBACK_RATE_PER_SOURCE_MAX {
+            assert!(limiter.allow("src-a", NOW + i as u64), "call {i} allowed");
+        }
+        assert!(!limiter.allow("src-a", NOW + 20), "per-source cap holds");
+        assert!(limiter.allow("src-b", NOW + 21), "other sources unaffected");
+        assert!(
+            limiter.allow("src-a", NOW + CALLBACK_RATE_WINDOW_MS + 25),
+            "window slides"
+        );
+    }
+}

--- a/src/bin/caller/github_pr/manifest_ceremony.rs
+++ b/src/bin/caller/github_pr/manifest_ceremony.rs
@@ -40,13 +40,10 @@ pub(crate) const STATE_REFUSED: &str =
 pub(crate) struct PendingManifest {
     /// SHA-256 of the state token, hex — the plaintext never rests.
     state_hash: String,
-    pub(crate) started_at_unix_ms: u64,
     pub(crate) expires_at_unix_ms: u64,
     /// The validated origin (`scheme://authority`) the ceremony started
     /// from; the redirect returns here and the callback page links back.
     pub(crate) origin: String,
-    /// Org handle for an org-owned App; `None` = personal account.
-    pub(crate) target_org: Option<String>,
     /// The principal whose CredentialsManage gesture opened the
     /// ceremony. The authority-free callback merely completes that
     /// authorized act, so this is the custody-audit actor at seal time
@@ -92,17 +89,14 @@ impl ManifestCeremonySlot {
     pub(crate) fn begin(
         &self,
         origin: String,
-        target_org: Option<String>,
         starter_principal: String,
         now_ms: u64,
     ) -> Result<String, String> {
         let token = random_state()?;
         let pending = PendingManifest {
             state_hash: token_hash(&token),
-            started_at_unix_ms: now_ms,
             expires_at_unix_ms: now_ms.saturating_add(MANIFEST_STATE_TTL_MS),
             origin,
-            target_org,
             starter_principal,
         };
         *self.pending.lock().unwrap_or_else(|p| p.into_inner()) = Some(pending);
@@ -137,8 +131,9 @@ impl ManifestCeremonySlot {
         Ok(pending)
     }
 
-    /// Whether a live (unexpired) ceremony is pending — status surface
-    /// only; never reveals the hash.
+    /// Whether a live (unexpired) ceremony is pending. Test-only today;
+    /// a status surface that wants it re-promotes it deliberately.
+    #[cfg(test)]
     pub(crate) fn active(&self, now_ms: u64) -> bool {
         self.pending
             .lock()
@@ -292,7 +287,6 @@ mod tests {
     fn begin(slot: &ManifestCeremonySlot) -> String {
         slot.begin(
             "http://127.0.0.1:8765".to_string(),
-            None,
             "principal:test".to_string(),
             NOW,
         )
@@ -340,16 +334,16 @@ mod tests {
         let _first = begin(&slot);
         let second = slot
             .begin(
-                "http://127.0.0.1:8765".to_string(),
-                Some("example-org".to_string()),
-                "principal:test".to_string(),
+                "https://box.example:8443".to_string(),
+                "principal:second".to_string(),
                 NOW,
             )
             .expect("second begin");
         // Replacement single-flight: only the live (second) token
         // redeems, and it carries the second ceremony's parameters.
         let pending = slot.consume(&second, NOW + 1).expect("live token redeems");
-        assert_eq!(pending.target_org.as_deref(), Some("example-org"));
+        assert_eq!(pending.origin, "https://box.example:8443");
+        assert_eq!(pending.starter_principal, "principal:second");
 
         // The voided first token: refused — and per burn-on-mismatch,
         // the attempt costs whatever ceremony is pending at the time

--- a/src/bin/caller/github_pr/manifest_ceremony.rs
+++ b/src/bin/caller/github_pr/manifest_ceremony.rs
@@ -116,7 +116,11 @@ impl ManifestCeremonySlot {
     /// ceremony, never a second try at it — and costs the owner one
     /// restart). Unknown, replayed, expired, and absent states are
     /// indistinguishable ([`STATE_REFUSED`]).
-    pub(crate) fn consume(&self, presented_state: &str, now_ms: u64) -> Result<PendingManifest, String> {
+    pub(crate) fn consume(
+        &self,
+        presented_state: &str,
+        now_ms: u64,
+    ) -> Result<PendingManifest, String> {
         let pending = self
             .pending
             .lock()
@@ -173,7 +177,8 @@ pub(crate) fn manifest_form_action(target_org: Option<&str>, state: &str) -> Str
     let encoded_state: String = url::form_urlencoded::byte_serialize(state.as_bytes()).collect();
     match target_org {
         Some(org) => {
-            let encoded_org: String = url::form_urlencoded::byte_serialize(org.as_bytes()).collect();
+            let encoded_org: String =
+                url::form_urlencoded::byte_serialize(org.as_bytes()).collect();
             format!(
                 "https://github.com/organizations/{encoded_org}/settings/apps/new?state={encoded_state}"
             )
@@ -327,7 +332,8 @@ mod tests {
         let slot = ManifestCeremonySlot::default();
         let token = begin(&slot);
         assert_eq!(
-            slot.consume(&token, NOW + MANIFEST_STATE_TTL_MS).unwrap_err(),
+            slot.consume(&token, NOW + MANIFEST_STATE_TTL_MS)
+                .unwrap_err(),
             STATE_REFUSED,
             "an expired state must refuse uniformly"
         );
@@ -350,7 +356,8 @@ mod tests {
         // (here: none), never a retry.
         let first_again = begin(&slot);
         assert_eq!(
-            slot.consume(&first_again[..first_again.len() - 1], NOW + 1).unwrap_err(),
+            slot.consume(&first_again[..first_again.len() - 1], NOW + 1)
+                .unwrap_err(),
             STATE_REFUSED,
             "a near-miss token is refused"
         );

--- a/src/bin/caller/github_pr/mod.rs
+++ b/src/bin/caller/github_pr/mod.rs
@@ -13,5 +13,6 @@
 pub(crate) mod client;
 pub(crate) mod credentials;
 pub(crate) mod join;
+pub(crate) mod manifest_ceremony;
 pub(crate) mod scanner;
 pub(crate) mod status;

--- a/src/bin/caller/github_pr/scanner.rs
+++ b/src/bin/caller/github_pr/scanner.rs
@@ -536,14 +536,29 @@ pub(crate) fn spawn_scanner(
                 // The one unseal site outside a configure gesture: the
                 // client holds the parsed key for its lifetime; a
                 // re-configure (new blob mtime) rebuilds it.
-                let built = crate::key_custody::github_app_from_custody()
-                    .and_then(|secret| {
-                        super::credentials::GithubAppCredentials::from_sealed_bytes(
-                            secret.as_bytes(),
-                        )
+                let parsed = crate::key_custody::github_app_from_custody().and_then(|secret| {
+                    super::credentials::GithubAppCredentials::from_sealed_bytes(secret.as_bytes())
                         .ok()
-                    })
-                    .and_then(|creds| GithubAppClient::new(runtime.api_base(), creds).ok());
+                });
+                // A pending-install document (manifest ceremony sealed,
+                // App not installed yet) is a named pause, not a
+                // failure — and this unseal re-establishes the runtime's
+                // pending cache after a daemon restart.
+                if let Some(creds) = parsed.as_ref() {
+                    if creds.installation_id.is_none() {
+                        runtime.set_pending_install(creds.slug.clone().unwrap_or_default());
+                        transition(
+                            "installation pending — install the App on GitHub; integration paused"
+                                .to_string(),
+                        );
+                        client = None;
+                        super::join::publish_client(None);
+                        tokio::time::sleep(std::time::Duration::from_secs(IDLE_RECHECK_S)).await;
+                        continue;
+                    }
+                }
+                let built =
+                    parsed.and_then(|creds| GithubAppClient::new(runtime.api_base(), creds).ok());
                 match built {
                     Some(fresh) => {
                         let fresh = std::sync::Arc::new(fresh);

--- a/src/bin/caller/github_pr/status.rs
+++ b/src/bin/caller/github_pr/status.rs
@@ -31,6 +31,14 @@ pub(crate) struct CheckOutcome {
 pub(crate) struct GithubIntegrationRuntime {
     api_base: String,
     last: Mutex<Option<CheckOutcome>>,
+    /// `Some(slug)` while the sealed document is pending install (the
+    /// manifest ceremony sealed a key with no installation yet). An
+    /// in-memory cache, not a second store: status never unseals, so
+    /// after a daemon restart this is unknown (reads `false`) until a
+    /// gated unsealing surface — GC2 discovery, a scanner pass — or the
+    /// completing save re-establishes it. The ceremony sets it; any
+    /// successful save or remove clears it.
+    pending_install_slug: Mutex<Option<String>>,
 }
 
 impl GithubIntegrationRuntime {
@@ -38,7 +46,29 @@ impl GithubIntegrationRuntime {
         Self {
             api_base: api_base.into(),
             last: Mutex::new(None),
+            pending_install_slug: Mutex::new(None),
         }
+    }
+
+    pub(crate) fn set_pending_install(&self, slug: String) {
+        *self
+            .pending_install_slug
+            .lock()
+            .expect("github status poisoned") = Some(slug);
+    }
+
+    pub(crate) fn clear_pending_install(&self) {
+        *self
+            .pending_install_slug
+            .lock()
+            .expect("github status poisoned") = None;
+    }
+
+    pub(crate) fn pending_install_slug(&self) -> Option<String> {
+        self.pending_install_slug
+            .lock()
+            .expect("github status poisoned")
+            .clone()
     }
 
     pub(crate) fn api_base(&self) -> &str {
@@ -53,9 +83,11 @@ impl GithubIntegrationRuntime {
     }
 
     /// Forget cached outcomes (the Remove gesture): an unconfigured
-    /// integration has no last exchange to report.
+    /// integration has no last exchange to report — and no pending
+    /// ceremony phase either.
     pub(crate) fn clear(&self) {
         *self.last.lock().expect("github status poisoned") = None;
+        self.clear_pending_install();
     }
 
     pub(crate) fn last(&self) -> Option<CheckOutcome> {

--- a/src/bin/caller/web_gateway/access_gates.rs
+++ b/src/bin/caller/web_gateway/access_gates.rs
@@ -350,6 +350,7 @@ pub(crate) fn allows_remote_certless_http(request_line: &str, method: &str, path
         || is_public_org_grant_path(request_line)
         || is_public_connect_bootstrap_path(request_line)
         || is_public_codex_cloud_enroll_path(request_line)
+        || is_public_github_manifest_callback_path(request_line)
         || is_public_dashboard_shell_or_asset(method, path)
 }
 

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -1662,6 +1662,36 @@ pub(crate) async fn serve_http_request(
                 )
                 .await;
             }
+            RouteHandlerId::GithubManifestStart => {
+                // The pre-dispatch IAM gate bound this principal
+                // (CredentialsManage); it becomes the ceremony's
+                // starter principal — the custody-audit actor when the
+                // authority-free callback later completes the act.
+                return handle_github_manifest_start(
+                    stream,
+                    route_body.as_bytes(),
+                    is_tls,
+                    http_header_value(header_text, "host"),
+                    http_access_context.principal.id.clone(),
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
+            }
+            RouteHandlerId::GithubManifestCallback => {
+                // Authority-free browser navigation (GitHub's redirect):
+                // the handler's state burn is the entire authorization.
+                // The rate-limit source is the peer IP, like the
+                // enrollment doorbell.
+                return handle_github_manifest_callback(
+                    stream,
+                    request_line,
+                    peer_addr.ip().to_string(),
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
+            }
             RouteHandlerId::ClaudeAuthStart => {
                 return handle_claude_auth_start(
                     stream,

--- a/src/bin/caller/web_gateway/routes_github.rs
+++ b/src/bin/caller/web_gateway/routes_github.rs
@@ -372,7 +372,9 @@ fn validate_org_handle(handle: &str) -> Result<(), String> {
     if ok {
         Ok(())
     } else {
-        Err(format!("organization {handle:?} is not a GitHub org handle"))
+        Err(format!(
+            "organization {handle:?} is not a GitHub org handle"
+        ))
     }
 }
 
@@ -457,8 +459,7 @@ pub(crate) fn github_manifest_start_api_response(
         Ok(state) => state,
         Err(error) => return ApiResponse::json_error(500, &error),
     };
-    let manifest =
-        crate::github_pr::manifest_ceremony::manifest_document(&origin, hostname_label);
+    let manifest = crate::github_pr::manifest_ceremony::manifest_document(&origin, hostname_label);
     let form_action =
         crate::github_pr::manifest_ceremony::manifest_form_action(target_org.as_deref(), &state);
     ApiResponse::json(
@@ -485,7 +486,12 @@ fn html_escape(text: &str) -> String {
 /// A self-contained ceremony page (no SPA assets, no secrets). The
 /// return link is the validated ceremony origin; success pages also
 /// meta-refresh there after a beat.
-fn ceremony_page(status: u16, title: &str, detail: &str, return_origin: Option<&str>) -> ApiResponse {
+fn ceremony_page(
+    status: u16,
+    title: &str,
+    detail: &str,
+    return_origin: Option<&str>,
+) -> ApiResponse {
     let (link, refresh) = match return_origin {
         Some(origin) => {
             let escaped = html_escape(origin);
@@ -515,7 +521,10 @@ fn ceremony_page(status: u16, title: &str, detail: &str, return_origin: Option<&
         headers: vec![
             ("Cache-Control", "no-cache".to_string()),
             ("X-Content-Type-Options", "nosniff".to_string()),
-            ("Content-Security-Policy", "frame-ancestors 'none'".to_string()),
+            (
+                "Content-Security-Policy",
+                "frame-ancestors 'none'".to_string(),
+            ),
             ("Connection", "close".to_string()),
         ],
         bytes: BytesPayload::InMemory(html.into_bytes()),
@@ -602,7 +611,9 @@ pub(crate) async fn github_manifest_callback_api_response(
         return ceremony_page(
             500,
             "GitHub's response could not be sealed",
-            &format!("The created App's key did not validate ({error}). Start again from the dashboard."),
+            &format!(
+                "The created App's key did not validate ({error}). Start again from the dashboard."
+            ),
             Some(&pending.origin),
         );
     }
@@ -622,7 +633,12 @@ pub(crate) async fn github_manifest_callback_api_response(
         &pending.starter_principal,
         "github-manifest-callback",
     ) {
-        return ceremony_page(500, "Custody refused the seal", &error, Some(&pending.origin));
+        return ceremony_page(
+            500,
+            "Custody refused the seal",
+            &error,
+            Some(&pending.origin),
+        );
     }
     runtime.set_pending_install(conversion.slug.clone());
     ceremony_page(
@@ -1023,9 +1039,8 @@ mod tests {
         );
 
         let sealed = custody.retrieve().expect("sealed document exists");
-        let doc =
-            crate::github_pr::credentials::GithubAppCredentials::from_sealed_bytes(&sealed)
-                .expect("parses in this build");
+        let doc = crate::github_pr::credentials::GithubAppCredentials::from_sealed_bytes(&sealed)
+            .expect("parses in this build");
         assert_eq!(doc.app_id, "4242");
         assert_eq!(doc.installation_id, None, "sealed pending-install");
         assert_eq!(doc.slug.as_deref(), Some("intendant-example"));
@@ -1067,7 +1082,10 @@ mod tests {
         assert_eq!(body["configured"], true);
         assert_eq!(body["pending_install"], true);
         assert_eq!(body["app_slug"], "intendant-example");
-        assert_eq!(body["status"], "configured", "the label vocabulary is unchanged");
+        assert_eq!(
+            body["status"], "configured",
+            "the label vocabulary is unchanged"
+        );
     }
 
     /// The named foreign-code pin: without a valid state — absent OR
@@ -1104,7 +1122,8 @@ mod tests {
         let (status, page) = page_status(&wrong);
         assert_eq!(status, 403);
         assert_eq!(
-            page, page_status(&absent).1,
+            page,
+            page_status(&absent).1,
             "refusals are uniform: absent and wrong states read identically"
         );
 
@@ -1282,9 +1301,7 @@ mod tests {
             NOW,
         );
         assert_eq!(status_of(&response), 400);
-        assert!(body_json(&response)
-            .to_string()
-            .contains("custody backend"));
+        assert!(body_json(&response).to_string().contains("custody backend"));
         assert!(!slot.active(NOW), "no state mints on a refused start");
     }
 
@@ -1377,13 +1394,7 @@ mod tests {
             validated_request_origin(true, Some("Box.Example")).as_deref(),
             Some("https://box.example")
         );
-        for bad in [
-            "user@host",
-            "host/path",
-            "host?query=1",
-            "host#frag",
-            "",
-        ] {
+        for bad in ["user@host", "host/path", "host?query=1", "host#frag", ""] {
             assert_eq!(
                 validated_request_origin(false, Some(bad)),
                 None,

--- a/src/bin/caller/web_gateway/routes_github.rs
+++ b/src/bin/caller/web_gateway/routes_github.rs
@@ -86,6 +86,23 @@ fn validate_repo_name(repo: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// Method-exact membership test for the certless carve-out
+/// ([`super::access_gates::allows_remote_certless_http`]): GitHub's
+/// manifest redirect is a top-level browser navigation carrying no
+/// daemon credential — the daemon-minted single-use state in the query
+/// is the entire authorization, so this one GET sits in the doorbell
+/// class beside peer pairing, org grants, and Codex Cloud enrollment.
+/// (A `RouteAuthz::Public` table row alone does NOT exempt a path from
+/// the mTLS/origin gates — both memberships are required.)
+pub(crate) fn is_public_github_manifest_callback_path(request_line: &str) -> bool {
+    let mut parts = request_line.split_whitespace();
+    let (Some(method), Some(path)) = (parts.next(), parts.next()) else {
+        return false;
+    };
+    let path = path.split('?').next().unwrap_or(path);
+    method == "GET" && path == crate::github_pr::manifest_ceremony::CALLBACK_PATH
+}
+
 fn integration_config(settings_root: Option<&Path>) -> crate::project::GithubIntegrationConfig {
     let Some(root) = settings_root else {
         return Default::default();
@@ -97,7 +114,12 @@ fn integration_config(settings_root: Option<&Path>) -> crate::project::GithubInt
 
 /// The shared status body every verb answers with — presence, the wire
 /// status label, the last exchange, and the non-secret config. Never
-/// touches the keystore.
+/// touches the keystore. `pending_install` is a status-body boolean
+/// beside the ruled label vocabulary, never a new label in it: the
+/// label describes exchange health, the boolean describes the ceremony
+/// phase, and the two stay orthogonal. After a daemon restart
+/// mid-pending it reads `false` until a gated unsealing surface
+/// re-establishes it (the runtime cache's documented transient).
 pub(crate) fn github_status_body(
     settings_root: Option<&Path>,
     custody: &dyn GithubAppCustody,
@@ -106,12 +128,19 @@ pub(crate) fn github_status_body(
     let present = custody.present();
     let last = runtime.last();
     let config = integration_config(settings_root);
+    let pending_slug = if present {
+        runtime.pending_install_slug()
+    } else {
+        None
+    };
     serde_json::json!({
         "configured": present,
         "status": crate::github_pr::status::status_label(present, last.as_ref()),
         "detail": crate::github_pr::status::status_detail(last.as_ref()),
         "checked_at_ms": last.as_ref().map(|outcome| outcome.at_unix_ms),
         "custody_backend_available": custody.backend_available(),
+        "pending_install": pending_slug.is_some(),
+        "app_slug": pending_slug.filter(|slug| !slug.is_empty()),
         "repos": config.repos,
         "poll_minutes": config.poll_minutes,
     })
@@ -173,7 +202,8 @@ pub(crate) async fn github_integration_save_api_response(
         Some(pem) => crate::github_pr::credentials::GithubAppCredentials {
             v: 1,
             app_id: payload.app_id.clone(),
-            installation_id: payload.installation_id,
+            installation_id: Some(payload.installation_id),
+            slug: None,
             private_key_pem: pem.to_string(),
         },
         None => {
@@ -193,7 +223,10 @@ pub(crate) async fn github_integration_save_api_response(
             {
                 Ok(mut existing) => {
                     existing.app_id = payload.app_id.clone();
-                    existing.installation_id = payload.installation_id;
+                    // Completing a pending-install document keeps its
+                    // ceremony-recorded slug; a plain ids update keeps
+                    // whatever was there.
+                    existing.installation_id = Some(payload.installation_id);
                     existing
                 }
                 Err(error) => return ApiResponse::json_error(500, &error),
@@ -210,6 +243,10 @@ pub(crate) async fn github_integration_save_api_response(
     if let Err(error) = custody.store(&sealed, actor_principal, audit_origin) {
         return ApiResponse::json_error(500, &error);
     }
+    // Every save writes a complete document (installation_id present),
+    // so any ceremony pending-phase is over — including the GC2
+    // auto-fill that completes a pending-install document.
+    runtime.clear_pending_install();
 
     // Persist the non-secret watch config beside the sealed entry.
     let mut config_persisted = true;
@@ -307,6 +344,360 @@ pub(crate) fn github_integration_remove_api_response(
         map.insert("removed".to_string(), serde_json::Value::Bool(true));
     }
     ApiResponse::json(200, JsonBody::Value(body))
+}
+
+// ---------------------------------------------------------------------------
+// The one-click connect ceremony (Track GC): manifest-start + callback.
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ManifestStartPayload {
+    /// Org handle for an org-owned App; absent/empty = personal account.
+    #[serde(default)]
+    organization: Option<String>,
+}
+
+/// GitHub login grammar (orgs and users): alphanumerics and inner
+/// hyphens, ≤ 39 chars. The handle rides a github.com URL path, so
+/// anything else is refused at intake.
+fn validate_org_handle(handle: &str) -> Result<(), String> {
+    let ok = !handle.is_empty()
+        && handle.len() <= 39
+        && !handle.starts_with('-')
+        && !handle.ends_with('-')
+        && handle
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-');
+    if ok {
+        Ok(())
+    } else {
+        Err(format!("organization {handle:?} is not a GitHub org handle"))
+    }
+}
+
+/// The exact origin the requesting browser is on, rebuilt from the
+/// `Host` header (the redirect must return to this origin and nowhere
+/// else). Same authority discipline as the loopback trusted-local lane:
+/// parse as an authority, refuse every URL component a legal Host
+/// cannot carry.
+pub(crate) fn validated_request_origin(is_tls: bool, host_header: Option<&str>) -> Option<String> {
+    let authority = host_header?.trim();
+    let url = url::Url::parse(&format!("http://{authority}")).ok()?;
+    if !url.username().is_empty()
+        || url.password().is_some()
+        || url.path() != "/"
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return None;
+    }
+    let host = url.host_str()?;
+    let scheme = if is_tls { "https" } else { "http" };
+    match url.port() {
+        Some(port) => Some(format!("{scheme}://{host}:{port}")),
+        None => Some(format!("{scheme}://{host}")),
+    }
+}
+
+/// Transport-neutral core of `POST /api/integrations/github/manifest-start`
+/// (HTTP-only; no tunnel twin — see the route row). Mints the ceremony
+/// state (single-flight by replacement) and answers the form target +
+/// manifest for the fragment to POST. The custody precheck refuses up
+/// front: the owner must never create an App whose key this daemon
+/// cannot seal.
+pub(crate) fn github_manifest_start_api_response(
+    body: &[u8],
+    custody: &dyn GithubAppCustody,
+    slot: &crate::github_pr::manifest_ceremony::ManifestCeremonySlot,
+    is_tls: bool,
+    host_header: Option<&str>,
+    hostname_label: &str,
+    starter_principal: &str,
+    now_ms: u64,
+) -> ApiResponse {
+    let payload: ManifestStartPayload = match serde_json::from_slice(body) {
+        Ok(payload) => payload,
+        Err(error) => {
+            return ApiResponse::json_error(400, format!("invalid payload: {error}"));
+        }
+    };
+    if !custody.backend_available() {
+        return ApiResponse::json_error(
+            400,
+            "no credential custody backend is available on this platform — the one-click \
+             ceremony cannot seal the App key it would create; use the manual form on a \
+             machine with custody support",
+        );
+    }
+    let target_org = match payload
+        .organization
+        .as_deref()
+        .map(str::trim)
+        .filter(|handle| !handle.is_empty())
+    {
+        Some(handle) => match validate_org_handle(handle) {
+            Ok(()) => Some(handle.to_string()),
+            Err(error) => return ApiResponse::json_error(400, &error),
+        },
+        None => None,
+    };
+    let Some(origin) = validated_request_origin(is_tls, host_header) else {
+        return ApiResponse::json_error(
+            400,
+            "the request carries no usable Host header to compose the redirect origin from",
+        );
+    };
+    let state = match slot.begin(
+        origin.clone(),
+        target_org.clone(),
+        starter_principal.to_string(),
+        now_ms,
+    ) {
+        Ok(state) => state,
+        Err(error) => return ApiResponse::json_error(500, &error),
+    };
+    let manifest =
+        crate::github_pr::manifest_ceremony::manifest_document(&origin, hostname_label);
+    let form_action =
+        crate::github_pr::manifest_ceremony::manifest_form_action(target_org.as_deref(), &state);
+    ApiResponse::json(
+        200,
+        JsonBody::Value(serde_json::json!({
+            "form_action": form_action,
+            "manifest": manifest,
+            "app_name": manifest["name"],
+        })),
+    )
+}
+
+/// Minimal HTML escaping for the ceremony pages (attribute + text
+/// positions). Inputs are already shape-validated; this is the second
+/// belt.
+fn html_escape(text: &str) -> String {
+    text.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+}
+
+/// A self-contained ceremony page (no SPA assets, no secrets). The
+/// return link is the validated ceremony origin; success pages also
+/// meta-refresh there after a beat.
+fn ceremony_page(status: u16, title: &str, detail: &str, return_origin: Option<&str>) -> ApiResponse {
+    let (link, refresh) = match return_origin {
+        Some(origin) => {
+            let escaped = html_escape(origin);
+            (
+                format!("<p><a href=\"{escaped}/\">Return to the dashboard</a></p>"),
+                format!("<meta http-equiv=\"refresh\" content=\"6;url={escaped}/\">"),
+            )
+        }
+        None => (
+            "<p>Return to the dashboard tab you started from.</p>".to_string(),
+            String::new(),
+        ),
+    };
+    let title = html_escape(title);
+    let detail = html_escape(detail);
+    let html = format!(
+        "<!DOCTYPE html><html><head><meta charset=\"utf-8\">{refresh}\
+         <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\
+         <title>{title}</title>\
+         <style>body{{font-family:system-ui,sans-serif;max-width:34rem;margin:15vh auto;\
+         padding:0 1rem;line-height:1.5}}h1{{font-size:1.2rem}}</style></head>\
+         <body><h1>{title}</h1><p>{detail}</p>{link}</body></html>"
+    );
+    ApiResponse::Bytes {
+        status,
+        content_type: "text/html; charset=utf-8".to_string(),
+        headers: vec![
+            ("Cache-Control", "no-cache".to_string()),
+            ("X-Content-Type-Options", "nosniff".to_string()),
+            ("Content-Security-Policy", "frame-ancestors 'none'".to_string()),
+            ("Connection", "close".to_string()),
+        ],
+        bytes: BytesPayload::InMemory(html.into_bytes()),
+        meta: serde_json::Value::Null,
+    }
+}
+
+/// The uniform refusal page: unknown, replayed, expired, and absent
+/// states — and malformed codes — all read identically (and none of
+/// them ever reaches GitHub).
+fn ceremony_refusal_page() -> ApiResponse {
+    ceremony_page(
+        403,
+        "This connect link cannot be used",
+        crate::github_pr::manifest_ceremony::STATE_REFUSED,
+        None,
+    )
+}
+
+/// Transport-neutral core of `GET /api/integrations/github/callback`
+/// (authority-free browser navigation; the state is the entire
+/// authorization). Order is load-bearing: shape checks (no burn) →
+/// atomic state burn → conversion → seal → render. A request that
+/// fails before the burn cannot cost the owner their pending ceremony;
+/// nothing that fails the burn ever reaches GitHub.
+pub(crate) async fn github_manifest_callback_api_response(
+    request_line: &str,
+    source_hint: &str,
+    custody: &dyn GithubAppCustody,
+    slot: &crate::github_pr::manifest_ceremony::ManifestCeremonySlot,
+    runtime: &crate::github_pr::status::GithubIntegrationRuntime,
+    now_ms: u64,
+) -> ApiResponse {
+    use crate::github_pr::manifest_ceremony as ceremony;
+    if !ceremony::callback_rate_ok(source_hint, now_ms) {
+        return ceremony_page(
+            429,
+            "Too many attempts",
+            "The connect callback is rate limited; retry shortly.",
+            None,
+        );
+    }
+    let (Some(state), Some(code)) = (
+        query_param(request_line, "state"),
+        query_param(request_line, "code"),
+    ) else {
+        return ceremony_refusal_page();
+    };
+    // Shape-gate the code before burning anything: a garbage probe must
+    // not cost the owner their pending ceremony, and a malformed code
+    // never reaches the conversion URL builder.
+    if !ceremony::code_shape_ok(&code) {
+        return ceremony_refusal_page();
+    }
+    let pending = match slot.consume(&state, now_ms) {
+        Ok(pending) => pending,
+        Err(_) => return ceremony_refusal_page(),
+    };
+    // The burn succeeded: this is the owner's ceremony completing.
+    // Convert server-side; the PEM never transits the browser.
+    let conversion =
+        match crate::github_pr::client::convert_manifest_code(runtime.api_base(), &code).await {
+            Ok(conversion) => conversion,
+            Err(error) => {
+                return ceremony_page(
+                    502,
+                    "GitHub did not complete the App creation",
+                    &format!(
+                        "The conversion exchange failed ({error}). The ceremony is closed — \
+                         start again from the dashboard."
+                    ),
+                    Some(&pending.origin),
+                );
+            }
+        };
+    let mut document = crate::github_pr::credentials::GithubAppCredentials {
+        v: 1,
+        app_id: conversion.id.to_string(),
+        installation_id: None,
+        slug: Some(conversion.slug.clone()),
+        private_key_pem: conversion.pem,
+    };
+    if let Err(error) = document.validate() {
+        return ceremony_page(
+            500,
+            "GitHub's response could not be sealed",
+            &format!("The created App's key did not validate ({error}). Start again from the dashboard."),
+            Some(&pending.origin),
+        );
+    }
+    let sealed = match document.sealed_bytes() {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            return ceremony_page(
+                500,
+                "GitHub's response could not be sealed",
+                &error,
+                Some(&pending.origin),
+            );
+        }
+    };
+    if let Err(error) = custody.store(
+        &sealed,
+        &pending.starter_principal,
+        "github-manifest-callback",
+    ) {
+        return ceremony_page(500, "Custody refused the seal", &error, Some(&pending.origin));
+    }
+    runtime.set_pending_install(conversion.slug.clone());
+    ceremony_page(
+        200,
+        "GitHub App created and sealed",
+        &format!(
+            "\"{}\" is registered and its key is sealed into custody — nothing was typed, \
+             nothing was shown. Return to the dashboard to install it on your repositories.",
+            conversion.slug
+        ),
+        Some(&pending.origin),
+    )
+}
+
+pub(crate) async fn handle_github_manifest_start(
+    stream: DemuxStream,
+    body: &[u8],
+    is_tls: bool,
+    host_header: Option<&str>,
+    starter_principal: String,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
+) {
+    let hostname_label = tokio::task::spawn_blocking(best_effort_hostname)
+        .await
+        .unwrap_or_default();
+    let response = github_manifest_start_api_response(
+        body,
+        &DaemonGithubAppCustody,
+        crate::github_pr::manifest_ceremony::slot(),
+        is_tls,
+        host_header,
+        &hostname_label,
+        &starter_principal,
+        now_unix_ms(),
+    );
+    write_api_response(stream, response, cors, fleet_origin).await;
+}
+
+pub(crate) async fn handle_github_manifest_callback(
+    stream: DemuxStream,
+    request_line: &str,
+    source_hint: String,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
+) {
+    let response = github_manifest_callback_api_response(
+        request_line,
+        &source_hint,
+        &DaemonGithubAppCustody,
+        crate::github_pr::manifest_ceremony::slot(),
+        crate::github_pr::status::global(),
+        now_unix_ms(),
+    )
+    .await;
+    write_api_response(stream, response, cors, fleet_origin).await;
+}
+
+fn now_unix_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Best-effort machine label for the App name — display only, never
+/// authority. The `hostname` binary exists on all three platforms; a
+/// missing or failing probe degrades to the bare "Intendant" name.
+fn best_effort_hostname() -> String {
+    std::process::Command::new("hostname")
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .unwrap_or_default()
 }
 
 pub(crate) async fn handle_github_integration_save(

--- a/src/bin/caller/web_gateway/routes_github.rs
+++ b/src/bin/caller/web_gateway/routes_github.rs
@@ -764,6 +764,7 @@ mod tests {
     struct TempCustody {
         backend: intendant_custody::PlainFileBackend,
         stores: Mutex<usize>,
+        available: bool,
     }
 
     impl TempCustody {
@@ -771,6 +772,15 @@ mod tests {
             Self {
                 backend: intendant_custody::PlainFileBackend::new(root.join("custody")).unwrap(),
                 stores: Mutex::new(0),
+                available: true,
+            }
+        }
+
+        /// The non-macOS shape: no backend to seal with.
+        fn unavailable(root: &Path) -> Self {
+            Self {
+                available: false,
+                ..Self::new(root)
             }
         }
     }
@@ -783,7 +793,7 @@ mod tests {
                 .unwrap_or(false)
         }
         fn backend_available(&self) -> bool {
-            true
+            self.available
         }
         fn retrieve(&self) -> Option<Vec<u8>> {
             use intendant_custody::CustodyBackend as _;
@@ -906,6 +916,569 @@ mod tests {
         }
         assert_eq!(*custody.stores.lock().unwrap(), 0, "nothing may be sealed");
         assert!(!custody.present());
+    }
+
+    // ── The one-click ceremony (Track GC) ─────────────────────────────
+
+    use crate::github_pr::client::test_fixture::{spawn_fixture, token_route, FixtureResponse};
+    use crate::github_pr::manifest_ceremony::ManifestCeremonySlot;
+    use std::collections::HashMap;
+
+    const NOW: u64 = 1_700_000_000_000;
+    const CLIENT_SECRET_CANARY: &str = "canary-client-secret-3f1";
+    const WEBHOOK_SECRET_CANARY: &str = "canary-webhook-secret-9d4";
+
+    fn conversion_route(code: &str) -> ((String, String), FixtureResponse) {
+        let body = serde_json::json!({
+            "id": 4242,
+            "slug": "intendant-example",
+            "node_id": "A_node",
+            "name": "Intendant (example)",
+            "client_id": "Iv1.fixture",
+            "client_secret": CLIENT_SECRET_CANARY,
+            "webhook_secret": WEBHOOK_SECRET_CANARY,
+            "pem": crate::github_pr::client::test_rsa_pem(),
+            "html_url": "https://github.com/apps/intendant-example",
+            "owner": {"login": "example-org"},
+        })
+        .to_string();
+        (
+            (
+                "POST".to_string(),
+                format!("/app-manifests/{code}/conversions"),
+            ),
+            (201, Vec::new(), body),
+        )
+    }
+
+    fn begun_slot(now_ms: u64) -> (ManifestCeremonySlot, String) {
+        let slot = ManifestCeremonySlot::default();
+        let state = slot
+            .begin(
+                "http://127.0.0.1:8765".to_string(),
+                None,
+                "principal:test-starter".to_string(),
+                now_ms,
+            )
+            .expect("begin ceremony");
+        (slot, state)
+    }
+
+    fn callback_line(code: Option<&str>, state: Option<&str>) -> String {
+        let mut query = Vec::new();
+        if let Some(code) = code {
+            query.push(format!("code={code}"));
+        }
+        if let Some(state) = state {
+            query.push(format!("state={state}"));
+        }
+        format!(
+            "GET /api/integrations/github/callback?{} HTTP/1.1",
+            query.join("&")
+        )
+    }
+
+    fn page_status(response: &ApiResponse) -> (u16, String) {
+        match response {
+            ApiResponse::Bytes { status, bytes, .. } => {
+                let BytesPayload::InMemory(body) = bytes;
+                (*status, String::from_utf8_lossy(body).to_string())
+            }
+            _ => panic!("ceremony pages ride the bytes lane"),
+        }
+    }
+
+    /// The happy path: a valid state + code converts once, seals the
+    /// pending-install document, and the secrets GitHub returned are
+    /// discarded at parse — no sealed byte and no file under the test
+    /// root carries either canary.
+    #[tokio::test]
+    async fn one_click_callback_converts_seals_pending_and_discards_secrets() {
+        let dir = tempfile::tempdir().unwrap();
+        let custody = TempCustody::new(dir.path());
+        let fixture = spawn_fixture(HashMap::from([conversion_route("goodcode123")])).await;
+        let runtime = GithubIntegrationRuntime::new(&fixture.base);
+        let (slot, state) = begun_slot(NOW);
+
+        let response = github_manifest_callback_api_response(
+            &callback_line(Some("goodcode123"), Some(&state)),
+            "test-src-happy",
+            &custody,
+            &slot,
+            &runtime,
+            NOW + 1,
+        )
+        .await;
+        let (status, page) = page_status(&response);
+        assert_eq!(status, 200, "page: {page}");
+        assert!(page.contains("intendant-example"), "page names the slug");
+        assert!(
+            page.contains("http://127.0.0.1:8765/"),
+            "page links the ceremony origin back"
+        );
+        assert_eq!(
+            fixture.hits.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "exactly one conversion exchange"
+        );
+
+        let sealed = custody.retrieve().expect("sealed document exists");
+        let doc =
+            crate::github_pr::credentials::GithubAppCredentials::from_sealed_bytes(&sealed)
+                .expect("parses in this build");
+        assert_eq!(doc.app_id, "4242");
+        assert_eq!(doc.installation_id, None, "sealed pending-install");
+        assert_eq!(doc.slug.as_deref(), Some("intendant-example"));
+        assert!(doc.private_key_pem.starts_with("-----BEGIN"));
+
+        // The named secrets-discard pin: the narrow parse never retained
+        // them, so no sealed byte sequence and no file under the test
+        // root contains either canary.
+        let sealed_text = String::from_utf8_lossy(&sealed);
+        assert!(!sealed_text.contains(CLIENT_SECRET_CANARY));
+        assert!(!sealed_text.contains(WEBHOOK_SECRET_CANARY));
+        let mut pending_dirs = vec![dir.path().to_path_buf()];
+        while let Some(scan) = pending_dirs.pop() {
+            for entry in std::fs::read_dir(&scan).unwrap() {
+                let path = entry.unwrap().path();
+                if path.is_dir() {
+                    pending_dirs.push(path);
+                } else {
+                    let bytes = std::fs::read(&path).unwrap();
+                    let text = String::from_utf8_lossy(&bytes);
+                    assert!(
+                        !text.contains(CLIENT_SECRET_CANARY)
+                            && !text.contains(WEBHOOK_SECRET_CANARY),
+                        "{path:?} must not carry a discarded secret"
+                    );
+                }
+            }
+        }
+
+        assert_eq!(
+            runtime.pending_install_slug().as_deref(),
+            Some("intendant-example")
+        );
+        let body = body_json(&github_integration_status_api_response(
+            Some(dir.path()),
+            &custody,
+            &runtime,
+        ));
+        assert_eq!(body["configured"], true);
+        assert_eq!(body["pending_install"], true);
+        assert_eq!(body["app_slug"], "intendant-example");
+        assert_eq!(body["status"], "configured", "the label vocabulary is unchanged");
+    }
+
+    /// The named foreign-code pin: without a valid state — absent OR
+    /// wrong — the conversion endpoint is NEVER called (hit count zero),
+    /// nothing seals, and the refusal page is uniform.
+    #[tokio::test]
+    async fn callback_without_valid_state_never_reaches_github() {
+        let dir = tempfile::tempdir().unwrap();
+        let custody = TempCustody::new(dir.path());
+        let fixture = spawn_fixture(HashMap::from([conversion_route("foreigncode")])).await;
+        let runtime = GithubIntegrationRuntime::new(&fixture.base);
+        let (slot, _state) = begun_slot(NOW);
+
+        let absent = github_manifest_callback_api_response(
+            &callback_line(Some("foreigncode"), None),
+            "test-src-foreign",
+            &custody,
+            &slot,
+            &runtime,
+            NOW + 1,
+        )
+        .await;
+        assert_eq!(page_status(&absent).0, 403);
+
+        let wrong = github_manifest_callback_api_response(
+            &callback_line(Some("foreigncode"), Some("not-the-state")),
+            "test-src-foreign",
+            &custody,
+            &slot,
+            &runtime,
+            NOW + 2,
+        )
+        .await;
+        let (status, page) = page_status(&wrong);
+        assert_eq!(status, 403);
+        assert_eq!(
+            page, page_status(&absent).1,
+            "refusals are uniform: absent and wrong states read identically"
+        );
+
+        assert_eq!(
+            fixture.hits.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "the conversion endpoint must never be reached without a valid state"
+        );
+        assert!(!custody.present(), "nothing seals on a refused callback");
+        assert_eq!(*custody.stores.lock().unwrap(), 0);
+    }
+
+    /// The named replay pin: the second identical callback refuses with
+    /// zero additional conversion exchanges and the store count stays 1.
+    #[tokio::test]
+    async fn replayed_callback_refuses_with_zero_new_conversions_and_one_store() {
+        let dir = tempfile::tempdir().unwrap();
+        let custody = TempCustody::new(dir.path());
+        let fixture = spawn_fixture(HashMap::from([conversion_route("replaycode")])).await;
+        let runtime = GithubIntegrationRuntime::new(&fixture.base);
+        let (slot, state) = begun_slot(NOW);
+        let line = callback_line(Some("replaycode"), Some(&state));
+
+        let first = github_manifest_callback_api_response(
+            &line,
+            "test-src-replay",
+            &custody,
+            &slot,
+            &runtime,
+            NOW + 1,
+        )
+        .await;
+        assert_eq!(page_status(&first).0, 200);
+
+        let replay = github_manifest_callback_api_response(
+            &line,
+            "test-src-replay",
+            &custody,
+            &slot,
+            &runtime,
+            NOW + 2,
+        )
+        .await;
+        assert_eq!(page_status(&replay).0, 403);
+        assert_eq!(
+            fixture.hits.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "a replayed callback must not reach GitHub again"
+        );
+        assert_eq!(*custody.stores.lock().unwrap(), 1, "one seal, ever");
+    }
+
+    /// The named expired-state pin: past the TTL the refusal is uniform
+    /// and the conversion endpoint is never called.
+    #[tokio::test]
+    async fn expired_state_refuses_without_conversion() {
+        let dir = tempfile::tempdir().unwrap();
+        let custody = TempCustody::new(dir.path());
+        let fixture = spawn_fixture(HashMap::from([conversion_route("latecode")])).await;
+        let runtime = GithubIntegrationRuntime::new(&fixture.base);
+        let (slot, state) = begun_slot(NOW);
+
+        let response = github_manifest_callback_api_response(
+            &callback_line(Some("latecode"), Some(&state)),
+            "test-src-expired",
+            &custody,
+            &slot,
+            &runtime,
+            NOW + crate::github_pr::manifest_ceremony::MANIFEST_STATE_TTL_MS,
+        )
+        .await;
+        assert_eq!(page_status(&response).0, 403);
+        assert_eq!(fixture.hits.load(std::sync::atomic::Ordering::SeqCst), 0);
+        assert!(!custody.present());
+    }
+
+    /// A conversion failure after the burn ends the ceremony: the state
+    /// cannot be replayed into a second attempt (fail-closed ordering).
+    #[tokio::test]
+    async fn failed_conversion_ends_the_ceremony() {
+        let dir = tempfile::tempdir().unwrap();
+        let custody = TempCustody::new(dir.path());
+        // No conversion route: the fixture answers 404 (an invalid code).
+        let fixture = spawn_fixture(HashMap::new()).await;
+        let runtime = GithubIntegrationRuntime::new(&fixture.base);
+        let (slot, state) = begun_slot(NOW);
+        let line = callback_line(Some("deadcode"), Some(&state));
+
+        let first = github_manifest_callback_api_response(
+            &line,
+            "test-src-dead",
+            &custody,
+            &slot,
+            &runtime,
+            NOW + 1,
+        )
+        .await;
+        assert_eq!(page_status(&first).0, 502, "conversion failure is named");
+        assert_eq!(fixture.hits.load(std::sync::atomic::Ordering::SeqCst), 1);
+        assert!(!custody.present(), "no seal without a conversion");
+
+        let retry = github_manifest_callback_api_response(
+            &line,
+            "test-src-dead",
+            &custody,
+            &slot,
+            &runtime,
+            NOW + 2,
+        )
+        .await;
+        assert_eq!(
+            page_status(&retry).0,
+            403,
+            "the burn preceded the exchange; the ceremony is over"
+        );
+        assert_eq!(
+            fixture.hits.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "a burned state never converts again"
+        );
+    }
+
+    /// A malformed code is refused BEFORE the burn: a garbage probe must
+    /// not cost the owner their pending ceremony.
+    #[tokio::test]
+    async fn malformed_code_refuses_before_burning_the_ceremony() {
+        let dir = tempfile::tempdir().unwrap();
+        let custody = TempCustody::new(dir.path());
+        let fixture = spawn_fixture(HashMap::from([conversion_route("kept-code")])).await;
+        let runtime = GithubIntegrationRuntime::new(&fixture.base);
+        let (slot, state) = begun_slot(NOW);
+
+        let garbage = github_manifest_callback_api_response(
+            &callback_line(Some("bad%2Fcode"), Some(&state)),
+            "test-src-shape",
+            &custody,
+            &slot,
+            &runtime,
+            NOW + 1,
+        )
+        .await;
+        assert_eq!(page_status(&garbage).0, 403);
+        assert_eq!(fixture.hits.load(std::sync::atomic::Ordering::SeqCst), 0);
+
+        // The pending ceremony survived the probe: the honest callback
+        // still completes.
+        let honest = github_manifest_callback_api_response(
+            &callback_line(Some("kept-code"), Some(&state)),
+            "test-src-shape",
+            &custody,
+            &slot,
+            &runtime,
+            NOW + 2,
+        )
+        .await;
+        assert_eq!(page_status(&honest).0, 200);
+    }
+
+    /// The custody precheck refuses manifest-start up front on a
+    /// backend-less platform — the owner must never create an App whose
+    /// key cannot seal — and no ceremony state is minted.
+    #[test]
+    fn manifest_start_refuses_without_custody_backend() {
+        let dir = tempfile::tempdir().unwrap();
+        let custody = TempCustody::unavailable(dir.path());
+        let slot = ManifestCeremonySlot::default();
+        let response = github_manifest_start_api_response(
+            b"{}",
+            &custody,
+            &slot,
+            false,
+            Some("127.0.0.1:8765"),
+            "example-host",
+            "principal:test-starter",
+            NOW,
+        );
+        assert_eq!(status_of(&response), 400);
+        assert!(body_json(&response)
+            .to_string()
+            .contains("custody backend"));
+        assert!(!slot.active(NOW), "no state mints on a refused start");
+    }
+
+    #[test]
+    fn manifest_start_mints_state_and_composes_the_form() {
+        let dir = tempfile::tempdir().unwrap();
+        let custody = TempCustody::new(dir.path());
+        let slot = ManifestCeremonySlot::default();
+        let response = github_manifest_start_api_response(
+            b"{}",
+            &custody,
+            &slot,
+            false,
+            Some("127.0.0.1:8765"),
+            "example-host",
+            "principal:test-starter",
+            NOW,
+        );
+        assert_eq!(status_of(&response), 200);
+        let body = body_json(&response);
+        let form_action = body["form_action"].as_str().unwrap();
+        assert!(
+            form_action.starts_with("https://github.com/settings/apps/new?state="),
+            "personal target: {form_action}"
+        );
+        assert_eq!(
+            body["manifest"]["redirect_url"],
+            "http://127.0.0.1:8765/api/integrations/github/callback"
+        );
+        assert_eq!(body["manifest"]["public"], false);
+        assert!(!body["manifest"]
+            .as_object()
+            .unwrap()
+            .contains_key("hook_attributes"));
+        assert!(slot.active(NOW + 1), "the ceremony is pending");
+
+        // Org target + validation.
+        let org = github_manifest_start_api_response(
+            br#"{"organization": "example-org"}"#,
+            &custody,
+            &slot,
+            true,
+            Some("box.example:8443"),
+            "example-host",
+            "principal:test-starter",
+            NOW,
+        );
+        let org_body = body_json(&org);
+        assert!(org_body["form_action"]
+            .as_str()
+            .unwrap()
+            .starts_with("https://github.com/organizations/example-org/settings/apps/new?state="));
+        assert_eq!(
+            org_body["manifest"]["redirect_url"],
+            "https://box.example:8443/api/integrations/github/callback"
+        );
+
+        let bad_org = github_manifest_start_api_response(
+            br#"{"organization": "-bad handle-"}"#,
+            &custody,
+            &slot,
+            false,
+            Some("127.0.0.1:8765"),
+            "example-host",
+            "principal:test-starter",
+            NOW,
+        );
+        assert_eq!(status_of(&bad_org), 400);
+
+        let no_host = github_manifest_start_api_response(
+            b"{}",
+            &custody,
+            &slot,
+            false,
+            None,
+            "example-host",
+            "principal:test-starter",
+            NOW,
+        );
+        assert_eq!(status_of(&no_host), 400);
+    }
+
+    #[test]
+    fn validated_origin_refuses_authority_smuggling() {
+        assert_eq!(
+            validated_request_origin(false, Some("127.0.0.1:8765")).as_deref(),
+            Some("http://127.0.0.1:8765")
+        );
+        assert_eq!(
+            validated_request_origin(true, Some("Box.Example")).as_deref(),
+            Some("https://box.example")
+        );
+        for bad in [
+            "user@host",
+            "host/path",
+            "host?query=1",
+            "host#frag",
+            "",
+        ] {
+            assert_eq!(
+                validated_request_origin(false, Some(bad)),
+                None,
+                "{bad:?} must be refused"
+            );
+        }
+    }
+
+    /// The named manual-form regression pin: the five-field path still
+    /// configures end to end — a complete document seals, pending stays
+    /// false — and the one-click machinery is never consulted (no
+    /// conversion route exists on the fixture, and the hit count proves
+    /// only the verify exchange ran).
+    #[tokio::test]
+    async fn manual_form_regression_five_field_path_ignores_one_click_machinery() {
+        let dir = tempfile::tempdir().unwrap();
+        let custody = TempCustody::new(dir.path());
+        let fixture = spawn_fixture(HashMap::from([token_route()])).await;
+        let runtime = GithubIntegrationRuntime::new(&fixture.base);
+        let payload = serde_json::json!({
+            "app_id": "123456",
+            "installation_id": 987,
+            "private_key_pem": crate::github_pr::client::test_rsa_pem(),
+        });
+        let response = github_integration_save_api_response(
+            payload.to_string().as_bytes(),
+            Some(dir.path()),
+            &custody,
+            &runtime,
+            "principal:test",
+            "local",
+        )
+        .await;
+        assert_eq!(status_of(&response), 200);
+        let body = body_json(&response);
+        assert_eq!(body["saved"], true);
+        assert_eq!(body["configured"], true);
+        assert_eq!(body["pending_install"], false);
+        assert_eq!(body["status"], "valid", "the real verify exchange ran");
+        let doc = crate::github_pr::credentials::GithubAppCredentials::from_sealed_bytes(
+            &custody.retrieve().unwrap(),
+        )
+        .unwrap();
+        assert_eq!(doc.installation_id, Some(987), "complete, never pending");
+        assert_eq!(
+            fixture.token_hits.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "exactly the verify exchange — no ceremony machinery"
+        );
+    }
+
+    /// Completing a pending-install document through the save verb (the
+    /// GC2 auto-fill path) preserves the ceremony's key + slug and
+    /// clears the pending phase.
+    #[tokio::test]
+    async fn ids_only_save_completes_a_pending_document_and_clears_the_phase() {
+        let dir = tempfile::tempdir().unwrap();
+        let custody = TempCustody::new(dir.path());
+        let fixture = spawn_fixture(HashMap::from([token_route()])).await;
+        let runtime = GithubIntegrationRuntime::new(&fixture.base);
+        let pending = crate::github_pr::credentials::GithubAppCredentials {
+            v: 1,
+            app_id: "123456".to_string(),
+            installation_id: None,
+            slug: Some("intendant-example".to_string()),
+            private_key_pem: crate::github_pr::client::test_rsa_pem().to_string(),
+        };
+        custody
+            .store(&pending.sealed_bytes().unwrap(), "principal:test", "test")
+            .unwrap();
+        runtime.set_pending_install("intendant-example".to_string());
+
+        let payload = serde_json::json!({"app_id": "123456", "installation_id": 987});
+        let response = github_integration_save_api_response(
+            payload.to_string().as_bytes(),
+            Some(dir.path()),
+            &custody,
+            &runtime,
+            "principal:test",
+            "local",
+        )
+        .await;
+        assert_eq!(status_of(&response), 200);
+        let body = body_json(&response);
+        assert_eq!(body["pending_install"], false);
+        let doc = crate::github_pr::credentials::GithubAppCredentials::from_sealed_bytes(
+            &custody.retrieve().unwrap(),
+        )
+        .unwrap();
+        assert_eq!(doc.installation_id, Some(987));
+        assert_eq!(
+            doc.slug.as_deref(),
+            Some("intendant-example"),
+            "the ceremony-recorded slug survives completion"
+        );
     }
 
     #[tokio::test]

--- a/src/bin/caller/web_gateway/routes_github.rs
+++ b/src/bin/caller/web_gateway/routes_github.rs
@@ -407,13 +407,13 @@ pub(crate) fn validated_request_origin(is_tls: bool, host_header: Option<&str>) 
 /// state (single-flight by replacement) and answers the form target +
 /// manifest for the fragment to POST. The custody precheck refuses up
 /// front: the owner must never create an App whose key this daemon
-/// cannot seal.
+/// cannot seal. `origin` is the edge-validated requesting origin
+/// ([`validated_request_origin`]); `None` = no usable Host header.
 pub(crate) fn github_manifest_start_api_response(
     body: &[u8],
     custody: &dyn GithubAppCustody,
     slot: &crate::github_pr::manifest_ceremony::ManifestCeremonySlot,
-    is_tls: bool,
-    host_header: Option<&str>,
+    origin: Option<String>,
     hostname_label: &str,
     starter_principal: &str,
     now_ms: u64,
@@ -444,18 +444,13 @@ pub(crate) fn github_manifest_start_api_response(
         },
         None => None,
     };
-    let Some(origin) = validated_request_origin(is_tls, host_header) else {
+    let Some(origin) = origin else {
         return ApiResponse::json_error(
             400,
             "the request carries no usable Host header to compose the redirect origin from",
         );
     };
-    let state = match slot.begin(
-        origin.clone(),
-        target_org.clone(),
-        starter_principal.to_string(),
-        now_ms,
-    ) {
+    let state = match slot.begin(origin.clone(), starter_principal.to_string(), now_ms) {
         Ok(state) => state,
         Err(error) => return ApiResponse::json_error(500, &error),
     };
@@ -669,8 +664,7 @@ pub(crate) async fn handle_github_manifest_start(
         body,
         &DaemonGithubAppCustody,
         crate::github_pr::manifest_ceremony::slot(),
-        is_tls,
-        host_header,
+        validated_request_origin(is_tls, host_header),
         &hostname_label,
         &starter_principal,
         now_unix_ms(),
@@ -972,7 +966,6 @@ mod tests {
         let state = slot
             .begin(
                 "http://127.0.0.1:8765".to_string(),
-                None,
                 "principal:test-starter".to_string(),
                 now_ms,
             )
@@ -1294,8 +1287,7 @@ mod tests {
             b"{}",
             &custody,
             &slot,
-            false,
-            Some("127.0.0.1:8765"),
+            validated_request_origin(false, Some("127.0.0.1:8765")),
             "example-host",
             "principal:test-starter",
             NOW,
@@ -1314,8 +1306,7 @@ mod tests {
             b"{}",
             &custody,
             &slot,
-            false,
-            Some("127.0.0.1:8765"),
+            validated_request_origin(false, Some("127.0.0.1:8765")),
             "example-host",
             "principal:test-starter",
             NOW,
@@ -1343,8 +1334,7 @@ mod tests {
             br#"{"organization": "example-org"}"#,
             &custody,
             &slot,
-            true,
-            Some("box.example:8443"),
+            validated_request_origin(true, Some("box.example:8443")),
             "example-host",
             "principal:test-starter",
             NOW,
@@ -1363,8 +1353,7 @@ mod tests {
             br#"{"organization": "-bad handle-"}"#,
             &custody,
             &slot,
-            false,
-            Some("127.0.0.1:8765"),
+            validated_request_origin(false, Some("127.0.0.1:8765")),
             "example-host",
             "principal:test-starter",
             NOW,
@@ -1375,8 +1364,7 @@ mod tests {
             b"{}",
             &custody,
             &slot,
-            false,
-            None,
+            validated_request_origin(false, None),
             "example-host",
             "principal:test-starter",
             NOW,

--- a/static/app.html
+++ b/static/app.html
@@ -18025,6 +18025,56 @@ html.ui-v2 #access-github-integration-section .vault-actions {
   gap: 8px;
   margin-top: 4px;
 }
+/* One-click connect lane (Track GC): the primary gesture above the
+   collapsed manual fallback. */
+html.ui-v2 #access-github-integration-section .vault-connect-line {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin: 4px 0 12px;
+}
+html.ui-v2 #access-github-integration-section .vault-connect-org {
+  flex: 1 1 220px;
+  max-width: 320px;
+  box-sizing: border-box;
+  min-height: 36px;
+  border: 1px solid var(--line-2);
+  border-radius: var(--r-ctl);
+  background: var(--surface-2);
+  color: var(--text);
+  font-size: 13px;
+  padding: 8px 12px;
+  outline: none;
+}
+html.ui-v2 #access-github-integration-section .vault-connect-org::placeholder {
+  color: var(--text-3);
+}
+html.ui-v2 #access-github-integration-section .vault-connect-org:focus-visible {
+  border-color: var(--iris);
+  box-shadow: 0 0 0 3px rgba(var(--iris-rgb), .22);
+}
+html.ui-v2 #access-github-integration-section .vault-connect-hint {
+  flex-basis: 100%;
+  font-size: 12px;
+  color: var(--text-3);
+}
+html.ui-v2 #access-github-integration-section .vault-install-link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 36px;
+  padding: 8px 14px;
+  border-radius: var(--r-ctl);
+  border: 1px solid rgba(var(--iris-rgb), .4);
+  background: rgba(var(--iris-rgb), .14);
+  color: var(--iris);
+  font-size: 13px;
+  font-weight: 700;
+  text-decoration: none;
+}
+html.ui-v2 #access-github-integration-section .vault-install-link:hover {
+  background: rgba(var(--iris-rgb), .22);
+}
 /* ── static/app/ui2-sessions.css ── */
 /* ── ui-v2 Sessions surface re-skin (design-overhaul P2) ───────────────
    Everything here is scoped under `html.ui-v2` and restyles the EXISTING
@@ -36431,7 +36481,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'd60e141ef387d3e3';
+const INTENDANT_APP_BUILD = 'cd1cffa59802ff72';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -44422,6 +44472,46 @@ function githubIntegrationChip(text, cls) {
   return chip;
 }
 
+// One-click connect (Track GC): manifest-start is an HTTP-only route
+// (no tunnel twin — the redirect must land back on THIS origin), so it
+// rides a plain same-origin fetch like the sibling-tokens lane, never
+// the daemonApi map. The response's form target + manifest are posted
+// as a real form navigation (target _self: works identically in
+// browsers and the macOS app's WKWebView, which drops _blank).
+async function githubIntegrationConnect(orgInput) {
+  if (githubIntegrationState.busy) return;
+  githubIntegrationState.busy = true;
+  githubIntegrationState.notice = null;
+  try {
+    const organization = String(orgInput?.value || '').trim();
+    const resp = await fetch('/api/integrations/github/manifest-start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(organization ? { organization } : {}),
+    });
+    const data = await resp.json().catch(() => null);
+    if (!resp.ok) {
+      throw new Error(String(data?.error || `manifest-start failed (${resp.status})`));
+    }
+    const form = document.createElement('form');
+    form.method = 'post';
+    form.action = String(data.form_action);
+    form.target = '_self';
+    const field = document.createElement('input');
+    field.type = 'hidden';
+    field.name = 'manifest';
+    field.value = JSON.stringify(data.manifest);
+    form.appendChild(field);
+    document.body.appendChild(form);
+    form.submit();
+    // The tab navigates to GitHub now; state past this point is moot.
+  } catch (e) {
+    githubIntegrationState.notice = { text: String(e?.message || e), cls: 'warn' };
+    githubIntegrationState.busy = false;
+    renderGithubIntegrationSection();
+  }
+}
+
 async function githubIntegrationSave(fields) {
   const payload = {
     app_id: fields.appId.value.trim(),
@@ -44496,6 +44586,10 @@ function renderGithubIntegrationSection() {
   if (data?.configured) {
     chips.appendChild(githubIntegrationChip('credentials sealed', 'ok'));
   }
+  if (data?.pending_install) {
+    chips.appendChild(githubIntegrationChip('pending install', 'warn'));
+    if (data.app_slug) chips.appendChild(githubIntegrationChip(String(data.app_slug)));
+  }
   const repoCount = Array.isArray(data?.repos) ? data.repos.length : 0;
   chips.appendChild(githubIntegrationChip(`${repoCount} repo${repoCount === 1 ? '' : 's'} watched`));
   if (data && data.custody_backend_available === false) {
@@ -44510,10 +44604,60 @@ function renderGithubIntegrationSection() {
   }
   mount.appendChild(chips);
 
+  // The one-click lane (primary). Unconfigured: Connect + optional org
+  // handle. Sealed-pending-install: the install link (discovery + repo
+  // picker arrive with the next slice). The manual form below stays the
+  // universal fallback either way.
+  const custodyAvailable = !data || data.custody_backend_available !== false;
+  if (data && !data.configured) {
+    const connect = document.createElement('div');
+    connect.className = 'vault-connect-line';
+    const org = document.createElement('input');
+    org.type = 'text';
+    org.autocomplete = 'off';
+    org.placeholder = 'Organization (blank = personal account)';
+    org.className = 'vault-connect-org';
+    connect.appendChild(org);
+    const button = vaultButton('Connect GitHub', () => {
+      void githubIntegrationConnect(org);
+    }, { primary: true });
+    button.disabled = githubIntegrationState.busy || !custodyAvailable;
+    if (!custodyAvailable) {
+      button.title = 'No credential custody backend on this platform — use the manual form on a machine with custody support.';
+    }
+    connect.appendChild(button);
+    const hint = document.createElement('div');
+    hint.className = 'vault-connect-hint';
+    hint.textContent = custodyAvailable
+      ? 'One click on GitHub creates a private read-only App and seals its key here — nothing to copy.'
+      : 'The one-click ceremony needs a custody backend to seal the App key.';
+    connect.appendChild(hint);
+    mount.appendChild(connect);
+  } else if (data?.pending_install) {
+    const install = document.createElement('div');
+    install.className = 'vault-connect-line';
+    if (data.app_slug) {
+      // _self like the manifest form POST: the macOS app's WKWebView
+      // silently drops _blank, and the same-tab round trip works
+      // everywhere.
+      const link = document.createElement('a');
+      link.className = 'vault-install-link';
+      link.href = `https://github.com/apps/${encodeURIComponent(String(data.app_slug))}/installations/new`;
+      link.rel = 'noopener noreferrer';
+      link.textContent = 'Install on GitHub';
+      install.appendChild(link);
+    }
+    const hint = document.createElement('div');
+    hint.className = 'vault-connect-hint';
+    hint.textContent = 'The App is created and its key is sealed. Install it on your repositories on GitHub; installation discovery lands in the next update.';
+    install.appendChild(hint);
+    mount.appendChild(install);
+  }
+
   const fold = document.createElement('details');
   fold.className = 'acc-fold';
   const summary = document.createElement('summary');
-  summary.textContent = data?.configured ? 'Update the GitHub App' : 'Connect a GitHub App';
+  summary.textContent = data?.configured ? 'Update the GitHub App' : 'Enter credentials manually';
   const body = document.createElement('div');
   body.className = 'acc-fold-body';
   const grid = document.createElement('div');

--- a/static/app/32-vault-custody.js
+++ b/static/app/32-vault-custody.js
@@ -4320,6 +4320,46 @@ function githubIntegrationChip(text, cls) {
   return chip;
 }
 
+// One-click connect (Track GC): manifest-start is an HTTP-only route
+// (no tunnel twin — the redirect must land back on THIS origin), so it
+// rides a plain same-origin fetch like the sibling-tokens lane, never
+// the daemonApi map. The response's form target + manifest are posted
+// as a real form navigation (target _self: works identically in
+// browsers and the macOS app's WKWebView, which drops _blank).
+async function githubIntegrationConnect(orgInput) {
+  if (githubIntegrationState.busy) return;
+  githubIntegrationState.busy = true;
+  githubIntegrationState.notice = null;
+  try {
+    const organization = String(orgInput?.value || '').trim();
+    const resp = await fetch('/api/integrations/github/manifest-start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(organization ? { organization } : {}),
+    });
+    const data = await resp.json().catch(() => null);
+    if (!resp.ok) {
+      throw new Error(String(data?.error || `manifest-start failed (${resp.status})`));
+    }
+    const form = document.createElement('form');
+    form.method = 'post';
+    form.action = String(data.form_action);
+    form.target = '_self';
+    const field = document.createElement('input');
+    field.type = 'hidden';
+    field.name = 'manifest';
+    field.value = JSON.stringify(data.manifest);
+    form.appendChild(field);
+    document.body.appendChild(form);
+    form.submit();
+    // The tab navigates to GitHub now; state past this point is moot.
+  } catch (e) {
+    githubIntegrationState.notice = { text: String(e?.message || e), cls: 'warn' };
+    githubIntegrationState.busy = false;
+    renderGithubIntegrationSection();
+  }
+}
+
 async function githubIntegrationSave(fields) {
   const payload = {
     app_id: fields.appId.value.trim(),
@@ -4394,6 +4434,10 @@ function renderGithubIntegrationSection() {
   if (data?.configured) {
     chips.appendChild(githubIntegrationChip('credentials sealed', 'ok'));
   }
+  if (data?.pending_install) {
+    chips.appendChild(githubIntegrationChip('pending install', 'warn'));
+    if (data.app_slug) chips.appendChild(githubIntegrationChip(String(data.app_slug)));
+  }
   const repoCount = Array.isArray(data?.repos) ? data.repos.length : 0;
   chips.appendChild(githubIntegrationChip(`${repoCount} repo${repoCount === 1 ? '' : 's'} watched`));
   if (data && data.custody_backend_available === false) {
@@ -4408,10 +4452,60 @@ function renderGithubIntegrationSection() {
   }
   mount.appendChild(chips);
 
+  // The one-click lane (primary). Unconfigured: Connect + optional org
+  // handle. Sealed-pending-install: the install link (discovery + repo
+  // picker arrive with the next slice). The manual form below stays the
+  // universal fallback either way.
+  const custodyAvailable = !data || data.custody_backend_available !== false;
+  if (data && !data.configured) {
+    const connect = document.createElement('div');
+    connect.className = 'vault-connect-line';
+    const org = document.createElement('input');
+    org.type = 'text';
+    org.autocomplete = 'off';
+    org.placeholder = 'Organization (blank = personal account)';
+    org.className = 'vault-connect-org';
+    connect.appendChild(org);
+    const button = vaultButton('Connect GitHub', () => {
+      void githubIntegrationConnect(org);
+    }, { primary: true });
+    button.disabled = githubIntegrationState.busy || !custodyAvailable;
+    if (!custodyAvailable) {
+      button.title = 'No credential custody backend on this platform — use the manual form on a machine with custody support.';
+    }
+    connect.appendChild(button);
+    const hint = document.createElement('div');
+    hint.className = 'vault-connect-hint';
+    hint.textContent = custodyAvailable
+      ? 'One click on GitHub creates a private read-only App and seals its key here — nothing to copy.'
+      : 'The one-click ceremony needs a custody backend to seal the App key.';
+    connect.appendChild(hint);
+    mount.appendChild(connect);
+  } else if (data?.pending_install) {
+    const install = document.createElement('div');
+    install.className = 'vault-connect-line';
+    if (data.app_slug) {
+      // _self like the manifest form POST: the macOS app's WKWebView
+      // silently drops _blank, and the same-tab round trip works
+      // everywhere.
+      const link = document.createElement('a');
+      link.className = 'vault-install-link';
+      link.href = `https://github.com/apps/${encodeURIComponent(String(data.app_slug))}/installations/new`;
+      link.rel = 'noopener noreferrer';
+      link.textContent = 'Install on GitHub';
+      install.appendChild(link);
+    }
+    const hint = document.createElement('div');
+    hint.className = 'vault-connect-hint';
+    hint.textContent = 'The App is created and its key is sealed. Install it on your repositories on GitHub; installation discovery lands in the next update.';
+    install.appendChild(hint);
+    mount.appendChild(install);
+  }
+
   const fold = document.createElement('details');
   fold.className = 'acc-fold';
   const summary = document.createElement('summary');
-  summary.textContent = data?.configured ? 'Update the GitHub App' : 'Connect a GitHub App';
+  summary.textContent = data?.configured ? 'Update the GitHub App' : 'Enter credentials manually';
   const body = document.createElement('div');
   body.className = 'acc-fold-body';
   const grid = document.createElement('div');

--- a/static/app/ui2-vault.css
+++ b/static/app/ui2-vault.css
@@ -924,3 +924,53 @@ html.ui-v2 #access-github-integration-section .vault-actions {
   gap: 8px;
   margin-top: 4px;
 }
+/* One-click connect lane (Track GC): the primary gesture above the
+   collapsed manual fallback. */
+html.ui-v2 #access-github-integration-section .vault-connect-line {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin: 4px 0 12px;
+}
+html.ui-v2 #access-github-integration-section .vault-connect-org {
+  flex: 1 1 220px;
+  max-width: 320px;
+  box-sizing: border-box;
+  min-height: 36px;
+  border: 1px solid var(--line-2);
+  border-radius: var(--r-ctl);
+  background: var(--surface-2);
+  color: var(--text);
+  font-size: 13px;
+  padding: 8px 12px;
+  outline: none;
+}
+html.ui-v2 #access-github-integration-section .vault-connect-org::placeholder {
+  color: var(--text-3);
+}
+html.ui-v2 #access-github-integration-section .vault-connect-org:focus-visible {
+  border-color: var(--iris);
+  box-shadow: 0 0 0 3px rgba(var(--iris-rgb), .22);
+}
+html.ui-v2 #access-github-integration-section .vault-connect-hint {
+  flex-basis: 100%;
+  font-size: 12px;
+  color: var(--text-3);
+}
+html.ui-v2 #access-github-integration-section .vault-install-link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 36px;
+  padding: 8px 14px;
+  border-radius: var(--r-ctl);
+  border: 1px solid rgba(var(--iris-rgb), .4);
+  background: rgba(var(--iris-rgb), .14);
+  color: var(--iris);
+  font-size: 13px;
+  font-weight: 700;
+  text-decoration: none;
+}
+html.ui-v2 #access-github-integration-section .vault-install-link:hover {
+  background: rgba(var(--iris-rgb), .22);
+}


### PR DESCRIPTION
Track GC slice GC1: replaces the five-field GitHub App form with GitHub's App Manifest flow — one Connect button, one green button on github.com, credentials sealed into custody without the owner ever seeing a PEM. The manual form remains the universal fallback.

Daemon side (this push):
- `github_pr/manifest_ceremony.rs`: single-flight-by-replacement pending slot; 32-byte state stored hashed, constant-time compared, atomically burned before any GitHub call; 30-min TTL; doorbell-shape rate limiter; manifest composition (private App, read-only metadata/pull_requests/checks, no webhook).
- Route rows: `POST /api/integrations/github/manifest-start` (CredentialsManage, HTTP-only — the payload is only meaningful to a browser on this origin) and `GET /api/integrations/github/callback` (public own-origin row + certless carve-out predicate; the state is the entire authorization — without it the code is never exchanged).
- Conversion is server-side on the fixture-injectable client transport; `client_secret`/`webhook_secret` are discarded at parse (narrow three-field struct). Sealed doc evolves additively in v1: `installation_id: Option<u64>` + `slug` (pending-install state); old builds fail pending docs closed into the named pause lane.
- Scanner: named 'installation pending' pause (re-establishes the runtime pending cache after restart); status body grows `pending_install` + `app_slug` beside the ruled label vocabulary.
- Custody-audit actor at seal = the principal whose CredentialsManage gesture opened the ceremony.

Still to come on this branch before ready: vault-section state machine (fragment + app.html regen), fixture test suite (named conversion-hits=0 pins, secrets-discard, replay/foreign-code/expired refusals, manual-form regression).

Design gate: agenda item 01KYCPDH8CBMN37G36941NAWAN (ruled 2026-07-25, all seven approved as recommended).