### PR TITLE
Update channels: Releases-default / Dev-from-main front door over the shipped produce+swap lanes

### DIFF
--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -1998,8 +1998,8 @@ response omits the header.
 | POST | `/api/agenda/stamp` | AgendaWrite | own origin | bounded | Stamp an automation definition (park + propose the instance graph; never approves) |
 | POST | `/api/daemon/takeover` | Settings | own origin | ≤ 4 KiB | Request drain of this daemon (handover): the scheduler lease frees for a successor; in-flight sessions finish here |
 | GET | `/api/daemon/handover` | StatsRead | own origin | none | Handover status: lease role, drain state, and co-homed daemons with probed liveness |
-| POST | `/api/daemon/update-lane/check` | Settings | own origin | ≤ 4 KiB | Self-update lane: run the bounded behind-origin-main / behind-latest-release check now |
-| POST | `/api/daemon/update-lane/produce` | Settings | own origin | ≤ 4 KiB | Self-update lane: produce the update artifact (source pull+build, or verified release download) for the swap chip |
+| POST | `/api/daemon/update-lane/check` | Settings | own origin | ≤ 4 KiB | Self-update lane: run the bounded behind-origin-main / behind-latest-release check now (optional body {"channel": "releases"|"dev"}; absent = the install's native lane) |
+| POST | `/api/daemon/update-lane/produce` | Settings | own origin | ≤ 4 KiB | Self-update lane: produce the update artifact on the named channel (dev = source pull+build, releases = verified release download) for the swap chip |
 | POST | `/api/daemon/update-swap` | Settings | own origin | ≤ 4 KiB | Ask the attached app supervisor for the one-click update swap (refused when no live supervisor is attached) |
 | POST | `/api/daemon/update-swap/claim` | Settings | own origin | ≤ 4 KiB | App supervisor poll: claim the pending one-click swap request (consuming; expired requests evaporate) |
 | POST | `/api/daemon/update-swap/result` | Settings | own origin | ≤ 4 KiB | App supervisor report: the outcome of a claimed swap attempt (failures surface on the chip and the notification lane) |

--- a/src/bin/caller/gateway_routes.rs
+++ b/src/bin/caller/gateway_routes.rs
@@ -1155,7 +1155,7 @@ pub(crate) static ROUTES: &[Route] = &[
         PeerOperation::Settings,
         BodyPolicy::Capped(4 * 1024),
         RouteHandlerId::DaemonUpdateLaneCheck,
-        "Self-update lane: run the bounded behind-origin-main / behind-latest-release check now",
+        "Self-update lane: run the bounded behind-origin-main / behind-latest-release check now (optional body {\"channel\": \"releases\"|\"dev\"}; absent = the install's native lane)",
     ),
     op_route(
         RouteMethod::Post,
@@ -1163,7 +1163,7 @@ pub(crate) static ROUTES: &[Route] = &[
         PeerOperation::Settings,
         BodyPolicy::Capped(4 * 1024),
         RouteHandlerId::DaemonUpdateLaneProduce,
-        "Self-update lane: produce the update artifact (source pull+build, or verified release download) for the swap chip",
+        "Self-update lane: produce the update artifact on the named channel (dev = source pull+build, releases = verified release download) for the swap chip",
     ),
     // The one-click swap relay (the SWAP half, beyond the app's own
     // webview): a dashboard surface asks the daemon, the daemon parks

--- a/src/bin/caller/handover/mod.rs
+++ b/src/bin/caller/handover/mod.rs
@@ -29,7 +29,7 @@ mod update_watch;
 
 pub(crate) use lease::{read_lease_sidecar, LeaseAttempt, SchedulerLease};
 pub(crate) use presence::{boot_id_is_live, read_presence_records, DaemonPresence};
-pub(crate) use update_lane::spawn_update_lane;
+pub(crate) use update_lane::{parse_channel_arg, spawn_update_lane};
 pub(crate) use update_watch::spawn_update_watch;
 
 use std::path::{Path, PathBuf};

--- a/src/bin/caller/handover/update_lane.rs
+++ b/src/bin/caller/handover/update_lane.rs
@@ -46,6 +46,11 @@ use std::sync::{Arc, Mutex, Weak};
 /// past this the panel says "500+" — a bounded compare, literally.
 const BEHIND_COUNT_CAP: u32 = 500;
 
+/// Bounds on the dev-channel shortlog (newest-first `%h %s` lines the
+/// panel renders as data beside the behind-count).
+const SHORTLOG_MAX_LINES: usize = 20;
+const SHORTLOG_LINE_CAP: usize = 160;
+
 /// Bounded log tail kept per job for the status payload (each line also
 /// goes to the daemon log as it happens).
 const JOB_LOG_TAIL_LINES: usize = 60;
@@ -96,6 +101,131 @@ impl InstallFlavor {
             InstallFlavor::Unmanaged { .. } => "unmanaged",
         }
     }
+
+    /// The channel a request without one means: a source checkout
+    /// updates from main, everything else from releases.
+    pub(crate) fn native_channel(&self) -> UpdateChannel {
+        match self {
+            InstallFlavor::Source { .. } => UpdateChannel::Dev,
+            _ => UpdateChannel::Releases,
+        }
+    }
+}
+
+// ── Channels (the front door's vocabulary) ──────────────────────────
+
+/// The update panel's two-channel vocabulary: **Releases** is the
+/// default lane for everyone — logged, PGP-verified builds, fail closed
+/// on every verify step; **Dev — build from main** sits behind the
+/// panel's Advanced fold and pulls + rebuilds a source checkout.
+/// Exactly two: there is no nightly lane and none is invented here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum UpdateChannel {
+    Releases,
+    Dev,
+}
+
+/// Parse the optional `{"channel": "releases"|"dev"}` request body.
+/// An absent body/field means the install's native channel; an unknown
+/// channel name is refused by name (the vocabulary is exactly two).
+pub(crate) fn parse_channel_arg(body_text: &str) -> Result<Option<UpdateChannel>, String> {
+    let Ok(body) = serde_json::from_str::<serde_json::Value>(body_text) else {
+        return Ok(None);
+    };
+    let Some(raw) = body.get("channel") else {
+        return Ok(None);
+    };
+    match raw.as_str() {
+        Some("releases") => Ok(Some(UpdateChannel::Releases)),
+        Some("dev") => Ok(Some(UpdateChannel::Dev)),
+        _ => Err(format!(
+            "unknown update channel {} — this daemon has exactly two: \"releases\" and \"dev\"",
+            raw.to_string().chars().take(60).collect::<String>()
+        )),
+    }
+}
+
+/// Why a check on `channel` cannot run for this install (`None` = it
+/// can). The releases check is data about the latest logged release —
+/// honest on every install shape; the dev compare needs a checkout.
+pub(crate) fn check_refusal(flavor: &InstallFlavor, channel: UpdateChannel) -> Option<String> {
+    match (channel, flavor) {
+        (UpdateChannel::Releases, _) => None,
+        (UpdateChannel::Dev, InstallFlavor::Source { .. }) => None,
+        (UpdateChannel::Dev, InstallFlavor::ConsumerApp { .. }) => Some(
+            "no source checkout around this install — the Dev channel compares against and \
+             rebuilds a git checkout"
+                .to_string(),
+        ),
+        (UpdateChannel::Dev, InstallFlavor::Unmanaged { reason }) => Some(reason.clone()),
+    }
+}
+
+/// Why a produce click on `channel` cannot run for this install
+/// (`None` = it can). `macos` is a parameter so the whole matrix stays
+/// hermetic under test on every host.
+pub(crate) fn produce_refusal(
+    flavor: &InstallFlavor,
+    channel: UpdateChannel,
+    macos: bool,
+) -> Option<String> {
+    match (channel, flavor) {
+        (_, InstallFlavor::Unmanaged { reason }) => {
+            Some(format!("no update lane for this install: {reason}"))
+        }
+        (UpdateChannel::Dev, InstallFlavor::Source { .. }) => None,
+        (UpdateChannel::Dev, InstallFlavor::ConsumerApp { .. }) => {
+            check_refusal(flavor, UpdateChannel::Dev)
+        }
+        (UpdateChannel::Releases, InstallFlavor::ConsumerApp { .. }) if !macos => Some(
+            "releases currently ship only the macOS app — rebuild from source on this \
+             platform"
+                .to_string(),
+        ),
+        (UpdateChannel::Releases, InstallFlavor::ConsumerApp { .. }) => None,
+        (
+            UpdateChannel::Releases,
+            InstallFlavor::Source {
+                repo_root,
+                app_bundle,
+            },
+        ) => Some(if *app_bundle {
+            format!(
+                "this app is a source build from {} — its update path rebuilds from main \
+                 (the Dev channel behind Advanced), not the release download",
+                repo_root.display()
+            )
+        } else {
+            format!(
+                "this daemon runs from the checkout at {} — a release would install the \
+                 packaged macOS app, not this binary; updates for this install build from \
+                 main (the Dev channel behind Advanced)",
+                repo_root.display()
+            )
+        }),
+    }
+}
+
+/// The per-channel availability catalog the panel derives its sections
+/// and buttons from — declared here once, never mirrored client-side.
+pub(crate) fn channel_catalog(flavor: &InstallFlavor, macos: bool) -> serde_json::Value {
+    let channel_block = |channel: UpdateChannel| {
+        let check = check_refusal(flavor, channel);
+        let produce = produce_refusal(flavor, channel, macos);
+        let mut block = serde_json::json!({
+            "check": check.is_none(),
+            "produce": produce.is_none(),
+        });
+        let obj = block.as_object_mut().expect("literal object");
+        if let Some(reason) = produce.or(check) {
+            obj.insert("reason".into(), reason.into());
+        }
+        block
+    };
+    serde_json::json!({
+        "releases": channel_block(UpdateChannel::Releases),
+        "dev": channel_block(UpdateChannel::Dev),
+    })
 }
 
 /// The stamp `scripts/bundle-macos.sh` writes into the bundle
@@ -202,17 +332,21 @@ pub(crate) struct SourceCheck {
     /// commit — capped at [`BEHIND_COUNT_CAP`].
     pub(crate) behind: u32,
     pub(crate) behind_capped: bool,
+    /// Newest-first `%h %s` lines for the commits behind — bounded
+    /// data for the panel, never markup.
+    pub(crate) shortlog: Vec<String>,
     /// Tracked files modified in the checkout: the produce step refuses
     /// to touch a dirty tree.
     pub(crate) dirty: bool,
 }
 
-/// Fold the three bounded git observations into the compare verdict.
+/// Fold the bounded git observations into the compare verdict.
 /// Pure — the child outputs come in as text; the pinned compare-seam
 /// tests live on this function.
 pub(crate) fn fold_source_check(
     rev_parse_tip: &str,
     rev_list_count: &str,
+    shortlog: &str,
     status_porcelain: &str,
 ) -> Result<SourceCheck, String> {
     let tip_sha = rev_parse_tip.trim().to_string();
@@ -232,8 +366,39 @@ pub(crate) fn fold_source_check(
         tip_sha,
         behind,
         behind_capped: behind >= BEHIND_COUNT_CAP,
+        shortlog: fold_shortlog(shortlog),
         dirty: tracked_dirty(status_porcelain),
     })
