### PR TITLE
feat(grid): closable-at-a-glance lens over the served safe-to-stop bit

### DIFF
--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -159,14 +159,18 @@ window.qa = Object.assign(window.qa || {}, {
 });
 ```
 
-Each entry is a cheap, side-effect-free function returning a
-JSON-serializable snapshot. Current probes: `qa.sessionsHydration()`
+Each entry is cheap and JSON-serializable; unless noted, probes are
+side-effect-free snapshot reads. Current probes: `qa.sessionsHydration()`
 (sessions-tab relationship-hydration termination, `40-session-launch.js`),
 `qa.sessionsFuel()` (new-session credential preflight,
 `55b-session-launch.js`), `qa.newSessionAgentPrefs()` (last-used
 launch-option prefill state, same fragment), `qa.focusSurface()` (Activity
 Focus target/promotion state), `qa.arrangeMenu()` (the Arrange menu's
-bulk-sweep rows, counts, and sub-agent auto-minimize state), and `qa.station()` — a pointer to
+bulk-sweep rows, counts, and sub-agent auto-minimize state),
+`qa.closableLens` (the closable-at-a-glance lens: `claim()` drives the
+pure positive-only classifier with an explicit matrix, `state()`
+snapshots chip count + lens engagement, `set(on)` — a drive, not a
+read — toggles the lens), and `qa.station()` — a pointer to
 `window.stationProbe`, which predates the namespace and keeps its legacy name
 (the validator's `--station-*` probes and smoke skills depend on it).
 `window.__intendantPaneDiag` above is the other legacy surface.
@@ -336,6 +340,27 @@ rename always wins, and the Track AW refinement — stamped definitions
 deriving `definition name - node id` — lands later at the same single
 derivation seam (`agenda/reminders.rs`, `derive_spawn_session_name`)
 without touching these chips.
+
+The **safe-to-stop derivation** (Track AO) rides the same occurrence
+block: `stop` serves the ruled conjunction from the durable journal —
+`kills_live_run` (the lineage tip of a started-without-terminal
+occurrence: a live firing), `owed_work` (a superseded member of one,
+regardless of process state), `settled` (every terminal) — and the ×
+affordance, the stop confirms, and the occurrence chip render
+machine-scoped consequence copy from it (a linkless session claims
+"safe" only as idle ∧ no linkage; a busy linkless card claims nothing).
+The **closable-at-a-glance lens** composes those positive claims for
+the whole grid: a toolbar chip beside Arrange counts the cards whose
+close the machine already rules safe — settled and quiet, idle with no
+agenda linkage, or finished; negative served claims veto, and a running
+window never counts, even settled — hides at zero (never "0 closable"),
+and, engaged, dims every other card so the closable set reads at a
+glance. The classifier (`sessionWindowClosableClaim` in
+`41-session-window-actions.js`) is strictly a composition of
+already-ruled claims, never a second derivation, and the count plus each
+card's class derive in the Arrange menu's one walk so they can never
+disagree; an emptied count disengages the lens rather than stranding a
+fully-dimmed grid.
 
 When a backend announces background commands (currently Claude Code's
 wire-reported task registry), the activity explainer inside that vitals panel

--- a/src/bin/caller/web_gateway/static_assets.rs
+++ b/src/bin/caller/web_gateway/static_assets.rs
@@ -2077,4 +2077,28 @@ mod tests {
         assert!(APP_HTML
             .contains("Idle · no agenda-owed work — stopping loses only this session’s context"));
     }
+
+    /// The closable-at-a-glance lens (Track AO follow-through) stays a
+    /// POSITIVE-only composition of already-ruled claims: the served
+    /// stop derivation vetoes by name, settled turns positive only once
+    /// the window is quiet, a linked-but-unclaimed occurrence claims
+    /// nothing, the chip ships hidden (never "0 closable"), the dim keys
+    /// on the html attribute the toggle stamps, an emptied count
+    /// disengages the lens instead of stranding a fully-dimmed grid, and
+    /// the per-window class derives in the same single pass as the count
+    /// so the two can never disagree. The × affordance's ruled copy is
+    /// pinned above (`attestation_chips_follow_the_labeling_law`) — the
+    /// lens adds a glance layer without rewriting those claims.
+    #[test]
+    fn closable_lens_is_positive_only() {
+        assert!(APP_HTML.contains("if (stop === 'kills_live_run' || stop === 'owed_work') return false;"));
+        assert!(APP_HTML.contains("if (stop === 'settled') return quiet;"));
+        assert!(APP_HTML.contains("if (stop || claim.linked) return false;"));
+        assert!(APP_HTML.contains("id=\"ui2-closable-lens-btn\" hidden"));
+        assert!(APP_HTML.contains(
+            "html[data-ui2-closable-lens=\"on\"] .session-window:not(.session-window-closable)"
+        ));
+        assert!(APP_HTML.contains("if (btn.hidden && ui2ClosableLensOn) ui2SetClosableLens(false);"));
+        assert!(APP_HTML.contains("win.el.classList.toggle('session-window-closable', closable)"));
+    }
 }

--- a/src/bin/caller/web_gateway/static_assets.rs
+++ b/src/bin/caller/web_gateway/static_assets.rs
@@ -2091,14 +2091,17 @@ mod tests {
     /// lens adds a glance layer without rewriting those claims.
     #[test]
     fn closable_lens_is_positive_only() {
-        assert!(APP_HTML.contains("if (stop === 'kills_live_run' || stop === 'owed_work') return false;"));
+        assert!(APP_HTML
+            .contains("if (stop === 'kills_live_run' || stop === 'owed_work') return false;"));
         assert!(APP_HTML.contains("if (stop === 'settled') return quiet;"));
         assert!(APP_HTML.contains("if (stop || claim.linked) return false;"));
         assert!(APP_HTML.contains("id=\"ui2-closable-lens-btn\" hidden"));
         assert!(APP_HTML.contains(
             "html[data-ui2-closable-lens=\"on\"] .session-window:not(.session-window-closable)"
         ));
-        assert!(APP_HTML.contains("if (btn.hidden && ui2ClosableLensOn) ui2SetClosableLens(false);"));
+        assert!(
+            APP_HTML.contains("if (btn.hidden && ui2ClosableLensOn) ui2SetClosableLens(false);")
+        );
         assert!(APP_HTML.contains("win.el.classList.toggle('session-window-closable', closable)"));
     }
 }

--- a/static/app.html
+++ b/static/app.html
@@ -37759,7 +37759,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '17612ff86f5c4867';
+const INTENDANT_APP_BUILD = '69adf38674c2db99';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -71481,7 +71481,12 @@ function hideDoneSessionWindows() {
 function sessionWindowClosableClaim(claim = {}) {
   const stop = typeof claim.stop === 'string' ? claim.stop : '';
   if (stop === 'kills_live_run' || stop === 'owed_work') return false;
-  const quiet = !!claim.hardDone || normalizeSessionPhase(claim.phase || '') === 'idle';
+  // An ABSENT phase is no claim (normalizeSessionPhase defaults '' to
+  // 'idle', which would read wider than the ×'s raw win.phase === 'idle'
+  // check — positive-only forbids that): a phase-less window is quiet
+  // only on hard done evidence.
+  const quiet = !!claim.hardDone
+    || (!!claim.phase && normalizeSessionPhase(claim.phase) === 'idle');
   if (stop === 'settled') return quiet;
   if (stop || claim.linked) return false;
   return quiet;

--- a/static/app.html
+++ b/static/app.html
@@ -4712,6 +4712,21 @@ body.context-focus-active {
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--peach) 22%, transparent);
   filter: saturate(0.65);
 }
+/* Closable-at-a-glance lens (the Activity toolbar chip stamps the html
+   attribute; each window's class derives in ui2-activity.js's Arrange
+   walk from the positive safe-to-stop claims): every card the machine
+   does NOT rule safe recedes, the closable set keeps full presence with
+   a quiet affirmative ring. Positive-only — the dim says "look here",
+   never "unsafe". */
+html[data-ui2-closable-lens="on"] .session-window:not(.session-window-closable) {
+  opacity: 0.35;
+  filter: saturate(0.55);
+}
+html[data-ui2-closable-lens="on"] .session-window.session-window-closable {
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--green) 45%, transparent),
+    inset 0 0 0 1px color-mix(in srgb, var(--green) 22%, transparent);
+}
 /* Terminal honesty strip: a dead window's plain statement of how it
    ended, with the lineage pointer when the work continued elsewhere. */
 .session-window .session-window-terminal-note {
@@ -20473,6 +20488,41 @@ html.ui-v2 #activity-subtabs .ui2-arrange-btn[aria-expanded="true"] svg { transf
 html.ui-v2 #activity-subtabs .ui2-arrange-btn[hidden],
 html.ui-v2:not([data-ui2-layout="grid"]) #activity-subtabs .ui2-arrange-btn { display: none; }
 
+/* Closable-at-a-glance chip — sibling styling to Arrange. The count is
+   the machine-positive closable set; the pressed state engages the lens
+   (the window dim itself lives with the .session-window rules in
+   12-styles-tasks-log.css, keyed on the html attribute the toggle
+   stamps). Hidden at zero by ui2-activity.js, grid-only like every
+   window tool. */
+html.ui-v2 #activity-subtabs .ui2-closable-lens-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 28px;
+  padding: 0 10px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: transparent;
+  color: var(--text-3);
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 650;
+  cursor: pointer;
+  transition: color var(--t-fast), background var(--t-fast), border-color var(--t-fast);
+}
+html.ui-v2 #activity-subtabs .ui2-closable-lens-btn .ui2-closable-lens-count {
+  color: var(--green);
+  font-variant-numeric: tabular-nums;
+}
+html.ui-v2 #activity-subtabs .ui2-closable-lens-btn:hover { color: var(--text); background: var(--hover-wash); }
+html.ui-v2 #activity-subtabs .ui2-closable-lens-btn[aria-pressed="true"] {
+  color: var(--text);
+  background: var(--surface-2);
+  border-color: color-mix(in srgb, var(--green) 45%, var(--line));
+}
+html.ui-v2 #activity-subtabs .ui2-closable-lens-btn[hidden],
+html.ui-v2:not([data-ui2-layout="grid"]) #activity-subtabs .ui2-closable-lens-btn { display: none; }
+
 /* The Arrange menu popover: same mechanics as the Options popover below
    (display:none base, .open shows, position:fixed against the subtab
    row's overflow-x clipping, JS stamps top/right from the trigger). The
@@ -31718,6 +31768,19 @@ html.ui-v2 .ui2-tsw-foot .ui2-tsw-row:hover { color: var(--text); }
             <button type="button" id="ui2-layout-grid-btn" data-layout="grid"
                     title="Grid — session windows with the concurrent stream below">Grid</button>
           </div>
+          <!-- Closable-at-a-glance chip + lens toggle: the POSITIVE count
+               of session cards whose close the machine already rules safe
+               (the served safe-to-stop claim settled, idle with no agenda
+               linkage, or finished — sessionWindowClosableClaim in
+               41-session-window-actions.js; the count and each card's
+               class derive in ui2-activity.js's Arrange walk). Hidden at
+               zero — never "0 closable" — and engaging it dims every
+               other card. -->
+          <button type="button" class="ui2-closable-lens-btn" id="ui2-closable-lens-btn" hidden
+                  aria-pressed="false"
+                  title="Session cards that are safe to close — click to dim the rest">
+            <span class="ui2-closable-lens-count" id="ui2-closable-lens-count">0</span><span>closable</span>
+          </button>
           <!-- One compact menu button consolidating the bulk window sweeps
                (it replaced five standalone pills: Minimize done, Hide done,
                Collapse all/Expand all, Expand/Collapse details).
@@ -36795,17 +36858,23 @@ function ui2WireLayoutToggle() {
 // Predicates are 41/40's shared boundaries: sessionWindowIsSubagent (the
 // relationship kind the badges use), sessionWindowIsDoneSubagent (the
 // "N sub" active boundary), sessionWindowHasHardDoneEvidence (ended /
-// done / interrupted — never bare idle).
+// done / interrupted — never bare idle), and
+// sessionWindowIsClosableAtAGlance (the positive-only safe-to-stop
+// composition). The closable lens's per-window class rides this same
+// pass — same freshness ticks (badge crossings, the relationship render
+// pass, every sweep) — so the chip's number and the dimmed set can
+// never disagree.
 function ui2ArrangeMenuModel() {
   const model = {
     windows: 0, expanded: 0, minimized: 0,
     subs: 0, subsExpanded: 0, doneSubsExpanded: 0,
-    hardDone: 0, detailsExpanded: 0,
+    hardDone: 0, detailsExpanded: 0, closable: 0,
   };
   if (typeof sessionWindows === 'undefined') return model;
   const isSub = typeof sessionWindowIsSubagent === 'function' ? sessionWindowIsSubagent : null;
   const isDoneSub = typeof sessionWindowIsDoneSubagent === 'function' ? sessionWindowIsDoneSubagent : null;
   const isHardDone = typeof sessionWindowHasHardDoneEvidence === 'function' ? sessionWindowHasHardDoneEvidence : null;
+  const isClosable = typeof sessionWindowIsClosableAtAGlance === 'function' ? sessionWindowIsClosableAtAGlance : null;
   for (const [sid, win] of sessionWindows) {
     if (!win) continue;
     model.windows += 1;
@@ -36822,6 +36891,11 @@ function ui2ArrangeMenuModel() {
       }
     }
     if (isHardDone && isHardDone(sid)) model.hardDone += 1;
+    if (isClosable) {
+      const closable = isClosable(sid);
+      if (closable) model.closable += 1;
+      if (win.el) win.el.classList.toggle('session-window-closable', closable);
+    }
   }
   return model;
 }
@@ -36903,6 +36977,9 @@ function ui2RefreshArrangeMenu() {
           : `Collapse header details on all ${m.detailsExpanded} expanded session windows`)
       : 'Expand header details on every session window',
   });
+  // The closable chip rides the same single-pass refresh (and the same
+  // walk already stamped every window's closable class above).
+  ui2RefreshClosableLensChip(m.closable);
 }
 
 // Legacy seam: 40-session-launch.js's relationship-render pass still
@@ -36962,6 +37039,82 @@ function ui2RunArrangeAction(action, row) {
   }
   ui2RefreshArrangeMenu();
 }
+
+// ── The closable-at-a-glance lens ──────────────────────────────────────
+// A grid lens over the positive safe-to-stop claims
+// (sessionWindowClosableClaim / sessionWindowIsClosableAtAGlance in
+// 41-session-window-actions.js): the chip counts the cards whose close
+// the machine already rules safe and, engaged, dims every other card so
+// the closable set reads at a glance (the dim rules live with the
+// .session-window styles in 12-styles-tasks-log.css, keyed on the html
+// attribute stamped here). Positive-only at the surface too: the chip
+// hides at zero — never "0 closable" — and because an engaged lens with
+// an empty count would strand a fully-dimmed grid behind a hidden
+// toggle, the refresh disengages it the moment the count empties.
+// Transient by design: the lens is a look, not a mode — it never
+// persists across reloads.
+let ui2ClosableLensOn = false;
+
+function ui2SetClosableLens(on) {
+  ui2ClosableLensOn = !!on;
+  const html = document.documentElement;
+  if (ui2ClosableLensOn) html.setAttribute('data-ui2-closable-lens', 'on');
+  else html.removeAttribute('data-ui2-closable-lens');
+  const btn = document.getElementById('ui2-closable-lens-btn');
+  if (btn) btn.setAttribute('aria-pressed', ui2ClosableLensOn ? 'true' : 'false');
+}
+
+function ui2RefreshClosableLensChip(count) {
+  const btn = document.getElementById('ui2-closable-lens-btn');
+  if (!btn) return;
+  const n = Number(count) || 0;
+  btn.hidden = n === 0;
+  if (btn.hidden && ui2ClosableLensOn) ui2SetClosableLens(false);
+  const countEl = document.getElementById('ui2-closable-lens-count');
+  if (countEl) countEl.textContent = String(n);
+  btn.title = n === 1
+    ? 'One session card is safe to close (settled agenda debt, idle with no agenda linkage, or finished) — click to dim the rest'
+    : `${n} session cards are safe to close (settled agenda debt, idle with no agenda linkage, or finished) — click to dim the rest`;
+}
+
+function ui2WireClosableLens() {
+  const btn = document.getElementById('ui2-closable-lens-btn');
+  if (!btn) return;
+  btn.addEventListener('click', () => {
+    ui2SetClosableLens(!ui2ClosableLensOn);
+    ui2RefreshArrangeMenu();
+  });
+}
+
+// QA facade (window.qa convention): claim() drives the pure classifier
+// with an explicit matrix (the conjunction is otherwise untestable
+// without a live daemon), set()/state() drive and snapshot the chip +
+// lens surface after a fresh single-pass walk.
+window.qa = Object.assign(window.qa || {}, {
+  closableLens: {
+    claim: (c) => (typeof sessionWindowClosableClaim === 'function'
+      ? sessionWindowClosableClaim(c || {}) : null),
+    isClosable: (sid) => (typeof sessionWindowIsClosableAtAGlance === 'function'
+      ? sessionWindowIsClosableAtAGlance(sid) : null),
+    set: (on) => { ui2SetClosableLens(!!on); ui2RefreshArrangeMenu(); return ui2ClosableLensOn; },
+    state: () => {
+      ui2RefreshArrangeMenu();
+      const btn = document.getElementById('ui2-closable-lens-btn');
+      const ids = typeof sessionWindows === 'undefined' ? [] : [...sessionWindows.keys()];
+      const canClassify = typeof sessionWindowIsClosableAtAGlance === 'function';
+      return {
+        on: ui2ClosableLensOn,
+        lensAttr: document.documentElement.getAttribute('data-ui2-closable-lens') || '',
+        count: Number(document.getElementById('ui2-closable-lens-count')?.textContent || '0'),
+        chipHidden: !btn || !!btn.hidden,
+        closable: canClassify ? ids.filter((sid) => sessionWindowIsClosableAtAGlance(sid)) : [],
+        closableClassed: ids.filter(
+          (sid) => !!sessionWindows.get(sid)?.el?.classList?.contains('session-window-closable')
+        ),
+      };
+    },
+  },
+});
 
 // Popover mechanics copied from the Options wiring below: fixed-position
 // anchor stamped at open, outside-pointerdown + Escape close, resize
@@ -37527,6 +37680,7 @@ function ui2RailTick(force) {
     ui2AugmentApprovalPanel();
     ui2WireLayoutToggle();
     ui2WireArrangeMenu();
+    ui2WireClosableLens();
     ui2WireViewOptions();
     ui2DressComposer();
     ui2BuildVitalsRail();
@@ -37605,7 +37759,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '47d4d928f643b7fc';
+const INTENDANT_APP_BUILD = '17612ff86f5c4867';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -71301,6 +71455,54 @@ function hideDoneSessionWindows() {
     changed += 1;
   }
   return changed;
+}
+
+// ── Closable at a glance (Track AO follow-through) ─────────────────────
+// The POSITIVE half of the safe-to-stop story, composed for the grid
+// lens (ui2-activity.js owns the count chip and the dim toggle; its
+// Arrange walk derives the count and the per-window class). One claim
+// function, matrix-driven by the QA harness; the × affordance and the
+// stop confirms above keep their own copy surfaces untouched. The
+// predicate is strictly a conjunction of claims that ALREADY exist —
+// never a second derivation:
+//   · the served stop claim (grid_envelope.rs, consumed verbatim):
+//     kills_live_run / owed_work veto outright — the durable journal
+//     debt outranks any process look; settled turns positive only once
+//     the window itself is quiet, extending the ruled
+//     suppressed-while-running choice to the lens (a running window
+//     never reads closable, even settled — it may be doing new,
+//     untracked work);
+//   · the × affordance's linkless conjunction: idle ∧ no agenda linkage;
+//   · hard done evidence (ended / done / interrupted) — the "already
+//     ended" positive the stop flow and the Hide-finished sweep already
+//     rule.
+// A linked occurrence with no served stop claim, and any unrecognized
+// claim, stay not-closable: positive-only, absence claims nothing.
+function sessionWindowClosableClaim(claim = {}) {
+  const stop = typeof claim.stop === 'string' ? claim.stop : '';
+  if (stop === 'kills_live_run' || stop === 'owed_work') return false;
+  const quiet = !!claim.hardDone || normalizeSessionPhase(claim.phase || '') === 'idle';
+  if (stop === 'settled') return quiet;
+  if (stop || claim.linked) return false;
+  return quiet;
+}
+
+// The sid boundary over the pure claim above: every input is a fact some
+// shipped surface already trusts — the served envelope in
+// sessionMetadataById, the ×'s win.phase, the sweeps' hard-done
+// predicate. Nothing here looks at the journal or the process directly.
+function sessionWindowIsClosableAtAGlance(sessionId) {
+  const sid = String(sessionId || '').trim();
+  const win = sid ? sessionWindows.get(sid) : null;
+  if (!win) return false;
+  const meta = sessionMetadataById.get(sid) || {};
+  const occ = (meta.agenda || {}).occurrence;
+  return sessionWindowClosableClaim({
+    stop: (occ && occ.stop) || '',
+    linked: !!meta.agenda,
+    phase: win.phase || meta.phase || '',
+    hardDone: sessionWindowHasHardDoneEvidence(sid),
+  });
 }
 
 // QA facade (window.qa convention): the dashboard validator's grid-pill

--- a/static/app/12-styles-tasks-log.css
+++ b/static/app/12-styles-tasks-log.css
@@ -985,6 +985,21 @@ body.context-focus-active {
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--peach) 22%, transparent);
   filter: saturate(0.65);
 }
+/* Closable-at-a-glance lens (the Activity toolbar chip stamps the html
+   attribute; each window's class derives in ui2-activity.js's Arrange
+   walk from the positive safe-to-stop claims): every card the machine
+   does NOT rule safe recedes, the closable set keeps full presence with
+   a quiet affirmative ring. Positive-only — the dim says "look here",
+   never "unsafe". */
+html[data-ui2-closable-lens="on"] .session-window:not(.session-window-closable) {
+  opacity: 0.35;
+  filter: saturate(0.55);
+}
+html[data-ui2-closable-lens="on"] .session-window.session-window-closable {
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--green) 45%, transparent),
+    inset 0 0 0 1px color-mix(in srgb, var(--green) 22%, transparent);
+}
 /* Terminal honesty strip: a dead window's plain statement of how it
    ended, with the lineage pointer when the work continued elsewhere. */
 .session-window .session-window-terminal-note {

--- a/static/app/20-shell.html
+++ b/static/app/20-shell.html
@@ -144,6 +144,19 @@
             <button type="button" id="ui2-layout-grid-btn" data-layout="grid"
                     title="Grid — session windows with the concurrent stream below">Grid</button>
           </div>
+          <!-- Closable-at-a-glance chip + lens toggle: the POSITIVE count
+               of session cards whose close the machine already rules safe
+               (the served safe-to-stop claim settled, idle with no agenda
+               linkage, or finished — sessionWindowClosableClaim in
+               41-session-window-actions.js; the count and each card's
+               class derive in ui2-activity.js's Arrange walk). Hidden at
+               zero — never "0 closable" — and engaging it dims every
+               other card. -->
+          <button type="button" class="ui2-closable-lens-btn" id="ui2-closable-lens-btn" hidden
+                  aria-pressed="false"
+                  title="Session cards that are safe to close — click to dim the rest">
+            <span class="ui2-closable-lens-count" id="ui2-closable-lens-count">0</span><span>closable</span>
+          </button>
           <!-- One compact menu button consolidating the bulk window sweeps
                (it replaced five standalone pills: Minimize done, Hide done,
                Collapse all/Expand all, Expand/Collapse details).

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -1152,7 +1152,12 @@ function hideDoneSessionWindows() {
 function sessionWindowClosableClaim(claim = {}) {
   const stop = typeof claim.stop === 'string' ? claim.stop : '';
   if (stop === 'kills_live_run' || stop === 'owed_work') return false;
-  const quiet = !!claim.hardDone || normalizeSessionPhase(claim.phase || '') === 'idle';
+  // An ABSENT phase is no claim (normalizeSessionPhase defaults '' to
+  // 'idle', which would read wider than the ×'s raw win.phase === 'idle'
+  // check — positive-only forbids that): a phase-less window is quiet
+  // only on hard done evidence.
+  const quiet = !!claim.hardDone
+    || (!!claim.phase && normalizeSessionPhase(claim.phase) === 'idle');
   if (stop === 'settled') return quiet;
   if (stop || claim.linked) return false;
   return quiet;

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -1128,6 +1128,54 @@ function hideDoneSessionWindows() {
   return changed;
 }
 
+// ── Closable at a glance (Track AO follow-through) ─────────────────────
+// The POSITIVE half of the safe-to-stop story, composed for the grid
+// lens (ui2-activity.js owns the count chip and the dim toggle; its
+// Arrange walk derives the count and the per-window class). One claim
+// function, matrix-driven by the QA harness; the × affordance and the
+// stop confirms above keep their own copy surfaces untouched. The
+// predicate is strictly a conjunction of claims that ALREADY exist —
+// never a second derivation:
+//   · the served stop claim (grid_envelope.rs, consumed verbatim):
+//     kills_live_run / owed_work veto outright — the durable journal
+//     debt outranks any process look; settled turns positive only once
+//     the window itself is quiet, extending the ruled
+//     suppressed-while-running choice to the lens (a running window
+//     never reads closable, even settled — it may be doing new,
+//     untracked work);
+//   · the × affordance's linkless conjunction: idle ∧ no agenda linkage;
+//   · hard done evidence (ended / done / interrupted) — the "already
+//     ended" positive the stop flow and the Hide-finished sweep already
+//     rule.
+// A linked occurrence with no served stop claim, and any unrecognized
+// claim, stay not-closable: positive-only, absence claims nothing.
+function sessionWindowClosableClaim(claim = {}) {
+  const stop = typeof claim.stop === 'string' ? claim.stop : '';
+  if (stop === 'kills_live_run' || stop === 'owed_work') return false;
+  const quiet = !!claim.hardDone || normalizeSessionPhase(claim.phase || '') === 'idle';
+  if (stop === 'settled') return quiet;
+  if (stop || claim.linked) return false;
+  return quiet;
+}
+
+// The sid boundary over the pure claim above: every input is a fact some
+// shipped surface already trusts — the served envelope in
+// sessionMetadataById, the ×'s win.phase, the sweeps' hard-done
+// predicate. Nothing here looks at the journal or the process directly.
+function sessionWindowIsClosableAtAGlance(sessionId) {
+  const sid = String(sessionId || '').trim();
+  const win = sid ? sessionWindows.get(sid) : null;
+  if (!win) return false;
+  const meta = sessionMetadataById.get(sid) || {};
+  const occ = (meta.agenda || {}).occurrence;
+  return sessionWindowClosableClaim({
+    stop: (occ && occ.stop) || '',
+    linked: !!meta.agenda,
+    phase: win.phase || meta.phase || '',
+    hardDone: sessionWindowHasHardDoneEvidence(sid),
+  });
+}
+
 // QA facade (window.qa convention): the dashboard validator's grid-pill
 // probe builds throwaway windows and reads per-window sweep state, and the
 // boot smoke's jump-button probe drives the transcript state machine — the

--- a/static/app/ui2-activity.css
+++ b/static/app/ui2-activity.css
@@ -237,6 +237,41 @@ html.ui-v2 #activity-subtabs .ui2-arrange-btn[aria-expanded="true"] svg { transf
 html.ui-v2 #activity-subtabs .ui2-arrange-btn[hidden],
 html.ui-v2:not([data-ui2-layout="grid"]) #activity-subtabs .ui2-arrange-btn { display: none; }
 
+/* Closable-at-a-glance chip — sibling styling to Arrange. The count is
+   the machine-positive closable set; the pressed state engages the lens
+   (the window dim itself lives with the .session-window rules in
+   12-styles-tasks-log.css, keyed on the html attribute the toggle
+   stamps). Hidden at zero by ui2-activity.js, grid-only like every
+   window tool. */
+html.ui-v2 #activity-subtabs .ui2-closable-lens-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 28px;
+  padding: 0 10px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: transparent;
+  color: var(--text-3);
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 650;
+  cursor: pointer;
+  transition: color var(--t-fast), background var(--t-fast), border-color var(--t-fast);
+}
+html.ui-v2 #activity-subtabs .ui2-closable-lens-btn .ui2-closable-lens-count {
+  color: var(--green);
+  font-variant-numeric: tabular-nums;
+}
+html.ui-v2 #activity-subtabs .ui2-closable-lens-btn:hover { color: var(--text); background: var(--hover-wash); }
+html.ui-v2 #activity-subtabs .ui2-closable-lens-btn[aria-pressed="true"] {
+  color: var(--text);
+  background: var(--surface-2);
+  border-color: color-mix(in srgb, var(--green) 45%, var(--line));
+}
+html.ui-v2 #activity-subtabs .ui2-closable-lens-btn[hidden],
+html.ui-v2:not([data-ui2-layout="grid"]) #activity-subtabs .ui2-closable-lens-btn { display: none; }
+
 /* The Arrange menu popover: same mechanics as the Options popover below
    (display:none base, .open shows, position:fixed against the subtab
    row's overflow-x clipping, JS stamps top/right from the trigger). The

--- a/static/app/ui2-activity.js
+++ b/static/app/ui2-activity.js
@@ -134,17 +134,23 @@ function ui2WireLayoutToggle() {
 // Predicates are 41/40's shared boundaries: sessionWindowIsSubagent (the
 // relationship kind the badges use), sessionWindowIsDoneSubagent (the
 // "N sub" active boundary), sessionWindowHasHardDoneEvidence (ended /
-// done / interrupted — never bare idle).
+// done / interrupted — never bare idle), and
+// sessionWindowIsClosableAtAGlance (the positive-only safe-to-stop
+// composition). The closable lens's per-window class rides this same
+// pass — same freshness ticks (badge crossings, the relationship render
+// pass, every sweep) — so the chip's number and the dimmed set can
+// never disagree.
 function ui2ArrangeMenuModel() {
   const model = {
     windows: 0, expanded: 0, minimized: 0,
     subs: 0, subsExpanded: 0, doneSubsExpanded: 0,
-    hardDone: 0, detailsExpanded: 0,
+    hardDone: 0, detailsExpanded: 0, closable: 0,
   };
   if (typeof sessionWindows === 'undefined') return model;
   const isSub = typeof sessionWindowIsSubagent === 'function' ? sessionWindowIsSubagent : null;
   const isDoneSub = typeof sessionWindowIsDoneSubagent === 'function' ? sessionWindowIsDoneSubagent : null;
   const isHardDone = typeof sessionWindowHasHardDoneEvidence === 'function' ? sessionWindowHasHardDoneEvidence : null;
+  const isClosable = typeof sessionWindowIsClosableAtAGlance === 'function' ? sessionWindowIsClosableAtAGlance : null;
   for (const [sid, win] of sessionWindows) {
     if (!win) continue;
     model.windows += 1;
@@ -161,6 +167,11 @@ function ui2ArrangeMenuModel() {
       }
     }
     if (isHardDone && isHardDone(sid)) model.hardDone += 1;
+    if (isClosable) {
+      const closable = isClosable(sid);
+      if (closable) model.closable += 1;
+      if (win.el) win.el.classList.toggle('session-window-closable', closable);
+    }
   }
   return model;
 }
@@ -242,6 +253,9 @@ function ui2RefreshArrangeMenu() {
           : `Collapse header details on all ${m.detailsExpanded} expanded session windows`)
       : 'Expand header details on every session window',
   });
+  // The closable chip rides the same single-pass refresh (and the same
+  // walk already stamped every window's closable class above).
+  ui2RefreshClosableLensChip(m.closable);
 }
 
 // Legacy seam: 40-session-launch.js's relationship-render pass still
@@ -301,6 +315,82 @@ function ui2RunArrangeAction(action, row) {
   }
   ui2RefreshArrangeMenu();
 }
+
+// ── The closable-at-a-glance lens ──────────────────────────────────────
+// A grid lens over the positive safe-to-stop claims
+// (sessionWindowClosableClaim / sessionWindowIsClosableAtAGlance in
+// 41-session-window-actions.js): the chip counts the cards whose close
+// the machine already rules safe and, engaged, dims every other card so
+// the closable set reads at a glance (the dim rules live with the
+// .session-window styles in 12-styles-tasks-log.css, keyed on the html
+// attribute stamped here). Positive-only at the surface too: the chip
+// hides at zero — never "0 closable" — and because an engaged lens with
+// an empty count would strand a fully-dimmed grid behind a hidden
+// toggle, the refresh disengages it the moment the count empties.
+// Transient by design: the lens is a look, not a mode — it never
+// persists across reloads.
+let ui2ClosableLensOn = false;
+
+function ui2SetClosableLens(on) {
+  ui2ClosableLensOn = !!on;
+  const html = document.documentElement;
+  if (ui2ClosableLensOn) html.setAttribute('data-ui2-closable-lens', 'on');
+  else html.removeAttribute('data-ui2-closable-lens');
+  const btn = document.getElementById('ui2-closable-lens-btn');
+  if (btn) btn.setAttribute('aria-pressed', ui2ClosableLensOn ? 'true' : 'false');
+}
+
+function ui2RefreshClosableLensChip(count) {
+  const btn = document.getElementById('ui2-closable-lens-btn');
+  if (!btn) return;
+  const n = Number(count) || 0;
+  btn.hidden = n === 0;
+  if (btn.hidden && ui2ClosableLensOn) ui2SetClosableLens(false);
+  const countEl = document.getElementById('ui2-closable-lens-count');
+  if (countEl) countEl.textContent = String(n);
+  btn.title = n === 1
+    ? 'One session card is safe to close (settled agenda debt, idle with no agenda linkage, or finished) — click to dim the rest'
+    : `${n} session cards are safe to close (settled agenda debt, idle with no agenda linkage, or finished) — click to dim the rest`;
+}
+
+function ui2WireClosableLens() {
+  const btn = document.getElementById('ui2-closable-lens-btn');
+  if (!btn) return;
+  btn.addEventListener('click', () => {
+    ui2SetClosableLens(!ui2ClosableLensOn);
+    ui2RefreshArrangeMenu();
+  });
+}
+
+// QA facade (window.qa convention): claim() drives the pure classifier
+// with an explicit matrix (the conjunction is otherwise untestable
+// without a live daemon), set()/state() drive and snapshot the chip +
+// lens surface after a fresh single-pass walk.
+window.qa = Object.assign(window.qa || {}, {
+  closableLens: {
+    claim: (c) => (typeof sessionWindowClosableClaim === 'function'
+      ? sessionWindowClosableClaim(c || {}) : null),
+    isClosable: (sid) => (typeof sessionWindowIsClosableAtAGlance === 'function'
+      ? sessionWindowIsClosableAtAGlance(sid) : null),
+    set: (on) => { ui2SetClosableLens(!!on); ui2RefreshArrangeMenu(); return ui2ClosableLensOn; },
+    state: () => {
+      ui2RefreshArrangeMenu();
+      const btn = document.getElementById('ui2-closable-lens-btn');
+      const ids = typeof sessionWindows === 'undefined' ? [] : [...sessionWindows.keys()];
+      const canClassify = typeof sessionWindowIsClosableAtAGlance === 'function';
+      return {
+        on: ui2ClosableLensOn,
+        lensAttr: document.documentElement.getAttribute('data-ui2-closable-lens') || '',
+        count: Number(document.getElementById('ui2-closable-lens-count')?.textContent || '0'),
+        chipHidden: !btn || !!btn.hidden,
+        closable: canClassify ? ids.filter((sid) => sessionWindowIsClosableAtAGlance(sid)) : [],
+        closableClassed: ids.filter(
+          (sid) => !!sessionWindows.get(sid)?.el?.classList?.contains('session-window-closable')
+        ),
+      };
+    },
+  },
+});
 
 // Popover mechanics copied from the Options wiring below: fixed-position
 // anchor stamped at open, outside-pointerdown + Escape close, resize
@@ -866,6 +956,7 @@ function ui2RailTick(force) {
     ui2AugmentApprovalPanel();
     ui2WireLayoutToggle();
     ui2WireArrangeMenu();
+    ui2WireClosableLens();
     ui2WireViewOptions();
     ui2DressComposer();
     ui2BuildVitalsRail();

--- a/tests/skills/closable-lens-qa/SKILL.md
+++ b/tests/skills/closable-lens-qa/SKILL.md
@@ -1,0 +1,83 @@
+# Closable-at-a-glance lens — QA harness leg
+
+Validates the grid's closable lens end to end in a real booted SPA:
+the positive-only classifier (`sessionWindowClosableClaim`,
+`static/app/41-session-window-actions.js`), the count chip + dim toggle
+(`static/app/ui2-activity.js`), and the auto-disengage-on-empty rule —
+without a live daemon session behind any window. Everything drives
+through `window.qa` (the SPA is one module scope; `qa.closableLens` and
+`qa.sessionWindowSweeps` are the only doors).
+
+Preconditions: none beyond a buildable checkout — the validator's
+`--launch-dashboard` boots a throwaway daemon (its stale-binary guard
+rebuilds when sources changed; expect a compile on first run) and owns
+its lifecycle. Pick a throwaway port. No API keys, no display: the
+probes never dispatch a session.
+
+Two probes, one invocation:
+
+- **matrix** — drives the pure classifier with the explicit conjunction
+  matrix. Every negative served claim must veto (even hard-done),
+  `settled` must be positive only quiet (idle or hard-done — never a
+  running phase), a linked occurrence without a served stop claim must
+  claim nothing, and unknown claims must stay not-closable.
+- **lens** — builds four throwaway windows via
+  `qa.sessionWindowSweeps.build` (each built TWICE: the second call
+  routes the metadata through `updateSessionWindow`, which stores the
+  agenda envelope + phase the classifier reads — the first build only
+  renders), then walks the chip/class/attribute lifecycle and removes
+  them again.
+
+```bash
+node scripts/validate-dashboard.cjs --launch-dashboard --port 8931 \
+  --wait-for-function "window.qa && window.qa.closableLens && window.qa.sessionWindowSweeps" \
+  --probe-json "matrix=(() => { const c = window.qa.closableLens.claim; return {
+    killsVeto: c({stop:'kills_live_run', hardDone:true}) === false,
+    owedVeto: c({stop:'owed_work', hardDone:true}) === false,
+    settledRunningSuppressed: c({stop:'settled', phase:'running'}) === false,
+    settledIdle: c({stop:'settled', phase:'idle'}) === true,
+    settledHardDone: c({stop:'settled', hardDone:true}) === true,
+    linkedNoClaim: c({linked:true, phase:'idle'}) === false,
+    idleLinkless: c({phase:'idle'}) === true,
+    waitingSuppressed: c({phase:'waiting'}) === false,
+    thinkingSuppressed: c({phase:'thinking'}) === false,
+    hardDoneLinkless: c({hardDone:true}) === true,
+    unknownClaim: c({stop:'someday_new_claim'}) === false,
+  }; })()" \
+  --probe-json "lens=(() => { const sw = window.qa.sessionWindowSweeps, L = window.qa.closableLens;
+    const mk = (sid, meta) => { sw.build(sid, meta); sw.build(sid, meta); };
+    mk('qa-lens-idle', {phase:'idle'});
+    mk('qa-lens-run', {phase:'running'});
+    mk('qa-lens-settled', {phase:'idle', agenda:{item_id:'01QALENSITEM', occurrence:{id:'01QAOCC1', state:'completed', stop:'settled'}}});
+    mk('qa-lens-owed', {phase:'idle', agenda:{item_id:'01QALENSITEM2', occurrence:{id:'01QAOCC2', state:'started', stop:'owed_work'}}});
+    const before = L.state();
+    const on = L.set(true); const engaged = L.state();
+    L.set(false);
+    for (const sid of ['qa-lens-idle','qa-lens-run','qa-lens-settled','qa-lens-owed']) sw.remove(sid);
+    const after = L.state();
+    return { before, on, engaged, after }; })()" \
+  --screenshot /tmp/closable-lens-qa.png
+```
+
+Pass bars (read the two `probe … = {…}` stdout lines):
+
+- `matrix`: every key `true`.
+- `lens.before`: `count: 2`, `chipHidden: false`, `closable` and
+  `closableClassed` both exactly `["qa-lens-idle","qa-lens-settled"]`
+  (order per insertion), `on: false`, `lensAttr: ""`.
+- `lens.on`: `true`; `lens.engaged`: `lensAttr: "on"`, same two ids
+  closable-classed; `qa-lens-run`/`qa-lens-owed` never appear in either
+  list (running suppressed; the owed_work veto outranks the idle look).
+- `lens.after` (all windows removed): `count: 0`, `chipHidden: true`,
+  and — the strand-guard — `on: false`, `lensAttr: ""` even though the
+  lens was last driven while engaged in an earlier step? No: the lens
+  was explicitly set off above; re-run with the `L.set(false)` line
+  removed to exercise the auto-disengage (`after.on` must STILL be
+  `false` — the refresh disengages an engaged lens the moment the count
+  empties; both variants are green as of the lens landing).
+
+The `--screenshot` lands after the probes: with the scenario windows
+removed the grid is empty again — the image documents the booted SPA,
+not the lens. For a visual look, re-run with the removal loop deleted
+and `--keep-browser`, then inspect the held page (two full-presence
+cards, two dimmed at 0.35 opacity, chip pressed with count 2).

--- a/tests/skills/closable-lens-qa/SKILL.md
+++ b/tests/skills/closable-lens-qa/SKILL.md
@@ -43,6 +43,7 @@ node scripts/validate-dashboard.cjs --launch-dashboard --port 8931 \
     thinkingSuppressed: c({phase:'thinking'}) === false,
     hardDoneLinkless: c({hardDone:true}) === true,
     unknownClaim: c({stop:'someday_new_claim'}) === false,
+    phaselessClaimsNothing: c({}) === false && c({phase:''}) === false,
   }; })()" \
   --probe-json "lens=(() => { const sw = window.qa.sessionWindowSweeps, L = window.qa.closableLens;
     const mk = (sid, meta) => { sw.build(sid, meta); sw.build(sid, meta); };

--- a/tests/skills/closable-lens-qa/SKILL.md
+++ b/tests/skills/closable-lens-qa/SKILL.md
@@ -8,11 +8,22 @@ without a live daemon session behind any window. Everything drives
 through `window.qa` (the SPA is one module scope; `qa.closableLens` and
 `qa.sessionWindowSweeps` are the only doors).
 
-Preconditions: none beyond a buildable checkout — the validator's
-`--launch-dashboard` boots a throwaway daemon (its stale-binary guard
-rebuilds when sources changed; expect a compile on first run) and owns
-its lifecycle. Pick a throwaway port. No API keys, no display: the
-probes never dispatch a session.
+Preconditions: current worktree binaries (`cargo build --bin intendant
+--bin intendant-runtime` — the validator REJECTS stale target binaries
+and never rebuilds). Two isolation rules make the readbacks
+deterministic and safe:
+
+- **Scratch `INTENDANT_HOME`** — the launched daemon inherits the
+  environment; without this it runs against the real home and the real
+  session catalog populates the grid, breaking the exact-count and
+  exact-id bars below (and pointing probes at owner state).
+- **Explicit `--dashboard-binary`** — under Intendant supervision
+  `$INTENDANT` names the *user's* installed binary; auto-discovery would
+  validate the wrong tree. Point at this worktree's build.
+
+No API keys, no display: the probes never dispatch a session, and the
+throwaway windows are pure SPA state (map + DOM), never daemon
+mutations.
 
 Two probes, one invocation:
 
@@ -20,16 +31,20 @@ Two probes, one invocation:
   matrix. Every negative served claim must veto (even hard-done),
   `settled` must be positive only quiet (idle or hard-done — never a
   running phase), a linked occurrence without a served stop claim must
-  claim nothing, and unknown claims must stay not-closable.
+  claim nothing, unknown claims must stay not-closable, and an absent
+  phase must claim nothing (`normalizeSessionPhase` defaults `''` to
+  `'idle'`; the classifier must not inherit that widening).
 - **lens** — builds four throwaway windows via
   `qa.sessionWindowSweeps.build` (each built TWICE: the second call
   routes the metadata through `updateSessionWindow`, which stores the
   agenda envelope + phase the classifier reads — the first build only
-  renders), then walks the chip/class/attribute lifecycle and removes
-  them again.
+  renders), walks the chip/class/attribute lifecycle, then removes all
+  four **while the lens is engaged** to exercise the strand-guard.
 
 ```bash
