### PR TITLE
feat(dashboard): operational-envelope extension — agenda linkage, sealed inputs, boot era on session windows

### DIFF
--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -294,6 +294,30 @@ cache, never after the fact. Sections appear as producers fill them; the
 chip hides in narrow windows. Station's agent focus panel shows the same
 vitals as git / cache / limits rows.
 
+The operational envelope extends with **grid-envelope chips**, served
+precomputed on the session-catalog row (`agenda` + `boot` blocks,
+`session_catalog/grid_envelope.rs` — one daemon payload, no SPA-side
+joins). Agenda-fired sessions show their **source item** (`⚡` + the
+item id's first 12 chars; hover reveals the full title, tap offers
+"Open the agenda card" and copy), the **occurrence** (`▶ started` /
+`✓ completed` / `✕ failed`… — the occurrence journal's reverse fold,
+lineage-following: a resume re-key's successors share the block, and
+the occurrence object is the extensible slot Track AO's attestation
+will land in), and the **sealed inputs** (`⛉ N sealed`; the explainer
+lists each digest-bound binding ref with its short digest via the one
+shared formatter, and per-ref actions copy the full sha256). Every
+window also states its **boot era** — `↻ this boot` vs `↻ pre-boot`,
+from HS1's presence substrate joined with live wrapper registry
+membership — and a session that predates the current daemon boot with
+no live wrapper renders unmistakably as a **ghost** (`👻` warn chip +
+dashed desaturated frame): the safe-to-close state, served as a
+precomputed bit. Fired sessions keep their derived names (the source
+item's title, or `workflow - node` for workflow nodes); an owner
+rename always wins, and the Track AW refinement — stamped definitions
+deriving `definition name - node id` — lands later at the same single
+derivation seam (`agenda/reminders.rs`, `derive_spawn_session_name`)
+without touching these chips.
+
 When a backend announces background commands (currently Claude Code's
 wire-reported task registry), the activity explainer inside that vitals panel
 adds a **Background tasks** list. A task with an announced output file gets a

--- a/src/bin/caller/agenda/handle.rs
+++ b/src/bin/caller/agenda/handle.rs
@@ -731,9 +731,10 @@ impl AgendaHandle {
                     let sealed_inputs = item
                         .and_then(|item| {
                             item.effects.iter().find(|effect| {
-                                effect.last_run.as_ref().is_some_and(|run| {
-                                    run.occurrence_id == link.occurrence_id
-                                })
+                                effect
+                                    .last_run
+                                    .as_ref()
+                                    .is_some_and(|run| run.occurrence_id == link.occurrence_id)
                             })
                         })
                         .map(|effect| effect.manifest.binding_refs.clone())
@@ -897,7 +898,9 @@ mod tests {
 
         let envelopes = handle.session_agenda_envelopes().unwrap();
         for lineage_member in ["sess-fired", "sess-successor"] {
-            let envelope = envelopes.get(lineage_member).expect("lineage member enveloped");
+            let envelope = envelopes
+                .get(lineage_member)
+                .expect("lineage member enveloped");
             assert_eq!(envelope.item_id, item.id);
             assert_eq!(envelope.item_title.as_deref(), Some("envelope source"));
             assert_eq!(envelope.occurrence_id, occ);
@@ -911,7 +914,10 @@ mod tests {
         }
         let orphan = envelopes.get("sess-orphan").expect("orphan linked");
         assert_eq!(orphan.item_id, "01GONE");
-        assert_eq!(orphan.item_title, None, "a deleted item degrades to id-only");
+        assert_eq!(
+            orphan.item_title, None,
+            "a deleted item degrades to id-only"
+        );
         assert!(orphan.sealed_inputs.is_empty());
     }
 

--- a/src/bin/caller/agenda/handle.rs
+++ b/src/bin/caller/agenda/handle.rs
@@ -9,7 +9,7 @@
 //! request/response surfaces already provide.
 
 use super::reminders::{
-    OccurrenceJournal, ReminderPolicy, ReminderPolicyPatch, ReminderPolicyStore,
+    OccurrenceJournal, OccurrenceState, ReminderPolicy, ReminderPolicyPatch, ReminderPolicyStore,
 };
 use super::spawn_project::{resolve_spawn_project, SessionSpawnContext};
 use super::store::{AgendaError, AgendaStore, OccurrenceWriteBack};
@@ -692,6 +692,79 @@ impl AgendaHandle {
                 ))
             })
     }
