### PR TITLE
feat(vitals): key rate-limit windows by credential era, with eviction and honest chips

### DIFF
--- a/crates/intendant-core/src/vitals.rs
+++ b/crates/intendant-core/src/vitals.rs
@@ -118,6 +118,17 @@ pub struct SessionLimitWindow {
     /// predate the field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub observed_at_epoch: Option<u64>,
+    /// Credential-era attribution. The provider wire carries no account
+    /// identity, so the daemon stamps the account label it knows the
+    /// reporting session runs under (the Vault sign-in ceremony's account,
+    /// or a minted era nonce when the ceremony learned no label). `None` =
+    /// the unattributed era: sessions whose credentials predate any
+    /// daemon-observed sign-in. Store- and wire-additive; on session
+    /// emissions the field is present only while more than one credential
+    /// era is live for the backend — the frontends' cue to label the
+    /// windows apart (a single-era steady state renders unchanged).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account: Option<String>,
 }
 
 /// What a session's model/backend is verifiably doing right now — the
@@ -481,10 +492,10 @@ mod tests {
         assert!(rewire.get("checkout").is_none());
     }
 
-    /// The limit window's `observed_at_epoch` is wire-additive: serialized
-    /// camelCase when known, absent otherwise, and legacy emissions
-    /// without it (or without `usedPct` — the no-synthesized-percentage
-    /// rule) deserialize losslessly.
+    /// The limit window's `observed_at_epoch` and `account` stamps are
+    /// wire-additive: serialized camelCase when known, absent otherwise,
+    /// and legacy emissions without them (or without `usedPct` — the
+    /// no-synthesized-percentage rule) deserialize losslessly.
     #[test]
     fn limit_window_observed_at_round_trips_and_stays_wire_additive() {
         let window = SessionLimitWindow {
@@ -493,11 +504,13 @@ mod tests {
             resets_at_epoch: Some(1_784_503_200),
             status: Some("allowed_warning".into()),
             observed_at_epoch: Some(1_784_499_000),
+            account: Some("owner@example.test".into()),
         };
         let wire = serde_json::to_value(&window).expect("serializes");
         assert_eq!(wire["observedAtEpoch"], 1_784_499_000u64);
         assert_eq!(wire["resetsAtEpoch"], 1_784_503_200u64);
         assert_eq!(wire["status"], "allowed_warning");
+        assert_eq!(wire["account"], "owner@example.test");
         assert!(
             wire.get("usedPct").is_none(),
             "an unreported percentage must not serialize as a number"
@@ -505,14 +518,19 @@ mod tests {
         let back: SessionLimitWindow = serde_json::from_value(wire).expect("deserializes");
         assert_eq!(back, window);
 
-        // Legacy wire without the stamp: defaults to None and never
+        // Legacy wire without the stamps: defaults to None and never
         // re-serializes as noise.
         let legacy: SessionLimitWindow =
             serde_json::from_str(r#"{"label":"7d","status":"allowed"}"#)
                 .expect("legacy deserializes");
         assert_eq!(legacy.observed_at_epoch, None);
+        assert_eq!(legacy.account, None);
         let rewire = serde_json::to_value(&legacy).expect("serializes");
         assert!(rewire.get("observedAtEpoch").is_none());
+        assert!(
+            rewire.get("account").is_none(),
+            "the unattributed era serializes as absence, not null"
+        );
     }
 
     /// The config section's wire shape: camelCase fields, absent when

--- a/src/bin/caller/auth_ceremony.rs
+++ b/src/bin/caller/auth_ceremony.rs
@@ -243,6 +243,29 @@ pub(crate) fn manager() -> &'static CeremonyManager {
     MANAGER.get_or_init(CeremonyManager::default)
 }
 
+/// Daemon event bus for ceremony outcome announcements
+/// ([`AppEvent::BackendCredentialAccount`] on success — the vitals hub's
+/// credential-era boundary). Published by the startup sites that own a
+/// daemon-wide bus, mirroring `session_vitals::publish_git_vitals_targets`
+/// — never from tests, whose manager interactions must stay silent.
+static CEREMONY_BUS: OnceLock<crate::event::EventBus> = OnceLock::new();
+
+pub(crate) fn publish_ceremony_bus(bus: crate::event::EventBus) {
+    let _ = CEREMONY_BUS.set(bus);
+}
+
+/// Announce a completed sign-in: the backend's credential store now holds
+/// `account`'s credentials (`None` when the provider probe stated no
+/// label). No-op until a bus is published.
+fn announce_ceremony_success(provider: Provider, account: Option<&CeremonyAccount>) {
+    if let Some(bus) = CEREMONY_BUS.get() {
+        bus.send(crate::event::AppEvent::BackendCredentialAccount {
+            source: provider.agent_backend().as_short_str().to_string(),
+            account: account.and_then(|account| account.email.clone()),
+        });
+    }
+}
+
 fn now_unix_ms() -> u64 {
     chrono::Utc::now().timestamp_millis().max(0) as u64
 }
@@ -395,6 +418,7 @@ impl CeremonyManager {
         state.phase = CeremonyPhase::Success;
         state.account = Some(probe.account);
         state.finished_at_unix_ms = Some(now_unix_ms());
+        announce_ceremony_success(state.provider, state.account.as_ref());
         if let Some(runtime) = inner.runtime.as_mut() {
             runtime.transport.kill();
         }
@@ -511,6 +535,7 @@ impl CeremonyManager {
                     Some(probe) if probe.logged_in => {
                         state.phase = CeremonyPhase::Success;
                         state.account = Some(probe.account);
+                        announce_ceremony_success(state.provider, state.account.as_ref());
                     }
                     Some(_) => {
                         state.phase = CeremonyPhase::Failed;
@@ -523,6 +548,7 @@ impl CeremonyManager {
                         // parse: trust the exit code, report the gap.
                         state.phase = CeremonyPhase::Success;
                         state.account = None;
+                        announce_ceremony_success(state.provider, None);
                     }
                 }
             } else {

--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -268,6 +268,18 @@ pub enum AppEvent {
     ReloadBackendCredentials {
         session_id: Option<String>,
     },
+    /// A dashboard sign-in ceremony for an external backend completed:
+    /// the credential store now holds `account`'s credentials (`None`
+    /// when the provider's status probe stated no label). `source` is the
+    /// backend-kind vocabulary (`AgentBackend::as_short_str`). The vitals
+    /// hub consumes this to open a new credential era for the backend —
+    /// sessions spawned or credential-reloaded from here on report their
+    /// rate-limit windows under the new account instead of overwriting
+    /// the old one's.
+    BackendCredentialAccount {
+        source: String,
+        account: Option<String>,
+    },
     /// User requested that a managed session stop completely. External-agent
     /// loops listen for this and shut down their backend process.
     SessionStopRequested {
@@ -2907,6 +2919,9 @@ pub fn app_event_to_outbound(event: &AppEvent) -> Option<crate::types::OutboundE
             session_id: session_id.clone(),
         }),
         AppEvent::SessionStopRequested { .. } => None,
+        // Hub-internal era signal; frontends see the outcome through the
+        // ordinary SessionVitals emissions the fold re-mirrors.
+        AppEvent::BackendCredentialAccount { .. } => None,
         // Loop-internal respawn signal; frontends follow the reload through
         // LogEntry lines and session lifecycle events.
         AppEvent::ReloadBackendCredentials { .. } => None,

--- a/src/bin/caller/external_agent/codex/reader.rs
+++ b/src/bin/caller/external_agent/codex/reader.rs
@@ -1216,6 +1216,9 @@ pub(crate) fn codex_rate_limit_windows(
                 .and_then(|v| v.as_u64()),
             status: None,
             observed_at_epoch: Some(now_epoch),
+            // The wire carries no account identity; the vitals hub stamps
+            // the reporting session's credential era at the fold.
+            account: None,
         });
     }
     windows
@@ -6162,6 +6165,7 @@ error: build failed
                 resets_at_epoch: Some(2000),
                 status: None,
                 observed_at_epoch: None,
+                account: None,
             },
             crate::types::SessionLimitWindow {
                 label: "7d".into(),
@@ -6169,6 +6173,7 @@ error: build failed
                 resets_at_epoch: Some(9000),
                 status: None,
                 observed_at_epoch: None,
+                account: None,
             },
         ];
         let none = serde_json::Value::Null;

--- a/src/bin/caller/mcp/events.rs
+++ b/src/bin/caller/mcp/events.rs
@@ -247,6 +247,7 @@ pub fn spawn_event_listener(
                     | AppEvent::FollowUpCancelRequested { .. }
                     | AppEvent::SessionStopRequested { .. }
                     | AppEvent::ReloadBackendCredentials { .. }
+                    | AppEvent::BackendCredentialAccount { .. }
                     | AppEvent::SessionRelationship { .. }
                     | AppEvent::SessionForkResult { .. }
                     | AppEvent::TaskReceived { .. }

--- a/src/bin/caller/peer/upcast.rs
+++ b/src/bin/caller/peer/upcast.rs
@@ -600,6 +600,7 @@ impl AppEventUpcaster {
             | AppEvent::FollowUpCancelRequested { .. }
             | AppEvent::SessionStopRequested { .. }
             | AppEvent::ReloadBackendCredentials { .. }
+            | AppEvent::BackendCredentialAccount { .. }
             | AppEvent::SessionCapabilities { .. }
             | AppEvent::FollowUpStatus { .. }
             | AppEvent::SharedView { .. }

--- a/src/bin/caller/presence.rs
+++ b/src/bin/caller/presence.rs
@@ -1112,6 +1112,7 @@ pub fn filter_event(event: &AppEvent, last_phase: &mut String) -> Option<Presenc
         | AppEvent::SessionAttached { .. }
         | AppEvent::SessionStopRequested { .. }
         | AppEvent::ReloadBackendCredentials { .. }
+        | AppEvent::BackendCredentialAccount { .. }
         | AppEvent::SessionEnded { .. }
         | AppEvent::DebugScreenReady { .. }
         | AppEvent::DebugScreenTornDown { .. }

--- a/src/bin/caller/provider/anthropic.rs
+++ b/src/bin/caller/provider/anthropic.rs
@@ -2010,6 +2010,7 @@ mod tests {
             resets_at_epoch: None,
             status: None,
             observed_at_epoch: None,
+            account: None,
         }];
         let transcript = concat!(
             "data: not json at all\n\n",

--- a/src/bin/caller/provider/mod.rs
+++ b/src/bin/caller/provider/mod.rs
@@ -126,6 +126,9 @@ fn anthropic_rate_limit_windows_from_headers(
                     .map(|d| d.as_secs())
                     .unwrap_or(0),
             ),
+            // The wire carries no account identity; the vitals hub stamps
+            // the reporting session's credential era at the fold.
+            account: None,
         });
     }
     windows

--- a/src/bin/caller/provider_mock.rs
+++ b/src/bin/caller/provider_mock.rs
@@ -324,6 +324,7 @@ impl ChatProvider for MockProvider {
                     resets_at_epoch: Some(now_epoch + 7200),
                     status: step.limit_status.clone(),
                     observed_at_epoch: Some(now_epoch),
+                    account: None,
                 }]
             })
             .unwrap_or_default();

