### PR TITLE
vault: out-of-band credential-change watch (Claude + Codex)

### DIFF
--- a/docs/src/credential-custody.md
+++ b/docs/src/credential-custody.md
@@ -578,6 +578,63 @@ thread-resume machinery), that re-reads the fresh store (a mid-turn
 session is interrupted first; a rate-limit park is cancelled with its
 pending re-send preserved). All three ceremonies are local-daemon only.
 
+### The out-of-band credential watch
+
+Ceremonies are not the only way credentials change: an owner can
+re-authenticate a backend CLI directly in a terminal, and until
+2026-08 that change was invisible to the reload lane — reload
+candidates keyed on the daemon-witnessed ceremony and on backend
+announce events, so sessions parked on the old account offered no
+reload until some backend happened to speak. The **credential watch**
+(`credential_watch.rs`) closes that gap with the same bounded pattern
+as the binary update watch: a slow stat poll (60 s;
+`INTENDANT_CREDENTIAL_POLL_MS` for rigs) over the auth artifact each
+backend CLI maintains, and on a change **one bounded identity probe**
+— the CLI's own status subcommand, run under the external-child env
+policy (the daemon's provider keys never reach a CLI it merely
+observes) with a hard timeout.
+
+A probe-confirmed switch does three things: it **mints the credential
+era** by publishing the same `BackendCredentialAccount` announce the
+ceremonies publish (a second *source* for era changes, never a second
+store — era keying by process announces stays primary), it records the
+observation the auth-status payloads serve as an `out_of_band` block
+carrying the **same `reload_candidates` list and reload-all offer**
+the ceremony's success payload carries (the Vault card renders both
+stories through one reload panel), and it posts **one info
+notification** — account labels only, never secret material.
+
+Honesty properties, all pinned by tests: the watch never opens the
+credential file (detection is `fs::metadata` alone — no secret byte
+can cross the observation boundary); token refreshes that rewrite the
+artifact under the *same* account never fire; a live ceremony defers
+the watch and a ceremony's announce folds into its baseline, so the
+ceremony lane never double-fires; a ceremony success newer than the
+observation supersedes it (failed/cancelled ceremonies, which change
+nothing, do not); a sign-out notifies without a reload offer
+(reloading onto an empty store is a trap); and probe failures are
+budget-bounded, adopting the change *without* a verdict rather than
+guessing (surfaced as `probe_error`). A persisted era label also lets
+the **first** poll after boot catch a switch made while the daemon was
+down.
+
+Per-backend applicability is explicit, served on every auth-status
+payload as a `credential_watch` block: **Claude Code** and **Codex**
+are watched (`~/.claude/.credentials.json` and `~/.codex/auth.json`,
+honoring `CLAUDE_CONFIG_DIR`/`CODEX_HOME`, with `claude auth status` /
+`codex login status` as the probes). **Kimi** is out of scope — its
+only identity probe is parsing the credential file itself, which stays
+ceremony-scoped; a background lane reading secret bytes on a timer is
+a custody posture change that needs its own ruling. **Pi** has no
+sign-in ceremony (API-key auth, no reload surface to mirror). A
+backend under an active `oauth:*` vault lease is not watched while the
+lease is active — sessions run the leased identity, and the lease
+lifecycle rewrites its own materialized files on its own clock. On
+macOS, Claude Code may keep credentials in the keychain with no
+on-disk artifact; the block says so (`artifact_present: false`), and
+keychain-side switches stay invisible to a stat poll until the backend
+next speaks.
+
 ## Local key custody: the daemon's own private keys
 
 Everything above moves *provider* credentials. The daemon also holds

--- a/src/bin/caller/auth_ceremony.rs
+++ b/src/bin/caller/auth_ceremony.rs
@@ -628,6 +628,18 @@ impl CeremonyManager {
         inner.state.as_ref().filter(|s| s.id == id).map(|s| s.phase)
     }
 
+    /// The provider of a live (non-terminal) ceremony, `None` when the
+    /// slot is idle or terminal — the credential watch's "the ceremony
+    /// owns the credential store right now" question.
+    pub(crate) fn live_provider(&self) -> Option<Provider> {
+        let inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        inner
+            .state
+            .as_ref()
+            .filter(|s| !s.phase.is_terminal())
+            .map(|s| s.provider)
+    }
+
     #[cfg(test)]
     pub(crate) fn current_phase(&self) -> Option<CeremonyPhase> {
         let inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());