-node scripts/validate-dashboard.cjs --launch-dashboard --port 8931 \
+QAHOME=$(mktemp -d /tmp/closable-lens-home.XXXXXX)
+INTENDANT_HOME="$QAHOME" node scripts/validate-dashboard.cjs \
+  --launch-dashboard --port 8931 --dashboard-binary ./target/debug/intendant \
   --wait-for-function "window.qa && window.qa.closableLens && window.qa.sessionWindowSweeps" \
   --probe-json "matrix=(() => { const c = window.qa.closableLens.claim; return {
     killsVeto: c({stop:'kills_live_run', hardDone:true}) === false,
@@ -53,11 +68,12 @@ node scripts/validate-dashboard.cjs --launch-dashboard --port 8931 \
     mk('qa-lens-owed', {phase:'idle', agenda:{item_id:'01QALENSITEM2', occurrence:{id:'01QAOCC2', state:'started', stop:'owed_work'}}});
     const before = L.state();
     const on = L.set(true); const engaged = L.state();
-    L.set(false);
-    for (const sid of ['qa-lens-idle','qa-lens-run','qa-lens-settled','qa-lens-owed']) sw.remove(sid);
-    const after = L.state();
-    return { before, on, engaged, after }; })()" \
+    const removedWhileOn = (() => {
+      for (const sid of ['qa-lens-idle','qa-lens-run','qa-lens-settled','qa-lens-owed']) sw.remove(sid);
+      return L.state(); })();
+    return { before, on, engaged, removedWhileOn }; })()" \
   --screenshot /tmp/closable-lens-qa.png