--- a/src/bin/caller/session_vitals.rs
+++ b/src/bin/caller/session_vitals.rs
@@ -644,21 +644,66 @@ pub(crate) struct SessionVitalsHub {
     /// wrapper). Chains are flattened at link time so `resolve` is one
     /// hop in practice; the hop cap is a cycle guard only.
     pub(crate) aliases: Mutex<HashMap<String, String>>,
-    /// canonical id → backend source ("claude-code", "codex"), fed by
-    /// `SessionIdentity`. Membership key for the account-scoped limits
-    /// fold; native sessions never appear here.
-    pub(crate) session_sources: Mutex<HashMap<String, String>>,
-    /// Per backend source: the account's latest known rate-limit windows,
-    /// by label, freshest report per window (`observed_at_epoch`). The
-    /// account outlives any one session, so a session starting mid-warning
-    /// inherits the known state instead of claiming ignorance.
-    pub(crate) account_limits:
-        Mutex<HashMap<String, std::collections::BTreeMap<String, SessionLimitWindow>>>,
+    /// canonical id → the (backend source, credential era) the session
+    /// was spawned or last credential-reloaded under, fed by
+    /// `SessionIdentity` (every backend process announce — spawns AND
+    /// reload respawns re-key here). Membership key for the era-scoped
+    /// limits fold; native sessions never appear here.
+    pub(crate) session_sources: Mutex<HashMap<String, SessionAccountMembership>>,
+    /// Per backend source, per credential era: the era's latest known
+    /// rate-limit windows, by label, freshest report per window
+    /// (`observed_at_epoch`). The provider wire carries no account
+    /// identity, so without the era key two accounts' same-label windows
+    /// overwrite each other into a chimera (proven live 2026-07-27: a 5h
+    /// reset anchor jumping backward between two interleaved accounts).
+    /// An era outlives any one session — a session starting mid-warning
+    /// inherits its era's known state instead of claiming ignorance.
+    pub(crate) account_limits: Mutex<HashMap<String, SourceLimitEras>>,
+    /// Per backend source: the era new members join (the credential
+    /// store's account as of the last observed sign-in ceremony), plus
+    /// the mint counter for label-less eras. Persisted with the window
+    /// store so restored sessions rejoin the right era after a restart.
+    pub(crate) backend_accounts: Mutex<BackendAccountEras>,
     /// Daemon state file the account window store persists to (see
     /// `session_vitals_restore::account_limit_store`) so a restart keeps
     /// the account's last known windows; `None` disables persistence
     /// (unit tests, embedded producers).
     pub(crate) limit_store: Option<PathBuf>,
+}
+
+/// Credential-era key inside one backend source: the account label a
+/// window or session belongs to. `None` is the unattributed era —
+/// credentials the daemon never observed a sign-in for (pre-ceremony
+/// spawns, legacy persisted stores). At most one unattributed era exists
+/// per source, so daemon-unmediated credential swaps still fold together
+/// — the irreducible limit of an identity-less wire.
+pub(crate) type AccountEra = Option<String>;
+
+/// One source's window stores, era-keyed. `BTreeMap` for deterministic
+/// persist order (unattributed first, then labels ascending).
+pub(crate) type SourceLimitEras =
+    std::collections::BTreeMap<AccountEra, std::collections::BTreeMap<String, SessionLimitWindow>>;
+
+/// A session's account-fold membership: the backend it reports for and
+/// the credential era it was handed at its last process announce.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SessionAccountMembership {
+    pub(crate) source: String,
+    pub(crate) account: AccountEra,
+}
+
+/// The per-source current-era registry (see
+/// [`SessionVitalsHub::observe_backend_account`]).
+#[derive(Debug, Default)]
+pub(crate) struct BackendAccountEras {
+    /// source → the era new spawns/reloads join. An absent key means the
+    /// unattributed era is current (no sign-in observed yet).
+    pub(crate) current: HashMap<String, AccountEra>,
+    /// Monotonic mint counter for label-less eras ("era-N"): a sign-in
+    /// whose probe stated no account still changed the credential store,
+    /// and folding on as if nothing happened is the chimera this keying
+    /// exists to prevent.
+    pub(crate) seq: u64,
 }
 
 impl SessionVitalsHub {
@@ -676,7 +721,7 @@ impl SessionVitalsHub {
     /// `observed_at_epoch`, and the frontends' reset-rollover degradation
     /// already refuses to present a lapsed window as current.
     pub(crate) fn with_limit_store(bus: EventBus, limit_store: Option<PathBuf>) -> Arc<Self> {
-        let account_limits = limit_store
+        let restored = limit_store
             .as_deref()
             .map(crate::session_vitals_restore::load_account_limit_store)
             .unwrap_or_default();
@@ -685,7 +730,11 @@ impl SessionVitalsHub {
             sessions: Mutex::new(HashMap::new()),
             aliases: Mutex::new(HashMap::new()),
             session_sources: Mutex::new(HashMap::new()),
-            account_limits: Mutex::new(account_limits),
+            account_limits: Mutex::new(restored.limits),
+            backend_accounts: Mutex::new(BackendAccountEras {
+                current: restored.current,
+                seq: restored.era_seq,
+            }),
             limit_store,
         })
     }
@@ -752,11 +801,15 @@ impl SessionVitalsHub {
         }
     }
 
-    /// Full `SessionIdentity` fold: alias linkage plus account-scope
-    /// membership. Recording the source seeds the account's known window
+    /// Full `SessionIdentity` fold: alias linkage plus era-scope
+    /// membership. Recording the membership seeds the era's known window
     /// state into the session (a session starting mid-warning must not
