### PR TITLE
restore live thinking parity for supervised claude-code sessions

### DIFF
--- a/docs/src/external-agent-orchestration.md
+++ b/docs/src/external-agent-orchestration.md
@@ -155,7 +155,7 @@ adapter from `[agent.<backend>]` config, then `run_external_agent_mode()`
 | Mid-turn steer | Yes (`turn/steer`) | Yes — a stdin user message is absorbed into the running turn at the CLI's next checkpoint (verified on 2.1.215; 2.1.207 discarded such lines). No stdout echo, so delivery is inferred at the next model checkpoint; an idle session delivers the steer immediately as its own turn | Yes — Kimi queued prompts plus `prompts::steer`; a completion race becomes an ordinary immediate follow-up without losing text | Yes (`steer`) |
 | Mid-turn interrupt | Yes (`turn/interrupt`) | Yes (`control_request` `interrupt`; the process survives for follow-up turns) | Yes — active prompt abort, with a session abort fallback | Yes (`abort`) |
 | Token usage / context meter | Yes | Yes (`message_delta` + `result` usage; context window from `modelUsage`) | Yes — usage events plus typed `agentRPCService.getContext` snapshots: Kimi's current post-compaction model history and measured `tokenCount`, scoped to the exact selected main/composite agent, with the configured model catalog's context window | Yes — assistant-message usage/cache fields plus model context window from state/model events |
-| Reasoning trace | Yes | Yes (`thinking` blocks) | Yes — thinking deltas/messages | Yes — thinking deltas/messages |
+| Reasoning trace | Yes | Yes (`thinking` blocks) — but print-mode CC ≥ 2.1.217 withholds summarized-thinking text on spawned seats (see the Usage bullet); adopted/attached interactive sessions keep it | Yes — thinking deltas/messages | Yes — thinking deltas/messages |
 | Rollback turns | Yes (`thread/rollback`) | No → session reset | Yes — native `undo`, including edit-and-rerun of an active historical user turn | No → fork or reset |
 | Fork / side threads / review / goals / compact / fast / memory-reset | Yes (`thread_action`) | `compact`, `fork` (respawns via `--resume <id> --fork-session`), `side` (`/btw` — the same respawn carrying a side boundary + question as the child's first prompt; lineage `fork_relationship: "side"`), the full `goal*` family (wrapper goal engine), and live `model` / `permission-mode` — all via universal `thread_actions`. No fast/review/memory-reset — see [Dashboard and Station parity](#dashboard-and-station-parity-codex-vs-claude-code) | Native `compact`, head and exact historical real-user-turn-boundary `fork`, `side`/`:btw`, `undo`, archive/restore/rename, goal get/set/pause/resume/complete/clear with enforced token/turn/wall-clock budgets, live model/thinking/permission/plan/swarm switches, official normal↔highspeed model toggling, supervisor-enforced tool-free read-only review turns over bounded controller-collected workspace evidence, background-task list/output/cancel, exact per-agent active-tool control, model catalog, and destructive per-agent context clear. Kimi has no persistent-memory plane equivalent to Codex `memory-reset`, explicit “mark budget-limited” setter, arbitrary item/message/child fork anchor, or child-only undo | Native compact and rename; fork/side respawn from the parent session; live model and thinking. No native goals/review/fast/memory reset |
 | Native sub-agents | Yes — collab tools spawn real attachable threads (`SubAgentToolCall`) | Yes — the in-band `Agent`/`Task` tool; async children stream `parent_tool_use_id`-tagged envelopes, surfaced as ephemeral `task-*` child sessions on the same `SubAgentToolCall`/relationship rail | Yes — native swarm and `:btw` agents retain their own ids, scoped activity, relationships, status, and results | No — upstream Pi deliberately omits built-in sub-agents |
@@ -678,9 +678,32 @@ through Claude Code 2.1.210):
 - **Usage**: per-API-call usage from `message_delta` stream events plus the
   turn `result` feed `AgentEvent::Usage`; the context window comes from the
   result's `modelUsage` map (200k default until the first result).
