### PR TITLE
fix(dashboard): transcript render lanes pair across the bootstrap addendum and at append time

### DIFF
--- a/src/bin/caller/external_agent/claude_code.rs
+++ b/src/bin/caller/external_agent/claude_code.rs
@@ -4673,6 +4673,56 @@ impl Drop for ClaudeCodeAgent {
 mod tests {
     use super::*;
 
+    /// Pin `render_lanes_pair_across_bootstrap_addendum`: the dashboard's
+    /// transcript dedupe aliases a user row's content net of the
+    /// supervision addendum so the wrapper-lane row (always net) and an
+    /// addendum-bearing backend-native row pair as one delivery. The SPA
+    /// can't derive the marker from this file, so its static mirror
+    /// (`SESSION_SUPERVISION_ADDENDUM_MARKER`) is pinned here
+    /// byte-for-byte, alongside the alias site that consumes it — a
+    /// marker change that forgets the dashboard fails the suite instead
+    /// of shipping as silent render-lane drift.
+    #[test]
+    fn render_lanes_pair_across_bootstrap_addendum() {
+        let app = include_str!("../../../../static/app.html");
+        let mirror = format!(
+            "const SESSION_SUPERVISION_ADDENDUM_MARKER = '{}';",
+            CLAUDE_CODE_BOOTSTRAP_ADDENDUM_MARKER
+        );
+        assert!(
+            app.contains(&mirror),
+            "static/app (31-init-identity-fleet.js) must mirror \
+             CLAUDE_CODE_BOOTSTRAP_ADDENDUM_MARKER verbatim: {mirror:?}"
+        );
+        assert!(
+            app.contains("raw.indexOf(SESSION_SUPERVISION_ADDENDUM_MARKER)"),
+            "the transcript content-alias site (39-session-windows.js) must \
+             consume the addendum marker"
+        );
+    }
+
+    /// Pin `appended_rows_arm_near_time_pairing`: the window-history
+    /// append/insert dedupe arms the same user-near-time bridge the batch
+    /// pass arms, so a wrapper-lane and transcript-lane copy of one
+    /// prompt pairs at append time instead of rendering twice until a
+    /// batch pass happens to run.
+    #[test]
+    fn appended_rows_arm_near_time_pairing() {
+        let app = include_str!("../../../../static/app.html");
+        assert!(
+            app.contains("const armed = { includeUserNearTime: true, ...options };"),
+            "addSessionWindowHistorySignatures (40-session-launch.js) must arm \
+             the user-near-time bridge for the append-path signature sets"
+        );
+        assert!(
+            app.contains(
+                "sessionWindowTranscriptSignaturesForHistoryItem(item, fallbackSessionId, { includeUserNearTime: true })"
+            ),
+            "sessionWindowHistoryHasMatchingSignature (40-session-launch.js) must \
+             match with the user-near-time bridge armed"
+        );
+    }
+
     fn test_reader() -> CcReader {
         CcReader::new(
             Arc::new(CcShared::new(None)),

--- a/static/app.html
+++ b/static/app.html
@@ -37044,7 +37044,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'f85a9667af33c785';
+const INTENDANT_APP_BUILD = '4a2747cd88d96af5';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -37796,6 +37796,15 @@ const SESSION_WINDOW_RESTORE_LIMIT = 6;
 const SESSION_WINDOW_RESTORE_LOG_LIMIT = 250;
 const SESSION_TEXT_SIGNATURE_CHAR_LIMIT = 8192;
 const SESSION_RENDERED_SIGNATURE_CHAR_LIMIT = 4096;
+// First heading of the supervision addendum the wrapper appends to an
+// external backend's first prompt. A backend-native transcript user row
+// can carry the prompt WITH this addendum while the wrapper's own user
+// row logs it net (older daemons serve the raw rollout text; current
+// ones strip at parse) — the transcript dedupe aliases the pre-marker
+// text so the two lanes pair across that skew. Static mirror of the
+// Rust source (CLAUDE_CODE_BOOTSTRAP_ADDENDUM_MARKER, claude_code.rs);
+// a daemon-side parity test pins the two byte-for-byte.
+const SESSION_SUPERVISION_ADDENDUM_MARKER = '### Intendant Supervision';
 const STATION_ACTIVITY_TEXT_CHAR_LIMIT = 1200;
 const STATION_ANCHOR_DETAIL_CHAR_LIMIT = 2000;
 // 0 = collapsed replay/hydration output rows NEVER carry their text in the
@@ -64291,8 +64300,17 @@ function sessionWindowTranscriptContentAliasesForRecord(record = {}) {
     seen.add(content);
     aliases.push(content);
   };
-  add(record.content || record.summary || record.message || '');
+  const raw = String(record.content || record.summary || record.message || '');
+  add(raw);
   add(sessionWindowTranscriptRenderedContentForRecord(record));
+  // A user row carrying the wrapper's supervision addendum also aliases
+  // the prompt net of it, so the wrapper-lane row (always net) and a
+  // backend-native transcript row (addendum-bearing when an older daemon
+  // serves the raw rollout) pair as one delivery instead of rendering
+  // twice. Turn metadata and the near-time bucket still have to agree —
+  // this only removes the appended-boilerplate content skew.
+  const markerAt = raw.indexOf(SESSION_SUPERVISION_ADDENDUM_MARKER);
+  if (markerAt > 0) add(raw.slice(0, markerAt).trimEnd());
   return aliases;
 }
 
@@ -64637,13 +64655,13 @@ function appendMissingRestoredSessionWindowEntries(win, entries, fallbackSession
   );
   const existing = new Set();
   for (const item of ensureSessionWindowHistory(win)) {
-    for (const signature of sessionWindowTranscriptSignaturesForHistoryItem(item, fallbackSessionId)) {
+    for (const signature of sessionWindowTranscriptSignaturesForHistoryItem(item, fallbackSessionId, { includeUserNearTime: true })) {
       existing.add(signature);
     }
   }
   const missing = [];
   for (const record of records) {
-    const signatures = sessionWindowTranscriptSignaturesForRecord(record, fallbackSessionId);
+    const signatures = sessionWindowTranscriptSignaturesForRecord(record, fallbackSessionId, { includeUserNearTime: true });
     if (signatures.length > 0 && signatures.some(signature => existing.has(signature))) continue;
     // The synthesized completed-terminal row (kind subagent_terminal,
     // served by the task-child hydration lane) and the live "Task
@@ -67402,9 +67420,19 @@ function appendSessionWindowRenderedTailItems(win, items, startIndex, historyLen
   return true;
 }
 
+// The window-history dedupe subsystem (the signature sets the append and
+// insert paths consult, and the membership check below) arms the same
+// user-near-time bridge the batch pass (deduplicateSessionWindowHistory)
+// arms: without it, a wrapper-lane and transcript-lane copy of one prompt
+// whose turn metadata disagrees deduped only when a later batch pass
+// happened to run, and a live-appended row rendered as a duplicate until
+// then. Near-time's distinct-repeated-prompts safety bar (<5s, see
+// sessionWindowTranscriptTimeBuckets) already governs the batch pass, so
+// arming appends widens no collapse envelope — it closes the timing hole.
 function addSessionWindowHistorySignatures(set, item, fallbackSessionId = '', options = {}) {
   if (!set) return;
-  for (const signature of sessionWindowTranscriptSignaturesForHistoryItem(item, fallbackSessionId, options)) {
+  const armed = { includeUserNearTime: true, ...options };
+  for (const signature of sessionWindowTranscriptSignaturesForHistoryItem(item, fallbackSessionId, armed)) {
     set.add(signature);
   }
 }
@@ -67463,7 +67491,7 @@ function invalidateSessionWindowHistorySignatureCache(win) {
 
 function sessionWindowHistoryHasMatchingSignature(signatures, item, fallbackSessionId = '') {
   if (!signatures) return false;
-  const itemSignatures = sessionWindowTranscriptSignaturesForHistoryItem(item, fallbackSessionId);
+  const itemSignatures = sessionWindowTranscriptSignaturesForHistoryItem(item, fallbackSessionId, { includeUserNearTime: true });
   return itemSignatures.length > 0 && itemSignatures.some(signature => signatures.has(signature));
 }
 

--- a/static/app/31-init-identity-fleet.js
+++ b/static/app/31-init-identity-fleet.js
@@ -765,6 +765,15 @@ const SESSION_WINDOW_RESTORE_LIMIT = 6;
 const SESSION_WINDOW_RESTORE_LOG_LIMIT = 250;
 const SESSION_TEXT_SIGNATURE_CHAR_LIMIT = 8192;
 const SESSION_RENDERED_SIGNATURE_CHAR_LIMIT = 4096;
+// First heading of the supervision addendum the wrapper appends to an
+// external backend's first prompt. A backend-native transcript user row
+// can carry the prompt WITH this addendum while the wrapper's own user
+// row logs it net (older daemons serve the raw rollout text; current
+// ones strip at parse) — the transcript dedupe aliases the pre-marker
+// text so the two lanes pair across that skew. Static mirror of the
+// Rust source (CLAUDE_CODE_BOOTSTRAP_ADDENDUM_MARKER, claude_code.rs);
+// a daemon-side parity test pins the two byte-for-byte.
+const SESSION_SUPERVISION_ADDENDUM_MARKER = '### Intendant Supervision';
 const STATION_ACTIVITY_TEXT_CHAR_LIMIT = 1200;
 const STATION_ANCHOR_DETAIL_CHAR_LIMIT = 2000;
 // 0 = collapsed replay/hydration output rows NEVER carry their text in the

--- a/static/app/39-session-windows.js
+++ b/static/app/39-session-windows.js
@@ -4590,8 +4590,17 @@ function sessionWindowTranscriptContentAliasesForRecord(record = {}) {
     seen.add(content);
     aliases.push(content);
   };
-  add(record.content || record.summary || record.message || '');
+  const raw = String(record.content || record.summary || record.message || '');
+  add(raw);
   add(sessionWindowTranscriptRenderedContentForRecord(record));
+  // A user row carrying the wrapper's supervision addendum also aliases
+  // the prompt net of it, so the wrapper-lane row (always net) and a
+  // backend-native transcript row (addendum-bearing when an older daemon
+  // serves the raw rollout) pair as one delivery instead of rendering
+  // twice. Turn metadata and the near-time bucket still have to agree —
+  // this only removes the appended-boilerplate content skew.
+  const markerAt = raw.indexOf(SESSION_SUPERVISION_ADDENDUM_MARKER);
+  if (markerAt > 0) add(raw.slice(0, markerAt).trimEnd());
   return aliases;
 }
 
@@ -4936,13 +4945,13 @@ function appendMissingRestoredSessionWindowEntries(win, entries, fallbackSession
   );
   const existing = new Set();
   for (const item of ensureSessionWindowHistory(win)) {
-    for (const signature of sessionWindowTranscriptSignaturesForHistoryItem(item, fallbackSessionId)) {
+    for (const signature of sessionWindowTranscriptSignaturesForHistoryItem(item, fallbackSessionId, { includeUserNearTime: true })) {
       existing.add(signature);
     }
   }
   const missing = [];
   for (const record of records) {
-    const signatures = sessionWindowTranscriptSignaturesForRecord(record, fallbackSessionId);
+    const signatures = sessionWindowTranscriptSignaturesForRecord(record, fallbackSessionId, { includeUserNearTime: true });
     if (signatures.length > 0 && signatures.some(signature => existing.has(signature))) continue;
     // The synthesized completed-terminal row (kind subagent_terminal,
     // served by the task-child hydration lane) and the live "Task

--- a/static/app/40-session-launch.js
+++ b/static/app/40-session-launch.js
@@ -1558,9 +1558,19 @@ function appendSessionWindowRenderedTailItems(win, items, startIndex, historyLen
   return true;
 }
 
+// The window-history dedupe subsystem (the signature sets the append and
+// insert paths consult, and the membership check below) arms the same
+// user-near-time bridge the batch pass (deduplicateSessionWindowHistory)
+// arms: without it, a wrapper-lane and transcript-lane copy of one prompt
+// whose turn metadata disagrees deduped only when a later batch pass
+// happened to run, and a live-appended row rendered as a duplicate until
+// then. Near-time's distinct-repeated-prompts safety bar (<5s, see
+// sessionWindowTranscriptTimeBuckets) already governs the batch pass, so
+// arming appends widens no collapse envelope — it closes the timing hole.
 function addSessionWindowHistorySignatures(set, item, fallbackSessionId = '', options = {}) {
   if (!set) return;
-  for (const signature of sessionWindowTranscriptSignaturesForHistoryItem(item, fallbackSessionId, options)) {
+  const armed = { includeUserNearTime: true, ...options };
+  for (const signature of sessionWindowTranscriptSignaturesForHistoryItem(item, fallbackSessionId, armed)) {
     set.add(signature);
   }
 }
@@ -1619,7 +1629,7 @@ function invalidateSessionWindowHistorySignatureCache(win) {
 
 function sessionWindowHistoryHasMatchingSignature(signatures, item, fallbackSessionId = '') {
   if (!signatures) return false;
-  const itemSignatures = sessionWindowTranscriptSignaturesForHistoryItem(item, fallbackSessionId);
+  const itemSignatures = sessionWindowTranscriptSignaturesForHistoryItem(item, fallbackSessionId, { includeUserNearTime: true });
   return itemSignatures.length > 0 && itemSignatures.some(signature => signatures.has(signature));
 }
 


### PR DESCRIPTION
Each real delivery of an external session's prompt could render **twice** in a session window — the wrapper daemon-log lane and the backend-native transcript lane both carry a user row for the same turn, and the signature dedupe missed the pair in two shapes (live specimen `e0497571`/`800e6f58`: the maximized window showed every delivery twice, 4 visible copies total with the daemon-side double delivery):

**Content skew across the supervision addendum.** A backend-native user row can carry the prompt WITH the `### Intendant Supervision` addendum while the wrapper row logs it net. Current daemons strip at parse (`user_prose`, transcripts.rs), but older/not-yet-restarted daemons and peer dashboards still serve the raw rollout text — and no signature could pair 7494-char vs 5168-char contents. The content aliases now include the pre-marker text (`trimEnd()`-normalized so the `[len:N]` compaction suffix agrees for >8k prompts); turn metadata and the near-time bucket still have to agree, so this only removes the appended-boilerplate skew. The marker is a static mirror of `CLAUDE_CODE_BOOTSTRAP_ADDENDUM_MARKER`, pinned byte-for-byte by a daemon-side parity test (same pattern as the peer-profile picker pin).

**Append-path timing hole.** The `user-near-time-text` bridge — the signature that pairs one prompt across lanes whose turn metadata disagrees (e.g. a native row served without `user_turn_revision`) — was armed only in the batch dedupe pass (`deduplicateSessionWindowHistory`), so a live-appended row rendered as a duplicate until some later batch pass happened to run. `addSessionWindowHistorySignatures` / `sessionWindowHistoryHasMatchingSignature` and the restored-entries path now arm the same bridge. Near-time's <5s distinct-repeated-prompts safety bar already governed the batch pass, so this widens no collapse envelope — it closes the timing hole.

Fragments only; `static/app.html` regenerated via `cargo run -p app-html-assembler` on top of #642/#641/#629's landings. Sibling daemon-side fix #643 (in queue) removes the double delivery itself.

Pins (test names): `render_lanes_pair_across_bootstrap_addendum` · `appended_rows_arm_near_time_pairing`.

Fired from agenda item 01KYN9HYRGM5PQPDKJ3X7FESHW (goal-redelivery findings, sha256 7eb108a8…).