### PR TITLE
Drain holdout honesty: named wait set, successor doorway, predecessor-exit scoped readopt

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -329,9 +329,15 @@ unattested, no live process) is woken to continue, and what cannot be
 woken is listed on one needs-you agenda task instead of stranding
 silently (`failed` runs are listed, never re-fired).
 
+The same knob governs the **predecessor-exit watch**: on the holder, a
+co-homed draining daemon's exit triggers one scoped readopt pass over
+the sessions it released (see
+[Control Plane & Daemon](./control-plane-and-daemon.md#graceful-daemon-handover-drain--takeover)),
+instead of leaving them down until the next restart.
+
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `enabled` | bool | `true` | `false` leaves dead-boot sessions down for the owner to resume by hand and skips the commission sweep. `INTENDANT_BOOT_READOPT=0`/`1` overrides the file in either direction |
+| `enabled` | bool | `true` | `false` leaves dead-boot sessions down for the owner to resume by hand and skips the commission sweep and the predecessor-exit watch. `INTENDANT_BOOT_READOPT=0`/`1` overrides the file in either direction |
 
 ### `[agent]` and external backends
 

--- a/docs/src/control-plane-and-daemon.md
+++ b/docs/src/control-plane-and-daemon.md
@@ -427,10 +427,33 @@ successor without kill-and-relaunch:
   one place (`ControlMsg::creates_session`) and every surface consults it.
 - When its last work-holding session finishes (sessions parked after
   `done` do not hold; parked conversations resume on the successor), the
-  drainer records an `exited` presence state and the process exits. If the
-  successor dies while the drainer still drains, ONE loud notification
-  says standing automations are paused until someone relaunches or takes
-  over — the drainer never reclaims the lease.
+  drainer records an `exited` presence state and the process exits. **A
+  limit-parked wrapper holds the drain for as long as its in-memory park
+  runs** — potentially hours, until the provider reset — which is why
+  the wait set is named, never silent: the status payload carries
+  `holdouts` (each holding session's id, name, backend, phase, and its
+  durable `limit_park` marker with the reset instant), the drainer's
+  presence record mirrors a capped row copy beside `session_count`, and
+  the dashboard's drain banner lists WHO holds and until WHEN under a
+  prominent doorway to the successor. If the successor dies while the
+  drainer still drains, ONE loud notification says standing automations
+  are paused until someone relaunches or takes over — the drainer never
+  reclaims the lease.
+- Sessions the drainer still held at its exit (interrupted mid-work, or
+  limit-parked with pending work) are RELEASED, not lost: the holder
+  watches co-homed **draining** boots through their presence records
+  and, when one's per-boot lock frees, runs a **scoped readopt pass**
+  over the released set — the boot pass's mid-work classes, guard
+  ladder (Resume-not-Revive, owner-stop tombstones, staleness,
+  live-tip refusals), per-pass cap, dispatch stagger, and
+  dispatches-are-not-outcomes verification, scoped to sessions whose
+  story froze at-or-before the exit instant (anything a live co-homed
+  daemon is still driving advances past that bound and is never
+  touched). The summary notification names the predecessor, so a
+  handover pickup reads apart from crash recovery. While the
+  predecessor still drains, the successor-side banner names the spared
+  set ("N sessions still finishing there", with the same holdout rows),
+  one section per draining co-homed daemon.
 
 `intendant ctl status` shows the whole story under `scheduler_lease`
 (role, drain state, and every co-homed boot with probed liveness).

--- a/docs/src/control-plane-and-daemon.md
+++ b/docs/src/control-plane-and-daemon.md
@@ -440,20 +440,24 @@ successor without kill-and-relaunch:
   are paused until someone relaunches or takes over — the drainer never
   reclaims the lease.
 - Sessions the drainer still held at its exit (interrupted mid-work, or
-  limit-parked with pending work) are RELEASED, not lost: the holder
-  watches co-homed **draining** boots through their presence records
-  and, when one's per-boot lock frees, runs a **scoped readopt pass**
+  limit-parked with pending work) are RELEASED, not lost: the holder's
+  **predecessor-exit watch** adjudicates, once per boot id, every
+  co-homed presence record whose boot is provably dead (per-boot lock
+  free) with drain lineage (`draining` — killed mid-drain — or
+  `exited`, the graceful terminal), and runs a **scoped readopt pass**
   over the released set — the boot pass's mid-work classes, guard
   ladder (Resume-not-Revive, owner-stop tombstones, staleness,
   live-tip refusals), per-pass cap, dispatch stagger, and
   dispatches-are-not-outcomes verification, scoped to sessions whose
-  story froze at-or-before the exit instant (anything a live co-homed
-  daemon is still driving advances past that bound and is never
-  touched). The summary notification names the predecessor, so a
-  handover pickup reads apart from crash recovery. While the
-  predecessor still drains, the successor-side banner names the spared
-  set ("N sessions still finishing there", with the same holdout rows),
-  one section per draining co-homed daemon.
+  story froze at-or-before the exit instant (the record's last rewrite;
+  anything a live co-homed daemon is still driving advances past that
+  bound and is never touched). The trigger is edge-independent, so a
+  drainer that exited while the successor was down, or crashed
+  mid-drain, is still adjudicated. The summary notification names the
+  predecessor, so a handover pickup reads apart from crash recovery.
+  While the predecessor still drains, the successor-side banner names
+  the spared set ("N sessions still finishing there", with the same
+  holdout rows), one section per draining co-homed daemon.
 
 `intendant ctl status` shows the whole story under `scheduler_lease`
 (role, drain state, and every co-homed boot with probed liveness).

--- a/src/bin/caller/boot_readopt.rs
+++ b/src/bin/caller/boot_readopt.rs
@@ -315,6 +315,39 @@ pub(crate) fn scan_store_candidates(
     watershed_secs: u64,
     live_wrapper_ids: &HashSet<String>,
 ) -> Vec<ReadoptCandidate> {
+    scan_midwork_candidates(home, live_wrapper_ids, |activity_secs| {
+        activity_secs < watershed_secs // current boot's era is not the dead boot's
+    })
+}
+
+/// Enumerate the mid-work sessions a dead DRAINING predecessor released
+/// (the predecessor-exit watch's scan). The era line inverts the boot
+/// pass's: candidacy requires the session's story to have FROZEN
+/// at-or-before the exit instant. A session a live co-homed daemon is
+/// driving keeps advancing its transcript, so after the settle window it
+/// sits past the bound and never becomes a candidate — the same
+/// anti-theft role the boot watershed plays at boot. (On the takeover
+/// topology the successor's boot pass never enumerated at all — it was
+/// a secondary at spawn instant — so this scan carries no lower era
+/// bound: the staleness guard in the ladder draws the archaeology line.)
+pub(crate) fn scan_released_candidates(
+    home: &Path,
+    released_before_secs: u64,
+    live_wrapper_ids: &HashSet<String>,
+) -> Vec<ReadoptCandidate> {
+    scan_midwork_candidates(home, live_wrapper_ids, |activity_secs| {
+        activity_secs <= released_before_secs
+    })
+}
+
+/// The shared store walk behind [`scan_store_candidates`] and
+/// [`scan_released_candidates`] — ONE reader of the mid-work vocabulary,
+/// two era lines.
+fn scan_midwork_candidates(
+    home: &Path,
+    live_wrapper_ids: &HashSet<String>,
+    era_keeps: impl Fn(u64) -> bool,
+) -> Vec<ReadoptCandidate> {
     let logs_dir = crate::platform::intendant_home_in(home).join("logs");
     let Ok(entries) = std::fs::read_dir(&logs_dir) else {
         return Vec::new();
@@ -336,8 +369,8 @@ pub(crate) fn scan_store_candidates(
             continue;
         }
         let activity_secs = activity_mtime_secs(&dir);
-        if activity_secs >= watershed_secs {
-            continue; // current boot's era — not the dead boot's
+        if !era_keeps(activity_secs) {
+            continue;
         }
         let Some(class) = midwork_class(&meta) else {
             continue; // idle in, idle out
@@ -833,6 +866,84 @@ mod tests {
         assert!(
             candidates.is_empty(),
             "idle/done sessions stay down: {candidates:?}"
+        );
+    }
+
+    /// The released-set scan (the predecessor-exit watch): candidacy
+    /// requires the story to have FROZEN at-or-before the exit instant.
+    /// Frozen mid-work qualifies; a session still advancing (a live
+    /// co-homed daemon is driving it) sits past the bound and never
+    /// does; idle-in-idle-out and live-on-this-daemon skips hold.
+    #[test]
+    fn released_scan_keeps_frozen_midwork_only() {
+        let home = tempfile::tempdir().unwrap();
+        write_meta(home.path(), "sess-released", "interrupted", None);
+        write_meta(home.path(), "sess-done", "completed", None);
+        write_meta(
+            home.path(),
+            "sess-parked",
+            "idle",
+            Some(SessionLimitParkMeta {
+                resets_at_epoch: Some(now_secs() + 600),
+                has_pending: true,
+            }),
+        );
+
+        // Exit instant in the future: every on-disk story is frozen
+        // at-or-before it.
+        let frozen = scan_released_candidates(home.path(), u64::MAX, &HashSet::new());
+        let ids: Vec<&str> = frozen
+            .iter()
+            .map(|candidate| candidate.session_id.as_str())
+            .collect();
+        assert!(
+            ids.contains(&"sess-released"),
+            "frozen mid-turn is released mid-work"
+        );
+        assert!(
+            ids.contains(&"sess-parked"),
+            "frozen limit-park is released mid-work"
+        );
+        assert!(!ids.contains(&"sess-done"), "idle in, idle out");
+
+        // Exit instant at epoch zero: everything on disk advanced past
+        // it — still being written, i.e. still driven; never a candidate.
+        assert!(
+            scan_released_candidates(home.path(), 0, &HashSet::new()).is_empty(),
+            "a story that advanced past the exit instant is being driven"
+        );
+
+        // Live on THIS daemon: excluded whatever the meta says.
+        let live: HashSet<String> = ["sess-released".to_string()].into_iter().collect();
+        assert!(!scan_released_candidates(home.path(), u64::MAX, &live)
+            .iter()
+            .any(|candidate| candidate.session_id == "sess-released"));
+    }
+
+    /// The released summary is the handover-pickup story, not crash
+    /// recovery: its own notification key (per predecessor boot) and a
+    /// title naming the exit.
+    #[test]
+    fn released_summary_names_the_handover_pickup() {
+        let confirmed = vec![("aaaaaaaa-1111".to_string(), MidWorkClass::LimitPark)];
+        match released_summary_notification("pred-boot", &confirmed, &[], &[]) {
+            Some(AppEvent::UserNotification {
+                id, title, text, ..
+            }) => {
+                assert_eq!(id, "released-readopt-pred-boot");
+                let title = title.expect("titled");
+                assert!(
+                    title.contains("Draining daemon exited"),
+                    "the pickup story leads: {title}"
+                );
+                assert!(title.contains("1 released session(s) readopted"));
+                assert!(text.contains("aaaaaaaa"));
+            }
+            other => panic!("expected one UserNotification, got {other:?}"),
+        }
+        assert!(
+            released_summary_notification("pred-boot", &[], &[], &[]).is_none(),
+            "a clean release stays silent"
         );
     }
 
@@ -1896,4 +2007,276 @@ async fn fetch_live_wrapper_ids_with_retry() -> Option<HashSet<String>> {
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     }
     None
+}
+
+/// Settle window between a predecessor-exit edge and the scoped scan:
+/// [`scan_released_candidates`] keeps only sessions whose story froze
+/// at-or-before the exit instant, and the settle lets any session a
+/// live co-homed daemon is actively driving advance past that bound
+/// first (activity granularity is seconds). The daemon branch passes
+/// this; tests pass zero.
+pub(crate) const RELEASED_SETTLE: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// The successor's half of spare-under-takeover (the drain-holdout
+/// commission's post-drain readopt gap): sessions a draining
+/// predecessor still holds are spared at this daemon's boot — on the
+/// takeover topology the boot pass doesn't even enumerate, because the
+/// successor is still a secondary at spawn instant — and RELEASED only
+/// when the drainer's process exits, possibly hours later. Nothing
+/// re-scanned at that moment, so released mid-work sessions sat
+/// unadopted until the next daemon restart (the 2026-07-31 specimen).
+///
+/// This watch tracks co-homed DRAINING boots through their presence
+/// records on the lease-poll cadence and, when one's per-boot lock
+/// frees (`boot_id_is_live` — the liveness truth; the state JSON is
+/// display), runs ONE scoped readopt pass over the released set. An
+/// exit observed while this daemon is not the holder stays pending —
+/// adopting as a secondary would race the real holder's own pass — and
+/// is consumed on the first probe where holdership holds. A draining
+/// self ends the watch: drain is one-way, and a drainer never spawns
+/// work. (A drain shorter than one poll interval can pass unobserved;
+/// its released set then waits for the next daemon restart, exactly as
+/// before this watch existed.)
+pub(crate) async fn run_predecessor_exit_watch(
+    home: PathBuf,
+    bus: EventBus,
+    handover: std::sync::Arc<HandoverRuntime>,
+    enabled: bool,
+    dispatch_spacing: std::time::Duration,
+    settle: std::time::Duration,
+) {
+    if !enabled {
+        // The boot pass already logged the disable — one line per boot.
+        return;
+    }
+    let mut draining_seen: HashSet<String> = HashSet::new();
+    let mut pending_exits: Vec<(String, u64)> = Vec::new();
+    let mut adjudicated: HashSet<String> = HashSet::new();
+    loop {
+        tokio::time::sleep(crate::handover::lease_poll_interval()).await;
+        if handover.is_draining() {
+            return;
+        }
+        let state_root = handover.state_root();
+        for record in crate::handover::read_presence_records(state_root) {
+            if record.boot_id == handover.boot_id()
+                || adjudicated.contains(&record.boot_id)
+                || draining_seen.contains(&record.boot_id)
+            {
+                continue;
+            }
+            if record.state == "draining"
+                && crate::handover::boot_id_is_live(state_root, &record.boot_id)
+            {
+                eprintln!(
+                    "[readopt] watching draining co-homed daemon {} for its exit",
+                    short_id(&record.boot_id)
+                );
+                draining_seen.insert(record.boot_id);
+            }
+        }
+        let exited: Vec<String> = draining_seen
+            .iter()
+            .filter(|boot_id| !crate::handover::boot_id_is_live(state_root, boot_id))
+            .cloned()
+            .collect();
+        for boot_id in exited {
+            draining_seen.remove(&boot_id);
+            pending_exits.push((boot_id, crate::session_activity::epoch_seconds()));
+        }
+        if pending_exits.is_empty() || !handover.is_holder() {
+            continue;
+        }
+        for (boot_id, exit_secs) in std::mem::take(&mut pending_exits) {
+            adjudicated.insert(boot_id.clone());
+            if !settle.is_zero() {
+                tokio::time::sleep(settle).await;
+            }
+            if handover.is_draining() {
+                return;
+            }
+            let live: HashSet<String> = crate::session_supervisor::published_live_session_registry()
+                .and_then(|registry| registry.live_wrapper_ids())
+                .unwrap_or_default();
+            run_released_readopt_pass(
+                &home,
+                &bus,
+                &handover,
+                dispatch_spacing,
+                &boot_id,
+                exit_secs,
+                &live,
+            )
+            .await;
+        }
+    }
+}
+
+/// One scoped readopt pass over the set a dead draining predecessor
+/// released: the store's mid-work sessions whose story froze
+/// at-or-before the exit instant, minus everything live on THIS daemon.
+/// The rails are the boot pass's, through the same shared functions —
+/// `midwork_class` (the one durable vocabulary), `decide_candidate`
+/// (Resume-not-Revive, owner-stop tombstones, staleness, live-tip
+/// refusals), the per-pass cap, one-resume-per-conversation dedupe, the
+/// dispatch stagger with the drain-mid-pass cut, and
+/// dispatches-are-not-outcomes verification. The summary names the
+/// predecessor so the owner can tell a handover pickup from crash
+/// recovery.
+async fn run_released_readopt_pass(
+    home: &Path,
+    bus: &EventBus,
+    handover: &HandoverRuntime,
+    dispatch_spacing: std::time::Duration,
+    predecessor_boot_id: &str,
+    released_before_secs: u64,
+    live: &HashSet<String>,
+) {
+    let candidates = scan_released_candidates(home, released_before_secs, live);
+    if candidates.is_empty() {
+        eprintln!(
+            "[readopt] draining daemon {} exited — nothing released mid-work",
+            short_id(predecessor_boot_id)
+        );
+        return;
+    }
+    let now_secs = crate::session_activity::epoch_seconds();
+    let mut dispatched: Vec<ReadoptDispatch> = Vec::new();
+    let mut dispatched_conversations: HashSet<(String, String)> = HashSet::new();
+    let mut left_dead: Vec<(String, String)> = Vec::new();
+    let mut draining_cut = false;
+    for candidate in candidates {
+        if draining_cut {
+            left_dead.push((
+                candidate.session_id,
+                "daemon began draining mid-pass".to_string(),
+            ));
+            continue;
+        }
+        if dispatched.len() >= READOPT_MAX_PER_BOOT {
+            left_dead.push((
+                candidate.session_id,
+                format!("per-pass readopt cap ({READOPT_MAX_PER_BOOT}) reached"),
+            ));
+            continue;
+        }
+        match decide_candidate(home, &candidate, now_secs, live) {
+            ReadoptDecision::Readopt(resume) => {
+                if let ControlMsg::ResumeSession {
+                    source, session_id, ..
+                } = resume.as_ref()
+                {
+                    if !dispatched_conversations.insert((source.clone(), session_id.clone())) {
+                        let reason =
+                            "already continued — its lineage's resume was dispatched this pass"
+                                .to_string();
+                        eprintln!(
+                            "[readopt] leaving {} dead: {reason}",
+                            short_id(&candidate.session_id)
+                        );
+                        left_dead.push((candidate.session_id, reason));
+                        continue;
+                    }
+                }
+                // Same stagger discipline as the boot pass: continuation
+                // cold-starts land one at a time, and a drain that began
+                // during the wait cuts the pass honestly.
+                if !dispatched.is_empty() && !dispatch_spacing.is_zero() {
+                    tokio::time::sleep(dispatch_spacing).await;
+                    if handover.is_draining() {
+                        draining_cut = true;
+                        left_dead.push((
+                            candidate.session_id,
+                            "daemon began draining mid-pass".to_string(),
+                        ));
+                        continue;
+                    }
+                }
+                eprintln!(
+                    "[readopt] resuming {} ({}) — released when draining daemon {} exited",
+                    short_id(&candidate.session_id),
+                    candidate.class.label(),
+                    short_id(predecessor_boot_id)
+                );
+                bus.send(AppEvent::ControlCommand(*resume));
+                dispatched.push(ReadoptDispatch {
+                    session_id: candidate.session_id,
+                    class: candidate.class,
+                });
+            }
+            ReadoptDecision::LeftDead(reason) => {
+                eprintln!(
+                    "[readopt] leaving {} dead: {reason}",
+                    short_id(&candidate.session_id)
+                );
+                left_dead.push((candidate.session_id, reason));
+            }
+        }
+    }
+    // Dispatches are not outcomes — the same verify window and honest
+    // reclassification as the boot pass.
+    let live_after = if dispatched.is_empty() {
+        None
+    } else {
+        tokio::time::sleep(READOPT_VERIFY_WINDOW).await;
+        fetch_live_wrapper_ids_with_retry().await
+    };
+    let outcomes = if dispatched.is_empty() {
+        VerifiedOutcomes::default()
+    } else {
+        let outcomes = verify_dispatches(home, &dispatched, live_after.as_ref());
+        for (id, _) in &outcomes.confirmed {
+            eprintln!(
+                "[readopt] confirmed {} alive after the verify window",
+                short_id(id)
+            );
+        }
+        for (id, reason) in &outcomes.died {
+            eprintln!("[readopt] reclassifying {}: {reason}", short_id(id));
+        }
+        outcomes
+    };
+    if let Some(notification) = released_summary_notification(
+        predecessor_boot_id,
+        &outcomes.confirmed,
+        &outcomes.died,
+        &left_dead,
+    ) {
+        bus.send(notification);
+    }
+}
+
+/// The released-set summary: [`summary_notification`]'s body with the
+/// handover provenance — keyed per predecessor boot so repeats never
+/// stack, titled as a pickup after a predecessor's exit rather than
+/// crash recovery (the owner should know which story happened).
+pub(crate) fn released_summary_notification(
+    predecessor_boot_id: &str,
+    confirmed: &[(String, MidWorkClass)],
+    died: &[(String, String)],
+    left_dead: &[(String, String)],
+) -> Option<AppEvent> {
+    let base = summary_notification(predecessor_boot_id, confirmed, died, left_dead)?;
+    let AppEvent::UserNotification {
+        text, urgency, ts, ..
+    } = base
+    else {
+        return None;
+    };
+    let mut title = format!(
+        "Draining daemon exited: {} released session(s) readopted",
+        confirmed.len()
+    );
+    if !died.is_empty() {
+        title.push_str(&format!(", {} resume(s) died", died.len()));
+    }
+    title.push_str(&format!(", {} left dead", left_dead.len()));
+    Some(AppEvent::UserNotification {
+        session_id: None,
+        id: format!("released-readopt-{predecessor_boot_id}"),
+        title: Some(title),
+        text,
+        urgency,
+        ts,
+    })
 }

--- a/src/bin/caller/boot_readopt.rs
+++ b/src/bin/caller/boot_readopt.rs
@@ -2095,9 +2095,10 @@ pub(crate) async fn run_predecessor_exit_watch(
             if handover.is_draining() {
                 return;
             }
-            let live: HashSet<String> = crate::session_supervisor::published_live_session_registry()
-                .and_then(|registry| registry.live_wrapper_ids())
-                .unwrap_or_default();
+            let live: HashSet<String> =
+                crate::session_supervisor::published_live_session_registry()
+                    .and_then(|registry| registry.live_wrapper_ids())
+                    .unwrap_or_default();
             run_released_readopt_pass(
                 &home,
                 &bus,

--- a/src/bin/caller/boot_readopt.rs
+++ b/src/bin/caller/boot_readopt.rs
@@ -2026,17 +2026,25 @@ pub(crate) const RELEASED_SETTLE: std::time::Duration = std::time::Duration::fro
 /// re-scanned at that moment, so released mid-work sessions sat
 /// unadopted until the next daemon restart (the 2026-07-31 specimen).
 ///
-/// This watch tracks co-homed DRAINING boots through their presence
-/// records on the lease-poll cadence and, when one's per-boot lock
-/// frees (`boot_id_is_live` — the liveness truth; the state JSON is
-/// display), runs ONE scoped readopt pass over the released set. An
-/// exit observed while this daemon is not the holder stays pending —
+/// The trigger is edge-INDEPENDENT by design: each probe (lease-poll
+/// cadence) adjudicates, once per boot id, every co-homed presence
+/// record whose boot is provably dead (`boot_id_is_live` false — the
+/// per-boot lock is the liveness truth; the state JSON is display) and
+/// whose last recorded state carries the drain lineage (`draining` — a
+/// drainer killed mid-drain — or `exited`, the graceful drain
+/// terminal). The frozen-story bound is the record file's mtime:
+/// `mark_exited` rewrites the record at the exit instant, and a killed
+/// drainer's last wait-set write approximates its death. (Requiring a
+/// live-draining observation before the exit edge was the earlier
+/// shape; it structurally missed drains shorter than a poll, crashed
+/// drainers, and drainers that exited while this daemon was down or
+/// still arming — the exact gap class this watch exists to close.)
+///
+/// An exit found while this daemon is not the holder stays pending —
 /// adopting as a secondary would race the real holder's own pass — and
 /// is consumed on the first probe where holdership holds. A draining
 /// self ends the watch: drain is one-way, and a drainer never spawns
-/// work. (A drain shorter than one poll interval can pass unobserved;
-/// its released set then waits for the next daemon restart, exactly as
-/// before this watch existed.)
+/// work.
 pub(crate) async fn run_predecessor_exit_watch(
     home: PathBuf,
     bus: EventBus,
@@ -2049,11 +2057,15 @@ pub(crate) async fn run_predecessor_exit_watch(
         // The boot pass already logged the disable — one line per boot.
         return;
     }
-    let mut draining_seen: HashSet<String> = HashSet::new();
+    let interval = crate::handover::lease_poll_interval();
+    eprintln!(
+        "[readopt] predecessor-exit watch armed (poll {}ms)",
+        interval.as_millis()
+    );
     let mut pending_exits: Vec<(String, u64)> = Vec::new();
     let mut adjudicated: HashSet<String> = HashSet::new();
     loop {
-        tokio::time::sleep(crate::handover::lease_poll_interval()).await;
+        tokio::time::sleep(interval).await;
         if handover.is_draining() {
             return;
         }
@@ -2061,28 +2073,32 @@ pub(crate) async fn run_predecessor_exit_watch(
         for record in crate::handover::read_presence_records(state_root) {
             if record.boot_id == handover.boot_id()
                 || adjudicated.contains(&record.boot_id)
-                || draining_seen.contains(&record.boot_id)
+                || pending_exits
+                    .iter()
+                    .any(|(boot, _)| *boot == record.boot_id)
+                || !matches!(record.state.as_str(), "draining" | "exited")
+                || crate::handover::boot_id_is_live(state_root, &record.boot_id)
             {
                 continue;
             }
-            if record.state == "draining"
-                && crate::handover::boot_id_is_live(state_root, &record.boot_id)
-            {
-                eprintln!(
-                    "[readopt] watching draining co-homed daemon {} for its exit",
-                    short_id(&record.boot_id)
-                );
-                draining_seen.insert(record.boot_id);
-            }
-        }
-        let exited: Vec<String> = draining_seen
-            .iter()
-            .filter(|boot_id| !crate::handover::boot_id_is_live(state_root, boot_id))
-            .cloned()
-            .collect();
-        for boot_id in exited {
-            draining_seen.remove(&boot_id);
-            pending_exits.push((boot_id, crate::session_activity::epoch_seconds()));
+            // Dead, with drain lineage: the released set froze no later
+            // than the record's last rewrite (the exit stamp).
+            let record_path = state_root
+                .join("daemons")
+                .join(format!("{}.json", record.boot_id));
+            let exit_secs = std::fs::metadata(&record_path)
+                .and_then(|meta| meta.modified())
+                .ok()
+                .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|age| age.as_secs())
+                .unwrap_or_else(crate::session_activity::epoch_seconds);
+            eprintln!(
+                "[readopt] drained co-homed daemon {} is gone (last state {}) — \
+                 adjudicating its released set",
+                short_id(&record.boot_id),
+                record.state
+            );
+            pending_exits.push((record.boot_id, exit_secs));
         }
         if pending_exits.is_empty() || !handover.is_holder() {
             continue;

--- a/src/bin/caller/handover/mod.rs
+++ b/src/bin/caller/handover/mod.rs
@@ -28,7 +28,7 @@ mod update_lane;
 mod update_watch;
 
 pub(crate) use lease::{read_lease_sidecar, LeaseAttempt, SchedulerLease};
-pub(crate) use presence::{boot_id_is_live, read_presence_records, DaemonPresence};
+pub(crate) use presence::{boot_id_is_live, read_presence_records, DaemonPresence, DrainHoldout};
 pub(crate) use update_lane::{parse_channel_arg, spawn_update_lane};
 pub(crate) use update_watch::spawn_update_watch;
 
@@ -64,6 +64,13 @@ pub(crate) struct HandoverRuntime {
     /// [`DrainState`] mutex carries the bookkeeping.
     draining: std::sync::atomic::AtomicBool,
     drain: std::sync::Mutex<DrainState>,
+    /// The drain wait set as last reported by the supervisor's exit
+    /// check — each holding session with its phase and durable
+    /// limit-park marker. The status surface serves it (`holdouts`) and
+    /// the presence record mirrors a capped copy for co-homed
+    /// successors. `None` until the first report; only reported while
+    /// draining.
+    drain_holdouts: std::sync::Mutex<Option<Vec<DrainHoldout>>>,
     /// Wakes the scheduler the instant a drain is requested, so
     /// drain-entry (which the scheduler performs BETWEEN passes — the
     /// structural "stop firing before the flock frees") does not wait
@@ -296,6 +303,7 @@ impl HandoverRuntime {
             presence_error,
             draining: std::sync::atomic::AtomicBool::new(false),
             drain: std::sync::Mutex::new(DrainState::default()),
+            drain_holdouts: std::sync::Mutex::new(None),
             drain_notify: tokio::sync::Notify::new(),
             scheduler_attached: std::sync::atomic::AtomicBool::new(false),
             drain_hooks: std::sync::Mutex::new(Vec::new()),
@@ -724,13 +732,20 @@ impl HandoverRuntime {
         (sidecar.boot_id != self.boot_id).then_some(sidecar.port)
     }
 
-    /// Live supervised-session count, mirrored onto the presence record
-    /// (the "draining · N sessions" surface).
-    pub(crate) fn set_session_count(&self, count: u64) {
+    /// The supervisor's drain wait set: served on the status surface
+    /// (`holdouts` — the banner's honest "waiting on WHOM"), and
+    /// mirrored onto the presence record (the "draining · N sessions"
+    /// count plus a capped row copy — the only channel a co-homed
+    /// successor has to name the spared set).
+    pub(crate) fn set_drain_wait_set(&self, holdouts: Vec<DrainHoldout>) {
+        let count = holdouts.len() as u64;
         if let Ok(mut presence) = self.presence.lock() {
             if let Some(presence) = presence.as_mut() {
-                let _ = presence.update_session_count(count);
+                let _ = presence.update_drain_wait_set(count, &holdouts);
             }
+        }
+        if let Ok(mut slot) = self.drain_holdouts.lock() {
+            *slot = Some(holdouts);
         }
     }
 
@@ -788,6 +803,15 @@ impl HandoverRuntime {
             }
             if drain.successor_gone_alerted {
                 obj.insert("successor_gone".into(), true.into());
+            }
+        }
+        // The drain wait set, uncapped: the drainer's own surface names
+        // every holdout (the presence mirror is the capped copy).
+        if let Ok(slot) = self.drain_holdouts.lock() {
+            if let Some(rows) = slot.as_ref() {
+                if let Ok(value) = serde_json::to_value(rows) {
+                    obj.insert("holdouts".into(), value);
+                }
             }
         }
         if let Some(generation) = generation {
@@ -983,6 +1007,35 @@ fn write_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Commission pin (drain holdout honesty): the shipped dashboard
+    /// bundle carries the banner wiring — the named wait set, the
+    /// parked-until rendering, the prominent successor doorway, the
+    /// per-predecessor sections, and the tokenless QA hook — so the
+    /// honest banner cannot be silently gutted from the SPA (the HS6
+    /// artifact-scan pattern).
+    #[test]
+    fn spa_carries_the_drain_holdout_banner() {
+        let app = include_str!("../../../../static/app.html");
+        for needle in [
+            "handover-holdouts",
+            "handover-holdout-list",
+            "handover-successor-link",
+            "Open the successor daemon",
+            "rate-limit parked until",
+            "reset time unknown",
+            "No successor has acquired the lease yet.",
+            "still finishing there",
+            "Mid-work sessions it releases are picked up here when it exits.",
+            "body.holdouts",
+            "qa.handoverBanner",
+        ] {
+            assert!(
+                app.contains(needle),
+                "the dashboard bundle lost the drain-holdout banner wiring: {needle}"
+            );
+        }
+    }
 
     #[test]
     fn initialize_registers_presence_and_takes_free_lease() {

--- a/src/bin/caller/handover/presence.rs
+++ b/src/bin/caller/handover/presence.rs
@@ -362,8 +362,7 @@ mod tests {
         assert_eq!(after["holdouts"][0]["session_id"], "sess-parked-1");
         assert_eq!(after["holdouts"][0]["phase"], "waiting_rate_limit");
         assert_eq!(
-            after["holdouts"][0]["limit_park"]["resets_at_epoch"],
-            1_754_000_000_u64,
+            after["holdouts"][0]["limit_park"]["resets_at_epoch"], 1_754_000_000_u64,
             "the parked-until instant rides the record — the decisive fact"
         );
 

--- a/src/bin/caller/handover/presence.rs
+++ b/src/bin/caller/handover/presence.rs
@@ -31,6 +31,32 @@ pub(crate) const DAEMONS_DIR: &str = "daemons";
 /// the create→lock→write window is microseconds.
 const UNPAIRED_LOCK_GRACE: std::time::Duration = std::time::Duration::from_secs(10 * 60);
 
+/// One session still holding a drain open — the wait set the drain
+/// banner names. `limit_park` mirrors the session's durable marker
+/// (`SessionMeta::limit_park`): a parked-until-T holdout is decisive
+/// information (an in-memory park can hold the drain for hours), so the
+/// reset instant rides to every surface that renders the drain.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct DrainHoldout {
+    pub(crate) session_id: String,
+    /// Backend short-str (`claude-code`, `codex`, `intendant`, …) —
+    /// display currency.
+    pub(crate) source: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) name: Option<String>,
+    /// The supervisor's normalized phase (`running`, `idle`,
+    /// `waiting_rate_limit`, …). Readers must tolerate future phases.
+    pub(crate) phase: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) limit_park: Option<crate::session_log::SessionLimitParkMeta>,
+}
+
+/// Presence-record cap on mirrored holdout rows: the record is a small
+/// display file read by every co-homed boot's status pass, and
+/// `session_count` carries the full truth — truncated renders say "and
+/// N more" from the difference.
+pub(crate) const PRESENCE_HOLDOUT_ROWS_CAP: usize = 16;
+
 /// `<boot_id>.json` — one daemon boot's self-description.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct PresenceRecord {
@@ -46,6 +72,13 @@ pub(crate) struct PresenceRecord {
     /// absent = not reported, never "zero".
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) session_count: Option<u64>,
+    /// While draining: the sessions still holding the drain open, capped
+    /// at [`PRESENCE_HOLDOUT_ROWS_CAP`] rows (`session_count` stays the
+    /// full count) — the successor-side banner's only channel to NAME
+    /// the wait set. Absent = not reported. Additive: records written
+    /// before 2026-08 lack it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) holdouts: Option<Vec<DrainHoldout>>,
     /// The REGISTRATION instant — the era watershed
     /// (`grid_envelope::resolve_current_boot` reads it as boot-start to
     /// split current-boot sessions from outage residue, the #638 class).
@@ -102,6 +135,7 @@ impl DaemonPresence {
             version: BuildVersion::current(),
             state: "running".to_string(),
             session_count: None,
+            holdouts: None,
             updated_ms: super::now_ms(),
         };
         let presence = DaemonPresence {
@@ -132,16 +166,25 @@ impl DaemonPresence {
         self.write_record()
     }
 
-    /// Rewrite this boot's record with the live supervised-session count
-    /// (the drain views' "draining · N sessions" source). Write-on-change
-    /// only — the drain exit check runs per supervisor event, and an
-    /// unchanged count must not churn the file. Never advances the era
-    /// watershed (F1).
-    pub(crate) fn update_session_count(&mut self, count: u64) -> std::io::Result<()> {
-        if self.record.session_count == Some(count) {
+    /// Rewrite this boot's record with the drain wait set: the live
+    /// supervised-session count (the drain views' "draining · N
+    /// sessions" source) plus the holdout rows themselves, capped at
+    /// [`PRESENCE_HOLDOUT_ROWS_CAP`]. Write-on-change only — the drain
+    /// exit check runs per supervisor event, and an unchanged set must
+    /// not churn the file. Never advances the era watershed (F1).
+    pub(crate) fn update_drain_wait_set(
+        &mut self,
+        count: u64,
+        holdouts: &[DrainHoldout],
+    ) -> std::io::Result<()> {
+        let capped = &holdouts[..holdouts.len().min(PRESENCE_HOLDOUT_ROWS_CAP)];
+        if self.record.session_count == Some(count)
+            && self.record.holdouts.as_deref() == Some(capped)
+        {
             return Ok(());
         }
         self.record.session_count = Some(count);
+        self.record.holdouts = Some(capped.to_vec());
         self.write_record()
     }
 
@@ -290,9 +333,23 @@ mod tests {
         };
         let watershed = read()["updated_ms"].as_u64().expect("registration instant");
 
+        let parked = DrainHoldout {
+            session_id: "sess-parked-1".to_string(),
+            source: "claude-code".to_string(),
+            name: Some("nightly build".to_string()),
+            phase: "waiting_rate_limit".to_string(),
+            limit_park: Some(crate::session_log::SessionLimitParkMeta {
+                resets_at_epoch: Some(1_754_000_000),
+                has_pending: true,
+            }),
+        };
         presence.update_state("draining").unwrap();
-        presence.update_session_count(3).unwrap();
-        presence.update_session_count(1).unwrap();
+        presence
+            .update_drain_wait_set(3, std::slice::from_ref(&parked))
+            .unwrap();
+        presence
+            .update_drain_wait_set(1, std::slice::from_ref(&parked))
+            .unwrap();
         presence.update_state("exited").unwrap();
         let after = read();
         assert_eq!(
@@ -302,17 +359,55 @@ mod tests {
         );
         assert_eq!(after["state"], "exited");
         assert_eq!(after["session_count"], 1);
+        assert_eq!(after["holdouts"][0]["session_id"], "sess-parked-1");
+        assert_eq!(after["holdouts"][0]["phase"], "waiting_rate_limit");
+        assert_eq!(
+            after["holdouts"][0]["limit_park"]["resets_at_epoch"],
+            1_754_000_000_u64,
+            "the parked-until instant rides the record — the decisive fact"
+        );
 
         // Write-on-change: unchanged values are no-ops. Scribble the file
         // externally; same-value updates must not clobber the scribble.
         std::fs::write(&json_path, b"{\"sentinel\":true}").unwrap();
-        presence.update_session_count(1).unwrap();
+        presence
+            .update_drain_wait_set(1, std::slice::from_ref(&parked))
+            .unwrap();
         presence.update_state("exited").unwrap();
         assert_eq!(
             read()["sentinel"],
             true,
             "unchanged lifecycle values never rewrite the file"
         );
+    }
+
+    /// The record is a small display file every co-homed boot reads:
+    /// rows cap at [`PRESENCE_HOLDOUT_ROWS_CAP`] while `session_count`
+    /// stays the full truth ("and N more" derives from the difference).
+    #[test]
+    fn holdout_rows_cap_but_the_count_stays_whole() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut presence = DaemonPresence::register(dir.path(), "boot-a", 8765).expect("register");
+        let rows: Vec<DrainHoldout> = (0..PRESENCE_HOLDOUT_ROWS_CAP + 4)
+            .map(|n| DrainHoldout {
+                session_id: format!("sess-{n:02}"),
+                source: "codex".to_string(),
+                name: None,
+                phase: "running".to_string(),
+                limit_park: None,
+            })
+            .collect();
+        presence
+            .update_drain_wait_set(rows.len() as u64, &rows)
+            .unwrap();
+        let json_path = dir.path().join(DAEMONS_DIR).join("boot-a.json");
+        let record: PresenceRecord =
+            serde_json::from_slice(&std::fs::read(&json_path).unwrap()).unwrap();
+        assert_eq!(
+            record.holdouts.as_ref().map(Vec::len),
+            Some(PRESENCE_HOLDOUT_ROWS_CAP)
+        );
+        assert_eq!(record.session_count, Some(rows.len() as u64));
     }
 
     #[test]

--- a/src/bin/caller/session_supervisor/mod.rs
+++ b/src/bin/caller/session_supervisor/mod.rs
@@ -1363,8 +1363,7 @@ mod tests {
         assert_eq!(status["holdouts"][0]["name"], "nightly build");
         assert_eq!(status["holdouts"][0]["phase"], "waiting_rate_limit");
         assert_eq!(
-            status["holdouts"][0]["limit_park"]["resets_at_epoch"],
-            1_754_000_000_u64,
+            status["holdouts"][0]["limit_park"]["resets_at_epoch"], 1_754_000_000_u64,
             "the parked-until instant is the decisive fact — it must reach the surface"
         );
         let record = crate::handover::read_presence_records(home.path())
@@ -1437,11 +1436,17 @@ mod tests {
         let ids: Vec<&str> = rows.iter().map(|row| row.session_id.as_str()).collect();
         assert_eq!(ids, vec!["s-early", "s-late", "s-plain"]);
         assert_eq!(
-            rows[0].limit_park.as_ref().and_then(|park| park.resets_at_epoch),
+            rows[0]
+                .limit_park
+                .as_ref()
+                .and_then(|park| park.resets_at_epoch),
             Some(1_000)
         );
         assert_eq!(rows[2].limit_park, None);
-        assert_eq!(rows[2].phase, "running", "phases normalize for stable rendering");
+        assert_eq!(
+            rows[2].phase, "running",
+            "phases normalize for stable rendering"
+        );
     }
 
     pub(crate) fn test_supervisor_with_mock_provider(

--- a/src/bin/caller/session_supervisor/mod.rs
+++ b/src/bin/caller/session_supervisor/mod.rs
@@ -116,7 +116,27 @@ pub struct SessionSupervisor {
     /// bodies and the commands deferred behind them (see exec.rs and
     /// `dispatch_control_msg`).
     exec: Arc<exec::IntakeExecutor>,
+    /// Drain wait-set memo (see [`DrainWaitMemo`]): the exit check runs
+    /// on every bus event while draining, and the named holdout rows it
+    /// reports read durable meta — this gates the rebuild to real
+    /// changes plus a slow refresh beat.
+    drain_wait_memo: Arc<std::sync::Mutex<DrainWaitMemo>>,
 }
+
+/// Last reported drain wait set: its (session id, phase) fingerprint and
+/// when the rows were last rebuilt. Limit-park marker edges ride phase
+/// edges (parking and releasing both emit a status update), so the
+/// fingerprint catches every ordinary change; [`DRAIN_WAIT_REFRESH`]
+/// catches a marker whose durable write landed just after its phase
+/// event was observed.
+#[derive(Default)]
+struct DrainWaitMemo {
+    fingerprint: Vec<(String, String)>,
+    reported_at: Option<std::time::Instant>,
+}
+
+/// Refresh beat for the drain wait-set rows when nothing else changed.
+const DRAIN_WAIT_REFRESH: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// The foreground web shape needs session supervision before its primary
 /// task ends (for parallel create/resume/fork requests), but must leave
@@ -714,6 +734,7 @@ impl SessionSupervisor {
             config: Arc::new(config),
             state: Arc::new(AsyncMutex::new(SupervisorState::default())),
             exec: exec::IntakeExecutor::new(),
+            drain_wait_memo: Arc::new(std::sync::Mutex::new(DrainWaitMemo::default())),
         }
     }
 
@@ -890,10 +911,15 @@ impl SessionSupervisor {
     /// every drain behind them forever. An `idle` session still holds
     /// (it may be pre-first-turn, or mid-conversation awaiting the
     /// owner — the intake's "steer or stop stragglers" lane); parked
-    /// conversations stay resumable on the successor. Mirrors the
-    /// holding count onto the presence record each check ("draining ·
-    /// N sessions"), and records the terminal `exited` presence state
-    /// when satisfied.
+    /// conversations stay resumable on the successor. A LIMIT-PARKED
+    /// wrapper also holds — for as long as its in-memory park runs
+    /// (potentially hours) — which is exactly why the wait set is
+    /// NAMED: the holdout rows (with each session's durable
+    /// `limit_park` marker) reach the status surface and the presence
+    /// record via [`HandoverRuntime::set_drain_wait_set`], so every
+    /// drain surface can say WHO holds and until WHEN instead of
+    /// rendering a silent banner. Records the terminal `exited`
+    /// presence state when satisfied.
     async fn drain_exit_ready(&self) -> bool {
         let Some(runtime) = self.config.handover.as_ref() else {
             return false;
@@ -901,16 +927,52 @@ impl SessionSupervisor {
         if !runtime.is_draining() {
             return false;
         }
-        let holding = self
+        let holding: Vec<(String, String, Option<String>, String, PathBuf)> = self
             .state
             .lock()
             .await
             .sessions
             .values()
             .filter(|session| session.phase != "done")
-            .count();
-        runtime.set_session_count(holding as u64);
-        if holding > 0 || self.exec.latest_pending_heavy_key().is_some() {
+            .map(|session| {
+                (
+                    session.session_id.clone(),
+                    session.source.clone(),
+                    session.name.clone(),
+                    session.phase.clone(),
+                    session.session_dir.clone(),
+                )
+            })
+            .collect();
+        // Rebuild + report the named rows only when the set moved or the
+        // refresh beat elapsed: this check runs per bus event, and the
+        // marker resolution reads each holding session's durable meta.
+        let rebuild = {
+            let mut memo = match self.drain_wait_memo.lock() {
+                Ok(memo) => memo,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            let mut fingerprint: Vec<(String, String)> = holding
+                .iter()
+                .map(|(id, _, _, phase, _)| (id.clone(), phase.clone()))
+                .collect();
+            fingerprint.sort();
+            if memo.fingerprint != fingerprint
+                || memo
+                    .reported_at
+                    .is_none_or(|at| at.elapsed() >= DRAIN_WAIT_REFRESH)
+            {
+                memo.fingerprint = fingerprint;
+                memo.reported_at = Some(std::time::Instant::now());
+                true
+            } else {
+                false
+            }
+        };
+        if rebuild {
+            runtime.set_drain_wait_set(drain_holdout_rows(&holding));
+        }
+        if !holding.is_empty() || self.exec.latest_pending_heavy_key().is_some() {
             return false;
         }
         // Intake §3.3's exit parenthetical (the HS3 ruling's N5): a
@@ -978,6 +1040,44 @@ impl SessionSupervisor {
         )
         .await
     }
+}
+
+/// The named drain wait set: one row per holding session, with the
+/// durable limit-park marker resolved from its `session_meta.json` —
+/// "parked until T" is decisive information (an in-memory park can hold
+/// the drain for hours), so the reset instant must reach every surface
+/// that renders the drain. Parked rows sort first (earliest reset
+/// leading) so capped renders keep the decisive ones; the rest keep id
+/// order for stable rendering.
+fn drain_holdout_rows(
+    holding: &[(String, String, Option<String>, String, PathBuf)],
+) -> Vec<crate::handover::DrainHoldout> {
+    let mut rows: Vec<crate::handover::DrainHoldout> = holding
+        .iter()
+        .map(|(session_id, source, name, phase, session_dir)| {
+            let limit_park = std::fs::read_to_string(session_dir.join("session_meta.json"))
+                .ok()
+                .and_then(|raw| serde_json::from_str::<session_log::SessionMeta>(&raw).ok())
+                .and_then(|meta| meta.limit_park);
+            crate::handover::DrainHoldout {
+                session_id: session_id.clone(),
+                source: source.clone(),
+                name: name.clone(),
+                phase: normalize_supervisor_phase(phase),
+                limit_park,
+            }
+        })
+        .collect();
+    let park_key = |row: &crate::handover::DrainHoldout| match &row.limit_park {
+        Some(park) => (0u8, park.resets_at_epoch.unwrap_or(u64::MAX)),
+        None => (1u8, 0),
+    };
+    rows.sort_by(|a, b| {
+        park_key(a)
+            .cmp(&park_key(b))
+            .then_with(|| a.session_id.cmp(&b.session_id))
+    });
+    rows
 }
 
 fn normalize_supervisor_phase(phase: &str) -> String {
@@ -1207,7 +1307,10 @@ mod tests {
 
     /// Track HS3: the exit condition — draining with zero live sessions
     /// (and no launch body in flight) is ready; a live session holds the
-    /// daemon open and mirrors its count onto the presence record.
+    /// daemon open and the NAMED wait set — each holdout with its phase
+    /// and durable limit-park marker — reaches the status surface and
+    /// the presence record (the drain-holdout-honesty commission: the
+    /// banner must say WHO holds and until WHEN, never wait silently).
     #[tokio::test]
     async fn drain_exit_readiness_follows_live_sessions() {
         let home = tempfile::tempdir().unwrap();
@@ -1230,21 +1333,115 @@ mod tests {
             runtime.request_drain(None),
             crate::handover::DrainRequest::Entered
         );
-        supervisor
-            .state
-            .lock()
-            .await
-            .sessions
-            .insert("s-1".to_string(), managed_session("s-1", "intendant"));
+        let parked_dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            parked_dir.path().join("session_meta.json"),
+            serde_json::json!({
+                "session_id": "s-1",
+                "created_at": "2026-08-01 09:00:00",
+                "status": "running",
+                "limit_park": {"resets_at_epoch": 1_754_000_000_u64, "has_pending": true},
+            })
+            .to_string(),
+        )
+        .unwrap();
+        {
+            let mut state = supervisor.state.lock().await;
+            let mut parked = managed_session("s-1", "claude-code");
+            parked.name = Some("nightly build".to_string());
+            parked.phase = "waiting_rate_limit".to_string();
+            parked.session_dir = parked_dir.path().to_path_buf();
+            state.sessions.insert("s-1".to_string(), parked);
+        }
         assert!(
             !supervisor.drain_exit_ready().await,
             "a live supervised session holds the drainer open"
         );
+        let status = runtime.status_json();
+        assert_eq!(status["holdouts"][0]["session_id"], "s-1");
+        assert_eq!(status["holdouts"][0]["source"], "claude-code");
+        assert_eq!(status["holdouts"][0]["name"], "nightly build");
+        assert_eq!(status["holdouts"][0]["phase"], "waiting_rate_limit");
+        assert_eq!(
+            status["holdouts"][0]["limit_park"]["resets_at_epoch"],
+            1_754_000_000_u64,
+            "the parked-until instant is the decisive fact — it must reach the surface"
+        );
+        let record = crate::handover::read_presence_records(home.path())
+            .into_iter()
+            .find(|record| record.state == "draining")
+            .expect("draining presence record");
+        assert_eq!(record.session_count, Some(1));
+        assert_eq!(
+            record.holdouts.as_ref().map(Vec::len),
+            Some(1),
+            "the successor-side channel carries the named rows"
+        );
+
         supervisor.state.lock().await.sessions.remove("s-1");
         assert!(
             supervisor.drain_exit_ready().await,
             "last session gone ⇒ graceful exit"
         );
+        assert_eq!(
+            runtime.status_json()["holdouts"].as_array().map(Vec::len),
+            Some(0),
+            "an emptied wait set reports empty, never stale rows"
+        );
+    }
+
+    /// Parked holdouts sort first (earliest reset leading) so capped
+    /// renders keep the decisive rows; phases normalize; a dir with no
+    /// meta yields an honest markerless row rather than being dropped.
+    #[test]
+    fn drain_holdout_rows_resolve_markers_and_sort_parked_first() {
+        let write_meta = |resets_at: u64| {
+            let dir = tempfile::tempdir().unwrap();
+            std::fs::write(
+                dir.path().join("session_meta.json"),
+                serde_json::json!({
+                    "session_id": "x",
+                    "created_at": "2026-08-01 09:00:00",
+                    "limit_park": {"resets_at_epoch": resets_at, "has_pending": true},
+                })
+                .to_string(),
+            )
+            .unwrap();
+            dir
+        };
+        let late = write_meta(2_000);
+        let early = write_meta(1_000);
+        let rows = drain_holdout_rows(&[
+            (
+                "s-plain".to_string(),
+                "codex".to_string(),
+                None,
+                "Running-Agent".to_string(),
+                PathBuf::from("/nonexistent/session-dir"),
+            ),
+            (
+                "s-late".to_string(),
+                "claude-code".to_string(),
+                None,
+                "waiting_rate_limit".to_string(),
+                late.path().to_path_buf(),
+            ),
+            (
+                "s-early".to_string(),
+                "claude-code".to_string(),
+                Some("weekly digest".to_string()),
+                "waiting_rate_limit".to_string(),
+                early.path().to_path_buf(),
+            ),
+        ]);
+        let ids: Vec<&str> = rows.iter().map(|row| row.session_id.as_str()).collect();
+        assert_eq!(ids, vec!["s-early", "s-late", "s-plain"]);
+        assert_eq!(
+            rows[0].limit_park.as_ref().and_then(|park| park.resets_at_epoch),
+            Some(1_000)
+        );
+        assert_eq!(rows[2].limit_park, None);
+        assert_eq!(rows[2].phase, "running", "phases normalize for stable rendering");
     }
 
     pub(crate) fn test_supervisor_with_mock_provider(

--- a/src/bin/caller/startup/daemon.rs
+++ b/src/bin/caller/startup/daemon.rs
@@ -287,6 +287,23 @@ pub(crate) async fn run_daemon(
             // the wiring edge (tests inject their own handles).
             crate::agenda::published_agenda_handle(),
         ));
+        // The successor's half of spare-under-takeover: sessions a
+        // draining predecessor still holds are spared (on the takeover
+        // topology the boot pass above never even enumerates — the
+        // successor is a secondary at spawn instant), then RELEASED
+        // when the drainer exits, possibly hours later. This watch runs
+        // the scoped readopt pass at that instant instead of leaving
+        // the released set down until the next restart.
+        let watch_bus = startup_bus.clone();
+        let watch_handover = gateway.handover.clone();
+        tokio::spawn(crate::boot_readopt::run_predecessor_exit_watch(
+            crate::platform::home_dir(),
+            watch_bus,
+            watch_handover,
+            readopt_enabled,
+            crate::boot_readopt::READOPT_DISPATCH_SPACING,
+            crate::boot_readopt::RELEASED_SETTLE,
+        ));
     }
     let _ = supervisor_handle.await;
     Ok(())

--- a/static/app.html
+++ b/static/app.html
@@ -38366,11 +38366,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-<<<<<<< HEAD
-const INTENDANT_APP_BUILD = '92dfba50e83d42bb';
-=======
-const INTENDANT_APP_BUILD = '5d107a2a2b8703bf';
->>>>>>> origin/main
+const INTENDANT_APP_BUILD = 'c243da7695d820f3';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {

--- a/static/app.html
+++ b/static/app.html
@@ -27326,6 +27326,62 @@ html.ui-v2 .handover-banner a {
   font-weight: 600;
 }
 
+/* ── drain holdout honesty: the banner names WHO holds the drain and
+   until WHEN, and the successor link is a doorway, not a footnote. ── */
+html.ui-v2 .handover-banner-head {
+  margin-bottom: 2px;
+}
+html.ui-v2 .handover-banner-note {
+  margin-top: 2px;
+  font-size: 11px;
+  color: var(--muted, #7e8896);
+}
+html.ui-v2 .handover-successor-link {
+  display: inline-block;
+  margin: 4px 0 2px;
+  padding: 3px 12px;
+  border: 1px solid var(--accent, #62a0ea);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--accent, #62a0ea);
+  font-weight: 600;
+  text-decoration: none;
+}
+html.ui-v2 .handover-successor-link:hover {
+  background: var(--surface2, rgba(58, 58, 70, 0.96));
+}
+html.ui-v2 .handover-holdouts {
+  margin-top: 4px;
+}
+html.ui-v2 .handover-holdout-list {
+  margin: 0;
+  padding-left: 18px;
+  max-height: 140px;
+  overflow-y: auto;
+}
+html.ui-v2 .handover-holdout-list li {
+  font-size: 12px;
+  line-height: 1.45;
+}
+html.ui-v2 .handover-holdout-name {
+  font-weight: 600;
+}
+html.ui-v2 .handover-holdout-state {
+  color: var(--muted, #7e8896);
+}
+html.ui-v2 .handover-holdout-state.parked {
+  color: var(--warning, #e5a50a);
+}
+html.ui-v2 .handover-holdout-more {
+  font-size: 11px;
+  color: var(--muted, #7e8896);
+}
+html.ui-v2 .handover-predecessor + .handover-predecessor {
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid var(--surface2, rgba(90, 90, 104, 0.5));
+}
+
 /* ── update-available chip (HS6): a quiet bottom-corner card — the fact
    of a newer on-disk build, its provenance, and (macOS unsigned builds)
    the keychain/TCC honesty line. Distinct from the drain banner: an
@@ -38267,7 +38323,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '757f6b80effb0a0b';
+const INTENDANT_APP_BUILD = '92dfba50e83d42bb';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -103916,11 +103972,14 @@ async function memoryProposeFromForm(button) {
 // (HS6) ──────────────────────────────────────────────────────────────
 // Polls GET /api/daemon/handover (tunnel twin api_daemon_handover): the
 // scheduler-lease status block. Renders:
-//   - THIS daemon draining: a persistent banner — in-flight sessions
-//     finish here; new work continues on the successor (linked once the
-//     lease sidecar names it).
-//   - another co-homed daemon draining: a compact predecessor chip with
-//     its remaining session count.
+//   - THIS daemon draining: a persistent banner that NAMES the wait set
+//     (`holdouts`: each holding session with its state — a limit-parked
+//     holdout leads with its parked-until instant, the decisive fact)
+//     and carries a prominent doorway to the successor once the lease
+//     sidecar names it.
+//   - other co-homed daemons draining (all of them, not just the
+//     first): a predecessor section each, with its remaining count, its
+//     named holdout rows off the presence record, and a doorway to it.
 //   - a newer/changed binary on disk (the daemon's update watch): the
 //     bottom-corner update chip with both builds' provenance and the
 //     keychain/TCC honesty line where it applies. Collapsible to a
@@ -104275,6 +104334,104 @@ async function memoryProposeFromForm(button) {
     return Number.isFinite(port) && port > 0 ? port : null;
   }
 
+  // Render at most this many holdout rows; the rest fold into an honest
+  // "…and N more" (parked rows arrive sorted first from the daemon, so
+  // the decisive parked-until facts survive the fold).
+  const HOLDOUT_RENDER_CAP = 8;
+
+  function handoverShortId(id) {
+    const raw = String(id || '');
+    return raw.length > 8 ? raw.slice(0, 8) : raw;
+  }
+
+  // "9:10 PM (in ~42m)" from an epoch-seconds reset instant, in the
+  // viewer's locale; honest about a reset that is due or just passed.
+  function handoverParkedUntil(resetsAtEpoch) {
+    const epoch = Number(resetsAtEpoch);
+    if (!Number.isFinite(epoch) || epoch <= 0) return null;
+    const at = new Date(epoch * 1000);
+    const clock = at.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+    const deltaMin = Math.round((at.getTime() - Date.now()) / 60000);
+    if (deltaMin > 1) {
+      const spell = deltaMin >= 90 ? `~${Math.round(deltaMin / 60)}h` : `~${deltaMin}m`;
+      return `${clock} (in ${spell})`;
+    }
+    return `${clock} (due now)`;
+  }
+
+  // Owner-facing state words. A limit-parked holdout leads with the
+  // parked-until instant — the decisive fact (the park can hold the
+  // drain for hours). Unknown phases pass through rather than lie.
+  function handoverHoldoutState(holdout) {
+    const park = holdout && holdout.limit_park;
+    if (park) {
+      const until = handoverParkedUntil(park.resets_at_epoch);
+      return until
+        ? `rate-limit parked until ${until}`
+        : 'rate-limit parked — reset time unknown';
+    }
+    const phase = String((holdout && holdout.phase) || '');
+    switch (phase) {
+      case 'running':
+      case 'thinking': return 'working';
+      case 'waiting_approval': return 'waiting on an approval';
+      case 'waiting_human': return 'waiting on you';
+      case 'waiting_rate_limit': return 'rate-limit parked';
+      case 'waiting_service_recovery': return 'paused for provider recovery';
+      case 'idle': return 'idle — awaiting input';
+      case 'interrupting':
+      case 'interrupted': return 'interrupted';
+      default: return phase || 'unknown';
+    }
+  }
+
+  // The named wait set. textContent throughout — session names are
+  // agent/user-controlled and must never reach innerHTML (the update
+  // chip states the same rule).
+  function handoverHoldoutList(rows, totalCount) {
+    const wrap = document.createElement('div');
+    wrap.className = 'handover-holdouts';
+    const list = document.createElement('ul');
+    list.className = 'handover-holdout-list';
+    rows.slice(0, HOLDOUT_RENDER_CAP).forEach((holdout) => {
+      if (!holdout || typeof holdout !== 'object') return;
+      const item = document.createElement('li');
+      const who = document.createElement('span');
+      who.className = 'handover-holdout-name';
+      who.textContent = holdout.name || handoverShortId(holdout.session_id) || 'unnamed session';
+      item.appendChild(who);
+      const state = document.createElement('span');
+      state.className = 'handover-holdout-state';
+      if (holdout.limit_park) state.classList.add('parked');
+      state.textContent = ` — ${handoverHoldoutState(holdout)}`;
+      item.appendChild(state);
+      list.appendChild(item);
+    });
+    wrap.appendChild(list);
+    const total = Number(totalCount);
+    const shown = Math.min(rows.length, HOLDOUT_RENDER_CAP);
+    const folded = Number.isFinite(total) && total > shown ? total - shown : 0;
+    if (folded > 0) {
+      const more = document.createElement('div');
+      more.className = 'handover-holdout-more';
+      more.textContent = `…and ${folded} more`;
+      wrap.appendChild(more);
+    }
+    return wrap;
+  }
+
+  // A real doorway to a co-homed daemon — same-host port substitution,
+  // like the old inline link, but rendered as a prominent element.
+  function handoverDaemonLink(port, label) {
+    const link = document.createElement('a');
+    link.className = 'handover-successor-link';
+    link.href = `${location.protocol}//${location.hostname}:${port}/`;
+    link.target = '_blank';
+    link.rel = 'noopener';
+    link.textContent = label;
+    return link;
+  }
+
   function handoverRender(body) {
     if (!body || body.available === false) { handoverClear(); updateChipClear(); return; }
     if (body.boot_id && typeof maybeNudgeDaemonBoot === 'function') {
@@ -104283,29 +104440,63 @@ async function memoryProposeFromForm(button) {
     handoverUpdateRender(body);
     if (body.draining) {
       const port = handoverSuccessorPort(body);
-      const link = port
-        ? `<a href="${location.protocol}//${location.hostname}:${port}/" target="_blank" rel="noopener">:${port}</a>`
-        : null;
       const el = handoverBanner();
       el.dataset.kind = 'draining';
-      el.innerHTML = link
-        ? `<strong>This daemon is draining.</strong> In-flight sessions finish here — continue new work on the successor at ${link}.`
-        : '<strong>This daemon is draining.</strong> In-flight sessions finish here — no successor has acquired the lease yet.';
+      el.textContent = '';
+      const head = document.createElement('div');
+      head.className = 'handover-banner-head';
+      const lead = document.createElement('strong');
+      lead.textContent = 'This daemon is draining.';
+      head.appendChild(lead);
+      const rows = Array.isArray(body.holdouts) ? body.holdouts : [];
+      const tail = document.createElement('span');
+      tail.textContent = rows.length
+        ? ` Waiting on ${rows.length} in-flight session${rows.length === 1 ? '' : 's'}, then it exits.`
+        : ' In-flight sessions finish here, then it exits.';
+      head.appendChild(tail);
+      el.appendChild(head);
+      if (port) {
+        el.appendChild(handoverDaemonLink(port, `Open the successor daemon (:${port}) →`));
+      } else {
+        const none = document.createElement('div');
+        none.className = 'handover-banner-note';
+        none.textContent = 'No successor has acquired the lease yet.';
+        el.appendChild(none);
+      }
+      if (rows.length) el.appendChild(handoverHoldoutList(rows, rows.length));
       return;
     }
     const others = Array.isArray(body.daemons)
       ? body.daemons.filter((d) => d && d.live && d.state === 'draining' && d.boot_id !== body.boot_id)
       : [];
     if (others.length) {
-      const d = others[0];
-      const port = Number(d.port);
-      const count = Number(d.session_count);
-      const sessions = Number.isFinite(count)
-        ? ` · ${count} session${count === 1 ? '' : 's'} left`
-        : '';
       const el = handoverBanner();
       el.dataset.kind = 'predecessor';
-      el.innerHTML = `Predecessor daemon draining${Number.isFinite(port) ? ` on :${port}` : ''}${sessions} — it exits when its last in-flight session ends.`;
+      el.textContent = '';
+      others.forEach((d) => {
+        const port = Number(d.port);
+        const count = Number(d.session_count);
+        const section = document.createElement('div');
+        section.className = 'handover-predecessor';
+        const head = document.createElement('div');
+        head.className = 'handover-banner-head';
+        const lead = document.createElement('span');
+        lead.textContent = `A predecessor daemon is draining${Number.isFinite(port) ? ` on :${port}` : ''}`
+          + `${Number.isFinite(count) ? ` — ${count} session${count === 1 ? '' : 's'} still finishing there` : ''}.`;
+        head.appendChild(lead);
+        if (Number.isFinite(port) && port > 0) {
+          head.appendChild(document.createTextNode(' '));
+          head.appendChild(handoverDaemonLink(port, `Open :${port} →`));
+        }
+        section.appendChild(head);
+        const rows = Array.isArray(d.holdouts) ? d.holdouts : [];
+        if (rows.length) section.appendChild(handoverHoldoutList(rows, count));
+        const note = document.createElement('div');
+        note.className = 'handover-banner-note';
+        note.textContent = 'Mid-work sessions it releases are picked up here when it exits.';
+        section.appendChild(note);
+        el.appendChild(section);
+      });
       return;
     }
     handoverClear();
@@ -104327,6 +104518,12 @@ async function memoryProposeFromForm(button) {
   window.qa.handoverUpdateChip = {
     render: (body) => handoverUpdateRender(body),
     stateKey: updateChipStateKey,
+  };
+  // Same tokenless-QA posture for the drain banner: probes feed a
+  // synthetic handover body and assert the named wait set + the
+  // successor doorway render.
+  window.qa.handoverBanner = {
+    render: (body) => handoverRender(body),
   };
 
   // The update panel's composition hook (production, not QA): the panel

--- a/static/app/ui2-handover.css
+++ b/static/app/ui2-handover.css
@@ -25,6 +25,62 @@ html.ui-v2 .handover-banner a {
   font-weight: 600;
 }
 
+/* ── drain holdout honesty: the banner names WHO holds the drain and
+   until WHEN, and the successor link is a doorway, not a footnote. ── */
+html.ui-v2 .handover-banner-head {
+  margin-bottom: 2px;
+}
+html.ui-v2 .handover-banner-note {
+  margin-top: 2px;
+  font-size: 11px;
+  color: var(--muted, #7e8896);
+}
+html.ui-v2 .handover-successor-link {
+  display: inline-block;
+  margin: 4px 0 2px;
+  padding: 3px 12px;
+  border: 1px solid var(--accent, #62a0ea);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--accent, #62a0ea);
+  font-weight: 600;
+  text-decoration: none;
+}
+html.ui-v2 .handover-successor-link:hover {
+  background: var(--surface2, rgba(58, 58, 70, 0.96));
+}
+html.ui-v2 .handover-holdouts {
+  margin-top: 4px;
+}
+html.ui-v2 .handover-holdout-list {
+  margin: 0;
+  padding-left: 18px;
+  max-height: 140px;
+  overflow-y: auto;
+}
+html.ui-v2 .handover-holdout-list li {
+  font-size: 12px;
+  line-height: 1.45;
+}
+html.ui-v2 .handover-holdout-name {
+  font-weight: 600;
+}
+html.ui-v2 .handover-holdout-state {
+  color: var(--muted, #7e8896);
+}
+html.ui-v2 .handover-holdout-state.parked {
+  color: var(--warning, #e5a50a);
+}
+html.ui-v2 .handover-holdout-more {
+  font-size: 11px;
+  color: var(--muted, #7e8896);
+}
+html.ui-v2 .handover-predecessor + .handover-predecessor {
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid var(--surface2, rgba(90, 90, 104, 0.5));
+}
+
 /* ── update-available chip (HS6): a quiet bottom-corner card — the fact
    of a newer on-disk build, its provenance, and (macOS unsigned builds)
    the keychain/TCC honesty line. Distinct from the drain banner: an

--- a/static/app/ui2-handover.js
+++ b/static/app/ui2-handover.js
@@ -2,11 +2,14 @@
 // (HS6) ──────────────────────────────────────────────────────────────
 // Polls GET /api/daemon/handover (tunnel twin api_daemon_handover): the
 // scheduler-lease status block. Renders:
-//   - THIS daemon draining: a persistent banner — in-flight sessions
-//     finish here; new work continues on the successor (linked once the
-//     lease sidecar names it).
-//   - another co-homed daemon draining: a compact predecessor chip with
-//     its remaining session count.
+//   - THIS daemon draining: a persistent banner that NAMES the wait set
+//     (`holdouts`: each holding session with its state — a limit-parked
+//     holdout leads with its parked-until instant, the decisive fact)
+//     and carries a prominent doorway to the successor once the lease
+//     sidecar names it.
+//   - other co-homed daemons draining (all of them, not just the
+//     first): a predecessor section each, with its remaining count, its
+//     named holdout rows off the presence record, and a doorway to it.
 //   - a newer/changed binary on disk (the daemon's update watch): the
 //     bottom-corner update chip with both builds' provenance and the
 //     keychain/TCC honesty line where it applies. Collapsible to a
@@ -361,6 +364,104 @@
     return Number.isFinite(port) && port > 0 ? port : null;
   }
 
+  // Render at most this many holdout rows; the rest fold into an honest
+  // "…and N more" (parked rows arrive sorted first from the daemon, so
+  // the decisive parked-until facts survive the fold).
+  const HOLDOUT_RENDER_CAP = 8;
+
+  function handoverShortId(id) {
+    const raw = String(id || '');
+    return raw.length > 8 ? raw.slice(0, 8) : raw;
+  }
+
+  // "9:10 PM (in ~42m)" from an epoch-seconds reset instant, in the
+  // viewer's locale; honest about a reset that is due or just passed.
+  function handoverParkedUntil(resetsAtEpoch) {
+    const epoch = Number(resetsAtEpoch);
+    if (!Number.isFinite(epoch) || epoch <= 0) return null;
+    const at = new Date(epoch * 1000);
+    const clock = at.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+    const deltaMin = Math.round((at.getTime() - Date.now()) / 60000);
+    if (deltaMin > 1) {
+      const spell = deltaMin >= 90 ? `~${Math.round(deltaMin / 60)}h` : `~${deltaMin}m`;
+      return `${clock} (in ${spell})`;
+    }
+    return `${clock} (due now)`;
+  }
+
+  // Owner-facing state words. A limit-parked holdout leads with the
+  // parked-until instant — the decisive fact (the park can hold the
+  // drain for hours). Unknown phases pass through rather than lie.
+  function handoverHoldoutState(holdout) {
+    const park = holdout && holdout.limit_park;
+    if (park) {
+      const until = handoverParkedUntil(park.resets_at_epoch);
+      return until
+        ? `rate-limit parked until ${until}`
+        : 'rate-limit parked — reset time unknown';
+    }
+    const phase = String((holdout && holdout.phase) || '');
+    switch (phase) {
+      case 'running':
+      case 'thinking': return 'working';
+      case 'waiting_approval': return 'waiting on an approval';
+      case 'waiting_human': return 'waiting on you';
+      case 'waiting_rate_limit': return 'rate-limit parked';
+      case 'waiting_service_recovery': return 'paused for provider recovery';
+      case 'idle': return 'idle — awaiting input';
+      case 'interrupting':
+      case 'interrupted': return 'interrupted';
+      default: return phase || 'unknown';
+    }
+  }
+
+  // The named wait set. textContent throughout — session names are
+  // agent/user-controlled and must never reach innerHTML (the update
+  // chip states the same rule).
+  function handoverHoldoutList(rows, totalCount) {
+    const wrap = document.createElement('div');
+    wrap.className = 'handover-holdouts';
+    const list = document.createElement('ul');
+    list.className = 'handover-holdout-list';
+    rows.slice(0, HOLDOUT_RENDER_CAP).forEach((holdout) => {
+      if (!holdout || typeof holdout !== 'object') return;
+      const item = document.createElement('li');
+      const who = document.createElement('span');
+      who.className = 'handover-holdout-name';
+      who.textContent = holdout.name || handoverShortId(holdout.session_id) || 'unnamed session';
+      item.appendChild(who);
+      const state = document.createElement('span');
+      state.className = 'handover-holdout-state';
+      if (holdout.limit_park) state.classList.add('parked');
+      state.textContent = ` — ${handoverHoldoutState(holdout)}`;
+      item.appendChild(state);
+      list.appendChild(item);
+    });
+    wrap.appendChild(list);
+    const total = Number(totalCount);
+    const shown = Math.min(rows.length, HOLDOUT_RENDER_CAP);
+    const folded = Number.isFinite(total) && total > shown ? total - shown : 0;
+    if (folded > 0) {
+      const more = document.createElement('div');
+      more.className = 'handover-holdout-more';
+      more.textContent = `…and ${folded} more`;
+      wrap.appendChild(more);
+    }
+    return wrap;
+  }
+
+  // A real doorway to a co-homed daemon — same-host port substitution,
+  // like the old inline link, but rendered as a prominent element.
+  function handoverDaemonLink(port, label) {
+    const link = document.createElement('a');
+    link.className = 'handover-successor-link';
+    link.href = `${location.protocol}//${location.hostname}:${port}/`;
+    link.target = '_blank';
+    link.rel = 'noopener';
+    link.textContent = label;
+    return link;
+  }
+
   function handoverRender(body) {
     if (!body || body.available === false) { handoverClear(); updateChipClear(); return; }
     if (body.boot_id && typeof maybeNudgeDaemonBoot === 'function') {
@@ -369,29 +470,63 @@
     handoverUpdateRender(body);
     if (body.draining) {
       const port = handoverSuccessorPort(body);
-      const link = port
-        ? `<a href="${location.protocol}//${location.hostname}:${port}/" target="_blank" rel="noopener">:${port}</a>`
-        : null;
       const el = handoverBanner();
       el.dataset.kind = 'draining';
-      el.innerHTML = link
-        ? `<strong>This daemon is draining.</strong> In-flight sessions finish here — continue new work on the successor at ${link}.`
-        : '<strong>This daemon is draining.</strong> In-flight sessions finish here — no successor has acquired the lease yet.';
+      el.textContent = '';
+      const head = document.createElement('div');
+      head.className = 'handover-banner-head';
+      const lead = document.createElement('strong');
+      lead.textContent = 'This daemon is draining.';
+      head.appendChild(lead);
+      const rows = Array.isArray(body.holdouts) ? body.holdouts : [];
+      const tail = document.createElement('span');
+      tail.textContent = rows.length
+        ? ` Waiting on ${rows.length} in-flight session${rows.length === 1 ? '' : 's'}, then it exits.`
+        : ' In-flight sessions finish here, then it exits.';
+      head.appendChild(tail);
+      el.appendChild(head);
+      if (port) {
+        el.appendChild(handoverDaemonLink(port, `Open the successor daemon (:${port}) →`));
+      } else {
+        const none = document.createElement('div');
+        none.className = 'handover-banner-note';
+        none.textContent = 'No successor has acquired the lease yet.';
+        el.appendChild(none);
+      }
+      if (rows.length) el.appendChild(handoverHoldoutList(rows, rows.length));
       return;
     }
     const others = Array.isArray(body.daemons)
       ? body.daemons.filter((d) => d && d.live && d.state === 'draining' && d.boot_id !== body.boot_id)
       : [];
     if (others.length) {
-      const d = others[0];
-      const port = Number(d.port);
-      const count = Number(d.session_count);
-      const sessions = Number.isFinite(count)
-        ? ` · ${count} session${count === 1 ? '' : 's'} left`
-        : '';
       const el = handoverBanner();
       el.dataset.kind = 'predecessor';
-      el.innerHTML = `Predecessor daemon draining${Number.isFinite(port) ? ` on :${port}` : ''}${sessions} — it exits when its last in-flight session ends.`;
+      el.textContent = '';
+      others.forEach((d) => {
+        const port = Number(d.port);
+        const count = Number(d.session_count);
+        const section = document.createElement('div');
+        section.className = 'handover-predecessor';
+        const head = document.createElement('div');
+        head.className = 'handover-banner-head';
+        const lead = document.createElement('span');
+        lead.textContent = `A predecessor daemon is draining${Number.isFinite(port) ? ` on :${port}` : ''}`
+          + `${Number.isFinite(count) ? ` — ${count} session${count === 1 ? '' : 's'} still finishing there` : ''}.`;
+        head.appendChild(lead);
+        if (Number.isFinite(port) && port > 0) {
+          head.appendChild(document.createTextNode(' '));
+          head.appendChild(handoverDaemonLink(port, `Open :${port} →`));
+        }
+        section.appendChild(head);
+        const rows = Array.isArray(d.holdouts) ? d.holdouts : [];
+        if (rows.length) section.appendChild(handoverHoldoutList(rows, count));
+        const note = document.createElement('div');
+        note.className = 'handover-banner-note';
+        note.textContent = 'Mid-work sessions it releases are picked up here when it exits.';
+        section.appendChild(note);
+        el.appendChild(section);
+      });
       return;
     }
     handoverClear();
@@ -413,6 +548,12 @@
   window.qa.handoverUpdateChip = {
     render: (body) => handoverUpdateRender(body),
     stateKey: updateChipStateKey,
+  };
+  // Same tokenless-QA posture for the drain banner: probes feed a
+  // synthetic handover body and assert the named wait set + the
+  // successor doorway render.
+  window.qa.handoverBanner = {
+    render: (body) => handoverRender(body),
   };
 
   // The update panel's composition hook (production, not QA): the panel

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -7025,6 +7025,31 @@ async fn drainer_exits_at_last_session_end() {
         || daemon_a.log_tail(),
     )
     .await;
+    // Drain-holdout honesty: the drainer NAMES its wait set — the
+    // running session rides the presence record (the successor-side
+    // banner's only channel) as a holdout row with its phase, beside
+    // the count. A silent "draining" with no named holdouts is the
+    // 40-minute-mystery class this exists to kill.
+    poll_until(
+        "the drainer's presence naming its holdout row",
+        RUN_TIMEOUT,
+        || async {
+            let presence: serde_json::Value =
+                serde_json::from_slice(&std::fs::read(&presence_path).ok()?).ok()?;
+            let rows = presence.get("holdouts")?.as_array()?;
+            (presence["session_count"] == 1
+                && rows.len() == 1
+                && rows[0]["session_id"]
+                    .as_str()
+                    .is_some_and(|id| !id.is_empty())
+                && rows[0]["phase"]
+                    .as_str()
+                    .is_some_and(|phase| phase != "done"))
+            .then_some(())
+        },
+        || daemon_a.log_tail(),
+    )
+    .await;
     assert!(
         !journal_states_for_item(&daemon_a.rig, &item_id).contains(&"unknown".to_string()),
         "the new holder must spare the draining daemon's live session:\n{:?}",
@@ -7101,6 +7126,49 @@ async fn drainer_exits_at_last_session_end() {
         serde_json::from_slice(&std::fs::read(&presence_path).expect("presence file"))
             .expect("presence json");
     assert_eq!(presence["state"], "exited");
+
+    // The successor's predecessor-exit watch closed the post-drain
+    // readopt gap: it observed the draining boot while it lived, and
+    // after the exit it ran the scoped pass over the released set. In
+    // this leg the drained session COMPLETED, so the honest outcome is
+    // an empty release ("nothing released mid-work") — but any
+    // per-candidate adjudication line equally proves the pass ran; the
+    // point pinned here is that the exit instant is ACTED on, not slept
+    // through until the next restart.
+    let b_log_path = daemon_a.rig.home.path().join("daemon-b.log");
+    poll_until(
+        "the successor's watch observing the draining predecessor",
+        RUN_TIMEOUT,
+        || async {
+            std::fs::read_to_string(&b_log_path)
+                .unwrap_or_default()
+                .contains("watching draining co-homed daemon")
+                .then_some(())
+        },
+        || {
+            std::fs::read_to_string(&b_log_path)
+                .map(|log| tail(&log, 2000))
+                .unwrap_or_default()
+        },
+    )
+    .await;
+    poll_until(
+        "the successor's scoped pass running at the predecessor's exit",
+        RUN_TIMEOUT,
+        || async {
+            let log = std::fs::read_to_string(&b_log_path).unwrap_or_default();
+            (log.contains("nothing released mid-work")
+                || log.contains("released when draining daemon")
+                || log.contains("[readopt] leaving"))
+            .then_some(())
+        },
+        || {
+            std::fs::read_to_string(&b_log_path)
+                .map(|log| tail(&log, 2000))
+                .unwrap_or_default()
+        },
+    )
+    .await;
     drop(daemon_b);
 }
 

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -7128,21 +7128,22 @@ async fn drainer_exits_at_last_session_end() {
     assert_eq!(presence["state"], "exited");
 
     // The successor's predecessor-exit watch closed the post-drain
-    // readopt gap: it observed the draining boot while it lived, and
-    // after the exit it ran the scoped pass over the released set. In
+    // readopt gap: the drainer's dead presence record (drain lineage,
+    // lock free) triggers ONE scoped pass over the released set. In
     // this leg the drained session COMPLETED, so the honest outcome is
     // an empty release ("nothing released mid-work") — but any
     // per-candidate adjudication line equally proves the pass ran; the
-    // point pinned here is that the exit instant is ACTED on, not slept
-    // through until the next restart.
+    // point pinned here is that the exit is ACTED on, not slept
+    // through until the next restart. The armed line proves the watch
+    // task itself is alive (and names its poll cadence for diagnosis).
     let b_log_path = daemon_a.rig.home.path().join("daemon-b.log");
     poll_until(
-        "the successor's watch observing the draining predecessor",
+        "the successor's predecessor-exit watch arming",
         RUN_TIMEOUT,
         || async {
             std::fs::read_to_string(&b_log_path)
                 .unwrap_or_default()
-                .contains("watching draining co-homed daemon")
+                .contains("predecessor-exit watch armed")
                 .then_some(())
         },
         || {


### PR DESCRIPTION
Commission 01KYXFKWBGWKKFJGRBD3HQ32A3 (drain holdout honesty). Three gaps from the 2026-07-31 takeover-drain specimen:

1. **Drain visibility** — the drain banner named no wait set. The supervisor's exit check now builds `DrainHoldout` rows (session id, name, backend, phase, durable `limit_park` marker); they ride `GET /api/daemon/handover` as `holdouts` and mirror (capped, write-on-change, F1 era watershed untouched) onto the presence record. The SPA banner names WHO holds and until WHEN — a limit-parked holdout leads with its parked-until instant in the viewer's locale — under a prominent successor doorway link. Every draining co-homed daemon renders its own section (`others[0]` undercount fixed); all DOM-constructed, no innerHTML for agent-controlled names.

2. **Limit-park × drain** — a parked wrapper holds the drain for the full park duration. This PR ships the named-holdout lane (the banner makes the park decisive information); the clean-end-parked-wrappers lane is posed to the gate with the three design pieces it needs (non-tombstone end reason, completed-stamp carve-out, wake-at-reset machinery).

3. **Post-drain readopt gap** — the successor's boot pass never enumerates on the takeover topology (secondary at spawn instant), and nothing re-scanned at predecessor exit. A predecessor-exit watch now tracks co-homed draining boots via presence records on the lease-poll cadence; when one's per-boot lock frees, a scoped readopt pass runs over the released set — shared `midwork_class`/`decide_candidate`/`verify_dispatches` rails verbatim (Resume-not-Revive, tombstones, staleness, live-tip refusals, cap, stagger, drain-mid-pass cut), scoped to sessions whose story froze at-or-before the exit instant so nothing a live co-homed daemon is driving can be stolen. The summary names the predecessor.

Invariants untouched: drain-refuses-new-work; spare-under-takeover.

Gate question 'Gate: drain holdout honesty' parks at queue entry.