### PR TITLE
feat(agenda-ui): AO S4 — two-axis surfaces under the Q8 labeling law

### DIFF
--- a/docs/src/agenda-and-memory.md
+++ b/docs/src/agenda-and-memory.md
@@ -587,10 +587,12 @@ orchestration).
 Quiet hours do not delay scheduled sessions: approving a 03:00 run is an
 explicit decision distinct from reminder loudness. A launch that misses its
 window while the daemon is down, or is interrupted before launch
-confirmation, fails closed and is not automatically retried. The outcome is
-written back to `effects[].last_run`.
+confirmation, fails closed. The time lane never auto-retries it (the owner
+re-approves to reschedule); a **triggered** cause regenerates a bounded
+successor attempt (Track AO, below). The outcome is written back to
+`effects[].last_run`.
 
-Three display-only fields ride the served item DTO so frontends never
+Four display-only fields ride the served item DTO so frontends never
 reimplement planner math — each computed at read time by the planner's own
 functions, never stored, never folded from operations. `effects[].next_fire_ms`
 is the next instant the effect would actually fire (approval-gated,
@@ -609,7 +611,10 @@ abandoned, or completed without resolving the item) drops the claim, so the
 item re-joins the needs-you complement on the next read. The parked-question
 notification, the Agenda tab's Needs-you lens and badge, and the watched
 chip all branch on it; delivery and urgency never change — only the
-classification. All three are stamped at the serving seam — list snapshots,
+classification. `effects[].last_run_attempt` is the last run's Track AO
+regeneration ordinal from the occurrence journal fold, present exactly when
+that run is a bounded auto-retry (attempt k>0) so the run line can say
+"attempt 2 (auto-retry)". All four are stamped at the serving seam — list snapshots,
 command responses, `agenda_changed` broadcasts, the MCP tool — with the
 clock of that read (single-item broadcast copies are decorated against the
 full fold, so they carry the same cross-item derivations as snapshots), and
@@ -621,6 +626,67 @@ bounded broadcast EventBus. A lagged receiver is logged but not reconciled
 in-process; under extreme event pressure an occurrence can remain
 `awaiting_receipt` or `running` until daemon restart resolves it fail-closed
 (normally to `unknown`).
+
+### Attested outcomes and cause regeneration (Track AO)
+
+The machinery's run vocabulary is **two axes that compose, never one**:
+
+- **Transport** — `started/completed/failed/missed/unknown`, written back
+  by the scheduler alone. It says only how the session *ended*:
+  `completed` means "stopped normally" (denials, approval walls, and
+  interrupts ride it), and absence of a report is not success.
+- **Self-report** — the fired session's own verdict on the GOAL, written
+  by the `attest` command (`ctl agenda attest <item> --occurrence <id>
+  --outcome … [--note …] [--ref file:PATH]…`, the same one command
+  vocabulary over MCP `agenda_op` and `POST /api/agenda/op`). Closed set:
+  `achieved` (the goal, as stated, was accomplished), `partial` (real
+  progress, not done — deliberately inert machine-side, so there is no
+  reason to inflate), `blocked` (cannot proceed without something outside
+  the session's power), `abandoned` (deliberately stopped; nothing should
+  retry it). Only sessions in the occurrence's own started lineage can
+  attest (superseded originals and admitted successors both; last wins);
+  refs are pointer + sha256 pin, hash-verified at intake, never sealed,
+  drift-checked on expand. **Unattested** is the derived absence state —
+  fold-`None`, never synthesized into anything.
+
+Renderings compose the axes ("completed · self-reported blocked";
+"failed · no self-report") under a binding labeling law: every
+self-report surface says **self-reported** and hovers "the session's own
+report — not verified"; the transport verdict and the self-report never
+share a glyph (attested-achieved gets its own ◆ mark and hue, never the
+transport-success chip); `blocked`/`abandoned` render amber-class, never
+rose (rose stays transport-failure); unattested is a hollow neutral ◇
+"no self-report" — absence, never anomaly styling. The transport note
+(`last_run.note`) stays the transport's last-words line and is never
+rendered as, beside, or styled like a self-report. Machinery never
+fabricates an attestation from transport signals — a wrapper death seeds
+nothing, and closing-message harvesting is backstop, never the channel.
+
+Attestations feed the suspend streak (one fold arm): `failed`/`unknown`
++1 as ever; `completed` self-reported `blocked`/`abandoned` now +1 (the
+silent-defeat fix); `partial` neutral; attested-`achieved` and
+unattested-`completed` reset (legacy semantics — the honest path to
+counting unattested is a per-manifest `required` contract, a future
+knob); late attests never retro-adjust a computed streak.
+
+**Cause regeneration** re-mints spent *triggered* causes (`on_unblock` +
+`on_item_match`) whose transport terminal is `failed` or `unknown` — the
+two machine-verified wedge classes; attestation never feeds the retry
+decision (attested-`blocked` rides its transport `completed` out of the
+family — a retry cannot clear an external blocker, and `on_unblock` is
+the lane for dependency-shaped blockers). Attempt k>0 is a distinct,
+stable occurrence identity for the same raw cause (attempt 0 hashes
+exactly the pre-AO bytes); bounds stack: the trigger cooldown floor
+spaces attempts, streak suspension halts the walk, and a hard per-cause
+cap (3 attempts total) holds even across streak resets. `on_item_match`
+retries re-derive the ORIGINAL batch from the dispatch-time consumed
+markers naming the failed attempt's occurrence id — nothing un-consumes,
+ever; re-annotation is append-only. The one-shot time lane keeps its
+re-approve ceremony (the owner scheduled a moment), and reminders are
+untouched. Journal rows for retries carry the additive display field
+`attempt`; the run line says "attempt 2 (auto-retry)" so regeneration is
+legible, and a suspended card names the last self-reported reason when
+one exists.
 
 ### Attribution, provenance display, and `--source`
 

