### PR TITLE
install: bootstrap git via the platform package manager when missing

### DIFF
--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -37,6 +37,15 @@ built-in restart supervisor on systemd-less Linux — no init system is a
 dependency) and prints where the one-time claim code lands. `intendant service
 uninstall|status` manage it afterwards.
 
+The installer stands up its own prerequisites: when `git` is missing (stock
+Debian minimal cloud images ship without it), the pre-flight installs it
+through the platform package manager — apt/dnf/yum/zypper/pacman/apk/brew,
+winget or choco on Windows — announcing the exact command before it runs,
+escalating via `sudo` only where it exists and never silently, and otherwise
+stopping to name the command for you to run. Rust and the native build
+dependencies follow the same law via the per-OS setup scripts from the
+cloned tree.
+
 For reproducibility, pin the tag instead of `latest`:
 `…/releases/download/v0.1.0/install.sh`. Release assets are immutable, and a
 stamped installer double-checks itself: it prints its release identity

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -93,8 +93,37 @@ $elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsId
     ).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
 
 # -- Toolchain --
+# git is needed before anything else -- the clone is how the repo's own
+# setup scripts (scripts\setup-windows.ps1) arrive, so they cannot
+# install it for us. A stock box may lack it: try winget, then choco,
+# announcing the exact command before it runs -- elevation only ever
+# happens through their own visible prompts (UAC), never silently. With
+# neither manager present, stop and name the command to run.
 if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
-    Fail "git is required. Install it (winget install Git.Git) and re-run -- or run scripts\setup-windows.ps1 from an elevated shell after cloning $Repo."
+    if (Get-Command winget -ErrorAction SilentlyContinue) {
+        $gitInstall = @("winget", "install", "--id", "Git.Git", "-e", "--source", "winget",
+            "--accept-package-agreements", "--accept-source-agreements")
+    } elseif (Get-Command choco -ErrorAction SilentlyContinue) {
+        $gitInstall = @("choco", "install", "git", "-y")
+    } else {
+        Fail "git is required and neither winget nor choco is here to install it. Install it yourself (winget install Git.Git) and re-run -- or run scripts\setup-windows.ps1 from an elevated shell after cloning $Repo."
+    }
+    $gitInstallShown = $gitInstall -join " "
+    Say "git is missing -- installing it via: $gitInstallShown"
+    $gitInstallExe, $gitInstallArgs = $gitInstall
+    & $gitInstallExe @gitInstallArgs
+    if ($LASTEXITCODE -ne 0) {
+        Fail "git install failed -- run it yourself ($gitInstallShown), then re-run this installer."
+    }
+    # The package manager extends PATH for future shells only -- append the
+    # machine/user PATH here so this session sees the new git (append, not
+    # replace: process-only entries must survive).
+    $env:Path = $env:Path + ";" +
+        [Environment]::GetEnvironmentVariable("Path", "Machine") + ";" +
+        [Environment]::GetEnvironmentVariable("Path", "User")
+    if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+        Fail "git was installed but is not on PATH in this session -- open a new PowerShell and re-run this installer."
+    }
 }
 
 # -- Source --

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -120,7 +120,46 @@ esac
 # Only git is needed this early (for the clone). Rust may legitimately be
 # missing on a fresh box — scripts/setup-linux.sh installs it below, so
 # the hard requirement is enforced after dependency setup, not before it.
