### PR TITLE
copy(connect): honest install timing + understated closer

### DIFF
--- a/src/bin/connect/ui.rs
+++ b/src/bin/connect/ui.rs
@@ -2618,7 +2618,7 @@ mod tests {
         // The name is the thesis, told through the house metaphor — the
         // ambition itself stays understated on the public page.
         assert!(html.contains("Why “Intendant”"));
-        assert!(html.contains("house rules always win"));
+        assert!(html.contains("companies tour on signed contracts"));
         // Custody names both stores and makes the missing bridge explicit.
         assert!(html.contains(r#"class="fuelmap""#));
         assert!(html.contains("account-vault API/storage only"));

--- a/src/bin/connect/ui.rs
+++ b/src/bin/connect/ui.rs
@@ -791,7 +791,7 @@ pub(crate) fn landing_ui_html(origin: &str) -> String {
     </section>
 
     <section class="install-section" id="install">
-      <h2>Stand up a daemon in about ninety seconds</h2>
+      <h2>Stand up a daemon in a few minutes</h2>
       <p class="sectionlede">
         Four answers about the machine the agent will live on, and the exact
         command appears. You can discover it from your phone without a separate
@@ -986,7 +986,7 @@ pub(crate) fn landing_ui_html(origin: &str) -> String {
       perform, orchestrators conduct (Codex, Claude Code, Kimi Code, and Pi as
       guest conductors), and the Intendant runs the house and answers to you —
       houses federate, companies tour on signed contracts, house rules always
-      win: a network of agentic networks.</p>
+      win.</p>
     </section>
 
     <section class="trustrow">
@@ -2615,9 +2615,10 @@ mod tests {
             install_at < heroshot_at && heroshot_at < tour_at,
             "install must lead, then the product tour"
         );
-        // The name is the thesis, stated once, quietly, before the trust row.
+        // The name is the thesis, told through the house metaphor — the
+        // ambition itself stays understated on the public page.
         assert!(html.contains("Why “Intendant”"));
-        assert!(html.contains("a network of agentic networks"));
+        assert!(html.contains("house rules always win"));
         // Custody names both stores and makes the missing bridge explicit.
         assert!(html.contains(r#"class="fuelmap""#));
         assert!(html.contains("account-vault API/storage only"));


### PR DESCRIPTION
Two owner-directed softenings of live landing copy ahead of the alpha redeploy: the install headline drops the ninety-seconds claim for the installer's own honest wording (a few minutes; 15m measured on 2 vCPU, second datapoint pending), and the Why-Intendant closer ends on the concrete house-rules beat instead of naming the network thesis (understatement law). Landing test re-pinned to the surviving phrase; targeted landing battery green locally.