### PR TITLE
agenda graph: visible projection switcher + territory satellite projection

### DIFF
--- a/static/app.html
+++ b/static/app.html
@@ -24552,10 +24552,50 @@ html.ui-v2 .ag2-graph-swatch.s-line.t-rel { border-top: 2px dashed var(--text-3)
 html.ui-v2 .ag2-graph-swatch.s-line.t-typed { border-top: 2px solid var(--text-2); }
 html.ui-v2 .ag2-graph-swatch.s-line.t-dep { border-top: 2px solid rgba(var(--rose-rgb), 0.6); }
 html.ui-v2 .ag2-graph-swatch.s-ring.t-terr { border: 1.5px dotted var(--text-2); }
-html.ui-v2 .ag2-graph-clear {
+html.ui-v2 .ag2-graph-swatch.s-sq { width: 7px; height: 7px; }
+html.ui-v2 .ag2-graph-swatch.s-sq.t-file { background: var(--text-3); }
+html.ui-v2 .ag2-graph-swatch.s-sq.t-dir {
+  border: 1.5px solid var(--text-2);
+  box-sizing: border-box;
+}
+html.ui-v2 .ag2-graph-projrow {
   position: absolute;
   top: 38px;
   right: 14px;
+  display: flex;
+  gap: 5px;
+}
+html.ui-v2 .ag2-graph-projchip {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  color: var(--text-3);
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--r-pill);
+  padding: 2px 9px;
+  cursor: pointer;
+}
+html.ui-v2 .ag2-graph-projchip:hover:not(:disabled) { color: var(--text); }
+html.ui-v2 .ag2-graph-projchip.active {
+  color: var(--iris);
+  border-color: var(--iris);
+}
+html.ui-v2 .ag2-graph-projchip:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+html.ui-v2 .ag2-graph-capnote {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text-3);
+  pointer-events: none;
+  padding: 0 40px;
+  text-align: center;
 }
 
 /* ---- Upcoming lens (slice C): the 14-day day-grouped timeline. Rows
@@ -37706,7 +37746,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'b22f92800244a141';
+const INTENDANT_APP_BUILD = '6fcbd38244a182bc';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -98089,11 +98129,17 @@ let agendaGraphCanvasHooks = null;
 let agendaGraphPaneObserver = null;
 let agendaGraphAutoTimer = null;
 let agendaGraphCam = { yaw: 0.6, pitch: -0.34, auto: true };
-// Projection state: 'all' (whole non-retired ledger), 'hubs' (the
-// over-cap hub overview), 'focus' (one hub's placed subtree). The render
-// pass decides the projection; build/draw only read it.
+// Projection state: 'all' (whole non-retired ledger), 'hubs' (the hub
+// overview — automatic past the node cap, or chosen), 'focus' (one
+// hub's placed subtree). The render pass decides the projection from
+// the chip row + focus + cap; build/draw only read it. `territory`
+// overlays derived file/dir satellite nodes on the 'all'/'focus' pools.
 let agendaGraphFocus = null;
 let agendaGraphProjection = 'all';
+let agendaGraphChosen = null; // null = auto ('hubs' past the cap, else 'all')
+let agendaGraphTerritory = false;
+let agendaGraphSubtreeTerr = new Map();
+let agendaGraphTerrStats = { shown: 0, total: 0 };
 let agendaGraphMouse = { x: -1e4, y: -1e4, down: false, moved: 0 };
 let agendaGraphHover = null;
 let agendaGraphPalCache = null;
@@ -98151,17 +98197,29 @@ function agendaGraphProjectionItems() {
 // ---- Lens surface (the AGENDA_LENSES render/deactivate pair) ----
 
 function agendaGraphRenderLens(host) {
-  // Pick the projection: focused subtree when a focus is set; the whole
-  // ledger under the cap; past the cap, degrade to the hub overview
-  // (the ratified cap still bounds every projection — the O(n²)
-  // relaxation and the label field stop earning their keep beyond it).
+  // Resolve the projection: an explicit chip choice wins; focus
+  // overrides the pool; auto degrades an over-cap ledger to the hub
+  // overview (the ratified cap still bounds every projection — the
+  // O(n²) relaxation and the label field stop earning their keep
+  // beyond it).
   let items = agendaGraphPoolItems();
-  agendaGraphProjection = agendaGraphFocus ? 'focus' : 'all';
-  if (!agendaGraphFocus && items.length > AGENDA_GRAPH_NODE_CAP) {
-    const hubs = agendaGraphHubOverviewItems(items);
-    if (hubs.length && hubs.length <= AGENDA_GRAPH_NODE_CAP) {
-      items = hubs;
-      agendaGraphProjection = 'hubs';
+  let overCapAll = false;
+  if (agendaGraphFocus) {
+    agendaGraphProjection = 'focus';
+  } else {
+    const wantHubs = agendaGraphChosen === 'hubs'
+      || (agendaGraphChosen !== 'all' && items.length > AGENDA_GRAPH_NODE_CAP);
+    agendaGraphProjection = 'all';
+    if (wantHubs) {
+      const hubs = agendaGraphHubOverviewItems(items);
+      if (hubs.length && hubs.length <= AGENDA_GRAPH_NODE_CAP) {
+        items = hubs;
+        agendaGraphProjection = 'hubs';
+      }
+    } else if (agendaGraphChosen === 'all' && items.length > AGENDA_GRAPH_NODE_CAP) {
+      // The owner explicitly asked for Everything past the cap: keep
+      // the panel and its chips, park the canvas, say why.
+      overCapAll = true;
     }
   }
   if (!items.length) {
@@ -98173,16 +98231,15 @@ function agendaGraphRenderLens(host) {
     </div>`;
     return;
   }
-  if (items.length > AGENDA_GRAPH_NODE_CAP) {
+  if (!overCapAll && items.length > AGENDA_GRAPH_NODE_CAP) {
+    // A focused subtree past the cap has no cheaper projection to
+    // degrade to — the flat refusal names the way out.
     agendaGraphTeardown();
-    const hint = agendaGraphFocus
-      ? 'This subtree exceeds the cap — focus a narrower hub, or use By hub.'
-      : 'Use By hub for large flat ledgers.';
     host.innerHTML = `<div class="ag2-graph-panel empty">
       <div class="ag2-empty">
         <div class="ag2-empty-glyph">◍</div>
         <div class="ag2-empty-title">The constellation caps at ${AGENDA_GRAPH_NODE_CAP} items</div>
-        <div class="ag2-empty-hint">${hint}</div>
+        <div class="ag2-empty-hint">This subtree exceeds the cap — focus a narrower hub, or use By hub.</div>
       </div>
     </div>`;
     return;
@@ -98192,25 +98249,77 @@ function agendaGraphRenderLens(host) {
     host.innerHTML = agendaGraphPanelHtml();
     canvas = host.querySelector('#ag2-graph-canvas');
   }
-  // Per-projection static chrome: hint text and the clear-focus button.
-  const hintLine = host.querySelector('#ag2-graph-hint');
-  if (hintLine) {
-    hintLine.textContent = agendaGraphProjection === 'hubs'
-      ? 'hub overview — click a hub to focus its subtree'
-      : agendaGraphProjection === 'focus'
-        ? 'focused subtree — double-click empty space to clear'
-        : 'drag to orbit · click a node to open it · double-click a hub to focus';
-  }
-  const clear = host.querySelector('#ag2-graph-clear');
-  if (clear) {
-    clear.hidden = !agendaGraphFocus;
-    clear.onclick = () => {
-      agendaGraphFocus = null;
-      agendaRenderTab();
-    };
+  agendaGraphWireChrome(host, overCapAll);
+  if (overCapAll) {
+    agendaGraphTeardown();
+    return;
   }
   agendaGraphBindCanvas(canvas);
   agendaGraphEnsureLoop();
+}
+
+// Per-projection static chrome: the projection chip row, the cap note,
+// and the hint line. Static strings only — no item text ever lands in
+// this markup (the painted badge carries titles as inert pixels).
+function agendaGraphWireChrome(host, overCapAll) {
+  const hintLine = host.querySelector('#ag2-graph-hint');
+  if (hintLine) {
+    hintLine.textContent = overCapAll
+      ? 'everything exceeds the cap — pick hubs, or focus one hub'
+      : agendaGraphProjection === 'hubs'
+        ? 'hub overview — click a hub to focus its subtree'
+        : agendaGraphProjection === 'focus'
+          ? (agendaGraphTerritory
+            ? 'focused territory — squares are files/dirs; click one to open its newest carrier'
+            : 'focused subtree — double-click empty space to clear')
+          : 'drag to orbit · click a node to open it · double-click a hub to focus';
+  }
+  const note = host.querySelector('#ag2-graph-capnote');
+  if (note) note.hidden = !overCapAll;
+  const inHubs = !overCapAll && agendaGraphProjection === 'hubs';
+  const chips = host.querySelectorAll('.ag2-graph-projchip');
+  chips.forEach((chip) => {
+    const kind = chip.dataset.proj;
+    if (kind === 'hubs') {
+      chip.classList.toggle('active', inHubs);
+      chip.disabled = false;
+      chip.title = 'only the hubs — click one to focus its subtree';
+      chip.onclick = () => {
+        agendaGraphChosen = 'hubs';
+        agendaGraphFocus = null;
+        agendaRenderTab();
+      };
+    } else if (kind === 'all') {
+      chip.classList.toggle('active', overCapAll
+        || (!inHubs && agendaGraphProjection === 'all'));
+      chip.disabled = false;
+      chip.title = 'every non-retired item (bounded by the node cap)';
+      chip.onclick = () => {
+        agendaGraphChosen = 'all';
+        agendaGraphFocus = null;
+        agendaRenderTab();
+      };
+    } else if (kind === 'terr') {
+      chip.classList.toggle('active', agendaGraphTerritory && !inHubs);
+      chip.disabled = inHubs || overCapAll;
+      chip.title = inHubs
+        ? 'territory needs a concrete pool — focus a hub or pick everything'
+        : 'overlay file/dir satellites from the pool’s refs';
+      chip.onclick = () => {
+        agendaGraphTerritory = !agendaGraphTerritory;
+        agendaRenderTab();
+      };
+    } else if (kind === 'clearfocus') {
+      chip.hidden = !agendaGraphFocus;
+      chip.classList.add('active');
+      chip.disabled = false;
+      chip.title = 'clear the focused hub';
+      chip.onclick = () => {
+        agendaGraphFocus = null;
+        agendaRenderTab();
+      };
+    }
+  });
 }
 
 function agendaGraphLegendChip(swatchClass, label) {
@@ -98228,7 +98337,15 @@ function agendaGraphPanelHtml() {
       <div class="ag2-graph-eyebrow-sub">placement · adjacency · dependencies</div>
     </div>
     <div class="ag2-graph-hint" id="ag2-graph-hint">drag to orbit · click a node to open it</div>
-    <button type="button" class="ag2-dashbtn ag2-graph-clear" id="ag2-graph-clear" hidden>show all</button>
+    <div class="ag2-graph-projrow">
+      <button type="button" class="ag2-graph-projchip" data-proj="hubs">hubs</button>
+      <button type="button" class="ag2-graph-projchip" data-proj="all">everything</button>
+      <button type="button" class="ag2-graph-projchip" data-proj="terr">territory</button>
+      <button type="button" class="ag2-graph-projchip" data-proj="clearfocus" hidden>focused ✕</button>
+    </div>
+    <div class="ag2-graph-capnote" id="ag2-graph-capnote" hidden>
+      past the ${AGENDA_GRAPH_NODE_CAP}-node cap — the hubs projection or a focused hub keeps the map legible
+    </div>
     <div class="ag2-graph-legend">
       ${agendaGraphLegendChip('s-dot t-iris', 'open')}
       ${agendaGraphLegendChip('s-dot t-amber', 'question')}
@@ -98236,6 +98353,8 @@ function agendaGraphPanelHtml() {
       ${agendaGraphLegendChip('s-ring t-rose', 'blocked')}
       ${agendaGraphLegendChip('s-ring t-green', 'standing run')}
       ${agendaGraphLegendChip('s-ring t-terr', 'territory')}
+      ${agendaGraphLegendChip('s-sq t-file', 'file')}
+      ${agendaGraphLegendChip('s-sq t-dir', 'dir')}
       ${agendaGraphLegendChip('s-line t-place', 'filed under')}
       ${agendaGraphLegendChip('s-line t-rel', 'see-also')}
       ${agendaGraphLegendChip('s-line t-typed', 'typed →')}
@@ -98280,7 +98399,14 @@ function agendaGraphBindCanvas(canvas) {
       // overview a click focuses the hub's subtree; everywhere else it
       // opens the node in the slice-A inspector.
       if (m.down && m.moved < 6 && agendaGraphHover) {
-        if (agendaGraphProjection === 'hubs') {
+        const satNode = agendaGraphHover.startsWith('terr|')
+          ? agendaGraphNodes.find((n) => n.id === agendaGraphHover)
+          : null;
+        if (satNode && satNode.sat) {
+          // Satellites are view-materialized, not store items: the
+          // click opens the newest carrying item.
+          agendaOpenInspector(satNode.sat.carrier);
+        } else if (agendaGraphProjection === 'hubs') {
           agendaGraphFocus = agendaGraphHover;
           agendaRenderTab();
         } else {
@@ -98409,7 +98535,70 @@ function agendaGraphTeardown() {
 // shape relaxes in over the following frames.
 function agendaGraphBuild() {
   const items = agendaGraphProjectionItems();
-  const key = `${agendaGraphProjection}|${agendaGraphFocus || ''};` + items.map((x) => [
+  // Territory satellites: one node per distinct file/dir locator across
+  // the pool's refs (DECLARED territory; observed affinity joins later
+  // via the gardener), newest attach first, capped into the node-cap
+  // room so items + satellites never exceed the ratified bound.
+  const territoryOn = agendaGraphTerritory && agendaGraphProjection !== 'hubs';
+  let satellites = [];
+  if (territoryOn) {
+    const best = new Map();
+    items.forEach((x) => (x.refs || []).forEach((r) => {
+      if (r.ref_type !== 'file' && r.ref_type !== 'dir') return;
+      const skey = `${r.ref_type}:${r.locator}`;
+      let entry = best.get(skey);
+      if (!entry) {
+        entry = {
+          key: skey, t: r.ref_type, locator: r.locator,
+          newest: 0, carrier: x.id, owners: [],
+        };
+        best.set(skey, entry);
+      }
+      entry.owners.push(x.id);
+      if ((r.added_ms || 0) >= entry.newest) {
+        entry.newest = r.added_ms || 0;
+        entry.carrier = x.id;
+      }
+    }));
+    const room = Math.max(0, AGENDA_GRAPH_NODE_CAP - items.length);
+    const all = [...best.values()].sort((a, b) =>
+      b.newest - a.newest || (a.locator < b.locator ? -1 : 1));
+    satellites = all.slice(0, Math.min(60, room));
+    agendaGraphTerrStats = { shown: satellites.length, total: all.length };
+  } else {
+    agendaGraphTerrStats = { shown: 0, total: 0 };
+  }
+  // Hub overview: halo hubs by their SUBTREE's declared territory — a
+  // client-side walk over the full pool (no daemon change), so the map
+  // shows where the files live before diving in.
+  agendaGraphSubtreeTerr = new Map();
+  if (agendaGraphProjection === 'hubs') {
+    const pool = agendaGraphPoolItems();
+    const kids = new Map();
+    pool.forEach((x) => {
+      if (x.part_of) {
+        const list = kids.get(x.part_of.parent_id) || [];
+        list.push(x.id);
+        kids.set(x.part_of.parent_id, list);
+      }
+    });
+    const own = new Map(pool.map((x) => [x.id,
+      (x.refs || []).filter((r) => r.ref_type === 'file' || r.ref_type === 'dir').length]));
+    items.forEach((hub) => {
+      let sum = 0;
+      const seen = new Set();
+      const queue = [hub.id];
+      while (queue.length) {
+        const id = queue.pop();
+        if (seen.has(id)) continue;
+        seen.add(id);
+        sum += own.get(id) || 0;
+        (kids.get(id) || []).forEach((k) => queue.push(k));
+      }
+      agendaGraphSubtreeTerr.set(hub.id, sum);
+    });
+  }
+  const key = `${agendaGraphProjection}|${agendaGraphFocus || ''}|terr:${satellites.map((s) => s.key).join(',')};` + items.map((x) => [
     x.id,
     x.status,
     x.part_of ? x.part_of.parent_id : '',
@@ -98432,6 +98621,22 @@ function agendaGraphBuild() {
     };
   });
   const idx = new Map(agendaGraphNodes.map((n, i) => [n.id, i]));
+  satellites.forEach((sat, i) => {
+    const nodeId = `terr|${sat.key}`;
+    const near = idx.get(sat.carrier);
+    const base = near !== undefined ? agendaGraphNodes[near].p : [0, 0, 0];
+    const a = i * 1.7;
+    agendaGraphNodes.push({
+      id: nodeId,
+      sat,
+      p: previous.get(nodeId) || [
+        base[0] + Math.cos(a) * 26,
+        base[1] + (Math.random() - 0.5) * 22,
+        base[2] + Math.sin(a) * 26,
+      ],
+    });
+    idx.set(nodeId, agendaGraphNodes.length - 1);
+  });
   const links = [];
   const seenRel = new Set();
   items.forEach((x) => {
@@ -98457,6 +98662,12 @@ function agendaGraphBuild() {
         t: 'rel',
         k: link.link_kind || null,
       });
+    });
+  });
+  satellites.forEach((sat) => {
+    const b = idx.get(`terr|${sat.key}`);
+    sat.owners.forEach((owner) => {
+      if (idx.has(owner)) links.push({ a: idx.get(owner), b, t: 'terr' });
     });
   });
   agendaGraphLinks = links;
@@ -98494,8 +98705,10 @@ function agendaGraphRelax(iterations) {
     links.forEach((link) => {
       const A = nodes[link.a].p;
       const B = nodes[link.b].p;
-      const rest = link.t === 'place' ? 74 : link.t === 'dep' ? 96 : 116;
-      const k = link.t === 'place' ? 0.014 : 0.007;
+      const rest = link.t === 'place' ? 74
+        : link.t === 'terr' ? 52
+          : link.t === 'dep' ? 96 : 116;
+      const k = link.t === 'place' ? 0.014 : link.t === 'terr' ? 0.012 : 0.007;
       const dx = B[0] - A[0];
       const dy = B[1] - A[1];
       const dz = B[2] - A[2];
@@ -98531,6 +98744,34 @@ function agendaGraphPalette() {
     agendaGraphPalAt = now;
   }
   return agendaGraphPalCache;
+}
+
+// One territory satellite: a small square (dirs slightly larger), the
+// basename labeled while hot, full locator + carrier count on the
+// subtitle. Locators are data — fillText only, inert pixels.
+function agendaGraphDrawSatellite(g, node, q, hot, pal, w) {
+  const sat = node.sat;
+  const size = (sat.t === 'dir' ? 3.4 : 2.6) * q.s + (hot ? 0.9 : 0);
+  const alpha = Math.max(0.3, Math.min(0.85, q.s * 1.05 - 0.1));
+  g.beginPath();
+  g.rect(q.x - size, q.y - size, size * 2, size * 2);
+  g.fillStyle = `rgba(${pal.text},${alpha * (hot ? 0.85 : 0.45)})`;
+  g.fill();
+  if (hot) {
+    const name = sat.locator.replace(/\/+$/, '').split('/').pop() || sat.locator;
+    const label = sat.t === 'dir' ? `${name}/` : name;
+    g.font = '700 10px "JetBrains Mono", monospace';
+    const tw = g.measureText(label).width;
+    let lx = q.x + size + 7;
+    if (lx + tw > w - 10) lx = q.x - size - 7 - tw;
+    g.fillStyle = `rgba(${pal.text},.95)`;
+    g.fillText(label, lx, q.y + 3.5);
+    g.font = '9px "JetBrains Mono", monospace';
+    g.fillStyle = pal.t3;
+    g.fillText(
+      `${sat.locator} · ${sat.owners.length} item${sat.owners.length === 1 ? '' : 's'} — click opens newest carrier`,
+      lx, q.y + 16);
+  }
 }
 
 // ---- Draw (3D-ish projection, hover picking, rings, labels) ----
@@ -98625,6 +98866,11 @@ function agendaGraphDraw(ts) {
       g.setLineDash([]);
       g.strokeStyle = `rgba(${pal.iris},${depth * (hot ? 0.75 : 0.38)})`;
       g.lineWidth = hot ? 1.6 : 1.1;
+    } else if (link.t === 'terr') {
+      g.setLineDash([1.5, 3.5]);
+      g.lineDashOffset = 0;
+      g.strokeStyle = `rgba(${pal.text},${depth * (hot ? 0.45 : 0.14)})`;
+      g.lineWidth = 1;
     } else if (link.t === 'rel') {
       if (link.k) {
         // Typed adjacency: solid and slightly stronger than see-also.
@@ -98675,6 +98921,10 @@ function agendaGraphDraw(ts) {
   order.forEach((i) => {
     const node = nodes[i];
     const q = pts[i];
+    if (node.sat) {
+      agendaGraphDrawSatellite(g, node, q, hover === node.id, pal, w);
+      return;
+    }
     const item = byId.get(node.id);
     if (!item) return;
     const kids = childCount.get(node.id) || 0;
@@ -98713,9 +98963,11 @@ function agendaGraphDraw(ts) {
     if (st && st.kind === 'pending') ring(pal.amber, 5.4, 0.75 * alpha);
     // Territory halo: a dotted outer ring on nodes carrying file/dir
     // refs — the declared working set made visible.
-    const territory = (item.refs || []).filter(
-      (r) => r.ref_type === 'file' || r.ref_type === 'dir',
-    ).length;
+    const territory = agendaGraphProjection === 'hubs'
+      ? agendaGraphSubtreeTerr.get(node.id) || 0
+      : (item.refs || []).filter(
+        (r) => r.ref_type === 'file' || r.ref_type === 'dir',
+      ).length;
     if (territory) {
       g.setLineDash([1.5, 3.2]);
       ring(pal.text, 7.6, 0.3 * alpha);
@@ -98749,22 +99001,28 @@ function agendaGraphDraw(ts) {
   });
   // Projection badge (painted, inert pixels like every label): what the
   // constellation is currently showing.
-  if (agendaGraphProjection !== 'all') {
+  const terrBadge = agendaGraphTerrStats.shown
+    ? ` · territory ${agendaGraphTerrStats.shown}${agendaGraphTerrStats.total > agendaGraphTerrStats.shown ? ` of ${agendaGraphTerrStats.total}` : ''}`
+    : '';
+  if (agendaGraphProjection !== 'all' || terrBadge) {
     const allCount = (agendaItems || []).filter(
       (x) => x.status !== 'retired',
     ).length;
+    const itemCount = nodes.filter((n) => !n.sat).length;
     let badge = '';
     if (agendaGraphProjection === 'hubs') {
-      badge = `hub overview · ${nodes.length} hubs of ${allCount} items`;
-    } else {
+      badge = `hub overview · ${itemCount} hubs of ${allCount} items`;
+    } else if (agendaGraphProjection === 'focus') {
       const focused = byId.get(agendaGraphFocus);
       const title = focused ? String(focused.title || '') : '';
       const short = title.length > 40 ? `${title.slice(0, 39)}…` : title;
-      badge = `focused: ${short} · ${nodes.length} of ${allCount} items`;
+      badge = `focused: ${short} · ${itemCount} of ${allCount} items`;
+    } else {
+      badge = `everything · ${itemCount} items`;
     }
     g.font = '10px "JetBrains Mono", monospace';
     g.fillStyle = pal.t3;
-    g.fillText(badge, 14, 64);
+    g.fillText(badge + terrBadge, 14, 64);
   }
 }
 

--- a/static/app/ui2-agenda-graph.js
+++ b/static/app/ui2-agenda-graph.js
@@ -48,11 +48,17 @@ let agendaGraphCanvasHooks = null;
 let agendaGraphPaneObserver = null;
 let agendaGraphAutoTimer = null;
 let agendaGraphCam = { yaw: 0.6, pitch: -0.34, auto: true };
-// Projection state: 'all' (whole non-retired ledger), 'hubs' (the
-// over-cap hub overview), 'focus' (one hub's placed subtree). The render
-// pass decides the projection; build/draw only read it.
+// Projection state: 'all' (whole non-retired ledger), 'hubs' (the hub
+// overview — automatic past the node cap, or chosen), 'focus' (one
+// hub's placed subtree). The render pass decides the projection from
+// the chip row + focus + cap; build/draw only read it. `territory`
+// overlays derived file/dir satellite nodes on the 'all'/'focus' pools.
 let agendaGraphFocus = null;
 let agendaGraphProjection = 'all';
+let agendaGraphChosen = null; // null = auto ('hubs' past the cap, else 'all')
+let agendaGraphTerritory = false;
+let agendaGraphSubtreeTerr = new Map();
+let agendaGraphTerrStats = { shown: 0, total: 0 };
 let agendaGraphMouse = { x: -1e4, y: -1e4, down: false, moved: 0 };
 let agendaGraphHover = null;
 let agendaGraphPalCache = null;
@@ -110,17 +116,29 @@ function agendaGraphProjectionItems() {
 // ---- Lens surface (the AGENDA_LENSES render/deactivate pair) ----
 
 function agendaGraphRenderLens(host) {
-  // Pick the projection: focused subtree when a focus is set; the whole
-  // ledger under the cap; past the cap, degrade to the hub overview
-  // (the ratified cap still bounds every projection — the O(n²)
-  // relaxation and the label field stop earning their keep beyond it).
+  // Resolve the projection: an explicit chip choice wins; focus
+  // overrides the pool; auto degrades an over-cap ledger to the hub
+  // overview (the ratified cap still bounds every projection — the
+  // O(n²) relaxation and the label field stop earning their keep
+  // beyond it).
   let items = agendaGraphPoolItems();
-  agendaGraphProjection = agendaGraphFocus ? 'focus' : 'all';
-  if (!agendaGraphFocus && items.length > AGENDA_GRAPH_NODE_CAP) {
-    const hubs = agendaGraphHubOverviewItems(items);
-    if (hubs.length && hubs.length <= AGENDA_GRAPH_NODE_CAP) {
-      items = hubs;
-      agendaGraphProjection = 'hubs';
+  let overCapAll = false;
+  if (agendaGraphFocus) {
+    agendaGraphProjection = 'focus';
+  } else {
+    const wantHubs = agendaGraphChosen === 'hubs'
+      || (agendaGraphChosen !== 'all' && items.length > AGENDA_GRAPH_NODE_CAP);
+    agendaGraphProjection = 'all';
+    if (wantHubs) {
+      const hubs = agendaGraphHubOverviewItems(items);
+      if (hubs.length && hubs.length <= AGENDA_GRAPH_NODE_CAP) {
+        items = hubs;
+        agendaGraphProjection = 'hubs';
+      }
+    } else if (agendaGraphChosen === 'all' && items.length > AGENDA_GRAPH_NODE_CAP) {
+      // The owner explicitly asked for Everything past the cap: keep
+      // the panel and its chips, park the canvas, say why.
+      overCapAll = true;
     }
   }
   if (!items.length) {
@@ -132,16 +150,15 @@ function agendaGraphRenderLens(host) {
     </div>`;
     return;
   }
-  if (items.length > AGENDA_GRAPH_NODE_CAP) {
+  if (!overCapAll && items.length > AGENDA_GRAPH_NODE_CAP) {
+    // A focused subtree past the cap has no cheaper projection to
+    // degrade to — the flat refusal names the way out.
     agendaGraphTeardown();
-    const hint = agendaGraphFocus
-      ? 'This subtree exceeds the cap — focus a narrower hub, or use By hub.'
-      : 'Use By hub for large flat ledgers.';
     host.innerHTML = `<div class="ag2-graph-panel empty">
       <div class="ag2-empty">
         <div class="ag2-empty-glyph">◍</div>
         <div class="ag2-empty-title">The constellation caps at ${AGENDA_GRAPH_NODE_CAP} items</div>
-        <div class="ag2-empty-hint">${hint}</div>
+        <div class="ag2-empty-hint">This subtree exceeds the cap — focus a narrower hub, or use By hub.</div>
       </div>
     </div>`;
     return;
@@ -151,25 +168,77 @@ function agendaGraphRenderLens(host) {
     host.innerHTML = agendaGraphPanelHtml();
     canvas = host.querySelector('#ag2-graph-canvas');
   }
-  // Per-projection static chrome: hint text and the clear-focus button.
-  const hintLine = host.querySelector('#ag2-graph-hint');
-  if (hintLine) {
-    hintLine.textContent = agendaGraphProjection === 'hubs'
-      ? 'hub overview — click a hub to focus its subtree'
-      : agendaGraphProjection === 'focus'
-        ? 'focused subtree — double-click empty space to clear'
-        : 'drag to orbit · click a node to open it · double-click a hub to focus';
-  }
-  const clear = host.querySelector('#ag2-graph-clear');
-  if (clear) {
-    clear.hidden = !agendaGraphFocus;
-    clear.onclick = () => {
-      agendaGraphFocus = null;
-      agendaRenderTab();
-    };
+  agendaGraphWireChrome(host, overCapAll);
+  if (overCapAll) {
+    agendaGraphTeardown();
+    return;
   }
   agendaGraphBindCanvas(canvas);
   agendaGraphEnsureLoop();
+}
+
+// Per-projection static chrome: the projection chip row, the cap note,
+// and the hint line. Static strings only — no item text ever lands in
+// this markup (the painted badge carries titles as inert pixels).
+function agendaGraphWireChrome(host, overCapAll) {
+  const hintLine = host.querySelector('#ag2-graph-hint');
+  if (hintLine) {
+    hintLine.textContent = overCapAll
+      ? 'everything exceeds the cap — pick hubs, or focus one hub'
+      : agendaGraphProjection === 'hubs'
+        ? 'hub overview — click a hub to focus its subtree'
+        : agendaGraphProjection === 'focus'
+          ? (agendaGraphTerritory
+            ? 'focused territory — squares are files/dirs; click one to open its newest carrier'
+            : 'focused subtree — double-click empty space to clear')
+          : 'drag to orbit · click a node to open it · double-click a hub to focus';
+  }
+  const note = host.querySelector('#ag2-graph-capnote');
+  if (note) note.hidden = !overCapAll;
+  const inHubs = !overCapAll && agendaGraphProjection === 'hubs';
+  const chips = host.querySelectorAll('.ag2-graph-projchip');
+  chips.forEach((chip) => {
+    const kind = chip.dataset.proj;
+    if (kind === 'hubs') {
+      chip.classList.toggle('active', inHubs);
+      chip.disabled = false;
+      chip.title = 'only the hubs — click one to focus its subtree';
+      chip.onclick = () => {
+        agendaGraphChosen = 'hubs';
+        agendaGraphFocus = null;
+        agendaRenderTab();
+      };
+    } else if (kind === 'all') {
+      chip.classList.toggle('active', overCapAll
+        || (!inHubs && agendaGraphProjection === 'all'));
+      chip.disabled = false;
+      chip.title = 'every non-retired item (bounded by the node cap)';
+      chip.onclick = () => {
+        agendaGraphChosen = 'all';
+        agendaGraphFocus = null;
+        agendaRenderTab();
+      };
+    } else if (kind === 'terr') {
+      chip.classList.toggle('active', agendaGraphTerritory && !inHubs);
+      chip.disabled = inHubs || overCapAll;
+      chip.title = inHubs
+        ? 'territory needs a concrete pool — focus a hub or pick everything'
+        : 'overlay file/dir satellites from the pool’s refs';
+      chip.onclick = () => {
+        agendaGraphTerritory = !agendaGraphTerritory;
+        agendaRenderTab();
+      };
+    } else if (kind === 'clearfocus') {
+      chip.hidden = !agendaGraphFocus;
+      chip.classList.add('active');
+      chip.disabled = false;
+      chip.title = 'clear the focused hub';
+      chip.onclick = () => {
+        agendaGraphFocus = null;
+        agendaRenderTab();
+      };
+    }
+  });
 }
 
 function agendaGraphLegendChip(swatchClass, label) {
@@ -187,7 +256,15 @@ function agendaGraphPanelHtml() {
       <div class="ag2-graph-eyebrow-sub">placement · adjacency · dependencies</div>
     </div>
     <div class="ag2-graph-hint" id="ag2-graph-hint">drag to orbit · click a node to open it</div>
-    <button type="button" class="ag2-dashbtn ag2-graph-clear" id="ag2-graph-clear" hidden>show all</button>
+    <div class="ag2-graph-projrow">
+      <button type="button" class="ag2-graph-projchip" data-proj="hubs">hubs</button>
+      <button type="button" class="ag2-graph-projchip" data-proj="all">everything</button>
+      <button type="button" class="ag2-graph-projchip" data-proj="terr">territory</button>
+      <button type="button" class="ag2-graph-projchip" data-proj="clearfocus" hidden>focused ✕</button>
+    </div>
+    <div class="ag2-graph-capnote" id="ag2-graph-capnote" hidden>
+      past the ${AGENDA_GRAPH_NODE_CAP}-node cap — the hubs projection or a focused hub keeps the map legible
+    </div>
     <div class="ag2-graph-legend">
       ${agendaGraphLegendChip('s-dot t-iris', 'open')}
       ${agendaGraphLegendChip('s-dot t-amber', 'question')}
@@ -195,6 +272,8 @@ function agendaGraphPanelHtml() {
       ${agendaGraphLegendChip('s-ring t-rose', 'blocked')}
       ${agendaGraphLegendChip('s-ring t-green', 'standing run')}
       ${agendaGraphLegendChip('s-ring t-terr', 'territory')}
+      ${agendaGraphLegendChip('s-sq t-file', 'file')}
+      ${agendaGraphLegendChip('s-sq t-dir', 'dir')}
       ${agendaGraphLegendChip('s-line t-place', 'filed under')}
       ${agendaGraphLegendChip('s-line t-rel', 'see-also')}
       ${agendaGraphLegendChip('s-line t-typed', 'typed →')}
@@ -239,7 +318,14 @@ function agendaGraphBindCanvas(canvas) {
       // overview a click focuses the hub's subtree; everywhere else it
       // opens the node in the slice-A inspector.
       if (m.down && m.moved < 6 && agendaGraphHover) {
-        if (agendaGraphProjection === 'hubs') {
+        const satNode = agendaGraphHover.startsWith('terr|')
+          ? agendaGraphNodes.find((n) => n.id === agendaGraphHover)
+          : null;
+        if (satNode && satNode.sat) {
+          // Satellites are view-materialized, not store items: the
+          // click opens the newest carrying item.
+          agendaOpenInspector(satNode.sat.carrier);
+        } else if (agendaGraphProjection === 'hubs') {
           agendaGraphFocus = agendaGraphHover;
           agendaRenderTab();
         } else {
@@ -368,7 +454,70 @@ function agendaGraphTeardown() {
 // shape relaxes in over the following frames.
 function agendaGraphBuild() {
   const items = agendaGraphProjectionItems();
-  const key = `${agendaGraphProjection}|${agendaGraphFocus || ''};` + items.map((x) => [
+  // Territory satellites: one node per distinct file/dir locator across
+  // the pool's refs (DECLARED territory; observed affinity joins later
+  // via the gardener), newest attach first, capped into the node-cap
+  // room so items + satellites never exceed the ratified bound.
+  const territoryOn = agendaGraphTerritory && agendaGraphProjection !== 'hubs';
+  let satellites = [];
+  if (territoryOn) {
+    const best = new Map();
+    items.forEach((x) => (x.refs || []).forEach((r) => {
+      if (r.ref_type !== 'file' && r.ref_type !== 'dir') return;
+      const skey = `${r.ref_type}:${r.locator}`;
+      let entry = best.get(skey);
+      if (!entry) {
+        entry = {
+          key: skey, t: r.ref_type, locator: r.locator,
+          newest: 0, carrier: x.id, owners: [],
+        };
+        best.set(skey, entry);
+      }
+      entry.owners.push(x.id);
+      if ((r.added_ms || 0) >= entry.newest) {
+        entry.newest = r.added_ms || 0;
+        entry.carrier = x.id;
+      }
+    }));
+    const room = Math.max(0, AGENDA_GRAPH_NODE_CAP - items.length);
+    const all = [...best.values()].sort((a, b) =>
+      b.newest - a.newest || (a.locator < b.locator ? -1 : 1));
+    satellites = all.slice(0, Math.min(60, room));
+    agendaGraphTerrStats = { shown: satellites.length, total: all.length };
+  } else {
+    agendaGraphTerrStats = { shown: 0, total: 0 };
+  }
+  // Hub overview: halo hubs by their SUBTREE's declared territory — a
+  // client-side walk over the full pool (no daemon change), so the map
+  // shows where the files live before diving in.
+  agendaGraphSubtreeTerr = new Map();
+  if (agendaGraphProjection === 'hubs') {
+    const pool = agendaGraphPoolItems();
+    const kids = new Map();
+    pool.forEach((x) => {
+      if (x.part_of) {
+        const list = kids.get(x.part_of.parent_id) || [];
+        list.push(x.id);
+        kids.set(x.part_of.parent_id, list);
+      }
+    });
+    const own = new Map(pool.map((x) => [x.id,
+      (x.refs || []).filter((r) => r.ref_type === 'file' || r.ref_type === 'dir').length]));
+    items.forEach((hub) => {
+      let sum = 0;
+      const seen = new Set();
+      const queue = [hub.id];
+      while (queue.length) {
+        const id = queue.pop();
+        if (seen.has(id)) continue;
+        seen.add(id);
+        sum += own.get(id) || 0;
+        (kids.get(id) || []).forEach((k) => queue.push(k));
+      }
+      agendaGraphSubtreeTerr.set(hub.id, sum);
+    });
+  }
+  const key = `${agendaGraphProjection}|${agendaGraphFocus || ''}|terr:${satellites.map((s) => s.key).join(',')};` + items.map((x) => [
     x.id,
     x.status,
     x.part_of ? x.part_of.parent_id : '',
@@ -391,6 +540,22 @@ function agendaGraphBuild() {
     };
   });
   const idx = new Map(agendaGraphNodes.map((n, i) => [n.id, i]));
+  satellites.forEach((sat, i) => {
+    const nodeId = `terr|${sat.key}`;
+    const near = idx.get(sat.carrier);
+    const base = near !== undefined ? agendaGraphNodes[near].p : [0, 0, 0];
+    const a = i * 1.7;
+    agendaGraphNodes.push({
+      id: nodeId,
+      sat,
+      p: previous.get(nodeId) || [
+        base[0] + Math.cos(a) * 26,
+        base[1] + (Math.random() - 0.5) * 22,
+        base[2] + Math.sin(a) * 26,
+      ],
+    });
+    idx.set(nodeId, agendaGraphNodes.length - 1);
+  });
   const links = [];
   const seenRel = new Set();
   items.forEach((x) => {
@@ -416,6 +581,12 @@ function agendaGraphBuild() {
         t: 'rel',
         k: link.link_kind || null,
       });
+    });
+  });
+  satellites.forEach((sat) => {
+    const b = idx.get(`terr|${sat.key}`);
+    sat.owners.forEach((owner) => {
+      if (idx.has(owner)) links.push({ a: idx.get(owner), b, t: 'terr' });
     });
   });
   agendaGraphLinks = links;
@@ -453,8 +624,10 @@ function agendaGraphRelax(iterations) {
     links.forEach((link) => {
       const A = nodes[link.a].p;
       const B = nodes[link.b].p;
-      const rest = link.t === 'place' ? 74 : link.t === 'dep' ? 96 : 116;
-      const k = link.t === 'place' ? 0.014 : 0.007;
+      const rest = link.t === 'place' ? 74
+        : link.t === 'terr' ? 52
+          : link.t === 'dep' ? 96 : 116;
+      const k = link.t === 'place' ? 0.014 : link.t === 'terr' ? 0.012 : 0.007;
       const dx = B[0] - A[0];
       const dy = B[1] - A[1];
       const dz = B[2] - A[2];
@@ -490,6 +663,34 @@ function agendaGraphPalette() {
     agendaGraphPalAt = now;
   }
   return agendaGraphPalCache;
+}
+
+// One territory satellite: a small square (dirs slightly larger), the
+// basename labeled while hot, full locator + carrier count on the
+// subtitle. Locators are data — fillText only, inert pixels.
+function agendaGraphDrawSatellite(g, node, q, hot, pal, w) {
+  const sat = node.sat;
+  const size = (sat.t === 'dir' ? 3.4 : 2.6) * q.s + (hot ? 0.9 : 0);
+  const alpha = Math.max(0.3, Math.min(0.85, q.s * 1.05 - 0.1));
+  g.beginPath();
+  g.rect(q.x - size, q.y - size, size * 2, size * 2);
+  g.fillStyle = `rgba(${pal.text},${alpha * (hot ? 0.85 : 0.45)})`;
+  g.fill();
+  if (hot) {
+    const name = sat.locator.replace(/\/+$/, '').split('/').pop() || sat.locator;
+    const label = sat.t === 'dir' ? `${name}/` : name;
+    g.font = '700 10px "JetBrains Mono", monospace';
+    const tw = g.measureText(label).width;
+    let lx = q.x + size + 7;
+    if (lx + tw > w - 10) lx = q.x - size - 7 - tw;
+    g.fillStyle = `rgba(${pal.text},.95)`;
+    g.fillText(label, lx, q.y + 3.5);
+    g.font = '9px "JetBrains Mono", monospace';
+    g.fillStyle = pal.t3;
+    g.fillText(
+      `${sat.locator} · ${sat.owners.length} item${sat.owners.length === 1 ? '' : 's'} — click opens newest carrier`,
+      lx, q.y + 16);
+  }
 }
 
 // ---- Draw (3D-ish projection, hover picking, rings, labels) ----
@@ -584,6 +785,11 @@ function agendaGraphDraw(ts) {
       g.setLineDash([]);
       g.strokeStyle = `rgba(${pal.iris},${depth * (hot ? 0.75 : 0.38)})`;
       g.lineWidth = hot ? 1.6 : 1.1;
+    } else if (link.t === 'terr') {
+      g.setLineDash([1.5, 3.5]);
+      g.lineDashOffset = 0;
+      g.strokeStyle = `rgba(${pal.text},${depth * (hot ? 0.45 : 0.14)})`;
+      g.lineWidth = 1;
     } else if (link.t === 'rel') {
       if (link.k) {
         // Typed adjacency: solid and slightly stronger than see-also.
@@ -634,6 +840,10 @@ function agendaGraphDraw(ts) {
   order.forEach((i) => {
     const node = nodes[i];
     const q = pts[i];
+    if (node.sat) {
+      agendaGraphDrawSatellite(g, node, q, hover === node.id, pal, w);
+      return;
+    }
     const item = byId.get(node.id);
     if (!item) return;
     const kids = childCount.get(node.id) || 0;
@@ -672,9 +882,11 @@ function agendaGraphDraw(ts) {
     if (st && st.kind === 'pending') ring(pal.amber, 5.4, 0.75 * alpha);
     // Territory halo: a dotted outer ring on nodes carrying file/dir
     // refs — the declared working set made visible.
-    const territory = (item.refs || []).filter(
-      (r) => r.ref_type === 'file' || r.ref_type === 'dir',
-    ).length;
+    const territory = agendaGraphProjection === 'hubs'
+      ? agendaGraphSubtreeTerr.get(node.id) || 0
+      : (item.refs || []).filter(
+        (r) => r.ref_type === 'file' || r.ref_type === 'dir',
+      ).length;
     if (territory) {
       g.setLineDash([1.5, 3.2]);
       ring(pal.text, 7.6, 0.3 * alpha);
@@ -708,22 +920,28 @@ function agendaGraphDraw(ts) {
   });
   // Projection badge (painted, inert pixels like every label): what the
   // constellation is currently showing.
-  if (agendaGraphProjection !== 'all') {
+  const terrBadge = agendaGraphTerrStats.shown
+    ? ` · territory ${agendaGraphTerrStats.shown}${agendaGraphTerrStats.total > agendaGraphTerrStats.shown ? ` of ${agendaGraphTerrStats.total}` : ''}`
+    : '';
+  if (agendaGraphProjection !== 'all' || terrBadge) {
     const allCount = (agendaItems || []).filter(
       (x) => x.status !== 'retired',
     ).length;
+    const itemCount = nodes.filter((n) => !n.sat).length;
     let badge = '';
     if (agendaGraphProjection === 'hubs') {
-      badge = `hub overview · ${nodes.length} hubs of ${allCount} items`;
-    } else {
+      badge = `hub overview · ${itemCount} hubs of ${allCount} items`;
+    } else if (agendaGraphProjection === 'focus') {
       const focused = byId.get(agendaGraphFocus);
       const title = focused ? String(focused.title || '') : '';
       const short = title.length > 40 ? `${title.slice(0, 39)}…` : title;
-      badge = `focused: ${short} · ${nodes.length} of ${allCount} items`;
+      badge = `focused: ${short} · ${itemCount} of ${allCount} items`;
+    } else {
+      badge = `everything · ${itemCount} items`;
     }
     g.font = '10px "JetBrains Mono", monospace';
     g.fillStyle = pal.t3;
-    g.fillText(badge, 14, 64);
+    g.fillText(badge + terrBadge, 14, 64);
   }
 }
 

--- a/static/app/ui2-agenda.css
+++ b/static/app/ui2-agenda.css
@@ -1039,10 +1039,50 @@ html.ui-v2 .ag2-graph-swatch.s-line.t-rel { border-top: 2px dashed var(--text-3)
 html.ui-v2 .ag2-graph-swatch.s-line.t-typed { border-top: 2px solid var(--text-2); }
 html.ui-v2 .ag2-graph-swatch.s-line.t-dep { border-top: 2px solid rgba(var(--rose-rgb), 0.6); }
 html.ui-v2 .ag2-graph-swatch.s-ring.t-terr { border: 1.5px dotted var(--text-2); }
-html.ui-v2 .ag2-graph-clear {
+html.ui-v2 .ag2-graph-swatch.s-sq { width: 7px; height: 7px; }
+html.ui-v2 .ag2-graph-swatch.s-sq.t-file { background: var(--text-3); }
+html.ui-v2 .ag2-graph-swatch.s-sq.t-dir {
+  border: 1.5px solid var(--text-2);
+  box-sizing: border-box;
+}
+html.ui-v2 .ag2-graph-projrow {
   position: absolute;
   top: 38px;
   right: 14px;
+  display: flex;
+  gap: 5px;
+}
+html.ui-v2 .ag2-graph-projchip {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  color: var(--text-3);
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--r-pill);
+  padding: 2px 9px;
+  cursor: pointer;
+}
+html.ui-v2 .ag2-graph-projchip:hover:not(:disabled) { color: var(--text); }
+html.ui-v2 .ag2-graph-projchip.active {
+  color: var(--iris);
+  border-color: var(--iris);
+}
+html.ui-v2 .ag2-graph-projchip:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+html.ui-v2 .ag2-graph-capnote {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text-3);
+  pointer-events: none;
+  padding: 0 40px;
+  text-align: center;
 }
 
 /* ---- Upcoming lens (slice C): the 14-day day-grouped timeline. Rows


### PR DESCRIPTION
P6b of the agenda ontology program (item 01KYT8J44F; closes the owner-challenged gap: projections were gesture-only and files never appeared as graph citizens). Renderer-only — no daemon or serving changes; Station-safe by construction.

- **Projection chip row** on the panel (hubs · everything · territory · focused ✕): the current projection is finally visible and switchable, not gesture-hidden. Explicit 'everything' past the 180-node cap keeps the panel and chips and says why (cap note overlay) instead of the dead-end refusal; the flat refusal remains only for over-cap focused subtrees.
- **Territory satellite projection** (toggle, on 'everything'/'focused' pools): one view-materialized square per distinct file/dir locator across the pool's declared refs — never store items — deduped newest-first, capped into the node-cap room (≤60), short spring links to every carrying item, basename label + full locator + carrier count on hover, click opens the newest carrying item. Declared refs only for now; observed (NS) affinity joins later via the gardener.
- **Hub overview halos got honest**: hubs now halo by their SUBTREE's territory (client-side walk over the full pool), so the over-cap landing view shows where the files live before diving.
- Painted projection badge now covers every mode (including 'everything · N items' and territory shown/total counts).
- Rulings preserved: aria-hidden decorative canvas, card-lens parity (all satellite facts remain reachable as refs in the inspector/territory sections), item text and locators drawn via fillText only, zero-background-frame lifecycle and reduced-motion behavior untouched.

Battery: bins 5298 + 150 + 97 pass, lib crates pass, workspace clippy -D warnings clean, node --check, app.html regenerated via the assembler.