### PR TITLE
fix(dashboard): live wrapper wins the ghost-bit alias fold

### DIFF
--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -311,7 +311,11 @@ from HS1's presence substrate joined with live wrapper registry
 membership — and a session that predates the current daemon boot with
 no live wrapper renders unmistakably as a **ghost** (`👻` warn chip +
 dashed desaturated frame): the safe-to-close state, served as a
-precomputed bit. Fired sessions keep their derived names (the source
+precomputed bit. A backend resumed across a restart is two wrapper rows
+aliasing one card — the dead pre-restart twin and the live
+resume-attached twin; the live wrapper's block wins that fold
+(`resolveSessionWindowBootMeta`), so the dead lineage never re-labels a
+live card as a ghost. Fired sessions keep their derived names (the source
 item's title, or `workflow - node` for workflow nodes); an owner
 rename always wins, and the Track AW refinement — stamped definitions
 deriving `definition name - node id` — lands later at the same single

--- a/src/bin/caller/web_gateway/session_catalog/grid_envelope.rs
+++ b/src/bin/caller/web_gateway/session_catalog/grid_envelope.rs
@@ -301,4 +301,106 @@ mod tests {
             "the stylesheet lost the ghost window treatment"
         );
     }
+
+    /// The join the original matrix missed (the 2026-07-28 ghost-flag
+    /// incident): a backend resumed across a daemon restart is TWO
+    /// wrapper rows — the dead pre-restart wrapper serves ghost:true
+    /// while the live resume-attached wrapper serves ghost:false, same
+    /// backend_session_id. Per-row truth is correct by construction;
+    /// the fragment pins below keep the SPA's alias fold from letting
+    /// the dead twin overwrite the live twin's card.
+    #[test]
+    fn resumed_across_restart_fixture_pinned() {
+        let root = tempfile::tempdir().unwrap();
+        let dead_dir = session_dir_with_transcript(root.path(), "wrapper-dead");
+        let live_dir = session_dir_with_transcript(root.path(), "wrapper-live");
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        // Both transcripts predate the restart watershed; live-set
+        // membership alone separates the twins.
+        let envelope = joins(Some(now_secs + 3_600), Some(&["wrapper-live"]), None);
+
+        let mut dead = serde_json::json!({ "backend_session_id": "backend-a" });
+        let mut live = serde_json::json!({ "backend_session_id": "backend-a" });
+        envelope.attach(&mut dead, "wrapper-dead", &dead_dir);
+        envelope.attach(&mut live, "wrapper-live", &live_dir);
+
+        assert_eq!(
+            dead["boot"]["ghost"], true,
+            "the pre-restart twin is a ghost"
+        );
+        assert_eq!(dead["boot"]["era"], "preboot");
+        assert_eq!(
+            live["boot"]["ghost"], false,
+            "the resume-attached twin never is"
+        );
+        assert_eq!(live["boot"]["live_wrapper"], true);
+        assert_eq!(live["boot"]["era"], "current");
+        assert_eq!(
+            dead["backend_session_id"], live["backend_session_id"],
+            "both rows alias one backend-keyed card — the fold fight the SPA resolver settles"
+        );
+    }
+
+    /// SPA half of the fixture above: the served boot block is stamped
+    /// with its writing row's identity and the metadata merge routes
+    /// collisions through the resolver, so a dead twin's ghost bit never
+    /// folds across alias ids onto a card a live wrapper backs.
+    #[test]
+    fn ghost_bit_never_folds_across_aliases() {
+        let fragment = include_str!("../../../../../static/app/39-session-windows.js");
+        for needle in [
+            // meta build: the writer stamp on the served block
+            "boot: session.boot && typeof session.boot === 'object'\n      ? { ...session.boot, source_session_id: session.session_id }\n      : session.boot,",
+            // normalize: the stamp survives both wire spellings
+            "compactSessionText(raw.source_session_id || raw.sourceSessionId)",
+            // merge: boot collisions resolve before the last-write spread
+            "normalized.boot = resolveSessionWindowBootMeta(previous.boot, normalized.boot);",
+        ] {
+            assert!(
+                fragment.contains(needle),
+                "session-windows fragment lost the alias-fold ghost guard: {needle}"
+            );
+        }
+    }
+
+    /// The dominance law, byte-pinned as one unit: a live-wrapper claim
+    /// on a shared card id is replaced only by the same writer's own
+    /// next state or by another live wrapper — never by a dead twin.
+    /// A behavior change must move this pin and the fragment together.
+    #[test]
+    fn live_wrapper_dominates_the_merge() {
+        let fragment = include_str!("../../../../../static/app/39-session-windows.js");
+        let resolver = "function resolveSessionWindowBootMeta(previous, incoming) {\n  if (!previous || !incoming) return incoming || previous || null;\n  const sameWriter = !!incoming.sourceSessionId\n    && incoming.sourceSessionId === previous.sourceSessionId;\n  if (previous.liveWrapper && !incoming.liveWrapper && !sameWriter) return previous;\n  return incoming;\n}";
+        assert!(
+            fragment.contains(resolver),
+            "resolveSessionWindowBootMeta drifted from the pinned dominance law"
+        );
+    }
+
+    /// The card's operative state is read from the RESOLVED metadata
+    /// store — the actions fragment's class toggle plus the signature
+    /// segment that lets a writer handoff with identical bits still
+    /// reach that store — so a resumed backend's card shows the live
+    /// wrapper's era and affordances, never the dead lineage's.
+    #[test]
+    fn resumed_backend_card_shows_live_state() {
+        let actions = include_str!("../../../../../static/app/41-session-window-actions.js");
+        for needle in [
+            "const bootEra = (sessionMetadataById.get(sid) || {}).boot;",
+            "win.el.classList.toggle('session-window-ghost', !!(bootEra && bootEra.ghost));",
+        ] {
+            assert!(
+                actions.contains(needle),
+                "the actions fragment stopped reading the resolved boot store: {needle}"
+            );
+        }
+        let fragment = include_str!("../../../../../static/app/39-session-windows.js");
+        assert!(
+            fragment.contains("${meta.boot.sourceSessionId || ''}"),
+            "the metadata signature lost the boot writer segment — same-bit writer handoffs would never land in the store"
+        );
+    }
 }

