### PR TITLE
Make Codex Cloud compiler caching durable

### DIFF
--- a/docs/src/codex-cloud-workers.md
+++ b/docs/src/codex-cloud-workers.md
@@ -472,6 +472,8 @@ The contract is intentionally stricter than an interactive terminal:
   `INTENDANT_REMOTE_CACHE_MAX_BYTES` may set a 256 MiB–1 TiB byte ceiling.
   Intendant configures `RUSTC_WRAPPER=sccache`, `CARGO_INCREMENTAL=0`, and a
   stable `SCCACHE_BASEDIRS`, then reports hit/miss/write/error deltas. The
+  loopback sidecar is automatically added to both `NO_PROXY` spellings so a
+  Cloud egress proxy cannot intercept its worker-local HTTP traffic. The
   default remains `cache: "none"`. The Cloud environment must provide
   sccache 0.14 or newer; an explicit durable-cache job fails before the
   requested command when sccache or its relay cannot start. During a running

--- a/docs/src/codex-cloud-workers.md
+++ b/docs/src/codex-cloud-workers.md
@@ -47,6 +47,24 @@ observation does not establish an eviction timeout, but it proves the loss
 mode is real: **an external build cache is a requirement for reuse that must
 survive replacement, not an optimization.**
 
+### Compute capacity is a lease property
+
+Do not treat the environment name as a machine size. OpenAI's published Cloud
+environment contract describes isolated containers and setup caching, but does
+not specify a fixed CPU/RAM allocation or expose a machine-size selector.
+Measured capacity has varied between tasks. Intendant therefore records the
+worker's current effective parallelism in every attachment fingerprint; that
+number is evidence about this lease, not a promise about the next one.
+
+For example, the 2026-08-01 acceptance worker exposed CPUs `0-2`, so Linux
+`nproc` reported 3, while its cgroup `cpu.max` was `200000 100000`: a hard
+quota of two CPU-core equivalents. Rust's quota-aware
+`available_parallelism()` and the Intendant fingerprint correctly reported 2.
+Use the fingerprint value for scheduling and performance expectations. Remote
+execution can still be worthwhile when its purpose is to remove load from
+home, but it must not be advertised as faster than a particular local machine
+without a measurement from the attached lease.
+
 Consequences Intendant encodes:
 
 - **An environment is a template, not a machine.** New tasks — sequential or

--- a/docs/src/codex-cloud-workers.md
+++ b/docs/src/codex-cloud-workers.md
@@ -455,25 +455,39 @@ The contract is intentionally stricter than an interactive terminal:
   snapshot. Commands using one snapshot are serialized. A command that
   mutates selected source invalidates that prepared workspace; ignored build
   outputs such as `target/` remain warm and reusable.
-- `cache: "durable_sccache"` is explicit and rejects a local backend at
-  setup. Home maps only
-  dedicated `INTENDANT_REMOTE_CACHE_` settings for sccache and its documented
-  backend credential families (`SCCACHE_*`, `AWS_*`, `ACTIONS_*`,
-  `ALIBABA_CLOUD_*`, and `TENCENTCLOUD_*`) into the authenticated command,
-  requires an
-  external backend (a task-local `SCCACHE_DIR` is refused), configures
-  `RUSTC_WRAPPER=sccache`, `CARGO_INCREMENTAL=0`, and a stable
-  `SCCACHE_BASEDIRS`, then reports hit/miss/write/error deltas. Backend
-  configuration is inherited by the requested build/test child because a
-  sccache client automatically restarts a missing server; carrying the same
-  configuration prevents that restart from quietly selecting the default
-  local-disk cache. Startup also rejects a server whose stats identify a
-  local-disk backend. The default is `cache: "none"`. The Cloud environment
-  must provide sccache 0.14 or newer; explicit durable-cache jobs fail before
-  the requested command when it is absent or the server/backend cannot start.
-  During a running build, sccache can still compile uncached after a backend
-  read/write error; the result reports those error counters rather than
-  pretending every compilation was cached.
+- `cache: "durable_sccache"` is explicit. By default, the worker starts a
+  loopback-only WebDAV sidecar and carries cache objects over the existing
+  authenticated attachment. Home stores them in an owner-private,
+  per-repository namespace under
+  `$INTENDANT_HOME/remote-cache/sccache-v1/`; the default ceiling is 20 GiB
+  with oldest-file eviction. Each command receives an opaque relay capability
+  valid only for that task and job. Home accepts no general filesystem
+  operation from it: keys must have sccache's content-addressed shape, objects
+  are capped at 128 MiB, job writes at 8 GiB, chunks are ordered and
+  digest-checked, and incomplete staging files are discarded. Cache frames
+  use a private bounded route rather than the worker's general reply
+  broadcast. Thus a worker gets durable cache reuse without home credentials
+  or general authority on home. `INTENDANT_REMOTE_CACHE_HOME_DIR` may select
+  another absolute home-side directory, and
+  `INTENDANT_REMOTE_CACHE_MAX_BYTES` may set a 256 MiB–1 TiB byte ceiling.
+  Intendant configures `RUSTC_WRAPPER=sccache`, `CARGO_INCREMENTAL=0`, and a
+  stable `SCCACHE_BASEDIRS`, then reports hit/miss/write/error deltas. The
+  default remains `cache: "none"`. The Cloud environment must provide
+  sccache 0.14 or newer; an explicit durable-cache job fails before the
+  requested command when sccache or its relay cannot start. During a running
+  build, sccache can still compile uncached after a backend read/write error;
+  the result reports those error counters rather than pretending every
+  compilation was cached.
+- Deployments that deliberately want the worker to contact an external
+  sccache backend itself can set `INTENDANT_REMOTE_CACHE_TRANSPORT=direct`.
+  Only in that mode does home map dedicated `INTENDANT_REMOTE_CACHE_`
+  variables for sccache and its documented credential families (`SCCACHE_*`,
+  `AWS_*`, `ACTIONS_*`, `ALIBABA_CLOUD_*`, and `TENCENTCLOUD_*`) into the
+  authenticated command. Direct mode requires an external backend, refuses
+  task-local `SCCACHE_DIR`, and carries the same configuration into the build
+  so an automatic sccache-server restart cannot silently fall back to local
+  disk. Use it only when the Cloud egress path is known to preserve that
+  backend's requests byte-for-byte.
 - Stdout and stderr are each bounded to 128 KiB. On overflow the result keeps
   the first 32 KiB and the latest tail and marks that stream truncated.
   Timeout, cancellation, and attachment loss terminate the owned process
@@ -649,9 +663,10 @@ an ephemeral hosted CI runner:
 
 - Keep repeated commands on the same attached task while it remains warm.
 - Put stable toolchain/package preparation in the environment setup cache.
-- Use `cache: "durable_sccache"` with a separately scoped external backend
-  when cold replacement performance matters. A task-local sccache directory
-  is refused because it is lost with the same worker as `target/`.
+- Use `cache: "durable_sccache"` when cold replacement performance matters.
+  The default attachment relay persists objects on home without exposing
+  object-store credentials to the worker. A task-local sccache directory is
+  never used because it is lost with the same worker as `target/`.
 - Do not promise a fully warm Rust build from sccache alone. Existing
   cross-worktree measurements show it can repopulate identical dependency
   outputs, but local incremental workspace crates, build scripts,
@@ -659,19 +674,18 @@ an ephemeral hosted CI runner:
   fresh target tree. Correctness never depends on cache hits, and the job
   result exposes the measured cache deltas instead of claiming warmth.
 
