### PR TITLE
Fix Kimi 0.29 readiness and reflected RPC compatibility

### DIFF
--- a/docs/src/external-agent-orchestration.md
+++ b/docs/src/external-agent-orchestration.md
@@ -147,8 +147,8 @@ adapter from `[agent.<backend>]` config, then `run_external_agent_mode()`
 | | **Codex** (reference impl) | **Claude Code** | **Kimi Code** | **Pi** |
 |---|---|---|---|---|
 | Module | `external_agent/codex/` (mod, threads, wire, context_trace, reader) | `external_agent/claude_code.rs` | `external_agent/kimi_code/` (mod, bridge, events, review, rpc, runtime, websocket, wire) | `external_agent/pi.rs` |
-| Spawn command | `codex app-server` | `claude -p --output-format stream-json --input-format stream-json --verbose --include-partial-messages --permission-prompt-tool stdio --permission-mode <mode>` | Kimi 0.27: `kimi server run --foreground --port 0 --log-level silent`; Kimi 0.28+: `kimi web --no-open --port 0 --log-level silent` | `pi --mode rpc --no-extensions --no-approve --extension <private> --append-system-prompt <bootstrap>` plus session/model/thinking/tool flags |
-| Wire protocol | JSON-RPC over JSONL (`app-server`) | stream-json over stdio | bearer-authenticated loopback REST + reconnecting cursor/snapshot WebSocket (`server-v1`), plus a typed allowlist over authenticated reflected v2 RPCs | documented LF-delimited JSON RPC over stdio |
+| Spawn command | `codex app-server` | `claude -p --output-format stream-json --input-format stream-json --verbose --include-partial-messages --permission-prompt-tool stdio --permission-mode <mode>` | Kimi 0.27: `kimi server run --foreground --port 0 --log-level silent`; Kimi 0.28+: `kimi web --no-open --port 0 --log-level silent --debug-endpoints` | `pi --mode rpc --no-extensions --no-approve --extension <private> --append-system-prompt <bootstrap>` plus session/model/thinking/tool flags |
+| Wire protocol | JSON-RPC over JSONL (`app-server`) | stream-json over stdio | bearer-authenticated loopback REST + reconnecting cursor/snapshot WebSocket (`server-v1`), plus a typed allowlist over the authenticated reflected dispatcher (`/api/v2` on 0.27; opt-in `/api/v1/debug` on 0.28+) | documented LF-delimited JSON RPC over stdio |
 | Intendant capability injection | Per-process `-c mcp_servers.intendant.{type,url,bearer_token_env_var}` overrides plus scoped env; no workspace config file | Inline `--mcp-config '{…}'` JSON with an environment-expanded Authorization header | Per-session bridge home containing generated `mcp.json`; scoped bearer stays in the child environment | No MCP. Scoped `$INTENDANT`, `INTENDANT_MCP_URL`, and session authority support on-demand `intendant ctl` calls |
 | Multi-thread | Yes — many threads per process | No | Yes — the main session plus native `:btw` and swarm agents | No — one Pi RPC process/session per wrapper |
 | Native thread id | Yes | Yes — announced via `AgentEvent::NativeSessionId` on the first turn (placeholder `claude-code-session` until then; `--resume` keeps the id stable so resumed threads are canonical immediately) | Yes — returned at create/resume before the first prompt | Yes — `get_state.sessionId` before the first prompt |
@@ -782,11 +782,24 @@ pre-registry server origin is still parsed from stdout. The bearer is read
 from `server.token`; neither origin nor bearer is put on argv or emitted as an
 Intendant event. Startup waits for the child-owned registration, token, and
 authenticated health while detecting early child exit. Once metadata and the
-typed v2 method catalog have also been authenticated, Intendant unlinks
+typed reflected-method catalog have also been authenticated, Intendant unlinks
 `server.token`; the bearer remains only inside the supervisor's in-memory
 REST/RPC clients. Those loopback clients explicitly disable
 environment/system proxies so neither the bearer nor private control traffic
 can be redirected through an egress proxy.
+
+Kimi 0.28+ mounts the reflected dispatcher only when `--debug-endpoints` is
+passed and the server is loopback-bound; the normal bearer check still applies.
+Intendant additionally requires the PID-bound registry entry to declare
+`127.0.0.1`, validates the origin again in both HTTP clients, and never offers a
+generic reflection primitive to a model or frontend. The authenticated channel
+catalog is used only to fail closed and select typed equivalents across Kimi
+generations. In 0.29, active-tool replacement moved from
+`agentRPCService.setActiveTools` to `agentProfileService.update`, native context
+clear moved from `agentRPCService.clearContext` to the exact delegated
+`agentPromptService.clear`, and model enumeration moved from
+`modelCatalogService.listModels` to `modelResolver.listModels`; 0.27-0.28 retain
+their original targets.
 
 Kimi keeps its server lock, token, journal, and MCP config under
 `KIMI_CODE_HOME`. Sharing the user's primary home among simultaneous

--- a/docs/src/external-agent-orchestration.md
+++ b/docs/src/external-agent-orchestration.md
@@ -147,7 +147,7 @@ adapter from `[agent.<backend>]` config, then `run_external_agent_mode()`
 | | **Codex** (reference impl) | **Claude Code** | **Kimi Code** | **Pi** |
 |---|---|---|---|---|
 | Module | `external_agent/codex/` (mod, threads, wire, context_trace, reader) | `external_agent/claude_code.rs` | `external_agent/kimi_code/` (mod, bridge, events, review, rpc, runtime, websocket, wire) | `external_agent/pi.rs` |
-| Spawn command | `codex app-server` | `claude -p --output-format stream-json --input-format stream-json --verbose --include-partial-messages --permission-prompt-tool stdio --permission-mode <mode>` | Kimi 0.27: `kimi server run --foreground --port 0 --log-level silent`; Kimi 0.28: `kimi web --no-open --port 0 --log-level silent` | `pi --mode rpc --no-extensions --no-approve --extension <private> --append-system-prompt <bootstrap>` plus session/model/thinking/tool flags |
+| Spawn command | `codex app-server` | `claude -p --output-format stream-json --input-format stream-json --verbose --include-partial-messages --permission-prompt-tool stdio --permission-mode <mode>` | Kimi 0.27: `kimi server run --foreground --port 0 --log-level silent`; Kimi 0.28+: `kimi web --no-open --port 0 --log-level silent` | `pi --mode rpc --no-extensions --no-approve --extension <private> --append-system-prompt <bootstrap>` plus session/model/thinking/tool flags |
 | Wire protocol | JSON-RPC over JSONL (`app-server`) | stream-json over stdio | bearer-authenticated loopback REST + reconnecting cursor/snapshot WebSocket (`server-v1`), plus a typed allowlist over authenticated reflected v2 RPCs | documented LF-delimited JSON RPC over stdio |
 | Intendant capability injection | Per-process `-c mcp_servers.intendant.{type,url,bearer_token_env_var}` overrides plus scoped env; no workspace config file | Inline `--mcp-config '{…}'` JSON with an environment-expanded Authorization header | Per-session bridge home containing generated `mcp.json`; scoped bearer stays in the child environment | No MCP. Scoped `$INTENDANT`, `INTENDANT_MCP_URL`, and session authority support on-demand `intendant ctl` calls |
 | Multi-thread | Yes — many threads per process | No | Yes — the main session plus native `:btw` and swarm agents | No — one Pi RPC process/session per wrapper |
@@ -163,12 +163,14 @@ adapter from `[agent.<backend>]` config, then `run_external_agent_mode()`
 All four spawn through `crate::platform::spawn_command(&cfg.command)` with the
 working dir set to the project root. Codex and Claude pipe their protocol over
 stdio and forward stderr into the session activity log; Pi does the same for
-its RPC stream. Kimi starts its local
-server in silent mode, reads the one-line ephemeral origin from stdout and the
-private bearer token from its isolated bridge home, validates the API/RPC
+its RPC stream. Kimi starts its local server in silent mode. For 0.28+,
+Intendant reads the actually-bound origin from Kimi's atomic instance registry
+and accepts only a new entry owned by the exact spawned PID on `127.0.0.1`;
+0.27 falls back to its one-line stdout origin. Intendant reads the
+private bearer token from the isolated bridge home, validates the API/RPC
 contract, and immediately unlinks the on-disk token while retaining it only in
-the supervisor's HTTP clients. It then drains both streams; REST or WebSocket
-failures are normalized as backend errors for every frontend.
+the supervisor's HTTP clients. It silently drains both child streams; REST or
+WebSocket failures are normalized as backend errors for every frontend.
 
 Kimi's exact native tool-call ids also keep tool starts, streaming output, and
 completion correlated in persistent daemon sessions. The legacy Codex/Claude
@@ -196,7 +198,8 @@ accumulate.
 
 The initial vocabulary baseline is Claude Code 2.1.210, Codex app-server
 0.144.1, the complete projected Kimi Code server-v1/agent-event-bus vocabulary
-in 0.27.0/0.28.0, and Pi RPC as source-audited in `pi-mono` package 0.81.1.
+in 0.27.0 through 0.29.2, and Pi RPC as source-audited in `pi-mono` package
+0.81.1.
 Known-but-intentionally-ignored notifications are
 included so the
 watch reports new protocol surface, not ordinary traffic the adapter already
@@ -761,21 +764,29 @@ warning on divergence (once per distinct echoed value).
 ### Kimi Code
 
 Kimi uses the local `server-v1` interface rather than ACP. ACP is convenient
-for editor interoperability, but Kimi Code 0.27-0.28's ACP facade does not
+for editor interoperability, but Kimi Code 0.27-0.29's ACP facade does not
 expose the native goal, undo, fork, side-agent, structured-interaction,
 background-task, usage, and live-profile surfaces needed for Intendant parity.
 The adapter therefore starts one private foreground server process per
 supervised session and speaks its bearer-authenticated loopback REST and
 WebSocket APIs. It starts 0.27's `kimi server run` entrypoint and retries with
-0.28's `kimi web --no-open` only when the first process exits with Kimi's exact
-entrypoint-removal diagnostic; other startup failures remain failures.
-The server binds port `0`; its chosen origin is read from stdout, and its bearer
-is read from `server.token`. Neither value is put on argv or emitted as an
-Intendant event. Once health, metadata, and the typed v2 method catalog have
-been authenticated, Intendant unlinks `server.token`; the bearer remains only
-inside the supervisor's in-memory REST/RPC clients. Those loopback clients
-explicitly disable environment/system proxies so neither the bearer nor
-private control traffic can be redirected through an egress proxy.
+0.28+'s `kimi web --no-open` only when the first process exits with Kimi's
+exact entrypoint-removal diagnostic; other startup failures remain failures.
+The server binds port `0`. Kimi 0.28+ atomically publishes the kernel-selected
+port under `server/instances`; Intendant snapshots pre-existing entries before
+spawn, then selects the newest new registration for the exact spawned PID and
+requires the declared host to be `127.0.0.1`.
+This PID-bound registry handshake is independent of Kimi's presentation banner
+(which contains its bearer and changed behavior in 0.29). Kimi 0.27's
+pre-registry server origin is still parsed from stdout. The bearer is read
+from `server.token`; neither origin nor bearer is put on argv or emitted as an
+Intendant event. Startup waits for the child-owned registration, token, and
+authenticated health while detecting early child exit. Once metadata and the
+typed v2 method catalog have also been authenticated, Intendant unlinks
+`server.token`; the bearer remains only inside the supervisor's in-memory
+REST/RPC clients. Those loopback clients explicitly disable
+environment/system proxies so neither the bearer nor private control traffic
+can be redirected through an egress proxy.
 
 Kimi keeps its server lock, token, journal, and MCP config under
 `KIMI_CODE_HOME`. Sharing the user's primary home among simultaneous
