### PR TITLE
dashboard: update actions in the Cmd/Ctrl-K palette

### DIFF
--- a/src/bin/caller/handover/mod.rs
+++ b/src/bin/caller/handover/mod.rs
@@ -1037,6 +1037,83 @@ mod tests {
         }
     }
 
+    /// The Cmd/Ctrl-K palette's update verbs are pure affordance
+    /// re-exposure — the emission-shape law: the chip module keeps the
+    /// only swap emissions (one relay POST, one webview bridge, one
+    /// takeover POST), the panel module the only check POSTs through
+    /// its one `updateLanePost`, and the palette fragment carries no
+    /// update wire shape at all — it reaches both solely through the
+    /// named composition surfaces. The dynamic entry is served by the
+    /// chip module itself (`paletteEntry`), so its label tracks exactly
+    /// the state the chip renders, and the chip's drain suppression is
+    /// inherited, never re-derived.
+    #[test]
+    fn palette_reexposes_update_affordances_through_one_emitter() {
+        let chrome = include_str!("../../../../static/app/ui2-chrome.js");
+        let chip = include_str!("../../../../static/app/ui2-handover.js");
+        let lane = include_str!("../../../../static/app/ui2-update-lane.js");
+        // Both entries exist and their labels carry 'update' — the
+        // palette matches labels only (users type what they see).
+        assert!(chrome.contains("label: 'Check for updates'"));
+        assert!(chrome.contains("updateChipSurface.paletteEntry"));
+        assert!(chrome.contains("window.qa.paletteUpdateActions"));
+        // The chip module serves the dynamic entry; its labels state
+        // the live arm (install / installing / hand off), and its
+        // suppression rule is the chip's own.
+        for needle in [
+            "paletteEntry: updatePaletteEntry",
+            "`Install ${what}`",
+            "`Installing ${what}…`",
+            "Update: hand off to :${successor.port}",
+            "if (!update || body.draining) return null;",
+        ] {
+            assert!(
+                chip.contains(needle),
+                "ui2-handover lost the palette snapshot wiring: {needle}"
+            );
+        }
+        // Emission shapes, unweakened and unduplicated: the swap wires
+        // live once each in the chip module (chip buttons and palette
+        // runs all route through the two named perform* functions), and
+        // every lane POST goes through the panel's one authedFetch.
+        assert_eq!(chip.matches("/api/daemon/update-swap").count(), 1);
+        assert_eq!(chip.matches("/api/daemon/takeover").count(), 1);
+        assert_eq!(chip.matches("messageHandlers.updateSwap").count(), 1);
+        assert_eq!(chip.matches("authedFetch(").count(), 2);
+        assert_eq!(lane.matches("authedFetch(").count(), 1);
+        // Two call sites for the check path — the panel button and the
+        // palette seam — one POST function between them.
+        assert_eq!(lane.matches("'/api/daemon/update-lane/check'").count(), 2);
+        // The palette fragment carries none of the wire shapes: it may
+        // only reach the update lanes through the composition surfaces.
+        for banned in [
+            "/api/daemon/update-swap",
+            "/api/daemon/takeover",
+            "/api/daemon/update-lane",
+            "messageHandlers.updateSwap",
+            "authedFetch(",
+        ] {
+            assert_eq!(
+                chrome.matches(banned).count(),
+                0,
+                "ui2-chrome must not carry the update wire shape {banned:?}"
+            );
+        }
+        // And the served bundle carries the whole wiring.
+        let app = include_str!("../../../../static/app.html");
+        for needle in [
+            "label: 'Check for updates'",
+            "window.qa.paletteUpdateActions",
+            "paletteEntry: updatePaletteEntry",
+            "window.intendantUpdateLane",
+        ] {
+            assert!(
+                app.contains(needle),
+                "the dashboard bundle lost the palette update actions: {needle}"
+            );
+        }
+    }
+
     #[test]
     fn initialize_registers_presence_and_takes_free_lease() {
         let dir = tempfile::tempdir().unwrap();

--- a/static/app.html
+++ b/static/app.html
@@ -36789,6 +36789,38 @@ function ui2PaletteActionEntries(q) {
       }
     }
   }
