### PR TITLE
feat(agenda): occurrence terminals follow resume lineage (shared successor resolver)

### DIFF
--- a/docs/src/agenda-and-memory.md
+++ b/docs/src/agenda-and-memory.md
@@ -478,6 +478,20 @@ External occurrences complete like native ones: a clean round journals
 recovery exhausted — emitter-typed on the bus event, never inferred
 from reason prose) journals `failed`, counts the failure streak, and
 suspends the series at the threshold exactly as a native run would.
+An external session's *end*, though, is not yet a verdict: the owner's
+Restart-with-saved-config and edit-branch gestures supersede the wrapper
+while the work continues under a resume-lineage successor, so terminal
+classification walks the lineage first — from durable state only
+(session-dir identity facts, wrapper-index rows and retirement edges,
+via the one resolver shared with the agenda-answer delivery arm) — and
+terminals only when the lineage is quiet. An owner Stop tombstone is
+quiet by decree (`failed` immediately); an admitted successor re-keys
+the occurrence to the lineage tip (a fresh `started` journal row and
+item write-back name it, and later terminals attribute to it, at any
+chain depth); a wrapper-backed end with no successor visible yet holds
+for a bounded grace window (60 s) before journaling `failed` with the
+original reason. Native sessions have no wrapper lineage and classify
+immediately, as before.
 
 **Interactive is the default** (`interactive`, additive on the manifest):
 the spawned session opens with the goal as its first user message and then

