### PR TITLE
feat(handover): HS2 — standing automations fire on the scheduler-lease holder only

### DIFF
--- a/docs/src/agenda-and-memory.md
+++ b/docs/src/agenda-and-memory.md
@@ -293,7 +293,18 @@ patching the due time creates a new occurrence.
 Notification delivery is at-least-once. The journal records `prepared` before
 delivery and a terminal result after it. A crash between those records can
 redeliver once. Two live daemons sharing the same home refold each other's
-journal writes, but there remains a narrow double-delivery window.
+journal writes for reads and dedup; firing itself is single-writer by
+construction — standing automations (the scheduler pass, reminder delivery,
+the PR scanner) run only on the daemon holding the **active-scheduler lease**
+(`scheduler-lease/holder.lock`, an advisory file lock held for the process
+lifetime; crash release is automatic). Co-homed secondaries plan nothing and
+poll the freed lock, so the population converges on a new holder within one
+poll interval after the holder exits. Journal rows carry the writer's
+`boot_id` and lease `generation`, and recovery only fail-closes occurrences
+whose writing daemon is provably gone (its per-boot presence lock under
+`daemons/` is takeable) — a live daemon's in-flight sessions are never
+clobbered by a co-homed boot. `intendant ctl status` shows the lease and
+every registered daemon under `scheduler_lease`.
 
 ### Scheduled sessions
 

--- a/src/bin/caller/agenda/reminders.rs
+++ b/src/bin/caller/agenda/reminders.rs
@@ -29,9 +29,14 @@
 //! (one-shot semantics — only a new due re-arms).
 //!
 //! Co-homed daemons: like the op log, the journal refolds when its file
-//! grows (`refresh_if_stale`), which narrows but cannot eliminate the
-//! double-fire window between two live daemons sharing one home —
-//! at-least-once, honestly.
+//! grows (`refresh_if_stale`) — the read-convergence lane. The
+//! check-then-`prepared` double-fire window between two LIVE daemons,
+//! which refold could only narrow, is closed structurally by the
+//! active-scheduler lease (`crate::handover`, Track HS2): only the lease
+//! holder runs the firing pass at all, so two live planners never race
+//! one due occurrence. At-least-once remains the honest contract for
+//! crash windows (a `prepared` row without a terminal re-delivers on the
+//! next wake, whichever daemon holds the lease by then).
 
 use super::types::{AgendaEffect, AgendaItem, AgendaStatus, BindingRef, RecurrenceSpec};
 use serde::{Deserialize, Serialize};
@@ -367,6 +372,31 @@ pub(crate) struct OccurrenceProgress {
     /// occurrences that never got past `prepared` (a dispatch lost with
     /// the process — no `started` row, no `last_run` lineage to match).
     pub(crate) item_id: Option<String>,
+    /// The boot id stamped on the last non-terminal (`prepared`/`started`)
+    /// row — whose daemon was driving this occurrence. Recovery scoping
+    /// (Track HS2) probes its liveness before fail-closing the occurrence.
+    /// Last non-terminal row wins, `None` included: a stampless row from a
+    /// pre-stamping build downgrades the occurrence to legacy boot-time
+    /// semantics — the fail-closed direction for mixed-version homes.
+    pub(crate) writer_boot_id: Option<String>,
+}
+
+/// One row of [`OccurrenceJournal::started_unresolved`].
+pub(crate) struct StartedUnresolved {
+    pub(crate) occurrence_id: String,
+    /// The started session (the lineage tip under a resume re-key).
+    pub(crate) session_id: Option<String>,
+    /// See [`OccurrenceProgress::writer_boot_id`].
+    pub(crate) writer_boot_id: Option<String>,
+}
+
+/// One row of [`OccurrenceJournal::prepared_unresolved`].
+pub(crate) struct PreparedUnresolved {
+    pub(crate) occurrence_id: String,
+    /// The owning item, when the journal rows retained it.
+    pub(crate) item_id: Option<String>,
+    /// See [`OccurrenceProgress::writer_boot_id`].
+    pub(crate) writer_boot_id: Option<String>,
 }
 
 /// The append-only delivery ledger. `prepare` records are fsync'd — the
@@ -421,9 +451,9 @@ impl OccurrenceJournal {
         self.stamp = stamp;
     }
 
-    /// See [`journal_generation_floor`]; live view of the same floor
-    /// (test/diagnostic seam, like [`Self::unresolved`]).
-    #[cfg(test)]
+    /// See [`journal_generation_floor`]; the live view of the same floor.
+    /// The secondary poll-acquire lane feeds this to lease acquisition
+    /// instead of re-folding the file (HS1 ruling note).
     pub(crate) fn max_generation(&self) -> u64 {
         self.max_generation
     }
@@ -480,28 +510,39 @@ impl OccurrenceJournal {
             .collect()
     }
 
