### PR TITLE
agenda graph: raise the node cap to 420 with a re-tiered settle budget

### DIFF
--- a/static/app.html
+++ b/static/app.html
@@ -37994,7 +37994,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'db0a5cc37ca738f8';
+const INTENDANT_APP_BUILD = 'f8120a46aa6316d7';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -98783,7 +98783,13 @@ function agendaBellRender() {
 // module-level visibilitychange listener below is the stop/resume
 // conduit itself and must outlive any one activation to resume it.
 
-const AGENDA_GRAPH_NODE_CAP = 180;
+// Owner-raised 2026-07-31 (from the original 180): the O(n²) cost only
+// bites during the brief settle window and the per-frame budget tiers
+// keep that window's frame work roughly constant as n grows, so the
+// honest bound is legibility — and legibility is what the hubs/focus
+// projections and arrangement modes are for. Past THIS cap the settle
+// window itself stops fitting a frame budget worth defending.
+const AGENDA_GRAPH_NODE_CAP = 420;
 // Design-parity settle budget, amortized: the prototype ran 260
 // synchronous O(n²) relaxation iterations per relayout; here the same
 // total is spread over frames (agendaGraphSettleBudget per rAF) so a
@@ -98922,9 +98928,8 @@ function agendaGraphProjectionItems() {
 function agendaGraphRenderLens(host) {
   // Resolve the projection: an explicit chip choice wins; focus
   // overrides the pool; auto degrades an over-cap ledger to the hub
-  // overview (the ratified cap still bounds every projection — the
-  // O(n²) relaxation and the label field stop earning their keep
-  // beyond it).
+  // overview (the cap still bounds every projection; past it the
+  // settle window's O(n²) relaxation stops fitting the frame budget).
   let items = agendaGraphPoolItems();
   let overCapAll = false;
   if (agendaGraphFocus) {
@@ -99517,7 +99522,11 @@ function agendaGraphBuild() {
 function agendaGraphSettleBudget(count) {
   if (count <= 60) return 30;
   if (count <= 120) return 12;
-  return 6;
+  if (count <= 240) return 6;
+  // Keeps per-frame settle work roughly constant as n² grows: 420
+  // nodes at 4 iterations/frame ≈ 240 at 6 (the settle just takes a
+  // few more frames to spend its 260-iteration total).
+  return 4;
 }
 
 function agendaGraphRelax(iterations) {

--- a/static/app/ui2-agenda-graph.js
+++ b/static/app/ui2-agenda-graph.js
@@ -28,7 +28,13 @@
 // module-level visibilitychange listener below is the stop/resume
 // conduit itself and must outlive any one activation to resume it.
 
-const AGENDA_GRAPH_NODE_CAP = 180;
+// Owner-raised 2026-07-31 (from the original 180): the O(n²) cost only
+// bites during the brief settle window and the per-frame budget tiers
+// keep that window's frame work roughly constant as n grows, so the
+// honest bound is legibility — and legibility is what the hubs/focus
+// projections and arrangement modes are for. Past THIS cap the settle
+// window itself stops fitting a frame budget worth defending.
+const AGENDA_GRAPH_NODE_CAP = 420;
 // Design-parity settle budget, amortized: the prototype ran 260
 // synchronous O(n²) relaxation iterations per relayout; here the same
 // total is spread over frames (agendaGraphSettleBudget per rAF) so a
@@ -167,9 +173,8 @@ function agendaGraphProjectionItems() {
 function agendaGraphRenderLens(host) {
   // Resolve the projection: an explicit chip choice wins; focus
   // overrides the pool; auto degrades an over-cap ledger to the hub
-  // overview (the ratified cap still bounds every projection — the
-  // O(n²) relaxation and the label field stop earning their keep
-  // beyond it).
+  // overview (the cap still bounds every projection; past it the
+  // settle window's O(n²) relaxation stops fitting the frame budget).
   let items = agendaGraphPoolItems();
   let overCapAll = false;
   if (agendaGraphFocus) {
@@ -762,7 +767,11 @@ function agendaGraphBuild() {
 function agendaGraphSettleBudget(count) {
   if (count <= 60) return 30;
   if (count <= 120) return 12;
-  return 6;
+  if (count <= 240) return 6;
+  // Keeps per-frame settle work roughly constant as n² grows: 420
+  // nodes at 4 iterations/frame ≈ 240 at 6 (the settle just takes a
+  // few more frames to spend its 260-iteration total).
+  return 4;
 }
 
 function agendaGraphRelax(iterations) {


### PR DESCRIPTION
Owner-directed: the 180 cap made a 244-item ledger's explicit 'everything' land on the over-cap note instead of the map. The only superlinear cost is the O(n²) relaxation during the brief settle window, and that is governed by the per-frame iteration budget — so the cap rises to 420 with one new budget tier (4 iterations/frame past 240 nodes) keeping settle-frame work roughly constant (420@4 ≈ 240@6; the 260-iteration total just spends over a few more frames). Steady-state rendering is linear and unaffected.

Behavior: current-size ledgers render fully under 'everything' (again the auto landing, since hub-overview degradation only engages past the cap); hubs/focus/modes remain the legibility instruments one click away; the over-cap note survives only past 420 non-retired items, where a narrower projection genuinely is the answer. Comments updated to carry the new rationale instead of the stale 'ratified 180' language.

Battery: bins + lib crates pass, workspace clippy -D warnings clean, node --check, app.html regenerated via the assembler.