-command -v git >/dev/null 2>&1 || die "git is required (install it and re-run)"
+# git lives under the same self-sufficiency law, but the repo's setup
+# scripts cannot carry it — they arrive BY the clone — and stock cloud
+# images (Debian minimal, for one) ship without it. So the pre-flight
+# installs git through the platform package manager, honestly: the exact
+# command is announced before it runs, sudo is used only where it exists
+# (prompting on its own terms), and with no root path the script stops
+# and names the command for you — never a silent escalation.
+if ! command -v git >/dev/null 2>&1; then
+  GIT_NEEDS_ROOT=1
+  if command -v apt-get >/dev/null 2>&1; then
+    GIT_INSTALL="apt-get update && apt-get install -y git"
+  elif command -v dnf >/dev/null 2>&1; then
+    GIT_INSTALL="dnf install -y git"
+  elif command -v yum >/dev/null 2>&1; then
+    GIT_INSTALL="yum install -y git"
+  elif command -v zypper >/dev/null 2>&1; then
+    GIT_INSTALL="zypper --non-interactive install git"
+  elif command -v pacman >/dev/null 2>&1; then
+    GIT_INSTALL="pacman -Sy --noconfirm git"
+  elif command -v apk >/dev/null 2>&1; then
+    GIT_INSTALL="apk add git"
+  elif command -v brew >/dev/null 2>&1; then
+    # brew refuses to run as root and does its own escalation.
+    GIT_INSTALL="brew install git"
+    GIT_NEEDS_ROOT=0
+  else
+    die "git is required, and no supported package manager was found to install it (apt-get, dnf, yum, zypper, pacman, apk, brew) — install git yourself, then re-run this installer"
+  fi
+  if [ "$GIT_NEEDS_ROOT" = "1" ] && [ "$(id -u)" != "0" ]; then
+    command -v sudo >/dev/null 2>&1 || die "git is required, this shell is not root, and there is no sudo — as root, run:
+    $GIT_INSTALL
+then re-run this installer"
+    say "git is missing — installing it now: sudo sh -c '$GIT_INSTALL' (sudo may prompt for your password)"
+    sudo sh -c "$GIT_INSTALL" || die "git install failed — run it yourself: sudo sh -c '$GIT_INSTALL' — then re-run this installer"
+  else
+    say "git is missing — installing it now: $GIT_INSTALL"
+    sh -c "$GIT_INSTALL" || die "git install failed — run it yourself: $GIT_INSTALL — then re-run this installer"
+  fi
+  command -v git >/dev/null 2>&1 || die "the install reported success but git is still not on PATH — install git yourself, then re-run this installer"
+fi
 
 # ── Source ──
 if [ -d "$INSTALL_DIR/.git" ]; then

