### PR TITLE
fix(external): backend-started limit rejections arm a real park

### DIFF
--- a/docs/src/external-agent-orchestration.md
+++ b/docs/src/external-agent-orchestration.md
@@ -1066,6 +1066,17 @@ persistent-daemon lane apply the same `external_supervision.rs` policy:
   make the backend re-read its whole mandate. The nudge inherits the rejected
   message's follow-up/steer ids, so cancelling it while parked works exactly
   like cancelling a full resend.
+- Backend-started rounds — a turn the backend opened itself while the lane
+  sat idle (its own background task completing, a native wake) — park through
+  the same policy (`backend_started_limit_park`). There is no driving message
+  on the supervisor's side to resend, so the park pends the resume nudge when
+  the turn had started and nothing when the rejection arrived before any
+  work; the reset timer and queue-while-parked behavior arm either way. The
+  constructor returns the armed park and its announcement line as one value,
+  so a session-log row claiming "parked" always has a live park behind it
+  (before 2026-07-29 this lane logged the line and armed nothing — the
+  session idled forever with its interrupted work lost, and a credential
+  reload found nothing to resume).
 - If the wire supplied `resetsAt`, the pending message is resent after that
   instant plus 30–90 seconds of jitter; any one sleep is capped at six hours
   so long windows are rechecked. Without a reset time, consecutive rejections
@@ -1081,8 +1092,11 @@ persistent-daemon lane apply the same `external_supervision.rs` policy:
 - An out-of-band `compact` action is refused with the reset-time explanation
   while a park is armed; request it again after the reset.
 
-The park is an in-memory session-lane state, not a durable scheduler. Activity
-and session-log rows make the pause, queued messages, cancellation, and resend
+The park timer is in-memory session-lane state, not a durable scheduler; the
+supervised external-mode lane additionally stamps a durable `limit_park`
+marker on the session meta (cleared on release/cancel) so boot auto-readopt
+can tell a daemon died mid-park with work still owed. Activity and
+session-log rows make the pause, queued messages, cancellation, and resend
 visible.
 
 ## Dashboard and Station parity

