### PR TITLE
RC-B1: relay peer admission and liveness

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -517,6 +517,7 @@ without changing that refusal or the Connect account's `role:none` posture.
 | `relay_enabled` | bool | `false` | Hold a reachability-relay control channel to Connect so this daemon's NAT'd fleet name is reachable through the relay's SNI passthrough (docs/src/self-hosted-rendezvous.md). Custom exact-name routes additionally prove possession of their publicly trusted certificate key. Dial-backs terminate on a dedicated loopback-only gateway ingress and cannot enter the trusted-local lane. Requires `relay_endpoint` |
 | `relay_endpoint` | string | unset | `host:port` of the relay's raw passthrough port, where this daemon dials back browser connections (e.g. `relay.example.com:443`) |
 | `hosted_control_enabled` | bool | `false` | Enable the daemon-local hosted lease doorbell and exact lease-proof/ticket carve on fleet/relay ingress. Restart-only; deliberately has no environment-variable override |
+| `relay_peer_admission` | bool | `false` | Admit this daemon's paired peer daemons (Approved, unexpired peer identity records) through fleet-name/relay ingress into the ordinary peer transport-auth ladder; peer profiles stay the sole control-depth authority (docs/src/self-hosted-rendezvous.md § Relay peer admission). Independent of `hosted_control_enabled` in both directions. Restart-only; deliberately has no environment-variable override |
 | `custom_domain.enabled` | bool | `false` | Enable the separate user-owned-name lane. Restart-only; no environment-variable override |
 | `custom_domain.name` | string | unset | Exact ASCII/punycode DNS name served by the daemon |
 | `custom_domain.rp_id` | string | `custom_domain.name` | WebAuthn relying-party id; when present it must equal the exact name |
@@ -542,8 +543,9 @@ and passkey enrollment.
 holds no certificate, and grants no authority — a relayed browser connection
 reaches this daemon bearing immutable relay/fleet provenance. It stays
 discovery-only unless `hosted_control_enabled` is true and the request proves
