### PR TITLE
feat(agenda): sealed-refs snapshot store — propose-time preservation, sealed serving despite live drift

### DIFF
--- a/docs/src/agenda-and-memory.md
+++ b/docs/src/agenda-and-memory.md
@@ -398,20 +398,27 @@ approval digest covers them, and changing a ref is a revision that
 re-opens review. Intake verifies each pin against the daemon's own read
 (mismatch, unreadable path, or a non-`file:` locator refuses by name —
 v1 seals absolute `file:` paths only; `body:` and `git:` forms are
-future vocabulary), and **every fire re-verifies**: a drifted or
-unreadable ref refuses to spawn — the occurrence journals terminal
-`failed` with the named reason (`binding ref drifted: <locator>` /
-`binding ref unreadable: <locator>`), the write-back lands on the item,
-and the failure counts on the standing streak, so a stale standing
-manifest suspends and surfaces to the owner instead of firing over its
-own drift. Each fired task carries one data line per ref (locator +
-approved sha256, verified at fire) under the source rider. Doctrine:
-the *content behind a verified pin* is exactly what the owner reviewed
-and may carry instructions for the fired session; everything else a
-fired session reads — bodies, annotations, unhashed G1 refs — remains
-data, never instructions. On older builds a sealed manifest degrades
-fail-closed like recurrence/trigger: digest mismatch, never an unsealed
-firing.
+future vocabulary) and **seals the verified bytes** into the
+content-addressed snapshot store (`<agenda dir>/blobs/<sha256>`, atomic
+writes, dedup by hash; GC deliberately deferred). **Every fire verifies
+the snapshot**: the sealed bytes are the binding content — the fired
+task's rider line points the session at the sealed copy, and a live
+file that drifted (or vanished) after approval is an *informational
+note* (`live file drifted from sealed revision`), never a refusal.
+Refusal remains where preservation itself broke: a corrupt snapshot
+(bytes no longer hash to the pin) or a missing one that cannot be
+healed from live bytes still matching the pin — the occurrence journals
+terminal `failed` with the named reason (`binding ref snapshot
+corrupt/missing: <locator>`), the write-back lands on the item, and the
+failure counts on the standing streak, so a broken seal suspends and
+surfaces to the owner. Each fired task carries one data line per ref
+(locator + approved sha256 + sealed-copy path, verified at fire) under
+the source rider. Doctrine: the *content a verified seal serves* is
+exactly what the owner reviewed and may carry instructions for the
+fired session; everything else a fired session reads — bodies,
+annotations, unhashed G1 refs — remains data, never instructions. On
+older builds a sealed manifest degrades fail-closed like
+recurrence/trigger: digest mismatch, never an unsealed firing.
 
 **Start now** (`start_now`, `ctl agenda start`, the item's button) is the
 owner's act-on-item. On dashboard surfaces the button opens a **confirm

--- a/skills/intendant-agenda/SKILL.md
+++ b/skills/intendant-agenda/SKILL.md
@@ -108,10 +108,11 @@ dashboard, attributed to your session.
   in `list --json`: state, session id, note) — check it next session.
   If the goal depends on a file (a brief, a rider), seal it:
   `--binding-ref file:PATH` (repeatable) sha256-pins the content at
-  propose time under the approval digest — editing the file after
-  approval makes the next fire refuse (occurrence `failed`, named
-  reason) instead of running against drifted content, so keep sealed
-  files stable or re-propose after editing them.
+  propose time under the approval digest AND snapshots the bytes into
+  the agenda's sealed store. Fired sessions read the SEALED copy (the
+  rider line names its path) — editing the live file after approval
+  only annotates the firing as drifted; to make edits count, re-run
+  `schedule` so the owner re-approves the new revision.
 
 - Titles are one actionable line; details go in `--body` (markdown, shown
   quoted). `--due` accepts `+45m/+2h/+3d/+1w`, `YYYY-MM-DD`, RFC3339.

--- a/src/bin/caller/agenda/blobs.rs
+++ b/src/bin/caller/agenda/blobs.rs
@@ -6,7 +6,12 @@
 //! a ref is a pointer (locator + attach-time digest), never content: no
 //! file bytes, copies, or uploads enter the agenda for refs, here or in
 //! the op log. If a future feature wants ref-adjacent bytes, that is a new
-//! owner decision, not an extension of this store.
+//! owner decision, not an extension of this store. (That decision arrived:
+//! the sealed-refs ruling, owner-approved 2026-07-26, snapshots BINDING
+//! refs' bytes — in the sibling content-addressed [`super::sealed_blobs`]
+//! store, `blobs/<sha256>` files beside this store's per-item directories,
+//! never through these functions or lifecycles. Plain G1 refs remain
+//! pointers.)
 //!
 //! **Copy, don't reference** (ratified guardrail): at park time preview
 //! bytes are committed HERE, under the agenda's own directory

--- a/src/bin/caller/agenda/mod.rs
+++ b/src/bin/caller/agenda/mod.rs
@@ -35,6 +35,7 @@ mod handle;
 mod mandate_templates;
 mod reminders;
 mod scheduler;
+mod sealed_blobs;
 mod spawn_project;
 mod store;
 mod types;

--- a/src/bin/caller/agenda/scheduler.rs
+++ b/src/bin/caller/agenda/scheduler.rs
@@ -76,6 +76,11 @@ struct PendingDispatch {
     /// than re-resolving (the manifest the owner approved has one
     /// resolution instant).
     project_root: String,
+    /// The binding refs' rider lines minted by the dispatch-time seal
+    /// verification — retries reuse them for the same reason as the
+    /// project: one verification instant per occurrence, identical task
+    /// bytes on every send.
+    binding_ref_lines: Vec<String>,
     first_attempt_ms: u64,
     last_attempt_ms: u64,
 }
@@ -505,17 +510,24 @@ fn dispatch_session(
             return false;
         }
     };
