### PR TITLE
Harden Codex Cloud enrollment and long remote jobs

### DIFF
--- a/docs/src/codex-cloud-workers.md
+++ b/docs/src/codex-cloud-workers.md
@@ -690,7 +690,9 @@ live worker to home over direct mTLS or an explicitly trusted, proof-bound
 HTTPS reverse proxy. The attachment carries terminal, tile display,
 computer-use, bounded source-transfer, and provider-neutral remote-command
 frames in addition to liveness; each direction has a closed allowlist, and
-worker replies are never dispatched as authority on home. Workers are
+worker replies are never dispatched as authority on home. Both endpoints send
+periodic WebSocket pings so a long command with no output survives idle egress
+proxies and a dead connection surfaces promptly. Workers are
 ephemeral enrollments with zero-authority expiring identities, not static
 `[[peer]]` registry entries, and home must be reachable from the worker's
 egress allowlist (there is no relay tier).

--- a/docs/src/codex-cloud-workers.md
+++ b/docs/src/codex-cloud-workers.md
@@ -435,7 +435,9 @@ The contract is intentionally stricter than an interactive terminal:
 - Commands are transported as an argv array and are not implicitly parsed by
   a shell. `cwd`, when present, is repository-relative and cannot escape the
   selected checkout. Explicit environment entries are additions to the
-  worker's agent-phase environment.
+  worker's agent-phase environment. The command does not inherit the
+  attachment agent's private `INTENDANT_HOME`; a caller may deliberately
+  supply a different value in the explicit environment.
 - `source: "git_revision"` is the default and requires
   `expected_revision`. The worker refuses a different checkout; abbreviated
   object ids are accepted from 7 hexadecimal characters.

--- a/docs/src/codex-cloud-workers.md
+++ b/docs/src/codex-cloud-workers.md
@@ -283,7 +283,12 @@ INTENDANT_CODEX_CLOUD_TLS_TERMINATED_PROXY=1
 In that mode the worker validates the public endpoint with normal WebPKI
 instead of pinning Intendant's inner TLS certificate. It still generates the
 same task-local P-256 key and receives the same zero-authority client
-certificate. Every WebSocket attempt signs a transcript containing the exact
+certificate. The enrollment request carries the same bounded JSON in its
+normal POST body and in a base64url header because some managed egress proxies
+have been observed to preserve request headers while dropping POST bodies.
+Home accepts the header only as a body fallback and requires the two byte
+copies to agree when both arrive; the single-use token never enters the URL.
+Every WebSocket attempt signs a transcript containing the exact
 attachment path, certificate fingerprint, task id, random nonce, and current
 timestamp. Home verifies it against the public key stored at enrollment and
 atomically consumes the nonce; a captured request cannot be replayed. The

--- a/scripts/codex-cloud/run-worker.sh
+++ b/scripts/codex-cloud/run-worker.sh
@@ -44,6 +44,7 @@ export XDG_DATA_HOME="$task_root/data"
 export XDG_CACHE_HOME="$task_root/cache"
 export INTENDANT_HOME="$task_root/intendant"
 mkdir -p "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME" "$INTENDANT_HOME"
+chmod 0700 "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME" "$INTENDANT_HOME"
 
 echo "Intendant Cloud worker runtime: $task_root" >&2
 exec "$@"

