### PR TITLE
feat(dashboard): Track AW slice 3 — Automate surfaces consume the served catalog + stamp op

### DIFF
--- a/docs/src/agenda-and-memory.md
+++ b/docs/src/agenda-and-memory.md
@@ -693,6 +693,12 @@ after "Later" renders exactly what was sealed. From the CLI,
 [--every INTERVAL] [--suspend-after N] [--agent …]` rides the ordinary
 op lane (works from owner shells and supervised sessions alike);
 approval stays per-effect on the dashboard or `ctl agenda approve`.
+The dashboard's Automate sheet and its workflow/triggered pickers
+consume exactly these surfaces: the picker renders the served catalog
+(invalid and shadowed entries stay visible, disabled with their
+reason), the preview shows the full text a stamp would seal, and every
+stamp rides the stamp op — the sheet neither proposes nor approves
+client-side.
 
 ### The housekeeping recipe
 
@@ -892,19 +898,23 @@ Run now (`request_occurrence`), Revoke, and re-approve-to-re-arm.
 
 ### The fix-task workflow
 
-Workflow templates (Track T) generalize create-from-template from one
-item to a small item-graph. **Stamping** one instance — a workflow
-entry in the automate sheet's picker — parks, over the ordinary op
-lane, an instance **hub whose body is the workflow's living
-orientation document** (an ordinary G2 hub, never a workflow object),
-one task per node placed under it, the `relies_on` edges, and one
-`on_unblock`-triggered manifest per node. Stamping never approves —
-that pin stands. The flow then opens the **approval sheet**: the
-orientation, every node's full goal text and executor, and one
-committed recommendation; the owner's single confirm emits one
-ordinary `approve_effect` per node (the UI batches; the ops stay
-per-effect and attributed; nothing cascades; "Later" leaves everything
-parked with pending digests on the ordinary cards). Once armed, the
+Workflow definitions (Track T → AW) generalize create-from-definition
+from one item to a small item-graph. **Stamping** one instance — a
+workflow entry in the automate sheet's picker — is one daemon-side
+stamp op: the daemon reads, validates, and seals the definition, parks
+an instance **hub whose body is the workflow's living orientation
+document** (an ordinary G2 hub, never a workflow object), one task per
+node placed under it, the `relies_on` edges, and one
+`on_unblock`-triggered manifest per node, every manifest pinning the
+sealed definition as a binding ref. Stamping never approves — that pin
+stands. The flow then opens the **approval sheet**: the sealed
+definition rendered once in full (fetched from the content-addressed
+serving lane — exactly the bytes every node's manifest pins), each
+node's executor and digest chip, and one committed recommendation; the
+owner's single confirm emits one ordinary `approve_effect` per node
+(the UI batches; the ops stay per-effect and attributed; nothing
+cascades; "Later" leaves everything parked with pending digests on the
+ordinary cards). Once armed, the
 first node fires on approval and each completion unblocks the next —
 the trigger machinery above, nothing workflow-specific. A failing node
 suspends its own lane (re-approve to re-arm); revoking one node's

--- a/src/bin/caller/web_gateway/static_assets.rs
+++ b/src/bin/caller/web_gateway/static_assets.rs
@@ -777,6 +777,119 @@ mod tests {
         assert!(inspector.contains("Re-proposed since your last approval"));
     }
 
+    /// Track AW slice 3, the automate-sheet half of the emission-shape
+    /// law, retargeted to the generic served-catalog flow (the
+    /// mandate_templates.rs twin of this pin dies with the registry at
+    /// cutover; this copy carries the law forward): the sheet consumes
+    /// the served definition catalog and stamps through the daemon's
+    /// stamp op — it neither proposes nor approves client-side, so the
+    /// owner's per-effect digest ceremony stays the only arming act.
+    #[test]
+    fn automate_sheet_consumes_the_catalog_and_never_approves() {
+        let sheet = include_str!("../../../../static/app/ui2-agenda.js");
+        assert!(
+            sheet.contains("api_agenda_definitions"),
+            "the automate sheet must read the served definition catalog"
+        );
+        assert!(
+            sheet.contains("api_agenda_stamp"),
+            "the automate sheet must stamp through the daemon's stamp op"
+        );
+        assert_eq!(
+            sheet.matches("approve_effect").count(),
+            0,
+            "the automate sheet cannot approve — the ceremony stays the owner's"
+        );
+        assert_eq!(
+            sheet.matches("propose_effect").count(),
+            0,
+            "the sheet stamps through the daemon — client-side proposing was the registry era"
+        );
+        // Refusals stay visible: invalid and shadowed entries render
+        // disabled with their reason, never hidden.
+        assert!(sheet.contains("invalid definition"));
+        assert!(sheet.contains("shadowed by a personal definition of the same name"));
+    }
+
+    /// Track AW slice 3, the workflow half of the emission-shape law,
+    /// retargeted to the generic flow (twin of
+    /// workflow_approval_sheet_approves_only_in_the_owner_confirm_lane
+    /// in mandate_templates.rs, which dies with the registry at
+    /// cutover): the workflow and triggered lanes stamp through the
+    /// daemon (no client-side graph assembly survives), the approval
+    /// sheet renders the sealed bytes from the content-addressed
+    /// serving lane, and the approval lane stays exactly one emitter —
+    /// one `approve_effect`, inside `agendaWorkflowEmitApprovals`,
+    /// iterating exactly the stamped node set, called once from the
+    /// owner-confirm handler.
+    #[test]
+    fn workflow_surfaces_stamp_through_the_daemon_with_one_emitter() {
+        let fragment = include_str!("../../../../static/app/ui2-agenda-workflows.js");
+        assert!(
+            fragment.contains("api_agenda_stamp"),
+            "the workflow lanes must stamp through the daemon's stamp op"
+        );
+        assert!(
+            fragment.contains("api_agenda_sealed"),
+            "the approval sheet must render the sealed bytes from the serving lane"
+        );
+        // The daemon owns graph assembly now: no client-side parking,
+        // placing, edge-drawing, or proposing survives in this fragment.
+        for gone in [
+            "add_relies_on",
+            "propose_effect",
+            "op: 'place'",
+            "op: 'add'",
+        ] {
+            assert_eq!(
+                fragment.matches(gone).count(),
+                0,
+                "client-side graph assembly must not survive the stamp-op rewire: found {gone:?}"
+            );
+        }
+        // The emission shape, unweakened: exactly one approve_effect in
+        // the fragment, inside the single pinned emitter, iterating the
+        // stamped node set, with exactly one call site that lives in the
+        // owner-confirm handler.
+        assert_eq!(
+            fragment.matches("approve_effect").count(),
+            1,
+            "the fragment must contain exactly one approval emission site"
+        );
+        let (_, emitter) = fragment
+            .split_once("async function agendaWorkflowEmitApprovals(")
+            .expect("the pinned emitter must exist");
+        let body = emitter
+            .split_once("\n}")
+            .expect("the emitter body must close")
+            .0;
+        assert!(
+            body.contains("for (const node of batch.nodes)"),
+            "the emitter iterates exactly the stamped node set"
+        );
+        assert!(
+            body.contains("approve_effect"),
+            "the one emission lives inside the pinned emitter"
+        );
+        assert_eq!(
+            fragment
+                .matches("agendaWorkflowEmitApprovals(stamped)")
+                .count(),
+            1,
+            "exactly one call site invokes the emitter"
+        );
+        let confirm = fragment
+            .find("async function agendaWorkflowApproveConfirm(")
+            .expect("the owner-confirm handler must exist");
+        let call = fragment
+            .find("agendaWorkflowEmitApprovals(stamped)")
+            .expect("the emitter call site must exist");
+        assert!(
+            call > confirm,
+            "the emitter is called from the owner-confirm handler, nowhere earlier"
+        );
+    }
+
     /// The ledger search executes SPA-side — `agendaSearchMatch` filters
     /// the served item snapshot in the browser (the daemon serves items
     /// unfiltered) — so the digest lane is pinned at the fragment:

--- a/static/app.html
+++ b/static/app.html
@@ -36915,7 +36915,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'cc7584ed9537a0c1';
+const INTENDANT_APP_BUILD = '927366ab0c379dfa';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -91673,12 +91673,13 @@ function agendaPositionCard() {
   else document.addEventListener('DOMContentLoaded', wire, { once: true });
 }
 
-// ---- Mandate template library (Track AU) ----
-// The create-from-template picker's data: PINNED copies of the daemon's
-// registry (src/bin/caller/agenda/mandate_templates.rs — the source of
-// truth; its parity test fails if these bytes drift). A template is data
-// the owner reads and approves — the flow parks the item and proposes
-// the effect, and NEVER approves: the digest ceremony stays the owner's.
+// ---- Mandate template library (Track AU → AW migration window) ----
+// PINNED copies of the daemon's registry (src/bin/caller/agenda/
+// mandate_templates.rs — its parity tests fail if these bytes drift).
+// Since Track AW slice 3 the sheet reads the SERVED definition catalog
+// (below) instead of this table — it survives only as the migration
+// window's parity anchor, deleted together with the registry and the
+// other two tables in the cutover PR.
 const AGENDA_MANDATE_TEMPLATES = [
   {
     id: 'triage',
@@ -91778,14 +91779,57 @@ you.`,
   },
 ];
 
