### PR TITLE
feat(agenda): hash-pinned binding refs sealed under the approval digest, verified at propose and every fire

### DIFF
--- a/docs/src/agenda-and-memory.md
+++ b/docs/src/agenda-and-memory.md
@@ -386,6 +386,33 @@ lands: a mandate whose SUB-agents park matching items can cycle at the
 cooldown rate — visible in the journal, bounded by suspension. An
 event trigger never widens who approves manifests.
 
+**Hash-pinned binding refs (sealed refs, owner-ruled 2026-07-26).** The
+approval digest covers the manifest, but a goal often *references*
+content — a must-read brief, a mandate rider — that lived outside the
+digest and stayed editable under an armed approval. A manifest may now
+carry `binding_refs` (`[{locator, sha256}]`, additive — absent means
+none and legacy digests are unchanged): `ctl agenda schedule
+--binding-ref file:PATH` (repeatable) hashes the file **at propose
+time** and embeds the pin; because the pins are manifest bytes, the
+approval digest covers them, and changing a ref is a revision that
+re-opens review. Intake verifies each pin against the daemon's own read
+(mismatch, unreadable path, or a non-`file:` locator refuses by name —
+v1 seals absolute `file:` paths only; `body:` and `git:` forms are
+future vocabulary), and **every fire re-verifies**: a drifted or
+unreadable ref refuses to spawn — the occurrence journals terminal
+`failed` with the named reason (`binding ref drifted: <locator>` /
+`binding ref unreadable: <locator>`), the write-back lands on the item,
+and the failure counts on the standing streak, so a stale standing
+manifest suspends and surfaces to the owner instead of firing over its
+own drift. Each fired task carries one data line per ref (locator +
+approved sha256, verified at fire) under the source rider. Doctrine:
+the *content behind a verified pin* is exactly what the owner reviewed
+and may carry instructions for the fired session; everything else a
+fired session reads — bodies, annotations, unhashed G1 refs — remains
+data, never instructions. On older builds a sealed manifest degrades
+fail-closed like recurrence/trigger: digest mismatch, never an unsealed
+firing.
+
 **Start now** (`start_now`, `ctl agenda start`, the item's button) is the
 owner's act-on-item. On dashboard surfaces the button opens a **confirm
 sheet** (bottom sheet on coarse pointers and narrow viewports, anchored

--- a/skills/intendant-agenda/SKILL.md
+++ b/skills/intendant-agenda/SKILL.md
@@ -106,6 +106,12 @@ dashboard, attributed to your session.
   digest, so revising the manifest (re-running `schedule`) voids any
   approval. The outcome writes back to the item (`effects[].last_run`
   in `list --json`: state, session id, note) — check it next session.
+  If the goal depends on a file (a brief, a rider), seal it:
+  `--binding-ref file:PATH` (repeatable) sha256-pins the content at
+  propose time under the approval digest — editing the file after
+  approval makes the next fire refuse (occurrence `failed`, named
+  reason) instead of running against drifted content, so keep sealed
+  files stable or re-propose after editing them.
 
 - Titles are one actionable line; details go in `--body` (markdown, shown
   quoted). `--due` accepts `+45m/+2h/+3d/+1w`, `YYYY-MM-DD`, RFC3339.

--- a/src/bin/caller/agenda/handle.rs
+++ b/src/bin/caller/agenda/handle.rs
@@ -745,6 +745,7 @@ mod tests {
         let proposed = handle
             .apply(
                 AgendaCommand::ProposeEffect {
+                    binding_refs: Vec::new(),
                     recurrence: None,
                     id: item.id.clone(),
                     goal: "run the cert sweep and report".into(),
@@ -1631,6 +1632,7 @@ mod tests {
         let first = handle
             .apply(
                 AgendaCommand::ProposeEffect {
+                    binding_refs: Vec::new(),
                     recurrence: None,
                     id: item.id.clone(),
                     goal: "summarize the week".into(),
@@ -1672,6 +1674,7 @@ mod tests {
         let revised = handle
             .apply(
                 AgendaCommand::ProposeEffect {
+                    binding_refs: Vec::new(),
                     recurrence: None,
                     id: item.id.clone(),
                     goal: "summarize the week AND email it".into(),
@@ -1823,6 +1826,7 @@ mod tests {
         let proposed = handle
             .apply(
                 AgendaCommand::ProposeEffect {
+                    binding_refs: Vec::new(),
                     recurrence: None,
                     id: item.id.clone(),
                     goal: "summarize the week".into(),

--- a/src/bin/caller/agenda/mod.rs
+++ b/src/bin/caller/agenda/mod.rs
@@ -48,7 +48,7 @@ pub(crate) use reminders::{
 pub(crate) use scheduler::spawn_reminder_scheduler;
 pub(crate) use spawn_project::{recorded_session_project_root, SessionSpawnContext};
 pub(crate) use store::{
-    file_ref_drift, AgendaError, AgendaOpsPage, AgendaStore, AGENDA_OPS_DEFAULT_LIMIT,
+    digest_file, file_ref_drift, AgendaError, AgendaOpsPage, AgendaStore, AGENDA_OPS_DEFAULT_LIMIT,
 };
 pub(crate) use types::{
     AgendaActor, AgendaAnswer, AgendaCommand, AgendaCounts, AgendaItem, AgendaKind, AgendaRefSpec,

--- a/src/bin/caller/agenda/reminders.rs
+++ b/src/bin/caller/agenda/reminders.rs
@@ -33,7 +33,7 @@
 //! double-fire window between two live daemons sharing one home —
 //! at-least-once, honestly.
 
-use super::types::{AgendaEffect, AgendaItem, AgendaStatus, RecurrenceSpec};
+use super::types::{AgendaEffect, AgendaItem, AgendaStatus, BindingRef, RecurrenceSpec};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::io::Write;
@@ -684,6 +684,10 @@ pub(crate) struct SpawnOccurrence {
     /// dispatch-time consumed-annotations — NEVER journal fields (rows
     /// stay shape-identical to cadence occurrences).
     pub(crate) matched_item_ids: Vec<String>,
+    /// The manifest's hash-pinned binding refs (sealed refs), carried to
+    /// the dispatcher for the fire-time seal check and the fired task's
+    /// per-ref data lines.
+    pub(crate) binding_refs: Vec<BindingRef>,
 }
 
 /// Occurrence identity for a scheduled session: entry + effect + the
@@ -1062,6 +1066,7 @@ pub(crate) fn plan(
                     agent_config: effect.manifest.agent_config.clone(),
                     provenance_session_id: item.provenance.session_id.clone(),
                     matched_item_ids: trigger_batch.clone(),
+                    binding_refs: effect.manifest.binding_refs.clone(),
                 };
                 if progress.prepared {
                     // Crash between prepare and launch confirmation: fail
@@ -1700,6 +1705,7 @@ mod tests {
     fn standing_item(id: &str, fire_at: u64, rec: RecurrenceSpec) -> AgendaItem {
         let mut base = item(id, AgendaStatus::Open, None);
         let manifest = SessionManifest {
+            binding_refs: Vec::new(),
             goal: "standing run".into(),
             fire_at_ms: fire_at,
             orchestrate: false,
@@ -2012,6 +2018,7 @@ mod tests {
         let one_shot = {
             let mut base = item("os", AgendaStatus::Open, None);
             let manifest = SessionManifest {
+                binding_refs: Vec::new(),
                 goal: "one shot".into(),
                 fire_at_ms: 50_000,
                 orchestrate: false,
@@ -2063,6 +2070,7 @@ mod tests {
     fn one_shot_item(id: &str, fire_at: u64) -> AgendaItem {
         let mut base = item(id, AgendaStatus::Open, None);
         let manifest = SessionManifest {
+            binding_refs: Vec::new(),
             goal: "one shot".into(),
             fire_at_ms: fire_at,
             orchestrate: false,
@@ -2742,6 +2750,7 @@ mod tests {
     ) -> AgendaItem {
         let mut base = item(id, AgendaStatus::Open, None);
         let manifest = SessionManifest {
+            binding_refs: Vec::new(),
             goal: "triggered run".into(),
             fire_at_ms: fire_at,
             orchestrate: false,

--- a/src/bin/caller/agenda/scheduler.rs
+++ b/src/bin/caller/agenda/scheduler.rs
@@ -505,6 +505,19 @@ fn dispatch_session(
             return false;
         }
     };
+    // Fire-time seal check (sealed refs): every binding ref must still
+    // hash to its approved pin — an approved goal never spawns against
+    // silently drifted or unreadable referenced content. The refusal is
+    // this occurrence's terminal `failed` outcome with the named reason,
+    // written back to the item and counted by the standing failure
+    // streak, so a stale standing manifest suspends and surfaces to the
+    // owner instead of firing over its own drift again and again.
+    for binding_ref in &spawn.binding_refs {
+        if let Err(why) = super::store::verify_binding_ref(binding_ref) {
+            resolve_spawnless(handle, journal, &spawn, OccurrenceState::Failed, now, &why);
+            return false;
+        }
+    }
     if !session_record(journal, &spawn, now, OccurrenceState::Prepared, None) {
         return false; // cannot journal ⇒ do not spawn what we cannot dedup
     }
@@ -568,13 +581,22 @@ fn send_start_task(handle: &AgendaHandle, spawn: &SpawnOccurrence, project_root:
     // Every fired session's task carries a data rider naming its source:
     // the agenda item + occurrence that fired it, so goal self-references
     // ("THIS item", "your prerequisite item") resolve mechanically through
-    // the session's own attributed ctl; an on_item_match batch adds its
-    // matched ids (Track T). Both lines are data to act on under the
-    // approved goal, never instructions themselves.
+    // the session's own attributed ctl; each binding ref adds one line —
+    // locator + approved sha256, verified at fire (sealed refs: the
+    // CONTENT behind a verified pin is what the owner reviewed and may
+    // carry instructions; the line itself is a pointer); an on_item_match
+    // batch adds its matched ids (Track T). All rider lines are data to
+    // act on under the approved goal, never instructions themselves.
     let mut task = format!(
         "{}\n\nFired from agenda item {} (occurrence {})",
         spawn.goal, spawn.item_id, spawn.occurrence_id
     );
+    for binding_ref in &spawn.binding_refs {
+        task.push_str(&format!(
+            "\nBinding ref {} sha256 {} — verified at fire",
+            binding_ref.locator, binding_ref.sha256
+        ));
+    }
     if !spawn.matched_item_ids.is_empty() {
         task.push_str(&format!(
             "\nMatched agenda items (this firing's batch): {}",
@@ -1089,7 +1111,7 @@ pub(crate) fn local_minute_of_day_at(instant_ms: u64) -> u16 {
 #[cfg(test)]
 mod tests {
     use super::super::store::AgendaStore;
-    use super::super::types::{AgendaCommand, AgendaKind};
+    use super::super::types::{AgendaCommand, AgendaKind, BindingRef, RecurrenceSpec};
     use super::*;
     use crate::event::EventBus;
 
@@ -1293,6 +1315,7 @@ mod tests {
         let proposed = handle
             .apply(
                 AgendaCommand::ProposeEffect {
+                    binding_refs: Vec::new(),
                     recurrence: None,
                     id: item.id.clone(),
                     goal: "run the nightly sweep".into(),
@@ -1318,6 +1341,223 @@ mod tests {
             )
             .unwrap();
         (item.id, effect_id, proposed.effects[0].digest.clone())
+    }
+
+    /// Parks one item and proposes+approves a sealed manifest on it —
+    /// binding refs riding the digest the owner approves (intake verifies
+    /// the pins, so the referenced files must exist with exactly the
+    /// pinned bytes at propose time).
+    fn approved_sealed_item(
+        handle: &AgendaHandle,
+        fire_at_ms: u64,
+        goal: &str,
+        binding_refs: Vec<BindingRef>,
+        recurrence: Option<RecurrenceSpec>,
+    ) -> String {
+        let item = handle
+            .apply(
+                AgendaCommand::Add {
+                    refs: Vec::new(),
+                    kind: AgendaKind::Task,
+                    title: "sealed work".into(),
+                    body: String::new(),
+                    tags: Vec::new(),
+                    due_ms: None,
+                    source: None,
+                },
+                None,
+            )
+            .unwrap();
+        let proposed = handle
+            .apply(
+                AgendaCommand::ProposeEffect {
+                    id: item.id.clone(),
+                    goal: goal.into(),
+                    fire_at_ms,
+                    orchestrate: false,
+                    recurrence,
+                    agent_config: None,
+                    trigger: None,
+                    project_root: None,
+                    binding_refs,
+                    source: None,
+                },
+                None,
+            )
+            .unwrap();
+        handle
+            .apply(
+                AgendaCommand::ApproveEffect {
+                    id: item.id.clone(),
+                    digest: proposed.effects[0].digest.clone(),
+                },
+                owner(),
+            )
+            .unwrap();
+        item.id
+    }
+
+    /// Sealed refs, pin (c): the fired task's exact bytes extend with one
+    /// data line per binding ref — locator + approved sha256, verified at
+    /// fire — under the source line, before any batch line.
+    #[tokio::test]
+    async fn sealed_manifest_task_carries_binding_ref_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        let default_project = tempfile::tempdir().unwrap();
+        let content = tempfile::tempdir().unwrap();
+        let brief = content.path().join("brief.md");
+        std::fs::write(&brief, b"sealed instructions v1\n").unwrap();
+        let pin = super::super::store::digest_file(&brief).unwrap();
+        let locator = format!("file:{}", brief.display());
+        let handle = handle_with_default_project(dir.path(), default_project.path());
+        let mut journal = OccurrenceJournal::open(handle.dir()).unwrap();
+        let mut state = SchedulerState::default();
+        let item_id = approved_sealed_item(
+            &handle,
+            now_ms() - 60_000,
+            "act on the sealed brief",
+            vec![BindingRef {
+                locator: locator.clone(),
+                sha256: pin.clone(),
+            }],
+            None,
+        );
+
+        let mut rx = handle.bus().subscribe();
+        run_pass(&handle, &mut journal, &mut state).await;
+        let mut dispatched = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            if let AppEvent::ControlCommand(ControlMsg::StartTask {
+                task,
+                delegation_id: Some(delegation_id),
+                ..
+            }) = event
+            {
+                dispatched.push((task, delegation_id));
+            }
+        }
+        assert_eq!(dispatched.len(), 1, "the sealed manifest dispatches");
+        let occurrence_id = dispatched[0].1.strip_prefix(DELEGATION_PREFIX).unwrap();
+        assert_eq!(
+            dispatched[0].0,
+            format!(
+                "act on the sealed brief\n\nFired from agenda item {item_id} \
+                 (occurrence {occurrence_id})\nBinding ref {locator} sha256 {pin} \
+                 — verified at fire"
+            ),
+            "each binding ref rides the fired task as one data line"
+        );
+    }
+
+    /// Sealed refs, pin (b): the live-failure shape. An approved STANDING
+    /// manifest whose referenced file changes after approval refuses to
+    /// spawn at fire time — no StartTask, the occurrence journals
+    /// terminal `failed` with the named drift reason, the write-back
+    /// lands on the item, and the failure counts on the standing streak
+    /// (the suspension counter) so a stale manifest suspends and
+    /// surfaces instead of firing over its own drift. A deleted ref
+    /// refuses the same way under the `unreadable` name.
+    #[tokio::test]
+    async fn binding_ref_drift_refuses_spawn_and_journals_failed() {
+        let dir = tempfile::tempdir().unwrap();
+        let default_project = tempfile::tempdir().unwrap();
+        let content = tempfile::tempdir().unwrap();
+        let drifting = content.path().join("drifting.md");
+        let vanishing = content.path().join("vanishing.md");
+        std::fs::write(&drifting, b"approved bytes\n").unwrap();
+        std::fs::write(&vanishing, b"soon gone\n").unwrap();
+        let drifting_locator = format!("file:{}", drifting.display());
+        let vanishing_locator = format!("file:{}", vanishing.display());
+        let handle = handle_with_default_project(dir.path(), default_project.path());
+        let mut journal = OccurrenceJournal::open(handle.dir()).unwrap();
+        let mut state = SchedulerState::default();
+        let recurrence = || {
+            Some(RecurrenceSpec {
+                every_ms: super::super::types::RECURRENCE_MIN_EVERY_MS,
+                until_ms: None,
+                max_occurrences: None,
+                suspend_after_failures: None,
+            })
+        };
+        let drift_item = approved_sealed_item(
+            &handle,
+            now_ms() - 60_000,
+            "sweep with the approved brief",
+            vec![BindingRef {
+                locator: drifting_locator.clone(),
+                sha256: super::super::store::digest_file(&drifting).unwrap(),
+            }],
+            recurrence(),
+        );
+        let vanish_item = approved_sealed_item(
+            &handle,
+            now_ms() - 60_000,
+            "sweep with the vanishing brief",
+            vec![BindingRef {
+                locator: vanishing_locator.clone(),
+                sha256: super::super::store::digest_file(&vanishing).unwrap(),
+            }],
+            recurrence(),
+        );
+
+        // The live specimen: the referenced file is amended (and the
+        // other deleted) UNDER the armed approval.
+        std::fs::write(&drifting, b"amended after approval\n").unwrap();
+        std::fs::remove_file(&vanishing).unwrap();
+
+        let mut rx = handle.bus().subscribe();
+        run_pass(&handle, &mut journal, &mut state).await;
+        while let Ok(event) = rx.try_recv() {
+            assert!(
+                !matches!(
+                    event,
+                    AppEvent::ControlCommand(ControlMsg::StartTask { .. })
+                ),
+                "a drifted seal must not spawn"
+            );
+        }
+        let (items, _, _) = handle.snapshot();
+        let drifted = items.iter().find(|i| i.id == drift_item).unwrap();
+        let run = drifted.effects[0].last_run.as_ref().unwrap();
+        assert_eq!(run.state, "failed");
+        let note = run.note.as_deref().unwrap_or_default();
+        assert!(
+            note.starts_with(&format!("binding ref drifted: {drifting_locator}")),
+            "the named reason reaches the item: {note}"
+        );
+        assert_eq!(
+            journal.progress(&run.occurrence_id).terminal,
+            Some(OccurrenceState::Failed),
+            "the journal records the terminal refusal"
+        );
+        assert_eq!(
+            drifted.effects[0].consecutive_failures, 1,
+            "the refusal counts on the standing streak — suspension machinery sees it"
+        );
+        let vanished = items.iter().find(|i| i.id == vanish_item).unwrap();
+        let run = vanished.effects[0].last_run.as_ref().unwrap();
+        assert_eq!(run.state, "failed");
+        let note = run.note.as_deref().unwrap_or_default();
+        assert!(
+            note.starts_with(&format!("binding ref unreadable: {vanishing_locator}")),
+            "the unreadable case refuses under its own name: {note}"
+        );
+        assert_eq!(vanished.effects[0].consecutive_failures, 1);
+
+        // Restoring the approved bytes does not resurrect the SPENT
+        // occurrence — the next series instant fires normally instead.
+        std::fs::write(&drifting, b"approved bytes\n").unwrap();
+        let mut rx = handle.bus().subscribe();
+        run_pass(&handle, &mut journal, &mut state).await;
+        while let Ok(event) = rx.try_recv() {
+            assert!(
+                !matches!(
+                    event,
+                    AppEvent::ControlCommand(ControlMsg::StartTask { .. })
+                ),
+                "a spent refused occurrence must not re-dispatch inside its instant"
+            );
+        }
     }
 
     /// The A5 lifecycle at unit level: an approved due manifest dispatches
@@ -1352,6 +1592,7 @@ mod tests {
         handle
             .apply(
                 AgendaCommand::ProposeEffect {
+                    binding_refs: Vec::new(),
                     recurrence: None,
                     id: bystander.id.clone(),
                     goal: "must not run".into(),
@@ -1470,6 +1711,7 @@ mod tests {
         handle
             .apply(
                 AgendaCommand::ProposeEffect {
+                    binding_refs: Vec::new(),
                     recurrence: None,
                     id: item_id.clone(),
                     goal: "run the nightly sweep, rev 2".into(),
@@ -1996,6 +2238,7 @@ mod tests {
 
         let mut rx = handle.bus().subscribe();
         let spawn = SpawnOccurrence {
+            binding_refs: Vec::new(),
             occurrence_id: "occ-batch".into(),
             item_id: "standing-item".into(),
             effect_id: "ef-1".into(),
@@ -2097,6 +2340,7 @@ mod tests {
         let proposed = handle
             .apply(
                 AgendaCommand::ProposeEffect {
+                    binding_refs: Vec::new(),
                     id: item.id.clone(),
                     goal: "triage pass".into(),
                     fire_at_ms: now_ms() - 30_000,
@@ -2731,6 +2975,7 @@ mod tests {
         let proposed = handle
             .apply(
                 AgendaCommand::ProposeEffect {
+                    binding_refs: Vec::new(),
                     recurrence: None,
                     id: item.id.clone(),
                     goal: "sweep it".into(),

--- a/src/bin/caller/agenda/store.rs
+++ b/src/bin/caller/agenda/store.rs
@@ -5,9 +5,10 @@
 
 use super::types::{
     apply_op, counts, AgendaActor, AgendaCommand, AgendaCounts, AgendaItem, AgendaOp,
-    AgendaOpRecord, AgendaPatch, AgendaRefType, AgendaStatus, AGENDA_LOG_VERSION,
-    MAX_ANNOTATIONS_PER_ITEM, MAX_BODY_BYTES, MAX_CHILDREN_PER_HUB, MAX_CRITERION_CHARS,
-    MAX_PART_OF_DEPTH, MAX_REFS_PER_ITEM, MAX_REF_FILE_HASH_BYTES, MAX_REF_FILE_LOCATOR_CHARS,
+    AgendaOpRecord, AgendaPatch, AgendaRefType, AgendaStatus, BindingRef, AGENDA_LOG_VERSION,
+    BINDING_REF_FILE_SCHEME, MAX_ANNOTATIONS_PER_ITEM, MAX_BINDING_REFS_PER_MANIFEST,
+    MAX_BODY_BYTES, MAX_CHILDREN_PER_HUB, MAX_CRITERION_CHARS, MAX_PART_OF_DEPTH,
+    MAX_REFS_PER_ITEM, MAX_REF_FILE_HASH_BYTES, MAX_REF_FILE_LOCATOR_CHARS,
     MAX_REF_ID_LOCATOR_CHARS, MAX_REF_LABEL_CHARS, MAX_REF_URL_LOCATOR_CHARS,
     MAX_RELATES_TO_PER_ITEM, MAX_RELIES_ON_PER_ITEM, MAX_SOURCE_CHARS, MAX_TAGS, MAX_TAG_CHARS,
     MAX_TITLE_CHARS, MAX_UNCLEARED_BLOCKERS_PER_ITEM, TRIGGER_MATCH_TAGS_MAX,
@@ -510,8 +511,12 @@ impl AgendaStore {
             recurrence: None,
             // start_now is the one-shot revise-and-run lane — a trigger
             // never rides it (standing triggered manifests run-now via
-            // request_occurrence instead).
+            // request_occurrence instead). Its minted manifest seals
+            // nothing: the gesture runs the ITEM, and a re-mint over a
+            // ref-bearing proposal is an owner-attributed revision that
+            // voids that approval like any other.
             trigger: None,
+            binding_refs: Vec::new(),
         };
         let digest = super::types::manifest_digest(id, &effect_id, &manifest);
         self.append_op(
@@ -1130,6 +1135,7 @@ impl AgendaStore {
                 agent_config,
                 trigger,
                 project_root,
+                binding_refs,
                 source: _,
             } => {
                 let item = self.require(&id)?;
@@ -1231,6 +1237,13 @@ impl AgendaStore {
                     }
                     goal.to_string()
                 };
+                // Binding refs (sealed refs) verify NOW, not just at fire
+                // time: the proposer stated a hash, and a pin the daemon's
+                // own read already contradicts would only park a manifest
+                // whose every firing refuses — the project_root precedent
+                // (name the deterministic fire-time refusal at review
+                // time).
+                let binding_refs = validate_binding_refs(binding_refs)?;
                 // v1: one session effect per item — a re-propose revises it
                 // (stable effect_id lineage, fresh digest, approval void).
                 let effect_id = item
@@ -1261,6 +1274,7 @@ impl AgendaStore {
                         agent_config,
                         recurrence,
                         trigger,
+                        binding_refs,
                     },
                 })
             }
@@ -2109,6 +2123,129 @@ pub(crate) fn digest_file(path: &Path) -> std::io::Result<String> {
         let _ = write!(hex, "{byte:02x}");
     }
     Ok(hex)
+}
+
+/// Parse a binding-ref locator (sealed refs). v1 grammar: `file:` + an
+/// absolute path, bounded like G1 file refs. Every other scheme is
+/// future vocabulary — refused by name so a `body:`/`git:` propose fails
+/// loudly today instead of sealing garbage.
+pub(crate) fn binding_ref_path(locator: &str) -> Result<&Path, String> {
+    let Some(raw) = locator.strip_prefix(BINDING_REF_FILE_SCHEME) else {
+        return Err(format!(
+            "binding ref locator {locator:?} must use the \
+             {BINDING_REF_FILE_SCHEME}<absolute path> scheme — v1 seals files only \
+             (body:/git: forms are future vocabulary)"
+        ));
+    };
+    if locator.chars().count() > MAX_REF_FILE_LOCATOR_CHARS {
+        return Err(format!(
+            "binding ref path exceeds {MAX_REF_FILE_LOCATOR_CHARS} characters"
+        ));
+    }
+    let path = Path::new(raw);
+    if !path.is_absolute() {
+        return Err(format!(
+            "binding ref {locator:?} must carry an absolute path"
+        ));
+    }
+    Ok(path)
+}
+
+/// Intake validation of proposed binding refs (sealed refs): locator
+/// grammar, pin shape, and the caller-stated sha256 verified against the
+/// daemon's OWN read of the live bytes — a pin this read already
+/// contradicts would only park a manifest whose every firing refuses,
+/// so the contradiction is named at review time (the project_root
+/// precedent). Pins normalize to lowercase hex; the returned refs are
+/// what the digest-bound manifest records.
+fn validate_binding_refs(refs: Vec<BindingRef>) -> Result<Vec<BindingRef>, AgendaError> {
+    if refs.len() > MAX_BINDING_REFS_PER_MANIFEST {
+        return Err(AgendaError::Invalid(format!(
+            "a manifest seals at most {MAX_BINDING_REFS_PER_MANIFEST} binding refs"
+        )));
+    }
+    let mut validated: Vec<BindingRef> = Vec::with_capacity(refs.len());
+    for BindingRef { locator, sha256 } in refs {
+        let path = binding_ref_path(&locator).map_err(AgendaError::Invalid)?;
+        let sha256 = sha256.to_ascii_lowercase();
+        if sha256.len() != 64 || !sha256.bytes().all(|b| b.is_ascii_hexdigit()) {
+            return Err(AgendaError::Invalid(format!(
+                "binding ref {locator}: sha256 must be 64 hex characters"
+            )));
+        }
+        if validated.iter().any(|seen| seen.locator == locator) {
+            return Err(AgendaError::Invalid(format!(
+                "binding ref {locator} is listed twice"
+            )));
+        }
+        let meta = std::fs::metadata(path).map_err(|err| {
+            AgendaError::Invalid(format!("binding ref {locator} is not readable ({err})"))
+        })?;
+        if !meta.is_file() {
+            return Err(AgendaError::Invalid(format!(
+                "binding ref {locator} is not a regular file"
+            )));
+        }
+        if meta.len() > MAX_REF_FILE_HASH_BYTES {
+            return Err(AgendaError::Invalid(format!(
+                "binding ref {locator} exceeds {MAX_REF_FILE_HASH_BYTES} bytes — \
+                 binding refs seal working artifacts, not archives"
+            )));
+        }
+        let live = digest_file(path).map_err(|err| {
+            AgendaError::Invalid(format!("cannot hash binding ref {locator}: {err}"))
+        })?;
+        if live != sha256 {
+            return Err(AgendaError::Invalid(format!(
+                "binding ref {locator}: the proposed pin {sha256} does not match the \
+                 live content ({live}) — re-read the file and re-propose"
+            )));
+        }
+        validated.push(BindingRef { locator, sha256 });
+    }
+    Ok(validated)
+}
+
+/// Fire-time seal check of one binding ref (sealed refs): the live file
+/// must still hash to the approved pin exactly. `Err` carries the named
+/// occurrence-failure reason — the scheduler journals it and refuses to
+/// spawn, so an approved goal never runs against silently drifted or
+/// unreadable referenced content.
+pub(crate) fn verify_binding_ref(binding_ref: &BindingRef) -> Result<(), String> {
+    let path = binding_ref_path(&binding_ref.locator)?;
+    let live = match std::fs::metadata(path) {
+        Ok(meta) if !meta.is_file() => {
+            return Err(format!(
+                "binding ref unreadable: {} (not a regular file)",
+                binding_ref.locator
+            ))
+        }
+        Ok(meta) if meta.len() > MAX_REF_FILE_HASH_BYTES => {
+            // Grown past the hash bound = changed by size alone; attach
+            // only ever pinned content within the bound (G1's rule).
+            return Err(format!(
+                "binding ref drifted: {} — the live file outgrew the \
+                 {MAX_REF_FILE_HASH_BYTES}-byte seal bound",
+                binding_ref.locator
+            ));
+        }
+        Ok(_) => digest_file(path)
+            .map_err(|err| format!("binding ref unreadable: {} ({err})", binding_ref.locator))?,
+        Err(err) => {
+            return Err(format!(
+                "binding ref unreadable: {} ({err})",
+                binding_ref.locator
+            ))
+        }
+    };
+    if live != binding_ref.sha256 {
+        return Err(format!(
+            "binding ref drifted: {} — approved sha256 {}, live file {live}; \
+             re-propose and re-approve to reseal",
+            binding_ref.locator, binding_ref.sha256
+        ));
+    }
+    Ok(())
 }
 
 fn validate_title(title: &str) -> Result<String, AgendaError> {
@@ -3779,6 +3916,7 @@ mod tests {
 
     fn propose_recurring(id: &str, every_ms: u64) -> AgendaCommand {
         AgendaCommand::ProposeEffect {
+            binding_refs: Vec::new(),
             id: id.to_string(),
             goal: "standing sweep".into(),
             fire_at_ms: 1_000_000,
@@ -3818,6 +3956,7 @@ mod tests {
             (propose_recurring(&id, 60_000), "floors at 15 minutes"),
             (
                 AgendaCommand::ProposeEffect {
+                    binding_refs: Vec::new(),
                     id: id.clone(),
                     goal: "g".into(),
                     fire_at_ms: 1_000_000,
@@ -3835,6 +3974,7 @@ mod tests {
             ),
             (
                 AgendaCommand::ProposeEffect {
+                    binding_refs: Vec::new(),
                     id: id.clone(),
                     goal: "g".into(),
                     fire_at_ms: 1_000_000,
@@ -4096,6 +4236,7 @@ mod tests {
     #[test]
     fn g3pre_cross_build_digest_degrades_fail_closed() {
         let with = super::super::types::SessionManifest {
+            binding_refs: Vec::new(),
             goal: "standing".into(),
             fire_at_ms: 1_000_000,
             orchestrate: false,
@@ -4130,6 +4271,238 @@ mod tests {
             .contains("recurrence"));
     }
 
+    /// Sealed-refs intake: the proposer's stated pin is verified against
+    /// the daemon's OWN read at propose time — a matching pin lands on
+    /// the digest-bound manifest (normalized to lowercase hex) and
+    /// survives replay, and every deterministic fire-time refusal is
+    /// named NOW instead: hash mismatch, unreadable path, non-`file:`
+    /// scheme, relative path, malformed pin, duplicate locator, and the
+    /// count rail.
+    #[test]
+    fn propose_binding_refs_verify_at_intake() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = tempfile::tempdir().unwrap();
+        let brief = content.path().join("brief.md");
+        std::fs::write(&brief, b"the sealed brief\n").unwrap();
+        let pin = digest_file(&brief).unwrap();
+        let locator = format!("file:{}", brief.display());
+        let mut store = AgendaStore::open(dir.path()).unwrap();
+        let item = store
+            .apply_command(add_cmd("sealed"), owner(), 1000)
+            .unwrap();
+        let propose = |refs: Vec<BindingRef>| AgendaCommand::ProposeEffect {
+            id: item.id.clone(),
+            goal: "read the sealed brief and act".into(),
+            fire_at_ms: 4_000_000_000_000,
+            orchestrate: false,
+            recurrence: None,
+            agent_config: None,
+            trigger: None,
+            project_root: None,
+            binding_refs: refs,
+            source: None,
+        };
+
+        // An UPPERCASE pin normalizes to canonical lowercase hex.
+        let sealed = store
+            .apply_command(
+                propose(vec![BindingRef {
+                    locator: locator.clone(),
+                    sha256: pin.to_ascii_uppercase(),
+                }]),
+                owner(),
+                1001,
+            )
+            .unwrap();
+        assert_eq!(
+            sealed.effects[0].manifest.binding_refs,
+            vec![BindingRef {
+                locator: locator.clone(),
+                sha256: pin.clone(),
+            }],
+            "the verified pin rides the digest-bound manifest"
+        );
+        let mut reopened = AgendaStore::open(dir.path()).unwrap();
+        assert_eq!(
+            reopened.item(&item.id).unwrap().effects[0]
+                .manifest
+                .binding_refs,
+            sealed.effects[0].manifest.binding_refs,
+            "replay converges — the op carries the sealed manifest verbatim"
+        );
+
+        // A pin the daemon's read contradicts refuses by name.
+        let err = store
+            .apply_command(
+                propose(vec![BindingRef {
+                    locator: locator.clone(),
+                    sha256: "cc".repeat(32),
+                }]),
+                owner(),
+                1002,
+            )
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("does not match the live content"),
+            "{err}"
+        );
+        // Unreadable path.
+        let err = store
+            .apply_command(
+                propose(vec![BindingRef {
+                    locator: format!("file:{}", content.path().join("gone.md").display()),
+                    sha256: pin.clone(),
+                }]),
+                owner(),
+                1003,
+            )
+            .unwrap_err();
+        assert!(err.to_string().contains("is not readable"), "{err}");
+        // Non-file: schemes are future vocabulary, refused by name.
+        for bad in ["body:", "git:brief.md@HEAD", "/etc/hosts", "https://x/y"] {
+            let err = store
+                .apply_command(
+                    propose(vec![BindingRef {
+                        locator: bad.to_string(),
+                        sha256: pin.clone(),
+                    }]),
+                    owner(),
+                    1004,
+                )
+                .unwrap_err();
+            assert!(
+                err.to_string().contains("file:<absolute path>"),
+                "{bad}: {err}"
+            );
+        }
+        // Relative path under the scheme.
+        let err = store
+            .apply_command(
+                propose(vec![BindingRef {
+                    locator: "file:relative/brief.md".into(),
+                    sha256: pin.clone(),
+                }]),
+                owner(),
+                1005,
+            )
+            .unwrap_err();
+        assert!(err.to_string().contains("absolute path"), "{err}");
+        // Malformed pins.
+        for bad_pin in ["abc", &"zz".repeat(32)] {
+            let err = store
+                .apply_command(
+                    propose(vec![BindingRef {
+                        locator: locator.clone(),
+                        sha256: bad_pin.to_string(),
+                    }]),
+                    owner(),
+                    1006,
+                )
+                .unwrap_err();
+            assert!(err.to_string().contains("64 hex characters"), "{err}");
+        }
+        // Duplicate locators.
+        let dup = BindingRef {
+            locator: locator.clone(),
+            sha256: pin.clone(),
+        };
+        let err = store
+            .apply_command(propose(vec![dup.clone(), dup.clone()]), owner(), 1007)
+            .unwrap_err();
+        assert!(err.to_string().contains("listed twice"), "{err}");
+        // Count rail (checked before any filesystem read).
+        let err = store
+            .apply_command(
+                propose(vec![dup; MAX_BINDING_REFS_PER_MANIFEST + 1]),
+                owner(),
+                1008,
+            )
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains(&MAX_BINDING_REFS_PER_MANIFEST.to_string()),
+            "{err}"
+        );
+    }
+
+    /// Fire-time seal check: unchanged content passes; drifted content,
+    /// missing files, and non-`file:` locators refuse with exactly the
+    /// named reasons the scheduler journals against the occurrence.
+    #[test]
+    fn verify_binding_ref_names_drift_and_unreadable() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sealed.md");
+        std::fs::write(&path, b"v1").unwrap();
+        let pin = digest_file(&path).unwrap();
+        let bref = BindingRef {
+            locator: format!("file:{}", path.display()),
+            sha256: pin,
+        };
+        assert_eq!(verify_binding_ref(&bref), Ok(()));
+
+        std::fs::write(&path, "v2 — amended under an armed approval").unwrap();
+        let err = verify_binding_ref(&bref).unwrap_err();
+        assert!(
+            err.starts_with(&format!("binding ref drifted: file:{}", path.display())),
+            "{err}"
+        );
+
+        std::fs::remove_file(&path).unwrap();
+        let err = verify_binding_ref(&bref).unwrap_err();
+        assert!(
+            err.starts_with(&format!("binding ref unreadable: file:{}", path.display())),
+            "{err}"
+        );
+
+        let err = verify_binding_ref(&BindingRef {
+            locator: "/no-scheme".into(),
+            sha256: "aa".repeat(32),
+        })
+        .unwrap_err();
+        assert!(err.contains("file:<absolute path>"), "{err}");
+    }
+
+    /// The sealed-refs twin of the cross-build rider: a build that
+    /// predates `binding_refs` re-serializes the manifest without it and
+    /// derives a DIFFERENT digest — the approval reads as a mismatch and
+    /// the effect never fires, so a sealed manifest degrades fail-closed
+    /// on older builds instead of firing UNSEALED (exactly the class of
+    /// silent unsealing the pin exists to catch).
+    #[test]
+    fn binding_refs_cross_build_digest_degrades_fail_closed() {
+        let with = super::super::types::SessionManifest {
+            goal: "sealed".into(),
+            fire_at_ms: 1_000_000,
+            orchestrate: false,
+            interactive: false,
+            project_root: None,
+            agent_config: None,
+            recurrence: None,
+            trigger: None,
+            binding_refs: vec![BindingRef {
+                locator: "file:/work/brief.md".into(),
+                sha256: "aa".repeat(32),
+            }],
+        };
+        let json = serde_json::to_value(&with).unwrap();
+        assert!(
+            json.get("binding_refs").is_some(),
+            "the field reaches the wire"
+        );
+        let mut stripped_json = json.clone();
+        stripped_json
+            .as_object_mut()
+            .unwrap()
+            .remove("binding_refs");
+        let stripped: super::super::types::SessionManifest =
+            serde_json::from_value(stripped_json).unwrap();
+        assert_ne!(
+            super::super::types::manifest_digest("i", "e", &with),
+            super::super::types::manifest_digest("i", "e", &stripped),
+            "binding refs must be digest-visible or old builds would fire the goal unsealed"
+        );
+    }
+
     /// The executor twin of the cross-build rider (Track AU): a build
     /// that predates the manifest's `agent_config` re-serializes without
     /// it and derives a DIFFERENT digest — the approval reads as a
@@ -4140,6 +4513,7 @@ mod tests {
     #[test]
     fn executor_cross_build_digest_degrades_fail_closed() {
         let with = super::super::types::SessionManifest {
+            binding_refs: Vec::new(),
             goal: "standing".into(),
             fire_at_ms: 1_000_000,
             orchestrate: false,
@@ -4189,6 +4563,7 @@ mod tests {
     #[test]
     fn trigger_cross_build_digest_degrades_fail_closed() {
         let with = super::super::types::SessionManifest {
+            binding_refs: Vec::new(),
             goal: "gated run".into(),
             fire_at_ms: 1_000_000,
             orchestrate: false,
@@ -4236,6 +4611,7 @@ mod tests {
         let propose = |recurrence: Option<super::super::types::RecurrenceSpec>,
                        trigger: Option<super::super::types::TriggerSpec>| {
             AgendaCommand::ProposeEffect {
+                binding_refs: Vec::new(),
                 id: id.clone(),
                 goal: "g".into(),
                 fire_at_ms: 1_000_000,
@@ -4317,6 +4693,7 @@ mod tests {
             .id;
         let propose =
             |config: Option<crate::event::AgentLaunchConfig>| AgendaCommand::ProposeEffect {
+                binding_refs: Vec::new(),
                 id: id.clone(),
                 goal: "triage pass".into(),
                 fire_at_ms: 1_000_000,
@@ -4681,6 +5058,7 @@ mod tests {
             .unwrap()
             .id;
         let propose = |project_root: Option<String>| AgendaCommand::ProposeEffect {
+            binding_refs: Vec::new(),
             id: id.clone(),
             goal: "g".into(),
             fire_at_ms: 1_000_000,

--- a/src/bin/caller/agenda/types.rs
+++ b/src/bin/caller/agenda/types.rs
@@ -310,6 +310,39 @@ pub enum TriggerSpec {
     },
 }
 
+/// One hash-pinned binding reference on a manifest (sealed refs,
+/// owner-ruled 2026-07-26): content the approved goal DEPENDS ON, sealed
+/// under the approval digest. The pin names the bytes (`sha256` of the
+/// locator's content at propose time); intake verifies it against the
+/// daemon's own read, and the scheduler re-verifies at fire time,
+/// refusing to spawn on drift — so the approval covers what the goal
+/// references, not just the goal text (item bodies and plain G1 refs
+/// stay editable under an armed approval; binding refs do not).
+/// Doctrine: sealed binding-ref content MAY carry instructions for the
+/// fired session — it is exactly what the owner reviewed; everything
+/// else a fired session reads (bodies, annotations, unhashed refs)
+/// stays data. v1 locator scheme is `file:<absolute path>` only —
+/// `body:` and `git:<path>@<commit>` are future vocabulary, refused by
+/// name at intake until priced.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct BindingRef {
+    /// `file:<absolute path>` (v1). Stored verbatim as intake validated
+    /// it.
+    pub locator: String,
+    /// Full sha256 of the referenced bytes as lowercase hex — stated by
+    /// the proposer (the pin says what THEY read), verified by the
+    /// daemon at intake and again at fire.
+    pub sha256: String,
+}
+
+/// Binding-ref count rail per manifest (a pathology bound, not a
+/// budget — a manifest sealing more artifacts than this is a design
+/// smell, split the work).
+pub(crate) const MAX_BINDING_REFS_PER_MANIFEST: usize = 16;
+/// The `file:` locator scheme prefix (v1's only binding-ref scheme).
+pub(crate) const BINDING_REF_FILE_SCHEME: &str = "file:";
+
 /// A scheduled-session manifest (slice A5): the complete statement of
 /// what firing does — reviewed by the owner at approval time. Immutable
 /// per revision: [`manifest_digest`] binds the approval, and any edit
@@ -376,6 +409,16 @@ pub struct SessionManifest {
     /// is a scheduled arming — do not "fix" it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) trigger: Option<TriggerSpec>,
+    /// Hash-pinned binding refs (sealed refs). Additive: absent-on-the-
+    /// wire when empty, so legacy manifest bytes — and the digests their
+    /// approvals bind — are unchanged, and the approval digest COVERS
+    /// the pins by construction (they are manifest bytes): swapping a
+    /// ref or its hash revises the manifest and voids the approval like
+    /// any other edit. An older build re-serializes without the field,
+    /// derives a different digest, and degrades fail-closed exactly like
+    /// recurrence/trigger.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) binding_refs: Vec<BindingRef>,
 }
 
 /// An owner's approval of one manifest revision. `digest` is the bound
@@ -981,6 +1024,14 @@ pub enum AgendaCommand {
         /// have, the live gap this field closes.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         project_root: Option<String>,
+        /// Hash-pinned binding refs (sealed refs): `{locator, sha256}`
+        /// pairs the PROPOSER hashed. Intake verifies each pin against
+        /// the daemon's own read of the locator and refuses a mismatch
+        /// by name — what gets sealed is what both sides read. Older
+        /// daemons reject the unknown field at strict intake rather
+        /// than silently parking an unsealed manifest.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        binding_refs: Vec<BindingRef>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         source: Option<String>,
     },
@@ -2172,6 +2223,7 @@ mod tests {
 
         // Full round-trip with the additive fields set preserves them.
         let full = SessionManifest {
+            binding_refs: Vec::new(),
             recurrence: None,
             goal: "g".into(),
             fire_at_ms: 9,
@@ -2215,6 +2267,7 @@ mod tests {
         assert_eq!(back, matcher);
 
         let base = SessionManifest {
+            binding_refs: Vec::new(),
             goal: "g".into(),
             fire_at_ms: 9,
             orchestrate: false,
@@ -2239,6 +2292,82 @@ mod tests {
         assert!(!serde_json::to_string(&base)
             .unwrap()
             .contains("\"trigger\""));
+    }
+
+    /// Sealed refs, pin (a): the binding-ref wire shape is pinned, the
+    /// field is absent-on-the-wire when empty (legacy manifest bytes —
+    /// and the digests their approvals bind — unchanged by
+    /// construction), and the approval digest COVERS the pins: adding a
+    /// ref, swapping its hash, or re-pointing its locator each mints a
+    /// new digest that voids any standing approval.
+    #[test]
+    fn binding_refs_are_digest_covered_and_additive() {
+        let base = SessionManifest {
+            goal: "g".into(),
+            fire_at_ms: 9,
+            orchestrate: false,
+            interactive: false,
+            project_root: None,
+            agent_config: None,
+            recurrence: None,
+            trigger: None,
+            binding_refs: Vec::new(),
+        };
+        assert!(
+            !serde_json::to_string(&base)
+                .unwrap()
+                .contains("binding_refs"),
+            "ref-less manifests keep the legacy bytes exactly"
+        );
+
+        let sealed = SessionManifest {
+            binding_refs: vec![BindingRef {
+                locator: "file:/work/brief.md".into(),
+                sha256: "aa".repeat(32),
+            }],
+            ..base.clone()
+        };
+        let json = serde_json::to_string(&sealed).unwrap();
+        assert!(
+            json.contains(&format!(
+                r#""binding_refs":[{{"locator":"file:/work/brief.md","sha256":"{}"}}]"#,
+                "aa".repeat(32)
+            )),
+            "the wire shape is pinned: {json}"
+        );
+        let round: SessionManifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(round, sealed);
+
+        let base_digest = manifest_digest("item-1", "ef-1", &base);
+        let sealed_digest = manifest_digest("item-1", "ef-1", &sealed);
+        assert_ne!(
+            base_digest, sealed_digest,
+            "sealing a ref revises the digest"
+        );
+        let swapped_hash = SessionManifest {
+            binding_refs: vec![BindingRef {
+                locator: "file:/work/brief.md".into(),
+                sha256: "bb".repeat(32),
+            }],
+            ..base.clone()
+        };
+        assert_ne!(
+            manifest_digest("item-1", "ef-1", &swapped_hash),
+            sealed_digest,
+            "swapping the pinned hash revises the digest — the owner re-approves what changed"
+        );
+        let repointed = SessionManifest {
+            binding_refs: vec![BindingRef {
+                locator: "file:/work/other.md".into(),
+                sha256: "aa".repeat(32),
+            }],
+            ..base.clone()
+        };
+        assert_ne!(
+            manifest_digest("item-1", "ef-1", &repointed),
+            sealed_digest,
+            "re-pointing the locator revises the digest"
+        );
     }
 
     #[test]
@@ -3982,6 +4111,7 @@ mod tests {
     #[test]
     fn g3pre_op_line_formats_are_pinned() {
         let manifest = SessionManifest {
+            binding_refs: Vec::new(),
             goal: "standing".into(),
             fire_at_ms: 1000,
             orchestrate: false,
@@ -4031,6 +4161,7 @@ mod tests {
                 id: "01X".into(),
                 effect_id: "ef-1".into(),
                 manifest: SessionManifest {
+                    binding_refs: Vec::new(),
                     goal: "standing".into(),
                     fire_at_ms: 1000,
                     orchestrate: false,
@@ -4099,6 +4230,7 @@ mod tests {
                     id: "01X".into(),
                     effect_id: "ef-1".into(),
                     manifest: SessionManifest {
+                        binding_refs: Vec::new(),
                         goal: "v2".into(),
                         fire_at_ms: 2000,
                         orchestrate: false,

--- a/src/bin/caller/ctl.rs
+++ b/src/bin/caller/ctl.rs
@@ -2168,6 +2168,7 @@ async fn run_agenda(
                 "--suspend-after",
                 "--on-item-match",
                 "--project",
+                "--binding-ref",
                 "--source",
             ];
             value_flags.extend(AGENDA_LAUNCH_FLAGS);
@@ -2277,6 +2278,18 @@ async fn run_agenda(
             // Explicit project pin (T3c): digest-bound on the manifest,
             // so the approval covers WHERE the sessions run.
             insert_string(&mut map, "project_root", args.one("--project"));
+            // Sealed refs: hash each --binding-ref at propose time — the
+            // pin states what THIS process read; the daemon verifies its
+            // own view at intake and re-verifies at every fire, so the
+            // approval digest covers the referenced content, not just
+            // the goal text.
+            let binding_refs = args
+                .all("--binding-ref")
+                .map(binding_ref_propose_value)
+                .collect::<Result<Vec<Value>, String>>()?;
+            if !binding_refs.is_empty() {
+                map.insert("binding_refs".to_string(), Value::Array(binding_refs));
+            }
             insert_string(&mut map, "source", args.one("--source"));
             // Executor pins (Track AU): the same launch vocabulary the
             // start-now sheet records, digest-bound on the standing
@@ -2708,6 +2721,43 @@ fn agenda_ref_spec(raw: &str, explicit: Option<&str>) -> Result<(String, String)
         locator.to_string()
     };
     Ok((ref_type, locator))
+}
+
+/// `--binding-ref file:PATH` propose-time hashing (sealed refs): resolve
+/// PATH, sha256 its bytes NOW, and embed `{locator, sha256}` — the
+/// manifest pin the approval digest covers. The daemon verifies the pin
+/// against its own read at intake (a remote `--url` daemon reading
+/// different bytes refuses by name) and re-verifies at every fire. v1
+/// accepts `file:` locators only; other schemes refuse by name.
+fn binding_ref_propose_value(spec: &str) -> Result<Value, String> {
+    let Some(raw) = spec.strip_prefix("file:") else {
+        return Err(format!(
+            "--binding-ref {spec:?}: v1 seals file:PATH locators only \
+             (body:/git: forms are future vocabulary)"
+        ));
+    };
+    if raw.is_empty() {
+        return Err("--binding-ref file: needs a path".to_string());
+    }
+    let path = std::path::Path::new(raw);
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(|err| format!("--binding-ref {spec:?}: cannot resolve the cwd ({err})"))?
+            .join(path)
+    };
+    // Canonical (symlink-free) so the daemon pins the same bytes at fire
+    // time that this hash read — a locator that dereferences differently
+    // later is exactly the drift the seal exists to catch.
+    let canonical = std::fs::canonicalize(&absolute)
+        .map_err(|err| format!("--binding-ref {spec:?}: not readable ({err})"))?;
+    let sha256 = crate::agenda::digest_file(&canonical)
+        .map_err(|err| format!("--binding-ref {spec:?}: cannot hash ({err})"))?;
+    Ok(serde_json::json!({
+        "locator": format!("file:{}", canonical.display()),
+        "sha256": sha256,
+    }))
 }
 
 fn agenda_add_args(raw: &[String]) -> Result<Value, String> {
@@ -5150,6 +5200,8 @@ fn help_agenda() {
       [--every INTERVAL [--until WHEN] [--max-occurrences N] [--suspend-after N]] [--source LABEL]\n\
       [--on-unblock | --on-item-match KIND:TAG[,TAG...]]   # event trigger: fires on state, not\n\
       # at an instant — cadence OR trigger, never both; --at then defaults to now (the arm floor)\n\
+      [--binding-ref file:PATH]...   # sealed refs: sha256-pin content the goal depends on —\n\
+      # hashed here at propose time, covered by the approval digest, re-verified at every fire\n\
       [--project DIR]   # digest-bound project pin: where fired sessions run (absolute, must\n\
       # exist; omitted = the parking session's root, else the daemon default)\n\
       [--agent BACKEND] [--claude-model M] [--claude-effort E]\n\
@@ -5229,7 +5281,12 @@ runs the goal (backend/model/effort), and editing the executor voids it\n\
 like any other revision; omitted fields inherit the daemon defaults\n\
 (explicit pin → daemon default → backend default). On a\n\
 standing approved item, `start` fires one extra occurrence of the approved\n\
-manifest immediately without touching the approval. Nothing fires until\n\
+manifest immediately without touching the approval. --binding-ref file:PATH\n\
+(repeatable) SEALS content the goal depends on: the file is sha256-pinned\n\
+at propose time on the digest-bound manifest — the approval covers the\n\
+referenced bytes, editing the pin re-opens review, and every fire\n\
+re-verifies the hash, refusing to spawn (occurrence `failed`, streak-\n\
+visible) if the file drifted from what was approved. Nothing fires until\n\
 the owner approves; approval is an owner-surface act (dashboard or an\n\
 owner shell) — agent and peer callers may propose but never approve, and\n\
 approval binds the exact manifest digest, so any revision voids it.\n\
@@ -5335,6 +5392,44 @@ mod tests {
 
     fn args(values: &[&str]) -> Vec<String> {
         values.iter().map(|value| value.to_string()).collect()
+    }
+
+    /// Sealed refs, pin (d): `--binding-ref` hashes at propose time — the
+    /// embedded pin is the sha256 of the file's bytes as THIS process
+    /// read them (NIST vector for "abc"), the locator canonicalizes under
+    /// `file:`, and every non-`file:` scheme refuses by name.
+    #[test]
+    fn binding_ref_flag_hashes_at_propose_time() {
+        let dir = tempfile::tempdir().unwrap();
+        let brief = dir.path().join("brief.md");
+        std::fs::write(&brief, b"abc").unwrap();
+        let value = binding_ref_propose_value(&format!("file:{}", brief.display())).unwrap();
+        let canonical = std::fs::canonicalize(&brief).unwrap();
+        assert_eq!(
+            value["locator"],
+            Value::String(format!("file:{}", canonical.display()))
+        );
+        assert_eq!(
+            value["sha256"],
+            Value::String(
+                "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad".into()
+            ),
+            "the pin is the propose-time sha256 of the referenced bytes"
+        );
+        for bad in [
+            "body:x",
+            "git:brief.md@HEAD",
+            "/no-scheme",
+            "https://x/y",
+            "file:",
+        ] {
+            let err = binding_ref_propose_value(bad).unwrap_err();
+            assert!(err.contains("--binding-ref"), "{bad}: {err}");
+        }
+        let err =
+            binding_ref_propose_value(&format!("file:{}", dir.path().join("missing.md").display()))
+                .unwrap_err();
+        assert!(err.contains("not readable"), "{err}");
     }
 
     /// The read verbs' `/api` URL assembly: origin derived from the


### PR DESCRIPTION
The approval digest covered the manifest but not what the goal
references — file content a must-read ref names stayed editable under
an armed approval (live specimen: the NS manifests' intake rider,
amended under an armed approval). Manifests now carry binding_refs
[{locator, sha256}] (serde-additive: absent = none, legacy digests
unchanged by construction): ctl agenda schedule --binding-ref file:PATH
hashes the content at propose time, intake verifies the stated pin
against the daemon's own read (mismatch, unreadable, non-file: scheme,
relative path, dup, and count rail refuse by name; file: absolute paths
only in v1 — body:/git: are future vocabulary), and every fire
re-verifies before spawning — drift or unreadability refuses the spawn
as the occurrence's terminal failed outcome ('binding ref drifted:
<locator>' / 'binding ref unreadable: <locator>'), written back to the
item and counted on the standing failure streak, so a stale standing
manifest suspends and surfaces to the owner. Each fired task names its
binding refs (locator + approved sha256, verified at fire) as data
lines under the #618 source rider; sealed content behind a verified pin
is what the owner reviewed and may carry instructions — everything else
a fired session reads stays data.

Pins: digest coverage (adding/swapping/repointing a ref mints a new
digest), the live-failure arc (approve, amend the file, next fire
refuses with the named reason journaled failed + streak-counted),
fired-task exact bytes, ctl propose-time hashing (NIST vector),
cross-build fail-closed degrade, and the intake refusal grammar.
