### PR TITLE
feat(agenda): fired sessions inherit derived names from their source

### DIFF
--- a/docs/src/agenda-and-memory.md
+++ b/docs/src/agenda-and-memory.md
@@ -456,6 +456,29 @@ echoed exactly as a pane-created session's (the persisted launch overlay,
 the vitals Model chip's `model · effort`), so scheduled spawns are
 config-indistinguishable from composer spawns.
 
+**Fired sessions inherit a name from their source.** At fire time the
+scheduler derives a deterministic display name — never model-generated —
+and sends it on the spawn's `StartTask` (`session_name`), where the
+launch path assigns it through the ordinary session naming system
+(persisted session meta / external-overlay store + the live registry),
+exactly as a composer-named create: no parallel store, and every surface
+that already applies name overlays renders it. Derivation
+(`derive_spawn_session_name`, the single seam — Track AW's stamped
+definitions plug in there as `<definition name> - <node id>` once they
+land): a standalone item firing takes the **item title** through the
+naming system's own normalize rules; a workflow-node firing (an
+`on_unblock`-triggered manifest on an item placed under a parent) takes
+`<workflow title> - <node title>`, the parent hub being the workflow
+instance; a title that normalizes to nothing spawns unnamed (naming
+never blocks a firing). Names derive from titles only, so the same item
+fires under the same name every occurrence — windows disambiguate by
+their existing timestamps. Precedence laws, pinned by tests: a derived
+name only ever seeds a fresh spawn (an owner rename wins — redeliveries
+of the same delegation re-ack without re-applying it), and a
+derived-named session is *titled* in the naming system's own read from
+the moment it spawns, so any generated-naming lane for untitled
+sessions skips it by construction.
+
 **The standing lane expresses the executor too** (Track AU):
 `propose_effect` accepts the same `agent_config` block, and
 `ctl agenda schedule` takes the same launch flags as `start`