-an active hosted lease; `/mcp`, direct signaling, and trusted-local fallback
-remain unavailable.
+an active hosted lease, or `relay_peer_admission` is true and the connection
+presents an active paired peer identity; for everything else `/mcp`, direct
+signaling, and trusted-local fallback remain unavailable.
 
 No file editing is required for the common case: the dashboard's
 **Access → Intendant Connect** card toggles `enabled` (persisting it

--- a/docs/src/self-hosted-rendezvous.md
+++ b/docs/src/self-hosted-rendezvous.md
@@ -346,16 +346,57 @@ The relay is **availability-only**: it terminates no TLS, holds no
 certificate, mints no authority, and logs no plaintext. The gateway
 records which listener accepted each connection before it parses TLS or
 HTTP. Connections from the relay-only ingress remain anonymous `role:none`
-unless the optional hosted-control lane validates a fresh lease proof. That
-carve admits only explicitly classified HTTPS routes, while `/mcp`, direct
-signaling, trusted-local fallback, unknown routes, and every unproved request
-remain refused. WebSocket upgrade additionally consumes a seconds-lived
-one-use ticket minted by a proof-bound HTTPS request. The tunnel's loopback
+unless one of two independent per-daemon opt-ins validates its own
+credential class. The optional hosted-control lane validates a fresh lease
+proof: that carve admits only explicitly classified HTTPS routes, while
+`/mcp`, direct signaling, trusted-local fallback, unknown routes, and every
+unproved request remain refused, and WebSocket upgrade additionally consumes
+a seconds-lived one-use ticket minted by a proof-bound HTTPS request. The
+optional peer-admission lane (`[connect] relay_peer_admission`, below)
+admits Approved, unexpired peer identity records into the ordinary peer
+transport-auth ladder. The tunnel's loopback
 last hop therefore cannot qualify for trusted-local authority even when the
 encrypted request contains `Host: localhost`; fleet-SNI classification is an
 independent second gate. Non-TLS bytes are dropped before the gateway's raw
 ICE-TCP and cleartext-MCP demultiplexer, so the relay-only listener cannot
 reach either local lane.
+
+### Relay peer admission (daemon-to-daemon federation through the relay)
+
+`[connect] relay_peer_admission = true` (default false; boot-pinned — read
+once at gateway spawn, restart to apply; deliberately no environment
+override) lets **this daemon's own paired peer daemons** reach it through
+the relay and, equivalently, through any fleet-name dial. The admitted
+class is exactly a TLS client certificate that resolves to an Approved,
+unexpired **peer identity record** — a daemon-side credential the target's
+own access CA minted through an owner-consented lane (pairing invite,
+doorbell approval, or org-grant materialization). The record check runs
+per request, so revoking or expiring an identity kills its next request.
+Admission converts transport provenance only: the connection proceeds into
+the same remote-client-auth, grant-minting, and per-operation profile/IAM
+ladder a direct-lane peer walks, and the peer profile the owner granted
+remains the sole control-depth authority. Browser-enrolled mTLS
+certificates resolve no peer record and keep the discovery-only refusal
+byte-identical in both key states; the hosted-control browser lane and its
+switch are independent in both directions. Connect needs no changes and
+learns nothing — under TLS 1.3 the client certificate crosses the relay
+inside the encrypted handshake.
+
+Relayed federation links are **episodic by design**, not permanent: the
+relay tears down splices idle for 120 s in either direction, caps each
+splice at 512 MiB per direction, and drops everything on a relay restart.
+Two daemon-side mechanisms make that livable. The dialing peer's control
+link originates a WebSocket ping every ~30–35 s (jittered per peer), so an
+idle-but-healthy link never hits the idle teardown and a half-open link
+surfaces as a prompt write error instead of a silent hang. When a splice
+does die — byte cap, relay restart, network blip — the peer actor walks
+its ordinary jittered reconnect backoff (0.5 s–30 s) and re-probes every
+transport candidate, so the link self-heals at the cost of a fresh
+dial-back. Consumers should treat a relayed peer as a
+session-with-reconnects, exactly like a direct peer on a flaky network.
+Control operations and signaling ride this link; display media and
+file-transfer bytes ride WebRTC and need a direct route or provisioned
+TURN — a relay-only-reachable peer has no media path.
 
 Enable it with the all-or-nothing `--relay-*` group (both flags or
 neither; default off, mirroring `--dns-*`):
@@ -449,7 +490,13 @@ The Rust gateway E2E
 then covers the opt-in carve end to end: signed doorbell creation through the
 real relay ingress, trusted-local approval, proof-bound HTTP, proof replay
 refusal, `/mcp` refusal, one-use ticketed WebSocket admission, preset action
-denial, ticket-reuse refusal, and live socket closure after revocation.
+denial, ticket-reuse refusal, and live socket closure after revocation. Its
+peer-lane siblings (`relay_peer_admission_*`, same module) pin the admission
+key's whole contract: key off, refusals stay byte-identical with an active
+peer identity presented; key on, active records (org-materialized included)
+land in the existing per-profile ladder with direct-lane parity while
+browser-enrolled certificates, revoked/expired records, and anonymous
+callers keep today's refusals.
 
 ```bash
 cargo build --bin intendant --bin intendant-runtime --bin intendant-connect

--- a/docs/src/trust-architecture.md
+++ b/docs/src/trust-architecture.md
@@ -61,13 +61,33 @@ own fleet certificate. The daemon tunnel splices that ciphertext into a
 dedicated loopback-only gateway ingress, separate from the public listener.
 Which listener accepted the connection is immutable transport provenance: the
 gateway marks every such connection `ReachabilityRelay` before TLS or HTTP
-parsing. With hosted control off, it serves only authority-free discovery bytes
+parsing. In the all-off default, it serves only authority-free discovery bytes
 under anonymous `role:none` and refuses every protected HTTP, MCP, signaling,
-and WebSocket route. With hosted control on, the sole protected-route carve-out
-is a fresh proof by an active daemon-minted `hosted_lease` principal, or a
-one-use WebSocket ticket minted by such a proof; a second compiled classifier
-then limits the route, method, frame, concrete action, target, and outbound
-event projection. Thus neither the loopback address of the tunnel's last hop
+and WebSocket route. Exactly two per-daemon opt-ins admit anything more, each
+gating its own credential class and neither moving the other:
+
+- With hosted control on (`[connect] hosted_control_enabled`), the
+  browser-lane carve-out is a fresh proof by an active daemon-minted
+  `hosted_lease` principal, or a one-use WebSocket ticket minted by such a
+  proof; a second compiled classifier then limits the route, method, frame,
+  concrete action, target, and outbound event projection.
+- With relay peer admission on (`[connect] relay_peer_admission` — default
+  off, boot-pinned, deliberately no environment override), the peer-lane
+  carve-out is a TLS client certificate that resolves to an **Approved,
+  unexpired peer identity record**: a daemon-side credential minted by the
+  target's own access CA through an owner-consented lane (pairing invite,
+  doorbell approval, or org grant materialization) whose private key lives in
+  daemon files — a class no browser keystore can hold or be scripted into
+  presenting. Admission converts transport provenance only: the connection
+  continues into the same transport-auth ladder every direct-lane peer
+  request passes, the peer profile the owner granted remains the sole
+  control-depth authority per operation and frame, and revocation or expiry
+  of the record kills the next request. A browser-enrolled mTLS certificate
+  resolves no peer record and keeps the refusal byte-identical, in both key
+  states. The relay itself is unchanged — it still sees only ciphertext and
+  admits nothing; the widening is entirely a daemon-side policy predicate.
+
+Thus neither the loopback address of the tunnel's last hop
 nor a browser-controlled `Host: localhost` can enter the trusted-local lane.
 Fleet SNI remains an independent provenance gate, not an mTLS bypass. The relay
 ingress also rejects non-TLS bytes before the gateway's raw ICE-TCP and

--- a/src/bin/caller/peer/actor.rs
+++ b/src/bin/caller/peer/actor.rs
@@ -134,6 +134,35 @@ fn backoff_seed(peer_id: &PeerId) -> u32 {
 }
 
 // ---------------------------------------------------------------------------
+// Keepalive
+// ---------------------------------------------------------------------------
+
+/// Dialer-originated keepalive cadence for the peer control link. The
+/// Connect relay tears down splices idle for
+/// [`crate::relay_tunnel::SPLICE_IDLE`] (120 s, enforced on both relay
+/// sides), so without traffic an idle relayed federation link dies by
+/// construction; on direct links, half-open detection is otherwise
+/// TCP-timeout-only. One wire ping per jittered ~30 s keeps both alive.
+/// Pinned by `keepalive_cadence_is_pinned_comfortably_under_relay_idle`:
+/// base + max jitter must stay at or under half the relay idle window.
+const KEEPALIVE_BASE: Duration = Duration::from_secs(30);
+/// Upper bound on the deterministic per-tick jitter added to
+/// [`KEEPALIVE_BASE`], decorrelating peer actors like the backoff jitter.
+const KEEPALIVE_JITTER_MAX: Duration = Duration::from_secs(5);
+
+/// Next keepalive delay: base plus deterministic jitter in
+/// `[0, KEEPALIVE_JITTER_MAX]`, stepped per tick and phase-shifted per
+/// actor — the same reproducible-jitter approach as [`Backoff`].
+fn keepalive_delay(seed: u32, tick: u32) -> Duration {
+    let span_ms = KEEPALIVE_JITTER_MAX.as_millis() as u64 + 1;
+    let jitter_ms = u64::from(tick)
+        .wrapping_mul(137)
+        .wrapping_add(u64::from(seed))
+        % span_ms;
+    KEEPALIVE_BASE + Duration::from_millis(jitter_ms)
+}
+
+// ---------------------------------------------------------------------------
 // The actor
 // ---------------------------------------------------------------------------
 
@@ -366,8 +395,28 @@ impl PeerActor {
     ///    narrative, then trip `StreamEnded` so the outer run
     ///    loop transitions to Reconnecting.
     async fn main_loop(&mut self) -> MainLoopExit {
+        // Dialer-originated liveness (see the keepalive constants above).
+        // The deadline is absolute, so serving events or commands does
+        // not defer the next ping — a receive-active link still writes
+        // bytes inside the relay's idle window.
+        let keepalive_seed = backoff_seed(&self.peer_id);
+        let mut keepalive_tick: u32 = 0;
+        let mut keepalive_at =
+            tokio::time::Instant::now() + keepalive_delay(keepalive_seed, keepalive_tick);
         loop {
             tokio::select! {
+                _ = tokio::time::sleep_until(keepalive_at) => {
+                    if self.transport.keepalive().await.is_err() {
+                        // The wire refused a ping: the connection is
+                        // unusable. Same exit as a drain-task disconnect —
+                        // the run loop emits Disconnected and walks the
+                        // reconnect backoff.
+                        return MainLoopExit::StreamEnded;
+                    }
+                    keepalive_tick = keepalive_tick.wrapping_add(1);
+                    keepalive_at = tokio::time::Instant::now()
+                        + keepalive_delay(keepalive_seed, keepalive_tick);
+                }
                 maybe_event = self.events_in_rx.recv() => {
                     match maybe_event {
                         Some(event) => {
@@ -725,6 +774,102 @@ mod tests {
                 "seed {seed}: got {d:?}, expected between {min:?} and {max:?}"
             );
         }
+    }
+
+    /// The relay tears down idle splices at `SPLICE_IDLE`; the dialer's
+    /// keepalive cadence must sit comfortably under it — pinned here at
+    /// half the window even at maximum jitter — and stay deterministic
+    /// and bounded like the backoff jitter.
+    #[test]
+    fn keepalive_cadence_is_pinned_comfortably_under_relay_idle() {
+        assert_eq!(KEEPALIVE_BASE, Duration::from_secs(30));
+        let ceiling = KEEPALIVE_BASE + KEEPALIVE_JITTER_MAX;
+        assert!(
+            ceiling * 2 <= crate::relay_tunnel::SPLICE_IDLE,
+            "keepalive ceiling {ceiling:?} must stay at or under half the relay idle \
+             teardown {:?}",
+            crate::relay_tunnel::SPLICE_IDLE,
+        );
+        for seed in [0, 1, 137, u32::MAX] {
+            for tick in 0..64 {
+                let delay = keepalive_delay(seed, tick);
+                assert!(
+                    delay >= KEEPALIVE_BASE && delay <= ceiling,
+                    "seed {seed} tick {tick}: {delay:?} outside [{KEEPALIVE_BASE:?}, {ceiling:?}]"
+                );
+                assert_eq!(delay, keepalive_delay(seed, tick), "jitter must be deterministic");
+            }
+        }
+    }
+
+    /// While connected, the main loop originates one wire ping per
+    /// jittered keepalive period, and a refused ping ends the loop like
+    /// a stream end (the run loop then walks reconnect).
+    #[tokio::test(start_paused = true)]
+    async fn main_loop_pings_on_the_keepalive_cadence_and_exits_on_ping_failure() {
+        struct KeepaliveProbeTransport {
+            spec: crate::peer::card::TransportSpec,
+            pings: Arc<std::sync::atomic::AtomicU32>,
+            fail_on: u32,
+        }
+
+        #[async_trait::async_trait]
+        impl PeerTransport for KeepaliveProbeTransport {
+            fn spec(&self) -> &crate::peer::card::TransportSpec {
+                &self.spec
+            }
+            fn features(&self) -> crate::peer::traits::TransportFeatures {
+                crate::peer::traits::TransportFeatures::default()
+            }
+            async fn connect(&mut self) -> Result<AgentCard, PeerError> {
+                Err(PeerError::NotConnected)
+            }
+            async fn disconnect(&mut self) -> Result<(), PeerError> {
+                Ok(())
+            }
+            fn is_connected(&self) -> bool {
+                true
+            }
+            async fn send(
+                &mut self,
+                _op: crate::peer::traits::PeerOp,
+            ) -> Result<crate::peer::traits::PeerOpAck, PeerError> {
+                Err(PeerError::NotConnected)
+            }
+            async fn keepalive(&mut self) -> Result<(), PeerError> {
+                let count = self
+                    .pings
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+                    + 1;
+                if count >= self.fail_on {
+                    Err(PeerError::Transport("wire gone".into()))
+                } else {
+                    Ok(())
+                }
+            }
+        }
+
+        let (log_tx, _log_rx) = mpsc::channel(8);
+        let (mut actor, (_commands_tx, _events_in_tx, _events_out_rx)) = test_actor(log_tx);
+        let pings = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        actor.transport = Box::new(KeepaliveProbeTransport {
+            spec: crate::peer::card::TransportSpec::IntendantWs {
+                url: "ws://127.0.0.1:1/ws".into(),
+            },
+            pings: Arc::clone(&pings),
+            fail_on: 3,
+        });
+
+        let started = tokio::time::Instant::now();
+        let exit = actor.main_loop().await;
+        assert!(matches!(exit, MainLoopExit::StreamEnded));
+        assert_eq!(pings.load(std::sync::atomic::Ordering::SeqCst), 3);
+        let elapsed = started.elapsed();
+        let ceiling = KEEPALIVE_BASE + KEEPALIVE_JITTER_MAX;
+        assert!(
+            elapsed >= KEEPALIVE_BASE * 3 && elapsed <= ceiling * 3,
+            "three keepalive periods expected, got {elapsed:?}"
+        );
     }
 
     struct StubTransport(crate::peer::card::TransportSpec);

--- a/src/bin/caller/peer/actor.rs
+++ b/src/bin/caller/peer/actor.rs
@@ -797,7 +797,11 @@ mod tests {
                     delay >= KEEPALIVE_BASE && delay <= ceiling,
                     "seed {seed} tick {tick}: {delay:?} outside [{KEEPALIVE_BASE:?}, {ceiling:?}]"
                 );
-                assert_eq!(delay, keepalive_delay(seed, tick), "jitter must be deterministic");
+                assert_eq!(
+                    delay,
+                    keepalive_delay(seed, tick),
+                    "jitter must be deterministic"
+                );
             }
         }
     }
@@ -837,10 +841,7 @@ mod tests {
                 Err(PeerError::NotConnected)
             }
             async fn keepalive(&mut self) -> Result<(), PeerError> {
-                let count = self
-                    .pings
-                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
-                    + 1;
+                let count = self.pings.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
                 if count >= self.fail_on {
                     Err(PeerError::Transport("wire gone".into()))
                 } else {

--- a/src/bin/caller/peer/traits.rs
+++ b/src/bin/caller/peer/traits.rs
@@ -264,7 +264,7 @@ pub fn check_feature(features: &TransportFeatures, op: &PeerOp) -> Result<(), Pe
 
 /// Low-level wire handler for one peer connection.
 ///
-/// Single trait, six methods. All role-specific ergonomics live on
+/// Single trait, seven methods. All role-specific ergonomics live on
 /// [`crate::peer::handle::PeerHandle`] — transports just move bytes.
 #[async_trait]
 pub trait PeerTransport: Send + Sync {
@@ -289,4 +289,17 @@ pub trait PeerTransport: Send + Sync {
     /// Execute one operation. Must call [`check_feature`] at the top
     /// as the invariant guard.
     async fn send(&mut self, op: PeerOp) -> Result<PeerOpAck, PeerError>;
+
+    /// Emit one wire-level liveness probe on the live connection.
+    ///
+    /// The actor calls this on a jittered ~30 s cadence
+    /// (`peer::actor` pins the constants) so relayed federation links
+    /// survive the Connect relay's 120 s splice idle teardown and
+    /// half-open direct links surface as write errors instead of
+    /// hanging silently. An error means the connection is unusable —
+    /// the actor treats it like a stream end and walks reconnect.
+    /// Default: no-op for transports without a persistent wire.
+    async fn keepalive(&mut self) -> Result<(), PeerError> {
+        Ok(())
+    }
 }

--- a/src/bin/caller/peer/transport/intendant.rs
+++ b/src/bin/caller/peer/transport/intendant.rs
@@ -602,6 +602,19 @@ impl PeerTransport for IntendantWsTransport {
         self.ws_write.is_some()
     }
 
+    /// One WebSocket `Ping` on the control link. The peer's tungstenite
+    /// answers the pong automatically (see `drain_ws`), so this needs no
+    /// application-level reply handling: the point is bytes on the wire
+    /// in both directions inside the relay's idle window, and a prompt
+    /// write error when the connection is half-open.
+    async fn keepalive(&mut self) -> Result<(), PeerError> {
+        let write = self.ws_write.as_mut().ok_or(PeerError::NotConnected)?;
+        write
+            .send(Message::Ping(Vec::new().into()))
+            .await
+            .map_err(|e| PeerError::Transport(format!("ws keepalive ping: {e}")))
+    }
+
     async fn send(&mut self, op: PeerOp) -> Result<PeerOpAck, PeerError> {
         check_feature(&self.features(), &op)?;
         if self.ws_write.is_none() {

--- a/src/bin/caller/peer/transport/multi.rs
+++ b/src/bin/caller/peer/transport/multi.rs
@@ -145,6 +145,15 @@ impl PeerTransport for MultiTransport {
             None => Err(PeerError::NotConnected),
         }
     }
+
+    async fn keepalive(&mut self) -> Result<(), PeerError> {
+        match self.active {
+            Some(i) => self.candidates[i].keepalive().await,
+            // No live connection to keep alive; the actor is between
+            // connects and the reconnect walk owns liveness there.
+            None => Ok(()),
+        }
+    }
 }
 
 /// Union of all candidates' features. Used by `MultiTransport::features`

--- a/src/bin/caller/project.rs
+++ b/src/bin/caller/project.rs
@@ -2157,8 +2157,7 @@ mod tests {
         assert!(!ConnectConfig::default().relay_peer_admission);
         let empty: ProjectConfig = toml::from_str("[connect]\nenabled = true\n").unwrap();
         assert!(!empty.connect.relay_peer_admission);
-        let on: ProjectConfig =
-            toml::from_str("[connect]\nrelay_peer_admission = true\n").unwrap();
+        let on: ProjectConfig = toml::from_str("[connect]\nrelay_peer_admission = true\n").unwrap();
         assert!(on.connect.relay_peer_admission);
 
         let _env = crate::test_support::TEST_ENV_LOCK.blocking_lock();

--- a/src/bin/caller/project.rs
+++ b/src/bin/caller/project.rs
@@ -1221,6 +1221,20 @@ pub struct ConnectConfig {
     /// behavior. There is intentionally no environment-variable override.
     #[serde(default)]
     pub hosted_control_enabled: bool,
+    /// Optional relay peer admission: admit this daemon's paired peer
+    /// daemons — TLS client certificates that resolve to an Approved,
+    /// unexpired peer identity record, a daemon-side credential class
+    /// minted by this daemon's own access CA that no browser keystore can
+    /// hold — through fleet-name/relay ingress into the ordinary peer
+    /// transport-auth ladder (peer profiles remain the sole control-depth
+    /// authority). Deliberately independent from `hosted_control_enabled`
+    /// in both directions, and default-off: when false, fleet/relay
+    /// ingress keeps the discovery-only `role:none` refusal for every
+    /// credential class, byte-identical to today. Boot-pinned: read once
+    /// at gateway spawn; restart to apply. There is intentionally no
+    /// environment-variable override.
+    #[serde(default)]
+    pub relay_peer_admission: bool,
     /// Opt-in user-owned-name control lane.
     #[serde(default)]
     pub custom_domain: CustomDomainConfig,
@@ -1294,6 +1308,7 @@ impl Default for ConnectConfig {
             relay_enabled: false,
             relay_endpoint: None,
             hosted_control_enabled: false,
+            relay_peer_admission: false,
             custom_domain: CustomDomainConfig::default(),
         }
     }
@@ -2130,6 +2145,35 @@ pub fn root_has_project_marker(root: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The relay-peer-admission opt-in is default-off, parses from the
+    /// `[connect]` table, and — mirroring `hosted_control_enabled` —
+    /// deliberately has no environment-variable override: an env name
+    /// shaped like the other Connect overrides must not flip it. The
+    /// gateway boot-pins the value at spawn, so this key changing at
+    /// runtime is a restart, never a live mutation.
+    #[test]
+    fn relay_peer_admission_defaults_off_with_no_env_override() {
+        assert!(!ConnectConfig::default().relay_peer_admission);
+        let empty: ProjectConfig = toml::from_str("[connect]\nenabled = true\n").unwrap();
+        assert!(!empty.connect.relay_peer_admission);
+        let on: ProjectConfig =
+            toml::from_str("[connect]\nrelay_peer_admission = true\n").unwrap();
+        assert!(on.connect.relay_peer_admission);
+
+        let _env = crate::test_support::TEST_ENV_LOCK.blocking_lock();
+        let guard = crate::web_gateway::tests::EnvVarGuard::set(
+            "INTENDANT_CONNECT_RELAY_PEER_ADMISSION",
+            "1",
+        );
+        assert!(
+            !ConnectConfig::default()
+                .effective_with_env()
+                .relay_peer_admission,
+            "relay peer admission is owner-file opt-in only — no env override exists"
+        );
+        drop(guard);
+    }
 
     #[test]
     fn codex_effective_command_prefers_the_fork_only_for_managed_sessions() {

--- a/src/bin/caller/relay_tunnel.rs
+++ b/src/bin/caller/relay_tunnel.rs
@@ -75,7 +75,9 @@ const BACKOFF_MAX: Duration = Duration::from_secs(30);
 /// fleet name keeps resolving to the relay (the DNS record TTL is short).
 const DNS_REASSERT_INTERVAL: Duration = Duration::from_secs(240);
 /// Idle teardown + per-direction byte cap on a spliced dial-back connection.
-const SPLICE_IDLE: Duration = Duration::from_secs(120);
+/// `pub(crate)` so the peer actor's keepalive cadence pin asserts against
+/// the real teardown window instead of a mirrored literal.
+pub(crate) const SPLICE_IDLE: Duration = Duration::from_secs(120);
 const SPLICE_MAX_BYTES: u64 = 512 * 1024 * 1024;
 const DIALBACK_SETUP_TIMEOUT: Duration = Duration::from_secs(10);
 const MAX_ACTIVE_DIALBACKS: usize = 64;

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -17,6 +17,10 @@ pub(crate) struct HttpRequestCtx {
     pub(crate) hosted_control: Arc<crate::access::hosted_control::HostedControlRuntime>,
     pub(crate) custom_domain: Arc<crate::custom_domain::CustomDomainRuntime>,
     pub(crate) fleet_hosted_control_enabled: bool,
+    /// Boot-pinned `[connect] relay_peer_admission`: stamped from the
+    /// gateway config at spawn like `fleet_hosted_control_enabled`, so a
+    /// live config edit never reclassifies an open connection.
+    pub(crate) relay_peer_admission: bool,
     pub(crate) bus: EventBus,
     pub(crate) config_json: String,
     pub(crate) session_provider: String,
@@ -102,6 +106,7 @@ pub(crate) async fn serve_http_request(
         hosted_control,
         custom_domain,
         fleet_hosted_control_enabled,
+        relay_peer_admission,
         bus,
         config_json,
         session_provider,
@@ -348,6 +353,24 @@ pub(crate) async fn serve_http_request(
     let public_lease_ingress = public_lane.public_lease_ingress;
     let configured_public_control_lane = public_lane.configured;
     let tls_custom_domain = public_lane.live_custom_domain;
+    // Relay peer admission (owner opt-in, boot-pinned, default off): an
+    // Approved, unexpired peer identity record exempts exactly the
+    // fleet/relay transport-provenance refusal below and continues into
+    // the SAME transport-auth ladder every direct-lane peer request
+    // passes (remote client auth, then per-operation profile/IAM). The
+    // discriminator is the resolved ACTIVE record — a daemon-side
+    // credential minted by this daemon's own access CA at pairing, org
+    // grant, or doorbell approval, a class no browser keystore can hold
+    // or be scripted into presenting. Browser-enrolled certificates
+    // resolve no record (`Ok(None)`) and keep the refusal byte-identical;
+    // revoked/expired records were already refused at resolution. The
+    // custom-domain (owner-name) browser lane is deliberately outside the
+    // exemption: peers dial the fleet name, and the owner-name lane stays
+    // lease-only in both key states.
+    let admitted_relay_peer = relay_peer_admission
+        && base_discovery_only_ingress
+        && !custom_domain_selected
+        && peer_connection_identity.is_some();
     // A custom-domain TLS name is itself a live authority decision even
     // before a passkey endpoint mints a lease. Retain that decision at the
     // transport edge now, so body reads, authority-worker awaits, and
@@ -448,7 +471,11 @@ pub(crate) async fn serve_http_request(
     } else {
         None
     };
-    if public_lease_ingress && !authority_free_request && hosted_verified.is_none() {
+    if public_lease_ingress
+        && !authority_free_request
+        && hosted_verified.is_none()
+        && !admitted_relay_peer
+    {
         use tokio::io::AsyncWriteExt;
         let error = if custom_domain_selected {
             "this public endpoint requires a valid bounded lease; use a trusted direct surface for root administration"

--- a/src/bin/caller/web_gateway/listener.rs
+++ b/src/bin/caller/web_gateway/listener.rs
@@ -2058,6 +2058,7 @@ fn spawn_web_gateway_from_cert_dir_with_relay_listener(
                         hosted_control: Arc::clone(&hosted_control),
                         custom_domain: Arc::clone(&custom_domain),
                         fleet_hosted_control_enabled: config.connect.hosted_control_enabled,
+                        relay_peer_admission: config.connect.relay_peer_admission,
                         bus: bus.clone(),
                         config_json: config_json.clone(),
                         session_provider: session_provider.clone(),
@@ -2150,6 +2151,21 @@ fn spawn_web_gateway_from_cert_dir_with_relay_listener(
                     let public_lease_ws = public_lane.public_lease_ingress;
                     let configured_public_ws = public_lane.configured;
                     let live_tls_custom_domain = public_lane.live_custom_domain;
+                    // Relay peer admission — the WS twin of the HTTP
+                    // exemption in `http_dispatch.rs` (see the comment
+                    // there for the full rationale): under the
+                    // boot-pinned owner opt-in, an Approved, unexpired
+                    // peer identity record passes the fleet/relay
+                    // transport-provenance refusal below into the SAME
+                    // ladder direct-lane peers walk (remote client auth,
+                    // grant minting, per-frame profile authorization).
+                    // Browser-enrolled certificates resolve no record and
+                    // are refused byte-identically; the owner-name
+                    // (custom-domain) lane stays lease-only.
+                    let admitted_relay_peer_ws = config.connect.relay_peer_admission
+                        && base_discovery_only_ws
+                        && !custom_domain_selected
+                        && peer_connection_identity.is_some();
                     let hosted_ws_authority = if configured_public_ws && hosted_control.enabled() {
                         let ticket =
                             query_param(header_text.lines().next().unwrap_or(""), "hosted_ticket");
@@ -2200,7 +2216,8 @@ fn spawn_web_gateway_from_cert_dir_with_relay_listener(
                     } else {
                         None
                     };
-                    if public_lease_ws && hosted_ws_authority.is_none() {
+                    if public_lease_ws && hosted_ws_authority.is_none() && !admitted_relay_peer_ws
+                    {
                         use tokio::io::AsyncWriteExt;
                         let error = if custom_domain_selected {
                             "this public endpoint requires a valid bounded lease; use a trusted direct surface for root administration"

--- a/src/bin/caller/web_gateway/listener.rs
+++ b/src/bin/caller/web_gateway/listener.rs
@@ -3655,6 +3655,227 @@ mod tests {
         connector.connect(server_name, tcp).await.unwrap()
     }
 
+    /// Relay-ingress gateway whose acceptor requests client certificates
+    /// against a real access CA (`ClientAuth::OptionalCa`, the production
+    /// shape from `startup/web.rs`), so tests can present CA-minted peer
+    /// client identities and install identity records beside them.
+    struct PeerAuthRelayGateway {
+        gateway: RelayIngressTestGateway,
+        /// The access CA certificate — the client-side trust root for the
+        /// CA-signed server certificate.
+        ca_der: rustls::pki_types::CertificateDer<'static>,
+    }
+
+    impl PeerAuthRelayGateway {
+        fn access_dir(&self) -> &std::path::Path {
+            self.gateway.access_dir.path()
+        }
+    }
+
+    async fn spawn_relay_ingress_test_gateway_with_peer_auth(
+        mut config: WebGatewayConfig,
+    ) -> PeerAuthRelayGateway {
+        let access_dir = tempfile::tempdir().expect("relay gateway test access store");
+        let hosted_identity_path = access_dir.path().join("hosted-identity.pk8");
+        config.hosted_control_identity_path = Some(hosted_identity_path.clone());
+        let server_names = crate::access::certs::ServerNames::new(
+            std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            [],
+            [],
+        )
+        .unwrap();
+        crate::access::certs::ensure_certs(access_dir.path(), &server_names, "relay-test", false)
+            .expect("generate access CA + server certificate");
+        let acceptor = crate::web_tls::build_single_cert_acceptor_with_client_auth(
+            &crate::web_tls::TlsCertSource::Files {
+                cert_path: access_dir.path().join("server.crt"),
+                key_path: access_dir.path().join("server.key"),
+            },
+            &crate::web_tls::ClientAuth::OptionalCa {
+                ca_path: access_dir.path().join("ca.crt"),
+            },
+        )
+        .unwrap();
+        let ca_pem = std::fs::read_to_string(access_dir.path().join("ca.crt")).unwrap();
+        let ca_der = rustls::pki_types::CertificateDer::from(
+            pem::parse(ca_pem.as_bytes()).unwrap().contents().to_vec(),
+        );
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let direct_addr = listener.local_addr().unwrap();
+        let relay_ingress_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let relay_addr = relay_ingress_listener.local_addr().unwrap();
+        let bus = EventBus::new();
+        let (broadcast_tx, _) = broadcast::channel::<String>(16);
+        let task = spawn_web_gateway_from_cert_dir_with_relay_listener(
+            listener,
+            bus.clone(),
+            broadcast_tx,
+            config,
+            ActiveSessionState::empty(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            Vec::new(),
+            None,
+            crate::peer::AuthRequirements::none(),
+            false,
+            Some(acceptor),
+            access_dir.path().to_path_buf(),
+            Some(relay_ingress_listener),
+        );
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        PeerAuthRelayGateway {
+            gateway: RelayIngressTestGateway {
+                task,
+                direct_addr,
+                relay_addr,
+                server_cert: ca_der.clone(),
+                access_dir,
+                hosted_identity_path,
+                bus,
+            },
+            ca_der,
+        }
+    }
+
+    /// TLS stream presenting a CA-minted client identity — the wire shape
+    /// of a dialing peer daemon (or, without an identity record installed,
+    /// of a browser-enrolled mTLS client).
+    async fn tls_client_identity_stream(
+        tcp: tokio::net::TcpStream,
+        ca_der: rustls::pki_types::CertificateDer<'static>,
+        identity: &crate::access::certs::IssuedClientIdentity,
+    ) -> tokio_rustls::client::TlsStream<tokio::net::TcpStream> {
+        let mut roots = rustls::RootCertStore::empty();
+        roots.add(ca_der).unwrap();
+        let chain = vec![rustls::pki_types::CertificateDer::from(
+            pem::parse(identity.cert_pem.as_bytes())
+                .unwrap()
+                .contents()
+                .to_vec(),
+        )];
+        let key = rustls::pki_types::PrivateKeyDer::Pkcs8(
+            pem::parse(identity.key_pem.as_bytes())
+                .unwrap()
+                .contents()
+                .to_vec()
+                .into(),
+        );
+        let config = rustls::ClientConfig::builder()
+            .with_root_certificates(roots)
+            .with_client_auth_cert(chain, key)
+            .unwrap();
+        let connector = tokio_rustls::TlsConnector::from(Arc::new(config));
+        let server_name = rustls::pki_types::ServerName::try_from("localhost".to_string()).unwrap();
+        connector.connect(server_name, tcp).await.unwrap()
+    }
+
+    /// One request over the given lane with a client identity presented.
+    /// `peer_header` mirrors the peer transport's `x-intendant-peer: 1`
+    /// routing hint (a browser-enrolled client sends no such header).
+    /// Reads to connection close — refusal lanes all close.
+    async fn identity_request(
+        addr: std::net::SocketAddr,
+        via_relay: bool,
+        ca_der: rustls::pki_types::CertificateDer<'static>,
+        identity: &crate::access::certs::IssuedClientIdentity,
+        peer_header: bool,
+        request: &str,
+    ) -> String {
+        let mut tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
+        if via_relay {
+            tcp.write_all(
+                format!(
+                    "{} {}\n",
+                    crate::relay_tunnel::GATEWAY_RELAY_SOURCE_MAGIC,
+                    "a".repeat(43)
+                )
+                .as_bytes(),
+            )
+            .await
+            .unwrap();
+        }
+        let mut tls = tls_client_identity_stream(tcp, ca_der, identity).await;
+        let request = if peer_header {
+            request.replacen("\r\n", "\r\nx-intendant-peer: 1\r\n", 1)
+        } else {
+            request.to_string()
+        };
+        tls.write_all(with_test_loopback_token(&request).as_bytes())
+            .await
+            .unwrap();
+        let mut response = Vec::new();
+        tokio::time::timeout(
+            tokio::time::Duration::from_secs(10),
+            tls.read_to_end(&mut response),
+        )
+        .await
+        .expect("identity request response timed out")
+        .unwrap();
+        String::from_utf8_lossy(&response).into_owned()
+    }
+
+    /// Same as [`identity_request`] but returns as soon as the response
+    /// head is complete — a successful WebSocket upgrade (101) never
+    /// closes the stream, so reading to EOF would hang there.
+    async fn identity_request_head(
+        addr: std::net::SocketAddr,
+        via_relay: bool,
+        ca_der: rustls::pki_types::CertificateDer<'static>,
+        identity: &crate::access::certs::IssuedClientIdentity,
+        peer_header: bool,
+        request: &str,
+    ) -> String {
+        let mut tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
+        if via_relay {
+            tcp.write_all(
+                format!(
+                    "{} {}\n",
+                    crate::relay_tunnel::GATEWAY_RELAY_SOURCE_MAGIC,
+                    "a".repeat(43)
+                )
+                .as_bytes(),
+            )
+            .await
+            .unwrap();
+        }
+        let mut tls = tls_client_identity_stream(tcp, ca_der, identity).await;
+        let request = if peer_header {
+            request.replacen("\r\n", "\r\nx-intendant-peer: 1\r\n", 1)
+        } else {
+            request.to_string()
+        };
+        tls.write_all(with_test_loopback_token(&request).as_bytes())
+            .await
+            .unwrap();
+        let mut response = Vec::new();
+        let mut byte = [0u8; 1];
+        tokio::time::timeout(tokio::time::Duration::from_secs(10), async {
+            while !response.ends_with(b"\r\n\r\n") {
+                match tls.read(&mut byte).await {
+                    Ok(0) => break,
+                    Ok(_) => response.extend_from_slice(&byte),
+                    Err(_) => break,
+                }
+            }
+        })
+        .await
+        .expect("identity request head timed out");
+        String::from_utf8_lossy(&response).into_owned()
+    }
+
+    const WS_UPGRADE_REQUEST: &str = "GET /ws HTTP/1.1\r\nHost: localhost\r\nConnection: Upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Version: 13\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\r\n";
+    const CONFIG_REQUEST: &str =
+        "GET /config HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n";
+    /// The exact fleet-lane refusal string pinned by
+    /// `reachability_relay_ingress_is_discovery_only_not_trusted_local` —
+    /// with the admission key OFF it must stay byte-identical for every
+    /// credential class, active peer identities included.
+    const DISCOVERY_ONLY_REFUSAL: &str = "the public fleet-name endpoint is discovery-only without a valid bounded lease; use loopback or the independently fingerprint-verified direct mTLS address for control";
+
     fn http_json(response: &str) -> serde_json::Value {
         let body = response
             .split_once("\r\n\r\n")
@@ -4233,6 +4454,304 @@ mod tests {
         assert!(
             closed.is_ok(),
             "live hosted socket did not close after lease revocation"
+        );
+    }
+
+    /// With `[connect] relay_peer_admission` at its default (off), an
+    /// ACTIVE peer identity presented through the relay changes nothing:
+    /// both lanes' refusals stay byte-identical to the anonymous ones the
+    /// discovery-only pin already freezes.
+    #[tokio::test]
+    async fn relay_peer_admission_default_off_keeps_refusals_byte_identical() {
+        let gw = spawn_relay_ingress_test_gateway_with_peer_auth(WebGatewayConfig::default()).await;
+        let identity =
+            crate::access::certs::issue_client_identity(gw.access_dir(), "peer-daemon").unwrap();
+        let fingerprint =
+            crate::peer::access_policy::fingerprint_pem(&identity.cert_pem).unwrap();
+        crate::peer::access_policy::write_approved_identity(
+            gw.access_dir(),
+            &fingerprint,
+            "peer-daemon",
+            "admin-peer",
+            None,
+            None,
+        )
+        .unwrap();
+
+        let with_identity = identity_request(
+            gw.gateway.relay_addr,
+            true,
+            gw.ca_der.clone(),
+            &identity,
+            true,
+            CONFIG_REQUEST,
+        )
+        .await;
+        let anonymous = relay_tls_request(
+            gw.gateway.relay_addr,
+            gw.gateway.server_cert.clone(),
+            CONFIG_REQUEST,
+        )
+        .await;
+        assert!(
+            with_identity.starts_with("HTTP/1.1 403") && with_identity.contains(DISCOVERY_ONLY_REFUSAL),
+            "key off: an active peer identity must not move the relay refusal: {with_identity}"
+        );
+        assert_eq!(
+            with_identity, anonymous,
+            "key off: the peer-identity refusal must be byte-identical to the anonymous one"
+        );
+
+        let ws_with_identity = identity_request(
+            gw.gateway.relay_addr,
+            true,
+            gw.ca_der.clone(),
+            &identity,
+            true,
+            WS_UPGRADE_REQUEST,
+        )
+        .await;
+        let ws_anonymous = relay_tls_request(
+            gw.gateway.relay_addr,
+            gw.gateway.server_cert.clone(),
+            WS_UPGRADE_REQUEST,
+        )
+        .await;
+        assert!(
+            ws_with_identity.starts_with("HTTP/1.1 403")
+                && ws_with_identity.contains(DISCOVERY_ONLY_REFUSAL),
+            "key off: the WS upgrade refusal must hold against a peer identity: {ws_with_identity}"
+        );
+        assert_eq!(
+            ws_with_identity, ws_anonymous,
+            "key off: the WS refusal must be byte-identical to the anonymous one"
+        );
+    }
+
+    /// The `hosted_lease_is_the_only_relay_control_authority` sibling:
+    /// with the admission key ON, an ACTIVE peer identity record is the
+    /// only OTHER relay authority, and it lands in the EXISTING ladder —
+    /// per-operation profile depth answers exactly as on the direct lane
+    /// (org-materialized records admit like pairing-lane ones; every
+    /// mint lane is owner-consented authority), while anonymous callers
+    /// keep the discovery-only refusal.
+    #[tokio::test]
+    async fn relay_peer_admission_admits_active_records_into_the_existing_ladder() {
+        let mut config = WebGatewayConfig::default();
+        config.connect.relay_peer_admission = true;
+        let gw = spawn_relay_ingress_test_gateway_with_peer_auth(config).await;
+
+        // Pairing-lane record at the profile the federation control link
+        // uses (admin-peer passes the legacy /ws observer-set gate).
+        let control_peer =
+            crate::access::certs::issue_client_identity(gw.access_dir(), "control-peer").unwrap();
+        let control_fp =
+            crate::peer::access_policy::fingerprint_pem(&control_peer.cert_pem).unwrap();
+        crate::peer::access_policy::write_approved_identity(
+            gw.access_dir(),
+            &control_fp,
+            "control-peer",
+            "admin-peer",
+            None,
+            None,
+        )
+        .unwrap();
+        // Org-materialized ACTIVE record (P1 admitted-set honesty): same
+        // admission, narrower operator depth.
+        let org_peer =
+            crate::access::certs::issue_client_identity(gw.access_dir(), "org-peer").unwrap();
+        let org_fp = crate::peer::access_policy::fingerprint_pem(&org_peer.cert_pem).unwrap();
+        let mut org_record = crate::peer::access_policy::write_approved_identity_expiring(
+            gw.access_dir(),
+            &org_fp,
+            "org-peer",
+            "operator",
+            None,
+            None,
+            Some(crate::access::client_key::now_unix_ms() / 1000 + 3600),
+        )
+        .unwrap();
+        org_record.source = Some("org:acme".to_string());
+        org_record.org_grant_id = Some("grant-1".to_string());
+        crate::peer::access_policy::write_identity_record(gw.access_dir(), &org_record).unwrap();
+
+        // HTTP through the relay = HTTP on the direct lane, same record.
+        let via_relay = identity_request(
+            gw.gateway.relay_addr,
+            true,
+            gw.ca_der.clone(),
+            &org_peer,
+            true,
+            CONFIG_REQUEST,
+        )
+        .await;
+        let via_direct = identity_request(
+            gw.gateway.direct_addr,
+            false,
+            gw.ca_der.clone(),
+            &org_peer,
+            true,
+            CONFIG_REQUEST,
+        )
+        .await;
+        assert!(
+            via_relay.starts_with("HTTP/1.1 200"),
+            "an active org-materialized peer identity must be admitted through the relay: {via_relay}"
+        );
+        assert_eq!(
+            via_relay.lines().next(),
+            via_direct.lines().next(),
+            "relay admission must land in the direct lane's ladder, not a new one"
+        );
+
+        // The federation control link attaches through the relay.
+        let ws_control = identity_request_head(
+            gw.gateway.relay_addr,
+            true,
+            gw.ca_der.clone(),
+            &control_peer,
+            true,
+            WS_UPGRADE_REQUEST,
+        )
+        .await;
+        assert!(
+            ws_control.starts_with("HTTP/1.1 101"),
+            "an admin-peer identity must complete the /ws upgrade through the relay: {ws_control}"
+        );
+
+        // Profile depth still answers: an operator-profile record gets the
+        // LADDER's own observer-set refusal — not the transport refusal —
+        // and identically on both lanes.
+        let ws_relay = identity_request(
+            gw.gateway.relay_addr,
+            true,
+            gw.ca_der.clone(),
+            &org_peer,
+            true,
+            WS_UPGRADE_REQUEST,
+        )
+        .await;
+        let ws_direct = identity_request(
+            gw.gateway.direct_addr,
+            false,
+            gw.ca_der.clone(),
+            &org_peer,
+            true,
+            WS_UPGRADE_REQUEST,
+        )
+        .await;
+        assert!(
+            ws_relay.starts_with("HTTP/1.1 403")
+                && ws_relay.contains("observer read set")
+                && !ws_relay.contains(DISCOVERY_ONLY_REFUSAL),
+            "an admitted narrow profile must hit the ladder's own refusal: {ws_relay}"
+        );
+        assert_eq!(
+            ws_relay, ws_direct,
+            "profile-depth refusals must be identical on both lanes"
+        );
+
+        // Nothing else got opened: anonymous relay callers keep the
+        // discovery-only refusal even with the key on.
+        let anonymous = relay_tls_request(
+            gw.gateway.relay_addr,
+            gw.gateway.server_cert.clone(),
+            CONFIG_REQUEST,
+        )
+        .await;
+        assert!(
+            anonymous.starts_with("HTTP/1.1 403") && anonymous.contains(DISCOVERY_ONLY_REFUSAL),
+            "key on: anonymous relay callers must keep the discovery-only refusal: {anonymous}"
+        );
+    }
+
+    /// Even with the admission key ON, the widening admits exactly the
+    /// active-peer-record class: a browser-enrolled certificate (chain
+    /// valid, no record) keeps the discovery-only refusal byte-identical,
+    /// and revoked/expired records die at identity resolution.
+    #[tokio::test]
+    async fn relay_peer_admission_refuses_browser_certs_and_inactive_records() {
+        let mut config = WebGatewayConfig::default();
+        config.connect.relay_peer_admission = true;
+        let gw = spawn_relay_ingress_test_gateway_with_peer_auth(config).await;
+
+        // Browser-enrolled class: CA-minted certificate, NO peer identity
+        // record (`resolve…` returns `Ok(None)`), no peer routing header.
+        let browser =
+            crate::access::certs::issue_client_identity(gw.access_dir(), "browser").unwrap();
+        for request in [CONFIG_REQUEST, WS_UPGRADE_REQUEST] {
+            let response = identity_request(
+                gw.gateway.relay_addr,
+                true,
+                gw.ca_der.clone(),
+                &browser,
+                false,
+                request,
+            )
+            .await;
+            assert!(
+                response.starts_with("HTTP/1.1 403")
+                    && response.contains(DISCOVERY_ONLY_REFUSAL),
+                "a browser-enrolled certificate must keep the discovery-only refusal with the key ON: {response}"
+            );
+        }
+
+        // Revoked record: refused at resolution, on both lanes.
+        let revoked =
+            crate::access::certs::issue_client_identity(gw.access_dir(), "revoked-peer").unwrap();
+        let revoked_fp =
+            crate::peer::access_policy::fingerprint_pem(&revoked.cert_pem).unwrap();
+        crate::peer::access_policy::write_approved_identity(
+            gw.access_dir(),
+            &revoked_fp,
+            "revoked-peer",
+            "admin-peer",
+            None,
+            None,
+        )
+        .unwrap();
+        crate::peer::access_policy::revoke_identity(gw.access_dir(), &revoked_fp).unwrap();
+        let response = identity_request(
+            gw.gateway.relay_addr,
+            true,
+            gw.ca_der.clone(),
+            &revoked,
+            true,
+            CONFIG_REQUEST,
+        )
+        .await;
+        assert!(
+            response.starts_with("HTTP/1.1 403") && response.contains("peer identity revoked"),
+            "a revoked record must be refused at resolution: {response}"
+        );
+
+        // Expired record: same fate.
+        let expired =
+            crate::access::certs::issue_client_identity(gw.access_dir(), "expired-peer").unwrap();
+        let expired_fp =
+            crate::peer::access_policy::fingerprint_pem(&expired.cert_pem).unwrap();
+        crate::peer::access_policy::write_approved_identity_expiring(
+            gw.access_dir(),
+            &expired_fp,
+            "expired-peer",
+            "admin-peer",
+            None,
+            None,
+            Some(crate::access::client_key::now_unix_ms() / 1000 - 60),
+        )
+        .unwrap();
+        let response = identity_request(
+            gw.gateway.relay_addr,
+            true,
+            gw.ca_der.clone(),
+            &expired,
+            true,
+            WS_UPGRADE_REQUEST,
+        )
+        .await;
+        assert!(
+            response.starts_with("HTTP/1.1 403") && response.contains("peer identity expired"),
+            "an expired record must be refused at resolution: {response}"
         );
     }
 

--- a/src/bin/caller/web_gateway/listener.rs
+++ b/src/bin/caller/web_gateway/listener.rs
@@ -2216,8 +2216,7 @@ fn spawn_web_gateway_from_cert_dir_with_relay_listener(
                     } else {
                         None
                     };
-                    if public_lease_ws && hosted_ws_authority.is_none() && !admitted_relay_peer_ws
-                    {
+                    if public_lease_ws && hosted_ws_authority.is_none() && !admitted_relay_peer_ws {
                         use tokio::io::AsyncWriteExt;
                         let error = if custom_domain_selected {
                             "this public endpoint requires a valid bounded lease; use a trusted direct surface for root administration"
@@ -4466,8 +4465,7 @@ mod tests {
         let gw = spawn_relay_ingress_test_gateway_with_peer_auth(WebGatewayConfig::default()).await;
         let identity =
             crate::access::certs::issue_client_identity(gw.access_dir(), "peer-daemon").unwrap();
-        let fingerprint =
-            crate::peer::access_policy::fingerprint_pem(&identity.cert_pem).unwrap();
+        let fingerprint = crate::peer::access_policy::fingerprint_pem(&identity.cert_pem).unwrap();
         crate::peer::access_policy::write_approved_identity(
             gw.access_dir(),
             &fingerprint,
@@ -4494,7 +4492,8 @@ mod tests {
         )
         .await;
         assert!(
-            with_identity.starts_with("HTTP/1.1 403") && with_identity.contains(DISCOVERY_ONLY_REFUSAL),
+            with_identity.starts_with("HTTP/1.1 403")
+                && with_identity.contains(DISCOVERY_ONLY_REFUSAL),
             "key off: an active peer identity must not move the relay refusal: {with_identity}"
         );
         assert_eq!(
@@ -4699,8 +4698,7 @@ mod tests {
         // Revoked record: refused at resolution, on both lanes.
         let revoked =
             crate::access::certs::issue_client_identity(gw.access_dir(), "revoked-peer").unwrap();
-        let revoked_fp =
-            crate::peer::access_policy::fingerprint_pem(&revoked.cert_pem).unwrap();
+        let revoked_fp = crate::peer::access_policy::fingerprint_pem(&revoked.cert_pem).unwrap();
         crate::peer::access_policy::write_approved_identity(
             gw.access_dir(),
             &revoked_fp,
@@ -4728,8 +4726,7 @@ mod tests {
         // Expired record: same fate.
         let expired =
             crate::access::certs::issue_client_identity(gw.access_dir(), "expired-peer").unwrap();
-        let expired_fp =
-            crate::peer::access_policy::fingerprint_pem(&expired.cert_pem).unwrap();
+        let expired_fp = crate::peer::access_policy::fingerprint_pem(&expired.cert_pem).unwrap();
         crate::peer::access_policy::write_approved_identity_expiring(
             gw.access_dir(),
             &expired_fp,

--- a/src/bin/caller/web_gateway/mod.rs
+++ b/src/bin/caller/web_gateway/mod.rs
@@ -502,6 +502,12 @@ mod tests {
             std::env::remove_var(key);
             Self { key, previous }
         }
+
+        pub(crate) fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
     }
 
     impl Drop for EnvVarGuard {

--- a/src/bin/caller/web_gateway/mod.rs
+++ b/src/bin/caller/web_gateway/mod.rs
@@ -488,7 +488,7 @@ async fn handle_diagnostics_visual_freshness(
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
 
     pub(crate) struct EnvVarGuard {

--- a/src/bin/caller/web_tls.rs
+++ b/src/bin/caller/web_tls.rs
@@ -189,6 +189,20 @@ pub fn build_acceptor_with_client_auth(
     Ok(TlsAcceptor::from(Arc::new(config)))
 }
 
+/// [`build_acceptor_with_client_auth`] minus the process-global fleet-SNI
+/// resolver: serves only `source`. Concurrent test gateways must not share
+/// the resolver's mutable base certificate, so client-auth test rigs use
+/// this form (the client-auth twin of [`build_single_cert_acceptor`]).
+#[cfg(test)]
+pub fn build_single_cert_acceptor_with_client_auth(
+    source: &TlsCertSource,
+    client_auth: &ClientAuth,
+) -> Result<TlsAcceptor, String> {
+    let (cert_chain, key) = load_cert_source(source)?;
+    let config = server_config_from(cert_chain, key, client_auth, false)?;
+    Ok(TlsAcceptor::from(Arc::new(config)))
+}
+
 fn load_cert_source(
     source: &TlsCertSource,
 ) -> Result<


### PR DESCRIPTION
Track RC Stage B, seat B1 (commission 01KYVKK04X69G5TZDZC6JJQAFT; binding basis: the accepted RC-B0 ruling in ~/rc-b0-intake.md — B1 checklist at the ruling tail).

Widens relay/fleet-name ingress by exactly one credential class — TLS client certificates that resolve to an Approved, unexpired peer identity record (daemon-side credentials minted by this daemon's own access CA through pairing, doorbell approval, or org-grant materialization) — under a new per-daemon, default-off, boot-pinned, deliberately-no-env `[connect] relay_peer_admission` key. Admitted connections continue into the existing peer transport-auth ladder (remote client auth, grant minting, per-operation/per-frame profile+IAM): no new principal type, transport provenance converts and nothing else. With the key off, every refusal stays byte-identical (test-pinned). Browser-enrolled certificates (no peer record) and revoked/expired records remain refused in both key states; hosted-lease, custom-domain, and loopback lanes untouched. Zero Connect changes.

Delivered:
- `[connect] relay_peer_admission` (default off, boot-pinned like `hosted_control_enabled`, no env override) + pin test `relay_peer_admission_defaults_off_with_no_env_override`
- HTTP + WS transport-provenance exemptions gated on the resolved ACTIVE record (`http_dispatch.rs`, `listener.rs`)
- Dialer-originated peer-control WS keepalive: `PeerTransport::keepalive` (default no-op; Intendant WS pings, MultiTransport delegates), jittered 30–35 s cadence in the peer actor, pinned at ≤ half the relay's 120 s `SPLICE_IDLE` (`keepalive_cadence_is_pinned_comfortably_under_relay_idle`, plus a paused-time loop test)
- e2e sibling family of `hosted_lease_is_the_only_relay_control_authority`: key-off byte-identity (both lanes, active record presented), key-on admission into the existing ladder with direct-lane parity (org-materialized record admits — P1 honesty; narrow profile hits the LADDER's own observer-set refusal, identically on both lanes), browser-cert/revoked/expired/anonymous negatives
- Docs: trust-architecture.md (second admitted class), self-hosted-rendezvous.md (§ Relay peer admission + episodic-link posture: 120 s idle, 512 MiB splice caps, keepalive, reconnect-through-backoff), configuration.md key row

Real-relay rig proof (sanctioned Option-C fleet-leaf pin recipe, loopback-only, zero Connect code changes; full findings + evidence at `~/rc-b1-rig/FINDINGS.md`):
1. TLS through the relay handshakes end-to-end against the target's own access cert (fingerprint byte-equal on the wire)
2. Paired dialer connects `wss://d-<fleet-label>.rig.localhost:18791/ws` through the live relay — registry `connected`; dialer's only TCP connection is to the relay
3. 150 s idle hold survives the 120 s splice teardown on the SAME socket (keepalive proof)
4. Key flipped off + target restart ⇒ every relayed attach refused 403; dialer walks jittered backoff
5. Key restored ⇒ self-heals to `connected` on the next walk
6. `ctl peer message` delivered end-to-end through the splice (`FollowUp` in the target's journal)

Battery: `cargo test -p intendant --bins` green; lib crates + e2e + `clippy --workspace -D warnings` + `cargo fmt --check` run before queueing with unmasked exits.