### PR TITLE
Pin standing agenda suspension notification

### DIFF
--- a/src/bin/caller/agenda/scheduler.rs
+++ b/src/bin/caller/agenda/scheduler.rs
@@ -1682,7 +1682,7 @@ fn record_on_item(
     session_id: Option<String>,
     note: Option<String>,
 ) {
-    if let Err(err) = handle.record_occurrence(OccurrenceWriteBack {
+    match handle.record_occurrence(OccurrenceWriteBack {
         item_id: &spawn.item_id,
         effect_id: &spawn.effect_id,
         occurrence_id: &spawn.occurrence_id,
@@ -1690,11 +1690,74 @@ fn record_on_item(
         session_id,
         note,
     }) {
-        eprintln!(
-            "[agenda] occurrence write-back failed ({state} on {}): {err}",
-            spawn.item_id
-        );
+        Ok(item) => surface_suspension_trip(handle, spawn, state, &item),
+        Err(err) => {
+            eprintln!(
+                "[agenda] occurrence write-back failed ({state} on {}): {err}",
+                spawn.item_id
+            );
+        }
     }
+}
+
+/// Surface the exact healthy → suspended transition for a standing
+/// effect. The fold increments a failure streak by one per contributing
+/// terminal, so equality with the digest-bound threshold identifies the
+/// trip without another durable marker: values below it are still armed,
+/// values above it already surfaced, and re-approval resets the streak so
+/// a later trip can notify again.
+fn surface_suspension_trip(
+    handle: &AgendaHandle,
+    spawn: &SpawnOccurrence,
+    state: &str,
+    item: &super::types::AgendaItem,
+) {
+    let Some(effect) = item
+        .effects
+        .iter()
+        .find(|effect| effect.effect_id == spawn.effect_id)
+    else {
+        return;
+    };
+    let Some(recurrence) = effect.manifest.recurrence.as_ref() else {
+        return;
+    };
+    let Some(run) = effect
+        .last_run
+        .as_ref()
+        .filter(|run| run.occurrence_id == spawn.occurrence_id && run.state == state)
+    else {
+        return;
+    };
+    let contributes_failure = match state {
+        "failed" | "unknown" => true,
+        "completed" => matches!(
+            run.attestation
+                .as_ref()
+                .map(|attestation| attestation.outcome),
+            Some(
+                super::types::AttestationOutcome::Blocked
+                    | super::types::AttestationOutcome::Abandoned
+            )
+        ),
+        _ => false,
+    };
+    let threshold = recurrence.suspend_threshold();
+    if !contributes_failure || effect.consecutive_failures != threshold || !effect.suspended() {
+        return;
+    }
+    handle.bus().send(AppEvent::UserNotification {
+        session_id: None,
+        id: format!("agenda-session-suspended-{}", spawn.occurrence_id),
+        title: Some("Standing session suspended".to_string()),
+        text: format!(
+            "{} — suspended after {threshold} consecutive failures; re-approve the \
+             unchanged manifest to re-arm",
+            item.title
+        ),
+        urgency: crate::types::NotificationUrgency::Attention,
+        ts: now_ms(),
+    });
 }
 
 /// Journal `prepared` (fsync'd) → notify → journal `delivered`. Muted
@@ -4194,6 +4257,141 @@ mod tests {
             ),
             "the source line + batch ride the goal as a data prologue: {task}"
         );
+    }
+
+    /// The failure which reaches a standing manifest's reviewed threshold
+    /// surfaces one owner-facing suspension notice. Earlier failures are
+    /// silent, and later write-backs cannot repeat the transition notice.
+    #[test]
+    fn suspension_trip_notifies_once_at_exact_failure_threshold() {
+        let dir = tempfile::tempdir().unwrap();
+        let default_project = tempfile::tempdir().unwrap();
+        let handle = handle_with_default_project(dir.path(), default_project.path());
+        let item = handle
+            .apply(
+                AgendaCommand::Add {
+                    refs: Vec::new(),
+                    kind: AgendaKind::Task,
+                    title: "standing triage".into(),
+                    body: String::new(),
+                    tags: Vec::new(),
+                    due_ms: None,
+                    source: None,
+                },
+                None,
+            )
+            .unwrap();
+        let proposed = handle
+            .apply(
+                AgendaCommand::ProposeEffect {
+                    binding_refs: Vec::new(),
+                    id: item.id.clone(),
+                    goal: "triage pass".into(),
+                    fire_at_ms: now_ms(),
+                    orchestrate: false,
+                    interactive: None,
+                    recurrence: Some(RecurrenceSpec {
+                        every_ms: super::super::types::RECURRENCE_MIN_EVERY_MS,
+                        until_ms: None,
+                        max_occurrences: None,
+                        suspend_after_failures: Some(3),
+                    }),
+                    agent_config: None,
+                    source: None,
+                    trigger: None,
+                    project_root: None,
+                },
+                None,
+            )
+            .unwrap();
+        let effect_id = proposed.effects[0].effect_id.clone();
+        handle
+            .apply(
+                AgendaCommand::ApproveEffect {
+                    id: item.id.clone(),
+                    digest: proposed.effects[0].digest.clone(),
+                },
+                owner(),
+            )
+            .unwrap();
+
+        let mut rx = handle.bus().subscribe();
+        let mut spawn = SpawnOccurrence {
+            binding_refs: Vec::new(),
+            occurrence_id: String::new(),
+            item_id: item.id.clone(),
+            effect_id,
+            goal: "standing triage".into(),
+            orchestrate: false,
+            fire_at_ms: 1_000,
+            approved_at_ms: 0,
+            recurring: true,
+            interactive: false,
+            project_root: None,
+            agent_config: None,
+            provenance_session_id: None,
+            matched_item_ids: Vec::new(),
+            session_name: None,
+            attempt: 0,
+        };
+
+        for failure in 1..=4 {
+            spawn.occurrence_id = format!("occ-trip-{failure}");
+            record_on_item(
+                &handle,
+                &spawn,
+                "failed",
+                None,
+                Some(format!("failure {failure}")),
+            );
+
+            let effect = handle
+                .snapshot()
+                .into_iter()
+                .find(|candidate| candidate.id == item.id)
+                .unwrap()
+                .effects
+                .into_iter()
+                .find(|effect| effect.effect_id == spawn.effect_id)
+                .unwrap();
+            assert_eq!(effect.consecutive_failures, failure);
+            assert_eq!(effect.suspended(), failure >= 3);
+
+            let mut notifications = Vec::new();
+            while let Ok(event) = rx.try_recv() {
+                if let AppEvent::UserNotification {
+                    session_id,
+                    id,
+                    title,
+                    text,
+                    urgency,
+                    ..
+                } = event
+                {
+                    notifications.push((session_id, id, title, text, urgency));
+                }
+            }
+            if failure == 3 {
+                assert_eq!(
+                    notifications,
+                    vec![(
+                        None,
+                        "agenda-session-suspended-occ-trip-3".to_string(),
+                        Some("Standing session suspended".to_string()),
+                        "standing triage — suspended after 3 consecutive failures; \
+                         re-approve the unchanged manifest to re-arm"
+                            .to_string(),
+                        crate::types::NotificationUrgency::Attention,
+                    )],
+                    "the threshold crossing surfaces exactly one suspension notice"
+                );
+            } else {
+                assert!(
+                    notifications.is_empty(),
+                    "failure {failure} must not surface the transition: {notifications:?}"
+                );
+            }
+        }
     }
 
     /// Track AU: a STANDING manifest with executor pins fires occurrences


### PR DESCRIPTION
## Scope

- Resolve agenda item `01KY5Y3XECWF9D0606Z0AXTGP6`.
- Pin the exact below-threshold → threshold standing-session suspension notification transition.
- Run the owed agenda-triage reference smoke through Intendant's Codex Cloud remote-compute path.

## Change

- Route successful `record_on_item` write-backs through `surface_suspension_trip`.
- Emit one attention notification only when a failure-contributing terminal outcome first reaches the configured suspension threshold and the standing effect is actually suspended.
- Add `suspension_trip_notifies_once_at_exact_failure_threshold`, covering no notice at streaks 1/2, one notice at 3, and no repeat at 4.

## Validation

- GitHub Actions: Windows, macOS, Linux, check, generated-fragment, and WASM-relevance legs green. The first Linux run hit the pre-existing `refresh_reprobes_after_each_terminal_edge` `Text file busy` flake; its failed leg was rerun and passed. The new unit test passed in both Linux runs.
- Codex Cloud focused test: job `remote-ca5a6517-ad5c-4cfb-a306-36205435be32`, worker task `task_e_6a6e8eb9fae08321a876c37c6d50b27a`, exact revision `d91c11d0c67d3597aaf72c8d918fe2db20cba0cb`, exit 0, 1 passed / 0 failed, 25m 41s compile-and-test time, clean checkout.
- Codex Cloud agenda-triage E2E: job `remote-4efc95cc-bbba-4c56-a1d2-6d4c95ade7d6`, same exact revision, exit 0 in 38.9s, clean checkout. It exercised real WebSocket `create_session` ingress, distinct recorded project roots, supervised-session `intendant ctl` writes, owner approval, scheduled execution, and an immediate rerun. Evidence: 3 placements, exactly 1 summary, 0 disposals, frontier 0, `frontier empty, no action` on rerun, and unchanged approval/digest.

## Cloud acceptance notes

- The worker attached successfully through the explicitly trusted TLS-terminating proxy on daemon `:8769` and reported 2 vCPUs.
- The scratch-daemon smoke needed the companion `intendant-runtime` binary (`remote-39df7389-0471-4a95-9365-011257425cd6`, built in 22s) and an explicit `--no-sandbox` because this Codex Cloud kernel does not enforce Landlock. Those are test-harness requirements; the Mac daemon and repository configuration were not changed.
