### PR TITLE
fix(github): section consumed the daemonApi envelope as the body — unwrap on every lane (Track GC live finding)

### DIFF
--- a/src/bin/caller/web_gateway/routes_github.rs
+++ b/src/bin/caller/web_gateway/routes_github.rs
@@ -1786,6 +1786,36 @@ mod tests {
         );
     }
 
+    /// The lane-parity regression pin (2026-07-25 live Safari finding):
+    /// the daemonApi facade yields an `{ok, status, body}` envelope on
+    /// EVERY lane — the local tunnel and the Safari/mTLS HTTP fallback
+    /// alike — and the github section must render the parsed BODY, never
+    /// the envelope (which renders HTTP codes as status labels and
+    /// undefined fields as "unconfigured"). Structural pin: the one
+    /// unwrap helper exists, checks `ok` and returns `body`, and no
+    /// direct github-method `daemonApi.request` call bypasses it.
+    #[test]
+    fn github_section_unwraps_the_daemon_api_envelope() {
+        let app = include_str!("../../../../static/app.html");
+        assert!(
+            app.contains("async function githubIntegrationApi("),
+            "the github section's envelope-unwrap helper is gone"
+        );
+        for marker in ["if (!resp.ok) {", "return resp.body ?? {};"] {
+            assert!(
+                app.contains(marker),
+                "the unwrap helper lost its envelope handling: {marker:?}"
+            );
+        }
+        assert_eq!(
+            app.matches("daemonApi.request('api_github_").count(),
+            0,
+            "a github-section call bypasses the envelope unwrap helper — \
+             it would render the envelope (HTTP status, undefined fields) \
+             on both transports"
+        );
+    }
+
     #[tokio::test]
     async fn remove_is_idempotent_and_clears_state() {
         let dir = tempfile::tempdir().unwrap();

--- a/static/app.html
+++ b/static/app.html
@@ -36507,7 +36507,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '07a8b743b9ced013';
+const INTENDANT_APP_BUILD = 'bafe666c8351f70d';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -44484,12 +44484,29 @@ const githubIntegrationState = {
   repoPicker: { loading: false, repositories: null, error: null },
 };
 
+// Every github-section daemon call unwraps here. The daemonApi
+// contract is an {ok, status, body} envelope ON EVERY LANE — the local
+// tunnel and the Safari/mTLS HTTP fallback alike — and consuming the
+// envelope as the body renders HTTP codes as status labels and
+// undefined fields as "unconfigured" (the 2026-07-25 live Safari
+// finding). A non-ok envelope throws the body's named error. The
+// daemon-side pin `github_section_unwraps_the_daemon_api_envelope`
+// keeps direct request() calls out of this section.
+async function githubIntegrationApi(method, params) {
+  const resp = await daemonApi.request(method, params);
+  if (!resp.ok) {
+    const detail = resp.body && (resp.body.error || resp.body.detail);
+    throw new Error(String(detail || `${method} returned ${resp.status}`));
+  }
+  return resp.body ?? {};
+}
+
 async function githubIntegrationRefresh(force = false) {
   if (!force && Date.now() - githubIntegrationState.fetchedAt < 30_000) return;
   githubIntegrationState.fetchedAt = Date.now();
   try {
-    const data = await daemonApi.request('api_github_integration_status', {});
-    githubIntegrationState.data = data || null;
+    const body = await githubIntegrationApi('api_github_integration_status', {});
+    githubIntegrationState.data = body || null;
     githubIntegrationState.lastError = null;
   } catch (e) {
     githubIntegrationState.lastError = String(e?.message || e);
@@ -44535,8 +44552,8 @@ async function githubIntegrationDiscoveryTick() {
   }
   d.polling = true;
   try {
-    const data = await daemonApi.request('api_github_installations', {});
-    const rows = Array.isArray(data?.installations) ? data.installations : [];
+    const body = await githubIntegrationApi('api_github_installations', {});
+    const rows = Array.isArray(body?.installations) ? body.installations : [];
     d.installations = rows;
     d.error = null;
     if (rows.length === 1 && rows[0]?.installation_id) {
@@ -44560,8 +44577,8 @@ async function githubIntegrationCompleteInstall(row) {
   try {
     const payload = { installation_id: Number(row.installation_id) };
     if (row.app_id != null) payload.app_id = String(row.app_id);
-    const data = await daemonApi.request('api_github_integration_save', payload);
-    githubIntegrationState.data = data || githubIntegrationState.data;
+    const body = await githubIntegrationApi('api_github_integration_save', payload);
+    githubIntegrationState.data = body || githubIntegrationState.data;
     githubIntegrationState.fetchedAt = Date.now();
     githubIntegrationState.notice = {
       text: `Installed as ${row.account_login || 'the selected account'} — pick repositories below.`,
@@ -44582,14 +44599,14 @@ async function githubIntegrationSaveSelection(payload) {
   githubIntegrationState.busy = true;
   githubIntegrationState.notice = null;
   try {
-    const data = await daemonApi.request('api_github_integration_save', payload);
-    githubIntegrationState.data = data || githubIntegrationState.data;
+    const body = await githubIntegrationApi('api_github_integration_save', payload);
+    githubIntegrationState.data = body || githubIntegrationState.data;
     githubIntegrationState.fetchedAt = Date.now();
-    const status = String(data?.status || 'unknown');
+    const status = String(body?.status || 'unknown');
     githubIntegrationState.notice = {
       text: status === 'valid'
         ? 'Watch list saved — verified against GitHub.'
-        : `Saved. Status: ${status}${data?.detail ? ` — ${data.detail}` : ''}`,
+        : `Saved. Status: ${status}${body?.detail ? ` — ${body.detail}` : ''}`,
       cls: status === 'valid' ? 'ok' : 'warn',
     };
   } catch (e) {
@@ -44605,8 +44622,8 @@ async function githubIntegrationLoadRepositories() {
   p.loading = true;
   p.error = null;
   try {
-    const data = await daemonApi.request('api_github_repositories', {});
-    p.repositories = Array.isArray(data?.repositories) ? data.repositories : [];
+    const body = await githubIntegrationApi('api_github_repositories', {});
+    p.repositories = Array.isArray(body?.repositories) ? body.repositories : [];
   } catch (e) {
     p.error = String(e?.message || e);
   }
@@ -44649,11 +44666,15 @@ async function githubIntegrationConnect(orgInput) {
 }
 
 async function githubIntegrationSave(fields) {
+  // Ids ride only when present — the evolved save contract keeps the
+  // sealed values for absent ids, so an update needn't retype them.
   const payload = {
-    app_id: fields.appId.value.trim(),
-    installation_id: Number(fields.installationId.value || 0),
     repos: fields.repos.value.split('\n').map(s => s.trim()).filter(Boolean),
   };
+  const appId = fields.appId.value.trim();
+  if (appId) payload.app_id = appId;
+  const installationId = Number(fields.installationId.value || 0);
+  if (installationId >= 1) payload.installation_id = installationId;
   const pem = fields.pem.value.trim();
   if (pem) payload.private_key_pem = pem;
   const minutes = fields.pollMinutes.value.trim();
@@ -44662,14 +44683,14 @@ async function githubIntegrationSave(fields) {
   githubIntegrationState.notice = null;
   renderGithubIntegrationSection();
   try {
-    const data = await daemonApi.request('api_github_integration_save', payload);
-    githubIntegrationState.data = data || githubIntegrationState.data;
+    const body = await githubIntegrationApi('api_github_integration_save', payload);
+    githubIntegrationState.data = body || githubIntegrationState.data;
     githubIntegrationState.fetchedAt = Date.now();
-    const status = data?.status || 'saved';
+    const status = body?.status || 'saved';
     githubIntegrationState.notice = {
       text: status === 'valid'
-        ? `Saved — verified against GitHub${Number.isFinite(data?.verified_open_prs) ? ` (${data.verified_open_prs} open PRs)` : ''}.`
-        : `Saved. Status: ${status}${data?.detail ? ` — ${data.detail}` : ''}`,
+        ? `Saved — verified against GitHub${Number.isFinite(body?.verified_open_prs) ? ` (${body.verified_open_prs} open PRs)` : ''}.`
+        : `Saved. Status: ${status}${body?.detail ? ` — ${body.detail}` : ''}`,
       cls: status === 'valid' ? 'ok' : 'warn',
     };
     // The pasted key was sealed daemon-side; drop it from the DOM now.
@@ -44692,8 +44713,8 @@ async function githubIntegrationRemove() {
   githubIntegrationState.busy = true;
   renderGithubIntegrationSection();
   try {
-    const data = await daemonApi.request('api_github_integration_remove', {});
-    githubIntegrationState.data = data || githubIntegrationState.data;
+    const body = await githubIntegrationApi('api_github_integration_remove', {});
+    githubIntegrationState.data = body || githubIntegrationState.data;
     githubIntegrationState.fetchedAt = Date.now();
     githubIntegrationState.notice = { text: 'Credentials removed from custody.', cls: 'ok' };
   } catch (e) {

--- a/static/app/32-vault-custody.js
+++ b/static/app/32-vault-custody.js
@@ -4304,12 +4304,29 @@ const githubIntegrationState = {
   repoPicker: { loading: false, repositories: null, error: null },
 };
 
+// Every github-section daemon call unwraps here. The daemonApi
+// contract is an {ok, status, body} envelope ON EVERY LANE — the local
+// tunnel and the Safari/mTLS HTTP fallback alike — and consuming the
+// envelope as the body renders HTTP codes as status labels and
+// undefined fields as "unconfigured" (the 2026-07-25 live Safari
+// finding). A non-ok envelope throws the body's named error. The
+// daemon-side pin `github_section_unwraps_the_daemon_api_envelope`
+// keeps direct request() calls out of this section.
+async function githubIntegrationApi(method, params) {
+  const resp = await daemonApi.request(method, params);
+  if (!resp.ok) {
+    const detail = resp.body && (resp.body.error || resp.body.detail);
+    throw new Error(String(detail || `${method} returned ${resp.status}`));
+  }
+  return resp.body ?? {};
+}
+
 async function githubIntegrationRefresh(force = false) {
   if (!force && Date.now() - githubIntegrationState.fetchedAt < 30_000) return;
   githubIntegrationState.fetchedAt = Date.now();
   try {
-    const data = await daemonApi.request('api_github_integration_status', {});
-    githubIntegrationState.data = data || null;
+    const body = await githubIntegrationApi('api_github_integration_status', {});
+    githubIntegrationState.data = body || null;
     githubIntegrationState.lastError = null;
   } catch (e) {
     githubIntegrationState.lastError = String(e?.message || e);
@@ -4355,8 +4372,8 @@ async function githubIntegrationDiscoveryTick() {
   }
   d.polling = true;
   try {
-    const data = await daemonApi.request('api_github_installations', {});
-    const rows = Array.isArray(data?.installations) ? data.installations : [];
+    const body = await githubIntegrationApi('api_github_installations', {});
+    const rows = Array.isArray(body?.installations) ? body.installations : [];
     d.installations = rows;
     d.error = null;
     if (rows.length === 1 && rows[0]?.installation_id) {
@@ -4380,8 +4397,8 @@ async function githubIntegrationCompleteInstall(row) {
   try {
     const payload = { installation_id: Number(row.installation_id) };
     if (row.app_id != null) payload.app_id = String(row.app_id);
-    const data = await daemonApi.request('api_github_integration_save', payload);
-    githubIntegrationState.data = data || githubIntegrationState.data;
+    const body = await githubIntegrationApi('api_github_integration_save', payload);
+    githubIntegrationState.data = body || githubIntegrationState.data;
     githubIntegrationState.fetchedAt = Date.now();
     githubIntegrationState.notice = {
       text: `Installed as ${row.account_login || 'the selected account'} — pick repositories below.`,
@@ -4402,14 +4419,14 @@ async function githubIntegrationSaveSelection(payload) {
   githubIntegrationState.busy = true;
   githubIntegrationState.notice = null;
   try {
-    const data = await daemonApi.request('api_github_integration_save', payload);
-    githubIntegrationState.data = data || githubIntegrationState.data;
+    const body = await githubIntegrationApi('api_github_integration_save', payload);
+    githubIntegrationState.data = body || githubIntegrationState.data;
     githubIntegrationState.fetchedAt = Date.now();
-    const status = String(data?.status || 'unknown');
+    const status = String(body?.status || 'unknown');
     githubIntegrationState.notice = {
       text: status === 'valid'
         ? 'Watch list saved — verified against GitHub.'
-        : `Saved. Status: ${status}${data?.detail ? ` — ${data.detail}` : ''}`,
+        : `Saved. Status: ${status}${body?.detail ? ` — ${body.detail}` : ''}`,
       cls: status === 'valid' ? 'ok' : 'warn',
     };
   } catch (e) {
@@ -4425,8 +4442,8 @@ async function githubIntegrationLoadRepositories() {
   p.loading = true;
   p.error = null;
   try {
-    const data = await daemonApi.request('api_github_repositories', {});
-    p.repositories = Array.isArray(data?.repositories) ? data.repositories : [];
+    const body = await githubIntegrationApi('api_github_repositories', {});
+    p.repositories = Array.isArray(body?.repositories) ? body.repositories : [];
   } catch (e) {
     p.error = String(e?.message || e);
   }
@@ -4469,11 +4486,15 @@ async function githubIntegrationConnect(orgInput) {
 }
 
 async function githubIntegrationSave(fields) {
+  // Ids ride only when present — the evolved save contract keeps the
+  // sealed values for absent ids, so an update needn't retype them.
   const payload = {
-    app_id: fields.appId.value.trim(),
-    installation_id: Number(fields.installationId.value || 0),
     repos: fields.repos.value.split('\n').map(s => s.trim()).filter(Boolean),
   };
+  const appId = fields.appId.value.trim();
+  if (appId) payload.app_id = appId;
+  const installationId = Number(fields.installationId.value || 0);
+  if (installationId >= 1) payload.installation_id = installationId;
   const pem = fields.pem.value.trim();
   if (pem) payload.private_key_pem = pem;
   const minutes = fields.pollMinutes.value.trim();
@@ -4482,14 +4503,14 @@ async function githubIntegrationSave(fields) {
   githubIntegrationState.notice = null;
   renderGithubIntegrationSection();
   try {
-    const data = await daemonApi.request('api_github_integration_save', payload);
-    githubIntegrationState.data = data || githubIntegrationState.data;
+    const body = await githubIntegrationApi('api_github_integration_save', payload);
+    githubIntegrationState.data = body || githubIntegrationState.data;
     githubIntegrationState.fetchedAt = Date.now();
-    const status = data?.status || 'saved';
+    const status = body?.status || 'saved';
     githubIntegrationState.notice = {
       text: status === 'valid'
-        ? `Saved — verified against GitHub${Number.isFinite(data?.verified_open_prs) ? ` (${data.verified_open_prs} open PRs)` : ''}.`
-        : `Saved. Status: ${status}${data?.detail ? ` — ${data.detail}` : ''}`,
+        ? `Saved — verified against GitHub${Number.isFinite(body?.verified_open_prs) ? ` (${body.verified_open_prs} open PRs)` : ''}.`
+        : `Saved. Status: ${status}${body?.detail ? ` — ${body.detail}` : ''}`,
       cls: status === 'valid' ? 'ok' : 'warn',
     };
     // The pasted key was sealed daemon-side; drop it from the DOM now.
@@ -4512,8 +4533,8 @@ async function githubIntegrationRemove() {
   githubIntegrationState.busy = true;
   renderGithubIntegrationSection();
   try {
-    const data = await daemonApi.request('api_github_integration_remove', {});
-    githubIntegrationState.data = data || githubIntegrationState.data;
+    const body = await githubIntegrationApi('api_github_integration_remove', {});
+    githubIntegrationState.data = body || githubIntegrationState.data;
     githubIntegrationState.fetchedAt = Date.now();
     githubIntegrationState.notice = { text: 'Credentials removed from custody.', cls: 'ok' };
   } catch (e) {


### PR DESCRIPTION
Steward-verified live finding from the owner's Safari tab: the status route returned the correct body, but the vault section rendered unconfigured with a literal `status: 200` chip.

Root cause: the daemonApi facade resolves an `{ok, status, body}` envelope **on every transport**; the github section consumed the resolution as if it were the body — so fields read undefined (state 1) and the chip rendered the HTTP code. Surfaced on the Safari/mTLS **HTTP fallback lane** (WebKit cannot client-cert the WS, so no tunnel — a lane Chromium QA never exercises), but the misread was latent on every lane.

Fix: one `githubIntegrationApi` unwrap helper fronts all seven section calls — non-ok envelopes now throw the body's named error (previously silently mis-rendered), and the manual form sends ids only when present (aligned with the evolved save contract). Lane-parity regression pin: `github_section_unwraps_the_daemon_api_envelope` (app.html structural pin — helper present with ok-check + body-return, zero direct github-method `request()` calls).

Named follow-up (reported, not ridden here): a fleet-wide sweep for the same misread class in other sections is worth commissioning — the facade-envelope contract has no per-section pin elsewhere.

Battery: fmt clean, 5219/5219 bins, 33/33 e2e, workspace clippy -D warnings.