### PR TITLE
RC-C1: peer targeting and session lifecycle

### DIFF
--- a/docs/src/peer-federation.md
+++ b/docs/src/peer-federation.md
@@ -237,13 +237,59 @@ view (cleared on disconnect — the fold is connection-scoped, and stale entries
 would ghost if the peer restarted), and `PeerSnapshot` carries it as
 `sessions`, so `GET /api/peers` seeds a late-joining dashboard and every
 pushed `peer_state_changed` snapshot replaces the row's list losslessly (same
-source of truth as the live events). The dashboard renders them as
-display-only nodes orbiting the peer's host in the Station scene (capped per
-peer — the scene is a bounded constellation; the peer's own dashboard is the
-exhaustive list). Action pills stay off peer session nodes in v1: the
-session-action handlers assume local session ids. None of this changes what a
-peer exposes — the sessions rail is derived entirely from the event stream the
-peer already sends under its access profile.
+source of truth as the live events). The dashboard renders them as nodes
+orbiting the peer's host in the Station scene (capped per peer — the scene is
+a bounded constellation; the peer's own dashboard is the exhaustive list).
+None of this changes what a peer exposes — the sessions rail is derived
+entirely from the event stream the peer already sends under its access
+profile.
+
+### Host-scoped session actions — `session-control`
+
+Peer sessions are operable, not just visible. `POST
+/api/peers/{peer_id}/session-control` (tunnel twin
+`api_peer_session_control`; dialer-side IAM `peer.use`, like the other
+`/api/peers/{id}/<op>` quick controls) takes one session-lifecycle
+`ControlMsg` in its wire form — `{"message": {"action": "interrupt",
+"session_id": "…"}}` — where every session id is the *peer's* session id,
+forwarded verbatim. The dialer validates the action against a **derived**
+allowlist (the local session RPC lane's set intersected with the
+Message/Task/Approval/SessionManage operation classes — so Settings-,
+credentials-, and access-classified actions fail closed locally with an
+honest 403; agenda, memory, vault/custody, access/IAM, and settings stay
+doctrine-closed to peer routing), then `PeerOp::SessionControl` writes the
+`ControlMsg` to the peer's `/ws` verbatim. The peer authorizes it per-action
+against the profile it granted this daemon — the same
+`control_msg_operation` → profile evaluation every `/ws` client passes — so
+the op carries no authority of its own and works identically for
+direct-dialed and relay-transiting links (it rides the federation control
+WS, never the browser↔peer datachannel). Fire-and-forget like approvals:
+outcomes come back on the event stream.
+
+### The grant echo and the connected link — honesty rails
+
+Two `PeerSnapshot` fields exist so the dashboard renders what a peer row
+can actually do *now*, instead of guessing from the row's existence:
+
+- **`grant`** — on every peer-identified `/ws` connect, the *target*
+  daemon's bootstrap emits a `peer_grant` event: the profile it resolved
+  for the connecting identity plus the operation permission ids that
+  profile allows, derived from `profile_allows_operation` over the frozen
+  operation set (never a hand-kept list). The dialer folds it into
+  `PeerSnapshot.grant` (connection-scoped; cleared on disconnect;
+  re-advertised each connect, so profile edits land on the next
+  reconnect). Display metadata only: the peer's per-request gates enforce
+  authority regardless. `None` means *unknown* (older peer) — dashboards
+  treat unknown as "act and report", never as denial.
+- **`link`** — after each successful connect the actor records which
+  transport candidate won (`MultiTransport` re-walks candidates per
+  reconnect) as `{url, transport_class}`. `transport_class` is `direct`
+  for every candidate built today; the Stage-B relay candidate (RC-B2)
+  classifies `relayed`. Media and datachannel affordances — live display,
+  file-transfer bytes, the browser↔peer dashboard-control tunnel — are
+  rendered from this class: a relay-only link carries signaling and
+  request/response but nothing ICE-borne without a direct route or
+  provisioned TURN. Cleared while disconnected.
 
 ### Per-peer displays — the folded availability rail
 

--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -110,6 +110,21 @@ the prompt to another live session without leaving the current destination, and
 the conversation peek mirrors the target transcript's latest 12 entries
 read-only, updates live, and links back to the full Activity view.
 
+The target switcher also lists connected **peers** (RC-C1): picking a peer row
+delegates the composed text as a task on that daemon; picking one of its
+sessions sends a session-scoped follow-up — both through this daemon's peer
+grant over the federation link, never a browser lane. One **global operating
+target** backs the per-pane host pickers (Shell, Files, Transfers, Sessions,
+Stats): changing any one moves them all (the Shell's cloud exec hosts stay
+pane-local — they are exec venues, not daemons). Peer session cards and
+Station peer nodes carry host-scoped action pills (resume, message, rename,
+interrupt) routed through `api_peer_session_control` and derived from the
+peer-advertised grant, and media affordances (live display, file transfer,
+the browser↔peer control tunnel) render from the connected link's transport
+class — a relay-only peer gets an honest "no live media" note plus the
+federation-fold session list instead of dead pills. Agenda, Memory,
+Vault/custody, Access/IAM, and Settings never route to a peer.
+
 The section headings below keep the internal pane names (`Video` is the Live
 display destination, `Stats` is Usage) — ids, routes, and deep links are
 unchanged by the redesign.

--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -2117,6 +2117,7 @@ response omits the header.
 | POST | `/api/peers/{peer_id}/message` | federation (per method/path) | own origin | bounded | Send a message to a connected peer |
 | POST | `/api/peers/{peer_id}/task` | federation (per method/path) | own origin | bounded | Delegate a task to a connected peer |
 | POST | `/api/peers/{peer_id}/approval` | federation (per method/path) | own origin | bounded | Resolve a peer-forwarded approval request |
+| POST | `/api/peers/{peer_id}/session-control` | federation (per method/path) | own origin | bounded | Forward a session-lifecycle action to a connected peer's session |
 | POST | `/api/peers/{peer_id}/webrtc` | federation (per method/path) | own origin | bounded | Relay display WebRTC signaling to a connected peer |
 | POST | `/api/peers/{peer_id}/file-transfer-webrtc` | federation (per method/path) | own origin | bounded | Relay file-transfer WebRTC signaling to a connected peer |
 | POST | `/api/peers/{peer_id}/dashboard-control-webrtc` | federation (per method/path) | own origin | bounded | Relay dashboard-control WebRTC signaling to a connected peer |

--- a/src/bin/caller/access/access_policy.rs
+++ b/src/bin/caller/access/access_policy.rs
@@ -343,6 +343,21 @@ pub const ALL_OPERATIONS: [PeerOperation; 26] = [
     PeerOperation::MemoryWrite,
 ];
 
+/// The operation permission ids a profile allows, derived from
+/// [`profile_allows_operation`] over the frozen operation set and
+/// rendered in the stable `operation_permission_id` vocabulary. This
+/// is the payload of the `peer_grant` bootstrap advertisement on
+/// peer-identified `/ws` connections — a derived catalog, never a
+/// hand-kept list, so profile changes can't drift out of the echo.
+pub fn profile_operation_permission_ids(profile: &str) -> Vec<String> {
+    ALL_OPERATIONS
+        .iter()
+        .copied()
+        .filter(|op| profile_allows_operation(profile, *op))
+        .map(|op| crate::access::iam::operation_permission_id(op).to_string())
+        .collect()
+}
+
 /// True when `granted` allows no operation that `cap` does not. Profiles
 /// are not a strict ladder (file-reader and session-reader are siblings),
 /// so the cap relation is operation-set containment, mirroring how role
@@ -1213,6 +1228,7 @@ pub fn federation_http_operation(method: &str, path: &str) -> Option<PeerOperati
                         | "message"
                         | "task"
                         | "approval"
+                        | "session-control"
                 )
             {
                 return Some(PeerOperation::PeerUse);

--- a/src/bin/caller/access/access_policy.rs
+++ b/src/bin/caller/access/access_policy.rs
@@ -1960,6 +1960,46 @@ mod tests {
         ));
     }
 
