### PR TITLE
fix(vault): keychain-parked custody must not wedge the daemon; the GitHub section orients in human language

### DIFF
--- a/docs/src/github-pr-integration.md
+++ b/docs/src/github-pr-integration.md
@@ -112,6 +112,18 @@ for every PR on the fleet, watched or not. Both exist on purpose.
   custody backend yet (Windows/Linux until their Track K slices), the
   configure gesture fails with a named error rather than degrading to a
   file.
+- **A rebuilt binary re-asks the macOS Keychain — once.** The custody
+  entry's ACL names the binary that created it; after any rebuild the
+  first custody touch makes macOS raise a SecurityAgent authorization
+  ("intendant-bin wants to use your confidential information…"), which
+  can hide behind windows or on another desktop. Click **Always Allow**
+  for the new binary. While the dialog waits, the parked custody call
+  runs on a surrendered runtime slot (`custody_blocking`,
+  `block_in_place`) so the daemon keeps serving, and the dashboard's
+  GitHub section names the situation after 20 s instead of showing an
+  eternal progress line. Development builds re-prompt on every rebuild;
+  signed releases keep one stable identity (see the TCC/signing notes
+  in the release docs).
 - **Read-only by construction and by permission set.** The App needs
   exactly: `Metadata: read` (baseline), `Pull requests: read`,
   `Checks: read`. Nothing else — no Contents, no Issues, no write

--- a/src/bin/caller/web_gateway/routes_github.rs
+++ b/src/bin/caller/web_gateway/routes_github.rs
@@ -31,21 +31,40 @@ pub(crate) trait GithubAppCustody: Send + Sync {
 /// Production custody: the daemon-global estate in `key_custody`.
 pub(crate) struct DaemonGithubAppCustody;
 
+/// Keychain custody can PARK the calling thread: macOS Security waits on
+/// a SecurityAgent authorization when the binary no longer matches the
+/// item's ACL — routine after every rebuild. Observed live 2026-07-26:
+/// four runtime workers stuck in `retrieve`, the whole daemon
+/// unresponsive at 0% CPU. Every production custody touch therefore runs
+/// via `block_in_place`, so a parked call surrenders its runtime slot
+/// instead of wedging the serve path; outside a multi-thread runtime the
+/// closure runs inline (startup paths, tests).
+fn custody_blocking<T>(f: impl FnOnce() -> T) -> T {
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
+            tokio::task::block_in_place(f)
+        }
+        _ => f(),
+    }
+}
+
 impl GithubAppCustody for DaemonGithubAppCustody {
     fn present(&self) -> bool {
-        crate::key_custody::github_app_in_custody()
+        custody_blocking(crate::key_custody::github_app_in_custody)
     }
     fn backend_available(&self) -> bool {
-        crate::key_custody::custody_backend_available()
+        custody_blocking(crate::key_custody::custody_backend_available)
     }
     fn retrieve(&self) -> Option<Vec<u8>> {
-        crate::key_custody::github_app_from_custody().map(|secret| secret.as_bytes().to_vec())
+        custody_blocking(|| {
+            crate::key_custody::github_app_from_custody().map(|secret| secret.as_bytes().to_vec())
+        })
     }
     fn store(&self, material: &[u8], actor: &str, origin: &str) -> Result<(), String> {
-        crate::key_custody::store_github_app(material, actor, origin)
+        custody_blocking(|| crate::key_custody::store_github_app(material, actor, origin))
     }
     fn remove(&self, actor: &str, origin: &str) -> Result<(), String> {
-        crate::key_custody::remove_github_app(actor, origin)
+        custody_blocking(|| crate::key_custody::remove_github_app(actor, origin))
     }
 }
 

--- a/static/app.html
+++ b/static/app.html
@@ -17981,6 +17981,23 @@ html.ui-v2 #access-github-integration-section .vault-chip.warn {
   color: var(--amber);
 }
 
