### PR TITLE
sessions list: O(changed) grid-envelope attach (fixes the 07-30 boot-storm hot-spin)

### DIFF
--- a/src/bin/caller/external_wrapper_index.rs
+++ b/src/bin/caller/external_wrapper_index.rs
@@ -47,12 +47,62 @@ fn index_cache() -> &'static Mutex<HashMap<PathBuf, CachedWrapperIndex>> {
     INDEX_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-/// Cheap change fingerprint of the on-disk index (length + mtime nanos).
-/// Serve-time lineage memos key on it: every new wrapper generation writes
-/// an index row (the eager resume identity), so a stale memo cannot
-/// outlive the chain it summarizes.
-pub fn index_fingerprint(home: &Path) -> (u64, u128) {
-    index_file_fingerprint(&index_path(home))
+/// Epoch of the index content the resume-lineage walk consumes: a hash
+/// over exactly the fields that can change a walk's outcome — the
+/// identity triple, `log_path`, `state`, and the two lineage tombstones —
+/// deliberately EXCLUDING `updated_at_secs` (and the cached
+/// `rollout_path` / `project_root`). The session-catalog list pass
+/// backfill-restamps Active rows' recency from live log-dir mtimes, so
+/// while any wrapper session is appending its transcript the raw file
+/// fingerprint (length + mtime) moves on every serve; lineage memos
+/// keyed on that fingerprint therefore invalidated wholesale per serve
+/// and every ghost row re-ran its walk — the 2026-07-30 sessions-list
+/// hot-spin. Equal epochs guarantee identical walk-relevant content; the
+/// accepted blind spot is recency REORDERING between multiple Active
+/// rows of one group (a transient double-active window during resume
+/// handoff, display-only, self-healing on the demotion's state change).
+/// Cached per index-file fingerprint, so an unchanged file costs one
+/// stat and a restamp-only rewrite costs one re-hash, not a re-walk.
+pub fn lineage_epoch(home: &Path) -> u64 {
+    use std::hash::{Hash, Hasher};
+    static EPOCH_CACHE: OnceLock<Mutex<HashMap<PathBuf, ((u64, u128), u64)>>> = OnceLock::new();
+    let cache = EPOCH_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    let path = index_path(home);
+    let fingerprint = index_file_fingerprint(&path);
+    if let Some((cached_fingerprint, epoch)) = cache
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(&path)
+    {
+        if *cached_fingerprint == fingerprint {
+            return *epoch;
+        }
+    }
+    let epoch = {
+        let _guard = INDEX_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        with_index_unlocked(home, |index| {
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            index.wrappers.len().hash(&mut hasher);
+            for record in &index.wrappers {
+                record.source.hash(&mut hasher);
+                record.backend_session_id.hash(&mut hasher);
+                record.intendant_session_id.hash(&mut hasher);
+                record.log_path.hash(&mut hasher);
+                record.state.hash(&mut hasher);
+                record.stopped_by_user_at_secs.hash(&mut hasher);
+                record.retired_successor.hash(&mut hasher);
+            }
+            hasher.finish()
+        })
+    };
+    cache
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(path, (fingerprint, epoch));
+    epoch
 }
 
 /// Run `f` against the current index without cloning it. Callers must hold
@@ -103,7 +153,9 @@ fn note_index_written(home: &Path, index: &ExternalWrapperIndex) {
 /// no `state`: those rows deserialize as `Active` and their demotions are
 /// still expressed by the legacy `updated_at_secs == 0` sentinel, which the
 /// preference order's timestamp tie-break honors.
-#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum WrapperState {
     #[default]
@@ -1161,6 +1213,44 @@ pub fn wrappers_for_source(home: &Path, source: &str) -> Vec<ExternalWrapperReco
     records
 }
 
+/// Every index record belonging to ONE wrapper session (the reverse of
+/// [`wrappers_for`]'s conversation lookup), matched the way every reader
+/// resolves wrapper identity — by the record's log-dir basename
+/// ([`normalize_log_identity`]) — and preference-sorted. One pass over
+/// the index with existence stats only on the matching rows: the
+/// per-session expansion inside `recorded_backend_conversations_in_home`
+/// previously swept [`wrappers_for_source`] once per backend, which
+/// stat'ed and cloned every source row in the whole index per resolved
+/// session — ruinous × every ghost row of a large session store.
+pub fn wrapper_records_for_wrapper_id(
+    home: &Path,
+    wrapper_session_id: &str,
+) -> Vec<ExternalWrapperRecord> {
+    let wrapper_session_id = wrapper_session_id.trim();
+    if wrapper_session_id.is_empty() {
+        return Vec::new();
+    }
+    let _guard = INDEX_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let mut records: Vec<_> = with_index_unlocked(home, |index| {
+        index
+            .wrappers
+            .iter()
+            .filter_map(|record| {
+                (log_dir_session_id(Path::new(&record.log_path)).as_deref()
+                    == Some(wrapper_session_id)
+                    && Path::new(&record.log_path).is_dir())
+                .then(|| normalize_log_identity(record.clone()))
+                .flatten()
+            })
+            .collect()
+    });
+    records.sort_by(wrapper_preference);
+    records
+}
+
 /// Remember the resolved native backend log (e.g. a Codex rollout file)
 /// for `(source, backend_session_id)`. The path is stamped on EVERY record
 /// of that backend session — the native file is a property of the backend
@@ -1327,6 +1417,159 @@ fn file_mtime_secs(path: &Path) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Direct index write honoring the INDEX_LOCK contract of
+    /// [`write_index_unlocked`].
+    fn write_index_for_tests(home: &Path, index: &ExternalWrapperIndex) {
+        let _guard = INDEX_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        write_index_unlocked(home, index).unwrap();
+    }
+
+    fn epoch_record(wrapper: &str, backend: &str, log_path: &str) -> ExternalWrapperRecord {
+        ExternalWrapperRecord {
+            source: "claude-code".to_string(),
+            backend_session_id: backend.to_string(),
+            intendant_session_id: wrapper.to_string(),
+            log_path: log_path.to_string(),
+            project_root: None,
+            updated_at_secs: 1,
+            state: WrapperState::Active,
+            rollout_path: None,
+            stopped_by_user_at_secs: None,
+            retired_successor: None,
+        }
+    }
+
+    /// The lineage epoch moves with walk-relevant content ONLY. Recency
+    /// restamps (`updated_at_secs`) and cached-lookup fields
+    /// (`rollout_path`) rewrite the file without moving the epoch — the
+    /// session-catalog backfill restamps live rows every list pass, and
+    /// an epoch that moved with them would re-walk every ghost row per
+    /// serve (the 2026-07-30 hot-spin). Identity, state, and tombstone
+    /// changes all move it.
+    #[test]
+    fn lineage_epoch_tracks_walk_relevant_content_only() {
+        let home = tempfile::tempdir().unwrap();
+        let mut index = ExternalWrapperIndex::default();
+        index
+            .wrappers
+            .push(epoch_record("wrap-epoch-1", "b-epoch-1", "/tmp/wrap-epoch-1"));
+        write_index_for_tests(home.path(), &index);
+        let base = lineage_epoch(home.path());
+
+        // Recency restamp: file bytes change, epoch holds.
+        index.wrappers[0].updated_at_secs = 100_000;
+        write_index_for_tests(home.path(), &index);
+        assert_eq!(
+            lineage_epoch(home.path()),
+            base,
+            "a recency-only restamp must not move the epoch"
+        );
+
+        // Cached rollout path: still not walk input.
+        index.wrappers[0].rollout_path = Some("/tmp/rollout.jsonl".to_string());
+        write_index_for_tests(home.path(), &index);
+        assert_eq!(
+            lineage_epoch(home.path()),
+            base,
+            "rollout-path caching must not move the epoch"
+        );
+
+        // State change (a demotion): moves.
+        index.wrappers[0].state = WrapperState::Superseded;
+        write_index_for_tests(home.path(), &index);
+        let demoted = lineage_epoch(home.path());
+        assert_ne!(demoted, base, "a demotion must move the epoch");
+
+        // Owner-stop tombstone: moves.
+        index.wrappers[0].stopped_by_user_at_secs = Some(9);
+        write_index_for_tests(home.path(), &index);
+        let stopped = lineage_epoch(home.path());
+        assert_ne!(stopped, demoted, "a stop tombstone must move the epoch");
+
+        // Retirement edge: moves.
+        index.wrappers[0].retired_successor = Some("b-epoch-2".to_string());
+        write_index_for_tests(home.path(), &index);
+        let retired = lineage_epoch(home.path());
+        assert_ne!(retired, stopped, "a retirement edge must move the epoch");
+
+        // A new wrapper generation: moves.
+        index
+            .wrappers
+            .push(epoch_record("wrap-epoch-2", "b-epoch-2", "/tmp/wrap-epoch-2"));
+        write_index_for_tests(home.path(), &index);
+        assert_ne!(
+            lineage_epoch(home.path()),
+            retired,
+            "a new wrapper row must move the epoch"
+        );
+    }
+
+    /// The reverse lookup returns exactly what the per-source sweep +
+    /// wrapper-id filter used to assemble: matched by log-dir basename
+    /// (the identity every reader resolves), existence-filtered,
+    /// preference-sorted — across all sources in one pass.
+    #[test]
+    fn wrapper_records_for_wrapper_id_matches_source_sweep() {
+        let home = tempfile::tempdir().unwrap();
+        let wrapper_a = "e9532107-8c7f-4c1f-b88d-410d6d365511";
+        let wrapper_b = "ec5865e5-a5af-4b8c-81a1-545a3a6f8b22";
+        let dir_a = home.path().join(".intendant").join("logs").join(wrapper_a);
+        let dir_b = home.path().join(".intendant").join("logs").join(wrapper_b);
+        std::fs::create_dir_all(&dir_a).unwrap();
+        std::fs::create_dir_all(&dir_b).unwrap();
+        let codex_id = "019ea8b9-0000-7000-8000-000000000011";
+        let claude_id = "0caf4660-7345-4f3b-b8e7-407e59aefa11";
+        upsert(home.path(), "codex", codex_id, wrapper_a, &dir_a, None).unwrap();
+        upsert(home.path(), "claude-code", claude_id, wrapper_a, &dir_a, None).unwrap();
+        upsert(home.path(), "codex", codex_id, wrapper_b, &dir_b, None).unwrap();
+
+        let direct = wrapper_records_for_wrapper_id(home.path(), wrapper_a);
+        let mut swept: Vec<ExternalWrapperRecord> = ["codex", "claude-code", "kimi"]
+            .iter()
+            .flat_map(|source| wrappers_for_source(home.path(), source))
+            .filter(|record| record.intendant_session_id == wrapper_a)
+            .collect();
+        swept.sort_by(wrapper_preference);
+        assert_eq!(direct, swept, "reverse lookup must equal the source sweep");
+        assert_eq!(direct.len(), 2, "both sources' records found");
+
+        // Matching is by log-dir basename, exactly like every reader: a
+        // stale stored id neither matches nor leaks.
+        let mut index = {
+            let _guard = INDEX_LOCK
+                .get_or_init(|| Mutex::new(()))
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            with_index_unlocked(home.path(), |index| index.clone())
+        };
+        let stale_pos = index
+            .wrappers
+            .iter()
+            .position(|record| record.intendant_session_id == wrapper_a)
+            .unwrap();
+        index.wrappers[stale_pos].intendant_session_id = "stale-alias".to_string();
+        write_index_for_tests(home.path(), &index);
+        assert!(
+            wrapper_records_for_wrapper_id(home.path(), "stale-alias").is_empty(),
+            "stored-id spelling must not match — the log dir decides"
+        );
+        assert_eq!(
+            wrapper_records_for_wrapper_id(home.path(), wrapper_a).len(),
+            2,
+            "basename matching survives a stale stored id"
+        );
+
+        // A record whose log dir is gone drops out, like the sweep.
+        std::fs::remove_dir_all(&dir_b).unwrap();
+        assert!(
+            wrapper_records_for_wrapper_id(home.path(), wrapper_b).is_empty(),
+            "existence filter parity"
+        );
+    }
 
     #[test]
     fn upsert_demotes_stale_wrapper_for_same_backend_session() {

--- a/src/bin/caller/external_wrapper_index.rs
+++ b/src/bin/caller/external_wrapper_index.rs
@@ -1456,9 +1456,11 @@ mod tests {
     fn lineage_epoch_tracks_walk_relevant_content_only() {
         let home = tempfile::tempdir().unwrap();
         let mut index = ExternalWrapperIndex::default();
-        index
-            .wrappers
-            .push(epoch_record("wrap-epoch-1", "b-epoch-1", "/tmp/wrap-epoch-1"));
+        index.wrappers.push(epoch_record(
+            "wrap-epoch-1",
+            "b-epoch-1",
+            "/tmp/wrap-epoch-1",
+        ));
         write_index_for_tests(home.path(), &index);
         let base = lineage_epoch(home.path());
 
@@ -1499,9 +1501,11 @@ mod tests {
         assert_ne!(retired, stopped, "a retirement edge must move the epoch");
 
         // A new wrapper generation: moves.
-        index
-            .wrappers
-            .push(epoch_record("wrap-epoch-2", "b-epoch-2", "/tmp/wrap-epoch-2"));
+        index.wrappers.push(epoch_record(
+            "wrap-epoch-2",
+            "b-epoch-2",
+            "/tmp/wrap-epoch-2",
+        ));
         write_index_for_tests(home.path(), &index);
         assert_ne!(
             lineage_epoch(home.path()),
@@ -1526,7 +1530,15 @@ mod tests {
         let codex_id = "019ea8b9-0000-7000-8000-000000000011";
         let claude_id = "0caf4660-7345-4f3b-b8e7-407e59aefa11";
         upsert(home.path(), "codex", codex_id, wrapper_a, &dir_a, None).unwrap();
-        upsert(home.path(), "claude-code", claude_id, wrapper_a, &dir_a, None).unwrap();
+        upsert(
+            home.path(),
+            "claude-code",
+            claude_id,
+            wrapper_a,
+            &dir_a,
+            None,
+        )
+        .unwrap();
         upsert(home.path(), "codex", codex_id, wrapper_b, &dir_b, None).unwrap();
 
         let direct = wrapper_records_for_wrapper_id(home.path(), wrapper_a);

--- a/src/bin/caller/external_wrapper_index.rs
+++ b/src/bin/caller/external_wrapper_index.rs
@@ -65,7 +65,9 @@ fn index_cache() -> &'static Mutex<HashMap<PathBuf, CachedWrapperIndex>> {
 /// stat and a restamp-only rewrite costs one re-hash, not a re-walk.
 pub fn lineage_epoch(home: &Path) -> u64 {
     use std::hash::{Hash, Hasher};
-    static EPOCH_CACHE: OnceLock<Mutex<HashMap<PathBuf, ((u64, u128), u64)>>> = OnceLock::new();
+    /// (file fingerprint the epoch was computed from, the epoch).
+    type CachedEpoch = ((u64, u128), u64);
+    static EPOCH_CACHE: OnceLock<Mutex<HashMap<PathBuf, CachedEpoch>>> = OnceLock::new();
     let cache = EPOCH_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
     let path = index_path(home);
     let fingerprint = index_file_fingerprint(&path);

--- a/src/bin/caller/session_supervisor/launch.rs
+++ b/src/bin/caller/session_supervisor/launch.rs
@@ -2197,6 +2197,25 @@ pub(crate) fn recorded_backend_conversations_in_home(
     if session_id.is_empty() {
         return Vec::new();
     }
+    let log_dir = session_log_dir_for_id_in_home(home, session_id);
+    recorded_backend_conversations_in_home_with_dir(home, session_id, log_dir.as_deref())
+}
+
+/// [`recorded_backend_conversations_in_home`] with the session's log dir
+/// already resolved (`None` = no dir; the scan section is skipped exactly
+/// as when the probe finds nothing). The resume-lineage walk passes dirs
+/// it already knows — the seed row's own dir, closure records'
+/// `log_path` — so per-session expansion never falls into
+/// [`session_log_dir_for_id_in_home`]'s O(store) directory probe.
+pub(crate) fn recorded_backend_conversations_in_home_with_dir(
+    home: &Path,
+    session_id: &str,
+    log_dir: Option<&Path>,
+) -> Vec<(String, String)> {
+    let session_id = session_id.trim();
+    if session_id.is_empty() {
+        return Vec::new();
+    }
     let mut out: Vec<(String, String)> = Vec::new();
     let mut push = |source: &str, backend_id: &str| {
         if !external_agent::source_session_id_is_canonical(source, backend_id) {
@@ -2210,36 +2229,106 @@ pub(crate) fn recorded_backend_conversations_in_home(
     for backend in EXTERNAL_BACKENDS {
         push(backend.as_short_str(), session_id);
     }
-    if let Some(log_dir) = session_log_dir_for_id_in_home(home, session_id) {
-        let canonical = crate::session_identity::canonical_session_id_from_meta(&log_dir);
-        if let Some(scan) = crate::session_identity::scan_session_dir(&log_dir, session_id) {
-            // Membership, not addressing: `event_names_session` (the
-            // predicate the index writer uses), NEVER `wrapper_matches` —
-            // the addressing predicate accepts ANY event id once the
-            // requested id prefixes the dir's canonical id, which would
-            // adopt the bus-tee copies in a daemon head-session's log.
-            for identity in scan.identities.iter().rev().filter(|identity| {
-                identity.wrapper_id.as_deref().is_some_and(|wrapper_id| {
-                    crate::session_identity::event_names_session(
-                        Some(wrapper_id),
-                        session_id,
-                        canonical.as_deref(),
-                    )
-                })
-            }) {
-                push(&identity.source, &identity.backend_session_id);
-            }
+    if let Some(log_dir) = log_dir {
+        for (source, backend_id) in recorded_identity_pairs_for_dir(log_dir, session_id) {
+            push(&source, &backend_id);
         }
     }
+    let records = crate::external_wrapper_index::wrapper_records_for_wrapper_id(home, session_id);
     for backend in EXTERNAL_BACKENDS {
         let source = backend.as_short_str();
-        for record in crate::external_wrapper_index::wrappers_for_source(home, source) {
-            if record.intendant_session_id == session_id {
-                push(&record.source, &record.backend_session_id);
-            }
+        for record in records.iter().filter(|record| record.source == source) {
+            push(&record.source, &record.backend_session_id);
         }
     }
     out
+}
+
+struct RecordedIdentityPairsMemoEntry {
+    transcript: (u64, u128),
+    meta: (u64, u128),
+    pairs: Vec<(String, String)>,
+}
+
+/// Comfortably above the session-store dir count (~4k on the machine
+/// that motivated the memo), so clear-on-full stays a corruption
+/// backstop instead of a per-pass thrash.
+const RECORDED_IDENTITY_PAIRS_MEMO_LIMIT: usize = 16_384;
+
+fn recorded_identity_pairs_memo(
+) -> &'static std::sync::Mutex<HashMap<(PathBuf, String), RecordedIdentityPairsMemoEntry>> {
+    static MEMO: std::sync::OnceLock<
+        std::sync::Mutex<HashMap<(PathBuf, String), RecordedIdentityPairsMemoEntry>>,
+    > = std::sync::OnceLock::new();
+    MEMO.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
+}
+
+fn recorded_identity_file_fingerprint(path: &Path) -> (u64, u128) {
+    match std::fs::metadata(path) {
+        Ok(meta) => (
+            meta.len(),
+            meta.modified()
+                .ok()
+                .and_then(|mtime| mtime.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_nanos())
+                .unwrap_or(0),
+        ),
+        Err(_) => (0, 0),
+    }
+}
+
+/// The dir-local half of a session's recorded conversations: the
+/// `session_identity` facts in its own transcript that name it, newest
+/// first. Memoized per (dir, session id) on the (transcript, meta)
+/// fingerprints — the two files the scan reads — because the scan parses
+/// the WHOLE transcript: the resume-lineage walk expands every ghost row
+/// through here, and dead transcripts never change, so without the memo
+/// every lineage re-walk re-parsed the entire session store.
+fn recorded_identity_pairs_for_dir(log_dir: &Path, session_id: &str) -> Vec<(String, String)> {
+    let transcript = recorded_identity_file_fingerprint(&log_dir.join("session.jsonl"));
+    let meta = recorded_identity_file_fingerprint(&log_dir.join("session_meta.json"));
+    let memo_key = (log_dir.to_path_buf(), session_id.to_string());
+    if let Ok(memo) = recorded_identity_pairs_memo().lock() {
+        if let Some(entry) = memo.get(&memo_key) {
+            if entry.transcript == transcript && entry.meta == meta {
+                return entry.pairs.clone();
+            }
+        }
+    }
+    let mut pairs: Vec<(String, String)> = Vec::new();
+    let canonical = crate::session_identity::canonical_session_id_from_meta(log_dir);
+    if let Some(scan) = crate::session_identity::scan_session_dir(log_dir, session_id) {
+        // Membership, not addressing: `event_names_session` (the
+        // predicate the index writer uses), NEVER `wrapper_matches` —
+        // the addressing predicate accepts ANY event id once the
+        // requested id prefixes the dir's canonical id, which would
+        // adopt the bus-tee copies in a daemon head-session's log.
+        for identity in scan.identities.iter().rev().filter(|identity| {
+            identity.wrapper_id.as_deref().is_some_and(|wrapper_id| {
+                crate::session_identity::event_names_session(
+                    Some(wrapper_id),
+                    session_id,
+                    canonical.as_deref(),
+                )
+            })
+        }) {
+            pairs.push((identity.source.clone(), identity.backend_session_id.clone()));
+        }
+    }
+    if let Ok(mut memo) = recorded_identity_pairs_memo().lock() {
+        if memo.len() >= RECORDED_IDENTITY_PAIRS_MEMO_LIMIT && !memo.contains_key(&memo_key) {
+            memo.clear();
+        }
+        memo.insert(
+            memo_key,
+            RecordedIdentityPairsMemoEntry {
+                transcript,
+                meta,
+                pairs: pairs.clone(),
+            },
+        );
+    }
+    pairs
 }
 
 /// The three supervisable external backends (no ALL constant exists on
@@ -2556,6 +2645,36 @@ mod tests {
         assert!(bare
             .iter()
             .all(|(_, backend_id)| backend_id.as_str() == "sess-native"));
+    }
+
+    /// The identity-scan memo behind the collector serves cached pairs
+    /// only while the dir's transcript/meta fingerprints hold: an
+    /// identity appended after a memoized read (a live wrapper's upgrade)
+    /// must surface on the next read, never the stale pair set.
+    #[test]
+    fn recorded_conversations_memo_revalidates_on_transcript_growth() {
+        let home = tempfile::tempdir().unwrap();
+        let wrapper_dir = home.path().join(".intendant").join("logs").join("wrap-m1");
+        let mut log = session_log::SessionLog::open(wrapper_dir).unwrap();
+        log.write_meta(None, None);
+        log.session_identity("wrap-m1", "claude-code", "thread-first");
+        let first = recorded_backend_conversations_in_home(home.path(), "wrap-m1");
+        assert!(first
+            .iter()
+            .any(|(_, backend_id)| backend_id == "thread-first"));
+        assert!(!first
+            .iter()
+            .any(|(_, backend_id)| backend_id == "thread-second"));
+
+        log.session_identity("wrap-m1", "claude-code", "thread-second");
+        drop(log);
+        let second = recorded_backend_conversations_in_home(home.path(), "wrap-m1");
+        assert!(
+            second
+                .iter()
+                .any(|(_, backend_id)| backend_id == "thread-second"),
+            "appended identity must invalidate the memoized scan: {second:?}"
+        );
     }
 
     /// The eager resume-identity write lands in the wrapper's own log and

--- a/src/bin/caller/session_supervisor/resume_lineage.rs
+++ b/src/bin/caller/session_supervisor/resume_lineage.rs
@@ -330,8 +330,12 @@ mod tests {
         );
         assert_eq!(hinted.stopped_by_user, probed.stopped_by_user);
         assert_eq!(
-            hinted.successor_tip(&["hint-old"]).map(|r| r.intendant_session_id.clone()),
-            probed.successor_tip(&["hint-old"]).map(|r| r.intendant_session_id.clone()),
+            hinted
+                .successor_tip(&["hint-old"])
+                .map(|r| r.intendant_session_id.clone()),
+            probed
+                .successor_tip(&["hint-old"])
+                .map(|r| r.intendant_session_id.clone()),
         );
     }
 

--- a/src/bin/caller/session_supervisor/resume_lineage.rs
+++ b/src/bin/caller/session_supervisor/resume_lineage.rs
@@ -16,12 +16,14 @@
 //! independent walkers WILL drift; add consumers here, never a private
 //! re-implementation.
 
-use super::launch::recorded_backend_conversations_in_home;
+use super::launch::{
+    recorded_backend_conversations_in_home, recorded_backend_conversations_in_home_with_dir,
+};
 use crate::external_wrapper_index::{
     lineage_tombstones, wrapper_preference, wrappers_for, ExternalWrapperRecord, WrapperState,
 };
-use std::collections::HashSet;
-use std::path::Path;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
 
 /// Walk bounds: a lineage is a restart chain (human-gesture scale), so
 /// real chains are short; the caps only defend against a corrupted or
@@ -92,11 +94,32 @@ impl ResumeLineage {
 /// recorded identity or from wrapper-index rows of a conversation
 /// already in the closure.
 pub(crate) fn resolve_resume_lineage(home: &Path, seeds: &[&str]) -> ResumeLineage {
+    resolve_resume_lineage_with_dir_hints(home, seeds, &[])
+}
+
+/// [`resolve_resume_lineage`] with log dirs the caller already knows
+/// (`(session id, dir)` pairs — e.g. the catalog row's own dir behind a
+/// serve-time lineage join). Hints are an I/O shortcut, never new
+/// authority: an id resolves to the same dir the probe would find (a
+/// wrapper dir is named by its id), and ids without a hint still resolve
+/// through [`session_log_dir_for_id_in_home`] — but each closure record
+/// contributes its `log_path` as a further hint, so a hinted walk never
+/// pays the probe's O(store) directory-scan fallback per hop.
+pub(crate) fn resolve_resume_lineage_with_dir_hints(
+    home: &Path,
+    seeds: &[&str],
+    dir_hints: &[(&str, &Path)],
+) -> ResumeLineage {
     let mut lineage = ResumeLineage {
         candidates: Vec::new(),
         wrapper_records: Vec::new(),
         stopped_by_user: false,
     };
+    let mut known_dirs: HashMap<String, PathBuf> = dir_hints
+        .iter()
+        .filter(|(id, _)| !id.trim().is_empty())
+        .map(|(id, dir)| (id.trim().to_string(), dir.to_path_buf()))
+        .collect();
     let mut seen_sessions: HashSet<String> = HashSet::new();
     let mut seen_conversations: HashSet<(String, String)> = HashSet::new();
     let mut session_frontier: Vec<String> = seeds
@@ -115,7 +138,15 @@ pub(crate) fn resolve_resume_lineage(home: &Path, seeds: &[&str]) -> ResumeLinea
         if seen_sessions.len() > MAX_LINEAGE_SESSIONS {
             break;
         }
-        for (source, conversation_id) in recorded_backend_conversations_in_home(home, &session_id) {
+        // A known dir (hint or closure record) skips the id→dir probe;
+        // hintless ids take the probing composition unchanged.
+        let conversations = match known_dirs.get(&session_id) {
+            Some(dir) => {
+                recorded_backend_conversations_in_home_with_dir(home, &session_id, Some(dir))
+            }
+            None => recorded_backend_conversations_in_home(home, &session_id),
+        };
+        for (source, conversation_id) in conversations {
             // Conversation frontier, itself chained by retirement edges.
             let mut conversation_frontier = vec![conversation_id];
             while let Some(conversation_id) = conversation_frontier.pop() {
@@ -129,6 +160,9 @@ pub(crate) fn resolve_resume_lineage(home: &Path, seeds: &[&str]) -> ResumeLinea
                     .candidates
                     .push((source.clone(), conversation_id.clone()));
                 for record in wrappers_for(home, &source, &conversation_id) {
+                    known_dirs
+                        .entry(record.intendant_session_id.clone())
+                        .or_insert_with(|| PathBuf::from(&record.log_path));
                     lineage
                         .candidates
                         .push((source.clone(), record.intendant_session_id.clone()));
@@ -262,6 +296,43 @@ mod tests {
             .successor_tip(&["wrapper-parent"])
             .expect("the retirement edge reaches the edit-branch child");
         assert_eq!(tip.intendant_session_id, "wrapper-child");
+    }
+
+    /// Dir hints are an I/O shortcut, never a semantic input: a hinted
+    /// walk resolves the exact same closure as the probing walk — same
+    /// candidate order, same records, same flags.
+    #[test]
+    fn dir_hints_change_no_outcomes() {
+        let home = tempfile::tempdir().unwrap();
+        announce(home.path(), "hint-old", "claude-code", &["hb1"]);
+        announce(home.path(), "hint-mid", "claude-code", &["hb1", "hb2"]);
+        announce(home.path(), "hint-new", "claude-code", &["hb2"]);
+
+        let probed = resolve_resume_lineage(home.path(), &["hint-old"]);
+        let hinted_dir = logs_root(home.path()).join("hint-old");
+        let hinted = resolve_resume_lineage_with_dir_hints(
+            home.path(),
+            &["hint-old"],
+            &[("hint-old", hinted_dir.as_path())],
+        );
+        assert_eq!(hinted.candidates, probed.candidates);
+        assert_eq!(
+            hinted
+                .wrapper_records
+                .iter()
+                .map(|record| record.intendant_session_id.clone())
+                .collect::<Vec<_>>(),
+            probed
+                .wrapper_records
+                .iter()
+                .map(|record| record.intendant_session_id.clone())
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(hinted.stopped_by_user, probed.stopped_by_user);
+        assert_eq!(
+            hinted.successor_tip(&["hint-old"]).map(|r| r.intendant_session_id.clone()),
+            probed.successor_tip(&["hint-old"]).map(|r| r.intendant_session_id.clone()),
+        );
     }
 
     /// No recorded wrapper history (a native session id) resolves to an

--- a/src/bin/caller/web_gateway/session_catalog/grid_envelope.rs
+++ b/src/bin/caller/web_gateway/session_catalog/grid_envelope.rs
@@ -22,9 +22,15 @@
 //! The successor pointer derives from the ONE shared lineage walker,
 //! [`crate::session_supervisor::resume_lineage::resolve_resume_lineage`]
 //! (never a private re-implementation), memoized on the seed dir's
-//! transcript fingerprint plus the wrapper-index fingerprint — every new
-//! wrapper generation writes the index, so a memo cannot outlive the
-//! chain it summarizes.
+//! transcript fingerprint plus the wrapper index's LINEAGE EPOCH
+//! ([`crate::external_wrapper_index::lineage_epoch`]) — every new
+//! wrapper generation writes an index row, so a memo cannot outlive the
+//! chain it summarizes. The epoch, not the raw file fingerprint: the
+//! list pass's own backfill restamps live rows' recency on every serve,
+//! and keying on the file fingerprint invalidated every memo per serve —
+//! each poll re-walked every ghost row's lineage over the whole store
+//! (the 2026-07-30 boot-storm hot-spin, 871% CPU starving the accept
+//! lane). The epoch moves only when walk-relevant content moves.
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -64,6 +70,10 @@ pub(crate) struct GridEnvelopeJoins {
     /// pointers; `None` skips the lineage join (tests that exercise only
     /// the boot matrix).
     home: Option<PathBuf>,
+    /// Wrapper-index lineage epoch, resolved ONCE per build (one stat on
+    /// an unchanged index) and handed to every row's tip memo check —
+    /// never re-derived per row.
+    lineage_epoch: Option<u64>,
 }
 
 impl GridEnvelopeJoins {
@@ -82,6 +92,7 @@ impl GridEnvelopeJoins {
             boot,
             live_wrappers,
             agenda,
+            lineage_epoch: Some(crate::external_wrapper_index::lineage_epoch(home_path)),
             home: Some(home_path.to_path_buf()),
         }
     }
@@ -94,6 +105,7 @@ impl GridEnvelopeJoins {
             live_wrappers: None,
             agenda: None,
             home: None,
+            lineage_epoch: None,
         }
     }
 
@@ -111,6 +123,9 @@ impl GridEnvelopeJoins {
             boot: boot_start_secs.map(|start_secs| CurrentBoot { start_secs }),
             live_wrappers,
             agenda,
+            lineage_epoch: home
+                .as_deref()
+                .map(crate::external_wrapper_index::lineage_epoch),
             home,
         }
     }
@@ -219,7 +234,7 @@ impl GridEnvelopeJoins {
             boot_block["terminal"] = terminal.clone();
         }
         if ghost {
-            match dead_row_lineage_tip(self.home.as_deref(), session_id, dir) {
+            match dead_row_lineage_tip(self.home.as_deref(), session_id, dir, self.lineage_epoch) {
                 LineageTip::NoWrapperHistory => {}
                 LineageTip::SelfTip => {
                     boot_block["lineage_tip"] = serde_json::Value::Bool(true);
@@ -264,11 +279,14 @@ enum LineageTip {
 
 struct LineageTipMemoEntry {
     transcript_fingerprint: (u64, u128),
-    index_fingerprint: (u64, u128),
+    lineage_epoch: u64,
     tip: LineageTip,
 }
 
-const LINEAGE_TIP_MEMO_LIMIT: usize = 4096;
+/// Comfortably above the session-store dir count (~4k on the machine the
+/// hot-spin hit), so clear-on-full stays a corruption backstop instead of
+/// wiping the memo mid-pass right at today's scale.
+const LINEAGE_TIP_MEMO_LIMIT: usize = 16_384;
 
 fn lineage_tip_memo() -> &'static Mutex<HashMap<String, LineageTipMemoEntry>> {
     static MEMO: OnceLock<Mutex<HashMap<String, LineageTipMemoEntry>>> = OnceLock::new();
@@ -293,24 +311,36 @@ fn transcript_fingerprint(dir: &Path) -> (u64, u128) {
 /// walker AND its own tip reduction (`successor_tip` past this row —
 /// only `Active` records qualify; `Superseded` rows are dead
 /// incarnations, never what a card should point at). Memoized on (own
-/// transcript, wrapper index) fingerprints: a dead dir never changes and
-/// every new wrapper generation writes the index, so hits are exact and
-/// misses are one bounded walk.
-fn dead_row_lineage_tip(home: Option<&Path>, session_id: &str, dir: &Path) -> LineageTip {
+/// transcript fingerprint, wrapper-index lineage epoch): a dead dir
+/// never changes and every new wrapper generation writes an index row,
+/// so hits are exact and misses are one bounded walk — seeded with the
+/// row's own dir so the walk never pays the id→dir directory probe for
+/// its seed. The epoch (not the raw index fingerprint — see the module
+/// header) is resolved once per build by the caller.
+fn dead_row_lineage_tip(
+    home: Option<&Path>,
+    session_id: &str,
+    dir: &Path,
+    lineage_epoch: Option<u64>,
+) -> LineageTip {
     let Some(home) = home else {
         return LineageTip::NoWrapperHistory;
     };
     let transcript = transcript_fingerprint(dir);
-    let index = crate::external_wrapper_index::index_fingerprint(home);
+    let epoch =
+        lineage_epoch.unwrap_or_else(|| crate::external_wrapper_index::lineage_epoch(home));
     if let Ok(memo) = lineage_tip_memo().lock() {
         if let Some(entry) = memo.get(session_id) {
-            if entry.transcript_fingerprint == transcript && entry.index_fingerprint == index {
+            if entry.transcript_fingerprint == transcript && entry.lineage_epoch == epoch {
                 return entry.tip.clone();
             }
         }
     }
-    let lineage =
-        crate::session_supervisor::resume_lineage::resolve_resume_lineage(home, &[session_id]);
+    let lineage = crate::session_supervisor::resume_lineage::resolve_resume_lineage_with_dir_hints(
+        home,
+        &[session_id],
+        &[(session_id, dir)],
+    );
     let tip = if let Some(record) = lineage.successor_tip(&[session_id]) {
         LineageTip::ContinuedAs {
             source: record.source.clone(),
@@ -330,7 +360,7 @@ fn dead_row_lineage_tip(home: Option<&Path>, session_id: &str, dir: &Path) -> Li
             session_id.to_string(),
             LineageTipMemoEntry {
                 transcript_fingerprint: transcript,
-                index_fingerprint: index,
+                lineage_epoch: epoch,
                 tip: tip.clone(),
             },
         );
@@ -1018,6 +1048,50 @@ mod tests {
         assert_eq!(
             row["boot"]["continued_as"]["session_id"], "gl4-wrapper-child",
             "the retirement edge must reach the edit-branch child — only the shared resolver walks it"
+        );
+    }
+
+    /// The tip memo's freshness law under its epoch key: a tip memoized
+    /// in one build (here: SelfTip — the chain's only wrapper) must NOT
+    /// be served by a later build once the index gained a walk-relevant
+    /// change (a successor generation demoting the seed). The memo keys
+    /// on the lineage EPOCH — recency restamps hold it steady (pinned in
+    /// `external_wrapper_index::tests::lineage_epoch_tracks_walk_relevant_content_only`),
+    /// so this test pins the other direction: real changes must break
+    /// the memo hit.
+    #[test]
+    fn stale_tip_never_served_across_epoch_change() {
+        let home = tempfile::tempdir().unwrap();
+        let solo_dir = announce(home.path(), "gl5-wrapper-solo", &["gl5-b1"]);
+        let watershed = now_secs() + 3_600;
+
+        let mut row = serde_json::json!({});
+        joins_with_home(Some(watershed), Some(&[]), home.path()).attach(
+            &mut row,
+            "gl5-wrapper-solo",
+            &solo_dir,
+        );
+        assert_eq!(
+            row["boot"]["lineage_tip"], true,
+            "the sole wrapper is its own tip (memoized this build)"
+        );
+
+        // A successor generation announces the same conversation: new
+        // index row + the solo row's demotion — a walk-relevant change.
+        announce(home.path(), "gl5-wrapper-heir", &["gl5-b1"]);
+        let mut row = serde_json::json!({});
+        joins_with_home(Some(watershed), Some(&[]), home.path()).attach(
+            &mut row,
+            "gl5-wrapper-solo",
+            &solo_dir,
+        );
+        assert_eq!(
+            row["boot"]["lineage_tip"], false,
+            "the memoized SelfTip must not survive the epoch change"
+        );
+        assert_eq!(
+            row["boot"]["continued_as"]["session_id"], "gl5-wrapper-heir",
+            "the re-walk must reach the successor generation"
         );
     }
 

--- a/src/bin/caller/web_gateway/session_catalog/grid_envelope.rs
+++ b/src/bin/caller/web_gateway/session_catalog/grid_envelope.rs
@@ -327,8 +327,7 @@ fn dead_row_lineage_tip(
         return LineageTip::NoWrapperHistory;
     };
     let transcript = transcript_fingerprint(dir);
-    let epoch =
-        lineage_epoch.unwrap_or_else(|| crate::external_wrapper_index::lineage_epoch(home));
+    let epoch = lineage_epoch.unwrap_or_else(|| crate::external_wrapper_index::lineage_epoch(home));
     if let Ok(memo) = lineage_tip_memo().lock() {
         if let Some(entry) = memo.get(session_id) {
             if entry.transcript_fingerprint == transcript && entry.lineage_epoch == epoch {


### PR DESCRIPTION
## What

Fixes the sessions-list serving lane's O(store)-per-poll grid-envelope attach — the 2026-07-30 post-restart hot-spin (daemon at 871% CPU, accept/TLS starvation; agenda item 01KYTKW2AR, evidence in the boot-storm findings).

## Root cause

The lineage-tip memo behind dead rows' successor pointers keyed on the wrapper index's raw file fingerprint. The list pass's own backfill restamps live rows' `updated_at_secs` from log-dir mtimes, so while any wrapper session is appending its transcript, **every serve rewrites the index and invalidates every memo entry** — and the next serve re-runs a lineage BFS per ghost row (~3.7k) that parses whole transcripts, sweeps the index once per backend per hop under the global INDEX_LOCK, and degrades to the O(store) `session_meta.json` directory probe.

## Fix (attach output is byte-identical; only the caching grains change)

- **`lineage_epoch`** (external_wrapper_index): hash over exactly the walk-relevant fields — identity triple, `log_path`, `state`, both tombstones — excluding recency restamps and cached lookup paths; cached per file fingerprint. The tip memo keys on it, resolved once per build.
- **`wrapper_records_for_wrapper_id`**: single-pass reverse lookup (log-dir basename match, existence stats on matching rows only), replacing the per-backend `wrappers_for_source` sweeps (full-index stat+clone+sort ×3 per hop) in the conversation collector.
- **`resolve_resume_lineage_with_dir_hints`**: the walk carries dirs it already knows (the seed row's own dir, closure records' `log_path`), so per-hop expansion skips the id→dir probe. Hintless callers (boot readopt, ask delivery, scheduler) are byte-for-byte unchanged.
- **Identity-scan memo**: the dir-local half of `recorded_backend_conversations` is memoized per (dir, id) on transcript+meta fingerprints — dead transcripts never re-parse.
- Tip memo cap 4096 → 16384 (store is ~4k dirs; clear-on-full at the old cap thrashes at exactly today's scale).

## Tests

4 new pins: epoch moves with walk-relevant content only; reverse lookup ≡ the source sweep (incl. basename-matching + existence parity); dir hints change no walk outcomes; a memoized tip is never served across a real epoch change. All existing suites in the touched modules pass.