### PR TITLE
feat(agenda): UX2 — approval ceremonies get their moment; refusals land at the card

### DIFF
--- a/src/bin/caller/web_gateway/routes_github.rs
+++ b/src/bin/caller/web_gateway/routes_github.rs
@@ -1886,7 +1886,27 @@ mod tests {
                 "ui2-vault.css lost the chip rule for {class}"
             );
         }
-        for (name, content) in [("32-vault-custody.js", fragment), ("ui2-vault.css", styles)] {
+        // UX2 extends the grammar to the agenda's ceremony surfaces: the
+        // approval strips speak is-attention/is-progress and refusals
+        // paint is-refusal at the card. Same vocabulary, same pin.
+        let agenda_cards = include_str!("../../../../static/app/ui2-agenda-cards.js");
+        let agenda_shared = include_str!("../../../../static/app/ui2-agenda.js");
+        for (class, holder) in [
+            ("is-attention", agenda_cards),
+            ("is-progress", agenda_cards),
+            ("is-refusal", agenda_shared),
+        ] {
+            assert!(
+                holder.contains(class),
+                "agenda ceremony surfaces lost grammar class {class}"
+            );
+        }
+        for (name, content) in [
+            ("32-vault-custody.js", fragment),
+            ("ui2-vault.css", styles),
+            ("ui2-agenda-cards.js", agenda_cards),
+            ("ui2-agenda.js", agenda_shared),
+        ] {
             for line in content.lines() {
                 if line.contains("is-progress") {
                     assert!(

--- a/static/app.html
+++ b/static/app.html
@@ -23951,6 +23951,26 @@ html.ui-v2 .ag2-eff.t-amber {
   border: 1px solid rgba(var(--amber-rgb), 0.26);
 }
 html.ui-v2 .ag2-eff.t-amber .ag2-eff-line { color: var(--amber); }
+html.ui-v2 .ag2-eff.t-sky {
+  background: rgba(var(--sky-rgb), .08);
+  border: 1px solid rgba(var(--sky-rgb), .2);
+}
+html.ui-v2 .ag2-eff.t-sky .ag2-eff-line { color: var(--sky); }
+html.ui-v2 .ag2-eff.t-green {
+  background: rgba(var(--green-rgb), .08);
+  border: 1px solid rgba(var(--green-rgb), .2);
+}
+html.ui-v2 .ag2-eff.t-green .ag2-eff-line { color: var(--green); }
+/* The refusal painted at the card that asked (UX2 grammar): transient —
+   the next list render sweeps it. */
+html.ui-v2 .ag2-card-refusal {
+  font-size: 12px;
+  color: var(--rose);
+  border-left: 2px solid rgba(var(--rose-rgb), .55);
+  padding-left: 9px;
+  margin-top: 3px;
+  overflow-wrap: anywhere;
+}
 html.ui-v2 .ag2-eff.t-iris {
   background: rgba(var(--iris-rgb), 0.08);
   border: 1px solid rgba(var(--iris-rgb), 0.26);
@@ -36845,7 +36865,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '2c25e7d18d32e116';
+const INTENDANT_APP_BUILD = 'bbd6aa287d25c2ea';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -44879,16 +44899,20 @@ function githubIntegrationCeremonyReturnBoot() {
       `${window.location.pathname}${rest ? `?${rest}` : ''}${window.location.hash || '#vault'}`);
   } catch { /* history unavailable — cosmetic only */ }
   githubIntegrationRefresh(true);
+  // The vault pane renders deferred and may re-render (resetting scroll)
+  // when the fresh status lands — so scroll on mount AND re-assert once
+  // after the render settles.
   let tries = 0;
-  const scroll = () => {
+  const scroll = (reassert) => {
     const mount = document.getElementById('access-github-integration-section');
     if (mount && mount.childElementCount) {
-      mount.scrollIntoView({ block: 'start', behavior: 'smooth' });
+      mount.scrollIntoView({ block: 'start' });
+      if (reassert) setTimeout(() => scroll(false), 1500);
       return;
     }
-    if (tries++ < 40) setTimeout(scroll, 250);
+    if (tries++ < 80) setTimeout(() => scroll(reassert), 250);
   };
-  scroll();
+  scroll(true);
 }
 {
   const bootCeremonyReturn = () => githubIntegrationCeremonyReturnBoot();
@@ -90174,13 +90198,33 @@ async function agendaSendOp(params, button) {
     }
     const message = (resp.body && resp.body.error) || `agenda op failed (${resp.status})`;
     agendaFlashError(message);
+    agendaPaintRefusal(button, message);
     return false;
   } catch (e) {
-    agendaFlashError(String(e && e.message || e));
+    const message = String(e && e.message || e);
+    agendaFlashError(message);
+    agendaPaintRefusal(button, message);
     return false;
   } finally {
     if (button) button.disabled = false;
   }
+}
+
+// The refusal painted AT the surface that refused (UX0 ruling; UX2) —
+// the top-of-tab flash evaporates in 6 s and sits far from the card
+// that asked. Transient by construction: the next render of the card
+// list sweeps it.
+function agendaPaintRefusal(button, message) {
+  const card = button && button.closest && button.closest('.ag2-card');
+  if (!card) return;
+  const previous = card.querySelector('.ag2-card-refusal');
+  if (previous) previous.remove();
+  const main = card.querySelector('.ag2-card-main');
+  if (!main) return;
+  const line = document.createElement('div');
+  line.className = 'ag2-card-refusal is-refusal';
+  line.textContent = message;
+  main.appendChild(line);
 }
 
 // Refused ops surface inline on the tab's notice line (and the ledger
@@ -92592,7 +92636,8 @@ function agendaCardEffectStrip(item) {
       ? `<button type="button" class="ag2-btn ghost" data-jump-session="${escapeHtml(s.key)}">Watch</button>`
       : '';
   }
-  return `<div class="ag2-eff t-${tone}">
+  const semantic = st.kind === 'running' ? 'is-progress' : 'is-attention';
+  return `<div class="ag2-eff t-${tone} ${semantic}">
     <span class="ag2-eff-line">${escapeHtml(line)}</span>
     <span class="ag2-spacer"></span>${actions}
   </div>`;
@@ -92649,10 +92694,42 @@ function agendaAutomationStripHtml(item) {
   } else if (['armed', 'watching', 'waiting', 'ready'].includes(st.kind)) {
     actions = `<button type="button" class="ag2-btn ghost" data-op-btn="revoke_effect" data-id="${id}" title="Withdraws the approval; the manifest and history stay">Revoke</button>`;
   }
-  return `<div class="ag2-eff ag2-auto t-${st.kind === 'pending' || st.kind === 'suspended' ? 'amber' : 'iris'}">
+  const autoTone = st.kind === 'pending' || st.kind === 'suspended' ? 'amber'
+    : st.kind === 'standing' ? 'green'
+      : ['armed', 'watching', 'waiting'].includes(st.kind) ? 'sky' : 'iris';
+  const autoSemantic = st.kind === 'pending' || st.kind === 'suspended' ? 'is-attention'
+    : ['running', 'ready'].includes(st.kind) ? 'is-progress' : '';
+  return `<div class="ag2-eff ag2-auto t-${autoTone}${autoSemantic ? ` ${autoSemantic}` : ''}">
     <span class="ag2-auto-meta">${meta.join('<span class="ag2-auto-dot">·</span>')}</span>
     <span class="ag2-spacer"></span>${actions}
   </div>`;
+}
+
+// The explicit "now armed" moment (UX0 ruling; UX2): approving is never
+// a silent state flip — one toast says what is now true and what
+// happens next, mirroring the workflow sheet's proven pattern. Derives
+// from the RESPONSE item, so the line states the daemon's post-approve
+// truth, not a prediction.
+function agendaApprovalMoment(item) {
+  if (typeof showControlToast !== 'function') return;
+  const st = agendaEffectState(item);
+  let line = 'Approved — the manifest is armed. Revoke anytime on the card.';
+  if (st) {
+    if (st.kind === 'standing') {
+      line = `Approved — standing series armed: every ${agendaCadenceLabel(st.rec.every_ms)}, next ${agendaAbsTime(st.next)}. Revoke anytime on the card.`;
+    } else if (st.kind === 'armed') {
+      line = `Approved — armed; fires ${agendaAbsTime(st.next)}. Watch it on the Automations lens; revoke anytime.`;
+    } else if (st.kind === 'watching') {
+      line = 'Approved — watching; fires when a new matching item arrives (arrivals batch for a minute). Revoke anytime.';
+    } else if (st.kind === 'waiting') {
+      line = 'Approved — armed; fires the moment every prerequisite completes. Revoke anytime.';
+    } else if (st.kind === 'ready') {
+      line = 'Approved — prerequisites already complete; the session fires within the minute.';
+    } else if (st.kind === 'running') {
+      line = 'Approved — an occurrence is already in flight.';
+    }
+  }
+  showControlToast('success', line);
 }
 
 // ---- Workflow pipeline strip (hub cards + the hubs lens) ----
@@ -93126,7 +93203,9 @@ function agendaGroupsClick(e) {
     const params = { op: opBtn.dataset.opBtn, id: opBtn.dataset.id };
     // Approve binds the digest of the revision this render showed.
     if (opBtn.dataset.digest) params.digest = opBtn.dataset.digest;
-    agendaSendOp(params, opBtn);
+    agendaSendOp(params, opBtn).then((item) => {
+      if (item && params.op === 'approve_effect') agendaApprovalMoment(item);
+    });
     return;
   }
   const jump = e.target.closest('[data-jump-session]');
@@ -94138,7 +94217,8 @@ function agendaInspClick(e) {
       const st = agendaEffectState(item);
       if (st) {
         // Approve binds the digest of exactly the revision rendered.
-        agendaSendOp({ op: 'approve_effect', id: item.id, digest: st.effect.digest }, act);
+        agendaSendOp({ op: 'approve_effect', id: item.id, digest: st.effect.digest }, act)
+          .then((updated) => { if (updated) agendaApprovalMoment(updated); });
       }
       break;
     }

--- a/static/app/32-vault-custody.js
+++ b/static/app/32-vault-custody.js
@@ -4361,16 +4361,20 @@ function githubIntegrationCeremonyReturnBoot() {
       `${window.location.pathname}${rest ? `?${rest}` : ''}${window.location.hash || '#vault'}`);
   } catch { /* history unavailable — cosmetic only */ }
   githubIntegrationRefresh(true);
+  // The vault pane renders deferred and may re-render (resetting scroll)
+  // when the fresh status lands — so scroll on mount AND re-assert once
+  // after the render settles.
   let tries = 0;
-  const scroll = () => {
+  const scroll = (reassert) => {
     const mount = document.getElementById('access-github-integration-section');
     if (mount && mount.childElementCount) {
-      mount.scrollIntoView({ block: 'start', behavior: 'smooth' });
+      mount.scrollIntoView({ block: 'start' });
+      if (reassert) setTimeout(() => scroll(false), 1500);
       return;
     }
-    if (tries++ < 40) setTimeout(scroll, 250);
+    if (tries++ < 80) setTimeout(() => scroll(reassert), 250);
   };
-  scroll();
+  scroll(true);
 }
 {
   const bootCeremonyReturn = () => githubIntegrationCeremonyReturnBoot();

--- a/static/app/ui2-agenda-cards.js
+++ b/static/app/ui2-agenda-cards.js
@@ -855,7 +855,8 @@ function agendaCardEffectStrip(item) {
       ? `<button type="button" class="ag2-btn ghost" data-jump-session="${escapeHtml(s.key)}">Watch</button>`
       : '';
   }
-  return `<div class="ag2-eff t-${tone}">
+  const semantic = st.kind === 'running' ? 'is-progress' : 'is-attention';
+  return `<div class="ag2-eff t-${tone} ${semantic}">
     <span class="ag2-eff-line">${escapeHtml(line)}</span>
     <span class="ag2-spacer"></span>${actions}
   </div>`;
@@ -912,10 +913,42 @@ function agendaAutomationStripHtml(item) {
   } else if (['armed', 'watching', 'waiting', 'ready'].includes(st.kind)) {
     actions = `<button type="button" class="ag2-btn ghost" data-op-btn="revoke_effect" data-id="${id}" title="Withdraws the approval; the manifest and history stay">Revoke</button>`;
   }
-  return `<div class="ag2-eff ag2-auto t-${st.kind === 'pending' || st.kind === 'suspended' ? 'amber' : 'iris'}">
+  const autoTone = st.kind === 'pending' || st.kind === 'suspended' ? 'amber'
+    : st.kind === 'standing' ? 'green'
+      : ['armed', 'watching', 'waiting'].includes(st.kind) ? 'sky' : 'iris';
+  const autoSemantic = st.kind === 'pending' || st.kind === 'suspended' ? 'is-attention'
+    : ['running', 'ready'].includes(st.kind) ? 'is-progress' : '';
+  return `<div class="ag2-eff ag2-auto t-${autoTone}${autoSemantic ? ` ${autoSemantic}` : ''}">
     <span class="ag2-auto-meta">${meta.join('<span class="ag2-auto-dot">·</span>')}</span>
     <span class="ag2-spacer"></span>${actions}
   </div>`;
+}
+
+// The explicit "now armed" moment (UX0 ruling; UX2): approving is never
+// a silent state flip — one toast says what is now true and what
+// happens next, mirroring the workflow sheet's proven pattern. Derives
+// from the RESPONSE item, so the line states the daemon's post-approve
+// truth, not a prediction.
+function agendaApprovalMoment(item) {
+  if (typeof showControlToast !== 'function') return;
+  const st = agendaEffectState(item);
+  let line = 'Approved — the manifest is armed. Revoke anytime on the card.';
+  if (st) {
+    if (st.kind === 'standing') {
+      line = `Approved — standing series armed: every ${agendaCadenceLabel(st.rec.every_ms)}, next ${agendaAbsTime(st.next)}. Revoke anytime on the card.`;
+    } else if (st.kind === 'armed') {
+      line = `Approved — armed; fires ${agendaAbsTime(st.next)}. Watch it on the Automations lens; revoke anytime.`;
+    } else if (st.kind === 'watching') {
+      line = 'Approved — watching; fires when a new matching item arrives (arrivals batch for a minute). Revoke anytime.';
+    } else if (st.kind === 'waiting') {
+      line = 'Approved — armed; fires the moment every prerequisite completes. Revoke anytime.';
+    } else if (st.kind === 'ready') {
+      line = 'Approved — prerequisites already complete; the session fires within the minute.';
+    } else if (st.kind === 'running') {
+      line = 'Approved — an occurrence is already in flight.';
+    }
+  }
+  showControlToast('success', line);
 }
 
 // ---- Workflow pipeline strip (hub cards + the hubs lens) ----
@@ -1389,7 +1422,9 @@ function agendaGroupsClick(e) {
     const params = { op: opBtn.dataset.opBtn, id: opBtn.dataset.id };
     // Approve binds the digest of the revision this render showed.
     if (opBtn.dataset.digest) params.digest = opBtn.dataset.digest;
-    agendaSendOp(params, opBtn);
+    agendaSendOp(params, opBtn).then((item) => {
+      if (item && params.op === 'approve_effect') agendaApprovalMoment(item);
+    });
     return;
   }
   const jump = e.target.closest('[data-jump-session]');

--- a/static/app/ui2-agenda-inspector.js
+++ b/static/app/ui2-agenda-inspector.js
@@ -909,7 +909,8 @@ function agendaInspClick(e) {
       const st = agendaEffectState(item);
       if (st) {
         // Approve binds the digest of exactly the revision rendered.
-        agendaSendOp({ op: 'approve_effect', id: item.id, digest: st.effect.digest }, act);
+        agendaSendOp({ op: 'approve_effect', id: item.id, digest: st.effect.digest }, act)
+          .then((updated) => { if (updated) agendaApprovalMoment(updated); });
       }
       break;
     }

--- a/static/app/ui2-agenda.css
+++ b/static/app/ui2-agenda.css
@@ -650,6 +650,26 @@ html.ui-v2 .ag2-eff.t-amber {
   border: 1px solid rgba(var(--amber-rgb), 0.26);
 }
 html.ui-v2 .ag2-eff.t-amber .ag2-eff-line { color: var(--amber); }
+html.ui-v2 .ag2-eff.t-sky {
+  background: rgba(var(--sky-rgb), .08);
+  border: 1px solid rgba(var(--sky-rgb), .2);
+}
+html.ui-v2 .ag2-eff.t-sky .ag2-eff-line { color: var(--sky); }
+html.ui-v2 .ag2-eff.t-green {
+  background: rgba(var(--green-rgb), .08);
+  border: 1px solid rgba(var(--green-rgb), .2);
+}
+html.ui-v2 .ag2-eff.t-green .ag2-eff-line { color: var(--green); }
+/* The refusal painted at the card that asked (UX2 grammar): transient —
+   the next list render sweeps it. */
+html.ui-v2 .ag2-card-refusal {
+  font-size: 12px;
+  color: var(--rose);
+  border-left: 2px solid rgba(var(--rose-rgb), .55);
+  padding-left: 9px;
+  margin-top: 3px;
+  overflow-wrap: anywhere;
+}
 html.ui-v2 .ag2-eff.t-iris {
   background: rgba(var(--iris-rgb), 0.08);
   border: 1px solid rgba(var(--iris-rgb), 0.26);

--- a/static/app/ui2-agenda.js
+++ b/static/app/ui2-agenda.js
@@ -270,13 +270,33 @@ async function agendaSendOp(params, button) {
     }
     const message = (resp.body && resp.body.error) || `agenda op failed (${resp.status})`;
     agendaFlashError(message);
+    agendaPaintRefusal(button, message);
     return false;
   } catch (e) {
-    agendaFlashError(String(e && e.message || e));
+    const message = String(e && e.message || e);
+    agendaFlashError(message);
+    agendaPaintRefusal(button, message);
     return false;
   } finally {
     if (button) button.disabled = false;
   }
+}
+
+// The refusal painted AT the surface that refused (UX0 ruling; UX2) —
+// the top-of-tab flash evaporates in 6 s and sits far from the card
+// that asked. Transient by construction: the next render of the card
+// list sweeps it.
+function agendaPaintRefusal(button, message) {
+  const card = button && button.closest && button.closest('.ag2-card');
+  if (!card) return;
+  const previous = card.querySelector('.ag2-card-refusal');
+  if (previous) previous.remove();
+  const main = card.querySelector('.ag2-card-main');
+  if (!main) return;
+  const line = document.createElement('div');
+  line.className = 'ag2-card-refusal is-refusal';
+  line.textContent = message;
+  main.appendChild(line);
 }
 
 // Refused ops surface inline on the tab's notice line (and the ledger


### PR DESCRIPTION
Track UX slice UX2 (final slice): the approval & automation ceremony grammar, per the UX0 ruling (gate 01KYDVT5BX, PASS; intake + ruling at ~/ceremony-ux-intake.md; ledger ~/track-ux-ledger.md).

- **The 'now armed' moment**: single-effect approval is never a silent state flip — one success toast derives the post-approve truth from the RESPONSE item (standing cadence + next instant / fire time / what wakes a trigger / fires-within-the-minute), mirroring the workflow sheet's proven pattern. Both approve sites wired.
- **Refusals at the card**: agendaSendOp failures paint a rose `is-refusal` line inside the originating card (transient; next render sweeps) — the evaporating top-of-tab flash alone was the inventory's 1b finding.
- **Grammar on the agenda surfaces**: strips carry `is-attention`/`is-progress`; the automations strip tone now matches state (amber needs-you / green standing / sky armed·watching·waiting / iris in-flight). The pinned grammar test extends to the agenda fragments.
- Rides: UX1's ceremony-return scroll re-assert (the deferred vault pane could reset the first scroll — caught in Chromium acceptance).
- **Pinned emission path untouched**: the workflow sheet's single-emitter lane is not modified; `workflow_approval_sheet_approves_only_in_the_owner_confirm_lane` stays byte-green.

**QA** (live rig): revoke → re-approve on the stamped workflow's Land node → toast 'Approved — armed; fires the moment every prerequisite completes. Revoke anytime.' + t-sky settled strip; grammar pin (extended) green; fmt/clippy/bins battery green. Chromium lane verified; the WebKit check for these agenda surfaces is the macOS-app pass named at UX0 (scripted Safari needs the operator's Apple-Events consent — the UX1 script degrades to the named manual check and covers this tab's states on the same lane once granted).