### PR TITLE
Self-update lane: dashboard build-from-main + verified release fetch feeding the one-click swap

### DIFF
--- a/docs/src/control-plane-and-daemon.md
+++ b/docs/src/control-plane-and-daemon.md
@@ -471,6 +471,62 @@ on its origin offers "The daemon updated — Reload" (auto-reloading only
 when hidden and composer-safe), so a stale tab can no longer
 misrepresent a replaced daemon.
 
+#### Producing the update: the self-update lane
+
+Everything above assumes a newer binary already ON disk. The
+**self-update lane** produces one, on the owner's explicit click, from
+the **Daemon update** panel in Access → Daemons (beside the daemons
+list's provenance rows). It classifies the install once at boot from
+the watched binary path:
+
+- **Source install** — the binary is a checkout's `target/release`
+  output, or the app bundle carries the `source-checkout` stamp
+  `scripts/bundle-macos.sh` writes (a stamp whose recorded path no
+  longer exists, e.g. a release app built on CI, falls down to the
+  consumer lane). The panel runs a **bounded behind-`origin/main`
+  compare** (a timeout-bounded fetch, `rev-list --count` capped at 500,
+  and a dirtiness probe) at boot, every 12 h, and on **Check now**. The
+  click then runs `git pull --ff-only` plus `cargo build --release`
+  (plain binary) or `scripts/bundle-macos.sh` (app shape — builds,
+  signs with the stable local identity, installs to /Applications) as
+  supervised child processes. The build **rides the machine's rustc
+  governor** (the child env never sets `RUSTC_WRAPPER`, so the box-wide
+  cargo-config wrapper stays engaged) and is **headroom-gated**: under
+  memory pressure (macOS `kern.memorystatus_vm_pressure_level` > 1,
+  Linux `MemAvailable` under a 3 GiB floor) the job refuses to start
+  instead of joining an OOM spiral. A dirty checkout or a
+  non-fast-forwardable branch refuses honestly — the lane never
+  stashes, resets, or merges over local work.
+- **Consumer install** — an installed release app with no reachable
+  checkout. The automatic cadence only runs when Connect is configured
+  (the tripwire's posture — an unprompted check reaches the rendezvous
+  and GitHub); **Check now** always may. The check verifies the
+  **latest logged release** through
+  the transparency-log ritual (`hosted_verify`: inclusion proof, signed
+  tree head, append-only pin, the compiled-in PGP identity and
+  signature-coverage checks) and compares versions. The click then
+  downloads the platform's app zip and its detached `.asc`, verifies
+  **sha256 against the log's committed digests**, verifies the
+  signature with **`gpg --verify` in a throwaway GNUPGHOME that trusts
+  only the compiled-in release signing key** (gpg absent = the lane
+  refuses; it never installs unverified bytes), probes the new app's
+  provenance, and swaps it in beside the running one (the old bundle
+  stays as `Intendant.app.previous`). **Fail closed everywhere**: any
+  verify failure deletes the staging bytes and reports the reason.
+
+Both lanes end the same way: a newer binary sits at the watched path,
+the update watch above announces it, and the **existing chip/one-click
+swap lane performs the actual handover** — produce and swap stay two
+honest phases, and the daemon never execs a build, a fetch ritual, or
+a successor into its own process. Progress and failure render live on
+the panel (phase, a bounded child-process log tail, and the outcome)
+served inside the `update_lane` block of `GET /api/daemon/handover`;
+the two actions (`POST /api/daemon/update-lane/{check,produce}`) are
+owner-grade and deliberately **HTTP-only** — remote tunnel-primary
+surfaces watch progress but cannot click a build onto the box.
+Checking is automatic and read-only; producing only ever happens on
+the click — there is no auto-update.
+
 ## Where to Go Next
 
 - [Architecture](./architecture.md) — the EventBus, the execution shapes, and

--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -1958,6 +1958,8 @@ response omits the header.
 | POST | `/api/agenda/stamp` | AgendaWrite | own origin | bounded | Stamp an automation definition (park + propose the instance graph; never approves) |
 | POST | `/api/daemon/takeover` | Settings | own origin | ≤ 4 KiB | Request drain of this daemon (handover): the scheduler lease frees for a successor; in-flight sessions finish here |
 | GET | `/api/daemon/handover` | StatsRead | own origin | none | Handover status: lease role, drain state, and co-homed daemons with probed liveness |
+| POST | `/api/daemon/update-lane/check` | Settings | own origin | ≤ 4 KiB | Self-update lane: run the bounded behind-origin-main / behind-latest-release check now |
+| POST | `/api/daemon/update-lane/produce` | Settings | own origin | ≤ 4 KiB | Self-update lane: produce the update artifact (source pull+build, or verified release download) for the swap chip |
 | GET | `/api/agenda/blobs/{item_id}/{blob_id}/raw` | AgendaRead | own origin | none | Fetch one parked-ask preview blob's raw bytes (attachment; MIME sniffing disabled) |
 | GET | `/api/agenda/items/{item_id}/refs/drift` | AgendaRead | own origin | none | Re-hash one item's file refs and manifest binding refs against their recorded pins (expand-time drift check) |
 | GET | `/api/agenda/items/{item_id}/refs/content` | AgendaRead | own origin | none | One attached file ref's bytes (?locator=; sealed snapshot when pinned, live with drift verdict otherwise) |

--- a/scripts/bundle-macos.sh
+++ b/scripts/bundle-macos.sh
@@ -220,6 +220,14 @@ if [ -f "macos-app/AppIcon.icns" ]; then
     cp "macos-app/AppIcon.icns" "$RESOURCES/AppIcon.icns"
 fi
 
+# Source-checkout stamp (written before signing, so the signature seals
+# it): the absolute path of the checkout this bundle was built from. The
+# daemon's self-update lane reads it so an INSTALLED source-built app can
+# still offer the pull+rebuild lane; on a machine where the recorded
+# path does not exist (a release built on CI), the probe falls down to
+# the verified release-download lane — exactly right.
+printf '%s\n' "$PROJECT_ROOT" > "$RESOURCES/source-checkout"
+
 # Info.plist — written before signing, so the signature seals it (the
 # pre-release-seam script signed first and wrote the plist after, which left
 # the seal broken and the code-signing identifier inferred from the executable

--- a/src/bin/caller/gateway_routes.rs
+++ b/src/bin/caller/gateway_routes.rs
@@ -425,6 +425,11 @@ pub(crate) enum RouteHandlerId {
     /// Handover status: lease role, drain state, co-homed daemons with
     /// probed liveness (the drain banner/successor chip's poll).
     DaemonHandoverStatus,
+    /// Self-update lane: run the bounded behind-ness check now.
+    DaemonUpdateLaneCheck,
+    /// Self-update lane: the owner's click — produce the update
+    /// artifact (source build or verified release download).
+    DaemonUpdateLaneProduce,
     /// Raw bytes of one parked-ask preview blob (agenda blob store).
     AgendaBlobRaw,
     AgendaRefDrift,
@@ -1127,6 +1132,31 @@ pub(crate) static ROUTES: &[Route] = &[
         "Handover status: lease role, drain state, and co-homed daemons with probed liveness",
     )
     .with_tunnel(tunnel_method("api_daemon_handover")),
+    // The self-update lane (the PRODUCE half of the update surface):
+    // owner-grade like the takeover row, same loopback/own-origin trust
+    // posture, deliberately NO tunnel twins — remote Connect-mode
+    // surfaces watch progress through the handover status block but
+    // cannot click a build/download onto the box (widening that is a
+    // trust-surface decision the owner has not ratified). The check is
+    // bounded compare only; produce is the consent click, and the
+    // daemon never execs a successor — the shipped chip/one-click lane
+    // performs the swap.
+    op_route(
+        RouteMethod::Post,
+        PathPattern::Exact("/api/daemon/update-lane/check"),
+        PeerOperation::Settings,
+        BodyPolicy::Capped(4 * 1024),
+        RouteHandlerId::DaemonUpdateLaneCheck,
+        "Self-update lane: run the bounded behind-origin-main / behind-latest-release check now",
+    ),
+    op_route(
+        RouteMethod::Post,
+        PathPattern::Exact("/api/daemon/update-lane/produce"),
+        PeerOperation::Settings,
+        BodyPolicy::Capped(4 * 1024),
+        RouteHandlerId::DaemonUpdateLaneProduce,
+        "Self-update lane: produce the update artifact (source pull+build, or verified release download) for the swap chip",
+    ),
     // Parked-ask preview bytes (agenda blob store). Served with the same
     // attachment + nosniff posture as the session-upload raw route; the
     // dashboard consumes via authenticated fetch. HTTP-only for now — the
@@ -3244,6 +3274,15 @@ mod tests {
         // The takeover request carries only a display label (HS3).
         assert_eq!(
             policy("POST", "/api/daemon/takeover"),
+            BodyPolicy::Capped(4 * 1024)
+        );
+        // The update-lane actions carry at most a small JSON body.
+        assert_eq!(
+            policy("POST", "/api/daemon/update-lane/check"),
+            BodyPolicy::Capped(4 * 1024)
+        );
+        assert_eq!(
+            policy("POST", "/api/daemon/update-lane/produce"),
             BodyPolicy::Capped(4 * 1024)
         );
         // The agenda command lane accepts the rich-ask park payload: the

--- a/src/bin/caller/handover/mod.rs
+++ b/src/bin/caller/handover/mod.rs
@@ -24,10 +24,12 @@
 
 mod lease;
 mod presence;
+mod update_lane;
 mod update_watch;
 
 pub(crate) use lease::{read_lease_sidecar, LeaseAttempt, SchedulerLease};
 pub(crate) use presence::{boot_id_is_live, read_presence_records, DaemonPresence};
+pub(crate) use update_lane::spawn_update_lane;
 pub(crate) use update_watch::spawn_update_watch;
 
 use std::path::{Path, PathBuf};
@@ -89,6 +91,11 @@ pub(crate) struct HandoverRuntime {
     /// watch task; `status_json` serves it. `None` = the on-disk image
     /// is the running one (no chip).
     update_status: std::sync::Mutex<Option<serde_json::Value>>,
+    /// The self-update lane (the PRODUCE half of the update surface),
+    /// installed at wiring beside the watch. Route handlers reach the
+    /// check/produce actions through it; `status_json` serves its
+    /// `update_lane` block. Unset in bare test constructions.
+    update_lane: std::sync::OnceLock<std::sync::Arc<update_lane::UpdateLane>>,
 }
 
 #[derive(Default)]
@@ -197,6 +204,7 @@ impl HandoverRuntime {
             drain_hooks: std::sync::Mutex::new(Vec::new()),
             bus: std::sync::OnceLock::new(),
             update_status: std::sync::Mutex::new(None),
+            update_lane: std::sync::OnceLock::new(),
         }
     }
 
@@ -233,6 +241,17 @@ impl HandoverRuntime {
         if let Ok(mut slot) = self.update_status.lock() {
             *slot = block;
         }
+    }
+
+    /// Install the self-update lane (wiring, once). First lane wins.
+    pub(crate) fn set_update_lane(&self, lane: std::sync::Arc<update_lane::UpdateLane>) {
+        let _ = self.update_lane.set(lane);
+    }
+
+    /// The self-update lane, when this boot wired one (route handlers'
+    /// entry point for the check/produce actions).
+    pub(crate) fn update_lane(&self) -> Option<std::sync::Arc<update_lane::UpdateLane>> {
+        self.update_lane.get().cloned()
     }
 
     pub(crate) fn boot_id(&self) -> &str {
@@ -600,6 +619,9 @@ impl HandoverRuntime {
             if let Some(update) = update.as_ref() {
                 obj.insert("update".into(), update.clone());
             }
+        }
+        if let Some(lane) = self.update_lane.get() {
+            obj.insert("update_lane".into(), lane.status_block());
         }
         block
     }

--- a/src/bin/caller/handover/update_lane.rs
+++ b/src/bin/caller/handover/update_lane.rs
@@ -232,8 +232,18 @@ pub(crate) fn fold_source_check(
         tip_sha,
         behind,
         behind_capped: behind >= BEHIND_COUNT_CAP,
-        dirty: !status_porcelain.trim().is_empty(),
+        dirty: tracked_dirty(status_porcelain),
     })
+}
+
+/// TRACKED modifications only (`git status --porcelain` lines whose
+/// status is not `??`): untracked files — a checkout's `target/`,
+/// scratch notes — never block a fast-forward pull, and a genuine
+/// path collision fails the pull child itself with git's own words.
+pub(crate) fn tracked_dirty(status_porcelain: &str) -> bool {
+    status_porcelain
+        .lines()
+        .any(|line| !line.trim().is_empty() && !line.starts_with("??"))
 }
 
 /// Is the latest logged release newer than the running package version?