+    /// Golden derivation for the `peer_grant` bootstrap echo: the
+    /// operation-id sets for the two profiles peers commonly hold, plus
+    /// the fail-closed shape for an unknown profile. If a profile's
+    /// operation set changes, this test names the delta — the echo
+    /// itself can't drift because it derives from the same predicate.
+    #[test]
+    fn profile_operation_permission_ids_golden() {
+        assert_eq!(
+            profile_operation_permission_ids("peer-operator"),
+            vec![
+                "presence.read",
+                "stats.read",
+                "display.view",
+                "display.input",
+                "message.send",
+                "task.run",
+                "approval.resolve",
+                "session.inspect",
+            ]
+        );
+
+        let root = profile_operation_permission_ids("peer-root");
+        assert!(root.contains(&"session.manage".to_string()));
+        assert!(root.contains(&"settings.manage".to_string()));
+        assert!(
+            !root.contains(&"access.manage".to_string()),
+            "peer-root must never carry access administration"
+        );
+        assert!(
+            !root.contains(&"credentials.manage".to_string()),
+            "peer-root must never carry credential administration"
+        );
+
+        // Unknown profiles fail closed to presence-only.
+        assert_eq!(
+            profile_operation_permission_ids("made-up-profile"),
+            vec!["presence.read"]
+        );
+    }
+
     #[test]
     fn peer_signal_relays_classify_as_peer_use() {
         // Acting through a connected peer — the three signaling relays and
@@ -1971,6 +2011,7 @@ mod tests {
             "message",
             "task",
             "approval",
+            "session-control",
         ] {
             assert_eq!(
                 federation_http_operation("POST", &format!("/api/peers/intendant:peer-b/{op}")),

--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -1740,6 +1740,33 @@ pub(crate) fn dashboard_session_control_msg_allowed(ctrl: &ControlMsg) -> bool {
     )
 }
 
+/// Derived allowlist for session-lifecycle `ControlMsg`s routable to a
+/// federated peer (`api_peer_session_control` →
+/// `PeerOp::SessionControl`): the session RPC lane's own allowlist
+/// intersected with the operation classes that cover session work
+/// (Message / Task / Approval / SessionManage). The class filter — not
+/// a second name list — is what keeps the doctrine-closed planes
+/// closed to peer routing: Settings-classified actions
+/// (`configure_session_agent`, the `set_*` config family), credential
+/// ceremonies, and access administration fall out of the intersection
+/// automatically. Both inputs are existing single declarations
+/// (`dashboard_session_control_msg_allowed`, `control_msg_operation`),
+/// so this cannot drift from either. The peer re-authorizes whatever
+/// passes against the profile it granted this daemon; this filter
+/// exists to fail closed locally with an honest error instead of
+/// spending a doomed remote round-trip.
+pub(crate) fn peer_session_control_allowed(ctrl: &ControlMsg) -> bool {
+    use crate::access::access_policy::{control_msg_operation, PeerOperation};
+    dashboard_session_control_msg_allowed(ctrl)
+        && matches!(
+            control_msg_operation(ctrl),
+            PeerOperation::Message
+                | PeerOperation::Task
+                | PeerOperation::Approval
+                | PeerOperation::SessionManage
+        )
+}
+
 /// The "dashboard action" RPC lane's allowlist, by wire action name. Single
 /// declaration: `dashboard_action_msg_allowed` gates against it, and the
 /// parity test below pins the SPA's `DASHBOARD_ACTION_MSG_RPC_ACTIONS`
@@ -2247,6 +2274,25 @@ pub(crate) async fn api_peer_approval_response(
     let (status, body) =
         crate::web_gateway::peers_resolve_approval(registry, &peer_id, &body_text).await;
     http_body_response(id, status, body, "peer approval")
+}
+
+pub(crate) async fn api_peer_session_control_response(
+    id: String,
+    params: Option<&serde_json::Value>,
+    runtime: &ControlRuntime,
+) -> serde_json::Value {
+    let Some(registry) = runtime.peer_registry.as_ref() else {
+        return peer_registry_unavailable_response(id);
+    };
+    let params = params.cloned().unwrap_or_else(|| serde_json::json!({}));
+    let peer_id = string_param(&params, &["peer_id", "peerId", "host_id", "hostId", "id"]);
+    if peer_id.is_empty() {
+        return missing_param_response(id, "peer_id");
+    }
+    let body_text = serde_json::to_string(&params).unwrap_or_else(|_| "{}".to_string());
+    let (status, body) =
+        crate::web_gateway::peers_session_control(registry, &peer_id, &body_text).await;
+    http_body_response(id, status, body, "peer session control")
 }
 
 pub(crate) async fn api_peer_webrtc_signal_response(

--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -2540,6 +2540,62 @@ pub(crate) async fn api_coordinator_route_response(
 mod tests {
     use super::*;
 
+    /// The peer session-control allowlist is the session RPC lane's
+    /// set intersected with the session-work operation classes
+    /// (Message / Task / Approval / SessionManage). Pin the doctrine
+    /// boundary: every Settings-, credentials-, or access-classified
+    /// action must refuse peer routing even when the session lane
+    /// itself allows it locally, and actions outside the session lane
+    /// never pass regardless of class.
+    #[test]
+    fn peer_session_control_allowlist_keeps_closed_planes_closed() {
+        let msg = |json: &str| -> ControlMsg {
+            serde_json::from_str(json).unwrap_or_else(|e| panic!("parse {json}: {e}"))
+        };
+
+        // Session lifecycle + conversation + approvals: routable.
+        for allowed in [
+            r#"{"action":"interrupt","session_id":"s"}"#,
+            r#"{"action":"follow_up","text":"hi","session_id":"s"}"#,
+            r#"{"action":"start_task","task":"do a thing"}"#,
+            r#"{"action":"resume_session","source":"intendant","session_id":"s"}"#,
+            r#"{"action":"rename_session","session_id":"s","name":"x"}"#,
+            r#"{"action":"stop_session","session_id":"s"}"#,
+            r#"{"action":"approve","id":7}"#,
+            r#"{"action":"steer","text":"go left"}"#,
+        ] {
+            assert!(
+                peer_session_control_allowed(&msg(allowed)),
+                "expected routable: {allowed}"
+            );
+        }
+
+        // Settings-classified (doctrine-closed to peer routing) —
+        // in the local session lane, refused for peers by class.
+        assert!(!peer_session_control_allowed(&msg(
+            r#"{"action":"configure_session_agent","session_id":"s"}"#
+        )));
+
+        // Outside the session lane entirely: refused regardless of
+        // how their operation classifies (settings, credentials,
+        // display, runtime).
+        for refused in [
+            r#"{"action":"set_autonomy","mode":"auto"}"#,
+            r#"{"action":"set_codex_command","command":"evil"}"#,
+            r#"{"action":"set_external_agent","agent":"codex"}"#,
+            r#"{"action":"take_display","display_id":1}"#,
+            r#"{"action":"status"}"#,
+        ] {
+            let parsed: Result<ControlMsg, _> = serde_json::from_str(refused);
+            if let Ok(ctrl) = parsed {
+                assert!(
+                    !peer_session_control_allowed(&ctrl),
+                    "expected refused: {refused}"
+                );
+            }
+        }
+    }
+
     // ── S4b tunnel/HTTP parity: worktrees (design §8) ──
     //
     // Extends the S4a enumeration (api_sessions.rs). The S4b-specific

--- a/src/bin/caller/dashboard_control/api_sessions.rs
+++ b/src/bin/caller/dashboard_control/api_sessions.rs
@@ -451,6 +451,9 @@ pub(crate) async fn control_request_frame(
         "api_peer_message" => api_peer_message_response(id, params.as_ref(), &runtime).await,
         "api_peer_task" => api_peer_task_response(id, params.as_ref(), &runtime).await,
         "api_peer_approval" => api_peer_approval_response(id, params.as_ref(), &runtime).await,
+        "api_peer_session_control" => {
+            api_peer_session_control_response(id, params.as_ref(), &runtime).await
+        }
         "api_peer_webrtc_signal" => {
             api_peer_webrtc_signal_response(id, params.as_ref(), &runtime).await
         }

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -6388,6 +6388,7 @@ mod tests {
             "api_peer_message",
             "api_peer_task",
             "api_peer_approval",
+            "api_peer_session_control",
             "api_peer_webrtc_signal",
             "api_peer_file_transfer_signal",
             "api_peer_dashboard_control_signal",

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -521,6 +521,7 @@ fn control_method_runtime_ready(runtime: &ControlRuntime, method: &str) -> bool 
         | "api_peer_message"
         | "api_peer_task"
         | "api_peer_approval"
+        | "api_peer_session_control"
         | "api_peer_webrtc_signal"
         | "api_peer_file_transfer_signal"
         | "api_peer_dashboard_control_signal"
@@ -5901,6 +5902,7 @@ mod tests {
             ("api_peer_message", Row, Some(Op::PeerUse)),
             ("api_peer_task", Row, Some(Op::PeerUse)),
             ("api_peer_approval", Row, Some(Op::PeerUse)),
+            ("api_peer_session_control", Row, Some(Op::PeerUse)),
             ("api_peer_add", Row, Some(Op::PeerManage)),
             ("api_peer_remove", Row, Some(Op::PeerManage)),
             ("api_peer_pairing_join", Row, Some(Op::PeerManage)),
@@ -6581,7 +6583,12 @@ mod tests {
             Some(PeerOperation::PresenceRead)
         );
         // Peer quick controls ride peer.use, not peer administration.
-        for method in ["api_peer_message", "api_peer_task", "api_peer_approval"] {
+        for method in [
+            "api_peer_message",
+            "api_peer_task",
+            "api_peer_approval",
+            "api_peer_session_control",
+        ] {
             assert_eq!(
                 method_operation(method),
                 Some(PeerOperation::PeerUse),

--- a/src/bin/caller/gateway_routes.rs
+++ b/src/bin/caller/gateway_routes.rs
@@ -2666,6 +2666,20 @@ pub(crate) static ROUTES: &[Route] = &[
             "/api/peers",
             &[
                 SegmentSpec::Capture("peer_id"),
+                SegmentSpec::Literal("session-control"),
+            ],
+        ),
+        BodyPolicy::Default,
+        RouteHandlerId::PeersSubRouter,
+        "Forward a session-lifecycle action to a connected peer's session",
+    )
+    .with_tunnel(tunnel_method("api_peer_session_control")),
+    federation_route(
+        RouteMethod::Post,
+        PathPattern::Segments(
+            "/api/peers",
+            &[
+                SegmentSpec::Capture("peer_id"),
                 SegmentSpec::Literal("webrtc"),
             ],
         ),

--- a/src/bin/caller/peer/actor.rs
+++ b/src/bin/caller/peer/actor.rs
@@ -27,7 +27,7 @@ use crate::peer::event::{
     MessageContent, MessageId, MessageRole, PeerDisplayInfo, PeerEvent, PeerStatus, SessionInfo,
     TaggedPeerEvent, TaskId,
 };
-use crate::peer::handle::{ConnectionState, PeerCommand};
+use crate::peer::handle::{ConnectionState, PeerCommand, PeerGrantInfo, PeerLinkInfo};
 use crate::peer::id::PeerId;
 use crate::peer::log_writer::EnqueuedPeerEvent;
 use crate::peer::traits::PeerTransport;
@@ -164,6 +164,17 @@ pub(crate) struct PeerActor {
     pub displays_tx: watch::Sender<Arc<Vec<PeerDisplayInfo>>>,
     /// Fold backing `displays_tx`, keyed by display id.
     pub displays: BTreeMap<u32, PeerDisplayInfo>,
+    /// Published view of the connected transport candidate (URL +
+    /// reachability class), recorded after every successful connect
+    /// and cleared while disconnected. `MultiTransport` re-walks
+    /// candidates each reconnect, so the value can change across the
+    /// link's lifetime.
+    pub link_tx: watch::Sender<Option<PeerLinkInfo>>,
+    /// Published view of the grant the peer advertised for this
+    /// daemon's identity, folded from [`PeerEvent::GrantAdvertised`].
+    /// Connection-scoped like `sessions_tx` — cleared on disconnect;
+    /// re-advertised by the peer on every connect.
+    pub grant_tx: watch::Sender<Option<PeerGrantInfo>>,
     /// Published delegation-receipt ledger, folded from
     /// [`PeerEvent::TaskReceipt`]: delegation id → the peer's local
     /// identity for the accepted task. `PeerHandle::delegate_task`
@@ -252,6 +263,14 @@ impl PeerActor {
                     self.apply_operator_overrides(&mut new_card);
                     let card_arc = Arc::new(new_card.clone());
                     let _ = self.card_tx.send(card_arc);
+                    // Record which candidate won this connect. Post-
+                    // connect, `MultiTransport::spec()` returns the
+                    // active candidate's spec (not the preferred one),
+                    // so this is the live link — the one fact the
+                    // dashboard's reachability honesty derives from.
+                    let _ = self
+                        .link_tx
+                        .send(PeerLinkInfo::from_spec(self.transport.spec()));
                     let _ = self.connection_tx.send(ConnectionState::Connected);
                     let _ = self.status_tx.send(PeerStatus::Idle);
                     self.emit_event(PeerEvent::Connected { card: new_card })
@@ -262,6 +281,7 @@ impl PeerActor {
                         MainLoopExit::Disconnect => {
                             let _ = self.connection_tx.send(ConnectionState::Disconnecting);
                             let _ = self.transport.disconnect().await;
+                            let _ = self.link_tx.send(None);
                             let _ = self.connection_tx.send(ConnectionState::Disconnected);
                             self.emit_event(PeerEvent::Disconnected {
                                 reason: "explicit disconnect".to_string(),
@@ -496,6 +516,15 @@ impl PeerActor {
                     }
                 }
             }
+            PeerEvent::GrantAdvertised {
+                profile,
+                operations,
+            } => {
+                let _ = self.grant_tx.send(Some(PeerGrantInfo {
+                    profile: profile.clone(),
+                    operations: operations.clone(),
+                }));
+            }
             PeerEvent::Disconnected { .. } => {
                 if !self.sessions.is_empty() {
                     self.sessions.clear();
@@ -505,6 +534,19 @@ impl PeerActor {
                     self.displays.clear();
                     self.publish_displays();
                 }
+                // Link + grant are connection-scoped like the folds
+                // above: the next connect re-records the winning
+                // candidate, and the peer re-advertises its grant.
+                self.link_tx.send_if_modified(|link| {
+                    let had = link.is_some();
+                    *link = None;
+                    had
+                });
+                self.grant_tx.send_if_modified(|grant| {
+                    let had = grant.is_some();
+                    *grant = None;
+                    had
+                });
                 // Interrupted replies: land each accumulated fold as one
                 // coalesced durable record before the Disconnected event
                 // itself is logged.
@@ -786,6 +828,8 @@ mod tests {
         let (sessions_tx, _sessions_rx) = watch::channel(Arc::new(Vec::new()));
         let (displays_tx, _displays_rx) = watch::channel(Arc::new(Vec::new()));
         let (receipts_tx, _receipts_rx) = watch::channel(Arc::new(HashMap::new()));
+        let (link_tx, _link_rx) = watch::channel(None);
+        let (grant_tx, _grant_rx) = watch::channel(None);
         let actor = PeerActor {
             peer_id,
             transport: Box::new(StubTransport(
@@ -804,6 +848,8 @@ mod tests {
             sessions: BTreeMap::new(),
             displays_tx,
             displays: BTreeMap::new(),
+            link_tx,
+            grant_tx,
             receipts_tx,
             receipts: HashMap::new(),
             receipt_order: VecDeque::new(),

--- a/src/bin/caller/peer/actor.rs
+++ b/src/bin/caller/peer/actor.rs
@@ -900,7 +900,7 @@ mod tests {
         // Simulate a recorded link so the disconnect clear is observable.
         let _ = actor.link_tx.send(Some(PeerLinkInfo {
             url: "wss://peer.example/ws".into(),
-            transport_class: crate::peer::PeerTransportClass::Direct,
+            transport_class: crate::peer::handle::PeerTransportClass::Direct,
         }));
 
         actor

--- a/src/bin/caller/peer/actor.rs
+++ b/src/bin/caller/peer/actor.rs
@@ -878,6 +878,47 @@ mod tests {
     /// on interruption salvage) ahead of the Disconnected record, while
     /// the deltas themselves stay off the durable log.
     #[tokio::test]
+    async fn grant_advertised_folds_and_clears_on_disconnect() {
+        let (log_tx, _log_rx) = mpsc::channel(64);
+        let (mut actor, _guards) = test_actor(log_tx);
+        let grant_rx = actor.grant_tx.subscribe();
+        let link_rx = actor.link_tx.subscribe();
+
+        actor
+            .handle_event(PeerEvent::GrantAdvertised {
+                profile: "peer-operator".into(),
+                operations: vec!["message.send".into(), "task.run".into()],
+            })
+            .await;
+        {
+            let grant = grant_rx.borrow();
+            let grant = grant.as_ref().expect("grant folded");
+            assert_eq!(grant.profile, "peer-operator");
+            assert_eq!(grant.operations, vec!["message.send", "task.run"]);
+        }
+
+        // Simulate a recorded link so the disconnect clear is observable.
+        let _ = actor.link_tx.send(Some(PeerLinkInfo {
+            url: "wss://peer.example/ws".into(),
+            transport_class: crate::peer::PeerTransportClass::Direct,
+        }));
+
+        actor
+            .handle_event(PeerEvent::Disconnected {
+                reason: "test".into(),
+            })
+            .await;
+        assert!(
+            grant_rx.borrow().is_none(),
+            "grant is connection-scoped and must clear on disconnect"
+        );
+        assert!(
+            link_rx.borrow().is_none(),
+            "link is connection-scoped and must clear on disconnect"
+        );
+    }
+
+    #[tokio::test]
     async fn interrupted_streaming_reply_lands_one_coalesced_log_record() {
         let (log_tx, mut log_rx) = mpsc::channel(64);
         let (mut actor, _guards) = test_actor(log_tx);

--- a/src/bin/caller/peer/event.rs
+++ b/src/bin/caller/peer/event.rs
@@ -59,6 +59,21 @@ pub enum PeerEvent {
         status: PeerStatus,
     },
 
+    /// The peer advertised the federation grant it resolved for this
+    /// daemon's identity on the current connection: the profile name
+    /// and the derived set of allowed operation permission ids
+    /// (`access::iam::operation_permission_id` vocabulary). Display
+    /// metadata only — authority stays entirely peer-side, enforced
+    /// per request; this echo exists so dashboards can render honest
+    /// affordances (no dead pills) instead of probing by denial.
+    /// Connection-scoped: re-advertised on every connect, cleared on
+    /// disconnect. Older peers never emit it, so `None` in the folded
+    /// view means "unknown", not "nothing allowed".
+    GrantAdvertised {
+        profile: String,
+        operations: Vec<String>,
+    },
+
     // ---- Activity stream — what the peer is doing right now ----
     /// A unit of work has begun (turn, tool call, sub-agent run, delegated
     /// task, etc). Activities have an opaque id and a kind for routing.

--- a/src/bin/caller/peer/handle.rs
+++ b/src/bin/caller/peer/handle.rs
@@ -1141,6 +1141,43 @@ mod tests {
     use super::*;
     use std::time::{Duration, Instant};
 
+    /// Snapshots from daemons predating the link/grant fields (and the
+    /// wire the dashboard round-trips) must keep parsing: both fields
+    /// are `serde(default)` and elided when absent.
+    #[test]
+    fn peer_snapshot_backcompat_without_link_and_grant() {
+        let json = r#"{
+            "id": "intendant:old-peer",
+            "label": "old",
+            "version": "0.0.9",
+            "connection_state": {"state": "connected"},
+            "status": "idle",
+            "capabilities": []
+        }"#;
+        let snap: PeerSnapshot = serde_json::from_str(json).expect("old snapshot parses");
+        assert!(snap.link.is_none());
+        assert!(snap.grant.is_none());
+
+        // And the new fields round-trip when present.
+        let mut snap = snap;
+        snap.link = Some(PeerLinkInfo {
+            url: "wss://peer.example/ws".into(),
+            transport_class: PeerTransportClass::Relayed,
+        });
+        snap.grant = Some(PeerGrantInfo {
+            profile: "peer-operator".into(),
+            operations: vec!["message.send".into()],
+        });
+        let round = serde_json::to_string(&snap).unwrap();
+        assert!(
+            round.contains(r#""transport_class":"relayed""#),
+            "snake_case wire form for the class: {round}"
+        );
+        let back: PeerSnapshot = serde_json::from_str(&round).unwrap();
+        assert_eq!(back.link, snap.link);
+        assert_eq!(back.grant, snap.grant);
+    }
+
     #[test]
     fn connection_state_is_copy_and_equatable() {
         let a = ConnectionState::Reconnecting { attempt: 3 };

--- a/src/bin/caller/peer/handle.rs
+++ b/src/bin/caller/peer/handle.rs
@@ -128,6 +128,73 @@ pub enum ConnectionState {
     Disconnected,
 }
 
+/// Class of the transport candidate a live federation link is using.
+/// Drives the dashboard's reachability honesty: media/datachannel
+/// affordances (live display, file-transfer bytes, browser↔peer
+/// dashboard-control tunnels) are rendered from this class, never
+/// inferred from the peer row existing.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PeerTransportClass {
+    /// The candidate URL is dialed directly (operator via-URL, card
+    /// address, direct IP/LAN/tailnet name).
+    Direct,
+    /// The candidate transits a reachability relay (Track RC Stage B:
+    /// the fleet-name candidate through the Connect relay). Signaling
+    /// and request/response work; ICE media and browser↔peer
+    /// datachannels need a direct route or provisioned TURN.
+    Relayed,
+}
+
+/// The transport candidate a live federation link is using, recorded
+/// by the actor after each successful connect and cleared while
+/// disconnected. `MultiTransport` re-walks candidates on every
+/// reconnect, so this can change across the link's lifetime.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct PeerLinkInfo {
+    /// URL of the connected candidate.
+    pub url: String,
+    /// Reachability class of the connected candidate.
+    pub transport_class: PeerTransportClass,
+}
+
+impl PeerLinkInfo {
+    /// Derive link info from the connected candidate's spec.
+    ///
+    /// Classification seam: every candidate the registry builds today
+    /// is an operator/card URL dialed directly, so the class is
+    /// `Direct`. The Stage-B relay work (RC-B2) introduces the
+    /// fleet-name relay candidate; its constructor is the one place
+    /// that should classify `Relayed`.
+    pub(crate) fn from_spec(spec: &crate::peer::card::TransportSpec) -> Option<Self> {
+        use crate::peer::card::TransportSpec;
+        let url = match spec {
+            TransportSpec::IntendantWs { url } => url.clone(),
+            TransportSpec::A2A { url } => url.clone(),
+            TransportSpec::Mcp { url, .. } => url.clone(),
+            TransportSpec::OpenClawWs { url, .. } => url.clone(),
+            TransportSpec::Unknown => return None,
+        };
+        Some(Self {
+            url,
+            transport_class: PeerTransportClass::Direct,
+        })
+    }
+}
+
+/// The federation grant the peer advertised for this daemon's identity
+/// on the current connection (see
+/// [`crate::peer::PeerEvent::GrantAdvertised`]). Display metadata only
+/// — the peer enforces authority per request regardless.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct PeerGrantInfo {
+    /// Profile name the peer granted (its own vocabulary).
+    pub profile: String,
+    /// Allowed operation permission ids derived by the peer from that
+    /// profile (`access::iam::operation_permission_id` vocabulary).
+    pub operations: Vec<String>,
+}
+
 // ---------------------------------------------------------------------------
 // Command envelope
 // ---------------------------------------------------------------------------
@@ -267,6 +334,13 @@ struct PeerHandleInner {
     /// Folded view of the peer's available displays (see the actor's
     /// `displays_tx` docs — connection-scoped, cleared on disconnect).
     displays: watch::Receiver<Arc<Vec<PeerDisplayInfo>>>,
+    /// The connected transport candidate (see [`PeerLinkInfo`]) —
+    /// `Some` while connected, `None` otherwise.
+    link: watch::Receiver<Option<PeerLinkInfo>>,
+    /// The peer-advertised grant for this daemon's identity (see
+    /// [`PeerGrantInfo`]) — connection-scoped; `None` means unknown
+    /// (older peer or not yet advertised), not "nothing allowed".
+    grant: watch::Receiver<Option<PeerGrantInfo>>,
     /// Delegation-receipt ledger folded by the actor from
     /// [`PeerEvent::TaskReceipt`] (delegation id → the peer's local
     /// task/session identity). [`PeerHandle::delegate_task`] awaits an
@@ -329,6 +403,20 @@ impl PeerHandle {
         self.inner.connection.clone()
     }
 
+    /// Subscribe to connected-link changes (candidate URL + transport
+    /// class). The registry's state observer folds these into
+    /// `PeerStateChanged` pushes so the dashboard tracks link class
+    /// without polling.
+    pub fn link_updates(&self) -> watch::Receiver<Option<PeerLinkInfo>> {
+        self.inner.link.clone()
+    }
+
+    /// Subscribe to peer-advertised grant changes (see
+    /// [`PeerGrantInfo`]).
+    pub fn grant_updates(&self) -> watch::Receiver<Option<PeerGrantInfo>> {
+        self.inner.grant.clone()
+    }
+
     #[allow(dead_code)]
     pub fn is_connected(&self) -> bool {
         matches!(*self.inner.connection.borrow(), ConnectionState::Connected)
@@ -371,6 +459,8 @@ impl PeerHandle {
             browser_tcp_via_url: self.inner.browser_tcp_via_url.clone(),
             sessions: self.inner.sessions.borrow().as_ref().clone(),
             displays: self.inner.displays.borrow().as_ref().clone(),
+            link: self.inner.link.borrow().clone(),
+            grant: self.inner.grant.borrow().clone(),
         }
     }
 
@@ -655,6 +745,37 @@ impl PeerHandle {
         }
     }
 
+    /// Forward a session-lifecycle `ControlMsg` to this peer
+    /// (host-scoped session actions: interrupt, resume, rename,
+    /// stop/restart, follow-up, approvals, …). Fire-and-forget like
+    /// approvals — outcomes come back on the event stream. The peer
+    /// authorizes the message per-action against the profile it
+    /// granted this daemon; this method carries no authority of its
+    /// own. Callers must pre-filter through
+    /// `dashboard_control::peer_session_control_allowed` so the
+    /// Settings/credentials/access planes stay closed to peer routing
+    /// with an honest local error instead of a remote deny.
+    pub async fn session_control(
+        &self,
+        message: crate::event::ControlMsg,
+    ) -> Result<(), PeerError> {
+        if !self.features().session_control {
+            return Err(PeerError::UnsupportedCapability("session_control".into()));
+        }
+        match self
+            .exec(PeerOp::SessionControl {
+                message: Box::new(message),
+            })
+            .await?
+        {
+            PeerOpAck::Ok => Ok(()),
+            other => Err(PeerError::Transport(format!(
+                "expected Ok ack, got {}",
+                other.name()
+            ))),
+        }
+    }
+
     /// Send one leg of a WebRTC signaling exchange to this peer.
     /// Returns immediately on dispatch; the peer's response (Answer,
     /// trickled IceCandidates) flows back asynchronously through the
@@ -871,6 +992,19 @@ pub struct PeerSnapshot {
     /// `serde(default)` keeps older producers parseable.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub displays: Vec<PeerDisplayInfo>,
+    /// The connected transport candidate (URL + reachability class).
+    /// `None` while disconnected. The dashboard derives
+    /// media/datachannel availability from `link.transport_class` —
+    /// never from the peer row merely existing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub link: Option<PeerLinkInfo>,
+    /// The grant the peer advertised for this daemon's identity on the
+    /// current connection (profile + derived operation permission
+    /// ids). `None` = unknown (older peer, or disconnected) — the
+    /// dashboard treats unknown as "act and report the outcome", not
+    /// as denial.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub grant: Option<PeerGrantInfo>,
 }
 
 // ---------------------------------------------------------------------------
@@ -947,6 +1081,8 @@ where
     let (sessions_tx, sessions_rx) = watch::channel(Arc::new(Vec::new()));
     let (displays_tx, displays_rx) = watch::channel(Arc::new(Vec::new()));
     let (receipts_tx, receipts_rx) = watch::channel(Arc::new(HashMap::new()));
+    let (link_tx, link_rx) = watch::channel(None);
+    let (grant_tx, grant_rx) = watch::channel(None);
 
     let transport = build_transport(events_in_tx);
     let features = transport.features();
@@ -965,6 +1101,8 @@ where
         sessions: std::collections::BTreeMap::new(),
         displays_tx,
         displays: std::collections::BTreeMap::new(),
+        link_tx,
+        grant_tx,
         receipts_tx,
         receipts: HashMap::new(),
         receipt_order: std::collections::VecDeque::new(),
@@ -986,6 +1124,8 @@ where
             card: card_rx,
             sessions: sessions_rx,
             displays: displays_rx,
+            link: link_rx,
+            grant: grant_rx,
             receipts: receipts_rx,
             commands: commands_tx,
             events: events_out_tx,

--- a/src/bin/caller/peer/mod.rs
+++ b/src/bin/caller/peer/mod.rs
@@ -116,9 +116,7 @@ pub use event::{
     MessageContent, MessageId, MessageRole, ModelUsage, PeerDisplayInfo, PeerEvent, PeerMessage,
     PeerStatus, SessionInfo, TaskId, UsageSnapshot, WebRtcSessionId, WebRtcSignal,
 };
-pub use handle::{
-    ConnectionState, PeerGrantInfo, PeerHandle, PeerLinkInfo, PeerSnapshot, PeerTransportClass,
-};
+pub use handle::{ConnectionState, PeerHandle, PeerSnapshot};
 pub use id::PeerId;
 // LOG_CHANNEL_CAPACITY and EnqueuedPeerEvent have cfg(test) consumers only
 // (the mcp_http / mcp tools_peer / gateway peer rigs build their log sinks

--- a/src/bin/caller/peer/mod.rs
+++ b/src/bin/caller/peer/mod.rs
@@ -116,7 +116,9 @@ pub use event::{
     MessageContent, MessageId, MessageRole, ModelUsage, PeerDisplayInfo, PeerEvent, PeerMessage,
     PeerStatus, SessionInfo, TaskId, UsageSnapshot, WebRtcSessionId, WebRtcSignal,
 };
-pub use handle::{ConnectionState, PeerHandle, PeerSnapshot};
+pub use handle::{
+    ConnectionState, PeerGrantInfo, PeerHandle, PeerLinkInfo, PeerSnapshot, PeerTransportClass,
+};
 pub use id::PeerId;
 // LOG_CHANNEL_CAPACITY and EnqueuedPeerEvent have cfg(test) consumers only
 // (the mcp_http / mcp tools_peer / gateway peer rigs build their log sinks

--- a/src/bin/caller/peer/registry.rs
+++ b/src/bin/caller/peer/registry.rs
@@ -587,6 +587,8 @@ fn spawn_state_observer(handle: PeerHandle, events: broadcast::Sender<RegistryEv
         let mut conn_rx = handle.connection_updates();
         let mut status_rx = handle.status_updates();
         let mut card_rx = handle.card_updates();
+        let mut link_rx = handle.link_updates();
+        let mut grant_rx = handle.grant_updates();
 
         // Mark current values as observed so we only react to *changes*
         // from this point forward — the initial values are already
@@ -594,12 +596,16 @@ fn spawn_state_observer(handle: PeerHandle, events: broadcast::Sender<RegistryEv
         let _ = conn_rx.borrow_and_update();
         let _ = status_rx.borrow_and_update();
         let _ = card_rx.borrow_and_update();
+        let _ = link_rx.borrow_and_update();
+        let _ = grant_rx.borrow_and_update();
 
         loop {
             let changed = tokio::select! {
                 r = conn_rx.changed() => r,
                 r = status_rx.changed() => r,
                 r = card_rx.changed() => r,
+                r = link_rx.changed() => r,
+                r = grant_rx.changed() => r,
             };
             if changed.is_err() {
                 // One of the watch senders dropped — peer actor has

--- a/src/bin/caller/peer/traits.rs
+++ b/src/bin/caller/peer/traits.rs
@@ -98,6 +98,11 @@ pub struct TransportFeatures {
     /// Transport supports sending an authenticated hosted-certificate
     /// observation to the peer daemon.
     pub certificate_witness: bool,
+    /// Transport supports [`PeerOp::SessionControl`] — forwarding a
+    /// session-lifecycle `ControlMsg` (interrupt, resume, rename,
+    /// follow-up, …) for the peer to authorize against this daemon's
+    /// granted profile.
+    pub session_control: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -152,6 +157,20 @@ pub enum PeerOp {
     HostedCertificateWitness {
         report: crate::access::hosted_control::HostedCertificateWitnessReport,
     },
+    /// A session-lifecycle control message targeted at one of the
+    /// peer's sessions (host-scoped session actions: interrupt,
+    /// resume, rename, stop/restart, follow-up, approvals, …). The
+    /// message is written to the peer verbatim; the peer authorizes
+    /// it per-action against the profile it granted this daemon
+    /// (`control_msg_operation` → `profile_allows_operation`), so
+    /// this op carries no authority of its own. Callers are expected
+    /// to pre-filter through
+    /// `dashboard_control::peer_session_control_allowed` — the
+    /// derived allowlist that keeps Settings/credentials/access
+    /// planes closed to peer routing.
+    SessionControl {
+        message: Box<crate::event::ControlMsg>,
+    },
 }
 
 impl PeerOp {
@@ -168,6 +187,7 @@ impl PeerOp {
             Self::PeerFileTransferSignal { .. } => "peer_file_transfer_signal",
             Self::PeerDashboardControlSignal { .. } => "peer_dashboard_control_signal",
             Self::HostedCertificateWitness { .. } => "hosted_certificate_witness",
+            Self::SessionControl { .. } => "session_control",
         }
     }
 }
@@ -251,6 +271,7 @@ pub fn check_feature(features: &TransportFeatures, op: &PeerOp) -> Result<(), Pe
         PeerOp::PeerFileTransferSignal { .. } => features.file_transfer_signal,
         PeerOp::PeerDashboardControlSignal { .. } => features.dashboard_control_signal,
         PeerOp::HostedCertificateWitness { .. } => features.certificate_witness,
+        PeerOp::SessionControl { .. } => features.session_control,
     };
     if !supported {
         return Err(PeerError::UnsupportedCapability(op.name().to_string()));

--- a/src/bin/caller/peer/transport/intendant.rs
+++ b/src/bin/caller/peer/transport/intendant.rs
@@ -1113,6 +1113,89 @@ mod tests {
         gateway.abort();
     }
 
+    /// `SendMessage` with a target session carries it into
+    /// `FollowUp.session_id` — peer session targeting. (Regression:
+    /// the session was silently dropped and every peer message went
+    /// to the primary session.)
+    #[tokio::test]
+    async fn send_message_with_session_scopes_followup() {
+        let (port, gateway, mut bus_rx) = spawn_test_peer_with_bus().await;
+        let (tx, _rx) = mpsc::channel::<PeerEvent>(64);
+        let url = format!("ws://127.0.0.1:{port}/ws");
+        let mut transport =
+            IntendantWsTransport::with_credentials(url, tx, test_loopback_credentials());
+        let _ = transport.connect().await.unwrap();
+
+        transport
+            .send(PeerOp::SendMessage {
+                message: PeerMessage {
+                    session: Some("sess-42".into()),
+                    role: MessageRole::User,
+                    content: MessageContent::Text {
+                        text: "scoped hello".into(),
+                    },
+                },
+            })
+            .await
+            .expect("send_message succeeds");
+
+        let event = wait_for_event(&mut bus_rx, |e| {
+            matches!(
+                e,
+                AppEvent::ControlCommand(ControlMsg::FollowUp { session_id: Some(sid), .. })
+                    if sid == "sess-42"
+            )
+        })
+        .await;
+        assert!(
+            event.is_some(),
+            "session-scoped follow-up did not land on the bus"
+        );
+
+        transport.disconnect().await.unwrap();
+        gateway.abort();
+    }
+
+    /// `SessionControl` writes the inner `ControlMsg` verbatim; the
+    /// peer's `/ws` dispatches it as an ordinary control command
+    /// (which its gates authorize per-action). Fire-and-forget ack.
+    #[tokio::test]
+    async fn session_control_writes_control_msg_verbatim() {
+        let (port, gateway, mut bus_rx) = spawn_test_peer_with_bus().await;
+        let (tx, _rx) = mpsc::channel::<PeerEvent>(64);
+        let url = format!("ws://127.0.0.1:{port}/ws");
+        let mut transport =
+            IntendantWsTransport::with_credentials(url, tx, test_loopback_credentials());
+        let _ = transport.connect().await.unwrap();
+
+        let ack = transport
+            .send(PeerOp::SessionControl {
+                message: Box::new(ControlMsg::Interrupt {
+                    session_id: Some("sess-9".into()),
+                    expected_turn: None,
+                }),
+            })
+            .await
+            .expect("session_control succeeds");
+        assert!(matches!(ack, PeerOpAck::Ok), "fire-and-forget ack");
+
+        let event = wait_for_event(&mut bus_rx, |e| {
+            matches!(
+                e,
+                AppEvent::ControlCommand(ControlMsg::Interrupt { session_id: Some(sid), .. })
+                    if sid == "sess-9"
+            )
+        })
+        .await;
+        assert!(
+            event.is_some(),
+            "interrupt ControlMsg did not land on the bus"
+        );
+
+        transport.disconnect().await.unwrap();
+        gateway.abort();
+    }
+
     /// `webrtc_signal` writes a `ControlMsg::WebRtcSignal` carrying
     /// display_id, session_id, and the inner signal kind verbatim.
     /// Returns `PeerOpAck::Ok` (fire-and-forget; the peer's response

--- a/src/bin/caller/peer/transport/intendant.rs
+++ b/src/bin/caller/peer/transport/intendant.rs
@@ -562,6 +562,7 @@ impl PeerTransport for IntendantWsTransport {
             file_transfer_signal: true,
             dashboard_control_signal: true,
             certificate_witness: true,
+            session_control: true,
         }
     }
 
@@ -612,7 +613,10 @@ impl PeerTransport for IntendantWsTransport {
             PeerOp::SendMessage { message } => {
                 let text = message_text(&message.content)?;
                 self.write_control_msg(&ControlMsg::FollowUp {
-                    session_id: None,
+                    // Scope to the caller's target session when given
+                    // (peer session targeting); None routes to the
+                    // peer's primary session as before.
+                    session_id: message.session.clone(),
                     text,
                     direct: None,
                     follow_up_id: None,
@@ -718,6 +722,16 @@ impl PeerTransport for IntendantWsTransport {
             PeerOp::HostedCertificateWitness { report } => {
                 self.write_control_msg(&ControlMsg::HostedCertificateWitness { report })
                     .await?;
+                Ok(PeerOpAck::Ok)
+            }
+            PeerOp::SessionControl { message } => {
+                // The ControlMsg goes out verbatim — the peer's /ws
+                // gate re-authorizes it per-action against the profile
+                // granted to this daemon's identity, exactly as if a
+                // local client of the peer had sent it. Fire-and-forget
+                // like approvals: outcomes come back on the event
+                // stream (session_updated / approval_resolved / …).
+                self.write_control_msg(&message).await?;
                 Ok(PeerOpAck::Ok)
             }
             // check_feature rejects the other variants before they

--- a/src/bin/caller/peer/transport/multi.rs
+++ b/src/bin/caller/peer/transport/multi.rs
@@ -167,6 +167,7 @@ fn union_features(candidates: &[Box<dyn PeerTransport>]) -> TransportFeatures {
         u.file_transfer_signal |= f.file_transfer_signal;
         u.dashboard_control_signal |= f.dashboard_control_signal;
         u.certificate_witness |= f.certificate_witness;
+        u.session_control |= f.session_control;
     }
     u
 }

--- a/src/bin/caller/peer/upcast.rs
+++ b/src/bin/caller/peer/upcast.rs
@@ -2123,6 +2123,18 @@ impl WireEventUpcaster {
             | OutboundEvent::PeerStateChanged { .. }
             | OutboundEvent::PeerEventForwarded { .. } => vec![],
 
+            // The peer's bootstrap advertisement of the grant it
+            // resolved for OUR identity on this connection. Folded by
+            // the actor into `PeerSnapshot.grant` so dashboards render
+            // honest affordances; carries no authority either way.
+            OutboundEvent::PeerGrant {
+                profile,
+                operations,
+            } => vec![PeerEvent::GrantAdvertised {
+                profile: profile.clone(),
+                operations: operations.clone(),
+            }],
+
             OutboundEvent::UserMessageEditStatus {
                 user_turn_index,
                 status,

--- a/src/bin/caller/types.rs
+++ b/src/bin/caller/types.rs
@@ -1288,6 +1288,21 @@ pub enum OutboundEvent {
     PeerStateChanged {
         peer: crate::peer::PeerSnapshot,
     },
+    /// Emitted once per peer-identified `/ws` connection at bootstrap:
+    /// the federation grant this daemon resolved for the connecting
+    /// peer's mTLS identity — the profile name plus the operation
+    /// permission ids that profile allows, derived from
+    /// `profile_allows_operation` over the frozen operation set (never
+    /// a hand-kept list). Display metadata for honest dashboards; the
+    /// per-request gates enforce authority regardless of what this
+    /// event said. The dialing daemon folds it into
+    /// [`crate::peer::PeerSnapshot::grant`]; browsers on the local
+    /// `/ws` never see it (it rides the peer connection's direct
+    /// lane only).
+    PeerGrant {
+        profile: String,
+        operations: Vec<String>,
+    },
     /// A peer-emitted [`crate::peer::PeerEvent`] forwarded by the
     /// local registry's translator. Lets the dashboard subscribe to
     /// per-peer activity (logs, model output, approval requests,

--- a/src/bin/caller/web_gateway/listener.rs
+++ b/src/bin/caller/web_gateway/listener.rs
@@ -2550,9 +2550,7 @@ fn spawn_web_gateway_from_cert_dir_with_relay_listener(
                     } = &dashboard_control_grant_for_ws
                     {
                         let operations =
-                            crate::access::access_policy::profile_operation_permission_ids(
-                                profile,
-                            );
+                            crate::access::access_policy::profile_operation_permission_ids(profile);
                         if let Ok(line) =
                             serde_json::to_string(&crate::types::OutboundEvent::PeerGrant {
                                 profile: profile.clone(),

--- a/src/bin/caller/web_gateway/listener.rs
+++ b/src/bin/caller/web_gateway/listener.rs
@@ -2536,6 +2536,33 @@ fn spawn_web_gateway_from_cert_dir_with_relay_listener(
                         let _ = direct_tx.send(bootstrap.to_string());
                     }
 
+                    // Peer-identified connections (a federated daemon on
+                    // its mTLS identity) get the grant echo: the profile
+                    // this daemon resolved for that identity plus the
+                    // operation permission ids derived from it. Display
+                    // metadata for the dialer's dashboard honesty (no
+                    // dead pills) — every request is still gated by the
+                    // per-op evaluators regardless. Re-advertised on
+                    // every connect, so a profile edit lands at the
+                    // dialer on its next reconnect.
+                    if let crate::dashboard_control::DashboardControlGrant::Peer {
+                        profile, ..
+                    } = &dashboard_control_grant_for_ws
+                    {
+                        let operations =
+                            crate::access::access_policy::profile_operation_permission_ids(
+                                profile,
+                            );
+                        if let Ok(line) =
+                            serde_json::to_string(&crate::types::OutboundEvent::PeerGrant {
+                                profile: profile.clone(),
+                                operations,
+                            })
+                        {
+                            let _ = direct_tx.send(line);
+                        }
+                    }
+
                     // Send cached usage data so late-connecting browsers
                     // populate the Usage tab without sending ControlMsg.
                     if let Ok(guard) = last_usage_json.lock() {

--- a/src/bin/caller/web_gateway/peer_requests.rs
+++ b/src/bin/caller/web_gateway/peer_requests.rs
@@ -221,6 +221,16 @@ pub(crate) struct ResolveApprovalRequest {
     pub(crate) decision: crate::peer::ApprovalDecision,
 }
 
+/// Body of `POST /api/peers/{id}/session-control`: one session-lifecycle
+/// `ControlMsg` in its wire form (`{"action": "...", ...}`), same shape
+/// the local `api_session_control_msg` RPC lane takes. Session ids
+/// inside the message are the PEER's session ids — the handler forwards
+/// them verbatim; nothing resolves them locally.
+#[derive(Deserialize)]
+pub(crate) struct PeerSessionControlRequest {
+    pub(crate) message: serde_json::Value,
+}
+
 /// Slice 3b: rewrite an outgoing federated `WebRtcSignal::Answer` to
 /// (a) register the peer's ICE ufrag in the relay registry and
 /// (b) inject a TCP candidate pointing at the primary's own address

--- a/src/bin/caller/web_gateway/routes_access.rs
+++ b/src/bin/caller/web_gateway/routes_access.rs
@@ -185,6 +185,12 @@ pub(crate) fn dashboard_targets_response_value(
                 "ws_url": snapshot.ws_url,
                 "browser_tcp_via_url": snapshot.browser_tcp_via_url,
                 "capabilities": snapshot.capabilities,
+                // Reachability honesty (RC-C1): the live link's candidate
+                // URL + transport class, and the peer-advertised grant for
+                // this daemon's identity. Both None while disconnected;
+                // grant is None for peers that predate the echo.
+                "link": snapshot.link,
+                "grant": snapshot.grant,
             }));
         }
     }

--- a/src/bin/caller/web_gateway/routes_peers.rs
+++ b/src/bin/caller/web_gateway/routes_peers.rs
@@ -224,6 +224,7 @@ pub(crate) async fn peers_sub_router_api_response(
                     "message" => peers_send_message(registry, &id, body_text).await,
                     "task" => peers_delegate_task(registry, &id, body_text).await,
                     "approval" => peers_resolve_approval(registry, &id, body_text).await,
+                    "session-control" => peers_session_control(registry, &id, body_text).await,
                     "webrtc" => peers_webrtc_signal(registry, &id, body_text, bus).await,
                     "file-transfer-webrtc" => {
                         peers_file_transfer_signal(registry, &id, body_text, bus).await
@@ -2384,6 +2385,62 @@ pub(crate) async fn peers_delegate_task(
             })
             .to_string(),
         ),
+        Err(e) => peer_error_response(e),
+    }
+}
+
+/// Handle `POST /api/peers/{id}/session-control`: forward one
+/// session-lifecycle `ControlMsg` to a connected peer (host-scoped
+/// session actions — interrupt, resume, rename, stop/restart,
+/// follow-up, approvals). The action is validated against the derived
+/// `peer_session_control_allowed` set (session-lane allowlist ∩
+/// session-work operation classes) so the doctrine-closed planes
+/// (Settings, credentials, access/IAM) fail closed locally with an
+/// honest error; the peer then re-authorizes whatever passes against
+/// the profile it granted this daemon's identity.
+pub(crate) async fn peers_session_control(
+    registry: &crate::peer::PeerRegistry,
+    id: &str,
+    body_text: &str,
+) -> (u16, String) {
+    let req: PeerSessionControlRequest = match serde_json::from_str(body_text) {
+        Ok(r) => r,
+        Err(e) => {
+            return (
+                400,
+                serde_json::json!({"error": format!("invalid request body: {e}")}).to_string(),
+            );
+        }
+    };
+    let ctrl: crate::event::ControlMsg = match serde_json::from_value(req.message) {
+        Ok(c) => c,
+        Err(e) => {
+            return (
+                400,
+                serde_json::json!({"error": format!("invalid control message: {e}")}).to_string(),
+            );
+        }
+    };
+    if !crate::dashboard_control::peer_session_control_allowed(&ctrl) {
+        let action = crate::dashboard_control::dashboard_control_msg_action(&ctrl);
+        return (
+            403,
+            serde_json::json!({
+                "error": format!(
+                    "action '{action}' is not routable to a peer session \
+                     (peer session control covers message/task/approval/\
+                     session-lifecycle actions only)"
+                )
+            })
+            .to_string(),
+        );
+    }
+    let handle = match peer_handle_or_404(registry, id) {
+        Ok(h) => h,
+        Err(resp) => return resp,
+    };
+    match handle.session_control(ctrl).await {
+        Ok(()) => (200, serde_json::json!({"ok": true}).to_string()),
         Err(e) => peer_error_response(e),
     }
 }

--- a/static/app.html
+++ b/static/app.html
@@ -31839,6 +31839,51 @@ html.ui-v2 .ui2-tsw-foot {
 html.ui-v2 .ui2-tsw-foot .ui2-tsw-row { color: var(--text-3); }
 html.ui-v2 .ui2-tsw-foot .ui2-tsw-row:hover { color: var(--text); }
 
+/* peers section (RC-C1): violet is the peer accent everywhere in the
+   chrome (files/access convention) — the rows read as "another
+   machine" at a glance */
+html.ui-v2 .ui2-tsw-peers-eyebrow {
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid var(--line);
+}
+html.ui-v2 .ui2-tsw-peer-badge {
+  color: var(--violet);
+  border: 1px solid rgba(var(--violet-rgb), .26);
+  background: rgba(var(--violet-rgb), .12);
+  border-radius: var(--r-pill);
+  padding: 1px 8px;
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 160px;
+}
+html.ui-v2 .ui2-tsw-peer-session { padding-left: 22px; }
+
+/* composer chip while a peer target is set — same violet voice */
+html.ui-v2 .task-target-peer-badge {
+  color: var(--violet);
+  border-color: rgba(var(--violet-rgb), .26);
+  background: rgba(var(--violet-rgb), .12);
+}
+html.ui-v2 .task-target-chip.target-reconnecting .task-target-peer-badge {
+  color: var(--amber);
+  border-color: rgba(var(--amber-rgb), .26);
+  background: rgba(var(--amber-rgb), .12);
+}
+
+/* Access → Daemons: honest stand-in where "View display" would be a
+   dead pill on a relay-only link */
+html.ui-v2 .daemon-relay-note {
+  color: var(--text-3);
+  font-size: 11px;
+  padding: 2px 6px;
+  border: 1px dashed var(--line-2);
+  border-radius: var(--r-pill);
+  white-space: nowrap;
+}
+
 /* touch targets (brief: rows ≥44px at ≤820px); 16px input font keeps
    iOS Safari from zooming the page on focus */
 @media (max-width: 820px) {
@@ -37994,7 +38039,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '5cd3a10d20a93aec';
+const INTENDANT_APP_BUILD = '5e2430347e404cac';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -38941,6 +38986,79 @@ if (DASHBOARD_ACCESS_PAGE_MODE) {
   document.title = 'Intendant Access';
 }
 let daemons = [];
+// ---- Global operating target (RC-C1) ----
+// One dashboard, one "operating <host>" selection. The per-pane host
+// pickers (Shell, Files, Transfers, Sessions, Stats) publish into and
+// follow this instead of each owning a private selection; panes with a
+// wider domain (the Shell's cloud exec hosts, which are not daemons)
+// may show a pane-local override without moving the global. '' = the
+// local daemon (self). Change notifications ride a
+// `ui2:target-changed` CustomEvent on document.
+let globalTargetHostId = '';
+function normalizeTargetHostId(hostId) {
+  const id = String(hostId == null ? '' : hostId).trim();
+  if (!id || id === 'local' || id === 'self') return '';
+  if (typeof selfPeerId !== 'undefined' && selfPeerId && id === selfPeerId) return '';
+  return id;
+}
+function currentGlobalTargetHostId() {
+  return globalTargetHostId;
+}
+function globalTargetIsLocal() {
+  return globalTargetHostId === '';
+}
+function peerEntryForHost(hostId) {
+  const id = normalizeTargetHostId(hostId);
+  if (!id) return null;
+  return daemons.find((d) => d.host_id === id) || null;
+}
+function setGlobalTargetHost(hostId, opts) {
+  const next = normalizeTargetHostId(hostId);
+  // Only daemon targets participate: '' (self) or a known peer row.
+  if (next && !peerEntryForHost(next)) return false;
+  if (next === globalTargetHostId) return true;
+  globalTargetHostId = next;
+  try {
+    document.dispatchEvent(
+      new CustomEvent('ui2:target-changed', {
+        detail: { hostId: next, source: (opts && opts.source) || '' },
+      }),
+    );
+  } catch (_e) {
+    /* CustomEvent is universal in shipped engines; never let a
+       dispatch failure strand the selection itself. */
+  }
+  return true;
+}
+// Honest-affordance helpers: what the peer advertised about OUR grant
+// and about the live link. Unknown grant (older peer, or the echo not
+// yet folded) is "act and report", never denial; unknown link means no
+// media promise.
+function peerGrantOperations(hostId) {
+  const entry = peerEntryForHost(hostId);
+  const ops = entry && entry.grant && Array.isArray(entry.grant.operations)
+    ? entry.grant.operations
+    : null;
+  return ops;
+}
+function peerAllowsOperation(hostId, operationId) {
+  const ops = peerGrantOperations(hostId);
+  if (!ops) return true; // unknown → optimistic, outcome reported honestly
+  return ops.includes(operationId);
+}
+function peerLinkTransportClass(hostId) {
+  const entry = peerEntryForHost(hostId);
+  return entry && entry.link && entry.link.transport_class
+    ? String(entry.link.transport_class)
+    : '';
+}
+// Media/datachannel affordances render from the transport class of the
+// live link — never from the peer row existing. Absent link info on a
+// connected row (daemon predating the field) keeps today's behavior.
+function peerLinkSupportsMedia(hostId) {
+  const cls = peerLinkTransportClass(hostId);
+  return cls !== 'relayed';
+}
 let dashboardAccessTargets = [];
 let dashboardAccessOverview = null;
 let accessUserClientGrantSubmitting = false;
@@ -50491,7 +50609,59 @@ function stationHandleSessionAction(action) {
     return;
   }
   if (!sessionId) return;
-  const session = stationFindSessionById(sessionId) || { session_id: sessionId };
+  // Host-scoped routing (RC-C1): scene nodes for a PEER's sessions
+  // carry the peer's raw session ids. When the id resolves to a peer
+  // fold and not to anything local, actions route through
+  // api_peer_session_control instead of assuming a local session id.
+  const localSession = stationFindSessionById(sessionId);
+  const peerHostId = !localSession && !sessionWindows.has(sessionId)
+    && typeof peerEntryForHost === 'function'
+    ? (Array.isArray(daemons)
+      ? (daemons.find(d => Array.isArray(d.sessions)
+          && d.sessions.some(s => String(s.session_id) === sessionId))?.host_id || '')
+      : '')
+    : '';
+  if (peerHostId) {
+    const peerName = peerEntryForHost(peerHostId)?.label || peerHostId;
+    if (op === 'focus' || op === 'target' || op === 'steer') {
+      if (setPromptTargetPeer(peerHostId, sessionId)) {
+        showControlToast?.('info', `Composer targets ${shortSessionId(sessionId)} on ${peerName}`);
+        if (stationRenderedPrimaryActive()) {
+          station?.set_composer?.(true, 'send');
+          stationHandleComposerEvent({ op: 'focus' });
+        }
+      }
+      return;
+    }
+    if (op === 'interrupt') {
+      daemonApi
+        .request('api_peer_session_control', {
+          peer_id: peerHostId,
+          message: { action: 'interrupt', session_id: sessionId },
+        })
+        .then(resp => {
+          if (resp.ok) {
+            showControlToast?.('info', `Interrupt sent to ${shortSessionId(sessionId)} on ${peerName}`);
+          } else {
+            const detail = resp.body && resp.body.error ? ` — ${resp.body.error}` : '';
+            showControlToast?.('error', `${peerName} refused interrupt (${resp.status})${detail}`);
+          }
+        })
+        .catch(err => showControlToast?.('error', `Could not reach ${peerName}: ${err?.message || err}`));
+      return;
+    }
+    if (op === 'copy') {
+      copyTextToClipboard(sessionId)
+        .then(() => showControlToast('success', `Copied session ID ${shortSessionId(sessionId)}`))
+        .catch(err => showControlToast('error', `Copy session ID failed: ${err?.message || err}`));
+      return;
+    }
+    // Anything else (transcript, thread ops, config) still lives on the
+    // peer's own dashboard — no silent no-ops.
+    showControlToast?.('info', `${op} for peer sessions happens on ${peerName}'s own dashboard.`);
+    return;
+  }
+  const session = localSession || { session_id: sessionId };
   const live = stationExternalLiveThreadDescriptor(session) || stationExternalLiveThreadDescriptor(sessionId);
   if (op === 'focus' || op === 'target') {
     focusSessionWindow(live?.liveId || sessionId);
@@ -53245,7 +53415,13 @@ function stationPeerSessionAgents(d) {
           ? String(goal.tokensUsed)
           : '',
         threadActions: [],
-        canInterrupt: false,
+        // Interrupt pill from the peer-advertised grant (RC-C1): the
+        // action routes through api_peer_session_control and the peer
+        // re-authorizes it; render it only when the session is live
+        // and the grant is not known to lack session.manage.
+        canInterrupt: (phase === 'running' || phase === 'thinking')
+          && (typeof peerAllowsOperation !== 'function'
+            || peerAllowsOperation(d.host_id, 'session.manage')),
       });
     }
     return out;
@@ -60892,7 +61068,78 @@ function markSessionWindowPendingActive(sessionId) {
 // automatic resolver rebind (pulse it) apart from a repeat render.
 let taskTargetChipRenderedTarget = null;
 
+// Composer peer target (RC-C1): when set, the composer sends to a
+// FEDERATED peer instead of a local session — a new task via
+// delegation ({hostId, sessionId: null}) or a follow-up scoped to one
+// of the peer's sessions ({hostId, sessionId}). Any explicit local
+// pick clears it (one composer, one target). Validity is re-checked
+// on read: a removed peer drops the target instead of stranding the
+// composer on a ghost.
+let promptTargetPeer = null;
+
+function currentPromptTargetPeer() {
+  if (!promptTargetPeer) return null;
+  const entry =
+    typeof peerEntryForHost === 'function' ? peerEntryForHost(promptTargetPeer.hostId) : null;
+  if (!entry) {
+    promptTargetPeer = null;
+    return null;
+  }
+  return promptTargetPeer;
+}
+
+function setPromptTargetPeer(hostId, sessionId) {
+  const entry = typeof peerEntryForHost === 'function' ? peerEntryForHost(hostId) : null;
+  if (!entry) return false;
+  promptTargetPeer = {
+    hostId: entry.host_id,
+    sessionId: sessionId ? String(sessionId) : null,
+  };
+  updateTaskTargetChip();
+  return true;
+}
+
+function clearPromptTargetPeer(opts) {
+  if (!promptTargetPeer) return;
+  promptTargetPeer = null;
+  if (!opts || !opts.skipChip) updateTaskTargetChip();
+}
+
 function updateTaskTargetChip() {
+  // A peer target owns the chip while set: the composer routes to the
+  // peer daemon, not to any local session window.
+  const peerTarget = currentPromptTargetPeer();
+  if (peerTarget) {
+    const chip = document.getElementById('task-target-chip');
+    taskTargetChipRenderedTarget = `peer:${peerTarget.hostId}:${peerTarget.sessionId || ''}`;
+    updatePromptTargetSessionHighlight('');
+    updateControlFastButtonState();
+    if (!chip) return;
+    clearSessionBadgeStyle(chip);
+    chip.style.display = '';
+    chip.classList.add('has-target');
+    const entry = peerEntryForHost(peerTarget.hostId);
+    const label = document.createElement('span');
+    label.className = 'task-target-label';
+    label.textContent = 'Target:';
+    const badge = document.createElement('span');
+    badge.className = 'task-target-session-badge task-target-peer-badge';
+    const peerLabel = (entry && (entry.label || entry.host_id)) || peerTarget.hostId;
+    badge.textContent = peerTarget.sessionId
+      ? `${peerLabel} · ${peerTarget.sessionId.slice(0, 8)}`
+      : peerLabel;
+    chip.replaceChildren(label, badge);
+    const reconnecting = entry && entry.connected === false;
+    const title = peerTarget.sessionId
+      ? `Sends a follow-up to session ${peerTarget.sessionId} on ${peerLabel} through this daemon's peer grant${reconnecting ? ' — peer link is down, reconnecting' : ''}`
+      : `Delegates the task to ${peerLabel} through this daemon's peer grant${reconnecting ? ' — peer link is down, reconnecting' : ''}`;
+    chip.title = title;
+    chip.setAttribute('aria-label', title);
+    chip.classList.toggle('target-reconnecting', Boolean(reconnecting));
+    return;
+  }
+  const chip0 = document.getElementById('task-target-chip');
+  if (chip0) chip0.classList.remove('target-reconnecting');
   const sid = resolvePromptTargetSessionId();
   const previousTarget = taskTargetChipRenderedTarget;
   taskTargetChipRenderedTarget = sid;
@@ -67117,7 +67364,7 @@ function closeSessionRenameModal() {
   showSessionRenameStatus('');
 }
 
-function requestSessionRename(sessionOrId, sourceArg = '') {
+function requestSessionRename(sessionOrId, sourceArg = '', opts = {}) {
   const session = typeof sessionOrId === 'object'
     ? sessionOrId
     : { session_id: sessionOrId, source: sourceArg };
@@ -67126,6 +67373,10 @@ function requestSessionRename(sessionOrId, sourceArg = '') {
     showControlToast('error', 'Rename session failed: session ID is missing');
     return false;
   }
+  // Host-scoped rename (RC-C1): when the card belongs to a peer host,
+  // the save dispatch routes through api_peer_session_control instead
+  // of the local lane.
+  const renameHostId = String(opts.hostId || '').trim();
   const source = String(sourceArg || session.source || 'intendant').trim();
   const cached = sessionMetadataById.get(sid) || {};
   const backendSessionId = String(
@@ -67146,6 +67397,7 @@ function requestSessionRename(sessionOrId, sourceArg = '') {
     sessionId: sid,
     source: effectiveSource,
     backendSessionId,
+    hostId: renameHostId,
   };
   const sessionInput = document.getElementById('session-rename-session');
   if (sessionInput) {
@@ -67177,13 +67429,36 @@ function saveSessionRenameModal() {
     return;
   }
   showSessionRenameStatus('Saving...');
-  dispatchControlMsg({
+  const message = {
     action: 'rename_session',
     session_id: sessionRenameEditing.sessionId,
     source: sessionRenameEditing.source,
     ...(sessionRenameEditing.backendSessionId ? { backend_session_id: sessionRenameEditing.backendSessionId } : {}),
     name,
-  });
+  };
+  if (sessionRenameEditing.hostId) {
+    // Peer-hosted session: the rename is authorized and applied by the
+    // peer; its result reaches us as a folded session_updated (no local
+    // rename-result echo), so close optimistically on accept.
+    const hostId = sessionRenameEditing.hostId;
+    daemonApi
+      .request('api_peer_session_control', { peer_id: hostId, message })
+      .then(resp => {
+        if (resp.ok) {
+          closeSessionRenameModal();
+          showControlToast('info', 'Rename sent — the peer applies it.');
+          if (typeof loadSessions === 'function') loadSessions({ force: true });
+        } else {
+          const detail = resp.body && resp.body.error ? ` — ${resp.body.error}` : '';
+          showSessionRenameStatus(`Peer refused (${resp.status})${detail}`, 'error');
+        }
+      })
+      .catch(err => {
+        showSessionRenameStatus(`Could not reach the peer: ${err?.message || err}`, 'error');
+      });
+    return;
+  }
+  dispatchControlMsg(message);
 }
 
 // Index over _cachedSessions for O(1) any-id lookups. Every mutation site
@@ -71900,6 +72175,9 @@ function focusSessionWindow(sessionId) {
   if (!sid) return;
   const win = ensureSessionWindow(sid);
   if (!win) return;
+  // One composer, one target: focusing a local session retargets the
+  // composer locally, dropping any peer target.
+  if (typeof clearPromptTargetPeer === 'function') clearPromptTargetPeer({ skipChip: true });
   foregroundSessionFullId = sid;
   currentSessionFullId = sid;
   if (app && typeof app.select_session === 'function') {
@@ -77020,6 +77298,11 @@ function dashboardAccessTargetFromPeerSnapshot(snap) {
     ws_url: snap.ws_url || '',
     browser_tcp_via_url: snap.browser_tcp_via_url || '',
     capabilities: snap.capabilities || [],
+    // Field-for-field parity with the server row (routes_access.rs):
+    // the connected candidate's {url, transport_class} and the
+    // peer-advertised {profile, operations} grant.
+    link: snap.link || null,
+    grant: snap.grant || null,
   };
 }
 
@@ -77343,7 +77626,12 @@ function dashboardLaneBadge(hostId) {
   }
   const conn = peerDashboardControlConnectionsByHost.get(String(hostId || '').trim());
   const status = conn?.lastStatus || {};
-  const profile = String(status.grant_profile || target.profile || '').trim() || 'peer';
+  const advertisedProfile =
+    typeof peerEntryForHost === 'function'
+      ? (peerEntryForHost(hostId)?.grant?.profile || '')
+      : '';
+  const profile =
+    String(status.grant_profile || advertisedProfile || target.profile || '').trim() || 'peer';
   const viaLabel = String(selfHostLabel || 'this daemon').trim();
   const attributed = Boolean(status.attributed_fingerprint);
   const record = accessFleetTargets().find(t =>
@@ -77397,7 +77685,15 @@ function dashboardTargetSummary(hostId, context = '') {
   const online = peer.connected !== false;
   const conn = peerDashboardControlConnectionsByHost.get(peerId);
   const status = conn?.lastStatus || {};
-  const profile = status.grant_profile || '';
+  // The federation-link grant echo (PeerSnapshot.grant) names the
+  // profile before any browser↔peer datachannel exists — prefer the
+  // datachannel's own status once it opens (it reflects the exact
+  // grant that tunnel authorizes under).
+  const advertisedProfile =
+    typeof peerEntryForHost === 'function'
+      ? (peerEntryForHost(peerId)?.grant?.profile || '')
+      : '';
+  const profile = status.grant_profile || advertisedProfile || '';
   const grantKind = status.grant_kind || '';
   const hasExactGrant = Boolean(profile || grantKind);
   const access = hasExactGrant
@@ -82258,6 +82554,12 @@ function setShellHost(hostId) {
   renderDashboardTargetSummary('shell-target-summary', next, 'shell');
   if (activeTab === 'terminal' && activeTermSubtab === 'shell') {
     openShellSessionIfPossible(true);
+  }
+  // Publish into the global operating target. Daemon targets move the
+  // whole dashboard; the Shell's cloud exec hosts are pane-local (the
+  // setter refuses non-daemon ids) and leave the global untouched.
+  if (typeof setGlobalTargetHost === 'function') {
+    setGlobalTargetHost(next === SHELL_HOST_ID ? '' : next, { source: 'shell' });
   }
 }
 /* ── static/app/44-shell-frames.js ── */
@@ -109957,6 +110259,10 @@ function peerDashboardControlSignalAvailable(peerId) {
   if (!window.RTCPeerConnection) return false;
   const peer = daemons.find(d => d.host_id === id);
   if (!peer || peer.connected === false) return false;
+  // A relay-transiting federation link carries signaling but nothing
+  // ICE-borne: the browser↔peer datachannel cannot form without a
+  // direct route or provisioned TURN, so don't offer it.
+  if (!peerLinkSupportsMedia(id)) return false;
   if (dashboardConnectModeEnabled()) {
     return Boolean(
       dashboardTransport?.canUseRpc?.() &&
@@ -111091,6 +111397,14 @@ function snapshotToDaemonEntry(p) {
     // live peer_display_ready/removed events produced this list, so
     // wholesale row replacement never loses display state.
     displays: Array.isArray(p.displays) ? p.displays : [],
+    // Reachability honesty (RC-C1): the connected transport candidate
+    // ({url, transport_class: 'direct'|'relayed'}, null while
+    // disconnected) and the grant the peer advertised for this
+    // daemon's identity ({profile, operations}, null = unknown).
+    // Media/datachannel affordances derive from link.transport_class;
+    // action pills derive from grant.operations.
+    link: p.link || null,
+    grant: p.grant || null,
   };
 }
 
@@ -111196,6 +111510,18 @@ function updateDaemonSnapshot(snap) {
 // Drop a peer from the local daemons list and tear down its WASM
 // secondary connection. Tolerates unknown ids (a `peer_removed` may
 // arrive after `refreshPeersFromApi` has already pruned the entry).
+function removeDaemonByIdResetGlobalTarget(id) {
+  // A removed peer cannot stay the operating target — snap the whole
+  // dashboard back to the local daemon (a mere disconnect keeps the
+  // selection: the row persists and panes render the reconnect state).
+  if (
+    typeof currentGlobalTargetHostId === 'function' &&
+    currentGlobalTargetHostId() === String(id || '')
+  ) {
+    setGlobalTargetHost('', { source: 'peer-removed' });
+  }
+}
+
 function removeDaemonById(id) {
   if (!id) return;
   const idx = daemons.findIndex(d => d.host_id === id);
@@ -111214,6 +111540,7 @@ function removeDaemonById(id) {
   // RTCPeerConnection has nowhere to send signaling, and leaving it
   // alive would just stall on ICE failure.
   closePeerDisplaysForHost(id).catch(() => {});
+  removeDaemonByIdResetGlobalTarget(id);
   renderDaemonsList();
 }
 
@@ -111556,8 +111883,14 @@ function renderDaemonRow(d, isSelf) {
   // 3b's primary-as-media-relay takes over when no non-loopback path
   // is known — same contract the peer-side loopback warn describes.
   const tcpViaUrl = resolveBrowserTcpViaUrl(d);
+  // Render the display affordance from the live link's transport
+  // class, never from the peer row existing: a relay-only link cannot
+  // carry WebRTC media, so the pill would be dead — say so instead.
+  const linkSupportsMedia = peerLinkSupportsMedia(d.host_id);
   const viewDisplayBtn = !isSelf && peerCanShareDisplay(d)
-    ? `<button class="daemon-display-view" data-host-id="${escapeHtml(d.host_id)}" data-display-id="0" data-tcp-via-url="${escapeHtml(tcpViaUrl)}" title="Open this peer's display via WebRTC (browser↔peer direct, primary signals only)">View display</button>`
+    ? (linkSupportsMedia
+      ? `<button class="daemon-display-view" data-host-id="${escapeHtml(d.host_id)}" data-display-id="0" data-tcp-via-url="${escapeHtml(tcpViaUrl)}" title="Open this peer's display via WebRTC (browser↔peer direct, primary signals only)">View display</button>`
+      : `<span class="daemon-relay-note" title="This peer is reachable over the relay link only. Live video and file transfer need a direct route or TURN; messages, tasks, approvals, and session actions still work.">relay link — no live media</span>`)
     : '';
   const controlsPanel = isSelf
     ? ''
@@ -116264,6 +116597,9 @@ function refreshStatsHostPicker() {
 function switchStatsHost(hostId) {
   activeStatsHost = hostId || '';
   renderStatsForActiveHost();
+  if (typeof setGlobalTargetHost === 'function') {
+    setGlobalTargetHost(activeStatsHost, { source: 'stats' });
+  }
 }
 
 // Render the Stats tab from whichever host is currently active,
@@ -117026,6 +117362,33 @@ document.getElementById('settings-save-keys').addEventListener('click', saveApiK
 // 31-init-identity-fleet.js with the early state: a #stats deep link
 // reaches them during script evaluation — the deep-link TDZ rule.)
 
+// The federation fold (PeerSnapshot.sessions, SessionInfo shape) mapped
+// into the session-list row vocabulary the Sessions tab renders. Used
+// when a peer is reachable over the control link only (relay-only, or
+// no browser-dialable URL): the list stays live via peer_state_changed
+// snapshots even though the peer's own /api/sessions is unreachable.
+function peerFoldSessionRows(entry) {
+  const sessions = Array.isArray(entry.sessions) ? entry.sessions : [];
+  return sessions.map(s => ({
+    session_id: s.session_id,
+    name: s.label || '',
+    source: s.source || 'intendant',
+    started_at: s.started_at || '',
+    phase: s.phase || '',
+    needs_approval: !!s.needs_approval,
+    is_primary: !!s.is_primary,
+    parent_session_id: s.parent_session_id || null,
+    tokens_used: s.tokens_used ?? null,
+    goal: s.goal || null,
+    vitals: s.vitals || null,
+    // The fold carries no per-session store facts; resume rides the
+    // peer's own resume-id defaulting (resume_id = session_id), local
+    // delete/report affordances stay off.
+    can_resume: true,
+    can_delete: false,
+  }));
+}
+
 function fetchSessionsForHost(hostId, options = {}) {
   hostId = hostId || selfPeerId;
   const cacheSessionMetadata = options.cacheSessionMetadata !== false;
@@ -117087,6 +117450,15 @@ function fetchSessionsForHost(hostId, options = {}) {
         if (dashboardConnectModeEnabled()) throw err;
         console.warn('[peer-dashboard-control] api_sessions RPC failed, falling back to direct peer HTTP', err);
       }
+    }
+    // Relay-only or otherwise browser-unreachable peers (RC-C1): no
+    // datachannel and no HTTP the browser can dial. Render the
+    // federation fold (PeerSnapshot.sessions, riding the control WS)
+    // instead of failing — thinner than the peer's own /api/sessions
+    // rows, honestly so.
+    const entry = daemons.find(x => x.host_id === hostId);
+    if (entry && (!peerLinkSupportsMedia(hostId) || !baseUrl)) {
+      return peerFoldSessionRows(entry);
     }
     if (dashboardConnectModeEnabled()) {
       throw new Error('Peer sessions are unavailable for this target');
@@ -120308,10 +120680,60 @@ function autoAttachUnmanagedFollowUp(evt = {}) {
 // artifact — all agents (native, Codex, Claude Code, Kimi Code, Pi) treat
 // subsequent messages as new turns in the existing conversation.
 // Shared by the Activity composer and the Station composer.
+// Composer routing for a peer target (RC-C1): a bare peer target
+// delegates the text as a task (`api_peer_task`); a peer session
+// target sends it as a follow-up scoped to that session
+// (`api_peer_session_control` → the federation link → the peer's own
+// per-action authorization). Both spend this daemon's peer grant.
+// Attachments stay local-only: frame ids resolve against this
+// daemon's stores, so they are refused up front instead of silently
+// dropped on the peer.
+function dispatchPeerTaskText(peerTarget, text) {
+  const entry = peerEntryForHost(peerTarget.hostId);
+  const label = (entry && (entry.label || entry.host_id)) || peerTarget.hostId;
+  if (!entry || entry.connected === false) {
+    showControlToast('error', `${label} is not connected — the peer link is reconnecting; try again shortly.`);
+    return false;
+  }
+  if (pendingAttachments.length > 0) {
+    showControlToast('error', 'Attachments cannot ride a peer target yet — remove them or target a local session.');
+    return false;
+  }
+  const done = (resp, verb) => {
+    if (resp.ok) {
+      showControlToast('info', `${verb} ${label}.`);
+    } else {
+      const detail = resp.body && resp.body.error ? ` — ${resp.body.error}` : '';
+      showControlToast('error', `${label} refused (${resp.status})${detail}`);
+    }
+  };
+  const fail = (err) => {
+    showControlToast('error', `Could not reach ${label}: ${err && err.message ? err.message : err}`);
+  };
+  if (peerTarget.sessionId) {
+    daemonApi
+      .request('api_peer_session_control', {
+        peer_id: peerTarget.hostId,
+        message: { action: 'follow_up', text, session_id: peerTarget.sessionId },
+      })
+      .then(resp => done(resp, `Follow-up sent to ${peerTarget.sessionId.slice(0, 8)} on`))
+      .catch(fail);
+  } else {
+    daemonApi
+      .request('api_peer_task', { peer_id: peerTarget.hostId, instructions: text })
+      .then(resp => done(resp, 'Task delegated to'))
+      .catch(fail);
+  }
+  return true;
+}
+
 function dispatchTaskText(text, options = {}) {
   if (!app) return false;
   text = String(text || '').trim();
   if (!text) return false;
+  const peerTarget =
+    typeof currentPromptTargetPeer === 'function' ? currentPromptTargetPeer() : null;
+  if (peerTarget) return dispatchPeerTaskText(peerTarget, text);
   const attachments = pendingAttachments.map(a => a.frameId);
   const attachmentReceipt = pendingAttachments.slice();
   const direct = document.getElementById('direct-mode-toggle')?.checked || false;
@@ -120364,6 +120786,13 @@ function submitComposedText(text) {
   if (!app) return false;
   text = String(text || '').trim();
   if (!text) return false;
+  const composerPeerTarget =
+    typeof currentPromptTargetPeer === 'function' ? currentPromptTargetPeer() : null;
+  if (composerPeerTarget) {
+    // Peer targets never steer or slash locally — the text goes to the
+    // peer daemon as a delegation or session follow-up.
+    return dispatchPeerTaskText(composerPeerTarget, text);
+  }
   const codexSlash = parseCodexSlashCommand(text);
   if (codexSlash) {
     return !!dispatchCodexSlashCommand(codexSlash);
@@ -120972,6 +121401,9 @@ function peerFileTransferSignalAvailable(peerId = filesDownloadSelectedPeerId())
   if (!window.RTCPeerConnection) return false;
   const peer = daemons.find(d => d.host_id === id);
   if (!peer || peer.connected === false) return false;
+  // File-transfer bytes ride a browser↔peer datachannel — nothing
+  // ICE-borne survives a relay-only link (RC-C1 honesty rail).
+  if (!peerLinkSupportsMedia(id)) return false;
   if (dashboardConnectModeEnabled()) {
     return Boolean(
       dashboardTransport?.canUseRpc?.() &&
@@ -121010,6 +121442,9 @@ function refreshFilesDownloadHostOptions() {
 function onFilesDownloadHostChanged(options = {}) {
   const browse = document.getElementById('files-download-browse-btn');
   const selectedPeer = filesDownloadSelectedPeerId();
+  if (typeof setGlobalTargetHost === 'function') {
+    setGlobalTargetHost(selectedPeer, { source: 'files-download' });
+  }
   if (browse) {
     // Peer browsing rides the fs-picker's api_fs_list target lane (55);
     // gate on reachability, not on peer-ness.
@@ -124875,6 +125310,9 @@ function refreshFilesIdeHostOptions() {
 
 function onFilesIdeHostChanged() {
   const hostId = filesIdeSelectedHostId();
+  if (typeof setGlobalTargetHost === 'function') {
+    setGlobalTargetHost(hostId, { source: 'files-ide' });
+  }
   renderDashboardTargetSummary('files-ide-target-summary', hostId, 'files');
   const state = filesIdeTreeState(hostId);
   const hiddenBtn = document.getElementById('files-ide-hidden-btn');
@@ -127789,6 +128227,9 @@ function setSessionsHost(hostId) {
   // Message lane (flagged): the tunnel twin serves the selected peer's own
   // index, so a host switch re-keys the search. No-op with the flag off.
   scheduleSessionMessageSearch();
+  if (typeof setGlobalTargetHost === 'function') {
+    setGlobalTargetHost(next, { source: 'sessions' });
+  }
 }
 
 // Whole-card action while browsing a peer: hand off to the peer's own
@@ -130629,6 +131070,87 @@ function buildSessionCard(m, derived, ctx) {
       actions.appendChild(btn);
     }
     card.appendChild(actions);
+  }
+
+  // Peer host cards (RC-C1): host-scoped session actions through
+  // api_peer_session_control — the peer authorizes each against the
+  // profile it granted this daemon. Pills derive from the advertised
+  // grant (peerAllowsOperation): a known-denied operation renders no
+  // pill; an unknown grant renders pills that act and report honestly.
+  if (ctx.viewingPeer && sessionId) {
+    const peerHostId = typeof currentSessionsHostId === 'function' ? currentSessionsHostId() : '';
+    const peerEntry = typeof peerEntryForHost === 'function' ? peerEntryForHost(peerHostId) : null;
+    if (peerEntry) {
+      const actions = document.createElement('div');
+      actions.className = 'sc-actions';
+      const linkDown = peerEntry.connected === false;
+      const peerName = peerEntry.label || peerEntry.host_id;
+      const addPill = (label, title, opId, onClick, cls) => {
+        if (!peerAllowsOperation(peerHostId, opId)) return;
+        const btn = document.createElement('button');
+        btn.className = cls || 'ui-btn';
+        btn.textContent = label;
+        btn.title = linkDown
+          ? `${title} — unavailable while the peer link reconnects`
+          : title;
+        btn.disabled = linkDown;
+        btn.addEventListener('click', (e) => {
+          e.stopPropagation();
+          onClick();
+        });
+        actions.appendChild(btn);
+      };
+      if (s.can_resume !== false) {
+        addPill(
+          'Resume on peer',
+          `Resume this session on ${peerName} (runs there under this daemon's peer grant)`,
+          'task.run',
+          () => {
+            const source = normalizeAgentId(s.backend_source || s.source || '') || 'intendant';
+            daemonApi
+              .request('api_peer_session_control', {
+                peer_id: peerHostId,
+                message: {
+                  action: 'resume_session',
+                  source,
+                  session_id: String(s.session_id),
+                  resume_id: String(s.backend_session_id || s.resume_id || s.session_id),
+                  project_root: s.project_root || null,
+                  direct: true,
+                },
+              })
+              .then(resp => {
+                if (resp.ok) showControlToast('info', `Resume sent to ${peerName}.`);
+                else {
+                  const detail = resp.body && resp.body.error ? ` — ${resp.body.error}` : '';
+                  showControlToast('error', `${peerName} refused resume (${resp.status})${detail}`);
+                }
+              })
+              .catch(err => showControlToast('error', `Could not reach ${peerName}: ${err?.message || err}`));
+          },
+          'ui-btn sc-resume-btn',
+        );
+      }
+      addPill(
+        'Message',
+        `Target the composer at this session on ${peerName}`,
+        'message.send',
+        () => {
+          if (setPromptTargetPeer(peerHostId, String(s.session_id))) {
+            routeTo('activity');
+            document.getElementById('activity-task-input')?.focus();
+          }
+        },
+      );
+      addPill(
+        'Rename',
+        `Rename this session on ${peerName}`,
+        'session.manage',
+        () => requestSessionRename(s, s.source || '', { hostId: peerHostId }),
+        'ui-btn sc-rename-btn',
+      );
+      if (actions.children.length) card.appendChild(actions);
+    }
   }
 
   if (ctx.viewingPeer) {
@@ -136749,6 +137271,41 @@ document.getElementById('stats-host-select').addEventListener('change', (e) => {
   switchStatsHost(e.target.value);
 });
 
+// Global operating target (RC-C1): the pane pickers publish into one
+// selection; this listener makes the others follow. Every pane setter
+// is equality-guarded and republishing the same value is a no-op, so
+// the publish→follow→publish cycle terminates immediately.
+document.addEventListener('ui2:target-changed', (e) => {
+  const hostId = String(e?.detail?.hostId || '');
+  // Shell (its local sentinel is SHELL_HOST_ID, not '').
+  if (typeof setShellHost === 'function') {
+    setShellHost(hostId || SHELL_HOST_ID);
+  }
+  // Files IDE + Transfers selects hold their own value; refresh the
+  // options first when the target isn't listed yet (a peer added since
+  // the last rebuild).
+  const followSelect = (selectId, refresh, onChanged) => {
+    const sel = document.getElementById(selectId);
+    if (!sel) return;
+    if (sel.value === hostId) return;
+    if (![...sel.options].some(o => o.value === hostId)) refresh();
+    if (sel.value !== hostId) {
+      sel.value = hostId;
+      onChanged();
+    }
+  };
+  followSelect('files-ide-host', refreshFilesIdeHostOptions, onFilesIdeHostChanged);
+  followSelect('files-download-host', refreshFilesDownloadHostOptions, onFilesDownloadHostChanged);
+  if (typeof setSessionsHost === 'function') setSessionsHost(hostId);
+  if (typeof switchStatsHost === 'function' && activeStatsHost !== hostId) {
+    const statsSel = document.getElementById('stats-host-select');
+    if (statsSel && [...statsSel.options].some(o => o.value === hostId)) {
+      statsSel.value = hostId;
+    }
+    switchStatsHost(hostId);
+  }
+});
+
 document.getElementById('access-link-daemon-btn')?.addEventListener('click', () => routeTo('access', 'peers'));
 
 // Join-with-an-org-grant: present the pasted document to this daemon. The
@@ -137697,6 +138254,27 @@ function handleDisplayRequestResolved(d) {
     return ids;
   }
 
+  const PEER_SESSION_ROWS = 6; // newest-first cap per peer (fold order)
+
+  // Connected peers are composer targets too (RC-C1): the peer row
+  // delegates a new task; a peer session row scopes a follow-up to
+  // that session. Both spend this daemon's peer grant on the target.
+  function targetablePeers() {
+    if (typeof daemons === 'undefined' || !Array.isArray(daemons)) return [];
+    return daemons.filter(d => d && d.host_id && d.connected !== false);
+  }
+
+  function peerSessionRowsFor(d) {
+    const sessions = Array.isArray(d.sessions) ? d.sessions : [];
+    return sessions.slice(0, PEER_SESSION_ROWS);
+  }
+
+  function activePeerKey() {
+    const t = typeof currentPromptTargetPeer === 'function' ? currentPromptTargetPeer() : null;
+    if (!t) return '';
+    return t.sessionId ? `ps:${t.hostId} ${t.sessionId}` : `p:${t.hostId}`;
+  }
+
   function rowPhase(sid) {
     if (hasPendingActiveSessionWindow(sid)) return 'active';
     const win = sessionWindows.get(sid);
@@ -137710,10 +138288,17 @@ function handleDisplayRequestResolved(d) {
     const parts = [
       resolvePromptTargetSessionId(),
       explicitForegroundSessionId() ? 'E' : 'A',
+      activePeerKey(),
       filterQuery,
     ];
     for (const sid of usableSessionIds()) {
       parts.push(sid, sessionIdentityParts(sid).name, rowPhase(sid));
+    }
+    for (const d of targetablePeers()) {
+      parts.push(d.host_id, d.label || '', d.connected === false ? 'off' : 'on');
+      for (const s of peerSessionRowsFor(d)) {
+        parts.push(s.session_id, s.label || '', s.phase || '');
+      }
     }
     return parts.join('\u0000');
   }
@@ -137778,6 +138363,44 @@ function handleDisplayRequestResolved(d) {
     return el;
   }
 
+  function buildPeerRow(d, activeKey) {
+    const key = `p:${d.host_id}`;
+    const row = makeRow(key, 'ui2-tsw-peer');
+    const label = d.label || d.host_id;
+    const badge = document.createElement('span');
+    badge.className = 'ui2-tsw-badge ui2-tsw-peer-badge';
+    badge.textContent = label;
+    const sub = document.createElement('span');
+    sub.className = 'ui2-tsw-row-sub';
+    sub.textContent = 'delegates a task';
+    row.append(badge, sub);
+    row.title = `Delegate the composed task to ${label} (runs there under this daemon's peer grant)`;
+    row.setAttribute('aria-label', `Peer ${label}: delegate a task`);
+    if (key === activeKey) row.setAttribute('aria-selected', 'true');
+    return row;
+  }
+
+  function buildPeerSessionRow(d, s, activeKey) {
+    const key = `ps:${d.host_id} ${s.session_id}`;
+    const row = makeRow(key, 'ui2-tsw-peer-session');
+    const label = d.label || d.host_id;
+    const name = s.label || s.session_id.slice(0, 8);
+    const nameEl = document.createElement('span');
+    nameEl.className = 'ui2-tsw-row-name';
+    nameEl.textContent = name;
+    const phase = (s.phase === 'working' || s.phase === 'thinking')
+      ? 'active'
+      : (s.needs_approval || s.phase === 'waiting_approval') ? 'waiting' : 'done';
+    const dot = document.createElement('span');
+    dot.className = `ui2-tsw-dot ${phase}`;
+    dot.setAttribute('aria-hidden', 'true');
+    row.append(nameEl, dot);
+    row.title = `Send the composed text as a follow-up to session ${s.session_id} on ${label}`;
+    row.setAttribute('aria-label', `Session ${name} on peer ${label}: send a follow-up`);
+    if (key === activeKey) row.setAttribute('aria-selected', 'true');
+    return row;
+  }
+
   function renderRows() {
     const usable = usableSessionIds();
     const target = resolvePromptTargetSessionId();
@@ -137809,7 +138432,34 @@ function handleDisplayRequestResolved(d) {
     if (usable.length) children.push(buildAutoRow(autoActive));
     for (const sid of list) children.push(buildSessionRow(sid, target));
     if (!usable.length) children.push(buildEmpty('No targetable sessions'));
-    else if (!list.length) children.push(buildEmpty('No matches'));
+    else if (!list.length && !q) children.push(buildEmpty('No matches'));
+
+    // Peers section: connected peer daemons and their known sessions.
+    const activeKey = activePeerKey();
+    const peers = targetablePeers();
+    let peerRows = [];
+    for (const d of peers) {
+      const label = d.label || d.host_id;
+      const peerMatches = !q || ui2FuzzyScore(q, label) >= 0 || ui2FuzzyScore(q, d.host_id) >= 0;
+      if (peerMatches) peerRows.push(buildPeerRow(d, activeKey));
+      for (const s of peerSessionRowsFor(d)) {
+        const sessionMatches = !q
+          || peerMatches
+          || ui2FuzzyScore(q, s.label || '') >= 0
+          || ui2FuzzyScore(q, s.session_id) >= 0;
+        if (sessionMatches) peerRows.push(buildPeerSessionRow(d, s, activeKey));
+      }
+    }
+    if (peerRows.length) {
+      const divider = document.createElement('div');
+      divider.className = 'ui2-tsw-eyebrow ui2-tsw-peers-eyebrow';
+      divider.textContent = 'Peers';
+      divider.setAttribute('aria-hidden', 'true');
+      children.push(divider, ...peerRows);
+    }
+    if (usable.length && !list.length && !peerRows.length && q) {
+      children.push(buildEmpty('No matches'));
+    }
     rowsEl.replaceChildren(...children);
     lastSig = currentSignature();
 
@@ -137869,6 +138519,7 @@ function handleDisplayRequestResolved(d) {
       // The explicit pick lives in two refs (foreground + current), possibly
       // holding different ids — discard until the explicit lane is empty so
       // the resolver takes over.
+      clearPromptTargetPeer({ skipChip: true });
       for (let i = 0; i < 4 && explicitForegroundSessionId(); i++) {
         discardPromptTargetReference(explicitForegroundSessionId());
       }
@@ -137877,6 +138528,7 @@ function handleDisplayRequestResolved(d) {
     } else if (key === 'new') {
       // Close without refocus: openNewSessionFromPrompt focuses the
       // new-session input on the next frame and must win.
+      clearPromptTargetPeer();
       openNewSessionFromPrompt();
       closePopover();
     } else if (key.startsWith('s:')) {
@@ -137885,8 +138537,22 @@ function handleDisplayRequestResolved(d) {
         renderRows();
         return;
       }
-      focusSessionWindow(sid);
+      focusSessionWindow(sid); // clears any peer target (one composer, one target)
       closePopover({ refocus: true });
+    } else if (key.startsWith('ps:')) {
+      const rest = key.slice(3);
+      const sep = rest.indexOf(' ');
+      if (sep > 0 && setPromptTargetPeer(rest.slice(0, sep), rest.slice(sep + 1))) {
+        closePopover({ refocus: true });
+      } else {
+        renderRows();
+      }
+    } else if (key.startsWith('p:')) {
+      if (setPromptTargetPeer(key.slice(2), null)) {
+        closePopover({ refocus: true });
+      } else {
+        renderRows();
+      }
     }
   }
 

--- a/static/app.html
+++ b/static/app.html
@@ -37994,7 +37994,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'f8120a46aa6316d7';
+const INTENDANT_APP_BUILD = '5cd3a10d20a93aec';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -40735,6 +40735,7 @@ const DAEMON_API_HTTP_MAP = Object.freeze({
   api_peer_message: { verb: 'POST', path: '/api/peers/{peer_id}/message' },
   api_peer_task: { verb: 'POST', path: '/api/peers/{peer_id}/task' },
   api_peer_approval: { verb: 'POST', path: '/api/peers/{peer_id}/approval' },
+  api_peer_session_control: { verb: 'POST', path: '/api/peers/{peer_id}/session-control' },
   api_peer_webrtc_signal: { verb: 'POST', path: '/api/peers/{peer_id}/webrtc' },
   api_peer_file_transfer_signal: { verb: 'POST', path: '/api/peers/{peer_id}/file-transfer-webrtc' },
   api_peer_dashboard_control_signal: { verb: 'POST', path: '/api/peers/{peer_id}/dashboard-control-webrtc' },

--- a/static/app/31-init-identity-fleet.js
+++ b/static/app/31-init-identity-fleet.js
@@ -960,6 +960,79 @@ if (DASHBOARD_ACCESS_PAGE_MODE) {
   document.title = 'Intendant Access';
 }
 let daemons = [];
+// ---- Global operating target (RC-C1) ----
+// One dashboard, one "operating <host>" selection. The per-pane host
+// pickers (Shell, Files, Transfers, Sessions, Stats) publish into and
+// follow this instead of each owning a private selection; panes with a
+// wider domain (the Shell's cloud exec hosts, which are not daemons)
+// may show a pane-local override without moving the global. '' = the
+// local daemon (self). Change notifications ride a
+// `ui2:target-changed` CustomEvent on document.
+let globalTargetHostId = '';
+function normalizeTargetHostId(hostId) {
+  const id = String(hostId == null ? '' : hostId).trim();
+  if (!id || id === 'local' || id === 'self') return '';
+  if (typeof selfPeerId !== 'undefined' && selfPeerId && id === selfPeerId) return '';
+  return id;
+}
+function currentGlobalTargetHostId() {
+  return globalTargetHostId;
+}
+function globalTargetIsLocal() {
+  return globalTargetHostId === '';
+}
+function peerEntryForHost(hostId) {
+  const id = normalizeTargetHostId(hostId);
+  if (!id) return null;
+  return daemons.find((d) => d.host_id === id) || null;
+}
+function setGlobalTargetHost(hostId, opts) {
+  const next = normalizeTargetHostId(hostId);
+  // Only daemon targets participate: '' (self) or a known peer row.
+  if (next && !peerEntryForHost(next)) return false;
+  if (next === globalTargetHostId) return true;
+  globalTargetHostId = next;
+  try {
+    document.dispatchEvent(
+      new CustomEvent('ui2:target-changed', {
+        detail: { hostId: next, source: (opts && opts.source) || '' },
+      }),
+    );
+  } catch (_e) {
+    /* CustomEvent is universal in shipped engines; never let a
+       dispatch failure strand the selection itself. */
+  }
+  return true;
+}
+// Honest-affordance helpers: what the peer advertised about OUR grant
+// and about the live link. Unknown grant (older peer, or the echo not
+// yet folded) is "act and report", never denial; unknown link means no
+// media promise.
+function peerGrantOperations(hostId) {
+  const entry = peerEntryForHost(hostId);
+  const ops = entry && entry.grant && Array.isArray(entry.grant.operations)
+    ? entry.grant.operations
+    : null;
+  return ops;
+}
+function peerAllowsOperation(hostId, operationId) {
+  const ops = peerGrantOperations(hostId);
+  if (!ops) return true; // unknown → optimistic, outcome reported honestly
+  return ops.includes(operationId);
+}
+function peerLinkTransportClass(hostId) {
+  const entry = peerEntryForHost(hostId);
+  return entry && entry.link && entry.link.transport_class
+    ? String(entry.link.transport_class)
+    : '';
+}
+// Media/datachannel affordances render from the transport class of the
+// live link — never from the peer row existing. Absent link info on a
+// connected row (daemon predating the field) keeps today's behavior.
+function peerLinkSupportsMedia(hostId) {
+  const cls = peerLinkTransportClass(hostId);
+  return cls !== 'relayed';
+}
 let dashboardAccessTargets = [];
 let dashboardAccessOverview = null;
 let accessUserClientGrantSubmitting = false;

--- a/static/app/32-daemon-api.js
+++ b/static/app/32-daemon-api.js
@@ -264,6 +264,7 @@ const DAEMON_API_HTTP_MAP = Object.freeze({
   api_peer_message: { verb: 'POST', path: '/api/peers/{peer_id}/message' },
   api_peer_task: { verb: 'POST', path: '/api/peers/{peer_id}/task' },
   api_peer_approval: { verb: 'POST', path: '/api/peers/{peer_id}/approval' },
+  api_peer_session_control: { verb: 'POST', path: '/api/peers/{peer_id}/session-control' },
   api_peer_webrtc_signal: { verb: 'POST', path: '/api/peers/{peer_id}/webrtc' },
   api_peer_file_transfer_signal: { verb: 'POST', path: '/api/peers/{peer_id}/file-transfer-webrtc' },
   api_peer_dashboard_control_signal: { verb: 'POST', path: '/api/peers/{peer_id}/dashboard-control-webrtc' },

--- a/static/app/34-station-panes.js
+++ b/static/app/34-station-panes.js
@@ -1011,7 +1011,59 @@ function stationHandleSessionAction(action) {
     return;
   }
   if (!sessionId) return;
-  const session = stationFindSessionById(sessionId) || { session_id: sessionId };
+  // Host-scoped routing (RC-C1): scene nodes for a PEER's sessions
+  // carry the peer's raw session ids. When the id resolves to a peer
+  // fold and not to anything local, actions route through
+  // api_peer_session_control instead of assuming a local session id.
+  const localSession = stationFindSessionById(sessionId);
+  const peerHostId = !localSession && !sessionWindows.has(sessionId)
+    && typeof peerEntryForHost === 'function'
+    ? (Array.isArray(daemons)
+      ? (daemons.find(d => Array.isArray(d.sessions)
+          && d.sessions.some(s => String(s.session_id) === sessionId))?.host_id || '')
+      : '')
+    : '';
+  if (peerHostId) {
+    const peerName = peerEntryForHost(peerHostId)?.label || peerHostId;
+    if (op === 'focus' || op === 'target' || op === 'steer') {
+      if (setPromptTargetPeer(peerHostId, sessionId)) {
+        showControlToast?.('info', `Composer targets ${shortSessionId(sessionId)} on ${peerName}`);
+        if (stationRenderedPrimaryActive()) {
+          station?.set_composer?.(true, 'send');
+          stationHandleComposerEvent({ op: 'focus' });
+        }
+      }
+      return;
+    }
+    if (op === 'interrupt') {
+      daemonApi
+        .request('api_peer_session_control', {
+          peer_id: peerHostId,
+          message: { action: 'interrupt', session_id: sessionId },
+        })
+        .then(resp => {
+          if (resp.ok) {
+            showControlToast?.('info', `Interrupt sent to ${shortSessionId(sessionId)} on ${peerName}`);
+          } else {
+            const detail = resp.body && resp.body.error ? ` — ${resp.body.error}` : '';
+            showControlToast?.('error', `${peerName} refused interrupt (${resp.status})${detail}`);
+          }
+        })
+        .catch(err => showControlToast?.('error', `Could not reach ${peerName}: ${err?.message || err}`));
+      return;
+    }
+    if (op === 'copy') {
+      copyTextToClipboard(sessionId)
+        .then(() => showControlToast('success', `Copied session ID ${shortSessionId(sessionId)}`))
+        .catch(err => showControlToast('error', `Copy session ID failed: ${err?.message || err}`));
+      return;
+    }
+    // Anything else (transcript, thread ops, config) still lives on the
+    // peer's own dashboard — no silent no-ops.
+    showControlToast?.('info', `${op} for peer sessions happens on ${peerName}'s own dashboard.`);
+    return;
+  }
+  const session = localSession || { session_id: sessionId };
   const live = stationExternalLiveThreadDescriptor(session) || stationExternalLiveThreadDescriptor(sessionId);
   if (op === 'focus' || op === 'target') {
     focusSessionWindow(live?.liveId || sessionId);

--- a/static/app/35-station-diff-viewer.js
+++ b/static/app/35-station-diff-viewer.js
@@ -1736,7 +1736,13 @@ function stationPeerSessionAgents(d) {
           ? String(goal.tokensUsed)
           : '',
         threadActions: [],
-        canInterrupt: false,
+        // Interrupt pill from the peer-advertised grant (RC-C1): the
+        // action routes through api_peer_session_control and the peer
+        // re-authorizes it; render it only when the session is live
+        // and the grant is not known to lack session.manage.
+        canInterrupt: (phase === 'running' || phase === 'thinking')
+          && (typeof peerAllowsOperation !== 'function'
+            || peerAllowsOperation(d.host_id, 'session.manage')),
       });
     }
     return out;

--- a/static/app/39-session-windows.js
+++ b/static/app/39-session-windows.js
@@ -59,7 +59,78 @@ function markSessionWindowPendingActive(sessionId) {
 // automatic resolver rebind (pulse it) apart from a repeat render.
 let taskTargetChipRenderedTarget = null;
 
+// Composer peer target (RC-C1): when set, the composer sends to a
+// FEDERATED peer instead of a local session — a new task via
+// delegation ({hostId, sessionId: null}) or a follow-up scoped to one
+// of the peer's sessions ({hostId, sessionId}). Any explicit local
+// pick clears it (one composer, one target). Validity is re-checked
+// on read: a removed peer drops the target instead of stranding the
+// composer on a ghost.
+let promptTargetPeer = null;
+
+function currentPromptTargetPeer() {
+  if (!promptTargetPeer) return null;
+  const entry =
+    typeof peerEntryForHost === 'function' ? peerEntryForHost(promptTargetPeer.hostId) : null;
+  if (!entry) {
+    promptTargetPeer = null;
+    return null;
+  }
+  return promptTargetPeer;
+}
+
+function setPromptTargetPeer(hostId, sessionId) {
+  const entry = typeof peerEntryForHost === 'function' ? peerEntryForHost(hostId) : null;
+  if (!entry) return false;
+  promptTargetPeer = {
+    hostId: entry.host_id,
+    sessionId: sessionId ? String(sessionId) : null,
+  };
+  updateTaskTargetChip();
+  return true;
+}
+
+function clearPromptTargetPeer(opts) {
+  if (!promptTargetPeer) return;
+  promptTargetPeer = null;
+  if (!opts || !opts.skipChip) updateTaskTargetChip();
+}
+
 function updateTaskTargetChip() {
+  // A peer target owns the chip while set: the composer routes to the
+  // peer daemon, not to any local session window.
+  const peerTarget = currentPromptTargetPeer();
+  if (peerTarget) {
+    const chip = document.getElementById('task-target-chip');
+    taskTargetChipRenderedTarget = `peer:${peerTarget.hostId}:${peerTarget.sessionId || ''}`;
+    updatePromptTargetSessionHighlight('');
+    updateControlFastButtonState();
+    if (!chip) return;
+    clearSessionBadgeStyle(chip);
+    chip.style.display = '';
+    chip.classList.add('has-target');
+    const entry = peerEntryForHost(peerTarget.hostId);
+    const label = document.createElement('span');
+    label.className = 'task-target-label';
+    label.textContent = 'Target:';
+    const badge = document.createElement('span');
+    badge.className = 'task-target-session-badge task-target-peer-badge';
+    const peerLabel = (entry && (entry.label || entry.host_id)) || peerTarget.hostId;
+    badge.textContent = peerTarget.sessionId
+      ? `${peerLabel} · ${peerTarget.sessionId.slice(0, 8)}`
+      : peerLabel;
+    chip.replaceChildren(label, badge);
+    const reconnecting = entry && entry.connected === false;
+    const title = peerTarget.sessionId
+      ? `Sends a follow-up to session ${peerTarget.sessionId} on ${peerLabel} through this daemon's peer grant${reconnecting ? ' — peer link is down, reconnecting' : ''}`
+      : `Delegates the task to ${peerLabel} through this daemon's peer grant${reconnecting ? ' — peer link is down, reconnecting' : ''}`;
+    chip.title = title;
+    chip.setAttribute('aria-label', title);
+    chip.classList.toggle('target-reconnecting', Boolean(reconnecting));
+    return;
+  }
+  const chip0 = document.getElementById('task-target-chip');
+  if (chip0) chip0.classList.remove('target-reconnecting');
   const sid = resolvePromptTargetSessionId();
   const previousTarget = taskTargetChipRenderedTarget;
   taskTargetChipRenderedTarget = sid;
@@ -6284,7 +6355,7 @@ function closeSessionRenameModal() {
   showSessionRenameStatus('');
 }
 
-function requestSessionRename(sessionOrId, sourceArg = '') {
+function requestSessionRename(sessionOrId, sourceArg = '', opts = {}) {
   const session = typeof sessionOrId === 'object'
     ? sessionOrId
     : { session_id: sessionOrId, source: sourceArg };
@@ -6293,6 +6364,10 @@ function requestSessionRename(sessionOrId, sourceArg = '') {
     showControlToast('error', 'Rename session failed: session ID is missing');
     return false;
   }
+  // Host-scoped rename (RC-C1): when the card belongs to a peer host,
+  // the save dispatch routes through api_peer_session_control instead
+  // of the local lane.
+  const renameHostId = String(opts.hostId || '').trim();
   const source = String(sourceArg || session.source || 'intendant').trim();
   const cached = sessionMetadataById.get(sid) || {};
   const backendSessionId = String(
@@ -6313,6 +6388,7 @@ function requestSessionRename(sessionOrId, sourceArg = '') {
     sessionId: sid,
     source: effectiveSource,
     backendSessionId,
+    hostId: renameHostId,
   };
   const sessionInput = document.getElementById('session-rename-session');
   if (sessionInput) {
@@ -6344,13 +6420,36 @@ function saveSessionRenameModal() {
     return;
   }
   showSessionRenameStatus('Saving...');
-  dispatchControlMsg({
+  const message = {
     action: 'rename_session',
     session_id: sessionRenameEditing.sessionId,
     source: sessionRenameEditing.source,
     ...(sessionRenameEditing.backendSessionId ? { backend_session_id: sessionRenameEditing.backendSessionId } : {}),
     name,
-  });
+  };
+  if (sessionRenameEditing.hostId) {
+    // Peer-hosted session: the rename is authorized and applied by the
+    // peer; its result reaches us as a folded session_updated (no local
+    // rename-result echo), so close optimistically on accept.
+    const hostId = sessionRenameEditing.hostId;
+    daemonApi
+      .request('api_peer_session_control', { peer_id: hostId, message })
+      .then(resp => {
+        if (resp.ok) {
+          closeSessionRenameModal();
+          showControlToast('info', 'Rename sent — the peer applies it.');
+          if (typeof loadSessions === 'function') loadSessions({ force: true });
+        } else {
+          const detail = resp.body && resp.body.error ? ` — ${resp.body.error}` : '';
+          showSessionRenameStatus(`Peer refused (${resp.status})${detail}`, 'error');
+        }
+      })
+      .catch(err => {
+        showSessionRenameStatus(`Could not reach the peer: ${err?.message || err}`, 'error');
+      });
+    return;
+  }
+  dispatchControlMsg(message);
 }
 
 // Index over _cachedSessions for O(1) any-id lookups. Every mutation site

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -1298,6 +1298,9 @@ function focusSessionWindow(sessionId) {
   if (!sid) return;
   const win = ensureSessionWindow(sid);
   if (!win) return;
+  // One composer, one target: focusing a local session retargets the
+  // composer locally, dropping any peer target.
+  if (typeof clearPromptTargetPeer === 'function') clearPromptTargetPeer({ skipChip: true });
   foregroundSessionFullId = sid;
   currentSessionFullId = sid;
   if (app && typeof app.select_session === 'function') {

--- a/static/app/42b-access-model.js
+++ b/static/app/42b-access-model.js
@@ -708,6 +708,11 @@ function dashboardAccessTargetFromPeerSnapshot(snap) {
     ws_url: snap.ws_url || '',
     browser_tcp_via_url: snap.browser_tcp_via_url || '',
     capabilities: snap.capabilities || [],
+    // Field-for-field parity with the server row (routes_access.rs):
+    // the connected candidate's {url, transport_class} and the
+    // peer-advertised {profile, operations} grant.
+    link: snap.link || null,
+    grant: snap.grant || null,
   };
 }
 
@@ -1031,7 +1036,12 @@ function dashboardLaneBadge(hostId) {
   }
   const conn = peerDashboardControlConnectionsByHost.get(String(hostId || '').trim());
   const status = conn?.lastStatus || {};
-  const profile = String(status.grant_profile || target.profile || '').trim() || 'peer';
+  const advertisedProfile =
+    typeof peerEntryForHost === 'function'
+      ? (peerEntryForHost(hostId)?.grant?.profile || '')
+      : '';
+  const profile =
+    String(status.grant_profile || advertisedProfile || target.profile || '').trim() || 'peer';
   const viaLabel = String(selfHostLabel || 'this daemon').trim();
   const attributed = Boolean(status.attributed_fingerprint);
   const record = accessFleetTargets().find(t =>
@@ -1085,7 +1095,15 @@ function dashboardTargetSummary(hostId, context = '') {
   const online = peer.connected !== false;
   const conn = peerDashboardControlConnectionsByHost.get(peerId);
   const status = conn?.lastStatus || {};
-  const profile = status.grant_profile || '';
+  // The federation-link grant echo (PeerSnapshot.grant) names the
+  // profile before any browser↔peer datachannel exists — prefer the
+  // datachannel's own status once it opens (it reflects the exact
+  // grant that tunnel authorizes under).
+  const advertisedProfile =
+    typeof peerEntryForHost === 'function'
+      ? (peerEntryForHost(peerId)?.grant?.profile || '')
+      : '';
+  const profile = status.grant_profile || advertisedProfile || '';
   const grantKind = status.grant_kind || '';
   const hasExactGrant = Boolean(profile || grantKind);
   const access = hasExactGrant

--- a/static/app/43-access-panes.js
+++ b/static/app/43-access-panes.js
@@ -2718,4 +2718,10 @@ function setShellHost(hostId) {
   if (activeTab === 'terminal' && activeTermSubtab === 'shell') {
     openShellSessionIfPossible(true);
   }
+  // Publish into the global operating target. Daemon targets move the
+  // whole dashboard; the Shell's cloud exec hosts are pane-local (the
+  // setter refuses non-daemon ids) and leave the global untouched.
+  if (typeof setGlobalTargetHost === 'function') {
+    setGlobalTargetHost(next === SHELL_HOST_ID ? '' : next, { source: 'shell' });
+  }
 }

--- a/static/app/50-control-transport.js
+++ b/static/app/50-control-transport.js
@@ -1483,6 +1483,10 @@ function peerDashboardControlSignalAvailable(peerId) {
   if (!window.RTCPeerConnection) return false;
   const peer = daemons.find(d => d.host_id === id);
   if (!peer || peer.connected === false) return false;
+  // A relay-transiting federation link carries signaling but nothing
+  // ICE-borne: the browser↔peer datachannel cannot form without a
+  // direct route or provisioned TURN, so don't offer it.
+  if (!peerLinkSupportsMedia(id)) return false;
   if (dashboardConnectModeEnabled()) {
     return Boolean(
       dashboardTransport?.canUseRpc?.() &&
@@ -2617,6 +2621,14 @@ function snapshotToDaemonEntry(p) {
     // live peer_display_ready/removed events produced this list, so
     // wholesale row replacement never loses display state.
     displays: Array.isArray(p.displays) ? p.displays : [],
+    // Reachability honesty (RC-C1): the connected transport candidate
+    // ({url, transport_class: 'direct'|'relayed'}, null while
+    // disconnected) and the grant the peer advertised for this
+    // daemon's identity ({profile, operations}, null = unknown).
+    // Media/datachannel affordances derive from link.transport_class;
+    // action pills derive from grant.operations.
+    link: p.link || null,
+    grant: p.grant || null,
   };
 }
 
@@ -2722,6 +2734,18 @@ function updateDaemonSnapshot(snap) {
 // Drop a peer from the local daemons list and tear down its WASM
 // secondary connection. Tolerates unknown ids (a `peer_removed` may
 // arrive after `refreshPeersFromApi` has already pruned the entry).
+function removeDaemonByIdResetGlobalTarget(id) {
+  // A removed peer cannot stay the operating target — snap the whole
+  // dashboard back to the local daemon (a mere disconnect keeps the
+  // selection: the row persists and panes render the reconnect state).
+  if (
+    typeof currentGlobalTargetHostId === 'function' &&
+    currentGlobalTargetHostId() === String(id || '')
+  ) {
+    setGlobalTargetHost('', { source: 'peer-removed' });
+  }
+}
+
 function removeDaemonById(id) {
   if (!id) return;
   const idx = daemons.findIndex(d => d.host_id === id);
@@ -2740,6 +2764,7 @@ function removeDaemonById(id) {
   // RTCPeerConnection has nowhere to send signaling, and leaving it
   // alive would just stall on ICE failure.
   closePeerDisplaysForHost(id).catch(() => {});
+  removeDaemonByIdResetGlobalTarget(id);
   renderDaemonsList();
 }
 
@@ -3082,8 +3107,14 @@ function renderDaemonRow(d, isSelf) {
   // 3b's primary-as-media-relay takes over when no non-loopback path
   // is known — same contract the peer-side loopback warn describes.
   const tcpViaUrl = resolveBrowserTcpViaUrl(d);
+  // Render the display affordance from the live link's transport
+  // class, never from the peer row existing: a relay-only link cannot
+  // carry WebRTC media, so the pill would be dead — say so instead.
+  const linkSupportsMedia = peerLinkSupportsMedia(d.host_id);
   const viewDisplayBtn = !isSelf && peerCanShareDisplay(d)
-    ? `<button class="daemon-display-view" data-host-id="${escapeHtml(d.host_id)}" data-display-id="0" data-tcp-via-url="${escapeHtml(tcpViaUrl)}" title="Open this peer's display via WebRTC (browser↔peer direct, primary signals only)">View display</button>`
+    ? (linkSupportsMedia
+      ? `<button class="daemon-display-view" data-host-id="${escapeHtml(d.host_id)}" data-display-id="0" data-tcp-via-url="${escapeHtml(tcpViaUrl)}" title="Open this peer's display via WebRTC (browser↔peer direct, primary signals only)">View display</button>`
+      : `<span class="daemon-relay-note" title="This peer is reachable over the relay link only. Live video and file transfer need a direct route or TURN; messages, tasks, approvals, and session actions still work.">relay link — no live media</span>`)
     : '';
   const controlsPanel = isSelf
     ? ''

--- a/static/app/53-stats-settings.js
+++ b/static/app/53-stats-settings.js
@@ -112,6 +112,9 @@ function refreshStatsHostPicker() {
 function switchStatsHost(hostId) {
   activeStatsHost = hostId || '';
   renderStatsForActiveHost();
+  if (typeof setGlobalTargetHost === 'function') {
+    setGlobalTargetHost(activeStatsHost, { source: 'stats' });
+  }
 }
 
 // Render the Stats tab from whichever host is currently active,
@@ -874,6 +877,33 @@ document.getElementById('settings-save-keys').addEventListener('click', saveApiK
 // 31-init-identity-fleet.js with the early state: a #stats deep link
 // reaches them during script evaluation — the deep-link TDZ rule.)
 
+// The federation fold (PeerSnapshot.sessions, SessionInfo shape) mapped
+// into the session-list row vocabulary the Sessions tab renders. Used
+// when a peer is reachable over the control link only (relay-only, or
+// no browser-dialable URL): the list stays live via peer_state_changed
+// snapshots even though the peer's own /api/sessions is unreachable.
+function peerFoldSessionRows(entry) {
+  const sessions = Array.isArray(entry.sessions) ? entry.sessions : [];
+  return sessions.map(s => ({
+    session_id: s.session_id,
+    name: s.label || '',
+    source: s.source || 'intendant',
+    started_at: s.started_at || '',
+    phase: s.phase || '',
+    needs_approval: !!s.needs_approval,
+    is_primary: !!s.is_primary,
+    parent_session_id: s.parent_session_id || null,
+    tokens_used: s.tokens_used ?? null,
+    goal: s.goal || null,
+    vitals: s.vitals || null,
+    // The fold carries no per-session store facts; resume rides the
+    // peer's own resume-id defaulting (resume_id = session_id), local
+    // delete/report affordances stay off.
+    can_resume: true,
+    can_delete: false,
+  }));
+}
+
 function fetchSessionsForHost(hostId, options = {}) {
   hostId = hostId || selfPeerId;
   const cacheSessionMetadata = options.cacheSessionMetadata !== false;
@@ -935,6 +965,15 @@ function fetchSessionsForHost(hostId, options = {}) {
         if (dashboardConnectModeEnabled()) throw err;
         console.warn('[peer-dashboard-control] api_sessions RPC failed, falling back to direct peer HTTP', err);
       }
+    }
+    // Relay-only or otherwise browser-unreachable peers (RC-C1): no
+    // datachannel and no HTTP the browser can dial. Render the
+    // federation fold (PeerSnapshot.sessions, riding the control WS)
+    // instead of failing — thinner than the peer's own /api/sessions
+    // rows, honestly so.
+    const entry = daemons.find(x => x.host_id === hostId);
+    if (entry && (!peerLinkSupportsMedia(hostId) || !baseUrl)) {
+      return peerFoldSessionRows(entry);
     }
     if (dashboardConnectModeEnabled()) {
       throw new Error('Peer sessions are unavailable for this target');

--- a/static/app/54-session-lifecycle.js
+++ b/static/app/54-session-lifecycle.js
@@ -747,10 +747,60 @@ function autoAttachUnmanagedFollowUp(evt = {}) {
 // artifact — all agents (native, Codex, Claude Code, Kimi Code, Pi) treat
 // subsequent messages as new turns in the existing conversation.
 // Shared by the Activity composer and the Station composer.
+// Composer routing for a peer target (RC-C1): a bare peer target
+// delegates the text as a task (`api_peer_task`); a peer session
+// target sends it as a follow-up scoped to that session
+// (`api_peer_session_control` → the federation link → the peer's own
+// per-action authorization). Both spend this daemon's peer grant.
+// Attachments stay local-only: frame ids resolve against this
+// daemon's stores, so they are refused up front instead of silently
+// dropped on the peer.
+function dispatchPeerTaskText(peerTarget, text) {
+  const entry = peerEntryForHost(peerTarget.hostId);
+  const label = (entry && (entry.label || entry.host_id)) || peerTarget.hostId;
+  if (!entry || entry.connected === false) {
+    showControlToast('error', `${label} is not connected — the peer link is reconnecting; try again shortly.`);
+    return false;
+  }
+  if (pendingAttachments.length > 0) {
+    showControlToast('error', 'Attachments cannot ride a peer target yet — remove them or target a local session.');
+    return false;
+  }
+  const done = (resp, verb) => {
+    if (resp.ok) {
+      showControlToast('info', `${verb} ${label}.`);
+    } else {
+      const detail = resp.body && resp.body.error ? ` — ${resp.body.error}` : '';
+      showControlToast('error', `${label} refused (${resp.status})${detail}`);
+    }
+  };
+  const fail = (err) => {
+    showControlToast('error', `Could not reach ${label}: ${err && err.message ? err.message : err}`);
+  };
+  if (peerTarget.sessionId) {
+    daemonApi
+      .request('api_peer_session_control', {
+        peer_id: peerTarget.hostId,
+        message: { action: 'follow_up', text, session_id: peerTarget.sessionId },
+      })
+      .then(resp => done(resp, `Follow-up sent to ${peerTarget.sessionId.slice(0, 8)} on`))
+      .catch(fail);
+  } else {
+    daemonApi
+      .request('api_peer_task', { peer_id: peerTarget.hostId, instructions: text })
+      .then(resp => done(resp, 'Task delegated to'))
+      .catch(fail);
+  }
+  return true;
+}
+
 function dispatchTaskText(text, options = {}) {
   if (!app) return false;
   text = String(text || '').trim();
   if (!text) return false;
+  const peerTarget =
+    typeof currentPromptTargetPeer === 'function' ? currentPromptTargetPeer() : null;
+  if (peerTarget) return dispatchPeerTaskText(peerTarget, text);
   const attachments = pendingAttachments.map(a => a.frameId);
   const attachmentReceipt = pendingAttachments.slice();
   const direct = document.getElementById('direct-mode-toggle')?.checked || false;
@@ -803,6 +853,13 @@ function submitComposedText(text) {
   if (!app) return false;
   text = String(text || '').trim();
   if (!text) return false;
+  const composerPeerTarget =
+    typeof currentPromptTargetPeer === 'function' ? currentPromptTargetPeer() : null;
+  if (composerPeerTarget) {
+    // Peer targets never steer or slash locally — the text goes to the
+    // peer daemon as a delegation or session follow-up.
+    return dispatchPeerTaskText(composerPeerTarget, text);
+  }
   const codexSlash = parseCodexSlashCommand(text);
   if (codexSlash) {
     return !!dispatchCodexSlashCommand(codexSlash);

--- a/static/app/54b-transfers.js
+++ b/static/app/54b-transfers.js
@@ -45,6 +45,9 @@ function peerFileTransferSignalAvailable(peerId = filesDownloadSelectedPeerId())
   if (!window.RTCPeerConnection) return false;
   const peer = daemons.find(d => d.host_id === id);
   if (!peer || peer.connected === false) return false;
+  // File-transfer bytes ride a browser↔peer datachannel — nothing
+  // ICE-borne survives a relay-only link (RC-C1 honesty rail).
+  if (!peerLinkSupportsMedia(id)) return false;
   if (dashboardConnectModeEnabled()) {
     return Boolean(
       dashboardTransport?.canUseRpc?.() &&
@@ -83,6 +86,9 @@ function refreshFilesDownloadHostOptions() {
 function onFilesDownloadHostChanged(options = {}) {
   const browse = document.getElementById('files-download-browse-btn');
   const selectedPeer = filesDownloadSelectedPeerId();
+  if (typeof setGlobalTargetHost === 'function') {
+    setGlobalTargetHost(selectedPeer, { source: 'files-download' });
+  }
   if (browse) {
     // Peer browsing rides the fs-picker's api_fs_list target lane (55);
     // gate on reachability, not on peer-ness.

--- a/static/app/55-files-ide.js
+++ b/static/app/55-files-ide.js
@@ -1403,6 +1403,9 @@ function refreshFilesIdeHostOptions() {
 
 function onFilesIdeHostChanged() {
   const hostId = filesIdeSelectedHostId();
+  if (typeof setGlobalTargetHost === 'function') {
+    setGlobalTargetHost(hostId, { source: 'files-ide' });
+  }
   renderDashboardTargetSummary('files-ide-target-summary', hostId, 'files');
   const state = filesIdeTreeState(hostId);
   const hiddenBtn = document.getElementById('files-ide-hidden-btn');

--- a/static/app/56-debug-sessions.js
+++ b/static/app/56-debug-sessions.js
@@ -462,6 +462,9 @@ function setSessionsHost(hostId) {
   // Message lane (flagged): the tunnel twin serves the selected peer's own
   // index, so a host switch re-keys the search. No-op with the flag off.
   scheduleSessionMessageSearch();
+  if (typeof setGlobalTargetHost === 'function') {
+    setGlobalTargetHost(next, { source: 'sessions' });
+  }
 }
 
 // Whole-card action while browsing a peer: hand off to the peer's own

--- a/static/app/57a-sessions-list.js
+++ b/static/app/57a-sessions-list.js
@@ -1029,6 +1029,87 @@ function buildSessionCard(m, derived, ctx) {
     card.appendChild(actions);
   }
 
+  // Peer host cards (RC-C1): host-scoped session actions through
+  // api_peer_session_control — the peer authorizes each against the
+  // profile it granted this daemon. Pills derive from the advertised
+  // grant (peerAllowsOperation): a known-denied operation renders no
+  // pill; an unknown grant renders pills that act and report honestly.
+  if (ctx.viewingPeer && sessionId) {
+    const peerHostId = typeof currentSessionsHostId === 'function' ? currentSessionsHostId() : '';
+    const peerEntry = typeof peerEntryForHost === 'function' ? peerEntryForHost(peerHostId) : null;
+    if (peerEntry) {
+      const actions = document.createElement('div');
+      actions.className = 'sc-actions';
+      const linkDown = peerEntry.connected === false;
+      const peerName = peerEntry.label || peerEntry.host_id;
+      const addPill = (label, title, opId, onClick, cls) => {
+        if (!peerAllowsOperation(peerHostId, opId)) return;
+        const btn = document.createElement('button');
+        btn.className = cls || 'ui-btn';
+        btn.textContent = label;
+        btn.title = linkDown
+          ? `${title} — unavailable while the peer link reconnects`
+          : title;
+        btn.disabled = linkDown;
+        btn.addEventListener('click', (e) => {
+          e.stopPropagation();
+          onClick();
+        });
+        actions.appendChild(btn);
+      };
+      if (s.can_resume !== false) {
+        addPill(
+          'Resume on peer',
+          `Resume this session on ${peerName} (runs there under this daemon's peer grant)`,
+          'task.run',
+          () => {
+            const source = normalizeAgentId(s.backend_source || s.source || '') || 'intendant';
+            daemonApi
+              .request('api_peer_session_control', {
+                peer_id: peerHostId,
+                message: {
+                  action: 'resume_session',
+                  source,
+                  session_id: String(s.session_id),
+                  resume_id: String(s.backend_session_id || s.resume_id || s.session_id),
+                  project_root: s.project_root || null,
+                  direct: true,
+                },
+              })
+              .then(resp => {
+                if (resp.ok) showControlToast('info', `Resume sent to ${peerName}.`);
+                else {
+                  const detail = resp.body && resp.body.error ? ` — ${resp.body.error}` : '';
+                  showControlToast('error', `${peerName} refused resume (${resp.status})${detail}`);
+                }
+              })
+              .catch(err => showControlToast('error', `Could not reach ${peerName}: ${err?.message || err}`));
+          },
+          'ui-btn sc-resume-btn',
+        );
+      }
+      addPill(
+        'Message',
+        `Target the composer at this session on ${peerName}`,
+        'message.send',
+        () => {
+          if (setPromptTargetPeer(peerHostId, String(s.session_id))) {
+            routeTo('activity');
+            document.getElementById('activity-task-input')?.focus();
+          }
+        },
+      );
+      addPill(
+        'Rename',
+        `Rename this session on ${peerName}`,
+        'session.manage',
+        () => requestSessionRename(s, s.source || '', { hostId: peerHostId }),
+        'ui-btn sc-rename-btn',
+      );
+      if (actions.children.length) card.appendChild(actions);
+    }
+  }
+
   if (ctx.viewingPeer) {
     card.classList.add('sc-peer');
     card.title = 'Open this session on the peer’s dashboard';

--- a/static/app/58-shortcuts-boot.js
+++ b/static/app/58-shortcuts-boot.js
@@ -727,6 +727,41 @@ document.getElementById('stats-host-select').addEventListener('change', (e) => {
   switchStatsHost(e.target.value);
 });
 
+// Global operating target (RC-C1): the pane pickers publish into one
+// selection; this listener makes the others follow. Every pane setter
+// is equality-guarded and republishing the same value is a no-op, so
+// the publish→follow→publish cycle terminates immediately.
+document.addEventListener('ui2:target-changed', (e) => {
+  const hostId = String(e?.detail?.hostId || '');
+  // Shell (its local sentinel is SHELL_HOST_ID, not '').
+  if (typeof setShellHost === 'function') {
+    setShellHost(hostId || SHELL_HOST_ID);
+  }
+  // Files IDE + Transfers selects hold their own value; refresh the
+  // options first when the target isn't listed yet (a peer added since
+  // the last rebuild).
+  const followSelect = (selectId, refresh, onChanged) => {
+    const sel = document.getElementById(selectId);
+    if (!sel) return;
+    if (sel.value === hostId) return;
+    if (![...sel.options].some(o => o.value === hostId)) refresh();
+    if (sel.value !== hostId) {
+      sel.value = hostId;
+      onChanged();
+    }
+  };
+  followSelect('files-ide-host', refreshFilesIdeHostOptions, onFilesIdeHostChanged);
+  followSelect('files-download-host', refreshFilesDownloadHostOptions, onFilesDownloadHostChanged);
+  if (typeof setSessionsHost === 'function') setSessionsHost(hostId);
+  if (typeof switchStatsHost === 'function' && activeStatsHost !== hostId) {
+    const statsSel = document.getElementById('stats-host-select');
+    if (statsSel && [...statsSel.options].some(o => o.value === hostId)) {
+      statsSel.value = hostId;
+    }
+    switchStatsHost(hostId);
+  }
+});
+
 document.getElementById('access-link-daemon-btn')?.addEventListener('click', () => routeTo('access', 'peers'));
 
 // Join-with-an-org-grant: present the pasted document to this daemon. The

--- a/static/app/ui2-target-switch.css
+++ b/static/app/ui2-target-switch.css
@@ -224,6 +224,51 @@ html.ui-v2 .ui2-tsw-foot {
 html.ui-v2 .ui2-tsw-foot .ui2-tsw-row { color: var(--text-3); }
 html.ui-v2 .ui2-tsw-foot .ui2-tsw-row:hover { color: var(--text); }
 
+/* peers section (RC-C1): violet is the peer accent everywhere in the
+   chrome (files/access convention) — the rows read as "another
+   machine" at a glance */
+html.ui-v2 .ui2-tsw-peers-eyebrow {
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid var(--line);
+}
+html.ui-v2 .ui2-tsw-peer-badge {
+  color: var(--violet);
+  border: 1px solid rgba(var(--violet-rgb), .26);
+  background: rgba(var(--violet-rgb), .12);
+  border-radius: var(--r-pill);
+  padding: 1px 8px;
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 160px;
+}
+html.ui-v2 .ui2-tsw-peer-session { padding-left: 22px; }
+
+/* composer chip while a peer target is set — same violet voice */
+html.ui-v2 .task-target-peer-badge {
+  color: var(--violet);
+  border-color: rgba(var(--violet-rgb), .26);
+  background: rgba(var(--violet-rgb), .12);
+}
+html.ui-v2 .task-target-chip.target-reconnecting .task-target-peer-badge {
+  color: var(--amber);
+  border-color: rgba(var(--amber-rgb), .26);
+  background: rgba(var(--amber-rgb), .12);
+}
+
+/* Access → Daemons: honest stand-in where "View display" would be a
+   dead pill on a relay-only link */
+html.ui-v2 .daemon-relay-note {
+  color: var(--text-3);
+  font-size: 11px;
+  padding: 2px 6px;
+  border: 1px dashed var(--line-2);
+  border-radius: var(--r-pill);
+  white-space: nowrap;
+}
+
 /* touch targets (brief: rows ≥44px at ≤820px); 16px input font keeps
    iOS Safari from zooming the page on focus */
 @media (max-width: 820px) {

--- a/static/app/ui2-target-switch.js
+++ b/static/app/ui2-target-switch.js
@@ -31,6 +31,27 @@
     return ids;
   }
 
+  const PEER_SESSION_ROWS = 6; // newest-first cap per peer (fold order)
+
+  // Connected peers are composer targets too (RC-C1): the peer row
+  // delegates a new task; a peer session row scopes a follow-up to
+  // that session. Both spend this daemon's peer grant on the target.
+  function targetablePeers() {
+    if (typeof daemons === 'undefined' || !Array.isArray(daemons)) return [];
+    return daemons.filter(d => d && d.host_id && d.connected !== false);
+  }
+
+  function peerSessionRowsFor(d) {
+    const sessions = Array.isArray(d.sessions) ? d.sessions : [];
+    return sessions.slice(0, PEER_SESSION_ROWS);
+  }
+
+  function activePeerKey() {
+    const t = typeof currentPromptTargetPeer === 'function' ? currentPromptTargetPeer() : null;
+    if (!t) return '';
+    return t.sessionId ? `ps:${t.hostId} ${t.sessionId}` : `p:${t.hostId}`;
+  }
+
   function rowPhase(sid) {
     if (hasPendingActiveSessionWindow(sid)) return 'active';
     const win = sessionWindows.get(sid);
@@ -44,10 +65,17 @@
     const parts = [
       resolvePromptTargetSessionId(),
       explicitForegroundSessionId() ? 'E' : 'A',
+      activePeerKey(),
       filterQuery,
     ];
     for (const sid of usableSessionIds()) {
       parts.push(sid, sessionIdentityParts(sid).name, rowPhase(sid));
+    }
+    for (const d of targetablePeers()) {
+      parts.push(d.host_id, d.label || '', d.connected === false ? 'off' : 'on');
+      for (const s of peerSessionRowsFor(d)) {
+        parts.push(s.session_id, s.label || '', s.phase || '');
+      }
     }
     return parts.join('\u0000');
   }
@@ -112,6 +140,44 @@
     return el;
   }
 
+  function buildPeerRow(d, activeKey) {
+    const key = `p:${d.host_id}`;
+    const row = makeRow(key, 'ui2-tsw-peer');
+    const label = d.label || d.host_id;
+    const badge = document.createElement('span');
+    badge.className = 'ui2-tsw-badge ui2-tsw-peer-badge';
+    badge.textContent = label;
+    const sub = document.createElement('span');
+    sub.className = 'ui2-tsw-row-sub';
+    sub.textContent = 'delegates a task';
+    row.append(badge, sub);
+    row.title = `Delegate the composed task to ${label} (runs there under this daemon's peer grant)`;
+    row.setAttribute('aria-label', `Peer ${label}: delegate a task`);
+    if (key === activeKey) row.setAttribute('aria-selected', 'true');
+    return row;
+  }
+
+  function buildPeerSessionRow(d, s, activeKey) {
+    const key = `ps:${d.host_id} ${s.session_id}`;
+    const row = makeRow(key, 'ui2-tsw-peer-session');
+    const label = d.label || d.host_id;
+    const name = s.label || s.session_id.slice(0, 8);
+    const nameEl = document.createElement('span');
+    nameEl.className = 'ui2-tsw-row-name';
+    nameEl.textContent = name;
+    const phase = (s.phase === 'working' || s.phase === 'thinking')
+      ? 'active'
+      : (s.needs_approval || s.phase === 'waiting_approval') ? 'waiting' : 'done';
+    const dot = document.createElement('span');
+    dot.className = `ui2-tsw-dot ${phase}`;
+    dot.setAttribute('aria-hidden', 'true');
+    row.append(nameEl, dot);
+    row.title = `Send the composed text as a follow-up to session ${s.session_id} on ${label}`;
+    row.setAttribute('aria-label', `Session ${name} on peer ${label}: send a follow-up`);
+    if (key === activeKey) row.setAttribute('aria-selected', 'true');
+    return row;
+  }
+
   function renderRows() {
     const usable = usableSessionIds();
     const target = resolvePromptTargetSessionId();
@@ -143,7 +209,34 @@
     if (usable.length) children.push(buildAutoRow(autoActive));
     for (const sid of list) children.push(buildSessionRow(sid, target));
     if (!usable.length) children.push(buildEmpty('No targetable sessions'));
-    else if (!list.length) children.push(buildEmpty('No matches'));
+    else if (!list.length && !q) children.push(buildEmpty('No matches'));
+
+    // Peers section: connected peer daemons and their known sessions.
+    const activeKey = activePeerKey();
+    const peers = targetablePeers();
+    let peerRows = [];
+    for (const d of peers) {
+      const label = d.label || d.host_id;
+      const peerMatches = !q || ui2FuzzyScore(q, label) >= 0 || ui2FuzzyScore(q, d.host_id) >= 0;
+      if (peerMatches) peerRows.push(buildPeerRow(d, activeKey));
+      for (const s of peerSessionRowsFor(d)) {
+        const sessionMatches = !q
+          || peerMatches
+          || ui2FuzzyScore(q, s.label || '') >= 0
+          || ui2FuzzyScore(q, s.session_id) >= 0;
+        if (sessionMatches) peerRows.push(buildPeerSessionRow(d, s, activeKey));
+      }
+    }
+    if (peerRows.length) {
+      const divider = document.createElement('div');
+      divider.className = 'ui2-tsw-eyebrow ui2-tsw-peers-eyebrow';
+      divider.textContent = 'Peers';
+      divider.setAttribute('aria-hidden', 'true');
+      children.push(divider, ...peerRows);
+    }
+    if (usable.length && !list.length && !peerRows.length && q) {
+      children.push(buildEmpty('No matches'));
+    }
     rowsEl.replaceChildren(...children);
     lastSig = currentSignature();
 
@@ -203,6 +296,7 @@
       // The explicit pick lives in two refs (foreground + current), possibly
       // holding different ids — discard until the explicit lane is empty so
       // the resolver takes over.
+      clearPromptTargetPeer({ skipChip: true });
       for (let i = 0; i < 4 && explicitForegroundSessionId(); i++) {
         discardPromptTargetReference(explicitForegroundSessionId());
       }
@@ -211,6 +305,7 @@
     } else if (key === 'new') {
       // Close without refocus: openNewSessionFromPrompt focuses the
       // new-session input on the next frame and must win.
+      clearPromptTargetPeer();
       openNewSessionFromPrompt();
       closePopover();
     } else if (key.startsWith('s:')) {
@@ -219,8 +314,22 @@
         renderRows();
         return;
       }
-      focusSessionWindow(sid);
+      focusSessionWindow(sid); // clears any peer target (one composer, one target)
       closePopover({ refocus: true });
+    } else if (key.startsWith('ps:')) {
+      const rest = key.slice(3);
+      const sep = rest.indexOf(' ');
+      if (sep > 0 && setPromptTargetPeer(rest.slice(0, sep), rest.slice(sep + 1))) {
+        closePopover({ refocus: true });
+      } else {
+        renderRows();
+      }
+    } else if (key.startsWith('p:')) {
+      if (setPromptTargetPeer(key.slice(2), null)) {
+        closePopover({ refocus: true });
+      } else {
+        renderRows();
+      }
     }
   }
 


### PR DESCRIPTION
Track RC Stage C, seat C1 (commission card 01KYVKK05RKY0YH6YBM6W340F0). One dashboard operates direct and relayed peers through the same peer-profile authority. Two layer-split commits: backend, then dashboard.

**Backend**
- `PeerOp::SessionControl` — host-scoped session lifecycle actions (interrupt, resume, rename, stop/restart, follow-up, approvals) forwarded over the federation control WS as the `ControlMsg` the target already gates per-action against the granted peer profile. Rides the control link, so it works identically for direct and (post-B) relayed peers — never the browser datachannel.
- Derived allowlist: session RPC lane ∩ {Message, Task, Approval, SessionManage} operation classes. Agenda, Memory, Vault/custody, Access/IAM, and Settings stay doctrine-closed to peer routing — enforced by the classifier, pinned by test.
- `POST /api/peers/{peer_id}/session-control` + `api_peer_session_control` tunnel twin (dialer-side IAM `peer.use` via the federation ladder; catalogs derived from the route row).
- `peer_grant` bootstrap echo on peer-identified `/ws` connects: granted profile + operation ids derived from `profile_allows_operation` over the frozen op set → `PeerSnapshot.grant`, so affordances render honestly (unknown = act-and-report, never denial).
- `PeerSnapshot.link` — the connected candidate's `{url, transport_class: direct|relayed}` (RC-B0 OPEN-6), recorded post-connect, cleared on disconnect. The RC-B2 relay candidate classifies `relayed`.
- Fix: `PeerMessage.session` was silently dropped (every peer message went to the primary session).

**Dashboard**
- Global operating target: one selection behind the Shell/Files/Transfers/Sessions/Stats host pickers (publish + follow; shell's cloud exec hosts stay pane-local; removal snaps back to local, disconnect keeps the selection with reconnect states).
- Composer target switch grows a Peers section: peer row = delegate the composed task; peer session row = session-scoped follow-up. Chip renders in the peer voice with honest reconnect state; attachments refuse peer targets instead of silently dropping.
- Peer session cards: grant-derived pills (Resume on peer / Message / Rename); Station peer nodes: interrupt + composer targeting routed by host. Known-denied operations render no pill; unknown grants act and report.
- Reachability honesty: display view, dashboard-control tunnel, and file-transfer affordances derive from `link.transport_class`; relay-only links get an honest note; the Sessions tab renders the federation fold when the peer has no browser-reachable lane.

**Tests**: closed-planes allowlist pins, grant-derivation goldens, transport writes verbatim + session-scoped FollowUp regression, actor fold/clear, snapshot back-compat, route/tunnel/docs/partition/parity pins extended.
**Docs**: peer-federation (session-control + honesty rails, replaces the stale no-action-pills paragraph), web-dashboard (endpoint table + target-model section).

Binding refs: Track RC kickoff (Stage C + doctrine riders), convergence findings §3, accepted RC-B0 ruling §6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)