### PR TITLE
Codex Cloud attach slice 3a: worker display on the Cloud card over the attachment socket

### DIFF
--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -1905,8 +1905,7 @@ impl DisplaySession {
         // flows), so the empty-baseline guard below — which protects real
         // displays from the silent-black-screen class — does not apply.
         let synthetic_source = self.backend.kind() == synthetic::KIND;
-        let bankless =
-            synthetic_source || self.video_bank_disabled.load(Ordering::Relaxed);
+        let bankless = synthetic_source || self.video_bank_disabled.load(Ordering::Relaxed);
         #[cfg(not(target_os = "windows"))]
         let baseline_empty = encode::pool::LayerSpec::vp8_simulcast(width, height, fps).is_empty();
         #[cfg(target_os = "windows")]

--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -54,6 +54,7 @@ pub mod macos;
 pub mod macos_keymap;
 pub mod synthetic;
 pub mod tile;
+pub mod tile_socket;
 pub mod twcc_tap;
 pub mod visual_marker;
 #[cfg(target_os = "linux")]
@@ -1046,6 +1047,17 @@ pub trait DisplayBackend: Send + Sync + 'static {
 
     /// Human-readable backend name (e.g. "wayland", "x11").
     fn kind(&self) -> &'static str;
+
+    /// The X11 display string this backend actually captures (e.g.
+    /// `":99"`), for consumers that must open their own connection to
+    /// the same server — the XDamage tile-damage backend in particular.
+    /// `None` for non-X11 backends; the damage layer then falls back to
+    /// the process `DISPLAY`. Without this hint a session created via
+    /// `X11Backend::with_display` while `DISPLAY` points elsewhere would
+    /// attach XDamage to the wrong X server.
+    fn x11_display_hint(&self) -> Option<String> {
+        None
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1244,6 +1256,10 @@ pub struct DisplaySession {
     /// for the intersection rule. `None` before `start()` / after
     /// `stop()`.
     layer_policy_handle: Mutex<Option<JoinHandle<()>>>,
+    /// See [`Self::disable_video_bank`]: treat this session like a
+    /// synthetic one for encoder-bank purposes (empty always-on set, no
+    /// small-source guard).
+    video_bank_disabled: AtomicBool,
 }
 
 /// Convert one BGRA frame to I420 for the pool-feed bridge.
@@ -1480,14 +1496,21 @@ fn make_damage_backend(
     width: u32,
     height: u32,
     backend_kind: &'static str,
+    x11_display_hint: Option<&str>,
 ) -> Box<dyn capture::damage::DamageBackend> {
     #[cfg(not(target_os = "linux"))]
-    let _ = backend_kind;
+    let _ = (backend_kind, x11_display_hint);
 
     #[cfg(target_os = "linux")]
     {
         if should_try_xdamage_for_tile_stream(backend_kind) {
-            let display = std::env::var("DISPLAY").unwrap_or_else(|_| ":0".to_string());
+            // The capturing backend's own display string wins: a session
+            // on `:99` must not damage-track whatever the process-wide
+            // DISPLAY happens to name.
+            let display = x11_display_hint
+                .map(str::to_string)
+                .or_else(|| std::env::var("DISPLAY").ok())
+                .unwrap_or_else(|| ":0".to_string());
             match capture::x11_damage::X11DamageBackend::new(&display) {
                 Ok(backend) => {
                     eprintln!("[display/tile] XDamage backend enabled on DISPLAY={display}");
@@ -1772,7 +1795,18 @@ impl DisplaySession {
             agent_visible: Arc::new(AtomicBool::new(true)),
             session_epoch: Instant::now(),
             layer_policy_handle: Mutex::new(None),
+            video_bank_disabled: AtomicBool::new(false),
         }
+    }
+
+    /// Run this session without the always-on video encoder bank, exactly
+    /// like a synthetic session does: the empty pool is an explicitly
+    /// supported state, and on-demand encoder flows still work. For
+    /// sessions whose only viewers ride the tile-socket stream (Codex
+    /// Cloud workers), the bank would burn CPU encoding video nobody can
+    /// ever subscribe to. Must be called before [`Self::start`].
+    pub fn disable_video_bank(&self) {
+        self.video_bank_disabled.store(true, Ordering::Relaxed);
     }
 
     /// Set whether agents may see this display (see the `agent_visible`
@@ -1871,12 +1905,14 @@ impl DisplaySession {
         // flows), so the empty-baseline guard below — which protects real
         // displays from the silent-black-screen class — does not apply.
         let synthetic_source = self.backend.kind() == synthetic::KIND;
+        let bankless =
+            synthetic_source || self.video_bank_disabled.load(Ordering::Relaxed);
         #[cfg(not(target_os = "windows"))]
         let baseline_empty = encode::pool::LayerSpec::vp8_simulcast(width, height, fps).is_empty();
         #[cfg(target_os = "windows")]
         let baseline_empty =
             width < encode::pool::MIN_LAYER_DIM || height < encode::pool::MIN_LAYER_DIM;
-        if baseline_empty && !synthetic_source {
+        if baseline_empty && !bankless {
             self.backend.stop_capture().await;
             return Err(CallerError::Display(format!(
                 "source too small for the always-on encoder baseline: \
@@ -1979,14 +2015,14 @@ impl DisplaySession {
         // `synthetic_source` rationale above the empty-baseline guard.)
         #[cfg(not(target_os = "windows"))]
         let layer_factory = move |w: u32, h: u32| {
-            if synthetic_source {
+            if bankless {
                 return Vec::new();
             }
             encode::pool::LayerSpec::vp8_simulcast(w, h, fps)
         };
         #[cfg(target_os = "windows")]
         let layer_factory = move |w: u32, h: u32| {
-            if synthetic_source {
+            if bankless {
                 return Vec::new();
             }
             vec![encode::pool::LayerSpec::single(
@@ -3111,6 +3147,7 @@ impl DisplaySession {
         let session_epoch = self.session_epoch;
         let (initial_w, initial_h) = self.backend.resolution();
         let backend_kind = self.backend.kind();
+        let x11_display_hint = self.backend.x11_display_hint();
         // Tile-standby plumbing (per-peer RTP standby under tile mode):
         // the bridge owns every standby transition, mirrors the mode
         // into `tile_video_active` for the Subscribe handler, kicks the
@@ -3127,7 +3164,12 @@ impl DisplaySession {
         let pool_feed_kf_tx = self.pool_feed_keyframe_tx.lock().await.clone();
 
         let task = tokio::spawn(async move {
-            let mut damage = make_damage_backend(initial_w, initial_h, backend_kind);
+            let mut damage = make_damage_backend(
+                initial_w,
+                initial_h,
+                backend_kind,
+                x11_display_hint.as_deref(),
+            );
             // `Option` so the tracker can round-trip through the
             // spawn_blocking diff below (moved in, moved back out).
             let mut frame_diff: Option<capture::frame_diff::FrameDiffDamageTracker> = Some(

--- a/crates/intendant-display/src/tile_socket.rs
+++ b/crates/intendant-display/src/tile_socket.rs
@@ -1,0 +1,417 @@
+//! Single-subscriber tile streaming into a byte sink.
+//!
+//! The WebRTC tile bridge in `lib.rs` fans encoded tile frames out to
+//! `WebRtcPeer` datachannels and owns the video-fallback/standby machinery
+//! that only makes sense when a video lane exists. A Codex Cloud worker has
+//! no WebRTC lane at all — its one viewer is the home daemon on the other
+//! end of the attachment WebSocket — so this module composes the same tile
+//! primitives (grid, damage, encode, wire transport) into a deliberately
+//! smaller shape: one ordered reliable sink, tile mode only, no fallback,
+//! no standby, session-independent epoch/seq counters.
+//!
+//! The consumer receives fully wire-encoded tile frames
+//! ([`crate::tile::transport`] framing, each ≤ the datachannel message
+//! cap) and can forward them verbatim; the browser's tile compositor is
+//! transport-agnostic and reassembles from any ordered frame stream.
+//! Backpressure is by `send().await`: a slow consumer pauses the encode
+//! loop, and skipped capture frames are absorbed by the broadcast
+//! channel's lag semantics — nothing is dropped mid-snapshot, so a
+//! delivered snapshot group is always whole.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tokio::sync::{broadcast, mpsc};
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    capture, current_visual_marker_value, encode_tile_records, encode_tile_snapshot_frames,
+    make_damage_backend, should_emit_tile_delta, tile, tile_delta_min_interval,
+    tile_grid_for_frame, DisplaySession, TILE_STREAM_TILE_SIZE_PX,
+};
+
+/// Snapshot re-anchor period for the socket stream. Shorter than the
+/// WebRTC bridge's 30 s tile-mode period: this lane has no GapReport
+/// round-trip yet, so a frame lost above the sink (bounded relay lanes on
+/// the home side) heals at the next periodic snapshot rather than via
+/// recovery requests.
+const SOCKET_SNAPSHOT_PERIOD: Duration = Duration::from_secs(10);
+
+/// Handle to a running socket tile stream. Dropping it does NOT stop the
+/// stream (the sink closing or the session shutting down does); call
+/// [`TileSocketStream::stop`] for an explicit teardown.
+pub struct TileSocketStream {
+    stop: CancellationToken,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl TileSocketStream {
+    /// Cancel the stream and wait for the task to exit.
+    pub async fn stop(self) {
+        self.stop.cancel();
+        let _ = self.task.await;
+    }
+
+    /// Cancel the stream without waiting.
+    pub fn stop_nowait(&self) {
+        self.stop.cancel();
+    }
+
+    pub fn is_finished(&self) -> bool {
+        self.task.is_finished()
+    }
+}
+
+impl DisplaySession {
+    /// Stream this session's display as wire-encoded tile frames into
+    /// `out` until the sink closes, the session shuts down, or the
+    /// returned handle is stopped.
+    ///
+    /// Subscribing counts as external frame demand (unlike the internal
+    /// WebRTC tile bridge), so a paced capture backend runs at full rate
+    /// exactly while a stream is attached and drops back to keepalive
+    /// cadence when it ends.
+    pub fn spawn_tile_socket_stream(&self, out: mpsc::Sender<bytes::Bytes>) -> TileSocketStream {
+        let mut frames = self.frame_tx.subscribe();
+        let shutdown = self.shutdown.clone();
+        let stop = CancellationToken::new();
+        let stopped = stop.clone();
+        let counters = Arc::clone(&self.counters);
+        let marker_flag = Arc::clone(&self.diagnostics_visual_marker);
+        let session_epoch = self.session_epoch;
+        let display_id = self.display_id;
+        let backend_kind = self.backend.kind();
+        let display_hint = self.backend.x11_display_hint();
+        let (initial_w, initial_h) = self.backend.resolution();
+
+        let task = tokio::spawn(async move {
+            let mut damage =
+                make_damage_backend(initial_w, initial_h, backend_kind, display_hint.as_deref());
+            let mut frame_diff: Option<capture::frame_diff::FrameDiffDamageTracker> = Some(
+                capture::frame_diff::FrameDiffDamageTracker::new(TILE_STREAM_TILE_SIZE_PX),
+            );
+            let mut grid: Option<tile::grid::TileGrid> = None;
+            let mut epoch: u32 = 1;
+            let mut seq: u32 = 1;
+            let mut snapshot_id: u32 = 1;
+            let mut next_snapshot_at = Instant::now();
+            let mut last_delta_tick_at: Option<Instant> = None;
+            let mut pending_rects: Vec<capture::damage::Rect> = Vec::new();
+
+            loop {
+                let frame = tokio::select! {
+                    _ = shutdown.cancelled() => break,
+                    _ = stopped.cancelled() => break,
+                    result = frames.recv() => match result {
+                        Ok(frame) => frame,
+                        Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                        Err(broadcast::error::RecvError::Closed) => break,
+                    },
+                };
+
+                let Some(next_grid) = tile_grid_for_frame(&frame) else {
+                    continue;
+                };
+                let visual_marker_value = current_visual_marker_value(&marker_flag, session_epoch);
+
+                // Resize (or first frame): announce the grid, re-anchor
+                // with a full snapshot, reset per-epoch state.
+                if grid != Some(next_grid) {
+                    if grid.is_some() {
+                        epoch = epoch.wrapping_add(1);
+                    }
+                    seq = 1;
+                    grid = Some(next_grid);
+                    last_delta_tick_at = None;
+                    pending_rects.clear();
+                    frame_diff = Some(capture::frame_diff::FrameDiffDamageTracker::new(
+                        TILE_STREAM_TILE_SIZE_PX,
+                    ));
+                    let resize = tile::transport::TileFrame::Resize {
+                        new_epoch: epoch,
+                        grid_w_tiles: next_grid.width_tiles,
+                        grid_h_tiles: next_grid.height_tiles,
+                        tile_size_px: next_grid.tile_size_px,
+                    };
+                    let encoded = match tile::transport::encode_frame(&resize) {
+                        Ok(bytes) => bytes::Bytes::from(bytes),
+                        Err(e) => {
+                            eprintln!("[display/tile-socket] display {display_id} resize encode failed: {e}");
+                            continue;
+                        }
+                    };
+                    if out.send(encoded).await.is_err() {
+                        break;
+                    }
+                    if !send_snapshot(
+                        &out,
+                        Arc::clone(&frame),
+                        epoch,
+                        &mut snapshot_id,
+                        visual_marker_value,
+                        &counters,
+                    )
+                    .await
+                    {
+                        break;
+                    }
+                    next_snapshot_at = Instant::now() + SOCKET_SNAPSHOT_PERIOD;
+                    continue;
+                }
+
+                // Periodic re-anchor snapshot.
+                if Instant::now() >= next_snapshot_at {
+                    if !send_snapshot(
+                        &out,
+                        Arc::clone(&frame),
+                        epoch,
+                        &mut snapshot_id,
+                        visual_marker_value,
+                        &counters,
+                    )
+                    .await
+                    {
+                        break;
+                    }
+                    next_snapshot_at = Instant::now() + SOCKET_SNAPSHOT_PERIOD;
+                    continue;
+                }
+
+                // Damage collection mirrors the WebRTC bridge: cheap
+                // sources every frame (nothing lost across cadence
+                // skips), frame-diff only on allowed ticks.
+                let uses_frame_diff = frame.dirty_rects.is_none()
+                    && matches!(
+                        damage.capability(),
+                        capture::damage::DamageCapability::FrameDiff
+                            | capture::damage::DamageCapability::None
+                    );
+                if let Some(rects) = frame.dirty_rects.clone() {
+                    pending_rects.extend(rects);
+                } else if !uses_frame_diff {
+                    match damage.poll_damage() {
+                        Ok(rects) => pending_rects.extend(rects),
+                        Err(e) => {
+                            eprintln!(
+                                "[display/tile-socket] display {display_id} damage poll failed: {e}"
+                            );
+                        }
+                    }
+                }
+
+                let now = Instant::now();
+                if !should_emit_tile_delta(now, last_delta_tick_at, tile_delta_min_interval()) {
+                    continue;
+                }
+                last_delta_tick_at = Some(now);
+
+                let mut rects = std::mem::take(&mut pending_rects);
+                if uses_frame_diff {
+                    let tracker = frame_diff.take().unwrap_or_else(|| {
+                        capture::frame_diff::FrameDiffDamageTracker::new(TILE_STREAM_TILE_SIZE_PX)
+                    });
+                    let diff_result = tokio::task::spawn_blocking({
+                        let frame = Arc::clone(&frame);
+                        move || {
+                            let mut tracker = tracker;
+                            let rects = tracker.diff_frame(&frame);
+                            (tracker, rects)
+                        }
+                    })
+                    .await;
+                    match diff_result {
+                        Ok((tracker, Ok(diff_rects))) => {
+                            frame_diff = Some(tracker);
+                            rects.extend(diff_rects);
+                        }
+                        Ok((tracker, Err(e))) => {
+                            frame_diff = Some(tracker);
+                            eprintln!(
+                                "[display/tile-socket] display {display_id} frame-diff failed: {e}"
+                            );
+                        }
+                        Err(e) => {
+                            eprintln!(
+                                "[display/tile-socket] display {display_id} frame-diff task failed: {e}"
+                            );
+                        }
+                    }
+                }
+
+                if rects.is_empty() {
+                    continue;
+                }
+                let dirty: Vec<_> = next_grid.dirty_tiles(&rects).into_iter().collect();
+                if dirty.is_empty() {
+                    continue;
+                }
+                counters.record_tile_damage_sample(
+                    rects.len(),
+                    dirty.len(),
+                    next_grid.dirty_fraction(dirty.len()),
+                );
+
+                let encode_result = tokio::task::spawn_blocking({
+                    let frame = Arc::clone(&frame);
+                    move || encode_tile_records(&frame, dirty, visual_marker_value)
+                })
+                .await;
+                let Ok(Ok(records)) = encode_result else {
+                    eprintln!("[display/tile-socket] display {display_id} tile encode failed");
+                    continue;
+                };
+                let record_count = records.len();
+                let wire_frames = match tile::transport::pack_tile_updates(epoch, seq, records) {
+                    Ok(frames) => frames,
+                    Err(e) => {
+                        eprintln!("[display/tile-socket] display {display_id} pack failed: {e}");
+                        continue;
+                    }
+                };
+                seq = seq.wrapping_add(wire_frames.len() as u32);
+
+                let mut byte_count = 0usize;
+                let frame_count = wire_frames.len();
+                let mut closed = false;
+                for wire_frame in wire_frames {
+                    match tile::transport::encode_frame(&wire_frame) {
+                        Ok(bytes) => {
+                            byte_count = byte_count.saturating_add(bytes.len());
+                            if out.send(bytes::Bytes::from(bytes)).await.is_err() {
+                                closed = true;
+                                break;
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!(
+                                "[display/tile-socket] display {display_id} wire encode failed: {e}"
+                            );
+                        }
+                    }
+                }
+                counters.record_tile_delta_source(record_count, frame_count, byte_count);
+                if closed {
+                    break;
+                }
+            }
+        });
+
+        TileSocketStream { stop, task }
+    }
+}
+
+/// Encode and send one complete snapshot group. Returns `false` when the
+/// sink closed (the caller breaks its loop).
+async fn send_snapshot(
+    out: &mpsc::Sender<bytes::Bytes>,
+    frame: Arc<crate::Frame>,
+    epoch: u32,
+    snapshot_id: &mut u32,
+    visual_marker_value: Option<u32>,
+    counters: &Arc<crate::DisplayMetricsCounters>,
+) -> bool {
+    let id = *snapshot_id;
+    *snapshot_id = snapshot_id.wrapping_add(1);
+    let Some(frames) =
+        encode_tile_snapshot_frames(frame, epoch, id, visual_marker_value, counters).await
+    else {
+        return true;
+    };
+    for bytes in frames {
+        if out.send(bytes).await.is_err() {
+            return false;
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::synthetic::SyntheticBackend;
+
+    /// End-to-end over the synthetic backend: the stream must open with a
+    /// Resize + a complete snapshot group, then keep emitting frames the
+    /// wire codec round-trips.
+    #[tokio::test]
+    async fn socket_stream_emits_resize_then_whole_snapshot() {
+        let backend = Arc::new(SyntheticBackend::new());
+        let session = Arc::new(DisplaySession::new(901, backend));
+        session
+            .start(10, None, None)
+            .await
+            .expect("synthetic session starts");
+        let (tx, mut rx) = mpsc::channel(1024);
+        let stream = session.spawn_tile_socket_stream(tx);
+
+        let first = tokio::time::timeout(Duration::from_secs(10), rx.recv())
+            .await
+            .expect("first frame within deadline")
+            .expect("stream open");
+        let decoded = tile::transport::decode_frame(&first).expect("decodable");
+        match decoded {
+            tile::transport::TileFrame::Resize {
+                grid_w_tiles,
+                grid_h_tiles,
+                tile_size_px,
+                ..
+            } => {
+                assert!(grid_w_tiles > 0 && grid_h_tiles > 0);
+                assert_eq!(tile_size_px, TILE_STREAM_TILE_SIZE_PX);
+            }
+            other => panic!("expected Resize first, got {other:?}"),
+        }
+
+        // The snapshot group follows immediately and must be complete:
+        // chunk indices 0..chunk_count for one snapshot_id.
+        let mut seen = 0u16;
+        let mut expected: Option<(u32, u16)> = None;
+        while expected.map(|(_, total)| seen < total).unwrap_or(true) {
+            let bytes = tokio::time::timeout(Duration::from_secs(10), rx.recv())
+                .await
+                .expect("snapshot chunk within deadline")
+                .expect("stream open");
+            match tile::transport::decode_frame(&bytes).expect("decodable") {
+                tile::transport::TileFrame::SnapshotChunk {
+                    snapshot_id,
+                    chunk_index,
+                    chunk_count,
+                    ..
+                } => {
+                    let (id, total) = *expected.get_or_insert((snapshot_id, chunk_count));
+                    assert_eq!(snapshot_id, id, "one snapshot group, no interleave");
+                    assert_eq!(chunk_count, total);
+                    assert_eq!(chunk_index, seen, "chunks in order");
+                    seen += 1;
+                }
+                other => panic!("expected SnapshotChunk, got {other:?}"),
+            }
+        }
+
+        stream.stop().await;
+        session.stop().await;
+    }
+
+    /// Closing the sink ends the stream task; the session stays healthy.
+    #[tokio::test]
+    async fn socket_stream_ends_when_sink_closes() {
+        let backend = Arc::new(SyntheticBackend::new());
+        let session = Arc::new(DisplaySession::new(902, backend));
+        session
+            .start(10, None, None)
+            .await
+            .expect("synthetic session starts");
+        let (tx, mut rx) = mpsc::channel(8);
+        let stream = session.spawn_tile_socket_stream(tx);
+        let _ = tokio::time::timeout(Duration::from_secs(10), rx.recv()).await;
+        drop(rx);
+        tokio::time::timeout(Duration::from_secs(10), async {
+            while !stream.is_finished() {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        })
+        .await
+        .expect("stream task exits after sink close");
+        session.stop().await;
+    }
+}

--- a/crates/intendant-display/src/x11.rs
+++ b/crates/intendant-display/src/x11.rs
@@ -370,6 +370,10 @@ impl DisplayBackend for X11Backend {
     fn kind(&self) -> &'static str {
         "x11"
     }
+
+    fn x11_display_hint(&self) -> Option<String> {
+        Some(self.display.clone())
+    }
 }
 
 /// Browser mouse-button index (0=left, 1=middle, 2=right) to the X11

--- a/docs/src/codex-cloud-workers.md
+++ b/docs/src/codex-cloud-workers.md
@@ -287,6 +287,32 @@ keeps exactly one output forwarder — a re-open (browser reload, host
 round-trip) replaces the listener on the surviving PTY rather than
 stacking a second one, which would double every output chunk.
 
+## Live view of a worker (display)
+
+A `connected` lease also renders a **View** button: the worker starts (or
+attaches) a virtual display — Xvfb on a Linux container (installed by
+`setup.sh`; the synthetic test card under the mock rig pair) — captures it
+with the standard X11 backend, and streams it through the real tile
+pipeline into a **single-subscriber socket stream** over the attachment
+(`DisplaySession::spawn_tile_socket_stream`: tile mode only, no video
+fallback, whole-snapshot delivery, 10 s re-anchor). Home bridges the
+frames onto the dashboard tunnel (`display_open`/`display_close` under
+`display.view`; tile frames arrive as `display_tiles`), and the Cloud
+card's viewer paints them with the same transport-agnostic tile
+compositor the peer display path ships. Pointer and keyboard input ride
+the existing `display_input` frame (`display.input`) with a
+`cloud:<task_id>` host, delivered to the worker's ordered input queue and
+injected via XTEST.
+
+WebRTC is deliberately absent from this path: a cloud worker can neither
+accept nor dial a peer connection (no inbound reachability; passive-only
+ICE-TCP; UDP-only TURN), so the attachment socket is the one lane —
+which also means the worker never runs video encoders at all
+(`disable_video_bank`): tiles are pure-Rust encodes, and capture idles to
+keepalive cadence when no viewer is subscribed. The same fail-closed
+rules as the terminal apply: only display reply kinds cross back from
+the worker, routed solely to the viewing connection.
+
 ## Attachment lifecycle
 
 The enrollment broker above records the attachment state for its workers;

--- a/scripts/codex-cloud/setup.sh
+++ b/scripts/codex-cloud/setup.sh
@@ -63,6 +63,23 @@ else
   build_checked_out_binary
 fi
 
+# Display slice (attach slice 3): the worker serves its virtual display
+# over the attachment. Xvfb + xdpyinfo are what vision::launch_display
+# requires; best-effort — a worker without them still attaches, and
+# display_open answers with a clear "launch Xvfb" error naming the gap.
+if command -v Xvfb >/dev/null 2>&1 && command -v xdpyinfo >/dev/null 2>&1; then
+  echo "worker display prerequisites present (Xvfb, xdpyinfo)"
+elif command -v apt-get >/dev/null 2>&1; then
+  if apt-get install -y --no-install-recommends xvfb x11-utils 2>/dev/null \
+    || sudo -n apt-get install -y --no-install-recommends xvfb x11-utils 2>/dev/null; then
+    echo "installed worker display prerequisites (xvfb, x11-utils)"
+  else
+    echo "warning: could not install xvfb/x11-utils; worker display will be unavailable" >&2
+  fi
+else
+  echo "warning: Xvfb/xdpyinfo missing and no apt-get; worker display will be unavailable" >&2
+fi
+
 script_root="$repo_root/scripts/codex-cloud"
 if [[ ! -f "$script_root/run-worker.sh" ]]; then
   echo "missing $script_root/run-worker.sh" >&2

--- a/src/bin/caller/access/access_policy.rs
+++ b/src/bin/caller/access/access_policy.rs
@@ -663,6 +663,25 @@ pub const FRAME_LANES: &[FrameLaneSpec] = &[
         tunnel: true,
         note: "pointer/keyboard injection into a display",
     },
+    // ---- tunnel only: cloud-worker display viewer ----
+    FrameLaneSpec {
+        frame: "display_open",
+        op: Some(PeerOperation::DisplayView),
+        ws: false,
+        tunnel: true,
+        note: "opens a cloud worker's virtual display over the task's attachment and \
+               subscribes this connection to its tile stream; local displays bootstrap \
+               via api_display_bootstrap + WebRTC instead, and cloud frames ride the \
+               tunnel only (slice-2 precedent: /ws stays local-only)",
+    },
+    FrameLaneSpec {
+        frame: "display_close",
+        op: Some(PeerOperation::DisplayView),
+        ws: false,
+        tunnel: true,
+        note: "tears down this connection's cloud-worker tile subscription — closing a \
+               viewer is view-scoped, not a display mutation",
+    },
     // ---- /ws only: display signaling + diagnostics marker ----
     FrameLaneSpec {
         frame: "set_diagnostics_visual_marker",
@@ -1624,6 +1643,9 @@ mod tests {
             ("terminal_close",                 Some(TerminalWrite),  Some(TerminalWrite)),
             ("terminal_share",                 Some(TerminalWrite),  Some(TerminalWrite)),
             ("display_input",                  Some(DisplayInput),   Some(DisplayInput)),
+            // -- tunnel only: cloud-worker display viewer --
+            ("display_open",                   None,                 Some(DisplayView)),
+            ("display_close",                  None,                 Some(DisplayView)),
             // -- /ws only: display signaling + diagnostics marker --
             ("set_diagnostics_visual_marker",  Some(DisplayInput),   None),
             ("display_offer",                  Some(DisplayView),    None),

--- a/src/bin/caller/access/hosted_control/policy.rs
+++ b/src/bin/caller/access/hosted_control/policy.rs
@@ -303,8 +303,8 @@ pub fn hosted_tunnel_frame_classification(preset: HostedPreset, frame_type: &str
     Some(match frame_type {
         "hello" | "ping" | "request" => true,
         "terminal_open" | "terminal_input" | "terminal_resize" | "terminal_close"
-        | "terminal_share" | "display_input" | "display_open" | "display_close" | "upload_start"
-        | "upload_chunk" | "upload_end" => preset == HostedPreset::Operate,
+        | "terminal_share" | "display_input" | "display_open" | "display_close"
+        | "upload_start" | "upload_chunk" | "upload_end" => preset == HostedPreset::Operate,
         "presence_frame" | "egress_response" | "egress_chunk" | "egress_end" | "egress_error"
         | "egress_request_ack" => false,
         _ => return None,

--- a/src/bin/caller/access/hosted_control/policy.rs
+++ b/src/bin/caller/access/hosted_control/policy.rs
@@ -303,9 +303,8 @@ pub fn hosted_tunnel_frame_classification(preset: HostedPreset, frame_type: &str
     Some(match frame_type {
         "hello" | "ping" | "request" => true,
         "terminal_open" | "terminal_input" | "terminal_resize" | "terminal_close"
-        | "terminal_share" | "display_input" | "upload_start" | "upload_chunk" | "upload_end" => {
-            preset == HostedPreset::Operate
-        }
+        | "terminal_share" | "display_input" | "display_open" | "display_close" | "upload_start"
+        | "upload_chunk" | "upload_end" => preset == HostedPreset::Operate,
         "presence_frame" | "egress_response" | "egress_chunk" | "egress_end" | "egress_error"
         | "egress_request_ack" => false,
         _ => return None,
@@ -661,7 +660,8 @@ fn hosted_outbound_value_allowed(preset: HostedPreset, value: &serde_json::Value
             | "display_input_authority_state"
             | "event_gap" => true,
             "terminal_opened" | "terminal_output" | "terminal_exited" | "terminal_error"
-            | "terminal_shared" => preset == HostedPreset::Operate,
+            | "terminal_shared" | "display_opened" | "display_tiles" | "display_closed"
+            | "display_error" => preset == HostedPreset::Operate,
             _ => false,
         };
     }

--- a/src/bin/caller/codex_cloud_attach.rs
+++ b/src/bin/caller/codex_cloud_attach.rs
@@ -928,9 +928,15 @@ pub async fn run_agent(args: &[String]) -> Result<(), String> {
     let mut display_state = WorkerDisplayState::default();
     let mut attempt: u32 = 0;
     loop {
-        let held =
-            hold_attachment(&home, &pinned, &identity, &task, &terminal_registry, &mut display_state)
-                .await;
+        let held = hold_attachment(
+            &home,
+            &pinned,
+            &identity,
+            &task,
+            &terminal_registry,
+            &mut display_state,
+        )
+        .await;
         // The per-viewer display half is socket-scoped: the pump and
         // stream unwind on their own when the socket's channels close,
         // and this reset clears the handles so the next open starts
@@ -1002,7 +1008,10 @@ async fn start_worker_display_session(
     let mock_synthetic = std::env::var("INTENDANT_MOCK_DISPLAY").as_deref() == Ok("synthetic")
         && std::env::var("PROVIDER").as_deref() == Ok("mock");
     let (display_id, backend): (u32, Arc<dyn crate::display::DisplayBackend>) = if mock_synthetic {
-        (0, Arc::new(crate::display::synthetic::SyntheticBackend::new()))
+        (
+            0,
+            Arc::new(crate::display::synthetic::SyntheticBackend::new()),
+        )
     } else if cfg!(target_os = "linux") {
         #[cfg(target_os = "linux")]
         {
@@ -1606,7 +1615,10 @@ mod tests {
             .expect("tiles within deadline")
             .expect("tile frame");
         let value: serde_json::Value = serde_json::from_str(&tiles).unwrap();
-        assert_eq!(value.get("t").and_then(|v| v.as_str()), Some("display_tiles"));
+        assert_eq!(
+            value.get("t").and_then(|v| v.as_str()),
+            Some("display_tiles")
+        );
         assert_eq!(
             value.get("host_id").and_then(|v| v.as_str()),
             Some("cloud:t")

--- a/src/bin/caller/codex_cloud_attach.rs
+++ b/src/bin/caller/codex_cloud_attach.rs
@@ -413,6 +413,10 @@ const WORKER_REPLY_KINDS: &[&str] = &[
     "terminal_exited",
     "terminal_error",
     "terminal_shared",
+    "display_opened",
+    "display_tiles",
+    "display_closed",
+    "display_error",
 ];
 
 /// Host-id prefix that routes a dashboard terminal frame to a connected
@@ -918,9 +922,21 @@ pub async fn run_agent(args: &[String]) -> Result<(), String> {
     let terminal_registry = crate::terminal::TerminalRegistry::new(
         std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
     );
+    // Same lifetime rule as the registry: the display session (and any
+    // worker-launched Xvfb) survives reconnects; per-viewer stream state
+    // dies with each socket.
+    let mut display_state = WorkerDisplayState::default();
     let mut attempt: u32 = 0;
     loop {
-        match hold_attachment(&home, &pinned, &identity, &task, &terminal_registry).await {
+        let held =
+            hold_attachment(&home, &pinned, &identity, &task, &terminal_registry, &mut display_state)
+                .await;
+        // The per-viewer display half is socket-scoped: the pump and
+        // stream unwind on their own when the socket's channels close,
+        // and this reset clears the handles so the next open starts
+        // clean.
+        display_state.stop_viewer();
+        match held {
             Ok(()) => {
                 attempt = 0;
                 eprintln!("[cloud-agent] attachment closed by home; reconnecting");
@@ -938,6 +954,102 @@ pub async fn run_agent(args: &[String]) -> Result<(), String> {
         let backoff = std::time::Duration::from_secs(2u64.saturating_pow(attempt.min(4)));
         tokio::time::sleep(backoff).await;
     }
+}
+
+/// Worker-side display state, hoisted to `run_agent` scope like the
+/// terminal registry: the display session (and any Xvfb it launched)
+/// survives socket reconnects; the per-viewer tile stream and pump die
+/// with each socket and are recreated by the next `display_open`.
+#[derive(Default)]
+pub(crate) struct WorkerDisplayState {
+    session: Option<(u32, std::sync::Arc<crate::display::DisplaySession>)>,
+    stream: Option<crate::display::tile_socket::TileSocketStream>,
+    pump: Option<tokio::task::JoinHandle<()>>,
+    input: Option<std::sync::Arc<crate::display::BrowserInputSource>>,
+    /// Kill-on-drop guard for a worker-launched Xvfb — held for RAII
+    /// only, never read.
+    _xvfb: Option<crate::vision::XvfbGuard>,
+}
+
+impl WorkerDisplayState {
+    /// Tear down the per-viewer half (stream + pump + input source),
+    /// keeping the session/Xvfb for the next open. The capture demand
+    /// probe idles a paced backend once the stream's subscription drops.
+    fn stop_viewer(&mut self) {
+        if let Some(stream) = self.stream.take() {
+            stream.stop_nowait();
+        }
+        if let Some(pump) = self.pump.take() {
+            pump.abort();
+        }
+        self.input = None;
+    }
+}
+
+/// Resolve and start the worker's display session: the synthetic backend
+/// under the mock rig pair (same fail-closed gate as the daemon), an
+/// existing X display, or a fresh Xvfb on Linux. Errors are the operator's
+/// actionable message — name what is missing.
+async fn start_worker_display_session(
+    state: &mut WorkerDisplayState,
+) -> Result<(u32, std::sync::Arc<crate::display::DisplaySession>), String> {
+    use std::sync::Arc;
+
+    // `state` only receives the Xvfb guard, which exists on Linux alone.
+    #[cfg(not(target_os = "linux"))]
+    let _ = &mut *state;
+
+    let mock_synthetic = std::env::var("INTENDANT_MOCK_DISPLAY").as_deref() == Ok("synthetic")
+        && std::env::var("PROVIDER").as_deref() == Ok("mock");
+    let (display_id, backend): (u32, Arc<dyn crate::display::DisplayBackend>) = if mock_synthetic {
+        (0, Arc::new(crate::display::synthetic::SyntheticBackend::new()))
+    } else if cfg!(target_os = "linux") {
+        #[cfg(target_os = "linux")]
+        {
+            let env_display = std::env::var("DISPLAY").ok();
+            let existing = env_display
+                .as_deref()
+                .and_then(|display| display.strip_prefix(':'))
+                .and_then(|rest| rest.split('.').next())
+                .and_then(|number| number.parse::<u32>().ok())
+                .filter(|id| crate::vision::virtual_display_socket_exists(*id));
+            let id = match existing {
+                Some(id) => id,
+                None => {
+                    let id = crate::vision::conventional_virtual_display().unwrap_or(99);
+                    let config = crate::vision::DisplayConfig {
+                        target: intendant_platform::DisplayTarget::Virtual { id },
+                        width: 1280,
+                        height: 800,
+                    };
+                    let guard = crate::vision::launch_display(&config)
+                        .await
+                        .map_err(|e| format!("launch Xvfb for the worker display: {e}"))?;
+                    state._xvfb = Some(guard);
+                    id
+                }
+            };
+            let backend = crate::display::x11::X11Backend::with_display(&format!(":{id}"))
+                .map_err(|e| format!("connect to worker X display :{id}: {e}"))?;
+            (id, Arc::new(backend))
+        }
+        #[cfg(not(target_os = "linux"))]
+        unreachable!()
+    } else {
+        return Err(
+            "worker display needs a Linux virtual display (Xvfb) or the synthetic mock backend"
+                .to_string(),
+        );
+    };
+    let session = Arc::new(crate::display::DisplaySession::new(display_id, backend));
+    // The only possible viewer rides the tile-socket stream; never spin
+    // the always-on video encoder bank in the container.
+    session.disable_video_bank();
+    session
+        .start(15, None, None)
+        .await
+        .map_err(|e| format!("start worker display session: {e}"))?;
+    Ok((display_id, session))
 }
 
 /// Collect the boot-identity fields the probe prompt measures, in the same
@@ -975,6 +1087,7 @@ async fn hold_attachment(
     identity: &crate::peer::transport::tls_client::ClientIdentityPaths,
     task: &str,
     registry: &crate::terminal::TerminalRegistry,
+    display: &mut WorkerDisplayState,
 ) -> Result<(), String> {
     use futures_util::{SinkExt as _, StreamExt as _};
     use tokio_tungstenite::tungstenite::client::IntoClientRequest as _;
@@ -1021,7 +1134,7 @@ async fn hold_attachment(
                 Some(Ok(message)) if message.is_close() => break,
                 Some(Ok(message)) => {
                     if let Ok(text) = message.into_text() {
-                        serve_worker_frame(registry, text.as_str(), &out_tx, &mut forwarders).await;
+                        serve_worker_frame(registry, text.as_str(), &out_tx, &mut forwarders, display).await;
                     }
                 }
                 Some(Err(error)) => return Err(format!("attachment socket: {error}")),
@@ -1053,6 +1166,7 @@ async fn serve_worker_frame(
         crate::terminal::TerminalKey,
         tokio::task::JoinHandle<()>,
     >,
+    display: &mut WorkerDisplayState,
 ) {
     use base64::Engine as _;
 
@@ -1069,6 +1183,85 @@ async fn serve_worker_frame(
     let kind = field("t");
     let host_id = field("host_id");
     let terminal_id = field("terminal_id");
+    let reply = |mut value: serde_json::Value| {
+        if let Some(map) = value.as_object_mut() {
+            map.insert("host_id".into(), host_id.clone().into());
+            if !terminal_id.is_empty() {
+                map.insert("terminal_id".into(), terminal_id.clone().into());
+            }
+        }
+        value.to_string()
+    };
+
+    // Display frames carry no terminal_id and no registry key.
+    match kind.as_str() {
+        "display_open" => {
+            display.stop_viewer();
+            let (display_id, session) = match display.session.as_ref() {
+                Some((id, session)) => (*id, std::sync::Arc::clone(session)),
+                None => match start_worker_display_session(display).await {
+                    Ok((id, session)) => {
+                        display.session = Some((id, std::sync::Arc::clone(&session)));
+                        (id, session)
+                    }
+                    Err(error) => {
+                        eprintln!("[cloud-agent] display_open failed: {error}");
+                        let _ = out_tx
+                            .send(reply(serde_json::json!({
+                                "t": "display_error", "error": error,
+                            })))
+                            .await;
+                        return;
+                    }
+                },
+            };
+            eprintln!("[cloud-agent] display_open (:{display_id})");
+            let _ = out_tx
+                .send(reply(serde_json::json!({
+                    "t": "display_opened", "display_id": display_id,
+                })))
+                .await;
+            display.input = Some(session.browser_input_source(
+                crate::display::BrowserInputAuthorization::new(std::sync::Arc::new(|| true)),
+            ));
+            let (tile_tx, mut tile_rx) = tokio::sync::mpsc::channel::<bytes::Bytes>(256);
+            display.stream = Some(session.spawn_tile_socket_stream(tile_tx));
+            let pump_out = out_tx.clone();
+            let pump_host = host_id.clone();
+            display.pump = Some(tokio::spawn(async move {
+                while let Some(bytes) = tile_rx.recv().await {
+                    let frame = serde_json::json!({
+                        "t": "display_tiles",
+                        "host_id": pump_host,
+                        "data": base64::engine::general_purpose::STANDARD.encode(&bytes),
+                    });
+                    if pump_out.send(frame.to_string()).await.is_err() {
+                        break;
+                    }
+                }
+            }));
+            return;
+        }
+        "display_input" => {
+            if let (Some(input), Some(event)) =
+                (display.input.as_ref(), frame.get("event").cloned())
+            {
+                if let Ok(event) = serde_json::from_value::<crate::display::InputEvent>(event) {
+                    input.enqueue(event);
+                }
+            }
+            return;
+        }
+        "display_close" => {
+            display.stop_viewer();
+            let _ = out_tx
+                .send(reply(serde_json::json!({ "t": "display_closed" })))
+                .await;
+            return;
+        }
+        _ => {}
+    }
+
     if terminal_id.is_empty() {
         return;
     }
@@ -1077,13 +1270,6 @@ async fn serve_worker_frame(
         terminal_id: terminal_id.clone(),
     };
     let actor = crate::terminal::TerminalActor::Root;
-    let reply = |mut value: serde_json::Value| {
-        if let Some(map) = value.as_object_mut() {
-            map.insert("host_id".into(), host_id.clone().into());
-            map.insert("terminal_id".into(), terminal_id.clone().into());
-        }
-        value.to_string()
-    };
     match kind.as_str() {
         "terminal_open" => {
             let cols = frame
@@ -1368,10 +1554,17 @@ mod tests {
             r#"{"t":"terminal_output","host_id":"cloud:x","terminal_id":"shell-0","data":"aGk="}"#,
         );
         assert!(rx.try_recv().is_ok());
+        route_worker_frame(
+            &tx,
+            r#"{"t":"display_tiles","host_id":"cloud:x","data":"aGk="}"#,
+        );
+        assert!(rx.try_recv().is_ok());
         // The worker cannot inject request kinds, hellos, or junk into
         // home — its inbound authority stays nothing.
         for dropped in [
             r#"{"t":"terminal_open","host_id":"cloud:x","terminal_id":"shell-0"}"#,
+            r#"{"t":"display_open","host_id":"cloud:x"}"#,
+            r#"{"t":"display_input","host_id":"cloud:x","event":{"t":"mm","x":0.1,"y":0.1}}"#,
             r#"{"v":2,"kind":"cloud-worker-hello","task_id":"x"}"#,
             r#"{"t":"api_sessions"}"#,
             "not json",
@@ -1381,6 +1574,70 @@ mod tests {
         }
     }
 
+    /// The worker's display arms end to end over a seeded synthetic
+    /// session (no env, no X server): open replies `display_opened` and
+    /// starts the tile stream (base64 wire frames stamped with the cloud
+    /// host), input enqueues, close stops the viewer and acks.
+    #[tokio::test]
+    async fn worker_display_open_streams_tiles_and_close_stops() {
+        let backend = std::sync::Arc::new(crate::display::synthetic::SyntheticBackend::new());
+        let session = std::sync::Arc::new(crate::display::DisplaySession::new(0, backend));
+        session.disable_video_bank();
+        session.start(10, None, None).await.expect("session starts");
+        let dir = tempfile::tempdir().unwrap();
+        let registry = crate::terminal::TerminalRegistry::new(dir.path().to_path_buf());
+        let (out_tx, mut out_rx) = tokio::sync::mpsc::channel::<String>(1024);
+        let mut forwarders = std::collections::HashMap::new();
+        let mut display = WorkerDisplayState {
+            session: Some((0, std::sync::Arc::clone(&session))),
+            ..Default::default()
+        };
+
+        let open = r#"{"t":"display_open","host_id":"cloud:t"}"#;
+        serve_worker_frame(&registry, open, &out_tx, &mut forwarders, &mut display).await;
+        let opened = tokio::time::timeout(std::time::Duration::from_secs(10), out_rx.recv())
+            .await
+            .expect("opened within deadline")
+            .expect("open reply");
+        assert!(opened.contains("display_opened"), "{opened}");
+
+        let tiles = tokio::time::timeout(std::time::Duration::from_secs(10), out_rx.recv())
+            .await
+            .expect("tiles within deadline")
+            .expect("tile frame");
+        let value: serde_json::Value = serde_json::from_str(&tiles).unwrap();
+        assert_eq!(value.get("t").and_then(|v| v.as_str()), Some("display_tiles"));
+        assert_eq!(
+            value.get("host_id").and_then(|v| v.as_str()),
+            Some("cloud:t")
+        );
+        assert!(value
+            .get("data")
+            .and_then(|v| v.as_str())
+            .is_some_and(|data| !data.is_empty()));
+
+        let input = r#"{"t":"display_input","host_id":"cloud:t","display_id":0,"event":{"t":"mm","x":0.5,"y":0.5}}"#;
+        serve_worker_frame(&registry, input, &out_tx, &mut forwarders, &mut display).await;
+
+        let close = r#"{"t":"display_close","host_id":"cloud:t"}"#;
+        serve_worker_frame(&registry, close, &out_tx, &mut forwarders, &mut display).await;
+        assert!(display.stream.is_none() && display.pump.is_none());
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        let mut saw_closed = false;
+        while tokio::time::Instant::now() < deadline {
+            match tokio::time::timeout(std::time::Duration::from_secs(10), out_rx.recv()).await {
+                Ok(Some(text)) if text.contains("display_closed") => {
+                    saw_closed = true;
+                    break;
+                }
+                Ok(Some(_)) => continue,
+                _ => break,
+            }
+        }
+        assert!(saw_closed, "close is acked");
+        session.stop().await;
+    }
+
     #[tokio::test]
     async fn reopening_a_worker_terminal_replaces_its_forwarder() {
         let dir = tempfile::tempdir().unwrap();
@@ -1388,7 +1645,8 @@ mod tests {
         let (out_tx, mut out_rx) = tokio::sync::mpsc::channel::<String>(64);
         let mut forwarders = std::collections::HashMap::new();
         let open = r#"{"t":"terminal_open","host_id":"cloud:t","terminal_id":"shell-0","cols":80,"rows":24}"#;
-        serve_worker_frame(&registry, open, &out_tx, &mut forwarders).await;
+        let mut display = WorkerDisplayState::default();
+        serve_worker_frame(&registry, open, &out_tx, &mut forwarders, &mut display).await;
         assert_eq!(forwarders.len(), 1);
         let first = out_rx.recv().await.expect("first opened reply");
         assert!(first.contains("terminal_opened"), "{first}");
@@ -1400,7 +1658,7 @@ mod tests {
         // A second open for the same key attaches the surviving PTY and
         // must replace the listener, never stack a second one (stacked
         // listeners double every output chunk on the dashboard).
-        serve_worker_frame(&registry, open, &out_tx, &mut forwarders).await;
+        serve_worker_frame(&registry, open, &out_tx, &mut forwarders, &mut display).await;
         assert_eq!(forwarders.len(), 1);
         let second = out_rx.recv().await.expect("second opened reply");
         assert!(second.contains("terminal_opened"), "{second}");

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -258,6 +258,17 @@ pub(crate) fn control_frame_response(
             "unix_ms": chrono::Utc::now().timestamp_millis(),
         })),
         "display_input" => {
+            // Cloud hosts: the event rides the attachment; ordering is
+            // preserved because the wire loop dispatches sequentially and
+            // the attachment sender is a single ordered channel.
+            if let Some(task_id) = parsed
+                .get("host_id")
+                .and_then(|value| value.as_str())
+                .and_then(crate::codex_cloud_attach::cloud_host_task_id)
+            {
+                let _ = forward_cloud_frame(&parsed, task_id);
+                return None;
+            }
             // Ordered handoff to the per-connection forwarder (see
             // `spawn_display_input_forwarder`): the wire loop dispatches
             // frames sequentially and this send preserves that order —
@@ -273,6 +284,10 @@ pub(crate) fn control_frame_response(
         "terminal_resize" => control_terminal_resize_frame(parsed, runtime),
         "terminal_close" => control_terminal_close_frame(parsed, runtime, terminal_forwarders),
         "terminal_share" => control_terminal_share_frame(parsed, runtime, terminal_events_tx),
+        "display_open" => {
+            control_cloud_display_open_frame(parsed, terminal_output_tx, terminal_forwarders)
+        }
+        "display_close" => control_cloud_display_close_frame(parsed, terminal_forwarders),
         "presence_frame" => control_presence_frame(parsed, runtime.clone()),
         "egress_response" | "egress_chunk" | "egress_end" | "egress_error"
         | "egress_request_ack" => {
@@ -1358,7 +1373,129 @@ pub(crate) fn terminal_frame_dimension(frame: &serde_json::Value, key: &str, def
 /// The per-frame IAM gate already cleared the same terminal operations
 /// the local registry would demand; past it, home spends its own (total)
 /// authority on the worker.
-fn forward_cloud_terminal_frame(frame: &serde_json::Value, task_id: &str) -> Result<(), String> {
+/// Reserved forwarder-map slot for a connection's cloud display
+/// subscription. Terminal forwarders key by (host_id, terminal_id); the
+/// display viewer is one-per-host, so it parks under a slot no browser
+/// terminal_id can collide with (control characters never survive the
+/// frame field extraction as meaningful ids).
+const CLOUD_DISPLAY_FORWARDER_SLOT: &str = "\u{1}cloud-display";
+
+/// `display_open` for `cloud:<task_id>` hosts: forward the open over the
+/// task's attachment and subscribe this connection to the worker's
+/// display reply frames (opened/tiles/closed/error), routed onto the same
+/// bounded outbound lane terminal output rides. Re-open replaces the
+/// forwarder (slice-2 dedup parity). The DisplayView floor was enforced
+/// by the frame table before dispatch.
+pub(crate) fn control_cloud_display_open_frame(
+    frame: serde_json::Value,
+    terminal_output_tx: &mpsc::Sender<serde_json::Value>,
+    terminal_forwarders: &mut HashMap<(String, String), tokio::task::JoinHandle<()>>,
+) -> Option<serde_json::Value> {
+    let host_id = frame
+        .get("host_id")
+        .and_then(|value| value.as_str())
+        .unwrap_or("")
+        .to_string();
+    let error_host = host_id.clone();
+    let error_frame = move |error: String| {
+        serde_json::json!({
+            "t": "display_error",
+            "host_id": error_host.clone(),
+            "error": error,
+        })
+    };
+    let Some(task_id) = crate::codex_cloud_attach::cloud_host_task_id(&host_id) else {
+        // Local displays bootstrap via api_display_bootstrap + WebRTC;
+        // this frame kind exists for cloud hosts alone.
+        let refusal = error_frame("display_open addresses cloud: hosts only".to_string());
+        let tx = terminal_output_tx.clone();
+        tokio::spawn(async move {
+            let _ = tx.send(refusal).await;
+        });
+        return None;
+    };
+    let forwarder_key = (host_id.clone(), CLOUD_DISPLAY_FORWARDER_SLOT.to_string());
+    if let Some(handle) = terminal_forwarders.remove(&forwarder_key) {
+        handle.abort();
+    }
+    let channel = crate::codex_cloud_attach::attachment_channel(task_id)
+        .ok_or_else(|| "cloud worker has no live attachment".to_string());
+    let terminal_output_tx = terminal_output_tx.clone();
+    let host = host_id.clone();
+    let handle = tokio::spawn(async move {
+        let (to_worker, mut from_worker) = match channel {
+            Ok(channel) => channel,
+            Err(error) => {
+                let _ = terminal_output_tx.send(error_frame(error)).await;
+                return;
+            }
+        };
+        if to_worker.send(frame.to_string()).await.is_err() {
+            let _ = terminal_output_tx
+                .send(error_frame("cloud worker detached".to_string()))
+                .await;
+            return;
+        }
+        loop {
+            match from_worker.recv().await {
+                Ok(text) => {
+                    let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) else {
+                        continue;
+                    };
+                    let kind = value.get("t").and_then(|v| v.as_str()).unwrap_or("");
+                    let reply_host = value
+                        .get("host_id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    if reply_host == host
+                        && matches!(
+                            kind,
+                            "display_opened" | "display_tiles" | "display_closed" | "display_error"
+                        )
+                        && terminal_output_tx.send(value).await.is_err()
+                    {
+                        break;
+                    }
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    let _ = terminal_output_tx
+                        .send(error_frame("cloud worker detached".to_string()))
+                        .await;
+                    break;
+                }
+            }
+        }
+    });
+    terminal_forwarders.insert(forwarder_key, handle);
+    None
+}
+
+/// `display_close` for cloud hosts: tell the worker to stop its stream,
+/// then drop this connection's subscription. The browser initiated the
+/// close and tears down its own viewer, so the forwarder need not
+/// survive to relay the worker's `display_closed` ack.
+pub(crate) fn control_cloud_display_close_frame(
+    frame: serde_json::Value,
+    terminal_forwarders: &mut HashMap<(String, String), tokio::task::JoinHandle<()>>,
+) -> Option<serde_json::Value> {
+    let host_id = frame
+        .get("host_id")
+        .and_then(|value| value.as_str())
+        .unwrap_or("")
+        .to_string();
+    if let Some(task_id) = crate::codex_cloud_attach::cloud_host_task_id(&host_id) {
+        let _ = forward_cloud_frame(&frame, task_id);
+    }
+    if let Some(handle) =
+        terminal_forwarders.remove(&(host_id, CLOUD_DISPLAY_FORWARDER_SLOT.to_string()))
+    {
+        handle.abort();
+    }
+    None
+}
+
+fn forward_cloud_frame(frame: &serde_json::Value, task_id: &str) -> Result<(), String> {
     let Some((to_worker, _)) = crate::codex_cloud_attach::attachment_channel(task_id) else {
         return Err("cloud worker has no live attachment".to_string());
     };
@@ -1548,7 +1685,7 @@ pub(crate) fn control_terminal_input_frame(
         return None;
     };
     if let Some(task_id) = crate::codex_cloud_attach::cloud_host_task_id(&host_id) {
-        let _ = forward_cloud_terminal_frame(&frame, task_id);
+        let _ = forward_cloud_frame(&frame, task_id);
         return None;
     }
     let registry = runtime.terminal_registry.clone();
@@ -1573,7 +1710,7 @@ pub(crate) fn control_terminal_resize_frame(
     let cols = terminal_frame_dimension(&frame, "cols", 80);
     let rows = terminal_frame_dimension(&frame, "rows", 24);
     if let Some(task_id) = crate::codex_cloud_attach::cloud_host_task_id(&host_id) {
-        let _ = forward_cloud_terminal_frame(&frame, task_id);
+        let _ = forward_cloud_frame(&frame, task_id);
         return None;
     }
     let registry = runtime.terminal_registry.clone();
@@ -1600,7 +1737,7 @@ pub(crate) fn control_terminal_close_frame(
         handle.abort();
     }
     if let Some(task_id) = crate::codex_cloud_attach::cloud_host_task_id(&host_id) {
-        let _ = forward_cloud_terminal_frame(&frame, task_id);
+        let _ = forward_cloud_frame(&frame, task_id);
         return None;
     }
     let registry = runtime.terminal_registry.clone();

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -1443,10 +1443,7 @@ pub(crate) fn control_cloud_display_open_frame(
                         continue;
                     };
                     let kind = value.get("t").and_then(|v| v.as_str()).unwrap_or("");
-                    let reply_host = value
-                        .get("host_id")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("");
+                    let reply_host = value.get("host_id").and_then(|v| v.as_str()).unwrap_or("");
                     if reply_host == host
                         && matches!(
                             kind,

--- a/static/app.html
+++ b/static/app.html
@@ -19925,6 +19925,48 @@ html.ui-v2 #tab-sessions .session-card .sc-id { font-family: var(--mono); }
 .cloud-worker-warmth.is-warm { color: var(--peach, var(--yellow, #fab387)); border-color: currentColor; }
 .cloud-worker-warmth.is-unknown { color: var(--text-3); border-style: dashed; }
 .cloud-worker-warmth.is-cold { color: var(--text-3); }
+
+/* ── Cloud worker live display viewer (attach slice 3a) ── */
+.cloud-worker-display {
+  margin: 0 0 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface-2);
+  overflow: hidden;
+}
+.cloud-worker-display-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--line);
+}
+.cloud-worker-display-title {
+  font-weight: 600;
+  color: var(--text);
+}
+.cloud-worker-display-status {
+  flex: 1;
+  font-size: 12px;
+  color: var(--text-3);
+}
+.cloud-worker-display-status.ok { color: var(--green, #7fbf7f); }
+.cloud-worker-display-status.error { color: var(--rose, #df6b6b); }
+.cloud-worker-display-stage {
+  display: flex;
+  justify-content: center;
+  padding: 8px;
+  outline: none;
+  overflow: auto;
+  max-height: 70vh;
+}
+.cloud-worker-display-stage .tile-compositor-frame {
+  position: relative;
+}
+.cloud-worker-display-stage .tile-compositor-canvas {
+  max-width: 100%;
+  height: auto;
+}
 /* ── static/app/ui2-activity.css ── */
 /* ── ui-v3 Activity ─────────────────────────────────────────────────────
    A ground-up re-presentation of the Activity tab (all five views) in the
@@ -32194,6 +32236,7 @@ html.ui-v2 .ui2-tsw-foot .ui2-tsw-row:hover { color: var(--text); }
               <div class="cloud-workers-hint">Codex Cloud tasks tracked as ephemeral worker leases — provider state and live-attachment state are independent. Submit with <code>intendant codex-cloud exec</code>; bring results home with <code>intendant codex-cloud pull</code>.</div>
             </div>
             <div class="sessions-search-status" id="cloud-workers-status"></div>
+            <div class="cloud-worker-display" id="cloud-worker-display" hidden></div>
             <div class="cloud-workers-list" id="cloud-workers-list">
               <div class="empty-state">No Codex Cloud tasks tracked yet</div>
             </div>
@@ -36507,7 +36550,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '638b8882cc488496';
+const INTENDANT_APP_BUILD = '51ce931f86d796ce';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -96690,6 +96733,13 @@ function cloudWorkerRow(lease) {
   row.appendChild(meta);
 
   if (lease.attachment_state === 'connected' && lease.task_id) {
+    const view = document.createElement('button');
+    view.type = 'button';
+    view.className = 'ui-btn ui-btn-sm cloud-worker-view';
+    view.textContent = cloudDisplayTask === lease.task_id ? 'Viewing' : 'View';
+    view.title = 'Watch the worker’s virtual display live (tiles bridged over the attachment)';
+    view.addEventListener('click', () => openCloudWorkerDisplay(lease.task_id));
+    head.appendChild(view);
     const term = document.createElement('button');
     term.type = 'button';
     term.className = 'ui-btn ui-btn-sm cloud-worker-terminal';
@@ -96727,6 +96777,224 @@ function cloudConnectedShellHosts() {
     }));
 }
 
+// ── Live worker display viewer (attach slice 3a) ───────────────────────
+//
+// One viewer at a time, rendered in the #cloud-worker-display panel ABOVE
+// the card list (the list re-renders on refresh; the panel survives it).
+// Frames ride the local dashboard tunnel: display_open subscribes, the
+// worker's tile stream arrives as display_tiles (base64 tile wire
+// frames), and the shipped transport-agnostic TileCompositor paints them.
+// Input needs the same display.input floor a local display does — the
+// daemon gates per-frame; the viewer just sends.
+
+let cloudDisplayTask = null;
+let cloudDisplayId = 0;
+let cloudDisplayCompositor = null;
+let cloudDisplayListener = null;
+let cloudDisplayOpenTimer = null;
+let cloudDisplayStatusEl = null;
+
+function cloudDisplaySendFrame(frame) {
+  // terminalFrame is the tunnel's generic frame sender (canUseRpc +
+  // sendFrame); cloud terminal frames already ride it.
+  return typeof dashboardTransport !== 'undefined'
+    && dashboardTransport.terminalFrame
+    && dashboardTransport.terminalFrame(frame);
+}
+
+function cloudDisplayStatus(text, kind = '') {
+  if (!cloudDisplayStatusEl) return;
+  cloudDisplayStatusEl.textContent = text;
+  cloudDisplayStatusEl.className = `cloud-worker-display-status${kind ? ` ${kind}` : ''}`;
+}
+
+function closeCloudWorkerDisplay(sendClose = true) {
+  if (cloudDisplayOpenTimer) {
+    clearInterval(cloudDisplayOpenTimer);
+    cloudDisplayOpenTimer = null;
+  }
+  if (sendClose && cloudDisplayTask) {
+    cloudDisplaySendFrame({ t: 'display_close', host_id: `cloud:${cloudDisplayTask}` });
+  }
+  if (cloudDisplayListener) {
+    window.removeEventListener('intendant-cloud-display-frame', cloudDisplayListener);
+    cloudDisplayListener = null;
+  }
+  cloudDisplayCompositor = null;
+  cloudDisplayStatusEl = null;
+  cloudDisplayTask = null;
+  cloudDisplayId = 0;
+  const panel = document.getElementById('cloud-worker-display');
+  if (panel) {
+    panel.hidden = true;
+    panel.replaceChildren();
+  }
+  renderCloudWorkers();
+}
+
+function cloudDisplayNormalizedCoords(canvas, ev) {
+  const rect = canvas.getBoundingClientRect();
+  if (!rect.width || !rect.height) return { x: 0, y: 0 };
+  const x = Math.min(1, Math.max(0, (ev.clientX - rect.left) / rect.width));
+  const y = Math.min(1, Math.max(0, (ev.clientY - rect.top) / rect.height));
+  return { x, y };
+}
+
+function cloudDisplaySendInput(event) {
+  if (!cloudDisplayTask) return;
+  cloudDisplaySendFrame({
+    t: 'display_input',
+    host_id: `cloud:${cloudDisplayTask}`,
+    display_id: cloudDisplayId,
+    event,
+  });
+}
+
+function cloudDisplayWireInput(stage) {
+  stage.tabIndex = 0;
+  const mods = (ev) => ({ shift: ev.shiftKey, ctrl: ev.ctrlKey, alt: ev.altKey, meta: ev.metaKey });
+  const canvasOf = () => cloudDisplayCompositor && cloudDisplayCompositor.canvas;
+  stage.addEventListener('mousedown', (ev) => {
+    const canvas = canvasOf();
+    if (!canvas) return;
+    stage.focus();
+    ev.preventDefault();
+    const { x, y } = cloudDisplayNormalizedCoords(canvas, ev);
+    cloudDisplaySendInput({ t: 'md', x, y, b: ev.button });
+  });
+  stage.addEventListener('mouseup', (ev) => {
+    const canvas = canvasOf();
+    if (!canvas) return;
+    ev.preventDefault();
+    const { x, y } = cloudDisplayNormalizedCoords(canvas, ev);
+    cloudDisplaySendInput({ t: 'mu', x, y, b: ev.button });
+  });
+  stage.addEventListener('mousemove', (ev) => {
+    const canvas = canvasOf();
+    if (!canvas) return;
+    const { x, y } = cloudDisplayNormalizedCoords(canvas, ev);
+    cloudDisplaySendInput({ t: 'mm', x, y, buttons: ev.buttons });
+  });
+  stage.addEventListener('wheel', (ev) => {
+    const canvas = canvasOf();
+    if (!canvas) return;
+    ev.preventDefault();
+    const { x, y } = cloudDisplayNormalizedCoords(canvas, ev);
+    cloudDisplaySendInput({ t: 'sc', x, y, dx: ev.deltaX, dy: ev.deltaY });
+  }, { passive: false });
+  stage.addEventListener('keydown', (ev) => {
+    ev.preventDefault();
+    cloudDisplaySendInput({ t: 'kd', code: ev.code, key: ev.key, ...mods(ev) });
+  });
+  stage.addEventListener('keyup', (ev) => {
+    ev.preventDefault();
+    cloudDisplaySendInput({ t: 'ku', code: ev.code, key: ev.key, ...mods(ev) });
+  });
+}
+
+function openCloudWorkerDisplay(taskId) {
+  if (cloudDisplayTask === taskId) {
+    closeCloudWorkerDisplay();
+    return;
+  }
+  closeCloudWorkerDisplay();
+  const panel = document.getElementById('cloud-worker-display');
+  if (!panel) return;
+  if (typeof maybeStartDashboardControlTransport === 'function') {
+    maybeStartDashboardControlTransport({ onDemand: true });
+  }
+  cloudDisplayTask = taskId;
+  const host = `cloud:${taskId}`;
+  panel.hidden = false;
+
+  const head = document.createElement('div');
+  head.className = 'cloud-worker-display-head';
+  const title = document.createElement('span');
+  title.className = 'cloud-worker-display-title';
+  title.textContent = `Worker display · ${taskId}`;
+  head.appendChild(title);
+  cloudDisplayStatusEl = document.createElement('span');
+  head.appendChild(cloudDisplayStatusEl);
+  const close = document.createElement('button');
+  close.type = 'button';
+  close.className = 'ui-btn ui-btn-sm';
+  close.textContent = 'Close';
+  close.addEventListener('click', () => closeCloudWorkerDisplay());
+  head.appendChild(close);
+  panel.appendChild(head);
+
+  const stage = document.createElement('div');
+  stage.className = 'cloud-worker-display-stage';
+  panel.appendChild(stage);
+  cloudDisplayWireInput(stage);
+
+  cloudDisplayListener = (ev) => {
+    const msg = ev.detail || {};
+    if (msg.host_id !== host) return;
+    if (msg.t === 'display_opened') {
+      cloudDisplayId = Number(msg.display_id) || 0;
+      cloudDisplayStatus(`connected · display :${cloudDisplayId}`, 'ok');
+      return;
+    }
+    if (msg.t === 'display_error') {
+      cloudDisplayStatus(String(msg.error || 'display error'), 'error');
+      return;
+    }
+    if (msg.t === 'display_closed') {
+      cloudDisplayStatus('display closed', '');
+      return;
+    }
+    if (msg.t === 'display_tiles' && typeof msg.data === 'string') {
+      let bytes;
+      try {
+        bytes = Uint8Array.from(atob(msg.data), (c) => c.charCodeAt(0));
+      } catch (_) {
+        return;
+      }
+      try {
+        if (!cloudDisplayCompositor) {
+          // The stream opens with a Resize frame; construct the
+          // compositor from it (placeholder dims — onResize below
+          // reconfigures everything) and feed it the same frame.
+          const parsed = parseTileWireFrame(bytes);
+          if (parsed.type !== 'resize') return;
+          cloudDisplayCompositor = new TileCompositor(stage, {
+            tileSize: parsed.tile_size_px,
+            gridW: parsed.grid_w_tiles,
+            gridH: parsed.grid_h_tiles,
+          });
+        }
+        cloudDisplayCompositor.onWireFrame(bytes);
+      } catch (err) {
+        cloudDisplayStatus(`tile decode failed: ${(err && err.message) || err}`, 'error');
+      }
+    }
+  };
+  window.addEventListener('intendant-cloud-display-frame', cloudDisplayListener);
+
+  // The open frame needs the tunnel; retry until the on-demand start
+  // connects (terminalFrame returns false while it cannot send).
+  const tryOpen = () => {
+    if (cloudDisplaySendFrame({ t: 'display_open', host_id: host })) {
+      if (cloudDisplayOpenTimer) {
+        clearInterval(cloudDisplayOpenTimer);
+        cloudDisplayOpenTimer = null;
+      }
+      cloudDisplayStatus('opening worker display…', '');
+      return true;
+    }
+    cloudDisplayStatus('connecting the dashboard tunnel…', '');
+    return false;
+  };
+  if (!tryOpen()) {
+    cloudDisplayOpenTimer = setInterval(() => {
+      if (!cloudDisplayTask) return;
+      tryOpen();
+    }, 1000);
+  }
+  renderCloudWorkers();
+}
+
 function openCloudWorkerTerminal(taskId) {
   // Cloud terminal frames ride only the dashboard-control tunnel; start it
   // on demand so the affordance works even when the legacy /ws is the
@@ -96742,6 +97010,8 @@ function openCloudWorkerTerminal(taskId) {
 window.cloudConnectedShellHosts = cloudConnectedShellHosts;
 window.loadCloudWorkers = loadCloudWorkers;
 window.cloudWorkersOnShown = cloudWorkersOnShown;
+window.openCloudWorkerDisplay = openCloudWorkerDisplay;
+window.closeCloudWorkerDisplay = closeCloudWorkerDisplay;
 /* ── static/app/48-router-settings.js ── */
 // ── Tab Switching ──
 document.querySelectorAll('.tab-btn').forEach(btn => {
@@ -101966,6 +102236,15 @@ class DashboardControlTransport {
     if (msg.t === 'egress_request' || msg.t === 'egress_request_chunk' ||
         msg.t === 'egress_request_end' || msg.t === 'egress_ack' || msg.t === 'egress_cancel') {
       vaultEgressHandleFrame(msg);
+      return;
+    }
+    if (msg.t === 'display_opened' || msg.t === 'display_tiles' || msg.t === 'display_closed' || msg.t === 'display_error') {
+      // Cloud-worker display frames (host_id = "cloud:<task>"): the Cloud
+      // card's viewer subscribes via this event; nothing else consumes
+      // the family, so an unhandled frame is simply dropped.
+      try {
+        window.dispatchEvent(new CustomEvent('intendant-cloud-display-frame', { detail: msg }));
+      } catch (_) {}
       return;
     }
     if (msg.t === 'terminal_output' || msg.t === 'terminal_exited' || msg.t === 'terminal_opened' || msg.t === 'terminal_error' || msg.t === 'terminal_shared') {

--- a/static/app/20-shell.html
+++ b/static/app/20-shell.html
@@ -1677,6 +1677,7 @@
               <div class="cloud-workers-hint">Codex Cloud tasks tracked as ephemeral worker leases — provider state and live-attachment state are independent. Submit with <code>intendant codex-cloud exec</code>; bring results home with <code>intendant codex-cloud pull</code>.</div>
             </div>
             <div class="sessions-search-status" id="cloud-workers-status"></div>
+            <div class="cloud-worker-display" id="cloud-worker-display" hidden></div>
             <div class="cloud-workers-list" id="cloud-workers-list">
               <div class="empty-state">No Codex Cloud tasks tracked yet</div>
             </div>

--- a/static/app/50-control-transport.js
+++ b/static/app/50-control-transport.js
@@ -255,6 +255,15 @@ class DashboardControlTransport {
       vaultEgressHandleFrame(msg);
       return;
     }
+    if (msg.t === 'display_opened' || msg.t === 'display_tiles' || msg.t === 'display_closed' || msg.t === 'display_error') {
+      // Cloud-worker display frames (host_id = "cloud:<task>"): the Cloud
+      // card's viewer subscribes via this event; nothing else consumes
+      // the family, so an unhandled frame is simply dropped.
+      try {
+        window.dispatchEvent(new CustomEvent('intendant-cloud-display-frame', { detail: msg }));
+      } catch (_) {}
+      return;
+    }
     if (msg.t === 'terminal_output' || msg.t === 'terminal_exited' || msg.t === 'terminal_opened' || msg.t === 'terminal_error' || msg.t === 'terminal_shared') {
       try {
         window.dispatchEvent(new CustomEvent('intendant-dashboard-terminal-frame', { detail: msg }));

--- a/static/app/ui2-cloud-workers.js
+++ b/static/app/ui2-cloud-workers.js
@@ -180,6 +180,13 @@ function cloudWorkerRow(lease) {
   row.appendChild(meta);
 
   if (lease.attachment_state === 'connected' && lease.task_id) {
+    const view = document.createElement('button');
+    view.type = 'button';
+    view.className = 'ui-btn ui-btn-sm cloud-worker-view';
+    view.textContent = cloudDisplayTask === lease.task_id ? 'Viewing' : 'View';
+    view.title = 'Watch the worker’s virtual display live (tiles bridged over the attachment)';
+    view.addEventListener('click', () => openCloudWorkerDisplay(lease.task_id));
+    head.appendChild(view);
     const term = document.createElement('button');
     term.type = 'button';
     term.className = 'ui-btn ui-btn-sm cloud-worker-terminal';
@@ -217,6 +224,224 @@ function cloudConnectedShellHosts() {
     }));
 }
 
+// ── Live worker display viewer (attach slice 3a) ───────────────────────
+//
+// One viewer at a time, rendered in the #cloud-worker-display panel ABOVE
+// the card list (the list re-renders on refresh; the panel survives it).
+// Frames ride the local dashboard tunnel: display_open subscribes, the
+// worker's tile stream arrives as display_tiles (base64 tile wire
+// frames), and the shipped transport-agnostic TileCompositor paints them.
+// Input needs the same display.input floor a local display does — the
+// daemon gates per-frame; the viewer just sends.
+
+let cloudDisplayTask = null;
+let cloudDisplayId = 0;
+let cloudDisplayCompositor = null;
+let cloudDisplayListener = null;
+let cloudDisplayOpenTimer = null;
+let cloudDisplayStatusEl = null;
+
+function cloudDisplaySendFrame(frame) {
+  // terminalFrame is the tunnel's generic frame sender (canUseRpc +
+  // sendFrame); cloud terminal frames already ride it.
+  return typeof dashboardTransport !== 'undefined'
+    && dashboardTransport.terminalFrame
+    && dashboardTransport.terminalFrame(frame);
+}
+
+function cloudDisplayStatus(text, kind = '') {
+  if (!cloudDisplayStatusEl) return;
+  cloudDisplayStatusEl.textContent = text;
+  cloudDisplayStatusEl.className = `cloud-worker-display-status${kind ? ` ${kind}` : ''}`;
+}
+
+function closeCloudWorkerDisplay(sendClose = true) {
+  if (cloudDisplayOpenTimer) {
+    clearInterval(cloudDisplayOpenTimer);
+    cloudDisplayOpenTimer = null;
+  }
+  if (sendClose && cloudDisplayTask) {
+    cloudDisplaySendFrame({ t: 'display_close', host_id: `cloud:${cloudDisplayTask}` });
+  }
+  if (cloudDisplayListener) {
+    window.removeEventListener('intendant-cloud-display-frame', cloudDisplayListener);
+    cloudDisplayListener = null;
+  }
+  cloudDisplayCompositor = null;
+  cloudDisplayStatusEl = null;
+  cloudDisplayTask = null;
+  cloudDisplayId = 0;
+  const panel = document.getElementById('cloud-worker-display');
+  if (panel) {
+    panel.hidden = true;
+    panel.replaceChildren();
+  }
+  renderCloudWorkers();
+}
+
+function cloudDisplayNormalizedCoords(canvas, ev) {
+  const rect = canvas.getBoundingClientRect();
+  if (!rect.width || !rect.height) return { x: 0, y: 0 };
+  const x = Math.min(1, Math.max(0, (ev.clientX - rect.left) / rect.width));
+  const y = Math.min(1, Math.max(0, (ev.clientY - rect.top) / rect.height));
+  return { x, y };
+}
+
+function cloudDisplaySendInput(event) {
+  if (!cloudDisplayTask) return;
+  cloudDisplaySendFrame({
+    t: 'display_input',
+    host_id: `cloud:${cloudDisplayTask}`,
+    display_id: cloudDisplayId,
+    event,
+  });
+}
+
+function cloudDisplayWireInput(stage) {
+  stage.tabIndex = 0;
+  const mods = (ev) => ({ shift: ev.shiftKey, ctrl: ev.ctrlKey, alt: ev.altKey, meta: ev.metaKey });
+  const canvasOf = () => cloudDisplayCompositor && cloudDisplayCompositor.canvas;
+  stage.addEventListener('mousedown', (ev) => {
+    const canvas = canvasOf();
+    if (!canvas) return;
+    stage.focus();
+    ev.preventDefault();
+    const { x, y } = cloudDisplayNormalizedCoords(canvas, ev);
+    cloudDisplaySendInput({ t: 'md', x, y, b: ev.button });
+  });
+  stage.addEventListener('mouseup', (ev) => {
+    const canvas = canvasOf();
+    if (!canvas) return;
+    ev.preventDefault();
+    const { x, y } = cloudDisplayNormalizedCoords(canvas, ev);
+    cloudDisplaySendInput({ t: 'mu', x, y, b: ev.button });
+  });
+  stage.addEventListener('mousemove', (ev) => {
+    const canvas = canvasOf();
+    if (!canvas) return;
+    const { x, y } = cloudDisplayNormalizedCoords(canvas, ev);
+    cloudDisplaySendInput({ t: 'mm', x, y, buttons: ev.buttons });
+  });
+  stage.addEventListener('wheel', (ev) => {
+    const canvas = canvasOf();
+    if (!canvas) return;
+    ev.preventDefault();
+    const { x, y } = cloudDisplayNormalizedCoords(canvas, ev);
+    cloudDisplaySendInput({ t: 'sc', x, y, dx: ev.deltaX, dy: ev.deltaY });
+  }, { passive: false });
+  stage.addEventListener('keydown', (ev) => {
+    ev.preventDefault();
+    cloudDisplaySendInput({ t: 'kd', code: ev.code, key: ev.key, ...mods(ev) });
+  });
+  stage.addEventListener('keyup', (ev) => {
+    ev.preventDefault();
+    cloudDisplaySendInput({ t: 'ku', code: ev.code, key: ev.key, ...mods(ev) });
+  });
+}
+
+function openCloudWorkerDisplay(taskId) {
+  if (cloudDisplayTask === taskId) {
+    closeCloudWorkerDisplay();
+    return;
+  }
+  closeCloudWorkerDisplay();
+  const panel = document.getElementById('cloud-worker-display');
+  if (!panel) return;
+  if (typeof maybeStartDashboardControlTransport === 'function') {
+    maybeStartDashboardControlTransport({ onDemand: true });
+  }
+  cloudDisplayTask = taskId;
+  const host = `cloud:${taskId}`;
+  panel.hidden = false;
+
+  const head = document.createElement('div');
+  head.className = 'cloud-worker-display-head';
+  const title = document.createElement('span');
+  title.className = 'cloud-worker-display-title';
+  title.textContent = `Worker display · ${taskId}`;
+  head.appendChild(title);
+  cloudDisplayStatusEl = document.createElement('span');
+  head.appendChild(cloudDisplayStatusEl);
+  const close = document.createElement('button');
+  close.type = 'button';
+  close.className = 'ui-btn ui-btn-sm';
+  close.textContent = 'Close';
+  close.addEventListener('click', () => closeCloudWorkerDisplay());
+  head.appendChild(close);
+  panel.appendChild(head);
+
+  const stage = document.createElement('div');
+  stage.className = 'cloud-worker-display-stage';
+  panel.appendChild(stage);
+  cloudDisplayWireInput(stage);
+
+  cloudDisplayListener = (ev) => {
+    const msg = ev.detail || {};
+    if (msg.host_id !== host) return;
+    if (msg.t === 'display_opened') {
+      cloudDisplayId = Number(msg.display_id) || 0;
+      cloudDisplayStatus(`connected · display :${cloudDisplayId}`, 'ok');
+      return;
+    }
+    if (msg.t === 'display_error') {
+      cloudDisplayStatus(String(msg.error || 'display error'), 'error');
+      return;
+    }
+    if (msg.t === 'display_closed') {
+      cloudDisplayStatus('display closed', '');
+      return;
+    }
+    if (msg.t === 'display_tiles' && typeof msg.data === 'string') {
+      let bytes;
+      try {
+        bytes = Uint8Array.from(atob(msg.data), (c) => c.charCodeAt(0));
+      } catch (_) {
+        return;
+      }
+      try {
+        if (!cloudDisplayCompositor) {
+          // The stream opens with a Resize frame; construct the
+          // compositor from it (placeholder dims — onResize below
+          // reconfigures everything) and feed it the same frame.
+          const parsed = parseTileWireFrame(bytes);
+          if (parsed.type !== 'resize') return;
+          cloudDisplayCompositor = new TileCompositor(stage, {
+            tileSize: parsed.tile_size_px,
+            gridW: parsed.grid_w_tiles,
+            gridH: parsed.grid_h_tiles,
+          });
+        }
+        cloudDisplayCompositor.onWireFrame(bytes);
+      } catch (err) {
+        cloudDisplayStatus(`tile decode failed: ${(err && err.message) || err}`, 'error');
+      }
+    }
+  };
+  window.addEventListener('intendant-cloud-display-frame', cloudDisplayListener);
+
+  // The open frame needs the tunnel; retry until the on-demand start
+  // connects (terminalFrame returns false while it cannot send).
+  const tryOpen = () => {
+    if (cloudDisplaySendFrame({ t: 'display_open', host_id: host })) {
+      if (cloudDisplayOpenTimer) {
+        clearInterval(cloudDisplayOpenTimer);
+        cloudDisplayOpenTimer = null;
+      }
+      cloudDisplayStatus('opening worker display…', '');
+      return true;
+    }
+    cloudDisplayStatus('connecting the dashboard tunnel…', '');
+    return false;
+  };
+  if (!tryOpen()) {
+    cloudDisplayOpenTimer = setInterval(() => {
+      if (!cloudDisplayTask) return;
+      tryOpen();
+    }, 1000);
+  }
+  renderCloudWorkers();
+}
+
 function openCloudWorkerTerminal(taskId) {
   // Cloud terminal frames ride only the dashboard-control tunnel; start it
   // on demand so the affordance works even when the legacy /ws is the
@@ -232,3 +457,5 @@ function openCloudWorkerTerminal(taskId) {
 window.cloudConnectedShellHosts = cloudConnectedShellHosts;
 window.loadCloudWorkers = loadCloudWorkers;
 window.cloudWorkersOnShown = cloudWorkersOnShown;
+window.openCloudWorkerDisplay = openCloudWorkerDisplay;
+window.closeCloudWorkerDisplay = closeCloudWorkerDisplay;

--- a/static/app/ui2-sessions.css
+++ b/static/app/ui2-sessions.css
@@ -1821,3 +1821,45 @@ html.ui-v2 #tab-sessions .session-card .sc-id { font-family: var(--mono); }
 .cloud-worker-warmth.is-warm { color: var(--peach, var(--yellow, #fab387)); border-color: currentColor; }
 .cloud-worker-warmth.is-unknown { color: var(--text-3); border-style: dashed; }
 .cloud-worker-warmth.is-cold { color: var(--text-3); }
+
+/* ── Cloud worker live display viewer (attach slice 3a) ── */
+.cloud-worker-display {
+  margin: 0 0 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface-2);
+  overflow: hidden;
+}
+.cloud-worker-display-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--line);
+}
+.cloud-worker-display-title {
+  font-weight: 600;
+  color: var(--text);
+}
+.cloud-worker-display-status {
+  flex: 1;
+  font-size: 12px;
+  color: var(--text-3);
+}
+.cloud-worker-display-status.ok { color: var(--green, #7fbf7f); }
+.cloud-worker-display-status.error { color: var(--rose, #df6b6b); }
+.cloud-worker-display-stage {
+  display: flex;
+  justify-content: center;
+  padding: 8px;
+  outline: none;
+  overflow: auto;
+  max-height: 70vh;
+}
+.cloud-worker-display-stage .tile-compositor-frame {
+  position: relative;
+}
+.cloud-worker-display-stage .tile-compositor-canvas {
+  max-width: 100%;
+  height: auto;
+}


### PR DESCRIPTION
Slice 3a of the attach track (design record: `~/codex-cloud-attach-slice3-design.md`): a live view of a cloud worker's virtual display on the Cloud card, over the attachment socket. The brief's "standard peer display pipeline" assumption is void for workers — WebRTC cannot form in either direction (verified in source: every ICE-TCP candidate the codebase emits is `tcptype passive`, the TURN client is UDP-only, and signaling itself would need inbound reach) — so this is the slice-2 frame-level inversion again, now for pixels.

## What ships

- **intendant-display foundation**: `tile_socket` module — `DisplaySession::spawn_tile_socket_stream` composes the existing tile primitives (grid, damage, encode, wire framing) into a single-subscriber stream for one ordered reliable sink: tile mode only (no video fallback/standby), `send().await` backpressure so a delivered snapshot group is always whole, 10 s re-anchor snapshots (no GapReport lane on this path yet). `disable_video_bank()` runs any session with the synthetic-style empty always-on encoder bank — a worker whose only viewer is the socket stream must not burn container CPU on VP8 nobody can subscribe to. `DisplayBackend::x11_display_hint()` fixes a latent wrong-server attach: the XDamage tile-damage backend now opens the capturing backend's own X display instead of the process-wide `DISPLAY`.
- **Worker side** (`codex-cloud agent`): `display_open` resolves a virtual display — existing X socket, fresh Xvfb via `vision::launch_display`, or the synthetic backend under the mock rig pair — starts a bankless `DisplaySession`, and pumps the tile stream up the attachment as base64 `display_tiles` frames; `display_input` enqueues `InputEvent`s into the session's ordered queue (XTEST on X11); `display_close` stops the viewer half while the session and Xvfb survive for the next open (reconnect parity with the terminal registry).
- **Home bridge** (`dashboard_control`): `display_open`/`display_close` arms bridge to the attachment (one forwarder per host under a reserved slot key; re-open replaces — slice-2 dedup parity), `display_input` gains the cloud host branch, and the reply filter admits only display reply kinds for the viewing host. `WORKER_REPLY_KINDS` widens with the display replies alone — the worker's inbound authority on home stays zero (pins extended).
- **Gates**: `FRAME_LANES` rows for `display_open`/`display_close` under `display.view`, tunnel-only (frozen golden mapping updated); hosted-control action-wall classifications at the Operate preset for the new inbound kinds and the display reply family.
- **Dashboard**: Cloud card **View** button + a persistent viewer panel above the card list — the shipped transport-agnostic `TileCompositor` paints the tile wire frames from the tunnel, pointer/keyboard capture sends `display_input`, and the tunnel starts on demand (slice-2 helper). One viewer at a time, matching the one-per-connection bridge.
- **Worker bootstrap**: `scripts/codex-cloud/setup.sh` installs Xvfb + x11-utils (best-effort with a named warning); docs chapter gains the live-view section.

## Verification

- Battery green: 5222 bins tests (new: tile-socket stream end-to-end over the synthetic backend with whole-snapshot-group ordering, worker display open→tiles→input→close over a seeded session, widened reply-kind pins, frozen golden update), the library crates, workspace Clippy `-D warnings`.
- **Live rig browser pass** (mTLS rig, Playwright client certificate, real click): View button → on-demand tunnel → `display_open` over the attachment → worker synthetic test card **painted on the Cloud card's compositor canvas (1280×768, color bars)** and **repainted between samples** (frame-counter strip advancing — deltas flowing, not a single snapshot); input events sent with the viewer staying healthy; status `connected · display :0`. Screenshot captured.
- The real-Xvfb leg (Linux container, XTEST input visibly landing) rides the slice-3b validation on the Linux box together with the CU click round-trip, which needs it anyway.

Slice 3b (CU over the attachment: `cu_execute`/`cu_result`, `execute_cu_actions` targeting `cloud:<task_id>`) follows as its own PR.
