### PR TITLE
feat(handover): HS1 — scheduler-lease primitive, presence files, journal generation stamping, status surfaces

### DIFF
--- a/src/bin/caller/agenda/handle.rs
+++ b/src/bin/caller/agenda/handle.rs
@@ -1906,6 +1906,8 @@ mod tests {
                     state: super::super::reminders::OccurrenceState::Delivered,
                     urgency: None,
                     session_id: None,
+                    generation: None,
+                    boot_id: None,
                 })
                 .unwrap();
         }

--- a/src/bin/caller/agenda/mod.rs
+++ b/src/bin/caller/agenda/mod.rs
@@ -44,7 +44,8 @@ pub(crate) use ask::{agenda_ask_pending, ask_outcome_delivery_text, spawn_ask_re
 pub(crate) use blobs::find_blob;
 pub(crate) use handle::AgendaHandle;
 pub(crate) use reminders::{
-    AgendaOccurrencesPage, ReminderPolicyPatch, AGENDA_OCCURRENCES_DEFAULT_LIMIT,
+    journal_generation_floor, AgendaOccurrencesPage, ReminderPolicyPatch,
+    AGENDA_OCCURRENCES_DEFAULT_LIMIT,
 };
 pub(crate) use scheduler::spawn_reminder_scheduler;
 pub(crate) use spawn_project::{recorded_session_project_root, SessionSpawnContext};

--- a/src/bin/caller/agenda/reminders.rs
+++ b/src/bin/caller/agenda/reminders.rs
@@ -1665,7 +1665,9 @@ mod tests {
             generation: None,
             boot_id: None,
         };
-        writer.append(&record("occ-1", OccurrenceState::Prepared)).unwrap();
+        writer
+            .append(&record("occ-1", OccurrenceState::Prepared))
+            .unwrap();
         writer
             .append(&OccurrenceRecord {
                 generation: Some(9),

--- a/src/bin/caller/agenda/reminders.rs
+++ b/src/bin/caller/agenda/reminders.rs
@@ -291,6 +291,30 @@ pub(crate) struct OccurrenceRecord {
     /// The spawned session, on `started` records (A5 scheduled sessions).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) session_id: Option<String>,
+    /// Scheduler-lease generation held by the writing daemon (Track HS
+    /// stamping). Absent on legacy rows and rows written without the
+    /// lease. Journal-side only — the agenda op-log vocabulary must NOT
+    /// grow this field (its op enum is `deny_unknown_fields` under a
+    /// skip-don't-brick fold; ruled in the HS intake, Q3 guardrail).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) generation: Option<u64>,
+    /// The writing daemon's boot id (Track HS stamping): what boot-
+    /// recovery scoping (HS2) probes for liveness before declaring a
+    /// foreign `started` row unknown. Absent on legacy rows, which keep
+    /// today's recover-at-boot semantics.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) boot_id: Option<String>,
+}
+
+/// Writer identity stamped onto journal rows (Track HS): set once per
+/// scheduler boot and refreshed when the lease role changes (HS2's
+/// poll-acquire). Additive JSON — older builds' folds ignore the fields
+/// by serde default, and the raw occurrences page serves them verbatim.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct JournalStamp {
+    pub(crate) boot_id: String,
+    /// The held lease generation; `None` while writing without the lease.
+    pub(crate) generation: Option<u64>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -345,6 +369,13 @@ pub(crate) struct OccurrenceJournal {
     file: std::fs::File,
     state: BTreeMap<String, OccurrenceProgress>,
     folded_len: u64,
+    /// Max lease generation observed across every folded row — the Q1
+    /// reseed floor ([`journal_generation_floor`]): lease acquisition
+    /// never mints a generation at or below what rows already record,
+    /// even with the sidecar deleted or corrupt.
+    max_generation: u64,
+    /// Writer identity stamped onto appended rows, when set (Track HS).
+    stamp: Option<JournalStamp>,
 }
 
 impl OccurrenceJournal {
@@ -356,7 +387,7 @@ impl OccurrenceJournal {
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => Vec::new(),
             Err(err) => return Err(err),
         };
-        let (state, mut folded_len) = fold_journal(&bytes);
+        let (state, mut folded_len, max_generation) = fold_journal(&bytes);
         let mut file = std::fs::File::options()
             .create(true)
             .append(true)
@@ -370,7 +401,23 @@ impl OccurrenceJournal {
             file,
             state,
             folded_len,
+            max_generation,
+            stamp: None,
         })
+    }
+
+    /// Install (or refresh) the writer stamp: appends fill their
+    /// `generation`/`boot_id` from it when the record carries none. Set
+    /// at scheduler boot; refreshed when the lease role changes (HS2).
+    pub(crate) fn set_stamp(&mut self, stamp: Option<JournalStamp>) {
+        self.stamp = stamp;
+    }
+
+    /// See [`journal_generation_floor`]; live view of the same floor
+    /// (test/diagnostic seam, like [`Self::unresolved`]).
+    #[cfg(test)]
+    pub(crate) fn max_generation(&self) -> u64 {
+        self.max_generation
     }
 
     pub(crate) fn progress(&self, occurrence_id: &str) -> OccurrenceProgress {
@@ -451,7 +498,24 @@ impl OccurrenceJournal {
     /// Append one record. `prepared` records are fsync'd to disk before
     /// returning; terminal records flush (an unflushed terminal record
     /// costs at worst one duplicate delivery, which at-least-once allows).
+    /// A set writer stamp fills `generation`/`boot_id` where the record
+    /// carries none — construction sites stay stamp-agnostic.
     pub(crate) fn append(&mut self, record: &OccurrenceRecord) -> std::io::Result<()> {
+        let stamped;
+        let record = match &self.stamp {
+            Some(stamp) if record.generation.is_none() || record.boot_id.is_none() => {
+                let mut filled = record.clone();
+                if filled.boot_id.is_none() {
+                    filled.boot_id = Some(stamp.boot_id.clone());
+                }
+                if filled.generation.is_none() {
+                    filled.generation = stamp.generation;
+                }
+                stamped = filled;
+                &stamped
+            }
+            _ => record,
+        };
         let mut line = serde_json::to_string(record)
             .map_err(|err| std::io::Error::other(format!("encode occurrence: {err}")))?;
         line.push('\n');
@@ -462,6 +526,9 @@ impl OccurrenceJournal {
             self.file.sync_data()?;
         }
         self.folded_len += line.len() as u64;
+        if let Some(generation) = record.generation {
+            self.max_generation = self.max_generation.max(generation);
+        }
         fold_record_into(
             self.state.entry(record.occurrence_id.clone()).or_default(),
             record,
@@ -481,9 +548,10 @@ impl OccurrenceJournal {
             return Ok(());
         }
         let bytes = std::fs::read(&self.path)?;
-        let (state, folded_len) = fold_journal(&bytes);
+        let (state, folded_len, max_generation) = fold_journal(&bytes);
         self.state = state;
         self.folded_len = folded_len;
+        self.max_generation = max_generation;
         if !bytes.is_empty() && bytes.last() != Some(&b'\n') {
             self.file.write_all(b"\n")?;
             self.folded_len += 1;
@@ -631,9 +699,10 @@ fn fold_record_into(entry: &mut OccurrenceProgress, record: &OccurrenceRecord) {
     }
 }
 
-fn fold_journal(bytes: &[u8]) -> (BTreeMap<String, OccurrenceProgress>, u64) {
+fn fold_journal(bytes: &[u8]) -> (BTreeMap<String, OccurrenceProgress>, u64, u64) {
     let text = String::from_utf8_lossy(bytes);
     let mut state: BTreeMap<String, OccurrenceProgress> = BTreeMap::new();
+    let mut max_generation = 0u64;
     for line in text.lines() {
         let line = line.trim();
         if line.is_empty() {
@@ -641,6 +710,9 @@ fn fold_journal(bytes: &[u8]) -> (BTreeMap<String, OccurrenceProgress>, u64) {
         }
         match serde_json::from_str::<OccurrenceRecord>(line) {
             Ok(record) => {
+                if let Some(generation) = record.generation {
+                    max_generation = max_generation.max(generation);
+                }
                 fold_record_into(
                     state.entry(record.occurrence_id.clone()).or_default(),
                     &record,
@@ -652,7 +724,18 @@ fn fold_journal(bytes: &[u8]) -> (BTreeMap<String, OccurrenceProgress>, u64) {
             }
         }
     }
-    (state, bytes.len() as u64)
+    (state, bytes.len() as u64, max_generation)
+}
+
+/// Max lease generation stamped on journal rows under `dir` — the Q1
+/// reseed floor for lease acquisition. Static tolerant read: a missing
+/// journal (or one with no stamped rows yet) floors at 0.
+pub(crate) fn journal_generation_floor(dir: &Path) -> u64 {
+    let bytes = match std::fs::read(dir.join(JOURNAL_FILE)) {
+        Ok(bytes) => bytes,
+        Err(_) => return 0,
+    };
+    fold_journal(&bytes).2
 }
 
 /// One deliverable occurrence, resolved against policy.
@@ -1439,6 +1522,8 @@ mod tests {
                 state: OccurrenceState::Prepared,
                 urgency: None,
                 session_id: None,
+                generation: None,
+                boot_id: None,
             })
             .unwrap();
         journal
@@ -1451,6 +1536,8 @@ mod tests {
                 state: OccurrenceState::Delivered,
                 urgency: Some(ReminderUrgency::Attention),
                 session_id: None,
+                generation: None,
+                boot_id: None,
             })
             .unwrap();
         let again = plan(
@@ -1490,6 +1577,8 @@ mod tests {
                         state: OccurrenceState::Prepared,
                         urgency: None,
                         session_id: None,
+                        generation: None,
+                        boot_id: None,
                     })
                     .unwrap();
                 if terminal {
@@ -1503,6 +1592,8 @@ mod tests {
                             state: OccurrenceState::Delivered,
                             urgency: None,
                             session_id: None,
+                            generation: None,
+                            boot_id: None,
                         })
                         .unwrap();
                 }
@@ -1521,6 +1612,90 @@ mod tests {
         );
         assert_eq!(replanned.deliver.len(), 1);
         assert_eq!(replanned.deliver[0].item_id, "torn-one");
+    }
+
+    /// Track HS additive-compat pin: a legacy row (no `generation`, no
+    /// `boot_id`) folds exactly as before stamping existed, and a record
+    /// written without a stamp serializes byte-identical to the legacy
+    /// shape — old and new builds share one journal without drift.
+    #[test]
+    fn journal_row_without_generation_folds_identically() {
+        let legacy_line = r#"{"v":1,"at_ms":1000,"occurrence_id":"occ-legacy","item_id":"a","due_ms":1000,"state":"started","session_id":"sess-1"}"#;
+        let (state, folded_len, max_generation) = fold_journal(legacy_line.as_bytes());
+        assert_eq!(folded_len, legacy_line.len() as u64);
+        assert_eq!(max_generation, 0, "legacy rows carry no generation");
+        let progress = state.get("occ-legacy").expect("row folded");
+        assert!(progress.prepared);
+        assert_eq!(progress.started.as_deref(), Some("sess-1"));
+        assert_eq!(progress.terminal, None);
+        assert_eq!(progress.item_id.as_deref(), Some("a"));
+
+        // Serialization round-trip without a stamp: no new keys appear.
+        let record: OccurrenceRecord = serde_json::from_str(legacy_line).unwrap();
+        assert_eq!(record.generation, None);
+        assert_eq!(record.boot_id, None);
+        assert_eq!(
+            serde_json::to_string(&record).unwrap(),
+            legacy_line,
+            "stampless records stay byte-identical to the legacy shape"
+        );
+    }
+
+    /// Track HS stamping: a set writer stamp fills appended rows, an
+    /// explicit field is never overwritten, and the max generation
+    /// converges to co-homed readers through the refold — the Q1 reseed
+    /// floor both live and via [`journal_generation_floor`].
+    #[test]
+    fn append_fills_writer_stamp_and_tracks_generation_floor() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut writer = journal(dir.path());
+        writer.set_stamp(Some(JournalStamp {
+            boot_id: "boot-a".to_string(),
+            generation: Some(4),
+        }));
+        let record = |occ: &str, state: OccurrenceState| OccurrenceRecord {
+            v: 1,
+            at_ms: 1_000,
+            occurrence_id: occ.to_string(),
+            item_id: "a".to_string(),
+            due_ms: 1_000,
+            state,
+            urgency: None,
+            session_id: None,
+            generation: None,
+            boot_id: None,
+        };
+        writer.append(&record("occ-1", OccurrenceState::Prepared)).unwrap();
+        writer
+            .append(&OccurrenceRecord {
+                generation: Some(9),
+                boot_id: Some("boot-x".to_string()),
+                ..record("occ-2", OccurrenceState::Prepared)
+            })
+            .unwrap();
+        assert_eq!(writer.max_generation(), 9);
+
+        let raw = std::fs::read_to_string(dir.path().join(JOURNAL_FILE)).unwrap();
+        let lines: Vec<serde_json::Value> = raw
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect();
+        assert_eq!(lines[0]["boot_id"], "boot-a", "stamp fills empty fields");
+        assert_eq!(lines[0]["generation"], 4);
+        assert_eq!(lines[1]["boot_id"], "boot-x", "explicit fields survive");
+        assert_eq!(lines[1]["generation"], 9);
+
+        // A co-homed reader converges on the same floor via refold, and
+        // the static read (lease acquisition's input) agrees.
+        let mut reader = journal(dir.path());
+        reader.refresh_if_stale().unwrap();
+        assert_eq!(reader.max_generation(), 9);
+        assert_eq!(journal_generation_floor(dir.path()), 9);
+        assert_eq!(
+            journal_generation_floor(&dir.path().join("missing")),
+            0,
+            "no journal floors at zero"
+        );
     }
 
     #[test]
@@ -1650,6 +1825,8 @@ mod tests {
                     state,
                     urgency: None,
                     session_id: None,
+                    generation: None,
+                    boot_id: None,
                 })
                 .unwrap();
         }
@@ -1775,6 +1952,8 @@ mod tests {
                     state: s,
                     urgency: None,
                     session_id: None,
+                    generation: None,
+                    boot_id: None,
                 })
                 .unwrap();
         }
@@ -2015,6 +2194,8 @@ mod tests {
                     state,
                     urgency: None,
                     session_id: Some("sess-live".into()),
+                    generation: None,
+                    boot_id: None,
                 })
                 .unwrap();
         }
