### PR TITLE
fix(external): delivery-aware rate-limit park re-send

### DIFF
--- a/docs/src/external-agent-orchestration.md
+++ b/docs/src/external-agent-orchestration.md
@@ -1052,15 +1052,24 @@ full credential before tearing its lease down.
 
 Claude Code's `rate_limit_event` with status `rejected`, correlated with the
 turn's terminal result, becomes `AgentEvent::TurnLimitRejected` rather than an
-ordinary completed round. The backend process remains usable, but the rejected
-round did no work and consumes no round budget. Both the foreground
-external-mode lane and persistent-daemon lane apply the same
-`external_supervision.rs` policy:
+ordinary completed round. The backend process remains usable and the rejected
+round consumes no round budget. Both the foreground external-mode lane and
+persistent-daemon lane apply the same `external_supervision.rs` policy:
 
-- The rejected message remains pending. If the wire supplied `resetsAt`, it is
-  resent after that instant plus 30–90 seconds of jitter; any one sleep is
-  capped at six hours so long windows are rechecked. Without a reset time,
-  consecutive rejections back off from 5 to 30 minutes.
+- The park is delivery-aware (`limit_park_pending`). When the rejection
+  arrived before the backend did anything (the instant-rejection shape), the
+  rejected message itself remains pending and is resent verbatim. When the
+  drain had already observed primary-turn work — assistant output, tool
+  activity — the backend consumed (and, for Claude Code, durably recorded)
+  the message mid-flight, so the park pends a short resume nudge instead:
+  resending the original would put the goal in the conversation twice and
+  make the backend re-read its whole mandate. The nudge inherits the rejected
+  message's follow-up/steer ids, so cancelling it while parked works exactly
+  like cancelling a full resend.
+- If the wire supplied `resetsAt`, the pending message is resent after that
+  instant plus 30–90 seconds of jitter; any one sleep is capped at six hours
+  so long windows are rechecked. Without a reset time, consecutive rejections
+  back off from 5 to 30 minutes.
 - Follow-ups arriving while parked queue FIFO behind the pending resend instead
   of being burned against the exhausted backend. A cancelled follow-up is
   skipped when the queue drains.

--- a/src/bin/caller/external_events.rs
+++ b/src/bin/caller/external_events.rs
@@ -37,6 +37,43 @@ pub(crate) const EXTERNAL_INTERRUPT_RPC_TIMEOUT: std::time::Duration =
 /// stop semantics even when a reload rides the same drain.
 pub(crate) const RELOAD_CREDENTIALS_INTERRUPT_REASON: &str = "reloading credentials";
 
+/// Whether an agent event proves the backend ENGAGED the round's driving
+/// message — assistant output, tool activity, plan/diff/file movement, an
+/// interaction request, or a completed turn. This is the rate-limit
+/// park's delivery awareness (`DrainOutcome::LimitRejected
+/// { turn_had_started }`): a rejection with none of these observed is the
+/// instant-rejection shape (the message never reached the model — safe to
+/// re-send verbatim), while a rejection after any of them cut a turn the
+/// backend already consumed the message for. Deliberately excluded:
+/// housekeeping that rides a rejected delivery too (`Log`, `Usage`,
+/// `RateLimitWindows`, `ActivityUpdate`, `ConfigFacts`, the park's own
+/// `GoalUpdated`/`GoalCleared`), identity/lifecycle announcements
+/// (`NativeSessionId`, `CwdAnnounced`, `Terminated`, `BackendError`), the
+/// rejection itself, and `UserMessage` echoes (adapters may surface
+/// queued/injected user rows before the model runs).
+pub(crate) fn agent_event_marks_round_started(event: &external_agent::AgentEvent) -> bool {
+    use external_agent::AgentEvent;
+    matches!(
+        event,
+        AgentEvent::MessageDelta { .. }
+            | AgentEvent::Message { .. }
+            | AgentEvent::Reasoning { .. }
+            | AgentEvent::PlanUpdate { .. }
+            | AgentEvent::SubAgentToolCall { .. }
+            | AgentEvent::ToolStarted { .. }
+            | AgentEvent::ToolOutputDelta { .. }
+            | AgentEvent::ToolCompleted { .. }
+            | AgentEvent::FileActivity { .. }
+            | AgentEvent::VcsActivity { .. }
+            | AgentEvent::CodeChangePublished { .. }
+            | AgentEvent::DiffUpdated { .. }
+            | AgentEvent::ApprovalRequest { .. }
+            | AgentEvent::FileApprovalRequest { .. }
+            | AgentEvent::UserQuestionRequest { .. }
+            | AgentEvent::TurnCompleted { .. }
+    )
+}
+
 /// Time-bounded `interrupt_turn()`. Every call inside the drain must go
 /// through this so an unresponsive backend can't wedge the drain loop itself.
 pub(crate) async fn interrupt_turn_bounded(
@@ -231,6 +268,13 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
     managed_context_density_handoff_completed: bool,
 ) -> DrainOutcome {
     let mut turns_in_round = 0usize;
+    // Delivery awareness for a limit rejection: set once the primary
+    // thread demonstrably engaged this round's driving message (see
+    // `agent_event_marks_round_started`). Round-scoped, never reset
+    // within the drain — any primary work means the delivery was
+    // consumed, even when a later backend-continued turn is the one the
+    // limit rejects.
+    let mut primary_round_started = false;
     let local_session_id = config.session_id.clone();
     let alias_session_id = config.alias_session_id.clone();
     // Track whether we've been asked to interrupt this drain cycle. When the
@@ -1245,6 +1289,10 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
         } else {
             config
         };
