### PR TITLE
feat(github): installation discovery, repo picker, docs re-lead (Track GC, GC2)

### DIFF
--- a/docs/src/github-pr-integration.md
+++ b/docs/src/github-pr-integration.md
@@ -125,10 +125,73 @@ for every PR on the fleet, watched or not. Both exist on purpose.
   honored. Configuration state (which repos to watch, the poll cadence)
   is non-secret and lives in `[integrations.github]` in
   `intendant.toml`.
+- **The one-click ceremony's guard is a daemon-minted single-use
+  state.** GitHub's redirect lands on an authority-free callback route
+  (a browser navigation carries no daemon credential); without the
+  matching unexpired state — 32 random bytes, stored hashed, burned
+  atomically before any GitHub call — the callback is a uniform refusal
+  and the code is **never exchanged**, so a foreign code can never
+  substitute attacker-App credentials. The state travels only inside
+  the GitHub form action and its redirect; the per-boot dashboard
+  admission token never rides the redirect URL.
+- **Intendant stores only what the daemon uses.** The conversion
+  response's `client_secret` and `webhook_secret` are discarded at
+  parse (the daemon retains the App id, slug, and private key — nothing
+  else); the PEM travels GitHub → daemon → custody without ever
+  touching a file, a log, or the browser.
 
-## Setup: the five-minute ceremony
+## Setup: one click
 
-You (the owner) do this once; agents cannot and must not.
+You (the owner) do this once; agents cannot and must not. Dashboard →
+**Vault** → *GitHub App integration*:
+
+1. **Connect GitHub** — optionally type your org handle (blank = your
+   personal account) and press **Connect GitHub**. Your browser goes to
+   github.com with a pre-filled manifest: a **private** App named
+   `Intendant (<host>)` with exactly the three read-only permissions
+   and **no webhook**. One green button — *Create GitHub App* — and
+   GitHub sends the browser back to the daemon, which exchanges the
+   single-use code server-side and **seals the App's key straight into
+   custody**. You never see, download, or paste a PEM. (If the name is
+   taken, GitHub's own page lets you edit it before creating.)
+2. **Install on GitHub** — the section now shows the sealed App with an
+   *Install on GitHub* link. Pick the account and the repositories the
+   App may see. Back in the dashboard, the installation is discovered
+   automatically within a few seconds (several installations render a
+   picker; none after two minutes leaves the link plus the manual
+   fallback).
+3. **Pick repositories** — tick the repos to watch and *Save selection
+   & verify*. The daemon performs one real exchange (token mint plus a
+   pull list) so the status chip says `valid` — or tells you exactly
+   why not. Poll cadence lives under *Advanced* (default 5 minutes,
+   floor 1).
+
+Status states are honest and few: `unconfigured` (nothing runs),
+`configured` (sealed, no exchange yet), `valid`, `unreachable`
+(network/rate trouble, self-healing), `denied` (bad or revoked
+credentials — fix the configuration). A `pending install` chip rides
+beside them between Create and Install. One transient to know: after a
+daemon restart mid-pending, the chip reads plain `configured` until the
+section's first discovery call (or a scanner pass) re-establishes the
+pending phase — status polls never unseal the document, by design.
+Remove deletes the sealed entry (idempotent, audited as
+`key_custody_removed`) and returns the integration to `unconfigured`.
+
+The effective watch set is the intersection of your configured list and
+the installation's repositories — a repo listed but not installed (or
+vice versa) simply isn't watched, and the status surface shows the
+configured list so nothing skips silently.
+
+The ceremony needs the browser to reach the daemon's own origin
+(loopback or a directly-reached TLS dashboard) and a custody backend on
+the daemon (macOS today — the Connect button refuses by name
+otherwise). Where either is missing, the manual fallback below is the
+path.
+
+## Fallback: the manual five-field ceremony
+
+The form under *Enter credentials manually* accepts everything the
+one-click path automates — it remains fully supported:
 
 1. **Register the App** — GitHub → your org (or user) → Settings →
    Developer settings → GitHub Apps → *New GitHub App*. Name it
@@ -145,30 +208,24 @@ You (the owner) do this once; agents cannot and must not.
    the account → *Only select repositories* → pick the repos to watch.
    After installing, the browser URL ends in the **installation id**
    (`…/settings/installations/<number>`).
-4. **Enter it in the Vault tab** — dashboard → **Vault** → *GitHub App
-   integration*: paste the App ID, installation id, and the `.pem`
-   contents; list the repos to watch (`owner/repo`, one per line);
-   *Save & verify*. The key seals into custody and the daemon performs
-   one real exchange (token mint plus, when repos are listed, a pull
-   list) so the status chip says `valid` — or tells you exactly why
-   not. Delete the downloaded `.pem` afterwards; the sealed copy is now
-   the working one.
-5. **Done.** Status states are honest and few: `unconfigured` (nothing
-   runs), `configured` (sealed, no exchange yet), `valid`,
-   `unreachable` (network/rate trouble, self-healing), `denied` (bad or
-   revoked credentials — fix the configuration). Remove deletes the
-   sealed entry (idempotent, audited as `key_custody_removed`) and
-   returns the integration to `unconfigured`.
-
-The effective watch set is the intersection of your configured list and
-the installation's repositories — a repo listed but not installed (or
-vice versa) simply isn't watched, and the status surface shows the
-configured list so nothing skips silently.
+4. **Enter it in the Vault tab** — paste the App ID, installation id,
+   and the `.pem` contents; list the repos to watch (`owner/repo`, one
+   per line); *Save & verify*. Delete the downloaded `.pem` afterwards;
+   the sealed copy is now the working one.
 
 ## Endpoints
 
 `POST /api/integrations/github` (configure; `credentials.manage`),
 `GET /api/integrations/github/status` (`settings`),