@@ -2062,6 +2243,8 @@ mod tests {
                 state: OccurrenceState::Completed,
                 urgency: None,
                 session_id: Some("sess-live".into()),
+                generation: None,
+                boot_id: None,
             })
             .unwrap();
         let released = plan(
@@ -2242,6 +2425,8 @@ mod tests {
                     state,
                     urgency: None,
                     session_id: None,
+                    generation: None,
+                    boot_id: None,
                 })
                 .unwrap();
         }
@@ -2574,6 +2759,8 @@ mod tests {
                 state: OccurrenceState::Delivered,
                 urgency: None,
                 session_id: None,
+                generation: None,
+                boot_id: None,
             })
             .unwrap();
         assert_eq!(
@@ -2666,6 +2853,8 @@ mod tests {
                     state,
                     urgency,
                     session_id: None,
+                    generation: None,
+                    boot_id: None,
                 })
                 .unwrap();
         }
@@ -2684,6 +2873,8 @@ mod tests {
                     state,
                     urgency: None,
                     session_id: session,
+                    generation: None,
+                    boot_id: None,
                 })
                 .unwrap();
         }
@@ -2830,6 +3021,8 @@ mod tests {
                             urgency: Some(ReminderUrgency::Info),
                             // Padding so a torn line would be visible.
                             session_id: Some("x".repeat(200)),
+                            generation: None,
+                            boot_id: None,
                         })
                         .unwrap();
                 }
@@ -3289,6 +3482,8 @@ mod tests {
                     state,
                     urgency: None,
                     session_id: Some("sess-fired".into()),
+                    generation: None,
+                    boot_id: None,
                 })
                 .unwrap();
         }

