### PR TITLE
PR-2: lineage exactly-once admission + terminal owner stop

### DIFF
--- a/src/bin/caller/external_mode.rs
+++ b/src/bin/caller/external_mode.rs
@@ -3864,7 +3864,8 @@ pub(crate) async fn run_external_agent_mode(
                 stats.rounds = round;
                 let user_requested_stop =
                     matches!(reason.as_str(), "stopped by user" | "restarting session")
-                        || reason == crate::session_supervisor::CLAUDE_EDIT_INPLACE_STOP_REASON;
+                        || reason == crate::session_supervisor::CLAUDE_EDIT_INPLACE_STOP_REASON
+                        || reason == crate::session_supervisor::CLAUDE_EDIT_SUPERSEDED_STOP_REASON;
                 if codex_managed_context_enabled && !user_requested_stop {
                     match refresh_external_context_usage_snapshot(&mut agent, &drain_config).await {
                         Ok(Some(snapshot)) => {

--- a/src/bin/caller/external_wrapper_index.rs
+++ b/src/bin/caller/external_wrapper_index.rs
@@ -136,6 +136,26 @@ pub struct ExternalWrapperRecord {
     /// migrate (Codex `sessions/` → `archived_sessions/`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rollout_path: Option<String>,
+    /// Durable owner-stop tombstone (unix seconds), written by
+    /// [`record_user_stop`] on every row of the lineage's group. While
+    /// set, [`admit`] refuses automatic revival lanes (`Resume`); only a
+    /// deliberate gesture (`Restart` / `Revive`) clears it. Survives
+    /// daemon restarts by construction — it lives in this file. (An
+    /// OLDER binary rewriting the index drops unknown fields, which
+    /// degrades the tombstone to the pre-PR in-memory behavior; the
+    /// newer daemon is the only writer in a normal deployment.)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stopped_by_user_at_secs: Option<u64>,
+    /// The backend session id this lineage was REPLACED by (an
+    /// edit-branch child), written by [`record_lineage_retired`] on
+    /// every row of the group. While set, [`admit`] refuses
+    /// `Resume`/`Restart`/`Revive` with the successor so a retired
+    /// parent is never stood back up beside its replacement — the
+    /// 2026-07-27 duplicate-orchestrator shape. Explicit anchor forks
+    /// (`ForkChild`) stay allowed: branching a retired lineage is
+    /// legitimate history use.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retired_successor: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -374,6 +394,8 @@ pub fn upsert(
             updated_at_secs,
             state: WrapperState::Active,
             rollout_path: None,
+            stopped_by_user_at_secs: None,
+            retired_successor: None,
         });
     }
 
@@ -501,6 +523,8 @@ pub fn backfill(
             updated_at_secs,
             state: WrapperState::Active,
             rollout_path: None,
+            stopped_by_user_at_secs: None,
+            retired_successor: None,
         });
     } else {
         // Some row already holds this backend session, or this wrapper is
@@ -515,6 +539,8 @@ pub fn backfill(
             updated_at_secs: 0,
             state: WrapperState::Superseded,
             rollout_path: None,
+            stopped_by_user_at_secs: None,
+            retired_successor: None,
         });
     }
 
@@ -746,6 +772,284 @@ pub fn wrappers_for(
     });
     records.sort_by(wrapper_preference);
     records
