### PR TITLE
agenda: propose-time fireability validation (one validator, missed-window card state, approve-gate)

### DIFF
--- a/docs/src/agenda-and-memory.md
+++ b/docs/src/agenda-and-memory.md
@@ -356,6 +356,49 @@ revoke them. Revising a manifest changes the digest and voids the previous
 approval. The spawned session gets ordinary session authority; the approval
 does not bypass its sandbox, IAM, autonomy policy, or action approvals.
 
+**Propose-time fireability (2026-07-30): an approvable manifest IS a
+fireable manifest.** One validator (`agenda/fireability.rs`, derived from
+`SessionManifest`'s own schema plus daemon state — a new manifest field
+fails the suite until its fireability class is declared) runs in the
+`propose_effect` intake arm, which every mint surface routes through —
+`ctl agenda schedule`, the dashboard's automate modal, the approval-time
+editor, and the stamp lane (each stamped node proposes through the same
+arm) — and runs again at `approve_effect`, the arm gate. Three legs,
+each mirroring what the fire path itself would refuse:
+
+- **Project** resolves NOW through the fire path's own chain — explicit
+  pin → the parking session's recorded root → the daemon default — and
+  the *resolution is recorded* on the digest-bound manifest, so the
+  approval covers WHERE. A projectless daemon that resolves nothing
+  refuses the propose by name, telling the caller exactly which flag to
+  add (`--project`; the sheet's Project field says "required" up front
+  from the same source).
+- **Executor** resolves (explicit selection → the daemon's default
+  backend → internal) and is recorded (`agent_config.agent`), with the
+  config validated *as recorded* — a pin contradicting the resolved
+  backend refuses at the mint instead of resolving surprisingly at fire
+  time. The approval names WHO runs, never empty-means-whatever.
+- **Floor** sanity mirrors the planner's missed rule (the reminder
+  policy's staleness bound): a one-shot whose window already passed, or
+  a series with no live instant left, refuses with the remedy named. A
+  triggered manifest's `fire_at_ms` is the arm floor and is never
+  floor-refused.
+
+Refusals carry the machine-readable grammar `unfireable(<field>): …`
+(field ∈ project/executor/floor — a pinned wire contract). The serving
+seam decorates pending and suspended effects with the same verdict
+(`fireability_refusal`, the `next_fire_ms` pattern: display-only, never
+folded), and the dashboard **never offers Approve or Re-arm against
+it** — the card offers **Fix plan…**, which opens the schedule sheet
+focused on the named field. Legacy pin-less manifests parked before the
+validator meet it at their next approve: the refusal surfaces as that
+same edit prompt, never a silent failure (the daemon-side class law is
+enforced in the approve intake regardless of frontend). A **missed
+window** (the floor passed while the daemon was down) is a
+self-explaining card state carrying its one-tap remedy — **Re-approve
+to reschedule** re-proposes the exact manifest with the floor moved to
+now and re-approves the fresh digest in one gesture.
+
 **The approval-time editor (owner-asked, 2026-07-29).** The pending
 card's **Edit…** opens the schedule sheet as a form over the manifest's
 owner-relevant fields — the goal text, the session **shape**

--- a/src/bin/caller/agenda/fireability.rs
+++ b/src/bin/caller/agenda/fireability.rs
@@ -1,0 +1,588 @@
+//! Propose-time fireability validation — THE one validator behind every
+//! manifest mint surface (CLI `agenda schedule`, the automate modal, the
+//! approval-time editor, the stamp lane) and the approve-time re-check.
+//!
+//! The principle (card 01KYSZAGQVHAAYS7BK9H3QFM3C): an approvable manifest
+//! IS a fireable manifest. Every contradiction the fire path would
+//! deterministically refuse — no resolvable project, a contradictory
+//! executor config, a floor whose window has already passed — is named at
+//! the mint, and named again at approve (the arm gate), instead of being
+//! discovered as an approved-but-dead card. Because the validation lives
+//! in the ProposeEffect intake arm ([`super::store`]'s `command_to_op`),
+//! which every mint surface routes through (the stamp lane proposes each
+//! node via the same arm), no surface can grow its own copy.
+//!
+//! Three legs, each derived from what the fire path itself does:
+//! - **project** — [`super::spawn_project::resolve_spawn_project`], the
+//!   SAME chain the scheduler dispatches through (explicit pin → the
+//!   parking session's recorded root → the daemon default → named
+//!   refusal). The chain is validated against, never narrowed: a
+//!   fallback-resolved root passes, and the resolution is RECORDED on the
+//!   manifest so the approval covers WHERE.
+//! - **executor** — [`crate::session_supervisor::validate_launch_config`]
+//!   over the config AS IT WILL BE RECORDED: an absent backend selection
+//!   resolves to the daemon default NOW and is written into the manifest
+//!   (`agent_config.agent`), so the owner approves a named executor
+//!   rather than empty-means-whatever-the-daemon-defaults-to-later — and
+//!   pins that contradict the resolved backend refuse at the mint
+//!   instead of resolving surprisingly at fire time.
+//! - **floor** — the planner's own missed rule mirrored
+//!   ([`super::reminders`]: a non-triggered instant more than the policy
+//!   staleness past due is `missed`, never fired): a one-shot whose
+//!   window has already passed, or a series with no live instant left,
+//!   refuses. A triggered manifest's `fire_at_ms` is the ARM FLOOR (T0
+//!   ruling 3) and is never floor-refused.
+//!
+//! Refusals carry a machine-readable grammar —
+//! `unfireable(<field>): <reason>` — so surfaces can map a refusal back
+//! to the offending editor field (the approval-time edit prompt) without
+//! a second vocabulary. [`fireability_schema_coverage`] pins the legs to
+//! the [`super::types::SessionManifest`] schemars schema: a new manifest
+//! field fails the parity test until its fireability class is declared.
+
+use super::spawn_project::{resolve_spawn_project, SessionSpawnContext, SpawnProjectSource};
+use super::types::{RecurrenceSpec, TriggerSpec};
+use crate::event::AgentLaunchConfig;
+use std::path::PathBuf;
+
+/// The manifest field a refusal names — the editor-focus vocabulary every
+/// surface shares (the sched sheet focuses this field on an approve-time
+/// refusal).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FireabilityField {
+    Project,
+    Executor,
+    Floor,
+}
+
+impl FireabilityField {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            FireabilityField::Project => "project",
+            FireabilityField::Executor => "executor",
+            FireabilityField::Floor => "floor",
+        }
+    }
+}
+
+/// The stable machine-readable head of every fireability refusal message:
+/// `unfireable(<field>): <reason>`. The SPA maps an approve-time refusal
+/// to the editor field by this grammar; changing it is a wire-contract
+/// change (pinned by `refusal_grammar_is_pinned` and the static-asset
+/// parity twin).
+pub(crate) const FIREABILITY_REFUSAL_PREFIX: &str = "unfireable(";
+
+/// One named fireability refusal: the offending field plus the reason.
+/// `message()` is the wire form (the grammar above); `field`/`reason`
+/// also ride the served [`FireabilityRefusalView`] so render surfaces
+/// never re-parse the grammar.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FireabilityRefusal {
+    pub(crate) field: FireabilityField,
+    pub(crate) reason: String,
+}
+
+impl FireabilityRefusal {
+    fn new(field: FireabilityField, reason: impl Into<String>) -> Self {
+        Self {
+            field,
+            reason: reason.into(),
+        }
+    }
+
+    /// The wire/CLI message: `unfireable(<field>): <reason>`.
+    pub(crate) fn message(&self) -> String {
+        format!(
+            "{}{}): {}",
+            FIREABILITY_REFUSAL_PREFIX,
+            self.field.as_str(),
+            self.reason
+        )
+    }
+
+    pub(crate) fn view(&self) -> FireabilityRefusalView {
+        FireabilityRefusalView {
+            field: self.field.as_str().to_string(),
+            reason: self.reason.clone(),
+        }
+    }
+}
+
+/// The served shape of a refusal — decorated onto pending/suspended
+/// effects at the serving seam (the `next_fire_ms` pattern: display-only,
+/// never folded, never stored) so the dashboard can withhold the Approve
+/// affordance and open the editor on the named field instead.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct FireabilityRefusalView {
+    /// `project` | `executor` | `floor` — the editor-focus key.
+    pub(crate) field: String,
+    /// Human reason, exactly the refusal the propose/approve lane would
+    /// state (minus the grammar head).
+    pub(crate) reason: String,
+}
+
+/// The manifest fields fireability reads — a borrow view so the propose
+/// intake (pre-manifest command fields) and the approve re-check (the
+/// stored manifest) share one validator without cloning.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct FireabilityCandidate<'a> {
+    pub(crate) fire_at_ms: u64,
+    pub(crate) recurrence: Option<&'a RecurrenceSpec>,
+    pub(crate) trigger: Option<&'a TriggerSpec>,
+    pub(crate) project_root: Option<&'a str>,
+    pub(crate) agent_config: Option<&'a AgentLaunchConfig>,
+}
+
+impl<'a> FireabilityCandidate<'a> {
+    /// The approve-time view of a stored manifest.
+    pub(crate) fn of_manifest(manifest: &'a super::types::SessionManifest) -> Self {
+        Self {
+            fire_at_ms: manifest.fire_at_ms,
+            recurrence: manifest.recurrence.as_ref(),
+            trigger: manifest.trigger.as_ref(),
+            project_root: manifest.project_root.as_deref(),
+            agent_config: manifest.agent_config.as_deref(),
+        }
+    }
+}
+
+/// What a passing validation resolved — the values the propose lane
+/// RECORDS onto the manifest (approve re-checks resolve too, but record
+/// nothing: an approval never rewrites the bytes it binds).
+#[derive(Debug, Clone)]
+pub(crate) struct FireabilityResolution {
+    /// The concrete project root the spawn will run under.
+    pub(crate) project_root: PathBuf,
+    pub(crate) project_source: SpawnProjectSource,
+    /// The effective executor backend (`internal`, `codex`, …): the
+    /// explicit `agent_config.agent` when given, else the daemon default
+    /// at this instant — the value the propose lane records.
+    pub(crate) agent: String,
+}
+
+/// Validate one manifest candidate against the daemon's current state.
+/// `provenance_session` is the parking session (item provenance) the
+/// project chain may resolve through; `staleness_ms` is the reminder
+/// policy's missed-window bound (the SAME bound the planner classifies
+/// missed sessions with); `now_ms` is the validation instant — propose
+/// time at the mint, approve time at the arm gate.
+pub(crate) fn validate(
+    candidate: FireabilityCandidate<'_>,
+    provenance_session: Option<&str>,
+    ctx: &SessionSpawnContext,
+    staleness_ms: u64,
+    now_ms: u64,
+) -> Result<FireabilityResolution, FireabilityRefusal> {
+    let (project_root, project_source) = resolve_spawn_project(
+        candidate.project_root,
+        provenance_session,
+        ctx,
+    )
+    .map_err(|reason| FireabilityRefusal::new(FireabilityField::Project, reason))?;
+    let agent = validate_executor(candidate.agent_config, ctx)?;
+    validate_floor(&candidate, staleness_ms, now_ms)?;
+    Ok(FireabilityResolution {
+        project_root,
+        project_source,
+        agent,
+    })
+}
+
+/// The executor leg: resolve the effective backend (explicit selection →
+/// the daemon default → internal) and validate the config AS RESOLVED —
+/// the same launch-config authority the session supervisor enforces, run
+/// against the backend that will actually be recorded, so pins that
+/// contradict the resolved default refuse at the mint instead of
+/// resolving surprisingly at fire time.
+fn validate_executor(
+    config: Option<&AgentLaunchConfig>,
+    ctx: &SessionSpawnContext,
+) -> Result<String, FireabilityRefusal> {
+    let explicit = config
+        .and_then(|config| config.agent.as_deref())
+        .map(str::trim)
+        .filter(|agent| !agent.is_empty());
+    let agent = explicit
+        .or(ctx.default_agent.as_deref())
+        .unwrap_or("internal")
+        .to_string();
+    let mut resolved = config.cloned().unwrap_or_default();
+    resolved.agent = Some(agent.clone());
+    crate::session_supervisor::validate_launch_config(&resolved).map_err(|reason| {
+        let reason = if explicit.is_none() {
+            format!("{reason} (backend {agent:?} is this daemon's default — pin --agent to override it)")
+        } else {
+            reason
+        };
+        FireabilityRefusal::new(FireabilityField::Executor, reason)
+    })?;
+    Ok(agent)
+}
+
+/// The floor leg — the planner's missed rule, applied at the instant a
+/// human is deciding: a floor that already guarantees `missed` refuses
+/// with the remedy named. Triggered manifests are exempt (their
+/// `fire_at_ms` is the arm floor, and trigger occurrences never
+/// stale-miss).
+fn validate_floor(
+    candidate: &FireabilityCandidate<'_>,
+    staleness_ms: u64,
+    now_ms: u64,
+) -> Result<(), FireabilityRefusal> {
+    if candidate.fire_at_ms == 0 {
+        return Err(FireabilityRefusal::new(
+            FireabilityField::Floor,
+            "fire_at_ms must be set",
+        ));
+    }
+    if candidate.trigger.is_some() {
+        return Ok(());
+    }
+    let window_floor = now_ms.saturating_sub(staleness_ms);
+    match candidate.recurrence {
+        None => {
+            if candidate.fire_at_ms < window_floor {
+                return Err(FireabilityRefusal::new(
+                    FireabilityField::Floor,
+                    format!(
+                        "the fire window already passed ({} + the {}h staleness bound is in \
+                         the past) — it would resolve missed, never run; pick a fresh time \
+                         (`--at` on ctl, the sheet's First-run field)",
+                        format_instant(candidate.fire_at_ms),
+                        staleness_ms / 3_600_000
+                    ),
+                ));
+            }
+        }
+        Some(rec) => {
+            // A stale FIRST instant is fine on a standing series (the
+            // planner records it missed and the series continues); what
+            // refuses is a series with no live instant left at all.
+            if let Some(last) = last_series_instant(candidate.fire_at_ms, rec) {
+                if last < window_floor {
+                    return Err(FireabilityRefusal::new(
+                        FireabilityField::Floor,
+                        format!(
+                            "the series is already spent — its last instant ({}) plus the \
+                             {}h staleness bound is in the past; extend `--until`/the run \
+                             cap or pick a fresh first run",
+                            format_instant(last),
+                            staleness_ms / 3_600_000
+                        ),
+                    ));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// The last instant a bounded series can fire, or `None` when unbounded
+/// (no `until_ms`, no `max_occurrences` — always live). Saturating math:
+/// a huge cap saturates to u64::MAX, which is simply "live".
+fn last_series_instant(fire_at_ms: u64, rec: &RecurrenceSpec) -> Option<u64> {
+    let by_max = rec.max_occurrences.map(|max| {
+        fire_at_ms.saturating_add(u64::from(max.saturating_sub(1)).saturating_mul(rec.every_ms))
+    });
+    let by_until = rec.until_ms.map(|until| {
+        if until <= fire_at_ms || rec.every_ms == 0 {
+            fire_at_ms
+        } else {
+            fire_at_ms.saturating_add(((until - fire_at_ms) / rec.every_ms) * rec.every_ms)
+        }
+    });
+    match (by_max, by_until) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
+    }
+}
+
+fn format_instant(ms: u64) -> String {
+    use chrono::TimeZone as _;
+    match chrono::Local.timestamp_millis_opt(ms as i64) {
+        chrono::LocalResult::Single(t) => t.format("%Y-%m-%d %H:%M").to_string(),
+        _ => format!("{ms}ms"),
+    }
+}
+
+/// How each `SessionManifest` schema field participates in fireability —
+/// the derive-from-schema contract. The parity test pins this map's keys
+/// to `schemars::schema_for!(SessionManifest)`, so a new manifest field
+/// fails the suite until its fireability class is declared here (covered
+/// by a leg, validated elsewhere in the same intake arm, or explicitly
+/// not a fireability input).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FireabilityCoverage {
+    /// Read by a validator leg ([`FireabilityCandidate`] carries it).
+    Leg(FireabilityField),
+    /// Validated by the same ProposeEffect intake arm the validator runs
+    /// in (shape/bounds/sealing), just not a fireability question.
+    IntakeValidated,
+    /// Launch/display shape with no failure mode the fire path could
+    /// deterministically refuse.
+    NotAFireabilityInput,
+}
+
+pub(crate) fn fireability_schema_coverage(
+) -> std::collections::BTreeMap<&'static str, FireabilityCoverage> {
+    use FireabilityCoverage as C;
+    [
+        ("goal", C::IntakeValidated),
+        ("fire_at_ms", C::Leg(FireabilityField::Floor)),
+        ("orchestrate", C::NotAFireabilityInput),
+        ("interactive", C::NotAFireabilityInput),
+        ("project_root", C::Leg(FireabilityField::Project)),
+        ("agent_config", C::Leg(FireabilityField::Executor)),
+        ("recurrence", C::Leg(FireabilityField::Floor)),
+        ("trigger", C::Leg(FireabilityField::Floor)),
+        ("binding_refs", C::IntakeValidated),
+    ]
+    .into_iter()
+    .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    const HOUR: u64 = 3_600_000;
+    const STALENESS: u64 = 12 * HOUR;
+    const NOW: u64 = 1_800_000_000_000;
+
+    fn ctx(default_project: Option<&Path>, default_agent: Option<&str>) -> SessionSpawnContext {
+        SessionSpawnContext {
+            home: std::env::temp_dir().join("fireability-no-home"),
+            default_project_root: default_project.map(Path::to_path_buf),
+            default_agent: default_agent.map(str::to_string),
+        }
+    }
+
+    fn candidate(fire_at_ms: u64) -> FireabilityCandidate<'static> {
+        FireabilityCandidate {
+            fire_at_ms,
+            recurrence: None,
+            trigger: None,
+            project_root: None,
+            agent_config: None,
+        }
+    }
+
+    /// The ONE-validator contract with the schema: every manifest field
+    /// declares its fireability class, and the set tracks
+    /// `SessionManifest` exactly — a new field fails here until covered.
+    #[test]
+    fn fireability_validator_covers_the_manifest_schema() {
+        let declared: std::collections::BTreeSet<String> = fireability_schema_coverage()
+            .keys()
+            .map(|k| k.to_string())
+            .collect();
+        assert_eq!(
+            declared,
+            super::super::types::session_manifest_schema_fields(),
+            "a SessionManifest field appeared without a declared fireability \
+             class — extend fireability_schema_coverage (and the validator, \
+             if the fire path can deterministically refuse on it)"
+        );
+    }
+
+    /// The grammar every surface maps refusals by: pinned as a wire
+    /// contract (the SPA's approve-time edit prompt parses it; the
+    /// static-asset parity twin pins the fragment literal).
+    #[test]
+    fn refusal_grammar_is_pinned() {
+        let refusal = FireabilityRefusal::new(FireabilityField::Project, "no project");
+        assert_eq!(refusal.message(), "unfireable(project): no project");
+        assert_eq!(FIREABILITY_REFUSAL_PREFIX, "unfireable(");
+        for (field, name) in [
+            (FireabilityField::Project, "project"),
+            (FireabilityField::Executor, "executor"),
+            (FireabilityField::Floor, "floor"),
+        ] {
+            assert_eq!(field.as_str(), name);
+            assert!(FireabilityRefusal::new(field, "x")
+                .message()
+                .starts_with(&format!("unfireable({name}): ")));
+        }
+        let view = refusal.view();
+        assert_eq!(view.field, "project");
+        assert_eq!(view.reason, "no project");
+    }
+
+    /// Projectless daemon + no provenance + no pin = the named refusal,
+    /// carrying the concrete flag to add.
+    #[test]
+    fn projectless_daemon_refuses_with_the_named_flag() {
+        let err = validate(candidate(NOW), None, &ctx(None, None), STALENESS, NOW).unwrap_err();
+        assert_eq!(err.field, FireabilityField::Project);
+        assert!(err.message().starts_with("unfireable(project): "), "{err:?}");
+        assert!(err.reason.contains("--project"), "{}", err.reason);
+    }
+
+    /// The fallback chain is validated against, never narrowed: a daemon
+    /// default resolves a pin-less candidate, and the resolution names
+    /// its source so the mint can record it.
+    #[test]
+    fn daemon_default_resolves_and_is_recorded() {
+        let dir = tempfile::tempdir().unwrap();
+        let resolved = validate(
+            candidate(NOW),
+            None,
+            &ctx(Some(dir.path()), None),
+            STALENESS,
+            NOW,
+        )
+        .unwrap();
+        assert_eq!(resolved.project_root, dir.path());
+        assert_eq!(resolved.project_source, SpawnProjectSource::DaemonDefault);
+        assert_eq!(resolved.agent, "internal");
+    }
+
+    /// Executor resolution: explicit pin wins; otherwise the daemon
+    /// default at this instant; otherwise internal.
+    #[test]
+    fn executor_resolves_explicit_then_default_then_internal() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = ctx(Some(dir.path()), Some("claude-code"));
+        let resolved = validate(candidate(NOW), None, &base, STALENESS, NOW).unwrap();
+        assert_eq!(resolved.agent, "claude-code");
+        let config = AgentLaunchConfig {
+            agent: Some("codex".into()),
+            ..Default::default()
+        };
+        let explicit = FireabilityCandidate {
+            agent_config: Some(&config),
+            ..candidate(NOW)
+        };
+        assert_eq!(
+            validate(explicit, None, &base, STALENESS, NOW).unwrap().agent,
+            "codex"
+        );
+    }
+
+    /// Pins that contradict the backend the mint would record refuse as
+    /// executor unfireability — at the mint, not surprisingly at fire.
+    #[test]
+    fn cross_backend_pins_refuse_against_the_resolved_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = AgentLaunchConfig {
+            claude_model: Some("claude-fable-5".into()),
+            ..Default::default()
+        };
+        let cand = FireabilityCandidate {
+            agent_config: Some(&config),
+            ..candidate(NOW)
+        };
+        let err = validate(
+            cand,
+            None,
+            &ctx(Some(dir.path()), Some("codex")),
+            STALENESS,
+            NOW,
+        )
+        .unwrap_err();
+        assert_eq!(err.field, FireabilityField::Executor);
+        assert!(err.reason.contains("daemon's default"), "{}", err.reason);
+        // The same pins under a matching resolved backend pass.
+        validate(
+            cand,
+            None,
+            &ctx(Some(dir.path()), Some("claude-code")),
+            STALENESS,
+            NOW,
+        )
+        .unwrap();
+    }
+
+    /// One-shot floor sanity mirrors the planner's missed rule: within
+    /// the staleness window passes (the CLI's `--at now` propose), past
+    /// it refuses with the remedy named.
+    #[test]
+    fn one_shot_floor_refuses_only_past_the_staleness_window() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = ctx(Some(dir.path()), None);
+        validate(candidate(NOW - STALENESS + HOUR), None, &base, STALENESS, NOW).unwrap();
+        validate(candidate(NOW + HOUR), None, &base, STALENESS, NOW).unwrap();
+        let err =
+            validate(candidate(NOW - STALENESS - HOUR), None, &base, STALENESS, NOW).unwrap_err();
+        assert_eq!(err.field, FireabilityField::Floor);
+        assert!(err.reason.contains("--at"), "{}", err.reason);
+        let err = validate(candidate(0), None, &base, STALENESS, NOW).unwrap_err();
+        assert_eq!(err.field, FireabilityField::Floor);
+    }
+
+    /// TRAP honored: a triggered manifest's floor is the arm floor — a
+    /// past floor is an immediate arming, never a refusal.
+    #[test]
+    fn trigger_arm_floor_is_never_floor_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let trigger = TriggerSpec::OnUnblock;
+        let cand = FireabilityCandidate {
+            trigger: Some(&trigger),
+            fire_at_ms: NOW - 30 * 24 * HOUR,
+            ..candidate(NOW)
+        };
+        validate(cand, None, &ctx(Some(dir.path()), None), STALENESS, NOW).unwrap();
+    }
+
+    /// Series liveness: a stale first instant on an unbounded or
+    /// still-running series passes (the planner misses it and continues);
+    /// a series whose LAST instant is past the window refuses.
+    #[test]
+    fn series_floor_refuses_only_spent_series() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = ctx(Some(dir.path()), None);
+        let day = 24 * HOUR;
+        let unbounded = RecurrenceSpec {
+            every_ms: day,
+            until_ms: None,
+            max_occurrences: None,
+            suspend_after_failures: None,
+        };
+        let cand = FireabilityCandidate {
+            recurrence: Some(&unbounded),
+            fire_at_ms: NOW - 30 * day,
+            ..candidate(NOW)
+        };
+        validate(cand, None, &base, STALENESS, NOW).unwrap();
+
+        let spent = RecurrenceSpec {
+            max_occurrences: Some(3),
+            ..unbounded
+        };
+        let cand = FireabilityCandidate {
+            recurrence: Some(&spent),
+            fire_at_ms: NOW - 30 * day,
+            ..candidate(NOW)
+        };
+        let err = validate(cand, None, &base, STALENESS, NOW).unwrap_err();
+        assert_eq!(err.field, FireabilityField::Floor);
+        assert!(err.reason.contains("already spent"), "{}", err.reason);
+
+        let expired_until = RecurrenceSpec {
+            until_ms: Some(NOW - 20 * day),
+            ..unbounded
+        };
+        let cand = FireabilityCandidate {
+            recurrence: Some(&expired_until),
+            fire_at_ms: NOW - 30 * day,
+            ..candidate(NOW)
+        };
+        let err = validate(cand, None, &base, STALENESS, NOW).unwrap_err();
+        assert_eq!(err.field, FireabilityField::Floor);
+
+        // A live bounded series (last instant ahead) passes.
+        let live = RecurrenceSpec {
+            until_ms: Some(NOW + 10 * day),
+            ..unbounded
+        };
+        let cand = FireabilityCandidate {
+            recurrence: Some(&live),
+            fire_at_ms: NOW - 30 * day,
+            ..candidate(NOW)
+        };
+        validate(cand, None, &base, STALENESS, NOW).unwrap();
+    }
+}