--- a/src/bin/caller/agenda/scheduler.rs
+++ b/src/bin/caller/agenda/scheduler.rs
@@ -10,8 +10,8 @@
 
 use super::handle::AgendaHandle;
 use super::reminders::{
-    plan, DueOccurrence, OccurrenceJournal, OccurrenceRecord, OccurrenceState, ReminderUrgency,
-    SpawnOccurrence,
+    plan, DueOccurrence, JournalStamp, OccurrenceJournal, OccurrenceRecord, OccurrenceState,
+    ReminderUrgency, SpawnOccurrence,
 };
 use super::store::OccurrenceWriteBack;
 use super::types::{AgendaActor, AgendaCommand};
@@ -197,7 +197,10 @@ impl SchedulerState {
     }
 }
 
-pub(crate) fn spawn_reminder_scheduler(handle: Arc<AgendaHandle>) -> tokio::task::JoinHandle<()> {
+pub(crate) fn spawn_reminder_scheduler(
+    handle: Arc<AgendaHandle>,
+    handover: Option<Arc<crate::handover::HandoverRuntime>>,
+) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut journal = match OccurrenceJournal::open(handle.dir()) {
             Ok(journal) => journal,
@@ -209,6 +212,15 @@ pub(crate) fn spawn_reminder_scheduler(handle: Arc<AgendaHandle>) -> tokio::task
                 return;
             }
         };
+        // Track HS: rows this daemon writes carry its boot id, and — when
+        // it holds the scheduler lease — the held generation. HS1 stamps
+        // only; HS2 gates the firing pass on the same runtime.
+        if let Some(handover) = &handover {
+            journal.set_stamp(Some(JournalStamp {
+                boot_id: handover.boot_id().to_string(),
+                generation: handover.held_generation(),
+            }));
+        }
         let mut state = SchedulerState::default();
         let mut events = handle.bus().subscribe();
         resolve_lost_sessions(&handle, &mut journal);
@@ -268,6 +280,8 @@ fn resolve_lost_sessions(handle: &AgendaHandle, journal: &mut OccurrenceJournal)
             state: OccurrenceState::Unknown,
             urgency: None,
             session_id: session_id.clone(),
+            generation: None,
+            boot_id: None,
         });
         // The journal row carries no effect_id, so find the owning effect by
         // its last_run lineage and make the item's state honest too.
@@ -320,6 +334,8 @@ fn resolve_lost_sessions(handle: &AgendaHandle, journal: &mut OccurrenceJournal)
             state: OccurrenceState::Unknown,
             urgency: None,
             session_id: None,
+            generation: None,
+            boot_id: None,
         });
         if let Some(item) = item_id
             .as_deref()
