### PR TITLE
agenda graph: density pass — degree-sized nodes, dilating time disc

### DIFF
--- a/static/app.html
+++ b/static/app.html
@@ -38267,7 +38267,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '3f81dc5b8d448cf0';
+const INTENDANT_APP_BUILD = '0d50dfbe09b248d1';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -100590,9 +100590,15 @@ const AGENDA_GRAPH_TIME_LADDER = [
   [17520, '2y', false], [43800, '5y', false],
 ];
 
+// Density-adaptive scale: the log mapping is fixed in SHAPE, but the
+// whole disc dilates with population (area ~ item count) so a
+// 300-item fortnight gets the room a 50-item fortnight never needed.
+// Set once per build; marks, targets, and the drift tick all read the
+// radius through this one function, so everything dilates together.
+let agendaGraphTimeScale = 1;
 function agendaGraphTimeRadius(ageMs) {
-  return AGENDA_GRAPH_TIME_INNER + AGENDA_GRAPH_TIME_STEP
-    * Math.log2(1 + Math.max(0, ageMs) / AGENDA_GRAPH_TIME_HOUR);
+  return (AGENDA_GRAPH_TIME_INNER + AGENDA_GRAPH_TIME_STEP
+    * Math.log2(1 + Math.max(0, ageMs) / AGENDA_GRAPH_TIME_HOUR)) * agendaGraphTimeScale;
 }
 
 // The ladder rings inside the pool's age span, plus a dashed ring at
@@ -100805,6 +100811,7 @@ function agendaGraphBuild() {
       if (b > 0 && b < oldest) oldest = b;
     });
     agendaGraphTimeOldest = oldest;
+    agendaGraphTimeScale = Math.max(1, Math.sqrt(items.length / 90));
     agendaGraphNodes.forEach((n) => {
       if (n.sat) return;
       const b = born(byIdBuild.get(n.id)) || oldest;
@@ -100880,6 +100887,16 @@ function agendaGraphBuild() {
       if (idx.has(owner)) links.push({ a: idx.get(owner), b, t: 'terr' });
     });
   });
+  // Degree (link endpoints of every kind) drives node SIZE in the draw
+  // pass — connectivity is visual mass. Children keep deciding which
+  // nodes carry labels; the two notions overlap on hubs but diverge on
+  // heavily-cited leaves, which is the point.
+  const degrees = new Array(agendaGraphNodes.length).fill(0);
+  links.forEach((link) => {
+    degrees[link.a] += 1;
+    degrees[link.b] += 1;
+  });
+  agendaGraphNodes.forEach((nd, i) => { nd.deg = degrees[i]; });
   agendaGraphLinks = links;
   agendaGraphSettleLeft = AGENDA_GRAPH_SETTLE_ITERATIONS;
   return items;