--- a/src/bin/caller/credential_watch.rs
+++ b/src/bin/caller/credential_watch.rs
@@ -1,0 +1,1260 @@
+//! Out-of-band credential-change watch: the daemon notices backend
+//! account switches made OUTSIDE its own sign-in ceremonies.
+//!
+//! The reload lane keys on daemon-witnessed sign-in ceremonies and on
+//! backend ANNOUNCE events — so a re-authentication done directly at the
+//! backend CLI (the 2026-07-30 incident: the owner switched the Claude
+//! account while a wave of sessions sat limit-parked on the old one)
+//! offered no reload until some backend happened to speak. This watch is
+//! the missing detector, built on the same bounded pattern as the binary
+//! update watch (`handover::update_watch`): a slow stat poll over the
+//! auth artifact the backend CLI maintains, and on change ONE bounded
+//! identity probe — the CLI's own status subcommand, never the file's
+//! bytes. On a real out-of-band change it mints the new credential era
+//! (the SAME `AppEvent::BackendCredentialAccount` announce the sign-in
+//! ceremonies publish — a second SOURCE for era changes, never a second
+//! store), records the observation the auth-status payload serves as its
+//! `out_of_band` block (which carries the SAME `reload_candidates` list
+//! and reload-all offer the ceremony's success payload carries), and
+//! posts one info notification.
+//!
+//! Custody posture:
+//! - **Read-only observation.** The watch never opens, rewrites, or
+//!   migrates a credential file: detection is `fs::metadata` alone
+//!   ([`AuthStamp`]), identity is the CLI's own status subcommand run
+//!   with the external-child env policy (provider keys scrubbed) under a
+//!   hard timeout. No secret bytes cross the observation boundary, and
+//!   nothing secret can reach a log or notification (account labels
+//!   only — the same facts the ceremony status payloads already serve).
+//! - **The ceremony lane stays primary and never double-fires.** A live
+//!   ceremony for the provider defers the watch entirely; a ceremony
+//!   outcome reaches the watch as the same bus announce everything else
+//!   hears, folding the new account into the watch's baseline so the
+//!   post-ceremony stat change reconciles silently. Era keying by
+//!   process announces (`SessionIdentity`) is untouched.
+//! - **Per-backend applicability is explicit.** Claude Code and Codex
+//!   are watched (real on-disk artifacts + CLI status probes that carry
+//!   no secrets). Kimi is out of scope ([`out_of_scope_reason`]): its
+//!   only identity probe is parsing the credential file itself —
+//!   ceremony-scoped today; a background lane reading secret bytes on a
+//!   timer is a custody posture change that needs its own ruling. Pi has
+//!   no sign-in ceremony (API-key auth file, no reload surface to
+//!   mirror). A backend whose credential is custody-managed (active
+//!   `oauth:<backend>` vault lease) is not watched while the lease is
+//!   active: sessions run the leased identity, and the lease lifecycle
+//!   rewrites its own materialized files on its own clock.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
+
+use crate::auth_ceremony::{AuthProbe, CeremonyAccount, Provider};
+
+/// Poll cadence for the auth-artifact stat. `INTENDANT_CREDENTIAL_POLL_MS`
+/// overrides for rigs (clamped to ≥100 ms so a typo cannot spin) —
+/// stat-only and exec-free, so unlike the update watch's path override it
+/// needs no mock gate.
+fn poll_interval() -> Duration {
+    std::env::var("INTENDANT_CREDENTIAL_POLL_MS")
+        .ok()
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .map(|ms| Duration::from_millis(ms.max(100)))
+        .unwrap_or(Duration::from_secs(60))
+}
+
+/// Bound on one identity-probe subprocess (the backend CLIs are Node
+/// apps — cold starts are slow, but not this slow).
+const PROBE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Probe give-up bound per distinct stamp: a mid-rewrite artifact can
+/// fail a probe once; a persistently unprobeable CLI stops burning
+/// subprocesses and the change is adopted without a verdict (surfaced as
+/// `probe_error`, never fired as an account change).
+const PROBE_FAILURE_LIMIT: u32 = 3;
+
+// ---------------------------------------------------------------------------
+// Applicability
+// ---------------------------------------------------------------------------
+
+/// Why a ceremony provider is NOT watched, `None` for the watched ones.
+/// Served verbatim in the applicability block so the exclusion is
+/// explicit on the same surface that would otherwise show the watch.
+pub(crate) fn out_of_scope_reason(provider: Provider) -> Option<&'static str> {
+    match provider {
+        Provider::Claude | Provider::Codex => None,
+        Provider::Kimi => Some(
+            "Kimi has no CLI status probe — the only identity check is parsing the credential \
+             file itself, which is ceremony-scoped today. Out-of-band Kimi switches go \
+             unwatched until the Kimi CLI grows a status command.",
+        ),
+    }
+}
+
+/// The CLI's own auth artifact for a watched provider, honoring the same
+/// home-redirect env the availability probes honor (`CLAUDE_CONFIG_DIR`,
+/// `CODEX_HOME`). `None` = provider out of scope.
+pub(crate) fn auth_file_for(provider: Provider, home: &Path) -> Option<PathBuf> {
+    match provider {
+        Provider::Claude => Some(claude_auth_file_in(
+            std::env::var_os("CLAUDE_CONFIG_DIR"),
+            home,
+        )),
+        Provider::Codex => Some(codex_auth_file_in(std::env::var_os("CODEX_HOME"), home)),
+        Provider::Kimi => None,
+    }
+}
+
+/// `CLAUDE_CONFIG_DIR` injected for hermetic tests.
+fn claude_auth_file_in(config_dir: Option<std::ffi::OsString>, home: &Path) -> PathBuf {
+    config_dir
+        .map(PathBuf::from)
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| home.join(".claude"))
+        .join(".credentials.json")
+}
+
+/// `CODEX_HOME` injected for hermetic tests.
+fn codex_auth_file_in(codex_home: Option<std::ffi::OsString>, home: &Path) -> PathBuf {
+    codex_home
+        .map(PathBuf::from)
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| home.join(".codex"))
+        .join("auth.json")
+}
+
+/// The vault lease kind whose activation custody-manages this provider's
+/// credential (the same vocabulary `credential_leases` speaks).
+pub(crate) fn lease_kind(provider: Provider) -> &'static str {
+    match provider {
+        Provider::Claude => "oauth:claude-code",
+        Provider::Codex => "oauth:codex",
+        Provider::Kimi => "oauth:kimi",
+    }
+}
+
+/// The `credential_watch` applicability block every auth-status payload
+/// carries: per-backend, explicit, and honest about limits (an absent
+/// artifact on a keychain-custody platform means keychain-side switches
+/// are invisible to a stat poll).
+pub(crate) fn applicability_block(provider: Provider) -> serde_json::Value {
+    if let Some(reason) = out_of_scope_reason(provider) {
+        return serde_json::json!({ "watching": false, "reason": reason });
+    }
+    if crate::credential_leases::kind_is_active(lease_kind(provider)) {
+        return serde_json::json!({
+            "watching": false,
+            "reason": "custody-managed: an active vault lease fuels this backend from a sealed \
+                       store; the lease lifecycle owns credential changes while it is active",
+        });
+    }
+    let artifact_present = auth_file_for(provider, &crate::platform::home_dir())
+        .as_deref()
+        .map(|path| AuthStamp::read(path).is_some())
+        .unwrap_or(false);
+    let mut block = serde_json::json!({ "watching": true, "artifact_present": artifact_present });
+    if let Some(error) = probe_gap_for(provider.agent_backend().as_short_str()) {
+        // A changed artifact whose identity probe exhausted its budget:
+        // the change was adopted without a verdict — say so.
+        block["probe_error"] = error.into();
+    }
+    block
+}
+
+// ---------------------------------------------------------------------------
+// The stat stamp (metadata only — the file is never opened)
+// ---------------------------------------------------------------------------
+
+/// Cheap identity stamp of the auth artifact, mirroring the update
+/// watch's `BinaryStamp`: metadata ONLY — reading it can never move a
+/// secret byte. Unix adds (dev, ino) so an atomic same-length rewrite
+/// (the CLIs write-temp-then-rename) still flips identity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AuthStamp {
+    len: u64,
+    modified_ms: Option<u64>,
+    #[cfg(unix)]
+    dev: u64,
+    #[cfg(unix)]
+    ino: u64,
+}
+
+impl AuthStamp {
+    /// `None` = the artifact is absent or unreadable — a real state
+    /// (keychain-only boxes, logged-out CLIs), not an error.
+    pub(crate) fn read(path: &Path) -> Option<Self> {
+        let meta = std::fs::metadata(path).ok()?;
+        if !meta.is_file() {
+            return None;
+        }
+        let modified_ms = meta
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_millis() as u64);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            Some(AuthStamp {
+                len: meta.len(),
+                modified_ms,
+                dev: meta.dev(),
+                ino: meta.ino(),
+            })
+        }
+        #[cfg(not(unix))]
+        Some(AuthStamp {
+            len: meta.len(),
+            modified_ms,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Identity + the detection state machine (pure — the task feeds it)
+// ---------------------------------------------------------------------------
+
+/// The watch's account baseline. Labels are the CLI status probes' own
+/// account facts (an email for Claude, best-effort for Codex) — the same
+/// vocabulary the ceremony announces and the vitals era registry keys on.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Identity {
+    /// Nothing trustworthy to compare against — a change observed from
+    /// here adopts silently and can never fire.
+    Unknown,
+    SignedOut,
+    SignedIn { label: Option<String> },
+}
+
+impl Identity {
+    fn from_probe(probe: &AuthProbe) -> Self {
+        if probe.logged_in {
+            Identity::SignedIn {
+                label: probe
+                    .account
+                    .email
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|label| !label.is_empty())
+                    .map(str::to_string),
+            }
+        } else {
+            Identity::SignedOut
+        }
+    }
+
+    fn label(&self) -> Option<&str> {
+        match self {
+            Identity::SignedIn { label } => label.as_deref(),
+            _ => None,
+        }
+    }
+}
+
+/// One confirmed out-of-band change: what the task must do (era mint,
+/// observation record, notification). Labels only — never material.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ChangeFire {
+    /// `AgentBackend::as_short_str` vocabulary — the era-mint `source`.
+    pub(crate) source: &'static str,
+    /// Era-mint label. `None` mints an opaque era nonce downstream
+    /// (`observe_backend_account`) — the store changed either way.
+    pub(crate) account_label: Option<String>,
+    /// Full probed account facts for the status payload's account row
+    /// (`None` exactly when the change is a sign-out).
+    pub(crate) account: Option<CeremonyAccount>,
+    /// The baseline label this change displaced, for notification copy.
+    pub(crate) prior_label: Option<String>,
+    pub(crate) signed_out: bool,
+}
+
+/// Per-provider detection state machine — pure (no I/O): the task feeds
+/// it stat results, probe outcomes, and ceremony liveness; it answers
+/// with at most one [`ChangeFire`] per confirmed change. Hermetically
+/// unit-testable, mirroring `handover::update_watch::UpdateWatch`.
+pub(crate) struct CredentialWatch {
+    provider: Provider,
+    /// The stamp the watch has reconciled (outer `None` until the first
+    /// tick lands — the baseline probe always runs once).
+    adopted: Option<Option<AuthStamp>>,
+    identity: Identity,
+    /// Consecutive probe failures for one stamp; a new stamp resets the
+    /// budget.
+    failed: Option<(Option<AuthStamp>, u32)>,
+    /// Give-up verdict for the currently adopted stamp, served in the
+    /// applicability block (`None` while probes succeed).
+    probe_error: Option<String>,
+}
+
+impl CredentialWatch {
+    /// `persisted_identity` is the account label the era registry
+    /// persisted for this source (skipping minted era nonces) — the
+    /// baseline that lets the FIRST tick catch a switch made while the
+    /// daemon was down.
+    pub(crate) fn new(provider: Provider, persisted_identity: Identity) -> Self {
+        CredentialWatch {
+            provider,
+            adopted: None,
+            identity: persisted_identity,
+            failed: None,
+            probe_error: None,
+        }
+    }
+
+    pub(crate) fn provider(&self) -> Provider {
+        self.provider
+    }
+
+    pub(crate) fn probe_error(&self) -> Option<&str> {
+        self.probe_error.as_deref()
+    }
+
+    /// A ceremony success (or any other era announce for this source)
+    /// heard on the bus: fold the announced account into the baseline so
+    /// the ceremony-authored stat change reconciles silently — this fold
+    /// is WHY the ceremony lane never double-fires here.
+    pub(crate) fn fold_announced_account(&mut self, account: Option<String>) {
+        self.identity = Identity::SignedIn { label: account };
+    }
+
+    /// Should this tick run the identity probe? Once at baseline, then
+    /// only for a stamp that differs from the reconciled one and still
+    /// has failure budget. Never while the provider's own ceremony is
+    /// live — the ceremony owns the credential store right now.
+    pub(crate) fn probe_wanted(&self, stamp: &Option<AuthStamp>, ceremony_live: bool) -> bool {
+        if ceremony_live {
+            return false;
+        }
+        let Some(adopted) = self.adopted.as_ref() else {
+            return true;
+        };
+        if adopted == stamp {
+            return false;
+        }
+        match &self.failed {
+            Some((failed_stamp, count)) => failed_stamp != stamp || *count < PROBE_FAILURE_LIMIT,
+            None => true,
+        }
+    }
+
+    /// Fold one tick. `probe` is `Some` exactly when
+    /// [`Self::probe_wanted`] asked for one. Returns the fire to act on,
+    /// only for a probe-confirmed identity CONFLICT — a rewrite that
+    /// probes to the same account (the CLIs refresh tokens in place
+    /// constantly) reconciles silently.
+    pub(crate) fn record(
+        &mut self,
+        stamp: Option<AuthStamp>,
+        probe: Option<Result<AuthProbe, String>>,
+        ceremony_live: bool,
+    ) -> Option<ChangeFire> {
+        if ceremony_live {
+            // The ceremony owns the store: defer even stamp adoption, so
+            // its outcome (announced on the bus) lands in the baseline
+            // before the changed artifact is reconciled.
+            return None;
+        }
+        let Some(probe) = probe else {
+            // Unchanged (or a stamp we gave up probing): keep state, and
+            // let a revert to the reconciled stamp clear the failure
+            // budget so a later change probes afresh.
+            if self.adopted.as_ref() == Some(&stamp) {
+                self.failed = None;
+            }
+            return None;
+        };
+        match probe {
+            Ok(auth) => {
+                let observed = Identity::from_probe(&auth);
+                self.failed = None;
+                self.probe_error = None;
+                self.adopted = Some(stamp);
+                let fire = self.conflict(&observed).then(|| {
+                    let signed_out = observed == Identity::SignedOut;
+                    ChangeFire {
+                        source: self.provider.agent_backend().as_short_str(),
+                        account_label: observed.label().map(str::to_string),
+                        account: (!signed_out).then(|| auth.account.clone()),
+                        prior_label: self.identity.label().map(str::to_string),
+                        signed_out,
+                    }
+                });
+                self.reconcile_identity(observed);
+                fire
+            }
+            Err(error) => {
+                let count = match &self.failed {
+                    Some((failed_stamp, count)) if failed_stamp == &stamp => count + 1,
+                    _ => 1,
+                };
+                if count >= PROBE_FAILURE_LIMIT {
+                    // Give up on this stamp: adopt it WITHOUT a verdict —
+                    // an unverifiable change must never fire, and honesty
+                    // lives in `probe_error` on the applicability block.
+                    self.adopted = Some(stamp);
+                    self.failed = None;
+                    self.probe_error = Some(error);
+                } else {
+                    self.failed = Some((stamp, count));
+                }
+                None
+            }
+        }
+    }
+
+    /// Does `observed` CONFLICT with the baseline? Unknown never
+    /// conflicts (nothing to claim a change from), and a label-less
+    /// signed-in probe is compatible with any signed-in baseline — the
+    /// daemon cannot truthfully claim a switch it cannot name.
+    fn conflict(&self, observed: &Identity) -> bool {
+        match (&self.identity, observed) {
+            (Identity::Unknown, _) => false,
+            (_, Identity::Unknown) => false,
+            (Identity::SignedOut, Identity::SignedOut) => false,
+            (Identity::SignedOut, Identity::SignedIn { .. }) => true,
+            (Identity::SignedIn { .. }, Identity::SignedOut) => true,
+            (Identity::SignedIn { label: prior }, Identity::SignedIn { label: observed }) => {
+                match (prior, observed) {
+                    (Some(prior), Some(observed)) => prior != observed,
+                    _ => false,
+                }
+            }
+        }
+    }
+
+    /// Baseline after an observation: adopt it, except that a label-less
+    /// signed-in probe never downgrades a labeled baseline (keep the
+    /// richer fact — a later labeled probe still compares truthfully).
+    fn reconcile_identity(&mut self, observed: Identity) {
+        if matches!(observed, Identity::SignedIn { label: None })
+            && matches!(self.identity, Identity::SignedIn { label: Some(_) })
+        {
+            return;
+        }
+        self.identity = observed;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Observations (what the auth-status payloads serve)
+// ---------------------------------------------------------------------------
+
+/// One recorded out-of-band change, served as the status payload's
+/// `out_of_band` block until a newer ceremony success supersedes it.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct OutOfBandObservation {
+    pub(crate) account: Option<CeremonyAccount>,
+    pub(crate) prior_label: Option<String>,
+    pub(crate) signed_out: bool,
+    pub(crate) detected_at_unix_ms: u64,
+}
+
+fn observations() -> &'static Mutex<HashMap<String, OutOfBandObservation>> {
+    static OBSERVATIONS: OnceLock<Mutex<HashMap<String, OutOfBandObservation>>> = OnceLock::new();
+    OBSERVATIONS.get_or_init(Mutex::default)
+}
+
+/// Give-up verdicts from the watch task, served on the applicability
+/// block (`probe_error`) until a later probe succeeds.
+fn probe_gaps() -> &'static Mutex<HashMap<String, String>> {
+    static PROBE_GAPS: OnceLock<Mutex<HashMap<String, String>>> = OnceLock::new();
+    PROBE_GAPS.get_or_init(Mutex::default)
+}
+
+fn sync_probe_gap(source: &str, error: Option<&str>) {
+    let mut gaps = probe_gaps().lock().unwrap_or_else(|e| e.into_inner());
+    match error {
+        Some(error) => {
+            gaps.insert(source.to_string(), error.to_string());
+        }
+        None => {
+            gaps.remove(source);
+        }
+    }
+}
+
+fn probe_gap_for(source: &str) -> Option<String> {
+    probe_gaps()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(source)
+        .cloned()
+}
+
+pub(crate) fn record_observation(source: &str, observation: OutOfBandObservation) {
+    observations()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert(source.to_string(), observation);
+}
+
+pub(crate) fn observation_for(source: &str) -> Option<OutOfBandObservation> {
+    observations()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(source)
+        .cloned()
+}
+
+/// The `out_of_band` block for a provider's auth-status payload, `None`
+/// when the ceremony lane owns the story: a live ceremony phase
+/// suppresses it outright (never distract mid-flow), and a ceremony
+/// SUCCESS that finished after the observation supersedes it — that
+/// sign-in re-keyed the store more recently than the watch's sighting.
+/// Every other terminal phase leaves the observation standing: a failed
+/// or cancelled ceremony changed nothing, so the out-of-band fact is
+/// still the newest credential truth. Pure over the served status value
+/// (the phase strings are the pinned wire vocabulary).
+pub(crate) fn out_of_band_block(
+    status: &serde_json::Value,
+    observation: &OutOfBandObservation,
+) -> Option<serde_json::Value> {
+    let phase = status
+        .get("phase")
+        .and_then(|v| v.as_str())
+        .unwrap_or("idle");
+    if matches!(
+        phase,
+        "starting" | "awaiting_browser" | "awaiting_code" | "awaiting_user" | "verifying"
+    ) {
+        return None;
+    }
+    if phase == "success" {
+        let finished = status
+            .get("finished_at_unix_ms")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        if finished >= observation.detected_at_unix_ms {
+            return None;
+        }
+    }
+    let mut block = serde_json::json!({
+        "detected_at_unix_ms": observation.detected_at_unix_ms,
+        "signed_out": observation.signed_out,
+        "reload_offer": !observation.signed_out,
+    });
+    let obj = block.as_object_mut().expect("literal object");
+    if let Some(account) = observation.account.as_ref() {
+        obj.insert(
+            "account".into(),
+            serde_json::json!({
+                "email": account.email,
+                "subscription_type": account.subscription_type,
+                "org_name": account.org_name,
+                "auth_method": account.auth_method,
+            }),
+        );
+    }
+    if let Some(prior) = observation.prior_label.as_ref() {
+        obj.insert("prior_account_label".into(), prior.clone().into());
+    }
+    Some(block)
+}
+
+/// Owner-facing copy for the one info notification per fire. Account
+/// labels only — nothing file-derived can reach this string.
+pub(crate) fn notification_text(provider: Provider, fire: &ChangeFire) -> String {
+    let backend = match provider {
+        Provider::Claude => "Claude Code",
+        Provider::Codex => "Codex",
+        Provider::Kimi => "Kimi Code",
+    };
+    let was = fire
+        .prior_label
+        .as_deref()
+        .map(|prior| format!(" (was {prior})"))
+        .unwrap_or_default();
+    if fire.signed_out {
+        format!(
+            "{backend} was signed out outside Intendant{was}. Live sessions keep the old \
+             account in-process until they restart; sign in again from the Vault card."
+        )
+    } else {
+        let now = fire
+            .account_label
+            .as_deref()
+            .map(|label| format!("now signed in as {label}"))
+            .unwrap_or_else(|| "now on a different account (the CLI reported no label)".into());
+        format!(
+            "{backend} credentials changed outside Intendant: {now}{was}. Live sessions keep \
+             the old account until reloaded — the Vault card offers per-session reload and \
+             reload-all."
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Transport edges (probe subprocess + the detection task)
+// ---------------------------------------------------------------------------
+
+/// The one bounded identity probe: the provider CLI's own status
+/// subcommand, external-child env policy applied (the daemon's provider
+/// authority never reaches a CLI it merely observes), hard timeout,
+/// output parsed by the same parsers the ceremonies trust. Probe errors
+/// carry no CLI output — a status line is no secret, but nothing
+/// file-adjacent rides an error string on principle.
+pub(crate) async fn run_identity_probe(
+    provider: Provider,
+    command: &str,
+) -> Result<AuthProbe, String> {
+    let (program, mut args) = crate::auth_ceremony::pty_program_invocation(command);
+    match provider {
+        Provider::Claude => args.extend(["auth".to_string(), "status".to_string()]),
+        Provider::Codex => args.extend(["login".to_string(), "status".to_string()]),
+        Provider::Kimi => return Err("kimi is out of scope for the credential watch".to_string()),
+    }
+    let mut cmd = tokio::process::Command::new(program);
+    cmd.args(args)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true);
+    crate::external_agent::apply_external_child_env_policy(&mut cmd);
+    let output = tokio::time::timeout(PROBE_TIMEOUT, cmd.output())
+        .await
+        .map_err(|_| format!("identity probe timed out ({}s)", PROBE_TIMEOUT.as_secs()))?
+        .map_err(|e| format!("identity probe failed to spawn: {e}"))?;
+    match provider {
+        Provider::Claude => {
+            crate::claude_auth_ceremony::parse_auth_status(&String::from_utf8_lossy(
+                &output.stdout,
+            ))
+            .ok_or_else(|| "auth status output did not parse".to_string())
+        }
+        Provider::Codex => {
+            let mut text = String::from_utf8_lossy(&output.stdout).into_owned();
+            text.push('\n');
+            text.push_str(&String::from_utf8_lossy(&output.stderr));
+            Ok(crate::codex_auth_ceremony::parse_login_status(
+                output.status.success(),
+                &text,
+            ))
+        }
+        Provider::Kimi => unreachable!("refused above"),
+    }
+}
+
+/// The persisted-era baseline for one source: the account label the
+/// vitals era registry last persisted, skipping minted era nonces (an
+/// `era-N` label names no account, so nothing can truthfully conflict
+/// with it).
+fn persisted_identity(
+    current: &HashMap<String, crate::session_vitals::AccountEra>,
+    source: &str,
+) -> Identity {
+    match current.get(source).cloned().flatten() {
+        Some(label) if !crate::session_vitals::is_minted_era_label(&label) => Identity::SignedIn {
+            label: Some(label),
+        },
+        _ => Identity::Unknown,
+    }
+}
+
+/// The configured CLI command for a watched provider (per-probe, so a
+/// config edit is honored without a daemon restart).
+fn probe_command(provider: Provider, project_root: Option<&Path>) -> String {
+    match provider {
+        Provider::Claude => crate::claude_auth_ceremony::configured_claude_command(project_root),
+        Provider::Codex => crate::codex_auth_ceremony::configured_codex_command(project_root),
+        Provider::Kimi => String::new(),
+    }
+}
+
+/// Spawn the detection task over every watched provider: one shared stat
+/// cadence, ceremony announces folded from the bus, and on each
+/// confirmed fire — the era mint announce, the served observation, one
+/// info notification, and a label-only log line. Detached like its
+/// sibling daemon tasks; the two startup sites that publish the ceremony
+/// bus spawn it with the same bus.
+pub(crate) fn spawn_credential_watch(bus: crate::event::EventBus, project_root: Option<PathBuf>) {
+    let home = crate::platform::home_dir();
+    let lanes: Vec<(CredentialWatch, PathBuf)> = {
+        let store = crate::session_vitals_restore::account_limit_store_path();
+        let persisted = crate::session_vitals_restore::load_account_limit_store(&store);
+        [Provider::Claude, Provider::Codex]
+            .into_iter()
+            .filter_map(|provider| {
+                let auth_path = auth_file_for(provider, &home)?;
+                let source = provider.agent_backend().as_short_str();
+                Some((
+                    CredentialWatch::new(provider, persisted_identity(&persisted.current, source)),
+                    auth_path,
+                ))
+            })
+            .collect()
+    };
+    if lanes.is_empty() {
+        return;
+    }
+    let mut lanes = lanes;
+    let mut events = bus.subscribe();
+    tokio::spawn(async move {
+        let mut ticks = tokio::time::interval(poll_interval());
+        ticks.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            tokio::select! {
+                _ = ticks.tick() => {
+                    for (watch, auth_path) in lanes.iter_mut() {
+                        let provider = watch.provider();
+                        if crate::credential_leases::kind_is_active(lease_kind(provider)) {
+                            // Custody-managed: the lease lifecycle owns
+                            // this credential while active.
+                            continue;
+                        }
+                        let ceremony_live =
+                            crate::auth_ceremony::manager().live_provider() == Some(provider);
+                        let stamp = AuthStamp::read(auth_path);
+                        let probe = if watch.probe_wanted(&stamp, ceremony_live) {
+                            let command = probe_command(provider, project_root.as_deref());
+                            Some(run_identity_probe(provider, &command).await)
+                        } else {
+                            None
+                        };
+                        if let Some(fire) = watch.record(stamp, probe, ceremony_live) {
+                            deliver_fire(&bus, provider, fire);
+                        }
+                        sync_probe_gap(
+                            provider.agent_backend().as_short_str(),
+                            watch.probe_error(),
+                        );
+                    }
+                }
+                event = events.recv() => match event {
+                    Ok(crate::event::AppEvent::BackendCredentialAccount { source, account }) => {
+                        for (watch, _) in lanes.iter_mut() {
+                            if watch.provider().agent_backend().as_short_str() == source {
+                                watch.fold_announced_account(account.clone());
+                            }
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                },
+            }
+        }
+    });
+}
+
+/// One fire's daemon-side effects, in announce-first order: the era mint
+/// rides the bus (the vitals hub folds it exactly as it folds a ceremony
+/// announce — and this watch's own bus fold hears it too, which is
+/// harmless: the baseline is already reconciled), then the observation
+/// the status payloads serve, then the one info notification.
+fn deliver_fire(bus: &crate::event::EventBus, provider: Provider, fire: ChangeFire) {
+    bus.send(crate::event::AppEvent::BackendCredentialAccount {
+        source: fire.source.to_string(),
+        account: fire.account_label.clone(),
+    });
+    record_observation(
+        fire.source,
+        OutOfBandObservation {
+            account: fire.account.clone(),
+            prior_label: fire.prior_label.clone(),
+            signed_out: fire.signed_out,
+            detected_at_unix_ms: now_ms(),
+        },
+    );
+    let text = notification_text(provider, &fire);
+    eprintln!("[credential-watch] {}: {text}", fire.source);
+    bus.send(crate::event::AppEvent::UserNotification {
+        session_id: None,
+        id: format!("credential-change-{}", fire.source),
+        title: Some("Credentials changed outside Intendant".to_string()),
+        text,
+        urgency: crate::types::NotificationUrgency::Info,
+        ts: now_ms(),
+    });
+}
+
+fn now_ms() -> u64 {
+    chrono::Utc::now().timestamp_millis().max(0) as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stamp(len: u64, modified_ms: u64, ino: u64) -> AuthStamp {
+        #[cfg(unix)]
+        {
+            AuthStamp {
+                len,
+                modified_ms: Some(modified_ms),
+                dev: 1,
+                ino,
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = ino;
+            AuthStamp {
+                len,
+                modified_ms: Some(modified_ms),
+            }
+        }
+    }
+
+    fn signed_in(email: Option<&str>) -> AuthProbe {
+        AuthProbe {
+            logged_in: true,
+            account: CeremonyAccount {
+                email: email.map(str::to_string),
+                subscription_type: email.map(|_| "max".to_string()),
+                org_name: None,
+                auth_method: Some("claudeai".to_string()),
+            },
+        }
+    }
+
+    fn signed_out() -> AuthProbe {
+        AuthProbe {
+            logged_in: false,
+            account: CeremonyAccount::default(),
+        }
+    }
+
+    fn baselined(identity: Identity) -> CredentialWatch {
+        let mut watch = CredentialWatch::new(Provider::Claude, identity);
+        // First tick: baseline stamp + probe reconcile silently when the
+        // probe agrees with the persisted identity (or it is Unknown).
+        let probe = match &watch.identity {
+            Identity::SignedIn { label } => signed_in(label.as_deref()),
+            Identity::SignedOut => signed_out(),
+            Identity::Unknown => signed_in(Some("a@x")),
+        };
+        let fire = watch.record(Some(stamp(100, 1_000, 1)), Some(Ok(probe)), false);
+        assert!(fire.is_none(), "baseline tick must not fire");
+        watch
+    }
+
+    /// The card's core pin: an out-of-band auth-file change whose probe
+    /// names a different account fires exactly once — era-mint label,
+    /// account facts, prior label, reload offer.
+    #[test]
+    fn out_of_band_switch_fires_with_era_label_and_reload_offer() {
+        let mut watch = baselined(Identity::SignedIn {
+            label: Some("a@x".to_string()),
+        });
+        let fire = watch
+            .record(
+                Some(stamp(200, 5_000, 2)),
+                Some(Ok(signed_in(Some("b@x")))),
+                false,
+            )
+            .expect("switch fires");
+        assert_eq!(fire.source, "claude-code");
+        assert_eq!(fire.account_label.as_deref(), Some("b@x"));
+        assert_eq!(fire.prior_label.as_deref(), Some("a@x"));
+        assert!(!fire.signed_out);
+        assert_eq!(
+            fire.account.as_ref().and_then(|a| a.email.as_deref()),
+            Some("b@x")
+        );
+        // The same stamp next tick: no re-probe, no re-fire.
+        assert!(!watch.probe_wanted(&Some(stamp(200, 5_000, 2)), false));
+        assert!(watch
+            .record(Some(stamp(200, 5_000, 2)), None, false)
+            .is_none());
+    }
+
+    /// Token refreshes rewrite the artifact constantly: a changed stamp
+    /// whose probe names the SAME account reconciles silently.
+    #[test]
+    fn token_refresh_same_account_stays_silent() {
+        let mut watch = baselined(Identity::SignedIn {
+            label: Some("a@x".to_string()),
+        });
+        for tick in 0u64..3 {
+            let fresh = Some(stamp(200 + tick, 5_000 + tick, 2 + tick));
+            assert!(watch.probe_wanted(&fresh, false), "changed stamp probes");
+            assert!(
+                watch
+                    .record(fresh, Some(Ok(signed_in(Some("a@x")))), false)
+                    .is_none(),
+                "same-account rewrite must never fire"
+            );
+        }
+    }
+
+    /// The ceremony lane never double-fires here: a live ceremony defers
+    /// the tick wholesale, and the ceremony's announce (folded from the
+    /// bus) re-baselines the watch so the post-ceremony stat change
+    /// probes to a match and reconciles silently.
+    #[test]
+    fn ceremony_change_never_double_fires() {
+        let mut watch = baselined(Identity::SignedIn {
+            label: Some("a@x".to_string()),
+        });
+        let rewritten = Some(stamp(300, 6_000, 3));
+        // Mid-ceremony: no probe, no adoption, no fire.
+        assert!(!watch.probe_wanted(&rewritten, true));
+        assert!(watch.record(rewritten.clone(), None, true).is_none());
+        // The ceremony succeeded and announced the new account.
+        watch.fold_announced_account(Some("b@x".to_string()));
+        // Next tick: the changed artifact probes to the announced
+        // account — reconciled silently, never fired.
+        assert!(watch.probe_wanted(&rewritten, false));
+        assert!(watch
+            .record(rewritten, Some(Ok(signed_in(Some("b@x")))), false)
+            .is_none());
+        // A LATER out-of-band switch still fires.
+        assert!(watch
+            .record(
+                Some(stamp(400, 7_000, 4)),
+                Some(Ok(signed_in(Some("c@x")))),
+                false
+            )
+            .is_some());
+    }
+
+    /// A probe-gap ceremony (announced with no label) must absorb the
+    /// watch's later labeled probe as an upgrade, not a change.
+    #[test]
+    fn label_less_announce_absorbs_labeled_probe() {
+        let mut watch = baselined(Identity::SignedIn {
+            label: Some("a@x".to_string()),
+        });
+        watch.fold_announced_account(None);
+        assert!(
+            watch
+                .record(
+                    Some(stamp(300, 6_000, 3)),
+                    Some(Ok(signed_in(Some("b@x")))),
+                    false
+                )
+                .is_none(),
+            "an unnamed baseline cannot truthfully conflict"
+        );
+        // The upgrade took: yet another account now conflicts.
+        assert!(watch
+            .record(
+                Some(stamp(400, 7_000, 4)),
+                Some(Ok(signed_in(Some("c@x")))),
+                false
+            )
+            .is_some());
+    }
+
+    /// A label-less probe never downgrades a labeled baseline and never
+    /// fires — the daemon cannot claim a switch it cannot name.
+    #[test]
+    fn label_less_probe_neither_fires_nor_downgrades() {
+        let mut watch = baselined(Identity::SignedIn {
+            label: Some("a@x".to_string()),
+        });
+        assert!(watch
+            .record(Some(stamp(300, 6_000, 3)), Some(Ok(signed_in(None))), false)
+            .is_none());
+        assert_eq!(
+            watch.identity,
+            Identity::SignedIn {
+                label: Some("a@x".to_string())
+            },
+            "labeled baseline survives a label-less probe"
+        );
+    }
+
+    /// Sign-out out-of-band: fires with `signed_out` (no reload offer,
+    /// no account block, label-less era mint), and the later sign-in
+    /// back fires again.
+    #[test]
+    fn signed_out_change_fires_without_reload_offer() {
+        let mut watch = baselined(Identity::SignedIn {
+            label: Some("a@x".to_string()),
+        });
+        let fire = watch
+            .record(None, Some(Ok(signed_out())), false)
+            .expect("sign-out fires");
+        assert!(fire.signed_out);
+        assert_eq!(fire.account_label, None);
+        assert_eq!(fire.account, None);
+        assert_eq!(fire.prior_label.as_deref(), Some("a@x"));
+        // Churn while signed out stays silent.
+        assert!(watch
+            .record(Some(stamp(10, 8_000, 9)), Some(Ok(signed_out())), false)
+            .is_none());
+        // Signing back in (any account) fires.
+        let fire = watch
+            .record(
+                Some(stamp(20, 9_000, 10)),
+                Some(Ok(signed_in(Some("a@x")))),
+                false,
+            )
+            .expect("sign-in fires");
+        assert!(!fire.signed_out);
+        assert_eq!(fire.account_label.as_deref(), Some("a@x"));
+        assert_eq!(fire.prior_label, None, "prior was signed-out, not a label");
+    }
+
+    /// The daemon-was-down case: a persisted era label conflicting with
+    /// the FIRST tick's probe fires immediately; an Unknown baseline
+    /// (no persisted label, or a minted era nonce) adopts silently.
+    #[test]
+    fn first_tick_fires_only_from_a_persisted_label() {
+        let mut watch = CredentialWatch::new(
+            Provider::Claude,
+            Identity::SignedIn {
+                label: Some("a@x".to_string()),
+            },
+        );
+        let fire = watch
+            .record(
+                Some(stamp(100, 1_000, 1)),
+                Some(Ok(signed_in(Some("b@x")))),
+                false,
+            )
+            .expect("down-switch fires on the baseline tick");
+        assert_eq!(fire.account_label.as_deref(), Some("b@x"));
+        assert_eq!(fire.prior_label.as_deref(), Some("a@x"));
+
+        let mut watch = CredentialWatch::new(Provider::Claude, Identity::Unknown);
+        assert!(
+            watch
+                .record(
+                    Some(stamp(100, 1_000, 1)),
+                    Some(Ok(signed_in(Some("b@x")))),
+                    false
+                )
+                .is_none(),
+            "an unknown baseline adopts silently"
+        );
+    }
+
+    /// Probe failures are bounded per stamp, and an exhausted budget
+    /// adopts the change WITHOUT firing (an unverifiable change must
+    /// never claim an account switch) — surfacing `probe_error`.
+    #[test]
+    fn probe_failures_bound_then_adopt_without_firing() {
+        let mut watch = baselined(Identity::SignedIn {
+            label: Some("a@x".to_string()),
+        });
+        let broken = Some(stamp(300, 6_000, 3));
+        for attempt in 1..=PROBE_FAILURE_LIMIT {
+            assert!(
+                watch.probe_wanted(&broken, false),
+                "attempt {attempt} still probes"
+            );
+            assert!(watch
+                .record(broken.clone(), Some(Err("spawn failed".to_string())), false)
+                .is_none());
+        }
+        assert!(!watch.probe_wanted(&broken, false), "budget exhausted");
+        assert_eq!(watch.probe_error(), Some("spawn failed"));
+        assert_eq!(
+            watch.identity,
+            Identity::SignedIn {
+                label: Some("a@x".to_string())
+            },
+            "identity untouched by an unverdicted change"
+        );
+        // A NEW stamp gets a fresh budget; success clears the error.
+        let replaced = Some(stamp(400, 7_000, 4));
+        assert!(watch.probe_wanted(&replaced, false));
+        assert!(watch
+            .record(replaced, Some(Ok(signed_in(Some("a@x")))), false)
+            .is_none());
+        assert_eq!(watch.probe_error(), None);
+    }
+
+    /// No secret bytes cross the observation boundary: the stamp is
+    /// metadata only (a file whose content is a known sentinel yields a
+    /// stamp carrying nothing content-derived beyond its length), and
+    /// this module's non-test code never opens the watched file at all.
+    #[test]
+    fn observation_boundary_carries_no_secret_bytes() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join(".credentials.json");
+        std::fs::write(&path, b"{\"secret\":\"sk-SENTINEL-VALUE\"}").unwrap();
+        let stamp = AuthStamp::read(&path).expect("stamp");
+        let rendered = format!("{stamp:?}");
+        assert!(
+            !rendered.contains("SENTINEL"),
+            "stamp must be pure metadata: {rendered}"
+        );
+
+        // The module itself never reads file contents: every fs call in
+        // non-test code is the metadata stat above. (`include_str!` of
+        // this very file; the test module below the marker is exempt.)
+        let source = include_str!("credential_watch.rs");
+        let non_test = &source[..source.find("#[cfg(test)]").expect("test marker")];
+        for forbidden in ["fs::read", "read_to_string", "File::open", "fs::write"] {
+            assert!(
+                !non_test.contains(forbidden),
+                "the watch must never open the credential file ({forbidden} found)"
+            );
+        }
+        assert!(
+            non_test.contains("fs::metadata"),
+            "the stat is the only filesystem observation"
+        );
+    }
+
+    /// Notification copy is built from labels alone and says the reload
+    /// story; the sign-out variant offers sign-in instead of reload.
+    #[test]
+    fn notification_copy_carries_labels_only() {
+        let fire = ChangeFire {
+            source: "claude-code",
+            account_label: Some("b@x".to_string()),
+            account: Some(CeremonyAccount::default()),
+            prior_label: Some("a@x".to_string()),
+            signed_out: false,
+        };
+        let text = notification_text(Provider::Claude, &fire);
+        assert!(text.contains("changed outside Intendant"));
+        assert!(text.contains("now signed in as b@x"));
+        assert!(text.contains("(was a@x)"));
+        assert!(text.contains("reload"));
+
+        let fire = ChangeFire {
+            source: "claude-code",
+            account_label: None,
+            account: None,
+            prior_label: Some("a@x".to_string()),
+            signed_out: true,
+        };
+        let text = notification_text(Provider::Claude, &fire);
+        assert!(text.contains("signed out outside Intendant"));
+        assert!(text.contains("sign in again"), "{text}");
+        assert!(!text.contains("reload-all"));
+    }
+
+    /// The out_of_band block defers to the ceremony lane exactly where
+    /// the ceremony owns the story: every live phase suppresses it, a
+    /// NEWER success supersedes it, and every other terminal phase
+    /// leaves it standing (a failed ceremony changed nothing).
+    #[test]
+    fn out_of_band_block_defers_to_live_and_newer_ceremonies() {
+        let observation = OutOfBandObservation {
+            account: Some(CeremonyAccount {
+                email: Some("b@x".to_string()),
+                ..Default::default()
+            }),
+            prior_label: Some("a@x".to_string()),
+            signed_out: false,
+            detected_at_unix_ms: 5_000,
+        };
+        use crate::auth_ceremony::CeremonyPhase;
+        for phase in [
+            CeremonyPhase::Starting,
+            CeremonyPhase::AwaitingBrowser,
+            CeremonyPhase::AwaitingCode,
+            CeremonyPhase::AwaitingUser,
+            CeremonyPhase::Verifying,
+        ] {
+            assert_eq!(
+                out_of_band_block(
+                    &serde_json::json!({ "phase": phase.as_str() }),
+                    &observation
+                ),
+                None,
+                "{} must suppress the block",
+                phase.as_str()
+            );
+        }
+        // A success that finished AFTER the observation supersedes it…
+        assert_eq!(
+            out_of_band_block(
+                &serde_json::json!({ "phase": "success", "finished_at_unix_ms": 6_000 }),
+                &observation
+            ),
+            None
+        );
+        // …an OLDER success does not, and neither do failure verdicts.
+        for status in [
+            serde_json::json!({ "phase": "success", "finished_at_unix_ms": 4_000 }),
+            serde_json::json!({ "phase": "idle" }),
+            serde_json::json!({ "phase": "idle", "busy_with": "codex" }),
+            serde_json::json!({ "phase": "failed", "finished_at_unix_ms": 6_000 }),
+            serde_json::json!({ "phase": "cancelled", "finished_at_unix_ms": 6_000 }),
+            serde_json::json!({ "phase": "timed_out", "finished_at_unix_ms": 6_000 }),
+        ] {
+            let block = out_of_band_block(&status, &observation).expect("block stands");
+            assert_eq!(block["reload_offer"], true);
+            assert_eq!(block["account"]["email"], "b@x");
+            assert_eq!(block["prior_account_label"], "a@x");
+            assert_eq!(block["detected_at_unix_ms"], 5_000);
+        }
+        // The sign-out shape: no account row, no reload offer.
+        let signed_out = OutOfBandObservation {
+            account: None,
+            prior_label: Some("a@x".to_string()),
+            signed_out: true,
+            detected_at_unix_ms: 5_000,
+        };
+        let block =
+            out_of_band_block(&serde_json::json!({ "phase": "idle" }), &signed_out).unwrap();
+        assert_eq!(block["reload_offer"], false);
+        assert_eq!(block["signed_out"], true);
+        assert!(block.get("account").is_none());
+    }
+
+    /// Per-backend applicability is explicit: Claude and Codex are
+    /// watched, Kimi's exclusion carries its reason, and the artifact
+    /// paths honor the same home-redirect env the availability probes
+    /// honor.
+    #[test]
+    fn applicability_and_artifact_paths_are_explicit() {
+        assert_eq!(out_of_scope_reason(Provider::Claude), None);
+        assert_eq!(out_of_scope_reason(Provider::Codex), None);
+        let kimi = out_of_scope_reason(Provider::Kimi).expect("kimi excluded");
+        assert!(kimi.contains("status probe"), "{kimi}");
+        let block = applicability_block(Provider::Kimi);
+        assert_eq!(block["watching"], false);
+        assert_eq!(block["reason"].as_str(), Some(kimi));
+
+        let home = Path::new("/home/owner");
+        assert_eq!(
+            claude_auth_file_in(None, home),
+            home.join(".claude/.credentials.json")
+        );
+        assert_eq!(
+            claude_auth_file_in(Some("/tmp/claude-rig".into()), home),
+            Path::new("/tmp/claude-rig/.credentials.json")
+        );
+        assert_eq!(
+            codex_auth_file_in(None, home),
+            home.join(".codex/auth.json")
+        );
+        assert_eq!(
+            codex_auth_file_in(Some("/tmp/codex-rig".into()), home),
+            Path::new("/tmp/codex-rig/auth.json")
+        );
+        assert_eq!(lease_kind(Provider::Claude), "oauth:claude-code");
+        assert_eq!(lease_kind(Provider::Codex), "oauth:codex");
+    }
+
+    /// The persisted-era baseline skips minted era nonces — an `era-N`
+    /// current era names no account, so the first tick adopts silently
+    /// instead of firing against it.
+    #[test]
+    fn persisted_baseline_skips_minted_era_nonces() {
+        let mut current: HashMap<String, crate::session_vitals::AccountEra> = HashMap::new();
+        current.insert("claude-code".to_string(), Some("a@x".to_string()));
+        current.insert("codex".to_string(), Some("era-7".to_string()));
+        assert_eq!(
+            persisted_identity(&current, "claude-code"),
+            Identity::SignedIn {
+                label: Some("a@x".to_string())
+            }
+        );
+        assert_eq!(persisted_identity(&current, "codex"), Identity::Unknown);
+        assert_eq!(persisted_identity(&current, "kimi"), Identity::Unknown);
+    }
+
+    /// AuthStamp reads: absent and directory paths read as `None` (real
+    /// states, never errors); a rewrite flips the stamp.
+    #[test]
+    fn stamp_reads_absence_and_change() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("auth.json");
+        assert_eq!(AuthStamp::read(&path), None, "absent artifact");
+        assert_eq!(AuthStamp::read(dir.path()), None, "a directory is not it");
+        std::fs::write(&path, b"one").unwrap();
+        let first = AuthStamp::read(&path).expect("present");
+        std::fs::write(&path, b"two-longer").unwrap();
+        let second = AuthStamp::read(&path).expect("present");
+        assert_ne!(first, second, "rewrite flips the stamp");
+    }
+}

--- a/src/bin/caller/credential_watch.rs
+++ b/src/bin/caller/credential_watch.rs
@@ -223,7 +223,9 @@ pub(crate) enum Identity {
     /// here adopts silently and can never fire.
     Unknown,
     SignedOut,
-    SignedIn { label: Option<String> },
+    SignedIn {
+        label: Option<String>,
+    },
 }
 
 impl Identity {
@@ -616,10 +618,8 @@ pub(crate) async fn run_identity_probe(
         .map_err(|e| format!("identity probe failed to spawn: {e}"))?;
     match provider {
         Provider::Claude => {
-            crate::claude_auth_ceremony::parse_auth_status(&String::from_utf8_lossy(
-                &output.stdout,
-            ))
-            .ok_or_else(|| "auth status output did not parse".to_string())
+            crate::claude_auth_ceremony::parse_auth_status(&String::from_utf8_lossy(&output.stdout))
+                .ok_or_else(|| "auth status output did not parse".to_string())
         }
         Provider::Codex => {
             let mut text = String::from_utf8_lossy(&output.stdout).into_owned();
@@ -643,9 +643,9 @@ fn persisted_identity(
     source: &str,
 ) -> Identity {
     match current.get(source).cloned().flatten() {
-        Some(label) if !crate::session_vitals::is_minted_era_label(&label) => Identity::SignedIn {
-            label: Some(label),
-        },
+        Some(label) if !crate::session_vitals::is_minted_era_label(&label) => {
+            Identity::SignedIn { label: Some(label) }
+        }
         _ => Identity::Unknown,
     }
 }

--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -297,7 +297,10 @@ pub enum AppEvent {
     /// hub consumes this to open a new credential era for the backend —
     /// sessions spawned or credential-reloaded from here on report their
     /// rate-limit windows under the new account instead of overwriting
-    /// the old one's.
+    /// the old one's. Two producers, one meaning: the sign-in ceremonies
+    /// (`auth_ceremony::announce_ceremony_success`) and the out-of-band
+    /// credential watch (`credential_watch`), which announces the same
+    /// era boundary for changes made directly at the backend CLI.
     BackendCredentialAccount {
         source: String,
         account: Option<String>,

--- a/src/bin/caller/external_agent/mod.rs
+++ b/src/bin/caller/external_agent/mod.rs
@@ -325,8 +325,10 @@ fn external_child_env_allowed(name: &str, passthrough: &HashSet<String>) -> bool
 /// Call this BEFORE a spawn site's deliberate `.env()` injections:
 /// explicit sets made after `env_clear()` survive it (the `INTENDANT_*`
 /// bootstrap env, leased `CODEX_HOME`/`CLAUDE_CONFIG_DIR`/`KIMI_CODE_HOME`/
-/// `PI_CODING_AGENT_DIR`, the Linux GUI env, trace roots).
-pub(super) fn apply_external_child_env_policy(command: &mut tokio::process::Command) {
+/// `PI_CODING_AGENT_DIR`, the Linux GUI env, trace roots). `pub(crate)`
+/// for the credential watch's identity probes, which run the same
+/// external CLIs and must not hand them the daemon's provider keys.
+pub(crate) fn apply_external_child_env_policy(command: &mut tokio::process::Command) {
     let passthrough = intendant_core::env_scrub::env_passthrough_set(
         std::env::var(intendant_core::env_scrub::ENV_PASSTHROUGH_VAR)
             .ok()

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -35,6 +35,7 @@ mod cli_descriptor;
 mod credential_audit;
 mod credential_egress;
 mod credential_leases;
+mod credential_watch;
 mod ctl;
 mod cu_observation;
 mod cu_readiness;

--- a/src/bin/caller/session_vitals.rs
+++ b/src/bin/caller/session_vitals.rs
@@ -692,6 +692,17 @@ pub(crate) struct SessionAccountMembership {
     pub(crate) account: AccountEra,
 }
 
+/// Whether an era label is a minted nonce (`era-N`) rather than an
+/// account label — the shape [`SessionVitalsHub::observe_backend_account`]
+/// mints for label-less sign-ins. The credential watch skips these when
+/// seeding its persisted-era baseline: a nonce names no account, so
+/// nothing can truthfully conflict with it.
+pub(crate) fn is_minted_era_label(label: &str) -> bool {
+    label
+        .strip_prefix("era-")
+        .is_some_and(|rest| !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_digit()))
+}
+
 /// The per-source current-era registry (see
 /// [`SessionVitalsHub::observe_backend_account`]).
 #[derive(Debug, Default)]
@@ -3652,6 +3663,27 @@ mod tests {
             .get(session_id)
             .map(|vitals| vitals.limits.clone())
             .unwrap_or_default()
+    }
+
+    /// The minted-nonce matcher recognizes exactly the shape
+    /// `observe_backend_account` mints for label-less sign-ins — the
+    /// credential watch relies on this to keep nonces out of its
+    /// persisted-era baseline.
+    #[test]
+    fn minted_era_label_matcher_pins_the_mint_format() {
+        let bus = EventBus::new();
+        let hub = SessionVitalsHub::new(bus);
+        hub.observe_backend_account("claude-code", None);
+        let minted = hub
+            .current_era("claude-code")
+            .expect("label-less sign-in mints an era");
+        assert!(
+            is_minted_era_label(&minted),
+            "the matcher must recognize the mint shape: {minted}"
+        );
+        for not_minted in ["a@x", "era-", "era-x", "era-1x", "owner@era-2.com", ""] {
+            assert!(!is_minted_era_label(not_minted), "{not_minted}");
+        }
     }
 
     /// THE COMMISSIONED KEYING PIN (2026-07-28): the limits fold is keyed

--- a/src/bin/caller/startup/daemon.rs
+++ b/src/bin/caller/startup/daemon.rs
@@ -162,6 +162,11 @@ pub(crate) async fn run_daemon(
     // hub's credential-era boundary); same publish-from-startup law as
     // the registries above so tests' manager use stays silent.
     crate::auth_ceremony::publish_ceremony_bus(bus.clone());
+    // Out-of-band credential changes announce on the same era boundary:
+    // a slow stat poll over the backend CLIs' own auth artifacts, one
+    // bounded identity probe per change, and the ceremony's reload
+    // surface + one info notification on a confirmed switch.
+    crate::credential_watch::spawn_credential_watch(bus.clone(), project_root.clone());
     // Collision radar (Track C, C2 — ruled §2.1): periodic zero-LLM
     // detection over bus declarations ∪ observed git status (the same
     // registry the vitals prober probes) ∪ open-PR file sets; publishes

--- a/src/bin/caller/startup/headless.rs
+++ b/src/bin/caller/startup/headless.rs
@@ -506,6 +506,9 @@ pub(crate) async fn run_headless_mode(
     // credential-era fold here too (the dashboard-on headless shape
     // serves the same Vault sign-in routes).
     crate::auth_ceremony::publish_ceremony_bus(bus.clone());
+    // And the out-of-band credential watch, for the same reason: this
+    // shape serves the auth-status routes that carry its observations.
+    crate::credential_watch::spawn_credential_watch(bus.clone(), Some(project.root.clone()));
     // Restored sessions, mirroring daemon boot: with the dashboard on,
     // the store's idle session windows keep their git/health chips here
     // too, and their vitals hydrate from disk (this shape falls through

--- a/src/bin/caller/web_gateway/routes_claude_auth.rs
+++ b/src/bin/caller/web_gateway/routes_claude_auth.rs
@@ -620,7 +620,10 @@ mod tests {
         // definition — the ceremony and watch stories may never drift
         // into separate reload lists.
         assert!(
-            fragment.matches("agentSigninReloadPanel(provider, spec)").count() >= 3,
+            fragment
+                .matches("agentSigninReloadPanel(provider, spec)")
+                .count()
+                >= 3,
             "the reload panel must be one shared implementation"
         );
     }

--- a/src/bin/caller/web_gateway/routes_claude_auth.rs
+++ b/src/bin/caller/web_gateway/routes_claude_auth.rs
@@ -97,10 +97,21 @@ fn start_mode_from_body(body_text: &str) -> Result<String, String> {
     }
 }
 
-/// Whether a status payload carries `reload_candidates`: exactly at
-/// `success`, the moment the Vault card offers the reload chips.
+/// Whether a status payload carries `reload_candidates`: at ceremony
+/// `success` (the moment the Vault card offers the reload chips), and
+/// whenever the credential watch's `out_of_band` block rides the payload
+/// with a reload offer — the SAME chips for a change made directly at
+/// the backend CLI (a sign-out observation carries no offer: reloading
+/// onto an empty store would be a trap, not a remedy).
 pub(crate) fn status_wants_reload_candidates(status: &serde_json::Value) -> bool {
-    status.get("phase").and_then(|v| v.as_str()) == Some("success")
+    if status.get("phase").and_then(|v| v.as_str()) == Some("success") {
+        return true;
+    }
+    status
+        .get("out_of_band")
+        .and_then(|block| block.get("reload_offer"))
+        .and_then(|v| v.as_bool())
+        == Some(true)
 }
 
 /// Merge the live registry's reload candidates into a status payload —
@@ -115,18 +126,27 @@ pub(crate) fn status_with_reload_candidates(
     status
 }
 
-/// The provider's auth-status payload; at `success` it carries
-/// `reload_candidates` derived from the LIVE session registry — the
-/// exact candidate set `route_reload_credentials` accepts, replacing the
-/// disk-catalog filtering that listed dead pre-restart sessions as live
-/// and aged parked ones off. Shared by all three providers' status
-/// routes and their tunnel twins.
+/// The provider's auth-status payload; at `success` — and whenever the
+/// out-of-band credential watch has an unsuperseded observation — it
+/// carries `reload_candidates` derived from the LIVE session registry:
+/// the exact candidate set `route_reload_credentials` accepts, replacing
+/// the disk-catalog filtering that listed dead pre-restart sessions as
+/// live and aged parked ones off. The watch's `out_of_band` block and
+/// its `credential_watch` applicability block ride the same body, so the
+/// Vault card renders one atomic truth. Shared by all three providers'
+/// status routes and their tunnel twins.
 pub(crate) async fn auth_status_payload(provider: Provider) -> serde_json::Value {
-    let status = auth_ceremony::manager().status_value_for(provider);
+    let mut status = auth_ceremony::manager().status_value_for(provider);
+    let source = provider.agent_backend().as_short_str();
+    if let Some(observation) = crate::credential_watch::observation_for(source) {
+        if let Some(block) = crate::credential_watch::out_of_band_block(&status, &observation) {
+            status["out_of_band"] = block;
+        }
+    }
+    status["credential_watch"] = crate::credential_watch::applicability_block(provider);
     if !status_wants_reload_candidates(&status) {
         return status;
     }
-    let source = provider.agent_backend().as_short_str();
     let candidates = match crate::session_supervisor::published_live_session_registry() {
         Some(registry) => registry.reload_candidates_for_source(source).await,
         // No supervisor ⇒ no supervised sessions ⇒ nothing reloadable:

--- a/src/bin/caller/web_gateway/routes_claude_auth.rs
+++ b/src/bin/caller/web_gateway/routes_claude_auth.rs
@@ -538,4 +538,90 @@ mod tests {
         assert_eq!(status, 409);
         assert!(body["error"].as_str().unwrap().contains("no sign-in"));
     }
+
+    /// The out-of-band lane rides the same body discipline as the
+    /// ceremony success: a credential-watch observation with a reload
+    /// offer makes the payload carry `reload_candidates` at any ceremony
+    /// phase — the SAME list, the same atomic body — while a sign-out
+    /// observation (nothing to reload onto) offers none, and a payload
+    /// without the block keeps the success-only rule.
+    #[test]
+    fn out_of_band_observations_carry_the_same_reload_surface() {
+        let base = serde_json::json!({ "phase": "idle" });
+        assert!(!status_wants_reload_candidates(&base));
+
+        let switched = crate::credential_watch::OutOfBandObservation {
+            account: Some(crate::auth_ceremony::CeremonyAccount {
+                email: Some("b@x".to_string()),
+                subscription_type: Some("max".to_string()),
+                org_name: None,
+                auth_method: Some("claudeai".to_string()),
+            }),
+            prior_label: Some("a@x".to_string()),
+            signed_out: false,
+            detected_at_unix_ms: 5_000,
+        };
+        let mut status = base.clone();
+        status["out_of_band"] = crate::credential_watch::out_of_band_block(&base, &switched)
+            .expect("idle payloads serve the block");
+        assert!(
+            status_wants_reload_candidates(&status),
+            "an out-of-band switch offers the reload surface"
+        );
+        let merged = status_with_reload_candidates(
+            status,
+            vec![crate::session_supervisor::ReloadCandidate {
+                session_id: "wrapper-1".to_string(),
+                source: "claude-code".to_string(),
+                name: Some("steward pass".to_string()),
+                phase: "waiting_rate_limit".to_string(),
+                reload: None,
+            }],
+        );
+        assert_eq!(merged["out_of_band"]["account"]["email"], "b@x");
+        assert_eq!(merged["out_of_band"]["prior_account_label"], "a@x");
+        assert_eq!(merged["reload_candidates"][0]["session_id"], "wrapper-1");
+
+        let signed_out = crate::credential_watch::OutOfBandObservation {
+            account: None,
+            prior_label: Some("b@x".to_string()),
+            signed_out: true,
+            detected_at_unix_ms: 6_000,
+        };
+        let mut status = base.clone();
+        status["out_of_band"] = crate::credential_watch::out_of_band_block(&base, &signed_out)
+            .expect("sign-out still serves the block");
+        assert!(
+            !status_wants_reload_candidates(&status),
+            "reloading onto an empty store is a trap, not a remedy"
+        );
+    }
+
+    /// The Vault card renders the out-of-band story with the SAME reload
+    /// panel the ceremony success renders: one implementation
+    /// (`agentSigninReloadPanel`), called from both stories, plus the
+    /// out-of-band notice copy and the watch's applicability honesty.
+    #[test]
+    fn out_of_band_renders_the_same_reload_panel_on_the_vault_card() {
+        let fragment = vault_fragment();
+        assert!(
+            fragment.contains("agentSigninOutOfBandSection"),
+            "the out-of-band section must exist"
+        );
+        assert!(
+            fragment.contains("changed outside Intendant"),
+            "the notice copy must name the out-of-band fact"
+        );
+        assert!(
+            fragment.contains("agentSigninWatchNotes"),
+            "the applicability honesty notes must render"
+        );
+        // One panel, ≥2 call sites (success + out-of-band) besides the
+        // definition — the ceremony and watch stories may never drift
+        // into separate reload lists.
+        assert!(
+            fragment.matches("agentSigninReloadPanel(provider, spec)").count() >= 3,
+            "the reload panel must be one shared implementation"
+        );
+    }
 }

--- a/static/app.html
+++ b/static/app.html
@@ -38267,7 +38267,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'ee53f229640920dd';
+const INTENDANT_APP_BUILD = '8084464841302c83';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -44150,6 +44150,166 @@ function agentSigninReloadLifecycleChip(reload) {
   return null;
 }
 
+/* The reload panel: the served candidate list + reload-all, rendered
+   identically for a ceremony success and an out-of-band change — one
+   panel, one daemon corpus (the `reload_candidates` riding the same
+   status body as whichever story offered them). */
+function agentSigninReloadPanel(provider, spec) {
+  const frag = document.createDocumentFragment();
+  const panelNote = (text, cls = 'vault-note') => {
+    const el = document.createElement('div');
+    el.className = cls;
+    el.textContent = text;
+    frag.appendChild(el);
+    return el;
+  };
+  const reloadCandidates = agentSigninReloadCandidates(provider);
+  const reloadHead = document.createElement('div');
+  reloadHead.className = 'vault-status-line';
+  const reloadTitle = document.createElement('span');
+  reloadTitle.className = 'lbl';
+  reloadTitle.style.fontWeight = '600';
+  reloadTitle.textContent = spec.sessionsTitle;
+  reloadHead.appendChild(reloadTitle);
+  if (reloadCandidates.length > 1) {
+    const allActions = document.createElement('span');
+    allActions.className = 'vault-entry-actions';
+    allActions.appendChild(
+      vaultButton(`Reload all ${reloadCandidates.length}`, () =>
+        agentSigninReloadAllSessions(provider)
+      )
+    );
+    reloadHead.appendChild(allActions);
+  }
+  frag.appendChild(reloadHead);
+  if (!reloadCandidates.length) {
+    panelNote(spec.noSessionsNote);
+    return frag;
+  }
+  panelNote('Live sessions — including parked and rate-limited ones — keep the old account until reloaded. Reloading restarts the backend on the same conversation; a mid-turn session is interrupted first.');
+  const list = document.createElement('div');
+  list.className = 'vault-entry-list';
+  for (const session of reloadCandidates) {
+    const sessionId = String(session.session_id || '');
+    const row = document.createElement('div');
+    row.className = 'vault-entry-row';
+    row.title = sessionId;
+    const lbl = document.createElement('span');
+    lbl.className = 'lbl';
+    lbl.textContent = session.name || 'session';
+    // The short-id chip (the session grid's first-8 dialect): with
+    // derived names, duplicate labels are otherwise unidentifiable —
+    // the id is what `intendant ctl` and the grid speak.
+    const idChip = document.createElement('span');
+    idChip.className = 'vault-chip';
+    idChip.textContent = sessionId.slice(0, 8) || '—';
+    idChip.title = sessionId;
+    const kindChip = document.createElement('span');
+    kindChip.className = 'vault-chip';
+    kindChip.textContent = spec.sessionKind;
+    const sessionState = agentSigninSessionStateChip(session);
+    const stateChip = document.createElement('span');
+    stateChip.className = 'vault-chip' + (sessionState.cls ? ` ${sessionState.cls}` : '');
+    stateChip.textContent = sessionState.label;
+    stateChip.title =
+      sessionState.label === 'rate-limited'
+        ? 'Rate-limit park — the backend is alive and stays on the old account until reloaded'
+        : 'Session state — alive sessions stay on the old account until reloaded';
+    const actions = document.createElement('span');
+    actions.className = 'vault-entry-actions';
+    // The actions cell renders the daemon's served lifecycle, and
+    // ONLY that: in-flight states stand in for the button; terminal
+    // states (done/failed) sit beside it as history. The button is
+    // therefore always available again the moment the daemon stops
+    // working — nothing client-side can latch a row.
+    const lifecycle = agentSigninReloadLifecycleChip(session.reload);
+    if (lifecycle) {
+      const chip = document.createElement('span');
+      chip.className = 'vault-chip' + (lifecycle.cls ? ` ${lifecycle.cls}` : '');
+      chip.textContent = lifecycle.label;
+      chip.title = lifecycle.title;
+      actions.appendChild(chip);
+    }
+    if (!lifecycle || !lifecycle.inFlight) {
+      actions.appendChild(
+        vaultButton('Reload credentials', () => agentSigninReloadSession(provider, sessionId))
+      );
+    }
+    row.append(lbl, idChip, kindChip, stateChip, actions);
+    list.appendChild(row);
+  }
+  frag.appendChild(list);
+  return frag;
+}
+
+/* The out-of-band story: the daemon's credential watch confirmed the
+   backend's auth store changed OUTSIDE any sign-in ceremony (a direct
+   CLI re-auth or sign-out). The daemon serves `out_of_band` only while
+   it is the NEWEST credential truth — a later ceremony success
+   supersedes it — and the block rides the same reload_candidates the
+   ceremony success rides, so the same reload panel renders them. */
+function agentSigninOutOfBandSection(provider, spec, status) {
+  const block = status?.out_of_band;
+  if (!block) return null;
+  const frag = document.createDocumentFragment();
+  const ago = agentSigninAgo(Number(block.detected_at_unix_ms)) || 'just now';
+  const notice = document.createElement('div');
+  notice.className = 'vault-warning';
+  const was = block.prior_account_label ? ` (was ${block.prior_account_label})` : '';
+  notice.textContent = block.signed_out
+    ? `${spec.label} was signed out outside Intendant ${ago}${was}. Live sessions keep the old account in-process until they restart.`
+    : `${spec.label} credentials changed outside Intendant ${ago}${was}. Live sessions keep the old account until reloaded.`;
+  frag.appendChild(notice);
+  const account = block.account || null;
+  if (account) {
+    const row = document.createElement('div');
+    row.className = 'vault-entry-row';
+    const lbl = document.createElement('span');
+    lbl.className = 'lbl';
+    lbl.textContent = account.email || 'Signed in';
+    row.appendChild(lbl);
+    if (account.subscription_type) {
+      const plan = document.createElement('span');
+      plan.className = 'vault-chip ok';
+      plan.textContent = account.subscription_type;
+      row.appendChild(plan);
+    }
+    if (account.org_name) {
+      const org = document.createElement('span');
+      org.className = 'vault-chip';
+      org.textContent = account.org_name;
+      row.appendChild(org);
+    }
+    frag.appendChild(row);
+  }
+  if (block.reload_offer) {
+    frag.appendChild(agentSigninReloadPanel(provider, spec));
+  }
+  return frag;
+}
+
+/* Applicability honesty for the credential watch, rendered only where
+   it says something actionable: an unwatched backend names its reason
+   (tooltip carries the full text), a watched-but-fileless artifact
+   admits the stat poll's blind spot, and a probe give-up is surfaced
+   instead of silently unverified changes. */
+function agentSigninWatchNotes(status, note) {
+  const watch = status?.credential_watch;
+  if (!watch) return;
+  if (watch.watching === false && watch.reason) {
+    const el = note('Out-of-band credential changes are not watched for this backend.');
+    el.title = String(watch.reason);
+  } else if (watch.watching === true && watch.artifact_present === false) {
+    note(
+      'No on-disk auth file to watch — credential changes made outside Intendant (e.g. via the OS keychain) may go unnoticed until this backend next speaks.'
+    );
+  }
+  if (watch.probe_error) {
+    const el = note('The credential store changed but its identity probe is failing — the change was adopted unverified.', 'vault-error');
+    el.title = String(watch.probe_error);
+  }
+}
+
 function renderAgentSigninSection() {
   const mount = document.getElementById('agent-signin-section');
   if (!mount) return;
@@ -44246,6 +44406,11 @@ function agentSigninProviderCard(provider) {
   }
 
   if (phase === 'idle' || ['failed', 'cancelled', 'timed_out'].includes(phase)) {
+    // A confirmed out-of-band change renders first — it is the newest
+    // credential truth, and it carries the reload panel with it.
+    const outOfBand = agentSigninOutOfBandSection(provider, spec, status);
+    if (outOfBand) card.appendChild(outOfBand);
+    agentSigninWatchNotes(status, note);
     // The shared single-flight slot: the daemon reports which provider
     // holds it, and a start here would 409 until that ceremony ends.
     const busyWith = String(status?.busy_with || '');
@@ -44399,6 +44564,16 @@ function agentSigninProviderCard(provider) {
   }
 
   if (phase === 'success') {
+    const outOfBand = agentSigninOutOfBandSection(provider, spec, status);
+    if (outOfBand) {
+      // The daemon serves out_of_band only when it is NEWER than this
+      // success — the store changed again, directly at the CLI, after
+      // the ceremony. The stale success story yields to it.
+      card.appendChild(outOfBand);
+      agentSigninWatchNotes(status, note);
+      actionsRow(vaultButton('Sign in again', () => agentSigninStart(provider)));
+      return card;
+    }
     const account = status?.account || null;
     if (account) {
       const row = document.createElement('div');
@@ -44434,85 +44609,10 @@ function agentSigninProviderCard(provider) {
     // rate-limit-parked — keep the OLD account until their backend
     // process restarts. Offer the per-session reload (graceful in-place
     // respawn, resume-attached); parked sessions are the ones pinned to
-    // the old account longest, so they matter most here. The list is the
-    // status payload's reload_candidates — the daemon's live registry,
-    // exactly as fresh as the success phase it arrived with.
-    const reloadCandidates = agentSigninReloadCandidates(provider);
-    const reloadHead = document.createElement('div');
-    reloadHead.className = 'vault-status-line';
-    const reloadTitle = document.createElement('span');
-    reloadTitle.className = 'lbl';
-    reloadTitle.style.fontWeight = '600';
-    reloadTitle.textContent = spec.sessionsTitle;
-    reloadHead.appendChild(reloadTitle);
-    if (reloadCandidates.length > 1) {
-      const allActions = document.createElement('span');
-      allActions.className = 'vault-entry-actions';
-      allActions.appendChild(
-        vaultButton(`Reload all ${reloadCandidates.length}`, () =>
-          agentSigninReloadAllSessions(provider)
-        )
-      );
-      reloadHead.appendChild(allActions);
-    }
-    card.appendChild(reloadHead);
-    if (!reloadCandidates.length) {
-      note(spec.noSessionsNote);
-    } else {
-      note('Live sessions — including parked and rate-limited ones — keep the old account until reloaded. Reloading restarts the backend on the same conversation; a mid-turn session is interrupted first.');
-      const list = document.createElement('div');
-      list.className = 'vault-entry-list';
-      for (const session of reloadCandidates) {
-        const sessionId = String(session.session_id || '');
-        const row = document.createElement('div');
-        row.className = 'vault-entry-row';
-        row.title = sessionId;
-        const lbl = document.createElement('span');
-        lbl.className = 'lbl';
-        lbl.textContent = session.name || 'session';
-        // The short-id chip (the session grid's first-8 dialect): with
-        // derived names, duplicate labels are otherwise unidentifiable —
-        // the id is what `intendant ctl` and the grid speak.
-        const idChip = document.createElement('span');
-        idChip.className = 'vault-chip';
-        idChip.textContent = sessionId.slice(0, 8) || '—';
-        idChip.title = sessionId;
-        const kindChip = document.createElement('span');
-        kindChip.className = 'vault-chip';
-        kindChip.textContent = spec.sessionKind;
-        const sessionState = agentSigninSessionStateChip(session);
-        const stateChip = document.createElement('span');
-        stateChip.className = 'vault-chip' + (sessionState.cls ? ` ${sessionState.cls}` : '');
-        stateChip.textContent = sessionState.label;
-        stateChip.title =
-          sessionState.label === 'rate-limited'
-            ? 'Rate-limit park — the backend is alive and stays on the old account until reloaded'
-            : 'Session state — alive sessions stay on the old account until reloaded';
-        const actions = document.createElement('span');
-        actions.className = 'vault-entry-actions';
-        // The actions cell renders the daemon's served lifecycle, and
-        // ONLY that: in-flight states stand in for the button; terminal
-        // states (done/failed) sit beside it as history. The button is
-        // therefore always available again the moment the daemon stops
-        // working — nothing client-side can latch a row.
-        const lifecycle = agentSigninReloadLifecycleChip(session.reload);
-        if (lifecycle) {
-          const chip = document.createElement('span');
-          chip.className = 'vault-chip' + (lifecycle.cls ? ` ${lifecycle.cls}` : '');
-          chip.textContent = lifecycle.label;
-          chip.title = lifecycle.title;
-          actions.appendChild(chip);
-        }
-        if (!lifecycle || !lifecycle.inFlight) {
-          actions.appendChild(
-            vaultButton('Reload credentials', () => agentSigninReloadSession(provider, sessionId))
-          );
-        }
-        row.append(lbl, idChip, kindChip, stateChip, actions);
-        list.appendChild(row);
-      }
-      card.appendChild(list);
-    }
+    // the old account longest, so they matter most here. The panel is
+    // the status payload's reload_candidates — the daemon's live
+    // registry, exactly as fresh as the success phase it arrived with.
+    card.appendChild(agentSigninReloadPanel(provider, spec));
     actionsRow(vaultButton('Sign in again', () => agentSigninStart(provider)));
     return card;
   }

--- a/static/app/32-vault-custody.js
+++ b/static/app/32-vault-custody.js
@@ -2072,6 +2072,166 @@ function agentSigninReloadLifecycleChip(reload) {
   return null;
 }
 
+/* The reload panel: the served candidate list + reload-all, rendered
+   identically for a ceremony success and an out-of-band change — one
+   panel, one daemon corpus (the `reload_candidates` riding the same
+   status body as whichever story offered them). */
+function agentSigninReloadPanel(provider, spec) {
+  const frag = document.createDocumentFragment();
+  const panelNote = (text, cls = 'vault-note') => {
+    const el = document.createElement('div');
+    el.className = cls;
+    el.textContent = text;
+    frag.appendChild(el);
+    return el;
+  };
+  const reloadCandidates = agentSigninReloadCandidates(provider);
+  const reloadHead = document.createElement('div');
+  reloadHead.className = 'vault-status-line';
+  const reloadTitle = document.createElement('span');
+  reloadTitle.className = 'lbl';
+  reloadTitle.style.fontWeight = '600';
+  reloadTitle.textContent = spec.sessionsTitle;
+  reloadHead.appendChild(reloadTitle);
+  if (reloadCandidates.length > 1) {
+    const allActions = document.createElement('span');
+    allActions.className = 'vault-entry-actions';
+    allActions.appendChild(
+      vaultButton(`Reload all ${reloadCandidates.length}`, () =>
+        agentSigninReloadAllSessions(provider)
+      )
+    );
+    reloadHead.appendChild(allActions);
+  }
+  frag.appendChild(reloadHead);
+  if (!reloadCandidates.length) {
+    panelNote(spec.noSessionsNote);
+    return frag;
+  }
+  panelNote('Live sessions — including parked and rate-limited ones — keep the old account until reloaded. Reloading restarts the backend on the same conversation; a mid-turn session is interrupted first.');
+  const list = document.createElement('div');
+  list.className = 'vault-entry-list';
+  for (const session of reloadCandidates) {
+    const sessionId = String(session.session_id || '');
+    const row = document.createElement('div');
+    row.className = 'vault-entry-row';
+    row.title = sessionId;
+    const lbl = document.createElement('span');
+    lbl.className = 'lbl';
+    lbl.textContent = session.name || 'session';
+    // The short-id chip (the session grid's first-8 dialect): with
+    // derived names, duplicate labels are otherwise unidentifiable —
+    // the id is what `intendant ctl` and the grid speak.
+    const idChip = document.createElement('span');
+    idChip.className = 'vault-chip';
+    idChip.textContent = sessionId.slice(0, 8) || '—';
+    idChip.title = sessionId;
+    const kindChip = document.createElement('span');
+    kindChip.className = 'vault-chip';
+    kindChip.textContent = spec.sessionKind;
+    const sessionState = agentSigninSessionStateChip(session);
+    const stateChip = document.createElement('span');
+    stateChip.className = 'vault-chip' + (sessionState.cls ? ` ${sessionState.cls}` : '');
+    stateChip.textContent = sessionState.label;
+    stateChip.title =
+      sessionState.label === 'rate-limited'
+        ? 'Rate-limit park — the backend is alive and stays on the old account until reloaded'
+        : 'Session state — alive sessions stay on the old account until reloaded';
+    const actions = document.createElement('span');
+    actions.className = 'vault-entry-actions';
+    // The actions cell renders the daemon's served lifecycle, and
+    // ONLY that: in-flight states stand in for the button; terminal
+    // states (done/failed) sit beside it as history. The button is
+    // therefore always available again the moment the daemon stops
+    // working — nothing client-side can latch a row.
+    const lifecycle = agentSigninReloadLifecycleChip(session.reload);
+    if (lifecycle) {
+      const chip = document.createElement('span');
+      chip.className = 'vault-chip' + (lifecycle.cls ? ` ${lifecycle.cls}` : '');
+      chip.textContent = lifecycle.label;
+      chip.title = lifecycle.title;
+      actions.appendChild(chip);
+    }
+    if (!lifecycle || !lifecycle.inFlight) {
+      actions.appendChild(
+        vaultButton('Reload credentials', () => agentSigninReloadSession(provider, sessionId))
+      );
+    }
+    row.append(lbl, idChip, kindChip, stateChip, actions);
+    list.appendChild(row);
+  }
+  frag.appendChild(list);
+  return frag;
+}
+
+/* The out-of-band story: the daemon's credential watch confirmed the
+   backend's auth store changed OUTSIDE any sign-in ceremony (a direct
+   CLI re-auth or sign-out). The daemon serves `out_of_band` only while
+   it is the NEWEST credential truth — a later ceremony success
+   supersedes it — and the block rides the same reload_candidates the
+   ceremony success rides, so the same reload panel renders them. */
+function agentSigninOutOfBandSection(provider, spec, status) {
+  const block = status?.out_of_band;
+  if (!block) return null;
+  const frag = document.createDocumentFragment();
+  const ago = agentSigninAgo(Number(block.detected_at_unix_ms)) || 'just now';
+  const notice = document.createElement('div');
+  notice.className = 'vault-warning';
+  const was = block.prior_account_label ? ` (was ${block.prior_account_label})` : '';
+  notice.textContent = block.signed_out
+    ? `${spec.label} was signed out outside Intendant ${ago}${was}. Live sessions keep the old account in-process until they restart.`
+    : `${spec.label} credentials changed outside Intendant ${ago}${was}. Live sessions keep the old account until reloaded.`;
+  frag.appendChild(notice);
+  const account = block.account || null;
+  if (account) {
+    const row = document.createElement('div');
+    row.className = 'vault-entry-row';
+    const lbl = document.createElement('span');
+    lbl.className = 'lbl';
+    lbl.textContent = account.email || 'Signed in';
+    row.appendChild(lbl);
+    if (account.subscription_type) {
+      const plan = document.createElement('span');
+      plan.className = 'vault-chip ok';
+      plan.textContent = account.subscription_type;
+      row.appendChild(plan);
+    }
+    if (account.org_name) {
+      const org = document.createElement('span');
+      org.className = 'vault-chip';
+      org.textContent = account.org_name;
+      row.appendChild(org);
+    }
+    frag.appendChild(row);
+  }
+  if (block.reload_offer) {
+    frag.appendChild(agentSigninReloadPanel(provider, spec));
+  }
+  return frag;
+}
+
+/* Applicability honesty for the credential watch, rendered only where
+   it says something actionable: an unwatched backend names its reason
+   (tooltip carries the full text), a watched-but-fileless artifact
+   admits the stat poll's blind spot, and a probe give-up is surfaced
+   instead of silently unverified changes. */
+function agentSigninWatchNotes(status, note) {
+  const watch = status?.credential_watch;
+  if (!watch) return;
+  if (watch.watching === false && watch.reason) {
+    const el = note('Out-of-band credential changes are not watched for this backend.');
+    el.title = String(watch.reason);
+  } else if (watch.watching === true && watch.artifact_present === false) {
+    note(
+      'No on-disk auth file to watch — credential changes made outside Intendant (e.g. via the OS keychain) may go unnoticed until this backend next speaks.'
+    );
+  }
+  if (watch.probe_error) {
+    const el = note('The credential store changed but its identity probe is failing — the change was adopted unverified.', 'vault-error');
+    el.title = String(watch.probe_error);
+  }
+}
+
 function renderAgentSigninSection() {
   const mount = document.getElementById('agent-signin-section');
   if (!mount) return;
@@ -2168,6 +2328,11 @@ function agentSigninProviderCard(provider) {
   }
 
   if (phase === 'idle' || ['failed', 'cancelled', 'timed_out'].includes(phase)) {
+    // A confirmed out-of-band change renders first — it is the newest
+    // credential truth, and it carries the reload panel with it.
+    const outOfBand = agentSigninOutOfBandSection(provider, spec, status);
+    if (outOfBand) card.appendChild(outOfBand);
+    agentSigninWatchNotes(status, note);
     // The shared single-flight slot: the daemon reports which provider
     // holds it, and a start here would 409 until that ceremony ends.
     const busyWith = String(status?.busy_with || '');
@@ -2321,6 +2486,16 @@ function agentSigninProviderCard(provider) {
   }
 
   if (phase === 'success') {
+    const outOfBand = agentSigninOutOfBandSection(provider, spec, status);
+    if (outOfBand) {
+      // The daemon serves out_of_band only when it is NEWER than this
+      // success — the store changed again, directly at the CLI, after
+      // the ceremony. The stale success story yields to it.
+      card.appendChild(outOfBand);
+      agentSigninWatchNotes(status, note);
+      actionsRow(vaultButton('Sign in again', () => agentSigninStart(provider)));
+      return card;
+    }
     const account = status?.account || null;
     if (account) {
       const row = document.createElement('div');
@@ -2356,85 +2531,10 @@ function agentSigninProviderCard(provider) {
     // rate-limit-parked — keep the OLD account until their backend
     // process restarts. Offer the per-session reload (graceful in-place
     // respawn, resume-attached); parked sessions are the ones pinned to
-    // the old account longest, so they matter most here. The list is the
-    // status payload's reload_candidates — the daemon's live registry,
-    // exactly as fresh as the success phase it arrived with.
-    const reloadCandidates = agentSigninReloadCandidates(provider);
-    const reloadHead = document.createElement('div');
-    reloadHead.className = 'vault-status-line';
-    const reloadTitle = document.createElement('span');
-    reloadTitle.className = 'lbl';
-    reloadTitle.style.fontWeight = '600';
-    reloadTitle.textContent = spec.sessionsTitle;
-    reloadHead.appendChild(reloadTitle);
-    if (reloadCandidates.length > 1) {
-      const allActions = document.createElement('span');
-      allActions.className = 'vault-entry-actions';
-      allActions.appendChild(
-        vaultButton(`Reload all ${reloadCandidates.length}`, () =>
-          agentSigninReloadAllSessions(provider)
-        )
-      );
-      reloadHead.appendChild(allActions);
-    }
-    card.appendChild(reloadHead);
-    if (!reloadCandidates.length) {
-      note(spec.noSessionsNote);
-    } else {
-      note('Live sessions — including parked and rate-limited ones — keep the old account until reloaded. Reloading restarts the backend on the same conversation; a mid-turn session is interrupted first.');
-      const list = document.createElement('div');
-      list.className = 'vault-entry-list';
-      for (const session of reloadCandidates) {
-        const sessionId = String(session.session_id || '');
-        const row = document.createElement('div');
-        row.className = 'vault-entry-row';
-        row.title = sessionId;
-        const lbl = document.createElement('span');
-        lbl.className = 'lbl';
-        lbl.textContent = session.name || 'session';
-        // The short-id chip (the session grid's first-8 dialect): with
-        // derived names, duplicate labels are otherwise unidentifiable —
-        // the id is what `intendant ctl` and the grid speak.
-        const idChip = document.createElement('span');
-        idChip.className = 'vault-chip';
-        idChip.textContent = sessionId.slice(0, 8) || '—';
-        idChip.title = sessionId;
-        const kindChip = document.createElement('span');
-        kindChip.className = 'vault-chip';
-        kindChip.textContent = spec.sessionKind;
-        const sessionState = agentSigninSessionStateChip(session);
-        const stateChip = document.createElement('span');
-        stateChip.className = 'vault-chip' + (sessionState.cls ? ` ${sessionState.cls}` : '');
-        stateChip.textContent = sessionState.label;
-        stateChip.title =
-          sessionState.label === 'rate-limited'
-            ? 'Rate-limit park — the backend is alive and stays on the old account until reloaded'
-            : 'Session state — alive sessions stay on the old account until reloaded';
-        const actions = document.createElement('span');
-        actions.className = 'vault-entry-actions';
-        // The actions cell renders the daemon's served lifecycle, and
-        // ONLY that: in-flight states stand in for the button; terminal
-        // states (done/failed) sit beside it as history. The button is
-        // therefore always available again the moment the daemon stops
-        // working — nothing client-side can latch a row.
-        const lifecycle = agentSigninReloadLifecycleChip(session.reload);
-        if (lifecycle) {
-          const chip = document.createElement('span');
-          chip.className = 'vault-chip' + (lifecycle.cls ? ` ${lifecycle.cls}` : '');
-          chip.textContent = lifecycle.label;
-          chip.title = lifecycle.title;
-          actions.appendChild(chip);
-        }
-        if (!lifecycle || !lifecycle.inFlight) {
-          actions.appendChild(
-            vaultButton('Reload credentials', () => agentSigninReloadSession(provider, sessionId))
-          );
-        }
-        row.append(lbl, idChip, kindChip, stateChip, actions);
-        list.appendChild(row);
-      }
-      card.appendChild(list);
-    }
+    // the old account longest, so they matter most here. The panel is
+    // the status payload's reload_candidates — the daemon's live
+    // registry, exactly as fresh as the success phase it arrived with.
+    card.appendChild(agentSigninReloadPanel(provider, spec));
     actionsRow(vaultButton('Sign in again', () => agentSigninStart(provider)));
     return card;
   }

--- a/tests/skills/credential-watch-rig/SKILL.md
+++ b/tests/skills/credential-watch-rig/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: credential-watch-rig
+description: Keyless rig for the out-of-band credential watch — scratch auth file + stub claude CLI under a fast poll; proves an account switch made outside Intendant is detected within one poll interval and delivered as the one info notification, secret-free
+---
+
+# Credential-watch rig (out-of-band change detection)
+
+Card 01KYT12BZ1G8V4XKVCYFCSQ5JT's rig leg: the daemon's credential
+watch (`credential_watch.rs`) must notice a backend re-authentication
+made directly at the CLI — no ceremony, no backend announce — within
+one poll interval, and deliver exactly the surface the card names (era
+mint + reload candidates ride the same fire; those are pinned by unit
+tests, this rig proves the live detection loop end to end). No API
+keys, no network, no real credential store touched, ~10 seconds. Unix
+(the stub CLI is a `/bin/sh` script).
+
+```bash
+cargo build --release --bin intendant --bin intendant-runtime
+node tests/skills/credential-watch-rig/driver.cjs "$PWD/target/release/intendant"
+```
+
+The driver builds a temp `$HOME` holding a scratch
+`~/.claude/.credentials.json` (fake bytes — the watch must never read
+them) and a stub `claude` whose `auth status` answers with whatever
+identity a state file names; the project's `intendant.toml` points
+`[agent.claude_code] command` at the stub, and
+`INTENDANT_CREDENTIAL_POLL_MS=400` makes the interval rig-fast. It
+spawns a mock-provider daemon with a trivial task, waits for the
+watch's baseline tick to adopt account A, then — the out-of-band act —
+flips the stub to account B and rewrites the scratch auth file,
+exactly what a direct `claude` re-login does. It asserts on the
+control socket:
+
+- a `user_notification` with id `credential-change-claude-code`
+  arrives within one poll interval (+ probe/delivery slack) of the
+  rewrite;
+- the copy names the switch (`now signed in as rig-b@example.com`,
+  `(was rig-a@example.com)`) and the reload story, at `info` urgency;
+- no scratch-file bytes appear in the notification (labels only).
+
+Gotchas encoded:
+
+- `HOME` is the temp dir, so the default `~/.claude` resolution is
+  exercised without touching the real box; `CLAUDE_CONFIG_DIR` /
+  `CODEX_HOME` are stripped from the spawn env so an operator shell
+  can't redirect the rig.
+- The stub bakes the state-file path in absolutely: the identity
+  probe runs under the external-child env policy (base allowlist
+  only), so env-var plumbing into the stub would be silently dropped.
+- The baseline wait matters: the watch's first tick adopts the
+  starting identity from Unknown (the temp state root has no
+  persisted era), and only a probe-confirmed CONFLICT fires — flip
+  the stub before the baseline lands and the rig sees no change at
+  all.

--- a/tests/skills/credential-watch-rig/driver.cjs
+++ b/tests/skills/credential-watch-rig/driver.cjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+// Credential-watch rig: scratch auth file + stub `claude` CLI under a
+// fast poll; prove an out-of-band account switch is detected within one
+// poll interval and delivered as the one info notification (the era
+// mint and reload surface ride the same fire — pinned by unit tests).
+const { spawn } = require('child_process');
+const fs = require('fs');
+const net = require('net');
+const os = require('os');
+const path = require('path');
+
+const BINARY = process.argv[2];
+const POLL_MS = 400;
+const HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'credwatch-home-'));
+const PROJ = fs.mkdtempSync(path.join(os.tmpdir(), 'credwatch-proj-'));
+
+// The scratch auth artifact at the default resolution ($HOME/.claude/
+// .credentials.json — HOME is the temp dir, so the real box is never
+// touched). Content is fake; the watch must never read it anyway.
+const CLAUDE_DIR = path.join(HOME, '.claude');
+fs.mkdirSync(CLAUDE_DIR, { recursive: true });
+const AUTH_FILE = path.join(CLAUDE_DIR, '.credentials.json');
+fs.writeFileSync(AUTH_FILE, JSON.stringify({ fake: 'account-a-material' }));
+
+// The stub CLI: `claude auth status` answers with whatever identity the
+// state file names (absolute path baked in — the probe's env policy
+// strips everything but the base allowlist, so no env plumbing).
+const IDENTITY_FILE = path.join(HOME, 'identity.json');
+const identity = (email) =>
+  JSON.stringify({ loggedIn: true, authMethod: 'claudeai', email, subscriptionType: 'max' });
+fs.writeFileSync(IDENTITY_FILE, identity('rig-a@example.com'));
+const STUB = path.join(HOME, 'claude-stub');
+fs.writeFileSync(
+  STUB,
+  `#!/bin/sh\nif [ "$1" = "auth" ] && [ "$2" = "status" ]; then /bin/cat "${IDENTITY_FILE}"; fi\nexit 0\n`
+);
+fs.chmodSync(STUB, 0o755);
+
+// Point the project's claude command at the stub.
+fs.writeFileSync(
+  path.join(PROJ, 'intendant.toml'),
+  `[agent.claude_code]\ncommand = "${STUB}"\n`
+);
+
+const script = { profiles: [{ steps: [
+  { content: 'ok', tool_calls: [{ name: 'signal_done', arguments: { message: 'credwatch rig task done' } }] },
+]}]};
+const scriptPath = path.join(HOME, 'mock_script.json');
+fs.writeFileSync(scriptPath, JSON.stringify(script));
+
+const env = {
+  ...process.env, HOME, USERPROFILE: HOME,
+  PROVIDER: 'mock', INTENDANT_MOCK_SCRIPT: scriptPath,
+  INTENDANT_CREDENTIAL_POLL_MS: String(POLL_MS),
+};
+for (const k of ['OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'GEMINI_API_KEY', 'MODEL_NAME',
+  'CLAUDE_CONFIG_DIR', 'CODEX_HOME']) delete env[k];
+
+const child = spawn(BINARY, ['--no-tui', '--web', '0', '--bind', '127.0.0.1', '--no-tls',
+  '--control-socket', '--autonomy', 'full', 'trivial task'], { cwd: PROJ, env, stdio: ['ignore', 'pipe', 'pipe'] });
+let exited = false;
+child.on('exit', () => { exited = true; });
+child.stderr.on('data', () => {});
+child.stdout.on('data', () => {});
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+(async () => {
+  const socketPath = `/tmp/intendant-${child.pid}.sock`;
+  const deadline = Date.now() + 30000;
+  let sock = null;
+  while (Date.now() < deadline && !sock) {
+    if (exited) throw new Error('daemon exited early');
+    if (fs.existsSync(socketPath)) {
+      try {
+        sock = await new Promise((resolve, reject) => {
+          const s = net.createConnection(socketPath);
+          s.on('connect', () => resolve(s));
+          s.on('error', reject);
+        });
+      } catch { /* retry */ }
+    }
+    if (!sock) await sleep(250);
+  }
+  if (!sock) throw new Error('no control socket');
+
+  // Let the watch's baseline tick land (first interval tick is
+  // immediate; the stub answers in milliseconds): the watch adopts
+  // rig-a as its identity baseline.
+  await sleep(Math.max(1000, POLL_MS * 3));
+
+  // THE OUT-OF-BAND CHANGE: flip the stub's identity and rewrite the
+  // scratch auth file — exactly what a direct `claude` re-login does.
+  fs.writeFileSync(IDENTITY_FILE, identity('rig-b@example.com'));
+  fs.writeFileSync(AUTH_FILE, JSON.stringify({ fake: 'account-b-material-longer' }));
+  const changedAt = Date.now();
+
+  let buf = '';
+  const notification = await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('timeout waiting for the credential-change notification')), 15000);
+    sock.on('data', (d) => {
+      buf += d.toString();
+      let i;
+      while ((i = buf.indexOf('\n')) >= 0) {
+        const line = buf.slice(0, i); buf = buf.slice(i + 1);
+        if (!line.includes('user_notification')) continue;
+        let e; try { e = JSON.parse(line); } catch { continue; }
+        if (e.event !== 'user_notification') continue;
+        if (e.id !== 'credential-change-claude-code') continue;
+        clearTimeout(timer);
+        resolve(e);
+      }
+    });
+  });
+  const elapsed = Date.now() - changedAt;
+  // Detection rides the first tick after the change: within one poll
+  // interval, plus probe/delivery slack.
+  const withinInterval = elapsed <= POLL_MS + 1600;
+  const text = String(notification.text || '');
+  const textOk = text.includes('changed outside Intendant')
+    && text.includes('now signed in as rig-b@example.com')
+    && text.includes('(was rig-a@example.com)')
+    && text.includes('reload');
+  const urgencyOk = String(notification.urgency || '') === 'info';
+  const noSecrets = !text.includes('account-b-material') && !text.includes('account-a-material');
+  console.log(`notification after ${elapsed}ms (poll ${POLL_MS}ms): ${text}`);
+  if (!withinInterval) console.log(`detection exceeded one poll interval (+slack): ${elapsed}ms`);
+  if (!textOk) console.log('notification copy mismatch');
+  if (!urgencyOk) console.log(`urgency mismatch: ${notification.urgency}`);
+  if (!noSecrets) console.log('SECRET MATERIAL LEAKED INTO THE NOTIFICATION');
+  const ok = withinInterval && textOk && urgencyOk && noSecrets;
+  console.log(ok ? 'CREDENTIAL WATCH RIG PASS' : 'CREDENTIAL WATCH RIG FAIL');
+  child.kill('SIGTERM');
+  process.exit(ok ? 0 : 1);
+})().catch((err) => { console.error('RIG ERROR: ' + err.message); child.kill('SIGTERM'); process.exit(1); });


### PR DESCRIPTION
Card 01KYT12BZ1G8V4XKVCYFCSQ5JT: the daemon now notices credential changes made directly at the backend CLI (the 2026-07-30 incident class: owner re-authenticated Claude Code outside Intendant while seats sat limit-parked on the old account, and the reload lane never noticed).

**Detection** — a slow stat poll (60s; `INTENDANT_CREDENTIAL_POLL_MS` rig override) over the auth artifact each backend CLI maintains, mirroring the binary update watch's bounded pattern. Metadata only: the watch never opens the file, and a source-scan test pins that no read API exists in the module's non-test code.

**On a probe-confirmed change** — one bounded identity probe (the CLI's own status subcommand under the external-child env policy + hard timeout), then:
- mints the credential era via the same `BackendCredentialAccount` announce the sign-in ceremonies publish (a second **source** for era changes, never a second store; announce keying stays primary),
- records the observation the auth-status payloads serve as an `out_of_band` block carrying the **same** `reload_candidates` list + reload-all offer the ceremony's success payload carries,
- posts one info notification (account labels only — never secret material).

**No double-fire with the ceremony lane** — a live ceremony defers the watch wholesale; ceremony announces fold into the watch baseline from the bus, so the ceremony-authored stat change reconciles silently. A ceremony success newer than the observation supersedes the out_of_band block; failed/cancelled ceremonies leave it standing. Token refreshes (same account) never fire. Sign-outs notify without a reload offer.

**Per-backend applicability, explicit** — Claude + Codex watched (real artifacts + secret-free CLI status probes); Kimi out of scope (its only identity probe parses the credential file itself — ceremony-scoped today); Pi out of scope (no sign-in ceremony/reload surface); custody-managed backends (active `oauth:*` lease) not watched while the lease is active. All served on the `credential_watch` applicability block.

Remaining in this PR: Vault card render of the out_of_band block, docs (credential-custody chapter), scratch-auth rig leg.