+  // Update verbs (CONTRACT: ui2-handover.js and ui2-update-lane.js are
+  // later fragments — their surfaces are read by name at event time,
+  // hidden entirely when absent. The chip module stays the ONE swap
+  // emitter and the panel the one check path; these entries only
+  // re-expose them). The dynamic install entry exists exactly while the
+  // chip serves a one-click affordance — its label carries the live
+  // state, and a busy affordance renders inert, like the chip's
+  // disabled button.
+  const updateChipSurface = window.intendantHandoverUpdate;
+  if (updateChipSurface && typeof updateChipSurface.paletteEntry === 'function') {
+    let served = null;
+    try { served = updateChipSurface.paletteEntry(); } catch (_) { served = null; }
+    if (served && served.label && typeof served.run === 'function') {
+      entries.push({
+        section: 'Actions', icon: 'daemon', label: String(served.label),
+        inert: served.busy === true,
+        run: () => { try { served.run(); } catch (e) { console.warn('[ui2] update action failed', e); } },
+      });
+    }
+  }
+  const updateLane = window.intendantUpdateLane;
+  if (updateLane && typeof updateLane.check === 'function') {
+    entries.push({
+      section: 'Actions', icon: 'daemon', label: 'Check for updates',
+      run: () => {
+        routeTo('access', 'daemons');
+        try { updateLane.check(); } catch (e) { console.warn('[ui2] update check failed', e); }
+        const card = document.getElementById('update-lane-card');
+        if (card) card.scrollIntoView({ block: 'start' });
+      },
+    });
+  }
   // The theme toggle keeps its palette seat.
   const light = typeof ui2Theme === 'function' && ui2Theme() === 'light';
   entries.push({
@@ -36961,6 +36993,17 @@ function ui2WirePalette() {
     }
   }, true);
 }
+
+// QA vector (tokenless posture): the palette's update verbs as data —
+// exactly what a palette query 'update' yields from the Actions lane,
+// through the same label-only match the palette itself applies. The
+// dynamic entry tracks the chip-served state; probes drive that state
+// synthetically via qa.handoverUpdateChip.render(body), then re-read
+// this.
+window.qa = window.qa || {};
+window.qa.paletteUpdateActions = () => ui2PaletteActionEntries('update')
+  .filter((item) => !item.matchless && String(item.label).toLowerCase().includes('update'))
+  .map((item) => ({ label: String(item.label), inert: item.inert === true }));
 
 // ── Fuel/lease chip (display-only) ─────────────────────────────────────
 // When the daemon's status reports the built-in agent unfueled but the
@@ -38373,7 +38416,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '4f1f5f15bb56cf65';
+const INTENDANT_APP_BUILD = '25b978807f04d3e9';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -104721,6 +104764,50 @@ async function memoryProposeFromForm(button) {
     mount.appendChild(handoverUpdateActions(body, disk));
   }
 