+}
+
+/// Bound the shortlog into displayable data lines: trimmed, width-
+/// capped, at most [`SHORTLOG_MAX_LINES`] (defense in depth beside the
+/// git child's own `--max-count`).
+pub(crate) fn fold_shortlog(raw: &str) -> Vec<String> {
+    raw.lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .take(SHORTLOG_MAX_LINES)
+        .map(|line| {
+            let mut line = line.to_string();
+            truncate_on_boundary(&mut line, SHORTLOG_LINE_CAP);
+            line
+        })
+        .collect()
+}
+
+/// Truncate to at most `cap` bytes on a char boundary
+/// (`String::truncate` panics mid-codepoint, and commit subjects and
+/// child output are arbitrary unicode).
+fn truncate_on_boundary(line: &mut String, cap: usize) {
+    if line.len() <= cap {
+        return;
+    }
+    let mut cut = cap;
+    while cut > 0 && !line.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    line.truncate(cut);
 }
 
 /// TRACKED modifications only (`git status --porcelain` lines whose
@@ -529,6 +694,23 @@ struct CheckState {
     outcome: Option<Result<CheckOutcome, String>>,
 }
 
+/// One slot per channel: the panel renders both lanes' last verdicts
+/// side by side, so a dev compare never overwrites the release story.
+#[derive(Debug, Default)]
+struct CheckSlots {
+    releases: CheckState,
+    dev: CheckState,
+}
+
+impl CheckSlots {
+    fn slot_mut(&mut self, channel: UpdateChannel) -> &mut CheckState {
+        match channel {
+            UpdateChannel::Releases => &mut self.releases,
+            UpdateChannel::Dev => &mut self.dev,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 struct JobState {
     lane: &'static str,
@@ -546,7 +728,7 @@ pub(crate) struct UpdateLane {
     runtime: Weak<super::HandoverRuntime>,
     exe_path: PathBuf,
     flavor: InstallFlavor,
-    check: Mutex<CheckState>,
+    check: Mutex<CheckSlots>,
     job: Mutex<Option<JobState>>,
     job_running: AtomicBool,
 }
@@ -558,7 +740,7 @@ impl UpdateLane {
             runtime: Arc::downgrade(runtime),
             exe_path,
             flavor,
-            check: Mutex::new(CheckState::default()),
+            check: Mutex::new(CheckSlots::default()),
             job: Mutex::new(None),
             job_running: AtomicBool::new(false),
         }
@@ -598,47 +780,20 @@ impl UpdateLane {
                 obj.insert("unavailable".into(), reason.clone().into());
             }
         }
-        if let Ok(check) = self.check.lock() {
-            let mut check_block = serde_json::json!({
-                "in_flight": check.in_flight,
-            });
-            let check_obj = check_block.as_object_mut().expect("literal object");
-            if let Some(at) = check.checked_at_ms {
-                check_obj.insert("checked_at_ms".into(), at.into());
-            }
-            match &check.outcome {
-                Some(Ok(CheckOutcome::Source(source))) => {
-                    check_obj.insert("tip_sha".into(), source.tip_sha.clone().into());
-                    check_obj.insert("behind".into(), source.behind.into());
-                    check_obj.insert("behind_capped".into(), source.behind_capped.into());
-                    check_obj.insert("dirty".into(), source.dirty.into());
-                }
-                Some(Ok(CheckOutcome::Consumer {
-                    tag,
-                    version,
-                    newer,
-                })) => {
-                    check_obj.insert("latest_tag".into(), tag.clone().into());
-                    check_obj.insert("latest_version".into(), version.clone().into());
-                    match newer {
-                        Some(newer) => {
-                            check_obj.insert("behind".into(), u32::from(*newer).into());
-                        }
-                        None => {
-                            check_obj.insert(
-                                "compare_error".into(),
-                                "release and running versions are not comparable".into(),
-                            );
-                        }
-                    }
-                }
-                Some(Err(error)) => {
-                    check_obj.insert("error".into(), error.clone().into());
-                }
-                None => {}
-            }
-            obj.insert("check".into(), check_block);
+        if let Ok(slots) = self.check.lock() {
+            obj.insert(
+                "checks".into(),
+                serde_json::json!({
+                    "releases": check_state_block(&slots.releases),
+                    "dev": check_state_block(&slots.dev),
+                }),
+            );
         }
+        obj.insert(
+            "channels".into(),
+            channel_catalog(&self.flavor, cfg!(target_os = "macos")),
+        );
+        obj.insert("default_channel".into(), "releases".into());
         if let Ok(job) = self.job.lock() {
             if let Some(job) = job.as_ref() {
                 let mut job_block = serde_json::json!({
@@ -669,9 +824,7 @@ impl UpdateLane {
 
     fn job_log(&self, line: impl Into<String>) {
         let mut line = line.into();
-        if line.len() > JOB_LOG_LINE_CAP {
-            line.truncate(JOB_LOG_LINE_CAP);
-        }
+        truncate_on_boundary(&mut line, JOB_LOG_LINE_CAP);
         eprintln!("[update-lane] {line}");
         if let Ok(mut job) = self.job.lock() {
             if let Some(job) = job.as_mut() {
@@ -806,45 +959,51 @@ impl UpdateLane {
 // ── Public entry points (routes + wiring) ───────────────────────────
 
 impl UpdateLane {
-    /// Start a bounded behind-ness check unless one is already running.
-    pub(crate) fn request_check(self: &Arc<Self>) -> serde_json::Value {
+    /// Start a bounded check on `channel` (the install's native lane
+    /// when unnamed) unless that channel's check is already running.
+    /// Refuses (honestly) a channel this install cannot check.
+    pub(crate) fn request_check(
+        self: &Arc<Self>,
+        channel: Option<UpdateChannel>,
+    ) -> Result<serde_json::Value, String> {
+        let channel = channel.unwrap_or_else(|| self.flavor.native_channel());
+        if let Some(refusal) = check_refusal(&self.flavor, channel) {
+            return Err(refusal);
+        }
         {
-            let Ok(mut check) = self.check.lock() else {
-                return self.status_block();
+            let Ok(mut slots) = self.check.lock() else {
+                return Ok(self.status_block());
             };
-            if check.in_flight {
-                return self.status_block();
+            let slot = slots.slot_mut(channel);
+            if slot.in_flight {
+                return Ok(self.status_block());
             }
-            check.in_flight = true;
+            slot.in_flight = true;
         }
         let lane = Arc::clone(self);
         tokio::spawn(async move {
-            let outcome = lane.run_check().await;
-            if let Ok(mut check) = lane.check.lock() {
-                check.in_flight = false;
-                check.checked_at_ms = Some(super::now_ms());
-                check.outcome = Some(outcome);
+            let outcome = lane.run_check(channel).await;
+            if let Ok(mut slots) = lane.check.lock() {
+                let slot = slots.slot_mut(channel);
+                slot.in_flight = false;
+                slot.checked_at_ms = Some(super::now_ms());
+                slot.outcome = Some(outcome);
             }
         });
-        self.status_block()
+        Ok(self.status_block())
     }
 
-    /// The owner's click: start the produce job. Refuses (honestly)
-    /// while one runs, on an unmanaged flavor, and on a consumer flavor
-    /// off macOS.
-    pub(crate) fn request_produce(self: &Arc<Self>) -> Result<serde_json::Value, String> {
-        match &self.flavor {
-            InstallFlavor::Unmanaged { reason } => {
-                return Err(format!("no update lane for this install: {reason}"));
-            }
-            InstallFlavor::ConsumerApp { .. } if !cfg!(target_os = "macos") => {
-                return Err(
-                    "releases currently ship only the macOS app — rebuild from source on this \
-                     platform"
-                        .to_string(),
-                );
-            }
-            _ => {}
+    /// The owner's click: start the produce job on `channel` (the
+    /// install's native lane when unnamed). Refuses (honestly) while one
+    /// runs and on any channel/install mismatch — the guard runs before
+    /// anything touches the network or the checkout.
+    pub(crate) fn request_produce(
+        self: &Arc<Self>,
+        channel: Option<UpdateChannel>,
+    ) -> Result<serde_json::Value, String> {
+        let channel = channel.unwrap_or_else(|| self.flavor.native_channel());
+        if let Some(refusal) = produce_refusal(&self.flavor, channel, cfg!(target_os = "macos")) {
+            return Err(refusal);
         }
         if self
             .job_running
@@ -853,10 +1012,11 @@ impl UpdateLane {
         {
             return Err("an update job is already running".to_string());
         }
-        let lane_kind = match &self.flavor {
-            InstallFlavor::Source { .. } => "source",
-            InstallFlavor::ConsumerApp { .. } => "consumer",
-            InstallFlavor::Unmanaged { .. } => unreachable!("refused above"),
+        // The guard above pins channel↔flavor: Dev only passes on a
+        // Source install, Releases only on a consumer app.
+        let lane_kind = match channel {
+            UpdateChannel::Dev => "source",
+            UpdateChannel::Releases => "consumer",
         };
         if let Ok(mut job) = self.job.lock() {
             *job = Some(JobState {
@@ -884,14 +1044,18 @@ impl UpdateLane {
 
     // ── The check ──
 
-    async fn run_check(self: &Arc<Self>) -> Result<CheckOutcome, String> {
-        match self.flavor.clone() {
-            InstallFlavor::Source { repo_root, .. } => self
-                .source_check(&repo_root)
-                .await
-                .map(CheckOutcome::Source),
-            InstallFlavor::ConsumerApp { .. } => self.consumer_check().await,
-            InstallFlavor::Unmanaged { reason } => Err(reason),
+    async fn run_check(self: &Arc<Self>, channel: UpdateChannel) -> Result<CheckOutcome, String> {
+        match channel {
+            UpdateChannel::Dev => match self.flavor.clone() {
+                InstallFlavor::Source { repo_root, .. } => self
+                    .source_check(&repo_root)
+                    .await
+                    .map(CheckOutcome::Source),
+                // request_check refused already; kept for direct callers.
+                other => Err(check_refusal(&other, UpdateChannel::Dev)
+                    .unwrap_or_else(|| "no source checkout for the Dev channel".to_string())),
+            },
+            UpdateChannel::Releases => self.consumer_check().await,
         }
     }
 
@@ -917,8 +1081,22 @@ impl UpdateLane {
                      {running_sha} in this checkout's history?): {err}"
                 )
             })?;
+        // `--format=%h %s` sidesteps decoration/color config entirely —
+        // the lines are data for the panel, newest first.
+        let shortlog_max = format!("--max-count={SHORTLOG_MAX_LINES}");
+        let shortlog = self
+            .git(
+                repo_root,
+                &[
+                    "log",
+                    "--format=%h %s",
+                    shortlog_max.as_str(),
+                    range.as_str(),
+                ],
+            )
+            .await?;
         let status = self.git(repo_root, &["status", "--porcelain"]).await?;
-        fold_source_check(&tip, &count, &status)
+        fold_source_check(&tip, &count, &shortlog, &status)
     }
 
     /// A bounded git child — check-lane runs skip the job log (no job
@@ -1277,6 +1455,50 @@ impl UpdateLane {
     }
 }
 
+/// Render one channel's check slot for the status payload.
+fn check_state_block(check: &CheckState) -> serde_json::Value {
+    let mut block = serde_json::json!({
+        "in_flight": check.in_flight,
+    });
+    let obj = block.as_object_mut().expect("literal object");
+    if let Some(at) = check.checked_at_ms {
+        obj.insert("checked_at_ms".into(), at.into());
+    }
+    match &check.outcome {
+        Some(Ok(CheckOutcome::Source(source))) => {
+            obj.insert("tip_sha".into(), source.tip_sha.clone().into());
+            obj.insert("behind".into(), source.behind.into());
+            obj.insert("behind_capped".into(), source.behind_capped.into());
+            obj.insert("shortlog".into(), source.shortlog.clone().into());
+            obj.insert("dirty".into(), source.dirty.into());
+        }
+        Some(Ok(CheckOutcome::Consumer {
+            tag,
+            version,
+            newer,
+        })) => {
+            obj.insert("latest_tag".into(), tag.clone().into());
+            obj.insert("latest_version".into(), version.clone().into());
+            match newer {
+                Some(newer) => {
+                    obj.insert("behind".into(), u32::from(*newer).into());
+                }
+                None => {
+                    obj.insert(
+                        "compare_error".into(),
+                        "release and running versions are not comparable".into(),
+                    );
+                }
+            }
+        }
+        Some(Err(error)) => {
+            obj.insert("error".into(), error.clone().into());
+        }
+        None => {}
+    }
+    block
+}
+
 /// Delete the staging tree on drop — a failed job never leaves
 /// unverified bytes behind. Success paths drop it too: the artifact has
 /// been installed; the staging copy is done.
@@ -1397,14 +1619,22 @@ pub(crate) fn spawn_update_lane(runtime: &Arc<super::HandoverRuntime>) {
     tokio::spawn(async move {
         tokio::time::sleep(BOOT_CHECK_DELAY).await;
         loop {
-            // The AUTOMATIC cadence follows the hosted-verify tripwire's
-            // posture: a consumer-flavor check reaches the rendezvous +
-            // GitHub, so it only runs unprompted when the owner has
-            // Connect configured; the panel's "Check now" click always
-            // may. Source-flavor checks fetch the owner's own origin.
-            let consumer = matches!(lane.flavor, InstallFlavor::ConsumerApp { .. });
-            if !consumer || crate::connect_rendezvous::status_snapshot().configured {
-                lane.request_check();
+            // The AUTOMATIC cadence checks the install's NATIVE channel,
+            // following the hosted-verify tripwire's posture: a releases
+            // check reaches the rendezvous + GitHub, so it only runs
+            // unprompted when the owner has Connect configured; a source
+            // install fetches the owner's own origin. An unmanaged
+            // install has nothing to check unprompted — the panel says
+            // why instead. The panel's check click always may.
+            let auto = match &lane.flavor {
+                InstallFlavor::Source { .. } => true,
+                InstallFlavor::ConsumerApp { .. } => {
+                    crate::connect_rendezvous::status_snapshot().configured
+                }
+                InstallFlavor::Unmanaged { .. } => false,
+            };
+            if auto {
+                let _ = lane.request_check(None);
             }
             tokio::time::sleep(CHECK_INTERVAL).await;
         }
@@ -1418,28 +1648,181 @@ mod tests {
     // ── The pinned compare seam ──
 
     /// Commission pin: the behind-main compare folds the bounded git
-    /// observations — tip, capped count, dirtiness — and refuses
-    /// unparseable output instead of guessing. Dirty means TRACKED
-    /// modifications: an untracked `target/` or scratch file never
-    /// blocks the lane.
+    /// observations — tip, capped count, shortlog, dirtiness — and
+    /// refuses unparseable output instead of guessing. Dirty means
+    /// TRACKED modifications: an untracked `target/` or scratch file
+    /// never blocks the lane.
     #[test]
     fn source_compare_folds_bounded_git_observations() {
-        let check = fold_source_check("3e4c79f8aa", "3\n", "?? target/\n?? notes.txt\n")
-            .expect("clean fold");
+        let check = fold_source_check(
+            "3e4c79f8aa",
+            "3\n",
+            "abc1234 fix: one thing\nabc2222 feat: another\n",
+            "?? target/\n?? notes.txt\n",
+        )
+        .expect("clean fold");
         assert_eq!(check.tip_sha, "3e4c79f8aa");
         assert_eq!(check.behind, 3);
         assert!(!check.behind_capped);
+        assert_eq!(
+            check.shortlog,
+            vec!["abc1234 fix: one thing", "abc2222 feat: another"],
+            "the shortlog rides the verdict as data lines"
+        );
         assert!(!check.dirty, "untracked files are not dirtiness");
 
-        let capped =
-            fold_source_check("abcdef012345", "500\n", "?? target/\n M src/main.rs\n").unwrap();
+        let capped = fold_source_check(
+            "abcdef012345",
+            "500\n",
+            "",
+            "?? target/\n M src/main.rs\n",
+        )
+        .unwrap();
         assert_eq!(capped.behind, BEHIND_COUNT_CAP);
         assert!(capped.behind_capped, "cap reached reads as 500+");
         assert!(capped.dirty, "a tracked modification is");
         assert!(tracked_dirty("A  staged.rs\n"), "staged changes count too");
 
-        assert!(fold_source_check("fatal: bad revision", "0", "").is_err());
-        assert!(fold_source_check("abcdef012345", "many", "").is_err());
+        assert!(fold_source_check("fatal: bad revision", "0", "", "").is_err());
+        assert!(fold_source_check("abcdef012345", "many", "", "").is_err());
+    }
+
+    /// The shortlog fold is bounded in count and width, and the width
+    /// cap lands on a char boundary (commit subjects are unicode).
+    #[test]
+    fn shortlog_fold_is_bounded() {
+        let many = (0..40)
+            .map(|n| format!("sha{n} subject {n}\n"))
+            .collect::<String>();
+        assert_eq!(fold_shortlog(&many).len(), SHORTLOG_MAX_LINES);
+
+        let wide = format!("abc1234 {}", "é".repeat(SHORTLOG_LINE_CAP));
+        let folded = fold_shortlog(&wide);
+        assert_eq!(folded.len(), 1);
+        assert!(folded[0].len() <= SHORTLOG_LINE_CAP);
+        assert!(folded[0].starts_with("abc1234 "), "truncated, not mangled");
+
+        assert!(fold_shortlog("\n  \n").is_empty(), "blank lines drop out");
+    }
+
+    // ── The channel vocabulary (the front door) ──
+
+    /// Commission pin: exactly two channels, and the catalog derives
+    /// availability + honest reasons from the install flavor — the
+    /// panel never hardcodes which lane an install can use.
+    #[test]
+    fn channel_catalog_derives_availability_and_reasons() {
+        let source = InstallFlavor::Source {
+            repo_root: PathBuf::from("/checkout"),
+            app_bundle: false,
+        };
+        let catalog = channel_catalog(&source, true);
+        assert_eq!(catalog["dev"]["check"], true);
+        assert_eq!(catalog["dev"]["produce"], true);
+        assert_eq!(catalog["releases"]["check"], true, "release data is honest anywhere");
+        assert_eq!(catalog["releases"]["produce"], false);
+        assert!(
+            catalog["releases"]["reason"]
+                .as_str()
+                .unwrap()
+                .contains("packaged macOS app"),
+            "{catalog}"
+        );
+
+        let consumer = InstallFlavor::ConsumerApp {
+            app_root: PathBuf::from("/Applications/Intendant.app"),
+        };
+        let catalog = channel_catalog(&consumer, true);
+        assert_eq!(catalog["releases"]["produce"], true);
+        assert_eq!(catalog["dev"]["check"], false);
+        assert_eq!(catalog["dev"]["produce"], false);
+        assert!(
+            catalog["dev"]["reason"]
+                .as_str()
+                .unwrap()
+                .contains("no source checkout"),
+            "{catalog}"
+        );
+        let off_macos = channel_catalog(&consumer, false);
+        assert_eq!(off_macos["releases"]["produce"], false);
+        assert!(
+            off_macos["releases"]["reason"]
+                .as_str()
+                .unwrap()
+                .contains("only the macOS app"),
+            "{off_macos}"
+        );
+
+        let unmanaged = InstallFlavor::Unmanaged {
+            reason: "stray binary".to_string(),
+        };
+        let catalog = channel_catalog(&unmanaged, true);
+        assert_eq!(catalog["releases"]["produce"], false);
+        assert_eq!(catalog["dev"]["produce"], false);
+        assert!(
+            catalog["dev"]["reason"].as_str().unwrap().contains("stray binary"),
+            "{catalog}"
+        );
+    }
+
+    /// The channel argument parser: absent means the native lane,
+    /// the two names parse, anything else is refused by name.
+    #[test]
+    fn channel_arg_parses_the_two_channel_vocabulary() {
+        assert_eq!(parse_channel_arg(""), Ok(None));
+        assert_eq!(parse_channel_arg("{}"), Ok(None));
+        assert_eq!(parse_channel_arg("not json"), Ok(None));
+        assert_eq!(
+            parse_channel_arg("{\"channel\":\"releases\"}"),
+            Ok(Some(UpdateChannel::Releases))
+        );
+        assert_eq!(
+            parse_channel_arg("{\"channel\":\"dev\"}"),
+            Ok(Some(UpdateChannel::Dev))
+        );
+        let refusal = parse_channel_arg("{\"channel\":\"nightly\"}").unwrap_err();
+        assert!(refusal.contains("nightly"), "{refusal}");
+        assert!(refusal.contains("exactly two"), "{refusal}");
+    }
+
+    /// A produce click on the wrong channel for the install refuses by
+    /// name BEFORE any network or checkout touch, and the native
+    /// channel resolves per flavor.
+    #[test]
+    fn produce_refusals_pin_channel_to_flavor() {
+        let source = InstallFlavor::Source {
+            repo_root: PathBuf::from("/checkout"),
+            app_bundle: false,
+        };
+        assert_eq!(source.native_channel(), UpdateChannel::Dev);
+        assert!(produce_refusal(&source, UpdateChannel::Dev, true).is_none());
+        let cross = produce_refusal(&source, UpdateChannel::Releases, true).unwrap();
+        assert!(cross.contains("/checkout"), "{cross}");
+
+        let bundle = InstallFlavor::Source {
+            repo_root: PathBuf::from("/checkout"),
+            app_bundle: true,
+        };
+        let cross = produce_refusal(&bundle, UpdateChannel::Releases, true).unwrap();
+        assert!(cross.contains("source build"), "{cross}");
+
+        let consumer = InstallFlavor::ConsumerApp {
+            app_root: PathBuf::from("/Applications/Intendant.app"),
+        };
+        assert_eq!(consumer.native_channel(), UpdateChannel::Releases);
+        assert!(produce_refusal(&consumer, UpdateChannel::Releases, true).is_none());
+        assert!(produce_refusal(&consumer, UpdateChannel::Dev, true)
+            .unwrap()
+            .contains("no source checkout"));
+
+        let unmanaged = InstallFlavor::Unmanaged {
+            reason: "stray".to_string(),
+        };
+        for channel in [UpdateChannel::Releases, UpdateChannel::Dev] {
+            assert!(produce_refusal(&unmanaged, channel, true)
+                .unwrap()
+                .contains("no update lane"));
+        }
     }
 
     /// Commission pin: release-vs-running is a semver compare that
@@ -1710,11 +2093,21 @@ mod tests {
         assert_eq!(block["flavor"], "unmanaged");
         assert!(block["unavailable"].is_string(), "{block}");
         assert!(block["running"]["git_sha"].is_string());
-        let refusal = lane.request_produce().unwrap_err();
+        assert_eq!(block["default_channel"], "releases");
+        assert_eq!(block["channels"]["dev"]["produce"], false, "{block}");
+        assert_eq!(block["checks"]["releases"]["in_flight"], false, "{block}");
+        let refusal = lane.request_produce(None).unwrap_err();
         assert!(refusal.contains("no update lane"), "{refusal}");
         assert!(
             !lane.job_running.load(Ordering::Acquire),
             "a refused click leaves the single-flight latch free"
+        );
+        let refusal = lane
+            .request_check(Some(UpdateChannel::Dev))
+            .unwrap_err();
+        assert!(
+            refusal.contains("no source checkout or app bundle"),
+            "a dev check on an unmanaged install refuses with the flavor's reason: {refusal}"
         );
     }
 

--- a/src/bin/caller/handover/update_lane.rs
+++ b/src/bin/caller/handover/update_lane.rs
@@ -2054,23 +2054,34 @@ mod tests {
     }
 
     /// Commission pin: the shipped dashboard bundle carries the Daemon
-    /// update panel — the Access→Daemons mount, both consent buttons,
-    /// and the two action POSTs — so the produce lane cannot be
-    /// silently gutted from the SPA (the HS6 artifact-scan pattern).
+    /// update panel — the Access→Daemons mount, the two-channel
+    /// vocabulary (Releases default, Dev behind Advanced), both consent
+    /// buttons, the action POSTs, and the swap-step composition hook —
+    /// so the front door cannot be silently gutted from the SPA (the
+    /// HS6 artifact-scan pattern).
     #[test]
     fn spa_carries_the_update_lane_panel() {
         let app = include_str!("../../../../static/app.html");
         for needle in [
             "update-lane-card",
-            "Update from main",
-            "Download & verify release",
+            "Releases — verified, signed builds (default)",
+            "Dev — build from main",
+            "Pull & build from main",
+            "Download & install release",
+            "Fetch & compare",
+            "update-lane-advanced",
+            "update-lane-shortlog",
             "/api/daemon/update-lane/produce",
             "/api/daemon/update-lane/check",
             "update_lane",
+            "intendantHandoverUpdate",
+            "renderSwapSection",
+            "Open the update panel",
+            "nothing installs or restarts automatically",
         ] {
             assert!(
                 app.contains(needle),
-                "the dashboard bundle lost the update-lane panel wiring: {needle}"
+                "the dashboard bundle lost the update-channels panel wiring: {needle}"
             );
         }
     }

--- a/src/bin/caller/handover/update_lane.rs
+++ b/src/bin/caller/handover/update_lane.rs
@@ -1671,13 +1671,8 @@ mod tests {
         );
         assert!(!check.dirty, "untracked files are not dirtiness");
 
-        let capped = fold_source_check(
-            "abcdef012345",
-            "500\n",
-            "",
-            "?? target/\n M src/main.rs\n",
-        )
-        .unwrap();
+        let capped =
+            fold_source_check("abcdef012345", "500\n", "", "?? target/\n M src/main.rs\n").unwrap();
         assert_eq!(capped.behind, BEHIND_COUNT_CAP);
         assert!(capped.behind_capped, "cap reached reads as 500+");
         assert!(capped.dirty, "a tracked modification is");
@@ -1719,7 +1714,10 @@ mod tests {
         let catalog = channel_catalog(&source, true);
         assert_eq!(catalog["dev"]["check"], true);
         assert_eq!(catalog["dev"]["produce"], true);
-        assert_eq!(catalog["releases"]["check"], true, "release data is honest anywhere");
+        assert_eq!(
+            catalog["releases"]["check"], true,
+            "release data is honest anywhere"
+        );
         assert_eq!(catalog["releases"]["produce"], false);
         assert!(
             catalog["releases"]["reason"]
@@ -1760,7 +1758,10 @@ mod tests {
         assert_eq!(catalog["releases"]["produce"], false);
         assert_eq!(catalog["dev"]["produce"], false);
         assert!(
-            catalog["dev"]["reason"].as_str().unwrap().contains("stray binary"),
+            catalog["dev"]["reason"]
+                .as_str()
+                .unwrap()
+                .contains("stray binary"),
             "{catalog}"
         );
     }
@@ -2113,9 +2114,7 @@ mod tests {
             !lane.job_running.load(Ordering::Acquire),
             "a refused click leaves the single-flight latch free"
         );
-        let refusal = lane
-            .request_check(Some(UpdateChannel::Dev))
-            .unwrap_err();
+        let refusal = lane.request_check(Some(UpdateChannel::Dev)).unwrap_err();
         assert!(
             refusal.contains("no source checkout or app bundle"),
             "a dev check on an unmanaged install refuses with the flavor's reason: {refusal}"

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -1320,6 +1320,7 @@ pub(crate) async fn serve_http_request(
                 return handle_daemon_update_lane(
                     stream,
                     false,
+                    route_body,
                     mcp_server,
                     route.cors,
                     fleet_cors_origin.as_deref(),
@@ -1330,6 +1331,7 @@ pub(crate) async fn serve_http_request(
                 return handle_daemon_update_lane(
                     stream,
                     true,
+                    route_body,
                     mcp_server,
                     route.cors,
                     fleet_cors_origin.as_deref(),

--- a/src/bin/caller/web_gateway/routes_handover.rs
+++ b/src/bin/caller/web_gateway/routes_handover.rs
@@ -103,14 +103,16 @@ pub(crate) async fn handle_daemon_handover_status(
 }
 
 /// Transport-neutral core of the two self-update-lane actions (`POST
-/// /api/daemon/update-lane/{check,produce}`). Check runs the bounded
-/// behind-ness compare; produce is the owner's consent click — it
-/// starts the supervised produce job (or refuses honestly: no lane for
-/// this install, a job already running, an unsupported platform). Both
-/// answer the lane's fresh status block so the panel renders truth
-/// immediately.
+/// /api/daemon/update-lane/{check,produce}`). The optional body names
+/// the channel (`{"channel": "releases"|"dev"}`; absent = the install's
+/// native lane). Check runs that channel's bounded compare; produce is
+/// the owner's consent click — it starts the supervised produce job (or
+/// refuses honestly: a channel this install cannot use, a job already
+/// running, an unsupported platform). Both answer the lane's fresh
+/// status block so the panel renders truth immediately.
 pub(crate) async fn daemon_update_lane_api_response(
     produce: bool,
+    body_text: &str,
     mcp_server: Option<&Arc<crate::mcp::IntendantServer>>,
 ) -> ApiResponse {
     let runtime = match mcp_server {
@@ -121,27 +123,28 @@ pub(crate) async fn daemon_update_lane_api_response(
     let Some(lane) = lane else {
         return ApiResponse::json_error(503, "the self-update lane is not wired on this daemon");
     };
-    if produce {
-        match lane.request_produce() {
-            Ok(block) => ApiResponse::json(
-                200,
-                JsonBody::Value(serde_json::json!({ "started": true, "update_lane": block })),
-            ),
-            Err(refusal) => ApiResponse::json(
-                409,
-                JsonBody::Value(serde_json::json!({
-                    "error": "update_lane_refused",
-                    "detail": refusal,
-                    "update_lane": lane.status_block(),
-                })),
-            ),
-        }
+    let channel = match crate::handover::parse_channel_arg(body_text) {
+        Ok(channel) => channel,
+        Err(refusal) => return ApiResponse::json_error(400, &refusal),
+    };
+    let outcome = if produce {
+        lane.request_produce(channel)
     } else {
-        let block = lane.request_check();
-        ApiResponse::json(
+        lane.request_check(channel)
+    };
+    match outcome {
+        Ok(block) => ApiResponse::json(
             200,
             JsonBody::Value(serde_json::json!({ "started": true, "update_lane": block })),
-        )
+        ),
+        Err(refusal) => ApiResponse::json(
+            409,
+            JsonBody::Value(serde_json::json!({
+                "error": "update_lane_refused",
+                "detail": refusal,
+                "update_lane": lane.status_block(),
+            })),
+        ),
     }
 }
 
@@ -149,11 +152,13 @@ pub(crate) async fn daemon_update_lane_api_response(
 pub(crate) async fn handle_daemon_update_lane(
     stream: DemuxStream,
     produce: bool,
+    body_text: String,
     mcp_server: Option<Arc<crate::mcp::IntendantServer>>,
     cors: crate::gateway_routes::CorsPosture,
     fleet_origin: Option<&str>,
 ) {
-    let response = daemon_update_lane_api_response(produce, mcp_server.as_ref()).await;
+    let response =
+        daemon_update_lane_api_response(produce, &body_text, mcp_server.as_ref()).await;
     write_api_response(stream, response, cors, fleet_origin).await;
 }
 

--- a/src/bin/caller/web_gateway/routes_handover.rs
+++ b/src/bin/caller/web_gateway/routes_handover.rs
@@ -157,8 +157,7 @@ pub(crate) async fn handle_daemon_update_lane(
     cors: crate::gateway_routes::CorsPosture,
     fleet_origin: Option<&str>,
 ) {
-    let response =
-        daemon_update_lane_api_response(produce, &body_text, mcp_server.as_ref()).await;
+    let response = daemon_update_lane_api_response(produce, &body_text, mcp_server.as_ref()).await;
     write_api_response(stream, response, cors, fleet_origin).await;
 }
 

--- a/static/app.html
+++ b/static/app.html
@@ -27346,6 +27346,74 @@ html.ui-v2 .update-lane-btn:disabled {
   opacity: 0.55;
   cursor: default;
 }
+
+/* ── update channels: the front door's two sections, the dev shortlog,
+   the Advanced fold, and the swap step ui2-handover renders in. ── */
+html.ui-v2 .update-lane-channel {
+  margin-top: 10px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--surface2, rgba(90, 90, 104, 0.4));
+  background: var(--surface0, rgba(24, 24, 30, 0.35));
+}
+html.ui-v2 .update-lane-channel-title {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--text, #e6e6e6);
+}
+html.ui-v2 .update-lane-shortlog {
+  margin: 4px 0 0;
+  padding: 6px 8px;
+  max-height: 180px;
+  overflow-y: auto;
+  border-radius: 6px;
+  background: var(--surface0, rgba(24, 24, 30, 0.9));
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 10px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--muted, #9aa4b2);
+}
+html.ui-v2 .update-lane-advanced {
+  margin-top: 8px;
+}
+html.ui-v2 .update-lane-advanced > summary {
+  cursor: pointer;
+  font-size: 11px;
+  color: var(--muted, #7e8896);
+}
+html.ui-v2 .update-lane-swap:not(:empty) {
+  margin-top: 10px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--accent, #62a0ea);
+  background: var(--surface0, rgba(24, 24, 30, 0.35));
+}
+html.ui-v2 .update-lane-swap-head {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text, #e6e6e6);
+}
+html.ui-v2 .update-lane-swap .handover-update-actions {
+  margin-top: 6px;
+}
+html.ui-v2 .update-lane-footer {
+  margin-top: 8px;
+  font-size: 10px;
+  color: var(--muted, #7e8896);
+}
+html.ui-v2 .handover-update-panel-link {
+  margin-top: 6px;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--accent, #62a0ea);
+  font-size: 11px;
+  cursor: pointer;
+  text-decoration: underline;
+  align-self: flex-start;
+}
 /* ── static/app/ui2-grid.css ── */
 /* ── ui-v2 Activity Grid mode: lineage lanes + session-window re-skin ──
    All scoped html.ui-v2. Grid layout (ratified 2026-07-21, candidate B
@@ -38039,7 +38107,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '75077ff6c32a322c';
+const INTENDANT_APP_BUILD = 'b1d128640e00ace5';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -102761,6 +102829,38 @@ async function memoryProposeFromForm(button) {
     if (lastHandoverBody) handoverUpdateRender(lastHandoverBody);
   };
 
+  // The update panel (ui2-update-lane) composes this SAME swap consumer
+  // instead of duplicating it: it hands over a mount element, and every
+  // chip-state render refills it — one implementation of the
+  // supervised / relay / hand-off logic, two surfaces. The mount is
+  // replaced wholesale per panel render; a disconnected mount is
+  // silently dropped.
+  let panelSwapMount = null;
+  function fillPanelSwapSection() {
+    const mount = panelSwapMount;
+    if (!mount) return;
+    if (!mount.isConnected) { panelSwapMount = null; return; }
+    mount.textContent = '';
+    const body = lastHandoverBody;
+    const update = body && body.update;
+    if (!update || body.draining) return;
+    const disk = update.on_disk;
+    const running = update.running || {};
+    const head = document.createElement('div');
+    head.className = 'update-lane-swap-head';
+    head.textContent = disk
+      ? `New build on disk: commit ${disk.git_sha || '?'} (${disk.version || '?'}, built ${disk.built_at || '?'}) — running ${running.git_sha || '?'}.`
+      : `The binary on disk changed but its provenance is unreadable${update.probe_error ? ` (${update.probe_error})` : ''}.`;
+    mount.appendChild(head);
+    if (update.honesty) {
+      const honesty = document.createElement('div');
+      honesty.className = 'handover-update-honesty';
+      honesty.textContent = update.honesty;
+      mount.appendChild(honesty);
+    }
+    mount.appendChild(handoverUpdateActions(body, disk));
+  }
+
   // The co-homed daemon a hand-off would drain toward: live, not this
   // boot, not already on its way out. Prefer one whose build matches the
   // on-disk update.
@@ -102860,6 +102960,7 @@ async function memoryProposeFromForm(button) {
   // come from probing a binary the daemon merely observed — never markup.
   function handoverUpdateRender(body) {
     lastHandoverBody = body;
+    fillPanelSwapSection();
     const update = body && body.update;
     if (!update || body.draining) { updateChipClear(); return; }
     const disk = update.on_disk;
@@ -102937,6 +103038,16 @@ async function memoryProposeFromForm(button) {
       el.appendChild(pending);
     }
     el.appendChild(handoverUpdateActions(body, disk));
+    // The pill expands into the full update panel: the chip stays the
+    // standing fact; channels, checks, and builds live there.
+    if (typeof routeTo === 'function') {
+      const panelLink = document.createElement('button');
+      panelLink.type = 'button';
+      panelLink.className = 'handover-update-panel-link';
+      panelLink.textContent = 'Open the update panel';
+      panelLink.addEventListener('click', () => routeTo('access', 'daemons'));
+      el.appendChild(panelLink);
+    }
   }
 
   function handoverBanner() {
@@ -103014,6 +103125,15 @@ async function memoryProposeFromForm(button) {
     stateKey: updateChipStateKey,
   };
 
+  // The update panel's composition hook (production, not QA): the panel
+  // registers its swap mount here and this module keeps it honest.
+  window.intendantHandoverUpdate = {
+    renderSwapSection: (mount) => {
+      panelSwapMount = mount;
+      fillPanelSwapSection();
+    },
+  };
+
   function handoverStart() {
     handoverPoll();
     setInterval(handoverPoll, HANDOVER_POLL_MS);
@@ -103025,21 +103145,30 @@ async function memoryProposeFromForm(button) {
   }
 })();
 /* ── static/app/ui2-update-lane.js ── */
-// ── ui2-update-lane — the self-update panel (Access → Daemons) ──────
-// Sits beside the daemons list's provenance rows and renders the
-// daemon's `update_lane` block from GET /api/daemon/handover: install
-// flavor, the bounded behind-origin-main / behind-latest-release check,
-// and the produce job's live phase + log tail. The buttons are the
-// owner's consent surface: POST /api/daemon/update-lane/{check,produce}
+// ── ui2-update-lane — the update panel (Access → Daemons) ───────────
+// The check-for-updates front door over the daemon's `update_lane`
+// block (GET /api/daemon/handover): running provenance, the two-channel
+// vocabulary — Releases (default; logged, PGP-verified builds) and
+// Dev — build from main (power-user lane behind the Advanced fold) —
+// each channel's bounded check as data (release compare; behind-count +
+// shortlog), and the produce job's live phase + log tail with real
+// errors verbatim. Which channel an install can check/produce comes
+// from the payload's `channels` catalog, never hardcoded here. The
+// buttons are the owner's consent surface: POST
+// /api/daemon/update-lane/{check,produce} with {"channel": …}
 // (HTTP-only by design — a tunnel-only remote surface watches progress
 // here but cannot click a build onto the box; the catch renders that
 // honestly). Producing lands a newer binary at the watched path; the
-// EXISTING update chip + one-click swap lane takes over from there.
-// textContent construction throughout: repo paths, versions, and child
-// process log lines are observed strings, never markup.
+// swap step below is the EXISTING chip consumer (ui2-handover renders
+// it into this panel's mount — one swap implementation, two surfaces).
+// Nothing here updates anything without an explicit click.
+// textContent construction throughout: repo paths, versions, commit
+// subjects, and child process log lines are observed strings, never
+// markup.
 (() => {
   const UPDATE_LANE_POLL_MS = 30000;
   const UPDATE_LANE_BUSY_POLL_MS = 3000;
+  const ADVANCED_OPEN_KEY = 'update-lane-advanced-open';
   const action = { inFlight: false, note: '' };
   let lastBlock = null;
   let pollTimer = null;
@@ -103048,7 +103177,17 @@ async function memoryProposeFromForm(button) {
     return document.getElementById('update-lane-card');
   }
 
-  async function updateLanePost(path) {
+  function advancedOpenStored() {
+    try { return localStorage.getItem(ADVANCED_OPEN_KEY) === '1'; } catch (_) { return false; }
+  }
+  function advancedOpenStore(open) {
+    try {
+      if (open) localStorage.setItem(ADVANCED_OPEN_KEY, '1');
+      else localStorage.removeItem(ADVANCED_OPEN_KEY);
+    } catch (_) { /* storage unavailable — the fold lives for this page only */ }
+  }
+
+  async function updateLanePost(path, channel) {
     if (action.inFlight) return;
     action.inFlight = true;
     action.note = '';
@@ -103057,7 +103196,7 @@ async function memoryProposeFromForm(button) {
       const resp = await authedFetch(path, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: '{}',
+        body: JSON.stringify({ channel }),
       });
       let body = null;
       try { body = await resp.json(); } catch (_) { /* non-JSON error body */ }
@@ -103076,12 +103215,12 @@ async function memoryProposeFromForm(button) {
     }
   }
 
-  function actionButton(label, path, disabled) {
+  function actionButton(label, path, channel, disabled) {
     const btn = document.createElement('button');
     btn.className = 'update-lane-btn';
     btn.textContent = label;
     btn.disabled = Boolean(disabled) || action.inFlight;
-    btn.addEventListener('click', () => updateLanePost(path));
+    btn.addEventListener('click', () => updateLanePost(path, channel));
     return btn;
   }
 
@@ -103093,49 +103232,104 @@ async function memoryProposeFromForm(button) {
     return el;
   }
 
-  function describeCheck(block, body) {
-    const check = block.check || {};
-    const running = block.running || {};
+  // ── Channel sections (availability + data come from the payload) ──
+
+  function channelInfo(block, name) {
+    return (block.channels && block.channels[name]) || { check: false, produce: false };
+  }
+  function channelCheck(block, name) {
+    return (block.checks && block.checks[name]) || {};
+  }
+
+  // The releases check as data: latest logged release vs the running
+  // package version.
+  function describeReleasesCheck(check, running, body) {
     if (check.error) {
-      line(body, 'update-lane-error', `Check failed: ${check.error}`);
+      line(body, 'update-lane-error', `Release check failed: ${check.error}`);
       return { behind: false };
     }
-    if (block.flavor === 'source') {
-      if (typeof check.behind !== 'number') {
-        line(body, 'update-lane-note', check.in_flight
-          ? 'Checking origin/main…'
-          : 'Not checked yet.');
-        return { behind: false };
-      }
-      const capped = check.behind_capped ? '+' : '';
-      if (check.behind > 0) {
-        line(body, 'update-lane-status',
-          `Behind origin/main by ${check.behind}${capped} commit${check.behind === 1 ? '' : 's'} `
-          + `(tip ${String(check.tip_sha || '').slice(0, 10)} — running ${running.git_sha || '?'}).`);
-      } else {
-        line(body, 'update-lane-note',
-          `Up to date with origin/main (running ${running.git_sha || '?'}).`);
-      }
-      if (check.dirty) {
-        line(body, 'update-lane-note',
-          'The checkout has local changes — the update will refuse to pull over them.');
-      }
-      return { behind: check.behind > 0 };
+    if (!check.latest_tag) {
+      line(body, 'update-lane-note', check.in_flight
+        ? 'Checking the latest logged release…'
+        : 'Not checked yet.');
+      return { behind: false };
     }
-    if (block.flavor === 'consumer-app') {
-      if (!check.latest_tag) {
-        line(body, 'update-lane-note', check.in_flight
-          ? 'Checking the latest logged release…'
-          : 'Not checked yet.');
-        return { behind: false };
-      }
-      const behind = Number(check.behind) > 0;
-      line(body, behind ? 'update-lane-status' : 'update-lane-note',
-        `Latest logged release: ${check.latest_tag} (${check.latest_version}) — running ${running.version || '?'}.`
-        + (check.compare_error ? ` ${check.compare_error}.` : ''));
-      return { behind };
+    const behind = Number(check.behind) > 0;
+    line(body, behind ? 'update-lane-status' : 'update-lane-note',
+      `Latest logged release: ${check.latest_tag} (${check.latest_version}) — running ${running.version || '?'}.`
+      + (check.compare_error ? ` ${check.compare_error}.` : ''));
+    return { behind };
+  }
+
+  // The dev check as data: behind-count + the bounded shortlog.
+  function describeDevCheck(check, running, body) {
+    if (check.error) {
+      line(body, 'update-lane-error', `Compare failed: ${check.error}`);
+      return { behind: false };
     }
-    return { behind: false };
+    if (typeof check.behind !== 'number') {
+      line(body, 'update-lane-note', check.in_flight
+        ? 'Fetching origin and comparing…'
+        : 'Not checked yet.');
+      return { behind: false };
+    }
+    const capped = check.behind_capped ? '+' : '';
+    if (check.behind > 0) {
+      line(body, 'update-lane-status',
+        `Behind origin/main by ${check.behind}${capped} commit${check.behind === 1 ? '' : 's'} `
+        + `(tip ${String(check.tip_sha || '').slice(0, 10)} — running ${running.git_sha || '?'}).`);
+      const shortlog = Array.isArray(check.shortlog) ? check.shortlog : [];
+      if (shortlog.length) {
+        const log = document.createElement('pre');
+        log.className = 'update-lane-shortlog';
+        log.textContent = shortlog.join('\n')
+          + (check.behind > shortlog.length ? `\n… and ${check.behind}${capped === '+' ? '+' : ''} total` : '');
+        body.appendChild(log);
+      }
+    } else {
+      line(body, 'update-lane-note',
+        `Up to date with origin/main (running ${running.git_sha || '?'}).`);
+    }
+    if (check.dirty) {
+      line(body, 'update-lane-note',
+        'The checkout has local changes to tracked files — a build will refuse to pull over them.');
+    }
+    return { behind: check.behind > 0 };
+  }
+
+  // One channel's section: data, then the consent buttons this install
+  // actually supports — an unavailable produce renders its reason
+  // instead of a button that cannot mean what it says.
+  function channelSection(block, name, title, jobRunning, describe, checkLabel, produceLabel) {
+    const info = channelInfo(block, name);
+    const check = channelCheck(block, name);
+    const section = document.createElement('div');
+    section.className = 'update-lane-channel';
+    line(section, 'update-lane-channel-title', title);
+    const body = document.createElement('div');
+    body.className = 'update-lane-body';
+    section.appendChild(body);
+    const verdict = info.check
+      ? describe(check, block.running || {}, body)
+      : { behind: false };
+    if (!info.produce && info.reason) {
+      line(body, 'update-lane-note', info.reason);
+    }
+    const actions = document.createElement('div');
+    actions.className = 'update-lane-actions';
+    if (info.check) {
+      actions.appendChild(actionButton(checkLabel, '/api/daemon/update-lane/check', name,
+        jobRunning || Boolean(check.in_flight)));
+    }
+    if (info.produce) {
+      actions.appendChild(actionButton(
+        jobRunning ? 'Working…' : produceLabel,
+        '/api/daemon/update-lane/produce', name,
+        jobRunning || !verdict.behind,
+      ));
+    }
+    if (actions.childElementCount) section.appendChild(actions);
+    return section;
   }
 
   function describeJob(block, body) {
@@ -103183,6 +103377,9 @@ async function memoryProposeFromForm(button) {
 
     const body = document.createElement('div');
     body.className = 'update-lane-body';
+    const running = block.running || {};
+    line(body, 'update-lane-note',
+      `Running: commit ${running.git_sha || '?'} · v${running.version || '?'} · built ${running.built_at || '?'}`);
     if (block.flavor === 'source' && block.repo_root) {
       line(body, 'update-lane-note', `Checkout: ${block.repo_root}${block.app_bundle ? ' (app bundle)' : ''}`);
     } else if (block.flavor === 'consumer-app' && block.app_root) {
@@ -103192,33 +103389,51 @@ async function memoryProposeFromForm(button) {
       line(body, 'update-lane-note', block.unavailable);
     }
 
-    const verdict = describeCheck(block, body);
     const jobRunning = describeJob(block, body);
-
     if (action.note) line(body, 'update-lane-note', action.note);
-
-    const actions = document.createElement('div');
-    actions.className = 'update-lane-actions';
-    if (!block.unavailable) {
-      if (block.flavor === 'source') {
-        actions.appendChild(actionButton(
-          jobRunning ? 'Updating…' : 'Update from main',
-          '/api/daemon/update-lane/produce',
-          jobRunning || !verdict.behind,
-        ));
-      } else if (block.flavor === 'consumer-app') {
-        actions.appendChild(actionButton(
-          jobRunning ? 'Updating…' : 'Download & verify release',
-          '/api/daemon/update-lane/produce',
-          jobRunning || !verdict.behind,
-        ));
-      }
-      actions.appendChild(actionButton('Check now', '/api/daemon/update-lane/check',
-        jobRunning || Boolean(block.check && block.check.in_flight)));
-    }
     card.appendChild(body);
-    if (actions.childElementCount) card.appendChild(actions);
+
+    // Releases — the default channel, for everyone.
+    card.appendChild(channelSection(
+      block, 'releases', 'Releases — verified, signed builds (default)', jobRunning,
+      describeReleasesCheck, 'Check latest release', 'Download & install release',
+    ));
+
+    // Dev — build from main, one obvious click deeper.
+    const advanced = document.createElement('details');
+    advanced.className = 'update-lane-advanced';
+    if (advancedOpenStored()) advanced.open = true;
+    advanced.addEventListener('toggle', () => advancedOpenStore(advanced.open));
+    const summary = document.createElement('summary');
+    summary.textContent = 'Advanced';
+    advanced.appendChild(summary);
+    advanced.appendChild(channelSection(
+      block, 'dev', 'Dev — build from main', jobRunning,
+      describeDevCheck, 'Fetch & compare', 'Pull & build from main',
+    ));
+    card.appendChild(advanced);
+
+    // The swap step: rendered by the EXISTING chip consumer
+    // (ui2-handover) into this mount — supervisor-claimed one-click
+    // when the daemon is app-supervised, its honest reach otherwise.
+    // Empty while no newer build sits on disk.
+    const swap = document.createElement('div');
+    swap.className = 'update-lane-swap';
+    card.appendChild(swap);
+    if (window.intendantHandoverUpdate
+        && typeof window.intendantHandoverUpdate.renderSwapSection === 'function') {
+      window.intendantHandoverUpdate.renderSwapSection(swap);
+    }
+
+    line(card, 'update-lane-footer',
+      'Updates happen only on your click here — nothing installs or restarts automatically.');
     mount.appendChild(card);
+  }
+
+  function anyCheckInFlight(block) {
+    if (!block || !block.checks) return false;
+    return ['releases', 'dev'].some((name) =>
+      block.checks[name] && block.checks[name].in_flight);
   }
 
   async function poll() {
@@ -103234,7 +103449,7 @@ async function memoryProposeFromForm(button) {
     if (pollTimer) clearTimeout(pollTimer);
     const busy = Boolean(lastBlock && (
       (lastBlock.job && !('ok' in lastBlock.job)) ||
-      (lastBlock.check && lastBlock.check.in_flight)));
+      anyCheckInFlight(lastBlock)));
     pollTimer = setTimeout(async () => {
       await poll();
       schedulePoll(false);

--- a/static/app/ui2-handover.css
+++ b/static/app/ui2-handover.css
@@ -194,3 +194,71 @@ html.ui-v2 .update-lane-btn:disabled {
   opacity: 0.55;
   cursor: default;
 }
+
+/* ── update channels: the front door's two sections, the dev shortlog,
+   the Advanced fold, and the swap step ui2-handover renders in. ── */
+html.ui-v2 .update-lane-channel {
+  margin-top: 10px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--surface2, rgba(90, 90, 104, 0.4));
+  background: var(--surface0, rgba(24, 24, 30, 0.35));
+}
+html.ui-v2 .update-lane-channel-title {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--text, #e6e6e6);
+}
+html.ui-v2 .update-lane-shortlog {
+  margin: 4px 0 0;
+  padding: 6px 8px;
+  max-height: 180px;
+  overflow-y: auto;
+  border-radius: 6px;
+  background: var(--surface0, rgba(24, 24, 30, 0.9));
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 10px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--muted, #9aa4b2);
+}
+html.ui-v2 .update-lane-advanced {
+  margin-top: 8px;
+}
+html.ui-v2 .update-lane-advanced > summary {
+  cursor: pointer;
+  font-size: 11px;
+  color: var(--muted, #7e8896);
+}
+html.ui-v2 .update-lane-swap:not(:empty) {
+  margin-top: 10px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--accent, #62a0ea);
+  background: var(--surface0, rgba(24, 24, 30, 0.35));
+}
+html.ui-v2 .update-lane-swap-head {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text, #e6e6e6);
+}
+html.ui-v2 .update-lane-swap .handover-update-actions {
+  margin-top: 6px;
+}
+html.ui-v2 .update-lane-footer {
+  margin-top: 8px;
+  font-size: 10px;
+  color: var(--muted, #7e8896);
+}
+html.ui-v2 .handover-update-panel-link {
+  margin-top: 6px;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--accent, #62a0ea);
+  font-size: 11px;
+  cursor: pointer;
+  text-decoration: underline;
+  align-self: flex-start;
+}

--- a/static/app/ui2-handover.js
+++ b/static/app/ui2-handover.js
@@ -119,6 +119,38 @@
     if (lastHandoverBody) handoverUpdateRender(lastHandoverBody);
   };
 
+  // The update panel (ui2-update-lane) composes this SAME swap consumer
+  // instead of duplicating it: it hands over a mount element, and every
+  // chip-state render refills it — one implementation of the
+  // supervised / relay / hand-off logic, two surfaces. The mount is
+  // replaced wholesale per panel render; a disconnected mount is
+  // silently dropped.
+  let panelSwapMount = null;
+  function fillPanelSwapSection() {
+    const mount = panelSwapMount;
+    if (!mount) return;
+    if (!mount.isConnected) { panelSwapMount = null; return; }
+    mount.textContent = '';
+    const body = lastHandoverBody;
+    const update = body && body.update;
+    if (!update || body.draining) return;
+    const disk = update.on_disk;
+    const running = update.running || {};
+    const head = document.createElement('div');
+    head.className = 'update-lane-swap-head';
+    head.textContent = disk
+      ? `New build on disk: commit ${disk.git_sha || '?'} (${disk.version || '?'}, built ${disk.built_at || '?'}) — running ${running.git_sha || '?'}.`
+      : `The binary on disk changed but its provenance is unreadable${update.probe_error ? ` (${update.probe_error})` : ''}.`;
+    mount.appendChild(head);
+    if (update.honesty) {
+      const honesty = document.createElement('div');
+      honesty.className = 'handover-update-honesty';
+      honesty.textContent = update.honesty;
+      mount.appendChild(honesty);
+    }
+    mount.appendChild(handoverUpdateActions(body, disk));
+  }
+
   // The co-homed daemon a hand-off would drain toward: live, not this
   // boot, not already on its way out. Prefer one whose build matches the
   // on-disk update.
@@ -218,6 +250,7 @@
   // come from probing a binary the daemon merely observed — never markup.
   function handoverUpdateRender(body) {
     lastHandoverBody = body;
+    fillPanelSwapSection();
     const update = body && body.update;
     if (!update || body.draining) { updateChipClear(); return; }
     const disk = update.on_disk;
@@ -295,6 +328,16 @@
       el.appendChild(pending);
     }
     el.appendChild(handoverUpdateActions(body, disk));
+    // The pill expands into the full update panel: the chip stays the
+    // standing fact; channels, checks, and builds live there.
+    if (typeof routeTo === 'function') {
+      const panelLink = document.createElement('button');
+      panelLink.type = 'button';
+      panelLink.className = 'handover-update-panel-link';
+      panelLink.textContent = 'Open the update panel';
+      panelLink.addEventListener('click', () => routeTo('access', 'daemons'));
+      el.appendChild(panelLink);
+    }
   }
 
   function handoverBanner() {
@@ -370,6 +413,15 @@
   window.qa.handoverUpdateChip = {
     render: (body) => handoverUpdateRender(body),
     stateKey: updateChipStateKey,
+  };
+
+  // The update panel's composition hook (production, not QA): the panel
+  // registers its swap mount here and this module keeps it honest.
+  window.intendantHandoverUpdate = {
+    renderSwapSection: (mount) => {
+      panelSwapMount = mount;
+      fillPanelSwapSection();
+    },
   };
 
   function handoverStart() {

--- a/static/app/ui2-update-lane.js
+++ b/static/app/ui2-update-lane.js
@@ -1,18 +1,27 @@
-// ── ui2-update-lane — the self-update panel (Access → Daemons) ──────
-// Sits beside the daemons list's provenance rows and renders the
-// daemon's `update_lane` block from GET /api/daemon/handover: install
-// flavor, the bounded behind-origin-main / behind-latest-release check,
-// and the produce job's live phase + log tail. The buttons are the
-// owner's consent surface: POST /api/daemon/update-lane/{check,produce}
+// ── ui2-update-lane — the update panel (Access → Daemons) ───────────
+// The check-for-updates front door over the daemon's `update_lane`
+// block (GET /api/daemon/handover): running provenance, the two-channel
+// vocabulary — Releases (default; logged, PGP-verified builds) and
+// Dev — build from main (power-user lane behind the Advanced fold) —
+// each channel's bounded check as data (release compare; behind-count +
+// shortlog), and the produce job's live phase + log tail with real
+// errors verbatim. Which channel an install can check/produce comes
+// from the payload's `channels` catalog, never hardcoded here. The
+// buttons are the owner's consent surface: POST
+// /api/daemon/update-lane/{check,produce} with {"channel": …}
 // (HTTP-only by design — a tunnel-only remote surface watches progress
 // here but cannot click a build onto the box; the catch renders that
 // honestly). Producing lands a newer binary at the watched path; the
-// EXISTING update chip + one-click swap lane takes over from there.
-// textContent construction throughout: repo paths, versions, and child
-// process log lines are observed strings, never markup.
+// swap step below is the EXISTING chip consumer (ui2-handover renders
+// it into this panel's mount — one swap implementation, two surfaces).
+// Nothing here updates anything without an explicit click.
+// textContent construction throughout: repo paths, versions, commit
+// subjects, and child process log lines are observed strings, never
+// markup.
 (() => {
   const UPDATE_LANE_POLL_MS = 30000;
   const UPDATE_LANE_BUSY_POLL_MS = 3000;
+  const ADVANCED_OPEN_KEY = 'update-lane-advanced-open';
   const action = { inFlight: false, note: '' };
   let lastBlock = null;
   let pollTimer = null;
@@ -21,7 +30,17 @@
     return document.getElementById('update-lane-card');
   }
 
-  async function updateLanePost(path) {
+  function advancedOpenStored() {
+    try { return localStorage.getItem(ADVANCED_OPEN_KEY) === '1'; } catch (_) { return false; }
+  }
+  function advancedOpenStore(open) {
+    try {
+      if (open) localStorage.setItem(ADVANCED_OPEN_KEY, '1');
+      else localStorage.removeItem(ADVANCED_OPEN_KEY);
+    } catch (_) { /* storage unavailable — the fold lives for this page only */ }
+  }
+
+  async function updateLanePost(path, channel) {
     if (action.inFlight) return;
     action.inFlight = true;
     action.note = '';
@@ -30,7 +49,7 @@
       const resp = await authedFetch(path, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: '{}',
+        body: JSON.stringify({ channel }),
       });
       let body = null;
       try { body = await resp.json(); } catch (_) { /* non-JSON error body */ }
@@ -49,12 +68,12 @@
     }
   }
 
-  function actionButton(label, path, disabled) {
+  function actionButton(label, path, channel, disabled) {
     const btn = document.createElement('button');
     btn.className = 'update-lane-btn';
     btn.textContent = label;
     btn.disabled = Boolean(disabled) || action.inFlight;
-    btn.addEventListener('click', () => updateLanePost(path));
+    btn.addEventListener('click', () => updateLanePost(path, channel));
     return btn;
   }
 
@@ -66,49 +85,104 @@
     return el;
   }
 
-  function describeCheck(block, body) {
-    const check = block.check || {};
-    const running = block.running || {};
+  // ── Channel sections (availability + data come from the payload) ──
+
+  function channelInfo(block, name) {
+    return (block.channels && block.channels[name]) || { check: false, produce: false };
+  }
+  function channelCheck(block, name) {
+    return (block.checks && block.checks[name]) || {};
+  }
+
+  // The releases check as data: latest logged release vs the running
+  // package version.
+  function describeReleasesCheck(check, running, body) {
     if (check.error) {
-      line(body, 'update-lane-error', `Check failed: ${check.error}`);
+      line(body, 'update-lane-error', `Release check failed: ${check.error}`);
       return { behind: false };
     }
-    if (block.flavor === 'source') {
-      if (typeof check.behind !== 'number') {
-        line(body, 'update-lane-note', check.in_flight
-          ? 'Checking origin/main…'
-          : 'Not checked yet.');
-        return { behind: false };
-      }
-      const capped = check.behind_capped ? '+' : '';
-      if (check.behind > 0) {
-        line(body, 'update-lane-status',
-          `Behind origin/main by ${check.behind}${capped} commit${check.behind === 1 ? '' : 's'} `
-          + `(tip ${String(check.tip_sha || '').slice(0, 10)} — running ${running.git_sha || '?'}).`);
-      } else {
-        line(body, 'update-lane-note',
-          `Up to date with origin/main (running ${running.git_sha || '?'}).`);
-      }
-      if (check.dirty) {
-        line(body, 'update-lane-note',
-          'The checkout has local changes — the update will refuse to pull over them.');
-      }
-      return { behind: check.behind > 0 };
+    if (!check.latest_tag) {
+      line(body, 'update-lane-note', check.in_flight
+        ? 'Checking the latest logged release…'
+        : 'Not checked yet.');
+      return { behind: false };
     }
-    if (block.flavor === 'consumer-app') {
-      if (!check.latest_tag) {
-        line(body, 'update-lane-note', check.in_flight
-          ? 'Checking the latest logged release…'
-          : 'Not checked yet.');
-        return { behind: false };
-      }
-      const behind = Number(check.behind) > 0;
-      line(body, behind ? 'update-lane-status' : 'update-lane-note',
-        `Latest logged release: ${check.latest_tag} (${check.latest_version}) — running ${running.version || '?'}.`
-        + (check.compare_error ? ` ${check.compare_error}.` : ''));
-      return { behind };
+    const behind = Number(check.behind) > 0;
+    line(body, behind ? 'update-lane-status' : 'update-lane-note',
+      `Latest logged release: ${check.latest_tag} (${check.latest_version}) — running ${running.version || '?'}.`
+      + (check.compare_error ? ` ${check.compare_error}.` : ''));
+    return { behind };
+  }
+
+  // The dev check as data: behind-count + the bounded shortlog.
+  function describeDevCheck(check, running, body) {
+    if (check.error) {
+      line(body, 'update-lane-error', `Compare failed: ${check.error}`);
+      return { behind: false };
     }
-    return { behind: false };
+    if (typeof check.behind !== 'number') {
+      line(body, 'update-lane-note', check.in_flight
+        ? 'Fetching origin and comparing…'
+        : 'Not checked yet.');
+      return { behind: false };
+    }
+    const capped = check.behind_capped ? '+' : '';
+    if (check.behind > 0) {
+      line(body, 'update-lane-status',
+        `Behind origin/main by ${check.behind}${capped} commit${check.behind === 1 ? '' : 's'} `
+        + `(tip ${String(check.tip_sha || '').slice(0, 10)} — running ${running.git_sha || '?'}).`);
+      const shortlog = Array.isArray(check.shortlog) ? check.shortlog : [];
+      if (shortlog.length) {
+        const log = document.createElement('pre');
+        log.className = 'update-lane-shortlog';
+        log.textContent = shortlog.join('\n')
+          + (check.behind > shortlog.length ? `\n… and ${check.behind}${capped === '+' ? '+' : ''} total` : '');
+        body.appendChild(log);
+      }
+    } else {
+      line(body, 'update-lane-note',
+        `Up to date with origin/main (running ${running.git_sha || '?'}).`);
+    }
+    if (check.dirty) {
+      line(body, 'update-lane-note',
+        'The checkout has local changes to tracked files — a build will refuse to pull over them.');
+    }
+    return { behind: check.behind > 0 };
+  }
+
+  // One channel's section: data, then the consent buttons this install
+  // actually supports — an unavailable produce renders its reason
+  // instead of a button that cannot mean what it says.
+  function channelSection(block, name, title, jobRunning, describe, checkLabel, produceLabel) {
+    const info = channelInfo(block, name);
+    const check = channelCheck(block, name);
+    const section = document.createElement('div');
+    section.className = 'update-lane-channel';
+    line(section, 'update-lane-channel-title', title);
+    const body = document.createElement('div');
+    body.className = 'update-lane-body';
+    section.appendChild(body);
+    const verdict = info.check
+      ? describe(check, block.running || {}, body)
+      : { behind: false };
+    if (!info.produce && info.reason) {
+      line(body, 'update-lane-note', info.reason);
+    }
+    const actions = document.createElement('div');
+    actions.className = 'update-lane-actions';
+    if (info.check) {
+      actions.appendChild(actionButton(checkLabel, '/api/daemon/update-lane/check', name,
+        jobRunning || Boolean(check.in_flight)));
+    }
+    if (info.produce) {
+      actions.appendChild(actionButton(
+        jobRunning ? 'Working…' : produceLabel,
+        '/api/daemon/update-lane/produce', name,
+        jobRunning || !verdict.behind,
+      ));
+    }
+    if (actions.childElementCount) section.appendChild(actions);
+    return section;
   }
 
   function describeJob(block, body) {
@@ -156,6 +230,9 @@
 
     const body = document.createElement('div');
     body.className = 'update-lane-body';
+    const running = block.running || {};
+    line(body, 'update-lane-note',
+      `Running: commit ${running.git_sha || '?'} · v${running.version || '?'} · built ${running.built_at || '?'}`);
     if (block.flavor === 'source' && block.repo_root) {
       line(body, 'update-lane-note', `Checkout: ${block.repo_root}${block.app_bundle ? ' (app bundle)' : ''}`);
     } else if (block.flavor === 'consumer-app' && block.app_root) {
@@ -165,33 +242,51 @@
       line(body, 'update-lane-note', block.unavailable);
     }
 
-    const verdict = describeCheck(block, body);
     const jobRunning = describeJob(block, body);
-
     if (action.note) line(body, 'update-lane-note', action.note);
-
-    const actions = document.createElement('div');
-    actions.className = 'update-lane-actions';
-    if (!block.unavailable) {
-      if (block.flavor === 'source') {
-        actions.appendChild(actionButton(
-          jobRunning ? 'Updating…' : 'Update from main',
-          '/api/daemon/update-lane/produce',
-          jobRunning || !verdict.behind,
-        ));
-      } else if (block.flavor === 'consumer-app') {
-        actions.appendChild(actionButton(
-          jobRunning ? 'Updating…' : 'Download & verify release',
-          '/api/daemon/update-lane/produce',
-          jobRunning || !verdict.behind,
-        ));
-      }
-      actions.appendChild(actionButton('Check now', '/api/daemon/update-lane/check',
-        jobRunning || Boolean(block.check && block.check.in_flight)));
-    }
     card.appendChild(body);
-    if (actions.childElementCount) card.appendChild(actions);
+
+    // Releases — the default channel, for everyone.
+    card.appendChild(channelSection(
+      block, 'releases', 'Releases — verified, signed builds (default)', jobRunning,
+      describeReleasesCheck, 'Check latest release', 'Download & install release',
+    ));
+
+    // Dev — build from main, one obvious click deeper.
+    const advanced = document.createElement('details');
+    advanced.className = 'update-lane-advanced';
+    if (advancedOpenStored()) advanced.open = true;
+    advanced.addEventListener('toggle', () => advancedOpenStore(advanced.open));
+    const summary = document.createElement('summary');
+    summary.textContent = 'Advanced';
+    advanced.appendChild(summary);
+    advanced.appendChild(channelSection(
+      block, 'dev', 'Dev — build from main', jobRunning,
+      describeDevCheck, 'Fetch & compare', 'Pull & build from main',
+    ));
+    card.appendChild(advanced);
+
+    // The swap step: rendered by the EXISTING chip consumer
+    // (ui2-handover) into this mount — supervisor-claimed one-click
+    // when the daemon is app-supervised, its honest reach otherwise.
+    // Empty while no newer build sits on disk.
+    const swap = document.createElement('div');
+    swap.className = 'update-lane-swap';
+    card.appendChild(swap);
+    if (window.intendantHandoverUpdate
+        && typeof window.intendantHandoverUpdate.renderSwapSection === 'function') {
+      window.intendantHandoverUpdate.renderSwapSection(swap);
+    }
+
+    line(card, 'update-lane-footer',
+      'Updates happen only on your click here — nothing installs or restarts automatically.');
     mount.appendChild(card);
+  }
+
+  function anyCheckInFlight(block) {
+    if (!block || !block.checks) return false;
+    return ['releases', 'dev'].some((name) =>
+      block.checks[name] && block.checks[name].in_flight);
   }
 
   async function poll() {
@@ -207,7 +302,7 @@
     if (pollTimer) clearTimeout(pollTimer);
     const busy = Boolean(lastBlock && (
       (lastBlock.job && !('ok' in lastBlock.job)) ||
-      (lastBlock.check && lastBlock.check.in_flight)));
+      anyCheckInFlight(lastBlock)));
     pollTimer = setTimeout(async () => {
       await poll();
       schedulePoll(false);

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -7526,7 +7526,10 @@ async fn update_lane_source_click_produces_artifact_and_chips() {
         .expect("shortlog rides the dev check");
     assert_eq!(shortlog.len(), 1, "{body}");
     assert!(
-        shortlog[0].as_str().unwrap_or_default().contains("commit B"),
+        shortlog[0]
+            .as_str()
+            .unwrap_or_default()
+            .contains("commit B"),
         "the shortlog carries the behind commit's subject: {body}"
     );
     assert_eq!(

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -7461,10 +7461,38 @@ async fn update_lane_source_click_produces_artifact_and_chips() {
     assert_eq!(body["update_lane"]["flavor"], "source", "{body}");
     assert!(body.get("update").is_none(), "no chip before any change");
 
-    // The bounded compare: behind origin/main by exactly commit B.
+    // The two-channel front door: a produce click on the channel this
+    // install cannot use refuses by name BEFORE touching anything (the
+    // fixture daemon is source-flavored; releases would install an app).
+    let cross: reqwest::Response = authed
+        .post(format!("{base}/api/daemon/update-lane/produce"))
+        .json(&serde_json::json!({"channel": "releases"}))
+        .send()
+        .await
+        .expect("POST cross-channel produce");
+    assert_eq!(cross.status(), 409, "cross-channel produce refuses");
+    let cross: serde_json::Value = cross.json().await.expect("refusal body");
+    assert!(
+        cross["detail"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("packaged macOS app"),
+        "the refusal names the mismatch: {cross}"
+    );
+    // And the vocabulary is exactly two: an unknown channel is a 400.
+    let unknown = authed
+        .post(format!("{base}/api/daemon/update-lane/check"))
+        .json(&serde_json::json!({"channel": "nightly"}))
+        .send()
+        .await
+        .expect("POST unknown-channel check");
+    assert_eq!(unknown.status(), 400, "unknown channel refused by name");
+
+    // The bounded dev compare (named explicitly): behind origin/main by
+    // exactly commit B, with the shortlog riding as data.
     let check: serde_json::Value = authed
         .post(format!("{base}/api/daemon/update-lane/check"))
-        .json(&serde_json::json!({}))
+        .json(&serde_json::json!({"channel": "dev"}))
         .send()
         .await
         .expect("POST update-lane check")
@@ -7479,7 +7507,7 @@ async fn update_lane_source_click_produces_artifact_and_chips() {
         RUN_TIMEOUT,
         || async {
             let body = http_get_json(&authed, &status_url).await?;
-            (body["update_lane"]["check"]["behind"] == 1).then_some(body)
+            (body["update_lane"]["checks"]["dev"]["behind"] == 1).then_some(body)
         },
         || {
             std::fs::read_to_string(rig.home.path().join("daemon.log"))
@@ -7489,10 +7517,27 @@ async fn update_lane_source_click_produces_artifact_and_chips() {
     )
     .await;
     assert_eq!(
-        body["update_lane"]["check"]["tip_sha"], sha_b,
+        body["update_lane"]["checks"]["dev"]["tip_sha"], sha_b,
         "the compare names origin/main's tip: {body}"
     );
-    assert_eq!(body["update_lane"]["check"]["dirty"], false);
+    assert_eq!(body["update_lane"]["checks"]["dev"]["dirty"], false);
+    let shortlog = body["update_lane"]["checks"]["dev"]["shortlog"]
+        .as_array()
+        .expect("shortlog rides the dev check");
+    assert_eq!(shortlog.len(), 1, "{body}");
+    assert!(
+        shortlog[0].as_str().unwrap_or_default().contains("commit B"),
+        "the shortlog carries the behind commit's subject: {body}"
+    );
+    assert_eq!(
+        body["update_lane"]["channels"]["dev"]["produce"], true,
+        "the catalog offers dev produce on a source install: {body}"
+    );
+    assert_eq!(
+        body["update_lane"]["channels"]["releases"]["produce"], false,
+        "the catalog withholds releases produce on a source install: {body}"
+    );
+    assert_eq!(body["update_lane"]["default_channel"], "releases");
 
     // The owner's click: pull (real) + build (mock) + verify. The job
     // finishes ok and reports the produced commit.


### PR DESCRIPTION
Commission 01KYX455X4A82W9PA0HAAFH11V: compose the shipped self-update produce lane (#681), the update watch, and the one-click swap consumer (#701) into a two-channel check-for-updates front door. Composition only — the produce/verify/swap machinery is untouched.

## Channels (exactly two)
- **Releases** (default): the #681 release check + gpg fail-closed consumer lane. On installs that can't take a release (source checkouts, non-macOS), the produce affordance is withheld and the payload carries the named reason.
- **Dev — build from main** (behind the panel's Advanced fold): fetch origin, behind-count (capped 500) **+ bounded shortlog (`%h %s`, 20 lines) as data**, then the existing governor-riding produce (headroom fail-closed, tracked-dirty refusal — both surfaced verbatim).
- No nightly channel exists and none is invented.

## Backend
- `POST /api/daemon/update-lane/{check,produce}` take an optional `{"channel": "releases"|"dev"}` body; absent = the install's native lane; unknown = 400 naming the two-channel vocabulary.
- Per-flavor `channels` catalog + `default_channel` on the status block (derive-don't-mirror: the SPA hardcodes nothing); per-channel `checks` slots so a dev compare never overwrites the release story; cross-channel produce refuses by name **before** touching network or checkout.
- Auto-check cadence unchanged in posture (native channel; consumer gated on Connect; unmanaged skips).

## Panel (Access → Daemons; the chip pill expands into it)
- Running commit/version/built-at; Releases section default; Dev inside `<details>` Advanced (open-state persisted).
- Labels say what happens NOW: "Check latest release", "Download & install release", "Fetch & compare", "Pull & build from main"; footer states nothing installs or restarts without a click.
- Honest progress: job phase + log tail + real cargo/gpg errors verbatim (existing #681 rendering).
- **Swap step is the existing #701 consumer, not a copy**: ui2-handover exposes `renderSwapSection` and refills the panel mount on every state change — supervisor-claimed one-click when app-supervised, the chip's honest reach otherwise. Chip card gains "Open the update panel".

## Deliberately NOT in this PR
The CLI-launched successor-exec question (may the daemon takeover-spawn its own successor on an explicit owner click?) goes to the gate question at queue entry with the commission's recommendation; #701's honest-reach copy ships unchanged until ruled.

## Evidence
- e2e `update_lane_source_click_produces_artifact_and_chips` extended: explicit dev-channel check (behind=1 + shortlog subject), cross-channel produce 409 naming the mismatch, unknown-channel 400, catalog + default_channel pins — green (40/40 suite).
- Scratch daemon (worktree debug build): releases check pre-v0.1.0 answers honestly — `release check unavailable: this rendezvous logs no release manifests (older intendant-connect, or none submitted yet)`; unmanaged install withholds both produces with the named reason.
- Battery: `cargo fmt --check` 0 · bins 0 · lib crates 0 · `clippy --workspace -D warnings` 0 · e2e 40/40.