### PR TITLE
agenda: typed relates_to link kinds (closed vocabulary, additive)

### DIFF
--- a/docs/src/agenda-and-memory.md
+++ b/docs/src/agenda-and-memory.md
@@ -259,11 +259,19 @@ attributed ops, both **pure navigation**:
   convention. Roll-up counts, the tree lens (the dashboard's "By hub"
   toggle, `ctl agenda list --under <id>`), and "hub done · open children"
   flags are all derived at render from the ordinary snapshot.
-- **`relates_to`** (`add_relates_to` / `remove_relates_to`) — untyped
-  see-also adjacency: stored directed (the writer's item carries the
-  link), rendered as the undirected union, deduped in both directions at
-  intake; removal names the pair in either order and the daemon resolves
-  the stored side. Capped at 32 stored links per item.
+- **`relates_to`** (`add_relates_to` / `remove_relates_to`) — see-also
+  adjacency, optionally typed: `link_kind` draws from a closed vocabulary
+  (`duplicates`, `supersedes`, `follow_up_of`, `evidences`; absent = plain
+  see-also). Intake refuses unknown kinds by name; the fold stores what
+  the log says, so a newer vocabulary never bricks an older reader (the
+  foreign kind rides through as text). Typed or not, adjacency stays pure
+  navigation — nothing derives, evaluates, blocks, or fires from it.
+  Stored directed (the writer's item carries the link; a typed link reads
+  storing-side → target, so "A supersedes B" lives on A), rendered as the
+  undirected union, deduped in both directions at intake — one link per
+  pair, so changing a kind is remove + re-add; removal names the pair in
+  either order and the daemon resolves the stored side. Capped at 32
+  stored links per item.
 
 **Two rules are pinned.** *Anti-hiding:* a `part_of` placement never
 removes an item from the flat recent lens — grouping is an opt-in reorder

--- a/src/bin/caller/agenda/store.rs
+++ b/src/bin/caller/agenda/store.rs
@@ -12,7 +12,7 @@ use super::types::{
     MAX_REF_FILE_LOCATOR_CHARS, MAX_REF_ID_LOCATOR_CHARS, MAX_REF_LABEL_CHARS,
     MAX_REF_URL_LOCATOR_CHARS, MAX_RELATES_TO_PER_ITEM, MAX_RELIES_ON_PER_ITEM, MAX_SOURCE_CHARS,
     MAX_TAGS, MAX_TAG_CHARS, MAX_TITLE_CHARS, MAX_UNCLEARED_BLOCKERS_PER_ITEM,
-    TRIGGER_MATCH_TAGS_MAX,
+    RELATES_TO_LINK_KINDS, TRIGGER_MATCH_TAGS_MAX,
 };
 use std::collections::BTreeMap;
 use std::io::Write;