+}
+
+/// What a caller is trying to do to a backend lineage, for [`admit`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WrapperLineageIntent {
+    /// An automatic lane: frontend auto-attach escalations, follow-up
+    /// driven attaches. Refused on stopped AND retired lineages.
+    Resume,
+    /// The owner's Restart gesture: supersedes a live wrapper and
+    /// revives a stopped lineage, but never a retired one.
+    Restart,
+    /// Explicit anchor forks: a NEW backend id is born, so lineage
+    /// tombstones on the parent never apply.
+    ForkChild,
+    /// A deliberate resume (dashboard Attach, `ctl session resume`, the
+    /// edit ladder's same-id surgery resume): revives a stopped
+    /// lineage, refuses a retired one.
+    Revive,
+}
+
+/// The admission verdict for spawning a wrapper on a backend lineage.
+#[derive(Debug)]
+pub enum WrapperAdmission {
+    /// Spawn. Hold the reservation (when one is issued) until the new
+    /// wrapper is registered; dropping it releases the lineage.
+    Admitted(Option<WrapperLaunchReservation>),
+    /// A live wrapper already serves this lineage — deliver the intent
+    /// (attach ack / task as follow-up) to it instead of spawning.
+    RouteToLive { wrapper_session_id: String },
+    /// Another launch for this lineage is in flight; spawning a second
+    /// wrapper would recreate the duplicate-orchestrator shape.
+    AlreadyLaunching,
+    /// The owner stopped this lineage; only a deliberate gesture
+    /// revives it.
+    RefusedStopped { stopped_at_secs: u64 },
+    /// The lineage was replaced by an edit-branch child; continue there.
+    RefusedRetired { successor: String },
+}
+
+/// In-flight launch reservations per `(source, backend_session_id)` —
+/// the in-memory half of admission (launches die with the daemon, so
+/// this is deliberately not persisted). Guarded by [`INDEX_LOCK`] like
+/// every other admission read/write.
+static LAUNCH_RESERVATIONS: OnceLock<Mutex<HashMap<(String, String), u64>>> = OnceLock::new();
+static RESERVATION_NONCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
+fn launch_reservations() -> &'static Mutex<HashMap<(String, String), u64>> {
+    LAUNCH_RESERVATIONS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// RAII hold on a lineage's launch slot. Dropped when the launch body
+/// finishes (the new wrapper is registered by then) or fails — either
+/// way the lineage becomes admittable again.
+#[derive(Debug)]
+pub struct WrapperLaunchReservation {
+    source: String,
+    backend_session_id: String,
+    nonce: u64,
+}
+
+impl Drop for WrapperLaunchReservation {
+    fn drop(&mut self) {
+        let mut reservations = launch_reservations()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let key = (self.source.clone(), self.backend_session_id.clone());
+        if reservations.get(&key) == Some(&self.nonce) {
+            reservations.remove(&key);
+        }
+    }
+}
+
+/// CAS admission for standing up a wrapper on `(source,
+/// backend_session_id)` — the single gate every external spawn lane
+/// (resume, restart, revive, edit-surgery resume) consults before
+/// creating another wrapper, under the same lock the index writes hold.
+/// `live_wrapper_session_id` is the caller-resolved live wrapper for
+/// the lineage (supervisor entry with an OPEN follow-up channel —
+/// liveness, never phase: a "done"-phase wrapper still serving
+/// follow-ups is live).
+///
+/// Ordering: durable refusals (stopped / retired) first, then routing
+/// to the live wrapper, then the in-flight-launch reservation. A
+/// `Restart` supersedes a live wrapper instead of routing to it — the
+/// caller stops it while holding the returned reservation, which is
+/// what makes restart-vs-restart (and restart-vs-resume) races
+/// single-winner.
+pub fn admit(
+    home: &Path,
+    source: &str,
+    backend_session_id: &str,
+    intent: WrapperLineageIntent,
+    live_wrapper_session_id: Option<&str>,
+) -> Result<WrapperAdmission, String> {
+    let source = crate::session_names::normalize_source(source);
+    let backend_session_id = backend_session_id.trim().to_string();
+    if source.is_empty() || backend_session_id.is_empty() {
+        return Ok(WrapperAdmission::Admitted(None));
+    }
+    let _guard = INDEX_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    if intent != WrapperLineageIntent::ForkChild {
+        let (stopped_at, successor) = with_index_unlocked(home, |index| {
+            let rows = index.wrappers.iter().filter(|record| {
+                record.source == source && record.backend_session_id == backend_session_id
+            });
+            let mut stopped_at: Option<u64> = None;
+            let mut successor: Option<String> = None;
+            for record in rows {
+                stopped_at = stopped_at.max(record.stopped_by_user_at_secs);
+                if successor.is_none() {
+                    successor = record.retired_successor.clone();
+                }
+            }
+            (stopped_at, successor)
+        });
+        if let Some(successor) = successor {
+            return Ok(WrapperAdmission::RefusedRetired { successor });
+        }
+        if let Some(stopped_at_secs) = stopped_at {
+            match intent {
+                WrapperLineageIntent::Resume => {
+                    return Ok(WrapperAdmission::RefusedStopped { stopped_at_secs });
+                }
+                WrapperLineageIntent::Restart | WrapperLineageIntent::Revive => {
+                    // The deliberate gesture clears the tombstone.
+                    let mut index = with_index_unlocked(home, |index| index.clone());
+                    for record in index.wrappers.iter_mut().filter(|record| {
+                        record.source == source && record.backend_session_id == backend_session_id
+                    }) {
+                        record.stopped_by_user_at_secs = None;
+                    }
+                    write_index_unlocked(home, &index)?;
+                    note_index_written(home, &index);
+                }
+                WrapperLineageIntent::ForkChild => unreachable!("guarded above"),
+            }
+        }
+    }
+
+    if let Some(live) = live_wrapper_session_id
+        .map(str::trim)
+        .filter(|live| !live.is_empty())
+    {
+        match intent {
+            WrapperLineageIntent::Resume | WrapperLineageIntent::Revive => {
+                return Ok(WrapperAdmission::RouteToLive {
+                    wrapper_session_id: live.to_string(),
+                });
+            }
+            // Restart supersedes; ForkChild never attaches to its parent.
+            WrapperLineageIntent::Restart | WrapperLineageIntent::ForkChild => {}
+        }
+    }
+
+    if intent == WrapperLineageIntent::ForkChild {
+        // The fork's own identity is a fresh backend id announced later;
+        // it never contends for the parent lineage's launch slot.
+        return Ok(WrapperAdmission::Admitted(None));
+    }
+
+    let mut reservations = launch_reservations()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let key = (source.clone(), backend_session_id.clone());
+    if reservations.contains_key(&key) {
+        return Ok(WrapperAdmission::AlreadyLaunching);
+    }
+    let nonce = RESERVATION_NONCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    reservations.insert(key, nonce);
+    Ok(WrapperAdmission::Admitted(Some(WrapperLaunchReservation {
+        source,
+        backend_session_id,
+        nonce,
+    })))
+}
+
+/// Read-only tombstone probe for a lineage:
+/// `(stopped_by_user_at_secs, retired_successor)`. For callers that
+/// must decide BEFORE side effects (a restart refuses a retired lineage
+/// before stopping anything) — [`admit`] stays the authoritative gate.
+pub fn lineage_tombstones(
+    home: &Path,
+    source: &str,
+    backend_session_id: &str,
+) -> (Option<u64>, Option<String>) {
+    let source = crate::session_names::normalize_source(source);
+    let backend_session_id = backend_session_id.trim();
+    if source.is_empty() || backend_session_id.is_empty() {
+        return (None, None);
+    }
+    let _guard = INDEX_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    with_index_unlocked(home, |index| {
+        let mut stopped_at: Option<u64> = None;
+        let mut successor: Option<String> = None;
+        for record in index.wrappers.iter().filter(|record| {
+            record.source == source && record.backend_session_id == backend_session_id
+        }) {
+            stopped_at = stopped_at.max(record.stopped_by_user_at_secs);
+            if successor.is_none() {
+                successor = record.retired_successor.clone();
+            }
+        }
+        (stopped_at, successor)
+    })
+}
+
+/// Durable owner-stop tombstone for a lineage: every group row gets the
+/// stamp so the fact survives any single row's pruning. No-op for a
+/// lineage the index has never seen (a stop before identity commit
+/// leaves nothing durable to revive either).
+pub fn record_user_stop(home: &Path, source: &str, backend_session_id: &str) -> Result<(), String> {
+    stamp_group(home, source, backend_session_id, |record| {
+        record.stopped_by_user_at_secs = Some(
+            std::time::SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0),
+        );
+    })
+}
+
+/// Durable retirement of a lineage replaced by an edit-branch child.
+pub fn record_lineage_retired(
+    home: &Path,
+    source: &str,
+    backend_session_id: &str,
+    successor_backend_session_id: &str,
+) -> Result<(), String> {
+    let successor = successor_backend_session_id.trim().to_string();
+    if successor.is_empty() {
+        return Ok(());
+    }
+    stamp_group(home, source, backend_session_id, move |record| {
+        record.retired_successor = Some(successor.clone());
+    })
+}
+
+fn stamp_group(
+    home: &Path,
+    source: &str,
+    backend_session_id: &str,
+    stamp: impl Fn(&mut ExternalWrapperRecord),
+) -> Result<(), String> {
+    let source = crate::session_names::normalize_source(source);
+    let backend_session_id = backend_session_id.trim();
+    if source.is_empty() || backend_session_id.is_empty() {
+        return Ok(());
+    }
+    let _guard = INDEX_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let any = with_index_unlocked(home, |index| {
+        index.wrappers.iter().any(|record| {
+            record.source == source && record.backend_session_id == backend_session_id
+        })
+    });
+    if !any {
+        return Ok(());
+    }
+    let mut index = with_index_unlocked(home, |index| index.clone());
+    for record in index
+        .wrappers
+        .iter_mut()
+        .filter(|record| record.source == source && record.backend_session_id == backend_session_id)
+    {
+        stamp(record);
+    }
+    write_index_unlocked(home, &index)?;
+    note_index_written(home, &index);
+    Ok(())
 }
 
 /// Resolve an arbitrary wrapper session id — active OR superseded — to its