-// ---- Create-from-template: the Automate sheet (Track AU) ----
-// The ctl walkthrough as a guided flow: pick a mandate template, read
-// the FULL text (data the owner reads — never hidden or truncated),
-// choose cadence, first fire, and executor, then PARK the item and
-// PROPOSE the standing effect. The flow never approves — it lands the
-// owner on the ordinary card whose Approve affordance binds the digest;
-// the ceremony stays the owner's untouched final act (a registry
-// parity test pins this fragment approve-free).
+// ---- Served definition catalog (Track AW) ----
+// The Automate surfaces' data source: the daemon-served catalog
+// (GET /api/agenda/definitions). Every entry carries its validation
+// state, advisories, and the FULL definition text — exactly the bytes
+// a stamp of that entry would seal. Fetched on sheet open; cached so a
+// reopen paints instantly and refreshes in place. Invalid and shadowed
+// entries stay VISIBLE (disabled, with the reason) — the catalog never
+// hides a refusal.
+let agendaDefinitionCatalog = null; // null = never fetched; else the entries array
+let agendaDefinitionCatalogError = '';
+let agendaDefinitionCatalogLoading = false;
+
+function agendaFetchDefinitionCatalog(onSettled) {
+  if (agendaDefinitionCatalogLoading) return;
+  agendaDefinitionCatalogLoading = true;
+  daemonApi.request('api_agenda_definitions', {})
+    .then((res) => {
+      if (res.ok && res.body && Array.isArray(res.body.definitions)) {
+        agendaDefinitionCatalog = res.body.definitions;
+        agendaDefinitionCatalogError = '';
+      } else {
+        agendaDefinitionCatalogError =
+          (res.body && res.body.error) || `catalog fetch failed (${res.status})`;
+      }
+    })
+    .catch((e) => { agendaDefinitionCatalogError = String((e && e.message) || e); })
+    .finally(() => {
+      agendaDefinitionCatalogLoading = false;
+      if (typeof onSettled === 'function') onSettled();
+    });
+}
+
+// Catalog view: the cadenced actions drive the automate sheet itself;
+// triggered actions and workflows render through the workflows
+// fragment's picker hook off the same fetch.
+function agendaCatalogActions(entries) {
+  return (entries || []).filter((d) => !d.workflow
+    && !(((d.nodes && d.nodes[0]) || {}).trigger_kind));
+}
+
+// ---- Create-from-definition: the Automate sheet (Track AU → AW) ----
+// The ctl walkthrough as a guided flow: pick a definition from the
+// served catalog, read the FULL text (data the owner reads — never
+// hidden or truncated; exactly what a stamp seals), choose cadence,
+// first fire, and executor, then STAMP through the daemon's stamp op —
+// the daemon reads, validates, and seals the definition, PARKS the item
+// and PROPOSES the standing effect with the sheet's choices as prefills
+// into the ordinary manifest intake. The flow never approves — it lands
+// the owner on the ordinary card whose Approve affordance binds the
+// digest; the ceremony stays the owner's untouched final act (a parity
+// test pins this fragment approve-free).
 
 let agendaAutomationSheetOpen = false;
 
@@ -91845,7 +91889,8 @@ function agendaOpenAutomationSheet(anchor) {
   const panel = host.querySelector('.ags-panel');
   panel.textContent = '';
   agendaAutomationSheetOpen = true;
-  let template = AGENDA_MANDATE_TEMPLATES[0];
+  let entry = null; // the selected cadenced-action catalog entry
+  let selectedName = '';
 
   const head = agendaStartSheetEl('div', 'ags-head');
   head.appendChild(agendaStartSheetEl('span', 'ags-title', 'New automation'));
@@ -91856,16 +91901,16 @@ function agendaOpenAutomationSheet(anchor) {
   head.appendChild(close);
   panel.appendChild(head);
   panel.appendChild(agendaStartSheetEl('div', 'ags-sub',
-    'A standing supervised session on a cadence. This parks the mandate as an item and proposes its schedule — nothing runs until you approve the digest on the card.'));
+    'A standing supervised session on a cadence. Stamping seals the definition, parks it as an item, and proposes its schedule — nothing runs until you approve the digest on the card.'));
 
-  // Template picker.
+  // Definition picker (served catalog).
   const seg = agendaStartSheetEl('div', 'ags-seg agsx-templates');
   panel.appendChild(seg);
 
-  // Full mandate text — the owner reads exactly what the session will
-  // receive; textContent rendering, no markup execution.
+  // Full definition text — the owner reads exactly the bytes a stamp
+  // seals; textContent rendering, no markup execution.
   panel.appendChild(agendaStartSheetEl('label', 'ags-label',
-    'The mandate — the full text the session receives, and the item body'));
+    'The definition — the full text a stamp seals; approval binds exactly this revision'));
   const preview = agendaStartSheetEl('pre', 'agsx-preview');
   panel.appendChild(preview);
 
@@ -92011,50 +92056,98 @@ function agendaOpenAutomationSheet(anchor) {
   const park = agendaStartSheetEl('button', 'ags-btn ags-start', 'Park + propose');
   park.type = 'button';
   park.addEventListener('click', () => agendaAutomationSheetSubmit(
-    { template: () => template, cadence, fire, suspend, project, configState, error, park }));
+    { entry: () => entry, cadence, fire, suspend, project, configState, error, park }));
   foot.appendChild(cancel);
   foot.appendChild(park);
   panel.appendChild(foot);
 
-  const applyTemplate = () => {
+  const applyEntry = () => {
     seg.querySelectorAll('button').forEach((b) =>
-      b.classList.toggle('active', b.dataset.template === template.id));
-    preview.textContent = template.mandate;
-    cadence.value = String(template.everyMs);
-    suspend.value = String(template.suspendAfter);
+      b.classList.toggle('active', !!entry && b.dataset.definition === entry.name));
+    if (!entry) {
+      preview.textContent = agendaDefinitionCatalog === null && !agendaDefinitionCatalogError
+        ? 'Loading the definition catalog…'
+        : (agendaDefinitionCatalogError
+          ? `Definition catalog unavailable: ${agendaDefinitionCatalogError}`
+          : 'No stampable cadenced definitions in the catalog.');
+      park.disabled = true;
+      return;
+    }
+    park.disabled = false;
+    preview.textContent = entry.text;
+    const prefill = (entry.nodes && entry.nodes[0]) || {};
+    if (prefill.every_ms) {
+      const ms = String(prefill.every_ms);
+      if (!Array.from(cadence.options).some((o) => o.value === ms)) {
+        const option = document.createElement('option');
+        option.value = ms;
+        option.textContent = 'Definition default';
+        cadence.appendChild(option);
+      }
+      cadence.value = ms;
+    }
+    if (prefill.suspend_after) suspend.value = String(prefill.suspend_after);
+    else if (!suspend.value) suspend.value = '3';
   };
