### PR TITLE
update copy honesty: install-alongside sentence on every update surface

### DIFF
--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -958,6 +958,11 @@ Unified administration for how dashboards and daemons reach each other:
   become Files/Terminal targets and expose no such actions.
   The pane also hosts the per-peer messaging/task/approval quick controls and
   capability routing, both in collapsed poweruser folds.
+  The **Daemon update** panel lives here too — the release/dev update checks,
+  producing a newer build, and the same one-click swap the bottom-corner
+  update chip offers. The update installs alongside the current version —
+  running sessions finish uninterrupted, and the old version may keep running
+  until they are done.
 - **People & Devices** owns the user/client domain. It shows your identity on
   this daemon, a guided grant flow (who → identity details → role → active or
   draft) with a role-card picker and advanced identity metadata folded away,

--- a/src/bin/caller/web_gateway/static_assets.rs
+++ b/src/bin/caller/web_gateway/static_assets.rs
@@ -669,6 +669,35 @@ mod tests {
         assert_eq!(asset.body, VAULT_KERNEL_JS.as_bytes());
     }
 
+    /// The update-copy honesty pin: the update chip, the Daemon update
+    /// panel, and the swap confirm affordance each state the same plain
+    /// sentence — installs alongside, running sessions finish
+    /// uninterrupted, the old version may keep running while they do.
+    /// Pinned against the served bytes (and the docs chapter) so a
+    /// rewording that drops the honest bounds fails here instead of
+    /// shipping.
+    #[test]
+    fn update_copy_honesty_sentence_is_pinned() {
+        const SENTENCE: &str = "The update installs alongside the current version — running sessions finish uninterrupted, and the old version may keep running until they are done.";
+        let served = APP_HTML.matches(SENTENCE).count();
+        assert_eq!(
+            served, 3,
+            "the served dashboard must state the update-copy honesty sentence \
+             on exactly its three surfaces (update chip, Daemon update panel, \
+             swap confirm) — found {served}; edit the static/app/ fragments \
+             and regenerate with `cargo run -p app-html-assembler`"
+        );
+        let chapter_path = concat!(env!("CARGO_MANIFEST_DIR"), "/docs/src/web-dashboard.md");
+        let chapter = std::fs::read_to_string(chapter_path)
+            .expect("docs/src/web-dashboard.md is part of the checkout");
+        assert_eq!(
+            chapter.matches(SENTENCE).count(),
+            1,
+            "docs/src/web-dashboard.md must state the same update-copy \
+             honesty sentence exactly once"
+        );
+    }
+
     #[test]
     fn vault_kernel_override_serves_disk_sibling() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/bin/caller/web_gateway/static_assets.rs
+++ b/src/bin/caller/web_gateway/static_assets.rs
@@ -690,8 +690,11 @@ mod tests {
         let chapter_path = concat!(env!("CARGO_MANIFEST_DIR"), "/docs/src/web-dashboard.md");
         let chapter = std::fs::read_to_string(chapter_path)
             .expect("docs/src/web-dashboard.md is part of the checkout");
+        // The chapter hard-wraps prose, so match against the
+        // whitespace-normalized text.
+        let chapter_flat = chapter.split_whitespace().collect::<Vec<_>>().join(" ");
         assert_eq!(
-            chapter.matches(SENTENCE).count(),
+            chapter_flat.matches(SENTENCE).count(),
             1,
             "docs/src/web-dashboard.md must state the same update-copy \
              honesty sentence exactly once"

--- a/static/app.html
+++ b/static/app.html
@@ -38373,7 +38373,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '4f1f5f15bb56cf65';
+const INTENDANT_APP_BUILD = 'b316762ffdaefe1a';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -104718,6 +104718,12 @@ async function memoryProposeFromForm(button) {
       honesty.textContent = update.honesty;
       mount.appendChild(honesty);
     }
+    // The pinned honesty sentence — byte-identical on every update surface
+    // (static_assets.rs pins the served copy).
+    const bounds = document.createElement('div');
+    bounds.className = 'update-lane-note';
+    bounds.textContent = 'The update installs alongside the current version — running sessions finish uninterrupted, and the old version may keep running until they are done.';
+    mount.appendChild(bounds);
     mount.appendChild(handoverUpdateActions(body, disk));
   }
 
@@ -104886,6 +104892,12 @@ async function memoryProposeFromForm(button) {
         `provenance unreadable${update.probe_error ? ` (${update.probe_error})` : ''}`
       ));
     }
