### PR TITLE
feat(daemon): boot auto-readopt — crash recovery resumes what died mid-work

### DIFF
--- a/docs/src/agenda-and-memory.md
+++ b/docs/src/agenda-and-memory.md
@@ -306,6 +306,26 @@ whose writing daemon is provably gone (its per-boot presence lock under
 clobbered by a co-homed boot. `intendant ctl status` shows the lease and
 every registered daemon under `scheduler_lease`.
 
+Recovery fail-closes a dead boot's `started`-without-terminal occurrences to
+`unknown` (never an automatic re-fire of the goal — RFC §7.5), but the
+**boot auto-readopt pass** (`[readopt]`, default on) separately
+resume-attaches the dead boot's mid-work *sessions* — started-without-
+terminal occurrences, mid-turn interruptions, and limit-parked wrappers
+with pending work — under fresh wrappers with a continuation nudge, on the
+automatic resume lane (owner-stopped and retired lineages refuse; a live
+successor is never doubled; suspended series stay down; only the lease
+holder readopts). The scheduler watches each fail-closed occurrence's
+durable resume lineage for a bounded window: when a successor is admitted
+(the readopt pass's, or a manual post-crash resume), it journals a fresh
+`started` row naming the successor — a later `started` **re-opens** a
+terminaled occurrence in the fold — re-arming the item's no-overlap hold
+and letting the successor's terminal close the occurrence normally. Each
+crash cycle still costs one `unknown` on the effect's failure streak until
+a completion resets it, so a crash-looping series suspends and the readopt
+pass respects the suspension — the existing streak law is the crash-loop
+brake. The pass is visible: one summary notification per boot with
+anything mid-work, naming what was resumed and what was left dead and why.
+
 ### Scheduled sessions
 
 Scheduled work is a separate effect object that references an agenda item.

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -314,6 +314,20 @@ production behavior must not depend on them.
 |-----|------|---------|-------------|
 | `cu_first_routing` | bool | `false` | Intercept every non-direct task with a fast CU model that completes it on the display or escalates to the main agent (vaulted 2026-07-04: adds a model hop to every task and, under subscription-based external agents, an API-key model dependency) |
 
+### `[readopt]`
+
+The boot auto-readopt pass: at daemon boot, the dead boot's mid-work
+sessions (started-without-terminal agenda occurrences, mid-turn
+interruptions, limit-parked wrappers with pending work) are
+resume-attached under fresh wrappers with a continuation nudge, under the
+existing admission guards (see
+[Agenda & Memory](./agenda-and-memory.md#reminders)). Idle or completed
+sessions stay down.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | bool | `true` | `false` leaves dead-boot sessions down for the owner to resume by hand. `INTENDANT_BOOT_READOPT=0`/`1` overrides the file in either direction |
+
 ### `[agent]` and external backends
 
 Routes coding tasks to an external CLI agent instead of the native loop (see

--- a/src/bin/caller/agenda/reminders.rs
+++ b/src/bin/caller/agenda/reminders.rs
@@ -795,6 +795,15 @@ fn fold_record_into(entry: &mut OccurrenceProgress, record: &OccurrenceRecord) {
             entry.prepared = true;
             entry.started = record.session_id.clone();
             entry.writer_boot_id = record.boot_id.clone();
+            // A later `started` re-opens the occurrence: the work
+            // continues under a successor session (the boot-readopt
+            // watch re-keying past recovery's fail-closed `Unknown`),
+            // so the newest state wins — the row is unresolved again,
+            // holds its item's no-overlap gate, and its successor's
+            // terminal will close it. Ordered folds make this safe:
+            // every pre-readopt writer only ever appended `started`
+            // before a terminal.
+            entry.terminal = None;
             if let Some(session_id) = record.session_id.as_ref() {
                 if !entry.started_history.contains(session_id) {
                     entry.started_history.push(session_id.clone());
@@ -1627,6 +1636,64 @@ mod tests {
             end_min: 300,
         };
         assert!(!empty.contains(300));
+    }
+
+    /// The re-open law: a later `started` row supersedes a terminal —
+    /// the occurrence is unresolved again (it re-arms its item's
+    /// no-overlap hold and its successor's terminal closes it), which
+    /// is how the boot-readopt watch re-keys past recovery's
+    /// fail-closed `Unknown`. Ordered folds make it safe: pre-readopt
+    /// writers only ever appended `started` before a terminal.
+    #[test]
+    fn started_reopens_a_terminaled_occurrence() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut journal = journal(dir.path());
+        let record = |state: OccurrenceState, session: Option<&str>| OccurrenceRecord {
+            v: 1,
+            at_ms: 1_000,
+            occurrence_id: "occ-reopen".to_string(),
+            item_id: "it-reopen".to_string(),
+            due_ms: 1_000,
+            state,
+            urgency: None,
+            session_id: session.map(str::to_string),
+            generation: None,
+            boot_id: None,
+        };
+        journal
+            .append(&record(OccurrenceState::Started, Some("sess-dead")))
+            .unwrap();
+        journal
+            .append(&record(OccurrenceState::Unknown, Some("sess-dead")))
+            .unwrap();
+        assert!(journal.started_unresolved().is_empty(), "fail-closed");
+
+        journal
+            .append(&record(OccurrenceState::Started, Some("sess-successor")))
+            .unwrap();
+        let progress = journal.progress("occ-reopen");
+        assert_eq!(progress.terminal, None, "the later started re-opens it");
+        assert_eq!(progress.started.as_deref(), Some("sess-successor"));
+        assert_eq!(
+            progress.started_history,
+            vec!["sess-dead".to_string(), "sess-successor".to_string()],
+            "both incarnations stay attributed"
+        );
+        assert!(
+            journal.started_unresolved_for_item("it-reopen"),
+            "the no-overlap hold re-arms"
+        );
+
+        // A terminal after the re-open closes it again — the successor's
+        // completion ends the story.
+        journal
+            .append(&record(OccurrenceState::Completed, Some("sess-successor")))
+            .unwrap();
+        assert_eq!(
+            journal.progress("occ-reopen").terminal,
+            Some(OccurrenceState::Completed)
+        );
+        assert!(!journal.started_unresolved_for_item("it-reopen"));
     }
 
     #[test]

--- a/src/bin/caller/agenda/scheduler.rs
+++ b/src/bin/caller/agenda/scheduler.rs
@@ -139,6 +139,10 @@ struct SchedulerState {
     /// Ended-but-unclassified running sessions awaiting their resume
     /// lineage (see [`PendingLineageEnd`]); swept on every wake.
     lineage_pending: Vec<PendingLineageEnd>,
+    /// Boot-recovery fail-closed occurrences whose dead session may yet
+    /// be readopted (see [`ReadoptWatch`]); swept on every wake, expire
+    /// after [`READOPT_WATCH_WINDOW_MS`].
+    readopt_watch: Vec<ReadoptWatch>,
 }
 
 impl SchedulerState {
@@ -260,20 +264,26 @@ pub(crate) fn spawn_reminder_scheduler(
         let mut events = handle.bus().subscribe();
         // Boot recovery, scoped (Track HS2): a live co-homed daemon's
         // in-flight rows are spared; legacy rows and provably dead
-        // writers fail-close exactly as before.
-        match handover.as_deref() {
+        // writers fail-close exactly as before. The classification
+        // output feeds the boot auto-readopt pass — seeds go to the
+        // published handoff slot (the pass sequences on it), watches
+        // stay here so an admitted successor re-keys its occurrence.
+        let classification = match handover.as_deref() {
             Some(runtime) => {
                 resolve_lost_sessions(&handle, &mut journal, RecoveryScope::Boot(runtime))
             }
             None => resolve_lost_sessions(&handle, &mut journal, RecoveryScope::Unscoped),
-        }
+        };
+        state.readopt_watch = classification.watches;
+        crate::boot_readopt::publish_agenda_readopt_seeds(classification.seeds);
         loop {
             let next_wake_ms =
                 run_pass(&handle, &mut journal, &mut state, handover.as_deref()).await;
             let now = now_ms();
             let retry_wake_ms = sweep_pending_dispatches(&handle, &mut journal, &mut state, now);
             let lineage_wake_ms = sweep_lineage_pending(&handle, &mut journal, &mut state, now);
-            let next_wake_ms = [next_wake_ms, retry_wake_ms, lineage_wake_ms]
+            let readopt_wake_ms = sweep_readopt_watch(&handle, &mut journal, &mut state, now);
+            let next_wake_ms = [next_wake_ms, retry_wake_ms, lineage_wake_ms, readopt_wake_ms]
                 .into_iter()
                 .flatten()
                 .min();
@@ -355,17 +365,46 @@ impl RecoveryScope<'_> {
     }
 }
 
+/// A dead session whose occurrence the boot recovery pass fail-closed,
+/// held so the scheduler can watch its durable resume lineage: when the
+/// boot auto-readopt pass (or the owner) resume-attaches the session
+/// within the window, the occurrence re-keys onto the successor — the
+/// same follow-the-lineage shape [`rekey_running_to_successor`] gives a
+/// live daemon — instead of staying an orphaned `Unknown` while its
+/// work continues.
+struct ReadoptWatch {
+    spawn: SpawnOccurrence,
+    dead_session_id: String,
+    parked_at_ms: u64,
+}
+
+/// What boot recovery classified (Track HS2 scope) — the readopt
+/// handoff: seeds go to the boot auto-readopt pass, watches stay here.
+#[derive(Default)]
+struct LostSessionClassification {
+    seeds: Vec<crate::boot_readopt::AgendaReadoptSeed>,
+    watches: Vec<ReadoptWatch>,
+}
+
 /// Fail-close unresolved occurrences within `scope`: `started`-without-
 /// terminal rows whose driving daemon is gone resolve `Unknown`, never
 /// auto-retried (RFC §7.5); the sessions themselves, if alive, are
 /// still visible in the Sessions tab. Runs at scheduler boot
 /// ([`RecoveryScope::Boot`]/[`RecoveryScope::Unscoped`]) and on every
 /// holder pass ([`RecoveryScope::Recurring`]).
+///
+/// The RFC rule governs the occurrence — no automatic RE-FIRE of the
+/// goal. Resuming the interrupted SESSION is a different act: the
+/// returned classification hands each fail-closed row's session to the
+/// boot auto-readopt pass, and the boot caller parks the watches that
+/// re-key an occurrence onto an admitted successor. Recovery itself
+/// stays fail-closed either way — a readopt that never materializes
+/// leaves exactly today's `Unknown`.
 fn resolve_lost_sessions(
     handle: &AgendaHandle,
     journal: &mut OccurrenceJournal,
     scope: RecoveryScope<'_>,
-) {
+) -> LostSessionClassification {
     let unresolved: Vec<_> = journal
         .started_unresolved()
         .into_iter()
@@ -376,8 +415,9 @@ fn resolve_lost_sessions(
         .into_iter()
         .filter(|row| scope.may_resolve(row.writer_boot_id.as_deref()))
         .collect();
+    let mut classification = LostSessionClassification::default();
     if unresolved.is_empty() && lost_dispatches.is_empty() {
-        return;
+        return classification;
     }
     // Why the writer died shapes the owner-facing note: a boot pass means
     // *this* executor restarted; the recurring pass means a co-homed
@@ -413,6 +453,7 @@ fn resolve_lost_sessions(
         });
         // The journal row carries no effect_id, so find the owning effect by
         // its last_run lineage and make the item's state honest too.
+        let mut matched_suspended: Option<bool> = None;
         for item in &items {
             for effect in &item.effects {
                 if effect
@@ -433,8 +474,48 @@ fn resolve_lost_sessions(
                             item.id
                         );
                     }
+                    // Readopt handoff: the fail-closed row's session is a
+                    // mid-work seed, and — unless the series is suspended
+                    // (the streak law is the crash-loop brake) — a watch
+                    // that re-keys the occurrence onto the successor the
+                    // readopt pass admits.
+                    if matched_suspended.is_none() {
+                        let suspended = effect.suspended();
+                        matched_suspended = Some(suspended);
+                        if let Some(dead_session_id) = session_id.clone().filter(|_| !suspended) {
+                            classification.watches.push(ReadoptWatch {
+                                spawn: SpawnOccurrence {
+                                    occurrence_id: occurrence_id.clone(),
+                                    item_id: item.id.clone(),
+                                    effect_id: effect.effect_id.clone(),
+                                    goal: effect.manifest.goal.clone(),
+                                    orchestrate: effect.manifest.orchestrate,
+                                    fire_at_ms: 0,
+                                    recurring: effect.manifest.recurrence.is_some(),
+                                    interactive: effect.manifest.interactive,
+                                    project_root: effect.manifest.project_root.clone(),
+                                    agent_config: effect.manifest.agent_config.clone(),
+                                    provenance_session_id: item.provenance.session_id.clone(),
+                                    matched_item_ids: Vec::new(),
+                                    binding_refs: Vec::new(),
+                                    session_name: None,
+                                },
+                                dead_session_id,
+                                parked_at_ms: now_ms(),
+                            });
+                        }
+                    }
                 }
             }
+        }
+        if let Some(dead_session_id) = session_id.clone() {
+            classification
+                .seeds
+                .push(crate::boot_readopt::AgendaReadoptSeed {
+                    occurrence_id: occurrence_id.clone(),
+                    session_id: dead_session_id,
+                    suspended: matched_suspended.unwrap_or(false),
+                });
         }
         eprintln!(
             "[agenda] occurrence {occurrence_id} resolved to unknown \
@@ -487,6 +568,7 @@ fn resolve_lost_sessions(
              (writer daemon gone before its session dispatched)"
         );
     }
+    classification
 }
 
 /// A broadcast lag means one or more launch receipts or terminal events may
@@ -1277,6 +1359,121 @@ fn sweep_lineage_pending(
         .iter()
         .map(|entry| entry.ended_at_ms + LINEAGE_QUIET_GRACE_MS)
         .min()
+}
+
+/// How long a boot-recovery [`ReadoptWatch`] waits for a successor to
+/// appear in durable lineage. Generous next to
+/// [`LINEAGE_QUIET_GRACE_MS`]: the readopt pass itself lands within
+/// seconds, but the window also re-links a MANUAL post-crash resume
+/// (the owner's "proceed" minutes after a restart) — after it closes,
+/// a late resume still runs, it just no longer re-keys the occurrence.
+const READOPT_WATCH_WINDOW_MS: u64 = 15 * 60 * 1000;
+
+/// Re-check boot-recovery readopt watches against durable lineage: runs
+/// on every scheduler wake, exactly like [`sweep_lineage_pending`], and
+/// through the same shared resolver — never a private walk. An
+/// owner-stop tombstone ends the watch (quiet by decree); an admitted
+/// successor re-keys the occurrence; everything else waits out the
+/// window and expires silently (the occurrence stays the fail-closed
+/// `Unknown` recovery wrote).
+fn sweep_readopt_watch(
+    handle: &AgendaHandle,
+    journal: &mut OccurrenceJournal,
+    state: &mut SchedulerState,
+    now: u64,
+) -> Option<u64> {
+    if state.readopt_watch.is_empty() {
+        return None;
+    }
+    let entries = std::mem::take(&mut state.readopt_watch);
+    for entry in entries {
+        let lineage = crate::session_supervisor::resume_lineage::resolve_resume_lineage(
+            &handle.spawn_ctx().home,
+            &[entry.dead_session_id.as_str()],
+        );
+        if lineage.stopped_by_user {
+            continue;
+        }
+        let excluded = [entry.dead_session_id.as_str()];
+        if let Some(tip) = lineage.successor_tip(&excluded) {
+            let successor = tip.intendant_session_id.clone();
+            readopt_rekey_to_successor(handle, journal, state, entry.spawn, &successor, now);
+            continue;
+        }
+        if now.saturating_sub(entry.parked_at_ms) < READOPT_WATCH_WINDOW_MS {
+            state.readopt_watch.push(entry);
+        }
+    }
+    state
+        .readopt_watch
+        .iter()
+        .map(|entry| entry.parked_at_ms + READOPT_WATCH_WINDOW_MS)
+        .min()
+}
+
+/// A watched occurrence's lineage grew an admitted successor: re-open
+/// tracking under it — [`rekey_running_to_successor`]'s shape, minus
+/// the `running` entry a live daemon would have had. The fresh
+/// `started` row re-opens the fail-closed occurrence (the journal fold
+/// law), re-stamps it to THIS boot, re-arms the item's no-overlap
+/// hold, and puts the successor in `running` so its eventual terminal
+/// classifies normally. `started` is streak-neutral: a crash cycle
+/// keeps its one `unknown` streak point until a completion resets —
+/// repeated crash-without-completion still suspends the series, which
+/// is the crash-loop brake the readopt pass respects.
+fn readopt_rekey_to_successor(
+    handle: &AgendaHandle,
+    journal: &mut OccurrenceJournal,
+    state: &mut SchedulerState,
+    spawn: SpawnOccurrence,
+    successor: &str,
+    now: u64,
+) {
+    if state.running.contains_key(successor)
+        || state
+            .running
+            .values()
+            .any(|running| running.occurrence_id == spawn.occurrence_id)
+    {
+        return;
+    }
+    eprintln!(
+        "[agenda] occurrence {} readopted after daemon restart: continuing under \
+         successor session {successor}",
+        spawn.occurrence_id
+    );
+    session_record(
+        journal,
+        &spawn,
+        now,
+        OccurrenceState::Started,
+        Some(successor.to_string()),
+    );
+    record_on_item(
+        handle,
+        &spawn,
+        "started",
+        Some(successor.to_string()),
+        Some(format!(
+            "readopted after daemon restart — continuing under successor session {successor}"
+        )),
+    );
+    state.running.insert(successor.to_string(), spawn);
+    if let Some(early) = state.take_early_outcome_aliased(successor) {
+        match early.failed {
+            None => complete_running(handle, journal, state, successor, early.note),
+            Some(end_reason) => classify_ended_running_session(
+                handle,
+                journal,
+                state,
+                successor,
+                successor,
+                &end_reason,
+                now,
+                now,
+            ),
+        }
+    }
 }
 
 /// Terminal resolution for occurrences that never spawned (missed window,
@@ -4493,6 +4690,224 @@ mod tests {
             journal.progress("occ-doomed").terminal,
             Some(OccurrenceState::Unknown),
             "a provably dead writer's rows fail-close"
+        );
+    }
+
+    /// Boot recovery's classification output is the readopt handoff:
+    /// each fail-closed started row yields a seed naming its dead
+    /// session, and — when the owning effect matches by `last_run`
+    /// lineage — a lineage watch carrying the reconstructed spawn
+    /// facts. The journal side stays exactly as fail-closed as before.
+    #[test]
+    fn boot_recovery_hands_readopt_seeds_and_watches() {
+        let home = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let default_project = tempfile::tempdir().unwrap();
+        let writer = crate::handover::HandoverRuntime::initialize(home.path(), 7001, 0);
+        let survivor = crate::handover::HandoverRuntime::initialize(home.path(), 7002, 0);
+        let handle = handle_with_default_project(dir.path(), default_project.path());
+        let (item_id, effect_id, _digest) = approved_effect_item(&handle, now_ms() - 60_000);
+        let occurrence_id = "occ-readopt".to_string();
+        handle
+            .record_occurrence(OccurrenceWriteBack {
+                item_id: &item_id,
+                effect_id: &effect_id,
+                occurrence_id: &occurrence_id,
+                state: "started",
+                session_id: Some("sess-occ-readopt".to_string()),
+                note: None,
+            })
+            .unwrap();
+        let mut journal = OccurrenceJournal::open(handle.dir()).unwrap();
+        journal.set_stamp(Some(JournalStamp {
+            boot_id: writer.boot_id().to_string(),
+            generation: Some(1),
+        }));
+        stamped_started_rows(&mut journal, "occ-readopt", &item_id);
+
+        drop(writer);
+        let classification =
+            resolve_lost_sessions(&handle, &mut journal, RecoveryScope::Boot(&survivor));
+        assert_eq!(
+            journal.progress("occ-readopt").terminal,
+            Some(OccurrenceState::Unknown),
+            "the journal side stays fail-closed (RFC §7.5) — readopt is a separate act"
+        );
+        assert_eq!(classification.seeds.len(), 1);
+        assert_eq!(classification.seeds[0].occurrence_id, "occ-readopt");
+        assert_eq!(classification.seeds[0].session_id, "sess-occ-readopt");
+        assert!(
+            !classification.seeds[0].suspended,
+            "a healthy effect's seed is not suspended"
+        );
+        assert_eq!(classification.watches.len(), 1);
+        let watch = &classification.watches[0];
+        assert_eq!(watch.dead_session_id, "sess-occ-readopt");
+        assert_eq!(watch.spawn.item_id, item_id);
+        assert_eq!(watch.spawn.effect_id, effect_id);
+        assert_eq!(watch.spawn.occurrence_id, "occ-readopt");
+    }
+
+    /// The readopt watch re-keys a fail-closed occurrence onto the
+    /// successor the resume lane admitted: fresh `started` row naming
+    /// the successor (re-opening the occurrence — the fold law), item
+    /// write-back, and a `running` entry so the successor's terminal
+    /// classifies normally.
+    #[test]
+    fn readopt_watch_rekeys_to_admitted_successor() {
+        let dir = tempfile::tempdir().unwrap();
+        let default_project = tempfile::tempdir().unwrap();
+        let handle = handle_with_default_project(dir.path(), default_project.path());
+        let (item_id, effect_id, _digest) = approved_effect_item(&handle, now_ms() - 60_000);
+        let mut journal = OccurrenceJournal::open(handle.dir()).unwrap();
+        // The fail-closed shape recovery left behind: started(dead) + unknown.
+        stamped_started_rows(&mut journal, "occ-watch", &item_id);
+        journal
+            .append(&OccurrenceRecord {
+                v: 1,
+                at_ms: 2_000,
+                occurrence_id: "occ-watch".to_string(),
+                item_id: String::new(),
+                due_ms: 0,
+                state: OccurrenceState::Unknown,
+                urgency: None,
+                session_id: Some("sess-occ-watch".to_string()),
+                generation: None,
+                boot_id: None,
+            })
+            .unwrap();
+        assert!(journal.started_unresolved().is_empty(), "fail-closed");
+
+        // The dead wrapper and its admitted successor, in durable state
+        // (the handle's spawn-context home is `dir`).
+        let logs = crate::platform::intendant_home_in(dir.path()).join("logs");
+        for wrapper in ["sess-occ-watch", "sess-successor"] {
+            let mut log = crate::session_log::SessionLog::open(logs.join(wrapper)).unwrap();
+            log.write_meta(None, None);
+            log.session_identity(wrapper, "claude-code", "b-watch-conv");
+        }
+
+        let mut state = SchedulerState::default();
+        state.readopt_watch.push(ReadoptWatch {
+            spawn: SpawnOccurrence {
+                occurrence_id: "occ-watch".to_string(),
+                item_id: item_id.clone(),
+                effect_id: effect_id.clone(),
+                goal: "run the nightly sweep".to_string(),
+                orchestrate: false,
+                fire_at_ms: 0,
+                recurring: false,
+                interactive: false,
+                project_root: None,
+                agent_config: None,
+                provenance_session_id: None,
+                matched_item_ids: Vec::new(),
+                binding_refs: Vec::new(),
+                session_name: None,
+            },
+            dead_session_id: "sess-occ-watch".to_string(),
+            parked_at_ms: now_ms(),
+        });
+        let wake = sweep_readopt_watch(&handle, &mut journal, &mut state, now_ms());
+        assert!(state.readopt_watch.is_empty(), "the watch resolved");
+        assert_eq!(wake, None, "nothing left to wake for");
+        let progress = journal.progress("occ-watch");
+        assert_eq!(
+            progress.started.as_deref(),
+            Some("sess-successor"),
+            "the occurrence follows the admitted successor"
+        );
+        assert_eq!(
+            progress.terminal, None,
+            "the fresh started row re-opens the fail-closed occurrence"
+        );
+        assert!(
+            state.running.contains_key("sess-successor"),
+            "the successor's terminal will classify normally"
+        );
+        assert!(
+            journal.started_unresolved_for_item(&item_id),
+            "the item's no-overlap hold re-arms while the successor runs"
+        );
+        let (items, _, _) = handle.snapshot();
+        let item = items.iter().find(|item| item.id == item_id).unwrap();
+        let run = item.effects[0].last_run.as_ref().unwrap();
+        assert_eq!(run.state, "started");
+        assert_eq!(run.session_id.as_deref(), Some("sess-successor"));
+    }
+
+    /// A watch with no successor expires quietly at the window (the
+    /// occurrence stays the fail-closed `Unknown`), and an owner-stop
+    /// tombstone anywhere in the lineage ends the watch immediately.
+    #[test]
+    fn readopt_watch_expires_and_respects_owner_stop() {
+        let dir = tempfile::tempdir().unwrap();
+        let default_project = tempfile::tempdir().unwrap();
+        let handle = handle_with_default_project(dir.path(), default_project.path());
+        let (item_id, effect_id, _digest) = approved_effect_item(&handle, now_ms() - 60_000);
+        let mut journal = OccurrenceJournal::open(handle.dir()).unwrap();
+        let watch_entry = |dead: &str, parked_at_ms: u64| ReadoptWatch {
+            spawn: SpawnOccurrence {
+                occurrence_id: format!("occ-{dead}"),
+                item_id: item_id.clone(),
+                effect_id: effect_id.clone(),
+                goal: "run the nightly sweep".to_string(),
+                orchestrate: false,
+                fire_at_ms: 0,
+                recurring: false,
+                interactive: false,
+                project_root: None,
+                agent_config: None,
+                provenance_session_id: None,
+                matched_item_ids: Vec::new(),
+                binding_refs: Vec::new(),
+                session_name: None,
+            },
+            dead_session_id: dead.to_string(),
+            parked_at_ms,
+        };
+
+        // No successor, window still open: the watch stays parked and
+        // bounds the wake.
+        let mut state = SchedulerState::default();
+        state
+            .readopt_watch
+            .push(watch_entry("sess-quiet", now_ms()));
+        let wake = sweep_readopt_watch(&handle, &mut journal, &mut state, now_ms());
+        assert_eq!(state.readopt_watch.len(), 1, "still watching");
+        assert!(wake.is_some(), "the window bounds the sleep");
+
+        // Window elapsed: the watch expires without journal writes.
+        let mut state = SchedulerState::default();
+        state.readopt_watch.push(watch_entry(
+            "sess-expired",
+            now_ms().saturating_sub(READOPT_WATCH_WINDOW_MS + 1),
+        ));
+        sweep_readopt_watch(&handle, &mut journal, &mut state, now_ms());
+        assert!(state.readopt_watch.is_empty(), "expired quietly");
+        assert_eq!(journal.progress("occ-sess-expired").started, None);
+
+        // Owner stop: the lineage is done by decree — watch dropped.
+        let logs = crate::platform::intendant_home_in(dir.path()).join("logs");
+        let mut log = crate::session_log::SessionLog::open(logs.join("sess-stopped")).unwrap();
+        log.write_meta(None, None);
+        log.session_identity("sess-stopped", "claude-code", "b-stopped-conv");
+        crate::external_wrapper_index::record_user_stop(
+            dir.path(),
+            "claude-code",
+            "b-stopped-conv",
+        )
+        .unwrap();
+        let mut state = SchedulerState::default();
+        state
+            .readopt_watch
+            .push(watch_entry("sess-stopped", now_ms()));
+        sweep_readopt_watch(&handle, &mut journal, &mut state, now_ms());
+        assert!(state.readopt_watch.is_empty(), "stopped lineage: watch ends");
+        assert_eq!(
+            journal.progress("occ-sess-stopped").started,
+            None,
+            "no re-key for an owner-stopped lineage"
         );
     }
 

--- a/src/bin/caller/agenda/scheduler.rs
+++ b/src/bin/caller/agenda/scheduler.rs
@@ -298,10 +298,15 @@ pub(crate) fn spawn_reminder_scheduler(
             let retry_wake_ms = sweep_pending_dispatches(&handle, &mut journal, &mut state, now);
             let lineage_wake_ms = sweep_lineage_pending(&handle, &mut journal, &mut state, now);
             let readopt_wake_ms = sweep_readopt_watch(&handle, &mut journal, &mut state, now);
-            let next_wake_ms = [next_wake_ms, retry_wake_ms, lineage_wake_ms, readopt_wake_ms]
-                .into_iter()
-                .flatten()
-                .min();
+            let next_wake_ms = [
+                next_wake_ms,
+                retry_wake_ms,
+                lineage_wake_ms,
+                readopt_wake_ms,
+            ]
+            .into_iter()
+            .flatten()
+            .min();
             let sleep_for = next_wake_ms
                 .map(|wake| std::time::Duration::from_millis(wake.saturating_sub(now)))
                 .map_or(SAFETY_TICK, |until| until.min(SAFETY_TICK));
@@ -4992,7 +4997,10 @@ mod tests {
             .readopt_watch
             .push(watch_entry("sess-stopped", now_ms()));
         sweep_readopt_watch(&handle, &mut journal, &mut state, now_ms());
-        assert!(state.readopt_watch.is_empty(), "stopped lineage: watch ends");
+        assert!(
+            state.readopt_watch.is_empty(),
+            "stopped lineage: watch ends"
+        );
         assert_eq!(
             journal.progress("occ-sess-stopped").started,
             None,

--- a/src/bin/caller/boot_readopt.rs
+++ b/src/bin/caller/boot_readopt.rs
@@ -1,0 +1,913 @@
+//! Boot auto-readopt: crash recovery resumes what died mid-work.
+//!
+//! Supervision is process plumbing and dies with the daemon; the designed
+//! recovery medium is RESUME from durable state. Every piece exists —
+//! durable transcripts, exactly-once wrapper admission
+//! (`external_wrapper_index::admit`), lineage-following occurrences (the
+//! scheduler's shared successor resolver), the mid-turn continuation
+//! nudge, boot/presence stamping and scoped boot recovery (Track HS) —
+//! and this module is the loop that was missing: at boot, after the
+//! agenda scheduler's scoped recovery classifies the dead boot's rows,
+//! enumerate the sessions that were MID-WORK and resume-attach each
+//! under a fresh wrapper with a synthesized continuation nudge, exactly
+//! as the owner does by hand.
+//!
+//! Mid-work is three durable shapes, and nothing else:
+//! - **agenda**: a `started`-without-terminal occurrence the boot
+//!   recovery pass just fail-closed (the classification output is
+//!   handed here — the journal side stays fail-closed per RFC §7.5, and
+//!   the scheduler separately re-keys the occurrence onto the readopted
+//!   successor when one appears);
+//! - **mid-turn**: `session_meta.json` status `running` (the daemon died
+//!   with a turn in flight — nothing survived to rewrite it) or
+//!   `interrupted` (a signal shutdown marked in-flight sessions on the
+//!   way down);
+//! - **limit-park**: the durable `limit_park` meta marker — the wrapper
+//!   was parked on a provider limit with its re-send still owed.
+//!
+//! Sessions that were idle or done are NOT resumed (idle in, idle out).
+//! The pass runs only on the scheduler-lease holder (secondaries never
+//! readopt), never while draining, and rides the AUTOMATIC resume lane
+//! (`ResumeSession { auto_attach: true }` → `WrapperLineageIntent::
+//! Resume`), so owner-stop tombstones and retired lineages refuse and a
+//! live successor routes instead of double-spawning. A lineage whose
+//! index already shows an admitted successor past the dead session is
+//! left dead here too — someone (an earlier boot, the owner, a co-homed
+//! daemon) already continued it.
+//!
+//! The pass is visible: one summary notification when there was anything
+//! to consider, and silence on clean boots. `[readopt] enabled = false`
+//! in intendant.toml (or `INTENDANT_BOOT_READOPT=0`) disables it.
+
+use crate::event::{AppEvent, ControlMsg, EventBus};
+use crate::handover::HandoverRuntime;
+use crate::session_log::SessionMeta;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+/// The synthesized continuation nudge — the same shape as the
+/// credential-reload and rate-limit mid-turn continuations
+/// (`external_mode::RELOAD_MIDTURN_CONTINUATION_TEXT`): resume-attach
+/// keeps the conversation context, so a nudge — never a re-send of the
+/// original goal, which would double-execute — is the safe first
+/// message.
+pub(crate) const READOPT_CONTINUATION_TEXT: &str =
+    "The daemon restarted mid-task — continue where you left off.";
+
+/// Resume-attaches per boot. A crash rarely strands more than a handful
+/// of genuinely mid-work sessions (idle-in/idle-out keeps the set
+/// small); the cap bounds the model-spend of a pathological boot, and
+/// overflow is reported as left-dead rather than silently dropped.
+const READOPT_MAX_PER_BOOT: usize = 16;
+
+/// Sessions whose last activity is older than this are archaeology, not
+/// crash recovery: the readopt pass resumes the DEAD BOOT's mid-work,
+/// and anything this stale was left dead by earlier boots (or predates
+/// the marker vocabulary) — surface it as left-dead, don't resurrect
+/// it.
+const READOPT_MAX_AGE_SECS: u64 = 7 * 24 * 3600;
+
+/// How long the readopt pass waits for the agenda scheduler's boot
+/// recovery to publish its classification before proceeding with the
+/// store-scan classes alone (the scheduler may be disabled or its
+/// journal unavailable).
+const AGENDA_SEED_WAIT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// One dead-boot `started`-without-terminal occurrence, as classified by
+/// the agenda scheduler's boot recovery pass (`resolve_lost_sessions`,
+/// `RecoveryScope::Boot`). The journal side has already fail-closed the
+/// occurrence to `Unknown`; this seed is the classification OUTPUT — the
+/// session that was mid-work — handed to the readopt pass. The
+/// scheduler separately parks a lineage watch so the occurrence re-keys
+/// onto the readopted successor.
+#[derive(Debug, Clone)]
+pub(crate) struct AgendaReadoptSeed {
+    pub(crate) occurrence_id: String,
+    pub(crate) session_id: String,
+    /// The owning effect was suspended (consecutive-failure streak) at
+    /// classification time: the owner has been told the series is off,
+    /// so the readopt pass must not stand its session back up.
+    pub(crate) suspended: bool,
+}
+
+/// The boot classification handoff slot: the scheduler's boot slot
+/// publishes exactly once per process; the readopt pass consumes it.
+/// (A channel in disguise — the scheduler task is spawned long before
+/// the readopt task exists, so a published slot is the simplest safe
+/// handoff, mirroring `publish_agenda_handle`.)
+static AGENDA_SEEDS: OnceLock<Mutex<Option<Vec<AgendaReadoptSeed>>>> = OnceLock::new();
+
+fn agenda_seed_slot() -> &'static Mutex<Option<Vec<AgendaReadoptSeed>>> {
+    AGENDA_SEEDS.get_or_init(|| Mutex::new(None))
+}
+
+/// Publish the boot recovery classification (agenda scheduler boot slot
+/// only). Later publishes win — only the daemon's single boot slot
+/// calls this in production.
+pub(crate) fn publish_agenda_readopt_seeds(seeds: Vec<AgendaReadoptSeed>) {
+    *agenda_seed_slot()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(seeds);
+}
+
+async fn await_agenda_readopt_seeds(timeout: std::time::Duration) -> Vec<AgendaReadoptSeed> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if let Some(seeds) = agenda_seed_slot()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take()
+        {
+            return seeds;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Vec::new();
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
+}
+
+/// Which durable mid-work shape flagged a candidate (the summary
+/// notification reports counts per class).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MidWorkClass {
+    Agenda,
+    MidTurn,
+    LimitPark,
+}
+
+impl MidWorkClass {
+    fn label(self) -> &'static str {
+        match self {
+            MidWorkClass::Agenda => "agenda occurrence",
+            MidWorkClass::MidTurn => "mid-turn",
+            MidWorkClass::LimitPark => "limit-parked",
+        }
+    }
+}
+
+/// A dead-boot session the enumeration flagged as mid-work, before the
+/// per-candidate guards run.
+#[derive(Debug, Clone)]
+pub(crate) struct ReadoptCandidate {
+    /// The dead wrapper session id (the session-store dir name).
+    pub(crate) session_id: String,
+    pub(crate) class: MidWorkClass,
+    /// Suspension flag carried from the agenda classification (store
+    /// classes are never suspended — the law protects standing series).
+    pub(crate) suspended: bool,
+    /// Last durable activity (session.jsonl mtime), for the staleness
+    /// guard. `0` = unknown (guarded as stale only if genuinely absent).
+    pub(crate) activity_secs: u64,
+}
+
+/// The per-candidate verdict.
+#[derive(Debug)]
+pub(crate) enum ReadoptDecision {
+    /// Send this resume — the exact control message, so tests pin the
+    /// wire shape (automatic lane, nudge, no fork/force).
+    Readopt(Box<ControlMsg>),
+    /// Leave dead, with the owner-facing reason.
+    LeftDead(String),
+}
+
+/// The boot watershed: this boot's presence-registration instant, in
+/// epoch seconds. Sessions whose durable activity predates it belong to
+/// dead boots. `None` when presence is unreadable — the pass then
+/// refuses to enumerate (fail closed: without an era line, "dead
+/// boot's" cannot be told from "live").
+fn boot_watershed_secs(state_root: &Path, own_boot_id: &str) -> Option<u64> {
+    crate::handover::read_presence_records(state_root)
+        .into_iter()
+        .filter(|record| record.boot_id == own_boot_id)
+        .map(|record| record.updated_ms / 1000)
+        .next()
+}
+
+/// Last durable activity of a session dir, epoch seconds (the same
+/// probe the session catalog's era classification uses:
+/// `session.jsonl` mtime, dir mtime as fallback).
+fn activity_mtime_secs(dir: &Path) -> u64 {
+    let mtime = |path: &Path| {
+        std::fs::metadata(path)
+            .and_then(|meta| meta.modified())
+            .ok()
+            .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|age| age.as_secs())
+    };
+    mtime(&dir.join("session.jsonl"))
+        .or_else(|| mtime(dir))
+        .unwrap_or(0)
+}
+
+/// Enumerate the store's dead-boot mid-work sessions (the mid-turn and
+/// limit-park classes; the agenda class arrives pre-classified from the
+/// scheduler). Idle in, idle out: `idle`/`completed` metas — and
+/// anything at-or-after the watershed, or with a live wrapper — never
+/// become candidates.
+pub(crate) fn scan_store_candidates(
+    home: &Path,
+    watershed_secs: u64,
+    live_wrapper_ids: &HashSet<String>,
+) -> Vec<ReadoptCandidate> {
+    let logs_dir = crate::platform::intendant_home_in(home).join("logs");
+    let Ok(entries) = std::fs::read_dir(&logs_dir) else {
+        return Vec::new();
+    };
+    let mut candidates = Vec::new();
+    for entry in entries.flatten() {
+        let dir = entry.path();
+        if !dir.is_dir() {
+            continue;
+        }
+        let Ok(raw) = std::fs::read_to_string(dir.join("session_meta.json")) else {
+            continue;
+        };
+        let Ok(meta) = serde_json::from_str::<SessionMeta>(&raw) else {
+            continue;
+        };
+        let session_id = meta.session_id.trim().to_string();
+        if session_id.is_empty() || live_wrapper_ids.contains(&session_id) {
+            continue;
+        }
+        let activity_secs = activity_mtime_secs(&dir);
+        if activity_secs >= watershed_secs {
+            continue; // current boot's era — not the dead boot's
+        }
+        let status = meta.status.as_deref().unwrap_or("");
+        let class = if matches!(status, "running" | "interrupted") {
+            MidWorkClass::MidTurn
+        } else if meta
+            .limit_park
+            .as_ref()
+            .is_some_and(|park| park.has_pending)
+            && status != "completed"
+        {
+            MidWorkClass::LimitPark
+        } else {
+            continue; // idle in, idle out
+        };
+        candidates.push(ReadoptCandidate {
+            session_id,
+            class,
+            suspended: false,
+            activity_secs,
+        });
+    }
+    // Newest first, so the per-boot cap spends its slots on the most
+    // recently active work.
+    candidates.sort_by(|a, b| b.activity_secs.cmp(&a.activity_secs));
+    candidates
+}
+
+/// Merge the agenda seeds into the store scan, deduplicating by session
+/// id (a scheduled session that was also mid-turn or parked is ONE
+/// candidate; the agenda class wins the label and carries suspension).
+pub(crate) fn merge_candidates(
+    seeds: &[AgendaReadoptSeed],
+    mut store: Vec<ReadoptCandidate>,
+) -> Vec<ReadoptCandidate> {
+    for seed in seeds {
+        let session_id = seed.session_id.trim();
+        if session_id.is_empty() {
+            continue;
+        }
+        if let Some(existing) = store
+            .iter_mut()
+            .find(|candidate| candidate.session_id == session_id)
+        {
+            existing.class = MidWorkClass::Agenda;
+            existing.suspended = seed.suspended;
+        } else {
+            store.push(ReadoptCandidate {
+                session_id: session_id.to_string(),
+                class: MidWorkClass::Agenda,
+                suspended: seed.suspended,
+                // Unknown to the store scan (no meta found there):
+                // resolve the dir directly so the staleness guard still
+                // has a line; 0 (missing) reads as stale.
+                activity_secs: 0,
+            });
+        }
+    }
+    store
+}
+
+/// The per-candidate guard ladder. Everything here reads durable state
+/// only; the resume lane's own admission (`admit`, intent `Resume`)
+/// stays the authoritative CAS gate — this ladder exists so refusals we
+/// can see coming are counted as honest left-dead reasons instead of
+/// spawn-time warnings.
+pub(crate) fn decide_candidate(
+    home: &Path,
+    candidate: &ReadoptCandidate,
+    now_secs: u64,
+) -> ReadoptDecision {
+    if candidate.suspended {
+        return ReadoptDecision::LeftDead(
+            "standing series suspended after repeated failures".to_string(),
+        );
+    }
+    let Some((source, backend_session_id)) =
+        crate::external_wrapper_index::conversation_for_wrapper(home, &candidate.session_id)
+    else {
+        // No recorded backend conversation: a native session (no
+        // external resume lane exists yet) or a wrapper that died
+        // before its identity landed — either way there is nothing to
+        // resume-attach.
+        return ReadoptDecision::LeftDead("no external resume lineage recorded".to_string());
+    };
+    if candidate.activity_secs == 0
+        || now_secs.saturating_sub(candidate.activity_secs) > READOPT_MAX_AGE_SECS
+    {
+        return ReadoptDecision::LeftDead(
+            "stale — last activity predates the readopt window".to_string(),
+        );
+    }
+    let lineage = crate::session_supervisor::resume_lineage::resolve_resume_lineage(
+        home,
+        &[&candidate.session_id],
+    );
+    if lineage.stopped_by_user {
+        return ReadoptDecision::LeftDead("owner stopped this lineage".to_string());
+    }
+    let excluded: Vec<&str> = vec![candidate.session_id.as_str()];
+    if let Some(tip) = lineage.successor_tip(&excluded) {
+        return ReadoptDecision::LeftDead(format!(
+            "already continued under session {}",
+            short_id(&tip.intendant_session_id)
+        ));
+    }
+    let project_root =
+        crate::external_wrapper_index::recorded_project_root_for_wrapper(home, &candidate.session_id)
+            .map(PathBuf::from);
+    if let Some(root) = &project_root {
+        if !root.is_dir() {
+            return ReadoptDecision::LeftDead(format!(
+                "recorded project root no longer exists ({})",
+                root.display()
+            ));
+        }
+    }
+    // The manual dashboard resume's exact wire shape: backend id as the
+    // display id, fresh wrapper minted by the spawn lane, nudge as the
+    // first message. `auto_attach` marks the AUTOMATIC lane — intent
+    // `Resume`, which refuses stopped and retired lineages and routes
+    // to a live wrapper instead of double-spawning; it must never be
+    // the tombstone-clearing `Revive`/`Restart`.
+    ReadoptDecision::Readopt(Box::new(ControlMsg::ResumeSession {
+        source,
+        session_id: backend_session_id,
+        resume_id: None,
+        project_root: project_root.map(|root| root.to_string_lossy().to_string()),
+        task: Some(READOPT_CONTINUATION_TEXT.to_string()),
+        direct: None,
+        attachments: Vec::new(),
+        fork: false,
+        relationship_kind: None,
+        auto_attach: true,
+        agent_command: None,
+        codex_sandbox: None,
+        codex_approval_policy: None,
+        codex_managed_context: None,
+        codex_context_archive: None,
+    }))
+}
+
+fn short_id(id: &str) -> &str {
+    id.get(..8).unwrap_or(id)
+}
+
+/// The visible summary: one notification per boot with candidates, id
+/// keyed by boot so repeats never stack, silence when nothing was
+/// mid-work.
+pub(crate) fn summary_notification(
+    boot_id: &str,
+    readopted: &[(String, MidWorkClass)],
+    left_dead: &[(String, String)],
+) -> Option<AppEvent> {
+    if readopted.is_empty() && left_dead.is_empty() {
+        return None;
+    }
+    let mut lines = Vec::new();
+    if !readopted.is_empty() {
+        lines.push(format!(
+            "Resuming: {}.",
+            readopted
+                .iter()
+                .map(|(id, class)| format!("{} ({})", short_id(id), class.label()))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    if !left_dead.is_empty() {
+        const DETAIL_CAP: usize = 8;
+        let mut detail = left_dead
+            .iter()
+            .take(DETAIL_CAP)
+            .map(|(id, reason)| format!("{} — {}", short_id(id), reason))
+            .collect::<Vec<_>>()
+            .join("; ");
+        if left_dead.len() > DETAIL_CAP {
+            detail.push_str(&format!(" (and {} more)", left_dead.len() - DETAIL_CAP));
+        }
+        lines.push(format!("Left as they were: {detail}."));
+    }
+    Some(AppEvent::UserNotification {
+        session_id: None,
+        id: format!("boot-readopt-{boot_id}"),
+        title: Some(format!(
+            "Crash recovery: {} session(s) readopted, {} left dead",
+            readopted.len(),
+            left_dead.len()
+        )),
+        text: lines.join(" "),
+        urgency: crate::types::NotificationUrgency::Attention,
+        ts: now_ms(),
+    })
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session_log::{SessionLimitParkMeta, SessionLog};
+
+    fn logs_root(home: &Path) -> PathBuf {
+        crate::platform::intendant_home_in(home).join("logs")
+    }
+
+    /// A wrapper log dir announcing its backend conversation — the same
+    /// eager-identity write live wrappers perform (meta + wrapper-index
+    /// row), borrowed from the resume-lineage tests.
+    fn announce(home: &Path, wrapper: &str, backend_id: &str) {
+        let mut log = SessionLog::open(logs_root(home).join(wrapper)).unwrap();
+        log.write_meta(None, None);
+        log.session_identity(wrapper, "claude-code", backend_id);
+    }
+
+    fn write_meta(
+        home: &Path,
+        session: &str,
+        status: &str,
+        limit_park: Option<SessionLimitParkMeta>,
+    ) {
+        let dir = logs_root(home).join(session);
+        std::fs::create_dir_all(&dir).unwrap();
+        let meta = serde_json::json!({
+            "session_id": session,
+            "created_at": "2026-07-28T00:00:00",
+            "status": status,
+            "limit_park": limit_park,
+        });
+        std::fs::write(
+            dir.join("session_meta.json"),
+            serde_json::to_string_pretty(&meta).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn now_secs() -> u64 {
+        crate::session_activity::epoch_seconds()
+    }
+
+    /// The enumeration takes only the DEAD boot's mid-work sessions:
+    /// a mid-turn (`running`) meta and a parked-with-pending meta are
+    /// candidates when their activity predates the boot watershed, and
+    /// NOTHING is a candidate when the watershed says the store's
+    /// activity belongs to the current boot.
+    #[test]
+    fn readopt_resumes_only_dead_boot_midwork() {
+        let home = tempfile::tempdir().unwrap();
+        write_meta(home.path(), "sess-midturn", "running", None);
+        write_meta(home.path(), "sess-idle", "idle", None);
+        write_meta(
+            home.path(),
+            "sess-parked",
+            "idle",
+            Some(SessionLimitParkMeta {
+                resets_at_epoch: Some(now_secs() + 600),
+                has_pending: true,
+            }),
+        );
+
+        // Watershed in the future: everything on disk predates it — the
+        // dead boot's era.
+        let live = HashSet::new();
+        let dead_era = scan_store_candidates(home.path(), u64::MAX, &live);
+        let ids: Vec<&str> = dead_era
+            .iter()
+            .map(|candidate| candidate.session_id.as_str())
+            .collect();
+        assert!(ids.contains(&"sess-midturn"), "mid-turn is mid-work");
+        assert!(ids.contains(&"sess-parked"), "parked-with-pending is mid-work");
+        assert!(!ids.contains(&"sess-idle"), "idle is not mid-work");
+        assert!(dead_era
+            .iter()
+            .all(|candidate| candidate.class != MidWorkClass::Agenda));
+
+        // Watershed at epoch zero: everything on disk is the CURRENT
+        // boot's era — a readopt pass must not touch live-boot sessions.
+        let current_era = scan_store_candidates(home.path(), 0, &live);
+        assert!(
+            current_era.is_empty(),
+            "current-boot sessions are never candidates: {current_era:?}"
+        );
+
+        // A live wrapper is excluded even when its meta says running.
+        let live: HashSet<String> = ["sess-midturn".to_string()].into_iter().collect();
+        let with_live = scan_store_candidates(home.path(), u64::MAX, &live);
+        assert!(
+            !with_live
+                .iter()
+                .any(|candidate| candidate.session_id == "sess-midturn"),
+            "a live wrapper is not a dead-boot session"
+        );
+    }
+
+    /// Idle in, idle out: `idle` and `completed` metas (and a park
+    /// marker without pending work) never become candidates.
+    #[test]
+    fn idle_sessions_stay_down() {
+        let home = tempfile::tempdir().unwrap();
+        write_meta(home.path(), "sess-idle", "idle", None);
+        write_meta(home.path(), "sess-done", "completed", None);
+        write_meta(
+            home.path(),
+            "sess-parked-nopending",
+            "idle",
+            Some(SessionLimitParkMeta {
+                resets_at_epoch: None,
+                has_pending: false,
+            }),
+        );
+        let candidates = scan_store_candidates(home.path(), u64::MAX, &HashSet::new());
+        assert!(
+            candidates.is_empty(),
+            "idle/done sessions stay down: {candidates:?}"
+        );
+    }
+
+    /// The automatic lane never stands a second wrapper beside an
+    /// admitted successor: a lineage whose index already shows an
+    /// active wrapper past the dead session is left dead.
+    #[test]
+    fn readopt_never_spawns_beside_live_successor() {
+        let home = tempfile::tempdir().unwrap();
+        announce(home.path(), "wrapper-dead", "b1-conv");
+        announce(home.path(), "wrapper-successor", "b1-conv");
+        let candidate = ReadoptCandidate {
+            session_id: "wrapper-dead".to_string(),
+            class: MidWorkClass::MidTurn,
+            suspended: false,
+            activity_secs: now_secs(),
+        };
+        match decide_candidate(home.path(), &candidate, now_secs()) {
+            ReadoptDecision::LeftDead(reason) => {
+                assert!(
+                    reason.contains("already continued"),
+                    "successor refusal names the cause: {reason}"
+                );
+            }
+            other => panic!("expected LeftDead beside a successor, got {other:?}"),
+        }
+    }
+
+    /// The nudge mirrors the reload-continuation shape: a short
+    /// continuation naming the cause — never a re-send of the original
+    /// goal — delivered as the resume's first message on the AUTOMATIC
+    /// lane (auto_attach ⇒ intent `Resume`: refuses owner-stopped and
+    /// retired lineages, never clears a tombstone).
+    #[test]
+    fn readopt_nudge_mirrors_reload_continuation() {
+        assert_eq!(
+            READOPT_CONTINUATION_TEXT,
+            "The daemon restarted mid-task — continue where you left off.",
+            "the nudge bytes are pinned"
+        );
+        let (_, reload_tail) = crate::external_mode::RELOAD_MIDTURN_CONTINUATION_TEXT
+            .split_once("—")
+            .expect("the reload continuation names cause — instruction");
+        let (_, readopt_tail) = READOPT_CONTINUATION_TEXT
+            .split_once("—")
+            .expect("the readopt continuation names cause — instruction");
+        assert_eq!(
+            readopt_tail, reload_tail,
+            "one continuation instruction, stated once, mirrored here"
+        );
+
+        let home = tempfile::tempdir().unwrap();
+        announce(home.path(), "wrapper-solo", "b2-conv");
+        let candidate = ReadoptCandidate {
+            session_id: "wrapper-solo".to_string(),
+            class: MidWorkClass::LimitPark,
+            suspended: false,
+            activity_secs: now_secs(),
+        };
+        match decide_candidate(home.path(), &candidate, now_secs()) {
+            ReadoptDecision::Readopt(resume) => match *resume {
+                ControlMsg::ResumeSession {
+                    source,
+                    session_id,
+                    task,
+                    fork,
+                    auto_attach,
+                    ..
+                } => {
+                    assert_eq!(source, "claude-code");
+                    assert_eq!(
+                        session_id, "b2-conv",
+                        "the backend conversation id is the display id, as the manual lane sends"
+                    );
+                    assert_eq!(
+                        task.as_deref(),
+                        Some(READOPT_CONTINUATION_TEXT),
+                        "the nudge is the first message — the goal is never re-sent"
+                    );
+                    assert!(!fork, "a readopt continues the thread, never forks it");
+                    assert!(auto_attach, "the automatic lane, so intent is `Resume`");
+                }
+                other => panic!("expected ResumeSession, got {other:?}"),
+            },
+            other => panic!("expected Readopt, got {other:?}"),
+        }
+    }
+
+    /// The guard ladder: a suspended series stays down (the streak law
+    /// is the crash-loop brake), an owner-stopped lineage stays down,
+    /// a native session has no resume lane, and stale sessions are
+    /// archaeology.
+    #[test]
+    fn readopt_respects_lease_and_suspension() {
+        let home = tempfile::tempdir().unwrap();
+        announce(home.path(), "wrapper-suspended", "b3-conv");
+        let suspended = ReadoptCandidate {
+            session_id: "wrapper-suspended".to_string(),
+            class: MidWorkClass::Agenda,
+            suspended: true,
+            activity_secs: now_secs(),
+        };
+        assert!(
+            matches!(
+                decide_candidate(home.path(), &suspended, now_secs()),
+                ReadoptDecision::LeftDead(reason) if reason.contains("suspended")
+            ),
+            "a suspended series is never stood back up"
+        );
+
+        announce(home.path(), "wrapper-stopped", "b4-conv");
+        crate::external_wrapper_index::record_user_stop(home.path(), "claude-code", "b4-conv")
+            .unwrap();
+        let stopped = ReadoptCandidate {
+            session_id: "wrapper-stopped".to_string(),
+            class: MidWorkClass::MidTurn,
+            suspended: false,
+            activity_secs: now_secs(),
+        };
+        assert!(
+            matches!(
+                decide_candidate(home.path(), &stopped, now_secs()),
+                ReadoptDecision::LeftDead(reason) if reason.contains("owner stopped")
+            ),
+            "an owner stop is terminal for the automatic lane"
+        );
+
+        let native = ReadoptCandidate {
+            session_id: "sess-native".to_string(),
+            class: MidWorkClass::MidTurn,
+            suspended: false,
+            activity_secs: now_secs(),
+        };
+        assert!(
+            matches!(
+                decide_candidate(home.path(), &native, now_secs()),
+                ReadoptDecision::LeftDead(reason) if reason.contains("no external resume lineage")
+            ),
+            "no recorded conversation ⇒ nothing to resume-attach"
+        );
+
+        announce(home.path(), "wrapper-stale", "b5-conv");
+        let stale = ReadoptCandidate {
+            session_id: "wrapper-stale".to_string(),
+            class: MidWorkClass::MidTurn,
+            suspended: false,
+            activity_secs: now_secs().saturating_sub(READOPT_MAX_AGE_SECS + 60),
+        };
+        assert!(
+            matches!(
+                decide_candidate(home.path(), &stale, now_secs()),
+                ReadoptDecision::LeftDead(reason) if reason.contains("stale")
+            ),
+            "stale sessions are archaeology, not crash recovery"
+        );
+
+        // The lease gate: a secondary daemon's pass sends nothing and
+        // notifies nothing — secondaries never readopt.
+        let state_root = tempfile::tempdir().unwrap();
+        let holder = crate::handover::HandoverRuntime::initialize(state_root.path(), 8765, 0);
+        assert!(holder.is_holder(), "first runtime on a root holds");
+        let secondary = crate::handover::HandoverRuntime::initialize(state_root.path(), 8766, 0);
+        assert!(!secondary.is_holder(), "second runtime is a secondary");
+        let bus = crate::event::EventBus::new();
+        let mut events = bus.subscribe();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap();
+        runtime.block_on(run_boot_readopt_pass(
+            home.path().to_path_buf(),
+            bus.clone(),
+            std::sync::Arc::new(secondary),
+            true,
+        ));
+        assert!(
+            events.try_recv().is_err(),
+            "a secondary readopts nothing and stays silent"
+        );
+    }
+
+    /// The pass is visible and summarized: one sessionless notification
+    /// carrying resumed/left-dead counts and reasons — and silence when
+    /// nothing was mid-work.
+    #[test]
+    fn readopt_is_visible_and_summarized() {
+        assert!(
+            summary_notification("boot-a", &[], &[]).is_none(),
+            "a clean boot stays silent"
+        );
+        let readopted = vec![
+            ("aaaaaaaa-1111".to_string(), MidWorkClass::MidTurn),
+            ("bbbbbbbb-2222".to_string(), MidWorkClass::Agenda),
+        ];
+        let left_dead = vec![(
+            "cccccccc-3333".to_string(),
+            "owner stopped this lineage".to_string(),
+        )];
+        match summary_notification("boot-a", &readopted, &left_dead) {
+            Some(AppEvent::UserNotification {
+                session_id,
+                id,
+                title,
+                text,
+                ..
+            }) => {
+                assert_eq!(session_id, None, "a daemon-level notification");
+                assert_eq!(id, "boot-readopt-boot-a", "boot-keyed, so repeats never stack");
+                let title = title.expect("titled");
+                assert!(
+                    title.contains("2 session(s) readopted") && title.contains("1 left dead"),
+                    "the counts lead: {title}"
+                );
+                assert!(
+                    text.contains("aaaaaaaa") && text.contains("mid-turn"),
+                    "resumed sessions are named with their class: {text}"
+                );
+                assert!(
+                    text.contains("cccccccc") && text.contains("owner stopped"),
+                    "left-dead sessions carry their reasons: {text}"
+                );
+            }
+            other => panic!("expected one UserNotification, got {other:?}"),
+        }
+    }
+
+    /// The knob and its env override: config default ON, env wins in
+    /// both directions.
+    #[test]
+    fn readopt_knob_env_override() {
+        let _guard = crate::test_support::TEST_ENV_LOCK.blocking_lock();
+        let restore = std::env::var("INTENDANT_BOOT_READOPT").ok();
+        std::env::remove_var("INTENDANT_BOOT_READOPT");
+        assert!(readopt_enabled(true));
+        assert!(!readopt_enabled(false));
+        std::env::set_var("INTENDANT_BOOT_READOPT", "0");
+        assert!(!readopt_enabled(true), "env off beats config on");
+        std::env::set_var("INTENDANT_BOOT_READOPT", "1");
+        assert!(readopt_enabled(false), "env on beats config off");
+        match restore {
+            Some(value) => std::env::set_var("INTENDANT_BOOT_READOPT", value),
+            None => std::env::remove_var("INTENDANT_BOOT_READOPT"),
+        }
+    }
+}
+
+/// Whether the pass is enabled: the intendant.toml knob, overridable by
+/// `INTENDANT_BOOT_READOPT` (`0`/`false`/`off` disable, anything else
+/// enables). The env read happens once here at the transport edge —
+/// everything below takes the resolved bool.
+pub(crate) fn readopt_enabled(config_enabled: bool) -> bool {
+    match std::env::var("INTENDANT_BOOT_READOPT") {
+        Ok(raw) => !matches!(
+            raw.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "off" | "no"
+        ),
+        Err(_) => config_enabled,
+    }
+}
+
+/// The boot pass. Spawned by the daemon branch after the session
+/// supervisor is subscribed (sends land in the intent lane, never the
+/// void). Holder-gated: secondaries never readopt; a draining daemon
+/// never spawns work.
+pub(crate) async fn run_boot_readopt_pass(
+    home: PathBuf,
+    bus: EventBus,
+    handover: std::sync::Arc<HandoverRuntime>,
+    enabled: bool,
+) {
+    if !enabled {
+        eprintln!("[readopt] disabled by configuration — dead-boot sessions stay down");
+        return;
+    }
+    if handover.is_draining() {
+        return;
+    }
+    if !handover.is_holder() {
+        eprintln!(
+            "[readopt] not the scheduler-lease holder — secondaries never readopt; \
+             dead-boot sessions stay down"
+        );
+        return;
+    }
+    // Ordering: the agenda scheduler's boot recovery classifies the dead
+    // boot's rows first; its classification output is this pass's agenda
+    // class. A quiet scheduler (disabled, journal unavailable) times out
+    // into the store classes alone.
+    let seeds = await_agenda_readopt_seeds(AGENDA_SEED_WAIT).await;
+    for seed in &seeds {
+        eprintln!(
+            "[readopt] agenda occurrence {} was mid-work in session {}{}",
+            seed.occurrence_id,
+            short_id(&seed.session_id),
+            if seed.suspended {
+                " (series suspended)"
+            } else {
+                ""
+            }
+        );
+    }
+    let Some(watershed) = boot_watershed_secs(handover.state_root(), handover.boot_id()) else {
+        eprintln!("[readopt] no presence record for this boot — cannot draw the era line; skipping");
+        return;
+    };
+    let live: HashSet<String> = crate::session_supervisor::published_live_session_registry()
+        .and_then(|registry| registry.live_wrapper_ids())
+        .unwrap_or_default();
+    let store = scan_store_candidates(&home, watershed, &live);
+    let mut candidates = merge_candidates(&seeds, store);
+    // Merged agenda-only seeds carry no activity line yet — resolve it
+    // from the store so the staleness guard judges them fairly.
+    for candidate in &mut candidates {
+        if candidate.activity_secs == 0 {
+            if let Some(dir) = crate::session_log::SessionLog::find_session_by_id_in_home(
+                &home,
+                &candidate.session_id,
+            ) {
+                candidate.activity_secs = activity_mtime_secs(&dir);
+            }
+        }
+    }
+    if candidates.is_empty() {
+        return;
+    }
+    let now_secs = crate::session_activity::epoch_seconds();
+    let mut readopted: Vec<(String, MidWorkClass)> = Vec::new();
+    let mut left_dead: Vec<(String, String)> = Vec::new();
+    for candidate in candidates {
+        if readopted.len() >= READOPT_MAX_PER_BOOT {
+            left_dead.push((
+                candidate.session_id,
+                format!("per-boot readopt cap ({READOPT_MAX_PER_BOOT}) reached"),
+            ));
+            continue;
+        }
+        match decide_candidate(&home, &candidate, now_secs) {
+            ReadoptDecision::Readopt(resume) => {
+                eprintln!(
+                    "[readopt] resuming {} ({}) after the daemon restart",
+                    short_id(&candidate.session_id),
+                    candidate.class.label()
+                );
+                bus.send(AppEvent::ControlCommand(*resume));
+                readopted.push((candidate.session_id, candidate.class));
+            }
+            ReadoptDecision::LeftDead(reason) => {
+                eprintln!(
+                    "[readopt] leaving {} dead: {reason}",
+                    short_id(&candidate.session_id)
+                );
+                left_dead.push((candidate.session_id, reason));
+            }
+        }
+    }
+    if let Some(notification) = summary_notification(handover.boot_id(), &readopted, &left_dead) {
+        bus.send(notification);
+    }
+}

--- a/src/bin/caller/boot_readopt.rs
+++ b/src/bin/caller/boot_readopt.rs
@@ -94,12 +94,17 @@ pub(crate) struct AgendaReadoptSeed {
 /// The boot classification handoff slot: the scheduler's boot slot
 /// publishes exactly once per process; the readopt pass consumes it.
 /// (A channel in disguise — the scheduler task is spawned long before
-/// the readopt task exists, so a published slot is the simplest safe
-/// handoff, mirroring `publish_agenda_handle`.)
+/// the readopt task exists, so a published slot plus a wake is the
+/// simplest safe handoff, mirroring `publish_agenda_handle`.)
 static AGENDA_SEEDS: OnceLock<Mutex<Option<Vec<AgendaReadoptSeed>>>> = OnceLock::new();
+static AGENDA_SEEDS_READY: OnceLock<tokio::sync::Notify> = OnceLock::new();
 
 fn agenda_seed_slot() -> &'static Mutex<Option<Vec<AgendaReadoptSeed>>> {
     AGENDA_SEEDS.get_or_init(|| Mutex::new(None))
+}
+
+fn agenda_seeds_ready() -> &'static tokio::sync::Notify {
+    AGENDA_SEEDS_READY.get_or_init(tokio::sync::Notify::new)
 }
 
 /// Publish the boot recovery classification (agenda scheduler boot slot
@@ -109,11 +114,15 @@ pub(crate) fn publish_agenda_readopt_seeds(seeds: Vec<AgendaReadoptSeed>) {
     *agenda_seed_slot()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(seeds);
+    agenda_seeds_ready().notify_waiters();
 }
 
 async fn await_agenda_readopt_seeds(timeout: std::time::Duration) -> Vec<AgendaReadoptSeed> {
     let deadline = tokio::time::Instant::now() + timeout;
     loop {
+        // Register the waiter BEFORE checking the slot: a publish landing
+        // between the check and the await still wakes us.
+        let notified = agenda_seeds_ready().notified();
         if let Some(seeds) = agenda_seed_slot()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
@@ -121,10 +130,9 @@ async fn await_agenda_readopt_seeds(timeout: std::time::Duration) -> Vec<AgendaR
         {
             return seeds;
         }
-        if tokio::time::Instant::now() >= deadline {
+        if tokio::time::timeout_at(deadline, notified).await.is_err() {
             return Vec::new();
         }
-        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
     }
 }
 

--- a/src/bin/caller/boot_readopt.rs
+++ b/src/bin/caller/boot_readopt.rs
@@ -257,7 +257,7 @@ pub(crate) fn scan_store_candidates(
     }
     // Newest first, so the per-boot cap spends its slots on the most
     // recently active work.
-    candidates.sort_by(|a, b| b.activity_secs.cmp(&a.activity_secs));
+    candidates.sort_by_key(|candidate| std::cmp::Reverse(candidate.activity_secs));
     candidates
 }
 
@@ -339,9 +339,11 @@ pub(crate) fn decide_candidate(
             short_id(&tip.intendant_session_id)
         ));
     }
-    let project_root =
-        crate::external_wrapper_index::recorded_project_root_for_wrapper(home, &candidate.session_id)
-            .map(PathBuf::from);
+    let project_root = crate::external_wrapper_index::recorded_project_root_for_wrapper(
+        home,
+        &candidate.session_id,
+    )
+    .map(PathBuf::from);
     if let Some(root) = &project_root {
         if !root.is_dir() {
             return ReadoptDecision::LeftDead(format!(
@@ -507,7 +509,10 @@ mod tests {
             .map(|candidate| candidate.session_id.as_str())
             .collect();
         assert!(ids.contains(&"sess-midturn"), "mid-turn is mid-work");
-        assert!(ids.contains(&"sess-parked"), "parked-with-pending is mid-work");
+        assert!(
+            ids.contains(&"sess-parked"),
+            "parked-with-pending is mid-work"
+        );
         assert!(!ids.contains(&"sess-idle"), "idle is not mid-work");
         assert!(dead_era
             .iter()
@@ -759,7 +764,10 @@ mod tests {
                 ..
             }) => {
                 assert_eq!(session_id, None, "a daemon-level notification");
-                assert_eq!(id, "boot-readopt-boot-a", "boot-keyed, so repeats never stack");
+                assert_eq!(
+                    id, "boot-readopt-boot-a",
+                    "boot-keyed, so repeats never stack"
+                );
                 let title = title.expect("titled");
                 assert!(
                     title.contains("2 session(s) readopted") && title.contains("1 left dead"),
@@ -854,7 +862,9 @@ pub(crate) async fn run_boot_readopt_pass(
         );
     }
     let Some(watershed) = boot_watershed_secs(handover.state_root(), handover.boot_id()) else {
-        eprintln!("[readopt] no presence record for this boot — cannot draw the era line; skipping");
+        eprintln!(
+            "[readopt] no presence record for this boot — cannot draw the era line; skipping"
+        );
         return;
     };
     let live: HashSet<String> = crate::session_supervisor::published_live_session_registry()

--- a/src/bin/caller/external_mode.rs
+++ b/src/bin/caller/external_mode.rs
@@ -156,6 +156,7 @@ async fn apply_backend_credentials_reload(
     };
     if let Some(park) = limit_park.take() {
         *limit_park_streak = 0;
+        slog(session_log, |l| l.set_limit_park(None));
         if let Some(pending) = park.pending {
             // Front of the queue: the parked re-send delivers first, then
             // everything queued while parked, oldest first.
@@ -794,6 +795,7 @@ pub(crate) async fn run_external_agent_mode(
                             .unwrap_or_else(tokio::time::Instant::now)
                     ), if limit_park.is_some() => {
                         let park = limit_park.take().expect("branch guarded by is_some");
+                        slog(&session_log, |l| l.set_limit_park(None));
                         match park.pending {
                             Some(pending)
                                 if !follow_up_message_was_cancelled(
@@ -1757,6 +1759,7 @@ pub(crate) async fn run_external_agent_mode(
                                 // park stay queued and flush normally).
                                 if let Some(park) = limit_park.take() {
                                     limit_park_streak = 0;
+                                    slog(&session_log, |l| l.set_limit_park(None));
                                     let line = if park.pending.is_some() {
                                         "Rate-limit park cancelled by interrupt — dropped the pending re-send"
                                     } else {
@@ -3469,6 +3472,15 @@ pub(crate) async fn run_external_agent_mode(
                 limit_park = Some(LimitParkState {
                     resume_at: tokio::time::Instant::now() + delay,
                     pending: Some(limit_park_pending(pending, turn_had_started)),
+                });
+                // Durable park marker: the in-memory park dies with the
+                // daemon, and the boot auto-readopt pass needs to know a
+                // dead boot's wrapper still owed its parked re-send.
+                slog(&session_log, |l| {
+                    l.set_limit_park(Some(crate::session_log::SessionLimitParkMeta {
+                        resets_at_epoch,
+                        has_pending: true,
+                    }))
                 });
             }
             DrainOutcome::ContextRewindRequested {

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -11,6 +11,7 @@ pub(crate) use intendant_core::autonomy;
 #[cfg(target_os = "macos")]
 mod ax;
 mod background_tasks;
+mod boot_readopt;
 mod browser_workspace;
 #[path = "../../build_info.rs"]
 mod build_info;

--- a/src/bin/caller/project.rs
+++ b/src/bin/caller/project.rs
@@ -93,6 +93,32 @@ pub struct ExperimentalConfig {
     pub cu_first_routing: bool,
 }
 
+/// `[readopt]` in intendant.toml: the boot auto-readopt pass — at
+/// daemon boot, the dead boot's mid-work sessions (started-without-
+/// terminal agenda occurrences, mid-turn interruptions, limit-parked
+/// wrappers with pending work) are resume-attached under fresh wrappers
+/// with a continuation nudge. See `boot_readopt`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReadoptConfig {
+    /// Default ON — crash recovery is the daemon's job. `enabled =
+    /// false` (or `INTENDANT_BOOT_READOPT=0`) leaves dead-boot sessions
+    /// down for the owner to resume by hand.
+    #[serde(default = "default_readopt_enabled")]
+    pub enabled: bool,
+}
+
+impl Default for ReadoptConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_readopt_enabled(),
+        }
+    }
+}
+
+fn default_readopt_enabled() -> bool {
+    true
+}
+
 /// `[integrations]` in intendant.toml — non-secret configuration for
 /// external service integrations. Credentials never live here: the
 /// GitHub App key and ids are sealed in OS-keystore custody
@@ -887,6 +913,10 @@ pub struct ProjectConfig {
     /// configuration (watch lists, cadences). See [`IntegrationsConfig`].
     #[serde(default)]
     pub integrations: IntegrationsConfig,
+    /// `[readopt]` section — the boot auto-readopt pass (default ON).
+    /// See [`ReadoptConfig`].
+    #[serde(default)]
+    pub readopt: ReadoptConfig,
     /// `[server]` section in intendant.toml — daemon-level settings
     /// for what this Intendant advertises to peers. See [`ServerConfig`].
     #[serde(default)]

--- a/src/bin/caller/session_log/mod.rs
+++ b/src/bin/caller/session_log/mod.rs
@@ -107,6 +107,30 @@ pub struct SessionMeta {
     /// session-end finish card, and the merge endpoint all derive from.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub worktree: Option<SessionWorktreeMeta>,
+    /// Durable trace of a live rate-limit park: written when the wrapper
+    /// parks on a provider limit, cleared when the park releases or is
+    /// cancelled. The in-memory park state dies with the daemon, so a
+    /// session still wearing this marker after a boot was limit-parked
+    /// with work owed when its daemon died — the boot auto-readopt
+    /// pass's "limit-parked mid-work" class. Additive: metas written
+    /// before 2026-07 lack it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit_park: Option<SessionLimitParkMeta>,
+}
+
+/// A parked rate-limit wait recorded durably (see
+/// [`SessionMeta::limit_park`]).
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct SessionLimitParkMeta {
+    /// The provider-stated reset instant the park targets, when the
+    /// rejection carried one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resets_at_epoch: Option<u64>,
+    /// Whether the park holds a pending re-send/nudge — work still owed
+    /// at the reset (parks always do today; the field keeps the marker
+    /// honest if a pending-less park shape returns).
+    #[serde(default)]
+    pub has_pending: bool,
 }
 
 /// Worktree linkage recorded on a session (see [`SessionMeta::worktree`]).
@@ -617,9 +641,9 @@ impl SessionLog {
         let existing = fs::read_to_string(self.dir.join("session_meta.json"))
             .ok()
             .and_then(|raw| serde_json::from_str::<SessionMeta>(&raw).ok());
-        let (existing_name, existing_worktree) = existing
-            .map(|meta| (meta.name, meta.worktree))
-            .unwrap_or((None, None));
+        let (existing_name, existing_worktree, existing_limit_park) = existing
+            .map(|meta| (meta.name, meta.worktree, meta.limit_park))
+            .unwrap_or((None, None, None));
         let meta = SessionMeta {
             session_id: self.session_id.clone(),
             created_at: Local::now().format("%Y-%m-%dT%H:%M:%S").to_string(),
@@ -634,6 +658,10 @@ impl SessionLog {
             // Worktree linkage is written once at launch and survives every
             // later meta rewrite (resume, rename), like the session name.
             worktree: existing_worktree,
+            // Park transitions alone touch the marker; a meta rewrite
+            // mid-park (a credential-reload respawn's write_meta) must
+            // not silently release it.
+            limit_park: existing_limit_park,
         };
         if let Ok(json) = serde_json::to_string_pretty(&meta) {
             if let Err(e) = write_session_meta_atomic(&self.dir, &json) {
@@ -657,6 +685,29 @@ impl SessionLog {
             return;
         };
         meta.worktree = Some(worktree.clone());
+        if let Ok(json) = serde_json::to_string_pretty(&meta) {
+            if let Err(e) = write_session_meta_atomic(&self.dir, &json) {
+                eprintln!("session_log: failed to write session_meta.json: {}", e);
+            }
+        }
+    }
+
+    /// Record (or clear) the durable rate-limit-park marker in
+    /// `session_meta.json` (see [`SessionMeta::limit_park`]). Missing or
+    /// unreadable meta is a quiet no-op: the marker is best-effort
+    /// recovery evidence, never worth failing a park transition over.
+    pub fn set_limit_park(&self, park: Option<SessionLimitParkMeta>) {
+        let meta_path = self.dir.join("session_meta.json");
+        let Some(mut meta) = fs::read_to_string(&meta_path)
+            .ok()
+            .and_then(|raw| serde_json::from_str::<SessionMeta>(&raw).ok())
+        else {
+            return;
+        };
+        if meta.limit_park == park {
+            return;
+        }
+        meta.limit_park = park;
         if let Ok(json) = serde_json::to_string_pretty(&meta) {
             if let Err(e) = write_session_meta_atomic(&self.dir, &json) {
                 eprintln!("session_log: failed to write session_meta.json: {}", e);
@@ -1750,6 +1801,7 @@ mod tests {
             role: None,
             rounds: None,
             worktree: None,
+            limit_park: None,
         };
         fs::write(
             log_dir.join("session_meta.json"),
@@ -1859,6 +1911,7 @@ mod tests {
             role: None,
             rounds: None,
             worktree: None,
+            limit_park: None,
         };
         fs::write(
             s1_dir.join("session_meta.json"),
@@ -1880,6 +1933,7 @@ mod tests {
             role: None,
             rounds: None,
             worktree: None,
+            limit_park: None,
         };
         fs::write(
             s2_dir.join("session_meta.json"),
@@ -1942,6 +1996,7 @@ mod tests {
             role: None,
             rounds: None,
             worktree: None,
+            limit_park: None,
         };
         fs::write(
             log_dir.join("session_meta.json"),

--- a/src/bin/caller/session_vitals.rs
+++ b/src/bin/caller/session_vitals.rs
@@ -2917,6 +2917,7 @@ mod tests {
                 base_branch: None,
                 base_sha: None,
             }),
+            limit_park: None,
         };
         let meta_path = dir.join("session_meta.json");
         std::fs::write(&meta_path, serde_json::to_string_pretty(&meta).unwrap()).unwrap();

--- a/src/bin/caller/startup/daemon.rs
+++ b/src/bin/caller/startup/daemon.rs
@@ -261,6 +261,24 @@ pub(crate) async fn run_daemon(
             codex_context_archive: None,
         }));
     }
+    // Boot auto-readopt: resume the dead boot's mid-work sessions
+    // (started-without-terminal occurrences, mid-turn interruptions,
+    // limit-parked wrappers) under fresh wrappers with a continuation
+    // nudge. Spawned AFTER the supervisor subscribes (same ordering law
+    // as the resume block above); the pass itself waits for the agenda
+    // scheduler's boot recovery classification and gates on lease
+    // holdership, so a secondary daemon never readopts.
+    {
+        let readopt_enabled = crate::boot_readopt::readopt_enabled(project.config.readopt.enabled);
+        let readopt_bus = startup_bus.clone();
+        let readopt_handover = gateway.handover.clone();
+        tokio::spawn(crate::boot_readopt::run_boot_readopt_pass(
+            crate::platform::home_dir(),
+            readopt_bus,
+            readopt_handover,
+            readopt_enabled,
+        ));
+    }
     let _ = supervisor_handle.await;
     Ok(())
 }


### PR DESCRIPTION
## What

At boot, after the agenda scheduler's HS2-scoped recovery classifies the dead boot's rows, a new **auto-readopt pass** enumerates the sessions that were mid-work and resume-attaches each under a fresh wrapper with a synthesized continuation nudge — the automated version of the owner's manual post-crash 'proceed' (specimen recorded in the 2026-07-28 session census, Ghost-flag incident section).

**Mid-work is three durable shapes** (idle in, idle out — everything else stays down):
- **agenda**: started-without-terminal occurrences — the boot recovery classification output, handed to the pass via a published seed slot;
- **mid-turn**: `session_meta.json` status `running` (crash) / `interrupted` (signal shutdown mid-turn);
- **limit-park**: a new durable `limit_park` meta marker written at park-arm and cleared at release/cancel (the in-memory park state dies with the daemon — previously only a prose warn line survived).

**Guards (all existing machinery, reused not re-derived):** lease holdership (secondaries never readopt) + drain; the automatic resume lane (`auto_attach` ⇒ `WrapperLineageIntent::Resume` — refuses owner-stopped and retired lineages, routes to live wrappers, launch-reservation single-winner; never the tombstone-clearing `Revive`); durable successor-tip via the shared `resolve_resume_lineage` (never beside an admitted successor); suspension (the unknown-streak law is the crash-loop brake: each crash cycle costs one `unknown` until a completion resets; a crash-looping series suspends and stays down); staleness bound; per-boot cap.

**Occurrence follow (#627 shape, boot edition):** the scheduler parks a lineage watch per fail-closed row; when a successor is admitted within a 15-minute window (the readopt pass's, or a manual post-crash resume), it journals a fresh `started` row naming the successor — with a new fold law: **a later `started` re-opens a terminaled occurrence** — re-arming the item's no-overlap hold and tracking the successor so its terminal classifies normally. When no readopt materializes the journal stays exactly as fail-closed as today (RFC §7.5).

**Visible:** one sessionless notification per boot with candidates ("N readopted, M left dead" + per-session reasons, detail-capped); silence on clean boots. Each readopted card continues the same backend-keyed conversation, so lineage shows as it does for manual resumes.

**Knob:** `[readopt] enabled = true` (default ON) in intendant.toml; `INTENDANT_BOOT_READOPT=0/1` overrides both ways.

## Conformance pins (mandated names)
`readopt_resumes_only_dead_boot_midwork` · `readopt_never_spawns_beside_live_successor` · `readopt_nudge_mirrors_reload_continuation` · `readopt_respects_lease_and_suspension` · `readopt_is_visible_and_summarized` · `idle_sessions_stay_down` — plus `started_reopens_a_terminaled_occurrence` (fold law), `boot_recovery_hands_readopt_seeds_and_watches`, `readopt_watch_rekeys_to_admitted_successor`, `readopt_watch_expires_and_respects_owner_stop`, `readopt_knob_env_override`.

Fired from agenda item 01KYNSS7KHQP4N88H9ZJX1D383.