+  // The one-click's behavior, NAMED: the chip button and the palette's
+  // dynamic entry both invoke this — the webview bridge or the daemon
+  // relay, one implementation, never a second swap path.
+  function performOneClickSwap(body) {
+    if (updateAction.inFlight || relayPendingNow(lastHandoverBody)) return;
+    if (window.__intendantAppSupervisor === true) {
+      updateAction.inFlight = true;
+      updateAction.note = 'Starting the new daemon — this dashboard reloads when it takes over; in-flight sessions finish on the old one.';
+      try {
+        window.webkit.messageHandlers.updateSwap.postMessage(null);
+      } catch (_) {
+        updateAction.inFlight = false;
+        updateAction.note = 'Could not reach the app supervisor.';
+      }
+      handoverUpdateRender(body);
+    } else {
+      updateAction.relayRequestedMs = Date.now();
+      relayUpdateSwap(body);
+    }
+  }
+
+  // The unsupervised arm's hand-off, equally named for both surfaces:
+  // ask THIS daemon to drain toward an already-running newer daemon.
+  async function performTakeoverHandoff(successor, body) {
+    if (updateAction.inFlight) return;
+    updateAction.inFlight = true;
+    updateAction.note = `Asking this daemon to drain — :${successor.port} takes over.`;
+    handoverUpdateRender(body);
+    try {
+      const resp = await authedFetch('/api/daemon/takeover', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ requested_by: 'dashboard update chip' }),
+      });
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      updateAction.note = 'Draining — in-flight sessions finish here, then this daemon exits.';
+    } catch (err) {
+      updateAction.note = `Hand-off failed from this surface: ${(err && err.message) || err}`;
+    } finally {
+      updateAction.inFlight = false;
+      if (lastHandoverBody) handoverUpdateRender(lastHandoverBody);
+    }
+  }
+
   // The co-homed daemon a hand-off would drain toward: live, not this
   // boot, not already on its way out. Prefer one whose build matches the
   // on-disk update.
@@ -104754,23 +104841,7 @@ async function memoryProposeFromForm(button) {
       const btn = document.createElement('button');
       btn.textContent = busy ? 'Updating…' : 'Update now';
       btn.disabled = busy;
-      btn.addEventListener('click', () => {
-        if (updateAction.inFlight || relayPendingNow(lastHandoverBody)) return;
-        if (window.__intendantAppSupervisor === true) {
-          updateAction.inFlight = true;
-          updateAction.note = 'Starting the new daemon — this dashboard reloads when it takes over; in-flight sessions finish on the old one.';
-          try {
-            window.webkit.messageHandlers.updateSwap.postMessage(null);
-          } catch (_) {
-            updateAction.inFlight = false;
-            updateAction.note = 'Could not reach the app supervisor.';
-          }
-          handoverUpdateRender(body);
-        } else {
-          updateAction.relayRequestedMs = Date.now();
-          relayUpdateSwap(body);
-        }
-      });
+      btn.addEventListener('click', () => performOneClickSwap(body));
       actions.appendChild(btn);
     } else {
       const successor = handoverSuccessorCandidate(body, disk);
@@ -104779,26 +104850,7 @@ async function memoryProposeFromForm(button) {
         const btn = document.createElement('button');
         btn.textContent = `Hand off to :${successor.port}${matches ? ' (runs the on-disk build)' : ''}`;
         btn.disabled = updateAction.inFlight;
-        btn.addEventListener('click', async () => {
-          if (updateAction.inFlight) return;
-          updateAction.inFlight = true;
-          updateAction.note = `Asking this daemon to drain — :${successor.port} takes over.`;
-          handoverUpdateRender(body);
-          try {
-            const resp = await authedFetch('/api/daemon/takeover', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ requested_by: 'dashboard update chip' }),
-            });
-            if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-            updateAction.note = 'Draining — in-flight sessions finish here, then this daemon exits.';
-          } catch (err) {
-            updateAction.note = `Hand-off failed from this surface: ${(err && err.message) || err}`;
-          } finally {
-            updateAction.inFlight = false;
-            if (lastHandoverBody) handoverUpdateRender(lastHandoverBody);
-          }
-        });
+        btn.addEventListener('click', () => performTakeoverHandoff(successor, body));
         actions.appendChild(btn);
       } else {
         const reach = document.createElement('div');
@@ -105123,13 +105175,49 @@ async function memoryProposeFromForm(button) {
     render: (body) => handoverRender(body),
   };
 
-  // The update panel's composition hook (production, not QA): the panel
-  // registers its swap mount here and this module keeps it honest.
+  // The palette's dynamic entry, as data (ui2-chrome reads this by name
+  // at event time): the SAME one-click affordance the chip is currently
+  // serving, or null — no update on disk, a drain in motion (the chip's
+  // own suppression), and the honest no-reach arm all serve no action,
+  // so the palette shows none. Labels say what happens NOW and always
+  // carry 'update' (the palette matches labels only — users type what
+  // they see); `busy` mirrors the chip button's disabled state.
+  function updatePaletteEntry() {
+    const body = lastHandoverBody;
+    const update = body && body.update;
+    if (!update || body.draining) return null;
+    const disk = update.on_disk;
+    const tag = disk ? String(disk.git_sha || disk.version || '').slice(0, 10) : '';
+    const what = tag ? `update ${tag}` : 'update (binary changed on disk)';
+    const supervised = window.__intendantAppSupervisor === true
+      || (body && body.app_supervised === true);
+    if (supervised) {
+      const busy = updateAction.inFlight || relayPendingNow(body);
+      return {
+        label: busy ? `Installing ${what}…` : `Install ${what}`,
+        busy,
+        run: () => performOneClickSwap(body),
+      };
+    }
+    const successor = handoverSuccessorCandidate(body, disk);
+    if (!successor) return null;
+    const matches = disk && successor.version && successor.version.git_sha === disk.git_sha;
+    return {
+      label: `Update: hand off to :${successor.port}${matches ? ' (runs the on-disk build)' : ''}`,
+      busy: updateAction.inFlight,
+      run: () => performTakeoverHandoff(successor, body),
+    };
+  }
+
+  // The update panel's and palette's composition hooks (production, not
+  // QA): the panel registers its swap mount here, the palette asks for
+  // the served one-click as data — this module keeps both honest.
   window.intendantHandoverUpdate = {
     renderSwapSection: (mount) => {
       panelSwapMount = mount;
       fillPanelSwapSection();
     },
+    paletteEntry: updatePaletteEntry,
   };
 
   function handoverStart() {
@@ -105453,6 +105541,29 @@ async function memoryProposeFromForm(button) {
       schedulePoll(false);
     }, immediate ? 400 : (busy ? UPDATE_LANE_BUSY_POLL_MS : UPDATE_LANE_POLL_MS));
   }