--- a/src/bin/caller/external_mode.rs
+++ b/src/bin/caller/external_mode.rs
@@ -1227,22 +1227,48 @@ pub(crate) async fn run_external_agent_mode(
                                                 });
                                             }
                                             DrainOutcome::LimitRejected {
-                                                resets_at_epoch, ..
+                                                resets_at_epoch,
+                                                message: _,
+                                                turn_had_started,
                                             } => {
                                                 // A backend-started round
                                                 // ended limit-rejected:
-                                                // nothing to re-send and no
-                                                // round to count — log and
-                                                // return to idle. (A later
-                                                // user message that gets
-                                                // rejected parks properly
-                                                // with itself as pending.)
+                                                // hand the round number
+                                                // back and arm a REAL park.
+                                                // This arm used to log
+                                                // "parked" while arming
+                                                // nothing (2026-07-29,
+                                                // sessions 379864df/
+                                                // a43b7f32): the reset
+                                                // never woke them, the
+                                                // credential reload's
+                                                // park-cancel found nothing
+                                                // to resume, and their
+                                                // interrupted work was
+                                                // silently lost. No driving
+                                                // message exists to re-send
+                                                // — the pending is the
+                                                // resume nudge when the
+                                                // backend had started the
+                                                // turn — and both the reset
+                                                // timer and the reload's
+                                                // cancel-and-preserve now
+                                                // resume this lane through
+                                                // the same paths as the
+                                                // follow-up lane's parks.
                                                 round = round.saturating_sub(1);
-                                                let park_line = limit_park_log_line(
-                                                    resets_at_epoch,
-                                                    crate::session_activity::epoch_seconds(),
-                                                    false,
-                                                );
+                                                limit_park_streak =
+                                                    limit_park_streak.saturating_add(1);
+                                                let (park, park_line) =
+                                                    backend_started_limit_park(
+                                                        resets_at_epoch,
+                                                        tokio::time::Instant::now(),
+                                                        crate::session_activity::epoch_seconds(),
+                                                        limit_park_streak,
+                                                        limit_park_jitter_secs(),
+                                                        turn_had_started,
+                                                    );
+                                                let has_pending = park.pending.is_some();
                                                 slog(&session_log, |l| l.warn(&park_line));
                                                 bus.send(AppEvent::LogEntry {
                                                     session_id: live_session_id.clone(),
@@ -1250,6 +1276,32 @@ pub(crate) async fn run_external_agent_mode(
                                                     source: "Intendant".to_string(),
                                                     content: park_line,
                                                     turn: None,
+                                                });
+                                                emit_external_turn_status(
+                                                    &bus,
+                                                    &autonomy,
+                                                    live_session_id.as_deref(),
+                                                    round.saturating_add(1),
+                                                    "waiting-rate-limit",
+                                                    format!(
+                                                        "{} rate-limited; parked until the limit resets",
+                                                        agent.name()
+                                                    ),
+                                                )
+                                                .await;
+                                                limit_park = Some(park);
+                                                // Durable marker: mirrors
+                                                // the follow-up arm, so a
+                                                // daemon death mid-park
+                                                // leaves the boot
+                                                // auto-readopt trace.
+                                                slog(&session_log, |l| {
+                                                    l.set_limit_park(Some(
+                                                        crate::session_log::SessionLimitParkMeta {
+                                                            resets_at_epoch,
+                                                            has_pending,
+                                                        },
+                                                    ))
                                                 });
                                             }
                                             DrainOutcome::ContextRewindRequested {
@@ -2679,18 +2731,28 @@ pub(crate) async fn run_external_agent_mode(
                             // The in-flight turn ended rejected at the
                             // provider limit; no round to record. The turn
                             // is over, so the user's edit rollback below
-                            // proceeds like any completed turn.
-                            let park_line = limit_park_log_line(
-                                resets_at_epoch,
-                                crate::session_activity::epoch_seconds(),
-                                false,
+                            // proceeds like any completed turn — and
+                            // deliberately WITHOUT a park: the edit rewinds
+                            // past the rejected turn, so a resume nudge
+                            // would re-drive work the user just superseded.
+                            // The edited message delivers next and parks
+                            // properly through the primary arm if the limit
+                            // still holds. The line must not claim "parked"
+                            // (a parked claim with nothing armed is the
+                            // silent-loss bug class).
+                            let line = format!(
+                                "Rate-limited — the in-flight turn was rejected; {}; proceeding with the edit rollback",
+                                external_agent::limit_reset_phrase(
+                                    resets_at_epoch,
+                                    crate::session_activity::epoch_seconds(),
+                                ),
                             );
-                            slog(&session_log, |l| l.warn(&park_line));
+                            slog(&session_log, |l| l.warn(&line));
                             bus.send(AppEvent::LogEntry {
                                 session_id: live_session_id.clone(),
                                 level: "warn".to_string(),
                                 source: "Intendant".to_string(),
-                                content: park_line,
+                                content: line,
                                 turn: None,
                             });
                         }

--- a/src/bin/caller/external_supervision.rs
+++ b/src/bin/caller/external_supervision.rs
@@ -1577,6 +1577,44 @@ pub(crate) fn limit_park_log_line(
     )
 }
 
+/// The park a BACKEND-STARTED round arms when a provider limit rejects
+/// it — the observed-from-idle lane in the supervised external-mode loop
+/// and the spontaneous-round lane in the persistent daemon lane. No
+/// driving message from this side exists to re-send (the backend woke
+/// itself: its own background task, a native timer), so the pending is
+/// the delivery-aware resume nudge when the turn had started and nothing
+/// when the rejection arrived before any work; either way the armed
+/// timer wakes the lane at reset and messages arriving meanwhile queue
+/// instead of burning against the rejected backend.
+///
+/// Returning the armed state TOGETHER with its announcement line is the
+/// point: these arms used to log "parked" while arming nothing (live
+/// 2026-07-29, sessions 379864df/a43b7f32 — the reset never woke them,
+/// the credential reload's park-cancel found nothing to resume, and
+/// their interrupted work was silently lost). A caller of this
+/// constructor cannot log the line without holding the park it
+/// announces, and the line's `has_pending` flavor is derived from the
+/// pending it ships with, so the two can never diverge.
+pub(crate) fn backend_started_limit_park(
+    resets_at_epoch: Option<u64>,
+    now: tokio::time::Instant,
+    now_epoch: u64,
+    streak: u32,
+    jitter_secs: u64,
+    turn_had_started: bool,
+) -> (LimitParkState, String) {
+    let delay = limit_park_delay(resets_at_epoch, now_epoch, streak, jitter_secs);
+    let pending = midturn_continuation(LIMIT_MIDTURN_CONTINUATION_TEXT, turn_had_started);
+    let park_line = limit_park_log_line(resets_at_epoch, now_epoch, pending.is_some());
+    (
+        LimitParkState {
+            resume_at: now + delay,
+            pending,
+        },
+        park_line,
+    )
+}
+
 /// The queued-while-parked row for a user follow-up held during a park.
 pub(crate) const LIMIT_PARK_QUEUED_MESSAGE_LOG: &str =
     "Message queued — delivers when the limit resets";
@@ -1772,6 +1810,132 @@ mod tests {
         assert_eq!(nudge.text, LIMIT_MIDTURN_CONTINUATION_TEXT);
         assert!(nudge.follow_up_id.is_none());
         assert!(nudge.steer_id.is_none());
+    }
+
+    /// Pin `backend_started_limit_arms_real_park`: a backend-started
+    /// round rejected at the provider limit arms a REAL
+    /// [`LimitParkState`] — resume-nudge pending when the turn had
+    /// started, a pending-less park (timer and queueing still armed)
+    /// when it never did. The 2026-07-29 incident class logged "parked"
+    /// from this lane while arming nothing, so neither the reset timer
+    /// nor the credential reload could ever resume the session.
+    #[tokio::test]
+    async fn backend_started_limit_arms_real_park() {
+        let now = tokio::time::Instant::now();
+        let now_epoch = 1_000;
+        let resets_at = Some(now_epoch + 3_600);
+
+        let (park, _line) = backend_started_limit_park(resets_at, now, now_epoch, 1, 30, true);
+        let pending = park.pending.as_ref().expect("started turn parks a nudge");
+        assert_eq!(pending.text, LIMIT_MIDTURN_CONTINUATION_TEXT);
+        assert!(pending.follow_up_id.is_none());
+        assert!(pending.steer_id.is_none());
+        assert_eq!(
+            park.resume_at,
+            now + limit_park_delay(resets_at, now_epoch, 1, 30)
+        );
+
+        // A rejection observed before any work still arms the park — no
+        // work is owed at reset, but the timer wakes the lane and
+        // messages arriving meanwhile queue instead of burning.
+        let (park, _line) = backend_started_limit_park(resets_at, now, now_epoch, 1, 30, false);
+        assert!(park.pending.is_none());
+        assert_eq!(
+            park.resume_at,
+            now + limit_park_delay(resets_at, now_epoch, 1, 30)
+        );
+    }
+
+    /// Pin `parked_log_line_implies_armed_state`: the constructor is the
+    /// unity seam — the "parked" announcement exists only as the second
+    /// half of a `(park, line)` pair, and the line's `has_pending`
+    /// flavor is derived from the pending the park actually ships with.
+    /// A log row claiming "parked" with nothing armed (the silent-loss
+    /// bug class) cannot be constructed through this seam.
+    #[tokio::test]
+    async fn parked_log_line_implies_armed_state() {
+        let now = tokio::time::Instant::now();
+        let now_epoch = 1_000;
+        let resets_at = Some(now_epoch + 3_600);
+
+        for turn_had_started in [true, false] {
+            let (park, line) = backend_started_limit_park(
+                resets_at,
+                now,
+                now_epoch,
+                1,
+                30,
+                turn_had_started,
+            );
+            assert_eq!(
+                line,
+                limit_park_log_line(resets_at, now_epoch, park.pending.is_some()),
+                "the announced flavor must match the armed pending"
+            );
+            assert!(line.starts_with("Rate-limited — parked"), "line: {line}");
+        }
+        let (_park, line) = backend_started_limit_park(resets_at, now, now_epoch, 1, 30, true);
+        assert!(
+            line.contains("will auto-resume and re-send the pending message"),
+            "a nudge-armed park announces the re-send: {line}"
+        );
+        let (_park, line) = backend_started_limit_park(resets_at, now, now_epoch, 1, 30, false);
+        assert!(
+            line.contains("messages arriving meanwhile queue until the limit resets"),
+            "a pending-less park announces queue-until-reset: {line}"
+        );
+    }
+
+    /// Pin `limit_reset_wakes_backend_started_parks`: the armed pending
+    /// is exactly what the idle select's park-elapse branch re-sends —
+    /// the nudge carries no follow-up/steer ids, so an unrelated cancel
+    /// recorded during the park cannot drop it, and the interrupted
+    /// work is re-driven at reset.
+    #[tokio::test]
+    async fn limit_reset_wakes_backend_started_parks() {
+        let now = tokio::time::Instant::now();
+        let (park, _line) = backend_started_limit_park(Some(4_600), now, 1_000, 1, 30, true);
+
+        // The park-elapse branch: deliver pending unless cancelled.
+        let mut cancelled: HashSet<String> = HashSet::from(["f-unrelated".to_string()]);
+        let pending = park.pending.expect("started turn parks a nudge");
+        assert!(!crate::external_events::follow_up_message_was_cancelled(
+            &mut cancelled,
+            &pending
+        ));
+        assert_eq!(pending.text, LIMIT_MIDTURN_CONTINUATION_TEXT);
+    }
+
+    /// Pin `reload_resumes_backend_started_parks`: the credential
+    /// reload's cancel-and-preserve push_fronts the armed pending, so a
+    /// backend-started session parked at the limit resumes its
+    /// interrupted work immediately after the respawn — ahead of
+    /// messages queued during the park — exactly like the follow-up
+    /// lane's parks behaved in the 2026-07-29 event (523c5c23/39dffb58
+    /// resumed; the unparked 379864df idled forever).
+    #[tokio::test]
+    async fn reload_resumes_backend_started_parks() {
+        let now = tokio::time::Instant::now();
+        let (park, _line) = backend_started_limit_park(Some(4_600), now, 1_000, 1, 30, true);
+
+        let mut parked_follow_ups: std::collections::VecDeque<FollowUpMessage> =
+            std::collections::VecDeque::new();
+        parked_follow_ups.push_back(FollowUpMessage::text("queued during park".to_string()));
+        // `apply_backend_credentials_reload` (external_mode): take the
+        // park, front-queue its pending, respawn; the flush preamble
+        // then delivers FIFO.
+        if let Some(pending) = park.pending {
+            parked_follow_ups.push_front(pending);
+        }
+        let mut cancelled = HashSet::new();
+        let (first, skipped) = next_parked_follow_up(&mut parked_follow_ups, &mut cancelled);
+        assert_eq!(skipped, 0);
+        assert_eq!(
+            first.map(|m| m.text),
+            Some(LIMIT_MIDTURN_CONTINUATION_TEXT.to_string())
+        );
+        let (second, _) = next_parked_follow_up(&mut parked_follow_ups, &mut cancelled);
+        assert_eq!(second.map(|m| m.text), Some("queued during park".to_string()));
     }
 
     #[test]

--- a/src/bin/caller/external_supervision.rs
+++ b/src/bin/caller/external_supervision.rs
@@ -1859,14 +1859,8 @@ mod tests {
         let resets_at = Some(now_epoch + 3_600);
 
         for turn_had_started in [true, false] {
-            let (park, line) = backend_started_limit_park(
-                resets_at,
-                now,
-                now_epoch,
-                1,
-                30,
-                turn_had_started,
-            );
+            let (park, line) =
+                backend_started_limit_park(resets_at, now, now_epoch, 1, 30, turn_had_started);
             assert_eq!(
                 line,
                 limit_park_log_line(resets_at, now_epoch, park.pending.is_some()),
@@ -1935,7 +1929,10 @@ mod tests {
             Some(LIMIT_MIDTURN_CONTINUATION_TEXT.to_string())
         );
         let (second, _) = next_parked_follow_up(&mut parked_follow_ups, &mut cancelled);
-        assert_eq!(second.map(|m| m.text), Some("queued during park".to_string()));
+        assert_eq!(
+            second.map(|m| m.text),
+            Some("queued during park".to_string())
+        );
     }
 
     #[test]

--- a/src/bin/caller/run_modes.rs
+++ b/src/bin/caller/run_modes.rs
@@ -2137,18 +2137,33 @@ pub(crate) async fn run_with_presence(
                                     cumulative_stats.rounds = round;
                                 }
                                 DrainOutcome::LimitRejected {
-                                    resets_at_epoch, ..
+                                    resets_at_epoch,
+                                    message: _,
+                                    turn_had_started,
                                 } => {
                                     // A backend-started round ended
-                                    // limit-rejected: nothing to re-send
-                                    // and no round to count — log and
-                                    // return to idle. (A later task that
-                                    // gets rejected parks properly with
-                                    // itself as pending.)
-                                    let park_line = limit_park_log_line(
+                                    // limit-rejected: no round to count,
+                                    // and the park is REAL — this arm is
+                                    // the persistent-lane twin of the
+                                    // observed-from-idle arm that logged
+                                    // "parked" while arming nothing
+                                    // (2026-07-29), so the reset never
+                                    // woke the lane and interrupted work
+                                    // was silently lost. No driving
+                                    // message exists to re-send; the
+                                    // pending is the resume nudge when
+                                    // the backend had started the turn,
+                                    // and the outer-select timer re-drives
+                                    // it at reset.
+                                    persistent_limit_park_streak =
+                                        persistent_limit_park_streak.saturating_add(1);
+                                    let (park, park_line) = backend_started_limit_park(
                                         resets_at_epoch,
+                                        tokio::time::Instant::now(),
                                         crate::session_activity::epoch_seconds(),
-                                        false,
+                                        persistent_limit_park_streak,
+                                        limit_park_jitter_secs(),
+                                        turn_had_started,
                                     );
                                     slog(&session_log, |l| l.warn(&park_line));
                                     bus.send(AppEvent::LogEntry {
@@ -2158,6 +2173,19 @@ pub(crate) async fn run_with_presence(
                                         content: park_line,
                                         turn: None,
                                     });
+                                    emit_external_turn_status(
+                                        &bus,
+                                        &autonomy,
+                                        session_log_id(&session_log).as_deref(),
+                                        round,
+                                        "waiting-rate-limit",
+                                        format!(
+                                            "{} rate-limited; parked until the limit resets",
+                                            agent.name()
+                                        ),
+                                    )
+                                    .await;
+                                    persistent_limit_park = Some(park);
                                 }
                                 DrainOutcome::RecoveryRequired {
                                     message,

--- a/src/bin/caller/session_log/mod.rs
+++ b/src/bin/caller/session_log/mod.rs
@@ -127,8 +127,11 @@ pub struct SessionLimitParkMeta {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resets_at_epoch: Option<u64>,
     /// Whether the park holds a pending re-send/nudge — work still owed
-    /// at the reset (parks always do today; the field keeps the marker
-    /// honest if a pending-less park shape returns).
+    /// at the reset. `false` on a pending-less park (a backend-started
+    /// round whose rejection arrived before any observed work): the
+    /// timer still wakes the lane and queued messages flush at reset,
+    /// but no work is owed, so boot auto-readopt's "limit-parked
+    /// mid-work" class rightly skips it.
     #[serde(default)]
     pub has_pending: bool,
 }


### PR DESCRIPTION
A backend-started round killed by a provider rate limit logged
"Rate-limited — parked" and armed NOTHING — no LimitParkState, no
pending, no durable marker (external_mode.rs observed-from-idle arm and
its persistent-lane twin in run_modes.rs). Live 2026-07-29 (sessions
379864df/a43b7f32): the reset timer never fired, the credential
reload's park-cancel found nothing to resume, and both sessions idled
forever with their interrupted work lost — while follow-up-driven
sessions parked by the same limit in the same minute resumed
immediately on reload.

Both backend-started arms now arm the same delivery-aware park the
follow-up lane arms, through one constructor
(backend_started_limit_park) that returns the armed state and its
announcement line as one value — a log row claiming "parked" can no
longer exist without the park it announces, and the line's has_pending
flavor derives from the pending it ships with. No driving message
exists to re-send in this lane, so the pending is the resume nudge
(midturn_continuation) when the turn had started and nothing when the
rejection arrived first; either way the reset timer wakes the lane,
messages arriving meanwhile queue instead of burning, and the
supervised lane stamps the durable limit_park marker (derived
has_pending) for boot auto-readopt. The arm also emits the
waiting-rate-limit status, so the stale "Running Agent" phase from
the incident clears.

The edit-rollback lane deliberately stays park-less — the user's edit
rewinds past the rejected turn, so a resume nudge would re-drive work
the edit supersedes — but its line no longer claims "parked"; it
names the rejection and the proceeding rollback instead.

Pins: backend_started_limit_arms_real_park;
parked_log_line_implies_armed_state;
limit_reset_wakes_backend_started_parks;
reload_resumes_backend_started_parks.