+
+        if event_is_primary && agent_event_marks_round_started(&event) {
+            primary_round_started = true;
+        }
 
         match event {
             external_agent::AgentEvent::NativeSessionId { session_id } => {
@@ -2709,11 +2757,16 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                         reason: interrupt_reason.clone(),
                     };
                 }
-                // Terminal immediately — a rejected turn ran nothing, so
-                // no trailing events justify the post-turn grace window.
+                // Terminal immediately — nothing runs after a rejection,
+                // so no trailing events justify the post-turn grace
+                // window. `turn_had_started` tells the park whether the
+                // rejection cut a turn mid-flight (re-send would double
+                // the delivered message) or refused it outright (re-send
+                // is safe).
                 return DrainOutcome::LimitRejected {
                     resets_at_epoch,
                     message,
+                    turn_had_started: primary_round_started,
                 };
             }
             external_agent::AgentEvent::Terminated { reason, exit_code } => {
@@ -3922,12 +3975,150 @@ mod tests {
             DrainOutcome::LimitRejected {
                 resets_at_epoch,
                 message,
+                turn_had_started,
             } => {
                 assert_eq!(resets_at_epoch, Some(1_783_990_800));
                 assert!(message.as_deref().is_some_and(|m| m.contains("limit")));
+                // Pin `full_resend_only_when_never_delivered`: an instant
+                // rejection saw no primary work, so the park may re-send
+                // the message verbatim.
+                assert!(!turn_had_started, "instant rejection did no work");
             }
             _ => panic!("expected LimitRejected, got a different outcome"),
         }
+    }
+
+    /// Pin `park_resend_is_delivery_aware`: a rejection that arrives
+    /// after the primary thread already streamed work (the mid-flight
+    /// shape — live specimen 800e6f58 did ~90s of tool calls before the
+    /// five_hour window cut the turn) reports `turn_had_started`, so the
+    /// park nudges instead of re-sending the delivered message.
+    #[tokio::test]
+    async fn drain_marks_limit_rejection_after_primary_work_as_started() {
+        let bus = EventBus::new();
+        let mut bus_rx_for_drain = bus.subscribe();
+        let dir = tempfile::tempdir().unwrap();
+        let log_dir = dir.path().join("session");
+        let session_log: SharedSessionLog = Arc::new(Mutex::new(
+            session_log::SessionLog::open(log_dir.clone()).unwrap(),
+        ));
+        let approval_registry: event::ApprovalRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let context_injection: event::ContextInjectionQueue = Arc::new(Mutex::new(Vec::new()));
+        let autonomy = autonomy::shared_autonomy(AutonomyState::default());
+        let config = DrainConfig {
+            bus: &bus,
+            web_port: None,
+            session_id: Some("native-thread".to_string()),
+            alias_session_id: None,
+            backend_thread_id: Some("native-thread".to_string()),
+            autonomy,
+            session_log: &session_log,
+            project_root: dir.path(),
+            log_dir: &log_dir,
+            approval_registry: &approval_registry,
+            json_approval: None,
+            agent_source: Some("Claude Code".to_string()),
+            suppress_agent_started: false,
+            persist_model_responses_inline: true,
+            headless: true,
+            context_injection: &context_injection,
+            reload_credentials: None,
+            coordination_declaration: None,
+        };
+        let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
+        event_tx
+            .send(external_agent::AgentEvent::Message {
+                text: "acknowledged — starting the mandate".to_string(),
+            })
+            .unwrap();
+        event_tx
+            .send(external_agent::AgentEvent::ToolStarted {
+                item_id: "tool-1".to_string(),
+                tool_name: "Bash".to_string(),
+                preview: "git status".to_string(),
+                message_uuid: None,
+            })
+            .unwrap();
+        event_tx
+            .send(external_agent::AgentEvent::TurnLimitRejected {
+                resets_at_epoch: Some(1_783_990_800),
+                message: Some("You've hit your session limit".to_string()),
+            })
+            .unwrap();
+
+        let interrupts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let steers = Arc::new(Mutex::new(Vec::new()));
+        let mut agent: Box<dyn external_agent::ExternalAgent> = Box::new(ManagedDrainTestAgent {
+            interrupts: interrupts.clone(),
+            steers: steers.clone(),
+        });
+        let mut stats = LoopStats::default();
+        let mut diff_tracker = ExternalDiffDeltaTracker::default();
+        let mut pending_runtime_steers = std::collections::VecDeque::new();
+        let mut handled_steer_ids = std::collections::HashSet::new();
+        let mut cancelled_follow_ups = HashSet::new();
+        let mut dedupe = CodexThreadActionDedupe::default();
+
+        let outcome = drain_external_agent_events(
+            &mut agent,
+            &mut event_rx,
+            &mut bus_rx_for_drain,
+            &config,
+            &mut stats,
+            &mut diff_tracker,
+            &mut pending_runtime_steers,
+            &mut handled_steer_ids,
+            &mut cancelled_follow_ups,
+            &mut dedupe,
+            None,
+            None,
+            false,
+            false,
+            false,
+        )
+        .await;
+        match outcome {
+            DrainOutcome::LimitRejected {
+                turn_had_started, ..
+            } => {
+                assert!(
+                    turn_had_started,
+                    "primary work before the rejection marks the turn started"
+                );
+            }
+            _ => panic!("expected LimitRejected, got a different outcome"),
+        }
+    }
+
+    /// The started-turn discriminator counts only events that prove the
+    /// model/tooling engaged the delivered message — housekeeping that
+    /// also rides an instantly-rejected delivery must not flip it.
+    #[test]
+    fn round_started_marker_ignores_rejection_housekeeping() {
+        use external_agent::AgentEvent;
+        for event in [
+            AgentEvent::Log {
+                level: "warn".to_string(),
+                message: "Rate-limited (five_hour window)".to_string(),
+            },
+            AgentEvent::NativeSessionId {
+                session_id: "800e6f58".to_string(),
+            },
+            AgentEvent::UserMessage {
+                text: "echoed queued prompt".to_string(),
+            },
+        ] {
+            assert!(
+                !agent_event_marks_round_started(&event),
+                "housekeeping event must not mark the round started: {event:?}"
+            );
+        }
+        assert!(agent_event_marks_round_started(&AgentEvent::Message {
+            text: "working".to_string()
+        }));
+        assert!(agent_event_marks_round_started(
+            &AgentEvent::TurnCompleted { message: None }
+        ));
     }
 
     /// Post-upgrade, frontends target the backend-native id; the drain's

