### PR TITLE
fix(dashboard-control): bind the api_daemon_handover tunnel arm (HS5 F2) + close the declared-but-unbound class

### DIFF
--- a/src/bin/caller/cli_descriptor.rs
+++ b/src/bin/caller/cli_descriptor.rs
@@ -116,6 +116,22 @@ mod tests {
         assert!(!dir.path().join("cli-path.tmp").exists());
     }
 
+    /// The tolerant lane of [`meta_port`] (HS5-N1): absent, non-JSON,
+    /// and out-of-range sidecars all resolve `None` — discovery data,
+    /// never an error surface — while a holder-written descriptor
+    /// resolves its port.
+    #[test]
+    fn meta_port_tolerates_absent_and_corrupt_sidecars() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(meta_port(dir.path()), None, "absent sidecar");
+        std::fs::write(dir.path().join(CLI_META_FILE), "not json").unwrap();
+        assert_eq!(meta_port(dir.path()), None, "unparseable sidecar");
+        std::fs::write(dir.path().join(CLI_META_FILE), "{\"port\": 70000}").unwrap();
+        assert_eq!(meta_port(dir.path()), None, "port outside u16");
+        write_boot_descriptor(dir.path(), 7001).unwrap();
+        assert_eq!(meta_port(dir.path()), Some(7001), "holder-written port");
+    }
+
     /// The F1.5 pin: every repo skill that shells to the Intendant CLI
     /// carries the canonical resolver preamble ($INTENDANT → PATH →
     /// descriptor → bare fallback), so a future skill cannot regress to

