### PR TITLE
agenda graph: remove the node cap — sprite glow + strided repulsion LOD

### DIFF
--- a/static/app.html
+++ b/static/app.html
@@ -24682,19 +24682,6 @@ html.ui-v2 .ag2-graph-panel.fullscreen canvas {
   height: 100vh;
   height: 100dvh;
 }
-html.ui-v2 .ag2-graph-capnote {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-family: var(--mono);
-  font-size: 11px;
-  color: var(--text-3);
-  pointer-events: none;
-  padding: 0 40px;
-  text-align: center;
-}
 
 /* ---- Upcoming lens (slice C): the 14-day day-grouped timeline. Rows
    ride the shared .ag2-chip family; dots pulse via the shared ui2-pulse
@@ -38039,7 +38026,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '75077ff6c32a322c';
+const INTENDANT_APP_BUILD = 'cdc496035a30adca';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -99118,13 +99105,14 @@ function agendaBellRender() {
 // module-level visibilitychange listener below is the stop/resume
 // conduit itself and must outlive any one activation to resume it.
 
-// Owner-raised 2026-07-31 (from the original 180): the O(n²) cost only
-// bites during the brief settle window and the per-frame budget tiers
-// keep that window's frame work roughly constant as n grows, so the
-// honest bound is legibility — and legibility is what the hubs/focus
-// projections and arrangement modes are for. Past THIS cap the settle
-// window itself stops fitting a frame budget worth defending.
-const AGENDA_GRAPH_NODE_CAP = 420;
+// NO node cap (owner-ruled 2026-07-31, after 180 and then 420 both got
+// hit within a day): density is a feature, and every projection always
+// renders. Cost stays flat through level of detail instead of refusal —
+// node glow comes from pre-baked sprites (drawImage, ~two orders
+// cheaper than per-arc shadowBlur), and past REPULSION_LOD nodes the
+// settle pass strides its O(n²) pair loop with a rotating offset
+// (approximate physics, same look, same 260-iteration budget).
+const AGENDA_GRAPH_REPULSION_LOD = 600;
 // Design-parity settle budget, amortized: the prototype ran 260
 // synchronous O(n²) relaxation iterations per relayout; here the same
 // total is spread over frames (agendaGraphSettleBudget per rAF) so a
@@ -99151,7 +99139,7 @@ let agendaGraphCam = { yaw: 0.6, pitch: -0.34, auto: true };
 // overlays derived file/dir satellite nodes on the 'all'/'focus' pools.
 let agendaGraphFocus = null;
 let agendaGraphProjection = 'all';
-let agendaGraphChosen = null; // null = auto ('hubs' past the cap, else 'all')
+let agendaGraphChosen = null; // null = 'all'; 'hubs' only when chosen
 let agendaGraphTerritory = false;
 let agendaGraphSubtreeTerr = new Map();
 let agendaGraphTerrStats = { shown: 0, total: 0 };
@@ -99237,7 +99225,7 @@ function agendaGraphPoolItems() {
   return all;
 }
 
-// The over-cap degradation: instead of refusing, the constellation
+// The chosen hubs projection: the constellation
 // becomes a hub overview — only items with placed children — and a
 // click focuses one hub's subtree. The projection stays functional at
 // any ledger size a real taxonomy produces.
@@ -99262,28 +99250,21 @@ function agendaGraphProjectionItems() {
 
 function agendaGraphRenderLens(host) {
   // Resolve the projection: an explicit chip choice wins; focus
-  // overrides the pool; auto degrades an over-cap ledger to the hub
-  // overview (the cap still bounds every projection; past it the
-  // settle window's O(n²) relaxation stops fitting the frame budget).
+  // overrides the pool. Every projection renders at any size — cost is
+  // handled by LOD (sprite glow, strided repulsion), never refusal.
   let items = agendaGraphPoolItems();
-  let overCapAll = false;
   if (agendaGraphFocus) {
     agendaGraphProjection = 'focus';
-  } else {
-    const wantHubs = agendaGraphChosen === 'hubs'
-      || (agendaGraphChosen !== 'all' && items.length > AGENDA_GRAPH_NODE_CAP);
-    agendaGraphProjection = 'all';
-    if (wantHubs) {
-      const hubs = agendaGraphHubOverviewItems(items);
-      if (hubs.length && hubs.length <= AGENDA_GRAPH_NODE_CAP) {
-        items = hubs;
-        agendaGraphProjection = 'hubs';
-      }
-    } else if (agendaGraphChosen === 'all' && items.length > AGENDA_GRAPH_NODE_CAP) {
-      // The owner explicitly asked for Everything past the cap: keep
-      // the panel and its chips, park the canvas, say why.
-      overCapAll = true;
+  } else if (agendaGraphChosen === 'hubs') {
+    const hubs = agendaGraphHubOverviewItems(items);
+    if (hubs.length) {
+      items = hubs;
+      agendaGraphProjection = 'hubs';
+    } else {
+      agendaGraphProjection = 'all';
     }
+  } else {
+    agendaGraphProjection = 'all';
   }
   if (!items.length) {
     agendaGraphFullscreen = false;
@@ -99295,39 +99276,20 @@ function agendaGraphRenderLens(host) {
     </div>`;
     return;
   }
-  if (!overCapAll && items.length > AGENDA_GRAPH_NODE_CAP) {
-    // A focused subtree past the cap has no cheaper projection to
-    // degrade to — the flat refusal names the way out (and drops any
-    // fullscreen so the refusal never fills the window).
-    agendaGraphFullscreen = false;
-    agendaGraphTeardown();
-    host.innerHTML = `<div class="ag2-graph-panel empty">
-      <div class="ag2-empty">
-        <div class="ag2-empty-glyph">◍</div>
-        <div class="ag2-empty-title">The constellation caps at ${AGENDA_GRAPH_NODE_CAP} items</div>
-        <div class="ag2-empty-hint">This subtree exceeds the cap — focus a narrower hub, or use By hub.</div>
-      </div>
-    </div>`;
-    return;
-  }
   let canvas = host.querySelector('#ag2-graph-canvas');
   if (!canvas) {
     host.innerHTML = agendaGraphPanelHtml();
     canvas = host.querySelector('#ag2-graph-canvas');
   }
-  agendaGraphWireChrome(host, overCapAll);
-  if (overCapAll) {
-    agendaGraphTeardown();
-    return;
-  }
+  agendaGraphWireChrome(host);
   agendaGraphBindCanvas(canvas);
   agendaGraphEnsureLoop();
 }
 
-// Per-projection static chrome: the projection chip row, the cap note,
-// and the hint line. Static strings only — no item text ever lands in
-// this markup (the painted badge carries titles as inert pixels).
-function agendaGraphWireChrome(host, overCapAll) {
+// Per-projection static chrome: the projection chip row and the hint
+// line. Static strings only — no item text ever lands in this markup
+// (the painted badge carries titles as inert pixels).
+function agendaGraphWireChrome(host) {
   const panel = host.querySelector('.ag2-graph-panel');
   if (panel) panel.classList.toggle('fullscreen', agendaGraphFullscreen);
   if (agendaGraphFullscreen) agendaGraphEnsureEsc();
@@ -99335,20 +99297,16 @@ function agendaGraphWireChrome(host, overCapAll) {
   const hintLine = host.querySelector('#ag2-graph-hint');
   if (hintLine) {
     const modeHint = (AGENDA_GRAPH_MODES.find(([m]) => m === agendaGraphMode) || [])[2];
-    hintLine.textContent = overCapAll
-      ? 'everything exceeds the cap — pick hubs, or focus one hub'
-      : modeHint
-        || (agendaGraphProjection === 'hubs'
-          ? 'hub overview — click a hub to focus its subtree'
-          : agendaGraphProjection === 'focus'
-            ? (agendaGraphTerritory
-              ? 'focused territory — squares are files/dirs; click one to open its newest carrier'
-              : 'focused subtree — double-click empty space to clear')
-            : 'drag to orbit · click a node to open it · double-click a hub to focus');
+    hintLine.textContent = modeHint
+      || (agendaGraphProjection === 'hubs'
+        ? 'hub overview — click a hub to focus its subtree'
+        : agendaGraphProjection === 'focus'
+          ? (agendaGraphTerritory
+            ? 'focused territory — squares are files/dirs; click one to open its newest carrier'
+            : 'focused subtree — double-click empty space to clear')
+          : 'drag to orbit · click a node to open it · double-click a hub to focus');
   }
-  const note = host.querySelector('#ag2-graph-capnote');
-  if (note) note.hidden = !overCapAll;
-  const inHubs = !overCapAll && agendaGraphProjection === 'hubs';
+  const inHubs = agendaGraphProjection === 'hubs';
   const chips = host.querySelectorAll('.ag2-graph-projchip');
   chips.forEach((chip) => {
     const kind = chip.dataset.proj;
@@ -99362,10 +99320,9 @@ function agendaGraphWireChrome(host, overCapAll) {
         agendaRenderTab();
       };
     } else if (kind === 'all') {
-      chip.classList.toggle('active', overCapAll
-        || (!inHubs && agendaGraphProjection === 'all'));
+      chip.classList.toggle('active', !inHubs && agendaGraphProjection === 'all');
       chip.disabled = false;
-      chip.title = 'every non-retired item (bounded by the node cap)';
+      chip.title = 'every non-retired item';
       chip.onclick = () => {
         agendaGraphChosen = 'all';
         agendaGraphFocus = null;
@@ -99373,7 +99330,7 @@ function agendaGraphWireChrome(host, overCapAll) {
       };
     } else if (kind === 'terr') {
       chip.classList.toggle('active', agendaGraphTerritory && !inHubs);
-      chip.disabled = inHubs || overCapAll;
+      chip.disabled = inHubs;
       chip.title = inHubs
         ? 'territory needs a concrete pool — focus a hub or pick everything'
         : 'overlay file/dir satellites from the pool’s refs';
@@ -99393,7 +99350,7 @@ function agendaGraphWireChrome(host, overCapAll) {
     } else if (kind && kind.startsWith('mode-')) {
       const mode = kind.slice(5);
       chip.classList.toggle('active', agendaGraphMode === mode);
-      chip.disabled = overCapAll;
+      chip.disabled = false;
       chip.title = agendaGraphMode === mode
         ? 'back to the orbit arrangement'
         : (AGENDA_GRAPH_MODES.find(([m]) => m === mode) || [])[2] || mode;
@@ -99440,9 +99397,6 @@ function agendaGraphPanelHtml() {
     `<button type="button" class="ag2-graph-projchip" data-proj="mode-${mode}">${label}</button>`).join('\n      ')}
       <span class="ag2-graph-projdiv"></span>
       <button type="button" class="ag2-graph-projchip" data-proj="full">⛶ full</button>
-    </div>
-    <div class="ag2-graph-capnote" id="ag2-graph-capnote" hidden>
-      past the ${AGENDA_GRAPH_NODE_CAP}-node cap — the hubs projection or a focused hub keeps the map legible
     </div>
     <div class="ag2-graph-legend">
       ${agendaGraphLegendChip('s-dot t-iris', 'open')}
@@ -99659,10 +99613,9 @@ function agendaGraphBuild() {
         entry.carrier = x.id;
       }
     }));
-    const room = Math.max(0, AGENDA_GRAPH_NODE_CAP - items.length);
     const all = [...best.values()].sort((a, b) =>
       b.newest - a.newest || (a.locator < b.locator ? -1 : 1));
-    satellites = all.slice(0, Math.min(60, room));
+    satellites = all.slice(0, 60);
     agendaGraphTerrStats = { shown: satellites.length, total: all.length };
   } else {
     agendaGraphTerrStats = { shown: 0, total: 0 };
@@ -99858,18 +99811,22 @@ function agendaGraphSettleBudget(count) {
   if (count <= 60) return 30;
   if (count <= 120) return 12;
   if (count <= 240) return 6;
-  // Keeps per-frame settle work roughly constant as n² grows: 420
-  // nodes at 4 iterations/frame ≈ 240 at 6 (the settle just takes a
-  // few more frames to spend its 260-iteration total).
+  // Together with the strided repulsion past REPULSION_LOD this keeps
+  // per-frame settle work roughly flat as n² grows; the settle just
+  // takes more frames to spend its 260-iteration total.
   return 4;
 }
 
 function agendaGraphRelax(iterations) {
   const nodes = agendaGraphNodes;
   const links = agendaGraphLinks;
+  // Past the LOD bound the pair loop strides with a rotating offset:
+  // each iteration touches 1/stride of the pairs, different ones each
+  // time, so big boards converge to the same shape at flat frame cost.
+  const stride = 1 + Math.floor(nodes.length / AGENDA_GRAPH_REPULSION_LOD);
   for (let it = 0; it < iterations; it++) {
     for (let i = 0; i < nodes.length; i++) {
-      for (let j = i + 1; j < nodes.length; j++) {
+      for (let j = i + 1 + ((it + i) % stride); j < nodes.length; j += stride) {
         const A = nodes[i].p;
         const B = nodes[j].p;
         let dx = A[0] - B[0];
@@ -99973,16 +99930,40 @@ function agendaGraphDrawSatellite(g, node, q, hot, pal, w) {
   }
 }
 
+// Pre-baked glow sprites: one radial-gradient canvas per palette color,
+// drawImage-scaled per node. This is what removes the node cap — the
+// shadowBlur look at ~1/100th its cost, so a thousand glowing nodes
+// draw inside a frame. Keyed by the palette's rgb string, so theme
+// flips mint fresh sprites and stale ones just idle in the map.
+const agendaGraphGlowSprites = new Map();
+function agendaGraphGlowSprite(rgb) {
+  let sprite = agendaGraphGlowSprites.get(rgb);
+  if (!sprite) {
+    sprite = document.createElement('canvas');
+    sprite.width = 64;
+    sprite.height = 64;
+    const sg = sprite.getContext('2d');
+    const grad = sg.createRadialGradient(32, 32, 2, 32, 32, 30);
+    grad.addColorStop(0, `rgba(${rgb},.85)`);
+    grad.addColorStop(0.35, `rgba(${rgb},.28)`);
+    grad.addColorStop(1, `rgba(${rgb},0)`);
+    sg.fillStyle = grad;
+    sg.fillRect(0, 0, 64, 64);
+    agendaGraphGlowSprites.set(rgb, sprite);
+  }
+  return sprite;
+}
+
 // ---- Draw (3D-ish projection, hover picking, rings, labels) ----
 
 function agendaGraphDraw(ts) {
   const canvas = agendaGraphCanvas;
   if (!canvas) return;
   const items = agendaGraphBuild();
-  if (!items.length || items.length > AGENDA_GRAPH_NODE_CAP) {
-    // The ledger crossed a boundary between renders (event-lane merge):
-    // re-enter through the render pass, which owns projection choice,
-    // the cap, and the empty states (it tears this loop down).
+  if (!items.length) {
+    // The ledger emptied between renders (event-lane merge): re-enter
+    // through the render pass, which owns projection choice and the
+    // empty state (it tears this loop down).
     agendaRenderTab();
     return;
   }
@@ -100171,14 +100152,16 @@ function agendaGraphDraw(ts) {
     let alpha = Math.max(0.35, Math.min(1, q.s * 1.15 - 0.1));
     // Attention mode: needs-you items glow, the rest recede.
     if (agendaGraphMode === 'attention' && !node.attn && !hot) alpha *= 0.45;
-    g.shadowColor = `rgba(${rgb},.8)`;
-    g.shadowBlur = hot ? 20
-      : (agendaGraphMode === 'attention' && node.attn ? 24 : 11 * q.s);
+    const glow = agendaGraphGlowSprite(rgb);
+    const gr = r * (hot ? 6.5
+      : agendaGraphMode === 'attention' && node.attn ? 7.5 : 4.5);
+    g.globalAlpha = alpha * (hot ? 0.95 : 0.6);
+    g.drawImage(glow, q.x - gr, q.y - gr, gr * 2, gr * 2);
+    g.globalAlpha = 1;
     g.beginPath();
     g.arc(q.x, q.y, r, 0, Math.PI * 2);
     g.fillStyle = `rgba(${rgb},${alpha})`;
     g.fill();
-    g.shadowBlur = 0;
     // Rings reuse slice A's derivations: blocked (uncleared blocker or
     // unmet prerequisite) rose; approved standing/armed green; suspended
     // amber with a slow pulse (static under reduced motion); pending
@@ -100247,7 +100230,7 @@ function agendaGraphDraw(ts) {
     : agendaGraphMode === 'attention'
       ? ` · attention — ${agendaGraphAttnCount} need you`
       : ` · ${agendaGraphMode}`;
-  if (agendaGraphProjection !== 'all' || terrBadge || modeBadge) {
+  {
     const allCount = (agendaItems || []).filter(
       (x) => x.status !== 'retired',
     ).length;

--- a/static/app/ui2-agenda-graph.js
+++ b/static/app/ui2-agenda-graph.js
@@ -28,13 +28,14 @@
 // module-level visibilitychange listener below is the stop/resume
 // conduit itself and must outlive any one activation to resume it.
 
-// Owner-raised 2026-07-31 (from the original 180): the O(n²) cost only
-// bites during the brief settle window and the per-frame budget tiers
-// keep that window's frame work roughly constant as n grows, so the
-// honest bound is legibility — and legibility is what the hubs/focus
-// projections and arrangement modes are for. Past THIS cap the settle
-// window itself stops fitting a frame budget worth defending.
-const AGENDA_GRAPH_NODE_CAP = 420;
+// NO node cap (owner-ruled 2026-07-31, after 180 and then 420 both got
+// hit within a day): density is a feature, and every projection always
+// renders. Cost stays flat through level of detail instead of refusal —
+// node glow comes from pre-baked sprites (drawImage, ~two orders
+// cheaper than per-arc shadowBlur), and past REPULSION_LOD nodes the
+// settle pass strides its O(n²) pair loop with a rotating offset
+// (approximate physics, same look, same 260-iteration budget).
+const AGENDA_GRAPH_REPULSION_LOD = 600;
 // Design-parity settle budget, amortized: the prototype ran 260
 // synchronous O(n²) relaxation iterations per relayout; here the same
 // total is spread over frames (agendaGraphSettleBudget per rAF) so a
@@ -61,7 +62,7 @@ let agendaGraphCam = { yaw: 0.6, pitch: -0.34, auto: true };
 // overlays derived file/dir satellite nodes on the 'all'/'focus' pools.
 let agendaGraphFocus = null;
 let agendaGraphProjection = 'all';
-let agendaGraphChosen = null; // null = auto ('hubs' past the cap, else 'all')
+let agendaGraphChosen = null; // null = 'all'; 'hubs' only when chosen
 let agendaGraphTerritory = false;
 let agendaGraphSubtreeTerr = new Map();
 let agendaGraphTerrStats = { shown: 0, total: 0 };
@@ -147,7 +148,7 @@ function agendaGraphPoolItems() {
   return all;
 }
 
-// The over-cap degradation: instead of refusing, the constellation
+// The chosen hubs projection: the constellation
 // becomes a hub overview — only items with placed children — and a
 // click focuses one hub's subtree. The projection stays functional at
 // any ledger size a real taxonomy produces.
@@ -172,28 +173,21 @@ function agendaGraphProjectionItems() {
 
 function agendaGraphRenderLens(host) {
   // Resolve the projection: an explicit chip choice wins; focus
-  // overrides the pool; auto degrades an over-cap ledger to the hub
-  // overview (the cap still bounds every projection; past it the
-  // settle window's O(n²) relaxation stops fitting the frame budget).
+  // overrides the pool. Every projection renders at any size — cost is
+  // handled by LOD (sprite glow, strided repulsion), never refusal.
   let items = agendaGraphPoolItems();
-  let overCapAll = false;
   if (agendaGraphFocus) {
     agendaGraphProjection = 'focus';
-  } else {
-    const wantHubs = agendaGraphChosen === 'hubs'
-      || (agendaGraphChosen !== 'all' && items.length > AGENDA_GRAPH_NODE_CAP);
-    agendaGraphProjection = 'all';
-    if (wantHubs) {
-      const hubs = agendaGraphHubOverviewItems(items);
-      if (hubs.length && hubs.length <= AGENDA_GRAPH_NODE_CAP) {
-        items = hubs;
-        agendaGraphProjection = 'hubs';
-      }
-    } else if (agendaGraphChosen === 'all' && items.length > AGENDA_GRAPH_NODE_CAP) {
-      // The owner explicitly asked for Everything past the cap: keep
-      // the panel and its chips, park the canvas, say why.
-      overCapAll = true;
+  } else if (agendaGraphChosen === 'hubs') {
+    const hubs = agendaGraphHubOverviewItems(items);
+    if (hubs.length) {
+      items = hubs;
+      agendaGraphProjection = 'hubs';
+    } else {
+      agendaGraphProjection = 'all';
     }
+  } else {
+    agendaGraphProjection = 'all';
   }
   if (!items.length) {
     agendaGraphFullscreen = false;
@@ -205,39 +199,20 @@ function agendaGraphRenderLens(host) {
     </div>`;
     return;
   }
-  if (!overCapAll && items.length > AGENDA_GRAPH_NODE_CAP) {
-    // A focused subtree past the cap has no cheaper projection to
-    // degrade to — the flat refusal names the way out (and drops any
-    // fullscreen so the refusal never fills the window).
-    agendaGraphFullscreen = false;
-    agendaGraphTeardown();
-    host.innerHTML = `<div class="ag2-graph-panel empty">
-      <div class="ag2-empty">
-        <div class="ag2-empty-glyph">◍</div>
-        <div class="ag2-empty-title">The constellation caps at ${AGENDA_GRAPH_NODE_CAP} items</div>
-        <div class="ag2-empty-hint">This subtree exceeds the cap — focus a narrower hub, or use By hub.</div>
-      </div>
-    </div>`;
-    return;
-  }
   let canvas = host.querySelector('#ag2-graph-canvas');
   if (!canvas) {
     host.innerHTML = agendaGraphPanelHtml();
     canvas = host.querySelector('#ag2-graph-canvas');
   }
-  agendaGraphWireChrome(host, overCapAll);
-  if (overCapAll) {
-    agendaGraphTeardown();
-    return;
-  }
+  agendaGraphWireChrome(host);
   agendaGraphBindCanvas(canvas);
   agendaGraphEnsureLoop();
 }
 
-// Per-projection static chrome: the projection chip row, the cap note,
-// and the hint line. Static strings only — no item text ever lands in
-// this markup (the painted badge carries titles as inert pixels).
-function agendaGraphWireChrome(host, overCapAll) {
+// Per-projection static chrome: the projection chip row and the hint
+// line. Static strings only — no item text ever lands in this markup
+// (the painted badge carries titles as inert pixels).
+function agendaGraphWireChrome(host) {
   const panel = host.querySelector('.ag2-graph-panel');
   if (panel) panel.classList.toggle('fullscreen', agendaGraphFullscreen);
   if (agendaGraphFullscreen) agendaGraphEnsureEsc();
@@ -245,20 +220,16 @@ function agendaGraphWireChrome(host, overCapAll) {
   const hintLine = host.querySelector('#ag2-graph-hint');
   if (hintLine) {
     const modeHint = (AGENDA_GRAPH_MODES.find(([m]) => m === agendaGraphMode) || [])[2];
-    hintLine.textContent = overCapAll
-      ? 'everything exceeds the cap — pick hubs, or focus one hub'
-      : modeHint
-        || (agendaGraphProjection === 'hubs'
-          ? 'hub overview — click a hub to focus its subtree'
-          : agendaGraphProjection === 'focus'
-            ? (agendaGraphTerritory
-              ? 'focused territory — squares are files/dirs; click one to open its newest carrier'
-              : 'focused subtree — double-click empty space to clear')
-            : 'drag to orbit · click a node to open it · double-click a hub to focus');
+    hintLine.textContent = modeHint
+      || (agendaGraphProjection === 'hubs'
+        ? 'hub overview — click a hub to focus its subtree'
+        : agendaGraphProjection === 'focus'
+          ? (agendaGraphTerritory
+            ? 'focused territory — squares are files/dirs; click one to open its newest carrier'
+            : 'focused subtree — double-click empty space to clear')
+          : 'drag to orbit · click a node to open it · double-click a hub to focus');
   }
-  const note = host.querySelector('#ag2-graph-capnote');
-  if (note) note.hidden = !overCapAll;
-  const inHubs = !overCapAll && agendaGraphProjection === 'hubs';
+  const inHubs = agendaGraphProjection === 'hubs';
   const chips = host.querySelectorAll('.ag2-graph-projchip');
   chips.forEach((chip) => {
     const kind = chip.dataset.proj;
@@ -272,10 +243,9 @@ function agendaGraphWireChrome(host, overCapAll) {
         agendaRenderTab();
       };
     } else if (kind === 'all') {
-      chip.classList.toggle('active', overCapAll
-        || (!inHubs && agendaGraphProjection === 'all'));
+      chip.classList.toggle('active', !inHubs && agendaGraphProjection === 'all');
       chip.disabled = false;
-      chip.title = 'every non-retired item (bounded by the node cap)';
+      chip.title = 'every non-retired item';
       chip.onclick = () => {
         agendaGraphChosen = 'all';
         agendaGraphFocus = null;
@@ -283,7 +253,7 @@ function agendaGraphWireChrome(host, overCapAll) {
       };
     } else if (kind === 'terr') {
       chip.classList.toggle('active', agendaGraphTerritory && !inHubs);
-      chip.disabled = inHubs || overCapAll;
+      chip.disabled = inHubs;
       chip.title = inHubs
         ? 'territory needs a concrete pool — focus a hub or pick everything'
         : 'overlay file/dir satellites from the pool’s refs';
@@ -303,7 +273,7 @@ function agendaGraphWireChrome(host, overCapAll) {
     } else if (kind && kind.startsWith('mode-')) {
       const mode = kind.slice(5);
       chip.classList.toggle('active', agendaGraphMode === mode);
-      chip.disabled = overCapAll;
+      chip.disabled = false;
       chip.title = agendaGraphMode === mode
         ? 'back to the orbit arrangement'
         : (AGENDA_GRAPH_MODES.find(([m]) => m === mode) || [])[2] || mode;
@@ -350,9 +320,6 @@ function agendaGraphPanelHtml() {
     `<button type="button" class="ag2-graph-projchip" data-proj="mode-${mode}">${label}</button>`).join('\n      ')}
       <span class="ag2-graph-projdiv"></span>
       <button type="button" class="ag2-graph-projchip" data-proj="full">⛶ full</button>
-    </div>
-    <div class="ag2-graph-capnote" id="ag2-graph-capnote" hidden>
-      past the ${AGENDA_GRAPH_NODE_CAP}-node cap — the hubs projection or a focused hub keeps the map legible
     </div>
     <div class="ag2-graph-legend">
       ${agendaGraphLegendChip('s-dot t-iris', 'open')}
@@ -569,10 +536,9 @@ function agendaGraphBuild() {
         entry.carrier = x.id;
       }
     }));
-    const room = Math.max(0, AGENDA_GRAPH_NODE_CAP - items.length);
     const all = [...best.values()].sort((a, b) =>
       b.newest - a.newest || (a.locator < b.locator ? -1 : 1));
-    satellites = all.slice(0, Math.min(60, room));
+    satellites = all.slice(0, 60);
     agendaGraphTerrStats = { shown: satellites.length, total: all.length };
   } else {
     agendaGraphTerrStats = { shown: 0, total: 0 };
@@ -768,18 +734,22 @@ function agendaGraphSettleBudget(count) {
   if (count <= 60) return 30;
   if (count <= 120) return 12;
   if (count <= 240) return 6;
-  // Keeps per-frame settle work roughly constant as n² grows: 420
-  // nodes at 4 iterations/frame ≈ 240 at 6 (the settle just takes a
-  // few more frames to spend its 260-iteration total).
+  // Together with the strided repulsion past REPULSION_LOD this keeps
+  // per-frame settle work roughly flat as n² grows; the settle just
+  // takes more frames to spend its 260-iteration total.
   return 4;
 }
 
 function agendaGraphRelax(iterations) {
   const nodes = agendaGraphNodes;
   const links = agendaGraphLinks;
+  // Past the LOD bound the pair loop strides with a rotating offset:
+  // each iteration touches 1/stride of the pairs, different ones each
+  // time, so big boards converge to the same shape at flat frame cost.
+  const stride = 1 + Math.floor(nodes.length / AGENDA_GRAPH_REPULSION_LOD);
   for (let it = 0; it < iterations; it++) {
     for (let i = 0; i < nodes.length; i++) {
-      for (let j = i + 1; j < nodes.length; j++) {
+      for (let j = i + 1 + ((it + i) % stride); j < nodes.length; j += stride) {
         const A = nodes[i].p;
         const B = nodes[j].p;
         let dx = A[0] - B[0];
@@ -883,16 +853,40 @@ function agendaGraphDrawSatellite(g, node, q, hot, pal, w) {
   }
 }
 
+// Pre-baked glow sprites: one radial-gradient canvas per palette color,
+// drawImage-scaled per node. This is what removes the node cap — the
+// shadowBlur look at ~1/100th its cost, so a thousand glowing nodes
+// draw inside a frame. Keyed by the palette's rgb string, so theme
+// flips mint fresh sprites and stale ones just idle in the map.
+const agendaGraphGlowSprites = new Map();
+function agendaGraphGlowSprite(rgb) {
+  let sprite = agendaGraphGlowSprites.get(rgb);
+  if (!sprite) {
+    sprite = document.createElement('canvas');
+    sprite.width = 64;
+    sprite.height = 64;
+    const sg = sprite.getContext('2d');
+    const grad = sg.createRadialGradient(32, 32, 2, 32, 32, 30);
+    grad.addColorStop(0, `rgba(${rgb},.85)`);
+    grad.addColorStop(0.35, `rgba(${rgb},.28)`);
+    grad.addColorStop(1, `rgba(${rgb},0)`);
+    sg.fillStyle = grad;
+    sg.fillRect(0, 0, 64, 64);
+    agendaGraphGlowSprites.set(rgb, sprite);
+  }
+  return sprite;
+}
+
 // ---- Draw (3D-ish projection, hover picking, rings, labels) ----
 
 function agendaGraphDraw(ts) {
   const canvas = agendaGraphCanvas;
   if (!canvas) return;
   const items = agendaGraphBuild();
-  if (!items.length || items.length > AGENDA_GRAPH_NODE_CAP) {
-    // The ledger crossed a boundary between renders (event-lane merge):
-    // re-enter through the render pass, which owns projection choice,
-    // the cap, and the empty states (it tears this loop down).
+  if (!items.length) {
+    // The ledger emptied between renders (event-lane merge): re-enter
+    // through the render pass, which owns projection choice and the
+    // empty state (it tears this loop down).
     agendaRenderTab();
     return;
   }
@@ -1081,14 +1075,16 @@ function agendaGraphDraw(ts) {
     let alpha = Math.max(0.35, Math.min(1, q.s * 1.15 - 0.1));
     // Attention mode: needs-you items glow, the rest recede.
     if (agendaGraphMode === 'attention' && !node.attn && !hot) alpha *= 0.45;
-    g.shadowColor = `rgba(${rgb},.8)`;
-    g.shadowBlur = hot ? 20
-      : (agendaGraphMode === 'attention' && node.attn ? 24 : 11 * q.s);
+    const glow = agendaGraphGlowSprite(rgb);
+    const gr = r * (hot ? 6.5
+      : agendaGraphMode === 'attention' && node.attn ? 7.5 : 4.5);
+    g.globalAlpha = alpha * (hot ? 0.95 : 0.6);
+    g.drawImage(glow, q.x - gr, q.y - gr, gr * 2, gr * 2);
+    g.globalAlpha = 1;
     g.beginPath();
     g.arc(q.x, q.y, r, 0, Math.PI * 2);
     g.fillStyle = `rgba(${rgb},${alpha})`;
     g.fill();
-    g.shadowBlur = 0;
     // Rings reuse slice A's derivations: blocked (uncleared blocker or
     // unmet prerequisite) rose; approved standing/armed green; suspended
     // amber with a slow pulse (static under reduced motion); pending
@@ -1157,7 +1153,7 @@ function agendaGraphDraw(ts) {
     : agendaGraphMode === 'attention'
       ? ` · attention — ${agendaGraphAttnCount} need you`
       : ` · ${agendaGraphMode}`;
-  if (agendaGraphProjection !== 'all' || terrBadge || modeBadge) {
+  {
     const allCount = (agendaItems || []).filter(
       (x) => x.status !== 'retired',
     ).length;

--- a/static/app/ui2-agenda.css
+++ b/static/app/ui2-agenda.css
@@ -1092,19 +1092,6 @@ html.ui-v2 .ag2-graph-panel.fullscreen canvas {
   height: 100vh;
   height: 100dvh;
 }
-html.ui-v2 .ag2-graph-capnote {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-family: var(--mono);
-  font-size: 11px;
-  color: var(--text-3);
-  pointer-events: none;
-  padding: 0 40px;
-  text-align: center;
-}
 
 /* ---- Upcoming lens (slice C): the 14-day day-grouped timeline. Rows
    ride the shared .ag2-chip family; dots pulse via the shared ui2-pulse


### PR DESCRIPTION
Owner-ruled: after 180 and then 420 both got hit within a day, the cap itself is the bug — density is a feature, and the constellation is one view among several. Every projection now renders at any size; the two real costs get engineering instead of refusal:

- **Sprite glow** replaces per-arc shadowBlur (the actual steady-state wall): one pre-baked radial-gradient canvas per palette color, drawImage-scaled per node — same look at ~1/100th the cost, so a thousand glowing nodes draw inside a frame. Hover and attention-mode emphasis ride the sprite scale/alpha.
- **Strided repulsion** past 600 nodes: the settle pass's O(n²) pair loop strides with a rotating per-iteration offset — each iteration touches 1/stride of the pairs, different ones each time — converging to the same shape at flat per-frame cost over the unchanged 260-iteration budget (stacking with the existing per-frame budget tiers).

Removed entirely: the over-cap refusal states, the capnote overlay, and the hub-overview auto-degrade — 'hubs' is purely a chip choice now, 'everything' is always the landing, and the painted badge always names what's shown ('everything · N items'). Satellite overlay keeps its flat 60 cap (digest grain, not an index).

Battery: bins + lib crates pass, workspace clippy -D warnings clean, node --check, app.html regenerated via the assembler.