### PR TITLE
vitals+radar: one git status per checkout per tick via the status ledger

### DIFF
--- a/src/bin/caller/coordination/radar.rs
+++ b/src/bin/caller/coordination/radar.rs
@@ -41,7 +41,7 @@ use super::messages::{self, MessageMeta, MessageSpace, RadarNoteInput};
 use super::scan::{self, ReadBudget};
 use super::{sanitize_key, CoordinationError, MAX_SCAN_ENTRIES};
 use crate::session_vitals::{
-    parse_status_v2, run_git, GitVitalsTargets, GIT_PROBE_TIMEOUT, GIT_STATUS_ARGS,
+    parse_status_v2, run_git, GitStatusLedger, GitVitalsTargets, GIT_PROBE_TIMEOUT, GIT_STATUS_ARGS,
 };
 
 /// Detection cadence. The protocol names no radar cadence, so the task
@@ -674,19 +674,36 @@ pub(crate) fn parse_pr_list_json(bytes: &[u8]) -> Option<Vec<PrFileSet>> {
 
 /// Observed dirty sets for one space's supervised members, one
 /// `git status` per distinct checkout toplevel (the vitals prober's
-/// dedup shape). A member outside any checkout, or a wedged/failed
-/// git, simply contributes no observed set — declarations still cover
-/// it.
+/// dedup shape). The producer's per-tick [`GitStatusLedger`] is
+/// consulted first — a checkout the vitals prober already statused
+/// this tick costs no second spawn (and a ledger-recorded status
+/// FAILURE contributes no observed set, exactly like a failed own
+/// spawn); only members the ledger doesn't cover fall back to this
+/// function's own subprocesses. A member outside any checkout, or a
+/// wedged/failed git, simply contributes no observed set —
+/// declarations still cover it.
 async fn collect_observed(
     git_program: &std::ffi::OsStr,
     members: &[(String, PathBuf)],
     toplevel_cache: &mut HashMap<PathBuf, PathBuf>,
+    ledger: &GitStatusLedger,
 ) -> Vec<ObservedSet> {
     let mut status_by_toplevel: HashMap<PathBuf, Option<BTreeSet<String>>> = HashMap::new();
     let mut merged: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
     for (writer_id, root) in members {
-        let toplevel = match toplevel_cache.get(root) {
-            Some(cached) => cached.clone(),
+        let toplevel = match ledger.toplevel_by_cwd.get(root).or_else(|| {
+            // Fall back to our own cache only past the ledger — the
+            // producer's resolution is this tick's truth.
+            toplevel_cache.get(root)
+        }) {
+            Some(cached) => {
+                let top = cached.clone();
+                if toplevel_cache.len() > 256 {
+                    toplevel_cache.clear(); // vitals prober's cheap cap
+                }
+                toplevel_cache.insert(root.clone(), top.clone());
+                top
+            }
             None => {
                 let out = run_git(
                     git_program,
@@ -709,26 +726,31 @@ async fn collect_observed(
                 top
             }
         };
-        let dirty = match status_by_toplevel.get(&toplevel) {
-            Some(cached) => cached.clone(),
-            None => {
-                let out =
-                    run_git(git_program, GIT_PROBE_TIMEOUT, &toplevel, &GIT_STATUS_ARGS).await;
-                let dirty = out.filter(|o| o.status.success()).map(|o| {
-                    parse_status_v2(&String::from_utf8_lossy(&o.stdout))
-                        .entries
-                        .into_iter()
-                        .map(|e| e.path)
-                        .collect::<BTreeSet<String>>()
-                });
-                if dirty.is_none() {
-                    // The cached toplevel may be stale (checkout gone):
-                    // drop it so the next tick re-resolves.
-                    toplevel_cache.remove(root);
+        let dirty = match ledger.dirty_by_toplevel.get(&toplevel) {
+            // The producer already statused this checkout this tick —
+            // same arguments, same parser; no second spawn.
+            Some(from_ledger) => from_ledger.clone(),
+            None => match status_by_toplevel.get(&toplevel) {
+                Some(cached) => cached.clone(),
+                None => {
+                    let out =
+                        run_git(git_program, GIT_PROBE_TIMEOUT, &toplevel, &GIT_STATUS_ARGS).await;
+                    let dirty = out.filter(|o| o.status.success()).map(|o| {
+                        parse_status_v2(&String::from_utf8_lossy(&o.stdout))
+                            .entries
+                            .into_iter()
+                            .map(|e| e.path)
+                            .collect::<BTreeSet<String>>()
+                    });
+                    if dirty.is_none() {
+                        // The cached toplevel may be stale (checkout gone):
+                        // drop it so the next tick re-resolves.
+                        toplevel_cache.remove(root);
+                    }
+                    status_by_toplevel.insert(toplevel.clone(), dirty.clone());
+                    dirty
                 }
-                status_by_toplevel.insert(toplevel.clone(), dirty.clone());
-                dirty
-            }
+            },
         };
         if let Some(paths) = dirty {
             merged.entry(writer_id.clone()).or_default().extend(paths);
@@ -773,6 +795,14 @@ struct RadarTask {
     /// `gh` participation — disabled only in tests via [`RadarTask`]
     /// construction (unit tests never spawn the task at all).
     gh_enabled: bool,
+    /// The vitals producer's per-tick status harvest (see
+    /// [`GitStatusLedger`]): detection consumes the producer's status
+    /// runs instead of spawning its own per checkout.
+    status_feed: tokio::sync::watch::Receiver<GitStatusLedger>,
+    /// Last consumed ledger seq — a ledger that hasn't advanced since
+    /// our previous look (fallback-timer wake, producer stalled) reads
+    /// as absent rather than as fresh truth.
+    last_ledger_seq: u64,
     space_key_cache: HashMap<PathBuf, String>,
     toplevel_cache: HashMap<PathBuf, PathBuf>,
     pr_cache: HashMap<String, PrCacheEntry>,
@@ -873,8 +903,25 @@ impl RadarTask {
         keys
     }
 
+    /// The freshest producer ledger, when it carries a NEW tick since
+    /// our last look. A ledger that hasn't advanced (we woke on the
+    /// fallback timer while the producer stalled) reads as an empty
+    /// ledger, steering [`collect_observed`] back to its own spawns —
+    /// detection never consumes staler data than it would have
+    /// gathered itself.
+    fn consume_ledger(&mut self) -> GitStatusLedger {
+        let ledger = self.status_feed.borrow().clone();
+        if ledger.seq != 0 && ledger.seq != self.last_ledger_seq {
+            self.last_ledger_seq = ledger.seq;
+            ledger
+        } else {
+            GitStatusLedger::default()
+        }
+    }
+
     async fn tick(&mut self) {
         let now_ms = super::now_ms();
+        let ledger = self.consume_ledger();
         // Registry members grouped by space: every supervised session
         // participates in git-scan detection, declared or not (§2.8).
         // Session ids ride along for the rail-badge flags — the bus
@@ -931,9 +978,13 @@ impl RadarTask {
                 .iter()
                 .map(|(_, writer_id, root)| (writer_id.clone(), root.clone()))
                 .collect();
-            let observed =
-                collect_observed(&self.git_program, &writer_members, &mut self.toplevel_cache)
-                    .await;
+            let observed = collect_observed(
+                &self.git_program,
+                &writer_members,
+                &mut self.toplevel_cache,
+                &ledger,
+            )
+            .await;
             let pr_sets = self.pr_sets(&key, &roots, now_ms).await;
             let snapshot = compute_space_snapshot(
                 &RadarSpaceInputs {
@@ -976,12 +1027,18 @@ impl RadarTask {
 
 /// Spawn the periodic radar task (daemon startup). Resolves the real
 /// coordination root at this edge — everything below takes explicit
-/// paths — publishes the state handle for the read side, and ticks
-/// forever on [`RADAR_TICK`]. `bus` carries the §2.8 rail-badge
+/// paths — publishes the state handle for the read side, and ticks in
+/// step with the vitals producer's published [`GitStatusLedger`]
+/// (same rhythm as [`RADAR_TICK`], plus the producer's VCS-notice
+/// wakes), so detection consumes the tick's status runs instead of
+/// spawning its own. A quiet or dead producer degrades to the old
+/// self-paced timer — with the ledger seq-guard steering the tick back
+/// to its own subprocesses. `bus` carries the §2.8 rail-badge
 /// transitions to the normal outbound broadcaster path.
 pub(crate) fn spawn_radar_task(
     targets: GitVitalsTargets,
     bus: crate::event::EventBus,
+    status_feed: tokio::sync::watch::Receiver<GitStatusLedger>,
 ) -> tokio::task::JoinHandle<()> {
     let state = RadarState::default();
     publish_radar_state(&state);
@@ -993,6 +1050,8 @@ pub(crate) fn spawn_radar_task(
         flags: RadarFlagTracker::default(),
         git_program: "git".into(),
         gh_enabled: true,
+        status_feed,
+        last_ledger_seq: 0,
         space_key_cache: HashMap::new(),
         toplevel_cache: HashMap::new(),
         pr_cache: HashMap::new(),
@@ -1001,7 +1060,17 @@ pub(crate) fn spawn_radar_task(
     tokio::spawn(async move {
         loop {
             task.tick().await;
-            tokio::time::sleep(RADAR_TICK).await;
+            match tokio::time::timeout(RADAR_TICK, task.status_feed.changed()).await {
+                // A new ledger landed: tick with it.
+                Ok(Ok(())) => {}
+                // Producer gone (no daemon runs without one today, but
+                // fail safe): pure timer cadence.
+                Ok(Err(_)) => tokio::time::sleep(RADAR_TICK).await,
+                // Producer quiet past a full cadence (wedged git, empty
+                // registry): tick anyway — disk spaces and messages
+                // still need scanning.
+                Err(_elapsed) => {}
+            }
         }
     })
 }
@@ -1396,7 +1465,13 @@ mod tests {
             ("s-none".to_string(), tmp.path().join("not-a-repo")),
         ];
         let mut cache = HashMap::new();
-        let observed = collect_observed(std::ffi::OsStr::new("git"), &members, &mut cache).await;
+        let observed = collect_observed(
+            std::ffi::OsStr::new("git"),
+            &members,
+            &mut cache,
+            &GitStatusLedger::default(),
+        )
+        .await;
         assert_eq!(observed.len(), 2, "{observed:?}");
         for set in &observed {
             assert!(set.paths.contains("tracked.rs"), "{observed:?}");
@@ -1404,6 +1479,48 @@ mod tests {
         }
         assert!(observed.iter().any(|s| s.writer_id == "s-one"));
         assert!(observed.iter().any(|s| s.writer_id == "s-two"));
+    }
+
+    #[tokio::test]
+    async fn collect_observed_consumes_the_producer_ledger_without_spawning() {
+        // Members covered by the producer's per-tick ledger must cost
+        // no git subprocess at all: the git program here is a path
+        // that cannot execute, so any spawn attempt would yield no
+        // observed set — the sets can only have come from the ledger.
+        // A ledger-recorded status FAILURE (None) contributes no
+        // observed set, exactly like a failed own spawn.
+        let tmp = tempfile::tempdir().unwrap();
+        let worked = tmp.path().join("worked");
+        let broken = tmp.path().join("broken");
+        let members = vec![
+            ("s-live".to_string(), worked.join("sub")),
+            ("s-broken".to_string(), broken.clone()),
+        ];
+        let ledger = GitStatusLedger {
+            seq: 7,
+            dirty_by_toplevel: Arc::new(HashMap::from([
+                (worked.clone(), Some(BTreeSet::from(["lib.rs".to_string()]))),
+                (broken.clone(), None),
+            ])),
+            toplevel_by_cwd: Arc::new(HashMap::from([
+                (worked.join("sub"), worked.clone()),
+                (broken.clone(), broken.clone()),
+            ])),
+        };
+        let mut cache = HashMap::new();
+        let observed = collect_observed(
+            std::ffi::OsStr::new("/nonexistent/never-a-git"),
+            &members,
+            &mut cache,
+            &ledger,
+        )
+        .await;
+        assert_eq!(observed.len(), 1, "{observed:?}");
+        assert_eq!(observed[0].writer_id, "s-live");
+        assert!(observed[0].paths.contains("lib.rs"));
+        // The ledger's resolutions warm the radar's own cwd → toplevel
+        // cache for ledger-less ticks.
+        assert_eq!(cache.get(&worked.join("sub")), Some(&worked));
     }
 
     #[test]
@@ -1585,6 +1702,8 @@ mod tests {
             flags: RadarFlagTracker::default(),
             git_program: "git".into(),
             gh_enabled: false,
+            status_feed: tokio::sync::watch::channel(GitStatusLedger::default()).1,
+            last_ledger_seq: 0,
             space_key_cache: HashMap::new(),
             toplevel_cache: HashMap::new(),
             pr_cache: HashMap::new(),

--- a/src/bin/caller/session_vitals.rs
+++ b/src/bin/caller/session_vitals.rs
@@ -422,6 +422,10 @@ impl GitVitalsProber {
         Some(toplevel)
     }
 
+    /// Probe one cwd to the vitals shape alone — the prober contract's
+    /// test seam (production flows through [`Self::probe_resolved`],
+    /// which additionally yields the ledger harvest).
+    #[cfg(test)]
     pub(crate) async fn probe(&mut self, cwd: &Path) -> Option<SessionGitVitals> {
         self.probe_resolved(cwd).await.map(|(_, vitals, _)| vitals)
     }

--- a/src/bin/caller/session_vitals.rs
+++ b/src/bin/caller/session_vitals.rs
@@ -52,7 +52,7 @@
 //! every write — one entry, and one complete emitted snapshot, per
 //! logical session.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -423,6 +423,19 @@ impl GitVitalsProber {
     }
 
     pub(crate) async fn probe(&mut self, cwd: &Path) -> Option<SessionGitVitals> {
+        self.probe_resolved(cwd).await.map(|(_, vitals, _)| vitals)
+    }
+
+    /// Like [`Self::probe`], but also yields the checkout toplevel and
+    /// the dirty entry paths the status run saw — the per-tick harvest
+    /// the producer publishes as the [`GitStatusLedger`], so
+    /// same-cadence consumers (the coordination radar's observed
+    /// working sets) ride the SAME status invocation as the chip
+    /// instead of spawning their own.
+    async fn probe_resolved(
+        &mut self,
+        cwd: &Path,
+    ) -> Option<(PathBuf, SessionGitVitals, BTreeSet<String>)> {
         let toplevel = self.toplevel_for(cwd).await?;
         let probed = self.probe_checkout(&toplevel).await;
         if probed.is_none() {
@@ -432,10 +445,13 @@ impl GitVitalsProber {
             self.toplevel_cache.remove(cwd);
             self.primary_cache.remove(&toplevel);
         }
-        probed
+        probed.map(|(vitals, paths)| (toplevel, vitals, paths))
     }
 
-    async fn probe_checkout(&mut self, toplevel: &Path) -> Option<SessionGitVitals> {
+    async fn probe_checkout(
+        &mut self,
+        toplevel: &Path,
+    ) -> Option<(SessionGitVitals, BTreeSet<String>)> {
         self.checkout_probes += 1;
         let status = self.git(toplevel, &GIT_STATUS_ARGS).await?;
         let facts = parse_status_v2(&status);
@@ -493,20 +509,28 @@ impl GitVitalsProber {
             }
         }
 
-        Some(SessionGitVitals {
-            dirty_files: facts.dirty_files(),
-            branch: facts.branch,
-            ahead,
-            behind,
-            primary_ref,
-            merge_parity,
-            unpushed,
-            primary_unpushed,
-            checkout: toplevel
-                .file_name()
-                .map(|name| name.to_string_lossy().into_owned())
-                .unwrap_or_default(),
-        })
+        let dirty_paths: BTreeSet<String> = facts
+            .entries
+            .iter()
+            .map(|entry| entry.path.clone())
+            .collect();
+        Some((
+            SessionGitVitals {
+                dirty_files: facts.dirty_files(),
+                branch: facts.branch,
+                ahead,
+                behind,
+                primary_ref,
+                merge_parity,
+                unpushed,
+                primary_unpushed,
+                checkout: toplevel
+                    .file_name()
+                    .map(|name| name.to_string_lossy().into_owned())
+                    .unwrap_or_default(),
+            },
+            dirty_paths,
+        ))
     }
 
     /// Primary-branch discovery, cached per checkout: origin's default
@@ -1780,6 +1804,35 @@ pub(crate) fn register_restored_session_targets(home: &Path, registry: &GitVital
         .count()
 }
 
+/// One tick's working-tree status harvest, published by the vitals
+/// producer over a `watch` channel for same-cadence consumers — the
+/// coordination radar's observed working sets ride the SAME
+/// `git status` invocations as the session chips instead of spawning
+/// their own (one status per checkout per tick, daemon-wide).
+///
+/// `dirty_by_toplevel`: per probed checkout toplevel, the status run's
+/// entry paths — `None` records that the status probe FAILED there this
+/// tick, so consumers state nothing rather than something stale.
+/// `toplevel_by_cwd`: the cwd → toplevel resolutions the tick performed
+/// (consumers skip their own `rev-parse` spawns).
+/// `seq` increments per tick: a consumer that already saw this seq
+/// holds no fresher data than its own last look and should fall back
+/// to probing rather than re-reading a stalled ledger.
+#[derive(Clone, Default)]
+pub(crate) struct GitStatusLedger {
+    pub(crate) seq: u64,
+    pub(crate) dirty_by_toplevel: Arc<HashMap<PathBuf, Option<BTreeSet<String>>>>,
+    pub(crate) toplevel_by_cwd: Arc<HashMap<PathBuf, PathBuf>>,
+}
+
+/// The per-tick accumulation behind [`GitStatusLedger`] (unshared: the
+/// tick fills plain maps and Arcs them once at publish).
+#[derive(Default)]
+struct TickLedger {
+    dirty_by_toplevel: HashMap<PathBuf, Option<BTreeSet<String>>>,
+    toplevel_by_cwd: HashMap<PathBuf, PathBuf>,
+}
+
 /// Probe `cwd` through the per-tick cache, keyed by checkout TOPLEVEL:
 /// sessions sharing a checkout (the common shape once restored sessions
 /// register at boot — many idle sessions per project root, or the root
@@ -1792,6 +1845,7 @@ pub(crate) fn register_restored_session_targets(home: &Path, registry: &GitVital
 async fn probe_cached(
     prober: &mut GitVitalsProber,
     tick_cache: &mut HashMap<PathBuf, Option<SessionGitVitals>>,
+    ledger: &mut TickLedger,
     cwd: &Path,
 ) -> Option<SessionGitVitals> {
     if let Some(cached) = tick_cache.get(cwd) {
@@ -1801,14 +1855,30 @@ async fn probe_cached(
         tick_cache.insert(cwd.to_path_buf(), None);
         return None;
     };
+    ledger
+        .toplevel_by_cwd
+        .insert(cwd.to_path_buf(), key.clone());
     if let Some(cached) = tick_cache.get(&key) {
         return cached.clone();
     }
     // Re-resolves the toplevel through the prober's cache (no
     // subprocess) — keeps the drop-caches-on-failure path in one place.
-    let probed = prober.probe(cwd).await;
-    tick_cache.insert(key, probed.clone());
-    probed
+    match prober.probe_resolved(cwd).await {
+        Some((toplevel, vitals, dirty_paths)) => {
+            ledger
+                .dirty_by_toplevel
+                .insert(toplevel.clone(), Some(dirty_paths));
+            tick_cache.insert(toplevel, Some(vitals.clone()));
+            Some(vitals)
+        }
+        None => {
+            // Status failed (or the checkout vanished): the ledger
+            // records the failure so consumers claim nothing here.
+            ledger.dirty_by_toplevel.insert(key.clone(), None);
+            tick_cache.insert(key, None);
+            None
+        }
+    }
 }
 
 /// Vitals producer: spawns the cache listener and runs the periodic git
@@ -1826,11 +1896,20 @@ async fn probe_cached(
 /// [`crate::session_vitals_restore::account_limit_store_path`]) makes the
 /// per-account rate-limit window store survive restarts: restored here,
 /// rewritten on change. `None` keeps the store memory-only.
+///
+/// The returned `watch` receiver carries the per-tick
+/// [`GitStatusLedger`] — the status harvest same-cadence consumers (the
+/// coordination radar) read instead of spawning their own `git status`
+/// per checkout.
 pub(crate) fn spawn_session_vitals_producer(
     bus: EventBus,
     seed_targets: Vec<(String, PathBuf)>,
     limit_store: Option<PathBuf>,
-) -> (GitVitalsTargets, tokio::task::JoinHandle<()>) {
+) -> (
+    GitVitalsTargets,
+    tokio::sync::watch::Receiver<GitStatusLedger>,
+    tokio::task::JoinHandle<()>,
+) {
     let registry = GitVitalsTargets::default();
     for (session_id, cwd) in seed_targets {
         registry.register(&session_id, cwd);
@@ -1840,28 +1919,40 @@ pub(crate) fn spawn_session_vitals_producer(
     let _cache_listener = spawn_cache_vitals_listener(bus.clone(), hub.clone());
     let _target_maintainer =
         spawn_git_target_maintainer(bus, registry.clone(), hub.clone(), wake.clone());
+    let (status_tx, status_rx) = tokio::sync::watch::channel(GitStatusLedger::default());
     let handle = tokio::spawn({
         let registry = registry.clone();
         async move {
             let mut prober = GitVitalsProber::default();
+            let mut tick_seq: u64 = 0;
             loop {
                 let mut tick_cache: HashMap<PathBuf, Option<SessionGitVitals>> = HashMap::new();
+                let mut tick_ledger = TickLedger::default();
                 // Live targets every tick; restored targets exactly once
                 // (the boot paint) until live evidence upgrades them —
                 // see [`TargetOrigin`].
                 for (session_id, cwd) in registry.snapshot_probe() {
-                    let mut probed = probe_cached(&mut prober, &mut tick_cache, &cwd).await;
+                    let mut probed =
+                        probe_cached(&mut prober, &mut tick_cache, &mut tick_ledger, &cwd).await;
                     if probed.is_none() {
                         // A dead activity locus (worktree deleted, checkout
                         // gone) falls back to the registered root in the
                         // same tick so the chip never blanks.
                         if let Some(root) = registry.demote_locus(&session_id, &cwd) {
-                            probed = probe_cached(&mut prober, &mut tick_cache, &root).await;
+                            probed =
+                                probe_cached(&mut prober, &mut tick_cache, &mut tick_ledger, &root)
+                                    .await;
                         }
                     }
                     hub.apply(&session_id, |vitals| vitals.git = probed);
                     registry.mark_probed(&session_id);
                 }
+                tick_seq += 1;
+                status_tx.send_replace(GitStatusLedger {
+                    seq: tick_seq,
+                    dirty_by_toplevel: Arc::new(tick_ledger.dirty_by_toplevel),
+                    toplevel_by_cwd: Arc::new(tick_ledger.toplevel_by_cwd),
+                });
                 // Wait out the cadence, or probe immediately when the
                 // maintainer sees a backend VCS notice. `Notify` holds at
                 // most one stored permit, so a burst of notices (a merge
@@ -1874,7 +1965,7 @@ pub(crate) fn spawn_session_vitals_producer(
             }
         }
     });
-    (registry, handle)
+    (registry, status_rx, handle)
 }
 
 /// Bus maintenance for the git-target registry:
@@ -2271,8 +2362,20 @@ mod tests {
 
         let mut prober = GitVitalsProber::default();
         let mut tick_cache: HashMap<PathBuf, Option<SessionGitVitals>> = HashMap::new();
-        let at_root = probe_cached(&mut prober, &mut tick_cache, root).await;
-        let at_subdir = probe_cached(&mut prober, &mut tick_cache, &root.join("src")).await;
+        let at_root = probe_cached(
+            &mut prober,
+            &mut tick_cache,
+            &mut TickLedger::default(),
+            root,
+        )
+        .await;
+        let at_subdir = probe_cached(
+            &mut prober,
+            &mut tick_cache,
+            &mut TickLedger::default(),
+            &root.join("src"),
+        )
+        .await;
         assert_eq!(at_root.as_ref().map(|g| g.branch.as_str()), Some("main"));
         assert_eq!(at_root, at_subdir, "one checkout, one shared result");
         assert_eq!(
@@ -2284,20 +2387,42 @@ mod tests {
         // Next tick: fresh per-tick cache, still one probe per checkout —
         // the path→toplevel resolutions are already cached.
         let mut next_tick: HashMap<PathBuf, Option<SessionGitVitals>> = HashMap::new();
-        probe_cached(&mut prober, &mut next_tick, &root.join("src")).await;
-        probe_cached(&mut prober, &mut next_tick, root).await;
+        probe_cached(
+            &mut prober,
+            &mut next_tick,
+            &mut TickLedger::default(),
+            &root.join("src"),
+        )
+        .await;
+        probe_cached(
+            &mut prober,
+            &mut next_tick,
+            &mut TickLedger::default(),
+            root,
+        )
+        .await;
         assert_eq!(prober.checkout_probes, 2);
 
         // Paths outside any checkout cache their per-tick miss under the
         // raw path and never reach a checkout probe.
         let outside = tempfile::tempdir().expect("tempdir");
         let mut tick: HashMap<PathBuf, Option<SessionGitVitals>> = HashMap::new();
-        assert!(probe_cached(&mut prober, &mut tick, outside.path())
-            .await
-            .is_none());
-        assert!(probe_cached(&mut prober, &mut tick, outside.path())
-            .await
-            .is_none());
+        assert!(probe_cached(
+            &mut prober,
+            &mut tick,
+            &mut TickLedger::default(),
+            outside.path()
+        )
+        .await
+        .is_none());
+        assert!(probe_cached(
+            &mut prober,
+            &mut tick,
+            &mut TickLedger::default(),
+            outside.path()
+        )
+        .await
+        .is_none());
         assert_eq!(prober.checkout_probes, 2);
         assert!(tick.contains_key(outside.path()), "miss cached per tick");
     }
@@ -3094,7 +3219,8 @@ mod tests {
 
         let bus = EventBus::new();
         let mut rx = bus.subscribe();
-        let (targets, _producer) = spawn_session_vitals_producer(bus.clone(), Vec::new(), None);
+        let (targets, _status_feed, _producer) =
+            spawn_session_vitals_producer(bus.clone(), Vec::new(), None);
         assert_eq!(
             register_restored_session_targets(home.path(), &targets),
             1,
@@ -3173,7 +3299,8 @@ mod tests {
 
         let bus = EventBus::new();
         let mut rx = bus.subscribe();
-        let (targets, _producer) = spawn_session_vitals_producer(bus.clone(), Vec::new(), None);
+        let (targets, _status_feed, _producer) =
+            spawn_session_vitals_producer(bus.clone(), Vec::new(), None);
         assert_eq!(register_restored_session_targets(home.path(), &targets), 1);
 
         let deadline = std::time::Duration::from_secs(20);
@@ -3242,6 +3369,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn producer_publishes_the_status_ledger_each_tick() {
+        let repo = tempfile::tempdir().expect("tempdir");
+        git_cmd(repo.path(), &["init", "-q", "-b", "main"]);
+        std::fs::write(repo.path().join("a.txt"), "one\n").unwrap();
+        git_cmd(repo.path(), &["add", "."]);
+        git_cmd(repo.path(), &["commit", "-qm", "base"]);
+
+        let bus = EventBus::new();
+        let (_targets, mut status_feed, _producer) = spawn_session_vitals_producer(
+            bus.clone(),
+            vec![("ledger-session".to_string(), repo.path().to_path_buf())],
+            None,
+        );
+
+        let deadline = std::time::Duration::from_secs(20);
+        tokio::time::timeout(deadline, status_feed.changed())
+            .await
+            .expect("a ledger arrives within the cadence")
+            .expect("producer alive");
+        let (toplevel, first_seq) = {
+            let ledger = status_feed.borrow();
+            assert!(ledger.seq > 0);
+            // The probed cwd resolves in the ledger (the toplevel may be
+            // a canonicalized spelling of the tempdir — consumers key by
+            // the mapping, never by textual equality).
+            let toplevel = ledger
+                .toplevel_by_cwd
+                .get(repo.path())
+                .cloned()
+                .expect("the probed cwd resolves in the ledger");
+            assert_eq!(
+                ledger.dirty_by_toplevel.get(&toplevel),
+                Some(&Some(BTreeSet::new())),
+                "clean checkout publishes an empty dirty set"
+            );
+            (toplevel, ledger.seq)
+        };
+
+        // Dirty the checkout: a later tick's ledger carries the path.
+        std::fs::write(repo.path().join("dirty.txt"), "x\n").unwrap();
+        let dirty = tokio::time::timeout(deadline, async {
+            loop {
+                status_feed.changed().await.expect("producer alive");
+                let ledger = status_feed.borrow().clone();
+                assert!(ledger.seq > first_seq, "seq is monotonic");
+                if let Some(Some(paths)) = ledger.dirty_by_toplevel.get(&toplevel) {
+                    if !paths.is_empty() {
+                        return paths.clone();
+                    }
+                }
+            }
+        })
+        .await
+        .expect("a later ledger sees the dirty file");
+        assert!(dirty.contains("dirty.txt"));
+    }
+
+    #[tokio::test]
     async fn vcs_activity_seeds_locus_and_wakes_prober() {
         // A backend's commit notice must retarget the probe to the
         // checkout the backend named (first-hand, like
@@ -3263,7 +3448,7 @@ mod tests {
 
         let bus = EventBus::new();
         let mut rx = bus.subscribe();
-        let (_targets, _producer) = spawn_session_vitals_producer(
+        let (_targets, _status_feed, _producer) = spawn_session_vitals_producer(
             bus.clone(),
             vec![("vcs-session".to_string(), repo_a.path().to_path_buf())],
             None,
@@ -3412,7 +3597,8 @@ mod tests {
 
         let bus = EventBus::new();
         let mut rx = bus.subscribe();
-        let (targets, _producer) = spawn_session_vitals_producer(bus.clone(), Vec::new(), None);
+        let (targets, _status_feed, _producer) =
+            spawn_session_vitals_producer(bus.clone(), Vec::new(), None);
         targets.register("shared-a", repo.path().to_path_buf());
         targets.register("shared-b", repo.path().to_path_buf());
 
@@ -3462,7 +3648,8 @@ mod tests {
         // Subscribed before the producer spawns, so every change-only hub
         // emission is queued here — sequential waits never miss one.
         let mut rx = bus.subscribe();
-        let (targets, _producer) = spawn_session_vitals_producer(bus.clone(), Vec::new(), None);
+        let (targets, _status_feed, _producer) =
+            spawn_session_vitals_producer(bus.clone(), Vec::new(), None);
         targets.register("s-fork", root.to_path_buf());
 
         let deadline = std::time::Duration::from_secs(20);
@@ -3529,7 +3716,8 @@ mod tests {
 
         let bus = EventBus::new();
         let mut rx = bus.subscribe();
-        let (targets, _producer) = spawn_session_vitals_producer(bus.clone(), Vec::new(), None);
+        let (targets, _status_feed, _producer) =
+            spawn_session_vitals_producer(bus.clone(), Vec::new(), None);
         targets.register("s-announce", root.to_path_buf());
 
         let deadline = std::time::Duration::from_secs(20);
@@ -3596,7 +3784,8 @@ mod tests {
 
         let bus = EventBus::new();
         let mut rx = bus.subscribe();
-        let (targets, _producer) = spawn_session_vitals_producer(bus.clone(), Vec::new(), None);
+        let (targets, _status_feed, _producer) =
+            spawn_session_vitals_producer(bus.clone(), Vec::new(), None);
         targets.register("supervised-1", root.to_path_buf());
 
         let deadline = std::time::Duration::from_secs(20);
@@ -3637,7 +3826,8 @@ mod tests {
         // (regression: the listener used to die with the git gating,
         // blanking the dashboard's Prompt cache row daemon-wide).
         let bus = EventBus::new();
-        let _producer = spawn_session_vitals_producer(bus.clone(), Vec::new(), None);
+        let (_targets, _status_feed, _producer) =
+            spawn_session_vitals_producer(bus.clone(), Vec::new(), None);
         let mut rx = bus.subscribe();
         bus.send(AppEvent::UsageSnapshot {
             session_id: Some("cc-session".into()),

--- a/src/bin/caller/startup/daemon.rs
+++ b/src/bin/caller/startup/daemon.rs
@@ -148,11 +148,12 @@ pub(crate) async fn run_daemon(
         (Some(session_id), Some(root)) => vec![(session_id, root)],
         _ => Vec::new(),
     };
-    let (vitals_git_targets, _vitals_producer) = session_vitals::spawn_session_vitals_producer(
-        bus.clone(),
-        vitals_git_seed,
-        Some(crate::session_vitals_restore::account_limit_store_path()),
-    );
+    let (vitals_git_targets, vitals_status_feed, _vitals_producer) =
+        session_vitals::spawn_session_vitals_producer(
+            bus.clone(),
+            vitals_git_seed,
+            Some(crate::session_vitals_restore::account_limit_store_path()),
+        );
     // Publish the live registry for read-side lanes: the Changes tab's
     // working-tree list resolves a session's checkout through the SAME
     // effective target the dirty chip probes (activity locus included),
@@ -169,12 +170,17 @@ pub(crate) async fn run_daemon(
     crate::credential_watch::spawn_credential_watch(bus.clone(), project_root.clone());
     // Collision radar (Track C, C2 — ruled §2.1): periodic zero-LLM
     // detection over bus declarations ∪ observed git status (the same
-    // registry the vitals prober probes) ∪ open-PR file sets; publishes
-    // per-space snapshots for the injection seam, writes deduplicated
-    // radar notes to flagged parties, and broadcasts the §2.8 rail-badge
+    // registry the vitals prober probes, consumed from the producer's
+    // per-tick status ledger — one `git status` per checkout per tick,
+    // daemon-wide) ∪ open-PR file sets; publishes per-space snapshots
+    // for the injection seam, writes deduplicated radar notes to
+    // flagged parties, and broadcasts the §2.8 rail-badge
     // raise/resolve transitions on the bus.
-    let _radar_task =
-        crate::coordination::radar::spawn_radar_task(vitals_git_targets.clone(), bus.clone());
+    let _radar_task = crate::coordination::radar::spawn_radar_task(
+        vitals_git_targets.clone(),
+        bus.clone(),
+        vitals_status_feed,
+    );
     // Restored sessions: a restart empties the target registry, so idle
     // session windows lose their git/health chips until the next resume.
     // One bounded walk (newest-first, insert-if-absent — see

--- a/src/bin/caller/startup/headless.rs
+++ b/src/bin/caller/startup/headless.rs
@@ -495,7 +495,7 @@ pub(crate) async fn run_headless_mode(
     } else {
         None
     };
-    let vitals_git_targets = vitals.as_ref().map(|(targets, _)| targets.clone());
+    let vitals_git_targets = vitals.as_ref().map(|(targets, _, _)| targets.clone());
     // Publish for read-side lanes (the Changes tab's working-tree list) —
     // mirrors daemon boot: the tab resolves a session's checkout through
     // the same effective target the dirty chip probes.


### PR DESCRIPTION
The vitals prober and the coordination radar each spawned their own git status over the same live checkouts on the same 5s cadence — two identical subprocesses per checkout per tick, plus the radar's own rev-parse toplevel resolutions.

The producer now publishes a per-tick GitStatusLedger over a watch channel: the dirty entry paths per probed toplevel (None = that status failed, so consumers claim nothing) and the tick's cwd → toplevel resolutions. The radar follows the producer's cadence — each published ledger is its tick signal, so it also inherits the VCS-notice wakes — and consumes the ledger in collect_observed; only members the ledger doesn't cover fall back to its own spawns. A seq guard steers a stalled ledger back to self-probing so detection never reads staler data than it would have gathered itself, and a dead producer degrades to the old self-paced timer.

Together with #732 this completes the git-probe diet: one status per live checkout per tick, daemon-wide.