### PR TITLE
era-lane re-announce gap: staleness cue on superseded-era limit chips + turn-free park-wake refresh

### DIFF
--- a/crates/intendant-core/src/vitals.rs
+++ b/crates/intendant-core/src/vitals.rs
@@ -124,11 +124,25 @@ pub struct SessionLimitWindow {
     /// or a minted era nonce when the ceremony learned no label). `None` =
     /// the unattributed era: sessions whose credentials predate any
     /// daemon-observed sign-in. Store- and wire-additive; on session
-    /// emissions the field is present only while more than one credential
-    /// era is live for the backend — the frontends' cue to label the
-    /// windows apart (a single-era steady state renders unchanged).
+    /// emissions the field is present while more than one credential era
+    /// is live for the backend (the frontends' cue to label the windows
+    /// apart; a single-era steady state renders unchanged) — and always
+    /// when [`Self::account_prior`] is set, so a superseded era's numbers
+    /// never render unlabeled.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub account: Option<String>,
+    /// The window belongs to a SUPERSEDED credential era: the daemon has
+    /// observed a newer sign-in for this backend, but the session wearing
+    /// this view last announced (process start = credential read) under
+    /// `account`, so these numbers are still that account's truth — the
+    /// frontends' cue to say "still ‹account›" instead of letting an
+    /// old era's chips read as the current sign-in. Display-shaped and
+    /// emission-only: stamped by the per-session mirror, never persisted
+    /// (`false` never serializes; store rows always carry `false`). Only
+    /// labeled eras stamp it — the unattributed era has no truthful
+    /// account to anchor the claim to.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub account_prior: bool,
 }
 
 /// What a session's model/backend is verifiably doing right now — the
@@ -505,12 +519,14 @@ mod tests {
             status: Some("allowed_warning".into()),
             observed_at_epoch: Some(1_784_499_000),
             account: Some("owner@example.test".into()),
+            account_prior: true,
         };
         let wire = serde_json::to_value(&window).expect("serializes");
         assert_eq!(wire["observedAtEpoch"], 1_784_499_000u64);
         assert_eq!(wire["resetsAtEpoch"], 1_784_503_200u64);
         assert_eq!(wire["status"], "allowed_warning");
         assert_eq!(wire["account"], "owner@example.test");
+        assert_eq!(wire["accountPrior"], true);
         assert!(
             wire.get("usedPct").is_none(),
             "an unreported percentage must not serialize as a number"
@@ -525,11 +541,16 @@ mod tests {
                 .expect("legacy deserializes");
         assert_eq!(legacy.observed_at_epoch, None);
         assert_eq!(legacy.account, None);
+        assert!(!legacy.account_prior);
         let rewire = serde_json::to_value(&legacy).expect("serializes");
         assert!(rewire.get("observedAtEpoch").is_none());
         assert!(
             rewire.get("account").is_none(),
             "the unattributed era serializes as absence, not null"
+        );
+        assert!(
+            rewire.get("accountPrior").is_none(),
+            "a current-era window serializes the prior stamp as absence"
         );
     }
 

--- a/src/bin/caller/external_agent/claude_code.rs
+++ b/src/bin/caller/external_agent/claude_code.rs
@@ -4136,6 +4136,20 @@ impl ExternalAgent for ClaudeCodeAgent {
         "claude-code"
     }
 
+    fn next_round_reads_fresh_credentials(&mut self) -> bool {
+        match self.child.as_mut() {
+            // No process: the next round spawns one, and the spawn reads
+            // the credential store fresh.
+            None => true,
+            // An exited process equally cannot carry its old credential
+            // read into the next round (the resume respawn reads fresh).
+            // A live child CAN — the persistent stream-input shape sends
+            // later turns into the same process — so only a confirmed
+            // exit answers true.
+            Some(child) => matches!(child.try_wait(), Ok(Some(_))),
+        }
+    }
+
     async fn initialize(
         &mut self,
         config: AgentConfig,
@@ -8841,6 +8855,20 @@ mod tests {
             CLAUDE_CODE_BOOTSTRAP_ADDENDUM.contains(CLAUDE_CODE_BOOTSTRAP_ADDENDUM_MARKER),
             "bootstrap addendum no longer contains its strip marker"
         );
+    }
+
+    /// The rate-limit park wake's turn-free era-refresh gate: with no
+    /// backend process at all, the next round's spawn reads the
+    /// credential store fresh, so the wake may re-announce identity on
+    /// the session's behalf. (A LIVE child answers false — its
+    /// spawn-time credentials still govern the next round — and only a
+    /// confirmed exit flips that; both riding `Child::try_wait` in the
+    /// override.)
+    #[test]
+    fn wake_refresh_gate_open_without_backend_process() {
+        let mut agent =
+            ClaudeCodeAgent::new("claude".into(), None, "default".into(), None, vec![], None);
+        assert!(agent.next_round_reads_fresh_credentials());
     }
 
     #[test]

--- a/src/bin/caller/external_agent/codex/reader.rs
+++ b/src/bin/caller/external_agent/codex/reader.rs
@@ -1217,8 +1217,10 @@ pub(crate) fn codex_rate_limit_windows(
             status: None,
             observed_at_epoch: Some(now_epoch),
             // The wire carries no account identity; the vitals hub stamps
-            // the reporting session's credential era at the fold.
+            // the reporting session's credential era at the fold (and
+            // prior-ness only on the per-session mirror).
             account: None,
+            account_prior: false,
         });
     }
     windows
@@ -6166,6 +6168,7 @@ error: build failed
                 status: None,
                 observed_at_epoch: None,
                 account: None,
