### PR TITLE
fix(external): honest TaskOutcome for zero-turn fatal backend errors (the launch-refusal class)

### DIFF
--- a/src/bin/caller/external_events.rs
+++ b/src/bin/caller/external_events.rs
@@ -268,6 +268,12 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
     let mut pending_context_rewind: Option<ExternalContextRewindRequest> = None;
     let mut pending_context_rewind_turn_stop = ManagedContextRewindTurnStopTracker::default();
     let mut pending_backend_recovery: Option<ExternalBackendRecovery> = None;
+    // The cause of a fatal, non-recoverable backend error that ended the
+    // round with no real completion (the launch-refusal class). Cleared by
+    // a real turn completion inside the grace window; consumed at the exit,
+    // where a zero-turn round resolves as `TurnFailed` instead of lying
+    // with a completion.
+    let mut pending_fatal_round_error: Option<String> = None;
     let mut managed_context_rewind_only_pressure: Option<ManagedContextRewindOnlyPressure> = None;
     let mut managed_context_pressure_interrupt_sent = false;
     let managed_context_density_steer_suppressed = managed_context_recovery_kickstart
@@ -1135,6 +1141,7 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                             pending_context_rewind.take(),
                             pending_context_rewind_turn_stop.status(),
                             pending_backend_recovery.take(),
+                            pending_fatal_round_error.take(),
                             message,
                             turns_in_round,
                         );
@@ -1157,6 +1164,7 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                     pending_context_rewind.take(),
                     pending_context_rewind_turn_stop.status(),
                     pending_backend_recovery.take(),
+                    pending_fatal_round_error.take(),
                     message,
                     turns_in_round,
                 );
@@ -1580,6 +1588,11 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                         l.error(&content);
                     }
                 });