--- a/src/bin/caller/external_mode.rs
+++ b/src/bin/caller/external_mode.rs
@@ -229,10 +229,11 @@ pub(crate) const RELOAD_MIDTURN_CONTINUATION_TEXT: &str =
 /// pass `false` (idle in, idle out), as does a turn that completed
 /// normally despite the request, or one whose interrupt belonged to the
 /// user (their stop wins). The message carries no steer/follow-up id, so
-/// id-keyed cancel matching can never drop it.
+/// id-keyed cancel matching can never drop it. Rides the shared
+/// [`midturn_continuation`] seam with the rate-limit park's resume nudge
+/// ([`limit_park_pending`]) — the started-turn decision lives once.
 fn synthesized_reload_continuation(reload_interrupted_turn: bool) -> Option<FollowUpMessage> {
-    reload_interrupted_turn
-        .then(|| FollowUpMessage::text(RELOAD_MIDTURN_CONTINUATION_TEXT.to_string()))
+    midturn_continuation(RELOAD_MIDTURN_CONTINUATION_TEXT, reload_interrupted_turn)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -3404,14 +3405,14 @@ pub(crate) async fn run_external_agent_mode(
             DrainOutcome::LimitRejected {
                 resets_at_epoch,
                 message: _,
+                turn_had_started,
             } => {
-                // The round did no work: hand its number back so the
-                // retried round reuses it, count no round (no DoneSignal /
-                // RoundComplete — those were the burn), and park instead
-                // of re-firing. The incident class burned follow-up
-                // rounds at decaying intervals until the budget silently
-                // exhausted, with the reset time on the wire the whole
-                // time.
+                // Hand the round number back so the retried round reuses
+                // it, count no round (no DoneSignal / RoundComplete —
+                // those were the burn), and park instead of re-firing.
+                // The incident class burned follow-up rounds at decaying
+                // intervals until the budget silently exhausted, with the
+                // reset time on the wire the whole time.
                 round = round.saturating_sub(1);
                 limit_park_streak = limit_park_streak.saturating_add(1);
                 let now_epoch = crate::session_activity::epoch_seconds();
@@ -3442,14 +3443,32 @@ pub(crate) async fn run_external_agent_mode(
                     ),
                 )
                 .await;
-                // Re-send exactly what the limit rejected: the merged
-                // text (queued steers were already consumed into it) with
-                // the original attachments.
+                // Delivery-aware pending (`limit_park_pending`): when the
+                // rejection arrived before the backend did anything, park
+                // exactly what it rejected — the merged text (queued
+                // steers were already consumed into it) with the original
+                // attachments. When the turn had already started, the
+                // backend holds that message; park a resume nudge instead
+                // of doubling it.
+                if turn_had_started {
+                    let line = format!(
+                        "The rejected turn had already started at {} — parking a resume nudge instead of re-sending the message",
+                        agent.name()
+                    );
+                    slog(&session_log, |l| l.info(&line));
+                    bus.send(AppEvent::LogEntry {
+                        session_id: live_session_id.clone(),
+                        level: "info".to_string(),
+                        source: "Intendant".to_string(),
+                        content: line,
+                        turn: None,
+                    });
+                }
                 let mut pending = active_followup_for_rewind_replay.clone();
                 pending.text = merged.clone();
                 limit_park = Some(LimitParkState {
                     resume_at: tokio::time::Instant::now() + delay,
-                    pending: Some(pending),
+                    pending: Some(limit_park_pending(pending, turn_had_started)),
                 });
             }
             DrainOutcome::ContextRewindRequested {

--- a/src/bin/caller/external_supervision.rs
+++ b/src/bin/caller/external_supervision.rs
@@ -1424,14 +1424,27 @@ pub(crate) enum DrainOutcome {
     },
     /// The turn ended rejected at a provider usage limit
     /// ([`external_agent::AgentEvent::TurnLimitRejected`]). The backend
-    /// process stays usable, but the round did no work: the caller must
-    /// consume no round budget and must NOT immediately re-fire —
-    /// instead it parks the pending follow-up until `resets_at_epoch`
-    /// (plus jitter; exponential backoff when absent) and queues user
-    /// input arriving meanwhile.
+    /// process stays usable; the caller must consume no round budget and
+    /// must NOT immediately re-fire — instead it parks the pending
+    /// follow-up until `resets_at_epoch` (plus jitter; exponential
+    /// backoff when absent) and queues user input arriving meanwhile.
+    ///
+    /// `turn_had_started` is the park's delivery awareness: `false` is
+    /// the classic instant-rejection shape (the round did no work; the
+    /// driving message never reached the model, so the park re-sends it
+    /// verbatim — true at-least-once). `true` means the drain observed
+    /// primary-turn work (assistant output, tool activity, a completed
+    /// turn) before the rejection: the backend consumed — and, for
+    /// backends with persistent rollouts, durably recorded — the driving
+    /// message, so re-sending it would put the goal in the conversation
+    /// twice ([`limit_park_pending`] parks a resume nudge instead;
+    /// observed live 2026-07-28, session 800e6f58: a five_hour rejection
+    /// ~90s into the first turn re-sent the whole goal at reset, and the
+    /// backend re-read its entire mandate).
     LimitRejected {
         resets_at_epoch: Option<u64>,
         message: Option<String>,
+        turn_had_started: bool,
     },
 }
 
@@ -1490,6 +1503,58 @@ pub(crate) fn limit_park_delay(
 pub(crate) struct LimitParkState {
     pub(crate) resume_at: tokio::time::Instant,
     pub(crate) pending: Option<FollowUpMessage>,
+}
+
+/// A continuation for a turn the backend had already STARTED when it was
+/// cut mid-flight. The turn's driving message is in the backend's
+/// conversation (Claude Code persists it to the rollout at delivery), so
+/// the safe continuation is a short nudge naming the cause — never a
+/// re-send of the original message, which would double it and make the
+/// backend re-read its whole mandate. `None` when the turn never started:
+/// the caller keeps its lane's never-delivered behavior (the rate-limit
+/// park re-sends the full rejected message; the credential-reload respawn
+/// queues nothing). Both mid-turn lanes ride this one constructor — the
+/// reload respawn's synthesized continuation
+/// (`external_mode::RELOAD_MIDTURN_CONTINUATION_TEXT`) and the limit
+/// park's resume nudge ([`LIMIT_MIDTURN_CONTINUATION_TEXT`]) — one seam
+/// for the delivery-aware decision, never two copies.
+pub(crate) fn midturn_continuation(text: &str, turn_had_started: bool) -> Option<FollowUpMessage> {
+    turn_had_started.then(|| FollowUpMessage::text(text.to_string()))
+}
+
+/// The resume nudge a rate-limit park re-sends when the provider limit
+/// rejected a turn the backend had already started (see
+/// [`limit_park_pending`]).
+pub(crate) const LIMIT_MIDTURN_CONTINUATION_TEXT: &str =
+    "A provider rate limit interrupted the previous turn mid-stream; the limit has reset — \
+     continue where you left off. Do not expect the interrupted message to be re-sent: it is \
+     already in this conversation.";
+
+/// The message a rate-limit park re-sends at reset — delivery-aware, and
+/// the one seam both park lanes (the supervised external-mode loop and
+/// the persistent daemon lane) construct their pending from. When the
+/// rejected round never started at the backend, the park pends `rejected`
+/// itself (the merged text with its original attachments — the message
+/// truly was never delivered). When the round HAD started, the park pends
+/// a [`midturn_continuation`] resume nudge instead, inheriting the
+/// rejected message's follow-up/steer ids so a user cancel during the
+/// park cancels the resume exactly like it cancels a full re-send; the
+/// nudge deliberately carries none of the rejected message's attachments
+/// or edit/rewind directives — those were already applied when the turn
+/// started, and re-playing an edit rollback would rewind the backend a
+/// second time.
+pub(crate) fn limit_park_pending(
+    rejected: FollowUpMessage,
+    turn_had_started: bool,
+) -> FollowUpMessage {
+    match midturn_continuation(LIMIT_MIDTURN_CONTINUATION_TEXT, turn_had_started) {
+        Some(mut nudge) => {
+            nudge.follow_up_id = rejected.follow_up_id;
+            nudge.steer_id = rejected.steer_id;
+            nudge
+        }
+        None => rejected,
+    }
 }
 
 /// The session-log/activity row announcing a park. One place so the two
@@ -1632,6 +1697,82 @@ pub(crate) fn shared_codex_config_from_project(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn rejected_park_message() -> FollowUpMessage {
+        let mut rejected = FollowUpMessage::text("the whole goal, re-merged".to_string());
+        rejected.follow_up_id = Some("f-goal".to_string());
+        rejected.steer_id = Some("s-goal".to_string());
+        rejected.edit_user_turn_index = Some(3);
+        rejected.edit_user_turn_revision = Some(1);
+        rejected.edit_original_text = Some("original".to_string());
+        rejected
+            .claude_inplace_rewind_targets
+            .push("uuid-1".to_string());
+        rejected
+    }
+
+    /// Pin `full_resend_only_when_never_delivered`: an instant rejection
+    /// (the backend never engaged the message) parks the rejected
+    /// message verbatim — text, ids, and edit/rewind directives intact —
+    /// because the delivery truly never happened.
+    #[test]
+    fn full_resend_only_when_never_delivered() {
+        let rejected = rejected_park_message();
+        let pending = limit_park_pending(rejected.clone(), false);
+        assert_eq!(pending.text, rejected.text);
+        assert_eq!(pending.follow_up_id, rejected.follow_up_id);
+        assert_eq!(pending.steer_id, rejected.steer_id);
+        assert_eq!(pending.edit_user_turn_index, Some(3));
+        assert_eq!(
+            pending.claude_inplace_rewind_targets,
+            vec!["uuid-1".to_string()]
+        );
+    }
+
+    /// Pin `resume_nudge_when_turn_had_started` (and
+    /// `park_resend_is_delivery_aware`): a rejection that cut a turn the
+    /// backend had already started parks a short resume nudge — the
+    /// delivered message is already in the backend's conversation, so
+    /// re-flushing it would double the goal (live specimen 2026-07-28,
+    /// session 800e6f58). The nudge inherits the rejected message's
+    /// follow-up/steer ids so the park-elapse cancel check still honors
+    /// a user cancel, and drops attachments and edit/rewind directives —
+    /// those were applied when the turn started.
+    #[test]
+    fn resume_nudge_when_turn_had_started() {
+        let rejected = rejected_park_message();
+        let pending = limit_park_pending(rejected, true);
+        assert_eq!(pending.text, LIMIT_MIDTURN_CONTINUATION_TEXT);
+        assert_eq!(pending.follow_up_id.as_deref(), Some("f-goal"));
+        assert_eq!(pending.steer_id.as_deref(), Some("s-goal"));
+        assert!(pending.attachments.items.is_empty());
+        assert_eq!(pending.edit_user_turn_index, None);
+        assert_eq!(pending.edit_user_turn_revision, None);
+        assert_eq!(pending.edit_original_text, None);
+        assert!(pending.claude_inplace_rewind_targets.is_empty());
+
+        // The park-elapse cancel gate matches the nudge through the
+        // inherited ids: cancelling the original message cancels the
+        // resume, exactly like it cancels a full re-send.
+        let mut cancelled: HashSet<String> = HashSet::from(["f-goal".to_string()]);
+        assert!(crate::external_events::follow_up_message_was_cancelled(
+            &mut cancelled,
+            &pending
+        ));
+    }
+
+    /// Both mid-turn continuation lanes ride [`midturn_continuation`]:
+    /// the started-turn decision ("nudge, never a re-send") has one home
+    /// for the rate-limit park and the credential-reload respawn alike.
+    #[test]
+    fn midturn_continuation_is_the_shared_started_turn_seam() {
+        assert!(midturn_continuation(LIMIT_MIDTURN_CONTINUATION_TEXT, false).is_none());
+        let nudge = midturn_continuation(LIMIT_MIDTURN_CONTINUATION_TEXT, true)
+            .expect("a started turn synthesizes a continuation");
+        assert_eq!(nudge.text, LIMIT_MIDTURN_CONTINUATION_TEXT);
+        assert!(nudge.follow_up_id.is_none());
+        assert!(nudge.steer_id.is_none());
+    }
 
     #[test]
     fn consumed_kimi_anchor_staging_is_not_a_durable_resume_pin() {

--- a/src/bin/caller/run_modes.rs
+++ b/src/bin/caller/run_modes.rs
@@ -3363,13 +3363,14 @@ pub(crate) async fn run_with_presence(
                     DrainOutcome::LimitRejected {
                         resets_at_epoch,
                         message: _,
+                        turn_had_started,
                     } => {
-                        // Park-until-reset: the round did no work — count
-                        // nothing, emit no DoneSignal/RoundComplete, and
-                        // arm the outer-select resume timer instead of
-                        // re-firing (the incident class burned rounds at
-                        // decaying intervals with the reset time on the
-                        // wire the whole time).
+                        // Park-until-reset: count nothing, emit no
+                        // DoneSignal/RoundComplete, and arm the
+                        // outer-select resume timer instead of re-firing
+                        // (the incident class burned rounds at decaying
+                        // intervals with the reset time on the wire the
+                        // whole time).
                         persistent_limit_park_streak =
                             persistent_limit_park_streak.saturating_add(1);
                         let now_epoch = crate::session_activity::epoch_seconds();
@@ -3397,16 +3398,34 @@ pub(crate) async fn run_with_presence(
                             format!("{} rate-limited; parked until the limit resets", backend),
                         )
                         .await;
-                        // Re-send exactly what the limit rejected: the
-                        // merged text (queued steers were already consumed
-                        // into it) with the original attachments. The
+                        // Delivery-aware pending (`limit_park_pending`):
+                        // an instant rejection parks exactly what the
+                        // limit rejected — the merged text (queued steers
+                        // were already consumed into it) with the
+                        // original attachments — while a turn the backend
+                        // had already started parks a resume nudge
+                        // instead of doubling the delivered message. The
                         // while-loop ends here; the outer select owns the
                         // timer and the parked-flush preamble re-sends.
+                        if turn_had_started {
+                            let line = format!(
+                                "The rejected turn had already started at {} — parking a resume nudge instead of re-sending the message",
+                                backend
+                            );
+                            slog(&session_log, |l| l.info(&line));
+                            bus.send(AppEvent::LogEntry {
+                                session_id: session_log_id(&session_log),
+                                level: "info".to_string(),
+                                source: "Intendant".to_string(),
+                                content: line,
+                                turn: None,
+                            });
+                        }
                         let mut pending = active_followup;
                         pending.text = merged_text.clone();
                         persistent_limit_park = Some(LimitParkState {
                             resume_at: tokio::time::Instant::now() + delay,
-                            pending: Some(pending),
+                            pending: Some(limit_park_pending(pending, turn_had_started)),
                         });
                     }
                     DrainOutcome::RecoveryRequired {


### PR DESCRIPTION
A provider limit that rejects a turn **mid-flight** (the backend already streamed work) used to park the full rejected message and re-send it verbatim at reset — the backend's conversation then held the goal twice and the model re-read its whole mandate. Live specimen `800e6f58` (2026-07-28): ~90s of tool calls before the five_hour window cut the first turn; the 17:00 re-send duplicated the goal. 8 of 15 grid sessions in the 16:54 agenda cohort hit the same shape.

**Drain:** `DrainOutcome::LimitRejected` now carries `turn_had_started`, set once any primary-thread work event was observed (assistant output, tool activity, plan/diff/file movement, an interaction request, a completed turn — `agent_event_marks_round_started`). Rejection housekeeping (`Log`, `Usage`, `RateLimitWindows`, the park's own `GoalUpdated`, `NativeSessionId`, `UserMessage` echoes) never flips it.

**Park lanes:** both lanes (supervised external-mode loop + persistent daemon lane) build their pending through one shared seam, `limit_park_pending`:
- turn never started → park the rejected message verbatim (true at-least-once; unchanged behavior),
- turn had started → park a short **resume nudge** that inherits the rejected message's follow-up/steer ids (park-elapse cancel still works) and drops attachments + edit/rewind directives (already applied when the turn started).

The nudge rides the same `midturn_continuation` constructor as the credential-reload respawn's synthesized continuation (#640) — the started-turn decision has one home. Docs chapter updated. Sibling SPA render-lane fix ships separately.

Pins (test names): `park_resend_is_delivery_aware` · `full_resend_only_when_never_delivered` · `resume_nudge_when_turn_had_started` · `midturn_continuation_is_the_shared_started_turn_seam` · `drain_marks_limit_rejection_after_primary_work_as_started` · `round_started_marker_ignores_rejection_housekeeping`.

Fired from agenda item 01KYN9HYRGM5PQPDKJ3X7FESHW (goal-redelivery findings, sha256 7eb108a8…).