### PR TITLE
dashboard: lineage pointer is shape-aware — same-window fold renders prose + scroll, cross-window focuses

### DIFF
--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -363,9 +363,16 @@ error for crash-frozen dirs), the window states them plainly ("Ended
 … : outcome" / "Died mid-turn — last activity …") instead of freezing
 on a mid-execution look, the status pill reads `Ended`/`Died` rather
 than a stale active phase, and a ghost whose lineage continued shows a
-clickable "continued as …" pointer derived from the shared
-resume-lineage resolver (`boot.continued_as`; the successor's state is
-joined client-side from its own card). Liveness itself stays
+"continued as …" pointer derived from the shared resume-lineage
+resolver (`boot.continued_as`; the successor's state is joined
+client-side from its own card). The pointer is shape-aware — never a
+link with no effect: when its target is folded into the same window
+(the dominant resume shape — the successor shares the backend id, so
+the chip already wears it and its transcript streams below the note)
+the pointer renders as prose ("this window continues live below") whose
+click scrolls to the tail; only a target in another window renders as a
+link, and its click force-focuses (opening if needed) that window and
+says so on hover. Liveness itself stays
 event/boot-derived — hydration never flips `ended` (the #637 stop-hide
 law), and the note is presentation of served facts. Fired sessions keep their derived names (the source
 item's title, or `workflow - node` for workflow nodes); an owner

--- a/scripts/validate-dashboard.cjs
+++ b/scripts/validate-dashboard.cjs
@@ -1648,16 +1648,32 @@ function loadDashboardLogHelperSandbox(appHtmlPath) {
   const helperSource = [
     constAssignmentSource(source, 'SESSION_TEXT_SIGNATURE_CHAR_LIMIT'),
     constAssignmentSource(source, 'SESSION_RENDERED_SIGNATURE_CHAR_LIMIT'),
+    // The signature span's content-alias path strips the supervision
+    // addendum, whose marker const lives in the identity fragment —
+    // extract the real value so the sandbox pins it, never a mirror.
+    constAssignmentSource(source, 'SESSION_SUPERVISION_ADDENDUM_MARKER'),
     sourceBetween(source, 'function compactSessionTextBounded', 'function utf8ByteLength'),
     sourceBetween(source, 'function sessionWindowTranscriptSignatureContent', 'function findSessionWindowHistoryIndexBySignatures'),
     sourceBetween(source, 'function sessionWindowHistoryNode', 'function isSessionWindowCommandOutputRecord'),
     sourceBetween(source, 'function isSessionWindowCommandOutputRecord', 'function commandOutputRecordOutputIds'),
     sourceBetween(source, 'function padTimestampPart', 'function formatLogTimestampTitle'),
+    // The lineage-pointer affordance plan (39-session-windows.js): the
+    // label/state/plan trio is pure by contract so both pointer shapes
+    // (same-window prose vs cross-window focusing link) pin here without
+    // a browser. shortSessionId is the label's one dependency;
+    // sessionWindowContinuationStateText reads the sandbox-provided
+    // sessionMetadataById map.
+    sourceBetween(source, 'function shortSessionId', 'function setDaemonSessionId'),
+    sourceBetween(source, 'function sessionWindowContinuationLabel', 'function sessionWindowContinuationTargetIsThisWindow'),
     `
 this.__helpers = {
   formatLogTimestampLabel,
   retargetSessionWindowHistoryItem,
   sessionWindowTranscriptSignaturesForRecord,
+  sessionWindowContinuationLabel,
+  sessionWindowContinuationStateText,
+  sessionWindowContinuationPlan,
+  sessionMetadataById,
 };
 `,
   ].join('\n');
@@ -1666,6 +1682,7 @@ this.__helpers = {
   const sandbox = {
     Element,
     Node,
+    sessionMetadataById: new Map(),
     document: {
       createElement() {
         throw new Error('dashboard log helper self-test does not render DOM content');
@@ -6106,6 +6123,11 @@ async function runSelfTest() {
     /unknown Station probe/,
   );
   assert.deepStrictEqual(parseArgs(['--station-probe', 'hidden-dock'], {}).stationProbes, ['dock-hidden']);
+  // Hermetic home for URL-building assertions: withLoopbackToken falls
+  // back to ~/.intendant/loopback-tokens/<port>.token, and a box that
+  // ever ran the harness holds tokens for these throwaway ports — the
+  // self-test must not read machine state it left behind itself.
+  const hermeticHomeEnv = { INTENDANT_HOME: path.join(os.tmpdir(), 'intendant-validate-self-test-void') };
   const launchParsed = parseArgs(
     [
       '--launch-dashboard',
@@ -6115,7 +6137,7 @@ async function runSelfTest() {
       '--no-presence',
       '--dashboard-timeout=5000',
     ],
-    {},
+    hermeticHomeEnv,
   );
   assert.strictEqual(launchParsed.launchDashboard, true);
   assert.strictEqual(dashboardLaunchPort(launchParsed), 8893);
@@ -6143,7 +6165,7 @@ async function runSelfTest() {
     '--no-tui',
     '--no-tls',
   ]);
-  const holdParsed = parseArgs(['--hold-dashboard', '--port', '8894', '--json'], {});
+  const holdParsed = parseArgs(['--hold-dashboard', '--port', '8894', '--json'], hermeticHomeEnv);
   assert.strictEqual(holdParsed.launchDashboard, true);
   assert.strictEqual(holdParsed.holdDashboard, true);
   assert.strictEqual(dashboardLaunchPort(holdParsed), 8894);
@@ -6302,6 +6324,56 @@ async function runSelfTest() {
       .some((signature) => liveSignatures.has(signature)),
     true,
   );
+  // Lineage-pointer affordance (agenda card 01KYRN634DYZEXN251N7JJXVY5):
+  // the same-window fold renders prose + scroll, a cross-window target a
+  // focusing link with a say-so hover, and no shape ever plans a dead
+  // link. Ids exercise the resume shape: same backend id, new wrapper.
+  const continuation = {
+    backendSessionId: 'b2b2b2b2-conversation',
+    sessionId: 'a1a1a1a1-wrapper-successor',
+    live: true,
+    source: 'claude-code',
+  };
+  const prosePlan = dashboardHelpers.sessionWindowContinuationPlan(
+    continuation,
+    true,
+    dashboardHelpers.sessionWindowContinuationStateText(continuation),
+  );
+  assert.strictEqual(prosePlan.kind, 'here');
+  assert.strictEqual(prosePlan.text, 'this window continues live below');
+  assert.strictEqual(prosePlan.text.includes('continued as'), false);
+  assert.ok(/scroll/i.test(prosePlan.title));
+  const linkPlan = dashboardHelpers.sessionWindowContinuationPlan(continuation, false, 'live');
+  assert.strictEqual(linkPlan.kind, 'link');
+  assert.strictEqual(linkPlan.text, 'continued as b2b2b2b2 (a1a1a1a1) — live');
+  assert.ok(/focus/i.test(linkPlan.title));
+  assert.strictEqual(dashboardHelpers.sessionWindowContinuationPlan(null, false, '').kind, 'none');
+  assert.strictEqual(dashboardHelpers.sessionWindowContinuationPlan({}, true, 'live').kind, 'none');
+  // A dead successor keeps the same-window prose honest…
+  const deadProse = dashboardHelpers.sessionWindowContinuationPlan(
+    { sessionId: 'a1a1a1a1-wrapper-successor', live: false },
+    true,
+    '',
+  );
+  assert.strictEqual(deadProse.kind, 'here');
+  assert.strictEqual(deadProse.text, 'this window continues below');
+  // …and the ended state joins from the successor's own card metadata.
+  dashboardHelpers.sessionMetadataById.set('a1a1a1a1-wrapper-successor', {
+    boot: { terminal: { outcome: 'completed', endedAt: '2026-07-30 00:24:32' } },
+  });
+  const endedState = dashboardHelpers.sessionWindowContinuationStateText({
+    sessionId: 'a1a1a1a1-wrapper-successor',
+    live: false,
+  });
+  assert.strictEqual(endedState, 'ended 2026-07-30 00:24:32 — completed');
+  const endedProse = dashboardHelpers.sessionWindowContinuationPlan(
+    { sessionId: 'a1a1a1a1-wrapper-successor', live: false },
+    true,
+    endedState,
+  );
+  assert.strictEqual(endedProse.kind, 'here');
+  assert.strictEqual(endedProse.text, `this window continues below — ${endedState}`);
+  dashboardHelpers.sessionMetadataById.delete('a1a1a1a1-wrapper-successor');
   assert.ok(waitFunctionExpression('document.body').includes('typeof candidate'));
   assert.ok(stationProbeExpression('rendered').includes('collectStationProbe'));
   assert.strictEqual(summarizeWaitValue(false), 'false');

--- a/src/bin/caller/web_gateway/session_catalog/grid_envelope.rs
+++ b/src/bin/caller/web_gateway/session_catalog/grid_envelope.rs
@@ -1006,10 +1006,17 @@ mod tests {
         );
         assert_eq!(relive["boot"]["continued_as"]["live"], true);
 
+        // The affordance split (card 01KYRN634DYZEXN251N7JJXVY5) must
+        // survive too: the cross-window pointer stays a link, the
+        // same-window fold renders prose — never a link with no effect.
         let fragment = include_str!("../../../../../static/app/39-session-windows.js");
         for needle in [
-            "continued as ${continuationLabel}",
+            "continued as ${label}",
             "session-window-terminal-continued",
+            "session-window-terminal-continued-here",
+            "this window continues",
+            "sessionWindowContinuationPlan(",
+            "sessionWindowContinuationTargetIsThisWindow(",
             "openSessionWindowForContinuation(",
         ] {
             assert!(

--- a/static/app.html
+++ b/static/app.html
@@ -4752,6 +4752,20 @@ html[data-ui2-closable-lens="on"] .session-window.session-window-closable {
 .session-window .session-window-terminal-continued:hover {
   text-decoration-style: solid;
 }
+/* Same-window fold (the resume shape): the pointer's target IS this
+   window — the successor's transcript streams below the note — so the
+   affordance is prose plus a courtesy scroll-to-tail, never a link that
+   goes nowhere. */
+.session-window .session-window-terminal-continued-here {
+  cursor: pointer;
+}
+.session-window .session-window-terminal-continued-here::after {
+  content: ' \2193';
+  opacity: 0.7;
+}
+.session-window .session-window-terminal-continued-here:hover {
+  text-decoration: underline dotted;
+}
 .session-window.minimized {
   min-height: 36px;
   max-height: 36px;
@@ -38416,7 +38430,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '25b978807f04d3e9';
+const INTENDANT_APP_BUILD = '6b02238ee1ae660a';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -62285,6 +62299,63 @@ function sessionWindowContinuationStateText(continuedAs) {
   return '';
 }
 
+// The pointer affordance contract (agenda card 01KYRN634DYZEXN251N7JJXVY5,
+// owner specimen 2026-07-30): never a link with no effect. In the dominant
+// live shape a resume shares the backend id, so the pointer's target is
+// folded into THIS window — the chip already wears the successor and its
+// transcript streams right below the note — and a "continued as
+// <own-chip-id>" link goes nowhere the owner can see. That shape renders
+// prose (plus a courtesy scroll to the tail); only a target OUTSIDE this
+// window renders the link, whose click force-focuses that window. Pure
+// (DOM-free) so the QA harness self-test pins both shapes.
+function sessionWindowContinuationPlan(continuedAs, sameWindow, stateText) {
+  const label = sessionWindowContinuationLabel(continuedAs);
+  if (!label) return { kind: 'none', text: '', title: '' };
+  const state = String(stateText || '').trim();
+  if (sameWindow) {
+    return {
+      kind: 'here',
+      text: state === 'live'
+        ? 'this window continues live below'
+        : `this window continues below${state ? ` — ${state}` : ''}`,
+      title: 'The continuation is this window\'s own transcript — click to scroll to the latest output',
+    };
+  }
+  return {
+    kind: 'link',
+    text: `continued as ${label}${state ? ` — ${state}` : ''}`,
+    title: `Focus the continuation's window — ${label}`,
+  };
+}
+
+// Is the pointer's target folded into THIS window? True when a target id
+// is one of the window's own identities (map key, merged backend/wrapper
+// ids) or when the target's row alias-folds into the same card (the
+// resume bridge: a shared id in sessionAliasIds). Decided at render time
+// against the same alias closure the fold uses — never fold order.
+function sessionWindowContinuationTargetIsThisWindow(win, sid, continuedAs) {
+  const targets = [continuedAs?.backendSessionId, continuedAs?.sessionId]
+    .map(id => String(id || '').trim())
+    .filter(Boolean);
+  if (!targets.length) return false;
+  const own = new Set([String(sid || '').trim()].filter(Boolean));
+  const meta = sessionMetadataById.get(String(sid || '').trim()) || {};
+  for (const id of [meta.backendSessionId, meta.intendantSessionId]) {
+    const value = String(id || '').trim();
+    if (value) own.add(value);
+  }
+  for (const [id, w] of sessionWindows) {
+    if (w === win) own.add(id);
+  }
+  if (targets.some(id => own.has(id))) return true;
+  for (const session of Array.isArray(_cachedSessions) ? _cachedSessions : []) {
+    const aliases = sessionAliasIds(session);
+    if (!aliases.length || !targets.some(id => aliases.includes(id))) continue;
+    if (aliases.some(id => own.has(id))) return true;
+  }
+  return false;
+}
+
 function openSessionWindowForContinuation(continuedAs) {
   const targets = [continuedAs?.backendSessionId, continuedAs?.sessionId]
     .map(id => String(id || '').trim())
@@ -62301,8 +62372,16 @@ function openSessionWindowForContinuation(continuedAs) {
     });
     Promise.resolve(hydrateSessionWindowIfEmpty(target)).catch(() => {});
   }
+  // An explicit pointer click must LAND: force past the composer-target
+  // focus veto (unforced, a foreign composer target silently swallows
+  // the click — the cross-window half of the dead-link card), then bring
+  // the window into the viewport.
   if (typeof focusSessionWindowFromLifecycle === 'function') {
-    focusSessionWindowFromLifecycle(target, {});
+    focusSessionWindowFromLifecycle(target, { force: true });
+  }
+  const targetWin = sessionWindows.get(target);
+  if (targetWin?.el?.scrollIntoView) {
+    targetWin.el.scrollIntoView({ block: 'nearest', inline: 'nearest' });
   }
 }
 
@@ -62331,8 +62410,10 @@ function renderSessionWindowTerminalNote(win, sid) {
     }
     win.terminalNote = note;
   }
-  const continuationLabel = sessionWindowContinuationLabel(statement.continuedAs);
-  const signature = `${statement.text}${continuationLabel}${sessionWindowContinuationStateText(statement.continuedAs)}`;
+  const stateText = sessionWindowContinuationStateText(statement.continuedAs);
+  const sameWindow = sessionWindowContinuationTargetIsThisWindow(win, sid, statement.continuedAs);
+  const plan = sessionWindowContinuationPlan(statement.continuedAs, sameWindow, stateText);
+  const signature = [statement.text, plan.kind, plan.text, plan.title].join('');
   if (note.dataset.signature === signature) return;
   note.dataset.signature = signature;
   note.textContent = '';
@@ -62340,18 +62421,32 @@ function renderSessionWindowTerminalNote(win, sid) {
   fact.className = 'session-window-terminal-fact';
   fact.textContent = statement.text;
   note.appendChild(fact);
-  if (continuationLabel) {
+  if (plan.kind === 'link') {
     const link = document.createElement('a');
     link.href = '#';
     link.className = 'session-window-terminal-continued';
-    const stateText = sessionWindowContinuationStateText(statement.continuedAs);
-    link.textContent = `continued as ${continuationLabel}${stateText ? ` — ${stateText}` : ''}`;
+    link.textContent = plan.text;
+    link.title = plan.title;
     link.addEventListener('click', (e) => {
       e.preventDefault();
       e.stopPropagation();
       openSessionWindowForContinuation(statement.continuedAs);
     });
     note.appendChild(link);
+  } else if (plan.kind === 'here') {
+    // Prose, not a link: the continuation IS this window's transcript.
+    // The click is a courtesy scroll to the live tail (40's follow lane).
+    const here = document.createElement('span');
+    here.className = 'session-window-terminal-continued-here';
+    here.textContent = plan.text;
+    here.title = plan.title;
+    here.addEventListener('click', (e) => {
+      e.stopPropagation();
+      if (typeof scrollSessionWindowToBottom === 'function') {
+        scrollSessionWindowToBottom(win);
+      }
+    });
+    note.appendChild(here);
   }
 }
 
@@ -65355,6 +65450,26 @@ window.qa = Object.assign(window.qa || {}, {
         id, anchor, proj, icon, text, tone,
       }))),
     }));
+  },
+  // Terminal-note pointer readback: the affordance plan the note renders
+  // for a window — {kind:'here'} prose on the same-window fold,
+  // {kind:'link'} on a cross-window target, never a dead link.
+  terminalNotePlan: (sessionId) => {
+    const sid = String(sessionId || '').trim();
+    const statement = sessionWindowTerminalStatement(sid);
+    if (!statement) return null;
+    const win = sessionWindows.get(sid) || null;
+    const sameWindow = !!win
+      && sessionWindowContinuationTargetIsThisWindow(win, sid, statement.continuedAs);
+    return {
+      text: statement.text,
+      sameWindow,
+      pointer: sessionWindowContinuationPlan(
+        statement.continuedAs,
+        sameWindow,
+        sessionWindowContinuationStateText(statement.continuedAs),
+      ),
+    };
   },
 });
 

--- a/static/app/12-styles-tasks-log.css
+++ b/static/app/12-styles-tasks-log.css
@@ -1025,6 +1025,20 @@ html[data-ui2-closable-lens="on"] .session-window.session-window-closable {
 .session-window .session-window-terminal-continued:hover {
   text-decoration-style: solid;
 }
+/* Same-window fold (the resume shape): the pointer's target IS this
+   window — the successor's transcript streams below the note — so the
+   affordance is prose plus a courtesy scroll-to-tail, never a link that
+   goes nowhere. */
+.session-window .session-window-terminal-continued-here {
+  cursor: pointer;
+}
+.session-window .session-window-terminal-continued-here::after {
+  content: ' \2193';
+  opacity: 0.7;
+}
+.session-window .session-window-terminal-continued-here:hover {
+  text-decoration: underline dotted;
+}
 .session-window.minimized {
   min-height: 36px;
   max-height: 36px;

--- a/static/app/39-session-windows.js
+++ b/static/app/39-session-windows.js
@@ -740,6 +740,63 @@ function sessionWindowContinuationStateText(continuedAs) {
   return '';
 }
 
+// The pointer affordance contract (agenda card 01KYRN634DYZEXN251N7JJXVY5,
+// owner specimen 2026-07-30): never a link with no effect. In the dominant
+// live shape a resume shares the backend id, so the pointer's target is
+// folded into THIS window — the chip already wears the successor and its
+// transcript streams right below the note — and a "continued as
+// <own-chip-id>" link goes nowhere the owner can see. That shape renders
+// prose (plus a courtesy scroll to the tail); only a target OUTSIDE this
+// window renders the link, whose click force-focuses that window. Pure
+// (DOM-free) so the QA harness self-test pins both shapes.
+function sessionWindowContinuationPlan(continuedAs, sameWindow, stateText) {
+  const label = sessionWindowContinuationLabel(continuedAs);
+  if (!label) return { kind: 'none', text: '', title: '' };
+  const state = String(stateText || '').trim();
+  if (sameWindow) {
+    return {
+      kind: 'here',
+      text: state === 'live'
+        ? 'this window continues live below'
+        : `this window continues below${state ? ` — ${state}` : ''}`,
+      title: 'The continuation is this window\'s own transcript — click to scroll to the latest output',
+    };
+  }
+  return {
+    kind: 'link',
+    text: `continued as ${label}${state ? ` — ${state}` : ''}`,
+    title: `Focus the continuation's window — ${label}`,
+  };
+}
+
+// Is the pointer's target folded into THIS window? True when a target id
+// is one of the window's own identities (map key, merged backend/wrapper
+// ids) or when the target's row alias-folds into the same card (the
+// resume bridge: a shared id in sessionAliasIds). Decided at render time
+// against the same alias closure the fold uses — never fold order.
+function sessionWindowContinuationTargetIsThisWindow(win, sid, continuedAs) {
+  const targets = [continuedAs?.backendSessionId, continuedAs?.sessionId]
+    .map(id => String(id || '').trim())
+    .filter(Boolean);
+  if (!targets.length) return false;
+  const own = new Set([String(sid || '').trim()].filter(Boolean));
+  const meta = sessionMetadataById.get(String(sid || '').trim()) || {};
+  for (const id of [meta.backendSessionId, meta.intendantSessionId]) {
+    const value = String(id || '').trim();
+    if (value) own.add(value);
+  }
+  for (const [id, w] of sessionWindows) {
+    if (w === win) own.add(id);
+  }
+  if (targets.some(id => own.has(id))) return true;
+  for (const session of Array.isArray(_cachedSessions) ? _cachedSessions : []) {
+    const aliases = sessionAliasIds(session);
+    if (!aliases.length || !targets.some(id => aliases.includes(id))) continue;
+    if (aliases.some(id => own.has(id))) return true;
+  }
+  return false;
+}
+
 function openSessionWindowForContinuation(continuedAs) {
   const targets = [continuedAs?.backendSessionId, continuedAs?.sessionId]
     .map(id => String(id || '').trim())
@@ -756,8 +813,16 @@ function openSessionWindowForContinuation(continuedAs) {
     });
     Promise.resolve(hydrateSessionWindowIfEmpty(target)).catch(() => {});
   }
+  // An explicit pointer click must LAND: force past the composer-target
+  // focus veto (unforced, a foreign composer target silently swallows
+  // the click — the cross-window half of the dead-link card), then bring
+  // the window into the viewport.
   if (typeof focusSessionWindowFromLifecycle === 'function') {
-    focusSessionWindowFromLifecycle(target, {});
+    focusSessionWindowFromLifecycle(target, { force: true });
+  }
+  const targetWin = sessionWindows.get(target);
+  if (targetWin?.el?.scrollIntoView) {
+    targetWin.el.scrollIntoView({ block: 'nearest', inline: 'nearest' });
   }
 }
 
@@ -786,8 +851,10 @@ function renderSessionWindowTerminalNote(win, sid) {
     }
     win.terminalNote = note;
   }