-    // Fire-time seal check (sealed refs): every binding ref must still
-    // hash to its approved pin — an approved goal never spawns against
-    // silently drifted or unreadable referenced content. The refusal is
-    // this occurrence's terminal `failed` outcome with the named reason,
-    // written back to the item and counted by the standing failure
-    // streak, so a stale standing manifest suspends and surfaces to the
-    // owner instead of firing over its own drift again and again.
+    // Fire-time seal verification (sealed refs): every binding ref's
+    // SNAPSHOT must verify against its approved pin — the sealed bytes
+    // are the binding content the fired session reads, so live-file
+    // drift only annotates the rider line (the deliberate PR-B
+    // semantics shift, stated in `sealed_blobs`). Refusal remains where
+    // preservation itself failed — corrupt or unreconstructable
+    // snapshot — as this occurrence's terminal `failed` outcome with
+    // the named reason, written back to the item and counted by the
+    // standing failure streak, so a broken seal suspends and surfaces
+    // to the owner instead of firing over it again and again.
+    let mut binding_ref_lines = Vec::with_capacity(spawn.binding_refs.len());
     for binding_ref in &spawn.binding_refs {
-        if let Err(why) = super::store::verify_binding_ref(binding_ref) {
-            resolve_spawnless(handle, journal, &spawn, OccurrenceState::Failed, now, &why);
-            return false;
+        match super::sealed_blobs::verify_sealed_binding_ref(handle.dir(), binding_ref) {
+            Ok(verification) => binding_ref_lines.push(verification.rider_line(binding_ref)),
+            Err(why) => {
+                resolve_spawnless(handle, journal, &spawn, OccurrenceState::Failed, now, &why);
+                return false;
+            }
         }
     }
     if !session_record(journal, &spawn, now, OccurrenceState::Prepared, None) {
@@ -552,13 +564,14 @@ fn dispatch_session(
     // it unconditionally made orchestrate manifests run Direct — the
     // defect the agenda chapter documented).
     let project_root = project_root.to_string_lossy().into_owned();
-    send_start_task(handle, &spawn, &project_root);
+    send_start_task(handle, &spawn, &project_root, &binding_ref_lines);
     let now = now_ms();
     state.awaiting.insert(
         spawn.occurrence_id.clone(),
         PendingDispatch {
             spawn,
             project_root,
+            binding_ref_lines,
             first_attempt_ms: now,
             last_attempt_ms: now,
         },
@@ -569,7 +582,12 @@ fn dispatch_session(
 /// The occurrence's `StartTask`, identical on first send and every
 /// retry — the delegation id is the occurrence id, so the supervisor's
 /// dedup collapses duplicates onto the original session.
-fn send_start_task(handle: &AgendaHandle, spawn: &SpawnOccurrence, project_root: &str) {
+fn send_start_task(
+    handle: &AgendaHandle,
+    spawn: &SpawnOccurrence,
+    project_root: &str,
+    binding_ref_lines: &[String],
+) {
     // Interactive spawns mirror the composer's launch shape; goal runs
     // stay explicit (`direct` outranks `orchestrate` at launch — see the
     // agenda chapter).
@@ -581,21 +599,21 @@ fn send_start_task(handle: &AgendaHandle, spawn: &SpawnOccurrence, project_root:
     // Every fired session's task carries a data rider naming its source:
     // the agenda item + occurrence that fired it, so goal self-references
     // ("THIS item", "your prerequisite item") resolve mechanically through
-    // the session's own attributed ctl; each binding ref adds one line —
-    // locator + approved sha256, verified at fire (sealed refs: the
-    // CONTENT behind a verified pin is what the owner reviewed and may
-    // carry instructions; the line itself is a pointer); an on_item_match
-    // batch adds its matched ids (Track T). All rider lines are data to
-    // act on under the approved goal, never instructions themselves.
+    // the session's own attributed ctl; each binding ref adds its
+    // dispatch-minted line — locator + approved sha256 + the SEALED
+    // snapshot path the session reads as the binding content (sealed
+    // refs: what a verified seal serves is what the owner reviewed and
+    // may carry instructions; the line itself is a pointer); an
+    // on_item_match batch adds its matched ids (Track T). All rider
+    // lines are data to act on under the approved goal, never
+    // instructions themselves.
     let mut task = format!(
         "{}\n\nFired from agenda item {} (occurrence {})",
         spawn.goal, spawn.item_id, spawn.occurrence_id
     );
-    for binding_ref in &spawn.binding_refs {
-        task.push_str(&format!(
-            "\nBinding ref {} sha256 {} — verified at fire",
-            binding_ref.locator, binding_ref.sha256
-        ));
+    for line in binding_ref_lines {
+        task.push('\n');
+        task.push_str(line);
     }
     if !spawn.matched_item_ids.is_empty() {
         task.push_str(&format!(
@@ -650,7 +668,12 @@ fn sweep_pending_dispatches(
                  (the supervisor's delegation dedup makes this exactly-once)",
                 now.saturating_sub(pending.first_attempt_ms) / 1000
             );
-            send_start_task(handle, &pending.spawn, &pending.project_root);
+            send_start_task(
+                handle,
+                &pending.spawn,
+                &pending.project_root,
+                &pending.binding_ref_lines,
+            );
             pending.last_attempt_ms = now;
         }
     }
@@ -1438,27 +1461,26 @@ mod tests {
         }
         assert_eq!(dispatched.len(), 1, "the sealed manifest dispatches");
         let occurrence_id = dispatched[0].1.strip_prefix(DELEGATION_PREFIX).unwrap();
+        let sealed_path = super::super::sealed_blobs::sealed_blob_path(handle.dir(), &pin);
         assert_eq!(
             dispatched[0].0,
             format!(
                 "act on the sealed brief\n\nFired from agenda item {item_id} \
                  (occurrence {occurrence_id})\nBinding ref {locator} sha256 {pin} \
-                 — verified at fire"
+                 — sealed copy {}, verified at fire",
+                sealed_path.display()
             ),
-            "each binding ref rides the fired task as one data line"
+            "each binding ref rides the fired task as one data line naming the sealed copy"
         );
     }
 
-    /// Sealed refs, pin (b): the live-failure shape. An approved STANDING
-    /// manifest whose referenced file changes after approval refuses to
-    /// spawn at fire time — no StartTask, the occurrence journals
-    /// terminal `failed` with the named drift reason, the write-back
-    /// lands on the item, and the failure counts on the standing streak
-    /// (the suspension counter) so a stale manifest suspends and
-    /// surfaces instead of firing over its own drift. A deleted ref
-    /// refuses the same way under the `unreadable` name.
+    /// Sealed refs (PR B): the preservation shape. A live file amended —
+    /// or deleted — under an armed approval no longer refuses the fire:
+    /// the SEALED snapshot is the binding content, the rider line points
+    /// at it and notes the drift informationally, and the sealed bytes
+    /// stay exactly what the owner approved.
     #[tokio::test]
-    async fn binding_ref_drift_refuses_spawn_and_journals_failed() {
+    async fn sealed_refs_serve_sealed_bytes_despite_live_drift() {
         let dir = tempfile::tempdir().unwrap();
         let default_project = tempfile::tempdir().unwrap();
         let content = tempfile::tempdir().unwrap();
@@ -1466,8 +1488,105 @@ mod tests {
         let vanishing = content.path().join("vanishing.md");
         std::fs::write(&drifting, b"approved bytes\n").unwrap();
         std::fs::write(&vanishing, b"soon gone\n").unwrap();
-        let drifting_locator = format!("file:{}", drifting.display());
-        let vanishing_locator = format!("file:{}", vanishing.display());
+        let drifting_pin = super::super::store::digest_file(&drifting).unwrap();
+        let handle = handle_with_default_project(dir.path(), default_project.path());
+        let mut journal = OccurrenceJournal::open(handle.dir()).unwrap();
+        let mut state = SchedulerState::default();
+        let drift_item = approved_sealed_item(
+            &handle,
+            now_ms() - 60_000,
+            "sweep with the approved brief",
+            vec![BindingRef {
+                locator: format!("file:{}", drifting.display()),
+                sha256: drifting_pin.clone(),
+            }],
+            None,
+        );
+        let vanish_item = approved_sealed_item(
+            &handle,
+            now_ms() - 60_000,
+            "sweep with the vanishing brief",
+            vec![BindingRef {
+                locator: format!("file:{}", vanishing.display()),
+                sha256: super::super::store::digest_file(&vanishing).unwrap(),
+            }],
+            None,
+        );
+
+        // The live specimen: the referenced file is amended (and the
+        // other deleted) UNDER the armed approval.
+        std::fs::write(&drifting, b"amended after approval\n").unwrap();
+        std::fs::remove_file(&vanishing).unwrap();
+
+        let mut rx = handle.bus().subscribe();
+        run_pass(&handle, &mut journal, &mut state).await;
+        let mut tasks = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            if let AppEvent::ControlCommand(ControlMsg::StartTask { task, .. }) = event {
+                tasks.push(task);
+            }
+        }
+        assert_eq!(
+            tasks.len(),
+            2,
+            "sealed snapshots fire despite live drift — that is the preservation point"
+        );
+        let drift_task = tasks
+            .iter()
+            .find(|t| t.starts_with("sweep with the approved brief"))
+            .expect("the drifted-ref manifest fires");
+        let sealed_path = super::super::sealed_blobs::sealed_blob_path(handle.dir(), &drifting_pin);
+        assert!(
+            drift_task.contains(&format!("sealed copy {}", sealed_path.display())),
+            "the rider points the session at the sealed snapshot: {drift_task}"
+        );
+        assert!(
+            drift_task.ends_with("(live file drifted from sealed revision)"),
+            "drift is noted informationally: {drift_task}"
+        );
+        assert_eq!(
+            std::fs::read(&sealed_path).unwrap(),
+            b"approved bytes\n",
+            "the sealed revision is byte-identical to what the owner approved"
+        );
+        let vanish_task = tasks
+            .iter()
+            .find(|t| t.starts_with("sweep with the vanishing brief"))
+            .expect("the deleted-ref manifest fires");
+        assert!(
+            vanish_task
+                .ends_with("(live file unreadable; the sealed revision is the binding content)"),
+            "a deleted live file is an informational note, not a refusal: {vanish_task}"
+        );
+        let (items, _, _) = handle.snapshot();
+        for id in [&drift_item, &vanish_item] {
+            let item = items.iter().find(|i| i.id == *id).unwrap();
+            assert_eq!(
+                item.effects[0].consecutive_failures, 0,
+                "serving sealed bytes is success-shaped, never a streak entry"
+            );
+        }
+    }
+
+    /// Sealed refs (PR B): refusal remains where PRESERVATION itself
+    /// broke. A corrupt snapshot (bytes under the pin's name no longer
+    /// hash to it) and an unreconstructable one (snapshot gone AND the
+    /// live file drifted) refuse the spawn — no StartTask, terminal
+    /// `failed` journaled with the named reason, write-back on the item,
+    /// streak-counted so a standing manifest suspends and surfaces.
+    #[tokio::test]
+    async fn broken_seal_refuses_spawn_and_journals_failed() {
+        let dir = tempfile::tempdir().unwrap();
+        let default_project = tempfile::tempdir().unwrap();
+        let content = tempfile::tempdir().unwrap();
+        let corrupt = content.path().join("corrupt.md");
+        let unreconstructable = content.path().join("unreconstructable.md");
+        std::fs::write(&corrupt, b"corrupt case approved bytes\n").unwrap();
+        std::fs::write(&unreconstructable, b"unreconstructable approved bytes\n").unwrap();
+        let corrupt_locator = format!("file:{}", corrupt.display());
+        let unrecon_locator = format!("file:{}", unreconstructable.display());
+        let corrupt_pin = super::super::store::digest_file(&corrupt).unwrap();
+        let unrecon_pin = super::super::store::digest_file(&unreconstructable).unwrap();
         let handle = handle_with_default_project(dir.path(), default_project.path());
         let mut journal = OccurrenceJournal::open(handle.dir()).unwrap();
         let mut state = SchedulerState::default();
@@ -1479,31 +1598,41 @@ mod tests {
                 suspend_after_failures: None,
             })
         };
-        let drift_item = approved_sealed_item(
+        let corrupt_item = approved_sealed_item(
             &handle,
             now_ms() - 60_000,
-            "sweep with the approved brief",
+            "sweep with the corrupt seal",
             vec![BindingRef {
-                locator: drifting_locator.clone(),
-                sha256: super::super::store::digest_file(&drifting).unwrap(),
+                locator: corrupt_locator.clone(),
+                sha256: corrupt_pin.clone(),
             }],
             recurrence(),
         );
-        let vanish_item = approved_sealed_item(
+        let unrecon_item = approved_sealed_item(
             &handle,
             now_ms() - 60_000,
-            "sweep with the vanishing brief",
+            "sweep with the unreconstructable seal",
             vec![BindingRef {
-                locator: vanishing_locator.clone(),
-                sha256: super::super::store::digest_file(&vanishing).unwrap(),
+                locator: unrecon_locator.clone(),
+                sha256: unrecon_pin.clone(),
             }],
             recurrence(),
         );
 
-        // The live specimen: the referenced file is amended (and the
-        // other deleted) UNDER the armed approval.
-        std::fs::write(&drifting, b"amended after approval\n").unwrap();
-        std::fs::remove_file(&vanishing).unwrap();
+        // Corruption class 1: the snapshot's bytes rot under the pin.
+        std::fs::write(
+            super::super::sealed_blobs::sealed_blob_path(handle.dir(), &corrupt_pin),
+            b"bitrot",
+        )
+        .unwrap();
+        // Corruption class 2: the snapshot vanishes AND the live file
+        // drifted — the approved revision is gone from both worlds.
+        std::fs::remove_file(super::super::sealed_blobs::sealed_blob_path(
+            handle.dir(),
+            &unrecon_pin,
+        ))
+        .unwrap();
+        std::fs::write(&unreconstructable, b"amended after approval\n").unwrap();
 
         let mut rx = handle.bus().subscribe();
         run_pass(&handle, &mut journal, &mut state).await;
@@ -1513,16 +1642,16 @@ mod tests {
                     event,
                     AppEvent::ControlCommand(ControlMsg::StartTask { .. })
                 ),
-                "a drifted seal must not spawn"
+                "a broken seal must not spawn"
             );
         }
         let (items, _, _) = handle.snapshot();
-        let drifted = items.iter().find(|i| i.id == drift_item).unwrap();
-        let run = drifted.effects[0].last_run.as_ref().unwrap();
+        let corrupted = items.iter().find(|i| i.id == corrupt_item).unwrap();
+        let run = corrupted.effects[0].last_run.as_ref().unwrap();
         assert_eq!(run.state, "failed");
         let note = run.note.as_deref().unwrap_or_default();
         assert!(
-            note.starts_with(&format!("binding ref drifted: {drifting_locator}")),
+            note.starts_with(&format!("binding ref snapshot corrupt: {corrupt_locator}")),
             "the named reason reaches the item: {note}"
         );
         assert_eq!(
@@ -1531,33 +1660,71 @@ mod tests {
             "the journal records the terminal refusal"
         );
         assert_eq!(
-            drifted.effects[0].consecutive_failures, 1,
+            corrupted.effects[0].consecutive_failures, 1,
             "the refusal counts on the standing streak — suspension machinery sees it"
         );
-        let vanished = items.iter().find(|i| i.id == vanish_item).unwrap();
-        let run = vanished.effects[0].last_run.as_ref().unwrap();
+        let unrecon = items.iter().find(|i| i.id == unrecon_item).unwrap();
+        let run = unrecon.effects[0].last_run.as_ref().unwrap();
         assert_eq!(run.state, "failed");
         let note = run.note.as_deref().unwrap_or_default();
         assert!(
-            note.starts_with(&format!("binding ref unreadable: {vanishing_locator}")),
-            "the unreadable case refuses under its own name: {note}"
+            note.starts_with(&format!(
+                "binding ref snapshot missing and live file drifted: {unrecon_locator}"
+            )),
+            "the unreconstructable case refuses under its own name: {note}"
         );
-        assert_eq!(vanished.effects[0].consecutive_failures, 1);
+        assert_eq!(unrecon.effects[0].consecutive_failures, 1);
+    }
 
-        // Restoring the approved bytes does not resurrect the SPENT
-        // occurrence — the next series instant fires normally instead.
-        std::fs::write(&drifting, b"approved bytes\n").unwrap();
+    /// Sealed refs (PR B): the A→B window heal. A manifest approved with
+    /// a hash pin but NO snapshot (sealed on the hash-pin build before
+    /// the store existed) fires when the live bytes still match the
+    /// approved pin — the verifier seals them in place first, so
+    /// preservation begins retroactively instead of refusing a firing
+    /// with zero corruption behind it.
+    #[tokio::test]
+    async fn missing_snapshot_heals_from_live_bytes_matching_the_pin() {
+        let dir = tempfile::tempdir().unwrap();
+        let default_project = tempfile::tempdir().unwrap();
+        let content = tempfile::tempdir().unwrap();
+        let brief = content.path().join("brief.md");
+        std::fs::write(&brief, b"pin-era approved bytes\n").unwrap();
+        let pin = super::super::store::digest_file(&brief).unwrap();
+        let handle = handle_with_default_project(dir.path(), default_project.path());
+        let mut journal = OccurrenceJournal::open(handle.dir()).unwrap();
+        let mut state = SchedulerState::default();
+        approved_sealed_item(
+            &handle,
+            now_ms() - 60_000,
+            "act on the pin-era brief",
+            vec![BindingRef {
+                locator: format!("file:{}", brief.display()),
+                sha256: pin.clone(),
+            }],
+            None,
+        );
+        // Simulate the PR-A-era manifest: the pin exists, the snapshot
+        // does not (today's propose seals it — delete to reconstruct).
+        let sealed_path = super::super::sealed_blobs::sealed_blob_path(handle.dir(), &pin);
+        std::fs::remove_file(&sealed_path).unwrap();
+
         let mut rx = handle.bus().subscribe();
         run_pass(&handle, &mut journal, &mut state).await;
+        let mut spawned = 0;
         while let Ok(event) = rx.try_recv() {
-            assert!(
-                !matches!(
-                    event,
-                    AppEvent::ControlCommand(ControlMsg::StartTask { .. })
-                ),
-                "a spent refused occurrence must not re-dispatch inside its instant"
-            );
+            if matches!(
+                event,
+                AppEvent::ControlCommand(ControlMsg::StartTask { .. })
+            ) {
+                spawned += 1;
+            }
         }
+        assert_eq!(spawned, 1, "the healable window fires");
+        assert_eq!(
+            std::fs::read(&sealed_path).unwrap(),
+            b"pin-era approved bytes\n",
+            "the verifier sealed the live bytes that matched the approved pin"
+        );
     }
 
     /// The A5 lifecycle at unit level: an approved due manifest dispatches

--- a/src/bin/caller/agenda/sealed_blobs.rs
+++ b/src/bin/caller/agenda/sealed_blobs.rs
@@ -1,0 +1,327 @@
+//! The sealed-refs snapshot store (owner-ruled 2026-07-26, PR B of the
+//! sealed-refs design): content-addressed custody for the exact bytes a
+//! binding ref pinned at propose time, so the approved revision of a
+//! referenced file SURVIVES later edits to the live file — preservation
+//! and traceability, not access control (IAM owns malice).
+//!
+//! Layout: `<agenda dir>/blobs/<sha256>` — one FILE per distinct
+//! content, named by its full lowercase sha256 hex, so dedup is the
+//! filename and integrity is re-checkable from the name alone. It
+//! shares the `blobs/` root with the Ask-v2 preview store's per-item
+//! DIRECTORIES (`blobs/<item ulid>/…`) without touching them: 64-hex
+//! filenames and ULID directories cannot collide, and the lifecycles
+//! stay disjoint — previews die with their item; sealed snapshots are
+//! shared by hash across manifests and have NO deletion path yet. GC is
+//! deliberately deferred: blobs are small text, dedup'd by content, and
+//! a wrong sweep here destroys exactly the history this store exists to
+//! preserve — a future pass can collect hashes no live manifest pins.
+//!
+//! **The deliberate PR-B semantics shift, stated here per the ruling:**
+//! with a snapshot present, live-file drift NO LONGER refuses the fire
+//! (PR A's shape) — the sealed bytes are the binding content, the fired
+//! task points the session at the snapshot path, and drift is noted
+//! informationally. Refusal remains only where preservation itself
+//! failed closed: a corrupt snapshot (bytes no longer hash to the pin),
+//! or a missing snapshot that cannot be healed from live bytes still
+//! matching the approved pin.
+
+use super::types::BindingRef;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+/// Full sha256 of an in-memory buffer as lowercase hex — the bytes twin
+/// of [`super::store::digest_file`], for callers that must hash and
+/// persist the SAME read (no re-read window between verify and seal).
+pub(crate) fn digest_bytes(bytes: &[u8]) -> String {
+    use sha2::Digest;
+    let digest = sha2::Sha256::digest(bytes);
+    let mut hex = String::with_capacity(64);
+    for byte in digest.iter() {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{byte:02x}");
+    }
+    hex
+}
+
+/// The sealed snapshot path for one pinned hash.
+pub(crate) fn sealed_blob_path(agenda_dir: &Path, sha256: &str) -> PathBuf {
+    super::blobs::blobs_root(agenda_dir).join(sha256)
+}
+
+/// Commit one sealed snapshot. `bytes` MUST already hash to `sha256` —
+/// both callers (propose intake, the fire-time heal) hold the verified
+/// bytes and the pin together; this is checked here anyway because a
+/// blob filed under the wrong name would refuse every later fire as
+/// corrupt. Content-addressed dedup: an existing blob under this hash
+/// is the same bytes by construction, so re-sealing is a no-op. The
+/// write is atomic (unique tmp + rename, fsync'd first) so a reader
+/// never sees a short blob; a crash mid-write leaves only tmp residue
+/// that the next seal of any content ignores.
+pub(crate) fn seal_content(
+    agenda_dir: &Path,
+    sha256: &str,
+    bytes: &[u8],
+) -> std::io::Result<PathBuf> {
+    let computed = digest_bytes(bytes);
+    if computed != sha256 {
+        return Err(std::io::Error::other(format!(
+            "refusing to seal under {sha256}: content hashes {computed}"
+        )));
+    }
+    let path = sealed_blob_path(agenda_dir, sha256);
+    if path.is_file() {
+        return Ok(path);
+    }
+    let dir = super::blobs::blobs_root(agenda_dir);
+    std::fs::create_dir_all(&dir)?;
+    let tmp = dir.join(format!(".tmp-{}", uuid::Uuid::new_v4().simple()));
+    let result = (|| {
+        let mut file = std::fs::File::create(&tmp)?;
+        file.write_all(bytes)?;
+        file.sync_all()?;
+        drop(file);
+        std::fs::rename(&tmp, &path)
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&tmp);
+    }
+    result.map(|()| path)
+}
+
+/// One verified seal at fire time: the snapshot path the fired session
+/// reads as the binding content, plus the informational live-file state.
+#[derive(Debug)]
+pub(crate) struct SealedVerification {
+    pub(crate) sealed_path: PathBuf,
+    /// `Some(note)` when the live file no longer matches the approved
+    /// pin — informational by design (the semantics shift above): it
+    /// rides the fired task's rider line, never refuses.
+    pub(crate) live_drift: Option<&'static str>,
+}
+
+impl SealedVerification {
+    /// The fired task's data line for this ref (sealed refs doctrine:
+    /// the CONTENT at the sealed path is what the owner reviewed and
+    /// may carry instructions; this line itself is a pointer, data).
+    pub(crate) fn rider_line(&self, binding_ref: &BindingRef) -> String {
+        let drift = match self.live_drift {
+            Some(note) => format!(" ({note})"),
+            None => String::new(),
+        };
+        format!(
+            "Binding ref {} sha256 {} — sealed copy {}, verified at fire{drift}",
+            binding_ref.locator,
+            binding_ref.sha256,
+            self.sealed_path.display()
+        )
+    }
+}
+
+/// The commission's exact informational drift note.
+const LIVE_DRIFTED: &str = "live file drifted from sealed revision";
+const LIVE_UNREADABLE: &str = "live file unreadable; the sealed revision is the binding content";
+
+/// Fire-time seal verification of one binding ref against the snapshot
+/// store. Success serves the SEALED bytes' path; the live file is
+/// probed only to note drift honestly. `Err` carries the named
+/// occurrence-failure reason the scheduler journals:
+///
+/// - snapshot corrupt (bytes no longer hash to the pin) — fail-closed;
+/// - snapshot missing and the live file no longer matches the pin —
+///   preservation cannot be reconstructed;
+/// - snapshot unreadable (I/O beyond absence).
+///
+/// A missing snapshot whose live file STILL hashes to the approved pin
+/// heals in place: those are the approved bytes by the digest-bound
+/// pin's own definition, so sealing them now is pure preservation.
+/// This closes the window for manifests approved on the hash-pin build
+/// (PR A) before this store existed, instead of refusing firings with
+/// zero corruption behind them.
+pub(crate) fn verify_sealed_binding_ref(
+    agenda_dir: &Path,
+    binding_ref: &BindingRef,
+) -> Result<SealedVerification, String> {
+    let live_path = super::store::binding_ref_path(&binding_ref.locator)?;
+    let sealed_path = sealed_blob_path(agenda_dir, &binding_ref.sha256);
+    match std::fs::read(&sealed_path) {
+        Ok(bytes) => {
+            let sealed_hash = digest_bytes(&bytes);
+            if sealed_hash != binding_ref.sha256 {
+                return Err(format!(
+                    "binding ref snapshot corrupt: {} (sealed blob hashes {sealed_hash}, \
+                     approved pin {}) — re-propose and re-approve to reseal",
+                    binding_ref.locator, binding_ref.sha256
+                ));
+            }
+            Ok(SealedVerification {
+                sealed_path,
+                live_drift: live_pin_note(live_path, &binding_ref.sha256),
+            })
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            let bytes = std::fs::read(live_path).map_err(|live_err| {
+                format!(
+                    "binding ref snapshot missing and live file unreadable: {} ({live_err}) — \
+                     re-propose and re-approve to reseal",
+                    binding_ref.locator
+                )
+            })?;
+            if digest_bytes(&bytes) != binding_ref.sha256 {
+                return Err(format!(
+                    "binding ref snapshot missing and live file drifted: {} — the approved \
+                     revision cannot be reconstructed; re-propose and re-approve to reseal",
+                    binding_ref.locator
+                ));
+            }
+            let sealed_path =
+                seal_content(agenda_dir, &binding_ref.sha256, &bytes).map_err(|seal_err| {
+                    format!(
+                        "binding ref snapshot missing and resealing failed: {} ({seal_err})",
+                        binding_ref.locator
+                    )
+                })?;
+            Ok(SealedVerification {
+                sealed_path,
+                live_drift: None,
+            })
+        }
+        Err(err) => Err(format!(
+            "binding ref snapshot unreadable: {} ({err})",
+            binding_ref.locator
+        )),
+    }
+}
+
+/// Informational live-file probe: `None` when the live file still
+/// matches the approved pin, otherwise the note the rider line carries.
+fn live_pin_note(path: &Path, pin: &str) -> Option<&'static str> {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return Some(LIVE_UNREADABLE);
+    };
+    if !meta.is_file() {
+        return Some(LIVE_UNREADABLE);
+    }
+    if meta.len() > super::types::MAX_REF_FILE_HASH_BYTES {
+        return Some(LIVE_DRIFTED);
+    }
+    match super::store::digest_file(path) {
+        Ok(live) if live == pin => None,
+        Ok(_) => Some(LIVE_DRIFTED),
+        Err(_) => Some(LIVE_UNREADABLE),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// NIST vector: sha256("abc").
+    const ABC: &str = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+
+    #[test]
+    fn seal_content_is_atomic_content_addressed_and_dedup() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = seal_content(dir.path(), ABC, b"abc").unwrap();
+        assert_eq!(path, sealed_blob_path(dir.path(), ABC));
+        assert_eq!(std::fs::read(&path).unwrap(), b"abc");
+        // No tmp residue after a clean seal.
+        let residue: Vec<_> = std::fs::read_dir(super::super::blobs::blobs_root(dir.path()))
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().starts_with(".tmp-"))
+            .collect();
+        assert!(residue.is_empty(), "atomic writes leave no tmp files");
+        // Dedup: re-sealing the same content is a no-op returning the
+        // same path.
+        let again = seal_content(dir.path(), ABC, b"abc").unwrap();
+        assert_eq!(again, path);
+        // Bytes that do not hash to the claimed pin are refused — a blob
+        // filed under the wrong name would refuse every later fire.
+        let err = seal_content(dir.path(), ABC, b"not abc").unwrap_err();
+        assert!(err.to_string().contains("refusing to seal"), "{err}");
+    }
+
+    #[test]
+    fn verification_serves_sealed_bytes_and_notes_live_drift() {
+        let agenda = tempfile::tempdir().unwrap();
+        let content = tempfile::tempdir().unwrap();
+        let live = content.path().join("brief.md");
+        std::fs::write(&live, b"abc").unwrap();
+        let binding_ref = BindingRef {
+            locator: format!("file:{}", live.display()),
+            sha256: ABC.to_string(),
+        };
+        seal_content(agenda.path(), ABC, b"abc").unwrap();
+
+        // Live intact: sealed path served, no drift note.
+        let verification = verify_sealed_binding_ref(agenda.path(), &binding_ref).unwrap();
+        assert_eq!(
+            verification.sealed_path,
+            sealed_blob_path(agenda.path(), ABC)
+        );
+        assert_eq!(verification.live_drift, None);
+
+        // Live drifted: STILL serves the sealed path — the semantics
+        // shift — with the commission's exact informational note.
+        std::fs::write(&live, b"amended after approval").unwrap();
+        let verification = verify_sealed_binding_ref(agenda.path(), &binding_ref).unwrap();
+        assert_eq!(verification.live_drift, Some(LIVE_DRIFTED));
+        assert_eq!(
+            std::fs::read(&verification.sealed_path).unwrap(),
+            b"abc",
+            "the sealed revision is the binding content despite live drift"
+        );
+        assert!(verification
+            .rider_line(&binding_ref)
+            .ends_with("(live file drifted from sealed revision)"));
+
+        // Live deleted: sealed still serves, unreadable note.
+        std::fs::remove_file(&live).unwrap();
+        let verification = verify_sealed_binding_ref(agenda.path(), &binding_ref).unwrap();
+        assert_eq!(verification.live_drift, Some(LIVE_UNREADABLE));
+    }
+
+    #[test]
+    fn corrupt_or_unreconstructable_snapshots_refuse_by_name() {
+        let agenda = tempfile::tempdir().unwrap();
+        let content = tempfile::tempdir().unwrap();
+        let live = content.path().join("brief.md");
+        std::fs::write(&live, b"abc").unwrap();
+        let binding_ref = BindingRef {
+            locator: format!("file:{}", live.display()),
+            sha256: ABC.to_string(),
+        };
+
+        // Corrupt snapshot: bytes under the pin's name no longer hash to
+        // it — fail-closed even though the live file is intact.
+        std::fs::create_dir_all(super::super::blobs::blobs_root(agenda.path())).unwrap();
+        std::fs::write(sealed_blob_path(agenda.path(), ABC), b"corrupted").unwrap();
+        let err = verify_sealed_binding_ref(agenda.path(), &binding_ref).unwrap_err();
+        assert!(err.starts_with("binding ref snapshot corrupt:"), "{err}");
+
+        // Missing snapshot + live matching the pin: heals in place (the
+        // PR-A window) and serves the fresh seal.
+        std::fs::remove_file(sealed_blob_path(agenda.path(), ABC)).unwrap();
+        let verification = verify_sealed_binding_ref(agenda.path(), &binding_ref).unwrap();
+        assert_eq!(std::fs::read(&verification.sealed_path).unwrap(), b"abc");
+        assert_eq!(verification.live_drift, None);
+
+        // Missing snapshot + drifted live: the approved revision cannot
+        // be reconstructed — refuse by name.
+        std::fs::remove_file(sealed_blob_path(agenda.path(), ABC)).unwrap();
+        std::fs::write(&live, b"amended").unwrap();
+        let err = verify_sealed_binding_ref(agenda.path(), &binding_ref).unwrap_err();
+        assert!(
+            err.starts_with("binding ref snapshot missing and live file drifted:"),
+            "{err}"
+        );
+
+        // Missing snapshot + unreadable live.
+        std::fs::remove_file(&live).unwrap();
+        let err = verify_sealed_binding_ref(agenda.path(), &binding_ref).unwrap_err();
+        assert!(
+            err.starts_with("binding ref snapshot missing and live file unreadable:"),
+            "{err}"
+        );
+    }
+}

--- a/src/bin/caller/agenda/store.rs
+++ b/src/bin/caller/agenda/store.rs
@@ -1242,8 +1242,11 @@ impl AgendaStore {
                 // own read already contradicts would only park a manifest
                 // whose every firing refuses — the project_root precedent
                 // (name the deterministic fire-time refusal at review
-                // time).
-                let binding_refs = validate_binding_refs(binding_refs)?;
+                // time). The verified bytes are SEALED into the snapshot
+                // store in the same act: preservation starts at propose,
+                // so the revision the owner reviews is the revision every
+                // fire serves, whatever happens to the live file later.
+                let binding_refs = validate_binding_refs(binding_refs, &self.dir)?;
                 // v1: one session effect per item — a re-propose revises it
                 // (stable effect_id lineage, fresh digest, approval void).
                 let effect_id = item
@@ -2156,9 +2159,14 @@ pub(crate) fn binding_ref_path(locator: &str) -> Result<&Path, String> {
 /// daemon's OWN read of the live bytes — a pin this read already
 /// contradicts would only park a manifest whose every firing refuses,
 /// so the contradiction is named at review time (the project_root
-/// precedent). Pins normalize to lowercase hex; the returned refs are
-/// what the digest-bound manifest records.
-fn validate_binding_refs(refs: Vec<BindingRef>) -> Result<Vec<BindingRef>, AgendaError> {
+/// precedent). The verified bytes are sealed into the snapshot store in
+/// the same act (single read: the bytes hashed ARE the bytes preserved —
+/// no re-read window). Pins normalize to lowercase hex; the returned
+/// refs are what the digest-bound manifest records.
+fn validate_binding_refs(
+    refs: Vec<BindingRef>,
+    agenda_dir: &Path,
+) -> Result<Vec<BindingRef>, AgendaError> {
     if refs.len() > MAX_BINDING_REFS_PER_MANIFEST {
         return Err(AgendaError::Invalid(format!(
             "a manifest seals at most {MAX_BINDING_REFS_PER_MANIFEST} binding refs"
@@ -2192,60 +2200,28 @@ fn validate_binding_refs(refs: Vec<BindingRef>) -> Result<Vec<BindingRef>, Agend
                  binding refs seal working artifacts, not archives"
             )));
         }
-        let live = digest_file(path).map_err(|err| {
-            AgendaError::Invalid(format!("cannot hash binding ref {locator}: {err}"))
+        let bytes = std::fs::read(path).map_err(|err| {
+            AgendaError::Invalid(format!("cannot read binding ref {locator}: {err}"))
         })?;
+        let live = super::sealed_blobs::digest_bytes(&bytes);
         if live != sha256 {
             return Err(AgendaError::Invalid(format!(
                 "binding ref {locator}: the proposed pin {sha256} does not match the \
                  live content ({live}) — re-read the file and re-propose"
             )));
         }
+        // Seal failure refuses the propose: a manifest whose snapshot
+        // never existed would refuse every firing — fail closed at the
+        // ceremony, not at 3am.
+        super::sealed_blobs::seal_content(agenda_dir, &sha256, &bytes).map_err(|err| {
+            AgendaError::Io(std::io::Error::new(
+                err.kind(),
+                format!("sealing binding ref {locator}: {err}"),
+            ))
+        })?;
         validated.push(BindingRef { locator, sha256 });
     }
     Ok(validated)
-}
-
-/// Fire-time seal check of one binding ref (sealed refs): the live file
-/// must still hash to the approved pin exactly. `Err` carries the named
-/// occurrence-failure reason — the scheduler journals it and refuses to
-/// spawn, so an approved goal never runs against silently drifted or
-/// unreadable referenced content.
-pub(crate) fn verify_binding_ref(binding_ref: &BindingRef) -> Result<(), String> {
-    let path = binding_ref_path(&binding_ref.locator)?;
-    let live = match std::fs::metadata(path) {
-        Ok(meta) if !meta.is_file() => {
-            return Err(format!(
-                "binding ref unreadable: {} (not a regular file)",
-                binding_ref.locator
-            ))
-        }
-        Ok(meta) if meta.len() > MAX_REF_FILE_HASH_BYTES => {
-            // Grown past the hash bound = changed by size alone; attach
-            // only ever pinned content within the bound (G1's rule).
-            return Err(format!(
-                "binding ref drifted: {} — the live file outgrew the \
-                 {MAX_REF_FILE_HASH_BYTES}-byte seal bound",
-                binding_ref.locator
-            ));
-        }
-        Ok(_) => digest_file(path)
-            .map_err(|err| format!("binding ref unreadable: {} ({err})", binding_ref.locator))?,
-        Err(err) => {
-            return Err(format!(
-                "binding ref unreadable: {} ({err})",
-                binding_ref.locator
-            ))
-        }
-    };
-    if live != binding_ref.sha256 {
-        return Err(format!(
-            "binding ref drifted: {} — approved sha256 {}, live file {live}; \
-             re-propose and re-approve to reseal",
-            binding_ref.locator, binding_ref.sha256
-        ));
-    }
-    Ok(())
 }
 
 fn validate_title(title: &str) -> Result<String, AgendaError> {
@@ -4330,6 +4306,18 @@ mod tests {
             sealed.effects[0].manifest.binding_refs,
             "replay converges — the op carries the sealed manifest verbatim"
         );
+        // The verified bytes were SEALED in the same act: the snapshot
+        // store holds the exact content under its pin (pin 3, atomic
+        // propose-time preservation).
+        assert_eq!(
+            std::fs::read(super::super::sealed_blobs::sealed_blob_path(
+                dir.path(),
+                &pin
+            ))
+            .unwrap(),
+            b"the sealed brief\n",
+            "propose seals the reviewed bytes content-addressed"
+        );
 
         // A pin the daemon's read contradicts refuses by name.
         let err = store
@@ -4423,43 +4411,6 @@ mod tests {
                 .contains(&MAX_BINDING_REFS_PER_MANIFEST.to_string()),
             "{err}"
         );
-    }
-
-    /// Fire-time seal check: unchanged content passes; drifted content,
-    /// missing files, and non-`file:` locators refuse with exactly the
-    /// named reasons the scheduler journals against the occurrence.
-    #[test]
-    fn verify_binding_ref_names_drift_and_unreadable() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("sealed.md");
-        std::fs::write(&path, b"v1").unwrap();
-        let pin = digest_file(&path).unwrap();
-        let bref = BindingRef {
-            locator: format!("file:{}", path.display()),
-            sha256: pin,
-        };
-        assert_eq!(verify_binding_ref(&bref), Ok(()));
-
-        std::fs::write(&path, "v2 — amended under an armed approval").unwrap();
-        let err = verify_binding_ref(&bref).unwrap_err();
-        assert!(
-            err.starts_with(&format!("binding ref drifted: file:{}", path.display())),
-            "{err}"
-        );
-
-        std::fs::remove_file(&path).unwrap();
-        let err = verify_binding_ref(&bref).unwrap_err();
-        assert!(
-            err.starts_with(&format!("binding ref unreadable: file:{}", path.display())),
-            "{err}"
-        );
-
-        let err = verify_binding_ref(&BindingRef {
-            locator: "/no-scheme".into(),
-            sha256: "aa".repeat(32),
-        })
-        .unwrap_err();
-        assert!(err.contains("file:<absolute path>"), "{err}");
     }
 
     /// The sealed-refs twin of the cross-build rider: a build that


### PR DESCRIPTION
PR B of the sealed-refs ruling (owner-approved 2026-07-26), the
deliberate semantics shift stated in-code: binding-ref bytes verified
at propose intake are SEALED into a content-addressed snapshot store
(<agenda dir>/blobs/<sha256> — atomic tmp+rename+fsync, dedup by hash,
64-hex files beside the preview store's per-item ULID dirs; GC
deliberately deferred), and fire time serves the SEALED revision as
the binding content: live-file drift or deletion under an armed
approval no longer refuses the spawn — the fired task's rider line
names the sealed copy path and notes drift informationally ('live
file drifted from sealed revision'). Refusal remains where
preservation itself broke, fail-closed and streak-visible: a corrupt
snapshot (bytes no longer hash to the pin) or a missing one that
cannot be healed from live bytes still matching the approved pin; a
missing snapshot whose live file still matches heals in place (the
PR-A window — those are the approved bytes by the digest-bound pin's
definition). Rider lines are minted once at dispatch verification and
reused verbatim on delegation retries, like the project resolution.
Seal failure at propose refuses the propose — a manifest whose
snapshot never existed would refuse every firing.

Pins: sealed bytes served byte-identical despite drift/deletion (no
streak entry), corrupt + unreconstructable snapshots refuse under
their names (journaled failed, streak-counted), the A→B heal, atomic
dedup'd seal writes, propose-time blob content, and the fired-task
exact bytes naming the sealed copy. The Ask-v2 preview store's
exclusivity pin is amended to name this sibling store as the ruled
owner decision.