--- a/src/bin/caller/access/access_policy.rs
+++ b/src/bin/caller/access/access_policy.rs
@@ -1809,6 +1809,7 @@ mod tests {
             attachments: Vec::new(),
             follow_up_id: None,
             delegation_id: None,
+            session_name: None,
             launch_config: Default::default(),
         };
         let approval = ControlMsg::Approve {

--- a/src/bin/caller/access/hosted_control/policy.rs
+++ b/src/bin/caller/access/hosted_control/policy.rs
@@ -414,6 +414,9 @@ pub fn hosted_control_msg_allowed(
             attachments,
             follow_up_id: _,
             delegation_id,
+            // A display name selects no capability — permitted exactly as
+            // CreateSession's `name` above.
+            session_name: _,
             launch_config,
         } => {
             preset >= HostedPreset::Tasks

--- a/src/bin/caller/agenda/reminders.rs
+++ b/src/bin/caller/agenda/reminders.rs
@@ -802,6 +802,43 @@ pub(crate) struct SpawnOccurrence {
     /// the dispatcher for the fire-time seal check and the fired task's
     /// per-ref data lines.
     pub(crate) binding_refs: Vec<BindingRef>,
+    /// Deterministic display name for the spawned session, derived from
+    /// the firing's source ([`derive_spawn_session_name`]) and assigned
+    /// through the existing session naming system at launch. `None` when
+    /// the source title normalizes to nothing — the spawn stays unnamed
+    /// (naming never blocks a firing).
+    pub(crate) session_name: Option<String>,
+}
+
+/// Deterministic display name for an agenda-fired session, derived from
+/// the firing's SOURCE — never model-generated. A workflow-node firing
+/// (an `on_unblock`-triggered manifest on an item placed under a parent)
+/// reads "<workflow title> - <node title>", the parent hub being the
+/// workflow instance (Track T's stamped shape); every other firing takes
+/// the item title alone, and an `on_unblock` node without a live parent
+/// degrades to the same. Normalized through the naming system's own
+/// rules so the launch path accepts the result verbatim; a title that
+/// normalizes to nothing yields `None` (an unnamed spawn, never a failed
+/// one). Titles are the only input, so the same item fires under the
+/// same name every occurrence — window disambiguation stays with the
+/// existing timestamps. Track AW seam: stamped definitions derive
+/// "<definition name> - <node id>" HERE once they land — this function
+/// is the single derivation point.
+fn derive_spawn_session_name(
+    item: &AgendaItem,
+    trigger: Option<&super::types::TriggerSpec>,
+    items: &[AgendaItem],
+) -> Option<String> {
+    let workflow_node = match trigger {
+        Some(super::types::TriggerSpec::OnUnblock) => item
+            .part_of
+            .as_ref()
+            .and_then(|placement| items.iter().find(|i| i.id == placement.parent_id))
+            .map(|workflow| format!("{} - {}", workflow.title, item.title)),
+        _ => None,
+    };
+    let raw = workflow_node.unwrap_or_else(|| item.title.clone());
+    crate::session_names::normalize_session_name(&raw).ok()
 }
 
 /// Occurrence identity for a scheduled session: entry + effect + the
@@ -1161,6 +1198,8 @@ pub(crate) fn plan(
                     .as_ref()
                     .is_some_and(|run| run.state == "started")
                 || journal.started_unresolved_for_item(&item.id);
+            let session_name =
+                derive_spawn_session_name(item, effect.manifest.trigger.as_ref(), items);
             for (instant, identity_ms, recurring) in candidates {
                 let occurrence_id = session_occurrence_id(
                     &item.id,
@@ -1189,6 +1228,7 @@ pub(crate) fn plan(
                     provenance_session_id: item.provenance.session_id.clone(),
                     matched_item_ids: trigger_batch.clone(),
                     binding_refs: effect.manifest.binding_refs.clone(),
+                    session_name: session_name.clone(),
                 };
                 if progress.prepared {
                     // Crash between prepare and launch confirmation: fail
@@ -3294,6 +3334,84 @@ mod tests {
             due,
             Some(150_000 + TRIGGER_COOLDOWN_MS),
             "the cooldown floors the refire for on_unblock too"
+        );
+    }
+
+    /// A workflow-node firing — an `on_unblock`-triggered manifest on an
+    /// item placed under a parent — derives "<workflow title> - <node
+    /// title>", the parent hub being the workflow instance in Track T's
+    /// stamped shape. A node whose parent is gone degrades to its own
+    /// title instead of firing nameless. Titles are the only input, so
+    /// the same node fires under the same name every occurrence.
+    #[test]
+    fn workflow_node_names_carry_workflow_and_node() {
+        let dir = tempfile::tempdir().unwrap();
+        let journal = journal(dir.path());
+        let policy = ReminderPolicy::default();
+        let approved = 10_000;
+        let mut node = triggered_item("node-b", TriggerSpec::OnUnblock, approved, approved);
+        depends_on(&mut node, "node-a");
+        node.part_of = Some(super::super::types::AgendaPlacement {
+            parent_id: "wf-hub".into(),
+            added_ms: 1,
+            principal: None,
+            session_id: None,
+            kind: None,
+            source: None,
+        });
+        let now = 500_000;
+
+        let hub = item("wf-hub", AgendaStatus::Open, None);
+        let items = vec![hub, done_at("node-a", 100_000), node.clone()];
+        let planned = plan(
+            &items,
+            &journal,
+            &policy,
+            now,
+            None,
+            &empty_sets(),
+            &empty_sets(),
+        );
+        assert_eq!(
+            planned.spawn[0].session_name.as_deref(),
+            Some("item wf-hub - item node-b"),
+            "a workflow-node spawn is named '<workflow title> - <node title>'"
+        );
+
+        let items = vec![done_at("node-a", 100_000), node.clone()];
+        let planned = plan(
+            &items,
+            &journal,
+            &policy,
+            now,
+            None,
+            &empty_sets(),
+            &empty_sets(),
+        );
+        assert_eq!(
+            planned.spawn[0].session_name.as_deref(),
+            Some("item node-b"),
+            "an on_unblock node without a live parent takes its own title"
+        );
+    }
+
+    /// Naming never blocks a firing: derivation is total. A standalone
+    /// (non-triggered) item derives its plain title through the naming
+    /// system's normalize rules; a title that normalizes to nothing
+    /// derives no name at all — the spawn goes out unnamed rather than
+    /// failing the launch-side name validation.
+    #[test]
+    fn spawn_name_derivation_is_total_and_title_shaped() {
+        let plain = item("solo", AgendaStatus::Open, None);
+        assert_eq!(
+            derive_spawn_session_name(&plain, None, std::slice::from_ref(&plain)).as_deref(),
+            Some("item solo")
+        );
+        let mut blank = item("blank", AgendaStatus::Open, None);
+        blank.title = "   ".into();
+        assert_eq!(
+            derive_spawn_session_name(&blank, None, std::slice::from_ref(&blank)),
+            None
         );
     }
 

--- a/src/bin/caller/agenda/scheduler.rs
+++ b/src/bin/caller/agenda/scheduler.rs
@@ -689,6 +689,11 @@ fn send_start_task(
             attachments: Vec::new(),
             follow_up_id: None,
             delegation_id: Some(format!("{DELEGATION_PREFIX}{}", spawn.occurrence_id)),
+            // Source-derived display name (item title / workflow-node
+            // composite), assigned through the existing naming system at
+            // launch. Stable across retries of this occurrence like the
+            // rest of the message.
+            session_name: spawn.session_name.clone(),
             // The manifest's owner-reviewed agent config, forwarded so the
             // spawn resolves launch settings through the same chain as a
             // pane-created session (explicit manifest pin → daemon default
@@ -2198,6 +2203,36 @@ mod tests {
         assert_eq!(run.session_id.as_deref(), Some("sess-run-2"));
     }
 
+    /// Agenda-fired sessions inherit a deterministic display name from
+    /// their source: a standalone item firing carries the ITEM TITLE on
+    /// the spawn's StartTask, assigned through the existing naming
+    /// system at launch — never model-generated, and stable across
+    /// firings of the same item (titles are the only input).
+    #[tokio::test]
+    async fn agenda_sessions_spawn_named_from_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let default_project = tempfile::tempdir().unwrap();
+        let handle = handle_with_default_project(dir.path(), default_project.path());
+        let mut journal = OccurrenceJournal::open(handle.dir()).unwrap();
+        let mut state = SchedulerState::default();
+        approved_effect_item(&handle, now_ms() - 60_000);
+
+        let mut rx = handle.bus().subscribe();
+        run_pass(&handle, &mut journal, &mut state).await;
+
+        let mut names = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            if let AppEvent::ControlCommand(ControlMsg::StartTask { session_name, .. }) = event {
+                names.push(session_name);
+            }
+        }
+        assert_eq!(
+            names,
+            vec![Some("scheduled work".to_string())],
+            "the spawn carries the source item's title as its derived session name"
+        );
+    }
+
     /// The duplicate-orchestrator regression, live shape (2026-07-26): a
     /// firing is `started`; the manifest is re-proposed mid-flight (the
     /// fold swaps the effect object) and re-approved. The swap must not
@@ -3211,6 +3246,7 @@ mod tests {
             agent_config: None,
             provenance_session_id: None,
             matched_item_ids: vec![q1.id.clone(), q2.id.clone()],
+            session_name: None,
         };
         assert!(dispatch_session(
             &handle,

--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -2177,6 +2177,18 @@ pub enum ControlMsg {
         /// gateway is unchanged.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         delegation_id: Option<String>,
+        /// Optional display name for the session this StartTask creates —
+        /// `CreateSession.name`'s twin, applied through the session naming
+        /// system at spawn (persisted meta/overlay + registry, exactly like
+        /// a composer-named create). The agenda's scheduled-session lane
+        /// derives it deterministically from the firing's source (item
+        /// title, or "<workflow title> - <node title>"). Create-time only:
+        /// ignored when `session_id` targets an existing session, and it
+        /// only ever seeds a fresh session's name — nothing re-applies it
+        /// later, so an owner rename always wins. Additive: absent frames
+        /// are byte-identical to pre-field builds.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        session_name: Option<String>,
         /// Optional agent-launch configuration for the session this
         /// StartTask creates — the same one-shot vocabulary `CreateSession`
         /// carries, flattened so the wire fields read identically
@@ -5282,6 +5294,7 @@ mod tests {
                 attachments: vec![],
                 follow_up_id: None,
                 delegation_id: None,
+                session_name: None,
                 launch_config: Default::default(),
             },
             ControlMsg::FollowUp {
@@ -5970,6 +5983,7 @@ mod tests {
             attachments: vec!["ann-recording-1".to_string(), "ann-recording-2".to_string()],
             follow_up_id: None,
             delegation_id: None,
+            session_name: None,
             launch_config: Default::default(),
         };
         let json = serde_json::to_string(&msg).unwrap();

--- a/src/bin/caller/mcp/commands.rs
+++ b/src/bin/caller/mcp/commands.rs
@@ -1527,6 +1527,7 @@ pub(crate) async fn handle_control_command_mcp(
                         attachments: vec![],
                         follow_up_id: None,
                         delegation_id: None,
+                        session_name: None,
                         launch_config: Default::default(),
                     }));
                     emit_control_result(

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -2024,6 +2024,7 @@ impl IntendantServer {
                     attachments: vec![],
                     follow_up_id: None,
                     delegation_id: None,
+                    session_name: None,
                     launch_config: Default::default(),
                 }));
             if target_phase
@@ -2059,6 +2060,7 @@ impl IntendantServer {
                     attachments: vec![],
                     follow_up_id: None,
                     delegation_id: None,
+                    session_name: None,
                     launch_config: Default::default(),
                 }));
             return "ok (CU task dispatched)".to_string();
@@ -2081,6 +2083,7 @@ impl IntendantServer {
                     attachments: vec![],
                     follow_up_id: None,
                     delegation_id: None,
+                    session_name: None,
                     launch_config: Default::default(),
                 }));
             return "ok (new session dispatched)".to_string();
@@ -3861,6 +3864,7 @@ pub(crate) mod tests {
                     attachments,
                     follow_up_id,
                     delegation_id,
+                    session_name,
                     launch_config,
                 }))) => {
                     assert!(project_root.is_none());
@@ -3873,6 +3877,7 @@ pub(crate) mod tests {
                     assert!(attachments.is_empty());
                     assert!(follow_up_id.is_none());
                     assert!(delegation_id.is_none());
+                    assert!(session_name.is_none());
                     assert!(launch_config.is_empty());
                 }
                 other => panic!("expected targeted StartTask control event, got {other:?}"),

--- a/src/bin/caller/peer/transport/intendant.rs
+++ b/src/bin/caller/peer/transport/intendant.rs
@@ -643,6 +643,7 @@ impl PeerTransport for IntendantWsTransport {
                     // the receipt wait lives on `PeerHandle::
                     // delegate_task`, not in the transport.
                     delegation_id: task.client_correlation_id.clone(),
+                    session_name: None,
                     // Peer delegations carry no launch pins: the receiving
                     // daemon's own defaults govern its spawns (its
                     // resolution chain fills every field).

--- a/src/bin/caller/presence.rs
+++ b/src/bin/caller/presence.rs
@@ -47,6 +47,7 @@ pub fn action_to_control_msg(action: &PresenceAction) -> Option<(ControlMsg, Str
                     attachments: envelope.attachment_frame_ids.clone(),
                     follow_up_id: None,
                     delegation_id: None,
+                    session_name: None,
                     launch_config: Default::default(),
                 },
                 confirmation,

--- a/src/bin/caller/session_supervisor/dispatch.rs
+++ b/src/bin/caller/session_supervisor/dispatch.rs
@@ -539,6 +539,7 @@ impl SessionSupervisor {
                 attachments,
                 follow_up_id: _,
                 delegation_id,
+                session_name,
                 launch_config,
             } => {
                 // Peer-delegation dedup: the delegating daemon re-sends
@@ -584,7 +585,7 @@ impl SessionSupervisor {
                             let started = self
                                 .start_new_session(
                                     String::new(),
-                                    None,
+                                    session_name,
                                     project_root,
                                     codex_fast_launch(&launch_config, agent),
                                     orchestrate,
@@ -624,14 +625,18 @@ impl SessionSupervisor {
                     return;
                 }
                 // The create-shaped StartTask threads its launch config
-                // through the SAME path CreateSession uses — the agenda's
+                // — and its optional source-derived session name — through
+                // the SAME path CreateSession uses: the agenda's
                 // scheduled/start-now spawns, ctl task, and peer
                 // delegations all get the identical resolution chain and
-                // recorded launch provenance.
+                // recorded launch provenance. The name only ever seeds a
+                // FRESH session (a duplicate delegation re-acks above
+                // without re-launching), so an owner rename is never
+                // overwritten by a redelivery.
                 let started = self
                     .start_new_session(
                         task,
-                        None,
+                        session_name,
                         project_root,
                         launch_config,
                         orchestrate,
@@ -1558,6 +1563,7 @@ mod tests {
             attachments: vec![],
             follow_up_id: None,
             delegation_id: Some(id.to_string()),
+            session_name: None,
             launch_config: Default::default(),
         };
         bus.send(AppEvent::ControlCommand(delegated("dg-mid-1")));
@@ -1629,6 +1635,142 @@ mod tests {
                 _ => break,
             }
         }
+    }
+
+    /// A create-shaped StartTask carrying a session name (the agenda's
+    /// derived-name lane rides this field).
+    fn delegated_named(id: &str, name: &str) -> event::ControlMsg {
+        event::ControlMsg::StartTask {
+            session_id: None,
+            task: "delegated: fired agenda goal".to_string(),
+            orchestrate: None,
+            direct: Some(true),
+            project_root: None,
+            reference_frame_ids: vec![],
+            display_target: None,
+            attachments: vec![],
+            follow_up_id: None,
+            delegation_id: Some(id.to_string()),
+            session_name: Some(name.to_string()),
+            launch_config: Default::default(),
+        }
+    }
+
+    /// Await the `TaskReceived` receipt for one delegation id; returns the
+    /// session it was dispatched as.
+    async fn await_delegation_receipt(
+        rx: &mut tokio::sync::broadcast::Receiver<AppEvent>,
+        delegation_id: &str,
+    ) -> String {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            assert!(
+                !remaining.is_zero(),
+                "timed out awaiting receipt for {delegation_id}"
+            );
+            match tokio::time::timeout(remaining, rx.recv()).await {
+                Ok(Ok(AppEvent::TaskReceived {
+                    delegation_id: got,
+                    session_id,
+                })) if got == delegation_id => return session_id,
+                Ok(Ok(_)) => {}
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => {}
+                other => panic!("bus closed before the receipt: {other:?}"),
+            }
+        }
+    }
+
+    /// Precedence law (agenda session naming): a derived name only ever
+    /// SEEDS a fresh spawn — an owner rename afterwards wins, and the
+    /// at-least-once redelivery of the same delegation (the derived name
+    /// still riding it) re-acks the original session without re-applying
+    /// the name.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn derived_name_never_clobbers_owner_rename() {
+        let bus = EventBus::new();
+        let project_dir = tempfile::tempdir().unwrap();
+        let (supervisor, gate) =
+            test_supervisor_with_gated_launches(project_dir.path().to_path_buf(), bus.clone());
+        gate.send(true)
+            .expect("launch body holds the gate receiver");
+        let mut bus_rx = bus.subscribe();
+        let _loop_handle = supervisor.clone().spawn();
+        let home = supervisor
+            .config
+            .logs_home_override
+            .clone()
+            .expect("test supervisor has a hermetic logs home");
+
+        bus.send(AppEvent::ControlCommand(delegated_named(
+            "dg-named-1",
+            "Agenda derived name",
+        )));
+        let session_id = await_delegation_receipt(&mut bus_rx, "dg-named-1").await;
+        assert_eq!(
+            crate::session_names::intendant_session_name(&home, &session_id),
+            Some(Some("Agenda derived name".to_string())),
+            "the derived name lands through the naming system at spawn"
+        );
+
+        supervisor
+            .rename_session(session_id.clone(), None, None, "Owner picked".to_string())
+            .await;
+        assert_eq!(
+            crate::session_names::intendant_session_name(&home, &session_id),
+            Some(Some("Owner picked".to_string()))
+        );
+
+        // At-least-once redelivery: same delegation id, derived name still
+        // riding the frame.
+        bus.send(AppEvent::ControlCommand(delegated_named(
+            "dg-named-1",
+            "Agenda derived name",
+        )));
+        let re_acked = await_delegation_receipt(&mut bus_rx, "dg-named-1").await;
+        assert_eq!(
+            re_acked, session_id,
+            "the duplicate re-acks the original session"
+        );
+        assert_eq!(
+            crate::session_names::intendant_session_name(&home, &session_id),
+            Some(Some("Owner picked".to_string())),
+            "a redelivered derived name never clobbers the owner's rename"
+        );
+    }
+
+    /// Suppression law (agenda session naming): a derived name makes the
+    /// session TITLED in the naming system's own read the moment it
+    /// spawns — the predicate any generated-naming lane for UNTITLED
+    /// sessions keys on — so such a lane skips derived-named sessions by
+    /// construction, and every surface that prefers `name` over
+    /// task-derived fallbacks renders the derived name.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn derived_name_suppresses_generated_naming() {
+        let bus = EventBus::new();
+        let project_dir = tempfile::tempdir().unwrap();
+        let (supervisor, gate) =
+            test_supervisor_with_gated_launches(project_dir.path().to_path_buf(), bus.clone());
+        gate.send(true)
+            .expect("launch body holds the gate receiver");
+        let mut bus_rx = bus.subscribe();
+        let _loop_handle = supervisor.clone().spawn();
+        let home = supervisor
+            .config
+            .logs_home_override
+            .clone()
+            .expect("test supervisor has a hermetic logs home");
+
+        bus.send(AppEvent::ControlCommand(delegated_named(
+            "dg-named-2",
+            "Agenda derived name",
+        )));
+        let session_id = await_delegation_receipt(&mut bus_rx, "dg-named-2").await;
+        assert_eq!(
+            crate::session_names::intendant_session_name(&home, &session_id),
+            Some(Some("Agenda derived name".to_string())),
+            "the session is titled at spawn — an untitled-keyed naming lane skips it"
+        );
     }
 
     #[tokio::test]
@@ -1929,6 +2071,7 @@ mod tests {
             attachments: vec![],
             follow_up_id: None,
             delegation_id: Some(delegation_id.to_string()),
+            session_name: None,
             launch_config: Default::default(),
         }
     }
