### PR TITLE
feat(agenda): question-audience classification — needs-you means needs YOU

### DIFF
--- a/docs/src/agenda-and-memory.md
+++ b/docs/src/agenda-and-memory.md
@@ -570,18 +570,31 @@ window while the daemon is down, or is interrupted before launch
 confirmation, fails closed and is not automatically retried. The outcome is
 written back to `effects[].last_run`.
 
-Two display-only fields ride the served item DTO so frontends never
-reimplement planner math — both computed at read time by the planner's own
+Three display-only fields ride the served item DTO so frontends never
+reimplement planner math — each computed at read time by the planner's own
 functions, never stored, never folded from operations. `effects[].next_fire_ms`
 is the next instant the effect would actually fire (approval-gated,
 suspension-aware, journal-deduped, series bounds respected; absent when
 nothing will fire). `deferred_until` is the instant a quiet-hours-deferred
 reminder would actually deliver (window end, midnight-spanning windows
 included; absent when nothing defers — including reminders disabled, where
-inventing a value would claim a delivery that never comes). They are stamped
-at the serving seam — list snapshots, command responses, `agenda_changed`
-broadcasts, the MCP tool — with the clock of that read, and are absent from
-the wire when unset, so the payload stays additive for older clients.
+inventing a value would claim a delivery that never comes). `watched_by` is
+the audience classification: the automation whose armed, healthy
+`on_item_match` trigger currently covers this open item (inverted from the
+same trigger derivation that powers `next_fire_ms`), or — for an item a
+firing already consumed — the automation whose occurrence is still running.
+Absent means needs-you: no machinery covers the item, only the owner can
+handle it. A sick watcher (suspended, approval voided, its firing crashed or
+abandoned, or completed without resolving the item) drops the claim, so the
+item re-joins the needs-you complement on the next read. The parked-question
+notification, the Agenda tab's Needs-you lens and badge, and the watched
+chip all branch on it; delivery and urgency never change — only the
+classification. All three are stamped at the serving seam — list snapshots,
+command responses, `agenda_changed` broadcasts, the MCP tool — with the
+clock of that read (single-item broadcast copies are decorated against the
+full fold, so they carry the same cross-item derivations as snapshots), and
+are absent from the wire when unset, so the payload stays additive for older
+clients.
 
 The scheduler observes dispatch receipts and completion events through the
 bounded broadcast EventBus. A lagged receiver is logged but not reconciled

--- a/src/bin/caller/agenda/ask.rs
+++ b/src/bin/caller/agenda/ask.rs
@@ -348,6 +348,7 @@ mod tests {
             part_of: None,
             relates_to: Vec::new(),
             deferred_until: None,
+            watched_by: None,
         }
     }
 