-`DELETE /api/integrations/github` (`credentials.manage`) — declared on
-the gateway route table with dashboard-tunnel twins
-(`api_github_integration_save` / `_status` / `_remove`).
+`DELETE /api/integrations/github` (`credentials.manage`),
+`GET /api/integrations/github/installations` and
+`GET /api/integrations/github/repositories` (both `credentials.manage`
+— they unseal the key to mint tokens) — declared on the gateway route
+table with dashboard-tunnel twins (`api_github_integration_save` /
+`_status` / `_remove`, `api_github_installations` /
+`api_github_repositories`). The ceremony's two HTTP-only routes carry
+no tunnel twin by design: `POST
+/api/integrations/github/manifest-start` (`credentials.manage`; its
+payload is only meaningful to a browser on the daemon's own origin) and
+`GET /api/integrations/github/callback` (the authority-free redirect
+landing — the single-use state is the authorization).

--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -1947,6 +1947,8 @@ response omits the header.
 | DELETE | `/api/integrations/github` | CredentialsManage | own origin | none | Remove the GitHub App integration credentials from custody |
 | POST | `/api/integrations/github/manifest-start` | CredentialsManage | own origin | ≤ 4 KiB | Begin the one-click GitHub App Manifest ceremony (mints the single-use state; refuses without a custody backend) |
 | GET | `/api/integrations/github/callback` | public | own origin | none | GitHub App Manifest redirect landing (single-use state is the authorization; renders a return-to-dashboard page) |
+| GET | `/api/integrations/github/installations` | CredentialsManage | own origin | none | The App's installations (App-JWT discovery; works while the install is pending) |
+| GET | `/api/integrations/github/repositories` | CredentialsManage | own origin | none | Repositories the installation can see (installation token; feeds the repo picker) |
 | GET | `/api/local-daemons/tokens` | CredentialsManage | own origin | none | Loopback admission tokens for same-home daemon instances (owner handoff) |
 | POST | `/api/claude-auth/start` | CredentialsManage | own origin | ≤ 4 KiB | Start the Claude sign-in ceremony (`claude auth login` on a daemon-private PTY) |
 | GET | `/api/claude-auth/status` | CredentialsManage | own origin | none | Claude sign-in ceremony state (validated sign-in URL; account info on success) |

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -5935,6 +5935,13 @@ mod tests {
                 Row,
                 Some(Op::CredentialsManage),
             ),
+            // One-click connect (Track GC): both reads UNSEAL the key
+            // (App JWT / installation token) — the family principle
+            // gates credential use at CredentialsManage, never
+            // Settings. Manifest-start and the callback are HTTP-only
+            // by design and deliberately absent here.
+            ("api_github_installations", Row, Some(Op::CredentialsManage)),
+            ("api_github_repositories", Row, Some(Op::CredentialsManage)),
             ("api_project_root", Row, Some(Op::Settings)),
             ("api_voice_session", Residue, Some(Op::RuntimeControl)),
             (
@@ -6209,6 +6216,8 @@ mod tests {
             "api_github_integration_save",
             "api_github_integration_status",
             "api_github_integration_remove",
+            "api_github_installations",
+            "api_github_repositories",
             "api_claude_auth_start",
             "api_claude_auth_status",
             "api_claude_auth_code",

--- a/src/bin/caller/gateway_routes.rs
+++ b/src/bin/caller/gateway_routes.rs
@@ -320,6 +320,10 @@ pub(crate) enum RouteHandlerId {
     /// GitHub's redirect landing (browser navigation): burn the state,
     /// convert the code server-side, seal pending-install.
     GithubManifestCallback,
+    /// Installation discovery under the App JWT (unseals; pending OK).
+    GithubInstallations,
+    /// The installation's visible repositories (unseals; complete only).
+    GithubRepositories,
     /// Claude sign-in ceremony: start `claude auth login` on a private PTY.
     ClaudeAuthStart,
     /// Ceremony state + validated sign-in URL + account info on success.
@@ -1722,6 +1726,27 @@ pub(crate) static ROUTES: &[Route] = &[
         RouteHandlerId::GithubManifestCallback,
         "GitHub App Manifest redirect landing (single-use state is the authorization; renders a return-to-dashboard page)",
     ),
+    //    Discovery + repo listing are reads that UNSEAL the key (App
+    //    JWT / installation token), so per the family principle above
+    //    they gate at CredentialsManage, never Settings.
+    op_route(
+        RouteMethod::Get,
+        PathPattern::Exact("/api/integrations/github/installations"),
+        PeerOperation::CredentialsManage,
+        BodyPolicy::None,
+        RouteHandlerId::GithubInstallations,
+        "The App's installations (App-JWT discovery; works while the install is pending)",
+    )
+    .with_tunnel(tunnel_method("api_github_installations")),
+    op_route(
+        RouteMethod::Get,
+        PathPattern::Exact("/api/integrations/github/repositories"),
+        PeerOperation::CredentialsManage,
+        BodyPolicy::None,
+        RouteHandlerId::GithubRepositories,
+        "Repositories the installation can see (installation token; feeds the repo picker)",
+    )
+    .with_tunnel(tunnel_method("api_github_repositories")),
     // ── Same-home sibling loopback-token handoff (ratified 2026-07-20):
     //    the response contains per-boot loopback admission tokens, so
     //    the route rides the credential-custody operation like the

--- a/src/bin/caller/github_pr/client.rs
+++ b/src/bin/caller/github_pr/client.rs
@@ -213,6 +213,16 @@ pub(crate) struct ReviewSummary {
     pub(crate) commented: usize,
 }
 
+/// One installation of the App, as the discovery surface renders it.
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct InstallationSummary {
+    pub(crate) installation_id: u64,
+    pub(crate) account_login: String,
+    /// GitHub also echoes the App id per row; the auto-fill save wants
+    /// it, and the sealed document is never unsealed for a status read.
+    pub(crate) app_id: Option<u64>,
+}
+
 pub(crate) struct GithubAppClient {
     http: reqwest::Client,
     api_base: String,
@@ -299,6 +309,82 @@ impl GithubAppClient {
             expires_unix_s,
         });
         Ok(token)
+    }
+
+    /// The App's installations, under the App JWT alone — the discovery
+    /// read of the connect ceremony, so it works on a pending-install
+    /// document (no installation token exists yet). One page of 100:
+    /// a private per-daemon App has one installation in practice; a
+    /// hundred is not a shape this integration mirrors.
+    pub(crate) async fn list_installations(&self) -> Result<Vec<InstallationSummary>, ApiError> {
+        let jwt = mint_app_jwt(&self.credentials, unix_now_s()).map_err(ApiError::Denied)?;
+        let url = format!("{}/app/installations?per_page=100", self.api_base);
+        let response = self
+            .http
+            .get(&url)
+            .bearer_auth(&jwt)
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", API_VERSION)
+            .send()
+            .await
+            .map_err(|error| ApiError::Unreachable(error.to_string()))?;
+        let response = classify(response).await?;
+        let value: serde_json::Value = response
+            .json()
+            .await
+            .map_err(|error| ApiError::Unreachable(format!("installations body: {error}")))?;
+        let rows = value
+            .as_array()
+            .ok_or_else(|| ApiError::Unreachable("installations shape: not a list".to_string()))?;
+        Ok(rows
+            .iter()
+            .filter_map(|row| {
+                Some(InstallationSummary {
+                    installation_id: row.get("id")?.as_u64()?,
+                    account_login: row
+                        .get("account")
+                        .and_then(|a| a.get("login"))
+                        .and_then(|l| l.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                    app_id: row.get("app_id").and_then(|v| v.as_u64()),
+                })
+            })
+            .collect())
+    }
+
+    /// Repositories the installation can see (the repo picker's read):
+    /// installation token, `full_name`s only, bounded pagination like
+    /// the PR list.
+    pub(crate) async fn list_installation_repositories(&self) -> Result<Vec<String>, ApiError> {
+        let mut names = Vec::new();
+        let mut url = format!("{}/installation/repositories?per_page=100", self.api_base);
+        for _ in 0..MAX_LIST_PAGES {
+            let value = match self.get_value(&url, None).await? {
+                Conditional::NotModified => {
+                    return Err(ApiError::Unreachable(
+                        "unconditional read answered 304".to_string(),
+                    ))
+                }
+                Conditional::Fresh { value, .. } => value,
+            };
+            let (page, next) = match (value.get("__page"), value.get("__next")) {
+                (Some(page), Some(next)) => (page.clone(), next.as_str().map(str::to_string)),
+                _ => (value, None),
+            };
+            if let Some(rows) = page.get("repositories").and_then(|r| r.as_array()) {
+                names.extend(rows.iter().filter_map(|row| {
+                    row.get("full_name")
+                        .and_then(|n| n.as_str())
+                        .map(str::to_string)
+                }));
+            }
+            match next {
+                Some(next_url) => url = next_url,
+                None => break,
+            }
+        }
+        Ok(names)
     }
 
     /// Conditional GET of an absolute API URL. `etag` rides

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -1692,6 +1692,22 @@ pub(crate) async fn serve_http_request(
                 )
                 .await;
             }
+            RouteHandlerId::GithubInstallations => {
+                return handle_github_installations(
+                    stream,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
+            }
+            RouteHandlerId::GithubRepositories => {
+                return handle_github_repositories(
+                    stream,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
+            }
             RouteHandlerId::ClaudeAuthStart => {
                 return handle_claude_auth_start(
                     stream,

--- a/src/bin/caller/web_gateway/routes_github.rs
+++ b/src/bin/caller/web_gateway/routes_github.rs
@@ -52,8 +52,13 @@ impl GithubAppCustody for DaemonGithubAppCustody {
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct GithubSavePayload {
-    app_id: String,
-    installation_id: u64,
+    /// Required with a fresh key; optional on an update of an existing
+    /// entry (absent = keep the sealed value). The repo picker's
+    /// config-only writes send neither id.
+    #[serde(default)]
+    app_id: Option<String>,
+    #[serde(default)]
+    installation_id: Option<u64>,
     /// Absent on an ids/watch-list-only update of an existing entry.
     #[serde(default)]
     private_key_pem: Option<String>,
@@ -194,18 +199,34 @@ pub(crate) async fn github_integration_save_api_response(
         return ApiResponse::json_error(400, "poll_minutes floor is 1");
     }
 
-    // Resolve the credentials document: a fresh key, or an ids-only
-    // update re-sealing the existing document. Updates need the current
-    // key, so this is the one configure-time unseal — an owner gesture
-    // under CredentialsManage, not a poll.
-    let mut document = match payload.private_key_pem.as_deref() {
-        Some(pem) => crate::github_pr::credentials::GithubAppCredentials {
-            v: 1,
-            app_id: payload.app_id.clone(),
-            installation_id: Some(payload.installation_id),
-            slug: None,
-            private_key_pem: pem.to_string(),
-        },
+    // Resolve the credentials document: a fresh key, an ids update
+    // re-sealing the existing document, or a config-only write (repo
+    // picker, poll minutes) that verifies against the sealed document
+    // without re-sealing it. Updates need the current key, so this is
+    // the one configure-time unseal — an owner gesture under
+    // CredentialsManage, not a poll.
+    let ids_supplied = payload.app_id.is_some() || payload.installation_id.is_some();
+    let (mut document, reseal) = match payload.private_key_pem.as_deref() {
+        Some(pem) => {
+            let (Some(app_id), Some(installation_id)) =
+                (payload.app_id.clone(), payload.installation_id)
+            else {
+                return ApiResponse::json_error(
+                    400,
+                    "app_id and installation_id are required with a new private key",
+                );
+            };
+            (
+                crate::github_pr::credentials::GithubAppCredentials {
+                    v: 1,
+                    app_id,
+                    installation_id: Some(installation_id),
+                    slug: None,
+                    private_key_pem: pem.to_string(),
+                },
+                true,
+            )
+        }
         None => {
             if !custody.present() {
                 return ApiResponse::json_error(
@@ -222,12 +243,16 @@ pub(crate) async fn github_integration_save_api_response(
             match crate::github_pr::credentials::GithubAppCredentials::from_sealed_bytes(&existing)
             {
                 Ok(mut existing) => {
-                    existing.app_id = payload.app_id.clone();
-                    // Completing a pending-install document keeps its
-                    // ceremony-recorded slug; a plain ids update keeps
-                    // whatever was there.
-                    existing.installation_id = Some(payload.installation_id);
-                    existing
+                    // Present ids overwrite; absent ids keep the sealed
+                    // values. Completing a pending-install document
+                    // keeps its ceremony-recorded slug either way.
+                    if let Some(app_id) = payload.app_id.clone() {
+                        existing.app_id = app_id;
+                    }
+                    if let Some(installation_id) = payload.installation_id {
+                        existing.installation_id = Some(installation_id);
+                    }
+                    (existing, ids_supplied)
                 }
                 Err(error) => return ApiResponse::json_error(500, &error),
             }
@@ -236,17 +261,21 @@ pub(crate) async fn github_integration_save_api_response(
     if let Err(error) = document.validate() {
         return ApiResponse::json_error(400, &error);
     }
-    let sealed = match document.sealed_bytes() {
-        Ok(bytes) => bytes,
-        Err(error) => return ApiResponse::json_error(500, &error),
-    };
-    if let Err(error) = custody.store(&sealed, actor_principal, audit_origin) {
-        return ApiResponse::json_error(500, &error);
+    if reseal {
+        let sealed = match document.sealed_bytes() {
+            Ok(bytes) => bytes,
+            Err(error) => return ApiResponse::json_error(500, &error),
+        };
+        if let Err(error) = custody.store(&sealed, actor_principal, audit_origin) {
+            return ApiResponse::json_error(500, &error);
+        }
+        // A re-sealed complete document ends the ceremony pending
+        // phase — including the auto-fill that completes it. A pending
+        // document (app_id-only update) stays pending.
+        if document.installation_id.is_some() {
+            runtime.clear_pending_install();
+        }
     }
-    // Every save writes a complete document (installation_id present),
-    // so any ceremony pending-phase is over — including the GC2
-    // auto-fill that completes a pending-install document.
-    runtime.clear_pending_install();
 
     // Persist the non-secret watch config beside the sealed entry.
     let mut config_persisted = true;
@@ -646,6 +675,118 @@ pub(crate) async fn github_manifest_callback_api_response(
         ),
         Some(&pending.origin),
     )
+}
+
+/// Unseal + parse the sealed document for a ceremony read. `None` =
+/// absent or custody-denied (the custody lane audited it by name).
+fn unsealed_document(
+    custody: &dyn GithubAppCustody,
+) -> Option<crate::github_pr::credentials::GithubAppCredentials> {
+    let bytes = custody.retrieve()?;
+    crate::github_pr::credentials::GithubAppCredentials::from_sealed_bytes(&bytes).ok()
+}
+
+/// Transport-neutral core of `GET /api/integrations/github/installations`
+/// (tunnel twin `api_github_installations`). App-JWT discovery: works on
+/// a pending-install document — and re-establishes the runtime's
+/// pending cache from the sealed doc (the restart-transient self-heal).
+pub(crate) async fn github_installations_api_response(
+    custody: &dyn GithubAppCustody,
+    runtime: &crate::github_pr::status::GithubIntegrationRuntime,
+) -> ApiResponse {
+    if !custody.present() {
+        return ApiResponse::json_error(400, "no GitHub App is configured");
+    }
+    let Some(document) = unsealed_document(custody) else {
+        return ApiResponse::json_error(
+            500,
+            "custody refused the sealed credentials (the custody trail carries the deny)",
+        );
+    };
+    if document.installation_id.is_none() {
+        runtime.set_pending_install(document.slug.clone().unwrap_or_default());
+    }
+    let client = match crate::github_pr::client::GithubAppClient::new(runtime.api_base(), document)
+    {
+        Ok(client) => client,
+        Err(error) => return ApiResponse::json_error(500, &error),
+    };
+    match client.list_installations().await {
+        Ok(installations) => ApiResponse::json(
+            200,
+            JsonBody::Value(serde_json::json!({ "installations": installations })),
+        ),
+        Err(error) => {
+            runtime.record_error(&error);
+            ApiResponse::json_error(502, format!("installation discovery failed: {error}"))
+        }
+    }
+}
+
+/// Transport-neutral core of `GET /api/integrations/github/repositories`
+/// (tunnel twin `api_github_repositories`). Installation-token read —
+/// a pending-install document is a named refusal, not an error class.
+pub(crate) async fn github_repositories_api_response(
+    custody: &dyn GithubAppCustody,
+    runtime: &crate::github_pr::status::GithubIntegrationRuntime,
+) -> ApiResponse {
+    if !custody.present() {
+        return ApiResponse::json_error(400, "no GitHub App is configured");
+    }
+    let Some(document) = unsealed_document(custody) else {
+        return ApiResponse::json_error(
+            500,
+            "custody refused the sealed credentials (the custody trail carries the deny)",
+        );
+    };
+    if document.installation_id.is_none() {
+        runtime.set_pending_install(document.slug.clone().unwrap_or_default());
+        return ApiResponse::json_error(
+            400,
+            "installation pending — install the App on GitHub and finish discovery first",
+        );
+    }
+    let client = match crate::github_pr::client::GithubAppClient::new(runtime.api_base(), document)
+    {
+        Ok(client) => client,
+        Err(error) => return ApiResponse::json_error(500, &error),
+    };
+    match client.list_installation_repositories().await {
+        Ok(repositories) => ApiResponse::json(
+            200,
+            JsonBody::Value(serde_json::json!({ "repositories": repositories })),
+        ),
+        Err(error) => {
+            runtime.record_error(&error);
+            ApiResponse::json_error(502, format!("repository listing failed: {error}"))
+        }
+    }
+}
+
+pub(crate) async fn handle_github_installations(
+    stream: DemuxStream,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
+) {
+    let response = github_installations_api_response(
+        &DaemonGithubAppCustody,
+        crate::github_pr::status::global(),
+    )
+    .await;
+    write_api_response(stream, response, cors, fleet_origin).await;
+}
+
+pub(crate) async fn handle_github_repositories(
+    stream: DemuxStream,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
+) {
+    let response = github_repositories_api_response(
+        &DaemonGithubAppCustody,
+        crate::github_pr::status::global(),
+    )
+    .await;
+    write_api_response(stream, response, cors, fleet_origin).await;
 }
 
 pub(crate) async fn handle_github_manifest_start(
@@ -1477,6 +1618,171 @@ mod tests {
             doc.slug.as_deref(),
             Some("intendant-example"),
             "the ceremony-recorded slug survives completion"
+        );
+    }
+
+    fn seal_direct(
+        custody: &TempCustody,
+        doc: &crate::github_pr::credentials::GithubAppCredentials,
+    ) {
+        custody
+            .store(&doc.sealed_bytes().unwrap(), "principal:test", "test")
+            .unwrap();
+    }
+
+    fn complete_doc() -> crate::github_pr::credentials::GithubAppCredentials {
+        crate::github_pr::credentials::GithubAppCredentials {
+            v: 1,
+            app_id: "123456".to_string(),
+            installation_id: Some(987),
+            slug: Some("intendant-example".to_string()),
+            private_key_pem: crate::github_pr::client::test_rsa_pem().to_string(),
+        }
+    }
+
+    fn pending_doc() -> crate::github_pr::credentials::GithubAppCredentials {
+        crate::github_pr::credentials::GithubAppCredentials {
+            installation_id: None,
+            ..complete_doc()
+        }
+    }
+
+    /// Discovery answers under the App JWT on a PENDING document — and
+    /// the unseal re-establishes the runtime's pending cache (the
+    /// restart-transient self-heal).
+    #[tokio::test]
+    async fn installations_discovery_works_on_pending_docs_and_reheals_the_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        let custody = TempCustody::new(dir.path());
+        seal_direct(&custody, &pending_doc());
+        let fixture = spawn_fixture(HashMap::from([(
+            ("GET".to_string(), "/app/installations".to_string()),
+            (
+                200,
+                Vec::new(),
+                serde_json::json!([{
+                    "id": 987,
+                    "account": {"login": "example-org"},
+                    "app_id": 123456,
+                    "app_slug": "intendant-example",
+                }])
+                .to_string(),
+            ),
+        )]))
+        .await;
+        let runtime = GithubIntegrationRuntime::new(&fixture.base);
+        assert!(runtime.pending_install_slug().is_none(), "fresh runtime");
+
+        let response = github_installations_api_response(&custody, &runtime).await;
+        assert_eq!(status_of(&response), 200);
+        let body = body_json(&response);
+        assert_eq!(body["installations"][0]["installation_id"], 987);
+        assert_eq!(body["installations"][0]["account_login"], "example-org");
+        assert_eq!(body["installations"][0]["app_id"], 123456);
+        assert_eq!(
+            runtime.pending_install_slug().as_deref(),
+            Some("intendant-example"),
+            "the gated unseal re-established the pending cache"
+        );
+    }
+
+    /// The repo listing refuses a pending document by name and lists
+    /// under the installation token once the document is complete.
+    #[tokio::test]
+    async fn repositories_refuse_on_pending_and_list_on_complete() {
+        let dir = tempfile::tempdir().unwrap();
+        let custody = TempCustody::new(dir.path());
+        seal_direct(&custody, &pending_doc());
+        let fixture = spawn_fixture(HashMap::from([
+            token_route(),
+            (
+                ("GET".to_string(), "/installation/repositories".to_string()),
+                (
+                    200,
+                    Vec::new(),
+                    serde_json::json!({
+                        "total_count": 2,
+                        "repositories": [
+                            {"full_name": "example-org/repo-a"},
+                            {"full_name": "example-org/repo-b"},
+                        ],
+                    })
+                    .to_string(),
+                ),
+            ),
+        ]))
+        .await;
+        let runtime = GithubIntegrationRuntime::new(&fixture.base);
+
+        let refused = github_repositories_api_response(&custody, &runtime).await;
+        assert_eq!(status_of(&refused), 400);
+        assert!(body_json(&refused)
+            .to_string()
+            .contains("installation pending"));
+        assert_eq!(
+            fixture.hits.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "a pending document never mints a token"
+        );
+
+        seal_direct(&custody, &complete_doc());
+        let listed = github_repositories_api_response(&custody, &runtime).await;
+        assert_eq!(status_of(&listed), 200);
+        assert_eq!(
+            body_json(&listed)["repositories"],
+            serde_json::json!(["example-org/repo-a", "example-org/repo-b"])
+        );
+    }
+
+    /// A config-only save (the repo picker's write) never touches
+    /// custody: the store count stays where seeding left it, the sealed
+    /// document is byte-identical, and the verify exchange still runs
+    /// against the sealed key.
+    #[tokio::test]
+    async fn repos_only_save_never_touches_custody() {
+        let dir = tempfile::tempdir().unwrap();
+        let custody = TempCustody::new(dir.path());
+        seal_direct(&custody, &complete_doc());
+        let sealed_before = custody.retrieve().unwrap();
+        assert_eq!(*custody.stores.lock().unwrap(), 1, "seeding store only");
+        let fixture = spawn_fixture(HashMap::from([
+            token_route(),
+            (
+                (
+                    "GET".to_string(),
+                    "/repos/example-org/repo-a/pulls".to_string(),
+                ),
+                (200, Vec::new(), "[]".to_string()),
+            ),
+        ]))
+        .await;
+        let runtime = GithubIntegrationRuntime::new(&fixture.base);
+
+        let payload = serde_json::json!({"repos": ["example-org/repo-a"], "poll_minutes": 7});
+        let response = github_integration_save_api_response(
+            payload.to_string().as_bytes(),
+            Some(dir.path()),
+            &custody,
+            &runtime,
+            "principal:test",
+            "local",
+        )
+        .await;
+        assert_eq!(status_of(&response), 200);
+        let body = body_json(&response);
+        assert_eq!(body["saved"], true);
+        assert_eq!(body["status"], "valid", "the verify exchange ran");
+        assert_eq!(body["repos"], serde_json::json!(["example-org/repo-a"]));
+        assert_eq!(body["poll_minutes"], 7);
+        assert_eq!(
+            *custody.stores.lock().unwrap(),
+            1,
+            "a config-only save must never re-seal"
+        );
+        assert_eq!(
+            custody.retrieve().unwrap(),
+            sealed_before,
+            "the sealed document is byte-identical"
         );
     }
 

--- a/static/app.html
+++ b/static/app.html
@@ -36481,7 +36481,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '7c9794c4b8006794';
+const INTENDANT_APP_BUILD = '0fb23b1551d9ee43';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -39059,6 +39059,8 @@ const DAEMON_API_HTTP_MAP = Object.freeze({
   api_github_integration_save: { verb: 'POST', path: '/api/integrations/github' },
   api_github_integration_status: { verb: 'GET', path: '/api/integrations/github/status' },
   api_github_integration_remove: { verb: 'DELETE', path: '/api/integrations/github' },
+  api_github_installations: { verb: 'GET', path: '/api/integrations/github/installations' },
+  api_github_repositories: { verb: 'GET', path: '/api/integrations/github/repositories' },
   api_fs_write: { verb: 'POST', path: '/api/fs/write', lane: 'upload', encode: 'json-b64' },
   api_fs_rename: { verb: 'POST', path: '/api/fs/rename' },
   api_fs_delete: { verb: 'POST', path: '/api/fs/delete' },

--- a/static/app.html
+++ b/static/app.html
@@ -18075,6 +18075,32 @@ html.ui-v2 #access-github-integration-section .vault-install-link {
 html.ui-v2 #access-github-integration-section .vault-install-link:hover {
   background: rgba(var(--iris-rgb), .22);
 }
+html.ui-v2 #access-github-integration-section .vault-repo-picker {
+  margin: 4px 0 12px;
+}
+html.ui-v2 #access-github-integration-section .vault-repo-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 220px;
+  overflow-y: auto;
+  margin: 4px 0 10px;
+  padding: 8px 10px;
+  border: 1px solid var(--line-2);
+  border-radius: var(--r-ctl);
+  background: var(--surface-2);
+}
+html.ui-v2 #access-github-integration-section .vault-repo-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text);
+  cursor: pointer;
+}
+html.ui-v2 #access-github-integration-section .vault-repo-item input {
+  accent-color: var(--iris);
+}
 /* ── static/app/ui2-sessions.css ── */
 /* ── ui-v2 Sessions surface re-skin (design-overhaul P2) ───────────────
    Everything here is scoped under `html.ui-v2` and restyles the EXISTING
@@ -36481,7 +36507,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '0fb23b1551d9ee43';
+const INTENDANT_APP_BUILD = '07a8b743b9ced013';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -44452,6 +44478,10 @@ const githubIntegrationState = {
   notice: null, // { text, cls } — the last action's outcome, transient
   lastError: null,
   removeArmedAt: 0,
+  // Bounded install discovery (pending state only).
+  discovery: { polling: false, until: 0, installations: null, error: null },
+  // Repo picker cache (installed state only).
+  repoPicker: { loading: false, repositories: null, error: null },
 };
 
 async function githubIntegrationRefresh(force = false) {
@@ -44480,6 +44510,110 @@ function githubIntegrationChip(text, cls) {
 // the daemonApi map. The response's form target + manifest are posted
 // as a real form navigation (target _self: works identically in
 // browsers and the macOS app's WKWebView, which drops _blank).
+// Bounded installation discovery (Track GC slice GC2): after the
+// Install click (or on opening a pending section) poll the discovery
+// route every 5 s for up to 2 minutes. Exactly one installation
+// auto-fills through the EXISTING save verb; several render a picker;
+// zero leaves the install link + the manual fallback. The route is a
+// plain request — the daemon runs no loop.
+const GITHUB_DISCOVERY_TICK_MS = 5000;
+const GITHUB_DISCOVERY_WINDOW_MS = 120000;
+
+function githubIntegrationDiscoveryStart() {
+  const d = githubIntegrationState.discovery;
+  d.until = Date.now() + GITHUB_DISCOVERY_WINDOW_MS;
+  d.error = null;
+  if (!d.polling) void githubIntegrationDiscoveryTick();
+}
+
+async function githubIntegrationDiscoveryTick() {
+  const d = githubIntegrationState.discovery;
+  if (!githubIntegrationState.data?.pending_install || Date.now() > d.until) {
+    d.polling = false;
+    renderGithubIntegrationSection();
+    return;
+  }
+  d.polling = true;
+  try {
+    const data = await daemonApi.request('api_github_installations', {});
+    const rows = Array.isArray(data?.installations) ? data.installations : [];
+    d.installations = rows;
+    d.error = null;
+    if (rows.length === 1 && rows[0]?.installation_id) {
+      d.polling = false;
+      await githubIntegrationCompleteInstall(rows[0]);
+      return;
+    }
+  } catch (e) {
+    d.error = String(e?.message || e);
+  }
+  setTimeout(() => { void githubIntegrationDiscoveryTick(); }, GITHUB_DISCOVERY_TICK_MS);
+  renderGithubIntegrationSection();
+}
+
+// The auto-fill: complete the pending document through the existing
+// save verb (ids-only update — the sealed key and slug survive, and
+// save's real verification runs).
+async function githubIntegrationCompleteInstall(row) {
+  if (githubIntegrationState.busy) return;
+  githubIntegrationState.busy = true;
+  try {
+    const payload = { installation_id: Number(row.installation_id) };
+    if (row.app_id != null) payload.app_id = String(row.app_id);
+    const data = await daemonApi.request('api_github_integration_save', payload);
+    githubIntegrationState.data = data || githubIntegrationState.data;
+    githubIntegrationState.fetchedAt = Date.now();
+    githubIntegrationState.notice = {
+      text: `Installed as ${row.account_login || 'the selected account'} — pick repositories below.`,
+      cls: 'ok',
+    };
+  } catch (e) {
+    githubIntegrationState.notice = { text: String(e?.message || e), cls: 'warn' };
+  }
+  githubIntegrationState.busy = false;
+  githubIntegrationState.repoPicker = { loading: false, repositories: null, error: null };
+  renderGithubIntegrationSection();
+}
+
+// The repo picker's write: config only (no ids, no key) — the daemon
+// verifies against the sealed document without re-sealing it.
+async function githubIntegrationSaveSelection(payload) {
+  if (githubIntegrationState.busy) return;
+  githubIntegrationState.busy = true;
+  githubIntegrationState.notice = null;
+  try {
+    const data = await daemonApi.request('api_github_integration_save', payload);
+    githubIntegrationState.data = data || githubIntegrationState.data;
+    githubIntegrationState.fetchedAt = Date.now();
+    const status = String(data?.status || 'unknown');
+    githubIntegrationState.notice = {
+      text: status === 'valid'
+        ? 'Watch list saved — verified against GitHub.'
+        : `Saved. Status: ${status}${data?.detail ? ` — ${data.detail}` : ''}`,
+      cls: status === 'valid' ? 'ok' : 'warn',
+    };
+  } catch (e) {
+    githubIntegrationState.notice = { text: String(e?.message || e), cls: 'warn' };
+  }
+  githubIntegrationState.busy = false;
+  renderGithubIntegrationSection();
+}
+
+async function githubIntegrationLoadRepositories() {
+  const p = githubIntegrationState.repoPicker;
+  if (p.loading || p.repositories) return;
+  p.loading = true;
+  p.error = null;
+  try {
+    const data = await daemonApi.request('api_github_repositories', {});
+    p.repositories = Array.isArray(data?.repositories) ? data.repositories : [];
+  } catch (e) {
+    p.error = String(e?.message || e);
+  }
+  p.loading = false;
+  renderGithubIntegrationSection();
+}
+
 async function githubIntegrationConnect(orgInput) {
   if (githubIntegrationState.busy) return;
   githubIntegrationState.busy = true;
@@ -44641,19 +44775,131 @@ function renderGithubIntegrationSection() {
     if (data.app_slug) {
       // _self like the manifest form POST: the macOS app's WKWebView
       // silently drops _blank, and the same-tab round trip works
-      // everywhere.
+      // everywhere. Clicking arms the bounded discovery loop so the
+      // installation is picked up when the owner returns.
       const link = document.createElement('a');
       link.className = 'vault-install-link';
       link.href = `https://github.com/apps/${encodeURIComponent(String(data.app_slug))}/installations/new`;
       link.rel = 'noopener noreferrer';
       link.textContent = 'Install on GitHub';
+      link.addEventListener('click', () => { githubIntegrationDiscoveryStart(); });
       install.appendChild(link);
     }
+    const d = githubIntegrationState.discovery;
+    const found = Array.isArray(d.installations) ? d.installations : [];
     const hint = document.createElement('div');
     hint.className = 'vault-connect-hint';
-    hint.textContent = 'The App is created and its key is sealed. Install it on your repositories on GitHub; installation discovery lands in the next update.';
+    if (d.polling && found.length === 0) {
+      hint.textContent = 'The App is created and its key is sealed. Waiting for the installation to appear on GitHub…';
+    } else if (found.length > 1) {
+      hint.textContent = 'Several installations found — pick the one to watch:';
+    } else if (d.error) {
+      hint.textContent = `Discovery hit a problem (${d.error}); it keeps retrying while this window is open.`;
+    } else if (d.until > 0 && Date.now() > d.until) {
+      hint.textContent = 'No installation appeared yet. Install the App on GitHub, then reopen this section — or finish with the manual form below.';
+    } else {
+      hint.textContent = 'The App is created and its key is sealed. Install it on your repositories on GitHub and the installation is picked up automatically.';
+      githubIntegrationDiscoveryStart();
+    }
     install.appendChild(hint);
+    if (found.length > 1) {
+      const picker = document.createElement('div');
+      picker.className = 'vault-actions';
+      for (const row of found) {
+        const pick = vaultButton(
+          `${row.account_login || 'account'} (#${row.installation_id})`,
+          () => { void githubIntegrationCompleteInstall(row); },
+        );
+        pick.disabled = githubIntegrationState.busy;
+        picker.appendChild(pick);
+      }
+      install.appendChild(picker);
+    }
     mount.appendChild(install);
+  } else if (data?.configured) {
+    // Installed: the repo picker (installed ∩ configured semantics —
+    // checked = watched; writes ride the existing save verb and never
+    // touch custody). Poll minutes live under Advanced.
+    void githubIntegrationLoadRepositories();
+    const p = githubIntegrationState.repoPicker;
+    const picker = document.createElement('div');
+    picker.className = 'vault-repo-picker';
+    const configured = new Set(Array.isArray(data.repos) ? data.repos : []);
+    if (p.error) {
+      const err = document.createElement('div');
+      err.className = 'vault-connect-hint';
+      err.textContent = `Repository listing failed: ${p.error}`;
+      picker.appendChild(err);
+    } else if (!p.repositories) {
+      const loading = document.createElement('div');
+      loading.className = 'vault-connect-hint';
+      loading.textContent = 'Listing the installation’s repositories…';
+      picker.appendChild(loading);
+    } else {
+      const list = document.createElement('div');
+      list.className = 'vault-repo-list';
+      const known = new Set();
+      for (const name of [...p.repositories, ...configured]) {
+        if (known.has(name)) continue;
+        known.add(name);
+        const label = document.createElement('label');
+        label.className = 'vault-repo-item';
+        const box = document.createElement('input');
+        box.type = 'checkbox';
+        box.value = name;
+        box.checked = configured.has(name);
+        label.appendChild(box);
+        const text = document.createElement('span');
+        // A configured repo the installation can no longer see still
+        // renders (checked) so unticking it stays possible.
+        text.textContent = p.repositories.includes(name) ? name : `${name} (not visible to the installation)`;
+        label.appendChild(text);
+        list.appendChild(label);
+      }
+      if (known.size === 0) {
+        const none = document.createElement('div');
+        none.className = 'vault-connect-hint';
+        none.textContent = 'The installation can see no repositories — grant it some on GitHub.';
+        list.appendChild(none);
+      }
+      picker.appendChild(list);
+
+      const advanced = document.createElement('details');
+      advanced.className = 'acc-fold';
+      const advSummary = document.createElement('summary');
+      advSummary.textContent = 'Advanced';
+      advanced.appendChild(advSummary);
+      const advBody = document.createElement('div');
+      advBody.className = 'acc-fold-body vault-connect-line';
+      const pollLabel = document.createElement('span');
+      pollLabel.className = 'vault-connect-hint';
+      pollLabel.textContent = 'Poll minutes (default 5):';
+      advBody.appendChild(pollLabel);
+      const poll = document.createElement('input');
+      poll.type = 'number';
+      poll.min = '1';
+      poll.className = 'vault-connect-org';
+      poll.placeholder = data?.poll_minutes ? String(data.poll_minutes) : '5';
+      advBody.appendChild(poll);
+      advanced.appendChild(advBody);
+      picker.appendChild(advanced);
+
+      const actions = document.createElement('div');
+      actions.className = 'vault-actions';
+      const saveSelection = vaultButton('Save selection & verify', () => {
+        const repos = Array.from(list.querySelectorAll('input[type=checkbox]'))
+          .filter((box) => box.checked)
+          .map((box) => box.value);
+        const payload = { repos };
+        const minutes = Number.parseInt(poll.value, 10);
+        if (Number.isFinite(minutes) && minutes >= 1) payload.poll_minutes = minutes;
+        void githubIntegrationSaveSelection(payload);
+      }, { primary: true });
+      saveSelection.disabled = githubIntegrationState.busy;
+      actions.appendChild(saveSelection);
+      picker.appendChild(actions);
+    }
+    mount.appendChild(picker);
   }
 
   const fold = document.createElement('details');

--- a/static/app/32-daemon-api.js
+++ b/static/app/32-daemon-api.js
@@ -153,6 +153,8 @@ const DAEMON_API_HTTP_MAP = Object.freeze({
   api_github_integration_save: { verb: 'POST', path: '/api/integrations/github' },
   api_github_integration_status: { verb: 'GET', path: '/api/integrations/github/status' },
   api_github_integration_remove: { verb: 'DELETE', path: '/api/integrations/github' },
+  api_github_installations: { verb: 'GET', path: '/api/integrations/github/installations' },
+  api_github_repositories: { verb: 'GET', path: '/api/integrations/github/repositories' },
   api_fs_write: { verb: 'POST', path: '/api/fs/write', lane: 'upload', encode: 'json-b64' },
   api_fs_rename: { verb: 'POST', path: '/api/fs/rename' },
   api_fs_delete: { verb: 'POST', path: '/api/fs/delete' },

--- a/static/app/32-vault-custody.js
+++ b/static/app/32-vault-custody.js
@@ -4298,6 +4298,10 @@ const githubIntegrationState = {
   notice: null, // { text, cls } — the last action's outcome, transient
   lastError: null,
   removeArmedAt: 0,
+  // Bounded install discovery (pending state only).
+  discovery: { polling: false, until: 0, installations: null, error: null },
+  // Repo picker cache (installed state only).
+  repoPicker: { loading: false, repositories: null, error: null },
 };
 
 async function githubIntegrationRefresh(force = false) {
@@ -4326,6 +4330,110 @@ function githubIntegrationChip(text, cls) {
 // the daemonApi map. The response's form target + manifest are posted
 // as a real form navigation (target _self: works identically in
 // browsers and the macOS app's WKWebView, which drops _blank).
+// Bounded installation discovery (Track GC slice GC2): after the
+// Install click (or on opening a pending section) poll the discovery
+// route every 5 s for up to 2 minutes. Exactly one installation
+// auto-fills through the EXISTING save verb; several render a picker;
+// zero leaves the install link + the manual fallback. The route is a
+// plain request — the daemon runs no loop.
+const GITHUB_DISCOVERY_TICK_MS = 5000;
+const GITHUB_DISCOVERY_WINDOW_MS = 120000;
+
+function githubIntegrationDiscoveryStart() {
+  const d = githubIntegrationState.discovery;
+  d.until = Date.now() + GITHUB_DISCOVERY_WINDOW_MS;
+  d.error = null;
+  if (!d.polling) void githubIntegrationDiscoveryTick();
+}
+
+async function githubIntegrationDiscoveryTick() {
+  const d = githubIntegrationState.discovery;
+  if (!githubIntegrationState.data?.pending_install || Date.now() > d.until) {
+    d.polling = false;
+    renderGithubIntegrationSection();
+    return;
+  }
+  d.polling = true;
+  try {
+    const data = await daemonApi.request('api_github_installations', {});
+    const rows = Array.isArray(data?.installations) ? data.installations : [];
+    d.installations = rows;
+    d.error = null;
+    if (rows.length === 1 && rows[0]?.installation_id) {
+      d.polling = false;
+      await githubIntegrationCompleteInstall(rows[0]);
+      return;
+    }
+  } catch (e) {
+    d.error = String(e?.message || e);
+  }
+  setTimeout(() => { void githubIntegrationDiscoveryTick(); }, GITHUB_DISCOVERY_TICK_MS);
+  renderGithubIntegrationSection();
+}
+
+// The auto-fill: complete the pending document through the existing
+// save verb (ids-only update — the sealed key and slug survive, and
+// save's real verification runs).
+async function githubIntegrationCompleteInstall(row) {
+  if (githubIntegrationState.busy) return;
+  githubIntegrationState.busy = true;
+  try {
+    const payload = { installation_id: Number(row.installation_id) };
+    if (row.app_id != null) payload.app_id = String(row.app_id);
+    const data = await daemonApi.request('api_github_integration_save', payload);
+    githubIntegrationState.data = data || githubIntegrationState.data;
+    githubIntegrationState.fetchedAt = Date.now();
+    githubIntegrationState.notice = {
+      text: `Installed as ${row.account_login || 'the selected account'} — pick repositories below.`,
+      cls: 'ok',
+    };
+  } catch (e) {
+    githubIntegrationState.notice = { text: String(e?.message || e), cls: 'warn' };
+  }
+  githubIntegrationState.busy = false;
+  githubIntegrationState.repoPicker = { loading: false, repositories: null, error: null };
+  renderGithubIntegrationSection();
+}
+
+// The repo picker's write: config only (no ids, no key) — the daemon
+// verifies against the sealed document without re-sealing it.
+async function githubIntegrationSaveSelection(payload) {
+  if (githubIntegrationState.busy) return;
+  githubIntegrationState.busy = true;
+  githubIntegrationState.notice = null;
+  try {
+    const data = await daemonApi.request('api_github_integration_save', payload);
+    githubIntegrationState.data = data || githubIntegrationState.data;
+    githubIntegrationState.fetchedAt = Date.now();
+    const status = String(data?.status || 'unknown');
+    githubIntegrationState.notice = {
+      text: status === 'valid'
+        ? 'Watch list saved — verified against GitHub.'
+        : `Saved. Status: ${status}${data?.detail ? ` — ${data.detail}` : ''}`,
+      cls: status === 'valid' ? 'ok' : 'warn',
+    };
+  } catch (e) {
+    githubIntegrationState.notice = { text: String(e?.message || e), cls: 'warn' };
+  }
+  githubIntegrationState.busy = false;
+  renderGithubIntegrationSection();
+}
+
+async function githubIntegrationLoadRepositories() {
+  const p = githubIntegrationState.repoPicker;
+  if (p.loading || p.repositories) return;
+  p.loading = true;
+  p.error = null;
+  try {
+    const data = await daemonApi.request('api_github_repositories', {});
+    p.repositories = Array.isArray(data?.repositories) ? data.repositories : [];
+  } catch (e) {
+    p.error = String(e?.message || e);
+  }
+  p.loading = false;
+  renderGithubIntegrationSection();
+}
+
 async function githubIntegrationConnect(orgInput) {
   if (githubIntegrationState.busy) return;
   githubIntegrationState.busy = true;
@@ -4487,19 +4595,131 @@ function renderGithubIntegrationSection() {
     if (data.app_slug) {
       // _self like the manifest form POST: the macOS app's WKWebView
       // silently drops _blank, and the same-tab round trip works
-      // everywhere.
+      // everywhere. Clicking arms the bounded discovery loop so the
+      // installation is picked up when the owner returns.
       const link = document.createElement('a');
       link.className = 'vault-install-link';
       link.href = `https://github.com/apps/${encodeURIComponent(String(data.app_slug))}/installations/new`;
       link.rel = 'noopener noreferrer';
       link.textContent = 'Install on GitHub';
+      link.addEventListener('click', () => { githubIntegrationDiscoveryStart(); });
       install.appendChild(link);
     }
+    const d = githubIntegrationState.discovery;
+    const found = Array.isArray(d.installations) ? d.installations : [];
     const hint = document.createElement('div');
     hint.className = 'vault-connect-hint';
-    hint.textContent = 'The App is created and its key is sealed. Install it on your repositories on GitHub; installation discovery lands in the next update.';
+    if (d.polling && found.length === 0) {
+      hint.textContent = 'The App is created and its key is sealed. Waiting for the installation to appear on GitHub…';
+    } else if (found.length > 1) {
+      hint.textContent = 'Several installations found — pick the one to watch:';
+    } else if (d.error) {
+      hint.textContent = `Discovery hit a problem (${d.error}); it keeps retrying while this window is open.`;
+    } else if (d.until > 0 && Date.now() > d.until) {
+      hint.textContent = 'No installation appeared yet. Install the App on GitHub, then reopen this section — or finish with the manual form below.';
+    } else {
+      hint.textContent = 'The App is created and its key is sealed. Install it on your repositories on GitHub and the installation is picked up automatically.';
+      githubIntegrationDiscoveryStart();
+    }
     install.appendChild(hint);
+    if (found.length > 1) {
+      const picker = document.createElement('div');
+      picker.className = 'vault-actions';
+      for (const row of found) {
+        const pick = vaultButton(
+          `${row.account_login || 'account'} (#${row.installation_id})`,
+          () => { void githubIntegrationCompleteInstall(row); },
+        );
+        pick.disabled = githubIntegrationState.busy;
+        picker.appendChild(pick);
+      }
+      install.appendChild(picker);
+    }
     mount.appendChild(install);
+  } else if (data?.configured) {
+    // Installed: the repo picker (installed ∩ configured semantics —
+    // checked = watched; writes ride the existing save verb and never
+    // touch custody). Poll minutes live under Advanced.
+    void githubIntegrationLoadRepositories();
+    const p = githubIntegrationState.repoPicker;
+    const picker = document.createElement('div');
+    picker.className = 'vault-repo-picker';
+    const configured = new Set(Array.isArray(data.repos) ? data.repos : []);
+    if (p.error) {
+      const err = document.createElement('div');
+      err.className = 'vault-connect-hint';
+      err.textContent = `Repository listing failed: ${p.error}`;
+      picker.appendChild(err);
+    } else if (!p.repositories) {
+      const loading = document.createElement('div');
+      loading.className = 'vault-connect-hint';
+      loading.textContent = 'Listing the installation’s repositories…';
+      picker.appendChild(loading);
+    } else {
+      const list = document.createElement('div');
+      list.className = 'vault-repo-list';
+      const known = new Set();
+      for (const name of [...p.repositories, ...configured]) {
+        if (known.has(name)) continue;
+        known.add(name);
+        const label = document.createElement('label');
+        label.className = 'vault-repo-item';
+        const box = document.createElement('input');
+        box.type = 'checkbox';
+        box.value = name;
+        box.checked = configured.has(name);
+        label.appendChild(box);
+        const text = document.createElement('span');
+        // A configured repo the installation can no longer see still
+        // renders (checked) so unticking it stays possible.
+        text.textContent = p.repositories.includes(name) ? name : `${name} (not visible to the installation)`;
+        label.appendChild(text);
+        list.appendChild(label);
+      }
+      if (known.size === 0) {
+        const none = document.createElement('div');
+        none.className = 'vault-connect-hint';
+        none.textContent = 'The installation can see no repositories — grant it some on GitHub.';
+        list.appendChild(none);
+      }
+      picker.appendChild(list);
+
+      const advanced = document.createElement('details');
+      advanced.className = 'acc-fold';
+      const advSummary = document.createElement('summary');
+      advSummary.textContent = 'Advanced';
+      advanced.appendChild(advSummary);
+      const advBody = document.createElement('div');
+      advBody.className = 'acc-fold-body vault-connect-line';
+      const pollLabel = document.createElement('span');
+      pollLabel.className = 'vault-connect-hint';
+      pollLabel.textContent = 'Poll minutes (default 5):';
+      advBody.appendChild(pollLabel);
+      const poll = document.createElement('input');
+      poll.type = 'number';
+      poll.min = '1';
+      poll.className = 'vault-connect-org';
+      poll.placeholder = data?.poll_minutes ? String(data.poll_minutes) : '5';
+      advBody.appendChild(poll);
+      advanced.appendChild(advBody);
+      picker.appendChild(advanced);
+
+      const actions = document.createElement('div');
+      actions.className = 'vault-actions';
+      const saveSelection = vaultButton('Save selection & verify', () => {
+        const repos = Array.from(list.querySelectorAll('input[type=checkbox]'))
+          .filter((box) => box.checked)
+          .map((box) => box.value);
+        const payload = { repos };
+        const minutes = Number.parseInt(poll.value, 10);
+        if (Number.isFinite(minutes) && minutes >= 1) payload.poll_minutes = minutes;
+        void githubIntegrationSaveSelection(payload);
+      }, { primary: true });
+      saveSelection.disabled = githubIntegrationState.busy;
+      actions.appendChild(saveSelection);
+      picker.appendChild(actions);
+    }
+    mount.appendChild(picker);
   }
 
   const fold = document.createElement('details');

--- a/static/app/ui2-vault.css
+++ b/static/app/ui2-vault.css
@@ -974,3 +974,29 @@ html.ui-v2 #access-github-integration-section .vault-install-link {
 html.ui-v2 #access-github-integration-section .vault-install-link:hover {
   background: rgba(var(--iris-rgb), .22);
 }
+html.ui-v2 #access-github-integration-section .vault-repo-picker {
+  margin: 4px 0 12px;
+}
+html.ui-v2 #access-github-integration-section .vault-repo-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 220px;
+  overflow-y: auto;
+  margin: 4px 0 10px;
+  padding: 8px 10px;
+  border: 1px solid var(--line-2);
+  border-radius: var(--r-ctl);
+  background: var(--surface-2);
+}
+html.ui-v2 #access-github-integration-section .vault-repo-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text);
+  cursor: pointer;
+}
+html.ui-v2 #access-github-integration-section .vault-repo-item input {
+  accent-color: var(--iris);
+}


### PR DESCRIPTION
Track GC slice GC2 — completes the one-click arc #602 started:

- **Installation discovery**: `GET /api/integrations/github/installations` answers under the App JWT (works on pending-install documents, and its unseal re-establishes the runtime's pending cache — the restart-transient self-heal). The section polls it bounded (5s × 2min after the Install click or on opening a pending section): exactly one installation auto-fills through the **existing save verb**, several render a picker, zero leaves the install link + manual fallback.
- **Repo picker**: `GET /api/integrations/github/repositories` lists the installation's `full_name`s (installation token, bounded pages; pending = named refusal). Checkboxes checked = watched; configured-but-invisible repos stay rendered so unticking works. Both new reads gate **CredentialsManage** per the ruled unseals-principle and twin onto the tunnel (partition, HTTP-map, and docs pins updated deliberately).
- **Save payload evolution**: `app_id`/`installation_id` optional on updates — the picker's config-only writes verify against the sealed key **without re-sealing** (store-count pinned byte-identical); fresh-pem saves still require both ids. Poll minutes demoted to an Advanced disclosure.
- **Docs re-led**: the chapter now leads with Connect → Create → Install → pick; the manual five-field ceremony is the fallback appendix; the trust shape gains the state-guard + secrets-discard bullets and the restart-mid-pending transient line. Agenda walkthrough item 01KYB9NKVR re-led the same way.

Battery: fmt clean, 5218/5218 bins, 33/33 e2e, workspace clippy -D warnings, library crates green.

Design gate: agenda item 01KYCPDH8CBMN37G36941NAWAN (ruled; GC1 conformance PASS recorded on 6a366db1).