+
+  // The palette's 'Check for updates' seam (production, not QA): the
+  // SAME consent POST the panel's check button sends, for the channel
+  // this install natively follows per the served catalog (source → dev,
+  // else releases; a channel the payload marks uncheckable falls back
+  // to the other) — never a new check path. Routing to the panel is the
+  // caller's job; the click lands here so the panel's in-flight latch,
+  // notes, and poll cadence stay the one story. A missing block (first
+  // poll not landed, or a daemon without the lane) no-ops honestly.
+  function nativeCheckChannel() {
+    const block = lastBlock;
+    if (!block) return null;
+    const native = block.flavor === 'source' ? 'dev' : 'releases';
+    if (channelInfo(block, native).check) return native;
+    const other = native === 'dev' ? 'releases' : 'dev';
+    return channelInfo(block, other).check ? other : null;
+  }
+  window.intendantUpdateLane = {
+    check: () => {
+      const channel = nativeCheckChannel();
+      if (channel) updateLanePost('/api/daemon/update-lane/check', channel);
+    },
+  };
 
   function start() {
     poll().then(() => schedulePoll(false));

--- a/static/app/ui2-chrome.js
+++ b/static/app/ui2-chrome.js
@@ -706,6 +706,38 @@ function ui2PaletteActionEntries(q) {
       }
     }
   }