-  const continuationLabel = sessionWindowContinuationLabel(statement.continuedAs);
-  const signature = `${statement.text}${continuationLabel}${sessionWindowContinuationStateText(statement.continuedAs)}`;
+  const stateText = sessionWindowContinuationStateText(statement.continuedAs);
+  const sameWindow = sessionWindowContinuationTargetIsThisWindow(win, sid, statement.continuedAs);
+  const plan = sessionWindowContinuationPlan(statement.continuedAs, sameWindow, stateText);
+  const signature = [statement.text, plan.kind, plan.text, plan.title].join('');
   if (note.dataset.signature === signature) return;
   note.dataset.signature = signature;
   note.textContent = '';
@@ -795,18 +862,32 @@ function renderSessionWindowTerminalNote(win, sid) {
   fact.className = 'session-window-terminal-fact';
   fact.textContent = statement.text;
   note.appendChild(fact);
-  if (continuationLabel) {
+  if (plan.kind === 'link') {
     const link = document.createElement('a');
     link.href = '#';
     link.className = 'session-window-terminal-continued';
-    const stateText = sessionWindowContinuationStateText(statement.continuedAs);
-    link.textContent = `continued as ${continuationLabel}${stateText ? ` — ${stateText}` : ''}`;
+    link.textContent = plan.text;
+    link.title = plan.title;
     link.addEventListener('click', (e) => {
       e.preventDefault();
       e.stopPropagation();
       openSessionWindowForContinuation(statement.continuedAs);
     });
     note.appendChild(link);
+  } else if (plan.kind === 'here') {
+    // Prose, not a link: the continuation IS this window's transcript.
+    // The click is a courtesy scroll to the live tail (40's follow lane).
+    const here = document.createElement('span');
+    here.className = 'session-window-terminal-continued-here';
+    here.textContent = plan.text;
+    here.title = plan.title;
+    here.addEventListener('click', (e) => {
+      e.stopPropagation();
+      if (typeof scrollSessionWindowToBottom === 'function') {
+        scrollSessionWindowToBottom(win);
+      }
+    });
+    note.appendChild(here);
   }
 }
 
@@ -3810,6 +3891,26 @@ window.qa = Object.assign(window.qa || {}, {
         id, anchor, proj, icon, text, tone,
       }))),
     }));
