### PR TITLE
PR-1: pencil edits rewind claude-code sessions in place (wire rewind → surgery → fork)

### DIFF
--- a/src/bin/caller/agent_loop.rs
+++ b/src/bin/caller/agent_loop.rs
@@ -154,6 +154,11 @@ pub(crate) struct FollowUpMessage {
     pub(crate) edit_original_text: Option<String>,
     pub(crate) unresolved_attachment_ids: Vec<String>,
     pub(crate) target_session_id: Option<String>,
+    /// Claude Code in-place edit: transcript uuids to rewind over the
+    /// control wire, newest-first, ending with the edited row itself
+    /// (resolved by the supervisor's `claude_edit_in_place_ladder`).
+    /// Empty for every other message kind.
+    pub(crate) claude_inplace_rewind_targets: Vec<String>,
     pub(crate) managed_context_recovery_kickstart: bool,
     pub(crate) managed_context_density_handoff: bool,
     pub(crate) managed_context_density_handoff_completed: bool,
@@ -171,6 +176,7 @@ impl FollowUpMessage {
             edit_original_text: None,
             unresolved_attachment_ids: Vec::new(),
             target_session_id: None,
+            claude_inplace_rewind_targets: Vec::new(),
             managed_context_recovery_kickstart: false,
             managed_context_density_handoff: false,
             managed_context_density_handoff_completed: false,
@@ -188,6 +194,7 @@ impl FollowUpMessage {
             edit_original_text: None,
             unresolved_attachment_ids: Vec::new(),
             target_session_id: None,
+            claude_inplace_rewind_targets: Vec::new(),
             managed_context_recovery_kickstart: false,
             managed_context_density_handoff: false,
             managed_context_density_handoff_completed: false,
@@ -205,6 +212,7 @@ impl FollowUpMessage {
             edit_original_text: None,
             unresolved_attachment_ids: Vec::new(),
             target_session_id: None,
+            claude_inplace_rewind_targets: Vec::new(),
             managed_context_recovery_kickstart: false,
             managed_context_density_handoff: false,
             managed_context_density_handoff_completed: false,
@@ -229,6 +237,7 @@ impl FollowUpMessage {
             edit_original_text: original_text,
             unresolved_attachment_ids,
             target_session_id: None,
+            claude_inplace_rewind_targets: Vec::new(),
             managed_context_recovery_kickstart: false,
             managed_context_density_handoff: false,
             managed_context_density_handoff_completed: false,
@@ -237,6 +246,11 @@ impl FollowUpMessage {
 
     pub(crate) fn for_target(mut self, target_session_id: Option<String>) -> Self {
         self.target_session_id = target_session_id;
+        self
+    }
+
+    pub(crate) fn with_claude_inplace_rewind_targets(mut self, targets: Vec<String>) -> Self {
+        self.claude_inplace_rewind_targets = targets;
         self
     }
 

--- a/src/bin/caller/external_agent/claude_code.rs
+++ b/src/bin/caller/external_agent/claude_code.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex as StdMutex, MutexGuard as StdMutexGuard};
 
@@ -7,15 +7,15 @@ use async_trait::async_trait;
 use serde::Serialize;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter};
 use tokio::process::{Child, ChildStdin};
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{mpsc, oneshot, Mutex};
 
 use crate::error::CallerError;
 use crate::session_activity::ActivityObservation as ActivityObs;
 
 use super::{
     normalize_plan_status, AgentConfig, AgentEvent, AgentImageAttachment, AgentThread,
-    AgentUsageSnapshot, ApprovalCategory, ApprovalDecision, ExternalAgent, GoalActionOutcome,
-    GoalEngine, SubAgentState, ToolCompletionStatus,
+    AgentUsageSnapshot, ApprovalCategory, ApprovalDecision, ConversationRewindOutcome,
+    ExternalAgent, GoalActionOutcome, GoalEngine, SubAgentState, ToolCompletionStatus,
 };
 
 /// Appended to the first user message when an Intendant web port is
@@ -178,6 +178,124 @@ fn lock_pending(
     match pending.lock() {
         Ok(guard) => guard,
         Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+/// Waiters for `control_response`s to OUR outbound `control_request`s,
+/// keyed by request_id — the correlated upgrade over the historically
+/// fire-and-forget `write_control_request`. The reader completes a
+/// waiter with the envelope's whole `response` object; requests without
+/// a registered waiter keep the fire-and-forget log behavior.
+type PendingControlResponses = Arc<StdMutex<HashMap<String, oneshot::Sender<serde_json::Value>>>>;
+
+fn lock_pending_controls(
+    pending: &PendingControlResponses,
+) -> StdMutexGuard<'_, HashMap<String, oneshot::Sender<serde_json::Value>>> {
+    match pending.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+/// The stream-json control subtype for CC's native in-place conversation
+/// rewind. Present in the installed CLI since 2.1.218; `rewind_wire_subtype_canary`
+/// pins this token and the probe mechanics, and
+/// `tests/skills/session-fork-probes/` carries the live-binary probe run
+/// on every CC bump.
+pub(crate) const CLAUDE_REWIND_WIRE_SUBTYPE: &str = "rewind_conversation";
+
+/// The CLI answers a rewind in ~0.1 s when idle and within its own 10 s
+/// interrupt wait when aborting a turn; past this the subtype is being
+/// ignored and the ladder should fall back.
+const CC_REWIND_RESPONSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+/// After a `result` line the CLI stays non-idle briefly (worst observed
+/// 3.3 s → `"turn running"` refusals); this retry cadence and budget
+/// absorb that window without masking a genuinely stuck session.
+const CC_REWIND_BUSY_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_millis(250);
+const CC_REWIND_BUSY_RETRY_BUDGET: std::time::Duration = std::time::Duration::from_secs(15);
+
+/// What a scan of the installed CC binary says about the rewind wire
+/// subtype. `Unknown` (unresolvable or unreadable executable — e.g. a
+/// wrapper script) is treated optimistically by callers: the wire
+/// refusal→fallback ladder catches a CLI that doesn't answer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ClaudeRewindWireCapability {
+    Supported,
+    Unsupported,
+    Unknown,
+}
+
+/// Capability-probe the configured CC executable for
+/// [`CLAUDE_REWIND_WIRE_SUBTYPE`]. Reads the binary in chunks (the CLI
+/// is ~250 MB) and caches the verdict per executable fingerprint, so
+/// the cost is paid once per installed version, not per edit.
+pub(crate) fn claude_rewind_wire_capability(command: &str) -> ClaudeRewindWireCapability {
+    static CACHE: std::sync::OnceLock<StdMutex<HashMap<String, (String, bool)>>> =
+        std::sync::OnceLock::new();
+    let Some(fingerprint) = super::protocol_watch::executable_fingerprint(command) else {
+        return ClaudeRewindWireCapability::Unknown;
+    };
+    let cache = CACHE.get_or_init(|| StdMutex::new(HashMap::new()));
+    {
+        let guard = match cache.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if let Some((digest, found)) = guard.get(&fingerprint.canonical_path) {
+            if *digest == fingerprint.digest {
+                return if *found {
+                    ClaudeRewindWireCapability::Supported
+                } else {
+                    ClaudeRewindWireCapability::Unsupported
+                };
+            }
+        }
+    }
+    let found = match binary_contains_token(
+        Path::new(&fingerprint.canonical_path),
+        CLAUDE_REWIND_WIRE_SUBTYPE.as_bytes(),
+    ) {
+        Ok(found) => found,
+        Err(_) => return ClaudeRewindWireCapability::Unknown,
+    };
+    let mut guard = match cache.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    guard.insert(fingerprint.canonical_path, (fingerprint.digest, found));
+    if found {
+        ClaudeRewindWireCapability::Supported
+    } else {
+        ClaudeRewindWireCapability::Unsupported
+    }
+}
+
+/// Chunked byte-substring scan (8 MiB windows overlapped by the token
+/// length), so a quarter-gigabyte executable never sits in memory whole.
+fn binary_contains_token(path: &Path, token: &[u8]) -> std::io::Result<bool> {
+    use std::io::Read;
+    if token.is_empty() {
+        return Ok(true);
+    }
+    const CHUNK: usize = 8 * 1024 * 1024;
+    let mut file = std::fs::File::open(path)?;
+    let mut buf = vec![0u8; CHUNK + token.len() - 1];
+    let mut carry = 0usize;
+    loop {
+        let read = file.read(&mut buf[carry..])?;
+        if read == 0 {
+            return Ok(false);
+        }
+        let filled = carry + read;
+        if buf[..filled]
+            .windows(token.len())
+            .any(|window| window == token)
+        {
+            return Ok(true);
+        }
+        carry = token.len().saturating_sub(1).min(filled);
+        let tail_start = filled - carry;
+        buf.copy_within(tail_start..filled, 0);
     }
 }
 
@@ -1177,6 +1295,9 @@ fn append_capped(dst: &mut String, src: &str, cap: usize) -> bool {
 struct CcReader {
     shared: Arc<CcShared>,
     pending_approvals: PendingApprovals,
+    /// Waiters for correlated outbound control requests; completed in
+    /// `handle_control_response`, keyed by request_id.
+    pending_control_responses: PendingControlResponses,
     /// True when an Intendant MCP endpoint was injected, so a missing or
     /// unhealthy `intendant` entry in the init message warrants a warning.
     expect_intendant_mcp: bool,
@@ -1293,11 +1414,13 @@ impl CcReader {
     fn new(
         shared: Arc<CcShared>,
         pending_approvals: PendingApprovals,
+        pending_control_responses: PendingControlResponses,
         expect_intendant_mcp: bool,
     ) -> Self {
         Self {
             shared,
             pending_approvals,
+            pending_control_responses,
             expect_intendant_mcp,
             approval_counter: 0,
             open_tools: HashMap::new(),
@@ -3283,6 +3406,14 @@ impl CcReader {
             .get("request_id")
             .and_then(|r| r.as_str())
             .unwrap_or("?");
+        // A correlated request's waiter takes the whole response object;
+        // fire-and-forget requests keep the log-only treatment below.
+        if let Some(waiter) =
+            lock_pending_controls(&self.pending_control_responses).remove(request_id)
+        {
+            let _ = waiter.send(response.clone());
+            return;
+        }
         if response.get("subtype").and_then(|s| s.as_str()) == Some("error") {
             let error = response
                 .get("error")
@@ -3584,6 +3715,9 @@ pub struct ClaudeCodeAgent {
     shared: Arc<CcShared>,
     /// Ids for client→CLI control requests (interrupts).
     control_counter: AtomicU64,
+    /// Correlated-response waiters shared with the reader
+    /// (`write_control_request_correlated`).
+    pending_control_responses: PendingControlResponses,
 }
 
 impl ClaudeCodeAgent {
@@ -3618,6 +3752,7 @@ impl ClaudeCodeAgent {
             mcp_session_id: None,
             shared: Arc::new(CcShared::new(None)),
             control_counter: AtomicU64::new(0),
+            pending_control_responses: Arc::new(StdMutex::new(HashMap::new())),
         }
     }
 
@@ -3760,7 +3895,8 @@ impl ClaudeCodeAgent {
     /// Send a live-reconfig control request (verified on CC 2.1.201:
     /// `set_model` and `set_permission_mode` succeed on a running process —
     /// no restart). Fire-and-forget like interrupt: the reader logs the
-    /// CLI's ack or failure when the `control_response` arrives.
+    /// CLI's ack or failure when the `control_response` arrives. Ops that
+    /// need the CLI's answer use `write_control_request_correlated`.
     async fn write_control_request(
         &mut self,
         kind: &str,
@@ -3780,6 +3916,117 @@ impl ClaudeCodeAgent {
         };
         let line = serde_json::to_string(&request)?;
         self.write_line(&line).await
+    }
+
+    /// The correlated twin of `write_control_request`: registers a
+    /// waiter BEFORE the write so the reader cannot race the
+    /// registration, and hands back the receiver the reader completes
+    /// with the envelope's `response` object. The caller owns the
+    /// timeout and MUST call `abandon_control_waiter` on expiry so the
+    /// map never leaks a dead entry.
+    async fn write_control_request_correlated(
+        &mut self,
+        kind: &str,
+        request: serde_json::Value,
+    ) -> Result<(String, oneshot::Receiver<serde_json::Value>), CallerError> {
+        if self.writer.is_none() {
+            return Err(CallerError::ExternalAgent("Not initialized".into()));
+        }
+        let request_id = format!(
+            "intendant-{kind}-{}",
+            self.control_counter.fetch_add(1, Ordering::Relaxed) + 1
+        );
+        let (tx, rx) = oneshot::channel();
+        lock_pending_controls(&self.pending_control_responses).insert(request_id.clone(), tx);
+        let envelope = CcControlRequest {
+            msg_type: "control_request".into(),
+            request_id: request_id.clone(),
+            request,
+        };
+        let line = match serde_json::to_string(&envelope) {
+            Ok(line) => line,
+            Err(err) => {
+                self.abandon_control_waiter(&request_id);
+                return Err(err.into());
+            }
+        };
+        if let Err(err) = self.write_line(&line).await {
+            self.abandon_control_waiter(&request_id);
+            return Err(err);
+        }
+        Ok((request_id, rx))
+    }
+
+    fn abandon_control_waiter(&self, request_id: &str) {
+        lock_pending_controls(&self.pending_control_responses).remove(request_id);
+    }
+
+    /// One `rewind_conversation` control round-trip. Distinguishes the
+    /// wire's three shapes: success-subtype with `rewound: true`,
+    /// success-subtype refusal (`rewound: false` + `error` string — the
+    /// CLI's normal way of saying no), and error-subtype (malformed
+    /// request / unknown subtype on an older CLI). Only transport
+    /// failures are `Err`.
+    async fn rewind_conversation_once(
+        &mut self,
+        target_message_uuid: &str,
+        interrupt_if_running: bool,
+    ) -> Result<ConversationRewindOutcome, CallerError> {
+        let (request_id, rx) = self
+            .write_control_request_correlated(
+                "rewind",
+                serde_json::json!({
+                    "subtype": CLAUDE_REWIND_WIRE_SUBTYPE,
+                    "target_message_uuid": target_message_uuid,
+                    "interrupt_if_running": interrupt_if_running,
+                }),
+            )
+            .await?;
+        let response = match tokio::time::timeout(CC_REWIND_RESPONSE_TIMEOUT, rx).await {
+            Ok(Ok(response)) => response,
+            Ok(Err(_)) => {
+                // Reader dropped the sender (process shutdown mid-wait).
+                self.abandon_control_waiter(&request_id);
+                return Err(CallerError::ExternalAgent(
+                    "claude-code exited before answering the rewind request".into(),
+                ));
+            }
+            Err(_) => {
+                self.abandon_control_waiter(&request_id);
+                // A CLI that never answers (subtype silently ignored) is
+                // a refusal, not a transport failure: the ladder's next
+                // rung serves the edit.
+                return Ok(ConversationRewindOutcome {
+                    rewound: false,
+                    detail: Some(format!(
+                        "no control_response within {}s",
+                        CC_REWIND_RESPONSE_TIMEOUT.as_secs()
+                    )),
+                });
+            }
+        };
+        if response.get("subtype").and_then(|s| s.as_str()) == Some("error") {
+            return Ok(ConversationRewindOutcome {
+                rewound: false,
+                detail: Some(
+                    response
+                        .get("error")
+                        .and_then(|e| e.as_str())
+                        .unwrap_or("control request failed")
+                        .to_string(),
+                ),
+            });
+        }
+        let payload = response.get("response");
+        let rewound = payload
+            .and_then(|p| p.get("rewound"))
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false);
+        let detail = payload
+            .and_then(|p| p.get("error"))
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string);
+        Ok(ConversationRewindOutcome { rewound, detail })
     }
 
     /// Live model switch. Only changes the RUNNING process (and the latch a
@@ -4090,6 +4337,7 @@ impl ExternalAgent for ClaudeCodeAgent {
         let reader_state = CcReader::new(
             Arc::clone(&self.shared),
             Arc::clone(&self.pending_approvals),
+            Arc::clone(&self.pending_control_responses),
             web_port.is_some(),
         )
         .with_task_spawn_resolver(spawn_resolver);
@@ -4284,6 +4532,30 @@ impl ExternalAgent for ClaudeCodeAgent {
         Ok(())
     }
 
+    async fn rewind_conversation_to_message(
+        &mut self,
+        target_message_uuid: &str,
+        interrupt_if_running: bool,
+    ) -> Result<ConversationRewindOutcome, CallerError> {
+        let started = std::time::Instant::now();
+        loop {
+            let outcome = self
+                .rewind_conversation_once(target_message_uuid, interrupt_if_running)
+                .await?;
+            if outcome.rewound {
+                return Ok(outcome);
+            }
+            let busy = outcome.detail.as_deref().is_some_and(|detail| {
+                let detail = detail.to_ascii_lowercase();
+                detail.contains("turn running") || detail.contains("commands queued")
+            });
+            if !busy || started.elapsed() >= CC_REWIND_BUSY_RETRY_BUDGET {
+                return Ok(outcome);
+            }
+            tokio::time::sleep(CC_REWIND_BUSY_RETRY_INTERVAL).await;
+        }
+    }
+
     async fn resolve_approval(
         &mut self,
         request_id: &str,
@@ -4404,6 +4676,7 @@ mod tests {
     fn test_reader() -> CcReader {
         CcReader::new(
             Arc::new(CcShared::new(None)),
+            Arc::new(StdMutex::new(HashMap::new())),
             Arc::new(StdMutex::new(HashMap::new())),
             true,
         )
@@ -6284,6 +6557,7 @@ mod tests {
         let mut reader = CcReader::new(
             Arc::new(CcShared::new(None)),
             Arc::new(StdMutex::new(HashMap::new())),
+            Arc::new(StdMutex::new(HashMap::new())),
             false,
         );
         let out = reader.process_line(
@@ -6337,6 +6611,7 @@ mod tests {
         let reader_shared = Arc::new(CcShared::new(None));
         let mut reader = CcReader::new(
             Arc::clone(&reader_shared),
+            Arc::new(StdMutex::new(HashMap::new())),
             Arc::new(StdMutex::new(HashMap::new())),
             true,
         );
@@ -8299,6 +8574,99 @@ mod tests {
         assert_eq!(json["type"], "control_request");
         assert_eq!(json["request_id"], "intendant-interrupt-1");
         assert_eq!(json["request"]["subtype"], "interrupt");
+    }
+
+    #[test]
+    fn rewind_conversation_control_request_serialization() {
+        let request = CcControlRequest {
+            msg_type: "control_request".into(),
+            request_id: "intendant-rewind-1".into(),
+            request: serde_json::json!({
+                "subtype": CLAUDE_REWIND_WIRE_SUBTYPE,
+                "target_message_uuid": "6a6d0939-0000-4000-8000-000000000000",
+                "interrupt_if_running": true,
+            }),
+        };
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(json["type"], "control_request");
+        assert_eq!(json["request"]["subtype"], "rewind_conversation");
+        assert_eq!(
+            json["request"]["target_message_uuid"],
+            "6a6d0939-0000-4000-8000-000000000000"
+        );
+        assert_eq!(json["request"]["interrupt_if_running"], true);
+    }
+
+    /// The reader must complete a registered correlated waiter with the
+    /// envelope's whole `response` object — and keep the fire-and-forget
+    /// log treatment for unregistered request ids.
+    #[test]
+    fn control_response_completes_pending_rewind_waiter() {
+        let pending_controls: PendingControlResponses = Arc::new(StdMutex::new(HashMap::new()));
+        let mut reader = CcReader::new(
+            Arc::new(CcShared::new(None)),
+            Arc::new(StdMutex::new(HashMap::new())),
+            Arc::clone(&pending_controls),
+            true,
+        );
+        let (tx, mut rx) = oneshot::channel();
+        lock_pending_controls(&pending_controls).insert("intendant-rewind-1".into(), tx);
+
+        let out = reader.process_line(
+            r#"{"type":"control_response","response":{"subtype":"success","request_id":"intendant-rewind-1","response":{"rewound":true,"targetMessageUuid":"6a6d0939","prefillText":"…","precedingAssistantUuid":"704a78c2"}}}"#,
+        );
+        let payload = rx.try_recv().expect("waiter completed");
+        assert_eq!(payload["subtype"], "success");
+        assert_eq!(payload["response"]["rewound"], true);
+        assert!(
+            lock_pending_controls(&pending_controls).is_empty(),
+            "completed waiter must leave the map"
+        );
+        // The correlated path handled it: no ack log line.
+        assert!(!out.events.iter().any(
+            |e| matches!(e, AgentEvent::Log { message, .. } if message.contains("acknowledged"))
+        ));
+
+        // An unregistered id keeps today's log-only treatment.
+        let out = reader.process_line(
+            r#"{"type":"control_response","response":{"subtype":"success","request_id":"intendant-set-model-9"}}"#,
+        );
+        assert!(out.events.iter().any(
+            |e| matches!(e, AgentEvent::Log { message, .. } if message.contains("acknowledged"))
+        ));
+    }
+
+    /// The commission's canary: pins the wire subtype token this build
+    /// speaks and the binary-probe mechanics that gate the ladder's wire
+    /// rung. If Claude Code renames or drops `rewind_conversation`, the
+    /// live probe (tests/skills/session-fork-probes) and the runtime
+    /// capability check fail loud instead of silently forking again —
+    /// and if this constant drifts from the serialized request, this
+    /// test fails at build time.
+    #[test]
+    fn rewind_wire_subtype_canary() {
+        assert_eq!(CLAUDE_REWIND_WIRE_SUBTYPE, "rewind_conversation");
+
+        let dir = tempfile::tempdir().unwrap();
+        // Token straddling a chunk boundary must still be found: build a
+        // synthetic binary bigger than one 8 MiB scan chunk with the
+        // token planted right across the boundary.
+        let chunk = 8 * 1024 * 1024;
+        let token = CLAUDE_REWIND_WIRE_SUBTYPE.as_bytes();
+        let mut straddling = vec![0u8; chunk + 64];
+        let start = chunk - token.len() / 2;
+        straddling[start..start + token.len()].copy_from_slice(token);
+        let with_token = dir.path().join("cc-with-token.bin");
+        std::fs::write(&with_token, &straddling).unwrap();
+        assert!(binary_contains_token(&with_token, token).unwrap());
+
+        let without = dir.path().join("cc-without.bin");
+        std::fs::write(&without, vec![0u8; 1024]).unwrap();
+        assert!(!binary_contains_token(&without, token).unwrap());
+        // A partial token must not match.
+        let partial = dir.path().join("cc-partial.bin");
+        std::fs::write(&partial, b"rewind_conversatio".as_slice()).unwrap();
+        assert!(!binary_contains_token(&partial, token).unwrap());
     }
 
     #[test]

--- a/src/bin/caller/external_agent/mod.rs
+++ b/src/bin/caller/external_agent/mod.rs
@@ -1073,6 +1073,14 @@ impl AgentBackend {
         }
     }
 
+    /// Whether the wrapper's INDEX-ADDRESSED edit protocol serves this
+    /// backend: the edited turn is located by its supervision-run
+    /// `user_turn_index` and rolled back by turn count
+    /// (`rollback_turns`). Claude Code is deliberately NOT here even
+    /// though it rewinds in place since CC ≥2.1.218: its wire rewind is
+    /// transcript-addressed (`rewind_conversation` by message uuid), so
+    /// claude-code edits route through the supervisor's in-place ladder
+    /// (`claude_edit_in_place_ladder`) before this gate is consulted.
     pub fn supports_user_message_rewind(&self) -> bool {
         matches!(self, AgentBackend::Codex | AgentBackend::Kimi)
     }
@@ -1804,6 +1812,16 @@ pub struct AutonomousGoalPauseResult {
     pub paused: bool,
 }
 
+/// Outcome of a message-addressed conversation rewind
+/// (`ExternalAgent::rewind_conversation_to_message`). A wire-level
+/// refusal is a NORMAL outcome (`rewound: false` + the backend's reason
+/// in `detail`), distinct from transport errors.
+#[derive(Debug, Clone)]
+pub struct ConversationRewindOutcome {
+    pub rewound: bool,
+    pub detail: Option<String>,
+}
+
 /// Trait for opaque external agent backends.
 ///
 /// Intendant supervises the agent, bridges approval requests to its
@@ -2075,6 +2093,28 @@ pub trait ExternalAgent: Send + Sync {
 
     fn supports_item_anchor_rewind(&self) -> bool {
         false
+    }
+
+    /// Rewind the backend's ACTIVE conversation to just before the given
+    /// message: the target and everything after leave the model's
+    /// context, and the next user message continues from the preserved
+    /// prefix. Claude Code implements this over its stream-json control
+    /// wire (`rewind_conversation`, CC ≥2.1.218); other backends use the
+    /// default error and callers fall back per their own ladder.
+    ///
+    /// Wire-level REFUSALS (target not found, stale target, first-message
+    /// gate off, still busy after the retry budget) return
+    /// `Ok(outcome)` with `rewound: false` and the reason in `detail` —
+    /// only transport/process failures are `Err`.
+    async fn rewind_conversation_to_message(
+        &mut self,
+        target_message_uuid: &str,
+        interrupt_if_running: bool,
+    ) -> Result<ConversationRewindOutcome, CallerError> {
+        let _ = (target_message_uuid, interrupt_if_running);
+        Err(CallerError::ExternalAgent(
+            "message-addressed conversation rewind not supported by this backend".into(),
+        ))
     }
 
     /// Ask the backend to drop the last `turns_to_drop` conversational
@@ -2836,6 +2876,10 @@ mod tests {
     #[test]
     fn user_message_rewind_capability_is_explicit() {
         assert!(AgentBackend::Codex.supports_user_message_rewind());
+        // ClaudeCode is false HERE because this gate is the
+        // index-addressed protocol only: claude-code edits rewind in
+        // place via the transcript-addressed ladder
+        // (`claude_edit_in_place_ladder`), routed before this gate.
         assert!(!AgentBackend::ClaudeCode.supports_user_message_rewind());
         assert!(AgentBackend::Kimi.supports_user_message_rewind());
         assert!(!AgentBackend::Pi.supports_user_message_rewind());

--- a/src/bin/caller/external_mode.rs
+++ b/src/bin/caller/external_mode.rs
@@ -1806,6 +1806,7 @@ pub(crate) async fn run_external_agent_mode(
         let edit_user_turn_index = followup.edit_user_turn_index;
         let edit_user_turn_revision = followup.edit_user_turn_revision;
         let edit_original_text = followup.edit_original_text;
+        let claude_inplace_rewind_targets = followup.claude_inplace_rewind_targets;
         let unresolved_attachment_ids = followup.unresolved_attachment_ids;
         let target_session_id = followup.target_session_id.clone();
         let managed_context_recovery_kickstart = followup.managed_context_recovery_kickstart;
@@ -2126,6 +2127,9 @@ pub(crate) async fn run_external_agent_mode(
                                 edit_original_text: edit_original_text.clone(),
                                 unresolved_attachment_ids: unresolved_attachment_ids.clone(),
                                 target_session_id: target_session_id.clone(),
+                                // Codex managed-context lane: never a
+                                // claude in-place edit.
+                                claude_inplace_rewind_targets: Vec::new(),
                                 managed_context_recovery_kickstart: false,
                                 managed_context_density_handoff: false,
                                 managed_context_density_handoff_completed: false,
@@ -2202,6 +2206,9 @@ pub(crate) async fn run_external_agent_mode(
                                 edit_original_text: edit_original_text.clone(),
                                 unresolved_attachment_ids: unresolved_attachment_ids.clone(),
                                 target_session_id: target_session_id.clone(),
+                                // Codex managed-context lane: never a
+                                // claude in-place edit.
+                                claude_inplace_rewind_targets: Vec::new(),
                                 managed_context_recovery_kickstart: false,
                                 managed_context_density_handoff: false,
                                 managed_context_density_handoff_completed: false,
@@ -2258,7 +2265,82 @@ pub(crate) async fn run_external_agent_mode(
         }
 
         let mut replacement_for_user_turn_index = None;
-        if let Some(user_turn_index) = edit_user_turn_index {
+        // Claude Code in-place edit: transcript-addressed (the supervisor
+        // resolved the uuid walk-back list), so it never consults the
+        // index-addressed `supports_user_message_rewind` protocol below.
+        // Refusals hand the edit BACK to the supervisor's ladder via the
+        // `rewind-unavailable` status — this arm must never service a
+        // refused edit itself, or two rungs would both run it.
+        let claude_inplace_edit = edit_user_turn_index.is_some()
+            && backend == external_agent::AgentBackend::ClaudeCode
+            && !claude_inplace_rewind_targets.is_empty();
+        if claude_inplace_edit {
+            let user_turn_index = edit_user_turn_index.unwrap_or_default();
+            bus.send(AppEvent::UserMessageEditStatus {
+                session_id: live_session_id.clone(),
+                user_turn_index,
+                status: "running".to_string(),
+                message: "rewinding this session in place — the edited prompt continues here"
+                    .to_string(),
+            });
+            let mut rewind_refusal: Option<String> = None;
+            for target_uuid in &claude_inplace_rewind_targets {
+                match agent
+                    .rewind_conversation_to_message(target_uuid, true)
+                    .await
+                {
+                    Ok(outcome) if outcome.rewound => {}
+                    Ok(outcome) => {
+                        rewind_refusal = Some(outcome.detail.unwrap_or_else(|| {
+                            "the CLI refused the rewind without a reason".to_string()
+                        }));
+                        break;
+                    }
+                    Err(err) => {
+                        rewind_refusal = Some(err.to_string());
+                        break;
+                    }
+                }
+            }
+            if let Some(reason) = rewind_refusal {
+                let message = format!("in-place rewind unavailable: {reason}");
+                slog(&session_log, |l| l.warn(&message));
+                bus.send(AppEvent::UserMessageEditStatus {
+                    session_id: live_session_id.clone(),
+                    user_turn_index,
+                    status: "rewind-unavailable".to_string(),
+                    message,
+                });
+                continue;
+            }
+            let turns_removed = claude_inplace_rewind_targets.len() as u32;
+            // Supervision-run turn bookkeeping is best-effort here: the
+            // transcript is truth after a rewind, and resumes re-seed
+            // from it; an out-of-range index only means this run's
+            // counter drift stays cosmetic.
+            if user_turn_index >= 1 && user_turn_index <= user_turn_revisions.active_count() {
+                user_turn_revisions.rewind_from_turn(user_turn_index);
+                round = user_turn_index.saturating_sub(1) as usize;
+            }
+            replacement_for_user_turn_index = Some(user_turn_index);
+            let message = format!(
+                "Rewound {} conversation turn{} in place; the edited prompt continues in this session",
+                turns_removed,
+                if turns_removed == 1 { "" } else { "s" }
+            );
+            slog(&session_log, |l| l.info(&message));
+            bus.send(AppEvent::UserMessageRewind {
+                session_id: live_session_id.clone(),
+                user_turn_index,
+                turns_removed,
+            });
+            bus.send(AppEvent::UserMessageEditStatus {
+                session_id: live_session_id.clone(),
+                user_turn_index,
+                status: "ok".to_string(),
+                message,
+            });
+        } else if let Some(user_turn_index) = edit_user_turn_index {
             bus.send(AppEvent::UserMessageEditStatus {
                 session_id: live_session_id.clone(),
                 user_turn_index,
@@ -3781,7 +3863,8 @@ pub(crate) async fn run_external_agent_mode(
             DrainOutcome::Terminated { reason, exit_code } => {
                 stats.rounds = round;
                 let user_requested_stop =
-                    matches!(reason.as_str(), "stopped by user" | "restarting session");
+                    matches!(reason.as_str(), "stopped by user" | "restarting session")
+                        || reason == crate::session_supervisor::CLAUDE_EDIT_INPLACE_STOP_REASON;
                 if codex_managed_context_enabled && !user_requested_stop {
                     match refresh_external_context_usage_snapshot(&mut agent, &drain_config).await {
                         Ok(Some(snapshot)) => {

--- a/src/bin/caller/session_fork/claude_inplace.rs
+++ b/src/bin/caller/session_fork/claude_inplace.rs
@@ -1,0 +1,342 @@
+//! Same-id in-place truncation of a Claude Code transcript — the
+//! pencil's surgery rung. Cuts the session's OWN file at the edited
+//! user row (minus its leading queue bookkeeping) so a plain
+//! `--resume <same id>` continues from just before that message with the
+//! edited prompt as the next turn. Unlike the fork rung's chain-slice
+//! copy, the session id and directory survive, so every sid-keyed
+//! sidecar (`subagents/`, todos) stays attached by construction.
+//!
+//! Semantics pinned by the 2026-07-27 in-place-edit probes (CC 2.1.220,
+//! `tests/skills/session-fork-probes/SKILL.md`): resume walks the chain
+//! back from the physical tail, torn tails are skipped, and chain
+//! topology is not strictly enforced on load — physical truncation, not
+//! parentUuid repair, is what guarantees the prune.
+//!
+//! HARD PRECONDITION (caller-enforced): no Claude Code process may be
+//! attached to the session — a live CLI's close-flush appends rows and
+//! would race or undo the cut. The supervisor stops the wrapper and
+//! waits for transcript quiescence before calling; as a backstop the
+//! execute step re-stats the file and aborts if it moved under us.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug)]
+pub(crate) struct ClaudeInplaceOutcome {
+    pub(crate) kept_lines: usize,
+    pub(crate) backup_path: PathBuf,
+}
+
+/// Row types that are queue bookkeeping for the user row that follows
+/// them: a cut at a user row also drops its contiguous run of these.
+fn is_queue_bookkeeping(row_type: Option<&str>) -> bool {
+    matches!(row_type, Some("queue-operation") | Some("queued_command"))
+}
+
+/// Truncate `transcript` in place just before `target_user_uuid` (and
+/// its leading queue-bookkeeping run). One read decides everything;
+/// the kept prefix is the file's own verbatim bytes (no
+/// re-serialization). Atomic: tmp + fsync + rename, with the original
+/// preserved beside the transcript as `.bak-edit-<ms>`.
+///
+/// Refusals (`Err`) leave the transcript untouched:
+/// - target missing, or not a `user` row, or off the active chain;
+/// - a first-message cut (nothing but meta would survive — resume
+///   behavior on a message-less transcript is unproven, and the fork
+///   rung refuses the same case);
+/// - the file changed between read and rename (attached-process race).
+pub(crate) fn truncate_claude_transcript_in_place(
+    transcript: &Path,
+    target_user_uuid: &str,
+) -> Result<ClaudeInplaceOutcome, String> {
+    let stat_before = std::fs::metadata(transcript)
+        .map_err(|err| format!("failed to stat the transcript: {err}"))?;
+    let raw = std::fs::read_to_string(transcript)
+        .map_err(|err| format!("failed to read the transcript: {err}"))?;
+
+    // Line starts by byte offset, so the kept prefix is byte-verbatim.
+    let mut line_starts: Vec<usize> = vec![0];
+    for (index, byte) in raw.bytes().enumerate() {
+        if byte == b'\n' && index + 1 < raw.len() {
+            line_starts.push(index + 1);
+        }
+    }
+    let lines: Vec<&str> = raw.lines().collect();
+    let mut target_line: Option<usize> = None;
+    let mut parsed_types: Vec<Option<String>> = Vec::with_capacity(lines.len());
+    for (index, line) in lines.iter().enumerate() {
+        let value = serde_json::from_str::<serde_json::Value>(line.trim()).ok();
+        let row_type = value
+            .as_ref()
+            .and_then(|v| v.get("type"))
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string);
+        if target_line.is_none()
+            && value
+                .as_ref()
+                .and_then(|v| v.get("uuid"))
+                .and_then(serde_json::Value::as_str)
+                == Some(target_user_uuid)
+        {
+            if row_type.as_deref() != Some("user") {
+                return Err(format!(
+                    "message {target_user_uuid} is not a user row — refusing to cut there"
+                ));
+            }
+            target_line = Some(index);
+        }
+        parsed_types.push(row_type);
+    }
+    let Some(target_line) = target_line else {
+        return Err(format!(
+            "message {target_user_uuid} not found in the transcript \
+             (history may have moved since the edit was resolved)"
+        ));
+    };
+    let tree = super::parse_claude_transcript_tree_from_lines(lines.iter().copied());
+    let Some(leaf) = tree.active_leaf.as_deref() else {
+        return Err("the transcript has no active message chain".to_string());
+    };
+    if !tree
+        .ancestor_chain(leaf)
+        .iter()
+        .any(|node| node.uuid == target_user_uuid)
+    {
+        return Err(format!(
+            "message {target_user_uuid} is not on the session's active chain — \
+             it may sit on an abandoned branch"
+        ));
+    }
+
+    // The cut also drops the target row's leading queue bookkeeping.
+    let mut cut_line = target_line;
+    while cut_line > 0 && is_queue_bookkeeping(parsed_types[cut_line - 1].as_deref()) {
+        cut_line -= 1;
+    }
+    // At least one real message row must survive the cut: a meta-only
+    // transcript's resume behavior is unproven, and losing the whole
+    // conversation is never what a pencil edit means.
+    let keeps_a_message_row = (0..cut_line).any(|index| {
+        matches!(
+            parsed_types[index].as_deref(),
+            Some("user") | Some("assistant")
+        )
+    });
+    if !keeps_a_message_row {
+        return Err("cannot rewind in place before the session's first message".to_string());
+    }
+
+    let cut_offset = line_starts
+        .get(cut_line)
+        .copied()
+        .ok_or_else(|| "cut line has no byte offset".to_string())?;
+    let kept = &raw.as_bytes()[..cut_offset];
+
+    let parent_dir = transcript
+        .parent()
+        .ok_or_else(|| "transcript has no parent directory".to_string())?;
+    let file_name = transcript
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| "transcript has no file name".to_string())?;
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or(0);
+    let backup_path = parent_dir.join(format!("{file_name}.bak-edit-{now_ms}"));
+    let tmp_path = parent_dir.join(format!(".{file_name}.tmp-edit-{now_ms}"));
+
+    let cleanup = |paths: &[&Path]| {
+        for path in paths {
+            let _ = std::fs::remove_file(path);
+        }
+    };
+
+    // Backup first (the bytes we read, not a racy re-read), then the
+    // kept prefix through tmp + fsync + atomic rename.
+    std::fs::write(&backup_path, raw.as_bytes())
+        .map_err(|err| format!("failed to write the pre-edit backup: {err}"))?;
+    let write_tmp = || -> std::io::Result<()> {
+        let mut tmp = std::fs::File::create(&tmp_path)?;
+        tmp.write_all(kept)?;
+        tmp.sync_all()
+    };
+    if let Err(err) = write_tmp() {
+        cleanup(&[&backup_path, &tmp_path]);
+        return Err(format!("failed to stage the truncated transcript: {err}"));
+    }
+
+    // Attached-process backstop: if the file moved since our read, the
+    // rename would clobber rows we never saw. Abort instead.
+    match std::fs::metadata(transcript) {
+        Ok(stat_now)
+            if stat_now.len() == stat_before.len()
+                && stat_now.modified().ok() == stat_before.modified().ok() => {}
+        Ok(_) => {
+            cleanup(&[&backup_path, &tmp_path]);
+            return Err(
+                "the transcript changed during surgery (a process is writing it) — aborted"
+                    .to_string(),
+            );
+        }
+        Err(err) => {
+            cleanup(&[&backup_path, &tmp_path]);
+            return Err(format!("failed to re-stat the transcript: {err}"));
+        }
+    }
+    if let Err(err) = std::fs::rename(&tmp_path, transcript) {
+        cleanup(&[&backup_path, &tmp_path]);
+        return Err(format!("failed to swap in the truncated transcript: {err}"));
+    }
+    // Durability of the rename itself, where the platform allows a
+    // directory handle sync (no-op elsewhere).
+    #[cfg(unix)]
+    {
+        let _ = std::fs::File::open(parent_dir).and_then(|dir| dir.sync_all());
+    }
+
+    Ok(ClaudeInplaceOutcome {
+        kept_lines: cut_line,
+        backup_path,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_fixtures::message_line;
+    use super::*;
+    use sha2::Digest;
+
+    fn queue_row(operation: &str) -> String {
+        serde_json::json!({
+            "type": "queue-operation",
+            "operation": operation,
+            "timestamp": "2026-07-27T00:00:00.000Z",
+            "sessionId": "aaaaaaaa-0000-0000-0000-000000000000",
+        })
+        .to_string()
+    }
+
+    fn write_transcript(dir: &Path, lines: &[String]) -> PathBuf {
+        let path = dir.join("aaaaaaaa-0000-0000-0000-000000000000.jsonl");
+        std::fs::write(&path, lines.join("\n") + "\n").expect("write transcript");
+        path
+    }
+
+    fn sha256(path: &Path) -> String {
+        format!(
+            "{:x}",
+            sha2::Sha256::digest(std::fs::read(path).expect("read"))
+        )
+    }
+
+    #[test]
+    fn inplace_truncation_cuts_queue_operation_prefix_and_is_atomic() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let lines = [
+            message_line("u1", None, "user", "first prompt", false),
+            message_line("a1", Some("u1"), "assistant", "reply one", false),
+            queue_row("enqueue"),
+            queue_row("dequeue"),
+            message_line("u2", Some("a1"), "user", "edit me", false),
+            message_line("a2", Some("u2"), "assistant", "stale answer", false),
+        ];
+        let path = write_transcript(dir.path(), &lines);
+        let original = std::fs::read_to_string(&path).expect("original");
+
+        let outcome = truncate_claude_transcript_in_place(&path, "u2").expect("truncate");
+        assert_eq!(outcome.kept_lines, 2, "queue rows must fall with the cut");
+
+        let truncated = std::fs::read_to_string(&path).expect("truncated");
+        assert!(truncated.contains("reply one"));
+        assert!(!truncated.contains("edit me"));
+        assert!(!truncated.contains("queue-operation"));
+        assert!(!truncated.contains("stale answer"));
+        // Byte-verbatim prefix of the original — no re-serialization.
+        assert!(original.starts_with(&truncated));
+
+        // The backup carries the FULL original; no tmp strays remain.
+        assert_eq!(
+            std::fs::read_to_string(&outcome.backup_path).expect("backup"),
+            original
+        );
+        let strays: Vec<_> = std::fs::read_dir(dir.path())
+            .expect("read dir")
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .filter(|name| name.contains(".tmp-edit-"))
+            .collect();
+        assert!(strays.is_empty(), "tmp strays: {strays:?}");
+    }
+
+    /// The commission's pin: sid-keyed sidecars (the fork lane's known
+    /// blindspot) survive the surgery byte-identical, because the id and
+    /// directory are never touched.
+    #[test]
+    fn surgery_preserves_subagent_sidecars_byte_identical() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let lines = [
+            message_line("u1", None, "user", "spawn the task", false),
+            message_line("a1", Some("u1"), "assistant", "spawned", false),
+            message_line("u2", Some("a1"), "user", "edit me", false),
+            message_line("a2", Some("u2"), "assistant", "stale", false),
+        ];
+        let path = write_transcript(dir.path(), &lines);
+
+        let subagents = dir
+            .path()
+            .join("aaaaaaaa-0000-0000-0000-000000000000")
+            .join("subagents");
+        std::fs::create_dir_all(&subagents).expect("subagents dir");
+        let sidecar = subagents.join("agent-42cafe.jsonl");
+        let sidecar_meta = subagents.join("agent-42cafe.meta.json");
+        std::fs::write(&sidecar, "{\"type\":\"user\",\"uuid\":\"s1\"}\n").expect("sidecar");
+        std::fs::write(&sidecar_meta, "{\"agentId\":\"42cafe\"}\n").expect("sidecar meta");
+        let sidecar_hash = sha256(&sidecar);
+        let meta_hash = sha256(&sidecar_meta);
+
+        truncate_claude_transcript_in_place(&path, "u2").expect("truncate");
+
+        assert_eq!(sha256(&sidecar), sidecar_hash);
+        assert_eq!(sha256(&sidecar_meta), meta_hash);
+    }
+
+    #[test]
+    fn inplace_truncation_refuses_first_message_off_chain_and_non_user_rows() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let lines = [
+            message_line("u1", None, "user", "first prompt", false),
+            message_line("a1", Some("u1"), "assistant", "reply", false),
+            message_line("u2a", Some("a1"), "user", "abandoned", false),
+            message_line("u2b", Some("a1"), "user", "active", false),
+            message_line("a2", Some("u2b"), "assistant", "done", false),
+        ];
+        let path = write_transcript(dir.path(), &lines);
+        let before = sha256(&path);
+
+        let first = truncate_claude_transcript_in_place(&path, "u1").expect_err("first message");
+        assert!(first.contains("first message"), "{first}");
+        let off_chain = truncate_claude_transcript_in_place(&path, "u2a").expect_err("off chain");
+        assert!(off_chain.contains("active chain"), "{off_chain}");
+        let non_user = truncate_claude_transcript_in_place(&path, "a1").expect_err("non-user");
+        assert!(non_user.contains("not a user row"), "{non_user}");
+        let missing = truncate_claude_transcript_in_place(&path, "zz").expect_err("missing");
+        assert!(missing.contains("not found"), "{missing}");
+
+        assert_eq!(
+            sha256(&path),
+            before,
+            "refusals must leave the file untouched"
+        );
+        let strays: Vec<_> = std::fs::read_dir(dir.path())
+            .expect("read dir")
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .filter(|name| name.contains(".bak-edit-") || name.contains(".tmp-edit-"))
+            .collect();
+        assert!(
+            strays.is_empty(),
+            "refusals must leave no strays: {strays:?}"
+        );
+    }
+}

--- a/src/bin/caller/session_fork/fork_points.rs
+++ b/src/bin/caller/session_fork/fork_points.rs
@@ -413,23 +413,60 @@ pub(crate) fn native_fork_points(
     Ok(catalog)
 }
 
-/// Resolve the fork anchor for an edited Claude Code user message by its
-/// exact prose. Claude Code has no in-place rewind on the supervision
-/// wire, so an edit is serviced as an anchor-fork branch — and the
-/// edited row's original text is the address: match it against the
-/// active chain's user turns and anchor at the unique match's parent.
-/// Text stays the anchor key even though resumes now seed the live
-/// lane's `user_turn_index` from the transcript
+/// A resolved Claude Code edit target: everything each rung of the
+/// pencil's in-place ladder needs (`session_supervisor/claude_edit.rs`).
+/// `fork_anchor` cuts at the edited row's PARENT — the fork rung's
+/// chain-slice anchor and the surgery rung's kept tail. `None` means the
+/// edited row is the session's first message: the wire rung may still
+/// serve it (CC's own first-message rewind, feature-gated), the
+/// truncation and fork rungs refuse it.
+#[derive(Debug, Clone)]
+pub(crate) struct ClaudeEditAnchor {
+    /// The edited user row itself — the wire rewind's `target_message_uuid`
+    /// and the surgery rung's cut row.
+    pub(crate) target_user_uuid: String,
+    /// Chain-slice anchor at the edited row's parent, for the fork rung.
+    /// `None` for a first-message edit.
+    pub(crate) fork_anchor: Option<ForkAnchorSpec>,
+    /// Real human user rows AFTER the target on the active chain,
+    /// newest first. CC's wire rewind only accepts the CURRENT last
+    /// human turn per call, so an earlier edit rewinds these first, in
+    /// this order, then the target itself.
+    pub(crate) later_human_rows: Vec<String>,
+}
+
+impl ClaudeEditAnchor {
+    /// The wire rung's call order: every later human row newest-first,
+    /// then the edited row itself.
+    pub(crate) fn rewind_targets_newest_first(&self) -> Vec<String> {
+        let mut targets = self.later_human_rows.clone();
+        targets.push(self.target_user_uuid.clone());
+        targets
+    }
+}
+
+/// Resolve an edited Claude Code user message to its transcript address
+/// by its exact prose: match it against the active chain's user turns,
+/// refusing ambiguity or absence rather than guessing (the transcript's
+/// inline fork affordance covers those cases exactly). Text stays the
+/// address even though resumes now seed the live lane's
+/// `user_turn_index` from the transcript
 /// (`claude_user_turn_state_from_history`; `--fork-session` resumes
 /// seed from the fork source via
 /// `claude_user_turn_state_from_fork_source`): the seed is best-effort,
-/// while prose matching addresses the chain regardless. Ambiguity or
-/// absence is a refusal, never a guess — the transcript's inline fork
-/// affordance covers those cases exactly.
+/// while prose matching addresses the chain regardless.
+///
+/// Only REAL human prompt rows are candidates (no meta, compact-summary,
+/// sidechain, tool_result-only, or harness-injected rows): CC's own wire
+/// rewind accepts ANY `type:"user"` row as a target — including
+/// tool_result rows, observed live splicing mid-turn — so the daemon
+/// must never offer those. `later_human_rows` mirrors CC's own
+/// walk-back predicate instead (harness-injected prompts ARE real human
+/// turns to CC and must be counted), minus the prose filter.
 pub(crate) fn claude_edit_branch_anchor(
     transcript_path: &Path,
     original_text: &str,
-) -> Result<ForkAnchorSpec, String> {
+) -> Result<ClaudeEditAnchor, String> {
     let wanted = original_text.trim();
     if wanted.is_empty() {
         return Err("the edited row carried no original text to locate".to_string());
@@ -448,6 +485,9 @@ pub(crate) fn claude_edit_branch_anchor(
     let file = std::fs::File::open(transcript_path)
         .map_err(|err| format!("transcript open failed: {err}"))?;
     let mut matches: Vec<(String, Option<String>)> = Vec::new();
+    // Every on-chain human user row in file order, prose-matching or not
+    // — the walk-back universe the wire rung counts positions in.
+    let mut human_rows: Vec<String> = Vec::new();
     for line in std::io::BufRead::lines(std::io::BufReader::new(file)) {
         let Ok(line) = line else { continue };
         let trimmed = line.trim();
@@ -499,9 +539,14 @@ pub(crate) fn claude_edit_branch_anchor(
             .next()
             .unwrap_or("")
             .trim();
-        if prose.is_empty()
-            || crate::external_agent::transcript_text::is_injected_external_user_text(prose)
-        {
+        if prose.is_empty() {
+            // tool_result-only content yields no prose: not a human turn.
+            continue;
+        }
+        human_rows.push(uuid.to_string());
+        if crate::external_agent::transcript_text::is_injected_external_user_text(prose) {
+            // Harness rows count for the walk-back but are never the
+            // edited row itself.
             continue;
         }
         if prose == wanted {
@@ -520,17 +565,29 @@ pub(crate) fn claude_edit_branch_anchor(
              abandoned branch or behind a compaction) — use the transcript row's fork button"
                 .to_string(),
         ),
-        [(_, parent)] => match parent {
-            Some(parent) => Ok(ForkAnchorSpec {
-                kind: "message".to_string(),
-                turn: None,
-                item_id: None,
-                position: None,
-                seq: None,
-                message_uuid: Some(parent.clone()),
-            }),
-            None => Err("cannot branch from before the session's first message".to_string()),
-        },
+        [(uuid, parent)] => {
+            let later_human_rows: Vec<String> = match human_rows.iter().position(|row| row == uuid)
+            {
+                Some(target_position) => human_rows[target_position + 1..]
+                    .iter()
+                    .rev()
+                    .cloned()
+                    .collect(),
+                None => Vec::new(),
+            };
+            Ok(ClaudeEditAnchor {
+                target_user_uuid: uuid.clone(),
+                fork_anchor: parent.as_ref().map(|parent| ForkAnchorSpec {
+                    kind: "message".to_string(),
+                    turn: None,
+                    item_id: None,
+                    position: None,
+                    seq: None,
+                    message_uuid: Some(parent.clone()),
+                }),
+                later_human_rows,
+            })
+        }
         many => Err(format!(
             "this prompt appears {} times in the session — use the transcript row's fork \
              button to pick the exact occurrence",
@@ -1131,8 +1188,57 @@ mod tests {
         // The abandoned duplicate is off-chain and must not create
         // ambiguity: the unique on-chain match anchors at its parent.
         let anchor = claude_edit_branch_anchor(&path, "do the thing").expect("anchor");
-        assert_eq!(anchor.kind, "message");
-        assert_eq!(anchor.message_uuid.as_deref(), Some("a1"));
+        let fork_anchor = anchor.fork_anchor.as_ref().expect("fork anchor");
+        assert_eq!(fork_anchor.kind, "message");
+        assert_eq!(fork_anchor.message_uuid.as_deref(), Some("a1"));
+        assert_eq!(anchor.target_user_uuid, "u2b");
+        assert!(anchor.later_human_rows.is_empty());
+        assert_eq!(
+            anchor.rewind_targets_newest_first(),
+            vec!["u2b".to_string()]
+        );
+    }
+
+    /// The wire rung rewinds every later human turn newest-first, then
+    /// the target; tool_result user rows are NOT human turns and never
+    /// appear — CC's own handler happily splices at them (observed
+    /// live), so the daemon must never offer them.
+    #[test]
+    fn claude_edit_anchor_returns_target_user_uuid_and_walk_back() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("edit.jsonl");
+        let tool_result_row = serde_json::json!({
+            "uuid": "tr1",
+            "parentUuid": "u2",
+            "type": "user",
+            "timestamp": "2026-07-19T00:00:00.000Z",
+            "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "ran"}]},
+        })
+        .to_string();
+        let lines = [
+            edit_fixture_line("u1", None, "user", "first prompt"),
+            edit_fixture_line("a1", Some("u1"), "assistant", "ok"),
+            edit_fixture_line("u2", Some("a1"), "user", "edit me"),
+            tool_result_row,
+            edit_fixture_line("a2", Some("tr1"), "assistant", "done"),
+            edit_fixture_line("u3", Some("a2"), "user", "later one"),
+            edit_fixture_line("a3", Some("u3"), "assistant", "more"),
+            edit_fixture_line("u4", Some("a3"), "user", "later two"),
+            edit_fixture_line("a4", Some("u4"), "assistant", "end"),
+        ];
+        std::fs::write(&path, lines.join("\n")).unwrap();
+
+        let anchor = claude_edit_branch_anchor(&path, "edit me").expect("anchor");
+        assert_eq!(anchor.target_user_uuid, "u2");
+        assert_eq!(
+            anchor.later_human_rows,
+            vec!["u4".to_string(), "u3".to_string()],
+            "later human rows must come newest-first and exclude tool_result rows"
+        );
+        assert_eq!(
+            anchor.rewind_targets_newest_first(),
+            vec!["u4".to_string(), "u3".to_string(), "u2".to_string()]
+        );
     }
 
     #[test]
@@ -1152,7 +1258,14 @@ mod tests {
         std::fs::write(&path, lines.join("\n")).unwrap();
 
         let anchor = claude_edit_branch_anchor(&path, "run the tests").expect("anchor");
-        assert_eq!(anchor.message_uuid.as_deref(), Some("a1"));
+        assert_eq!(
+            anchor
+                .fork_anchor
+                .as_ref()
+                .and_then(|a| a.message_uuid.as_deref()),
+            Some("a1")
+        );
+        assert_eq!(anchor.target_user_uuid, "u2");
     }
 
     #[test]
@@ -1173,7 +1286,14 @@ mod tests {
         assert!(ambiguous.contains("2 times"), "{ambiguous}");
         let missing = claude_edit_branch_anchor(&path, "never said this").expect_err("missing");
         assert!(missing.contains("not found"), "{missing}");
-        let first = claude_edit_branch_anchor(&path, "first prompt").expect_err("first turn");
-        assert!(first.contains("first message"), "{first}");
+        // A first-message edit resolves (the wire rung may serve it) but
+        // carries no fork anchor: the truncation and fork rungs refuse.
+        let first = claude_edit_branch_anchor(&path, "first prompt").expect("first turn");
+        assert_eq!(first.target_user_uuid, "u1");
+        assert!(first.fork_anchor.is_none());
+        assert_eq!(
+            first.later_human_rows,
+            vec!["u3".to_string(), "u2".to_string()]
+        );
     }
 }

--- a/src/bin/caller/session_fork/mod.rs
+++ b/src/bin/caller/session_fork/mod.rs
@@ -25,11 +25,13 @@
 //!   undo on the idle child before subscription or its first prompt. Item,
 //!   message, and independently addressed child-agent anchors stay unsupported.
 
+mod claude_inplace;
 mod claude_surgery;
 mod claude_tree;
 mod codex_stage;
 mod fork_points;
 mod native;
+pub(crate) use claude_inplace::*;
 pub(crate) use claude_surgery::*;
 pub(crate) use claude_tree::*;
 pub(crate) use codex_stage::*;

--- a/src/bin/caller/session_supervisor/claude_edit.rs
+++ b/src/bin/caller/session_supervisor/claude_edit.rs
@@ -1,0 +1,855 @@
+//! The pencil's in-place edit ladder for Claude Code sessions.
+//!
+//! Since CC ≥2.1.218 the supervision wire exposes `rewind_conversation`,
+//! so a pencil edit rewinds the SAME backend session id instead of
+//! forking a new one. Three rungs, tried in order, each refusal mapping
+//! honestly to the next:
+//!
+//! 1. **Wire rewind** (live wrapper, capability-probed CLI): the
+//!    supervisor resolves the edited row and its walk-back list from
+//!    the transcript, and the wrapper drives CC's native
+//!    `rewind_conversation` control requests, then sends the edited
+//!    prompt as the next turn. Same id, same wrapper, sidecars and
+//!    config untouched.
+//! 2. **Transcript surgery** (no live process): stop the wrapper if one
+//!    is alive, wait for the file to quiesce, truncate the session's
+//!    own transcript at the edited row (`claude_inplace.rs`), and
+//!    resume the same id with the edited prompt as the first task.
+//! 3. **Anchor fork** (`fork_claude_edit_branch_from_anchor`) — the
+//!    pre-ladder behavior, kept only for the cases neither in-place
+//!    rung can serve (off-active-chain target, first-message edit) and
+//!    labeled honestly when it runs.
+//!
+//! Single-ownership rule: once the wire rung's message is queued on a
+//! wrapper, the ladder NEVER races a second rung against it on a
+//! timeout — only the wrapper's own `rewind-unavailable` refusal hands
+//! the edit to the surgery rung. A parked (rate-limited) wrapper
+//! services the queued edit when it wakes; that is one lineage doing
+//! the work once, which is the whole point.
+
+use super::*;
+
+/// Stop reason the surgery rung uses; the wrapper's terminal-outcome
+/// handling treats it as a user-requested stop (`external_mode.rs`).
+pub(crate) const CLAUDE_EDIT_INPLACE_STOP_REASON: &str = "rewinding in place for an edited message";
+
+/// How long the ladder listens for the wire rung's outcome before
+/// reaping the listener task. NOT a fallback trigger: a queued edit on
+/// a parked wrapper may legitimately take hours, and racing surgery
+/// against a still-queued wire edit would run the edit twice.
+const CLAUDE_EDIT_WAITER_CAP: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+
+/// Transcript-quiescence probe before surgery: the file must hold still
+/// this long (two identical stats) within the budget, or surgery is
+/// refused — something is still writing it.
+const CLAUDE_EDIT_QUIESCENCE_SAMPLE_GAP: std::time::Duration =
+    std::time::Duration::from_millis(300);
+const CLAUDE_EDIT_QUIESCENCE_BUDGET: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Backend ids with an edit ladder currently in flight. A second pencil
+/// on the same session while one is unresolved refuses honestly instead
+/// of racing two rungs — the 2026-07-27 incident's lesson is precisely
+/// that concurrent revival lanes for one logical session must not exist.
+static ACTIVE_CLAUDE_EDITS: std::sync::OnceLock<
+    std::sync::Mutex<std::collections::HashSet<String>>,
+> = std::sync::OnceLock::new();
+
+fn active_claude_edits() -> &'static std::sync::Mutex<std::collections::HashSet<String>> {
+    ACTIVE_CLAUDE_EDITS.get_or_init(|| std::sync::Mutex::new(std::collections::HashSet::new()))
+}
+
+/// RAII claim on a backend id in [`ACTIVE_CLAUDE_EDITS`].
+struct ClaudeEditClaim {
+    backend_id: String,
+}
+
+impl ClaudeEditClaim {
+    fn take(backend_id: &str) -> Option<Self> {
+        let mut active = match active_claude_edits().lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if !active.insert(backend_id.to_string()) {
+            return None;
+        }
+        Some(Self {
+            backend_id: backend_id.to_string(),
+        })
+    }
+}
+
+impl Drop for ClaudeEditClaim {
+    fn drop(&mut self) {
+        let mut active = match active_claude_edits().lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        active.remove(&self.backend_id);
+    }
+}
+
+impl SessionSupervisor {
+    /// Entry point for every claude-code pencil edit (routed from
+    /// `deliver_edit_user_message` when a live wrapper exists, and from
+    /// `route_edit_user_message` for detached sessions).
+    pub(crate) async fn claude_edit_in_place_ladder(
+        &self,
+        request: EditUserMessageRequest,
+        target: Option<EditRouteTarget>,
+    ) {
+        let status_sid = target
+            .as_ref()
+            .map(|t| t.managed_id.clone())
+            .unwrap_or_else(|| request.requested_id.clone());
+        let turn = request.user_turn_index;
+        let Some(original_text) = request
+            .original_text
+            .as_deref()
+            .map(str::trim)
+            .filter(|text| !text.is_empty())
+            .map(str::to_string)
+        else {
+            self.emit_edit_user_message_status(
+                Some(status_sid),
+                turn,
+                "failed",
+                "the edited row carried no original text to locate in the transcript",
+            );
+            return;
+        };
+
+        // Resolve the backend identity and transcript exactly as the
+        // fork lane always has.
+        let token = status_sid.clone();
+        let home = self.logs_home();
+        let backend_id = match persisted_external_identity_for_session_in_home(&home, &token) {
+            Some((source, id)) if source == "claude-code" => id,
+            Some((source, _)) => {
+                self.emit_edit_user_message_status(
+                    Some(status_sid),
+                    turn,
+                    "failed",
+                    format!("session is a {source} session, not claude-code"),
+                );
+                return;
+            }
+            None => token.clone(),
+        };
+        let Some(transcript) = crate::web_gateway::find_claude_session_file(&home, &backend_id)
+        else {
+            self.emit_edit_user_message_status(
+                Some(status_sid),
+                turn,
+                "failed",
+                format!("transcript for claude-code session {backend_id} not found"),
+            );
+            return;
+        };
+
+        let Some(claim) = ClaudeEditClaim::take(&backend_id) else {
+            self.emit_edit_user_message_status(
+                Some(status_sid),
+                turn,
+                "failed",
+                "another edit of this session is still being applied — wait for it to finish",
+            );
+            return;
+        };
+
+        let anchor_transcript = transcript.clone();
+        let anchor = match tokio::task::spawn_blocking(move || {
+            crate::session_fork::claude_edit_branch_anchor(&anchor_transcript, &original_text)
+        })
+        .await
+        .unwrap_or_else(|err| Err(format!("anchor resolution task failed: {err}")))
+        {
+            Ok(anchor) => anchor,
+            Err(reason) => {
+                self.emit_edit_user_message_status(Some(status_sid), turn, "failed", reason);
+                return;
+            }
+        };
+
+        // Rung 1: wire rewind, when a live wrapper can carry it and the
+        // installed CLI speaks the subtype.
+        if let Some(target) = target {
+            let capability = match self.config.claude_rewind_capability_for_tests {
+                Some(capability) => capability,
+                None => {
+                    self.claude_rewind_wire_capability_for(&target.project_root)
+                        .await
+                }
+            };
+            match capability {
+                external_agent::claude_code::ClaudeRewindWireCapability::Unsupported => {
+                    // The canary firing live: the configured CLI does not
+                    // expose the rewind subtype this build was probed
+                    // against. Loud, then fall through to surgery.
+                    self.warn(&format!(
+                        "installed claude does not expose the `{}` control subtype (CC wire drift, or a pre-2.1.218 CLI) — pencil edits fall back to transcript surgery",
+                        external_agent::claude_code::CLAUDE_REWIND_WIRE_SUBTYPE
+                    ));
+                }
+                _ => {
+                    let resolved_attachments = self
+                        .resolve_session_attachments(
+                            &request.attachments,
+                            &target.session_dir,
+                            &target.project_root,
+                        )
+                        .await;
+                    let msg = FollowUpMessage::edit_user_message(
+                        request.text.clone(),
+                        resolved_attachments,
+                        request.user_turn_index,
+                        request.user_turn_revision.unwrap_or(1),
+                        request.original_text.clone(),
+                        request.attachments.clone(),
+                    )
+                    .with_claude_inplace_rewind_targets(anchor.rewind_targets_newest_first());
+                    // Subscribe BEFORE queueing so a fast wrapper outcome
+                    // cannot slip past the waiter.
+                    let outcome_rx = self.config.bus.subscribe();
+                    match target.follow_up_tx.try_send(msg) {
+                        Ok(()) => {
+                            self.emit_edit_user_message_status(
+                                Some(target.managed_id.clone()),
+                                turn,
+                                "queued",
+                                format!(
+                                    "in-place edit queued for claude-code session {}",
+                                    short_session(&target.managed_id)
+                                ),
+                            );
+                            self.spawn_claude_edit_outcome_waiter(
+                                request,
+                                anchor,
+                                backend_id,
+                                transcript,
+                                target.managed_id,
+                                claim,
+                                outcome_rx,
+                            );
+                            return;
+                        }
+                        Err(mpsc::error::TrySendError::Full(_)) => {
+                            self.emit_edit_user_message_status(
+                                Some(target.managed_id.clone()),
+                                turn,
+                                "failed",
+                                "claude-code session input queue is full",
+                            );
+                            return;
+                        }
+                        Err(mpsc::error::TrySendError::Closed(_)) => {
+                            // The wrapper died under us: the process is
+                            // gone, which is exactly the surgery rung's
+                            // precondition.
+                        }
+                    }
+                }
+            }
+            self.claude_edit_surgery_rung(request, anchor, backend_id, transcript, claim)
+                .await;
+            return;
+        }
+
+        // No live wrapper: surgery directly (no process to stop).
+        self.claude_edit_surgery_rung(request, anchor, backend_id, transcript, claim)
+            .await;
+    }
+
+    /// Wire-rung outcome listener. Terminal `ok`/`failed` end the
+    /// ladder; the wrapper's `rewind-unavailable` refusal hands the edit
+    /// to the surgery rung. Deliberately NO timeout-to-fallback: the
+    /// queued message stays the single owner of the edit until the
+    /// wrapper reports (see the module doc).
+    #[allow(clippy::too_many_arguments)] // internal plumbing: each param is a distinct dependency of the waiter
+    fn spawn_claude_edit_outcome_waiter(
+        &self,
+        request: EditUserMessageRequest,
+        anchor: crate::session_fork::ClaudeEditAnchor,
+        backend_id: String,
+        transcript: PathBuf,
+        managed_id: String,
+        claim: ClaudeEditClaim,
+        mut outcome_rx: tokio::sync::broadcast::Receiver<AppEvent>,
+    ) {
+        let supervisor = self.clone();
+        tokio::spawn(async move {
+            let claim = claim;
+            let turn = request.user_turn_index;
+            let matches_session = |sid: &Option<String>| {
+                sid.as_deref().is_some_and(|sid| {
+                    sid == request.requested_id || sid == managed_id || sid == backend_id
+                })
+            };
+            let deadline = tokio::time::Instant::now() + CLAUDE_EDIT_WAITER_CAP;
+            loop {
+                let event = tokio::select! {
+                    event = outcome_rx.recv() => event,
+                    _ = tokio::time::sleep_until(deadline) => {
+                        supervisor.warn(&format!(
+                            "edit of claude-code session {} is still queued after {} minutes — it will apply when the session next drains its queue",
+                            short_session(&backend_id),
+                            CLAUDE_EDIT_WAITER_CAP.as_secs() / 60
+                        ));
+                        return;
+                    }
+                };
+                match event {
+                    Ok(AppEvent::UserMessageEditStatus {
+                        session_id,
+                        user_turn_index,
+                        status,
+                        ..
+                    }) if user_turn_index == turn && matches_session(&session_id) => {
+                        match status.as_str() {
+                            "ok" | "failed" => return,
+                            "rewind-unavailable" => {
+                                supervisor
+                                    .claude_edit_surgery_rung(
+                                        request, anchor, backend_id, transcript, claim,
+                                    )
+                                    .await;
+                                return;
+                            }
+                            _ => {}
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
+                }
+            }
+        });
+    }
+
+    /// Rung 2: stop the wrapper if one is still alive, wait for the
+    /// transcript to quiesce, truncate it at the edited row, and resume
+    /// the SAME session id with the edited prompt. Refusals fall to the
+    /// fork rung with the reason in the status.
+    async fn claude_edit_surgery_rung(
+        &self,
+        request: EditUserMessageRequest,
+        anchor: crate::session_fork::ClaudeEditAnchor,
+        backend_id: String,
+        transcript: PathBuf,
+        claim: ClaudeEditClaim,
+    ) {
+        let _claim = claim;
+        let turn = request.user_turn_index;
+        let status_sid = request.requested_id.clone();
+        self.emit_edit_user_message_status(
+            Some(status_sid.clone()),
+            turn,
+            "running",
+            "rewinding this session in place — truncating the transcript at the edited message",
+        );
+
+        // A wrapper may still hold the session (wire refusal path, or a
+        // lookup race): stop it and wait for the backend process to go.
+        let (_, live_target, _) = self.lookup_edit_route_target(&backend_id).await;
+        if let Some(live) = live_target {
+            if let Some(stopped) = self
+                .stop_managed_session(Some(live.managed_id), CLAUDE_EDIT_INPLACE_STOP_REASON)
+                .await
+            {
+                self.wait_for_stopped_session(stopped).await;
+            }
+        }
+        if let Err(reason) = wait_for_transcript_quiescence(&transcript).await {
+            self.claude_edit_fork_rung(request, anchor, reason).await;
+            return;
+        }
+
+        let surgery_transcript = transcript.clone();
+        let target_uuid = anchor.target_user_uuid.clone();
+        let outcome = tokio::task::spawn_blocking(move || {
+            crate::session_fork::truncate_claude_transcript_in_place(
+                &surgery_transcript,
+                &target_uuid,
+            )
+        })
+        .await
+        .unwrap_or_else(|err| Err(format!("surgery task failed: {err}")));
+        let outcome = match outcome {
+            Ok(outcome) => outcome,
+            Err(reason) => {
+                self.claude_edit_fork_rung(request, anchor, reason).await;
+                return;
+            }
+        };
+
+        // Same-id resume with the edited prompt as the first task; the
+        // parent's project root keeps the resume in the right project
+        // dir, exactly like the fork lane.
+        let home = self.logs_home();
+        let project_root = crate::session_config::load_for_resume(
+            &home,
+            "claude-code",
+            &backend_id,
+            Some(&backend_id),
+        )
+        .and_then(|cfg| cfg.project_root);
+        self.resume_session(
+            "claude-code".to_string(),
+            backend_id.clone(),
+            Some(backend_id.clone()),
+            project_root,
+            Some(request.text.clone()),
+            Some(true),
+            request.attachments.clone(),
+            false,
+            None,
+            LaunchOverrides::default(),
+            false,
+            false,
+        )
+        .await;
+        self.emit_edit_user_message_status(
+            Some(status_sid),
+            turn,
+            "ok",
+            format!(
+                "rewound in place — the edited prompt continues in this session ({} lines kept; the pre-edit transcript is retained as {})",
+                outcome.kept_lines,
+                outcome
+                    .backup_path
+                    .file_name()
+                    .map(|name| name.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| "a .bak-edit backup".to_string())
+            ),
+        );
+    }
+
+    /// Rung 3: the anchor fork, labeled with WHY the in-place rungs
+    /// refused. First-message edits have no fork anchor and fail
+    /// honestly here.
+    async fn claude_edit_fork_rung(
+        &self,
+        request: EditUserMessageRequest,
+        anchor: crate::session_fork::ClaudeEditAnchor,
+        reason: String,
+    ) {
+        let token = request.requested_id.clone();
+        let Some(fork_anchor) = anchor.fork_anchor.clone() else {
+            self.emit_edit_user_message_status(
+                Some(token),
+                request.user_turn_index,
+                "failed",
+                format!(
+                    "in-place rewind unavailable ({reason}) and the first message cannot be branched from before — the edit was not applied"
+                ),
+            );
+            return;
+        };
+        self.fork_claude_edit_branch_from_anchor(
+            request,
+            token,
+            fork_anchor,
+            format!(
+                "in-place rewind unavailable ({reason}) — branching into a new session from before this message"
+            ),
+        )
+        .await;
+    }
+
+    /// Capability-probe the CLI the target project would spawn
+    /// (project-configured command, default `claude`), off the async
+    /// runtime — the cold probe scans a quarter-gigabyte binary.
+    async fn claude_rewind_wire_capability_for(
+        &self,
+        project_root: &Path,
+    ) -> external_agent::claude_code::ClaudeRewindWireCapability {
+        let command = crate::project::Project::from_root(project_root.to_path_buf())
+            .map(|project| project.config.agent.claude_code.command.clone())
+            .unwrap_or_else(|_| "claude".to_string());
+        tokio::task::spawn_blocking(move || {
+            external_agent::claude_code::claude_rewind_wire_capability(&command)
+        })
+        .await
+        .unwrap_or(external_agent::claude_code::ClaudeRewindWireCapability::Unknown)
+    }
+}
+
+/// The transcript must hold still (two identical len+mtime stats,
+/// [`CLAUDE_EDIT_QUIESCENCE_SAMPLE_GAP`] apart) before surgery touches
+/// it. A file that never settles within the budget means some process —
+/// ours mid-shutdown or a foreign CLI — is still writing it.
+async fn wait_for_transcript_quiescence(transcript: &Path) -> Result<(), String> {
+    let stat = |path: &Path| {
+        std::fs::metadata(path)
+            .map(|meta| (meta.len(), meta.modified().ok()))
+            .map_err(|err| format!("failed to stat the transcript: {err}"))
+    };
+    let deadline = tokio::time::Instant::now() + CLAUDE_EDIT_QUIESCENCE_BUDGET;
+    let mut previous = stat(transcript)?;
+    loop {
+        tokio::time::sleep(CLAUDE_EDIT_QUIESCENCE_SAMPLE_GAP).await;
+        let current = stat(transcript)?;
+        if current == previous {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(
+                "the transcript is still being written (a claude process is attached)".to_string(),
+            );
+        }
+        previous = current;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session_supervisor::tests::{managed_session, test_supervisor};
+
+    fn fixture_line(uuid: &str, parent: Option<&str>, kind: &str, text: &str) -> String {
+        serde_json::json!({
+            "uuid": uuid,
+            "parentUuid": parent,
+            "type": kind,
+            "timestamp": "2026-07-27T00:00:00.000Z",
+            "message": {"role": kind, "content": [{"type": "text", "text": text}]},
+        })
+        .to_string()
+    }
+
+    /// Hermetic claude store + supervisor wired for ladder tests. The
+    /// capability seam avoids the real-binary probe; the launch gate
+    /// holds any resume body until the test opens it.
+    struct LadderRig {
+        home: tempfile::TempDir,
+        project: tempfile::TempDir,
+        supervisor: SessionSupervisor,
+        bus: EventBus,
+        gate_tx: tokio::sync::watch::Sender<bool>,
+        transcript: PathBuf,
+    }
+
+    fn ladder_rig(
+        parent_id: &str,
+        capability: external_agent::claude_code::ClaudeRewindWireCapability,
+    ) -> LadderRig {
+        let home = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let project_dir = home.path().join(".claude").join("projects").join("proj");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let lines = [
+            fixture_line("u1", None, "user", "first prompt"),
+            fixture_line("a1", Some("u1"), "assistant", "reply one"),
+            fixture_line("u2", Some("a1"), "user", "do the thing"),
+            fixture_line("a2", Some("u2"), "assistant", "stale answer"),
+        ];
+        let transcript = project_dir.join(format!("{parent_id}.jsonl"));
+        std::fs::write(&transcript, lines.join("\n") + "\n").unwrap();
+
+        let bus = EventBus::new();
+        let (gate_tx, gate_rx) = tokio::sync::watch::channel(false);
+        let mut config =
+            (*test_supervisor(project.path().to_path_buf(), bus.clone()).config).clone();
+        config.logs_home_override = Some(home.path().to_path_buf());
+        config.launch_gate_for_tests = Some(gate_rx);
+        config.claude_rewind_capability_for_tests = Some(capability);
+        let supervisor = SessionSupervisor::new(config);
+        LadderRig {
+            home,
+            project,
+            supervisor,
+            bus,
+            gate_tx,
+            transcript,
+        }
+    }
+
+    fn edit_request(parent_id: &str) -> EditUserMessageRequest {
+        EditUserMessageRequest {
+            requested_id: parent_id.to_string(),
+            user_turn_index: 2,
+            user_turn_revision: Some(1),
+            original_text: Some("do the thing".to_string()),
+            text: "do the improved thing".to_string(),
+            attachments: Vec::new(),
+        }
+    }
+
+    async fn register_live_session(
+        rig: &LadderRig,
+        parent_id: &str,
+    ) -> mpsc::Receiver<FollowUpMessage> {
+        let (tx, rx) = mpsc::channel(4);
+        let mut session = managed_session(parent_id, "claude-code");
+        session.project_root = rig.project.path().to_path_buf();
+        session.session_dir = rig.project.path().join("session-dir");
+        session.follow_up_tx = tx;
+        rig.supervisor
+            .state
+            .lock()
+            .await
+            .sessions
+            .insert(parent_id.to_string(), session);
+        rx
+    }
+
+    /// The incident's shape: a live (e.g. limit-parked) wrapper gets a
+    /// pencil edit. The ladder must queue the in-place rewind on THAT
+    /// wrapper — one live session before, one after, and no fork.
+    #[tokio::test]
+    async fn edit_after_limit_yields_exactly_one_live_session() {
+        let parent_id = "5c1e2a51-0000-4000-8000-0000000000aa";
+        let rig = ladder_rig(
+            parent_id,
+            external_agent::claude_code::ClaudeRewindWireCapability::Supported,
+        );
+        let mut follow_rx = register_live_session(&rig, parent_id).await;
+        let mut bus_rx = rig.bus.subscribe();
+        let _ = &rig.home;
+
+        rig.supervisor
+            .route_edit_user_message(
+                Some(parent_id.to_string()),
+                Some("claude-code".to_string()),
+                Some(parent_id.to_string()),
+                None,
+                Some(true),
+                2,
+                Some(1),
+                Some("do the thing".to_string()),
+                "do the improved thing".to_string(),
+                Vec::new(),
+            )
+            .await;
+
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(10), follow_rx.recv())
+            .await
+            .expect("edit delivered to the live wrapper")
+            .expect("channel open");
+        assert_eq!(msg.text, "do the improved thing");
+        assert_eq!(msg.edit_user_turn_index, Some(2));
+        assert_eq!(
+            msg.claude_inplace_rewind_targets,
+            vec!["u2".to_string()],
+            "the wire rung must carry the resolved rewind target"
+        );
+
+        // Exactly one live session; nothing forked, nothing spawned.
+        assert_eq!(rig.supervisor.state.lock().await.sessions.len(), 1);
+        while let Ok(event) = bus_rx.try_recv() {
+            assert!(
+                !matches!(event, AppEvent::SessionForkResult { .. }),
+                "an in-place edit must not fork"
+            );
+        }
+    }
+
+    /// The ladder's order pin: the wire rung is attempted first; a
+    /// wrapper `rewind-unavailable` refusal (and only that — never a
+    /// supervisor-side timeout) hands the edit to the surgery rung,
+    /// which truncates the SAME transcript and resumes the SAME id.
+    #[tokio::test]
+    async fn pencil_prefers_wire_rewind_and_falls_back_in_order() {
+        let parent_id = "5c1e2a51-0000-4000-8000-0000000000ab";
+        let rig = ladder_rig(
+            parent_id,
+            external_agent::claude_code::ClaudeRewindWireCapability::Supported,
+        );
+        let mut follow_rx = register_live_session(&rig, parent_id).await;
+        let mut bus_rx = rig.bus.subscribe();
+
+        rig.supervisor
+            .claude_edit_in_place_ladder(
+                edit_request(parent_id),
+                Some(EditRouteTarget {
+                    managed_id: parent_id.to_string(),
+                    source: "claude-code".to_string(),
+                    project_root: rig.project.path().to_path_buf(),
+                    session_dir: rig.project.path().join("session-dir"),
+                    follow_up_tx: rig
+                        .supervisor
+                        .state
+                        .lock()
+                        .await
+                        .sessions
+                        .get(parent_id)
+                        .expect("registered")
+                        .follow_up_tx
+                        .clone(),
+                }),
+            )
+            .await;
+
+        // Rung 1 first: the wire message reaches the live wrapper.
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(10), follow_rx.recv())
+            .await
+            .expect("wire rung attempted first")
+            .expect("channel open");
+        assert_eq!(msg.claude_inplace_rewind_targets, vec!["u2".to_string()]);
+
+        // The wrapper refuses → the waiter must run the surgery rung.
+        rig.bus.send(AppEvent::UserMessageEditStatus {
+            session_id: Some(parent_id.to_string()),
+            user_turn_index: 2,
+            status: "rewind-unavailable".to_string(),
+            message: "in-place rewind unavailable: stale target".to_string(),
+        });
+
+        // Surgery stops the wrapper (our channel closes)…
+        tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            loop {
+                match follow_rx.recv().await {
+                    Some(_) => continue,
+                    None => break,
+                }
+            }
+        })
+        .await
+        .expect("surgery rung stops the live wrapper first");
+        // …truncates the transcript in place…
+        tokio::time::timeout(std::time::Duration::from_secs(15), async {
+            loop {
+                let body = std::fs::read_to_string(&rig.transcript).unwrap_or_default();
+                if !body.contains("do the thing") && !body.contains("stale answer") {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+        })
+        .await
+        .expect("transcript truncated at the edited row");
+        assert!(std::fs::read_to_string(&rig.transcript)
+            .expect("transcript readable")
+            .contains("reply one"));
+
+        // …and resumes the SAME id: register the same-id session while
+        // the launch gate holds the resume, then open it — the funnel
+        // must route the edited prompt there as a follow-up.
+        let (tx, mut resumed_rx) = mpsc::channel(4);
+        {
+            let mut state = rig.supervisor.state.lock().await;
+            let mut session = managed_session(parent_id, "claude-code");
+            session.project_root = rig.project.path().to_path_buf();
+            session.session_dir = rig.project.path().join("session-dir");
+            session.follow_up_tx = tx;
+            state.sessions.insert(parent_id.to_string(), session);
+        }
+        rig.gate_tx.send(true).unwrap();
+        let resumed = tokio::time::timeout(std::time::Duration::from_secs(10), resumed_rx.recv())
+            .await
+            .expect("edited prompt delivered to the same session id")
+            .expect("channel open");
+        assert_eq!(resumed.text, "do the improved thing");
+        assert!(resumed.claude_inplace_rewind_targets.is_empty());
+
+        // A backup of the pre-edit transcript sits beside it, and the
+        // whole ladder never forked.
+        let parent_dir = rig.transcript.parent().unwrap();
+        let backups: Vec<_> = std::fs::read_dir(parent_dir)
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .filter(|name| name.contains(".bak-edit-"))
+            .collect();
+        assert_eq!(backups.len(), 1, "surgery keeps exactly one backup");
+        while let Ok(event) = bus_rx.try_recv() {
+            assert!(
+                !matches!(event, AppEvent::SessionForkResult { .. }),
+                "the in-place ladder must not fork"
+            );
+        }
+    }
+
+    /// Detached session (no wrapper at all): the ladder goes straight to
+    /// surgery and resumes the same id — the case today's fork lane
+    /// couldn't serve at all.
+    #[tokio::test]
+    async fn detached_edit_rewinds_in_place_and_resumes_same_id() {
+        let parent_id = "5c1e2a51-0000-4000-8000-0000000000ac";
+        let rig = ladder_rig(
+            parent_id,
+            external_agent::claude_code::ClaudeRewindWireCapability::Supported,
+        );
+        let mut bus_rx = rig.bus.subscribe();
+
+        let ladder = {
+            let supervisor = rig.supervisor.clone();
+            let request = edit_request(parent_id);
+            tokio::spawn(async move {
+                supervisor.claude_edit_in_place_ladder(request, None).await;
+            })
+        };
+
+        tokio::time::timeout(std::time::Duration::from_secs(15), async {
+            loop {
+                let body = std::fs::read_to_string(&rig.transcript).unwrap_or_default();
+                if !body.contains("do the thing") {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+        })
+        .await
+        .expect("transcript truncated");
+
+        let (tx, mut resumed_rx) = mpsc::channel(4);
+        {
+            let mut state = rig.supervisor.state.lock().await;
+            let mut session = managed_session(parent_id, "claude-code");
+            session.project_root = rig.project.path().to_path_buf();
+            session.session_dir = rig.project.path().join("session-dir");
+            session.follow_up_tx = tx;
+            state.sessions.insert(parent_id.to_string(), session);
+        }
+        rig.gate_tx.send(true).unwrap();
+        let resumed = tokio::time::timeout(std::time::Duration::from_secs(10), resumed_rx.recv())
+            .await
+            .expect("edited prompt delivered")
+            .expect("channel open");
+        assert_eq!(resumed.text, "do the improved thing");
+        ladder.await.expect("ladder completes");
+        while let Ok(event) = bus_rx.try_recv() {
+            assert!(!matches!(event, AppEvent::SessionForkResult { .. }));
+        }
+    }
+
+    /// A first-message edit has no fork anchor and (with the wire rung
+    /// unavailable) must fail honestly — never fork, never truncate the
+    /// whole conversation away.
+    #[tokio::test]
+    async fn first_message_edit_fails_honestly_without_forking() {
+        let parent_id = "5c1e2a51-0000-4000-8000-0000000000ad";
+        let rig = ladder_rig(
+            parent_id,
+            external_agent::claude_code::ClaudeRewindWireCapability::Unsupported,
+        );
+        let before = std::fs::read_to_string(&rig.transcript).unwrap();
+        let mut bus_rx = rig.bus.subscribe();
+
+        let mut request = edit_request(parent_id);
+        request.user_turn_index = 1;
+        request.original_text = Some("first prompt".to_string());
+        rig.supervisor
+            .claude_edit_in_place_ladder(request, None)
+            .await;
+
+        let mut saw_honest_failure = false;
+        while let Ok(event) = bus_rx.try_recv() {
+            match event {
+                AppEvent::SessionForkResult { .. } => panic!("first-message edit must not fork"),
+                AppEvent::UserMessageEditStatus {
+                    status, message, ..
+                } if status == "failed" => {
+                    assert!(message.contains("first message"), "{message}");
+                    saw_honest_failure = true;
+                }
+                _ => {}
+            }
+        }
+        assert!(saw_honest_failure, "the failure must be reported");
+        assert_eq!(
+            std::fs::read_to_string(&rig.transcript).unwrap(),
+            before,
+            "the transcript must be untouched"
+        );
+    }
+}

--- a/src/bin/caller/session_supervisor/fork.rs
+++ b/src/bin/caller/session_supervisor/fork.rs
@@ -464,84 +464,21 @@ impl SessionSupervisor {
         .await;
     }
 
-    /// Chain-slice the parent transcript into a fresh child uuid in the
-    /// same project dir. Returns `(parent_backend_id, child_uuid,
-    /// kept_lines, parent_project_root)`.
-    /// Service an EDIT of a claude-code user message as an anchor-fork
-    /// branch: Claude Code has no in-place rewind on the supervision wire
-    /// (its /rewind is an interactive TUI feature of the CLI itself), so
-    /// "edit turn N and redo" becomes "fork from before that message and
-    /// run the edited prompt in the child". The live lane's turn numbers
-    /// count this supervision run — not the transcript chain — so the
-    /// edited row is located by its exact original prose
-    /// (`claude_edit_branch_anchor`), refusing ambiguity rather than
-    /// guessing; the transcript's inline fork affordance covers refusals.
-    pub(crate) async fn fork_claude_edit_branch(
+    /// The fork rung with a pre-resolved anchor: emits the honest
+    /// "running" reason (why the edit is branching instead of rewinding
+    /// in place), chain-slices the parent, and activates the child with
+    /// the edited prompt.
+    pub(crate) async fn fork_claude_edit_branch_from_anchor(
         &self,
         request: super::EditUserMessageRequest,
-        target: super::EditRouteTarget,
+        session_token: String,
+        anchor: ForkAnchorSpec,
+        running_reason: String,
     ) {
-        let sid = Some(target.managed_id.clone());
+        let sid = Some(session_token.clone());
         let turn = request.user_turn_index;
-        let Some(original_text) = request
-            .original_text
-            .as_deref()
-            .map(str::trim)
-            .filter(|text| !text.is_empty())
-            .map(str::to_string)
-        else {
-            self.emit_edit_user_message_status(
-                sid,
-                turn,
-                "failed",
-                "the edited row carried no original text to locate in the transcript",
-            );
-            return;
-        };
-        self.emit_edit_user_message_status(
-            sid.clone(),
-            turn,
-            "running",
-            "Claude Code cannot rewind in place — branching into a new session from before this message",
-        );
-        let token = target.managed_id.clone();
-        let home = self.logs_home();
-        let backend_id = match persisted_external_identity_for_session_in_home(&home, &token) {
-            Some((source, id)) if source == "claude-code" => id,
-            Some((source, _)) => {
-                self.emit_edit_user_message_status(
-                    sid,
-                    turn,
-                    "failed",
-                    format!("session is a {source} session, not claude-code"),
-                );
-                return;
-            }
-            None => token.clone(),
-        };
-        let Some(transcript) = crate::web_gateway::find_claude_session_file(&home, &backend_id)
-        else {
-            self.emit_edit_user_message_status(
-                sid,
-                turn,
-                "failed",
-                format!("transcript for claude-code session {backend_id} not found"),
-            );
-            return;
-        };
-        let anchor = match tokio::task::spawn_blocking(move || {
-            crate::session_fork::claude_edit_branch_anchor(&transcript, &original_text)
-        })
-        .await
-        .unwrap_or_else(|err| Err(format!("anchor resolution task failed: {err}")))
-        {
-            Ok(anchor) => anchor,
-            Err(reason) => {
-                self.emit_edit_user_message_status(sid, turn, "failed", reason);
-                return;
-            }
-        };
-        match self.fork_claude_session(&token, &anchor).await {
+        self.emit_edit_user_message_status(sid.clone(), turn, "running", running_reason);
+        match self.fork_claude_session(&session_token, &anchor).await {
             Ok((resolved_backend_id, child_uuid, kept_lines, parent_project_root)) => {
                 let child_short: String = child_uuid.chars().take(8).collect();
                 self.announce_claude_fork(
@@ -577,6 +514,9 @@ impl SessionSupervisor {
         }
     }
 
+    /// Chain-slice the parent transcript into a fresh child uuid in the
+    /// same project dir. Returns `(parent_backend_id, child_uuid,
+    /// kept_lines, parent_project_root)`.
     async fn fork_claude_session(
         &self,
         token: &str,
@@ -885,16 +825,16 @@ mod tests {
         assert!(error.contains("before the latest compaction"), "{error}");
     }
 
-    /// The edit-as-branch path must hand the request's attachment ids to
-    /// the child's resume call (they used to be dropped with a "not
-    /// carried yet" notice). The child uuid is minted inside the fork
-    /// surgery, so the test learns it from the `SessionForkResult` event
-    /// while the resume body is held at the launch gate, registers a
-    /// managed child under that uuid, and opens the gate: the resume
+    /// The edit ladder's FORK RUNG must hand the request's attachment
+    /// ids to the child's resume call (they used to be dropped with a
+    /// "not carried yet" notice). The child uuid is minted inside the
+    /// fork surgery, so the test learns it from the `SessionForkResult`
+    /// event while the resume body is held at the launch gate, registers
+    /// a managed child under that uuid, and opens the gate: the resume
     /// funnel then routes the edited prompt as a follow-up to the child,
     /// where the staged upload must arrive resolved.
     #[tokio::test]
-    async fn edit_branch_fork_carries_attachments_into_child_first_task() {
+    async fn edit_fork_rung_carries_attachments_into_child_first_task() {
         let home = tempfile::tempdir().unwrap();
         let project = tempfile::tempdir().unwrap();
         let parent_id = "3b8e2a51-0000-4000-8000-0000000000aa";
@@ -909,11 +849,8 @@ mod tests {
             claude_fixture_line("u2", Some("a1"), "user", "do the thing"),
             claude_fixture_line("a2", Some("u2"), "assistant", "done"),
         ];
-        std::fs::write(
-            project_dir.join(format!("{parent_id}.jsonl")),
-            lines.join("\n"),
-        )
-        .unwrap();
+        let transcript_path = project_dir.join(format!("{parent_id}.jsonl"));
+        std::fs::write(&transcript_path, lines.join("\n")).unwrap();
 
         // A real staged upload in the project-scoped store, so delivery
         // resolves the ref exactly as a plain dashboard message would.
@@ -940,14 +877,6 @@ mod tests {
         config.launch_gate_for_tests = Some(gate_rx);
         let supervisor = SessionSupervisor::new(config);
 
-        let (dummy_tx, _dummy_rx) = mpsc::channel(1);
-        let target = super::super::EditRouteTarget {
-            managed_id: parent_id.to_string(),
-            source: "claude-code".to_string(),
-            project_root: project.path().to_path_buf(),
-            session_dir: project.path().join("unused-session-dir"),
-            follow_up_tx: dummy_tx,
-        };
         let request = super::super::EditUserMessageRequest {
             requested_id: "edit-req-1".to_string(),
             user_turn_index: 2,
@@ -956,11 +885,26 @@ mod tests {
             text: "do the thing with the attachment".to_string(),
             attachments: vec![upload_ref],
         };
+        let anchor =
+            crate::session_fork::claude_edit_branch_anchor(&transcript_path, "do the thing")
+                .expect("anchor resolves");
+        let fork_anchor = anchor
+            .fork_anchor
+            .expect("non-first turn has a fork anchor");
 
         let mut bus_rx = bus.subscribe();
         let fork_task = {
             let supervisor = supervisor.clone();
-            tokio::spawn(async move { supervisor.fork_claude_edit_branch(request, target).await })
+            tokio::spawn(async move {
+                supervisor
+                    .fork_claude_edit_branch_from_anchor(
+                        request,
+                        parent_id.to_string(),
+                        fork_anchor,
+                        "test: forced fork rung".to_string(),
+                    )
+                    .await
+            })
         };
 
         // The announce emits the child uuid before resume hits the gate.

--- a/src/bin/caller/session_supervisor/mod.rs
+++ b/src/bin/caller/session_supervisor/mod.rs
@@ -22,6 +22,8 @@ mod sub_agents;
 pub(crate) use routing::*;
 mod agent_config;
 pub(crate) use agent_config::*;
+mod claude_edit;
+pub(crate) use claude_edit::CLAUDE_EDIT_INPLACE_STOP_REASON;
 mod dispatch;
 mod fork;
 mod registry;
@@ -83,6 +85,13 @@ pub struct SessionSupervisorConfig {
     /// in-flight while asserting what the intake still serves. None in
     /// production (zero cost).
     pub launch_gate_for_tests: Option<tokio::sync::watch::Receiver<bool>>,
+    /// Test seam for the claude edit ladder's CLI capability probe: when
+    /// set, the ladder uses this verdict instead of scanning the
+    /// project-configured executable — the real probe reads a
+    /// quarter-gigabyte binary off the machine, which hermetic tests
+    /// must never touch. None in production.
+    pub claude_rewind_capability_for_tests:
+        Option<external_agent::claude_code::ClaudeRewindWireCapability>,
     /// The daemon's agenda authority, when this process runs one (the
     /// gateway shapes wire it through). The ask-delivery arm records
     /// whether a recorded answer reached a live asking session
@@ -881,6 +890,7 @@ mod tests {
             git_vitals_targets: None,
             hosted_control_cert_dir: None,
             launch_gate_for_tests: None,
+            claude_rewind_capability_for_tests: None,
             agenda: None,
         })
     }

--- a/src/bin/caller/session_supervisor/routing.rs
+++ b/src/bin/caller/session_supervisor/routing.rs
@@ -306,7 +306,9 @@ impl SessionSupervisor {
 
         let (target_id, entry, relation) = self.lookup_edit_route_target(&requested_id).await;
         if entry.is_none() {
-            if let Some(attach) = edit_attach_request(source, resume_id, project_root, direct) {
+            if let Some(attach) =
+                edit_attach_request(source.clone(), resume_id, project_root, direct)
+            {
                 let lookup_id = attach
                     .resume_id
                     .as_deref()
@@ -351,6 +353,18 @@ impl SessionSupervisor {
                     codex_context_archive: None,
                 })
                 .await;
+                return;
+            }
+            // A detached claude-code session needs no attach round-trip:
+            // with no process on the transcript, the ladder's surgery
+            // rung edits the store directly and resumes the same id.
+            let claude_detached = source.as_deref() == Some("claude-code") || {
+                let home = self.logs_home();
+                persisted_external_identity_for_session_in_home(&home, &requested_id)
+                    .is_some_and(|(persisted_source, _)| persisted_source == "claude-code")
+            };
+            if claude_detached {
+                self.claude_edit_in_place_ladder(request, None).await;
                 return;
             }
         }
@@ -499,11 +513,12 @@ impl SessionSupervisor {
             return;
         };
         if backend == external_agent::AgentBackend::ClaudeCode {
-            // No in-place rewind exists on the claude-code supervision
-            // wire — service the edit as an anchor-fork branch instead
-            // (the child keeps everything before the edited message and
-            // the edited prompt becomes its first task).
-            self.fork_claude_edit_branch(request, target).await;
+            // Claude Code edits rewind the SAME backend session in place
+            // (wire rewind → transcript surgery → fork as the labeled
+            // last resort) — the ladder owns rung selection and every
+            // fallback (`claude_edit.rs`).
+            self.claude_edit_in_place_ladder(request, Some(target))
+                .await;
             return;
         }
         if !backend.supports_user_message_rewind() {

--- a/src/bin/caller/startup/daemon.rs
+++ b/src/bin/caller/startup/daemon.rs
@@ -218,6 +218,7 @@ pub(crate) async fn run_daemon(
             git_vitals_targets: Some(vitals_git_targets.clone()),
             hosted_control_cert_dir: Some(crate::startup::installed_access_cert_dir()),
             launch_gate_for_tests: None,
+            claude_rewind_capability_for_tests: None,
             agenda: gateway.agenda.clone(),
         })
         .spawn();

--- a/src/bin/caller/startup/headless.rs
+++ b/src/bin/caller/startup/headless.rs
@@ -546,6 +546,7 @@ pub(crate) async fn run_headless_mode(
                     git_vitals_targets: vitals_git_targets.clone(),
                     hosted_control_cert_dir: Some(crate::startup::installed_access_cert_dir()),
                     launch_gate_for_tests: None,
+                    claude_rewind_capability_for_tests: None,
                     agenda: headless_agenda.clone(),
                 },
             )

--- a/static/app.html
+++ b/static/app.html
@@ -36882,7 +36882,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '9f813dc055ec5f5c';
+const INTENDANT_APP_BUILD = '7c3292466b6aa287';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -71708,15 +71708,13 @@ function appendEditUserMessageButton(entry, c) {
   const btn = document.createElement('button');
   btn.type = 'button';
   btn.className = 'log-edit-message';
-  const meta = typeof sessionConfigMetadata === 'function'
-    ? sessionConfigMetadata(String(c?.session_id || ''))
-    : null;
-  const editSource = typeof sessionConfigSource === 'function' ? sessionConfigSource(meta) : '';
+  // Claude Code edits rewind the SAME session in place since CC 2.1.218
+  // (wire rewind, with transcript surgery as the fallback), so the
+  // pencil means the same thing on every backend; the explicit "Fork
+  // from here" affordance stays the branch verb.
   btn.title = c.superseded
     ? 'Create a managed branch from this historical message'
-    : editSource === 'claude-code'
-      ? 'Edit this message and branch: the edited prompt reruns in a new session (Claude Code cannot rewind in place)'
-      : 'Edit this user message and rerun from here';
+    : 'Edit this user message and rerun from here';
   btn.innerHTML = '&#9998;';
   btn.dataset.sessionId = c.session_id || '';
   btn.dataset.userTurnIndex = String(c.user_turn_index);
@@ -114728,13 +114726,10 @@ function renderEditMessageChip() {
     return;
   }
   const sid = shortSessionId(editMessageDraft.sessionId);
-  // Claude Code has no in-place rewind on the supervision wire: an edit
-  // there is serviced as an anchor-fork branch, so label it honestly.
-  const meta = typeof sessionConfigMetadata === 'function'
-    ? sessionConfigMetadata(editMessageDraft.sessionId)
-    : null;
-  const source = typeof sessionConfigSource === 'function' ? sessionConfigSource(meta) : '';
-  const branching = editMessageDraft.historical || source === 'claude-code';
+  // Every live backend now rewinds edits in place (Claude Code since
+  // CC 2.1.218 via the daemon's in-place ladder); only historical rows
+  // still branch, so only they get the branching label.
+  const branching = editMessageDraft.historical;
   const action = branching ? 'Branching' : 'Editing';
   label.textContent = `${action} ${sid} #${editMessageDraft.userTurnIndex}`;
   chip.title = branching

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -2978,15 +2978,13 @@ function appendEditUserMessageButton(entry, c) {
   const btn = document.createElement('button');
   btn.type = 'button';
   btn.className = 'log-edit-message';
-  const meta = typeof sessionConfigMetadata === 'function'
-    ? sessionConfigMetadata(String(c?.session_id || ''))
-    : null;
-  const editSource = typeof sessionConfigSource === 'function' ? sessionConfigSource(meta) : '';
+  // Claude Code edits rewind the SAME session in place since CC 2.1.218
+  // (wire rewind, with transcript surgery as the fallback), so the
+  // pencil means the same thing on every backend; the explicit "Fork
+  // from here" affordance stays the branch verb.
   btn.title = c.superseded
     ? 'Create a managed branch from this historical message'
-    : editSource === 'claude-code'
-      ? 'Edit this message and branch: the edited prompt reruns in a new session (Claude Code cannot rewind in place)'
-      : 'Edit this user message and rerun from here';
+    : 'Edit this user message and rerun from here';
   btn.innerHTML = '&#9998;';
   btn.dataset.sessionId = c.session_id || '';
   btn.dataset.userTurnIndex = String(c.user_turn_index);

--- a/static/app/54-session-lifecycle.js
+++ b/static/app/54-session-lifecycle.js
@@ -436,13 +436,10 @@ function renderEditMessageChip() {
     return;
   }
   const sid = shortSessionId(editMessageDraft.sessionId);
-  // Claude Code has no in-place rewind on the supervision wire: an edit
-  // there is serviced as an anchor-fork branch, so label it honestly.
-  const meta = typeof sessionConfigMetadata === 'function'
-    ? sessionConfigMetadata(editMessageDraft.sessionId)
-    : null;
-  const source = typeof sessionConfigSource === 'function' ? sessionConfigSource(meta) : '';
-  const branching = editMessageDraft.historical || source === 'claude-code';
+  // Every live backend now rewinds edits in place (Claude Code since
+  // CC 2.1.218 via the daemon's in-place ladder); only historical rows
+  // still branch, so only they get the branching label.
+  const branching = editMessageDraft.historical;
   const action = branching ? 'Branching' : 'Editing';
   label.textContent = `${action} ${sid} #${editMessageDraft.userTurnIndex}`;
   chip.title = branching

--- a/tests/skills/session-fork-probes/SKILL.md
+++ b/tests/skills/session-fork-probes/SKILL.md
@@ -85,23 +85,31 @@ What these pin (CC 2.1.211 semantics the surgery engine assumes):
 The script exits non-zero on any unexpected verdict and prints the exact
 cleanup command for the scratch project dir.
 
-## Tripwire — the claude rewind wire surface (checked against 2.1.215)
+## The claude rewind wire — LANDED (CC ≥2.1.218); probe on every bump
 
-The claude TUI's `/rewind` is real, and as of CC **2.1.215** part of it
-reached the headless control wire: the stream-json control request
-`{subtype: "rewind_files", user_message_id, dry_run}` restores checkpoint
-**file state** to a given user message (SDK method `rewindFiles`).
-**Conversation** rewind remains TUI-internal (`repl_rewind_conversation`;
-internal contract names a `target_message_uuid`) — there is **no**
-stream-json subtype for it, which is why a supervisor edit of a claude
-message is serviced as an anchor-fork *branch*, never an in-place rewind.
+The 2.1.215-era tripwire fired: since CC **2.1.218** the stream-json
+control wire handles `{subtype: "rewind_conversation",
+target_message_uuid, interrupt_if_running}` — true in-place conversation
+rewind of the same session id, proven live 2026-07-27 on 2.1.220. The
+daemon's pencil edits now ride it (`session_supervisor/claude_edit.rs`:
+wire rewind → same-id transcript surgery → anchor fork, in that order),
+and the build pins the subtype token (`rewind_wire_subtype_canary`) plus
+a runtime binary scan (`claude_rewind_wire_capability`) that skips the
+wire rung loudly when the installed CLI predates it.
 
-Watch on every CC upgrade (grep the versioned binary under
-`~/.local/share/claude/versions/` for `subtype:"rewind`):
-- `rewind_conversation` (or similar) appearing as a wire subtype → claude
-  edits can graduate from branch-on-edit to true in-place rewind; revisit
-  `session_supervisor/fork.rs::fork_claude_edit_branch` and the
-  `supports_user_message_rewind()` gate.
-- `rewind_files` semantics vs forked children: a chain-slice child keeps
-  parent-era `user_message_id`s — whether the child can restore the
-  parent's file checkpoints is unprobed. Probe before building on it.
+**Run `spike3_cc_rewind.py` on every CC upgrade** (and whenever pencil
+edits misbehave): it exercises the wire contract for real — refusal
+vocabulary ("stale target" / "target not found" / "turn running"), the
+last-human-turn-only constraint, ghost-free continuation, the
+append-only `last-prompt` pin, restart continuity, `interrupt_if_running`
+mid-turn, the remote `tengu_rewind_first_message` gate direction, and the
+Lane-B truncation + sidecar-survival contract. Any drift exits non-zero.
+
+Still-open adjacent surface:
+- `rewind_files` (checkpoint **file state** restore, present since
+  2.1.215, `user_message_id`-keyed): availability under `-p` mode is
+  unprobed, and pruned turns' file side effects survive both rewind
+  lanes until it's built on. Probe before building.
+- `rewind_conversation` targets pre-compaction rows only while they are
+  in the CLI's memory: after auto-compaction expect "target not found"
+  (the surgery/fork rungs cover those edits).

--- a/tests/skills/session-fork-probes/spike3_cc_rewind.py
+++ b/tests/skills/session-fork-probes/spike3_cc_rewind.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Spike 3: pin the Claude Code IN-PLACE rewind surfaces the pencil's edit
+ladder is built on (src/bin/caller/session_supervisor/claude_edit.rs).
+
+Run on every CC version bump and whenever pencil edits misbehave. NOT CI:
+real haiku calls via the installed CLI (subscription OAuth; pennies).
+
+Findings this probe encodes (first proven on CC 2.1.220, 2026-07-27; the
+handler is present in every installed version since 2.1.218):
+
+  LANE A — `rewind_conversation` control subtype (the wire rung):
+  - request: {"subtype":"rewind_conversation","target_message_uuid":U,
+    "interrupt_if_running":B}; refusals arrive as SUCCESS-subtype
+    responses with rewound:false + an `error` string ("stale target",
+    "target not found", "turn running", "commands queued",
+    "no preceding assistant").
+  - only the CURRENT last real-human turn may be rewound per call →
+    earlier edits walk back newest-first (N+1 calls).
+  - success appends an {explicit:true,rewound:true} `last-prompt` pin
+    (append-only; no rows deleted) and the next user message lands as a
+    sibling branch at precedingAssistantUuid — ghost-free, same id.
+  - `interrupt_if_running:true` aborts a mid-stream turn and rewinds it.
+  - the walked-back state survives a clean exit + `--resume <same id>`.
+  - first-message rewind rides the remote `tengu_rewind_first_message`
+    gate: this probe only REPORTS which way the gate points today.
+  - post-`result` the CLI stays non-idle briefly (worst observed 3.3 s):
+    "turn running" refusals are retried at 250 ms, mirroring the daemon.
+
+  LANE B — same-id transcript truncation (the surgery rung):
+  - with NO process attached, truncating the session's own .jsonl at a
+    user row and resuming the same id continues ghost-free from the cut;
+    the resumed CLI parents the next user row onto the physical tail.
+  - sid-keyed sidecars (subagents/) survive byte-identical.
+
+The daemon's canary (`rewind_wire_subtype_canary` +
+`claude_rewind_wire_capability`) scans the installed binary for the
+subtype token; this probe is the LIVE half — it exercises the wire for
+real and exits non-zero on any drift.
+
+Cost: ~8 short haiku turns. Cleanup command printed at the end.
+"""
+
+import glob
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+
+CLAUDE = os.path.expanduser("~/.local/bin/claude")
+SCRATCH = f"/tmp/cc-rewind-spike-{int(time.time())}"
+LOG_PATH = os.path.join(SCRATCH, "spike3.wire.jsonl")
+DAEMON_FLAGS = [
+    "-p",
+    "--output-format", "stream-json",
+    "--input-format", "stream-json",
+    "--verbose",
+    "--include-partial-messages",
+    "--permission-prompt-tool", "stdio",
+]
+NO_TOOLS = ["--disallowedTools",
+            "Bash,Skill,Task,TodoWrite,Read,Write,Edit,MultiEdit,NotebookEdit,"
+            "WebSearch,WebFetch,Glob,Grep,BashOutput,KillShell"]
+
+checks = []
+
+
+def check(name, ok, detail=""):
+    checks.append((name, bool(ok)))
+    print(f"{'PASS' if ok else 'FAIL'}: {name}  {detail}")
+
+
+class CcProc:
+    """Minimal stream-json driver mirroring the daemon's spawn shape
+    (src/bin/caller/external_agent/claude_code.rs `initialize`)."""
+
+    def __init__(self, cwd, extra_flags=None, approve_tools=False):
+        self.approve_tools = approve_tools
+        args = [CLAUDE] + DAEMON_FLAGS + ["--permission-mode", "default", "--model", "haiku"]
+        if extra_flags:
+            args += extra_flags
+        os.makedirs(cwd, exist_ok=True)
+        self.log = open(LOG_PATH, "a")
+        self.log.write(f"\n=== SPAWN {time.strftime('%H:%M:%S')} {' '.join(args)}\n")
+        env = dict(os.environ)
+        env["CLAUDE_CODE_DISABLE_AUTO_MEMORY"] = "1"  # keep ghost checks transcript-pure
+        self.proc = subprocess.Popen(args, cwd=cwd, stdin=subprocess.PIPE,
+                                     stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+                                     text=True, bufsize=1, env=env)
+        self.lines, self.lock, self.ctr, self.cursor = [], threading.Lock(), 0, 0
+        threading.Thread(target=self._read, daemon=True).start()
+
+    def _read(self):
+        for line in self.proc.stdout:
+            line = line.strip()
+            if not line:
+                continue
+            self.log.write(line + "\n"); self.log.flush()
+            try:
+                obj = json.loads(line)
+            except Exception:
+                continue
+            with self.lock:
+                self.lines.append(obj)
+            if obj.get("type") == "control_request":
+                req = obj.get("request", {})
+                if req.get("subtype") == "can_use_tool":
+                    behavior = ({"behavior": "allow", "updatedInput": req.get("input", {})}
+                                if self.approve_tools else
+                                {"behavior": "deny", "message": "tools disabled in this probe"})
+                    self.send({"type": "control_response", "response": {
+                        "subtype": "success", "request_id": obj.get("request_id"),
+                        "response": behavior}})
+
+    def send(self, obj):
+        line = json.dumps(obj)
+        self.log.write(">>> " + line + "\n"); self.log.flush()
+        self.proc.stdin.write(line + "\n")
+        self.proc.stdin.flush()
+
+    def send_user(self, text):
+        self.send({"type": "user", "message": {"role": "user",
+                   "content": [{"type": "text", "text": text}]}})
+
+    def send_control(self, kind, request):
+        self.ctr += 1
+        rid = f"spike3-{kind}-{self.ctr}"
+        self.send({"type": "control_request", "request_id": rid, "request": request})
+        return rid
+
+    def wait(self, pred, timeout=180, desc="condition"):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            with self.lock:
+                for i in range(self.cursor, len(self.lines)):
+                    if pred(self.lines[i]):
+                        self.cursor = i + 1
+                        return self.lines[i]
+                exited = self.proc.poll() is not None and self.cursor >= len(self.lines)
+            if exited:
+                raise RuntimeError(f"process exited waiting for {desc}")
+            time.sleep(0.05)
+        raise TimeoutError(f"timeout waiting for {desc}")
+
+    def wait_result(self):
+        return self.wait(lambda o: o.get("type") == "result", desc="result")
+
+    def session_id(self):
+        obj = self.wait(lambda o: o.get("type") == "system" and o.get("subtype") == "init",
+                        60, "system:init")
+        return obj.get("session_id")
+
+    def close(self):
+        try:
+            self.proc.stdin.close()
+        except Exception:
+            pass
+        try:
+            self.proc.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            self.proc.terminate()
+            self.proc.wait(timeout=10)
+        return self.proc.returncode
+
+
+def rewind(p, target_uuid, interrupt=False):
+    """One rewind with the daemon's 250 ms 'turn running' retry."""
+    for _ in range(60):
+        req = {"subtype": "rewind_conversation", "target_message_uuid": target_uuid,
+               "interrupt_if_running": interrupt}
+        rid = p.send_control("rewind", req)
+        resp = p.wait(lambda o: o.get("type") == "control_response"
+                      and o.get("response", {}).get("request_id") == rid,
+                      60, f"control_response {rid}")
+        if resp.get("response", {}).get("subtype") == "error":
+            return {"error": resp["response"].get("error"), "_subtype": "error"}
+        inner = resp.get("response", {}).get("response", {}) or {}
+        if inner.get("error") in ("turn running", "commands queued") and not interrupt:
+            time.sleep(0.25)
+            continue
+        return inner
+    return inner
+
+
+def transcript_path(sid):
+    hits = glob.glob(os.path.expanduser(f"~/.claude/projects/*/{sid}.jsonl"))
+    assert len(hits) == 1, f"expected 1 transcript for {sid}, got {hits}"
+    return hits[0]
+
+
+def read_rows(path):
+    rows = []
+    for line in open(path):
+        line = line.strip()
+        if line:
+            try:
+                rows.append(json.loads(line))
+            except Exception:
+                rows.append({"_torn": True})
+    return rows
+
+
+def human_uuid_by_text(path, needle, timeout=15):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        for r in read_rows(path):
+            if r.get("type") != "user" or r.get("isMeta") or r.get("isSidechain"):
+                continue
+            content = r.get("message", {}).get("content")
+            text = content if isinstance(content, str) else "".join(
+                b.get("text", "") for b in content or [] if isinstance(b, dict))
+            if needle in text:
+                return r["uuid"]
+        time.sleep(0.25)
+    return None
+
+
+def main():
+    os.makedirs(SCRATCH, exist_ok=True)
+
+    # 0. Binary fingerprint — the canary's live half.
+    binary = os.path.realpath(CLAUDE)
+    blob = open(binary, "rb").read()
+    check("installed CC binary carries the rewind_conversation subtype",
+          b"rewind_conversation" in blob, binary)
+
+    # 1. Lane A wire contract on a fresh 2-turn session.
+    p = CcProc(SCRATCH, extra_flags=NO_TOOLS)
+    p.send_user("For this conversation only, note (no tools): my lucky number is 41. Reply exactly: OK")
+    sid = p.session_id()
+    p.wait_result()
+    p.send_user("One more fact (no tools): my favorite animal is the axolotl. Reply exactly: OK")
+    p.wait_result()
+    tp = transcript_path(sid)
+    u1 = human_uuid_by_text(tp, "lucky number")
+    u2 = human_uuid_by_text(tp, "axolotl")
+
+    inner = rewind(p, u1)
+    check("earlier target refused (stale target)",
+          inner.get("rewound") is False and "stale" in (inner.get("error") or ""), str(inner))
+    inner = rewind(p, "00000000-dead-beef-0000-000000000000")
+    check("garbage target refused (target not found)",
+          inner.get("rewound") is False and "not found" in (inner.get("error") or ""), str(inner))
+    inner = rewind(p, u2)
+    check("last-human rewind succeeds", inner.get("rewound") is True, str(inner))
+    preceding = inner.get("precedingAssistantUuid")
+
+    p.send_user("New fact (no tools): my favorite animal is the quokka. One line: every animal mentioned so far, plus my lucky number.")
+    r = p.wait_result()
+    t = (r.get("result") or "").lower()
+    check("edited turn ran in the SAME session id", r.get("session_id") == sid)
+    check("ghost-free: quokka+41 present, pruned axolotl absent",
+          "quokka" in t and "41" in t and "axolotl" not in t, t[:120])
+    u2p = human_uuid_by_text(tp, "quokka")
+    edited = next((row for row in read_rows(tp) if row.get("uuid") == u2p), {})
+    check("edited row is a sibling at precedingAssistantUuid",
+          edited.get("parentUuid") == preceding)
+
+    # First-message gate: report, don't fail — it's remote config.
+    inner = rewind(p, u2p)
+    check("walk-back loop viable (second rewind succeeds)", inner.get("rewound") is True)
+    inner = rewind(p, u1)
+    gate_on = inner.get("rewound") is True
+    print(f"INFO: tengu_rewind_first_message gate is {'ON' if gate_on else 'OFF'} "
+          f"in this environment ({inner})")
+    check("clean exit", p.close() == 0)
+
+    # 2. Restart continuity of the walked-back state.
+    p2 = CcProc(SCRATCH, extra_flags=NO_TOOLS + ["--resume", sid])
+    p2.send_user("One line (no tools): my lucky number, and every animal mentioned in this conversation (NO-ANIMALS if none).")
+    sid2 = p2.session_id()
+    r = p2.wait_result()
+    t = (r.get("result") or "").lower()
+    check("resume keeps the same backend session id", sid2 == sid)
+    if gate_on:
+        check("restart honors the walked-back state (everything pruned)",
+              "quokka" not in t and "axolotl" not in t, t[:120])
+    else:
+        check("restart honors the walked-back state (41 kept, animals pruned)",
+              "41" in t and "quokka" not in t and "axolotl" not in t, t[:120])
+
+    # 3. interrupt_if_running against a mid-stream turn.
+    p2.send_user("Slowly count from 1 to 40, one number per line, no tools, then say DONE-COUNTING.")
+    p2.wait(lambda o: o.get("type") == "stream_event", 60, "slow turn streaming")
+    u_slow = human_uuid_by_text(tp, "Slowly count")
+    inner = rewind(p2, u_slow, interrupt=True)
+    check("interrupt_if_running rewinds a RUNNING turn", inner.get("rewound") is True, str(inner))
+    check("resumed process clean exit", p2.close() == 0)
+
+    # 4. Lane B: same-id truncation with NO process attached, then resume.
+    #    Also plant a sidecar to pin byte-identical survival.
+    sidecar_dir = os.path.join(os.path.dirname(tp), sid, "subagents")
+    os.makedirs(sidecar_dir, exist_ok=True)
+    sidecar = os.path.join(sidecar_dir, "agent-spike3.jsonl")
+    open(sidecar, "w").write('{"type":"user","uuid":"sidecar-row"}\n')
+    sidecar_hash = hashlib.sha256(open(sidecar, "rb").read()).hexdigest()
+
+    rows_raw = open(tp).read().splitlines(keepends=False)
+    cut_uuid = u_slow if gate_on is not None else None
+    cut_index = next(i for i, line in enumerate(rows_raw) if cut_uuid and cut_uuid in line)
+    open(tp, "w").write("\n".join(rows_raw[:cut_index]) + "\n")
+    p3 = CcProc(SCRATCH, extra_flags=NO_TOOLS + ["--resume", sid])
+    p3.send_user("One line (no tools): did I ever ask you to count numbers in this conversation? YES or NO.")
+    sid3 = p3.session_id()
+    r = p3.wait_result()
+    t = (r.get("result") or "").lower()
+    check("surgery resume keeps the same backend session id", sid3 == sid)
+    check("surgery pruned the counting turn ghost-free", t.strip().startswith("no") or " no" in t,
+          t[:120])
+    check("surgery leaves the subagent sidecar byte-identical",
+          hashlib.sha256(open(sidecar, "rb").read()).hexdigest() == sidecar_hash)
+    check("surgery-resumed process clean exit", p3.close() == 0)
+
+    fails = [name for name, ok in checks if not ok]
+    print(f"\n=== {len(checks) - len(fails)}/{len(checks)} passed ===")
+    print(f"cleanup: rm -rf {SCRATCH} "
+          f"~/.claude/projects/{os.path.basename(os.path.dirname(tp))}")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
First of three separable PRs from the pencil-edit in-place + lineage exactly-once commission (agenda item 01KYJVDKVSS7ZHQG7X5EHXWRBY; root-cause and feasibility reports verified line-by-line firsthand).

The dashboard pencil on a claude-code session becomes a true in-place edit of the SAME backend session id — the fork-on-edit lane that produced the 2026-07-27 duplicate-orchestrator incident is now the labeled last resort.

**Ladder** (each refusal maps honestly to the next rung):
1. **Wire rewind** — CC native `rewind_conversation` control subtype ({target_message_uuid, interrupt_if_running}; CC >=2.1.218, proven live on 2.1.220). Supervisor resolves the edited row + newest-first walk-back by prose; the wrapper drives correlated control requests (new request/response upgrade on `write_control_request`, mirrored pending map completed by the reader). Capability-probed against the installed CLI (cached fingerprint-keyed binary scan); fails loud on drift.
2. **Same-id transcript surgery** — stop wrapper → transcript quiescence → truncate at the anchor row boundary (dropping its queue-operation run; tmp+fsync+atomic rename, .bak retained) → resume the same id with the edited prompt. Subagent sidecars survive byte-identical by construction.
3. **Anchor fork** — the pre-existing lane, only for off-chain/first-message/race cases, with the reason in the status. The explicit 'Fork from here' affordance stays the branch verb.

**Guards:** one in-flight edit per backend lineage (RAII claim); the wire rung's waiter falls back only on the wrapper's own `rewind-unavailable` refusal, never a timeout (a queued edit on a limit-parked wrapper stays that wrapper's to serve).

**Pins:** `edit_after_limit_yields_exactly_one_live_session`, `pencil_prefers_wire_rewind_and_falls_back_in_order`, `surgery_preserves_subagent_sidecars_byte_identical`, `rewind_wire_subtype_canary` (+ detached same-id resume, honest first-message refusal, anchor widening pins, correlated-response reader pin). `tests/skills/session-fork-probes/spike3_cc_rewind.py` is the live-binary probe for CC bumps; SKILL.md tripwire flipped to landed.

Stale `Claude Code cannot rewind in place` comments/assertions fixed (fork.rs, external_agent/mod.rs:2839, fork_points.rs, UI copy in 41/54 fragments).

Battery: 5283 bin tests, 6 library crates, 33 e2e, clippy -D warnings, fmt --check — all green.

PR-2 (lineage exactly-once + terminal stop) and PR-3 (fork fidelity) follow separately.