--- a/src/bin/caller/agenda/mod.rs
+++ b/src/bin/caller/agenda/mod.rs
@@ -51,7 +51,8 @@ pub(crate) use reminders::{
 pub(crate) use scheduler::spawn_reminder_scheduler;
 pub(crate) use spawn_project::{recorded_session_project_root, SessionSpawnContext};
 pub(crate) use store::{
-    digest_file, file_ref_drift, AgendaError, AgendaOpsPage, AgendaStore, AGENDA_OPS_DEFAULT_LIMIT,
+    attestation_ref_drift, digest_file, file_ref_drift, AgendaError, AgendaOpsPage, AgendaStore,
+    AGENDA_OPS_DEFAULT_LIMIT,
 };
 pub(crate) use types::{
     AgendaActor, AgendaAnswer, AgendaCommand, AgendaCounts, AgendaItem, AgendaKind, AgendaRefSpec,

--- a/src/bin/caller/agenda/reminders.rs
+++ b/src/bin/caller/agenda/reminders.rs
@@ -395,6 +395,12 @@ pub(crate) struct OccurrenceProgress {
     /// pre-stamping build downgrades the occurrence to legacy boot-time
     /// semantics — the fail-closed direction for mixed-version homes.
     pub(crate) writer_boot_id: Option<String>,
+    /// Track AO regeneration ordinal, retained from the last row that
+    /// carried one — DISPLAY-ONLY (the run-line/grid "attempt N" copy):
+    /// identity lives in the occurrence id's retry segment, and no
+    /// planner or recovery decision reads this. Recovery rows carry no
+    /// stamp and never clear it.
+    pub(crate) attempt: Option<u32>,
 }
 
 /// One row of [`OccurrenceJournal::started_unresolved`].
@@ -801,6 +807,9 @@ pub(crate) struct AgendaOccurrencesPage {
 fn fold_record_into(entry: &mut OccurrenceProgress, record: &OccurrenceRecord) {
     if !record.item_id.is_empty() && entry.item_id.is_none() {
         entry.item_id = Some(record.item_id.clone());
+    }
+    if record.attempt.is_some() {
+        entry.attempt = record.attempt;
     }
     match record.state {
         OccurrenceState::Prepared => {
@@ -1940,6 +1949,10 @@ pub(crate) fn decorate_planner_fields(
         item.watched_by = consumed.or_else(|| watched.remove(&item.id));
         for (effect, view) in item.effects.iter_mut().zip(item_views) {
             effect.next_fire_ms = view.and_then(|view| view.next_fire_ms);
+            effect.last_run_attempt = effect
+                .last_run
+                .as_ref()
+                .and_then(|run| journal.progress(&run.occurrence_id).attempt);
         }
     }
 }
@@ -2755,6 +2768,7 @@ mod tests {
             consecutive_failures: 0,
             requested: Vec::new(),
             next_fire_ms: None,
+            last_run_attempt: None,
         });
         base
     }
@@ -3179,6 +3193,7 @@ mod tests {
                 consecutive_failures: 0,
                 requested: Vec::new(),
                 next_fire_ms: None,
+                last_run_attempt: None,
             });
             base
         };
@@ -3197,6 +3212,69 @@ mod tests {
     }
 
     // ---- Display-only planner derivations (next_fire_ms / deferred_until) ----
+
+    /// Track AO: `last_run_attempt` is a serving-seam decoration from
+    /// the journal fold's display-only `attempt` retention — present
+    /// exactly when the last run's occurrence carries a retry ordinal,
+    /// absent from the wire otherwise (the additive-DTO discipline).
+    /// Retention is last-Some-wins: a stampless recovery row never
+    /// clears the ordinal.
+    #[test]
+    fn last_run_attempt_is_decorated_from_the_journal_fold() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut journal = self::journal(dir.path());
+        let policy = ReminderPolicy::default();
+        let noon = |_: u64| 12 * 60;
+        let mut solo = one_shot_item("solo", 50_000);
+        solo.effects[0].last_run = Some(AgendaRun {
+            occurrence_id: "occ-retry".into(),
+            state: "failed".into(),
+            session_id: None,
+            at_ms: 60_000,
+            note: None,
+            attestation: None,
+        });
+        for (state, attempt) in [
+            (OccurrenceState::Prepared, Some(2)),
+            (OccurrenceState::Started, Some(2)),
+            (OccurrenceState::Unknown, None),
+        ] {
+            journal
+                .append(&OccurrenceRecord {
+                    v: 1,
+                    at_ms: 60_000,
+                    occurrence_id: "occ-retry".into(),
+                    item_id: "solo".into(),
+                    due_ms: 60_000,
+                    state,
+                    urgency: None,
+                    session_id: None,
+                    generation: None,
+                    boot_id: None,
+                    attempt,
+                })
+                .unwrap();
+        }
+        let mut items = vec![solo];
+        decorate_planner_fields(None, &mut items, &journal, &policy, 70_000, &noon);
+        assert_eq!(items[0].effects[0].last_run_attempt, Some(2));
+        let json = serde_json::to_value(&items[0]).unwrap();
+        assert_eq!(json["effects"][0]["last_run_attempt"], serde_json::json!(2));
+
+        // Attempt-0 (and every legacy) run: no ordinal, no wire field.
+        items[0].effects[0].last_run = Some(AgendaRun {
+            occurrence_id: "occ-plain".into(),
+            state: "completed".into(),
+            session_id: None,
+            at_ms: 61_000,
+            note: None,
+            attestation: None,
+        });
+        decorate_planner_fields(None, &mut items, &journal, &policy, 70_000, &noon);
+        assert_eq!(items[0].effects[0].last_run_attempt, None);
+        let json = serde_json::to_value(&items[0]).unwrap();
+        assert!(json["effects"][0].get("last_run_attempt").is_none());
+    }
 
     /// An approved one-shot item (no recurrence), effect id `ef-1`.
     fn one_shot_item(id: &str, fire_at: u64) -> AgendaItem {
@@ -3231,6 +3309,7 @@ mod tests {
             consecutive_failures: 0,
             requested: Vec::new(),
             next_fire_ms: None,
+            last_run_attempt: None,
         });
         base
     }
@@ -3931,6 +4010,7 @@ mod tests {
             consecutive_failures: 0,
             requested: Vec::new(),
             next_fire_ms: None,
+            last_run_attempt: None,
         });
         base
     }

