### PR TITLE
feat(vault): serve reload candidates from the live session registry in auth-status payloads

### DIFF
--- a/src/bin/caller/auth_ceremony.rs
+++ b/src/bin/caller/auth_ceremony.rs
@@ -56,6 +56,18 @@ impl Provider {
         }
     }
 
+    /// The supervised backend this ceremony signs in — the identity a
+    /// `ManagedSession::source` carries (`AgentBackend::as_short_str`
+    /// vocabulary), which keys the status payload's `reload_candidates`
+    /// to exactly the sessions the new account applies to.
+    pub(crate) fn agent_backend(self) -> crate::external_agent::AgentBackend {
+        match self {
+            Provider::Claude => crate::external_agent::AgentBackend::ClaudeCode,
+            Provider::Codex => crate::external_agent::AgentBackend::Codex,
+            Provider::Kimi => crate::external_agent::AgentBackend::Kimi,
+        }
+    }
+
     /// Hard ceiling on one ceremony, spawn to terminal state. Claude's
     /// paste-code exchange is quick; Codex's ceiling is the device
     /// code's own 15-minute expiry.

--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -1997,7 +1997,8 @@ pub(crate) async fn api_claude_auth_status_response(
         id,
         crate::web_gateway::claude_auth_status_api_response(control_grant_is_hosted(
             &runtime.grant,
-        )),
+        ))
+        .await,
         "claude auth status",
     )
 }
@@ -2054,7 +2055,8 @@ pub(crate) async fn api_codex_auth_status_response(
 ) -> serde_json::Value {
     frame_api_response(
         id,
-        crate::web_gateway::codex_auth_status_api_response(control_grant_is_hosted(&runtime.grant)),
+        crate::web_gateway::codex_auth_status_api_response(control_grant_is_hosted(&runtime.grant))
+            .await,
         "codex auth status",
     )
 }
@@ -2093,7 +2095,8 @@ pub(crate) async fn api_kimi_auth_status_response(
 ) -> serde_json::Value {
     frame_api_response(
         id,
-        crate::web_gateway::kimi_auth_status_api_response(control_grant_is_hosted(&runtime.grant)),
+        crate::web_gateway::kimi_auth_status_api_response(control_grant_is_hosted(&runtime.grant))
+            .await,
         "kimi auth status",
     )
 }

--- a/src/bin/caller/session_supervisor/mod.rs
+++ b/src/bin/caller/session_supervisor/mod.rs
@@ -332,6 +332,78 @@ pub(crate) struct StoppedManagedSession {
     finished_rx: Option<oneshot::Receiver<()>>,
 }
 
+/// One row of the Vault sign-in cards' "live sessions to reload" list: a
+/// LIVE registry entry (`SupervisorState::sessions`) of the provider's
+/// backend — the exact candidate set
+/// [`SessionSupervisor::route_reload_credentials`] accepts. The list is
+/// served from the live registry, never the disk catalog: registry
+/// membership is liveness (the Stop-button doctrine at the source), so a
+/// parked or rate-limit-parked session stays listed and a session gone
+/// from the registry never does. Phase rides along as a chip, not a
+/// filter.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub(crate) struct ReloadCandidate {
+    pub(crate) session_id: String,
+    pub(crate) source: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) name: Option<String>,
+    pub(crate) phase: String,
+}
+
+/// Read-side view of the live managed-session registry for lanes outside
+/// the supervisor (the sign-in ceremony status payloads). Holds a `Weak`
+/// so the read side never extends the state's lifetime: a handle whose
+/// supervisor is gone truthfully reports no live sessions.
+#[derive(Clone)]
+pub(crate) struct LiveSessionRegistry {
+    state: std::sync::Weak<AsyncMutex<SupervisorState>>,
+}
+
+impl LiveSessionRegistry {
+    /// Live sessions whose backend is `source`
+    /// (`AgentBackend::as_short_str` vocabulary), sorted by session id for
+    /// stable rendering. Every registry entry of the source is a candidate
+    /// — parked, rate-limit-parked, and mid-turn alike — with no row cap:
+    /// the disk catalog's truncation and status heuristics never apply
+    /// here.
+    pub(crate) async fn reload_candidates_for_source(&self, source: &str) -> Vec<ReloadCandidate> {
+        let Some(state) = self.state.upgrade() else {
+            return Vec::new();
+        };
+        let state = state.lock().await;
+        let mut rows: Vec<ReloadCandidate> = state
+            .sessions
+            .values()
+            .filter(|session| session.source == source)
+            .map(|session| ReloadCandidate {
+                session_id: session.session_id.clone(),
+                source: session.source.clone(),
+                name: session.name.clone(),
+                phase: session.phase.clone(),
+            })
+            .collect();
+        rows.sort_by(|a, b| a.session_id.cmp(&b.session_id));
+        rows
+    }
+}
+
+static PUBLISHED_LIVE_SESSION_REGISTRY: std::sync::OnceLock<LiveSessionRegistry> =
+    std::sync::OnceLock::new();
+
+/// Publish the daemon's live-session registry for read-side lanes,
+/// mirroring `session_vitals::publish_git_vitals_targets`: called from
+/// the startup paths that construct a supervisor, never from tests
+/// (which read their own instance's [`SessionSupervisor::live_session_registry`]
+/// directly).
+pub(crate) fn publish_live_session_registry(registry: LiveSessionRegistry) {
+    let _ = PUBLISHED_LIVE_SESSION_REGISTRY.set(registry);
+}
+
+/// The published live registry, when a startup path wired one.
+pub(crate) fn published_live_session_registry() -> Option<&'static LiveSessionRegistry> {
+    PUBLISHED_LIVE_SESSION_REGISTRY.get()
+}
+
 #[derive(Clone)]
 pub(crate) struct EditRouteTarget {
     managed_id: String,
@@ -539,6 +611,15 @@ impl SessionSupervisor {
             config: Arc::new(config),
             state: Arc::new(AsyncMutex::new(SupervisorState::default())),
             exec: exec::IntakeExecutor::new(),
+        }
+    }
+
+    /// Read-side handle over this supervisor's live registry (see
+    /// [`LiveSessionRegistry`]); startup publishes it via
+    /// [`publish_live_session_registry`].
+    pub(crate) fn live_session_registry(&self) -> LiveSessionRegistry {
+        LiveSessionRegistry {
+            state: Arc::downgrade(&self.state),
         }
     }
 
@@ -892,6 +973,147 @@ mod tests {
                 as Box<dyn provider::ChatProvider>
         }));
         SessionSupervisor::new(config)
