### PR TITLE
Release-lane hardening: preflights, keychain search-list verify, keepalives, provisioning recipe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,31 @@ jobs:
             exit 1
           fi
 
+      # Machine-tool preflight: the PGP lane needs gnupg and the publish
+      # step needs the gh CLI, but no dry-run exercises either (publish is
+      # tag-only; signing needs secrets), so a missing tool otherwise
+      # surfaces deep into a real tag build — the v0.1.0 ladder burned a
+      # run each on absent gnupg and absent gh. Fail a tag build here, in
+      # seconds; dispatch dry-runs warn and continue, changing nothing on
+      # paths that never reach those steps.
+      - name: Release tool preflight (gnupg, gh)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Self-hosted runner PATH may not include Homebrew (same export
+          # as the publish step).
+          export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+          missing=""
+          command -v gpg > /dev/null || missing="$missing gnupg"
+          command -v gh > /dev/null || missing="$missing gh"
+          if [ -n "$missing" ]; then
+            if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+              echo "::error::Missing on this runner:$missing — a tag release needs gnupg (PGP artifact signing) and the gh CLI (publish step). Install on the runner account (brew install$missing), then rerun."
+              exit 1
+            fi
+            echo "::warning::Missing on this runner:$missing — tolerable for a dry-run, but a tag release will fail this preflight. Install on the runner account: brew install$missing"
+          fi
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # The default persisted token grants every later step push access;

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -405,11 +405,19 @@ PGP signing key — `PGP_SIGN_KEY_B64`, `PGP_SIGN_KEY_PASSPHRASE`
    mint, rotation, and revocation ceremonies). The certify-only primary
    key never enters CI — only the signing subkey does, and it carries a
    two-year expiry as a dead-man switch.
-2. `base64 -i ~/.intendant/release-signing/secret-subkey-ci.asc | pbcopy`
-   → `PGP_SIGN_KEY_B64`; the escrow's `passphrase` file content →
-   `PGP_SIGN_KEY_PASSPHRASE`.
-3. The release runner needs `gpg` on PATH (`brew install gnupg` on the
-   fleet Mac); the workflow imports the subkey into a throwaway
+2. Provision both secrets deterministically with the gh CLI, straight from
+   the escrow files — stdin only, never clipboard hand-paste (a hand-pasted
+   `PGP_SIGN_KEY_PASSPHRASE` drifted from the escrow and failed the v0.1.0
+   tag run with `Bad passphrase`):
+
+   ```bash
+   base64 -i ~/.intendant/release-signing/secret-subkey-ci.asc | gh secret set PGP_SIGN_KEY_B64 --repo intendant-dev/Intendant
+   gh secret set PGP_SIGN_KEY_PASSPHRASE --repo intendant-dev/Intendant < ~/.intendant/release-signing/passphrase
+   ```
+3. The release runner needs `gpg` and the `gh` CLI on PATH
+   (`scripts/setup-macos.sh` installs both, and the workflow preflights
+   them at job start — a tag build missing either fails in seconds, not
+   after the build); the workflow imports the subkey into a throwaway
    `GNUPGHOME` under `RUNNER_TEMP` and removes it in an `always()`
    cleanup step.
 4. Before cutting a release, `scripts/release-pgp-dryrun.sh` rehearses

--- a/scripts/bundle-macos.sh
+++ b/scripts/bundle-macos.sh
@@ -58,6 +58,9 @@
 #                              codesign does not find identities in
 #                              out-of-search-list keychains (verified
 #                              empirically; --keychain alone is not enough).
+#                              Verified up front: an out-of-search-list
+#                              keychain fails the run immediately with the
+#                              remedy named, before the long build.
 #   INTENDANT_NOTARY_KEY_FILE  App Store Connect API private key (.p8) for
 #                              `notarytool`.
 #   INTENDANT_NOTARY_KEY_ID    Key ID of that API key.