@@ -2053,6 +2196,7 @@ mod tests {
                 attachments: vec![],
                 follow_up_id: None,
                 delegation_id: None,
+                session_name: None,
                 launch_config: Default::default(),
             })
             .await;
@@ -2209,6 +2353,7 @@ mod tests {
                 attachments: vec![],
                 follow_up_id: None,
                 delegation_id: None,
+                session_name: None,
                 launch_config: launch,
             })
             .await;
@@ -2255,6 +2400,7 @@ mod tests {
                         attachments: vec![],
                         follow_up_id: None,
                         delegation_id: None,
+                        session_name: None,
                         launch_config: launch,
                     })
                     .await;
@@ -2300,6 +2446,7 @@ mod tests {
                 attachments: vec![],
                 follow_up_id: None,
                 delegation_id: None,
+                session_name: None,
                 launch_config: codex_launch,
             })
             .await;

--- a/src/bin/caller/task_dispatch.rs
+++ b/src/bin/caller/task_dispatch.rs
@@ -142,9 +142,11 @@ impl Dispatcher {
                 // path exactly as against a pre-receipt build — see the
                 // compatibility matrix in peer::transport::intendant.
                 delegation_id: _,
-                // Launch config is create-time only; this dispatcher
-                // routes into an already-running loop whose config
-                // latched at spawn (same reasoning as project_root).
+                // Launch config and the create-time session name are
+                // create-time only; this dispatcher routes into an
+                // already-running loop whose config and name latched at
+                // spawn (same reasoning as project_root).
+                session_name: _,
                 launch_config: _,
             } => {
                 let is_direct = direct.unwrap_or(false) || orchestrate == Some(false);
@@ -445,6 +447,7 @@ mod tests {
             attachments: vec![],
             follow_up_id: None,
             delegation_id: None,
+            session_name: None,
             launch_config: Default::default(),
         }));
 