-    /// claim "ok"), and any windows the session accumulated before its
-    /// identity landed seed the account store in turn.
+    /// claim "ok"); on a FIRST join, any windows the session accumulated
+    /// before its identity landed seed the era store in turn. A re-link
+    /// (a respawn's re-announce — the credential-reload path) must NOT
+    /// re-seed: the session's limits are then the hub's own mirror of its
+    /// previous era, and folding them into the new era would relabel the
+    /// old account's numbers as the new one's.
     fn link_identity(&self, alias: &str, canonical: &str, source: &str) {
         self.link_alias(alias, canonical);
         let source = source.trim();
@@ -767,69 +820,229 @@ impl SessionVitalsHub {
         if canonical.is_empty() {
             return;
         }
-        self.session_sources
-            .lock()
-            .expect("vitals source lock")
-            .insert(canonical.clone(), source.to_string());
-        let pre_identity = self
-            .sessions
-            .lock()
-            .expect("vitals state lock")
-            .get(&canonical)
-            .map(|vitals| vitals.limits.clone())
-            .unwrap_or_default();
+        let previous = self.record_membership(&canonical, source);
+        let pre_identity = if previous.is_some() {
+            Vec::new()
+        } else {
+            self.sessions
+                .lock()
+                .expect("vitals state lock")
+                .get(&canonical)
+                .map(|vitals| vitals.limits.clone())
+                .unwrap_or_default()
+        };
         self.apply_rate_limit_windows(&canonical, pre_identity);
     }
 
+    /// The era a `source`'s new members join right now.
+    fn current_era(&self, source: &str) -> AccountEra {
+        self.backend_accounts
+            .lock()
+            .expect("vitals era lock")
+            .current
+            .get(source)
+            .cloned()
+            .unwrap_or(None)
+    }
+
+    /// Record `canonical` as a member of `source`'s CURRENT credential
+    /// era. Backends re-read the credential store only at process start,
+    /// and `SessionIdentity` fires exactly at process announces — so both
+    /// a fresh spawn and a credential-reload respawn stamp here, and a
+    /// reload re-keys the session out of its birth era. A re-key that
+    /// empties a non-current era retires that era's windows: the last
+    /// member carried them out. Returns the membership this stamp
+    /// replaced (`None` on a session's first join).
+    pub(crate) fn record_membership(
+        &self,
+        canonical: &str,
+        source: &str,
+    ) -> Option<SessionAccountMembership> {
+        let membership = SessionAccountMembership {
+            source: source.to_string(),
+            account: self.current_era(source),
+        };
+        let previous = self
+            .session_sources
+            .lock()
+            .expect("vitals source lock")
+            .insert(canonical.to_string(), membership.clone());
+        if let Some(rekeyed) = previous
+            .as_ref()
+            .filter(|previous| **previous != membership)
+        {
+            if self.retire_era_if_orphaned(&rekeyed.source, &rekeyed.account) {
+                self.persist_account_limits();
+            }
+            if rekeyed.source != membership.source {
+                self.remirror_source(&rekeyed.source);
+            }
+        }
+        previous
+    }
+
+    /// A sign-in ceremony completed for `source`: open the credential era
+    /// new spawns and reloads will join. `label` is the ceremony's
+    /// account when the provider probe stated one; a label-less success
+    /// mints an opaque era nonce — the credential store changed either
+    /// way. Re-signing into the SAME labeled account keeps its era (the
+    /// windows are account-anchored truth). Existing sessions keep their
+    /// birth era — they run on the credentials they were spawned with
+    /// until a reload respawns them — and the superseded era's bucket
+    /// retires immediately only when nothing references it (it survived
+    /// memberless purely as the then-active account's truth).
+    pub(crate) fn observe_backend_account(&self, source: &str, label: Option<String>) {
+        let source = source.trim();
+        if source.is_empty() {
+            return;
+        }
+        let previous = {
+            let mut eras = self.backend_accounts.lock().expect("vitals era lock");
+            let era = match label
+                .map(|l| l.trim().to_string())
+                .filter(|l| !l.is_empty())
+            {
+                Some(label) => Some(label),
+                None => {
+                    eras.seq += 1;
+                    Some(format!("era-{}", eras.seq))
+                }
+            };
+            let previous = eras.current.insert(source.to_string(), era.clone());
+            if previous == Some(era) {
+                return;
+            }
+            previous.unwrap_or(None)
+        };
+        self.retire_era_if_orphaned(source, &previous);
+        // The current-era registry changed regardless of retirement.
+        self.persist_account_limits();
+    }
+
+    /// Drop `era`'s window bucket for `source` when it has no member
+    /// sessions left AND it is not the era new members would join — the
+    /// active account's windows deliberately survive memberless (account
+    /// truth the next session inherits), a switched-out account's die
+    /// with their last member. Returns whether a bucket was removed.
+    fn retire_era_if_orphaned(&self, source: &str, era: &AccountEra) -> bool {
+        if self.current_era(source) == *era {
+            return false;
+        }
+        let has_members = self
+            .session_sources
+            .lock()
+            .expect("vitals source lock")
+            .values()
+            .any(|member| member.source == source && member.account == *era);
+        if has_members {
+            return false;
+        }
+        let mut accounts = self.account_limits.lock().expect("vitals account lock");
+        let Some(eras) = accounts.get_mut(source) else {
+            return false;
+        };
+        let removed = eras.remove(era).is_some();
+        if removed && eras.is_empty() {
+            accounts.remove(source);
+        }
+        removed
+    }
+
+    /// Deliver every member session of `source` its own era's window
+    /// view. The `account` stamp on delivered windows is the multi-era
+    /// cue: present only while more than one era has live members, so the
+    /// frontends label ambiguous chips apart and a single-era steady
+    /// state renders exactly as before (the unattributed era never
+    /// stamps — the daemon has no truthful label to give it). A member
+    /// whose era holds no windows gets an EMPTY view: after a re-key the
+    /// alternative is the old era's chips lingering on a session that no
+    /// longer runs those credentials.
+    fn remirror_source(&self, source: &str) {
+        let members: Vec<(String, AccountEra)> = {
+            let sources = self.session_sources.lock().expect("vitals source lock");
+            sources
+                .iter()
+                .filter(|(_, member)| member.source == source)
+                .map(|(id, member)| (id.clone(), member.account.clone()))
+                .collect()
+        };
+        if members.is_empty() {
+            return;
+        }
+        let live_eras: std::collections::BTreeSet<&AccountEra> =
+            members.iter().map(|(_, era)| era).collect();
+        let multiple = live_eras.len() > 1;
+        for (member, era) in &members {
+            let view: Vec<SessionLimitWindow> = {
+                let accounts = self.account_limits.lock().expect("vitals account lock");
+                accounts
+                    .get(source)
+                    .and_then(|eras| eras.get(era))
+                    .map(|store| {
+                        store
+                            .values()
+                            .map(|window| {
+                                let mut window = window.clone();
+                                window.account = if multiple { era.clone() } else { None };
+                                window
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default()
+            };
+            self.apply(member, |vitals| vitals.limits = view);
+        }
+    }
+
     /// Fold a rate-limit report from `session_id` into the vitals limit
-    /// gauges. Sessions with a backend source share one ACCOUNT view: the
-    /// report merges into the source's window store (per label, freshest
-    /// `observed_at_epoch` wins) and the merged view mirrors into every
-    /// session of that source. Sourceless (native) sessions keep
-    /// per-session windows. An empty report still mirrors the account
-    /// view — that is how a newly linked session inherits known state.
+    /// gauges. Sessions with a backend source share one view PER
+    /// (source, credential era): the report — stamped with the reporting
+    /// session's era, since the wire itself carries no identity — merges
+    /// into that era's window store (per label, freshest
+    /// `observed_at_epoch` wins) and every member session of the source
+    /// then receives its own era's view. Sourceless (native) sessions
+    /// keep per-session windows. An empty report still re-mirrors — that
+    /// is how a newly linked session inherits known state.
     pub(crate) fn apply_rate_limit_windows(
         &self,
         session_id: &str,
         windows: Vec<SessionLimitWindow>,
     ) {
         let session_id = self.resolve(session_id);
-        let source = self
+        let membership = self
             .session_sources
             .lock()
             .expect("vitals source lock")
             .get(&session_id)
             .cloned();
-        let Some(source) = source else {
+        let Some(SessionAccountMembership { source, account }) = membership else {
             if !windows.is_empty() {
                 self.apply(&session_id, |vitals| vitals.limits = windows);
             }
             return;
         };
-        let (merged, store_changed): (Vec<SessionLimitWindow>, bool) = {
-            let mut accounts = self.account_limits.lock().expect("vitals account lock");
-            let store = accounts.entry(source.clone()).or_default();
-            let changed = fold_limit_windows(store, &windows);
-            (store.values().cloned().collect(), changed)
-        };
-        if store_changed {
-            self.persist_account_limits();
+        if !windows.is_empty() {
+            let stamped: Vec<SessionLimitWindow> = windows
+                .into_iter()
+                .map(|mut window| {
+                    window.account = account.clone();
+                    window
+                })
+                .collect();
+            let store_changed = {
+                let mut accounts = self.account_limits.lock().expect("vitals account lock");
+                let store = accounts
+                    .entry(source.clone())
+                    .or_default()
+                    .entry(account.clone())
+                    .or_default();
+                fold_limit_windows(store, &stamped)
+            };
+            if store_changed {
+                self.persist_account_limits();
+            }
         }
-        if merged.is_empty() {
-            return;
-        }
-        let members: Vec<String> = {
-            let sources = self.session_sources.lock().expect("vitals source lock");
-            sources
-                .iter()
-                .filter(|(_, member_source)| member_source.as_str() == source)
-                .map(|(id, _)| id.clone())
-                .collect()
-        };
-        for member in members {
-            let view = merged.clone();
-            self.apply(&member, |vitals| vitals.limits = view);
-        }
+        self.remirror_source(&source);
     }
 
     pub(crate) fn apply(&self, session_id: &str, update: impl FnOnce(&mut SessionVitals)) {
@@ -915,21 +1128,32 @@ impl SessionVitalsHub {
             sessions.remove(session_id.trim());
             sessions.remove(&canonical);
         }
-        {
+        let membership = {
             let mut sources = self.session_sources.lock().expect("vitals source lock");
-            sources.remove(session_id.trim());
-            sources.remove(&canonical);
-        }
+            let trimmed = sources.remove(session_id.trim());
+            sources.remove(&canonical).or(trimmed)
+        };
         // Drop the group's alias records too — an ended session's ids
         // never come back, and the map otherwise grows for daemon-life.
-        // The account window stores deliberately survive: they are account
-        // truth, and the next session of that backend inherits them.
+        // The ACTIVE era's window store deliberately survives: it is
+        // account truth, and the next session of that backend inherits
+        // it. A switched-out era's store dies with its last member —
+        // nothing will ever refresh it, and reviving it on a future
+        // session would present another account's numbers as current.
         self.aliases
             .lock()
             .expect("vitals alias lock")
             .retain(|alias, target| {
                 alias != session_id.trim() && target != &canonical && alias != &canonical
             });
+        if let Some(membership) = membership {
+            if self.retire_era_if_orphaned(&membership.source, &membership.account) {
+                self.persist_account_limits();
+            }
+            // The live-era set may have shrunk to one — the remaining
+            // members' chips drop their account suffixes.
+            self.remirror_source(&membership.source);
+        }
     }
 }
 
@@ -1119,6 +1343,12 @@ pub(crate) fn spawn_cache_vitals_listener(
                     backend_session_id,
                     source,
                 }) => hub.link_identity(&backend_session_id, &session_id, &source),
+                // A sign-in ceremony completed: open the backend's new
+                // credential era (spawns/reloads from here on report
+                // under it; running sessions keep their birth era).
+                Ok(AppEvent::BackendCredentialAccount { source, account }) => {
+                    hub.observe_backend_account(&source, account);
+                }
                 Ok(AppEvent::SessionEnded { session_id, .. }) => hub.remove(&session_id),
                 Ok(_) => {}
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
@@ -3182,6 +3412,7 @@ mod tests {
             resets_at_epoch: Some(1_783_807_200),
             status: None,
             observed_at_epoch: Some(1_783_800_000),
+            account: None,
         }];
         bus.send(AppEvent::UsageSnapshot {
             session_id: Some("s7".into()),
@@ -3244,6 +3475,7 @@ mod tests {
             resets_at_epoch: Some(observed_at + 3_600),
             status: Some("allowed_warning".into()),
             observed_at_epoch: Some(observed_at),
+            account: None,
         }
     }
 
@@ -3386,6 +3618,258 @@ mod tests {
         })
         .await
         .expect("fresh recovery reaches the vitals");
+    }
+
+    /// A session's mirrored limit view, straight from the hub state.
+    fn limits_of(
+        hub: &SessionVitalsHub,
+        session_id: &str,
+    ) -> Vec<crate::types::SessionLimitWindow> {
+        hub.sessions
+            .lock()
+            .expect("vitals state lock")
+            .get(session_id)
+            .map(|vitals| vitals.limits.clone())
+            .unwrap_or_default()
+    }
+
+    /// THE COMMISSIONED KEYING PIN (2026-07-28): the limits fold is keyed
+    /// (backend, credential era), so same-label windows from different
+    /// accounts COEXIST — a fresher report from account B may never
+    /// overwrite account A's window (the live chimera of 2026-07-27: a 5h
+    /// reset anchor jumping backward within minutes as two accounts'
+    /// wrappers interleaved through one unkeyed bucket). Each session's
+    /// mirror carries exactly its own era's windows. A label-less sign-in
+    /// still opens a fresh era under a minted nonce.
+    #[test]
+    fn limit_windows_keyed_by_account_era() {
+        let bus = EventBus::new();
+        let hub = SessionVitalsHub::new(bus.clone());
+
+        hub.observe_backend_account("claude-code", Some("a@x".into()));
+        hub.link_identity("native-a", "wrapper-a", "claude-code");
+        hub.apply_rate_limit_windows(
+            "native-a",
+            vec![crate::types::SessionLimitWindow {
+                resets_at_epoch: Some(5_000),
+                ..warn_window(1_000)
+            }],
+        );
+
+        hub.observe_backend_account("claude-code", Some("b@x".into()));
+        hub.link_identity("native-b", "wrapper-b", "claude-code");
+        // Fresher observation, same label, different reset anchor: under
+        // the old (backend, label) keying this overwrote account A.
+        hub.apply_rate_limit_windows(
+            "native-b",
+            vec![crate::types::SessionLimitWindow {
+                resets_at_epoch: Some(9_000),
+                status: Some("allowed".into()),
+                ..warn_window(2_000)
+            }],
+        );
+
+        let a = limits_of(&hub, "wrapper-a");
+        assert_eq!(a.len(), 1);
+        assert_eq!(
+            a[0].resets_at_epoch,
+            Some(5_000),
+            "account B's fresher report may not move account A's anchor"
+        );
+        assert_eq!(a[0].account.as_deref(), Some("a@x"));
+        let b = limits_of(&hub, "wrapper-b");
+        assert_eq!(b[0].resets_at_epoch, Some(9_000));
+        assert_eq!(b[0].account.as_deref(), Some("b@x"));
+
+        {
+            let accounts = hub.account_limits.lock().expect("vitals account lock");
+            let eras = accounts.get("claude-code").expect("source store");
+            assert_eq!(eras.len(), 2, "both eras' buckets coexist");
+            assert_eq!(
+                eras[&Some("a@x".to_string())]["5h"].resets_at_epoch,
+                Some(5_000)
+            );
+            assert_eq!(
+                eras[&Some("b@x".to_string())]["5h"].resets_at_epoch,
+                Some(9_000)
+            );
+        }
+
+        // A sign-in whose probe stated no label mints an opaque era: the
+        // credential store changed, and pretending otherwise re-opens the
+        // chimera.
+        hub.observe_backend_account("claude-code", None);
+        assert_eq!(hub.current_era("claude-code").as_deref(), Some("era-1"));
+    }
+
+    /// THE COMMISSIONED EVICTION PIN (2026-07-28): when the last member
+    /// session of a NON-active era ends, the era's windows evict — nothing
+    /// will ever refresh them, and the next session would inherit another
+    /// account's numbers as current. The ACTIVE era's store deliberately
+    /// survives memberless: it is account truth for the next spawn.
+    #[test]
+    fn stale_era_windows_evict_on_last_member_end() {
+        let bus = EventBus::new();
+        let hub = SessionVitalsHub::new(bus.clone());
+
+        hub.observe_backend_account("claude-code", Some("a@x".into()));
+        hub.link_identity("native-a", "wrapper-a", "claude-code");
+        hub.apply_rate_limit_windows("native-a", vec![warn_window(1_000)]);
+        hub.observe_backend_account("claude-code", Some("b@x".into()));
+        hub.link_identity("native-b", "wrapper-b", "claude-code");
+        hub.apply_rate_limit_windows("native-b", vec![warn_window(2_000)]);
+
+        // Two live eras: B's view is era-labeled.
+        assert_eq!(
+            limits_of(&hub, "wrapper-b")[0].account.as_deref(),
+            Some("b@x")
+        );
+
+        hub.remove("wrapper-a");
+        {
+            let accounts = hub.account_limits.lock().expect("vitals account lock");
+            let eras = accounts.get("claude-code").expect("source store");
+            assert!(
+                !eras.contains_key(&Some("a@x".to_string())),
+                "switched-out era dies with its last member"
+            );
+            assert!(eras.contains_key(&Some("b@x".to_string())));
+        }
+        // Back to a single era: the survivor's chips drop the suffix.
+        assert_eq!(limits_of(&hub, "wrapper-b")[0].account, None);
+
+        // The ACTIVE era survives its last member's end.
+        hub.remove("wrapper-b");
+        {
+            let accounts = hub.account_limits.lock().expect("vitals account lock");
+            let eras = accounts.get("claude-code").expect("source store");
+            assert!(
+                eras.contains_key(&Some("b@x".to_string())),
+                "the active account's windows are the next session's inheritance"
+            );
+        }
+    }
+
+    /// THE COMMISSIONED RELOAD PIN (2026-07-28): a credential reload
+    /// respawns the backend process, which re-announces its identity —
+    /// re-keying the session into the CURRENT era. Until then the running
+    /// wrapper keeps reporting into its BIRTH era (it still runs on the
+    /// credentials it was spawned with); after the re-key the old era
+    /// retires when the session was its last member, and the session's
+    /// view stops showing the old account's windows at once.
+    #[test]
+    fn reload_rekeys_membership_and_retires_old_era() {
+        let bus = EventBus::new();
+        let hub = SessionVitalsHub::new(bus.clone());
+
+        hub.observe_backend_account("claude-code", Some("a@x".into()));
+        hub.link_identity("native-a", "wrapper-a", "claude-code");
+        hub.apply_rate_limit_windows("native-a", vec![warn_window(1_000)]);
+
+        // Vault sign-in to B: the RUNNING wrapper still reports its birth
+        // account's windows — they must keep folding into era A.
+        hub.observe_backend_account("claude-code", Some("b@x".into()));
+        hub.apply_rate_limit_windows(
+            "native-a",
+            vec![crate::types::SessionLimitWindow {
+                resets_at_epoch: Some(7_777),
+                ..warn_window(1_500)
+            }],
+        );
+        {
+            let accounts = hub.account_limits.lock().expect("vitals account lock");
+            let eras = accounts.get("claude-code").expect("source store");
+            assert_eq!(
+                eras[&Some("a@x".to_string())]["5h"].resets_at_epoch,
+                Some(7_777),
+                "pre-reload reports stay in the birth era"
+            );
+            assert!(!eras.contains_key(&Some("b@x".to_string())));
+        }
+
+        // Reload: the respawned process re-announces identity (the same
+        // ids), which re-keys membership to the current era.
+        hub.link_identity("native-a", "wrapper-a", "claude-code");
+        {
+            let sources = hub.session_sources.lock().expect("vitals source lock");
+            assert_eq!(
+                sources.get("wrapper-a").map(|m| m.account.clone()),
+                Some(Some("b@x".to_string()))
+            );
+        }
+        {
+            let accounts = hub.account_limits.lock().expect("vitals account lock");
+            assert!(
+                !accounts
+                    .get("claude-code")
+                    .is_some_and(|eras| eras.contains_key(&Some("a@x".to_string()))),
+                "the re-key carried the old era's last member out — its windows retire"
+            );
+        }
+        assert!(
+            limits_of(&hub, "wrapper-a").is_empty(),
+            "the old account's chips stop rendering on the reloaded session"
+        );
+
+        // The next report lands in the new era.
+        hub.apply_rate_limit_windows("native-a", vec![warn_window(2_000)]);
+        {
+            let accounts = hub.account_limits.lock().expect("vitals account lock");
+            let eras = accounts.get("claude-code").expect("source store");
+            assert!(eras.contains_key(&Some("b@x".to_string())));
+        }
+        assert_eq!(limits_of(&hub, "wrapper-a")[0].account, None);
+    }
+
+    /// THE COMMISSIONED SUFFIX PIN (2026-07-28), daemon half: delivered
+    /// windows carry their era's account label ONLY while more than one
+    /// era has live members — the single-era steady state renders exactly
+    /// as before, and the unattributed era never stamps (the daemon has
+    /// no truthful label to give it; its chips stay plain and the LABELED
+    /// era's suffix is what tells them apart). The SPA half renders the
+    /// suffix whenever `account` is present — pinned against the fragment
+    /// beside the wire-parity test.
+    #[test]
+    fn chips_suffix_account_only_when_multiple_eras() {
+        let bus = EventBus::new();
+        let hub = SessionVitalsHub::new(bus.clone());
+
+        // Pre-ceremony spawn: the unattributed era, alone — no stamp.
+        hub.link_identity("native-a", "wrapper-a", "claude-code");
+        hub.apply_rate_limit_windows("native-a", vec![warn_window(1_000)]);
+        assert_eq!(limits_of(&hub, "wrapper-a")[0].account, None);
+
+        // A labeled era joins: the labeled member's windows stamp, the
+        // unattributed member's stay plain — and the existing member was
+        // re-mirrored without any report of its own.
+        hub.observe_backend_account("claude-code", Some("b@x".into()));
+        hub.link_identity("native-b", "wrapper-b", "claude-code");
+        hub.apply_rate_limit_windows("native-b", vec![warn_window(2_000)]);
+        assert_eq!(limits_of(&hub, "wrapper-a")[0].account, None);
+        assert_eq!(
+            limits_of(&hub, "wrapper-b")[0].account.as_deref(),
+            Some("b@x")
+        );
+
+        // The unattributed member ends: single era again — the stamp
+        // drops from the survivor without a fresh report.
+        hub.remove("wrapper-a");
+        assert_eq!(limits_of(&hub, "wrapper-b")[0].account, None);
+
+        // SPA half: the vitals catalog consumes the account field and
+        // renders it as the chip suffix.
+        let fragment = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("static/app/39-session-windows.js"),
+        )
+        .expect("dashboard session-windows fragment");
+        let begin = fragment.find("VITALS_SYMBOLS_BEGIN").expect("begin marker");
+        let end = fragment.find("VITALS_SYMBOLS_END").expect("end marker");
+        let catalog = &fragment[begin..end];
+        assert!(
+            catalog.contains("vitalsLimitAccountShort(v.account)"),
+            "the limit chip grammar renders the account suffix from the single map"
+        );
     }
 
     /// The pure fold: union by label, freshest wins, unstamped incumbents
@@ -3626,6 +4110,9 @@ mod tests {
             "status",
             "observedAtEpoch",
             "label",
+            // Credential-era attribution (present only under multi-era
+            // ambiguity — the chip-suffix cue).
+            "account",
             "state",
             "sinceEpoch",
             "lastStreamByteEpoch",
@@ -3701,5 +4188,99 @@ mod tests {
                 "fragment 41 lost the context-meter vitals fallback ({marker})"
             );
         }
+    }
+
+    /// The vitals-catalog slice of fragment 39 (VITALS_SYMBOLS_BEGIN..END).
+    fn vitals_catalog_slice() -> String {
+        let fragment = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("static/app/39-session-windows.js"),
+        )
+        .expect("dashboard session-windows fragment");
+        let begin = fragment
+            .find("VITALS_SYMBOLS_BEGIN")
+            .expect("catalog begin marker");
+        let end = fragment
+            .find("VITALS_SYMBOLS_END")
+            .expect("catalog end marker");
+        fragment[begin..end].to_string()
+    }
+
+    /// THE COMMISSIONED LABELING PIN (2026-07-28, Part 1 of the sealed
+    /// findings): the 7-day overage window is a DISTINCT provider window
+    /// — beside the base 7d chip, an identical prefix and pixel-identical
+    /// gauge icon made two real allowances read as one chip rendered
+    /// twice. Both distinctions live in the single label/symbol map
+    /// ("derive, don't mirror"): the short label says "7d extra", the
+    /// long name says "extra usage", and the icon resolver hands the
+    /// overage window its own glyph variant.
+    #[test]
+    fn overage_window_labeled_distinct_in_the_single_map() {
+        let catalog = vitals_catalog_slice();
+        assert!(
+            catalog.contains("'7d extra'"),
+            "vitalsLimitLabelShort lost the overage window's distinct short label"
+        );
+        assert!(
+            catalog.contains("'7-day extra usage'"),
+            "vitalsLimitLabelLong lost the overage window's product wording"
+        );
+        assert!(
+            catalog.contains("'gauge-plus' : 'gauge'"),
+            "the limit icon resolver stopped giving the overage window its own glyph"
+        );
+        // The variant glyph must actually exist in the icon set, outside
+        // the catalog slice.
+        let fragment = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("static/app/39-session-windows.js"),
+        )
+        .expect("dashboard session-windows fragment");
+        assert!(
+            fragment.contains("'gauge-plus':"),
+            "VITALS_ICON_PATHS lost the gauge-plus glyph"
+        );
+    }
+
+    /// THE COMMISSIONED A11Y PIN (2026-07-28, Part 1 of the sealed
+    /// findings): the 1 Hz in-place ticker updates chip text and title —
+    /// and must update `aria-label` in the same pass (both the per-window
+    /// chips and the compact attention chip, through the one shared aria
+    /// grammar). The drift seen live: aria announcing ↻2:25:14 against a
+    /// visible ↻2:07:43 in a long-lived grid.
+    #[test]
+    fn aria_countdown_tracks_ticker() {
+        let fragment = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("static/app/39-session-windows.js"),
+        )
+        .expect("dashboard session-windows fragment");
+        let tick_start = fragment
+            .find("win.vitals.dataset.vitSig === signature")
+            .expect("stable-DOM tick fast path");
+        let tick_end = fragment[tick_start..]
+            .find("return models.some((m) => m.ticking);")
+            .map(|offset| tick_start + offset)
+            .expect("tick fast path return");
+        let tick_path = &fragment[tick_start..tick_end];
+        assert!(
+            tick_path.contains("chip.setAttribute('aria-label'"),
+            "the in-place ticker stopped refreshing chip aria-labels"
+        );
+        assert!(
+            tick_path.contains(
+                "attnChip.setAttribute('aria-label', vitalsAttentionAriaLabel(attention))"
+            ),
+            "the in-place ticker stopped refreshing the attention chip's aria-label"
+        );
+        // One aria grammar, used by build AND tick — the announced text
+        // can never fork from the rendered text.
+        assert_eq!(
+            fragment
+                .matches("setAttribute('aria-label', vitalsAttentionAriaLabel(attention))")
+                .count(),
+            2,
+            "build and tick must share the single attention aria grammar"
+        );
     }
 }

