### PR TITLE
agenda: dir territory refs (digestless pointers)

### DIFF
--- a/docs/src/agenda-and-memory.md
+++ b/docs/src/agenda-and-memory.md
@@ -221,6 +221,7 @@ attributed ops):
 | type | locator | resolves to |
 |---|---|---|
 | `file` | absolute path | the file, plus the drift check below |
+| `dir` | absolute directory path | the directory — pointer only (no digest, no content lane) |
 | `memory` | Memory claim id | the Explorer claim |
 | `session` | conversation id | the Sessions row (F1 join) |
 | `url` | http(s) URL | a plain link |
@@ -243,7 +244,11 @@ button) and renders "changed since attached" or "missing" honestly —
 never on list render, and nothing derived is ever stored. **No blobs,
 ever**: no file contents, copies, or uploads enter the agenda for refs —
 the preview blob store remains exclusively Ask-v2's (pinned in
-`agenda/blobs.rs`). Digests travel; blobs wouldn't.
+`agenda/blobs.rs`). Digests travel; blobs wouldn't. `dir` refs are
+deliberately digest-less pointers (trailing slashes normalized at
+intake): a directory has no attach-time byte identity without a priced
+tree-hash scheme — future vocabulary — so presence is its only drift
+signal.
 
 ### The graph: placement and adjacency (G2)
 