--- a/src/bin/caller/codex_cloud_attach.rs
+++ b/src/bin/caller/codex_cloud_attach.rs
@@ -1251,11 +1251,21 @@ pub async fn run_agent(args: &[String]) -> Result<(), String> {
 
     // 2. Redeem the token for a certificate at the public enroll route.
     let enroll_url = enrollment_url_from_home(&home)?;
-    let client = crate::peer::transport::tls_client::reqwest_client(
-        std::time::Duration::from_secs(20),
-        &pinned,
-        None,
-    )
+    let client = if tls_terminated_proxy {
+        // Managed Cloud egress can terminate TLS under a private CA that is
+        // installed in the worker's native trust store. This mode already
+        // makes that proxy an explicit trust decision; use the same roots
+        // for enrollment that the WebSocket leg uses below.
+        crate::peer::transport::tls_client::reqwest_client_with_native_roots(
+            std::time::Duration::from_secs(20),
+        )
+    } else {
+        crate::peer::transport::tls_client::reqwest_client(
+            std::time::Duration::from_secs(20),
+            &pinned,
+            None,
+        )
+    }
     .map_err(|e| format!("build enroll HTTP client: {e}"))?;
     let worker_fingerprint = collect_worker_fingerprint(crate::codex_cloud::now_unix_ms());
     let enrollment_deadline =

--- a/src/bin/caller/codex_cloud_attach.rs
+++ b/src/bin/caller/codex_cloud_attach.rs
@@ -24,6 +24,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use crate::codex_cloud::{record_attachment_state, state_path, AttachmentState, StoreLock};
 
@@ -56,6 +57,10 @@ const ATTACH_PROOF_MAX_SKEW_MS: i64 = 5 * 60 * 1000;
 const ATTACH_PROOF_REPLAY_TTL_MS: u64 = 10 * 60 * 1000;
 const ATTACH_PROOF_REPLAY_GLOBAL_CAP: usize = 4096;
 const ATTACH_PROOF_REPLAY_PER_WORKER_CAP: usize = 64;
+/// Stay comfortably below the five-minute idle teardown observed on managed
+/// Cloud egress paths. Both endpoints originate pings, so a half-open write
+/// fails promptly and long silent commands keep their control socket.
+const ATTACHMENT_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(30);
 
 const CLOUD_WORKER_HEADER: &str = "x-intendant-cloud-worker";
 const CLOUD_WORKER_FINGERPRINT_HEADER: &str = "x-intendant-cloud-worker-fingerprint";
@@ -63,6 +68,15 @@ const CLOUD_WORKER_TASK_HEADER: &str = "x-intendant-cloud-worker-task";
 const CLOUD_WORKER_NONCE_HEADER: &str = "x-intendant-cloud-worker-nonce";
 const CLOUD_WORKER_TIMESTAMP_HEADER: &str = "x-intendant-cloud-worker-timestamp";
 const CLOUD_WORKER_PROOF_HEADER: &str = "x-intendant-cloud-worker-proof";
+
+fn attachment_keepalive_timer() -> tokio::time::Interval {
+    let mut interval = tokio::time::interval_at(
+        tokio::time::Instant::now() + ATTACHMENT_KEEPALIVE_INTERVAL,
+        ATTACHMENT_KEEPALIVE_INTERVAL,
+    );
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    interval
+}
 
 // ── Broker store ───────────────────────────────────────────────────────
 
@@ -803,6 +817,7 @@ pub(crate) async fn serve_attachment_socket<S>(
     );
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(remaining_ms);
     let (mut write, mut read) = ws_stream.split();
+    let mut keepalive = attachment_keepalive_timer();
     loop {
         tokio::select! {
             frame = read.next() => match frame {
@@ -826,6 +841,15 @@ pub(crate) async fn serve_attachment_socket<S>(
                     }
                 }
                 None => break,
+            },
+            _ = keepalive.tick() => {
+                if write
+                    .send(tokio_tungstenite::tungstenite::Message::Ping(Vec::new().into()))
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
             },
             _ = tokio::time::sleep_until(deadline) => {
                 eprintln!(
@@ -2025,6 +2049,7 @@ async fn hold_attachment(
         tokio::task::JoinHandle<()>,
     > = std::collections::HashMap::new();
     let (mut sink, mut stream) = ws.split();
+    let mut keepalive = attachment_keepalive_timer();
     loop {
         tokio::select! {
             frame = stream.next() => match frame {
@@ -2051,6 +2076,11 @@ async fn hold_attachment(
                         .map_err(|e| format!("send frame: {e}"))?;
                 }
                 None => break,
+            },
+            _ = keepalive.tick() => {
+                sink.send(tokio_tungstenite::tungstenite::Message::Ping(Vec::new().into()))
+                    .await
+                    .map_err(|e| format!("send attachment keepalive: {e}"))?;
             },
             _ = remote_commands.retired() => {
                 let _ = sink.close().await;
@@ -2533,6 +2563,17 @@ mod tests {
         assert_eq!(attachment_remaining_ms(100, 100_000), 0);
         assert_eq!(attachment_remaining_ms(100, 99_000), 1_000);
         assert_eq!(attachment_remaining_ms(-5, 0), 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn attachment_keepalive_waits_then_repeats() {
+        let started = tokio::time::Instant::now();
+        let mut keepalive = attachment_keepalive_timer();
+        keepalive.tick().await;
+        assert_eq!(started.elapsed(), ATTACHMENT_KEEPALIVE_INTERVAL);
+        keepalive.tick().await;
+        assert_eq!(started.elapsed(), ATTACHMENT_KEEPALIVE_INTERVAL * 2);
+        assert!(ATTACHMENT_KEEPALIVE_INTERVAL < Duration::from_secs(5 * 60));
     }
 
     #[test]

--- a/src/bin/caller/codex_cloud_attach.rs
+++ b/src/bin/caller/codex_cloud_attach.rs
@@ -37,6 +37,12 @@ pub(crate) const DEFAULT_IDENTITY_TTL_S: u64 = 3600;
 /// The public redemption doorbell's path — the one spelling shared by the
 /// route table, the certless carve-out predicate, and the worker's dial.
 pub(crate) const ENROLL_PATH: &str = "/api/codex-cloud/enroll";
+/// Bounded base64url copy of the enrollment JSON. Some managed egress
+/// proxies preserve request headers while dropping POST bodies; the worker
+/// sends both, and home requires byte equality whenever both arrive.
+pub(crate) const ENROLL_REQUEST_HEADER: &str = "x-intendant-cloud-enrollment";
+/// One limit shared by the HTTP body policy and the header fallback decoder.
+pub(crate) const ENROLL_REQUEST_MAX_BYTES: usize = 8 * 1024;
 /// Dedicated WebSocket target for Cloud attachments. Keeping the
 /// application-proof fallback off the dashboard's ordinary `/ws` target
 /// makes the zero-authority lane explicit even when a reverse proxy has
@@ -1268,17 +1274,31 @@ pub async fn run_agent(args: &[String]) -> Result<(), String> {
     }
     .map_err(|e| format!("build enroll HTTP client: {e}"))?;
     let worker_fingerprint = collect_worker_fingerprint(crate::codex_cloud::now_unix_ms());
+    let enrollment_payload = serde_json::to_vec(&serde_json::json!({
+        "version": 1,
+        "token": &token,
+        "public_key_pem": key_pair.public_key_pem(),
+        "worker": &worker_fingerprint,
+    }))
+    .map_err(|e| format!("serialize enrollment request: {e}"))?;
+    if enrollment_payload.len() > ENROLL_REQUEST_MAX_BYTES {
+        return Err(format!(
+            "enrollment request is too large ({} bytes; limit {ENROLL_REQUEST_MAX_BYTES})",
+            enrollment_payload.len()
+        ));
+    }
+    let enrollment_header = {
+        use base64::Engine as _;
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&enrollment_payload)
+    };
     let enrollment_deadline =
         tokio::time::Instant::now() + std::time::Duration::from_secs(DEFAULT_TOKEN_TTL_S);
     let text = loop {
         let response = client
             .post(&enroll_url)
-            .json(&serde_json::json!({
-                "version": 1,
-                "token": &token,
-                "public_key_pem": key_pair.public_key_pem(),
-                "worker": &worker_fingerprint,
-            }))
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .header(ENROLL_REQUEST_HEADER, &enrollment_header)
+            .body(enrollment_payload.clone())
             .send()
             .await
             .map_err(|e| format!("POST {enroll_url}: {e}"))?;

--- a/src/bin/caller/codex_cloud_attach.rs
+++ b/src/bin/caller/codex_cloud_attach.rs
@@ -927,6 +927,18 @@ pub(crate) fn home_url_from(args_value: Option<String>) -> Result<String, String
     Ok(parsed.to_string())
 }
 
+fn enrollment_url_from_home(home: &str) -> Result<String, String> {
+    let mut parsed = url::Url::parse(home).map_err(|e| format!("invalid home URL: {e}"))?;
+    parsed
+        .set_scheme("https")
+        .map_err(|_| "home URL cannot be converted to HTTPS".to_string())?;
+    // Enrollment and attachment share one origin but deliberately use
+    // different routes. Replace the normalized attachment path instead of
+    // appending to it.
+    parsed.set_path(ENROLL_PATH);
+    Ok(parsed.to_string())
+}
+
 /// The attach follow-up prompt: everything in it is public except the
 /// single-use token, which is the point of the ceremony.
 pub fn attach_prompt(
@@ -1238,8 +1250,7 @@ pub async fn run_agent(args: &[String]) -> Result<(), String> {
         .map_err(|e| format!("write {}: {e}", key_path.display()))?;
 
     // 2. Redeem the token for a certificate at the public enroll route.
-    let http_base = crate::peer::transport::ws_url_to_http_base(&home);
-    let enroll_url = format!("{http_base}{ENROLL_PATH}");
+    let enroll_url = enrollment_url_from_home(&home)?;
     let client = crate::peer::transport::tls_client::reqwest_client(
         std::time::Duration::from_secs(20),
         &pinned,
@@ -2501,6 +2512,14 @@ mod tests {
         assert_eq!(
             home_url_from(Some("wss://home.example:8443/ws".into())).unwrap(),
             "wss://home.example:8443/api/codex-cloud/attach"
+        );
+    }
+
+    #[test]
+    fn enrollment_replaces_the_attachment_path_on_the_same_origin() {
+        assert_eq!(
+            enrollment_url_from_home("wss://home.example:8443/api/codex-cloud/attach").unwrap(),
+            "https://home.example:8443/api/codex-cloud/enroll"
         );
     }
 

--- a/src/bin/caller/gateway_routes.rs
+++ b/src/bin/caller/gateway_routes.rs
@@ -1009,7 +1009,7 @@ pub(crate) static ROUTES: &[Route] = &[
     public_route(
         RouteMethod::Post,
         PathPattern::Exact(crate::codex_cloud_attach::ENROLL_PATH),
-        BodyPolicy::Capped(8 * 1024),
+        BodyPolicy::Capped(crate::codex_cloud_attach::ENROLL_REQUEST_MAX_BYTES),
         RouteHandlerId::CodexCloudEnroll,
         "Redeem a single-use Codex Cloud attach token (public key in, zero-authority cloud-worker certificate out)",
     ),

--- a/src/bin/caller/peer/transport/tls_client.rs
+++ b/src/bin/caller/peer/transport/tls_client.rs
@@ -78,6 +78,21 @@ pub fn reqwest_client(
         .map_err(|e| PeerError::CardFetch(format!("build http client: {e}")))
 }
 
+/// Build a reqwest client that trusts the host's native certificate roots.
+///
+/// This is distinct from reqwest's compiled WebPKI-root default: managed
+/// execution environments can install a private egress-proxy CA in their
+/// native trust store. Callers must opt in deliberately when that proxy is
+/// part of the selected transport trust boundary.
+pub fn reqwest_client_with_native_roots(timeout: Duration) -> Result<reqwest::Client, PeerError> {
+    let config = native_roots_client_config(None)?;
+    reqwest::Client::builder()
+        .timeout(timeout)
+        .use_preconfigured_tls(config)
+        .build()
+        .map_err(|e| PeerError::CardFetch(format!("build http client: {e}")))
+}
+
 /// Build a rustls client config for peer WebSocket/HTTP clients.
 ///
 /// Returns `None` when neither pinning nor client-auth is required, allowing
@@ -107,20 +122,29 @@ pub fn rustls_client_config(
         return Ok(Some(config));
     }
 
-    let Some((cert_chain, key)) = identity else {
+    let Some(identity) = identity else {
         return Ok(None);
     };
 
+    Ok(Some(native_roots_client_config(Some(identity))?))
+}
+
+fn native_roots_client_config(
+    identity: Option<crate::web_tls::RustlsIdentity>,
+) -> Result<rustls::ClientConfig, PeerError> {
     let roots = crate::web_tls::load_native_root_store()
         .map_err(|e| PeerError::Auth(format!("load native TLS roots: {e}")))?;
     let provider = Arc::new(rustls::crypto::ring::default_provider());
-    let config = rustls::ClientConfig::builder_with_provider(provider)
+    let builder = rustls::ClientConfig::builder_with_provider(provider)
         .with_protocol_versions(rustls::DEFAULT_VERSIONS)
         .map_err(|e| PeerError::Auth(format!("peer TLS protocol setup failed: {e}")))?
-        .with_root_certificates(roots)
-        .with_client_auth_cert(cert_chain, key)
-        .map_err(|e| PeerError::Auth(format!("peer TLS client identity setup failed: {e}")))?;
-    Ok(Some(config))
+        .with_root_certificates(roots);
+    match identity {
+        Some((cert_chain, key)) => builder
+            .with_client_auth_cert(cert_chain, key)
+            .map_err(|e| PeerError::Auth(format!("peer TLS client identity setup failed: {e}"))),
+        None => Ok(builder.with_no_client_auth()),
+    }
 }
 
 fn load_client_identity(
@@ -451,6 +475,11 @@ mod tests {
     fn rustls_client_config_none_without_pin_or_identity() {
         let config = rustls_client_config(&[], None, false).unwrap();
         assert!(config.is_none());
+    }
+
+    #[test]
+    fn native_roots_reqwest_client_builds_without_an_identity() {
+        reqwest_client_with_native_roots(Duration::from_secs(1)).unwrap();
     }
 
     #[test]

--- a/src/bin/caller/remote_compute.rs
+++ b/src/bin/caller/remote_compute.rs
@@ -34,10 +34,15 @@ const WORKER_JOB_CAP: usize = 8;
 const WORKER_SEND_TIMEOUT_S: u64 = 5;
 const WORKER_WATCHDOG_GRACE_S: u64 = 60;
 const CACHE_SERVER_IDLE_TIMEOUT_S: u64 = 600;
+const WORKER_PRIVATE_STATE_ENV: &str = "INTENDANT_HOME";
 
 pub(crate) const REMOTE_COMMAND_START_KIND: &str = "remote_command_start";
 pub(crate) const REMOTE_COMMAND_CANCEL_KIND: &str = "remote_command_cancel";
 pub(crate) const REMOTE_COMMAND_RESULT_KIND: &str = "remote_command_result";
+
+fn remove_worker_private_state(command: &mut tokio::process::Command) {
+    command.env_remove(WORKER_PRIVATE_STATE_ENV);
+}
 
 #[derive(
     Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema,
@@ -1273,6 +1278,11 @@ async fn run_worker_command(
     };
 
     let mut command = crate::platform::spawn_command(&spec.argv[0]);
+    // The attachment agent's INTENDANT_HOME contains its ephemeral client
+    // identity. Remote workloads must not inherit that private control-plane
+    // state. Apply the caller's explicit environment afterwards so a workload
+    // that deliberately needs its own INTENDANT_HOME can still request one.
+    remove_worker_private_state(&mut command);
     command
         .args(&spec.argv[1..])
         .current_dir(cwd)
@@ -1931,6 +1941,30 @@ mod tests {
             .validate()
             .unwrap_err()
             .contains("invalid dedicated cache"));
+    }
+
+    #[test]
+    fn remote_command_does_not_inherit_worker_private_state() {
+        let mut command = tokio::process::Command::new("unused");
+        remove_worker_private_state(&mut command);
+        assert_eq!(
+            command
+                .as_std()
+                .get_envs()
+                .find(|(name, _)| *name == WORKER_PRIVATE_STATE_ENV)
+                .map(|(_, value)| value),
+            Some(None)
+        );
+
+        command.env(WORKER_PRIVATE_STATE_ENV, "/caller-selected-state");
+        assert_eq!(
+            command
+                .as_std()
+                .get_envs()
+                .find(|(name, _)| *name == WORKER_PRIVATE_STATE_ENV)
+                .and_then(|(_, value)| value),
+            Some(std::ffi::OsStr::new("/caller-selected-state"))
+        );
     }
 
     #[test]

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -1224,9 +1224,14 @@ pub(crate) async fn serve_http_request(
                 .await;
             }
             RouteHandlerId::CodexCloudEnroll => {
+                let enrollment_header = extract_header_value(
+                    header_text,
+                    crate::codex_cloud_attach::ENROLL_REQUEST_HEADER,
+                );
                 return handle_codex_cloud_enroll(
                     stream,
                     route_body,
+                    enrollment_header,
                     cert_dir,
                     source_hint.clone(),
                     route.cors,

--- a/src/bin/caller/web_gateway/routes_codex_cloud.rs
+++ b/src/bin/caller/web_gateway/routes_codex_cloud.rs
@@ -169,23 +169,72 @@ pub(crate) fn is_public_codex_cloud_enroll_path(request_line: &str) -> bool {
 pub(crate) async fn handle_codex_cloud_enroll(
     stream: DemuxStream,
     body: String,
+    enrollment_header: Option<String>,
     cert_dir: PathBuf,
     source_hint: String,
     cors: crate::gateway_routes::CorsPosture,
     fleet_origin: Option<&str>,
 ) {
-    let response = codex_cloud_enroll_response(body, cert_dir, source_hint).await;
+    let response =
+        codex_cloud_enroll_response(body, enrollment_header, cert_dir, source_hint).await;
     write_api_response(stream, response, cors, fleet_origin).await;
+}
+
+fn enrollment_request_payload(body: &str, encoded_header: Option<&str>) -> Result<Vec<u8>, String> {
+    let body = body.as_bytes();
+    if body.len() > crate::codex_cloud_attach::ENROLL_REQUEST_MAX_BYTES {
+        return Err(format!(
+            "body exceeds {} bytes",
+            crate::codex_cloud_attach::ENROLL_REQUEST_MAX_BYTES
+        ));
+    }
+    let header = encoded_header
+        .map(|encoded| {
+            let max_encoded_len = (crate::codex_cloud_attach::ENROLL_REQUEST_MAX_BYTES * 4 + 2) / 3;
+            if encoded.len() > max_encoded_len {
+                return Err(format!(
+                    "fallback header exceeds {} decoded bytes",
+                    crate::codex_cloud_attach::ENROLL_REQUEST_MAX_BYTES
+                ));
+            }
+            use base64::Engine as _;
+            let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+                .decode(encoded)
+                .map_err(|_| "fallback header is not valid base64url".to_string())?;
+            if decoded.len() > crate::codex_cloud_attach::ENROLL_REQUEST_MAX_BYTES {
+                return Err(format!(
+                    "fallback header exceeds {} decoded bytes",
+                    crate::codex_cloud_attach::ENROLL_REQUEST_MAX_BYTES
+                ));
+            }
+            Ok(decoded)
+        })
+        .transpose()?;
+
+    match (body.is_empty(), header) {
+        (false, None) => Ok(body.to_vec()),
+        (true, Some(header)) => Ok(header),
+        (false, Some(header)) if header == body => Ok(body.to_vec()),
+        (false, Some(_)) => Err("body and fallback header disagree".to_string()),
+        (true, None) => Err("body is empty and fallback header is missing".to_string()),
+    }
 }
 
 async fn codex_cloud_enroll_response(
     body: String,
+    enrollment_header: Option<String>,
     cert_dir: PathBuf,
     source_hint: String,
 ) -> ApiResponse {
     // Parse before counting: unparseable spray never consumes the
     // allowance, so it cannot starve well-formed redemptions.
-    let request: crate::codex_cloud_attach::EnrollRequest = match serde_json::from_str(&body) {
+    let payload = match enrollment_request_payload(&body, enrollment_header.as_deref()) {
+        Ok(payload) => payload,
+        Err(error) => {
+            return ApiResponse::json_error(400, format!("invalid enrollment request: {error}"))
+        }
+    };
+    let request: crate::codex_cloud_attach::EnrollRequest = match serde_json::from_slice(&payload) {
         Ok(request) => request,
         Err(error) => {
             return ApiResponse::json_error(400, format!("invalid enrollment request: {error}"))
@@ -230,7 +279,12 @@ async fn codex_cloud_enroll_response(
 
 #[cfg(test)]
 mod tests {
-    use super::parse_codex_cloud_submit_body;
+    use super::{enrollment_request_payload, parse_codex_cloud_submit_body};
+
+    fn encode_enrollment_header(payload: &[u8]) -> String {
+        use base64::Engine as _;
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload)
+    }
 
     #[test]
     fn submit_body_defaults_mirror_the_exec_verb() {
@@ -273,5 +327,56 @@ mod tests {
         .expect("blank optionals parse");
         assert_eq!(request.branch, None);
         assert_eq!(request.title, None);
+    }
+
+    #[test]
+    fn enrollment_payload_accepts_the_normal_body() {
+        assert_eq!(
+            enrollment_request_payload(r#"{"token":"one"}"#, None).unwrap(),
+            br#"{"token":"one"}"#
+        );
+    }
+
+    #[test]
+    fn enrollment_payload_falls_back_to_the_header_when_the_body_is_empty() {
+        let payload = br#"{"token":"one"}"#;
+        let header = encode_enrollment_header(payload);
+        assert_eq!(
+            enrollment_request_payload("", Some(&header)).unwrap(),
+            payload
+        );
+    }
+
+    #[test]
+    fn enrollment_payload_requires_duplicate_copies_to_match() {
+        let payload = br#"{"token":"one"}"#;
+        let matching = encode_enrollment_header(payload);
+        assert_eq!(
+            enrollment_request_payload(std::str::from_utf8(payload).unwrap(), Some(&matching))
+                .unwrap(),
+            payload
+        );
+
+        let conflicting = encode_enrollment_header(br#"{"token":"two"}"#);
+        assert!(enrollment_request_payload(
+            std::str::from_utf8(payload).unwrap(),
+            Some(&conflicting)
+        )
+        .unwrap_err()
+        .contains("disagree"));
+    }
+
+    #[test]
+    fn enrollment_payload_rejects_missing_invalid_and_oversized_headers() {
+        assert!(enrollment_request_payload("", None).is_err());
+        assert!(enrollment_request_payload("", Some("%%%"))
+            .unwrap_err()
+            .contains("base64url"));
+
+        let oversized = vec![b'x'; crate::codex_cloud_attach::ENROLL_REQUEST_MAX_BYTES + 1];
+        let header = encode_enrollment_header(&oversized);
+        assert!(enrollment_request_payload("", Some(&header))
+            .unwrap_err()
+            .contains("exceeds"));
     }
 }

--- a/src/bin/caller/web_gateway/routes_codex_cloud.rs
+++ b/src/bin/caller/web_gateway/routes_codex_cloud.rs
@@ -190,7 +190,8 @@ fn enrollment_request_payload(body: &str, encoded_header: Option<&str>) -> Resul
     }
     let header = encoded_header
         .map(|encoded| {
-            let max_encoded_len = (crate::codex_cloud_attach::ENROLL_REQUEST_MAX_BYTES * 4 + 2) / 3;
+            let max_encoded_len =
+                (crate::codex_cloud_attach::ENROLL_REQUEST_MAX_BYTES * 4).div_ceil(3);
             if encoded.len() > max_encoded_len {
                 return Err(format!(
                     "fallback header exceeds {} decoded bytes",


### PR DESCRIPTION
## Summary

- derive the enrollment endpoint by replacing the attachment path instead of appending a second API path
- use native WebPKI roots for the explicitly trusted TLS-terminating proxy lane
- tolerate managed egress proxies that strip a POST body by carrying the same bounded enrollment JSON in an authenticated header; when both arrive, require byte equality
- send 30-second WebSocket pings from both attachment endpoints so silent, long-running jobs survive idle proxy timeouts
- keep the attachment agent's private `INTENDANT_HOME` out of remote child processes and create all task-local identity directories with mode `0700`

## Live acceptance

- Environment: `Intendant` (`6a62e054bb648191aeff28634173bc30`)
- Worker task: https://chatgpt.com/codex/tasks/task_e_6a6d4e3211fc8321ae059d7053ab1cb7
- Home candidate: exact macOS artifact for `02edeb82`; worker command runtime: exact Linux build from this PR's earlier `189feb1a` revision
- Enrollment and signed WebSocket attachment succeeded through Codex Cloud egress and a Tailscale Funnel after the enrollment-body fallback was added
- The provider-neutral `remote_command` tool (the same surface exposed to Codex, Claude Code, Kimi Code, Pi, and native sessions) ran all 228 `intendant-core` tests successfully; the warm repeat completed in 2.073 seconds after a 3m54s cold build
- Before the keepalive, two identical `intendant` test builds detached reproducibly at about 5:01. With `02edeb82` on home, the same real job stayed attached for the full 20-minute cold compile until its own command timeout; an identical warm retry then finished in 6m28s with the focused test passing, exit 0, and a clean workspace
- Durable S3 sccache remains a separate deployment limitation: the Cloud path returns `SignatureDoesNotMatch` on the 13-byte write check, while the same restricted principal can put/head/delete the exact prefix from the Mac and direct no-proxy Cloud egress cannot resolve the endpoint. Remote compute works; cold-replacement cache repair is being tracked separately.

## Validation

- `cargo fmt --all -- --check`
- `bash -n scripts/codex-cloud/run-worker.sh`
- launcher smoke: all generated XDG/Intendant state directories were mode `0700`
- GitHub CI on `02edeb82`: Linux tests + clippy, macOS tests, Windows tests, generated dashboard parity, and WASM relevance all green
- exact Cloud validation on `189feb1a`: route/header regression tests, native-root regression test, clippy with warnings denied, build, and binary revision check all green
- live signed attachment, source snapshot transfer, generic remote command execution, warm reuse, worker replacement observation, and >5-minute idle-proxy survival exercised end to end
