### PR TITLE
agenda graph: projections — hub-focus, over-cap hub overview, typed edges, territory halos

### DIFF
--- a/src/bin/caller/agenda/types.rs
+++ b/src/bin/caller/agenda/types.rs
@@ -3450,6 +3450,36 @@ mod tests {
         }
     }
 
+    /// The dashboard's typed-adjacency vocabulary is a static mirror of
+    /// [`RELATES_TO_LINK_KINDS`] (the sanctioned frontend-fallback
+    /// pattern): the generated app.html must carry the mirror array —
+    /// derived here from the daemon constant, order included — and a
+    /// chip-label entry per ruled kind, so a vocabulary change that
+    /// forgets the dashboard fails this suite instead of shipping as
+    /// drift.
+    #[test]
+    fn relates_link_kind_vocabulary_is_pinned_in_app_html() {
+        let app = include_str!("../../../../static/app.html");
+        let mirror = format!(
+            "const AGENDA_REL_KINDS = [{}]",
+            RELATES_TO_LINK_KINDS
+                .iter()
+                .map(|kind| format!("'{kind}'"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        assert!(
+            app.contains(&mirror),
+            "app.html lost the AGENDA_REL_KINDS mirror ({mirror})"
+        );
+        for kind in RELATES_TO_LINK_KINDS {
+            assert!(
+                app.contains(&format!("{kind}: [")),
+                "app.html chip-label map lost the {kind:?} entry"
+            );
+        }
+    }
+
     /// Pins the `--source` envelope field (additive to v1): recorded
     /// verbatim beside the actor, folded into add provenance, absent from
     /// the wire when unset (the existing pin tests prove that half).

--- a/static/app.html
+++ b/static/app.html
@@ -24549,7 +24549,14 @@ html.ui-v2 .ag2-graph-swatch.s-ring.t-green { border: 1.5px solid var(--green); 
 html.ui-v2 .ag2-graph-swatch.s-line { width: 14px; }
 html.ui-v2 .ag2-graph-swatch.s-line.t-place { border-top: 2px solid rgba(var(--iris-rgb), 0.55); }
 html.ui-v2 .ag2-graph-swatch.s-line.t-rel { border-top: 2px dashed var(--text-3); }
+html.ui-v2 .ag2-graph-swatch.s-line.t-typed { border-top: 2px solid var(--text-2); }
 html.ui-v2 .ag2-graph-swatch.s-line.t-dep { border-top: 2px solid rgba(var(--rose-rgb), 0.6); }
+html.ui-v2 .ag2-graph-swatch.s-ring.t-terr { border: 1.5px dotted var(--text-2); }
+html.ui-v2 .ag2-graph-clear {
+  position: absolute;
+  top: 38px;
+  right: 14px;
+}
 
 /* ---- Upcoming lens (slice C): the 14-day day-grouped timeline. Rows
    ride the shared .ag2-chip family; dots pulse via the shared ui2-pulse
@@ -25951,6 +25958,18 @@ html.ui-v2 .ag2-reladd {
   max-width: 150px;
   font-size: 10.5px !important;
   padding: 2px 6px !important;
+}
+html.ui-v2 .ag2-relkind-add {
+  border-radius: var(--r-pill) !important;
+  max-width: 110px;
+  font-size: 10.5px !important;
+  padding: 2px 6px !important;
+}
+html.ui-v2 .ag2-relkind {
+  font-family: var(--mono);
+  font-size: 9px;
+  color: var(--text-3);
+  white-space: nowrap;
 }
 html.ui-v2 .ag2-tagchip {
   display: inline-flex;
@@ -37605,7 +37624,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '5b63a39a509248a8';
+const INTENDANT_APP_BUILD = '075cc48118221633';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -92498,6 +92517,29 @@ function agendaRelationPartners(item) {
   return partners;
 }
 
+// The typed view of the same union: one row per partner with the link's
+// kind and direction from whichever side stores it (a typed link reads
+// storer → target; `outgoing` = this item stores it). Untyped links
+// carry kind ''.
+function agendaRelationEdges(item) {
+  const edges = [];
+  const seen = new Set([item.id]);
+  (item.relates_to || []).forEach((link) => {
+    if (seen.has(link.target_id)) return;
+    seen.add(link.target_id);
+    edges.push({ pid: link.target_id, kind: link.link_kind || '', outgoing: true });
+  });
+  (agendaItems || []).forEach((other) => {
+    if (seen.has(other.id)) return;
+    const link = (other.relates_to || []).find((e) => e.target_id === item.id);
+    if (link) {
+      seen.add(other.id);
+      edges.push({ pid: other.id, kind: link.link_kind || '', outgoing: false });
+    }
+  });
+  return edges;
+}
+
 // Triage-rank convention: the triage mandate writes ordinary annotations
 // with the self-described `triage` source, and a "rank N" phrase in the
 // text is its DECLARED ranking convention. The /rank (\d+)/ parse here is
@@ -95870,6 +95912,28 @@ let agendaInspAnnDraft = '';
 let agendaInspTagDraft = '';
 let agendaInspRefDraft = '';
 let agendaInspRefMust = false;
+let agendaInspRelKind = '';
+
+// The typed-adjacency vocabulary (G2 `link_kind`) — a static mirror of
+// the daemon's RELATES_TO_LINK_KINDS, pinned by a daemon-side parity
+// test so a vocabulary change that forgets this file fails the suite
+// instead of shipping as drift.
+const AGENDA_REL_KINDS = ['duplicates', 'supersedes', 'follow_up_of', 'evidences'];
+// Reading direction: a typed link reads storer → target ("A supersedes
+// B" lives on A). The passive forms keep the incoming side readable.
+const AGENDA_REL_KIND_LABELS = {
+  duplicates: ['duplicates ▸', '◂ duplicated by'],
+  supersedes: ['supersedes ▸', '◂ superseded by'],
+  follow_up_of: ['follow-up of ▸', '◂ has follow-up'],
+  evidences: ['evidences ▸', '◂ evidenced by'],
+};
+
+function agendaRelKindLabel(kind, outgoing) {
+  const pair = AGENDA_REL_KIND_LABELS[kind];
+  // Unknown kinds (a newer daemon's vocabulary) stay readable as text.
+  if (!pair) return outgoing ? `${kind} ▸` : `◂ ${kind}`;
+  return outgoing ? pair[0] : pair[1];
+}
 
 function agendaOpenInspector(id) {
   const opened = agendaFindItem(id);
@@ -96579,14 +96643,23 @@ function agendaInspOrganizationHtml(item) {
       const selected = item.part_of && item.part_of.parent_id === x.id ? ' selected' : '';
       return `<option value="${escapeHtml(x.id)}"${selected}>${hub}${escapeHtml(x.title.slice(0, 46))}</option>`;
     }).join('');
-  const partners = agendaRelationPartners(item);
-  const rels = [...partners].map((pid) => {
+  const relEdges = agendaRelationEdges(item);
+  const partners = new Set(relEdges.map((edge) => edge.pid));
+  const rels = relEdges.map(({ pid, kind, outgoing }) => {
     const target = agendaFindItem(pid);
     if (!target) return '';
+    const kindChip = kind
+      ? `<span class="ag2-relkind">${escapeHtml(agendaRelKindLabel(kind, outgoing))}</span>`
+      : '';
     return `<span class="ag2-relchip">
-      <a data-open-item="${escapeHtml(pid)}">${escapeHtml(target.title.slice(0, 34))}</a>
-      <button type="button" class="ag2-x" data-remove-rel="${escapeHtml(pid)}" title="Remove the see-also link (the log keeps history)">×</button>
+      ${kindChip}<a data-open-item="${escapeHtml(pid)}">${escapeHtml(target.title.slice(0, 34))}</a>
+      <button type="button" class="ag2-x" data-remove-rel="${escapeHtml(pid)}" title="Remove the link (the log keeps history; re-add to change its kind)">×</button>
     </span>`;
+  }).join('');
+  const relKindOptions = ['', ...AGENDA_REL_KINDS].map((kind) => {
+    const selected = kind === agendaInspRelKind ? ' selected' : '';
+    const label = kind ? kind.replace(/_/g, ' ') : 'see-also';
+    return `<option value="${kind}"${selected}>${label}</option>`;
   }).join('');
   const relOptions = others
     .filter((x) => !partners.has(x.id))
@@ -96611,6 +96684,9 @@ function agendaInspOrganizationHtml(item) {
         <span class="ag2-orgk">See also</span>
         <div class="ag2-orgv">
           ${rels}
+          <select class="ag2-relkind-add" data-act-change="rel-kind" aria-label="Link kind (reads this item → target)">
+            ${relKindOptions}
+          </select>
           <select class="ag2-reladd" data-act-change="rel-add" aria-label="Relate to">
             <option value="">+ relate…</option>${relOptions}
           </select>
@@ -96992,10 +97068,18 @@ function agendaInspChange(e) {
     agendaSetItemUrgency(item.id, t.value, t);
   } else if (t.dataset.actChange === 'place') {
     agendaInspPlace(item, t.value, t);
+  } else if (t.dataset.actChange === 'rel-kind') {
+    // Draft only — the link sends when a target is picked.
+    agendaInspRelKind = t.value;
   } else if (t.dataset.actChange === 'rel-add') {
     const v = t.value;
     t.value = '';
-    if (v) agendaSendOp({ op: 'add_relates_to', id: item.id, target_id: v }, t);
+    if (v) {
+      const params = { op: 'add_relates_to', id: item.id, target_id: v };
+      if (agendaInspRelKind) params.link_kind = agendaInspRelKind;
+      agendaInspRelKind = '';
+      agendaSendOp(params, t);
+    }
   } else if (t.dataset.actChange === 'dep-add') {
     const v = t.value;
     if (v) {
@@ -97923,6 +98007,11 @@ let agendaGraphCanvasHooks = null;
 let agendaGraphPaneObserver = null;
 let agendaGraphAutoTimer = null;
 let agendaGraphCam = { yaw: 0.6, pitch: -0.34, auto: true };
+// Projection state: 'all' (whole non-retired ledger), 'hubs' (the
+// over-cap hub overview), 'focus' (one hub's placed subtree). The render
+// pass decides the projection; build/draw only read it.
+let agendaGraphFocus = null;
+let agendaGraphProjection = 'all';
 let agendaGraphMouse = { x: -1e4, y: -1e4, down: false, moved: 0 };
 let agendaGraphHover = null;
 let agendaGraphPalCache = null;
@@ -97938,15 +98027,61 @@ function agendaGraphReducedMotion() {
 
 // The graph's pool: every non-retired item, deliberately unfiltered —
 // the constellation shows the whole topology; search and the lens-bar
-// filter chips keep applying to the card lenses only.
+// filter chips keep applying to the card lenses only. A focused hub
+// narrows the pool to its placed subtree (self included); a focus whose
+// item left the ledger clears itself.
 function agendaGraphPoolItems() {
-  return (agendaItems || []).filter((item) => item.status !== 'retired');
+  const all = (agendaItems || []).filter((item) => item.status !== 'retired');
+  if (agendaGraphFocus) {
+    if (!all.some((item) => item.id === agendaGraphFocus)) {
+      agendaGraphFocus = null;
+    } else {
+      const desc = agendaDescendantIds(agendaGraphFocus);
+      return all.filter(
+        (item) => item.id === agendaGraphFocus || desc.has(item.id),
+      );
+    }
+  }
+  return all;
+}
+
+// The over-cap degradation: instead of refusing, the constellation
+// becomes a hub overview — only items with placed children — and a
+// click focuses one hub's subtree. The projection stays functional at
+// any ledger size a real taxonomy produces.
+function agendaGraphHubOverviewItems(all) {
+  const parents = new Set();
+  all.forEach((item) => {
+    if (item.part_of) parents.add(item.part_of.parent_id);
+  });
+  return all.filter((item) => parents.has(item.id));
+}
+
+// The active projection's node pool — the one truth build and draw use.
+function agendaGraphProjectionItems() {
+  const pool = agendaGraphPoolItems();
+  if (agendaGraphProjection === 'hubs' && !agendaGraphFocus) {
+    return agendaGraphHubOverviewItems(pool);
+  }
+  return pool;
 }
 
 // ---- Lens surface (the AGENDA_LENSES render/deactivate pair) ----
 
 function agendaGraphRenderLens(host) {
-  const items = agendaGraphPoolItems();
+  // Pick the projection: focused subtree when a focus is set; the whole
+  // ledger under the cap; past the cap, degrade to the hub overview
+  // (the ratified cap still bounds every projection — the O(n²)
+  // relaxation and the label field stop earning their keep beyond it).
+  let items = agendaGraphPoolItems();
+  agendaGraphProjection = agendaGraphFocus ? 'focus' : 'all';
+  if (!agendaGraphFocus && items.length > AGENDA_GRAPH_NODE_CAP) {
+    const hubs = agendaGraphHubOverviewItems(items);
+    if (hubs.length && hubs.length <= AGENDA_GRAPH_NODE_CAP) {
+      items = hubs;
+      agendaGraphProjection = 'hubs';
+    }
+  }
   if (!items.length) {
     agendaGraphTeardown();
     host.innerHTML = `<div class="ag2-empty">
@@ -97957,14 +98092,15 @@ function agendaGraphRenderLens(host) {
     return;
   }
   if (items.length > AGENDA_GRAPH_NODE_CAP) {
-    // Ratified cap: past this the O(n²) relaxation and the label field
-    // stop earning their keep — skip the layout entirely.
     agendaGraphTeardown();
+    const hint = agendaGraphFocus
+      ? 'This subtree exceeds the cap — focus a narrower hub, or use By hub.'
+      : 'Use By hub for large flat ledgers.';
     host.innerHTML = `<div class="ag2-graph-panel empty">
       <div class="ag2-empty">
         <div class="ag2-empty-glyph">◍</div>
         <div class="ag2-empty-title">The constellation caps at ${AGENDA_GRAPH_NODE_CAP} items</div>
-        <div class="ag2-empty-hint">Use By hub for large ledgers.</div>
+        <div class="ag2-empty-hint">${hint}</div>
       </div>
     </div>`;
     return;
@@ -97973,6 +98109,23 @@ function agendaGraphRenderLens(host) {
   if (!canvas) {
     host.innerHTML = agendaGraphPanelHtml();
     canvas = host.querySelector('#ag2-graph-canvas');
+  }
+  // Per-projection static chrome: hint text and the clear-focus button.
+  const hintLine = host.querySelector('#ag2-graph-hint');
+  if (hintLine) {
+    hintLine.textContent = agendaGraphProjection === 'hubs'
+      ? 'hub overview — click a hub to focus its subtree'
+      : agendaGraphProjection === 'focus'
+        ? 'focused subtree — double-click empty space to clear'
+        : 'drag to orbit · click a node to open it · double-click a hub to focus';
+  }
+  const clear = host.querySelector('#ag2-graph-clear');
+  if (clear) {
+    clear.hidden = !agendaGraphFocus;
+    clear.onclick = () => {
+      agendaGraphFocus = null;
+      agendaRenderTab();
+    };
   }
   agendaGraphBindCanvas(canvas);
   agendaGraphEnsureLoop();
@@ -97992,15 +98145,18 @@ function agendaGraphPanelHtml() {
       <div class="ag2-graph-eyebrow-title">Constellation</div>
       <div class="ag2-graph-eyebrow-sub">placement · adjacency · dependencies</div>
     </div>
-    <div class="ag2-graph-hint">drag to orbit · click a node to open it</div>
+    <div class="ag2-graph-hint" id="ag2-graph-hint">drag to orbit · click a node to open it</div>
+    <button type="button" class="ag2-dashbtn ag2-graph-clear" id="ag2-graph-clear" hidden>show all</button>
     <div class="ag2-graph-legend">
       ${agendaGraphLegendChip('s-dot t-iris', 'open')}
       ${agendaGraphLegendChip('s-dot t-amber', 'question')}
       ${agendaGraphLegendChip('s-dot t-green', 'done')}
       ${agendaGraphLegendChip('s-ring t-rose', 'blocked')}
       ${agendaGraphLegendChip('s-ring t-green', 'standing run')}
+      ${agendaGraphLegendChip('s-ring t-terr', 'territory')}
       ${agendaGraphLegendChip('s-line t-place', 'filed under')}
       ${agendaGraphLegendChip('s-line t-rel', 'see-also')}
+      ${agendaGraphLegendChip('s-line t-typed', 'typed →')}
       ${agendaGraphLegendChip('s-line t-dep', 'waits on')}
     </div>
   </div>`;
@@ -98038,13 +98194,30 @@ function agendaGraphBindCanvas(canvas) {
     },
     up: () => {
       const m = agendaGraphMouse;
-      // A press that traveled under ~6px is a click; open its node in
-      // the slice-A inspector.
+      // A press that traveled under ~6px is a click. In the hub
+      // overview a click focuses the hub's subtree; everywhere else it
+      // opens the node in the slice-A inspector.
       if (m.down && m.moved < 6 && agendaGraphHover) {
-        agendaOpenInspector(agendaGraphHover);
+        if (agendaGraphProjection === 'hubs') {
+          agendaGraphFocus = agendaGraphHover;
+          agendaRenderTab();
+        } else {
+          agendaOpenInspector(agendaGraphHover);
+        }
       }
       m.down = false;
       agendaGraphArmAutoResume();
+    },
+    dbl: () => {
+      // Double-click a hub to focus its subtree; double-click empty
+      // space to clear an active focus.
+      if (agendaGraphHover && agendaChildrenOf(agendaGraphHover).length) {
+        agendaGraphFocus = agendaGraphHover;
+        agendaRenderTab();
+      } else if (!agendaGraphHover && agendaGraphFocus) {
+        agendaGraphFocus = null;
+        agendaRenderTab();
+      }
     },
     leave: () => {
       const wasDown = agendaGraphMouse.down;
@@ -98060,6 +98233,7 @@ function agendaGraphBindCanvas(canvas) {
   canvas.addEventListener('mousedown', hooks.down);
   canvas.addEventListener('mouseup', hooks.up);
   canvas.addEventListener('mouseleave', hooks.leave);
+  canvas.addEventListener('dblclick', hooks.dbl);
   agendaGraphCanvasHooks = hooks;
 }
 
@@ -98071,6 +98245,7 @@ function agendaGraphUnbindCanvas() {
     canvas.removeEventListener('mousedown', hooks.down);
     canvas.removeEventListener('mouseup', hooks.up);
     canvas.removeEventListener('mouseleave', hooks.leave);
+    canvas.removeEventListener('dblclick', hooks.dbl);
   }
   agendaGraphCanvas = null;
   agendaGraphCanvasHooks = null;
@@ -98151,12 +98326,14 @@ function agendaGraphTeardown() {
 // nodes keep their positions and the settle budget re-arms so the new
 // shape relaxes in over the following frames.
 function agendaGraphBuild() {
-  const items = agendaGraphPoolItems();
-  const key = items.map((x) => [
+  const items = agendaGraphProjectionItems();
+  const key = `${agendaGraphProjection}|${agendaGraphFocus || ''};` + items.map((x) => [
     x.id,
     x.status,
     x.part_of ? x.part_of.parent_id : '',
-    (x.relates_to || []).length,
+    // Adjacency keyed per-link (target + kind) so a re-typed link
+    // rebuilds even when the count is unchanged.
+    (x.relates_to || []).map((l) => `${l.target_id}~${l.link_kind || ''}`).join(','),
     (x.relies_on || []).length,
     x.kind,
   ].join('|')).join(';');
@@ -98184,13 +98361,20 @@ function agendaGraphBuild() {
         links.push({ a: idx.get(x.id), b: idx.get(link.target_id), t: 'dep' });
       }
     });
-    // relates_to renders undirected: dedupe the two stored directions.
+    // relates_to renders undirected and deduped across the two stored
+    // directions; a typed link keeps its stored direction (a = storer,
+    // b = target — "A supersedes B" draws its arrow at B).
     (x.relates_to || []).forEach((link) => {
       if (!idx.has(link.target_id)) return;
       const pair = [x.id, link.target_id].sort().join(':');
       if (seenRel.has(pair)) return;
       seenRel.add(pair);
-      links.push({ a: idx.get(x.id), b: idx.get(link.target_id), t: 'rel' });
+      links.push({
+        a: idx.get(x.id),
+        b: idx.get(link.target_id),
+        t: 'rel',
+        k: link.link_kind || null,
+      });
     });
   });
   agendaGraphLinks = links;
@@ -98275,8 +98459,8 @@ function agendaGraphDraw(ts) {
   const items = agendaGraphBuild();
   if (!items.length || items.length > AGENDA_GRAPH_NODE_CAP) {
     // The ledger crossed a boundary between renders (event-lane merge):
-    // re-enter through the render pass, which owns the cap and empty
-    // states (it tears this loop down).
+    // re-enter through the render pass, which owns projection choice,
+    // the cap, and the empty states (it tears this loop down).
     agendaRenderTab();
     return;
   }
@@ -98360,10 +98544,17 @@ function agendaGraphDraw(ts) {
       g.strokeStyle = `rgba(${pal.iris},${depth * (hot ? 0.75 : 0.38)})`;
       g.lineWidth = hot ? 1.6 : 1.1;
     } else if (link.t === 'rel') {
-      g.setLineDash([3, 5]);
-      g.lineDashOffset = 0;
-      g.strokeStyle = `rgba(${pal.text},${depth * (hot ? 0.5 : 0.16)})`;
-      g.lineWidth = 1;
+      if (link.k) {
+        // Typed adjacency: solid and slightly stronger than see-also.
+        g.setLineDash([]);
+        g.strokeStyle = `rgba(${pal.text},${depth * (hot ? 0.6 : 0.26)})`;
+        g.lineWidth = hot ? 1.4 : 1.05;
+      } else {
+        g.setLineDash([3, 5]);
+        g.lineDashOffset = 0;
+        g.strokeStyle = `rgba(${pal.text},${depth * (hot ? 0.5 : 0.16)})`;
+        g.lineWidth = 1;
+      }
     } else {
       g.setLineDash([2, 6]);
       g.lineDashOffset = reduced ? 0 : -ts * 0.02;
@@ -98372,6 +98563,30 @@ function agendaGraphDraw(ts) {
     }
     g.stroke();
     g.setLineDash([]);
+    if (link.t === 'rel' && link.k) {
+      // A typed link reads storer → target: arrowhead at the target
+      // end, the kind labeled at the midpoint while an endpoint is hot.
+      const ang = Math.atan2(b.y - a.y, b.x - a.x);
+      const ax = b.x - Math.cos(ang) * 11;
+      const ay = b.y - Math.sin(ang) * 11;
+      const sz = 3.2 + (hot ? 0.9 : 0);
+      g.beginPath();
+      g.moveTo(ax + Math.cos(ang) * sz, ay + Math.sin(ang) * sz);
+      g.lineTo(ax + Math.cos(ang + 2.5) * sz, ay + Math.sin(ang + 2.5) * sz);
+      g.lineTo(ax + Math.cos(ang - 2.5) * sz, ay + Math.sin(ang - 2.5) * sz);
+      g.closePath();
+      g.fillStyle = `rgba(${pal.text},${depth * (hot ? 0.7 : 0.32)})`;
+      g.fill();
+      if (hot) {
+        g.font = '9px "JetBrains Mono", monospace';
+        g.fillStyle = `rgba(${pal.text},.8)`;
+        g.fillText(
+          link.k.replace(/_/g, ' '),
+          (a.x + b.x) / 2 + 5,
+          (a.y + b.y) / 2 - 5,
+        );
+      }
+    }
   });
   // Nodes far → near.
   const order = nodes.map((n, i) => i).sort((a, b) => pts[b].z - pts[a].z);
@@ -98414,6 +98629,16 @@ function agendaGraphDraw(ts) {
         (reduced ? 0.65 : 0.45 + 0.4 * Math.sin(ts / 280)) * alpha);
     }
     if (st && st.kind === 'pending') ring(pal.amber, 5.4, 0.75 * alpha);
+    // Territory halo: a dotted outer ring on nodes carrying file/dir
+    // refs — the declared working set made visible.
+    const territory = (item.refs || []).filter(
+      (r) => r.ref_type === 'file' || r.ref_type === 'dir',
+    ).length;
+    if (territory) {
+      g.setLineDash([1.5, 3.2]);
+      ring(pal.text, 7.6, 0.3 * alpha);
+      g.setLineDash([]);
+    }
     if (kids || hot) {
       g.font = `${hot ? '700' : '600'} 11px "Hanken Grotesk", sans-serif`;
       const title = String(item.title || '');
@@ -98431,12 +98656,34 @@ function agendaGraphDraw(ts) {
       if (hot) {
         g.font = '9.5px "JetBrains Mono", monospace';
         g.fillStyle = pal.t3;
+        const open = agendaGraphProjection === 'hubs'
+          ? 'click to focus'
+          : 'click to open';
         g.fillText(
-          `${item.kind} · ${item.status}${kids ? ` · hub, ${kids} filed` : ''} — click to open`,
+          `${item.kind} · ${item.status}${kids ? ` · hub, ${kids} filed` : ''}${territory ? ` · ${territory} territory` : ''} — ${open}`,
           lx, ly + 13);
       }
     }
   });
+  // Projection badge (painted, inert pixels like every label): what the
+  // constellation is currently showing.
+  if (agendaGraphProjection !== 'all') {
+    const allCount = (agendaItems || []).filter(
+      (x) => x.status !== 'retired',
+    ).length;
+    let badge = '';
+    if (agendaGraphProjection === 'hubs') {
+      badge = `hub overview · ${nodes.length} hubs of ${allCount} items`;
+    } else {
+      const focused = byId.get(agendaGraphFocus);
+      const title = focused ? String(focused.title || '') : '';
+      const short = title.length > 40 ? `${title.slice(0, 39)}…` : title;
+      badge = `focused: ${short} · ${nodes.length} of ${allCount} items`;
+    }
+    g.font = '10px "JetBrains Mono", monospace';
+    g.fillStyle = pal.t3;
+    g.fillText(badge, 14, 64);
+  }
 }
 
 // ---- Wire (the one permanent listener; see the fragment header) ----

--- a/static/app/ui2-agenda-graph.js
+++ b/static/app/ui2-agenda-graph.js
@@ -48,6 +48,11 @@ let agendaGraphCanvasHooks = null;
 let agendaGraphPaneObserver = null;
 let agendaGraphAutoTimer = null;
 let agendaGraphCam = { yaw: 0.6, pitch: -0.34, auto: true };
+// Projection state: 'all' (whole non-retired ledger), 'hubs' (the
+// over-cap hub overview), 'focus' (one hub's placed subtree). The render
+// pass decides the projection; build/draw only read it.
+let agendaGraphFocus = null;
+let agendaGraphProjection = 'all';
 let agendaGraphMouse = { x: -1e4, y: -1e4, down: false, moved: 0 };
 let agendaGraphHover = null;
 let agendaGraphPalCache = null;
@@ -63,15 +68,61 @@ function agendaGraphReducedMotion() {
 
 // The graph's pool: every non-retired item, deliberately unfiltered —
 // the constellation shows the whole topology; search and the lens-bar
-// filter chips keep applying to the card lenses only.
+// filter chips keep applying to the card lenses only. A focused hub
+// narrows the pool to its placed subtree (self included); a focus whose
+// item left the ledger clears itself.
 function agendaGraphPoolItems() {
-  return (agendaItems || []).filter((item) => item.status !== 'retired');
+  const all = (agendaItems || []).filter((item) => item.status !== 'retired');
+  if (agendaGraphFocus) {
+    if (!all.some((item) => item.id === agendaGraphFocus)) {
+      agendaGraphFocus = null;
+    } else {
+      const desc = agendaDescendantIds(agendaGraphFocus);
+      return all.filter(
+        (item) => item.id === agendaGraphFocus || desc.has(item.id),
+      );
+    }
+  }
+  return all;
+}
+
+// The over-cap degradation: instead of refusing, the constellation
+// becomes a hub overview — only items with placed children — and a
+// click focuses one hub's subtree. The projection stays functional at
+// any ledger size a real taxonomy produces.
+function agendaGraphHubOverviewItems(all) {
+  const parents = new Set();
+  all.forEach((item) => {
+    if (item.part_of) parents.add(item.part_of.parent_id);
+  });
+  return all.filter((item) => parents.has(item.id));
+}
+
+// The active projection's node pool — the one truth build and draw use.
+function agendaGraphProjectionItems() {
+  const pool = agendaGraphPoolItems();
+  if (agendaGraphProjection === 'hubs' && !agendaGraphFocus) {
+    return agendaGraphHubOverviewItems(pool);
+  }
+  return pool;
 }
 
 // ---- Lens surface (the AGENDA_LENSES render/deactivate pair) ----
 
 function agendaGraphRenderLens(host) {
-  const items = agendaGraphPoolItems();
+  // Pick the projection: focused subtree when a focus is set; the whole
+  // ledger under the cap; past the cap, degrade to the hub overview
+  // (the ratified cap still bounds every projection — the O(n²)
+  // relaxation and the label field stop earning their keep beyond it).
+  let items = agendaGraphPoolItems();
+  agendaGraphProjection = agendaGraphFocus ? 'focus' : 'all';
+  if (!agendaGraphFocus && items.length > AGENDA_GRAPH_NODE_CAP) {
+    const hubs = agendaGraphHubOverviewItems(items);
+    if (hubs.length && hubs.length <= AGENDA_GRAPH_NODE_CAP) {
+      items = hubs;
+      agendaGraphProjection = 'hubs';
+    }
+  }
   if (!items.length) {
     agendaGraphTeardown();
     host.innerHTML = `<div class="ag2-empty">
@@ -82,14 +133,15 @@ function agendaGraphRenderLens(host) {
     return;
   }
   if (items.length > AGENDA_GRAPH_NODE_CAP) {
-    // Ratified cap: past this the O(n²) relaxation and the label field
-    // stop earning their keep — skip the layout entirely.
     agendaGraphTeardown();
+    const hint = agendaGraphFocus
+      ? 'This subtree exceeds the cap — focus a narrower hub, or use By hub.'
+      : 'Use By hub for large flat ledgers.';
     host.innerHTML = `<div class="ag2-graph-panel empty">
       <div class="ag2-empty">
         <div class="ag2-empty-glyph">◍</div>
         <div class="ag2-empty-title">The constellation caps at ${AGENDA_GRAPH_NODE_CAP} items</div>
-        <div class="ag2-empty-hint">Use By hub for large ledgers.</div>
+        <div class="ag2-empty-hint">${hint}</div>
       </div>
     </div>`;
     return;
@@ -98,6 +150,23 @@ function agendaGraphRenderLens(host) {
   if (!canvas) {
     host.innerHTML = agendaGraphPanelHtml();
     canvas = host.querySelector('#ag2-graph-canvas');
+  }
+  // Per-projection static chrome: hint text and the clear-focus button.
+  const hintLine = host.querySelector('#ag2-graph-hint');
+  if (hintLine) {
+    hintLine.textContent = agendaGraphProjection === 'hubs'
+      ? 'hub overview — click a hub to focus its subtree'
+      : agendaGraphProjection === 'focus'
+        ? 'focused subtree — double-click empty space to clear'
+        : 'drag to orbit · click a node to open it · double-click a hub to focus';
+  }
+  const clear = host.querySelector('#ag2-graph-clear');
+  if (clear) {
+    clear.hidden = !agendaGraphFocus;
+    clear.onclick = () => {
+      agendaGraphFocus = null;
+      agendaRenderTab();
+    };
   }
   agendaGraphBindCanvas(canvas);
   agendaGraphEnsureLoop();
@@ -117,15 +186,18 @@ function agendaGraphPanelHtml() {
       <div class="ag2-graph-eyebrow-title">Constellation</div>
       <div class="ag2-graph-eyebrow-sub">placement · adjacency · dependencies</div>
     </div>
-    <div class="ag2-graph-hint">drag to orbit · click a node to open it</div>
+    <div class="ag2-graph-hint" id="ag2-graph-hint">drag to orbit · click a node to open it</div>
+    <button type="button" class="ag2-dashbtn ag2-graph-clear" id="ag2-graph-clear" hidden>show all</button>
     <div class="ag2-graph-legend">
       ${agendaGraphLegendChip('s-dot t-iris', 'open')}
       ${agendaGraphLegendChip('s-dot t-amber', 'question')}
       ${agendaGraphLegendChip('s-dot t-green', 'done')}
       ${agendaGraphLegendChip('s-ring t-rose', 'blocked')}
       ${agendaGraphLegendChip('s-ring t-green', 'standing run')}
+      ${agendaGraphLegendChip('s-ring t-terr', 'territory')}
       ${agendaGraphLegendChip('s-line t-place', 'filed under')}
       ${agendaGraphLegendChip('s-line t-rel', 'see-also')}
+      ${agendaGraphLegendChip('s-line t-typed', 'typed →')}
       ${agendaGraphLegendChip('s-line t-dep', 'waits on')}
     </div>
   </div>`;
@@ -163,13 +235,30 @@ function agendaGraphBindCanvas(canvas) {
     },
     up: () => {
       const m = agendaGraphMouse;
-      // A press that traveled under ~6px is a click; open its node in
-      // the slice-A inspector.
+      // A press that traveled under ~6px is a click. In the hub
+      // overview a click focuses the hub's subtree; everywhere else it
+      // opens the node in the slice-A inspector.
       if (m.down && m.moved < 6 && agendaGraphHover) {
-        agendaOpenInspector(agendaGraphHover);
+        if (agendaGraphProjection === 'hubs') {
+          agendaGraphFocus = agendaGraphHover;
+          agendaRenderTab();
+        } else {
+          agendaOpenInspector(agendaGraphHover);
+        }
       }
       m.down = false;
       agendaGraphArmAutoResume();
+    },
+    dbl: () => {
+      // Double-click a hub to focus its subtree; double-click empty
+      // space to clear an active focus.
+      if (agendaGraphHover && agendaChildrenOf(agendaGraphHover).length) {
+        agendaGraphFocus = agendaGraphHover;
+        agendaRenderTab();
+      } else if (!agendaGraphHover && agendaGraphFocus) {
+        agendaGraphFocus = null;
+        agendaRenderTab();
+      }
     },
     leave: () => {
       const wasDown = agendaGraphMouse.down;
@@ -185,6 +274,7 @@ function agendaGraphBindCanvas(canvas) {
   canvas.addEventListener('mousedown', hooks.down);
   canvas.addEventListener('mouseup', hooks.up);
   canvas.addEventListener('mouseleave', hooks.leave);
+  canvas.addEventListener('dblclick', hooks.dbl);
   agendaGraphCanvasHooks = hooks;
 }
 
@@ -196,6 +286,7 @@ function agendaGraphUnbindCanvas() {
     canvas.removeEventListener('mousedown', hooks.down);
     canvas.removeEventListener('mouseup', hooks.up);
     canvas.removeEventListener('mouseleave', hooks.leave);
+    canvas.removeEventListener('dblclick', hooks.dbl);
   }
   agendaGraphCanvas = null;
   agendaGraphCanvasHooks = null;
@@ -276,12 +367,14 @@ function agendaGraphTeardown() {
 // nodes keep their positions and the settle budget re-arms so the new
 // shape relaxes in over the following frames.
 function agendaGraphBuild() {
-  const items = agendaGraphPoolItems();
-  const key = items.map((x) => [
+  const items = agendaGraphProjectionItems();
+  const key = `${agendaGraphProjection}|${agendaGraphFocus || ''};` + items.map((x) => [
     x.id,
     x.status,
     x.part_of ? x.part_of.parent_id : '',
-    (x.relates_to || []).length,
+    // Adjacency keyed per-link (target + kind) so a re-typed link
+    // rebuilds even when the count is unchanged.
+    (x.relates_to || []).map((l) => `${l.target_id}~${l.link_kind || ''}`).join(','),
     (x.relies_on || []).length,
     x.kind,
   ].join('|')).join(';');
@@ -309,13 +402,20 @@ function agendaGraphBuild() {
         links.push({ a: idx.get(x.id), b: idx.get(link.target_id), t: 'dep' });
       }
     });
-    // relates_to renders undirected: dedupe the two stored directions.
+    // relates_to renders undirected and deduped across the two stored
+    // directions; a typed link keeps its stored direction (a = storer,
+    // b = target — "A supersedes B" draws its arrow at B).
     (x.relates_to || []).forEach((link) => {
       if (!idx.has(link.target_id)) return;
       const pair = [x.id, link.target_id].sort().join(':');
       if (seenRel.has(pair)) return;
       seenRel.add(pair);
-      links.push({ a: idx.get(x.id), b: idx.get(link.target_id), t: 'rel' });
+      links.push({
+        a: idx.get(x.id),
+        b: idx.get(link.target_id),
+        t: 'rel',
+        k: link.link_kind || null,
+      });
     });
   });
   agendaGraphLinks = links;
@@ -400,8 +500,8 @@ function agendaGraphDraw(ts) {
   const items = agendaGraphBuild();
   if (!items.length || items.length > AGENDA_GRAPH_NODE_CAP) {
     // The ledger crossed a boundary between renders (event-lane merge):
-    // re-enter through the render pass, which owns the cap and empty
-    // states (it tears this loop down).
+    // re-enter through the render pass, which owns projection choice,
+    // the cap, and the empty states (it tears this loop down).
     agendaRenderTab();
     return;
   }
@@ -485,10 +585,17 @@ function agendaGraphDraw(ts) {
       g.strokeStyle = `rgba(${pal.iris},${depth * (hot ? 0.75 : 0.38)})`;
       g.lineWidth = hot ? 1.6 : 1.1;
     } else if (link.t === 'rel') {
-      g.setLineDash([3, 5]);
-      g.lineDashOffset = 0;
-      g.strokeStyle = `rgba(${pal.text},${depth * (hot ? 0.5 : 0.16)})`;
-      g.lineWidth = 1;
+      if (link.k) {
+        // Typed adjacency: solid and slightly stronger than see-also.
+        g.setLineDash([]);
+        g.strokeStyle = `rgba(${pal.text},${depth * (hot ? 0.6 : 0.26)})`;
+        g.lineWidth = hot ? 1.4 : 1.05;
+      } else {
+        g.setLineDash([3, 5]);
+        g.lineDashOffset = 0;
+        g.strokeStyle = `rgba(${pal.text},${depth * (hot ? 0.5 : 0.16)})`;
+        g.lineWidth = 1;
+      }
     } else {
       g.setLineDash([2, 6]);
       g.lineDashOffset = reduced ? 0 : -ts * 0.02;
@@ -497,6 +604,30 @@ function agendaGraphDraw(ts) {
     }
     g.stroke();
     g.setLineDash([]);
+    if (link.t === 'rel' && link.k) {
+      // A typed link reads storer → target: arrowhead at the target
+      // end, the kind labeled at the midpoint while an endpoint is hot.
+      const ang = Math.atan2(b.y - a.y, b.x - a.x);
+      const ax = b.x - Math.cos(ang) * 11;
+      const ay = b.y - Math.sin(ang) * 11;
+      const sz = 3.2 + (hot ? 0.9 : 0);
+      g.beginPath();
+      g.moveTo(ax + Math.cos(ang) * sz, ay + Math.sin(ang) * sz);
+      g.lineTo(ax + Math.cos(ang + 2.5) * sz, ay + Math.sin(ang + 2.5) * sz);
+      g.lineTo(ax + Math.cos(ang - 2.5) * sz, ay + Math.sin(ang - 2.5) * sz);
+      g.closePath();
+      g.fillStyle = `rgba(${pal.text},${depth * (hot ? 0.7 : 0.32)})`;
+      g.fill();
+      if (hot) {
+        g.font = '9px "JetBrains Mono", monospace';
+        g.fillStyle = `rgba(${pal.text},.8)`;
+        g.fillText(
+          link.k.replace(/_/g, ' '),
+          (a.x + b.x) / 2 + 5,
+          (a.y + b.y) / 2 - 5,
+        );
+      }
+    }
   });
   // Nodes far → near.
   const order = nodes.map((n, i) => i).sort((a, b) => pts[b].z - pts[a].z);
@@ -539,6 +670,16 @@ function agendaGraphDraw(ts) {
         (reduced ? 0.65 : 0.45 + 0.4 * Math.sin(ts / 280)) * alpha);
     }
     if (st && st.kind === 'pending') ring(pal.amber, 5.4, 0.75 * alpha);
+    // Territory halo: a dotted outer ring on nodes carrying file/dir
+    // refs — the declared working set made visible.
+    const territory = (item.refs || []).filter(
+      (r) => r.ref_type === 'file' || r.ref_type === 'dir',
+    ).length;
+    if (territory) {
+      g.setLineDash([1.5, 3.2]);
+      ring(pal.text, 7.6, 0.3 * alpha);
+      g.setLineDash([]);
+    }
     if (kids || hot) {
       g.font = `${hot ? '700' : '600'} 11px "Hanken Grotesk", sans-serif`;
       const title = String(item.title || '');
@@ -556,12 +697,34 @@ function agendaGraphDraw(ts) {
       if (hot) {
         g.font = '9.5px "JetBrains Mono", monospace';
         g.fillStyle = pal.t3;
+        const open = agendaGraphProjection === 'hubs'
+          ? 'click to focus'
+          : 'click to open';
         g.fillText(
-          `${item.kind} · ${item.status}${kids ? ` · hub, ${kids} filed` : ''} — click to open`,
+          `${item.kind} · ${item.status}${kids ? ` · hub, ${kids} filed` : ''}${territory ? ` · ${territory} territory` : ''} — ${open}`,
           lx, ly + 13);
       }
     }
   });
+  // Projection badge (painted, inert pixels like every label): what the
+  // constellation is currently showing.
+  if (agendaGraphProjection !== 'all') {
+    const allCount = (agendaItems || []).filter(
+      (x) => x.status !== 'retired',
+    ).length;
+    let badge = '';
+    if (agendaGraphProjection === 'hubs') {
+      badge = `hub overview · ${nodes.length} hubs of ${allCount} items`;
+    } else {
+      const focused = byId.get(agendaGraphFocus);
+      const title = focused ? String(focused.title || '') : '';
+      const short = title.length > 40 ? `${title.slice(0, 39)}…` : title;
+      badge = `focused: ${short} · ${nodes.length} of ${allCount} items`;
+    }
+    g.font = '10px "JetBrains Mono", monospace';
+    g.fillStyle = pal.t3;
+    g.fillText(badge, 14, 64);
+  }
 }
 
 // ---- Wire (the one permanent listener; see the fragment header) ----

--- a/static/app/ui2-agenda-inspector.css
+++ b/static/app/ui2-agenda-inspector.css
@@ -550,6 +550,18 @@ html.ui-v2 .ag2-reladd {
   font-size: 10.5px !important;
   padding: 2px 6px !important;
 }
+html.ui-v2 .ag2-relkind-add {
+  border-radius: var(--r-pill) !important;
+  max-width: 110px;
+  font-size: 10.5px !important;
+  padding: 2px 6px !important;
+}
+html.ui-v2 .ag2-relkind {
+  font-family: var(--mono);
+  font-size: 9px;
+  color: var(--text-3);
+  white-space: nowrap;
+}
 html.ui-v2 .ag2-tagchip {
   display: inline-flex;
   align-items: center;

--- a/static/app/ui2-agenda-inspector.js
+++ b/static/app/ui2-agenda-inspector.js
@@ -21,6 +21,28 @@ let agendaInspAnnDraft = '';
 let agendaInspTagDraft = '';
 let agendaInspRefDraft = '';
 let agendaInspRefMust = false;
+let agendaInspRelKind = '';
+
+// The typed-adjacency vocabulary (G2 `link_kind`) — a static mirror of
+// the daemon's RELATES_TO_LINK_KINDS, pinned by a daemon-side parity
+// test so a vocabulary change that forgets this file fails the suite
+// instead of shipping as drift.
+const AGENDA_REL_KINDS = ['duplicates', 'supersedes', 'follow_up_of', 'evidences'];
+// Reading direction: a typed link reads storer → target ("A supersedes
+// B" lives on A). The passive forms keep the incoming side readable.
+const AGENDA_REL_KIND_LABELS = {
+  duplicates: ['duplicates ▸', '◂ duplicated by'],
+  supersedes: ['supersedes ▸', '◂ superseded by'],
+  follow_up_of: ['follow-up of ▸', '◂ has follow-up'],
+  evidences: ['evidences ▸', '◂ evidenced by'],
+};
+
+function agendaRelKindLabel(kind, outgoing) {
+  const pair = AGENDA_REL_KIND_LABELS[kind];
+  // Unknown kinds (a newer daemon's vocabulary) stay readable as text.
+  if (!pair) return outgoing ? `${kind} ▸` : `◂ ${kind}`;
+  return outgoing ? pair[0] : pair[1];
+}
 
 function agendaOpenInspector(id) {
   const opened = agendaFindItem(id);
@@ -730,14 +752,23 @@ function agendaInspOrganizationHtml(item) {
       const selected = item.part_of && item.part_of.parent_id === x.id ? ' selected' : '';
       return `<option value="${escapeHtml(x.id)}"${selected}>${hub}${escapeHtml(x.title.slice(0, 46))}</option>`;
     }).join('');
-  const partners = agendaRelationPartners(item);
-  const rels = [...partners].map((pid) => {
+  const relEdges = agendaRelationEdges(item);
+  const partners = new Set(relEdges.map((edge) => edge.pid));
+  const rels = relEdges.map(({ pid, kind, outgoing }) => {
     const target = agendaFindItem(pid);
     if (!target) return '';
+    const kindChip = kind
+      ? `<span class="ag2-relkind">${escapeHtml(agendaRelKindLabel(kind, outgoing))}</span>`
+      : '';
     return `<span class="ag2-relchip">
-      <a data-open-item="${escapeHtml(pid)}">${escapeHtml(target.title.slice(0, 34))}</a>
-      <button type="button" class="ag2-x" data-remove-rel="${escapeHtml(pid)}" title="Remove the see-also link (the log keeps history)">×</button>
+      ${kindChip}<a data-open-item="${escapeHtml(pid)}">${escapeHtml(target.title.slice(0, 34))}</a>
+      <button type="button" class="ag2-x" data-remove-rel="${escapeHtml(pid)}" title="Remove the link (the log keeps history; re-add to change its kind)">×</button>
     </span>`;
+  }).join('');
+  const relKindOptions = ['', ...AGENDA_REL_KINDS].map((kind) => {
+    const selected = kind === agendaInspRelKind ? ' selected' : '';
+    const label = kind ? kind.replace(/_/g, ' ') : 'see-also';
+    return `<option value="${kind}"${selected}>${label}</option>`;
   }).join('');
   const relOptions = others
     .filter((x) => !partners.has(x.id))
@@ -762,6 +793,9 @@ function agendaInspOrganizationHtml(item) {
         <span class="ag2-orgk">See also</span>
         <div class="ag2-orgv">
           ${rels}
+          <select class="ag2-relkind-add" data-act-change="rel-kind" aria-label="Link kind (reads this item → target)">
+            ${relKindOptions}
+          </select>
           <select class="ag2-reladd" data-act-change="rel-add" aria-label="Relate to">
             <option value="">+ relate…</option>${relOptions}
           </select>
@@ -1143,10 +1177,18 @@ function agendaInspChange(e) {
     agendaSetItemUrgency(item.id, t.value, t);
   } else if (t.dataset.actChange === 'place') {
     agendaInspPlace(item, t.value, t);
+  } else if (t.dataset.actChange === 'rel-kind') {
+    // Draft only — the link sends when a target is picked.
+    agendaInspRelKind = t.value;
   } else if (t.dataset.actChange === 'rel-add') {
     const v = t.value;
     t.value = '';
-    if (v) agendaSendOp({ op: 'add_relates_to', id: item.id, target_id: v }, t);
+    if (v) {
+      const params = { op: 'add_relates_to', id: item.id, target_id: v };
+      if (agendaInspRelKind) params.link_kind = agendaInspRelKind;
+      agendaInspRelKind = '';
+      agendaSendOp(params, t);
+    }
   } else if (t.dataset.actChange === 'dep-add') {
     const v = t.value;
     if (v) {

--- a/static/app/ui2-agenda.css
+++ b/static/app/ui2-agenda.css
@@ -1036,7 +1036,14 @@ html.ui-v2 .ag2-graph-swatch.s-ring.t-green { border: 1.5px solid var(--green); 
 html.ui-v2 .ag2-graph-swatch.s-line { width: 14px; }
 html.ui-v2 .ag2-graph-swatch.s-line.t-place { border-top: 2px solid rgba(var(--iris-rgb), 0.55); }
 html.ui-v2 .ag2-graph-swatch.s-line.t-rel { border-top: 2px dashed var(--text-3); }
+html.ui-v2 .ag2-graph-swatch.s-line.t-typed { border-top: 2px solid var(--text-2); }
 html.ui-v2 .ag2-graph-swatch.s-line.t-dep { border-top: 2px solid rgba(var(--rose-rgb), 0.6); }
+html.ui-v2 .ag2-graph-swatch.s-ring.t-terr { border: 1.5px dotted var(--text-2); }
+html.ui-v2 .ag2-graph-clear {
+  position: absolute;
+  top: 38px;
+  right: 14px;
+}
 
 /* ---- Upcoming lens (slice C): the 14-day day-grouped timeline. Rows
    ride the shared .ag2-chip family; dots pulse via the shared ui2-pulse

--- a/static/app/ui2-agenda.js
+++ b/static/app/ui2-agenda.js
@@ -783,6 +783,29 @@ function agendaRelationPartners(item) {
   return partners;
 }
 
+// The typed view of the same union: one row per partner with the link's
+// kind and direction from whichever side stores it (a typed link reads
+// storer → target; `outgoing` = this item stores it). Untyped links
+// carry kind ''.
+function agendaRelationEdges(item) {
+  const edges = [];
+  const seen = new Set([item.id]);
+  (item.relates_to || []).forEach((link) => {
+    if (seen.has(link.target_id)) return;
+    seen.add(link.target_id);
+    edges.push({ pid: link.target_id, kind: link.link_kind || '', outgoing: true });
+  });
+  (agendaItems || []).forEach((other) => {
+    if (seen.has(other.id)) return;
+    const link = (other.relates_to || []).find((e) => e.target_id === item.id);
+    if (link) {
+      seen.add(other.id);
+      edges.push({ pid: other.id, kind: link.link_kind || '', outgoing: false });
+    }
+  });
+  return edges;
+}
+
 // Triage-rank convention: the triage mandate writes ordinary annotations
 // with the self-described `triage` source, and a "rank N" phrase in the
 // text is its DECLARED ranking convention. The /rank (\d+)/ parse here is


### PR DESCRIPTION
Slice 5 (P6) of the agenda ontology program (agenda item 01KYT8J44F, design note ~/agenda-ontology-next.md): the Graph lens becomes a small projection library over the same served fold — owner-clarified direction (richer views à la Station's constellation/orbit; anti-hiding is orthogonal, it only forbids placement from subtracting).

- **Hub focus**: double-click a hub (or click one in the overview) to project its placed subtree; painted focus badge, static 'show all' button, double-click empty space to clear. A focus whose item leaves the ledger clears itself.
- **Over-cap degradation becomes functional**: past the 180-node cap the refusal is replaced by a hub-overview projection (only items with children) — click a hub to focus. The ratified cap still bounds every projection; the refusal remains for over-cap flat ledgers and over-cap subtrees.
- **Typed edges** (#685 vocabulary): typed see-also links draw solid with an arrowhead at the target end (storer → target reading), kind labeled at the midpoint on hover; untyped stay dashed. Legend gains 'typed →'.
- **Territory halos** (#686/#688): nodes carrying file/dir refs get a dotted outer ring; hover subtitle counts territory. Legend gains 'territory'.
- **Inspector**: relation chips label kind + direction (passive forms for incoming); a kind picker joins the relate control (draft-state, sends link_kind); unknown future kinds render as text.
- **Parity pin**: `relates_link_kind_vocabulary_is_pinned_in_app_html` derives the expected frontend mirror from `RELATES_TO_LINK_KINDS` (order included) — vocabulary drift fails the suite.
- Ruled constraints preserved: canvas stays an aria-hidden decorative projection with card-lens parity; item text is fillText-only; zero-background-frame lifecycle untouched; reduced-motion behavior unchanged.

Battery: bins 5278 (+1 parity) + 150 + 97 pass, lib crates pass, workspace clippy -D warnings clean, node --check on all three fragments, app.html regenerated via the assembler.