### PR TITLE
Recovery scheduling for early round endings: transient service conditions arm an error park

### DIFF
--- a/docs/src/external-agent-orchestration.md
+++ b/docs/src/external-agent-orchestration.md
@@ -1123,6 +1123,43 @@ can tell a daemon died mid-park with work still owed. Activity and
 session-log rows make the pause, queued messages, cancellation, and resend
 visible.
 
+## Service-condition Error Parking
+
+A round can also die early on a **temporary service condition** — the
+provider-incident class: repeated HTTP 5xx after the backend's own transport
+retries gave up, gateway drops, stream cuts. Claude Code surfaces these as an
+errored result ("API Error: 500 …"), which used to end the round "cleanly"
+(error row → done signal → round complete): nothing was armed, so the session
+sat fake-idle, invisible to the credential-reload lane and every wake clock —
+and for a scheduled occurrence the DoneSignal journaled COMPLETED with the
+failure invisible (2026-07-29 specimens, both commission seats, stranded for
+over an hour).
+
+The drain now classifies early round endings at the round-outcome seam
+(`transient_service_condition` in `external_supervision.rs`, conservative
+marker matching): a fatal backend error with a temporary-service cause drains
+as `DrainOutcome::TransientRoundDeath`; **permanent causes — auth problems,
+refusals, invalid model pins, deliberate exits — keep their terminal shapes**
+(`TurnFailed` for the zero-turn round, the completion shape after real work).
+Temporary-class deaths enter the **same armed park** as the limit lanes — one
+`LimitParkState` slot, the same wake timer, queue-while-parked, cancel, and
+reload-preserve machinery, the same delivery-aware pending seam
+(`delivery_aware_park_pending` / `midturn_continuation`), with a
+`ParkKind::ServiceCondition` tag so every shared line says "Service-recovery
+pause", never "rate-limited" — plus a **wake schedule of their own**: limit
+parks wake at the provider's reset time, service-condition parks wake on a
+bounded widening backoff (30s → 2m → 5m → 15m → 30m, small jitter; integers
+tunable in `ERROR_PARK_BACKOFF_SCHEDULE_SECS`), each wake re-driving the
+interrupted work (the continue-where-you-left-off nudge when the turn had
+started, the driving message verbatim when it never did). A completed turn —
+or an explicit intervention (interrupt, reload, `/new`) — resets the attempt
+counter. When the schedule exhausts, the supervised lane ends the session
+with a FAILED terminal carrying the cause, so a scheduled occurrence journals
+`failed` — counting on the agenda's suspension streak and surfacing to the
+owner — instead of waiting unattended; the persistent daemon lane reports the
+outage on the error/presence surfaces and stops parking until the next user
+message re-drives it.
+
 ## Dashboard and Station parity
 
 The per-session dashboard features (Activity → Timeline agent windows and the

--- a/src/bin/caller/external_events.rs
+++ b/src/bin/caller/external_events.rs
@@ -2741,9 +2741,7 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                 // stays unreachable on the CC wire.
                 let completion_is_the_error_itself = pending_fatal_round_error
                     .as_ref()
-                    .is_some_and(|fatal| {
-                        message.as_deref() == Some(fatal.raw_message.as_str())
-                    });
+                    .is_some_and(|fatal| message.as_deref() == Some(fatal.raw_message.as_str()));
                 pending_turn_completion = Some((message, turns_in_round));
                 if !completion_is_the_error_itself {
                     pending_fatal_round_error = None;

--- a/src/bin/caller/external_events.rs
+++ b/src/bin/caller/external_events.rs
@@ -320,11 +320,18 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
     let mut pending_context_rewind_turn_stop = ManagedContextRewindTurnStopTracker::default();
     let mut pending_backend_recovery: Option<ExternalBackendRecovery> = None;
     // The cause of a fatal, non-recoverable backend error that ended the
-    // round with no real completion (the launch-refusal class). Cleared by
-    // a real turn completion inside the grace window; consumed at the exit,
-    // where a zero-turn round resolves as `TurnFailed` instead of lying
-    // with a completion.
-    let mut pending_fatal_round_error: Option<String> = None;
+    // round (the launch-refusal class, and the transient
+    // provider-incident class the error park recovers). Cleared by a REAL
+    // turn completion inside the grace window — but not by the error's
+    // own synthesized completion (Claude Code pushes `TurnCompleted`
+    // carrying the same result text right after the fatal `BackendError`,
+    // one wire line; treating that echo as a real completion made the
+    // zero-turn TurnFailed pin unreachable on the CC wire and dropped the
+    // cause the round-outcome classification needs). Consumed at the
+    // exit, where the classification decides: transient service
+    // condition → `TransientRoundDeath`; permanent at zero turns →
+    // `TurnFailed`; permanent after real work → the completion shape.
+    let mut pending_fatal_round_error: Option<FatalRoundError> = None;
     let mut managed_context_rewind_only_pressure: Option<ManagedContextRewindOnlyPressure> = None;
     let mut managed_context_pressure_interrupt_sent = false;
     let managed_context_density_steer_suppressed = managed_context_recovery_kickstart
@@ -1196,6 +1203,7 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                             pending_fatal_round_error.take(),
                             message,
                             turns_in_round,
+                            primary_round_started,
                         );
                     }
                     None => return DrainOutcome::ChannelClosed,
@@ -1219,6 +1227,7 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                     pending_fatal_round_error.take(),
                     message,
                     turns_in_round,
+                    primary_round_started,
                 );
             }
             }
@@ -1646,9 +1655,15 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                 });
                 // A fatal error the wrapper deems unrecoverable is the
                 // round's honest cause; recoverable ones resolve through
-                // the recovery precedence at the exit instead.
+                // the recovery precedence at the exit instead. The raw
+                // adapter message rides along so the error's own
+                // synthesized turn completion can be told apart from a
+                // real one.
                 let fatal_round_error = (!will_retry && event_is_primary && !recovery_required)
-                    .then(|| content.clone());
+                    .then(|| FatalRoundError {
+                        reason: content.clone(),
+                        raw_message: message.clone(),
+                    });
                 config.bus.send(AppEvent::LogEntry {
                     session_id: config.session_id.clone(),
                     level: if will_retry || recovery_required {
@@ -1681,8 +1696,8 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                     pending_turn_completion = Some((None, turns_in_round));
                     // First cause wins; an already-buffered REAL completion
                     // (the branch guard above) never gets a fatal cause.
-                    if let Some(reason) = fatal_round_error {
-                        pending_fatal_round_error.get_or_insert(reason);
+                    if let Some(cause) = fatal_round_error {
+                        pending_fatal_round_error.get_or_insert(cause);
                     }
                     if active_side_turns.is_empty() {
                         post_turn_sleep_active = true;
@@ -2714,10 +2729,25 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                         ))
                     });
                 }
+                // A REAL completion inside the grace window supersedes a
+                // buffered fatal cause — the turn did land after all. The
+                // guard: an error result's own synthesized completion
+                // (Claude Code pushes `TurnCompleted` carrying the SAME
+                // result text right after the fatal `BackendError`, one
+                // wire line) is the error restated, not a recovery — it
+                // must leave the cause standing or the round-outcome
+                // classification never sees it (the 2026-07-29 specimens'
+                // exact silent path) and the zero-turn TurnFailed pin
+                // stays unreachable on the CC wire.
+                let completion_is_the_error_itself = pending_fatal_round_error
+                    .as_ref()
+                    .is_some_and(|fatal| {
+                        message.as_deref() == Some(fatal.raw_message.as_str())
+                    });
                 pending_turn_completion = Some((message, turns_in_round));