+
+    /// Per-session source linkage for the session catalog's grid
+    /// envelope, composed here so the catalog never touches the store:
+    /// the journal's reverse fold names the occurrence and owning item
+    /// (every resume-lineage member resolves to the same occurrence,
+    /// whose current state speaks for the lineage), and the item store
+    /// contributes the title plus the digest-bound sealed inputs of the
+    /// effect whose `last_run` recorded that occurrence.
+    /// Derive-don't-mirror: computed per read, nothing persisted. A
+    /// deleted item degrades to the id-only block; an effect
+    /// re-proposed since the fire loses its ref match (`last_run` is
+    /// the durable occurrence↔effect link, and the manifest is the only
+    /// record of the refs). `None` when the journal cannot be opened.
+    /// Journal mutex and store lock are taken sequentially, never
+    /// nested — the [`Self::decorate_items`] discipline.
+    pub(crate) fn session_agenda_envelopes(
+        &self,
+    ) -> Option<std::collections::HashMap<String, SessionAgendaEnvelope>> {
+        let links = self.with_journal(|journal| {
+            if let Err(err) = journal.refresh_if_stale() {
+                eprintln!("[agenda] journal refresh for session links failed: {err}");
+            }
+            journal.session_links()
+        })?;
+        let mut items: std::collections::HashMap<String, Option<AgendaItem>> =
+            std::collections::HashMap::new();
+        for link in links.values() {
+            if !items.contains_key(&link.item_id) {
+                items.insert(link.item_id.clone(), self.item_by_id(&link.item_id));
+            }
+        }
+        Some(
+            links
+                .into_iter()
+                .map(|(session_id, link)| {
+                    let item = items.get(&link.item_id).and_then(|item| item.as_ref());
+                    let sealed_inputs = item
+                        .and_then(|item| {
+                            item.effects.iter().find(|effect| {
+                                effect.last_run.as_ref().is_some_and(|run| {
+                                    run.occurrence_id == link.occurrence_id
+                                })
+                            })
+                        })
+                        .map(|effect| effect.manifest.binding_refs.clone())
+                        .unwrap_or_default();
+                    let envelope = SessionAgendaEnvelope {
+                        item_id: link.item_id,
+                        item_title: item.map(|item| item.title.clone()),
+                        occurrence_id: link.occurrence_id,
+                        occurrence_state: link.state,
+                        sealed_inputs,
+                    };
+                    (session_id, envelope)
+                })
+                .collect(),
+        )
+    }
+}
+
+/// One fired session's derived source linkage — the grid envelope's
+/// agenda block ([`AgendaHandle::session_agenda_envelopes`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SessionAgendaEnvelope {
+    pub(crate) item_id: String,
+    /// `None` when the item no longer exists (the linkage outlives it).
+    pub(crate) item_title: Option<String>,
+    pub(crate) occurrence_id: String,
+    pub(crate) occurrence_state: OccurrenceState,
+    /// The digest-bound binding refs of the manifest that ran this
+    /// occurrence; empty when unmatched (item gone, or re-proposed
+    /// since the fire).
+    pub(crate) sealed_inputs: Vec<super::types::BindingRef>,
 }
 
 fn now_ms() -> u64 {
@@ -713,8 +786,134 @@ fn truncate(text: &str, max_chars: usize) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::super::types::AgendaKind;
+    use super::super::types::{AgendaKind, BindingRef};
     use super::*;
+
+    /// The grid-envelope composition: a fired session resolves to its
+    /// source item, occurrence state, title, and the sealed inputs of
+    /// the manifest that ran it; every resume-lineage member shares the
+    /// block; linkage outliving its item degrades to the id-only shape.
+    #[test]
+    fn session_agenda_envelopes_compose_journal_store_and_refs() {
+        let dir = tempfile::tempdir().unwrap();
+        let bus = EventBus::new();
+        let handle = AgendaHandle::new(AgendaStore::open(dir.path()).unwrap(), bus, dir.path());
+
+        // A sealed input the proposer really read (intake re-hashes it).
+        let sealed_src = dir.path().join("inputs.md");
+        std::fs::write(&sealed_src, b"binding ref bytes").unwrap();
+        let sha256 = super::super::store::digest_file(&sealed_src).unwrap();
+
+        let owner = Some(AgendaActor {
+            principal: Some("principal:root:dashboard".into()),
+            session_id: None,
+            kind: Some("dashboard".into()),
+        });
+        let item = handle
+            .apply(
+                AgendaCommand::Add {
+                    refs: Vec::new(),
+                    kind: AgendaKind::Task,
+                    title: "envelope source".into(),
+                    body: String::new(),
+                    tags: Vec::new(),
+                    due_ms: None,
+                    source: None,
+                },
+                owner.clone(),
+            )
+            .unwrap();
+        let proposed = handle
+            .apply(
+                AgendaCommand::ProposeEffect {
+                    id: item.id.clone(),
+                    goal: "run it".into(),
+                    fire_at_ms: 1_000,
+                    orchestrate: false,
+                    recurrence: None,
+                    agent_config: None,
+                    trigger: None,
+                    project_root: None,
+                    binding_refs: vec![BindingRef {
+                        locator: format!("file:{}", sealed_src.display()),
+                        sha256: sha256.clone(),
+                    }],
+                    source: None,
+                },
+                owner.clone(),
+            )
+            .unwrap();
+        let effect_id = proposed.effects[0].effect_id.clone();
+        let digest = proposed.effects[0].digest.clone();
+        handle
+            .apply(
+                AgendaCommand::ApproveEffect {
+                    id: item.id.clone(),
+                    digest,
+                },
+                owner,
+            )
+            .unwrap();
+
+        // The scheduler's post-dispatch write-back: `last_run` is the
+        // durable occurrence↔effect link.
+        let occ = "occ-under-test";
+        handle
+            .record_occurrence(OccurrenceWriteBack {
+                item_id: &item.id,
+                effect_id: &effect_id,
+                occurrence_id: occ,
+                state: "started",
+                session_id: Some("sess-fired".into()),
+                note: None,
+            })
+            .unwrap();
+        // Journal rows: the fired session, then its resume-lineage
+        // successor, plus an occurrence whose item is gone.
+        {
+            let mut journal = OccurrenceJournal::open(dir.path()).unwrap();
+            let row = |occurrence: &str, item_id: &str, session: &str| {
+                super::super::reminders::OccurrenceRecord {
+                    v: 1,
+                    at_ms: 1,
+                    occurrence_id: occurrence.to_string(),
+                    item_id: item_id.to_string(),
+                    due_ms: 1_000,
+                    state: OccurrenceState::Started,
+                    urgency: None,
+                    session_id: Some(session.to_string()),
+                    generation: None,
+                    boot_id: None,
+                }
+            };
+            journal.append(&row(occ, &item.id, "sess-fired")).unwrap();
+            journal
+                .append(&row(occ, &item.id, "sess-successor"))
+                .unwrap();
+            journal
+                .append(&row("occ-orphaned", "01GONE", "sess-orphan"))
+                .unwrap();
+        }
+
+        let envelopes = handle.session_agenda_envelopes().unwrap();
+        for lineage_member in ["sess-fired", "sess-successor"] {
+            let envelope = envelopes.get(lineage_member).expect("lineage member enveloped");
+            assert_eq!(envelope.item_id, item.id);
+            assert_eq!(envelope.item_title.as_deref(), Some("envelope source"));
+            assert_eq!(envelope.occurrence_id, occ);
+            assert_eq!(envelope.occurrence_state, OccurrenceState::Started);
+            assert_eq!(
+                envelope.sealed_inputs.len(),
+                1,
+                "the fired manifest's binding refs ride the envelope"
+            );
+            assert_eq!(envelope.sealed_inputs[0].sha256, sha256);
+        }
+        let orphan = envelopes.get("sess-orphan").expect("orphan linked");
+        assert_eq!(orphan.item_id, "01GONE");
+        assert_eq!(orphan.item_title, None, "a deleted item degrades to id-only");
+        assert!(orphan.sealed_inputs.is_empty());
+    }
 
     #[test]
     fn apply_broadcasts_agenda_changed() {

--- a/src/bin/caller/agenda/mod.rs
+++ b/src/bin/caller/agenda/mod.rs
@@ -44,7 +44,7 @@ mod types;
 pub(crate) use ask::{agenda_ask_pending, ask_outcome_delivery_text, spawn_ask_resolver};
 pub(crate) use blobs::find_blob;
 pub(crate) use definitions::materialize_house_definitions;
-pub(crate) use handle::AgendaHandle;
+pub(crate) use handle::{AgendaHandle, SessionAgendaEnvelope};
 pub(crate) use reminders::{
     journal_generation_floor, AgendaOccurrencesPage, ReminderPolicyPatch,
     AGENDA_OCCURRENCES_DEFAULT_LIMIT,
@@ -59,9 +59,12 @@ pub(crate) use types::{
     AgendaRefType, AgendaStatus,
 };
 // Test-support seam: cross-module tests (supervisor delivery, blocking
-// waiter) drive real handle-side resolutions with structured content.
+// waiter, the grid-envelope attach) drive real handle-side resolutions
+// with structured content.
 #[cfg(test)]
 pub(crate) use ask::resolution_from_wire;
+#[cfg(test)]
+pub(crate) use reminders::OccurrenceState;
 #[cfg(test)]
 pub(crate) use types::AgendaAskResolution;
 
@@ -78,4 +81,20 @@ pub(crate) fn agenda_dir_in(state_root: &Path) -> PathBuf {
 /// under [`AgendaStore`] takes explicit paths.
 pub(crate) fn agenda_dir() -> PathBuf {
     agenda_dir_in(&intendant_core::state_paths::intendant_home())
+}
+
+/// The daemon's published agenda handle — the read-side seam for lanes
+/// outside the state graph (the session catalog's grid-envelope join),
+/// mirroring `session_supervisor::publish_live_session_registry`. Set once
+/// at the wiring edge; tests construct their own handles and never publish.
+static PUBLISHED_AGENDA_HANDLE: std::sync::OnceLock<std::sync::Arc<AgendaHandle>> =
+    std::sync::OnceLock::new();
+
+pub(crate) fn publish_agenda_handle(handle: std::sync::Arc<AgendaHandle>) {
+    let _ = PUBLISHED_AGENDA_HANDLE.set(handle);
+}
+
+/// The published agenda handle, when a startup path wired one.
+pub(crate) fn published_agenda_handle() -> Option<std::sync::Arc<AgendaHandle>> {
+    PUBLISHED_AGENDA_HANDLE.get().cloned()
 }

--- a/src/bin/caller/agenda/reminders.rs
+++ b/src/bin/caller/agenda/reminders.rs
@@ -369,6 +369,20 @@ pub(crate) struct OccurrenceProgress {
     pub(crate) item_id: Option<String>,
 }
 
+/// One session's journal-derived source linkage — the grid envelope's
+/// agenda block ([`OccurrenceJournal::session_links`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SessionOccurrenceLink {
+    pub(crate) occurrence_id: String,
+    pub(crate) item_id: String,
+    /// `Started` until a terminal row lands, then that terminal. The
+    /// occurrence's state speaks for every lineage member: a resume
+    /// re-key appends the successor's `started` row without
+    /// un-attributing the original, and the one terminal that follows
+    /// the lineage tip resolves the whole occurrence.
+    pub(crate) state: OccurrenceState,
+}
+
 /// The append-only delivery ledger. `prepare` records are fsync'd — the
 /// brief's "journal fsync'd before delivery" is load-bearing for the
 /// at-least-once contract.
@@ -450,6 +464,40 @@ impl OccurrenceJournal {
             .filter(|progress| progress.item_id.as_deref() == Some(item_id))
             .flat_map(|progress| progress.started_history.iter().cloned())
             .collect()
+    }
+
+    /// Reverse fold for the session catalog's grid envelope: every
+    /// session id any `started` row ever named → its occurrence, owning
+    /// item, and the occurrence's current state. The whole resume
+    /// lineage maps to one occurrence (see
+    /// [`Self::started_sessions_for_item`] on why history, not tip).
+    /// Rows that never retained an item id (boot-recovery unknowns) are
+    /// unattributable and skipped.
+    pub(crate) fn session_links(
+        &self,
+    ) -> std::collections::HashMap<String, SessionOccurrenceLink> {
+        let mut links = std::collections::HashMap::new();
+        for (occurrence_id, progress) in &self.state {
+            let Some(item_id) = progress
+                .item_id
+                .as_deref()
+                .filter(|item_id| !item_id.is_empty())
+            else {
+                continue;
+            };
+            let state = progress.terminal.unwrap_or(OccurrenceState::Started);
+            for session_id in &progress.started_history {
+                links.insert(
+                    session_id.clone(),
+                    SessionOccurrenceLink {
+                        occurrence_id: occurrence_id.clone(),
+                        item_id: item_id.to_string(),
+                        state,
+                    },
+                );
+            }
+        }
+        links
     }
 
     /// True while any session occurrence of this item is `started` with no
@@ -1606,6 +1654,72 @@ mod tests {
         );
         assert!(again.deliver.is_empty());
         assert_eq!(again.next_wake_ms, Some(5_000));
+    }
+
+    /// The grid envelope's reverse fold: every lineage member maps to
+    /// its occurrence, the occurrence's terminal speaks for the whole
+    /// lineage, and rows that never retained an item id stay
+    /// unattributable.
+    #[test]
+    fn session_links_follow_lineage_and_terminals() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut journal = OccurrenceJournal::open(dir.path()).unwrap();
+        let row = |occ: &str, item: &str, state: OccurrenceState, session: Option<&str>| {
+            OccurrenceRecord {
+                v: 1,
+                at_ms: 1_000,
+                occurrence_id: occ.to_string(),
+                item_id: item.to_string(),
+                due_ms: 1_000,
+                state,
+                urgency: None,
+                session_id: session.map(str::to_string),
+                generation: None,
+                boot_id: None,
+            }
+        };
+        // occ-1: started by s1, re-keyed to successor s2, then completed.
+        journal
+            .append(&row("occ-1", "item-a", OccurrenceState::Started, Some("s1")))
+            .unwrap();
+        journal
+            .append(&row("occ-1", "item-a", OccurrenceState::Started, Some("s2")))
+            .unwrap();
+        journal
+            .append(&row(
+                "occ-1",
+                "item-a",
+                OccurrenceState::Completed,
+                Some("s2"),
+            ))
+            .unwrap();
+        // occ-2: still running.
+        journal
+            .append(&row("occ-2", "item-b", OccurrenceState::Started, Some("s3")))
+            .unwrap();
+        // occ-3: boot-recovery shape — no item id retained.
+        journal
+            .append(&row("occ-3", "", OccurrenceState::Started, Some("s4")))
+            .unwrap();
+
+        let links = journal.session_links();
+        for lineage_member in ["s1", "s2"] {
+            let link = links.get(lineage_member).expect("lineage member linked");
+            assert_eq!(link.occurrence_id, "occ-1");
+            assert_eq!(link.item_id, "item-a");
+            assert_eq!(
+                link.state,
+                OccurrenceState::Completed,
+                "the terminal follows the whole lineage"
+            );
+        }
+        let running = links.get("s3").expect("running session linked");
+        assert_eq!(running.item_id, "item-b");
+        assert_eq!(running.state, OccurrenceState::Started);
+        assert!(
+            !links.contains_key("s4"),
+            "itemless boot-recovery rows stay unattributable"
+        );
     }
 
     /// The A3 restart contract: a terminal record survives reopen (never

--- a/src/bin/caller/agenda/reminders.rs
+++ b/src/bin/caller/agenda/reminders.rs
@@ -473,9 +473,7 @@ impl OccurrenceJournal {
     /// [`Self::started_sessions_for_item`] on why history, not tip).
     /// Rows that never retained an item id (boot-recovery unknowns) are
     /// unattributable and skipped.
-    pub(crate) fn session_links(
-        &self,
-    ) -> std::collections::HashMap<String, SessionOccurrenceLink> {
+    pub(crate) fn session_links(&self) -> std::collections::HashMap<String, SessionOccurrenceLink> {
         let mut links = std::collections::HashMap::new();
         for (occurrence_id, progress) in &self.state {
             let Some(item_id) = progress
@@ -1680,10 +1678,20 @@ mod tests {
         };
         // occ-1: started by s1, re-keyed to successor s2, then completed.
         journal
-            .append(&row("occ-1", "item-a", OccurrenceState::Started, Some("s1")))
+            .append(&row(
+                "occ-1",
+                "item-a",
+                OccurrenceState::Started,
+                Some("s1"),
+            ))
             .unwrap();
         journal
-            .append(&row("occ-1", "item-a", OccurrenceState::Started, Some("s2")))
+            .append(&row(
+                "occ-1",
+                "item-a",
+                OccurrenceState::Started,
+                Some("s2"),
+            ))
             .unwrap();
         journal
             .append(&row(
@@ -1695,7 +1703,12 @@ mod tests {
             .unwrap();
         // occ-2: still running.
         journal
-            .append(&row("occ-2", "item-b", OccurrenceState::Started, Some("s3")))
+            .append(&row(
+                "occ-2",
+                "item-b",
+                OccurrenceState::Started,
+                Some("s3"),
+            ))
             .unwrap();
         // occ-3: boot-recovery shape — no item id retained.
         journal

--- a/src/bin/caller/session_supervisor/mod.rs
+++ b/src/bin/caller/session_supervisor/mod.rs
@@ -385,6 +385,30 @@ impl LiveSessionRegistry {
         rows.sort_by(|a, b| a.session_id.cmp(&b.session_id));
         rows
     }
+
+    /// Wrapper-liveness snapshot for the session catalog's boot-era
+    /// join: session ids whose registry entry still holds an open
+    /// follow-up channel — the `live_external_wrapper_for` doctrine
+    /// (`launch.rs`): membership plus the open channel is "this daemon
+    /// still drives it", never phase. Non-blocking because the catalog
+    /// build runs on blocking-pool threads and inside async handlers
+    /// alike: lock contention yields `None` and the caller omits the
+    /// join rather than serve a wrong liveness bit; a gone supervisor
+    /// truthfully reports no live sessions.
+    pub(crate) fn live_wrapper_ids(&self) -> Option<std::collections::HashSet<String>> {
+        let Some(state) = self.state.upgrade() else {
+            return Some(std::collections::HashSet::new());
+        };
+        let guard = state.try_lock().ok()?;
+        Some(
+            guard
+                .sessions
+                .values()
+                .filter(|session| !session.follow_up_tx.is_closed())
+                .map(|session| session.session_id.clone())
+                .collect(),
+        )
+    }
 }
 
 static PUBLISHED_LIVE_SESSION_REGISTRY: std::sync::OnceLock<LiveSessionRegistry> =

--- a/src/bin/caller/session_vitals.rs
+++ b/src/bin/caller/session_vitals.rs
@@ -3603,6 +3603,12 @@ mod tests {
             "'cache-hit':",
             "'cache-ttl':",
             "limit:",
+            // Grid-envelope symbols (catalog-row `agenda` + `boot`
+            // blocks — grid_envelope.rs pins their wire fields).
+            "'agenda-source':",
+            "'agenda-occurrence':",
+            "'sealed-inputs':",
+            "boot:",
         ] {
             assert!(catalog.contains(key), "catalog lost symbol {key}");
         }

--- a/src/bin/caller/startup/wiring.rs
+++ b/src/bin/caller/startup/wiring.rs
@@ -358,6 +358,9 @@ pub(crate) fn spawn_mode_web_gateway(
                         default_project_root: project_root.clone(),
                     }),
             );
+            // Read-side seam for lanes outside the state graph (the
+            // session catalog's grid-envelope join).
+            crate::agenda::publish_agenda_handle(handle.clone());
             // Detaches on drop like the mode listeners; one per daemon.
             let _scheduler =
                 crate::agenda::spawn_reminder_scheduler(handle.clone(), Some(handover.clone()));

--- a/src/bin/caller/web_gateway/session_catalog/external_rows.rs
+++ b/src/bin/caller/web_gateway/session_catalog/external_rows.rs
@@ -213,6 +213,11 @@ pub(crate) fn merge_intendant_wrapper_into_external_session(
         ("pi_model", "pi_model"),
         ("pi_thinking", "pi_thinking"),
         ("pi_allowed_tools", "pi_allowed_tools"),
+        // The grid envelope's serve-time blocks (agenda linkage + boot
+        // era) ride the wrapper row and must survive the collapse into
+        // the backend's native row.
+        ("agenda", "agenda"),
+        ("boot", "boot"),
     ] {
         if let Some(value) = wrapper_obj.get(wrapper_key) {
             obj.insert(target_key.to_string(), value.clone());

--- a/src/bin/caller/web_gateway/session_catalog/grid_envelope.rs
+++ b/src/bin/caller/web_gateway/session_catalog/grid_envelope.rs
@@ -272,4 +272,40 @@ mod tests {
         joins(None, None, Some(HashMap::new())).attach(&mut row, "s2", &dir);
         assert!(row.get("agenda").is_none());
     }
+
+    /// Daemon↔SPA drift guard for the envelope blocks: the session
+    /// windows fragment consumes exactly these wire names, renders the
+    /// ghost class, and its sealed-inputs chip shares the one
+    /// short-digest formatter instead of minting a truncation.
+    #[test]
+    fn grid_envelope_wire_reaches_the_fragment() {
+        let fragment = include_str!("../../../../../static/app/39-session-windows.js");
+        for needle in [
+            "item_id",
+            "item_title",
+            "occurrence",
+            "sealed_inputs",
+            "live_wrapper",
+            "ghost",
+            "preboot",
+            "agendaShortDigest(",
+        ] {
+            assert!(
+                fragment.contains(needle),
+                "session-windows fragment stopped consuming {needle} — the grid envelope drifted"
+            );
+        }
+        // The window-level ghost treatment lives in the actions fragment
+        // (class toggle) and the stylesheet (the dashed-frame rule).
+        let actions = include_str!("../../../../../static/app/41-session-window-actions.js");
+        assert!(
+            actions.contains("session-window-ghost"),
+            "the actions fragment stopped toggling the ghost window class"
+        );
+        let styles = include_str!("../../../../../static/app/12-styles-tasks-log.css");
+        assert!(
+            styles.contains(".session-window.session-window-ghost"),
+            "the stylesheet lost the ghost window treatment"
+        );
+    }
 }

--- a/src/bin/caller/web_gateway/session_catalog/grid_envelope.rs
+++ b/src/bin/caller/web_gateway/session_catalog/grid_envelope.rs
@@ -1,0 +1,275 @@
+//! The grid session window's operational-envelope extension: derived
+//! agenda linkage (source item / occurrence / sealed inputs) and boot
+//! era, attached to intendant catalog rows at serve time.
+//!
+//! Derive-don't-mirror: nothing here is persisted or event-plumbed — the
+//! agenda block is [`crate::agenda::AgendaHandle::session_agenda_envelopes`]
+//! (journal reverse fold joined with the item store at read time), and
+//! the boot block joins HS1's presence substrate (`crate::handover`)
+//! with live wrapper registry membership
+//! ([`crate::session_supervisor::LiveSessionRegistry::live_wrapper_ids`]).
+//! Both blocks attach POST row-cache: `intendant_session_list_row_from_dir`
+//! is fingerprint-cached on session-dir state, and every input here moves
+//! without touching session dirs (a daemon restart, a wrapper's death, a
+//! journal terminal), so the two list entry paths attach per build
+//! instead of baking the blocks into cached rows.
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+/// This process's boot, per its own HS1 presence record.
+pub(crate) struct CurrentBoot {
+    /// Presence-registration instant — the era watershed.
+    pub(crate) start_secs: u64,
+}
+
+/// Our own presence record → boot start. `None` when this daemon runs
+/// without presence (registration failed, exotic shapes, pre-HS1 state
+/// roots) — the boot block is then omitted rather than guessed. Own =
+/// the record naming this pid; freshest wins if debris left more.
+pub(crate) fn resolve_current_boot(state_root: &Path) -> Option<CurrentBoot> {
+    let pid = std::process::id();
+    crate::handover::read_presence_records(state_root)
+        .into_iter()
+        .filter(|record| record.pid == pid)
+        .max_by_key(|record| record.updated_ms)
+        .map(|record| CurrentBoot {
+            start_secs: record.updated_ms / 1000,
+        })
+}
+
+/// The serve-time join set for one catalog build, resolved once at the
+/// listing edge and applied per intendant row.
+pub(crate) struct GridEnvelopeJoins {
+    boot: Option<CurrentBoot>,
+    /// `None` = unknown (registry unpublished, or its lock was
+    /// contended this instant) — the boot block is omitted rather than
+    /// computed from a guess.
+    live_wrappers: Option<HashSet<String>>,
+    agenda: Option<HashMap<String, crate::agenda::SessionAgendaEnvelope>>,
+}
+
+impl GridEnvelopeJoins {
+    /// Resolve from the process-global seams + disk. The published
+    /// agenda handle joins only when it serves the same state root this
+    /// listing reads (exotic homes join nothing).
+    pub(crate) fn resolve(home_path: &Path) -> Self {
+        let state_root = crate::platform::intendant_home_in(home_path);
+        let boot = resolve_current_boot(&state_root);
+        let live_wrappers = crate::session_supervisor::published_live_session_registry()
+            .and_then(|registry| registry.live_wrapper_ids());
+        let agenda = crate::agenda::published_agenda_handle()
+            .filter(|handle| handle.dir() == crate::agenda::agenda_dir_in(&state_root))
+            .and_then(|handle| handle.session_agenda_envelopes());
+        Self {
+            boot,
+            live_wrappers,
+            agenda,
+        }
+    }
+
+    /// A joins set that attaches nothing (non-daemon shapes and tests).
+    #[cfg(test)]
+    pub(crate) fn empty() -> Self {
+        Self {
+            boot: None,
+            live_wrappers: None,
+            agenda: None,
+        }
+    }
+
+    /// Attach the envelope blocks to one intendant wrapper row.
+    pub(crate) fn attach(
+        &self,
+        row: &mut serde_json::Value,
+        session_id: &str,
+        dir: &Path,
+    ) {
+        if let Some(envelope) = self
+            .agenda
+            .as_ref()
+            .and_then(|envelopes| envelopes.get(session_id))
+        {
+            let mut block = serde_json::json!({
+                "item_id": envelope.item_id,
+                // The occurrence rides as an object so Track AO's
+                // attestation can land beside `state` without reshaping
+                // the wire.
+                "occurrence": {
+                    "id": envelope.occurrence_id,
+                    "state": serde_json::to_value(envelope.occurrence_state)
+                        .unwrap_or(serde_json::Value::Null),
+                },
+            });
+            if let Some(title) = envelope.item_title.as_ref() {
+                block["item_title"] = serde_json::Value::String(title.clone());
+            }
+            if !envelope.sealed_inputs.is_empty() {
+                block["sealed_inputs"] = envelope
+                    .sealed_inputs
+                    .iter()
+                    .map(|binding_ref| {
+                        serde_json::json!({
+                            "locator": binding_ref.locator,
+                            "sha256": binding_ref.sha256,
+                        })
+                    })
+                    .collect();
+            }
+            row["agenda"] = block;
+        }
+
+        let (Some(boot), Some(live)) = (self.boot.as_ref(), self.live_wrappers.as_ref())
+        else {
+            return;
+        };
+        let live_wrapper = live.contains(session_id);
+        // Era: a live wrapper IS current-boot (a resumed pre-outage
+        // session belongs to the daemon driving it now); otherwise the
+        // transcript decides. `session.jsonl` mtime is rename-immune
+        // (meta rewrites don't touch it); the dir-mtime fallback for
+        // transcript-less dirs can over-claim currency after any file
+        // lands in the dir — the fail direction that never wrongly
+        // claims safe-to-close.
+        let current = live_wrapper
+            || super::caches::session_activity_mtime_secs(dir) >= boot.start_secs;
+        row["boot"] = serde_json::json!({
+            "era": if current { "current" } else { "preboot" },
+            "live_wrapper": live_wrapper,
+            // Served, not SPA-derived: pre-boot with no live wrapper is
+            // the safe-to-close state.
+            "ghost": !current && !live_wrapper,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_presence(state_root: &Path, boot_id: &str, pid: u32, updated_ms: u64) {
+        let dir = state_root.join("daemons");
+        std::fs::create_dir_all(&dir).unwrap();
+        let record = serde_json::json!({
+            "v": 1,
+            "boot_id": boot_id,
+            "pid": pid,
+            "port": 8765,
+            "version": {"pkg": "0.0.0", "git_sha": "test", "built_at": "test"},
+            "state": "running",
+            "updated_ms": updated_ms,
+        });
+        std::fs::write(dir.join(format!("{boot_id}.json")), record.to_string()).unwrap();
+    }
+
+    #[test]
+    fn resolve_current_boot_matches_own_pid_only() {
+        let root = tempfile::tempdir().unwrap();
+        assert!(resolve_current_boot(root.path()).is_none(), "no presence");
+        write_presence(root.path(), "boot-foreign", std::process::id() + 1, 9_000);
+        assert!(
+            resolve_current_boot(root.path()).is_none(),
+            "a foreign daemon's record never claims this process"
+        );
+        write_presence(root.path(), "boot-own", std::process::id(), 5_000);
+        write_presence(root.path(), "boot-own-fresh", std::process::id(), 7_000);
+        let boot = resolve_current_boot(root.path()).expect("own record");
+        assert_eq!(boot.start_secs, 7, "freshest own record wins");
+    }
+
+    fn joins(
+        boot_start_secs: Option<u64>,
+        live: Option<&[&str]>,
+        agenda: Option<HashMap<String, crate::agenda::SessionAgendaEnvelope>>,
+    ) -> GridEnvelopeJoins {
+        GridEnvelopeJoins {
+            boot: boot_start_secs.map(|start_secs| CurrentBoot { start_secs }),
+            live_wrappers: live
+                .map(|ids| ids.iter().map(|id| id.to_string()).collect()),
+            agenda,
+        }
+    }
+
+    fn session_dir_with_transcript(root: &Path, session_id: &str) -> std::path::PathBuf {
+        let dir = root.join(session_id);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("session.jsonl"), b"{}\n").unwrap();
+        dir
+    }
+
+    /// The ghost predicate matrix: pre-boot + no live wrapper is the one
+    /// ghost shape; a live wrapper is current-boot regardless of
+    /// transcript age; unknown liveness or unknown boot omits the block
+    /// instead of guessing.
+    #[test]
+    fn boot_block_era_and_ghost_matrix() {
+        let root = tempfile::tempdir().unwrap();
+        let dir = session_dir_with_transcript(root.path(), "s1");
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let preboot_watershed = now_secs + 3_600; // transcript predates "boot"
+        let current_watershed = now_secs.saturating_sub(3_600);
+
+        // Pre-boot transcript, no wrapper → ghost.
+        let mut row = serde_json::json!({});
+        joins(Some(preboot_watershed), Some(&[]), None).attach(&mut row, "s1", &dir);
+        assert_eq!(row["boot"]["era"], "preboot");
+        assert_eq!(row["boot"]["live_wrapper"], false);
+        assert_eq!(row["boot"]["ghost"], true);
+
+        // Same transcript age, live wrapper → current, never a ghost.
+        let mut row = serde_json::json!({});
+        joins(Some(preboot_watershed), Some(&["s1"]), None).attach(&mut row, "s1", &dir);
+        assert_eq!(row["boot"]["era"], "current");
+        assert_eq!(row["boot"]["live_wrapper"], true);
+        assert_eq!(row["boot"]["ghost"], false);
+
+        // Transcript written this boot, no wrapper → current (ended
+        // this boot), not a ghost.
+        let mut row = serde_json::json!({});
+        joins(Some(current_watershed), Some(&[]), None).attach(&mut row, "s1", &dir);
+        assert_eq!(row["boot"]["era"], "current");
+        assert_eq!(row["boot"]["ghost"], false);
+
+        // Unknown liveness or unknown boot → no block, never a guess.
+        let mut row = serde_json::json!({});
+        joins(Some(preboot_watershed), None, None).attach(&mut row, "s1", &dir);
+        assert!(row.get("boot").is_none());
+        let mut row = serde_json::json!({});
+        joins(None, Some(&[]), None).attach(&mut row, "s1", &dir);
+        assert!(row.get("boot").is_none());
+    }
+
+    /// The agenda block's wire shape: id chip + extensible occurrence
+    /// object + title + sealed inputs; linkless sessions get no block.
+    #[test]
+    fn agenda_block_rides_the_row() {
+        let root = tempfile::tempdir().unwrap();
+        let dir = session_dir_with_transcript(root.path(), "s1");
+        let envelope = crate::agenda::SessionAgendaEnvelope {
+            item_id: "01ITEM".into(),
+            item_title: Some("the source".into()),
+            occurrence_id: "occ-1".into(),
+            occurrence_state: crate::agenda::OccurrenceState::Started,
+            sealed_inputs: Vec::new(),
+        };
+        let mut envelopes = HashMap::new();
+        envelopes.insert("s1".to_string(), envelope);
+        let mut row = serde_json::json!({});
+        joins(None, None, Some(envelopes)).attach(&mut row, "s1", &dir);
+        assert_eq!(row["agenda"]["item_id"], "01ITEM");
+        assert_eq!(row["agenda"]["item_title"], "the source");
+        assert_eq!(row["agenda"]["occurrence"]["id"], "occ-1");
+        assert_eq!(row["agenda"]["occurrence"]["state"], "started");
+        assert!(
+            row["agenda"].get("sealed_inputs").is_none(),
+            "refless manifests serve no empty array"
+        );
+
+        let mut row = serde_json::json!({});
+        joins(None, None, Some(HashMap::new())).attach(&mut row, "s2", &dir);
+        assert!(row.get("agenda").is_none());
+    }
+}

--- a/src/bin/caller/web_gateway/session_catalog/grid_envelope.rs
+++ b/src/bin/caller/web_gateway/session_catalog/grid_envelope.rs
@@ -79,12 +79,7 @@ impl GridEnvelopeJoins {
     }
 
     /// Attach the envelope blocks to one intendant wrapper row.
-    pub(crate) fn attach(
-        &self,
-        row: &mut serde_json::Value,
-        session_id: &str,
-        dir: &Path,
-    ) {
+    pub(crate) fn attach(&self, row: &mut serde_json::Value, session_id: &str, dir: &Path) {
         if let Some(envelope) = self
             .agenda
             .as_ref()
@@ -119,8 +114,7 @@ impl GridEnvelopeJoins {
             row["agenda"] = block;
         }
 
-        let (Some(boot), Some(live)) = (self.boot.as_ref(), self.live_wrappers.as_ref())
-        else {
+        let (Some(boot), Some(live)) = (self.boot.as_ref(), self.live_wrappers.as_ref()) else {
             return;
         };
         let live_wrapper = live.contains(session_id);
@@ -131,8 +125,8 @@ impl GridEnvelopeJoins {
         // transcript-less dirs can over-claim currency after any file
         // lands in the dir — the fail direction that never wrongly
         // claims safe-to-close.
-        let current = live_wrapper
-            || super::caches::session_activity_mtime_secs(dir) >= boot.start_secs;
+        let current =
+            live_wrapper || super::caches::session_activity_mtime_secs(dir) >= boot.start_secs;
         row["boot"] = serde_json::json!({
             "era": if current { "current" } else { "preboot" },
             "live_wrapper": live_wrapper,
@@ -184,8 +178,7 @@ mod tests {
     ) -> GridEnvelopeJoins {
         GridEnvelopeJoins {
             boot: boot_start_secs.map(|start_secs| CurrentBoot { start_secs }),
-            live_wrappers: live
-                .map(|ids| ids.iter().map(|id| id.to_string()).collect()),
+            live_wrappers: live.map(|ids| ids.iter().map(|id| id.to_string()).collect()),
             agenda,
         }
     }

--- a/src/bin/caller/web_gateway/session_catalog/mod.rs
+++ b/src/bin/caller/web_gateway/session_catalog/mod.rs
@@ -16,6 +16,8 @@ pub(crate) use replay::*;
 mod replay_cache;
 pub(crate) use replay_cache::*;
 mod external_rows;
+
+mod grid_envelope;
 pub(crate) use external_rows::*;
 mod detail_search;
 pub(crate) use detail_search::*;
@@ -968,12 +970,16 @@ pub(crate) fn targeted_intendant_session_rows_from_home(
         }
     }
 
+    // The ids path serves the open grid windows' polls — the envelope
+    // joins attach here too, post row-cache (see `grid_envelope`).
+    let grid_joins = grid_envelope::GridEnvelopeJoins::resolve(home);
     for dir_key in seen_dirs {
         let dir = PathBuf::from(&dir_key);
         let Some(session_id) = dir.file_name().map(|n| n.to_string_lossy().to_string()) else {
             continue;
         };
-        if let Some(row) = intendant_session_list_row_from_dir(&dir, &session_id) {
+        if let Some(mut row) = intendant_session_list_row_from_dir(&dir, &session_id) {
+            grid_joins.attach(&mut row, &session_id, &dir);
             push_unique_session_row_for_ids(rows, seen, row, requested_ids);
         }
     }
@@ -2537,6 +2543,9 @@ pub(crate) fn list_sessions_from_home_impl(
         return serde_json::to_string(&external_sessions).unwrap_or_else(|_| "[]".to_string());
     }
     let external_context_by_id = external_session_context_by_id(&external_sessions);
+    // Serve-time envelope joins (agenda linkage + boot era), resolved
+    // once per build and attached post row-cache — see `grid_envelope`.
+    let grid_joins = grid_envelope::GridEnvelopeJoins::resolve(home_path);
 
     let mut sessions: Vec<serde_json::Value> = Vec::new();
 
@@ -2575,6 +2584,7 @@ pub(crate) fn list_sessions_from_home_impl(
             .unwrap_or_default();
 
         if let Some(mut wrapper_session) = intendant_session_list_row_from_dir(&dir, &session_id) {
+            grid_joins.attach(&mut wrapper_session, &session_id, &dir);
             index_external_wrapper_session_row(home_path, &wrapper_session);
             apply_external_context_to_intendant_wrapper(
                 &mut wrapper_session,

--- a/src/bin/caller/web_gateway/static_assets.rs
+++ b/src/bin/caller/web_gateway/static_assets.rs
@@ -852,6 +852,12 @@ mod tests {
                 "ui2-agenda-workflows.js",
                 include_str!("../../../../static/app/ui2-agenda-workflows.js"),
             ),
+            // The session windows' sealed-inputs chip consumes digests
+            // too (the grid envelope) — same one-formatter law.
+            (
+                "39-session-windows.js",
+                include_str!("../../../../static/app/39-session-windows.js"),
+            ),
         ] {
             for (idx, line) in content.lines().enumerate() {
                 let lower = line.to_ascii_lowercase();

--- a/static/app.html
+++ b/static/app.html
@@ -4696,6 +4696,17 @@ body.context-focus-active {
     0 0 0 1px color-mix(in srgb, var(--session-badge-border, color-mix(in srgb, var(--blue) 62%, transparent)) 30%, transparent),
     0 0 18px color-mix(in srgb, var(--session-badge-fg, var(--blue)) 26%, transparent);
 }
+/* Grid envelope's ghost state (served bit: pre-boot + no live wrapper —
+   safe to close). Last in the border-modifier chain so a ghost reads as
+   a ghost even when other window states apply: dashed peach frame,
+   tinted wash, desaturated content — unmistakable, not screaming. */
+.session-window.session-window-ghost {
+  border-style: dashed;
+  border-color: color-mix(in srgb, var(--peach) 65%, var(--surface1));
+  background: color-mix(in srgb, var(--peach) 5%, var(--session-window-bg));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--peach) 22%, transparent);
+  filter: saturate(0.65);
+}
 .session-window.minimized {
   min-height: 36px;
   max-height: 36px;
@@ -36904,7 +36915,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '70545ba64e0dc79d';
+const INTENDANT_APP_BUILD = 'e24456a9d57bf779';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -60033,8 +60044,53 @@ function sessionGoalSignature(goal) {
   ].join('\u001f');
 }
 
+// Grid-envelope blocks (catalog-row `agenda` + `boot`, grid_envelope.rs):
+// served precomputed in the one daemon payload — the SPA validates shape
+// and renders, never joins.
+function normalizeSessionAgendaEnvelope(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const itemId = compactSessionText(raw.item_id || raw.itemId);
+  if (!itemId) return null;
+  const out = { itemId };
+  const itemTitle = compactSessionText(raw.item_title || raw.itemTitle);
+  if (itemTitle) out.itemTitle = itemTitle;
+  const occ = raw.occurrence;
+  if (occ && typeof occ === 'object') {
+    const id = compactSessionText(occ.id);
+    if (id) {
+      out.occurrence = { id };
+      const state = compactSessionText(occ.state);
+      if (state) out.occurrence.state = state.toLowerCase();
+    }
+  }
+  const rawRefs = raw.sealed_inputs ?? raw.sealedInputs;
+  const sealed = (Array.isArray(rawRefs) ? rawRefs : [])
+    .map((ref) => ({
+      locator: String(ref?.locator || ''),
+      sha256: String(ref?.sha256 || ''),
+    }))
+    .filter((ref) => ref.sha256);
+  if (sealed.length) out.sealedInputs = sealed;
+  return out;
+}
+
+function normalizeSessionBootEra(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const era = String(raw.era || '').toLowerCase();
+  if (era !== 'current' && era !== 'preboot') return null;
+  return {
+    era,
+    liveWrapper: raw.live_wrapper === true || raw.liveWrapper === true,
+    ghost: raw.ghost === true,
+  };
+}
+
 function normalizeSessionWindowMeta(meta = {}) {
   const out = {};
+  const agendaEnvelope = normalizeSessionAgendaEnvelope(meta.agenda);
+  if (agendaEnvelope) out.agenda = agendaEnvelope;
+  const bootEra = normalizeSessionBootEra(meta.boot);
+  if (bootEra) out.boot = bootEra;
   const name = compactSessionText(meta.name || meta.display_name || meta.displayName || meta.thread_name || meta.threadName || meta.title);
   if (name) out.name = name;
   const task = compactSessionText(meta.initial_message || meta.initialMessage || meta.task);
@@ -60151,6 +60207,18 @@ function sessionWindowMetadataSignature(meta = {}) {
     meta.relationshipEphemeral === undefined ? '' : (meta.relationshipEphemeral ? '1' : '0'),
     meta.phase || '',
     meta.ended === undefined ? '' : (meta.ended ? '1' : '0'),
+    meta.agenda
+      ? [
+        meta.agenda.itemId,
+        meta.agenda.itemTitle || '',
+        meta.agenda.occurrence?.id || '',
+        meta.agenda.occurrence?.state || '',
+        (meta.agenda.sealedInputs || []).map((ref) => ref.sha256).join(','),
+      ].join('|')
+      : '',
+    meta.boot
+      ? `${meta.boot.era}|${meta.boot.liveWrapper ? '1' : '0'}|${meta.boot.ghost ? '1' : '0'}`
+      : '',
   ].join('\u001f');
 }
 
@@ -61160,6 +61228,91 @@ const VITALS_SYMBOLS = {
       return `${vitalsLimitLabelLong(v.label)} limit: ${what}${v.reset ? ` — resets in ${v.reset}` : ''}`;
     },
   },
+  // ── Grid envelope (catalog-row `agenda` + `boot` blocks, served
+  // precomputed by grid_envelope.rs — one daemon payload, no SPA
+  // joins). Quiet session-facts chips like model/permissions; only a
+  // ghost elevates.
+  'agenda-source': {
+    label: 'Source item',
+    priority: 27,
+    icon: 'bolt',
+    chip: (v) => `⚡ ${v.shortId}`,
+    // Hover = explain[0], so the full title rides the chip tooltip.
+    explain: (v) => [
+      v.title
+        ? `Fired from agenda item “${v.title}”.`
+        : 'Fired from an agenda item (title unavailable — the item may be gone).',
+      `Item id: ${v.itemId}`,
+    ],
+    action: (v) => {
+      const actions = [];
+      if (typeof agendaOpenInspector === 'function') {
+        actions.push({
+          label: 'Open the agenda card',
+          run: () => {
+            if (typeof switchTab === 'function') switchTab('agenda');
+            agendaOpenInspector(v.itemId);
+          },
+        });
+      }
+      actions.push({ label: 'Copy item id', run: () => vitalsCopyText(v.itemId) });
+      return actions;
+    },
+  },
+  'agenda-occurrence': {
+    label: 'Occurrence',
+    priority: 26,
+    icon: (v) => (v.state === 'started' ? 'dots' : v.state === 'completed' ? 'check' : 'triangle'),
+    chip: (v) => `${v.glyph} ${v.state}`,
+    // The occurrence object is the extensible slot: Track AO's
+    // attestation lands beside `state` on the same wire.
+    explain: (v) => [
+      v.state === 'started'
+        ? 'This firing is still running — no terminal record yet.'
+        : `This firing resolved: ${v.state}.`,
+      `Occurrence id: ${v.occurrenceId}`,
+    ],
+    action: (v) => [
+      { label: 'Copy occurrence id', run: () => vitalsCopyText(v.occurrenceId) },
+    ],
+  },
+  'sealed-inputs': {
+    label: 'Sealed inputs',
+    priority: 25,
+    icon: 'shield',
+    chip: (v) => `⛉ ${v.count} sealed`,
+    explain: (v) => [
+      `${v.count} sealed input${v.count === 1 ? '' : 's'} rode this firing — digest-bound copies of what the approval covered.`,
+      ...v.refs.map((ref) => `${ref.name} — sha256 ${ref.shortDigest}`),
+    ],
+    action: (v) => v.refs.map((ref) => ({
+      label: `Copy full sha256 — ${ref.name} (${ref.shortDigest})`,
+      run: () => vitalsCopyText(ref.sha256),
+    })),
+  },
+  boot: {
+    label: 'Boot era',
+    priority: 24,
+    icon: (v) => (v.ghost ? 'slash' : 'clock'),
+    chip: (v) => (v.ghost ? '👻 ghost' : v.era === 'preboot' ? '↻ pre-boot' : '↻ this boot'),
+    explain: (v) => {
+      if (v.ghost) {
+        return [
+          'This session predates the current daemon boot and no live wrapper backs it — a ghost window.',
+          'Closing it is safe; nothing is running behind it.',
+        ];
+      }
+      return [
+        v.era === 'preboot'
+          ? 'This session predates the current daemon boot.'
+          : 'This session belongs to the current daemon boot.',
+        v.liveWrapper
+          ? 'A live wrapper backs it right now.'
+          : 'No live wrapper backs it right now.',
+      ];
+    },
+    brief: (v) => (v.ghost ? 'Ghost — pre-boot, nothing behind it; safe to close' : ''),
+  },
 };
 
 // Fixed display order for chips and the glossary (semantic, not priority:
@@ -61167,7 +61320,8 @@ const VITALS_SYMBOLS = {
 // model + permissions form the session-facts group, right after the live
 // activity signal.
 const VITALS_SYMBOL_ORDER = [
-  'health', 'activity', 'model', 'permissions', 'worktree', 'branch', 'dirty',
+  'health', 'activity', 'model', 'permissions', 'agenda-source',
+  'agenda-occurrence', 'sealed-inputs', 'boot', 'worktree', 'branch', 'dirty',
   'divergence', 'parity', 'unpushed', 'primary-unpushed', 'cache-hit',
   'cache-ttl', 'limit',
 ];
@@ -61362,6 +61516,50 @@ function vitalsChipModels(vitals, meta, sessionId) {
       path: worktree.path || '',
       baseBranch: worktree.baseBranch || '',
       baseSha: worktree.baseSha || '',
+    });
+  }
+
+  // Grid envelope (the catalog-row `agenda` + `boot` blocks).
+  const agendaMeta = meta?.agenda && typeof meta.agenda === 'object' ? meta.agenda : null;
+  if (agendaMeta?.itemId) {
+    push('agenda-source', 'agenda-source', {
+      itemId: agendaMeta.itemId,
+      shortId: agendaMeta.itemId.length > 12 ? agendaMeta.itemId.slice(0, 12) : agendaMeta.itemId,
+      title: agendaMeta.itemTitle || '',
+    });
+    const occurrence = agendaMeta.occurrence;
+    if (occurrence?.id) {
+      const state = occurrence.state || 'started';
+      push('agenda-occurrence', 'agenda-occurrence', {
+        occurrenceId: occurrence.id,
+        state,
+        glyph: ({ started: '▶', completed: '✓', failed: '✕', missed: '⌀', unknown: '?' })[state] || '▸',
+      }, {
+        tone: state === 'failed' || state === 'unknown' || state === 'missed' ? 'warn' : '',
+      });
+    }
+    const sealedRefs = Array.isArray(agendaMeta.sealedInputs) ? agendaMeta.sealedInputs : [];
+    if (sealedRefs.length) {
+      push('sealed-inputs', 'sealed-inputs', {
+        count: sealedRefs.length,
+        refs: sealedRefs.map((ref) => ({
+          name: String(ref.locator || '').split('/').pop() || 'input',
+          sha256: ref.sha256,
+          // The one short-digest formatter (ui2-agenda.js) — shared,
+          // never re-minted here.
+          shortDigest: agendaShortDigest(ref.sha256),
+        })),
+      });
+    }
+  }
+  const bootMeta = meta?.boot && typeof meta.boot === 'object' ? meta.boot : null;
+  if (bootMeta?.era) {
+    push('boot', 'boot', {
+      era: bootMeta.era,
+      liveWrapper: bootMeta.liveWrapper === true,
+      ghost: bootMeta.ghost === true,
+    }, {
+      severity: bootMeta.ghost ? 'warn' : '',
     });
   }
 
@@ -63160,6 +63358,8 @@ function sessionWindowMetaFromSession(session) {
     relationship_kind: session.relationship_kind || session.relationship,
     thread_source: session.thread_source,
     agent_nickname: session.agent_nickname,
+    agenda: session.agenda,
+    boot: session.boot,
   };
   if (
     Object.prototype.hasOwnProperty.call(session, 'goal') ||
@@ -69372,6 +69572,13 @@ function updateSessionWindow(sessionId, meta = {}) {
   }
   if (meta.phase) {
     applySessionWindowPhase(win, sid, meta.phase);
+  }
+  // Grid envelope: the served ghost bit (pre-boot AND no live wrapper)
+  // marks the whole window — the unmistakable safe-to-close treatment.
+  // Missing block ≠ cleared: only a present block moves the class.
+  const bootEra = (sessionMetadataById.get(sid) || {}).boot;
+  if (bootEra !== undefined) {
+    win.el.classList.toggle('session-window-ghost', !!(bootEra && bootEra.ghost));
   }
   // Arm-only: this window's goal was just rendered; the 1 s ticker owns
   // elapsed-time repaints for the rest (re-rendering EVERY window's goal

--- a/static/app/12-styles-tasks-log.css
+++ b/static/app/12-styles-tasks-log.css
@@ -974,6 +974,17 @@ body.context-focus-active {
     0 0 0 1px color-mix(in srgb, var(--session-badge-border, color-mix(in srgb, var(--blue) 62%, transparent)) 30%, transparent),
     0 0 18px color-mix(in srgb, var(--session-badge-fg, var(--blue)) 26%, transparent);
 }
+/* Grid envelope's ghost state (served bit: pre-boot + no live wrapper —
+   safe to close). Last in the border-modifier chain so a ghost reads as
+   a ghost even when other window states apply: dashed peach frame,
+   tinted wash, desaturated content — unmistakable, not screaming. */
+.session-window.session-window-ghost {
+  border-style: dashed;
+  border-color: color-mix(in srgb, var(--peach) 65%, var(--surface1));
+  background: color-mix(in srgb, var(--peach) 5%, var(--session-window-bg));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--peach) 22%, transparent);
+  filter: saturate(0.65);
+}
 .session-window.minimized {
   min-height: 36px;
   max-height: 36px;

--- a/static/app/39-session-windows.js
+++ b/static/app/39-session-windows.js
@@ -475,8 +475,53 @@ function sessionGoalSignature(goal) {
   ].join('\u001f');
 }
 
+// Grid-envelope blocks (catalog-row `agenda` + `boot`, grid_envelope.rs):
+// served precomputed in the one daemon payload — the SPA validates shape
+// and renders, never joins.
+function normalizeSessionAgendaEnvelope(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const itemId = compactSessionText(raw.item_id || raw.itemId);
+  if (!itemId) return null;
+  const out = { itemId };
+  const itemTitle = compactSessionText(raw.item_title || raw.itemTitle);
+  if (itemTitle) out.itemTitle = itemTitle;
+  const occ = raw.occurrence;
+  if (occ && typeof occ === 'object') {
+    const id = compactSessionText(occ.id);
+    if (id) {
+      out.occurrence = { id };
+      const state = compactSessionText(occ.state);
+      if (state) out.occurrence.state = state.toLowerCase();
+    }
+  }
+  const rawRefs = raw.sealed_inputs ?? raw.sealedInputs;
+  const sealed = (Array.isArray(rawRefs) ? rawRefs : [])
+    .map((ref) => ({
+      locator: String(ref?.locator || ''),
+      sha256: String(ref?.sha256 || ''),
+    }))
+    .filter((ref) => ref.sha256);
+  if (sealed.length) out.sealedInputs = sealed;
+  return out;
+}
+
+function normalizeSessionBootEra(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const era = String(raw.era || '').toLowerCase();
+  if (era !== 'current' && era !== 'preboot') return null;
+  return {
+    era,
+    liveWrapper: raw.live_wrapper === true || raw.liveWrapper === true,
+    ghost: raw.ghost === true,
+  };
+}
+
 function normalizeSessionWindowMeta(meta = {}) {
   const out = {};
+  const agendaEnvelope = normalizeSessionAgendaEnvelope(meta.agenda);
+  if (agendaEnvelope) out.agenda = agendaEnvelope;
+  const bootEra = normalizeSessionBootEra(meta.boot);
+  if (bootEra) out.boot = bootEra;
   const name = compactSessionText(meta.name || meta.display_name || meta.displayName || meta.thread_name || meta.threadName || meta.title);
   if (name) out.name = name;
   const task = compactSessionText(meta.initial_message || meta.initialMessage || meta.task);
@@ -593,6 +638,18 @@ function sessionWindowMetadataSignature(meta = {}) {
     meta.relationshipEphemeral === undefined ? '' : (meta.relationshipEphemeral ? '1' : '0'),
     meta.phase || '',
     meta.ended === undefined ? '' : (meta.ended ? '1' : '0'),
+    meta.agenda
+      ? [
+        meta.agenda.itemId,
+        meta.agenda.itemTitle || '',
+        meta.agenda.occurrence?.id || '',
+        meta.agenda.occurrence?.state || '',
+        (meta.agenda.sealedInputs || []).map((ref) => ref.sha256).join(','),
+      ].join('|')
+      : '',
+    meta.boot
+      ? `${meta.boot.era}|${meta.boot.liveWrapper ? '1' : '0'}|${meta.boot.ghost ? '1' : '0'}`
+      : '',
   ].join('\u001f');
 }
 
@@ -1602,6 +1659,91 @@ const VITALS_SYMBOLS = {
       return `${vitalsLimitLabelLong(v.label)} limit: ${what}${v.reset ? ` — resets in ${v.reset}` : ''}`;
     },
   },
+  // ── Grid envelope (catalog-row `agenda` + `boot` blocks, served
+  // precomputed by grid_envelope.rs — one daemon payload, no SPA
+  // joins). Quiet session-facts chips like model/permissions; only a
+  // ghost elevates.
+  'agenda-source': {
+    label: 'Source item',
+    priority: 27,
+    icon: 'bolt',
+    chip: (v) => `⚡ ${v.shortId}`,
+    // Hover = explain[0], so the full title rides the chip tooltip.
+    explain: (v) => [
+      v.title
+        ? `Fired from agenda item “${v.title}”.`
+        : 'Fired from an agenda item (title unavailable — the item may be gone).',
+      `Item id: ${v.itemId}`,
+    ],
+    action: (v) => {
+      const actions = [];
+      if (typeof agendaOpenInspector === 'function') {
+        actions.push({
+          label: 'Open the agenda card',
+          run: () => {
+            if (typeof switchTab === 'function') switchTab('agenda');
+            agendaOpenInspector(v.itemId);
+          },
+        });
+      }
+      actions.push({ label: 'Copy item id', run: () => vitalsCopyText(v.itemId) });
+      return actions;
+    },
+  },
+  'agenda-occurrence': {
+    label: 'Occurrence',
+    priority: 26,
+    icon: (v) => (v.state === 'started' ? 'dots' : v.state === 'completed' ? 'check' : 'triangle'),
+    chip: (v) => `${v.glyph} ${v.state}`,
+    // The occurrence object is the extensible slot: Track AO's
+    // attestation lands beside `state` on the same wire.
+    explain: (v) => [
+      v.state === 'started'
+        ? 'This firing is still running — no terminal record yet.'
+        : `This firing resolved: ${v.state}.`,
+      `Occurrence id: ${v.occurrenceId}`,
+    ],
+    action: (v) => [
+      { label: 'Copy occurrence id', run: () => vitalsCopyText(v.occurrenceId) },
+    ],
+  },
+  'sealed-inputs': {
+    label: 'Sealed inputs',
+    priority: 25,
+    icon: 'shield',
+    chip: (v) => `⛉ ${v.count} sealed`,
+    explain: (v) => [
+      `${v.count} sealed input${v.count === 1 ? '' : 's'} rode this firing — digest-bound copies of what the approval covered.`,
+      ...v.refs.map((ref) => `${ref.name} — sha256 ${ref.shortDigest}`),
+    ],
+    action: (v) => v.refs.map((ref) => ({
+      label: `Copy full sha256 — ${ref.name} (${ref.shortDigest})`,
+      run: () => vitalsCopyText(ref.sha256),
+    })),
+  },
+  boot: {
+    label: 'Boot era',
+    priority: 24,
+    icon: (v) => (v.ghost ? 'slash' : 'clock'),
+    chip: (v) => (v.ghost ? '👻 ghost' : v.era === 'preboot' ? '↻ pre-boot' : '↻ this boot'),
+    explain: (v) => {
+      if (v.ghost) {
+        return [
+          'This session predates the current daemon boot and no live wrapper backs it — a ghost window.',
+          'Closing it is safe; nothing is running behind it.',
+        ];
+      }
+      return [
+        v.era === 'preboot'
+          ? 'This session predates the current daemon boot.'
+          : 'This session belongs to the current daemon boot.',
+        v.liveWrapper
+          ? 'A live wrapper backs it right now.'
+          : 'No live wrapper backs it right now.',
+      ];
+    },
+    brief: (v) => (v.ghost ? 'Ghost — pre-boot, nothing behind it; safe to close' : ''),
+  },
 };
 
 // Fixed display order for chips and the glossary (semantic, not priority:
@@ -1609,7 +1751,8 @@ const VITALS_SYMBOLS = {
 // model + permissions form the session-facts group, right after the live
 // activity signal.
 const VITALS_SYMBOL_ORDER = [
-  'health', 'activity', 'model', 'permissions', 'worktree', 'branch', 'dirty',
+  'health', 'activity', 'model', 'permissions', 'agenda-source',
+  'agenda-occurrence', 'sealed-inputs', 'boot', 'worktree', 'branch', 'dirty',
   'divergence', 'parity', 'unpushed', 'primary-unpushed', 'cache-hit',
   'cache-ttl', 'limit',
 ];
@@ -1804,6 +1947,50 @@ function vitalsChipModels(vitals, meta, sessionId) {
       path: worktree.path || '',
       baseBranch: worktree.baseBranch || '',
       baseSha: worktree.baseSha || '',
+    });
+  }
+
+  // Grid envelope (the catalog-row `agenda` + `boot` blocks).
+  const agendaMeta = meta?.agenda && typeof meta.agenda === 'object' ? meta.agenda : null;
+  if (agendaMeta?.itemId) {
+    push('agenda-source', 'agenda-source', {
+      itemId: agendaMeta.itemId,
+      shortId: agendaMeta.itemId.length > 12 ? agendaMeta.itemId.slice(0, 12) : agendaMeta.itemId,
+      title: agendaMeta.itemTitle || '',
+    });
+    const occurrence = agendaMeta.occurrence;
+    if (occurrence?.id) {
+      const state = occurrence.state || 'started';
+      push('agenda-occurrence', 'agenda-occurrence', {
+        occurrenceId: occurrence.id,
+        state,
+        glyph: ({ started: '▶', completed: '✓', failed: '✕', missed: '⌀', unknown: '?' })[state] || '▸',
+      }, {
+        tone: state === 'failed' || state === 'unknown' || state === 'missed' ? 'warn' : '',
+      });
+    }
+    const sealedRefs = Array.isArray(agendaMeta.sealedInputs) ? agendaMeta.sealedInputs : [];
+    if (sealedRefs.length) {
+      push('sealed-inputs', 'sealed-inputs', {
+        count: sealedRefs.length,
+        refs: sealedRefs.map((ref) => ({
+          name: String(ref.locator || '').split('/').pop() || 'input',
+          sha256: ref.sha256,
+          // The one short-digest formatter (ui2-agenda.js) — shared,
+          // never re-minted here.
+          shortDigest: agendaShortDigest(ref.sha256),
+        })),
+      });
+    }
+  }
+  const bootMeta = meta?.boot && typeof meta.boot === 'object' ? meta.boot : null;
+  if (bootMeta?.era) {
+    push('boot', 'boot', {
+      era: bootMeta.era,
+      liveWrapper: bootMeta.liveWrapper === true,
+      ghost: bootMeta.ghost === true,
+    }, {
+      severity: bootMeta.ghost ? 'warn' : '',
     });
   }
 
@@ -3602,6 +3789,8 @@ function sessionWindowMetaFromSession(session) {
     relationship_kind: session.relationship_kind || session.relationship,
     thread_source: session.thread_source,
     agent_nickname: session.agent_nickname,
+    agenda: session.agenda,
+    boot: session.boot,
   };
   if (
     Object.prototype.hasOwnProperty.call(session, 'goal') ||

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -681,6 +681,13 @@ function updateSessionWindow(sessionId, meta = {}) {
   if (meta.phase) {
     applySessionWindowPhase(win, sid, meta.phase);
   }
+  // Grid envelope: the served ghost bit (pre-boot AND no live wrapper)
+  // marks the whole window — the unmistakable safe-to-close treatment.
+  // Missing block ≠ cleared: only a present block moves the class.
+  const bootEra = (sessionMetadataById.get(sid) || {}).boot;
+  if (bootEra !== undefined) {
+    win.el.classList.toggle('session-window-ghost', !!(bootEra && bootEra.ghost));
+  }
   // Arm-only: this window's goal was just rendered; the 1 s ticker owns
   // elapsed-time repaints for the rest (re-rendering EVERY window's goal
   // per metadata update was the waste).


### PR DESCRIPTION
Extends the grid session window's operational envelope (today: model, effort, project) with derived agenda-linkage chips and a boot-era indicator, per the owner-corrected design 2026-07-27/28 (agenda item 01KYKBBY9GQEFYE2ZYCZS6MC6H).

**Daemon (landed in this PR's first commit):** session-catalog intendant rows gain two serve-time blocks in the one payload the chips render — `agenda` {item_id, item_title, occurrence{id,state}, sealed_inputs[{locator,sha256}]} via a new occurrence-journal reverse fold (lineage-following per #627) joined with the item store; `boot` {era, live_wrapper, ghost} via HS1's presence substrate (#628) joined with live wrapper registry membership (#631 idiom). Ghost = preboot AND no live wrapper, served precomputed.

**SPA (coming in this PR):** envelope chips in the session-window vitals row (source item, occurrence state, sealed inputs sharing the #630 short-digest formatter), unmistakable ghost rendering, fragments-only + regenerated app.html.

**Naming:** PR #633's derived-name behavior untouched; owner-rename precedence already pinned by `derived_name_never_clobbers_owner_rename`. Track AW refinement stays design-only (the seam comment at `agenda/reminders.rs` derivation point).

Pins: envelope_carries_source_item_and_sealed_inputs; envelope_derives_from_one_daemon_payload; preboot_ghosts_render_unmistakably; owner_rename_always_wins; short_digest_formatter_shared_not_duplicated; derived_names_not_regressed.