@@ -923,6 +939,8 @@ fn session_record(
         state,
         urgency: None,
         session_id,
+        generation: None,
+        boot_id: None,
     });
     if let Err(err) = &result {
         eprintln!(
@@ -1065,6 +1083,8 @@ fn record(
         state,
         urgency,
         session_id: None,
+        generation: None,
+        boot_id: None,
     });
     if let Err(err) = &result {
         eprintln!(

--- a/src/bin/caller/handover/lease.rs
+++ b/src/bin/caller/handover/lease.rs
@@ -263,7 +263,12 @@ mod tests {
         let _held = acquire(dir.path(), "boot-a", 0);
         let raw: serde_json::Value =
             serde_json::from_slice(&std::fs::read(sidecar_path(dir.path())).unwrap()).unwrap();
-        let mut keys: Vec<&str> = raw.as_object().unwrap().keys().map(String::as_str).collect();
+        let mut keys: Vec<&str> = raw
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
         keys.sort_unstable();
         assert_eq!(
             keys,

--- a/src/bin/caller/handover/lease.rs
+++ b/src/bin/caller/handover/lease.rs
@@ -1,0 +1,284 @@
+//! The active-scheduler lease (Track HS, intake §3.1): ONE co-homed daemon
+//! holds `<state root>/scheduler-lease/holder.lock` at a time, and that
+//! holder is the daemon that runs standing automations (the scheduler
+//! firing pass, reminder delivery, the PR scanner — gated in HS2).
+//!
+//! Two files, two jobs, deliberately separate:
+//!
+//! - `holder.lock` — an **empty** advisory-exclusive-locked file, held for
+//!   the holder's process lifetime. The flock IS the authority: crash
+//!   release is free (the OS drops the lock with the process), so there
+//!   are no heartbeats, no clocks, no staleness heuristics, and a zombie
+//!   holder is impossible. Same primitive the codebase already trusts in
+//!   `memory/store.rs` (`plane.lock`) and `file_watcher.rs` (`store.lock`).
+//!   It stays empty because Windows' LockFileEx blocks *reads* of a locked
+//!   file — data never rides the locked file itself.
+//! - `lease.json` — an atomically replaced sidecar describing the holder:
+//!   **observability only, never authority**. Dashboards, `ctl status`,
+//!   and a would-be successor read it; only a flock holder writes it
+//!   (writes are serialized by the flock itself).
+//!
+//! Generation is a monotonic audit counter: acquisition writes
+//! `max(previous sidecar generation, journal generation floor) + 1`. The
+//! journal floor (Q1 ruling hardening) means a deleted or corrupt sidecar
+//! cannot regress the counter below what journal rows already record.
+
+use serde::{Deserialize, Serialize};
+use std::fs::File;
+use std::path::{Path, PathBuf};
+
+/// Subdirectory of the state root holding the lease files.
+pub(crate) const LEASE_DIR: &str = "scheduler-lease";
+const HOLDER_LOCK_FILE: &str = "holder.lock";
+const LEASE_SIDECAR_FILE: &str = "lease.json";
+
+/// Build provenance of a lease/presence writer, embedded in the sidecars
+/// so "which binary is holding/draining" is answerable from disk.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct BuildVersion {
+    pub(crate) pkg: String,
+    pub(crate) git_sha: String,
+    pub(crate) built_at: String,
+}
+
+impl BuildVersion {
+    /// The running binary's own provenance (compile-time stamps).
+    pub(crate) fn current() -> Self {
+        BuildVersion {
+            pkg: crate::build_info::pkg_version().to_string(),
+            git_sha: crate::build_info::git_sha().to_string(),
+            built_at: crate::build_info::build_timestamp().to_string(),
+        }
+    }
+}
+
+/// `lease.json` — the holder's self-description. Additive evolution only;
+/// every reader treats a missing/corrupt sidecar as "no observability
+/// data", never as authority about the flock.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct LeaseSidecar {
+    pub(crate) v: u32,
+    /// Monotonic acquisition counter (see the module docs for the floor
+    /// rule). Survives crashes because the file does.
+    pub(crate) generation: u64,
+    pub(crate) boot_id: String,
+    pub(crate) pid: u32,
+    /// The holder's web-gateway port — how a secondary/successor names
+    /// the holder to the owner ("held by :8765").
+    pub(crate) port: u16,
+    pub(crate) version: BuildVersion,
+    /// `"active"` | `"draining"` (drain lands in HS3; readers must
+    /// tolerate future states).
+    pub(crate) state: String,
+    pub(crate) acquired_at_ms: u64,
+}
+
+/// The held lease: dropping releases the flock (process exit included).
+pub(crate) struct SchedulerLease {
+    /// Held for the holder's lifetime — the authority.
+    _lock: File,
+    sidecar: LeaseSidecar,
+}
+
+/// Outcome of a boot-time (or poll) acquisition attempt.
+pub(crate) enum LeaseAttempt {
+    /// We hold the flock; the sidecar was rewritten to name us.
+    Held(SchedulerLease),
+    /// Another live process holds the flock. The sidecar, if readable,
+    /// says who.
+    HeldElsewhere(Option<LeaseSidecar>),
+}
+
+impl SchedulerLease {
+    /// Try to acquire the lease under `state_root`. Never blocks; never
+    /// panics. `journal_generation_floor` is the max generation already
+    /// stamped on occurrence-journal rows (0 when none) — the Q1 reseed
+    /// floor.
+    ///
+    /// Errors are real I/O or lock-infrastructure failures (an unwritable
+    /// state root, a filesystem without lock support) — the caller
+    /// degrades to running without the lease and says so; `WouldBlock` is
+    /// not an error, it is [`LeaseAttempt::HeldElsewhere`].
+    pub(crate) fn try_acquire(
+        state_root: &Path,
+        boot_id: &str,
+        port: u16,
+        journal_generation_floor: u64,
+    ) -> std::io::Result<LeaseAttempt> {
+        let dir = state_root.join(LEASE_DIR);
+        std::fs::create_dir_all(&dir)?;
+        let lock = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(dir.join(HOLDER_LOCK_FILE))?;
+        match lock.try_lock() {
+            Ok(()) => {}
+            Err(std::fs::TryLockError::WouldBlock) => {
+                return Ok(LeaseAttempt::HeldElsewhere(read_lease_sidecar(state_root)));
+            }
+            Err(std::fs::TryLockError::Error(err)) => return Err(err),
+        }
+        let previous = read_lease_sidecar(state_root)
+            .map(|sidecar| sidecar.generation)
+            .unwrap_or(0);
+        let sidecar = LeaseSidecar {
+            v: 1,
+            generation: previous.max(journal_generation_floor) + 1,
+            boot_id: boot_id.to_string(),
+            pid: std::process::id(),
+            port,
+            version: BuildVersion::current(),
+            state: "active".to_string(),
+            acquired_at_ms: super::now_ms(),
+        };
+        write_lease_sidecar(&dir, &sidecar)?;
+        Ok(LeaseAttempt::Held(SchedulerLease {
+            _lock: lock,
+            sidecar,
+        }))
+    }
+
+    pub(crate) fn generation(&self) -> u64 {
+        self.sidecar.generation
+    }
+
+    pub(crate) fn sidecar(&self) -> &LeaseSidecar {
+        &self.sidecar
+    }
+}
+
+fn sidecar_path(state_root: &Path) -> PathBuf {
+    state_root.join(LEASE_DIR).join(LEASE_SIDECAR_FILE)
+}
+
+/// Read `lease.json` tolerantly: absent or unparseable yields `None`
+/// (observability data, never authority — a corrupt sidecar must not
+/// wedge acquisition; the generation floor covers the counter).
+pub(crate) fn read_lease_sidecar(state_root: &Path) -> Option<LeaseSidecar> {
+    let bytes = std::fs::read(sidecar_path(state_root)).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+fn write_lease_sidecar(dir: &Path, sidecar: &LeaseSidecar) -> std::io::Result<()> {
+    let body = serde_json::to_vec_pretty(sidecar)
+        .map_err(|err| std::io::Error::other(format!("encode lease sidecar: {err}")))?;
+    super::write_atomic(&dir.join(LEASE_SIDECAR_FILE), &body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn acquire(root: &Path, boot_id: &str, floor: u64) -> LeaseAttempt {
+        SchedulerLease::try_acquire(root, boot_id, 8765, floor).expect("lease io")
+    }
+
+    #[test]
+    fn lease_generation_monotonic_across_reacquire() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = match acquire(dir.path(), "boot-a", 0) {
+            LeaseAttempt::Held(lease) => lease,
+            LeaseAttempt::HeldElsewhere(_) => panic!("fresh dir must acquire"),
+        };
+        assert_eq!(first.generation(), 1);
+        drop(first); // release (crash or graceful — same OS semantics)
+
+        let second = match acquire(dir.path(), "boot-b", 0) {
+            LeaseAttempt::Held(lease) => lease,
+            LeaseAttempt::HeldElsewhere(_) => panic!("released lock must reacquire"),
+        };
+        assert_eq!(second.generation(), 2, "sidecar carries the counter");
+        drop(second);
+
+        let third = match acquire(dir.path(), "boot-c", 0) {
+            LeaseAttempt::Held(lease) => lease,
+            LeaseAttempt::HeldElsewhere(_) => panic!("released lock must reacquire"),
+        };
+        assert_eq!(third.generation(), 3);
+    }
+
+    #[test]
+    fn acquire_with_missing_sidecar_reseeds_generation_from_journal_floor() {
+        let dir = tempfile::tempdir().unwrap();
+        // No sidecar at all: the journal floor alone carries the history.
+        let lease = match acquire(dir.path(), "boot-a", 7) {
+            LeaseAttempt::Held(lease) => lease,
+            LeaseAttempt::HeldElsewhere(_) => panic!("fresh dir must acquire"),
+        };
+        assert_eq!(
+            lease.generation(),
+            8,
+            "a deleted sidecar cannot regress the audit counter below journal rows"
+        );
+        drop(lease);
+
+        // Corrupt sidecar: same reseed path (tolerant read = None).
+        std::fs::write(sidecar_path(dir.path()), b"not json at all").unwrap();
+        let lease = match acquire(dir.path(), "boot-b", 9) {
+            LeaseAttempt::Held(lease) => lease,
+            LeaseAttempt::HeldElsewhere(_) => panic!("corrupt sidecar must not wedge"),
+        };
+        assert_eq!(lease.generation(), 10);
+        drop(lease);
+
+        // Sidecar ahead of the floor: the sidecar wins the max.
+        let lease = match acquire(dir.path(), "boot-c", 3) {
+            LeaseAttempt::Held(lease) => lease,
+            LeaseAttempt::HeldElsewhere(_) => panic!("released lock must reacquire"),
+        };
+        assert_eq!(lease.generation(), 11);
+    }
+
+    #[test]
+    fn second_acquire_while_held_reports_holder_not_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let held = match acquire(dir.path(), "boot-a", 0) {
+            LeaseAttempt::Held(lease) => lease,
+            LeaseAttempt::HeldElsewhere(_) => panic!("fresh dir must acquire"),
+        };
+        // A second open file description in this same process is denied
+        // exactly like a second process would be (flock/LockFileEx are
+        // per-description, not per-process) — the two-daemons-one-home
+        // topology in one test.
+        match acquire(dir.path(), "boot-b", 0) {
+            LeaseAttempt::Held(_) => panic!("held lock must not double-acquire"),
+            LeaseAttempt::HeldElsewhere(sidecar) => {
+                let sidecar = sidecar.expect("holder wrote the sidecar before we probed");
+                assert_eq!(sidecar.boot_id, "boot-a");
+                assert_eq!(sidecar.state, "active");
+                assert_eq!(sidecar.generation, held.generation());
+            }
+        }
+        // Sidecar survives verbatim for observability while held.
+        let on_disk = read_lease_sidecar(dir.path()).expect("sidecar readable");
+        assert_eq!(on_disk.boot_id, "boot-a");
+        assert_eq!(on_disk.pid, std::process::id());
+    }
+
+    #[test]
+    fn sidecar_shape_is_the_declared_contract() {
+        let dir = tempfile::tempdir().unwrap();
+        let _held = acquire(dir.path(), "boot-a", 0);
+        let raw: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(sidecar_path(dir.path())).unwrap()).unwrap();
+        let mut keys: Vec<&str> = raw.as_object().unwrap().keys().map(String::as_str).collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            [
+                "acquired_at_ms",
+                "boot_id",
+                "generation",
+                "pid",
+                "port",
+                "state",
+                "v",
+                "version"
+            ],
+            "lease.json grows only by deliberate review — no secrets, ever"
+        );
+        assert_eq!(raw["version"]["pkg"], crate::build_info::pkg_version());
+    }
+}

--- a/src/bin/caller/handover/mod.rs
+++ b/src/bin/caller/handover/mod.rs
@@ -56,14 +56,14 @@ impl HandoverRuntime {
     /// (HS1 is behavior-neutral — the daemon must run exactly as before).
     pub(crate) fn initialize(state_root: &Path, port: u16, journal_generation_floor: u64) -> Self {
         let boot_id = ulid::Ulid::new().to_string().to_lowercase();
-        let (presence, presence_error) =
-            match DaemonPresence::register(state_root, &boot_id, port) {
-                Ok(presence) => (Some(presence), None),
-                Err(err) => {
-                    eprintln!("[handover] presence registration failed: {err}");
-                    (None, Some(err.to_string()))
-                }
-            };
+        let (presence, presence_error) = match DaemonPresence::register(state_root, &boot_id, port)
+        {
+            Ok(presence) => (Some(presence), None),
+            Err(err) => {
+                eprintln!("[handover] presence registration failed: {err}");
+                (None, Some(err.to_string()))
+            }
+        };
         let (held, lease_error) =
             match SchedulerLease::try_acquire(state_root, &boot_id, port, journal_generation_floor)
             {

--- a/src/bin/caller/handover/mod.rs
+++ b/src/bin/caller/handover/mod.rs
@@ -1,0 +1,249 @@
+//! Graceful daemon handover (Track HS). Co-homed daemons are the normal
+//! dev topology on this codebase (worktree agent instances boot
+//! constantly against one `~/.intendant`), and binary updates want a
+//! successor daemon to take over standing automations without
+//! kill-and-relaunch. The machinery, per the sealed design intake
+//! (`daemon-handover-intake.md`, ruled 2026-07-26):
+//!
+//! - [`lease`] — the **active-scheduler lease**: an advisory flock
+//!   (`scheduler-lease/holder.lock`) whose holder is the one daemon that
+//!   runs standing automations, plus an observability sidecar
+//!   (`lease.json`). Crash release is free; authority is the flock,
+//!   never the JSON.
+//! - [`presence`] — **per-boot presence files** (`daemons/<boot_id>.*`):
+//!   liveness of any boot is "can I take its lock?", the substrate for
+//!   scoped boot recovery (HS2) and the handover UI (HS3/HS5).
+//! - [`HandoverRuntime`] — the process-wide view: this boot's identity,
+//!   whether it holds the lease, and the status JSON `ctl status` and
+//!   the dashboard serve.
+//!
+//! Slice map: HS1 (this module + journal generation stamping; behavior-
+//! neutral), HS2 (firing gated on the lease + scoped boot recovery +
+//! secondary poll-acquire), HS3 (drain + takeover), HS4 (memory-plane
+//! transfer), HS5 (discovery handoff), HS6 (update surface).
+
+mod lease;
+mod presence;
+
+pub(crate) use lease::{read_lease_sidecar, LeaseAttempt, SchedulerLease};
+pub(crate) use presence::{boot_id_is_live, read_presence_records, DaemonPresence};
+
+use std::path::{Path, PathBuf};
+
+/// The process-wide handover state: one per gateway-shaped boot, shared
+/// (via `Arc`) by the scheduler, the MCP status surface, and — in later
+/// slices — the drain/takeover lanes.
+pub(crate) struct HandoverRuntime {
+    state_root: PathBuf,
+    boot_id: String,
+    /// The held lease. `None` = secondary (another daemon holds it) or
+    /// lease infrastructure failure (`lease_error` says which). Std
+    /// mutex — never held across an await; HS2's poll-acquire and HS3's
+    /// drain release mutate the slot.
+    lease: std::sync::Mutex<Option<SchedulerLease>>,
+    /// A real I/O or lock-infrastructure failure at the boot attempt
+    /// ("held elsewhere" is NOT an error). Status surfaces carry it so a
+    /// lockless filesystem degrades loudly, not silently.
+    lease_error: Option<String>,
+    _presence: Option<DaemonPresence>,
+    presence_error: Option<String>,
+}
+
+impl HandoverRuntime {
+    /// Mint this boot's identity, register presence, and try the lease
+    /// once. Infallible by design: every failure degrades to a named
+    /// field on the status surface and a log line, never a refused boot
+    /// (HS1 is behavior-neutral — the daemon must run exactly as before).
+    pub(crate) fn initialize(state_root: &Path, port: u16, journal_generation_floor: u64) -> Self {
+        let boot_id = ulid::Ulid::new().to_string().to_lowercase();
+        let (presence, presence_error) =
+            match DaemonPresence::register(state_root, &boot_id, port) {
+                Ok(presence) => (Some(presence), None),
+                Err(err) => {
+                    eprintln!("[handover] presence registration failed: {err}");
+                    (None, Some(err.to_string()))
+                }
+            };
+        let (held, lease_error) =
+            match SchedulerLease::try_acquire(state_root, &boot_id, port, journal_generation_floor)
+            {
+                Ok(LeaseAttempt::Held(lease)) => {
+                    println!(
+                        "[handover] holding the scheduler lease (generation {})",
+                        lease.generation()
+                    );
+                    (Some(lease), None)
+                }
+                Ok(LeaseAttempt::HeldElsewhere(sidecar)) => {
+                    match &sidecar {
+                        Some(holder) => eprintln!(
+                            "[handover] scheduler lease held by boot {} (pid {}, :{}) — \
+                             running as secondary",
+                            holder.boot_id, holder.pid, holder.port
+                        ),
+                        None => eprintln!(
+                            "[handover] scheduler lease held by another daemon — \
+                             running as secondary"
+                        ),
+                    }
+                    (None, None)
+                }
+                Err(err) => {
+                    eprintln!(
+                        "[handover] scheduler lease unavailable ({err}) — \
+                         running without the lease"
+                    );
+                    (None, Some(err.to_string()))
+                }
+            };
+        HandoverRuntime {
+            state_root: state_root.to_path_buf(),
+            boot_id,
+            lease: std::sync::Mutex::new(held),
+            lease_error,
+            _presence: presence,
+            presence_error,
+        }
+    }
+
+    pub(crate) fn boot_id(&self) -> &str {
+        &self.boot_id
+    }
+
+    /// The held lease's generation; `None` while running as secondary.
+    pub(crate) fn held_generation(&self) -> Option<u64> {
+        self.lease
+            .lock()
+            .ok()
+            .and_then(|slot| slot.as_ref().map(SchedulerLease::generation))
+    }
+
+    /// The `scheduler_lease` status block (`ctl status` / dashboard):
+    /// this daemon's own view, the sidecar as it sits on disk
+    /// (observability of whoever holds, honest `null` when nobody does),
+    /// and every registered co-homed boot with its probed liveness — the
+    /// dual-run topology made visible.
+    pub(crate) fn status_json(&self) -> serde_json::Value {
+        let (held, generation, acquired_at_ms) = match self.lease.lock() {
+            Ok(slot) => match slot.as_ref() {
+                Some(lease) => (
+                    true,
+                    Some(lease.generation()),
+                    Some(lease.sidecar().acquired_at_ms),
+                ),
+                None => (false, None, None),
+            },
+            Err(_) => (false, None, None),
+        };
+        let daemons: Vec<serde_json::Value> = read_presence_records(&self.state_root)
+            .into_iter()
+            .map(|record| {
+                let live = boot_id_is_live(&self.state_root, &record.boot_id);
+                let mut value =
+                    serde_json::to_value(&record).unwrap_or_else(|_| serde_json::json!({}));
+                if let Some(obj) = value.as_object_mut() {
+                    obj.insert("live".into(), live.into());
+                }
+                value
+            })
+            .collect();
+        let mut block = serde_json::json!({
+            "boot_id": self.boot_id,
+            "held": held,
+            "sidecar": read_lease_sidecar(&self.state_root),
+            "daemons": daemons,
+        });
+        let obj = block.as_object_mut().expect("literal object");
+        if let Some(generation) = generation {
+            obj.insert("generation".into(), generation.into());
+        }
+        if let Some(acquired_at_ms) = acquired_at_ms {
+            obj.insert("acquired_at_ms".into(), acquired_at_ms.into());
+        }
+        if let Some(err) = &self.lease_error {
+            obj.insert("error".into(), err.clone().into());
+        }
+        if let Some(err) = &self.presence_error {
+            obj.insert("presence_error".into(), err.clone().into());
+        }
+        block
+    }
+}
+
+pub(crate) fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Atomic replace, the `cli_descriptor` shape: readers never see a
+/// partial file. Same-directory rename; the temp name is deterministic
+/// per target, which is safe everywhere it is used (lease.json writes
+/// are serialized by the flock; presence targets are per-boot).
+fn write_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let tmp = path.with_extension("tmp");
+    std::fs::write(&tmp, bytes)?;
+    std::fs::rename(&tmp, path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn initialize_registers_presence_and_takes_free_lease() {
+        let dir = tempfile::tempdir().unwrap();
+        let runtime = HandoverRuntime::initialize(dir.path(), 8765, 0);
+        assert_eq!(runtime.held_generation(), Some(1));
+        assert!(boot_id_is_live(dir.path(), runtime.boot_id()));
+
+        let status = runtime.status_json();
+        assert_eq!(status["held"], true);
+        assert_eq!(status["generation"], 1);
+        assert_eq!(status["boot_id"], runtime.boot_id());
+        assert_eq!(status["sidecar"]["boot_id"], runtime.boot_id());
+        assert!(status.get("error").is_none());
+        let daemons = status["daemons"].as_array().expect("daemons array");
+        assert_eq!(daemons.len(), 1);
+        assert_eq!(daemons[0]["boot_id"], runtime.boot_id());
+        assert_eq!(daemons[0]["live"], true);
+    }
+
+    #[test]
+    fn second_runtime_on_one_home_runs_as_secondary() {
+        let dir = tempfile::tempdir().unwrap();
+        let holder = HandoverRuntime::initialize(dir.path(), 8765, 0);
+        let secondary = HandoverRuntime::initialize(dir.path(), 8766, 0);
+        assert_eq!(secondary.held_generation(), None);
+
+        let status = secondary.status_json();
+        assert_eq!(status["held"], false);
+        assert!(status.get("generation").is_none());
+        // The sidecar still names the holder — that is the observability
+        // contract a secondary's dashboard leans on.
+        assert_eq!(status["sidecar"]["boot_id"], holder.boot_id());
+        assert!(
+            status.get("error").is_none(),
+            "held-elsewhere is a role, not an error"
+        );
+        // Both boots are live presences (the dual-run topology, visible).
+        assert!(boot_id_is_live(dir.path(), holder.boot_id()));
+        assert!(boot_id_is_live(dir.path(), secondary.boot_id()));
+    }
+
+    #[test]
+    fn dropped_runtime_releases_lease_and_liveness() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = HandoverRuntime::initialize(dir.path(), 8765, 0);
+        let first_boot = first.boot_id().to_string();
+        drop(first);
+        assert!(!boot_id_is_live(dir.path(), &first_boot));
+        let second = HandoverRuntime::initialize(dir.path(), 8766, 0);
+        assert_eq!(
+            second.held_generation(),
+            Some(2),
+            "released lease reacquires with a bumped generation"
+        );
+    }
+}

--- a/src/bin/caller/handover/presence.rs
+++ b/src/bin/caller/handover/presence.rs
@@ -1,0 +1,318 @@
+//! Per-boot daemon presence (Track HS, intake §3.2): each gateway-shaped
+//! boot registers itself under `<state root>/daemons/` as
+//!
+//! - `<boot_id>.lock` — an **empty** file whose advisory exclusive lock
+//!   the daemon holds for its process lifetime. Liveness of any boot_id
+//!   is "can I take its lock?" — the same clock-free primitive as the
+//!   scheduler lease, so a crashed daemon is *provably* dead (the OS
+//!   released its lock) and a live one *provably* live (the probe gets
+//!   `WouldBlock`). No heartbeats, no staleness heuristics.
+//! - `<boot_id>.json` — an atomically rewritten description
+//!   (pid/port/version/state), observability only. Boot-recovery scoping
+//!   (HS2) keys on the *lock*, never the JSON.
+//!
+//! Registration order is load-bearing: the lock is acquired **before**
+//! the JSON is written, so a probe that finds `<boot_id>.json` and a
+//! takeable `<boot_id>.lock` has proof of death, not a boot-in-progress.
+//! GC (at registration) additionally spares unpaired lock files unless
+//! they are old — a just-created lock whose JSON hasn't landed yet is
+//! never swept by a concurrently booting daemon.
+
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+use super::lease::BuildVersion;
+
+/// Subdirectory of the state root holding per-boot presence files.
+pub(crate) const DAEMONS_DIR: &str = "daemons";
+
+/// Spare an unpaired `.lock` (no `.json` beside it) younger than this
+/// during GC: it is a registration in progress, not a corpse. Generous —
+/// the create→lock→write window is microseconds.
+const UNPAIRED_LOCK_GRACE: std::time::Duration = std::time::Duration::from_secs(10 * 60);
+
+/// `<boot_id>.json` — one daemon boot's self-description.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct PresenceRecord {
+    pub(crate) v: u32,
+    pub(crate) boot_id: String,
+    pub(crate) pid: u32,
+    pub(crate) port: u16,
+    pub(crate) version: BuildVersion,
+    /// `"running"` now; HS3 adds `"draining"`/`"exited"`. Readers must
+    /// tolerate future states.
+    pub(crate) state: String,
+    /// Supervised-session count, once a reporter exists (HS3 wires the
+    /// drain-exit condition); absent = not reported, never "zero".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) session_count: Option<u64>,
+    pub(crate) updated_ms: u64,
+}
+
+/// A live registration: dropping releases the boot lock (the JSON stays
+/// for the next GC sweep to reap, or for HS3's graceful-exit rewrite).
+pub(crate) struct DaemonPresence {
+    dir: PathBuf,
+    record: PresenceRecord,
+    /// Held for the process lifetime — the liveness substrate.
+    _lock: std::fs::File,
+}
+
+impl DaemonPresence {
+    /// Sweep provably dead boots, then register this one. Never panics;
+    /// I/O errors surface to the caller, which degrades to running
+    /// without presence (and says so).
+    pub(crate) fn register(
+        state_root: &Path,
+        boot_id: &str,
+        port: u16,
+    ) -> std::io::Result<DaemonPresence> {
+        let dir = state_root.join(DAEMONS_DIR);
+        std::fs::create_dir_all(&dir)?;
+        sweep_dead_boots(&dir);
+        let lock = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(dir.join(format!("{boot_id}.lock")))?;
+        match lock.try_lock() {
+            Ok(()) => {}
+            Err(std::fs::TryLockError::WouldBlock) => {
+                // Boot ids are fresh ULIDs; a held lock under our id means
+                // id reuse, which is a bug worth refusing loudly.
+                return Err(std::io::Error::other(format!(
+                    "presence lock for boot {boot_id} is already held"
+                )));
+            }
+            Err(std::fs::TryLockError::Error(err)) => return Err(err),
+        }
+        let record = PresenceRecord {
+            v: 1,
+            boot_id: boot_id.to_string(),
+            pid: std::process::id(),
+            port,
+            version: BuildVersion::current(),
+            state: "running".to_string(),
+            session_count: None,
+            updated_ms: super::now_ms(),
+        };
+        let presence = DaemonPresence {
+            dir,
+            record,
+            _lock: lock,
+        };
+        presence.write_record()?;
+        Ok(presence)
+    }
+
+    /// This boot's own record (HS3 mutates it through the drain states;
+    /// until then a test/diagnostic seam).
+    #[cfg(test)]
+    pub(crate) fn record(&self) -> &PresenceRecord {
+        &self.record
+    }
+
+    fn write_record(&self) -> std::io::Result<()> {
+        let body = serde_json::to_vec_pretty(&self.record)
+            .map_err(|err| std::io::Error::other(format!("encode presence: {err}")))?;
+        super::write_atomic(
+            &self.dir.join(format!("{}.json", self.record.boot_id)),
+            &body,
+        )
+    }
+}
+
+/// Is the daemon that minted `boot_id` still alive? True on `WouldBlock`
+/// (its process holds the lock), false when the lock is takeable or the
+/// lock file is gone (the process died or never registered). Probe
+/// errors report **live** — the fail-safe direction for every consumer
+/// (recovery must not clobber, GC must not sweep, on uncertainty).
+pub(crate) fn boot_id_is_live(state_root: &Path, boot_id: &str) -> bool {
+    let path = state_root
+        .join(DAEMONS_DIR)
+        .join(format!("{boot_id}.lock"));
+    probe_lock_is_held(&path).unwrap_or(true)
+}
+
+/// `Ok(true)` = held (live), `Ok(false)` = takeable or absent (dead),
+/// `Err` = cannot tell.
+fn probe_lock_is_held(path: &Path) -> std::io::Result<bool> {
+    let file = match std::fs::OpenOptions::new().read(true).write(true).open(path) {
+        Ok(file) => file,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(err) => return Err(err),
+    };
+    match file.try_lock() {
+        Ok(()) => {
+            // Release promptly rather than waiting for close (Windows may
+            // release handle-held locks asynchronously on close).
+            let _ = file.unlock();
+            Ok(false)
+        }
+        Err(std::fs::TryLockError::WouldBlock) => Ok(true),
+        Err(std::fs::TryLockError::Error(err)) => Err(err),
+    }
+}
+
+/// Reap presence pairs whose boot is provably dead (takeable lock), plus
+/// orphan JSONs with no lock file at all. NotFound-tolerant like the
+/// coordination-bus GC — concurrent sweeps at two daemons' boots are
+/// safe. Unpaired lock files get [`UNPAIRED_LOCK_GRACE`] before they are
+/// treated as debris.
+fn sweep_dead_boots(dir: &Path) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        match path.extension().and_then(|ext| ext.to_str()) {
+            Some("lock") => {
+                let json = path.with_extension("json");
+                if !json.exists() {
+                    // Registration in progress, or debris: age decides.
+                    let old = entry
+                        .metadata()
+                        .and_then(|meta| meta.modified())
+                        .ok()
+                        .and_then(|modified| modified.elapsed().ok())
+                        .is_some_and(|age| age > UNPAIRED_LOCK_GRACE);
+                    if !old {
+                        continue;
+                    }
+                }
+                if matches!(probe_lock_is_held(&path), Ok(false)) {
+                    let _ = std::fs::remove_file(&json);
+                    let _ = std::fs::remove_file(&path);
+                }
+            }
+            Some("json") => {
+                if !path.with_extension("lock").exists() {
+                    let _ = std::fs::remove_file(&path);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Every readable presence record, for status surfaces (the successor
+/// chip and the drain views read these in HS3/HS5). Unreadable files are
+/// skipped — display currency, never authority.
+pub(crate) fn read_presence_records(state_root: &Path) -> Vec<PresenceRecord> {
+    let dir = state_root.join(DAEMONS_DIR);
+    let mut records = Vec::new();
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return records;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(bytes) = std::fs::read(&path) else {
+            continue;
+        };
+        if let Ok(record) = serde_json::from_slice::<PresenceRecord>(&bytes) {
+            records.push(record);
+        }
+    }
+    records.sort_by(|a, b| a.boot_id.cmp(&b.boot_id));
+    records
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn boot_liveness_is_lock_takeability() {
+        let dir = tempfile::tempdir().unwrap();
+        // Never registered: not live.
+        assert!(!boot_id_is_live(dir.path(), "boot-a"));
+
+        let presence = DaemonPresence::register(dir.path(), "boot-a", 8765).expect("register");
+        // Held lock (probed from a second description in this same
+        // process — flock/LockFileEx deny per-description, so the probe
+        // sees exactly what another daemon would): live.
+        assert!(boot_id_is_live(dir.path(), "boot-a"));
+
+        // Released lock (crash or exit — the OS frees it either way): dead,
+        // even though the files are still on disk.
+        drop(presence);
+        assert!(!boot_id_is_live(dir.path(), "boot-a"));
+    }
+
+    #[test]
+    fn register_writes_record_and_next_boot_sweeps_the_dead() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = DaemonPresence::register(dir.path(), "boot-a", 8765).expect("register");
+        assert_eq!(first.record().state, "running");
+        assert_eq!(first.record().pid, std::process::id());
+        let json_path = dir.path().join(DAEMONS_DIR).join("boot-a.json");
+        let raw: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&json_path).unwrap()).unwrap();
+        assert_eq!(raw["boot_id"], "boot-a");
+        assert!(
+            raw.get("session_count").is_none(),
+            "unreported count stays absent, never a fake zero"
+        );
+
+        // "Crash" boot-a, then boot-b registers: the sweep reaps the
+        // provably dead pair and leaves the live one alone.
+        drop(first);
+        let second = DaemonPresence::register(dir.path(), "boot-b", 8766).expect("register");
+        assert!(!json_path.exists(), "dead presence swept at next boot");
+        assert!(!dir.path().join(DAEMONS_DIR).join("boot-a.lock").exists());
+        assert!(boot_id_is_live(dir.path(), "boot-b"));
+        drop(second);
+    }
+
+    #[test]
+    fn sweep_spares_live_boots_and_young_unpaired_locks() {
+        let dir = tempfile::tempdir().unwrap();
+        let live = DaemonPresence::register(dir.path(), "boot-live", 8765).expect("register");
+
+        // A registration in progress elsewhere: lock file exists (young,
+        // unpaired) — must survive the sweep.
+        let daemons = dir.path().join(DAEMONS_DIR);
+        std::fs::write(daemons.join("boot-young.lock"), b"").unwrap();
+        // An orphan record with no lock file at all: debris — swept.
+        std::fs::write(daemons.join("boot-orphan.json"), b"{}").unwrap();
+
+        let other = DaemonPresence::register(dir.path(), "boot-b", 8766).expect("register");
+        assert!(boot_id_is_live(dir.path(), "boot-live"));
+        assert!(daemons.join("boot-live.json").exists());
+        assert!(
+            daemons.join("boot-young.lock").exists(),
+            "young unpaired lock = boot in progress, never debris"
+        );
+        assert!(!daemons.join("boot-orphan.json").exists());
+        drop(other);
+        drop(live);
+    }
+
+    #[test]
+    fn read_presence_records_skips_unreadable_and_sorts() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = DaemonPresence::register(dir.path(), "boot-a", 1111).expect("register");
+        let b = DaemonPresence::register(dir.path(), "boot-b", 2222).expect("register");
+        std::fs::write(
+            dir.path().join(DAEMONS_DIR).join("boot-junk.json"),
+            b"not json",
+        )
+        .unwrap();
+        let records = read_presence_records(dir.path());
+        assert_eq!(
+            records
+                .iter()
+                .map(|record| record.boot_id.as_str())
+                .collect::<Vec<_>>(),
+            ["boot-a", "boot-b"]
+        );
+        assert_eq!(records[0].port, 1111);
+        drop(a);
+        drop(b);
+    }
+}

--- a/src/bin/caller/handover/presence.rs
+++ b/src/bin/caller/handover/presence.rs
@@ -129,16 +129,18 @@ impl DaemonPresence {
 /// errors report **live** — the fail-safe direction for every consumer
 /// (recovery must not clobber, GC must not sweep, on uncertainty).
 pub(crate) fn boot_id_is_live(state_root: &Path, boot_id: &str) -> bool {
-    let path = state_root
-        .join(DAEMONS_DIR)
-        .join(format!("{boot_id}.lock"));
+    let path = state_root.join(DAEMONS_DIR).join(format!("{boot_id}.lock"));
     probe_lock_is_held(&path).unwrap_or(true)
 }
 
 /// `Ok(true)` = held (live), `Ok(false)` = takeable or absent (dead),
 /// `Err` = cannot tell.
 fn probe_lock_is_held(path: &Path) -> std::io::Result<bool> {
-    let file = match std::fs::OpenOptions::new().read(true).write(true).open(path) {
+    let file = match std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)
+    {
         Ok(file) => file,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(false),
         Err(err) => return Err(err),
@@ -187,10 +189,8 @@ fn sweep_dead_boots(dir: &Path) {
                     let _ = std::fs::remove_file(&path);
                 }
             }
-            Some("json") => {
-                if !path.with_extension("lock").exists() {
-                    let _ = std::fs::remove_file(&path);
-                }
+            Some("json") if !path.with_extension("lock").exists() => {
+                let _ = std::fs::remove_file(&path);
             }
             _ => {}
         }

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -57,6 +57,7 @@ pub(crate) use intendant_core::frames;
 mod frontend;
 mod gateway_routes;
 mod global_store;
+mod handover;
 mod hosted_verify;
 mod key_custody;
 mod lease_transcript_staging;

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -1575,6 +1575,12 @@ impl IntendantServer {
                 "daemon_version".to_string(),
                 serde_json::Value::String(crate::build_info::version_line("intendant")),
             );
+            // The scheduler-lease view (Track HS): this daemon's boot id
+            // and lease role, plus the on-disk sidecar naming whoever
+            // holds — how `ctl status`/the dashboard see a handover.
+            if let Some(handover) = &s.handover {
+                obj.insert("scheduler_lease".to_string(), handover.status_json());
+            }
             obj.insert(
                 "session_id".to_string(),
                 serde_json::Value::String(session_id.clone()),

--- a/src/bin/caller/mcp/state.rs
+++ b/src/bin/caller/mcp/state.rs
@@ -140,6 +140,10 @@ pub struct McpAppState {
     /// bootstrap ceremony failed — memory surfaces then answer
     /// "unavailable" instead of failing the daemon.
     pub memory: Option<std::sync::Arc<crate::memory::MemoryHandle>>,
+    /// The daemon-handover runtime (Track HS): this boot's identity and
+    /// scheduler-lease view, for the `scheduler_lease` status block.
+    /// `None` outside the gateway/daemon shapes.
+    pub handover: Option<std::sync::Arc<crate::handover::HandoverRuntime>>,
     /// Directory for screenshot output.
     pub screenshot_dir: Option<std::path::PathBuf>,
     /// Persistent counter for screenshot filenames (avoids overwriting).
@@ -327,6 +331,7 @@ impl McpAppState {
             peer_registry: None,
             agenda: None,
             memory: None,
+            handover: None,
             user_display_activation_pending: std::collections::HashMap::new(),
             display_capture_ready: HashSet::new(),
             screenshot_dir: None,

--- a/src/bin/caller/startup/wiring.rs
+++ b/src/bin/caller/startup/wiring.rs
@@ -312,12 +312,25 @@ pub(crate) fn spawn_mode_web_gateway(
     // attach while an `ask_user` blocks, so asks wait instead of
     // auto-answering.
     mcp_http_state.interactive_frontends = true;
+    // The handover runtime (Track HS): mint this boot's identity,
+    // register its liveness presence, and try the active-scheduler lease
+    // once. HS1 is behavior-neutral — holding or not holding changes
+    // nothing yet (HS2 gates standing automations on it); the primitive,
+    // the presence files, the journal stamp, and the status surfaces land
+    // first so the protocol has ground truth to stand on. Every failure
+    // degrades to a named status field, never a refused boot.
+    let agenda_dir = crate::agenda::agenda_dir();
+    let handover = Arc::new(crate::handover::HandoverRuntime::initialize(
+        &crate::platform::intendant_home(),
+        web_port,
+        crate::agenda::journal_generation_floor(&agenda_dir),
+    ));
+    mcp_http_state.handover = Some(handover.clone());
     // The daemon's agenda ledger: one single-writer handle shared by the
     // MCP tools, the HTTP routes, and the dashboard tunnel twins, plus
     // the reminder scheduler that delivers due items through the
     // notification ladder. A store that fails to open degrades to
     // "agenda unavailable" instead of failing the gateway.
-    let agenda_dir = crate::agenda::agenda_dir();
     mcp_http_state.agenda = match crate::agenda::AgendaStore::open(&agenda_dir) {
         Ok(store) => {
             let handle = Arc::new(
@@ -333,7 +346,8 @@ pub(crate) fn spawn_mode_web_gateway(
                     }),
             );
             // Detaches on drop like the mode listeners; one per daemon.
-            let _scheduler = crate::agenda::spawn_reminder_scheduler(handle.clone());
+            let _scheduler =
+                crate::agenda::spawn_reminder_scheduler(handle.clone(), Some(handover.clone()));
             // Resolves rail answers/dismissals for parked (agenda-backed)
             // asks — nothing blocks on them, so the daemon records the
             // outcome. Detaches on drop like the scheduler.

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -11,6 +11,26 @@
 //! could not resolve git — or a hypothetical build where the directives are
 //! absent — still compiles and reports `unknown` instead of failing.
 
+/// Package version (`unknown` only in a hypothetical directive-less build).
+pub(crate) fn pkg_version() -> &'static str {
+    option_env!("CARGO_PKG_VERSION").unwrap_or("unknown")
+}
+
+/// Git commit short SHA, with `-dirty` marker when built from a dirty tree.
+pub(crate) fn git_sha() -> &'static str {
+    option_env!("INTENDANT_GIT_SHA").unwrap_or("unknown")
+}
+
+/// Build timestamp as `build.rs` stamped it.
+pub(crate) fn build_timestamp() -> &'static str {
+    option_env!("INTENDANT_BUILD_TIMESTAMP").unwrap_or("unknown")
+}
+
+/// Target triple the binary was compiled for.
+pub(crate) fn target_triple() -> &'static str {
+    option_env!("INTENDANT_TARGET_TRIPLE").unwrap_or("unknown")
+}
+
 /// One-line version + provenance string: package version, git commit short
 /// SHA (with `-dirty` marker), build timestamp, and target triple. Contains
 /// no credentials, hostnames, usernames, or filesystem paths — safe to print
@@ -19,10 +39,10 @@ pub(crate) fn version_line(binary: &str) -> String {
     format!(
         "{} {} (commit {}, built {}, {})",
         binary,
-        option_env!("CARGO_PKG_VERSION").unwrap_or("unknown"),
-        option_env!("INTENDANT_GIT_SHA").unwrap_or("unknown"),
-        option_env!("INTENDANT_BUILD_TIMESTAMP").unwrap_or("unknown"),
-        option_env!("INTENDANT_TARGET_TRIPLE").unwrap_or("unknown"),
+        pkg_version(),
+        git_sha(),
+        build_timestamp(),
+        target_triple(),
     )
 }
 


### PR DESCRIPTION
Track HS slice 1 of 6 (graceful daemon handover; sealed design intake `daemon-handover-intake.md`, ruled 2026-07-26 with Q1–Q10 accepted). **Behavior-neutral by design** — nothing fires differently yet; HS2 gates standing automations on the lease.

## What lands

- **`src/bin/caller/handover/`** — the active-scheduler lease: `scheduler-lease/holder.lock` (advisory exclusive flock held for the holder's process lifetime — crash release is free, no heartbeats/clocks; the same primitive as `memory/store.rs` `plane.lock` and `file_watcher.rs` `store.lock`) + `lease.json` observability sidecar (atomic replace; **never authority**). Generation = `max(previous sidecar, journal floor) + 1` — the Q1 ruling hardening: a deleted/corrupt sidecar cannot regress the audit counter.
- **Per-boot presence files** `daemons/<boot_id>.{lock,json}`: liveness of any boot is "can I take its lock?" — the substrate for HS2's scoped boot recovery. Lock acquired **before** the JSON is written; NotFound-tolerant GC at registration with a grace window for unpaired young locks.
- **Journal generation stamping**: `OccurrenceRecord` gains optional `generation`/`boot_id` (additive JSON, serde-default folds, raw page serves them verbatim; journal-side ONLY per the Q3 guardrail — the `deny_unknown_fields` op-log vocabulary is untouched). The scheduler's journal instance is stamped at open; the fold tracks max stamped generation as the lease reseed floor.
- **Status surfaces**: `get_status` (ctl status + dashboard tunnel) gains `scheduler_lease` — this boot's role, the on-disk sidecar, and every registered co-homed boot with probed liveness.

## Conformance (intake checklist, all green)

- `lease_generation_monotonic_across_reacquire`
- `acquire_with_missing_sidecar_reseeds_generation_from_journal_floor`
- `journal_row_without_generation_folds_identically` (additive-compat)
- `boot_liveness_is_lock_takeability`

Plus: dual-runtime secondary role, sidecar shape pin (no-secrets contract), presence GC sweep/spare cases, stamp fill + floor convergence across co-homed journal instances.

All tests hermetic (tempdir state roots, no env mutation). Platform note: flock semantics are per-open-description on all three OSes (flock / LockFileEx), so same-process dual-instance tests exercise exactly the two-daemons-one-home topology; lock files stay empty because Windows LockFileEx blocks reads of locked files — data rides the sidecars.

Known overlap: #627 touches `reminders.rs`/`scheduler.rs` in adjacent regions (fold + spawn); changes are semantically independent — whichever lands second reconciles mechanically.