--- a/src/bin/caller/session_vitals_restore.rs
+++ b/src/bin/caller/session_vitals_restore.rs
@@ -142,37 +142,42 @@ impl SessionVitalsHub {
             });
         }
         // Membership last, so the mirrored account-limit emission (if
-        // any) already carries the sections filled above.
+        // any) already carries the sections filled above. Restored
+        // sessions join the source's CURRENT era — the credential store
+        // survives a daemon restart unchanged, so the persisted era is
+        // the honest attribution for whatever these sessions report next.
         if let Some(source) = source.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
             let canonical = self.resolve(session_id);
             if !canonical.is_empty() {
-                self.session_sources
-                    .lock()
-                    .expect("vitals source lock")
-                    .insert(canonical, source.to_string());
-                // An empty report mirrors the account's known windows into
+                self.record_membership(&canonical, source);
+                // An empty report re-mirrors the era's known windows into
                 // the newly joined member (the `link_identity` pattern).
                 self.apply_rate_limit_windows(session_id, Vec::new());
             }
         }
     }
 
-    /// Persist the account rate-limit window store to the hub's state
-    /// file, if one is configured. Serialization happens under the lock
-    /// (the store is a handful of windows); the write itself is handed to
-    /// the blocking pool when a runtime is present, falling back to an
-    /// inline write in plain-sync callers (tests).
+    /// Persist the account rate-limit window store — era-keyed windows
+    /// plus the current-era registry — to the hub's state file, if one is
+    /// configured. Serialization happens under the locks (the store is a
+    /// handful of windows); the write itself is handed to the blocking
+    /// pool when a runtime is present, falling back to an inline write in
+    /// plain-sync callers (tests).
     pub(crate) fn persist_account_limits(&self) {
         let Some(path) = self.limit_store.clone() else {
             return;
         };
-        let snapshot = self
+        let limits = self
             .account_limits
             .lock()
             .expect("vitals account lock")
             .clone();
+        let (current, era_seq) = {
+            let eras = self.backend_accounts.lock().expect("vitals era lock");
+            (eras.current.clone(), eras.seq)
+        };
         let write = move || {
-            if let Err(err) = persist_account_limit_store(&path, &snapshot) {
+            if let Err(err) = persist_account_limit_store(&path, &limits, &current, era_seq) {
                 eprintln!("Session vitals: account limit store write failed: {err}");
             }
         };
@@ -190,17 +195,42 @@ impl SessionVitalsHub {
 
 /// Store format version this daemon writes. Readers accept exactly this
 /// major shape; unknown FIELDS anywhere are ignored (additive evolution
-/// needs no bump), while a future breaking shape bumps the version and
-/// this reader fails closed to an empty store (windows re-learn on the
-/// next provider report — honest, never corrupting).
+/// needs no bump — the credential-era fields below rode in that way,
+/// and account-less files from before them load as the unattributed
+/// era), while a future breaking shape bumps the version and this
+/// reader fails closed to an empty store (windows re-learn on the next
+/// provider report — honest, never corrupting).
 const ACCOUNT_LIMIT_STORE_VERSION: u32 = 1;
 
 #[derive(serde::Serialize, serde::Deserialize)]
 struct AccountLimitStoreFile {
     version: u32,
-    /// Backend source → that account's windows (label-keyed map flattened
-    /// to a list on disk; labels re-key on load).
+    /// Backend source → its windows across every era (each window's
+    /// `account` stamp is its era; era-and-label re-key on load; the
+    /// label-keyed maps flatten to a list on disk).
     accounts: BTreeMap<String, Vec<SessionLimitWindow>>,
+    /// Backend source → the current era's account label. Absent entries
+    /// (and files from before this field) mean the unattributed era is
+    /// current.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    current_accounts: BTreeMap<String, String>,
+    /// Mint counter for label-less eras ("era-N") — persisted so a
+    /// restart can never re-mint a live era's name.
+    #[serde(default, skip_serializing_if = "era_seq_is_zero")]
+    era_seq: u64,
+}
+
+fn era_seq_is_zero(seq: &u64) -> bool {
+    *seq == 0
+}
+
+/// The persisted store, decoded: era-keyed windows plus the current-era
+/// registry, exactly the hub fields they hydrate.
+#[derive(Debug, Default, PartialEq)]
+pub(crate) struct AccountLimitStoreState {
+    pub(crate) limits: HashMap<String, crate::session_vitals::SourceLimitEras>,
+    pub(crate) current: HashMap<String, crate::session_vitals::AccountEra>,
+    pub(crate) era_seq: u64,
 }
 
 /// Production location of the account rate-limit window store.
@@ -208,48 +238,108 @@ pub(crate) fn account_limit_store_path() -> PathBuf {
     crate::platform::intendant_home().join("account-rate-limits.json")
 }
 
+/// An era bucket whose EVERY window's provider-stated reset has passed
+/// is a corpse: nothing will refresh it (its reporters are gone or
+/// re-keyed), and each entry describes a window that no longer exists.
+/// Applied at load and persist so corpses never resurrect through the
+/// restore hydrator. Windows that never stated a reset keep the bucket
+/// alive — nothing proves them stale.
+pub(crate) fn era_bucket_lapsed(
+    store: &BTreeMap<String, SessionLimitWindow>,
+    now_epoch: u64,
+) -> bool {
+    !store.is_empty()
+        && store
+            .values()
+            .all(|window| matches!(window.resets_at_epoch, Some(resets) if resets <= now_epoch))
+}
+
+fn now_epoch_seconds() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
 /// Load the persisted per-account window store. Missing file, parse
 /// failures, and future-versioned files all read as empty — the store is
-/// a warm-start convenience, never load-bearing state.
-pub(crate) fn load_account_limit_store(
-    path: &Path,
-) -> HashMap<String, BTreeMap<String, SessionLimitWindow>> {
+/// a warm-start convenience, never load-bearing state. Windows group
+/// into era buckets by their `account` stamp (absent = the unattributed
+/// era, which is how pre-era files load), and fully-lapsed era buckets
+/// expire here instead of rehydrating.
+pub(crate) fn load_account_limit_store(path: &Path) -> AccountLimitStoreState {
     let Ok(raw) = std::fs::read_to_string(path) else {
-        return HashMap::new();
+        return AccountLimitStoreState::default();
     };
     let Ok(file) = serde_json::from_str::<AccountLimitStoreFile>(&raw) else {
-        return HashMap::new();
+        return AccountLimitStoreState::default();
     };
     if file.version != ACCOUNT_LIMIT_STORE_VERSION {
-        return HashMap::new();
+        return AccountLimitStoreState::default();
     }
-    file.accounts
+    let now = now_epoch_seconds();
+    let limits: HashMap<String, crate::session_vitals::SourceLimitEras> = file
+        .accounts
         .into_iter()
         .map(|(source, windows)| {
-            let store: BTreeMap<String, SessionLimitWindow> = windows
-                .into_iter()
-                .filter(|window| !window.label.trim().is_empty())
-                .map(|window| (window.label.trim().to_string(), window))
-                .collect();
-            (source, store)
+            let mut eras = crate::session_vitals::SourceLimitEras::default();
+            for window in windows {
+                let label = window.label.trim().to_string();
+                if label.is_empty() {
+                    continue;
+                }
+                eras.entry(window.account.clone())
+                    .or_default()
+                    .insert(label, window);
+            }
+            eras.retain(|_, store| !era_bucket_lapsed(store, now));
+            (source, eras)
         })
-        .filter(|(source, store)| !source.trim().is_empty() && !store.is_empty())
-        .collect()
+        .filter(|(source, eras)| !source.trim().is_empty() && !eras.is_empty())
+        .collect();
+    AccountLimitStoreState {
+        limits,
+        current: file
+            .current_accounts
+            .into_iter()
+            .filter(|(source, label)| !source.trim().is_empty() && !label.trim().is_empty())
+            .map(|(source, label)| (source, Some(label)))
+            .collect(),
+        era_seq: file.era_seq,
+    }
 }
 
 /// Atomically write the account window store (temp file + rename via the
 /// shared helper). Windows persist exactly as reported — `used_pct`
-/// stays absent when the provider never stated one.
+/// stays absent when the provider never stated one — and fully-lapsed
+/// era buckets are dropped at the write, the persist half of
+/// [`era_bucket_lapsed`].
 pub(crate) fn persist_account_limit_store(
     path: &Path,
-    accounts: &HashMap<String, BTreeMap<String, SessionLimitWindow>>,
+    accounts: &HashMap<String, crate::session_vitals::SourceLimitEras>,
+    current: &HashMap<String, crate::session_vitals::AccountEra>,
+    era_seq: u64,
 ) -> Result<(), String> {
+    let now = now_epoch_seconds();
     let file = AccountLimitStoreFile {
         version: ACCOUNT_LIMIT_STORE_VERSION,
         accounts: accounts
             .iter()
-            .map(|(source, store)| (source.clone(), store.values().cloned().collect()))
+            .map(|(source, eras)| {
+                let windows: Vec<SessionLimitWindow> = eras
+                    .iter()
+                    .filter(|(_, store)| !era_bucket_lapsed(store, now))
+                    .flat_map(|(_, store)| store.values().cloned())
+                    .collect();
+                (source.clone(), windows)
+            })
+            .filter(|(_, windows)| !windows.is_empty())
             .collect(),
+        current_accounts: current
+            .iter()
+            .filter_map(|(source, era)| era.as_ref().map(|label| (source.clone(), label.clone())))
+            .collect(),
+        era_seq,
     };
     let json = serde_json::to_string_pretty(&file).map_err(|e| e.to_string())?;
     if let Some(parent) = path.parent() {
@@ -1483,52 +1573,188 @@ mod tests {
         );
     }
 
-    /// The account limit store round-trips through its state file,
-    /// tolerates unknown fields (additive forward-compat), fails closed
-    /// on a future version, and never invents percentages.
+    /// A reset epoch safely in the future for fixtures that must survive
+    /// the load/persist lapsed-bucket reap (year 2096).
+    const FUTURE_RESET: u64 = 4_000_000_000;
+
+    fn era_window(
+        label: &str,
+        account: Option<&str>,
+        resets_at_epoch: Option<u64>,
+    ) -> SessionLimitWindow {
+        SessionLimitWindow {
+            label: label.into(),
+            used_pct: None,
+            resets_at_epoch,
+            status: Some("allowed_warning".into()),
+            observed_at_epoch: Some(1_784_499_000),
+            account: account.map(str::to_string),
+        }
+    }
+
+    /// The account limit store round-trips through its state file —
+    /// windows era-keyed by their `account` stamp, plus the current-era
+    /// registry and mint counter — tolerates unknown fields (additive
+    /// forward-compat), fails closed on a future version, and never
+    /// invents percentages.
     #[test]
     fn limit_store_round_trip_and_forward_compat() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("account-rate-limits.json");
-        let mut accounts: HashMap<String, BTreeMap<String, SessionLimitWindow>> = HashMap::new();
-        let mut store = BTreeMap::new();
-        store.insert(
-            "5h".to_string(),
-            SessionLimitWindow {
-                label: "5h".into(),
-                used_pct: None,
-                resets_at_epoch: Some(1_784_503_200),
-                status: Some("allowed_warning".into()),
-                observed_at_epoch: Some(1_784_499_000),
-            },
-        );
-        accounts.insert("claude-code".to_string(), store);
-        persist_account_limit_store(&path, &accounts).expect("persist");
+        let mut accounts: HashMap<String, crate::session_vitals::SourceLimitEras> = HashMap::new();
+        let mut eras = crate::session_vitals::SourceLimitEras::default();
+        let unattributed = era_window("5h", None, Some(FUTURE_RESET));
+        let labeled = era_window("5h", Some("owner@example.test"), Some(FUTURE_RESET + 60));
+        eras.entry(None)
+            .or_default()
+            .insert("5h".to_string(), unattributed.clone());
+        eras.entry(Some("owner@example.test".to_string()))
+            .or_default()
+            .insert("5h".to_string(), labeled.clone());
+        accounts.insert("claude-code".to_string(), eras);
+        let current: HashMap<String, crate::session_vitals::AccountEra> = HashMap::from([(
+            "claude-code".to_string(),
+            Some("owner@example.test".to_string()),
+        )]);
+        persist_account_limit_store(&path, &accounts, &current, 3).expect("persist");
 
         let loaded = load_account_limit_store(&path);
-        assert_eq!(loaded, accounts, "round-trip is lossless");
-        let window = &loaded["claude-code"]["5h"];
+        assert_eq!(loaded.limits, accounts, "round-trip is lossless");
+        assert_eq!(loaded.current, current, "current era registry survives");
+        assert_eq!(loaded.era_seq, 3, "era mint counter survives");
+        let window = &loaded.limits["claude-code"][&None]["5h"];
         assert_eq!(window.used_pct, None, "unreported percentage stays absent");
         assert_eq!(window.observed_at_epoch, Some(1_784_499_000));
+        assert_eq!(window.account, None);
+        assert_eq!(
+            loaded.limits["claude-code"][&Some("owner@example.test".to_string())]["5h"].account,
+            Some("owner@example.test".to_string()),
+            "same-label windows of two eras coexist on disk"
+        );
 
-        // Additive forward-compat: unknown fields anywhere are ignored.
+        // Additive forward-compat: unknown fields anywhere are ignored,
+        // and a pre-era file (no account stamps, no current_accounts)
+        // loads as the unattributed era.
         let raw = std::fs::read_to_string(&path).unwrap();
         let mut value: serde_json::Value = serde_json::from_str(&raw).unwrap();
         value["future_top_level"] = serde_json::json!({"x": 1});
         value["accounts"]["claude-code"][0]["futureField"] = serde_json::json!(true);
         std::fs::write(&path, serde_json::to_string(&value).unwrap()).unwrap();
         let loaded = load_account_limit_store(&path);
-        assert_eq!(loaded["claude-code"]["5h"].label, "5h");
+        assert_eq!(loaded.limits["claude-code"][&None]["5h"].label, "5h");
+        let legacy = serde_json::json!({
+            "version": 1,
+            "accounts": {
+                "claude-code": [
+                    { "label": "5h", "resetsAtEpoch": FUTURE_RESET, "status": "allowed" }
+                ]
+            }
+        });
+        std::fs::write(&path, legacy.to_string()).unwrap();
+        let loaded = load_account_limit_store(&path);
+        assert_eq!(
+            loaded.limits["claude-code"][&None]["5h"].status.as_deref(),
+            Some("allowed"),
+            "account-less files load as the unattributed era"
+        );
+        assert!(loaded.current.is_empty());
 
         // A future breaking version fails closed to empty.
         value["version"] = serde_json::json!(2);
         std::fs::write(&path, serde_json::to_string(&value).unwrap()).unwrap();
-        assert!(load_account_limit_store(&path).is_empty());
+        assert_eq!(
+            load_account_limit_store(&path),
+            AccountLimitStoreState::default()
+        );
 
         // Missing / corrupt files read as empty.
-        assert!(load_account_limit_store(&dir.path().join("gone.json")).is_empty());
+        assert_eq!(
+            load_account_limit_store(&dir.path().join("gone.json")),
+            AccountLimitStoreState::default()
+        );
         std::fs::write(&path, "{").unwrap();
-        assert!(load_account_limit_store(&path).is_empty());
+        assert_eq!(
+            load_account_limit_store(&path),
+            AccountLimitStoreState::default()
+        );
+    }
+
+    /// The commissioned lapsed-resets rule: an era bucket whose EVERY
+    /// window's provider-stated reset has passed expires at load AND at
+    /// persist, so a switched-out account's corpse can never resurrect
+    /// through the restore hydrator — while a bucket with any live (or
+    /// reset-less) window survives, legacy unattributed eras included.
+    #[test]
+    fn lapsed_resets_expire_at_load_and_persist() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("account-rate-limits.json");
+        let mut accounts: HashMap<String, crate::session_vitals::SourceLimitEras> = HashMap::new();
+        let mut eras = crate::session_vitals::SourceLimitEras::default();
+        // Fully-lapsed labeled era: both resets in the past.
+        let mut lapsed = BTreeMap::new();
+        lapsed.insert(
+            "5h".to_string(),
+            era_window("5h", Some("old@x"), Some(1_000)),
+        );
+        lapsed.insert(
+            "7d".to_string(),
+            era_window("7d", Some("old@x"), Some(2_000)),
+        );
+        eras.insert(Some("old@x".to_string()), lapsed);
+        // Live era: one window lapsed, one in the future — survives whole.
+        let mut live = BTreeMap::new();
+        live.insert(
+            "5h".to_string(),
+            era_window("5h", Some("new@x"), Some(1_000)),
+        );
+        live.insert(
+            "7d".to_string(),
+            era_window("7d", Some("new@x"), Some(FUTURE_RESET)),
+        );
+        eras.insert(Some("new@x".to_string()), live.clone());
+        // Reset-less window: nothing proves it stale; the bucket stays.
+        let mut resetless = BTreeMap::new();
+        resetless.insert("req/min".to_string(), era_window("req/min", None, None));
+        eras.insert(None, resetless.clone());
+        accounts.insert("claude-code".to_string(), eras);
+
+        // Persist-side: the lapsed bucket never reaches the file.
+        persist_account_limit_store(&path, &accounts, &HashMap::new(), 0).expect("persist");
+        let loaded = load_account_limit_store(&path);
+        let eras = &loaded.limits["claude-code"];
+        assert!(
+            !eras.contains_key(&Some("old@x".to_string())),
+            "fully-lapsed era dropped at persist"
+        );
+        assert_eq!(eras[&Some("new@x".to_string())], live);
+        assert_eq!(eras[&None], resetless, "reset-less legacy windows survive");
+
+        // Load-side: a file that still carries a fully-lapsed era (written
+        // by an older daemon) drops it at read.
+        let stale = serde_json::json!({
+            "version": 1,
+            "accounts": {
+                "claude-code": [
+                    { "label": "5h", "resetsAtEpoch": 1_000, "status": "allowed", "account": "old@x" },
+                    { "label": "7d", "resetsAtEpoch": FUTURE_RESET, "status": "allowed", "account": "new@x" }
+                ],
+                "codex": [
+                    { "label": "5h", "resetsAtEpoch": 1_000, "status": "allowed" }
+                ]
+            }
+        });
+        std::fs::write(&path, stale.to_string()).unwrap();
+        let loaded = load_account_limit_store(&path);
+        let eras = &loaded.limits["claude-code"];
+        assert!(
+            !eras.contains_key(&Some("old@x".to_string())),
+            "lapsed era dropped at load"
+        );
+        assert!(eras.contains_key(&Some("new@x".to_string())));
+        assert!(
+            !loaded.limits.contains_key("codex"),
+            "a source whose every era lapsed drops entirely"
+        );
     }
 
     /// End-to-end persistence: a report through one hub lands in the
@@ -1552,9 +1778,12 @@ mod tests {
         let window = SessionLimitWindow {
             label: "7d".into(),
             used_pct: None,
-            resets_at_epoch: Some(1_784_900_000),
+            // In the future: a lapsed window would (correctly) be reaped
+            // by the persist/load rule this fixture is not about.
+            resets_at_epoch: Some(FUTURE_RESET),
             status: Some("allowed".into()),
             observed_at_epoch: Some(1_784_499_000),
+            account: None,
         };
         hub.apply_rate_limit_windows("cc-1", vec![window.clone()]);
         // The persist may ride the blocking pool: wait for the file.

--- a/src/bin/caller/startup/daemon.rs
+++ b/src/bin/caller/startup/daemon.rs
@@ -158,6 +158,10 @@ pub(crate) async fn run_daemon(
     // effective target the dirty chip probes (activity locus included),
     // so the chip and the tab can never state different checkouts.
     session_vitals::publish_git_vitals_targets(&vitals_git_targets);
+    // Sign-in ceremonies announce their outcome on the bus (the vitals
+    // hub's credential-era boundary); same publish-from-startup law as
+    // the registries above so tests' manager use stays silent.
+    crate::auth_ceremony::publish_ceremony_bus(bus.clone());
     // Collision radar (Track C, C2 — ruled §2.1): periodic zero-LLM
     // detection over bus declarations ∪ observed git status (the same
     // registry the vitals prober probes) ∪ open-PR file sets; publishes

--- a/src/bin/caller/startup/headless.rs
+++ b/src/bin/caller/startup/headless.rs
@@ -500,6 +500,10 @@ pub(crate) async fn run_headless_mode(
     if let Some(registry) = vitals_git_targets.as_ref() {
         session_vitals::publish_git_vitals_targets(registry);
     }
+    // Mirrors daemon boot: ceremony outcomes reach the vitals hub's
+    // credential-era fold here too (the dashboard-on headless shape
+    // serves the same Vault sign-in routes).
+    crate::auth_ceremony::publish_ceremony_bus(bus.clone());
     // Restored sessions, mirroring daemon boot: with the dashboard on,
     // the store's idle session windows keep their git/health chips here
     // too, and their vitals hydrate from disk (this shape falls through

--- a/src/bin/caller/usage_rail.rs
+++ b/src/bin/caller/usage_rail.rs
@@ -281,6 +281,7 @@ mod tests {
             resets_at_epoch: None,
             status: None,
             observed_at_epoch: None,
+            account: None,
         }];
         let second = rail
             .on_event(&response(Some("s1"), with_limits))

--- a/static/app.html
+++ b/static/app.html
@@ -36904,7 +36904,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '70545ba64e0dc79d';
+const INTENDANT_APP_BUILD = 'a7ee1182fcbddecb';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -60524,10 +60524,26 @@ const VITALS_SEVERITY_RANK = { '': 0, ok: 0, warn: 1, crit: 2 };
 function vitalsLimitLabelLong(label) {
   if (label === '5h') return '5-hour';
   if (label === '7d') return '7-day';
-  if (label === '7d-overage') return '7-day overage';
+  // Claude's own product wording: the overage window is the paid "extra
+  // usage" allowance, and naming it a variant of "7-day" is what made
+  // two distinct gauges read as one chip rendered twice.
+  if (label === '7d-overage') return '7-day extra usage';
   // Unknown window names arrive as raw provider vocabulary — keep every
   // word (the pane owns the full name), just soften the wire spelling.
   return String(label || '').replace(/_/g, ' ').trim();
+}
+
+// Compact chip form of a window's credential-era account label. The
+// daemon sends `account` only while MORE than one credential era is live
+// for the backend (single-account steady state stays suffix-free), so
+// presence alone means "label this chip apart". Emails compress to their
+// local part — the pane and tooltips keep the full label.
+function vitalsLimitAccountShort(account) {
+  const raw = String(account || '').trim();
+  if (!raw) return '';
+  const at = raw.indexOf('@');
+  const short = at > 0 ? raw.slice(0, at) : raw;
+  return short.length > 14 ? `${short.slice(0, 13)}…` : short;
 }
 
 // Compact chip form of a limit-window label. Known labels pass through;
@@ -60538,6 +60554,9 @@ function vitalsLimitLabelLong(label) {
 // the full name stays available in the pane (vitalsLimitLabelLong).
 function vitalsLimitLabelShort(label) {
   const raw = String(label || '').trim();
+  // The 7-day overage window: "extra", never "-overage" — beside the base
+  // "7d" chip the shared prefix + hyphen chain read as a duplicate.
+  if (raw === '7d-overage') return '7d extra';
   // Already-compact daemon labels ("5h", "7d", "30d", "1w").
   if (/^\d+\s*(mo|[smhdw])$/i.test(raw)) return raw.replace(/\s+/g, '');
   const NUMBER_WORDS = {
@@ -60753,6 +60772,10 @@ const VITALS_ICON_PATHS = {
   triangle: '<path d="M12 3 22 20H2Z"/><path d="M12 10v4.5"/><path d="M12 17.5v.5"/>',
   push: '<path d="M12 19V7"/><path d="M7.5 11.5 12 7l4.5 4.5"/><path d="M6 3.5h12"/>',
   gauge: '<path d="M4.5 15.5a8 8 0 1 1 15 0"/><path d="M12 15l4-4.4"/>',
+  // The gauge with a "+" riding its top-right shoulder: the 7-day
+  // overage ("extra usage") window — visibly a sibling of the base
+  // gauge, never its pixel-identical twin.
+  'gauge-plus': '<path d="M4.5 15.5a8 8 0 1 1 15 0"/><path d="M12 15l4-4.4"/><path d="M18.5 3.5v5"/><path d="M16 6h5"/>',
   branch: '<path d="M6 4v11"/><circle cx="6" cy="19" r="2.4"/><circle cx="18" cy="6" r="2.4"/><path d="M18 8.4v2.2a4 4 0 0 1-4 4H10"/>',
   folder: '<rect x="4" y="4" width="12" height="12" rx="2.5"/><path d="M20 9v8.5A2.5 2.5 0 0 1 17.5 20H9"/>',
   pencil: '<path d="M14.5 5.5l4 4"/><path d="M4 20l1-4.5L15.5 5a2.12 2.12 0 0 1 3 3L8 18.5Z"/>',
@@ -61114,24 +61137,31 @@ const VITALS_SYMBOLS = {
     // window) until the next report. Chips always speak the SHORT window
     // grammar ("▮95% 7d-overage · ↻6:12:03") — a full provider sentence
     // in a header chip is the failure mode; the pane keeps the full name.
-    icon: 'gauge',
+    // The overage ("extra usage") window gets its own glyph: beside the
+    // base 7d chip a pixel-identical gauge is what made two real windows
+    // read as a duplicate.
+    icon: (v) => (String(v.label || '').includes('overage') ? 'gauge-plus' : 'gauge'),
     chip: (v) => {
       const label = vitalsLimitLabelShort(v.label);
-      if (v.rolled) return `${label} reset`;
+      const acct = vitalsLimitAccountShort(v.account);
+      const suffix = acct ? ` · ${acct}` : '';
+      if (v.rolled) return `${label} reset${suffix}`;
       const reset = v.reset ? ` · ↻${v.reset}` : '';
-      if (v.usedPct !== null) return `▮${v.usedPct}% ${label}${reset}`;
+      if (v.usedPct !== null) return `▮${v.usedPct}% ${label}${reset}${suffix}`;
       const mark = v.severity === 'crit' ? '⛔' : v.severity === 'warn' ? '⚠' : v.statusWord;
-      return `${label} ${mark}${reset}`;
+      return `${label} ${mark}${reset}${suffix}`;
     },
     // Fact-line twin of the chip grammar: the gauge icon plus severity
     // color carry what the ⛔/⚠/▮ glyphs said, so the mark is always the
     // provider's word.
     factText: (v) => {
       const label = vitalsLimitLabelShort(v.label);
-      if (v.rolled) return `${label} reset`;
+      const acct = vitalsLimitAccountShort(v.account);
+      const suffix = acct ? ` · ${acct}` : '';
+      if (v.rolled) return `${label} reset${suffix}`;
       const reset = v.reset ? ` · ↻${v.reset}` : '';
-      if (v.usedPct !== null) return `${v.usedPct}% ${label}${reset}`;
-      return `${label} ${v.statusWord}${reset}`;
+      if (v.usedPct !== null) return `${v.usedPct}% ${label}${reset}${suffix}`;
+      return `${label} ${v.statusWord}${reset}${suffix}`;
     },
     explain: (v) => {
       const lines = [];
@@ -61148,6 +61178,7 @@ const VITALS_SYMBOLS = {
       if (v.reset) lines.push(`The window resets in ${v.reset}${wall ? ` — at ${wall}` : ''}.`);
       if (v.severity === 'crit') lines.push('When an allowance runs out, the provider pauses this agent until the window resets.');
       else if (v.severity === 'warn') lines.push('If the window fills up, the provider will pause this agent until it resets.');
+      if (v.account) lines.push(`This window belongs to the “${v.account}” sign-in — sessions running under a different account track their own windows.`);
       if (v.observedAgo) lines.push(`Last provider report: ${v.observedAgo} ago. Windows are account-wide, so any session's report updates this.`);
       return lines;
     },
@@ -61445,6 +61476,10 @@ function vitalsChipModels(vitals, meta, sessionId) {
     const observedAgoSecs = Number.isFinite(observedAt) && observedAt > 0
       ? Math.floor(Date.now() / 1000 - observedAt)
       : null;
+    // Credential-era attribution: present only while the daemon sees
+    // more than one live era for the backend — the cue to suffix the
+    // chip apart from another account's same-named window.
+    const account = String(w?.account || '').trim();
     push('limit', `limit:${label}`, {
       label,
       usedPct,
@@ -61452,6 +61487,7 @@ function vitalsChipModels(vitals, meta, sessionId) {
       reset,
       resetsAtEpoch: Number(w?.resetsAtEpoch) || 0,
       rolled,
+      account,
       observedAgo: observedAgoSecs !== null && observedAgoSecs > 120
         ? formatActivityElapsed(observedAgoSecs)
         : '',
@@ -61461,7 +61497,7 @@ function vitalsChipModels(vitals, meta, sessionId) {
       // The countdown ticks in place (cache-ttl pattern): the sig excludes
       // it so the 1 Hz ticker hits the stable-DOM fast path.
       ticking: !!reset,
-      sig: `${label}|${usedPct}|${w?.status || ''}|${severity}|${rolled ? 1 : 0}`,
+      sig: `${label}|${usedPct}|${w?.status || ''}|${severity}|${rolled ? 1 : 0}|${account}`,
     });
   }
 
@@ -61585,6 +61621,16 @@ function vitalsAttentionSummary(models) {
   };
 }
 
+// One aria grammar for the attention chip, shared by the build and the
+// 1 Hz in-place ticker so the announced text can never lag the visible
+// countdown.
+function vitalsAttentionAriaLabel(attention) {
+  const top = `${attention.top.label}: ${attention.top.factText || attention.top.text}`;
+  return attention.aggregate
+    ? `${top}, plus ${attention.extra} more — show all vitals`
+    : top;
+}
+
 // Renders the chip row; returns true while a cache countdown is live (the
 // vitals ticker keeps re-rendering until everything is cold or gone).
 //
@@ -61636,15 +61682,19 @@ function renderSessionWindowVitals(win, vitals) {
     .join('|');
   if (win.vitals.dataset.vitSig === signature) {
     // Every ticking model updates in place by id — cache-ttl, activity,
-    // and each limit window's exact reset countdown.
+    // and each limit window's exact reset countdown. The aria-label
+    // carries the same countdown text, so it ticks too: a screen reader
+    // must never be read a staler countdown than the one on screen.
     const tickingById = new Map(models.filter((m) => m.ticking).map((m) => [m.id, m]));
     if (tickingById.size) {
       for (const chip of win.vitals.querySelectorAll('.vit-chip')) {
         const model = tickingById.get(chip.dataset.chip || '');
         if (!model) continue;
+        const factText = model.factText || model.text;
         const txt = chip.querySelector('.vit-txt');
-        if (txt) txt.textContent = model.factText || model.text;
+        if (txt) txt.textContent = factText;
         chip.title = model.explainLines[0] || model.label;
+        chip.setAttribute('aria-label', factText ? `${model.label}: ${factText}` : model.label);
       }
     }
     // The attention chip mirrors its top model's text (elapsed/quiet
@@ -61655,6 +61705,7 @@ function renderSessionWindowVitals(win, vitals) {
       const attnTxt = attnChip.querySelector('.vit-txt');
       if (attention && attnTxt && attnTxt.textContent !== attention.factText) {
         attnTxt.textContent = attention.factText;
+        attnChip.setAttribute('aria-label', vitalsAttentionAriaLabel(attention));
       }
     }
     return models.some((m) => m.ticking);
@@ -61707,9 +61758,7 @@ function renderSessionWindowVitals(win, vitals) {
     attn.title = attention.aggregate
       ? 'Needs attention — show all vitals'
       : (attention.top.explainLines[0] || attention.top.label);
-    attn.setAttribute('aria-label', attention.aggregate
-      ? `${attention.top.label}: ${attention.top.factText || attention.top.text}, plus ${attention.extra} more — show all vitals`
-      : `${attention.top.label}: ${attention.top.factText || attention.top.text}`);
+    attn.setAttribute('aria-label', vitalsAttentionAriaLabel(attention));
     healthNodes.push(attn);
   }
   if (foldedWhenCollapsed > 0) {

--- a/static/app/39-session-windows.js
+++ b/static/app/39-session-windows.js
@@ -966,10 +966,26 @@ const VITALS_SEVERITY_RANK = { '': 0, ok: 0, warn: 1, crit: 2 };
 function vitalsLimitLabelLong(label) {
   if (label === '5h') return '5-hour';
   if (label === '7d') return '7-day';
-  if (label === '7d-overage') return '7-day overage';
+  // Claude's own product wording: the overage window is the paid "extra
+  // usage" allowance, and naming it a variant of "7-day" is what made
+  // two distinct gauges read as one chip rendered twice.
+  if (label === '7d-overage') return '7-day extra usage';
   // Unknown window names arrive as raw provider vocabulary — keep every
   // word (the pane owns the full name), just soften the wire spelling.
   return String(label || '').replace(/_/g, ' ').trim();
+}
+
+// Compact chip form of a window's credential-era account label. The
+// daemon sends `account` only while MORE than one credential era is live
+// for the backend (single-account steady state stays suffix-free), so
+// presence alone means "label this chip apart". Emails compress to their
+// local part — the pane and tooltips keep the full label.
+function vitalsLimitAccountShort(account) {
+  const raw = String(account || '').trim();
+  if (!raw) return '';
+  const at = raw.indexOf('@');
+  const short = at > 0 ? raw.slice(0, at) : raw;
+  return short.length > 14 ? `${short.slice(0, 13)}…` : short;
 }
 
 // Compact chip form of a limit-window label. Known labels pass through;
@@ -980,6 +996,9 @@ function vitalsLimitLabelLong(label) {
 // the full name stays available in the pane (vitalsLimitLabelLong).
 function vitalsLimitLabelShort(label) {
   const raw = String(label || '').trim();
+  // The 7-day overage window: "extra", never "-overage" — beside the base
+  // "7d" chip the shared prefix + hyphen chain read as a duplicate.
+  if (raw === '7d-overage') return '7d extra';
   // Already-compact daemon labels ("5h", "7d", "30d", "1w").
   if (/^\d+\s*(mo|[smhdw])$/i.test(raw)) return raw.replace(/\s+/g, '');
   const NUMBER_WORDS = {
@@ -1195,6 +1214,10 @@ const VITALS_ICON_PATHS = {
   triangle: '<path d="M12 3 22 20H2Z"/><path d="M12 10v4.5"/><path d="M12 17.5v.5"/>',
   push: '<path d="M12 19V7"/><path d="M7.5 11.5 12 7l4.5 4.5"/><path d="M6 3.5h12"/>',
   gauge: '<path d="M4.5 15.5a8 8 0 1 1 15 0"/><path d="M12 15l4-4.4"/>',
+  // The gauge with a "+" riding its top-right shoulder: the 7-day
+  // overage ("extra usage") window — visibly a sibling of the base
+  // gauge, never its pixel-identical twin.
+  'gauge-plus': '<path d="M4.5 15.5a8 8 0 1 1 15 0"/><path d="M12 15l4-4.4"/><path d="M18.5 3.5v5"/><path d="M16 6h5"/>',
   branch: '<path d="M6 4v11"/><circle cx="6" cy="19" r="2.4"/><circle cx="18" cy="6" r="2.4"/><path d="M18 8.4v2.2a4 4 0 0 1-4 4H10"/>',
   folder: '<rect x="4" y="4" width="12" height="12" rx="2.5"/><path d="M20 9v8.5A2.5 2.5 0 0 1 17.5 20H9"/>',
   pencil: '<path d="M14.5 5.5l4 4"/><path d="M4 20l1-4.5L15.5 5a2.12 2.12 0 0 1 3 3L8 18.5Z"/>',
@@ -1556,24 +1579,31 @@ const VITALS_SYMBOLS = {
     // window) until the next report. Chips always speak the SHORT window
     // grammar ("▮95% 7d-overage · ↻6:12:03") — a full provider sentence
     // in a header chip is the failure mode; the pane keeps the full name.
-    icon: 'gauge',
+    // The overage ("extra usage") window gets its own glyph: beside the
+    // base 7d chip a pixel-identical gauge is what made two real windows
+    // read as a duplicate.
+    icon: (v) => (String(v.label || '').includes('overage') ? 'gauge-plus' : 'gauge'),
     chip: (v) => {
       const label = vitalsLimitLabelShort(v.label);
-      if (v.rolled) return `${label} reset`;
+      const acct = vitalsLimitAccountShort(v.account);
+      const suffix = acct ? ` · ${acct}` : '';
+      if (v.rolled) return `${label} reset${suffix}`;
       const reset = v.reset ? ` · ↻${v.reset}` : '';
-      if (v.usedPct !== null) return `▮${v.usedPct}% ${label}${reset}`;
+      if (v.usedPct !== null) return `▮${v.usedPct}% ${label}${reset}${suffix}`;
       const mark = v.severity === 'crit' ? '⛔' : v.severity === 'warn' ? '⚠' : v.statusWord;
-      return `${label} ${mark}${reset}`;
+      return `${label} ${mark}${reset}${suffix}`;
     },
     // Fact-line twin of the chip grammar: the gauge icon plus severity
     // color carry what the ⛔/⚠/▮ glyphs said, so the mark is always the
     // provider's word.
     factText: (v) => {
       const label = vitalsLimitLabelShort(v.label);
-      if (v.rolled) return `${label} reset`;
+      const acct = vitalsLimitAccountShort(v.account);
+      const suffix = acct ? ` · ${acct}` : '';
+      if (v.rolled) return `${label} reset${suffix}`;
       const reset = v.reset ? ` · ↻${v.reset}` : '';
-      if (v.usedPct !== null) return `${v.usedPct}% ${label}${reset}`;
-      return `${label} ${v.statusWord}${reset}`;
+      if (v.usedPct !== null) return `${v.usedPct}% ${label}${reset}${suffix}`;
+      return `${label} ${v.statusWord}${reset}${suffix}`;
     },
     explain: (v) => {
       const lines = [];
@@ -1590,6 +1620,7 @@ const VITALS_SYMBOLS = {
       if (v.reset) lines.push(`The window resets in ${v.reset}${wall ? ` — at ${wall}` : ''}.`);
       if (v.severity === 'crit') lines.push('When an allowance runs out, the provider pauses this agent until the window resets.');
       else if (v.severity === 'warn') lines.push('If the window fills up, the provider will pause this agent until it resets.');
+      if (v.account) lines.push(`This window belongs to the “${v.account}” sign-in — sessions running under a different account track their own windows.`);
       if (v.observedAgo) lines.push(`Last provider report: ${v.observedAgo} ago. Windows are account-wide, so any session's report updates this.`);
       return lines;
     },
@@ -1887,6 +1918,10 @@ function vitalsChipModels(vitals, meta, sessionId) {
     const observedAgoSecs = Number.isFinite(observedAt) && observedAt > 0
       ? Math.floor(Date.now() / 1000 - observedAt)
       : null;
+    // Credential-era attribution: present only while the daemon sees
+    // more than one live era for the backend — the cue to suffix the
+    // chip apart from another account's same-named window.
+    const account = String(w?.account || '').trim();
     push('limit', `limit:${label}`, {
       label,
       usedPct,
@@ -1894,6 +1929,7 @@ function vitalsChipModels(vitals, meta, sessionId) {
       reset,
       resetsAtEpoch: Number(w?.resetsAtEpoch) || 0,
       rolled,
+      account,
       observedAgo: observedAgoSecs !== null && observedAgoSecs > 120
         ? formatActivityElapsed(observedAgoSecs)
         : '',
@@ -1903,7 +1939,7 @@ function vitalsChipModels(vitals, meta, sessionId) {
       // The countdown ticks in place (cache-ttl pattern): the sig excludes
       // it so the 1 Hz ticker hits the stable-DOM fast path.
       ticking: !!reset,
-      sig: `${label}|${usedPct}|${w?.status || ''}|${severity}|${rolled ? 1 : 0}`,
+      sig: `${label}|${usedPct}|${w?.status || ''}|${severity}|${rolled ? 1 : 0}|${account}`,
     });
   }
 
@@ -2027,6 +2063,16 @@ function vitalsAttentionSummary(models) {
   };
 }
 
+// One aria grammar for the attention chip, shared by the build and the
+// 1 Hz in-place ticker so the announced text can never lag the visible
+// countdown.
+function vitalsAttentionAriaLabel(attention) {
+  const top = `${attention.top.label}: ${attention.top.factText || attention.top.text}`;
+  return attention.aggregate
+    ? `${top}, plus ${attention.extra} more — show all vitals`
+    : top;
+}
+
 // Renders the chip row; returns true while a cache countdown is live (the
 // vitals ticker keeps re-rendering until everything is cold or gone).
 //
@@ -2078,15 +2124,19 @@ function renderSessionWindowVitals(win, vitals) {
     .join('|');
   if (win.vitals.dataset.vitSig === signature) {
     // Every ticking model updates in place by id — cache-ttl, activity,
-    // and each limit window's exact reset countdown.
+    // and each limit window's exact reset countdown. The aria-label
+    // carries the same countdown text, so it ticks too: a screen reader
+    // must never be read a staler countdown than the one on screen.
     const tickingById = new Map(models.filter((m) => m.ticking).map((m) => [m.id, m]));
     if (tickingById.size) {
       for (const chip of win.vitals.querySelectorAll('.vit-chip')) {
         const model = tickingById.get(chip.dataset.chip || '');
         if (!model) continue;
+        const factText = model.factText || model.text;
         const txt = chip.querySelector('.vit-txt');
-        if (txt) txt.textContent = model.factText || model.text;
+        if (txt) txt.textContent = factText;
         chip.title = model.explainLines[0] || model.label;
+        chip.setAttribute('aria-label', factText ? `${model.label}: ${factText}` : model.label);
       }
     }
     // The attention chip mirrors its top model's text (elapsed/quiet
@@ -2097,6 +2147,7 @@ function renderSessionWindowVitals(win, vitals) {
       const attnTxt = attnChip.querySelector('.vit-txt');
       if (attention && attnTxt && attnTxt.textContent !== attention.factText) {
         attnTxt.textContent = attention.factText;
+        attnChip.setAttribute('aria-label', vitalsAttentionAriaLabel(attention));
       }
     }
     return models.some((m) => m.ticking);
@@ -2149,9 +2200,7 @@ function renderSessionWindowVitals(win, vitals) {
     attn.title = attention.aggregate
       ? 'Needs attention — show all vitals'
       : (attention.top.explainLines[0] || attention.top.label);
-    attn.setAttribute('aria-label', attention.aggregate
-      ? `${attention.top.label}: ${attention.top.factText || attention.top.text}, plus ${attention.extra} more — show all vitals`
-      : `${attention.top.label}: ${attention.top.factText || attention.top.text}`);
+    attn.setAttribute('aria-label', vitalsAttentionAriaLabel(attention));
     healthNodes.push(attn);
   }
   if (foldedWhenCollapsed > 0) {


### PR DESCRIPTION
The limits fold was keyed (backend, label) with no account identity
anywhere on the wire, struct, store, or index — so two accounts' same-
label windows overwrote each other (freshest-observed wins; proven live
as a 5h reset anchor jumping backward within minutes) while stale
entries were immortal (session end keeps the store, credential reload
never touched vitals, restart re-mirrored, nothing expired a label).

Daemon:
- SessionLimitWindow gains an additive account field (the credential-era
  stamp; absent = the unattributed era, so old stores and wires load
  unchanged).
- Sign-in ceremony success announces the account on the bus
  (BackendCredentialAccount via a startup-published ceremony bus);
  the vitals hub opens a new era per source — label from the probe
  email, minted era-N nonce when label-less.
- Membership is (source, era), stamped at every SessionIdentity: spawns
  AND reload respawns re-key (backends read credentials at process
  start). Re-links never re-seed the session's mirrored windows into the
  new era.
- Eviction: a re-key or session end that empties a NON-active era
  retires its bucket (the active era survives memberless as account
  truth); era buckets whose every window's reset has lapsed expire at
  store load and persist, so corpses cannot resurrect through the
  restore hydrator.
- Mirrors deliver each session ITS era's windows, account-stamped only
  while more than one era has live members (the chip-suffix cue; the
  unattributed era never stamps — nothing truthful to label it with).
- The store file stays version 1: windows carry their era stamp, plus
  additive current_accounts and era_seq registries.

SPA (fragments; app.html regenerated):
- Chips suffix the account short label only when the daemon stamped one.
- The 7-day overage window reads '7d extra' / '7-day extra usage' with
  its own gauge-plus glyph, in the single vitals label map.
- The 1 Hz in-place ticker now refreshes aria-labels (chips and the
  attention chip, through one shared aria grammar).

Pins: limit_windows_keyed_by_account_era,
stale_era_windows_evict_on_last_member_end,
reload_rekeys_membership_and_retires_old_era,
lapsed_resets_expire_at_load_and_persist,
chips_suffix_account_only_when_multiple_eras,
overage_window_labeled_distinct_in_the_single_map,
aria_countdown_tracks_ticker.