-  `thinking` blocks surface as `AgentEvent::Reasoning`. Turn `result`s with
-  error subtypes (`error_max_turns`, `error_during_execution`, …) emit
-  `AgentEvent::BackendError` before completing the turn.
+  `thinking` blocks surface as `AgentEvent::Reasoning` — with one upstream
+  limitation the wrapper cannot repair: **print-mode Claude Code
+  (≥ 2.1.217, the `-p`/sdk-cli entrypoint every daemon-spawned seat uses)
+  withholds summarized-thinking text entirely** on summarized-thinking
+  models (e.g. `claude-fable-5`). Raw wire capture (2026-07-30, CC
+  2.1.220, the wrapper's exact spawn args): `thinking_delta` events carry
+  `{"thinking":"","estimated_tokens":N}`, the `content_block_start` and
+  assistant-envelope blocks are signature-only shells, and the same
+  turn's native `~/.claude` transcript stores the same empty shell — so
+  there is no text to render anywhere, and `AgentEvent::Reasoning` never
+  fires. The strip is entrypoint-conditional and upstream-deliberate:
+  interactive (`cli`-entrypoint) sessions at the same versions keep full
+  thinking text, both live and in their transcripts. Intendant renders
+  honest absence (never a fabricated row): spawned print-mode seats show
+  the "Thinking" activity phase (the empty deltas still heartbeat) but no
+  thinking rows, while interactive-born sessions the daemon adopted or
+  attached get their transcript-materialized thinking forwarded into the
+  live Activity feed by the dashboard's transcript-sync parity lane
+  (`static/app/41b-reasoning-log.js`), deduplicated against the live lane
+  by the shared `level model` + `kind reasoning` signature grammar. The
+  wrapper also buffers any initial `content_block_start` thinking text
+  (none shipped today), so a future CLI that restores text in any
+  streamed shape lights the whole live chain back up unchanged. Turn
+  `result`s with error subtypes (`error_max_turns`,
+  `error_during_execution`, …) emit `AgentEvent::BackendError` before
+  completing the turn.
 - **Thread actions**: `compact` writes the native `/compact` user message —
   the CLI answers `status: compacting` → `compact_boundary` (with
   `pre_tokens`) → a free zero-usage `result`, and the session keeps its

--- a/src/bin/caller/external_agent/claude_code.rs
+++ b/src/bin/caller/external_agent/claude_code.rs
@@ -6087,7 +6087,10 @@ mod tests {
         let out = reader.process_line(
             r#"{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"","signature":"sig-s"}]},"session_id":"s1"}"#,
         );
-        assert_eq!(reasoning_texts(&out), vec!["Opening thought. Then a delta."]);
+        assert_eq!(
+            reasoning_texts(&out),
+            vec!["Opening thought. Then a delta."]
+        );
         assert!(reader.thinking_buffers.is_empty());
     }
 

--- a/src/bin/caller/external_agent/claude_code.rs
+++ b/src/bin/caller/external_agent/claude_code.rs
@@ -3003,12 +3003,30 @@ impl CcReader {
                     .pointer("/content_block/type")
                     .and_then(|t| t.as_str())
                 {
-                    Some("thinking") | Some("redacted_thinking") => self.observe_activity(
-                        ActivityObs::ReasoningStarted {
-                            delta_heartbeat: true,
-                        },
-                        out,
-                    ),
+                    Some("thinking") | Some("redacted_thinking") => {
+                        // The stream shape permits the opening block to carry
+                        // initial `thinking` text. No shipped CLI does today
+                        // (2.1.220 wire capture: {"thinking":"","signature":""},
+                        // and print mode withholds summarized-thinking text
+                        // everywhere), but text materialized here has no other
+                        // path into the envelope drain — buffer it exactly
+                        // like a thinking_delta so it would render, never be
+                        // silently dropped.
+                        if let Some(text) = event
+                            .pointer("/content_block/thinking")
+                            .and_then(|t| t.as_str())
+                            .filter(|t| !t.is_empty())
+                        {
+                            let index = event.get("index").and_then(|i| i.as_u64()).unwrap_or(0);
+                            self.buffer_thinking_delta(Self::thinking_scope(msg), index, text);
+                        }
+                        self.observe_activity(
+                            ActivityObs::ReasoningStarted {
+                                delta_heartbeat: true,
+                            },
+                            out,
+                        )
+                    }
                     _ => self.observe_activity(ActivityObs::ResponseDelta, out),
                 }
             }
@@ -6050,6 +6068,27 @@ mod tests {
             reader.thinking_buffers.is_empty(),
             "the envelope drain must consume the buffered block"
         );
+    }
+
+    /// A thinking block whose `content_block_start` carries initial text
+    /// (no shipped CLI does — the 2.1.220 print-mode wire opens with
+    /// `{"thinking":"","signature":""}` — but the stream shape permits it)
+    /// must reach the envelope drain like any streamed delta, ahead of
+    /// whatever deltas follow.
+    #[test]
+    fn reader_recovers_thinking_from_content_block_start_initial_text() {
+        let mut reader = test_reader();
+        reader.process_line(
+            r#"{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"Opening thought. "}},"session_id":"s1"}"#,
+        );
+        reader.process_line(
+            r#"{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Then a delta."}},"session_id":"s1"}"#,
+        );
+        let out = reader.process_line(
+            r#"{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"","signature":"sig-s"}]},"session_id":"s1"}"#,
+        );
+        assert_eq!(reasoning_texts(&out), vec!["Opening thought. Then a delta."]);
+        assert!(reader.thinking_buffers.is_empty());
     }
 
     /// Older CLIs (≤ 2.1.210) still materialize the thinking text into the

--- a/src/bin/caller/web_gateway/session_catalog/transcripts.rs
+++ b/src/bin/caller/web_gateway/session_catalog/transcripts.rs
@@ -3707,6 +3707,40 @@ mod tests {
         assert_eq!(entries[0]["ts_ms"], 1_783_912_976_000_i64);
     }
 