@@ -91,6 +94,36 @@ PROFILE="${1:-release}"
 
 die() {
     echo "Error: $*" >&2
+    exit 1
+}
+
+# codesign resolves identities ONLY through the keychain search list — an
+# unlocked keychain passed via --keychain alone is not enough (verified
+# empirically). The search list is per-session state: a `security
+# list-keychains -s` write from a daemon/LaunchDaemon session (a CI
+# runner's service session) can fail to apply or persist, so a later run's
+# codesign dies with a bare "no identity found" long after the write
+# looked successful (v0.1.0 release, 2026-08-01). Verify instead of
+# trusting the write, and name the remedy.
+require_keychain_in_search_list() {
+    local keychain="$1"
+    if security list-keychains -d user | sed 's/^ *"//; s/"$//' | grep -qxF "$keychain"; then
+        return 0
+    fi
+    {
+        echo "Error: signing keychain is not in the user keychain search list:"
+        echo "  $keychain"
+        echo "codesign cannot find identities in out-of-search-list keychains, so"
+        echo "signing would fail later with a misleading 'identity not found'."
+        echo "A 'security list-keychains -s' write from this session type does"
+        echo "not stick — daemon/LaunchDaemon sessions (e.g. a CI runner"
+        echo "service) drop it. Fix it ONCE from an interactive ssh (or GUI)"
+        echo "session as this account:"
+        echo ""
+        echo "  security list-keychains -d user -s \"$keychain\" \$(security list-keychains -d user | tr -d '\"')"
+        echo ""
+        echo "then re-run this script."
+    } >&2
     exit 1
 }
 
@@ -128,6 +161,13 @@ case "$NOTARY_STATE" in
             || die "INTENDANT_NOTARY_KEY_FILE does not exist: $NOTARY_KEY_FILE"
         ;;
 esac
+
+# The release keychain must already be searchable (see the header note):
+# verify now, before the long build, not at codesign time.
+if [ -n "$SIGN_RELEASE_IDENTITY" ] && [ -n "$SIGN_RELEASE_KEYCHAIN" ]; then
+    [ -f "$SIGN_RELEASE_KEYCHAIN" ] || die "INTENDANT_SIGN_KEYCHAIN does not exist: $SIGN_RELEASE_KEYCHAIN"
+    require_keychain_in_search_list "$SIGN_RELEASE_KEYCHAIN"
+fi
 
 # --- Version stamp ----------------------------------------------------------
 # Release builds get the tag (workflow passes INTENDANT_APP_VERSION=v1.2.3);
@@ -484,6 +524,10 @@ CERTCONF
     echo "Signing app bundle..."
     security unlock-keychain -p "$SIGN_KEYCHAIN_PASS" "$SIGN_KEYCHAIN" 2>/dev/null
     if security find-identity -p codesigning "$SIGN_KEYCHAIN" 2>/dev/null | grep -q "$SIGN_IDENTITY"; then
+        # The identity is in the keychain (find-identity queries the file
+        # directly), but codesign resolves through the SEARCH LIST — verify
+        # it, or die with the remedy instead of an opaque codesign error.
+        require_keychain_in_search_list "$SIGN_KEYCHAIN"
         codesign --force --deep --keychain "$SIGN_KEYCHAIN" --sign "$SIGN_IDENTITY" "$APP"
         echo "Signed with '$SIGN_IDENTITY' (TCC grants will persist across recompiles)"
     else

