### PR TITLE
feat(agenda): AO S1 — the attest lane

### DIFF
--- a/skills/intendant-agenda/SKILL.md
+++ b/skills/intendant-agenda/SKILL.md
@@ -51,6 +51,7 @@ dashboard, attributed to your session.
 "$INTENDANT" ctl agenda schedule 01KX --goal "Run the soak checks and summarize" --at +2d
 "$INTENDANT" ctl agenda schedule 01KX --goal "Weekly housekeeping pass" --at "+1d" --every 7d   # STANDING: one approval covers the series
 "$INTENDANT" ctl agenda annotate 01KX "Tried the vendor API — still 403; evidence in run 88."
+"$INTENDANT" ctl agenda attest 01KX --occurrence 98eb14c2... --outcome partial --note "3 of 5 slices landed" --ref file:$HOME/handoff.md   # fired sessions: self-report your occurrence (rider names its id)
 "$INTENDANT" ctl agenda block 01KX "gpt-live-1 available on the API (currently app-only)"
 "$INTENDANT" ctl agenda relies-on 01KX 01KY    # 01KX waits on 01KY (--remove drops the link)
 "$INTENDANT" ctl agenda list --blocked         # open items with uncleared blockers / unmet deps
@@ -118,11 +119,17 @@ dashboard, attributed to your session.
   message reaches nobody by default.** A fired session ends into a
   dead-letter channel — the run write-back keeps one last-wins note
   nobody is pointed at, and transcripts are only mined after the fact.
-  Durable channels are the verbs above: `annotate` your source item with
-  what happened and what comes next, `ref` a handoff file you wrote (a
-  durable path, not /tmp — the digest makes drift visible), and park
-  follow-ups as their own items. Write your handoff there before your
-  last token.
+  Durable channels are the verbs above: **attest your occurrence**
+  (`attest` — the self-report machinery reads: outcome from the closed
+  set, a short note, refs to what you produced), `annotate` your source
+  item with what happened and what comes next, `ref` a handoff file you
+  wrote (a durable path, not /tmp — the digest makes drift visible),
+  and park follow-ups as their own items. Write your handoff there
+  before your last token. Attest honestly — `achieved` only when the
+  goal as stated is done; `partial` buys nothing machine-side, so there
+  is no reason to inflate; `blocked`/`abandoned` say so and why. Your
+  report is labeled self-report wherever it renders, and only sessions
+  in the occurrence's own lineage can write it.
 
 - Titles are one actionable line; details go in `--body` (markdown, shown
   quoted). `--due` accepts `+45m/+2h/+3d/+1w`, `YYYY-MM-DD`, RFC3339.

--- a/src/bin/caller/agenda/handle.rs
+++ b/src/bin/caller/agenda/handle.rs
@@ -200,6 +200,14 @@ impl AgendaHandle {
                 }));
             }
         }
+        // Attest binds HERE, at the tenant edge (Track AO): the handle
+        // holds the occurrence journal, so the journal-side intake
+        // checks — occurrence-belongs-to-item, actor in the started
+        // lineage — run before the store validates the rest. Every
+        // refusal is named (ruling R5).
+        if let AgendaCommand::Attest { id, occurrence, .. } = &cmd {
+            self.verify_attest_binding(id, occurrence, actor.as_ref())?;
+        }
         // Start-now resolves its project HERE, at the tenant edge where the
         // daemon context lives: explicit pick → the parking session's
         // recorded root → the daemon default — refused with a named error
@@ -701,6 +709,79 @@ impl AgendaHandle {
         }
     }
 
+    /// Track AO intake, the journal-side checks (ruling Q2): the
+    /// occurrence exists and belongs to the named item, and the
+    /// gate-resolved actor session is in its `started_history` —
+    /// Rider A's lineage law, with NO second resolver: superseded
+    /// originals and admitted successors both attest (last-wins is the
+    /// fold's concern). Non-session actors are refused by name (R5):
+    /// attestation is the fired session's self-report; an owner
+    /// statement about a run is a verification lane and must not wear
+    /// this label. Accepted while `started` and after a terminal alike
+    /// (late attests are display-only downstream); a prepared-only
+    /// occurrence has no started lineage and refuses on membership.
+    /// The session id is gate-bound by token possession — never echoed
+    /// from request fields — so membership here is attribution, not
+    /// claim.
+    fn verify_attest_binding(
+        &self,
+        id: &str,
+        occurrence: &str,
+        actor: Option<&super::types::AgendaActor>,
+    ) -> Result<(), AgendaError> {
+        let Some(session_id) = actor.and_then(|actor| actor.session_id.as_deref()) else {
+            return Err(AgendaError::Invalid(
+                "attest is the fired session's self-report — non-session actors cannot \
+                 attest (an owner statement about a run is a verification lane, not \
+                 self-report)"
+                    .into(),
+            ));
+        };
+        let progress = self
+            .with_journal(|journal| {
+                journal
+                    .refresh_if_stale()
+                    .map(|()| journal.progress(occurrence))
+            })
+            .ok_or_else(|| {
+                AgendaError::Invalid(
+                    "attest: the occurrence journal is unavailable — cannot verify the \
+                     attestation binding"
+                        .into(),
+                )
+            })?
+            .map_err(|err| {
+                AgendaError::Invalid(format!(
+                    "attest: the occurrence journal is unreadable ({err}) — cannot verify \
+                     the attestation binding"
+                ))
+            })?;
+        match progress.item_id.as_deref() {
+            None => {
+                return Err(AgendaError::NotFound(format!(
+                    "attest: occurrence {occurrence} is not in this daemon's journal"
+                )))
+            }
+            Some(owner) if owner != id => {
+                return Err(AgendaError::Invalid(format!(
+                    "attest: occurrence {occurrence} belongs to item {owner}, not {id}"
+                )))
+            }
+            Some(_) => {}
+        }
+        if !progress
+            .started_history
+            .iter()
+            .any(|started| started == session_id)
+        {
+            return Err(AgendaError::Invalid(format!(
+                "attest: session {session_id} is not in occurrence {occurrence}'s started \
+                 lineage — only the fired session (or its resume successors) attests"
+            )));
+        }
+        Ok(())
+    }
+
     /// Run `f` with the handle's journal reader (lazily opened, its own
     /// mutex — never nested with the store lock). `None` when the
     /// journal cannot be opened; callers degrade honestly.