+  },
+  // Terminal-note pointer readback: the affordance plan the note renders
+  // for a window — {kind:'here'} prose on the same-window fold,
+  // {kind:'link'} on a cross-window target, never a dead link.
+  terminalNotePlan: (sessionId) => {
+    const sid = String(sessionId || '').trim();
+    const statement = sessionWindowTerminalStatement(sid);
+    if (!statement) return null;
+    const win = sessionWindows.get(sid) || null;
+    const sameWindow = !!win
+      && sessionWindowContinuationTargetIsThisWindow(win, sid, statement.continuedAs);
+    return {
+      text: statement.text,
+      sameWindow,
+      pointer: sessionWindowContinuationPlan(
+        statement.continuedAs,
+        sameWindow,
+        sessionWindowContinuationStateText(statement.continuedAs),
+      ),
+    };
   },
 });
 


### PR DESCRIPTION
Implements agenda card 01KYRN634DYZEXN251N7JJXVY5 (owner specimen 2026-07-30 00:31: clicked `continued as 12195e65 (34706612) — live` on the window whose chip already read 12195e65 — nothing happened).

**Live fold shapes verified first** (served catalog, 800 rows): all 37 rows carrying `boot.continued_as` are the same-card resume shape — `continued_as.backend_session_id` equals the row's own backend id (new wrapper id parenthetical), so the pointer's primary label IS the window's chip and `openSessionWindowForContinuation` resolves back to the window rendering it. Zero cross-card rows live today, but the server serves them (grid_envelope's `gl4` edit-branch retirement test: parent/child with different backend ids), so both shapes get real affordances.