-    /// `started` occurrences with no terminal record — sessions this
-    /// executor launched and (after a restart) lost sight of. The boot
-    /// pass resolves them to `Unknown`, fail-closed per RFC §7.5.
-    pub(crate) fn started_unresolved(&self) -> Vec<(String, Option<String>)> {
+    /// `started` occurrences with no terminal record — sessions some
+    /// executor launched and lost sight of. Recovery scoping (Track HS2)
+    /// decides per row, on `writer_boot_id` liveness, whether it may
+    /// fail-close the occurrence to `Unknown` (RFC §7.5) or must leave it
+    /// to the live daemon still driving it.
+    pub(crate) fn started_unresolved(&self) -> Vec<StartedUnresolved> {
         self.state
             .iter()
             .filter(|(_, progress)| progress.started.is_some() && progress.terminal.is_none())
-            .map(|(id, progress)| (id.clone(), progress.started.clone()))
+            .map(|(id, progress)| StartedUnresolved {
+                occurrence_id: id.clone(),
+                session_id: progress.started.clone(),
+                writer_boot_id: progress.writer_boot_id.clone(),
+            })
             .collect()
     }
 
-    /// Occurrences a previous process dispatched but never got a receipt
-    /// for: `prepared`, no `started`, no terminal — the lost-dispatch
-    /// shape (the StartTask died with the process). Paired with the
-    /// owning item id retained from the journal rows.
-    pub(crate) fn prepared_unresolved(&self) -> Vec<(String, Option<String>)> {
+    /// Occurrences a process dispatched but never got a receipt for:
+    /// `prepared`, no `started`, no terminal — the lost-dispatch shape
+    /// (the StartTask died with the process, or is still in the writer's
+    /// retry window). Paired with the owning item id retained from the
+    /// journal rows, and the writer's boot id for recovery scoping.
+    pub(crate) fn prepared_unresolved(&self) -> Vec<PreparedUnresolved> {
         self.state
             .iter()
             .filter(|(_, progress)| {
                 progress.prepared && progress.started.is_none() && progress.terminal.is_none()
             })
-            .map(|(id, progress)| (id.clone(), progress.item_id.clone()))
+            .map(|(id, progress)| PreparedUnresolved {
+                occurrence_id: id.clone(),
+                item_id: progress.item_id.clone(),
+                writer_boot_id: progress.writer_boot_id.clone(),
+            })
             .collect()
     }
 
@@ -700,10 +741,14 @@ fn fold_record_into(entry: &mut OccurrenceProgress, record: &OccurrenceRecord) {
         entry.item_id = Some(record.item_id.clone());
     }
     match record.state {
-        OccurrenceState::Prepared => entry.prepared = true,
+        OccurrenceState::Prepared => {
+            entry.prepared = true;
+            entry.writer_boot_id = record.boot_id.clone();
+        }
         OccurrenceState::Started => {
             entry.prepared = true;
             entry.started = record.session_id.clone();
+            entry.writer_boot_id = record.boot_id.clone();
             if let Some(session_id) = record.session_id.as_ref() {
                 if !entry.started_history.contains(session_id) {
                     entry.started_history.push(session_id.clone());
@@ -1693,6 +1738,61 @@ mod tests {
             serde_json::to_string(&record).unwrap(),
             legacy_line,
             "stampless records stay byte-identical to the legacy shape"
+        );
+    }
+
+    /// Recovery scoping's fold input (Track HS2): the last non-terminal
+    /// row's boot id wins — `None` included, so a stampless row from a
+    /// pre-stamping build downgrades the occurrence to legacy boot-time
+    /// recovery, the fail-closed direction for mixed-version homes.
+    #[test]
+    fn writer_boot_id_follows_last_non_terminal_row() {
+        let mk = |state: OccurrenceState, boot: Option<&str>| OccurrenceRecord {
+            v: 1,
+            at_ms: 1_000,
+            occurrence_id: "occ-1".to_string(),
+            item_id: "a".to_string(),
+            due_ms: 1_000,
+            state,
+            urgency: None,
+            session_id: Some("sess-1".to_string()),
+            generation: None,
+            boot_id: boot.map(str::to_string),
+        };
+        let lines = [
+            serde_json::to_string(&mk(OccurrenceState::Prepared, Some("boot-a"))).unwrap(),
+            serde_json::to_string(&mk(OccurrenceState::Started, Some("boot-b"))).unwrap(),
+        ]
+        .join("\n");
+        let (state, _, _) = fold_journal(lines.as_bytes());
+        assert_eq!(
+            state.get("occ-1").unwrap().writer_boot_id.as_deref(),
+            Some("boot-b"),
+            "last non-terminal row wins"
+        );
+
+        let lines = [
+            serde_json::to_string(&mk(OccurrenceState::Prepared, Some("boot-a"))).unwrap(),
+            serde_json::to_string(&mk(OccurrenceState::Started, None)).unwrap(),
+        ]
+        .join("\n");
+        let (state, _, _) = fold_journal(lines.as_bytes());
+        assert_eq!(
+            state.get("occ-1").unwrap().writer_boot_id,
+            None,
+            "a stampless writer downgrades the occurrence to legacy semantics"
+        );
+
+        // Terminal rows never disturb the writer attribution.
+        let lines = [
+            serde_json::to_string(&mk(OccurrenceState::Started, Some("boot-a"))).unwrap(),
+            serde_json::to_string(&mk(OccurrenceState::Completed, None)).unwrap(),
+        ]
+        .join("\n");
+        let (state, _, _) = fold_journal(lines.as_bytes());
+        assert_eq!(
+            state.get("occ-1").unwrap().writer_boot_id.as_deref(),
+            Some("boot-a")
         );
     }
 

--- a/src/bin/caller/agenda/scheduler.rs
+++ b/src/bin/caller/agenda/scheduler.rs
@@ -255,9 +255,18 @@ pub(crate) fn spawn_reminder_scheduler(
         }
         let mut state = SchedulerState::default();
         let mut events = handle.bus().subscribe();
-        resolve_lost_sessions(&handle, &mut journal);
+        // Boot recovery, scoped (Track HS2): a live co-homed daemon's
+        // in-flight rows are spared; legacy rows and provably dead
+        // writers fail-close exactly as before.
+        match handover.as_deref() {
+            Some(runtime) => {
+                resolve_lost_sessions(&handle, &mut journal, RecoveryScope::Boot(runtime))
+            }
+            None => resolve_lost_sessions(&handle, &mut journal, RecoveryScope::Unscoped),
+        }
         loop {
-            let next_wake_ms = run_pass(&handle, &mut journal, &mut state).await;
+            let next_wake_ms =
+                run_pass(&handle, &mut journal, &mut state, handover.as_deref()).await;
             let now = now_ms();
             let retry_wake_ms = sweep_pending_dispatches(&handle, &mut journal, &mut state, now);
             let lineage_wake_ms = sweep_lineage_pending(&handle, &mut journal, &mut state, now);
@@ -292,18 +301,92 @@ pub(crate) fn spawn_reminder_scheduler(
     })
 }
 
-/// Boot pass: `started`-without-terminal occurrences belong to a previous
-/// process — this executor lost sight of them. Fail-closed `Unknown`,
-/// never auto-retried (RFC §7.5); the sessions themselves, if alive, are
-/// still visible in the Sessions tab.
-fn resolve_lost_sessions(handle: &AgendaHandle, journal: &mut OccurrenceJournal) {
-    let unresolved = journal.started_unresolved();
-    let lost_dispatches = journal.prepared_unresolved();
+/// Which unresolved journal rows this daemon may fail-close (Track HS2,
+/// intake §3.5 + the Q3 recurring amendment). The pre-HS2 rule — every
+/// unresolved row is mine to declare unknown at boot — clobbered a live
+/// co-homed daemon's in-flight occurrences (the intake's one BROKEN
+/// edge). Scoping keys on the row's stamped writer boot id and that
+/// boot's provable liveness: its `daemons/<boot_id>.lock` is takeable
+/// iff the process is gone (crash included — the OS freed it).
+#[derive(Clone, Copy)]
+enum RecoveryScope<'a> {
+    /// No handover runtime (non-gateway shapes, direct test drives):
+    /// single-daemon semantics — every unresolved row is recoverable.
+    Unscoped,
+    /// Scheduler boot: legacy (pre-stamping) rows keep today's
+    /// resolve-at-boot semantics; stamped rows only when provably dead.
+    /// (Our own fresh boot id cannot be on any row yet.)
+    Boot(&'a crate::handover::HandoverRuntime),
+    /// The holder's steady-state re-check: stamped rows whose writer died
+    /// SINCE some boot pass spared them resolve without waiting for any
+    /// daemon restart — until resolved, a `started` row holds its
+    /// effect's no-overlap gate shut and would suppress every future
+    /// fire. Never touches our own rows (boot-id inequality) or legacy
+    /// rows (the boot pass owned those).
+    Recurring(&'a crate::handover::HandoverRuntime),
+}
+
+impl RecoveryScope<'_> {
+    fn may_resolve(&self, writer_boot_id: Option<&str>) -> bool {
+        let (runtime, legacy_recoverable) = match self {
+            RecoveryScope::Unscoped => return true,
+            RecoveryScope::Boot(runtime) => (runtime, true),
+            RecoveryScope::Recurring(runtime) => (runtime, false),
+        };
+        match writer_boot_id {
+            None => legacy_recoverable,
+            Some(boot) => {
+                boot != runtime.boot_id()
+                    && !crate::handover::boot_id_is_live(runtime.state_root(), boot)
+            }
+        }
+    }
+}
+
+/// Fail-close unresolved occurrences within `scope`: `started`-without-
+/// terminal rows whose driving daemon is gone resolve `Unknown`, never
+/// auto-retried (RFC §7.5); the sessions themselves, if alive, are
+/// still visible in the Sessions tab. Runs at scheduler boot
+/// ([`RecoveryScope::Boot`]/[`RecoveryScope::Unscoped`]) and on every
+/// holder pass ([`RecoveryScope::Recurring`]).
+fn resolve_lost_sessions(
+    handle: &AgendaHandle,
+    journal: &mut OccurrenceJournal,
+    scope: RecoveryScope<'_>,
+) {
+    let unresolved: Vec<_> = journal
+        .started_unresolved()
+        .into_iter()
+        .filter(|row| scope.may_resolve(row.writer_boot_id.as_deref()))
+        .collect();
+    let lost_dispatches: Vec<_> = journal
+        .prepared_unresolved()
+        .into_iter()
+        .filter(|row| scope.may_resolve(row.writer_boot_id.as_deref()))
+        .collect();
     if unresolved.is_empty() && lost_dispatches.is_empty() {
         return;
     }
+    // Why the writer died shapes the owner-facing note: a boot pass means
+    // *this* executor restarted; the recurring pass means a co-homed
+    // writer (a drainer, a crashed holder) went away under a daemon that
+    // kept running.
+    let (started_note, prepared_note) = match scope {
+        RecoveryScope::Recurring(_) => (
+            "the daemon driving this session exited without a terminal \
+             record — outcome unknown; check the session log",
+            "the daemon that dispatched this occurrence exited before a \
+             receipt — outcome unknown",
+        ),
+        _ => (
+            "daemon restarted while the session ran — outcome unknown; \
+             check the session log",
+            "daemon restarted before the session dispatched — outcome unknown",
+        ),
+    };
     let (items, _, _) = handle.snapshot();
-    for (occurrence_id, session_id) in unresolved {
+    for row in unresolved {
+        let (occurrence_id, session_id) = (row.occurrence_id, row.session_id);
         let _ = journal.append(&OccurrenceRecord {
             v: 1,
             at_ms: now_ms(),
@@ -331,11 +414,7 @@ fn resolve_lost_sessions(handle: &AgendaHandle, journal: &mut OccurrenceJournal)
                         occurrence_id: &occurrence_id,
                         state: "unknown",
                         session_id: session_id.clone(),
-                        note: Some(
-                            "daemon restarted while the session ran — outcome \
-                             unknown; check the session log"
-                                .to_string(),
-                        ),
+                        note: Some(started_note.to_string()),
                     }) {
                         eprintln!(
                             "[agenda] occurrence write-back failed (unknown on {}): {err}",
@@ -347,17 +426,18 @@ fn resolve_lost_sessions(handle: &AgendaHandle, journal: &mut OccurrenceJournal)
         }
         eprintln!(
             "[agenda] occurrence {occurrence_id} resolved to unknown \
-             (daemon restarted while session {} ran)",
+             (writer daemon gone while session {} ran)",
             session_id.as_deref().unwrap_or("?")
         );
     }
     // The lost-dispatch shape: `prepared` with no receipt and no terminal
-    // belongs to a previous process whose StartTask died with it. Same
+    // belongs to a gone process whose StartTask died with it. Same
     // fail-closed `unknown`, written back via the item id the journal
     // rows retained (there is no `last_run` lineage to match — the
     // occurrence never started); v1's one-effect-per-item names the
     // effect. Never auto-retried; the owner sees `unknown` and decides.
-    for (occurrence_id, item_id) in lost_dispatches {
+    for row in lost_dispatches {
+        let (occurrence_id, item_id) = (row.occurrence_id, row.item_id);
         let _ = journal.append(&OccurrenceRecord {
             v: 1,
             at_ms: now_ms(),
@@ -381,11 +461,7 @@ fn resolve_lost_sessions(handle: &AgendaHandle, journal: &mut OccurrenceJournal)
                     occurrence_id: &occurrence_id,
                     state: "unknown",
                     session_id: None,
-                    note: Some(
-                        "daemon restarted before the session dispatched — outcome \
-                         unknown"
-                            .to_string(),
-                    ),
+                    note: Some(prepared_note.to_string()),
                 }) {
                     eprintln!(
                         "[agenda] occurrence write-back failed (unknown on {}): {err}",
@@ -396,7 +472,7 @@ fn resolve_lost_sessions(handle: &AgendaHandle, journal: &mut OccurrenceJournal)
         }
         eprintln!(
             "[agenda] occurrence {occurrence_id} resolved to unknown \
-             (daemon restarted before its session dispatched)"
+             (writer daemon gone before its session dispatched)"
         );
     }
 }
@@ -481,9 +557,39 @@ async fn run_pass(
     handle: &AgendaHandle,
     journal: &mut OccurrenceJournal,
     state: &mut SchedulerState,
+    handover: Option<&crate::handover::HandoverRuntime>,
 ) -> Option<u64> {
     if let Err(err) = journal.refresh_if_stale() {
         eprintln!("[agenda] occurrence journal refresh failed: {err}");
+    }
+    // Track HS2: the firing pass is holder-only — this is what turns the
+    // co-homed check-then-`prepared` double-fire window from a
+    // probabilistic race into a structural impossibility (two live
+    // planners never both reach `plan`). `None` = no gateway runtime
+    // (direct test drives, legacy shapes): ungated, today's semantics.
+    if let Some(runtime) = handover {
+        if runtime.is_holder() {
+            // Steady state: the recurring Q3 re-check — a co-homed
+            // writer that died since its rows were spared resolves now,
+            // not at some future daemon restart (an unresolved `started`
+            // row holds its effect's no-overlap gate shut).
+            resolve_lost_sessions(handle, journal, RecoveryScope::Recurring(runtime));
+        } else if runtime.poll_acquire(journal.max_generation()) {
+            // Freed lease taken over (the previous holder exited or
+            // crashed): stamp rows with the new generation, fail-close
+            // what the dead generation left behind, then fire normally
+            // this same pass.
+            journal.set_stamp(Some(JournalStamp {
+                boot_id: runtime.boot_id().to_string(),
+                generation: runtime.held_generation(),
+            }));
+            resolve_lost_sessions(handle, journal, RecoveryScope::Recurring(runtime));
+        } else {
+            // Secondary: standing automations off — plan nothing, fire
+            // nothing, deliver nothing. Wake at the poll cadence so a
+            // freed lease converges without owner action.
+            return Some(now_ms() + crate::handover::lease_poll_interval().as_millis() as u64);
+        }
     }
     let (items, _, _) = handle.snapshot();
     let policy = handle.reminder_policy();
@@ -1420,7 +1526,7 @@ mod tests {
         let mut journal = OccurrenceJournal::open(handle.dir()).unwrap();
         let mut rx = handle.bus().subscribe();
 
-        run_pass(&handle, &mut journal, &mut SchedulerState::default()).await;
+        run_pass(&handle, &mut journal, &mut SchedulerState::default(), None).await;
         let mut reminder_seen = false;
         while let Ok(event) = rx.try_recv() {
             if let AppEvent::UserNotification { id, urgency, .. } = event {
@@ -1432,7 +1538,7 @@ mod tests {
         assert!(reminder_seen, "overdue item must deliver");
 
         // Second pass: spent occurrence, no re-delivery.
-        run_pass(&handle, &mut journal, &mut SchedulerState::default()).await;
+        run_pass(&handle, &mut journal, &mut SchedulerState::default(), None).await;
         while let Ok(event) = rx.try_recv() {
             assert!(
                 !matches!(event, AppEvent::UserNotification { .. }),
@@ -1475,7 +1581,7 @@ mod tests {
                 None,
             )
             .unwrap();
-        let wake = run_pass(&handle, &mut journal, &mut SchedulerState::default()).await;
+        let wake = run_pass(&handle, &mut journal, &mut SchedulerState::default(), None).await;
         assert_eq!(wake, None, "no open due items ⇒ nothing scheduled");
         while let Ok(event) = rx.try_recv() {
             assert!(!matches!(event, AppEvent::UserNotification { .. }));
@@ -1491,7 +1597,7 @@ mod tests {
         let mut journal = OccurrenceJournal::open(handle.dir()).unwrap();
         let mut rx = handle.bus().subscribe();
 
-        run_pass(&handle, &mut journal, &mut SchedulerState::default()).await;
+        run_pass(&handle, &mut journal, &mut SchedulerState::default(), None).await;
         let mut digest_seen = false;
         while let Ok(event) = rx.try_recv() {
             if let AppEvent::UserNotification { id, title, .. } = event {
@@ -1502,7 +1608,7 @@ mod tests {
         }
         assert!(digest_seen);
         // Spent: a second pass is silent.
-        run_pass(&handle, &mut journal, &mut SchedulerState::default()).await;
+        run_pass(&handle, &mut journal, &mut SchedulerState::default(), None).await;
         while let Ok(event) = rx.try_recv() {
             assert!(!matches!(event, AppEvent::UserNotification { .. }));
         }
@@ -1523,7 +1629,7 @@ mod tests {
             .unwrap();
         let mut journal = OccurrenceJournal::open(handle.dir()).unwrap();
         let mut rx = handle.bus().subscribe();
-        run_pass(&handle, &mut journal, &mut SchedulerState::default()).await;
+        run_pass(&handle, &mut journal, &mut SchedulerState::default(), None).await;
         while let Ok(event) = rx.try_recv() {
             assert!(
                 !matches!(event, AppEvent::UserNotification { .. }),
@@ -1539,7 +1645,7 @@ mod tests {
                 .unwrap(),
             )
             .unwrap();
-        run_pass(&handle, &mut journal, &mut SchedulerState::default()).await;
+        run_pass(&handle, &mut journal, &mut SchedulerState::default(), None).await;
         while let Ok(event) = rx.try_recv() {
             assert!(!matches!(event, AppEvent::UserNotification { .. }));
         }
@@ -1699,7 +1805,7 @@ mod tests {
         );
 
         let mut rx = handle.bus().subscribe();
-        run_pass(&handle, &mut journal, &mut state).await;
+        run_pass(&handle, &mut journal, &mut state, None).await;
         let mut dispatched = Vec::new();
         while let Ok(event) = rx.try_recv() {
             if let AppEvent::ControlCommand(ControlMsg::StartTask {
@@ -1771,7 +1877,7 @@ mod tests {
         std::fs::remove_file(&vanishing).unwrap();
 
         let mut rx = handle.bus().subscribe();
-        run_pass(&handle, &mut journal, &mut state).await;
+        run_pass(&handle, &mut journal, &mut state, None).await;
         let mut tasks = Vec::new();
         while let Ok(event) = rx.try_recv() {
             if let AppEvent::ControlCommand(ControlMsg::StartTask { task, .. }) = event {
@@ -1887,7 +1993,7 @@ mod tests {
         std::fs::write(&unreconstructable, b"amended after approval\n").unwrap();
 
         let mut rx = handle.bus().subscribe();
-        run_pass(&handle, &mut journal, &mut state).await;
+        run_pass(&handle, &mut journal, &mut state, None).await;
         while let Ok(event) = rx.try_recv() {
             assert!(
                 !matches!(
@@ -1961,7 +2067,7 @@ mod tests {
         std::fs::remove_file(&sealed_path).unwrap();
 
         let mut rx = handle.bus().subscribe();
-        run_pass(&handle, &mut journal, &mut state).await;
+        run_pass(&handle, &mut journal, &mut state, None).await;
         let mut spawned = 0;
         while let Ok(event) = rx.try_recv() {
             if matches!(
@@ -2027,7 +2133,7 @@ mod tests {
             .unwrap();
 
         let mut rx = handle.bus().subscribe();
-        run_pass(&handle, &mut journal, &mut state).await;
+        run_pass(&handle, &mut journal, &mut state, None).await;
 
         let mut dispatched = Vec::new();
         while let Ok(event) = rx.try_recv() {
@@ -2113,7 +2219,7 @@ mod tests {
 
         // Spent: another pass dispatches nothing.
         let mut rx = handle.bus().subscribe();
-        run_pass(&handle, &mut journal, &mut state).await;
+        run_pass(&handle, &mut journal, &mut state, None).await;
         while let Ok(event) = rx.try_recv() {
             assert!(
                 !matches!(
@@ -2160,7 +2266,7 @@ mod tests {
             )
             .unwrap();
         let mut rx = handle.bus().subscribe();
-        run_pass(&handle, &mut journal, &mut state).await;
+        run_pass(&handle, &mut journal, &mut state, None).await;
         let mut second = None;
         while let Ok(event) = rx.try_recv() {
             if let AppEvent::ControlCommand(ControlMsg::StartTask {
@@ -2218,7 +2324,7 @@ mod tests {
         approved_effect_item(&handle, now_ms() - 60_000);
 
         let mut rx = handle.bus().subscribe();
-        run_pass(&handle, &mut journal, &mut state).await;
+        run_pass(&handle, &mut journal, &mut state, None).await;
 
         let mut names = Vec::new();
         while let Ok(event) = rx.try_recv() {
@@ -2251,7 +2357,7 @@ mod tests {
 
         // Fire + receipt: the run is live.
         let mut rx = handle.bus().subscribe();
-        run_pass(&handle, &mut journal, &mut state).await;
+        run_pass(&handle, &mut journal, &mut state, None).await;
         let mut first = None;
         while let Ok(event) = rx.try_recv() {
             if let AppEvent::ControlCommand(ControlMsg::StartTask {
@@ -2312,7 +2418,7 @@ mod tests {
         // The pass after swap + re-approval plans NOTHING for the item —
         // the defect dispatched a duplicate orchestrator right here.
         let mut rx = handle.bus().subscribe();
-        run_pass(&handle, &mut journal, &mut state).await;
+        run_pass(&handle, &mut journal, &mut state, None).await;
         while let Ok(event) = rx.try_recv() {
             assert!(
                 !matches!(
@@ -2334,7 +2440,7 @@ mod tests {
             },
         );
         let mut rx = handle.bus().subscribe();
-        run_pass(&handle, &mut journal, &mut state).await;
+        run_pass(&handle, &mut journal, &mut state, None).await;
         let mut second = None;
         while let Ok(event) = rx.try_recv() {
             if let AppEvent::ControlCommand(ControlMsg::StartTask {
@@ -2392,7 +2498,7 @@ mod tests {
             .unwrap();
 
         let mut rx = handle.bus().subscribe();
-        run_pass(&handle, &mut journal, &mut state).await;
+        run_pass(&handle, &mut journal, &mut state, None).await;
         let mut dispatched = Vec::new();
         while let Ok(event) = rx.try_recv() {
             if let AppEvent::ControlCommand(ControlMsg::StartTask {
@@ -2459,7 +2565,7 @@ mod tests {
 
         // Spent: another pass dispatches nothing.
         let mut rx = handle.bus().subscribe();
-        run_pass(&handle, &mut journal, &mut state).await;
+        run_pass(&handle, &mut journal, &mut state, None).await;
         while let Ok(event) = rx.try_recv() {
             assert!(
                 !matches!(
@@ -2513,7 +2619,7 @@ mod tests {
             )
             .unwrap();
         let mut rx = handle.bus().subscribe();
-        run_pass(&handle, &mut journal, &mut state).await;
+        run_pass(&handle, &mut journal, &mut state, None).await;
         let mut delegation_id = None;
         while let Ok(event) = rx.try_recv() {
             if let AppEvent::ControlCommand(ControlMsg::StartTask {
@@ -2622,7 +2728,7 @@ mod tests {
             )
             .unwrap();
         let mut rx = handle.bus().subscribe();
-        run_pass(&handle, &mut journal, &mut state).await;
+        run_pass(&handle, &mut journal, &mut state, None).await;
         let mut delegation_id = None;
         while let Ok(event) = rx.try_recv() {
             if let AppEvent::ControlCommand(ControlMsg::StartTask {
@@ -2772,7 +2878,7 @@ mod tests {
             )
             .unwrap();
         let mut rx = handle.bus().subscribe();
-        run_pass(handle, journal, state).await;
+        run_pass(handle, journal, state, None).await;
         let mut delegation_id = None;
         while let Ok(event) = rx.try_recv() {
             if let AppEvent::ControlCommand(ControlMsg::StartTask {
@@ -3183,7 +3289,7 @@ mod tests {
         );
 
         let mut rx = handle.bus().subscribe();
-        run_pass(&handle, &mut journal, &mut state).await;
+        run_pass(&handle, &mut journal, &mut state, None).await;
         let mut dispatched = 0;
         while let Ok(event) = rx.try_recv() {
             if let AppEvent::ControlCommand(ControlMsg::StartTask {
@@ -3380,7 +3486,7 @@ mod tests {
             config: &crate::event::AgentLaunchConfig,
         ) -> Option<String> {
             let mut rx = handle.bus().subscribe();
-            run_pass(handle, journal, state).await;
+            run_pass(handle, journal, state, None).await;
             let mut delegation = None;
             while let Ok(event) = rx.try_recv() {
                 if let AppEvent::ControlCommand(ControlMsg::StartTask {
@@ -3651,7 +3757,7 @@ mod tests {
             )
             .unwrap();
         let mut rx = handle.bus().subscribe();
-        run_pass(&handle, &mut journal, &mut state).await;
+        run_pass(&handle, &mut journal, &mut state, None).await;
         let mut first = None;
         while let Ok(event) = rx.try_recv() {
             if let AppEvent::ControlCommand(ControlMsg::StartTask {
@@ -3750,12 +3856,12 @@ mod tests {
             .unwrap();
         // Dispatch journals `prepared`; the process "dies" before any
         // receipt (we simply drop the in-memory state).
-        run_pass(&handle, &mut journal, &mut state).await;
+        run_pass(&handle, &mut journal, &mut state, None).await;
         drop(state);
 
         // Next boot: a fresh journal fold sees prepared-without-started.
         let mut journal = OccurrenceJournal::open(handle.dir()).unwrap();
-        resolve_lost_sessions(&handle, &mut journal);
+        resolve_lost_sessions(&handle, &mut journal, RecoveryScope::Unscoped);
         let (items, _, _) = handle.snapshot();
         let run = items.iter().find(|i| i.id == item.id).unwrap().effects[0]
             .last_run
@@ -3782,7 +3888,7 @@ mod tests {
         approved_effect_item(&handle, now_ms() - 60_000);
         approved_effect_item(&handle, now_ms() - 60_000);
 
-        run_pass(&handle, &mut journal, &mut state).await;
+        run_pass(&handle, &mut journal, &mut state, None).await;
         assert_eq!(state.awaiting.len(), 2);
         let running_occurrence = state.awaiting.keys().next().unwrap().clone();
         let running_item = state.awaiting[&running_occurrence].spawn.item_id.clone();
@@ -3841,7 +3947,7 @@ mod tests {
             .is_none());
 
         let mut events = handle.bus().subscribe();
-        run_pass(&handle, &mut journal, &mut state).await;
+        run_pass(&handle, &mut journal, &mut state, None).await;
         while let Ok(event) = events.try_recv() {
             assert!(
                 !matches!(
@@ -3865,7 +3971,7 @@ mod tests {
         let mut state = SchedulerState::default();
         let (item_id, _, _) = approved_effect_item(&handle, now_ms() - 60_000);
 
-        run_pass(&handle, &mut journal, &mut state).await;
+        run_pass(&handle, &mut journal, &mut state, None).await;
         let occurrence_id = state.awaiting.keys().next().unwrap().clone();
         observe_event(
             &handle,
@@ -3897,7 +4003,7 @@ mod tests {
         // Missed window: approved 25h ago (past the 12h staleness default).
         let (missed_item, _, _) = approved_effect_item(&handle, now_ms() - 25 * 3_600_000);
         let mut rx = handle.bus().subscribe();
-        run_pass(&handle, &mut journal, &mut state).await;
+        run_pass(&handle, &mut journal, &mut state, None).await;
         let mut saw_start = false;
         let mut saw_missed_note = false;
         while let Ok(event) = rx.try_recv() {
@@ -3996,7 +4102,7 @@ mod tests {
             .unwrap();
 
         let mut rx = handle.bus().subscribe();
-        run_pass(&handle, &mut journal, &mut state).await;
+        run_pass(&handle, &mut journal, &mut state, None).await;
         let mut spawned_root = None;
         while let Ok(event) = rx.try_recv() {
             if let AppEvent::ControlCommand(ControlMsg::StartTask { project_root, .. }) = event {
@@ -4029,7 +4135,7 @@ mod tests {
         let (item_id, _, _) = approved_effect_item(&handle, now_ms() - 60_000);
 
         let mut rx = handle.bus().subscribe();
-        run_pass(&handle, &mut journal, &mut state).await;
+        run_pass(&handle, &mut journal, &mut state, None).await;
         let mut saw_start = false;
         let mut refusal_note = None;
         while let Ok(event) = rx.try_recv() {
@@ -4060,7 +4166,7 @@ mod tests {
 
         // Terminal: the next pass does not retry the spent occurrence.
         let mut rx = handle.bus().subscribe();
-        run_pass(&handle, &mut journal, &mut state).await;
+        run_pass(&handle, &mut journal, &mut state, None).await;
         while let Ok(event) = rx.try_recv() {
             assert!(
                 !matches!(
@@ -4071,5 +4177,314 @@ mod tests {
                 "a failed occurrence must not re-fire or re-notify"
             );
         }
+    }
+
+    // ------------------------------------------------------------------
+    // Track HS2: firing gated on the active-scheduler lease + scoped
+    // recovery. Conformance pins named by the sealed intake's checklist.
+    // ------------------------------------------------------------------
+
+    fn stamped_started_rows(journal: &mut OccurrenceJournal, occ: &str, item: &str) {
+        for state in [OccurrenceState::Prepared, OccurrenceState::Started] {
+            journal
+                .append(&OccurrenceRecord {
+                    v: 1,
+                    at_ms: 1_000,
+                    occurrence_id: occ.to_string(),
+                    item_id: item.to_string(),
+                    due_ms: 1_000,
+                    state,
+                    urgency: None,
+                    session_id: matches!(state, OccurrenceState::Started)
+                        .then(|| format!("sess-{occ}")),
+                    generation: None,
+                    boot_id: None,
+                })
+                .unwrap();
+        }
+    }
+
+    /// A secondary's pass never reaches the planner: no deliveries, no
+    /// spawns, no journal rows — and it wakes at the poll cadence, not at
+    /// any item's due instant.
+    #[tokio::test]
+    async fn non_holder_pass_plans_nothing() {
+        let home = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let _holder = crate::handover::HandoverRuntime::initialize(home.path(), 7001, 0);
+        let secondary = crate::handover::HandoverRuntime::initialize(home.path(), 7002, 0);
+        assert!(!secondary.is_holder());
+
+        // An overdue item that an ungated pass would deliver immediately.
+        let (handle, _) = handle_with_item(dir.path(), 1_000);
+        let mut journal = OccurrenceJournal::open(handle.dir()).unwrap();
+        let mut rx = handle.bus().subscribe();
+        let now = now_ms();
+        let wake = run_pass(
+            &handle,
+            &mut journal,
+            &mut SchedulerState::default(),
+            Some(&secondary),
+        )
+        .await;
+
+        while let Ok(event) = rx.try_recv() {
+            assert!(
+                !matches!(
+                    event,
+                    AppEvent::UserNotification { .. }
+                        | AppEvent::ControlCommand(ControlMsg::StartTask { .. })
+                ),
+                "a non-holder pass must fire nothing"
+            );
+        }
+        assert!(
+            journal.unresolved().is_empty() && journal.started_unresolved().is_empty(),
+            "a non-holder pass must journal nothing"
+        );
+        let wake = wake.expect("secondaries wake at the poll cadence");
+        assert!(
+            wake >= now + 30_000,
+            "the wake is the lease poll interval, never the overdue instant: {wake} vs {now}"
+        );
+    }
+
+    /// The commissioned race pin. (a) With lease coordination absent, two
+    /// planners over one home read the same pre-append state — the
+    /// check-then-`prepared` window — and BOTH dispatch the one due
+    /// occurrence: the journal ends with two started sessions on one
+    /// occurrence id. (b) With the lease, the secondary's pass returns
+    /// before the planner ever runs, so exactly one prepared row and one
+    /// dispatch exist — the lease closes the window structurally, not by
+    /// refold luck.
+    #[tokio::test]
+    async fn double_fire_demonstrated_without_lease_and_closed_with_it() {
+        // ---- leg (a): the window, demonstrated ----
+        let dir = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let handle = handle_with_default_project(dir.path(), project.path());
+        let now = now_ms();
+        // A due, owner-approved standing manifest — the intake's exact
+        // race subject.
+        approved_effect_item(&handle, now - 1_000);
+        let (items, _, _) = handle.snapshot();
+        let policy = handle.reminder_policy();
+        // Two daemons' journals over one file, both still empty: both
+        // planners pass the check before either appends `prepared`.
+        let mut journal_a = OccurrenceJournal::open(handle.dir()).unwrap();
+        let mut journal_b = OccurrenceJournal::open(handle.dir()).unwrap();
+        let planned_a = plan(
+            &items,
+            &journal_a,
+            &policy,
+            now,
+            None,
+            &Default::default(),
+            &Default::default(),
+        );
+        let planned_b = plan(
+            &items,
+            &journal_b,
+            &policy,
+            now,
+            None,
+            &Default::default(),
+            &Default::default(),
+        );
+        let spawn_a = planned_a
+            .spawn
+            .first()
+            .expect("due occurrence planned")
+            .clone();
+        let spawn_b = planned_b
+            .spawn
+            .first()
+            .expect("same occurrence planned")
+            .clone();
+        assert_eq!(spawn_a.occurrence_id, spawn_b.occurrence_id);
+        // Both dispatch: prepared + started through each daemon's journal.
+        assert!(session_record(
+            &mut journal_a,
+            &spawn_a,
+            now,
+            OccurrenceState::Prepared,
+            None
+        ));
+        assert!(session_record(
+            &mut journal_a,
+            &spawn_a,
+            now,
+            OccurrenceState::Started,
+            Some("sess-a".into())
+        ));
+        assert!(session_record(
+            &mut journal_b,
+            &spawn_b,
+            now,
+            OccurrenceState::Prepared,
+            None
+        ));
+        assert!(session_record(
+            &mut journal_b,
+            &spawn_b,
+            now,
+            OccurrenceState::Started,
+            Some("sess-b".into())
+        ));
+        let folded = OccurrenceJournal::open(handle.dir()).unwrap();
+        let progress = folded.progress(&spawn_a.occurrence_id);
+        assert_eq!(
+            progress.started_history,
+            vec!["sess-a".to_string(), "sess-b".to_string()],
+            "the double-fire, on disk: two sessions for one occurrence"
+        );
+
+        // ---- leg (b): the lease closes it ----
+        let home = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let holder = crate::handover::HandoverRuntime::initialize(home.path(), 7001, 0);
+        let secondary = crate::handover::HandoverRuntime::initialize(home.path(), 7002, 0);
+        let handle = handle_with_default_project(dir.path(), project.path());
+        approved_effect_item(&handle, now_ms() - 1_000);
+        let mut journal_a = OccurrenceJournal::open(handle.dir()).unwrap();
+        let mut journal_b = OccurrenceJournal::open(handle.dir()).unwrap();
+        let mut rx = handle.bus().subscribe();
+        // The secondary looks first — the racing order that used to
+        // double-fire — and never reaches the planner at all.
+        run_pass(
+            &handle,
+            &mut journal_b,
+            &mut SchedulerState::default(),
+            Some(&secondary),
+        )
+        .await;
+        run_pass(
+            &handle,
+            &mut journal_a,
+            &mut SchedulerState::default(),
+            Some(&holder),
+        )
+        .await;
+        let mut dispatches = 0;
+        while let Ok(event) = rx.try_recv() {
+            if matches!(
+                event,
+                AppEvent::ControlCommand(ControlMsg::StartTask { .. })
+            ) {
+                dispatches += 1;
+            }
+        }
+        assert_eq!(dispatches, 1, "exactly one dispatch under the lease");
+        let raw = std::fs::read_to_string(handle.dir().join("occurrences.jsonl")).unwrap();
+        let prepared_rows = raw
+            .lines()
+            .filter(|line| line.contains("\"prepared\""))
+            .count();
+        assert_eq!(
+            prepared_rows, 1,
+            "exactly one prepared row — the secondary appended nothing:\n{raw}"
+        );
+    }
+
+    /// Boot recovery spares rows whose stamped writer is provably alive
+    /// (its presence lock is held), while legacy stampless rows keep
+    /// today's resolve-at-boot semantics.
+    #[test]
+    fn boot_recovery_spares_live_generation_rows() {
+        let home = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let live_writer = crate::handover::HandoverRuntime::initialize(home.path(), 7001, 0);
+        let booting = crate::handover::HandoverRuntime::initialize(home.path(), 7002, 0);
+        let (handle, _) = handle_with_item(dir.path(), now_ms() + 3_600_000);
+        let mut journal = OccurrenceJournal::open(handle.dir()).unwrap();
+
+        // A live co-homed daemon's in-flight occurrence…
+        journal.set_stamp(Some(JournalStamp {
+            boot_id: live_writer.boot_id().to_string(),
+            generation: Some(1),
+        }));
+        stamped_started_rows(&mut journal, "occ-live", "it-live");
+        // …and a legacy (pre-stamping) row.
+        journal.set_stamp(None);
+        stamped_started_rows(&mut journal, "occ-legacy", "it-legacy");
+
+        resolve_lost_sessions(&handle, &mut journal, RecoveryScope::Boot(&booting));
+        assert_eq!(
+            journal.progress("occ-live").terminal,
+            None,
+            "a live writer's row is spared — the intake's BROKEN edge, fixed"
+        );
+        assert_eq!(
+            journal.progress("occ-legacy").terminal,
+            Some(OccurrenceState::Unknown),
+            "legacy rows keep today's boot semantics"
+        );
+        drop(live_writer);
+    }
+
+    /// Once the writer is provably dead, its rows fail-close `Unknown`.
+    #[test]
+    fn dead_generation_rows_resolve_unknown() {
+        let home = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let writer = crate::handover::HandoverRuntime::initialize(home.path(), 7001, 0);
+        let survivor = crate::handover::HandoverRuntime::initialize(home.path(), 7002, 0);
+        let (handle, _) = handle_with_item(dir.path(), now_ms() + 3_600_000);
+        let mut journal = OccurrenceJournal::open(handle.dir()).unwrap();
+        journal.set_stamp(Some(JournalStamp {
+            boot_id: writer.boot_id().to_string(),
+            generation: Some(1),
+        }));
+        stamped_started_rows(&mut journal, "occ-doomed", "it-doomed");
+
+        // Crash the writer (drop = the OS frees its presence lock).
+        drop(writer);
+        resolve_lost_sessions(&handle, &mut journal, RecoveryScope::Boot(&survivor));
+        assert_eq!(
+            journal.progress("occ-doomed").terminal,
+            Some(OccurrenceState::Unknown),
+            "a provably dead writer's rows fail-close"
+        );
+    }
+
+    /// The Q3 recurring amendment: rows a pass spared (writer alive)
+    /// resolve on a LATER holder pass the moment the writer's boot lock
+    /// frees — no daemon restart required. Until resolved, a `started`
+    /// row holds its effect's no-overlap gate shut.
+    #[tokio::test]
+    async fn foreign_started_rows_resolve_without_restart_once_boot_lock_frees() {
+        let home = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        // The holder boots first; the foreign writer is a live secondary.
+        let holder = crate::handover::HandoverRuntime::initialize(home.path(), 7001, 0);
+        let foreign = crate::handover::HandoverRuntime::initialize(home.path(), 7002, 0);
+        assert!(holder.is_holder());
+        let (handle, _) = handle_with_item(dir.path(), now_ms() + 3_600_000);
+        let mut journal = OccurrenceJournal::open(handle.dir()).unwrap();
+        journal.set_stamp(Some(JournalStamp {
+            boot_id: foreign.boot_id().to_string(),
+            generation: None,
+        }));
+        stamped_started_rows(&mut journal, "occ-foreign", "it-foreign");
+        journal.set_stamp(None);
+
+        let mut state = SchedulerState::default();
+        run_pass(&handle, &mut journal, &mut state, Some(&holder)).await;
+        assert_eq!(
+            journal.progress("occ-foreign").terminal,
+            None,
+            "spared while the foreign writer lives"
+        );
+
+        // The foreign writer dies; the NEXT ordinary holder pass — not a
+        // restart — fail-closes its row.
+        drop(foreign);
+        run_pass(&handle, &mut journal, &mut state, Some(&holder)).await;
+        assert_eq!(
+            journal.progress("occ-foreign").terminal,
+            Some(OccurrenceState::Unknown),
+            "resolved by the recurring re-check once the boot lock freed"
+        );
     }
 }

--- a/src/bin/caller/github_pr/scanner.rs
+++ b/src/bin/caller/github_pr/scanner.rs
@@ -503,6 +503,7 @@ const MAX_BACKOFF_S: u64 = 60 * 60;
 pub(crate) fn spawn_scanner(
     agenda: std::sync::Arc<AgendaHandle>,
     settings_root: std::path::PathBuf,
+    handover: Option<std::sync::Arc<crate::handover::HandoverRuntime>>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let runtime = super::status::global();
@@ -517,6 +518,18 @@ pub(crate) fn spawn_scanner(
             }
         };
         loop {
+            // Track HS2 (intake Q9): the scanner is a standing automation
+            // — a daemon-attributed mirror writer on a poll loop — so it
+            // runs on the scheduler-lease holder only; two daemons
+            // scanning race anchor parks against slightly stale folds.
+            // Secondaries idle at the same recheck cadence as the
+            // keystore-free state and follow the lease as it moves.
+            if let Some(runtime) = &handover {
+                if !runtime.is_holder() {
+                    tokio::time::sleep(std::time::Duration::from_secs(IDLE_RECHECK_S)).await;
+                    continue;
+                }
+            }
             let config = crate::project::Project::from_root(settings_root.clone())
                 .map(|proj| proj.config.integrations.github.clone())
                 .unwrap_or_default();

--- a/src/bin/caller/handover/mod.rs
+++ b/src/bin/caller/handover/mod.rs
@@ -36,15 +36,18 @@ use std::path::{Path, PathBuf};
 pub(crate) struct HandoverRuntime {
     state_root: PathBuf,
     boot_id: String,
+    port: u16,
     /// The held lease. `None` = secondary (another daemon holds it) or
     /// lease infrastructure failure (`lease_error` says which). Std
-    /// mutex — never held across an await; HS2's poll-acquire and HS3's
-    /// drain release mutate the slot.
+    /// mutex — never held across an await; the poll-acquire lane and
+    /// HS3's drain release mutate the slot.
     lease: std::sync::Mutex<Option<SchedulerLease>>,
-    /// A real I/O or lock-infrastructure failure at the boot attempt
-    /// ("held elsewhere" is NOT an error). Status surfaces carry it so a
-    /// lockless filesystem degrades loudly, not silently.
-    lease_error: Option<String>,
+    /// The most recent real I/O or lock-infrastructure failure ("held
+    /// elsewhere" is NOT an error) — from the boot attempt or a later
+    /// poll. Status surfaces carry it so a lockless filesystem degrades
+    /// loudly, not silently; poll failures log only on message change so
+    /// a broken filesystem cannot spam one line per poll.
+    lease_error: std::sync::Mutex<Option<String>>,
     _presence: Option<DaemonPresence>,
     presence_error: Option<String>,
 }
@@ -99,8 +102,9 @@ impl HandoverRuntime {
         HandoverRuntime {
             state_root: state_root.to_path_buf(),
             boot_id,
+            port,
             lease: std::sync::Mutex::new(held),
-            lease_error,
+            lease_error: std::sync::Mutex::new(lease_error),
             _presence: presence,
             presence_error,
         }
@@ -110,12 +114,74 @@ impl HandoverRuntime {
         &self.boot_id
     }
 
+    pub(crate) fn state_root(&self) -> &Path {
+        &self.state_root
+    }
+
+    /// Does this daemon hold the active-scheduler lease right now?
+    /// Standing automations (the scheduler firing pass, reminder
+    /// delivery, the PR scanner) run iff this is true.
+    pub(crate) fn is_holder(&self) -> bool {
+        self.held_generation().is_some()
+    }
+
     /// The held lease's generation; `None` while running as secondary.
     pub(crate) fn held_generation(&self) -> Option<u64> {
         self.lease
             .lock()
             .ok()
             .and_then(|slot| slot.as_ref().map(SchedulerLease::generation))
+    }
+
+    /// Secondary lane: one non-blocking attempt on the (possibly freed)
+    /// lease. `true` = acquired on THIS call — the caller refreshes its
+    /// journal stamp and turns standing automations on. Already-holding
+    /// and still-held-elsewhere both return `false` without noise; real
+    /// lock-infrastructure errors record on the status surface and log
+    /// once per distinct message.
+    pub(crate) fn poll_acquire(&self, journal_generation_floor: u64) -> bool {
+        {
+            let Ok(slot) = self.lease.lock() else {
+                return false;
+            };
+            if slot.is_some() {
+                return false;
+            }
+        }
+        // The attempt runs without the slot lock held (file I/O); the
+        // scheduler is the only poll caller, so the slot cannot race.
+        match SchedulerLease::try_acquire(
+            &self.state_root,
+            &self.boot_id,
+            self.port,
+            journal_generation_floor,
+        ) {
+            Ok(LeaseAttempt::Held(lease)) => {
+                println!(
+                    "[handover] scheduler lease acquired (generation {}) — \
+                     standing automations on",
+                    lease.generation()
+                );
+                if let Ok(mut slot) = self.lease.lock() {
+                    *slot = Some(lease);
+                }
+                if let Ok(mut last) = self.lease_error.lock() {
+                    *last = None;
+                }
+                true
+            }
+            Ok(LeaseAttempt::HeldElsewhere(_)) => false,
+            Err(err) => {
+                let message = err.to_string();
+                if let Ok(mut last) = self.lease_error.lock() {
+                    if last.as_deref() != Some(message.as_str()) {
+                        eprintln!("[handover] scheduler lease poll failed: {message}");
+                        *last = Some(message);
+                    }
+                }
+                false
+            }
+        }
     }
 
     /// The `scheduler_lease` status block (`ctl status` / dashboard):
@@ -160,14 +226,34 @@ impl HandoverRuntime {
         if let Some(acquired_at_ms) = acquired_at_ms {
             obj.insert("acquired_at_ms".into(), acquired_at_ms.into());
         }
-        if let Some(err) = &self.lease_error {
-            obj.insert("error".into(), err.clone().into());
+        if let Ok(last) = self.lease_error.lock() {
+            if let Some(err) = last.as_ref() {
+                obj.insert("error".into(), err.clone().into());
+            }
         }
         if let Some(err) = &self.presence_error {
             obj.insert("presence_error".into(), err.clone().into());
         }
         block
     }
+}
+
+/// Secondary poll cadence for a freed lease (crash convergence: when the
+/// holder dies, the longest-standing daemon population converges on a new
+/// holder within one interval, no owner action). The scheduler bounds its
+/// idle sleep with this. `INTENDANT_LEASE_POLL_MS` overrides for rigs —
+/// a two-daemon e2e cannot wait a minute per takeover; read once at
+/// first use (a process-edge config read, like the memory kill switch).
+pub(crate) fn lease_poll_interval() -> std::time::Duration {
+    static INTERVAL: std::sync::OnceLock<std::time::Duration> = std::sync::OnceLock::new();
+    *INTERVAL.get_or_init(|| {
+        std::env::var("INTENDANT_LEASE_POLL_MS")
+            .ok()
+            .and_then(|raw| raw.parse::<u64>().ok())
+            .filter(|ms| *ms > 0)
+            .map(std::time::Duration::from_millis)
+            .unwrap_or(std::time::Duration::from_secs(60))
+    })
 }
 
 pub(crate) fn now_ms() -> u64 {
@@ -230,6 +316,28 @@ mod tests {
         // Both boots are live presences (the dual-run topology, visible).
         assert!(boot_id_is_live(dir.path(), holder.boot_id()));
         assert!(boot_id_is_live(dir.path(), secondary.boot_id()));
+    }
+
+    #[test]
+    fn poll_acquire_takes_a_freed_lease_and_noops_otherwise() {
+        let dir = tempfile::tempdir().unwrap();
+        let holder = HandoverRuntime::initialize(dir.path(), 8765, 0);
+        let secondary = HandoverRuntime::initialize(dir.path(), 8766, 0);
+        assert!(!secondary.poll_acquire(0), "held elsewhere: no acquisition");
+        assert!(!holder.poll_acquire(0), "already holding: no-op");
+        assert!(holder.is_holder());
+        assert!(!secondary.is_holder());
+
+        // Holder dies (drop = crash semantics): one poll converges.
+        drop(holder);
+        assert!(secondary.poll_acquire(5));
+        assert!(secondary.is_holder());
+        assert_eq!(
+            secondary.held_generation(),
+            Some(6),
+            "the journal floor rule applies on the poll lane too"
+        );
+        assert!(!secondary.poll_acquire(0), "already holding after the poll");
     }
 
     #[test]

--- a/src/bin/caller/startup/wiring.rs
+++ b/src/bin/caller/startup/wiring.rs
@@ -368,12 +368,17 @@ pub(crate) fn spawn_mode_web_gateway(
             // The GitHub PR scanner (Track PR): mirrors watched repos'
             // PRs as thin anchors under the PRs hub. Natural on/off —
             // it idles keystore-free until credentials are sealed and a
-            // watch list exists. Detaches on drop like its siblings.
+            // watch list exists; under the scheduler lease (Track HS2)
+            // it runs on the holder only. Detaches on drop like its
+            // siblings.
             let scanner_settings_root = project_root
                 .clone()
                 .unwrap_or_else(crate::project::daemon_settings_config_root);
-            let _pr_scanner =
-                crate::github_pr::scanner::spawn_scanner(handle.clone(), scanner_settings_root);
+            let _pr_scanner = crate::github_pr::scanner::spawn_scanner(
+                handle.clone(),
+                scanner_settings_root,
+                Some(handover.clone()),
+            );
             Some(handle)
         }
         Err(err) => {

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -6311,3 +6311,468 @@ async fn fresh_sessions_receive_zero_unrequested_memory() {
 
     daemon.child.kill().await.expect("stop the daemon");
 }
+
+// ---------------------------------------------------------------------------
+// Track HS2: the active-scheduler lease across two REAL co-homed daemons.
+// One state root (agenda, occurrence journal, lease, presence), two
+// controller processes on their own ports — the dual-run topology that used
+// to double-fire standing automations and clobber a live peer's in-flight
+// occurrences at boot.
+// ---------------------------------------------------------------------------
+
+/// A second daemon booted against ANOTHER rig's home. Kept separate from
+/// [`DaemonRig`] because the rig's tempdirs stay owned by the first
+/// daemon; the child still dies on drop (`kill_on_drop`).
+struct CoDaemon {
+    /// Held for `kill_on_drop` — dropping the rig kills the process.
+    _child: tokio::process::Child,
+    port: u16,
+}
+
+/// Boot a co-homed daemon on `rig` (same HOME, same mock script, own
+/// port), teeing its log to `<log_name>` so the port parse never reads
+/// the first daemon's line. `extra_env` carries per-test knobs
+/// (`INTENDANT_LEASE_POLL_MS` for takeover legs).
+async fn spawn_co_daemon(
+    client: &reqwest::Client,
+    rig: &TestRig,
+    log_name: &str,
+    extra_env: &[(&str, &str)],
+) -> CoDaemon {
+    let script_path = rig.home.path().join("mock_script.json");
+    let log_path = rig.home.path().join(log_name);
+    let log = std::fs::File::create(&log_path).expect("co-daemon log");
+    let mut cmd = rig.command();
+    cmd.env("INTENDANT_MOCK_SCRIPT", &script_path)
+        .stdout(log.try_clone().expect("clone co-daemon log"))
+        .stderr(log);
+    for (key, value) in extra_env {
+        cmd.env(key, value);
+    }
+    cmd.arg("--web").arg("0").args([
+        "--bind",
+        "127.0.0.1",
+        "--no-tui",
+        "--autonomy",
+        "full",
+        "--no-tls",
+    ]);
+    let mut child = cmd.spawn().expect("spawn co-homed intendant daemon");
+
+    let deadline = tokio::time::Instant::now() + DAEMON_START_TIMEOUT;
+    let port = loop {
+        let contents = std::fs::read_to_string(&log_path).unwrap_or_default();
+        if let Some(port) = dashboard_port(&contents) {
+            break port;
+        }
+        if let Ok(Some(status)) = child.try_wait() {
+            panic!(
+                "co-daemon exited during startup ({status}):\n{}",
+                tail(&contents, 4000)
+            );
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "co-daemon did not print its Dashboard startup line within \
+             {DAEMON_START_TIMEOUT:?}:\n{}",
+            tail(&contents, 4000)
+        );
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    };
+    let probe_url = format!("http://127.0.0.1:{port}/.well-known/agent-card.json");
+    loop {
+        if http_get_json(client, &probe_url).await.is_some() {
+            return CoDaemon {
+                _child: child,
+                port,
+            };
+        }
+        if let Ok(Some(status)) = child.try_wait() {
+            let contents = std::fs::read_to_string(&log_path).unwrap_or_default();
+            panic!(
+                "co-daemon on port {port} exited during startup ({status}):\n{}",
+                tail(&contents, 4000)
+            );
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "co-daemon on port {port} did not serve its agent card within \
+             {DAEMON_START_TIMEOUT:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+}
+
+fn now_epoch_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// The lease sidecar as it sits in the shared home (`None` until a holder
+/// writes it, or on a torn read — tolerant like every sidecar reader).
+fn lease_sidecar(rig: &TestRig) -> Option<serde_json::Value> {
+    let path = rig
+        .home
+        .path()
+        .join(".intendant")
+        .join("scheduler-lease")
+        .join("lease.json");
+    serde_json::from_slice(&std::fs::read(path).ok()?).ok()
+}
+
+/// The shared occurrence journal's parsed rows.
+fn journal_rows(rig: &TestRig) -> Vec<serde_json::Value> {
+    let path = rig
+        .home
+        .path()
+        .join(".intendant")
+        .join("agenda")
+        .join("occurrences.jsonl");
+    std::fs::read_to_string(path)
+        .unwrap_or_default()
+        .lines()
+        .filter_map(|line| serde_json::from_str(line).ok())
+        .collect()
+}
+
+/// The journal's state sequence for one item's occurrences. Recovery
+/// `unknown` rows carry an empty `item_id` (the journal row retains only
+/// the occurrence id), so membership is by the occurrence-id set the
+/// item's attributed rows establish — never by `item_id` alone.
+fn journal_states_for_item(rig: &TestRig, item_id: &str) -> Vec<String> {
+    let rows = journal_rows(rig);
+    let occurrence_ids: std::collections::HashSet<&str> = rows
+        .iter()
+        .filter(|row| row["item_id"] == item_id)
+        .filter_map(|row| row["occurrence_id"].as_str())
+        .collect();
+    rows.iter()
+        .filter(|row| {
+            row["occurrence_id"]
+                .as_str()
+                .is_some_and(|occ| occurrence_ids.contains(occ))
+        })
+        .filter_map(|row| row["state"].as_str().map(str::to_string))
+        .collect()
+}
+
+/// Schedule + approve a one-shot manifest on a fresh item through owner
+/// ctl against `port`, due at `fire_at_ms`. Returns the item id.
+async fn approve_manifest_at(rig: &TestRig, port: u16, fire_at_ms: u64, title: &str) -> String {
+    let added = ctl_on_rig(rig, port, &["--json", "agenda", "add", title, "--task"]).await;
+    assert!(added.status.success(), "{}", text_of(&added));
+    let item_id = stdout_json(&added)["item"]["id"]
+        .as_str()
+        .expect("minted item id")
+        .to_string();
+    let scheduled = ctl_on_rig(
+        rig,
+        port,
+        &[
+            "agenda",
+            "schedule",
+            &item_id[..10],
+            "--goal",
+            "handover rig follow-through",
+            "--at",
+            &fire_at_ms.to_string(),
+        ],
+    )
+    .await;
+    assert!(scheduled.status.success(), "{}", text_of(&scheduled));
+    // Review-then-bind: approval requires echoing the exact digest the
+    // proposal minted (digestless `approve` only prints the manifest).
+    let listed = ctl_on_rig(rig, port, &["--json", "agenda", "list", "--all"]).await;
+    assert!(listed.status.success(), "{}", text_of(&listed));
+    let listed_json = stdout_json(&listed);
+    let items = listed_json
+        .get("items")
+        .and_then(serde_json::Value::as_array)
+        .cloned()
+        .or_else(|| listed_json.as_array().cloned())
+        .expect("agenda list items");
+    let digest = items
+        .iter()
+        .find(|item| item["id"] == item_id.as_str())
+        .and_then(|item| item.pointer("/effects/0/digest"))
+        .and_then(serde_json::Value::as_str)
+        .expect("scheduled effect digest")
+        .to_string();
+    let approved = ctl_on_rig(
+        rig,
+        port,
+        &["agenda", "approve", &item_id[..10], "--digest", &digest],
+    )
+    .await;
+    assert!(approved.status.success(), "{}", text_of(&approved));
+    item_id
+}
+
+/// A mock script whose scheduled-session profile parks on `barrier` (the
+/// provider's race-free file barrier) before signalling done — the
+/// cross-platform way to hold an occurrence in `started` while the test
+/// acts. `None` = complete immediately.
+fn handover_script(barrier: Option<&std::path::Path>) -> serde_json::Value {
+    let mut steps = Vec::new();
+    if let Some(barrier) = barrier {
+        steps.push(serde_json::json!({
+            "content": "Working until released.",
+            "wait_for_file": barrier,
+        }));
+    }
+    steps.push(serde_json::json!({
+        "content": "All work finished.",
+        "tool_calls": [{ "name": "signal_done",
+                         "arguments": { "message": "handover fire complete" } }]
+    }));
+    serde_json::json!({
+        "profiles": [
+            { "match": "handover rig follow-through", "steps": steps },
+            { "steps": [
+                { "content": "fallback profile (unexpected session)",
+                  "tool_calls": [{ "name": "signal_done",
+                                   "arguments": { "message": "unexpected session" } }] }
+            ]}
+        ]
+    })
+}
+
+/// Intake §4 rig pin: a due, owner-approved manifest under TWO live
+/// co-homed daemons fires EXACTLY once, and every journal row is stamped
+/// by the lease holder's boot. The secondary is provably alive (it
+/// answers agenda ops) yet never plans.
+#[tokio::test]
+async fn due_manifest_fires_exactly_once_across_two_live_daemons() {
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("http client");
+    let daemon_a = spawn_daemon(&client, &handover_script(None)).await;
+    let daemon_b = spawn_co_daemon(&client, &daemon_a.rig, "daemon-b.log", &[]).await;
+
+    // A booted first: it holds the lease; B runs secondary.
+    let sidecar = lease_sidecar(&daemon_a.rig).expect("holder wrote the sidecar");
+    let holder_boot = sidecar["boot_id"].as_str().expect("boot id").to_string();
+
+    // The due manifest, minted through A; a nudge op through B proves B
+    // is live and writing the same ledger while never firing.
+    let fire_at = now_epoch_ms() + 4_000;
+    let item_id =
+        approve_manifest_at(&daemon_a.rig, daemon_a.port, fire_at, "exactly-once-item").await;
+    let nudge = ctl_on_rig(
+        &daemon_a.rig,
+        daemon_b.port,
+        &["agenda", "add", "secondary-is-alive-nudge", "--note"],
+    )
+    .await;
+    assert!(nudge.status.success(), "{}", text_of(&nudge));
+
+    // The outcome writes back through the standard lane on the holder.
+    let client_a = daemon_a.authed_client();
+    let port_a = daemon_a.port;
+    poll_until(
+        "the exactly-once outcome write-back",
+        RUN_TIMEOUT,
+        || async {
+            let agenda =
+                http_get_json(&client_a, &format!("http://127.0.0.1:{port_a}/api/agenda")).await?;
+            let item = agenda
+                .get("items")?
+                .as_array()?
+                .iter()
+                .find(|item| item["id"] == item_id.as_str())?
+                .clone();
+            (item.pointer("/effects/0/last_run/state")? == "completed").then_some(())
+        },
+        || {
+            format!(
+                "--- journal ---\n{:?}\n--- daemon A tail ---\n{}",
+                journal_rows(&daemon_a.rig),
+                daemon_a.log_tail()
+            )
+        },
+    )
+    .await;
+
+    // Exactly one prepared→started→completed arc, all rows stamped by
+    // the holder's boot — the secondary wrote nothing.
+    assert_eq!(
+        journal_states_for_item(&daemon_a.rig, &item_id),
+        vec!["prepared", "started", "completed"],
+        "one clean arc under two live daemons:\n{:?}",
+        journal_rows(&daemon_a.rig)
+    );
+    for row in journal_rows(&daemon_a.rig)
+        .iter()
+        .filter(|row| row["item_id"] == item_id.as_str())
+    {
+        assert_eq!(
+            row["boot_id"].as_str(),
+            Some(holder_boot.as_str()),
+            "every row stamped by the lease holder:\n{row}"
+        );
+    }
+    drop(daemon_b);
+}
+
+/// Intake §4 rig pin: kill -9 the holder → the secondary poll-acquires
+/// (generation bumps in the shared sidecar) and the dead generation's
+/// in-flight row fail-closes `unknown` without any daemon restart.
+#[tokio::test]
+async fn holder_crash_secondary_poll_acquires_and_resolves_dead_rows() {
+    let rig = TestRig::new();
+    // A barrier file the test never creates: the holder's fired session
+    // parks in `started` (the provider's bounded 30s barrier outlives
+    // the few seconds until the kill).
+    let barrier = rig.home.path().join("never-released");
+    let script = handover_script(Some(&barrier));
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("http client");
+    let mut daemon_a = spawn_daemon_on_rig(&client, rig, &script, false).await;
+    let daemon_b = spawn_co_daemon(
+        &client,
+        &daemon_a.rig,
+        "daemon-b.log",
+        &[("INTENDANT_LEASE_POLL_MS", "500")],
+    )
+    .await;
+    let first_generation = lease_sidecar(&daemon_a.rig).expect("holder sidecar")["generation"]
+        .as_u64()
+        .expect("generation");
+
+    // Fire the parked session on A and wait for its `started` row.
+    let item_id = approve_manifest_at(
+        &daemon_a.rig,
+        daemon_a.port,
+        now_epoch_ms() + 1_500,
+        "crash-recovery-item",
+    )
+    .await;
+    poll_until(
+        "the holder's in-flight started row",
+        RUN_TIMEOUT,
+        || async {
+            journal_states_for_item(&daemon_a.rig, &item_id)
+                .contains(&"started".to_string())
+                .then_some(())
+        },
+        || daemon_a.log_tail(),
+    )
+    .await;
+
+    // SIGKILL the holder: the OS frees its lease flock and presence lock.
+    daemon_a.child.start_kill().expect("kill -9 the holder");
+    let _ = daemon_a.child.wait().await;
+
+    // The secondary converges: fresh holder, bumped generation…
+    poll_until(
+        "the secondary's poll-acquire",
+        RUN_TIMEOUT,
+        || async {
+            let sidecar = lease_sidecar(&daemon_a.rig)?;
+            (sidecar["generation"].as_u64()? > first_generation).then_some(())
+        },
+        || format!("sidecar: {:?}", lease_sidecar(&daemon_a.rig)),
+    )
+    .await;
+    // …and the dead generation's row fail-closes without any restart.
+    poll_until(
+        "the dead holder's row resolving unknown",
+        RUN_TIMEOUT,
+        || async {
+            journal_states_for_item(&daemon_a.rig, &item_id)
+                .contains(&"unknown".to_string())
+                .then_some(())
+        },
+        || format!("journal: {:?}", journal_rows(&daemon_a.rig)),
+    )
+    .await;
+    drop(daemon_b);
+}
+
+/// THE §2.2 regression pin: a second daemon booting while the holder's
+/// scheduled session RUNS must spare the live row — the session then
+/// completes on the holder and its `completed` terminal stands; no
+/// `unknown` is ever written over it. (Pre-HS2, the booting daemon
+/// marked every started-without-terminal row unknown and polluted the
+/// item — the burn class that commissioned this track.)
+#[tokio::test]
+async fn handover_boot_spares_live_scheduled_session_and_completed_stands() {
+    let rig = TestRig::new();
+    let barrier = rig.home.path().join("release-the-session");
+    let script = handover_script(Some(&barrier));
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("http client");
+    let daemon_a = spawn_daemon_on_rig(&client, rig, &script, false).await;
+
+    // Fire on the holder and hold the session in-flight on the barrier.
+    let item_id = approve_manifest_at(
+        &daemon_a.rig,
+        daemon_a.port,
+        now_epoch_ms() + 1_500,
+        "spare-live-row-item",
+    )
+    .await;
+    poll_until(
+        "the in-flight started row",
+        RUN_TIMEOUT,
+        || async {
+            journal_states_for_item(&daemon_a.rig, &item_id)
+                .contains(&"started".to_string())
+                .then_some(())
+        },
+        || daemon_a.log_tail(),
+    )
+    .await;
+
+    // A second daemon boots MID-SESSION: its boot recovery runs against
+    // the shared journal and must spare the live generation's row.
+    let daemon_b = spawn_co_daemon(&client, &daemon_a.rig, "daemon-b.log", &[]).await;
+    assert!(
+        !journal_states_for_item(&daemon_a.rig, &item_id).contains(&"unknown".to_string()),
+        "the co-booting daemon must not clobber a live session's row:\n{:?}",
+        journal_rows(&daemon_a.rig)
+    );
+
+    // Release the barrier; the session completes ON THE HOLDER and the
+    // terminal stands.
+    std::fs::write(&barrier, b"go").expect("release the barrier");
+    let client_a = daemon_a.authed_client();
+    let port_a = daemon_a.port;
+    poll_until(
+        "the spared session's completed write-back",
+        RUN_TIMEOUT,
+        || async {
+            let agenda =
+                http_get_json(&client_a, &format!("http://127.0.0.1:{port_a}/api/agenda")).await?;
+            let item = agenda
+                .get("items")?
+                .as_array()?
+                .iter()
+                .find(|item| item["id"] == item_id.as_str())?
+                .clone();
+            (item.pointer("/effects/0/last_run/state")? == "completed").then_some(())
+        },
+        || {
+            format!(
+                "--- journal ---\n{:?}\n--- A tail ---\n{}",
+                journal_rows(&daemon_a.rig),
+                daemon_a.log_tail()
+            )
+        },
+    )
+    .await;
+    assert_eq!(
+        journal_states_for_item(&daemon_a.rig, &item_id),
+        vec!["prepared", "started", "completed"],
+        "the completed terminal stands; no unknown was ever written:\n{:?}",
+        journal_rows(&daemon_a.rig)
+    );
+    drop(daemon_b);
+}


### PR DESCRIPTION
Track HS slice 2 of 6 (sealed intake `daemon-handover-intake.md` §5; HS1 pass recorded in `~/daemon-handover-rulings.md`). **The value slice**: closes the live co-homed double-fire window and fixes the intake's one BROKEN edge.

## What lands

- **Holder-only firing**: `run_pass` gates on the scheduler lease before the planner ever runs. Secondaries plan/fire/deliver nothing and wake at the lease poll cadence (`INTENDANT_LEASE_POLL_MS` rig knob; 60s default). A freed lease **poll-acquires** — after a holder crash the daemon population converges on a new holder within one interval, generation bumped, journal stamp refreshed (floor from the live journal's `max_generation`, per the HS1 ruling note — no re-fold).
- **Scoped boot recovery** (intake §3.5 + the Q3 amendment): the fold retains each occurrence's stamped writer `boot_id` (last non-terminal row wins; a stampless mixed-version row downgrades to legacy semantics — fail-closed). Recovery fail-closes only rows whose writer is **provably dead** (its `daemons/<boot_id>.lock` is takeable) or legacy rows at boot. The **recurring** re-check runs the same scoped resolve on every holder pass, so a writer dying mid-run resolves without any daemon restart (an unresolved `started` row otherwise holds its effect's no-overlap gate shut forever).
- **PR scanner under the lease** (Q9 holder-only set): idles on secondaries, follows the lease as it moves.
- **Docs codified**: the old honest "narrow double-delivery window" texts (reminders.rs module doc, `agenda-and-memory.md`) now describe the lease.

## Conformance (intake checklist, names verbatim, all green)

Unit: `double_fire_demonstrated_without_lease_and_closed_with_it` (plan-level interleave demonstrates the check-then-prepared window — two started sessions on one occurrence — then the same due state under the lease yields exactly one prepared row and one dispatch), `non_holder_pass_plans_nothing`, `boot_recovery_spares_live_generation_rows`, `dead_generation_rows_resolve_unknown`, `foreign_started_rows_resolve_without_restart_once_boot_lock_frees`.

Rig (two REAL co-homed daemons, one state root, mock provider): `due_manifest_fires_exactly_once_across_two_live_daemons` (every journal row stamped by the holder's boot; the secondary answers agenda ops yet never fires), `holder_crash_secondary_poll_acquires_and_resolves_dead_rows` (SIGKILL → generation bump ~0.5s + dead rows unknown, no restart), `handover_boot_spares_live_scheduled_session_and_completed_stands` (**THE §2.2 regression pin** — the burn class that commissioned the track). Session barriers use the mock provider's `wait_for_file` — cross-platform, no shell loops.

Battery: fmt + workspace clippy `-D warnings` + 5342 bin tests + lib crates + 36 e2e, all green.

Known adjacency: #635 also edits `docs/src/agenda-and-memory.md` (different section) — whichever lands second reconciles mechanically (coordinated on the bus).