--- a/src/bin/caller/agenda/handle.rs
+++ b/src/bin/caller/agenda/handle.rs
@@ -2471,10 +2471,7 @@ mod tests {
         assert_eq!(watched.watcher_title, "Steward gate");
         assert_eq!(
             watched.due_ms,
-            Some(
-                question.provenance.created_ms
-                    + super::super::types::TRIGGER_BATCH_WINDOW_MS
-            ),
+            Some(question.provenance.created_ms + super::super::types::TRIGGER_BATCH_WINDOW_MS),
             "pickup = the planner's batching-window instant"
         );
         // …snapshot reads carry the same derivation…

--- a/src/bin/caller/agenda/handle.rs
+++ b/src/bin/caller/agenda/handle.rs
@@ -293,11 +293,23 @@ impl AgendaHandle {
         // rail (attention = tab badge + hidden-tab browser notification)
         // so the owner finds it without watching the agenda tab. The
         // notification is display-only; the reply rides the `answer` op.
+        // The copy classifies the audience — a question an armed
+        // automation already covers (the freshly decorated `watched_by`)
+        // says so instead of claiming the owner is needed; delivery and
+        // urgency stay identical either way (the owner asked to SEE
+        // every parked question — only the classification was wrong).
         if asked {
+            let title = match item.watched_by.as_ref() {
+                Some(watched) => format!(
+                    "Question parked — watched by \u{201c}{}\u{201d}",
+                    truncate(&watched.watcher_title, 120)
+                ),
+                None => "Question parked on the agenda".to_string(),
+            };
             self.bus.send(AppEvent::UserNotification {
                 session_id: None,
                 id: format!("agenda-question-{}", item.id),
-                title: Some("Question parked on the agenda".to_string()),
+                title: Some(title),
                 text: item.title.clone(),
                 urgency: crate::types::NotificationUrgency::Attention,
                 ts: now_ms(),
@@ -722,15 +734,41 @@ impl AgendaHandle {
     }
 
     /// Stamp the display-only planner derivations
-    /// (`effects[].next_fire_ms`, `deferred_until`) onto freshly folded
-    /// item clones, with the clock of this read — the serving seam for
-    /// every client-facing copy (list snapshots, command responses,
-    /// `agenda_changed` broadcasts). Computed by the REAL planner
-    /// functions ([`super::reminders::decorate_planner_fields`]), so
-    /// frontends never reimplement the math. Journal trouble degrades to
+    /// (`effects[].next_fire_ms`, `deferred_until`, `watched_by`) onto
+    /// freshly folded item clones, with the clock of this read — the
+    /// serving seam for every client-facing copy (list snapshots,
+    /// command responses, `agenda_changed` broadcasts). Computed by the
+    /// REAL planner functions
+    /// ([`super::reminders::decorate_planner_fields`]), so frontends
+    /// never reimplement the math. Journal trouble degrades to
     /// undecorated items (absence claims nothing). Never called under
-    /// the store lock — the journal reader has its own.
+    /// the store lock — the journal reader has its own. `items` here is
+    /// the FULL folded set (the list snapshot); a partial slice goes
+    /// through [`Self::decorate_item`], which supplies the full-fold
+    /// context the cross-item derivations need.
     fn decorate_items(&self, items: &mut [AgendaItem]) {
+        self.decorate_in_context(None, items);
+    }
+
+    /// Decorate one item copy (command responses, `agenda_changed`
+    /// broadcasts) against the FULL current fold: the trigger-lane
+    /// derivations read across items (match candidates, dependency
+    /// targets, watcher effects), so a lone item decorated against
+    /// itself under-reports `next_fire_ms` and never carries
+    /// `watched_by`. Sequential locks, never nested: the store lock for
+    /// the context snapshot drops before the journal lock is taken.
+    fn decorate_item(&self, item: &mut AgendaItem) {
+        let context = {
+            let mut store = self.lock();
+            if let Err(err) = store.refresh_if_stale() {
+                eprintln!("[agenda] refresh before decoration failed: {err}");
+            }
+            store.snapshot()
+        };
+        self.decorate_in_context(Some(&context), std::slice::from_mut(item));
+    }
+
+    fn decorate_in_context(&self, context: Option<&[AgendaItem]>, items: &mut [AgendaItem]) {
         let policy = self.reminder_policy();
         let now_ms = now_ms();
         self.with_journal(|journal| {
@@ -738,6 +776,7 @@ impl AgendaHandle {
                 eprintln!("[agenda] journal refresh for decoration failed: {err}");
             }
             super::reminders::decorate_planner_fields(
+                context,
                 items,
                 journal,
                 &policy,
@@ -745,10 +784,6 @@ impl AgendaHandle {
                 &super::scheduler::local_minute_of_day_at,
             );
         });
-    }
-
-    fn decorate_item(&self, item: &mut AgendaItem) {
-        self.decorate_items(std::slice::from_mut(item));
     }
 
     /// One page of the raw occurrence journal (read-only; the
@@ -2330,6 +2365,271 @@ mod tests {
         let store = AgendaStore::open(dir.path()).unwrap();
         let raw = store.snapshot();
         assert_eq!(raw[0].effects[0].next_fire_ms, None);
+    }
+
+    /// An armed steward-gate style matcher, built through the real ops:
+    /// a watcher item titled `Steward gate` with an approved
+    /// `on_item_match(question + gate)` effect, armed strictly before
+    /// anything parked after it (the 2ms sleep keeps `created_ms >` the
+    /// arm floor on any clock). Returns the watcher's item id.
+    fn armed_gate_watcher(handle: &AgendaHandle) -> String {
+        let watcher = handle
+            .apply(
+                AgendaCommand::Add {
+                    refs: Vec::new(),
+                    kind: AgendaKind::Task,
+                    title: "Steward gate".into(),
+                    body: String::new(),
+                    tags: Vec::new(),
+                    due_ms: None,
+                    source: None,
+                },
+                None,
+            )
+            .unwrap();
+        let proposed = handle
+            .apply(
+                AgendaCommand::ProposeEffect {
+                    binding_refs: Vec::new(),
+                    recurrence: None,
+                    id: watcher.id.clone(),
+                    goal: "rule on gate questions".into(),
+                    fire_at_ms: now_ms() - 60_000,
+                    orchestrate: false,
+                    agent_config: None,
+                    source: None,
+                    trigger: Some(super::super::types::TriggerSpec::OnItemMatch {
+                        item_kind: AgendaKind::Question,
+                        tags: vec!["gate".into()],
+                    }),
+                    project_root: None,
+                },
+                None,
+            )
+            .unwrap();
+        handle
+            .apply(
+                AgendaCommand::ApproveEffect {
+                    id: watcher.id.clone(),
+                    digest: proposed.effects[0].digest.clone(),
+                },
+                actor("dashboard", None),
+            )
+            .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        watcher.id
+    }
+
+    fn park_question(handle: &AgendaHandle, title: &str, tags: Vec<String>) -> AgendaItem {
+        handle
+            .apply(
+                AgendaCommand::Add {
+                    refs: Vec::new(),
+                    kind: AgendaKind::Question,
+                    title: title.into(),
+                    body: String::new(),
+                    tags,
+                    due_ms: None,
+                    source: None,
+                },
+                None,
+            )
+            .unwrap()
+    }
+
+    /// watched_by derives at the serving seam: a question an armed
+    /// matcher covers carries the automation's identity on the command
+    /// response and on snapshot reads — while the fold product on disk
+    /// never does (the classification is recomputed per read, never
+    /// stored, exactly like `next_fire_ms`).
+    #[test]
+    fn watched_by_derives_at_the_serving_seam() {
+        let dir = tempfile::tempdir().unwrap();
+        let handle = AgendaHandle::new(
+            AgendaStore::open(dir.path()).unwrap(),
+            EventBus::new(),
+            dir.path(),
+        );
+        let watcher_id = armed_gate_watcher(&handle);
+        let question = handle
+            .apply(
+                AgendaCommand::Add {
+                    refs: Vec::new(),
+                    kind: AgendaKind::Question,
+                    title: "Gate: review the landing".into(),
+                    body: String::new(),
+                    tags: vec!["gate".into()],
+                    due_ms: None,
+                    source: None,
+                },
+                None,
+            )
+            .unwrap();
+        // The command response (a decorated copy) carries the claim…
+        let watched = question.watched_by.as_ref().expect("watched at the seam");
+        assert_eq!(watched.watcher_item_id, watcher_id);
+        assert_eq!(watched.watcher_title, "Steward gate");
+        assert_eq!(
+            watched.due_ms,
+            Some(
+                question.provenance.created_ms
+                    + super::super::types::TRIGGER_BATCH_WINDOW_MS
+            ),
+            "pickup = the planner's batching-window instant"
+        );
+        // …snapshot reads carry the same derivation…
+        let (items, _, _) = handle.snapshot();
+        let served = items.iter().find(|item| item.id == question.id).unwrap();
+        assert_eq!(served.watched_by, question.watched_by);
+        // …and the fold product itself never does.
+        let raw = AgendaStore::open(dir.path()).unwrap().snapshot();
+        let folded = raw.iter().find(|item| item.id == question.id).unwrap();
+        assert_eq!(folded.watched_by, None, "derived, never stored");
+    }
+
+    /// The parked-question notification names the watching automation
+    /// when one covers the question — and only then: an uncovered
+    /// question keeps the needs-you copy byte-for-byte.
+    #[test]
+    fn watched_copy_names_the_automation() {
+        let dir = tempfile::tempdir().unwrap();
+        let bus = EventBus::new();
+        let mut rx = bus.subscribe();
+        let handle = AgendaHandle::new(AgendaStore::open(dir.path()).unwrap(), bus, dir.path());
+        armed_gate_watcher(&handle);
+        let covered = park_question(&handle, "Gate: sign off HS6", vec!["gate".into()]);
+        let uncovered = park_question(&handle, "Which vendor for the NAS?", Vec::new());
+        let mut titles = std::collections::HashMap::new();
+        while let Ok(event) = rx.try_recv() {
+            if let AppEvent::UserNotification { id, title, .. } = event {
+                titles.insert(id, title);
+            }
+        }
+        assert_eq!(
+            titles.get(&format!("agenda-question-{}", covered.id)),
+            Some(&Some(
+                "Question parked — watched by \u{201c}Steward gate\u{201d}".to_string()
+            )),
+            "the watched copy names the automation"
+        );
+        assert_eq!(
+            titles.get(&format!("agenda-question-{}", uncovered.id)),
+            Some(&Some("Question parked on the agenda".to_string())),
+            "the unwatched copy stays the legacy needs-you line"
+        );
+    }
+
+    /// Classification changes the COPY, never the delivery: watched and
+    /// unwatched questions both emit the parked-question notification on
+    /// the same id lane at the same Attention urgency — the owner asked
+    /// to see every parked question.
+    #[test]
+    fn notification_delivery_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let bus = EventBus::new();
+        let mut rx = bus.subscribe();
+        let handle = AgendaHandle::new(AgendaStore::open(dir.path()).unwrap(), bus, dir.path());
+        armed_gate_watcher(&handle);
+        let covered = park_question(&handle, "Gate: queue entry", vec!["gate".into()]);
+        let uncovered = park_question(&handle, "Pick the offsite week?", Vec::new());
+        let mut seen = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            if let AppEvent::UserNotification {
+                id, text, urgency, ..
+            } = event
+            {
+                assert!(
+                    matches!(urgency, crate::types::NotificationUrgency::Attention),
+                    "same urgency on every parked-question notification"
+                );
+                seen.push((id, text));
+            }
+        }
+        let expected = [
+            (
+                format!("agenda-question-{}", covered.id),
+                covered.title.clone(),
+            ),
+            (
+                format!("agenda-question-{}", uncovered.id),
+                uncovered.title.clone(),
+            ),
+        ];
+        for (id, text) in expected {
+            assert!(
+                seen.contains(&(id.clone(), text)),
+                "notification {id} delivered regardless of classification"
+            );
+        }
+    }
+
+    /// Broadcast copies carry full decorations: a single-item
+    /// `agenda_changed` copy is decorated against the whole fold, so a
+    /// watcher's copy reports the trigger-lane `next_fire_ms` and a
+    /// watched question's copy carries `watched_by` — neither of which a
+    /// single-item universe could derive (the pre-fix starvation left
+    /// broadcast copies degraded until the next full-list read).
+    #[test]
+    fn broadcast_copies_carry_full_decorations() {
+        let dir = tempfile::tempdir().unwrap();
+        let bus = EventBus::new();
+        let handle = AgendaHandle::new(AgendaStore::open(dir.path()).unwrap(), bus, dir.path());
+        let watcher_id = armed_gate_watcher(&handle);
+        let question = park_question(&handle, "Gate: soak the queue", vec!["gate".into()]);
+        let due = question.watched_by.as_ref().and_then(|w| w.due_ms);
+        assert!(due.is_some(), "fixture: the question is covered");
+
+        // An op touching the WATCHER broadcasts a singleton copy that
+        // still sees its match candidates.
+        let mut rx = handle.bus().subscribe();
+        let watcher = handle
+            .apply(
+                AgendaCommand::Annotate {
+                    id: watcher_id,
+                    text: "steward pass noted".into(),
+                    source: None,
+                },
+                None,
+            )
+            .unwrap();
+        assert_eq!(
+            watcher.effects[0].next_fire_ms, due,
+            "the watcher's singleton copy carries the trigger-lane fire instant"
+        );
+        // An op touching the QUESTION broadcasts a copy that still knows
+        // its watcher.
+        let question = handle
+            .apply(
+                AgendaCommand::Annotate {
+                    id: question.id.clone(),
+                    text: "context added".into(),
+                    source: None,
+                },
+                None,
+            )
+            .unwrap();
+        let watched = question
+            .watched_by
+            .as_ref()
+            .expect("the question's singleton copy carries watched_by");
+        assert_eq!(watched.watcher_title, "Steward gate");
+        // And the broadcast events carry the same decorated copies.
+        let mut broadcast_fire = None;
+        let mut broadcast_watched = None;
+        while let Ok(event) = rx.try_recv() {
+            if let AppEvent::AgendaChanged { item, .. } = event {
+                if item.id == question.id {
+                    broadcast_watched = item.watched_by.clone();
+                } else {
+                    broadcast_fire = item.effects[0].next_fire_ms;
+                }
+            }
+        }
+        assert_eq!(broadcast_fire, due);
+        assert_eq!(
+            broadcast_watched.map(|watched| watched.watcher_title),
+            Some("Steward gate".to_string())
+        );
     }
 
     /// The occurrence-journal read surface converges on scheduler writes:

--- a/src/bin/caller/agenda/reminders.rs
+++ b/src/bin/caller/agenda/reminders.rs
@@ -4219,8 +4219,8 @@ mod tests {
             });
             question
         };
-        let record = |occurrence: &str, state: OccurrenceState, session: Option<&str>| {
-            OccurrenceRecord {
+        let record =
+            |occurrence: &str, state: OccurrenceState, session: Option<&str>| OccurrenceRecord {
                 v: 1,
                 at_ms: 21_000,
                 occurrence_id: occurrence.into(),
@@ -4231,8 +4231,7 @@ mod tests {
                 session_id: session.map(Into::into),
                 generation: None,
                 boot_id: None,
-            }
-        };
+            };
         journal
             .append(&record("occ-dispatching", OccurrenceState::Prepared, None))
             .unwrap();

--- a/src/bin/caller/agenda/reminders.rs
+++ b/src/bin/caller/agenda/reminders.rs
@@ -38,7 +38,9 @@
 //! crash windows (a `prepared` row without a terminal re-delivers on the
 //! next wake, whichever daemon holds the lease by then).
 
-use super::types::{AgendaEffect, AgendaItem, AgendaStatus, BindingRef, RecurrenceSpec};
+use super::types::{
+    AgendaEffect, AgendaItem, AgendaStatus, AgendaWatchedBy, BindingRef, RecurrenceSpec,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::io::Write;
@@ -985,7 +987,7 @@ pub(crate) struct TriggerDue {
 
 /// The trigger derivation, pure over the fold + journal-derived
 /// exclusion set. ONE implementation shared by [`plan`] and
-/// [`effect_next_fire_ms`] (the differential pin covers the trigger
+/// [`effect_planner_view`] (the differential pin covers the trigger
 /// cases), mirroring the [`series_instants`] discipline.
 ///
 /// Floors, in force for BOTH kinds: the ARM floor
@@ -1094,7 +1096,8 @@ pub(crate) fn trigger_due(
 /// from the daemon marks the item spent for this effect. Attribution-
 /// checked — the text prefix alone gates nothing (a non-daemon writer
 /// echoing the marker changes nothing, per the unverified-label
-/// doctrine).
+/// doctrine). The candidate-walk hot path; the full parse of the same
+/// marker format lives in [`trigger_consumed_markers`].
 fn trigger_consumed(item: &AgendaItem, effect_id: &str) -> bool {
     let marker = format!(
         "{}effect={effect_id} ",
@@ -1107,10 +1110,35 @@ fn trigger_consumed(item: &AgendaItem, effect_id: &str) -> bool {
     })
 }
 
+/// Every attribution-checked consumed-marker on the item, parsed to
+/// `(effect_id, occurrence_id)` — the `watched_by` decoration's join key
+/// into the occurrence journal (the marker text names the exact firing
+/// that took the item, written by the dispatcher). Same attribution and
+/// text shape [`trigger_consumed`] gates on; a marker that does not
+/// parse claims nothing.
+fn trigger_consumed_markers(item: &AgendaItem) -> Vec<(String, String)> {
+    item.annotations
+        .iter()
+        .filter(|note| {
+            note.kind.as_deref() == Some("daemon")
+                && note.source.as_deref() == Some(super::types::TRIGGER_CONSUMED_SOURCE)
+        })
+        .filter_map(|note| {
+            let rest = note
+                .text
+                .strip_prefix(super::types::TRIGGER_CONSUMED_PREFIX)?;
+            let mut tokens = rest.split_whitespace();
+            let effect_id = tokens.next()?.strip_prefix("effect=")?;
+            let occurrence_id = tokens.next()?.strip_prefix("occurrence=")?;
+            Some((effect_id.to_string(), occurrence_id.to_string()))
+        })
+        .collect()
+}
+
 /// A standing series' planner-relevant instants at one moment, from
 /// [`series_instants`] — the single implementation of the recurrence
 /// k-index math (G3-pre), shared by [`plan`] and the display-only
-/// [`effect_next_fire_ms`] derivation so the two can never drift.
+/// [`effect_planner_view`] derivation so the two can never drift.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct SeriesInstants {
     /// The latest due series instant — the one catch-up the planner
@@ -1387,39 +1415,55 @@ pub(crate) fn plan(
     plan
 }
 
-/// The next instant `effect` would actually fire, by [`plan`]'s own rules
-/// — the dashboard's display-only derivation (decorated onto the DTO at
-/// the serving seam, never stored, never folded from ops). `None` means
-/// nothing will fire: unapproved (an approval binds the current digest or
-/// does not exist), suspended, a spent or in-flight one-shot, an
-/// exhausted series.
-///
-/// Mirrors `plan` exactly, candidate for candidate: the same
-/// [`series_instants`] math, the same journal dedup (a `prepared`,
-/// `started`, or terminal occurrence never re-fires — `prepared` resolves
-/// through the crashed lane, fail-closed), the same staleness
-/// classification (a due instant past the window is `missed`, not a
-/// fire), and the same requested-instant handling (every pending request
-/// is a candidate; spent ones are journal-deduped). The one deliberate
-/// difference: transient execution state — the scheduler's private
-/// in-flight set, and the no-overlap hold while a run of this effect is
-/// still `started` (per the effect object or any started-without-terminal
-/// journal row of the item) — only DELAYS a fire, so a due instant held
-/// by either keeps showing here (it fires when the run settles;
-/// mid-dispatch, the write-back settles the display). The
-/// `next_fire_agrees_with_the_planner` differential test pins this mirror
-/// to `plan` itself.
-pub(crate) fn effect_next_fire_ms(
+/// One effect's planner-derived display state at one moment: the next
+/// fire instant plus, for an armed healthy trigger, the [`TriggerDue`]
+/// behind it — kept instead of dropped so the `watched_by` decoration
+/// can invert `matched_item_ids` from the SAME call the next-fire
+/// derivation already makes.
+#[derive(Debug, Default)]
+pub(crate) struct EffectPlannerView {
+    /// The next instant `effect` would actually fire, by [`plan`]'s own
+    /// rules — the dashboard's display-only derivation (decorated onto
+    /// the DTO at the serving seam, never stored, never folded from
+    /// ops). `None` means nothing will fire: unapproved (an approval
+    /// binds the current digest or does not exist), suspended, a spent
+    /// or in-flight one-shot, an exhausted series.
+    pub(crate) next_fire_ms: Option<u64>,
+    /// The trigger derivation's answer, present only while the watcher
+    /// can deliver: approval bound, not suspended, a cause exists. The
+    /// journal dedup never clears it — a spent cause with the
+    /// occurrence still running is covered machinery, not silence.
+    pub(crate) trigger: Option<TriggerDue>,
+}
+
+/// The planner mirrored for display ([`EffectPlannerView`]), candidate
+/// for candidate: the same [`series_instants`] math, the same journal
+/// dedup (a `prepared`, `started`, or terminal occurrence never
+/// re-fires — `prepared` resolves through the crashed lane,
+/// fail-closed), the same staleness classification (a due instant past
+/// the window is `missed`, not a fire), and the same requested-instant
+/// handling (every pending request is a candidate; spent ones are
+/// journal-deduped). The one deliberate difference: transient execution
+/// state — the scheduler's private in-flight set, and the no-overlap
+/// hold while a run of this effect is still `started` (per the effect
+/// object or any started-without-terminal journal row of the item) —
+/// only DELAYS a fire, so a due instant held by either keeps showing
+/// here (it fires when the run settles; mid-dispatch, the write-back
+/// settles the display). The `next_fire_agrees_with_the_planner`
+/// differential test pins this mirror to `plan` itself.
+pub(crate) fn effect_planner_view(
     items: &[AgendaItem],
     item: &AgendaItem,
     effect: &AgendaEffect,
     journal: &OccurrenceJournal,
     staleness_ms: u64,
     now_ms: u64,
-) -> Option<u64> {
-    let approval = effect.approval.as_ref()?;
+) -> EffectPlannerView {
+    let Some(approval) = effect.approval.as_ref() else {
+        return EffectPlannerView::default();
+    };
     if effect.suspended() {
-        return None;
+        return EffectPlannerView::default();
     }
     // Candidate instants as (fire, identity), exactly as `plan` assembles
     // them — including the trigger lane (Track T), which shares
@@ -1432,10 +1476,12 @@ pub(crate) fn effect_next_fire_ms(
         *upcoming = Some(upcoming.map_or(instant, |cur: u64| cur.min(instant)));
     }
     let triggered = effect.manifest.trigger.is_some();
+    let mut trigger: Option<TriggerDue> = None;
     if let Some(trig) = &effect.manifest.trigger {
         let started = journal.started_sessions_for_item(&item.id);
         if let Some(due) = trigger_due(items, item, effect, trig, approval.at_ms, &started) {
             candidates.push((due.due_ms, due.cause_ms));
+            trigger = Some(due);
         }
         for req in &effect.requested {
             candidates.push((req.at_ms, req.at_ms));
@@ -1477,7 +1523,10 @@ pub(crate) fn effect_next_fire_ms(
             fires_next_pass = Some(fires_next_pass.map_or(instant, |cur| cur.min(instant)));
         }
     }
-    fires_next_pass.or(upcoming)
+    EffectPlannerView {
+        next_fire_ms: fires_next_pass.or(upcoming),
+        trigger,
+    }
 }
 
 /// When quiet hours would defer this item's pending reminder, the instant
@@ -1520,11 +1569,19 @@ pub(crate) fn reminder_deferred_until(
 }
 
 /// Stamp the DTO's display-only planner fields onto `items` in place:
-/// [`effect_next_fire_ms`] on every open item's effects and
-/// [`reminder_deferred_until`] on every item. The serving seam
-/// (`AgendaHandle`) calls this on freshly folded clones with the clock
-/// of the read — the fold product itself always carries `None`.
+/// [`effect_planner_view`]'s next fire on every open item's effects,
+/// [`reminder_deferred_until`] and the `watched_by` classification on
+/// every item. The serving seam (`AgendaHandle`) calls this on freshly
+/// folded clones with the clock of the read — the fold product itself
+/// always carries `None`.
+///
+/// `context` is the full folded set when `items` is only a slice of it
+/// (the single-item `agenda_changed` broadcast path): the trigger lane
+/// reads ACROSS items — dependency statuses, match candidates, watcher
+/// effects — so a lone item decorated against itself starves every
+/// cross-item derivation. `None` means `items` IS the full set.
 pub(crate) fn decorate_planner_fields(
+    context: Option<&[AgendaItem]>,
     items: &mut [AgendaItem],
     journal: &OccurrenceJournal,
     policy: &ReminderPolicy,
@@ -1533,29 +1590,140 @@ pub(crate) fn decorate_planner_fields(
 ) {
     let staleness_ms = policy.staleness_ms();
     // The trigger lane (Track T) reads ACROSS items — dependency
-    // statuses, match candidates — so next-fire values are computed in
+    // statuses, match candidates — so planner views are computed in
     // an immutable pass and stamped in a second. Same values, no
     // aliasing; non-open items keep the fold's `None` (the planner
     // considers open items only — nothing fires).
-    let next_fires: Vec<Vec<Option<u64>>> = items
+    let universe: &[AgendaItem] = context.unwrap_or(items);
+    let views: Vec<Vec<Option<EffectPlannerView>>> = items
         .iter()
         .map(|item| {
             item.effects
                 .iter()
                 .map(|effect| {
-                    (item.status == AgendaStatus::Open)
-                        .then(|| {
-                            effect_next_fire_ms(items, item, effect, journal, staleness_ms, now_ms)
-                        })
-                        .flatten()
+                    (item.status == AgendaStatus::Open).then(|| {
+                        effect_planner_view(universe, item, effect, journal, staleness_ms, now_ms)
+                    })
                 })
                 .collect()
         })
         .collect();
-    for (item, fires) in items.iter_mut().zip(next_fires) {
+    // The watched_by inversion — needs-you is the unwatched complement,
+    // so the claim source is the planner's own match derivation: every
+    // open watcher whose armed, non-suspended matcher currently covers
+    // an item claims it. Watchers in the stamped slice reuse the views
+    // computed above (one [`trigger_due`] call per effect per pass);
+    // watchers only in the context get their own call.
+    let mut watched: BTreeMap<String, AgendaWatchedBy> = BTreeMap::new();
+    for (item, item_views) in items.iter().zip(&views) {
+        for (effect, view) in item.effects.iter().zip(item_views) {
+            if let Some(due) = view.as_ref().and_then(|view| view.trigger.as_ref()) {
+                claim_watched(&mut watched, item, effect, due);
+            }
+        }
+    }
+    if context.is_some() {
+        let stamped: std::collections::BTreeSet<&str> =
+            items.iter().map(|item| item.id.as_str()).collect();
+        for watcher in universe {
+            if watcher.status != AgendaStatus::Open || stamped.contains(watcher.id.as_str()) {
+                continue;
+            }
+            for effect in &watcher.effects {
+                let Some(approval) = &effect.approval else {
+                    continue;
+                };
+                if effect.suspended() {
+                    continue;
+                }
+                let Some(trig) = &effect.manifest.trigger else {
+                    continue;
+                };
+                let started = journal.started_sessions_for_item(&watcher.id);
+                if let Some(due) =
+                    trigger_due(universe, watcher, effect, trig, approval.at_ms, &started)
+                {
+                    claim_watched(&mut watched, watcher, effect, &due);
+                }
+            }
+        }
+    }
+    // The consumed lane: an open item a firing already took (the
+    // dispatch-time marker names the exact occurrence) stays watched
+    // while that occurrence is still running — and re-joins needs-you
+    // the moment it settles without closing the item (completed-but-
+    // still-open, crashed, retry-walk-abandoned: every terminal that
+    // leaves the item open means machinery could not deliver).
+    let consumed: Vec<Option<AgendaWatchedBy>> = items
+        .iter()
+        .map(|item| {
+            if item.status != AgendaStatus::Open {
+                return None;
+            }
+            trigger_consumed_markers(item)
+                .into_iter()
+                .find_map(|(effect_id, occurrence_id)| {
+                    let progress = journal.progress(&occurrence_id);
+                    let running = progress.terminal.is_none()
+                        && (progress.prepared || progress.started.is_some());
+                    if !running {
+                        return None;
+                    }
+                    // The claim needs a live name — the watcher item
+                    // owning the effect (`effect_id` is stable across
+                    // re-proposes). A vanished automation claims
+                    // nothing: the item stays needs-you.
+                    universe.iter().find_map(|watcher| {
+                        watcher
+                            .effects
+                            .iter()
+                            .any(|effect| effect.effect_id == effect_id)
+                            .then(|| AgendaWatchedBy {
+                                watcher_item_id: watcher.id.clone(),
+                                watcher_title: watcher.title.clone(),
+                                effect_id: effect_id.clone(),
+                                due_ms: None,
+                            })
+                    })
+                })
+        })
+        .collect();
+    for ((item, item_views), consumed) in items.iter_mut().zip(views).zip(consumed) {
         item.deferred_until = reminder_deferred_until(item, journal, policy, now_ms, minute_of_day);
-        for (effect, fire) in item.effects.iter_mut().zip(fires) {
-            effect.next_fire_ms = fire;
+        // A running consuming occurrence outranks a pending matcher
+        // claim: it is the more concrete promise of delivery.
+        item.watched_by = consumed.or_else(|| watched.remove(&item.id));
+        for (effect, view) in item.effects.iter_mut().zip(item_views) {
+            effect.next_fire_ms = view.and_then(|view| view.next_fire_ms);
+        }
+    }
+}
+
+/// One watcher's claim over each item its trigger derivation matched.
+/// Earliest pickup wins when several automations watch the same item;
+/// ties keep the first claim (walk order — deterministic because the
+/// fold is).
+fn claim_watched(
+    watched: &mut BTreeMap<String, AgendaWatchedBy>,
+    watcher: &AgendaItem,
+    effect: &AgendaEffect,
+    due: &TriggerDue,
+) {
+    for matched_id in &due.matched_item_ids {
+        let replace = match watched.get(matched_id) {
+            None => true,
+            Some(cur) => cur.due_ms.is_some_and(|cur_due| due.due_ms < cur_due),
+        };
+        if replace {
+            watched.insert(
+                matched_id.clone(),
+                AgendaWatchedBy {
+                    watcher_item_id: watcher.id.clone(),
+                    watcher_title: watcher.title.clone(),
+                    effect_id: effect.effect_id.clone(),
+                    due_ms: Some(due.due_ms),
+                },
+            );
         }
     }
 }
@@ -1594,6 +1762,7 @@ mod tests {
             part_of: None,
             relates_to: Vec::new(),
             deferred_until: None,
+            watched_by: None,
         }
     }
 
@@ -2716,7 +2885,7 @@ mod tests {
         }
     }
 
-    /// The differential pin: whatever `effect_next_fire_ms` claims must
+    /// The differential pin: whatever `effect_planner_view` claims must
     /// be exactly what `plan` does with the same inputs — a due claim is
     /// a spawn on the next pass, a future claim is the wake instant, and
     /// `None` plans no spawn and no wake (single-effect, no-reminder
@@ -2741,7 +2910,8 @@ mod tests {
         now_ms: u64,
     ) -> Option<u64> {
         let effect = &item.effects[0];
-        let next = effect_next_fire_ms(items, item, effect, journal, policy.staleness_ms(), now_ms);
+        let next = effect_planner_view(items, item, effect, journal, policy.staleness_ms(), now_ms)
+            .next_fire_ms;
         let planned = plan(
             items,
             journal,
@@ -3091,7 +3261,7 @@ mod tests {
         let mut items = vec![plain];
         items[0].due_ms = Some(now - 1_000);
         let at_23 = |_: u64| 23 * 60;
-        decorate_planner_fields(&mut items, &journal, &policy, now, &at_23);
+        decorate_planner_fields(None, &mut items, &journal, &policy, now, &at_23);
         let json = serde_json::to_value(&items[0]).unwrap();
         assert_eq!(
             json["deferred_until"].as_u64(),
@@ -3106,7 +3276,7 @@ mod tests {
         let mut done = vec![one_shot_item("ser-done", now + 5_000)];
         done[0].status = AgendaStatus::Done;
         done[0].due_ms = Some(now - 1_000);
-        decorate_planner_fields(&mut done, &journal, &policy, now, &at_23);
+        decorate_planner_fields(None, &mut done, &journal, &policy, now, &at_23);
         assert_eq!(done[0].deferred_until, None);
         assert_eq!(done[0].effects[0].next_fire_ms, None);
     }
@@ -3932,5 +4102,180 @@ mod tests {
         );
         assert!(planned.missed_sessions.is_empty(), "never missed");
         assert_eq!(planned.spawn.len(), 1, "fires on wake regardless of gap");
+    }
+
+    // ---- watched_by: the needs-you complement ----
+
+    fn decorate(items: &mut [AgendaItem], journal: &OccurrenceJournal, now: u64) {
+        let noon = |_: u64| 12 * 60;
+        decorate_planner_fields(None, items, journal, &ReminderPolicy::default(), now, &noon);
+    }
+
+    /// needs-you is the unwatched complement: exactly the items the
+    /// armed matcher's own derivation reports carry `watched_by`; every
+    /// exclusion the planner applies — wrong tags, parked before the arm
+    /// floor, parked by a session the effect's firings started, done —
+    /// leaves the item unwatched (only the owner can handle it). The
+    /// watcher never claims itself.
+    #[test]
+    fn needs_you_is_the_unwatched_complement() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut journal = journal(dir.path());
+        // A prior firing started sess-fired for the watcher item — the
+        // loop-exclusion input.
+        for state in [OccurrenceState::Prepared, OccurrenceState::Started] {
+            journal
+                .append(&OccurrenceRecord {
+                    v: 1,
+                    at_ms: 15_000,
+                    occurrence_id: "occ-prior".into(),
+                    item_id: "steward".into(),
+                    due_ms: 15_000,
+                    state,
+                    urgency: None,
+                    session_id: matches!(state, OccurrenceState::Started)
+                        .then(|| "sess-fired".to_string()),
+                    generation: None,
+                    boot_id: None,
+                })
+                .unwrap();
+        }
+        let watcher = triggered_item("steward", gate_trigger(), 10_000, 10_000);
+        let covered = matching_question("q-covered", 20_000, None);
+        let mut wrong_tags = matching_question("q-tags", 20_000, None);
+        wrong_tags.tags = vec!["other".into()];
+        let pre_arm = matching_question("q-backlog", 9_000, None);
+        let self_parked = matching_question("q-loop", 21_000, Some("sess-fired"));
+        let mut done = matching_question("q-done", 21_500, None);
+        done.status = AgendaStatus::Done;
+        let mut items = vec![watcher, covered, wrong_tags, pre_arm, self_parked, done];
+        decorate(&mut items, &journal, 30_000);
+
+        let by_id = |id: &str| items.iter().find(|item| item.id == id).unwrap();
+        let watched = by_id("q-covered").watched_by.as_ref().expect("covered");
+        assert_eq!(watched.watcher_item_id, "steward");
+        assert_eq!(watched.watcher_title, "item steward");
+        assert_eq!(watched.effect_id, "ef-1");
+        assert_eq!(
+            watched.due_ms,
+            Some(20_000 + TRIGGER_BATCH_WINDOW_MS),
+            "pickup = the batching window after the covered arrival \
+             (excluded items never move the window)"
+        );
+        for unwatched in ["steward", "q-tags", "q-backlog", "q-loop", "q-done"] {
+            assert_eq!(
+                by_id(unwatched).watched_by,
+                None,
+                "{unwatched} is the owner's — no healthy matcher covers it"
+            );
+        }
+        // The stamped watcher also carries the trigger-lane next fire —
+        // the shared derivation, one call.
+        assert_eq!(
+            by_id("steward").effects[0].next_fire_ms,
+            Some(20_000 + TRIGGER_BATCH_WINDOW_MS)
+        );
+    }
+
+    /// A sick watcher returns its items to needs-you: suspension and a
+    /// lost approval clear the pending claim, and a consumed question
+    /// stays watched only while the consuming occurrence is running —
+    /// crash residue (terminal `unknown`), abandonment, or a completed
+    /// firing that left the question open all hand it back to the owner.
+    #[test]
+    fn sick_watcher_returns_item_to_needs_you() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut journal = journal(dir.path());
+        let policy = ReminderPolicy::default();
+        let noon = |_: u64| 12 * 60;
+
+        // Suspended: the failure streak reached the threshold.
+        let mut suspended = triggered_item("steward", gate_trigger(), 10_000, 10_000);
+        suspended.effects[0].consecutive_failures = 3;
+        let mut items = vec![suspended, matching_question("q1", 20_000, None)];
+        decorate_planner_fields(None, &mut items, &journal, &policy, 30_000, &noon);
+        assert_eq!(items[1].watched_by, None, "suspension escalates");
+
+        // Unapproved: a re-propose voided the approval.
+        let mut unapproved = triggered_item("steward", gate_trigger(), 10_000, 10_000);
+        unapproved.effects[0].approval = None;
+        let mut items = vec![unapproved, matching_question("q1", 20_000, None)];
+        decorate_planner_fields(None, &mut items, &journal, &policy, 30_000, &noon);
+        assert_eq!(items[1].watched_by, None, "no approval, no watcher");
+
+        // Consumed questions: the marker names the occurrence; its
+        // journal progress decides. Running (prepared, and started)
+        // keeps the claim with no pending instant; a crashed or
+        // completed-but-unresolved firing does not.
+        let consumed_by = |id: &str, occurrence: &str| {
+            let mut question = matching_question(id, 20_000, None);
+            question.annotations.push(AgendaAnnotation {
+                text: format!("trigger-consumed effect=ef-1 occurrence={occurrence}"),
+                at_ms: 20_500,
+                principal: None,
+                session_id: None,
+                kind: Some("daemon".into()),
+                source: Some("trigger-evaluator".into()),
+            });
+            question
+        };
+        let record = |occurrence: &str, state: OccurrenceState, session: Option<&str>| {
+            OccurrenceRecord {
+                v: 1,
+                at_ms: 21_000,
+                occurrence_id: occurrence.into(),
+                item_id: "steward".into(),
+                due_ms: 21_000,
+                state,
+                urgency: None,
+                session_id: session.map(Into::into),
+                generation: None,
+                boot_id: None,
+            }
+        };
+        journal
+            .append(&record("occ-dispatching", OccurrenceState::Prepared, None))
+            .unwrap();
+        for row in [
+            record("occ-live", OccurrenceState::Prepared, None),
+            record("occ-live", OccurrenceState::Started, Some("sess-live")),
+            record("occ-crash", OccurrenceState::Prepared, None),
+            record("occ-crash", OccurrenceState::Unknown, None),
+            record("occ-shrug", OccurrenceState::Prepared, None),
+            record("occ-shrug", OccurrenceState::Started, Some("sess-done")),
+            record("occ-shrug", OccurrenceState::Completed, Some("sess-done")),
+        ] {
+            journal.append(&row).unwrap();
+        }
+        let mut items = vec![
+            triggered_item("steward", gate_trigger(), 10_000, 10_000),
+            consumed_by("q-dispatching", "occ-dispatching"),
+            consumed_by("q-live", "occ-live"),
+            consumed_by("q-crash", "occ-crash"),
+            consumed_by("q-open-after-run", "occ-shrug"),
+        ];
+        decorate_planner_fields(None, &mut items, &journal, &policy, 30_000, &noon);
+        let by_id = |id: &str| items.iter().find(|item| item.id == id).unwrap();
+        for running in ["q-dispatching", "q-live"] {
+            let watched = by_id(running)
+                .watched_by
+                .as_ref()
+                .unwrap_or_else(|| panic!("{running}: a running firing is covered machinery"));
+            assert_eq!(watched.watcher_title, "item steward");
+            assert_eq!(
+                watched.due_ms, None,
+                "{running}: no pending instant — the occurrence is already running"
+            );
+        }
+        assert_eq!(
+            by_id("q-crash").watched_by,
+            None,
+            "crash residue over a spent cause is the owner's again"
+        );
+        assert_eq!(
+            by_id("q-open-after-run").watched_by,
+            None,
+            "machinery fired and did not resolve it — needs the owner"
+        );
     }
 }

--- a/src/bin/caller/agenda/types.rs
+++ b/src/bin/caller/agenda/types.rs
@@ -506,7 +506,7 @@ pub struct AgendaEffect {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(crate) requested: Vec<AgendaRequestedRun>,
     /// Display-only planner derivation: the next instant this effect
-    /// would actually fire ([`super::reminders::effect_next_fire_ms`] —
+    /// would actually fire ([`super::reminders::effect_planner_view`] —
     /// the real planner math, so frontends never reimplement it), or
     /// `None` when nothing will fire (unapproved, suspended, spent,
     /// exhausted). Decorated at the serving seam
@@ -670,6 +670,40 @@ pub struct AgendaItem {
     /// never folded from ops, never stored.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) deferred_until: Option<u64>,
+    /// Display-only planner derivation: the automation currently covering
+    /// this open item — an inversion of the matches the planner's own
+    /// trigger derivation reports ([`super::reminders::trigger_due`]), so
+    /// "needs you" surfaces can subtract what machinery already watches.
+    /// Claimed only while the watcher can deliver: the effect armed and
+    /// not suspended, or the consuming occurrence still running. `None`
+    /// is the needs-you complement — no healthy automation covers this
+    /// item, only the owner can. Decorated at the serving seam
+    /// ([`super::AgendaHandle`]) with the clock of the read; always
+    /// `None` in the fold product, never folded from ops, never stored.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) watched_by: Option<AgendaWatchedBy>,
+}
+
+/// The automation claiming an open item (the `watched_by` decoration):
+/// which watcher item, which effect, and when it picks the item up.
+/// Derived at the serving seam, never authored at park time — a static
+/// audience stamp would misroute self-excluded parks (an item parked by
+/// the mandate's own executor session never re-fires it) and could not
+/// follow watcher health.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgendaWatchedBy {
+    /// The agenda item carrying the watching effect.
+    pub(crate) watcher_item_id: String,
+    /// That item's title — the human name surfaces render ("watched by
+    /// <title>"). Item-authored text: render quoted, like every title.
+    pub(crate) watcher_title: String,
+    /// The watching effect (stable across re-proposes).
+    pub(crate) effect_id: String,
+    /// The planner's fire instant over this item (batching window +
+    /// floors — [`super::reminders::TriggerDue::due_ms`]). `None` when
+    /// the claim comes from a consuming occurrence already running.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) due_ms: Option<u64>,
 }
 
 /// One attributed note on an item (F2 `annotate` fold view). Attribution
@@ -1595,6 +1629,7 @@ pub(crate) fn apply_op(
                     part_of: None,
                     relates_to: Vec::new(),
                     deferred_until: None,
+                    watched_by: None,
                 },
             );
             None

--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -3773,7 +3773,7 @@ pub fn app_event_to_outbound(event: &AppEvent) -> Option<crate::types::OutboundE
             method: method.clone(),
         }),
         AppEvent::AgendaChanged { item, counts } => Some(OutboundEvent::AgendaChanged {
-            item: item.clone(),
+            item: Box::new(item.clone()),
             counts: *counts,
         }),
         // Supervisor-internal delivery signal: browsers already see the

--- a/src/bin/caller/types.rs
+++ b/src/bin/caller/types.rs
@@ -1299,9 +1299,12 @@ pub enum OutboundEvent {
     /// `OutboundEvent`'s serde tag is also `"event"`, and a struct
     /// field with the same name would collide with the variant
     /// discriminator at the same JSON nesting level.
+    /// Boxed like [`crate::peer::RegistryEvent::PeerEventForwarded`]'s
+    /// payload — the enum's largest field on some targets (serde is
+    /// transparent to the box).
     PeerEventForwarded {
         peer_id: String,
-        payload: crate::peer::PeerEvent,
+        payload: Box<crate::peer::PeerEvent>,
     },
     /// One leg of a federation-driven WebRTC signaling exchange,
     /// emitted *by* this daemon back toward a connector. Carries the
@@ -1339,8 +1342,11 @@ pub enum OutboundEvent {
         signal: crate::peer::WebRtcSignal,
     },
     /// The agenda ledger changed; frontends refresh their agenda views.
+    /// Boxed: the decorated item DTO is the enum's largest payload by a
+    /// margin Clippy flags on some targets (serde is transparent to the
+    /// box — the wire shape is unchanged).
     AgendaChanged {
-        item: crate::agenda::AgendaItem,
+        item: Box<crate::agenda::AgendaItem>,
         counts: crate::agenda::AgendaCounts,
     },
     /// The Memory plane admitted a claim; frontends refresh their

--- a/src/bin/caller/web_gateway/listener.rs
+++ b/src/bin/caller/web_gateway/listener.rs
@@ -1298,7 +1298,7 @@ fn spawn_web_gateway_from_cert_dir_with_relay_listener(
                                 .await;
                                 crate::types::OutboundEvent::PeerEventForwarded {
                                     peer_id: peer.as_str().to_string(),
-                                    payload: rewritten_event,
+                                    payload: Box::new(rewritten_event),
                                 }
                             }
                         };

--- a/static/app.html
+++ b/static/app.html
@@ -37071,7 +37071,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '2e25844c8e73b41d';
+const INTENDANT_APP_BUILD = 'fd2dad17a4e60704';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -92742,9 +92742,13 @@ function agendaLensGroupsNow() {
   const pool = agendaFilteredPool();
   const seen = new Set();
   const take = (arr) => arr.filter((x) => !seen.has(x.id) && (seen.add(x.id), true));
-  const answer = take(pool
+  // The audience split (daemon-derived watched_by): questions an armed
+  // automation covers are machinery's inbox, not the owner's — they
+  // leave Answer for the FYI-grade Watched group below.
+  const openQuestions = pool
     .filter((x) => x.kind === 'question' && x.status === 'open' && !x.dismissed)
-    .sort(agendaByNew));
+    .sort(agendaByNew);
+  const answer = take(openQuestions.filter((x) => !x.watched_by));
   const approve = take(pool.filter((x) => {
     const st = agendaEffectState(x);
     return x.status === 'open' && st && st.kind === 'pending';
@@ -92758,6 +92762,11 @@ function agendaLensGroupsNow() {
   const attend = take(pool
     .filter((x) => x.status === 'open' && agendaTriageInfo(x))
     .sort(agendaAttendOrder));
+  // Watched questions take LAST: any needs-you-grade state above (a
+  // pending approval, a suspension) outranks the FYI grouping. Calm
+  // depth folds machinery-audience away entirely.
+  const watched = agendaDepthCalm() ? []
+    : take(openQuestions.filter((x) => x.watched_by));
   const groups = [];
   if (answer.length) {
     groups.push({
@@ -92792,6 +92801,13 @@ function agendaLensGroupsNow() {
       label: 'Attend',
       hint: 'triage-flagged items, ranked — ordinary annotations from the triage mandate; ranking gates nothing',
       rows: attend.map((x) => ({ item: x })),
+    });
+  }
+  if (watched.length) {
+    groups.push({
+      label: 'Watched',
+      hint: 'questions an armed automation will pick up — machinery’s inbox, not yours; anything it can’t deliver returns to Answer',
+      rows: watched.map((x) => ({ item: x, composer: true })),
     });
   }
   return groups;
@@ -92963,11 +92979,14 @@ function agendaLensGroupsArchive() {
 }
 
 // Distinct items the "Needs you" lens would show — the lens badge.
+// Watched questions (an armed automation covers them — daemon-derived
+// watched_by) are machinery's inbox and never count as needing you.
 function agendaNeedsYouCount() {
   const needs = new Set();
   (agendaItems || []).forEach((x) => {
     const st = agendaEffectState(x);
-    if (x.kind === 'question' && x.status === 'open' && !x.dismissed) needs.add(x.id);
+    if (x.kind === 'question' && x.status === 'open' && !x.dismissed
+      && !x.watched_by) needs.add(x.id);
     if (x.status === 'open' && st && st.kind === 'pending') needs.add(x.id);
     if (st && st.kind === 'suspended') needs.add(x.id);
     if (x.status === 'open' && x.due_ms && x.due_ms < Date.now()) needs.add(x.id);
@@ -93025,6 +93044,16 @@ function agendaCardChips(item) {
   if (item.kind === 'question' && item.status === 'open' && item.dismissed) {
     chips.push(agendaChipHtml('dismissed · still open', 'neutral',
       agendaDismissedTip(item.dismissed), true));
+  }
+  // Machinery-audience classification (daemon-derived, never stored):
+  // an armed automation covers this item. Absence = needs you.
+  if (item.status === 'open' && item.watched_by) {
+    const w = item.watched_by;
+    chips.push(agendaChipHtml(
+      agendaDepthCalm() ? 'watched' : `watched by ${w.watcher_title}`, 'sky',
+      w.due_ms
+        ? `“${w.watcher_title}” picks this up ${agendaRelTime(w.due_ms)} — returns to Needs you if it can’t deliver`
+        : `“${w.watcher_title}” is handling this now — returns to Needs you if it can’t deliver`));
   }
   // Answered ask whose delivery reached no session (the daemon-recorded
   // `delivered: false` marker; absent data claims nothing).

--- a/static/app.html
+++ b/static/app.html
@@ -37071,7 +37071,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'fd2dad17a4e60704';
+const INTENDANT_APP_BUILD = '695a74290b962c2c';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -97247,7 +97247,7 @@ function agendaHoodFooterHtml(item) {
 // the served DTO minus visual noise, pretty-printed. The label below the
 // pre names the truth precisely — the served item is the fold product
 // PLUS the planner's display-only decorations (next_fire_ms,
-// deferred_until), so "pure fold product" would be false.
+// deferred_until, watched_by), so "pure fold product" would be false.
 function agendaHoodStripRaw(value) {
   return JSON.parse(JSON.stringify(value, (key, v) =>
     (v === null || (Array.isArray(v) && !v.length) ? undefined : v)));
@@ -97262,7 +97262,7 @@ function agendaRawSheetHtml(item) {
     </div>
     <div class="ag2-sheet-item">${escapeHtml(`${item.id.slice(0, 6).toLowerCase()} · ${item.title}`)}</div>
     <pre class="ag2-sheet-raw">${escapeHtml(pretty)}</pre>
-    <div class="ag2-hood-footnote">Exactly what GET /api/agenda serves — the fold product of agenda.jsonl plus the planner’s display-only decorations (next_fire_ms, deferred_until). Nothing here is stored state beyond the ops.</div>`;
+    <div class="ag2-hood-footnote">Exactly what GET /api/agenda serves — the fold product of agenda.jsonl plus the planner’s display-only decorations (next_fire_ms, deferred_until, watched_by). Nothing here is stored state beyond the ops.</div>`;
 }
 
 // ---- Ledger footer ops count ----

--- a/static/app/ui2-agenda-cards.js
+++ b/static/app/ui2-agenda-cards.js
@@ -456,9 +456,13 @@ function agendaLensGroupsNow() {
   const pool = agendaFilteredPool();
   const seen = new Set();
   const take = (arr) => arr.filter((x) => !seen.has(x.id) && (seen.add(x.id), true));
-  const answer = take(pool
+  // The audience split (daemon-derived watched_by): questions an armed
+  // automation covers are machinery's inbox, not the owner's — they
+  // leave Answer for the FYI-grade Watched group below.
+  const openQuestions = pool
     .filter((x) => x.kind === 'question' && x.status === 'open' && !x.dismissed)
-    .sort(agendaByNew));
+    .sort(agendaByNew);
+  const answer = take(openQuestions.filter((x) => !x.watched_by));
   const approve = take(pool.filter((x) => {
     const st = agendaEffectState(x);
     return x.status === 'open' && st && st.kind === 'pending';
@@ -472,6 +476,11 @@ function agendaLensGroupsNow() {
   const attend = take(pool
     .filter((x) => x.status === 'open' && agendaTriageInfo(x))
     .sort(agendaAttendOrder));
+  // Watched questions take LAST: any needs-you-grade state above (a
+  // pending approval, a suspension) outranks the FYI grouping. Calm
+  // depth folds machinery-audience away entirely.
+  const watched = agendaDepthCalm() ? []
+    : take(openQuestions.filter((x) => x.watched_by));
   const groups = [];
   if (answer.length) {
     groups.push({
@@ -506,6 +515,13 @@ function agendaLensGroupsNow() {
       label: 'Attend',
       hint: 'triage-flagged items, ranked — ordinary annotations from the triage mandate; ranking gates nothing',
       rows: attend.map((x) => ({ item: x })),
+    });
+  }
+  if (watched.length) {
+    groups.push({
+      label: 'Watched',
+      hint: 'questions an armed automation will pick up — machinery’s inbox, not yours; anything it can’t deliver returns to Answer',
+      rows: watched.map((x) => ({ item: x, composer: true })),
     });
   }
   return groups;
@@ -677,11 +693,14 @@ function agendaLensGroupsArchive() {
 }
 
 // Distinct items the "Needs you" lens would show — the lens badge.
+// Watched questions (an armed automation covers them — daemon-derived
+// watched_by) are machinery's inbox and never count as needing you.
 function agendaNeedsYouCount() {
   const needs = new Set();
   (agendaItems || []).forEach((x) => {
     const st = agendaEffectState(x);
-    if (x.kind === 'question' && x.status === 'open' && !x.dismissed) needs.add(x.id);
+    if (x.kind === 'question' && x.status === 'open' && !x.dismissed
+      && !x.watched_by) needs.add(x.id);
     if (x.status === 'open' && st && st.kind === 'pending') needs.add(x.id);
     if (st && st.kind === 'suspended') needs.add(x.id);
     if (x.status === 'open' && x.due_ms && x.due_ms < Date.now()) needs.add(x.id);
@@ -739,6 +758,16 @@ function agendaCardChips(item) {
   if (item.kind === 'question' && item.status === 'open' && item.dismissed) {
     chips.push(agendaChipHtml('dismissed · still open', 'neutral',
       agendaDismissedTip(item.dismissed), true));
+  }
+  // Machinery-audience classification (daemon-derived, never stored):
+  // an armed automation covers this item. Absence = needs you.
+  if (item.status === 'open' && item.watched_by) {
+    const w = item.watched_by;
+    chips.push(agendaChipHtml(
+      agendaDepthCalm() ? 'watched' : `watched by ${w.watcher_title}`, 'sky',
+      w.due_ms
+        ? `“${w.watcher_title}” picks this up ${agendaRelTime(w.due_ms)} — returns to Needs you if it can’t deliver`
+        : `“${w.watcher_title}” is handling this now — returns to Needs you if it can’t deliver`));
   }
   // Answered ask whose delivery reached no session (the daemon-recorded
   // `delivered: false` marker; absent data claims nothing).

--- a/static/app/ui2-agenda-hood.js
+++ b/static/app/ui2-agenda-hood.js
@@ -481,7 +481,7 @@ function agendaHoodFooterHtml(item) {
 // the served DTO minus visual noise, pretty-printed. The label below the
 // pre names the truth precisely — the served item is the fold product
 // PLUS the planner's display-only decorations (next_fire_ms,
-// deferred_until), so "pure fold product" would be false.
+// deferred_until, watched_by), so "pure fold product" would be false.
 function agendaHoodStripRaw(value) {
   return JSON.parse(JSON.stringify(value, (key, v) =>
     (v === null || (Array.isArray(v) && !v.length) ? undefined : v)));
@@ -496,7 +496,7 @@ function agendaRawSheetHtml(item) {
     </div>
     <div class="ag2-sheet-item">${escapeHtml(`${item.id.slice(0, 6).toLowerCase()} · ${item.title}`)}</div>
     <pre class="ag2-sheet-raw">${escapeHtml(pretty)}</pre>
-    <div class="ag2-hood-footnote">Exactly what GET /api/agenda serves — the fold product of agenda.jsonl plus the planner’s display-only decorations (next_fire_ms, deferred_until). Nothing here is stored state beyond the ops.</div>`;
+    <div class="ag2-hood-footnote">Exactly what GET /api/agenda serves — the fold product of agenda.jsonl plus the planner’s display-only decorations (next_fire_ms, deferred_until, watched_by). Nothing here is stored state beyond the ops.</div>`;
 }
 
 // ---- Ledger footer ops count ----


### PR DESCRIPTION
Derives `AgendaItem.watched_by` at the serving seam (inverting the `matched_item_ids` the planner's `trigger_due` already computes) so parked questions an armed, healthy automation covers stop classifying as needs-you: the notification copy names the watching automation (same urgency and delivery), and the Agenda Needs-you lens/badge subtract watched questions. Sick watchers (suspended, crashed/abandoned/completed-but-unresolved firings) return items to the needs-you complement.

Also fixes the latent broadcast-path decoration starvation: single-item `agenda_changed` copies were decorated against a one-item universe, degrading `next_fire_ms` on matcher/on_unblock automations until the next full-list read; `decorate_item` now supplies the full fold as read-only context.

SPA half (Watched group in the Now lens, badge split, watched chip) lands in this same PR.

Pins: `watched_by_derives_at_the_serving_seam`, `needs_you_is_the_unwatched_complement`, `watched_copy_names_the_automation`, `sick_watcher_returns_item_to_needs_you`, `broadcast_copies_carry_full_decorations`, `notification_delivery_unchanged`.

Evidence: the sealed investigation report (question-audience findings, sha256 5a74d2f5…), fired from agenda item 01KYNSKCDYEZE1D1EZ5XTMP5QD.