### PR TITLE
feat(agenda): depth dial, trigger vocabulary + pipeline strips, rich-ask composing (prototype slices 2-4)

### DIFF
--- a/static/app.html
+++ b/static/app.html
@@ -23298,6 +23298,19 @@ html.ui-v2 .ag2-sub {
   font-size: 13px;
   color: var(--text-2);
 }
+html.ui-v2 .ag2-head-tools {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  flex-shrink: 0;
+  margin-top: 4px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+html.ui-v2 .ag2-depth button {
+  padding: 5px 12px;
+  font-size: 12px;
+}
 html.ui-v2 .ag2-bell {
   display: inline-flex;
   align-items: center;
@@ -23311,7 +23324,6 @@ html.ui-v2 .ag2-bell {
   padding: 6px 11px;
   cursor: pointer;
   flex-shrink: 0;
-  margin-top: 4px;
 }
 html.ui-v2 .ag2-bell:hover {
   border-color: var(--line-2);
@@ -24247,6 +24259,17 @@ html.ui-v2 .ag2-diary-item.plain {
 html.ui-v2 .ag2-diary-who {
   font-size: 11px;
   color: var(--text-3);
+}
+html.ui-v2 .ag2-diary-raw {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  color: var(--text-3);
+}
+html.ui-v2 .ag2-ulid {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  color: var(--text-3);
+  white-space: nowrap;
 }
 
 /* ---- Empty state + footer ledger ---- */
@@ -36612,7 +36635,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '7201a6e5178dc146';
+const INTENDANT_APP_BUILD = '7f8b8570ec46a2bb';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -89648,6 +89671,30 @@ const agendaExpandedThreads = new Set();
 // ---- Lens + inspector view state (the redesigned tab). Ephemeral
 // browser state — never persisted, never on the wire.
 let agendaLens = 'now';
+
+// Progressive-disclosure depth for the whole tab — a persisted
+// presentation preference, never wire state: calm folds the machinery
+// away (triage/must-read chips, tags, exec labels, manifest plumbing,
+// the hood), standard is the working view, everything adds ids and raw
+// op coordinates inline. Gates read agendaDepthCalm()/agendaDepthAll()
+// at render time.
+let agendaDepth = 'standard';
+try {
+  const savedDepth = localStorage.getItem('ui2.agenda.depth');
+  if (['calm', 'standard', 'everything'].includes(savedDepth)) agendaDepth = savedDepth;
+} catch { /* storage unavailable — session-local default */ }
+
+function agendaDepthCalm() { return agendaDepth === 'calm'; }
+function agendaDepthAll() { return agendaDepth === 'everything'; }
+
+function agendaSetDepth(depth) {
+  if (!['calm', 'standard', 'everything'].includes(depth) || depth === agendaDepth) return;
+  agendaDepth = depth;
+  try { localStorage.setItem('ui2.agenda.depth', depth); } catch { /* session-local */ }
+  agendaDepthSyncSeg();
+  agendaRenderTab();
+  if (typeof agendaInspectorRender === 'function') agendaInspectorRender();
+}
 let agendaSearch = '';
 let agendaFilterBlocked = false;
 let agendaFilterFrontier = false;
@@ -91484,9 +91531,16 @@ function agendaEnsureScaffold() {
             <h2 class="ag2-title">Agenda</h2>
             <p class="ag2-sub">Parked intent that outlives any one session — one ledger for this daemon, every project.</p>
           </div>
-          <button type="button" class="ag2-bell" id="ag2-bell" title="Reminder delivery policy — owner authority (settings.manage)">
-            ${typeof ui2Icon === 'function' ? ui2Icon('bell', 14) : ''}<span>Reminders</span><span class="ag2-bell-dot" id="ag2-bell-dot" hidden title="Quiet hours are active now"></span>
-          </button>
+          <div class="ag2-head-tools">
+            <div class="ag2-seg ag2-depth" id="ag2-depth" role="group" aria-label="How much machinery to show">
+              <button type="button" data-depth="calm" title="Just what needs you — machinery folded away">Calm</button>
+              <button type="button" data-depth="standard" title="The working view">Standard</button>
+              <button type="button" data-depth="everything" title="Ids, digests, raw op coordinates — the whole engine room">Everything</button>
+            </div>
+            <button type="button" class="ag2-bell" id="ag2-bell" title="Reminder delivery policy — owner authority (settings.manage)">
+              ${typeof ui2Icon === 'function' ? ui2Icon('bell', 14) : ''}<span>Reminders</span><span class="ag2-bell-dot" id="ag2-bell-dot" hidden title="Quiet hours are active now"></span>
+            </button>
+          </div>
         </div>
         <div class="ag2-compose">
           <div class="ag2-seg" id="ag2-kind-seg" role="group" aria-label="Kind">
@@ -91529,6 +91583,16 @@ function agendaEnsureScaffold() {
   agendaWireScaffold();
 }
 
+// The depth seg's active state lives on the persistent scaffold, so it
+// syncs directly (wire time and every agendaSetDepth) rather than
+// through the groups re-render.
+function agendaDepthSyncSeg() {
+  const seg = document.getElementById('ag2-depth');
+  if (!seg) return;
+  seg.querySelectorAll('button[data-depth]').forEach((btn) =>
+    btn.classList.toggle('active', btn.dataset.depth === agendaDepth));
+}
+
 function agendaWireScaffold() {
   const kindSeg = document.getElementById('ag2-kind-seg');
   const title = document.getElementById('ag2-compose-title');
@@ -91569,6 +91633,11 @@ function agendaWireScaffold() {
     e.stopPropagation();
     agendaBellToggle();
   });
+  document.getElementById('ag2-depth').addEventListener('click', (e) => {
+    const btn = e.target.closest('[data-depth]');
+    if (btn) agendaSetDepth(btn.dataset.depth);
+  });
+  agendaDepthSyncSeg();
   const groups = document.getElementById('ag2-groups');
   groups.addEventListener('click', agendaGroupsClick);
   groups.addEventListener('input', agendaGroupsInput);
@@ -92034,14 +92103,16 @@ function agendaCardChips(item) {
         'Render-level flag only — completion never cascades'));
     }
   }
+  // Machinery chips — folded away at calm depth (status, due, blocked,
+  // and attention states above always show).
   const triage = agendaTriageInfo(item);
-  if (triage) {
+  if (triage && !agendaDepthCalm()) {
     chips.push(agendaChipHtml(
       triage.rank !== null ? `triage #${triage.rank}` : 'triage',
       'iris', triage.text, true));
   }
   const mustReads = (item.refs || []).filter((r) => r.must_read).length;
-  if (mustReads) {
+  if (mustReads && !agendaDepthCalm()) {
     chips.push(agendaChipHtml(`${mustReads} must-read`, 'iris',
       'Typed pointers the reading agent weighs — never orders'));
   }
@@ -92072,7 +92143,7 @@ function agendaCardByline(item, opts) {
             : p.kind === 'peer' ? 'a peer daemon' : (p.kind || 'unattributed');
     by = `by <span title="${escapeHtml(tip)}">${escapeHtml(label)}</span>`;
   }
-  const selfDesc = p.source
+  const selfDesc = p.source && !agendaDepthCalm()
     ? '<span class="agenda-self-described" title="Self-described label — unverified, never an identity">· self-described</span>'
     : '';
   const bits = [
@@ -92085,7 +92156,7 @@ function agendaCardByline(item, opts) {
   if (hub && !opts.noHub) {
     bits.push(`<span>· in</span> <a class="ag2-hub-link" data-open-item="${escapeHtml(hub.id)}">${escapeHtml(hub.title.length > 34 ? `${hub.title.slice(0, 33)}…` : hub.title)}</a>`);
   }
-  (item.tags || []).slice(0, 3).forEach((tag) => {
+  (agendaDepthCalm() ? [] : (item.tags || []).slice(0, 3)).forEach((tag) => {
     bits.push(`<span class="ag2-tag">${escapeHtml(tag)}</span>`);
   });
   return bits.filter(Boolean).join(' ');
@@ -92141,7 +92212,9 @@ function agendaAutomationStripHtml(item) {
   const e = st.effect;
   const id = escapeHtml(item.id);
   const meta = [];
-  meta.push(`<span class="ag2-auto-exec" title="Executor — digest-bound like the rest of the manifest: editing it voids the approval">${escapeHtml(agendaExecutorLabel(st.manifest.agent_config))}</span>`);
+  if (!agendaDepthCalm()) {
+    meta.push(`<span class="ag2-auto-exec" title="Executor — digest-bound like the rest of the manifest: editing it voids the approval">${escapeHtml(agendaExecutorLabel(st.manifest.agent_config))}</span>`);
+  }
   meta.push(`<span>${escapeHtml(st.rec ? `every ${agendaCadenceLabel(st.rec.every_ms)}` : 'once')}</span>`);
   const last = e.last_run;
   if (last) {
@@ -92429,7 +92502,13 @@ function agendaCardHtml(row) {
   const item = row.item;
   const opts = row;
   const id = escapeHtml(item.id);
-  const blockedLine = agendaBlockedLine(item);
+  // Calm depth folds prerequisite-only wait lines (the blocked chip
+  // still shows); an explicit uncleared blocker always renders — it
+  // names what someone must do.
+  const blockedRaw = agendaBlockedLine(item);
+  const blockedLine = blockedRaw
+    && agendaDepthCalm() && !(item.blockers || []).some((b) => !b.cleared)
+    ? null : blockedRaw;
   const answerLine = opts.showAnswer && item.answer && item.answer.text
     ? `<div class="ag2-ansline">${escapeHtml(item.answer.text.length > 180 ? `${item.answer.text.slice(0, 180)}…` : item.answer.text)}</div>`
     : '';
@@ -92443,6 +92522,7 @@ function agendaCardHtml(row) {
       <div class="ag2-card-titlerow">
         <span class="ag2-card-title${item.status === 'done' ? ' done' : ''}${item.status !== 'open' ? ' dim' : ''}">${escapeHtml(item.title)}</span>
         ${agendaCardChips(item)}
+        ${agendaDepthAll() ? `<span class="ag2-ulid" title="ulid prefix — creation-ordered; the full id is on the item panel">${escapeHtml(item.id.slice(0, 10).toLowerCase())}</span>` : ''}
       </div>
       <div class="ag2-card-meta">${agendaCardByline(item, opts)}</div>
       ${blockedLine ? `<div class="ag2-blocked-line">${escapeHtml(blockedLine)}</div>` : ''}
@@ -92770,7 +92850,7 @@ function agendaInspectorRender() {
         ${agendaInspPrStateHtml(item)}
         ${agendaInspRefsHtml(item)}
         ${agendaInspThreadHtml(item)}
-        ${agendaHoodSectionHtml(item)}
+        ${agendaDepthCalm() ? '' : agendaHoodSectionHtml(item)}
       </div>
     </div>`;
   });
@@ -93069,11 +93149,15 @@ function agendaInspEffectHtml(item) {
       R('ends', `${st.rec.until_ms ? agendaAbsTime(st.rec.until_ms) : ''}${st.rec.max_occurrences ? `${st.rec.until_ms ? ' or ' : ''}after ${st.rec.max_occurrences} runs` : ''}`);
     }
     R('shape', `${m.interactive ? 'interactive — opens and waits for you' : 'goal run — autonomous, writes back'} · ${m.orchestrate ? 'orchestrated' : 'direct'}`);
-    R('project', m.project_root || 'inherited at fire time: parking session’s root, else daemon default', !!m.project_root);
-    const cfg = m.agent_config || null;
-    R('config', cfg
-      ? `${[cfg.agent, ...Object.entries(cfg).filter(([k]) => k !== 'agent').map(([, v]) => v)].filter(Boolean).join(' · ')} — explicit, recorded on the manifest`
-      : 'inherits daemon defaults (Settings → reasoning)', !!cfg);
+    // Manifest plumbing rows fold away at calm depth; the sealed facts
+    // stay one depth notch (or the raw sheet) away.
+    if (!agendaDepthCalm()) {
+      R('project', m.project_root || 'inherited at fire time: parking session’s root, else daemon default', !!m.project_root);
+      const cfg = m.agent_config || null;
+      R('config', cfg
+        ? `${[cfg.agent, ...Object.entries(cfg).filter(([k]) => k !== 'agent').map(([, v]) => v)].filter(Boolean).join(' · ')} — explicit, recorded on the manifest`
+        : 'inherits daemon defaults (Settings → reasoning)', !!cfg);
+    }
     if (st.rec) {
       R('on failure', `suspend after ${st.threshold} failed runs in a row — surfaced, never silently re-fired`);
     }
@@ -93090,7 +93174,7 @@ function agendaInspEffectHtml(item) {
       lastRun = `<div class="ag2-eff-lastrun">
         <div class="ag2-eff-lastrun-head">
           ${agendaChipHtml(`last run · ${run.state}`, runTone)}
-          <span class="ag2-hint">${escapeHtml(`${agendaRelTime(run.at_ms)} · occurrence ${run.occurrence_id}`)}</span>
+          <span class="ag2-hint">${escapeHtml(agendaDepthCalm() ? agendaRelTime(run.at_ms) : `${agendaRelTime(run.at_ms)} · occurrence ${run.occurrence_id}`)}</span>
           ${sessionLink}
         </div>
         ${run.note ? `<div class="ag2-eff-note">${escapeHtml(run.note)}</div>` : ''}
@@ -93126,10 +93210,12 @@ function agendaInspEffectHtml(item) {
         <span class="ag2-eff-dot"></span>
         <span class="ag2-eff-state">${escapeHtml(stateLabel)}</span>
         <span class="ag2-spacer"></span>
-        <span class="ag2-hint mono">digest ${escapeHtml(String(e.digest || '').slice(0, 10))}…${e.approval ? ' · approved' : ' · unapproved'}</span>
+        <span class="ag2-hint mono">${agendaDepthCalm()
+    ? (e.approval ? 'approved' : 'unapproved')
+    : `digest ${escapeHtml(String(e.digest || '').slice(0, 10))}…${e.approval ? ' · approved' : ' · unapproved'}`}</span>
       </div>
       <div class="ag2-eff-grid">${rows.join('')}</div>
-      <div class="ag2-eff-goal">${escapeHtml(m.goal || '')}</div>
+      ${agendaDepthCalm() ? '' : `<div class="ag2-eff-goal">${escapeHtml(m.goal || '')}</div>`}
       ${lastRun}
       ${acts.length ? `<div class="ag2-insp-actions">${acts.join('')}</div>` : ''}
     </div>`;
@@ -95410,7 +95496,8 @@ function agendaDiaryRowHtml(entry) {
       <span class="ag2-plan-time">${escapeHtml(envelope.at_ms ? agendaPlanHm(envelope.at_ms) : '—')}</span>
       <span class="ag2-diary-verb">${escapeHtml(verb)}</span>
       ${target}
-      ${who ? `<span class="ag2-diary-who">${escapeHtml(`by ${who}`)}</span>` : ''}
+      ${who && !agendaDepthCalm() ? `<span class="ag2-diary-who">${escapeHtml(`by ${who}`)}</span>` : ''}
+      ${agendaDepthAll() ? `<span class="ag2-diary-raw">${escapeHtml(raw)}</span>` : ''}
     </div>
   </div>`;
 }
@@ -95439,7 +95526,9 @@ function agendaDiarySegHtml() {
        class="${agendaDiaryFilter === id ? 'active' : ''}">${escapeHtml(label)}</button>`).join('');
   return `<div class="ag2-diary-bar">
     <div class="ag2-seg ag2-diary-seg" role="group" aria-label="Diary filter">${buttons}</div>
-    <span class="ag2-diary-hint">attributed, append-only — dismissals, failures, and revocations included</span>
+    <span class="ag2-diary-hint">${agendaDepthCalm()
+    ? 'what happened, day by day'
+    : 'attributed, append-only — dismissals, failures, and revocations included'}</span>
   </div>`;
 }
 

--- a/static/app.html
+++ b/static/app.html
@@ -23343,11 +23343,94 @@ html.ui-v2 .ag2-compose {
   display: flex;
   gap: 8px;
   align-items: center;
+  flex-wrap: wrap;
   padding: 10px;
   border: 1px solid var(--line);
   border-radius: 13px;
   background: var(--surface);
   margin: 16px 0 12px;
+}
+html.ui-v2 .ag2-rich-toggle {
+  background: none;
+  border: 1px dashed var(--line-2);
+  border-radius: 999px;
+  color: var(--text-3);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 3px 11px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+html.ui-v2 .ag2-rich-toggle:hover,
+html.ui-v2 .ag2-rich-toggle.on {
+  border-color: var(--iris);
+  color: var(--iris-2);
+}
+html.ui-v2 .ag2-rich-row {
+  flex-basis: 100%;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  flex-wrap: wrap;
+  border-top: 1px solid var(--line);
+  padding-top: 9px;
+}
+html.ui-v2 .ag2-rich-eyebrow {
+  font-family: var(--mono);
+  font-size: var(--eyebrow-size);
+  font-weight: 700;
+  letter-spacing: var(--eyebrow-track);
+  text-transform: uppercase;
+  color: var(--text-3);
+}
+html.ui-v2 .ag2-rich-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: 1px solid var(--line);
+  background: var(--surface-2);
+  color: var(--text-2);
+  border-radius: 999px;
+  padding: 3px 6px 3px 11px;
+  font-size: 12px;
+  font-weight: 600;
+}
+html.ui-v2 .ag2-rich-chip button {
+  background: none;
+  border: 0;
+  color: var(--text-3);
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 3px;
+}
+html.ui-v2 .ag2-rich-chip button:hover {
+  color: var(--rose);
+}
+html.ui-v2 .ag2-rich-row input {
+  flex: 0 1 200px;
+  border-radius: 999px;
+  font-size: 12px;
+  padding: 4px 11px;
+}
+html.ui-v2 #ag2-rich-multi {
+  background: none;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--text-3);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 3px 11px;
+  cursor: pointer;
+}
+html.ui-v2 #ag2-rich-multi.on {
+  border-color: var(--iris);
+  color: var(--iris-2);
+  background: var(--surface-2);
+}
+html.ui-v2 .ag2-rich-hint {
+  font-size: 10.5px;
+  color: var(--text-3);
 }
 html.ui-v2 .ag2-compose input {
   flex: 1;
@@ -36708,7 +36791,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'e61ac05d4f99e2ce';
+const INTENDANT_APP_BUILD = '0aaf6fcab8f52c48';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -89966,9 +90049,10 @@ async function agendaSendOp(params, button) {
     const resp = await daemonApi.request('api_agenda_op', params);
     if (resp.ok && resp.body && resp.body.item) {
       // The event lane repaints too; merging here keeps the UI honest
-      // even if this tab's event socket is briefly down.
+      // even if this tab's event socket is briefly down. Returns the
+      // item (truthy) so multi-op gestures can chain on the minted id.
       agendaObserveServerMessage({ item: resp.body.item });
-      return true;
+      return resp.body.item;
     }
     const message = (resp.body && resp.body.error) || `agenda op failed (${resp.status})`;
     agendaFlashError(message);
@@ -91601,6 +91685,14 @@ const AGENDA_COMPOSE_PLACEHOLDERS = {
 
 let agendaComposeKind = 'task';
 
+// Rich-ask composing (question kind only): the owner builds pick-one /
+// pick-many options inline and the compose bar parks `{op:'ask'}` — the
+// same durable rich-ask lane sessions use; options render on every
+// dashboard's question rail, nothing blocks, nothing expires.
+let agendaRichOn = false;
+let agendaRichOptions = [];
+let agendaRichMulti = false;
+
 // ---- Scaffold ----
 
 function agendaEnsureScaffold() {
@@ -91634,6 +91726,8 @@ function agendaEnsureScaffold() {
           </div>
           <input id="ag2-compose-title" type="text" maxlength="500" autocomplete="off"
                  placeholder="${escapeHtml(AGENDA_COMPOSE_PLACEHOLDERS.task)}" aria-label="New agenda item title" />
+          <button type="button" class="ag2-rich-toggle" id="ag2-rich-toggle" hidden
+                  title="Give the owner options to pick from — the question still parks durably and resolves everywhere">+ options</button>
           <select id="ag2-compose-due" aria-label="Reminder"
                   title="A due time delivers a reminder to you — it never authorizes work">
             <option value="">No reminder</option>
@@ -91643,6 +91737,7 @@ function agendaEnsureScaffold() {
             <option value="mon">Next Monday 09:00</option>
           </select>
           <button type="button" class="ag2-park" id="ag2-park">Park</button>
+          <div class="ag2-rich-row" id="ag2-rich-row" hidden></div>
         </div>
         <div class="ag2-lensbar">
           <div class="ag2-seg ag2-lenses" id="ag2-lenses" role="tablist" aria-label="Agenda lens"></div>
@@ -91667,6 +91762,29 @@ function agendaEnsureScaffold() {
   agendaWireScaffold();
 }
 
+// ---- Rich-ask compose row (persistent scaffold; re-rendered on state) ----
+
+function agendaRichRowRender() {
+  const row = document.getElementById('ag2-rich-row');
+  const toggle = document.getElementById('ag2-rich-toggle');
+  if (!row || !toggle) return;
+  const isQuestion = agendaComposeKind === 'question';
+  toggle.hidden = !isQuestion;
+  toggle.classList.toggle('on', agendaRichOn);
+  row.hidden = !isQuestion || !agendaRichOn;
+  if (row.hidden) {
+    row.innerHTML = '';
+    return;
+  }
+  const chips = agendaRichOptions.map((label, i) =>
+    `<span class="ag2-rich-chip">${escapeHtml(label)}<button type="button" data-rich-remove="${i}" title="Remove option">×</button></span>`).join('');
+  row.innerHTML = `<span class="ag2-rich-eyebrow">Options</span>
+    ${chips}
+    <input type="text" maxlength="80" id="ag2-rich-draft" placeholder="Add an option, press Enter…" aria-label="Add an option" />
+    <button type="button" id="ag2-rich-multi" class="${agendaRichMulti ? 'on' : ''}" title="Allow picking more than one option">pick many</button>
+    <span class="ag2-rich-hint">Parks as a rich ask — options render on every dashboard’s question rail; nothing blocks, nothing expires.</span>`;
+}
+
 // The depth seg's active state lives on the persistent scaffold, so it
 // syncs directly (wire time and every agendaSetDepth) rather than
 // through the groups re-render.
@@ -91687,7 +91805,43 @@ function agendaWireScaffold() {
         b.classList.toggle('active', b === btn));
       title.placeholder = AGENDA_COMPOSE_PLACEHOLDERS[agendaComposeKind]
         || AGENDA_COMPOSE_PLACEHOLDERS.task;
+      agendaRichRowRender();
     });
+  });
+  document.getElementById('ag2-rich-toggle').addEventListener('click', () => {
+    agendaRichOn = !agendaRichOn;
+    agendaRichRowRender();
+    const draft = document.getElementById('ag2-rich-draft');
+    if (draft) draft.focus();
+  });
+  const richRow = document.getElementById('ag2-rich-row');
+  richRow.addEventListener('click', (e) => {
+    const remove = e.target.closest('[data-rich-remove]');
+    if (remove) {
+      agendaRichOptions.splice(Number(remove.dataset.richRemove), 1);
+      agendaRichRowRender();
+      return;
+    }
+    if (e.target.closest('#ag2-rich-multi')) {
+      agendaRichMulti = !agendaRichMulti;
+      agendaRichRowRender();
+    }
+  });
+  richRow.addEventListener('keydown', (e) => {
+    if (e.key !== 'Enter' || !e.target.closest('#ag2-rich-draft')) return;
+    e.preventDefault();
+    const draft = e.target;
+    const label = (draft.value || '').trim();
+    if (!label || agendaRichOptions.includes(label)) return;
+    if (agendaRichOptions.length >= 4) {
+      agendaFlashError('Four options at most — the rail renders up to four.');
+      return;
+    }
+    agendaRichOptions.push(label);
+    draft.value = '';
+    agendaRichRowRender();
+    const next = document.getElementById('ag2-rich-draft');
+    if (next) next.focus();
   });
   document.getElementById('ag2-park').addEventListener('click', agendaComposePark);
   title.addEventListener('keydown', (e) => {
@@ -91791,16 +91945,47 @@ async function agendaComposePark() {
     title.focus();
     return;
   }
-  const params = { op: 'add', kind: agendaComposeKind, title: text };
+  const rich = agendaComposeKind === 'question' && agendaRichOn
+    && agendaRichOptions.length > 0;
   const dueMs = agendaDuePresetMs(due.value);
-  if (dueMs) params.due_ms = dueMs;
+  let params;
+  if (rich) {
+    // The same durable rich-ask lane sessions use (AgendaCommand::Ask):
+    // the daemon mints the item and the rail ask_id; options land on
+    // every dashboard's question rail. A due reminder rides a follow-up
+    // patch — the ask command deliberately carries no reminder field.
+    params = {
+      op: 'ask',
+      questions: [{
+        question: text,
+        options: agendaRichOptions.map((label) => ({ label })),
+        pick_max: agendaRichMulti ? agendaRichOptions.length : 1,
+      }],
+    };
+  } else {
+    params = { op: 'add', kind: agendaComposeKind, title: text };
+    if (dueMs) params.due_ms = dueMs;
+  }
   const ok = await agendaSendOp(params, btn);
   if (ok) {
+    if (rich && dueMs && ok.id) {
+      // The reminder rides a follow-up patch on the minted item — the
+      // ask command itself deliberately carries no reminder field.
+      await agendaSendOp({ op: 'patch', id: ok.id, patch: { due_ms: dueMs } });
+    }
     title.value = '';
     due.value = '';
     title.focus();
+    if (rich) {
+      agendaRichOptions = [];
+      agendaRichMulti = false;
+      agendaRichOn = false;
+      agendaRichRowRender();
+    }
     if (typeof showControlToast === 'function') {
-      showControlToast('success', `Parked${dueMs ? ' — reminder set' : ''}.`);
+      showControlToast('success', rich
+        ? `Parked as a rich ask — ${params.questions[0].options.length} options on the question rail.`
+        : `Parked${dueMs ? ' — reminder set' : ''}.`);
     }
   }
 }

--- a/static/app.html
+++ b/static/app.html
@@ -24272,6 +24272,79 @@ html.ui-v2 .ag2-ulid {
   white-space: nowrap;
 }
 
+/* ---- Workflow pipeline strip: node chains on hub cards + the hubs
+   lens. Dots are static siblings (unlike the timeline's absolute
+   .ag2-plan-dot), so they carry their own tone classes; pulse rides the
+   shared ui2-pulse keyframes. ---- */
+
+html.ui-v2 .ag2-pipeline {
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+  margin: 5px 0 4px;
+  overflow-x: auto;
+  padding-bottom: 2px;
+}
+html.ui-v2 .ag2-pipe-node {
+  flex: 1;
+  min-width: 116px;
+  border: 1px solid var(--line);
+  background: var(--surface);
+  border-radius: 9px;
+  padding: 6px 9px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  align-items: flex-start;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+}
+html.ui-v2 .ag2-pipe-node:hover {
+  border-color: var(--line-2);
+  background: var(--surface-2);
+}
+html.ui-v2 .ag2-pipe-arrow {
+  align-self: center;
+  color: var(--text-3);
+  padding: 0 5px;
+  font-size: 12px;
+  flex-shrink: 0;
+}
+html.ui-v2 .ag2-pipe-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+html.ui-v2 .ag2-pipe-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+html.ui-v2 .ag2-pipe-dot.t-sky { background: var(--sky); }
+html.ui-v2 .ag2-pipe-dot.t-iris { background: var(--iris); }
+html.ui-v2 .ag2-pipe-dot.t-amber { background: var(--amber); }
+html.ui-v2 .ag2-pipe-dot.t-green { background: var(--green); }
+html.ui-v2 .ag2-pipe-dot.t-rose { background: var(--rose); }
+html.ui-v2 .ag2-pipe-dot.t-neutral { background: var(--neutral-dot); }
+html.ui-v2 .ag2-pipe-dot.pulse.slow { animation: ui2-pulse 2s ease-in-out infinite; }
+html.ui-v2 .ag2-pipe-dot.pulse.fast { animation: ui2-pulse 1.3s ease-in-out infinite; }
+html.ui-v2 .ag2-pipe-title {
+  font-size: 11.5px;
+  font-weight: 700;
+  color: var(--text);
+}
+html.ui-v2 .ag2-pipe-state {
+  font-size: 10px;
+  color: var(--text-3);
+}
+html.ui-v2 .ag2-pipe-exec {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  color: var(--text-3);
+}
+
 /* ---- Empty state + footer ledger ---- */
 
 html.ui-v2 .ag2-empty {
@@ -36635,7 +36708,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '7f8b8570ec46a2bb';
+const INTENDANT_APP_BUILD = 'e61ac05d4f99e2ce';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -89968,16 +90041,24 @@ function agendaBlockedLine(item) {
 }
 
 // The item's scheduled-session effect, judged for render: kind is one of
-// running | suspended | pending | standing | armed | finished. Mirrors
-// the daemon's fold judgments (AgendaEffect::suspended, the scheduler's
-// next-instant derivation) — derived here every paint, never stored.
+// running | suspended | pending | standing | armed | finished, plus the
+// trigger vocabulary (Track T manifests carry `trigger` INSTEAD of a
+// clock cadence): watching (on_item_match, approved), waiting
+// (on_unblock, prerequisites still open), ready (on_unblock, every
+// prerequisite complete — the scheduler dispatches within the minute).
+// Mirrors the daemon's fold judgments (AgendaEffect::suspended, the
+// scheduler's next-instant derivation, the trigger arm rules) — derived
+// here every paint, never stored.
 function agendaEffectState(item) {
   const effect = (item.effects || [])[0];
   if (!effect || !effect.manifest) return null;
   const manifest = effect.manifest;
   const rec = manifest.recurrence || null;
-  const threshold = rec ? Math.max(1, rec.suspend_after_failures || 3) : 0;
-  const suspended = !!rec && (effect.consecutive_failures || 0) >= threshold;
+  const trig = manifest.trigger || null;
+  // Failure-suspend covers standing series AND triggered mandates (the
+  // C-floor guardrail); one-shot clock manifests never suspend.
+  const threshold = rec || trig ? Math.max(1, (rec && rec.suspend_after_failures) || 3) : 0;
+  const suspended = !!(rec || trig) && (effect.consecutive_failures || 0) >= threshold;
   const running = !!(effect.last_run && effect.last_run.state === 'started');
   // The daemon decorates each effect with the planner's REAL next firing
   // instant (`next_fire_ms`, absent when nothing will fire) — prefer it
@@ -89991,9 +90072,12 @@ function agendaEffectState(item) {
   const kind = running ? 'running'
     : suspended ? 'suspended'
       : !effect.approval ? 'pending'
-        : rec ? 'standing'
-          : next > Date.now() ? 'armed' : 'finished';
-  return { effect, manifest, rec, threshold, suspended, running, next, kind };
+        : trig ? (trig.kind === 'on_item_match' ? 'watching'
+          : (item.relies_on || []).every((link) => agendaLinkState(link).satisfied)
+            ? 'ready' : 'waiting')
+          : rec ? 'standing'
+            : next > Date.now() ? 'armed' : 'finished';
+  return { effect, manifest, rec, trig, threshold, suspended, running, next, kind };
 }
 
 // One-line executor description for a manifest's `agent_config` block:
@@ -92088,6 +92172,16 @@ function agendaCardChips(item) {
         `One approval covers the series · next ${agendaAbsTime(st.next)}`));
     } else if (st.kind === 'armed') {
       chips.push(agendaChipHtml('armed', 'sky', `Fires ${agendaAbsTime(st.next)}`));
+    } else if (st.kind === 'watching') {
+      const predicate = `${st.trig.item_kind || 'item'}${(st.trig.tags || []).length ? ` + ${st.trig.tags.join(',')}` : ''}`;
+      chips.push(agendaChipHtml(agendaDepthCalm() ? 'watching' : `watching · ${predicate}`, 'sky',
+        'Fires when a NEW open item matches — arrivals batch for a minute'));
+    } else if (st.kind === 'waiting') {
+      chips.push(agendaChipHtml('auto · on unblock', 'sky',
+        'Armed — fires the moment every prerequisite completes; no one has to remember', true));
+    } else if (st.kind === 'ready') {
+      chips.push(agendaChipHtml('fires momentarily', 'iris',
+        'Prerequisites complete — the scheduler dispatches within the minute'));
     }
   }
   const kids = agendaChildrenOf(item.id);
@@ -92215,7 +92309,9 @@ function agendaAutomationStripHtml(item) {
   if (!agendaDepthCalm()) {
     meta.push(`<span class="ag2-auto-exec" title="Executor — digest-bound like the rest of the manifest: editing it voids the approval">${escapeHtml(agendaExecutorLabel(st.manifest.agent_config))}</span>`);
   }
-  meta.push(`<span>${escapeHtml(st.rec ? `every ${agendaCadenceLabel(st.rec.every_ms)}` : 'once')}</span>`);
+  meta.push(`<span>${escapeHtml(st.trig
+    ? (st.trig.kind === 'on_item_match' ? 'on matching items' : 'on unblock')
+    : st.rec ? `every ${agendaCadenceLabel(st.rec.every_ms)}` : 'once')}</span>`);
   const last = e.last_run;
   if (last) {
     const tip = `${last.state}${last.note ? ` — ${last.note}` : ''}`;
@@ -92247,13 +92343,73 @@ function agendaAutomationStripHtml(item) {
   } else if (st.kind === 'standing' && e.next_fire_ms) {
     actions = `<button type="button" class="ag2-btn ghost" data-op-btn="request_occurrence" data-id="${id}" title="One extra occurrence of the approved digest — the standing approval is untouched">Run now</button>`
       + `<button type="button" class="ag2-btn ghost" data-op-btn="revoke_effect" data-id="${id}" title="Withdraws the approval; the manifest and history stay">Revoke</button>`;
-  } else if (st.kind === 'armed') {
+  } else if (['armed', 'watching', 'waiting', 'ready'].includes(st.kind)) {
     actions = `<button type="button" class="ag2-btn ghost" data-op-btn="revoke_effect" data-id="${id}" title="Withdraws the approval; the manifest and history stay">Revoke</button>`;
   }
   return `<div class="ag2-eff ag2-auto t-${st.kind === 'pending' || st.kind === 'suspended' ? 'amber' : 'iris'}">
     <span class="ag2-auto-meta">${meta.join('<span class="ag2-auto-dot">·</span>')}</span>
     <span class="ag2-spacer"></span>${actions}
   </div>`;
+}
+
+// ---- Workflow pipeline strip (hub cards + the hubs lens) ----
+
+// A hub reads as a pipeline when at least two children carry
+// on_unblock-triggered manifests — the workflow stamp's shape, DERIVED
+// from the graph every paint; no workflow-level object or marker exists
+// anywhere (Track T's contract).
+function agendaPipelineNodes(hub) {
+  const kids = agendaChildrenOf(hub.id).filter((k) =>
+    (k.effects || []).some((e) => e.manifest && e.manifest.trigger
+      && e.manifest.trigger.kind === 'on_unblock'));
+  if (kids.length < 2) return null;
+  // relies_on topological order within the set (bounded passes; a cycle
+  // or cross-hub dependency appends in creation order at the tail).
+  const inSet = new Set(kids.map((k) => k.id));
+  const order = [];
+  const placed = new Set();
+  for (let pass = 0; pass < kids.length && order.length < kids.length; pass++) {
+    kids.forEach((k) => {
+      if (placed.has(k.id)) return;
+      const deps = (k.relies_on || []).map((l) => l.target_id).filter((id) => inSet.has(id));
+      if (deps.every((id) => placed.has(id))) {
+        placed.add(k.id);
+        order.push(k);
+      }
+    });
+  }
+  kids.forEach((k) => { if (!placed.has(k.id)) order.push(k); });
+  return order;
+}
+
+function agendaPipelineStripHtml(hub) {
+  const nodes = agendaPipelineNodes(hub);
+  if (!nodes) return '';
+  const cells = nodes.map((node, i) => {
+    const st = agendaEffectState(node);
+    let tone = 'neutral';
+    let state = 'parked';
+    let pulse = '';
+    if (node.status === 'done') { tone = 'green'; state = 'done'; }
+    else if (node.status === 'retired') { state = 'retired'; }
+    else if (st) {
+      if (st.kind === 'running') { tone = 'iris'; state = 'running'; pulse = 'fast'; }
+      else if (st.kind === 'ready') { tone = 'iris'; state = 'fires momentarily'; pulse = 'slow'; }
+      else if (st.kind === 'waiting') { tone = 'sky'; state = 'waiting on prerequisites'; }
+      else if (st.kind === 'pending') { tone = 'amber'; state = 'needs approval'; }
+      else if (st.kind === 'suspended') { tone = 'amber'; state = `suspended · ${st.effect.consecutive_failures} failures`; }
+      else { state = st.kind; }
+    }
+    const exec = st && !agendaDepthCalm() ? agendaExecutorLabel(st.manifest.agent_config) : '';
+    const arrow = i ? '<span class="ag2-pipe-arrow" aria-hidden="true">→</span>' : '';
+    const title = String(node.title || '');
+    return `${arrow}<button type="button" class="ag2-pipe-node" data-open-item="${escapeHtml(node.id)}" title="${escapeHtml(`${title} — ${state}`)}">
+      <span class="ag2-pipe-head"><span class="ag2-pipe-dot t-${tone}${pulse ? ` pulse ${pulse}` : ''}"></span><span class="ag2-pipe-title">${escapeHtml(title.length > 22 ? `${title.slice(0, 21)}…` : title)}</span></span>
+      <span class="ag2-pipe-state">${escapeHtml(state)}</span>
+      ${exec ? `<span class="ag2-pipe-exec">${escapeHtml(exec)}</span>` : ''}
+    </button>`;
+  });
+  return `<div class="ag2-pipeline">${cells.join('')}</div>`;
 }
 
 // ---- Inline question answering ----
@@ -92526,6 +92682,7 @@ function agendaCardHtml(row) {
       </div>
       <div class="ag2-card-meta">${agendaCardByline(item, opts)}</div>
       ${blockedLine ? `<div class="ag2-blocked-line">${escapeHtml(blockedLine)}</div>` : ''}
+      ${agendaPipelineStripHtml(item)}
       ${opts.automation ? agendaAutomationStripHtml(item) : agendaCardEffectStrip(item)}
       ${qa}${answerLine}
     </div>
@@ -92624,12 +92781,14 @@ function agendaRenderTab() {
       const hubLink = group.hubId
         ? `<a class="ag2-hub-open" data-open-item="${escapeHtml(group.hubId)}">open the hub ›</a>`
         : '';
+      const hub = group.hubId ? agendaFindItem(group.hubId) : null;
       return `<div class="ag2-group">
         <div class="ag2-group-head">
           <span class="ag2-group-label">${escapeHtml(group.label)}</span>
           <span class="ag2-group-hint">${escapeHtml(group.hint)}</span>
           ${hubLink}
         </div>
+        ${hub ? agendaPipelineStripHtml(hub) : ''}
         <div class="ag2-cards">${group.rows.map(agendaCardHtml).join('')}</div>
       </div>`;
     }).join('');
@@ -93137,14 +93296,26 @@ function agendaInspEffectHtml(item) {
       suspended: ['amber', `Suspended — ${e.consecutive_failures} failures in a row`],
       running: ['iris', 'Running now'],
       finished: ['neutral', 'Ran — outcome below'],
+      watching: ['sky', 'Watching for matching items'],
+      waiting: ['sky', 'Armed — fires when the prerequisites complete'],
+      ready: ['iris', 'Prerequisites complete — fires within the minute'],
     };
     const [tone, stateLabel] = states[st.kind] || states.finished;
     const rows = [];
     const R = (k, v, mono) =>
       rows.push(`<div class="ag2-eff-k">${escapeHtml(k)}</div><div class="ag2-eff-v${mono ? ' mono' : ''}">${escapeHtml(v)}</div>`);
-    R('when', st.rec
-      ? `every ${agendaCadenceLabel(st.rec.every_ms)} · next ${agendaAbsTime(st.next)}`
-      : `${agendaAbsTime(m.fire_at_ms)} (${agendaRelTime(m.fire_at_ms)})`);
+    if (st.trig) {
+      R('fires', st.trig.kind === 'on_item_match'
+        ? `when a NEW open ${st.trig.item_kind || 'item'} carries ${(st.trig.tags || []).length ? `tags ${st.trig.tags.join(', ')}` : 'the matched shape'} — arrivals batch for a minute`
+        : 'the moment every prerequisite completes — no clock involved');
+      if (!agendaDepthCalm()) {
+        R('guardrails', `arrivals coalesce · one occurrence in flight · suspends after ${st.threshold} failures in a row`);
+      }
+    } else {
+      R('when', st.rec
+        ? `every ${agendaCadenceLabel(st.rec.every_ms)} · next ${agendaAbsTime(st.next)}`
+        : `${agendaAbsTime(m.fire_at_ms)} (${agendaRelTime(m.fire_at_ms)})`);
+    }
     if (st.rec && (st.rec.until_ms || st.rec.max_occurrences)) {
       R('ends', `${st.rec.until_ms ? agendaAbsTime(st.rec.until_ms) : ''}${st.rec.max_occurrences ? `${st.rec.until_ms ? ' or ' : ''}after ${st.rec.max_occurrences} runs` : ''}`);
     }
@@ -93187,7 +93358,7 @@ function agendaInspEffectHtml(item) {
       A('Approve this exact plan', 'eff-approve', 'prim',
         `Binds digest ${String(e.digest || '').slice(0, 8)}… — any edit voids it`);
       A('Edit schedule…', 'sched');
-    } else if (st.kind === 'armed') {
+    } else if (['armed', 'watching', 'waiting', 'ready'].includes(st.kind)) {
       A('Edit (voids approval)', 'sched');
       A('Revoke approval', 'eff-revoke', 'danger', 'Instant, owner-surface only');
     } else if (st.kind === 'standing') {
@@ -95167,6 +95338,25 @@ function agendaPlanEvents() {
           'Consecutive non-success outcomes since the last approval')],
         note: 'nothing fires while suspended — re-approving the unchanged digest re-arms the series',
       });
+    } else if (st.kind === 'watching') {
+      const predicate = `${st.trig.item_kind || 'item'}${(st.trig.tags || []).length ? ` + ${st.trig.tags.join(',')}` : ''}`;
+      events.push({
+        at: now, item, what: 'watching for matching items', tone: 'sky', pulse: 'slow',
+        chips: [agendaChipHtml(predicate, 'sky',
+          'Fires when a NEW open item of this kind carries these tags — arrivals batch for a minute')],
+        note: null,
+      });
+    } else if (st.kind === 'waiting') {
+      events.push({
+        at: now, item, what: 'armed — fires on unblock', tone: 'sky', pulse: '',
+        chips: [],
+        note: 'fires the moment its prerequisites complete — no clock involved',
+      });
+    } else if (st.kind === 'ready') {
+      events.push({
+        at: now, item, what: 'prerequisites complete — fires within the minute',
+        tone: 'iris', pulse: 'fast', chips: [], note: null,
+      });
     }
     // Fire rows ride the SERVED planner instant exclusively: absent
     // means nothing will fire (unapproved, suspended, spent, exhausted),
@@ -96220,7 +96410,7 @@ function agendaPaletteEntries(query) {
 // ---- Workflow templates: stamp + one-gesture approval (Track T) ----
 // A workflow template stamps a small item-graph: an instance HUB whose
 // body is the workflow's living orientation document, N node items
-// placed under it, relies_on edges, and one on_unblock-triggered
+// placed under it, relies_on links, and one on_unblock-triggered
 // manifest per node. STAMPING parks and proposes only; the approval
 // sheet then previews the whole graph, and the owner's single confirm
 // emits one ordinary per-node approval op — the UI batches, the

--- a/static/app/ui2-agenda-cards.js
+++ b/static/app/ui2-agenda-cards.js
@@ -80,9 +80,16 @@ function agendaEnsureScaffold() {
             <h2 class="ag2-title">Agenda</h2>
             <p class="ag2-sub">Parked intent that outlives any one session — one ledger for this daemon, every project.</p>
           </div>
-          <button type="button" class="ag2-bell" id="ag2-bell" title="Reminder delivery policy — owner authority (settings.manage)">
-            ${typeof ui2Icon === 'function' ? ui2Icon('bell', 14) : ''}<span>Reminders</span><span class="ag2-bell-dot" id="ag2-bell-dot" hidden title="Quiet hours are active now"></span>
-          </button>
+          <div class="ag2-head-tools">
+            <div class="ag2-seg ag2-depth" id="ag2-depth" role="group" aria-label="How much machinery to show">
+              <button type="button" data-depth="calm" title="Just what needs you — machinery folded away">Calm</button>
+              <button type="button" data-depth="standard" title="The working view">Standard</button>
+              <button type="button" data-depth="everything" title="Ids, digests, raw op coordinates — the whole engine room">Everything</button>
+            </div>
+            <button type="button" class="ag2-bell" id="ag2-bell" title="Reminder delivery policy — owner authority (settings.manage)">
+              ${typeof ui2Icon === 'function' ? ui2Icon('bell', 14) : ''}<span>Reminders</span><span class="ag2-bell-dot" id="ag2-bell-dot" hidden title="Quiet hours are active now"></span>
+            </button>
+          </div>
         </div>
         <div class="ag2-compose">
           <div class="ag2-seg" id="ag2-kind-seg" role="group" aria-label="Kind">
@@ -125,6 +132,16 @@ function agendaEnsureScaffold() {
   agendaWireScaffold();
 }
 
+// The depth seg's active state lives on the persistent scaffold, so it
+// syncs directly (wire time and every agendaSetDepth) rather than
+// through the groups re-render.
+function agendaDepthSyncSeg() {
+  const seg = document.getElementById('ag2-depth');
+  if (!seg) return;
+  seg.querySelectorAll('button[data-depth]').forEach((btn) =>
+    btn.classList.toggle('active', btn.dataset.depth === agendaDepth));
+}
+
 function agendaWireScaffold() {
   const kindSeg = document.getElementById('ag2-kind-seg');
   const title = document.getElementById('ag2-compose-title');
@@ -165,6 +182,11 @@ function agendaWireScaffold() {
     e.stopPropagation();
     agendaBellToggle();
   });
+  document.getElementById('ag2-depth').addEventListener('click', (e) => {
+    const btn = e.target.closest('[data-depth]');
+    if (btn) agendaSetDepth(btn.dataset.depth);
+  });
+  agendaDepthSyncSeg();
   const groups = document.getElementById('ag2-groups');
   groups.addEventListener('click', agendaGroupsClick);
   groups.addEventListener('input', agendaGroupsInput);
@@ -630,14 +652,16 @@ function agendaCardChips(item) {
         'Render-level flag only — completion never cascades'));
     }
   }
+  // Machinery chips — folded away at calm depth (status, due, blocked,
+  // and attention states above always show).
   const triage = agendaTriageInfo(item);
-  if (triage) {
+  if (triage && !agendaDepthCalm()) {
     chips.push(agendaChipHtml(
       triage.rank !== null ? `triage #${triage.rank}` : 'triage',
       'iris', triage.text, true));
   }
   const mustReads = (item.refs || []).filter((r) => r.must_read).length;
-  if (mustReads) {
+  if (mustReads && !agendaDepthCalm()) {
     chips.push(agendaChipHtml(`${mustReads} must-read`, 'iris',
       'Typed pointers the reading agent weighs — never orders'));
   }
@@ -668,7 +692,7 @@ function agendaCardByline(item, opts) {
             : p.kind === 'peer' ? 'a peer daemon' : (p.kind || 'unattributed');
     by = `by <span title="${escapeHtml(tip)}">${escapeHtml(label)}</span>`;
   }
-  const selfDesc = p.source
+  const selfDesc = p.source && !agendaDepthCalm()
     ? '<span class="agenda-self-described" title="Self-described label — unverified, never an identity">· self-described</span>'
     : '';
   const bits = [
@@ -681,7 +705,7 @@ function agendaCardByline(item, opts) {
   if (hub && !opts.noHub) {
     bits.push(`<span>· in</span> <a class="ag2-hub-link" data-open-item="${escapeHtml(hub.id)}">${escapeHtml(hub.title.length > 34 ? `${hub.title.slice(0, 33)}…` : hub.title)}</a>`);
   }
-  (item.tags || []).slice(0, 3).forEach((tag) => {
+  (agendaDepthCalm() ? [] : (item.tags || []).slice(0, 3)).forEach((tag) => {
     bits.push(`<span class="ag2-tag">${escapeHtml(tag)}</span>`);
   });
   return bits.filter(Boolean).join(' ');
@@ -737,7 +761,9 @@ function agendaAutomationStripHtml(item) {
   const e = st.effect;
   const id = escapeHtml(item.id);
   const meta = [];
-  meta.push(`<span class="ag2-auto-exec" title="Executor — digest-bound like the rest of the manifest: editing it voids the approval">${escapeHtml(agendaExecutorLabel(st.manifest.agent_config))}</span>`);
+  if (!agendaDepthCalm()) {
+    meta.push(`<span class="ag2-auto-exec" title="Executor — digest-bound like the rest of the manifest: editing it voids the approval">${escapeHtml(agendaExecutorLabel(st.manifest.agent_config))}</span>`);
+  }
   meta.push(`<span>${escapeHtml(st.rec ? `every ${agendaCadenceLabel(st.rec.every_ms)}` : 'once')}</span>`);
   const last = e.last_run;
   if (last) {
@@ -1025,7 +1051,13 @@ function agendaCardHtml(row) {
   const item = row.item;
   const opts = row;
   const id = escapeHtml(item.id);
-  const blockedLine = agendaBlockedLine(item);
+  // Calm depth folds prerequisite-only wait lines (the blocked chip
+  // still shows); an explicit uncleared blocker always renders — it
+  // names what someone must do.
+  const blockedRaw = agendaBlockedLine(item);
+  const blockedLine = blockedRaw
+    && agendaDepthCalm() && !(item.blockers || []).some((b) => !b.cleared)
+    ? null : blockedRaw;
   const answerLine = opts.showAnswer && item.answer && item.answer.text
     ? `<div class="ag2-ansline">${escapeHtml(item.answer.text.length > 180 ? `${item.answer.text.slice(0, 180)}…` : item.answer.text)}</div>`
     : '';
@@ -1039,6 +1071,7 @@ function agendaCardHtml(row) {
       <div class="ag2-card-titlerow">
         <span class="ag2-card-title${item.status === 'done' ? ' done' : ''}${item.status !== 'open' ? ' dim' : ''}">${escapeHtml(item.title)}</span>
         ${agendaCardChips(item)}
+        ${agendaDepthAll() ? `<span class="ag2-ulid" title="ulid prefix — creation-ordered; the full id is on the item panel">${escapeHtml(item.id.slice(0, 10).toLowerCase())}</span>` : ''}
       </div>
       <div class="ag2-card-meta">${agendaCardByline(item, opts)}</div>
       ${blockedLine ? `<div class="ag2-blocked-line">${escapeHtml(blockedLine)}</div>` : ''}

--- a/static/app/ui2-agenda-cards.js
+++ b/static/app/ui2-agenda-cards.js
@@ -66,6 +66,14 @@ const AGENDA_COMPOSE_PLACEHOLDERS = {
 
 let agendaComposeKind = 'task';
 
+// Rich-ask composing (question kind only): the owner builds pick-one /
+// pick-many options inline and the compose bar parks `{op:'ask'}` — the
+// same durable rich-ask lane sessions use; options render on every
+// dashboard's question rail, nothing blocks, nothing expires.
+let agendaRichOn = false;
+let agendaRichOptions = [];
+let agendaRichMulti = false;
+
 // ---- Scaffold ----
 
 function agendaEnsureScaffold() {
@@ -99,6 +107,8 @@ function agendaEnsureScaffold() {
           </div>
           <input id="ag2-compose-title" type="text" maxlength="500" autocomplete="off"
                  placeholder="${escapeHtml(AGENDA_COMPOSE_PLACEHOLDERS.task)}" aria-label="New agenda item title" />
+          <button type="button" class="ag2-rich-toggle" id="ag2-rich-toggle" hidden
+                  title="Give the owner options to pick from — the question still parks durably and resolves everywhere">+ options</button>
           <select id="ag2-compose-due" aria-label="Reminder"
                   title="A due time delivers a reminder to you — it never authorizes work">
             <option value="">No reminder</option>
@@ -108,6 +118,7 @@ function agendaEnsureScaffold() {
             <option value="mon">Next Monday 09:00</option>
           </select>
           <button type="button" class="ag2-park" id="ag2-park">Park</button>
+          <div class="ag2-rich-row" id="ag2-rich-row" hidden></div>
         </div>
         <div class="ag2-lensbar">
           <div class="ag2-seg ag2-lenses" id="ag2-lenses" role="tablist" aria-label="Agenda lens"></div>
@@ -132,6 +143,29 @@ function agendaEnsureScaffold() {
   agendaWireScaffold();
 }
 
+// ---- Rich-ask compose row (persistent scaffold; re-rendered on state) ----
+
+function agendaRichRowRender() {
+  const row = document.getElementById('ag2-rich-row');
+  const toggle = document.getElementById('ag2-rich-toggle');
+  if (!row || !toggle) return;
+  const isQuestion = agendaComposeKind === 'question';
+  toggle.hidden = !isQuestion;
+  toggle.classList.toggle('on', agendaRichOn);
+  row.hidden = !isQuestion || !agendaRichOn;
+  if (row.hidden) {
+    row.innerHTML = '';
+    return;
+  }
+  const chips = agendaRichOptions.map((label, i) =>
+    `<span class="ag2-rich-chip">${escapeHtml(label)}<button type="button" data-rich-remove="${i}" title="Remove option">×</button></span>`).join('');
+  row.innerHTML = `<span class="ag2-rich-eyebrow">Options</span>
+    ${chips}
+    <input type="text" maxlength="80" id="ag2-rich-draft" placeholder="Add an option, press Enter…" aria-label="Add an option" />
+    <button type="button" id="ag2-rich-multi" class="${agendaRichMulti ? 'on' : ''}" title="Allow picking more than one option">pick many</button>
+    <span class="ag2-rich-hint">Parks as a rich ask — options render on every dashboard’s question rail; nothing blocks, nothing expires.</span>`;
+}
+
 // The depth seg's active state lives on the persistent scaffold, so it
 // syncs directly (wire time and every agendaSetDepth) rather than
 // through the groups re-render.
@@ -152,7 +186,43 @@ function agendaWireScaffold() {
         b.classList.toggle('active', b === btn));
       title.placeholder = AGENDA_COMPOSE_PLACEHOLDERS[agendaComposeKind]
         || AGENDA_COMPOSE_PLACEHOLDERS.task;
+      agendaRichRowRender();
     });
+  });
+  document.getElementById('ag2-rich-toggle').addEventListener('click', () => {
+    agendaRichOn = !agendaRichOn;
+    agendaRichRowRender();
+    const draft = document.getElementById('ag2-rich-draft');
+    if (draft) draft.focus();
+  });
+  const richRow = document.getElementById('ag2-rich-row');
+  richRow.addEventListener('click', (e) => {
+    const remove = e.target.closest('[data-rich-remove]');
+    if (remove) {
+      agendaRichOptions.splice(Number(remove.dataset.richRemove), 1);
+      agendaRichRowRender();
+      return;
+    }
+    if (e.target.closest('#ag2-rich-multi')) {
+      agendaRichMulti = !agendaRichMulti;
+      agendaRichRowRender();
+    }
+  });
+  richRow.addEventListener('keydown', (e) => {
+    if (e.key !== 'Enter' || !e.target.closest('#ag2-rich-draft')) return;
+    e.preventDefault();
+    const draft = e.target;
+    const label = (draft.value || '').trim();
+    if (!label || agendaRichOptions.includes(label)) return;
+    if (agendaRichOptions.length >= 4) {
+      agendaFlashError('Four options at most — the rail renders up to four.');
+      return;
+    }
+    agendaRichOptions.push(label);
+    draft.value = '';
+    agendaRichRowRender();
+    const next = document.getElementById('ag2-rich-draft');
+    if (next) next.focus();
   });
   document.getElementById('ag2-park').addEventListener('click', agendaComposePark);
   title.addEventListener('keydown', (e) => {
@@ -256,16 +326,47 @@ async function agendaComposePark() {
     title.focus();
     return;
   }
-  const params = { op: 'add', kind: agendaComposeKind, title: text };
+  const rich = agendaComposeKind === 'question' && agendaRichOn
+    && agendaRichOptions.length > 0;
   const dueMs = agendaDuePresetMs(due.value);
-  if (dueMs) params.due_ms = dueMs;
+  let params;
+  if (rich) {
+    // The same durable rich-ask lane sessions use (AgendaCommand::Ask):
+    // the daemon mints the item and the rail ask_id; options land on
+    // every dashboard's question rail. A due reminder rides a follow-up
+    // patch — the ask command deliberately carries no reminder field.
+    params = {
+      op: 'ask',
+      questions: [{
+        question: text,
+        options: agendaRichOptions.map((label) => ({ label })),
+        pick_max: agendaRichMulti ? agendaRichOptions.length : 1,
+      }],
+    };
+  } else {
+    params = { op: 'add', kind: agendaComposeKind, title: text };
+    if (dueMs) params.due_ms = dueMs;
+  }
   const ok = await agendaSendOp(params, btn);
   if (ok) {
+    if (rich && dueMs && ok.id) {
+      // The reminder rides a follow-up patch on the minted item — the
+      // ask command itself deliberately carries no reminder field.
+      await agendaSendOp({ op: 'patch', id: ok.id, patch: { due_ms: dueMs } });
+    }
     title.value = '';
     due.value = '';
     title.focus();
+    if (rich) {
+      agendaRichOptions = [];
+      agendaRichMulti = false;
+      agendaRichOn = false;
+      agendaRichRowRender();
+    }
     if (typeof showControlToast === 'function') {
-      showControlToast('success', `Parked${dueMs ? ' — reminder set' : ''}.`);
+      showControlToast('success', rich
+        ? `Parked as a rich ask — ${params.questions[0].options.length} options on the question rail.`
+        : `Parked${dueMs ? ' — reminder set' : ''}.`);
     }
   }
 }

--- a/static/app/ui2-agenda-cards.js
+++ b/static/app/ui2-agenda-cards.js
@@ -637,6 +637,16 @@ function agendaCardChips(item) {
         `One approval covers the series · next ${agendaAbsTime(st.next)}`));
     } else if (st.kind === 'armed') {
       chips.push(agendaChipHtml('armed', 'sky', `Fires ${agendaAbsTime(st.next)}`));
+    } else if (st.kind === 'watching') {
+      const predicate = `${st.trig.item_kind || 'item'}${(st.trig.tags || []).length ? ` + ${st.trig.tags.join(',')}` : ''}`;
+      chips.push(agendaChipHtml(agendaDepthCalm() ? 'watching' : `watching · ${predicate}`, 'sky',
+        'Fires when a NEW open item matches — arrivals batch for a minute'));
+    } else if (st.kind === 'waiting') {
+      chips.push(agendaChipHtml('auto · on unblock', 'sky',
+        'Armed — fires the moment every prerequisite completes; no one has to remember', true));
+    } else if (st.kind === 'ready') {
+      chips.push(agendaChipHtml('fires momentarily', 'iris',
+        'Prerequisites complete — the scheduler dispatches within the minute'));
     }
   }
   const kids = agendaChildrenOf(item.id);
@@ -764,7 +774,9 @@ function agendaAutomationStripHtml(item) {
   if (!agendaDepthCalm()) {
     meta.push(`<span class="ag2-auto-exec" title="Executor — digest-bound like the rest of the manifest: editing it voids the approval">${escapeHtml(agendaExecutorLabel(st.manifest.agent_config))}</span>`);
   }
-  meta.push(`<span>${escapeHtml(st.rec ? `every ${agendaCadenceLabel(st.rec.every_ms)}` : 'once')}</span>`);
+  meta.push(`<span>${escapeHtml(st.trig
+    ? (st.trig.kind === 'on_item_match' ? 'on matching items' : 'on unblock')
+    : st.rec ? `every ${agendaCadenceLabel(st.rec.every_ms)}` : 'once')}</span>`);
   const last = e.last_run;
   if (last) {
     const tip = `${last.state}${last.note ? ` — ${last.note}` : ''}`;
@@ -796,13 +808,73 @@ function agendaAutomationStripHtml(item) {
   } else if (st.kind === 'standing' && e.next_fire_ms) {
     actions = `<button type="button" class="ag2-btn ghost" data-op-btn="request_occurrence" data-id="${id}" title="One extra occurrence of the approved digest — the standing approval is untouched">Run now</button>`
       + `<button type="button" class="ag2-btn ghost" data-op-btn="revoke_effect" data-id="${id}" title="Withdraws the approval; the manifest and history stay">Revoke</button>`;
-  } else if (st.kind === 'armed') {
+  } else if (['armed', 'watching', 'waiting', 'ready'].includes(st.kind)) {
     actions = `<button type="button" class="ag2-btn ghost" data-op-btn="revoke_effect" data-id="${id}" title="Withdraws the approval; the manifest and history stay">Revoke</button>`;
   }
   return `<div class="ag2-eff ag2-auto t-${st.kind === 'pending' || st.kind === 'suspended' ? 'amber' : 'iris'}">
     <span class="ag2-auto-meta">${meta.join('<span class="ag2-auto-dot">·</span>')}</span>
     <span class="ag2-spacer"></span>${actions}
   </div>`;
+}
+
+// ---- Workflow pipeline strip (hub cards + the hubs lens) ----
+
+// A hub reads as a pipeline when at least two children carry
+// on_unblock-triggered manifests — the workflow stamp's shape, DERIVED
+// from the graph every paint; no workflow-level object or marker exists
+// anywhere (Track T's contract).
+function agendaPipelineNodes(hub) {
+  const kids = agendaChildrenOf(hub.id).filter((k) =>
+    (k.effects || []).some((e) => e.manifest && e.manifest.trigger
+      && e.manifest.trigger.kind === 'on_unblock'));
+  if (kids.length < 2) return null;
+  // relies_on topological order within the set (bounded passes; a cycle
+  // or cross-hub dependency appends in creation order at the tail).
+  const inSet = new Set(kids.map((k) => k.id));
+  const order = [];
+  const placed = new Set();
+  for (let pass = 0; pass < kids.length && order.length < kids.length; pass++) {
+    kids.forEach((k) => {
+      if (placed.has(k.id)) return;
+      const deps = (k.relies_on || []).map((l) => l.target_id).filter((id) => inSet.has(id));
+      if (deps.every((id) => placed.has(id))) {
+        placed.add(k.id);
+        order.push(k);
+      }
+    });
+  }
+  kids.forEach((k) => { if (!placed.has(k.id)) order.push(k); });
+  return order;
+}
+
+function agendaPipelineStripHtml(hub) {
+  const nodes = agendaPipelineNodes(hub);
+  if (!nodes) return '';
+  const cells = nodes.map((node, i) => {
+    const st = agendaEffectState(node);
+    let tone = 'neutral';
+    let state = 'parked';
+    let pulse = '';
+    if (node.status === 'done') { tone = 'green'; state = 'done'; }
+    else if (node.status === 'retired') { state = 'retired'; }
+    else if (st) {
+      if (st.kind === 'running') { tone = 'iris'; state = 'running'; pulse = 'fast'; }
+      else if (st.kind === 'ready') { tone = 'iris'; state = 'fires momentarily'; pulse = 'slow'; }
+      else if (st.kind === 'waiting') { tone = 'sky'; state = 'waiting on prerequisites'; }
+      else if (st.kind === 'pending') { tone = 'amber'; state = 'needs approval'; }
+      else if (st.kind === 'suspended') { tone = 'amber'; state = `suspended · ${st.effect.consecutive_failures} failures`; }
+      else { state = st.kind; }
+    }
+    const exec = st && !agendaDepthCalm() ? agendaExecutorLabel(st.manifest.agent_config) : '';
+    const arrow = i ? '<span class="ag2-pipe-arrow" aria-hidden="true">→</span>' : '';
+    const title = String(node.title || '');
+    return `${arrow}<button type="button" class="ag2-pipe-node" data-open-item="${escapeHtml(node.id)}" title="${escapeHtml(`${title} — ${state}`)}">
+      <span class="ag2-pipe-head"><span class="ag2-pipe-dot t-${tone}${pulse ? ` pulse ${pulse}` : ''}"></span><span class="ag2-pipe-title">${escapeHtml(title.length > 22 ? `${title.slice(0, 21)}…` : title)}</span></span>
+      <span class="ag2-pipe-state">${escapeHtml(state)}</span>
+      ${exec ? `<span class="ag2-pipe-exec">${escapeHtml(exec)}</span>` : ''}
+    </button>`;
+  });
+  return `<div class="ag2-pipeline">${cells.join('')}</div>`;
 }
 
 // ---- Inline question answering ----
@@ -1075,6 +1147,7 @@ function agendaCardHtml(row) {
       </div>
       <div class="ag2-card-meta">${agendaCardByline(item, opts)}</div>
       ${blockedLine ? `<div class="ag2-blocked-line">${escapeHtml(blockedLine)}</div>` : ''}
+      ${agendaPipelineStripHtml(item)}
       ${opts.automation ? agendaAutomationStripHtml(item) : agendaCardEffectStrip(item)}
       ${qa}${answerLine}
     </div>
@@ -1173,12 +1246,14 @@ function agendaRenderTab() {
       const hubLink = group.hubId
         ? `<a class="ag2-hub-open" data-open-item="${escapeHtml(group.hubId)}">open the hub ›</a>`
         : '';
+      const hub = group.hubId ? agendaFindItem(group.hubId) : null;
       return `<div class="ag2-group">
         <div class="ag2-group-head">
           <span class="ag2-group-label">${escapeHtml(group.label)}</span>
           <span class="ag2-group-hint">${escapeHtml(group.hint)}</span>
           ${hubLink}
         </div>
+        ${hub ? agendaPipelineStripHtml(hub) : ''}
         <div class="ag2-cards">${group.rows.map(agendaCardHtml).join('')}</div>
       </div>`;
     }).join('');

--- a/static/app/ui2-agenda-diary.js
+++ b/static/app/ui2-agenda-diary.js
@@ -205,7 +205,8 @@ function agendaDiaryRowHtml(entry) {
       <span class="ag2-plan-time">${escapeHtml(envelope.at_ms ? agendaPlanHm(envelope.at_ms) : '—')}</span>
       <span class="ag2-diary-verb">${escapeHtml(verb)}</span>
       ${target}
-      ${who ? `<span class="ag2-diary-who">${escapeHtml(`by ${who}`)}</span>` : ''}
+      ${who && !agendaDepthCalm() ? `<span class="ag2-diary-who">${escapeHtml(`by ${who}`)}</span>` : ''}
+      ${agendaDepthAll() ? `<span class="ag2-diary-raw">${escapeHtml(raw)}</span>` : ''}
     </div>
   </div>`;
 }
@@ -234,7 +235,9 @@ function agendaDiarySegHtml() {
        class="${agendaDiaryFilter === id ? 'active' : ''}">${escapeHtml(label)}</button>`).join('');
   return `<div class="ag2-diary-bar">
     <div class="ag2-seg ag2-diary-seg" role="group" aria-label="Diary filter">${buttons}</div>
-    <span class="ag2-diary-hint">attributed, append-only — dismissals, failures, and revocations included</span>
+    <span class="ag2-diary-hint">${agendaDepthCalm()
+    ? 'what happened, day by day'
+    : 'attributed, append-only — dismissals, failures, and revocations included'}</span>
   </div>`;
 }
 

--- a/static/app/ui2-agenda-inspector.js
+++ b/static/app/ui2-agenda-inspector.js
@@ -83,7 +83,7 @@ function agendaInspectorRender() {
         ${agendaInspPrStateHtml(item)}
         ${agendaInspRefsHtml(item)}
         ${agendaInspThreadHtml(item)}
-        ${agendaHoodSectionHtml(item)}
+        ${agendaDepthCalm() ? '' : agendaHoodSectionHtml(item)}
       </div>
     </div>`;
   });
@@ -382,11 +382,15 @@ function agendaInspEffectHtml(item) {
       R('ends', `${st.rec.until_ms ? agendaAbsTime(st.rec.until_ms) : ''}${st.rec.max_occurrences ? `${st.rec.until_ms ? ' or ' : ''}after ${st.rec.max_occurrences} runs` : ''}`);
     }
     R('shape', `${m.interactive ? 'interactive — opens and waits for you' : 'goal run — autonomous, writes back'} · ${m.orchestrate ? 'orchestrated' : 'direct'}`);
-    R('project', m.project_root || 'inherited at fire time: parking session’s root, else daemon default', !!m.project_root);
-    const cfg = m.agent_config || null;
-    R('config', cfg
-      ? `${[cfg.agent, ...Object.entries(cfg).filter(([k]) => k !== 'agent').map(([, v]) => v)].filter(Boolean).join(' · ')} — explicit, recorded on the manifest`
-      : 'inherits daemon defaults (Settings → reasoning)', !!cfg);
+    // Manifest plumbing rows fold away at calm depth; the sealed facts
+    // stay one depth notch (or the raw sheet) away.
+    if (!agendaDepthCalm()) {
+      R('project', m.project_root || 'inherited at fire time: parking session’s root, else daemon default', !!m.project_root);
+      const cfg = m.agent_config || null;
+      R('config', cfg
+        ? `${[cfg.agent, ...Object.entries(cfg).filter(([k]) => k !== 'agent').map(([, v]) => v)].filter(Boolean).join(' · ')} — explicit, recorded on the manifest`
+        : 'inherits daemon defaults (Settings → reasoning)', !!cfg);
+    }
     if (st.rec) {
       R('on failure', `suspend after ${st.threshold} failed runs in a row — surfaced, never silently re-fired`);
     }
@@ -403,7 +407,7 @@ function agendaInspEffectHtml(item) {
       lastRun = `<div class="ag2-eff-lastrun">
         <div class="ag2-eff-lastrun-head">
           ${agendaChipHtml(`last run · ${run.state}`, runTone)}
-          <span class="ag2-hint">${escapeHtml(`${agendaRelTime(run.at_ms)} · occurrence ${run.occurrence_id}`)}</span>
+          <span class="ag2-hint">${escapeHtml(agendaDepthCalm() ? agendaRelTime(run.at_ms) : `${agendaRelTime(run.at_ms)} · occurrence ${run.occurrence_id}`)}</span>
           ${sessionLink}
         </div>
         ${run.note ? `<div class="ag2-eff-note">${escapeHtml(run.note)}</div>` : ''}
@@ -439,10 +443,12 @@ function agendaInspEffectHtml(item) {
         <span class="ag2-eff-dot"></span>
         <span class="ag2-eff-state">${escapeHtml(stateLabel)}</span>
         <span class="ag2-spacer"></span>
-        <span class="ag2-hint mono">digest ${escapeHtml(String(e.digest || '').slice(0, 10))}…${e.approval ? ' · approved' : ' · unapproved'}</span>
+        <span class="ag2-hint mono">${agendaDepthCalm()
+    ? (e.approval ? 'approved' : 'unapproved')
+    : `digest ${escapeHtml(String(e.digest || '').slice(0, 10))}…${e.approval ? ' · approved' : ' · unapproved'}`}</span>
       </div>
       <div class="ag2-eff-grid">${rows.join('')}</div>
-      <div class="ag2-eff-goal">${escapeHtml(m.goal || '')}</div>
+      ${agendaDepthCalm() ? '' : `<div class="ag2-eff-goal">${escapeHtml(m.goal || '')}</div>`}
       ${lastRun}
       ${acts.length ? `<div class="ag2-insp-actions">${acts.join('')}</div>` : ''}
     </div>`;

--- a/static/app/ui2-agenda-inspector.js
+++ b/static/app/ui2-agenda-inspector.js
@@ -370,14 +370,26 @@ function agendaInspEffectHtml(item) {
       suspended: ['amber', `Suspended — ${e.consecutive_failures} failures in a row`],
       running: ['iris', 'Running now'],
       finished: ['neutral', 'Ran — outcome below'],
+      watching: ['sky', 'Watching for matching items'],
+      waiting: ['sky', 'Armed — fires when the prerequisites complete'],
+      ready: ['iris', 'Prerequisites complete — fires within the minute'],
     };
     const [tone, stateLabel] = states[st.kind] || states.finished;
     const rows = [];
     const R = (k, v, mono) =>
       rows.push(`<div class="ag2-eff-k">${escapeHtml(k)}</div><div class="ag2-eff-v${mono ? ' mono' : ''}">${escapeHtml(v)}</div>`);
-    R('when', st.rec
-      ? `every ${agendaCadenceLabel(st.rec.every_ms)} · next ${agendaAbsTime(st.next)}`
-      : `${agendaAbsTime(m.fire_at_ms)} (${agendaRelTime(m.fire_at_ms)})`);
+    if (st.trig) {
+      R('fires', st.trig.kind === 'on_item_match'
+        ? `when a NEW open ${st.trig.item_kind || 'item'} carries ${(st.trig.tags || []).length ? `tags ${st.trig.tags.join(', ')}` : 'the matched shape'} — arrivals batch for a minute`
+        : 'the moment every prerequisite completes — no clock involved');
+      if (!agendaDepthCalm()) {
+        R('guardrails', `arrivals coalesce · one occurrence in flight · suspends after ${st.threshold} failures in a row`);
+      }
+    } else {
+      R('when', st.rec
+        ? `every ${agendaCadenceLabel(st.rec.every_ms)} · next ${agendaAbsTime(st.next)}`
+        : `${agendaAbsTime(m.fire_at_ms)} (${agendaRelTime(m.fire_at_ms)})`);
+    }
     if (st.rec && (st.rec.until_ms || st.rec.max_occurrences)) {
       R('ends', `${st.rec.until_ms ? agendaAbsTime(st.rec.until_ms) : ''}${st.rec.max_occurrences ? `${st.rec.until_ms ? ' or ' : ''}after ${st.rec.max_occurrences} runs` : ''}`);
     }
@@ -420,7 +432,7 @@ function agendaInspEffectHtml(item) {
       A('Approve this exact plan', 'eff-approve', 'prim',
         `Binds digest ${String(e.digest || '').slice(0, 8)}… — any edit voids it`);
       A('Edit schedule…', 'sched');
-    } else if (st.kind === 'armed') {
+    } else if (['armed', 'watching', 'waiting', 'ready'].includes(st.kind)) {
       A('Edit (voids approval)', 'sched');
       A('Revoke approval', 'eff-revoke', 'danger', 'Instant, owner-surface only');
     } else if (st.kind === 'standing') {

--- a/static/app/ui2-agenda-plan.js
+++ b/static/app/ui2-agenda-plan.js
@@ -199,6 +199,25 @@ function agendaPlanEvents() {
           'Consecutive non-success outcomes since the last approval')],
         note: 'nothing fires while suspended — re-approving the unchanged digest re-arms the series',
       });
+    } else if (st.kind === 'watching') {
+      const predicate = `${st.trig.item_kind || 'item'}${(st.trig.tags || []).length ? ` + ${st.trig.tags.join(',')}` : ''}`;
+      events.push({
+        at: now, item, what: 'watching for matching items', tone: 'sky', pulse: 'slow',
+        chips: [agendaChipHtml(predicate, 'sky',
+          'Fires when a NEW open item of this kind carries these tags — arrivals batch for a minute')],
+        note: null,
+      });
+    } else if (st.kind === 'waiting') {
+      events.push({
+        at: now, item, what: 'armed — fires on unblock', tone: 'sky', pulse: '',
+        chips: [],
+        note: 'fires the moment its prerequisites complete — no clock involved',
+      });
+    } else if (st.kind === 'ready') {
+      events.push({
+        at: now, item, what: 'prerequisites complete — fires within the minute',
+        tone: 'iris', pulse: 'fast', chips: [], note: null,
+      });
     }
     // Fire rows ride the SERVED planner instant exclusively: absent
     // means nothing will fire (unapproved, suspended, spent, exhausted),

--- a/static/app/ui2-agenda-workflows.js
+++ b/static/app/ui2-agenda-workflows.js
@@ -1,7 +1,7 @@
 // ---- Workflow templates: stamp + one-gesture approval (Track T) ----
 // A workflow template stamps a small item-graph: an instance HUB whose
 // body is the workflow's living orientation document, N node items
-// placed under it, relies_on edges, and one on_unblock-triggered
+// placed under it, relies_on links, and one on_unblock-triggered
 // manifest per node. STAMPING parks and proposes only; the approval
 // sheet then previews the whole graph, and the owner's single confirm
 // emits one ordinary per-node approval op — the UI batches, the

--- a/static/app/ui2-agenda.css
+++ b/static/app/ui2-agenda.css
@@ -51,6 +51,19 @@ html.ui-v2 .ag2-sub {
   font-size: 13px;
   color: var(--text-2);
 }
+html.ui-v2 .ag2-head-tools {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  flex-shrink: 0;
+  margin-top: 4px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+html.ui-v2 .ag2-depth button {
+  padding: 5px 12px;
+  font-size: 12px;
+}
 html.ui-v2 .ag2-bell {
   display: inline-flex;
   align-items: center;
@@ -64,7 +77,6 @@ html.ui-v2 .ag2-bell {
   padding: 6px 11px;
   cursor: pointer;
   flex-shrink: 0;
-  margin-top: 4px;
 }
 html.ui-v2 .ag2-bell:hover {
   border-color: var(--line-2);
@@ -1000,6 +1012,17 @@ html.ui-v2 .ag2-diary-item.plain {
 html.ui-v2 .ag2-diary-who {
   font-size: 11px;
   color: var(--text-3);
+}
+html.ui-v2 .ag2-diary-raw {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  color: var(--text-3);
+}
+html.ui-v2 .ag2-ulid {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  color: var(--text-3);
+  white-space: nowrap;
 }
 
 /* ---- Empty state + footer ledger ---- */

--- a/static/app/ui2-agenda.css
+++ b/static/app/ui2-agenda.css
@@ -96,11 +96,94 @@ html.ui-v2 .ag2-compose {
   display: flex;
   gap: 8px;
   align-items: center;
+  flex-wrap: wrap;
   padding: 10px;
   border: 1px solid var(--line);
   border-radius: 13px;
   background: var(--surface);
   margin: 16px 0 12px;
+}
+html.ui-v2 .ag2-rich-toggle {
+  background: none;
+  border: 1px dashed var(--line-2);
+  border-radius: 999px;
+  color: var(--text-3);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 3px 11px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+html.ui-v2 .ag2-rich-toggle:hover,
+html.ui-v2 .ag2-rich-toggle.on {
+  border-color: var(--iris);
+  color: var(--iris-2);
+}
+html.ui-v2 .ag2-rich-row {
+  flex-basis: 100%;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  flex-wrap: wrap;
+  border-top: 1px solid var(--line);
+  padding-top: 9px;
+}
+html.ui-v2 .ag2-rich-eyebrow {
+  font-family: var(--mono);
+  font-size: var(--eyebrow-size);
+  font-weight: 700;
+  letter-spacing: var(--eyebrow-track);
+  text-transform: uppercase;
+  color: var(--text-3);
+}
+html.ui-v2 .ag2-rich-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: 1px solid var(--line);
+  background: var(--surface-2);
+  color: var(--text-2);
+  border-radius: 999px;
+  padding: 3px 6px 3px 11px;
+  font-size: 12px;
+  font-weight: 600;
+}
+html.ui-v2 .ag2-rich-chip button {
+  background: none;
+  border: 0;
+  color: var(--text-3);
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 3px;
+}
+html.ui-v2 .ag2-rich-chip button:hover {
+  color: var(--rose);
+}
+html.ui-v2 .ag2-rich-row input {
+  flex: 0 1 200px;
+  border-radius: 999px;
+  font-size: 12px;
+  padding: 4px 11px;
+}
+html.ui-v2 #ag2-rich-multi {
+  background: none;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--text-3);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 3px 11px;
+  cursor: pointer;
+}
+html.ui-v2 #ag2-rich-multi.on {
+  border-color: var(--iris);
+  color: var(--iris-2);
+  background: var(--surface-2);
+}
+html.ui-v2 .ag2-rich-hint {
+  font-size: 10.5px;
+  color: var(--text-3);
 }
 html.ui-v2 .ag2-compose input {
   flex: 1;

--- a/static/app/ui2-agenda.css
+++ b/static/app/ui2-agenda.css
@@ -1025,6 +1025,79 @@ html.ui-v2 .ag2-ulid {
   white-space: nowrap;
 }
 
+/* ---- Workflow pipeline strip: node chains on hub cards + the hubs
+   lens. Dots are static siblings (unlike the timeline's absolute
+   .ag2-plan-dot), so they carry their own tone classes; pulse rides the
+   shared ui2-pulse keyframes. ---- */
+
+html.ui-v2 .ag2-pipeline {
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+  margin: 5px 0 4px;
+  overflow-x: auto;
+  padding-bottom: 2px;
+}
+html.ui-v2 .ag2-pipe-node {
+  flex: 1;
+  min-width: 116px;
+  border: 1px solid var(--line);
+  background: var(--surface);
+  border-radius: 9px;
+  padding: 6px 9px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  align-items: flex-start;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+}
+html.ui-v2 .ag2-pipe-node:hover {
+  border-color: var(--line-2);
+  background: var(--surface-2);
+}
+html.ui-v2 .ag2-pipe-arrow {
+  align-self: center;
+  color: var(--text-3);
+  padding: 0 5px;
+  font-size: 12px;
+  flex-shrink: 0;
+}
+html.ui-v2 .ag2-pipe-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+html.ui-v2 .ag2-pipe-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+html.ui-v2 .ag2-pipe-dot.t-sky { background: var(--sky); }
+html.ui-v2 .ag2-pipe-dot.t-iris { background: var(--iris); }
+html.ui-v2 .ag2-pipe-dot.t-amber { background: var(--amber); }
+html.ui-v2 .ag2-pipe-dot.t-green { background: var(--green); }
+html.ui-v2 .ag2-pipe-dot.t-rose { background: var(--rose); }
+html.ui-v2 .ag2-pipe-dot.t-neutral { background: var(--neutral-dot); }
+html.ui-v2 .ag2-pipe-dot.pulse.slow { animation: ui2-pulse 2s ease-in-out infinite; }
+html.ui-v2 .ag2-pipe-dot.pulse.fast { animation: ui2-pulse 1.3s ease-in-out infinite; }
+html.ui-v2 .ag2-pipe-title {
+  font-size: 11.5px;
+  font-weight: 700;
+  color: var(--text);
+}
+html.ui-v2 .ag2-pipe-state {
+  font-size: 10px;
+  color: var(--text-3);
+}
+html.ui-v2 .ag2-pipe-exec {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  color: var(--text-3);
+}
+
 /* ---- Empty state + footer ledger ---- */
 
 html.ui-v2 .ag2-empty {

--- a/static/app/ui2-agenda.js
+++ b/static/app/ui2-agenda.js
@@ -263,9 +263,10 @@ async function agendaSendOp(params, button) {
     const resp = await daemonApi.request('api_agenda_op', params);
     if (resp.ok && resp.body && resp.body.item) {
       // The event lane repaints too; merging here keeps the UI honest
-      // even if this tab's event socket is briefly down.
+      // even if this tab's event socket is briefly down. Returns the
+      // item (truthy) so multi-op gestures can chain on the minted id.
       agendaObserveServerMessage({ item: resp.body.item });
-      return true;
+      return resp.body.item;
     }
     const message = (resp.body && resp.body.error) || `agenda op failed (${resp.status})`;
     agendaFlashError(message);

--- a/static/app/ui2-agenda.js
+++ b/static/app/ui2-agenda.js
@@ -41,6 +41,30 @@ const agendaExpandedThreads = new Set();
 // ---- Lens + inspector view state (the redesigned tab). Ephemeral
 // browser state — never persisted, never on the wire.
 let agendaLens = 'now';
+
+// Progressive-disclosure depth for the whole tab — a persisted
+// presentation preference, never wire state: calm folds the machinery
+// away (triage/must-read chips, tags, exec labels, manifest plumbing,
+// the hood), standard is the working view, everything adds ids and raw
+// op coordinates inline. Gates read agendaDepthCalm()/agendaDepthAll()
+// at render time.
+let agendaDepth = 'standard';
+try {
+  const savedDepth = localStorage.getItem('ui2.agenda.depth');
+  if (['calm', 'standard', 'everything'].includes(savedDepth)) agendaDepth = savedDepth;
+} catch { /* storage unavailable — session-local default */ }
+
+function agendaDepthCalm() { return agendaDepth === 'calm'; }
+function agendaDepthAll() { return agendaDepth === 'everything'; }
+
+function agendaSetDepth(depth) {
+  if (!['calm', 'standard', 'everything'].includes(depth) || depth === agendaDepth) return;
+  agendaDepth = depth;
+  try { localStorage.setItem('ui2.agenda.depth', depth); } catch { /* session-local */ }
+  agendaDepthSyncSeg();
+  agendaRenderTab();
+  if (typeof agendaInspectorRender === 'function') agendaInspectorRender();
+}
 let agendaSearch = '';
 let agendaFilterBlocked = false;
 let agendaFilterFrontier = false;

--- a/static/app/ui2-agenda.js
+++ b/static/app/ui2-agenda.js
@@ -338,16 +338,24 @@ function agendaBlockedLine(item) {
 }
 
 // The item's scheduled-session effect, judged for render: kind is one of
-// running | suspended | pending | standing | armed | finished. Mirrors
-// the daemon's fold judgments (AgendaEffect::suspended, the scheduler's
-// next-instant derivation) — derived here every paint, never stored.
+// running | suspended | pending | standing | armed | finished, plus the
+// trigger vocabulary (Track T manifests carry `trigger` INSTEAD of a
+// clock cadence): watching (on_item_match, approved), waiting
+// (on_unblock, prerequisites still open), ready (on_unblock, every
+// prerequisite complete — the scheduler dispatches within the minute).
+// Mirrors the daemon's fold judgments (AgendaEffect::suspended, the
+// scheduler's next-instant derivation, the trigger arm rules) — derived
+// here every paint, never stored.
 function agendaEffectState(item) {
   const effect = (item.effects || [])[0];
   if (!effect || !effect.manifest) return null;
   const manifest = effect.manifest;
   const rec = manifest.recurrence || null;
-  const threshold = rec ? Math.max(1, rec.suspend_after_failures || 3) : 0;
-  const suspended = !!rec && (effect.consecutive_failures || 0) >= threshold;
+  const trig = manifest.trigger || null;
+  // Failure-suspend covers standing series AND triggered mandates (the
+  // C-floor guardrail); one-shot clock manifests never suspend.
+  const threshold = rec || trig ? Math.max(1, (rec && rec.suspend_after_failures) || 3) : 0;
+  const suspended = !!(rec || trig) && (effect.consecutive_failures || 0) >= threshold;
   const running = !!(effect.last_run && effect.last_run.state === 'started');
   // The daemon decorates each effect with the planner's REAL next firing
   // instant (`next_fire_ms`, absent when nothing will fire) — prefer it
@@ -361,9 +369,12 @@ function agendaEffectState(item) {
   const kind = running ? 'running'
     : suspended ? 'suspended'
       : !effect.approval ? 'pending'
-        : rec ? 'standing'
-          : next > Date.now() ? 'armed' : 'finished';
-  return { effect, manifest, rec, threshold, suspended, running, next, kind };
+        : trig ? (trig.kind === 'on_item_match' ? 'watching'
+          : (item.relies_on || []).every((link) => agendaLinkState(link).satisfied)
+            ? 'ready' : 'waiting')
+          : rec ? 'standing'
+            : next > Date.now() ? 'armed' : 'finished';
+  return { effect, manifest, rec, trig, threshold, suspended, running, next, kind };
 }
 
 // One-line executor description for a manifest's `agent_config` block:


### PR DESCRIPTION
Slices 2-4 of the owner-commissioned Agenda Dashboard prototype implementation (slice 1 = the Diary lens, #610). Three commits, separately readable; stacked same-file work in ui2-agenda* so they ride one PR. Program ledger: ~/track-ux-ledger.md; seat guest-track-ux-impl.

**Depth dial (commit 1)** — Calm / Standard / Everything progressive disclosure, one persisted presentation dial (localStorage, never wire state). Calm folds machinery chips, byline tags, exec labels, manifest plumbing rows, prerequisite-only wait lines, and the inspector hood; Everything adds ulid prefixes on cards and raw op coordinates on diary rows; Standard is today's view unchanged.

**Trigger vocabulary + pipeline strips (commit 2)** — agendaEffectState learns Track T's trigger manifests: watching (on_item_match), waiting (on_unblock, prerequisites open), ready (all complete), failure-suspend covering triggered mandates. Before this an approved trigger mis-read through the clock vocabulary (finished/armed) on chips, strips, inspector, and Upcoming — all consumers taught the new kinds. On top: a hub whose children carry on_unblock manifests (derived, no marker) renders its nodes as an inline relies_on-ordered chain with live state dots, on the hub card and the By-hub lens. QA on a live stamped fix-task workflow: Investigate 'fires momentarily' / three 'waiting on prerequisites', topological order correct.

**Rich-ask composing (commit 3)** — the composer's question kind grows '+ options' (up to four, pick-one/pick-many) parking {op:'ask'} on the same durable lane sessions use; a chosen reminder rides a follow-up patch on the minted item. QA: options render as rail pills, 'due in 3h' chip present, row resets.

All slices: fragments + generated app.html only, existing tokens both themes, both transport lanes (daemonApi), escapeHtml on all interpolations. Battery: bins tests, workspace clippy -D warnings, lib crates, fmt — green. validate-dashboard PASS runs with screenshots in both themes.