-The daemon-side prefixes are a custody boundary, not new sccache option
-names: for example, `INTENDANT_REMOTE_CACHE_SCCACHE_BUCKET` becomes
-`SCCACHE_BUCKET`, and `INTENDANT_REMOTE_CACHE_AWS_ACCESS_KEY_ID` becomes
-`AWS_ACCESS_KEY_ID` only inside the authenticated remote command. Consult
-sccache's upstream [configuration reference](https://github.com/mozilla/sccache/blob/main/docs/Configuration.md)
+For optional direct transport, the daemon-side prefixes are a custody
+boundary, not new sccache option names: for example,
+`INTENDANT_REMOTE_CACHE_SCCACHE_BUCKET` becomes `SCCACHE_BUCKET`, and
+`INTENDANT_REMOTE_CACHE_AWS_ACCESS_KEY_ID` becomes `AWS_ACCESS_KEY_ID` only
+inside the authenticated remote command. The worker container is a
+shell-authority boundary, not a credential enclave: another same-UID process
+could inspect those direct-mode values. Use only a cache-only principal
+restricted to one cache namespace, never a general AWS/account credential or
+any daemon/provider credential. Consult sccache's upstream
+[configuration reference](https://github.com/mozilla/sccache/blob/main/docs/Configuration.md)
 for backend-specific variables and its [Rust caveats](https://github.com/mozilla/sccache/blob/main/docs/Rust.md)
 for what can and cannot be cached.
-
-The worker container is still a shell-authority boundary, not a credential
-enclave: the requested command inherits the cache configuration, and another
-same-UID process could inspect it too. Use a cache-only principal restricted
-to the one cache namespace, never a general AWS/account credential or any
-daemon/provider credential.
 
 The practical split is therefore: Linux workers run platform-neutral
 `cargo check`, tests, clippy, code generation, and other heavy computation;

--- a/src/bin/caller/codex_cloud_attach.rs
+++ b/src/bin/caller/codex_cloud_attach.rs
@@ -825,7 +825,7 @@ pub(crate) async fn serve_attachment_socket<S>(
                 Some(Ok(message)) if message.is_close() => break,
                 Some(Ok(message)) => {
                     if let Ok(text) = message.into_text() {
-                        route_worker_frame(&from_worker_tx, text.as_str());
+                        route_worker_frame(&task_id, &from_worker_tx, text.as_str());
                     }
                 }
                 Some(Err(_)) => break,
@@ -879,9 +879,17 @@ pub(crate) async fn serve_attachment_socket<S>(
     }
 }
 
-/// Route one worker frame: reply kinds fan out to dashboard subscribers,
+/// Route one worker frame: a live job's capability-bound cache requests take
+/// their private bounded lane; ordinary reply kinds fan out to subscribers;
 /// everything else (hello included) is dropped without dispatch.
-fn route_worker_frame(from_worker_tx: &tokio::sync::broadcast::Sender<String>, text: &str) {
+fn route_worker_frame(
+    task_id: &str,
+    from_worker_tx: &tokio::sync::broadcast::Sender<String>,
+    text: &str,
+) {
+    if crate::remote_compute::route_remote_cache_frame(task_id, text) {
+        return;
+    }
     let kind = serde_json::from_str::<serde_json::Value>(text)
         .ok()
         .and_then(|value| {
@@ -2645,21 +2653,25 @@ mod tests {
         let (tx, mut rx) = tokio::sync::broadcast::channel::<String>(8);
         // A reply kind reaches subscribers.
         route_worker_frame(
+            "task-test",
             &tx,
             r#"{"t":"terminal_output","host_id":"cloud:x","terminal_id":"shell-0","data":"aGk="}"#,
         );
         assert!(rx.try_recv().is_ok());
         route_worker_frame(
+            "task-test",
             &tx,
             r#"{"t":"display_tiles","host_id":"cloud:x","data":"aGk="}"#,
         );
         assert!(rx.try_recv().is_ok());
         route_worker_frame(
+            "task-test",
             &tx,
             r#"{"t":"remote_command_result","host_id":"cloud:x","id":"remote-1","result":{"state":"succeeded","exit_code":0,"stdout":"","stderr":"","stdout_truncated":false,"stderr_truncated":false,"duration_ms":1}}"#,
         );
         assert!(rx.try_recv().is_ok());
         route_worker_frame(
+            "task-test",
             &tx,
             r#"{"t":"remote_source_result","host_id":"cloud:x","id":"source-a","state":"ready"}"#,
         );
@@ -2673,11 +2685,12 @@ mod tests {
             r#"{"t":"remote_command_start","host_id":"cloud:x","id":"remote-1"}"#,
             r#"{"t":"remote_command_cancel","host_id":"cloud:x","id":"remote-1"}"#,
             r#"{"t":"remote_source_begin","host_id":"cloud:x","id":"source-a"}"#,
+            r#"{"t":"remote_cache_request","host_id":"cloud:x","id":"remote-1","relay_token":"00000000000000000000000000000000","request_id":"11111111111111111111111111111111","op":"stat"}"#,
             r#"{"v":2,"kind":"cloud-worker-hello","task_id":"x"}"#,
             r#"{"t":"api_sessions"}"#,
             "not json",
         ] {
-            route_worker_frame(&tx, dropped);
+            route_worker_frame("task-test", &tx, dropped);
             assert!(rx.try_recv().is_err(), "{dropped}");
         }
     }

--- a/src/bin/caller/remote_compute.rs
+++ b/src/bin/caller/remote_compute.rs
@@ -6,6 +6,7 @@
 //! clean-worktree default keep a caller from accidentally validating a
 //! different source tree than the one it intended to send.
 
+mod cache_relay;
 mod scheduler;
 pub(crate) mod source;
 
@@ -39,6 +40,10 @@ const WORKER_PRIVATE_STATE_ENV: &str = "INTENDANT_HOME";
 pub(crate) const REMOTE_COMMAND_START_KIND: &str = "remote_command_start";
 pub(crate) const REMOTE_COMMAND_CANCEL_KIND: &str = "remote_command_cancel";
 pub(crate) const REMOTE_COMMAND_RESULT_KIND: &str = "remote_command_result";
+
+pub(crate) fn route_remote_cache_frame(task_id: &str, text: &str) -> bool {
+    cache_relay::route_worker_frame(task_id, text)
+}
 
 fn remove_worker_private_state(command: &mut tokio::process::Command) {
     command.env_remove(WORKER_PRIVATE_STATE_ENV);
@@ -83,6 +88,10 @@ pub(crate) struct RemoteCommandSpec {
     /// views or result logs.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     cache_env: BTreeMap<String, String>,
+    /// Opaque, one-job capability for the attachment-backed home cache.
+    /// It is never copied into job views, results, or debug output.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    cache_relay_token: Option<String>,
     #[serde(default = "default_require_clean")]
     pub require_clean: bool,
     pub timeout_s: u64,
@@ -98,6 +107,7 @@ impl std::fmt::Debug for RemoteCommandSpec {
             .field("source_id", &self.source_id)
             .field("cache", &self.cache)
             .field("cache_env_keys", &self.cache_env.keys().collect::<Vec<_>>())
+            .field("cache_relay", &self.cache_relay_token.is_some())
             .field("require_clean", &self.require_clean)
             .field("timeout_s", &self.timeout_s)
             .finish()
@@ -178,11 +188,18 @@ impl RemoteCommandSpec {
                 "env may contain at most {MAX_ENV_BYTES} bytes in total"
             ));
         }
-        if self.cache == RemoteCacheMode::None && !self.cache_env.is_empty() {
+        let has_direct_cache = !self.cache_env.is_empty();
+        let has_home_relay = self.cache_relay_token.is_some();
+        if self.cache == RemoteCacheMode::None && (has_direct_cache || has_home_relay) {
             return Err("cache configuration was supplied while cache mode is none".to_string());
         }
-        if self.cache == RemoteCacheMode::DurableSccache && self.cache_env.is_empty() {
-            return Err("durable_sccache requires dedicated cache configuration".to_string());
+        if self.cache == RemoteCacheMode::DurableSccache && (has_direct_cache == has_home_relay) {
+            return Err("durable_sccache requires exactly one durable cache transport".to_string());
+        }
+        if let Some(token) = self.cache_relay_token.as_deref() {
+            if token.len() != 32 || !token.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+                return Err("durable cache relay capability has an invalid shape".to_string());
+            }
         }
         let cache_env_bytes = self.cache_env.iter().try_fold(
             0usize,
@@ -509,6 +526,7 @@ fn subscribe_home_job(
 async fn start_remote_command(
     requested_host: Option<String>,
     spec: RemoteCommandSpec,
+    cache_store: Option<cache_relay::HomeCacheStore>,
     source_mode: RemoteSourceMode,
     snapshot: Option<source::HomeSourceSnapshot>,
     branch_hint: Option<String>,
@@ -557,8 +575,15 @@ async fn start_remote_command(
     insert_home_job(view.clone(), caller.owner_session_id())?;
 
     tokio::spawn(async move {
-        if let Err(error) =
-            prepare_and_dispatch(job_id.clone(), requested_host, spec, snapshot, branch_hint).await
+        if let Err(error) = prepare_and_dispatch(
+            job_id.clone(),
+            requested_host,
+            spec,
+            cache_store,
+            snapshot,
+            branch_hint,
+        )
+        .await
         {
             update_home_job(&job_id, |job| {
                 if !job.state.is_terminal() {
@@ -576,6 +601,7 @@ async fn prepare_and_dispatch(
     job_id: String,
     requested_host: String,
     mut spec: RemoteCommandSpec,
+    cache_store: Option<cache_relay::HomeCacheStore>,
     snapshot: Option<source::HomeSourceSnapshot>,
     branch_hint: Option<String>,
 ) -> Result<(), String> {
@@ -610,6 +636,13 @@ async fn prepare_and_dispatch(
         .to_string();
     let (to_worker, from_worker) = crate::codex_cloud_attach::attachment_channel(&task_id)
         .ok_or_else(|| format!("remote host {host} has no live attachment"))?;
+    let cache_session = match (cache_store, spec.cache_relay_token.as_deref()) {
+        (Some(store), Some(token)) => Some(cache_relay::HomeCacheSession::register(
+            &task_id, &job_id, token, store,
+        )?),
+        (None, None) => None,
+        _ => return Err("durable cache relay preparation was internally inconsistent".into()),
+    };
     let watchdog_s = spec.timeout_s.saturating_add(WORKER_WATCHDOG_GRACE_S);
     let frame = serde_json::json!({
         "t": REMOTE_COMMAND_START_KIND,
@@ -649,6 +682,7 @@ async fn prepare_and_dispatch(
             worker_use,
             from_worker,
             to_worker,
+            cache_session,
             Duration::from_secs(watchdog_s),
         )
         .await;
@@ -671,6 +705,7 @@ async fn await_worker_result(
     _worker_use: scheduler::WorkerUse,
     mut from_worker: tokio::sync::broadcast::Receiver<String>,
     to_worker: mpsc::Sender<String>,
+    mut cache_session: Option<cache_relay::HomeCacheSession>,
     watchdog: Duration,
 ) {
     let deadline = tokio::time::Instant::now() + watchdog;
@@ -679,8 +714,9 @@ async fn await_worker_result(
         if remaining.is_zero() {
             break;
         }
-        match tokio::time::timeout(remaining, from_worker.recv()).await {
-            Ok(Ok(text)) => {
+        tokio::select! {
+            worker = from_worker.recv() => match worker {
+            Ok(text) => {
                 let Ok(frame) = serde_json::from_str::<serde_json::Value>(&text) else {
                     continue;
                 };
@@ -725,15 +761,26 @@ async fn await_worker_result(
                 }
                 return;
             }
-            Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => continue,
-            Ok(Err(tokio::sync::broadcast::error::RecvError::Closed)) => {
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => {
                 update_home_job(&job_id, |job| {
                     job.state = RemoteCommandState::Failed;
                     job.error = Some("remote host detached while the command was running".into());
                 });
                 return;
             }
-            Err(_) => break,
+            },
+            cache_frame = async {
+                match cache_session.as_mut() {
+                    Some(session) => session.next_frame().await,
+                    None => std::future::pending().await,
+                }
+            } => {
+                if let (Some(session), Some(frame)) = (cache_session.as_mut(), cache_frame) {
+                    session.handle_frame(frame, &to_worker).await;
+                }
+            }
+            _ = tokio::time::sleep(remaining) => break,
         }
     }
 
@@ -902,9 +949,13 @@ pub(crate) async fn execute_remote_command_operation(
                     (base_revision, Some(snapshot), branch_hint)
                 }
             };
-            let cache_env = match cache {
-                RemoteCacheMode::None => BTreeMap::new(),
-                RemoteCacheMode::DurableSccache => durable_sccache_env()?,
+            let DurableSccacheConfig {
+                cache_env,
+                cache_relay_token,
+                cache_store,
+            } = match cache {
+                RemoteCacheMode::None => DurableSccacheConfig::default(),
+                RemoteCacheMode::DurableSccache => durable_sccache_config(project_root)?,
             };
             let spec = RemoteCommandSpec {
                 argv,
@@ -914,10 +965,20 @@ pub(crate) async fn execute_remote_command_operation(
                 source_id: None,
                 cache,
                 cache_env,
+                cache_relay_token,
                 require_clean: require_clean.unwrap_or(true),
                 timeout_s: timeout_s.unwrap_or(900),
             };
-            start_remote_command(host, spec, source, snapshot, branch_hint, caller).await
+            start_remote_command(
+                host,
+                spec,
+                cache_store,
+                source,
+                snapshot,
+                branch_hint,
+                caller,
+            )
+            .await
         }
         crate::mcp::RemoteCommandParams::Status { job_id } => {
             remote_command_status(&job_id, &caller)
@@ -933,6 +994,39 @@ pub(crate) async fn execute_remote_command_operation(
         crate::mcp::RemoteCommandParams::Cancel { job_id } => {
             cancel_remote_command(&job_id, &caller).await
         }
+    }
+}
+
+#[derive(Default)]
+struct DurableSccacheConfig {
+    cache_env: BTreeMap<String, String>,
+    cache_relay_token: Option<String>,
+    cache_store: Option<cache_relay::HomeCacheStore>,
+}
+
+fn durable_sccache_config(project_root: Option<&Path>) -> Result<DurableSccacheConfig, String> {
+    const TRANSPORT_ENV: &str = "INTENDANT_REMOTE_CACHE_TRANSPORT";
+    let transport = std::env::var(TRANSPORT_ENV)
+        .unwrap_or_else(|_| "home".to_string())
+        .trim()
+        .to_ascii_lowercase();
+    match transport.as_str() {
+        "home" | "attachment" => {
+            let project_root = project_root
+                .ok_or("durable_sccache through home requires a supervised project root")?;
+            let store = cache_relay::HomeCacheStore::for_project(project_root)?;
+            Ok(DurableSccacheConfig {
+                cache_env: BTreeMap::new(),
+                cache_relay_token: Some(uuid::Uuid::new_v4().simple().to_string()),
+                cache_store: Some(store),
+            })
+        }
+        "direct" => Ok(DurableSccacheConfig {
+            cache_env: durable_sccache_env()?,
+            cache_relay_token: None,
+            cache_store: None,
+        }),
+        _ => Err(format!("{TRANSPORT_ENV} must be home (default) or direct")),
     }
 }
 
@@ -994,6 +1088,7 @@ pub(crate) struct WorkerRemoteCommands {
     project_root: PathBuf,
     jobs: WorkerCancelMap,
     sources: source::WorkerSources,
+    cache_relay: cache_relay::WorkerCacheRelay,
     retired: tokio_util::sync::CancellationToken,
 }
 
@@ -1007,6 +1102,7 @@ impl WorkerRemoteCommands {
             project_root,
             jobs: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             sources,
+            cache_relay: cache_relay::WorkerCacheRelay::default(),
             retired: tokio_util::sync::CancellationToken::new(),
         })
     }
@@ -1017,6 +1113,9 @@ impl WorkerRemoteCommands {
         out_tx: &mpsc::Sender<String>,
         host_id: &str,
     ) -> bool {
+        if self.cache_relay.serve_frame(frame).await {
+            return true;
+        }
         if self.sources.serve_frame(frame, out_tx, host_id).await {
             return true;
         }
@@ -1124,10 +1223,19 @@ impl WorkerRemoteCommands {
 
         let project_root = self.project_root.clone();
         let sources = self.sources.clone();
+        let cache_relay = self.cache_relay.clone();
         let jobs = Arc::clone(&self.jobs);
         let reply_tx = out_tx.clone();
         let reply_host = host_id.to_string();
         tokio::spawn(async move {
+            let cache_client = spec.cache_relay_token.as_ref().map(|token| {
+                cache_relay.client(
+                    id.clone(),
+                    token.clone(),
+                    reply_host.clone(),
+                    reply_tx.clone(),
+                )
+            });
             let source_lease = match spec.source_id.as_deref() {
                 Some(source_id) => {
                     let acquired = tokio::select! {
@@ -1164,8 +1272,11 @@ impl WorkerRemoteCommands {
                 }
                 None => None,
             };
-            let result = run_worker_command(&project_root, spec, source_lease, cancel_rx).await;
+            let result =
+                run_worker_command(&project_root, spec, source_lease, cache_client, cancel_rx)
+                    .await;
             send_worker_result(&reply_tx, &reply_host, &id, result).await;
+            cache_relay.cancel_job(&id).await;
             jobs.lock().await.remove(&id);
         });
     }
@@ -1205,6 +1316,7 @@ async fn run_worker_command(
     project_root: &Path,
     spec: RemoteCommandSpec,
     source_lease: Option<source::WorkerSourceLease>,
+    cache_client: Option<cache_relay::WorkerCacheClient>,
     mut cancel_rx: oneshot::Receiver<()>,
 ) -> RemoteCommandResult {
     let started = Instant::now();
@@ -1272,9 +1384,17 @@ async fn run_worker_command(
     } else {
         None
     };
-    let cache_execution = match prepare_cache(&spec, selected_root).await {
-        Ok(cache) => cache,
-        Err(error) => return RemoteCommandResult::failed(error, started),
+    let cache_execution = tokio::select! {
+        cache = prepare_cache(&spec, selected_root, cache_client) => match cache {
+            Ok(cache) => cache,
+            Err(error) => return RemoteCommandResult::failed(error, started),
+        },
+        _ = &mut cancel_rx => {
+            return RemoteCommandResult::cancelled(
+                "command was cancelled while preparing its durable cache",
+                started,
+            )
+        }
     };
 
     let mut command = crate::platform::spawn_command(&spec.argv[0]);
@@ -1410,6 +1530,9 @@ struct CacheExecution {
     command_env: BTreeMap<String, String>,
     stats_env: BTreeMap<String, String>,
     before: CacheStats,
+    /// Keeps the loopback WebDAV relay alive through the final stats read.
+    sidecar: Option<cache_relay::WorkerCacheSidecar>,
+    stop_server: bool,
 }
 
 type CacheLockMap = HashMap<String, std::sync::Weak<tokio::sync::Mutex<()>>>;
@@ -1457,17 +1580,32 @@ fn cache_lane_digest(config: &BTreeMap<String, String>, selected_root: &Path) ->
 async fn prepare_cache(
     spec: &RemoteCommandSpec,
     selected_root: &Path,
+    cache_client: Option<cache_relay::WorkerCacheClient>,
 ) -> Result<Option<CacheExecution>, String> {
     if spec.cache == RemoteCacheMode::None {
         return Ok(None);
     }
-    if spec.cache_env.is_empty() {
-        return Err(
-            "durable_sccache carried no dedicated backend configuration; refusing an implicit worker-local cache"
-                .to_string(),
-        );
-    }
-    let mut stats_env = spec.cache_env.clone();
+    let (mut stats_env, sidecar, stop_server) = match (
+        spec.cache_relay_token.as_ref(),
+        cache_client,
+    ) {
+        (Some(_), Some(client)) => {
+            let sidecar = cache_relay::WorkerCacheSidecar::start(client).await?;
+            let mut env = BTreeMap::new();
+            env.insert(
+                "SCCACHE_WEBDAV_ENDPOINT".to_string(),
+                sidecar.endpoint().to_string(),
+            );
+            (env, Some(sidecar), true)
+        }
+        (None, None) if !spec.cache_env.is_empty() => (spec.cache_env.clone(), None, false),
+        _ => {
+            return Err(
+                "durable_sccache carried no usable durable transport; refusing an implicit worker-local cache"
+                    .to_string(),
+            )
+        }
+    };
     let digest = cache_lane_digest(&stats_env, selected_root);
     let socket = std::env::temp_dir().join(format!("intendant-sccache-{}.sock", &digest[..24]));
     stats_env.insert(
@@ -1526,11 +1664,13 @@ async fn prepare_cache(
         command_env,
         stats_env,
         before,
+        sidecar,
+        stop_server,
     }))
 }
 
 async fn finish_cache(cache: CacheExecution) -> RemoteCacheReport {
-    match run_sccache_stats(&cache.stats_env).await {
+    let report = match run_sccache_stats(&cache.stats_env).await {
         Ok(after) => RemoteCacheReport {
             mode: RemoteCacheMode::DurableSccache,
             hits_delta: after.hits.saturating_sub(cache.before.hits),
@@ -1550,7 +1690,12 @@ async fn finish_cache(cache: CacheExecution) -> RemoteCacheReport {
             errors_delta: 0,
             stats_error: Some(format!("read final sccache stats: {error}")),
         },
+    };
+    if cache.stop_server {
+        let _ = run_sccache(&["--stop-server"], &cache.stats_env).await;
     }
+    drop(cache.sidecar);
+    report
 }
 
 async fn run_sccache(args: &[&str], env: &BTreeMap<String, String>) -> Result<String, String> {
@@ -1834,6 +1979,7 @@ mod tests {
             source_id: None,
             cache: RemoteCacheMode::None,
             cache_env: BTreeMap::new(),
+            cache_relay_token: None,
             require_clean: true,
             timeout_s: 300,
         }
@@ -1941,6 +2087,16 @@ mod tests {
             .validate()
             .unwrap_err()
             .contains("invalid dedicated cache"));
+
+        command.cache_env.clear();
+        command.cache_relay_token = Some("a".repeat(32));
+        command.validate().unwrap();
+        assert!(!format!("{command:?}").contains(&"a".repeat(32)));
+        command.cache_env = BTreeMap::from([("SCCACHE_BUCKET".into(), "compiler-cache".into())]);
+        assert!(command
+            .validate()
+            .unwrap_err()
+            .contains("exactly one durable cache transport"));
     }
 
     #[test]
@@ -2034,12 +2190,14 @@ mod tests {
             source_id: None,
             cache: RemoteCacheMode::None,
             cache_env: BTreeMap::new(),
+            cache_relay_token: None,
             require_clean: true,
             timeout_s: 10,
         };
 
         let (cancel_tx, cancel_rx) = oneshot::channel();
-        let result = run_worker_command(&project_root, command.clone(), None, cancel_rx).await;
+        let result =
+            run_worker_command(&project_root, command.clone(), None, None, cancel_rx).await;
         drop(cancel_tx);
         assert_eq!(result.state, RemoteCommandState::Succeeded, "{result:#?}");
         assert_eq!(result.stdout.trim(), revision);
@@ -2049,7 +2207,7 @@ mod tests {
         let mut wrong_revision = command.clone();
         wrong_revision.expected_revision = "deadbee".into();
         let (cancel_tx, cancel_rx) = oneshot::channel();
-        let result = run_worker_command(&project_root, wrong_revision, None, cancel_rx).await;
+        let result = run_worker_command(&project_root, wrong_revision, None, None, cancel_rx).await;
         drop(cancel_tx);
         assert_eq!(result.state, RemoteCommandState::Failed);
         assert!(result
@@ -2059,7 +2217,7 @@ mod tests {
 
         std::fs::write(repo.path().join("uncommitted.txt"), "not selected\n").unwrap();
         let (cancel_tx, cancel_rx) = oneshot::channel();
-        let result = run_worker_command(&project_root, command, None, cancel_rx).await;
+        let result = run_worker_command(&project_root, command, None, None, cancel_rx).await;
         drop(cancel_tx);
         assert_eq!(result.state, RemoteCommandState::Failed);
         assert!(result

--- a/src/bin/caller/remote_compute.rs
+++ b/src/bin/caller/remote_compute.rs
@@ -1577,6 +1577,22 @@ fn cache_lane_digest(config: &BTreeMap<String, String>, selected_root: &Path) ->
         .collect()
 }
 
+fn no_proxy_with_loopback(existing: Option<&str>) -> String {
+    let mut value = existing.unwrap_or_default().trim().to_string();
+    for host in ["127.0.0.1", "localhost"] {
+        let present = value
+            .split(',')
+            .any(|entry| entry.trim().eq_ignore_ascii_case(host));
+        if !present {
+            if !value.is_empty() {
+                value.push(',');
+            }
+            value.push_str(host);
+        }
+    }
+    value
+}
+
 async fn prepare_cache(
     spec: &RemoteCommandSpec,
     selected_root: &Path,
@@ -1596,6 +1612,19 @@ async fn prepare_cache(
                 "SCCACHE_WEBDAV_ENDPOINT".to_string(),
                 sidecar.endpoint().to_string(),
             );
+            // Codex Cloud injects HTTP(S) proxy variables. Without an
+            // explicit bypass, sccache sends even this loopback WebDAV URL
+            // through the egress proxy, which correctly rejects private
+            // targets. Preserve any caller/worker bypasses while making the
+            // attachment-local sidecar unconditionally direct.
+            for name in ["NO_PROXY", "no_proxy"] {
+                let inherited = spec
+                    .env
+                    .get(name)
+                    .cloned()
+                    .or_else(|| std::env::var(name).ok());
+                env.insert(name.to_string(), no_proxy_with_loopback(inherited.as_deref()));
+            }
             (env, Some(sidecar), true)
         }
         (None, None) if !spec.cache_env.is_empty() => (spec.cache_env.clone(), None, false),
@@ -2026,6 +2055,19 @@ mod tests {
         assert!(output[OUTPUT_LIMIT_BYTES - tail.len()..]
             .iter()
             .all(|byte| *byte == b't'));
+    }
+
+    #[test]
+    fn loopback_cache_proxy_bypass_preserves_existing_hosts() {
+        assert_eq!(
+            no_proxy_with_loopback(Some("registry.example, localhost")),
+            "registry.example, localhost,127.0.0.1"
+        );
+        assert_eq!(
+            no_proxy_with_loopback(Some("127.0.0.1,LOCALHOST")),
+            "127.0.0.1,LOCALHOST"
+        );
+        assert_eq!(no_proxy_with_loopback(None), "127.0.0.1,localhost");
     }
 
     #[test]

--- a/src/bin/caller/remote_compute/cache_relay.rs
+++ b/src/bin/caller/remote_compute/cache_relay.rs
@@ -622,21 +622,49 @@ impl HomeCacheSession {
             return error_response(error);
         }
         match self.store.open(&key).await {
-            Ok(Some((file, bytes))) => {
+            Ok(Some((mut file, bytes))) => {
                 if bytes > MAX_CACHE_OBJECT_BYTES as u64 {
                     return error_response("cached object exceeds the relay object limit");
                 }
-                if bytes > 0 {
+                // Old workers omit `inline`; keep their offset-zero exchange
+                // intact so a daemon upgrade does not strand an attachment.
+                if frame.get("inline").and_then(Value::as_bool) != Some(true) {
+                    if bytes > 0 {
+                        self.downloads.insert(
+                            transfer_id.clone(),
+                            HomeDownload {
+                                file,
+                                bytes,
+                                offset: 0,
+                            },
+                        );
+                    }
+                    return json!({"state":"hit", "transfer_id":transfer_id, "bytes":bytes});
+                }
+                let mut first = vec![0u8; bytes.min(CACHE_CHUNK_BYTES as u64) as usize];
+                if let Err(error) = file.read_exact(&mut first).await {
+                    return error_response(format!("read cached object: {error}"));
+                }
+                let offset = first.len() as u64;
+                let done = offset == bytes;
+                if !done {
                     self.downloads.insert(
                         transfer_id.clone(),
                         HomeDownload {
                             file,
                             bytes,
-                            offset: 0,
+                            offset,
                         },
                     );
                 }
-                json!({"state":"hit", "transfer_id":transfer_id, "bytes":bytes})
+                json!({
+                    "state":"hit",
+                    "transfer_id":transfer_id,
+                    "bytes":bytes,
+                    "offset":0,
+                    "data":base64::engine::general_purpose::STANDARD.encode(first),
+                    "done":done,
+                })
             }
             Ok(None) => json!({"state":"miss"}),
             Err(error) => error_response(error),
@@ -698,10 +726,42 @@ impl HomeCacheSession {
         if expected_digest.len() != 64 || !expected_digest.bytes().all(hex_byte) {
             return error_response("cache upload digest has an invalid shape");
         }
-        let (temp_path, file) = match self.store.create_upload_file(&transfer_id) {
+        // `inline` is an additive protocol capability. An old worker gets
+        // the original offset-zero reply; a new worker can also fall back
+        // when an old home ignores these fields.
+        let first = match (
+            frame.get("inline").and_then(Value::as_bool),
+            frame.get("data"),
+        ) {
+            (Some(true), None) => Vec::new(),
+            (Some(true), Some(Value::String(value))) => {
+                match base64::engine::general_purpose::STANDARD.decode(value) {
+                    Ok(bytes)
+                        if bytes.len() <= CACHE_CHUNK_BYTES
+                            && bytes.len() as u64 <= expected_bytes =>
+                    {
+                        bytes
+                    }
+                    _ => return error_response("cache upload opening chunk is invalid"),
+                }
+            }
+            (Some(true), Some(_)) => {
+                return error_response("cache upload opening chunk is invalid")
+            }
+            _ => Vec::new(),
+        };
+        let (temp_path, mut file) = match self.store.create_upload_file(&transfer_id) {
             Ok(created) => created,
             Err(error) => return error_response(error),
         };
+        if let Err(error) = file.write_all(&first).await {
+            drop(file);
+            let _ = std::fs::remove_file(&temp_path);
+            return error_response(format!("write cache upload: {error}"));
+        }
+        let mut digest = sha2::Sha256::new();
+        digest.update(&first);
+        let written = first.len() as u64;
         self.uploads.insert(
             transfer_id.clone(),
             HomeUpload {
@@ -710,11 +770,11 @@ impl HomeCacheSession {
                 file,
                 expected_bytes,
                 expected_digest,
-                written: 0,
-                digest: sha2::Sha256::new(),
+                written,
+                digest,
             },
         );
-        json!({"state":"ready", "transfer_id":transfer_id, "offset":0})
+        json!({"state":"ready", "transfer_id":transfer_id, "offset":written})
     }
 
     async fn put_chunk(&mut self, frame: &Value) -> Value {
@@ -957,7 +1017,10 @@ impl WorkerCacheClient {
     async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, String> {
         let transfer_id = uuid::Uuid::new_v4().simple().to_string();
         let response = self
-            .exchange("get_begin", json!({"key":key, "transfer_id":transfer_id}))
+            .exchange(
+                "get_begin",
+                json!({"key":key, "transfer_id":transfer_id, "inline":true}),
+            )
             .await?;
         let expected = match response.get("state").and_then(Value::as_str) {
             Some("miss") => return Ok(None),
@@ -970,6 +1033,22 @@ impl WorkerCacheClient {
             _ => return Err(response_error(&response)),
         };
         let mut bytes = Vec::with_capacity(expected.min(4 * 1024 * 1024));
+        if let Some(encoded) = response.get("data").and_then(Value::as_str) {
+            let first = base64::engine::general_purpose::STANDARD
+                .decode(encoded)
+                .ok()
+                .filter(|chunk| chunk.len() <= CACHE_CHUNK_BYTES)
+                .ok_or_else(|| "cache relay opening download chunk is invalid".to_string())?;
+            let done = response.get("done").and_then(Value::as_bool);
+            if response.get("offset").and_then(Value::as_u64) != Some(0)
+                || first.len() > expected
+                || (first.is_empty() && expected > 0)
+                || done != Some(first.len() == expected)
+            {
+                return Err("cache relay opening download chunk made invalid progress".to_string());
+            }
+            bytes.extend_from_slice(&first);
+        }
         while bytes.len() < expected {
             let response = self
                 .exchange(
@@ -1001,6 +1080,7 @@ impl WorkerCacheClient {
             return Err("cache object exceeds the relay object limit".to_string());
         }
         let transfer_id = uuid::Uuid::new_v4().simple().to_string();
+        let first_len = bytes.len().min(CACHE_CHUNK_BYTES);
         let response = self
             .exchange(
                 "put_begin",
@@ -1009,14 +1089,24 @@ impl WorkerCacheClient {
                     "transfer_id":transfer_id,
                     "bytes":bytes.len(),
                     "sha256":sha256_hex(bytes),
+                    "inline":true,
+                    "data":base64::engine::general_purpose::STANDARD.encode(&bytes[..first_len]),
                 }),
             )
             .await?;
         if response.get("state").and_then(Value::as_str) != Some("ready") {
             return Err(response_error(&response));
         }
-        let mut offset = 0usize;
-        for chunk in bytes.chunks(CACHE_CHUNK_BYTES) {
+        let Some(offset) = response
+            .get("offset")
+            .and_then(Value::as_u64)
+            .and_then(|offset| usize::try_from(offset).ok())
+            .filter(|offset| *offset == 0 || *offset == first_len)
+        else {
+            return Err("cache relay upload began at the wrong offset".to_string());
+        };
+        let mut offset = offset;
+        for chunk in bytes[offset..].chunks(CACHE_CHUNK_BYTES) {
             let response = self
                 .exchange(
                     "put_chunk",
@@ -1080,7 +1170,7 @@ impl WorkerCacheSidecar {
         let shutdown_task = shutdown.clone();
         let state = Arc::new(WebDavState {
             client,
-            operation: tokio::sync::Mutex::new(()),
+            operations: tokio::sync::Semaphore::new(MAX_TRANSFERS_PER_JOB),
         });
         let app = Router::new().fallback(webdav_request).with_state(state);
         tokio::spawn(async move {
@@ -1104,10 +1194,10 @@ impl Drop for WorkerCacheSidecar {
 
 struct WebDavState {
     client: WorkerCacheClient,
-    /// sccache may issue backend calls concurrently. Serializing the relay
-    /// keeps both memory and attachment traffic bounded independently of the
-    /// compiler's job count.
-    operation: tokio::sync::Mutex<()>,
+    /// sccache may issue backend calls concurrently. Limiting the relay to
+    /// the same two-operation budget enforced by home keeps memory and
+    /// attachment traffic bounded independently of the compiler's job count.
+    operations: tokio::sync::Semaphore,
 }
 
 async fn webdav_request(
@@ -1117,7 +1207,9 @@ async fn webdav_request(
     _headers: HeaderMap,
     body: Body,
 ) -> Response<Body> {
-    let _operation = state.operation.lock().await;
+    let Ok(_operation) = state.operations.acquire().await else {
+        return empty_response(StatusCode::SERVICE_UNAVAILABLE);
+    };
     let raw_path = uri.path();
     let key = raw_path.strip_prefix('/').unwrap_or(raw_path);
     match method.as_str() {

--- a/src/bin/caller/remote_compute/cache_relay.rs
+++ b/src/bin/caller/remote_compute/cache_relay.rs
@@ -1,0 +1,1432 @@
+//! Capability-scoped durable compiler cache relay.
+//!
+//! Codex Cloud's managed HTTP egress is not a byte-transparent path for all
+//! signed object-store requests.  A remote command therefore gets a tiny,
+//! job-scoped WebDAV endpoint on loopback.  The endpoint carries bounded
+//! cache objects over the already-authenticated Cloud attachment and the home
+//! daemon stores them under its private state root.  The worker never receives
+//! home filesystem authority or durable storage credentials.
+
+use axum::body::{to_bytes, Body};
+use axum::extract::State;
+use axum::http::{header, HeaderMap, Method, StatusCode, Uri};
+use axum::response::Response;
+use axum::Router;
+use base64::Engine as _;
+use serde_json::{json, Value};
+use sha2::Digest as _;
+use std::collections::HashMap;
+use std::path::{Component, Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock, Weak};
+use std::time::{Duration, SystemTime};
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+use tokio::sync::{mpsc, oneshot};
+
+pub(super) const REMOTE_CACHE_REQUEST_KIND: &str = "remote_cache_request";
+pub(super) const REMOTE_CACHE_RESPONSE_KIND: &str = "remote_cache_response";
+
+const CACHE_CHUNK_BYTES: usize = 192 * 1024;
+const MAX_CACHE_OBJECT_BYTES: usize = 128 * 1024 * 1024;
+const MAX_CACHE_WRITES_PER_JOB: u64 = 8 * 1024 * 1024 * 1024;
+const DEFAULT_HOME_CACHE_BYTES: u64 = 20 * 1024 * 1024 * 1024;
+const MIN_HOME_CACHE_BYTES: u64 = 256 * 1024 * 1024;
+const MAX_HOME_CACHE_BYTES: u64 = 1024 * 1024 * 1024 * 1024;
+const RELAY_FRAME_CAP: usize = 16;
+const RELAY_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+const MAX_TRANSFERS_PER_JOB: usize = 2;
+
+const HOME_CACHE_DIR_ENV: &str = "INTENDANT_REMOTE_CACHE_HOME_DIR";
+const HOME_CACHE_MAX_BYTES_ENV: &str = "INTENDANT_REMOTE_CACHE_MAX_BYTES";
+
+#[derive(Clone)]
+pub(super) struct HomeCacheStore {
+    inner: Arc<HomeCacheStoreInner>,
+}
+
+struct HomeCacheStoreInner {
+    root: PathBuf,
+    max_bytes: u64,
+    accounting: tokio::sync::Mutex<StoreAccounting>,
+}
+
+#[derive(Default)]
+struct StoreAccounting {
+    total_bytes: Option<u64>,
+}
+
+type StoreKey = (PathBuf, u64);
+type StoreMap = HashMap<StoreKey, Weak<HomeCacheStoreInner>>;
+
+static HOME_CACHE_STORES: OnceLock<Mutex<StoreMap>> = OnceLock::new();
+
+impl HomeCacheStore {
+    pub(super) fn for_project(project_root: &Path) -> Result<Self, String> {
+        let identity = project_identity(project_root)?;
+        let base = match std::env::var_os(HOME_CACHE_DIR_ENV) {
+            Some(raw) if !raw.is_empty() => {
+                let path = PathBuf::from(raw);
+                if !path.is_absolute() {
+                    return Err(format!("{HOME_CACHE_DIR_ENV} must be an absolute path"));
+                }
+                path
+            }
+            _ => crate::platform::intendant_home()
+                .join("remote-cache")
+                .join("sccache-v1"),
+        };
+        let max_bytes = parse_cache_size_env()?;
+        Self::new(base.join(identity), max_bytes)
+    }
+
+    fn new(root: PathBuf, max_bytes: u64) -> Result<Self, String> {
+        intendant_core::state_paths::create_private_dir_all(&root)
+            .map_err(|error| format!("create home compiler cache {}: {error}", root.display()))?;
+        harden_private_path(&root)
+            .map_err(|error| format!("protect home compiler cache {}: {error}", root.display()))?;
+        let key = (root.clone(), max_bytes);
+        let inner = {
+            let mut stores = HOME_CACHE_STORES
+                .get_or_init(|| Mutex::new(HashMap::new()))
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            stores.retain(|_, store| store.strong_count() > 0);
+            stores.get(&key).and_then(Weak::upgrade).unwrap_or_else(|| {
+                let inner = Arc::new(HomeCacheStoreInner {
+                    root,
+                    max_bytes,
+                    accounting: tokio::sync::Mutex::new(StoreAccounting::default()),
+                });
+                stores.insert(key, Arc::downgrade(&inner));
+                inner
+            })
+        };
+        Ok(Self { inner })
+    }
+
+    #[cfg(test)]
+    fn new_for_test(root: PathBuf, max_bytes: u64) -> Self {
+        Self::new(root, max_bytes).expect("test cache store")
+    }
+
+    fn path_for_key(&self, key: &str) -> Result<PathBuf, String> {
+        validate_cache_key(key)?;
+        Ok(self.inner.root.join(key))
+    }
+
+    async fn stat(&self, key: &str) -> Result<Option<u64>, String> {
+        let path = self.path_for_key(key)?;
+        match tokio::fs::metadata(&path).await {
+            Ok(metadata) if metadata.is_file() => Ok(Some(metadata.len())),
+            Ok(_) => Err("cache key did not resolve to a regular file".to_string()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(format!("inspect cached object: {error}")),
+        }
+    }
+
+    async fn open(&self, key: &str) -> Result<Option<(tokio::fs::File, u64)>, String> {
+        let path = self.path_for_key(key)?;
+        match tokio::fs::File::open(&path).await {
+            Ok(file) => {
+                let metadata = file
+                    .metadata()
+                    .await
+                    .map_err(|error| format!("inspect cached object: {error}"))?;
+                if !metadata.is_file() {
+                    return Err("cache key did not resolve to a regular file".to_string());
+                }
+                Ok(Some((file, metadata.len())))
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(format!("open cached object: {error}")),
+        }
+    }
+
+    fn create_upload_file(&self, transfer_id: &str) -> Result<(PathBuf, tokio::fs::File), String> {
+        validate_transfer_id(transfer_id)?;
+        let temp_dir = self.inner.root.join(".tmp");
+        intendant_core::state_paths::create_private_dir_all(&temp_dir)
+            .map_err(|error| format!("create cache staging directory: {error}"))?;
+        harden_private_path(&temp_dir)
+            .map_err(|error| format!("protect cache staging directory: {error}"))?;
+        let path = temp_dir.join(format!("{transfer_id}.part"));
+        let file = intendant_core::state_paths::private_file_options()
+            .create_new(true)
+            .truncate(false)
+            .open(&path)
+            .map_err(|error| format!("create cache staging file: {error}"))?;
+        harden_private_path(&path)
+            .map_err(|error| format!("protect cache staging file: {error}"))?;
+        Ok((path, tokio::fs::File::from_std(file)))
+    }
+
+    async fn commit(&self, temp: PathBuf, key: String, size: u64) -> Result<(), String> {
+        let destination = self.path_for_key(&key)?;
+        let mut accounting = self.inner.accounting.lock().await;
+        if accounting.total_bytes.is_none() {
+            let root = self.inner.root.clone();
+            accounting.total_bytes = Some(
+                tokio::task::spawn_blocking(move || cache_total_bytes(&root))
+                    .await
+                    .map_err(|error| format!("scan home compiler cache task: {error}"))??,
+            );
+        }
+        let current_total = accounting.total_bytes.unwrap_or_default();
+        let root = self.inner.root.clone();
+        let max_bytes = self.inner.max_bytes;
+        let cleanup_temp = temp.clone();
+        let outcome = tokio::task::spawn_blocking(move || {
+            commit_cache_file(&root, &temp, &destination, size, current_total, max_bytes)
+        })
+        .await
+        .map_err(|error| format!("commit home compiler cache task: {error}"))?;
+        match outcome {
+            Ok(total) => {
+                accounting.total_bytes = Some(total);
+                Ok(())
+            }
+            Err(error) => {
+                accounting.total_bytes = None;
+                let _ = std::fs::remove_file(&cleanup_temp);
+                Err(error)
+            }
+        }
+    }
+
+    async fn delete(&self, key: &str) -> Result<bool, String> {
+        let path = self.path_for_key(key)?;
+        let mut accounting = self.inner.accounting.lock().await;
+        let metadata = match std::fs::metadata(&path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(error) => return Err(format!("inspect cached object before delete: {error}")),
+        };
+        std::fs::remove_file(&path).map_err(|error| format!("delete cached object: {error}"))?;
+        if let Some(total) = accounting.total_bytes.as_mut() {
+            *total = total.saturating_sub(metadata.len());
+        }
+        Ok(true)
+    }
+}
+
+fn project_identity(project_root: &Path) -> Result<String, String> {
+    let root = project_root
+        .canonicalize()
+        .map_err(|error| format!("resolve cache project root: {error}"))?;
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&root)
+        .args(["rev-parse", "--git-common-dir"])
+        .output()
+        .map_err(|error| format!("resolve Git common directory for compiler cache: {error}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "resolve Git common directory for compiler cache: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if raw.is_empty() {
+        return Err("Git returned an empty common directory for compiler cache".to_string());
+    }
+    let common = PathBuf::from(raw);
+    let common = if common.is_absolute() {
+        common
+    } else {
+        root.join(common)
+    };
+    let common = common
+        .canonicalize()
+        .map_err(|error| format!("resolve Git common directory for compiler cache: {error}"))?;
+    Ok(sha256_hex(common.to_string_lossy().as_bytes()))
+}
+
+fn parse_cache_size_env() -> Result<u64, String> {
+    let Some(raw) = std::env::var(HOME_CACHE_MAX_BYTES_ENV).ok() else {
+        return Ok(DEFAULT_HOME_CACHE_BYTES);
+    };
+    let bytes = raw
+        .trim()
+        .parse::<u64>()
+        .map_err(|_| format!("{HOME_CACHE_MAX_BYTES_ENV} must be an integer byte count"))?;
+    if !(MIN_HOME_CACHE_BYTES..=MAX_HOME_CACHE_BYTES).contains(&bytes) {
+        return Err(format!(
+            "{HOME_CACHE_MAX_BYTES_ENV} must be between {MIN_HOME_CACHE_BYTES} and {MAX_HOME_CACHE_BYTES} bytes"
+        ));
+    }
+    Ok(bytes)
+}
+
+fn harden_private_path(path: &Path) -> std::io::Result<()> {
+    #[cfg(windows)]
+    {
+        crate::platform::set_owner_private_permissions(path)
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = path;
+        Ok(())
+    }
+}
+
+fn cache_total_bytes(root: &Path) -> Result<u64, String> {
+    Ok(cache_files(root)?
+        .into_iter()
+        .map(|file| file.bytes)
+        .fold(0u64, u64::saturating_add))
+}
+
+struct CacheFile {
+    path: PathBuf,
+    bytes: u64,
+    modified: SystemTime,
+}
+
+fn cache_files(root: &Path) -> Result<Vec<CacheFile>, String> {
+    let mut pending = vec![root.to_path_buf()];
+    let mut files = Vec::new();
+    while let Some(dir) = pending.pop() {
+        let entries = std::fs::read_dir(&dir)
+            .map_err(|error| format!("scan compiler cache {}: {error}", dir.display()))?;
+        for entry in entries {
+            let entry = entry.map_err(|error| format!("scan compiler cache entry: {error}"))?;
+            if entry.file_name() == ".tmp" {
+                continue;
+            }
+            let file_type = entry
+                .file_type()
+                .map_err(|error| format!("inspect compiler cache entry type: {error}"))?;
+            if file_type.is_symlink() {
+                return Err(format!(
+                    "compiler cache contains an unexpected symlink at {}",
+                    entry.path().display()
+                ));
+            }
+            let metadata = std::fs::symlink_metadata(entry.path())
+                .map_err(|error| format!("inspect compiler cache entry: {error}"))?;
+            if file_type.is_dir() {
+                pending.push(entry.path());
+            } else if file_type.is_file() {
+                files.push(CacheFile {
+                    path: entry.path(),
+                    bytes: metadata.len(),
+                    modified: metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH),
+                });
+            }
+        }
+    }
+    Ok(files)
+}
+
+fn commit_cache_file(
+    root: &Path,
+    temp: &Path,
+    destination: &Path,
+    size: u64,
+    current_total: u64,
+    max_bytes: u64,
+) -> Result<u64, String> {
+    if size > max_bytes {
+        return Err(format!(
+            "cache object is {size} bytes, larger than the {max_bytes}-byte home cache"
+        ));
+    }
+    let replaced = std::fs::metadata(destination)
+        .ok()
+        .filter(|metadata| metadata.is_file())
+        .map(|metadata| metadata.len())
+        .unwrap_or_default();
+    let mut projected = current_total.saturating_sub(replaced).saturating_add(size);
+    if projected > max_bytes {
+        let mut files = cache_files(root)?;
+        files.sort_by_key(|file| file.modified);
+        for file in files {
+            if file.path == destination {
+                continue;
+            }
+            match std::fs::remove_file(&file.path) {
+                Ok(()) => projected = projected.saturating_sub(file.bytes),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(format!(
+                        "evict compiler cache object {}: {error}",
+                        file.path.display()
+                    ))
+                }
+            }
+            if projected <= max_bytes {
+                break;
+            }
+        }
+    }
+    if projected > max_bytes {
+        return Err("home compiler cache could not free enough space for an object".to_string());
+    }
+    let parent = destination
+        .parent()
+        .ok_or_else(|| "cache destination has no parent directory".to_string())?;
+    intendant_core::state_paths::create_private_dir_all(parent)
+        .map_err(|error| format!("create compiler cache object directory: {error}"))?;
+    harden_private_path(parent)
+        .map_err(|error| format!("protect compiler cache object directory: {error}"))?;
+    if let Err(first_error) = std::fs::rename(temp, destination) {
+        // Unix rename replaces an existing file atomically; Windows does not.
+        // The store-wide commit lock makes the remove+rename compatibility
+        // fallback safe, and a concurrent reader merely observes a cache miss.
+        if destination.is_file() {
+            std::fs::remove_file(destination).map_err(|error| {
+                format!("replace existing compiler cache object after {first_error}: {error}")
+            })?;
+            std::fs::rename(temp, destination)
+                .map_err(|error| format!("commit replacement compiler cache object: {error}"))?;
+        } else {
+            return Err(format!(
+                "atomically commit compiler cache object: {first_error}"
+            ));
+        }
+    }
+    harden_private_path(destination)
+        .map_err(|error| format!("protect compiler cache object: {error}"))?;
+    Ok(projected)
+}
+
+fn validate_cache_key(key: &str) -> Result<(), String> {
+    if key == ".sccache_check" {
+        return Ok(());
+    }
+    if key.is_empty() || key.len() > 512 || key.starts_with('.') || key.contains('%') {
+        return Err("cache key has an invalid shape".to_string());
+    }
+    let path = Path::new(key);
+    if path.is_absolute()
+        || path
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err("cache key must be a safe relative path".to_string());
+    }
+    let parts = key.split('/').collect::<Vec<_>>();
+    let valid = (2..=8).contains(&parts.len())
+        && parts[..parts.len() - 1]
+            .iter()
+            .all(|part| !part.is_empty() && part.len() <= 16 && part.bytes().all(hex_byte))
+        && parts
+            .last()
+            .is_some_and(|part| (32..=128).contains(&part.len()) && part.bytes().all(hex_byte));
+    if !valid {
+        return Err("cache key is not a content-addressed sccache path".to_string());
+    }
+    Ok(())
+}
+
+fn validate_cache_directory(path: &str) -> Result<(), String> {
+    if path.is_empty() {
+        return Ok(());
+    }
+    if path.len() > 256 || path.contains('%') {
+        return Err("cache directory has an invalid shape".to_string());
+    }
+    if path
+        .split('/')
+        .any(|part| part.is_empty() || part.len() > 16 || !part.bytes().all(hex_byte))
+    {
+        return Err("cache directory is not a safe sccache prefix".to_string());
+    }
+    Ok(())
+}
+
+fn hex_byte(byte: u8) -> bool {
+    byte.is_ascii_hexdigit()
+}
+
+fn validate_transfer_id(id: &str) -> Result<(), String> {
+    if id.len() == 32 && id.bytes().all(hex_byte) {
+        Ok(())
+    } else {
+        Err("cache transfer id has an invalid shape".to_string())
+    }
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    sha2::Sha256::digest(bytes)
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+struct RelayRoute {
+    token: String,
+    frames: mpsc::Sender<Value>,
+}
+
+type RelayKey = (String, String);
+static HOME_RELAYS: OnceLock<Mutex<HashMap<RelayKey, RelayRoute>>> = OnceLock::new();
+
+fn home_relays() -> &'static Mutex<HashMap<RelayKey, RelayRoute>> {
+    HOME_RELAYS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Route a cache frame into its one active, home-authorized job.  Cache
+/// frames never enter the general worker-reply broadcast.
+pub(super) fn route_worker_frame(task_id: &str, text: &str) -> bool {
+    let Ok(frame) = serde_json::from_str::<Value>(text) else {
+        return false;
+    };
+    if frame.get("t").and_then(Value::as_str) != Some(REMOTE_CACHE_REQUEST_KIND) {
+        return false;
+    }
+    let job_id = frame.get("id").and_then(Value::as_str).unwrap_or_default();
+    let token = frame
+        .get("relay_token")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let relays = home_relays()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let Some(route) = relays.get(&(task_id.to_string(), job_id.to_string())) else {
+        return true;
+    };
+    if !constant_time_eq(route.token.as_bytes(), token.as_bytes()) {
+        return true;
+    }
+    let _ = route.frames.try_send(frame);
+    true
+}
+
+fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    left.iter()
+        .zip(right)
+        .fold(0u8, |difference, (left, right)| difference | (left ^ right))
+        == 0
+}
+
+pub(super) struct HomeCacheSession {
+    key: RelayKey,
+    token: String,
+    host_id: String,
+    store: HomeCacheStore,
+    frames: mpsc::Receiver<Value>,
+    uploads: HashMap<String, HomeUpload>,
+    downloads: HashMap<String, HomeDownload>,
+    committed_bytes: u64,
+}
+
+struct HomeUpload {
+    key: String,
+    temp_path: PathBuf,
+    file: tokio::fs::File,
+    expected_bytes: u64,
+    expected_digest: String,
+    written: u64,
+    digest: sha2::Sha256,
+}
+
+struct HomeDownload {
+    file: tokio::fs::File,
+    bytes: u64,
+    offset: u64,
+}
+
+impl HomeCacheSession {
+    pub(super) fn register(
+        task_id: &str,
+        job_id: &str,
+        token: &str,
+        store: HomeCacheStore,
+    ) -> Result<Self, String> {
+        validate_relay_token(token)?;
+        let key = (task_id.to_string(), job_id.to_string());
+        let (frames_tx, frames) = mpsc::channel(RELAY_FRAME_CAP);
+        let mut relays = home_relays()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if relays.contains_key(&key) {
+            return Err("a cache relay is already registered for this remote job".to_string());
+        }
+        relays.insert(
+            key.clone(),
+            RelayRoute {
+                token: token.to_string(),
+                frames: frames_tx,
+            },
+        );
+        drop(relays);
+        Ok(Self {
+            key,
+            token: token.to_string(),
+            host_id: format!(
+                "{}{}",
+                super::super::codex_cloud_attach::CLOUD_HOST_PREFIX,
+                task_id
+            ),
+            store,
+            frames,
+            uploads: HashMap::new(),
+            downloads: HashMap::new(),
+            committed_bytes: 0,
+        })
+    }
+
+    pub(super) async fn next_frame(&mut self) -> Option<Value> {
+        self.frames.recv().await
+    }
+
+    pub(super) async fn handle_frame(&mut self, frame: Value, to_worker: &mpsc::Sender<String>) {
+        let request_id = frame
+            .get("request_id")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let response = if validate_request_id(&request_id).is_err() {
+            error_response("cache relay request id has an invalid shape")
+        } else {
+            match frame.get("op").and_then(Value::as_str).unwrap_or_default() {
+                "stat" => self.stat(&frame).await,
+                "get_begin" => self.get_begin(&frame).await,
+                "get_chunk" => self.get_chunk(&frame).await,
+                "put_begin" => self.put_begin(&frame).await,
+                "put_chunk" => self.put_chunk(&frame).await,
+                "put_finish" => self.put_finish(&frame).await,
+                "delete" => self.delete(&frame).await,
+                _ => error_response("cache relay operation is not supported"),
+            }
+        };
+        let mut response = response;
+        if let Some(map) = response.as_object_mut() {
+            map.insert("t".into(), REMOTE_CACHE_RESPONSE_KIND.into());
+            map.insert("host_id".into(), self.host_id.clone().into());
+            map.insert("id".into(), self.key.1.clone().into());
+            map.insert("request_id".into(), request_id.into());
+        }
+        let _ = super::send_home_frame(to_worker, response.to_string()).await;
+    }
+
+    async fn stat(&self, frame: &Value) -> Value {
+        let key = frame_string(frame, "key");
+        match self.store.stat(&key).await {
+            Ok(Some(bytes)) => json!({"state":"hit", "bytes":bytes}),
+            Ok(None) => json!({"state":"miss"}),
+            Err(error) => error_response(error),
+        }
+    }
+
+    async fn get_begin(&mut self, frame: &Value) -> Value {
+        if self.downloads.len() >= MAX_TRANSFERS_PER_JOB {
+            return error_response("too many cache downloads are active for this job");
+        }
+        let key = frame_string(frame, "key");
+        let transfer_id = frame_string(frame, "transfer_id");
+        if let Err(error) = validate_transfer_id(&transfer_id) {
+            return error_response(error);
+        }
+        match self.store.open(&key).await {
+            Ok(Some((file, bytes))) => {
+                if bytes > MAX_CACHE_OBJECT_BYTES as u64 {
+                    return error_response("cached object exceeds the relay object limit");
+                }
+                if bytes > 0 {
+                    self.downloads.insert(
+                        transfer_id.clone(),
+                        HomeDownload {
+                            file,
+                            bytes,
+                            offset: 0,
+                        },
+                    );
+                }
+                json!({"state":"hit", "transfer_id":transfer_id, "bytes":bytes})
+            }
+            Ok(None) => json!({"state":"miss"}),
+            Err(error) => error_response(error),
+        }
+    }
+
+    async fn get_chunk(&mut self, frame: &Value) -> Value {
+        let transfer_id = frame_string(frame, "transfer_id");
+        let offset = frame.get("offset").and_then(Value::as_u64);
+        let Some(download) = self.downloads.get_mut(&transfer_id) else {
+            return error_response("cache download was not begun");
+        };
+        if offset != Some(download.offset) {
+            self.downloads.remove(&transfer_id);
+            return error_response("cache download chunk is out of order");
+        }
+        let remaining = download.bytes.saturating_sub(download.offset);
+        let mut bytes = vec![0u8; remaining.min(CACHE_CHUNK_BYTES as u64) as usize];
+        if let Err(error) = download.file.read_exact(&mut bytes).await {
+            self.downloads.remove(&transfer_id);
+            return error_response(format!("read cached object: {error}"));
+        }
+        let chunk_offset = download.offset;
+        download.offset = download.offset.saturating_add(bytes.len() as u64);
+        let done = download.offset == download.bytes;
+        if done {
+            self.downloads.remove(&transfer_id);
+        }
+        json!({
+            "state":"chunk",
+            "offset":chunk_offset,
+            "data":base64::engine::general_purpose::STANDARD.encode(bytes),
+            "done":done,
+        })
+    }
+
+    async fn put_begin(&mut self, frame: &Value) -> Value {
+        if self.uploads.len() >= MAX_TRANSFERS_PER_JOB {
+            return error_response("too many cache uploads are active for this job");
+        }
+        let key = frame_string(frame, "key");
+        if let Err(error) = validate_cache_key(&key) {
+            return error_response(error);
+        }
+        let transfer_id = frame_string(frame, "transfer_id");
+        if let Err(error) = validate_transfer_id(&transfer_id) {
+            return error_response(error);
+        }
+        let Some(expected_bytes) = frame.get("bytes").and_then(Value::as_u64) else {
+            return error_response("cache upload carried no byte count");
+        };
+        if expected_bytes > MAX_CACHE_OBJECT_BYTES as u64 {
+            return error_response("cache upload exceeds the relay object limit");
+        }
+        if self.committed_bytes.saturating_add(expected_bytes) > MAX_CACHE_WRITES_PER_JOB {
+            return error_response("cache upload exceeds the per-job write allowance");
+        }
+        let expected_digest = frame_string(frame, "sha256");
+        if expected_digest.len() != 64 || !expected_digest.bytes().all(hex_byte) {
+            return error_response("cache upload digest has an invalid shape");
+        }
+        let (temp_path, file) = match self.store.create_upload_file(&transfer_id) {
+            Ok(created) => created,
+            Err(error) => return error_response(error),
+        };
+        self.uploads.insert(
+            transfer_id.clone(),
+            HomeUpload {
+                key,
+                temp_path,
+                file,
+                expected_bytes,
+                expected_digest,
+                written: 0,
+                digest: sha2::Sha256::new(),
+            },
+        );
+        json!({"state":"ready", "transfer_id":transfer_id, "offset":0})
+    }
+
+    async fn put_chunk(&mut self, frame: &Value) -> Value {
+        let transfer_id = frame_string(frame, "transfer_id");
+        let offset = frame.get("offset").and_then(Value::as_u64);
+        let data = frame
+            .get("data")
+            .and_then(Value::as_str)
+            .and_then(|value| base64::engine::general_purpose::STANDARD.decode(value).ok());
+        let Some(upload) = self.uploads.get_mut(&transfer_id) else {
+            return error_response("cache upload was not begun");
+        };
+        let valid = offset == Some(upload.written)
+            && data.as_ref().is_some_and(|data| {
+                data.len() <= CACHE_CHUNK_BYTES
+                    && upload.written.saturating_add(data.len() as u64) <= upload.expected_bytes
+            });
+        if !valid {
+            let upload = self.uploads.remove(&transfer_id).expect("upload exists");
+            discard_upload(upload);
+            return error_response("cache upload chunk is invalid or out of order");
+        }
+        let data = data.unwrap_or_default();
+        if let Err(error) = upload.file.write_all(&data).await {
+            let upload = self.uploads.remove(&transfer_id).expect("upload exists");
+            discard_upload(upload);
+            return error_response(format!("write cache upload: {error}"));
+        }
+        upload.digest.update(&data);
+        upload.written = upload.written.saturating_add(data.len() as u64);
+        json!({"state":"ready", "transfer_id":transfer_id, "offset":upload.written})
+    }
+
+    async fn put_finish(&mut self, frame: &Value) -> Value {
+        let transfer_id = frame_string(frame, "transfer_id");
+        let Some(mut upload) = self.uploads.remove(&transfer_id) else {
+            return error_response("cache upload was not begun");
+        };
+        if upload.written != upload.expected_bytes {
+            discard_upload(upload);
+            return error_response("cache upload finished at the wrong byte count");
+        }
+        if let Err(error) = upload.file.flush().await {
+            discard_upload(upload);
+            return error_response(format!("flush cache upload: {error}"));
+        }
+        if let Err(error) = upload.file.sync_all().await {
+            discard_upload(upload);
+            return error_response(format!("sync cache upload: {error}"));
+        }
+        let actual_digest = upload
+            .digest
+            .clone()
+            .finalize()
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+        if actual_digest != upload.expected_digest {
+            discard_upload(upload);
+            return error_response("cache upload digest did not match its declared content");
+        }
+        let HomeUpload {
+            key,
+            temp_path,
+            file,
+            expected_bytes: bytes,
+            ..
+        } = upload;
+        drop(file);
+        match self.store.commit(temp_path, key, bytes).await {
+            Ok(()) => {
+                self.committed_bytes = self.committed_bytes.saturating_add(bytes);
+                json!({"state":"stored", "bytes":bytes})
+            }
+            Err(error) => error_response(error),
+        }
+    }
+
+    async fn delete(&self, frame: &Value) -> Value {
+        let key = frame_string(frame, "key");
+        match self.store.delete(&key).await {
+            Ok(deleted) => json!({"state":"deleted", "deleted":deleted}),
+            Err(error) => error_response(error),
+        }
+    }
+}
+
+impl Drop for HomeCacheSession {
+    fn drop(&mut self) {
+        let mut relays = home_relays()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if relays
+            .get(&self.key)
+            .is_some_and(|route| constant_time_eq(route.token.as_bytes(), self.token.as_bytes()))
+        {
+            relays.remove(&self.key);
+        }
+        drop(relays);
+        for (_, upload) in self.uploads.drain() {
+            discard_upload(upload);
+        }
+    }
+}
+
+fn discard_upload(upload: HomeUpload) {
+    let path = upload.temp_path.clone();
+    drop(upload);
+    let _ = std::fs::remove_file(path);
+}
+
+fn frame_string(frame: &Value, key: &str) -> String {
+    frame
+        .get(key)
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn error_response(error: impl Into<String>) -> Value {
+    json!({"state":"error", "error":error.into()})
+}
+
+fn validate_relay_token(token: &str) -> Result<(), String> {
+    if token.len() == 32 && token.bytes().all(hex_byte) {
+        Ok(())
+    } else {
+        Err("cache relay token has an invalid shape".to_string())
+    }
+}
+
+fn validate_request_id(id: &str) -> Result<(), String> {
+    validate_transfer_id(id)
+}
+
+type PendingCacheResponses = HashMap<(String, String), oneshot::Sender<Value>>;
+
+#[derive(Clone, Default)]
+pub(super) struct WorkerCacheRelay {
+    pending: Arc<tokio::sync::Mutex<PendingCacheResponses>>,
+}
+
+impl WorkerCacheRelay {
+    pub(super) async fn serve_frame(&self, frame: &Value) -> bool {
+        if frame.get("t").and_then(Value::as_str) != Some(REMOTE_CACHE_RESPONSE_KIND) {
+            return false;
+        }
+        let job_id = frame_string(frame, "id");
+        let request_id = frame_string(frame, "request_id");
+        if let Some(sender) = self.pending.lock().await.remove(&(job_id, request_id)) {
+            let _ = sender.send(frame.clone());
+        }
+        true
+    }
+
+    pub(super) fn client(
+        &self,
+        job_id: String,
+        token: String,
+        host_id: String,
+        outbound: mpsc::Sender<String>,
+    ) -> WorkerCacheClient {
+        WorkerCacheClient {
+            relay: self.clone(),
+            job_id,
+            token,
+            host_id,
+            outbound,
+        }
+    }
+
+    pub(super) async fn cancel_job(&self, job_id: &str) {
+        self.pending
+            .lock()
+            .await
+            .retain(|(pending_job, _), _| pending_job != job_id);
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct WorkerCacheClient {
+    relay: WorkerCacheRelay,
+    job_id: String,
+    token: String,
+    host_id: String,
+    outbound: mpsc::Sender<String>,
+}
+
+impl WorkerCacheClient {
+    async fn exchange(&self, op: &str, fields: Value) -> Result<Value, String> {
+        let request_id = uuid::Uuid::new_v4().simple().to_string();
+        let key = (self.job_id.clone(), request_id.clone());
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.relay
+            .pending
+            .lock()
+            .await
+            .insert(key.clone(), reply_tx);
+        let mut frame = json!({
+            "t":REMOTE_CACHE_REQUEST_KIND,
+            "host_id":self.host_id,
+            "id":self.job_id,
+            "relay_token":self.token,
+            "request_id":request_id,
+            "op":op,
+        });
+        if let (Some(target), Some(source)) = (frame.as_object_mut(), fields.as_object()) {
+            target.extend(source.clone());
+        }
+        let send =
+            tokio::time::timeout(RELAY_REQUEST_TIMEOUT, self.outbound.send(frame.to_string()))
+                .await;
+        if !matches!(send, Ok(Ok(()))) {
+            self.relay.pending.lock().await.remove(&key);
+            return Err("cache relay attachment stopped accepting requests".to_string());
+        }
+        match tokio::time::timeout(RELAY_REQUEST_TIMEOUT, reply_rx).await {
+            Ok(Ok(reply)) => Ok(reply),
+            Ok(Err(_)) => Err("cache relay response lane closed".to_string()),
+            Err(_) => {
+                self.relay.pending.lock().await.remove(&key);
+                Err("cache relay request timed out".to_string())
+            }
+        }
+    }
+
+    async fn stat(&self, key: &str) -> Result<Option<u64>, String> {
+        let response = self.exchange("stat", json!({"key":key})).await?;
+        match response.get("state").and_then(Value::as_str) {
+            Some("hit") => response
+                .get("bytes")
+                .and_then(Value::as_u64)
+                .map(Some)
+                .ok_or_else(|| "cache relay stat carried no byte count".to_string()),
+            Some("miss") => Ok(None),
+            _ => Err(response_error(&response)),
+        }
+    }
+
+    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, String> {
+        let transfer_id = uuid::Uuid::new_v4().simple().to_string();
+        let response = self
+            .exchange("get_begin", json!({"key":key, "transfer_id":transfer_id}))
+            .await?;
+        let expected = match response.get("state").and_then(Value::as_str) {
+            Some("miss") => return Ok(None),
+            Some("hit") => response
+                .get("bytes")
+                .and_then(Value::as_u64)
+                .and_then(|bytes| usize::try_from(bytes).ok())
+                .filter(|bytes| *bytes <= MAX_CACHE_OBJECT_BYTES)
+                .ok_or_else(|| "cache relay download size is invalid".to_string())?,
+            _ => return Err(response_error(&response)),
+        };
+        let mut bytes = Vec::with_capacity(expected.min(4 * 1024 * 1024));
+        while bytes.len() < expected {
+            let response = self
+                .exchange(
+                    "get_chunk",
+                    json!({"transfer_id":transfer_id, "offset":bytes.len()}),
+                )
+                .await?;
+            if response.get("state").and_then(Value::as_str) != Some("chunk")
+                || response.get("offset").and_then(Value::as_u64) != Some(bytes.len() as u64)
+            {
+                return Err(response_error(&response));
+            }
+            let chunk = response
+                .get("data")
+                .and_then(Value::as_str)
+                .and_then(|value| base64::engine::general_purpose::STANDARD.decode(value).ok())
+                .filter(|chunk| chunk.len() <= CACHE_CHUNK_BYTES)
+                .ok_or_else(|| "cache relay download chunk is invalid".to_string())?;
+            if chunk.is_empty() || bytes.len().saturating_add(chunk.len()) > expected {
+                return Err("cache relay download made invalid progress".to_string());
+            }
+            bytes.extend_from_slice(&chunk);
+        }
+        Ok(Some(bytes))
+    }
+
+    async fn put(&self, key: &str, bytes: &[u8]) -> Result<(), String> {
+        if bytes.len() > MAX_CACHE_OBJECT_BYTES {
+            return Err("cache object exceeds the relay object limit".to_string());
+        }
+        let transfer_id = uuid::Uuid::new_v4().simple().to_string();
+        let response = self
+            .exchange(
+                "put_begin",
+                json!({
+                    "key":key,
+                    "transfer_id":transfer_id,
+                    "bytes":bytes.len(),
+                    "sha256":sha256_hex(bytes),
+                }),
+            )
+            .await?;
+        if response.get("state").and_then(Value::as_str) != Some("ready") {
+            return Err(response_error(&response));
+        }
+        let mut offset = 0usize;
+        for chunk in bytes.chunks(CACHE_CHUNK_BYTES) {
+            let response = self
+                .exchange(
+                    "put_chunk",
+                    json!({
+                        "transfer_id":transfer_id,
+                        "offset":offset,
+                        "data":base64::engine::general_purpose::STANDARD.encode(chunk),
+                    }),
+                )
+                .await?;
+            offset = offset.saturating_add(chunk.len());
+            if response.get("state").and_then(Value::as_str) != Some("ready")
+                || response.get("offset").and_then(Value::as_u64) != Some(offset as u64)
+            {
+                return Err(response_error(&response));
+            }
+        }
+        let response = self
+            .exchange("put_finish", json!({"transfer_id":transfer_id}))
+            .await?;
+        if response.get("state").and_then(Value::as_str) == Some("stored") {
+            Ok(())
+        } else {
+            Err(response_error(&response))
+        }
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), String> {
+        let response = self.exchange("delete", json!({"key":key})).await?;
+        if response.get("state").and_then(Value::as_str) == Some("deleted") {
+            Ok(())
+        } else {
+            Err(response_error(&response))
+        }
+    }
+}
+
+fn response_error(response: &Value) -> String {
+    response
+        .get("error")
+        .and_then(Value::as_str)
+        .unwrap_or("cache relay returned an invalid response")
+        .to_string()
+}
+
+pub(super) struct WorkerCacheSidecar {
+    endpoint: String,
+    shutdown: tokio_util::sync::CancellationToken,
+}
+
+impl WorkerCacheSidecar {
+    pub(super) async fn start(client: WorkerCacheClient) -> Result<Self, String> {
+        let listener = tokio::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+            .await
+            .map_err(|error| format!("bind worker cache relay: {error}"))?;
+        let address = listener
+            .local_addr()
+            .map_err(|error| format!("read worker cache relay address: {error}"))?;
+        let endpoint = format!("http://127.0.0.1:{}", address.port());
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        let shutdown_task = shutdown.clone();
+        let state = Arc::new(WebDavState {
+            client,
+            operation: tokio::sync::Mutex::new(()),
+        });
+        let app = Router::new().fallback(webdav_request).with_state(state);
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app)
+                .with_graceful_shutdown(shutdown_task.cancelled_owned())
+                .await;
+        });
+        Ok(Self { endpoint, shutdown })
+    }
+
+    pub(super) fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+}
+
+impl Drop for WorkerCacheSidecar {
+    fn drop(&mut self) {
+        self.shutdown.cancel();
+    }
+}
+
+struct WebDavState {
+    client: WorkerCacheClient,
+    /// sccache may issue backend calls concurrently. Serializing the relay
+    /// keeps both memory and attachment traffic bounded independently of the
+    /// compiler's job count.
+    operation: tokio::sync::Mutex<()>,
+}
+
+async fn webdav_request(
+    State(state): State<Arc<WebDavState>>,
+    method: Method,
+    uri: Uri,
+    _headers: HeaderMap,
+    body: Body,
+) -> Response<Body> {
+    let _operation = state.operation.lock().await;
+    let raw_path = uri.path();
+    let key = raw_path.strip_prefix('/').unwrap_or(raw_path);
+    match method.as_str() {
+        "GET" => match validate_cache_key(key) {
+            Ok(()) => match state.client.get(key).await {
+                Ok(Some(bytes)) => binary_response(StatusCode::OK, bytes),
+                Ok(None) => empty_response(StatusCode::NOT_FOUND),
+                Err(error) => {
+                    eprintln!("[cloud-agent] compiler cache read degraded to a miss: {error}");
+                    empty_response(StatusCode::NOT_FOUND)
+                }
+            },
+            Err(_) => empty_response(StatusCode::BAD_REQUEST),
+        },
+        "HEAD" => match validate_cache_key(key) {
+            Ok(()) => match state.client.stat(key).await {
+                Ok(Some(bytes)) => sized_empty_response(StatusCode::OK, bytes),
+                Ok(None) => empty_response(StatusCode::NOT_FOUND),
+                Err(_) => empty_response(StatusCode::NOT_FOUND),
+            },
+            Err(_) => empty_response(StatusCode::BAD_REQUEST),
+        },
+        "PUT" => {
+            if validate_cache_key(key).is_err() {
+                return empty_response(StatusCode::BAD_REQUEST);
+            }
+            match to_bytes(body, MAX_CACHE_OBJECT_BYTES).await {
+                Ok(bytes) => match state.client.put(key, &bytes).await {
+                    Ok(()) => empty_response(StatusCode::CREATED),
+                    Err(error) => {
+                        eprintln!("[cloud-agent] compiler cache write failed: {error}");
+                        empty_response(StatusCode::INSUFFICIENT_STORAGE)
+                    }
+                },
+                Err(_) => empty_response(StatusCode::PAYLOAD_TOO_LARGE),
+            }
+        }
+        "DELETE" => {
+            if validate_cache_key(key).is_err() {
+                return empty_response(StatusCode::BAD_REQUEST);
+            }
+            match state.client.delete(key).await {
+                Ok(()) => empty_response(StatusCode::NO_CONTENT),
+                Err(_) => empty_response(StatusCode::BAD_GATEWAY),
+            }
+        }
+        "MKCOL" => {
+            let directory = key.trim_end_matches('/');
+            match validate_cache_directory(directory) {
+                Ok(()) => empty_response(StatusCode::CREATED),
+                Err(_) => empty_response(StatusCode::BAD_REQUEST),
+            }
+        }
+        "PROPFIND" => {
+            if raw_path == "/" || raw_path.ends_with('/') {
+                let directory = key.trim_end_matches('/');
+                return match validate_cache_directory(directory) {
+                    Ok(()) => webdav_properties(raw_path, 0, true),
+                    Err(_) => empty_response(StatusCode::BAD_REQUEST),
+                };
+            }
+            match validate_cache_key(key) {
+                Ok(()) => match state.client.stat(key).await {
+                    Ok(Some(bytes)) => webdav_properties(raw_path, bytes, false),
+                    Ok(None) | Err(_) => empty_response(StatusCode::NOT_FOUND),
+                },
+                Err(_) => empty_response(StatusCode::BAD_REQUEST),
+            }
+        }
+        "OPTIONS" => Response::builder()
+            .status(StatusCode::NO_CONTENT)
+            .header("dav", "1")
+            .header("allow", "GET, HEAD, PUT, DELETE, MKCOL, PROPFIND, OPTIONS")
+            .body(Body::empty())
+            .unwrap_or_else(|_| empty_response(StatusCode::INTERNAL_SERVER_ERROR)),
+        _ => empty_response(StatusCode::METHOD_NOT_ALLOWED),
+    }
+}
+
+fn empty_response(status: StatusCode) -> Response<Body> {
+    Response::builder()
+        .status(status)
+        .header(header::CONTENT_LENGTH, "0")
+        .body(Body::empty())
+        .unwrap_or_else(|_| Response::new(Body::empty()))
+}
+
+fn sized_empty_response(status: StatusCode, bytes: u64) -> Response<Body> {
+    Response::builder()
+        .status(status)
+        .header(header::CONTENT_LENGTH, bytes.to_string())
+        .body(Body::empty())
+        .unwrap_or_else(|_| Response::new(Body::empty()))
+}
+
+fn binary_response(status: StatusCode, bytes: Vec<u8>) -> Response<Body> {
+    Response::builder()
+        .status(status)
+        .header(header::CONTENT_TYPE, "application/octet-stream")
+        .header(header::CONTENT_LENGTH, bytes.len().to_string())
+        .body(Body::from(bytes))
+        .unwrap_or_else(|_| Response::new(Body::empty()))
+}
+
+fn webdav_properties(path: &str, bytes: u64, directory: bool) -> Response<Body> {
+    let resource_type = if directory {
+        "<D:resourcetype><D:collection/></D:resourcetype>"
+    } else {
+        "<D:resourcetype/>"
+    };
+    let body = format!(
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?><D:multistatus xmlns:D=\"DAV:\"><D:response><D:href>{path}</D:href><D:propstat><D:prop>{resource_type}<D:getlastmodified>Sat, 01 Aug 2026 00:00:00 GMT</D:getlastmodified><D:getcontentlength>{bytes}</D:getcontentlength><D:getcontenttype>application/octet-stream</D:getcontenttype><D:getetag>\"intendant-cache\"</D:getetag></D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response></D:multistatus>"
+    );
+    Response::builder()
+        .status(StatusCode::MULTI_STATUS)
+        .header(header::CONTENT_TYPE, "application/xml")
+        .header(header::CONTENT_LENGTH, body.len().to_string())
+        .body(Body::from(body))
+        .unwrap_or_else(|_| Response::new(Body::empty()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cache_key(seed: char) -> String {
+        let digest = std::iter::repeat_n(seed, 64).collect::<String>();
+        format!("{0}/{0}/{0}/{digest}", seed)
+    }
+
+    #[test]
+    fn cache_paths_are_content_addressed_and_never_traverse() {
+        assert!(validate_cache_key(&cache_key('a')).is_ok());
+        assert!(validate_cache_key(".sccache_check").is_ok());
+        for invalid in [
+            "../secret",
+            "/absolute",
+            ".tmp/file",
+            "a/b/not-hex",
+            "a/%2e%2e/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        ] {
+            assert!(validate_cache_key(invalid).is_err(), "{invalid}");
+        }
+        assert!(validate_cache_directory("").is_ok());
+        assert!(validate_cache_directory("a/b/c").is_ok());
+        assert!(validate_cache_directory("a/../b").is_err());
+    }
+
+    #[tokio::test]
+    async fn home_cache_evicts_old_objects_before_crossing_its_ceiling() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = HomeCacheStore::new_for_test(temp.path().join("cache"), 600);
+        async fn commit(store: &HomeCacheStore, key: String, byte: u8) {
+            let transfer_id = uuid::Uuid::new_v4().simple().to_string();
+            let (path, mut file) = store.create_upload_file(&transfer_id).unwrap();
+            let bytes = [byte; 400];
+            file.write_all(&bytes).await.unwrap();
+            file.sync_all().await.unwrap();
+            drop(file);
+            store.commit(path, key, 400).await.unwrap();
+        }
+
+        let first = cache_key('e');
+        let second = cache_key('f');
+        commit(&store, first.clone(), 1).await;
+        commit(&store, second.clone(), 2).await;
+        assert_eq!(store.stat(&first).await.unwrap(), None);
+        assert_eq!(store.stat(&second).await.unwrap(), Some(400));
+    }
+
+    #[tokio::test]
+    async fn capability_scoped_relay_round_trips_chunked_objects() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = HomeCacheStore::new_for_test(temp.path().join("cache"), 4 * 1024 * 1024);
+        let task = format!("task-test-{}", uuid::Uuid::new_v4());
+        let job = format!("remote-test-{}", uuid::Uuid::new_v4());
+        let token = uuid::Uuid::new_v4().simple().to_string();
+        let mut home = HomeCacheSession::register(&task, &job, &token, store).unwrap();
+        let (home_to_worker_tx, mut home_to_worker_rx) = mpsc::channel::<String>(64);
+        let (worker_to_home_tx, mut worker_to_home_rx) = mpsc::channel::<String>(64);
+        let worker = WorkerCacheRelay::default();
+        let worker_inbound = worker.clone();
+        let inbound_task = tokio::spawn(async move {
+            while let Some(text) = home_to_worker_rx.recv().await {
+                let frame: Value = serde_json::from_str(&text).unwrap();
+                worker_inbound.serve_frame(&frame).await;
+            }
+        });
+        let route_task_id = task.clone();
+        let route_task = tokio::spawn(async move {
+            while let Some(text) = worker_to_home_rx.recv().await {
+                assert!(route_worker_frame(&route_task_id, &text));
+            }
+        });
+        let home_task = tokio::spawn(async move {
+            while let Some(frame) = home.next_frame().await {
+                home.handle_frame(frame, &home_to_worker_tx).await;
+            }
+        });
+        let client = worker.client(job, token, format!("cloud:{task}"), worker_to_home_tx);
+        let key = cache_key('b');
+        let body = vec![0x5a; CACHE_CHUNK_BYTES * 2 + 17];
+        assert_eq!(client.get(&key).await.unwrap(), None);
+        client.put(&key, &body).await.unwrap();
+        assert_eq!(client.stat(&key).await.unwrap(), Some(body.len() as u64));
+        assert_eq!(client.get(&key).await.unwrap(), Some(body));
+        client.delete(&key).await.unwrap();
+        assert_eq!(client.get(&key).await.unwrap(), None);
+        drop(client);
+        route_task.abort();
+        home_task.abort();
+        inbound_task.abort();
+    }
+
+    #[tokio::test]
+    async fn loopback_webdav_sidecar_serves_the_sccache_method_set() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = HomeCacheStore::new_for_test(temp.path().join("cache"), 4 * 1024 * 1024);
+        let task = format!("task-test-{}", uuid::Uuid::new_v4());
+        let job = format!("remote-test-{}", uuid::Uuid::new_v4());
+        let token = uuid::Uuid::new_v4().simple().to_string();
+        let mut home = HomeCacheSession::register(&task, &job, &token, store).unwrap();
+        let (home_to_worker_tx, mut home_to_worker_rx) = mpsc::channel::<String>(64);
+        let (worker_to_home_tx, mut worker_to_home_rx) = mpsc::channel::<String>(64);
+        let worker = WorkerCacheRelay::default();
+        let worker_inbound = worker.clone();
+        let inbound_task = tokio::spawn(async move {
+            while let Some(text) = home_to_worker_rx.recv().await {
+                let frame: Value = serde_json::from_str(&text).unwrap();
+                worker_inbound.serve_frame(&frame).await;
+            }
+        });
+        let route_task_id = task.clone();
+        let route_task = tokio::spawn(async move {
+            while let Some(text) = worker_to_home_rx.recv().await {
+                assert!(route_worker_frame(&route_task_id, &text));
+            }
+        });
+        let home_task = tokio::spawn(async move {
+            while let Some(frame) = home.next_frame().await {
+                home.handle_frame(frame, &home_to_worker_tx).await;
+            }
+        });
+        let relay_client = worker.client(job, token, format!("cloud:{task}"), worker_to_home_tx);
+        let sidecar = WorkerCacheSidecar::start(relay_client).await.unwrap();
+        let http = reqwest::Client::builder().no_proxy().build().unwrap();
+        let root = format!("{}/", sidecar.endpoint());
+        let propfind = Method::from_bytes(b"PROPFIND").unwrap();
+        let response = http.request(propfind.clone(), &root).send().await.unwrap();
+        assert_eq!(response.status(), StatusCode::MULTI_STATUS);
+        let root_xml = response.text().await.unwrap();
+        assert!(root_xml.contains("<D:collection/>"));
+        assert!(root_xml.contains("<D:getlastmodified>"));
+
+        let key = cache_key('d');
+        let object_url = format!("{}/{key}", sidecar.endpoint());
+        assert_eq!(
+            http.get(&object_url).send().await.unwrap().status(),
+            StatusCode::NOT_FOUND
+        );
+        let body = vec![0xa5; CACHE_CHUNK_BYTES + 31];
+        assert_eq!(
+            http.put(&object_url)
+                .body(body.clone())
+                .send()
+                .await
+                .unwrap()
+                .status(),
+            StatusCode::CREATED
+        );
+        let response = http.get(&object_url).send().await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.bytes().await.unwrap().as_ref(), body.as_slice());
+        let response = http.request(propfind, &object_url).send().await.unwrap();
+        assert_eq!(response.status(), StatusCode::MULTI_STATUS);
+        let object_xml = response.text().await.unwrap();
+        assert!(object_xml.contains(&format!(
+            "<D:getcontentlength>{}</D:getcontentlength>",
+            body.len()
+        )));
+        assert!(object_xml.contains("<D:resourcetype/>"));
+
+        drop(sidecar);
+        route_task.abort();
+        home_task.abort();
+        inbound_task.abort();
+    }
+
+    #[tokio::test]
+    async fn wrong_relay_capability_never_enters_the_home_session() {
+        let temp = tempfile::tempdir().unwrap();
+        let task = format!("task-test-{}", uuid::Uuid::new_v4());
+        let job = format!("remote-test-{}", uuid::Uuid::new_v4());
+        let token = uuid::Uuid::new_v4().simple().to_string();
+        let store = HomeCacheStore::new_for_test(temp.path().join("cache"), 1024 * 1024);
+        let mut home = HomeCacheSession::register(&task, &job, &token, store).unwrap();
+        let frame = json!({
+            "t":REMOTE_CACHE_REQUEST_KIND,
+            "id":job,
+            "relay_token":uuid::Uuid::new_v4().simple().to_string(),
+            "request_id":uuid::Uuid::new_v4().simple().to_string(),
+            "op":"stat",
+            "key":cache_key('c'),
+        });
+        assert!(route_worker_frame(&task, &frame.to_string()));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), home.next_frame())
+                .await
+                .is_err()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- make the attachment-backed home relay the default durable `sccache` transport for Codex Cloud jobs
- expose a loopback-only WebDAV sidecar on each worker and transfer cache objects through the existing authenticated attachment
- scope every relay to one task/job capability, validate content-addressed keys, bound objects/chunks/job writes, verify digests, and keep cache frames out of the general worker reply broadcast
- persist per-repository cache data under the owner-private Intendant state root with a configurable 20 GiB default ceiling and oldest-file eviction
- automatically exempt the loopback sidecar from both Cloud proxy variable spellings while preserving inherited/user bypass entries
- pipeline two cache transfers and piggyback the first chunk so high-latency attachment transport does not serialize every object round trip
- retain the existing direct external-backend path behind `INTENDANT_REMOTE_CACHE_TRANSPORT=direct`
- document custody, limits, configuration, ephemeral target loss, and the fact that Cloud CPU capacity is measured per lease rather than promised by the environment name

## End-to-end Codex Cloud acceptance

Task: [task_e_6a6e7e5942508321be9c3061daae8cb2](https://chatgpt.com/codex/tasks/task_e_6a6e7e5942508321be9c3061daae8cb2)

- exact code-under-test worker revision: `0ee0aa5d102be055fdae6e58e57e55b62e4448d0` (the current head adds documentation only)
- exact macOS controller artifact: `intendant 0.1.0 (commit 0ee0aa5d, built 2026-08-01T23:01:26Z, aarch64-apple-darwin)` from successful Actions run 30722451964
- attachment connected through the Tailscale HTTPS terminator; revision and clean-tree requirements both passed
- no `NO_PROXY`/`no_proxy` override was supplied to either build
- command: `cargo test -p intendant-core --lib --no-run` with a fresh `/tmp/intendant-cache-final-target`

Cold job `remote-26b0f1c0-b2dd-482e-9a53-d645a804add1`:

- exit 0 in 328,284 ms
- 0 hits, 141 misses, 141 writes, 0 cache errors
- exact worker revision and clean workspace after completion

The target directory was then moved aside by job `remote-d3da459f-3089-418a-81ef-970109cbfd67` (exit 0), forcing an identical build to reconstruct a new target tree.

Warm job `remote-a66b082d-0e30-43cd-a925-283a18b4a856`:

- exit 0 in 201,989 ms (38.5% faster than the cold run)
- 141 hits, 0 misses, 0 writes, 0 cache errors
- exact worker revision and clean workspace after completion
- 142 home-side cache objects occupy 85 MiB after the proof

This also fixes the earlier live failure where Cloud's Envoy proxy intercepted the worker's `127.0.0.1` WebDAV request (`Loopback targets forbidden`). The prior serialized 141-hit replay took 279,870 ms on the same effective 2-vCPU quota; the pipelined replay is 27.8% faster.

## Capacity caveat

This acceptance worker exposed cpuset `0-2` and `nproc` reported 3, but cgroup `cpu.max` was `200000 100000`, so its effective quota was two CPU-core equivalents; Intendant's quota-aware fingerprint correctly reported `cpus: 2`. Earlier tasks exposed larger allocations. Current [official Cloud environment documentation](https://learn.chatgpt.com/docs/environments/cloud-environment) specifies isolated containers and setup caching but no fixed vCPU/RAM size or machine-tier selector. The PR therefore documents capacity as a measured lease property, not an environment guarantee. Offloading still protects the Mac from local contention, but Cloud must not be described as consistently faster than the M5 Pro.

## Validation

- `cargo check -p intendant --bin intendant` (Linux fleet)
- `cargo clippy -p intendant --bin intendant -- -D warnings` (Linux fleet)
- `cargo test -p intendant --bin intendant remote_compute:: -- --nocapture` — 18 passed
- final relay-focused tests — 5 passed
- attachment reply/private-cache routing test — passed
- live local `sccache 0.15.0` WebDAV compatibility probe — miss, write, then hit
- hermetic loopback WebDAV GET/PUT/PROPFIND/MKCOL contract test — passed
- `cargo fmt --all` and `git diff --check`
- prior code head passed Ubuntu, macOS, Windows, fragment, and check workflows; current docs-only head is running the merge-gate matrix