@@ -100958,9 +100975,11 @@ function agendaGraphRelax(iterations) {
         n.p[2] += n.p[2] * f;
         // With the radius pinned, repulsion would escape into the free
         // vertical axis and smear the disc — clamp y hard in time mode
-        // so crowding spreads AROUND a ring instead (beads, not fuzz),
-        // leaving just a whisper of off-plane shimmer.
-        n.p[1] *= agendaGraphMode === 'time' ? 0.6 : 0.97;
+        // so crowding spreads AROUND a ring instead (beads, not fuzz).
+        // The clamp eases as population grows: a dense board earns back
+        // a little shimmer thickness as an overflow valve.
+        n.p[1] *= agendaGraphMode === 'time'
+          ? Math.min(0.82, 0.6 + nodes.length / 1200) : 0.97;
       }
       if (n.anchor) {
         n.p[0] += (n.anchor[0] - n.p[0]) * 0.025;
@@ -101326,13 +101345,18 @@ function agendaGraphDraw(ts) {
     const rgb = item.status === 'done' ? pal.green
       : item.kind === 'question' ? pal.amber : pal.iris;
     const hot = hover === node.id;
-    const r = (3.4 + Math.min(kids, 4) * 1.3 + (hot ? 1.4 : 0)) * q.s;
+    // Radius by degree, sub-linear and capped: landmarks, not planets.
+    const r = (3.0 + Math.min(6, Math.sqrt(node.deg || 0) * 1.35)
+      + (hot ? 1.4 : 0)) * q.s;
     let alpha = Math.max(0.35, Math.min(1, q.s * 1.15 - 0.1));
     // Attention mode: needs-you items glow, the rest recede.
     if (agendaGraphMode === 'attention' && !node.attn && !hot) alpha *= 0.45;
     const glow = agendaGraphGlowSprite(rgb);
+    // Halo budget shrinks on crowded boards — past ~150 nodes the full
+    // glow tiles the disc into one nebula and drowns the geometry.
     let glowK = hot ? 6.5
-      : agendaGraphMode === 'attention' && node.attn ? 7.5 : 4.5;
+      : agendaGraphMode === 'attention' && node.attn ? 7.5
+        : agendaGraphNodes.length > 150 ? 3.1 : 4.5;
     if (!hot && agendaGraphMode === 'time' && node.born) {
       // Recency emphasis: items parked within the last hour breathe a
       // little brighter around the "now" beacon, fading out as they age.

--- a/static/app/ui2-agenda-graph.js
+++ b/static/app/ui2-agenda-graph.js
@@ -579,9 +579,15 @@ const AGENDA_GRAPH_TIME_LADDER = [
   [17520, '2y', false], [43800, '5y', false],
 ];
 
+// Density-adaptive scale: the log mapping is fixed in SHAPE, but the
+// whole disc dilates with population (area ~ item count) so a
+// 300-item fortnight gets the room a 50-item fortnight never needed.
+// Set once per build; marks, targets, and the drift tick all read the
+// radius through this one function, so everything dilates together.
+let agendaGraphTimeScale = 1;
 function agendaGraphTimeRadius(ageMs) {
-  return AGENDA_GRAPH_TIME_INNER + AGENDA_GRAPH_TIME_STEP
-    * Math.log2(1 + Math.max(0, ageMs) / AGENDA_GRAPH_TIME_HOUR);
+  return (AGENDA_GRAPH_TIME_INNER + AGENDA_GRAPH_TIME_STEP
+    * Math.log2(1 + Math.max(0, ageMs) / AGENDA_GRAPH_TIME_HOUR)) * agendaGraphTimeScale;
 }
 
 // The ladder rings inside the pool's age span, plus a dashed ring at
@@ -794,6 +800,7 @@ function agendaGraphBuild() {
       if (b > 0 && b < oldest) oldest = b;
     });
     agendaGraphTimeOldest = oldest;
+    agendaGraphTimeScale = Math.max(1, Math.sqrt(items.length / 90));
     agendaGraphNodes.forEach((n) => {
       if (n.sat) return;
       const b = born(byIdBuild.get(n.id)) || oldest;
@@ -869,6 +876,16 @@ function agendaGraphBuild() {
       if (idx.has(owner)) links.push({ a: idx.get(owner), b, t: 'terr' });
     });
   });
+  // Degree (link endpoints of every kind) drives node SIZE in the draw
+  // pass — connectivity is visual mass. Children keep deciding which
+  // nodes carry labels; the two notions overlap on hubs but diverge on
+  // heavily-cited leaves, which is the point.
+  const degrees = new Array(agendaGraphNodes.length).fill(0);
+  links.forEach((link) => {
+    degrees[link.a] += 1;
+    degrees[link.b] += 1;
+  });
+  agendaGraphNodes.forEach((nd, i) => { nd.deg = degrees[i]; });
   agendaGraphLinks = links;
   agendaGraphSettleLeft = AGENDA_GRAPH_SETTLE_ITERATIONS;
   return items;
@@ -947,9 +964,11 @@ function agendaGraphRelax(iterations) {
         n.p[2] += n.p[2] * f;
         // With the radius pinned, repulsion would escape into the free
         // vertical axis and smear the disc — clamp y hard in time mode
-        // so crowding spreads AROUND a ring instead (beads, not fuzz),
-        // leaving just a whisper of off-plane shimmer.
-        n.p[1] *= agendaGraphMode === 'time' ? 0.6 : 0.97;
+        // so crowding spreads AROUND a ring instead (beads, not fuzz).
+        // The clamp eases as population grows: a dense board earns back
+        // a little shimmer thickness as an overflow valve.
+        n.p[1] *= agendaGraphMode === 'time'
+          ? Math.min(0.82, 0.6 + nodes.length / 1200) : 0.97;
       }
       if (n.anchor) {
         n.p[0] += (n.anchor[0] - n.p[0]) * 0.025;
@@ -1315,13 +1334,18 @@ function agendaGraphDraw(ts) {
     const rgb = item.status === 'done' ? pal.green
       : item.kind === 'question' ? pal.amber : pal.iris;
     const hot = hover === node.id;
-    const r = (3.4 + Math.min(kids, 4) * 1.3 + (hot ? 1.4 : 0)) * q.s;
+    // Radius by degree, sub-linear and capped: landmarks, not planets.
+    const r = (3.0 + Math.min(6, Math.sqrt(node.deg || 0) * 1.35)
+      + (hot ? 1.4 : 0)) * q.s;
     let alpha = Math.max(0.35, Math.min(1, q.s * 1.15 - 0.1));
     // Attention mode: needs-you items glow, the rest recede.
     if (agendaGraphMode === 'attention' && !node.attn && !hot) alpha *= 0.45;
     const glow = agendaGraphGlowSprite(rgb);
+    // Halo budget shrinks on crowded boards — past ~150 nodes the full
+    // glow tiles the disc into one nebula and drowns the geometry.
     let glowK = hot ? 6.5
-      : agendaGraphMode === 'attention' && node.attn ? 7.5 : 4.5;
+      : agendaGraphMode === 'attention' && node.attn ? 7.5
+        : agendaGraphNodes.length > 150 ? 3.1 : 4.5;
     if (!hot && agendaGraphMode === 'time' && node.born) {
       // Recency emphasis: items parked within the last hour breathe a
       // little brighter around the "now" beacon, fading out as they age.


### PR DESCRIPTION
Real-ledger follow-up to #722: 310 items over a fortnight packed the fixed-scale time disc into nebula. Four population-aware adjustments:

- **Node radius follows total link degree** (sqrt, capped) instead of child count alone — connectivity is visual mass, so heavily-cited leaves become landmarks too. Child count still decides which nodes carry labels.
- **The time disc dilates with population** (`× max(1, √(n/90))`) through the single radius function — rings, marks, and drift targets scale together, ring meaning unchanged.
- **The time-mode flatness clamp eases as boards grow** (0.6 → 0.82 ceiling), returning shimmer thickness as an overflow valve.
- **Glow halo budget drops past 150 nodes** (4.5 → 3.1) so dense boards keep their geometry.

Verified on the deterministic probe rig at 310 items / 15 days (the live board's shape) in both themes, plus the 56-item fixture to confirm small boards are untouched (scale factor 1 below 90 items). `static_assets` fragment pins green; app.html regenerated.