+    /// Print-mode (sdk-cli entrypoint) Claude Code ≥ 2.1.217 writes
+    /// summarized-thinking blocks as empty shells — signature kept for
+    /// resume, text withheld (wire capture 2026-07-30, CC 2.1.220). The
+    /// parser renders honest absence: no reasoning row, never a
+    /// placeholder — and the non-empty (cli-entrypoint) arm keeps the
+    /// live grammar so every lane's dedupe signatures collapse copies.
+    #[test]
+    fn claude_transcript_empty_thinking_shell_renders_no_reasoning_row() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session.jsonl");
+        let lines = [
+            r#"{"type":"assistant","timestamp":"2026-07-30T10:00:01.000Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"","signature":"CAISpRoK"},{"type":"text","text":"Answer."}]}}"#,
+            r#"{"type":"assistant","timestamp":"2026-07-30T10:00:05.000Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"cli-era full text","signature":"sig2"},{"type":"text","text":"More."}]}}"#,
+        ];
+        std::fs::write(&path, lines.join("\n")).unwrap();
+
+        let entries =
+            parse_claude_session_entries(&path, &ExternalSteerLedger::default()).expect("parse");
+        let reasoning: Vec<&str> = entries
+            .iter()
+            .filter(|e| e["kind"].as_str() == Some("reasoning"))
+            .map(|e| e["content"].as_str().unwrap_or(""))
+            .collect();
+        assert_eq!(
+            reasoning,
+            vec!["cli-era full text"],
+            "empty sdk-era shells must render nothing; cli-era text renders as level model + kind reasoning"
+        );
+        assert!(entries
+            .iter()
+            .filter(|e| e["kind"].as_str() == Some("reasoning"))
+            .all(|e| e["level"].as_str() == Some("model")));
+    }
+
     /// `isMeta` synthetic turns and `isCompactSummary` context summaries are
     /// machine-generated — the ground truth
     /// (`message_search::extract_claude::record_from_line`) skips both, and