@@ -996,6 +1077,317 @@ mod tests {
             "a deleted item degrades to id-only"
         );
         assert!(orphan.sealed_inputs.is_empty());
+    }
+
+    /// Attest test rig: an item with a proposed session effect, a bare
+    /// item without one, and journal `started` rows — occ-1 fired for
+    /// the effect item by sess-original then re-keyed to
+    /// sess-successor (Rider A's lineage), occ-2 fired under the bare
+    /// item by sess-other.
+    fn attest_rig(dir: &std::path::Path) -> (AgendaHandle, AgendaItem, AgendaItem) {
+        let handle = AgendaHandle::new(AgendaStore::open(dir).unwrap(), EventBus::new(), dir);
+        let owner = Some(AgendaActor {
+            principal: Some("principal:root:dashboard".into()),
+            session_id: None,
+            kind: Some("dashboard".into()),
+        });
+        let add = |title: &str| AgendaCommand::Add {
+            refs: Vec::new(),
+            kind: AgendaKind::Task,
+            title: title.into(),
+            body: String::new(),
+            tags: Vec::new(),
+            due_ms: None,
+            source: None,
+        };
+        let item = handle.apply(add("fired work"), owner.clone()).unwrap();
+        let item = handle
+            .apply(
+                AgendaCommand::ProposeEffect {
+                    id: item.id.clone(),
+                    goal: "run it".into(),
+                    fire_at_ms: 1_000,
+                    orchestrate: false,
+                    recurrence: None,
+                    agent_config: None,
+                    trigger: None,
+                    project_root: None,
+                    binding_refs: Vec::new(),
+                    source: None,
+                },
+                owner.clone(),
+            )
+            .unwrap();
+        let bare = handle.apply(add("no effect here"), owner).unwrap();
+        {
+            let mut journal = OccurrenceJournal::open(dir).unwrap();
+            let row = |occurrence: &str, item_id: &str, session: &str| {
+                super::super::reminders::OccurrenceRecord {
+                    v: 1,
+                    at_ms: 1,
+                    occurrence_id: occurrence.to_string(),
+                    item_id: item_id.to_string(),
+                    due_ms: 1_000,
+                    state: OccurrenceState::Started,
+                    urgency: None,
+                    session_id: Some(session.to_string()),
+                    generation: None,
+                    boot_id: None,
+                }
+            };
+            journal
+                .append(&row("occ-1", &item.id, "sess-original"))
+                .unwrap();
+            journal
+                .append(&row("occ-1", &item.id, "sess-successor"))
+                .unwrap();
+            journal
+                .append(&row("occ-2", &bare.id, "sess-other"))
+                .unwrap();
+        }
+        (handle, item, bare)
+    }
+
+    fn session_actor(session_id: &str) -> Option<AgendaActor> {
+        Some(AgendaActor {
+            principal: None,
+            session_id: Some(session_id.into()),
+            kind: Some("agent_session".into()),
+        })
+    }
+
+    fn attest_cmd(
+        item_id: &str,
+        occurrence: &str,
+        outcome: super::super::types::AttestationOutcome,
+        refs: Vec<BindingRef>,
+    ) -> AgendaCommand {
+        AgendaCommand::Attest {
+            id: item_id.into(),
+            occurrence: occurrence.into(),
+            outcome,
+            note: Some("what happened, shortly".into()),
+            refs,
+            source: None,
+        }
+    }
+
+    /// Track AO pin `attest_requires_lineage_membership` (ruling Q2 +
+    /// R5): the superseded original and the admitted successor both
+    /// attest (last-wins is the fold's concern); a non-lineage session,
+    /// a non-session actor, an unknown occurrence, a wrong item, and an
+    /// effect-less item are each refused BY NAME.
+    #[test]
+    fn attest_requires_lineage_membership() {
+        use super::super::types::AttestationOutcome;
+        let dir = tempfile::tempdir().unwrap();
+        let (handle, item, bare) = attest_rig(dir.path());
+
+        // Both lineage members attest — Rider A: a re-key never
+        // un-attributes the original.
+        handle
+            .apply(
+                attest_cmd(&item.id, "occ-1", AttestationOutcome::Blocked, Vec::new()),
+                session_actor("sess-original"),
+            )
+            .expect("the superseded original attests");
+        handle
+            .apply(
+                attest_cmd(&item.id, "occ-1", AttestationOutcome::Partial, Vec::new()),
+                session_actor("sess-successor"),
+            )
+            .expect("the admitted successor attests");
+
+        let stranger = handle
+            .apply(
+                attest_cmd(&item.id, "occ-1", AttestationOutcome::Achieved, Vec::new()),
+                session_actor("sess-stranger"),
+            )
+            .unwrap_err();
+        assert!(
+            stranger.to_string().contains("started lineage"),
+            "{stranger}"
+        );
+
+        let owner_attempt = handle
+            .apply(
+                attest_cmd(&item.id, "occ-1", AttestationOutcome::Achieved, Vec::new()),
+                Some(AgendaActor {
+                    principal: Some("principal:root:dashboard".into()),
+                    session_id: None,
+                    kind: Some("dashboard".into()),
+                }),
+            )
+            .unwrap_err();
+        assert!(
+            owner_attempt.to_string().contains("non-session actors"),
+            "{owner_attempt}"
+        );
+
+        let unknown = handle
+            .apply(
+                attest_cmd(
+                    &item.id,
+                    "occ-nope",
+                    AttestationOutcome::Achieved,
+                    Vec::new(),
+                ),
+                session_actor("sess-original"),
+            )
+            .unwrap_err();
+        assert!(
+            unknown.to_string().contains("not in this daemon's journal"),
+            "{unknown}"
+        );
+
+        let wrong_item = handle
+            .apply(
+                attest_cmd(&item.id, "occ-2", AttestationOutcome::Achieved, Vec::new()),
+                session_actor("sess-other"),
+            )
+            .unwrap_err();
+        assert!(
+            wrong_item.to_string().contains("belongs to item"),
+            "{wrong_item}"
+        );
+
+        let no_effect = handle
+            .apply(
+                attest_cmd(&bare.id, "occ-2", AttestationOutcome::Achieved, Vec::new()),
+                session_actor("sess-other"),
+            )
+            .unwrap_err();
+        assert!(
+            no_effect
+                .to_string()
+                .contains("no scheduled-session effect"),
+            "{no_effect}"
+        );
+
+        // Both accepted attests are durable ops, attributed on the
+        // envelope; the wire field `occurrence` landed as
+        // `occurrence_id` with the effect resolved server-side.
+        let page = handle.read_ops(0, Some(&item.id), 50).unwrap();
+        let attests: Vec<&serde_json::Value> = page
+            .ops
+            .iter()
+            .filter(|entry| entry["op"]["op"]["type"] == "attest")
+            .collect();
+        assert_eq!(attests.len(), 2, "last-wins keeps BOTH ops as history");
+        assert_eq!(attests[0]["op"]["actor"]["session_id"], "sess-original");
+        assert_eq!(attests[0]["op"]["op"]["outcome"], "blocked");
+        assert_eq!(attests[1]["op"]["actor"]["session_id"], "sess-successor");
+        assert_eq!(attests[1]["op"]["op"]["outcome"], "partial");
+        assert_eq!(
+            attests[0]["op"]["op"]["effect_id"],
+            item.effects[0].effect_id.as_str()
+        );
+        assert_eq!(attests[0]["op"]["op"]["occurrence_id"], "occ-1");
+    }
+
+    /// Track AO pin `attest_refs_hash_verified_at_intake` (Q2 check 3 +
+    /// OPEN-3 ruled verify-only): a stated pin the daemon's own read
+    /// contradicts is refused as malformed; the v1 grammar and the ≤ 8
+    /// rail hold; and NOTHING lands in the sealed store — pointer +
+    /// pin, never custody.
+    #[test]
+    fn attest_refs_hash_verified_at_intake() {
+        use super::super::types::AttestationOutcome;
+        let dir = tempfile::tempdir().unwrap();
+        let (handle, item, _bare) = attest_rig(dir.path());
+        let handoff = dir.path().join("handoff.md");
+        std::fs::write(&handoff, b"the durable handoff\n").unwrap();
+        let locator = format!("file:{}", handoff.display());
+        let good = super::super::store::digest_file(&handoff).unwrap();
+
+        handle
+            .apply(
+                attest_cmd(
+                    &item.id,
+                    "occ-1",
+                    AttestationOutcome::Achieved,
+                    vec![BindingRef {
+                        locator: locator.clone(),
+                        sha256: good.clone(),
+                    }],
+                ),
+                session_actor("sess-original"),
+            )
+            .expect("a pin matching the daemon's own read is accepted");
+        let page = handle.read_ops(0, Some(&item.id), 50).unwrap();
+        let attest = page
+            .ops
+            .iter()
+            .find(|entry| entry["op"]["op"]["type"] == "attest")
+            .expect("the attest op is durable");
+        assert_eq!(attest["op"]["op"]["refs"][0]["sha256"], good.as_str());
+        assert!(
+            !super::super::sealed_blobs::sealed_blob_path(dir.path(), &good).exists(),
+            "verify-only: attestation refs are never sealed"
+        );
+
+        let wrong = format!(
+            "{}{}",
+            &good[..63],
+            if good.ends_with('0') { "1" } else { "0" }
+        );
+        let mismatch = handle
+            .apply(
+                attest_cmd(
+                    &item.id,
+                    "occ-1",
+                    AttestationOutcome::Achieved,
+                    vec![BindingRef {
+                        locator: locator.clone(),
+                        sha256: wrong,
+                    }],
+                ),
+                session_actor("sess-original"),
+            )
+            .unwrap_err();
+        assert!(
+            mismatch
+                .to_string()
+                .contains("does not match the live content"),
+            "{mismatch}"
+        );
+
+        let over_rail = handle
+            .apply(
+                attest_cmd(
+                    &item.id,
+                    "occ-1",
+                    AttestationOutcome::Achieved,
+                    (0..9)
+                        .map(|_| BindingRef {
+                            locator: locator.clone(),
+                            sha256: good.clone(),
+                        })
+                        .collect(),
+                ),
+                session_actor("sess-original"),
+            )
+            .unwrap_err();
+        assert!(over_rail.to_string().contains("at most 8"), "{over_rail}");
+
+        let bad_hex = handle
+            .apply(
+                attest_cmd(
+                    &item.id,
+                    "occ-1",
+                    AttestationOutcome::Achieved,
+                    vec![BindingRef {
+                        locator,
+                        sha256: "deadbeef".into(),
+                    }],
+                ),
+                session_actor("sess-original"),
+            )
+            .unwrap_err();
+        assert!(
+            bad_hex.to_string().contains("64 hex characters"),
+            "{bad_hex}"
+        );
     }
 
     #[test]