-  for (const t of AGENDA_MANDATE_TEMPLATES) {
-    const btn = agendaStartSheetEl('button', 'ags-seg-btn', t.title);
-    btn.type = 'button';
-    btn.dataset.template = t.id;
-    btn.addEventListener('click', () => { template = t; applyTemplate(); });
-    seg.appendChild(btn);
-  }
-  // Workflow templates (Track T) stamp an item-graph and hand off to
-  // their own approval sheet — rendered by the workflows fragment,
-  // which owns that whole lane.
-  if (typeof agendaWorkflowRenderPickerButtons === 'function') {
-    agendaWorkflowRenderPickerButtons(seg, agendaCloseAutomationSheet,
-      () => project.value.trim());
-  }
-  applyTemplate();
+  const selectable = (d) => d.valid && !d.shadowed;
+  const renderPicker = () => {
+    seg.textContent = '';
+    const actions = agendaCatalogActions(agendaDefinitionCatalog);
+    entry = actions.find((d) => selectable(d) && d.name === selectedName)
+      || actions.find(selectable) || null;
+    selectedName = entry ? entry.name : '';
+    for (const d of actions) {
+      const usable = selectable(d);
+      const btn = agendaStartSheetEl('button', 'ags-seg-btn', usable
+        ? (d.title || d.name)
+        : `${d.title || d.name} (${d.shadowed ? 'shadowed' : 'invalid'})`);
+      btn.type = 'button';
+      btn.dataset.definition = d.name;
+      if (!usable) {
+        btn.disabled = true;
+        btn.title = d.shadowed
+          ? 'shadowed by a personal definition of the same name'
+          : (d.reason || 'invalid definition');
+      } else {
+        if (d.advisories && d.advisories.length) btn.title = d.advisories.join('; ');
+        btn.addEventListener('click', () => { entry = d; selectedName = d.name; applyEntry(); });
+      }
+      seg.appendChild(btn);
+    }
+    // Triggered actions and workflows stamp their own lanes and hand
+    // off to their own surfaces — rendered by the workflows fragment
+    // off the same catalog fetch.
+    if (typeof agendaWorkflowRenderPickerButtons === 'function') {
+      agendaWorkflowRenderPickerButtons(seg, agendaCloseAutomationSheet,
+        () => project.value.trim(), agendaDefinitionCatalog || []);
+    }
+    applyEntry();
+  };
+  renderPicker();
+  agendaFetchDefinitionCatalog(() => {
+    if (agendaAutomationSheetOpen) renderPicker();
+  });
   agendaPresentStartSheet(host, panel, anchor);
 }
 
 async function agendaAutomationSheetSubmit(form) {
-  const template = form.template();
+  const entry = form.entry();
   const showError = (message) => {
     form.error.textContent = message;
     form.error.hidden = false;
   };
   form.error.hidden = true;
+  if (!entry) {
+    showError('Pick a definition first.');
+    return;
+  }
   const fireAt = form.fire.value ? new Date(form.fire.value).getTime() : NaN;
   if (!Number.isFinite(fireAt) || fireAt <= Date.now()) {
     showError('Pick a first-run time in the future.');
     form.fire.focus();
     return;
   }
-  const suspendAfter = Math.max(1, Number(form.suspend.value) || template.suspendAfter);
+  const suspendAfter = Math.max(1, Number(form.suspend.value) || 3);
   // Explicit executor picks only — untouched selects inherit (the start
   // sheet's exact assembly, so both lanes speak one vocabulary).
   const spec = form.configState && form.configState.spec;
@@ -92071,44 +92164,39 @@ async function agendaAutomationSheetSubmit(form) {
   }
   form.park.disabled = true;
   try {
-    // Park the mandate as an ordinary item (body = the template text,
-    // byte-verbatim — the parity pin's contract)…
-    const added = await daemonApi.request('api_agenda_op', {
-      op: 'add', kind: 'task', title: template.title, body: template.mandate,
-    });
-    if (!added.ok || !added.body || !added.body.item) {
-      showError((added.body && added.body.error) || `park failed (${added.status})`);
-      return;
-    }
-    agendaObserveServerMessage({ item: added.body.item });
-    const itemId = added.body.item.id;
-    // …then propose the standing effect on it. The goal is the same
-    // mandate text, so Run now and the cadence carry identical orders.
-    const propose = {
-      op: 'propose_effect',
-      id: itemId,
-      goal: template.mandate,
+    // One daemon-side stamp: the daemon reads, validates, and SEALS the
+    // definition, parks the item, and proposes the manifest — the
+    // sheet's choices ride as prefills into the ordinary manifest
+    // intake, never around it. Parks + proposes ONLY; approval stays
+    // the owner's per-effect act on the card.
+    const stamp = {
+      definition: entry.name,
       fire_at_ms: fireAt,
-      recurrence: {
-        every_ms: Number(form.cadence.value) || template.everyMs,
-        suspend_after_failures: suspendAfter,
-      },
+      suspend_after: suspendAfter,
     };
+    const everyMs = Number(form.cadence.value);
+    if (Number.isFinite(everyMs) && everyMs > 0) stamp.every_ms = everyMs;
     const projectRoot = form.project && form.project.value.trim();
-    if (projectRoot) propose.project_root = projectRoot;
-    if (Object.keys(agentConfig).length) propose.agent_config = agentConfig;
-    const proposed = await daemonApi.request('api_agenda_op', propose);
-    if (!proposed.ok || !proposed.body || !proposed.body.item) {
-      showError((proposed.body && proposed.body.error) || `propose failed (${proposed.status})`);
+    if (projectRoot) stamp.project_root = projectRoot;
+    if (Object.keys(agentConfig).length) stamp.agent_config = agentConfig;
+    const res = await daemonApi.request('api_agenda_stamp', stamp);
+    if (!res.ok || !res.body || !res.body.stamp) {
+      showError((res.body && res.body.error) || `stamp failed (${res.status})`);
       return;
     }
-    agendaObserveServerMessage({ item: proposed.body.item });
+    const outcome = res.body.stamp;
+    if (outcome.hub) agendaObserveServerMessage({ item: outcome.hub });
+    for (const node of outcome.nodes || []) {
+      if (node.item) agendaObserveServerMessage({ item: node.item });
+    }
     agendaCloseAutomationSheet();
     // Land the owner on the ordinary Approve affordance.
-    if (typeof agendaOpenInspector === 'function') agendaOpenInspector(itemId);
+    const landId = outcome.nodes && outcome.nodes[0] && outcome.nodes[0].item
+      ? outcome.nodes[0].item.id : null;
+    if (landId && typeof agendaOpenInspector === 'function') agendaOpenInspector(landId);
     if (typeof showControlToast === 'function') {
       showControlToast('success',
-        'Parked and proposed — approve the digest on the card to arm the series.');
+        'Stamped — sealed, parked, and proposed. Approve the digest on the card to arm the series.');
     }
   } catch (e) {
     showError(String(e && e.message || e));
@@ -97164,19 +97252,23 @@ function agendaPaletteEntries(query) {
   return entries;
 }
 /* ── static/app/ui2-agenda-workflows.js ── */
-// ---- Workflow templates: stamp + one-gesture approval (Track T) ----
-// A workflow template stamps a small item-graph: an instance HUB whose
-// body is the workflow's living orientation document, N node items
-// placed under it, relies_on links, and one on_unblock-triggered
-// manifest per node. STAMPING parks and proposes only; the approval
-// sheet then previews the whole graph, and the owner's single confirm
-// emits one ordinary per-node approval op — the UI batches, the
-// semantics never cascade, and no workflow-level object exists
-// anywhere. Pinned copies of the daemon's registry
-// (src/bin/caller/agenda/mandate_templates.rs — the source of truth;
-// its parity tests fail if these bytes drift, and the emission-shape
-// pin holds the approval lane to exactly one emitter called from the
-// owner-confirm handler).
+// ---- Workflows & triggered mandates: catalog picks, daemon stamp,
+// one-gesture approval (Track T → AW) ----
+// Picker entries derive from the SERVED definition catalog; a click
+// stamps through the daemon's stamp op — the daemon reads, validates,
+// and SEALS the definition, parks the instance graph (an instance HUB
+// with the orientation body iff workflow, node items placed under it,
+// relies_on links), and proposes one on_unblock manifest per node.
+// STAMPING parks and proposes only; the approval sheet then previews
+// the sealed definition and the stamped graph, and the owner's single
+// confirm emits one ordinary per-node approval op — the UI batches,
+// the semantics never cascade, and no workflow-level object exists
+// anywhere (the emission-shape pin holds the approval lane to exactly
+// one emitter called from the owner-confirm handler). The template
+// tables below are the migration window's parity anchors (pinned
+// byte-verbatim against src/bin/caller/agenda/mandate_templates.rs) —
+// no longer read by the pickers, deleted together with the registry in
+// the cutover PR.
 
 const AGENDA_WORKFLOW_TEMPLATES = [
   {
@@ -97315,55 +97407,27 @@ async function agendaWorkflowOp(params) {
   return res.body.item;
 }
 
-// Stamp one instance: hub (orientation body) + placed nodes + edges +
-// one on_unblock proposal per node. Parks and proposes ONLY — approval
-// is the separate explicit act on the sheet this feeds. A mid-stamp
-// failure leaves ordinary parked items visible on the board
-// (append-only history; nothing rolls back silently).
-async function agendaWorkflowStamp(template, projectRoot) {
-  const hub = await agendaWorkflowOp({
-    op: 'add', kind: 'note', title: template.title, body: template.orientation,
-  });
-  const ids = {};
-  for (const node of template.nodes) {
-    const item = await agendaWorkflowOp({
-      op: 'add', kind: 'task', title: node.title, body: node.goal,
-    });
-    ids[node.slug] = item.id;
-    await agendaWorkflowOp({ op: 'place', id: item.id, under: hub.id });
+// Stamp one instance through the daemon (the stamp op): one request
+// reads, validates, and seals the definition, parks the graph, and
+// proposes per node — the response is the whole stamped outcome (hub,
+// nodes, per-node digests, the sealed pin). Parks and proposes ONLY —
+// approval is the separate explicit act on the sheet this feeds. A
+// mid-stamp failure leaves ordinary parked items visible on the board
+// (append-only history; nothing rolls back silently). Both the
+// workflow and triggered-action lanes ride this wrapper.
+async function agendaWorkflowStamp(entry, projectRoot) {
+  const params = { definition: entry.name };
+  if (projectRoot) params.project_root = projectRoot;
+  const res = await daemonApi.request('api_agenda_stamp', params);
+  if (!res.ok || !res.body || !res.body.stamp) {
+    throw new Error((res.body && res.body.error) || `stamp failed (${res.status})`);
   }
-  for (const [node, dep] of template.edges) {
-    await agendaWorkflowOp({ op: 'add_relies_on', id: ids[node], target_id: ids[dep] });
+  const stamp = res.body.stamp;
+  if (stamp.hub) agendaObserveServerMessage({ item: stamp.hub });
+  for (const node of stamp.nodes || []) {
+    if (node.item) agendaObserveServerMessage({ item: node.item });
   }
-  const stamped = { hubId: hub.id, title: template.title, orientation: template.orientation, nodes: [] };
-  for (const node of template.nodes) {
-    const config = {};
-    if (node.agent) config.agent = node.agent;
-    if (node.claudeModel) config.claude_model = node.claudeModel;
-    if (node.claudeEffort) config.claude_effort = node.claudeEffort;
-    const propose = {
-      op: 'propose_effect',
-      id: ids[node.slug],
-      goal: node.goal,
-      fire_at_ms: Date.now(),
-      trigger: { kind: 'on_unblock' },
-    };
-    if (projectRoot) propose.project_root = projectRoot;
-    if (Object.keys(config).length) propose.agent_config = config;
-    const item = await agendaWorkflowOp(propose);
-    const effect = (item.effects || [])[0] || {};
-    stamped.nodes.push({
-      id: ids[node.slug],
-      slug: node.slug,
-      title: node.title,
-      goal: node.goal,
-      digest: effect.digest || '',
-      executor: config.agent
-        ? [config.agent, config.claude_model, config.claude_effort].filter(Boolean).join(' · ')
-        : 'daemon default',
-    });
-  }
-  return stamped;
+  return stamp;
 }
 
 let agendaWorkflowSheetOpen = false;
@@ -97398,11 +97462,12 @@ function agendaWorkflowCloseSheet() {
   agendaWorkflowSheetOpen = false;
 }
 
-// The graph preview + the one gesture, briefing-standard shaped:
-// orientation first, then each node's manifest (full goal text — the
-// owner reads exactly what each session receives), then the committed
-// recommendation. "Later" keeps everything parked with pending digests
-// on the ordinary cards — silence arms nothing.
+// The stamped graph + the one gesture, briefing-standard shaped: the
+// SEALED definition first (fetched from the content-addressed serving
+// lane — exactly the bytes the stamp sealed, rendered once and in
+// full), then each node's row (title, executor, digest chip), then the
+// committed recommendation. "Later" keeps everything parked with
+// pending digests on the ordinary cards — silence arms nothing.
 function agendaWorkflowOpenApprovalSheet(stamped) {
   const host = agendaWorkflowEnsureSheet();
   const panel = host.querySelector('.ags-panel');
@@ -97418,26 +97483,42 @@ function agendaWorkflowOpenApprovalSheet(stamped) {
   head.appendChild(close);
   panel.appendChild(head);
   panel.appendChild(agendaStartSheetEl('div', 'ags-sub',
-    'Stamped and proposed — nothing runs yet. Each node below is its own digest-bound manifest; approving arms them all, and the first node fires on approval.'));
+    'Stamped and sealed — nothing runs yet. Each node below is its own digest-bound manifest pinning the sealed definition; approving arms them all, and the first node fires on approval.'));
 
-  panel.appendChild(agendaStartSheetEl('label', 'ags-label', 'The hub orientation'));
-  const orient = agendaStartSheetEl('pre', 'agsx-preview');
-  orient.textContent = stamped.orientation;
-  panel.appendChild(orient);
+  panel.appendChild(agendaStartSheetEl('label', 'ags-label',
+    `The sealed definition (sha256 ${String(stamped.sha256 || '').slice(0, 12)}…) — every node pins exactly these bytes`));
+  const sealed = agendaStartSheetEl('pre', 'agsx-preview');
+  sealed.textContent = 'Loading the sealed definition…';
+  panel.appendChild(sealed);
+  const sealedFallback = (detail) => {
+    sealed.textContent = `Sealed view unavailable${detail ? ` (${detail})` : ''}` +
+      ' — each node item carries a display copy of its section.';
+  };
+  daemonApi.request('api_agenda_sealed', { sha256: stamped.sha256 })
+    .then((res) => {
+      if (res.ok && res.body && res.body.encoding === 'utf8') {
+        sealed.textContent = res.body.content;
+      } else {
+        sealedFallback((res.body && res.body.error) || `status ${res.status}`);
+      }
+    })
+    .catch((e) => { sealedFallback(String((e && e.message) || e)); });
 
   for (const node of stamped.nodes) {
     const row = agendaStartSheetEl('div', 'ags-config-row');
     row.appendChild(agendaStartSheetEl('label', 'ags-label', node.title));
     // Executor as text, digest as the shared chip: each row shows the
-    // exact revision "Approve all" would bind for that node.
+    // exact revision "Approve all" would bind for that node. The
+    // executor pins ride the manifest the digest covers.
+    const pins = ((((node.item || {}).effects || [])[0] || {}).manifest || {}).agent_config;
+    const executor = pins && pins.agent
+      ? [pins.agent, pins.claude_model, pins.claude_effort].filter(Boolean).join(' · ')
+      : 'daemon default';
     const hint = agendaStartSheetEl('div', 'ags-hint');
-    hint.innerHTML = `${escapeHtml(node.executor)} · ${agendaDigestChipHtml(node.digest,
+    hint.innerHTML = `${escapeHtml(executor)} · ${agendaDigestChipHtml(node.digest,
       'Approve all binds this node to exactly this manifest revision')}`;
     row.appendChild(hint);
     panel.appendChild(row);
-    const goal = agendaStartSheetEl('pre', 'agsx-preview');
-    goal.textContent = node.goal;
-    panel.appendChild(goal);
   }
 
   panel.appendChild(agendaStartSheetEl('div', 'ags-sub',
@@ -97467,7 +97548,7 @@ function agendaWorkflowOpenApprovalSheet(stamped) {
 // iterating exactly the stamped node set.
 async function agendaWorkflowEmitApprovals(batch) {
   for (const node of batch.nodes) {
-    await agendaWorkflowOp({ op: 'approve_effect', id: node.id, digest: node.digest });
+    await agendaWorkflowOp({ op: 'approve_effect', id: node.item.id, digest: node.digest });
   }
 }
 
@@ -97482,7 +97563,9 @@ async function agendaWorkflowApproveConfirm(stamped, button, error) {
       showControlToast('success',
         `Workflow armed — ${stamped.nodes.length} approvals recorded; the first node fires now.`);
     }
-    if (typeof agendaOpenInspector === 'function') agendaOpenInspector(stamped.hubId);
+    const landId = stamped.hub ? stamped.hub.id
+      : (stamped.nodes[0] && stamped.nodes[0].item ? stamped.nodes[0].item.id : null);
+    if (landId && typeof agendaOpenInspector === 'function') agendaOpenInspector(landId);
   } catch (e) {
     error.textContent = String((e && e.message) || e);
     error.hidden = false;
@@ -97491,20 +97574,36 @@ async function agendaWorkflowApproveConfirm(stamped, button, error) {
 }
 
 // The automate sheet's picker hook: workflow entries beside the
-// mandate templates. Stamping happens on click; the approval sheet
-// opens the moment the stamp lands.
-function agendaWorkflowRenderPickerButtons(seg, closeAutomationSheet, getProjectRoot) {
+// cadenced actions, derived from the served catalog the sheet fetched.
+// Stamping happens on click; the approval sheet opens the moment the
+// stamp lands. Invalid and shadowed entries render disabled with the
+// reason — visible, never hidden.
+function agendaWorkflowRenderPickerButtons(seg, closeAutomationSheet, getProjectRoot, entries) {
+  const catalog = Array.isArray(entries) ? entries : [];
   if (typeof agendaTriggeredMandateRenderButtons === 'function') {
-    agendaTriggeredMandateRenderButtons(seg, closeAutomationSheet, getProjectRoot);
+    agendaTriggeredMandateRenderButtons(seg, closeAutomationSheet, getProjectRoot, catalog);
   }
-  for (const template of AGENDA_WORKFLOW_TEMPLATES) {
-    const btn = agendaStartSheetEl('button', 'ags-seg-btn', `${template.title} →`);
+  for (const entry of catalog) {
+    if (!entry.workflow) continue;
+    const usable = entry.valid && !entry.shadowed;
+    const btn = agendaStartSheetEl('button', 'ags-seg-btn', usable
+      ? `${entry.title || entry.name} →`
+      : `${entry.title || entry.name} (${entry.shadowed ? 'shadowed' : 'invalid'})`);
     btn.type = 'button';
-    btn.dataset.workflow = template.id;
+    btn.dataset.workflow = entry.name;
+    if (!usable) {
+      btn.disabled = true;
+      btn.title = entry.shadowed
+        ? 'shadowed by a personal definition of the same name'
+        : (entry.reason || 'invalid definition');
+      seg.appendChild(btn);
+      continue;
+    }
+    if (entry.advisories && entry.advisories.length) btn.title = entry.advisories.join('; ');
     btn.addEventListener('click', async () => {
       btn.disabled = true;
       try {
-        const stamped = await agendaWorkflowStamp(template,
+        const stamped = await agendaWorkflowStamp(entry,
           typeof getProjectRoot === 'function' ? getProjectRoot() : '');
         closeAutomationSheet();
         agendaWorkflowOpenApprovalSheet(stamped);
@@ -97520,13 +97619,14 @@ function agendaWorkflowRenderPickerButtons(seg, closeAutomationSheet, getProject
   }
 }
 
-// ---- Triggered standing mandates (Track T, T3) ----
+// ---- Triggered standing mandates (Track T, T3 → AW) ----
 // Fire-on-event instead of cadence: one item + one on_item_match
-// manifest. The steward-gate consumer is the first entry. Pinned copy
-// of the registry (same parity discipline as the tables above); the
-// stamp path parks + proposes and lands the owner on the ordinary
-// Approve card — one digest, no sheet, and this lane emits no
-// approvals (the fragment's single-emitter pin counts them).
+// manifest, stamped through the same daemon stamp op off the served
+// catalog. The stamp path parks + proposes and lands the owner on the
+// ordinary Approve card — one digest, no sheet, and this lane emits no
+// approvals (the fragment's single-emitter pin counts them). The table
+// below is the migration window's parity anchor only (same discipline
+// as the tables above), deleted with the registry in the cutover PR.
 
 const AGENDA_TRIGGERED_MANDATE_TEMPLATES = [
   {
@@ -97561,44 +97661,46 @@ beyond those; propose-don't-dispose governs every write.`,
   },
 ];
 
-// Park + propose a triggered standing mandate; approval stays the
-// owner's ordinary card act.
-async function agendaTriggeredMandateStamp(template, projectRoot) {
-  const item = await agendaWorkflowOp({
-    op: 'add', kind: 'task', title: template.title, body: template.mandate,
-  });
-  const propose = {
-    op: 'propose_effect',
-    id: item.id,
-    goal: template.mandate,
-    fire_at_ms: Date.now(),
-    trigger: { kind: 'on_item_match', item_kind: template.itemKind, tags: template.tags },
-  };
-  if (projectRoot) propose.project_root = projectRoot;
-  const config = {};
-  if (template.agent) config.agent = template.agent;
-  if (template.claudeModel) config.claude_model = template.claudeModel;
-  if (template.claudeEffort) config.claude_effort = template.claudeEffort;
-  if (Object.keys(config).length) propose.agent_config = config;
-  await agendaWorkflowOp(propose);
-  if (typeof agendaOpenInspector === 'function') agendaOpenInspector(item.id);
+// Stamp a triggered standing mandate through the daemon (the trigger
+// prefill rides the definition's config block into the ordinary
+// intake); approval stays the owner's ordinary card act.
+async function agendaTriggeredMandateStamp(entry, projectRoot) {
+  const stamp = await agendaWorkflowStamp(entry, projectRoot);
+  const landId = stamp.nodes && stamp.nodes[0] && stamp.nodes[0].item
+    ? stamp.nodes[0].item.id : null;
+  if (landId && typeof agendaOpenInspector === 'function') agendaOpenInspector(landId);
   if (typeof showControlToast === 'function') {
     showControlToast('success',
-      'Parked and proposed — approve the digest on the card to arm the standing mandate.');
+      'Stamped — sealed, parked, and proposed. Approve the digest on the card to arm the standing mandate.');
   }
 }
 
-// Picker entries for the triggered mandates, rendered by the same hook.
-function agendaTriggeredMandateRenderButtons(seg, closeAutomationSheet, getProjectRoot) {
-  for (const template of AGENDA_TRIGGERED_MANDATE_TEMPLATES) {
+// Picker entries for the triggered actions (catalog entries whose
+// single node declares a trigger), rendered by the same hook.
+function agendaTriggeredMandateRenderButtons(seg, closeAutomationSheet, getProjectRoot, entries) {
+  for (const entry of (Array.isArray(entries) ? entries : [])) {
+    if (entry.workflow) continue;
+    const node = (entry.nodes && entry.nodes[0]) || {};
+    if (!node.trigger_kind) continue;
+    const usable = entry.valid && !entry.shadowed;
+    const base = `${entry.title || entry.name} (${node.trigger_kind}:${(node.trigger_tags || []).join(',')})`;
     const btn = agendaStartSheetEl('button', 'ags-seg-btn',
-      `${template.title} (${template.itemKind}:${template.tags.join(',')})`);
+      usable ? base : `${base} (${entry.shadowed ? 'shadowed' : 'invalid'})`);
     btn.type = 'button';
-    btn.dataset.triggeredMandate = template.id;
+    btn.dataset.triggeredMandate = entry.name;
+    if (!usable) {
+      btn.disabled = true;
+      btn.title = entry.shadowed
+        ? 'shadowed by a personal definition of the same name'
+        : (entry.reason || 'invalid definition');
+      seg.appendChild(btn);
+      continue;
+    }
+    if (entry.advisories && entry.advisories.length) btn.title = entry.advisories.join('; ');
     btn.addEventListener('click', async () => {
       btn.disabled = true;
       try {
-        await agendaTriggeredMandateStamp(template,
+        await agendaTriggeredMandateStamp(entry,
           typeof getProjectRoot === 'function' ? getProjectRoot() : '');
         closeAutomationSheet();
       } catch (e) {

--- a/static/app/ui2-agenda-workflows.js
+++ b/static/app/ui2-agenda-workflows.js
@@ -1,16 +1,20 @@
-// ---- Workflow templates: stamp + one-gesture approval (Track T) ----
-// A workflow template stamps a small item-graph: an instance HUB whose
-// body is the workflow's living orientation document, N node items
-// placed under it, relies_on links, and one on_unblock-triggered
-// manifest per node. STAMPING parks and proposes only; the approval
-// sheet then previews the whole graph, and the owner's single confirm
-// emits one ordinary per-node approval op — the UI batches, the
-// semantics never cascade, and no workflow-level object exists
-// anywhere. Pinned copies of the daemon's registry
-// (src/bin/caller/agenda/mandate_templates.rs — the source of truth;
-// its parity tests fail if these bytes drift, and the emission-shape
-// pin holds the approval lane to exactly one emitter called from the
-// owner-confirm handler).
+// ---- Workflows & triggered mandates: catalog picks, daemon stamp,
+// one-gesture approval (Track T → AW) ----
+// Picker entries derive from the SERVED definition catalog; a click
+// stamps through the daemon's stamp op — the daemon reads, validates,
+// and SEALS the definition, parks the instance graph (an instance HUB
+// with the orientation body iff workflow, node items placed under it,
+// relies_on links), and proposes one on_unblock manifest per node.
+// STAMPING parks and proposes only; the approval sheet then previews
+// the sealed definition and the stamped graph, and the owner's single
+// confirm emits one ordinary per-node approval op — the UI batches,
+// the semantics never cascade, and no workflow-level object exists
+// anywhere (the emission-shape pin holds the approval lane to exactly
+// one emitter called from the owner-confirm handler). The template
+// tables below are the migration window's parity anchors (pinned
+// byte-verbatim against src/bin/caller/agenda/mandate_templates.rs) —
+// no longer read by the pickers, deleted together with the registry in
+// the cutover PR.
 
 const AGENDA_WORKFLOW_TEMPLATES = [
   {
@@ -149,55 +153,27 @@ async function agendaWorkflowOp(params) {
   return res.body.item;
 }
 
-// Stamp one instance: hub (orientation body) + placed nodes + edges +
-// one on_unblock proposal per node. Parks and proposes ONLY — approval
-// is the separate explicit act on the sheet this feeds. A mid-stamp
-// failure leaves ordinary parked items visible on the board
-// (append-only history; nothing rolls back silently).
-async function agendaWorkflowStamp(template, projectRoot) {
-  const hub = await agendaWorkflowOp({
-    op: 'add', kind: 'note', title: template.title, body: template.orientation,
-  });
-  const ids = {};
-  for (const node of template.nodes) {
-    const item = await agendaWorkflowOp({
-      op: 'add', kind: 'task', title: node.title, body: node.goal,
-    });
-    ids[node.slug] = item.id;
-    await agendaWorkflowOp({ op: 'place', id: item.id, under: hub.id });
+// Stamp one instance through the daemon (the stamp op): one request
+// reads, validates, and seals the definition, parks the graph, and
+// proposes per node — the response is the whole stamped outcome (hub,
+// nodes, per-node digests, the sealed pin). Parks and proposes ONLY —
+// approval is the separate explicit act on the sheet this feeds. A
+// mid-stamp failure leaves ordinary parked items visible on the board
+// (append-only history; nothing rolls back silently). Both the
+// workflow and triggered-action lanes ride this wrapper.
+async function agendaWorkflowStamp(entry, projectRoot) {
+  const params = { definition: entry.name };
+  if (projectRoot) params.project_root = projectRoot;
+  const res = await daemonApi.request('api_agenda_stamp', params);
+  if (!res.ok || !res.body || !res.body.stamp) {
+    throw new Error((res.body && res.body.error) || `stamp failed (${res.status})`);
   }
-  for (const [node, dep] of template.edges) {
-    await agendaWorkflowOp({ op: 'add_relies_on', id: ids[node], target_id: ids[dep] });
+  const stamp = res.body.stamp;
+  if (stamp.hub) agendaObserveServerMessage({ item: stamp.hub });
+  for (const node of stamp.nodes || []) {
+    if (node.item) agendaObserveServerMessage({ item: node.item });
   }
-  const stamped = { hubId: hub.id, title: template.title, orientation: template.orientation, nodes: [] };
-  for (const node of template.nodes) {
-    const config = {};
-    if (node.agent) config.agent = node.agent;
-    if (node.claudeModel) config.claude_model = node.claudeModel;
-    if (node.claudeEffort) config.claude_effort = node.claudeEffort;
-    const propose = {
-      op: 'propose_effect',
-      id: ids[node.slug],
-      goal: node.goal,
-      fire_at_ms: Date.now(),
-      trigger: { kind: 'on_unblock' },
-    };
-    if (projectRoot) propose.project_root = projectRoot;
-    if (Object.keys(config).length) propose.agent_config = config;
-    const item = await agendaWorkflowOp(propose);
-    const effect = (item.effects || [])[0] || {};
-    stamped.nodes.push({
-      id: ids[node.slug],
-      slug: node.slug,
-      title: node.title,
-      goal: node.goal,
-      digest: effect.digest || '',
-      executor: config.agent
-        ? [config.agent, config.claude_model, config.claude_effort].filter(Boolean).join(' · ')
-        : 'daemon default',
-    });
-  }
-  return stamped;
+  return stamp;
 }
 
 let agendaWorkflowSheetOpen = false;
@@ -232,11 +208,12 @@ function agendaWorkflowCloseSheet() {
   agendaWorkflowSheetOpen = false;
 }
 
-// The graph preview + the one gesture, briefing-standard shaped:
-// orientation first, then each node's manifest (full goal text — the
-// owner reads exactly what each session receives), then the committed
-// recommendation. "Later" keeps everything parked with pending digests
-// on the ordinary cards — silence arms nothing.
+// The stamped graph + the one gesture, briefing-standard shaped: the
+// SEALED definition first (fetched from the content-addressed serving
+// lane — exactly the bytes the stamp sealed, rendered once and in
+// full), then each node's row (title, executor, digest chip), then the
+// committed recommendation. "Later" keeps everything parked with
+// pending digests on the ordinary cards — silence arms nothing.
 function agendaWorkflowOpenApprovalSheet(stamped) {
   const host = agendaWorkflowEnsureSheet();
   const panel = host.querySelector('.ags-panel');
@@ -252,26 +229,42 @@ function agendaWorkflowOpenApprovalSheet(stamped) {
   head.appendChild(close);
   panel.appendChild(head);
   panel.appendChild(agendaStartSheetEl('div', 'ags-sub',
-    'Stamped and proposed — nothing runs yet. Each node below is its own digest-bound manifest; approving arms them all, and the first node fires on approval.'));
+    'Stamped and sealed — nothing runs yet. Each node below is its own digest-bound manifest pinning the sealed definition; approving arms them all, and the first node fires on approval.'));
 
-  panel.appendChild(agendaStartSheetEl('label', 'ags-label', 'The hub orientation'));
-  const orient = agendaStartSheetEl('pre', 'agsx-preview');
-  orient.textContent = stamped.orientation;
-  panel.appendChild(orient);
+  panel.appendChild(agendaStartSheetEl('label', 'ags-label',
+    `The sealed definition (sha256 ${String(stamped.sha256 || '').slice(0, 12)}…) — every node pins exactly these bytes`));
+  const sealed = agendaStartSheetEl('pre', 'agsx-preview');
+  sealed.textContent = 'Loading the sealed definition…';
+  panel.appendChild(sealed);
+  const sealedFallback = (detail) => {
+    sealed.textContent = `Sealed view unavailable${detail ? ` (${detail})` : ''}` +
+      ' — each node item carries a display copy of its section.';
+  };
+  daemonApi.request('api_agenda_sealed', { sha256: stamped.sha256 })
+    .then((res) => {
+      if (res.ok && res.body && res.body.encoding === 'utf8') {
+        sealed.textContent = res.body.content;
+      } else {
+        sealedFallback((res.body && res.body.error) || `status ${res.status}`);
+      }
+    })
+    .catch((e) => { sealedFallback(String((e && e.message) || e)); });
 
   for (const node of stamped.nodes) {
     const row = agendaStartSheetEl('div', 'ags-config-row');
     row.appendChild(agendaStartSheetEl('label', 'ags-label', node.title));
     // Executor as text, digest as the shared chip: each row shows the
-    // exact revision "Approve all" would bind for that node.
+    // exact revision "Approve all" would bind for that node. The
+    // executor pins ride the manifest the digest covers.
+    const pins = ((((node.item || {}).effects || [])[0] || {}).manifest || {}).agent_config;
+    const executor = pins && pins.agent
+      ? [pins.agent, pins.claude_model, pins.claude_effort].filter(Boolean).join(' · ')
+      : 'daemon default';
     const hint = agendaStartSheetEl('div', 'ags-hint');
-    hint.innerHTML = `${escapeHtml(node.executor)} · ${agendaDigestChipHtml(node.digest,
+    hint.innerHTML = `${escapeHtml(executor)} · ${agendaDigestChipHtml(node.digest,
       'Approve all binds this node to exactly this manifest revision')}`;
     row.appendChild(hint);
     panel.appendChild(row);
-    const goal = agendaStartSheetEl('pre', 'agsx-preview');
-    goal.textContent = node.goal;
-    panel.appendChild(goal);
   }
 
   panel.appendChild(agendaStartSheetEl('div', 'ags-sub',
@@ -301,7 +294,7 @@ function agendaWorkflowOpenApprovalSheet(stamped) {
 // iterating exactly the stamped node set.
 async function agendaWorkflowEmitApprovals(batch) {
   for (const node of batch.nodes) {
-    await agendaWorkflowOp({ op: 'approve_effect', id: node.id, digest: node.digest });
+    await agendaWorkflowOp({ op: 'approve_effect', id: node.item.id, digest: node.digest });
   }
 }
 
@@ -316,7 +309,9 @@ async function agendaWorkflowApproveConfirm(stamped, button, error) {
       showControlToast('success',
         `Workflow armed — ${stamped.nodes.length} approvals recorded; the first node fires now.`);
     }
-    if (typeof agendaOpenInspector === 'function') agendaOpenInspector(stamped.hubId);
+    const landId = stamped.hub ? stamped.hub.id
+      : (stamped.nodes[0] && stamped.nodes[0].item ? stamped.nodes[0].item.id : null);
+    if (landId && typeof agendaOpenInspector === 'function') agendaOpenInspector(landId);
   } catch (e) {
     error.textContent = String((e && e.message) || e);
     error.hidden = false;
@@ -325,20 +320,36 @@ async function agendaWorkflowApproveConfirm(stamped, button, error) {
 }
 
 // The automate sheet's picker hook: workflow entries beside the
-// mandate templates. Stamping happens on click; the approval sheet
-// opens the moment the stamp lands.
-function agendaWorkflowRenderPickerButtons(seg, closeAutomationSheet, getProjectRoot) {
+// cadenced actions, derived from the served catalog the sheet fetched.
+// Stamping happens on click; the approval sheet opens the moment the
+// stamp lands. Invalid and shadowed entries render disabled with the
+// reason — visible, never hidden.
+function agendaWorkflowRenderPickerButtons(seg, closeAutomationSheet, getProjectRoot, entries) {
+  const catalog = Array.isArray(entries) ? entries : [];
   if (typeof agendaTriggeredMandateRenderButtons === 'function') {
-    agendaTriggeredMandateRenderButtons(seg, closeAutomationSheet, getProjectRoot);
+    agendaTriggeredMandateRenderButtons(seg, closeAutomationSheet, getProjectRoot, catalog);
   }
-  for (const template of AGENDA_WORKFLOW_TEMPLATES) {
-    const btn = agendaStartSheetEl('button', 'ags-seg-btn', `${template.title} →`);
+  for (const entry of catalog) {
+    if (!entry.workflow) continue;
+    const usable = entry.valid && !entry.shadowed;
+    const btn = agendaStartSheetEl('button', 'ags-seg-btn', usable
+      ? `${entry.title || entry.name} →`
+      : `${entry.title || entry.name} (${entry.shadowed ? 'shadowed' : 'invalid'})`);
     btn.type = 'button';
-    btn.dataset.workflow = template.id;
+    btn.dataset.workflow = entry.name;
+    if (!usable) {
+      btn.disabled = true;
+      btn.title = entry.shadowed
+        ? 'shadowed by a personal definition of the same name'
+        : (entry.reason || 'invalid definition');
+      seg.appendChild(btn);
+      continue;
+    }
+    if (entry.advisories && entry.advisories.length) btn.title = entry.advisories.join('; ');
     btn.addEventListener('click', async () => {
       btn.disabled = true;
       try {
-        const stamped = await agendaWorkflowStamp(template,
+        const stamped = await agendaWorkflowStamp(entry,
           typeof getProjectRoot === 'function' ? getProjectRoot() : '');
         closeAutomationSheet();
         agendaWorkflowOpenApprovalSheet(stamped);
@@ -354,13 +365,14 @@ function agendaWorkflowRenderPickerButtons(seg, closeAutomationSheet, getProject
   }
 }
 
-// ---- Triggered standing mandates (Track T, T3) ----
+// ---- Triggered standing mandates (Track T, T3 → AW) ----
 // Fire-on-event instead of cadence: one item + one on_item_match
-// manifest. The steward-gate consumer is the first entry. Pinned copy
-// of the registry (same parity discipline as the tables above); the
-// stamp path parks + proposes and lands the owner on the ordinary
-// Approve card — one digest, no sheet, and this lane emits no
-// approvals (the fragment's single-emitter pin counts them).
+// manifest, stamped through the same daemon stamp op off the served
+// catalog. The stamp path parks + proposes and lands the owner on the
+// ordinary Approve card — one digest, no sheet, and this lane emits no
+// approvals (the fragment's single-emitter pin counts them). The table
+// below is the migration window's parity anchor only (same discipline
+// as the tables above), deleted with the registry in the cutover PR.
 
 const AGENDA_TRIGGERED_MANDATE_TEMPLATES = [
   {
@@ -395,44 +407,46 @@ beyond those; propose-don't-dispose governs every write.`,
   },
 ];
 
-// Park + propose a triggered standing mandate; approval stays the
-// owner's ordinary card act.
-async function agendaTriggeredMandateStamp(template, projectRoot) {
-  const item = await agendaWorkflowOp({
-    op: 'add', kind: 'task', title: template.title, body: template.mandate,
-  });
-  const propose = {
-    op: 'propose_effect',
-    id: item.id,
-    goal: template.mandate,
-    fire_at_ms: Date.now(),
-    trigger: { kind: 'on_item_match', item_kind: template.itemKind, tags: template.tags },
-  };
-  if (projectRoot) propose.project_root = projectRoot;
-  const config = {};
-  if (template.agent) config.agent = template.agent;
-  if (template.claudeModel) config.claude_model = template.claudeModel;
-  if (template.claudeEffort) config.claude_effort = template.claudeEffort;
-  if (Object.keys(config).length) propose.agent_config = config;
-  await agendaWorkflowOp(propose);
-  if (typeof agendaOpenInspector === 'function') agendaOpenInspector(item.id);
+// Stamp a triggered standing mandate through the daemon (the trigger
+// prefill rides the definition's config block into the ordinary
+// intake); approval stays the owner's ordinary card act.
+async function agendaTriggeredMandateStamp(entry, projectRoot) {
+  const stamp = await agendaWorkflowStamp(entry, projectRoot);
+  const landId = stamp.nodes && stamp.nodes[0] && stamp.nodes[0].item
+    ? stamp.nodes[0].item.id : null;
+  if (landId && typeof agendaOpenInspector === 'function') agendaOpenInspector(landId);
   if (typeof showControlToast === 'function') {
     showControlToast('success',
-      'Parked and proposed — approve the digest on the card to arm the standing mandate.');
+      'Stamped — sealed, parked, and proposed. Approve the digest on the card to arm the standing mandate.');
   }
 }
 
-// Picker entries for the triggered mandates, rendered by the same hook.
-function agendaTriggeredMandateRenderButtons(seg, closeAutomationSheet, getProjectRoot) {
-  for (const template of AGENDA_TRIGGERED_MANDATE_TEMPLATES) {
+// Picker entries for the triggered actions (catalog entries whose
+// single node declares a trigger), rendered by the same hook.
+function agendaTriggeredMandateRenderButtons(seg, closeAutomationSheet, getProjectRoot, entries) {
+  for (const entry of (Array.isArray(entries) ? entries : [])) {
+    if (entry.workflow) continue;
+    const node = (entry.nodes && entry.nodes[0]) || {};
+    if (!node.trigger_kind) continue;
+    const usable = entry.valid && !entry.shadowed;
+    const base = `${entry.title || entry.name} (${node.trigger_kind}:${(node.trigger_tags || []).join(',')})`;
     const btn = agendaStartSheetEl('button', 'ags-seg-btn',
-      `${template.title} (${template.itemKind}:${template.tags.join(',')})`);
+      usable ? base : `${base} (${entry.shadowed ? 'shadowed' : 'invalid'})`);
     btn.type = 'button';
-    btn.dataset.triggeredMandate = template.id;
+    btn.dataset.triggeredMandate = entry.name;
+    if (!usable) {
+      btn.disabled = true;
+      btn.title = entry.shadowed
+        ? 'shadowed by a personal definition of the same name'
+        : (entry.reason || 'invalid definition');
+      seg.appendChild(btn);
+      continue;
+    }
+    if (entry.advisories && entry.advisories.length) btn.title = entry.advisories.join('; ');
     btn.addEventListener('click', async () => {
       btn.disabled = true;
       try {
-        await agendaTriggeredMandateStamp(template,
+        await agendaTriggeredMandateStamp(entry,
           typeof getProjectRoot === 'function' ? getProjectRoot() : '');
         closeAutomationSheet();
       } catch (e) {

--- a/static/app/ui2-agenda.js
+++ b/static/app/ui2-agenda.js
@@ -1439,12 +1439,13 @@ function agendaPositionCard() {
   else document.addEventListener('DOMContentLoaded', wire, { once: true });
 }
 
-// ---- Mandate template library (Track AU) ----
-// The create-from-template picker's data: PINNED copies of the daemon's
-// registry (src/bin/caller/agenda/mandate_templates.rs — the source of
-// truth; its parity test fails if these bytes drift). A template is data
-// the owner reads and approves — the flow parks the item and proposes
-// the effect, and NEVER approves: the digest ceremony stays the owner's.
+// ---- Mandate template library (Track AU → AW migration window) ----
+// PINNED copies of the daemon's registry (src/bin/caller/agenda/
+// mandate_templates.rs — its parity tests fail if these bytes drift).
+// Since Track AW slice 3 the sheet reads the SERVED definition catalog
+// (below) instead of this table — it survives only as the migration
+// window's parity anchor, deleted together with the registry and the
+// other two tables in the cutover PR.
 const AGENDA_MANDATE_TEMPLATES = [
   {
     id: 'triage',
@@ -1544,14 +1545,57 @@ you.`,
   },
 ];
 
-// ---- Create-from-template: the Automate sheet (Track AU) ----
-// The ctl walkthrough as a guided flow: pick a mandate template, read
-// the FULL text (data the owner reads — never hidden or truncated),
-// choose cadence, first fire, and executor, then PARK the item and
-// PROPOSE the standing effect. The flow never approves — it lands the
-// owner on the ordinary card whose Approve affordance binds the digest;
-// the ceremony stays the owner's untouched final act (a registry
-// parity test pins this fragment approve-free).
+// ---- Served definition catalog (Track AW) ----
+// The Automate surfaces' data source: the daemon-served catalog
+// (GET /api/agenda/definitions). Every entry carries its validation
+// state, advisories, and the FULL definition text — exactly the bytes
+// a stamp of that entry would seal. Fetched on sheet open; cached so a
+// reopen paints instantly and refreshes in place. Invalid and shadowed
+// entries stay VISIBLE (disabled, with the reason) — the catalog never
+// hides a refusal.
+let agendaDefinitionCatalog = null; // null = never fetched; else the entries array
+let agendaDefinitionCatalogError = '';
+let agendaDefinitionCatalogLoading = false;
+
+function agendaFetchDefinitionCatalog(onSettled) {
+  if (agendaDefinitionCatalogLoading) return;
+  agendaDefinitionCatalogLoading = true;
+  daemonApi.request('api_agenda_definitions', {})
+    .then((res) => {
+      if (res.ok && res.body && Array.isArray(res.body.definitions)) {
+        agendaDefinitionCatalog = res.body.definitions;
+        agendaDefinitionCatalogError = '';
+      } else {
+        agendaDefinitionCatalogError =
+          (res.body && res.body.error) || `catalog fetch failed (${res.status})`;
+      }
+    })
+    .catch((e) => { agendaDefinitionCatalogError = String((e && e.message) || e); })
+    .finally(() => {
+      agendaDefinitionCatalogLoading = false;
+      if (typeof onSettled === 'function') onSettled();
+    });
+}
+
+// Catalog view: the cadenced actions drive the automate sheet itself;
+// triggered actions and workflows render through the workflows
+// fragment's picker hook off the same fetch.
+function agendaCatalogActions(entries) {
+  return (entries || []).filter((d) => !d.workflow
+    && !(((d.nodes && d.nodes[0]) || {}).trigger_kind));
+}
+
+// ---- Create-from-definition: the Automate sheet (Track AU → AW) ----
+// The ctl walkthrough as a guided flow: pick a definition from the
+// served catalog, read the FULL text (data the owner reads — never
+// hidden or truncated; exactly what a stamp seals), choose cadence,
+// first fire, and executor, then STAMP through the daemon's stamp op —
+// the daemon reads, validates, and seals the definition, PARKS the item
+// and PROPOSES the standing effect with the sheet's choices as prefills
+// into the ordinary manifest intake. The flow never approves — it lands
+// the owner on the ordinary card whose Approve affordance binds the
+// digest; the ceremony stays the owner's untouched final act (a parity
+// test pins this fragment approve-free).
 
 let agendaAutomationSheetOpen = false;
 
@@ -1611,7 +1655,8 @@ function agendaOpenAutomationSheet(anchor) {
   const panel = host.querySelector('.ags-panel');
   panel.textContent = '';
   agendaAutomationSheetOpen = true;
-  let template = AGENDA_MANDATE_TEMPLATES[0];
+  let entry = null; // the selected cadenced-action catalog entry
+  let selectedName = '';
 
   const head = agendaStartSheetEl('div', 'ags-head');
   head.appendChild(agendaStartSheetEl('span', 'ags-title', 'New automation'));
@@ -1622,16 +1667,16 @@ function agendaOpenAutomationSheet(anchor) {
   head.appendChild(close);
   panel.appendChild(head);
   panel.appendChild(agendaStartSheetEl('div', 'ags-sub',
-    'A standing supervised session on a cadence. This parks the mandate as an item and proposes its schedule — nothing runs until you approve the digest on the card.'));
+    'A standing supervised session on a cadence. Stamping seals the definition, parks it as an item, and proposes its schedule — nothing runs until you approve the digest on the card.'));
 
-  // Template picker.
+  // Definition picker (served catalog).
   const seg = agendaStartSheetEl('div', 'ags-seg agsx-templates');
   panel.appendChild(seg);
 
-  // Full mandate text — the owner reads exactly what the session will
-  // receive; textContent rendering, no markup execution.
+  // Full definition text — the owner reads exactly the bytes a stamp
+  // seals; textContent rendering, no markup execution.
   panel.appendChild(agendaStartSheetEl('label', 'ags-label',
-    'The mandate — the full text the session receives, and the item body'));
+    'The definition — the full text a stamp seals; approval binds exactly this revision'));
   const preview = agendaStartSheetEl('pre', 'agsx-preview');
   panel.appendChild(preview);
 
@@ -1777,50 +1822,98 @@ function agendaOpenAutomationSheet(anchor) {
   const park = agendaStartSheetEl('button', 'ags-btn ags-start', 'Park + propose');
   park.type = 'button';
   park.addEventListener('click', () => agendaAutomationSheetSubmit(
-    { template: () => template, cadence, fire, suspend, project, configState, error, park }));
+    { entry: () => entry, cadence, fire, suspend, project, configState, error, park }));
   foot.appendChild(cancel);
   foot.appendChild(park);
   panel.appendChild(foot);
 
-  const applyTemplate = () => {
+  const applyEntry = () => {
     seg.querySelectorAll('button').forEach((b) =>
-      b.classList.toggle('active', b.dataset.template === template.id));
-    preview.textContent = template.mandate;
-    cadence.value = String(template.everyMs);
-    suspend.value = String(template.suspendAfter);
+      b.classList.toggle('active', !!entry && b.dataset.definition === entry.name));
+    if (!entry) {
+      preview.textContent = agendaDefinitionCatalog === null && !agendaDefinitionCatalogError
+        ? 'Loading the definition catalog…'
+        : (agendaDefinitionCatalogError
+          ? `Definition catalog unavailable: ${agendaDefinitionCatalogError}`
+          : 'No stampable cadenced definitions in the catalog.');
+      park.disabled = true;
+      return;
+    }
+    park.disabled = false;
+    preview.textContent = entry.text;
+    const prefill = (entry.nodes && entry.nodes[0]) || {};
+    if (prefill.every_ms) {
+      const ms = String(prefill.every_ms);
+      if (!Array.from(cadence.options).some((o) => o.value === ms)) {
+        const option = document.createElement('option');
+        option.value = ms;
+        option.textContent = 'Definition default';
+        cadence.appendChild(option);
+      }
+      cadence.value = ms;
+    }
+    if (prefill.suspend_after) suspend.value = String(prefill.suspend_after);
+    else if (!suspend.value) suspend.value = '3';
   };
-  for (const t of AGENDA_MANDATE_TEMPLATES) {
-    const btn = agendaStartSheetEl('button', 'ags-seg-btn', t.title);
-    btn.type = 'button';
-    btn.dataset.template = t.id;
-    btn.addEventListener('click', () => { template = t; applyTemplate(); });
-    seg.appendChild(btn);
-  }
-  // Workflow templates (Track T) stamp an item-graph and hand off to
-  // their own approval sheet — rendered by the workflows fragment,
-  // which owns that whole lane.
-  if (typeof agendaWorkflowRenderPickerButtons === 'function') {
-    agendaWorkflowRenderPickerButtons(seg, agendaCloseAutomationSheet,
-      () => project.value.trim());
-  }
-  applyTemplate();
+  const selectable = (d) => d.valid && !d.shadowed;
+  const renderPicker = () => {
+    seg.textContent = '';
+    const actions = agendaCatalogActions(agendaDefinitionCatalog);
+    entry = actions.find((d) => selectable(d) && d.name === selectedName)
+      || actions.find(selectable) || null;
+    selectedName = entry ? entry.name : '';
+    for (const d of actions) {
+      const usable = selectable(d);
+      const btn = agendaStartSheetEl('button', 'ags-seg-btn', usable
+        ? (d.title || d.name)
+        : `${d.title || d.name} (${d.shadowed ? 'shadowed' : 'invalid'})`);
+      btn.type = 'button';
+      btn.dataset.definition = d.name;
+      if (!usable) {
+        btn.disabled = true;
+        btn.title = d.shadowed
+          ? 'shadowed by a personal definition of the same name'
+          : (d.reason || 'invalid definition');
+      } else {
+        if (d.advisories && d.advisories.length) btn.title = d.advisories.join('; ');
+        btn.addEventListener('click', () => { entry = d; selectedName = d.name; applyEntry(); });
+      }
+      seg.appendChild(btn);
+    }
+    // Triggered actions and workflows stamp their own lanes and hand
+    // off to their own surfaces — rendered by the workflows fragment
+    // off the same catalog fetch.
+    if (typeof agendaWorkflowRenderPickerButtons === 'function') {
+      agendaWorkflowRenderPickerButtons(seg, agendaCloseAutomationSheet,
+        () => project.value.trim(), agendaDefinitionCatalog || []);
+    }
+    applyEntry();
+  };
+  renderPicker();
+  agendaFetchDefinitionCatalog(() => {
+    if (agendaAutomationSheetOpen) renderPicker();
+  });
   agendaPresentStartSheet(host, panel, anchor);
 }
 
 async function agendaAutomationSheetSubmit(form) {
-  const template = form.template();
+  const entry = form.entry();
   const showError = (message) => {
     form.error.textContent = message;
     form.error.hidden = false;
   };
   form.error.hidden = true;
+  if (!entry) {
+    showError('Pick a definition first.');
+    return;
+  }
   const fireAt = form.fire.value ? new Date(form.fire.value).getTime() : NaN;
   if (!Number.isFinite(fireAt) || fireAt <= Date.now()) {
     showError('Pick a first-run time in the future.');
     form.fire.focus();
     return;
   }
-  const suspendAfter = Math.max(1, Number(form.suspend.value) || template.suspendAfter);
+  const suspendAfter = Math.max(1, Number(form.suspend.value) || 3);
   // Explicit executor picks only — untouched selects inherit (the start
   // sheet's exact assembly, so both lanes speak one vocabulary).
   const spec = form.configState && form.configState.spec;
@@ -1837,44 +1930,39 @@ async function agendaAutomationSheetSubmit(form) {
   }
   form.park.disabled = true;
   try {
-    // Park the mandate as an ordinary item (body = the template text,
-    // byte-verbatim — the parity pin's contract)…
-    const added = await daemonApi.request('api_agenda_op', {
-      op: 'add', kind: 'task', title: template.title, body: template.mandate,
-    });
-    if (!added.ok || !added.body || !added.body.item) {
-      showError((added.body && added.body.error) || `park failed (${added.status})`);
-      return;
-    }
-    agendaObserveServerMessage({ item: added.body.item });
-    const itemId = added.body.item.id;
-    // …then propose the standing effect on it. The goal is the same
-    // mandate text, so Run now and the cadence carry identical orders.
-    const propose = {
-      op: 'propose_effect',
-      id: itemId,
-      goal: template.mandate,
+    // One daemon-side stamp: the daemon reads, validates, and SEALS the
+    // definition, parks the item, and proposes the manifest — the
+    // sheet's choices ride as prefills into the ordinary manifest
+    // intake, never around it. Parks + proposes ONLY; approval stays
+    // the owner's per-effect act on the card.
+    const stamp = {
+      definition: entry.name,
       fire_at_ms: fireAt,
-      recurrence: {
-        every_ms: Number(form.cadence.value) || template.everyMs,
-        suspend_after_failures: suspendAfter,
-      },
+      suspend_after: suspendAfter,
     };
+    const everyMs = Number(form.cadence.value);
+    if (Number.isFinite(everyMs) && everyMs > 0) stamp.every_ms = everyMs;
     const projectRoot = form.project && form.project.value.trim();
-    if (projectRoot) propose.project_root = projectRoot;
-    if (Object.keys(agentConfig).length) propose.agent_config = agentConfig;
-    const proposed = await daemonApi.request('api_agenda_op', propose);
-    if (!proposed.ok || !proposed.body || !proposed.body.item) {
-      showError((proposed.body && proposed.body.error) || `propose failed (${proposed.status})`);
+    if (projectRoot) stamp.project_root = projectRoot;
+    if (Object.keys(agentConfig).length) stamp.agent_config = agentConfig;
+    const res = await daemonApi.request('api_agenda_stamp', stamp);
+    if (!res.ok || !res.body || !res.body.stamp) {
+      showError((res.body && res.body.error) || `stamp failed (${res.status})`);
       return;
     }
-    agendaObserveServerMessage({ item: proposed.body.item });
+    const outcome = res.body.stamp;
+    if (outcome.hub) agendaObserveServerMessage({ item: outcome.hub });
+    for (const node of outcome.nodes || []) {
+      if (node.item) agendaObserveServerMessage({ item: node.item });
+    }
     agendaCloseAutomationSheet();
     // Land the owner on the ordinary Approve affordance.
-    if (typeof agendaOpenInspector === 'function') agendaOpenInspector(itemId);
+    const landId = outcome.nodes && outcome.nodes[0] && outcome.nodes[0].item
+      ? outcome.nodes[0].item.id : null;
+    if (landId && typeof agendaOpenInspector === 'function') agendaOpenInspector(landId);
     if (typeof showControlToast === 'function') {
       showControlToast('success',
-        'Parked and proposed — approve the digest on the card to arm the series.');
+        'Stamped — sealed, parked, and proposed. Approve the digest on the card to arm the series.');
     }
   } catch (e) {
     showError(String(e && e.message || e));


### PR DESCRIPTION
Slice 3 of the Track AW migration arc (sealed automation definitions; design basis: the sealed intake + RULING + A1, slice-2 pass tail declares this slice's scope).

**What moves:** the Automate sheet and the workflow/triggered pickers stop reading the client template tables and consume the served surfaces from slice 2 (#635):

- Picker + preview derive from `GET /api/agenda/definitions` — entries carry validation state; invalid and shadowed entries render disabled with their reason (visible, never hidden); advisories ride as tooltips; cadence/suspend prefill from the catalog node.
- Every stamp is the daemon-side stamp op (`POST /api/agenda/stamp`): the daemon reads, validates, seals, parks, proposes; the sheet sends only the owner's overrides (prefills into the ordinary manifest intake). The sheet neither parks, proposes, nor approves client-side.
- The one-gesture approval sheet renders the SEALED definition once, in full, fetched from `GET /api/agenda/sealed/{sha256}` (exactly the bytes every node manifest pins), then per-node executor + digest chip rows — the ruled §2.4 shape.
- Landing targets and board observation ride the stamp outcome (`hub`/`nodes[].item`).

**What deliberately does not move (the migration window):** the three template tables stay byte-verbatim as parity anchors — `registry_files_byte_parity_during_the_window` and the three fragment-verbatim pins keep passing untouched — and die together with `mandate_templates.rs` in the cutover PR (next slice).

**Pin retarget (rename with cause):** the emission-shape law gets surviving copies in `static_assets.rs` — `automate_sheet_consumes_the_catalog_and_never_approves` and `workflow_surfaces_stamp_through_the_daemon_with_one_emitter`. Renamed from the ruled names because the ruled-name twins keep running in `mandate_templates.rs` until cutover (two same-named tests in one crate would be fine across modules, but distinct names keep the window's dual anchors legible); substance carried without weakening — 0×/1×-inside-emitter/single-callsite/after-confirm all asserted, plus new assertions: no client-side graph assembly survives (`add_relies_on`/`propose_effect`/`op: 'add'`/`op: 'place'` all 0×) and the sealed serving lane is consumed.

app.html regenerated through the assembler; docs updated (Surfaces paragraph + the fix-task stamping walkthrough prose; the byte-pinned walkthrough blocks untouched).