--- a/static/app.html
+++ b/static/app.html
@@ -37605,7 +37605,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '47d4d928f643b7fc';
+const INTENDANT_APP_BUILD = 'fa41f30d6c6f9c8e';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -59771,6 +59771,10 @@ function clearLogs(options = {}) {
   updateLogEmptyState();
   activeCommandOutputGroups.clear();
   commandOutputGroups.clear();
+  // The main feed's reasoning-dedupe registry tracks what the feed SHOWS
+  // — emptied feed, emptied registry (41b-reasoning-log.js), or a
+  // reconnect replay's rows would be skipped as already-rendered.
+  resetLiveFeedReasoningDedupe();
   if (clearSessionWindows) {
     for (const win of sessionWindows.values()) {
       resetSessionWindowLog(win);
@@ -65801,16 +65805,23 @@ async function syncExternalSessionWindowTranscript(sessionId) {
     }
     if (!data) throw lastError || new Error('session detail fetch failed');
     const entries = Array.isArray(data.entries) ? data.entries : [];
-    if (!entries.length) return;
     applySessionIdentitiesFromReplayEntries(entries);
     applyExternalIdentitiesFromLogEntries(entries);
     applySessionGoalsFromReplayEntries(entries);
     applySessionPrsFromReplayEntries(entries);
     const targetSid = sessionWindowTargetForLogSession(record.sessionId) || record.sessionId;
+    // Live-feed parity lane: fresh transcript-materialized reasoning rows
+    // enter the MAIN Activity feed before the window merge below, so the
+    // mirrored copy is already in the window history and the merge's
+    // signature scan collapses the pair (41b-reasoning-log.js). Runs on
+    // the empty fetch too — the first pass arms the per-session
+    // watermark even when the transcript has no rows yet.
+    const injected = injectTranscriptReasoningIntoLiveFeed(entries, targetSid, record.source);
+    if (!entries.length) return;
     const targetWin = sessionWindows.get(targetSid) || record.win;
     updateSessionWindowRemotePageState(targetWin, data, record.source, record.sessionId);
     const rendered = appendMissingRestoredSessionWindowEntries(targetWin, entries, targetSid);
-    if (rendered > 0) stationScheduleUpdate();
+    if (rendered > 0 || injected > 0) stationScheduleUpdate();
   } catch (err) {
     console.warn('Failed to sync external session window transcript', record.sessionId, err);
   } finally {
@@ -75303,14 +75314,224 @@ function wireReasoningLogClone(clone, sourceEntry) {
 
 // Live-feed path (dispatched from renderLogEntry): append to the main
 // stream and mirror into the owning session window, exactly like the
-// other special row types.
+// other special row types. The injected-signature check guards the
+// append: when the transcript-sync lane already forwarded this row into
+// the feed, its delayed live/replayed copy must not double it. The match
+// is CONSUMED — an identical text the model genuinely thinks again later
+// renders like it always did; only the injected row's own copy skips.
 function renderReasoningLogEntry(c) {
   finalizeSessionCommandOutputGroups(c);
   inferSessionPhaseFromLog(c);
+  const record = sessionWindowRecordFromLogCommand(c);
+  const signatures = liveFeedReasoningSignatures(record);
+  if (signatures.some(signature => _injectedReasoningSignatures.has(signature))) {
+    for (const signature of signatures) {
+      _injectedReasoningSignatures.delete(signature);
+    }
+    return;
+  }
   const entry = buildReasoningLogEntryNode(c);
   if (!entry) return;
-  appendLogEntryElement(entry, sessionWindowRecordFromLogCommand(c));
+  for (const signature of signatures) {
+    _liveFeedReasoningSignatures.add(signature);
+  }
+  appendLogEntryElement(entry, record);
 }
+
+// ── Transcript → live-feed reasoning parity ────────────────────────────
+// The live lane's only source is the wrapper's normalized event stream —
+// and print-mode Claude Code (sdk-cli entrypoint, ≥ 2.1.217) withholds
+// summarized-thinking TEXT everywhere that stream can see: the streamed
+// thinking_deltas, the completed envelope block, and the native
+// transcript all carry empty signature-only shells (wire capture
+// 2026-07-30, CC 2.1.220 — {"thinking":"","estimated_tokens":N}). For
+// spawned print-mode seats there is honestly nothing to render, and
+// nothing is fabricated. But transcript-materialized thinking DOES exist
+// for cli-entrypoint stretches (interactive-born sessions the daemon
+// adopted or attached), and the session-window transcript sync already
+// fetches those rows on a live cadence — into the window only. This lane
+// forwards the FRESH ones into the main Activity feed too, so live
+// viewers see the same rows the Sessions detail and rehydrated cards
+// render: derived from the one transcript source (derive, don't mirror),
+// same grammar (level model + kind reasoning), same renderer.
+//
+// Three structures, two lifetimes:
+//   - _liveFeedReasoningSignatures is the UNION registry: every reasoning
+//     row the MAIN feed currently shows, from either lane. The injector
+//     checks it so a row the live lane already rendered (or a prior sync
+//     already forwarded) is never forwarded again.
+//   - _injectedReasoningSignatures holds the injected rows only. The
+//     live-lane renderer checks (and consumes from) THIS set, so the one
+//     delayed copy of an injected row skips while a genuinely repeated
+//     identical thought still renders.
+//   Both reset with the feed (clearLogs — a reconnect replay rebuilds the
+//   feed from the session log, which never persisted injected rows).
+//   - the per-(source, session) watermark makes the FIRST sync pass a
+//     catch-up (history belongs to the card/window; the feed starts at
+//     "now") and every later pass live. Page-lifetime: it tracks the
+//     sync lane's coverage, not the feed's contents.
+const _liveFeedReasoningSignatures = new Set();
+const _injectedReasoningSignatures = new Set();
+const _transcriptReasoningSyncWatermarks = new Map();
+
+// Signatures under the window/session canonical id, so the live lane
+// (backend or daemon sid on the row) and the transcript lane (window
+// sid) hash identically. Empty when the record can't be signed — such
+// rows render unguarded, exactly like before this lane existed.
+function liveFeedReasoningSignatures(record) {
+  if (!record || !record.content) return [];
+  const sid = String(record.session_id || record.sessionId || '').trim();
+  const targetSid = (sid && sessionWindowTargetForLogSession(sid)) || sid;
+  if (!targetSid) return [];
+  return sessionWindowTranscriptSignaturesForRecord(
+    { ...record, session_id: targetSid },
+    targetSid
+  );
+}
+
+// The main feed was cleared (reconnect replay, explicit clear): its
+// registries empty with it. Watermarks survive — the transcript's
+// already-covered span is unchanged by what the feed shows.
+function resetLiveFeedReasoningDedupe() {
+  _liveFeedReasoningSignatures.clear();
+  _injectedReasoningSignatures.clear();
+}
+
+// Forward fresh transcript-materialized reasoning rows into the main
+// Activity feed. Called from syncExternalSessionWindowTranscript with
+// the fetched detail entries BEFORE the window merge, so the mirrored
+// copy is already in the window history and the merge's signature scan
+// collapses the pair. Deliberately NOT renderReasoningLogEntry: these
+// rows are late-materialized, so the live side-effects (phase inference,
+// output-group finalization) must not fire from them — a post-round
+// injection would flip a settled card back to "thinking", and a mid-turn
+// one could clip a still-streaming output group. Returns the number of
+// rows appended.
+function injectTranscriptReasoningIntoLiveFeed(entries, targetSid, source) {
+  const sid = String(targetSid || '').trim();
+  if (!sid || !Array.isArray(entries)) return 0;
+  const key = `${String(source || '').trim().toLowerCase()}\u001f${sid}`;
+  let maxTs = null;
+  for (const entry of entries) {
+    const ts = sessionWindowTranscriptTimestampMs(
+      entry?.ts_ms ?? entry?.tsMs ?? entry?.ts ?? entry?.timestamp ?? ''
+    );
+    if (ts !== null && (maxTs === null || ts > maxTs)) maxTs = ts;
+  }
+  if (!_transcriptReasoningSyncWatermarks.has(key)) {
+    // First pass = catch-up. An empty transcript starts the watermark at
+    // 0 so everything that materializes after we started watching counts
+    // as live; a populated one starts at its newest row.
+    _transcriptReasoningSyncWatermarks.set(key, maxTs ?? 0);
+    return 0;
+  }
+  const watermark = _transcriptReasoningSyncWatermarks.get(key);
+  const fresh = [];
+  for (const entry of entries) {
+    if (String(entry?.kind || '') !== 'reasoning') continue;
+    if (String(entry?.level || '') !== 'model') continue;
+    if (!String(entry?.content || '').trim()) continue;
+    const ts = sessionWindowTranscriptTimestampMs(
+      entry?.ts_ms ?? entry?.tsMs ?? entry?.ts ?? entry?.timestamp ?? ''
+    );
+    if (ts === null || ts <= watermark) continue;
+    fresh.push({ entry, ts });
+  }
+  fresh.sort((a, b) => a.ts - b.ts);
+  let injected = 0;
+  for (const { entry } of fresh) {
+    const record = sessionWindowRecordFromReplayEntry(entry, sid);
+    if (!record) continue;
+    const targeted = { ...record, session_id: sid };
+    const signatures = liveFeedReasoningSignatures(targeted);
+    // Unsignable rows stay out: an injected row the live lane could not
+    // recognize later would double with its own delayed copy.
+    if (signatures.length === 0) continue;
+    if (signatures.some(signature => _liveFeedReasoningSignatures.has(signature))) continue;
+    const node = buildReasoningLogEntryNode(targeted);
+    if (!node) continue;
+    for (const signature of signatures) {
+      _liveFeedReasoningSignatures.add(signature);
+      _injectedReasoningSignatures.add(signature);
+    }
+    appendLogEntryElement(node, targeted);
+    injected += 1;
+  }
+  if (maxTs !== null && maxTs > watermark) {
+    _transcriptReasoningSyncWatermarks.set(key, maxTs);
+  }
+  return injected;
+}
+
+// QA readback (window.qa convention): a self-contained behavioral probe
+// of this lane against the REAL functions — watermark catch-up, the
+// freshness gate, idempotent re-sync, and the cross-lane dedupe in both
+// directions. Uses a unique synthetic session id per run and scrubs its
+// rows and mirror window on the way out; meant for throwaway QA
+// dashboards (scripts/validate-dashboard.cjs --wait-for-function
+// "window.qa.reasoningLiveParity().pass").
+window.qa = Object.assign(window.qa || {}, {
+  reasoningLiveParity() {
+    const sid = 'qa-reasoning-parity-' + Date.now().toString(36);
+    const source = 'claude-code';
+    const t0 = Date.now() - 60000;
+    const mk = (content, tsMs) => ({
+      level: 'model',
+      source: 'Claude Code',
+      kind: 'reasoning',
+      content,
+      ts: new Date(tsMs).toISOString(),
+      ts_ms: tsMs,
+    });
+    const countRows = () => document.querySelectorAll(
+      `#log-stream .reasoning-log-entry[data-session-id="${sid}"]`
+    ).length;
+    const live = content => renderReasoningLogEntry({
+      level: 'model', source: 'Claude Code', kind: 'reasoning',
+      content, session_id: sid, ts_ms: Date.now(),
+    });
+    const report = { pass: false, sid };
+    try {
+      report.firstPassInjected = injectTranscriptReasoningIntoLiveFeed(
+        [mk('probe row A', t0)], sid, source);
+      report.secondPassInjected = injectTranscriptReasoningIntoLiveFeed(
+        [mk('probe row A', t0), mk('probe row B', t0 + 1000)], sid, source);
+      report.resyncInjected = injectTranscriptReasoningIntoLiveFeed(
+        [mk('probe row A', t0), mk('probe row B', t0 + 1000)], sid, source);
+      report.rowsAfterInject = countRows();
+      // The injected row's own delayed live copy skips (and is consumed)…
+      live('probe row B');
+      report.rowsAfterLiveDup = countRows();
+      // …so the same text genuinely thought again still renders.
+      live('probe row B');
+      report.rowsAfterLiveRepeat = countRows();
+      live('probe row C');
+      report.rowsAfterLiveNew = countRows();
+      report.postLiveResyncInjected = injectTranscriptReasoningIntoLiveFeed(
+        [mk('probe row C', t0 + 2000)], sid, source);
+      report.pass =
+        report.firstPassInjected === 0 &&
+        report.secondPassInjected === 1 &&
+        report.resyncInjected === 0 &&
+        report.rowsAfterInject === 1 &&
+        report.rowsAfterLiveDup === 1 &&
+        report.rowsAfterLiveRepeat === 2 &&
+        report.rowsAfterLiveNew === 3 &&
+        report.postLiveResyncInjected === 0;
+    } finally {
+      const synthetic = document.querySelectorAll(`.log-entry[data-session-id="${sid}"]`);
+      const removedFromMain = Array.from(synthetic)
+        .filter(el => el.closest('#log-stream')).length;
+      synthetic.forEach(el => el.remove());
+      if (typeof removeSessionWindow === 'function') removeSessionWindow(sid);
+      if (typeof logEntryCount === 'number') {
+        logEntryCount = Math.max(0, logEntryCount - removedFromMain);
+        updateLogEmptyState();
+      }
+    }
+    return report;
+  },
+});
 /* ── static/app/42-usage-terminal.js ── */
 // ── Usage Tab Rendering ──
 // ── Token Ticker ──

--- a/static/app/38-managed-context.js
+++ b/static/app/38-managed-context.js
@@ -1821,6 +1821,10 @@ function clearLogs(options = {}) {
   updateLogEmptyState();
   activeCommandOutputGroups.clear();
   commandOutputGroups.clear();
+  // The main feed's reasoning-dedupe registry tracks what the feed SHOWS
+  // — emptied feed, emptied registry (41b-reasoning-log.js), or a
+  // reconnect replay's rows would be skipped as already-rendered.
+  resetLiveFeedReasoningDedupe();
   if (clearSessionWindows) {
     for (const win of sessionWindows.values()) {
       resetSessionWindowLog(win);

--- a/static/app/39-session-windows.js
+++ b/static/app/39-session-windows.js
@@ -5362,16 +5362,23 @@ async function syncExternalSessionWindowTranscript(sessionId) {
     }
     if (!data) throw lastError || new Error('session detail fetch failed');
     const entries = Array.isArray(data.entries) ? data.entries : [];
-    if (!entries.length) return;
     applySessionIdentitiesFromReplayEntries(entries);
     applyExternalIdentitiesFromLogEntries(entries);
     applySessionGoalsFromReplayEntries(entries);
     applySessionPrsFromReplayEntries(entries);
     const targetSid = sessionWindowTargetForLogSession(record.sessionId) || record.sessionId;
+    // Live-feed parity lane: fresh transcript-materialized reasoning rows
+    // enter the MAIN Activity feed before the window merge below, so the
+    // mirrored copy is already in the window history and the merge's
+    // signature scan collapses the pair (41b-reasoning-log.js). Runs on
+    // the empty fetch too — the first pass arms the per-session
+    // watermark even when the transcript has no rows yet.
+    const injected = injectTranscriptReasoningIntoLiveFeed(entries, targetSid, record.source);
+    if (!entries.length) return;
     const targetWin = sessionWindows.get(targetSid) || record.win;
     updateSessionWindowRemotePageState(targetWin, data, record.source, record.sessionId);
     const rendered = appendMissingRestoredSessionWindowEntries(targetWin, entries, targetSid);
-    if (rendered > 0) stationScheduleUpdate();
+    if (rendered > 0 || injected > 0) stationScheduleUpdate();
   } catch (err) {
     console.warn('Failed to sync external session window transcript', record.sessionId, err);
   } finally {

--- a/static/app/41b-reasoning-log.js
+++ b/static/app/41b-reasoning-log.js
@@ -146,11 +146,221 @@ function wireReasoningLogClone(clone, sourceEntry) {
 
 // Live-feed path (dispatched from renderLogEntry): append to the main
 // stream and mirror into the owning session window, exactly like the
-// other special row types.
+// other special row types. The injected-signature check guards the
+// append: when the transcript-sync lane already forwarded this row into
+// the feed, its delayed live/replayed copy must not double it. The match
+// is CONSUMED — an identical text the model genuinely thinks again later
+// renders like it always did; only the injected row's own copy skips.
 function renderReasoningLogEntry(c) {
   finalizeSessionCommandOutputGroups(c);
   inferSessionPhaseFromLog(c);
+  const record = sessionWindowRecordFromLogCommand(c);
+  const signatures = liveFeedReasoningSignatures(record);
+  if (signatures.some(signature => _injectedReasoningSignatures.has(signature))) {
+    for (const signature of signatures) {
+      _injectedReasoningSignatures.delete(signature);
+    }
+    return;
+  }
   const entry = buildReasoningLogEntryNode(c);
   if (!entry) return;
-  appendLogEntryElement(entry, sessionWindowRecordFromLogCommand(c));
+  for (const signature of signatures) {
+    _liveFeedReasoningSignatures.add(signature);
+  }
+  appendLogEntryElement(entry, record);
 }
+
+// ── Transcript → live-feed reasoning parity ────────────────────────────
+// The live lane's only source is the wrapper's normalized event stream —
+// and print-mode Claude Code (sdk-cli entrypoint, ≥ 2.1.217) withholds
+// summarized-thinking TEXT everywhere that stream can see: the streamed
+// thinking_deltas, the completed envelope block, and the native
+// transcript all carry empty signature-only shells (wire capture
+// 2026-07-30, CC 2.1.220 — {"thinking":"","estimated_tokens":N}). For
+// spawned print-mode seats there is honestly nothing to render, and
+// nothing is fabricated. But transcript-materialized thinking DOES exist
+// for cli-entrypoint stretches (interactive-born sessions the daemon
+// adopted or attached), and the session-window transcript sync already
+// fetches those rows on a live cadence — into the window only. This lane
+// forwards the FRESH ones into the main Activity feed too, so live
+// viewers see the same rows the Sessions detail and rehydrated cards
+// render: derived from the one transcript source (derive, don't mirror),
+// same grammar (level model + kind reasoning), same renderer.
+//
+// Three structures, two lifetimes:
+//   - _liveFeedReasoningSignatures is the UNION registry: every reasoning
+//     row the MAIN feed currently shows, from either lane. The injector
+//     checks it so a row the live lane already rendered (or a prior sync
+//     already forwarded) is never forwarded again.
+//   - _injectedReasoningSignatures holds the injected rows only. The
+//     live-lane renderer checks (and consumes from) THIS set, so the one
+//     delayed copy of an injected row skips while a genuinely repeated
+//     identical thought still renders.
+//   Both reset with the feed (clearLogs — a reconnect replay rebuilds the
+//   feed from the session log, which never persisted injected rows).
+//   - the per-(source, session) watermark makes the FIRST sync pass a
+//     catch-up (history belongs to the card/window; the feed starts at
+//     "now") and every later pass live. Page-lifetime: it tracks the
+//     sync lane's coverage, not the feed's contents.
+const _liveFeedReasoningSignatures = new Set();
+const _injectedReasoningSignatures = new Set();
+const _transcriptReasoningSyncWatermarks = new Map();
+
+// Signatures under the window/session canonical id, so the live lane
+// (backend or daemon sid on the row) and the transcript lane (window
+// sid) hash identically. Empty when the record can't be signed — such
+// rows render unguarded, exactly like before this lane existed.
+function liveFeedReasoningSignatures(record) {
+  if (!record || !record.content) return [];
+  const sid = String(record.session_id || record.sessionId || '').trim();
+  const targetSid = (sid && sessionWindowTargetForLogSession(sid)) || sid;
+  if (!targetSid) return [];
+  return sessionWindowTranscriptSignaturesForRecord(
+    { ...record, session_id: targetSid },
+    targetSid
+  );
+}
+
+// The main feed was cleared (reconnect replay, explicit clear): its
+// registries empty with it. Watermarks survive — the transcript's
+// already-covered span is unchanged by what the feed shows.
+function resetLiveFeedReasoningDedupe() {
+  _liveFeedReasoningSignatures.clear();
+  _injectedReasoningSignatures.clear();
+}
+
+// Forward fresh transcript-materialized reasoning rows into the main
+// Activity feed. Called from syncExternalSessionWindowTranscript with
+// the fetched detail entries BEFORE the window merge, so the mirrored
+// copy is already in the window history and the merge's signature scan
+// collapses the pair. Deliberately NOT renderReasoningLogEntry: these
+// rows are late-materialized, so the live side-effects (phase inference,
+// output-group finalization) must not fire from them — a post-round
+// injection would flip a settled card back to "thinking", and a mid-turn
+// one could clip a still-streaming output group. Returns the number of
+// rows appended.
+function injectTranscriptReasoningIntoLiveFeed(entries, targetSid, source) {
+  const sid = String(targetSid || '').trim();
+  if (!sid || !Array.isArray(entries)) return 0;
+  const key = `${String(source || '').trim().toLowerCase()}\u001f${sid}`;
+  let maxTs = null;
+  for (const entry of entries) {
+    const ts = sessionWindowTranscriptTimestampMs(
+      entry?.ts_ms ?? entry?.tsMs ?? entry?.ts ?? entry?.timestamp ?? ''
+    );
+    if (ts !== null && (maxTs === null || ts > maxTs)) maxTs = ts;
+  }
+  if (!_transcriptReasoningSyncWatermarks.has(key)) {
+    // First pass = catch-up. An empty transcript starts the watermark at
+    // 0 so everything that materializes after we started watching counts
+    // as live; a populated one starts at its newest row.
+    _transcriptReasoningSyncWatermarks.set(key, maxTs ?? 0);
+    return 0;
+  }
+  const watermark = _transcriptReasoningSyncWatermarks.get(key);
+  const fresh = [];
+  for (const entry of entries) {
+    if (String(entry?.kind || '') !== 'reasoning') continue;
+    if (String(entry?.level || '') !== 'model') continue;
+    if (!String(entry?.content || '').trim()) continue;
+    const ts = sessionWindowTranscriptTimestampMs(
+      entry?.ts_ms ?? entry?.tsMs ?? entry?.ts ?? entry?.timestamp ?? ''
+    );
+    if (ts === null || ts <= watermark) continue;
+    fresh.push({ entry, ts });
+  }
+  fresh.sort((a, b) => a.ts - b.ts);
+  let injected = 0;
+  for (const { entry } of fresh) {
+    const record = sessionWindowRecordFromReplayEntry(entry, sid);
+    if (!record) continue;
+    const targeted = { ...record, session_id: sid };
+    const signatures = liveFeedReasoningSignatures(targeted);
+    // Unsignable rows stay out: an injected row the live lane could not
+    // recognize later would double with its own delayed copy.
+    if (signatures.length === 0) continue;
+    if (signatures.some(signature => _liveFeedReasoningSignatures.has(signature))) continue;
+    const node = buildReasoningLogEntryNode(targeted);
+    if (!node) continue;
+    for (const signature of signatures) {
+      _liveFeedReasoningSignatures.add(signature);
+      _injectedReasoningSignatures.add(signature);
+    }
+    appendLogEntryElement(node, targeted);
+    injected += 1;
+  }
+  if (maxTs !== null && maxTs > watermark) {
+    _transcriptReasoningSyncWatermarks.set(key, maxTs);
+  }
+  return injected;
+}
+
+// QA readback (window.qa convention): a self-contained behavioral probe
+// of this lane against the REAL functions — watermark catch-up, the
+// freshness gate, idempotent re-sync, and the cross-lane dedupe in both
+// directions. Uses a unique synthetic session id per run and scrubs its
+// rows and mirror window on the way out; meant for throwaway QA
+// dashboards (scripts/validate-dashboard.cjs --wait-for-function
+// "window.qa.reasoningLiveParity().pass").
+window.qa = Object.assign(window.qa || {}, {
+  reasoningLiveParity() {
+    const sid = 'qa-reasoning-parity-' + Date.now().toString(36);
+    const source = 'claude-code';
+    const t0 = Date.now() - 60000;
+    const mk = (content, tsMs) => ({
+      level: 'model',
+      source: 'Claude Code',
+      kind: 'reasoning',
+      content,
+      ts: new Date(tsMs).toISOString(),
+      ts_ms: tsMs,
+    });
+    const countRows = () => document.querySelectorAll(
+      `#log-stream .reasoning-log-entry[data-session-id="${sid}"]`
+    ).length;
+    const live = content => renderReasoningLogEntry({
+      level: 'model', source: 'Claude Code', kind: 'reasoning',
+      content, session_id: sid, ts_ms: Date.now(),
+    });
+    const report = { pass: false, sid };
+    try {
+      report.firstPassInjected = injectTranscriptReasoningIntoLiveFeed(
+        [mk('probe row A', t0)], sid, source);
+      report.secondPassInjected = injectTranscriptReasoningIntoLiveFeed(
+        [mk('probe row A', t0), mk('probe row B', t0 + 1000)], sid, source);
+      report.resyncInjected = injectTranscriptReasoningIntoLiveFeed(
+        [mk('probe row A', t0), mk('probe row B', t0 + 1000)], sid, source);
+      report.rowsAfterInject = countRows();
+      // The injected row's own delayed live copy skips (and is consumed)…
+      live('probe row B');
+      report.rowsAfterLiveDup = countRows();
+      // …so the same text genuinely thought again still renders.
+      live('probe row B');
+      report.rowsAfterLiveRepeat = countRows();
+      live('probe row C');
+      report.rowsAfterLiveNew = countRows();
+      report.postLiveResyncInjected = injectTranscriptReasoningIntoLiveFeed(
+        [mk('probe row C', t0 + 2000)], sid, source);
+      report.pass =
+        report.firstPassInjected === 0 &&
+        report.secondPassInjected === 1 &&
+        report.resyncInjected === 0 &&
+        report.rowsAfterInject === 1 &&
+        report.rowsAfterLiveDup === 1 &&
+        report.rowsAfterLiveRepeat === 2 &&
+        report.rowsAfterLiveNew === 3 &&
+        report.postLiveResyncInjected === 0;
+    } finally {
+      const synthetic = document.querySelectorAll(`.log-entry[data-session-id="${sid}"]`);
+      const removedFromMain = Array.from(synthetic)
+        .filter(el => el.closest('#log-stream')).length;
+      synthetic.forEach(el => el.remove());
+      if (typeof removeSessionWindow === 'function') removeSessionWindow(sid);
+      if (typeof logEntryCount === 'number') {
+        logEntryCount = Math.max(0, logEntryCount - removedFromMain);
+        updateLogEmptyState();
+      }
+    }
+    return report;
+  },
+});


### PR DESCRIPTION
## Summary

Card 01KYRQRXF9KP626Y9MF4GVR996 (item-as-brief) + findings /Users/vm/thinking-activity-findings.md: thinking summaries never appear in the live Activity feed for supervised claude-code seats, while the Sessions tab and rehydrated Activity cards render them.

**Wire capture first** (house pattern; CC 2.1.220, fable-5, the wrapper's exact spawn args, raw stdout teed): the wire is DRY — `thinking_delta` events stream `{"thinking":"","estimated_tokens":N}` (cadence and volume, no text), `content_block_start` and the assistant envelope carry signature-only shells, a new `system`/`thinking_tokens` progress subtype also carries no text, and the same turn's native transcript stores the same empty shell. The strip is entrypoint-conditional (cli-entrypoint transcripts at the same versions carry full text) and upstream-deliberate → **branch (b)**: derive the live feed from the transcript source the working lanes already read; never fabricate thinking. Capture artifacts + README: `/Users/vm/cc-wire-captures/2026-07-30-thinking-parity/`.

## Changes

- **41b-reasoning-log.js** — transcript → live-feed parity lane: the session-window transcript sync now forwards *fresh* transcript-materialized reasoning rows into the main Activity feed through the shared renderer (same `level model` + `kind reasoning` grammar and styling as replay). First sync pass per (source, session) is catch-up (history belongs to the card; the feed starts at now); later passes are live. A union signature registry (what the feed shows) guards the injector; an injected-only registry guards the live renderer — the delayed live copy of an injected row skips and is *consumed*, so a genuinely repeated identical thought still renders. Registries reset with `clearLogs` (reconnect replay); watermarks are page-lifetime. Deliberately not `renderReasoningLogEntry` for injected rows: late-materialized rows must not run phase inference (post-round injection would flip a settled card to "thinking") or output-group finalization (mid-turn injection could clip a streaming group).
- **39-session-windows.js** — injection call placed before the window merge, so the mirrored copy is already in window history and the merge's signature scan collapses the pair (no duplicate rows, replay-after-live included).
- **38-managed-context.js** — `clearLogs` resets the feed registries.
- **claude_code.rs** — buffer `content_block_start` initial thinking text into the existing delta buffer (none shipped today; if upstream restores text in any streamed shape the whole chain lights up unchanged) + pinned test. No wrapper behavior change on today's wire.
- **transcripts.rs** — pin the empty-shell honesty case: sdk-era `{"thinking":"","signature":…}` renders NO reasoning row; cli-era text keeps the live grammar.
- **docs/src/external-agent-orchestration.md** — the upstream limitation documented honestly (Usage bullet + capability-table cell).
- **static/app.html** — regenerated from fragments (assembler).

For spawned print-mode seats nothing renders because nothing exists — honest absence (the "Thinking" activity phase still heartbeats from the empty deltas). Adopted/attached interactive sessions (e.g. the steward seat, 1,378 nonempty blocks) now get live-feed thinking parity.

## Coverage

- `reader_recovers_thinking_from_content_block_start_initial_text` (wrapper)
- `claude_transcript_empty_thinking_shell_renders_no_reasoning_row` (parser)
- `window.qa.reasoningLiveParity()` behavioral probe (watermark catch-up, freshness gate, idempotent re-sync, both dedupe directions, consumption): **PASS** via `node scripts/validate-dashboard.cjs --launch-dashboard --port 18921 --dashboard-binary target/debug/intendant --wait-for-function 'window.qa.reasoningLiveParity().pass'`

Touch surface disjoint from the ui2-agenda / decision-card territory (#663/#664/#670 all merged).