--- a/scripts/setup-linux.sh
+++ b/scripts/setup-linux.sh
@@ -63,9 +63,17 @@ detect_distro() {
 
 # ── Sudo ──────────────────────────────────────────────────────────────────
 
+# Prefix for the few commands that need root. ensure_sudo sets it: empty
+# when this shell already IS root (stock root images -- containers, many
+# VPS defaults -- ship no sudo at all, so hardcoding it would break the
+# exact boxes that need setup most), "sudo" once access is confirmed
+# otherwise.
+SUDO="sudo"
+
 ensure_sudo() {
-    # Already root -- nothing to check.
+    # Already root -- nothing to escalate through.
     if [[ $EUID -eq 0 ]]; then
+        SUDO=""
         return
     fi
 
@@ -217,8 +225,8 @@ install_apt_packages() {
     fi
 
     info "installing ${#missing[@]} system packages..."
-    sudo apt-get update -qq
-    sudo apt-get install -y -qq "${missing[@]}"
+    $SUDO apt-get update -qq
+    $SUDO apt-get install -y -qq "${missing[@]}"
 }
 
 # ── Rust ──────────────────────────────────────────────────────────────────
@@ -613,8 +621,8 @@ build_intendant() {
     # downstream tools (e.g. setup-lan.bat invoking `intendant access` over
     # SSH on this guest).
     info "linking intendant into /usr/local/bin..."
-    sudo ln -sf "$bin_dir/intendant" /usr/local/bin/intendant
-    sudo ln -sf "$bin_dir/intendant-runtime" /usr/local/bin/intendant-runtime
+    $SUDO ln -sf "$bin_dir/intendant" /usr/local/bin/intendant
+    $SUDO ln -sf "$bin_dir/intendant-runtime" /usr/local/bin/intendant-runtime
 
     echo ""
     ok "intendant          -> $bin_dir/intendant"
@@ -698,7 +706,11 @@ run_install() {
     # Phase 1: sudo
     info "checking sudo access..."
     ensure_sudo
-    ok "sudo access confirmed"
+    if [[ -z "$SUDO" ]]; then
+        ok "running as root (no sudo needed)"
+    else
+        ok "sudo access confirmed"
+    fi
 
     # Phase 2: system packages
     echo ""

--- a/src/bin/connect/ui.rs
+++ b/src/bin/connect/ui.rs
@@ -2853,6 +2853,42 @@ mod tests {
     }
 
     #[test]
+    fn install_scripts_bootstrap_git_before_first_use() {
+        // Stock cloud images (Debian minimal, for one) ship without git,
+        // and the repo's setup scripts arrive BY the clone — the installer
+        // itself must stand git up through the platform package manager.
+        // Escalation stays honest: the exact command is announced before it
+        // runs, sudo is used only where it exists, and the no-root path
+        // dies naming the command instead of escalating silently.
+        assert!(
+            INSTALL_SH.contains("apt-get update && apt-get install -y git"),
+            "install.sh must bootstrap git via apt on Debian-family boxes"
+        );
+        assert!(
+            INSTALL_SH.contains("sudo sh -c '$GIT_INSTALL'"),
+            "install.sh must announce and run the identical command under sudo"
+        );
+        assert!(
+            INSTALL_SH.contains("there is no sudo — as root, run:"),
+            "the no-sudo path must name the exact command, never escalate"
+        );
+        assert!(
+            !INSTALL_SH.contains("git is required (install it and re-run)"),
+            "the bounce-to-manual git pre-flight must stay gone"
+        );
+        // The ps1 twin: winget first, choco fallback, honest fail with
+        // neither — plus the PATH pickup that makes the fresh git visible
+        // to the already-running session.
+        assert!(INSTALL_PS1.contains("\"winget\", \"install\", \"--id\", \"Git.Git\""));
+        assert!(INSTALL_PS1.contains("\"choco\", \"install\", \"git\", \"-y\""));
+        assert!(INSTALL_PS1.contains("GetEnvironmentVariable(\"Path\", \"Machine\")"));
+        assert!(
+            INSTALL_PS1.contains("neither winget nor choco"),
+            "install.ps1 must fail honestly when no package manager exists"
+        );
+    }
+
+    #[test]
     fn install_routes_redirect_to_the_release_assets() {
         // The canonical anchors live under the project repo on GitHub —
         // never under a serving origin. Golden twin of


### PR DESCRIPTION
The landing one-liner died at step zero on stock Debian 12: minimal cloud images ship without git, and the repo's setup scripts arrive BY the clone, so nothing downstream could ever fix it. Fresh-VPS rehearsal finding #1; agenda card 01KYV1DCAF331S66DWK1W5X0FE (item-as-brief).

- **install.sh pre-flight**: when git is missing, pick the platform package manager (apt-get, dnf, yum, zypper, pacman, apk, brew) and install it — announcing the exact command before it runs, sudo only where it exists (prompting on its own terms), and an honest stop that names the command when there is no root path. Never a silent escalation. This joins the deferred-rust self-sufficiency law (setup-linux.sh installs rustup because cloud images lack cargo); git is the one tool the cloned tree cannot install for us.
- **install.ps1 twin**: winget → choco with the same announce-first honesty, honest fail with neither, and a machine/user PATH pickup (append, not replace) so the already-running session sees the fresh git. Stays pure ASCII (the PowerShell 5.1 BOM-less ANSI-decode pin).
- **setup-linux.sh**: found by the rig one step later — root shells without sudo (stock containers, VPS root defaults) tripped over four hardcoded `sudo` call sites while ensure_sudo happily reported access. `ensure_sudo` now sets a `$SUDO` prefix: empty as root, `sudo` once confirmed.
- **Stamp/verify machinery byte-stable**: the sentinel assignment lines, the RELEASE_PIN_MISMATCH contract, and the redirect-target twins are untouched. New deliberate pin test `install_scripts_bootstrap_git_before_first_use` in connect ui.rs covers the bootstrap contract (apt command literal, announced-sudo form, honest no-sudo stop, ps1 winget/choco + PATH pickup).
- **docs**: getting-started's one-command section now states the installer stands up its own prerequisites.

Acceptance — all green (rig: stock `debian:12` containers, amd64, piped `sh -s -- --no-run` exactly like the one-liner, `--ref` to this branch so the cloned tree carries the setup-linux.sh fix):
- **root without sudo**: full run to completion, **exit 0** (~17 min) — announce `git is missing — installing it now: apt-get update && apt-get install -y git`, clone, setup-linux.sh "running as root (no sudo needed)" + 31 packages + rustup + full release build, `--locked` build, links, done.
- **non-root + passwordless sudo (the GCP debian-12 shape)**: full run to completion, **exit 0** — announce `git is missing — installing it now: sudo sh -c 'apt-get update && apt-get install -y git' (sudo may prompt for your password)`.
- **non-root without sudo**: honest die naming `apt-get update && apt-get install -y git`, **exit 1**, no escalation attempted.
- **stock-image preflight**: plain `apt-get install -y git` on debian:12 yields TLS-capable git 2.39.5 (ca-certificates via recommends) that reaches the repo — verified before committing to the minimal announced command.

Local battery: `cargo test -p intendant --bins` 5359+151+97 all green (connect suite includes the new pin test); workspace clippy `-D warnings` clean.