--- a/scripts/deploy-connect-prod-alpha.sh
+++ b/scripts/deploy-connect-prod-alpha.sh
@@ -91,6 +91,12 @@ SSH_OPTS=(
     -i "$CONNECT_SSH_KEY"
     -o IdentitiesOnly=yes
     -o StrictHostKeyChecking=accept-new
+    # Keepalives: the remote build/restart legs sit at the far end of a
+    # long-idle connection, and a half-dead session once hung 35 minutes
+    # past a completed remote build. 15s probes × 4 misses ≈ fail within
+    # a minute instead.
+    -o ServerAliveInterval=15
+    -o ServerAliveCountMax=4
 )
 
 remote_quote() {

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -213,6 +213,34 @@ check_recording() {
     $all_ok
 }
 
+# Release-lane deps: the macOS release workflow (release.yml) runs on a
+# fleet Mac provisioned by this script — gnupg detach-signs the release
+# artifacts, the gh CLI publishes them. Both were absent on the fleet
+# runner and each cost a v0.1.0 release run (2026-08-01): the same
+# missing-machine-dep class as the libvpx incident.
+check_release_lane() {
+    local all_ok=true
+
+    echo ""
+    echo "Release-lane dependencies (CI release signing/publish):"
+
+    if has_cmd gpg; then
+        ok "gnupg ($(gpg --version 2>/dev/null | head -n1 | awk '{print $3}'))"
+    else
+        miss "gnupg" "brew install gnupg"
+        all_ok=false
+    fi
+
+    if has_cmd gh; then
+        ok "gh ($(gh --version 2>/dev/null | head -n1 | awk '{print $3}'))"
+    else
+        miss "gh" "brew install gh"
+        all_ok=false
+    fi
+
+    $all_ok
+}
+
 check_managed_browser() {
     local all_ok=true
 
@@ -435,12 +463,13 @@ run_check() {
     echo "  Intendant macOS Dependency Check"
     echo "════════════════════════════════════════════════════════"
 
-    local core_ok cu_ok audio_ok rec_ok browser_ok
+    local core_ok cu_ok audio_ok rec_ok browser_ok release_ok
     check_core         && core_ok=true  || core_ok=false
     check_computer_use && cu_ok=true    || cu_ok=false
     check_audio        && audio_ok=true || audio_ok=false
     check_recording    && rec_ok=true   || rec_ok=false
     check_managed_browser && browser_ok=true || browser_ok=false
+    check_release_lane && release_ok=true || release_ok=false
 
     check_wasm
 
@@ -471,6 +500,12 @@ run_check() {
         echo "  Browser workspaces: missing managed browser"
     fi
 
+    if $release_ok; then
+        echo "  Release lane (gpg/gh): ready"
+    else
+        echo "  Release lane (gpg/gh): missing dependencies"
+    fi
+
     echo ""
 }
 
@@ -493,6 +528,10 @@ run_install() {
     brew_install ffmpeg
     brew_install switchaudio-osx
     brew_install sox
+    # Release-lane tools (check_release_lane): gnupg's command is `gpg`,
+    # so gate on the command, not the formula name.
+    has_cmd gpg || brew_install gnupg
+    brew_install gh
 
     # Phase 3: Audio routing
     # Try Vortex first (preferred), fall back to BlackHole


### PR DESCRIPTION
The five in-repo halves of the v0.1.0 release failure ladder (agenda card 01KYYXFYG5YSQ4X0TWKN3CMN7F — each rung was a real machine-state gap fixed at operator level during the release; this makes them durable so the next release is one green run):

- **setup-macos.sh** — release-lane dependency checks + installs for gnupg and the gh CLI (both were absent on the fleet Mac runner; same missing-machine-dep class as the libvpx incident).
- **bundle-macos.sh** — verify the signing keychain is actually in the user keychain search list before codesign (both the release path and the local-dev path), failing loudly with the interactive-ssh-session remedy named. `security list-keychains -s` writes from daemon/LaunchDaemon sessions (CI runner services) don't stick, and codesign's resulting failure is opaque.
- **release.yml** — gnupg + gh preflight at job start: a tag build missing either fails in seconds instead of deep into a full build (publish is tag-only and signing needs secrets, so no dry-run structurally exercises these tools). Dispatch dry-runs warn and continue.
- **deploy-connect-prod-alpha.sh** — `ServerAliveInterval=15` + `ServerAliveCountMax=4` in SSH_OPTS (a half-dead session hung 35 minutes past a completed remote build; second specimen of the wedged-transfer class).
- **getting-started.md** — the deterministic `gh secret set < file` provisioning recipe replaces the pbcopy hand-paste ceremony that drifted `PGP_SIGN_KEY_PASSPHRASE` vs the escrow (runner said `Bad passphrase` while the local escrow signed clean).

Invariants held: no behavior change on green paths; fail-closed stays fail-closed; every new error names its remedy.

Note: dependabot #623 also touches release.yml (actions-group pin bumps); the hunks are disjoint — this PR inserts a step above the checkout line without modifying it — and dependabot auto-rebases.