### PR TITLE
fix(agenda): derive the no-overlap hold from the journal — manifest swap mid-firing no longer fires a duplicate session

### DIFF
--- a/src/bin/caller/agenda/reminders.rs
+++ b/src/bin/caller/agenda/reminders.rs
@@ -395,6 +395,22 @@ impl OccurrenceJournal {
             .collect()
     }
 
+    /// True while any session occurrence of this item is `started` with no
+    /// terminal record — the journal-derived no-overlap hold. The journal
+    /// is the one record of a live firing that survives a manifest
+    /// re-propose: the fold replaces the effect object, and a re-approval's
+    /// fresh digest mints occurrence ids the per-occurrence dedup has never
+    /// seen, so effect state alone goes blind mid-swap. Never a wedge:
+    /// every `started` row resolves through the write-back's terminal or
+    /// the boot/lag passes' fail-closed `unknown`.
+    pub(crate) fn started_unresolved_for_item(&self, item_id: &str) -> bool {
+        self.state.values().any(|progress| {
+            progress.item_id.as_deref() == Some(item_id)
+                && progress.started.is_some()
+                && progress.terminal.is_none()
+        })
+    }
+
     /// Occurrences with a `prepared` record but no terminal one — a crash
     /// interrupted delivery; at-least-once means they retry. (The planner
     /// derives retries from item state; this is the test/diagnostic view.)
@@ -1033,12 +1049,20 @@ pub(crate) fn plan(
             }
             // No-overlap (G3-pre): while any occurrence of this effect is
             // dispatched or running, fire nothing new — the write-back
-            // nudge replans when it settles.
+            // nudge replans when it settles. The hold derives from the
+            // JOURNAL, item-wide, not just the effect object: a re-propose
+            // replaces the effect (approval void, `last_run` at best
+            // carried) while the swapped-out revision's firing may still
+            // run, and the re-approved digest mints occurrence ids the
+            // per-occurrence dedup below has never seen — the
+            // started-without-terminal row is the record of that live
+            // firing which survives the swap.
             let overlap = in_flight_effects.contains(&effect.effect_id)
                 || effect
                     .last_run
                     .as_ref()