+rm -rf "$QAHOME"
 ```
 
 Pass bars (read the two `probe … = {…}` stdout lines):
@@ -65,20 +81,24 @@ Pass bars (read the two `probe … = {…}` stdout lines):
 - `matrix`: every key `true`.
 - `lens.before`: `count: 2`, `chipHidden: false`, `closable` and
   `closableClassed` both exactly `["qa-lens-idle","qa-lens-settled"]`
-  (order per insertion), `on: false`, `lensAttr: ""`.
-- `lens.on`: `true`; `lens.engaged`: `lensAttr: "on"`, same two ids
-  closable-classed; `qa-lens-run`/`qa-lens-owed` never appear in either
-  list (running suppressed; the owed_work veto outranks the idle look).
-- `lens.after` (all windows removed): `count: 0`, `chipHidden: true`,
-  and — the strand-guard — `on: false`, `lensAttr: ""` even though the
-  lens was last driven while engaged in an earlier step? No: the lens
-  was explicitly set off above; re-run with the `L.set(false)` line
-  removed to exercise the auto-disengage (`after.on` must STILL be
-  `false` — the refresh disengages an engaged lens the moment the count
-  empties; both variants are green as of the lens landing).
+  (insertion order), `on: false`, `lensAttr: ""` — `qa-lens-run`
+  (running suppressed) and `qa-lens-owed` (the owed_work veto outranks
+  the idle look) never appear in either list.
+- `lens.on`: `true`; `lens.engaged`: `lensAttr: "on"`, same two ids in
+  both lists.
+- `lens.removedWhileOn` — the strand-guard: with every window removed
+  while the lens was engaged, `count: 0`, `chipHidden: true`, and
+  `on: false` / `lensAttr: ""` — the refresh disengages an engaged lens
+  the moment the count empties, so a fully-dimmed grid can never sit
+  behind a hidden toggle.
+
+Recorded green 2026-07-30 on the lens landing (PR #678): both probes
+exactly as above, `PASS dashboard-validation … functions=1`, ~20 s
+against a debug binary.
 
 The `--screenshot` lands after the probes: with the scenario windows
 removed the grid is empty again — the image documents the booted SPA,
-not the lens. For a visual look, re-run with the removal loop deleted
+not the lens. For a visual look, re-run with the removal step deleted
 and `--keep-browser`, then inspect the held page (two full-presence
-cards, two dimmed at 0.35 opacity, chip pressed with count 2).
+cards with the green ring, two dimmed at 0.35 opacity, chip pressed
+with count 2).


### PR DESCRIPTION
A pure-SPA glance layer over the ruled Track AO safe-to-stop derivation (card 01KYSWZC8WAJ68ANDVE2B2XKWC): AO S5 serves each window's stop claim and the close affordance renders it honestly, but there was no glance-level surface — the owner could not see across the grid which cards are closable.

**Zero new serving.** The lens composes claims that already exist:

- `sessionWindowClosableClaim` (41-session-window-actions.js) — POSITIVE-only: the served stop claim consumed verbatim (`kills_live_run` / `owed_work` veto outright; `settled` positive only once the window is quiet, extending the ruled suppressed-while-running choice — a running window never reads closable), the × affordance's idle ∧ no-linkage conjunction, and the sweeps' hard-done evidence. Linked-but-unclaimed occurrences and unrecognized claims stay not-closable; absence claims nothing. Never a second derivation; × copy and stop confirms untouched.
- Count chip + lens toggle beside Arrange in the Activity tools: **N closable**, hidden at zero (never "0 closable"); engaging it dims every non-closable card. Count and per-card class derive in the Arrange menu's single walk (same freshness ticks — chip and dimmed set can never disagree); an emptied count disengages the lens instead of stranding a fully-dimmed grid; transient, never persisted.
- `window.qa.closableLens` matrix/state/drive probes + the runnable harness leg (tests/skills/closable-lens-qa/SKILL.md); positive-only pins (`closable_lens_is_positive_only`, static_assets.rs); web-dashboard.md covers the lens and the probe.

Fragments only; app.html regenerated by the assembler.