@@ -1822,5 +2126,315 @@ mod tests {
             resolved_rollout_path(home.path(), "codex", backend_id, |_| true),
             None
         );
+    }
+
+    fn admission_home_with_wrapper(
+        wrapper_id: &str,
+        backend_id: &str,
+    ) -> (tempfile::TempDir, PathBuf) {
+        let home = tempfile::tempdir().unwrap();
+        let log_dir = home.path().join(".intendant").join("logs").join(wrapper_id);
+        std::fs::create_dir_all(&log_dir).unwrap();
+        upsert(
+            home.path(),
+            "claude-code",
+            backend_id,
+            wrapper_id,
+            &log_dir,
+            None,
+        )
+        .unwrap();
+        (home, log_dir)
+    }
+
+    fn active_rows_per_group(home: &Path) -> HashMap<(String, String), usize> {
+        let _guard = INDEX_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        with_index_unlocked(home, |index| {
+            let mut map: HashMap<(String, String), usize> = HashMap::new();
+            for record in &index.wrappers {
+                if record.state == WrapperState::Active {
+                    *map.entry((record.source.clone(), record.backend_session_id.clone()))
+                        .or_default() += 1;
+                }
+            }
+            map
+        })
+    }
+
+    /// The commission's pin: however upserts, backfills, and admissions
+    /// interleave, no `(source, backend_session_id)` group ever holds two
+    /// Active rows — that is the on-disk half of "one live wrapper per
+    /// backend lineage".
+    #[test]
+    fn wrapper_index_never_holds_two_active_entries_for_one_backend_group() {
+        let home = tempfile::tempdir().unwrap();
+        let backend_a = "5d000000-0000-4000-8000-00000000000a";
+        let backend_b = "5d000000-0000-4000-8000-00000000000b";
+        let wrappers = [
+            "aaaa0000-0000-4000-8000-000000000001",
+            "aaaa0000-0000-4000-8000-000000000002",
+            "aaaa0000-0000-4000-8000-000000000003",
+        ];
+        let dir_for = |wrapper: &str| {
+            let dir = home.path().join(".intendant").join("logs").join(wrapper);
+            std::fs::create_dir_all(&dir).unwrap();
+            dir
+        };
+        // Interleave activating upserts (identity commits), scan-shaped
+        // backfills, admissions with reservations, and cross-group
+        // wrapper reuse (a wrapper restarting onto another backend id).
+        let ops: Vec<Box<dyn Fn(&Path)>> = vec![
+            Box::new(move |h| {
+                upsert(
+                    h,
+                    "claude-code",
+                    backend_a,
+                    wrappers[0],
+                    &dir_for(wrappers[0]),
+                    None,
+                )
+                .unwrap();
+            }),
+            Box::new(move |h| {
+                backfill(
+                    h,
+                    "claude-code",
+                    backend_a,
+                    wrappers[1],
+                    &dir_for(wrappers[1]),
+                    None,
+                )
+                .unwrap();
+            }),
+            Box::new(move |h| {
+                let admission = admit(
+                    h,
+                    "claude-code",
+                    backend_a,
+                    WrapperLineageIntent::Restart,
+                    None,
+                )
+                .unwrap();
+                assert!(matches!(admission, WrapperAdmission::Admitted(_)));
+            }),
+            Box::new(move |h| {
+                upsert(
+                    h,
+                    "claude-code",
+                    backend_a,
+                    wrappers[1],
+                    &dir_for(wrappers[1]),
+                    None,
+                )
+                .unwrap();
+            }),
+            Box::new(move |h| {
+                upsert(
+                    h,
+                    "claude-code",
+                    backend_b,
+                    wrappers[1],
+                    &dir_for(wrappers[1]),
+                    None,
+                )
+                .unwrap();
+            }),
+            Box::new(move |h| {
+                backfill(
+                    h,
+                    "claude-code",
+                    backend_b,
+                    wrappers[2],
+                    &dir_for(wrappers[2]),
+                    None,
+                )
+                .unwrap();
+            }),
+            Box::new(move |h| {
+                upsert(
+                    h,
+                    "claude-code",
+                    backend_a,
+                    wrappers[2],
+                    &dir_for(wrappers[2]),
+                    None,
+                )
+                .unwrap();
+            }),
+        ];
+        for (step, op) in ops.iter().enumerate() {
+            op(home.path());
+            for (group, active) in active_rows_per_group(home.path()) {
+                assert!(
+                    active <= 1,
+                    "step {step}: group {group:?} holds {active} active rows"
+                );
+            }
+        }
+    }
+
+    /// The commission's pin: an owner stop is durable across a daemon
+    /// restart — the tombstone lives in the index FILE, and admission
+    /// refuses the automatic revival lane while it stands. A deliberate
+    /// Restart clears it.
+    #[test]
+    fn stop_tombstone_survives_daemon_restart() {
+        let backend_id = "5d100000-0000-4000-8000-000000000001";
+        let wrapper_id = "bbbb0000-0000-4000-8000-000000000001";
+        let (home, _log_dir) = admission_home_with_wrapper(wrapper_id, backend_id);
+
+        record_user_stop(home.path(), "claude-code", backend_id).unwrap();
+
+        // The tombstone is ON DISK (what a daemon restart re-reads), not
+        // only in this process's cache.
+        let raw = std::fs::read_to_string(index_path(home.path())).unwrap();
+        let disk: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert!(
+            disk["wrappers"][0]["stopped_by_user_at_secs"]
+                .as_u64()
+                .is_some(),
+            "{disk}"
+        );
+
+        // The automatic lane is refused…
+        match admit(
+            home.path(),
+            "claude-code",
+            backend_id,
+            WrapperLineageIntent::Resume,
+            None,
+        )
+        .unwrap()
+        {
+            WrapperAdmission::RefusedStopped { stopped_at_secs } => {
+                assert!(stopped_at_secs > 0);
+            }
+            other => panic!("expected RefusedStopped, got {other:?}"),
+        }
+        // …until the owner's deliberate gesture revives the lineage.
+        let admission = admit(
+            home.path(),
+            "claude-code",
+            backend_id,
+            WrapperLineageIntent::Restart,
+            None,
+        )
+        .unwrap();
+        assert!(matches!(admission, WrapperAdmission::Admitted(Some(_))));
+        let raw = std::fs::read_to_string(index_path(home.path())).unwrap();
+        assert!(
+            !raw.contains("stopped_by_user_at_secs"),
+            "tombstone must clear"
+        );
+    }
+
+    #[test]
+    fn admission_routes_resumes_to_live_wrappers_and_serializes_launches() {
+        let backend_id = "5d200000-0000-4000-8000-000000000001";
+        let wrapper_id = "cccc0000-0000-4000-8000-000000000001";
+        let (home, _log_dir) = admission_home_with_wrapper(wrapper_id, backend_id);
+
+        // A live wrapper absorbs resumes and revives instead of spawning.
+        match admit(
+            home.path(),
+            "claude-code",
+            backend_id,
+            WrapperLineageIntent::Resume,
+            Some(wrapper_id),
+        )
+        .unwrap()
+        {
+            WrapperAdmission::RouteToLive { wrapper_session_id } => {
+                assert_eq!(wrapper_session_id, wrapper_id);
+            }
+            other => panic!("expected RouteToLive, got {other:?}"),
+        }
+
+        // Restart supersedes the live wrapper: it takes the launch slot.
+        let first = admit(
+            home.path(),
+            "claude-code",
+            backend_id,
+            WrapperLineageIntent::Restart,
+            Some(wrapper_id),
+        )
+        .unwrap();
+        let WrapperAdmission::Admitted(Some(reservation)) = first else {
+            panic!("expected a reserved admission, got {first:?}");
+        };
+        // A second restart (or a resume) while the launch is in flight
+        // must not mint a second wrapper.
+        assert!(matches!(
+            admit(
+                home.path(),
+                "claude-code",
+                backend_id,
+                WrapperLineageIntent::Restart,
+                None
+            )
+            .unwrap(),
+            WrapperAdmission::AlreadyLaunching
+        ));
+        assert!(matches!(
+            admit(
+                home.path(),
+                "claude-code",
+                backend_id,
+                WrapperLineageIntent::Revive,
+                None
+            )
+            .unwrap(),
+            WrapperAdmission::AlreadyLaunching
+        ));
+        drop(reservation);
+        assert!(matches!(
+            admit(
+                home.path(),
+                "claude-code",
+                backend_id,
+                WrapperLineageIntent::Revive,
+                None
+            )
+            .unwrap(),
+            WrapperAdmission::Admitted(Some(_))
+        ));
+    }
+
+    #[test]
+    fn retired_lineage_refuses_revival_but_allows_explicit_forks() {
+        let backend_id = "5d300000-0000-4000-8000-000000000001";
+        let successor = "5d300000-0000-4000-8000-000000000002";
+        let wrapper_id = "dddd0000-0000-4000-8000-000000000001";
+        let (home, _log_dir) = admission_home_with_wrapper(wrapper_id, backend_id);
+
+        record_lineage_retired(home.path(), "claude-code", backend_id, successor).unwrap();
+
+        for intent in [
+            WrapperLineageIntent::Resume,
+            WrapperLineageIntent::Restart,
+            WrapperLineageIntent::Revive,
+        ] {
+            match admit(home.path(), "claude-code", backend_id, intent, None).unwrap() {
+                WrapperAdmission::RefusedRetired { successor: got } => {
+                    assert_eq!(got, successor, "{intent:?}");
+                }
+                other => panic!("{intent:?}: expected RefusedRetired, got {other:?}"),
+            }
+        }
+        // Branching a retired lineage stays legitimate.
+        assert!(matches!(
+            admit(
+                home.path(),
+                "claude-code",
+                backend_id,
+                WrapperLineageIntent::ForkChild,
+                None
+            )
+            .unwrap(),
+            WrapperAdmission::Admitted(None)
+        ));
     }
 }

