### PR TITLE
agenda graph: cursor-anchored zoom + pan, and the fullscreen inspector lift

### DIFF
--- a/static/app.html
+++ b/static/app.html
@@ -25574,6 +25574,31 @@ html.ui-v2 .ag2-inspector-backdrop { display: none; }
     background: rgba(4, 5, 8, 0.45);
   }
 }
+/* Graph theater-mode fullscreen (ag2-graph-fs on <html>, managed by the
+   graph fragment): the fullscreen panel is fixed at z 600, so the
+   inspector lifts above it as a floating card — full functionality over
+   the constellation, any viewport width. Backdrop stays off so the map
+   remains interactive beside the card. */
+html.ui-v2.ag2-graph-fs .ag2-inspector {
+  position: fixed;
+  top: 12px;
+  right: 12px;
+  bottom: 12px;
+  width: 0;
+  z-index: 620;
+  border: 1px solid var(--line);
+  border-radius: 15px;
+  box-shadow: var(--shadow-overlay);
+  overflow: hidden;
+  transition: none;
+}
+html.ui-v2.ag2-graph-fs .ag2-inspector.open {
+  width: min(478px, calc(100vw - 40px));
+}
+html.ui-v2.ag2-graph-fs .ag2-inspector-backdrop {
+  display: none !important;
+}
+
 html.ui-v2 .ag2-insp-col {
   width: 100%;
   min-width: 280px;
@@ -38026,7 +38051,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'cdc496035a30adca';
+const INTENDANT_APP_BUILD = 'e950941ff47c2152';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -99131,7 +99156,9 @@ let agendaGraphCanvas = null;
 let agendaGraphCanvasHooks = null;
 let agendaGraphPaneObserver = null;
 let agendaGraphAutoTimer = null;
-let agendaGraphCam = { yaw: 0.6, pitch: -0.34, auto: true };
+let agendaGraphCam = {
+  yaw: 0.6, pitch: -0.34, auto: true, zoom: 1, panX: 0, panY: 0,
+};
 // Projection state: 'all' (whole non-retired ledger), 'hubs' (the hub
 // overview — automatic past the node cap, or chosen), 'focus' (one
 // hub's placed subtree). The render pass decides the projection from
@@ -99176,12 +99203,25 @@ function agendaGraphSetFullscreen(on) {
   agendaRenderTab();
 }
 
+// While graph-fullscreen is active a marker class on <html> lifts the
+// agenda inspector above the fixed panel (see ui2-agenda-inspector.css)
+// so node-click keeps its full behavior — inspector over constellation.
+function agendaGraphSyncFsMarker() {
+  document.documentElement.classList.toggle('ag2-graph-fs', agendaGraphFullscreen);
+}
+
 function agendaGraphEnsureEsc() {
   if (agendaGraphEscHook) return;
   agendaGraphEscHook = (e) => {
-    if (e.key === 'Escape' && !e.defaultPrevented) {
-      agendaGraphSetFullscreen(false);
+    if (e.key !== 'Escape' || e.defaultPrevented) return;
+    // Polite ordering: an open inspector consumes the first ESC;
+    // fullscreen exits on the next.
+    const insp = document.getElementById('ag2-inspector');
+    if (insp && insp.classList.contains('open')) {
+      agendaCloseInspector();
+      return;
     }
+    agendaGraphSetFullscreen(false);
   };
   document.addEventListener('keydown', agendaGraphEscHook);
 }
@@ -99292,6 +99332,7 @@ function agendaGraphRenderLens(host) {
 function agendaGraphWireChrome(host) {
   const panel = host.querySelector('.ag2-graph-panel');
   if (panel) panel.classList.toggle('fullscreen', agendaGraphFullscreen);
+  agendaGraphSyncFsMarker();
   if (agendaGraphFullscreen) agendaGraphEnsureEsc();
   else agendaGraphRemoveEsc();
   const hintLine = host.querySelector('#ag2-graph-hint');
@@ -99304,7 +99345,7 @@ function agendaGraphWireChrome(host) {
           ? (agendaGraphTerritory
             ? 'focused territory — squares are files/dirs; click one to open its newest carrier'
             : 'focused subtree — double-click empty space to clear')
-          : 'drag to orbit · click a node to open it · double-click a hub to focus');
+          : 'drag to orbit · wheel to zoom · shift-drag to pan · click a node to open it · double-click a hub to focus');
   }
   const inHubs = agendaGraphProjection === 'hubs';
   const chips = host.querySelectorAll('.ag2-graph-projchip');
@@ -99432,9 +99473,15 @@ function agendaGraphBindCanvas(canvas) {
       const nx = e.clientX - rect.left;
       const ny = e.clientY - rect.top;
       if (m.down) {
-        agendaGraphCam.yaw += (nx - m.x) * 0.005;
-        agendaGraphCam.pitch = Math.max(-1.2, Math.min(1.2,
-          agendaGraphCam.pitch + (ny - m.y) * 0.004));
+        if (e.shiftKey) {
+          // Shift-drag pans in screen space (zoom's natural partner).
+          agendaGraphCam.panX += nx - m.x;
+          agendaGraphCam.panY += ny - m.y;
+        } else {
+          agendaGraphCam.yaw += (nx - m.x) * 0.005;
+          agendaGraphCam.pitch = Math.max(-1.2, Math.min(1.2,
+            agendaGraphCam.pitch + (ny - m.y) * 0.004));
+        }
         m.moved += Math.abs(nx - m.x) + Math.abs(ny - m.y);
         agendaGraphCam.auto = false;
       }
@@ -99470,14 +99517,42 @@ function agendaGraphBindCanvas(canvas) {
     },
     dbl: () => {
       // Double-click a hub to focus its subtree; double-click empty
-      // space to clear an active focus.
+      // space to reset a zoom/pan first, then to clear an active focus.
       if (agendaGraphHover && agendaChildrenOf(agendaGraphHover).length) {
         agendaGraphFocus = agendaGraphHover;
         agendaRenderTab();
-      } else if (!agendaGraphHover && agendaGraphFocus) {
-        agendaGraphFocus = null;
-        agendaRenderTab();
+      } else if (!agendaGraphHover) {
+        const cam = agendaGraphCam;
+        if (cam.zoom !== 1 || cam.panX || cam.panY) {
+          cam.zoom = 1;
+          cam.panX = 0;
+          cam.panY = 0;
+        } else if (agendaGraphFocus) {
+          agendaGraphFocus = null;
+          agendaRenderTab();
+        }
       }
+    },
+    wheel: (e) => {
+      // Wheel / trackpad-pinch (ctrl-wheel) zoom, anchored to the
+      // cursor: the world point under the pointer stays put via the
+      // screen-space pan. preventDefault keeps the page from scrolling
+      // — scoped to the canvas, removed on unbind.
+      e.preventDefault();
+      const rect = canvas.getBoundingClientRect();
+      const mx = e.clientX - rect.left;
+      const my = e.clientY - rect.top;
+      const cam = agendaGraphCam;
+      const factor = Math.exp(-e.deltaY * (e.ctrlKey ? 0.01 : 0.0022));
+      const next = Math.max(0.35, Math.min(3.5, cam.zoom * factor));
+      const ratio = next / cam.zoom;
+      const ax = rect.width / 2;
+      const ay = rect.height / 2 + 8;
+      cam.panX = mx - ax - (mx - ax - cam.panX) * ratio;
+      cam.panY = my - ay - (my - ay - cam.panY) * ratio;
+      cam.zoom = next;
+      cam.auto = false;
+      agendaGraphArmAutoResume();
     },
     leave: () => {
       const wasDown = agendaGraphMouse.down;
@@ -99494,6 +99569,7 @@ function agendaGraphBindCanvas(canvas) {
   canvas.addEventListener('mouseup', hooks.up);
   canvas.addEventListener('mouseleave', hooks.leave);
   canvas.addEventListener('dblclick', hooks.dbl);
+  canvas.addEventListener('wheel', hooks.wheel, { passive: false });
   agendaGraphCanvasHooks = hooks;
 }
 
@@ -99506,6 +99582,7 @@ function agendaGraphUnbindCanvas() {
     canvas.removeEventListener('mouseup', hooks.up);
     canvas.removeEventListener('mouseleave', hooks.leave);
     canvas.removeEventListener('dblclick', hooks.dbl);
+    canvas.removeEventListener('wheel', hooks.wheel);
   }
   agendaGraphCanvas = null;
   agendaGraphCanvasHooks = null;
@@ -99576,6 +99653,7 @@ function agendaGraphTeardown() {
   }
   agendaGraphUnbindCanvas();
   agendaGraphRemoveEsc();
+  document.documentElement.classList.remove('ag2-graph-fs');
   agendaGraphMouse.down = false;
   agendaGraphMouse.moved = 0;
   agendaGraphHover = null;
@@ -100008,7 +100086,13 @@ function agendaGraphDraw(ts) {
     const ry = p[1] * cp - rz * sp;
     rz = p[1] * sp + rz * cp;
     const s = focal / (focal + rz + 40);
-    return { x: cx + rx * s * 1.35, y: cyy + ry * s * 1.35, s, z: rz };
+    const k = s * 1.35 * cam.zoom;
+    return {
+      x: cx + cam.panX + rx * k,
+      y: cyy + cam.panY + ry * k,
+      s: s * cam.zoom,
+      z: rz,
+    };
   };
   const nodes = agendaGraphNodes;
   const pts = nodes.map((n) => project(n.p));
@@ -100230,6 +100314,9 @@ function agendaGraphDraw(ts) {
     : agendaGraphMode === 'attention'
       ? ` · attention — ${agendaGraphAttnCount} need you`
       : ` · ${agendaGraphMode}`;
+  const zoomBadge = Math.abs(cam.zoom - 1) > 0.01
+    ? ` · ${cam.zoom.toFixed(1)}× (double-click empty to reset)`
+    : '';
   {
     const allCount = (agendaItems || []).filter(
       (x) => x.status !== 'retired',
@@ -100248,7 +100335,7 @@ function agendaGraphDraw(ts) {
     }
     g.font = '10px "JetBrains Mono", monospace';
     g.fillStyle = pal.t3;
-    g.fillText(badge + modeBadge + terrBadge, 14, 64);
+    g.fillText(badge + modeBadge + terrBadge + zoomBadge, 14, 64);
   }
 }
 

--- a/static/app/ui2-agenda-graph.js
+++ b/static/app/ui2-agenda-graph.js
@@ -54,7 +54,9 @@ let agendaGraphCanvas = null;
 let agendaGraphCanvasHooks = null;
 let agendaGraphPaneObserver = null;
 let agendaGraphAutoTimer = null;
-let agendaGraphCam = { yaw: 0.6, pitch: -0.34, auto: true };
+let agendaGraphCam = {
+  yaw: 0.6, pitch: -0.34, auto: true, zoom: 1, panX: 0, panY: 0,
+};
 // Projection state: 'all' (whole non-retired ledger), 'hubs' (the hub
 // overview — automatic past the node cap, or chosen), 'focus' (one
 // hub's placed subtree). The render pass decides the projection from
@@ -99,12 +101,25 @@ function agendaGraphSetFullscreen(on) {
   agendaRenderTab();
 }
 
+// While graph-fullscreen is active a marker class on <html> lifts the
+// agenda inspector above the fixed panel (see ui2-agenda-inspector.css)
+// so node-click keeps its full behavior — inspector over constellation.
+function agendaGraphSyncFsMarker() {
+  document.documentElement.classList.toggle('ag2-graph-fs', agendaGraphFullscreen);
+}
+
 function agendaGraphEnsureEsc() {
   if (agendaGraphEscHook) return;
   agendaGraphEscHook = (e) => {
-    if (e.key === 'Escape' && !e.defaultPrevented) {
-      agendaGraphSetFullscreen(false);
+    if (e.key !== 'Escape' || e.defaultPrevented) return;
+    // Polite ordering: an open inspector consumes the first ESC;
+    // fullscreen exits on the next.
+    const insp = document.getElementById('ag2-inspector');
+    if (insp && insp.classList.contains('open')) {
+      agendaCloseInspector();
+      return;
     }
+    agendaGraphSetFullscreen(false);
   };
   document.addEventListener('keydown', agendaGraphEscHook);
 }
@@ -215,6 +230,7 @@ function agendaGraphRenderLens(host) {
 function agendaGraphWireChrome(host) {
   const panel = host.querySelector('.ag2-graph-panel');
   if (panel) panel.classList.toggle('fullscreen', agendaGraphFullscreen);
+  agendaGraphSyncFsMarker();
   if (agendaGraphFullscreen) agendaGraphEnsureEsc();
   else agendaGraphRemoveEsc();
   const hintLine = host.querySelector('#ag2-graph-hint');
@@ -227,7 +243,7 @@ function agendaGraphWireChrome(host) {
           ? (agendaGraphTerritory
             ? 'focused territory — squares are files/dirs; click one to open its newest carrier'
             : 'focused subtree — double-click empty space to clear')
-          : 'drag to orbit · click a node to open it · double-click a hub to focus');
+          : 'drag to orbit · wheel to zoom · shift-drag to pan · click a node to open it · double-click a hub to focus');
   }
   const inHubs = agendaGraphProjection === 'hubs';
   const chips = host.querySelectorAll('.ag2-graph-projchip');
@@ -355,9 +371,15 @@ function agendaGraphBindCanvas(canvas) {
       const nx = e.clientX - rect.left;
       const ny = e.clientY - rect.top;
       if (m.down) {
-        agendaGraphCam.yaw += (nx - m.x) * 0.005;
-        agendaGraphCam.pitch = Math.max(-1.2, Math.min(1.2,
-          agendaGraphCam.pitch + (ny - m.y) * 0.004));
+        if (e.shiftKey) {
+          // Shift-drag pans in screen space (zoom's natural partner).
+          agendaGraphCam.panX += nx - m.x;
+          agendaGraphCam.panY += ny - m.y;
+        } else {
+          agendaGraphCam.yaw += (nx - m.x) * 0.005;
+          agendaGraphCam.pitch = Math.max(-1.2, Math.min(1.2,
+            agendaGraphCam.pitch + (ny - m.y) * 0.004));
+        }
         m.moved += Math.abs(nx - m.x) + Math.abs(ny - m.y);
         agendaGraphCam.auto = false;
       }
@@ -393,14 +415,42 @@ function agendaGraphBindCanvas(canvas) {
     },
     dbl: () => {
       // Double-click a hub to focus its subtree; double-click empty
-      // space to clear an active focus.
+      // space to reset a zoom/pan first, then to clear an active focus.
       if (agendaGraphHover && agendaChildrenOf(agendaGraphHover).length) {
         agendaGraphFocus = agendaGraphHover;
         agendaRenderTab();
-      } else if (!agendaGraphHover && agendaGraphFocus) {
-        agendaGraphFocus = null;
-        agendaRenderTab();
+      } else if (!agendaGraphHover) {
+        const cam = agendaGraphCam;
+        if (cam.zoom !== 1 || cam.panX || cam.panY) {
+          cam.zoom = 1;
+          cam.panX = 0;
+          cam.panY = 0;
+        } else if (agendaGraphFocus) {
+          agendaGraphFocus = null;
+          agendaRenderTab();
+        }
       }
+    },
+    wheel: (e) => {
+      // Wheel / trackpad-pinch (ctrl-wheel) zoom, anchored to the
+      // cursor: the world point under the pointer stays put via the
+      // screen-space pan. preventDefault keeps the page from scrolling
+      // — scoped to the canvas, removed on unbind.
+      e.preventDefault();
+      const rect = canvas.getBoundingClientRect();
+      const mx = e.clientX - rect.left;
+      const my = e.clientY - rect.top;
+      const cam = agendaGraphCam;
+      const factor = Math.exp(-e.deltaY * (e.ctrlKey ? 0.01 : 0.0022));
+      const next = Math.max(0.35, Math.min(3.5, cam.zoom * factor));
+      const ratio = next / cam.zoom;
+      const ax = rect.width / 2;
+      const ay = rect.height / 2 + 8;
+      cam.panX = mx - ax - (mx - ax - cam.panX) * ratio;
+      cam.panY = my - ay - (my - ay - cam.panY) * ratio;
+      cam.zoom = next;
+      cam.auto = false;
+      agendaGraphArmAutoResume();
     },
     leave: () => {
       const wasDown = agendaGraphMouse.down;
@@ -417,6 +467,7 @@ function agendaGraphBindCanvas(canvas) {
   canvas.addEventListener('mouseup', hooks.up);
   canvas.addEventListener('mouseleave', hooks.leave);
   canvas.addEventListener('dblclick', hooks.dbl);
+  canvas.addEventListener('wheel', hooks.wheel, { passive: false });
   agendaGraphCanvasHooks = hooks;
 }
 
@@ -429,6 +480,7 @@ function agendaGraphUnbindCanvas() {
     canvas.removeEventListener('mouseup', hooks.up);
     canvas.removeEventListener('mouseleave', hooks.leave);
     canvas.removeEventListener('dblclick', hooks.dbl);
+    canvas.removeEventListener('wheel', hooks.wheel);
   }
   agendaGraphCanvas = null;
   agendaGraphCanvasHooks = null;
@@ -499,6 +551,7 @@ function agendaGraphTeardown() {
   }
   agendaGraphUnbindCanvas();
   agendaGraphRemoveEsc();
+  document.documentElement.classList.remove('ag2-graph-fs');
   agendaGraphMouse.down = false;
   agendaGraphMouse.moved = 0;
   agendaGraphHover = null;
@@ -931,7 +984,13 @@ function agendaGraphDraw(ts) {
     const ry = p[1] * cp - rz * sp;
     rz = p[1] * sp + rz * cp;
     const s = focal / (focal + rz + 40);
-    return { x: cx + rx * s * 1.35, y: cyy + ry * s * 1.35, s, z: rz };
+    const k = s * 1.35 * cam.zoom;
+    return {
+      x: cx + cam.panX + rx * k,
+      y: cyy + cam.panY + ry * k,
+      s: s * cam.zoom,
+      z: rz,
+    };
   };
   const nodes = agendaGraphNodes;
   const pts = nodes.map((n) => project(n.p));
@@ -1153,6 +1212,9 @@ function agendaGraphDraw(ts) {
     : agendaGraphMode === 'attention'
       ? ` · attention — ${agendaGraphAttnCount} need you`
       : ` · ${agendaGraphMode}`;
+  const zoomBadge = Math.abs(cam.zoom - 1) > 0.01
+    ? ` · ${cam.zoom.toFixed(1)}× (double-click empty to reset)`
+    : '';
   {
     const allCount = (agendaItems || []).filter(
       (x) => x.status !== 'retired',
@@ -1171,7 +1233,7 @@ function agendaGraphDraw(ts) {
     }
     g.font = '10px "JetBrains Mono", monospace';
     g.fillStyle = pal.t3;
-    g.fillText(badge + modeBadge + terrBadge, 14, 64);
+    g.fillText(badge + modeBadge + terrBadge + zoomBadge, 14, 64);
   }
 }
 

--- a/static/app/ui2-agenda-inspector.css
+++ b/static/app/ui2-agenda-inspector.css
@@ -40,6 +40,31 @@ html.ui-v2 .ag2-inspector-backdrop { display: none; }
     background: rgba(4, 5, 8, 0.45);
   }
 }
+/* Graph theater-mode fullscreen (ag2-graph-fs on <html>, managed by the
+   graph fragment): the fullscreen panel is fixed at z 600, so the
+   inspector lifts above it as a floating card — full functionality over
+   the constellation, any viewport width. Backdrop stays off so the map
+   remains interactive beside the card. */
+html.ui-v2.ag2-graph-fs .ag2-inspector {
+  position: fixed;
+  top: 12px;
+  right: 12px;
+  bottom: 12px;
+  width: 0;
+  z-index: 620;
+  border: 1px solid var(--line);
+  border-radius: 15px;
+  box-shadow: var(--shadow-overlay);
+  overflow: hidden;
+  transition: none;
+}
+html.ui-v2.ag2-graph-fs .ag2-inspector.open {
+  width: min(478px, calc(100vw - 40px));
+}
+html.ui-v2.ag2-graph-fs .ag2-inspector-backdrop {
+  display: none !important;
+}
+
 html.ui-v2 .ag2-insp-col {
   width: 100%;
   min-width: 280px;


### PR DESCRIPTION
Two owner asks on the constellation:

- **Zoom**: wheel / trackpad-pinch (ctrl-wheel), clamped 0.35–3.5×, anchored to the cursor — the world point under the pointer stays put via a screen-space pan, which also unlocks shift-drag panning. Double-click empty space resets the view first, then clears focus on the next. Painted badge shows the factor with the reset hint; default hint teaches wheel/shift-drag. Picking, labels, satellites, halos all unchanged (they live after the projection). Wheel is canvas-scoped passive:false with symmetric unbind.
- **Fullscreen dead-click fix**: node-click in theater mode DID open the inspector — underneath the z-600 fixed panel. While graph-fullscreen is active a marker class on <html> (wire pass on, teardown off) lifts the inspector to a fixed floating card at z 620 over the constellation (any viewport width, backdrop suppressed so the map stays interactive). ESC gains polite ordering: first press closes an open inspector, second exits fullscreen.

Battery: bins 5377 + 150 + 97 pass, lib crates pass, workspace clippy -D warnings clean, node --check, app.html regenerated via the assembler.