--- a/src/bin/caller/agenda/reminders.rs
+++ b/src/bin/caller/agenda/reminders.rs
@@ -328,7 +328,15 @@ impl OccurrenceState {
 pub(crate) struct OccurrenceProgress {
     pub(crate) prepared: bool,
     /// Session id from a `started` record, while no terminal followed.
+    /// Last wins: a resume-lineage re-key journals a fresh `started` row
+    /// naming the successor, so recovery and attribution follow the tip.
     pub(crate) started: Option<String>,
+    /// EVERY session id a `started` row ever named, in order — the
+    /// loop-exclusion source: a lineage re-key must not drop the
+    /// original session from [`OccurrenceJournal::started_sessions_for_item`]
+    /// (items it parked before the supersede would otherwise re-fire the
+    /// effect that spawned it).
+    pub(crate) started_history: Vec<String>,
     pub(crate) terminal: Option<OccurrenceState>,
     /// The owning item, retained from the journal rows so boot recovery
     /// can write a fail-closed outcome back to the item even for
@@ -380,10 +388,12 @@ impl OccurrenceJournal {
     /// Session ids this item's occurrences have STARTED with, from the
     /// journal fold — the verified-attribution loop-exclusion key
     /// (Track T, T0 ruling 7 direct branch): an item parked by one of
-    /// these sessions never re-fires this item's effect. Durable across
-    /// restarts because the journal is; keyed on the gate-resolved
-    /// session id the write-back recorded, never on `--source` or any
-    /// text a mandate controls.
+    /// these sessions never re-fires this item's effect. Every session a
+    /// `started` row EVER named counts (a resume-lineage re-key appends
+    /// the successor without un-attributing the superseded original).
+    /// Durable across restarts because the journal is; keyed on the
+    /// gate-resolved session id the write-back recorded, never on
+    /// `--source` or any text a mandate controls.
     pub(crate) fn started_sessions_for_item(
         &self,
         item_id: &str,
@@ -391,7 +401,7 @@ impl OccurrenceJournal {
         self.state
             .values()
             .filter(|progress| progress.item_id.as_deref() == Some(item_id))
-            .filter_map(|progress| progress.started.clone())
+            .flat_map(|progress| progress.started_history.iter().cloned())
             .collect()
     }
 
@@ -626,6 +636,11 @@ fn fold_record_into(entry: &mut OccurrenceProgress, record: &OccurrenceRecord) {
         OccurrenceState::Started => {
             entry.prepared = true;
             entry.started = record.session_id.clone();
+            if let Some(session_id) = record.session_id.as_ref() {
+                if !entry.started_history.contains(session_id) {
+                    entry.started_history.push(session_id.clone());
+                }
+            }
         }
         state => entry.terminal = Some(state),
     }

--- a/src/bin/caller/agenda/scheduler.rs
+++ b/src/bin/caller/agenda/scheduler.rs
@@ -2788,7 +2788,11 @@ mod tests {
             journal.progress(&occurrence_id).terminal.is_none(),
             "an end with live wrapper lineage must not terminal the occurrence"
         );
-        assert_eq!(state.lineage_pending.len(), 1, "the end is held, not dropped");
+        assert_eq!(
+            state.lineage_pending.len(),
+            1,
+            "the end is held, not dropped"
+        );
         assert!(
             state.running.contains_key("wrapper-old"),
             "the occurrence stays in-flight while held"

--- a/src/bin/caller/agenda/scheduler.rs
+++ b/src/bin/caller/agenda/scheduler.rs
@@ -41,6 +41,16 @@ const SESSION_ALIAS_CAP: usize = 64;
 /// Re-send an un-receipted dispatch after this long (at-least-once
 /// delivery; the supervisor's delegation dedup makes duplicates safe).
 const DISPATCH_RETRY_AFTER_MS: u64 = 30_000;
+/// How long a wrapper-backed session's end may wait for its resume-lineage
+/// successor before the occurrence terminals `failed`. Every supersede lane
+/// (owner Restart with saved config, the edit-branch fork) emits
+/// `SessionEnded` on the OLD wrapper BEFORE the successor's durable trace
+/// lands (admission, then the eager resume identity writes the index row —
+/// seconds later), so terminal classification must out-wait that window or
+/// it fails occurrences whose work continues under the successor. Bounded:
+/// a genuinely dead session's `failed` write-back arrives at worst this
+/// much later, and nothing user-blocking hangs on it.
+const LINEAGE_QUIET_GRACE_MS: u64 = 60_000;
 /// Give up on an un-receipted dispatch after this long: journal the
 /// fail-closed `unknown` (never auto-retried past this point) and free
 /// the effect's in-flight slot.
@@ -60,6 +70,25 @@ struct EarlyOutcome {
     /// `Some(reason)` = the session ended without finishing.
     failed: Option<String>,
     note: String,
+}
+
+/// A running scheduled session whose `SessionEnded` arrived while its
+/// resume lineage may still continue elsewhere: the session has recorded
+/// external-wrapper history, no owner-stop tombstone, and no admitted
+/// successor visible in durable state YET (the supersede lanes stop the
+/// old wrapper before the successor registers). Held un-classified until
+/// the successor appears (re-key) or [`LINEAGE_QUIET_GRACE_MS`] expires
+/// with the lineage still quiet (`failed`, the honest terminal). The
+/// running entry stays in place meanwhile, so the no-overlap rule keeps
+/// counting the occurrence as in-flight.
+struct PendingLineageEnd {
+    /// The `running` map key at end time (the receipt id, or its aliased
+    /// upgrade — whatever `running_key` resolved).
+    session_key: String,
+    /// The id the end event named (a walk seed alongside the key).
+    ended_id: String,
+    reason: String,
+    ended_at_ms: u64,
 }
 
 /// A dispatched occurrence still waiting for its `TaskReceived` receipt,
@@ -107,6 +136,9 @@ struct SchedulerState {
     /// native id and the occurrence sat `started` forever). Both
     /// directions resolve; bounded, oldest evicted, newest pair wins.
     session_aliases: Vec<(String, String)>,
+    /// Ended-but-unclassified running sessions awaiting their resume
+    /// lineage (see [`PendingLineageEnd`]); swept on every wake.
+    lineage_pending: Vec<PendingLineageEnd>,
 }
 
 impl SchedulerState {
@@ -216,10 +248,11 @@ pub(crate) fn spawn_reminder_scheduler(handle: Arc<AgendaHandle>) -> tokio::task
             let next_wake_ms = run_pass(&handle, &mut journal, &mut state).await;
             let now = now_ms();
             let retry_wake_ms = sweep_pending_dispatches(&handle, &mut journal, &mut state, now);
-            let next_wake_ms = match (next_wake_ms, retry_wake_ms) {
-                (Some(a), Some(b)) => Some(a.min(b)),
-                (wake, None) | (None, wake) => wake,
-            };
+            let lineage_wake_ms = sweep_lineage_pending(&handle, &mut journal, &mut state, now);
+            let next_wake_ms = [next_wake_ms, retry_wake_ms, lineage_wake_ms]
+                .into_iter()
+                .flatten()
+                .min();
             let sleep_for = next_wake_ms
                 .map(|wake| std::time::Duration::from_millis(wake.saturating_sub(now)))
                 .map_or(SAFETY_TICK, |until| until.min(SAFETY_TICK));
@@ -387,6 +420,12 @@ fn resolve_lagged_occurrences(
             resolved += 1;
         }
     }
+    // Held lineage ends belong to running entries; drop the ones whose
+    // entry the fail-close just resolved.
+    let running = &state.running;
+    state
+        .lineage_pending
+        .retain(|entry| running.contains_key(&entry.session_key));
 
     resolved
 }
@@ -729,11 +768,19 @@ fn observe_event(
             // remembered outcome resolves the occurrence now, keeping the
             // journal arc in order (started, then the terminal). The
             // aliased lookup covers a terminal that arrived under an
-            // already-upgraded address.
+            // already-upgraded address. A remembered END goes through
+            // lineage classification like a live one: when a successor was
+            // admitted the occurrence follows it; with no successor it
+            // still fails.
             if let Some(early) = state.take_early_outcome_aliased(session_id) {
                 match early.failed {
                     None => complete_running(handle, journal, state, session_id, early.note),
-                    Some(reason) => fail_running(handle, journal, state, session_id, &reason),
+                    Some(reason) => {
+                        let now = now_ms();
+                        classify_ended_running_session(
+                            handle, journal, state, session_id, session_id, &reason, now, now,
+                        );
+                    }
                 }
             }
         }
@@ -801,12 +848,19 @@ fn observe_event(
         } => {
             // Normal completion removes the entry first (supervised
             // sessions park after done); a RUNNING session reaching here
-            // stopped or errored before finishing — and pre-receipt the
-            // same end is remembered as a failed outcome (first terminal
-            // per session wins, so a done session's later end never
-            // downgrades its completion).
+            // stopped or errored before finishing — but an end is not yet
+            // a verdict: the owner's Restart/edit supersede ends the
+            // wrapper while the work continues under a resume-lineage
+            // successor, so classification walks the lineage first
+            // (terminal only when it is quiet). Pre-receipt the same end
+            // is remembered as a failed outcome and classified by the
+            // receipt (first terminal per session wins, so a done
+            // session's later end never downgrades its completion).
             if let Some(key) = state.running_key(session_id) {
-                fail_running(handle, journal, state, &key, reason);
+                let now = now_ms();
+                classify_ended_running_session(
+                    handle, journal, state, &key, session_id, reason, now, now,
+                );
             } else {
                 state.remember_early_outcome(
                     session_id,
@@ -875,6 +929,179 @@ fn complete_running(
         Some(session_id.to_string()),
         Some(note),
     );
+}
+
+/// Terminal classification for a RUNNING scheduled session that ended:
+/// the resume lineage decides, from durable state only
+/// ([`crate::session_supervisor::resume_lineage`] — the walker shared
+/// with the agenda-answer delivery arm), and the occurrence terminals
+/// only when the lineage is quiet:
+///
+/// - an owner-stop tombstone anywhere in the chain is quiet BY DECREE
+///   (the Stop lane stamps it before emitting the end) — `failed` now;
+/// - an admitted successor (active wrapper past the ended ids) means the
+///   work continues — the occurrence re-keys to the lineage tip and no
+///   terminal fires;
+/// - no wrapper history at all (native sessions, mock e2e) classifies
+///   immediately — today's behavior, unchanged;
+/// - wrapper history but no successor visible YET defers up to
+///   [`LINEAGE_QUIET_GRACE_MS`] from the end instant (the supersede
+///   lanes end the old wrapper seconds before the successor's index row
+///   lands), then fails with the original reason.
+#[allow(clippy::too_many_arguments)] // internal classification core: the params are the event facts
+fn classify_ended_running_session(
+    handle: &AgendaHandle,
+    journal: &mut OccurrenceJournal,
+    state: &mut SchedulerState,
+    session_key: &str,
+    ended_id: &str,
+    reason: &str,
+    ended_at_ms: u64,
+    now: u64,
+) {
+    if !state.running.contains_key(session_key) {
+        return;
+    }
+    let mut ended_ids: Vec<String> = vec![session_key.to_string()];
+    if ended_id != session_key {
+        ended_ids.push(ended_id.to_string());
+    }
+    if let Some(counterpart) = state.alias_counterpart(session_key) {
+        if !ended_ids.iter().any(|id| id == counterpart) {
+            ended_ids.push(counterpart.to_string());
+        }
+    }
+    let seeds: Vec<&str> = ended_ids.iter().map(String::as_str).collect();
+    let lineage = crate::session_supervisor::resume_lineage::resolve_resume_lineage(
+        &handle.spawn_ctx().home,
+        &seeds,
+    );
+    if lineage.stopped_by_user {
+        fail_running(handle, journal, state, session_key, reason);
+        return;
+    }
+    if let Some(tip) = lineage.successor_tip(&seeds) {
+        let successor = tip.intendant_session_id.clone();
+        rekey_running_to_successor(handle, journal, state, session_key, &successor, reason, now);
+        return;
+    }
+    if !lineage.has_wrapper_history() {
+        fail_running(handle, journal, state, session_key, reason);
+        return;
+    }
+    if now.saturating_sub(ended_at_ms) >= LINEAGE_QUIET_GRACE_MS {
+        fail_running(handle, journal, state, session_key, reason);
+        return;
+    }
+    eprintln!(
+        "[agenda] scheduled session {session_key} ended (\"{reason}\") with wrapper lineage \
+         and no successor yet — holding the occurrence terminal for a resume-lineage \
+         successor (grace {}s)",
+        LINEAGE_QUIET_GRACE_MS / 1000
+    );
+    state.lineage_pending.push(PendingLineageEnd {
+        session_key: session_key.to_string(),
+        ended_id: ended_id.to_string(),
+        reason: reason.to_string(),
+        ended_at_ms,
+    });
+}
+
+/// The ended session's lineage continues under `successor`: move the
+/// running entry to the tip, journal a fresh `started` row naming it, and
+/// write the re-attribution back to the item — every later terminal then
+/// resolves (and attributes) through the tip. A terminal already
+/// remembered under the successor resolves right away: a completion
+/// applies, an end re-classifies (a successor that itself restarted
+/// chains again).
+fn rekey_running_to_successor(
+    handle: &AgendaHandle,
+    journal: &mut OccurrenceJournal,
+    state: &mut SchedulerState,
+    session_key: &str,
+    successor: &str,
+    reason: &str,
+    now: u64,
+) {
+    let Some(spawn) = state.running.remove(session_key) else {
+        return;
+    };
+    eprintln!(
+        "[agenda] occurrence {} follows its resume lineage: session {session_key} ended \
+         (\"{reason}\"), continuing under successor session {successor}",
+        spawn.occurrence_id
+    );
+    session_record(
+        journal,
+        &spawn,
+        now,
+        OccurrenceState::Started,
+        Some(successor.to_string()),
+    );
+    record_on_item(
+        handle,
+        &spawn,
+        "started",
+        Some(successor.to_string()),
+        Some(format!(
+            "continued under successor session {successor} \
+             (previous session ended: {reason})"
+        )),
+    );
+    state.running.insert(successor.to_string(), spawn);
+    if let Some(early) = state.take_early_outcome_aliased(successor) {
+        match early.failed {
+            None => complete_running(handle, journal, state, successor, early.note),
+            Some(end_reason) => classify_ended_running_session(
+                handle,
+                journal,
+                state,
+                successor,
+                successor,
+                &end_reason,
+                now,
+                now,
+            ),
+        }
+    }
+}
+
+/// Re-classify held lineage ends (see [`PendingLineageEnd`]) against
+/// durable state: runs on every scheduler wake — bus activity from the
+/// successor's own spawn re-checks promptly, and the returned instant
+/// bounds the sleep so a quiet bus still meets the grace deadline.
+/// Entries whose running entry vanished meanwhile (lag fail-close) are
+/// dropped.
+fn sweep_lineage_pending(
+    handle: &AgendaHandle,
+    journal: &mut OccurrenceJournal,
+    state: &mut SchedulerState,
+    now: u64,
+) -> Option<u64> {
+    if state.lineage_pending.is_empty() {
+        return None;
+    }
+    let pending = std::mem::take(&mut state.lineage_pending);
+    for entry in pending {
+        if !state.running.contains_key(&entry.session_key) {
+            continue;
+        }
+        classify_ended_running_session(
+            handle,
+            journal,
+            state,
+            &entry.session_key,
+            &entry.ended_id,
+            &entry.reason,
+            entry.ended_at_ms,
+            now,
+        );
+    }
+    state
+        .lineage_pending
+        .iter()
+        .map(|entry| entry.ended_at_ms + LINEAGE_QUIET_GRACE_MS)
+        .min()
 }
 
 /// Terminal resolution for occurrences that never spawned (missed window,
@@ -2421,6 +2648,430 @@ mod tests {
             "oldest entry evicted at the cap"
         );
         assert!(state.take_early_outcome("two-more").is_some());
+    }
+
+    /// Handle whose spawn context carries BOTH a hermetic lineage home
+    /// (wrapper logs + wrapper index resolve under it) and a default
+    /// project — the resume-lineage tests' baseline.
+    fn handle_with_home_and_project(
+        dir: &std::path::Path,
+        home: &std::path::Path,
+        default_project: &std::path::Path,
+    ) -> Arc<AgendaHandle> {
+        let bus = EventBus::new();
+        Arc::new(
+            AgendaHandle::new(AgendaStore::open(dir).unwrap(), bus, dir).with_spawn_context(
+                super::super::spawn_project::SessionSpawnContext {
+                    home: home.to_path_buf(),
+                    default_project_root: Some(default_project.to_path_buf()),
+                },
+            ),
+        )
+    }
+
+    /// A wrapper log dir announcing its backend conversation(s) under the
+    /// hermetic home — how live wrappers persist lineage (the identity
+    /// event also writes the wrapper-index row).
+    fn announce_wrapper(home: &std::path::Path, wrapper: &str, source: &str, backend_ids: &[&str]) {
+        let logs = crate::platform::intendant_home_in(home).join("logs");
+        let mut log = crate::session_log::SessionLog::open(logs.join(wrapper)).unwrap();
+        log.write_meta(None, None);
+        for backend_id in backend_ids {
+            log.session_identity(wrapper, source, backend_id);
+        }
+    }
+
+    /// StartNow the item and run one pass; returns `(item_id,
+    /// occurrence_id, delegation_id)` with the dispatch drained off the
+    /// bus.
+    async fn start_now_dispatch(
+        handle: &Arc<AgendaHandle>,
+        journal: &mut OccurrenceJournal,
+        state: &mut SchedulerState,
+        title: &str,
+    ) -> (String, String, String) {
+        let item = handle
+            .apply(
+                AgendaCommand::Add {
+                    refs: Vec::new(),
+                    kind: AgendaKind::Task,
+                    title: title.into(),
+                    body: String::new(),
+                    tags: Vec::new(),
+                    due_ms: None,
+                    source: None,
+                },
+                None,
+            )
+            .unwrap();
+        handle
+            .apply(
+                AgendaCommand::StartNow {
+                    id: item.id.clone(),
+                    goal: None,
+                    project_root: None,
+                    interactive: None,
+                    agent_config: None,
+                },
+                owner(),
+            )
+            .unwrap();
+        let mut rx = handle.bus().subscribe();
+        run_pass(handle, journal, state).await;
+        let mut delegation_id = None;
+        while let Ok(event) = rx.try_recv() {
+            if let AppEvent::ControlCommand(ControlMsg::StartTask {
+                delegation_id: Some(id),
+                ..
+            }) = event
+            {
+                delegation_id = Some(id);
+            }
+        }
+        let delegation_id = delegation_id.expect("occurrence dispatched");
+        let occurrence_id = delegation_id
+            .strip_prefix(DELEGATION_PREFIX)
+            .unwrap()
+            .to_string();
+        (item.id, occurrence_id, delegation_id)
+    }
+
+    fn last_run_of(handle: &AgendaHandle, item_id: &str) -> super::super::types::AgendaRun {
+        let (items, _, _) = handle.snapshot();
+        items.iter().find(|i| i.id == item_id).unwrap().effects[0]
+            .last_run
+            .clone()
+            .unwrap()
+    }
+
+    /// THE commission arc: the owner's account-switch flow (Restart with
+    /// saved config, then continue) ends the ORIGINAL wrapper session
+    /// seconds before the successor's durable trace lands. The occurrence
+    /// must hold instead of terminaling `failed`, re-key to the successor
+    /// once it registers, and complete from the successor's own terminal
+    /// — and a PARKED tip (no `SessionEnded` ever) keeps the lineage
+    /// non-quiet: no terminal, however long the sweep runs.
+    #[tokio::test]
+    async fn restart_with_saved_config_keeps_occurrence_linked() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let default_project = tempfile::tempdir().unwrap();
+        let handle = handle_with_home_and_project(dir.path(), home.path(), default_project.path());
+        let mut journal = OccurrenceJournal::open(handle.dir()).unwrap();
+        let mut state = SchedulerState::default();
+        announce_wrapper(home.path(), "wrapper-old", "claude-code", &["b-acct"]);
+        let (item_id, occurrence_id, delegation_id) =
+            start_now_dispatch(&handle, &mut journal, &mut state, "switch accounts").await;
+
+        observe_event(
+            &handle,
+            &mut journal,
+            &mut state,
+            &AppEvent::TaskReceived {
+                delegation_id,
+                session_id: "wrapper-old".into(),
+            },
+        );
+        // The restart lane stops the old wrapper FIRST; no successor is
+        // visible anywhere durable yet.
+        observe_event(
+            &handle,
+            &mut journal,
+            &mut state,
+            &AppEvent::SessionEnded {
+                session_id: "wrapper-old".into(),
+                reason: "restarting session".into(),
+                error_kind: None,
+            },
+        );
+        assert!(
+            journal.progress(&occurrence_id).terminal.is_none(),
+            "an end with live wrapper lineage must not terminal the occurrence"
+        );
+        assert_eq!(state.lineage_pending.len(), 1, "the end is held, not dropped");
+        assert!(
+            state.running.contains_key("wrapper-old"),
+            "the occurrence stays in-flight while held"
+        );
+
+        // The successor registers under the SAME backend conversation
+        // (the eager resume identity) — the next sweep follows it.
+        announce_wrapper(home.path(), "wrapper-new", "claude-code", &["b-acct"]);
+        sweep_lineage_pending(&handle, &mut journal, &mut state, now_ms());
+        assert!(state.lineage_pending.is_empty(), "the held end resolved");
+        assert!(
+            state.running.contains_key("wrapper-new") && !state.running.contains_key("wrapper-old"),
+            "the occurrence re-keyed to the successor"
+        );
+        assert!(journal.progress(&occurrence_id).terminal.is_none());
+        let run = last_run_of(&handle, &item_id);
+        assert_eq!(run.state, "started");
+        assert_eq!(run.session_id.as_deref(), Some("wrapper-new"));
+
+        // Edge: a parked tip (done or rate-limited — emits no
+        // SessionEnded) means the lineage is NOT quiet: sweeps far past
+        // the grace window terminal nothing.
+        sweep_lineage_pending(
+            &handle,
+            &mut journal,
+            &mut state,
+            now_ms() + 10 * LINEAGE_QUIET_GRACE_MS,
+        );
+        assert!(journal.progress(&occurrence_id).terminal.is_none());
+
+        // The successor finishes the work: the occurrence completes,
+        // attributed to it.
+        observe_event(
+            &handle,
+            &mut journal,
+            &mut state,
+            &AppEvent::DoneSignal {
+                session_id: Some("wrapper-new".into()),
+                message: Some("switched and finished".into()),
+            },
+        );
+        let progress = journal.progress(&occurrence_id);
+        assert_eq!(progress.terminal, Some(OccurrenceState::Completed));
+        assert_eq!(progress.started.as_deref(), Some("wrapper-new"));
+        let run = last_run_of(&handle, &item_id);
+        assert_eq!(run.state, "completed");
+        assert_eq!(run.session_id.as_deref(), Some("wrapper-new"));
+        assert_eq!(run.note.as_deref(), Some("switched and finished"));
+    }
+
+    /// A wrapper-backed end with NO successor holds for the grace window
+    /// (the supersede lanes register the successor seconds after the
+    /// end), then terminals `failed` with the original reason once the
+    /// lineage is still quiet at expiry — never earlier.
+    #[tokio::test]
+    async fn terminal_fires_only_when_lineage_quiet() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let default_project = tempfile::tempdir().unwrap();
+        let handle = handle_with_home_and_project(dir.path(), home.path(), default_project.path());
+        let mut journal = OccurrenceJournal::open(handle.dir()).unwrap();
+        let mut state = SchedulerState::default();
+        announce_wrapper(home.path(), "wrapper-solo", "claude-code", &["b-solo"]);
+        let (item_id, occurrence_id, delegation_id) =
+            start_now_dispatch(&handle, &mut journal, &mut state, "die quietly").await;
+        observe_event(
+            &handle,
+            &mut journal,
+            &mut state,
+            &AppEvent::TaskReceived {
+                delegation_id,
+                session_id: "wrapper-solo".into(),
+            },
+        );
+        observe_event(
+            &handle,
+            &mut journal,
+            &mut state,
+            &AppEvent::SessionEnded {
+                session_id: "wrapper-solo".into(),
+                reason: "error: wrapper died".into(),
+                error_kind: None,
+            },
+        );
+        assert!(journal.progress(&occurrence_id).terminal.is_none());
+
+        // Inside the grace window the lineage may still grow a
+        // successor: no terminal.
+        sweep_lineage_pending(&handle, &mut journal, &mut state, now_ms());
+        assert!(journal.progress(&occurrence_id).terminal.is_none());
+        assert_eq!(state.lineage_pending.len(), 1);
+
+        // Grace expired with the lineage still quiet: the end classifies
+        // as the failure it is, original reason attributed.
+        sweep_lineage_pending(
+            &handle,
+            &mut journal,
+            &mut state,
+            now_ms() + LINEAGE_QUIET_GRACE_MS + 1_000,
+        );
+        let progress = journal.progress(&occurrence_id);
+        assert_eq!(progress.terminal, Some(OccurrenceState::Failed));
+        let run = last_run_of(&handle, &item_id);
+        assert_eq!(run.state, "failed");
+        assert_eq!(run.session_id.as_deref(), Some("wrapper-solo"));
+        assert_eq!(run.note.as_deref(), Some("error: wrapper died"));
+        assert!(state.lineage_pending.is_empty());
+        assert!(state.running.is_empty());
+    }
+
+    /// A chain that hops twice (old wrapper → resumed successor that
+    /// upgraded to its own conversation → its successor) resolves to the
+    /// TIP, not the first hop — and the terminal attributes to the tip
+    /// in the journal and on the item.
+    #[tokio::test]
+    async fn occurrence_attributes_to_lineage_tip() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let default_project = tempfile::tempdir().unwrap();
+        let handle = handle_with_home_and_project(dir.path(), home.path(), default_project.path());
+        let mut journal = OccurrenceJournal::open(handle.dir()).unwrap();
+        let mut state = SchedulerState::default();
+        announce_wrapper(home.path(), "wrapper-old", "claude-code", &["b1-chain"]);
+        announce_wrapper(
+            home.path(),
+            "wrapper-mid",
+            "claude-code",
+            &["b1-chain", "b2-chain"],
+        );
+        announce_wrapper(home.path(), "wrapper-new", "claude-code", &["b2-chain"]);
+        let (item_id, occurrence_id, delegation_id) =
+            start_now_dispatch(&handle, &mut journal, &mut state, "chase the tip").await;
+        observe_event(
+            &handle,
+            &mut journal,
+            &mut state,
+            &AppEvent::TaskReceived {
+                delegation_id,
+                session_id: "wrapper-old".into(),
+            },
+        );
+        observe_event(
+            &handle,
+            &mut journal,
+            &mut state,
+            &AppEvent::SessionEnded {
+                session_id: "wrapper-old".into(),
+                reason: "restarting session".into(),
+                error_kind: None,
+            },
+        );
+        // The whole chain is durable already: classification walks to
+        // the tip in one step — no depth-2 blindness, no hold.
+        assert!(state.lineage_pending.is_empty());
+        assert!(
+            state.running.contains_key("wrapper-new"),
+            "the occurrence follows the chain to its tip"
+        );
+        assert_eq!(
+            journal.progress(&occurrence_id).started.as_deref(),
+            Some("wrapper-new")
+        );
+        observe_event(
+            &handle,
+            &mut journal,
+            &mut state,
+            &AppEvent::DoneSignal {
+                session_id: Some("wrapper-new".into()),
+                message: Some("tip finished".into()),
+            },
+        );
+        let progress = journal.progress(&occurrence_id);
+        assert_eq!(progress.terminal, Some(OccurrenceState::Completed));
+        assert_eq!(progress.started.as_deref(), Some("wrapper-new"));
+        let run = last_run_of(&handle, &item_id);
+        assert_eq!(run.state, "completed");
+        assert_eq!(run.session_id.as_deref(), Some("wrapper-new"));
+    }
+
+    /// An owner Stop is quiet BY DECREE: the durable tombstone (written
+    /// before the end event) terminals the occurrence immediately — no
+    /// grace hold, nothing pending.
+    #[tokio::test]
+    async fn stop_tombstone_terminals_the_occurrence() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let default_project = tempfile::tempdir().unwrap();
+        let handle = handle_with_home_and_project(dir.path(), home.path(), default_project.path());
+        let mut journal = OccurrenceJournal::open(handle.dir()).unwrap();
+        let mut state = SchedulerState::default();
+        announce_wrapper(home.path(), "wrapper-stopme", "claude-code", &["b-stop"]);
+        let (item_id, occurrence_id, delegation_id) =
+            start_now_dispatch(&handle, &mut journal, &mut state, "stop me").await;
+        observe_event(
+            &handle,
+            &mut journal,
+            &mut state,
+            &AppEvent::TaskReceived {
+                delegation_id,
+                session_id: "wrapper-stopme".into(),
+            },
+        );
+        crate::external_wrapper_index::record_user_stop(home.path(), "claude-code", "b-stop")
+            .unwrap();
+        observe_event(
+            &handle,
+            &mut journal,
+            &mut state,
+            &AppEvent::SessionEnded {
+                session_id: "wrapper-stopme".into(),
+                reason: "stopped by user".into(),
+                error_kind: None,
+            },
+        );
+        let progress = journal.progress(&occurrence_id);
+        assert_eq!(progress.terminal, Some(OccurrenceState::Failed));
+        let run = last_run_of(&handle, &item_id);
+        assert_eq!(run.state, "failed");
+        assert_eq!(run.note.as_deref(), Some("stopped by user"));
+        assert!(state.lineage_pending.is_empty());
+        assert!(state.running.is_empty());
+    }
+
+    /// The pre-receipt end of a wrapper-backed session with NO admitted
+    /// successor still fails the occurrence: the receipt routes the
+    /// remembered end through lineage classification, which holds for
+    /// the grace window and then terminals `failed` — never strands the
+    /// occurrence and never completes it.
+    #[tokio::test]
+    async fn early_end_without_successor_still_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let default_project = tempfile::tempdir().unwrap();
+        let handle = handle_with_home_and_project(dir.path(), home.path(), default_project.path());
+        let mut journal = OccurrenceJournal::open(handle.dir()).unwrap();
+        let mut state = SchedulerState::default();
+        announce_wrapper(home.path(), "wrapper-early", "claude-code", &["b-early"]);
+        let (item_id, occurrence_id, delegation_id) =
+            start_now_dispatch(&handle, &mut journal, &mut state, "die before receipt").await;
+        observe_event(
+            &handle,
+            &mut journal,
+            &mut state,
+            &AppEvent::SessionEnded {
+                session_id: "wrapper-early".into(),
+                reason: "error: died at boot".into(),
+                error_kind: None,
+            },
+        );
+        assert!(
+            journal.progress(&occurrence_id).started.is_none(),
+            "no receipt yet — nothing journaled"
+        );
+        observe_event(
+            &handle,
+            &mut journal,
+            &mut state,
+            &AppEvent::TaskReceived {
+                delegation_id,
+                session_id: "wrapper-early".into(),
+            },
+        );
+        // The receipt consumed the remembered end into a lineage hold
+        // (a successor may still register), keeping the journal arc in
+        // order: started, then the eventual terminal.
+        assert_eq!(
+            journal.progress(&occurrence_id).started.as_deref(),
+            Some("wrapper-early")
+        );
+        assert!(journal.progress(&occurrence_id).terminal.is_none());
+        assert_eq!(state.lineage_pending.len(), 1);
+
+        sweep_lineage_pending(
+            &handle,
+            &mut journal,
+            &mut state,
+            now_ms() + LINEAGE_QUIET_GRACE_MS + 1_000,
+        );
+        let progress = journal.progress(&occurrence_id);
+        assert_eq!(progress.terminal, Some(OccurrenceState::Failed));
+        let run = last_run_of(&handle, &item_id);
+        assert_eq!(run.state, "failed");
+        assert_eq!(run.note.as_deref(), Some("error: died at boot"));
     }
 
     /// A start-now carrying the confirm sheet's launch pins records them on