- **Same-window fold** → prose, never a link: `this window continues live below` (dead successor stays honest: `… — ended <when> — <outcome>` joined from the successor's own card). Click is a courtesy scroll to the live tail through `scrollSessionWindowToBottom` (the follow/jump lane).
- **Cross-window target** → the link stays, click **force-focuses** the target window (`focusSessionWindowFromLifecycle {force:true}` — unforced, a foreign composer target silently swallowed the click even cross-window) then `scrollIntoView`; hover title says so.
- **Never a no-op link**: no target → no pointer; detection (`sessionWindowContinuationTargetIsThisWindow`) checks the window's identity set plus the `sessionAliasIds` closure — the same alias bridge the fold uses, decided at render time, never fold order.

**Reconciliation**: the #650 dominance ladder, #669 fold semantics, terminal statement, and `resolveSessionWindowBootMeta` are untouched — this is affordance-layer only. The 663/664/670 drafts all merged before this branch was cut; touch surface disjoint (session-window chrome, not ui2-agenda).

**Coverage**: harness `--self-test` extracts the pure label/state/plan trio and pins both shapes + the dead-successor state join (no browser); `grid_envelope.rs` fragment-needle pin extended to the plan split (`session-window-terminal-continued-here`, `this window continues`, plan/detection markers); `window.qa.terminalNotePlan` readback for live probes.

**Rides along, both pre-existing self-test breakages on main it had to clear**: (1) URL-building asserts read the box's real `~/.intendant/loopback-tokens` residue — the harness's own past runs mint tokens for its throwaway ports 8893/8894, failing the self-test on any box that ever ran it; now a hermetic `INTENDANT_HOME`. (2) the transcript-signature span references `SESSION_SUPERVISION_ADDENDUM_MARKER` (fragment 31) that the sandbox never extracted — latent, masked by (1) aborting first. Self-test PASSES end-to-end now.

SPA changes ride the fragments; `static/app.html` regenerated by the assembler.