+  // Update verbs (CONTRACT: ui2-handover.js and ui2-update-lane.js are
+  // later fragments — their surfaces are read by name at event time,
+  // hidden entirely when absent. The chip module stays the ONE swap
+  // emitter and the panel the one check path; these entries only
+  // re-expose them). The dynamic install entry exists exactly while the
+  // chip serves a one-click affordance — its label carries the live
+  // state, and a busy affordance renders inert, like the chip's
+  // disabled button.
+  const updateChipSurface = window.intendantHandoverUpdate;
+  if (updateChipSurface && typeof updateChipSurface.paletteEntry === 'function') {
+    let served = null;
+    try { served = updateChipSurface.paletteEntry(); } catch (_) { served = null; }
+    if (served && served.label && typeof served.run === 'function') {
+      entries.push({
+        section: 'Actions', icon: 'daemon', label: String(served.label),
+        inert: served.busy === true,
+        run: () => { try { served.run(); } catch (e) { console.warn('[ui2] update action failed', e); } },
+      });
+    }
+  }
+  const updateLane = window.intendantUpdateLane;
+  if (updateLane && typeof updateLane.check === 'function') {
+    entries.push({
+      section: 'Actions', icon: 'daemon', label: 'Check for updates',
+      run: () => {
+        routeTo('access', 'daemons');
+        try { updateLane.check(); } catch (e) { console.warn('[ui2] update check failed', e); }
+        const card = document.getElementById('update-lane-card');
+        if (card) card.scrollIntoView({ block: 'start' });
+      },
+    });
+  }
   // The theme toggle keeps its palette seat.
   const light = typeof ui2Theme === 'function' && ui2Theme() === 'light';
   entries.push({
@@ -878,6 +910,17 @@ function ui2WirePalette() {
     }
   }, true);
 }
+
+// QA vector (tokenless posture): the palette's update verbs as data —
+// exactly what a palette query 'update' yields from the Actions lane,
+// through the same label-only match the palette itself applies. The
+// dynamic entry tracks the chip-served state; probes drive that state
+// synthetically via qa.handoverUpdateChip.render(body), then re-read
+// this.
+window.qa = window.qa || {};
+window.qa.paletteUpdateActions = () => ui2PaletteActionEntries('update')
+  .filter((item) => !item.matchless && String(item.label).toLowerCase().includes('update'))
+  .map((item) => ({ label: String(item.label), inert: item.inert === true }));
 
 // ── Fuel/lease chip (display-only) ─────────────────────────────────────
 // When the daemon's status reports the built-in agent unfueled but the

--- a/static/app/ui2-handover.js
+++ b/static/app/ui2-handover.js
@@ -154,6 +154,50 @@
     mount.appendChild(handoverUpdateActions(body, disk));
   }
 
+  // The one-click's behavior, NAMED: the chip button and the palette's
+  // dynamic entry both invoke this — the webview bridge or the daemon
+  // relay, one implementation, never a second swap path.
+  function performOneClickSwap(body) {
+    if (updateAction.inFlight || relayPendingNow(lastHandoverBody)) return;
+    if (window.__intendantAppSupervisor === true) {
+      updateAction.inFlight = true;
+      updateAction.note = 'Starting the new daemon — this dashboard reloads when it takes over; in-flight sessions finish on the old one.';
+      try {
+        window.webkit.messageHandlers.updateSwap.postMessage(null);
+      } catch (_) {
+        updateAction.inFlight = false;
+        updateAction.note = 'Could not reach the app supervisor.';
+      }
+      handoverUpdateRender(body);
+    } else {
+      updateAction.relayRequestedMs = Date.now();
+      relayUpdateSwap(body);
+    }
+  }
+
+  // The unsupervised arm's hand-off, equally named for both surfaces:
+  // ask THIS daemon to drain toward an already-running newer daemon.
+  async function performTakeoverHandoff(successor, body) {
+    if (updateAction.inFlight) return;
+    updateAction.inFlight = true;
+    updateAction.note = `Asking this daemon to drain — :${successor.port} takes over.`;
+    handoverUpdateRender(body);
+    try {
+      const resp = await authedFetch('/api/daemon/takeover', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ requested_by: 'dashboard update chip' }),
+      });
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      updateAction.note = 'Draining — in-flight sessions finish here, then this daemon exits.';
+    } catch (err) {
+      updateAction.note = `Hand-off failed from this surface: ${(err && err.message) || err}`;
+    } finally {
+      updateAction.inFlight = false;
+      if (lastHandoverBody) handoverUpdateRender(lastHandoverBody);
+    }
+  }
+
   // The co-homed daemon a hand-off would drain toward: live, not this
   // boot, not already on its way out. Prefer one whose build matches the
   // on-disk update.
