### PR TITLE
bundle-macos: pin /usr/bin/openssl for the local signing cert

### DIFF
--- a/scripts/bundle-macos.sh
+++ b/scripts/bundle-macos.sh
@@ -441,10 +441,14 @@ CN = Intendant Dev
 keyUsage = digitalSignature
 extendedKeyUsage = codeSigning
 CERTCONF
-            openssl req -x509 -newkey rsa:2048 -nodes \
+            # /usr/bin/openssl (LibreSSL) deliberately: Homebrew openssl@3's
+            # PKCS12 defaults (AES/PBKDF2) produce blobs SecKeychainItemImport
+            # rejects with "MAC verification failed", and PATH order decides
+            # which openssl a bare invocation resolves on runner accounts.
+            /usr/bin/openssl req -x509 -newkey rsa:2048 -nodes \
                 -keyout "$CERT_DIR/key.pem" -out "$CERT_DIR/cert.pem" \
                 -days 3650 -config "$CERT_DIR/cert.conf" 2>/dev/null
-            openssl pkcs12 -export -out "$CERT_DIR/cert.p12" \
+            /usr/bin/openssl pkcs12 -export -out "$CERT_DIR/cert.p12" \
                 -inkey "$CERT_DIR/key.pem" -in "$CERT_DIR/cert.pem" \
                 -passout "pass:$SIGN_P12_PASS" 2>/dev/null
             security import "$CERT_DIR/cert.p12" -k "$SIGN_KEYCHAIN" -P "$SIGN_P12_PASS" -T /usr/bin/codesign -A


### PR DESCRIPTION
Release-operator fix, steward-authored under the owner's release directive (2026-08-01).

The release.yml dry-run's macos-app leg fails at 'Bundle, sign, notarize': the local 'Intendant Dev' signing-cert creation exports its PKCS12 with a bare `openssl`, which resolves to Homebrew openssl@3 on the runner account (`/opt/homebrew/bin` precedes `/usr/bin` in the runner PATH), and SecKeychainItemImport refuses openssl@3's default PKCS12 encoding with 'MAC verification failed during PKCS12 import (wrong password?)'.

Differential repro on the runner host: the identical export/import pair succeeds with `/usr/bin/openssl` (LibreSSL) and fails with `/opt/homebrew/bin/openssl` (3.6.2). Pinning `/usr/bin/openssl` — present on every macOS — makes the cert lane PATH-independent.

Two invocations pinned (req + pkcs12 -export); no behavior change on boxes without a Homebrew openssl.