@@ -487,6 +490,7 @@ mod tests {
             attachments: vec![],
             follow_up_id: None,
             delegation_id: None,
+            session_name: None,
             launch_config: Default::default(),
         }));
 
@@ -524,6 +528,7 @@ mod tests {
             attachments: vec![],
             follow_up_id: None,
             delegation_id: None,
+            session_name: None,
             launch_config: Default::default(),
         }));
 
@@ -620,6 +625,7 @@ mod tests {
             attachments: vec![],
             follow_up_id: None,
             delegation_id: None,
+            session_name: None,
             launch_config: Default::default(),
         }));
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -663,6 +669,7 @@ mod tests {
                 attachments: vec![],
                 follow_up_id: None,
                 delegation_id: None,
+                session_name: None,
                 launch_config: Default::default(),
             })
         };
@@ -716,6 +723,7 @@ mod tests {
                 attachments: vec![],
                 follow_up_id: None,
                 delegation_id: None,
+                session_name: None,
                 launch_config: Default::default(),
             })
         };
@@ -766,6 +774,7 @@ mod tests {
             attachments: vec![],
             follow_up_id: None,
             delegation_id: None,
+            session_name: None,
             launch_config: Default::default(),
         }));
 


### PR DESCRIPTION
AGENDA SESSION NAMING (fired from agenda item 01KYKBBY9GQEFYE2ZYCZS6MC6H): every agenda-fired session rendered nameless because the spawn path never assigned a name, while session_names.rs sat complete.

