### PR TITLE
feat(app+dashboard): one-click takeover lane — app supervisor update swap + honest CLI hand-off (HS6/P3)

### DIFF
--- a/macos-app/BackendSupervisor.swift
+++ b/macos-app/BackendSupervisor.swift
@@ -31,6 +31,11 @@ protocol BackendSupervisorDelegate: AnyObject {
     /// alive and health checks run (the app layer uses it for dashboard
     /// idle-unload).
     func backendSupervisorHealthTick(_ supervisor: BackendSupervisor)
+    /// A one-click update swap promoted a successor child on `newPort`
+    /// (HS6/P3): the app layer re-points the scheme handler, injected
+    /// scripts, and webview. Deliberately NOT a `didChangeState` screen —
+    /// the working dashboard must never be painted over mid-swap.
+    func backendSupervisor(_ supervisor: BackendSupervisor, didSwapToPort newPort: Int)
 }
 
 /// Supervises the bundled Rust daemon: spawn, readiness polling, health
@@ -48,14 +53,24 @@ final class BackendSupervisor {
     weak var delegate: BackendSupervisorDelegate?
 
     private let binaryPath: String
-    private let arguments: [String]
-    private let port: Int
+    /// Arguments WITHOUT the `--web <port>` pair — composed per spawn, so
+    /// an update swap can launch the successor on a fresh port with the
+    /// same policy args.
+    private let baseArguments: [String]
+    /// The port the CURRENT backend serves; flips at update-swap promote.
+    private(set) var port: Int
     private let scheme: String
     /// Trust-configured session shared with the app layer (pins the
     /// installed access server cert / presents the mTLS client identity).
     private let session: URLSession
 
     private var backendProcess: Process?
+    /// The swapped-out predecessor, draining toward its own exit (HS6/P3).
+    /// The swap NEVER terminates it — it serves its in-flight sessions and
+    /// exits at the last one (`app_supervisor_one_click_swaps_without_kill`);
+    /// only app quit tears it down along with everything else.
+    private var drainingProcess: Process?
+    private var swapInFlight = false
     private var healthTimer: Timer?
     private var healthProbeFailures = 0
     // Backend auto-restart: exponential backoff on abnormal exits, reset
@@ -72,9 +87,9 @@ final class BackendSupervisor {
     /// Rotate `app-backend.log` at launch once it exceeds this many bytes.
     private static let maxLogBytes: UInt64 = 10 * 1024 * 1024
 
-    init(binaryPath: String, arguments: [String], port: Int, scheme: String, session: URLSession) {
+    init(binaryPath: String, baseArguments: [String], port: Int, scheme: String, session: URLSession) {
         self.binaryPath = binaryPath
-        self.arguments = arguments
+        self.baseArguments = baseArguments
         self.port = port
         self.scheme = scheme
         self.session = session
@@ -86,14 +101,34 @@ final class BackendSupervisor {
     /// launchd), wiring stdout/stderr into the append-mode backend log.
     @discardableResult
     func startBackend() -> Bool {
+        guard let process = spawnChild(onPort: port) else { return false }
+        backendProcess = process
+        backendLastStart = Date()
+        // React to backend death immediately (the 5s health tick stays
+        // as the belt for a missed handler). Remote dashboards have no
+        // crash screen — without a restart this machine just goes dark.
+        process.terminationHandler = { [weak self] proc in
+            DispatchQueue.main.async {
+                self?.backendDidExit(proc)
+            }
+        }
+        NSLog("Started intendant-bin (PID \(process.processIdentifier)) on port \(port)")
+        return true
+    }
+
+    /// Spawn one daemon child on `childPort` (shared by the normal boot
+    /// and the update swap's successor): environment, working directory,
+    /// and the append-mode backend log, but NO lifecycle wiring — the
+    /// caller owns handlers and slots.
+    private func spawnChild(onPort childPort: Int) -> Process? {
         guard FileManager.default.fileExists(atPath: binaryPath) else {
             NSLog("intendant-bin not found at \(binaryPath)")
-            return false
+            return nil
         }
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: binaryPath)
-        process.arguments = arguments
+        process.arguments = ["--web", String(childPort)] + baseArguments
 
         // Inherit environment + ensure Homebrew PATH
         var env = ProcessInfo.processInfo.environment
@@ -139,22 +174,144 @@ final class BackendSupervisor {
 
         do {
             try process.run()
-            backendProcess = process
-            backendLastStart = Date()
-            // React to backend death immediately (the 5s health tick stays
-            // as the belt for a missed handler). Remote dashboards have no
-            // crash screen — without a restart this machine just goes dark.
-            process.terminationHandler = { [weak self] proc in
-                DispatchQueue.main.async {
-                    self?.backendDidExit(proc)
-                }
-            }
-            NSLog("Started intendant-bin (PID \(process.processIdentifier)) on port \(port)")
-            return true
+            return process
         } catch {
             NSLog("Failed to start intendant-bin: \(error)")
-            return false
+            return nil
         }
+    }
+
+    // MARK: - One-click update swap (HS6/P3)
+
+    /// One-click update (the owner directive on HS6): spawn a SECOND
+    /// child from the (updated) on-disk binary on `newPort`, poll
+    /// readiness THERE, and only once the successor answers: promote it,
+    /// ask the predecessor to drain (the HS3 takeover lane on its own
+    /// port), and report `didSwapToPort` so the app layer re-points the
+    /// webview. Ordering is the intake sketch's — spawn → readiness →
+    /// swap → drain — so a successor that never comes up is simply
+    /// terminated (it acquired nothing and drained nothing) and the
+    /// running daemon is left exactly as it was; the predecessor is
+    /// NEVER terminated by the swap — it serves its in-flight sessions
+    /// and exits on its own at the last one.
+    func beginUpdateSwap(newPort: Int, completion: @escaping (Bool, String) -> Void) {
+        guard !swapInFlight else {
+            completion(false, "an update swap is already in flight")
+            return
+        }
+        guard let old = backendProcess, old.isRunning else {
+            completion(false, "no running backend to swap from")
+            return
+        }
+        guard let successor = spawnChild(onPort: newPort) else {
+            completion(false, "could not start the new daemon — see ~/.intendant/app-backend.log")
+            return
+        }
+        swapInFlight = true
+        NSLog("Update swap: successor spawned (PID \(successor.processIdentifier)) on port \(newPort)")
+        pollSwapReadiness(successor: successor, newPort: newPort, attempts: 0, completion: completion)
+    }
+
+    private func pollSwapReadiness(successor: Process, newPort: Int, attempts: Int,
+                                   completion: @escaping (Bool, String) -> Void) {
+        // A successor that died mid-boot (the broken-new-binary case)
+        // fails the swap fast and leaves the running daemon untouched.
+        if !successor.isRunning {
+            finishFailedSwap(successor: successor, completion: completion,
+                             detail: "the new daemon exited during startup — the running daemon is untouched (see ~/.intendant/app-backend.log)")
+            return
+        }
+        if attempts > 30 {
+            finishFailedSwap(successor: successor, completion: completion,
+                             detail: "the new daemon never became ready — the running daemon is untouched (see ~/.intendant/app-backend.log)")
+            return
+        }
+        var request = URLRequest(url: URL(string: "\(scheme)://127.0.0.1:\(newPort)/")!, timeoutInterval: 1)
+        request.httpMethod = "HEAD"
+        session.dataTask(with: request) { _, response, _ in
+            DispatchQueue.main.async {
+                if let http = response as? HTTPURLResponse, http.statusCode == 200 {
+                    self.promoteSuccessor(successor, newPort: newPort, completion: completion)
+                } else {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                        self.pollSwapReadiness(successor: successor, newPort: newPort,
+                                               attempts: attempts + 1, completion: completion)
+                    }
+                }
+            }
+        }.resume()
+    }
+
+    /// The successor answered: swap roles, then ask the predecessor to
+    /// drain. The predecessor keeps running (never terminated here) with
+    /// a log-only exit handler — its clean drain exit must paint no
+    /// crash/stopped screen and schedule no restart.
+    private func promoteSuccessor(_ successor: Process, newPort: Int,
+                                  completion: @escaping (Bool, String) -> Void) {
+        guard swapInFlight else { return }
+        swapInFlight = false
+        let oldPort = port
+        if let old = backendProcess {
+            old.terminationHandler = { [weak self] proc in
+                DispatchQueue.main.async {
+                    NSLog("Drained predecessor exited (status \(proc.terminationStatus))")
+                    self?.writeExitMarker(status: proc.terminationStatus,
+                                          signalled: proc.terminationReason == .uncaughtSignal)
+                    if self?.drainingProcess === proc {
+                        self?.drainingProcess = nil
+                    }
+                }
+            }
+            drainingProcess = old
+        }
+        backendProcess = successor
+        port = newPort
+        backendLastStart = Date()
+        backendRestartAttempts = 0
+        healthProbeFailures = 0
+        successor.terminationHandler = { [weak self] proc in
+            DispatchQueue.main.async {
+                self?.backendDidExit(proc)
+            }
+        }
+        startHealthCheck()
+        NSLog("Update swap: promoted successor on port \(newPort); asking :\(oldPort) to drain")
+        requestDrain(ofPort: oldPort)
+        delegate?.backendSupervisor(self, didSwapToPort: newPort)
+        completion(true, "")
+    }
+
+    private func finishFailedSwap(successor: Process, completion: @escaping (Bool, String) -> Void,
+                                  detail: String) {
+        swapInFlight = false
+        successor.terminationHandler = nil
+        if successor.isRunning {
+            // The successor acquired nothing and drained nothing — a
+            // plain secondary; terminating it is clean recovery.
+            successor.terminate()
+        }
+        NSLog("Update swap failed: \(detail)")
+        completion(false, detail)
+    }
+
+    /// The HS3 takeover lane against the predecessor's own port: ask it
+    /// to drain so the promoted successor's lease poll acquires. Rides
+    /// the same per-port loopback admission token every owner surface
+    /// uses; the request is logged, never fatal — the drain banner and
+    /// the Q4 successor watch carry the story from here.
+    private func requestDrain(ofPort oldPort: Int) {
+        guard let url = URL(string: "\(scheme)://127.0.0.1:\(oldPort)/api/daemon/takeover") else { return }
+        var request = URLRequest(url: url, timeoutInterval: 5)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let token = loopbackAdmissionToken(port: oldPort), !token.isEmpty {
+            request.setValue(token, forHTTPHeaderField: "x-intendant-loopback-token")
+        }
+        request.httpBody = try? JSONSerialization.data(withJSONObject: ["requested_by": "app update swap"])
+        session.dataTask(with: request) { _, response, error in
+            let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+            NSLog("Update swap: drain request to :\(oldPort) answered \(status)\(error.map { " error: \($0.localizedDescription)" } ?? "")")
+        }.resume()
     }
 
     /// Manual (crash-screen Restart button) or auto-restart-timer restart:
@@ -177,21 +334,26 @@ final class BackendSupervisor {
         return started
     }
 
-    /// Quit teardown: kill the child on purpose without letting the exit
-    /// handler paint a crash screen or schedule a restart mid-teardown.
+    /// Quit teardown: kill the children on purpose without letting exit
+    /// handlers paint a crash screen or schedule a restart mid-teardown.
+    /// Quit is the explicit "stop everything" gesture, so a mid-drain
+    /// predecessor goes down with the promoted successor.
     func shutdown() {
         isTerminating = true
         backendAutoRestartTimer?.invalidate()
         healthTimer?.invalidate()
-        guard let proc = backendProcess, proc.isRunning else { return }
-        proc.terminationHandler = nil
-        proc.terminate()
+        let children = [backendProcess, drainingProcess].compactMap { $0 }.filter { $0.isRunning }
+        guard !children.isEmpty else { return }
+        for proc in children {
+            proc.terminationHandler = nil
+            proc.terminate()
+        }
         // Wait up to 3 seconds, then force-kill to avoid hanging on quit
         let deadline = Date().addingTimeInterval(3.0)
-        while proc.isRunning && Date() < deadline {
+        while children.contains(where: { $0.isRunning }) && Date() < deadline {
             Thread.sleep(forTimeInterval: 0.1)
         }
-        if proc.isRunning {
+        for proc in children where proc.isRunning {
             kill(proc.processIdentifier, SIGKILL)
         }
     }

--- a/macos-app/main.swift
+++ b/macos-app/main.swift
@@ -192,7 +192,9 @@ class BackendTrustDelegate: NSObject, URLSessionDelegate {
 /// status while the proxy can still speak HTTP or HTTPS to the spawned daemon.
 class BackendSchemeHandler: NSObject, WKURLSchemeHandler {
     let launchPlan: BackendLaunchPlan
-    let port: Int
+    /// Mutable: a one-click update swap re-points the proxy at the
+    /// promoted successor's port (main-thread writes; per-request reads).
+    var port: Int
     private var stopped = Set<Int>()
     private let lock = NSLock()
     private let session: URLSession
@@ -276,6 +278,7 @@ final class AppMessageBridge: NSObject, WKScriptMessageHandler {
         switch message.name {
         case "activate": appDelegate?.activateDashboard()
         case "restart": appDelegate?.restartBackend()
+        case "updateSwap": appDelegate?.beginUpdateSwapFromDashboard()
         default: break
         }
     }
@@ -288,6 +291,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
     let messageBridge = AppMessageBridge()
     var window: NSWindow!
     var webView: WKWebView!
+    /// Retained so an update swap can re-point the `intendant://` proxy
+    /// at the promoted successor's port.
+    var schemeHandler: BackendSchemeHandler!
     /// Owns the daemon child process, restart/backoff policy, readiness
     /// polling, health checks, and the backend log (see
     /// macos-app/BackendSupervisor.swift). State changes come back through
@@ -787,8 +793,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
     /// process lifecycle, restart backoff, readiness polling, health
     /// checks, and the backend log live in BackendSupervisor.
     func makeBackendSupervisor() -> BackendSupervisor {
-        // Forward any extra CLI arguments (e.g. --agent codex) to the backend
-        var args = ["--web", String(port)]
+        // Forward any extra CLI arguments (e.g. --agent codex) to the
+        // backend. The `--web <port>` pair is composed per spawn by the
+        // supervisor, so an update swap can boot the successor on a
+        // fresh port with the same policy args.
+        var args: [String] = []
         if launchPlan.autoMtls {
             args.append("--mtls")
         } else if launchPlan.autoNoTls {
@@ -797,7 +806,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
         args.append(contentsOf: launchPlan.extraArgs)
         let supervisor = BackendSupervisor(
             binaryPath: Bundle.main.bundlePath + "/Contents/MacOS/intendant-bin",
-            arguments: args,
+            baseArguments: args,
             port: port,
             scheme: launchPlan.scheme,
             session: backendSession
@@ -844,45 +853,81 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
         }
     }
 
+    // MARK: - One-click update swap (HS6/P3)
+
+    /// The dashboard's update chip asked for the one-click update
+    /// (bridge message `updateSwap`): pick a fresh port and let the
+    /// supervisor run the spawn → readiness → swap → drain sequence.
+    /// Failure feedback rides `window.__intendantAppSwapFailed` back
+    /// into the chip; success repaints through `didSwapToPort`.
+    func beginUpdateSwapFromDashboard() {
+        guard let fresh = findAvailablePort(startingAt: port + 1) else {
+            NSLog("Update swap: no free port near \(port)")
+            notifySwapFailed("no free port for the new daemon")
+            return
+        }
+        NSLog("Update swap requested from the dashboard — successor on port \(fresh)")
+        backendSupervisor.beginUpdateSwap(newPort: fresh) { [weak self] ok, detail in
+            if !ok {
+                self?.notifySwapFailed(detail)
+            }
+        }
+    }
+
+    func notifySwapFailed(_ detail: String) {
+        let literal: String
+        if let data = try? JSONSerialization.data(withJSONObject: detail, options: .fragmentsAllowed),
+           let encoded = String(data: data, encoding: .utf8) {
+            literal = encoded
+        } else {
+            literal = "\"update swap failed\""
+        }
+        webView?.evaluateJavaScript(
+            "window.__intendantAppSwapFailed && window.__intendantAppSwapFailed(\(literal))",
+            completionHandler: nil
+        )
+    }
+
+    /// The supervisor promoted the successor: re-point the proxy and the
+    /// injected port script, then reload whatever surface is up so the
+    /// tab attaches to the new daemon (fresh boot_id, fresh token). The
+    /// drained predecessor keeps serving its in-flight sessions until it
+    /// exits on its own.
+    func backendSupervisor(_ supervisor: BackendSupervisor, didSwapToPort newPort: Int) {
+        NSLog("Update swap: dashboard re-pointing to port \(newPort)")
+        port = newPort
+        schemeHandler?.port = newPort
+        if let controller = webView?.configuration.userContentController {
+            installUserScripts(controller, port: newPort)
+        }
+        window?.title = newPort == 8765 ? "Intendant" : "Intendant (port \(newPort))"
+        if dashboardActive {
+            dashboardActive = false
+            activateDashboard()
+        } else {
+            showPlaceholder(paused: false)
+        }
+    }
+
     // MARK: - Window
 
-    func createWindow() {
-        let config = WKWebViewConfiguration()
-        config.preferences.setValue(true, forKey: "developerExtrasEnabled")
-
-        // Allow media autoplay (for voice features)
-        config.mediaTypesRequiringUserActionForPlayback = []
-
-        // Use a non-persistent data store so WKWebView never caches WASM/JS
-        // across app launches. Without this, recompiled WASM may not load.
-        config.websiteDataStore = WKWebsiteDataStore.nonPersistent()
-
-        // Serve pages from a custom scheme so WKWebView grants a secure
-        // context (required for navigator.mediaDevices / getUserMedia).
-        config.setURLSchemeHandler(
-            BackendSchemeHandler(port: port, launchPlan: launchPlan, session: backendSession),
-            forURLScheme: "intendant"
-        )
-
-        // Inject backend port so JS can build WebSocket URLs (WebSocket
-        // connections bypass the scheme handler and need the real address).
+    /// (Re-)install the injected user scripts for `port`. The port and
+    /// TLS flag ride a document-start script (WebSocket connections
+    /// bypass the scheme handler and need the real address), and
+    /// `__intendantAppSupervisor` marks the supervisor's presence so the
+    /// dashboard's update chip renders the one-click action instead of
+    /// the CLI-daemon hand-off. Re-run at update swap with the new port
+    /// (scripts are fixed strings, so a swap must replace them).
+    func installUserScripts(_ controller: WKUserContentController, port: Int) {
+        controller.removeAllUserScripts()
         let tlsLiteral = launchPlan.usesTLS ? "true" : "false"
-        let script = WKUserScript(
-            source: "window.__intendantPort = \(port); window.__intendantBackendTls = \(tlsLiteral);",
+        let portScript = WKUserScript(
+            source: "window.__intendantPort = \(port); window.__intendantBackendTls = \(tlsLiteral); "
+                + "window.__intendantAppSupervisor = true;",
             injectionTime: .atDocumentStart,
             forMainFrameOnly: true
         )
-        config.userContentController.addUserScript(script)
-
-        // Forward page console output to NSLog so `Console.app` and
-        // terminal launches can see what the dashboard is doing — the
-        // WKWebView inspector is rarely attached when it matters.
-        config.userContentController.add(consoleBridge, name: "log")
-
-        // Placeholder "Activate Dashboard" + crash-screen "Restart".
-        messageBridge.appDelegate = self
-        config.userContentController.add(messageBridge, name: "activate")
-        config.userContentController.add(messageBridge, name: "restart")
+        controller.addUserScript(portScript)
         let consoleScript = WKUserScript(
             source: """
             (() => {
@@ -904,7 +949,37 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
             injectionTime: .atDocumentStart,
             forMainFrameOnly: true
         )
-        config.userContentController.addUserScript(consoleScript)
+        controller.addUserScript(consoleScript)
+    }
+
+    func createWindow() {
+        let config = WKWebViewConfiguration()
+        config.preferences.setValue(true, forKey: "developerExtrasEnabled")
+
+        // Allow media autoplay (for voice features)
+        config.mediaTypesRequiringUserActionForPlayback = []
+
+        // Use a non-persistent data store so WKWebView never caches WASM/JS
+        // across app launches. Without this, recompiled WASM may not load.
+        config.websiteDataStore = WKWebsiteDataStore.nonPersistent()
+
+        // Serve pages from a custom scheme so WKWebView grants a secure
+        // context (required for navigator.mediaDevices / getUserMedia).
+        schemeHandler = BackendSchemeHandler(port: port, launchPlan: launchPlan, session: backendSession)
+        config.setURLSchemeHandler(schemeHandler, forURLScheme: "intendant")
+
+        // Forward page console output to NSLog so `Console.app` and
+        // terminal launches can see what the dashboard is doing — the
+        // WKWebView inspector is rarely attached when it matters.
+        config.userContentController.add(consoleBridge, name: "log")
+
+        // Placeholder "Activate Dashboard" + crash-screen "Restart" +
+        // the update chip's one-click swap.
+        messageBridge.appDelegate = self
+        config.userContentController.add(messageBridge, name: "activate")
+        config.userContentController.add(messageBridge, name: "restart")
+        config.userContentController.add(messageBridge, name: "updateSwap")
+        installUserScripts(config.userContentController, port: port)
 
         webView = WKWebView(frame: .zero, configuration: config)
         webView.uiDelegate = self

--- a/src/bin/caller/handover/mod.rs
+++ b/src/bin/caller/handover/mod.rs
@@ -1027,4 +1027,102 @@ mod tests {
             );
         }
     }
+
+    /// Commission pin `update_chip_offers_action_not_command` (owner
+    /// directive on HS6): the update chip carries BUTTONS — the app
+    /// supervisor's one-click and the CLI daemon's hand-off — never a
+    /// command string for the owner to retype.
+    #[test]
+    fn update_chip_offers_action_not_command() {
+        let fragment = include_str!("../../../../static/app/ui2-handover.js");
+        for needle in [
+            "'Update now'",
+            "updateSwap.postMessage",
+            "Hand off to :",
+            "'/api/daemon/takeover'",
+            "__intendantAppSupervisor",
+        ] {
+            assert!(
+                fragment.contains(needle),
+                "the update chip lost its action affordance: {needle}"
+            );
+        }
+    }
+
+    /// Commission pin `cli_daemon_button_is_honest_about_its_reach`: on
+    /// a CLI-launched daemon the chip can drain THIS daemon toward an
+    /// already-running newer one (the takeover lane), and when none is
+    /// running it says it cannot launch one — on the glass, without
+    /// delegating anyone to a terminal.
+    #[test]
+    fn cli_daemon_button_is_honest_about_its_reach() {
+        let fragment = include_str!("../../../../static/app/ui2-handover.js");
+        assert!(
+            fragment.contains("cannot launch one itself"),
+            "the no-successor state lost its honest reach line"
+        );
+        assert!(
+            fragment.contains("handoverSuccessorCandidate"),
+            "the hand-off candidate selection is gone"
+        );
+        assert!(
+            fragment.contains("runs the on-disk build"),
+            "the build-match hint on the hand-off button is gone"
+        );
+    }
+
+    /// Commission pin `empty_states_never_instruct_cli`, asserted for
+    /// the surfaces this commission touches: the handover fragment (the
+    /// drain banner's no-successor arm and every update-chip state)
+    /// carries no CLI invocation for the owner to retype.
+    #[test]
+    fn empty_states_never_instruct_cli() {
+        let fragment = include_str!("../../../../static/app/ui2-handover.js");
+        for banned in ["--takeover", "intendant ctl", "intendant --"] {
+            assert!(
+                !fragment.contains(banned),
+                "the handover surface must never instruct CLI usage: found {banned:?}"
+            );
+        }
+    }
+
+    /// Commission pin `app_supervisor_one_click_swaps_without_kill`
+    /// (source-scan reach, stated honestly: the behavioral guarantee
+    /// lives in the supervisor's swap path and its doc contract; this
+    /// pin keeps the machinery and its load-bearing markers from being
+    /// gutted silently). The app supervisor's one-click swap exists,
+    /// follows the intake's spawn → readiness → swap → drain order, and
+    /// parks the predecessor in a draining slot the swap never
+    /// terminates; the app layer re-points the webview on
+    /// `didSwapToPort` and the SPA marker gates the one-click button.
+    #[test]
+    fn app_supervisor_one_click_swaps_without_kill() {
+        let supervisor = include_str!("../../../../macos-app/BackendSupervisor.swift");
+        for needle in [
+            "func beginUpdateSwap",
+            "drainingProcess",
+            // The intake's ordering marker (comment-wrapped in source).
+            "spawn → readiness",
+            "swap → drain",
+            "/api/daemon/takeover",
+            "didSwapToPort",
+        ] {
+            assert!(
+                supervisor.contains(needle),
+                "the app supervisor lost its update-swap machinery: {needle}"
+            );
+        }
+        let app_layer = include_str!("../../../../macos-app/main.swift");
+        for needle in [
+            "beginUpdateSwapFromDashboard",
+            "__intendantAppSupervisor = true",
+            "\"updateSwap\"",
+            "didSwapToPort",
+        ] {
+            assert!(
+                app_layer.contains(needle),
+                "the app layer lost its update-swap wiring: {needle}"
+            );
+        }
+    }
 }

--- a/static/app.html
+++ b/static/app.html
@@ -26611,6 +26611,31 @@ html.ui-v2 .handover-update-honesty {
   font-size: 11px;
   color: var(--warning, #e5a50a);
 }
+html.ui-v2 .handover-update-actions {
+  margin-top: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+html.ui-v2 .handover-update-actions button {
+  align-self: flex-start;
+  padding: 3px 12px;
+  border: 1px solid var(--accent, #62a0ea);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--accent, #62a0ea);
+  font-size: 12px;
+  cursor: pointer;
+}
+html.ui-v2 .handover-update-actions button:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+html.ui-v2 .handover-update-reach,
+html.ui-v2 .handover-update-note {
+  font-size: 11px;
+  color: var(--muted, #7e8896);
+}
 /* ── static/app/ui2-grid.css ── */
 /* ── ui-v2 Activity Grid mode: lineage lanes + session-window re-skin ──
    All scoped html.ui-v2. Grid layout (ratified 2026-07-21, candidate B
@@ -37154,7 +37179,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'f385bb8f65d8b0e8';
+const INTENDANT_APP_BUILD = '890d84709c8a62f7';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -98345,9 +98370,105 @@ async function memoryProposeFromForm(button) {
     if (updateEl) { updateEl.remove(); updateEl = null; }
   }
 
+  // The one action's client state (the button must never double-fire and
+  // its feedback must survive the 30s poll cadence).
+  const updateAction = { inFlight: false, note: '' };
+  let lastHandoverBody = null;
+  // The app supervisor reports a failed swap here (the success path
+  // reloads the tab against the promoted successor instead).
+  window.__intendantAppSwapFailed = (detail) => {
+    updateAction.inFlight = false;
+    updateAction.note = `Update failed: ${detail || 'see the app log'}. The running daemon is untouched.`;
+    if (lastHandoverBody) handoverUpdateRender(lastHandoverBody);
+  };
+
+  // The co-homed daemon a hand-off would drain toward: live, not this
+  // boot, not already on its way out. Prefer one whose build matches the
+  // on-disk update.
+  function handoverSuccessorCandidate(body, disk) {
+    const daemons = Array.isArray(body && body.daemons) ? body.daemons : [];
+    const live = daemons.filter((d) =>
+      d && d.live && d.boot_id !== body.boot_id && d.state !== 'draining' && d.state !== 'exited');
+    if (disk && disk.git_sha) {
+      const matching = live.find((d) => d.version && d.version.git_sha === disk.git_sha);
+      if (matching) return matching;
+    }
+    return live[0] || null;
+  }
+
+  // The chip's action row. Inside the macOS app (__intendantAppSupervisor)
+  // the supervisor owns the spawn, so the chip offers the real one-click.
+  // On a CLI-launched daemon the chip is honest about its reach: it can
+  // ask THIS daemon to drain toward an already-running newer daemon; it
+  // cannot launch one, and it says so instead of pointing at a terminal.
+  function handoverUpdateActions(body, disk) {
+    const actions = document.createElement('div');
+    actions.className = 'handover-update-actions';
+    if (window.__intendantAppSupervisor === true) {
+      const btn = document.createElement('button');
+      btn.textContent = updateAction.inFlight ? 'Updating…' : 'Update now';
+      btn.disabled = updateAction.inFlight;
+      btn.addEventListener('click', () => {
+        if (updateAction.inFlight) return;
+        updateAction.inFlight = true;
+        updateAction.note = 'Starting the new daemon — this dashboard reloads when it takes over; in-flight sessions finish on the old one.';
+        try {
+          window.webkit.messageHandlers.updateSwap.postMessage(null);
+        } catch (_) {
+          updateAction.inFlight = false;
+          updateAction.note = 'Could not reach the app supervisor.';
+        }
+        handoverUpdateRender(body);
+      });
+      actions.appendChild(btn);
+    } else {
+      const successor = handoverSuccessorCandidate(body, disk);
+      if (successor) {
+        const matches = disk && successor.version && successor.version.git_sha === disk.git_sha;
+        const btn = document.createElement('button');
+        btn.textContent = `Hand off to :${successor.port}${matches ? ' (runs the on-disk build)' : ''}`;
+        btn.disabled = updateAction.inFlight;
+        btn.addEventListener('click', async () => {
+          if (updateAction.inFlight) return;
+          updateAction.inFlight = true;
+          updateAction.note = `Asking this daemon to drain — :${successor.port} takes over.`;
+          handoverUpdateRender(body);
+          try {
+            const resp = await authedFetch('/api/daemon/takeover', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ requested_by: 'dashboard update chip' }),
+            });
+            if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+            updateAction.note = 'Draining — in-flight sessions finish here, then this daemon exits.';
+          } catch (err) {
+            updateAction.note = `Hand-off failed from this surface: ${(err && err.message) || err}`;
+          } finally {
+            updateAction.inFlight = false;
+            if (lastHandoverBody) handoverUpdateRender(lastHandoverBody);
+          }
+        });
+        actions.appendChild(btn);
+      } else {
+        const reach = document.createElement('div');
+        reach.className = 'handover-update-reach';
+        reach.textContent = 'No other daemon is running to hand off to — this daemon cannot launch one itself. The macOS app (and a service-managed install) can do this in one click.';
+        actions.appendChild(reach);
+      }
+    }
+    if (updateAction.note) {
+      const note = document.createElement('div');
+      note.className = 'handover-update-note';
+      note.textContent = updateAction.note;
+      actions.appendChild(note);
+    }
+    return actions;
+  }
+
   // textContent construction throughout: the on-disk provenance strings
   // come from probing a binary the daemon merely observed — never markup.
   function handoverUpdateRender(body) {
+    lastHandoverBody = body;
     const update = body && body.update;
     if (!update || body.draining) { updateChipClear(); return; }
     const disk = update.on_disk;
@@ -98373,6 +98494,7 @@ async function memoryProposeFromForm(button) {
         ` — provenance unreadable${update.probe_error ? ` (${update.probe_error})` : ''}`
       ));
     }
+    el.appendChild(handoverUpdateActions(body, disk));
   }
 
   function handoverBanner() {

--- a/static/app/ui2-handover.css
+++ b/static/app/ui2-handover.css
@@ -52,3 +52,28 @@ html.ui-v2 .handover-update-honesty {
   font-size: 11px;
   color: var(--warning, #e5a50a);
 }
+html.ui-v2 .handover-update-actions {
+  margin-top: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+html.ui-v2 .handover-update-actions button {
+  align-self: flex-start;
+  padding: 3px 12px;
+  border: 1px solid var(--accent, #62a0ea);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--accent, #62a0ea);
+  font-size: 12px;
+  cursor: pointer;
+}
+html.ui-v2 .handover-update-actions button:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+html.ui-v2 .handover-update-reach,
+html.ui-v2 .handover-update-note {
+  font-size: 11px;
+  color: var(--muted, #7e8896);
+}

--- a/static/app/ui2-handover.js
+++ b/static/app/ui2-handover.js
@@ -34,9 +34,105 @@
     if (updateEl) { updateEl.remove(); updateEl = null; }
   }
 
+  // The one action's client state (the button must never double-fire and
+  // its feedback must survive the 30s poll cadence).
+  const updateAction = { inFlight: false, note: '' };
+  let lastHandoverBody = null;
+  // The app supervisor reports a failed swap here (the success path
+  // reloads the tab against the promoted successor instead).
+  window.__intendantAppSwapFailed = (detail) => {
+    updateAction.inFlight = false;
+    updateAction.note = `Update failed: ${detail || 'see the app log'}. The running daemon is untouched.`;
+    if (lastHandoverBody) handoverUpdateRender(lastHandoverBody);
+  };
+
+  // The co-homed daemon a hand-off would drain toward: live, not this
+  // boot, not already on its way out. Prefer one whose build matches the
+  // on-disk update.
+  function handoverSuccessorCandidate(body, disk) {
+    const daemons = Array.isArray(body && body.daemons) ? body.daemons : [];
+    const live = daemons.filter((d) =>
+      d && d.live && d.boot_id !== body.boot_id && d.state !== 'draining' && d.state !== 'exited');
+    if (disk && disk.git_sha) {
+      const matching = live.find((d) => d.version && d.version.git_sha === disk.git_sha);
+      if (matching) return matching;
+    }
+    return live[0] || null;
+  }
+
+  // The chip's action row. Inside the macOS app (__intendantAppSupervisor)
+  // the supervisor owns the spawn, so the chip offers the real one-click.
+  // On a CLI-launched daemon the chip is honest about its reach: it can
+  // ask THIS daemon to drain toward an already-running newer daemon; it
+  // cannot launch one, and it says so instead of pointing at a terminal.
+  function handoverUpdateActions(body, disk) {
+    const actions = document.createElement('div');
+    actions.className = 'handover-update-actions';
+    if (window.__intendantAppSupervisor === true) {
+      const btn = document.createElement('button');
+      btn.textContent = updateAction.inFlight ? 'Updating…' : 'Update now';
+      btn.disabled = updateAction.inFlight;
+      btn.addEventListener('click', () => {
+        if (updateAction.inFlight) return;
+        updateAction.inFlight = true;
+        updateAction.note = 'Starting the new daemon — this dashboard reloads when it takes over; in-flight sessions finish on the old one.';
+        try {
+          window.webkit.messageHandlers.updateSwap.postMessage(null);
+        } catch (_) {
+          updateAction.inFlight = false;
+          updateAction.note = 'Could not reach the app supervisor.';
+        }
+        handoverUpdateRender(body);
+      });
+      actions.appendChild(btn);
+    } else {
+      const successor = handoverSuccessorCandidate(body, disk);
+      if (successor) {
+        const matches = disk && successor.version && successor.version.git_sha === disk.git_sha;
+        const btn = document.createElement('button');
+        btn.textContent = `Hand off to :${successor.port}${matches ? ' (runs the on-disk build)' : ''}`;
+        btn.disabled = updateAction.inFlight;
+        btn.addEventListener('click', async () => {
+          if (updateAction.inFlight) return;
+          updateAction.inFlight = true;
+          updateAction.note = `Asking this daemon to drain — :${successor.port} takes over.`;
+          handoverUpdateRender(body);
+          try {
+            const resp = await authedFetch('/api/daemon/takeover', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ requested_by: 'dashboard update chip' }),
+            });
+            if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+            updateAction.note = 'Draining — in-flight sessions finish here, then this daemon exits.';
+          } catch (err) {
+            updateAction.note = `Hand-off failed from this surface: ${(err && err.message) || err}`;
+          } finally {
+            updateAction.inFlight = false;
+            if (lastHandoverBody) handoverUpdateRender(lastHandoverBody);
+          }
+        });
+        actions.appendChild(btn);
+      } else {
+        const reach = document.createElement('div');
+        reach.className = 'handover-update-reach';
+        reach.textContent = 'No other daemon is running to hand off to — this daemon cannot launch one itself. The macOS app (and a service-managed install) can do this in one click.';
+        actions.appendChild(reach);
+      }
+    }
+    if (updateAction.note) {
+      const note = document.createElement('div');
+      note.className = 'handover-update-note';
+      note.textContent = updateAction.note;
+      actions.appendChild(note);
+    }
+    return actions;
+  }
+
   // textContent construction throughout: the on-disk provenance strings
   // come from probing a binary the daemon merely observed — never markup.
   function handoverUpdateRender(body) {
+    lastHandoverBody = body;
     const update = body && body.update;
     if (!update || body.draining) { updateChipClear(); return; }
     const disk = update.on_disk;
@@ -62,6 +158,7 @@
         ` — provenance unreadable${update.probe_error ? ` (${update.probe_error})` : ''}`
       ));
     }
+    el.appendChild(handoverUpdateActions(body, disk));
   }
 
   function handoverBanner() {


### PR DESCRIPTION
## Track HS — HS6/P3 (the commission's final slice): the update chip gets its actions

Per the owner directive overriding the ruled notice-plus-command posture ('I am not doing ANYTHING from the CLI'): the surface offers the action itself, on every surface, honestly scoped to what each surface can actually do. Builds on landed #659 (F2) + #661 (HS6 surface).

**macOS app — the real one-click** (`BackendSupervisor.beginUpdateSwap`, intake §3.7's sketched follow-up now in scope): spawn the successor from the (updated) on-disk binary on a fresh port → poll readiness THERE → promote (health checks + restart policy follow the new child) → re-point the webview (`didSwapToPort`: scheme-handler port, injected port script, window title, reload with fresh boot_id + token) → ask the predecessor to drain via its own `/api/daemon/takeover` (per-port loopback token). The ordering is the intake's spawn → readiness → swap → drain, so a successor that never comes up — the broken-new-binary case — is terminated as the plain secondary it still is and the running daemon is left exactly as it was. **The swap never terminates the predecessor**: it serves its in-flight sessions, exits at the last one, and its clean exit paints no screen and schedules no restart (log-only handler on the draining slot). App quit still tears down both children. The `--web` pair moved out of stored args (composed per spawn) so post-swap restarts follow the promoted port.

**SPA chip actions** (`ui2-handover.js`): inside the app (the injected `__intendantAppSupervisor` marker) the chip offers **Update now** → the `updateSwap` bridge message, with in-flight state and a `__intendantAppSwapFailed` feedback hook (failure re-enables with the honest detail; success reloads the tab against the promoted successor). On a CLI-launched daemon the chip is honest about its reach: with a live co-homed non-draining daemon it offers **Hand off to :PORT** (preferring one whose presence `version.git_sha` matches the on-disk build, labeled 'runs the on-disk build') → POST `/api/daemon/takeover` on THIS daemon, the successor's lease poll acquires; with none it states it **cannot launch one itself** — no terminal delegation anywhere.

**Pins**: `update_chip_offers_action_not_command`, `cli_daemon_button_is_honest_about_its_reach`, `empty_states_never_instruct_cli` (scoped to the touched surfaces), `app_supervisor_one_click_swaps_without_kill` (source-scan reach, stated honestly in its doc — Swift has no test harness here; the pin keeps the machinery + ordering markers from silent gutting).

**Battery**: 5446 bins tests green, workspace clippy -D warnings, fmt clean, `swiftc -typecheck` clean over all three app sources, app.html regenerated via the assembler (incl. the #662 reconcile). Known residuals disclosed for the gate: the successor lease hop on the CLI hand-off rides the secondary's poll cadence (≤60s automation pause, self-healing); the CLI hand-off button uses the HTTP lane (the takeover route has no tunnel twin by the Q2 trust-class pin — on a tunnel-only surface the button fails with the honest line rather than widening the route's reach unilaterally).

Refs: sealed intake `~/daemon-handover-intake.md` (sha256 a028ae33…) + rulings `~/daemon-handover-rulings.md` + the owner directive in the firing goal.