@@ -187,23 +231,7 @@
       const btn = document.createElement('button');
       btn.textContent = busy ? 'Updating…' : 'Update now';
       btn.disabled = busy;
-      btn.addEventListener('click', () => {
-        if (updateAction.inFlight || relayPendingNow(lastHandoverBody)) return;
-        if (window.__intendantAppSupervisor === true) {
-          updateAction.inFlight = true;
-          updateAction.note = 'Starting the new daemon — this dashboard reloads when it takes over; in-flight sessions finish on the old one.';
-          try {
-            window.webkit.messageHandlers.updateSwap.postMessage(null);
-          } catch (_) {
-            updateAction.inFlight = false;
-            updateAction.note = 'Could not reach the app supervisor.';
-          }
-          handoverUpdateRender(body);
-        } else {
-          updateAction.relayRequestedMs = Date.now();
-          relayUpdateSwap(body);
-        }
-      });
+      btn.addEventListener('click', () => performOneClickSwap(body));
       actions.appendChild(btn);
     } else {
       const successor = handoverSuccessorCandidate(body, disk);
@@ -212,26 +240,7 @@
         const btn = document.createElement('button');
         btn.textContent = `Hand off to :${successor.port}${matches ? ' (runs the on-disk build)' : ''}`;
         btn.disabled = updateAction.inFlight;
-        btn.addEventListener('click', async () => {
-          if (updateAction.inFlight) return;
-          updateAction.inFlight = true;
-          updateAction.note = `Asking this daemon to drain — :${successor.port} takes over.`;
-          handoverUpdateRender(body);
-          try {
-            const resp = await authedFetch('/api/daemon/takeover', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ requested_by: 'dashboard update chip' }),
-            });
-            if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-            updateAction.note = 'Draining — in-flight sessions finish here, then this daemon exits.';
-          } catch (err) {
-            updateAction.note = `Hand-off failed from this surface: ${(err && err.message) || err}`;
-          } finally {
-            updateAction.inFlight = false;
-            if (lastHandoverBody) handoverUpdateRender(lastHandoverBody);
-          }
-        });
+        btn.addEventListener('click', () => performTakeoverHandoff(successor, body));
         actions.appendChild(btn);
       } else {
         const reach = document.createElement('div');
@@ -556,13 +565,49 @@
     render: (body) => handoverRender(body),
   };
 
-  // The update panel's composition hook (production, not QA): the panel
-  // registers its swap mount here and this module keeps it honest.
+  // The palette's dynamic entry, as data (ui2-chrome reads this by name
+  // at event time): the SAME one-click affordance the chip is currently
+  // serving, or null — no update on disk, a drain in motion (the chip's
+  // own suppression), and the honest no-reach arm all serve no action,
+  // so the palette shows none. Labels say what happens NOW and always
+  // carry 'update' (the palette matches labels only — users type what
+  // they see); `busy` mirrors the chip button's disabled state.
+  function updatePaletteEntry() {
+    const body = lastHandoverBody;
+    const update = body && body.update;
+    if (!update || body.draining) return null;
+    const disk = update.on_disk;
+    const tag = disk ? String(disk.git_sha || disk.version || '').slice(0, 10) : '';
+    const what = tag ? `update ${tag}` : 'update (binary changed on disk)';
+    const supervised = window.__intendantAppSupervisor === true
+      || (body && body.app_supervised === true);
+    if (supervised) {
+      const busy = updateAction.inFlight || relayPendingNow(body);
+      return {
+        label: busy ? `Installing ${what}…` : `Install ${what}`,
+        busy,
+        run: () => performOneClickSwap(body),
+      };
+    }
+    const successor = handoverSuccessorCandidate(body, disk);
+    if (!successor) return null;
+    const matches = disk && successor.version && successor.version.git_sha === disk.git_sha;
+    return {
+      label: `Update: hand off to :${successor.port}${matches ? ' (runs the on-disk build)' : ''}`,
+      busy: updateAction.inFlight,
+      run: () => performTakeoverHandoff(successor, body),
+    };
+  }
+
+  // The update panel's and palette's composition hooks (production, not
+  // QA): the panel registers its swap mount here, the palette asks for
+  // the served one-click as data — this module keeps both honest.
   window.intendantHandoverUpdate = {
     renderSwapSection: (mount) => {
       panelSwapMount = mount;
       fillPanelSwapSection();
     },
+    paletteEntry: updatePaletteEntry,
   };
 
   function handoverStart() {

--- a/static/app/ui2-update-lane.js
+++ b/static/app/ui2-update-lane.js
@@ -309,6 +309,29 @@
     }, immediate ? 400 : (busy ? UPDATE_LANE_BUSY_POLL_MS : UPDATE_LANE_POLL_MS));
   }
 