--- a/static/app.html
+++ b/static/app.html
@@ -37071,7 +37071,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '2e25844c8e73b41d';
+const INTENDANT_APP_BUILD = '49fb964636a6e2fb';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -60247,11 +60247,17 @@ function normalizeSessionBootEra(raw) {
   if (!raw || typeof raw !== 'object') return null;
   const era = String(raw.era || '').toLowerCase();
   if (era !== 'current' && era !== 'preboot') return null;
-  return {
+  const out = {
     era,
     liveWrapper: raw.live_wrapper === true || raw.liveWrapper === true,
     ghost: raw.ghost === true,
   };
+  // The folding row's own id (stamped in sessionWindowMetaFromSession)
+  // rides along so resolveSessionWindowBootMeta can tell a writer's own
+  // lifecycle update from a dead twin's alias-folded claim.
+  const sourceSessionId = compactSessionText(raw.source_session_id || raw.sourceSessionId);
+  if (sourceSessionId) out.sourceSessionId = sourceSessionId;
+  return out;
 }
 
 function normalizeSessionWindowMeta(meta = {}) {
@@ -60386,15 +60392,33 @@ function sessionWindowMetadataSignature(meta = {}) {
       ].join('|')
       : '',
     meta.boot
-      ? `${meta.boot.era}|${meta.boot.liveWrapper ? '1' : '0'}|${meta.boot.ghost ? '1' : '0'}`
+      ? `${meta.boot.era}|${meta.boot.liveWrapper ? '1' : '0'}|${meta.boot.ghost ? '1' : '0'}|${meta.boot.sourceSessionId || ''}`
       : '',
   ].join('\u001f');
+}
+
+// A backend resumed across a daemon restart has TWO wrapper rows alias-
+// folding onto its backend-keyed card: the dead pre-restart twin
+// (ghost:true) and the live resume-attached twin (ghost:false). Fold
+// order must never decide which one the card wears: a live-wrapper
+// claim is only replaced by the same writer moving through its own
+// lifecycle, or by another live wrapper — never by a dead twin whose
+// ghost bit would sell a live session as safe to close.
+function resolveSessionWindowBootMeta(previous, incoming) {
+  if (!previous || !incoming) return incoming || previous || null;
+  const sameWriter = !!incoming.sourceSessionId
+    && incoming.sourceSessionId === previous.sourceSessionId;
+  if (previous.liveWrapper && !incoming.liveWrapper && !sameWriter) return previous;
+  return incoming;
 }
 
 function mergeSessionWindowMetadata(sessionId, meta = {}) {
   const sid = String(sessionId || '').trim();
   const normalized = normalizeSessionWindowMeta(meta);
   const previous = sid ? (sessionMetadataById.get(sid) || {}) : {};
+  if (normalized.boot && previous.boot) {
+    normalized.boot = resolveSessionWindowBootMeta(previous.boot, normalized.boot);
+  }
   const merged = Object.keys(normalized).length > 0
     ? { ...previous, ...normalized }
     : previous;
@@ -63577,7 +63601,9 @@ function sessionWindowMetaFromSession(session) {
     thread_source: session.thread_source,
     agent_nickname: session.agent_nickname,
     agenda: session.agenda,
-    boot: session.boot,
+    boot: session.boot && typeof session.boot === 'object'
+      ? { ...session.boot, source_session_id: session.session_id }
+      : session.boot,
   };
   if (
     Object.prototype.hasOwnProperty.call(session, 'goal') ||

--- a/static/app/39-session-windows.js
+++ b/static/app/39-session-windows.js
@@ -509,11 +509,17 @@ function normalizeSessionBootEra(raw) {
   if (!raw || typeof raw !== 'object') return null;
   const era = String(raw.era || '').toLowerCase();
   if (era !== 'current' && era !== 'preboot') return null;
-  return {
+  const out = {
     era,
     liveWrapper: raw.live_wrapper === true || raw.liveWrapper === true,
     ghost: raw.ghost === true,
   };
+  // The folding row's own id (stamped in sessionWindowMetaFromSession)
+  // rides along so resolveSessionWindowBootMeta can tell a writer's own
+  // lifecycle update from a dead twin's alias-folded claim.
+  const sourceSessionId = compactSessionText(raw.source_session_id || raw.sourceSessionId);
+  if (sourceSessionId) out.sourceSessionId = sourceSessionId;
+  return out;
 }
 
 function normalizeSessionWindowMeta(meta = {}) {
@@ -648,15 +654,33 @@ function sessionWindowMetadataSignature(meta = {}) {
       ].join('|')
       : '',
     meta.boot
-      ? `${meta.boot.era}|${meta.boot.liveWrapper ? '1' : '0'}|${meta.boot.ghost ? '1' : '0'}`
+      ? `${meta.boot.era}|${meta.boot.liveWrapper ? '1' : '0'}|${meta.boot.ghost ? '1' : '0'}|${meta.boot.sourceSessionId || ''}`
       : '',
   ].join('\u001f');
+}
+
+// A backend resumed across a daemon restart has TWO wrapper rows alias-
+// folding onto its backend-keyed card: the dead pre-restart twin
+// (ghost:true) and the live resume-attached twin (ghost:false). Fold
+// order must never decide which one the card wears: a live-wrapper
+// claim is only replaced by the same writer moving through its own
+// lifecycle, or by another live wrapper — never by a dead twin whose
+// ghost bit would sell a live session as safe to close.
+function resolveSessionWindowBootMeta(previous, incoming) {
+  if (!previous || !incoming) return incoming || previous || null;
+  const sameWriter = !!incoming.sourceSessionId
+    && incoming.sourceSessionId === previous.sourceSessionId;
+  if (previous.liveWrapper && !incoming.liveWrapper && !sameWriter) return previous;
+  return incoming;
 }
 
 function mergeSessionWindowMetadata(sessionId, meta = {}) {
   const sid = String(sessionId || '').trim();
   const normalized = normalizeSessionWindowMeta(meta);
   const previous = sid ? (sessionMetadataById.get(sid) || {}) : {};
+  if (normalized.boot && previous.boot) {
+    normalized.boot = resolveSessionWindowBootMeta(previous.boot, normalized.boot);
+  }
   const merged = Object.keys(normalized).length > 0
     ? { ...previous, ...normalized }
     : previous;
@@ -3839,7 +3863,9 @@ function sessionWindowMetaFromSession(session) {
     thread_source: session.thread_source,
     agent_nickname: session.agent_nickname,
     agenda: session.agenda,
-    boot: session.boot,
+    boot: session.boot && typeof session.boot === 'object'
+      ? { ...session.boot, source_session_id: session.session_id }
+      : session.boot,
   };
   if (
     Object.prototype.hasOwnProperty.call(session, 'goal') ||


### PR DESCRIPTION
## The defect

A live supervised session wore a dead twin's ghost chip. A backend resumed across a daemon restart is two wrapper rows aliasing one backend-keyed card: the dead pre-restart wrapper (`ghost:true` — correctly) and the live resume-attached wrapper (`ghost:false` — correctly). The daemon side (`grid_envelope.rs`) is right per row; the SPA then folds each row's `boot` block under every alias id including `backend_session_id` (`39-session-windows.js` `_foldSessionWindowMetadataRow`) and `mergeSessionWindowMetadata` is last-write-wins — so the dead twin's `ghost:true` overwrites the live twin's on the backend-keyed card. Observed live 2026-07-28 on two backends (7310d37d mid-work, c9c3ef3b): a card reporting "Running tools" while wearing the ghost chip and its "safe to close" brief — a lie inviting the owner to stop a live worker. Evidence: session-census-2026-07-28.md, section "Ghost-flag incident" (sealed as a binding ref on the agenda manifest, sha256 `e164b316…`).

## The fix (choice stated)

Of the two directions the evidence file's mechanism section offers — key `boot` strictly to the row's own session id, or let `live_wrapper:true` dominate the merge — this PR ships **dominance**. The mechanism section itself records why own-key-only is the larger change: the external backend row serves no `boot` block (`external_rows.rs` folds wrapper identity only), so the aliased wrapper blocks are the backend-keyed card's *only* boot writers; keying strictly to the own id would strip the ghost treatment from every backend-keyed card — the honestly-dead ones included (three of the five ghost-flagged cards in the census were correct) — unless the daemon also grew backend-row boot serving. Dominance is SPA-only and keeps the honest ghosts.

Mechanics: the served `boot` block is stamped with its writing row's own session id at meta build; `mergeSessionWindowMetadata` routes boot collisions through `resolveSessionWindowBootMeta` — a live-wrapper claim is replaced only by the same writer moving through its own lifecycle (stop, next restart's ghost) or by another live wrapper, never by a dead twin. The metadata signature gains the writer segment so a same-bit writer handoff still reaches the store. Known residual: if a session dir holding the last live claim is deleted while a stale tab holds it, the card can miss the ghost flip until reload — the safe direction relative to the shipped defect (a live card was being dressed as safe-to-close).

A resumed backend's card now shows the live wrapper's era and affordances; the dead lineage stays visible as its own wrapper-keyed history, never as the card's operative state.

## Pins

- `resumed_across_restart_fixture_pinned` — the two-wrapper-same-backend-across-restart fixture the original envelope matrix missed (served truth: dead twin `ghost:true`, live twin `ghost:false`)
- `ghost_bit_never_folds_across_aliases` — writer stamp + normalize carry + resolver routing in the fold path
- `live_wrapper_dominates_the_merge` — the resolver byte-pinned as one unit
- `resumed_backend_card_shows_live_state` — the card reads the resolved store; the signature keeps the writer segment

## Validation

- `cargo nextest run -p intendant --bins` — 5391 passed
- library crates (`intendant-core`, `-custody`, `-display`, `-platform`, `owner-plane-core`, `owner-plane-reducer`) — all green
- `cargo clippy --workspace -- -D warnings` clean; `cargo fmt --check` clean; `node --check` on the edited fragment
- `static/app.html` regenerated via `app-html-assembler` and committed with the fragments