+                // A fatal error the wrapper deems unrecoverable is the
+                // round's honest cause; recoverable ones resolve through
+                // the recovery precedence at the exit instead.
+                let fatal_round_error =
+                    (!will_retry && event_is_primary && !recovery_required).then(|| content.clone());
                 config.bus.send(AppEvent::LogEntry {
                     session_id: config.session_id.clone(),
                     level: if will_retry || recovery_required {
@@ -1610,6 +1623,11 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                 // still takes precedence at the exit.
                 if !will_retry && event_is_primary && pending_turn_completion.is_none() {
                     pending_turn_completion = Some((None, turns_in_round));
+                    // First cause wins; an already-buffered REAL completion
+                    // (the branch guard above) never gets a fatal cause.
+                    if let Some(reason) = fatal_round_error {
+                        pending_fatal_round_error.get_or_insert(reason);
+                    }
                     if active_side_turns.is_empty() {
                         post_turn_sleep_active = true;
                         post_turn_sleep
@@ -2641,6 +2659,9 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                     });
                 }
                 pending_turn_completion = Some((message, turns_in_round));
+                // A real completion inside the grace window supersedes a
+                // buffered fatal cause — the turn did land after all.
+                pending_fatal_round_error = None;
                 if active_side_turns.is_empty() {
                     post_turn_sleep_active = true;
                     post_turn_sleep
@@ -3327,6 +3348,230 @@ mod tests {
             ["mid-turn steer text"],
             "targeted steer must reach the backend steer hook"
         );
+    }
+
+    fn drain_outcome_name(outcome: &DrainOutcome) -> &'static str {
+        match outcome {
+            DrainOutcome::TurnCompleted { .. } => "TurnCompleted",
+            DrainOutcome::TurnFailed { .. } => "TurnFailed",
+            DrainOutcome::Terminated { .. } => "Terminated",
+            DrainOutcome::ChannelClosed => "ChannelClosed",
+            DrainOutcome::RecoveryRequired { .. } => "RecoveryRequired",
+            DrainOutcome::Interrupted { .. } => "Interrupted",
+            DrainOutcome::ContextRewindRequested { .. } => "ContextRewindRequested",
+            DrainOutcome::LimitRejected { .. } => "LimitRejected",
+        }
+    }
+
+    /// The launch-refusal pin (2026-07-26): a fatal, non-recoverable
+    /// backend error that ends a round with ZERO completed turns must
+    /// drain as `TurnFailed` — the specimen (Claude Code refusing the
+    /// `fable-5` model pin at spawn) previously exited `TurnCompleted`,
+    /// rode a DoneSignal, and journaled its scheduled occurrence
+    /// COMPLETED with the failure invisible (occurrence 21fe746a).
+    #[tokio::test]
+    async fn fatal_backend_error_with_zero_turns_drains_as_turn_failed() {
+        let bus = EventBus::new();
+        let mut bus_rx_for_drain = bus.subscribe();
+        let dir = tempfile::tempdir().unwrap();
+        let log_dir = dir.path().join("session");
+        let session_log: SharedSessionLog = Arc::new(Mutex::new(
+            session_log::SessionLog::open(log_dir.clone()).unwrap(),
+        ));
+        let approval_registry: event::ApprovalRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let context_injection: event::ContextInjectionQueue = Arc::new(Mutex::new(Vec::new()));
+        let autonomy = autonomy::shared_autonomy(AutonomyState::default());
+        let config = DrainConfig {
+            bus: &bus,
+            web_port: None,
+            session_id: Some("cc-session".to_string()),
+            alias_session_id: None,
+            backend_thread_id: Some("cc-session".to_string()),
+            autonomy,
+            session_log: &session_log,
+            project_root: dir.path(),
+            log_dir: &log_dir,
+            approval_registry: &approval_registry,
+            json_approval: None,
+            agent_source: Some("Claude Code".to_string()),
+            suppress_agent_started: false,
+            persist_model_responses_inline: true,
+            headless: true,
+            context_injection: &context_injection,
+            reload_credentials: None,
+            coordination_declaration: None,
+        };
+        let refusal = "There's an issue with the selected model (fable-5). It may not exist \
+                       or you may not have access to it.";
+        let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
+        event_tx
+            .send(external_agent::AgentEvent::BackendError {
+                message: refusal.to_string(),
+                code: Some("success".to_string()),
+                details: None,
+                will_retry: false,
+                likely_generation_starvation: false,
+                recovery_hint: None,
+            })
+            .unwrap();
+        drop(event_tx);
+
+        let interrupts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let steers = Arc::new(Mutex::new(Vec::new()));
+        let mut agent: Box<dyn external_agent::ExternalAgent> = Box::new(ManagedDrainTestAgent {
+            interrupts: interrupts.clone(),
+            steers: steers.clone(),
+        });
+        let mut stats = LoopStats::default();
+        let mut diff_tracker = ExternalDiffDeltaTracker::default();
+        let mut pending_runtime_steers = std::collections::VecDeque::new();
+        let mut handled_steer_ids = std::collections::HashSet::new();
+        let mut cancelled_follow_ups = HashSet::new();
+        let mut dedupe = CodexThreadActionDedupe::default();
+
+        let outcome = drain_external_agent_events(
+            &mut agent,
+            &mut event_rx,
+            &mut bus_rx_for_drain,
+            &config,
+            &mut stats,
+            &mut diff_tracker,
+            &mut pending_runtime_steers,
+            &mut handled_steer_ids,
+            &mut cancelled_follow_ups,
+            &mut dedupe,
+            None,
+            None,
+            false,
+            false,
+            false,
+        )
+        .await;
+        match outcome {
+            DrainOutcome::TurnFailed {
+                reason,
+                turns_in_round,
+            } => {
+                assert_eq!(turns_in_round, 0);
+                assert!(
+                    reason.contains("fable-5") && reason.contains("backend error"),
+                    "reason carries the cause: {reason}"
+                );
+            }
+            other => panic!(
+                "zero-turn fatal backend error must drain TurnFailed, got {}",
+                drain_outcome_name(&other)
+            ),
+        }
+    }
+
+    /// A real turn completion inside the grace window supersedes a buffered
+    /// fatal cause, and a fatal error that ends a round AFTER completed
+    /// turns keeps the completion shape (real work happened) — only the
+    /// did-nothing round fails.
+    #[tokio::test]
+    async fn fatal_backend_error_yields_to_real_completions_and_real_turns() {
+        for (feed_real_completion, feed_tool_start) in [(true, false), (false, true)] {
+            let bus = EventBus::new();
+            let mut bus_rx_for_drain = bus.subscribe();
+            let dir = tempfile::tempdir().unwrap();
+            let log_dir = dir.path().join("session");
+            let session_log: SharedSessionLog = Arc::new(Mutex::new(
+                session_log::SessionLog::open(log_dir.clone()).unwrap(),
+            ));
+            let approval_registry: event::ApprovalRegistry = Arc::new(Mutex::new(HashMap::new()));
+            let context_injection: event::ContextInjectionQueue = Arc::new(Mutex::new(Vec::new()));
+            let autonomy = autonomy::shared_autonomy(AutonomyState::default());
+            let config = DrainConfig {
+                bus: &bus,
+                web_port: None,
+                session_id: Some("cc-session".to_string()),
+                alias_session_id: None,
+                backend_thread_id: Some("cc-session".to_string()),
+                autonomy,
+                session_log: &session_log,
+                project_root: dir.path(),
+                log_dir: &log_dir,
+                approval_registry: &approval_registry,
+                json_approval: None,
+                agent_source: Some("Claude Code".to_string()),
+                suppress_agent_started: false,
+                persist_model_responses_inline: true,
+                headless: true,
+                context_injection: &context_injection,
+                reload_credentials: None,
+                coordination_declaration: None,
+            };
+            let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
+            if feed_tool_start {
+                event_tx
+                    .send(external_agent::AgentEvent::ToolStarted {
+                        item_id: "tool-1".to_string(),
+                        tool_name: "bash".to_string(),
+                        preview: "ls".to_string(),
+                        message_uuid: None,
+                    })
+                    .unwrap();
+            }
+            event_tx
+                .send(external_agent::AgentEvent::BackendError {
+                    message: "transient provider outage".to_string(),
+                    code: None,
+                    details: None,
+                    will_retry: false,
+                    likely_generation_starvation: false,
+                    recovery_hint: None,
+                })
+                .unwrap();
+            if feed_real_completion {
+                event_tx
+                    .send(external_agent::AgentEvent::TurnCompleted {
+                        message: Some("recovered and finished".to_string()),
+                    })
+                    .unwrap();
+            }
+            drop(event_tx);
+
+            let interrupts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+            let steers = Arc::new(Mutex::new(Vec::new()));
+            let mut agent: Box<dyn external_agent::ExternalAgent> =
+                Box::new(ManagedDrainTestAgent {
+                    interrupts: interrupts.clone(),
+                    steers: steers.clone(),
+                });
+            let mut stats = LoopStats::default();
+            let mut diff_tracker = ExternalDiffDeltaTracker::default();
+            let mut pending_runtime_steers = std::collections::VecDeque::new();
+            let mut handled_steer_ids = std::collections::HashSet::new();
+            let mut cancelled_follow_ups = HashSet::new();
+            let mut dedupe = CodexThreadActionDedupe::default();
+
+            let outcome = drain_external_agent_events(
+                &mut agent,
+                &mut event_rx,
+                &mut bus_rx_for_drain,
+                &config,
+                &mut stats,
+                &mut diff_tracker,
+                &mut pending_runtime_steers,
+                &mut handled_steer_ids,
+                &mut cancelled_follow_ups,
+                &mut dedupe,
+                None,
+                None,
+                false,
+                false,
+                false,
+            )
+            .await;
+            assert!(
+                matches!(outcome, DrainOutcome::TurnCompleted { .. }),
+                "fatal error must not fail a round with real work \
+                 (real_completion={feed_real_completion}, tool_start={feed_tool_start}); \
+                 got {}",
+                drain_outcome_name(&outcome)
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/bin/caller/external_events.rs
+++ b/src/bin/caller/external_events.rs
@@ -1591,8 +1591,8 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                 // A fatal error the wrapper deems unrecoverable is the
                 // round's honest cause; recoverable ones resolve through
                 // the recovery precedence at the exit instead.
-                let fatal_round_error =
-                    (!will_retry && event_is_primary && !recovery_required).then(|| content.clone());
+                let fatal_round_error = (!will_retry && event_is_primary && !recovery_required)
+                    .then(|| content.clone());
                 config.bus.send(AppEvent::LogEntry {
                     session_id: config.session_id.clone(),
                     level: if will_retry || recovery_required {

--- a/src/bin/caller/external_mode.rs
+++ b/src/bin/caller/external_mode.rs
@@ -1109,6 +1109,43 @@ pub(crate) async fn run_external_agent_mode(
                                             }
                                         }
                                         match drain_outcome {
+                                            DrainOutcome::TurnFailed {
+                                                reason,
+                                                turns_in_round,
+                                            } => {
+                                                // A backend-started round
+                                                // observed from idle died on
+                                                // a fatal error before any
+                                                // turn ran: fail honestly,
+                                                // like the primary loop.
+                                                stats.rounds = round;
+                                                slog(&session_log, |l| {
+                                                    l.error(&format!(
+                                                        "External agent round failed before any turn completed while observed from idle: {reason}"
+                                                    ))
+                                                });
+                                                record_external_round_inline(
+                                                    &session_log,
+                                                    persist_model_responses_inline,
+                                                    round,
+                                                    turns_in_round,
+                                                );
+                                                bus.send(AppEvent::RoundComplete {
+                                                    session_id: live_session_id.clone(),
+                                                    round,
+                                                    turns_in_round,
+                                                    native_message_count: None,
+                                                    project_root: round_session_root.clone(),
+                                                });
+                                                bus.send(AppEvent::TaskComplete {
+                                                    session_id: live_session_id.clone(),
+                                                    reason: reason.clone(),
+                                                    summary: None,
+                                                    outcome: crate::event::TaskOutcome::Failed,
+                                                });
+                                                stats.terminal_outcome = Some(reason);
+                                                break 'outer;
+                                            }
                                             DrainOutcome::TurnCompleted {
                                                 message,
                                                 turns_in_round,
@@ -2573,6 +2610,20 @@ pub(crate) async fn run_external_agent_mode(
                                 project_root: round_session_root.clone(),
                             });
                         }
+                        DrainOutcome::TurnFailed { reason, .. } => {
+                            // The in-flight turn died on a fatal error
+                            // before running anything; the edit cannot be
+                            // applied to a failed round — report and skip
+                            // the rollback, like recovery/termination.
+                            let message = format!(
+                                "{} turn failed before edit rollback: {}",
+                                agent.name(),
+                                reason
+                            );
+                            slog(&session_log, |l| l.warn(&message));
+                            bus.send(AppEvent::LoopError(message));
+                            continue;
+                        }
                         DrainOutcome::RecoveryRequired {
                             message,
                             recovery_hint,
@@ -2816,6 +2867,49 @@ pub(crate) async fn run_external_agent_mode(
             }
         }
         match drain_outcome {
+            DrainOutcome::TurnFailed {
+                reason,
+                turns_in_round,
+            } => {
+                // The launch-refusal class: a fatal backend error ended the
+                // round before any turn ran (an invalid model pin, an auth
+                // refusal at spawn). The honest terminal is FAILED — the
+                // typed outcome is what the agenda scheduler journals
+                // (streaks, suspension, owner visibility); a DoneSignal
+                // here journaled a fable-5 refusal COMPLETED on 2026-07-26
+                // (occurrence 21fe746a). Follow-ups would re-fire into the
+                // same refusal (the pin rides the launch config), so the
+                // supervised span ends like a termination.
+                stats.rounds = round;
+                slog(&session_log, |l| {
+                    l.error(&format!(
+                        "External agent round failed before any turn completed: {reason}"
+                    ))
+                });
+                record_external_round_inline(
+                    &session_log,
+                    persist_model_responses_inline,
+                    round,
+                    turns_in_round,
+                );
+                bus.send(AppEvent::RoundComplete {
+                    session_id: live_session_id.clone(),
+                    round,
+                    turns_in_round,
+                    native_message_count: None,
+                    project_root: round_session_root.clone(),
+                });
+                bus.send(AppEvent::TaskComplete {
+                    session_id: live_session_id.clone(),
+                    reason: reason.clone(),
+                    // Never the "agent's last words": for a round that ran
+                    // nothing, the cause is the whole story.
+                    summary: None,
+                    outcome: crate::event::TaskOutcome::Failed,
+                });
+                stats.terminal_outcome = Some(reason);
+                break;
+            }
             DrainOutcome::TurnCompleted {
                 message,
                 turns_in_round,

--- a/src/bin/caller/external_supervision.rs
+++ b/src/bin/caller/external_supervision.rs
@@ -1377,6 +1377,21 @@ pub(crate) enum DrainOutcome {
         message: Option<String>,
         turns_in_round: usize,
     },
+    /// A fatal (non-retryable, non-recoverable) backend error ended the
+    /// round before any turn completed — the launch-refusal class: an
+    /// invalid `--model` pin, an auth refusal at spawn. The backend
+    /// process may still be running, but the round did no work and the
+    /// error is its honest outcome. The caller must end with a FAILED
+    /// terminal ([`crate::event::TaskOutcome::Failed`]), never a
+    /// DoneSignal: a scheduled occurrence resolved by this shape journals
+    /// `failed` (suspend streaks, owner visibility), not `completed`
+    /// (2026-07-26: a fable-5 launch refusal rode a DoneSignal into a
+    /// COMPLETED occurrence and the failure was invisible — specimen
+    /// occurrence 21fe746a, session 6993c73f).
+    TurnFailed {
+        reason: String,
+        turns_in_round: usize,
+    },
     /// The agent process terminated.
     Terminated {
         reason: String,

--- a/src/bin/caller/managed_context_ops/mod.rs
+++ b/src/bin/caller/managed_context_ops/mod.rs
@@ -425,6 +425,7 @@ pub(crate) fn backend_recovery_outcome_or_context_rewind(
     request: Option<ExternalContextRewindRequest>,
     turn_stop_status: ManagedContextRewindTurnStopStatus,
     recovery: Option<ExternalBackendRecovery>,
+    fatal_round_error: Option<String>,
     message: Option<String>,
     turns_in_round: usize,
 ) -> DrainOutcome {
@@ -442,6 +443,19 @@ pub(crate) fn backend_recovery_outcome_or_context_rewind(
             recovery_hint: recovery.recovery_hint,
             turns_in_round,
         };
+    }
+    // A fatal backend error that ended a ZERO-turn round is the
+    // launch-refusal class: nothing ran, so completing the round would
+    // journal a lie. A round with completed turns keeps its completion
+    // shape even when a fatal error ends it — real work happened and the
+    // error is already logged; only the did-nothing round fails.
+    if turns_in_round == 0 {
+        if let Some(reason) = fatal_round_error {
+            return DrainOutcome::TurnFailed {
+                reason,
+                turns_in_round,
+            };
+        }
     }
     DrainOutcome::TurnCompleted {
         message,
@@ -800,6 +814,61 @@ pub(crate) fn find_context_rewind_anchor_entry(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Drain-exit precedence: a pending rewind and a pending recovery both
+    /// outrank a fatal round error, and the fatal error fails ONLY a
+    /// zero-turn round — a round with real turns keeps its completion
+    /// shape (the 2026-07-26 launch-refusal rider's deliberate scope).
+    #[test]
+    fn drain_exit_fails_only_zero_turn_rounds_with_a_fatal_error() {
+        let outcome = backend_recovery_outcome_or_context_rewind(
+            None,
+            ManagedContextRewindTurnStopStatus::NotRequested,
+            None,
+            Some("claude-code backend error (success): bad model".to_string()),
+            None,
+            0,
+        );
+        match outcome {
+            DrainOutcome::TurnFailed {
+                reason,
+                turns_in_round,
+            } => {
+                assert_eq!(turns_in_round, 0);
+                assert!(reason.contains("bad model"));
+            }
+            _ => panic!("zero-turn fatal error must resolve TurnFailed"),
+        }
+
+        // Real turns: the fatal error never downgrades a round with work.
+        assert!(matches!(
+            backend_recovery_outcome_or_context_rewind(
+                None,
+                ManagedContextRewindTurnStopStatus::NotRequested,
+                None,
+                Some("late fatal error".to_string()),
+                Some("did things".to_string()),
+                2,
+            ),
+            DrainOutcome::TurnCompleted { .. }
+        ));
+
+        // Recovery outranks the fatal cause even at zero turns.
+        assert!(matches!(
+            backend_recovery_outcome_or_context_rewind(
+                None,
+                ManagedContextRewindTurnStopStatus::NotRequested,
+                Some(ExternalBackendRecovery {
+                    message: "starved".to_string(),
+                    recovery_hint: None,
+                }),
+                Some("fatal cause".to_string()),
+                None,
+                0,
+            ),
+            DrainOutcome::RecoveryRequired { .. }
+        ));
+    }
 
     #[test]
     fn context_rewind_thread_id_candidates_prefers_session_then_alias() {

--- a/src/bin/caller/run_modes.rs
+++ b/src/bin/caller/run_modes.rs
@@ -943,6 +943,31 @@ pub(crate) async fn run_with_presence(
                                             project_root: round_session_root.clone(),
                                         });
                                     }
+                                    Ok(DrainOutcome::TurnFailed {
+                                        reason,
+                                        turns_in_round,
+                                    }) => {
+                                        // The resumed turn died on a fatal
+                                        // error before running anything —
+                                        // report the failure, never a done
+                                        // signal for a turn that never ran.
+                                        cumulative_stats.rounds += 1;
+                                        bus.send(AppEvent::RoundComplete {
+                                            session_id: session_log_id(&session_log),
+                                            round: cumulative_stats.rounds,
+                                            turns_in_round,
+                                            native_message_count: None,
+                                            project_root: round_session_root.clone(),
+                                        });
+                                        bus.send(AppEvent::PresenceLog {
+                                            message: format!(
+                                                "External agent turn failed before any work: {}",
+                                                reason
+                                            ),
+                                            level: Some(types::LogLevel::Error),
+                                            turn: None,
+                                        });
+                                    }
                                     Ok(DrainOutcome::ContextRewindRequested {
                                         request, ..
                                     }) => {
@@ -970,6 +995,27 @@ pub(crate) async fn run_with_presence(
                                                     turns_in_round,
                                                     native_message_count: None,
                                                     project_root: round_session_root.clone(),
+                                                });
+                                            }
+                                            Ok(Some(DrainOutcome::TurnFailed {
+                                                reason,
+                                                turns_in_round,
+                                            })) => {
+                                                cumulative_stats.rounds += 1;
+                                                bus.send(AppEvent::RoundComplete {
+                                                    session_id: session_log_id(&session_log),
+                                                    round: cumulative_stats.rounds,
+                                                    turns_in_round,
+                                                    native_message_count: None,
+                                                    project_root: round_session_root.clone(),
+                                                });
+                                                bus.send(AppEvent::PresenceLog {
+                                                    message: format!(
+                                                        "External agent turn failed before any work during resumed context-rewind turn: {}",
+                                                        reason
+                                                    ),
+                                                    level: Some(types::LogLevel::Error),
+                                                    turn: None,
                                                 });
                                             }
                                             Ok(Some(DrainOutcome::LimitRejected {
@@ -2066,6 +2112,27 @@ pub(crate) async fn run_with_presence(
                                         project_root: round_session_root.clone(),
                                     });
                                 }
+                                DrainOutcome::TurnFailed {
+                                    reason,
+                                    turns_in_round,
+                                } => {
+                                    // A spontaneous round died on a fatal
+                                    // error before running anything: close
+                                    // the round without a done signal.
+                                    cumulative_stats.rounds = round;
+                                    slog(&session_log, |l| {
+                                        l.error(&format!(
+                                            "Spontaneous external round failed before any turn completed: {reason}"
+                                        ))
+                                    });
+                                    bus.send(AppEvent::RoundComplete {
+                                        session_id: session_log_id(&session_log),
+                                        round,
+                                        turns_in_round,
+                                        native_message_count: None,
+                                        project_root: round_session_root.clone(),
+                                    });
+                                }
                                 DrainOutcome::Interrupted { .. } => {
                                     cumulative_stats.rounds = round;
                                 }
@@ -2935,6 +3002,35 @@ pub(crate) async fn run_with_presence(
                 }
 
                 match outcome {
+                    DrainOutcome::TurnFailed {
+                        reason,
+                        turns_in_round,
+                    } => {
+                        // The turn died on a fatal error before running
+                        // anything (the launch-refusal class): close the
+                        // round as a failure — no done signal for a turn
+                        // that never ran.
+                        cumulative_stats.rounds += 1;
+                        slog(&session_log, |l| {
+                            l.error(&format!(
+                                "External agent turn failed before any work: {reason}"
+                            ))
+                        });
+                        bus.send(AppEvent::RoundComplete {
+                            session_id: session_log_id(&session_log),
+                            round: cumulative_stats.rounds,
+                            turns_in_round,
+                            native_message_count: None,
+                            project_root: round_session_root.clone(),
+                        });
+                        bus.send(AppEvent::PresenceLog {
+                            message: format!(
+                                "External agent turn failed before any work: {reason}"
+                            ),
+                            level: Some(types::LogLevel::Error),
+                            turn: None,
+                        });
+                    }
                     DrainOutcome::TurnCompleted {
                         message,
                         turns_in_round,

--- a/src/bin/caller/thread_actions.rs
+++ b/src/bin/caller/thread_actions.rs
@@ -3490,6 +3490,21 @@ pub(crate) async fn drain_external_child_turn(
         DrainOutcome::TurnCompleted { message, .. } => {
             emit_child_turn_complete(&child_config, conversation_kind, message);
         }
+        DrainOutcome::TurnFailed { reason, .. } => {
+            // A zero-turn fatal error inside a child conversation: report
+            // the cause; no child completion is emitted for a turn that
+            // never ran.
+            child_config.bus.send(AppEvent::LogEntry {
+                session_id: child_config.session_id.clone(),
+                level: "error".to_string(),
+                source: backend_label.clone(),
+                content: format!(
+                    "{} conversation turn failed before any work: {}",
+                    conversation_kind, reason
+                ),
+                turn: None,
+            });
+        }
         DrainOutcome::LimitRejected {
             resets_at_epoch,
             message,


### PR DESCRIPTION
## The rider

Commission 01KYFJRC's rider (owner-plane steward, 2026-07-26): a claude-code LAUNCH failure — the CLI refusing the `fable-5` model pin at spawn, printed as `claude-code backend error (success): There's an issue with the selected model (fable-5)…` — journaled its scheduled occurrence **COMPLETED**, not failed. No streak, no suspension, failure invisible. Specimen: occurrence `21fe746a`, session `6993c73f`.

## Mechanism

The drain buffered the fatal BackendError as a synthetic turn completion (`pending_turn_completion = (None, turns)`), the post-turn grace elapsed, and the exit resolved `TurnCompleted` → the supervised loop emitted a **DoneSignal carrying the refusal text** → the agenda scheduler's `DoneSignal → complete_running` journaled COMPLETED.

## The fix

- New `DrainOutcome::TurnFailed { reason, turns_in_round }`: at drain exit, a fatal, non-recoverable backend error that ended a **zero-turn** round resolves as failure. Precedence: context-rewind > recovery > fatal(zero-turn) > completed.
- A real completion inside the grace window supersedes the buffered cause; a fatal error after completed turns keeps the completion shape (real work happened) — the did-nothing round is the deliberate scope.
- The supervised loops map `TurnFailed` → `TaskComplete { outcome: TaskOutcome::Failed, reason }` — the same typed mapping the AU work gave external kills — so the scheduler journals `failed` and standing-mandate suspension streaks see it. All eight `DrainOutcome` consumers handled per their local idiom (presence lanes report via PresenceLog error; child drains log; edit-rollback skips like recovery).

## Pins

- `fatal_backend_error_with_zero_turns_drains_as_turn_failed` — the specimen shape end-to-end through the real drain.
- `fatal_backend_error_yields_to_real_completions_and_real_turns` — supersede + scope.
- `drain_exit_fails_only_zero_turn_rounds_with_a_fatal_error` — exit precedence.

Part of commission 01KYFJRC (registry sweep + intake normalization landed as #615).