-                    .is_some_and(|run| run.state == "started");
+                    .is_some_and(|run| run.state == "started")
+                || journal.started_unresolved_for_item(&item.id);
             for (instant, identity_ms, recurring) in candidates {
                 let occurrence_id = session_occurrence_id(
                     &item.id,
@@ -1150,9 +1174,10 @@ pub(crate) fn plan(
 /// is a candidate; spent ones are journal-deduped). The one deliberate
 /// difference: transient execution state — the scheduler's private
 /// in-flight set, and the no-overlap hold while a run of this effect is
-/// still `started` — only DELAYS a fire, so a due instant held by either
-/// keeps showing here (it fires when the run settles; mid-dispatch, the
-/// write-back settles the display). The
+/// still `started` (per the effect object or any started-without-terminal
+/// journal row of the item) — only DELAYS a fire, so a due instant held
+/// by either keeps showing here (it fires when the run settles;
+/// mid-dispatch, the write-back settles the display). The
 /// `next_fire_agrees_with_the_planner` differential test pins this mirror
 /// to `plan` itself.
 pub(crate) fn effect_next_fire_ms(
@@ -1956,6 +1981,107 @@ mod tests {
             &effects_in_flight,
         );
         assert!(held.spawn.is_empty());
+    }
+
+    /// The duplicate-orchestrator regression (live shape 2026-07-26): a
+    /// firing is `started`, the manifest is re-proposed and re-approved —
+    /// the fold swaps the effect object, and the fresh digest mints
+    /// occurrence ids the per-occurrence dedup has never seen. Even when
+    /// the effect object claims no live run (`last_run: None`, the
+    /// swapped shape), the item's started-without-terminal JOURNAL row
+    /// holds every schedule firing of that item closed until it resolves;
+    /// unrelated items keep their own per-effect semantics and fire.
+    #[test]
+    fn started_journal_row_holds_the_item_across_a_manifest_swap() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut journal = journal_at(dir.path());
+        let policy = ReminderPolicy::default();
+        let now = 100_000;
+
+        // The swapped-out revision's firing: `started`, no terminal. Its
+        // occurrence id derives from the OLD digest — nothing the
+        // re-approved effect will ever recompute.
+        for (at_ms, state) in [
+            (now - 10_000, OccurrenceState::Prepared),
+            (now - 9_000, OccurrenceState::Started),
+        ] {
+            journal
+                .append(&OccurrenceRecord {
+                    v: 1,
+                    at_ms,
+                    occurrence_id: "occ-old-digest".into(),
+                    item_id: "swapped".into(),
+                    due_ms: now - 10_000,
+                    state,
+                    urgency: None,
+                    session_id: Some("sess-live".into()),
+                })
+                .unwrap();
+        }
+
+        // The post-swap effect object: fresh digest + approval,
+        // `last_run: None` — exactly what the planner saw live.
+        let swapped = one_shot_item("swapped", now - 5_000);
+        let unrelated = one_shot_item("unrelated", now - 5_000);
+        let held = plan(
+            &[swapped.clone(), unrelated.clone()],
+            &journal,
+            &policy,
+            now,
+            None,
+            &Default::default(),
+            &Default::default(),
+        );
+        assert!(
+            held.spawn.iter().all(|s| s.item_id != "swapped"),
+            "a started-without-terminal row must hold the item: {held:?}"
+        );
+        assert!(
+            held.missed_sessions.iter().all(|s| s.item_id != "swapped"),
+            "a held instant is delayed, never missed: {held:?}"
+        );
+        assert!(held.crashed.is_empty(), "{held:?}");
+        assert_eq!(
+            held.spawn
+                .iter()
+                .filter(|s| s.item_id == "unrelated")
+                .count(),
+            1,
+            "the hold is per-item — unrelated items keep firing: {held:?}"
+        );
+
+        // The old firing resolves → the hold releases and the
+        // re-approved instant fires.
+        journal
+            .append(&OccurrenceRecord {
+                v: 1,
+                at_ms: now,
+                occurrence_id: "occ-old-digest".into(),
+                item_id: "swapped".into(),
+                due_ms: now - 10_000,
+                state: OccurrenceState::Completed,
+                urgency: None,
+                session_id: Some("sess-live".into()),
+            })
+            .unwrap();
+        let released = plan(
+            &[swapped, unrelated],
+            &journal,
+            &policy,
+            now,
+            None,
+            &Default::default(),
+            &Default::default(),
+        );
+        assert_eq!(
+            released
+                .spawn
+                .iter()
+                .filter(|s| s.item_id == "swapped")
+                .count(),
+            1,
+            "the hold releases when the started row resolves: {released:?}"
+        );
     }
 
     fn journal_at(dir: &Path) -> OccurrenceJournal {
@@ -3145,18 +3271,27 @@ mod tests {
         let policy = ReminderPolicy::default();
         let approved = 10_000;
         let standing = triggered_item("steward", gate_trigger(), approved, approved);
-        journal
-            .append(&OccurrenceRecord {
-                v: 1,
-                at_ms: 15_000,
-                occurrence_id: "occ-prior".into(),
-                item_id: "steward".into(),
-                due_ms: 15_000,
-                state: OccurrenceState::Started,
-                urgency: None,
-                session_id: Some("sess-fired".into()),
-            })
-            .unwrap();
+        // The prior firing SETTLED: loop exclusion derives from the
+        // started row's attribution, which survives the terminal — a
+        // still-unresolved row would trip the item-wide no-overlap hold
+        // and this pass would (correctly) plan nothing at all.
+        for (at_ms, state) in [
+            (15_000, OccurrenceState::Started),
+            (15_500, OccurrenceState::Completed),
+        ] {
+            journal
+                .append(&OccurrenceRecord {
+                    v: 1,
+                    at_ms,
+                    occurrence_id: "occ-prior".into(),
+                    item_id: "steward".into(),
+                    due_ms: 15_000,
+                    state,
+                    urgency: None,
+                    session_id: Some("sess-fired".into()),
+                })
+                .unwrap();
+        }
 
         let mut consumed = matching_question("q-consumed", 20_000, None);
         consumed.annotations.push(AgendaAnnotation {

--- a/src/bin/caller/agenda/scheduler.rs
+++ b/src/bin/caller/agenda/scheduler.rs
@@ -1951,6 +1951,124 @@ mod tests {
         assert_eq!(run.session_id.as_deref(), Some("sess-run-2"));
     }
 
+    /// The duplicate-orchestrator regression, live shape (2026-07-26): a
+    /// firing is `started`; the manifest is re-proposed mid-flight (the
+    /// fold swaps the effect object) and re-approved. The swap must not
+    /// blind the no-overlap hold — the swap carries the live run forward
+    /// on the effect, the item's started-without-terminal journal row
+    /// holds regardless, the pass after re-approval dispatches NOTHING,
+    /// and the revision fires exactly once the old firing resolves.
+    #[tokio::test]
+    async fn revision_mid_firing_holds_until_the_started_row_resolves() {
+        let dir = tempfile::tempdir().unwrap();
+        let default_project = tempfile::tempdir().unwrap();
+        let handle = handle_with_default_project(dir.path(), default_project.path());
+        let mut journal = OccurrenceJournal::open(handle.dir()).unwrap();
+        let mut state = SchedulerState::default();
+        let (item_id, _, _) = approved_effect_item(&handle, now_ms() - 60_000);
+
+        // Fire + receipt: the run is live.
+        let mut rx = handle.bus().subscribe();
+        run_pass(&handle, &mut journal, &mut state).await;
+        let mut first = None;
+        while let Ok(event) = rx.try_recv() {
+            if let AppEvent::ControlCommand(ControlMsg::StartTask {
+                delegation_id: Some(delegation_id),
+                ..
+            }) = event
+            {
+                first = Some(delegation_id);
+            }
+        }
+        let first = first.expect("the approved manifest dispatches");
+        observe_event(
+            &handle,
+            &mut journal,
+            &mut state,
+            &AppEvent::TaskReceived {
+                delegation_id: first,
+                session_id: "sess-live".into(),
+            },
+        );
+
+        // Swap mid-flight: re-propose (new bytes), then owner re-approval.
+        let revised = handle
+            .apply(
+                AgendaCommand::ProposeEffect {
+                    binding_refs: Vec::new(),
+                    recurrence: None,
+                    id: item_id.clone(),
+                    goal: "run the nightly sweep, rev 2".into(),
+                    fire_at_ms: now_ms() - 30_000,
+                    orchestrate: false,
+                    source: None,
+                    agent_config: None,
+                    trigger: None,
+                    project_root: None,
+                },
+                None,
+            )
+            .unwrap();
+        assert_eq!(
+            revised.effects[0]
+                .last_run
+                .as_ref()
+                .map(|run| run.state.as_str()),
+            Some("started"),
+            "a mid-flight revision carries the live run forward"
+        );
+        handle
+            .apply(
+                AgendaCommand::ApproveEffect {
+                    id: item_id.clone(),
+                    digest: revised.effects[0].digest.clone(),
+                },
+                owner(),
+            )
+            .unwrap();
+
+        // The pass after swap + re-approval plans NOTHING for the item —
+        // the defect dispatched a duplicate orchestrator right here.
+        let mut rx = handle.bus().subscribe();
+        run_pass(&handle, &mut journal, &mut state).await;
+        while let Ok(event) = rx.try_recv() {
+            assert!(
+                !matches!(
+                    event,
+                    AppEvent::ControlCommand(ControlMsg::StartTask { .. })
+                ),
+                "a live firing must hold the re-approved manifest closed"
+            );
+        }
+
+        // The old firing settles → the hold releases → rev 2 fires.
+        observe_event(
+            &handle,
+            &mut journal,
+            &mut state,
+            &AppEvent::DoneSignal {
+                session_id: Some("sess-live".into()),
+                message: Some("old firing done".into()),
+            },
+        );
+        let mut rx = handle.bus().subscribe();
+        run_pass(&handle, &mut journal, &mut state).await;
+        let mut second = None;
+        while let Ok(event) = rx.try_recv() {
+            if let AppEvent::ControlCommand(ControlMsg::StartTask {
+                delegation_id: Some(delegation_id),
+                ..
+            }) = event
+            {
+                second = Some(delegation_id);
+            }
+        }
+        assert!(
+            second.is_some(),
+            "the revision fires once the started row resolves"
+        );
+    }
+
     /// F3 start-now rides the ordinary scheduled lane end to end at unit
     /// level: the gesture's approved now-manifest dispatches exactly one
     /// delegation-tagged StartTask on the next pass, the receipt journals

--- a/src/bin/caller/agenda/types.rs
+++ b/src/bin/caller/agenda/types.rs
@@ -485,6 +485,12 @@ pub struct AgendaEffect {
     /// Owner approval of exactly `digest`; cleared by any re-propose.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) approval: Option<AgendaApproval>,
+    /// Latest occurrence write-back on this effect lineage. A re-propose
+    /// clears a settled outcome (a fresh revision shows no stale outcome
+    /// view) but carries a `started` run forward — the firing belongs to
+    /// the `effect_id` lineage, not the digest, and the no-overlap hold,
+    /// run-now's one-occurrence-at-a-time gate, and boot recovery's
+    /// lineage match must survive a mid-firing revision.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) last_run: Option<AgendaRun>,
     /// Consecutive non-success (`failed`/`unknown`) occurrence outcomes
@@ -1875,7 +1881,7 @@ pub(crate) fn apply_op(
                 return Some(format!("propose_effect for unknown {id} ignored"));
             };
             let actor = rec.actor.clone().unwrap_or_default();
-            let effect = AgendaEffect {
+            let mut effect = AgendaEffect {
                 effect_id: effect_id.clone(),
                 digest: manifest_digest(id, effect_id, manifest),
                 manifest: manifest.clone(),
@@ -1893,7 +1899,21 @@ pub(crate) fn apply_op(
                 next_fire_ms: None,
             };
             match item.effects.iter_mut().find(|e| e.effect_id == *effect_id) {
-                Some(existing) => *existing = effect,
+                Some(existing) => {
+                    // A run still in flight belongs to the effect_id
+                    // lineage, not the digest: the write-back and boot
+                    // recovery match outcomes by `last_run`, and the
+                    // planner's no-overlap hold and run-now's
+                    // one-occurrence-at-a-time gate read it — a swap
+                    // mid-firing must not blind them. A SETTLED outcome
+                    // still clears: a fresh revision shows no stale
+                    // outcome view.
+                    effect.last_run = existing
+                        .last_run
+                        .take()
+                        .filter(|run| run.state == "started");
+                    *existing = effect;
+                }
                 None => item.effects.push(effect),
             }
             item.updated_ms = at_ms;


### PR DESCRIPTION
## The defect (live specimen 2026-07-26 night)

NS backfill session 019fa0df spawned while the prior orchestrator still ran a 22-worker pool, immediately after a manifest swap (v6) + owner approve. Evidence on agenda item `01KYGE459E9B23KAQT5KRXTYTV`; every cite verified firsthand against `main` @ 8953b9f6:

- `plan()`'s no-overlap guard read **the effect object alone** (`effect.last_run.state == "started"`, reminders.rs).
- `AgendaOp::ProposeEffect`'s fold **replaces the effect object** — stable `effect_id` lineage, but `last_run: None` (types.rs), so the hold vanished while the old firing lived.
- Session occurrence ids include the **approval digest**, so re-approval mints occurrence ids the per-occurrence journal dedup has never seen — nothing else stood in the way.
- The journal **did** know: a started-without-terminal occurrence row existed for the item (`started_sessions_for_item` is the in-tree journal-derivation precedent, trigger lane).

## The fix (two layers)

1. **The hold derives from the JOURNAL, item-wide** (`OccurrenceJournal::started_unresolved_for_item`): any started-without-terminal occurrence row of the item holds every schedule firing of that item closed until it resolves. Never a wedge — every started row resolves through the write-back's terminal or the boot/lag passes' fail-closed `unknown`. Unrelated items keep the existing per-effect semantics untouched.
2. **Belt-and-braces: the fold carries a `started` `last_run` across a re-propose** — the run belongs to the `effect_id` lineage, not the digest; the run-now one-occurrence-at-a-time gate (store.rs) and boot recovery's lineage match (scheduler.rs) read it too. A **settled** outcome still clears on re-propose, exactly as the existing test pins ("a fresh revision clears the stale outcome view").

## Regression pins

- `started_journal_row_holds_the_item_across_a_manifest_swap` (planner-level, reminders.rs): the swap-blinded shape — effect object claims no live run, journal row holds; a held instant is delayed, never missed; **unrelated item fires in the same pass**; terminal releases the hold.
- `revision_mid_firing_holds_until_the_started_row_resolves` (scheduler e2e): the live shape — firing started → re-propose (asserts the swap **carries** the started run) → re-approve → pass dispatches NOTHING → DoneSignal settles → the revision fires.
- Reconciled fixture: the trigger loop-exclusion test now settles its prior occurrence — its target (verified-attribution exclusion, T0 ruling 7) derives from the started row's session id, which survives the terminal; an unresolved row now correctly holds the item.

Display semantics unchanged: `effect_next_fire_ms` deliberately keeps showing a held instant (holds only delay); its doc names the new hold source. Battery: fmt --check, nextest bins (5272 pass), lib crates, workspace clippy -D warnings, headless e2e (33 pass) — all green.