### PR TITLE
dashboard: render GFM tables in the message renderer

### DIFF
--- a/scripts/smoke-dashboard-boot.cjs
+++ b/scripts/smoke-dashboard-boot.cjs
@@ -797,6 +797,59 @@ const CHAPTER_JUMP_PROBE_EXPRESSION = `(async () => {
   return out;
 })()`;
 
+// ---------------------------------------------------------------------------
+// Markdown-table render probe (assertion (f)).
+//
+// Pins GFM table rendering in the message renderer (renderMarkdown,
+// 41-session-window-actions.js): on 2026-07-29 an agent's per-PR status
+// table reached the owner as raw pipe lines — the renderer had no table
+// path, and nothing in CI executes the renderer, so the drop shipped
+// silently. Same admission argument as (d)/(e), with a leaner shape: pure
+// string → string through the window.qa.markdown facade — no DOM, no
+// timing, no daemon state — so it runs on every boot leg. Pins the three
+// load-bearing properties: a GFM table renders as a real <table> (header,
+// alignment, inline markup inside cells); the escape-first sanitizer
+// posture holds through the table path (raw HTML stays text); and
+// non-table markdown is byte-identical to the pre-table renderer on
+// pinned control vectors (bold/italic/code + lone-pipe prose).
+const MARKDOWN_TABLE_PROBE_EXPRESSION = `(() => {
+  const out = { failures: [], steps: [] };
+  const check = (cond, label) => {
+    out.steps.push((cond ? 'pass' : 'FAIL') + ' ' + label);
+    if (!cond) out.failures.push(label);
+  };
+  const qa = window.qa && window.qa.markdown;
+  if (!qa || typeof qa.render !== 'function') {
+    out.failures.push('window.qa.markdown.render missing');
+    return out;
+  }
+  const table = qa.render([
+    'Per-PR status:',
+    '| PR | State | Notes |',
+    '|--|:--:|--:|',
+    '| **#663** | merged | <script>alert(1)</script> |',
+    '| a \\\\| b | \`code\` | [x](https://example.com/x) |',
+  ].join('\\n'));
+  out.steps.push('table html: ' + table.slice(0, 400));
+  check(table.indexOf('<p>Per-PR status:</p><div class="md-table-wrap"><table>') === 0,
+    'table interrupts the paragraph and opens the wrap');
+  check((table.match(/<th[ >]/g) || []).length === 3, 'three header cells');
+  check(table.indexOf('<th style="text-align:center">State</th>') !== -1, 'center alignment on header');
+  check(table.indexOf('<td style="text-align:right">') !== -1, 'right alignment on cells');
+  check(table.indexOf('<td><strong>#663</strong></td>') !== -1, 'bold renders inside a cell');
+  check(table.indexOf('<code>code</code>') !== -1, 'inline code renders inside a cell');
+  check(table.indexOf('href="https://example.com/x"') !== -1, 'link renders inside a cell');
+  check(table.indexOf('a | b') !== -1, 'escaped pipe stays a literal pipe');
+  check(!/<script/i.test(table), 'no script element passes through');
+  check(table.indexOf('&lt;script&gt;alert(1)&lt;/script&gt;') !== -1, 'raw HTML stays escaped text');
+  check(qa.render('**bold** *em* \`code\` plain')
+    === '<p><strong>bold</strong> <em>em</em> <code>code</code> plain</p>',
+    'non-table markdown byte-identical (control vector)');
+  check(qa.render('| a | b |') === '<p>| a | b |</p>',
+    'lone piped line without a delimiter stays prose');
+  return out;
+})()`;
+
 function remoteObjectText(arg) {
   if (!arg || typeof arg !== 'object') return '';
   if (arg.value !== undefined) {
@@ -956,6 +1009,19 @@ async function main() {
     }
 
     await delay(POST_BOOT_SETTLE_MS);
+
+    // Assertion (f): markdown-table rendering — pure page-side function
+    // eval through window.qa.markdown (no DOM, no timing), so it runs on
+    // every boot leg including deep links.
+    const markdown = await evaluate(MARKDOWN_TABLE_PROBE_EXPRESSION);
+    const markdownSteps = Array.isArray(markdown && markdown.steps) ? markdown.steps : [];
+    const markdownFailures = Array.isArray(markdown && markdown.failures) ? markdown.failures : ['probe returned no result'];
+    console.log(`markdown-table probe: ${markdownSteps.length} steps, ${markdownFailures.length} failures`);
+    for (const line of markdownSteps.slice(0, MAX_REPORT_LINES)) console.log(`  ${line}`);
+    if (markdownFailures.length > 0) {
+      for (const line of markdownFailures) ledger.record('markdown-table', line, { fatal: true });
+      throw new Error(`markdown-table probe failed ${markdownFailures.length} assertion(s)`);
+    }
 
     // Assertion (d): drive the jump-button state machine on a synthetic
     // window. Runs before the ledger verdict so any page error the probe

--- a/static/app.html
+++ b/static/app.html
@@ -6122,6 +6122,33 @@ a.vx-pr-row:focus-visible { outline: 2px solid var(--lavender); outline-offset: 
   font-size: 13px;
   line-height: 1.35;
 }
+/* GFM tables (renderMarkdownTable). The wrap div owns horizontal overflow
+   so a wide table scrolls inside the bubble instead of stretching it. */
+.log-markdown .md-table-wrap {
+  margin: 4px 0 7px;
+  max-width: 100%;
+  overflow-x: auto;
+}
+.log-markdown .md-table-wrap:last-child { margin-bottom: 0; }
+.log-markdown table {
+  border-collapse: collapse;
+  line-height: 1.4;
+}
+.log-markdown th,
+.log-markdown td {
+  padding: 3px 9px;
+  border: 1px solid var(--surface1);
+  text-align: left;
+  vertical-align: top;
+}
+.log-markdown th {
+  color: var(--text);
+  font-weight: 700;
+  background: color-mix(in srgb, var(--surface0) 55%, transparent);
+}
+.log-markdown tbody tr:nth-child(even) td {
+  background: color-mix(in srgb, var(--surface0) 30%, transparent);
+}
 .log-command {
   white-space: normal;
 }
@@ -37605,7 +37632,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '47d4d928f643b7fc';
+const INTENDANT_APP_BUILD = '73bcb5d6cddeb373';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -71791,6 +71818,68 @@ function renderMarkdownList(lines, start) {
   };
 }
 
+// GFM tables. Recognition is the two-line GFM rule: a pipe-bearing header
+// line whose NEXT line is a delimiter row (cells of `:?-+:?` only) with the
+// SAME cell count — the count match is what keeps prose pipes and `---`
+// rules out of the table path. Cell text renders through
+// renderInlineMarkdown, so the escape-first sanitizer posture holds: table
+// syntax never opens a raw-HTML lane.
+function markdownTableCells(line) {
+  // \| is GFM's literal pipe inside a cell — hidden from the split via a
+  // sentinel (no regex lookbehind: older WebKit parses this whole module).
+  let raw = String(line || '').trim().replace(/\\\|/g, '\u0000PIPE\u0000');
+  if (raw.startsWith('|')) raw = raw.slice(1);
+  if (raw.endsWith('|')) raw = raw.slice(0, -1);
+  return raw.split('|').map(cell => cell.replace(/\u0000PIPE\u0000/g, '|').trim());
+}
+
+function markdownTableAlignments(line) {
+  const raw = String(line || '').trim();
+  if (!raw.includes('|') || !raw.includes('-') || !/^[\s|:-]+$/.test(raw)) return null;
+  const aligns = [];
+  for (const cell of markdownTableCells(raw)) {
+    if (!/^:?-+:?$/.test(cell)) return null;
+    const left = cell.startsWith(':');
+    const right = cell.endsWith(':');
+    aligns.push(left && right ? 'center' : right ? 'right' : left ? 'left' : '');
+  }
+  return aligns.length ? aligns : null;
+}
+
+function markdownTableStart(lines, i) {
+  const line = lines[i];
+  if (!line || !line.includes('|')) return null;
+  const aligns = markdownTableAlignments(lines[i + 1]);
+  if (!aligns || markdownTableCells(line).length !== aligns.length) return null;
+  return aligns;
+}
+
+function renderMarkdownTable(lines, start, aligns) {
+  // Alignment values come from the closed set in markdownTableAlignments —
+  // safe as attribute text.
+  const alignAttr = idx => (aligns[idx] ? ` style="text-align:${aligns[idx]}"` : '');
+  const renderRow = (cells, tag) => aligns
+    .map((_, idx) => `<${tag}${alignAttr(idx)}>${renderInlineMarkdown(cells[idx] || '')}</${tag}>`)
+    .join('');
+  let html = '<div class="md-table-wrap"><table>'
+    + `<thead><tr>${renderRow(markdownTableCells(lines[start]), 'th')}</tr></thead>`;
+  let body = '';
+  let i = start + 2;
+  while (i < lines.length) {
+    const line = lines[i];
+    // GFM ends the table at a blank line or a new block; a pipeless line
+    // returns to prose. Rows pad/truncate to the header width (renderRow
+    // maps over aligns).
+    if (!line.trim() || !line.includes('|')) break;
+    if (/^(#{1,3})\s+/.test(line) || /^\s*>/.test(line) || markdownListMarker(line)) break;
+    body += `<tr>${renderRow(markdownTableCells(line), 'td')}</tr>`;
+    i++;
+  }
+  if (body) html += `<tbody>${body}</tbody>`;
+  html += '</table></div>';
+  return { html, next: i };
+}
+
 function renderMarkdownBlocks(text) {
   const lines = String(text || '').replace(/\r\n?/g, '\n').split('\n');
   let html = '';
@@ -71828,8 +71917,18 @@ function renderMarkdownBlocks(text) {
       continue;
     }
 
+    const tableAligns = markdownTableStart(lines, i);
+    if (tableAligns) {
+      const table = renderMarkdownTable(lines, i, tableAligns);
+      html += table.html;
+      i = table.next;
+      continue;
+    }
+
     const para = [];
-    while (i < lines.length && lines[i].trim() && !isBlockStart(lines[i])) {
+    // A table may interrupt a paragraph (GFM): break on a header+delimiter
+    // pair, not on lone pipe-bearing prose lines.
+    while (i < lines.length && lines[i].trim() && !isBlockStart(lines[i]) && !markdownTableStart(lines, i)) {
       para.push(lines[i]);
       i++;
     }
@@ -71862,6 +71961,17 @@ function renderMarkdown(text) {
   }
   return parts.join('');
 }
+
+// QA readback (window.qa convention): module-scope functions are
+// unreachable from page evals, so the boot smoke's markdown probe
+// (assertion (f) in scripts/smoke-dashboard-boot.cjs) reaches the real
+// renderer through this facade. Pure string → string; no DOM, no state.
+window.qa = Object.assign(window.qa || {}, {
+  markdown: {
+    render: text => renderMarkdown(text),
+    renderInline: text => renderInlineMarkdown(text),
+  },
+});
 
 function detectCommandLog(content) {
   const text = String(content || '').trim();

--- a/static/app/12-styles-tasks-log.css
+++ b/static/app/12-styles-tasks-log.css
@@ -2395,6 +2395,33 @@ a.vx-pr-row:focus-visible { outline: 2px solid var(--lavender); outline-offset: 
   font-size: 13px;
   line-height: 1.35;
 }
+/* GFM tables (renderMarkdownTable). The wrap div owns horizontal overflow
+   so a wide table scrolls inside the bubble instead of stretching it. */
+.log-markdown .md-table-wrap {
+  margin: 4px 0 7px;
+  max-width: 100%;
+  overflow-x: auto;
+}
+.log-markdown .md-table-wrap:last-child { margin-bottom: 0; }
+.log-markdown table {
+  border-collapse: collapse;
+  line-height: 1.4;
+}
+.log-markdown th,
+.log-markdown td {
+  padding: 3px 9px;
+  border: 1px solid var(--surface1);
+  text-align: left;
+  vertical-align: top;
+}
+.log-markdown th {
+  color: var(--text);
+  font-weight: 700;
+  background: color-mix(in srgb, var(--surface0) 55%, transparent);
+}
+.log-markdown tbody tr:nth-child(even) td {
+  background: color-mix(in srgb, var(--surface0) 30%, transparent);
+}
 .log-command {
   white-space: normal;
 }

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -1616,6 +1616,68 @@ function renderMarkdownList(lines, start) {
   };
 }
 
+// GFM tables. Recognition is the two-line GFM rule: a pipe-bearing header
+// line whose NEXT line is a delimiter row (cells of `:?-+:?` only) with the
+// SAME cell count — the count match is what keeps prose pipes and `---`
+// rules out of the table path. Cell text renders through
+// renderInlineMarkdown, so the escape-first sanitizer posture holds: table
+// syntax never opens a raw-HTML lane.
+function markdownTableCells(line) {
+  // \| is GFM's literal pipe inside a cell — hidden from the split via a
+  // sentinel (no regex lookbehind: older WebKit parses this whole module).
+  let raw = String(line || '').trim().replace(/\\\|/g, '\u0000PIPE\u0000');
+  if (raw.startsWith('|')) raw = raw.slice(1);
+  if (raw.endsWith('|')) raw = raw.slice(0, -1);
+  return raw.split('|').map(cell => cell.replace(/\u0000PIPE\u0000/g, '|').trim());
+}
+
+function markdownTableAlignments(line) {
+  const raw = String(line || '').trim();
+  if (!raw.includes('|') || !raw.includes('-') || !/^[\s|:-]+$/.test(raw)) return null;
+  const aligns = [];
+  for (const cell of markdownTableCells(raw)) {
+    if (!/^:?-+:?$/.test(cell)) return null;
+    const left = cell.startsWith(':');
+    const right = cell.endsWith(':');
+    aligns.push(left && right ? 'center' : right ? 'right' : left ? 'left' : '');
+  }
+  return aligns.length ? aligns : null;
+}
+
+function markdownTableStart(lines, i) {
+  const line = lines[i];
+  if (!line || !line.includes('|')) return null;
+  const aligns = markdownTableAlignments(lines[i + 1]);
+  if (!aligns || markdownTableCells(line).length !== aligns.length) return null;
+  return aligns;
+}
+
+function renderMarkdownTable(lines, start, aligns) {
+  // Alignment values come from the closed set in markdownTableAlignments —
+  // safe as attribute text.
+  const alignAttr = idx => (aligns[idx] ? ` style="text-align:${aligns[idx]}"` : '');
+  const renderRow = (cells, tag) => aligns
+    .map((_, idx) => `<${tag}${alignAttr(idx)}>${renderInlineMarkdown(cells[idx] || '')}</${tag}>`)
+    .join('');
+  let html = '<div class="md-table-wrap"><table>'
+    + `<thead><tr>${renderRow(markdownTableCells(lines[start]), 'th')}</tr></thead>`;
+  let body = '';
+  let i = start + 2;
+  while (i < lines.length) {
+    const line = lines[i];
+    // GFM ends the table at a blank line or a new block; a pipeless line
+    // returns to prose. Rows pad/truncate to the header width (renderRow
+    // maps over aligns).
+    if (!line.trim() || !line.includes('|')) break;
+    if (/^(#{1,3})\s+/.test(line) || /^\s*>/.test(line) || markdownListMarker(line)) break;
+    body += `<tr>${renderRow(markdownTableCells(line), 'td')}</tr>`;
+    i++;
+  }
+  if (body) html += `<tbody>${body}</tbody>`;
+  html += '</table></div>';
+  return { html, next: i };
+}
+
 function renderMarkdownBlocks(text) {
   const lines = String(text || '').replace(/\r\n?/g, '\n').split('\n');
   let html = '';
@@ -1653,8 +1715,18 @@ function renderMarkdownBlocks(text) {
       continue;
     }
 
+    const tableAligns = markdownTableStart(lines, i);
+    if (tableAligns) {
+      const table = renderMarkdownTable(lines, i, tableAligns);
+      html += table.html;
+      i = table.next;
+      continue;
+    }
+
     const para = [];
-    while (i < lines.length && lines[i].trim() && !isBlockStart(lines[i])) {
+    // A table may interrupt a paragraph (GFM): break on a header+delimiter
+    // pair, not on lone pipe-bearing prose lines.
+    while (i < lines.length && lines[i].trim() && !isBlockStart(lines[i]) && !markdownTableStart(lines, i)) {
       para.push(lines[i]);
       i++;
     }
@@ -1687,6 +1759,17 @@ function renderMarkdown(text) {
   }
   return parts.join('');
 }
+
+// QA readback (window.qa convention): module-scope functions are
+// unreachable from page evals, so the boot smoke's markdown probe
+// (assertion (f) in scripts/smoke-dashboard-boot.cjs) reaches the real
+// renderer through this facade. Pure string → string; no DOM, no state.
+window.qa = Object.assign(window.qa || {}, {
+  markdown: {
+    render: text => renderMarkdown(text),
+    renderInline: text => renderInlineMarkdown(text),
+  },
+});
 
 function detectCommandLog(content) {
   const text = String(content || '').trim();


### PR DESCRIPTION
## What

Adds GFM table rendering to the dashboard message renderer (`renderMarkdown` in `static/app/41-session-window-actions.js`). A message containing a GFM table now renders as a real `<table>` (header, body, per-column alignment, inline markup inside cells) instead of raw pipe-delimited paragraph lines.

Card: 01KYRF9YHZDGQ36WGQKHY6XC6R (owner report 2026-07-29 — a per-PR status table reached the owner as pipe soup while the same message's bold/italic rendered fine).

## Pipeline check (the card's CHECK FIRST)

The message renderer and the agenda item-body renderer do **not** share a markdown pipeline — and that is deliberate, not drift: agenda item-authored strings are data-never-instructions and render through `escapeHtml` as plain quoted text by design (`ui2-agenda.js` header comment; reaffirmed by the decision-card seat, #670). Executing markdown on that surface would weaken a documented security posture, so convergence here means the message path stays the **one** markdown pipeline in the SPA, and the fix lands there. The question-detail surface intentionally does not change.

## How

- **Recognition** is the two-line GFM rule: a pipe-bearing header line whose next line is a delimiter row (cells of `:?-+:?`) with the **same cell count**. The count match plus the pipe requirement keeps prose pipes, `---` rules, and setext-style underlines out of the table path (pinned by vectors). Tables may interrupt a paragraph (GFM); blank lines, pipeless lines, and heading/quote/list starts end the table; rows pad/truncate to header width; `\|` escapes a literal pipe (NUL sentinel, same pattern as the code-span sentinel — no regex lookbehind, so older WebKit still parses the module).
- **Sanitizer posture unchanged**: cells render through `renderInlineMarkdown`, which escapes first — no raw-HTML passthrough anywhere in the table path. Alignment attributes come from a closed `left|center|right` set.
- **Styling**: `.md-table-wrap` overflow scroller + table rules in `12-styles-tasks-log.css` using the ui2 token aliases (`--text`, `--surface0/1`, `color-mix`), readable in both themes; wide tables scroll inside the bubble instead of stretching it.
- `static/app.html` regenerated via the assembler (fragments are the source of truth).

## Coverage

Boot-smoke **assertion (f)** (`scripts/smoke-dashboard-boot.cjs`, the CI dashboard-boot leg): a pure string→string probe through a new `window.qa.markdown` facade — no DOM, no timing, runs on every boot leg. It pins: table emission + paragraph interrupt, header/alignment shape, bold/code/link inside cells, escaped-pipe literalness, script-injection stays escaped text, and **byte-identical control vectors** for non-table markdown (bold/italic/code and lone-pipe prose), so the pre-table behavior is pinned, not just assumed. Same admission argument as assertions (d)/(e) — renderer behavior that regressed silently in production because nothing in CI executes the renderer — with a strictly leaner, deterministic shape.

## Validation

- 27-vector node harness against the extracted renderer (table shapes, guards, blockquote nesting, fence precedence): all pass
- Probe simulated with exact template-literal escaping against the real fragment functions: 12/12
- Real-browser boot smoke + full local battery: running now (draft → ready once green)