-                // A real completion inside the grace window supersedes a
-                // buffered fatal cause — the turn did land after all.
-                pending_fatal_round_error = None;
+                if !completion_is_the_error_itself {
+                    pending_fatal_round_error = None;
+                }
                 if active_side_turns.is_empty() {
                     post_turn_sleep_active = true;
                     post_turn_sleep
@@ -3415,6 +3445,7 @@ mod tests {
         match outcome {
             DrainOutcome::TurnCompleted { .. } => "TurnCompleted",
             DrainOutcome::TurnFailed { .. } => "TurnFailed",
+            DrainOutcome::TransientRoundDeath { .. } => "TransientRoundDeath",
             DrainOutcome::Terminated { .. } => "Terminated",
             DrainOutcome::ChannelClosed => "ChannelClosed",
             DrainOutcome::RecoveryRequired { .. } => "RecoveryRequired",
@@ -3632,6 +3663,162 @@ mod tests {
                  got {}",
                 drain_outcome_name(&outcome)
             );
+        }
+    }
+
+    /// The 2026-07-29 specimen wire shape (sessions 24f01636/13e53300,
+    /// commission seats killed by provider API-500s): Claude Code ends
+    /// an errored turn by emitting the fatal `BackendError` AND a
+    /// synthesized `TurnCompleted` carrying the SAME result text on one
+    /// wire line. That echo must not clear the buffered cause — the
+    /// round drains as `TransientRoundDeath` (the error park's input)
+    /// instead of the completion that rode a DoneSignal and stranded
+    /// both specimens fake-idle. A permanent cause through the same
+    /// echo shape keeps its terminal: zero turns drain `TurnFailed`
+    /// (restoring the 2026-07-26 launch-refusal pin on the CC wire,
+    /// where the echo had made it unreachable).
+    #[tokio::test]
+    async fn api_500_round_death_with_completion_echo_drains_transient() {
+        for (error_text, feed_tool_start, expect) in [
+            (
+                "API Error: 500 {\"type\":\"api_error\",\"message\":\"Internal server error\"}",
+                true,
+                "TransientRoundDeath",
+            ),
+            (
+                "API Error: 500 {\"type\":\"api_error\",\"message\":\"Internal server error\"}",
+                false,
+                "TransientRoundDeath",
+            ),
+            (
+                "There's an issue with the selected model (fable-5). It may not exist or you \
+                 may not have access to it.",
+                false,
+                "TurnFailed",
+            ),
+        ] {
+            let bus = EventBus::new();
+            let mut bus_rx_for_drain = bus.subscribe();
+            let dir = tempfile::tempdir().unwrap();
+            let log_dir = dir.path().join("session");
+            let session_log: SharedSessionLog = Arc::new(Mutex::new(
+                session_log::SessionLog::open(log_dir.clone()).unwrap(),
+            ));
+            let approval_registry: event::ApprovalRegistry = Arc::new(Mutex::new(HashMap::new()));
+            let context_injection: event::ContextInjectionQueue = Arc::new(Mutex::new(Vec::new()));
+            let autonomy = autonomy::shared_autonomy(AutonomyState::default());
+            let config = DrainConfig {
+                bus: &bus,
+                web_port: None,
+                session_id: Some("cc-session".to_string()),
+                alias_session_id: None,
+                backend_thread_id: Some("cc-session".to_string()),
+                autonomy,
+                session_log: &session_log,
+                project_root: dir.path(),
+                log_dir: &log_dir,
+                approval_registry: &approval_registry,
+                json_approval: None,
+                agent_source: Some("Claude Code".to_string()),
+                suppress_agent_started: false,
+                persist_model_responses_inline: true,
+                headless: true,
+                context_injection: &context_injection,
+                reload_credentials: None,
+                coordination_declaration: None,
+            };
+            let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
+            if feed_tool_start {
+                event_tx
+                    .send(external_agent::AgentEvent::ToolStarted {
+                        item_id: "tool-1".to_string(),
+                        tool_name: "bash".to_string(),
+                        preview: "cargo test".to_string(),
+                        message_uuid: None,
+                    })
+                    .unwrap();
+            }
+            event_tx
+                .send(external_agent::AgentEvent::BackendError {
+                    message: error_text.to_string(),
+                    code: Some("error_during_execution".to_string()),
+                    details: None,
+                    will_retry: false,
+                    likely_generation_starvation: false,
+                    recovery_hint: None,
+                })
+                .unwrap();
+            // The adapter's synthesized completion: the same result text,
+            // pushed by the same `handle_result` call.
+            event_tx
+                .send(external_agent::AgentEvent::TurnCompleted {
+                    message: Some(error_text.to_string()),
+                })
+                .unwrap();
+            drop(event_tx);
+
+            let interrupts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+            let steers = Arc::new(Mutex::new(Vec::new()));
+            let mut agent: Box<dyn external_agent::ExternalAgent> =
+                Box::new(ManagedDrainTestAgent {
+                    interrupts: interrupts.clone(),
+                    steers: steers.clone(),
+                });
+            let mut stats = LoopStats::default();
+            let mut diff_tracker = ExternalDiffDeltaTracker::default();
+            let mut pending_runtime_steers = std::collections::VecDeque::new();
+            let mut handled_steer_ids = std::collections::HashSet::new();
+            let mut cancelled_follow_ups = HashSet::new();
+            let mut dedupe = CodexThreadActionDedupe::default();
+
+            let outcome = drain_external_agent_events(
+                &mut agent,
+                &mut event_rx,
+                &mut bus_rx_for_drain,
+                &config,
+                &mut stats,
+                &mut diff_tracker,
+                &mut pending_runtime_steers,
+                &mut handled_steer_ids,
+                &mut cancelled_follow_ups,
+                &mut dedupe,
+                None,
+                None,
+                false,
+                false,
+                false,
+            )
+            .await;
+            match (expect, outcome) {
+                (
+                    "TransientRoundDeath",
+                    DrainOutcome::TransientRoundDeath {
+                        reason,
+                        turns_in_round,
+                        turn_had_started,
+                    },
+                ) => {
+                    assert!(
+                        reason.contains("API Error: 500"),
+                        "reason carries the cause: {reason}"
+                    );
+                    assert_eq!(turns_in_round, usize::from(feed_tool_start));
+                    // The completion echo marks the round started even
+                    // with zero tools — CC persisted the driving message
+                    // to its rollout, so the resume must be a nudge.
+                    assert!(turn_had_started);
+                }
+                ("TurnFailed", DrainOutcome::TurnFailed { reason, .. }) => {
+                    assert!(
+                        reason.contains("fable-5"),
+                        "reason carries the refusal: {reason}"
+                    );
+                }
+                (expect, other) => panic!(
+                    "expected {expect} (tool_start={feed_tool_start}), got {}",
+                    drain_outcome_name(&other)
+                ),
+            }
         }
     }
 

--- a/src/bin/caller/external_mode.rs
+++ b/src/bin/caller/external_mode.rs
@@ -138,6 +138,7 @@ async fn apply_backend_credentials_reload(
     stats: &LoopStats,
     limit_park: &mut Option<LimitParkState>,
     limit_park_streak: &mut u32,
+    error_park_streak: &mut u32,
     parked_follow_ups: &mut std::collections::VecDeque<FollowUpMessage>,
     agent: &mut Box<dyn external_agent::ExternalAgent>,
     event_rx: &mut tokio::sync::mpsc::UnboundedReceiver<external_agent::AgentEvent>,
@@ -167,15 +168,17 @@ async fn apply_backend_credentials_reload(
     };
     if let Some(park) = limit_park.take() {
         *limit_park_streak = 0;
+        *error_park_streak = 0;
         slog(session_log, |l| l.set_limit_park(None));
+        let noun = park.kind.noun();
         if let Some(pending) = park.pending {
             // Front of the queue: the parked re-send delivers first, then
             // everything queued while parked, oldest first.
             parked_follow_ups.push_front(pending);
         }
-        announce(
-            "Rate-limit park cancelled for the credential reload — parked messages deliver after the respawn",
-        );
+        announce(&format!(
+            "{noun} cancelled for the credential reload — parked messages deliver after the respawn",
+        ));
     }
     let resume_id = stats
         .announced_native_session_id
@@ -549,6 +552,12 @@ pub(crate) async fn run_external_agent_mode(
     // the wire carries no reset time) and clears on any completed turn.
     let mut limit_park: Option<LimitParkState> = None;
     let mut limit_park_streak: u32 = 0;
+    // Consecutive transient-service-condition round deaths (the error
+    // park's recovery-attempt counter): +1 each death, reset by a
+    // completed turn or an explicit intervention (interrupt, reload) —
+    // past the bounded widening schedule the session suspends visibly
+    // instead of parking again.
+    let mut error_park_streak: u32 = 0;
     let mut parked_follow_ups: std::collections::VecDeque<FollowUpMessage> =
         std::collections::VecDeque::new();
     let mut managed_context_recovery_kickstarts_without_rewind = 0u8;
@@ -676,6 +685,7 @@ pub(crate) async fn run_external_agent_mode(
                 &stats,
                 &mut limit_park,
                 &mut limit_park_streak,
+                &mut error_park_streak,
                 &mut parked_follow_ups,
                 &mut agent,
                 &mut event_rx,
@@ -800,10 +810,11 @@ pub(crate) async fn run_external_agent_mode(
                             }
                         }
                     }
-                    // Rate-limit park timer: at the reset (plus jitter),
-                    // re-send the message the limit rejected. Messages
-                    // queued meanwhile flush right after via the
-                    // parked-flush preamble above.
+                    // Park timer (both kinds ride this one slot): at the
+                    // limit's reset or the recovery schedule's next step,
+                    // re-send what the park held. Messages queued
+                    // meanwhile flush right after via the parked-flush
+                    // preamble above.
                     _ = tokio::time::sleep_until(
                         limit_park
                             .as_ref()
@@ -812,6 +823,7 @@ pub(crate) async fn run_external_agent_mode(
                     ), if limit_park.is_some() => {
                         let park = limit_park.take().expect("branch guarded by is_some");
                         slog(&session_log, |l| l.set_limit_park(None));
+                        let noun = park.kind.noun();
                         match park.pending {
                             Some(pending)
                                 if !follow_up_message_was_cancelled(
@@ -819,28 +831,29 @@ pub(crate) async fn run_external_agent_mode(
                                     &pending,
                                 ) =>
                             {
-                                let line =
-                                    "Rate-limit park elapsed — re-sending the parked message";
-                                slog(&session_log, |l| l.info(line));
+                                let line = format!(
+                                    "{noun} elapsed — re-sending the parked message"
+                                );
+                                slog(&session_log, |l| l.info(&line));
                                 bus.send(AppEvent::LogEntry {
                                     session_id: live_session_id.clone(),
                                     level: "info".to_string(),
                                     source: "Intendant".to_string(),
-                                    content: line.to_string(),
+                                    content: line,
                                     turn: None,
                                 });
                                 break pending;
                             }
                             Some(_) => {
                                 slog(&session_log, |l| {
-                                    l.info(
-                                        "Rate-limit park elapsed — the parked message was cancelled; awaiting input",
-                                    )
+                                    l.info(&format!(
+                                        "{noun} elapsed — the parked message was cancelled; awaiting input",
+                                    ))
                                 });
                             }
                             None => {
                                 slog(&session_log, |l| {
-                                    l.info("Rate-limit park elapsed — awaiting input")
+                                    l.info(&format!("{noun} elapsed — awaiting input"))
                                 });
                             }
                         }
@@ -1315,6 +1328,102 @@ pub(crate) async fn run_external_agent_mode(
                                                     l.set_limit_park(Some(
                                                         crate::session_log::SessionLimitParkMeta {
                                                             resets_at_epoch,
+                                                            has_pending,
+                                                        },
+                                                    ))
+                                                });
+                                            }
+                                            DrainOutcome::TransientRoundDeath {
+                                                reason,
+                                                turns_in_round,
+                                                turn_had_started,
+                                            } => {
+                                                // A backend-started round
+                                                // died on a temporary
+                                                // service condition: arm
+                                                // the error park (no
+                                                // driving message from
+                                                // this side — the pending
+                                                // is the resume nudge
+                                                // exactly when the turn
+                                                // had started), or
+                                                // suspend visibly once
+                                                // the widening schedule
+                                                // is exhausted.
+                                                error_park_streak =
+                                                    error_park_streak.saturating_add(1);
+                                                if error_park_attempts_exhausted(error_park_streak)
+                                                {
+                                                    stats.rounds = round;
+                                                    let line = error_park_exhausted_line(
+                                                        &reason,
+                                                        error_park_streak.saturating_sub(1),
+                                                    );
+                                                    slog(&session_log, |l| l.error(&line));
+                                                    record_external_round_inline(
+                                                        &session_log,
+                                                        persist_model_responses_inline,
+                                                        round,
+                                                        turns_in_round,
+                                                    );
+                                                    bus.send(AppEvent::RoundComplete {
+                                                        session_id: live_session_id.clone(),
+                                                        round,
+                                                        turns_in_round,
+                                                        native_message_count: None,
+                                                        project_root: round_session_root.clone(),
+                                                    });
+                                                    bus.send(AppEvent::TaskComplete {
+                                                        session_id: live_session_id.clone(),
+                                                        reason: line.clone(),
+                                                        summary: None,
+                                                        outcome: crate::event::TaskOutcome::Failed,
+                                                    });
+                                                    stats.terminal_outcome = Some(line);
+                                                    break 'outer;
+                                                }
+                                                round = round.saturating_sub(1);
+                                                let (park, park_line) =
+                                                    transient_round_death_error_park(
+                                                        &reason,
+                                                        tokio::time::Instant::now(),
+                                                        error_park_streak,
+                                                        error_park_jitter_secs(),
+                                                        turn_had_started,
+                                                        None,
+                                                    );
+                                                let has_pending = park.pending.is_some();
+                                                slog(&session_log, |l| l.warn(&park_line));
+                                                bus.send(AppEvent::LogEntry {
+                                                    session_id: live_session_id.clone(),
+                                                    level: "warn".to_string(),
+                                                    source: "Intendant".to_string(),
+                                                    content: park_line,
+                                                    turn: None,
+                                                });
+                                                emit_external_turn_status(
+                                                    &bus,
+                                                    &autonomy,
+                                                    live_session_id.as_deref(),
+                                                    round.saturating_add(1),
+                                                    "waiting-service-recovery",
+                                                    format!(
+                                                        "{} waiting out a temporary service condition; parked for recovery",
+                                                        agent.name()
+                                                    ),
+                                                )
+                                                .await;
+                                                limit_park = Some(park);
+                                                // Durable marker: like the
+                                                // limit arms, so a daemon
+                                                // death mid-park leaves
+                                                // the boot auto-readopt
+                                                // trace (no reset clock —
+                                                // the schedule is ours).
+                                                slog(&session_log, |l| {
+                                                    l.set_limit_park(Some(
+                                                        crate::session_log::SessionLimitParkMeta {
+                                                            resets_at_epoch: None,
                                                             has_pending,
                                                         },
                                                     ))
@@ -1827,18 +1936,20 @@ pub(crate) async fn run_external_agent_mode(
                                 // park stay queued and flush normally).
                                 if let Some(park) = limit_park.take() {
                                     limit_park_streak = 0;
+                                    error_park_streak = 0;
                                     slog(&session_log, |l| l.set_limit_park(None));
+                                    let noun = park.kind.noun();
                                     let line = if park.pending.is_some() {
-                                        "Rate-limit park cancelled by interrupt — dropped the pending re-send"
+                                        format!("{noun} cancelled by interrupt — dropped the pending re-send")
                                     } else {
-                                        "Rate-limit park cancelled by interrupt"
+                                        format!("{noun} cancelled by interrupt")
                                     };
-                                    slog(&session_log, |l| l.info(line));
+                                    slog(&session_log, |l| l.info(&line));
                                     bus.send(AppEvent::LogEntry {
                                         session_id: live_session_id.clone(),
                                         level: "info".to_string(),
                                         source: "Intendant".to_string(),
-                                        content: line.to_string(),
+                                        content: line,
                                         turn: None,
                                     });
                                 }
@@ -1866,6 +1977,7 @@ pub(crate) async fn run_external_agent_mode(
                                     &stats,
                                     &mut limit_park,
                                     &mut limit_park_streak,
+                                    &mut error_park_streak,
                                     &mut parked_follow_ups,
                                     &mut agent,
                                     &mut event_rx,
@@ -1898,17 +2010,17 @@ pub(crate) async fn run_external_agent_mode(
             });
             continue;
         }
-        if limit_park.is_some() {
-            // Rate-limit park: never burn input against the rejected
-            // backend (a delivered message would be consumed with zero
-            // work). Queue it and return to the idle wait; the flush
-            // preamble delivers it after the pending re-send.
-            slog(&session_log, |l| l.info(LIMIT_PARK_QUEUED_MESSAGE_LOG));
+        if let Some(park) = limit_park.as_ref() {
+            // Armed park (either kind): never burn input against the
+            // unavailable backend (a delivered message would be consumed
+            // with zero work). Queue it and return to the idle wait; the
+            // flush preamble delivers it after the pending re-send.
+            slog(&session_log, |l| l.info(park.kind.queued_log()));
             bus.send(AppEvent::LogEntry {
                 session_id: live_session_id.clone(),
                 level: "info".to_string(),
                 source: "Intendant".to_string(),
-                content: LIMIT_PARK_QUEUED_MESSAGE_LOG.to_string(),
+                content: park.kind.queued_log().to_string(),
                 turn: None,
             });
             emit_follow_up_status(
@@ -1917,7 +2029,7 @@ pub(crate) async fn run_external_agent_mode(
                 &followup.follow_up_id,
                 Some(&followup.text),
                 "queued",
-                Some("rate-limited; delivers when the limit resets"),
+                Some(park.kind.queued_status_detail()),
             );
             parked_follow_ups.push_back(followup);
             continue;
@@ -2772,6 +2884,28 @@ pub(crate) async fn run_external_agent_mode(
                                 turn: None,
                             });
                         }
+                        DrainOutcome::TransientRoundDeath { reason, .. } => {
+                            // The in-flight turn died on a temporary
+                            // service condition mid-edit. Like the limit
+                            // arm above: no park — the edit rewinds past
+                            // the dead turn, so a parked continuation
+                            // would re-drive work the user just
+                            // superseded. The edited message delivers
+                            // next and parks through the primary arm if
+                            // the condition still holds.
+                            let line = format!(
+                                "Temporary service condition ended the in-flight turn ({}); proceeding with the edit rollback",
+                                reason
+                            );
+                            slog(&session_log, |l| l.warn(&line));
+                            bus.send(AppEvent::LogEntry {
+                                session_id: live_session_id.clone(),
+                                level: "warn".to_string(),
+                                source: "Intendant".to_string(),
+                                content: line,
+                                turn: None,
+                            });
+                        }
                         DrainOutcome::ContextRewindRequested {
                             request,
                             message,
@@ -3133,6 +3267,7 @@ pub(crate) async fn run_external_agent_mode(
                 stats.rounds = round;
                 // A completed turn proves the provider is serving again.
                 limit_park_streak = 0;
+                error_park_streak = 0;
                 if codex_managed_context_enabled {
                     match refresh_external_context_usage_snapshot(&mut agent, &drain_config).await {
                         Ok(Some(snapshot)) => {
@@ -3550,6 +3685,7 @@ pub(crate) async fn run_external_agent_mode(
                 limit_park = Some(LimitParkState {
                     resume_at: tokio::time::Instant::now() + delay,
                     pending: Some(limit_park_pending(pending, turn_had_started)),
+                    kind: ParkKind::ProviderLimit,
                 });
                 // Durable park marker: the in-memory park dies with the
                 // daemon, and the boot auto-readopt pass needs to know a
@@ -3558,6 +3694,94 @@ pub(crate) async fn run_external_agent_mode(
                     l.set_limit_park(Some(crate::session_log::SessionLimitParkMeta {
                         resets_at_epoch,
                         has_pending: true,
+                    }))
+                });
+            }
+            DrainOutcome::TransientRoundDeath {
+                reason,
+                turns_in_round,
+                turn_had_started,
+            } => {
+                // The round this side drove died on a temporary service
+                // condition (the 2026-07-29 specimen shape: an API-500
+                // round-death that rode a DoneSignal and stranded the
+                // commission fake-idle). Hand the round number back,
+                // count nothing, and arm the error park with the
+                // delivery-aware pending — the driving message verbatim
+                // when the backend never started the turn, the resume
+                // nudge when it did. Past the widening schedule the
+                // session ends FAILED so the outage surfaces (agenda
+                // occurrences journal `failed` and count on the
+                // suspension streak) instead of waiting unattended.
+                error_park_streak = error_park_streak.saturating_add(1);
+                if error_park_attempts_exhausted(error_park_streak) {
+                    stats.rounds = round;
+                    let line =
+                        error_park_exhausted_line(&reason, error_park_streak.saturating_sub(1));
+                    slog(&session_log, |l| l.error(&line));
+                    record_external_round_inline(
+                        &session_log,
+                        persist_model_responses_inline,
+                        round,
+                        turns_in_round,
+                    );
+                    bus.send(AppEvent::RoundComplete {
+                        session_id: live_session_id.clone(),
+                        round,
+                        turns_in_round,
+                        native_message_count: None,
+                        project_root: round_session_root.clone(),
+                    });
+                    bus.send(AppEvent::TaskComplete {
+                        session_id: live_session_id.clone(),
+                        reason: line.clone(),
+                        summary: None,
+                        outcome: crate::event::TaskOutcome::Failed,
+                    });
+                    stats.terminal_outcome = Some(line);
+                    break;
+                }
+                round = round.saturating_sub(1);
+                let mut pending = active_followup_for_rewind_replay.clone();
+                pending.text = merged.clone();
+                let (park, park_line) = transient_round_death_error_park(
+                    &reason,
+                    tokio::time::Instant::now(),
+                    error_park_streak,
+                    error_park_jitter_secs(),
+                    turn_had_started,
+                    Some(pending),
+                );
+                let has_pending = park.pending.is_some();
+                slog(&session_log, |l| l.warn(&park_line));
+                bus.send(AppEvent::LogEntry {
+                    session_id: live_session_id.clone(),
+                    level: "warn".to_string(),
+                    source: "Intendant".to_string(),
+                    content: park_line,
+                    turn: None,
+                });
+                emit_external_turn_status(
+                    &bus,
+                    &autonomy,
+                    live_session_id.as_deref(),
+                    round.saturating_add(1),
+                    "waiting-service-recovery",
+                    format!(
+                        "{} waiting out a temporary service condition; parked for recovery",
+                        agent.name()
+                    ),
+                )
+                .await;
+                limit_park = Some(park);
+                // Durable park marker, like the limit arm — the boot
+                // auto-readopt pass must see a dead boot's wrapper still
+                // owed its parked continuation (no reset clock: the
+                // widening schedule is the wrapper's own).
+                slog(&session_log, |l| {
+                    l.set_limit_park(Some(crate::session_log::SessionLimitParkMeta {
+                        resets_at_epoch: None,
+                        has_pending,
                     }))
                 });
             }

--- a/src/bin/caller/external_supervision.rs
+++ b/src/bin/caller/external_supervision.rs
@@ -1446,6 +1446,28 @@ pub(crate) enum DrainOutcome {
         message: Option<String>,
         turn_had_started: bool,
     },
+    /// A fatal backend error whose cause classifies as a TEMPORARY
+    /// service condition ([`transient_service_condition`]) ended the
+    /// round — the provider-incident class the interruption family was
+    /// missing (2026-07-29 specimens 24f01636/13e53300: API-500
+    /// round-deaths rode a DoneSignal and stranded both commissions
+    /// fake-idle for over an hour, invisible to the credential-reload
+    /// lane and every wake clock). The backend process stays usable and
+    /// its conversation holds whatever the round delivered; the caller
+    /// must count no round and arm the service-condition error park
+    /// ([`transient_round_death_error_park`]) — bounded widening wakes,
+    /// visible suspension when the schedule exhausts — instead of
+    /// completing or failing the round. `turn_had_started` is the same
+    /// delivery awareness as [`DrainOutcome::LimitRejected`]'s: whether
+    /// the primary thread demonstrably engaged this round's driving
+    /// message. Permanent-cause deaths never take this shape — they keep
+    /// their terminal outcomes ([`DrainOutcome::TurnFailed`] at zero
+    /// turns, the completion shape after real work).
+    TransientRoundDeath {
+        reason: String,
+        turns_in_round: usize,
+        turn_had_started: bool,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -1496,13 +1518,65 @@ pub(crate) fn limit_park_delay(
     Duration::from_secs(secs)
 }
 
-/// One armed rate-limit park in an external-session lane: the lane sleeps
-/// until `resume_at`, then re-sends `pending` (if still uncancelled).
-/// User messages arriving while parked queue behind it instead of burning
-/// against the rejected backend.
+/// What a park is waiting out. Both kinds ride the SAME armed-park state,
+/// wake timer, queue-while-parked, cancel, and reload-preserve machinery —
+/// the kind only decides the wake clock's policy at arm time and the
+/// honest wording of the shared lines.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ParkKind {
+    /// A provider usage limit rejected the turn; the wake clock is the
+    /// limit's reset time (plus jitter; backoff when untimed).
+    ProviderLimit,
+    /// A temporary service condition (the provider-incident class:
+    /// repeated 5xx after the backend's own transport retries, gateway
+    /// drops, stream cuts) killed the round; the wake clock is the
+    /// bounded widening [`ERROR_PARK_BACKOFF_SCHEDULE_SECS`] schedule.
+    ServiceCondition,
+}
+
+impl ParkKind {
+    /// The park's display noun for the shared log lines ("<noun>
+    /// elapsed/cancelled/…"), so an error park never claims to be
+    /// rate-limited (the display-lie class the 2026-07-29 diagnosis
+    /// stacked three of).
+    pub(crate) fn noun(&self) -> &'static str {
+        match self {
+            ParkKind::ProviderLimit => "Rate-limit park",
+            ParkKind::ServiceCondition => "Service-recovery pause",
+        }
+    }
+
+    /// The queued-while-parked row for a user message held during a park.
+    pub(crate) fn queued_log(&self) -> &'static str {
+        match self {
+            ParkKind::ProviderLimit => LIMIT_PARK_QUEUED_MESSAGE_LOG,
+            ParkKind::ServiceCondition => {
+                "Message queued — delivers when the service-recovery pause elapses"
+            }
+        }
+    }
+
+    /// The follow-up status detail for a message queued behind the park.
+    pub(crate) fn queued_status_detail(&self) -> &'static str {
+        match self {
+            ParkKind::ProviderLimit => "rate-limited; delivers when the limit resets",
+            ParkKind::ServiceCondition => {
+                "waiting out a service condition; delivers when the recovery pause elapses"
+            }
+        }
+    }
+}
+
+/// One armed park in an external-session lane: the lane sleeps until
+/// `resume_at`, then re-sends `pending` (if still uncancelled). User
+/// messages arriving while parked queue behind it instead of burning
+/// against the unavailable backend. `kind` says what the park waits out
+/// (a provider limit's reset, or a temporary service condition's
+/// recovery schedule) — one slot, one wake timer, honest wording.
 pub(crate) struct LimitParkState {
     pub(crate) resume_at: tokio::time::Instant,
     pub(crate) pending: Option<FollowUpMessage>,
+    pub(crate) kind: ParkKind,
 }
 
 /// A continuation for a turn the backend had already STARTED when it was
@@ -1547,7 +1621,27 @@ pub(crate) fn limit_park_pending(
     rejected: FollowUpMessage,
     turn_had_started: bool,
 ) -> FollowUpMessage {
-    match midturn_continuation(LIMIT_MIDTURN_CONTINUATION_TEXT, turn_had_started) {
+    delivery_aware_park_pending(rejected, turn_had_started, LIMIT_MIDTURN_CONTINUATION_TEXT)
+}
+
+/// The one delivery-aware pending decision every park lane rides
+/// (never copies): a round whose driving message never reached the
+/// backend parks the message itself for a verbatim re-send (true
+/// at-least-once); a round the backend had started parks a resume nudge
+/// carrying the interruption's cause instead — inheriting the driving
+/// message's follow-up/steer ids so a user cancel during the park
+/// cancels the resume exactly like it cancels a full re-send, and
+/// deliberately carrying none of its attachments or edit/rewind
+/// directives (those were already applied when the turn started).
+/// `midturn_text` names the cause: the rate-limit park passes
+/// [`LIMIT_MIDTURN_CONTINUATION_TEXT`], the service-condition error park
+/// [`ERROR_MIDTURN_CONTINUATION_TEXT`].
+pub(crate) fn delivery_aware_park_pending(
+    rejected: FollowUpMessage,
+    turn_had_started: bool,
+    midturn_text: &str,
+) -> FollowUpMessage {
+    match midturn_continuation(midturn_text, turn_had_started) {
         Some(mut nudge) => {
             nudge.follow_up_id = rejected.follow_up_id;
             nudge.steer_id = rejected.steer_id;
@@ -1610,6 +1704,188 @@ pub(crate) fn backend_started_limit_park(
         LimitParkState {
             resume_at: now + delay,
             pending,
+            kind: ParkKind::ProviderLimit,
+        },
+        park_line,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Service-condition error park (recovery scheduling for early round endings)
+// ---------------------------------------------------------------------------
+
+/// The bounded widening wake schedule for a round killed by a temporary
+/// service condition, indexed by consecutive-death `attempt` (1-based):
+/// short first (a provider blip recovers in seconds), then longer, so a
+/// real incident is retried patiently. Past the last entry the schedule
+/// is EXHAUSTED and the lane suspends visibly instead of parking again
+/// ([`error_park_attempts_exhausted`]). Integers deliberately tunable.
+pub(crate) const ERROR_PARK_BACKOFF_SCHEDULE_SECS: [u64; 5] = [30, 120, 300, 900, 1800];
+/// Jitter cap stacked on each schedule step so a fleet whose sessions
+/// all died on the same provider incident doesn't wake in lockstep.
+/// Deliberately smaller than the rate-limit park's 30–90s band — the
+/// first schedule step is only 30s.
+pub(crate) const ERROR_PARK_JITTER_MAX_SECS: u64 = 15;
+
+/// Random error-park jitter in `0..=ERROR_PARK_JITTER_MAX_SECS`. Tests
+/// inject a fixed value into [`error_park_delay`] instead of calling this.
+pub(crate) fn error_park_jitter_secs() -> u64 {
+    use rand::Rng;
+    rand::thread_rng().gen_range(0..=ERROR_PARK_JITTER_MAX_SECS)
+}
+
+/// The wake delay for recovery `attempt` (1-based). Attempts past the
+/// schedule clamp to its last step — but callers gate on
+/// [`error_park_attempts_exhausted`] first, so the clamp only matters if
+/// a caller deliberately keeps retrying past exhaustion.
+pub(crate) fn error_park_delay(attempt: u32, jitter_secs: u64) -> Duration {
+    let index = (attempt.max(1) as usize - 1).min(ERROR_PARK_BACKOFF_SCHEDULE_SECS.len() - 1);
+    Duration::from_secs(ERROR_PARK_BACKOFF_SCHEDULE_SECS[index].saturating_add(jitter_secs))
+}
+
+/// Whether recovery `attempt` (1-based) lies past the bounded schedule.
+/// The first exhausted attempt is `len + 1`: every entry in the schedule
+/// buys one real wake before the lane gives up visibly.
+pub(crate) fn error_park_attempts_exhausted(attempt: u32) -> bool {
+    attempt as usize > ERROR_PARK_BACKOFF_SCHEDULE_SECS.len()
+}
+
+/// The resume nudge a service-condition error park re-sends at wake when
+/// the killed round had already started at the backend (the delivery-aware
+/// twin of [`LIMIT_MIDTURN_CONTINUATION_TEXT`], through the same
+/// [`delivery_aware_park_pending`] seam).
+pub(crate) const ERROR_MIDTURN_CONTINUATION_TEXT: &str =
+    "A temporary service error interrupted the previous turn (the provider returned repeated \
+     server errors); the recovery pause has elapsed — continue where you left off. Do not \
+     expect the interrupted message to be re-sent: it is already in this conversation.";
+
+/// Classify a fatal round-ending backend error: `true` means a TEMPORARY
+/// service condition — the provider-incident class (HTTP 5xx after the
+/// backend's own transport retries gave up, gateway drops, stream cuts) —
+/// whose round death should arm the error park instead of ending the
+/// round's story. Everything else (auth problems, refusals, invalid
+/// pins, budget stops, deliberate exits) is PERMANENT: those endings
+/// keep today's terminal shapes. Matching is deliberately conservative
+/// and marker-based; the observed shapes:
+///
+/// - Claude Code surfaces provider errors as a result whose text starts
+///   "API Error: <status>" (the 2026-07-29 specimens: "API Error: 500",
+///   sessions 24f01636/13e53300) — `api error: 5` covers the 5xx band
+///   without matching auth statuses (401/403) or limits (429).
+/// - Anthropic 529s carry "overloaded"; generic 5xx bodies carry
+///   "internal server error" / "bad gateway" / "service unavailable" /
+///   "gateway timeout".
+/// - Codex labels stream cuts `streamDisconnected` with "stream
+///   disconnected before completion" prose; raw socket deaths surface
+///   "connection reset" / "fetch failed".
+pub(crate) fn transient_service_condition(reason: &str) -> bool {
+    let reason = reason.to_ascii_lowercase();
+    [
+        "api error: 5",
+        "overloaded",
+        "internal server error",
+        "bad gateway",
+        "service unavailable",
+        "gateway timeout",
+        "stream disconnected",
+        "streamdisconnected",
+        "connection reset",
+        "fetch failed",
+    ]
+    .iter()
+    .any(|marker| reason.contains(marker))
+}
+
+/// The cause of a fatal, non-recoverable backend error buffered while the
+/// drain waits out the post-turn grace window. `reason` is the formatted
+/// announcement (agent name + code + message — what logs and outcomes
+/// carry); `raw_message` is the adapter's verbatim error text, kept so
+/// the drain can recognize the error's OWN synthesized turn completion
+/// (Claude Code pushes `TurnCompleted` carrying the same text right after
+/// the fatal `BackendError`, one wire line) and not mistake it for a real
+/// completion superseding the cause.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FatalRoundError {
+    pub(crate) reason: String,
+    pub(crate) raw_message: String,
+}
+
+/// First line of a (possibly multi-line, JSON-bearing) backend error,
+/// truncated for one-row announcements. The full cause is already in the
+/// session log as the drain's own error row.
+fn error_reason_preview(reason: &str) -> String {
+    let first_line = reason.lines().next().unwrap_or("").trim();
+    truncate_string_copy(first_line, 160)
+}
+
+/// The session-log/activity row announcing a service-condition park —
+/// the error-park twin of [`limit_park_log_line`], one place so the
+/// lanes cannot drift.
+pub(crate) fn error_park_log_line(
+    reason: &str,
+    attempt: u32,
+    delay: Duration,
+    has_pending: bool,
+) -> String {
+    let tail = if has_pending {
+        "will auto-resume and continue the interrupted work (messages arriving meanwhile queue)"
+    } else {
+        "messages arriving meanwhile queue until the pause elapses"
+    };
+    format!(
+        "Temporary service condition ended the round ({}) — parked; recovery attempt {attempt} of {} wakes in ~{}m{}s; {tail}",
+        error_reason_preview(reason),
+        ERROR_PARK_BACKOFF_SCHEDULE_SECS.len(),
+        delay.as_secs() / 60,
+        delay.as_secs() % 60,
+    )
+}
+
+/// The visible-suspension announcement when the widening schedule is
+/// exhausted: the lane stops parking and ends/reports FAILED so the
+/// outage surfaces (agenda occurrences journal `failed` and count on the
+/// suspension streak) instead of waiting unattended.
+pub(crate) fn error_park_exhausted_line(reason: &str, attempts_made: u32) -> String {
+    format!(
+        "Temporary service condition persisted through {attempts_made} recovery attempts — \
+         suspending instead of waiting unattended: {}",
+        error_reason_preview(reason),
+    )
+}
+
+/// The armed service-condition park PLUS its announcement line — the
+/// error-park twin of [`backend_started_limit_park`]'s (park, line)
+/// unity: a caller cannot log the park without holding the state it
+/// announces, and the line's flavor derives from the pending it ships
+/// with. `rejected` is the round's driving message when this side sent
+/// one (the follow-up lane; delivery-aware verbatim re-send when the
+/// backend never started the turn) and `None` for backend-started
+/// rounds (nothing of ours to re-send; the pending is the resume nudge
+/// exactly when the turn had started). Both shapes ride the one
+/// [`delivery_aware_park_pending`] / [`midturn_continuation`] seam.
+pub(crate) fn transient_round_death_error_park(
+    reason: &str,
+    now: tokio::time::Instant,
+    attempt: u32,
+    jitter_secs: u64,
+    turn_had_started: bool,
+    rejected: Option<FollowUpMessage>,
+) -> (LimitParkState, String) {
+    let delay = error_park_delay(attempt, jitter_secs);
+    let pending = match rejected {
+        Some(rejected) => Some(delivery_aware_park_pending(
+            rejected,
+            turn_had_started,
+            ERROR_MIDTURN_CONTINUATION_TEXT,
+        )),
+        None => midturn_continuation(ERROR_MIDTURN_CONTINUATION_TEXT, turn_had_started),
+    };
+    let park_line = error_park_log_line(reason, attempt, delay, pending.is_some());
+    (
+        LimitParkState {
+            resume_at: now + delay,
+            pending,
+            kind: ParkKind::ServiceCondition,
         },
         park_line,
     )
@@ -1640,10 +1916,15 @@ pub(crate) fn compact_deferred_by_limit_park(
     let park = limit_park.as_ref()?;
     let resets_at_epoch =
         now_epoch.saturating_add(park.resume_at.saturating_duration_since(now).as_secs());
-    Some(format!(
-        "Compaction deferred — rate-limited; {}; request it again after the limit resets",
-        external_agent::limit_reset_phrase(Some(resets_at_epoch), now_epoch)
-    ))
+    let phrase = external_agent::limit_reset_phrase(Some(resets_at_epoch), now_epoch);
+    Some(match park.kind {
+        ParkKind::ProviderLimit => format!(
+            "Compaction deferred — rate-limited; {phrase}; request it again after the limit resets",
+        ),
+        ParkKind::ServiceCondition => format!(
+            "Compaction deferred — waiting out a service condition; {phrase}; request it again after the pause elapses",
+        ),
+    })
 }
 
 /// Pop the next still-deliverable message off a rate-limit park queue,
@@ -2500,5 +2781,198 @@ new file mode 100644
         let (popped, skipped) = next_parked_follow_up(&mut parked, &mut cancelled);
         assert!(popped.is_none());
         assert_eq!(skipped, 0);
+    }
+
+    /// PIN `transient_round_death_arms_error_park`: a round death whose
+    /// cause classifies as a temporary service condition (the 2026-07-29
+    /// specimens: "API Error: 500" round-deaths that rode a DoneSignal
+    /// and stranded both commissions fake-idle) arms a REAL park through
+    /// the (park, line) unity constructor — armed timer, service kind,
+    /// delivery-aware pending, and an announcement that cannot exist
+    /// without the state it announces.
+    #[tokio::test]
+    async fn transient_round_death_arms_error_park() {
+        let specimen =
+            "Claude Code backend error (error_during_execution): API Error: 500 \
+             {\"type\":\"api_error\",\"message\":\"Internal server error\"}";
+        assert!(transient_service_condition(specimen));
+
+        let now = tokio::time::Instant::now();
+        // The specimen shape: a backend-started/mid-commission round the
+        // backend had engaged — the pending is the resume nudge.
+        let (park, line) =
+            transient_round_death_error_park(specimen, now, 1, 0, true, None);
+        assert_eq!(park.kind, ParkKind::ServiceCondition);
+        assert_eq!(park.resume_at, now + error_park_delay(1, 0));
+        let pending = park.pending.as_ref().expect("started turn parks a nudge");
+        assert_eq!(pending.text, ERROR_MIDTURN_CONTINUATION_TEXT);
+        assert!(line.contains("parked"), "announcement names the park: {line}");
+        assert!(
+            line.contains("recovery attempt 1 of 5"),
+            "announcement names the schedule position: {line}"
+        );
+
+        // A backend-started death observed before any work parks
+        // pending-less — the timer still wakes the lane and messages
+        // arriving meanwhile queue instead of burning.
+        let (park, _line) =
+            transient_round_death_error_park(specimen, now, 1, 0, false, None);
+        assert!(park.pending.is_none());
+        assert_eq!(park.kind, ParkKind::ServiceCondition);
+    }
+
+    /// PIN `error_park_wakes_on_backoff_expiry`: the error park's wake
+    /// clock is the bounded widening schedule — short first, then longer
+    /// — indexed by consecutive-death attempt, and the armed park's
+    /// `resume_at` is exactly that delay out (the shared park timer
+    /// branch re-sends the pending when it fires, same slot as the
+    /// limit park's reset wake).
+    #[tokio::test]
+    async fn error_park_wakes_on_backoff_expiry() {
+        // Widening: each schedule step is at least the previous one.
+        let mut previous = 0u64;
+        for (index, step) in ERROR_PARK_BACKOFF_SCHEDULE_SECS.iter().enumerate() {
+            assert!(
+                *step >= previous,
+                "schedule must widen monotonically at step {index}"
+            );
+            previous = *step;
+            assert_eq!(
+                error_park_delay(index as u32 + 1, 0),
+                Duration::from_secs(*step)
+            );
+        }
+        // Short first: the first wake is prompt (a provider blip
+        // recovers in seconds, not an hour).
+        assert!(ERROR_PARK_BACKOFF_SCHEDULE_SECS[0] <= 60);
+        // Jitter stacks on the step; attempts past the schedule clamp
+        // to the last step.
+        assert_eq!(
+            error_park_delay(1, 7),
+            Duration::from_secs(ERROR_PARK_BACKOFF_SCHEDULE_SECS[0] + 7)
+        );
+        assert_eq!(
+            error_park_delay(99, 0),
+            Duration::from_secs(*ERROR_PARK_BACKOFF_SCHEDULE_SECS.last().unwrap())
+        );
+        // The armed park wakes exactly on the schedule.
+        let now = tokio::time::Instant::now();
+        let (park, _line) = transient_round_death_error_park(
+            "API Error: 503 Service Unavailable",
+            now,
+            3,
+            5,
+            true,
+            None,
+        );
+        assert_eq!(park.resume_at, now + error_park_delay(3, 5));
+
+        for _ in 0..32 {
+            assert!(error_park_jitter_secs() <= ERROR_PARK_JITTER_MAX_SECS);
+        }
+    }
+
+    /// PIN `exhausted_error_parks_suspend_visibly`: the schedule is
+    /// attempt-capped — one wake per schedule step, and the first
+    /// attempt PAST the schedule is exhausted. The lanes map exhaustion
+    /// to a FAILED terminal (`TaskOutcome::Failed`) with this
+    /// announcement instead of parking again, so a lasting outage
+    /// journals `failed` on the scheduled occurrence — counting on the
+    /// agenda's suspension streak and surfacing to the owner — rather
+    /// than waiting unattended (the specimens waited over an hour,
+    /// invisible to every wake clock).
+    #[test]
+    fn exhausted_error_parks_suspend_visibly() {
+        let attempts = ERROR_PARK_BACKOFF_SCHEDULE_SECS.len() as u32;
+        for attempt in 1..=attempts {
+            assert!(
+                !error_park_attempts_exhausted(attempt),
+                "attempt {attempt} is within the schedule"
+            );
+        }
+        assert!(error_park_attempts_exhausted(attempts + 1));
+
+        let line = error_park_exhausted_line("API Error: 500 internal server error", attempts);
+        assert!(
+            line.contains("suspending"),
+            "exhaustion announces a suspension, not a wait: {line}"
+        );
+        assert!(
+            line.contains(&format!("{attempts} recovery attempts")),
+            "exhaustion counts the schedule it burned: {line}"
+        );
+        assert!(line.contains("API Error: 500"));
+    }
+
+    /// PIN `error_park_shares_the_delivery_aware_seam`: the error park's
+    /// pending decision IS the limit park's — one
+    /// [`delivery_aware_park_pending`] / [`midturn_continuation`] seam,
+    /// never a copy. Never-delivered → the driving message verbatim
+    /// (ids, attachments, edit/rewind directives intact); started → a
+    /// resume nudge naming the service condition, inheriting the
+    /// follow-up/steer ids (a user cancel during the park cancels the
+    /// resume) and carrying none of the applied directives.
+    #[tokio::test]
+    async fn error_park_shares_the_delivery_aware_seam() {
+        // Never delivered: verbatim re-send, exactly like the limit twin.
+        let rejected = rejected_park_message();
+        let pending = delivery_aware_park_pending(
+            rejected.clone(),
+            false,
+            ERROR_MIDTURN_CONTINUATION_TEXT,
+        );
+        assert_eq!(pending.text, rejected.text);
+        assert_eq!(pending.follow_up_id, rejected.follow_up_id);
+        assert_eq!(pending.edit_user_turn_index, Some(3));
+        assert_eq!(
+            pending.claude_inplace_rewind_targets,
+            vec!["uuid-1".to_string()]
+        );
+
+        // Started: the nudge, with inherited ids and nothing else.
+        let pending = delivery_aware_park_pending(
+            rejected_park_message(),
+            true,
+            ERROR_MIDTURN_CONTINUATION_TEXT,
+        );
+        assert_eq!(pending.text, ERROR_MIDTURN_CONTINUATION_TEXT);
+        assert_eq!(pending.follow_up_id.as_deref(), Some("f-goal"));
+        assert_eq!(pending.steer_id.as_deref(), Some("s-goal"));
+        assert!(pending.attachments.items.is_empty());
+        assert_eq!(pending.edit_user_turn_index, None);
+        assert!(pending.claude_inplace_rewind_targets.is_empty());
+        let mut cancelled: HashSet<String> = HashSet::from(["f-goal".to_string()]);
+        assert!(crate::external_events::follow_up_message_was_cancelled(
+            &mut cancelled,
+            &pending
+        ));
+
+        // The limit park rides the identical seam — same function, its
+        // own cause text — so the two lanes cannot drift.
+        let limit_twin = limit_park_pending(rejected_park_message(), true);
+        let shared = delivery_aware_park_pending(
+            rejected_park_message(),
+            true,
+            LIMIT_MIDTURN_CONTINUATION_TEXT,
+        );
+        assert_eq!(limit_twin.text, shared.text);
+        assert_eq!(limit_twin.follow_up_id, shared.follow_up_id);
+        assert_eq!(limit_twin.steer_id, shared.steer_id);
+
+        // The full-message re-send inherits the error text through the
+        // constructor too: a never-started follow-up round parks the
+        // driving message itself.
+        let (park, _line) = transient_round_death_error_park(
+            "API Error: 502 Bad Gateway",
+            tokio::time::Instant::now(),
+            1,
+            0,
+            false,
+            Some(rejected_park_message()),
+        );
+        assert_eq!(
+            park.pending.expect("driving message parks verbatim").text,
+            "the whole goal, re-merged"
+        );
     }
 }

--- a/src/bin/caller/external_supervision.rs
+++ b/src/bin/caller/external_supervision.rs
@@ -2267,6 +2267,7 @@ mod tests {
         let parked = Some(LimitParkState {
             resume_at: now + Duration::from_secs(10 * 60),
             pending: None,
+            kind: ParkKind::ProviderLimit,
         });
 
         let deferral = compact_deferred_by_limit_park("compact", &parked, now, 1_000)
@@ -2276,6 +2277,20 @@ mod tests {
             "deferral: {deferral}"
         );
         assert!(deferral.contains("in ~10m"), "deferral: {deferral}");
+
+        // A service-condition park defers the same compact with its own
+        // honest wording (never "rate-limited").
+        let error_parked = Some(LimitParkState {
+            resume_at: now + Duration::from_secs(120),
+            pending: None,
+            kind: ParkKind::ServiceCondition,
+        });
+        let deferral = compact_deferred_by_limit_park("compact", &error_parked, now, 1_000)
+            .expect("error-parked compact must defer");
+        assert!(
+            deferral.starts_with("Compaction deferred — waiting out a service condition"),
+            "deferral: {deferral}"
+        );
 
         // Not a compact: the park does not block other thread actions here.
         assert_eq!(

--- a/src/bin/caller/external_supervision.rs
+++ b/src/bin/caller/external_supervision.rs
@@ -2792,21 +2792,22 @@ new file mode 100644
     /// without the state it announces.
     #[tokio::test]
     async fn transient_round_death_arms_error_park() {
-        let specimen =
-            "Claude Code backend error (error_during_execution): API Error: 500 \
+        let specimen = "Claude Code backend error (error_during_execution): API Error: 500 \
              {\"type\":\"api_error\",\"message\":\"Internal server error\"}";
         assert!(transient_service_condition(specimen));
 
         let now = tokio::time::Instant::now();
         // The specimen shape: a backend-started/mid-commission round the
         // backend had engaged — the pending is the resume nudge.
-        let (park, line) =
-            transient_round_death_error_park(specimen, now, 1, 0, true, None);
+        let (park, line) = transient_round_death_error_park(specimen, now, 1, 0, true, None);
         assert_eq!(park.kind, ParkKind::ServiceCondition);
         assert_eq!(park.resume_at, now + error_park_delay(1, 0));
         let pending = park.pending.as_ref().expect("started turn parks a nudge");
         assert_eq!(pending.text, ERROR_MIDTURN_CONTINUATION_TEXT);
-        assert!(line.contains("parked"), "announcement names the park: {line}");
+        assert!(
+            line.contains("parked"),
+            "announcement names the park: {line}"
+        );
         assert!(
             line.contains("recovery attempt 1 of 5"),
             "announcement names the schedule position: {line}"
@@ -2815,8 +2816,7 @@ new file mode 100644
         // A backend-started death observed before any work parks
         // pending-less — the timer still wakes the lane and messages
         // arriving meanwhile queue instead of burning.
-        let (park, _line) =
-            transient_round_death_error_park(specimen, now, 1, 0, false, None);
+        let (park, _line) = transient_round_death_error_park(specimen, now, 1, 0, false, None);
         assert!(park.pending.is_none());
         assert_eq!(park.kind, ParkKind::ServiceCondition);
     }
@@ -2916,11 +2916,8 @@ new file mode 100644
     async fn error_park_shares_the_delivery_aware_seam() {
         // Never delivered: verbatim re-send, exactly like the limit twin.
         let rejected = rejected_park_message();
-        let pending = delivery_aware_park_pending(
-            rejected.clone(),
-            false,
-            ERROR_MIDTURN_CONTINUATION_TEXT,
-        );
+        let pending =
+            delivery_aware_park_pending(rejected.clone(), false, ERROR_MIDTURN_CONTINUATION_TEXT);
         assert_eq!(pending.text, rejected.text);
         assert_eq!(pending.follow_up_id, rejected.follow_up_id);
         assert_eq!(pending.edit_user_turn_index, Some(3));

--- a/src/bin/caller/managed_context_ops/mod.rs
+++ b/src/bin/caller/managed_context_ops/mod.rs
@@ -12,9 +12,10 @@ use crate::{
     emit_external_turn_status, emit_fission_detach_relationships, emit_follow_up_status,
     emit_user_message_log, fission_anchor_cut_line, fission_anchor_first_lines,
     fission_anchor_reachable_after_rewind, fission_detach_parent_candidates,
-    is_codex_injected_user_text_for_main, CodexThreadActionDedupe, DrainOutcome,
-    ExternalBackendRecovery, ExternalContextSnapshotState, ExternalDiffDeltaTracker,
-    PendingRuntimeSteer, UserAttachments, UserTurnRevisionState,
+    is_codex_injected_user_text_for_main, transient_service_condition, CodexThreadActionDedupe,
+    DrainOutcome, ExternalBackendRecovery, ExternalContextSnapshotState,
+    ExternalDiffDeltaTracker, FatalRoundError, PendingRuntimeSteer, UserAttachments,
+    UserTurnRevisionState,
 };
 use crate::{
     context_rewind, external_wrapper_index, fission_ledger, fission_lifecycle, frontend,
@@ -425,9 +426,10 @@ pub(crate) fn backend_recovery_outcome_or_context_rewind(
     request: Option<ExternalContextRewindRequest>,
     turn_stop_status: ManagedContextRewindTurnStopStatus,
     recovery: Option<ExternalBackendRecovery>,
-    fatal_round_error: Option<String>,
+    fatal_round_error: Option<FatalRoundError>,
     message: Option<String>,
     turns_in_round: usize,
+    turn_had_started: bool,
 ) -> DrainOutcome {
     if let Some(request) = request {
         return DrainOutcome::ContextRewindRequested {
@@ -444,15 +446,31 @@ pub(crate) fn backend_recovery_outcome_or_context_rewind(
             turns_in_round,
         };
     }
-    // A fatal backend error that ended a ZERO-turn round is the
-    // launch-refusal class: nothing ran, so completing the round would
-    // journal a lie. A round with completed turns keeps its completion
-    // shape even when a fatal error ends it — real work happened and the
-    // error is already logged; only the did-nothing round fails.
-    if turns_in_round == 0 {
-        if let Some(reason) = fatal_round_error {
+    if let Some(fatal) = fatal_round_error {
+        // The round-outcome classification (recovery scheduling for
+        // early round endings): a TEMPORARY service condition — the
+        // provider-incident class — must not end the round's story with
+        // a completion (a DoneSignal journals a scheduled occurrence
+        // COMPLETED and strands the commission fake-idle; 2026-07-29
+        // specimens 24f01636/13e53300) or a terminal failure; the
+        // caller arms the error park and the work resumes on its wake
+        // schedule regardless of how many turns died with the round.
+        if transient_service_condition(&fatal.reason) {
+            return DrainOutcome::TransientRoundDeath {
+                reason: fatal.reason,
+                turns_in_round,
+                turn_had_started,
+            };
+        }
+        // PERMANENT causes keep their terminal shapes. A fatal error
+        // that ended a ZERO-turn round is the launch-refusal class:
+        // nothing ran, so completing the round would journal a lie. A
+        // round with completed turns keeps its completion shape even
+        // when a fatal error ends it — real work happened and the error
+        // is already logged; only the did-nothing round fails.
+        if turns_in_round == 0 {
             return DrainOutcome::TurnFailed {
-                reason,
+                reason: fatal.reason,
                 turns_in_round,
             };
         }
@@ -815,19 +833,29 @@ pub(crate) fn find_context_rewind_anchor_entry(
 mod tests {
     use super::*;
 
+    fn fatal(reason: &str) -> Option<FatalRoundError> {
+        Some(FatalRoundError {
+            reason: reason.to_string(),
+            raw_message: reason.to_string(),
+        })
+    }
+
     /// Drain-exit precedence: a pending rewind and a pending recovery both
-    /// outrank a fatal round error, and the fatal error fails ONLY a
-    /// zero-turn round — a round with real turns keeps its completion
-    /// shape (the 2026-07-26 launch-refusal rider's deliberate scope).
+    /// outrank a fatal round error, and a PERMANENT-cause fatal error
+    /// fails ONLY a zero-turn round — a round with real turns keeps its
+    /// completion shape (the 2026-07-26 launch-refusal rider's deliberate
+    /// scope). Transient-cause deaths take their own outcome
+    /// ([`terminal_deaths_stay_terminal`] pins the permanent side).
     #[test]
     fn drain_exit_fails_only_zero_turn_rounds_with_a_fatal_error() {
         let outcome = backend_recovery_outcome_or_context_rewind(
             None,
             ManagedContextRewindTurnStopStatus::NotRequested,
             None,
-            Some("claude-code backend error (success): bad model".to_string()),
+            fatal("claude-code backend error (success): bad model"),
             None,
             0,
+            false,
         );
         match outcome {
             DrainOutcome::TurnFailed {
@@ -846,9 +874,10 @@ mod tests {
                 None,
                 ManagedContextRewindTurnStopStatus::NotRequested,
                 None,
-                Some("late fatal error".to_string()),
+                fatal("late fatal error"),
                 Some("did things".to_string()),
                 2,
+                true,
             ),
             DrainOutcome::TurnCompleted { .. }
         ));
@@ -862,12 +891,131 @@ mod tests {
                     message: "starved".to_string(),
                     recovery_hint: None,
                 }),
-                Some("fatal cause".to_string()),
+                fatal("fatal cause"),
                 None,
                 0,
+                false,
             ),
             DrainOutcome::RecoveryRequired { .. }
         ));
+    }
+
+    /// PIN `terminal_deaths_stay_terminal`: permanent-class round endings
+    /// — auth problems, refusals, invalid pins, deliberate exits — keep
+    /// today's terminal shapes exactly (TurnFailed for the did-nothing
+    /// round, the completion shape after real work), and never classify
+    /// as a temporary service condition.
+    #[test]
+    fn terminal_deaths_stay_terminal() {
+        for permanent in [
+            "Claude Code backend error (success): There's an issue with the selected model \
+             (fable-5). It may not exist or you may not have access to it.",
+            "Claude Code backend error (error_during_execution): API Error: 401 \
+             {\"type\":\"authentication_error\"}",
+            "Codex backend error (usageNotIncluded): To use Codex with your plan, upgrade",
+            "Claude Code backend error: OAuth token has expired",
+            "Claude Code turn failed: error_max_budget_usd",
+            "Session ended: stopped by user",
+        ] {
+            assert!(
+                !transient_service_condition(permanent),
+                "permanent cause misclassified transient: {permanent}"
+            );
+            // Zero-turn: the launch-refusal terminal, unchanged.
+            assert!(
+                matches!(
+                    backend_recovery_outcome_or_context_rewind(
+                        None,
+                        ManagedContextRewindTurnStopStatus::NotRequested,
+                        None,
+                        fatal(permanent),
+                        None,
+                        0,
+                        false,
+                    ),
+                    DrainOutcome::TurnFailed { .. }
+                ),
+                "zero-turn permanent death must stay TurnFailed: {permanent}"
+            );
+            // After real work: the completion shape, unchanged.
+            assert!(
+                matches!(
+                    backend_recovery_outcome_or_context_rewind(
+                        None,
+                        ManagedContextRewindTurnStopStatus::NotRequested,
+                        None,
+                        fatal(permanent),
+                        Some("partial work".to_string()),
+                        3,
+                        true,
+                    ),
+                    DrainOutcome::TurnCompleted { .. }
+                ),
+                "permanent death after real turns must keep the completion shape: {permanent}"
+            );
+        }
+    }
+
+    /// The transient half of the round-outcome classification: a fatal
+    /// cause carrying a service-condition marker resolves as
+    /// `TransientRoundDeath` — at zero turns AND after real work (the
+    /// 2026-07-29 specimens died with 91/76 turns and rode a DoneSignal)
+    /// — carrying the drain's delivery awareness through.
+    #[test]
+    fn transient_causes_classify_to_transient_round_death() {
+        for transient in [
+            "Claude Code backend error (error_during_execution): API Error: 500 \
+             {\"type\":\"api_error\",\"message\":\"Internal server error\"}",
+            "Claude Code backend error: API Error: 529 {\"type\":\"overloaded_error\"}",
+            "Codex backend error (streamDisconnected): stream disconnected before completion",
+            "Codex backend error: 502 Bad Gateway",
+            "Kimi backend error: 503 Service Unavailable",
+            "backend error: connection reset by peer",
+        ] {
+            assert!(
+                transient_service_condition(transient),
+                "transient cause not recognized: {transient}"
+            );
+            match backend_recovery_outcome_or_context_rewind(
+                None,
+                ManagedContextRewindTurnStopStatus::NotRequested,
+                None,
+                fatal(transient),
+                Some(transient.to_string()),
+                91,
+                true,
+            ) {
+                DrainOutcome::TransientRoundDeath {
+                    reason,
+                    turns_in_round,
+                    turn_had_started,
+                } => {
+                    assert_eq!(reason, transient);
+                    assert_eq!(turns_in_round, 91);
+                    assert!(turn_had_started);
+                }
+                _ => panic!("transient death after real turns must classify: {transient}"),
+            }
+            assert!(
+                matches!(
+                    backend_recovery_outcome_or_context_rewind(
+                        None,
+                        ManagedContextRewindTurnStopStatus::NotRequested,
+                        None,
+                        fatal(transient),
+                        None,
+                        0,
+                        false,
+                    ),
+                    DrainOutcome::TransientRoundDeath {
+                        turns_in_round: 0,
+                        turn_had_started: false,
+                        ..
+                    }
+                ),
+                "zero-turn transient death must classify, not TurnFailed: {transient}"
+            );
+        }
     }
 
     #[test]

--- a/src/bin/caller/managed_context_ops/mod.rs
+++ b/src/bin/caller/managed_context_ops/mod.rs
@@ -13,9 +13,8 @@ use crate::{
     emit_user_message_log, fission_anchor_cut_line, fission_anchor_first_lines,
     fission_anchor_reachable_after_rewind, fission_detach_parent_candidates,
     is_codex_injected_user_text_for_main, transient_service_condition, CodexThreadActionDedupe,
-    DrainOutcome, ExternalBackendRecovery, ExternalContextSnapshotState,
-    ExternalDiffDeltaTracker, FatalRoundError, PendingRuntimeSteer, UserAttachments,
-    UserTurnRevisionState,
+    DrainOutcome, ExternalBackendRecovery, ExternalContextSnapshotState, ExternalDiffDeltaTracker,
+    FatalRoundError, PendingRuntimeSteer, UserAttachments, UserTurnRevisionState,
 };
 use crate::{
     context_rewind, external_wrapper_index, fission_ledger, fission_lifecycle, frontend,

--- a/src/bin/caller/run_modes.rs
+++ b/src/bin/caller/run_modes.rs
@@ -2279,9 +2279,7 @@ pub(crate) async fn run_with_presence(
                                     // the next user message re-drives.
                                     persistent_error_park_streak =
                                         persistent_error_park_streak.saturating_add(1);
-                                    if error_park_attempts_exhausted(
-                                        persistent_error_park_streak,
-                                    ) {
+                                    if error_park_attempts_exhausted(persistent_error_park_streak) {
                                         cumulative_stats.rounds = round;
                                         let line = error_park_exhausted_line(
                                             &reason,
@@ -2301,15 +2299,14 @@ pub(crate) async fn run_with_presence(
                                             turn: None,
                                         });
                                     } else {
-                                        let (park, park_line) =
-                                            transient_round_death_error_park(
-                                                &reason,
-                                                tokio::time::Instant::now(),
-                                                persistent_error_park_streak,
-                                                error_park_jitter_secs(),
-                                                turn_had_started,
-                                                None,
-                                            );
+                                        let (park, park_line) = transient_round_death_error_park(
+                                            &reason,
+                                            tokio::time::Instant::now(),
+                                            persistent_error_park_streak,
+                                            error_park_jitter_secs(),
+                                            turn_had_started,
+                                            None,
+                                        );
                                         slog(&session_log, |l| l.warn(&park_line));
                                         bus.send(AppEvent::LogEntry {
                                             session_id: session_log_id(&session_log),

--- a/src/bin/caller/run_modes.rs
+++ b/src/bin/caller/run_modes.rs
@@ -324,6 +324,12 @@ pub(crate) async fn run_with_presence(
     // rejections (backoff input when the wire carries no reset time).
     let mut persistent_limit_park: Option<LimitParkState> = None;
     let mut persistent_limit_park_streak: u32 = 0;
+    // Consecutive transient-service-condition round deaths (the error
+    // park's recovery-attempt counter). Past the bounded widening
+    // schedule the lane stops parking and reports the outage instead of
+    // waiting unattended; a completed turn or an explicit intervention
+    // resets it.
+    let mut persistent_error_park_streak: u32 = 0;
     let mut persistent_parked_follow_ups: std::collections::VecDeque<FollowUpMessage> =
         std::collections::VecDeque::new();
     let mut persistent_managed_context_recovery_kickstarts_without_rewind = 0u8;
@@ -484,8 +490,9 @@ pub(crate) async fn run_with_presence(
                     Some(e) => OuterSignal::Task(e),
                     None => OuterSignal::Done,
                 },
-                // Rate-limit park timer: at the reset (plus jitter), queue
-                // the rejected message back at the front and let the
+                // Park timer (both kinds ride this one slot): at the
+                // limit's reset or the recovery schedule's next step,
+                // queue what the park held back at the front and let the
                 // parked-flush preamble above dispatch the queue FIFO.
                 _ = tokio::time::sleep_until(
                     persistent_limit_park
@@ -496,6 +503,7 @@ pub(crate) async fn run_with_presence(
                     let park = persistent_limit_park
                         .take()
                         .expect("branch guarded by is_some");
+                    let noun = park.kind.noun();
                     match park.pending {
                         Some(pending)
                             if !follow_up_message_was_cancelled(
@@ -503,28 +511,29 @@ pub(crate) async fn run_with_presence(
                                 &pending,
                             ) =>
                         {
-                            let line =
-                                "Rate-limit park elapsed — re-sending the parked message";
-                            slog(&session_log, |l| l.info(line));
+                            let line = format!(
+                                "{noun} elapsed — re-sending the parked message"
+                            );
+                            slog(&session_log, |l| l.info(&line));
                             bus.send(AppEvent::LogEntry {
                                 session_id: session_log_id(&session_log),
                                 level: "info".to_string(),
                                 source: "Intendant".to_string(),
-                                content: line.to_string(),
+                                content: line,
                                 turn: None,
                             });
                             persistent_parked_follow_ups.push_front(pending);
                         }
                         Some(_) => {
                             slog(&session_log, |l| {
-                                l.info(
-                                    "Rate-limit park elapsed — the parked message was cancelled; awaiting input",
-                                )
+                                l.info(&format!(
+                                    "{noun} elapsed — the parked message was cancelled; awaiting input",
+                                ))
                             });
                         }
                         None => {
                             slog(&session_log, |l| {
-                                l.info("Rate-limit park elapsed — awaiting input")
+                                l.info(&format!("{noun} elapsed — awaiting input"))
                             });
                         }
                     }
@@ -582,17 +591,19 @@ pub(crate) async fn run_with_presence(
                         // queued and flush normally).
                         if let Some(park) = persistent_limit_park.take() {
                             persistent_limit_park_streak = 0;
+                            persistent_error_park_streak = 0;
+                            let noun = park.kind.noun();
                             let line = if park.pending.is_some() {
-                                "Rate-limit park cancelled by interrupt — dropped the pending re-send"
+                                format!("{noun} cancelled by interrupt — dropped the pending re-send")
                             } else {
-                                "Rate-limit park cancelled by interrupt"
+                                format!("{noun} cancelled by interrupt")
                             };
-                            slog(&session_log, |l| l.info(line));
+                            slog(&session_log, |l| l.info(&line));
                             bus.send(AppEvent::LogEntry {
                                 session_id: session_log_id(&session_log),
                                 level: "info".to_string(),
                                 source: "Intendant".to_string(),
-                                content: line.to_string(),
+                                content: line,
                                 turn: None,
                             });
                         }
@@ -968,6 +979,34 @@ pub(crate) async fn run_with_presence(
                                             turn: None,
                                         });
                                     }
+                                    Ok(DrainOutcome::TransientRoundDeath {
+                                        reason,
+                                        turns_in_round,
+                                        ..
+                                    }) => {
+                                        // A temporary service condition
+                                        // killed the resumed rewind turn.
+                                        // Like this lane's limit arm:
+                                        // report only, no park claim — the
+                                        // session idles and the next user
+                                        // message re-drives it.
+                                        cumulative_stats.rounds += 1;
+                                        bus.send(AppEvent::RoundComplete {
+                                            session_id: session_log_id(&session_log),
+                                            round: cumulative_stats.rounds,
+                                            turns_in_round,
+                                            native_message_count: None,
+                                            project_root: round_session_root.clone(),
+                                        });
+                                        bus.send(AppEvent::PresenceLog {
+                                            message: format!(
+                                                "Temporary service condition ended the resumed context-rewind turn ({}); send a message to resume",
+                                                reason
+                                            ),
+                                            level: Some(types::LogLevel::Warn),
+                                            turn: None,
+                                        });
+                                    }
                                     Ok(DrainOutcome::ContextRewindRequested {
                                         request, ..
                                     }) => {
@@ -1033,6 +1072,27 @@ pub(crate) async fn run_with_presence(
                                                     level: "warn".to_string(),
                                                     source: "Intendant".to_string(),
                                                     content: park_line,
+                                                    turn: None,
+                                                });
+                                            }
+                                            Ok(Some(DrainOutcome::TransientRoundDeath {
+                                                reason,
+                                                ..
+                                            })) => {
+                                                // Report only, no park
+                                                // claim — the chained
+                                                // rewind lane idles and
+                                                // the next user message
+                                                // re-drives it.
+                                                let line = format!(
+                                                    "Temporary service condition ended the chained context-rewind turn ({reason}); send a message to resume"
+                                                );
+                                                slog(&session_log, |l| l.warn(&line));
+                                                bus.send(AppEvent::LogEntry {
+                                                    session_id: session_log_id(&session_log),
+                                                    level: "warn".to_string(),
+                                                    source: "Intendant".to_string(),
+                                                    content: line,
                                                     turn: None,
                                                 });
                                             }
@@ -1252,15 +1312,25 @@ pub(crate) async fn run_with_presence(
                     // A fresh thread is an explicit reset: cancel a live
                     // rate-limit park and drop what it held — those
                     // messages targeted the discarded conversation.
-                    if persistent_limit_park.take().is_some()
-                        || !persistent_parked_follow_ups.is_empty()
-                    {
+                    if let Some(park) = persistent_limit_park.take() {
                         persistent_limit_park_streak = 0;
+                        persistent_error_park_streak = 0;
                         let dropped = persistent_parked_follow_ups.len();
                         persistent_parked_follow_ups.clear();
                         slog(&session_log, |l| {
                             l.info(&format!(
-                                "Rate-limit park cancelled by /new; dropped {dropped} queued message(s)"
+                                "{} cancelled by /new; dropped {dropped} queued message(s)",
+                                park.kind.noun()
+                            ))
+                        });
+                    } else if !persistent_parked_follow_ups.is_empty() {
+                        persistent_limit_park_streak = 0;
+                        persistent_error_park_streak = 0;
+                        let dropped = persistent_parked_follow_ups.len();
+                        persistent_parked_follow_ups.clear();
+                        slog(&session_log, |l| {
+                            l.info(&format!(
+                                "Parked queue cleared by /new; dropped {dropped} queued message(s)"
                             ))
                         });
                     }
@@ -2001,15 +2071,19 @@ pub(crate) async fn run_with_presence(
                             level: Some(types::LogLevel::Warn),
                             turn: None,
                         });
-                        // Session end cancels a live rate-limit park (the
-                        // parked re-send targeted the dead conversation);
-                        // queued user messages stay queued like any other
-                        // post-termination follow-up and run against the
-                        // next agent build.
-                        if persistent_limit_park.take().is_some() {
+                        // Session end cancels a live park of either kind
+                        // (the parked re-send targeted the dead
+                        // conversation); queued user messages stay queued
+                        // like any other post-termination follow-up and
+                        // run against the next agent build.
+                        if let Some(park) = persistent_limit_park.take() {
                             persistent_limit_park_streak = 0;
+                            persistent_error_park_streak = 0;
                             slog(&session_log, |l| {
-                                l.info("Rate-limit park cancelled — the agent terminated")
+                                l.info(&format!(
+                                    "{} cancelled — the agent terminated",
+                                    park.kind.noun()
+                                ))
                             });
                         }
                         persistent_agent = None;
@@ -2186,6 +2260,78 @@ pub(crate) async fn run_with_presence(
                                     )
                                     .await;
                                     persistent_limit_park = Some(park);
+                                }
+                                DrainOutcome::TransientRoundDeath {
+                                    reason,
+                                    turns_in_round,
+                                    turn_had_started,
+                                } => {
+                                    // A spontaneous round died on a
+                                    // temporary service condition: arm
+                                    // the error park (nothing of ours to
+                                    // re-send; the pending is the resume
+                                    // nudge exactly when the turn had
+                                    // started). Past the widening
+                                    // schedule, report the outage and
+                                    // stop parking — the persistent lane
+                                    // never exits, so visibility is the
+                                    // error row and the presence surface;
+                                    // the next user message re-drives.
+                                    persistent_error_park_streak =
+                                        persistent_error_park_streak.saturating_add(1);
+                                    if error_park_attempts_exhausted(
+                                        persistent_error_park_streak,
+                                    ) {
+                                        cumulative_stats.rounds = round;
+                                        let line = error_park_exhausted_line(
+                                            &reason,
+                                            persistent_error_park_streak.saturating_sub(1),
+                                        );
+                                        slog(&session_log, |l| l.error(&line));
+                                        bus.send(AppEvent::RoundComplete {
+                                            session_id: session_log_id(&session_log),
+                                            round,
+                                            turns_in_round,
+                                            native_message_count: None,
+                                            project_root: round_session_root.clone(),
+                                        });
+                                        bus.send(AppEvent::PresenceLog {
+                                            message: line,
+                                            level: Some(types::LogLevel::Error),
+                                            turn: None,
+                                        });
+                                    } else {
+                                        let (park, park_line) =
+                                            transient_round_death_error_park(
+                                                &reason,
+                                                tokio::time::Instant::now(),
+                                                persistent_error_park_streak,
+                                                error_park_jitter_secs(),
+                                                turn_had_started,
+                                                None,
+                                            );
+                                        slog(&session_log, |l| l.warn(&park_line));
+                                        bus.send(AppEvent::LogEntry {
+                                            session_id: session_log_id(&session_log),
+                                            level: "warn".to_string(),
+                                            source: "Intendant".to_string(),
+                                            content: park_line,
+                                            turn: None,
+                                        });
+                                        emit_external_turn_status(
+                                            &bus,
+                                            &autonomy,
+                                            session_log_id(&session_log).as_deref(),
+                                            round,
+                                            "waiting-service-recovery",
+                                            format!(
+                                                "{} waiting out a temporary service condition; parked for recovery",
+                                                agent.name()
+                                            ),
+                                        )
+                                        .await;
+                                        persistent_limit_park = Some(park);
+                                    }
                                 }
                                 DrainOutcome::RecoveryRequired {
                                     message,
@@ -2747,18 +2893,19 @@ pub(crate) async fn run_with_presence(
             initial_followup.steer_id = envelope.steer_id.clone();
             let initial_followup_is_real = !initial_followup.text.trim().is_empty()
                 || !initial_followup.attachments.is_empty();
-            // Rate-limit park: while parked, a new task queues (visibly)
-            // instead of burning against the rejected backend. The resume
-            // path dispatches the queue FIFO through the synthesized
-            // flush task — pending re-send first, then what queued.
-            if persistent_limit_park.is_some() {
+            // Armed park (either kind): while parked, a new task queues
+            // (visibly) instead of burning against the unavailable
+            // backend. The resume path dispatches the queue FIFO through
+            // the synthesized flush task — pending re-send first, then
+            // what queued.
+            if let Some(park) = persistent_limit_park.as_ref() {
                 if initial_followup_is_real {
-                    slog(&session_log, |l| l.info(LIMIT_PARK_QUEUED_MESSAGE_LOG));
+                    slog(&session_log, |l| l.info(park.kind.queued_log()));
                     bus.send(AppEvent::LogEntry {
                         session_id: session_log_id(&session_log),
                         level: "info".to_string(),
                         source: "Intendant".to_string(),
-                        content: LIMIT_PARK_QUEUED_MESSAGE_LOG.to_string(),
+                        content: park.kind.queued_log().to_string(),
                         turn: None,
                     });
                     persistent_parked_follow_ups.push_back(initial_followup);
@@ -3068,6 +3215,7 @@ pub(crate) async fn run_with_presence(
                         // A completed turn proves the provider is serving
                         // again.
                         persistent_limit_park_streak = 0;
+                        persistent_error_park_streak = 0;
                         if codex_managed_context_enabled {
                             match refresh_external_context_usage_snapshot(agent, &drain_config)
                                 .await
@@ -3454,7 +3602,78 @@ pub(crate) async fn run_with_presence(
                         persistent_limit_park = Some(LimitParkState {
                             resume_at: tokio::time::Instant::now() + delay,
                             pending: Some(limit_park_pending(pending, turn_had_started)),
+                            kind: ParkKind::ProviderLimit,
                         });
+                    }
+                    DrainOutcome::TransientRoundDeath {
+                        reason,
+                        turns_in_round,
+                        turn_had_started,
+                    } => {
+                        // The task-driven round died on a temporary
+                        // service condition: count nothing, arm the error
+                        // park with the delivery-aware pending (the
+                        // driving message verbatim when the backend never
+                        // started the turn, the resume nudge when it
+                        // did), and let the outer-select timer wake it on
+                        // the widening schedule. Past the schedule,
+                        // report the outage and stop parking — the
+                        // persistent lane never exits; the next user
+                        // message re-drives.
+                        persistent_error_park_streak =
+                            persistent_error_park_streak.saturating_add(1);
+                        if error_park_attempts_exhausted(persistent_error_park_streak) {
+                            cumulative_stats.rounds += 1;
+                            let line = error_park_exhausted_line(
+                                &reason,
+                                persistent_error_park_streak.saturating_sub(1),
+                            );
+                            slog(&session_log, |l| l.error(&line));
+                            bus.send(AppEvent::RoundComplete {
+                                session_id: session_log_id(&session_log),
+                                round: cumulative_stats.rounds,
+                                turns_in_round,
+                                native_message_count: None,
+                                project_root: round_session_root.clone(),
+                            });
+                            bus.send(AppEvent::PresenceLog {
+                                message: line,
+                                level: Some(types::LogLevel::Error),
+                                turn: None,
+                            });
+                        } else {
+                            let mut pending = active_followup;
+                            pending.text = merged_text.clone();
+                            let (park, park_line) = transient_round_death_error_park(
+                                &reason,
+                                tokio::time::Instant::now(),
+                                persistent_error_park_streak,
+                                error_park_jitter_secs(),
+                                turn_had_started,
+                                Some(pending),
+                            );
+                            slog(&session_log, |l| l.warn(&park_line));
+                            bus.send(AppEvent::LogEntry {
+                                session_id: session_log_id(&session_log),
+                                level: "warn".to_string(),
+                                source: "Intendant".to_string(),
+                                content: park_line,
+                                turn: None,
+                            });
+                            emit_external_turn_status(
+                                &bus,
+                                &autonomy,
+                                session_log_id(&session_log).as_deref(),
+                                round,
+                                "waiting-service-recovery",
+                                format!(
+                                    "{} waiting out a temporary service condition; parked for recovery",
+                                    backend
+                                ),
+                            )
+                            .await;
+                            persistent_limit_park = Some(park);
+                        }
                     }
                     DrainOutcome::RecoveryRequired {
                         message,

--- a/src/bin/caller/thread_actions.rs
+++ b/src/bin/caller/thread_actions.rs
@@ -3529,6 +3529,23 @@ pub(crate) async fn drain_external_child_turn(
             });
             emit_child_turn_complete(&child_config, conversation_kind, message);
         }
+        DrainOutcome::TransientRoundDeath { reason, .. } => {
+            // A temporary service condition killed the child turn. Child
+            // conversations have no park machinery — report honestly and
+            // end the child turn like a completion; the primary lane owns
+            // recovery scheduling.
+            child_config.bus.send(AppEvent::LogEntry {
+                session_id: child_config.session_id.clone(),
+                level: "warn".to_string(),
+                source: external_agent_log_source(child_config.agent_source.as_deref()),
+                content: format!(
+                    "Temporary service condition ended the {} conversation turn: {}",
+                    conversation_kind, reason
+                ),
+                turn: None,
+            });
+            emit_child_turn_complete(&child_config, conversation_kind, Some(reason));
+        }
         DrainOutcome::ContextRewindRequested { request, .. } => {
             emit_context_rewind_failure(
                 &request,


### PR DESCRIPTION
## The gap

When a backend's working round ends early because the provider returned repeated 500-class responses, the wrapper recorded the outcome and scheduled nothing afterward — no pause state, no wake timer, no notification. Both 2026-07-29 specimens (commission seats `24f01636`/`13e53300`, diagnosed in the sealed investigation report on agenda item 01KYQX3M8TP0HGMD8BWAGV9NK7) waited unattended for over an hour, invisible to the credential-reload lane (nothing pending to resume) and to every wake clock — and their DoneSignals journaled the occurrences COMPLETED with the failure invisible.

Layering: transport-level retry lives in the backend (it retried; the condition outlasted its patience); round-level recovery scheduling lives in Intendant supervision — that lane was missing.

## The build

- **Classification at the round-outcome seam** (`backend_recovery_outcome_or_context_rewind`): a fatal backend error whose cause classifies as a temporary service condition (`transient_service_condition` — conservative markers: `API Error: 5xx`, overloaded, bad gateway/service unavailable/gateway timeout, stream disconnects, connection resets) drains as the new `DrainOutcome::TransientRoundDeath`. **Permanent causes — auth problems, refusals, invalid pins, deliberate exits — keep today's terminal shapes exactly.**
- **The error park rides the limit-park machinery** — one `LimitParkState` slot with a new `ParkKind` tag (honest wording per kind at every shared line), the same wake timer, queue-while-parked, interrupt/`/new`/termination cancels, reload cancel-preserve, and the one delivery-aware pending seam (`delivery_aware_park_pending` / `midturn_continuation`; `limit_park_pending` now delegates to it). Share, never copy.
- **Wake schedule**: bounded widening backoff `[30s, 2m, 5m, 15m, 30m]` + 0–15s jitter (`ERROR_PARK_BACKOFF_SCHEDULE_SECS`, tunable), each wake carrying the continue-where-you-left-off follow-up (nudge when the turn had started; the driving message verbatim when it never did; pending-less for backend-started rounds that hadn't begun). Limit parks wake at reset time; service-condition parks wake on their schedule; both ride the one seam.
- **Exhaustion is a visible suspension**: past the schedule the supervised lane ends with `TaskComplete { outcome: Failed }` carrying the cause — scheduled occurrences journal `failed` and count on the agenda suspension streak (standing series suspend; one-shots surface FAILED) instead of waiting unattended. The persistent daemon lane reports the outage on the error/presence surfaces and stops parking until re-driven. Streaks reset on a completed turn or explicit intervention.
- **Durable marker**: the supervised lane stamps the same `limit_park` session-meta marker (no reset clock) so boot auto-readopt sees a dead boot's wrapper still owed its parked continuation.
- **Rider (drain honesty fix)**: Claude Code ends an errored turn by emitting the fatal `BackendError` AND a synthesized `TurnCompleted` carrying the same result text on one wire line. The drain treated that echo as a real completion superseding the buffered fatal cause — which not only dropped the cause this lane classifies, but made the 2026-07-26 zero-turn `TurnFailed` pin unreachable on the CC wire. The supersede guard now recognizes the echo (message-equality against the buffered raw error text); genuinely later real completions still supersede.

## Pins (conformance contract, all as named tests)

- `transient_round_death_arms_error_park` (+ drain-level specimen replay `api_500_round_death_with_completion_echo_drains_transient`, + classifier coverage `transient_causes_classify_to_transient_round_death`)
- `error_park_wakes_on_backoff_expiry`
- `exhausted_error_parks_suspend_visibly`
- `terminal_deaths_stay_terminal`
- `error_park_shares_the_delivery_aware_seam`

Scope note: the Vault feedback rider from the investigation report is deliberately NOT here — superseded by card 01KYR238D2 (no Vault fragments touched).

Docs: new "Service-condition Error Parking" section in `docs/src/external-agent-orchestration.md`.