+    }
+
+    /// The Vault reload list's corpus is the LIVE registry, filtered by
+    /// backend source — id/source/name/phase ride verbatim, native
+    /// sessions and other backends never appear, and the order is
+    /// stable.
+    #[tokio::test]
+    async fn reload_candidates_derive_from_live_registry() {
+        let supervisor = test_supervisor(PathBuf::from("/tmp/project"), EventBus::new());
+        {
+            let mut state = supervisor.state.lock().await;
+            let mut claude = managed_session("claude-b", "claude-code");
+            claude.name = Some("steward pass".to_string());
+            claude.phase = "running".to_string();
+            state.sessions.insert("claude-b".to_string(), claude);
+            state.sessions.insert(
+                "claude-a".to_string(),
+                managed_session("claude-a", "claude-code"),
+            );
+            state
+                .sessions
+                .insert("codex-1".to_string(), managed_session("codex-1", "codex"));
+            state.sessions.insert(
+                "native-1".to_string(),
+                managed_session("native-1", "intendant"),
+            );
+        }
+        let registry = supervisor.live_session_registry();
+        let candidates = registry.reload_candidates_for_source("claude-code").await;
+        assert_eq!(
+            candidates,
+            vec![
+                ReloadCandidate {
+                    session_id: "claude-a".to_string(),
+                    source: "claude-code".to_string(),
+                    name: None,
+                    phase: "idle".to_string(),
+                },
+                ReloadCandidate {
+                    session_id: "claude-b".to_string(),
+                    source: "claude-code".to_string(),
+                    name: Some("steward pass".to_string()),
+                    phase: "running".to_string(),
+                },
+            ]
+        );
+        assert_eq!(
+            registry.reload_candidates_for_source("codex").await.len(),
+            1,
+            "other backends filter by their own source"
+        );
+    }
+
+    /// Parked, rate-limit-parked, and mid-turn sessions are all reload
+    /// candidates (registry membership is liveness — phase is never a
+    /// filter), and no row cap applies: the disk catalog's limit:100
+    /// truncation that aged parked sessions off the Vault list has no
+    /// analogue here.
+    #[tokio::test]
+    async fn parked_sessions_remain_reload_candidates() {
+        let supervisor = test_supervisor(PathBuf::from("/tmp/project"), EventBus::new());
+        {
+            let mut state = supervisor.state.lock().await;
+            for (id, phase) in [
+                ("parked", "idle"),
+                ("rate-limited", "waiting_rate_limit"),
+                ("mid-turn", "running"),
+                ("waiting", "waiting_approval"),
+            ] {
+                let mut session = managed_session(id, "codex");
+                session.phase = phase.to_string();
+                state.sessions.insert(id.to_string(), session);
+            }
+            for i in 0..150 {
+                let id = format!("bulk-{i:03}");
+                state
+                    .sessions
+                    .insert(id.clone(), managed_session(&id, "codex"));
+            }
+        }
+        let candidates = supervisor
+            .live_session_registry()
+            .reload_candidates_for_source("codex")
+            .await;
+        assert_eq!(
+            candidates.len(),
+            154,
+            "every live session of the source is a candidate — no truncation"
+        );
+        for id in ["parked", "rate-limited", "mid-turn", "waiting"] {
+            assert!(
+                candidates.iter().any(|c| c.session_id == id),
+                "{id} must stay a reload candidate"
+            );
+        }
+    }
+
+    /// Sessions absent from the live registry are never candidates: a
+    /// finished session drops off the moment the supervisor removes it,
+    /// and a dead read-handle (supervisor gone) reports none — the disk
+    /// catalog's summary-less "in_progress forever" dirs can't leak in.
+    #[tokio::test]
+    async fn dead_sessions_never_listed_as_live() {
+        let supervisor = test_supervisor(PathBuf::from("/tmp/project"), EventBus::new());
+        {
+            let mut state = supervisor.state.lock().await;
+            state
+                .sessions
+                .insert("live-1".to_string(), managed_session("live-1", "codex"));
+            state
+                .sessions
+                .insert("ends".to_string(), managed_session("ends", "codex"));
+        }
+        let registry = supervisor.live_session_registry();
+        assert_eq!(
+            registry.reload_candidates_for_source("codex").await.len(),
+            2
+        );
+
+        {
+            let mut state = supervisor.state.lock().await;
+            state.remove_session("ends");
+        }
+        let candidates = registry.reload_candidates_for_source("codex").await;
+        assert_eq!(
+            candidates
+                .iter()
+                .map(|c| c.session_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["live-1"],
+            "a session removed from the registry is no longer a candidate"
+        );
+
+        drop(supervisor);
+        assert!(
+            registry
+                .reload_candidates_for_source("codex")
+                .await
+                .is_empty(),
+            "a dead registry handle truthfully reports no live sessions"
+        );
     }
 
     /// The delegation dedup ledger: first writer wins for a given id,

--- a/src/bin/caller/startup/daemon.rs
+++ b/src/bin/caller/startup/daemon.rs
@@ -198,7 +198,7 @@ pub(crate) async fn run_daemon(
     let _usage_rail = crate::usage_rail::spawn_native_usage_rail(bus.clone(), provider_identity);
 
     let startup_bus = bus.clone();
-    let supervisor_handle =
+    let supervisor =
         session_supervisor::SessionSupervisor::new(session_supervisor::SessionSupervisorConfig {
             bus,
             project_root,
@@ -220,8 +220,12 @@ pub(crate) async fn run_daemon(
             launch_gate_for_tests: None,
             claude_rewind_capability_for_tests: None,
             agenda: gateway.agenda.clone(),
-        })
-        .spawn();
+        });
+    // Publish the live registry for read-side lanes (the sign-in
+    // ceremony status payloads' reload_candidates) — mirrors the
+    // vitals-targets publish above.
+    session_supervisor::publish_live_session_registry(supervisor.live_session_registry());
+    let supervisor_handle = supervisor.spawn();
     // --continue/--resume under the daemon: the supervisor (subscribed
     // above, before this send) resumes the target session — attach only,
     // no task; follow-ups come from the dashboard/TUI like any session.

--- a/src/bin/caller/startup/headless.rs
+++ b/src/bin/caller/startup/headless.rs
@@ -525,33 +525,34 @@ pub(crate) async fn run_headless_mode(
     // session runs: parallel sessions are owned by the session supervisor
     // (the dispatcher deliberately ignores them).
     let foreground_supervisor_handle = if use_web {
-        Some(
-            session_supervisor::SessionSupervisor::new(
-                session_supervisor::SessionSupervisorConfig {
-                    bus: bus.clone(),
-                    project_root: Some(project.root.clone()),
-                    autonomy: autonomy.clone(),
-                    shared_external_agent: shared_external_agent.clone(),
-                    shared_codex_config: shared_codex_config.clone(),
-                    shared_claude_config: shared_claude_config.clone(),
-                    shared_kimi_config: shared_kimi_config.clone(),
-                    frame_registry: frame_registry.clone(),
-                    session_registry: Some(session_registry.clone()),
-                    peer_registry: headless_peer_registry.clone(),
-                    web_port: web_port_for_agent,
-                    flags_direct: flags.direct,
-                    shared_session: headless_shared_session.clone(),
-                    provider_factory: None,
-                    logs_home_override: None,
-                    git_vitals_targets: vitals_git_targets.clone(),
-                    hosted_control_cert_dir: Some(crate::startup::installed_access_cert_dir()),
-                    launch_gate_for_tests: None,
-                    claude_rewind_capability_for_tests: None,
-                    agenda: headless_agenda.clone(),
-                },
-            )
-            .spawn_foreground_listener(session_id.clone()),
-        )
+        let supervisor = session_supervisor::SessionSupervisor::new(
+            session_supervisor::SessionSupervisorConfig {
+                bus: bus.clone(),
+                project_root: Some(project.root.clone()),
+                autonomy: autonomy.clone(),
+                shared_external_agent: shared_external_agent.clone(),
+                shared_codex_config: shared_codex_config.clone(),
+                shared_claude_config: shared_claude_config.clone(),
+                shared_kimi_config: shared_kimi_config.clone(),
+                frame_registry: frame_registry.clone(),
+                session_registry: Some(session_registry.clone()),
+                peer_registry: headless_peer_registry.clone(),
+                web_port: web_port_for_agent,
+                flags_direct: flags.direct,
+                shared_session: headless_shared_session.clone(),
+                provider_factory: None,
+                logs_home_override: None,
+                git_vitals_targets: vitals_git_targets.clone(),
+                hosted_control_cert_dir: Some(crate::startup::installed_access_cert_dir()),
+                launch_gate_for_tests: None,
+                claude_rewind_capability_for_tests: None,
+                agenda: headless_agenda.clone(),
+            },
+        );
+        // Publish for read-side lanes (the sign-in ceremony status
+        // payloads' reload_candidates), mirroring daemon boot.
+        session_supervisor::publish_live_session_registry(supervisor.live_session_registry());
+        Some(supervisor.spawn_foreground_listener(session_id.clone()))
     } else {
         None
     };

--- a/src/bin/caller/web_gateway/routes_claude_auth.rs
+++ b/src/bin/caller/web_gateway/routes_claude_auth.rs
@@ -97,14 +97,53 @@ fn start_mode_from_body(body_text: &str) -> Result<String, String> {
     }
 }
 
+/// Whether a status payload carries `reload_candidates`: exactly at
+/// `success`, the moment the Vault card offers the reload chips.
+pub(crate) fn status_wants_reload_candidates(status: &serde_json::Value) -> bool {
+    status.get("phase").and_then(|v| v.as_str()) == Some("success")
+}
+
+/// Merge the live registry's reload candidates into a status payload —
+/// one body, so the list arrives atomically with the polled `success`
+/// response (no separate fetch, no cache window, no truncation).
+pub(crate) fn status_with_reload_candidates(
+    mut status: serde_json::Value,
+    candidates: Vec<crate::session_supervisor::ReloadCandidate>,
+) -> serde_json::Value {
+    status["reload_candidates"] =
+        serde_json::to_value(candidates).unwrap_or_else(|_| serde_json::json!([]));
+    status
+}
+
+/// The provider's auth-status payload; at `success` it carries
+/// `reload_candidates` derived from the LIVE session registry — the
+/// exact candidate set `route_reload_credentials` accepts, replacing the
+/// disk-catalog filtering that listed dead pre-restart sessions as live
+/// and aged parked ones off. Shared by all three providers' status
+/// routes and their tunnel twins.
+pub(crate) async fn auth_status_payload(provider: Provider) -> serde_json::Value {
+    let status = auth_ceremony::manager().status_value_for(provider);
+    if !status_wants_reload_candidates(&status) {
+        return status;
+    }
+    let source = provider.agent_backend().as_short_str();
+    let candidates = match crate::session_supervisor::published_live_session_registry() {
+        Some(registry) => registry.reload_candidates_for_source(source).await,
+        // No supervisor ⇒ no supervised sessions ⇒ nothing reloadable:
+        // an empty list is the truthful answer, not an omission.
+        None => Vec::new(),
+    };
+    status_with_reload_candidates(status, candidates)
+}
+
 /// GET /api/claude-auth/status + the tunnel's `api_claude_auth_status`.
-pub(crate) fn claude_auth_status_api_response(hosted_provenance: bool) -> ApiResponse {
+pub(crate) async fn claude_auth_status_api_response(hosted_provenance: bool) -> ApiResponse {
     if hosted_provenance {
         return hosted_refusal_response();
     }
     ApiResponse::json(
         200,
-        JsonBody::Value(auth_ceremony::manager().status_value_for(Provider::Claude)),
+        JsonBody::Value(auth_status_payload(Provider::Claude).await),
     )
 }
 
@@ -175,7 +214,7 @@ pub(crate) async fn handle_claude_auth_status(
     cors: crate::gateway_routes::CorsPosture,
     fleet_origin: Option<&str>,
 ) {
-    let response = claude_auth_status_api_response(request_authority_is_hosted(access));
+    let response = claude_auth_status_api_response(request_authority_is_hosted(access)).await;
     write_api_response(stream, response, cors, fleet_origin).await;
 }
 
@@ -221,11 +260,11 @@ mod tests {
         principal
     }
 
-    #[test]
-    fn hosted_provenance_is_refused_on_every_leaf() {
+    #[tokio::test]
+    async fn hosted_provenance_is_refused_on_every_leaf() {
         for response in [
             claude_auth_start_api_response(true, "", None),
-            claude_auth_status_api_response(true),
+            claude_auth_status_api_response(true).await,
             claude_auth_code_api_response(true, "{\"code\":\"x\"}"),
             claude_auth_cancel_api_response(true),
         ] {
@@ -260,6 +299,88 @@ mod tests {
             )),
         };
         assert!(request_authority_is_hosted(&hosted_with_state));
+    }
+
+    /// The reload list rides INSIDE the status payload: the same JSON
+    /// body that announces `success` carries the candidates, so the
+    /// Vault card can never render success with a list fetched at a
+    /// different moment (the old separate `api_sessions` fetch could be
+    /// served a stale cache body, or be skipped entirely on a fast
+    /// "Sign in again"). Non-success phases carry no list at all.
+    #[test]
+    fn vault_list_arrives_atomically_with_success() {
+        let success = serde_json::json!({
+            "provider": "claude",
+            "phase": "success",
+        });
+        assert!(status_wants_reload_candidates(&success));
+        let merged = status_with_reload_candidates(
+            success,
+            vec![crate::session_supervisor::ReloadCandidate {
+                session_id: "wrapper-1".to_string(),
+                source: "claude-code".to_string(),
+                name: Some("steward pass".to_string()),
+                phase: "waiting_rate_limit".to_string(),
+            }],
+        );
+        assert_eq!(merged["phase"], "success");
+        assert_eq!(
+            merged["reload_candidates"],
+            serde_json::json!([{
+                "session_id": "wrapper-1",
+                "source": "claude-code",
+                "name": "steward pass",
+                "phase": "waiting_rate_limit",
+            }]),
+            "candidates and the success phase share one body"
+        );
+
+        // An alive daemon with nothing to reload states that explicitly.
+        let empty =
+            status_with_reload_candidates(serde_json::json!({ "phase": "success" }), Vec::new());
+        assert_eq!(empty["reload_candidates"], serde_json::json!([]));
+
+        for phase in ["idle", "starting", "awaiting_user", "verifying", "failed"] {
+            assert!(
+                !status_wants_reload_candidates(&serde_json::json!({ "phase": phase })),
+                "{phase} payloads never carry a reload list"
+            );
+        }
+    }
+
+    /// "Sign in again" (and every success render) can only show the
+    /// list the daemon just served: the vault fragment renders the
+    /// status payload's own `reload_candidates`, and the legacy
+    /// second-fetch lane — a truncated `api_sessions` snapshot behind
+    /// freshness guards, whose phase-transition force a fast re-sign-in
+    /// skipped (`lastPhase` never reset) — is gone. Sliced to the
+    /// fragment so other panes' legitimate `api_sessions` uses don't
+    /// blur the pin.
+    #[test]
+    fn sign_in_again_always_refreshes() {
+        let app = include_str!("../../../../static/app.html");
+        let banner = "/* ── static/app/32-vault-custody.js ── */";
+        let start = app
+            .find(banner)
+            .expect("vault fragment banner not found in app.html");
+        let rest = &app[start + banner.len()..];
+        let end = rest.find("/* ── static/app/").unwrap_or(rest.len());
+        let fragment = &rest[..end];
+
+        assert!(
+            fragment.contains("reload_candidates"),
+            "the success card must render the status payload's reload_candidates"
+        );
+        for legacy in [
+            "api_sessions",
+            "lastPhase",
+            "AGENT_SIGNIN_TERMINAL_STATUSES",
+        ] {
+            assert!(
+                !fragment.contains(legacy),
+                "the vault sign-in lane must not rebuild its own session list ({legacy} found)"
+            );
+        }
     }
 
     #[test]

--- a/src/bin/caller/web_gateway/routes_codex_auth.rs
+++ b/src/bin/caller/web_gateway/routes_codex_auth.rs
@@ -73,13 +73,15 @@ fn start_mode_from_body(body_text: &str) -> Result<String, String> {
 }
 
 /// GET /api/codex-auth/status + the tunnel's `api_codex_auth_status`.
-pub(crate) fn codex_auth_status_api_response(hosted_provenance: bool) -> ApiResponse {
+/// At `success` the payload carries the live registry's
+/// `reload_candidates` (see [`auth_status_payload`]).
+pub(crate) async fn codex_auth_status_api_response(hosted_provenance: bool) -> ApiResponse {
     if hosted_provenance {
         return hosted_refusal_response();
     }
     ApiResponse::json(
         200,
-        JsonBody::Value(auth_ceremony::manager().status_value_for(Provider::Codex)),
+        JsonBody::Value(auth_status_payload(Provider::Codex).await),
     )
 }
 
@@ -122,7 +124,7 @@ pub(crate) async fn handle_codex_auth_status(
     cors: crate::gateway_routes::CorsPosture,
     fleet_origin: Option<&str>,
 ) {
-    let response = codex_auth_status_api_response(request_authority_is_hosted(access));
+    let response = codex_auth_status_api_response(request_authority_is_hosted(access)).await;
     write_api_response(stream, response, cors, fleet_origin).await;
 }
 
@@ -150,11 +152,11 @@ mod tests {
         }
     }
 
-    #[test]
-    fn hosted_provenance_is_refused_on_every_leaf() {
+    #[tokio::test]
+    async fn hosted_provenance_is_refused_on_every_leaf() {
         for response in [
             codex_auth_start_api_response(true, "", None),
-            codex_auth_status_api_response(true),
+            codex_auth_status_api_response(true).await,
             codex_auth_cancel_api_response(true),
         ] {
             let (status, body) = response_status_and_body(response);

--- a/src/bin/caller/web_gateway/routes_kimi_auth.rs
+++ b/src/bin/caller/web_gateway/routes_kimi_auth.rs
@@ -63,13 +63,16 @@ fn start_mode_from_body(body_text: &str) -> Result<String, String> {
     }
 }
 
-pub(crate) fn kimi_auth_status_api_response(hosted_provenance: bool) -> ApiResponse {
+/// GET /api/kimi-auth/status + the tunnel's `api_kimi_auth_status`. At
+/// `success` the payload carries the live registry's `reload_candidates`
+/// (see [`auth_status_payload`]).
+pub(crate) async fn kimi_auth_status_api_response(hosted_provenance: bool) -> ApiResponse {
     if hosted_provenance {
         return hosted_refusal_response();
     }
     ApiResponse::json(
         200,
-        JsonBody::Value(auth_ceremony::manager().status_value_for(Provider::Kimi)),
+        JsonBody::Value(auth_status_payload(Provider::Kimi).await),
     )
 }
 
@@ -111,7 +114,7 @@ pub(crate) async fn handle_kimi_auth_status(
     cors: crate::gateway_routes::CorsPosture,
     fleet_origin: Option<&str>,
 ) {
-    let response = kimi_auth_status_api_response(request_authority_is_hosted(access));
+    let response = kimi_auth_status_api_response(request_authority_is_hosted(access)).await;
     write_api_response(stream, response, cors, fleet_origin).await;
 }
 
@@ -138,11 +141,11 @@ mod tests {
         }
     }
 
-    #[test]
-    fn hosted_provenance_is_refused_on_every_leaf() {
+    #[tokio::test]
+    async fn hosted_provenance_is_refused_on_every_leaf() {
         for response in [
             kimi_auth_start_api_response(true, "", None),
-            kimi_auth_status_api_response(true),
+            kimi_auth_status_api_response(true).await,
             kimi_auth_cancel_api_response(true),
         ] {
             let (status, body) = response_status_and_body(response);

--- a/src/bin/caller/web_gateway/session_catalog/mod.rs
+++ b/src/bin/caller/web_gateway/session_catalog/mod.rs
@@ -1774,10 +1774,6 @@ pub(crate) fn session_file_fingerprints_digest(entries: &[SessionFileFingerprint
 /// `idle`, `resident`, `external` — describes a session that may still be
 /// alive). The bare-dir `"abandoned"` classification applied in
 /// `intendant_session_list_row_from_dir` is terminal for consumers too.
-/// The dashboard's agent sign-in reload panels mirror this set
-/// (`AGENT_SIGNIN_TERMINAL_STATUSES` in `static/app/32-vault-custody.js`)
-/// — pinned by the parity test below, so a vocabulary change here fails
-/// the suite instead of shipping as drift.
 pub(crate) const SESSION_ENDED_STATUSES: [&str; 3] = ["completed", "failed", "interrupted"];
 
 fn summary_json_status(dir: &Path) -> Option<&'static str> {
@@ -2982,43 +2978,6 @@ mod tests {
         // No summary at all → the session has not ended.
         std::fs::remove_file(dir.path().join("summary.json")).unwrap();
         assert_eq!(summary_json_status(dir.path()), None);
-    }
-
-    /// The agent sign-in reload panels offer chips for ALIVE supervised
-    /// sessions by excluding this module's terminal statuses — a static
-    /// frontend mirror ("derive, don't mirror" fallback rule: the mirror
-    /// gets a daemon-side parity test). The fragment's set must equal
-    /// `SESSION_ENDED_STATUSES` plus the `"abandoned"` classification,
-    /// exactly — an addition or rename on either side fails here.
-    #[test]
-    fn agent_signin_terminal_status_mirror_matches_catalog_vocabulary() {
-        let app = include_str!("../../../../../static/app.html");
-        let start = "const AGENT_SIGNIN_TERMINAL_STATUSES = new Set([";
-        let from = app
-            .find(start)
-            .expect("AGENT_SIGNIN_TERMINAL_STATUSES not found in app.html")
-            + start.len();
-        let rest = &app[from..];
-        let to = rest
-            .find("])")
-            .expect("AGENT_SIGNIN_TERMINAL_STATUSES is unterminated");
-        let mirrored: std::collections::BTreeSet<String> = rest[..to]
-            .split('\'')
-            .skip(1)
-            .step_by(2)
-            .map(str::to_string)
-            .collect();
-
-        let mut expected: std::collections::BTreeSet<String> = SESSION_ENDED_STATUSES
-            .iter()
-            .map(|s| s.to_string())
-            .collect();
-        expected.insert("abandoned".to_string());
-        assert_eq!(
-            mirrored, expected,
-            "static/app/32-vault-custody.js AGENT_SIGNIN_TERMINAL_STATUSES \
-             must mirror the catalog's terminal vocabulary"
-        );
     }
 
     #[test]

--- a/static/app.html
+++ b/static/app.html
@@ -36882,7 +36882,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'd176cbd77cce5465';
+const INTENDANT_APP_BUILD = '2cade3d65e18bea0';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -42223,7 +42223,6 @@ const AGENT_SIGNIN_PROVIDERS = {
     checkNote: 'Check that your browser shows claude.com before signing in.',
     unsupportedNote:
       'This daemon predates the Claude sign-in ceremony — upgrade it to sign in from here.',
-    backendMatch: backend => backend.includes('claude'),
     sessionsTitle: 'Live Claude Code sessions',
     noSessionsNote: 'No live Claude Code sessions — new sessions start on the new account.',
     sessionKind: 'claude-code',
@@ -42252,7 +42251,6 @@ const AGENT_SIGNIN_PROVIDERS = {
     devicePageName: 'OpenAI',
     unsupportedNote:
       'This daemon predates the Codex sign-in ceremony — upgrade it to sign in from here.',
-    backendMatch: backend => backend.includes('codex'),
     sessionsTitle: 'Live Codex sessions',
     noSessionsNote: 'No live Codex sessions — new sessions start on the new account.',
     sessionKind: 'codex',
@@ -42285,7 +42283,6 @@ const AGENT_SIGNIN_PROVIDERS = {
     devicePageName: 'Kimi',
     unsupportedNote:
       'This daemon predates the Kimi sign-in ceremony — upgrade it to sign in from here.',
-    backendMatch: backend => backend.includes('kimi'),
     sessionsTitle: 'Live Kimi sessions',
     noSessionsNote: 'No live Kimi sessions — new sessions start on the new account.',
     sessionKind: 'kimi',
@@ -42304,14 +42301,14 @@ const AGENT_SIGNIN_PROVIDERS = {
 
 function agentSigninProviderState() {
   return {
-    status: null, // last daemon status payload ({phase, url?, user_code?, account?, error?…})
+    // Last daemon status payload ({phase, url?, user_code?, account?,
+    // error?…}; at success it carries reload_candidates — the daemon's
+    // LIVE session registry, riding the same body as the phase).
+    status: null,
     fetchedAt: 0,
     busy: false,
     lastError: '',
     pollTimer: null,
-    sessions: [], // live sessions of this provider's backend for the reload panel
-    sessionsFetchedAt: 0,
-    lastPhase: '', // transition detector: entering success forces a fresh fetch
     reloadRequested: new Set(),
   };
 }
@@ -42355,16 +42352,12 @@ async function agentSigninRefresh(provider, { force = false } = {}) {
     state.lastError = String(err?.message || err);
   }
   agentSigninEnsurePoll(provider);
+  // The reload chips render straight from the fetched status payload:
+  // at success the daemon serves reload_candidates (its live session
+  // registry) in the SAME body as the phase, so the list is exactly as
+  // fresh as the success it arrives with — no second fetch to force,
+  // cache, or skip.
   renderAgentSigninSection();
-  const phaseNow = agentSigninPhase(provider);
-  const phaseChanged = phaseNow !== state.lastPhase;
-  state.lastPhase = phaseNow;
-  // Entering success forces the fetch past the freshness window: the
-  // reload chips must reflect live sessions at the exact moment the user
-  // needs them (a cached pre-success list here hid a parked session).
-  if (phaseNow === 'success') {
-    agentSigninRefreshSessions(provider, { force: phaseChanged }).catch(() => {});
-  }
 }
 
 /* 2s poll while a ceremony is in flight and the page is looking at it;
@@ -42489,92 +42482,34 @@ async function agentSigninCancel(provider) {
   renderAgentSigninSection();
 }
 
-/* Catalog statuses that mean a session row has ENDED — a mirror of the
-   daemon's session-catalog terminal vocabulary (SESSION_ENDED_STATUSES
-   plus the bare-dir "abandoned" classification). A daemon-side parity
-   test pins this set to the source
-   (agent_signin_terminal_status_mirror_matches_catalog_vocabulary), so
-   keep the one-status-per-quote shape scrapable. */
-const AGENT_SIGNIN_TERMINAL_STATUSES = new Set([
-  'completed', 'failed', 'interrupted', 'abandoned',
-]);
-
-/* Reload candidates are ALIVE supervised sessions of the provider's
-   backend: wrapper evidence (a supervised session always has an
-   Intendant wrapper row — merged rows carry intendant_status /
-   intendant_session_id, unmerged wrapper rows have source "intendant")
-   and a non-terminal status. The old `status === 'running'` filter
-   excluded exactly the sessions whose reload matters most — limit-parked
-   and between-turn sessions read idle/external on the row, never running
-   (live incident 2026-07-17). Raw transcript rows with no wrapper are
-   history, not reload targets. */
-function agentSigninSessionIsReloadCandidate(spec, row) {
-  const backend = String(row?.backend_source || row?.source || '').toLowerCase();
-  if (!spec.backendMatch(backend)) return false;
-  const wrapperStatus = String(row?.intendant_status || '').trim();
-  const supervised =
-    String(row?.source || '') === 'intendant' ||
-    !!wrapperStatus ||
-    !!String(row?.intendant_session_id || '').trim();
-  if (!supervised) return false;
-  const effective = (wrapperStatus || String(row?.status || '').trim()).toLowerCase();
-  return !AGENT_SIGNIN_TERMINAL_STATUSES.has(effective);
+/* The reload panel's corpus is the daemon's LIVE session registry,
+   served as `reload_candidates` inside the success status payload — the
+   exact candidate set the daemon's reload_credentials route accepts.
+   Registry membership is liveness (the Stop-button doctrine): parked and
+   rate-limit-parked sessions stay listed, sessions gone from the
+   registry never appear, and no row cap or disk-status heuristic
+   applies. The old lane filtered a truncated disk catalog here and got
+   both directions wrong (live resumed sessions dropped by a stale
+   terminal status, dead pre-restart dirs listed as live). */
+function agentSigninReloadCandidates(provider) {
+  const status = agentSigninState[provider].status;
+  const rows = status?.reload_candidates;
+  return Array.isArray(rows) ? rows : [];
 }
 
-/* Chip copy for a reload candidate: live phase (open session windows,
-   recent status events) beats the catalog row's disk-derived status — a
-   limit-parked session reads idle on disk but waiting_rate_limit live.
-   Lookups are guarded: the live maps are declared in later fragments. */
-function agentSigninSessionStateChip(row) {
-  const ids = [row?.session_id, row?.backend_session_id, row?.intendant_session_id]
-    .map(v => String(v || '').trim())
-    .filter(Boolean);
-  let phase = '';
-  try {
-    for (const id of ids) {
-      if (typeof sessionWindows !== 'undefined' && sessionWindows.get(id)?.phase) {
-        phase = String(sessionWindows.get(id).phase);
-      }
-      if (!phase && typeof recentSessionStatusPhase === 'function') {
-        phase = String(recentSessionStatusPhase(id) || '');
-      }
-      if (phase) break;
-    }
-  } catch (_) {
-    /* live maps unavailable: fall back to the row's status below */
-  }
-  const key = phase.toLowerCase().replace(/-/g, '_');
+/* Chip copy for a reload candidate: the candidate's phase IS the live
+   registry phase (the same source the session windows show), so a
+   limit-parked session reads rate-limited here even though its disk row
+   says idle. */
+function agentSigninSessionStateChip(candidate) {
+  const key = String(candidate?.phase || '').toLowerCase().replace(/-/g, '_');
   if (key === 'waiting_rate_limit') return { label: 'rate-limited', cls: 'warn' };
   if (key === 'interrupting' || key.startsWith('waiting')) return { label: 'waiting', cls: 'warn' };
   if (key.startsWith('running') || key === 'thinking' || key === 'orchestrating') {
     return { label: 'running', cls: 'ok' };
   }
-  if (key === 'idle') return { label: 'parked', cls: '' };
-  const status = String(row?.intendant_status || row?.status || '').trim().toLowerCase();
-  if (status === 'running' || status === 'in_progress') return { label: 'running', cls: 'ok' };
-  if (status === 'idle' || status === 'external') return { label: 'parked', cls: '' };
-  return { label: status || 'live', cls: '' };
-}
-
-/* The reload panel's corpus: this provider's live sessions on this
-   daemon. The daemon is the authority on reloadability — this list only
-   decides which chips to offer. */
-async function agentSigninRefreshSessions(provider, { force = false } = {}) {
-  const spec = AGENT_SIGNIN_PROVIDERS[provider];
-  const state = agentSigninState[provider];
-  /* 2.5s freshness (was 10s): right after sign-in success a stale empty
-     list is the worst answer; the ceremony/render cadence bounds the
-     request rate while the pane is watched. */
-  if (!force && Date.now() - state.sessionsFetchedAt < 2500) return;
-  state.sessionsFetchedAt = Date.now();
-  try {
-    const resp = await daemonApi.request('api_sessions', { limit: 100 });
-    if (!resp.ok || !Array.isArray(resp.body)) return;
-    state.sessions = resp.body.filter(row => agentSigninSessionIsReloadCandidate(spec, row));
-    renderAgentSigninSection();
-  } catch (_) {
-    /* the next poll or manual refresh recovers */
-  }
+  if (key === 'idle' || key === 'done') return { label: 'parked', cls: '' };
+  return { label: key || 'live', cls: '' };
 }
 
 function agentSigninReloadSession(provider, sessionId) {
@@ -42883,8 +42818,10 @@ function agentSigninProviderCard(provider) {
     // rate-limit-parked — keep the OLD account until their backend
     // process restarts. Offer the per-session reload (graceful in-place
     // respawn, resume-attached); parked sessions are the ones pinned to
-    // the old account longest, so they matter most here.
-    agentSigninRefreshSessions(provider).catch(() => {});
+    // the old account longest, so they matter most here. The list is the
+    // status payload's reload_candidates — the daemon's live registry,
+    // exactly as fresh as the success phase it arrived with.
+    const reloadCandidates = agentSigninReloadCandidates(provider);
     const reloadHead = document.createElement('div');
     reloadHead.className = 'vault-status-line';
     const reloadTitle = document.createElement('span');
@@ -42893,13 +42830,13 @@ function agentSigninProviderCard(provider) {
     reloadTitle.textContent = spec.sessionsTitle;
     reloadHead.appendChild(reloadTitle);
     card.appendChild(reloadHead);
-    if (!state.sessions.length) {
+    if (!reloadCandidates.length) {
       note(spec.noSessionsNote);
     } else {
       note('Live sessions — including parked and rate-limited ones — keep the old account until reloaded. Reloading restarts the backend on the same conversation; a mid-turn session is interrupted first.');
       const list = document.createElement('div');
       list.className = 'vault-entry-list';
-      for (const session of state.sessions) {
+      for (const session of reloadCandidates) {
         const sessionId = String(session.session_id || '');
         const row = document.createElement('div');
         row.className = 'vault-entry-row';

--- a/static/app/32-vault-custody.js
+++ b/static/app/32-vault-custody.js
@@ -1668,7 +1668,6 @@ const AGENT_SIGNIN_PROVIDERS = {
     checkNote: 'Check that your browser shows claude.com before signing in.',
     unsupportedNote:
       'This daemon predates the Claude sign-in ceremony — upgrade it to sign in from here.',
-    backendMatch: backend => backend.includes('claude'),
     sessionsTitle: 'Live Claude Code sessions',
     noSessionsNote: 'No live Claude Code sessions — new sessions start on the new account.',
     sessionKind: 'claude-code',
@@ -1697,7 +1696,6 @@ const AGENT_SIGNIN_PROVIDERS = {
     devicePageName: 'OpenAI',
     unsupportedNote:
       'This daemon predates the Codex sign-in ceremony — upgrade it to sign in from here.',
-    backendMatch: backend => backend.includes('codex'),
     sessionsTitle: 'Live Codex sessions',
     noSessionsNote: 'No live Codex sessions — new sessions start on the new account.',
     sessionKind: 'codex',
@@ -1730,7 +1728,6 @@ const AGENT_SIGNIN_PROVIDERS = {
     devicePageName: 'Kimi',
     unsupportedNote:
       'This daemon predates the Kimi sign-in ceremony — upgrade it to sign in from here.',
-    backendMatch: backend => backend.includes('kimi'),
     sessionsTitle: 'Live Kimi sessions',
     noSessionsNote: 'No live Kimi sessions — new sessions start on the new account.',
     sessionKind: 'kimi',
@@ -1749,14 +1746,14 @@ const AGENT_SIGNIN_PROVIDERS = {
 
 function agentSigninProviderState() {
   return {
-    status: null, // last daemon status payload ({phase, url?, user_code?, account?, error?…})
+    // Last daemon status payload ({phase, url?, user_code?, account?,
+    // error?…}; at success it carries reload_candidates — the daemon's
+    // LIVE session registry, riding the same body as the phase).
+    status: null,
     fetchedAt: 0,
     busy: false,
     lastError: '',
     pollTimer: null,
-    sessions: [], // live sessions of this provider's backend for the reload panel
-    sessionsFetchedAt: 0,
-    lastPhase: '', // transition detector: entering success forces a fresh fetch
     reloadRequested: new Set(),
   };
 }
@@ -1800,16 +1797,12 @@ async function agentSigninRefresh(provider, { force = false } = {}) {
     state.lastError = String(err?.message || err);
   }
   agentSigninEnsurePoll(provider);
+  // The reload chips render straight from the fetched status payload:
+  // at success the daemon serves reload_candidates (its live session
+  // registry) in the SAME body as the phase, so the list is exactly as
+  // fresh as the success it arrives with — no second fetch to force,
+  // cache, or skip.
   renderAgentSigninSection();
-  const phaseNow = agentSigninPhase(provider);
-  const phaseChanged = phaseNow !== state.lastPhase;
-  state.lastPhase = phaseNow;
-  // Entering success forces the fetch past the freshness window: the
-  // reload chips must reflect live sessions at the exact moment the user
-  // needs them (a cached pre-success list here hid a parked session).
-  if (phaseNow === 'success') {
-    agentSigninRefreshSessions(provider, { force: phaseChanged }).catch(() => {});
-  }
 }
 
 /* 2s poll while a ceremony is in flight and the page is looking at it;
@@ -1934,92 +1927,34 @@ async function agentSigninCancel(provider) {
   renderAgentSigninSection();
 }
 
-/* Catalog statuses that mean a session row has ENDED — a mirror of the
-   daemon's session-catalog terminal vocabulary (SESSION_ENDED_STATUSES
-   plus the bare-dir "abandoned" classification). A daemon-side parity
-   test pins this set to the source
-   (agent_signin_terminal_status_mirror_matches_catalog_vocabulary), so
-   keep the one-status-per-quote shape scrapable. */
-const AGENT_SIGNIN_TERMINAL_STATUSES = new Set([
-  'completed', 'failed', 'interrupted', 'abandoned',
-]);
-
-/* Reload candidates are ALIVE supervised sessions of the provider's
-   backend: wrapper evidence (a supervised session always has an
-   Intendant wrapper row — merged rows carry intendant_status /
-   intendant_session_id, unmerged wrapper rows have source "intendant")
-   and a non-terminal status. The old `status === 'running'` filter
-   excluded exactly the sessions whose reload matters most — limit-parked
-   and between-turn sessions read idle/external on the row, never running
-   (live incident 2026-07-17). Raw transcript rows with no wrapper are
-   history, not reload targets. */
-function agentSigninSessionIsReloadCandidate(spec, row) {
-  const backend = String(row?.backend_source || row?.source || '').toLowerCase();
-  if (!spec.backendMatch(backend)) return false;
-  const wrapperStatus = String(row?.intendant_status || '').trim();
-  const supervised =
-    String(row?.source || '') === 'intendant' ||
-    !!wrapperStatus ||
-    !!String(row?.intendant_session_id || '').trim();
-  if (!supervised) return false;
-  const effective = (wrapperStatus || String(row?.status || '').trim()).toLowerCase();
-  return !AGENT_SIGNIN_TERMINAL_STATUSES.has(effective);
+/* The reload panel's corpus is the daemon's LIVE session registry,
+   served as `reload_candidates` inside the success status payload — the
+   exact candidate set the daemon's reload_credentials route accepts.
+   Registry membership is liveness (the Stop-button doctrine): parked and
+   rate-limit-parked sessions stay listed, sessions gone from the
+   registry never appear, and no row cap or disk-status heuristic
+   applies. The old lane filtered a truncated disk catalog here and got
+   both directions wrong (live resumed sessions dropped by a stale
+   terminal status, dead pre-restart dirs listed as live). */
+function agentSigninReloadCandidates(provider) {
+  const status = agentSigninState[provider].status;
+  const rows = status?.reload_candidates;
+  return Array.isArray(rows) ? rows : [];
 }
 
-/* Chip copy for a reload candidate: live phase (open session windows,
-   recent status events) beats the catalog row's disk-derived status — a
-   limit-parked session reads idle on disk but waiting_rate_limit live.
-   Lookups are guarded: the live maps are declared in later fragments. */
-function agentSigninSessionStateChip(row) {
-  const ids = [row?.session_id, row?.backend_session_id, row?.intendant_session_id]
-    .map(v => String(v || '').trim())
-    .filter(Boolean);
-  let phase = '';
-  try {
-    for (const id of ids) {
-      if (typeof sessionWindows !== 'undefined' && sessionWindows.get(id)?.phase) {
-        phase = String(sessionWindows.get(id).phase);
-      }
-      if (!phase && typeof recentSessionStatusPhase === 'function') {
-        phase = String(recentSessionStatusPhase(id) || '');
-      }
-      if (phase) break;
-    }
-  } catch (_) {
-    /* live maps unavailable: fall back to the row's status below */
-  }
-  const key = phase.toLowerCase().replace(/-/g, '_');
+/* Chip copy for a reload candidate: the candidate's phase IS the live
+   registry phase (the same source the session windows show), so a
+   limit-parked session reads rate-limited here even though its disk row
+   says idle. */
+function agentSigninSessionStateChip(candidate) {
+  const key = String(candidate?.phase || '').toLowerCase().replace(/-/g, '_');
   if (key === 'waiting_rate_limit') return { label: 'rate-limited', cls: 'warn' };
   if (key === 'interrupting' || key.startsWith('waiting')) return { label: 'waiting', cls: 'warn' };
   if (key.startsWith('running') || key === 'thinking' || key === 'orchestrating') {
     return { label: 'running', cls: 'ok' };
   }
-  if (key === 'idle') return { label: 'parked', cls: '' };
-  const status = String(row?.intendant_status || row?.status || '').trim().toLowerCase();
-  if (status === 'running' || status === 'in_progress') return { label: 'running', cls: 'ok' };
-  if (status === 'idle' || status === 'external') return { label: 'parked', cls: '' };
-  return { label: status || 'live', cls: '' };
-}
-
-/* The reload panel's corpus: this provider's live sessions on this
-   daemon. The daemon is the authority on reloadability — this list only
-   decides which chips to offer. */
-async function agentSigninRefreshSessions(provider, { force = false } = {}) {
-  const spec = AGENT_SIGNIN_PROVIDERS[provider];
-  const state = agentSigninState[provider];
-  /* 2.5s freshness (was 10s): right after sign-in success a stale empty
-     list is the worst answer; the ceremony/render cadence bounds the
-     request rate while the pane is watched. */
-  if (!force && Date.now() - state.sessionsFetchedAt < 2500) return;
-  state.sessionsFetchedAt = Date.now();
-  try {
-    const resp = await daemonApi.request('api_sessions', { limit: 100 });
-    if (!resp.ok || !Array.isArray(resp.body)) return;
-    state.sessions = resp.body.filter(row => agentSigninSessionIsReloadCandidate(spec, row));
-    renderAgentSigninSection();
-  } catch (_) {
-    /* the next poll or manual refresh recovers */
-  }
+  if (key === 'idle' || key === 'done') return { label: 'parked', cls: '' };
+  return { label: key || 'live', cls: '' };
 }
 
 function agentSigninReloadSession(provider, sessionId) {
@@ -2328,8 +2263,10 @@ function agentSigninProviderCard(provider) {
     // rate-limit-parked — keep the OLD account until their backend
     // process restarts. Offer the per-session reload (graceful in-place
     // respawn, resume-attached); parked sessions are the ones pinned to
-    // the old account longest, so they matter most here.
-    agentSigninRefreshSessions(provider).catch(() => {});
+    // the old account longest, so they matter most here. The list is the
+    // status payload's reload_candidates — the daemon's live registry,
+    // exactly as fresh as the success phase it arrived with.
+    const reloadCandidates = agentSigninReloadCandidates(provider);
     const reloadHead = document.createElement('div');
     reloadHead.className = 'vault-status-line';
     const reloadTitle = document.createElement('span');
@@ -2338,13 +2275,13 @@ function agentSigninProviderCard(provider) {
     reloadTitle.textContent = spec.sessionsTitle;
     reloadHead.appendChild(reloadTitle);
     card.appendChild(reloadHead);
-    if (!state.sessions.length) {
+    if (!reloadCandidates.length) {
       note(spec.noSessionsNote);
     } else {
       note('Live sessions — including parked and rate-limited ones — keep the old account until reloaded. Reloading restarts the backend on the same conversation; a mid-turn session is interrupted first.');
       const list = document.createElement('div');
       list.className = 'vault-entry-list';
-      for (const session of state.sessions) {
+      for (const session of reloadCandidates) {
         const sessionId = String(session.session_id || '');
         const row = document.createElement('div');
         row.className = 'vault-entry-row';


### PR DESCRIPTION
The post-sign-in "live sessions to reload" list becomes truthful — primary fix from the vault-reload commission (agenda item 01KYKA64Z8F4Z0N7A2JJMCXJ6C).

**Defect (three classes, all killed by one change):** the Vault filtered a truncated (`limit:100`, mtime-sorted) disk-catalog snapshot by disk status — parked live sessions aged off, dead pre-restart dirs listed as live, and the separate fetch could serve a stale SWR cache body at success or be skipped on a fast "Sign in again" (`lastPhase` never reset).

**Fix:** the daemon serves `reload_candidates` inside the auth-status payload at `success`, derived from the live SessionSupervisor registry — the exact candidate set `route_reload_credentials` accepts. The supervisor publishes a `Weak` read-handle at startup (mirrors `publish_git_vitals_targets`); all three providers' status routes + tunnel twins share one payload assembly. The Vault card renders that list directly; the second fetch, its freshness guards, and the `AGENT_SIGNIN_TERMINAL_STATUSES` mirror (with its parity test) retire.

**Pins:** `reload_candidates_derive_from_live_registry`, `vault_list_arrives_atomically_with_success`, `parked_sessions_remain_reload_candidates`, `dead_sessions_never_listed_as_live`, `sign_in_again_always_refreshes`.

Note for concurrent landings: touches generated `static/app.html` (fragment: `32-vault-custody.js` only).