--- a/src/bin/caller/agenda/scheduler.rs
+++ b/src/bin/caller/agenda/scheduler.rs
@@ -36,12 +36,13 @@ const DELEGATION_PREFIX: &str = "agenda-occ-";
 /// task names the durable end-channels instead. Lives beside the
 /// source-ids line in the ONE task builder (`send_start_task`), so
 /// dispatch and the resweep both carry it; the exact bytes are pinned
-/// by `epistemic_line_rides_every_fired_task`. The AO teaching pass
-/// AMENDS this line in place — never a second line.
+/// by `epistemic_line_rides_every_fired_task`. AMENDED in place by the
+/// AO teaching pass (ruling R4) when the attest lane shipped — one
+/// line, never two.
 const EPISTEMIC_RIDER_LINE: &str =
     "Your closing message reaches nobody by default — fired sessions end into a dead-letter \
-     channel. Durable channels are item annotations, refs, and durable files: write your \
-     handoff there before your last token.";
+     channel. Durable channels are item annotations, refs, durable files, and your occurrence \
+     attestation (ctl agenda attest): write your handoff there before your last token.";
 
 /// Cap on remembered pre-receipt session outcomes. Terminal events are
 /// rare (one per session end), and most remembered entries belong to
@@ -1900,15 +1901,17 @@ mod tests {
     /// teaching line rides EVERY fired task — the exact bytes are pinned
     /// here, and the resweep's re-send is byte-identical to the first
     /// send (the single-builder property: both send sites call
-    /// `send_start_task`). The AO teaching pass amends THIS pin when it
-    /// adds the attest verb — one block, never two.
+    /// `send_start_task`). The AO teaching pass (R4) AMENDED the line in
+    /// place with the attest verb — one block, never two; this pin is
+    /// the amendment's proof.
     #[tokio::test]
     async fn epistemic_line_rides_every_fired_task() {
         assert_eq!(
             EPISTEMIC_RIDER_LINE,
             "Your closing message reaches nobody by default — fired sessions end into a \
-             dead-letter channel. Durable channels are item annotations, refs, and durable \
-             files: write your handoff there before your last token.",
+             dead-letter channel. Durable channels are item annotations, refs, durable \
+             files, and your occurrence attestation (ctl agenda attest): write your \
+             handoff there before your last token.",
             "the taught bytes are law (amended only by the AO teaching pass)"
         );
         let dir = tempfile::tempdir().unwrap();

--- a/src/bin/caller/agenda/store.rs
+++ b/src/bin/caller/agenda/store.rs
@@ -6,12 +6,13 @@
 use super::types::{
     apply_op, counts, AgendaActor, AgendaCommand, AgendaCounts, AgendaItem, AgendaOp,
     AgendaOpRecord, AgendaPatch, AgendaRefType, AgendaStatus, BindingRef, AGENDA_LOG_VERSION,
-    BINDING_REF_FILE_SCHEME, MAX_ANNOTATIONS_PER_ITEM, MAX_BINDING_REFS_PER_MANIFEST,
-    MAX_BODY_BYTES, MAX_CHILDREN_PER_HUB, MAX_CRITERION_CHARS, MAX_PART_OF_DEPTH,
-    MAX_REFS_PER_ITEM, MAX_REF_FILE_HASH_BYTES, MAX_REF_FILE_LOCATOR_CHARS,
-    MAX_REF_ID_LOCATOR_CHARS, MAX_REF_LABEL_CHARS, MAX_REF_URL_LOCATOR_CHARS,
-    MAX_RELATES_TO_PER_ITEM, MAX_RELIES_ON_PER_ITEM, MAX_SOURCE_CHARS, MAX_TAGS, MAX_TAG_CHARS,
-    MAX_TITLE_CHARS, MAX_UNCLEARED_BLOCKERS_PER_ITEM, TRIGGER_MATCH_TAGS_MAX,
+    BINDING_REF_FILE_SCHEME, MAX_ANNOTATIONS_PER_ITEM, MAX_ATTESTATION_NOTE_BYTES,
+    MAX_ATTESTATION_REFS, MAX_BINDING_REFS_PER_MANIFEST, MAX_BODY_BYTES, MAX_CHILDREN_PER_HUB,
+    MAX_CRITERION_CHARS, MAX_PART_OF_DEPTH, MAX_REFS_PER_ITEM, MAX_REF_FILE_HASH_BYTES,
+    MAX_REF_FILE_LOCATOR_CHARS, MAX_REF_ID_LOCATOR_CHARS, MAX_REF_LABEL_CHARS,
+    MAX_REF_URL_LOCATOR_CHARS, MAX_RELATES_TO_PER_ITEM, MAX_RELIES_ON_PER_ITEM, MAX_SOURCE_CHARS,
+    MAX_TAGS, MAX_TAG_CHARS, MAX_TITLE_CHARS, MAX_UNCLEARED_BLOCKERS_PER_ITEM,
+    TRIGGER_MATCH_TAGS_MAX,
 };
 use std::collections::BTreeMap;
 use std::io::Write;
@@ -43,7 +44,7 @@ pub(crate) enum AgendaError {
 /// preserved on disk but skipped at load (forward compatibility: a newer
 /// build's vocabulary — effects, journal curation — must not brick an older
 /// daemon's ledger).
-const KNOWN_OPS: [&str; 24] = [
+const KNOWN_OPS: [&str; 25] = [
     "add",
     "patch",
     "complete",
@@ -68,6 +69,7 @@ const KNOWN_OPS: [&str; 24] = [
     "request_occurrence",
     "record_occurrence",
     "record_ask_delivery",
+    "attest",
 ];
 
 const LOG_FILE: &str = "agenda.jsonl";
@@ -1592,6 +1594,50 @@ impl AgendaStore {
                     text: text.to_string(),
                 })
             }
+            AgendaCommand::Attest {
+                id,
+                occurrence,
+                outcome,
+                note,
+                refs,
+                source: _,
+            } => {
+                // The journal-side checks (occurrence-belongs-to-item,
+                // actor in the started lineage) ran at the tenant edge
+                // (`AgendaHandle::verify_attest_binding`) — the handle
+                // holds the journal; this store validates the rest.
+                let item = self.require(&id)?;
+                // v1: one session effect per item names the effect.
+                let Some(effect) = item.effects.first() else {
+                    return Err(AgendaError::Invalid(format!(
+                        "attest: {id} has no scheduled-session effect — only fired \
+                         occurrences can be attested"
+                    )));
+                };
+                let effect_id = effect.effect_id.clone();
+                let note = match note {
+                    Some(note) => {
+                        let trimmed = note.trim();
+                        if trimmed.len() > MAX_ATTESTATION_NOTE_BYTES {
+                            return Err(AgendaError::Invalid(format!(
+                                "attest note exceeds {MAX_ATTESTATION_NOTE_BYTES} bytes — \
+                                 write the handoff into a durable file and ref it"
+                            )));
+                        }
+                        (!trimmed.is_empty()).then(|| trimmed.to_string())
+                    }
+                    None => None,
+                };
+                let refs = validate_attestation_refs(refs)?;
+                Ok(AgendaOp::Attest {
+                    id,
+                    effect_id,
+                    occurrence_id: occurrence,
+                    outcome,
+                    note,
+                    refs,
+                })
+            }
             AgendaCommand::SetBlocker {
                 id,
                 criterion,
@@ -2521,52 +2567,97 @@ fn validate_binding_refs(
     }
     let mut validated: Vec<BindingRef> = Vec::with_capacity(refs.len());
     for BindingRef { locator, sha256 } in refs {
-        let path = binding_ref_path(&locator).map_err(AgendaError::Invalid)?;
-        let sha256 = sha256.to_ascii_lowercase();
-        if sha256.len() != 64 || !sha256.bytes().all(|b| b.is_ascii_hexdigit()) {
-            return Err(AgendaError::Invalid(format!(
-                "binding ref {locator}: sha256 must be 64 hex characters"
-            )));
-        }
         if validated.iter().any(|seen| seen.locator == locator) {
             return Err(AgendaError::Invalid(format!(
                 "binding ref {locator} is listed twice"
             )));
         }
-        let meta = std::fs::metadata(path).map_err(|err| {
-            AgendaError::Invalid(format!("binding ref {locator} is not readable ({err})"))
-        })?;
-        if !meta.is_file() {
-            return Err(AgendaError::Invalid(format!(
-                "binding ref {locator} is not a regular file"
-            )));
-        }
-        if meta.len() > MAX_REF_FILE_HASH_BYTES {
-            return Err(AgendaError::Invalid(format!(
-                "binding ref {locator} exceeds {MAX_REF_FILE_HASH_BYTES} bytes — \
-                 binding refs seal working artifacts, not archives"
-            )));
-        }
-        let bytes = std::fs::read(path).map_err(|err| {
-            AgendaError::Invalid(format!("cannot read binding ref {locator}: {err}"))
-        })?;
-        let live = super::sealed_blobs::digest_bytes(&bytes);
-        if live != sha256 {
-            return Err(AgendaError::Invalid(format!(
-                "binding ref {locator}: the proposed pin {sha256} does not match the \
-                 live content ({live}) — re-read the file and re-propose"
-            )));
-        }
+        let (binding_ref, bytes) = verify_stated_ref(locator, sha256, "binding ref")?;
         // Seal failure refuses the propose: a manifest whose snapshot
         // never existed would refuse every firing — fail closed at the
         // ceremony, not at 3am.
-        super::sealed_blobs::seal_content(agenda_dir, &sha256, &bytes).map_err(|err| {
-            AgendaError::Io(std::io::Error::new(
-                err.kind(),
-                format!("sealing binding ref {locator}: {err}"),
-            ))
-        })?;
-        validated.push(BindingRef { locator, sha256 });
+        super::sealed_blobs::seal_content(agenda_dir, &binding_ref.sha256, &bytes).map_err(
+            |err| {
+                AgendaError::Io(std::io::Error::new(
+                    err.kind(),
+                    format!("sealing binding ref {}: {err}", binding_ref.locator),
+                ))
+            },
+        )?;
+        validated.push(binding_ref);
+    }
+    Ok(validated)
+}
+
+/// One caller-stated `{locator, sha256}` pin verified against the
+/// daemon's OWN read: v1 grammar (`file:` + 64-hex, normalized
+/// lowercase), a regular file under the hash rail, live bytes hashing
+/// exactly to the stated pin. Returns the normalized ref WITH the bytes
+/// this read hashed — the propose lane seals exactly those bytes
+/// (single read: the bytes hashed ARE the bytes preserved, no re-read
+/// window); verify-only lanes (attest — Track AO OPEN-3) drop them.
+/// `what` names the lane in refusals ("binding ref" / "attestation
+/// ref"), which R5 requires named, never silent.
+fn verify_stated_ref(
+    locator: String,
+    sha256: String,
+    what: &str,
+) -> Result<(BindingRef, Vec<u8>), AgendaError> {
+    let path = binding_ref_path(&locator).map_err(AgendaError::Invalid)?;
+    let sha256 = sha256.to_ascii_lowercase();
+    if sha256.len() != 64 || !sha256.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(AgendaError::Invalid(format!(
+            "{what} {locator}: sha256 must be 64 hex characters"
+        )));
+    }
+    let meta = std::fs::metadata(path)
+        .map_err(|err| AgendaError::Invalid(format!("{what} {locator} is not readable ({err})")))?;
+    if !meta.is_file() {
+        return Err(AgendaError::Invalid(format!(
+            "{what} {locator} is not a regular file"
+        )));
+    }
+    if meta.len() > MAX_REF_FILE_HASH_BYTES {
+        return Err(AgendaError::Invalid(format!(
+            "{what} {locator} exceeds {MAX_REF_FILE_HASH_BYTES} bytes — \
+             refs point at working artifacts, not archives"
+        )));
+    }
+    let bytes = std::fs::read(path)
+        .map_err(|err| AgendaError::Invalid(format!("cannot read {what} {locator}: {err}")))?;
+    let live = super::sealed_blobs::digest_bytes(&bytes);
+    if live != sha256 {
+        return Err(AgendaError::Invalid(format!(
+            "{what} {locator}: the stated pin {sha256} does not match the \
+             live content ({live}) — re-read the file and restate the pin"
+        )));
+    }
+    Ok((BindingRef { locator, sha256 }, bytes))
+}
+
+/// Attestation refs (Track AO, Q2 check 3 + OPEN-3): the ≤
+/// [`MAX_ATTESTATION_REFS`] rail, `BindingRef`'s v1 grammar, and the
+/// stated pin verified against the daemon's own read — an attestation
+/// citing bytes that do not hash as claimed is refused as malformed.
+/// VERIFY-ONLY: pointer + pin, nothing sealed — the sealed store stays
+/// the ceremony for owner-approved binding content, and render-time
+/// drift chips tell the truth later.
+fn validate_attestation_refs(refs: Vec<BindingRef>) -> Result<Vec<BindingRef>, AgendaError> {
+    if refs.len() > MAX_ATTESTATION_REFS {
+        return Err(AgendaError::Invalid(format!(
+            "an attest carries at most {MAX_ATTESTATION_REFS} refs — write the handoff \
+             into one durable file and ref that"
+        )));
+    }
+    let mut validated: Vec<BindingRef> = Vec::with_capacity(refs.len());
+    for BindingRef { locator, sha256 } in refs {
+        if validated.iter().any(|seen| seen.locator == locator) {
+            return Err(AgendaError::Invalid(format!(
+                "attestation ref {locator} is listed twice"
+            )));
+        }
+        let (verified, _bytes) = verify_stated_ref(locator, sha256, "attestation ref")?;
+        validated.push(verified);
     }
     Ok(validated)
 }
@@ -5121,6 +5212,46 @@ mod tests {
         // The foreign line survives on disk verbatim.
         let text = std::fs::read_to_string(dir.path().join(LOG_FILE)).unwrap();
         assert!(text.contains("sigil"));
+    }
+
+    /// Track AO pin `attest_op_skips_whole_line_on_old_builds`: the
+    /// KNOWN_OPS posture. THIS build folds `attest` (a member — the
+    /// line costs nothing and serves `known:true`); a build without the
+    /// vocabulary treats an attest line exactly as this build treats
+    /// the future `attest_v2` fixture — the WHOLE line skipped at load,
+    /// preserved on disk, served verbatim `known:false` — while every
+    /// transport op beside it still folds. The failure mode is "an old
+    /// build doesn't see attestations", never "an old build goes blind
+    /// to outcomes".
+    #[test]
+    fn attest_op_skips_whole_line_on_old_builds() {
+        assert!(
+            KNOWN_OPS.contains(&"attest"),
+            "this build folds attest; only OLDER vocabularies skip it"
+        );
+        let dir = tempfile::tempdir().unwrap();
+        let lines = concat!(
+            "{\"v\":1,\"at_ms\":1,\"op\":{\"type\":\"add\",\"id\":\"01ARZ3NDEKTSV4RRFFQ69G5FAV\",\"kind\":\"task\",\"title\":\"host\"}}\n",
+            "{\"v\":1,\"at_ms\":2,\"actor\":{\"session_id\":\"sess-fired\",\"kind\":\"agent_session\"},\"op\":{\"type\":\"attest\",\"id\":\"01ARZ3NDEKTSV4RRFFQ69G5FAV\",\"effect_id\":\"ef-1\",\"occurrence_id\":\"occ-1\",\"outcome\":\"blocked\",\"note\":\"waiting on the vendor\"}}\n",
+            "{\"v\":1,\"at_ms\":3,\"op\":{\"type\":\"attest_v2\",\"id\":\"01ARZ3NDEKTSV4RRFFQ69G5FAV\",\"outcome\":\"transcended\"}}\n",
+        );
+        std::fs::create_dir_all(dir.path()).unwrap();
+        std::fs::write(dir.path().join(LOG_FILE), lines).unwrap();
+        let mut store = AgendaStore::open(dir.path()).unwrap();
+        assert_eq!(
+            store.skipped_lines(),
+            1,
+            "the attest line folds on this build; only the future vocabulary skips"
+        );
+        assert!(store.item("01ARZ3NDEKTSV4RRFFQ69G5FAV").is_some());
+        let page = store.read_ops(0, None, 10).unwrap();
+        assert_eq!(page.ops[1]["known"], serde_json::Value::Bool(true));
+        assert_eq!(page.ops[1]["op"]["op"]["outcome"], "blocked");
+        assert_eq!(page.ops[2]["known"], serde_json::Value::Bool(false));
+        // Both survive on disk verbatim — preservation is the compat
+        // promise either direction.
+        let text = std::fs::read_to_string(dir.path().join(LOG_FILE)).unwrap();
+        assert!(text.contains("\"attest\"") && text.contains("attest_v2"));
     }
 
     /// Seed the read_ops fixture through the real command path (two

--- a/src/bin/caller/agenda/types.rs
+++ b/src/bin/caller/agenda/types.rs
@@ -343,6 +343,39 @@ pub(crate) const MAX_BINDING_REFS_PER_MANIFEST: usize = 16;
 /// The `file:` locator scheme prefix (v1's only binding-ref scheme).
 pub(crate) const BINDING_REF_FILE_SCHEME: &str = "file:";
 
+/// Attestation-ref count rail per attest op (Track AO, Q2/Q3 ruling:
+/// refs ≤ 8 in `BindingRef`'s v1 grammar, hash-verified at intake,
+/// VERIFY-ONLY — pointer + pin, never sealed; OPEN-3).
+pub(crate) const MAX_ATTESTATION_REFS: usize = 8;
+/// Attestation note bound (Track AO, Q2 ruling: short prose, ≤ 4 KiB —
+/// the handoff itself belongs in a durable file behind a ref).
+pub(crate) const MAX_ATTESTATION_NOTE_BYTES: usize = 4096;
+
+/// The fired session's self-reported goal outcome (Track AO §2.1 — the
+/// meanings are binding). A second axis BESIDE the transport vocabulary
+/// (`started/completed/failed/missed/unknown`), never a
+/// reclassification: self-report, never verified, labeled so wherever
+/// it renders. The derived absence state — unattested — is fold-`None`,
+/// rendered distinctly, never equal to achieved, never synthesized.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AttestationOutcome {
+    /// The goal, as stated, was accomplished. Self-report, never
+    /// verified.
+    Achieved,
+    /// Real progress; the goal is not met; a future run (or the
+    /// standing cadence) can continue productively.
+    Partial,
+    /// Cannot proceed without something outside the session's power (an
+    /// owner decision, missing access, an external dependency). The
+    /// note should say what; an agenda-shaped blocker is what
+    /// `on_unblock` is for.
+    Blocked,
+    /// Deliberately stopped: wrong premise, obsolete goal, safety
+    /// refusal. Terminal by intent; nothing should retry it.
+    Abandoned,
+}
+
 /// A scheduled-session manifest (slice A5): the complete statement of
 /// what firing does — reviewed by the owner at approval time. Immutable
 /// per revision: [`manifest_digest`] binds the approval, and any edit
@@ -1095,6 +1128,30 @@ pub enum AgendaCommand {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         source: Option<String>,
     },
+    /// The fired session's self-report on its occurrence (Track AO): a
+    /// second axis beside the transport verdict, accepted only from a
+    /// session in the occurrence's started lineage (Rider A —
+    /// superseded originals and admitted successors both attest;
+    /// last-wins within the lineage). Non-session actors are refused by
+    /// name: an owner statement about a run is a verification lane, not
+    /// self-report. Refs are pointer + pin in `BindingRef`'s v1
+    /// grammar, hash-verified at intake against the daemon's own read
+    /// and never sealed (OPEN-3: verify-only). Accepted while the
+    /// occurrence is `started` and after a terminal alike (late attests
+    /// are display-only downstream).
+    Attest {
+        id: String,
+        /// The occurrence being attested — the fired task's rider names
+        /// it, so self-reference resolves mechanically.
+        occurrence: String,
+        outcome: AttestationOutcome,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        note: Option<String>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        refs: Vec<BindingRef>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        source: Option<String>,
+    },
     /// State a blocking criterion on an open item. Plain text about the
     /// world — NO watcher, poller, or condition language ever evaluates
     /// it. The daemon mints the blocker id at intake.
@@ -1280,6 +1337,7 @@ impl AgendaCommand {
             | AgendaCommand::Answer { source, .. }
             | AgendaCommand::ProposeEffect { source, .. }
             | AgendaCommand::Annotate { source, .. }
+            | AgendaCommand::Attest { source, .. }
             | AgendaCommand::SetBlocker { source, .. }
             | AgendaCommand::ClearBlocker { source, .. }
             | AgendaCommand::AddReliesOn { source, .. }
@@ -1463,6 +1521,26 @@ pub(crate) enum AgendaOp {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         note: Option<String>,
     },
+    /// The fired session's self-report (Track AO §2.3): an act by an
+    /// attributed principal, so it is an op — attribution rides the
+    /// envelope like every act, and the op log is the attestation
+    /// history. Older builds skip exactly this line (unknown variant —
+    /// whole-line, the `KNOWN_OPS` posture) while keeping full
+    /// transport fidelity; old daemons refuse the wire command
+    /// fail-closed (`deny_unknown_fields`). Intake verified:
+    /// occurrence-belongs-to-item, actor in the occurrence's started
+    /// lineage, closed outcome set, bounded note, refs hash-verified
+    /// (verify-only — never sealed).
+    Attest {
+        id: String,
+        effect_id: String,
+        occurrence_id: String,
+        outcome: AttestationOutcome,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        note: Option<String>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        refs: Vec<BindingRef>,
+    },
     /// Daemon-authored ask-delivery write-back (the session supervisor's
     /// delivery arm only — no command twin, like `record_occurrence`):
     /// whether the recorded answer reached a live asking session (or its
@@ -1505,6 +1583,7 @@ impl AgendaOp {
             | AgendaOp::RevokeEffect { id, .. }
             | AgendaOp::RequestOccurrence { id, .. }
             | AgendaOp::RecordOccurrence { id, .. }
+            | AgendaOp::Attest { id, .. }
             | AgendaOp::RecordAskDelivery { id, .. } => id,
         }
     }
@@ -2066,6 +2145,15 @@ pub(crate) fn apply_op(
                 _ => {}
             }
             item.updated_ms = at_ms;
+            None
+        }
+        AgendaOp::Attest { .. } => {
+            // History-only in this slice (Track AO): the op log IS the
+            // attestation history (`/api/agenda/ops` serves it). The
+            // run-view attach (`AgendaRun.attestation` — last-wins on
+            // the same occurrence, carried through the terminal
+            // write-back, warn-skip on mismatch) and the ruled streak
+            // weights land with the AO fold slice.
             None
         }
         AgendaOp::Answer {

--- a/src/bin/caller/ctl.rs
+++ b/src/bin/caller/ctl.rs
@@ -2553,6 +2553,53 @@ async fn run_agenda(
             let response = call_tool(client, config, "agenda_op", Value::Object(map)).await?;
             print_tool_response(response, config, None)?;
         }
+        "attest" => {
+            // The fired session's self-report on its occurrence (Track
+            // AO): the daemon binds it to the started lineage at intake
+            // — only the fired session (or its resume successors) may
+            // attest, and every refusal is named. Refs are hashed HERE
+            // (the pin says what this side read) and verified against
+            // the daemon's own read; pointer + pin, never sealed.
+            let args = parse_command_args(
+                &raw[1..],
+                &["--occurrence", "--outcome", "--note", "--ref", "--source"],
+                &[],
+            )?;
+            let id = agenda_resolve_id(
+                client,
+                config,
+                &args,
+                "agenda attest requires an item id (a unique prefix is enough)",
+            )
+            .await?;
+            let occurrence = args.one("--occurrence").ok_or_else(|| {
+                "agenda attest requires --occurrence OCCURRENCE_ID — your fired task's \
+                 rider names it"
+                    .to_string()
+            })?;
+            let outcome = args.one("--outcome").ok_or_else(|| {
+                "agenda attest requires --outcome achieved|partial|blocked|abandoned".to_string()
+            })?;
+            let mut map = Map::new();
+            map.insert("op".to_string(), Value::String("attest".to_string()));
+            map.insert("id".to_string(), Value::String(id));
+            map.insert(
+                "occurrence".to_string(),
+                Value::String(occurrence.to_string()),
+            );
+            map.insert("outcome".to_string(), Value::String(outcome.to_string()));
+            insert_string(&mut map, "note", args.one("--note"));
+            let refs = args
+                .all("--ref")
+                .map(|spec| hashed_file_ref_value("--ref", spec))
+                .collect::<Result<Vec<_>, _>>()?;
+            if !refs.is_empty() {
+                map.insert("refs".to_string(), Value::Array(refs));
+            }
+            insert_string(&mut map, "source", args.one("--source"));
+            let response = call_tool(client, config, "agenda_op", Value::Object(map)).await?;
+            print_tool_response(response, config, None)?;
+        }
         "block" => {
             let args = parse_command_args(&raw[1..], &["--source"], &[])?;
             let id = agenda_resolve_id(
@@ -2824,37 +2871,45 @@ fn agenda_ref_spec(raw: &str, explicit: Option<&str>) -> Result<(String, String)
     Ok((ref_type, locator))
 }
 
-/// `--binding-ref file:PATH` propose-time hashing (sealed refs): resolve
-/// PATH, sha256 its bytes NOW, and embed `{locator, sha256}` — the
+/// `--binding-ref file:PATH` propose-time hashing (sealed refs): the
 /// manifest pin the approval digest covers. The daemon verifies the pin
 /// against its own read at intake (a remote `--url` daemon reading
-/// different bytes refuses by name) and re-verifies at every fire. v1
-/// accepts `file:` locators only; other schemes refuse by name.
+/// different bytes refuses by name) and re-verifies at every fire.
 fn binding_ref_propose_value(spec: &str) -> Result<Value, String> {
+    hashed_file_ref_value("--binding-ref", spec)
+}
+
+/// `FLAG file:PATH` local hashing: resolve PATH, sha256 its bytes NOW,
+/// and embed `{locator, sha256}` — the pin says what THIS side read;
+/// the daemon verifies it against its own read at intake. v1 accepts
+/// `file:` locators only; other schemes refuse by name. `flag` names
+/// the CLI flag in refusals (`--binding-ref` on propose, `--ref` on
+/// attest).
+fn hashed_file_ref_value(flag: &str, spec: &str) -> Result<Value, String> {
     let Some(raw) = spec.strip_prefix("file:") else {
         return Err(format!(
-            "--binding-ref {spec:?}: v1 seals file:PATH locators only \
+            "{flag} {spec:?}: v1 accepts file:PATH locators only \
              (body:/git: forms are future vocabulary)"
         ));
     };
     if raw.is_empty() {
-        return Err("--binding-ref file: needs a path".to_string());
+        return Err(format!("{flag} file: needs a path"));
     }
     let path = std::path::Path::new(raw);
     let absolute = if path.is_absolute() {
         path.to_path_buf()
     } else {
         std::env::current_dir()
-            .map_err(|err| format!("--binding-ref {spec:?}: cannot resolve the cwd ({err})"))?
+            .map_err(|err| format!("{flag} {spec:?}: cannot resolve the cwd ({err})"))?
             .join(path)
     };
-    // Canonical (symlink-free) so the daemon pins the same bytes at fire
-    // time that this hash read — a locator that dereferences differently
-    // later is exactly the drift the seal exists to catch.
+    // Canonical (symlink-free) so the daemon reads the same bytes this
+    // hash read — a locator that dereferences differently later is
+    // exactly the drift the pin exists to catch.
     let canonical = std::fs::canonicalize(&absolute)
-        .map_err(|err| format!("--binding-ref {spec:?}: not readable ({err})"))?;
+        .map_err(|err| format!("{flag} {spec:?}: not readable ({err})"))?;
     let sha256 = crate::agenda::digest_file(&canonical)
-        .map_err(|err| format!("--binding-ref {spec:?}: cannot hash ({err})"))?;
+        .map_err(|err| format!("{flag} {spec:?}: cannot hash ({err})"))?;
     Ok(serde_json::json!({
         "locator": format!("file:{}", canonical.display()),
         "sha256": sha256,
@@ -5300,6 +5355,8 @@ fn help_agenda() {
   intendant ctl agenda answer ID_PREFIX REPLY... [--source LABEL]\n\
   intendant ctl agenda list [--all|--open|--done|--retired] [--blocked] [--json]\n\
   intendant ctl agenda annotate ID_PREFIX NOTE... [--source LABEL]\n\
+  intendant ctl agenda attest ID_PREFIX --occurrence OCC_ID --outcome achieved|partial|blocked|abandoned\n\
+      [--note TEXT] [--ref file:PATH]... [--source LABEL]   # fired session's self-report on its occurrence\n\
   intendant ctl agenda block ID_PREFIX CRITERION... [--source LABEL]\n\
   intendant ctl agenda unblock ID_PREFIX [BLOCKER_PREFIX] [--source LABEL]\n\
   intendant ctl agenda relies-on ID_PREFIX TARGET_PREFIX [--remove] [--source LABEL]\n\

--- a/src/bin/caller/mcp/tool_gate.rs
+++ b/src/bin/caller/mcp/tool_gate.rs
@@ -1493,6 +1493,7 @@ mod tests {
                     "answer",
                     "approve_effect",
                     "ask",
+                    "attest",
                     "clear_blocker",
                     "complete",
                     "patch",


### PR DESCRIPTION
Track AO slice S1. Sealed basis: the AO intake + ruling + rider ruling (sha256 34e39cfb…). Builds on landed S0 (#648).

- `AgendaCommand::Attest` on the one agenda command vocabulary — ctl `agenda attest` / MCP `agenda_op` / `POST /api/agenda/op` + tunnel twin all fan from the same enum; **zero new routes**. Old daemons refuse the wire command fail-closed (`deny_unknown_fields`).
- `AgendaOp::Attest` as the durable act (`KNOWN_OPS` → 25). Old builds skip exactly the attestation line (whole-line, the KNOWN_OPS posture) and keep full transport fidelity; the line is preserved on disk and served `known:false`.
- The four ruled intake checks, every refusal named (R5): occurrence-belongs-to-item; gate-resolved actor session ∈ `started_history` (Rider A lineage — superseded original AND admitted successor attest; **non-session actors refused**); closed outcome set + note ≤ 4 KiB + refs ≤ 8 in BindingRef v1 grammar **hash-verified against the daemon's own read, VERIFY-ONLY** (OPEN-3 — nothing sealed); accepted while started and after terminals (late = display-only downstream).
- Fold arm is history-only this slice; `AgendaRun.attestation` + streak weights land in S2 per the commission.
- Teaching (R4): the S0 epistemic rider line + skill paragraph are **AMENDED in place** with the attest verb — the byte-pin proves one block, never two.

Pins: `attest_requires_lineage_membership`, `attest_refs_hash_verified_at_intake`, `attest_op_skips_whole_line_on_old_builds` (+ the amended `epistemic_line_rides_every_fired_task`).

Battery: bins 5146+148+97, e2e 37, workspace clippy -D warnings, fmt — all green, explicit exit codes.