+    // The pinned honesty sentence — byte-identical on every update surface
+    // (static_assets.rs pins the served copy).
+    const bounds = document.createElement('div');
+    bounds.className = 'handover-update-note';
+    bounds.textContent = 'The update installs alongside the current version — running sessions finish uninterrupted, and the old version may keep running until they are done.';
+    el.appendChild(bounds);
     if (body.swap_result && body.swap_result.ok === false && !updateAction.note) {
       const failed = document.createElement('div');
       failed.className = 'handover-update-note';
@@ -105423,6 +105435,10 @@ async function memoryProposeFromForm(button) {
       window.intendantHandoverUpdate.renderSwapSection(swap);
     }
 
+    // The pinned honesty sentence — byte-identical on every update surface
+    // (static_assets.rs pins the served copy).
+    line(card, 'update-lane-footer',
+      'The update installs alongside the current version — running sessions finish uninterrupted, and the old version may keep running until they are done.');
     line(card, 'update-lane-footer',
       'Updates happen only on your click here — nothing installs or restarts automatically.');
     mount.appendChild(card);

--- a/static/app/ui2-handover.js
+++ b/static/app/ui2-handover.js
@@ -151,6 +151,12 @@
       honesty.textContent = update.honesty;
       mount.appendChild(honesty);
     }
+    // The pinned honesty sentence — byte-identical on every update surface
+    // (static_assets.rs pins the served copy).
+    const bounds = document.createElement('div');
+    bounds.className = 'update-lane-note';
+    bounds.textContent = 'The update installs alongside the current version — running sessions finish uninterrupted, and the old version may keep running until they are done.';
+    mount.appendChild(bounds);
     mount.appendChild(handoverUpdateActions(body, disk));
   }
 
@@ -319,6 +325,12 @@
         `provenance unreadable${update.probe_error ? ` (${update.probe_error})` : ''}`
       ));
     }
+    // The pinned honesty sentence — byte-identical on every update surface
+    // (static_assets.rs pins the served copy).
+    const bounds = document.createElement('div');
+    bounds.className = 'handover-update-note';
+    bounds.textContent = 'The update installs alongside the current version — running sessions finish uninterrupted, and the old version may keep running until they are done.';
+    el.appendChild(bounds);
     if (body.swap_result && body.swap_result.ok === false && !updateAction.note) {
       const failed = document.createElement('div');
       failed.className = 'handover-update-note';

--- a/static/app/ui2-update-lane.js
+++ b/static/app/ui2-update-lane.js
@@ -278,6 +278,10 @@
       window.intendantHandoverUpdate.renderSwapSection(swap);
     }
 
+    // The pinned honesty sentence — byte-identical on every update surface
+    // (static_assets.rs pins the served copy).
+    line(card, 'update-lane-footer',
+      'The update installs alongside the current version — running sessions finish uninterrupted, and the old version may keep running until they are done.');
     line(card, 'update-lane-footer',
       'Updates happen only on your click here — nothing installs or restarts automatically.');
     mount.appendChild(card);


### PR DESCRIPTION
The update chip, the Daemon update panel, and the swap confirm affordance
each state the same plain sentence: the update installs alongside the
current version, running sessions finish uninterrupted, and the old
version may keep running until they are done. web-dashboard.md (Access ->
Daemons) gains the same sentence, and static_assets pins the served copy
(exactly three surfaces) plus the docs occurrence by test.