--- a/src/bin/caller/ctl.rs
+++ b/src/bin/caller/ctl.rs
@@ -5583,7 +5583,8 @@ mod tests {
     /// descriptor meta port comes next, and the historical 8765 default
     /// is only the last resort. Composed with
     /// `cli_descriptor::meta_port`'s tolerant parse (pinned in its own
-    /// module), this is the whole resolution ladder.
+    /// module by `meta_port_tolerates_absent_and_corrupt_sidecars`),
+    /// this is the whole resolution ladder.
     #[test]
     fn ctl_meta_port_fallback_before_default() {
         assert_eq!(resolve_local_port(Some(9001), Some(9002)), 9001);

--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -1955,6 +1955,43 @@ pub(crate) async fn api_github_integration_remove_response(
     )
 }
 
+/// Tunnel twin of `GET /api/integrations/github/installations` — wraps
+/// the same transport-neutral core as the HTTP route (App-JWT
+/// discovery), with the edge resolving the ambient custody backend and
+/// global integration runtime exactly like the HTTP wrapper. Status-
+/// carrying envelope (`frame_api_response`): the core answers named
+/// refusals — no App, custody deny, upstream failure — that the
+/// installation picker must distinguish from success. Bound by the F2
+/// class walk (`every_declared_method_binds_in_a_dispatch_lane`): the
+/// twin was declared but unbound, so the picker was dead on
+/// tunnel-primary surfaces.
+pub(crate) async fn api_github_installations_response(id: String) -> serde_json::Value {
+    frame_api_response(
+        id,
+        crate::web_gateway::github_installations_api_response(
+            &crate::web_gateway::DaemonGithubAppCustody,
+            crate::github_pr::status::global(),
+        )
+        .await,
+        "github installations",
+    )
+}
+
+/// Tunnel twin of `GET /api/integrations/github/repositories` — the
+/// installation-token repo listing behind the repo picker; same edge
+/// resolution and envelope rationale as the installations twin above.
+pub(crate) async fn api_github_repositories_response(id: String) -> serde_json::Value {
+    frame_api_response(
+        id,
+        crate::web_gateway::github_repositories_api_response(
+            &crate::web_gateway::DaemonGithubAppCustody,
+            crate::github_pr::status::global(),
+        )
+        .await,
+        "github repositories",
+    )
+}
+
 /// Hosted-provenance fact for the Claude sign-in twins, from the grant
 /// that opened this control session: the trusted-local surface and peer
 /// daemons are direct by construction; user clients go through the

--- a/src/bin/caller/dashboard_control/api_sessions.rs
+++ b/src/bin/caller/dashboard_control/api_sessions.rs
@@ -266,6 +266,7 @@ pub(crate) async fn control_request_frame(
         "api_agenda_reminder_policy" => {
             api_agenda_reminder_policy_response(id, params.as_ref(), &runtime).await
         }
+        "api_daemon_handover" => api_daemon_handover_response(id, &runtime).await,
         "api_memory_search" => api_memory_search_response(id, params.as_ref(), &runtime).await,
         "api_memory_claim" => api_memory_claim_response(id, params.as_ref(), &runtime).await,
         "api_memory_propose" => api_memory_propose_response(id, params.as_ref(), &runtime).await,
@@ -372,6 +373,8 @@ pub(crate) async fn control_request_frame(
         "api_github_integration_status" => {
             api_github_integration_status_response(id, &runtime).await
         }
+        "api_github_installations" => api_github_installations_response(id).await,
+        "api_github_repositories" => api_github_repositories_response(id).await,
         "api_github_integration_remove" => {
             api_github_integration_remove_response(
                 id,
@@ -1530,6 +1533,22 @@ pub(crate) async fn api_agenda_stamp_response(
     )
 }
 
+/// Tunnel twin of `GET /api/daemon/handover` — wraps the same
+/// transport-neutral core the HTTP route serves, so the drain banner and
+/// predecessor chip render on tunnel-primary surfaces (the packaged
+/// macOS app, Connect-mode dashboards, WebKit's mTLS fallback, peer
+/// dashboards) exactly as they do over plain HTTP.
+pub(crate) async fn api_daemon_handover_response(
+    id: String,
+    runtime: &ControlRuntime,
+) -> serde_json::Value {
+    frame_api_response(
+        id,
+        crate::web_gateway::daemon_handover_status_api_response(runtime.mcp_server.as_ref()).await,
+        "daemon handover",
+    )
+}
+
 /// Tunnel twin of `GET /api/memory/search` — args ride `params`.
 pub(crate) async fn api_memory_search_response(
     id: String,
@@ -1889,6 +1908,35 @@ pub(crate) async fn api_sessions_search_response(
 mod tests {
     use super::*;
     use crate::dashboard_control::tests::runtime;
+
+    /// F2 (the HS5 ruling): the declared `api_daemon_handover` tunnel
+    /// twin BINDS in the spawned request lane. An authorizer-admitted
+    /// method with no dispatch arm answers `unknown method` as a
+    /// DELIVERED response — the SPA facade's HTTP fallback never fires
+    /// (transport errors only) while `availability()` keeps saying ok,
+    /// so the handover chrome would be dead exactly where the tunnel is
+    /// the primary lane.
+    #[tokio::test]
+    async fn handover_state_reaches_tunneled_dashboards() {
+        let response = control_request_response(
+            "hs".to_string(),
+            "api_daemon_handover".to_string(),
+            None,
+            runtime(),
+            CancellationToken::new(),
+        )
+        .await;
+        let frame = &response.frame;
+        assert_eq!(
+            frame["ok"], true,
+            "the handover twin must bind, never answer unknown-method: {frame}"
+        );
+        // The storeless test runtime carries no handover runtime: the
+        // core's honest degrade shape, delivered through the tunnel
+        // envelope with the facade's status metadata.
+        assert_eq!(frame["result"]["_httpStatus"], 200);
+        assert_eq!(frame["result"]["available"], false);
+    }
 
     /// A cancelled stream must signal its producer immediately, yet must NOT
     /// free its live-work slot while a running `spawn_blocking` producer is

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -5609,6 +5609,116 @@ mod tests {
         ));
     }
 
+    /// The dispatch half of derive-don't-mirror (F2, the HS5 ruling's
+    /// class-closing walk): every method the effective table declares
+    /// must BIND in a dispatch lane. The authorizer admits declared
+    /// names and `availability()` advertises them, but the
+    /// method→handler bindings are literal match arms in `dispatch.rs`
+    /// (inline + upload-lane arms) and `api_sessions.rs` (the spawned
+    /// request lane) — a declared name bound in neither answers
+    /// `unknown method` as a DELIVERED response, which the SPA facade
+    /// never falls back from, so the surface dies silently exactly
+    /// where the tunnel is the primary transport (the shipped F2 bug).
+    /// Source-scanned because the arms are `match` literals: a name
+    /// counts as bound when it appears as an arm shape — `"name" =>`,
+    /// `"name" |`, or `"name" if` — outside `//` comments.
+    #[test]
+    fn every_declared_method_binds_in_a_dispatch_lane() {
+        fn collect_match_arm_literals(
+            source: &str,
+            bound: &mut std::collections::BTreeSet<String>,
+        ) {
+            // Strip `//` comments per line (a `//` inside a string
+            // literal is body, not comment), then scan the joined text
+            // so a multi-line or-pattern's first alternative — a lone
+            // `"name"` at end of line, `| "next"` on the following one
+            // (the rustfmt shape) — still reads as an arm.
+            let mut code = String::new();
+            for line in source.lines() {
+                let mut in_string = false;
+                let mut escaped = false;
+                let mut chars = line.chars().peekable();
+                while let Some(c) = chars.next() {
+                    if in_string {
+                        code.push(c);
+                        if escaped {
+                            escaped = false;
+                        } else if c == '\\' {
+                            escaped = true;
+                        } else if c == '"' {
+                            in_string = false;
+                        }
+                    } else if c == '/' && chars.peek() == Some(&'/') {
+                        break;
+                    } else {
+                        code.push(c);
+                        if c == '"' {
+                            in_string = true;
+                        }
+                    }
+                }
+                code.push('\n');
+            }
+            // Quoted literals whose next token is an arm shape.
+            let mut rest = code.as_str();
+            while let Some(open) = rest.find('"') {
+                let tail = &rest[open + 1..];
+                let mut end = None;
+                let mut escaped = false;
+                for (i, c) in tail.char_indices() {
+                    if escaped {
+                        escaped = false;
+                    } else if c == '\\' {
+                        escaped = true;
+                    } else if c == '"' {
+                        end = Some(i);
+                        break;
+                    }
+                }
+                let Some(end) = end else { break };
+                let literal = &tail[..end];
+                let follower = tail[end + 1..].trim_start();
+                if follower.starts_with("=>")
+                    || follower.starts_with('|')
+                    || follower.starts_with("if ")
+                {
+                    bound.insert(literal.to_string());
+                }
+                rest = &tail[end + 1..];
+            }
+        }
+
+        let mut bound = std::collections::BTreeSet::new();
+        // Extractor semantics pinned on a fixture: comment-stripped,
+        // tuple entries excluded, or-patterns (single- and multi-line)
+        // and guards included.
+        collect_match_arm_literals(
+            "\"a\" => x, // \"c1\" =>\n(\"t\", 1)\n\"d\" | \"e\" => y\n\"g\" if z => w\n\"h\"\n| \"i\" => j",
+            &mut bound,
+        );
+        assert_eq!(
+            bound.iter().map(String::as_str).collect::<Vec<_>>(),
+            ["a", "d", "e", "g", "h", "i"],
+            "the arm extractor drifted"
+        );
+        bound.clear();
+
+        for source in [include_str!("dispatch.rs"), include_str!("api_sessions.rs")] {
+            collect_match_arm_literals(source, &mut bound);
+        }
+        let missing: Vec<&str> = all_control_methods()
+            .iter()
+            .filter(|spec| !bound.contains(spec.name))
+            .map(|spec| spec.name)
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "declared tunnel methods with no dispatch-lane binding — each \
+             would answer `unknown method` as a delivered response (the F2 \
+             dead-surface class): {missing:?}"
+        );
+    }
+
     /// Transport-unification S3 differential pin (design §8, risks
     /// R2/R4): the complete tunnel-method partition — every wire method
     /// name, the declaration source that carries it (`Row` = a `tunnel:`

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -6855,9 +6855,17 @@ async fn drainer_exits_at_last_session_end() {
         "the successor opening the durable memory plane",
         RUN_TIMEOUT,
         || async {
+            // The OPEN line exactly ("durable plane <id> at <dir>") —
+            // the unavailable→ephemeral failure line shares the prefix,
+            // so a genuine store failure must not false-pass (HS5-N2).
             std::fs::read_to_string(daemon_a.rig.home.path().join("daemon-b.log"))
                 .unwrap_or_default()
-                .contains("[memory] durable plane")
+                .lines()
+                .any(|line| {
+                    line.contains("[memory] durable plane")
+                        && line.contains(" at ")
+                        && !line.contains("unavailable")
+                })
                 .then_some(())
         },
         || {


### PR DESCRIPTION
## Track HS — F2 (required fix-forward from the HS5 ruling)

**The bug (HS5 ruling, verbatim radius):** the `api_daemon_handover` tunnel twin was declared — route-row tunnel column, authorizer-admitted, `availability()` ok — but the spawned request lane had no arm, so a tunnel call answered `unknown method` as a **delivered** response. The SPA facade only falls back to HTTP on transport errors, so the drain banner / predecessor chip were dead exactly where the dashboard-control tunnel is the primary lane: the packaged macOS app, Connect-mode dashboards, WebKit's mTLS capability-fallback, and peer dashboards. Plain-HTTP Chromium (CI's posture) worked, which is why nothing red caught it.

**The fix:** bind the arm over the same transport-neutral core the HTTP route serves (`daemon_handover_status_api_response`, the api_memory_search shared-core pattern), pinned by `handover_state_reaches_tunneled_dashboards`.

**The class close (ruling-recommended shape):** `every_declared_method_binds_in_a_dispatch_lane` — a source-scan parity walk asserting every effective-table method (ROUTES tunnel columns ∪ `CONTROL_ONLY_METHODS`) appears as a literal match arm in `dispatch.rs` or `api_sessions.rs`. Extractor semantics are themselves fixture-pinned (comments stripped, tuple entries excluded, single- and multi-line or-patterns + guards included).

**The walk's first catch — two more dead surfaces of the same class:** `api_github_installations` and `api_github_repositories` were declared but unbound (the GitHub App installation/repo pickers' tunnel legs). Bound here over their existing cores with the status-carrying envelope (`frame_api_response`): their named refusals (no App / custody deny / upstream failure) must surface as ok:false through the facade normalizer — the family's body-only envelope would have read a 400 as ok:200.

**Riders (per the HS5 ruling):**
- **N1** — `cli_descriptor::meta_port` tolerant lane pinned in its own module (`meta_port_tolerates_absent_and_corrupt_sidecars`); the ctl ladder pin's doc now names the real pin instead of claiming one that didn't exist.
- **N2** — the takeover rig's durable-plane needle tightened to the open-line shape (`" at "` + negative-match `unavailable`): the unavailable→ephemeral failure line shared the old needle's prefix, so a genuine store failure on the successor could false-pass the leg.

**Battery:** 5425 bins tests green (incl. the 6 pins here), `drainer_exits_at_last_session_end` e2e green on macOS (7.7s, exercises the tightened needle), workspace clippy -D warnings, fmt clean.

Refs: sealed intake `~/daemon-handover-intake.md` (sha256 a028ae33…) + HS5 ruling at `~/daemon-handover-rulings.md` tail. HS6 (final slice) stacks on this.