+  // The palette's 'Check for updates' seam (production, not QA): the
+  // SAME consent POST the panel's check button sends, for the channel
+  // this install natively follows per the served catalog (source → dev,
+  // else releases; a channel the payload marks uncheckable falls back
+  // to the other) — never a new check path. Routing to the panel is the
+  // caller's job; the click lands here so the panel's in-flight latch,
+  // notes, and poll cadence stay the one story. A missing block (first
+  // poll not landed, or a daemon without the lane) no-ops honestly.
+  function nativeCheckChannel() {
+    const block = lastBlock;
+    if (!block) return null;
+    const native = block.flavor === 'source' ? 'dev' : 'releases';
+    if (channelInfo(block, native).check) return native;
+    const other = native === 'dev' ? 'releases' : 'dev';
+    return channelInfo(block, other).check ? other : null;
+  }
+  window.intendantUpdateLane = {
+    check: () => {
+      const channel = nativeCheckChannel();
+      if (channel) updateLanePost('/api/daemon/update-lane/check', channel);
+    },
+  };
+
   function start() {
     poll().then(() => schedulePoll(false));
   }


### PR DESCRIPTION
Two 'Actions'-section entries in the Cmd/Ctrl-K palette (static/app/ui2-chrome.js), per agenda card 01KYZQ76S87E206HTWZYG474Z7:

- **Check for updates** (static): routes to the update panel (Access → Daemons) and fires the panel's own check POST through a new `window.intendantUpdateLane.check()` seam — the natively-followed channel per the served catalog (source → dev, else releases; falls back to the other checkable channel). Never a new check path.
- **Install update <short-sha>** (dynamic): served by the chip module itself via `window.intendantHandoverUpdate.paletteEntry()` — appears only while the chip serves a one-click affordance, labels the live arm ('Install update <sha10>'; 'Installing …' renders inert while busy; 'Update: hand off to :<port>' on the unsupervised arm), and is null while draining (the chip's own suppression, inherited never re-derived), when nothing is on disk, or on the honest no-reach arm.

One emitter: the chip's two click bodies are extracted verbatim into named `performOneClickSwap` / `performTakeoverHandoff`, called by the chip buttons and the palette runs alike; the palette fragment carries zero update wire shapes. Label-only matching per the palette's convention — typing 'update' hits both entries. Drain-suppression and supervisor-claim semantics untouched.

QA + pins:
- `window.qa.paletteUpdateActions()` — the palette's update verbs as data through the palette's own label match; proven live against a scratch mock daemon via `validate-dashboard.cjs --probe-json` (all arms: static-only, supervised install, drain-suppressed, takeover hand-off, cleared).
- `palette_reexposes_update_affordances_through_one_emitter` (handover/mod.rs): the emission-shape law — swap wires exactly once each in ui2-handover.js, lane POSTs through the one `updateLanePost`, banned outright in ui2-chrome.js, plus bundle needles.

Battery: `cargo test -p intendant --bins` ✓, lib-crate tests ✓, `cargo clippy --workspace -- -D warnings` ✓, `cargo fmt --check` ✓.