### PR TITLE
feat(handover): HS4 — memory-plane transfer follows the lease (+ the HS3 ruling's F1)

### DIFF
--- a/docs/src/agenda-and-memory.md
+++ b/docs/src/agenda-and-memory.md
@@ -1255,7 +1255,7 @@ durability.
 The current durable directory is:
 
 ```text
-~/.intendant/memory-plane/
+<INTENDANT_HOME or ~/.intendant>/memory-plane/
 ├── ctrl.iplog          plaintext genesis/control log
 ├── tenant.iplog        encrypted tenant item commits
 ├── custody.v1.json     0600 custody seeds and plane identifiers
@@ -1272,10 +1272,19 @@ mode rather than the macOS Keychain. Full multi-platform and OS-keystore
 custody remain outside this product slice. Memory is local to one daemon; no
 replica, backup, or cross-machine synchronization guarantee is shipped.
 
-> **Current path exception:** unlike other daemon state, durable Memory
-> currently resolves `~/.intendant/memory-plane` directly and does not honor
-> `INTENDANT_HOME`. This is a source/configuration inconsistency, not a
-> supported second state-root policy.
+**Co-homed daemons and handover:** durable-plane-open authority follows the
+active-scheduler lease. A co-homed secondary never opens the durable store —
+its memory surface serves a named `plane-follows-holder` refusal pointing at
+the holder (this replaced the old silent lifetime-ephemeral fallback, whose
+durable-intent writes were lost on exit). The lease holder acquires the store
+with a bounded retry: `plane.lock` held by another live daemon
+(`lock-denied`) is retried — it is not store corruption, and only genuine
+store failure falls to the labeled ephemeral plane. During a drain the
+departing daemon releases the store at drain entry (before the lease flock
+frees) and refuses reads and writes with `plane-handed-over` and the
+successor's port; the successor's retry acquires the same plane — identity,
+claims, and judgments carry over, because the plane's writer device is
+per-installation, not per-process.
 
 ### Surfaces and permissions
 

--- a/src/bin/caller/gateway_routes.rs
+++ b/src/bin/caller/gateway_routes.rs
@@ -3161,6 +3161,11 @@ mod tests {
             policy("POST", "/api/diagnostics/visual-freshness"),
             BodyPolicy::Capped(DIAGNOSTICS_BODY_CAP_BYTES)
         );
+        // The takeover request carries only a display label (HS3).
+        assert_eq!(
+            policy("POST", "/api/daemon/takeover"),
+            BodyPolicy::Capped(4 * 1024)
+        );
         // The agenda command lane accepts the rich-ask park payload: the
         // ≤8 MB preview budget as base64 JSON needs more than Default.
         assert_eq!(

--- a/src/bin/caller/handover/mod.rs
+++ b/src/bin/caller/handover/mod.rs
@@ -72,6 +72,11 @@ pub(crate) struct HandoverRuntime {
     /// (agenda store failed — nothing fires), `request_drain` performs
     /// the entry inline.
     scheduler_attached: std::sync::atomic::AtomicBool,
+    /// Drain-entry hooks (§3.2 step 3), run BETWEEN the sidecar's
+    /// `draining` flip and the flock release — HS4's memory-plane
+    /// release installs here. Hooks must be quick, idempotent, and
+    /// infallible (failures are their own to log).
+    drain_hooks: std::sync::Mutex<Vec<Box<dyn Fn() + Send + Sync>>>,
 }
 
 #[derive(Default)]
@@ -176,6 +181,7 @@ impl HandoverRuntime {
             drain: std::sync::Mutex::new(DrainState::default()),
             drain_notify: tokio::sync::Notify::new(),
             scheduler_attached: std::sync::atomic::AtomicBool::new(false),
+            drain_hooks: std::sync::Mutex::new(Vec::new()),
         }
     }
 
@@ -266,6 +272,25 @@ impl HandoverRuntime {
         }
     }
 
+    /// Register a drain-entry hook (HS4+: the memory-plane release).
+    /// Runs between the sidecar's `draining` flip and the flock release,
+    /// in registration order. Late registration during an active drain
+    /// runs the hook immediately — the entry already happened.
+    pub(crate) fn on_drain_entry(&self, hook: Box<dyn Fn() + Send + Sync>) {
+        let already_entered = self
+            .drain
+            .lock()
+            .map(|drain| drain.entered_ms.is_some())
+            .unwrap_or(false);
+        if already_entered {
+            hook();
+            return;
+        }
+        if let Ok(mut hooks) = self.drain_hooks.lock() {
+            hooks.push(hook);
+        }
+    }
+
     /// A scheduler attached: drain entry becomes its between-passes duty
     /// (a firing pass can then never straddle the flock release).
     pub(crate) fn attach_scheduler(&self) {
@@ -350,6 +375,16 @@ impl HandoverRuntime {
             if let Some(mut lease) = slot.take() {
                 if let Err(err) = lease.mark_draining(&self.state_root) {
                     eprintln!("[handover] drain sidecar write failed ({err}) — releasing anyway");
+                }
+                // §3.2 step 3 (HS4): the drain hooks run while the flock
+                // is still ours — the memory hook drops the durable store
+                // (freeing plane.lock) BEFORE the successor can acquire
+                // the lease, so its bounded plane retry always races an
+                // already-freed lock.
+                if let Ok(hooks) = self.drain_hooks.lock() {
+                    for hook in hooks.iter() {
+                        hook();
+                    }
                 }
                 drop(lease); // the flock frees HERE
             }

--- a/src/bin/caller/handover/presence.rs
+++ b/src/bin/caller/handover/presence.rs
@@ -39,13 +39,20 @@ pub(crate) struct PresenceRecord {
     pub(crate) pid: u32,
     pub(crate) port: u16,
     pub(crate) version: BuildVersion,
-    /// `"running"` now; HS3 adds `"draining"`/`"exited"`. Readers must
-    /// tolerate future states.
+    /// `"running"` / `"draining"` / `"exited"`. Readers must tolerate
+    /// future states.
     pub(crate) state: String,
-    /// Supervised-session count, once a reporter exists (HS3 wires the
-    /// drain-exit condition); absent = not reported, never "zero".
+    /// Supervised-session count while draining ("draining · N sessions");
+    /// absent = not reported, never "zero".
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) session_count: Option<u64>,
+    /// The REGISTRATION instant — the era watershed
+    /// (`grid_envelope::resolve_current_boot` reads it as boot-start to
+    /// split current-boot sessions from outage residue, the #638 class).
+    /// Lifecycle rewrites (drain states, session counts) must NEVER
+    /// advance it — a drainer whose watershed kept moving to "now" would
+    /// relabel its own live sessions `preboot` (the HS3 ruling's F1
+    /// amendment). Freshness, if ever wanted, is a NEW field.
     pub(crate) updated_ms: u64,
 }
 
@@ -114,18 +121,27 @@ impl DaemonPresence {
 
     /// Rewrite this boot's record with a new lifecycle state
     /// (`draining`/`exited`). Failure is display debt, never fatal — the
-    /// per-boot lock stays the liveness truth.
+    /// per-boot lock stays the liveness truth. `updated_ms` is the era
+    /// watershed and deliberately NOT advanced (see the field doc; the
+    /// HS3 ruling's F1 amendment).
     pub(crate) fn update_state(&mut self, state: &str) -> std::io::Result<()> {
+        if self.record.state == state {
+            return Ok(());
+        }
         self.record.state = state.to_string();
-        self.record.updated_ms = super::now_ms();
         self.write_record()
     }
 
     /// Rewrite this boot's record with the live supervised-session count
-    /// (the drain views' "draining · N sessions" source).
+    /// (the drain views' "draining · N sessions" source). Write-on-change
+    /// only — the drain exit check runs per supervisor event, and an
+    /// unchanged count must not churn the file. Never advances the era
+    /// watershed (F1).
     pub(crate) fn update_session_count(&mut self, count: u64) -> std::io::Result<()> {
+        if self.record.session_count == Some(count) {
+            return Ok(());
+        }
         self.record.session_count = Some(count);
-        self.record.updated_ms = super::now_ms();
         self.write_record()
     }
 
@@ -258,6 +274,44 @@ mod tests {
         // even though the files are still on disk.
         drop(presence);
         assert!(!boot_id_is_live(dir.path(), "boot-a"));
+    }
+
+    /// The HS3 ruling's F1 amendment: `updated_ms` is the era watershed
+    /// (`grid_envelope::resolve_current_boot`'s boot-start split) —
+    /// drain-lifecycle rewrites and count mirrors must never advance it,
+    /// and unchanged values must not rewrite the file at all.
+    #[test]
+    fn drain_rewrites_preserve_the_era_watershed() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut presence = DaemonPresence::register(dir.path(), "boot-a", 8765).expect("register");
+        let json_path = dir.path().join(DAEMONS_DIR).join("boot-a.json");
+        let read = || -> serde_json::Value {
+            serde_json::from_slice(&std::fs::read(&json_path).unwrap()).unwrap()
+        };
+        let watershed = read()["updated_ms"].as_u64().expect("registration instant");
+
+        presence.update_state("draining").unwrap();
+        presence.update_session_count(3).unwrap();
+        presence.update_session_count(1).unwrap();
+        presence.update_state("exited").unwrap();
+        let after = read();
+        assert_eq!(
+            after["updated_ms"].as_u64(),
+            Some(watershed),
+            "lifecycle rewrites never advance the watershed"
+        );
+        assert_eq!(after["state"], "exited");
+        assert_eq!(after["session_count"], 1);
+
+        // Write-on-change: unchanged values are no-ops. Scribble the file
+        // externally; same-value updates must not clobber the scribble.
+        std::fs::write(&json_path, b"{\"sentinel\":true}").unwrap();
+        presence.update_session_count(1).unwrap();
+        presence.update_state("exited").unwrap();
+        assert_eq!(
+            read()["sentinel"], true,
+            "unchanged lifecycle values never rewrite the file"
+        );
     }
 
     #[test]

--- a/src/bin/caller/handover/presence.rs
+++ b/src/bin/caller/handover/presence.rs
@@ -309,7 +309,8 @@ mod tests {
         presence.update_session_count(1).unwrap();
         presence.update_state("exited").unwrap();
         assert_eq!(
-            read()["sentinel"], true,
+            read()["sentinel"],
+            true,
             "unchanged lifecycle values never rewrite the file"
         );
     }

--- a/src/bin/caller/memory/handle.rs
+++ b/src/bin/caller/memory/handle.rs
@@ -4,7 +4,17 @@
 //! one lock (the plane's single-writer contract). Storage is selected
 //! at bootstrap: the primary OS normally uses the durable store while
 //! other modes use an in-memory plane. Every view reports the
-//! effective `durability` (`"durable"` or `"ephemeral"`).
+//! effective `durability`.
+//!
+//! Track HS4: durable-plane-open authority is LEASE-HOLDER-ONLY (the
+//! design gate's Q6 amendment). The handle is a state machine
+//! ([`PlaneSlot`]): a secondary never opens the durable store at all —
+//! it serves a steady named refusal instead of the old silent lifetime
+//! ephemeral fallback (whose durable-intent writes were lost on exit) —
+//! and a draining daemon hands the plane over (drops the store, freeing
+//! `plane.lock` for the successor's bounded-retry acquisition). Reads
+//! AND writes refuse while the plane is not open here (Q5(b): serving
+//! reads from a closed store is dishonest staleness).
 
 use std::sync::Mutex;
 
@@ -15,14 +25,49 @@ use super::service::MemoryService;
 /// P1.8 storage-mode selector for [`MemoryHandle::bootstrap`].
 pub(crate) enum MemoryStorage {
     Ephemeral,
+    /// One-shot durable open. The daemon's durable lane goes through
+    /// [`MemoryHandle::deferred`] + the role watch instead (HS4:
+    /// lease-holder-only acquisition); this variant remains as the
+    /// tests' lock-holder fixture and for direct tooling.
+    #[allow(dead_code)]
     Durable(std::path::PathBuf),
 }
 use super::types::{ClaimView, JudgeArgs, MemoryError, ProposeArgs, SearchArgs};
 
+/// The durable plane's home under a state root — one derivation for the
+/// wiring edge and every test (the HS4 path fix: the old code resolved
+/// `dirs::home_dir()/.intendant/memory-plane` directly, ignoring
+/// `INTENDANT_HOME`, which made a dual-daemon rig unable to exercise
+/// durable handover hermetically; the docs already framed that as an
+/// inconsistency, not a policy).
+pub(crate) fn durable_plane_dir(state_root: &std::path::Path) -> std::path::PathBuf {
+    state_root.join("memory-plane")
+}
+
+/// What sits behind the handle right now (Track HS4).
+enum PlaneSlot {
+    /// A live plane (durable or ephemeral) — every op serves. Boxed:
+    /// the service dwarfs the unit states.
+    Ready(Box<MemoryService>),
+    /// This daemon holds the lease and is acquiring the durable store
+    /// (the bounded `LockDenied` retry runs in the role watch).
+    Pending,
+    /// This daemon is a co-homed secondary: the durable plane follows
+    /// the lease holder (Q6 — never opened here).
+    FollowsHolder,
+    /// Drained: the store was dropped (releasing `plane.lock`) for the
+    /// successor. One-way, like drain itself.
+    HandedOver,
+}
+
 pub(crate) struct MemoryHandle {
-    service: Mutex<MemoryService>,
-    plane_id_hex: String,
+    slot: Mutex<PlaneSlot>,
+    /// Latched when a service installs; `"pending"` before that.
+    plane_id_hex: Mutex<String>,
     bus: EventBus,
+    /// Successor-pointer source for the named refusals (`None` outside
+    /// the handover shapes and in plain bootstraps).
+    handover: Option<std::sync::Arc<crate::handover::HandoverRuntime>>,
 }
 
 impl MemoryHandle {
@@ -31,6 +76,9 @@ impl MemoryHandle {
     /// broadcast `memory_changed` on `bus` so every connected frontend
     /// updates live. `storage` picks the P1.8 mode: `Durable(dir)` on
     /// the proven-custody OS, `Ephemeral` elsewhere (and in tests).
+    /// One-shot form (no lease coupling) — the daemon's durable lane
+    /// uses [`MemoryHandle::deferred`] + [`super::spawn_plane_role_watch`]
+    /// instead.
     pub(crate) fn bootstrap(
         bus: EventBus,
         storage: MemoryStorage,
@@ -42,19 +90,93 @@ impl MemoryHandle {
         };
         let plane_id_hex = service.plane_id_hex();
         Ok(MemoryHandle {
-            service: Mutex::new(service),
-            plane_id_hex,
+            slot: Mutex::new(PlaneSlot::Ready(Box::new(service))),
+            plane_id_hex: Mutex::new(plane_id_hex),
             bus,
+            handover: None,
         })
     }
 
-    /// The mode label views carry ("durable" / "ephemeral").
-    pub(crate) fn durability_label(&self) -> &'static str {
-        self.lock().durability_label()
+    /// The lease-following form (Track HS4): starts without a plane —
+    /// `Pending` when this boot already holds the lease, `FollowsHolder`
+    /// otherwise — and the role watch installs/refuses from there.
+    pub(crate) fn deferred(
+        bus: EventBus,
+        handover: std::sync::Arc<crate::handover::HandoverRuntime>,
+    ) -> MemoryHandle {
+        let initial = if handover.is_holder() {
+            PlaneSlot::Pending
+        } else {
+            PlaneSlot::FollowsHolder
+        };
+        MemoryHandle {
+            slot: Mutex::new(initial),
+            plane_id_hex: Mutex::new("pending".to_string()),
+            bus,
+            handover: Some(handover),
+        }
     }
 
-    pub(crate) fn plane_id_hex(&self) -> &str {
-        &self.plane_id_hex
+    /// Install a live service (role watch: durable acquired, or the
+    /// labeled ephemeral fallback for genuine store failure). No-op
+    /// after a hand-over — drain is one-way.
+    pub(crate) fn install_service(&self, service: MemoryService) {
+        let mut slot = self.lock_slot();
+        if matches!(*slot, PlaneSlot::HandedOver) {
+            return;
+        }
+        *self.lock_plane_id() = service.plane_id_hex();
+        *slot = PlaneSlot::Ready(Box::new(service));
+    }
+
+    /// Role watch: this daemon holds the lease and the durable open is
+    /// in its retry window. No-op over `Ready` and after hand-over.
+    pub(crate) fn set_pending(&self) {
+        let mut slot = self.lock_slot();
+        if matches!(*slot, PlaneSlot::FollowsHolder | PlaneSlot::Pending) {
+            *slot = PlaneSlot::Pending;
+        }
+    }
+
+    /// Role watch: this daemon is a secondary — the plane follows the
+    /// holder (Q6: never opened here). No-op over `Ready` (a holder
+    /// never demotes without draining) and after hand-over.
+    pub(crate) fn set_follows_holder(&self) {
+        let mut slot = self.lock_slot();
+        if matches!(*slot, PlaneSlot::FollowsHolder | PlaneSlot::Pending) {
+            *slot = PlaneSlot::FollowsHolder;
+        }
+    }
+
+    /// Drain entry (§3.2 step 3, wired as a
+    /// [`crate::handover::HandoverRuntime::on_drain_entry`] hook): drop
+    /// the store — `plane.lock` frees HERE, before the scheduler lease's
+    /// flock release — and refuse every subsequent op with the named
+    /// `plane-handed-over`. One-way; idempotent.
+    pub(crate) fn hand_over(&self) {
+        let mut slot = self.lock_slot();
+        if matches!(*slot, PlaneSlot::HandedOver) {
+            return;
+        }
+        if matches!(*slot, PlaneSlot::Ready(_)) {
+            eprintln!("[memory] durable plane released for the handover successor");
+        }
+        *slot = PlaneSlot::HandedOver;
+    }
+
+    /// The mode label views carry ("durable" / "ephemeral" / the HS4
+    /// unavailability states).
+    pub(crate) fn durability_label(&self) -> &'static str {
+        match &*self.lock_slot() {
+            PlaneSlot::Ready(service) => service.durability_label(),
+            PlaneSlot::Pending => "pending",
+            PlaneSlot::FollowsHolder => "follows-holder",
+            PlaneSlot::HandedOver => "handed-over",
+        }
+    }
+
+    pub(crate) fn plane_id_hex(&self) -> String {
+        self.lock_plane_id().clone()
     }
 
     /// Author a claim. `actor` is the gate-resolved binding from the
@@ -68,7 +190,10 @@ impl MemoryHandle {
         args: ProposeArgs,
         actor: &crate::access::actor::ActorBinding,
     ) -> Result<ClaimView, MemoryError> {
-        let view = self.lock().propose(args, actor)?;
+        let view = {
+            let mut slot = self.lock_slot();
+            self.ready(&mut slot)?.propose(args, actor)?
+        };
         self.bus.send(AppEvent::MemoryChanged {
             claim: view.clone(),
         });
@@ -85,38 +210,396 @@ impl MemoryHandle {
         args: JudgeArgs,
         actor: &crate::access::actor::ActorBinding,
     ) -> Result<ClaimView, MemoryError> {
-        let view = self.lock().judge(args, actor)?;
+        let view = {
+            let mut slot = self.lock_slot();
+            self.ready(&mut slot)?.judge(args, actor)?
+        };
         self.bus.send(AppEvent::MemoryChanged {
             claim: view.clone(),
         });
         Ok(view)
     }
 
+    /// HS4: search refuses like every other op while the plane is not
+    /// open here (Q5(b)); the infallible signature predates the state
+    /// machine, so the refusal shape is an empty result — the label and
+    /// the read/propose refusals carry the named state.
     pub(crate) fn search(&self, args: &SearchArgs) -> Vec<ClaimView> {
-        self.lock().search(args)
+        match &mut *self.lock_slot() {
+            PlaneSlot::Ready(service) => service.search(args),
+            _ => Vec::new(),
+        }
     }
 
     pub(crate) fn read(&self, id_prefix: &str) -> Result<ClaimView, MemoryError> {
-        self.lock().read(id_prefix)
+        let mut slot = self.lock_slot();
+        self.ready(&mut slot)?.read(id_prefix)
     }
 
-    fn lock(&self) -> std::sync::MutexGuard<'_, MemoryService> {
+    /// The Q6/Q5(b) gate every op passes: `Ready` serves; every other
+    /// slot refuses with its named state and the successor pointer when
+    /// the lease sidecar names one.
+    fn ready<'a>(&self, slot: &'a mut PlaneSlot) -> Result<&'a mut MemoryService, MemoryError> {
+        let outcome = match slot {
+            PlaneSlot::Ready(service) => return Ok(service),
+            PlaneSlot::Pending => "plane-pending",
+            PlaneSlot::FollowsHolder => "plane-follows-holder",
+            PlaneSlot::HandedOver => "plane-handed-over",
+        };
+        let successor = self
+            .handover
+            .as_ref()
+            .and_then(|runtime| runtime.successor_port());
+        let detail = match (outcome, successor) {
+            ("plane-pending", _) => {
+                "the durable plane is being acquired on this daemon — retry shortly".to_string()
+            }
+            (_, Some(port)) => {
+                format!("the durable plane follows the active daemon — use :{port}")
+            }
+            (_, None) => "the durable plane follows the active daemon (not this one)".to_string(),
+        };
+        Err(MemoryError::PlaneUnavailable { outcome, detail })
+    }
+
+    fn lock_slot(&self) -> std::sync::MutexGuard<'_, PlaneSlot> {
         // Poison recovery is sound: the op log + fold cache are the
         // authority and every mutation re-derives the fold from the
         // full set, so a panicked writer cannot leave a half-applied
         // fold behind (worst case: an admitted claim missing from the
         // lexical registry, which the next propose does not disturb).
-        match self.service.lock() {
+        match self.slot.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+
+    fn lock_plane_id(&self) -> std::sync::MutexGuard<'_, String> {
+        match self.plane_id_hex.lock() {
             Ok(guard) => guard,
             Err(poisoned) => poisoned.into_inner(),
         }
     }
 }
 
+/// Fast-retry window for a `LockDenied` durable open (intake §3.4: the
+/// predecessor's `plane.lock` frees at ITS drain entry — the successor's
+/// bounded retry bridges the hop). Past the window the watch keeps
+/// self-healing at the lease-poll cadence behind the steady named
+/// `plane-pending` refusal — "another live daemon holds the plane" is
+/// not "the store is corrupt", and only the latter deserves ephemeral.
+const LOCK_DENIED_RETRY_WINDOW: std::time::Duration = std::time::Duration::from_secs(60);
+const LOCK_DENIED_RETRY_PAUSE: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// One decision of the lease-following plane watch — extracted from the
+/// spawned loop so tests drive role transitions without sleeping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PlaneRoleStep {
+    /// Sleep the lease-poll cadence (secondary, or the slow self-heal
+    /// lane past the fast window).
+    Idle,
+    /// Retry the durable open soon (inside the bounded window).
+    RetrySoon,
+    /// Steady state reached (service installed, or handed over) — the
+    /// watch ends; drain hand-over is the drain hook's job from here.
+    Settled,
+}
+
+/// The Q6 boot order, one decision at a time: acquire-lease-then-open-
+/// plane. A secondary NEVER calls the durable open; a holder opens with
+/// the bounded `LockDenied` retry; genuine store failure (corruption,
+/// custody, IO) falls to the labeled ephemeral plane exactly as before.
+pub(crate) fn plane_role_step(
+    handle: &MemoryHandle,
+    runtime: &crate::handover::HandoverRuntime,
+    dir: &std::path::Path,
+    lock_denied_since: &mut Option<std::time::Instant>,
+) -> PlaneRoleStep {
+    if runtime.is_draining() {
+        handle.hand_over();
+        return PlaneRoleStep::Settled;
+    }
+    if !runtime.is_holder() {
+        handle.set_follows_holder();
+        *lock_denied_since = None;
+        return PlaneRoleStep::Idle;
+    }
+    match MemoryService::new_durable(dir) {
+        Ok(service) => {
+            println!(
+                "[memory] durable plane {} at {}",
+                &service.plane_id_hex()[..16],
+                dir.display()
+            );
+            handle.install_service(service);
+            PlaneRoleStep::Settled
+        }
+        Err(super::store::StoreError::LockDenied) => {
+            handle.set_pending();
+            let since = lock_denied_since.get_or_insert_with(std::time::Instant::now);
+            if since.elapsed() <= LOCK_DENIED_RETRY_WINDOW {
+                PlaneRoleStep::RetrySoon
+            } else {
+                PlaneRoleStep::Idle
+            }
+        }
+        Err(err) => {
+            eprintln!("[memory] durable plane unavailable ({err}) — falling back to ephemeral");
+            match MemoryService::new() {
+                Ok(service) => {
+                    println!(
+                        "[memory] ephemeral plane {} (nothing persists across restarts)",
+                        &service.plane_id_hex()[..16]
+                    );
+                    handle.install_service(service);
+                }
+                Err(err) => eprintln!("[memory] ephemeral plane bootstrap failed: {err}"),
+            }
+            PlaneRoleStep::Settled
+        }
+    }
+}
+
+/// The spawned watch: follows the lease until a steady state lands.
+/// Detaches on drop like the wiring's sibling tasks.
+pub(crate) fn spawn_plane_role_watch(
+    handle: std::sync::Arc<MemoryHandle>,
+    runtime: std::sync::Arc<crate::handover::HandoverRuntime>,
+    dir: std::path::PathBuf,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut lock_denied_since = None;
+        loop {
+            match plane_role_step(&handle, &runtime, &dir, &mut lock_denied_since) {
+                PlaneRoleStep::Settled => return,
+                PlaneRoleStep::RetrySoon => tokio::time::sleep(LOCK_DENIED_RETRY_PAUSE).await,
+                PlaneRoleStep::Idle => {
+                    tokio::time::sleep(crate::handover::lease_poll_interval()).await
+                }
+            }
+        }
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::access::actor::ActorBinding;
+
+    fn propose_args(statement: &str) -> ProposeArgs {
+        ProposeArgs {
+            kind: "observation".into(),
+            statement: statement.into(),
+            sensitivity: "private".into(),
+            session: None,
+            project: None,
+            model: None,
+            labels: vec![],
+        }
+    }
+
+    /// The HS4 path fix: one derivation, state-root-relative — the
+    /// wiring edge passes `intendant_home()`, so `INTENDANT_HOME` scopes
+    /// the durable plane exactly like every other store (the old code
+    /// resolved `dirs::home_dir()` directly and a dual-daemon rig could
+    /// not exercise durable handover hermetically).
+    #[test]
+    fn durable_plane_honors_intendant_home() {
+        let root = tempfile::tempdir().unwrap();
+        assert_eq!(
+            durable_plane_dir(root.path()),
+            root.path().join("memory-plane")
+        );
+    }
+
+    /// The Q6 amendment pin: a co-homed SECONDARY never opens the
+    /// durable plane — the role step refuses without ever touching the
+    /// store (the plane dir is not even created), and every op serves
+    /// the named follows-holder refusal with the holder's port.
+    #[tokio::test]
+    async fn secondary_never_opens_durable_plane() {
+        let home = tempfile::tempdir().unwrap();
+        let plane = tempfile::tempdir().unwrap();
+        let plane_dir = plane.path().join("memory-plane");
+        let _holder = std::sync::Arc::new(crate::handover::HandoverRuntime::initialize(
+            home.path(),
+            7001,
+            0,
+        ));
+        let secondary = std::sync::Arc::new(crate::handover::HandoverRuntime::initialize(
+            home.path(),
+            7002,
+            0,
+        ));
+        let handle = MemoryHandle::deferred(EventBus::new(), secondary.clone());
+        assert_eq!(handle.durability_label(), "follows-holder");
+
+        let mut since = None;
+        let step = plane_role_step(&handle, &secondary, &plane_dir, &mut since);
+        assert_eq!(step, PlaneRoleStep::Idle);
+        assert!(
+            !plane_dir.exists(),
+            "a secondary must never even create the plane dir"
+        );
+        let err = handle.read("anything").unwrap_err();
+        match err {
+            MemoryError::PlaneUnavailable { outcome, detail } => {
+                assert_eq!(outcome, "plane-follows-holder");
+                assert!(
+                    detail.contains(":7001"),
+                    "the holder's port rides: {detail}"
+                );
+            }
+            other => panic!("expected the named refusal, got {other:?}"),
+        }
+    }
+
+    /// The intake's bootstrap amendment: `LockDenied` means "another
+    /// live daemon holds the plane", NOT "the store is corrupt" — the
+    /// holder retries fast inside the bounded window, then keeps a
+    /// steady named `plane-pending` refusal (slow self-heal), and never
+    /// falls to the old silent lifetime ephemeral.
+    #[tokio::test]
+    async fn lock_denied_bootstrap_bounded_retry_then_named_refusal() {
+        let home = tempfile::tempdir().unwrap();
+        let plane = tempfile::tempdir().unwrap();
+        let plane_dir = plane.path().join("memory-plane");
+        // Another live handle holds the plane (the co-homed predecessor).
+        let occupant =
+            MemoryHandle::bootstrap(EventBus::new(), MemoryStorage::Durable(plane_dir.clone()))
+                .expect("first durable open");
+
+        let holder = std::sync::Arc::new(crate::handover::HandoverRuntime::initialize(
+            home.path(),
+            7001,
+            0,
+        ));
+        let handle = MemoryHandle::deferred(EventBus::new(), holder.clone());
+        let mut since = None;
+        assert_eq!(
+            plane_role_step(&handle, &holder, &plane_dir, &mut since),
+            PlaneRoleStep::RetrySoon,
+            "inside the bounded window: fast retry"
+        );
+        assert_eq!(handle.durability_label(), "pending");
+        match handle.read("anything").unwrap_err() {
+            MemoryError::PlaneUnavailable { outcome, .. } => {
+                assert_eq!(outcome, "plane-pending")
+            }
+            other => panic!("expected plane-pending, got {other:?}"),
+        }
+        // Past the window: the steady named refusal with slow self-heal
+        // (never ephemeral). Instant cannot always rewind on a fresh VM;
+        // skip the aging assert when it cannot.
+        if let Some(old) = std::time::Instant::now().checked_sub(std::time::Duration::from_secs(61))
+        {
+            since = Some(old);
+            assert_eq!(
+                plane_role_step(&handle, &holder, &plane_dir, &mut since),
+                PlaneRoleStep::Idle,
+                "past the window: slow lane, still pending — never ephemeral"
+            );
+            assert_eq!(handle.durability_label(), "pending");
+        }
+
+        // The predecessor releases (its drain entry / exit): the very
+        // next step acquires and the handle serves durably.
+        drop(occupant);
+        assert_eq!(
+            plane_role_step(&handle, &holder, &plane_dir, &mut since),
+            PlaneRoleStep::Settled
+        );
+        assert_eq!(handle.durability_label(), "durable");
+        handle
+            .propose(
+                propose_args("acquired after the lock freed"),
+                &ActorBinding::dashboard(Some("principal:root-session:test".into())),
+            )
+            .expect("the acquired plane serves writes");
+    }
+
+    /// The transfer pin: a draining holder's drain-entry hook releases
+    /// the plane (plane.lock frees BEFORE the scheduler flock), the
+    /// successor's role step acquires it within the retry window, the
+    /// SAME plane resumes (identity and claims survive the hop), and the
+    /// drainer's memory surface refuses with the successor pointer.
+    #[tokio::test]
+    async fn plane_transfers_within_retry_window_on_drain() {
+        let home = tempfile::tempdir().unwrap();
+        let plane = tempfile::tempdir().unwrap();
+        let plane_dir = plane.path().join("memory-plane");
+
+        let runtime_a = std::sync::Arc::new(crate::handover::HandoverRuntime::initialize(
+            home.path(),
+            7001,
+            0,
+        ));
+        let handle_a =
+            std::sync::Arc::new(MemoryHandle::deferred(EventBus::new(), runtime_a.clone()));
+        let mut since_a = None;
+        assert_eq!(
+            plane_role_step(&handle_a, &runtime_a, &plane_dir, &mut since_a),
+            PlaneRoleStep::Settled
+        );
+        assert_eq!(handle_a.durability_label(), "durable");
+        let plane_id_a = handle_a.plane_id_hex();
+        let claim = handle_a
+            .propose(
+                propose_args("written before the handover"),
+                &ActorBinding::dashboard(Some("principal:root-session:test".into())),
+            )
+            .expect("durable write on the predecessor");
+
+        // Drain: the hook releases the plane between the sidecar flip
+        // and the flock release (§3.2 step 3).
+        let hook_handle = handle_a.clone();
+        runtime_a.on_drain_entry(Box::new(move || hook_handle.hand_over()));
+        assert_eq!(
+            runtime_a.request_drain(None),
+            crate::handover::DrainRequest::Entered
+        );
+        assert_eq!(handle_a.durability_label(), "handed-over");
+
+        // The successor: acquires the lease, then the plane.
+        let runtime_b = std::sync::Arc::new(crate::handover::HandoverRuntime::initialize(
+            home.path(),
+            7002,
+            0,
+        ));
+        assert!(
+            runtime_b.is_holder(),
+            "the freed lease transfers at the successor's boot try-acquire"
+        );
+        let handle_b = MemoryHandle::deferred(EventBus::new(), runtime_b.clone());
+        let mut since_b = None;
+        assert_eq!(
+            plane_role_step(&handle_b, &runtime_b, &plane_dir, &mut since_b),
+            PlaneRoleStep::Settled,
+            "the freed plane.lock acquires on the first try"
+        );
+        assert_eq!(handle_b.durability_label(), "durable");
+        assert_eq!(
+            handle_b.plane_id_hex(),
+            plane_id_a,
+            "the SAME plane resumed — identity survives the hop"
+        );
+        let read_back = handle_b
+            .read(&claim.id)
+            .expect("the predecessor's claim survives the transfer");
+        assert_eq!(read_back.statement, claim.statement);
+
+        // The drainer's refusal now names the successor.
+        match handle_a.read("anything").unwrap_err() {
+            MemoryError::PlaneUnavailable { outcome, detail } => {
+                assert_eq!(outcome, "plane-handed-over");
+                assert!(
+                    detail.contains(":7002"),
+                    "successor pointer rides: {detail}"
+                );
+            }
+            other => panic!("expected plane-handed-over, got {other:?}"),
+        }
+    }
 
     /// Admitted proposals broadcast `memory_changed` with the same view
     /// the caller received (the live-update lane the Explorer rides);

--- a/src/bin/caller/memory/mod.rs
+++ b/src/bin/caller/memory/mod.rs
@@ -30,5 +30,5 @@ pub(crate) mod service;
 pub(crate) mod store;
 pub(crate) mod types;
 
-pub(crate) use handle::{MemoryHandle, MemoryStorage};
+pub(crate) use handle::{durable_plane_dir, spawn_plane_role_watch, MemoryHandle, MemoryStorage};
 pub(crate) use types::{ClaimView, JudgeArgs, MemoryError, ProposeArgs, SearchArgs};

--- a/src/bin/caller/memory/types.rs
+++ b/src/bin/caller/memory/types.rs
@@ -245,4 +245,17 @@ pub(crate) enum MemoryError {
     Ambiguous(String, usize),
     #[error("{0}")]
     InvalidArg(String),
+    /// Track HS4: the durable plane is not open on THIS daemon right now
+    /// — being acquired (`plane-pending`), owned by the lease holder
+    /// (`plane-follows-holder`), or handed to a successor
+    /// (`plane-handed-over`). Named and fail-closed: reads AND writes
+    /// refuse (serving reads from a closed store would be dishonest
+    /// staleness — intake Q5(b)); the message carries the successor
+    /// pointer when the sidecar names one. Never the silent lifetime
+    /// ephemeral fallback this replaces.
+    #[error("unavailable: {outcome} — {detail}")]
+    PlaneUnavailable {
+        outcome: &'static str,
+        detail: String,
+    },
 }

--- a/src/bin/caller/session_supervisor/mod.rs
+++ b/src/bin/caller/session_supervisor/mod.rs
@@ -840,6 +840,14 @@ impl SessionSupervisor {
         if holding > 0 || self.exec.latest_pending_heavy_key().is_some() {
             return false;
         }
+        // Intake §3.3's exit parenthetical (the HS3 ruling's N5): a
+        // transfer append mid-copy holds the daemon open — cutting a
+        // multi-GB spool at exit wastes it entirely. (Mid-stream HTTP
+        // uploads are the priced residual: request-scoped, usually
+        // session-accompanied, and re-uploadable against the successor.)
+        if crate::transfer_store::any_transfer_appending() {
+            return false;
+        }
         runtime.mark_exited();
         true
     }

--- a/src/bin/caller/startup/wiring.rs
+++ b/src/bin/caller/startup/wiring.rs
@@ -417,51 +417,41 @@ pub(crate) fn spawn_mode_web_gateway(
     let agenda_boot_announce = mcp_http_state.agenda.clone();
     let agenda_for_supervisor = mcp_http_state.agenda.clone();
     // The P1 Memory service. The durable plane runs on the
-    // proven-custody OS (macOS);
-    // multi-platform custody stays full Gate B, so other OSes run
-    // ephemeral and say so on every view. INTENDANT_MEMORY_EPHEMERAL=1
-    // is the operator kill switch. Durable bootstrap failure fails
-    // SOFT to ephemeral (service stays available; the label stays
-    // honest) with the named outcome logged.
+    // proven-custody OS (macOS); multi-platform custody stays full
+    // Gate B, so other OSes run ephemeral and say so on every view.
+    // INTENDANT_MEMORY_EPHEMERAL=1 is the operator kill switch.
+    //
+    // Track HS4: durable-plane-open authority is LEASE-HOLDER-ONLY (the
+    // Q6 amendment) — the handle starts without a plane and the role
+    // watch follows the lease: a holder acquires with the bounded
+    // `LockDenied` retry (a held plane is not a corrupt store; only
+    // genuine store failure falls to the labeled ephemeral), a
+    // secondary serves the named follows-holder refusal instead of the
+    // old silent lifetime-ephemeral fallback, and drain entry hands the
+    // plane over (the runtime hook drops the store, freeing plane.lock
+    // for the successor). The plane dir follows the STATE ROOT
+    // (`durable_plane_dir` — the HS4 path fix; the old dirs::home_dir
+    // resolution ignored INTENDANT_HOME).
     let durable_default = cfg!(target_os = "macos")
         && std::env::var("INTENDANT_MEMORY_EPHEMERAL").map_or(true, |v| v != "1");
-    let storage = if durable_default {
-        match dirs::home_dir() {
-            Some(home) => {
-                crate::memory::MemoryStorage::Durable(home.join(".intendant").join("memory-plane"))
-            }
-            None => crate::memory::MemoryStorage::Ephemeral,
-        }
+    if durable_default {
+        let plane_dir = crate::memory::durable_plane_dir(&crate::platform::intendant_home());
+        let handle = Arc::new(crate::memory::MemoryHandle::deferred(
+            bus.clone(),
+            handover.clone(),
+        ));
+        mcp_http_state.memory = Some(handle.clone());
+        let hook_handle = handle.clone();
+        handover.on_drain_entry(Box::new(move || hook_handle.hand_over()));
+        // Detaches on drop like the mode listeners; settles once a plane
+        // installs (drain hand-over is the hook's job from there).
+        let _plane_watch =
+            crate::memory::spawn_plane_role_watch(handle, handover.clone(), plane_dir);
     } else {
-        crate::memory::MemoryStorage::Ephemeral
-    };
-    let storage = match &storage {
-        crate::memory::MemoryStorage::Durable(dir) => {
-            match crate::memory::MemoryHandle::bootstrap(
-                bus.clone(),
-                crate::memory::MemoryStorage::Durable(dir.clone()),
-            ) {
-                Ok(handle) => {
-                    println!(
-                        "[memory] durable plane {} at {}",
-                        &handle.plane_id_hex()[..16],
-                        dir.display()
-                    );
-                    mcp_http_state.memory = Some(Arc::new(handle));
-                    None
-                }
-                Err(err) => {
-                    eprintln!(
-                        "[memory] durable plane unavailable ({err}) — falling back to ephemeral"
-                    );
-                    Some(crate::memory::MemoryStorage::Ephemeral)
-                }
-            }
-        }
-        crate::memory::MemoryStorage::Ephemeral => Some(crate::memory::MemoryStorage::Ephemeral),
-    };
-    if let Some(storage) = storage {
-        mcp_http_state.memory = match crate::memory::MemoryHandle::bootstrap(bus.clone(), storage) {
+        mcp_http_state.memory = match crate::memory::MemoryHandle::bootstrap(
+            bus.clone(),
+            crate::memory::MemoryStorage::Ephemeral,
+        ) {
             Ok(handle) => {
                 println!(
                     "[memory] ephemeral plane {} (nothing persists across restarts)",

--- a/src/bin/caller/transfer_store.rs
+++ b/src/bin/caller/transfer_store.rs
@@ -288,6 +288,17 @@ fn evict_job(path: &Path) {
     map.remove(path);
 }
 
+/// Track HS4 (the HS3 ruling's N5): is any transfer append copying bytes
+/// RIGHT NOW? The drain exit condition holds the daemon open for these —
+/// cutting a multi-gigabyte copy at exit would waste the whole spool.
+/// Idle entries are resumable disk state (the successor serves resume)
+/// and do not hold.
+pub(crate) fn any_transfer_appending() -> bool {
+    let mut map = active_jobs().lock().unwrap_or_else(|e| e.into_inner());
+    prune_active_jobs_locked(&mut map, now_unix());
+    map.values().any(|entry| entry.appending)
+}
+
 #[cfg(test)]
 fn reset_active_jobs_for_path(path: &Path) {
     evict_job(path);

--- a/src/bin/caller/web_gateway/routes_memory.rs
+++ b/src/bin/caller/web_gateway/routes_memory.rs
@@ -117,6 +117,11 @@ fn memory_error_status(err: &crate::memory::MemoryError) -> u16 {
         E::NotPermitted { .. } => 403,
         E::Ambiguous(..) | E::Vocabulary { .. } | E::InvalidArg(_) => 400,
         E::Rejected { .. } | E::Pending { .. } => 422,
+        // HS4: the plane is not open on this daemon right now (being
+        // acquired / follows the lease holder / handed to a successor) —
+        // service-unavailable with the named state and retry semantics,
+        // never a client error.
+        E::PlaneUnavailable { .. } => 503,
         E::Unimplemented(_) => 500,
     }
 }


### PR DESCRIPTION
Track HS slice 4 of 6 (intake §3.4 + the Q6 amendment; HS3 PASS + required F1 in `~/daemon-handover-rulings.md`).

## F1 first (the HS3 ruling's required fix-forward, first commit)

Presence `updated_ms` is the **era watershed** `grid_envelope::resolve_current_boot` (#638) splits current-boot sessions from outage residue with. HS3's drain rewrites bumped it continuously — a drainer's own sessions would relabel `preboot`. Lifecycle rewrites now never advance it (field doc states the invariant), both rewrite lanes are write-on-change (ruling N3 folded), pinned by `drain_rewrites_preserve_the_era_watershed` (with a sentinel-scribble proof of the no-op path). Ruling N1 rides too: the takeover route's 4 KiB cap asserted in `body_policies_pin_their_caps`.

## HS4: the plane follows the lease

- **Path fix (the intake's prerequisite)**: `durable_plane_dir(state_root)` — the durable plane honors `INTENDANT_HOME` like every other store (pinned).
- **`MemoryHandle` state machine** (`Ready | Pending | FollowsHolder | HandedOver`): durable-open authority is **lease-holder-only** (Q6) — a secondary never opens the store (never even creates the dir) and serves the named `plane-follows-holder` refusal with the holder's port, replacing the old silent lifetime-ephemeral fallback whose durable-intent writes were lost on exit. Reads AND writes refuse while the plane is not open here (Q5(b)); HTTP maps `PlaneUnavailable` to 503.
- **The role watch** (step-extracted, sleepless tests): acquire-lease-then-open-plane; `LockDenied` retries fast for 60s then keeps a steady named `plane-pending` refusal with slow self-heal — a held plane is not a corrupt store; only genuine store failure falls to labeled ephemeral.
- **Drain-entry release** (§3.2 step 3): `HandoverRuntime::on_drain_entry` hooks run between the sidecar's `draining` flip and the flock release; the memory hook drops the store so `plane.lock` frees **before** the successor can acquire the lease. The successor resumes the **same plane** — identity and claims survive the hop.
- **N5 (HS3 ruling)**: drain exit now holds for a transfer append mid-copy (`any_transfer_appending`; idle entries are resumable disk state and don't hold). Mid-stream HTTP uploads are the **priced residual**: request-scoped, usually session-accompanied (the session holds the drain), re-uploadable against the successor — disclosed for the gate to rule.

## Conformance (names verbatim, all green)

`durable_plane_honors_intendant_home`, `secondary_never_opens_durable_plane`, `lock_denied_bootstrap_bounded_retry_then_named_refusal`, `plane_transfers_within_retry_window_on_drain` (full arc: durable write on the predecessor → drain hook releases → successor boot-acquires lease + plane, same plane id, claim survives → drainer refuses with the successor pointer), plus F1's `drain_rewrites_preserve_the_era_watershed`. Custody is the Gate-B-lite **file** sidecar, so every pin is hermetic and cross-platform — no macOS gating needed.

Battery: fmt + workspace clippy `-D warnings` + 5385 bin tests + lib crates + 37 e2e.