--- a/src/bin/caller/agenda/store.rs
+++ b/src/bin/caller/agenda/store.rs
@@ -2624,6 +2624,7 @@ fn validate_park_refs(
 /// Validate one typed-ref spec (G1). Per-type locator rules with named
 /// rejections; file refs must exist, be regular files within the digest
 /// bound, and are hashed HERE — attach-time truth, recorded in the op.
+/// Dir refs must exist and stay digestless pointers.
 fn validate_ref(
     ref_type: AgendaRefType,
     locator: &str,
@@ -2634,6 +2635,19 @@ fn validate_ref(
     if locator.is_empty() {
         return Err(AgendaError::Invalid("ref locator must not be empty".into()));
     }
+    // Dir refs: trailing slashes are display sugar — store the one
+    // slashless spelling so `(type, locator)` addressing cannot mint two
+    // addresses for one directory.
+    let locator = if ref_type == AgendaRefType::Dir {
+        let trimmed = locator.trim_end_matches('/');
+        if trimmed.is_empty() {
+            "/"
+        } else {
+            trimmed
+        }
+    } else {
+        locator
+    };
     let label = match label {
         None => None,
         Some(label) => {
@@ -2684,6 +2698,32 @@ fn validate_ref(
             Some(digest_file(path).map_err(|err| {
                 AgendaError::Invalid(format!("cannot digest file ref {locator}: {err}"))
             })?)
+        }
+        AgendaRefType::Dir => {
+            if locator.chars().count() > MAX_REF_FILE_LOCATOR_CHARS {
+                return Err(AgendaError::Invalid(format!(
+                    "dir ref path exceeds {MAX_REF_FILE_LOCATOR_CHARS} characters"
+                )));
+            }
+            let path = Path::new(locator);
+            if !path.is_absolute() {
+                return Err(AgendaError::Invalid("dir ref path must be absolute".into()));
+            }
+            let meta = std::fs::metadata(path).map_err(|err| {
+                AgendaError::Invalid(format!(
+                    "cannot attach a dir ref: {locator} is not readable ({err})"
+                ))
+            })?;
+            if !meta.is_dir() {
+                return Err(AgendaError::Invalid(format!(
+                    "cannot attach a dir ref: {locator} is not a directory \
+                     (attach a file ref instead)"
+                )));
+            }
+            // Deliberately digestless: a directory has no attach-time
+            // byte identity without a priced tree-hash scheme (future
+            // vocabulary); presence is its only honest drift signal.
+            None
         }
         AgendaRefType::Memory | AgendaRefType::Session => {
             if locator.chars().count() > MAX_REF_ID_LOCATOR_CHARS {
@@ -4317,6 +4357,22 @@ mod tests {
                 "not a regular file",
             ),
             (
+                add_ref_cmd(&id, AgendaRefType::Dir, "relative/dir"),
+                "absolute",
+            ),
+            (
+                add_ref_cmd(
+                    &id,
+                    AgendaRefType::Dir,
+                    &files.path().join("gone-dir").to_string_lossy(),
+                ),
+                "not readable",
+            ),
+            (
+                add_ref_cmd(&id, AgendaRefType::Dir, &brief_loc),
+                "not a directory",
+            ),
+            (
                 add_ref_cmd(&id, AgendaRefType::Url, "ftp://example.com/x"),
                 "http:// or https://",
             ),
@@ -4387,6 +4443,24 @@ mod tests {
             assert_eq!(r.ref_type, rt);
             assert!(r.digest.is_none());
         }
+
+        // dir refs: absolute existing directories attach as digestless
+        // pointers, trailing slashes normalized to one spelling.
+        let dir_loc = files.path().to_string_lossy().into_owned();
+        let item = store
+            .apply_command(
+                add_ref_cmd(&id, AgendaRefType::Dir, &format!("{dir_loc}/")),
+                owner(),
+                1006,
+            )
+            .unwrap();
+        let r = item
+            .refs
+            .iter()
+            .find(|r| r.ref_type == AgendaRefType::Dir)
+            .unwrap();
+        assert_eq!(r.locator, dir_loc, "trailing slash normalized away");
+        assert!(r.digest.is_none());
 
         // Remove is an op: the view drops the ref, the log keeps history.
         let ops_before = store.ops();

--- a/src/bin/caller/agenda/types.rs
+++ b/src/bin/caller/agenda/types.rs
@@ -912,6 +912,7 @@ pub struct AgendaRelation {
 /// What a typed reference points at (G1). The discriminator mirrors the
 /// kernel's Appendix A.5 `evref` spirit (scheme + locator + digest) so the
 /// future D0-Agenda-Data migration maps refs mechanically: `file`→`file`,
+/// `dir`→directory pointer (locator-only, deliberately digestless),
 /// `session`→`session-log`, `url`→`url`, `memory`→plane claim ref. A
 /// ref type this build does not know fails the typed parse, so the whole
 /// line degrades to preserved-skipped — future types are op-vocabulary
@@ -920,6 +921,7 @@ pub struct AgendaRelation {
 #[serde(rename_all = "snake_case")]
 pub enum AgendaRefType {
     File,
+    Dir,
     Memory,
     Session,
     Url,
@@ -929,6 +931,7 @@ impl AgendaRefType {
     pub(crate) fn as_str(self) -> &'static str {
         match self {
             AgendaRefType::File => "file",
+            AgendaRefType::Dir => "dir",
             AgendaRefType::Memory => "memory",
             AgendaRefType::Session => "session",
             AgendaRefType::Url => "url",
@@ -947,8 +950,9 @@ impl AgendaRefType {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AgendaRef {
     pub(crate) ref_type: AgendaRefType,
-    /// `file`: absolute path; `memory`: claim id; `session`: conversation
-    /// id; `url`: http(s) URL. Stored verbatim as intake validated it.
+    /// `file`/`dir`: absolute path; `memory`: claim id; `session`:
+    /// conversation id; `url`: http(s) URL. Stored verbatim as intake
+    /// validated it (dir refs: trailing slashes normalized away).
     pub(crate) locator: String,
     /// File refs only: full sha256 hex of the file as it stood at attach —
     /// intake-minted and recorded in the op (replay never hashes). The

--- a/src/bin/caller/ctl.rs
+++ b/src/bin/caller/ctl.rs
@@ -2880,38 +2880,43 @@ async fn run_agenda(
 
 /// Resolve one ctl-side ref spec: `[type:]locator` with a `--type`
 /// override. Inference: http(s) URLs are `url`; a path that exists
-/// locally is `file` (canonicalized to the absolute path the daemon
-/// stores); anything else needs an explicit type. Client-side sugar only —
-/// the daemon re-validates everything at intake (and mints the digest).
+/// locally is `file` — or `dir` when it is a directory (both
+/// canonicalized to the absolute path the daemon stores); anything else
+/// needs an explicit type. Client-side sugar only — the daemon
+/// re-validates everything at intake (and mints file digests).
 fn agenda_ref_spec(raw: &str, explicit: Option<&str>) -> Result<(String, String), String> {
     let (prefixed, rest) = match raw.split_once(':') {
-        Some((t, rest)) if ["file", "memory", "session", "url"].contains(&t) => (Some(t), rest),
+        Some((t, rest)) if ["file", "dir", "memory", "session", "url"].contains(&t) => {
+            (Some(t), rest)
+        }
         _ => (None, raw),
     };
     let ref_type = match explicit.or(prefixed) {
         Some(t) => match t.trim().to_ascii_lowercase().as_str() {
-            t @ ("file" | "memory" | "session" | "url") => t.to_string(),
+            t @ ("file" | "dir" | "memory" | "session" | "url") => t.to_string(),
             other => {
                 return Err(format!(
-                    "unknown ref type '{other}' (file, memory, session, or url)"
+                    "unknown ref type '{other}' (file, dir, memory, session, or url)"
                 ))
             }
         },
         None => {
             if raw.starts_with("http://") || raw.starts_with("https://") {
                 "url".to_string()
+            } else if std::path::Path::new(raw).is_dir() {
+                "dir".to_string()
             } else if std::path::Path::new(raw).exists() {
                 "file".to_string()
             } else {
                 return Err(format!(
                     "cannot infer the ref type of {raw:?} — prefix it \
-                     (file:…, memory:…, session:…, url:https://…) or pass --type"
+                     (file:…, dir:…, memory:…, session:…, url:https://…) or pass --type"
                 ));
             }
         }
     };
     let locator = if prefixed.is_some() { rest } else { raw };
-    let locator = if ref_type == "file" {
+    let locator = if ref_type == "file" || ref_type == "dir" {
         // The daemon stores absolute paths; resolve relative args here. A
         // since-deleted file (removals) passes the stored path verbatim.
         match std::fs::canonicalize(locator) {
@@ -5631,7 +5636,7 @@ fn help_agenda() {
   intendant ctl agenda block ID_PREFIX CRITERION... [--source LABEL]\n\
   intendant ctl agenda unblock ID_PREFIX [BLOCKER_PREFIX] [--source LABEL]\n\
   intendant ctl agenda relies-on ID_PREFIX TARGET_PREFIX [--remove] [--source LABEL]\n\
-  intendant ctl agenda ref ID_PREFIX [TYPE:]LOCATOR [--type file|memory|session|url]\n\
+  intendant ctl agenda ref ID_PREFIX [TYPE:]LOCATOR [--type file|dir|memory|session|url]\n\
       [--must-read] [--label TEXT] [--remove] [--source LABEL]\n\
   intendant ctl agenda place ID_PREFIX HUB_PREFIX|--under HUB [--remove] [--source LABEL]\n\
   intendant ctl agenda relates ID_PREFIX TARGET_PREFIX [--kind KIND] [--remove] [--source LABEL]\n\
@@ -5706,9 +5711,11 @@ lane — no --peer, and a supervised session's injected lane deliberately\n\
 lacks them (use `agenda list` there).\n\
 \n\
 `ref` attaches a typed POINTER (never content): a file path (digested at\n\
-attach so the detail view can show drift honestly), a Memory claim id, a\n\
+attach so the detail view can show drift honestly), a directory path\n\
+(pointer only — never digested), a Memory claim id, a\n\
 session/conversation id, or an http(s) URL. Type is inferred (URLs,\n\
-existing paths) or explicit via TYPE: prefix / --type; --must-read marks\n\
+existing paths — a directory infers dir) or explicit via TYPE: prefix /\n\
+--type; --must-read marks\n\
 it prominent for whoever picks the item up (a pointer they weigh, not an\n\
 order); --remove drops it (history stays). On `add`, repeat --ref to\n\
 attach at park time — one item, its context, one gesture.\n\

--- a/static/app.html
+++ b/static/app.html
@@ -37605,7 +37605,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'fa41f30d6c6f9c8e';
+const INTENDANT_APP_BUILD = '5b63a39a509248a8';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -97061,12 +97061,14 @@ function agendaInspAddTag(item) {
 // Pointer type inference for the add row (the daemon validates the typed
 // command either way — this only picks the claimed type): http(s) → url,
 // a 12+-hex run → memory claim id, an id the sessions join knows → session,
-// anything else → file path.
+// a trailing slash → dir (the browser cannot stat; the daemon re-checks
+// and normalizes the slash away), anything else → file path.
 function agendaInspInferRefType(locator) {
   if (/^https?:\/\//i.test(locator)) return 'url';
   if (/^[0-9a-f]{12,}$/i.test(locator)) return 'memory';
   if (agendaSessions && agendaSessions[locator]) return 'session';
   if (/^sess-/.test(locator)) return 'session';
+  if (locator.length > 1 && /\/$/.test(locator)) return 'dir';
   return 'file';
 }
 

--- a/static/app/ui2-agenda-inspector.js
+++ b/static/app/ui2-agenda-inspector.js
@@ -1212,12 +1212,14 @@ function agendaInspAddTag(item) {
 // Pointer type inference for the add row (the daemon validates the typed
 // command either way — this only picks the claimed type): http(s) → url,
 // a 12+-hex run → memory claim id, an id the sessions join knows → session,
-// anything else → file path.
+// a trailing slash → dir (the browser cannot stat; the daemon re-checks
+// and normalizes the slash away), anything else → file path.
 function agendaInspInferRefType(locator) {
   if (/^https?:\/\//i.test(locator)) return 'url';
   if (/^[0-9a-f]{12,}$/i.test(locator)) return 'memory';
   if (agendaSessions && agendaSessions[locator]) return 'session';
   if (/^sess-/.test(locator)) return 'session';
+  if (locator.length > 1 && /\/$/.test(locator)) return 'dir';
   return 'file';
 }
 


### PR DESCRIPTION
Slice 2 of the agenda ontology program (agenda item 01KYT8J44F, design note ~/agenda-ontology-next.md): `AgendaRefType::Dir` — territory anchors for items and hubs, since directories survive this repo's file-split velocity better than file paths.

- Intake: absolute existing directories only, refusals named (relative / unreadable / file-as-dir mirror the file-as-dir case already pinned); deliberately digestless — a directory has no attach-time byte identity without a priced tree-hash scheme (future vocabulary), so presence is its only drift signal. Trailing slashes normalize to one spelling so (type, locator) addressing cannot mint two addresses for one directory.
- Drift lane naturally skips digestless refs; the ref-content reader already refuses non-file refs by name (pointer-only preserved).
- ctl: `dir:` prefix + `--type dir` + inference (an existing directory infers dir, canonicalized like file paths); help + docs table updated.
- Dashboard: inference treats a trailing slash as dir (the browser cannot stat; the daemon re-checks); ref chips render the new type generically. app.html regenerated from the fragment.
- `agenda_op` MCP schema follows via schemars; older builds degrade a dir-ref op line to preserved-skipped exactly as the enum's evolution note prescribes.

Battery: bins 5272 + 150 + 97 pass, lib crates pass, workspace clippy -D warnings clean, fmt applied.