--- a/src/bin/caller/agenda/store.rs
+++ b/src/bin/caller/agenda/store.rs
@@ -2480,7 +2480,21 @@ fn validate_ref(
 /// Presentation only: never stored, never a DTO field; callers invoke it
 /// on detail expand, never on list render.
 pub(crate) fn file_ref_drift(locator: &str, attach_digest: &str) -> &'static str {
-    let path = Path::new(locator);
+    path_ref_drift(Path::new(locator), attach_digest)
+}
+
+/// Track AO attestation-ref drift: the same expand-time honesty check
+/// as [`file_ref_drift`], for `BindingRef`-grammar locators
+/// (`file:<absolute path>`). Verify-only — the pin is re-hashed on
+/// demand; nothing is sealed and nothing is stored (Q3/OPEN-3).
+pub(crate) fn attestation_ref_drift(locator: &str, attest_sha256: &str) -> &'static str {
+    match binding_ref_path(locator) {
+        Ok(path) => path_ref_drift(path, attest_sha256),
+        Err(_) => "missing",
+    }
+}
+
+fn path_ref_drift(path: &Path, attach_digest: &str) -> &'static str {
     let Ok(meta) = std::fs::metadata(path) else {
         return "missing";
     };
@@ -4146,6 +4160,29 @@ mod tests {
         assert_eq!(file_ref_drift(&loc, &attach), "changed");
         std::fs::remove_file(&path).unwrap();
         assert_eq!(file_ref_drift(&loc, &attach), "missing");
+    }
+
+    /// Track AO: attestation refs ride the same expand-time judgment
+    /// through their `file:` BindingRef grammar — resolved, re-hashed
+    /// against the attest-time pin, and fail-closed to `missing` for a
+    /// locator outside the v1 scheme (never touching the filesystem).
+    #[test]
+    fn attestation_ref_drift_resolves_the_binding_ref_scheme() {
+        let files = tempfile::tempdir().unwrap();
+        let path = files.path().join("handoff.md");
+        std::fs::write(&path, b"findings v1").unwrap();
+        let sha = digest_file(&path).unwrap();
+        let locator = format!("file:{}", path.display());
+
+        assert_eq!(attestation_ref_drift(&locator, &sha), "unchanged");
+        std::fs::write(&path, b"findings v2 - drifted").unwrap();
+        assert_eq!(attestation_ref_drift(&locator, &sha), "changed");
+        std::fs::remove_file(&path).unwrap();
+        assert_eq!(attestation_ref_drift(&locator, &sha), "missing");
+        assert_eq!(
+            attestation_ref_drift("url:https://example.com", &sha),
+            "missing"
+        );
     }
 
     /// The G2 intake omnibus: placement strictness (cycle, self, depth,

--- a/src/bin/caller/agenda/types.rs
+++ b/src/bin/caller/agenda/types.rs
@@ -576,6 +576,14 @@ pub struct AgendaEffect {
     /// `None` in the fold product, never folded from ops, never stored.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) next_fire_ms: Option<u64>,
+    /// Display-only serving-seam decoration (Track AO, the
+    /// `next_fire_ms` pattern): `last_run`'s regeneration ordinal from
+    /// the occurrence journal fold — present exactly when the run is a
+    /// bounded auto-retry (attempt k>0), so the run line can say
+    /// "attempt 2 (auto-retry)". Always `None` in the fold product,
+    /// never folded from ops, never stored.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) last_run_attempt: Option<u32>,
 }
 
 fn is_zero_u32(n: &u32) -> bool {
@@ -2077,6 +2085,7 @@ pub(crate) fn apply_op(
                 consecutive_failures: 0,
                 requested: Vec::new(),
                 next_fire_ms: None,
+                last_run_attempt: None,
             };
             match item.effects.iter_mut().find(|e| e.effect_id == *effect_id) {
                 Some(existing) => {

--- a/src/bin/caller/web_gateway/routes_agenda.rs
+++ b/src/bin/caller/web_gateway/routes_agenda.rs
@@ -953,6 +953,24 @@ pub(crate) async fn agenda_ref_drift_api_response(
                 "status": crate::agenda::file_ref_drift(&r.locator, digest),
             }))
         })
+        // Attestation refs (Track AO): the current run's self-report
+        // pointers ride the same expand-time honesty check — verify-only
+        // pins, re-hashed against the attest-time sha256; nothing is
+        // sealed and nothing is stored (Q3/OPEN-3).
+        .chain(
+            item.effects
+                .iter()
+                .filter_map(|effect| effect.last_run.as_ref())
+                .filter_map(|run| run.attestation.as_ref())
+                .flat_map(|attestation| attestation.refs.iter())
+                .map(|r| {
+                    serde_json::json!({
+                        "ref_type": "file",
+                        "locator": r.locator,
+                        "status": crate::agenda::attestation_ref_drift(&r.locator, &r.sha256),
+                    })
+                }),
+        )
         .collect();
     ApiResponse::json(
         200,

--- a/src/bin/caller/web_gateway/static_assets.rs
+++ b/src/bin/caller/web_gateway/static_assets.rs
@@ -1623,4 +1623,54 @@ mod tests {
         assert!(head.starts_with("HTTP/1.1 500"));
         assert!(head.ends_with("\r\n\r\n"));
     }
+
+    /// Track AO — the Q8 labeling law plus R6's negative, asserted where
+    /// chip/tooltip copy is generated (the agenda fragments riding the
+    /// assembled artifact). Binding: every attestation surface says
+    /// self-reported and hovers not-verified; the transport verdict and
+    /// the self-report never share a glyph (attested-achieved is sky —
+    /// never the transport-success green chip); blocked/abandoned render
+    /// amber-class, never rose (rose stays transport-failure);
+    /// unattested is a hollow neutral "no self-report" — absence, never
+    /// anomaly styling. R6: the transport note stays the transport's
+    /// last-words line — never rendered as, beside, or styled like a
+    /// self-report, tooltips included.
+    #[test]
+    fn attestation_chips_follow_the_labeling_law() {
+        // The one attestation tone map: achieved = sky, everything else
+        // amber — an exhaustive ternary, so no outcome can reach rose or
+        // the transport green.
+        assert!(APP_HTML.contains("return outcome === 'achieved' ? 'sky' : 'amber';"));
+        // Every chip label carries the self-report word, ◆-marked.
+        assert!(APP_HTML.contains("`◆ self-reported: ${att.outcome}`"));
+        assert!(APP_HTML.contains("◆ self-reported: ${escapeHtml(last.attestation.outcome)}"));
+        // The not-verified hover, on every attestation surface.
+        assert!(APP_HTML.contains("The session’s own report — not verified."));
+        // Unattested: hollow (dashed) neutral, absence copy — never
+        // anomaly styling.
+        assert!(APP_HTML.contains(
+            "agendaChipHtml('◇ no self-report', 'neutral', AGENDA_UNATTESTED_HOVER, true)"
+        ));
+        assert!(APP_HTML
+            .contains("No self-report exists for this run — the session ended without attesting."));
+        // The hood's op rows: attest ops are first-class, labeled
+        // self-report, achieved sky / the rest amber (never rose).
+        assert!(APP_HTML.contains("attested ${op.outcome || '—'} — self-report"));
+        assert!(APP_HTML.contains("return op.outcome === 'achieved' ? 'sky' : 'amber';"));
+        // The CSS side of the hue law.
+        assert!(APP_HTML.contains(".ag2-auto-attest.att-achieved { color: var(--sky); }"));
+        assert!(APP_HTML.contains(".ag2-auto-attest.att-abandoned { color: var(--amber); }"));
+        // R6's negative: the strip's transport tip stays state + last
+        // words only (no self-report wording can enter the template),
+        // and the inspector's transport-note tooltip names it the
+        // transport record, not a self-report.
+        assert!(
+            APP_HTML.contains("const tip = `${last.state}${last.note ? ` — ${last.note}` : ''}`;")
+        );
+        assert!(APP_HTML
+            .contains("The session’s final message as the run ended — the transport record, not a self-report"));
+        // Regeneration legibility rides the same surfaces: the run line
+        // names the bounded auto-retry.
+        assert!(APP_HTML.contains("attempt ${e.last_run_attempt} (auto-retry)"));
+    }
 }