--- a/src/bin/caller/external_wrapper_index.rs
+++ b/src/bin/caller/external_wrapper_index.rs
@@ -713,7 +713,10 @@ fn active_wrapper_ids_by_group(
 /// before `state` existed), then the lexically-greatest wrapper session id
 /// as a deterministic tie-break. [`wrappers_for`] / [`wrappers_for_source`]
 /// sort with this, so their first record is the preferred one.
-fn wrapper_preference(a: &ExternalWrapperRecord, b: &ExternalWrapperRecord) -> std::cmp::Ordering {
+pub(crate) fn wrapper_preference(
+    a: &ExternalWrapperRecord,
+    b: &ExternalWrapperRecord,
+) -> std::cmp::Ordering {
     a.state
         .cmp(&b.state)
         .then_with(|| b.updated_at_secs.cmp(&a.updated_at_secs))

--- a/src/bin/caller/session_supervisor/mod.rs
+++ b/src/bin/caller/session_supervisor/mod.rs
@@ -27,6 +27,7 @@ pub(crate) use claude_edit::{CLAUDE_EDIT_INPLACE_STOP_REASON, CLAUDE_EDIT_SUPERS
 mod dispatch;
 mod fork;
 mod registry;
+pub(crate) mod resume_lineage;
 
 #[derive(Clone)]
 pub struct SessionSupervisorConfig {

--- a/src/bin/caller/session_supervisor/resume_lineage.rs
+++ b/src/bin/caller/session_supervisor/resume_lineage.rs
@@ -1,0 +1,305 @@
+//! Durable resume-lineage resolution: the ONE walker behind every
+//! "which session carries this conversation now?" question. A wrapper
+//! session's work survives it — owner Restart supersedes the wrapper on
+//! the same backend conversation, an edit branch retires the
+//! conversation to a successor conversation, and each successor can
+//! chain again — so any consumer that classifies or delivers against a
+//! session id must resolve the whole chain, from durable state only
+//! (session-dir identity facts + the wrapper index): in-memory alias
+//! maps die with the daemon and cap out under churn.
+//!
+//! Consumers today: the agenda-answer delivery arm
+//! (`resolve_ask_delivery_entry`, probing candidates against live
+//! supervisor state) and the agenda scheduler's occurrence terminal
+//! classification (following an ended session to its successor before
+//! journaling a terminal). They deliberately share this walk — two
+//! independent walkers WILL drift; add consumers here, never a private
+//! re-implementation.
+
+use super::launch::recorded_backend_conversations_in_home;
+use crate::external_wrapper_index::{
+    lineage_tombstones, wrapper_preference, wrappers_for, ExternalWrapperRecord, WrapperState,
+};
+use std::collections::HashSet;
+use std::path::Path;
+
+/// Walk bounds: a lineage is a restart chain (human-gesture scale), so
+/// real chains are short; the caps only defend against a corrupted or
+/// adversarial index (e.g. a `retired_successor` cycle) spinning the
+/// walk.
+const MAX_LINEAGE_SESSIONS: usize = 64;
+const MAX_LINEAGE_CONVERSATIONS: usize = 64;
+
+/// The transitive resume lineage of a seed session, resolved from
+/// durable state. Empty collections mean the seeds have no recorded
+/// external-wrapper history at all (a native session, or a wrapper that
+/// died before any identity fact landed).
+pub(crate) struct ResumeLineage {
+    /// Ordered delivery-probe candidates: each conversation id first
+    /// (a live successor is aliased or keyed under it once it
+    /// announces), then that conversation's indexed wrappers, newest
+    /// first — the seed's own conversations lead, transitive hops
+    /// follow. `(source, id)` pairs; ids may name conversations or
+    /// wrapper sessions, which is exactly what a live-session probe
+    /// wants to try.
+    pub(crate) candidates: Vec<(String, String)>,
+    /// Every wrapper record in the closure, preference-ordered (active
+    /// first, then newest).
+    pub(crate) wrapper_records: Vec<ExternalWrapperRecord>,
+    /// An owner-stop tombstone anywhere in the chain: the owner
+    /// declared this lineage done (`record_user_stop`); only a
+    /// deliberate revival gesture clears it.
+    pub(crate) stopped_by_user: bool,
+}
+
+impl ResumeLineage {
+    /// True when the walk found any durable wrapper trace — the
+    /// external-lineage discriminator: without one there is no
+    /// successor chain to wait on.
+    pub(crate) fn has_wrapper_history(&self) -> bool {
+        !self.wrapper_records.is_empty()
+    }
+
+    /// The lineage tip a consumer should follow PAST the given ended
+    /// sessions: the preferred (active, newest) wrapper record whose
+    /// session is not excluded. `None` means the lineage is quiet — no
+    /// admitted successor is visible in durable state (yet). Only
+    /// `Active` rows qualify: a superseded row is a dead incarnation,
+    /// never a successor to re-attach to.
+    pub(crate) fn successor_tip(&self, exclude: &[&str]) -> Option<&ExternalWrapperRecord> {
+        self.wrapper_records.iter().find(|record| {
+            record.state == WrapperState::Active
+                && !exclude
+                    .iter()
+                    .any(|id| *id == record.intendant_session_id.as_str())
+        })
+    }
+}
+
+/// Resolve the transitive resume lineage of `seeds` (typically one
+/// session id plus its known aliases). Breadth-first over two durable
+/// edge kinds, deduplicated and bounded:
+///
+/// - session → the backend conversations its OWN records tie it to
+///   ([`recorded_backend_conversations_in_home`]: id-form, its session
+///   dir's identity facts, wrapper-index rows), then conversation → its
+///   indexed wrapper sessions (a resume registers the successor under
+///   the resumed conversation via the eager identity, which is the edge
+///   that chains wrapper generations);
+/// - conversation → its `retired_successor` conversation (an edit
+///   branch replaces the conversation itself, so no shared wrapper row
+///   exists to follow).
+///
+/// Never an unrelated session: every hop derives from the seed's own
+/// recorded identity or from wrapper-index rows of a conversation
+/// already in the closure.
+pub(crate) fn resolve_resume_lineage(home: &Path, seeds: &[&str]) -> ResumeLineage {
+    let mut lineage = ResumeLineage {
+        candidates: Vec::new(),
+        wrapper_records: Vec::new(),
+        stopped_by_user: false,
+    };
+    let mut seen_sessions: HashSet<String> = HashSet::new();
+    let mut seen_conversations: HashSet<(String, String)> = HashSet::new();
+    let mut session_frontier: Vec<String> = seeds
+        .iter()
+        .map(|seed| seed.trim().to_string())
+        .filter(|seed| !seed.is_empty())
+        .collect();
+
+    let mut cursor = 0;
+    while cursor < session_frontier.len() {
+        let session_id = session_frontier[cursor].clone();
+        cursor += 1;
+        if !seen_sessions.insert(session_id.clone()) {
+            continue;
+        }
+        if seen_sessions.len() > MAX_LINEAGE_SESSIONS {
+            break;
+        }
+        for (source, conversation_id) in recorded_backend_conversations_in_home(home, &session_id) {
+            // Conversation frontier, itself chained by retirement edges.
+            let mut conversation_frontier = vec![conversation_id];
+            while let Some(conversation_id) = conversation_frontier.pop() {
+                if !seen_conversations.insert((source.clone(), conversation_id.clone())) {
+                    continue;
+                }
+                if seen_conversations.len() > MAX_LINEAGE_CONVERSATIONS {
+                    break;
+                }
+                lineage
+                    .candidates
+                    .push((source.clone(), conversation_id.clone()));
+                for record in wrappers_for(home, &source, &conversation_id) {
+                    lineage
+                        .candidates
+                        .push((source.clone(), record.intendant_session_id.clone()));
+                    if session_frontier.len() < MAX_LINEAGE_SESSIONS {
+                        session_frontier.push(record.intendant_session_id.clone());
+                    }
+                    lineage.wrapper_records.push(record);
+                }
+                let (stopped_at, successor) = lineage_tombstones(home, &source, &conversation_id);
+                if stopped_at.is_some() {
+                    lineage.stopped_by_user = true;
+                }
+                if let Some(successor) = successor {
+                    conversation_frontier.push(successor);
+                }
+            }
+        }
+    }
+
+    lineage.wrapper_records.sort_by(wrapper_preference);
+    lineage
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session_log::SessionLog;
+    use std::path::PathBuf;
+
+    fn logs_root(home: &Path) -> PathBuf {
+        crate::platform::intendant_home_in(home).join("logs")
+    }
+
+    /// A wrapper log dir announcing its backend conversation(s), which
+    /// is exactly how live wrappers persist lineage (the identity event
+    /// also writes the wrapper-index row).
+    fn announce(home: &Path, wrapper: &str, source: &str, backend_ids: &[&str]) {
+        let mut log = SessionLog::open(logs_root(home).join(wrapper)).unwrap();
+        log.write_meta(None, None);
+        for backend_id in backend_ids {
+            log.session_identity(wrapper, source, backend_id);
+        }
+    }
+
+    /// The shared-resolver pin: ONE walk serves both consumers — the
+    /// answer-delivery arm's candidate order (the seed's own
+    /// conversation and wrappers lead, successors follow) and the
+    /// scheduler's tip reduction (`successor_tip` resolves PAST the
+    /// ended session to the newest active wrapper, across BOTH edge
+    /// kinds and at depth > 1). Both call sites route through
+    /// [`resolve_resume_lineage`]; this test pins the walk's reach so a
+    /// private re-implementation of either half has nothing left to
+    /// add.
+    #[test]
+    fn lineage_resolver_shared_with_answer_delivery() {
+        let home = tempfile::tempdir().unwrap();
+
+        // Chain: wrapper-old announced b1; wrapper-mid resumed b1 (eager
+        // row) and upgraded to its own b2; wrapper-new resumed b2. Two
+        // wrapper generations plus an identity upgrade — the resolver
+        // must reach wrapper-new from wrapper-old (depth 2, no
+        // blindness).
+        announce(home.path(), "wrapper-old", "claude-code", &["b1-old"]);
+        announce(home.path(), "wrapper-mid", "claude-code", &["b1-old", "b2-mid"]);
+        announce(home.path(), "wrapper-new", "claude-code", &["b2-mid"]);
+
+        let lineage = resolve_resume_lineage(home.path(), &["wrapper-old"]);
+
+        // Delivery-arm shape: the seed's OWN hop leads (its id-form
+        // probes, then its recorded conversation and that conversation's
+        // wrappers), transitive hops follow — and every chain wrapper is
+        // a candidate.
+        assert_eq!(
+            lineage.candidates.first().map(|(_, id)| id.as_str()),
+            Some("wrapper-old"),
+            "the seed's own id-form probe must lead the candidate order"
+        );
+        let position = |needle: &str| {
+            lineage
+                .candidates
+                .iter()
+                .position(|(source, id)| source == "claude-code" && id == needle)
+                .unwrap_or_else(|| panic!("candidate list must cover {needle}"))
+        };
+        assert!(
+            position("b1-old") < position("wrapper-mid")
+                && position("wrapper-mid") < position("b2-mid")
+                && position("b2-mid") < position("wrapper-new"),
+            "the seed's conversation and wrappers precede transitive hops: {:?}",
+            lineage.candidates
+        );
+
+        // Scheduler shape: the tip past the ended wrapper is the newest
+        // ACTIVE record — wrapper-new, two hops out.
+        let tip = lineage
+            .successor_tip(&["wrapper-old"])
+            .expect("the chain has a live successor");
+        assert_eq!(tip.intendant_session_id, "wrapper-new");
+        assert!(!lineage.stopped_by_user);
+
+        // The retirement edge (an edit branch replaces the conversation
+        // itself; the child shares no wrapper row with the parent) also
+        // chains: without it the child is unreachable.
+        let edit_home = tempfile::tempdir().unwrap();
+        announce(edit_home.path(), "wrapper-parent", "claude-code", &["b1-parent"]);
+        announce(edit_home.path(), "wrapper-child", "claude-code", &["b2-child"]);
+        crate::external_wrapper_index::record_lineage_retired(
+            edit_home.path(),
+            "claude-code",
+            "b1-parent",
+            "b2-child",
+        )
+        .unwrap();
+        let lineage = resolve_resume_lineage(edit_home.path(), &["wrapper-parent"]);
+        let tip = lineage
+            .successor_tip(&["wrapper-parent"])
+            .expect("the retirement edge reaches the edit-branch child");
+        assert_eq!(tip.intendant_session_id, "wrapper-child");
+    }
+
+    /// No recorded wrapper history (a native session id) resolves to an
+    /// empty lineage: no candidates beyond the id-form probes, no
+    /// wrapper records, no tip — the discriminator consumers classify
+    /// immediately on.
+    #[test]
+    fn native_session_has_no_wrapper_history() {
+        let home = tempfile::tempdir().unwrap();
+        let lineage = resolve_resume_lineage(home.path(), &["sess-native"]);
+        assert!(!lineage.has_wrapper_history());
+        assert!(lineage.successor_tip(&[]).is_none());
+        assert!(!lineage.stopped_by_user);
+    }
+
+    /// An owner stop anywhere in the chain surfaces as
+    /// `stopped_by_user` — quiet by decree, whatever rows remain
+    /// active.
+    #[test]
+    fn stop_tombstone_surfaces_from_the_chain() {
+        let home = tempfile::tempdir().unwrap();
+        announce(home.path(), "wrapper-one", "claude-code", &["b1-stop"]);
+        crate::external_wrapper_index::record_user_stop(home.path(), "claude-code", "b1-stop")
+            .unwrap();
+        let lineage = resolve_resume_lineage(home.path(), &["wrapper-one"]);
+        assert!(lineage.has_wrapper_history());
+        assert!(lineage.stopped_by_user);
+    }
+
+    /// A `retired_successor` cycle (corrupt index) terminates under the
+    /// walk bounds instead of spinning.
+    #[test]
+    fn cyclic_retirement_edges_terminate() {
+        let home = tempfile::tempdir().unwrap();
+        announce(home.path(), "wrapper-a", "claude-code", &["b-cycle-1"]);
+        announce(home.path(), "wrapper-b", "claude-code", &["b-cycle-2"]);
+        crate::external_wrapper_index::record_lineage_retired(
+            home.path(),
+            "claude-code",
+            "b-cycle-1",
+            "b-cycle-2",
+        )
+        .unwrap();
+        crate::external_wrapper_index::record_lineage_retired(
+            home.path(),
+            "claude-code",
+            "b-cycle-2",
+            "b-cycle-1",
+        )
+        .unwrap();
+        let lineage = resolve_resume_lineage(home.path(), &["wrapper-a"]);
+        assert!(lineage.has_wrapper_history());
+    }
+}

--- a/src/bin/caller/session_supervisor/resume_lineage.rs
+++ b/src/bin/caller/session_supervisor/resume_lineage.rs
@@ -194,7 +194,12 @@ mod tests {
         // must reach wrapper-new from wrapper-old (depth 2, no
         // blindness).
         announce(home.path(), "wrapper-old", "claude-code", &["b1-old"]);
-        announce(home.path(), "wrapper-mid", "claude-code", &["b1-old", "b2-mid"]);
+        announce(
+            home.path(),
+            "wrapper-mid",
+            "claude-code",
+            &["b1-old", "b2-mid"],
+        );
         announce(home.path(), "wrapper-new", "claude-code", &["b2-mid"]);
 
         let lineage = resolve_resume_lineage(home.path(), &["wrapper-old"]);
@@ -235,8 +240,18 @@ mod tests {
         // itself; the child shares no wrapper row with the parent) also
         // chains: without it the child is unreachable.
         let edit_home = tempfile::tempdir().unwrap();
-        announce(edit_home.path(), "wrapper-parent", "claude-code", &["b1-parent"]);
-        announce(edit_home.path(), "wrapper-child", "claude-code", &["b2-child"]);
+        announce(
+            edit_home.path(),
+            "wrapper-parent",
+            "claude-code",
+            &["b1-parent"],
+        );
+        announce(
+            edit_home.path(),
+            "wrapper-child",
+            "claude-code",
+            &["b2-child"],
+        );
         crate::external_wrapper_index::record_lineage_retired(
             edit_home.path(),
             "claude-code",

--- a/src/bin/caller/session_supervisor/resume_lineage.rs
+++ b/src/bin/caller/session_supervisor/resume_lineage.rs
@@ -69,9 +69,7 @@ impl ResumeLineage {
     pub(crate) fn successor_tip(&self, exclude: &[&str]) -> Option<&ExternalWrapperRecord> {
         self.wrapper_records.iter().find(|record| {
             record.state == WrapperState::Active
-                && !exclude
-                    .iter()
-                    .any(|id| *id == record.intendant_session_id.as_str())
+                && !exclude.contains(&record.intendant_session_id.as_str())
         })
     }
 }

--- a/src/bin/caller/session_supervisor/routing.rs
+++ b/src/bin/caller/session_supervisor/routing.rs
@@ -1423,16 +1423,18 @@ impl SessionSupervisor {
     /// 2. the persisted-external re-resolution (`route_follow_up`'s second
     ///    pass): the asker's own dir names its backend conversation, whose
     ///    live wrapper re-registered under an alias;
-    /// 3. the resume lineage: every backend conversation the asker's OWN
-    ///    records tie it to ([`recorded_backend_conversations_in_home`]),
-    ///    resolved to the newest LIVE wrapper of that conversation via the
-    ///    wrapper index (preference order: active first, most recent
-    ///    first) — the successor pass that survives a daemon restart.
+    /// 3. the resume lineage: the TRANSITIVE successor walk over durable
+    ///    state ([`resume_lineage::resolve_resume_lineage`] — the ONE
+    ///    walker, shared with the agenda scheduler's occurrence terminal
+    ///    classification), probed against live supervisor state in
+    ///    candidate order — the successor pass that survives a daemon
+    ///    restart, at any chain depth.
     ///
     /// Never an unrelated session: every candidate derives from the
     /// asker's own aliases, its own session dir's identity facts, or
-    /// wrapper-index records of its backend conversation, and successor
-    /// candidates must match the recorded source and accept input.
+    /// wrapper-index records of its backend conversation's lineage, and
+    /// successor candidates must match the recorded source and accept
+    /// input.
     async fn resolve_ask_delivery_entry(
         &self,
         asker: &str,
@@ -1455,16 +1457,7 @@ impl SessionSupervisor {
             }
         }
         let home = self.logs_home();
-        // Candidate ids per conversation: the backend id itself (a live
-        // successor is aliased or keyed under it once it announces), then
-        // every indexed wrapper of the conversation, newest first.
-        let mut candidates: Vec<(String, String)> = Vec::new();
-        for (source, backend_id) in recorded_backend_conversations_in_home(&home, asker) {
-            candidates.push((source.clone(), backend_id.clone()));
-            for record in crate::external_wrapper_index::wrappers_for(&home, &source, &backend_id) {
-                candidates.push((source.clone(), record.intendant_session_id));
-            }
-        }
+        let candidates = resume_lineage::resolve_resume_lineage(&home, &[asker]).candidates;
         if candidates.is_empty() {
             return None;
         }


### PR DESCRIPTION
LIFECYCLE RIDER A — agenda occurrences follow resume lineage (fired from agenda item 01KYK50FW72X3ESM1TJ3BCMTSD, occurrence dfcb541b6e58e635e32ae9093193d75a).

**Defect** (steward-verified 2026-07-27): the scheduler terminaled an occurrence from `SessionEnded` of the spawned session id. The owner's account-switch flow — Restart with saved config, then continue — supersedes the wrapper and resumes the conversation under a successor, so the ORIGINAL id ends: the occurrence journaled `failed` while the successor carried the work unlinked to any occurrence.

**Fix**: occurrence terminal classification walks the resume-lineage successor chain before classifying — terminal only when the LINEAGE is quiet, attributed to the lineage tip.

- ONE shared walker (`session_supervisor/resume_lineage.rs`), extracted from the agenda-answer delivery arm's successor pass and now serving both consumers (the delivery arm gains transitive reach; it had one durable hop).
- Durable state only: session-dir identity facts + wrapper-index rows + `retired_successor` edges — survives daemon restarts, no in-memory maps.
- Owner Stop tombstone = quiet by decree → `failed` immediately (the Stop lane stamps it before the end event).
- Admitted successor → the running occurrence re-keys to the lineage tip (fresh `started` journal row + item write-back); terminals resolve and attribute through the tip; chains of any depth.
- No wrapper history (native/mock sessions) → immediate classification, unchanged.
- Wrapper history but no successor visible yet → held up to 60s from the end (every supersede lane ends the old wrapper before the successor's index row lands), then `failed` with the original reason.
- `started_history` on the journal fold keeps the Track T loop-exclusion set covering superseded originals.

**Pins**: `restart_with_saved_config_keeps_occurrence_linked`, `terminal_fires_only_when_lineage_quiet`, `occurrence_attributes_to_lineage_tip`, `lineage_resolver_shared_with_answer_delivery`, `stop_tombstone_terminals_the_occurrence`, `early_end_without_successor_still_fails`.