--- a/src/bin/caller/session_supervisor/claude_edit.rs
+++ b/src/bin/caller/session_supervisor/claude_edit.rs
@@ -33,6 +33,12 @@ use super::*;
 /// handling treats it as a user-requested stop (`external_mode.rs`).
 pub(crate) const CLAUDE_EDIT_INPLACE_STOP_REASON: &str = "rewinding in place for an edited message";
 
+/// Stop reason the FORK rung uses on the parent it replaces: edit
+/// semantics are replace even on the last-resort rung, so the parent
+/// wrapper stops and the lineage retires to the child instead of
+/// staying alive beside it (RC1 of the 2026-07-27 incident).
+pub(crate) const CLAUDE_EDIT_SUPERSEDED_STOP_REASON: &str = "superseded by an edit branch";
+
 /// How long the ladder listens for the wire rung's outcome before
 /// reaping the listener task. NOT a fallback trigger: a queued edit on
 /// a parked wrapper may legitimately take hours, and racing surgery

--- a/src/bin/caller/session_supervisor/fork.rs
+++ b/src/bin/caller/session_supervisor/fork.rs
@@ -481,6 +481,40 @@ impl SessionSupervisor {
         match self.fork_claude_session(&session_token, &anchor).await {
             Ok((resolved_backend_id, child_uuid, kept_lines, parent_project_root)) => {
                 let child_short: String = child_uuid.chars().take(8).collect();
+                // Edit semantics are REPLACE even on this last-resort
+                // rung: the parent's continuation past the edited turn is
+                // semantically dead, so stop its live wrapper and retire
+                // the lineage to the child BEFORE activation — leaving
+                // both branches alive is how the 2026-07-27 duplicate
+                // orchestrators happened. The explicit fork verb
+                // (`fork_session_at_anchor`) deliberately does neither.
+                if let Some(live) = self
+                    .live_external_wrapper_for(
+                        "claude-code",
+                        &[&session_token, &resolved_backend_id],
+                    )
+                    .await
+                {
+                    if let Some(stopped) = self
+                        .stop_managed_session(Some(live), super::CLAUDE_EDIT_SUPERSEDED_STOP_REASON)
+                        .await
+                    {
+                        self.wait_for_stopped_session(stopped).await;
+                    }
+                }
+                if let Err(error) = crate::external_wrapper_index::record_lineage_retired(
+                    &self.logs_home(),
+                    "claude-code",
+                    &resolved_backend_id,
+                    &child_uuid,
+                ) {
+                    self.warn(&format!(
+                        "could not retire claude-code lineage {} to its edit branch {}: {}",
+                        short_session(&resolved_backend_id),
+                        child_short,
+                        error
+                    ));
+                }
                 self.announce_claude_fork(
                     "claude-code",
                     resolved_backend_id,

--- a/src/bin/caller/session_supervisor/launch.rs
+++ b/src/bin/caller/session_supervisor/launch.rs
@@ -934,6 +934,137 @@ impl SessionSupervisor {
             }
         };
 
+        // Lineage admission (external only): ONE live wrapper per backend
+        // lineage. Stopped/retired tombstones refuse the automatic lanes,
+        // resumes route to the live wrapper (liveness = open channel,
+        // never phase), and the launch reservation makes concurrent
+        // restart/resume races single-winner. The reservation is held
+        // until this call returns — the new wrapper is registered inside
+        // `spawn_agent_session` before then.
+        let mut _lineage_reservation: Option<
+            crate::external_wrapper_index::WrapperLaunchReservation,
+        > = None;
+        if external_backend.is_some() {
+            use crate::external_wrapper_index::{
+                admit, WrapperAdmission as Admission, WrapperLineageIntent as Intent,
+            };
+            let intent = if fork {
+                Intent::ForkChild
+            } else if force_new {
+                Intent::Restart
+            } else if auto_attach {
+                Intent::Resume
+            } else {
+                Intent::Revive
+            };
+            if let Some(backend_group_id) =
+                self.external_lineage_backend_id(&source_norm, &session_id, &resume_token)
+            {
+                let mut live = self
+                    .live_external_wrapper_for(
+                        &source_norm,
+                        &[&session_id, &resume_token, &backend_group_id],
+                    )
+                    .await;
+                if live.is_none() {
+                    // The lineage's indexed active wrapper may carry an id
+                    // the request never named.
+                    if let Some(indexed) = crate::external_wrapper_index::active_wrapper_for(
+                        &self.logs_home(),
+                        &source_norm,
+                        &backend_group_id,
+                    ) {
+                        live = self
+                            .live_external_wrapper_for(
+                                &source_norm,
+                                &[&indexed.intendant_session_id],
+                            )
+                            .await;
+                    }
+                }
+                match admit(
+                    &self.logs_home(),
+                    &source_norm,
+                    &backend_group_id,
+                    intent,
+                    live.as_deref(),
+                ) {
+                    Ok(Admission::Admitted(reservation)) => {
+                        _lineage_reservation = reservation;
+                    }
+                    Ok(Admission::RouteToLive { wrapper_session_id }) => {
+                        if let Some(task) = resume_task {
+                            self.route_follow_up(
+                                Some(wrapper_session_id),
+                                task,
+                                direct,
+                                attachments,
+                                None,
+                            )
+                            .await;
+                        } else {
+                            {
+                                let mut state = self.state.lock().await;
+                                state.active_session_id = Some(wrapper_session_id);
+                            }
+                            self.emit_attached_status(&resume_token, &source_norm).await;
+                            self.config.bus.send(AppEvent::SessionAttached {
+                                session_id: resume_token.clone(),
+                                source: source_norm.clone(),
+                            });
+                        }
+                        return;
+                    }
+                    Ok(Admission::AlreadyLaunching) => {
+                        let message = format!(
+                            "{} session {} is already starting — not spawning a second wrapper",
+                            source_norm,
+                            short_session(&backend_group_id)
+                        );
+                        self.warn(&message);
+                        self.ack_targeted_action_noop(&resume_token, &message);
+                        return;
+                    }
+                    Ok(Admission::RefusedStopped { stopped_at_secs }) => {
+                        let age_minutes = std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .map(|now| now.as_secs().saturating_sub(stopped_at_secs) / 60)
+                            .unwrap_or(0);
+                        let message = format!(
+                            "{} session {} was stopped by you {} minute(s) ago — automatic revival is off; use Restart (or resume it deliberately) to revive it",
+                            source_norm,
+                            short_session(&backend_group_id),
+                            age_minutes
+                        );
+                        self.warn(&message);
+                        self.ack_targeted_action_noop(&resume_token, &message);
+                        return;
+                    }
+                    Ok(Admission::RefusedRetired { successor }) => {
+                        let message = format!(
+                            "{} session {} was replaced by an edit branch — continue in {} instead",
+                            source_norm,
+                            short_session(&backend_group_id),
+                            short_session(&successor)
+                        );
+                        self.warn(&message);
+                        self.ack_targeted_action_noop(&resume_token, &message);
+                        return;
+                    }
+                    Err(error) => {
+                        // A broken index must not brick resumes; say so
+                        // loudly and proceed unguarded.
+                        self.warn(&format!(
+                            "wrapper-index admission unavailable for {} session {}: {} — proceeding without the lineage gate",
+                            source_norm,
+                            short_session(&backend_group_id),
+                            error
+                        ));
+                    }
+                }
+            }
+        }
+
         if resume_task.is_none() {
             if let Some(existing_id) = self
                 .find_managed_session_id(&source_norm, &session_id, &resume_token)
@@ -1298,6 +1429,83 @@ impl SessionSupervisor {
                             .map(|_| resolved)
                     })
             })
+    }
+
+    /// The LIVE wrapper for an external lineage: a supervisor entry with
+    /// an OPEN follow-up channel — liveness, never phase. This is the
+    /// admission-side twin of [`Self::find_managed_session_id`], which
+    /// keeps its phase filter for input-delivery decisions: a wrapper
+    /// whose phase says "done" but which still holds its channel is
+    /// alive (it serves follow-ups and must be stoppable/supersedable),
+    /// and conflating the two is how the 2026-07-27 incident's restarts
+    /// minted duplicate wrappers.
+    pub(crate) async fn live_external_wrapper_for(
+        &self,
+        source: &str,
+        candidate_ids: &[&str],
+    ) -> Option<String> {
+        let state = self.state.lock().await;
+        let live = |session: &ManagedSession| {
+            session.source == source && !session.follow_up_tx.is_closed()
+        };
+        state
+            .sessions
+            .values()
+            .find(|session| live(session) && candidate_ids.contains(&session.session_id.as_str()))
+            .map(|session| session.session_id.clone())
+            .or_else(|| {
+                candidate_ids.iter().find_map(|candidate| {
+                    let resolved = state.resolve_session_id(candidate)?;
+                    state
+                        .sessions
+                        .get(&resolved)
+                        .filter(|session| live(session))
+                        .map(|_| resolved)
+                })
+            })
+    }
+
+    /// Resolve the backend lineage group id an external resume/restart
+    /// addresses, for [`crate::external_wrapper_index::admit`]: the
+    /// wrapper index first (works for wrapper ids and backend ids
+    /// alike), then persisted identity, then the token itself when it is
+    /// already a canonical backend id for the source. `None` means the
+    /// lineage has no resolvable group (a fresh backend id the store has
+    /// never seen) — admission is skipped, exactly like today.
+    pub(crate) fn external_lineage_backend_id(
+        &self,
+        source: &str,
+        session_id: &str,
+        resume_token: &str,
+    ) -> Option<String> {
+        let home = self.logs_home();
+        for candidate in [resume_token, session_id] {
+            let candidate = candidate.trim();
+            if candidate.is_empty() {
+                continue;
+            }
+            if let Some((indexed_source, backend_id)) =
+                crate::external_wrapper_index::conversation_for_wrapper(&home, candidate)
+            {
+                if indexed_source == source {
+                    return Some(backend_id);
+                }
+            }
+            if !crate::external_wrapper_index::wrappers_for(&home, source, candidate).is_empty() {
+                return Some(candidate.to_string());
+            }
+            if let Some((persisted_source, backend_id)) =
+                persisted_external_identity_for_session_in_home(&home, candidate)
+            {
+                if persisted_source == source {
+                    return Some(backend_id);
+                }
+            }
+            if crate::external_agent::source_session_id_is_canonical(source, candidate) {
+                return Some(candidate.to_string());
+            }
+        }
+        None
     }
 }
 