+                account_prior: false,
             },
             crate::types::SessionLimitWindow {
                 label: "7d".into(),
@@ -6174,6 +6177,7 @@ error: build failed
                 status: None,
                 observed_at_epoch: None,
                 account: None,
+                account_prior: false,
             },
         ];
         let none = serde_json::Value::Null;

--- a/src/bin/caller/external_agent/mod.rs
+++ b/src/bin/caller/external_agent/mod.rs
@@ -1857,6 +1857,22 @@ pub trait ExternalAgent: Send + Sync {
         None
     }
 
+    /// Whether the session's NEXT round is guaranteed to start under the
+    /// credential store's current state: no live backend process is
+    /// holding an older credential read (backends re-read credentials
+    /// only at process start). Gates the rate-limit park's turn-free era
+    /// re-announce (`session_vitals` account-era membership): when true,
+    /// the reset wake may re-key the session into the current credential
+    /// era without burning a turn — the announce the next process start
+    /// would make anyway. When a live process exists, its spawn-time
+    /// credentials still govern the next round, and a re-key would
+    /// relabel that account's numbers as the current one (the chimera
+    /// the era keying exists to prevent) — so the conservative default
+    /// is `false`; only adapters that can check their process override.
+    fn next_round_reads_fresh_credentials(&mut self) -> bool {
+        false
+    }
+
     /// Send a user message into an existing thread (starts a turn).
     async fn send_message(
         &mut self,

--- a/src/bin/caller/external_mode.rs
+++ b/src/bin/caller/external_mode.rs
@@ -844,6 +844,30 @@ pub(crate) async fn run_external_agent_mode(
                                 });
                             }
                         }
+                        // A pending-less wake runs no turn, so nothing
+                        // re-announces identity until the next message —
+                        // after an account switch the idle session would
+                        // wear the superseded era's limit chips
+                        // indefinitely. When no live backend process holds
+                        // an older credential read, re-announce now: the
+                        // vitals hub re-keys membership into the CURRENT
+                        // era (the same announce the next process start
+                        // would make) without burning a turn.
+                        if agent.next_round_reads_fresh_credentials() {
+                            slog(&session_log, |l| {
+                                l.debug(
+                                    "Reset wake refreshed account-era membership without a turn (no live backend process)",
+                                )
+                            });
+                            emit_external_session_identity(
+                                &bus,
+                                intendant_session_id
+                                    .clone()
+                                    .or_else(|| session_log_id(&session_log)),
+                                backend.as_short_str(),
+                                live_session_id.as_deref().unwrap_or_default(),
+                            );
+                        }
                     }
                     maybe_event = event_rx.recv() => {
                         match maybe_event {

--- a/src/bin/caller/provider/anthropic.rs
+++ b/src/bin/caller/provider/anthropic.rs
@@ -2011,6 +2011,7 @@ mod tests {
             status: None,
             observed_at_epoch: None,
             account: None,
+            account_prior: false,
         }];
         let transcript = concat!(
             "data: not json at all\n\n",

--- a/src/bin/caller/provider/mod.rs
+++ b/src/bin/caller/provider/mod.rs
@@ -127,8 +127,10 @@ fn anthropic_rate_limit_windows_from_headers(
                     .unwrap_or(0),
             ),
             // The wire carries no account identity; the vitals hub stamps
-            // the reporting session's credential era at the fold.
+            // the reporting session's credential era at the fold (and
+            // prior-ness only on the per-session mirror).
             account: None,
+            account_prior: false,
         });
     }
     windows

--- a/src/bin/caller/provider_mock.rs
+++ b/src/bin/caller/provider_mock.rs
@@ -325,6 +325,7 @@ impl ChatProvider for MockProvider {
                     status: step.limit_status.clone(),
                     observed_at_epoch: Some(now_epoch),
                     account: None,
+                    account_prior: false,
                 }]
             })
             .unwrap_or_default();