--- a/src/bin/caller/agenda/fireability.rs
+++ b/src/bin/caller/agenda/fireability.rs
@@ -173,12 +173,9 @@ pub(crate) fn validate(
     staleness_ms: u64,
     now_ms: u64,
 ) -> Result<FireabilityResolution, FireabilityRefusal> {
-    let (project_root, project_source) = resolve_spawn_project(
-        candidate.project_root,
-        provenance_session,
-        ctx,
-    )
-    .map_err(|reason| FireabilityRefusal::new(FireabilityField::Project, reason))?;
+    let (project_root, project_source) =
+        resolve_spawn_project(candidate.project_root, provenance_session, ctx)
+            .map_err(|reason| FireabilityRefusal::new(FireabilityField::Project, reason))?;
     let agent = validate_executor(candidate.agent_config, ctx)?;
     validate_floor(&candidate, staleness_ms, now_ms)?;
     Ok(FireabilityResolution {
@@ -313,6 +310,7 @@ fn format_instant(ms: u64) -> String {
 /// fails the suite until its fireability class is declared here (covered
 /// by a leg, validated elsewhere in the same intake arm, or explicitly
 /// not a fireability input).
+#[cfg(test)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum FireabilityCoverage {
     /// Read by a validator leg ([`FireabilityCandidate`] carries it).
@@ -325,6 +323,7 @@ pub(crate) enum FireabilityCoverage {
     NotAFireabilityInput,
 }
 
+#[cfg(test)]
 pub(crate) fn fireability_schema_coverage(
 ) -> std::collections::BTreeMap<&'static str, FireabilityCoverage> {
     use FireabilityCoverage as C;
@@ -417,7 +416,10 @@ mod tests {
     fn projectless_daemon_refuses_with_the_named_flag() {
         let err = validate(candidate(NOW), None, &ctx(None, None), STALENESS, NOW).unwrap_err();
         assert_eq!(err.field, FireabilityField::Project);
-        assert!(err.message().starts_with("unfireable(project): "), "{err:?}");
+        assert!(
+            err.message().starts_with("unfireable(project): "),
+            "{err:?}"
+        );
         assert!(err.reason.contains("--project"), "{}", err.reason);
     }
 
@@ -457,7 +459,9 @@ mod tests {
             ..candidate(NOW)
         };
         assert_eq!(
-            validate(explicit, None, &base, STALENESS, NOW).unwrap().agent,
+            validate(explicit, None, &base, STALENESS, NOW)
+                .unwrap()
+                .agent,
             "codex"
         );
     }
@@ -503,10 +507,23 @@ mod tests {
     fn one_shot_floor_refuses_only_past_the_staleness_window() {
         let dir = tempfile::tempdir().unwrap();
         let base = ctx(Some(dir.path()), None);
-        validate(candidate(NOW - STALENESS + HOUR), None, &base, STALENESS, NOW).unwrap();
+        validate(
+            candidate(NOW - STALENESS + HOUR),
+            None,
+            &base,
+            STALENESS,
+            NOW,
+        )
+        .unwrap();
         validate(candidate(NOW + HOUR), None, &base, STALENESS, NOW).unwrap();
-        let err =
-            validate(candidate(NOW - STALENESS - HOUR), None, &base, STALENESS, NOW).unwrap_err();
+        let err = validate(
+            candidate(NOW - STALENESS - HOUR),
+            None,
+            &base,
+            STALENESS,
+            NOW,
+        )
+        .unwrap_err();
         assert_eq!(err.field, FireabilityField::Floor);
         assert!(err.reason.contains("--at"), "{}", err.reason);
         let err = validate(candidate(0), None, &base, STALENESS, NOW).unwrap_err();

--- a/src/bin/caller/agenda/handle.rs
+++ b/src/bin/caller/agenda/handle.rs
@@ -1225,11 +1225,24 @@ mod tests {
     /// source item, occurrence state, title, and the sealed inputs of
     /// the manifest that ran it; every resume-lineage member shares the
     /// block; linkage outliving its item degrades to the id-only shape.
+
+    /// Fireability rig for handle tests: a spawn context whose daemon
+    /// default project is the agenda dir itself (absolute, exists for
+    /// the test's lifetime) so pin-less proposes resolve and record.
+    fn ctx_with_default_project(dir: &std::path::Path) -> SessionSpawnContext {
+        SessionSpawnContext {
+            home: dir.to_path_buf(),
+            default_project_root: Some(dir.to_path_buf()),
+            default_agent: None,
+        }
+    }
+
     #[test]
     fn session_agenda_envelopes_compose_journal_store_and_refs() {
         let dir = tempfile::tempdir().unwrap();
         let bus = EventBus::new();
-        let handle = AgendaHandle::new(AgendaStore::open(dir.path()).unwrap(), bus, dir.path());
+        let handle = AgendaHandle::new(AgendaStore::open(dir.path()).unwrap(), bus, dir.path())
+            .with_spawn_context(ctx_with_default_project(dir.path()));
 
         // A sealed input the proposer really read (intake re-hashes it).
         let sealed_src = dir.path().join("inputs.md");
@@ -1260,7 +1273,7 @@ mod tests {
                 AgendaCommand::ProposeEffect {
                     id: item.id.clone(),
                     goal: "run it".into(),
-                    fire_at_ms: 1_000,
+                    fire_at_ms: 4_102_444_800_000, // far-future floor: these tests never fire it
                     orchestrate: false,
                     interactive: None,
                     recurrence: None,
@@ -1370,7 +1383,8 @@ mod tests {
     /// sess-successor (Rider A's lineage), occ-2 fired under the bare
     /// item by sess-other.
     fn attest_rig(dir: &std::path::Path) -> (AgendaHandle, AgendaItem, AgendaItem) {
-        let handle = AgendaHandle::new(AgendaStore::open(dir).unwrap(), EventBus::new(), dir);
+        let handle = AgendaHandle::new(AgendaStore::open(dir).unwrap(), EventBus::new(), dir)
+            .with_spawn_context(ctx_with_default_project(dir));
         let owner = Some(AgendaActor {
             principal: Some("principal:root:dashboard".into()),
             session_id: None,
@@ -1391,7 +1405,7 @@ mod tests {
                 AgendaCommand::ProposeEffect {
                     id: item.id.clone(),
                     goal: "run it".into(),
-                    fire_at_ms: 1_000,
+                    fire_at_ms: 4_102_444_800_000, // far-future floor: these tests never fire it
                     orchestrate: false,
                     interactive: None,
                     recurrence: None,
@@ -2008,7 +2022,8 @@ mod tests {
         std::fs::create_dir_all(&agenda).unwrap();
         let bus = EventBus::new();
         let mut rx = bus.subscribe();
-        let handle = AgendaHandle::new(AgendaStore::open(&agenda).unwrap(), bus, &agenda);
+        let handle = AgendaHandle::new(AgendaStore::open(&agenda).unwrap(), bus, &agenda)
+            .with_spawn_context(ctx_with_default_project(&agenda));
         // Stamping parks + proposes, so agent sessions may do it —
         // approval stays the owner-surface act the existing gate tests
         // pin.
@@ -2065,7 +2080,8 @@ mod tests {
     fn agent_cannot_approve_its_own_manifest() {
         let dir = tempfile::tempdir().unwrap();
         let bus = EventBus::new();
-        let handle = AgendaHandle::new(AgendaStore::open(dir.path()).unwrap(), bus, dir.path());
+        let handle = AgendaHandle::new(AgendaStore::open(dir.path()).unwrap(), bus, dir.path())
+            .with_spawn_context(ctx_with_default_project(dir.path()));
         let item = handle
             .apply(
                 AgendaCommand::Add {
@@ -2968,8 +2984,11 @@ mod tests {
         );
         std::fs::create_dir_all(dir.path()).unwrap();
         std::fs::write(dir.path().join("agenda.jsonl"), legacy).unwrap();
-        let projectless =
-            AgendaHandle::new(AgendaStore::open(dir.path()).unwrap(), bus.clone(), dir.path());
+        let projectless = AgendaHandle::new(
+            AgendaStore::open(dir.path()).unwrap(),
+            bus.clone(),
+            dir.path(),
+        );
         let served = projectless.snapshot();
         let effect = &served.iter().find(|i| i.id == "it").unwrap().effects[0];
         let refusal = effect
@@ -2982,13 +3001,12 @@ mod tests {
         // The same ledger under a daemon that CAN resolve it: verdict
         // absent, approve proceeds, and the ARMED effect is unstamped.
         let default_project = tempfile::tempdir().unwrap();
-        let resolvable =
-            AgendaHandle::new(AgendaStore::open(dir.path()).unwrap(), bus, dir.path())
-                .with_spawn_context(super::super::spawn_project::SessionSpawnContext {
-                    home: dir.path().to_path_buf(),
-                    default_project_root: Some(default_project.path().to_path_buf()),
-                    default_agent: None,
-                });
+        let resolvable = AgendaHandle::new(AgendaStore::open(dir.path()).unwrap(), bus, dir.path())
+            .with_spawn_context(super::super::spawn_project::SessionSpawnContext {
+                home: dir.path().to_path_buf(),
+                default_project_root: Some(default_project.path().to_path_buf()),
+                default_agent: None,
+            });
         let served = resolvable.snapshot();
         let effect = &served.iter().find(|i| i.id == "it").unwrap().effects[0];
         assert!(effect.fireability_refusal.is_none());
@@ -3016,7 +3034,8 @@ mod tests {
     fn approval_binds_the_manifest_digest() {
         let dir = tempfile::tempdir().unwrap();
         let bus = EventBus::new();
-        let handle = AgendaHandle::new(AgendaStore::open(dir.path()).unwrap(), bus, dir.path());
+        let handle = AgendaHandle::new(AgendaStore::open(dir.path()).unwrap(), bus, dir.path())
+            .with_spawn_context(ctx_with_default_project(dir.path()));
         let item = handle
             .apply(
                 AgendaCommand::Add {
@@ -3211,7 +3230,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let bus = EventBus::new();
         let mut rx = bus.subscribe();
-        let handle = AgendaHandle::new(AgendaStore::open(dir.path()).unwrap(), bus, dir.path());
+        let handle = AgendaHandle::new(AgendaStore::open(dir.path()).unwrap(), bus, dir.path())
+            .with_spawn_context(ctx_with_default_project(dir.path()));
         let item = handle
             .apply(
                 AgendaCommand::Add {
@@ -3366,7 +3386,8 @@ mod tests {
             AgendaStore::open(dir.path()).unwrap(),
             EventBus::new(),
             dir.path(),
-        );
+        )
+        .with_spawn_context(ctx_with_default_project(dir.path()));
         let watcher_id = armed_gate_watcher(&handle);
         let question = handle
             .apply(
@@ -3409,7 +3430,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let bus = EventBus::new();
         let mut rx = bus.subscribe();
-        let handle = AgendaHandle::new(AgendaStore::open(dir.path()).unwrap(), bus, dir.path());
+        let handle = AgendaHandle::new(AgendaStore::open(dir.path()).unwrap(), bus, dir.path())
+            .with_spawn_context(ctx_with_default_project(dir.path()));
         armed_gate_watcher(&handle);
         let covered = park_question(&handle, "Gate: sign off HS6", vec!["gate".into()]);
         let uncovered = park_question(&handle, "Which vendor for the NAS?", Vec::new());
@@ -3442,7 +3464,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let bus = EventBus::new();
         let mut rx = bus.subscribe();
-        let handle = AgendaHandle::new(AgendaStore::open(dir.path()).unwrap(), bus, dir.path());
+        let handle = AgendaHandle::new(AgendaStore::open(dir.path()).unwrap(), bus, dir.path())
+            .with_spawn_context(ctx_with_default_project(dir.path()));
         armed_gate_watcher(&handle);
         let covered = park_question(&handle, "Gate: queue entry", vec!["gate".into()]);
         let uncovered = park_question(&handle, "Pick the offsite week?", Vec::new());
@@ -3487,7 +3510,8 @@ mod tests {
     fn broadcast_copies_carry_full_decorations() {
         let dir = tempfile::tempdir().unwrap();
         let bus = EventBus::new();
-        let handle = AgendaHandle::new(AgendaStore::open(dir.path()).unwrap(), bus, dir.path());
+        let handle = AgendaHandle::new(AgendaStore::open(dir.path()).unwrap(), bus, dir.path())
+            .with_spawn_context(ctx_with_default_project(dir.path()));
         let watcher_id = armed_gate_watcher(&handle);
         let question = park_question(&handle, "Gate: soak the queue", vec!["gate".into()]);
         let due = question.watched_by.as_ref().and_then(|w| w.due_ms);

--- a/src/bin/caller/agenda/handle.rs
+++ b/src/bin/caller/agenda/handle.rs
@@ -2753,6 +2753,7 @@ mod tests {
             .with_spawn_context(super::super::spawn_project::SessionSpawnContext {
                 home: dir.path().to_path_buf(),
                 default_project_root: Some(default_project.path().to_path_buf()),
+                default_agent: None,
             });
         let item = handle
             .apply(
@@ -2858,6 +2859,7 @@ mod tests {
             .with_spawn_context(super::super::spawn_project::SessionSpawnContext {
                 home: home.path().to_path_buf(),
                 default_project_root: None,
+                default_agent: None,
             });
         let item = handle
             .apply(
@@ -2941,6 +2943,71 @@ mod tests {
         let items = handle.snapshot();
         let orphan_now = items.iter().find(|i| i.id == orphan.id).unwrap();
         assert!(orphan_now.effects.is_empty(), "refusal mints nothing");
+    }
+
+    /// The serving half of the fireability class law: an approvable
+    /// state (pending review) whose manifest the validator refuses is
+    /// SERVED with the verdict (`fireability_refusal`, the
+    /// `next_fire_ms` decoration pattern) so no frontend has to offer
+    /// Approve blind — and the verdict clears once the daemon state
+    /// resolves it. Armed effects are never stamped (no approve
+    /// affordance renders there).
+    #[test]
+    fn pending_effects_serve_their_fireability_verdict() {
+        let dir = tempfile::tempdir().unwrap();
+        let bus = EventBus::new();
+        // A LEGACY pin-less manifest folded from the log — the propose
+        // intake would refuse minting this on a projectless daemon, so
+        // seed it as history (the migration-honesty class).
+        let legacy = concat!(
+            "{\"v\":1,\"at_ms\":1,\"op\":{\"type\":\"add\",\"id\":\"it\",\"kind\":\"task\",",
+            "\"title\":\"legacy\",\"body\":\"\",\"tags\":[]}}\n",
+            "{\"v\":1,\"at_ms\":2,\"op\":{\"type\":\"propose_effect\",\"id\":\"it\",",
+            "\"effect_id\":\"ef-legacy000000\",\"manifest\":{\"goal\":\"g\",",
+            "\"fire_at_ms\":4102444800000}}}\n"
+        );
+        std::fs::create_dir_all(dir.path()).unwrap();
+        std::fs::write(dir.path().join("agenda.jsonl"), legacy).unwrap();
+        let projectless =
+            AgendaHandle::new(AgendaStore::open(dir.path()).unwrap(), bus.clone(), dir.path());
+        let served = projectless.snapshot();
+        let effect = &served.iter().find(|i| i.id == "it").unwrap().effects[0];
+        let refusal = effect
+            .fireability_refusal
+            .as_ref()
+            .expect("a pending unresolvable manifest serves its refusal");
+        assert_eq!(refusal.field, "project");
+        assert!(refusal.reason.contains("--project"), "{}", refusal.reason);
+
+        // The same ledger under a daemon that CAN resolve it: verdict
+        // absent, approve proceeds, and the ARMED effect is unstamped.
+        let default_project = tempfile::tempdir().unwrap();
+        let resolvable =
+            AgendaHandle::new(AgendaStore::open(dir.path()).unwrap(), bus, dir.path())
+                .with_spawn_context(super::super::spawn_project::SessionSpawnContext {
+                    home: dir.path().to_path_buf(),
+                    default_project_root: Some(default_project.path().to_path_buf()),
+                    default_agent: None,
+                });
+        let served = resolvable.snapshot();
+        let effect = &served.iter().find(|i| i.id == "it").unwrap().effects[0];
+        assert!(effect.fireability_refusal.is_none());
+        let digest = effect.digest.clone();
+        let armed = resolvable
+            .apply(
+                AgendaCommand::ApproveEffect {
+                    id: "it".into(),
+                    digest,
+                },
+                Some(AgendaActor {
+                    principal: Some("owner".into()),
+                    session_id: None,
+                    kind: Some("dashboard".into()),
+                }),
+            )
+            .unwrap();
+        assert!(armed.effects[0].approval.is_some());
+        assert!(armed.effects[0].fireability_refusal.is_none());
     }
 
     /// Approval binds the digest: an edit (re-propose) voids it, and a

--- a/src/bin/caller/agenda/handle.rs
+++ b/src/bin/caller/agenda/handle.rs
@@ -94,10 +94,12 @@ impl AgendaHandle {
             reminder_nudge: tokio::sync::Notify::new(),
             spawn_ctx: SessionSpawnContext {
                 // The agenda dir contains no session records, so the
-                // default context resolves no provenance and no default
-                // project — and never touches the real home.
+                // default context resolves no provenance, no default
+                // project, and no default agent — and never touches the
+                // real home.
                 home: dir.to_path_buf(),
                 default_project_root: None,
+                default_agent: None,
             },
             decoration_journal: Mutex::new(None),
             handover: None,
@@ -105,9 +107,15 @@ impl AgendaHandle {
     }
 
     /// Install the daemon's real spawn context (wiring edge; tests inject
-    /// tempdir-scoped ones to exercise resolution).
+    /// tempdir-scoped ones to exercise resolution). Pushed down into the
+    /// store too: the fireability legs of the propose/approve intake
+    /// resolve against it there, so the ONE validator lives in the ONE
+    /// lane (`command_to_op`) every mint surface routes through.
     pub(crate) fn with_spawn_context(mut self, spawn_ctx: SessionSpawnContext) -> Self {
-        self.spawn_ctx = spawn_ctx;
+        self.spawn_ctx = spawn_ctx.clone();
+        if let Ok(store) = self.store.get_mut() {
+            store.set_spawn_context(spawn_ctx);
+        }
         self
     }
 
@@ -1047,6 +1055,35 @@ impl AgendaHandle {
                 &super::scheduler::local_minute_of_day_at,
             );
         });
+        // Fireability decoration (display-only, the `next_fire_ms`
+        // pattern): stamped exactly where an approve/re-arm affordance
+        // could render — an open item's pending-review or suspended
+        // effect — so the dashboard withholds Approve on an unfireable
+        // manifest and opens the editor on the named field instead. The
+        // SAME validator the propose/approve intake runs, so the served
+        // verdict and the refusal a click would meet can never disagree.
+        let staleness_ms = policy.staleness_ms();
+        for item in items.iter_mut() {
+            if item.status != super::types::AgendaStatus::Open {
+                continue;
+            }
+            let provenance = item.provenance.session_id.clone();
+            for effect in item.effects.iter_mut() {
+                let approvable = effect.approval.is_none() || effect.suspended();
+                if !approvable {
+                    continue;
+                }
+                effect.fireability_refusal = super::fireability::validate(
+                    super::fireability::FireabilityCandidate::of_manifest(&effect.manifest),
+                    provenance.as_deref(),
+                    &self.spawn_ctx,
+                    staleness_ms,
+                    now_ms,
+                )
+                .err()
+                .map(|refusal| refusal.view());
+            }
+        }
     }
 
     /// One page of the raw occurrence journal (read-only; the

--- a/src/bin/caller/agenda/mod.rs
+++ b/src/bin/caller/agenda/mod.rs
@@ -45,7 +45,6 @@ mod types;
 pub(crate) use ask::{agenda_ask_pending, ask_outcome_delivery_text, spawn_ask_resolver};
 pub(crate) use blobs::find_blob;
 pub(crate) use definitions::materialize_house_definitions;
-pub(crate) use fireability::FIREABILITY_REFUSAL_PREFIX;
 pub(crate) use handle::now_ms;
 pub(crate) use handle::{AgendaHandle, AgendaPrefixResolution, SessionAgendaEnvelope};
 pub(crate) use reminders::{
@@ -69,6 +68,8 @@ pub(crate) use types::{
 // with structured content.
 #[cfg(test)]
 pub(crate) use ask::resolution_from_wire;
+#[cfg(test)]
+pub(crate) use fireability::FIREABILITY_REFUSAL_PREFIX;
 #[cfg(test)]
 pub(crate) use sealed_blobs::seal_content;
 #[cfg(test)]

--- a/src/bin/caller/agenda/mod.rs
+++ b/src/bin/caller/agenda/mod.rs
@@ -32,6 +32,7 @@
 mod ask;
 mod blobs;
 mod definitions;
+mod fireability;
 mod handle;
 mod reminders;
 mod scheduler;
@@ -44,6 +45,7 @@ mod types;
 pub(crate) use ask::{agenda_ask_pending, ask_outcome_delivery_text, spawn_ask_resolver};
 pub(crate) use blobs::find_blob;
 pub(crate) use definitions::materialize_house_definitions;
+pub(crate) use fireability::FIREABILITY_REFUSAL_PREFIX;
 pub(crate) use handle::now_ms;
 pub(crate) use handle::{AgendaHandle, AgendaPrefixResolution, SessionAgendaEnvelope};
 pub(crate) use reminders::{

--- a/src/bin/caller/agenda/reminders.rs
+++ b/src/bin/caller/agenda/reminders.rs
@@ -162,7 +162,7 @@ impl ReminderPolicy {
             .unwrap_or(self.default_urgency)
     }
 
-    fn staleness_ms(&self) -> u64 {
+    pub(crate) fn staleness_ms(&self) -> u64 {
         u64::from(self.staleness_hours) * 3_600_000
     }
 }
@@ -2816,6 +2816,7 @@ mod tests {
             requested: Vec::new(),
             next_fire_ms: None,
             last_run_attempt: None,
+            fireability_refusal: None,
         });
         base
     }
@@ -3241,6 +3242,7 @@ mod tests {
                 requested: Vec::new(),
                 next_fire_ms: None,
                 last_run_attempt: None,
+                fireability_refusal: None,
             });
             base
         };
@@ -3357,6 +3359,7 @@ mod tests {
             requested: Vec::new(),
             next_fire_ms: None,
             last_run_attempt: None,
+            fireability_refusal: None,
         });
         base
     }
@@ -4058,6 +4061,7 @@ mod tests {
             requested: Vec::new(),
             next_fire_ms: None,
             last_run_attempt: None,
+            fireability_refusal: None,
         });
         base
     }

--- a/src/bin/caller/agenda/scheduler.rs
+++ b/src/bin/caller/agenda/scheduler.rs
@@ -1961,6 +1961,50 @@ mod tests {
         )
     }
 
+    /// Seed an item + APPROVED pin-less manifest straight into the op
+    /// log — the history lane (folds never re-validate). The fireability
+    /// mint law refuses to CREATE this shape through intake now, but
+    /// pre-law logs and daemon downtime still hand it to the fire path,
+    /// which these tests pin. Call BEFORE the handle's next read; the
+    /// store absorbs the append via its stale-length refold.
+    fn seed_approved_legacy_effect(dir: &std::path::Path, item_id: &str, fire_at_ms: u64) {
+        let manifest = super::super::types::SessionManifest {
+            goal: "run the nightly sweep".into(),
+            fire_at_ms,
+            orchestrate: false,
+            interactive: false,
+            project_root: None,
+            agent_config: None,
+            recurrence: None,
+            trigger: None,
+            binding_refs: Vec::new(),
+        };
+        let effect_id = format!(
+            "ef-{}",
+            &super::super::reminders::occurrence_id(item_id, fire_at_ms)[..12]
+        );
+        let digest = super::super::types::manifest_digest(item_id, &effect_id, &manifest);
+        let mut lines = String::new();
+        for op in [
+            serde_json::json!({"v":1,"at_ms":1,"op":{"type":"add","id":item_id,
+                "kind":"task","title":"scheduled work","body":"","tags":[]}}),
+            serde_json::json!({"v":1,"at_ms":2,"op":{"type":"propose_effect","id":item_id,
+                "effect_id":effect_id,"manifest":manifest}}),
+            serde_json::json!({"v":1,"at_ms":3,"op":{"type":"approve_effect","id":item_id,
+                "effect_id":effect_id,"digest":digest}}),
+        ] {
+            lines.push_str(&op.to_string());
+            lines.push('\n');
+        }
+        use std::io::Write as _;
+        let mut log = std::fs::File::options()
+            .create(true)
+            .append(true)
+            .open(dir.join("agenda.jsonl"))
+            .unwrap();
+        log.write_all(lines.as_bytes()).unwrap();
+    }
+
     fn approved_effect_item(handle: &AgendaHandle, fire_at_ms: u64) -> (String, String, String) {
         let item = handle
             .apply(
@@ -4363,8 +4407,12 @@ mod tests {
         let failed = items.iter().find(|i| i.id == item_id).unwrap();
         assert_eq!(failed.effects[0].last_run.as_ref().unwrap().state, "failed");
 
-        // Missed window: approved 25h ago (past the 12h staleness default).
-        let (missed_item, _, _) = approved_effect_item(&handle, now_ms() - 25 * 3_600_000);
+        // Missed window: approved 25h ago (past the 12h staleness
+        // default). The mint law refuses to CREATE a stale floor, so the
+        // shape is seeded as history — exactly what daemon downtime
+        // produces.
+        let missed_item = "it-missed-window".to_string();
+        seed_approved_legacy_effect(dir.path(), &missed_item, now_ms() - 25 * 3_600_000);
         let mut rx = handle.bus().subscribe();
         run_pass(&handle, &mut journal, &mut state, None).await;
         let mut saw_start = false;
@@ -4497,7 +4545,11 @@ mod tests {
         ));
         let mut journal = OccurrenceJournal::open(handle.dir()).unwrap();
         let mut state = SchedulerState::default();
-        let (item_id, _, _) = approved_effect_item(&handle, now_ms() - 60_000);
+        // A pin-less approved manifest can no longer be MINTED on a
+        // projectless daemon (the fireability law) — seed it as history,
+        // the shape pre-law logs still carry to the fire path.
+        let item_id = "it-unresolvable".to_string();
+        seed_approved_legacy_effect(dir.path(), &item_id, now_ms() - 60_000);
 
         let mut rx = handle.bus().subscribe();
         run_pass(&handle, &mut journal, &mut state, None).await;

--- a/src/bin/caller/agenda/scheduler.rs
+++ b/src/bin/caller/agenda/scheduler.rs
@@ -1955,6 +1955,7 @@ mod tests {
                 super::super::spawn_project::SessionSpawnContext {
                     home: dir.to_path_buf(),
                     default_project_root: Some(default_project.to_path_buf()),
+                    default_agent: None,
                 },
             ),
         )
@@ -3183,6 +3184,7 @@ mod tests {
                 super::super::spawn_project::SessionSpawnContext {
                     home: home.to_path_buf(),
                     default_project_root: Some(default_project.to_path_buf()),
+                    default_agent: None,
                 },
             ),
         )
@@ -4413,6 +4415,7 @@ mod tests {
                 .with_spawn_context(super::super::spawn_project::SessionSpawnContext {
                     home: home.path().to_path_buf(),
                     default_project_root: None,
+                    default_agent: None,
                 }),
         );
         let mut journal = OccurrenceJournal::open(handle.dir()).unwrap();

--- a/src/bin/caller/agenda/spawn_project.rs
+++ b/src/bin/caller/agenda/spawn_project.rs
@@ -20,9 +20,11 @@
 
 use std::path::{Path, PathBuf};
 
-/// Daemon-level facts the agenda needs to resolve spawn projects: the
-/// state home (session records live under it) and the daemon's default
-/// project root, if it has one. Constructed once at wiring; tests inject
+/// Daemon-level facts the agenda needs to resolve spawn projects and
+/// executors: the state home (session records live under it), the
+/// daemon's default project root, and the daemon's default agent
+/// backend. Constructed once at wiring (boot-captured, like the default
+/// project — a later settings edit shows up after restart); tests inject
 /// temp dirs. The default context ([`AgendaHandle::new`] without
 /// `with_spawn_context`) resolves nothing — it never reads the real home.
 #[derive(Debug, Clone)]
@@ -32,6 +34,11 @@ pub(crate) struct SessionSpawnContext {
     pub(crate) home: PathBuf,
     /// The daemon's default project root (`None` on a projectless daemon).
     pub(crate) default_project_root: Option<PathBuf>,
+    /// The daemon's effective default agent backend (`--agent` flag →
+    /// `[agent] default_backend`), as its short wire string; `None` =
+    /// the internal native agent. The propose lane records this onto
+    /// executor-less manifests so the approval names WHO runs.
+    pub(crate) default_agent: Option<String>,
 }
 
 /// Where a resolved spawn project came from — surfaced in refusals, item
@@ -156,6 +163,7 @@ mod tests {
         SessionSpawnContext {
             home: home.to_path_buf(),
             default_project_root: default.map(Path::to_path_buf),
+            default_agent: None,
         }
     }
 

--- a/src/bin/caller/agenda/store.rs
+++ b/src/bin/caller/agenda/store.rs
@@ -1680,6 +1680,21 @@ impl AgendaStore {
                     now_ms,
                 )
                 .map_err(|refusal| AgendaError::Invalid(refusal.message()))?;
+                // The chain's resolution, named in the daemon log: a
+                // fallback-resolved recording is a real decision the
+                // owner reviews on the manifest, and this line says
+                // where it came from.
+                match resolved.project_source {
+                    super::spawn_project::SpawnProjectSource::Explicit => {}
+                    super::spawn_project::SpawnProjectSource::Provenance => eprintln!(
+                        "[agenda] propose: recorded the parking session's project root {}",
+                        resolved.project_root.display()
+                    ),
+                    super::spawn_project::SpawnProjectSource::DaemonDefault => eprintln!(
+                        "[agenda] propose: recorded the daemon default project root {}",
+                        resolved.project_root.display()
+                    ),
+                }
                 let project_root = Some(resolved.project_root.to_string_lossy().into_owned());
                 let agent_config = {
                     let mut config = agent_config.unwrap_or_default();
@@ -4898,6 +4913,7 @@ mod tests {
     fn g3pre_recurrence_intake_streak_and_rearm() {
         let dir = tempfile::tempdir().unwrap();
         let mut store = AgendaStore::open(dir.path()).unwrap();
+        let _project = with_default_project(&mut store);
         let id = store
             .apply_command(add_cmd("standing"), owner(), 1000)
             .unwrap()
@@ -5095,6 +5111,7 @@ mod tests {
     fn g3pre_start_now_routes_standing_manifests_to_requests() {
         let dir = tempfile::tempdir().unwrap();
         let mut store = AgendaStore::open(dir.path()).unwrap();
+        let _project = with_default_project(&mut store);
         let id = store
             .apply_command(add_cmd("standing"), owner(), 1000)
             .unwrap()
@@ -5241,6 +5258,7 @@ mod tests {
         let pin = digest_file(&brief).unwrap();
         let locator = format!("file:{}", brief.display());
         let mut store = AgendaStore::open(dir.path()).unwrap();
+        let _project = with_default_project(&mut store);
         let item = store
             .apply_command(add_cmd("sealed"), owner(), 1000)
             .unwrap();
@@ -5409,6 +5427,7 @@ mod tests {
         let pin = digest_file(&brief).unwrap();
         let locator = format!("file:{}", brief.display());
         let mut store = AgendaStore::open(dir.path()).unwrap();
+        let _project = with_default_project(&mut store);
         let item = store
             .apply_command(add_cmd("editable"), owner(), 1000)
             .unwrap();
@@ -5511,6 +5530,7 @@ mod tests {
     fn approve_signs_the_edited_digest() {
         let dir = tempfile::tempdir().unwrap();
         let mut store = AgendaStore::open(dir.path()).unwrap();
+        let _project = with_default_project(&mut store);
         let item = store
             .apply_command(add_cmd("edit me"), owner(), 1000)
             .unwrap();
@@ -5595,6 +5615,7 @@ mod tests {
     fn propose_shape_toggle_rides_the_digest_bound_manifest() {
         let dir = tempfile::tempdir().unwrap();
         let mut store = AgendaStore::open(dir.path()).unwrap();
+        let _project = with_default_project(&mut store);
         let item = store
             .apply_command(add_cmd("shaped"), owner(), 1000)
             .unwrap();
@@ -5774,6 +5795,7 @@ mod tests {
     fn trigger_intake_enforces_exclusion_and_the_predicate_bounds() {
         let dir = tempfile::tempdir().unwrap();
         let mut store = AgendaStore::open(dir.path()).unwrap();
+        let _project = with_default_project(&mut store);
         let id = store
             .apply_command(add_cmd("triggered"), owner(), 1000)
             .unwrap()
@@ -5858,6 +5880,7 @@ mod tests {
     fn executor_propose_intake_records_validates_and_normalizes() {
         let dir = tempfile::tempdir().unwrap();
         let mut store = AgendaStore::open(dir.path()).unwrap();
+        let _project = with_default_project(&mut store);
         let id = store
             .apply_command(add_cmd("standing"), owner(), 1000)
             .unwrap()
@@ -5893,16 +5916,28 @@ mod tests {
         );
         let executor_digest = item.effects[0].digest.clone();
 
+        // A config-less propose RECORDS the resolved executor (the
+        // fireability mint law: no default backend on this hermetic
+        // store, so `internal`) — the owner approves WHO runs, never
+        // empty-means-whatever.
         let item = store.apply_command(propose(None), owner(), 1002).unwrap();
-        assert!(item.effects[0].manifest.agent_config.is_none());
+        assert_eq!(
+            item.effects[0]
+                .manifest
+                .agent_config
+                .as_deref()
+                .and_then(|config| config.agent.as_deref()),
+            Some("internal")
+        );
         let plain_digest = item.effects[0].digest.clone();
         assert_ne!(
             executor_digest, plain_digest,
             "the executor is digest-visible — the owner approves WHO runs"
         );
 
-        // All-inherit normalizes to ABSENT: identical manifest bytes,
-        // identical digest — a config-less gesture is unchanged by AU.
+        // All-inherit normalizes to the SAME recorded shape as a
+        // config-less propose: identical manifest bytes, identical
+        // digest — the empty-config gesture and no config agree.
         let item = store
             .apply_command(
                 propose(Some(crate::event::AgentLaunchConfig::default())),
@@ -5910,7 +5945,14 @@ mod tests {
                 1003,
             )
             .unwrap();
-        assert!(item.effects[0].manifest.agent_config.is_none());
+        assert_eq!(
+            item.effects[0]
+                .manifest
+                .agent_config
+                .as_deref()
+                .and_then(|config| config.agent.as_deref()),
+            Some("internal")
+        );
         assert_eq!(item.effects[0].digest, plain_digest);
 
         // Named intake rejections — the launch path's own rules, at
@@ -6423,8 +6465,8 @@ mod tests {
             .apply_command(add_cmd("who runs"), owner(), 1000)
             .unwrap()
             .id;
-        let propose = |config: Option<crate::event::AgentLaunchConfig>| {
-            AgendaCommand::ProposeEffect {
+        let propose =
+            |config: Option<crate::event::AgentLaunchConfig>| AgendaCommand::ProposeEffect {
                 binding_refs: Vec::new(),
                 id: id.clone(),
                 goal: "g".into(),
@@ -6436,8 +6478,7 @@ mod tests {
                 trigger: None,
                 project_root: None,
                 source: None,
-            }
-        };
+            };
         // No daemon default: internal is the recorded executor.
         let parked = store.apply_command(propose(None), owner(), 2000).unwrap();
         let recorded = parked.effects[0].manifest.agent_config.as_deref().unwrap();
@@ -6619,9 +6660,16 @@ mod tests {
     /// approvable-but-dead nodes.
     #[test]
     fn stamp_inherits_the_fireability_mint_law() {
-        let (_root, mut store) = stamp_rig();
+        // A BARE rig — house set materialized, but no daemon default
+        // project (stamp_rig() installs one; this test needs its
+        // absence).
+        let root = tempfile::tempdir().unwrap();
+        super::super::definitions::materialize_house_definitions(root.path()).unwrap();
+        let agenda = root.path().join("agenda");
+        std::fs::create_dir_all(&agenda).unwrap();
+        let mut store = AgendaStore::open(&agenda).unwrap();
         let err = store
-            .apply_stamp_command(stamp_cmd("daily-digest"), owner(), 1000)
+            .apply_stamp_command(stamp_cmd("fix-task"), owner(), 1000)
             .unwrap_err();
         assert!(
             err.to_string().starts_with("unfireable(project): "),
@@ -6629,20 +6677,27 @@ mod tests {
         );
         let _project = with_default_project(&mut store);
         store
-            .apply_stamp_command(stamp_cmd("daily-digest"), owner(), 2000)
+            .apply_stamp_command(stamp_cmd("fix-task"), owner(), 2000)
             .unwrap();
     }
 
     // ---- Track AW: the stamp lane ----
 
     /// A state root with the house set materialized and the agenda under
-    /// `<root>/agenda` — the deployed layout, hermetic in a tempdir.
+    /// `<root>/agenda` — the deployed layout, hermetic in a tempdir. The
+    /// state root doubles as the daemon default project so pin-less
+    /// stamped nodes resolve (the fireability mint law refuses them
+    /// otherwise; `stamp_inherits_the_fireability_mint_law` exercises
+    /// the projectless refusal on a bare rig).
     fn stamp_rig() -> (tempfile::TempDir, AgendaStore) {
         let root = tempfile::tempdir().unwrap();
         super::super::definitions::materialize_house_definitions(root.path()).unwrap();
         let agenda = root.path().join("agenda");
         std::fs::create_dir_all(&agenda).unwrap();
-        let store = AgendaStore::open(&agenda).unwrap();
+        let mut store = AgendaStore::open(&agenda).unwrap();
+        let mut ctx = store.spawn_ctx.clone();
+        ctx.default_project_root = Some(root.path().to_path_buf());
+        store.set_spawn_context(ctx);
         (root, store)
     }
 
@@ -6730,10 +6785,17 @@ mod tests {
         assert_eq!(investigate.agent.as_deref(), Some("claude-code"));
         assert_eq!(investigate.claude_model.as_deref(), Some("claude-fable-5"));
         assert_eq!(investigate.claude_effort.as_deref(), Some("max"));
-        assert!(by_node("implement").item.effects[0]
-            .manifest
-            .agent_config
-            .is_none());
+        // An unpinned node records the resolved executor (the
+        // fireability mint law — internal on this default-less rig)
+        // instead of the legacy absent shape.
+        assert_eq!(
+            by_node("implement").item.effects[0]
+                .manifest
+                .agent_config
+                .as_deref()
+                .and_then(|config| config.agent.as_deref()),
+            Some("internal")
+        );
         // The durable log carries ordinary ops only — and no approval op
         // of any kind.
         let log = std::fs::read_to_string(store.log_path()).unwrap();

--- a/src/bin/caller/agenda/store.rs
+++ b/src/bin/caller/agenda/store.rs
@@ -3124,6 +3124,18 @@ mod tests {
         })
     }
 
+    /// Fireability rig: give the hermetic store a daemon default project
+    /// so pin-less proposes resolve (the mint law refuses them
+    /// otherwise). Returns the tempdir GUARD — it must outlive every
+    /// propose, or the recorded root stops existing and approve refuses.
+    fn with_default_project(store: &mut AgendaStore) -> tempfile::TempDir {
+        let project = tempfile::tempdir().unwrap();
+        let mut ctx = store.spawn_ctx.clone();
+        ctx.default_project_root = Some(project.path().to_path_buf());
+        store.set_spawn_context(ctx);
+        project
+    }
+
     #[test]
     fn add_persists_and_survives_reopen() {
         let dir = tempfile::tempdir().unwrap();
@@ -6245,10 +6257,12 @@ mod tests {
         }
     }
 
-    /// T3c: an explicit project pin is validated at review time — the
-    /// same contradiction the launch path would refuse at fire time,
-    /// named NOW — and binds the digest (the approval covers WHERE);
-    /// blank normalizes to the legacy absent shape.
+    /// T3c, extended by the fireability mint law: an explicit project
+    /// pin is validated at review time — the same contradiction the
+    /// launch path would refuse at fire time, named NOW — and binds the
+    /// digest (the approval covers WHERE). A blank/absent pin resolves
+    /// through the fire path's chain and the RESOLUTION is recorded;
+    /// with nothing to resolve against, the propose refuses named.
     #[test]
     fn propose_project_root_validates_and_binds() {
         let dir = tempfile::tempdir().unwrap();
@@ -6270,6 +6284,17 @@ mod tests {
             project_root,
             source: None,
         };
+        // Projectless store, no provenance: a pin-less propose refuses
+        // with the concrete missing flag named (the mint law's headline
+        // case — the approvable-but-unfireable class dies here).
+        let err = store
+            .apply_command(propose(Some("   ".into())), owner(), 1500)
+            .unwrap_err();
+        assert!(
+            err.to_string().starts_with("unfireable(project): "),
+            "{err}"
+        );
+        assert!(err.to_string().contains("--project"), "{err}");
         for (bad, needle) in [
             (
                 Some("relative/path".to_string()),
@@ -6288,12 +6313,16 @@ mod tests {
                 "expected {needle:?} in {err}"
             );
         }
+        // With a daemon default: blank RESOLVES and the resolution is
+        // recorded — the digest the owner reviews names where.
+        let default_project = with_default_project(&mut store);
         let parked = store
             .apply_command(propose(Some("   ".into())), owner(), 3000)
             .unwrap();
         assert_eq!(
-            parked.effects[0].manifest.project_root, None,
-            "blank normalizes absent"
+            parked.effects[0].manifest.project_root,
+            Some(default_project.path().display().to_string()),
+            "the chain's resolution is recorded, never left empty"
         );
         let unpinned_digest = parked.effects[0].digest.clone();
         let proj = tempfile::tempdir().unwrap();
@@ -6312,6 +6341,296 @@ mod tests {
             pinned.effects[0].digest, unpinned_digest,
             "the pin revises the digest"
         );
+    }
+
+    // ---- Fireability (card 01KYSZAGQVHAAYS7BK9H3QFM3C) ----
+
+    /// The parking-session leg of the mint law: a pin-less propose on an
+    /// item parked BY A SESSION resolves through that session's recorded
+    /// project root and records it — the fallback chain is validated
+    /// against, never narrowed to explicit-only.
+    #[test]
+    fn propose_records_the_parking_session_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = AgendaStore::open(dir.path()).unwrap();
+        // The parking session's recorded project, under the ctx home.
+        let home = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let meta_dir = crate::platform::intendant_home_in(home.path())
+            .join("logs")
+            .join("sess-parker");
+        std::fs::create_dir_all(&meta_dir).unwrap();
+        std::fs::write(
+            meta_dir.join("session_meta.json"),
+            serde_json::json!({
+                "session_id": "sess-parker",
+                "created_at": "now",
+                "project_root": project.path().to_string_lossy(),
+            })
+            .to_string(),
+        )
+        .unwrap();
+        store.set_spawn_context(super::super::spawn_project::SessionSpawnContext {
+            home: home.path().to_path_buf(),
+            default_project_root: None,
+            default_agent: None,
+        });
+        let parker = Some(AgendaActor {
+            principal: Some("principal:agent-session:sess-parker".into()),
+            session_id: Some("sess-parker".into()),
+            kind: Some("agent_session".into()),
+        });
+        let id = store
+            .apply_command(add_cmd("parked by a session"), parker, 1000)
+            .unwrap()
+            .id;
+        let parked = store
+            .apply_command(
+                AgendaCommand::ProposeEffect {
+                    binding_refs: Vec::new(),
+                    id: id.clone(),
+                    goal: "g".into(),
+                    fire_at_ms: 1_000_000,
+                    orchestrate: false,
+                    interactive: None,
+                    recurrence: None,
+                    agent_config: None,
+                    trigger: None,
+                    project_root: None,
+                    source: None,
+                },
+                owner(),
+                2000,
+            )
+            .unwrap();
+        assert_eq!(
+            parked.effects[0].manifest.project_root,
+            Some(project.path().display().to_string()),
+            "the parking session's root is the recorded resolution"
+        );
+    }
+
+    /// Executor honesty: a config-less propose records the daemon's
+    /// default backend (or internal), an explicit selection is kept, and
+    /// a pin contradicting the resolved default refuses at the mint.
+    #[test]
+    fn propose_records_the_resolved_executor() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = AgendaStore::open(dir.path()).unwrap();
+        let project = with_default_project(&mut store);
+        let _ = &project;
+        let id = store
+            .apply_command(add_cmd("who runs"), owner(), 1000)
+            .unwrap()
+            .id;
+        let propose = |config: Option<crate::event::AgentLaunchConfig>| {
+            AgendaCommand::ProposeEffect {
+                binding_refs: Vec::new(),
+                id: id.clone(),
+                goal: "g".into(),
+                fire_at_ms: 1_000_000,
+                orchestrate: false,
+                interactive: None,
+                recurrence: None,
+                agent_config: config.map(Box::new),
+                trigger: None,
+                project_root: None,
+                source: None,
+            }
+        };
+        // No daemon default: internal is the recorded executor.
+        let parked = store.apply_command(propose(None), owner(), 2000).unwrap();
+        let recorded = parked.effects[0].manifest.agent_config.as_deref().unwrap();
+        assert_eq!(recorded.agent.as_deref(), Some("internal"));
+        // A daemon default backend is recorded when the config is bare.
+        let mut ctx = store.spawn_ctx.clone();
+        ctx.default_agent = Some("claude-code".into());
+        store.set_spawn_context(ctx);
+        let parked = store.apply_command(propose(None), owner(), 3000).unwrap();
+        let recorded = parked.effects[0].manifest.agent_config.as_deref().unwrap();
+        assert_eq!(recorded.agent.as_deref(), Some("claude-code"));
+        // Explicit selection wins over the default.
+        let parked = store
+            .apply_command(
+                propose(Some(crate::event::AgentLaunchConfig {
+                    agent: Some("codex".into()),
+                    ..Default::default()
+                })),
+                owner(),
+                4000,
+            )
+            .unwrap();
+        let recorded = parked.effects[0].manifest.agent_config.as_deref().unwrap();
+        assert_eq!(recorded.agent.as_deref(), Some("codex"));
+        // A model pin contradicting the resolved default refuses at the
+        // mint — executor unfireability, named.
+        let err = store
+            .apply_command(
+                propose(Some(crate::event::AgentLaunchConfig {
+                    codex_model: Some("gpt-5.3-codex".into()),
+                    ..Default::default()
+                })),
+                owner(),
+                5000,
+            )
+            .unwrap_err();
+        assert!(
+            err.to_string().starts_with("unfireable(executor): "),
+            "{err}"
+        );
+    }
+
+    /// THE CLASS TEST: approve is never offered on an unfireable
+    /// manifest — the approve intake re-runs the same validator against
+    /// the daemon's state NOW, so a legacy pin-less manifest (folded
+    /// from an old log) or a plan whose window already passed refuses
+    /// at the arm gate with the named edit prompt, never arms dead.
+    #[test]
+    fn approve_is_never_armed_on_an_unfireable_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        // A LEGACY pin-less manifest enters via the op log (the fold
+        // never validates — parked history loads untouched).
+        let legacy = concat!(
+            "{\"v\":1,\"at_ms\":1,\"op\":{\"type\":\"add\",\"id\":\"it\",\"kind\":\"task\",",
+            "\"title\":\"legacy\",\"body\":\"\",\"tags\":[]}}\n",
+            "{\"v\":1,\"at_ms\":2,\"op\":{\"type\":\"propose_effect\",\"id\":\"it\",",
+            "\"effect_id\":\"ef-legacy000000\",\"manifest\":{\"goal\":\"g\",",
+            "\"fire_at_ms\":1000000}}}\n"
+        );
+        std::fs::write(dir.path().join(LOG_FILE), legacy).unwrap();
+        let mut store = AgendaStore::open(dir.path()).unwrap();
+        let digest = store.item("it").unwrap().effects[0].digest.clone();
+        let approve = AgendaCommand::ApproveEffect {
+            id: "it".into(),
+            digest: digest.clone(),
+        };
+        // Projectless daemon: the arm gate refuses, named — the edit
+        // prompt's grammar, field first.
+        let err = store
+            .apply_command(approve.clone(), owner(), 3000)
+            .unwrap_err();
+        assert!(
+            err.to_string().starts_with("unfireable(project): "),
+            "{err}"
+        );
+        // The same manifest arms once the daemon can resolve it — the
+        // chain is consulted at the gate, legacy bytes untouched.
+        let _project = with_default_project(&mut store);
+        store.apply_command(approve, owner(), 4000).unwrap();
+        assert!(store.item("it").unwrap().effects[0].approval.is_some());
+
+        // Floor half of the class law: a one-shot proposed sane can
+        // still go stale before the owner approves — the arm gate is
+        // where the guarantee holds, so approving past the staleness
+        // window refuses with the reschedule remedy named.
+        let id = store
+            .apply_command(add_cmd("stale floor"), owner(), 5000)
+            .unwrap()
+            .id;
+        let hour = 3_600_000u64;
+        let fire_at = 24 * hour;
+        let parked = store
+            .apply_command(
+                AgendaCommand::ProposeEffect {
+                    binding_refs: Vec::new(),
+                    id: id.clone(),
+                    goal: "g".into(),
+                    fire_at_ms: fire_at,
+                    orchestrate: false,
+                    interactive: None,
+                    recurrence: None,
+                    agent_config: None,
+                    trigger: None,
+                    project_root: None,
+                    source: None,
+                },
+                owner(),
+                23 * hour,
+            )
+            .unwrap();
+        let digest = parked.effects[0].digest.clone();
+        let err = store
+            .apply_command(
+                AgendaCommand::ApproveEffect {
+                    id: id.clone(),
+                    digest: digest.clone(),
+                },
+                owner(),
+                fire_at + 13 * hour, // 12h staleness default + 1h
+            )
+            .unwrap_err();
+        assert!(err.to_string().starts_with("unfireable(floor): "), "{err}");
+        assert!(err.to_string().contains("--at"), "{err}");
+        // Within the window the same approve arms.
+        store
+            .apply_command(
+                AgendaCommand::ApproveEffect { id, digest },
+                owner(),
+                fire_at + hour,
+            )
+            .unwrap();
+    }
+
+    /// TRAP pin: trigger-armed schedules are never floor-refused — the
+    /// floor is the ARM floor, and a long-past floor is an immediate
+    /// arming, at propose and at approve alike.
+    #[test]
+    fn trigger_manifests_are_never_floor_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = AgendaStore::open(dir.path()).unwrap();
+        let _project = with_default_project(&mut store);
+        let id = store
+            .apply_command(add_cmd("gate"), owner(), 1000)
+            .unwrap()
+            .id;
+        let month = 30 * 24 * 3_600_000u64;
+        let parked = store
+            .apply_command(
+                AgendaCommand::ProposeEffect {
+                    binding_refs: Vec::new(),
+                    id: id.clone(),
+                    goal: "g".into(),
+                    fire_at_ms: 1, // the arm floor, arbitrarily old
+                    orchestrate: false,
+                    interactive: None,
+                    recurrence: None,
+                    agent_config: None,
+                    trigger: Some(super::super::types::TriggerSpec::OnUnblock),
+                    project_root: None,
+                    source: None,
+                },
+                owner(),
+                2 * month,
+            )
+            .unwrap();
+        let digest = parked.effects[0].digest.clone();
+        store
+            .apply_command(
+                AgendaCommand::ApproveEffect { id, digest },
+                owner(),
+                3 * month,
+            )
+            .unwrap();
+    }
+
+    /// The stamp lane inherits the mint law per node (it proposes
+    /// through the same intake arm): a projectless stamp with no
+    /// project pin anywhere refuses named instead of parking
+    /// approvable-but-dead nodes.
+    #[test]
+    fn stamp_inherits_the_fireability_mint_law() {
+        let (_root, mut store) = stamp_rig();
+        let err = store
+            .apply_stamp_command(stamp_cmd("daily-digest"), owner(), 1000)
+            .unwrap_err();
+        assert!(
+            err.to_string().starts_with("unfireable(project): "),
+            "{err}"
+        );
+        let _project = with_default_project(&mut store);
+        store
+            .apply_stamp_command(stamp_cmd("daily-digest"), owner(), 2000)
+            .unwrap();
     }
 
     // ---- Track AW: the stamp lane ----

--- a/src/bin/caller/agenda/store.rs
+++ b/src/bin/caller/agenda/store.rs
@@ -169,6 +169,14 @@ pub(crate) struct AgendaStore {
     /// ([`Self::drain_foreign_changes`], Track AS S8/Q6). Deduped;
     /// bounded by the item count.
     foreign_changes: Vec<String>,
+    /// Daemon spawn facts the fireability legs of the ProposeEffect /
+    /// ApproveEffect intake resolve against (the ONE validator lives in
+    /// `command_to_op`, so the stamp lane inherits it per node). The
+    /// handle's `with_spawn_context` pushes the wiring-edge context down;
+    /// [`AgendaStore::open`] defaults to the hermetic nothing-resolves
+    /// shape (home = the agenda dir, no default project, no default
+    /// agent) so tests never touch the real home.
+    spawn_ctx: super::spawn_project::SessionSpawnContext,
 }
 
 /// Facts of one scheduled-session occurrence outcome, written back by the
@@ -296,9 +304,32 @@ impl AgendaStore {
             item_seqs: fold.item_seqs,
             boot_fold,
             foreign_changes: Vec::new(),
+            spawn_ctx: super::spawn_project::SessionSpawnContext {
+                home: dir.to_path_buf(),
+                default_project_root: None,
+                default_agent: None,
+            },
         };
         store.sync_ask_state();
         Ok(store)
+    }
+
+    /// Install the daemon's real spawn context for the fireability legs
+    /// of the propose/approve intake (pushed down by the handle's
+    /// `with_spawn_context`; tests inject tempdir-scoped contexts).
+    pub(crate) fn set_spawn_context(&mut self, ctx: super::spawn_project::SessionSpawnContext) {
+        self.spawn_ctx = ctx;
+    }
+
+    /// The reminder policy's staleness bound, read live from this
+    /// agenda's own policy file — the SAME bound the planner classifies
+    /// missed sessions with, so the floor leg of fireability and the
+    /// fire path can never disagree. A propose/approve is a rare verb;
+    /// the read is one small JSON file (absent = defaults).
+    fn staleness_ms(&self) -> u64 {
+        super::reminders::ReminderPolicyStore::open(&self.dir)
+            .policy()
+            .staleness_ms()
     }
 
     /// Post-fold bookkeeping for persisted rich asks: floor the process
@@ -1579,26 +1610,7 @@ impl AgendaStore {
                         "{id} is not open — reopen it before scheduling work on it"
                     )));
                 }
-                if fire_at_ms == 0 {
-                    return Err(AgendaError::Invalid("fire_at_ms must be set".into()));
-                }
-                // Executor pins are validated NOW, not at fire time: a
-                // digest-bound manifest is reviewed and approved long
-                // before it spawns, so every contradiction the launch
-                // path would deterministically reject must be named here
-                // (same rules, same wording — one authority). All-inherit
-                // normalizes to the legacy absent shape so a config-less
-                // propose keeps byte-identical manifest bytes and digests.
                 let agent_config = agent_config.filter(|config| !config.is_empty());
-                if let Some(config) = agent_config.as_deref() {
-                    crate::session_supervisor::validate_launch_config(config)
-                        .map_err(AgendaError::Invalid)?;
-                    if let Some(warning) =
-                        crate::session_supervisor::unrecognized_claude_model_warning(config)
-                    {
-                        eprintln!("[agenda] propose advisory: {warning}");
-                    }
-                }
                 if let Some(rec) = &recurrence {
                     if rec.every_ms < super::types::RECURRENCE_MIN_EVERY_MS {
                         return Err(AgendaError::Invalid(format!(
@@ -1635,30 +1647,57 @@ impl AgendaStore {
                     }
                     validate_trigger(trig)?;
                 }
-                // Explicit project pin (T3c): the same contradiction the
-                // launch path would deterministically refuse at fire time
-                // is named NOW, at review time — a picker-stamped
-                // standing manifest on a projectless daemon otherwise
-                // fires straight into the named refusal.
-                let project_root = match project_root.map(|p| p.trim().to_string()) {
-                    None => None,
-                    Some(p) if p.is_empty() => None,
-                    Some(p) => {
-                        let path = std::path::Path::new(&p);
-                        if !path.is_absolute() {
-                            return Err(AgendaError::Invalid(format!(
-                                "project_root must be an absolute path, got {p:?}"
-                            )));
-                        }
-                        if !path.is_dir() {
-                            return Err(AgendaError::Invalid(format!(
-                                "project_root {p:?} is not an existing directory — the spawn \
-                                 would be refused at fire time; fix the path or omit it for \
-                                 the daemon default"
-                            )));
-                        }
-                        Some(p)
+                // Fireability (card 01KYSZAGQVHAAYS7BK9H3QFM3C): an
+                // approvable manifest IS a fireable manifest — the ONE
+                // validator resolves the project through the fire path's
+                // own chain (explicit pin → the parking session's root →
+                // the daemon default, refused named when nothing
+                // resolves), resolves the executor (explicit selection →
+                // the daemon default → internal) and validates the
+                // config AS RESOLVED, and applies the planner's own
+                // missed rule to the floor. The resolutions are RECORDED
+                // below: the digest the owner approves names WHERE and
+                // WHO, never empty-means-whatever-fires. (This
+                // deliberately ends the byte-identical-to-legacy shape
+                // for pin-less proposes — a fresh propose mints a fresh
+                // digest anyway; parked legacy manifests refold
+                // untouched and keep their bound digests.)
+                let explicit_project = project_root
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|root| !root.is_empty());
+                let resolved = super::fireability::validate(
+                    super::fireability::FireabilityCandidate {
+                        fire_at_ms,
+                        recurrence: recurrence.as_ref(),
+                        trigger: trigger.as_ref(),
+                        project_root: explicit_project,
+                        agent_config: agent_config.as_deref(),
+                    },
+                    item.provenance.session_id.as_deref(),
+                    &self.spawn_ctx,
+                    self.staleness_ms(),
+                    now_ms,
+                )
+                .map_err(|refusal| AgendaError::Invalid(refusal.message()))?;
+                let project_root = Some(resolved.project_root.to_string_lossy().into_owned());
+                let agent_config = {
+                    let mut config = agent_config.unwrap_or_default();
+                    if config
+                        .agent
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|agent| !agent.is_empty())
+                        .is_none()
+                    {
+                        config.agent = Some(resolved.agent.clone());
                     }
+                    if let Some(warning) =
+                        crate::session_supervisor::unrecognized_claude_model_warning(&config)
+                    {
+                        eprintln!("[agenda] propose advisory: {warning}");
+                    }
+                    Some(config)
                 };
                 let goal = {
                     let goal = goal.trim();
@@ -1714,12 +1753,11 @@ impl AgendaStore {
                         orchestrate,
                         // Shape rides the command (the approval-time
                         // editor's toggle); absent keeps the legacy
-                        // autonomous goal run. Without an explicit pin
-                        // the project resolves at fire time (provenance
-                        // → daemon default → named refusal). The
-                        // executor pins (if any) ride the digest-bound
-                        // manifest; absent fields inherit the daemon
-                        // defaults.
+                        // autonomous goal run. Project and executor are
+                        // the RESOLVED values recorded above — the
+                        // digest the owner approves names where and who;
+                        // remaining absent executor pins (model, effort)
+                        // inherit backend defaults at launch.
                         interactive: interactive.unwrap_or(false),
                         project_root,
                         agent_config,
@@ -2122,6 +2160,24 @@ impl AgendaStore {
                         effect.digest
                     )));
                 }
+                // Approve is the ARM gate: the same fireability check the
+                // propose lane runs, against the daemon's state NOW —
+                // approval can never arm a plan the fire path already
+                // refuses (the class law: approve is never offered on an
+                // unfireable manifest). This is also where a LEGACY
+                // pin-less manifest meets the validator: its project
+                // resolves through the unchanged fallback chain when the
+                // daemon can, and refuses named (the edit prompt) when it
+                // cannot. Check-only — an approval binds bytes and never
+                // rewrites them, so nothing is recorded here.
+                super::fireability::validate(
+                    super::fireability::FireabilityCandidate::of_manifest(&effect.manifest),
+                    item.provenance.session_id.as_deref(),
+                    &self.spawn_ctx,
+                    self.staleness_ms(),
+                    now_ms,
+                )
+                .map_err(|refusal| AgendaError::Invalid(refusal.message()))?;
                 Ok(AgendaOp::ApproveEffect {
                     id,
                     effect_id: effect.effect_id.clone(),

--- a/src/bin/caller/agenda/summary.rs
+++ b/src/bin/caller/agenda/summary.rs
@@ -676,6 +676,11 @@ mod tests {
     fn summary_fields_derive_from_the_full_dto() {
         let dir = tempfile::tempdir().unwrap();
         let mut store = AgendaStore::open(dir.path()).unwrap();
+        store.set_spawn_context(super::super::spawn_project::SessionSpawnContext {
+            home: dir.path().to_path_buf(),
+            default_project_root: Some(dir.path().to_path_buf()),
+            default_agent: None,
+        });
         let prereq = add(&mut store, "prerequisite", 1000).unwrap();
         let dependent = add(&mut store, "dependent", 2000).unwrap();
         store
@@ -945,6 +950,11 @@ mod tests {
     fn query_reach_matches_the_client_search() {
         let dir = tempfile::tempdir().unwrap();
         let mut store = AgendaStore::open(dir.path()).unwrap();
+        store.set_spawn_context(super::super::spawn_project::SessionSpawnContext {
+            home: dir.path().to_path_buf(),
+            default_project_root: Some(dir.path().to_path_buf()),
+            default_agent: None,
+        });
         let item = store
             .apply_command(
                 AgendaCommand::Add {

--- a/src/bin/caller/agenda/summary.rs
+++ b/src/bin/caller/agenda/summary.rs
@@ -293,6 +293,11 @@ pub(crate) struct SummaryEffect {
     pub(crate) last_run_attempt: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) last_run: Option<SummaryRun>,
+    /// The serving-seam fireability verdict (same field path as the full
+    /// DTO): present exactly when an approve/re-arm affordance would
+    /// meet a named refusal — the cards withhold Approve on it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) fireability_refusal: Option<super::fireability::FireabilityRefusalView>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -482,6 +487,7 @@ fn summarize_one(all: &[AgendaItem], item: &AgendaItem, watermark: u64) -> Agend
                 next_fire_ms: effect.next_fire_ms,
                 consecutive_failures: effect.consecutive_failures,
                 last_run_attempt: effect.last_run_attempt,
+                fireability_refusal: effect.fireability_refusal.clone(),
                 last_run: effect.last_run.as_ref().map(|run| SummaryRun {
                     state: run.state.clone(),
                     at_ms: run.at_ms,

--- a/src/bin/caller/agenda/types.rs
+++ b/src/bin/caller/agenda/types.rs
@@ -584,6 +584,16 @@ pub struct AgendaEffect {
     /// never folded from ops, never stored.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) last_run_attempt: Option<u32>,
+    /// Display-only serving-seam decoration (the `next_fire_ms`
+    /// pattern): the fireability refusal an approve of THIS revision
+    /// would meet right now — stamped only on effects whose approve/
+    /// re-arm affordance could render (pending review, or suspended),
+    /// `None` otherwise and always `None` in the fold product. The
+    /// dashboard withholds the Approve affordance on it and opens the
+    /// plan editor on the named field instead (the class law: approve is
+    /// never offered on an unfireable manifest).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) fireability_refusal: Option<super::fireability::FireabilityRefusalView>,
 }
 
 fn is_zero_u32(n: &u32) -> bool {
@@ -2129,6 +2139,7 @@ pub(crate) fn apply_op(
                 requested: Vec::new(),
                 next_fire_ms: None,
                 last_run_attempt: None,
+                fireability_refusal: None,
             };
             match item.effects.iter_mut().find(|e| e.effect_id == *effect_id) {
                 Some(existing) => {

--- a/src/bin/caller/agenda/types.rs
+++ b/src/bin/caller/agenda/types.rs
@@ -399,24 +399,30 @@ pub struct SessionManifest {
     /// digests their approvals bind — are unchanged.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub(crate) interactive: bool,
-    /// Additive: the project root the spawned session runs under. `None`
-    /// (the legacy shape) resolves at fire time: the parking session's
-    /// recorded project root, else the daemon default — and the spawn is
-    /// refused with a named failure when neither exists, never launched
-    /// project-less.
+    /// Additive: the project root the spawned session runs under. Since
+    /// propose-time fireability (2026-07-30) every NEW manifest records
+    /// the resolved root at the mint — explicit pick, or the fire-path
+    /// chain's resolution (parking-session root → daemon default) — so
+    /// the approval digest covers WHERE. `None` survives only on legacy
+    /// parked manifests, which keep the fire-time resolution (the same
+    /// chain, consulted at dispatch) and meet the validator at their
+    /// next approve; the spawn is refused with a named failure when
+    /// nothing resolves, never launched project-less.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) project_root: Option<String>,
     /// Additive: the agent-launch configuration the spawned session runs
     /// with — exactly the CreateSession vocabulary (backend selection,
-    /// model/effort/permission pins per backend). `None` (the legacy
-    /// shape) inherits every field, so legacy manifest bytes — and the
-    /// digests their approvals bind — are unchanged. Setting it revises
-    /// the manifest and mints a new digest, exactly like any other
-    /// manifest edit: the owner approves the config they reviewed. At
-    /// fire time each field resolves explicit pin → daemon default →
-    /// backend default, through the same launch path every session uses.
-    /// Boxed for enum-size hygiene only — serde and the digest see the
-    /// inner value verbatim.
+    /// model/effort/permission pins per backend). Since propose-time
+    /// fireability (2026-07-30) every NEW manifest records at least the
+    /// resolved backend (`agent`: the explicit selection, else the
+    /// daemon default at the mint, else `internal`) so the approval
+    /// names WHO runs; remaining absent fields inherit backend defaults
+    /// at launch. `None` survives only on legacy parked manifests
+    /// (all-inherit at fire time, bytes and bound digests unchanged).
+    /// Setting or editing it revises the manifest and mints a new
+    /// digest, exactly like any other manifest edit: the owner approves
+    /// the config they reviewed. Boxed for enum-size hygiene only —
+    /// serde and the digest see the inner value verbatim.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) agent_config: Option<Box<crate::event::AgentLaunchConfig>>,
     /// Standing cadence (G3-pre). Additive: absent-on-the-wire when
@@ -1167,10 +1173,12 @@ pub enum AgendaCommand {
         /// the digest-bound manifest so the approval covers WHERE.
         /// Validated at intake (absolute, existing directory — the same
         /// contradiction the launch path would refuse at fire time,
-        /// named now). Absent = the legacy resolution: the parking
-        /// session's recorded root, else the daemon default — which a
-        /// picker-stamped manifest on a projectless daemon does not
-        /// have, the live gap this field closes.
+        /// named now). Absent = resolve NOW through the fire path's own
+        /// chain (the parking session's recorded root, else the daemon
+        /// default) and record the resolution; a daemon that resolves
+        /// nothing refuses the propose by name — the fireability mint
+        /// law, closing the approvable-but-unfireable class the
+        /// picker-stamped projectless park exposed.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         project_root: Option<String>,
         /// Hash-pinned binding refs (sealed refs): `{locator, sha256}`

--- a/src/bin/caller/ctl.rs
+++ b/src/bin/caller/ctl.rs
@@ -5640,7 +5640,8 @@ fn help_agenda() {
       [--binding-ref file:PATH]...   # sealed refs: sha256-pin content the goal depends on —\n\
       # hashed here at propose time, covered by the approval digest, re-verified at every fire\n\
       [--project DIR]   # digest-bound project pin: where fired sessions run (absolute, must\n\
-      # exist; omitted = the parking session's root, else the daemon default)\n\
+      # exist; omitted = the parking session's root, else the daemon default, RESOLVED and\n\
+      # recorded at propose — a daemon that resolves nothing refuses, naming this flag)\n\
       [--agent BACKEND] [--claude-model M] [--claude-effort E]\n\
       [--codex-model M] [--codex-reasoning-effort E] [--kimi-model M] [--kimi-thinking T]\n\
   intendant ctl agenda stamp NAME|file:PATH/SKILL.md [--project DIR] [--at WHEN]\n\

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -3473,7 +3473,9 @@ pub(crate) mod tests {
                     recurrence: None,
                     agent_config: None,
                     trigger: None,
-                    project_root: None,
+                    // Fireability: the mint resolves and records a real
+                    // directory — the test's own tempdir.
+                    project_root: Some(dir.path().display().to_string()),
                     binding_refs: Vec::new(),
                     source: None,
                 },

--- a/src/bin/caller/startup/wiring.rs
+++ b/src/bin/caller/startup/wiring.rs
@@ -384,6 +384,13 @@ pub(crate) fn spawn_mode_web_gateway(
                     .with_spawn_context(crate::agenda::SessionSpawnContext {
                         home: crate::platform::home_dir(),
                         default_project_root: project_root.clone(),
+                        // The boot-effective default backend (--agent →
+                        // `[agent] default_backend`): what the propose
+                        // lane records onto executor-less manifests so
+                        // the approval names WHO runs.
+                        default_agent: initial_agent_backend
+                            .as_ref()
+                            .map(|backend| backend.as_short_str().to_string()),
                     })
                     // Track HS3: the immediacy verbs (start_now,
                     // request_occurrence) refuse while draining.

--- a/src/bin/caller/web_gateway/routes_agenda.rs
+++ b/src/bin/caller/web_gateway/routes_agenda.rs
@@ -835,7 +835,9 @@ mod tests {
                     recurrence: None,
                     agent_config: None,
                     trigger: None,
-                    project_root: None,
+                    // Fireability: the mint resolves and records a real
+                    // directory — the test's own tempdir.
+                    project_root: Some(dir.path().display().to_string()),
                     binding_refs: Vec::new(),
                     source: None,
                 },

--- a/src/bin/caller/web_gateway/static_assets.rs
+++ b/src/bin/caller/web_gateway/static_assets.rs
@@ -900,20 +900,24 @@ mod tests {
     /// affordance is an OPENER for the one schedule sheet, whose save is
     /// the manifest-EDIT lane's single `propose_effect` emitter — the
     /// edit UI is a client of re-propose, never a second writer. The
-    /// fragment set's only other emitter is the seals module's adopt
+    /// fragment set's other emitters are the seals module's adopt
     /// confirm — the RE-SEAL ceremony (fresh pins from drift review),
-    /// pinned here to carry the manifest verbatim including the shape.
-    /// (The automate and workflow guards above pin their fragments to
-    /// zero.)
+    /// pinned here to carry the manifest verbatim including the shape —
+    /// and the missed-card RESCHEDULE lane (`agendaRescheduleMissed`,
+    /// fireability card): verbatim re-propose with the floor moved to
+    /// now + re-approve, one tap. Each lane exactly one emitter. (The
+    /// automate and workflow guards above pin their fragments to zero.)
     #[test]
     fn edit_mints_through_the_repropose_lane() {
         let inspector = include_str!("../../../../static/app/ui2-agenda-inspector.js");
         let cards = include_str!("../../../../static/app/ui2-agenda-cards.js");
         let seals = include_str!("../../../../static/app/ui2-agenda-seals.js");
         assert_eq!(
-            inspector.matches("propose_effect").count(),
-            1,
-            "exactly one edit-lane emission site: the schedule sheet's confirm"
+            inspector.matches("op: 'propose_effect'").count(),
+            2,
+            "exactly two emission sites in the inspector fragment: the \
+             schedule sheet's confirm (edit lane) and the missed-card \
+             reschedule (one-tap lane)"
         );
         assert_eq!(
             seals.matches("propose_effect").count(),
@@ -930,27 +934,93 @@ mod tests {
             .expect("the sheet confirm must exist");
         assert!(
             confirm.contains("op: 'propose_effect'"),
-            "the one emission lives inside the sheet confirm"
+            "the edit-lane emission lives inside the sheet confirm"
+        );
+        let (_, resched) = inspector
+            .split_once("async function agendaRescheduleMissed(")
+            .expect("the reschedule lane must exist");
+        assert!(
+            resched.contains("op: 'propose_effect'"),
+            "the reschedule emission lives inside agendaRescheduleMissed"
+        );
+        assert!(
+            resched.contains("if (m.interactive) params.interactive = true;"),
+            "the reschedule carries the manifest verbatim — shape included; \
+             only the floor moves"
         );
         assert_eq!(
             cards.matches("propose_effect").count(),
             0,
-            "the card never proposes — its Edit affordance only opens the sheet"
+            "the card never proposes — its affordances open the sheet or \
+             call the inspector's reschedule lane"
         );
         // The pending strips carry the affordance; the delegation opens
         // the sheet and sends no op.
         assert!(cards.contains("data-edit-sched"));
         assert!(
-            cards.contains("agendaOpenSchedSheet(editSched.dataset.editSched)"),
+            cards.contains("agendaOpenSchedSheet(editSched.dataset.editSched"),
             "the card edit handler opens the one editor"
         );
         // No edit lane for ALREADY-approved effects from the card: the
-        // affordance renders only in the pending branches (the inline
-        // strip and the automations strip), never beside Revoke.
+        // affordance renders only in the pending/suspended branches (the
+        // inline strip and the automations strip), never beside Revoke.
+        // Five sites: the inline strip's Fix-plan closure + its plain
+        // Edit…, the automations strip's Fix-plan + its plain Edit…, and
+        // the one delegation handler.
         assert_eq!(
             cards.matches("data-edit-sched").count(),
+            5,
+            "four branch buttons (two Fix-plan, two Edit…) + the one \
+             delegation handler"
+        );
+        // The missed-card one-tap: two strip emissions + the one
+        // delegation handler, which routes to the inspector lane.
+        assert_eq!(
+            cards.matches("data-resched-effect").count(),
             3,
-            "two pending-branch buttons + the one delegation handler"
+            "two missed-branch buttons + the one delegation handler"
+        );
+        assert!(
+            cards.contains("agendaRescheduleMissed(resched.dataset.reschedEffect"),
+            "the card reschedule handler calls the one reschedule lane"
+        );
+    }
+
+    /// The fireability class law on the render side: the cards NEVER
+    /// offer Approve/Re-arm against a served `fireability_refusal` —
+    /// both strips branch on the served verdict before emitting the
+    /// approve button, and the daemon's approve intake backs the law
+    /// (`approve_is_never_armed_on_an_unfireable_manifest` in the
+    /// agenda store tests). The SPA maps refusals by the daemon's
+    /// pinned grammar (`FIREABILITY_REFUSAL_PREFIX`).
+    #[test]
+    fn approve_is_gated_on_the_served_fireability_verdict() {
+        let cards = include_str!("../../../../static/app/ui2-agenda-cards.js");
+        let inspector = include_str!("../../../../static/app/ui2-agenda-inspector.js");
+        assert!(
+            cards.matches("fireability_refusal").count() >= 2,
+            "both card strips read the served verdict"
+        );
+        // The inline strip's approve emission sits in the refusal-gated
+        // ternary; the automations strip's pending branch is reachable
+        // only past the refusal branch above it.
+        assert!(
+            cards.contains("refusal\n        ? fixBtn('Fix plan…')"),
+            "the inline strip offers Fix plan INSTEAD of Approve on a refusal"
+        );
+        assert!(
+            cards.contains("if (refusal && (st.kind === 'pending' || st.kind === 'suspended'))"),
+            "the automations strip gates Approve/Re-arm on the served refusal"
+        );
+        assert!(
+            inspector.contains("/^unfireable\\((project|executor|floor)\\): /"),
+            "the SPA parses exactly the daemon's refusal grammar \
+             (FIREABILITY_REFUSAL_PREFIX in agenda/fireability.rs)"
+        );
+        assert_eq!(
+            crate::agenda::FIREABILITY_REFUSAL_PREFIX,
+            "unfireable(",
+            "the grammar the SPA regex above matches"
         );
     }
 

--- a/static/app.html
+++ b/static/app.html
@@ -24271,6 +24271,10 @@ html.ui-v2 .ag2-auto-last.st-failed,
 html.ui-v2 .ag2-auto-last.st-unknown,
 html.ui-v2 .ag2-auto-streak { color: var(--rose); font-weight: 600; }
 html.ui-v2 .ag2-auto-last.st-completed { color: var(--green); }
+/* The missed-window terminal is a state the owner acts on (re-approve to
+   reschedule), not benign body text — amber, like the card state. */
+html.ui-v2 .ag2-auto-last.st-missed,
+html.ui-v2 .ag2-auto-unfireable { color: var(--amber); font-weight: 600; }
 html.ui-v2 .ag2-auto-run { cursor: pointer; text-decoration: underline; }
 /* Attestation (Track AO) — the self-report axis, never the transport
    palette: achieved sky (never transport-success green), the rest
@@ -26462,6 +26466,16 @@ html.ui-v2 .ag2-sheet-error {
   padding-left: 8px;
   overflow-wrap: anywhere;
 }
+/* Fireability edit prompt: the field a refusal named gets a brief
+   attention ring when the sheet lands on it; the required-project hint
+   matches the start sheet's amber emphasis. */
+html.ui-v2 .ag2-field-attn {
+  outline: 2px solid rgba(var(--amber-rgb), 0.55);
+  outline-offset: 2px;
+  border-radius: 8px;
+  transition: outline-color 0.4s ease;
+}
+html.ui-v2 .ag2-hint.ags-hint-required { color: var(--amber); font-weight: 600; }
 /* Sealed refs on the schedule sheet: read-only rows — locator + the
    pinned hash chip. Deliberately input-less: the edit lane carries them
    verbatim; re-sealing is its own ceremony. */
@@ -37605,7 +37619,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '47d4d928f643b7fc';
+const INTENDANT_APP_BUILD = '38e82a937e68d816';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -92098,11 +92112,17 @@ async function agendaSendOp(params, button) {
     const message = (resp.body && resp.body.error) || `agenda op failed (${resp.status})`;
     agendaFlashError(message);
     agendaPaintRefusal(button, message);
+    if (typeof agendaFireabilityEditPrompt === 'function') {
+      agendaFireabilityEditPrompt(params, message);
+    }
     return false;
   } catch (e) {
     const message = String(e && e.message || e);
     agendaFlashError(message);
     agendaPaintRefusal(button, message);
+    if (typeof agendaFireabilityEditPrompt === 'function') {
+      agendaFireabilityEditPrompt(params, message);
+    }
     return false;
   } finally {
     if (button) button.disabled = false;
@@ -92224,7 +92244,14 @@ function agendaEffectState(item) {
           : (item.relies_on || []).every((link) => agendaLinkState(link).satisfied)
             ? 'ready' : 'waiting')
           : rec ? 'standing'
-            : next > Date.now() ? 'armed' : 'finished';
+            // The missed-window terminal is its own self-explaining
+            // state, not a silent 'finished': a one-shot whose floor
+            // passed while the daemon was down carries its one-tap
+            // remedy (re-approve to reschedule) on the card. A missed
+            // instant on a standing series stays 'standing' above —
+            // the series continues unaffected.
+            : effect.last_run && effect.last_run.state === 'missed' ? 'missed'
+              : next > Date.now() ? 'armed' : 'finished';
   return { effect, manifest, rec, trig, threshold, suspended, running, next, kind };
 }
 
@@ -94818,24 +94845,40 @@ function agendaCardByline(item, opts) {
 function agendaCardEffectStrip(item) {
   const st = agendaEffectState(item);
   if (!st || item.status !== 'open') return '';
-  if (!['pending', 'suspended', 'running'].includes(st.kind)) return '';
+  if (!['pending', 'suspended', 'running', 'missed'].includes(st.kind)) return '';
   const e = st.effect;
   let line = '';
   let tone = 'amber';
   let actions = '';
   const id = escapeHtml(item.id);
+  // The served fireability verdict (the daemon's own validator, decorated
+  // per read): Approve/Re-arm is NEVER offered against it — the primary
+  // affordance becomes fixing the plan, with the named field focused.
+  const refusal = e.fireability_refusal || null;
+  const fixBtn = (label) => `<button type="button" class="ag2-btn prim" data-edit-sched="${id}" data-focus="${escapeHtml((refusal && refusal.field) || '')}" title="${escapeHtml((refusal && refusal.reason) || 'Fix the plan')}">${label}</button>`;
   if (st.kind === 'pending') {
     const proposer = e.proposed_kind === 'dashboard'
       ? 'You proposed'
       : `“${agendaActorLabel({ session_id: e.proposed_session_id, kind: e.proposed_kind, principal: e.proposed_principal }) || 'a session'}” proposes`;
     line = `${proposer}: runs ${agendaAbsTime(st.manifest.fire_at_ms)}`
       + (st.rec ? ` · every ${agendaCadenceLabel(st.rec.every_ms)}` : ' · once')
-      + ' — needs your approval';
+      + (refusal ? ` — not fireable as planned: ${refusal.reason}` : ' — needs your approval');
     actions = agendaEffectRevisionChipHtml(e)
       + agendaDigestChipHtml(e.digest, 'Approve binds exactly this manifest revision',
         agendaDigestPulseClass(e.effect_id))
-      + `<button type="button" class="ag2-btn prim" data-op-btn="approve_effect" data-id="${id}" data-digest="${escapeHtml(e.digest || '')}" title="Binds this exact manifest digest — any edit voids it">Approve</button>`
-      + `<button type="button" class="ag2-btn ghost" data-edit-sched="${id}" title="Small tweaks without ceremony — shape, executor, project, goal, cadence. Saving mints a new digest for you to approve">Edit…</button>`
+      + (refusal
+        ? fixBtn('Fix plan…')
+        : `<button type="button" class="ag2-btn prim" data-op-btn="approve_effect" data-id="${id}" data-digest="${escapeHtml(e.digest || '')}" title="Binds this exact manifest digest — any edit voids it">Approve</button>`
+          + `<button type="button" class="ag2-btn ghost" data-edit-sched="${id}" data-focus="" title="Small tweaks without ceremony — shape, executor, project, goal, cadence. Saving mints a new digest for you to approve">Edit…</button>`)
+      + `<button type="button" class="ag2-btn ghost" data-open-item="${id}">Review</button>`;
+  } else if (st.kind === 'missed') {
+    // The missed-window terminal, self-explaining and carrying its one
+    // remedy: the run resolved `missed` (floor passed while the daemon
+    // was down), the approval is spent, and one tap re-proposes the
+    // SAME plan to run now and re-approves it.
+    line = 'Missed its window — the fire time passed while the daemon was down; nothing ran';
+    actions = agendaDigestChipHtml(e.digest, 'The manifest revision whose window was missed')
+      + `<button type="button" class="ag2-btn prim" data-resched-effect="${id}" title="Re-proposes this exact plan to run now and re-approves it in one tap">Re-approve to reschedule</button>`
       + `<button type="button" class="ag2-btn ghost" data-open-item="${id}">Review</button>`;
   } else if (st.kind === 'suspended') {
     line = `Standing run suspended after ${e.consecutive_failures} failures — never silently re-fired`;
@@ -94848,7 +94891,9 @@ function agendaCardEffectStrip(item) {
       line += ` · last self-report: ${rep.outcome}${repNote}`;
     }
     actions = agendaDigestChipHtml(e.digest, 'Re-arm re-approves exactly this unchanged manifest revision')
-      + `<button type="button" class="ag2-btn prim" data-op-btn="approve_effect" data-id="${id}" data-digest="${escapeHtml(e.digest || '')}" title="Re-approve the unchanged digest — resets the streak">Re-arm</button>`
+      + (refusal
+        ? fixBtn('Fix plan…')
+        : `<button type="button" class="ag2-btn prim" data-op-btn="approve_effect" data-id="${id}" data-digest="${escapeHtml(e.digest || '')}" title="Re-approve the unchanged digest — resets the streak">Re-arm</button>`)
       + `<button type="button" class="ag2-btn ghost" data-open-item="${id}">Review</button>`;
   } else {
     tone = 'iris';
@@ -94932,11 +94977,19 @@ function agendaAutomationStripHtml(item) {
     agendaDigestPulseClass(e.effect_id)));
   let actions = '';
   const digest = escapeHtml(e.digest || '');
-  if (st.kind === 'pending') {
+  // Same fireability gating as the inline strip: a served refusal
+  // withholds Approve/Re-arm and offers the focused fix instead.
+  const refusal = e.fireability_refusal || null;
+  if (refusal && (st.kind === 'pending' || st.kind === 'suspended')) {
+    meta.push(`<span class="ag2-auto-unfireable" title="${escapeHtml(refusal.reason)}">not fireable: ${escapeHtml(refusal.field)}</span>`);
+    actions = `<button type="button" class="ag2-btn prim" data-edit-sched="${id}" data-focus="${escapeHtml(refusal.field)}" title="${escapeHtml(refusal.reason)}">Fix plan…</button>`;
+  } else if (st.kind === 'pending') {
     actions = `<button type="button" class="ag2-btn prim" data-op-btn="approve_effect" data-id="${id}" data-digest="${digest}" title="Binds this exact manifest digest — any edit voids it">Approve</button>`
       + `<button type="button" class="ag2-btn ghost" data-edit-sched="${id}" title="Small tweaks without ceremony — saving mints a new digest for you to approve">Edit…</button>`;
   } else if (st.kind === 'suspended') {
     actions = `<button type="button" class="ag2-btn prim" data-op-btn="approve_effect" data-id="${id}" data-digest="${digest}" title="Re-approve the unchanged digest — resets the streak">Re-arm</button>`;
+  } else if (st.kind === 'missed') {
+    actions = `<button type="button" class="ag2-btn prim" data-resched-effect="${id}" title="Re-proposes this exact plan to run now and re-approves it in one tap">Re-approve to reschedule</button>`;
   } else if (st.kind === 'running') {
     const sess = e.last_run && e.last_run.session_id && agendaSessionInfo(e.last_run.session_id);
     actions = sess && sess.key
@@ -94947,10 +95000,10 @@ function agendaAutomationStripHtml(item) {
   } else if (['armed', 'watching', 'waiting', 'ready'].includes(st.kind)) {
     actions = `<button type="button" class="ag2-btn ghost" data-op-btn="revoke_effect" data-id="${id}" title="Withdraws the approval; the manifest and history stay">Revoke</button>`;
   }
-  const autoTone = st.kind === 'pending' || st.kind === 'suspended' ? 'amber'
+  const autoTone = ['pending', 'suspended', 'missed'].includes(st.kind) ? 'amber'
     : st.kind === 'standing' ? 'green'
       : ['armed', 'watching', 'waiting'].includes(st.kind) ? 'sky' : 'iris';
-  const autoSemantic = st.kind === 'pending' || st.kind === 'suspended' ? 'is-attention'
+  const autoSemantic = ['pending', 'suspended', 'missed'].includes(st.kind) ? 'is-attention'
     : ['running', 'ready'].includes(st.kind) ? 'is-progress' : '';
   return `<div class="ag2-eff ag2-auto t-${autoTone}${autoSemantic ? ` ${autoSemantic}` : ''}">
     <span class="ag2-auto-meta">${meta.join('<span class="ag2-auto-dot">·</span>')}</span>
@@ -95525,7 +95578,18 @@ function agendaGroupsClick(e) {
   if (editSched) {
     // The card's edit affordance OPENS the one editor — the schedule
     // sheet — whose save is the one re-propose emitter. No op here.
-    agendaOpenSchedSheet(editSched.dataset.editSched);
+    // `data-focus` (a served fireability field) lands the sheet on the
+    // named broken field.
+    agendaOpenSchedSheet(editSched.dataset.editSched,
+      editSched.dataset.focus ? { focus: editSched.dataset.focus } : undefined);
+    return;
+  }
+  const resched = e.target.closest('[data-resched-effect]');
+  if (resched) {
+    // The missed-window card's one-tap remedy: re-propose the SAME plan
+    // to run now + re-approve, in the reschedule lane's single emitter
+    // (ui2-agenda-inspector.js). No op emitted from the card itself.
+    agendaRescheduleMissed(resched.dataset.reschedEffect, resched);
     return;
   }
   const jump = e.target.closest('[data-jump-session]');
@@ -95858,6 +95922,52 @@ window.qa = Object.assign(window.qa || {}, {
       answerDraft: agendaQaDrafts[item.id] || '',
       openableFileRefs: document.querySelectorAll('#ag2-inspector [data-open-ref]').length,
       refReader: sheet,
+    };
+  },
+  // Fireability readback + driver (card 01KYSZAGQVHAAYS7BK9H3QFM3C QA
+  // leg): per-item effect state as the cards judge it (kind, the served
+  // refusal, which affordances the DOM actually offers), plus the
+  // schedule sheet's focus state. Drivers: `{route:true}` opens the tab,
+  // `{sched:id}` the schedule sheet, `{reschedule:id}` fires the
+  // missed-card one-tap (async — poll the readback for the outcome).
+  agendaFireability: (drive) => {
+    drive = drive || {};
+    if (drive.route && typeof routeTo === 'function') routeTo('agenda');
+    if (drive.sched && agendaFindItem(drive.sched)) {
+      agendaOpenSchedSheet(drive.sched);
+    }
+    if (drive.reschedule) {
+      const btn = document.querySelector(
+        `[data-resched-effect="${(window.CSS && CSS.escape) ? CSS.escape(drive.reschedule) : drive.reschedule}"]`
+      );
+      agendaRescheduleMissed(drive.reschedule, btn || undefined);
+    }
+    const effects = (agendaItems || []).flatMap((row) => {
+      const item = agendaFullItemFor(row.id) || row;
+      const st = agendaEffectState(item);
+      if (!st) return [];
+      const sel = (window.CSS && CSS.escape) ? CSS.escape(item.id) : item.id;
+      return [{
+        id: item.id,
+        kind: st.kind,
+        refusal: st.effect.fireability_refusal || null,
+        hasApprove: !!document.querySelector(`[data-op-btn="approve_effect"][data-id="${sel}"]`),
+        hasReschedule: !!document.querySelector(`[data-resched-effect="${sel}"]`),
+        hasFixPlan: !!document.querySelector(`[data-edit-sched="${sel}"][data-focus]:not([data-focus=""])`),
+      }];
+    });
+    const s = agendaSheetState;
+    return {
+      effects,
+      sheet: s && (s.kind === 'sched' || s.kind === 'sched-loading')
+        ? {
+          kind: s.kind,
+          itemId: s.itemId,
+          focusField: s.focusField || '',
+          error: s.error || '',
+          projectRequired: !!document.querySelector('#ag2-sheet .ags-hint-required'),
+        }
+        : null,
     };
   },
 });
@@ -97085,7 +97195,16 @@ function agendaRefReadDownload() {
 
 // -- Schedule sheet --
 
-function agendaOpenSchedSheet(itemId) {
+function agendaOpenSchedSheet(itemId, opts) {
+  // A fireability edit prompt (`opts.focus` = the refused field,
+  // `opts.refusal` = the daemon's named message) lands the sheet on the
+  // broken field with the refusal shown — the approve-time refusal is
+  // an edit prompt, never a dead end. Parked through the loading state
+  // and re-adopted when the arrival hook re-enters without opts.
+  if (!opts && agendaSheetState && agendaSheetState.kind === 'sched-loading'
+    && agendaSheetState.itemId === itemId) {
+    opts = agendaSheetState.opts || undefined;
+  }
   // Serving grain (Track AS): list rows are summaries — the manifest
   // MINUS goal and sealed refs. The editor round-trips the WHOLE
   // manifest, so it prefills only from the FULL item; until the
@@ -97096,7 +97215,7 @@ function agendaOpenSchedSheet(itemId) {
   const item = agendaFullItemFor(itemId);
   if (!item) {
     if (!agendaFindItem(itemId)) return;
-    agendaSheetState = { kind: 'sched-loading', itemId };
+    agendaSheetState = { kind: 'sched-loading', itemId, opts: opts || null };
     agendaSheetRender();
     return;
   }
@@ -97148,13 +97267,22 @@ function agendaOpenSchedSheet(itemId) {
     execEffort: cfg.claude_effort || cfg.codex_reasoning_effort || cfg.kimi_thinking || cfg.pi_thinking || '',
     approveNow: true,
     voids: !!(st && st.effect.approval),
-    error: '',
+    // A served fireability refusal (or an approve-time one carried in
+    // opts) renders as the sheet's inline error from the first paint,
+    // and the named field gets focus below.
+    error: (opts && opts.refusal)
+      || (st && st.effect.fireability_refusal
+        ? `unfireable(${st.effect.fireability_refusal.field}): ${st.effect.fireability_refusal.reason}`
+        : ''),
+    focusField: (opts && opts.focus)
+      || (st && st.effect.fireability_refusal && st.effect.fireability_refusal.field) || '',
   };
   // Opening the editor IS looking at the current revision.
   if (st && typeof agendaAckEffectDigest === 'function') {
     agendaAckEffectDigest(st.effect.effect_id, st.effect.digest);
   }
   agendaSheetRender();
+  agendaSchedApplyFocus();
   // Model/effort option lists come from the served settings; fetch like
   // the start sheet does and re-render when they land.
   if (agendaStartSheetSettings === null && typeof fetchDashboardSettings === 'function') {
@@ -97165,6 +97293,57 @@ function agendaOpenSchedSheet(itemId) {
         if (agendaSheetState && agendaSheetState.kind === 'sched') agendaSheetRender();
       });
   }
+  // The projectless-required hint derives from the SAME source the
+  // start sheet uses (api_project_root); fetch once and re-render so
+  // the Project row can say "required" instead of guessing.
+  if (agendaDaemonDefaultProject === null && typeof fetchProjectRoot === 'function') {
+    fetchProjectRoot()
+      .then((root) => { agendaDaemonDefaultProject = root || ''; })
+      .catch(() => { agendaDaemonDefaultProject = ''; })
+      .finally(() => {
+        if (agendaSheetState && agendaSheetState.kind === 'sched') agendaSheetRender();
+      });
+  }
+}
+
+// Migration honesty (fireability): an op refused by the daemon's
+// `unfireable(<field>): …` grammar — a parked pin-less manifest meeting
+// the validator at its next approve, or the missed-card one-tap hitting
+// a now-unresolvable plan — surfaces as an EDIT prompt, never a dead
+// end: the one plan editor opens with the named field focused and the
+// refusal shown. Called by agendaSendOp on every refusal; the grammar is
+// the daemon's pinned wire contract (FIREABILITY_REFUSAL_PREFIX in
+// agenda/fireability.rs).
+function agendaFireabilityEditPrompt(params, message) {
+  if (!params) return;
+  // approve refusals always prompt; a propose refusal prompts only when
+  // no sheet owns the gesture (the missed-card one-tap) — sheet flows
+  // keep their own inline errors.
+  const prompts = params.op === 'approve_effect'
+    || (params.op === 'propose_effect' && !agendaSheetState);
+  if (!prompts) return;
+  const match = /^unfireable\((project|executor|floor)\): /.exec(String(message || ''));
+  if (!match) return;
+  agendaOpenSchedSheet(params.id, { focus: match[1], refusal: String(message) });
+}
+
+// Land the sheet on the field a fireability refusal named: focus it and
+// pulse its row. project → the Project input, executor → the backend
+// select, floor → the First-run input.
+function agendaSchedApplyFocus() {
+  const s = agendaSheetState;
+  if (!s || s.kind !== 'sched' || !s.focusField) return;
+  const selector = s.focusField === 'project' ? '[data-sheet="projectRoot"]'
+    : s.focusField === 'executor' ? '[data-sheet="execBackend"]'
+      : s.focusField === 'floor' ? '[data-sheet="when"]' : '';
+  if (!selector) return;
+  const host = document.getElementById('ag2-sheet');
+  const el = host && host.querySelector(selector);
+  if (!el) return;
+  el.focus();
+  const row = el.closest('div') || el;
+  row.classList.add('ag2-field-attn');
+  setTimeout(() => row.classList.remove('ag2-field-attn'), 4000);
 }
 
 function agendaSchedSheetHtml(item) {
@@ -97268,8 +97447,8 @@ function agendaSchedSheetHtml(item) {
       ${cadenceBlock}
       <span class="ag2-sheet-k">Project</span>
       <div>
-        <input type="text" data-sheet="projectRoot" data-mf-field="project_root" aria-label="Project root" placeholder="resolves at fire time" value="${escapeHtml(s.projectRoot)}" />
-        <div class="ag2-hint">Absolute directory the fired session runs under; digest-bound. Empty = the parking session’s project, else the daemon default.</div>
+        <input type="text" data-sheet="projectRoot" data-mf-field="project_root" aria-label="Project root" placeholder="${escapeHtml(agendaSchedProjectPlaceholder(item))}" value="${escapeHtml(s.projectRoot)}" />
+        ${agendaSchedProjectHintHtml(item, s)}
       </div>
     </div>
     ${standingBlock}
@@ -97283,6 +97462,34 @@ function agendaSchedSheetHtml(item) {
       <button type="button" class="ag2-btn ghost" data-sheet-act="close">Cancel</button>
       <button type="button" class="ag2-btn prim" data-sheet-act="sched-confirm">${s.approveNow ? 'Propose & approve' : 'Propose schedule'}</button>
     </div>`;
+}
+
+// The Project row's hint, derived from the SAME resolution the daemon's
+// fireability validator runs (explicit → the parking session's root →
+// the daemon default → refused named): an empty pick on an item the
+// chain cannot cover says "required" up front, exactly like the
+// start-now sheet — one knowledge source (agendaStartProjectResolution),
+// never a sheet-local copy of the rule. The daemon remains the
+// authority: its propose-time refusal renders inline if a stale hint
+// let an unresolvable propose through.
+function agendaSchedProjectHintHtml(item, s) {
+  if (s.projectRoot) {
+    return '<div class="ag2-hint">Absolute directory the fired session runs under; digest-bound — recorded on the manifest so the approval covers where.</div>';
+  }
+  const res = agendaStartProjectResolution(item);
+  const hint = `empty = ${agendaStartProjectHint(res.source)}`
+    + (res.value ? ` (${res.value})` : '');
+  const required = res.source === 'none';
+  return `<div class="ag2-hint${required ? ' ags-hint-required' : ''}">${escapeHtml(
+    required
+      ? 'required — this daemon runs without a default project and the propose will be refused without one'
+      : hint
+  )}</div>`;
+}
+
+function agendaSchedProjectPlaceholder(item) {
+  const res = agendaStartProjectResolution(item);
+  return res.value ? res.value : res.source === 'none' ? 'required on this daemon' : 'resolves when proposed';
 }
 
 // The executor rows on the schedule sheet (Track AU): backend/model/
@@ -97396,12 +97603,16 @@ async function agendaSchedConfirm(button) {
       agendaAckEffectDigest(effect.effect_id, effect.digest);
       agendaDigestPulse = { effectId: effect.effect_id, at: Date.now() };
     }
+    // Close BEFORE the approve leg: a refused approve surfaces through
+    // agendaSendOp (tab flash, card paint, and the fireability edit
+    // prompt re-opening this sheet focused) — closing afterwards would
+    // clobber that re-open.
+    agendaSheetClose();
+    agendaSheetRender();
     let approved = false;
     if (s.approveNow && effect && effect.digest) {
       approved = await agendaSendOp({ op: 'approve_effect', id: item.id, digest: effect.digest });
     }
-    agendaSheetClose();
-    agendaSheetRender();
     if (typeof showControlToast === 'function') {
       const short = effect && effect.digest ? agendaShortDigest(effect.digest) : '';
       showControlToast(approved ? 'success' : 'info', approved
@@ -97410,6 +97621,73 @@ async function agendaSchedConfirm(button) {
     }
   } catch (e) {
     fail(String(e && e.message || e));
+  } finally {
+    if (button) button.disabled = false;
+  }
+}
+
+// The missed-window card's one-tap remedy — the RESCHEDULE lane's single
+// propose emitter (the third lane beside the edit sheet's confirm and
+// the seals adopt; each lane one emitter). Re-proposes the manifest
+// VERBATIM with the floor moved to now (the one thing the miss broke)
+// and re-approves the fresh digest — the tap happens on an owner
+// surface, and the copy on the button names exactly that. Grain law:
+// the manifest comes from the FULL item (a summary would blank the goal
+// and unseal the refs); a cache miss awaits the item route directly.
+async function agendaRescheduleMissed(itemId, button) {
+  if (button) button.disabled = true;
+  try {
+    let item = agendaFullItemFor(itemId);
+    if (!item) {
+      try {
+        const resp = await daemonApi.request('api_agenda_item', { item_id: itemId });
+        if (resp.ok && resp.body && resp.body.item) {
+          agendaAdoptFullItem(resp.body.item);
+          item = resp.body.item;
+        }
+      } catch (e) { /* named refusal below */ }
+    }
+    if (!item) {
+      agendaFlashError('could not load the full plan to reschedule — try again');
+      return false;
+    }
+    const st = agendaEffectState(item);
+    const m = st && st.manifest;
+    if (!st || !m || st.kind !== 'missed') {
+      agendaFlashError('nothing to reschedule — the plan changed under this card');
+      agendaRenderTab();
+      return false;
+    }
+    const params = {
+      op: 'propose_effect',
+      id: item.id,
+      goal: m.goal,
+      fire_at_ms: Date.now(),
+      orchestrate: !!m.orchestrate,
+    };
+    if (m.interactive) params.interactive = true;
+    if (m.project_root) params.project_root = m.project_root;
+    if (m.agent_config) params.agent_config = m.agent_config;
+    if (m.recurrence) params.recurrence = m.recurrence;
+    if (m.trigger) params.trigger = m.trigger;
+    if (Array.isArray(m.binding_refs) && m.binding_refs.length) params.binding_refs = m.binding_refs;
+    const proposed = await agendaSendOp(params, button);
+    if (!proposed) return false;
+    const effect = (proposed.effects || [])[0];
+    if (effect && typeof agendaAckEffectDigest === 'function') {
+      agendaAckEffectDigest(effect.effect_id, effect.digest);
+      agendaDigestPulse = { effectId: effect.effect_id, at: Date.now() };
+    }
+    const approved = effect && effect.digest
+      ? await agendaSendOp({ op: 'approve_effect', id: item.id, digest: effect.digest }, button)
+      : false;
+    if (approved) {
+      if (typeof agendaApprovalMoment === 'function') agendaApprovalMoment(approved);
+      if (typeof showControlToast === 'function') {
+        showControlToast('success', 'Rescheduled — the same plan runs now under a fresh approval.');
+      }
+    }
+    return !!approved;
   } finally {
     if (button) button.disabled = false;
   }

--- a/static/app/ui2-agenda-cards.js
+++ b/static/app/ui2-agenda-cards.js
@@ -966,24 +966,40 @@ function agendaCardByline(item, opts) {
 function agendaCardEffectStrip(item) {
   const st = agendaEffectState(item);
   if (!st || item.status !== 'open') return '';
-  if (!['pending', 'suspended', 'running'].includes(st.kind)) return '';
+  if (!['pending', 'suspended', 'running', 'missed'].includes(st.kind)) return '';
   const e = st.effect;
   let line = '';
   let tone = 'amber';
   let actions = '';
   const id = escapeHtml(item.id);
+  // The served fireability verdict (the daemon's own validator, decorated
+  // per read): Approve/Re-arm is NEVER offered against it — the primary
+  // affordance becomes fixing the plan, with the named field focused.
+  const refusal = e.fireability_refusal || null;
+  const fixBtn = (label) => `<button type="button" class="ag2-btn prim" data-edit-sched="${id}" data-focus="${escapeHtml((refusal && refusal.field) || '')}" title="${escapeHtml((refusal && refusal.reason) || 'Fix the plan')}">${label}</button>`;
   if (st.kind === 'pending') {
     const proposer = e.proposed_kind === 'dashboard'
       ? 'You proposed'
       : `“${agendaActorLabel({ session_id: e.proposed_session_id, kind: e.proposed_kind, principal: e.proposed_principal }) || 'a session'}” proposes`;
     line = `${proposer}: runs ${agendaAbsTime(st.manifest.fire_at_ms)}`
       + (st.rec ? ` · every ${agendaCadenceLabel(st.rec.every_ms)}` : ' · once')
-      + ' — needs your approval';
+      + (refusal ? ` — not fireable as planned: ${refusal.reason}` : ' — needs your approval');
     actions = agendaEffectRevisionChipHtml(e)
       + agendaDigestChipHtml(e.digest, 'Approve binds exactly this manifest revision',
         agendaDigestPulseClass(e.effect_id))
-      + `<button type="button" class="ag2-btn prim" data-op-btn="approve_effect" data-id="${id}" data-digest="${escapeHtml(e.digest || '')}" title="Binds this exact manifest digest — any edit voids it">Approve</button>`
-      + `<button type="button" class="ag2-btn ghost" data-edit-sched="${id}" title="Small tweaks without ceremony — shape, executor, project, goal, cadence. Saving mints a new digest for you to approve">Edit…</button>`
+      + (refusal
+        ? fixBtn('Fix plan…')
+        : `<button type="button" class="ag2-btn prim" data-op-btn="approve_effect" data-id="${id}" data-digest="${escapeHtml(e.digest || '')}" title="Binds this exact manifest digest — any edit voids it">Approve</button>`
+          + `<button type="button" class="ag2-btn ghost" data-edit-sched="${id}" data-focus="" title="Small tweaks without ceremony — shape, executor, project, goal, cadence. Saving mints a new digest for you to approve">Edit…</button>`)
+      + `<button type="button" class="ag2-btn ghost" data-open-item="${id}">Review</button>`;
+  } else if (st.kind === 'missed') {
+    // The missed-window terminal, self-explaining and carrying its one
+    // remedy: the run resolved `missed` (floor passed while the daemon
+    // was down), the approval is spent, and one tap re-proposes the
+    // SAME plan to run now and re-approves it.
+    line = 'Missed its window — the fire time passed while the daemon was down; nothing ran';
+    actions = agendaDigestChipHtml(e.digest, 'The manifest revision whose window was missed')
+      + `<button type="button" class="ag2-btn prim" data-resched-effect="${id}" title="Re-proposes this exact plan to run now and re-approves it in one tap">Re-approve to reschedule</button>`
       + `<button type="button" class="ag2-btn ghost" data-open-item="${id}">Review</button>`;
   } else if (st.kind === 'suspended') {
     line = `Standing run suspended after ${e.consecutive_failures} failures — never silently re-fired`;
@@ -996,7 +1012,9 @@ function agendaCardEffectStrip(item) {
       line += ` · last self-report: ${rep.outcome}${repNote}`;
     }
     actions = agendaDigestChipHtml(e.digest, 'Re-arm re-approves exactly this unchanged manifest revision')
-      + `<button type="button" class="ag2-btn prim" data-op-btn="approve_effect" data-id="${id}" data-digest="${escapeHtml(e.digest || '')}" title="Re-approve the unchanged digest — resets the streak">Re-arm</button>`
+      + (refusal
+        ? fixBtn('Fix plan…')
+        : `<button type="button" class="ag2-btn prim" data-op-btn="approve_effect" data-id="${id}" data-digest="${escapeHtml(e.digest || '')}" title="Re-approve the unchanged digest — resets the streak">Re-arm</button>`)
       + `<button type="button" class="ag2-btn ghost" data-open-item="${id}">Review</button>`;
   } else {
     tone = 'iris';
@@ -1080,11 +1098,19 @@ function agendaAutomationStripHtml(item) {
     agendaDigestPulseClass(e.effect_id)));
   let actions = '';
   const digest = escapeHtml(e.digest || '');
-  if (st.kind === 'pending') {
+  // Same fireability gating as the inline strip: a served refusal
+  // withholds Approve/Re-arm and offers the focused fix instead.
+  const refusal = e.fireability_refusal || null;
+  if (refusal && (st.kind === 'pending' || st.kind === 'suspended')) {
+    meta.push(`<span class="ag2-auto-unfireable" title="${escapeHtml(refusal.reason)}">not fireable: ${escapeHtml(refusal.field)}</span>`);
+    actions = `<button type="button" class="ag2-btn prim" data-edit-sched="${id}" data-focus="${escapeHtml(refusal.field)}" title="${escapeHtml(refusal.reason)}">Fix plan…</button>`;
+  } else if (st.kind === 'pending') {
     actions = `<button type="button" class="ag2-btn prim" data-op-btn="approve_effect" data-id="${id}" data-digest="${digest}" title="Binds this exact manifest digest — any edit voids it">Approve</button>`
       + `<button type="button" class="ag2-btn ghost" data-edit-sched="${id}" title="Small tweaks without ceremony — saving mints a new digest for you to approve">Edit…</button>`;
   } else if (st.kind === 'suspended') {
     actions = `<button type="button" class="ag2-btn prim" data-op-btn="approve_effect" data-id="${id}" data-digest="${digest}" title="Re-approve the unchanged digest — resets the streak">Re-arm</button>`;
+  } else if (st.kind === 'missed') {
+    actions = `<button type="button" class="ag2-btn prim" data-resched-effect="${id}" title="Re-proposes this exact plan to run now and re-approves it in one tap">Re-approve to reschedule</button>`;
   } else if (st.kind === 'running') {
     const sess = e.last_run && e.last_run.session_id && agendaSessionInfo(e.last_run.session_id);
     actions = sess && sess.key
@@ -1095,10 +1121,10 @@ function agendaAutomationStripHtml(item) {
   } else if (['armed', 'watching', 'waiting', 'ready'].includes(st.kind)) {
     actions = `<button type="button" class="ag2-btn ghost" data-op-btn="revoke_effect" data-id="${id}" title="Withdraws the approval; the manifest and history stay">Revoke</button>`;
   }
-  const autoTone = st.kind === 'pending' || st.kind === 'suspended' ? 'amber'
+  const autoTone = ['pending', 'suspended', 'missed'].includes(st.kind) ? 'amber'
     : st.kind === 'standing' ? 'green'
       : ['armed', 'watching', 'waiting'].includes(st.kind) ? 'sky' : 'iris';
-  const autoSemantic = st.kind === 'pending' || st.kind === 'suspended' ? 'is-attention'
+  const autoSemantic = ['pending', 'suspended', 'missed'].includes(st.kind) ? 'is-attention'
     : ['running', 'ready'].includes(st.kind) ? 'is-progress' : '';
   return `<div class="ag2-eff ag2-auto t-${autoTone}${autoSemantic ? ` ${autoSemantic}` : ''}">
     <span class="ag2-auto-meta">${meta.join('<span class="ag2-auto-dot">·</span>')}</span>
@@ -1673,7 +1699,18 @@ function agendaGroupsClick(e) {
   if (editSched) {
     // The card's edit affordance OPENS the one editor — the schedule
     // sheet — whose save is the one re-propose emitter. No op here.
-    agendaOpenSchedSheet(editSched.dataset.editSched);
+    // `data-focus` (a served fireability field) lands the sheet on the
+    // named broken field.
+    agendaOpenSchedSheet(editSched.dataset.editSched,
+      editSched.dataset.focus ? { focus: editSched.dataset.focus } : undefined);
+    return;
+  }
+  const resched = e.target.closest('[data-resched-effect]');
+  if (resched) {
+    // The missed-window card's one-tap remedy: re-propose the SAME plan
+    // to run now + re-approve, in the reschedule lane's single emitter
+    // (ui2-agenda-inspector.js). No op emitted from the card itself.
+    agendaRescheduleMissed(resched.dataset.reschedEffect, resched);
     return;
   }
   const jump = e.target.closest('[data-jump-session]');

--- a/static/app/ui2-agenda-inspector.css
+++ b/static/app/ui2-agenda-inspector.css
@@ -1060,6 +1060,16 @@ html.ui-v2 .ag2-sheet-error {
   padding-left: 8px;
   overflow-wrap: anywhere;
 }
+/* Fireability edit prompt: the field a refusal named gets a brief
+   attention ring when the sheet lands on it; the required-project hint
+   matches the start sheet's amber emphasis. */
+html.ui-v2 .ag2-field-attn {
+  outline: 2px solid rgba(var(--amber-rgb), 0.55);
+  outline-offset: 2px;
+  border-radius: 8px;
+  transition: outline-color 0.4s ease;
+}
+html.ui-v2 .ag2-hint.ags-hint-required { color: var(--amber); font-weight: 600; }
 /* Sealed refs on the schedule sheet: read-only rows — locator + the
    pinned hash chip. Deliberately input-less: the edit lane carries them
    verbatim; re-sealing is its own ceremony. */

--- a/static/app/ui2-agenda-inspector.js
+++ b/static/app/ui2-agenda-inspector.js
@@ -232,6 +232,52 @@ window.qa = Object.assign(window.qa || {}, {
       refReader: sheet,
     };
   },
+  // Fireability readback + driver (card 01KYSZAGQVHAAYS7BK9H3QFM3C QA
+  // leg): per-item effect state as the cards judge it (kind, the served
+  // refusal, which affordances the DOM actually offers), plus the
+  // schedule sheet's focus state. Drivers: `{route:true}` opens the tab,
+  // `{sched:id}` the schedule sheet, `{reschedule:id}` fires the
+  // missed-card one-tap (async — poll the readback for the outcome).
+  agendaFireability: (drive) => {
+    drive = drive || {};
+    if (drive.route && typeof routeTo === 'function') routeTo('agenda');
+    if (drive.sched && agendaFindItem(drive.sched)) {
+      agendaOpenSchedSheet(drive.sched);
+    }
+    if (drive.reschedule) {
+      const btn = document.querySelector(
+        `[data-resched-effect="${(window.CSS && CSS.escape) ? CSS.escape(drive.reschedule) : drive.reschedule}"]`
+      );
+      agendaRescheduleMissed(drive.reschedule, btn || undefined);
+    }
+    const effects = (agendaItems || []).flatMap((row) => {
+      const item = agendaFullItemFor(row.id) || row;
+      const st = agendaEffectState(item);
+      if (!st) return [];
+      const sel = (window.CSS && CSS.escape) ? CSS.escape(item.id) : item.id;
+      return [{
+        id: item.id,
+        kind: st.kind,
+        refusal: st.effect.fireability_refusal || null,
+        hasApprove: !!document.querySelector(`[data-op-btn="approve_effect"][data-id="${sel}"]`),
+        hasReschedule: !!document.querySelector(`[data-resched-effect="${sel}"]`),
+        hasFixPlan: !!document.querySelector(`[data-edit-sched="${sel}"][data-focus]:not([data-focus=""])`),
+      }];
+    });
+    const s = agendaSheetState;
+    return {
+      effects,
+      sheet: s && (s.kind === 'sched' || s.kind === 'sched-loading')
+        ? {
+          kind: s.kind,
+          itemId: s.itemId,
+          focusField: s.focusField || '',
+          error: s.error || '',
+          projectRequired: !!document.querySelector('#ag2-sheet .ags-hint-required'),
+        }
+        : null,
+    };
+  },
 });
 
 // ---- Header ----
@@ -1457,7 +1503,16 @@ function agendaRefReadDownload() {
 
 // -- Schedule sheet --
 
-function agendaOpenSchedSheet(itemId) {
+function agendaOpenSchedSheet(itemId, opts) {
+  // A fireability edit prompt (`opts.focus` = the refused field,
+  // `opts.refusal` = the daemon's named message) lands the sheet on the
+  // broken field with the refusal shown — the approve-time refusal is
+  // an edit prompt, never a dead end. Parked through the loading state
+  // and re-adopted when the arrival hook re-enters without opts.
+  if (!opts && agendaSheetState && agendaSheetState.kind === 'sched-loading'
+    && agendaSheetState.itemId === itemId) {
+    opts = agendaSheetState.opts || undefined;
+  }
   // Serving grain (Track AS): list rows are summaries — the manifest
   // MINUS goal and sealed refs. The editor round-trips the WHOLE
   // manifest, so it prefills only from the FULL item; until the
@@ -1468,7 +1523,7 @@ function agendaOpenSchedSheet(itemId) {
   const item = agendaFullItemFor(itemId);
   if (!item) {
     if (!agendaFindItem(itemId)) return;
-    agendaSheetState = { kind: 'sched-loading', itemId };
+    agendaSheetState = { kind: 'sched-loading', itemId, opts: opts || null };
     agendaSheetRender();
     return;
   }
@@ -1520,13 +1575,22 @@ function agendaOpenSchedSheet(itemId) {
     execEffort: cfg.claude_effort || cfg.codex_reasoning_effort || cfg.kimi_thinking || cfg.pi_thinking || '',
     approveNow: true,
     voids: !!(st && st.effect.approval),
-    error: '',
+    // A served fireability refusal (or an approve-time one carried in
+    // opts) renders as the sheet's inline error from the first paint,
+    // and the named field gets focus below.
+    error: (opts && opts.refusal)
+      || (st && st.effect.fireability_refusal
+        ? `unfireable(${st.effect.fireability_refusal.field}): ${st.effect.fireability_refusal.reason}`
+        : ''),
+    focusField: (opts && opts.focus)
+      || (st && st.effect.fireability_refusal && st.effect.fireability_refusal.field) || '',
   };
   // Opening the editor IS looking at the current revision.
   if (st && typeof agendaAckEffectDigest === 'function') {
     agendaAckEffectDigest(st.effect.effect_id, st.effect.digest);
   }
   agendaSheetRender();
+  agendaSchedApplyFocus();
   // Model/effort option lists come from the served settings; fetch like
   // the start sheet does and re-render when they land.
   if (agendaStartSheetSettings === null && typeof fetchDashboardSettings === 'function') {
@@ -1537,6 +1601,57 @@ function agendaOpenSchedSheet(itemId) {
         if (agendaSheetState && agendaSheetState.kind === 'sched') agendaSheetRender();
       });
   }
+  // The projectless-required hint derives from the SAME source the
+  // start sheet uses (api_project_root); fetch once and re-render so
+  // the Project row can say "required" instead of guessing.
+  if (agendaDaemonDefaultProject === null && typeof fetchProjectRoot === 'function') {
+    fetchProjectRoot()
+      .then((root) => { agendaDaemonDefaultProject = root || ''; })
+      .catch(() => { agendaDaemonDefaultProject = ''; })
+      .finally(() => {
+        if (agendaSheetState && agendaSheetState.kind === 'sched') agendaSheetRender();
+      });
+  }
+}
+
+// Migration honesty (fireability): an op refused by the daemon's
+// `unfireable(<field>): …` grammar — a parked pin-less manifest meeting
+// the validator at its next approve, or the missed-card one-tap hitting
+// a now-unresolvable plan — surfaces as an EDIT prompt, never a dead
+// end: the one plan editor opens with the named field focused and the
+// refusal shown. Called by agendaSendOp on every refusal; the grammar is
+// the daemon's pinned wire contract (FIREABILITY_REFUSAL_PREFIX in
+// agenda/fireability.rs).
+function agendaFireabilityEditPrompt(params, message) {
+  if (!params) return;
+  // approve refusals always prompt; a propose refusal prompts only when
+  // no sheet owns the gesture (the missed-card one-tap) — sheet flows
+  // keep their own inline errors.
+  const prompts = params.op === 'approve_effect'
+    || (params.op === 'propose_effect' && !agendaSheetState);
+  if (!prompts) return;
+  const match = /^unfireable\((project|executor|floor)\): /.exec(String(message || ''));
+  if (!match) return;
+  agendaOpenSchedSheet(params.id, { focus: match[1], refusal: String(message) });
+}
+
+// Land the sheet on the field a fireability refusal named: focus it and
+// pulse its row. project → the Project input, executor → the backend
+// select, floor → the First-run input.
+function agendaSchedApplyFocus() {
+  const s = agendaSheetState;
+  if (!s || s.kind !== 'sched' || !s.focusField) return;
+  const selector = s.focusField === 'project' ? '[data-sheet="projectRoot"]'
+    : s.focusField === 'executor' ? '[data-sheet="execBackend"]'
+      : s.focusField === 'floor' ? '[data-sheet="when"]' : '';
+  if (!selector) return;
+  const host = document.getElementById('ag2-sheet');
+  const el = host && host.querySelector(selector);
+  if (!el) return;
+  el.focus();
+  const row = el.closest('div') || el;
+  row.classList.add('ag2-field-attn');
+  setTimeout(() => row.classList.remove('ag2-field-attn'), 4000);
 }
 
 function agendaSchedSheetHtml(item) {
@@ -1640,8 +1755,8 @@ function agendaSchedSheetHtml(item) {
       ${cadenceBlock}
       <span class="ag2-sheet-k">Project</span>
       <div>
-        <input type="text" data-sheet="projectRoot" data-mf-field="project_root" aria-label="Project root" placeholder="resolves at fire time" value="${escapeHtml(s.projectRoot)}" />
-        <div class="ag2-hint">Absolute directory the fired session runs under; digest-bound. Empty = the parking session’s project, else the daemon default.</div>
+        <input type="text" data-sheet="projectRoot" data-mf-field="project_root" aria-label="Project root" placeholder="${escapeHtml(agendaSchedProjectPlaceholder(item))}" value="${escapeHtml(s.projectRoot)}" />
+        ${agendaSchedProjectHintHtml(item, s)}
       </div>
     </div>
     ${standingBlock}
@@ -1655,6 +1770,34 @@ function agendaSchedSheetHtml(item) {
       <button type="button" class="ag2-btn ghost" data-sheet-act="close">Cancel</button>
       <button type="button" class="ag2-btn prim" data-sheet-act="sched-confirm">${s.approveNow ? 'Propose & approve' : 'Propose schedule'}</button>
     </div>`;
+}
+
+// The Project row's hint, derived from the SAME resolution the daemon's
+// fireability validator runs (explicit → the parking session's root →
+// the daemon default → refused named): an empty pick on an item the
+// chain cannot cover says "required" up front, exactly like the
+// start-now sheet — one knowledge source (agendaStartProjectResolution),
+// never a sheet-local copy of the rule. The daemon remains the
+// authority: its propose-time refusal renders inline if a stale hint
+// let an unresolvable propose through.
+function agendaSchedProjectHintHtml(item, s) {
+  if (s.projectRoot) {
+    return '<div class="ag2-hint">Absolute directory the fired session runs under; digest-bound — recorded on the manifest so the approval covers where.</div>';
+  }
+  const res = agendaStartProjectResolution(item);
+  const hint = `empty = ${agendaStartProjectHint(res.source)}`
+    + (res.value ? ` (${res.value})` : '');
+  const required = res.source === 'none';
+  return `<div class="ag2-hint${required ? ' ags-hint-required' : ''}">${escapeHtml(
+    required
+      ? 'required — this daemon runs without a default project and the propose will be refused without one'
+      : hint
+  )}</div>`;
+}
+
+function agendaSchedProjectPlaceholder(item) {
+  const res = agendaStartProjectResolution(item);
+  return res.value ? res.value : res.source === 'none' ? 'required on this daemon' : 'resolves when proposed';
 }
 
 // The executor rows on the schedule sheet (Track AU): backend/model/
@@ -1768,12 +1911,16 @@ async function agendaSchedConfirm(button) {
       agendaAckEffectDigest(effect.effect_id, effect.digest);
       agendaDigestPulse = { effectId: effect.effect_id, at: Date.now() };
     }
+    // Close BEFORE the approve leg: a refused approve surfaces through
+    // agendaSendOp (tab flash, card paint, and the fireability edit
+    // prompt re-opening this sheet focused) — closing afterwards would
+    // clobber that re-open.
+    agendaSheetClose();
+    agendaSheetRender();
     let approved = false;
     if (s.approveNow && effect && effect.digest) {
       approved = await agendaSendOp({ op: 'approve_effect', id: item.id, digest: effect.digest });
     }
-    agendaSheetClose();
-    agendaSheetRender();
     if (typeof showControlToast === 'function') {
       const short = effect && effect.digest ? agendaShortDigest(effect.digest) : '';
       showControlToast(approved ? 'success' : 'info', approved
@@ -1782,6 +1929,73 @@ async function agendaSchedConfirm(button) {
     }
   } catch (e) {
     fail(String(e && e.message || e));
+  } finally {
+    if (button) button.disabled = false;
+  }
+}
+
+// The missed-window card's one-tap remedy — the RESCHEDULE lane's single
+// propose emitter (the third lane beside the edit sheet's confirm and
+// the seals adopt; each lane one emitter). Re-proposes the manifest
+// VERBATIM with the floor moved to now (the one thing the miss broke)
+// and re-approves the fresh digest — the tap happens on an owner
+// surface, and the copy on the button names exactly that. Grain law:
+// the manifest comes from the FULL item (a summary would blank the goal
+// and unseal the refs); a cache miss awaits the item route directly.
+async function agendaRescheduleMissed(itemId, button) {
+  if (button) button.disabled = true;
+  try {
+    let item = agendaFullItemFor(itemId);
+    if (!item) {
+      try {
+        const resp = await daemonApi.request('api_agenda_item', { item_id: itemId });
+        if (resp.ok && resp.body && resp.body.item) {
+          agendaAdoptFullItem(resp.body.item);
+          item = resp.body.item;
+        }
+      } catch (e) { /* named refusal below */ }
+    }
+    if (!item) {
+      agendaFlashError('could not load the full plan to reschedule — try again');
+      return false;
+    }
+    const st = agendaEffectState(item);
+    const m = st && st.manifest;
+    if (!st || !m || st.kind !== 'missed') {
+      agendaFlashError('nothing to reschedule — the plan changed under this card');
+      agendaRenderTab();
+      return false;
+    }
+    const params = {
+      op: 'propose_effect',
+      id: item.id,
+      goal: m.goal,
+      fire_at_ms: Date.now(),
+      orchestrate: !!m.orchestrate,
+    };
+    if (m.interactive) params.interactive = true;
+    if (m.project_root) params.project_root = m.project_root;
+    if (m.agent_config) params.agent_config = m.agent_config;
+    if (m.recurrence) params.recurrence = m.recurrence;
+    if (m.trigger) params.trigger = m.trigger;
+    if (Array.isArray(m.binding_refs) && m.binding_refs.length) params.binding_refs = m.binding_refs;
+    const proposed = await agendaSendOp(params, button);
+    if (!proposed) return false;
+    const effect = (proposed.effects || [])[0];
+    if (effect && typeof agendaAckEffectDigest === 'function') {
+      agendaAckEffectDigest(effect.effect_id, effect.digest);
+      agendaDigestPulse = { effectId: effect.effect_id, at: Date.now() };
+    }
+    const approved = effect && effect.digest
+      ? await agendaSendOp({ op: 'approve_effect', id: item.id, digest: effect.digest }, button)
+      : false;
+    if (approved) {
+      if (typeof agendaApprovalMoment === 'function') agendaApprovalMoment(approved);
+      if (typeof showControlToast === 'function') {
+        showControlToast('success', 'Rescheduled — the same plan runs now under a fresh approval.');
+      }
+    }
+    return !!approved;
   } finally {
     if (button) button.disabled = false;
   }

--- a/static/app/ui2-agenda.css
+++ b/static/app/ui2-agenda.css
@@ -758,6 +758,10 @@ html.ui-v2 .ag2-auto-last.st-failed,
 html.ui-v2 .ag2-auto-last.st-unknown,
 html.ui-v2 .ag2-auto-streak { color: var(--rose); font-weight: 600; }
 html.ui-v2 .ag2-auto-last.st-completed { color: var(--green); }
+/* The missed-window terminal is a state the owner acts on (re-approve to
+   reschedule), not benign body text — amber, like the card state. */
+html.ui-v2 .ag2-auto-last.st-missed,
+html.ui-v2 .ag2-auto-unfireable { color: var(--amber); font-weight: 600; }
 html.ui-v2 .ag2-auto-run { cursor: pointer; text-decoration: underline; }
 /* Attestation (Track AO) — the self-report axis, never the transport
    palette: achieved sky (never transport-success green), the rest

--- a/static/app/ui2-agenda.js
+++ b/static/app/ui2-agenda.js
@@ -604,11 +604,17 @@ async function agendaSendOp(params, button) {
     const message = (resp.body && resp.body.error) || `agenda op failed (${resp.status})`;
     agendaFlashError(message);
     agendaPaintRefusal(button, message);
+    if (typeof agendaFireabilityEditPrompt === 'function') {
+      agendaFireabilityEditPrompt(params, message);
+    }
     return false;
   } catch (e) {
     const message = String(e && e.message || e);
     agendaFlashError(message);
     agendaPaintRefusal(button, message);
+    if (typeof agendaFireabilityEditPrompt === 'function') {
+      agendaFireabilityEditPrompt(params, message);
+    }
     return false;
   } finally {
     if (button) button.disabled = false;
@@ -730,7 +736,14 @@ function agendaEffectState(item) {
           : (item.relies_on || []).every((link) => agendaLinkState(link).satisfied)
             ? 'ready' : 'waiting')
           : rec ? 'standing'
-            : next > Date.now() ? 'armed' : 'finished';
+            // The missed-window terminal is its own self-explaining
+            // state, not a silent 'finished': a one-shot whose floor
+            // passed while the daemon was down carries its one-tap
+            // remedy (re-approve to reschedule) on the card. A missed
+            // instant on a standing series stays 'standing' above —
+            // the series continues unaffected.
+            : effect.last_run && effect.last_run.state === 'missed' ? 'missed'
+              : next > Date.now() ? 'armed' : 'finished';
   return { effect, manifest, rec, trig, threshold, suspended, running, next, kind };
 }
 

--- a/tests/skills/fireability-qa/SKILL.md
+++ b/tests/skills/fireability-qa/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: fireability-qa
+description: >
+  QA-harness leg for propose-time fireability (card 01KYSZAGQVHAAYS7BK9H3QFM3C):
+  against a scratch daemon seeded with (a) an APPROVED one-shot whose floor
+  passed more than a staleness window ago — the missed-window terminal —
+  and (b) a pending manifest pinned to a directory that no longer exists,
+  the dashboard must render the missed card state with its one-tap
+  Re-approve-to-reschedule affordance (tapping it re-proposes the plan at
+  now and re-approves, leaving the effect armed), and must render the
+  pending card WITHOUT an Approve button — Fix plan… instead, opening the
+  schedule sheet focused on the named field; `ctl agenda approve` on the
+  same manifest is refused with the `unfireable(project): …` grammar.
+  Keyless for the render legs; the post-reschedule spawn uses the mock
+  provider. Drives the real SPA over CDP via scripts/validate-dashboard.cjs.
+compatibility: Operator hardware or any box with Chromium — never CI as-is
+  (spawns a daemon and a browser). No display capture involved.
+allowed-tools: Bash Read
+---
+
+# Propose-time fireability — QA harness leg
+
+What ships under test: the ONE validator (`agenda/fireability.rs`) run in
+the propose/approve intake, the served `fireability_refusal` decoration,
+the missed-window card state with the one-tap reschedule
+(`agendaRescheduleMissed`), and the approve-refusal edit prompt. The SPA
+exposes the readback as `window.qa.agendaFireability()`.
+
+## 1. Seed the agenda log BEFORE the daemon boots
+
+The missed terminal needs a floor that passed while no daemon was up —
+seed the op log directly (the fold loads history untouched; approval
+digests bind `sha256("agenda-effect\0item\0effect\0" + manifest JSON)`,
+first 16 bytes hex):
+
+```bash
+cargo build --bin intendant --bin intendant-runtime
+export QA_HOME=$(mktemp -d) QA_PORT=18973
+mkdir -p "$QA_HOME/agenda"
+python3 - "$QA_HOME/agenda/agenda.jsonl" <<'EOF'
+import hashlib, json, sys, time
+now = int(time.time() * 1000)
+stale = now - 26 * 3600_000          # 26h ago — past the 12h staleness default
+mf_m = {"goal": "qa: missed window", "fire_at_ms": stale}
+digest = hashlib.sha256(
+    b"agenda-effect\0it-missed\0ef-qa-missed00\0"
+    + json.dumps(mf_m, separators=(",", ":")).encode()
+).hexdigest()[:32]
+mf_u = {"goal": "qa: unfireable plan", "fire_at_ms": now + 3600_000,
+        "project_root": "/nonexistent-fireability-qa"}
+ops = [
+    {"v": 1, "at_ms": stale - 2, "op": {"type": "add", "id": "it-missed",
+     "kind": "task", "title": "qa missed window", "body": "", "tags": []}},
+    {"v": 1, "at_ms": stale - 1, "op": {"type": "propose_effect", "id": "it-missed",
+     "effect_id": "ef-qa-missed00", "manifest": mf_m}},
+    {"v": 1, "at_ms": stale, "op": {"type": "approve_effect", "id": "it-missed",
+     "effect_id": "ef-qa-missed00", "digest": digest}},
+    {"v": 1, "at_ms": now - 2, "op": {"type": "add", "id": "it-unfire",
+     "kind": "task", "title": "qa unfireable", "body": "", "tags": []}},
+    {"v": 1, "at_ms": now - 1, "op": {"type": "propose_effect", "id": "it-unfire",
+     "effect_id": "ef-qa-unfire00", "manifest": mf_u}},
+]
+with open(sys.argv[1], "w") as f:
+    f.writelines(json.dumps(op) + "\n" for op in ops)
+EOF
+```
+
+(`it-unfire`'s pin names a directory that does not exist, so the served
+verdict is `unfireable(project)` even though the scratch daemon itself
+has a default project — the repo checkout it launches from.)
+
+## 2. Launch the scratch dashboard over the seeded home
+
+```bash
+printf 'profiles: [{ match: "", turns: [{ text: "qa run done", done: true }] }]\n' > "$QA_HOME/mock.yaml"
+INTENDANT_HOME="$QA_HOME" PROVIDER=mock INTENDANT_MOCK_SCRIPT="$QA_HOME/mock.yaml" \
+  INTENDANT_MOCK_DISPLAY=synthetic node scripts/validate-dashboard.cjs \
+  --launch-dashboard --hold-dashboard --port "$QA_PORT" \
+  --dashboard-binary target/debug/intendant --selector body &
+HOLD_PID=$!
+export INTENDANT_LOOPBACK_TOKEN=$(cat "$QA_HOME"/loopback-tokens/$QA_PORT.token)
+```
+
+Give the first scheduler pass a few seconds: it resolves the seeded
+approved instant as `missed` (journal + write-back) — verify with
+`env -u INTENDANT_MCP_URL -u INTENDANT_SESSION_ID ./target/debug/intendant ctl \
+  --url "http://127.0.0.1:$QA_PORT/mcp" agenda show it-missed --json | grep '"state": "missed"'`.
+
+## 3. The card states (the acceptance's QA leg)
+
+One probe asserts both cards: the missed state with its reschedule
+affordance and no Approve; the unfireable pending with the served
+refusal, Fix plan…, and no Approve (the class law's render half):
+
+```bash
+node scripts/validate-dashboard.cjs --url "http://127.0.0.1:$QA_PORT" --timeout 30000 \
+  --wait-for-function "(() => { const qa = window.qa && window.qa.agendaFireability
+      && window.qa.agendaFireability({ route: true });
+    if (!qa) return false;
+    const m = qa.effects.find((e) => e.id === 'it-missed');
+    const u = qa.effects.find((e) => e.id === 'it-unfire');
+    if (!m || m.kind !== 'missed' || !m.hasReschedule || m.hasApprove) return false;
+    return !!u && u.kind === 'pending' && !!u.refusal
+      && u.refusal.field === 'project' && !u.hasApprove && u.hasFixPlan;
+  })()" \
+  --probe-json "fireability=window.qa.agendaFireability()"
+```
+
+## 4. The approve refusal is an edit prompt, never a silent failure
+
+CLI half — the daemon's named refusal with the pinned grammar:
+
+```bash
+DIGEST=$(env -u INTENDANT_MCP_URL -u INTENDANT_SESSION_ID ./target/debug/intendant ctl \
+  --url "http://127.0.0.1:$QA_PORT/mcp" agenda show it-unfire --json \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["item"]["effects"][0]["digest"])')
+env -u INTENDANT_MCP_URL -u INTENDANT_SESSION_ID ./target/debug/intendant ctl \
+  --url "http://127.0.0.1:$QA_PORT/mcp" agenda approve it-unfire --digest "$DIGEST" 2>&1 \
+  | grep 'unfireable(project): '   # MUST refuse, named
+```
+
+SPA half — Fix plan… opens the one schedule sheet focused on the named
+field with the refusal shown inline:
+
+```bash
+node scripts/validate-dashboard.cjs --url "http://127.0.0.1:$QA_PORT" --timeout 30000 \
+  --wait-for-function "(() => {
+    const btn = document.querySelector('[data-edit-sched=\"it-unfire\"][data-focus=\"project\"]');
+    if (!btn) return false;
+    if (!(window.qa.agendaFireability().sheet || {}).itemId) btn.click();
+    const s = window.qa.agendaFireability().sheet;
+    if (!s || s.itemId !== 'it-unfire') return false;
+    if (s.kind !== 'sched') return true && false; // loading — keep polling
+    return s.focusField === 'project' && s.error.indexOf('unfireable(project)') === 0;
+  })()"
+```
+
+## 5. The one-tap re-approve-to-reschedule
+
+```bash
+node scripts/validate-dashboard.cjs --url "http://127.0.0.1:$QA_PORT" --timeout 45000 \
+  --wait-for-function "(() => { const qa = window.qa && window.qa.agendaFireability
+      && window.qa.agendaFireability({ route: true });
+    if (!qa) return false;
+    const m = qa.effects.find((e) => e.id === 'it-missed');
+    if (!m) return false;
+    if (m.kind === 'missed') { window.qa.agendaFireability({ reschedule: 'it-missed' }); return false; }
+    return m.kind !== 'missed' && !m.hasReschedule;
+  })()" \
+  --probe-json "after=window.qa.agendaFireability()"
+```
+
+Then confirm daemon-side that the tap minted a FRESH approved revision:
+`… agenda show it-missed --json` shows `effects[0].approval` bound to a
+digest ≠ the seeded one and `last_run` no longer `missed` (cleared by the
+re-propose; under the mock provider the rescheduled run then starts and
+completes).
+
+## 6. Teardown
+
+`kill -INT "$HOLD_PID"` (the helper stops the daemon it launched), then
+delete `$QA_HOME`.
+
+## Acceptance
+
+Steps 3–5's harness invocations exit 0 and the ctl approve in step 4
+prints the `unfireable(project): …` refusal. The step-3 probe JSON shows
+`it-missed {kind:'missed', hasReschedule:true, hasApprove:false}` and
+`it-unfire {kind:'pending', refusal.field:'project', hasApprove:false,
+hasFixPlan:true}`; after step 5 the `it-missed` effect is armed under a
+new digest.

--- a/tests/skills/fireability-qa/SKILL.md
+++ b/tests/skills/fireability-qa/SKILL.md
@@ -72,8 +72,13 @@ has a default project — the repo checkout it launches from.)
 ## 2. Launch the scratch dashboard over the seeded home
 
 ```bash
-printf 'profiles: [{ match: "", turns: [{ text: "qa run done", done: true }] }]\n' > "$QA_HOME/mock.yaml"
-INTENDANT_HOME="$QA_HOME" PROVIDER=mock INTENDANT_MOCK_SCRIPT="$QA_HOME/mock.yaml" \
+cat > "$QA_HOME/mock.json" <<'EOF'
+{ "model": "mock-1", "profiles": [{ "match": "", "steps": [
+  { "content": "Done.", "tool_calls": [{ "name": "signal_done",
+    "arguments": { "message": "qa run complete" } }] }
+] }] }
+EOF
+INTENDANT_HOME="$QA_HOME" PROVIDER=mock INTENDANT_MOCK_SCRIPT="$QA_HOME/mock.json" \
   INTENDANT_MOCK_DISPLAY=synthetic node scripts/validate-dashboard.cjs \
   --launch-dashboard --hold-dashboard --port "$QA_PORT" \
   --dashboard-binary target/debug/intendant --selector body &


### PR DESCRIPTION
Card 01KYSZAGQVHAAYS7BK9H3QFM3C — an approvable manifest IS a fireable manifest: fail closed at the mint, never at the fire.

- ONE validator (src/bin/caller/agenda/fireability.rs) derived from the SessionManifest schemars schema (coverage-map parity test) + daemon state, run in the ProposeEffect intake arm — the lane every mint surface routes through (ctl agenda schedule, the automate modal, the approval-time editor, the stamp lane per node) — and re-run at approve, the arm gate.
- Project resolvable NOW (explicit / parking-session root / daemon default, else a named refusal carrying the concrete missing flag); the resolution is RECORDED on the digest-bound manifest so the approval covers WHERE.
- Executor resolved (explicit / daemon default at the mint / internal) and RECORDED (agent_config.agent); the config validates AS RECORDED, so cross-backend pins refuse at the mint.
- Floor sanity mirrors the planner's missed rule (live policy staleness); trigger arm floors exempt (pinned); recurrence refuses only dead series.
- Served fireability_refusal decoration (full + summary grain, the next_fire_ms pattern): the cards never offer Approve/Re-arm against it — Fix plan… opens the plan editor focused on the named field. unfireable(<field>): grammar is the pinned wire contract (server test + static-asset parity twin).
- The missed-window terminal is a self-explaining card state with the one-tap Re-approve-to-reschedule (verbatim re-propose at now + approve; the reschedule lane's single emitter, pinned).
- Legacy pin-less manifests meet the validator at their next approve and surface as the edit prompt, never a silent failure; the fire-time fallback chain is unchanged for them (validated against, never narrowed).

Tests: pinned intake/approve tests incl. the class test (approve_is_never_armed_on_an_unfireable_manifest), parking-root recording, executor recording, trigger-floor exemption, stamp-lane inheritance, served-verdict decoration; static_assets pins updated (inspector 2 propose emitters, cards data-edit-sched 5, data-resched-effect 3, cards propose_effect still 0). QA leg: tests/skills/fireability-qa/SKILL.md (daemon side live-proven: offline-computed digest binds, boot planner resolves the seeded miss with the re-approve note). Docs: 'Propose-time fireability' section in the agenda chapter.