## What
- At fire time the scheduler derives a deterministic display name from the firing's source and sends it on `StartTask`'s new additive `session_name` field (create-time only, `CreateSession.name`'s twin — same serde shape as the SpawnSubAgent precedent).
- Derivation (`derive_spawn_session_name`, agenda/reminders.rs — the single seam, documented for Track AW's stamped definitions to plug into): standalone item firing → item title through `normalize_session_name`'s rules; workflow-node firing (`on_unblock`-triggered manifest on an item placed under a parent hub) → `<workflow title> - <node title>`; parentless on_unblock degrades to the item title; a title normalizing to nothing spawns unnamed (naming never blocks a firing).
- The supervisor's create-shaped StartTask arm passes it into `start_new_session` — the EXISTING naming pipeline persists and renders it (session meta at spawn, external overlay at identity upgrade, ManagedSession.name in the registry). No parallel store, no new rendering.
- Hosted-control action wall: `session_name` permitted like CreateSession's `name` (a display name selects no capability); legacy dispatcher ignores it like the other create-time fields.
- Names derive from titles only — stable across firings; windows keep disambiguating by timestamps.

## Pins
- `agenda_sessions_spawn_named_from_source` — scheduler dispatch carries the item title.
- `workflow_node_names_carry_workflow_and_node` — planner derives the composite (+ parentless degrade).
- `derived_name_never_clobbers_owner_rename` — owner rename survives an at-least-once redelivery of the named delegation.
- `derived_name_suppresses_generated_naming` — the session reads as titled at spawn (the predicate an untitled-keyed naming lane keys on).
- plus `spawn_name_derivation_is_total_and_title_shaped` (whitespace-title → unnamed).

Docs: one paragraph in the agenda chapter's scheduled-sessions section.