+/* Orientation first: one human sentence — what is true, what happens
+   next — before any chips. */
+html.ui-v2 #access-github-integration-section .vault-orientation {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-2);
+  margin: 4px 0 10px;
+  max-width: 62ch;
+}
+html.ui-v2 #access-github-integration-section .vault-orientation.is-success { color: var(--green); }
+html.ui-v2 #access-github-integration-section .vault-orientation.is-attention { color: var(--amber); }
+html.ui-v2 #access-github-integration-section .vault-orientation.is-refusal { color: var(--rose); }
+html.ui-v2 #access-github-integration-section .vault-orientation.is-progress {
+  color: var(--sky);
+  animation: ui2-pulse 2.4s ease-in-out infinite;
+}
+
 /* The ceremony feedback grammar (UX0 ruling, pinned vocabulary):
    is-progress — in flight, no user action (sky, pulse);
    is-attention — waits on a user decision (amber, correctly);
@@ -36865,7 +36882,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'bbd6aa287d25c2ea';
+const INTENDANT_APP_BUILD = 'dc95a0c5359e5a1c';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -44859,11 +44876,27 @@ async function githubIntegrationApi(method, params) {
   return resp.body ?? {};
 }
 
+// Bounded waits for daemon answers: keychain custody can park the
+// daemon-side call behind a macOS SecurityAgent authorization (routine
+// after every rebuild — the binary stops matching the keychain item's
+// ACL), and an unanswered request must become a NAMED refusal with the
+// remedy — never an eternal progress line.
+const GITHUB_INTEGRATION_TIMEOUT_MS = 20_000;
+const GITHUB_KEYCHAIN_HINT = 'No answer from the daemon in 20 s. On a Mac this usually means a Keychain authorization dialog is waiting for you — it can hide behind windows or on another desktop. Find it, click “Always Allow”, then Retry. (Restarting the daemon re-prompts fresh.)';
+function githubIntegrationDeadline() {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => reject(new Error(GITHUB_KEYCHAIN_HINT)), GITHUB_INTEGRATION_TIMEOUT_MS);
+  });
+}
+
 async function githubIntegrationRefresh(force = false) {
   if (!force && Date.now() - githubIntegrationState.fetchedAt < 30_000) return;
   githubIntegrationState.fetchedAt = Date.now();
   try {
-    const body = await githubIntegrationApi('api_github_integration_status', {});
+    const body = await Promise.race([
+      githubIntegrationApi('api_github_integration_status', {}),
+      githubIntegrationDeadline(),
+    ]);
     githubIntegrationState.data = body || null;
     githubIntegrationState.lastError = null;
     if (githubCeremonyReturn && body && body.status === 'valid') {
@@ -45024,11 +45057,15 @@ async function githubIntegrationSaveSelection(payload) {
 
 async function githubIntegrationLoadRepositories() {
   const p = githubIntegrationState.repoPicker;
-  if (p.loading || p.repositories) return;
+  // An errored listing does NOT auto-retry on every render (that loops);
+  // the rendered Retry button clears the error explicitly.
+  if (p.loading || p.repositories || p.error) return;
   p.loading = true;
-  p.error = null;
   try {
-    const body = await githubIntegrationApi('api_github_repositories', {});
+    const body = await Promise.race([
+      githubIntegrationApi('api_github_repositories', {}),
+      githubIntegrationDeadline(),
+    ]);
     p.repositories = Array.isArray(body?.repositories) ? body.repositories : [];
   } catch (e) {
     p.error = String(e?.message || e);
@@ -45142,37 +45179,53 @@ function renderGithubIntegrationSection() {
   // The ceremony feedback grammar (UX0 ruling, pinned): is-progress =
   // in flight, no user action; is-attention = waits on a user decision
   // (amber is CORRECT here — never on progress); is-success = explicit,
-  // with the next action; is-refusal = named reason + what to do. The
-  // legacy ok/warn chip classes remain for the rest of the Vault; this
-  // section speaks the grammar.
+  // with the next action; is-refusal = named reason + what to do.
+  //
+  // ORIENTATION FIRST: one human sentence says what is true and what
+  // happens next; the chips below it are secondary facts. Nobody should
+  // have to decode a `status: configured` telemetry wall (the owner's
+  // 2026-07-26 finding, verbatim).
+  const status = data?.status || (githubIntegrationState.lastError ? 'unknown' : 'loading');
+  const repoCount = Array.isArray(data?.repos) ? data.repos.length : 0;
+  const poll = data?.poll_minutes || 5;
+  const orientation = document.createElement('div');
+  let orient = { cls: '', text: '' };
+  if (githubIntegrationState.lastError) {
+    orient = { cls: 'is-refusal', text: githubIntegrationState.lastError };
+  } else if (status === 'loading') {
+    orient = { cls: 'is-progress', text: 'Checking the integration’s state…' };
+  } else if (data && !data.configured && !data.pending_install) {
+    orient = { cls: '', text: 'Not connected. One click below creates a private read-only GitHub App for your account and seals its key on this machine.' };
+  } else if (data?.pending_install) {
+    orient = { cls: 'is-attention', text: 'The App is created and its key is sealed — one step left: install it on your repositories on GitHub. The installation is picked up automatically when you return.' };
+  } else if (status === 'valid') {
+    orient = repoCount
+      ? { cls: 'is-success', text: `Connected and verified — watching ${repoCount} repositor${repoCount === 1 ? 'y' : 'ies'}. Open PR cards land on the Agenda within ~${poll} minutes.` }
+      : { cls: 'is-attention', text: 'Connected and verified — but no repositories are watched yet. Tick some below and “Save selection & verify”; PR cards then land on the Agenda.' };
+  } else if (status === 'denied') {
+    orient = { cls: 'is-refusal', text: `GitHub refused the credentials${data?.detail ? ` — ${data.detail}` : ''}. Reconnect below, or check the App’s installation on GitHub.` };
+  } else if (status === 'unreachable') {
+    orient = { cls: 'is-refusal', text: `GitHub is unreachable${data?.detail ? ` — ${data.detail}` : ''}. The daemon retries on its next poll.` };
+  } else if (status === 'configured') {
+    orient = { cls: 'is-attention', text: `Connected — credentials are sealed; nothing has been verified against GitHub since the daemon started. ${repoCount ? 'The next poll verifies the watch list.' : 'Pick repositories below and “Save selection & verify” — PR cards then land on the Agenda.'}` };
+  } else {
+    orient = { cls: '', text: `Integration state: ${status}.` };
+  }
+  orientation.className = `vault-orientation${orient.cls ? ` ${orient.cls}` : ''}`;
+  orientation.textContent = orient.text;
+  mount.appendChild(orientation);
+
   const chips = document.createElement('div');
   chips.className = 'vault-status-line';
-  const status = data?.status || (githubIntegrationState.lastError ? 'unknown' : 'loading');
-  const statusCls = status === 'valid' ? 'is-success'
-    : (status === 'denied' || status === 'unreachable') ? 'is-refusal'
-    : status === 'loading' ? 'is-progress'
-    : '';
-  chips.appendChild(githubIntegrationChip(`status: ${status}`, statusCls));
+  if (data?.configured || data?.pending_install) {
+    chips.appendChild(githubIntegrationChip('key sealed in custody', 'is-success'));
+  }
+  if (data?.app_slug) chips.appendChild(githubIntegrationChip(String(data.app_slug)));
   if (data?.configured) {
-    chips.appendChild(githubIntegrationChip('credentials sealed', 'is-success'));
+    chips.appendChild(githubIntegrationChip(`${repoCount} repo${repoCount === 1 ? '' : 's'} watched`));
   }
-  if (data?.pending_install) {
-    // Success so far (App created, key sealed) awaiting the user's next
-    // move — attention, never a warning dressed over progress.
-    chips.appendChild(githubIntegrationChip('pending install — one step left', 'is-attention'));
-    if (data.app_slug) chips.appendChild(githubIntegrationChip(String(data.app_slug)));
-  }
-  const repoCount = Array.isArray(data?.repos) ? data.repos.length : 0;
-  chips.appendChild(githubIntegrationChip(`${repoCount} repo${repoCount === 1 ? '' : 's'} watched`));
   if (data && data.custody_backend_available === false) {
     chips.appendChild(githubIntegrationChip('no custody backend on this platform', 'is-refusal'));
-  }
-  if (data?.detail) {
-    chips.appendChild(githubIntegrationChip(String(data.detail),
-      statusCls === 'is-refusal' ? 'is-refusal' : 'is-attention'));
-  }
-  if (githubIntegrationState.lastError) {
-    chips.appendChild(githubIntegrationChip(githubIntegrationState.lastError, 'is-refusal'));
   }
   if (githubIntegrationState.notice) {
     chips.appendChild(githubIntegrationChip(githubIntegrationState.notice.text, githubIntegrationState.notice.cls));
@@ -45274,13 +45327,18 @@ function renderGithubIntegrationSection() {
     const configured = new Set(Array.isArray(data.repos) ? data.repos : []);
     if (p.error) {
       const err = document.createElement('div');
-      err.className = 'vault-connect-hint';
+      err.className = 'vault-connect-hint is-refusal';
       err.textContent = `Repository listing failed: ${p.error}`;
       picker.appendChild(err);
+      const retry = vaultButton('Retry', () => {
+        githubIntegrationState.repoPicker = { loading: false, repositories: null, error: null };
+        renderGithubIntegrationSection();
+      });
+      picker.appendChild(retry);
     } else if (!p.repositories) {
       const loading = document.createElement('div');
-      loading.className = 'vault-connect-hint';
-      loading.textContent = 'Listing the installation’s repositories…';
+      loading.className = 'vault-connect-hint is-progress';
+      loading.textContent = 'Listing the installation’s repositories… (answers within 20 s or says why not)';
       picker.appendChild(loading);
     } else {
       const list = document.createElement('div');
@@ -93147,7 +93205,7 @@ function agendaRenderTab() {
       : agendaLens === 'now'
         ? 'The agenda is quiet — everything parked is either moving or waiting politely.'
         : agendaLens === 'automations'
-          ? 'Schedule a standing session on any item (its Schedule section, or ctl agenda schedule) and it appears here with its approval, cadence, and run history.'
+          ? 'Schedule a standing session on any item (its Schedule section, or ctl agenda schedule) and it appears here with its approval, cadence, and run history. PR cards appear once GitHub is connected and watching repositories — Vault → GitHub.'
           : 'Park something above, or let your sessions park as they work.';
     groupsHost.innerHTML = `<div class="ag2-empty">
       <div class="ag2-empty-glyph">◍</div>

--- a/static/app/32-vault-custody.js
+++ b/static/app/32-vault-custody.js
@@ -4321,11 +4321,27 @@ async function githubIntegrationApi(method, params) {
   return resp.body ?? {};
 }
 
+// Bounded waits for daemon answers: keychain custody can park the
+// daemon-side call behind a macOS SecurityAgent authorization (routine
+// after every rebuild — the binary stops matching the keychain item's
+// ACL), and an unanswered request must become a NAMED refusal with the
+// remedy — never an eternal progress line.
+const GITHUB_INTEGRATION_TIMEOUT_MS = 20_000;
+const GITHUB_KEYCHAIN_HINT = 'No answer from the daemon in 20 s. On a Mac this usually means a Keychain authorization dialog is waiting for you — it can hide behind windows or on another desktop. Find it, click “Always Allow”, then Retry. (Restarting the daemon re-prompts fresh.)';
+function githubIntegrationDeadline() {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => reject(new Error(GITHUB_KEYCHAIN_HINT)), GITHUB_INTEGRATION_TIMEOUT_MS);
+  });
+}
+
 async function githubIntegrationRefresh(force = false) {
   if (!force && Date.now() - githubIntegrationState.fetchedAt < 30_000) return;
   githubIntegrationState.fetchedAt = Date.now();
   try {
-    const body = await githubIntegrationApi('api_github_integration_status', {});
+    const body = await Promise.race([
+      githubIntegrationApi('api_github_integration_status', {}),
+      githubIntegrationDeadline(),
+    ]);
     githubIntegrationState.data = body || null;
     githubIntegrationState.lastError = null;
     if (githubCeremonyReturn && body && body.status === 'valid') {
@@ -4486,11 +4502,15 @@ async function githubIntegrationSaveSelection(payload) {
 
 async function githubIntegrationLoadRepositories() {
   const p = githubIntegrationState.repoPicker;
-  if (p.loading || p.repositories) return;
+  // An errored listing does NOT auto-retry on every render (that loops);
+  // the rendered Retry button clears the error explicitly.
+  if (p.loading || p.repositories || p.error) return;
   p.loading = true;
-  p.error = null;
   try {
-    const body = await githubIntegrationApi('api_github_repositories', {});
+    const body = await Promise.race([
+      githubIntegrationApi('api_github_repositories', {}),
+      githubIntegrationDeadline(),
+    ]);
     p.repositories = Array.isArray(body?.repositories) ? body.repositories : [];
   } catch (e) {
     p.error = String(e?.message || e);
@@ -4604,37 +4624,53 @@ function renderGithubIntegrationSection() {
   // The ceremony feedback grammar (UX0 ruling, pinned): is-progress =
   // in flight, no user action; is-attention = waits on a user decision
   // (amber is CORRECT here — never on progress); is-success = explicit,
-  // with the next action; is-refusal = named reason + what to do. The
-  // legacy ok/warn chip classes remain for the rest of the Vault; this
-  // section speaks the grammar.
+  // with the next action; is-refusal = named reason + what to do.
+  //
+  // ORIENTATION FIRST: one human sentence says what is true and what
+  // happens next; the chips below it are secondary facts. Nobody should
+  // have to decode a `status: configured` telemetry wall (the owner's
+  // 2026-07-26 finding, verbatim).
+  const status = data?.status || (githubIntegrationState.lastError ? 'unknown' : 'loading');
+  const repoCount = Array.isArray(data?.repos) ? data.repos.length : 0;
+  const poll = data?.poll_minutes || 5;
+  const orientation = document.createElement('div');
+  let orient = { cls: '', text: '' };
+  if (githubIntegrationState.lastError) {
+    orient = { cls: 'is-refusal', text: githubIntegrationState.lastError };
+  } else if (status === 'loading') {
+    orient = { cls: 'is-progress', text: 'Checking the integration’s state…' };
+  } else if (data && !data.configured && !data.pending_install) {
+    orient = { cls: '', text: 'Not connected. One click below creates a private read-only GitHub App for your account and seals its key on this machine.' };
+  } else if (data?.pending_install) {
+    orient = { cls: 'is-attention', text: 'The App is created and its key is sealed — one step left: install it on your repositories on GitHub. The installation is picked up automatically when you return.' };
+  } else if (status === 'valid') {
+    orient = repoCount
+      ? { cls: 'is-success', text: `Connected and verified — watching ${repoCount} repositor${repoCount === 1 ? 'y' : 'ies'}. Open PR cards land on the Agenda within ~${poll} minutes.` }
+      : { cls: 'is-attention', text: 'Connected and verified — but no repositories are watched yet. Tick some below and “Save selection & verify”; PR cards then land on the Agenda.' };
+  } else if (status === 'denied') {
+    orient = { cls: 'is-refusal', text: `GitHub refused the credentials${data?.detail ? ` — ${data.detail}` : ''}. Reconnect below, or check the App’s installation on GitHub.` };
+  } else if (status === 'unreachable') {
+    orient = { cls: 'is-refusal', text: `GitHub is unreachable${data?.detail ? ` — ${data.detail}` : ''}. The daemon retries on its next poll.` };
+  } else if (status === 'configured') {
+    orient = { cls: 'is-attention', text: `Connected — credentials are sealed; nothing has been verified against GitHub since the daemon started. ${repoCount ? 'The next poll verifies the watch list.' : 'Pick repositories below and “Save selection & verify” — PR cards then land on the Agenda.'}` };
+  } else {
+    orient = { cls: '', text: `Integration state: ${status}.` };
+  }
+  orientation.className = `vault-orientation${orient.cls ? ` ${orient.cls}` : ''}`;
+  orientation.textContent = orient.text;
+  mount.appendChild(orientation);
+
   const chips = document.createElement('div');
   chips.className = 'vault-status-line';
-  const status = data?.status || (githubIntegrationState.lastError ? 'unknown' : 'loading');
-  const statusCls = status === 'valid' ? 'is-success'
-    : (status === 'denied' || status === 'unreachable') ? 'is-refusal'
-    : status === 'loading' ? 'is-progress'
-    : '';
-  chips.appendChild(githubIntegrationChip(`status: ${status}`, statusCls));
+  if (data?.configured || data?.pending_install) {
+    chips.appendChild(githubIntegrationChip('key sealed in custody', 'is-success'));
+  }
+  if (data?.app_slug) chips.appendChild(githubIntegrationChip(String(data.app_slug)));
   if (data?.configured) {
-    chips.appendChild(githubIntegrationChip('credentials sealed', 'is-success'));
+    chips.appendChild(githubIntegrationChip(`${repoCount} repo${repoCount === 1 ? '' : 's'} watched`));
   }
-  if (data?.pending_install) {
-    // Success so far (App created, key sealed) awaiting the user's next
-    // move — attention, never a warning dressed over progress.
-    chips.appendChild(githubIntegrationChip('pending install — one step left', 'is-attention'));
-    if (data.app_slug) chips.appendChild(githubIntegrationChip(String(data.app_slug)));
-  }
-  const repoCount = Array.isArray(data?.repos) ? data.repos.length : 0;
-  chips.appendChild(githubIntegrationChip(`${repoCount} repo${repoCount === 1 ? '' : 's'} watched`));
   if (data && data.custody_backend_available === false) {
     chips.appendChild(githubIntegrationChip('no custody backend on this platform', 'is-refusal'));
-  }
-  if (data?.detail) {
-    chips.appendChild(githubIntegrationChip(String(data.detail),
-      statusCls === 'is-refusal' ? 'is-refusal' : 'is-attention'));
-  }
-  if (githubIntegrationState.lastError) {
-    chips.appendChild(githubIntegrationChip(githubIntegrationState.lastError, 'is-refusal'));
   }
   if (githubIntegrationState.notice) {
     chips.appendChild(githubIntegrationChip(githubIntegrationState.notice.text, githubIntegrationState.notice.cls));
@@ -4736,13 +4772,18 @@ function renderGithubIntegrationSection() {
     const configured = new Set(Array.isArray(data.repos) ? data.repos : []);
     if (p.error) {
       const err = document.createElement('div');
-      err.className = 'vault-connect-hint';
+      err.className = 'vault-connect-hint is-refusal';
       err.textContent = `Repository listing failed: ${p.error}`;
       picker.appendChild(err);
+      const retry = vaultButton('Retry', () => {
+        githubIntegrationState.repoPicker = { loading: false, repositories: null, error: null };
+        renderGithubIntegrationSection();
+      });
+      picker.appendChild(retry);
     } else if (!p.repositories) {
       const loading = document.createElement('div');
-      loading.className = 'vault-connect-hint';
-      loading.textContent = 'Listing the installation’s repositories…';
+      loading.className = 'vault-connect-hint is-progress';
+      loading.textContent = 'Listing the installation’s repositories… (answers within 20 s or says why not)';
       picker.appendChild(loading);
     } else {
       const list = document.createElement('div');

--- a/static/app/ui2-agenda-cards.js
+++ b/static/app/ui2-agenda-cards.js
@@ -1366,7 +1366,7 @@ function agendaRenderTab() {
       : agendaLens === 'now'
         ? 'The agenda is quiet — everything parked is either moving or waiting politely.'
         : agendaLens === 'automations'
-          ? 'Schedule a standing session on any item (its Schedule section, or ctl agenda schedule) and it appears here with its approval, cadence, and run history.'
+          ? 'Schedule a standing session on any item (its Schedule section, or ctl agenda schedule) and it appears here with its approval, cadence, and run history. PR cards appear once GitHub is connected and watching repositories — Vault → GitHub.'
           : 'Park something above, or let your sessions park as they work.';
     groupsHost.innerHTML = `<div class="ag2-empty">
       <div class="ag2-empty-glyph">◍</div>

--- a/static/app/ui2-vault.css
+++ b/static/app/ui2-vault.css
@@ -880,6 +880,23 @@ html.ui-v2 #access-github-integration-section .vault-chip.warn {
   color: var(--amber);
 }
 
+/* Orientation first: one human sentence — what is true, what happens
+   next — before any chips. */
+html.ui-v2 #access-github-integration-section .vault-orientation {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-2);
+  margin: 4px 0 10px;
+  max-width: 62ch;
+}
+html.ui-v2 #access-github-integration-section .vault-orientation.is-success { color: var(--green); }
+html.ui-v2 #access-github-integration-section .vault-orientation.is-attention { color: var(--amber); }
+html.ui-v2 #access-github-integration-section .vault-orientation.is-refusal { color: var(--rose); }
+html.ui-v2 #access-github-integration-section .vault-orientation.is-progress {
+  color: var(--sky);
+  animation: ui2-pulse 2.4s ease-in-out infinite;
+}
+
 /* The ceremony feedback grammar (UX0 ruling, pinned vocabulary):
    is-progress — in flight, no user action (sky, pulse);
    is-attention — waits on a user decision (amber, correctly);


### PR DESCRIPTION
**Live incident, owner-reported 2026-07-26** (post-rebuild): the rebuilt binary stopped matching the Keychain ACL on the sealed GitHub credentials; macOS parked the first custody retrieve behind a SecurityAgent authorization, and the synchronous call sat on the async serve path — sampled: four runtime workers piled into `retrieve`, 16 lock-waits behind them, whole daemon unresponsive at 0% CPU. The dashboard showed `status: configured · credentials sealed · 0 repos watched · Listing the installation's repositories…` forever — the owner's verbatim complaint, and the same wedge signature seen once on the Track UX QA rig (now explained: rigs share the user keychain and my unsigned debug binary parked the same way).

Three layers:
- **`custody_blocking`**: every production `GithubAppCustody` touch runs via `block_in_place` (guarded for non-multi-thread contexts) — a parked Keychain call surrenders its runtime slot; the daemon keeps serving while the dialog waits.
- **Client watchdogs**: status + repository fetches race a 20 s deadline → NAMED refusal with the remedy (find the SecurityAgent dialog, Always Allow, Retry — button provided; errored listings no longer auto-retry every render). Progress lines are `is-progress` and honest about their bound.
- **Orientation-first copy**: one human sentence per state leads the section (what is true + what happens next); chips demoted to secondary facts; raw `status: X` pair removed; the `configured` status (sealed, no exchange this boot) mapped into the grammar — it previously fell through. The Automations empty state names the prerequisite chain (the UX0 §3 pointer, previously unshipped). Docs: rebuild→re-authorization bullet in the GitHub integration chapter.

**Scope note for the steward**: `custody_blocking` is daemon hardening beyond Track UX's restyle fence — shipped as a surgical live-incident fix and flagged here; the wider custody-call-site audit remains the parked GC commissioning candidate. Grammar pins hold (sweep clean, 21 routes_github tests green); fmt/clippy/bins battery green pre-queue this time.