--- a/static/app.html
+++ b/static/app.html
@@ -23964,6 +23964,7 @@ html.ui-v2 .ag2-chip.dashed {
   background: none;
   border-style: dashed;
 }
+html.ui-v2 .ag2-chip.t-neutral.dashed { border-color: var(--line-2); }
 html.ui-v2 .ag2-chip.t-green.dashed { border-color: rgba(var(--green-rgb), 0.45); }
 html.ui-v2 .ag2-chip.t-amber.dashed { border-color: rgba(var(--amber-rgb), 0.45); }
 html.ui-v2 .ag2-chip.t-rose.dashed { border-color: rgba(var(--rose-rgb), 0.45); }
@@ -24159,6 +24160,15 @@ html.ui-v2 .ag2-auto-last.st-unknown,
 html.ui-v2 .ag2-auto-streak { color: var(--rose); font-weight: 600; }
 html.ui-v2 .ag2-auto-last.st-completed { color: var(--green); }
 html.ui-v2 .ag2-auto-run { cursor: pointer; text-decoration: underline; }
+/* Attestation (Track AO) — the self-report axis, never the transport
+   palette: achieved sky (never transport-success green), the rest
+   amber-class (never rose = transport failure); unattested is neutral
+   absence, no anomaly styling. */
+html.ui-v2 .ag2-auto-attest.att-achieved { color: var(--sky); }
+html.ui-v2 .ag2-auto-attest.att-partial,
+html.ui-v2 .ag2-auto-attest.att-blocked,
+html.ui-v2 .ag2-auto-attest.att-abandoned { color: var(--amber); }
+html.ui-v2 .ag2-auto-attest.att-none { color: var(--text-2); opacity: 0.85; }
 
 /* ---- Inline question answering ---- */
 