@@ -1981,9 +1981,24 @@ impl AgendaStore {
             AgendaCommand::AddRelatesTo {
                 id,
                 target_id,
+                link_kind,
                 source: _,
             } => {
                 let target_id = target_id.trim().to_string();
+                // The vocabulary gate lives at intake so the durable log
+                // only ever carries ruled kinds; the fold stays tolerant
+                // of whatever a foreign log says.
+                let link_kind = link_kind
+                    .map(|kind| kind.trim().to_string())
+                    .filter(|kind| !kind.is_empty());
+                if let Some(kind) = &link_kind {
+                    if !RELATES_TO_LINK_KINDS.contains(&kind.as_str()) {
+                        return Err(AgendaError::Invalid(format!(
+                            "unknown link kind {kind:?}; the vocabulary is {}",
+                            RELATES_TO_LINK_KINDS.join(", ")
+                        )));
+                    }
+                }
                 let item = self.require(&id)?;
                 if target_id == id {
                     return Err(AgendaError::Invalid(
@@ -2005,7 +2020,11 @@ impl AgendaStore {
                         "more than {MAX_RELATES_TO_PER_ITEM} relations"
                     )));
                 }
-                Ok(AgendaOp::AddRelatesTo { id, target_id })
+                Ok(AgendaOp::AddRelatesTo {
+                    id,
+                    target_id,
+                    link_kind,
+                })
             }
             AgendaCommand::RemoveRelatesTo {
                 id,
@@ -4727,6 +4746,7 @@ mod tests {
                 AgendaCommand::AddRelatesTo {
                     id: child.clone(),
                     target_id: grand.clone(),
+                    link_kind: None,
                     source: None,
                 },
                 owner(),
@@ -4738,6 +4758,7 @@ mod tests {
                 AgendaCommand::AddRelatesTo {
                     id: grand.clone(),
                     target_id: child.clone(),
+                    link_kind: None,
                     source: None,
                 },
                 owner(),
@@ -4759,6 +4780,40 @@ mod tests {
             )
             .unwrap();
         assert!(store.item(&child).unwrap().relates_to.is_empty());
+
+        // Typed adjacency: a ruled kind rides intake to the stored link;
+        // an unknown kind refuses, named.
+        store
+            .apply_command(
+                AgendaCommand::AddRelatesTo {
+                    id: child.clone(),
+                    target_id: grand.clone(),
+                    link_kind: Some("supersedes".into()),
+                    source: None,
+                },
+                owner(),
+                1403,
+            )
+            .unwrap();
+        assert_eq!(
+            store.item(&child).unwrap().relates_to[0]
+                .link_kind
+                .as_deref(),
+            Some("supersedes")
+        );
+        let err = store
+            .apply_command(
+                AgendaCommand::AddRelatesTo {
+                    id: child.clone(),
+                    target_id: hub2.clone(),
+                    link_kind: Some("rhymes_with".into()),
+                    source: None,
+                },
+                owner(),
+                1404,
+            )
+            .unwrap_err();
+        assert!(err.to_string().contains("unknown link kind"));
 
         // Depth rail: a chain of exactly MAX_PART_OF_DEPTH nodes is legal;
         // the link that would make it deeper refuses, named.

--- a/src/bin/caller/agenda/summary.rs
+++ b/src/bin/caller/agenda/summary.rs
@@ -242,6 +242,10 @@ pub(crate) struct SummaryBlocker {
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct SummaryEdge {
     pub(crate) target_id: String,
+    /// G2 typed-adjacency kind — served on `relates_to` edges only
+    /// (`relies_on` edges carry none).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) link_kind: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -426,6 +430,7 @@ fn summarize_one(all: &[AgendaItem], item: &AgendaItem, watermark: u64) -> Agend
             .iter()
             .map(|edge| SummaryEdge {
                 target_id: edge.target_id.clone(),
+                link_kind: None,
             })
             .collect(),
         part_of: item.part_of.as_ref().map(|placement| SummaryPlacement {
@@ -436,6 +441,7 @@ fn summarize_one(all: &[AgendaItem], item: &AgendaItem, watermark: u64) -> Agend
             .iter()
             .map(|edge| SummaryEdge {
                 target_id: edge.target_id.clone(),
+                link_kind: edge.link_kind.clone(),
             })
             .collect(),
         refs: item

--- a/src/bin/caller/agenda/types.rs
+++ b/src/bin/caller/agenda/types.rs
@@ -24,6 +24,15 @@ pub(crate) const MAX_CRITERION_CHARS: usize = 1000;
 /// primary intended use), and the depth cap keeps the tree a working
 /// surface, not an ontology.
 pub(crate) const MAX_RELATES_TO_PER_ITEM: usize = 32;
+/// The closed `relates_to` link vocabulary (G2 typed adjacency, v1).
+/// Absent = plain "see-also". A typed link reads storing-side → target
+/// ("A supersedes B" lives on A targeting B). Intake refuses kinds
+/// outside this set by name; the fold stores what the log says, so a
+/// newer vocabulary never bricks an older reader. Typed or not,
+/// adjacency stays non-causal — nothing derives, evaluates, blocks, or
+/// fires from it.
+pub(crate) const RELATES_TO_LINK_KINDS: [&str; 4] =
+    ["duplicates", "supersedes", "follow_up_of", "evidences"];
 pub(crate) const MAX_PART_OF_DEPTH: usize = 16;
 pub(crate) const MAX_CHILDREN_PER_HUB: usize = 500;
 /// G1 caps (steward-ruled 2026-07-22). Refs follow the blockers/links
@@ -876,13 +885,19 @@ pub struct AgendaPlacement {
     pub(crate) source: Option<String>,
 }
 
-/// One stored adjacency link (G2 `add_relates_to` fold view): untyped,
-/// purely navigational — nothing derives, evaluates, blocks, or fires
-/// from adjacency, ever. Stored directed (the writer's item carries it),
-/// rendered undirected and deduped by every surface.
+/// One stored adjacency link (G2 `add_relates_to` fold view): see-also
+/// adjacency, optionally typed via `link_kind` from the closed
+/// [`RELATES_TO_LINK_KINDS`] vocabulary (absent = plain see-also).
+/// Typed or not, purely navigational — nothing derives, evaluates,
+/// blocks, or fires from adjacency, ever. Stored directed (the writer's
+/// item carries it; a typed link reads storing-side → target), rendered
+/// undirected and deduped by every surface; one link per pair either
+/// direction, so changing a kind is remove + re-add.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AgendaRelation {
     pub(crate) target_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) link_kind: Option<String>,
     pub(crate) added_ms: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) principal: Option<String>,
@@ -1314,11 +1329,15 @@ pub enum AgendaCommand {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         source: Option<String>,
     },
-    /// Add an undirected adjacency link (stored on this item). Purely
-    /// navigational.
+    /// Add an adjacency link (stored on this item), optionally typed via
+    /// `link_kind` from the closed [`RELATES_TO_LINK_KINDS`] vocabulary
+    /// (unknown kinds refuse at intake, named). Purely navigational
+    /// either way; a typed link reads `id` → `target_id`.
     AddRelatesTo {
         id: String,
         target_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        link_kind: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         source: Option<String>,
     },
@@ -1568,10 +1587,14 @@ pub(crate) enum AgendaOp {
         id: String,
         parent_id: String,
     },
-    /// Adjacency link added (G2), stored on `id`'s side.
+    /// Adjacency link added (G2), stored on `id`'s side. `link_kind`
+    /// (additive) was vocabulary-checked at intake; the fold stores
+    /// what the log says.
     AddRelatesTo {
         id: String,
         target_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        link_kind: Option<String>,
     },
     /// Adjacency link removed (G2).
     RemoveRelatesTo {
@@ -1941,7 +1964,11 @@ pub(crate) fn apply_op(
                 )),
             }
         }
-        AgendaOp::AddRelatesTo { id, target_id } => {
+        AgendaOp::AddRelatesTo {
+            id,
+            target_id,
+            link_kind,
+        } => {
             if target_id == id {
                 return Some(format!("self-relation on {id} ignored"));
             }
@@ -1956,6 +1983,7 @@ pub(crate) fn apply_op(
             let actor = rec.actor.clone().unwrap_or_default();
             item.relates_to.push(AgendaRelation {
                 target_id: target_id.clone(),
+                link_kind: link_kind.clone(),
                 added_ms: at_ms,
                 principal: actor.principal,
                 session_id: actor.session_id,
@@ -4564,6 +4592,7 @@ mod tests {
                 AgendaOp::AddRelatesTo {
                     id: "01CHILD".into(),
                     target_id: "01PEER".into(),
+                    link_kind: None,
                 },
             ),
         )
@@ -4575,6 +4604,7 @@ mod tests {
                 AgendaOp::AddRelatesTo {
                     id: "01CHILD".into(),
                     target_id: "01PEER".into(),
+                    link_kind: None,
                 },
             ),
         )
@@ -4586,6 +4616,7 @@ mod tests {
                 AgendaOp::AddRelatesTo {
                     id: "01PEER".into(),
                     target_id: "01PEER".into(),
+                    link_kind: None,
                 },
             ),
         )
@@ -4603,6 +4634,24 @@ mod tests {
         )
         .is_none());
         assert!(items["01CHILD"].relates_to.is_empty());
+
+        // Typed re-add: the kind rides the op and lands on the relation.
+        assert!(apply_op(
+            &mut items,
+            &rec(
+                11,
+                AgendaOp::AddRelatesTo {
+                    id: "01CHILD".into(),
+                    target_id: "01PEER".into(),
+                    link_kind: Some("supersedes".into()),
+                },
+            ),
+        )
+        .is_none());
+        assert_eq!(
+            items["01CHILD"].relates_to[0].link_kind.as_deref(),
+            Some("supersedes")
+        );
     }
 
     /// The ruled no-transitive pin: placement NEVER propagates blocking —
@@ -4690,6 +4739,7 @@ mod tests {
                     op: AgendaOp::AddRelatesTo {
                         id: "01X".into(),
                         target_id: "01Y".into(),
+                        link_kind: None,
                     },
                 },
                 r#"{"v":1,"at_ms":42,"op":{"type":"add_relates_to","id":"01X","target_id":"01Y"}}"#,
@@ -4706,6 +4756,20 @@ mod tests {
                     },
                 },
                 r#"{"v":1,"at_ms":43,"op":{"type":"remove_relates_to","id":"01X","target_id":"01Y"}}"#,
+            ),
+            (
+                AgendaOpRecord {
+                    v: 1,
+                    at_ms: 44,
+                    actor: None,
+                    source: None,
+                    op: AgendaOp::AddRelatesTo {
+                        id: "01X".into(),
+                        target_id: "01Y".into(),
+                        link_kind: Some("supersedes".into()),
+                    },
+                },
+                r#"{"v":1,"at_ms":44,"op":{"type":"add_relates_to","id":"01X","target_id":"01Y","link_kind":"supersedes"}}"#,
             ),
         ] {
             let line = serde_json::to_string(&record).unwrap();
@@ -4887,6 +4951,10 @@ mod tests {
             ),
             (
                 r#"{"op":"add_relates_to","id":"01X","target_id":"01Y"}"#,
+                true,
+            ),
+            (
+                r#"{"op":"add_relates_to","id":"01X","target_id":"01Y","link_kind":"supersedes"}"#,
                 true,
             ),
             (

--- a/src/bin/caller/ctl.rs
+++ b/src/bin/caller/ctl.rs
@@ -2758,7 +2758,7 @@ async fn run_agenda(
             print_tool_response(response, config, None)?;
         }
         "relates" | "relates-to" => {
-            let args = parse_command_args(&raw[1..], &["--source"], &["--remove"])?;
+            let args = parse_command_args(&raw[1..], &["--source", "--kind"], &["--remove"])?;
             let id = agenda_resolve_id(
                 client,
                 config,
@@ -2770,7 +2770,14 @@ async fn run_agenda(
                 return Err("agenda relates requires the related item id second".to_string());
             };
             let target = agenda_resolve_id_str(client, config, target_raw).await?;
-            let op = if args.has("--remove") {
+            let removing = args.has("--remove");
+            if removing && args.one("--kind").is_some() {
+                return Err(
+                    "agenda relates --kind types the link being added; drop it with --remove"
+                        .to_string(),
+                );
+            }
+            let op = if removing {
                 "remove_relates_to"
             } else {
                 "add_relates_to"
@@ -2779,6 +2786,9 @@ async fn run_agenda(
             map.insert("op".to_string(), Value::String(op.to_string()));
             map.insert("id".to_string(), Value::String(id));
             map.insert("target_id".to_string(), Value::String(target));
+            if !removing {
+                insert_string(&mut map, "link_kind", args.one("--kind"));
+            }
             insert_string(&mut map, "source", args.one("--source"));
             let response = call_tool(client, config, "agenda_op", Value::Object(map)).await?;
             print_tool_response(response, config, None)?;
@@ -5624,7 +5634,8 @@ fn help_agenda() {
   intendant ctl agenda ref ID_PREFIX [TYPE:]LOCATOR [--type file|memory|session|url]\n\
       [--must-read] [--label TEXT] [--remove] [--source LABEL]\n\
   intendant ctl agenda place ID_PREFIX HUB_PREFIX|--under HUB [--remove] [--source LABEL]\n\
-  intendant ctl agenda relates ID_PREFIX TARGET_PREFIX [--remove] [--source LABEL]\n\
+  intendant ctl agenda relates ID_PREFIX TARGET_PREFIX [--kind KIND] [--remove] [--source LABEL]\n\
+      # KIND: duplicates|supersedes|follow_up_of|evidences — optional typed edge, reads ITEM -> TARGET\n\
   intendant ctl agenda list --under HUB_PREFIX   # the hub's placed subtree\n\
   intendant ctl agenda list --frontier           # the un-triaged frontier (triage mandate's scope)\n\
   intendant ctl agenda ops [ID_PREFIX] [--since N] [--limit N]           # raw op-log page\n\
@@ -5708,7 +5719,11 @@ attach at park time — one item, its context, one gesture.\n\
 old placement is touched); --remove unplaces. Placement is pure\n\
 navigation: it NEVER propagates blocking, completion never cascades, and\n\
 a placed item still appears in the flat list (nothing hides). `relates`\n\
-draws an untyped see-also edge, deduped in both directions; `list\n\
+draws a see-also edge, deduped in both directions — one link per pair;\n\
+--kind types it from the closed vocabulary (duplicates, supersedes,\n\
+follow_up_of, evidences; a typed edge reads ITEM -> TARGET, e.g. A\n\
+supersedes B is drawn from A; change a kind by --remove then re-add).\n\
+Typed or not, nothing derives or fires from adjacency. `list\n\
 --under` scopes to a hub's subtree; hub rows show open-children roll-ups\n\
 derived at print time.\n\
 \n\


### PR DESCRIPTION
Slice 1 of the agenda ontology program (agenda item 01KYT8J44F, design note ~/agenda-ontology-next.md): `relates_to` links accept an optional `link_kind` from a closed vocabulary — `duplicates`, `supersedes`, `follow_up_of`, `evidences`; absent stays plain see-also.

- `AgendaRelation` / `AgendaCommand::AddRelatesTo` / `AgendaOp::AddRelatesTo` gain an additive optional `link_kind` (serde skip-if-none: kindless op-log bytes unchanged, the byte-pin suite gains the typed form; commands stay `deny_unknown_fields` so older daemons refuse typed commands fail-closed; the fold stores what the log says, so a foreign kind never bricks a reader).
- Intake gates the vocabulary by name (store.rs); pair uniqueness unchanged — changing a kind is remove + re-add; a typed link reads storing-side → target ("A supersedes B" lives on A).
- Non-causal ruling preserved: nothing derives, evaluates, blocks, or fires from adjacency, typed or not.
- Served: item DTO verbatim plus `SummaryEdge.link_kind` (relates_to edges only); `ctl agenda relates --kind` + help text; docs G2 section updated.
- The `agenda_op` MCP schema follows automatically (schemars derives from `AgendaCommand`).

Rendering (graph-lens legend, inspector picker, vocabulary served for frontends) follows in the next slice.

Battery: bins 5272 + 150 + 97 pass, lib crates pass, workspace clippy -D warnings clean, cargo fmt applied.