--- a/src/bin/caller/session_supervisor/mod.rs
+++ b/src/bin/caller/session_supervisor/mod.rs
@@ -23,7 +23,7 @@ pub(crate) use routing::*;
 mod agent_config;
 pub(crate) use agent_config::*;
 mod claude_edit;
-pub(crate) use claude_edit::CLAUDE_EDIT_INPLACE_STOP_REASON;
+pub(crate) use claude_edit::{CLAUDE_EDIT_INPLACE_STOP_REASON, CLAUDE_EDIT_SUPERSEDED_STOP_REASON};
 mod dispatch;
 mod fork;
 mod registry;
@@ -130,7 +130,6 @@ impl ForegroundSupervisorHandle {
 
 const EXTERNAL_ATTACH_READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 const SESSION_STOP_WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
-const SESSION_RESTART_DEDUPE_WINDOW: std::time::Duration = std::time::Duration::from_secs(5);
 /// Bound on the peer-delegation dedup ledger (`delegation_receipts`).
 /// Entries only need to outlive the delegating side's bounded re-send
 /// window (~30 s), so a FIFO of this size is generous; the bound keeps
@@ -160,7 +159,6 @@ pub(crate) struct SupervisorState {
     related_sessions: HashMap<String, RelatedSession>,
     active_session_id: Option<String>,
     next_session_instance: u64,
-    restart_dedupe: HashMap<String, std::time::Instant>,
     external_attach_dedupe: HashMap<String, std::time::Instant>,
     /// Ids (wrapper AND native) of every external session that announced a
     /// SessionIdentity on this bus — including sessions the supervisor does
@@ -444,18 +442,6 @@ impl SupervisorState {
             return None;
         }
         self.remove_session(&canonical)
-    }
-
-    fn mark_restart_requested(&mut self, key: &str) -> bool {
-        let now = std::time::Instant::now();
-        self.restart_dedupe
-            .retain(|_, expires_at| *expires_at > now);
-        if self.restart_dedupe.contains_key(key) {
-            return false;
-        }
-        self.restart_dedupe
-            .insert(key.to_string(), now + SESSION_RESTART_DEDUPE_WINDOW);
-        true
     }
 
     fn mark_external_attach_requested(&mut self, keys: &[String]) -> bool {
@@ -1023,15 +1009,6 @@ mod tests {
         assert!(state.session_is_managed("thread"));
         assert!(state.remove_session_instance("thread", 1).is_some());
         assert!(!state.session_is_managed("thread"));
-    }
-
-    #[test]
-    fn supervisor_state_dedupes_concurrent_restart_requests() {
-        let mut state = SupervisorState::default();
-
-        assert!(state.mark_restart_requested("codex:thread"));
-        assert!(!state.mark_restart_requested("codex:thread"));
-        assert!(state.mark_restart_requested("codex:other-thread"));
     }
 
     /// The user-halt ledger behind the auto-attach cancel: marks are

--- a/src/bin/caller/session_supervisor/routing.rs
+++ b/src/bin/caller/session_supervisor/routing.rs
@@ -778,7 +778,7 @@ impl SessionSupervisor {
     /// render in that session's window through the ordinary log lane, so a
     /// targeted user action never evaporates silently (`route_interrupt`'s
     /// `Interrupted` ack is the twin of this pattern).
-    fn ack_targeted_action_noop(&self, session_id: &str, content: &str) {
+    pub(crate) fn ack_targeted_action_noop(&self, session_id: &str, content: &str) {
         self.config.bus.send(AppEvent::LogEntry {
             session_id: Some(session_id.to_string()),
             level: "warn".to_string(),
@@ -911,6 +911,30 @@ impl SessionSupervisor {
             self.ack_targeted_action_noop(&target_id, "Session already ended — nothing to stop.");
             return None;
         };
+        // An owner stop is TERMINAL for the lineage: write the durable
+        // tombstone (it survives daemon restarts) so no automatic lane —
+        // auto-attach escalation, follow-up-driven resume — stands the
+        // lineage back up. Only the owner's deliberate Restart/resume
+        // revives it (`external_wrapper_index::admit`). In-memory halt
+        // marks stay as the fast secondary for pre-identity sessions.
+        if reason == "stopped by user" && session.source != "intendant" {
+            if let Some(backend_group_id) =
+                self.external_lineage_backend_id(&session.source, &canonical, &canonical)
+            {
+                if let Err(error) = crate::external_wrapper_index::record_user_stop(
+                    &self.logs_home(),
+                    &session.source,
+                    &backend_group_id,
+                ) {
+                    self.warn(&format!(
+                        "could not record the stop tombstone for {} session {}: {}",
+                        session.source,
+                        short_session(&backend_group_id),
+                        error
+                    ));
+                }
+            }
+        }
         self.config.bus.send(AppEvent::SessionStopRequested {
             session_id: Some(canonical.clone()),
             reason: reason.to_string(),
@@ -965,20 +989,37 @@ impl SessionSupervisor {
             return;
         }
         let resume_token = resume_id.clone().unwrap_or_else(|| session_id.clone());
-        let restart_key = format!("{}:{}", source_norm, resume_token);
+        // A retired lineage (replaced by an edit branch) refuses the
+        // restart BEFORE anything is stopped: standing the parent back up
+        // beside its replacement is the duplicate-orchestrator shape.
+        // Concurrent-restart dedupe is the admission gate's launch
+        // reservation inside `resume_session` — the old time-window
+        // heuristic (`mark_restart_requested`) is retired.
+        if let Some(backend_group_id) =
+            self.external_lineage_backend_id(&source_norm, &session_id, &resume_token)
         {
-            let mut state = self.state.lock().await;
-            if !state.mark_restart_requested(&restart_key) {
-                drop(state);
-                self.warn(&format!(
-                    "Restart session ignored: {} was already restarted recently",
-                    short_session(&resume_token)
-                ));
+            let (_, successor) = crate::external_wrapper_index::lineage_tombstones(
+                &self.logs_home(),
+                &source_norm,
+                &backend_group_id,
+            );
+            if let Some(successor) = successor {
+                let message = format!(
+                    "{} session {} was replaced by an edit branch — continue in {} instead",
+                    source_norm,
+                    short_session(&backend_group_id),
+                    short_session(&successor)
+                );
+                self.warn(&message);
+                self.ack_targeted_action_noop(&resume_token, &message);
                 return;
             }
         }
+        // Liveness, never phase: a wrapper whose phase chip says "done"
+        // but which still holds its follow-up channel is alive and must
+        // be superseded, or the restart mints a duplicate beside it.
         if let Some(existing_id) = self
-            .find_managed_session_id(&source_norm, &session_id, &resume_token)
+            .live_external_wrapper_for(&source_norm, &[&session_id, &resume_token])
             .await
         {
             if let Some(stopped) = self
@@ -3865,5 +3906,195 @@ mod tests {
         )
         .is_none());
         assert!(edit_attach_request(None, None, None, None).is_none());
+    }
+
+    /// Hermetic lineage rig: a persisted wrapper (log dir + index row)
+    /// for a claude-code backend id under a temp home, plus a supervisor
+    /// whose persisted-session resolution reads that home.
+    fn lineage_rig(
+        backend_id: &str,
+        wrapper_id: &str,
+    ) -> (
+        tempfile::TempDir,
+        tempfile::TempDir,
+        SessionSupervisor,
+        EventBus,
+    ) {
+        let home = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let log_dir = home.path().join(".intendant").join("logs").join(wrapper_id);
+        std::fs::create_dir_all(&log_dir).unwrap();
+        crate::external_wrapper_index::upsert(
+            home.path(),
+            "claude-code",
+            backend_id,
+            wrapper_id,
+            &log_dir,
+            None,
+        )
+        .unwrap();
+        let bus = EventBus::new();
+        let mut config =
+            (*test_supervisor(project.path().to_path_buf(), bus.clone()).config).clone();
+        config.logs_home_override = Some(home.path().to_path_buf());
+        let supervisor = SessionSupervisor::new(config);
+        (home, project, supervisor, bus)
+    }
+
+    /// The commission's pin: a restart (or resume) aimed at a lineage
+    /// that was RETIRED to an edit-branch successor spawns nothing,
+    /// stops nothing, and answers with the successor — the parent stands
+    /// down instead of being stood back up beside its replacement.
+    #[tokio::test]
+    async fn respawn_finds_successor_and_stands_down() {
+        let backend_id = "6d000000-0000-4000-8000-000000000001";
+        let successor = "6d000000-0000-4000-8000-000000000002";
+        let wrapper_id = "eeee0000-0000-4000-8000-000000000001";
+        let (home, project, supervisor, bus) = lineage_rig(backend_id, wrapper_id);
+        crate::external_wrapper_index::record_lineage_retired(
+            home.path(),
+            "claude-code",
+            backend_id,
+            successor,
+        )
+        .unwrap();
+
+        // A live wrapper for the retired parent (the incident's shape:
+        // the parent lingered attachable). The refusal must leave it
+        // untouched — refusing means refusing, not stop-then-refuse.
+        let (tx, mut rx) = mpsc::channel(1);
+        {
+            let mut state = supervisor.state.lock().await;
+            let mut session = managed_session(backend_id, "claude-code");
+            session.project_root = project.path().to_path_buf();
+            session.follow_up_tx = tx;
+            state.sessions.insert(backend_id.to_string(), session);
+        }
+
+        let mut bus_rx = bus.subscribe();
+        supervisor
+            .restart_session(
+                "claude-code".to_string(),
+                backend_id.to_string(),
+                Some(backend_id.to_string()),
+                None,
+                None,
+                Some(true),
+                Vec::new(),
+                LaunchOverrides::default(),
+            )
+            .await;
+
+        assert_eq!(
+            supervisor.state.lock().await.sessions.len(),
+            1,
+            "the retired lineage must not be respawned"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "no delivery and no stop may reach the standing wrapper"
+        );
+        let mut saw_successor_pointer = false;
+        while let Ok(event) = bus_rx.try_recv() {
+            if let AppEvent::LogEntry { content, .. } = event {
+                if content.contains("replaced by an edit branch")
+                    && content.contains(&successor[..8])
+                {
+                    saw_successor_pointer = true;
+                }
+            }
+        }
+        assert!(saw_successor_pointer, "the refusal must name the successor");
+    }
+
+    /// Liveness, never phase: a wrapper whose phase says "done" but
+    /// whose follow-up channel is open absorbs a task-carrying resume as
+    /// a follow-up instead of a second wrapper being spawned beside it.
+    #[tokio::test]
+    async fn resume_routes_to_live_wrapper_regardless_of_phase() {
+        let backend_id = "6d100000-0000-4000-8000-000000000001";
+        let wrapper_id = "eeee0000-0000-4000-8000-000000000011";
+        let (_home, project, supervisor, _bus) = lineage_rig(backend_id, wrapper_id);
+
+        let (tx, mut rx) = mpsc::channel(4);
+        {
+            let mut state = supervisor.state.lock().await;
+            let mut session = managed_session(backend_id, "claude-code");
+            session.project_root = project.path().to_path_buf();
+            session.phase = "done".to_string();
+            session.follow_up_tx = tx;
+            state.sessions.insert(backend_id.to_string(), session);
+        }
+
+        supervisor
+            .resume_session(
+                "claude-code".to_string(),
+                backend_id.to_string(),
+                Some(backend_id.to_string()),
+                None,
+                Some("follow this up".to_string()),
+                Some(true),
+                Vec::new(),
+                false,
+                None,
+                LaunchOverrides::default(),
+                false,
+                false,
+            )
+            .await;
+
+        let delivered = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv())
+            .await
+            .expect("task delivered to the done-phase live wrapper")
+            .expect("channel open");
+        assert_eq!(delivered.text, "follow this up");
+        assert_eq!(
+            supervisor.state.lock().await.sessions.len(),
+            1,
+            "no second wrapper may be spawned for a live lineage"
+        );
+    }
+
+    /// A stopped lineage's tombstone blocks the AUTOMATIC revival lane
+    /// (auto-attach escalation) with an honest answer and no spawn.
+    #[tokio::test]
+    async fn stopped_lineage_refuses_auto_attach_revival() {
+        let backend_id = "6d200000-0000-4000-8000-000000000001";
+        let wrapper_id = "eeee0000-0000-4000-8000-000000000021";
+        let (home, _project, supervisor, bus) = lineage_rig(backend_id, wrapper_id);
+        crate::external_wrapper_index::record_user_stop(home.path(), "claude-code", backend_id)
+            .unwrap();
+
+        let mut bus_rx = bus.subscribe();
+        supervisor
+            .resume_session(
+                "claude-code".to_string(),
+                backend_id.to_string(),
+                Some(backend_id.to_string()),
+                None,
+                Some("the halted prompt".to_string()),
+                Some(true),
+                Vec::new(),
+                false,
+                None,
+                LaunchOverrides::default(),
+                false,
+                true, // auto_attach: the frontend escalation lane
+            )
+            .await;
+
+        assert!(
+            supervisor.state.lock().await.sessions.is_empty(),
+            "a stopped lineage must not be auto-revived"
+        );
+        let mut saw_refusal = false;
+        while let Ok(event) = bus_rx.try_recv() {
+            if let AppEvent::LogEntry { content, .. } = event {
+                if content.contains("stopped by you") {
+                    saw_refusal = true;
+                }
+            }
+        }
+        assert!(saw_refusal, "the refusal must be reported honestly");
     }
 }

--- a/static/app.html
+++ b/static/app.html
@@ -36882,7 +36882,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '7c3292466b6aa287';
+const INTENDANT_APP_BUILD = 'd176cbd77cce5465';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -68590,15 +68590,18 @@ function sessionWindowExternalActionAvailability(sessionId) {
 
 function sessionWindowStopAvailability(sessionId) {
   const sid = String(sessionId || '').trim();
-  // A window in a terminal phase has nothing left to stop — retire the
-  // Stop affordance (Close/Hide stays available) instead of dispatching
-  // a stop the daemon can only drop (live incident 2026-07-17: repeated
-  // Stop clicks on an ended session read as "can't stop this session").
+  // Liveness, never phase: only the daemon's own end signals
+  // (SessionEnded → win.ended, store-level terminal status) retire the
+  // Stop affordance. Phase is a chip, not liveness — an external
+  // wrapper whose phase says "done" (or which is parked on a rate
+  // limit) still holds its follow-up channel and MUST stay stoppable:
+  // keying Stop on phase left the 2026-07-27 runaway pair unstoppable
+  // for 51 minutes while Restart kept reviving it. A stop dispatched to
+  // a genuinely dead session gets the daemon's honest "already ended"
+  // ack (the 2026-07-17 concern), which is the correct answer.
   const win = sessionWindows.get(sid);
   const meta = sessionMetadataById.get(sid) || {};
-  const phase = normalizeSessionPhase(win?.phase || meta.phase || '');
   const terminal = !!win?.ended || meta.ended === true
-    || phase === 'done' || phase === 'interrupted'
     || promptTargetTerminalStatus(meta);
   if (terminal) {
     return {

--- a/static/app/40-session-launch.js
+++ b/static/app/40-session-launch.js
@@ -3086,15 +3086,18 @@ function sessionWindowExternalActionAvailability(sessionId) {
 
 function sessionWindowStopAvailability(sessionId) {
   const sid = String(sessionId || '').trim();
-  // A window in a terminal phase has nothing left to stop — retire the
-  // Stop affordance (Close/Hide stays available) instead of dispatching
-  // a stop the daemon can only drop (live incident 2026-07-17: repeated
-  // Stop clicks on an ended session read as "can't stop this session").
+  // Liveness, never phase: only the daemon's own end signals
+  // (SessionEnded → win.ended, store-level terminal status) retire the
+  // Stop affordance. Phase is a chip, not liveness — an external
+  // wrapper whose phase says "done" (or which is parked on a rate
+  // limit) still holds its follow-up channel and MUST stay stoppable:
+  // keying Stop on phase left the 2026-07-27 runaway pair unstoppable
+  // for 51 minutes while Restart kept reviving it. A stop dispatched to
+  // a genuinely dead session gets the daemon's honest "already ended"
+  // ack (the 2026-07-17 concern), which is the correct answer.
   const win = sessionWindows.get(sid);
   const meta = sessionMetadataById.get(sid) || {};
-  const phase = normalizeSessionPhase(win?.phase || meta.phase || '');
   const terminal = !!win?.ended || meta.ended === true
-    || phase === 'done' || phase === 'interrupted'
     || promptTargetTerminalStatus(meta);
   if (terminal) {
     return {


### PR DESCRIPTION
Second of three separable PRs from the pencil-edit in-place + lineage exactly-once commission (agenda item 01KYJVDKVSS7ZHQG7X5EHXWRBY). **Stacked on #624** — its base diff includes PR-1 until #624 merges, then collapses to this commit alone.

No component owned "one live execution per logical session" (the incident's RC2/RC3). This PR makes the wrapper index the admission gate:

- **`admit(source, backend_id, intent, live_wrapper)`** under the existing `INDEX_LOCK`: resumes route to the lineage's live wrapper (**liveness = open follow-up channel, never phase**); restarts supersede transactionally via a launch reservation held until the new wrapper registers (concurrent restart/resume races are single-winner; `mark_restart_requested`'s time-window heuristic retired); fork children never contend.
- **`Stopped{by_user}`**: an owner stop writes a durable tombstone (survives daemon restarts); automatic revival lanes are refused honestly; only a deliberate Restart/resume revives.
- **`Retired{successor}`**: the edit ladder's fork rung now stops the parent and retires the lineage to the edit-branch child before activation — restart/resume of the parent answers with the successor and stands down. The explicit "Fork from here" verb still branches without retiring.
- **Dashboard Stop keys on daemon liveness, never phase** (40-session-launch.js): a limit-parked or phase-done live wrapper stays stoppable — the single UX change that would have ended the incident at 16:51.

**Pins:** `wrapper_index_never_holds_two_active_entries_for_one_backend_group`, `stop_tombstone_survives_daemon_restart`, `respawn_finds_successor_and_stands_down`, + `resume_routes_to_live_wrapper_regardless_of_phase`, `stopped_lineage_refuses_auto_attach_revival`, admission reservation/retired/fork semantics.

Battery: 5289 bin tests, 33 e2e, clippy -D warnings, fmt --check — green.

PR-3 (fork fidelity) follows.