@@ -993,10 +1003,10 @@ impl UpdateLane {
 
         self.set_phase("pull");
         let status = self.git(repo_root, &["status", "--porcelain"]).await?;
-        if !status.trim().is_empty() {
+        if tracked_dirty(&status) {
             return Err(
-                "the checkout has local changes — not pulling over them; commit or stash by \
-                 hand, then retry"
+                "the checkout has local changes to tracked files — not pulling over them; \
+                 commit or stash by hand, then retry"
                     .to_string(),
             );
         }
@@ -1409,19 +1419,24 @@ mod tests {
 
     /// Commission pin: the behind-main compare folds the bounded git
     /// observations — tip, capped count, dirtiness — and refuses
-    /// unparseable output instead of guessing.
+    /// unparseable output instead of guessing. Dirty means TRACKED
+    /// modifications: an untracked `target/` or scratch file never
+    /// blocks the lane.
     #[test]
     fn source_compare_folds_bounded_git_observations() {
-        let check = fold_source_check("3e4c79f8aa", "3\n", "").expect("clean fold");
+        let check = fold_source_check("3e4c79f8aa", "3\n", "?? target/\n?? notes.txt\n")
+            .expect("clean fold");
         assert_eq!(check.tip_sha, "3e4c79f8aa");
         assert_eq!(check.behind, 3);
         assert!(!check.behind_capped);
-        assert!(!check.dirty);
+        assert!(!check.dirty, "untracked files are not dirtiness");
 
-        let capped = fold_source_check("abcdef012345", "500\n", " M src/main.rs\n").unwrap();
+        let capped =
+            fold_source_check("abcdef012345", "500\n", "?? target/\n M src/main.rs\n").unwrap();
         assert_eq!(capped.behind, BEHIND_COUNT_CAP);
         assert!(capped.behind_capped, "cap reached reads as 500+");
-        assert!(capped.dirty);
+        assert!(capped.dirty, "a tracked modification is");
+        assert!(tracked_dirty("A  staged.rs\n"), "staged changes count too");
 
         assert!(fold_source_check("fatal: bad revision", "0", "").is_err());
         assert!(fold_source_check("abcdef012345", "many", "").is_err());

--- a/src/bin/caller/handover/update_lane.rs
+++ b/src/bin/caller/handover/update_lane.rs
@@ -222,10 +222,12 @@ pub(crate) fn fold_source_check(
             rev_parse_tip.trim().chars().take(120).collect::<String>()
         ));
     }
-    let behind: u32 = rev_list_count
-        .trim()
-        .parse()
-        .map_err(|_| format!("unparseable behind-count from git: {:?}", rev_list_count.trim()))?;
+    let behind: u32 = rev_list_count.trim().parse().map_err(|_| {
+        format!(
+            "unparseable behind-count from git: {:?}",
+            rev_list_count.trim()
+        )
+    })?;
     Ok(SourceCheck {
         tip_sha,
         behind,
@@ -379,10 +381,13 @@ pub(crate) fn bundle_arch(rust_arch: &str) -> &'static str {
 pub(crate) fn select_release_asset<'a>(
     artifacts: &'a [crate::hosted_verify::ReleaseArtifactPlan],
     arch: &str,
-) -> Result<(
-    &'a crate::hosted_verify::ReleaseArtifactPlan,
-    &'a crate::hosted_verify::ReleaseArtifactPlan,
-), String> {
+) -> Result<
+    (
+        &'a crate::hosted_verify::ReleaseArtifactPlan,
+        &'a crate::hosted_verify::ReleaseArtifactPlan,
+    ),
+    String,
+> {
     let suffix = format!("-macos-{arch}.zip");
     let zip = artifacts
         .iter()
@@ -405,7 +410,11 @@ pub(crate) fn select_release_asset<'a>(
 
 /// Fail-closed download verdict: the bytes on disk must hash to exactly
 /// what the transparency log committed.
-pub(crate) fn download_verdict(name: &str, logged_sha: &str, actual_sha: &str) -> Result<(), String> {
+pub(crate) fn download_verdict(
+    name: &str,
+    logged_sha: &str,
+    actual_sha: &str,
+) -> Result<(), String> {
     if logged_sha == actual_sha {
         Ok(())
     } else {
@@ -429,7 +438,9 @@ pub(crate) fn gpg_verify_verdict(
     pinned_primary_fingerprint: &str,
 ) -> Result<(), String> {
     if !exit_ok {
-        return Err("gpg --verify failed — the artifact's signature does not check out".to_string());
+        return Err(
+            "gpg --verify failed — the artifact's signature does not check out".to_string(),
+        );
     }
     let valid = status_out.lines().any(|line| {
         let mut fields = line.split_whitespace();
@@ -463,7 +474,12 @@ const CHILD_ENV_BASE: &[&str] = &[
 /// Extra names for build/bundle children (toolchain discovery). No
 /// `CARGO_TARGET_DIR`: the artifact must land at the checkout's own
 /// `target/release` — the path the update watch watches.
-const CHILD_ENV_BUILD: &[&str] = &["CARGO_HOME", "RUSTUP_HOME", "RUSTUP_TOOLCHAIN", "DEVELOPER_DIR"];
+const CHILD_ENV_BUILD: &[&str] = &[
+    "CARGO_HOME",
+    "RUSTUP_HOME",
+    "RUSTUP_TOOLCHAIN",
+    "DEVELOPER_DIR",
+];
 
 /// Extra names for git children: the owner's click authorizes exactly a
 /// pull from origin, so the agent socket (ssh remotes) and HOME-based
@@ -476,7 +492,11 @@ fn curated_env(extra: &[&str]) -> Vec<(String, String)> {
     CHILD_ENV_BASE
         .iter()
         .chain(extra.iter())
-        .filter_map(|name| std::env::var(name).ok().map(|value| (name.to_string(), value)))
+        .filter_map(|name| {
+            std::env::var(name)
+                .ok()
+                .map(|value| (name.to_string(), value))
+        })
         .collect()
 }
 
@@ -548,7 +568,10 @@ impl UpdateLane {
         });
         let obj = block.as_object_mut().expect("literal object");
         match &self.flavor {
-            InstallFlavor::Source { repo_root, app_bundle } => {
+            InstallFlavor::Source {
+                repo_root,
+                app_bundle,
+            } => {
                 obj.insert("repo_root".into(), repo_root.display().to_string().into());
                 obj.insert("app_bundle".into(), (*app_bundle).into());
             }
@@ -580,7 +603,11 @@ impl UpdateLane {
                     check_obj.insert("behind_capped".into(), source.behind_capped.into());
                     check_obj.insert("dirty".into(), source.dirty.into());
                 }
-                Some(Ok(CheckOutcome::Consumer { tag, version, newer })) => {
+                Some(Ok(CheckOutcome::Consumer {
+                    tag,
+                    version,
+                    newer,
+                })) => {
                     check_obj.insert("latest_tag".into(), tag.clone().into());
                     check_obj.insert("latest_version".into(), version.clone().into());
                     match newer {
@@ -833,9 +860,10 @@ impl UpdateLane {
         let lane = Arc::clone(self);
         tokio::spawn(async move {
             let outcome = match lane.flavor.clone() {
-                InstallFlavor::Source { repo_root, app_bundle } => {
-                    lane.produce_source(&repo_root, app_bundle).await
-                }
+                InstallFlavor::Source {
+                    repo_root,
+                    app_bundle,
+                } => lane.produce_source(&repo_root, app_bundle).await,
                 InstallFlavor::ConsumerApp { app_root } => lane.produce_consumer(&app_root).await,
                 InstallFlavor::Unmanaged { .. } => unreachable!("refused above"),
             };
@@ -848,9 +876,10 @@ impl UpdateLane {
 
     async fn run_check(self: &Arc<Self>) -> Result<CheckOutcome, String> {
         match self.flavor.clone() {
-            InstallFlavor::Source { repo_root, .. } => {
-                self.source_check(&repo_root).await.map(CheckOutcome::Source)
-            }
+            InstallFlavor::Source { repo_root, .. } => self
+                .source_check(&repo_root)
+                .await
+                .map(CheckOutcome::Source),
             InstallFlavor::ConsumerApp { .. } => self.consumer_check().await,
             InstallFlavor::Unmanaged { reason } => Err(reason),
         }
@@ -878,9 +907,7 @@ impl UpdateLane {
                      {running_sha} in this checkout's history?): {err}"
                 )
             })?;
-        let status = self
-            .git(repo_root, &["status", "--porcelain"])
-            .await?;
+        let status = self.git(repo_root, &["status", "--porcelain"]).await?;
         fold_source_check(&tip, &count, &status)
     }
 
@@ -934,7 +961,10 @@ impl UpdateLane {
             crate::hosted_verify::VerifyFailure::Unavailable(detail) => {
                 format!("release check unavailable: {detail}")
             }
-            crate::hosted_verify::VerifyFailure::Verification { summary, mismatches } => {
+            crate::hosted_verify::VerifyFailure::Verification {
+                summary,
+                mismatches,
+            } => {
                 format!(
                     "release verification FAILED: {summary}{}",
                     if mismatches.is_empty() {
@@ -1016,10 +1046,17 @@ impl UpdateLane {
                 self.run_child(
                     "build",
                     "cargo",
-                    ["build", "--release", "--bin", "intendant", "--bin", "intendant-runtime"]
-                        .iter()
-                        .map(|arg| arg.to_string())
-                        .collect(),
+                    [
+                        "build",
+                        "--release",
+                        "--bin",
+                        "intendant",
+                        "--bin",
+                        "intendant-runtime",
+                    ]
+                    .iter()
+                    .map(|arg| arg.to_string())
+                    .collect(),
                     Some(repo_root),
                     CHILD_ENV_BUILD,
                     BUILD_TIMEOUT,
@@ -1050,8 +1087,9 @@ impl UpdateLane {
     async fn produce_consumer(self: &Arc<Self>, app_root: &Path) -> Result<String, String> {
         self.set_phase("verify-manifest");
         let report = self.verified_release(None).await?;
-        let (zip, asc) = select_release_asset(&report.artifacts, bundle_arch(std::env::consts::ARCH))
-            .map(|(zip, asc)| (zip.clone(), asc.clone()))?;
+        let (zip, asc) =
+            select_release_asset(&report.artifacts, bundle_arch(std::env::consts::ARCH))
+                .map(|(zip, asc)| (zip.clone(), asc.clone()))?;
         self.job_log(format!(
             "release {} verified against the transparency log ({} artifacts; signing key {})",
             report.tag, report.artifact_count, report.pgp_fingerprint
@@ -1263,7 +1301,10 @@ fn install_app_swap(new_app: &Path, app_root: &Path) -> Result<(), String> {
             .status()
             .map_err(|err| format!("ditto copy into {}: {err}", parent.display()))?;
         if !status.success() {
-            return Err(format!("ditto copy into {} exited {status}", parent.display()));
+            return Err(format!(
+                "ditto copy into {} exited {status}",
+                parent.display()
+            ));
         }
     }
     let _ = std::fs::remove_dir_all(&previous);
@@ -1477,8 +1518,8 @@ mod tests {
     #[test]
     fn download_verdict_fails_closed_on_hash_mismatch() {
         assert!(download_verdict("a.zip", "aabbcc", "aabbcc").is_ok());
-        let err = download_verdict("a.zip", "aabbccddeeff00112233", "deadbeefdeadbeefdead")
-            .unwrap_err();
+        let err =
+            download_verdict("a.zip", "aabbccddeeff00112233", "deadbeefdeadbeefdead").unwrap_err();
         assert!(err.contains("refusing to install"));
         assert!(err.contains("a.zip"));
     }
@@ -1564,13 +1605,21 @@ mod tests {
         // No stamp: a consumer install.
         assert_eq!(
             detect_install_flavor(&exe),
-            InstallFlavor::ConsumerApp { app_root: app.clone() }
+            InstallFlavor::ConsumerApp {
+                app_root: app.clone()
+            }
         );
 
         // A valid stamp names the checkout: the source lane, app shape.
-        touch(&app.join("Contents").join("Resources").join(SOURCE_STAMP_RESOURCE));
+        touch(
+            &app.join("Contents")
+                .join("Resources")
+                .join(SOURCE_STAMP_RESOURCE),
+        );
         std::fs::write(
-            app.join("Contents").join("Resources").join(SOURCE_STAMP_RESOURCE),
+            app.join("Contents")
+                .join("Resources")
+                .join(SOURCE_STAMP_RESOURCE),
             format!("{}\n", repo.display()),
         )
         .unwrap();
@@ -1585,13 +1634,17 @@ mod tests {
         // A stamp whose path is gone (a release app carrying its CI
         // runner's checkout) falls down to the consumer lane.
         std::fs::write(
-            app.join("Contents").join("Resources").join(SOURCE_STAMP_RESOURCE),
+            app.join("Contents")
+                .join("Resources")
+                .join(SOURCE_STAMP_RESOURCE),
             "/nonexistent/ci/checkout\n",
         )
         .unwrap();
         assert_eq!(
             detect_install_flavor(&exe),
-            InstallFlavor::ConsumerApp { app_root: app.clone() }
+            InstallFlavor::ConsumerApp {
+                app_root: app.clone()
+            }
         );
 
         let stray = dir.path().join("bin").join("intendant");
@@ -1662,7 +1715,11 @@ mod tests {
         touch(&new_app.join("Contents").join("MacOS").join("new-marker"));
 
         install_app_swap(&new_app, &app).expect("swap succeeds");
-        assert!(app.join("Contents").join("MacOS").join("new-marker").is_file());
+        assert!(app
+            .join("Contents")
+            .join("MacOS")
+            .join("new-marker")
+            .is_file());
         assert!(parent
             .join("Intendant.app.previous")
             .join("Contents")

--- a/src/bin/caller/handover/update_lane.rs
+++ b/src/bin/caller/handover/update_lane.rs
@@ -22,10 +22,10 @@
 //!   the latest release manifest via the transparency-log ritual
 //!   (`hosted_verify::verify_hosted_release` — inclusion proof, signed
 //!   tree head, append-only pin, PGP identity/coverage), then download
-//!   + sha256 against the LOG + `gpg --verify` against the compiled-in
-//!   release signing key in a throwaway GNUPGHOME, then install beside
-//!   the running app. FAIL CLOSED on every verify step: unverified
-//!   bytes are deleted, never installed.
+//!   with sha256 checked against the LOG, `gpg --verify` against the
+//!   compiled-in release signing key in a throwaway GNUPGHOME, then
+//!   install beside the running app. FAIL CLOSED on every verify step:
+//!   unverified bytes are deleted, never installed.
 //!
 //! Boundary (the commission's first-class gate line): the daemon never
 //! self-execs the build or fetch and NEVER execs a successor daemon —

--- a/src/bin/caller/handover/update_lane.rs
+++ b/src/bin/caller/handover/update_lane.rs
@@ -1,0 +1,1673 @@
+//! The self-update lane — the PRODUCE half of the update surface
+//! (commission 01KYSWZC7BBPJGT48G9WYFF7J3). Track HS shipped the SWAP
+//! half completely: the on-disk watch ([`super::update_watch`]), the
+//! update chip + one-per-sha notification, and the packaged app's
+//! one-click drain-swap of whatever binary is ON DISK. This module adds
+//! the missing first phase: getting a NEWER binary onto disk, on the
+//! owner's explicit click, then handing off to that shipped lane.
+//!
+//! Two lanes, selected by install flavor:
+//!
+//! - **Source** (the running binary sits in a git checkout's
+//!   `target/release`, or the packaged app carries a valid
+//!   source-checkout stamp): a bounded behind-`origin/main` compare;
+//!   on click, `git pull --ff-only` + `cargo build` (or
+//!   `scripts/bundle-macos.sh` for the app shape) as supervised child
+//!   processes. The build rides the machine's rustc governor untouched
+//!   (the child env never sets `RUSTC_WRAPPER`, so the box-wide cargo
+//!   config wrapper stays engaged) and is HEADROOM-GATED: under memory
+//!   pressure the job refuses to start rather than joining an OOM
+//!   spiral.
+//! - **Consumer** (an installed release app with no source checkout):
+//!   the latest release manifest via the transparency-log ritual
+//!   (`hosted_verify::verify_hosted_release` — inclusion proof, signed
+//!   tree head, append-only pin, PGP identity/coverage), then download
+//!   + sha256 against the LOG + `gpg --verify` against the compiled-in
+//!   release signing key in a throwaway GNUPGHOME, then install beside
+//!   the running app. FAIL CLOSED on every verify step: unverified
+//!   bytes are deleted, never installed.
+//!
+//! Boundary (the commission's first-class gate line): the daemon never
+//! self-execs the build or fetch and NEVER execs a successor daemon —
+//! the work runs as supervised, timeout-bounded, env-curated child
+//! processes (`git`, `cargo`, `bash scripts/bundle-macos.sh`, `gpg`,
+//! `ditto`) plus the already-ruled hosted-verify fetch machinery, with
+//! progress and failure rendered honestly on the handover status
+//! payload. The update stays two phases: this module PRODUCES the
+//! artifact on disk; the shipped watch/chip/one-click lane performs the
+//! swap. The owner's click is the consent surface — nothing here runs
+//! without it except the bounded behind-ness check.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, Weak};
+
+/// Cap on the behind-main count (`git rev-list --count --max-count`):
+/// past this the panel says "500+" — a bounded compare, literally.
+const BEHIND_COUNT_CAP: u32 = 500;
+
+/// Bounded log tail kept per job for the status payload (each line also
+/// goes to the daemon log as it happens).
+const JOB_LOG_TAIL_LINES: usize = 60;
+const JOB_LOG_LINE_CAP: usize = 400;
+
+/// Per-phase child timeouts. Builds get an hour — a cold release build
+/// on a loaded box is slow, and the governor may queue the link.
+const GIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+const BUILD_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3600);
+const GPG_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+const UNPACK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+const PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Linux headroom floor: a debug `intendant` link alone peaks ~2 GiB of
+/// linker RSS; starting a build with less than this available joins the
+/// swap-storm class the governor exists to prevent.
+const LINUX_MIN_AVAILABLE_KB: u64 = 3 * 1024 * 1024;
+
+/// The `.asc` detached signatures are small armored text.
+const ASC_BYTE_CAP: usize = 64 * 1024;
+
+// ── Install flavor ──────────────────────────────────────────────────
+
+/// How this binary got onto disk — decides which lane the panel offers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum InstallFlavor {
+    /// A git checkout this daemon can rebuild. `app_bundle` selects the
+    /// produce step: plain `cargo build` (artifact lands AT the watched
+    /// path) vs `scripts/bundle-macos.sh` (builds, signs, installs to
+    /// /Applications — the script's only install target).
+    Source {
+        repo_root: PathBuf,
+        app_bundle: bool,
+    },
+    /// An installed app bundle with no reachable source checkout: the
+    /// release download lane.
+    ConsumerApp { app_root: PathBuf },
+    /// Neither lane can honestly produce an artifact at the watched
+    /// path; the panel says why instead of offering a button.
+    Unmanaged { reason: String },
+}
+
+impl InstallFlavor {
+    pub(crate) fn kind(&self) -> &'static str {
+        match self {
+            InstallFlavor::Source { .. } => "source",
+            InstallFlavor::ConsumerApp { .. } => "consumer-app",
+            InstallFlavor::Unmanaged { .. } => "unmanaged",
+        }
+    }
+}
+
+/// The stamp `scripts/bundle-macos.sh` writes into the bundle
+/// (`Contents/Resources/<file>`): the absolute checkout path the app was
+/// built from, so an INSTALLED source-built app can still offer the
+/// source lane. A release app carries its CI runner's path, which does
+/// not exist on a consumer machine — the probe fails down to the
+/// consumer lane, which is exactly right.
+pub(crate) const SOURCE_STAMP_RESOURCE: &str = "source-checkout";
+
+/// The app bundle containing `exe`, when `exe` sits at
+/// `<name>.app/Contents/MacOS/<binary>`.
+fn containing_app_bundle(exe: &Path) -> Option<PathBuf> {
+    let macos_dir = exe.parent()?;
+    if macos_dir.file_name()? != "MacOS" {
+        return None;
+    }
+    let contents = macos_dir.parent()?;
+    if contents.file_name()? != "Contents" {
+        return None;
+    }
+    let app = contents.parent()?;
+    if app.extension()? != "app" {
+        return None;
+    }
+    Some(app.to_path_buf())
+}
+
+/// A directory is a usable intendant checkout when it has a git
+/// dir/file (worktrees carry a `.git` FILE) and the build entry points
+/// the produce step needs. Deliberately shallow — the git/cargo
+/// children fail honestly on anything subtler.
+fn is_buildable_checkout(dir: &Path) -> bool {
+    dir.join(".git").exists()
+        && dir.join("Cargo.toml").is_file()
+        && dir.join("scripts").join("bundle-macos.sh").is_file()
+}
+
+/// Classify the watched binary path. Pure over the filesystem shape —
+/// hermetic under a tempdir.
+pub(crate) fn detect_install_flavor(exe: &Path) -> InstallFlavor {
+    if let Some(app_root) = containing_app_bundle(exe) {
+        // Source-built app? The bundle stamp names its checkout.
+        let stamp = app_root
+            .join("Contents")
+            .join("Resources")
+            .join(SOURCE_STAMP_RESOURCE);
+        if let Ok(text) = std::fs::read_to_string(&stamp) {
+            let recorded = PathBuf::from(text.trim());
+            if !recorded.as_os_str().is_empty() && is_buildable_checkout(&recorded) {
+                return InstallFlavor::Source {
+                    repo_root: recorded,
+                    app_bundle: true,
+                };
+            }
+        }
+        return InstallFlavor::ConsumerApp { app_root };
+    }
+    // Plain binary: offer the source lane only when the binary IS the
+    // checkout's release output — that is the path the update watch
+    // watches, so a rebuild lands exactly where the chip looks.
+    let mut ancestor = exe.parent();
+    while let Some(dir) = ancestor {
+        if dir.join(".git").exists() {
+            if !is_buildable_checkout(dir) {
+                return InstallFlavor::Unmanaged {
+                    reason: "the running binary sits in a git repository that is not a \
+                             buildable intendant checkout"
+                        .to_string(),
+                };
+            }
+            let release_binary = dir
+                .join("target")
+                .join("release")
+                .join(format!("intendant{}", std::env::consts::EXE_SUFFIX));
+            if exe == release_binary.as_path() {
+                return InstallFlavor::Source {
+                    repo_root: dir.to_path_buf(),
+                    app_bundle: false,
+                };
+            }
+            return InstallFlavor::Unmanaged {
+                reason: format!(
+                    "the running binary is inside the checkout at {} but is not its \
+                     target/release output — a rebuild would not land at the watched path",
+                    dir.display()
+                ),
+            };
+        }
+        ancestor = dir.parent();
+    }
+    InstallFlavor::Unmanaged {
+        reason: "no source checkout or app bundle found around the running binary".to_string(),
+    }
+}
+
+// ── The bounded behind-main compare (source lane) ───────────────────
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SourceCheck {
+    /// `origin/main` tip after the bounded fetch.
+    pub(crate) tip_sha: String,
+    /// Commits in `origin/main` not reachable from the RUNNING build's
+    /// commit — capped at [`BEHIND_COUNT_CAP`].
+    pub(crate) behind: u32,
+    pub(crate) behind_capped: bool,
+    /// Tracked files modified in the checkout: the produce step refuses
+    /// to touch a dirty tree.
+    pub(crate) dirty: bool,
+}
+
+/// Fold the three bounded git observations into the compare verdict.
+/// Pure — the child outputs come in as text; the pinned compare-seam
+/// tests live on this function.
+pub(crate) fn fold_source_check(
+    rev_parse_tip: &str,
+    rev_list_count: &str,
+    status_porcelain: &str,
+) -> Result<SourceCheck, String> {
+    let tip_sha = rev_parse_tip.trim().to_string();
+    if tip_sha.len() < 7 || !tip_sha.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(format!(
+            "origin/main did not resolve to a commit (git said: {})",
+            rev_parse_tip.trim().chars().take(120).collect::<String>()
+        ));
+    }
+    let behind: u32 = rev_list_count
+        .trim()
+        .parse()
+        .map_err(|_| format!("unparseable behind-count from git: {:?}", rev_list_count.trim()))?;
+    Ok(SourceCheck {
+        tip_sha,
+        behind,
+        behind_capped: behind >= BEHIND_COUNT_CAP,
+        dirty: !status_porcelain.trim().is_empty(),
+    })
+}
+
+/// Is the latest logged release newer than the running package version?
+/// Plain semver-triple compare (`v` prefix and any pre-release/build
+/// suffix on the release tag tolerated); `None` = not comparable, which
+/// the panel reports instead of guessing.
+pub(crate) fn release_version_newer(latest: &str, running: &str) -> Option<bool> {
+    fn triple(raw: &str) -> Option<(u64, u64, u64)> {
+        let raw = raw.trim().trim_start_matches('v');
+        let core = raw
+            .split_once(['-', '+'])
+            .map(|(core, _)| core)
+            .unwrap_or(raw);
+        let mut parts = core.split('.');
+        let major = parts.next()?.parse().ok()?;
+        let minor = parts.next()?.parse().ok()?;
+        let patch = parts.next()?.parse().ok()?;
+        if parts.next().is_some() {
+            return None;
+        }
+        Some((major, minor, patch))
+    }
+    Some(triple(latest)? > triple(running)?)
+}
+
+// ── Headroom (the capacity linkage) ─────────────────────────────────
+
+/// What the memory-headroom probe observed. `Low` refuses the build;
+/// `Unknown` proceeds with the note carried into the job log — the
+/// probe that CAN run fails closed on pressure, a platform without one
+/// degrades honestly rather than blocking updates forever.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Headroom {
+    Ok(String),
+    Low(String),
+    Unknown(String),
+}
+
+/// The pure gate the pinned test covers: never build under pressure.
+pub(crate) fn headroom_gate(headroom: &Headroom) -> Result<Option<String>, String> {
+    match headroom {
+        Headroom::Ok(detail) => Ok(Some(detail.clone())),
+        Headroom::Unknown(note) => Ok(Some(format!("headroom unknown: {note} — proceeding"))),
+        Headroom::Low(reason) => Err(format!(
+            "not building under memory pressure ({reason}) — retry when the box has headroom"
+        )),
+    }
+}
+
+/// Interpret macOS `sysctl -n kern.memorystatus_vm_pressure_level`
+/// output: 1 = normal, 2 = warn, 4 = critical.
+pub(crate) fn fold_macos_pressure(raw: &str) -> Headroom {
+    match raw.trim().parse::<u32>() {
+        Ok(1) => Headroom::Ok("memory pressure level 1 (normal)".to_string()),
+        Ok(level) => Headroom::Low(format!("macOS memory pressure level {level}")),
+        Err(_) => Headroom::Unknown(format!(
+            "unparseable pressure level {:?}",
+            raw.trim().chars().take(40).collect::<String>()
+        )),
+    }
+}
+
+/// Interpret `/proc/meminfo` (Linux): `MemAvailable` under the floor is
+/// pressure.
+pub(crate) fn fold_linux_meminfo(meminfo: &str) -> Headroom {
+    for line in meminfo.lines() {
+        if let Some(rest) = line.strip_prefix("MemAvailable:") {
+            let kb: u64 = match rest.trim().trim_end_matches(" kB").trim().parse() {
+                Ok(kb) => kb,
+                Err(_) => return Headroom::Unknown("unparseable MemAvailable".to_string()),
+            };
+            return if kb < LINUX_MIN_AVAILABLE_KB {
+                Headroom::Low(format!(
+                    "{} MiB available, floor {} MiB",
+                    kb / 1024,
+                    LINUX_MIN_AVAILABLE_KB / 1024
+                ))
+            } else {
+                Headroom::Ok(format!("{} MiB available", kb / 1024))
+            };
+        }
+    }
+    Headroom::Unknown("no MemAvailable in /proc/meminfo".to_string())
+}
+
+/// Transport edge: probe the platform's memory headroom. The
+/// `INTENDANT_UPDATE_LANE_HEADROOM` override (`ok` / `low`) is honored
+/// only under `PROVIDER=mock` — the fail-closed rig-knob pattern of
+/// `INTENDANT_UPDATE_WATCH_PATH`.
+async fn probe_headroom() -> Headroom {
+    if let Ok(forced) = std::env::var("INTENDANT_UPDATE_LANE_HEADROOM") {
+        if std::env::var("PROVIDER").as_deref() == Ok("mock") {
+            return match forced.as_str() {
+                "low" => Headroom::Low("forced by INTENDANT_UPDATE_LANE_HEADROOM".to_string()),
+                _ => Headroom::Ok("forced by INTENDANT_UPDATE_LANE_HEADROOM".to_string()),
+            };
+        }
+        eprintln!(
+            "[update-lane] INTENDANT_UPDATE_LANE_HEADROOM ignored: PROVIDER=mock is not set \
+             (the override is a mock-rig knob, never a production bypass)"
+        );
+    }
+    if cfg!(target_os = "macos") {
+        let out = tokio::time::timeout(
+            PROBE_TIMEOUT,
+            tokio::process::Command::new("sysctl")
+                .args(["-n", "kern.memorystatus_vm_pressure_level"])
+                .env_clear()
+                .envs(curated_env(&[]))
+                .stdin(std::process::Stdio::null())
+                .output(),
+        )
+        .await;
+        return match out {
+            Ok(Ok(output)) if output.status.success() => {
+                fold_macos_pressure(&String::from_utf8_lossy(&output.stdout))
+            }
+            _ => Headroom::Unknown("sysctl pressure probe failed".to_string()),
+        };
+    }
+    if cfg!(target_os = "linux") {
+        return match std::fs::read_to_string("/proc/meminfo") {
+            Ok(meminfo) => fold_linux_meminfo(&meminfo),
+            Err(err) => Headroom::Unknown(format!("/proc/meminfo unreadable: {err}")),
+        };
+    }
+    Headroom::Unknown("no headroom probe on this platform".to_string())
+}
+
+// ── Verify seams (consumer lane) ────────────────────────────────────
+
+/// Map the running binary's arch vocabulary to the bundle script's
+/// (`uname -m`): release zips are named `Intendant-<ver>-macos-<arch>.zip`.
+pub(crate) fn bundle_arch(rust_arch: &str) -> &'static str {
+    match rust_arch {
+        "aarch64" => "arm64",
+        _ => "x86_64",
+    }
+}
+
+/// Pick the installable app artifact for this machine from a VERIFIED
+/// release plan, requiring its detached signature beside it. Refuses
+/// `-unsigned-dev` / `-signed-unnotarized` artifacts by construction:
+/// the accepted name shape is exactly `Intendant-…-macos-<arch>.zip`.
+pub(crate) fn select_release_asset<'a>(
+    artifacts: &'a [crate::hosted_verify::ReleaseArtifactPlan],
+    arch: &str,
+) -> Result<(
+    &'a crate::hosted_verify::ReleaseArtifactPlan,
+    &'a crate::hosted_verify::ReleaseArtifactPlan,
+), String> {
+    let suffix = format!("-macos-{arch}.zip");
+    let zip = artifacts
+        .iter()
+        .find(|artifact| {
+            artifact.name.starts_with("Intendant-") && artifact.name.ends_with(&suffix)
+        })
+        .ok_or_else(|| {
+            format!(
+                "this release carries no installable macOS app for {arch} \
+                 (wanted Intendant-…{suffix}; dev/unnotarized artifacts are refused)"
+            )
+        })?;
+    let asc_name = format!("{}.asc", zip.name);
+    let asc = artifacts
+        .iter()
+        .find(|artifact| artifact.name == asc_name)
+        .ok_or_else(|| format!("{asc_name}: missing from the logged manifest"))?;
+    Ok((zip, asc))
+}
+
+/// Fail-closed download verdict: the bytes on disk must hash to exactly
+/// what the transparency log committed.
+pub(crate) fn download_verdict(name: &str, logged_sha: &str, actual_sha: &str) -> Result<(), String> {
+    if logged_sha == actual_sha {
+        Ok(())
+    } else {
+        Err(format!(
+            "{name}: downloaded bytes hash {} but the transparency log committed {} — \
+             refusing to install",
+            &actual_sha[..12.min(actual_sha.len())],
+            &logged_sha[..12.min(logged_sha.len())],
+        ))
+    }
+}
+
+/// Fail-closed `gpg --verify` verdict over the `--status-fd` output: the
+/// run must exit 0 AND report a `VALIDSIG` whose PRIMARY key fingerprint
+/// (the line's last field — signatures come from a signing SUBKEY) is
+/// exactly the compiled-in release key pin. GOODSIG alone is not enough:
+/// it names a key id, not the full primary fingerprint.
+pub(crate) fn gpg_verify_verdict(
+    exit_ok: bool,
+    status_out: &str,
+    pinned_primary_fingerprint: &str,
+) -> Result<(), String> {
+    if !exit_ok {
+        return Err("gpg --verify failed — the artifact's signature does not check out".to_string());
+    }
+    let valid = status_out.lines().any(|line| {
+        let mut fields = line.split_whitespace();
+        if fields.next() != Some("[GNUPG:]") || fields.next() != Some("VALIDSIG") {
+            return false;
+        }
+        line.split_whitespace().last() == Some(pinned_primary_fingerprint)
+    });
+    if valid {
+        Ok(())
+    } else {
+        Err(format!(
+            "gpg reported no VALIDSIG by the pinned release key {pinned_primary_fingerprint} — \
+             refusing to install"
+        ))
+    }
+}
+
+// ── Curated child environment ───────────────────────────────────────
+
+/// Base allowlist every supervised child gets: enough to run the tool,
+/// none of the daemon's provider or ambient credential authority. The
+/// governor stays engaged because `RUSTC_WRAPPER` is simply never set —
+/// the box-wide cargo config supplies it (never override, per the
+/// repo's governor doctrine).
+const CHILD_ENV_BASE: &[&str] = &[
+    "PATH", "HOME", "USER", "LOGNAME", "SHELL", "TMPDIR", "TEMP", "TMP", "LANG", "LC_ALL",
+    "LC_CTYPE", "TERM",
+];
+
+/// Extra names for build/bundle children (toolchain discovery). No
+/// `CARGO_TARGET_DIR`: the artifact must land at the checkout's own
+/// `target/release` — the path the update watch watches.
+const CHILD_ENV_BUILD: &[&str] = &["CARGO_HOME", "RUSTUP_HOME", "RUSTUP_TOOLCHAIN", "DEVELOPER_DIR"];
+
+/// Extra names for git children: the owner's click authorizes exactly a
+/// pull from origin, so the agent socket (ssh remotes) and HOME-based
+/// credential helpers work as they would by hand.
+const CHILD_ENV_GIT: &[&str] = &["SSH_AUTH_SOCK", "GIT_SSH_COMMAND"];
+
+/// Resolve the curated env for a child: base allowlist + the given
+/// extras, values from THIS process's environment.
+fn curated_env(extra: &[&str]) -> Vec<(String, String)> {
+    CHILD_ENV_BASE
+        .iter()
+        .chain(extra.iter())
+        .filter_map(|name| std::env::var(name).ok().map(|value| (name.to_string(), value)))
+        .collect()
+}
+
+// ── Job + check state (rendered onto the handover status payload) ───
+
+#[derive(Debug, Clone)]
+enum CheckOutcome {
+    Source(SourceCheck),
+    Consumer {
+        tag: String,
+        version: String,
+        newer: Option<bool>,
+    },
+}
+
+#[derive(Debug, Clone, Default)]
+struct CheckState {
+    in_flight: bool,
+    checked_at_ms: Option<u64>,
+    outcome: Option<Result<CheckOutcome, String>>,
+}
+
+#[derive(Debug, Clone)]
+struct JobState {
+    lane: &'static str,
+    phase: String,
+    started_ms: u64,
+    log: std::collections::VecDeque<String>,
+    /// `Some` = finished; `Ok` carries the success detail.
+    outcome: Option<Result<String, String>>,
+}
+
+/// The lane singleton, installed on the [`super::HandoverRuntime`] at
+/// spawn. Route handlers reach it through the runtime; the status block
+/// rides `status_json()` beside the update watch's chip block.
+pub(crate) struct UpdateLane {
+    runtime: Weak<super::HandoverRuntime>,
+    exe_path: PathBuf,
+    flavor: InstallFlavor,
+    check: Mutex<CheckState>,
+    job: Mutex<Option<JobState>>,
+    job_running: AtomicBool,
+}
+
+impl UpdateLane {
+    fn new(runtime: &Arc<super::HandoverRuntime>, exe_path: PathBuf) -> Self {
+        let flavor = detect_install_flavor(&exe_path);
+        UpdateLane {
+            runtime: Arc::downgrade(runtime),
+            exe_path,
+            flavor,
+            check: Mutex::new(CheckState::default()),
+            job: Mutex::new(None),
+            job_running: AtomicBool::new(false),
+        }
+    }
+
+    /// The `update_lane` block on the handover status payload: flavor,
+    /// running provenance, the last compare, and the job (with its
+    /// bounded log tail) — the panel's whole truth.
+    pub(crate) fn status_block(&self) -> serde_json::Value {
+        let mut block = serde_json::json!({
+            "flavor": self.flavor.kind(),
+            "running": {
+                "version": crate::build_info::pkg_version(),
+                "git_sha": crate::build_info::git_sha(),
+                "built_at": crate::build_info::build_timestamp(),
+            },
+        });
+        let obj = block.as_object_mut().expect("literal object");
+        match &self.flavor {
+            InstallFlavor::Source { repo_root, app_bundle } => {
+                obj.insert("repo_root".into(), repo_root.display().to_string().into());
+                obj.insert("app_bundle".into(), (*app_bundle).into());
+            }
+            InstallFlavor::ConsumerApp { app_root } => {
+                obj.insert("app_root".into(), app_root.display().to_string().into());
+                if !cfg!(target_os = "macos") {
+                    obj.insert(
+                        "unavailable".into(),
+                        "releases currently ship only the macOS app".into(),
+                    );
+                }
+            }
+            InstallFlavor::Unmanaged { reason } => {
+                obj.insert("unavailable".into(), reason.clone().into());
+            }
+        }
+        if let Ok(check) = self.check.lock() {
+            let mut check_block = serde_json::json!({
+                "in_flight": check.in_flight,
+            });
+            let check_obj = check_block.as_object_mut().expect("literal object");
+            if let Some(at) = check.checked_at_ms {
+                check_obj.insert("checked_at_ms".into(), at.into());
+            }
+            match &check.outcome {
+                Some(Ok(CheckOutcome::Source(source))) => {
+                    check_obj.insert("tip_sha".into(), source.tip_sha.clone().into());
+                    check_obj.insert("behind".into(), source.behind.into());
+                    check_obj.insert("behind_capped".into(), source.behind_capped.into());
+                    check_obj.insert("dirty".into(), source.dirty.into());
+                }
+                Some(Ok(CheckOutcome::Consumer { tag, version, newer })) => {
+                    check_obj.insert("latest_tag".into(), tag.clone().into());
+                    check_obj.insert("latest_version".into(), version.clone().into());
+                    match newer {
+                        Some(newer) => {
+                            check_obj.insert("behind".into(), u32::from(*newer).into());
+                        }
+                        None => {
+                            check_obj.insert(
+                                "compare_error".into(),
+                                "release and running versions are not comparable".into(),
+                            );
+                        }
+                    }
+                }
+                Some(Err(error)) => {
+                    check_obj.insert("error".into(), error.clone().into());
+                }
+                None => {}
+            }
+            obj.insert("check".into(), check_block);
+        }
+        if let Ok(job) = self.job.lock() {
+            if let Some(job) = job.as_ref() {
+                let mut job_block = serde_json::json!({
+                    "lane": job.lane,
+                    "phase": job.phase,
+                    "started_ms": job.started_ms,
+                    "log_tail": job.log.iter().cloned().collect::<Vec<_>>(),
+                });
+                let job_obj = job_block.as_object_mut().expect("literal object");
+                match &job.outcome {
+                    Some(Ok(detail)) => {
+                        job_obj.insert("ok".into(), true.into());
+                        job_obj.insert("detail".into(), detail.clone().into());
+                    }
+                    Some(Err(error)) => {
+                        job_obj.insert("ok".into(), false.into());
+                        job_obj.insert("error".into(), error.clone().into());
+                    }
+                    None => {}
+                }
+                obj.insert("job".into(), job_block);
+            }
+        }
+        block
+    }
+
+    // ── Job bookkeeping ──
+
+    fn job_log(&self, line: impl Into<String>) {
+        let mut line = line.into();
+        if line.len() > JOB_LOG_LINE_CAP {
+            line.truncate(JOB_LOG_LINE_CAP);
+        }
+        eprintln!("[update-lane] {line}");
+        if let Ok(mut job) = self.job.lock() {
+            if let Some(job) = job.as_mut() {
+                if job.log.len() >= JOB_LOG_TAIL_LINES {
+                    job.log.pop_front();
+                }
+                job.log.push_back(line);
+            }
+        }
+    }
+
+    fn set_phase(&self, phase: &str) {
+        if let Ok(mut job) = self.job.lock() {
+            if let Some(job) = job.as_mut() {
+                job.phase = phase.to_string();
+            }
+        }
+        self.job_log(format!("phase: {phase}"));
+    }
+
+    fn finish_job(&self, outcome: Result<String, String>) {
+        let (id_suffix, title, text, urgency) = match &outcome {
+            Ok(detail) => (
+                "done",
+                "Update produced",
+                detail.clone(),
+                crate::types::NotificationUrgency::Info,
+            ),
+            Err(error) => (
+                "failed",
+                "Update failed",
+                error.clone(),
+                crate::types::NotificationUrgency::Attention,
+            ),
+        };
+        match &outcome {
+            Ok(detail) => self.job_log(format!("done: {detail}")),
+            Err(error) => self.job_log(format!("failed: {error}")),
+        }
+        if let Ok(mut job) = self.job.lock() {
+            if let Some(job) = job.as_mut() {
+                job.outcome = Some(outcome);
+            }
+        }
+        if let Some(runtime) = self.runtime.upgrade() {
+            runtime.notify_user(
+                &format!("update-lane-{id_suffix}-{}", super::now_ms()),
+                Some(title),
+                &text,
+                urgency,
+            );
+        }
+        self.job_running.store(false, Ordering::Release);
+    }
+
+    // ── Supervised children ──
+
+    /// Run one supervised child: curated env, bounded runtime, stdout+
+    /// stderr streamed line-by-line into the job log as they happen
+    /// (ordinary visibility), kill-on-drop. Returns the captured stdout
+    /// on success.
+    async fn run_child(
+        self: &Arc<Self>,
+        label: &str,
+        program: &str,
+        args: Vec<String>,
+        cwd: Option<&Path>,
+        extra_env: &[&str],
+        timeout: std::time::Duration,
+    ) -> Result<String, String> {
+        self.job_log(format!("$ {program} {}", args.join(" ")));
+        let mut command = tokio::process::Command::new(program);
+        command
+            .args(&args)
+            .env_clear()
+            .envs(curated_env(extra_env))
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true);
+        if let Some(cwd) = cwd {
+            command.current_dir(cwd);
+        }
+        let mut child = command
+            .spawn()
+            .map_err(|err| format!("{label}: could not spawn {program}: {err}"))?;
+        let stdout = child.stdout.take();
+        let stderr = child.stderr.take();
+        let stdout_task = tokio::spawn(Self::pump_lines(Arc::clone(self), stdout, false));
+        let stderr_task = tokio::spawn(Self::pump_lines(Arc::clone(self), stderr, true));
+        let status = tokio::time::timeout(timeout, child.wait())
+            .await
+            .map_err(|_| {
+                format!(
+                    "{label}: timed out after {}s (child killed)",
+                    timeout.as_secs()
+                )
+            })?
+            .map_err(|err| format!("{label}: {err}"))?;
+        let captured = stdout_task.await.ok().flatten().unwrap_or_default();
+        let _ = stderr_task.await;
+        if !status.success() {
+            return Err(format!("{label}: {program} exited {status}"));
+        }
+        Ok(captured)
+    }
+
+    /// Stream a child pipe into the job log; returns the captured text
+    /// (stdout only — callers parse it).
+    async fn pump_lines(
+        lane: Arc<UpdateLane>,
+        pipe: Option<impl tokio::io::AsyncRead + Unpin>,
+        is_stderr: bool,
+    ) -> Option<String> {
+        use tokio::io::AsyncBufReadExt as _;
+        let pipe = pipe?;
+        let mut lines = tokio::io::BufReader::new(pipe).lines();
+        let mut captured = String::new();
+        while let Ok(Some(line)) = lines.next_line().await {
+            if !is_stderr {
+                captured.push_str(&line);
+                captured.push('\n');
+            }
+            if !line.trim().is_empty() {
+                lane.job_log(format!("  {}", line.trim_end()));
+            }
+        }
+        Some(captured)
+    }
+}
+
+// ── Public entry points (routes + wiring) ───────────────────────────
+
+impl UpdateLane {
+    /// Start a bounded behind-ness check unless one is already running.
+    pub(crate) fn request_check(self: &Arc<Self>) -> serde_json::Value {
+        {
+            let Ok(mut check) = self.check.lock() else {
+                return self.status_block();
+            };
+            if check.in_flight {
+                return self.status_block();
+            }
+            check.in_flight = true;
+        }
+        let lane = Arc::clone(self);
+        tokio::spawn(async move {
+            let outcome = lane.run_check().await;
+            if let Ok(mut check) = lane.check.lock() {
+                check.in_flight = false;
+                check.checked_at_ms = Some(super::now_ms());
+                check.outcome = Some(outcome);
+            }
+        });
+        self.status_block()
+    }
+
+    /// The owner's click: start the produce job. Refuses (honestly)
+    /// while one runs, on an unmanaged flavor, and on a consumer flavor
+    /// off macOS.
+    pub(crate) fn request_produce(self: &Arc<Self>) -> Result<serde_json::Value, String> {
+        match &self.flavor {
+            InstallFlavor::Unmanaged { reason } => {
+                return Err(format!("no update lane for this install: {reason}"));
+            }
+            InstallFlavor::ConsumerApp { .. } if !cfg!(target_os = "macos") => {
+                return Err(
+                    "releases currently ship only the macOS app — rebuild from source on this \
+                     platform"
+                        .to_string(),
+                );
+            }
+            _ => {}
+        }
+        if self
+            .job_running
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return Err("an update job is already running".to_string());
+        }
+        let lane_kind = match &self.flavor {
+            InstallFlavor::Source { .. } => "source",
+            InstallFlavor::ConsumerApp { .. } => "consumer",
+            InstallFlavor::Unmanaged { .. } => unreachable!("refused above"),
+        };
+        if let Ok(mut job) = self.job.lock() {
+            *job = Some(JobState {
+                lane: lane_kind,
+                phase: "starting".to_string(),
+                started_ms: super::now_ms(),
+                log: std::collections::VecDeque::new(),
+                outcome: None,
+            });
+        }
+        let lane = Arc::clone(self);
+        tokio::spawn(async move {
+            let outcome = match lane.flavor.clone() {
+                InstallFlavor::Source { repo_root, app_bundle } => {
+                    lane.produce_source(&repo_root, app_bundle).await
+                }
+                InstallFlavor::ConsumerApp { app_root } => lane.produce_consumer(&app_root).await,
+                InstallFlavor::Unmanaged { .. } => unreachable!("refused above"),
+            };
+            lane.finish_job(outcome);
+        });
+        Ok(self.status_block())
+    }
+
+    // ── The check ──
+
+    async fn run_check(self: &Arc<Self>) -> Result<CheckOutcome, String> {
+        match self.flavor.clone() {
+            InstallFlavor::Source { repo_root, .. } => {
+                self.source_check(&repo_root).await.map(CheckOutcome::Source)
+            }
+            InstallFlavor::ConsumerApp { .. } => self.consumer_check().await,
+            InstallFlavor::Unmanaged { reason } => Err(reason),
+        }
+    }
+
+    async fn source_check(self: &Arc<Self>, repo_root: &Path) -> Result<SourceCheck, String> {
+        self.git(repo_root, &["fetch", "--quiet", "origin", "main"])
+            .await?;
+        let tip = self
+            .git(repo_root, &["rev-parse", "--verify", "origin/main"])
+            .await?;
+        let running_sha =
+            mock_running_sha_override().unwrap_or_else(|| crate::build_info::git_sha().to_string());
+        let range = format!("{running_sha}..origin/main");
+        let max_count = format!("--max-count={BEHIND_COUNT_CAP}");
+        let count = self
+            .git(
+                repo_root,
+                &["rev-list", "--count", max_count.as_str(), range.as_str()],
+            )
+            .await
+            .map_err(|err| {
+                format!(
+                    "could not count commits behind origin/main (is the running build's commit \
+                     {running_sha} in this checkout's history?): {err}"
+                )
+            })?;
+        let status = self
+            .git(repo_root, &["status", "--porcelain"])
+            .await?;
+        fold_source_check(&tip, &count, &status)
+    }
+
+    /// A bounded git child — check-lane runs skip the job log (no job
+    /// exists), produce-lane runs stream into it.
+    async fn git(self: &Arc<Self>, repo_root: &Path, args: &[&str]) -> Result<String, String> {
+        let mut argv = vec!["-C".to_string(), repo_root.display().to_string()];
+        argv.extend(args.iter().map(|arg| arg.to_string()));
+        self.run_child(
+            &format!("git {}", args.first().copied().unwrap_or_default()),
+            "git",
+            argv,
+            None,
+            CHILD_ENV_GIT,
+            GIT_TIMEOUT,
+        )
+        .await
+    }
+
+    async fn consumer_check(self: &Arc<Self>) -> Result<CheckOutcome, String> {
+        let report = self.verified_release(None).await?;
+        let newer = release_version_newer(&report.version, crate::build_info::pkg_version());
+        Ok(CheckOutcome::Consumer {
+            tag: report.tag,
+            version: report.version,
+            newer,
+        })
+    }
+
+    /// The consumer lane's verify seam: the shipped transparency-log
+    /// release ritual (inclusion proof + signed tree head + append-only
+    /// pin + PGP identity/coverage + GitHub metadata). Fail closed —
+    /// any divergence refuses the whole lane.
+    async fn verified_release(
+        &self,
+        tag: Option<&str>,
+    ) -> Result<crate::hosted_verify::ReleaseVerifyReport, String> {
+        let base = update_rendezvous_url()?;
+        let github_api = url::Url::parse(crate::hosted_verify::GITHUB_API_BASE)
+            .map_err(|err| format!("GitHub API base: {err}"))?;
+        crate::hosted_verify::verify_hosted_release(
+            &base,
+            &github_api,
+            crate::hosted_verify::DEFAULT_RELEASE_REPO,
+            tag,
+            false,
+            &crate::platform::intendant_home(),
+        )
+        .await
+        .map_err(|failure| match failure {
+            crate::hosted_verify::VerifyFailure::Unavailable(detail) => {
+                format!("release check unavailable: {detail}")
+            }
+            crate::hosted_verify::VerifyFailure::Verification { summary, mismatches } => {
+                format!(
+                    "release verification FAILED: {summary}{}",
+                    if mismatches.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" — {}", mismatches.join("; "))
+                    }
+                )
+            }
+        })
+    }
+
+    // ── Produce: source lane ──
+
+    async fn produce_source(
+        self: &Arc<Self>,
+        repo_root: &Path,
+        app_bundle: bool,
+    ) -> Result<String, String> {
+        self.set_phase("headroom");
+        match headroom_gate(&probe_headroom().await) {
+            Ok(Some(note)) => self.job_log(note),
+            Ok(None) => {}
+            Err(refusal) => return Err(refusal),
+        }
+
+        self.set_phase("pull");
+        let status = self.git(repo_root, &["status", "--porcelain"]).await?;
+        if !status.trim().is_empty() {
+            return Err(
+                "the checkout has local changes — not pulling over them; commit or stash by \
+                 hand, then retry"
+                    .to_string(),
+            );
+        }
+        self.git(repo_root, &["pull", "--ff-only", "origin", "main"])
+            .await
+            .map_err(|err| {
+                format!(
+                    "fast-forward pull of origin/main failed (diverged branch or detached \
+                     checkout — reconcile by hand): {err}"
+                )
+            })?;
+
+        self.set_phase("build");
+        let produced = if app_bundle {
+            if !cfg!(target_os = "macos") {
+                return Err("app-bundle rebuilds only exist on macOS".to_string());
+            }
+            // Builds, signs with the stable local identity, and installs
+            // to /Applications — the script's only install target, which
+            // is also the watched path for a stamped installed app.
+            self.run_child(
+                "bundle",
+                "bash",
+                vec!["scripts/bundle-macos.sh".to_string()],
+                Some(repo_root),
+                CHILD_ENV_BUILD,
+                BUILD_TIMEOUT,
+            )
+            .await?;
+            self.exe_path.clone()
+        } else {
+            if let Some(mock_build) = mock_build_override() {
+                // Rig lane (PROVIDER=mock only): the e2e legs cannot pay
+                // for a real cargo build; the override script stands in
+                // for it and must still land the artifact at the watched
+                // path for the flow to count.
+                self.run_child(
+                    "build (mock)",
+                    "bash",
+                    vec![mock_build],
+                    Some(repo_root),
+                    CHILD_ENV_BUILD,
+                    BUILD_TIMEOUT,
+                )
+                .await?;
+            } else {
+                self.run_child(
+                    "build",
+                    "cargo",
+                    ["build", "--release", "--bin", "intendant", "--bin", "intendant-runtime"]
+                        .iter()
+                        .map(|arg| arg.to_string())
+                        .collect(),
+                    Some(repo_root),
+                    CHILD_ENV_BUILD,
+                    BUILD_TIMEOUT,
+                )
+                .await?;
+            }
+            repo_root
+                .join("target")
+                .join("release")
+                .join(format!("intendant{}", std::env::consts::EXE_SUFFIX))
+        };
+
+        self.set_phase("verify");
+        let build = super::update_watch::run_version_probe(&produced)
+            .await
+            .map_err(|err| format!("the produced binary failed its --version probe: {err}"))?;
+        Ok(format!(
+            "built commit {} ({}) at {} — the update chip offers the swap once the watch \
+             confirms it on disk",
+            build.git_sha,
+            build.version,
+            produced.display(),
+        ))
+    }
+
+    // ── Produce: consumer lane ──
+
+    async fn produce_consumer(self: &Arc<Self>, app_root: &Path) -> Result<String, String> {
+        self.set_phase("verify-manifest");
+        let report = self.verified_release(None).await?;
+        let (zip, asc) = select_release_asset(&report.artifacts, bundle_arch(std::env::consts::ARCH))
+            .map(|(zip, asc)| (zip.clone(), asc.clone()))?;
+        self.job_log(format!(
+            "release {} verified against the transparency log ({} artifacts; signing key {})",
+            report.tag, report.artifact_count, report.pgp_fingerprint
+        ));
+
+        let staging = crate::platform::intendant_home()
+            .join("update-lane")
+            .join(format!("staging-{}", report.tag.replace(['/', '\\'], "_")));
+        let cleanup = StagingCleanup(staging.clone());
+        let _ = std::fs::remove_dir_all(&staging);
+        std::fs::create_dir_all(&staging).map_err(|err| format!("staging dir: {err}"))?;
+
+        self.set_phase("download");
+        let zip_path = staging.join(&zip.name);
+        let zip_sha = self.download_asset(&zip, &zip_path).await?;
+        download_verdict(&zip.name, &zip.sha256, &zip_sha)?;
+        let asc_path = staging.join(&asc.name);
+        let asc_sha = self.download_asset(&asc, &asc_path).await?;
+        download_verdict(&asc.name, &asc.sha256, &asc_sha)?;
+        self.job_log(format!(
+            "downloaded {} ({} bytes) + detached signature; both hash-match the log",
+            zip.name, zip.size
+        ));
+
+        self.set_phase("pgp-verify");
+        self.gpg_verify(&staging, &zip_path, &asc_path).await?;
+        self.job_log(format!(
+            "gpg VALIDSIG by the pinned release key {}",
+            crate::pgp_identity::RELEASE_SIGNING_KEY_FINGERPRINT
+        ));
+
+        self.set_phase("install");
+        let unpack_dir = staging.join("unpacked");
+        std::fs::create_dir_all(&unpack_dir).map_err(|err| format!("unpack dir: {err}"))?;
+        self.run_child(
+            "unpack",
+            "ditto",
+            vec![
+                "-x".to_string(),
+                "-k".to_string(),
+                zip_path.display().to_string(),
+                unpack_dir.display().to_string(),
+            ],
+            None,
+            &[],
+            UNPACK_TIMEOUT,
+        )
+        .await?;
+        let new_app = unpack_dir.join("Intendant.app");
+        if !new_app.is_dir() {
+            return Err("the release zip did not contain Intendant.app at its root".to_string());
+        }
+        let new_binary = new_app.join("Contents").join("MacOS").join("intendant-bin");
+        let build = super::update_watch::run_version_probe(&new_binary)
+            .await
+            .map_err(|err| format!("the downloaded app failed its --version probe: {err}"))?;
+        {
+            // The swap is filesystem renames (a ditto copy on the rare
+            // cross-volume staging) — blocking work off the executor.
+            let new_app = new_app.clone();
+            let app_root = app_root.to_path_buf();
+            tokio::task::spawn_blocking(move || install_app_swap(&new_app, &app_root))
+                .await
+                .map_err(|err| format!("install task: {err}"))??;
+        }
+        drop(cleanup);
+        Ok(format!(
+            "release {} (commit {}, {}) installed at {} — the update chip offers the swap once \
+             the watch confirms it on disk",
+            report.tag,
+            build.git_sha,
+            build.version,
+            app_root.display(),
+        ))
+    }
+
+    async fn download_asset(
+        &self,
+        artifact: &crate::hosted_verify::ReleaseArtifactPlan,
+        dest: &Path,
+    ) -> Result<String, String> {
+        let url = artifact
+            .download_url
+            .as_deref()
+            .ok_or_else(|| format!("{}: GitHub exposes no download URL", artifact.name))?;
+        let cap = if artifact.name.ends_with(".asc") {
+            ASC_BYTE_CAP
+        } else {
+            // The log commits the exact size; pad for safety margin only.
+            usize::try_from(artifact.size)
+                .unwrap_or(usize::MAX)
+                .saturating_add(1024)
+        };
+        crate::hosted_verify::download_release_asset_to_file(url, dest, cap).await
+    }
+
+    /// The PGP leg: throwaway GNUPGHOME, import ONLY the compiled-in
+    /// release key, verify the detached signature. gpg missing = fail
+    /// closed (this lane's whole point is the independent signature
+    /// check).
+    async fn gpg_verify(
+        self: &Arc<Self>,
+        staging: &Path,
+        artifact: &Path,
+        signature: &Path,
+    ) -> Result<(), String> {
+        let gnupg_home = staging.join("gnupg");
+        std::fs::create_dir_all(&gnupg_home).map_err(|err| format!("gnupg home: {err}"))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let _ = std::fs::set_permissions(&gnupg_home, std::fs::Permissions::from_mode(0o700));
+        }
+        let key_path = staging.join("release-signing-key.asc");
+        std::fs::write(&key_path, crate::pgp_identity::RELEASE_SIGNING_PUBKEY_ASC)
+            .map_err(|err| format!("write pinned key: {err}"))?;
+        let home = gnupg_home.display().to_string();
+        self.run_child(
+            "gpg import",
+            "gpg",
+            vec![
+                "--batch".to_string(),
+                "--homedir".to_string(),
+                home.clone(),
+                "--import".to_string(),
+                key_path.display().to_string(),
+            ],
+            None,
+            &[],
+            GPG_TIMEOUT,
+        )
+        .await
+        .map_err(|err| {
+            format!(
+                "{err} — the consumer lane needs gnupg for the signature check \
+                 (macOS: brew install gnupg); refusing to install without it"
+            )
+        })?;
+        let status_out = self
+            .run_child(
+                "gpg verify",
+                "gpg",
+                vec![
+                    "--batch".to_string(),
+                    "--homedir".to_string(),
+                    home,
+                    "--status-fd".to_string(),
+                    "1".to_string(),
+                    "--verify".to_string(),
+                    signature.display().to_string(),
+                    artifact.display().to_string(),
+                ],
+                None,
+                &[],
+                GPG_TIMEOUT,
+            )
+            .await;
+        match status_out {
+            Ok(out) => gpg_verify_verdict(
+                true,
+                &out,
+                crate::pgp_identity::RELEASE_SIGNING_KEY_FINGERPRINT,
+            ),
+            Err(err) => {
+                // Exit != 0 IS the fail-closed verdict; keep the child's
+                // words for the log.
+                self.job_log(err);
+                gpg_verify_verdict(
+                    false,
+                    "",
+                    crate::pgp_identity::RELEASE_SIGNING_KEY_FINGERPRINT,
+                )
+            }
+        }
+    }
+}
+
+/// Delete the staging tree on drop — a failed job never leaves
+/// unverified bytes behind. Success paths drop it too: the artifact has
+/// been installed; the staging copy is done.
+struct StagingCleanup(PathBuf);
+impl Drop for StagingCleanup {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+/// Swap the verified new app into place: stage it beside the target
+/// (same volume, so renames are atomic), keep the old bundle as
+/// `<name>.app.previous`, roll back on a failed final rename. The
+/// running processes keep their open inodes; the update watch sees the
+/// path flip and takes it from there.
+fn install_app_swap(new_app: &Path, app_root: &Path) -> Result<(), String> {
+    let parent = app_root
+        .parent()
+        .ok_or_else(|| "the installed app has no parent directory".to_string())?;
+    let file_name = app_root
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| "the installed app has no usable name".to_string())?;
+    let staged = parent.join(format!(".{file_name}.update-{}", std::process::id()));
+    let previous = parent.join(format!("{file_name}.previous"));
+    let _ = std::fs::remove_dir_all(&staged);
+    if std::fs::rename(new_app, &staged).is_err() {
+        // Cross-volume staging: fall back to a bundle-faithful copy.
+        let status = std::process::Command::new("ditto")
+            .arg(new_app)
+            .arg(&staged)
+            .status()
+            .map_err(|err| format!("ditto copy into {}: {err}", parent.display()))?;
+        if !status.success() {
+            return Err(format!("ditto copy into {} exited {status}", parent.display()));
+        }
+    }
+    let _ = std::fs::remove_dir_all(&previous);
+    std::fs::rename(app_root, &previous)
+        .map_err(|err| format!("could not set the running app aside: {err}"))?;
+    if let Err(err) = std::fs::rename(&staged, app_root) {
+        // Roll the old app back so the machine is never left app-less.
+        let _ = std::fs::rename(&previous, app_root);
+        let _ = std::fs::remove_dir_all(&staged);
+        return Err(format!("could not move the new app into place: {err}"));
+    }
+    Ok(())
+}
+
+/// Rig knob (PROVIDER=mock only): a script standing in for the cargo
+/// build. Mirrors the `INTENDANT_UPDATE_WATCH_PATH` fail-closed shape.
+fn mock_build_override() -> Option<String> {
+    let script = std::env::var("INTENDANT_UPDATE_LANE_BUILD_CMD").ok()?;
+    if std::env::var("PROVIDER").as_deref() == Ok("mock") {
+        return Some(script);
+    }
+    eprintln!(
+        "[update-lane] INTENDANT_UPDATE_LANE_BUILD_CMD ignored: PROVIDER=mock is not set \
+         (the override is a mock-rig knob, never a production redirect)"
+    );
+    None
+}
+
+/// Rig knob (PROVIDER=mock only): the "running" commit for the compare.
+/// The e2e fixture repos cannot contain the test binary's compiled-in
+/// sha, so the rig injects one that is; production always compares the
+/// real `build_info` provenance.
+fn mock_running_sha_override() -> Option<String> {
+    let sha = std::env::var("INTENDANT_UPDATE_LANE_RUNNING_SHA").ok()?;
+    if std::env::var("PROVIDER").as_deref() == Ok("mock") {
+        return Some(sha);
+    }
+    eprintln!(
+        "[update-lane] INTENDANT_UPDATE_LANE_RUNNING_SHA ignored: PROVIDER=mock is not set \
+         (the override is a mock-rig knob, never a production redirect)"
+    );
+    None
+}
+
+/// The rendezvous the consumer lane verifies against: the live Connect
+/// configuration when one is set, else the env override, else the
+/// hosted default — the same ladder as `intendant hosted-verify`.
+fn update_rendezvous_url() -> Result<url::Url, String> {
+    let configured = crate::connect_rendezvous::status_snapshot()
+        .rendezvous_url
+        .map(|url| url.trim().to_string())
+        .filter(|url| !url.is_empty());
+    let raw = configured
+        .or_else(|| {
+            std::env::var("INTENDANT_CONNECT_RENDEZVOUS_URL")
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+        })
+        .unwrap_or_else(|| crate::project::DEFAULT_CONNECT_RENDEZVOUS_URL.to_string());
+    url::Url::parse(&raw).map_err(|err| format!("rendezvous URL {raw:?}: {err}"))
+}
+
+/// Delay before the boot check, and the standing cadence after it. The
+/// check never produces anything — behind-ness only; producing takes
+/// the owner's click.
+const BOOT_CHECK_DELAY: std::time::Duration = std::time::Duration::from_secs(180);
+const CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(12 * 60 * 60);
+
+/// Wire the lane onto the runtime and start the gentle check cadence.
+/// Spawned beside the update watch; shares its watched-path resolution
+/// (and therefore its mock-rig override).
+pub(crate) fn spawn_update_lane(runtime: &Arc<super::HandoverRuntime>) {
+    let Some(exe_path) = super::update_watch::watched_binary_path() else {
+        eprintln!("[update-lane] current_exe unresolvable — update lane off for this boot");
+        return;
+    };
+    let lane = Arc::new(UpdateLane::new(runtime, exe_path));
+    runtime.set_update_lane(lane.clone());
+    tokio::spawn(async move {
+        tokio::time::sleep(BOOT_CHECK_DELAY).await;
+        loop {
+            // The AUTOMATIC cadence follows the hosted-verify tripwire's
+            // posture: a consumer-flavor check reaches the rendezvous +
+            // GitHub, so it only runs unprompted when the owner has
+            // Connect configured; the panel's "Check now" click always
+            // may. Source-flavor checks fetch the owner's own origin.
+            let consumer = matches!(lane.flavor, InstallFlavor::ConsumerApp { .. });
+            if !consumer || crate::connect_rendezvous::status_snapshot().configured {
+                lane.request_check();
+            }
+            tokio::time::sleep(CHECK_INTERVAL).await;
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── The pinned compare seam ──
+
+    /// Commission pin: the behind-main compare folds the bounded git
+    /// observations — tip, capped count, dirtiness — and refuses
+    /// unparseable output instead of guessing.
+    #[test]
+    fn source_compare_folds_bounded_git_observations() {
+        let check = fold_source_check("3e4c79f8aa", "3\n", "").expect("clean fold");
+        assert_eq!(check.tip_sha, "3e4c79f8aa");
+        assert_eq!(check.behind, 3);
+        assert!(!check.behind_capped);
+        assert!(!check.dirty);
+
+        let capped = fold_source_check("abcdef012345", "500\n", " M src/main.rs\n").unwrap();
+        assert_eq!(capped.behind, BEHIND_COUNT_CAP);
+        assert!(capped.behind_capped, "cap reached reads as 500+");
+        assert!(capped.dirty);
+
+        assert!(fold_source_check("fatal: bad revision", "0", "").is_err());
+        assert!(fold_source_check("abcdef012345", "many", "").is_err());
+    }
+
+    /// Commission pin: release-vs-running is a semver compare that
+    /// refuses to guess on unparseable versions.
+    #[test]
+    fn consumer_compare_is_honest_semver() {
+        assert_eq!(release_version_newer("v0.2.0", "0.1.0"), Some(true));
+        assert_eq!(release_version_newer("v0.1.0", "0.1.0"), Some(false));
+        assert_eq!(release_version_newer("0.1.0", "0.2.0"), Some(false));
+        assert_eq!(release_version_newer("v1.0.0-rc.1", "0.9.9"), Some(true));
+        assert_eq!(release_version_newer("nightly", "0.1.0"), None);
+        assert_eq!(release_version_newer("v0.1.0", "unknown"), None);
+    }
+
+    // ── The headroom gate (the capacity linkage) ──
+
+    /// Commission pin: the produce job never builds under memory
+    /// pressure — `Low` refuses, `Unknown` proceeds with the note.
+    #[test]
+    fn headroom_gate_refuses_pressure() {
+        assert!(headroom_gate(&Headroom::Ok("fine".into())).is_ok());
+        let unknown = headroom_gate(&Headroom::Unknown("no probe".into())).unwrap();
+        assert!(unknown.unwrap().contains("no probe"));
+        let refusal = headroom_gate(&Headroom::Low("level 4".into())).unwrap_err();
+        assert!(refusal.contains("memory pressure"));
+        assert!(refusal.contains("level 4"));
+    }
+
+    #[test]
+    fn headroom_probes_fold_platform_output() {
+        assert!(matches!(fold_macos_pressure("1\n"), Headroom::Ok(_)));
+        assert!(matches!(fold_macos_pressure("2"), Headroom::Low(_)));
+        assert!(matches!(fold_macos_pressure("4"), Headroom::Low(_)));
+        assert!(matches!(fold_macos_pressure("??"), Headroom::Unknown(_)));
+
+        let low = fold_linux_meminfo("MemTotal: 16 kB\nMemAvailable: 1048576 kB\n");
+        assert!(matches!(low, Headroom::Low(_)), "1 GiB is under the floor");
+        let ok = fold_linux_meminfo("MemAvailable: 8388608 kB\n");
+        assert!(matches!(ok, Headroom::Ok(_)));
+        assert!(matches!(
+            fold_linux_meminfo("MemTotal: 1 kB\n"),
+            Headroom::Unknown(_)
+        ));
+    }
+
+    // ── The pinned verify seams (fail closed) ──
+
+    fn plan(name: &str, sha: &str) -> crate::hosted_verify::ReleaseArtifactPlan {
+        crate::hosted_verify::ReleaseArtifactPlan {
+            name: name.to_string(),
+            sha256: sha.to_string(),
+            size: 10,
+            download_url: Some(format!("https://example.invalid/{name}")),
+        }
+    }
+
+    /// Commission pin: the consumer lane installs only a release-shaped,
+    /// signed macOS artifact for THIS machine's arch — dev/unnotarized
+    /// suffixes and signature-less artifacts are refused.
+    #[test]
+    fn release_asset_selection_fails_closed() {
+        let artifacts = vec![
+            plan("Intendant-v0.1.0-macos-arm64.zip", "aa"),
+            plan("Intendant-v0.1.0-macos-arm64.zip.asc", "bb"),
+            plan("install.sh", "cc"),
+        ];
+        let (zip, asc) = select_release_asset(&artifacts, "arm64").expect("selects the app zip");
+        assert_eq!(zip.name, "Intendant-v0.1.0-macos-arm64.zip");
+        assert_eq!(asc.name, "Intendant-v0.1.0-macos-arm64.zip.asc");
+
+        assert!(
+            select_release_asset(&artifacts, "x86_64").is_err(),
+            "no artifact for another arch"
+        );
+        let unsigned = vec![plan("Intendant-v0.1.0-macos-arm64-unsigned-dev.zip", "aa")];
+        assert!(
+            select_release_asset(&unsigned, "arm64").is_err(),
+            "dev-suffixed artifacts never install"
+        );
+        let missing_asc = vec![plan("Intendant-v0.1.0-macos-arm64.zip", "aa")];
+        assert!(
+            select_release_asset(&missing_asc, "arm64").is_err(),
+            "an artifact without its .asc is refused"
+        );
+        assert_eq!(bundle_arch("aarch64"), "arm64");
+        assert_eq!(bundle_arch("x86_64"), "x86_64");
+    }
+
+    /// Commission pin (verify seam): downloaded bytes must hash to the
+    /// LOG's committed sha — anything else refuses the install.
+    #[test]
+    fn download_verdict_fails_closed_on_hash_mismatch() {
+        assert!(download_verdict("a.zip", "aabbcc", "aabbcc").is_ok());
+        let err = download_verdict("a.zip", "aabbccddeeff00112233", "deadbeefdeadbeefdead")
+            .unwrap_err();
+        assert!(err.contains("refusing to install"));
+        assert!(err.contains("a.zip"));
+    }
+
+    /// Commission pin (verify seam): the PGP verdict requires a gpg
+    /// VALIDSIG whose PRIMARY fingerprint is the compiled-in pin —
+    /// success exit alone, GOODSIG alone, or a foreign key all refuse.
+    #[test]
+    fn gpg_verdict_requires_validsig_by_the_pinned_primary() {
+        const PIN: &str = "A9B389C058DD177B3303A13522FC08F0A26D3D18";
+        let status = format!(
+            "[GNUPG:] NEWSIG\n[GNUPG:] GOODSIG 22FC08F0A26D3D18 Intendant Release Signing\n\
+             [GNUPG:] VALIDSIG 1111222233334444555566667777888899990000 2026-07-30 1785000000 0 4 0 1 8 00 {PIN}\n"
+        );
+        assert!(gpg_verify_verdict(true, &status, PIN).is_ok());
+
+        assert!(
+            gpg_verify_verdict(false, &status, PIN).is_err(),
+            "a failing gpg exit refuses regardless of output"
+        );
+        assert!(
+            gpg_verify_verdict(true, "[GNUPG:] GOODSIG 22FC08F0A26D3D18 x\n", PIN).is_err(),
+            "GOODSIG without VALIDSIG refuses"
+        );
+        let foreign = "[GNUPG:] VALIDSIG 1111 2026-07-30 1 0 4 0 1 8 00 \
+                       BBBB389C058DD177B3303A13522FC08F0A26D3D1\n";
+        assert!(
+            gpg_verify_verdict(true, foreign, PIN).is_err(),
+            "a VALIDSIG by another primary key refuses"
+        );
+    }
+
+    // ── Flavor detection (hermetic) ──
+
+    fn touch(path: &Path) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, b"x").unwrap();
+    }
+
+    #[test]
+    fn flavor_detects_source_checkout_release_binary() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("checkout");
+        std::fs::create_dir_all(repo.join(".git")).unwrap();
+        touch(&repo.join("Cargo.toml"));
+        touch(&repo.join("scripts").join("bundle-macos.sh"));
+        let exe = repo
+            .join("target")
+            .join("release")
+            .join(format!("intendant{}", std::env::consts::EXE_SUFFIX));
+        touch(&exe);
+        assert_eq!(
+            detect_install_flavor(&exe),
+            InstallFlavor::Source {
+                repo_root: repo.clone(),
+                app_bundle: false
+            }
+        );
+        // A debug binary is inside the checkout but NOT the watched
+        // release output: unmanaged, with the reason said out loud.
+        let debug_exe = repo.join("target").join("debug").join("intendant");
+        touch(&debug_exe);
+        match detect_install_flavor(&debug_exe) {
+            InstallFlavor::Unmanaged { reason } => {
+                assert!(reason.contains("target/release"))
+            }
+            other => panic!("expected unmanaged, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn flavor_detects_app_bundles_by_source_stamp() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("checkout");
+        std::fs::create_dir_all(repo.join(".git")).unwrap();
+        touch(&repo.join("Cargo.toml"));
+        touch(&repo.join("scripts").join("bundle-macos.sh"));
+
+        let app = dir.path().join("Applications").join("Intendant.app");
+        let exe = app.join("Contents").join("MacOS").join("intendant-bin");
+        touch(&exe);
+
+        // No stamp: a consumer install.
+        assert_eq!(
+            detect_install_flavor(&exe),
+            InstallFlavor::ConsumerApp { app_root: app.clone() }
+        );
+
+        // A valid stamp names the checkout: the source lane, app shape.
+        touch(&app.join("Contents").join("Resources").join(SOURCE_STAMP_RESOURCE));
+        std::fs::write(
+            app.join("Contents").join("Resources").join(SOURCE_STAMP_RESOURCE),
+            format!("{}\n", repo.display()),
+        )
+        .unwrap();
+        assert_eq!(
+            detect_install_flavor(&exe),
+            InstallFlavor::Source {
+                repo_root: repo.clone(),
+                app_bundle: true
+            }
+        );
+
+        // A stamp whose path is gone (a release app carrying its CI
+        // runner's checkout) falls down to the consumer lane.
+        std::fs::write(
+            app.join("Contents").join("Resources").join(SOURCE_STAMP_RESOURCE),
+            "/nonexistent/ci/checkout\n",
+        )
+        .unwrap();
+        assert_eq!(
+            detect_install_flavor(&exe),
+            InstallFlavor::ConsumerApp { app_root: app.clone() }
+        );
+
+        let stray = dir.path().join("bin").join("intendant");
+        touch(&stray);
+        assert!(matches!(
+            detect_install_flavor(&stray),
+            InstallFlavor::Unmanaged { .. }
+        ));
+    }
+
+    /// Commission pin: the shipped dashboard bundle carries the Daemon
+    /// update panel — the Access→Daemons mount, both consent buttons,
+    /// and the two action POSTs — so the produce lane cannot be
+    /// silently gutted from the SPA (the HS6 artifact-scan pattern).
+    #[test]
+    fn spa_carries_the_update_lane_panel() {
+        let app = include_str!("../../../../static/app.html");
+        for needle in [
+            "update-lane-card",
+            "Update from main",
+            "Download & verify release",
+            "/api/daemon/update-lane/produce",
+            "/api/daemon/update-lane/check",
+            "update_lane",
+        ] {
+            assert!(
+                app.contains(needle),
+                "the dashboard bundle lost the update-lane panel wiring: {needle}"
+            );
+        }
+    }
+
+    /// An unmanaged install refuses the click with the reason on the
+    /// block — the consent surface never offers a button it cannot
+    /// honor, and the refusal releases the single-flight latch.
+    #[tokio::test]
+    async fn unmanaged_flavor_refuses_produce_honestly() {
+        let home = tempfile::tempdir().unwrap();
+        let runtime = Arc::new(crate::handover::HandoverRuntime::initialize(
+            home.path(),
+            0,
+            0,
+        ));
+        let exe = home.path().join("bin").join("intendant");
+        touch(&exe);
+        let lane = Arc::new(UpdateLane::new(&runtime, exe));
+        let block = lane.status_block();
+        assert_eq!(block["flavor"], "unmanaged");
+        assert!(block["unavailable"].is_string(), "{block}");
+        assert!(block["running"]["git_sha"].is_string());
+        let refusal = lane.request_produce().unwrap_err();
+        assert!(refusal.contains("no update lane"), "{refusal}");
+        assert!(
+            !lane.job_running.load(Ordering::Acquire),
+            "a refused click leaves the single-flight latch free"
+        );
+    }
+
+    // ── The install swap ──
+
+    #[test]
+    fn app_swap_keeps_previous_and_rolls_back() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("Applications");
+        let app = parent.join("Intendant.app");
+        touch(&app.join("Contents").join("MacOS").join("old-marker"));
+        let new_app = dir.path().join("staging").join("Intendant.app");
+        touch(&new_app.join("Contents").join("MacOS").join("new-marker"));
+
+        install_app_swap(&new_app, &app).expect("swap succeeds");
+        assert!(app.join("Contents").join("MacOS").join("new-marker").is_file());
+        assert!(parent
+            .join("Intendant.app.previous")
+            .join("Contents")
+            .join("MacOS")
+            .join("old-marker")
+            .is_file());
+    }
+}

--- a/src/bin/caller/handover/update_watch.rs
+++ b/src/bin/caller/handover/update_watch.rs
@@ -339,8 +339,9 @@ fn format_instant_ms(ms: u64) -> String {
 /// The `--version` probe (transport edge): bounded subprocess with a
 /// scrubbed environment — the probe target needs nothing, and the
 /// daemon's provider authority must never leak into an on-disk image we
-/// merely observe.
-async fn run_version_probe(path: &Path) -> Result<ProbedBuild, String> {
+/// merely observe. Shared with the update lane, which probes the
+/// artifact it just produced the same way.
+pub(crate) async fn run_version_probe(path: &Path) -> Result<ProbedBuild, String> {
     let output = tokio::time::timeout(
         PROBE_TIMEOUT,
         tokio::process::Command::new(path)
@@ -404,7 +405,7 @@ async fn developer_id_signed(path: &Path) -> bool {
 /// alongside `PROVIDER=mock` (fail-closed otherwise, mirroring
 /// `INTENDANT_MOCK_DISPLAY`) — the probe execs this path, so a plain
 /// env var must never redirect a real daemon's exec target.
-fn watched_binary_path() -> Option<PathBuf> {
+pub(crate) fn watched_binary_path() -> Option<PathBuf> {
     if let Ok(override_path) = std::env::var("INTENDANT_UPDATE_WATCH_PATH") {
         if std::env::var("PROVIDER").as_deref() == Ok("mock") {
             return Some(PathBuf::from(override_path));

--- a/src/bin/caller/hosted_verify.rs
+++ b/src/bin/caller/hosted_verify.rs
@@ -4617,13 +4617,9 @@ mod tests {
 
         let dir = tempfile::tempdir().unwrap();
         let dest = dir.path().join("asset.zip");
-        let sha = download_release_asset_to_file(
-            &format!("http://{addr}/asset.zip"),
-            &dest,
-            1024,
-        )
-        .await
-        .expect("download succeeds");
+        let sha = download_release_asset_to_file(&format!("http://{addr}/asset.zip"), &dest, 1024)
+            .await
+            .expect("download succeeds");
         assert_eq!(sha, sha256_hex(payload), "digest is of the written bytes");
         assert_eq!(std::fs::read(&dest).unwrap(), payload);
 

--- a/src/bin/caller/hosted_verify.rs
+++ b/src/bin/caller/hosted_verify.rs
@@ -1733,8 +1733,8 @@ pub(crate) async fn verify_hosted_bundle(
 /// Repository whose GitHub releases the hosted log's release manifests
 /// describe (`macos-app/UpdateChecker.swift` twins this slug);
 /// `--repo` overrides for self-hosted forks.
-const DEFAULT_RELEASE_REPO: &str = "intendant-dev/Intendant";
-const GITHUB_API_BASE: &str = "https://api.github.com";
+pub(crate) const DEFAULT_RELEASE_REPO: &str = "intendant-dev/Intendant";
+pub(crate) const GITHUB_API_BASE: &str = "https://api.github.com";
 
 /// `--download` re-fetches whole release artifacts, which are allowed to
 /// be far bigger than Connect page/installer bundles.
@@ -2108,6 +2108,23 @@ pub(crate) struct ReleaseVerifyReport {
     pub downloaded: usize,
     /// `None` = first contact (this run created the pin).
     pub pinned_from_size: Option<u64>,
+    /// The verified plan: every LOGGED artifact with its log-committed
+    /// digest/size and the GitHub download URL observed beside it. Only
+    /// meaningful when verification passed (the fn errors otherwise);
+    /// the self-update lane consumes it to fetch exactly the committed
+    /// bytes.
+    pub artifacts: Vec<ReleaseArtifactPlan>,
+}
+
+/// One verified release artifact as the update lane consumes it: the
+/// name/digest/size come from the transparency log's manifest leaf, the
+/// download URL from the GitHub release the leaf was verified against.
+#[derive(Debug, Clone)]
+pub(crate) struct ReleaseArtifactPlan {
+    pub name: String,
+    pub sha256: String,
+    pub size: u64,
+    pub download_url: Option<String>,
 }
 
 fn github_release_tag_url(github_api: &Url, repo: &str, tag: &str) -> Result<Url, String> {
@@ -2280,6 +2297,20 @@ pub(crate) async fn verify_hosted_release(
     // Everything held — advance the pin.
     commit_verified_pin(&client, base, &entry).await?;
 
+    let artifact_plans = leaf
+        .artifacts
+        .iter()
+        .map(|artifact| ReleaseArtifactPlan {
+            name: artifact.name.clone(),
+            sha256: artifact.sha256.clone(),
+            size: artifact.size,
+            download_url: assets
+                .iter()
+                .find(|asset| asset.name == artifact.name)
+                .and_then(|asset| asset.download_url.clone()),
+        })
+        .collect();
+
     Ok(ReleaseVerifyReport {
         log_size: entry.sth.size,
         manifest_index: entry.index,
@@ -2294,7 +2325,67 @@ pub(crate) async fn verify_hosted_release(
         presence_only,
         downloaded,
         pinned_from_size: entry.pinned_from_size,
+        artifacts: artifact_plans,
     })
+}
+
+/// Download one release asset to a file, hashing the exact bytes as
+/// they stream (the same bounded client + timeout discipline as the
+/// `--download` verification lane). Returns the sha256 hex of what was
+/// WRITTEN — the caller compares it against the log's committed digest
+/// and deletes the file on mismatch (fail closed).
+pub(crate) async fn download_release_asset_to_file(
+    url: &str,
+    dest: &Path,
+    byte_cap: usize,
+) -> Result<String, String> {
+    use futures_util::StreamExt as _;
+    use tokio::io::AsyncWriteExt as _;
+
+    let client = release_download_client()?;
+    let url = Url::parse(url).map_err(|e| format!("asset URL {url}: {e}"))?;
+    let response = tokio::time::timeout(ARTIFACT_RESPONSE_TIMEOUT, client.get(url.clone()).send())
+        .await
+        .map_err(|_| format!("GET {url}: response headers timed out"))?
+        .map_err(|e| format!("GET {url}: {e}"))?;
+    let status = response.status();
+    if !status.is_success() {
+        return Err(format!("GET {url}: HTTP {status}"));
+    }
+    if response
+        .content_length()
+        .is_some_and(|length| length > byte_cap as u64)
+    {
+        return Err(format!("GET {url}: response exceeds {byte_cap} bytes"));
+    }
+    let mut file = tokio::fs::File::create(dest)
+        .await
+        .map_err(|e| format!("create {}: {e}", dest.display()))?;
+    let mut hasher = Sha256::new();
+    let mut total = 0usize;
+    let mut stream = response.bytes_stream();
+    loop {
+        let chunk = tokio::time::timeout(ARTIFACT_IDLE_TIMEOUT, stream.next())
+            .await
+            .map_err(|_| format!("GET {url}: response body became idle"))?;
+        let Some(chunk) = chunk else { break };
+        let chunk = chunk.map_err(|e| format!("GET {url}: {e}"))?;
+        total = total.saturating_add(chunk.len());
+        if total > byte_cap {
+            drop(file);
+            let _ = tokio::fs::remove_file(dest).await;
+            return Err(format!("GET {url}: response exceeds {byte_cap} bytes"));
+        }
+        hasher.update(&chunk);
+        file.write_all(&chunk)
+            .await
+            .map_err(|e| format!("write {}: {e}", dest.display()))?;
+    }
+    file.flush()
+        .await
+        .map_err(|e| format!("flush {}: {e}", dest.display()))?;
+    let digest: [u8; 32] = hasher.finalize().into();
+    Ok(digest.iter().map(|byte| format!("{byte:02x}")).collect())
 }
 
 // ── The daemon tripwire (advisory, fail-open; the CT tripwire's rhyme) ──
@@ -4507,5 +4598,46 @@ mod tests {
         assert!(!waiting.is_finished());
         drop(first);
         waiting.await.unwrap();
+    }
+
+    /// The self-update lane's fetch edge: bytes stream to the file while
+    /// hashing (the returned digest is of what was WRITTEN), and the
+    /// byte cap refuses oversize bodies, deleting the partial file —
+    /// the update lane's fail-closed download seam.
+    #[tokio::test]
+    async fn release_asset_download_writes_and_hashes_exactly() {
+        let payload: &[u8] = b"release artifact bytes";
+        let router = axum::Router::new().route(
+            "/asset.zip",
+            axum::routing::get(|| async { payload.to_vec() }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, router).await.ok() });
+
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("asset.zip");
+        let sha = download_release_asset_to_file(
+            &format!("http://{addr}/asset.zip"),
+            &dest,
+            1024,
+        )
+        .await
+        .expect("download succeeds");
+        assert_eq!(sha, sha256_hex(payload), "digest is of the written bytes");
+        assert_eq!(std::fs::read(&dest).unwrap(), payload);
+
+        let capped = download_release_asset_to_file(
+            &format!("http://{addr}/asset.zip"),
+            &dir.path().join("capped.zip"),
+            4,
+        )
+        .await;
+        assert!(capped.is_err(), "over-cap bodies refuse");
+        assert!(
+            !dir.path().join("capped.zip").exists(),
+            "a refused download leaves no partial bytes behind"
+        );
+        server.abort();
     }
 }

--- a/src/bin/caller/startup/wiring.rs
+++ b/src/bin/caller/startup/wiring.rs
@@ -344,6 +344,11 @@ pub(crate) fn spawn_mode_web_gateway(
     // the handover status payload + ONE deduped notification per
     // distinct on-disk sha.
     crate::handover::spawn_update_watch(handover.clone());
+    // The self-update lane (the PRODUCE half): bounded behind-main /
+    // behind-latest-release checks, and the owner-click produce job
+    // (supervised children; fail-closed verify) that lands a newer
+    // binary at the watched path for the chip/one-click swap above.
+    crate::handover::spawn_update_lane(&handover);
     // --takeover (Track HS3): this boot is the intended successor — ask
     // the current holder to drain, then fast-poll the freed lease.
     // Detached; bounded; failure degrades to ordinary secondary polling.

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -1256,6 +1256,26 @@ pub(crate) async fn serve_http_request(
                 )
                 .await;
             }
+            RouteHandlerId::DaemonUpdateLaneCheck => {
+                return handle_daemon_update_lane(
+                    stream,
+                    false,
+                    mcp_server,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
+            }
+            RouteHandlerId::DaemonUpdateLaneProduce => {
+                return handle_daemon_update_lane(
+                    stream,
+                    true,
+                    mcp_server,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
+            }
             RouteHandlerId::AgendaOp => {
                 // The authenticated edge: the pre-dispatch IAM gate bound
                 // this principal; no token names a session on this lane.

--- a/src/bin/caller/web_gateway/routes_handover.rs
+++ b/src/bin/caller/web_gateway/routes_handover.rs
@@ -101,3 +101,58 @@ pub(crate) async fn handle_daemon_handover_status(
     let response = daemon_handover_status_api_response(mcp_server.as_ref()).await;
     write_api_response(stream, response, cors, fleet_origin).await;
 }
+
+/// Transport-neutral core of the two self-update-lane actions (`POST
+/// /api/daemon/update-lane/{check,produce}`). Check runs the bounded
+/// behind-ness compare; produce is the owner's consent click — it
+/// starts the supervised produce job (or refuses honestly: no lane for
+/// this install, a job already running, an unsupported platform). Both
+/// answer the lane's fresh status block so the panel renders truth
+/// immediately.
+pub(crate) async fn daemon_update_lane_api_response(
+    produce: bool,
+    mcp_server: Option<&Arc<crate::mcp::IntendantServer>>,
+) -> ApiResponse {
+    let runtime = match mcp_server {
+        Some(server) => server.handover_runtime().await,
+        None => None,
+    };
+    let lane = runtime.as_ref().and_then(|runtime| runtime.update_lane());
+    let Some(lane) = lane else {
+        return ApiResponse::json_error(503, "the self-update lane is not wired on this daemon");
+    };
+    if produce {
+        match lane.request_produce() {
+            Ok(block) => ApiResponse::json(
+                200,
+                JsonBody::Value(serde_json::json!({ "started": true, "update_lane": block })),
+            ),
+            Err(refusal) => ApiResponse::json(
+                409,
+                JsonBody::Value(serde_json::json!({
+                    "error": "update_lane_refused",
+                    "detail": refusal,
+                    "update_lane": lane.status_block(),
+                })),
+            ),
+        }
+    } else {
+        let block = lane.request_check();
+        ApiResponse::json(
+            200,
+            JsonBody::Value(serde_json::json!({ "started": true, "update_lane": block })),
+        )
+    }
+}
+
+/// `POST /api/daemon/update-lane/{check,produce}` — the HTTP wrappers.
+pub(crate) async fn handle_daemon_update_lane(
+    stream: DemuxStream,
+    produce: bool,
+    mcp_server: Option<Arc<crate::mcp::IntendantServer>>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
+) {
+    let response = daemon_update_lane_api_response(produce, mcp_server.as_ref()).await;
+    write_api_response(stream, response, cors, fleet_origin).await;
+}

--- a/static/app.html
+++ b/static/app.html
@@ -27062,6 +27062,87 @@ html.ui-v2 .handover-update-note {
   font-size: 11px;
   color: var(--muted, #7e8896);
 }
+
+/* ── self-update panel (Access → Daemons): the PRODUCE half — flavor,
+   behind-ness, the consent buttons, and the job's live log tail. Same
+   family as the update chip above; the chip stays the SWAP surface. ── */
+html.ui-v2 .update-lane-card {
+  margin: 10px 0 14px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  background: var(--surface1, rgba(40, 40, 48, 0.96));
+  border: 1px solid var(--surface2, rgba(90, 90, 104, 0.5));
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--text, #e6e6e6);
+}
+html.ui-v2 .update-lane-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+html.ui-v2 .update-lane-flavor {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 1px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--surface2, rgba(90, 90, 104, 0.5));
+  color: var(--muted, #7e8896);
+}
+html.ui-v2 .update-lane-body {
+  margin-top: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+html.ui-v2 .update-lane-status {
+  color: var(--text, #e6e6e6);
+  font-weight: 600;
+}
+html.ui-v2 .update-lane-note {
+  font-size: 11px;
+  color: var(--muted, #7e8896);
+}
+html.ui-v2 .update-lane-done {
+  font-size: 11px;
+  color: var(--success, #57e389);
+}
+html.ui-v2 .update-lane-error {
+  font-size: 11px;
+  color: var(--error, #ff7b63);
+}
+html.ui-v2 .update-lane-log {
+  margin: 4px 0 0;
+  padding: 6px 8px;
+  max-height: 140px;
+  overflow-y: auto;
+  border-radius: 6px;
+  background: var(--surface0, rgba(24, 24, 30, 0.9));
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 10px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--muted, #9aa4b2);
+}
+html.ui-v2 .update-lane-actions {
+  margin-top: 8px;
+  display: flex;
+  gap: 8px;
+}
+html.ui-v2 .update-lane-btn {
+  padding: 3px 12px;
+  border: 1px solid var(--accent, #62a0ea);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--accent, #62a0ea);
+  font-size: 12px;
+  cursor: pointer;
+}
+html.ui-v2 .update-lane-btn:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
 /* ── static/app/ui2-grid.css ── */
 /* ── ui-v2 Activity Grid mode: lineage lanes + session-window re-skin ──
    All scoped html.ui-v2. Grid layout (ratified 2026-07-21, candidate B
@@ -33767,6 +33848,7 @@ html.ui-v2 .ui2-tsw-foot .ui2-tsw-row:hover { color: var(--text); }
               </div>
             </div>
             <div id="access-target-overview" class="access-target-surface"></div>
+            <div id="update-lane-card"></div>
             <details class="acc-fold" id="access-peer-controls-fold">
               <summary>Peer messaging &amp; quick controls</summary>
               <div class="acc-fold-body">
@@ -37605,7 +37687,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '47d4d928f643b7fc';
+const INTENDANT_APP_BUILD = '6bb667345321cb68';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -100822,6 +100904,232 @@ async function memoryProposeFromForm(button) {
     document.addEventListener('DOMContentLoaded', handoverStart);
   } else {
     handoverStart();
+  }
+})();
+/* ── static/app/ui2-update-lane.js ── */
+// ── ui2-update-lane — the self-update panel (Access → Daemons) ──────
+// Sits beside the daemons list's provenance rows and renders the
+// daemon's `update_lane` block from GET /api/daemon/handover: install
+// flavor, the bounded behind-origin-main / behind-latest-release check,
+// and the produce job's live phase + log tail. The buttons are the
+// owner's consent surface: POST /api/daemon/update-lane/{check,produce}
+// (HTTP-only by design — a tunnel-only remote surface watches progress
+// here but cannot click a build onto the box; the catch renders that
+// honestly). Producing lands a newer binary at the watched path; the
+// EXISTING update chip + one-click swap lane takes over from there.
+// textContent construction throughout: repo paths, versions, and child
+// process log lines are observed strings, never markup.
+(() => {
+  const UPDATE_LANE_POLL_MS = 30000;
+  const UPDATE_LANE_BUSY_POLL_MS = 3000;
+  const action = { inFlight: false, note: '' };
+  let lastBlock = null;
+  let pollTimer = null;
+
+  function updateLaneMount() {
+    return document.getElementById('update-lane-card');
+  }
+
+  async function updateLanePost(path) {
+    if (action.inFlight) return;
+    action.inFlight = true;
+    action.note = '';
+    render(lastBlock);
+    try {
+      const resp = await authedFetch(path, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+      });
+      let body = null;
+      try { body = await resp.json(); } catch (_) { /* non-JSON error body */ }
+      if (body && body.update_lane) lastBlock = body.update_lane;
+      if (!resp.ok) {
+        action.note = (body && body.detail)
+          ? body.detail
+          : `This surface cannot reach the update lane (HTTP ${resp.status}).`;
+      }
+    } catch (err) {
+      action.note = `This surface cannot reach the update lane: ${(err && err.message) || err}`;
+    } finally {
+      action.inFlight = false;
+      render(lastBlock);
+      schedulePoll(true);
+    }
+  }
+
+  function actionButton(label, path, disabled) {
+    const btn = document.createElement('button');
+    btn.className = 'update-lane-btn';
+    btn.textContent = label;
+    btn.disabled = Boolean(disabled) || action.inFlight;
+    btn.addEventListener('click', () => updateLanePost(path));
+    return btn;
+  }
+
+  function line(parent, cls, text) {
+    const el = document.createElement('div');
+    el.className = cls;
+    el.textContent = text;
+    parent.appendChild(el);
+    return el;
+  }
+
+  function describeCheck(block, body) {
+    const check = block.check || {};
+    const running = block.running || {};
+    if (check.error) {
+      line(body, 'update-lane-error', `Check failed: ${check.error}`);
+      return { behind: false };
+    }
+    if (block.flavor === 'source') {
+      if (typeof check.behind !== 'number') {
+        line(body, 'update-lane-note', check.in_flight
+          ? 'Checking origin/main…'
+          : 'Not checked yet.');
+        return { behind: false };
+      }
+      const capped = check.behind_capped ? '+' : '';
+      if (check.behind > 0) {
+        line(body, 'update-lane-status',
+          `Behind origin/main by ${check.behind}${capped} commit${check.behind === 1 ? '' : 's'} `
+          + `(tip ${String(check.tip_sha || '').slice(0, 10)} — running ${running.git_sha || '?'}).`);
+      } else {
+        line(body, 'update-lane-note',
+          `Up to date with origin/main (running ${running.git_sha || '?'}).`);
+      }
+      if (check.dirty) {
+        line(body, 'update-lane-note',
+          'The checkout has local changes — the update will refuse to pull over them.');
+      }
+      return { behind: check.behind > 0 };
+    }
+    if (block.flavor === 'consumer-app') {
+      if (!check.latest_tag) {
+        line(body, 'update-lane-note', check.in_flight
+          ? 'Checking the latest logged release…'
+          : 'Not checked yet.');
+        return { behind: false };
+      }
+      const behind = Number(check.behind) > 0;
+      line(body, behind ? 'update-lane-status' : 'update-lane-note',
+        `Latest logged release: ${check.latest_tag} (${check.latest_version}) — running ${running.version || '?'}.`
+        + (check.compare_error ? ` ${check.compare_error}.` : ''));
+      return { behind };
+    }
+    return { behind: false };
+  }
+
+  function describeJob(block, body) {
+    const job = block.job;
+    if (!job) return false;
+    const runningJob = !('ok' in job);
+    if (runningJob) {
+      line(body, 'update-lane-status',
+        `${job.lane === 'source' ? 'Building from main' : 'Downloading release'} — ${job.phase}…`);
+    } else if (job.ok) {
+      line(body, 'update-lane-done', job.detail || 'Update produced.');
+    } else {
+      line(body, 'update-lane-error', `Update failed: ${job.error || 'see the daemon log'}. The running daemon is untouched.`);
+    }
+    const tail = Array.isArray(job.log_tail) ? job.log_tail.slice(-8) : [];
+    if (tail.length && (runningJob || !job.ok)) {
+      const log = document.createElement('pre');
+      log.className = 'update-lane-log';
+      log.textContent = tail.join('\n');
+      body.appendChild(log);
+    }
+    return runningJob;
+  }
+
+  function render(block) {
+    const mount = updateLaneMount();
+    if (!mount) return;
+    lastBlock = block;
+    mount.textContent = '';
+    if (!block) return;
+    const card = document.createElement('div');
+    card.className = 'update-lane-card';
+    const head = document.createElement('div');
+    head.className = 'update-lane-head';
+    const title = document.createElement('strong');
+    title.textContent = 'Daemon update';
+    head.appendChild(title);
+    const flavorChip = document.createElement('span');
+    flavorChip.className = 'update-lane-flavor';
+    flavorChip.textContent = block.flavor === 'source'
+      ? 'source install'
+      : block.flavor === 'consumer-app' ? 'release install' : 'unmanaged';
+    head.appendChild(flavorChip);
+    card.appendChild(head);
+
+    const body = document.createElement('div');
+    body.className = 'update-lane-body';
+    if (block.flavor === 'source' && block.repo_root) {
+      line(body, 'update-lane-note', `Checkout: ${block.repo_root}${block.app_bundle ? ' (app bundle)' : ''}`);
+    } else if (block.flavor === 'consumer-app' && block.app_root) {
+      line(body, 'update-lane-note', `Installed app: ${block.app_root}`);
+    }
+    if (block.unavailable) {
+      line(body, 'update-lane-note', block.unavailable);
+    }
+
+    const verdict = describeCheck(block, body);
+    const jobRunning = describeJob(block, body);
+
+    if (action.note) line(body, 'update-lane-note', action.note);
+
+    const actions = document.createElement('div');
+    actions.className = 'update-lane-actions';
+    if (!block.unavailable) {
+      if (block.flavor === 'source') {
+        actions.appendChild(actionButton(
+          jobRunning ? 'Updating…' : 'Update from main',
+          '/api/daemon/update-lane/produce',
+          jobRunning || !verdict.behind,
+        ));
+      } else if (block.flavor === 'consumer-app') {
+        actions.appendChild(actionButton(
+          jobRunning ? 'Updating…' : 'Download & verify release',
+          '/api/daemon/update-lane/produce',
+          jobRunning || !verdict.behind,
+        ));
+      }
+      actions.appendChild(actionButton('Check now', '/api/daemon/update-lane/check',
+        jobRunning || Boolean(block.check && block.check.in_flight)));
+    }
+    card.appendChild(body);
+    if (actions.childElementCount) card.appendChild(actions);
+    mount.appendChild(card);
+  }
+
+  async function poll() {
+    try {
+      if (typeof daemonApi === 'undefined') return;
+      if (!daemonApi.availability('api_daemon_handover').ok) return;
+      const resp = await daemonApi.request('api_daemon_handover', {});
+      if (resp && resp.ok && resp.body) render(resp.body.update_lane || null);
+    } catch (_) { /* transient — keep the last render */ }
+  }
+
+  function schedulePoll(immediate) {
+    if (pollTimer) clearTimeout(pollTimer);
+    const busy = Boolean(lastBlock && (
+      (lastBlock.job && !('ok' in lastBlock.job)) ||
+      (lastBlock.check && lastBlock.check.in_flight)));
+    pollTimer = setTimeout(async () => {
+      await poll();
+      schedulePoll(false);
+    }, immediate ? 400 : (busy ? UPDATE_LANE_BUSY_POLL_MS : UPDATE_LANE_POLL_MS));
+  }
+
+  function start() {
+    poll().then(() => schedulePoll(false));
+  }
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start);
+  } else {
+    start();
   }
 })();
 /* ── static/app/ui2-cloud-workers.js ── */

--- a/static/app/21-access-dialogs.html
+++ b/static/app/21-access-dialogs.html
@@ -27,6 +27,7 @@
               </div>
             </div>
             <div id="access-target-overview" class="access-target-surface"></div>
+            <div id="update-lane-card"></div>
             <details class="acc-fold" id="access-peer-controls-fold">
               <summary>Peer messaging &amp; quick controls</summary>
               <div class="acc-fold-body">

--- a/static/app/manifest.txt
+++ b/static/app/manifest.txt
@@ -111,6 +111,7 @@ ui2-agenda-seals.js
 # module-level lets. Top level declares only lets/functions.
 ui2-memory.js
 ui2-handover.js
+ui2-update-lane.js
 # Cloud workers: same deep-link TDZ rule — a #sessions/cloud deep link makes
 # the router's eval-time boot call cloudWorkersOnShown(), which reads this
 # fragment's module-level lets. Top level declares only lets/consts/functions.

--- a/static/app/ui2-handover.css
+++ b/static/app/ui2-handover.css
@@ -77,3 +77,84 @@ html.ui-v2 .handover-update-note {
   font-size: 11px;
   color: var(--muted, #7e8896);
 }
+
+/* ── self-update panel (Access → Daemons): the PRODUCE half — flavor,
+   behind-ness, the consent buttons, and the job's live log tail. Same
+   family as the update chip above; the chip stays the SWAP surface. ── */
+html.ui-v2 .update-lane-card {
+  margin: 10px 0 14px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  background: var(--surface1, rgba(40, 40, 48, 0.96));
+  border: 1px solid var(--surface2, rgba(90, 90, 104, 0.5));
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--text, #e6e6e6);
+}
+html.ui-v2 .update-lane-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+html.ui-v2 .update-lane-flavor {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 1px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--surface2, rgba(90, 90, 104, 0.5));
+  color: var(--muted, #7e8896);
+}
+html.ui-v2 .update-lane-body {
+  margin-top: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+html.ui-v2 .update-lane-status {
+  color: var(--text, #e6e6e6);
+  font-weight: 600;
+}
+html.ui-v2 .update-lane-note {
+  font-size: 11px;
+  color: var(--muted, #7e8896);
+}
+html.ui-v2 .update-lane-done {
+  font-size: 11px;
+  color: var(--success, #57e389);
+}
+html.ui-v2 .update-lane-error {
+  font-size: 11px;
+  color: var(--error, #ff7b63);
+}
+html.ui-v2 .update-lane-log {
+  margin: 4px 0 0;
+  padding: 6px 8px;
+  max-height: 140px;
+  overflow-y: auto;
+  border-radius: 6px;
+  background: var(--surface0, rgba(24, 24, 30, 0.9));
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 10px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--muted, #9aa4b2);
+}
+html.ui-v2 .update-lane-actions {
+  margin-top: 8px;
+  display: flex;
+  gap: 8px;
+}
+html.ui-v2 .update-lane-btn {
+  padding: 3px 12px;
+  border: 1px solid var(--accent, #62a0ea);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--accent, #62a0ea);
+  font-size: 12px;
+  cursor: pointer;
+}
+html.ui-v2 .update-lane-btn:disabled {
+  opacity: 0.55;
+  cursor: default;
+}

--- a/static/app/ui2-update-lane.js
+++ b/static/app/ui2-update-lane.js
@@ -1,0 +1,225 @@
+// ── ui2-update-lane — the self-update panel (Access → Daemons) ──────
+// Sits beside the daemons list's provenance rows and renders the
+// daemon's `update_lane` block from GET /api/daemon/handover: install
+// flavor, the bounded behind-origin-main / behind-latest-release check,
+// and the produce job's live phase + log tail. The buttons are the
+// owner's consent surface: POST /api/daemon/update-lane/{check,produce}
+// (HTTP-only by design — a tunnel-only remote surface watches progress
+// here but cannot click a build onto the box; the catch renders that
+// honestly). Producing lands a newer binary at the watched path; the
+// EXISTING update chip + one-click swap lane takes over from there.
+// textContent construction throughout: repo paths, versions, and child
+// process log lines are observed strings, never markup.
+(() => {
+  const UPDATE_LANE_POLL_MS = 30000;
+  const UPDATE_LANE_BUSY_POLL_MS = 3000;
+  const action = { inFlight: false, note: '' };
+  let lastBlock = null;
+  let pollTimer = null;
+
+  function updateLaneMount() {
+    return document.getElementById('update-lane-card');
+  }
+
+  async function updateLanePost(path) {
+    if (action.inFlight) return;
+    action.inFlight = true;
+    action.note = '';
+    render(lastBlock);
+    try {
+      const resp = await authedFetch(path, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+      });
+      let body = null;
+      try { body = await resp.json(); } catch (_) { /* non-JSON error body */ }
+      if (body && body.update_lane) lastBlock = body.update_lane;
+      if (!resp.ok) {
+        action.note = (body && body.detail)
+          ? body.detail
+          : `This surface cannot reach the update lane (HTTP ${resp.status}).`;
+      }
+    } catch (err) {
+      action.note = `This surface cannot reach the update lane: ${(err && err.message) || err}`;
+    } finally {
+      action.inFlight = false;
+      render(lastBlock);
+      schedulePoll(true);
+    }
+  }
+
+  function actionButton(label, path, disabled) {
+    const btn = document.createElement('button');
+    btn.className = 'update-lane-btn';
+    btn.textContent = label;
+    btn.disabled = Boolean(disabled) || action.inFlight;
+    btn.addEventListener('click', () => updateLanePost(path));
+    return btn;
+  }
+
+  function line(parent, cls, text) {
+    const el = document.createElement('div');
+    el.className = cls;
+    el.textContent = text;
+    parent.appendChild(el);
+    return el;
+  }
+
+  function describeCheck(block, body) {
+    const check = block.check || {};
+    const running = block.running || {};
+    if (check.error) {
+      line(body, 'update-lane-error', `Check failed: ${check.error}`);
+      return { behind: false };
+    }
+    if (block.flavor === 'source') {
+      if (typeof check.behind !== 'number') {
+        line(body, 'update-lane-note', check.in_flight
+          ? 'Checking origin/main…'
+          : 'Not checked yet.');
+        return { behind: false };
+      }
+      const capped = check.behind_capped ? '+' : '';
+      if (check.behind > 0) {
+        line(body, 'update-lane-status',
+          `Behind origin/main by ${check.behind}${capped} commit${check.behind === 1 ? '' : 's'} `
+          + `(tip ${String(check.tip_sha || '').slice(0, 10)} — running ${running.git_sha || '?'}).`);
+      } else {
+        line(body, 'update-lane-note',
+          `Up to date with origin/main (running ${running.git_sha || '?'}).`);
+      }
+      if (check.dirty) {
+        line(body, 'update-lane-note',
+          'The checkout has local changes — the update will refuse to pull over them.');
+      }
+      return { behind: check.behind > 0 };
+    }
+    if (block.flavor === 'consumer-app') {
+      if (!check.latest_tag) {
+        line(body, 'update-lane-note', check.in_flight
+          ? 'Checking the latest logged release…'
+          : 'Not checked yet.');
+        return { behind: false };
+      }
+      const behind = Number(check.behind) > 0;
+      line(body, behind ? 'update-lane-status' : 'update-lane-note',
+        `Latest logged release: ${check.latest_tag} (${check.latest_version}) — running ${running.version || '?'}.`
+        + (check.compare_error ? ` ${check.compare_error}.` : ''));
+      return { behind };
+    }
+    return { behind: false };
+  }
+
+  function describeJob(block, body) {
+    const job = block.job;
+    if (!job) return false;
+    const runningJob = !('ok' in job);
+    if (runningJob) {
+      line(body, 'update-lane-status',
+        `${job.lane === 'source' ? 'Building from main' : 'Downloading release'} — ${job.phase}…`);
+    } else if (job.ok) {
+      line(body, 'update-lane-done', job.detail || 'Update produced.');
+    } else {
+      line(body, 'update-lane-error', `Update failed: ${job.error || 'see the daemon log'}. The running daemon is untouched.`);
+    }
+    const tail = Array.isArray(job.log_tail) ? job.log_tail.slice(-8) : [];
+    if (tail.length && (runningJob || !job.ok)) {
+      const log = document.createElement('pre');
+      log.className = 'update-lane-log';
+      log.textContent = tail.join('\n');
+      body.appendChild(log);
+    }
+    return runningJob;
+  }
+
+  function render(block) {
+    const mount = updateLaneMount();
+    if (!mount) return;
+    lastBlock = block;
+    mount.textContent = '';
+    if (!block) return;
+    const card = document.createElement('div');
+    card.className = 'update-lane-card';
+    const head = document.createElement('div');
+    head.className = 'update-lane-head';
+    const title = document.createElement('strong');
+    title.textContent = 'Daemon update';
+    head.appendChild(title);
+    const flavorChip = document.createElement('span');
+    flavorChip.className = 'update-lane-flavor';
+    flavorChip.textContent = block.flavor === 'source'
+      ? 'source install'
+      : block.flavor === 'consumer-app' ? 'release install' : 'unmanaged';
+    head.appendChild(flavorChip);
+    card.appendChild(head);
+
+    const body = document.createElement('div');
+    body.className = 'update-lane-body';
+    if (block.flavor === 'source' && block.repo_root) {
+      line(body, 'update-lane-note', `Checkout: ${block.repo_root}${block.app_bundle ? ' (app bundle)' : ''}`);
+    } else if (block.flavor === 'consumer-app' && block.app_root) {
+      line(body, 'update-lane-note', `Installed app: ${block.app_root}`);
+    }
+    if (block.unavailable) {
+      line(body, 'update-lane-note', block.unavailable);
+    }
+
+    const verdict = describeCheck(block, body);
+    const jobRunning = describeJob(block, body);
+
+    if (action.note) line(body, 'update-lane-note', action.note);
+
+    const actions = document.createElement('div');
+    actions.className = 'update-lane-actions';
+    if (!block.unavailable) {
+      if (block.flavor === 'source') {
+        actions.appendChild(actionButton(
+          jobRunning ? 'Updating…' : 'Update from main',
+          '/api/daemon/update-lane/produce',
+          jobRunning || !verdict.behind,
+        ));
+      } else if (block.flavor === 'consumer-app') {
+        actions.appendChild(actionButton(
+          jobRunning ? 'Updating…' : 'Download & verify release',
+          '/api/daemon/update-lane/produce',
+          jobRunning || !verdict.behind,
+        ));
+      }
+      actions.appendChild(actionButton('Check now', '/api/daemon/update-lane/check',
+        jobRunning || Boolean(block.check && block.check.in_flight)));
+    }
+    card.appendChild(body);
+    if (actions.childElementCount) card.appendChild(actions);
+    mount.appendChild(card);
+  }
+
+  async function poll() {
+    try {
+      if (typeof daemonApi === 'undefined') return;
+      if (!daemonApi.availability('api_daemon_handover').ok) return;
+      const resp = await daemonApi.request('api_daemon_handover', {});
+      if (resp && resp.ok && resp.body) render(resp.body.update_lane || null);
+    } catch (_) { /* transient — keep the last render */ }
+  }
+
+  function schedulePoll(immediate) {
+    if (pollTimer) clearTimeout(pollTimer);
+    const busy = Boolean(lastBlock && (
+      (lastBlock.job && !('ok' in lastBlock.job)) ||
+      (lastBlock.check && lastBlock.check.in_flight)));
+    pollTimer = setTimeout(async () => {
+      await poll();
+      schedulePoll(false);
+    }, immediate ? 400 : (busy ? UPDATE_LANE_BUSY_POLL_MS : UPDATE_LANE_POLL_MS));
+  }
+
+  function start() {
+    poll().then(() => schedulePoll(false));
+  }
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start);
+  } else {
+    start();
+  }
+})();

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -7142,8 +7142,11 @@ async fn update_lane_source_click_produces_artifact_and_chips() {
     );
     std::fs::write(checkout.join("Cargo.toml"), "[workspace]\n").expect("seed Cargo.toml");
     std::fs::create_dir_all(checkout.join("scripts")).expect("seed scripts dir");
-    std::fs::write(checkout.join("scripts").join("bundle-macos.sh"), "#!/bin/bash\n")
-        .expect("seed bundle script");
+    std::fs::write(
+        checkout.join("scripts").join("bundle-macos.sh"),
+        "#!/bin/bash\n",
+    )
+    .expect("seed bundle script");
     fixture_git(&checkout, &["add", "."]);
     fixture_git(&checkout, &["commit", "-m", "commit A"]);
     fixture_git(&checkout, &["push", "origin", "main"]);
@@ -7306,6 +7309,10 @@ async fn update_lane_source_click_produces_artifact_and_chips() {
     )
     .await;
     // Zero kills: the same boot answers, undrained, end to end.
-    assert_eq!(body["boot_id"], boot_id.as_str(), "same daemon boot: {body}");
+    assert_eq!(
+        body["boot_id"],
+        boot_id.as_str(),
+        "same daemon boot: {body}"
+    );
     assert_eq!(body["draining"], false);
 }

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -7141,6 +7141,7 @@ async fn update_lane_source_click_produces_artifact_and_chips() {
         &["clone", origin.to_str().expect("utf8"), "checkout"],
     );
     std::fs::write(checkout.join("Cargo.toml"), "[workspace]\n").expect("seed Cargo.toml");
+    std::fs::write(checkout.join(".gitignore"), "/target\n").expect("seed gitignore");
     std::fs::create_dir_all(checkout.join("scripts")).expect("seed scripts dir");
     std::fs::write(
         checkout.join("scripts").join("bundle-macos.sh"),

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -7078,3 +7078,234 @@ async fn update_surface_probes_swapped_binary_and_serves_the_chip_block() {
         "the running provenance rides beside the on-disk build: {body}"
     );
 }
+
+/// Run one git command in the update-lane fixture repos, with a pinned
+/// identity so commits work on a bare CI account.
+#[cfg(unix)]
+fn fixture_git(cwd: &std::path::Path, args: &[&str]) -> String {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args([
+            "-c",
+            "user.name=e2e",
+            "-c",
+            "user.email=e2e@example.invalid",
+            "-c",
+            "commit.gpgsign=false",
+            "-c",
+            "init.defaultBranch=main",
+        ])
+        .args(args)
+        .output()
+        .expect("run fixture git");
+    assert!(
+        output.status.success(),
+        "fixture git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+/// The self-update lane's source leg (commission
+/// 01KYSWZC7BBPJGT48G9WYFF7J3 acceptance): a daemon whose running build
+/// is behind origin/main runs the bounded compare, the owner's click
+/// produces the artifact — REAL `git pull --ff-only` against a local
+/// origin, the build stubbed by the mock-gated
+/// `INTENDANT_UPDATE_LANE_BUILD_CMD` (a cargo build is not payable in
+/// CI) landing a new probe-able image at the watched path — and the
+/// EXISTING update watch then serves the chip block for the shipped
+/// one-click swap lane (whose drain half `drainer_exits_at_last_
+/// session_end` proves). Zero kills: the daemon's boot_id answers
+/// unchanged, undrained, through the whole flow. Unix-gated like its
+/// sibling (shebang-exec fakes).
+#[cfg(unix)]
+#[tokio::test]
+async fn update_lane_source_click_produces_artifact_and_chips() {
+    let client = reqwest::Client::new();
+    let rig = TestRig::new();
+    std::fs::write(rig.project.path().join("intendant.toml"), "")
+        .expect("mark the rig's project root");
+    rig.write_script(&serde_json::json!({ "profiles": [] }));
+
+    // A real origin one commit ahead of the checkout: clone, seed the
+    // buildable-checkout shape, push commit A; commit B lands on origin
+    // through a second clone, so the checkout itself never sees it
+    // until the lane's own fetch/pull.
+    let origin = rig.home.path().join("origin.git");
+    std::fs::create_dir_all(&origin).expect("origin dir");
+    fixture_git(&origin, &["init", "--bare", "--initial-branch=main", "."]);
+    let checkout = rig.home.path().join("checkout");
+    fixture_git(
+        rig.home.path(),
+        &["clone", origin.to_str().expect("utf8"), "checkout"],
+    );
+    std::fs::write(checkout.join("Cargo.toml"), "[workspace]\n").expect("seed Cargo.toml");
+    std::fs::create_dir_all(checkout.join("scripts")).expect("seed scripts dir");
+    std::fs::write(checkout.join("scripts").join("bundle-macos.sh"), "#!/bin/bash\n")
+        .expect("seed bundle script");
+    fixture_git(&checkout, &["add", "."]);
+    fixture_git(&checkout, &["commit", "-m", "commit A"]);
+    fixture_git(&checkout, &["push", "origin", "main"]);
+    let sha_a = fixture_git(&checkout, &["rev-parse", "HEAD"]);
+    let ahead = rig.home.path().join("ahead");
+    fixture_git(
+        rig.home.path(),
+        &["clone", origin.to_str().expect("utf8"), "ahead"],
+    );
+    std::fs::write(ahead.join("NEWS.md"), "commit B\n").expect("seed ahead change");
+    fixture_git(&ahead, &["add", "."]);
+    fixture_git(&ahead, &["commit", "-m", "commit B"]);
+    fixture_git(&ahead, &["push", "origin", "main"]);
+    let sha_b = fixture_git(&ahead, &["rev-parse", "HEAD"]);
+
+    // The "running" image sits at the checkout's release path (the
+    // watched path AND what makes flavor detection read "source"), and
+    // the mock build script stands in for cargo: it writes a NEW
+    // probe-able image there, exactly what a real build does.
+    let watched = checkout.join("target").join("release").join("intendant");
+    std::fs::create_dir_all(watched.parent().expect("target dir")).expect("target dirs");
+    write_fake_watched_binary(&watched, "fakesha1");
+    let build_cmd = rig.home.path().join("mock-build.sh");
+    std::fs::write(
+        &build_cmd,
+        "#!/bin/bash\necho building...\ncat > target/release/intendant << 'FAKE'\n#!/bin/sh\n\
+         echo \"intendant 9.9.10 (commit fakesha2, built 2026-07-30T00:00:00Z, e2e-fake-triple)\"\n\
+         FAKE\nchmod +x target/release/intendant\n",
+    )
+    .expect("write mock build script");
+
+    let daemon = spawn_co_daemon(
+        &client,
+        &rig,
+        "daemon.log",
+        &[
+            (
+                "INTENDANT_UPDATE_WATCH_PATH",
+                watched.to_str().expect("utf8 rig path"),
+            ),
+            ("INTENDANT_UPDATE_POLL_MS", "300"),
+            ("INTENDANT_UPDATE_LANE_RUNNING_SHA", sha_a.as_str()),
+            (
+                "INTENDANT_UPDATE_LANE_BUILD_CMD",
+                build_cmd.to_str().expect("utf8 rig path"),
+            ),
+            ("INTENDANT_UPDATE_LANE_HEADROOM", "ok"),
+        ],
+        &[],
+    )
+    .await;
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(
+        "x-intendant-loopback-token",
+        rig_loopback_token(&rig, daemon.port)
+            .parse()
+            .expect("token header value"),
+    );
+    let authed = reqwest::Client::builder()
+        .default_headers(headers)
+        .build()
+        .expect("build token-authed client");
+    let base = format!("http://127.0.0.1:{}", daemon.port);
+    let status_url = format!("{base}/api/daemon/handover");
+
+    // Flavor detected + no chip yet (the watched image is the boot one).
+    let body = http_get_json(&authed, &status_url)
+        .await
+        .expect("handover status body");
+    let boot_id = body["boot_id"].as_str().expect("boot id").to_string();
+    assert_eq!(body["update_lane"]["flavor"], "source", "{body}");
+    assert!(body.get("update").is_none(), "no chip before any change");
+
+    // The bounded compare: behind origin/main by exactly commit B.
+    let check: serde_json::Value = authed
+        .post(format!("{base}/api/daemon/update-lane/check"))
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .expect("POST update-lane check")
+        .error_for_status()
+        .expect("check accepted")
+        .json()
+        .await
+        .expect("check body");
+    assert_eq!(check["started"], true, "{check}");
+    let body = poll_until(
+        "the behind-main compare verdict",
+        RUN_TIMEOUT,
+        || async {
+            let body = http_get_json(&authed, &status_url).await?;
+            (body["update_lane"]["check"]["behind"] == 1).then_some(body)
+        },
+        || {
+            std::fs::read_to_string(rig.home.path().join("daemon.log"))
+                .map(|log| tail(&log, 3000))
+                .unwrap_or_default()
+        },
+    )
+    .await;
+    assert_eq!(
+        body["update_lane"]["check"]["tip_sha"], sha_b,
+        "the compare names origin/main's tip: {body}"
+    );
+    assert_eq!(body["update_lane"]["check"]["dirty"], false);
+
+    // The owner's click: pull (real) + build (mock) + verify. The job
+    // finishes ok and reports the produced commit.
+    let produce: serde_json::Value = authed
+        .post(format!("{base}/api/daemon/update-lane/produce"))
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .expect("POST update-lane produce")
+        .error_for_status()
+        .expect("produce accepted")
+        .json()
+        .await
+        .expect("produce body");
+    assert_eq!(produce["started"], true, "{produce}");
+    let body = poll_until(
+        "the produce job finishing ok",
+        RUN_TIMEOUT,
+        || async {
+            let body = http_get_json(&authed, &status_url).await?;
+            (body["update_lane"]["job"]["ok"] == true).then_some(body)
+        },
+        || {
+            std::fs::read_to_string(rig.home.path().join("daemon.log"))
+                .map(|log| tail(&log, 4000))
+                .unwrap_or_default()
+        },
+    )
+    .await;
+    assert!(
+        body["update_lane"]["job"]["detail"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("fakesha2"),
+        "the job reports the produced commit: {body}"
+    );
+    let pulled = fixture_git(&checkout, &["rev-parse", "HEAD"]);
+    assert_eq!(pulled, sha_b, "the pull really fast-forwarded the checkout");
+
+    // Hand-off: the EXISTING watch sees the produced image and serves
+    // the chip block — from here the shipped one-click swap lane owns
+    // the story.
+    let body = poll_until(
+        "the update chip naming the produced sha",
+        RUN_TIMEOUT,
+        || async {
+            let body = http_get_json(&authed, &status_url).await?;
+            (body["update"]["on_disk"]["git_sha"] == "fakesha2").then_some(body)
+        },
+        || {
+            std::fs::read_to_string(rig.home.path().join("daemon.log"))
+                .map(|log| tail(&log, 3000))
+                .unwrap_or_default()
+        },
+    )
+    .await;
+    // Zero kills: the same boot answers, undrained, end to end.
+    assert_eq!(body["boot_id"], boot_id.as_str(), "same daemon boot: {body}");
+    assert_eq!(body["draining"], false);
+}


### PR DESCRIPTION
Implements commission 01KYSWZC7BBPJGT48G9WYFF7J3 — the PRODUCE half of the update surface. Track HS shipped the swap half (watch, chip, one-per-sha notification, app one-click drain-swap); this adds the dashboard button that gets a NEWER binary onto disk on the owner's click, then hands off to that shipped lane.

## Source lane
- Install-flavor detection from the watched binary path: a checkout's `target/release` output, or an app bundle carrying the new `source-checkout` stamp `bundle-macos.sh` now writes (a stamp whose path is gone — a CI-built release app — falls down to the consumer lane).
- Bounded behind-`origin/main` compare: timeout-bounded fetch, `rev-list --count` capped at 500, dirtiness probe. Auto at boot + 12 h + on demand; compare only, never produces.
- Click ⇒ supervised children: `git pull --ff-only` (refuses dirty/diverged checkouts) + `cargo build --release` (plain) or `scripts/bundle-macos.sh` (app shape). Child env is a curated allowlist — provider/ambient credentials never leak, `RUSTC_WRAPPER` is never set so the box-wide governor stays engaged, and `CARGO_TARGET_DIR` is dropped so the artifact lands at the watched path.
- Headroom-gated (the capacity linkage): macOS `kern.memorystatus_vm_pressure_level` > 1 or Linux `MemAvailable` < 3 GiB refuses the build honestly.

## Consumer lane
- Latest-release check through the shipped PR-656 machinery (`hosted_verify`: inclusion proof, signed tree head, append-only pin, PGP identity/coverage, GitHub metadata) — fail closed on any divergence.
- Click ⇒ download the platform app zip + detached `.asc` (streamed to disk, hashed; sha256 must equal the LOG's committed digest), `gpg --verify` in a throwaway GNUPGHOME importing only the compiled-in release signing key (PR-671's pin; VALIDSIG primary fingerprint must match; gpg absent = refuse), probe the new app, swap it in with the old bundle kept as `.previous` (rollback on failure). Unverified bytes are always deleted.
- Auto-cadence follows the tripwire posture: unprompted consumer checks only when Connect is configured.

## Boundary (the commission's gate line)
The daemon never self-execs the build or fetch and never execs a successor: exec work runs as supervised, timeout-bounded, env-curated children with stdout/stderr streamed into the job's bounded log tail; the download rides the already-ruled hosted-verify fetch machinery. Produce and swap stay two honest phases; the owner's click is the only trigger — no auto-update.

## Surface
`Daemon update` panel in Access→Daemons beside the daemons list (new `ui2-update-lane` fragment): flavor, behind-ness, live phase + child-log tail, honest failures. Served in the `update_lane` block of `GET /api/daemon/handover`; actions are two owner-grade route-table rows `POST /api/daemon/update-lane/{check,produce}`, deliberately HTTP-only (no tunnel twins — remote tunnel-primary surfaces observe progress but cannot click a build onto the box; widening that is an owner trust decision).

## Tests
- Pinned seams: `fold_source_check`, semver compare, `headroom_gate`, platform probe folds, `select_release_asset` (arch map; dev-suffix + missing-.asc refusal), `download_verdict`, `gpg_verify_verdict` (VALIDSIG-primary pin), flavor detection, app swap + rollback, unmanaged-refusal, SPA artifact scan, route body caps.
- e2e rig leg `update_lane_source_click_produces_artifact_and_chips`: real local origin one commit ahead, real `git pull` by the daemon's child, mock-gated build stub (`INTENDANT_UPDATE_LANE_BUILD_CMD`, PROVIDER=mock only) landing a probe-able image at the watched path, chip served by the existing watch — same boot_id, undrained, zero kills. The drain-swap half stays proven by `drainer_exits_at_last_session_end`.
- `download_release_asset_to_file` fixture test (hash-of-written-bytes; cap refusal deletes partials).

Docs: the update-surface section of `control-plane-and-daemon.md` + endpoint table rows in `web-dashboard.md`.

Consumer-lane dry-run against a real release is blocked on the first real release existing (v0.1.0 cut awaits the two CI secrets — owner-owed); the verify seams are pinned and the fetch/verify machinery is the already-shipped hosted-verify code path.