@@ -904,7 +915,7 @@ adapters:
   files are uploaded to Kimi's file API before the prompt, preserving their
   name, media type, and size.
 
-The capability list intentionally omits operations Kimi 0.27-0.28 cannot perform
+The capability list intentionally omits operations Kimi 0.27-0.29 cannot perform
 honestly: arbitrary item/message/child fork anchors, item-anchor rewind, an
 explicit “mark budget-limited” transition, persistent-memory reset, and
 independent undo of one child agent. Historical forks are exact only at active
@@ -1150,7 +1161,7 @@ The intentional non-parity cells are upstream capability boundaries, not
 missing UI: no arbitrary item/message/child fork point, item-anchor rewind,
 explicit budget-limited setter or individual budget clear, Codex
 managed-context/fission or persistent-memory reset, or independent undo of one
-Kimi child agent in Kimi Code 0.27-0.28.
+Kimi child agent in Kimi Code 0.27-0.29.
 
 Catch-up order (each step unlocks UI in both surfaces at once):
 

--- a/src/bin/caller/external_agent/kimi_code/mod.rs
+++ b/src/bin/caller/external_agent/kimi_code/mod.rs
@@ -87,7 +87,19 @@ impl KimiServerEntrypoint {
                 "--log-level",
                 "silent",
             ],
-            Self::Web => &["web", "--no-open", "--port", "0", "--log-level", "silent"],
+            Self::Web => &[
+                "web",
+                "--no-open",
+                "--port",
+                "0",
+                "--log-level",
+                "silent",
+                // Kimi 0.28+ moved its authenticated service dispatcher to
+                // this opt-in surface. Kimi itself also requires a loopback
+                // bind; Intendant independently validates the registered host
+                // and confines every typed RPC call to that origin.
+                "--debug-endpoints",
+            ],
         }
     }
 }
@@ -1609,7 +1621,11 @@ impl ExternalAgent for KimiCodeAgent {
                 return Err(error);
             }
         };