--- a/src/bin/caller/run_modes.rs
+++ b/src/bin/caller/run_modes.rs
@@ -496,7 +496,7 @@ pub(crate) async fn run_with_presence(
                     let park = persistent_limit_park
                         .take()
                         .expect("branch guarded by is_some");
-                    match park.pending {
+                    let resumed = match park.pending {
                         Some(pending)
                             if !follow_up_message_was_cancelled(
                                 &mut persistent_cancelled_follow_ups,
@@ -514,6 +514,7 @@ pub(crate) async fn run_with_presence(
                                 turn: None,
                             });
                             persistent_parked_follow_ups.push_front(pending);
+                            true
                         }
                         Some(_) => {
                             slog(&session_log, |l| {
@@ -521,11 +522,44 @@ pub(crate) async fn run_with_presence(
                                     "Rate-limit park elapsed — the parked message was cancelled; awaiting input",
                                 )
                             });
+                            false
                         }
                         None => {
                             slog(&session_log, |l| {
                                 l.info("Rate-limit park elapsed — awaiting input")
                             });
+                            false
+                        }
+                    };
+                    // A wake that re-queues nothing runs no turn, so
+                    // nothing re-announces identity until the next
+                    // message — after an account switch the idle session
+                    // would wear the superseded era's limit chips
+                    // indefinitely. When no live backend process holds an
+                    // older credential read, re-announce now: the vitals
+                    // hub re-keys membership into the CURRENT era (the
+                    // same announce the next process start would make)
+                    // without burning a turn.
+                    if !resumed
+                        && persistent_agent
+                            .as_mut()
+                            .is_some_and(|agent| agent.next_round_reads_fresh_credentials())
+                    {
+                        if let Some(backend) = persistent_agent_backend.as_ref() {
+                            slog(&session_log, |l| {
+                                l.debug(
+                                    "Reset wake refreshed account-era membership without a turn (no live backend process)",
+                                )
+                            });
+                            emit_external_session_identity(
+                                &bus,
+                                session_log_id(&session_log),
+                                backend.as_short_str(),
+                                persistent_thread
+                                    .as_ref()
+                                    .map(|thread| thread.thread_id.as_str())
+                                    .unwrap_or_default(),
+                            );
                         }
                     }
                     continue;

--- a/src/bin/caller/session_vitals.rs
+++ b/src/bin/caller/session_vitals.rs
@@ -917,6 +917,10 @@ impl SessionVitalsHub {
         self.retire_era_if_orphaned(source, &previous);
         // The current-era registry changed regardless of retirement.
         self.persist_account_limits();
+        // Members that stay on the superseded era must gain their
+        // `account_prior` cue NOW — at the switch, not at their era's
+        // next report (which, for an idle stale era, never comes).
+        self.remirror_source(source);
     }
 
     /// Drop `era`'s window bucket for `source` when it has no member
@@ -949,14 +953,21 @@ impl SessionVitalsHub {
     }
 
     /// Deliver every member session of `source` its own era's window
-    /// view. The `account` stamp on delivered windows is the multi-era
-    /// cue: present only while more than one era has live members, so the
-    /// frontends label ambiguous chips apart and a single-era steady
+    /// view. The `account` stamp on delivered windows is the ambiguity
+    /// cue: present while more than one era has live members, so the
+    /// frontends label ambiguous chips apart, and a single-era steady
     /// state renders exactly as before (the unattributed era never
     /// stamps — the daemon has no truthful label to give it). A member
-    /// whose era holds no windows gets an EMPTY view: after a re-key the
-    /// alternative is the old era's chips lingering on a session that no
-    /// longer runs those credentials.
+    /// whose LABELED era is no longer the source's current era
+    /// additionally carries `account_prior` — and always its label, even
+    /// as the only live era: its backend has not announced (= re-read
+    /// credentials) since a newer sign-in, and an unlabeled chip would
+    /// read as the current account's truth (the 2026-07-30 grid: two
+    /// sessions wearing red limited chips of the switched-out account
+    /// beside fresh-era sessions wearing none, nothing explaining the
+    /// split). A member whose era holds no windows gets an EMPTY view:
+    /// after a re-key the alternative is the old era's chips lingering
+    /// on a session that no longer runs those credentials.
     fn remirror_source(&self, source: &str) {
         let members: Vec<(String, AccountEra)> = {
             let sources = self.session_sources.lock().expect("vitals source lock");
@@ -972,7 +983,9 @@ impl SessionVitalsHub {
         let live_eras: std::collections::BTreeSet<&AccountEra> =
             members.iter().map(|(_, era)| era).collect();
         let multiple = live_eras.len() > 1;
+        let current = self.current_era(source);
         for (member, era) in &members {
+            let prior = era.is_some() && *era != current;
             let view: Vec<SessionLimitWindow> = {
                 let accounts = self.account_limits.lock().expect("vitals account lock");
                 accounts
@@ -983,7 +996,8 @@ impl SessionVitalsHub {
                             .values()
                             .map(|window| {
                                 let mut window = window.clone();
-                                window.account = if multiple { era.clone() } else { None };
+                                window.account = if multiple || prior { era.clone() } else { None };
+                                window.account_prior = prior;
                                 window
                             })
                             .collect()
@@ -1026,6 +1040,10 @@ impl SessionVitalsHub {
                 .into_iter()
                 .map(|mut window| {
                     window.account = account.clone();
+                    // Store rows are era truth, not a view: prior-ness is
+                    // relative to the CURRENT era and stamps only on the
+                    // per-session mirror (`remirror_source`).
+                    window.account_prior = false;
                     window
                 })
                 .collect();
@@ -3414,6 +3432,7 @@ mod tests {
             status: None,
             observed_at_epoch: Some(1_783_800_000),
             account: None,
+            account_prior: false,
         }];
         bus.send(AppEvent::UsageSnapshot {
             session_id: Some("s7".into()),
@@ -3477,6 +3496,7 @@ mod tests {
             status: Some("allowed_warning".into()),
             observed_at_epoch: Some(observed_at),
             account: None,
+            account_prior: false,
         }
     }
 
@@ -3827,8 +3847,13 @@ mod tests {
     /// era has live members — the single-era steady state renders exactly
     /// as before, and the unattributed era never stamps (the daemon has
     /// no truthful label to give it; its chips stay plain and the LABELED
-    /// era's suffix is what tells them apart). The SPA half renders the
-    /// suffix whenever `account` is present — pinned against the fragment
+    /// era's suffix is what tells them apart). Amended 2026-07-30 (card
+    /// 01KYRPSG3D9FHVAS2N4RF2A9S4): a SUPERSEDED era also stamps its
+    /// label regardless of the member count — see
+    /// `prior_era_members_carry_labeled_staleness_cue`; every era in
+    /// this test is current when it is the only live one, so the
+    /// original claims hold unchanged. The SPA half renders the suffix
+    /// whenever `account` is present — pinned against the fragment
     /// beside the wire-parity test.
     #[test]
     fn chips_suffix_account_only_when_multiple_eras() {
@@ -3870,6 +3895,173 @@ mod tests {
         assert!(
             catalog.contains("vitalsLimitAccountShort(v.account)"),
             "the limit chip grammar renders the account suffix from the single map"
+        );
+    }
+
+    /// THE COMMISSIONED RE-ANNOUNCE-GAP PIN (2026-07-30, card
+    /// 01KYRPSG3D9FHVAS2N4RF2A9S4): announce-based era membership is
+    /// deliberate — after an account switch a member that has not
+    /// re-announced keeps its birth era — but its mirrored windows must
+    /// SAY so. A superseded labeled era stamps `account_prior` and its
+    /// label even as the only live era (an unlabeled chip reads as the
+    /// current sign-in's truth — the 2026-07-30 grid confusion), the cue
+    /// lands AT the switch rather than at the era's next report (an idle
+    /// stale era never reports again), the current era never claims
+    /// prior, and a re-announce — the next process start, or the
+    /// pending-less park wake's turn-free announce riding the same
+    /// `SessionIdentity` path — re-keys membership and clears the cue.
+    #[test]
+    fn prior_era_members_carry_labeled_staleness_cue() {
+        let bus = EventBus::new();
+        let hub = SessionVitalsHub::new(bus.clone());
+
+        hub.observe_backend_account("claude-code", Some("a@x".into()));
+        hub.link_identity("native-a", "wrapper-a", "claude-code");
+        hub.apply_rate_limit_windows("native-a", vec![warn_window(1_000)]);
+        // Current era, single: unlabeled, no cue — steady state.
+        let view = limits_of(&hub, "wrapper-a");
+        assert_eq!(view[0].account, None);
+        assert!(!view[0].account_prior);
+
+        // The switch. The member keeps era A (announce-based membership),
+        // but its chips gain label + cue IMMEDIATELY — era A is the only
+        // live era, and no report of its own ever arrives again.
+        hub.observe_backend_account("claude-code", Some("b@x".into()));
+        let view = limits_of(&hub, "wrapper-a");
+        assert_eq!(
+            view[0].account.as_deref(),
+            Some("a@x"),
+            "a superseded era's numbers never render unlabeled"
+        );
+        assert!(
+            view[0].account_prior,
+            "the superseded era must carry the staleness cue"
+        );
+
+        // A member announces under the new era: both labeled (multi-era
+        // ambiguity), only the superseded one prior.
+        hub.link_identity("native-b", "wrapper-b", "claude-code");
+        hub.apply_rate_limit_windows("native-b", vec![warn_window(2_000)]);
+        assert!(limits_of(&hub, "wrapper-a")[0].account_prior);
+        let b = limits_of(&hub, "wrapper-b");
+        assert_eq!(b[0].account.as_deref(), Some("b@x"));
+        assert!(!b[0].account_prior, "the current era never claims prior");
+
+        // The stale member re-announces (a respawn's process start, or
+        // the park wake's turn-free announce): membership re-keys into
+        // the current era, era A retires with its last member, and the
+        // cue clears everywhere.
+        hub.link_identity("native-a", "wrapper-a", "claude-code");
+        let a = limits_of(&hub, "wrapper-a");
+        assert_eq!(a[0].account, None, "single CURRENT era — suffix-free");
+        assert!(!a[0].account_prior);
+        assert!(!limits_of(&hub, "wrapper-b")[0].account_prior);
+    }
+
+    /// The unattributed era never claims prior: the daemon has no
+    /// truthful account to anchor "still ‹account›" to, and the
+    /// pre-ceremony credentials may well BE the account the owner then
+    /// signed into (same-label re-login keeps its era for the same
+    /// reason). Its chips stay plain through a switch.
+    #[test]
+    fn unattributed_era_never_carries_prior_cue() {
+        let bus = EventBus::new();
+        let hub = SessionVitalsHub::new(bus.clone());
+
+        hub.link_identity("native-u", "wrapper-u", "claude-code");
+        hub.apply_rate_limit_windows("native-u", vec![warn_window(1_000)]);
+        hub.observe_backend_account("claude-code", Some("b@x".into()));
+        let view = limits_of(&hub, "wrapper-u");
+        assert_eq!(view[0].account, None);
+        assert!(!view[0].account_prior);
+    }
+
+    /// The bucket-mate caveat, delivery half (the store half — a bucket
+    /// with any live window survives whole — is pinned in
+    /// session_vitals_restore::lapsed_resets_expire_at_load_and_persist):
+    /// a reset-passed row beside a live bucket-mate is neither deduped
+    /// into its mate nor dropped from the member's mirror. Both rows
+    /// deliver, label-keyed, so the frontend renders the lapsed one as
+    /// "reset" until the next report replaces it — 7d base and
+    /// 7d-overage stay two real windows (the 01KYKA22 lesson).
+    #[test]
+    fn lapsed_row_beside_live_mate_stays_delivered() {
+        let bus = EventBus::new();
+        let hub = SessionVitalsHub::new(bus.clone());
+
+        hub.observe_backend_account("claude-code", Some("a@x".into()));
+        hub.link_identity("native-a", "wrapper-a", "claude-code");
+        hub.apply_rate_limit_windows(
+            "native-a",
+            vec![
+                // Reset already passed (epoch 1_000).
+                crate::types::SessionLimitWindow {
+                    resets_at_epoch: Some(1_000),
+                    status: Some("rejected".into()),
+                    ..warn_window(900)
+                },
+                // Live mate, far-future reset.
+                crate::types::SessionLimitWindow {
+                    label: "7d-overage".into(),
+                    used_pct: Some(79),
+                    resets_at_epoch: Some(4_000_000_000),
+                    ..warn_window(950)
+                },
+            ],
+        );
+        let view = limits_of(&hub, "wrapper-a");
+        assert_eq!(view.len(), 2, "lapsed row and live mate both deliver");
+        let lapsed = view.iter().find(|w| w.label == "5h").expect("lapsed row");
+        assert_eq!(lapsed.resets_at_epoch, Some(1_000));
+        assert_eq!(lapsed.status.as_deref(), Some("rejected"));
+        let mate = view
+            .iter()
+            .find(|w| w.label == "7d-overage")
+            .expect("live mate");
+        assert_eq!(mate.used_pct, Some(79));
+    }
+
+    /// SPA half of the re-announce-gap pin: the fragment's chip grammar
+    /// carries the "still ‹acct›" cue on both text twins, the
+    /// tap-to-explain sentence rides the live AND reset-passed paths,
+    /// the reset-passed row keeps its neutral "reset" wording composed
+    /// with the account suffix (the bucket-mate caveat's display half —
+    /// beside a live mate it reads "reset", never a live claim), and a
+    /// rolled window can never elevate.
+    #[test]
+    fn prior_and_rolled_chip_grammar_pinned_in_fragment() {
+        let catalog = vitals_catalog_slice();
+        assert_eq!(
+            catalog
+                .matches("v.accountPrior ? ` · still ${acct}` : ` · ${acct}`")
+                .count(),
+            2,
+            "chip and fact-line twins lost the still-cue suffix grammar"
+        );
+        assert!(
+            catalog.contains("function vitalsLimitPriorAccountLine"),
+            "the fragment lost the prior-era explainer sentence"
+        );
+        assert_eq!(
+            catalog
+                .matches("vitalsLimitPriorAccountLine(v.account)")
+                .count(),
+            2,
+            "the prior-era explainer must ride the live and reset-passed explain paths"
+        );
+        assert_eq!(
+            catalog.matches("`${label} reset${suffix}`").count(),
+            2,
+            "the reset-passed row lost its neutral grammar (chip + fact-line twins)"
+        );
+        assert!(
+            catalog.contains("if (limitWindowRolled(w)) return '';"),
+            "a reset-passed window must never elevate (severity none)"
+        );
+        // The wire field feeding the cue is consumed inside the catalog.
+        assert!(
+            catalog.contains("w?.accountPrior"),
+            "the catalog stopped consuming accountPrior"
         );
     }
 
@@ -4118,9 +4310,12 @@ mod tests {
             "status",
             "observedAtEpoch",
             "label",
-            // Credential-era attribution (present only under multi-era
-            // ambiguity — the chip-suffix cue).
+            // Credential-era attribution (present under multi-era
+            // ambiguity and on superseded eras — the chip-suffix cue).
             "account",
+            // The superseded-era staleness cue ("still ‹account›"): the
+            // backend hasn't announced since a newer sign-in.
+            "accountPrior",
             "state",
             "sinceEpoch",
             "lastStreamByteEpoch",

--- a/src/bin/caller/session_vitals_restore.rs
+++ b/src/bin/caller/session_vitals_restore.rs
@@ -1589,6 +1589,7 @@ mod tests {
             status: Some("allowed_warning".into()),
             observed_at_epoch: Some(1_784_499_000),
             account: account.map(str::to_string),
+            account_prior: false,
         }
     }
 
@@ -1784,6 +1785,7 @@ mod tests {
             status: Some("allowed".into()),
             observed_at_epoch: Some(1_784_499_000),
             account: None,
+            account_prior: false,
         };
         hub.apply_rate_limit_windows("cc-1", vec![window.clone()]);
         // The persist may ride the blocking pool: wait for the file.

--- a/src/bin/caller/usage_rail.rs
+++ b/src/bin/caller/usage_rail.rs
@@ -282,6 +282,7 @@ mod tests {
             status: None,
             observed_at_epoch: None,
             account: None,
+            account_prior: false,
         }];
         let second = rail
             .on_event(&response(Some("s1"), with_limits))

--- a/static/app.html
+++ b/static/app.html
@@ -37605,7 +37605,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '47d4d928f643b7fc';
+const INTENDANT_APP_BUILD = '3f4dbadacf6fffdb';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -61723,16 +61723,26 @@ function vitalsLimitLabelLong(label) {
 }
 
 // Compact chip form of a window's credential-era account label. The
-// daemon sends `account` only while MORE than one credential era is live
-// for the backend (single-account steady state stays suffix-free), so
-// presence alone means "label this chip apart". Emails compress to their
-// local part — the pane and tooltips keep the full label.
+// daemon sends `account` while MORE than one credential era is live for
+// the backend (single-account steady state stays suffix-free), and
+// always alongside `accountPrior` — a superseded era's numbers never
+// arrive unlabeled — so presence alone means "label this chip apart".
+// Emails compress to their local part — the pane and tooltips keep the
+// full label.
 function vitalsLimitAccountShort(account) {
   const raw = String(account || '').trim();
   if (!raw) return '';
   const at = raw.indexOf('@');
   const short = at > 0 ? raw.slice(0, at) : raw;
   return short.length > 14 ? `${short.slice(0, 13)}…` : short;
+}
+
+// The tap-to-explain sentence for a superseded-era window ("still ‹acct›"
+// chips): why an old sign-in's numbers are still on screen, and what
+// makes them go away. One sentence, shared by the live and reset-passed
+// explain paths.
+function vitalsLimitPriorAccountLine(account) {
+  return `This window belongs to the “${account}” sign-in. The daemon has since signed into a different account, but this agent's backend still runs under “${account}” — it reads the new credentials when its process next starts.`;
 }
 
 // Compact chip form of a limit-window label. Known labels pass through;
@@ -62330,10 +62340,16 @@ const VITALS_SYMBOLS = {
     // base 7d chip a pixel-identical gauge is what made two real windows
     // read as a duplicate.
     icon: (v) => (String(v.label || '').includes('overage') ? 'gauge-plus' : 'gauge'),
+    // A window from a SUPERSEDED credential era (`accountPrior`: the
+    // daemon signed into another account, but this agent's backend has
+    // not restarted since, so these numbers are still that sign-in's
+    // truth) says "still ‹account›" — the explicit cue that keeps two
+    // eras' chips on one grid from reading as duplicate or conflicting
+    // data.
     chip: (v) => {
       const label = vitalsLimitLabelShort(v.label);
       const acct = vitalsLimitAccountShort(v.account);
-      const suffix = acct ? ` · ${acct}` : '';
+      const suffix = acct ? (v.accountPrior ? ` · still ${acct}` : ` · ${acct}`) : '';
       if (v.rolled) return `${label} reset${suffix}`;
       const reset = v.reset ? ` · ↻${v.reset}` : '';
       if (v.usedPct !== null) return `▮${v.usedPct}% ${label}${reset}${suffix}`;
@@ -62346,7 +62362,7 @@ const VITALS_SYMBOLS = {
     factText: (v) => {
       const label = vitalsLimitLabelShort(v.label);
       const acct = vitalsLimitAccountShort(v.account);
-      const suffix = acct ? ` · ${acct}` : '';
+      const suffix = acct ? (v.accountPrior ? ` · still ${acct}` : ` · ${acct}`) : '';
       if (v.rolled) return `${label} reset${suffix}`;
       const reset = v.reset ? ` · ↻${v.reset}` : '';
       if (v.usedPct !== null) return `${v.usedPct}% ${label}${reset}${suffix}`;
@@ -62357,6 +62373,7 @@ const VITALS_SYMBOLS = {
       const wall = formatLimitResetWallClock(v.resetsAtEpoch);
       if (v.rolled) {
         lines.push(`The provider's ${vitalsLimitLabelLong(v.label)} window has reset${wall ? ` (at ${wall})` : ''} — the last report predates it, so current usage is unknown until the agent's next model call refreshes it.`);
+        if (v.account && v.accountPrior) lines.push(vitalsLimitPriorAccountLine(v.account));
         return lines;
       }
       if (v.usedPct !== null) {
@@ -62367,17 +62384,21 @@ const VITALS_SYMBOLS = {
       if (v.reset) lines.push(`The window resets in ${v.reset}${wall ? ` — at ${wall}` : ''}.`);
       if (v.severity === 'crit') lines.push('When an allowance runs out, the provider pauses this agent until the window resets.');
       else if (v.severity === 'warn') lines.push('If the window fills up, the provider will pause this agent until it resets.');
-      if (v.account) lines.push(`This window belongs to the “${v.account}” sign-in — sessions running under a different account track their own windows.`);
+      if (v.account && v.accountPrior) lines.push(vitalsLimitPriorAccountLine(v.account));
+      else if (v.account) lines.push(`This window belongs to the “${v.account}” sign-in — sessions running under a different account track their own windows.`);
       if (v.observedAgo) lines.push(`Last provider report: ${v.observedAgo} ago. Windows are account-wide, so any session's report updates this.`);
       return lines;
     },
     brief: (v) => {
-      if (v.rolled) return `${vitalsLimitLabelLong(v.label)} limit: window reset — awaiting a fresh report`;
+      const still = v.account && v.accountPrior
+        ? ` — still under the “${vitalsLimitAccountShort(v.account)}” sign-in`
+        : '';
+      if (v.rolled) return `${vitalsLimitLabelLong(v.label)} limit: window reset — awaiting a fresh report${still}`;
       // Name the driver: a hard status outranks the percentage.
       const what = v.usedPct !== null && v.usedPct >= 90 ? `${v.usedPct}% used`
         : v.statusWord !== 'ok' ? v.statusWord
           : `${v.usedPct}% used`;
-      return `${vitalsLimitLabelLong(v.label)} limit: ${what}${v.reset ? ` — resets in ${v.reset}` : ''}`;
+      return `${vitalsLimitLabelLong(v.label)} limit: ${what}${v.reset ? ` — resets in ${v.reset}` : ''}${still}`;
     },
   },
   // ── Grid envelope (catalog-row `agenda` + `boot` blocks, served
@@ -62850,10 +62871,14 @@ function vitalsChipModels(vitals, meta, sessionId) {
     const observedAgoSecs = Number.isFinite(observedAt) && observedAt > 0
       ? Math.floor(Date.now() / 1000 - observedAt)
       : null;
-    // Credential-era attribution: present only while the daemon sees
-    // more than one live era for the backend — the cue to suffix the
-    // chip apart from another account's same-named window.
+    // Credential-era attribution: present while the daemon sees more
+    // than one live era for the backend — the cue to suffix the chip
+    // apart from another account's same-named window — and always on a
+    // superseded era (`accountPrior`: the backend hasn't announced since
+    // a newer sign-in), whose chips say "still ‹account›" instead of
+    // letting an old era's numbers read as the current sign-in's.
     const account = String(w?.account || '').trim();
+    const accountPrior = !!(account && w?.accountPrior);
     push('limit', `limit:${label}`, {
       label,
       usedPct,
@@ -62862,6 +62887,7 @@ function vitalsChipModels(vitals, meta, sessionId) {
       resetsAtEpoch: Number(w?.resetsAtEpoch) || 0,
       rolled,
       account,
+      accountPrior,
       observedAgo: observedAgoSecs !== null && observedAgoSecs > 120
         ? formatActivityElapsed(observedAgoSecs)
         : '',
@@ -62871,7 +62897,7 @@ function vitalsChipModels(vitals, meta, sessionId) {
       // The countdown ticks in place (cache-ttl pattern): the sig excludes
       // it so the 1 Hz ticker hits the stable-DOM fast path.
       ticking: !!reset,
-      sig: `${label}|${usedPct}|${w?.status || ''}|${severity}|${rolled ? 1 : 0}|${account}`,
+      sig: `${label}|${usedPct}|${w?.status || ''}|${severity}|${rolled ? 1 : 0}|${account}|${accountPrior ? 1 : 0}`,
     });
   }
 

--- a/static/app/39-session-windows.js
+++ b/static/app/39-session-windows.js
@@ -1284,16 +1284,26 @@ function vitalsLimitLabelLong(label) {
 }
 
 // Compact chip form of a window's credential-era account label. The
-// daemon sends `account` only while MORE than one credential era is live
-// for the backend (single-account steady state stays suffix-free), so
-// presence alone means "label this chip apart". Emails compress to their
-// local part — the pane and tooltips keep the full label.
+// daemon sends `account` while MORE than one credential era is live for
+// the backend (single-account steady state stays suffix-free), and
+// always alongside `accountPrior` — a superseded era's numbers never
+// arrive unlabeled — so presence alone means "label this chip apart".
+// Emails compress to their local part — the pane and tooltips keep the
+// full label.
 function vitalsLimitAccountShort(account) {
   const raw = String(account || '').trim();
   if (!raw) return '';
   const at = raw.indexOf('@');
   const short = at > 0 ? raw.slice(0, at) : raw;
   return short.length > 14 ? `${short.slice(0, 13)}…` : short;
+}
+
+// The tap-to-explain sentence for a superseded-era window ("still ‹acct›"
+// chips): why an old sign-in's numbers are still on screen, and what
+// makes them go away. One sentence, shared by the live and reset-passed
+// explain paths.
+function vitalsLimitPriorAccountLine(account) {
+  return `This window belongs to the “${account}” sign-in. The daemon has since signed into a different account, but this agent's backend still runs under “${account}” — it reads the new credentials when its process next starts.`;
 }
 
 // Compact chip form of a limit-window label. Known labels pass through;
@@ -1891,10 +1901,16 @@ const VITALS_SYMBOLS = {
     // base 7d chip a pixel-identical gauge is what made two real windows
     // read as a duplicate.
     icon: (v) => (String(v.label || '').includes('overage') ? 'gauge-plus' : 'gauge'),
+    // A window from a SUPERSEDED credential era (`accountPrior`: the
+    // daemon signed into another account, but this agent's backend has
+    // not restarted since, so these numbers are still that sign-in's
+    // truth) says "still ‹account›" — the explicit cue that keeps two
+    // eras' chips on one grid from reading as duplicate or conflicting
+    // data.
     chip: (v) => {
       const label = vitalsLimitLabelShort(v.label);
       const acct = vitalsLimitAccountShort(v.account);
-      const suffix = acct ? ` · ${acct}` : '';
+      const suffix = acct ? (v.accountPrior ? ` · still ${acct}` : ` · ${acct}`) : '';
       if (v.rolled) return `${label} reset${suffix}`;
       const reset = v.reset ? ` · ↻${v.reset}` : '';
       if (v.usedPct !== null) return `▮${v.usedPct}% ${label}${reset}${suffix}`;
@@ -1907,7 +1923,7 @@ const VITALS_SYMBOLS = {
     factText: (v) => {
       const label = vitalsLimitLabelShort(v.label);
       const acct = vitalsLimitAccountShort(v.account);
-      const suffix = acct ? ` · ${acct}` : '';
+      const suffix = acct ? (v.accountPrior ? ` · still ${acct}` : ` · ${acct}`) : '';
       if (v.rolled) return `${label} reset${suffix}`;
       const reset = v.reset ? ` · ↻${v.reset}` : '';
       if (v.usedPct !== null) return `${v.usedPct}% ${label}${reset}${suffix}`;
@@ -1918,6 +1934,7 @@ const VITALS_SYMBOLS = {
       const wall = formatLimitResetWallClock(v.resetsAtEpoch);
       if (v.rolled) {
         lines.push(`The provider's ${vitalsLimitLabelLong(v.label)} window has reset${wall ? ` (at ${wall})` : ''} — the last report predates it, so current usage is unknown until the agent's next model call refreshes it.`);
+        if (v.account && v.accountPrior) lines.push(vitalsLimitPriorAccountLine(v.account));
         return lines;
       }
       if (v.usedPct !== null) {
@@ -1928,17 +1945,21 @@ const VITALS_SYMBOLS = {
       if (v.reset) lines.push(`The window resets in ${v.reset}${wall ? ` — at ${wall}` : ''}.`);
       if (v.severity === 'crit') lines.push('When an allowance runs out, the provider pauses this agent until the window resets.');
       else if (v.severity === 'warn') lines.push('If the window fills up, the provider will pause this agent until it resets.');
-      if (v.account) lines.push(`This window belongs to the “${v.account}” sign-in — sessions running under a different account track their own windows.`);
+      if (v.account && v.accountPrior) lines.push(vitalsLimitPriorAccountLine(v.account));
+      else if (v.account) lines.push(`This window belongs to the “${v.account}” sign-in — sessions running under a different account track their own windows.`);
       if (v.observedAgo) lines.push(`Last provider report: ${v.observedAgo} ago. Windows are account-wide, so any session's report updates this.`);
       return lines;
     },
     brief: (v) => {
-      if (v.rolled) return `${vitalsLimitLabelLong(v.label)} limit: window reset — awaiting a fresh report`;
+      const still = v.account && v.accountPrior
+        ? ` — still under the “${vitalsLimitAccountShort(v.account)}” sign-in`
+        : '';
+      if (v.rolled) return `${vitalsLimitLabelLong(v.label)} limit: window reset — awaiting a fresh report${still}`;
       // Name the driver: a hard status outranks the percentage.
       const what = v.usedPct !== null && v.usedPct >= 90 ? `${v.usedPct}% used`
         : v.statusWord !== 'ok' ? v.statusWord
           : `${v.usedPct}% used`;
-      return `${vitalsLimitLabelLong(v.label)} limit: ${what}${v.reset ? ` — resets in ${v.reset}` : ''}`;
+      return `${vitalsLimitLabelLong(v.label)} limit: ${what}${v.reset ? ` — resets in ${v.reset}` : ''}${still}`;
     },
   },
   // ── Grid envelope (catalog-row `agenda` + `boot` blocks, served
@@ -2411,10 +2432,14 @@ function vitalsChipModels(vitals, meta, sessionId) {
     const observedAgoSecs = Number.isFinite(observedAt) && observedAt > 0
       ? Math.floor(Date.now() / 1000 - observedAt)
       : null;
-    // Credential-era attribution: present only while the daemon sees
-    // more than one live era for the backend — the cue to suffix the
-    // chip apart from another account's same-named window.
+    // Credential-era attribution: present while the daemon sees more
+    // than one live era for the backend — the cue to suffix the chip
+    // apart from another account's same-named window — and always on a
+    // superseded era (`accountPrior`: the backend hasn't announced since
+    // a newer sign-in), whose chips say "still ‹account›" instead of
+    // letting an old era's numbers read as the current sign-in's.
     const account = String(w?.account || '').trim();
+    const accountPrior = !!(account && w?.accountPrior);
     push('limit', `limit:${label}`, {
       label,
       usedPct,
@@ -2423,6 +2448,7 @@ function vitalsChipModels(vitals, meta, sessionId) {
       resetsAtEpoch: Number(w?.resetsAtEpoch) || 0,
       rolled,
       account,
+      accountPrior,
       observedAgo: observedAgoSecs !== null && observedAgoSecs > 120
         ? formatActivityElapsed(observedAgoSecs)
         : '',
@@ -2432,7 +2458,7 @@ function vitalsChipModels(vitals, meta, sessionId) {
       // The countdown ticks in place (cache-ttl pattern): the sig excludes
       // it so the 1 Hz ticker hits the stable-DOM fast path.
       ticking: !!reset,
-      sig: `${label}|${usedPct}|${w?.status || ''}|${severity}|${rolled ? 1 : 0}|${account}`,
+      sig: `${label}|${usedPct}|${w?.status || ''}|${severity}|${rolled ? 1 : 0}|${account}|${accountPrior ? 1 : 0}`,
     });
   }
 


### PR DESCRIPTION
Closes the era-lane re-announce gap on session limit chips (agenda card 01KYRPSG3D9FHVAS2N4RF2A9S4, the park owed by gate 01KYQJ97S9 residual R1; screenshot recurrence 2026-07-30 00:52).

Announce-based era membership is ruled design — this is display/refresh lane only; no era-registry redesign, and real base+overage windows are never deduped.

## What changed

**Staleness cue (daemon).** `SessionLimitWindow.account_prior` — wire-additive, emission-only (`false` never serializes; store rows always carry `false`). `remirror_source` stamps it when a member's LABELED era is no longer the source's current era, and such windows always carry their era label even as the only live era, so a superseded era's numbers never render unlabeled (previously the label appeared only under multi-era ambiguity, and a lone stale era's red chips read as the current sign-in's truth). `observe_backend_account` now re-mirrors the source at the switch, so the cue lands the moment the split begins — an idle stale era never reports again. The unattributed era never claims prior (nothing truthful to anchor the claim to; pre-ceremony credentials may BE the account then signed into).

**Staleness cue (SPA, fragment 39).** Prior windows say `still <acct>` on both chip and fact-line twins (`5h limited · ↻2:17:22 · still lennyovon8`), with a prior-aware tap-to-explain sentence on both the live and reset-passed explain paths. Rolled rows compose: `5h reset · still lennyovon8`.

**Turn-free refresh at the pending-less park reset wake (both lanes).** A pending-less wake runs no turn, so nothing re-announced identity until the next message. Now the wake re-emits the session's `SessionIdentity` — the exact announce the next process start would make — re-keying membership into the current era without burning a turn, gated by a new `ExternalAgent::next_round_reads_fresh_credentials()` (default `false`). Claude Code overrides it via `Child::try_wait`: only a missing or confirmed-exited process answers true, so a live process holding an older credential read is never re-labeled (that would be the chimera the era keying exists to prevent). Codex/kimi/pi hold persistent children and keep the conservative default — their stale chips rely on the cue.

**Bucket-mate caveat pinned.** A reset-passed row beside a live bucket-mate stays delivered as its own labeled row — never deduped into its mate, never per-row reaped — so the frontend renders it as `reset` (severity none, renderer ticker settles it at the crossing) until the next report replaces it. The store half (a bucket with any live window survives whole) was already pinned in `lapsed_resets_expire_at_load_and_persist`.

## Pins

`prior_era_members_carry_labeled_staleness_cue`, `unattributed_era_never_carries_prior_cue`, `lapsed_row_beside_live_mate_stays_delivered`, `prior_and_rolled_chip_grammar_pinned_in_fragment`, `wake_refresh_gate_open_without_backend_process`; `accountPrior` joined the `vitals_symbol_catalog_covers_wire_fields` parity list; `chips_suffix_account_only_when_multiple_eras` docstring amended with the superseded-era exception.