@@ -25430,6 +25440,33 @@ html.ui-v2 .ag2-eff-note {
   overflow-wrap: anywhere;
   border-left: 2px solid var(--line);
   padding-left: 9px;
+}
+/* The self-report block (Track AO): its own labeled lane under the
+   transport row — amber-edged so the axis never blends into the
+   transport note above it. */
+html.ui-v2 .ag2-eff-attest {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+html.ui-v2 .ag2-eff-attest-note {
+  font-size: 12px;
+  color: var(--text-2);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  border-left: 2px solid rgba(var(--amber-rgb), 0.45);
+  padding-left: 9px;
+}
+html.ui-v2 .ag2-attest-ref {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 11px;
+}
+html.ui-v2 .ag2-attest-ref-loc {
+  font-family: var(--mono);
+  color: var(--text-2);
+  overflow-wrap: anywhere;
 }
 html.ui-v2 .ag2-insp-noeff {
   display: flex;
@@ -37071,7 +37108,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'afa9f0ce05134128';
+const INTENDANT_APP_BUILD = '246c785dad2bf61d';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -93032,6 +93069,39 @@ function agendaChipHtml(label, tone, tip, dashed) {
   return `<span class="${cls.join(' ')}"${tip ? ` title="${escapeHtml(tip)}"` : ''}>${escapeHtml(label)}</span>`;
 }
 
+// ---- Attestation chips (Track AO — the Q8 labeling law, binding) ----
+// The self-report axis renders BESIDE the transport verdict, never as
+// it: every attestation surface says "self-reported" and carries the
+// not-verified hover; the ◆ self-report mark is the axis's own glyph,
+// never the transport palette's meaning (attested-achieved is sky —
+// never the transport-success green or its chip), and
+// blocked/abandoned/partial wear amber-class warning hues — never
+// rose, which stays transport-failure. Unattested is the DERIVED
+// absence state: a hollow neutral ◇ chip, "no self-report" — absence,
+// never anomaly styling, never synthesized into achieved.
+function agendaAttestTone(outcome) {
+  return outcome === 'achieved' ? 'sky' : 'amber';
+}
+
+function agendaAttestHover(att) {
+  const base = 'The session’s own report — not verified.';
+  if (!att || !att.note) return base;
+  const note = att.note.length > 200 ? `${att.note.slice(0, 200)}…` : att.note;
+  return `${base} “${note}”`;
+}
+
+function agendaAttestChipHtml(att) {
+  return agendaChipHtml(`◆ self-reported: ${att.outcome}`, agendaAttestTone(att.outcome),
+    agendaAttestHover(att));
+}
+
+const AGENDA_UNATTESTED_HOVER =
+  'No self-report exists for this run — the session ended without attesting. Absence, not failure.';
+
+function agendaUnattestedChipHtml() {
+  return agendaChipHtml('◇ no self-report', 'neutral', AGENDA_UNATTESTED_HOVER, true);
+}
+
 function agendaCardChips(item) {
   const chips = [];
   const st = agendaEffectState(item);
@@ -93209,6 +93279,14 @@ function agendaCardEffectStrip(item) {
       + `<button type="button" class="ag2-btn ghost" data-open-item="${id}">Review</button>`;
   } else if (st.kind === 'suspended') {
     line = `Standing run suspended after ${e.consecutive_failures} failures — never silently re-fired`;
+    // The last self-reported reason, when one exists (Track AO): the
+    // owner sees WHY it kept failing, not just that it did.
+    const rep = e.last_run && e.last_run.attestation;
+    if (rep && (rep.outcome === 'blocked' || rep.outcome === 'abandoned')) {
+      const repNote = rep.note
+        ? ` — ${rep.note.length > 140 ? `${rep.note.slice(0, 140)}…` : rep.note}` : '';
+      line += ` · last self-report: ${rep.outcome}${repNote}`;
+    }
     actions = agendaDigestChipHtml(e.digest, 'Re-arm re-approves exactly this unchanged manifest revision')
       + `<button type="button" class="ag2-btn prim" data-op-btn="approve_effect" data-id="${id}" data-digest="${escapeHtml(e.digest || '')}" title="Re-approve the unchanged digest — resets the streak">Re-arm</button>`
       + `<button type="button" class="ag2-btn ghost" data-open-item="${id}">Review</button>`;
@@ -93247,11 +93325,21 @@ function agendaAutomationStripHtml(item) {
     : st.rec ? `every ${agendaCadenceLabel(st.rec.every_ms)}` : 'once')}</span>`);
   const last = e.last_run;
   if (last) {
+    // The transport tip stays the transport's own line — state + last
+    // words — never labeled or styled as a self-report (R6).
     const tip = `${last.state}${last.note ? ` — ${last.note}` : ''}`;
     const sess = last.session_id && agendaSessionInfo(last.session_id);
     const jump = sess && sess.key
       ? ` <a class="ag2-auto-run" data-jump-session="${escapeHtml(sess.key)}">open run</a>` : '';
     meta.push(`<span class="ag2-auto-last st-${escapeHtml(last.state)}" title="${escapeHtml(tip)}">last: ${escapeHtml(last.state)} ${escapeHtml(agendaRelTime(last.at_ms))}${jump}</span>`);
+    if (last.attestation) {
+      meta.push(`<span class="ag2-auto-attest att-${escapeHtml(last.attestation.outcome)}" title="${escapeHtml(agendaAttestHover(last.attestation))}">◆ self-reported: ${escapeHtml(last.attestation.outcome)}</span>`);
+    } else if (last.state !== 'started') {
+      meta.push(`<span class="ag2-auto-attest att-none" title="${escapeHtml(AGENDA_UNATTESTED_HOVER)}">◇ no self-report</span>`);
+    }
+    if ((e.last_run_attempt || 0) > 0) {
+      meta.push(`<span title="A bounded auto-retry of the same spent cause — the cooldown floor spaces attempts, the failure streak suspends the series">attempt ${e.last_run_attempt} (auto-retry)</span>`);
+    }
   }
   if ((e.consecutive_failures || 0) > 0 && !st.suspended) {
     meta.push(`<span class="ag2-auto-streak" title="Consecutive failed/unknown outcomes — the series suspends at ${st.threshold}">streak ${e.consecutive_failures}/${st.threshold}</span>`);
@@ -94318,13 +94406,39 @@ function agendaInspEffectHtml(item) {
       const sessionLink = s && s.key
         ? ` <a class="ag2-linkbtn" data-jump-session="${escapeHtml(s.key)}">view session ›</a>`
         : '';
+      const attempt = (e.last_run_attempt || 0) > 0
+        ? ` · attempt ${e.last_run_attempt} (auto-retry after failure)` : '';
+      // The self-report axis (Track AO): rendered as its own labeled
+      // block BESIDE the transport verdict — never sharing its glyph
+      // or palette. The transport note above it stays the transport's
+      // last-words line (R6), tooltip included.
+      const att = run.attestation || null;
+      let attestHtml = '';
+      if (att) {
+        const refs = (att.refs || []).map((r) => `<div class="ag2-attest-ref">
+            <span class="ag2-attest-ref-loc">${escapeHtml(r.locator)}</span>
+            <span class="ag2-hint" title="The pin the session stated at attest time — hash-verified at intake, re-checked on demand; a pointer, never inlined content">pin ${escapeHtml((r.sha256 || '').slice(0, 8))}</span>
+            <span class="agenda-ref-drift" data-item="${escapeHtml(item.id)}" data-locator="${escapeHtml(r.locator)}"></span>
+          </div>`).join('');
+        attestHtml = `<div class="ag2-eff-attest">
+          <div class="ag2-eff-lastrun-head">
+            ${agendaAttestChipHtml(att)}
+            <span class="ag2-hint">${escapeHtml(agendaRelTime(att.at_ms))}</span>
+          </div>
+          ${att.note ? `<div class="ag2-eff-attest-note">${escapeHtml(att.note)}</div>` : ''}
+          ${refs}
+        </div>`;
+      } else if (run.state !== 'started') {
+        attestHtml = `<div class="ag2-eff-attest">${agendaUnattestedChipHtml()}</div>`;
+      }
       lastRun = `<div class="ag2-eff-lastrun">
         <div class="ag2-eff-lastrun-head">
           ${agendaChipHtml(`last run · ${run.state}`, runTone)}
-          <span class="ag2-hint">${escapeHtml(agendaDepthCalm() ? agendaRelTime(run.at_ms) : `${agendaRelTime(run.at_ms)} · occurrence ${run.occurrence_id}`)}</span>
+          <span class="ag2-hint">${escapeHtml(agendaDepthCalm() ? agendaRelTime(run.at_ms) : `${agendaRelTime(run.at_ms)} · occurrence ${run.occurrence_id}${attempt}`)}</span>
           ${sessionLink}
         </div>
-        ${run.note ? `<div class="ag2-eff-note">${escapeHtml(run.note)}</div>` : ''}
+        ${run.note ? `<div class="ag2-eff-note" title="The session’s final message as the run ended — the transport record, not a self-report">${escapeHtml(run.note)}</div>` : ''}
+        ${attestHtml}
       </div>`;
     }
     const acts = [];
@@ -97003,6 +97117,12 @@ function agendaHoodOccurrenceLine(item, effect) {
   if (!run) return '';
   let state = run.state;
   let source = 'journal synced before dispatch';
+  // Track AO decorations: the regeneration ordinal (journal display
+  // field, fold-decorated fallback) and the run's self-report — always
+  // labeled as such, never blended into the transport state word.
+  let attempt = effect.last_run_attempt || 0;
+  const attest = run.attestation
+    ? ` · self-reported ${run.attestation.outcome} (the session’s own report — not verified)` : '';
   if (agendaHoodOcc && agendaHoodOcc.itemId !== item.id) {
     // Cache from a previous selection (only reachable when this item's
     // fetch is gated): claim nothing from it.
@@ -97013,7 +97133,9 @@ function agendaHoodOccurrenceLine(item, effect) {
       .filter((entry) => entry && entry.record
         && entry.record.occurrence_id === run.occurrence_id);
     if (records.length) {
-      state = records[records.length - 1].record.state || state;
+      const last = records[records.length - 1].record;
+      state = last.state || state;
+      attempt = records.reduce((n, entry) => entry.record.attempt || n, attempt);
     } else {
       source = 'fold view — the journal page holds no record for it';
     }
@@ -97022,9 +97144,10 @@ function agendaHoodOccurrenceLine(item, effect) {
   } else if (agendaHoodOcc && agendaHoodOcc.error) {
     source = 'fold view — journal read unavailable';
   }
+  const attemptPart = attempt > 0 ? ` · attempt ${attempt} (auto-retry)` : '';
   const requested = (effect.requested || []).length;
   const tail = requested ? ` · ${requested} owner run-request${requested > 1 ? 's' : ''}` : '';
-  return `<div class="ag2-hood-occ">${escapeHtml(`occurrence ${run.occurrence_id} · ${state} · ${source}${tail}`)}</div>`;
+  return `<div class="ag2-hood-occ">${escapeHtml(`occurrence ${run.occurrence_id} · ${state}${attemptPart} · ${source}${tail}${attest}`)}</div>`;
 }
 
 function agendaHoodManifestHtml(item) {
@@ -97153,6 +97276,7 @@ function agendaHoodOpVerb(op, envelope) {
     case 'revoke_effect': return 'approval revoked';
     case 'request_occurrence': return 'run requested';
     case 'record_occurrence': return `run ${op.state || '—'}`;
+    case 'attest': return `attested ${op.outcome || '—'} — self-report`;
     case 'record_ask_delivery':
       return op.delivered === false ? 'delivery pending — no live asker' : 'answer delivered';
     default: return `op · ${type || '—'}`;
@@ -97171,6 +97295,11 @@ function agendaHoodOpDot(op, known) {
       return op.state === 'completed' || op.state === 'delivered' ? 'green'
         : op.state === 'failed' ? 'rose'
           : op.state === 'started' ? 'iris' : 'amber';
+    // Self-report hues (Q8): achieved is sky — never the transport
+    // green; blocked/abandoned/partial are amber — never rose, which
+    // stays transport-failure.
+    case 'attest':
+      return op.outcome === 'achieved' ? 'sky' : 'amber';
     default: return 'neutral';
   }
 }

--- a/static/app/ui2-agenda-cards.js
+++ b/static/app/ui2-agenda-cards.js
@@ -720,6 +720,39 @@ function agendaChipHtml(label, tone, tip, dashed) {
   return `<span class="${cls.join(' ')}"${tip ? ` title="${escapeHtml(tip)}"` : ''}>${escapeHtml(label)}</span>`;
 }
 
+// ---- Attestation chips (Track AO — the Q8 labeling law, binding) ----
+// The self-report axis renders BESIDE the transport verdict, never as
+// it: every attestation surface says "self-reported" and carries the
+// not-verified hover; the ◆ self-report mark is the axis's own glyph,
+// never the transport palette's meaning (attested-achieved is sky —
+// never the transport-success green or its chip), and
+// blocked/abandoned/partial wear amber-class warning hues — never
+// rose, which stays transport-failure. Unattested is the DERIVED
+// absence state: a hollow neutral ◇ chip, "no self-report" — absence,
+// never anomaly styling, never synthesized into achieved.
+function agendaAttestTone(outcome) {
+  return outcome === 'achieved' ? 'sky' : 'amber';
+}
+
+function agendaAttestHover(att) {
+  const base = 'The session’s own report — not verified.';
+  if (!att || !att.note) return base;
+  const note = att.note.length > 200 ? `${att.note.slice(0, 200)}…` : att.note;
+  return `${base} “${note}”`;
+}
+
+function agendaAttestChipHtml(att) {
+  return agendaChipHtml(`◆ self-reported: ${att.outcome}`, agendaAttestTone(att.outcome),
+    agendaAttestHover(att));
+}
+
+const AGENDA_UNATTESTED_HOVER =
+  'No self-report exists for this run — the session ended without attesting. Absence, not failure.';
+
+function agendaUnattestedChipHtml() {
+  return agendaChipHtml('◇ no self-report', 'neutral', AGENDA_UNATTESTED_HOVER, true);
+}
+
 function agendaCardChips(item) {
   const chips = [];
   const st = agendaEffectState(item);
@@ -897,6 +930,14 @@ function agendaCardEffectStrip(item) {
       + `<button type="button" class="ag2-btn ghost" data-open-item="${id}">Review</button>`;
   } else if (st.kind === 'suspended') {
     line = `Standing run suspended after ${e.consecutive_failures} failures — never silently re-fired`;
+    // The last self-reported reason, when one exists (Track AO): the
+    // owner sees WHY it kept failing, not just that it did.
+    const rep = e.last_run && e.last_run.attestation;
+    if (rep && (rep.outcome === 'blocked' || rep.outcome === 'abandoned')) {
+      const repNote = rep.note
+        ? ` — ${rep.note.length > 140 ? `${rep.note.slice(0, 140)}…` : rep.note}` : '';
+      line += ` · last self-report: ${rep.outcome}${repNote}`;
+    }
     actions = agendaDigestChipHtml(e.digest, 'Re-arm re-approves exactly this unchanged manifest revision')
       + `<button type="button" class="ag2-btn prim" data-op-btn="approve_effect" data-id="${id}" data-digest="${escapeHtml(e.digest || '')}" title="Re-approve the unchanged digest — resets the streak">Re-arm</button>`
       + `<button type="button" class="ag2-btn ghost" data-open-item="${id}">Review</button>`;
@@ -935,11 +976,21 @@ function agendaAutomationStripHtml(item) {
     : st.rec ? `every ${agendaCadenceLabel(st.rec.every_ms)}` : 'once')}</span>`);
   const last = e.last_run;
   if (last) {
+    // The transport tip stays the transport's own line — state + last
+    // words — never labeled or styled as a self-report (R6).
     const tip = `${last.state}${last.note ? ` — ${last.note}` : ''}`;
     const sess = last.session_id && agendaSessionInfo(last.session_id);
     const jump = sess && sess.key
       ? ` <a class="ag2-auto-run" data-jump-session="${escapeHtml(sess.key)}">open run</a>` : '';
     meta.push(`<span class="ag2-auto-last st-${escapeHtml(last.state)}" title="${escapeHtml(tip)}">last: ${escapeHtml(last.state)} ${escapeHtml(agendaRelTime(last.at_ms))}${jump}</span>`);
+    if (last.attestation) {
+      meta.push(`<span class="ag2-auto-attest att-${escapeHtml(last.attestation.outcome)}" title="${escapeHtml(agendaAttestHover(last.attestation))}">◆ self-reported: ${escapeHtml(last.attestation.outcome)}</span>`);
+    } else if (last.state !== 'started') {
+      meta.push(`<span class="ag2-auto-attest att-none" title="${escapeHtml(AGENDA_UNATTESTED_HOVER)}">◇ no self-report</span>`);
+    }
+    if ((e.last_run_attempt || 0) > 0) {
+      meta.push(`<span title="A bounded auto-retry of the same spent cause — the cooldown floor spaces attempts, the failure streak suspends the series">attempt ${e.last_run_attempt} (auto-retry)</span>`);
+    }
   }
   if ((e.consecutive_failures || 0) > 0 && !st.suspended) {
     meta.push(`<span class="ag2-auto-streak" title="Consecutive failed/unknown outcomes — the series suspends at ${st.threshold}">streak ${e.consecutive_failures}/${st.threshold}</span>`);

--- a/static/app/ui2-agenda-hood.js
+++ b/static/app/ui2-agenda-hood.js
@@ -211,6 +211,12 @@ function agendaHoodOccurrenceLine(item, effect) {
   if (!run) return '';
   let state = run.state;
   let source = 'journal synced before dispatch';
+  // Track AO decorations: the regeneration ordinal (journal display
+  // field, fold-decorated fallback) and the run's self-report — always
+  // labeled as such, never blended into the transport state word.
+  let attempt = effect.last_run_attempt || 0;
+  const attest = run.attestation
+    ? ` · self-reported ${run.attestation.outcome} (the session’s own report — not verified)` : '';
   if (agendaHoodOcc && agendaHoodOcc.itemId !== item.id) {
     // Cache from a previous selection (only reachable when this item's
     // fetch is gated): claim nothing from it.
@@ -221,7 +227,9 @@ function agendaHoodOccurrenceLine(item, effect) {
       .filter((entry) => entry && entry.record
         && entry.record.occurrence_id === run.occurrence_id);
     if (records.length) {
-      state = records[records.length - 1].record.state || state;
+      const last = records[records.length - 1].record;
+      state = last.state || state;
+      attempt = records.reduce((n, entry) => entry.record.attempt || n, attempt);
     } else {
       source = 'fold view — the journal page holds no record for it';
     }
@@ -230,9 +238,10 @@ function agendaHoodOccurrenceLine(item, effect) {
   } else if (agendaHoodOcc && agendaHoodOcc.error) {
     source = 'fold view — journal read unavailable';
   }
+  const attemptPart = attempt > 0 ? ` · attempt ${attempt} (auto-retry)` : '';
   const requested = (effect.requested || []).length;
   const tail = requested ? ` · ${requested} owner run-request${requested > 1 ? 's' : ''}` : '';
-  return `<div class="ag2-hood-occ">${escapeHtml(`occurrence ${run.occurrence_id} · ${state} · ${source}${tail}`)}</div>`;
+  return `<div class="ag2-hood-occ">${escapeHtml(`occurrence ${run.occurrence_id} · ${state}${attemptPart} · ${source}${tail}${attest}`)}</div>`;
 }
 
 function agendaHoodManifestHtml(item) {
@@ -361,6 +370,7 @@ function agendaHoodOpVerb(op, envelope) {
     case 'revoke_effect': return 'approval revoked';
     case 'request_occurrence': return 'run requested';
     case 'record_occurrence': return `run ${op.state || '—'}`;
+    case 'attest': return `attested ${op.outcome || '—'} — self-report`;
     case 'record_ask_delivery':
       return op.delivered === false ? 'delivery pending — no live asker' : 'answer delivered';
     default: return `op · ${type || '—'}`;
@@ -379,6 +389,11 @@ function agendaHoodOpDot(op, known) {
       return op.state === 'completed' || op.state === 'delivered' ? 'green'
         : op.state === 'failed' ? 'rose'
           : op.state === 'started' ? 'iris' : 'amber';
+    // Self-report hues (Q8): achieved is sky — never the transport
+    // green; blocked/abandoned/partial are amber — never rose, which
+    // stays transport-failure.
+    case 'attest':
+      return op.outcome === 'achieved' ? 'sky' : 'amber';
     default: return 'neutral';
   }
 }

--- a/static/app/ui2-agenda-inspector.css
+++ b/static/app/ui2-agenda-inspector.css
@@ -373,6 +373,33 @@ html.ui-v2 .ag2-eff-note {
   border-left: 2px solid var(--line);
   padding-left: 9px;
 }
+/* The self-report block (Track AO): its own labeled lane under the
+   transport row — amber-edged so the axis never blends into the
+   transport note above it. */
+html.ui-v2 .ag2-eff-attest {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+html.ui-v2 .ag2-eff-attest-note {
+  font-size: 12px;
+  color: var(--text-2);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  border-left: 2px solid rgba(var(--amber-rgb), 0.45);
+  padding-left: 9px;
+}
+html.ui-v2 .ag2-attest-ref {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 11px;
+}
+html.ui-v2 .ag2-attest-ref-loc {
+  font-family: var(--mono);
+  color: var(--text-2);
+  overflow-wrap: anywhere;
+}
 html.ui-v2 .ag2-insp-noeff {
   display: flex;
   align-items: center;

--- a/static/app/ui2-agenda-inspector.js
+++ b/static/app/ui2-agenda-inspector.js
@@ -416,13 +416,39 @@ function agendaInspEffectHtml(item) {
       const sessionLink = s && s.key
         ? ` <a class="ag2-linkbtn" data-jump-session="${escapeHtml(s.key)}">view session ›</a>`
         : '';
+      const attempt = (e.last_run_attempt || 0) > 0
+        ? ` · attempt ${e.last_run_attempt} (auto-retry after failure)` : '';
+      // The self-report axis (Track AO): rendered as its own labeled
+      // block BESIDE the transport verdict — never sharing its glyph
+      // or palette. The transport note above it stays the transport's
+      // last-words line (R6), tooltip included.
+      const att = run.attestation || null;
+      let attestHtml = '';
+      if (att) {
+        const refs = (att.refs || []).map((r) => `<div class="ag2-attest-ref">
+            <span class="ag2-attest-ref-loc">${escapeHtml(r.locator)}</span>
+            <span class="ag2-hint" title="The pin the session stated at attest time — hash-verified at intake, re-checked on demand; a pointer, never inlined content">pin ${escapeHtml((r.sha256 || '').slice(0, 8))}</span>
+            <span class="agenda-ref-drift" data-item="${escapeHtml(item.id)}" data-locator="${escapeHtml(r.locator)}"></span>
+          </div>`).join('');
+        attestHtml = `<div class="ag2-eff-attest">
+          <div class="ag2-eff-lastrun-head">
+            ${agendaAttestChipHtml(att)}
+            <span class="ag2-hint">${escapeHtml(agendaRelTime(att.at_ms))}</span>
+          </div>
+          ${att.note ? `<div class="ag2-eff-attest-note">${escapeHtml(att.note)}</div>` : ''}
+          ${refs}
+        </div>`;
+      } else if (run.state !== 'started') {
+        attestHtml = `<div class="ag2-eff-attest">${agendaUnattestedChipHtml()}</div>`;
+      }
       lastRun = `<div class="ag2-eff-lastrun">
         <div class="ag2-eff-lastrun-head">
           ${agendaChipHtml(`last run · ${run.state}`, runTone)}
-          <span class="ag2-hint">${escapeHtml(agendaDepthCalm() ? agendaRelTime(run.at_ms) : `${agendaRelTime(run.at_ms)} · occurrence ${run.occurrence_id}`)}</span>
+          <span class="ag2-hint">${escapeHtml(agendaDepthCalm() ? agendaRelTime(run.at_ms) : `${agendaRelTime(run.at_ms)} · occurrence ${run.occurrence_id}${attempt}`)}</span>
           ${sessionLink}
         </div>
-        ${run.note ? `<div class="ag2-eff-note">${escapeHtml(run.note)}</div>` : ''}
+        ${run.note ? `<div class="ag2-eff-note" title="The session’s final message as the run ended — the transport record, not a self-report">${escapeHtml(run.note)}</div>` : ''}
+        ${attestHtml}
       </div>`;
     }
     const acts = [];

--- a/static/app/ui2-agenda.css
+++ b/static/app/ui2-agenda.css
@@ -534,6 +534,7 @@ html.ui-v2 .ag2-chip.dashed {
   background: none;
   border-style: dashed;
 }
+html.ui-v2 .ag2-chip.t-neutral.dashed { border-color: var(--line-2); }
 html.ui-v2 .ag2-chip.t-green.dashed { border-color: rgba(var(--green-rgb), 0.45); }
 html.ui-v2 .ag2-chip.t-amber.dashed { border-color: rgba(var(--amber-rgb), 0.45); }
 html.ui-v2 .ag2-chip.t-rose.dashed { border-color: rgba(var(--rose-rgb), 0.45); }
@@ -729,6 +730,15 @@ html.ui-v2 .ag2-auto-last.st-unknown,
 html.ui-v2 .ag2-auto-streak { color: var(--rose); font-weight: 600; }
 html.ui-v2 .ag2-auto-last.st-completed { color: var(--green); }
 html.ui-v2 .ag2-auto-run { cursor: pointer; text-decoration: underline; }
+/* Attestation (Track AO) — the self-report axis, never the transport
+   palette: achieved sky (never transport-success green), the rest
+   amber-class (never rose = transport failure); unattested is neutral
+   absence, no anomaly styling. */
+html.ui-v2 .ag2-auto-attest.att-achieved { color: var(--sky); }
+html.ui-v2 .ag2-auto-attest.att-partial,
+html.ui-v2 .ag2-auto-attest.att-blocked,
+html.ui-v2 .ag2-auto-attest.att-abandoned { color: var(--amber); }
+html.ui-v2 .ag2-auto-attest.att-none { color: var(--text-2); opacity: 0.85; }
 
 /* ---- Inline question answering ---- */
 


### PR DESCRIPTION
Track AO slice S4 (sealed basis: the AO intake + RULING + RIDER RULING; fired from commission item 01KYNE12KPPZGH2XQ21A0CF1J2). Branch stacked on the landed S3 (#660) — the diff vs main is exactly the S4 delta.

**The Q8 labeling law, binding, asserted in a pin:** every attestation surface says **self-reported** + hovers 'the session's own report — not verified'; ◆ is the self-report axis's own mark; attested-achieved renders sky, never the transport-success green chip; blocked/abandoned/partial amber-class, never rose; unattested = hollow neutral ◇ 'no self-report' (absence, never anomaly). **R6's negative held:** the transport note stays the transport's last-words line, strip tip + inspector tooltip included.

Surfaces: automation strip + inspector run block (attestation chip, self-report note, refs as locator+pin with the expand-time drift chip through the existing lane), suspended card's last-self-reported-reason line, hood occurrence row '· attempt N' + attest ops first-class, streak fraction already served. Regeneration legibility: journal fold retains the display-only `attempt`; `effects[].last_run_attempt` is a serving-seam decoration (the `next_fire_ms` pattern) driving 'attempt 2 (auto-retry after failure)'. Docs: the two-axis vocabulary section + the docs-side boot/crash prose fix.

**Precision on the S3-seam declaration:** S4 adds display-only, additive code in reminders.rs (fold retention + decoration) and store.rs (the drift helper) — S3's regeneration logic (identity, walk, planner candidates, scheduler lanes) is byte-untouched.

Pins: `attestation_chips_follow_the_labeling_law`, `last_run_attempt_is_decorated_from_the_journal_fold`, `attestation_ref_drift_resolves_the_binding_ref_scheme`.

Battery: bins 5183+149+97 green, 14 lib suites green, workspace clippy -D warnings clean, e2e 37/37, fmt clean, fragments regenerated via the assembler (both committed).