-        let rpc = match KimiRpcApi::new(origin.clone(), token.clone()) {
+        let rpc_result = match entrypoint {
+            KimiServerEntrypoint::ServerRun => KimiRpcApi::new(origin.clone(), token.clone()),
+            KimiServerEntrypoint::Web => KimiRpcApi::new_debug(origin.clone(), token.clone()),
+        };
+        let mut rpc = match rpc_result {
             Ok(api) => api,
             Err(error) => {
                 terminate_spawned_child(child_pid, &mut child, &bridge_home).await;
@@ -3432,7 +3448,15 @@ mod tests {
         );
         assert_eq!(
             KimiServerEntrypoint::Web.args(),
-            &["web", "--no-open", "--port", "0", "--log-level", "silent"]
+            &[
+                "web",
+                "--no-open",
+                "--port",
+                "0",
+                "--log-level",
+                "silent",
+                "--debug-endpoints",
+            ]
         );
         assert!(legacy_server_entrypoint_removed_text(
             "`kimi server` has been deprecated and no longer works.\n\

--- a/src/bin/caller/external_agent/kimi_code/mod.rs
+++ b/src/bin/caller/external_agent/kimi_code/mod.rs
@@ -1509,9 +1509,7 @@ impl ExternalAgent for KimiCodeAgent {
         let (mut child, child_pid, origin, stdout_reader, stderr) = loop {
             let instance_baseline = match entrypoint {
                 KimiServerEntrypoint::ServerRun => HashSet::new(),
-                KimiServerEntrypoint::Web => {
-                    capture_server_instance_baseline(&bridge_home).await?
-                }
+                KimiServerEntrypoint::Web => capture_server_instance_baseline(&bridge_home).await?,
             };
             let mut command = crate::platform::spawn_command(&self.command);
             command
@@ -1565,16 +1563,14 @@ impl ExternalAgent for KimiCodeAgent {
             };
             let readiness = match entrypoint {
                 KimiServerEntrypoint::ServerRun => wait_for_server_origin(stdout).await,
-                KimiServerEntrypoint::Web => {
-                    wait_for_registered_server_origin(
-                        &bridge_home,
-                        &instance_baseline,
-                        child_pid,
-                        &mut child,
-                    )
-                    .await
-                    .map(|origin| (origin, BufReader::new(stdout)))
-                }
+                KimiServerEntrypoint::Web => wait_for_registered_server_origin(
+                    &bridge_home,
+                    &instance_baseline,
+                    child_pid,
+                    &mut child,
+                )
+                .await
+                .map(|origin| (origin, BufReader::new(stdout))),
             };
             match readiness {
                 Ok((origin, stdout_reader)) => {

--- a/src/bin/caller/external_agent/kimi_code/mod.rs
+++ b/src/bin/caller/external_agent/kimi_code/mod.rs
@@ -1,11 +1,13 @@
 //! Kimi Code external-agent adapter.
 //!
 //! The adapter supervises Kimi's local web server rather than the narrower ACP
-//! facade. Kimi 0.27 exposes it as `kimi server run`; 0.28 replaced that
-//! entrypoint with foreground `kimi web --no-open`. The authenticated REST/WS
-//! surface exposes native fork/undo/compaction, true queued-prompt steering,
-//! goals, side agents, background tasks, structured approvals/questions,
-//! multimodal files, live profile switches, and full sub-agent telemetry.
+//! facade. Kimi 0.27 exposes it as `kimi server run`; 0.28+ replaced that
+//! entrypoint with foreground `kimi web --no-open`. Web-server readiness is
+//! discovered through Kimi's PID-bound instance registry, not its
+//! token-bearing presentation banner. The authenticated REST/WS surface
+//! exposes native fork/undo/compaction, true queued-prompt steering, goals,
+//! side agents, background tasks, structured approvals/questions, multimodal
+//! files, live profile switches, and full sub-agent telemetry.
 
 mod bridge;
 mod events;
@@ -54,7 +56,7 @@ use super::{
     AutonomousGoalPauseResult, ExternalAgent,
 };
 
-const STARTUP_TIMEOUT: Duration = Duration::from_secs(25);
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(60);
 const KIMI_MAIN_AGENT_ID: &str = "main";
 const KIMI_MCP_TOOL_WILDCARD: &str = "mcp__*";
 const REVIEW_PROMPT_POLL_INTERVAL: Duration = Duration::from_millis(250);
@@ -242,7 +244,7 @@ impl KimiCodeAgent {
             ));
         }
 
-        // Kimi 0.27-0.28's fork response is returned only after the child
+        // Kimi 0.27-0.29's fork response is returned only after the child
         // session and its agents have been materialized from copied wire
         // history.
         // `:undo` prechecks the entire count before mutating that history, so
@@ -492,7 +494,7 @@ impl KimiCodeAgent {
         if let Some(prompt_id) = self.shared.prompt_id(&session_id, &agent_id) {
             return Ok(Some(prompt_id));
         }
-        // Kimi 0.27-0.28's prompt-list route exposes only the main agent.
+        // Kimi 0.27-0.29's prompt-list route exposes only the main agent.
         // Falling back to it while a child thread is selected could make a
         // child interrupt/steer target the parent's prompt.
         if agent_id != KIMI_MAIN_AGENT_ID {
@@ -1505,6 +1507,12 @@ impl ExternalAgent for KimiCodeAgent {
         let bootstrap_url = self.web_port.map(|port| self.intendant_mcp_url(port, true));
         let mut entrypoint = KimiServerEntrypoint::ServerRun;
         let (mut child, child_pid, origin, stdout_reader, stderr) = loop {
+            let instance_baseline = match entrypoint {
+                KimiServerEntrypoint::ServerRun => HashSet::new(),
+                KimiServerEntrypoint::Web => {
+                    capture_server_instance_baseline(&bridge_home).await?
+                }
+            };
             let mut command = crate::platform::spawn_command(&self.command);
             command
                 .args(entrypoint.args())
@@ -1555,12 +1563,25 @@ impl ExternalAgent for KimiCodeAgent {
                     return Err(external("failed to capture Kimi server stderr"));
                 }
             };
-            match wait_for_server_origin(stdout).await {
+            let readiness = match entrypoint {
+                KimiServerEntrypoint::ServerRun => wait_for_server_origin(stdout).await,
+                KimiServerEntrypoint::Web => {
+                    wait_for_registered_server_origin(
+                        &bridge_home,
+                        &instance_baseline,
+                        child_pid,
+                        &mut child,
+                    )
+                    .await
+                    .map(|origin| (origin, BufReader::new(stdout)))
+                }
+            };
+            match readiness {
                 Ok((origin, stdout_reader)) => {
                     break (child, child_pid, origin, stdout_reader, stderr);
                 }
                 Err(error) => {
-                    // Kimi 0.28 closes the deprecated entrypoint's stdout a
+                    // Kimi 0.28+ closes the deprecated entrypoint's stdout a
                     // few scheduler ticks before its process becomes
                     // reapable. An immediate `try_wait` therefore made the
                     // `kimi web` compatibility fallback intermittent.
@@ -1584,7 +1605,8 @@ impl ExternalAgent for KimiCodeAgent {
                 }
             }
         };
-        let token = match wait_for_server_token(&bridge_home.join("server.token")).await {
+        let token = match wait_for_server_token(&bridge_home.join("server.token"), &mut child).await
+        {
             Ok(token) => token,
             Err(error) => {
                 terminate_spawned_child(child_pid, &mut child, &bridge_home).await;
@@ -1605,7 +1627,7 @@ impl ExternalAgent for KimiCodeAgent {
                 return Err(error);
             }
         };
-        if let Err(error) = api.health().await {
+        if let Err(error) = wait_for_server_health(&api, &mut child).await {
             terminate_spawned_child(child_pid, &mut child, &bridge_home).await;
             return Err(error);
         }
@@ -1701,7 +1723,7 @@ impl ExternalAgent for KimiCodeAgent {
                 ));
             }
         }
-        // Kimi 0.27-0.28 validate `agent_config` on session creation but their
+        // Kimi 0.27-0.29 validate `agent_config` on session creation but their
         // create route does not apply the field. The profile route is the
         // authoritative live mutation path, so apply launch pins here for new,
         // resumed, and forked sessions before publication/subscription.
@@ -2041,7 +2063,7 @@ impl ExternalAgent for KimiCodeAgent {
             )
         {
             return Err(external(format!(
-                "Kimi 0.27-0.28 cannot apply /{op} to one :btw agent; target the parent session"
+                "Kimi 0.27-0.29 cannot apply /{op} to one :btw agent; target the parent session"
             )));
         }
         match op {
@@ -2199,7 +2221,7 @@ impl ExternalAgent for KimiCodeAgent {
     ) -> Result<AgentThread, CallerError> {
         if split_child_thread_id(thread_id).is_some() {
             return Err(external(
-                "Kimi 0.27-0.28 cannot fork one composite :btw conversation",
+                "Kimi 0.27-0.29 cannot fork one composite :btw conversation",
             ));
         }
         if let Some(cwd) = cwd {
@@ -2292,7 +2314,7 @@ impl ExternalAgent for KimiCodeAgent {
             return Err(external("Kimi fission charter must not be empty"));
         }
         self.api()?.get_session(thread_id).await?;
-        // Kimi 0.27-0.28 have no public developer-role append. A fission
+        // Kimi 0.27-0.29 have no public developer-role append. A fission
         // branch is supposed to begin work immediately, so submit Intendant's
         // delimited charter as its first user-origin prompt. The branch's
         // resumed supervisor attaches to that live turn and does not enqueue a
@@ -2342,7 +2364,7 @@ impl ExternalAgent for KimiCodeAgent {
     ) -> Result<(), CallerError> {
         if split_child_thread_id(thread_id).is_some() {
             return Err(external(
-                "Kimi 0.27-0.28 cannot target undo at one :btw agent",
+                "Kimi 0.27-0.29 cannot target undo at one :btw agent",
             ));
         }
         self.api()?

--- a/src/bin/caller/external_agent/kimi_code/rpc.rs
+++ b/src/bin/caller/external_agent/kimi_code/rpc.rs
@@ -1,4 +1,4 @@
-//! Authenticated helpers for Kimi 0.27-0.28's reflected `/api/v2` agent RPCs.
+//! Authenticated helpers for Kimi 0.27-0.29's reflected `/api/v2` agent RPCs.
 //!
 //! Kimi's v1 REST facade intentionally exposes a conservative subset of the
 //! underlying agent services. The bearer-authenticated v2 dispatcher exposes
@@ -22,7 +22,7 @@ const AGENT_RPC_SERVICE: &str = "agentRPCService";
 const MODEL_CATALOG_SERVICE: &str = "modelCatalogService";
 const KIMI_RPC_RESPONSE_LIMIT: usize = 32 * 1024 * 1024;
 
-/// Native Kimi goal limits. Kimi 0.27-0.28 enforce all three in the goal
+/// Native Kimi goal limits. Kimi 0.27-0.29 enforce all three in the goal
 /// service; omitted fields leave the corresponding existing limit unchanged.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -134,7 +134,7 @@ impl KimiRpcApi {
         })
     }
 
-    /// Fail closed when the reflected service surface is not the 0.27-0.28
+    /// Fail closed when the reflected service surface is not the 0.27-0.29
     /// shape this adapter was built against.
     pub(crate) async fn validate_required_methods(&self) -> Result<(), CallerError> {
         let channels = self

--- a/src/bin/caller/external_agent/kimi_code/rpc.rs
+++ b/src/bin/caller/external_agent/kimi_code/rpc.rs
@@ -1,11 +1,12 @@
-//! Authenticated helpers for Kimi 0.27-0.29's reflected `/api/v2` agent RPCs.
+//! Authenticated helpers for Kimi 0.27-0.29's reflected agent RPCs.
 //!
 //! Kimi's v1 REST facade intentionally exposes a conservative subset of the
-//! underlying agent services. The bearer-authenticated v2 dispatcher exposes
-//! registered services directly at
-//! `/api/v2/session/{session}/agent/{agent}/{service}/{method}`. Keep that
-//! reflection boundary private here: callers get typed, allowlisted helpers
-//! rather than a user-controlled service or method name.
+//! underlying agent services. Kimi 0.27 exposes its bearer-authenticated
+//! dispatcher at `/api/v2`; 0.28+ moved reflection behind the loopback-only,
+//! opt-in `/api/v1/debug` surface. Keep that boundary private here: callers get
+//! typed, allowlisted helpers rather than a user-controlled service or method
+//! name. The authenticated channel catalog negotiates the small service moves
+//! made by Kimi 0.29 without weakening any capability.
 
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
@@ -17,10 +18,60 @@ use super::wire::{component, external};
 
 const MAIN_AGENT_ID: &str = "main";
 const AGENT_GOAL_SERVICE: &str = "agentGoalService";
+const AGENT_PROMPT_SERVICE: &str = "agentPromptService";
 const AGENT_PROFILE_SERVICE: &str = "agentProfileService";
 const AGENT_RPC_SERVICE: &str = "agentRPCService";
 const MODEL_CATALOG_SERVICE: &str = "modelCatalogService";
+const MODEL_RESOLVER_SERVICE: &str = "modelResolver";
 const KIMI_RPC_RESPONSE_LIMIT: usize = 32 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum KimiRpcSurface {
+    LegacyV2,
+    DebugV1,
+}
+
+impl KimiRpcSurface {
+    fn base_path(self) -> &'static str {
+        match self {
+            Self::LegacyV2 => "/api/v2",
+            Self::DebugV1 => "/api/v1/debug",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SetActiveToolsCall {
+    AgentRpc,
+    ProfileUpdate,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClearContextCall {
+    AgentRpc,
+    PromptService,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ListModelsCall {
+    ModelCatalog,
+    ModelResolver,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct KimiRpcMethodSet {
+    set_active_tools: SetActiveToolsCall,
+    clear_context: ClearContextCall,
+    list_models: ListModelsCall,
+}
+
+impl KimiRpcMethodSet {
+    const LEGACY: Self = Self {
+        set_active_tools: SetActiveToolsCall::AgentRpc,
+        clear_context: ClearContextCall::AgentRpc,
+        list_models: ListModelsCall::ModelCatalog,
+    };
+}
 
 /// Native Kimi goal limits. Kimi 0.27-0.29 enforce all three in the goal
 /// service; omitted fields leave the corresponding existing limit unchanged.
@@ -113,10 +164,26 @@ pub(crate) struct KimiRpcApi {
     client: reqwest::Client,
     origin: String,
     token: String,
+    surface: KimiRpcSurface,
+    methods: KimiRpcMethodSet,
 }
 
 impl KimiRpcApi {
+    /// Kimi 0.27's always-mounted `/api/v2` surface.
     pub(crate) fn new(origin: String, token: String) -> Result<Self, CallerError> {
+        Self::with_surface(origin, token, KimiRpcSurface::LegacyV2)
+    }
+
+    /// Kimi 0.28+'s opt-in, loopback-only `/api/v1/debug` surface.
+    pub(crate) fn new_debug(origin: String, token: String) -> Result<Self, CallerError> {
+        Self::with_surface(origin, token, KimiRpcSurface::DebugV1)
+    }
+
+    fn with_surface(
+        origin: String,
+        token: String,
+        surface: KimiRpcSurface,
+    ) -> Result<Self, CallerError> {
         let origin = normalize_loopback_origin(&origin)?;
         let client = reqwest::Client::builder()
             // Never send the private loopback bearer or RPC payloads through
@@ -126,62 +193,75 @@ impl KimiRpcApi {
             .timeout(std::time::Duration::from_secs(60))
             .redirect(reqwest::redirect::Policy::none())
             .build()
-            .map_err(|error| external(format!("failed to build Kimi v2 HTTP client: {error}")))?;
+            .map_err(|error| external(format!("failed to build Kimi RPC HTTP client: {error}")))?;
         Ok(Self {
             client,
             origin,
             token,
+            surface,
+            methods: KimiRpcMethodSet::LEGACY,
         })
     }
 
-    /// Fail closed when the reflected service surface is not the 0.27-0.29
-    /// shape this adapter was built against.
-    pub(crate) async fn validate_required_methods(&self) -> Result<(), CallerError> {
+    /// Fail closed unless the reflected service surface contains every typed
+    /// operation this adapter uses. Kimi 0.29 kept the semantics but moved
+    /// three operations to their owning domain services, so choose those
+    /// targets from the authenticated catalog rather than from a version
+    /// string.
+    pub(crate) async fn validate_required_methods(&mut self) -> Result<(), CallerError> {
+        let catalog_path = format!("{}/channels", self.surface.base_path());
         let channels = self
-            .request_path(Method::GET, "/api/v2/channels", None, "channels")
+            .request_path(Method::GET, &catalog_path, None, "channels")
             .await?;
         let channels = channels
             .as_array()
-            .ok_or_else(|| external("Kimi /api/v2/channels returned a malformed catalog"))?;
+            .ok_or_else(|| external("Kimi RPC channels returned a malformed catalog"))?;
         for (service, methods) in [
             (
                 AGENT_GOAL_SERVICE,
                 &["getGoal", "markComplete", "setBudgetLimits"][..],
             ),
-            (
-                AGENT_RPC_SERVICE,
-                &["setActiveTools", "getTools", "getContext", "clearContext"][..],
-            ),
+            (AGENT_RPC_SERVICE, &["getTools", "getContext"][..]),
             (AGENT_PROFILE_SERVICE, &["data", "setModel"][..]),
-            (MODEL_CATALOG_SERVICE, &["listModels"][..]),
         ] {
-            let Some(channel) = channels
-                .iter()
-                .find(|channel| channel.get("name").and_then(Value::as_str) == Some(service))
-            else {
-                return Err(external(format!(
-                    "Kimi v2 RPC catalog omitted required service {service}"
-                )));
-            };
-            let advertised = channel
-                .get("methods")
-                .and_then(Value::as_array)
-                .ok_or_else(|| {
-                    external(format!(
-                        "Kimi v2 RPC catalog returned malformed methods for {service}"
-                    ))
-                })?;
             for method in methods {
-                if !advertised.iter().any(|candidate| {
-                    candidate.get("name").and_then(Value::as_str) == Some(*method)
-                        && candidate.get("kind").and_then(Value::as_str) == Some("method")
-                }) {
-                    return Err(external(format!(
-                        "Kimi v2 RPC catalog omitted required method {service}.{method}"
-                    )));
-                }
+                require_catalog_method(channels, service, method)?;
             }
         }
+
+        let set_active_tools = if catalog_has_method(channels, AGENT_RPC_SERVICE, "setActiveTools")?
+        {
+            SetActiveToolsCall::AgentRpc
+        } else if catalog_has_method(channels, AGENT_PROFILE_SERVICE, "update")? {
+            SetActiveToolsCall::ProfileUpdate
+        } else {
+            return Err(external(
+                "Kimi RPC catalog omitted an active-tool mutation method",
+            ));
+        };
+        let clear_context = if catalog_has_method(channels, AGENT_RPC_SERVICE, "clearContext")? {
+            ClearContextCall::AgentRpc
+        } else if catalog_has_method(channels, AGENT_PROMPT_SERVICE, "clear")? {
+            // Kimi's former AgentRPC.clearContext delegated to this exact
+            // method, which clears pending/active prompts and model context.
+            ClearContextCall::PromptService
+        } else {
+            return Err(external("Kimi RPC catalog omitted a context-clear method"));
+        };
+        let list_models = if catalog_has_method(channels, MODEL_CATALOG_SERVICE, "listModels")? {
+            ListModelsCall::ModelCatalog
+        } else if catalog_has_method(channels, MODEL_RESOLVER_SERVICE, "listModels")? {
+            ListModelsCall::ModelResolver
+        } else {
+            return Err(external(
+                "Kimi RPC catalog omitted a configured-model listing method",
+            ));
+        };
+        self.methods = KimiRpcMethodSet {
+            set_active_tools,
+            clear_context,
+            list_models,
+        };
         Ok(())
     }
 
@@ -285,15 +365,21 @@ impl KimiRpcApi {
         agent_id: &str,
         names: &[String],
     ) -> Result<(), CallerError> {
-        self.call_agent(
-            session_id,
-            agent_id,
-            AGENT_RPC_SERVICE,
-            "setActiveTools",
-            serde_json::json!({ "names": names }),
-        )
-        .await
-        .and_then(expect_null_rpc_result)
+        let (service, method, argument) = match self.methods.set_active_tools {
+            SetActiveToolsCall::AgentRpc => (
+                AGENT_RPC_SERVICE,
+                "setActiveTools",
+                serde_json::json!({ "names": names }),
+            ),
+            SetActiveToolsCall::ProfileUpdate => (
+                AGENT_PROFILE_SERVICE,
+                "update",
+                serde_json::json!({ "activeToolNames": names }),
+            ),
+        };
+        self.call_agent(session_id, agent_id, service, method, argument)
+            .await
+            .and_then(expect_null_rpc_result)
     }
 
     /// Read the active/inactive state of every registered tool for one agent.
@@ -364,14 +450,15 @@ impl KimiRpcApi {
     /// The catalog lets `/fast` discover a real `*-highspeed` companion for
     /// the current model rather than guessing or silently changing providers.
     pub(crate) async fn models(&self) -> Result<Vec<KimiRpcModel>, CallerError> {
+        let (service, method) = match self.methods.list_models {
+            ListModelsCall::ModelCatalog => (MODEL_CATALOG_SERVICE, "listModels"),
+            ListModelsCall::ModelResolver => (MODEL_RESOLVER_SERVICE, "listModels"),
+        };
         let value = self
-            .call_core(MODEL_CATALOG_SERVICE, "listModels", serde_json::json!([]))
+            .call_core(service, method, serde_json::json!([]))
             .await?;
-        serde_json::from_value(value).map_err(|error| {
-            external(format!(
-                "Kimi modelCatalogService.listModels malformed: {error}"
-            ))
-        })
+        serde_json::from_value(value)
+            .map_err(|error| external(format!("Kimi {service}.{method} malformed: {error}")))
     }
 
     /// Switch one live Kimi agent to an already configured model alias.
@@ -420,15 +507,17 @@ impl KimiRpcApi {
         session_id: &str,
         agent_id: &str,
     ) -> Result<(), CallerError> {
-        self.call_agent(
-            session_id,
-            agent_id,
-            AGENT_RPC_SERVICE,
-            "clearContext",
-            serde_json::json!({}),
-        )
-        .await
-        .and_then(expect_null_rpc_result)
+        let (service, method, argument) = match self.methods.clear_context {
+            ClearContextCall::AgentRpc => {
+                (AGENT_RPC_SERVICE, "clearContext", serde_json::json!({}))
+            }
+            ClearContextCall::PromptService => {
+                (AGENT_PROMPT_SERVICE, "clear", serde_json::json!([]))
+            }
+        };
+        self.call_agent(session_id, agent_id, service, method, argument)
+            .await
+            .and_then(expect_null_rpc_result)
     }
 
     async fn call_agent(
@@ -439,9 +528,10 @@ impl KimiRpcApi {
         method: &'static str,
         argument: Value,
     ) -> Result<Value, CallerError> {
+        let base = self.surface.base_path();
         self.call_path(
             &format!(
-                "/api/v2/session/{}/agent/{}/{}/{}",
+                "{base}/session/{}/agent/{}/{}/{}",
                 component(session_id),
                 component(agent_id),
                 component(service),
@@ -460,8 +550,9 @@ impl KimiRpcApi {
         method: &'static str,
         argument: Value,
     ) -> Result<Value, CallerError> {
+        let base = self.surface.base_path();
         self.call_path(
-            &format!("/api/v2/{}/{}", component(service), component(method)),
+            &format!("{base}/{}/{}", component(service), component(method)),
             service,
             method,
             argument,
@@ -506,8 +597,47 @@ impl KimiRpcApi {
         let response = request
             .send()
             .await
-            .map_err(|error| external(format!("Kimi v2 RPC request failed: {error}")))?;
+            .map_err(|error| external(format!("Kimi RPC request failed: {error}")))?;
         decode_rpc_response(response, operation).await
+    }
+}
+
+fn catalog_has_method(
+    channels: &[Value],
+    service: &str,
+    method: &str,
+) -> Result<bool, CallerError> {
+    let Some(channel) = channels
+        .iter()
+        .find(|channel| channel.get("name").and_then(Value::as_str) == Some(service))
+    else {
+        return Ok(false);
+    };
+    let advertised = channel
+        .get("methods")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            external(format!(
+                "Kimi RPC catalog returned malformed methods for {service}"
+            ))
+        })?;
+    Ok(advertised.iter().any(|candidate| {
+        candidate.get("name").and_then(Value::as_str) == Some(method)
+            && candidate.get("kind").and_then(Value::as_str) == Some("method")
+    }))
+}
+
+fn require_catalog_method(
+    channels: &[Value],
+    service: &str,
+    method: &str,
+) -> Result<(), CallerError> {
+    if catalog_has_method(channels, service, method)? {
+        Ok(())
+    } else {
+        Err(external(format!(
+            "Kimi RPC catalog omitted required method {service}.{method}"
+        )))
     }
 }
 
@@ -529,7 +659,7 @@ async fn decode_rpc_response(
         .is_some_and(|length| length > KIMI_RPC_RESPONSE_LIMIT as u64)
     {
         return Err(external(format!(
-            "Kimi v2 RPC response for {operation} exceeds the {} byte limit",
+            "Kimi RPC response for {operation} exceeds the {} byte limit",
             KIMI_RPC_RESPONSE_LIMIT
         )));
     }
@@ -543,11 +673,11 @@ async fn decode_rpc_response(
     while let Some(chunk) = response
         .chunk()
         .await
-        .map_err(|error| external(format!("failed to read Kimi v2 RPC response: {error}")))?
+        .map_err(|error| external(format!("failed to read Kimi RPC response: {error}")))?
     {
         if bytes.len().saturating_add(chunk.len()) > KIMI_RPC_RESPONSE_LIMIT {
             return Err(external(format!(
-                "Kimi v2 RPC response for {operation} exceeds the {} byte limit",
+                "Kimi RPC response for {operation} exceeds the {} byte limit",
                 KIMI_RPC_RESPONSE_LIMIT
             )));
         }
@@ -555,7 +685,7 @@ async fn decode_rpc_response(
     }
     let envelope: Value = serde_json::from_slice(&bytes).map_err(|error| {
         external(format!(
-            "Kimi v2 RPC returned non-JSON for {operation} (HTTP {status}): {error}"
+            "Kimi RPC returned non-JSON for {operation} (HTTP {status}): {error}"
         ))
     })?;
     if status.is_success() && envelope.get("code").and_then(Value::as_i64) == Some(0) {
@@ -747,13 +877,196 @@ mod tests {
             serde_json::json!({"code": 0, "msg": "success", "data": channels}),
         )
         .await;
-        let api = KimiRpcApi::new(origin, "handshake-token".into()).unwrap();
+        let mut api = KimiRpcApi::new(origin, "handshake-token".into()).unwrap();
         api.validate_required_methods().await.unwrap();
         let request = request.await.unwrap();
         let (line, headers, body) = request_parts(&request);
         assert_eq!(line, "GET /api/v2/channels HTTP/1.1");
         assert!(headers.contains("\r\nauthorization: bearer handshake-token\r\n"));
         assert_eq!(body, Value::Null);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn debug_handshake_keeps_kimi_028_legacy_method_layout() {
+        let channels = serde_json::json!([
+            {
+                "name": "agentGoalService",
+                "methods": [
+                    {"name": "getGoal", "kind": "method"},
+                    {"name": "markComplete", "kind": "method"},
+                    {"name": "setBudgetLimits", "kind": "method"}
+                ]
+            },
+            {
+                "name": "agentRPCService",
+                "methods": [
+                    {"name": "setActiveTools", "kind": "method"},
+                    {"name": "getTools", "kind": "method"},
+                    {"name": "getContext", "kind": "method"},
+                    {"name": "clearContext", "kind": "method"}
+                ]
+            },
+            {
+                "name": "agentProfileService",
+                "methods": [
+                    {"name": "data", "kind": "method"},
+                    {"name": "setModel", "kind": "method"}
+                ]
+            },
+            {
+                "name": "modelCatalogService",
+                "methods": [{"name": "listModels", "kind": "method"}]
+            }
+        ]);
+        let (origin, request, server) = mock_server(
+            "200 OK",
+            serde_json::json!({"code": 0, "msg": "success", "data": channels}),
+        )
+        .await;
+        let mut api = KimiRpcApi::new_debug(origin, "debug-token".into()).unwrap();
+        api.validate_required_methods().await.unwrap();
+        assert_eq!(api.surface, KimiRpcSurface::DebugV1);
+        assert_eq!(api.methods, KimiRpcMethodSet::LEGACY);
+
+        let request = request.await.unwrap();
+        let (line, headers, body) = request_parts(&request);
+        assert_eq!(line, "GET /api/v1/debug/channels HTTP/1.1");
+        assert!(headers.contains("\r\nauthorization: bearer debug-token\r\n"));
+        assert_eq!(body, Value::Null);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn debug_handshake_negotiates_kimi_029_service_moves() {
+        let channels = serde_json::json!([
+            {
+                "name": "agentGoalService",
+                "methods": [
+                    {"name": "getGoal", "kind": "method"},
+                    {"name": "markComplete", "kind": "method"},
+                    {"name": "setBudgetLimits", "kind": "method"}
+                ]
+            },
+            {
+                "name": "agentRPCService",
+                "methods": [
+                    {"name": "getTools", "kind": "method"},
+                    {"name": "getContext", "kind": "method"}
+                ]
+            },
+            {
+                "name": "agentProfileService",
+                "methods": [
+                    {"name": "data", "kind": "method"},
+                    {"name": "setModel", "kind": "method"},
+                    {"name": "update", "kind": "method"}
+                ]
+            },
+            {
+                "name": "agentPromptService",
+                "methods": [{"name": "clear", "kind": "method"}]
+            },
+            {
+                "name": "modelResolver",
+                "methods": [{"name": "listModels", "kind": "method"}]
+            }
+        ]);
+        let (origin, request, server) = mock_server(
+            "200 OK",
+            serde_json::json!({"code": 0, "msg": "success", "data": channels}),
+        )
+        .await;
+        let mut api = KimiRpcApi::new_debug(origin, "debug-token".into()).unwrap();
+        api.validate_required_methods().await.unwrap();
+        assert_eq!(api.surface, KimiRpcSurface::DebugV1);
+        assert_eq!(
+            api.methods,
+            KimiRpcMethodSet {
+                set_active_tools: SetActiveToolsCall::ProfileUpdate,
+                clear_context: ClearContextCall::PromptService,
+                list_models: ListModelsCall::ModelResolver,
+            }
+        );
+
+        let request = request.await.unwrap();
+        let (line, headers, body) = request_parts(&request);
+        assert_eq!(line, "GET /api/v1/debug/channels HTTP/1.1");
+        assert!(headers.contains("\r\nauthorization: bearer debug-token\r\n"));
+        assert_eq!(body, Value::Null);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn kimi_029_replacements_keep_typed_operations_and_debug_scope() {
+        let methods = KimiRpcMethodSet {
+            set_active_tools: SetActiveToolsCall::ProfileUpdate,
+            clear_context: ClearContextCall::PromptService,
+            list_models: ListModelsCall::ModelResolver,
+        };
+
+        let (origin, request, server) = mock_server(
+            "200 OK",
+            serde_json::json!({"code": 0, "msg": "success", "data": null}),
+        )
+        .await;
+        let mut api = KimiRpcApi::new_debug(origin, "token".into()).unwrap();
+        api.methods = methods;
+        api.set_active_tools(
+            "session/x",
+            "agent:a/b",
+            &["Read".to_string(), "Bash".to_string()],
+        )
+        .await
+        .unwrap();
+        let request = request.await.unwrap();
+        let (line, _, body) = request_parts(&request);
+        assert_eq!(
+            line,
+            "POST /api/v1/debug/session/session%2Fx/agent/agent%3Aa%2Fb/agentProfileService/update HTTP/1.1"
+        );
+        assert_eq!(
+            body,
+            serde_json::json!({"activeToolNames": ["Read", "Bash"]})
+        );
+        server.await.unwrap();
+
+        let (origin, request, server) = mock_server(
+            "200 OK",
+            serde_json::json!({"code": 0, "msg": "success", "data": null}),
+        )
+        .await;
+        let mut api = KimiRpcApi::new_debug(origin, "token".into()).unwrap();
+        api.methods = methods;
+        api.clear_context("session-1", "main").await.unwrap();
+        let request = request.await.unwrap();
+        let (line, _, body) = request_parts(&request);
+        assert_eq!(
+            line,
+            "POST /api/v1/debug/session/session-1/agent/main/agentPromptService/clear HTTP/1.1"
+        );
+        assert_eq!(body, serde_json::json!([]));
+        server.await.unwrap();
+
+        let response = serde_json::json!({
+            "code": 0,
+            "msg": "success",
+            "data": [{
+                "provider": "kimi-code",
+                "model": "kimi-code/kimi-for-coding",
+                "display_name": "K2.7 Coding",
+                "max_context_size": 262144
+            }]
+        });
+        let (origin, request, server) = mock_server("200 OK", response).await;
+        let mut api = KimiRpcApi::new_debug(origin, "token".into()).unwrap();
+        api.methods = methods;
+        let models = api.models().await.unwrap();
+        assert_eq!(models[0].model, "kimi-code/kimi-for-coding");
+        let request = request.await.unwrap();
+        let (line, _, body) = request_parts(&request);
+        assert_eq!(line, "POST /api/v1/debug/modelResolver/listModels HTTP/1.1");
+        assert_eq!(body, serde_json::json!([]));
         server.await.unwrap();
     }
 
@@ -793,7 +1106,7 @@ mod tests {
             serde_json::json!({"code": 0, "msg": "success", "data": channels}),
         )
         .await;
-        let api = KimiRpcApi::new(origin, "handshake-token".into()).unwrap();
+        let mut api = KimiRpcApi::new(origin, "handshake-token".into()).unwrap();
         let error = api.validate_required_methods().await.unwrap_err();
         assert!(error.to_string().contains("agentRPCService.getContext"));
         server.await.unwrap();

--- a/src/bin/caller/external_agent/kimi_code/runtime.rs
+++ b/src/bin/caller/external_agent/kimi_code/runtime.rs
@@ -76,9 +76,7 @@ pub(super) async fn capture_server_instance_baseline(
     let instances = bridge_home.join("server").join("instances");
     let mut entries = match tokio::fs::read_dir(instances).await {
         Ok(entries) => entries,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            return Ok(HashSet::new())
-        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(HashSet::new()),
         Err(_) => return Err(external("failed to inspect Kimi server instance registry")),
     };
     let mut baseline = HashSet::new();

--- a/src/bin/caller/external_agent/kimi_code/runtime.rs
+++ b/src/bin/caller/external_agent/kimi_code/runtime.rs
@@ -2,6 +2,17 @@
 
 use super::*;
 
+const MAX_SERVER_INSTANCE_FILES: usize = 256;
+const MAX_SERVER_INSTANCE_BYTES: u64 = 16 * 1024;
+
+#[derive(serde::Deserialize)]
+struct KimiServerInstanceRegistration {
+    pid: u64,
+    host: String,
+    port: u64,
+    started_at: u64,
+}
+
 pub(super) async fn wait_for_server_origin(
     stdout: tokio::process::ChildStdout,
 ) -> Result<(String, BufReader<tokio::process::ChildStdout>), CallerError> {
@@ -30,7 +41,147 @@ pub(super) async fn wait_for_server_origin(
     Ok((origin, reader))
 }
 
-/// Kimi 0.28 removed the 0.27 `server run` entrypoint. Detect only its bounded,
+/// Kimi 0.28+ publishes each foreground web server under its private
+/// `<KIMI_CODE_HOME>/server/instances` registry. Discover the actually-bound
+/// ephemeral port from the entry owned by the exact child we spawned. This is
+/// stronger than parsing the presentation banner (which carries the bearer and
+/// has changed independently of the API) and avoids a reserve/release port
+/// race.
+pub(super) async fn wait_for_registered_server_origin(
+    bridge_home: &Path,
+    baseline: &HashSet<PathBuf>,
+    child_pid: Option<u32>,
+    child: &mut Child,
+) -> Result<String, CallerError> {
+    let child_pid = child_pid.ok_or_else(|| external("Kimi server process has no PID"))?;
+    let instances = bridge_home.join("server").join("instances");
+    let deadline = tokio::time::Instant::now() + STARTUP_TIMEOUT;
+    loop {
+        ensure_server_child_running(child, "publishing its instance registration")?;
+        if let Some(origin) = registered_server_origin(&instances, baseline, child_pid).await? {
+            return Ok(origin);
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(external(
+                "timed out waiting for Kimi server instance registration",
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+pub(super) async fn capture_server_instance_baseline(
+    bridge_home: &Path,
+) -> Result<HashSet<PathBuf>, CallerError> {
+    let instances = bridge_home.join("server").join("instances");
+    let mut entries = match tokio::fs::read_dir(instances).await {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(HashSet::new())
+        }
+        Err(_) => return Err(external("failed to inspect Kimi server instance registry")),
+    };
+    let mut baseline = HashSet::new();
+    while let Some(entry) = entries
+        .next_entry()
+        .await
+        .map_err(|_| external("failed to enumerate Kimi server instance registry"))?
+    {
+        if entry.path().extension().and_then(|value| value.to_str()) != Some("json") {
+            continue;
+        }
+        if baseline.len() >= MAX_SERVER_INSTANCE_FILES {
+            return Err(external(
+                "Kimi server instance registry is unreasonably large",
+            ));
+        }
+        baseline.insert(entry.path());
+    }
+    Ok(baseline)
+}
+
+async fn registered_server_origin(
+    instances: &Path,
+    baseline: &HashSet<PathBuf>,
+    child_pid: u32,
+) -> Result<Option<String>, CallerError> {
+    let mut entries = match tokio::fs::read_dir(instances).await {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(_) => return Err(external("failed to inspect Kimi server instance registry")),
+    };
+    let mut seen = 0usize;
+    let mut newest: Option<KimiServerInstanceRegistration> = None;
+    while let Some(entry) = entries
+        .next_entry()
+        .await
+        .map_err(|_| external("failed to enumerate Kimi server instance registry"))?
+    {
+        if entry.path().extension().and_then(|value| value.to_str()) != Some("json") {
+            continue;
+        }
+        if baseline.contains(&entry.path()) {
+            continue;
+        }
+        seen += 1;
+        if seen > MAX_SERVER_INSTANCE_FILES {
+            return Err(external(
+                "Kimi server instance registry is unreasonably large",
+            ));
+        }
+        let metadata = match tokio::fs::symlink_metadata(entry.path()).await {
+            Ok(metadata) if metadata.file_type().is_file() => metadata,
+            Ok(_) => continue,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(_) => return Err(external("failed to inspect Kimi server instance entry")),
+        };
+        if metadata.len() > MAX_SERVER_INSTANCE_BYTES {
+            continue;
+        }
+        let bytes = match tokio::fs::read(entry.path()).await {
+            Ok(bytes) if bytes.len() as u64 <= MAX_SERVER_INSTANCE_BYTES => bytes,
+            Ok(_) => continue,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(_) => return Err(external("failed to read Kimi server instance entry")),
+        };
+        let Ok(registration) = serde_json::from_slice::<KimiServerInstanceRegistration>(&bytes)
+        else {
+            // Kimi deliberately retains unparseable entries because another
+            // process may own them. They cannot identify our exact child.
+            continue;
+        };
+        if registration.pid != u64::from(child_pid) {
+            continue;
+        }
+        if newest
+            .as_ref()
+            .is_none_or(|current| registration.started_at > current.started_at)
+        {
+            newest = Some(registration);
+        }
+    }
+
+    let Some(registration) = newest else {
+        return Ok(None);
+    };
+    if registration.port == 0 {
+        // The initial atomic registry write precedes the listen call; Kimi
+        // rewrites it with the kernel-selected port once binding succeeds.
+        return Ok(None);
+    }
+    if registration.host != "127.0.0.1" {
+        return Err(external(
+            "refusing non-loopback Kimi server instance registration",
+        ));
+    }
+    let port = u16::try_from(registration.port)
+        .ok()
+        .filter(|port| *port != 0)
+        .ok_or_else(|| external("Kimi server instance registration has an invalid port"))?;
+    Ok(Some(format!("http://127.0.0.1:{port}")))
+}
+
+/// Kimi 0.28+ removed the 0.27 `server run` entrypoint. Detect only its bounded,
 /// post-exit diagnostic and retry the same configured executable with the new
 /// foreground `web --no-open` entrypoint. The captured stderr is never logged:
 /// future Kimi builds may include sensitive startup material there.
@@ -74,9 +225,13 @@ pub(super) fn extract_loopback_origin(line: &str) -> Option<String> {
     None
 }
 
-pub(super) async fn wait_for_server_token(path: &Path) -> Result<String, CallerError> {
+pub(super) async fn wait_for_server_token(
+    path: &Path,
+    child: &mut Child,
+) -> Result<String, CallerError> {
     let deadline = tokio::time::Instant::now() + STARTUP_TIMEOUT;
     loop {
+        ensure_server_child_running(child, "publishing its token file")?;
         match tokio::fs::read_to_string(path).await {
             Ok(token) => {
                 validate_token_permissions(path).await?;
@@ -96,6 +251,38 @@ pub(super) async fn wait_for_server_token(path: &Path) -> Result<String, CallerE
             return Err(external("timed out waiting for Kimi server token file"));
         }
         tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+pub(super) async fn wait_for_server_health(
+    api: &KimiApi,
+    child: &mut Child,
+) -> Result<(), CallerError> {
+    let deadline = tokio::time::Instant::now() + STARTUP_TIMEOUT;
+    loop {
+        ensure_server_child_running(child, "passing its health check")?;
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            return Err(external("timed out waiting for Kimi server health"));
+        }
+        let attempt_timeout = std::cmp::min(deadline - now, Duration::from_secs(2));
+        if matches!(
+            tokio::time::timeout(attempt_timeout, api.health()).await,
+            Ok(Ok(()))
+        ) {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+fn ensure_server_child_running(child: &mut Child, phase: &str) -> Result<(), CallerError> {
+    match child.try_wait() {
+        Ok(Some(status)) => Err(external(format!(
+            "Kimi server exited before {phase} ({status})"
+        ))),
+        Ok(None) => Ok(()),
+        Err(_) => Err(external("failed to inspect Kimi server process")),
     }
 }
 
@@ -435,5 +622,84 @@ pub(super) async fn monitor_review_prompt(
             }
         }
         tokio::time::sleep(REVIEW_PROMPT_POLL_INTERVAL).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn write_registration(
+        directory: &Path,
+        name: &str,
+        pid: u64,
+        host: &str,
+        port: u64,
+        started_at: u64,
+    ) {
+        tokio::fs::write(
+            directory.join(name),
+            serde_json::json!({
+                "server_id": name,
+                "pid": pid,
+                "host": host,
+                "port": port,
+                "started_at": started_at,
+                "heartbeat_at": started_at,
+            })
+            .to_string(),
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn registered_origin_is_bound_to_the_newest_exact_child_entry() {
+        let temp = tempfile::tempdir().unwrap();
+        let instances = temp.path().join("server").join("instances");
+        tokio::fs::create_dir_all(&instances).await.unwrap();
+        tokio::fs::write(instances.join("malformed.json"), b"{")
+            .await
+            .unwrap();
+        write_registration(&instances, "sibling.json", 41, "127.0.0.1", 49_999, 9_000).await;
+        write_registration(&instances, "stale.json", 42, "127.0.0.1", 41_000, 1_000).await;
+        let baseline = capture_server_instance_baseline(temp.path()).await.unwrap();
+        write_registration(&instances, "current.json", 42, "127.0.0.1", 0, 2_000).await;
+
+        assert_eq!(
+            registered_server_origin(&instances, &baseline, 42)
+                .await
+                .unwrap(),
+            None
+        );
+
+        write_registration(&instances, "current.json", 42, "127.0.0.1", 42_000, 2_000).await;
+        assert_eq!(
+            registered_server_origin(&instances, &baseline, 42)
+                .await
+                .unwrap(),
+            Some("http://127.0.0.1:42000".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn registered_origin_rejects_non_loopback_and_invalid_ports() {
+        let temp = tempfile::tempdir().unwrap();
+        let instances = temp.path().join("instances");
+        tokio::fs::create_dir_all(&instances).await.unwrap();
+        let baseline = HashSet::new();
+        write_registration(&instances, "current.json", 42, "0.0.0.0", 42_000, 2_000).await;
+        assert!(registered_server_origin(&instances, &baseline, 42)
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("non-loopback"));
+
+        write_registration(&instances, "current.json", 42, "127.0.0.1", 70_000, 2_000).await;
+        assert!(registered_server_origin(&instances, &baseline, 42)
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("invalid port"));
     }
 }

--- a/src/bin/caller/external_agent/kimi_code/wire.rs
+++ b/src/bin/caller/external_agent/kimi_code/wire.rs
@@ -1,4 +1,4 @@
-//! Authenticated REST helpers for Kimi server 0.27-0.28's `/api/v1` contract.
+//! Authenticated REST helpers for Kimi server 0.27-0.29's `/api/v1` contract.
 
 use std::collections::HashSet;
 use std::io;

--- a/src/bin/caller/external_agent/protocol_watch.rs
+++ b/src/bin/caller/external_agent/protocol_watch.rs
@@ -325,13 +325,15 @@ const CODEX_ITEM_TYPES: &[&str] = &[
     "function_call_output",
 ];
 
-// Kimi Code 0.27.0-0.28.0's server-v1 WebSocket event vocabulary. The server
+// Kimi Code 0.27.0-0.29.2's server-v1 WebSocket event vocabulary. The server
 // projects both its public session events and the underlying agent event bus.
 // The adapter consumes a subset, but the watch distinguishes known ignorable
 // internal notifications from genuinely novel wire shapes.
 const KIMI_SERVER_EVENT_TYPES: &[&str] = &[
     "error",
     "warning",
+    "agent.created",
+    "agent.disposed",
     "agent.activity.updated",
     "agent.status.updated",
     "session.meta.updated",
@@ -379,6 +381,7 @@ const KIMI_SERVER_EVENT_TYPES: &[&str] = &[
     "context.apply_compaction",
     "context.clear",
     "context.spliced",
+    "context.undone",
     "context.undo",
     "context.update_token_count",
     "full_compaction.begin",
@@ -2428,7 +2431,13 @@ mod tests {
             "payload": { "text": "SENTINEL_KIMI_CONTENT" },
         }))
         .is_empty());
-        for event_type in ["context.spliced", "permission.approval.requested"] {
+        for event_type in [
+            "context.spliced",
+            "context.undone",
+            "agent.created",
+            "agent.disposed",
+            "permission.approval.requested",
+        ] {
             assert!(
                 kimi_findings(&serde_json::json!({
                     "type": event_type,

--- a/src/bin/caller/web_gateway/mcp_gate.rs
+++ b/src/bin/caller/web_gateway/mcp_gate.rs
@@ -32,11 +32,18 @@ pub(crate) fn session_mcp_port() -> Option<u16> {
     SESSION_MCP_PORT.get().copied()
 }
 
+/// Whether the request carries browser-origin provenance.
+///
+/// `Sec-Fetch-Mode` is deliberately insufficient by itself: Node's built-in
+/// `fetch` adds `Sec-Fetch-Mode: cors` to server-side requests, including the
+/// MCP SDK used by Kimi Code. Browsers also supply an Origin or another Fetch
+/// Metadata context header, which keeps browser calls out of the cleartext
+/// credential lanes without rejecting non-browser Node clients.
 pub(crate) fn has_browser_origin_headers(header_text: &str) -> bool {
     http_header_present(header_text, "origin")
         || http_header_present(header_text, "sec-fetch-site")
-        || http_header_present(header_text, "sec-fetch-mode")
         || http_header_present(header_text, "sec-fetch-dest")
+        || http_header_present(header_text, "sec-fetch-user")
 }
 
 /// Derive the session-scoped MCP token injected into a supervised backend's
@@ -1103,6 +1110,22 @@ mod tests {
         let authorized_mcp_bearer = format!(
             "POST /mcp?session_id=child HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer {token}\r\n\r\n"
         );
+        // Node's built-in fetch emits Sec-Fetch-Mode even for server-side
+        // requests. Kimi's MCP client uses that fetch implementation, so the
+        // mode header alone is not browser provenance. Origin and the other
+        // Fetch Metadata context headers remain fail-closed below.
+        let kimi_session = "kimi-managed-session";
+        let kimi_token = session_scoped_mcp_token(token, kimi_session);
+        let authorized_kimi_mcp = format!(
+            "POST /mcp?session_id={kimi_session}&tool_profile=core HTTP/1.1\r\n\
+             Host: localhost\r\n\
+             Authorization: Bearer {kimi_token}\r\n\
+             Content-Type: application/json\r\n\
+             Accept: application/json, text/event-stream\r\n\
+             Accept-Language: *\r\n\
+             Sec-Fetch-Mode: cors\r\n\
+             User-Agent: node\r\n\r\n"
+        );
 
         assert!(is_loopback_cleartext_mcp_request(
             loopback,
@@ -1118,6 +1141,12 @@ mod tests {
             loopback,
             false,
             &authorized_mcp_bearer
+        ));
+        assert!(!has_browser_origin_headers(&authorized_kimi_mcp));
+        assert!(is_loopback_cleartext_mcp_request(
+            loopback,
+            false,
+            &authorized_kimi_mcp
         ));
         assert!(!is_loopback_cleartext_mcp_request(
             loopback,
@@ -1161,6 +1190,13 @@ mod tests {
             false,
             &format!(
                 "POST /mcp?mcp_token={token} HTTP/1.1\r\nHost: localhost\r\nSec-Fetch-Site: cross-site\r\n\r\n"
+            )
+        ));
+        assert!(!is_loopback_cleartext_mcp_request(
+            loopback,
+            false,
+            &format!(
+                "POST /mcp?mcp_token={token} HTTP/1.1\r\nHost: localhost\r\nSec-Fetch-Dest: empty\r\n\r\n"
             )
         ));
     }

--- a/tests/skills/kimi-code-e2e/SKILL.md
+++ b/tests/skills/kimi-code-e2e/SKILL.md
@@ -2,13 +2,13 @@
 name: kimi-code-e2e
 description: >
   Reproducible live end-to-end acceptance test for Intendant's Kimi Code
-  external-agent backend. Exercises the real authenticated Kimi 0.27-0.28
+  external-agent backend. Exercises the real authenticated Kimi 0.27-0.29
   server-v1/v2 adapter with K2.7 Coding, including approvals/questions,
   attachments, streaming/usage/tools/diffs, native lifecycle and goal
   actions, exact historical fork/undo, side and background agents, search,
   interrupt/steer, and resume. Not for CI.
 compatibility: >
-  Requires an authenticated Kimi Code 0.27.x or 0.28.x installation and a
+  Requires an authenticated Kimi Code 0.27.x, 0.28.x, or 0.29.x installation and a
   release intendant build from this checkout. Makes real K2.7 Coding model
   calls.
 allowed-tools: Bash Read
@@ -19,7 +19,7 @@ disable-model-invocation: false
 
 This acceptance scenario catches protocol and orchestration drift that mock
 tests cannot: Intendant starts a private foreground Kimi server (`kimi server
-run` on 0.27, or `kimi web --no-open` on 0.28), uses its real
+run` on 0.27, or `kimi web --no-open` on 0.28+), uses its real
 bearer-authenticated REST/WebSocket server-v1 surface plus its allowlisted
 server-v2 agent RPCs, and drives it through the same control socket and
 dashboard HTTP routes used by frontends.
@@ -61,7 +61,8 @@ credentials and must be deleted securely afterward.
 - Kimi's distinct structured `AskUserQuestion` request/answer rail, including
   a one-choice answer that must remain typed as multi-select.
 - The generated bearer-authenticated Intendant MCP bridge, through a real
-  read-only `list_displays` call, Kimi 0.28's native MCP approval request, and
+  read-only `list_displays` call, Kimi's native MCP approval request when the
+  selected release requires one, and
   correlated tool output while a project MCP declaration deliberately
   occupies the default server name.
 - Dashboard-staged ordinary-file and image attachments delivered through

--- a/tests/skills/kimi-code-e2e/SKILL.md
+++ b/tests/skills/kimi-code-e2e/SKILL.md
@@ -3,7 +3,7 @@ name: kimi-code-e2e
 description: >
   Reproducible live end-to-end acceptance test for Intendant's Kimi Code
   external-agent backend. Exercises the real authenticated Kimi 0.27-0.29
-  server-v1/v2 adapter with K2.7 Coding, including approvals/questions,
+  server-v1/reflected-RPC adapter with K2.7 Coding, including approvals/questions,
   attachments, streaming/usage/tools/diffs, native lifecycle and goal
   actions, exact historical fork/undo, side and background agents, search,
   interrupt/steer, and resume. Not for CI.
@@ -21,7 +21,7 @@ This acceptance scenario catches protocol and orchestration drift that mock
 tests cannot: Intendant starts a private foreground Kimi server (`kimi server
 run` on 0.27, or `kimi web --no-open` on 0.28+), uses its real
 bearer-authenticated REST/WebSocket server-v1 surface plus its allowlisted
-server-v2 agent RPCs, and drives it through the same control socket and
+reflected agent RPCs, and drives it through the same control socket and
 dashboard HTTP routes used by frontends.
 
 It is test documentation and a runnable harness, not an operational Intendant
@@ -47,9 +47,12 @@ proven descendants, removes its Unix socket, and deletes the disposable root.
 Because Kimi's OAuth provider can rotate its refresh grant during a successful
 call, the stopped harness first compare-and-swap publishes a changed isolated
 credential back to the source file with an atomic 0600 replacement. It refuses
-to overwrite a source changed by a concurrent `kimi login` or direct refresh;
-without that copy-back, deleting the isolated home would strand the only valid
-rotated grant and make the machine login unusable.
+to overwrite a source changed by a concurrent `kimi login` or direct refresh,
+and refuses to publish an empty/logged-out credential record. The source
+credential must itself contain a non-empty refresh grant or an unexpired access
+grant before the run starts. Without guarded copy-back, deleting the isolated
+home could either strand the only valid rotated grant or replace the machine
+login with failed refresh state.
 Use `--keep` only when inspecting a failure; that root contains copied Kimi
 credentials and must be deleted securely afterward.
 
@@ -123,7 +126,7 @@ Options:
 --quick           Skip long steer/interrupt/background-agent phases
 --background-only Run only startup plus the background-agent acceptance phase
 --auth-sync-self-test
-                  Hermetically test OAuth rotation copy-back and CAS refusal
+                  Hermetically test OAuth copy-back, CAS, and logout refusal
 ```
 
 The full run can take several minutes because it intentionally waits on live
@@ -157,11 +160,11 @@ pass/fail table and exits non-zero on any failed assertion. With `--keep`,
   cursors, or the live indexer sweep regressed.
 - Resume binds a different native id: wrapper identity/overlay persistence or
   Kimi resume selection regressed.
-- Exact/empty/all tool checks fail: the v2 active-tool profile mutation or
+- Exact/empty/all tool checks fail: the negotiated active-tool profile mutation or
   readback diverged.
 - A model response appears between the two fast toggles: work ran on the
   temporary Highspeed alias instead of canonical K2.7 Coding.
-- Goal completion still leaves an active goal: the v2 goal terminal snapshot
+- Goal completion still leaves an active goal: the reflected goal terminal snapshot
   was not translated before Kimi cleared its standing goal.
-- Post-clear context still contains the attachment token: native
-  `clearContext` did not clear the live agent journal.
+- Post-clear context still contains the attachment token: the negotiated native
+  context-clear operation did not clear the live agent journal.

--- a/tests/skills/kimi-code-e2e/SKILL.md
+++ b/tests/skills/kimi-code-e2e/SKILL.md
@@ -64,8 +64,9 @@ credentials and must be deleted securely afterward.
 - Kimi's distinct structured `AskUserQuestion` request/answer rail, including
   a one-choice answer that must remain typed as multi-select.
 - The generated bearer-authenticated Intendant MCP bridge, through a real
-  read-only `list_displays` call, Kimi's native MCP approval request when the
-  selected release requires one, and
+  read-only `list_displays` call selected by its concrete collision-renamed
+  native tool name, Kimi's native MCP approval request when the selected
+  release requires one, and
   correlated tool output while a project MCP declaration deliberately
   occupies the default server name.
 - Dashboard-staged ordinary-file and image attachments delivered through

--- a/tests/skills/kimi-code-e2e/driver.cjs
+++ b/tests/skills/kimi-code-e2e/driver.cjs
@@ -83,6 +83,7 @@ const logLines = [];
 const checks = [];
 const skips = [];
 let kimiAuthSnapshot = null;
+const loopbackTokens = new Map();
 
 function ts() {
   return `${((Date.now() - t0) / 1000).toFixed(1).padStart(7)}s`;
@@ -270,6 +271,38 @@ function credentialDigest(bytes) {
   return crypto.createHash("sha256").update(bytes).digest("hex");
 }
 
+function requireUsableKimiCredential(bytes, label) {
+  if (bytes.length === 0 || bytes.length > 64 * 1024) {
+    throw new Error(`${label} must be between 1 byte and 64 KiB`);
+  }
+  let credential;
+  try {
+    credential = JSON.parse(bytes.toString("utf8"));
+  } catch {
+    throw new Error(`${label} must contain valid JSON`);
+  }
+  const scalarString = (name) =>
+    typeof credential?.[name] === "string" &&
+    credential[name].trim().length > 0;
+  let expiresAt = credential?.expires_at;
+  if (typeof expiresAt === "string" && /^-?\d+$/.test(expiresAt)) {
+    expiresAt = Number(expiresAt);
+  }
+  if (typeof expiresAt === "number" && Number.isFinite(expiresAt)) {
+    if (expiresAt > 10_000_000_000) expiresAt /= 1_000;
+  } else {
+    expiresAt = null;
+  }
+  const accessValid =
+    scalarString("access_token") &&
+    (expiresAt === null || expiresAt > Math.floor(Date.now() / 1_000));
+  if (!scalarString("refresh_token") && !accessValid) {
+    throw new Error(
+      `${label} is logged out or expired; refusing to treat it as authenticated OAuth state`,
+    );
+  }
+}
+
 function requirePrivateRegularCredential(credential, label) {
   const stat = fs.lstatSync(credential);
   if (!stat.isFile() || stat.isSymbolicLink()) {
@@ -293,11 +326,15 @@ function copyKimiAuthState() {
   }
   requirePrivateRegularCredential(credential, "Kimi source credential");
   const sourceBytes = fs.readFileSync(credential);
-  kimiAuthSnapshot = {
-    credential,
-    initialDigest: credentialDigest(sourceBytes),
-  };
-  sourceBytes.fill(0);
+  try {
+    requireUsableKimiCredential(sourceBytes, "Kimi source credential");
+    kimiAuthSnapshot = {
+      credential,
+      initialDigest: credentialDigest(sourceBytes),
+    };
+  } finally {
+    sourceBytes.fill(0);
+  }
 
   fs.mkdirSync(KIMI_HOME, { recursive: true, mode: 0o700 });
   for (const name of [
@@ -351,6 +388,10 @@ function syncKimiAuthState() {
         "Kimi source credential changed during E2E; refusing to overwrite a concurrent login or refresh",
       );
     }
+    requireUsableKimiCredential(
+      isolatedBytes,
+      "rotated Kimi isolated credential",
+    );
 
     const parent = path.dirname(kimiAuthSnapshot.credential);
     const temporary = path.join(
@@ -364,6 +405,20 @@ function syncKimiAuthState() {
       fs.fsyncSync(fd);
       fs.closeSync(fd);
       fd = undefined;
+      requirePrivateRegularCredential(
+        kimiAuthSnapshot.credential,
+        "Kimi source credential confirmation",
+      );
+      const confirmation = fs.readFileSync(kimiAuthSnapshot.credential);
+      try {
+        if (credentialDigest(confirmation) !== kimiAuthSnapshot.initialDigest) {
+          throw new Error(
+            "Kimi source credential changed during E2E; refusing to overwrite a concurrent login or refresh",
+          );
+        }
+      } finally {
+        confirmation.fill(0);
+      }
       fs.renameSync(temporary, kimiAuthSnapshot.credential);
       fs.chmodSync(kimiAuthSnapshot.credential, 0o600);
       const parentFd = fs.openSync(parent, "r");
@@ -417,21 +472,32 @@ function runAuthSyncSelfTest() {
   });
 
   const install = (source, isolated) => {
-    fs.writeFileSync(sourceCredential, source, { mode: 0o600 });
+    const encodedSource = JSON.stringify({
+      access_token: `${source}-access`,
+      refresh_token: `${source}-refresh`,
+      expires_at: 1,
+    });
+    const encodedIsolated = JSON.stringify({
+      access_token: `${isolated}-access`,
+      refresh_token: `${isolated}-refresh`,
+      expires_at: 2,
+    });
+    fs.writeFileSync(sourceCredential, encodedSource, { mode: 0o600 });
     fs.chmodSync(sourceCredential, 0o600);
-    fs.writeFileSync(isolatedCredential, isolated, { mode: 0o600 });
+    fs.writeFileSync(isolatedCredential, encodedIsolated, { mode: 0o600 });
     fs.chmodSync(isolatedCredential, 0o600);
     kimiAuthSnapshot = {
       credential: sourceCredential,
-      initialDigest: credentialDigest(Buffer.from(source)),
+      initialDigest: credentialDigest(Buffer.from(encodedSource)),
     };
+    return { encodedSource, encodedIsolated };
   };
 
-  install("synthetic-initial", "synthetic-rotated");
+  const first = install("synthetic-initial", "synthetic-rotated");
   syncKimiAuthState();
   check(
     "auth-refresh-copyback",
-    fs.readFileSync(sourceCredential, "utf8") === "synthetic-rotated",
+    fs.readFileSync(sourceCredential, "utf8") === first.encodedIsolated,
   );
 
   install("synthetic-second", "synthetic-second-rotated");
@@ -448,6 +514,56 @@ function runAuthSyncSelfTest() {
     refusedConcurrent &&
       fs.readFileSync(sourceCredential, "utf8") === "synthetic-concurrent",
   );
+
+  const loggedOut = install("synthetic-third", "synthetic-third-rotated");
+  fs.writeFileSync(
+    isolatedCredential,
+    JSON.stringify({
+      access_token: "",
+      refresh_token: "",
+      expires_at: 0,
+    }),
+    { mode: 0o600 },
+  );
+  fs.chmodSync(isolatedCredential, 0o600);
+  let refusedLoggedOut = false;
+  try {
+    syncKimiAuthState();
+  } catch (error) {
+    refusedLoggedOut = /logged out or expired/.test(String(error));
+  }
+  check(
+    "auth-refresh-logged-out-state-refused",
+    refusedLoggedOut &&
+      fs.readFileSync(sourceCredential, "utf8") === loggedOut.encodedSource,
+  );
+
+  let refreshOnlyAccepted = true;
+  try {
+    requireUsableKimiCredential(
+      Buffer.from(JSON.stringify({ refresh_token: "synthetic-refresh" })),
+      "synthetic refresh-only credential",
+    );
+  } catch {
+    refreshOnlyAccepted = false;
+  }
+  check("auth-refresh-only-credential-accepted", refreshOnlyAccepted);
+
+  let expiredAccessRefused = false;
+  try {
+    requireUsableKimiCredential(
+      Buffer.from(
+        JSON.stringify({
+          access_token: "synthetic-access",
+          expires_at: 1,
+        }),
+      ),
+      "synthetic expired credential",
+    );
+  } catch (error) {
+    expiredAccessRefused = /logged out or expired/.test(String(error));
+  }
+  check("auth-expired-access-only-state-refused", expiredAccessRefused);
 }
 
 function descendantsOf(rootPid) {
@@ -493,6 +609,39 @@ async function freePort() {
       server.close((error) => (error ? reject(error) : resolve(port)));
     });
   });
+}
+
+async function admitLoopbackClient(port, stateHome, timeoutMs = 30_000) {
+  const tokenPath = path.join(
+    stateHome,
+    "loopback-tokens",
+    `${port}.token`,
+  );
+  const deadline = Date.now() + timeoutMs;
+  let lastError;
+  while (Date.now() < deadline) {
+    try {
+      const stat = fs.lstatSync(tokenPath);
+      if (!stat.isFile() || stat.isSymbolicLink()) {
+        throw new Error("token path is not a regular file");
+      }
+      if (process.platform !== "win32" && (stat.mode & 0o077) !== 0) {
+        throw new Error("token file is not private");
+      }
+      const token = fs.readFileSync(tokenPath, "utf8").trim();
+      if (!/^[0-9a-f]{64}$/.test(token)) {
+        throw new Error("token file is malformed");
+      }
+      loopbackTokens.set(port, token);
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(50);
+  }
+  throw new Error(
+    `loopback admission token did not appear at ${tokenPath}: ${lastError}`,
+  );
 }
 
 function intendantEnv(stateHome) {
@@ -743,9 +892,18 @@ async function httpJson(port, pathname, options = {}, timeoutMs = 30_000) {
   let lastError;
   while (Date.now() < deadline) {
     try {
+      const headers = { ...(options.headers || {}) };
+      if (
+        loopbackTokens.has(port) &&
+        !Object.keys(headers).some(
+          (name) => name.toLowerCase() === "x-intendant-loopback-token",
+        )
+      ) {
+        headers["x-intendant-loopback-token"] = loopbackTokens.get(port);
+      }
       const response = await fetch(
         `http://127.0.0.1:${port}${pathname}`,
-        options,
+        { ...options, headers },
       );
       const text = await response.text();
       let body;
@@ -1273,8 +1431,10 @@ async function exerciseVaultSigninCeremonyOnIdleDaemon() {
     });
   });
   try {
+    await admitLoopbackClient(port, VAULT_STATE_HOME);
     await exerciseVaultSigninCeremony(port, VAULT_STATE_HOME);
   } finally {
+    loopbackTokens.delete(port);
     if (!exited) child.kill("SIGTERM");
     let result = await Promise.race([
       exitPromise,
@@ -2786,8 +2946,10 @@ async function main() {
   const port = REQUESTED_PORT || (await freePort());
   const run = new IntendantRun(port);
   try {
+    await admitLoopbackClient(port, STATE_HOME);
     await scenario(run, port, version);
   } finally {
+    loopbackTokens.delete(port);
     try {
       await run.stop();
     } finally {

--- a/tests/skills/kimi-code-e2e/driver.cjs
+++ b/tests/skills/kimi-code-e2e/driver.cjs
@@ -1018,10 +1018,32 @@ async function pollActiveTools(
     ) {
       return lastResult;
     }
-    await sleep(250);
+    await sleep(750);
   }
   throw new Error(
     `active tools did not converge to ${JSON.stringify(expected)}; last=` +
+      `${lastResult?.message || "none"}`,
+  );
+}
+
+async function pollRegisteredToolName(
+  run,
+  sessionId,
+  predicate,
+  timeoutMs = 30_000,
+) {
+  const deadline = Date.now() + timeoutMs;
+  let lastResult;
+  while (Date.now() < deadline) {
+    lastResult = await threadAction(run, sessionId, "tools", {}, 15_000);
+    if (lastResult.success === true) {
+      const match = registeredToolNames(lastResult.message).find(predicate);
+      if (match) return { name: match, result: lastResult };
+    }
+    await sleep(750);
+  }
+  throw new Error(
+    "registered Kimi tool did not appear; last=" +
       `${lastResult?.message || "none"}`,
   );
 }
@@ -1627,6 +1649,34 @@ async function scenario(run, port, kimiVersion) {
   // Exercise the generated, bearer-authenticated MCP bridge itself. This is
   // intentionally a read-only deterministic tool, but it proves Kimi loaded
   // the scoped server declaration and can reach Intendant through it.
+  //
+  // Discover the concrete collision-renamed tool from Kimi's native inventory
+  // rather than asking the model to infer the generated server suffix. Make it
+  // the only active tool for this turn so a stochastic EnterPlanMode or other
+  // built-in call cannot hide an otherwise healthy MCP bridge.
+  const managedMcp = await pollRegisteredToolName(
+    run,
+    sessionId,
+    (name) =>
+      /^mcp__intendant_managed_[a-f0-9]{8}(?:_\d+)?__list_displays$/.test(
+        name,
+      ),
+  );
+  check(
+    "injected-intendant-mcp-collision-name",
+    !managedMcp.name.startsWith("mcp__intendant__"),
+    managedMcp.name,
+  );
+  await expectAction(run, sessionId, "tools-set", {
+    names: [managedMcp.name],
+  });
+  const mcpOnlyTools = await pollActiveTools(run, sessionId, [managedMcp.name]);
+  check(
+    "injected-intendant-mcp-only-active-tool",
+    sameStrings(activeToolNames(mcpOnlyTools.message), [managedMcp.name]),
+    mcpOnlyTools.message || "",
+  );
+
   const mcpMark = run.mark();
   let mcpApproval = null;
   run.approvalResponder = (event) => {
@@ -1644,8 +1694,9 @@ async function scenario(run, port, kimiVersion) {
     session_id: sessionId,
     direct: true,
     text:
-      "Use the injected Intendant MCP server's list_displays tool exactly " +
-      "once. Do not use Bash or any other tool. After it succeeds, reply " +
+      `Call the exact registered tool named ${managedMcp.name} exactly once. ` +
+      "It is the only active tool; do not enter plan mode or call anything " +
+      "else. After it succeeds, reply " +
       "with exactly INTENDANT_MCP_OK and do nothing else.",
   });
   const mcpToolStart = await run.waitFor(
@@ -1698,6 +1749,7 @@ async function scenario(run, port, kimiVersion) {
       !/denied|forbidden|unauthorized/i.test(mcpToolOutput.stdout || ""),
     `${mcpToolStart.commands_preview || ""} ${(mcpToolOutput.stdout || "").slice(0, 300)}`,
   );
+  await expectAction(run, sessionId, "tools-all");
 
   // Upload one ordinary file and one image through the real dashboard route,
   // then target the live external session with StartTask attachments.
@@ -1731,11 +1783,13 @@ async function scenario(run, port, kimiVersion) {
     action: "start_task",
     session_id: sessionId,
     task:
-      `The attached text file contains a token. Remember both that token and ` +
-      `the conversation codeword ${KEEP_CODEWORD}. The attached image is red. ` +
-      "Use the Write tool (not Bash) to create probe.txt containing exactly " +
-      `${ATTACHMENT_TOKEN}. Then reply with exactly ` +
-      `ATTACHMENT_OK=${ATTACHMENT_TOKEN}; COLOR=red; CODEWORD=${KEEP_CODEWORD}.`,
+      "First call Read exactly once on the attached text file and remember " +
+      "the token you read. Call ReadMediaFile exactly once on the attached " +
+      "image and identify its color; do not infer either value from this " +
+      `instruction. Remember the conversation codeword ${KEEP_CODEWORD}. ` +
+      "Then use Write exactly once (not Bash) to create probe.txt containing " +
+      "exactly the token you read. Reply with exactly ATTACHMENT_OK=<the token " +
+      `you read>; COLOR=<the color you observed>; CODEWORD=${KEEP_CODEWORD}.`,
     direct: true,
     attachments: [`upload:${textUpload.id}`, `upload:${imageUpload.id}`],
   });
@@ -1752,8 +1806,28 @@ async function scenario(run, port, kimiVersion) {
   run.approvalResponder = null;
   check(
     "native-file-and-image-attachments",
-    /red/i.test(responseText(attachmentResponse)),
+    responseText(attachmentResponse).includes(ATTACHMENT_TOKEN) &&
+      /red/i.test(responseText(attachmentResponse)),
     responseText(attachmentResponse).slice(0, 300),
+  );
+  const attachmentToolStarts = run.events
+    .slice(attachmentMark)
+    .filter((event) => event.event === "agent_started")
+    .map((event) => event.commands_preview || "");
+  check(
+    "ordinary-attachment-read-natively",
+    attachmentToolStarts.some(
+      (preview) => /^Read:/i.test(preview) && /e2e-token\.txt/i.test(preview),
+    ),
+    attachmentToolStarts.join(" | ").slice(0, 500),
+  );
+  check(
+    "image-attachment-read-natively",
+    attachmentToolStarts.some(
+      (preview) =>
+        /ReadMediaFile/i.test(preview) && /red-pixel\.png/i.test(preview),
+    ),
+    attachmentToolStarts.join(" | ").slice(0, 500),
   );
   const probePath = path.join(WORKDIR, "probe.txt");
   check(
@@ -2297,14 +2371,20 @@ async function scenario(run, port, kimiVersion) {
     "/api/sessions",
     (body) => {
       const row = sessionRowForId(body, sessionId);
-      return Boolean(
-        row?.kimi_model &&
-          row?.kimi_thinking === expectedKimiThinking &&
-          row?.kimi_permission_mode &&
-          Array.isArray(row?.kimi_allowed_tools),
+      const tools = [...(row?.kimi_allowed_tools || [])]
+        .filter((value) => typeof value === "string")
+        .sort();
+      return (
+        row?.kimi_model === MODEL &&
+        row?.kimi_thinking === expectedKimiThinking &&
+        row?.kimi_permission_mode === "yolo" &&
+        row?.kimi_plan_mode === false &&
+        row?.kimi_swarm_mode === false &&
+        sameStrings(tools, restoredTools)
       );
     },
     60_000,
+    (body) => JSON.stringify(kimiProfileRowsForId(body, sessionId)),
   );
   const parentProfileRow = sessionRowForId(parentProfileSessions, sessionId);
   const parentConfiguredTools = [

--- a/tests/skills/kimi-code-e2e/driver.cjs
+++ b/tests/skills/kimi-code-e2e/driver.cjs
@@ -30,7 +30,7 @@ const path = require("path");
 const MODEL = "kimi-code/kimi-for-coding";
 const HIGHSPEED_MODEL = "kimi-code/kimi-for-coding-highspeed";
 const MODEL_DISPLAY = "K2.7 Coding";
-const SUPPORTED_KIMI_VERSION = /^0\.(?:27|28)\./;
+const SUPPORTED_KIMI_VERSION = /^0\.(?:27|28|29)\./;
 const args = process.argv.slice(2);
 const USAGE = `Usage:
   node driver.cjs [--binary <path>] [--workdir <path>] [--port <n>]


### PR DESCRIPTION
## What changed

- discover Kimi 0.28+ web-server readiness from its atomic per-instance registry instead of depending on a presentation banner
- require a post-spawn registration owned by the exact supervised child PID on `127.0.0.1`, with bounded parsing, stale-entry exclusion, early-exit detection, and authenticated health retry
- start Kimi 0.28+ with its loopback-only `--debug-endpoints` dispatcher and route the private typed RPC client through `/api/v1/debug`; retain the 0.27 `/api/v2` path
- negotiate the 0.29 service moves for active-tool replacement, native context clear, and configured-model enumeration from the authenticated channel catalog while preserving 0.28 method compatibility
- admit the Node MCP SDK request shape used by Kimi without weakening browser-origin rejection: `Sec-Fetch-Mode` alone is not treated as browser provenance, while Origin and the remaining Fetch Metadata context headers stay fail-closed
- recognize the complete observed Kimi 0.29.2 server event vocabulary in passive protocol-drift monitoring
- harden the live acceptance harness around collision-renamed managed MCP tools, native file/image reads, exact live-profile inheritance, and OAuth refresh copy-back
- document the versioned surfaces and security boundaries

## Root causes

Kimi Code 0.29.2 no longer reliably emits the stdout readiness URL expected by the adapter; its atomic instance registry is now the authoritative readiness signal. After that was fixed, 0.29 exposed two more incompatibilities: the reflected dispatcher moved from `/api/v2` to opt-in `/api/v1/debug` with several operations moving to their owning services, and Node built-in fetch adds `Sec-Fetch-Mode: cors` to Kimi MCP traffic. Intendant had incorrectly treated that header alone as proof of a browser request, rejecting the session-scoped MCP connection before token binding.

## Security posture

The debug dispatcher is enabled only on Kimi loopback servers. Intendant independently binds the registry entry to the exact child PID and `127.0.0.1`, rejects non-loopback origins in both HTTP clients, disables ambient proxies, keeps the bearer in memory, and exposes only fixed typed operations rather than a generic reflection primitive. Managed MCP remains bound to a derived per-session bearer; browser-origin requests are still rejected by Origin, `Sec-Fetch-Site`, `Sec-Fetch-Dest`, or `Sec-Fetch-User` provenance.

## Validation

- `cargo fmt --check` and `node --check tests/skills/kimi-code-e2e/driver.cjs`
- `cargo clippy --workspace -- -D warnings`
- `cargo test -p intendant --bins`: 5,469 passed, 10 explicit ignores
- workspace library/acceptance battery: 967 passed, 3 documented platform/display ignores
- `cargo test -p intendant --test e2e`: 38 passed
- complete Kimi module battery: 125 passed
- Kimi OAuth copy-back self-test: 5 passed
- real Kimi 0.29.2 authenticated debug-RPC diagnostic: tools, exact read-only profile, context, clear, archive, model, and thinking passed
- real Intendant/Kimi 0.29.2 K3/max/yolo smoke: exact reply and successful session completion passed
- exhaustive authenticated K2.7 Coding acceptance: 145/145 checks passed, including Vault auth, managed MCP, attachments, approvals, exact historical/head forks, resume, compact, steer, interrupt, side conversations, background task lifecycle, archive/restore, replay/search, and context clear
- passive Kimi 0.29.2 protocol watch after the exhaustive run: zero warnings and zero errors
