### PR TITLE
closable: interrupted-arc closability (worktree state + boot sweep audit)

### DIFF
--- a/src/bin/caller/boot_readopt.rs
+++ b/src/bin/caller/boot_readopt.rs
@@ -1963,7 +1963,8 @@ pub(crate) async fn run_boot_readopt_pass(
                 // need the lineage closure — the latter so a live or
                 // already-resumed successor settles them silently.
                 if let crate::commission_sweep::CommissionStanding::Wake(cref)
-                | crate::commission_sweep::CommissionStanding::CompletedUnattested(cref) = standing
+                | crate::commission_sweep::CommissionStanding::CompletedUnattested(cref) =
+                    standing
                 {
                     if let Some(sessions) = handle.occurrence_started_history(&cref.occurrence_id) {
                         history.insert(cref.occurrence_id.clone(), sessions);

--- a/src/bin/caller/boot_readopt.rs
+++ b/src/bin/caller/boot_readopt.rs
@@ -269,8 +269,9 @@ pub(crate) fn midwork_class(meta: &SessionMeta) -> Option<MidWorkClass> {
     None
 }
 
-/// The durable meta of a session dir, when one is readable.
-fn session_meta_for(home: &Path, session_id: &str) -> Option<SessionMeta> {
+/// The durable meta of a session dir, when one is readable. Shared with
+/// the commission sweep's interrupted-mid-arc consult.
+pub(crate) fn session_meta_for(home: &Path, session_id: &str) -> Option<SessionMeta> {
     let dir = crate::session_log::SessionLog::find_session_by_id_in_home(home, session_id)?;
     let raw = std::fs::read_to_string(dir.join("session_meta.json")).ok()?;
     serde_json::from_str::<SessionMeta>(&raw).ok()
@@ -1958,7 +1959,12 @@ pub(crate) async fn run_boot_readopt_pass(
             let mut history: std::collections::HashMap<String, Vec<String>> =
                 std::collections::HashMap::new();
             for standing in &standings {
-                if let crate::commission_sweep::CommissionStanding::Wake(cref) = standing {
+                // Wake candidates AND completed-unattested consults both
+                // need the lineage closure — the latter so a live or
+                // already-resumed successor settles them silently.
+                if let crate::commission_sweep::CommissionStanding::Wake(cref)
+                | crate::commission_sweep::CommissionStanding::CompletedUnattested(cref) = standing
+                {
                     if let Some(sessions) = handle.occurrence_started_history(&cref.occurrence_id) {
                         history.insert(cref.occurrence_id.clone(), sessions);
                     }

--- a/src/bin/caller/commission_sweep.rs
+++ b/src/bin/caller/commission_sweep.rs
@@ -636,7 +636,7 @@ mod tests {
             .iter()
             .filter_map(|standing| match standing {
                 CommissionStanding::Wake(cref) => Some(cref.occurrence_id.clone()),
-                CommissionStanding::List(..) => None,
+                CommissionStanding::List(..) | CommissionStanding::CompletedUnattested(_) => None,
             })
             .collect()
     }
@@ -657,9 +657,7 @@ mod tests {
         standings
             .iter()
             .filter_map(|standing| match standing {
-                CommissionStanding::CompletedUnattested(cref) => {
-                    Some(cref.occurrence_id.clone())
-                }
+                CommissionStanding::CompletedUnattested(cref) => Some(cref.occurrence_id.clone()),
                 _ => None,
             })
             .collect()
@@ -1084,7 +1082,10 @@ mod tests {
         };
         let plan = plan_sweep(
             home.path(),
-            vec![standing("occ-i", "sess-i"), standing("occ-done", "sess-done")],
+            vec![
+                standing("occ-i", "sess-i"),
+                standing("occ-done", "sess-done"),
+            ],
             &HashMap::new(),
             crate::session_activity::epoch_seconds(),
             &HashSet::new(),

--- a/src/bin/caller/commission_sweep.rs
+++ b/src/bin/caller/commission_sweep.rs
@@ -109,6 +109,15 @@ pub(crate) enum CommissionStanding {
     /// Owner lane: listed in the needs-you task with the reason —
     /// never woken, never re-fired.
     List(CommissionRef, String),
+    /// A `completed` transport terminal with NO attestation: the
+    /// write-back records the transport ending, not arc completion (the
+    /// 19:00 limit-wave class), so it may dress an interrupted mid-arc
+    /// seat as done. Whether the arc concluded needs the session's own
+    /// durable status — `plan_sweep` consults it and LISTS the
+    /// interrupted ones (never a wake: by sweep time the stranding
+    /// predates this boot, the stale-stranding law's lane); every other
+    /// completed run stays settled.
+    CompletedUnattested(CommissionRef),
 }
 
 /// The open-commission conjunction (the AO safe-to-stop rule read at
@@ -141,12 +150,6 @@ pub(crate) fn classify_commissions(
                 // not a silent stranding — idle-done stays down.
                 continue;
             }
-            if !matches!(run.state.as_str(), "failed" | "unknown") {
-                // `started` = a live (or co-homed) run owns it;
-                // `completed`/`missed` = settled terminals with their
-                // own lanes.
-                continue;
-            }
             if effect.next_fire_ms.is_some() {
                 // The planner will fire this effect again (armed
                 // standing series, trigger regeneration): machinery
@@ -161,6 +164,19 @@ pub(crate) fn classify_commissions(
                 run_state: run.state.clone(),
                 session_id: run.session_id.clone(),
             };
+            if run.state == "completed" {
+                // The interrupted-mid-arc blindness (2026-08-01 owner
+                // specimen): "completed" is a TRANSPORT ending, and
+                // unattested it proves nothing about the arc — the
+                // session's own status decides in plan_sweep.
+                standings.push(CommissionStanding::CompletedUnattested(cref));
+                continue;
+            }
+            if !matches!(run.state.as_str(), "failed" | "unknown") {
+                // `started` = a live (or co-homed) run owns it;
+                // `missed` = a settled terminal with its own lane.
+                continue;
+            }
             if run.state == "failed" {
                 standings.push(CommissionStanding::List(
                     cref,
@@ -221,13 +237,13 @@ pub(crate) fn plan_sweep(
 ) -> SweepPlan {
     let mut plan = SweepPlan::default();
     for standing in standings {
-        let (cref, session) = match standing {
+        let (cref, session, wake) = match standing {
             CommissionStanding::List(cref, reason) => {
                 plan.listed.push((cref, reason));
                 continue;
             }
             CommissionStanding::Wake(cref) => match cref.session_id.clone() {
-                Some(session) => (cref, session),
+                Some(session) => (cref, session, true),
                 // Unreachable by classification; fail toward the owner
                 // lane rather than dropping it.
                 None => {
@@ -238,6 +254,19 @@ pub(crate) fn plan_sweep(
                     continue;
                 }
             },
+            CommissionStanding::CompletedUnattested(cref) => {
+                let Some(session) = cref.session_id.clone() else {
+                    continue; // no session ever ran — nothing mid-arc
+                };
+                if !session_ended_interrupted(home, &session) {
+                    // The transport ending stands unchallenged: the
+                    // session's own durable status shows no
+                    // interrupted-mid-arc evidence — settled, today's
+                    // behavior.
+                    continue;
+                }
+                (cref, session, false)
+            }
         };
         let mut seeds: Vec<String> = lineage_history
             .get(&cref.occurrence_id)
@@ -265,6 +294,19 @@ pub(crate) fn plan_sweep(
             // The mid-work pass already dispatched this lineage's
             // resume; the commission rides that seat and the readopt
             // summary reports its outcome.
+            continue;
+        }
+        if !wake {
+            // The interrupted-mid-arc lane: a "completed"-dressed run
+            // whose seat's durable status says interrupted, with no
+            // live or already-resumed lineage — LISTED, never woken
+            // (prior-boot by construction; the stale-stranding law).
+            plan.listed.push((
+                cref,
+                "ended interrupted mid-task without attesting — the arc looks unconcluded; \
+                 resume the session by hand or re-approve the manifest"
+                    .to_string(),
+            ));
             continue;
         }
         let mut candidate = ReadoptCandidate {
@@ -484,6 +526,15 @@ pub(crate) fn report_sweep(
     }
 }
 
+/// Whether the session's own durable status says it ended interrupted —
+/// the arc evidence a "completed" transport terminal cannot see. Read
+/// through the shared meta reader; an unreadable meta claims nothing.
+fn session_ended_interrupted(home: &Path, session_id: &str) -> bool {
+    crate::boot_readopt::session_meta_for(home, session_id)
+        .and_then(|meta| meta.status)
+        .is_some_and(|status| status == "interrupted")
+}
+
 fn short_id(id: &str) -> &str {
     id.get(..8).unwrap_or(id)
 }
@@ -597,7 +648,19 @@ mod tests {
                 CommissionStanding::List(cref, reason) => {
                     Some((cref.occurrence_id.clone(), reason.clone()))
                 }
-                CommissionStanding::Wake(_) => None,
+                CommissionStanding::Wake(_) | CommissionStanding::CompletedUnattested(_) => None,
+            })
+            .collect()
+    }
+
+    fn completed_unattested_occurrences(standings: &[CommissionStanding]) -> Vec<String> {
+        standings
+            .iter()
+            .filter_map(|standing| match standing {
+                CommissionStanding::CompletedUnattested(cref) => {
+                    Some(cref.occurrence_id.clone())
+                }
+                _ => None,
             })
             .collect()
     }
@@ -706,6 +769,37 @@ mod tests {
             listed[0].0 == "occ-spawnless" && listed[0].1.contains("before its session"),
             "the spawnless fail-close goes to the owner lane: {listed:?}"
         );
+        assert_eq!(
+            completed_unattested_occurrences(&standings),
+            vec!["occ-completed".to_string()],
+            "an unattested completed run on an OPEN item is never ignorable — \
+             plan_sweep consults the seat's own status"
+        );
+    }
+
+    /// The next-fire guard bounds the interrupted-mid-arc consult
+    /// exactly as it bounds the wake lane: an armed standing series'
+    /// completed occurrence stays silent — the planner carries the
+    /// continuity.
+    #[test]
+    fn armed_series_completed_run_stays_settled() {
+        let fresh = HashSet::new();
+        let items = vec![item(
+            "i-armed-completed",
+            "open",
+            effect(
+                "occ-armed-completed",
+                "completed",
+                Some("sess-1"),
+                json!({}),
+                json!({"next_fire_ms": 12345u64}),
+            ),
+        )];
+        let standings = classify_commissions(&items, &fresh);
+        assert!(
+            standings.is_empty(),
+            "an armed series' completed run is settled: {standings:?}"
+        );
     }
 
     /// The idle-done exclusion by name: an attested run — ANY outcome,
@@ -713,7 +807,10 @@ mod tests {
     /// not a silent stranding, and the seat stays down.
     #[test]
     fn idle_done_seats_stay_down() {
-        let fresh: HashSet<String> = ["occ-a", "occ-b"].into_iter().map(String::from).collect();
+        let fresh: HashSet<String> = ["occ-a", "occ-b", "occ-c"]
+            .into_iter()
+            .map(String::from)
+            .collect();
         let items = vec![
             item(
                 "i-achieved",
@@ -734,6 +831,19 @@ mod tests {
                     "failed",
                     Some("sess-2"),
                     json!({"attestation": {"outcome": "blocked", "at_ms": 2}}),
+                    json!({}),
+                ),
+            ),
+            // An attested completed run never reaches the
+            // interrupted-mid-arc consult: the self-report settles it.
+            item(
+                "i-attested-completed",
+                "open",
+                effect(
+                    "occ-c",
+                    "completed",
+                    Some("sess-3"),
+                    json!({"attestation": {"outcome": "achieved", "at_ms": 2}}),
                     json!({}),
                 ),
             ),
@@ -949,6 +1059,56 @@ mod tests {
             crate::session_activity::epoch_seconds(),
             &HashSet::new(),
             &dispatched,
+        );
+        assert!(plan.wakes.is_empty() && plan.listed.is_empty());
+    }
+
+    /// The interrupted-mid-arc lane end to end: a "completed"-dressed
+    /// unattested run whose seat's durable status says interrupted is
+    /// LISTED with the arc-unconcluded reason — never woken; a seat
+    /// whose status shows a clean end stays settled (today's behavior);
+    /// a live lineage settles it silently (the running seat owns it).
+    #[test]
+    fn completed_unattested_interrupted_seat_is_listed() {
+        let home = tempfile::tempdir().unwrap();
+        write_status(home.path(), "sess-i", "interrupted");
+        write_status(home.path(), "sess-done", "completed");
+        let standing = |occ: &str, session: &str| {
+            CommissionStanding::CompletedUnattested(CommissionRef {
+                occurrence_id: occ.to_string(),
+                item_id: "i-1".to_string(),
+                item_title: format!("commission {occ}"),
+                run_state: "completed".to_string(),
+                session_id: Some(session.to_string()),
+            })
+        };
+        let plan = plan_sweep(
+            home.path(),
+            vec![standing("occ-i", "sess-i"), standing("occ-done", "sess-done")],
+            &HashMap::new(),
+            crate::session_activity::epoch_seconds(),
+            &HashSet::new(),
+            &HashSet::new(),
+        );
+        assert!(plan.wakes.is_empty(), "the lane never wakes");
+        assert_eq!(plan.listed.len(), 1, "only the interrupted seat lists");
+        assert_eq!(plan.listed[0].0.occurrence_id, "occ-i");
+        assert!(
+            plan.listed[0].1.contains("interrupted mid-task")
+                && plan.listed[0].1.contains("arc looks unconcluded"),
+            "the reason names the class: {}",
+            plan.listed[0].1
+        );
+
+        // A live wrapper in the lineage settles the consult silently.
+        let live: HashSet<String> = ["sess-i".to_string()].into_iter().collect();
+        let plan = plan_sweep(
+            home.path(),
+            vec![standing("occ-i", "sess-i")],
+            &HashMap::new(),
+            crate::session_activity::epoch_seconds(),
+            &live,
+            &HashSet::new(),
         );
         assert!(plan.wakes.is_empty() && plan.listed.is_empty());
     }

--- a/src/bin/caller/web_gateway/session_catalog/grid_envelope.rs
+++ b/src/bin/caller/web_gateway/session_catalog/grid_envelope.rs
@@ -311,7 +311,10 @@ fn worktree_state_json(state: &crate::worktree_inventory::WorktreeGitState) -> s
         "state": state.kind.as_str(),
         "checked_ms": state.checked_ms,
     });
-    if matches!(state.kind, WorktreeStateKind::Clean | WorktreeStateKind::Dirty) {
+    if matches!(
+        state.kind,
+        WorktreeStateKind::Clean | WorktreeStateKind::Dirty
+    ) {
         block["dirty"] = serde_json::Value::Bool(state.dirty);
         block["unpushed"] = serde_json::Value::Bool(state.unpushed);
         block["ahead"] = serde_json::json!(state.ahead);
@@ -1216,7 +1219,7 @@ mod tests {
             "Interrupted mid-work — resumable",
             "CLOSABLE_CLAIM_QA_VECTORS",
             "closableClaim: {",
-            "worktreeStranded: !!(ws && (ws.dirty || ws.unpushed))",
+            "const worktreeStranded = !!(ws && (ws.dirty || ws.unpushed));",
         ] {
             assert!(
                 actions.contains(needle),

--- a/src/bin/caller/web_gateway/session_catalog/grid_envelope.rs
+++ b/src/bin/caller/web_gateway/session_catalog/grid_envelope.rs
@@ -205,6 +205,21 @@ impl GridEnvelopeJoins {
             row["agenda"] = block;
         }
 
+        // Worktree state — the stranded-work axis (dirty / unpushed /
+        // ahead), probed from the daemon's worktree knowledge
+        // (worktree_inventory's serve-time memo). Attached post
+        // row-cache like the other blocks: tree state moves without
+        // touching the session dir. The path comes from the row's own
+        // recorded linkage; without linkage, a cwd or project root
+        // under a `.worktrees` directory (the external-seat convention)
+        // qualifies — never a main checkout, whose dirtiness says
+        // nothing about THIS session's arc. Missing/unknown serve
+        // state-only: honest ignorance, never a guessed clean.
+        if let Some(path) = row_worktree_path(row) {
+            let state = crate::worktree_inventory::cached_worktree_git_state(&path);
+            row["worktree_state"] = worktree_state_json(&state);
+        }
+
         let (Some(boot), Some(live)) = (self.boot.as_ref(), self.live_wrappers.as_ref()) else {
             return;
         };
@@ -261,6 +276,50 @@ impl GridEnvelopeJoins {
         }
         row["boot"] = boot_block;
     }
+}
+
+/// The checkout path whose git state speaks for this row's arc:
+/// recorded worktree linkage first (session_meta.json, native worktree
+/// launches), else a cwd/project-root under a `.worktrees` directory —
+/// the convention external seats create their own checkouts under. A
+/// main checkout never qualifies: its dirtiness is the merge target's,
+/// not this session's.
+fn row_worktree_path(row: &serde_json::Value) -> Option<PathBuf> {
+    if let Some(path) = row["worktree"]["path"].as_str().filter(|s| !s.is_empty()) {
+        return Some(PathBuf::from(path));
+    }
+    for key in ["cwd", "project_root"] {
+        if let Some(path) = row[key].as_str().filter(|s| !s.is_empty()) {
+            let path = Path::new(path);
+            if path
+                .components()
+                .any(|component| component.as_os_str() == ".worktrees")
+            {
+                return Some(path.to_path_buf());
+            }
+        }
+    }
+    None
+}
+
+/// The `worktree_state` wire block: `state` always; the probed facts
+/// (`dirty`/`unpushed`/`ahead`, `branch`) only when the probe answered
+/// (`clean`/`dirty`) — `missing`/`unknown` carry no fact fields.
+fn worktree_state_json(state: &crate::worktree_inventory::WorktreeGitState) -> serde_json::Value {
+    use crate::worktree_inventory::WorktreeStateKind;
+    let mut block = serde_json::json!({
+        "state": state.kind.as_str(),
+        "checked_ms": state.checked_ms,
+    });
+    if matches!(state.kind, WorktreeStateKind::Clean | WorktreeStateKind::Dirty) {
+        block["dirty"] = serde_json::Value::Bool(state.dirty);
+        block["unpushed"] = serde_json::Value::Bool(state.unpushed);
+        block["ahead"] = serde_json::json!(state.ahead);
+        if let Some(branch) = state.branch.as_ref() {
+            block["branch"] = serde_json::Value::String(branch.clone());
+        }
+    }
+    block
 }
 
 /// Where a dead row's lineage stands: no recorded wrapper history (native
@@ -677,6 +736,11 @@ mod tests {
             "lineage_tip",
             "continued_as",
             "raw.terminal",
+            // The stranded-work axis: served worktree state consumed by
+            // the normalize + chip surfaces.
+            "worktree_state",
+            "normalizeSessionWorktreeState(",
+            "'worktree-state'",
         ] {
             assert!(
                 fragment.contains(needle),
@@ -1115,6 +1179,129 @@ mod tests {
         assert!(
             fragment.contains("${meta.boot.sourceSessionId || ''}"),
             "the metadata signature lost the boot writer segment — same-bit writer handoffs would never land in the store"
+        );
+    }
+
+    fn git(repo: &Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    /// The interrupted-arc closability amendment (2026-08-01, lex
+    /// posterior over the ruled conjunction's CLOSABLE application —
+    /// stop-safety untouched), byte-pinned where it bites: the claim
+    /// function's interrupted guard, the arc-evidence helper, the
+    /// mid-work card copy, the extracted tooltip matrix, and the QA
+    /// vector facade. A behavior change must move these pins and the
+    /// fragment together.
+    #[test]
+    fn interrupted_arc_closable_amendment_pinned() {
+        let actions = include_str!("../../../../../static/app/41-session-window-actions.js");
+        let guard = "  if (claim.interrupted) {\n    if (claim.attested !== 'achieved' || claim.worktreeStranded) return false;\n  }";
+        assert!(
+            actions.contains(guard),
+            "the closable claim's interrupted guard drifted from the amendment"
+        );
+        for needle in [
+            "function sessionWindowInterruptedArcState(",
+            "function sessionWindowCloseTitle(",
+            "Interrupted mid-work — resumable",
+            "CLOSABLE_CLAIM_QA_VECTORS",
+            "closableClaim: {",
+            "worktreeStranded: !!(ws && (ws.dirty || ws.unpushed))",
+        ] {
+            assert!(
+                actions.contains(needle),
+                "the actions fragment lost the interrupted-arc amendment surface: {needle}"
+            );
+        }
+        // Stop-safety semantics unchanged: interrupted remains HARD done
+        // evidence for the sweeps and the stop flow.
+        assert!(
+            actions.contains(
+                "return !!(win.ended || meta.ended) || phase === 'done' || phase === 'interrupted';"
+            ),
+            "hard done evidence must keep interrupted — only the CLOSABLE application was amended"
+        );
+    }
+
+    /// The stranded-work axis rides the row: a dirty, never-pushed
+    /// checkout named by the row's recorded worktree linkage serves the
+    /// probed facts — independent of the boot/agenda joins.
+    #[test]
+    fn worktree_state_rides_the_row() {
+        let root = tempfile::tempdir().unwrap();
+        let checkout = root.path().join("checkout");
+        std::fs::create_dir_all(&checkout).unwrap();
+        git(&checkout, &["init"]);
+        git(&checkout, &["checkout", "-b", "seat-branch"]);
+        git(&checkout, &["config", "user.email", "t@example.com"]);
+        git(&checkout, &["config", "user.name", "T"]);
+        std::fs::write(checkout.join("README.md"), "hi\n").unwrap();
+        git(&checkout, &["add", "README.md"]);
+        git(&checkout, &["commit", "-m", "initial"]);
+        std::fs::write(checkout.join("scratch.txt"), "local\n").unwrap();
+        crate::worktree_inventory::probe_and_memoize_worktree_git_state(&checkout);
+
+        let dir = session_dir_with_transcript(root.path(), "s1");
+        let mut row = serde_json::json!({
+            "worktree": {"branch": "seat-branch", "path": checkout.to_string_lossy()},
+        });
+        joins(None, None, None).attach(&mut row, "s1", &dir);
+        assert_eq!(row["worktree_state"]["state"], "dirty");
+        assert_eq!(row["worktree_state"]["dirty"], true);
+        assert_eq!(
+            row["worktree_state"]["unpushed"], true,
+            "a remoteless checkout's commits exist nowhere else"
+        );
+        assert_eq!(row["worktree_state"]["branch"], "seat-branch");
+        assert!(row["worktree_state"]["checked_ms"].as_u64().unwrap() > 0);
+    }
+
+    /// Honest degradation + scope: a gone linkage path serves state-only
+    /// `missing`; a linkage-less cwd qualifies only under a `.worktrees`
+    /// directory (honest `unknown` for a non-git dir); a main-checkout
+    /// cwd serves NO block — its dirtiness is the merge target's, not
+    /// this session's.
+    #[test]
+    fn worktree_state_degrades_and_scopes_honestly() {
+        let root = tempfile::tempdir().unwrap();
+        let dir = session_dir_with_transcript(root.path(), "s1");
+
+        let mut row = serde_json::json!({
+            "worktree": {"branch": "b", "path": root.path().join("reclaimed").to_string_lossy()},
+        });
+        joins(None, None, None).attach(&mut row, "s1", &dir);
+        assert_eq!(row["worktree_state"]["state"], "missing");
+        assert!(
+            row["worktree_state"].get("dirty").is_none(),
+            "missing serves no fact fields"
+        );
+
+        let seat = root.path().join(".worktrees").join("seat");
+        std::fs::create_dir_all(&seat).unwrap();
+        let mut row = serde_json::json!({ "cwd": seat.to_string_lossy() });
+        joins(None, None, None).attach(&mut row, "s2", &dir);
+        assert_eq!(
+            row["worktree_state"]["state"], "unknown",
+            "first sight of a non-git seat dir is honest ignorance"
+        );
+
+        let repo_root = root.path().join("repo-root");
+        std::fs::create_dir_all(&repo_root).unwrap();
+        let mut row = serde_json::json!({ "cwd": repo_root.to_string_lossy() });
+        joins(None, None, None).attach(&mut row, "s3", &dir);
+        assert!(
+            row.get("worktree_state").is_none(),
+            "a main checkout never speaks for a session's arc"
         );
     }
 }

--- a/src/bin/caller/worktree_inventory.rs
+++ b/src/bin/caller/worktree_inventory.rs
@@ -2065,8 +2065,9 @@ fn probe_worktree_git_state(path: &Path) -> WorktreeGitState {
     }
 }
 
-/// Blocking probe + memo fill: the deterministic lane (tests, eager
-/// warms). The serving path never calls this.
+/// Blocking probe + memo fill: the deterministic lane for tests (the
+/// serving path never blocks — it goes through the cached read below).
+#[cfg(test)]
 pub(crate) fn probe_and_memoize_worktree_git_state(path: &Path) -> WorktreeGitState {
     let snapshot = probe_worktree_git_state(path);
     if let Ok(mut memo) = worktree_state_memo().lock() {
@@ -2529,7 +2530,10 @@ mod tests {
         let repo = repo_path(&tmp);
         let wt = tmp.path().join("state-worktree");
         let wt_str = wt.to_string_lossy().to_string();
-        git(&repo, &["worktree", "add", "-b", "state-probe", &wt_str, "main"]);
+        git(
+            &repo,
+            &["worktree", "add", "-b", "state-probe", &wt_str, "main"],
+        );
         std::fs::write(wt.join("scratch.txt"), "local\n").unwrap();
 
         let dirty = probe_and_memoize_worktree_git_state(&wt);
@@ -2597,7 +2601,10 @@ mod tests {
         let repo = repo_path(&tmp);
         let wt = tmp.path().join("cached-worktree");
         let wt_str = wt.to_string_lossy().to_string();
-        git(&repo, &["worktree", "add", "-b", "cached-probe", &wt_str, "main"]);
+        git(
+            &repo,
+            &["worktree", "add", "-b", "cached-probe", &wt_str, "main"],
+        );
         std::fs::write(wt.join("scratch.txt"), "local\n").unwrap();
 
         probe_and_memoize_worktree_git_state(&wt);

--- a/src/bin/caller/worktree_inventory.rs
+++ b/src/bin/caller/worktree_inventory.rs
@@ -1935,6 +1935,217 @@ fn seconds_to_days(secs: i64) -> i64 {
     (secs / 86_400).max(0)
 }
 
+// ── Serve-time worktree git state ──────────────────────────────────────
+// The session envelope's stranded-work axis (dirty / unpushed / ahead),
+// probed from the daemon's own worktree knowledge on the session list's
+// serving path. A full `scan_worktrees` is subprocess-heavy and
+// on-demand only, so this seam keeps its own bounded memo: the
+// non-blocking read serves the last-known snapshot (or an honest
+// "unknown"), and a stale entry re-probes on a detached background
+// thread — never on the serving thread. Facts only; the closable fold
+// lives with the claim's other inputs (grid envelope + the SPA).
+
+/// How current a memoized worktree state may be before a serve kicks a
+/// background re-probe. Prompt-line cadence: ~2 status probes per minute
+/// per distinct live worktree, only while something serves the list.
+const WORKTREE_STATE_TTL: std::time::Duration = std::time::Duration::from_secs(30);
+/// A refresh marked in-flight longer than this is presumed lost (a hung
+/// git, a killed thread) and may be re-spawned.
+const WORKTREE_STATE_REFRESH_STUCK: std::time::Duration = std::time::Duration::from_secs(120);
+/// Clear-on-full corruption backstop, comfortably above the distinct
+/// checkout paths a session list can name (`MAX_WORKTREES` per scan).
+const WORKTREE_STATE_MEMO_LIMIT: usize = 4_096;
+
+/// The honest four-way behind one checkout path: `Clean`/`Dirty` are
+/// probed facts, `Missing` means the path is gone, `Unknown` means no
+/// probe has answered (yet, or git failed there). Never guess clean.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WorktreeStateKind {
+    Clean,
+    Dirty,
+    Missing,
+    Unknown,
+}
+
+impl WorktreeStateKind {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            WorktreeStateKind::Clean => "clean",
+            WorktreeStateKind::Dirty => "dirty",
+            WorktreeStateKind::Missing => "missing",
+            WorktreeStateKind::Unknown => "unknown",
+        }
+    }
+}
+
+/// One worktree's git state as last probed. `dirty`/`unpushed`/`ahead`
+/// are meaningful only when `kind` is `Clean`/`Dirty` — consumers serve
+/// state-only for `Missing`/`Unknown`.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct WorktreeGitState {
+    pub(crate) kind: WorktreeStateKind,
+    /// Any uncommitted working-tree change: staged, unstaged, untracked,
+    /// or conflicted.
+    pub(crate) dirty: bool,
+    /// `HEAD` is reachable from NO remote ref — commits that exist only
+    /// in this checkout (subsumes ahead-of-upstream and never-pushed
+    /// branches alike; a remoteless repository reads unpushed, which is
+    /// the truth of it).
+    pub(crate) unpushed: bool,
+    /// Commits ahead of the configured upstream (0 without one).
+    pub(crate) ahead: i64,
+    pub(crate) branch: Option<String>,
+    /// Wall-clock instant of the probe that produced this snapshot.
+    pub(crate) checked_ms: u64,
+}
+
+impl WorktreeGitState {
+    fn factless(kind: WorktreeStateKind, checked_ms: u64) -> Self {
+        Self {
+            kind,
+            dirty: false,
+            unpushed: false,
+            ahead: 0,
+            branch: None,
+            checked_ms,
+        }
+    }
+}
+
+struct WorktreeStateMemoEntry {
+    snapshot: WorktreeGitState,
+    checked: std::time::Instant,
+    refreshing_since: Option<std::time::Instant>,
+}
+
+fn worktree_state_memo() -> &'static Mutex<HashMap<PathBuf, WorktreeStateMemoEntry>> {
+    static MEMO: std::sync::OnceLock<Mutex<HashMap<PathBuf, WorktreeStateMemoEntry>>> =
+        std::sync::OnceLock::new();
+    MEMO.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn wall_clock_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Probe one checkout now, on the calling thread: one `git status
+/// --porcelain=v2 --branch` plus one bounded `rev-list` for the
+/// unpushed bit. Failures degrade to `Unknown`, a gone path to
+/// `Missing` — never a guessed clean.
+fn probe_worktree_git_state(path: &Path) -> WorktreeGitState {
+    let checked_ms = wall_clock_ms();
+    if !path.is_dir() {
+        return WorktreeGitState::factless(WorktreeStateKind::Missing, checked_ms);
+    }
+    let Ok(info) = status_info(path) else {
+        return WorktreeGitState::factless(WorktreeStateKind::Unknown, checked_ms);
+    };
+    let dirty = info.staged + info.unstaged + info.untracked + info.conflicted > 0;
+    // Errors (unborn HEAD, exotic states) read as not-unpushed: `dirty`
+    // already carries the evidence for a tree with no commits yet.
+    let unpushed = git_string(path, &["rev-list", "-1", "HEAD", "--not", "--remotes"])
+        .map(|out| !out.trim().is_empty())
+        .unwrap_or(false);
+    WorktreeGitState {
+        kind: if dirty {
+            WorktreeStateKind::Dirty
+        } else {
+            WorktreeStateKind::Clean
+        },
+        dirty,
+        unpushed,
+        ahead: info.ahead.max(0),
+        branch: info
+            .branch_head
+            .filter(|head| !head.is_empty() && head != "(detached)"),
+        checked_ms,
+    }
+}
+
+/// Blocking probe + memo fill: the deterministic lane (tests, eager
+/// warms). The serving path never calls this.
+pub(crate) fn probe_and_memoize_worktree_git_state(path: &Path) -> WorktreeGitState {
+    let snapshot = probe_worktree_git_state(path);
+    if let Ok(mut memo) = worktree_state_memo().lock() {
+        if memo.len() >= WORKTREE_STATE_MEMO_LIMIT && !memo.contains_key(path) {
+            memo.clear();
+        }
+        memo.insert(
+            path.to_path_buf(),
+            WorktreeStateMemoEntry {
+                snapshot: snapshot.clone(),
+                checked: std::time::Instant::now(),
+                refreshing_since: None,
+            },
+        );
+    }
+    snapshot
+}
+
+/// Non-blocking read for the serving path: returns the last-known
+/// snapshot immediately (stale included — `checked_ms` says how stale);
+/// a stale or absent entry kicks ONE background re-probe (single-flight
+/// per path) whose answer the next serve picks up. A gone path answers
+/// `Missing` synchronously — one stat, no subprocess. First sight of a
+/// live path answers an honest `Unknown` while the probe runs.
+pub(crate) fn cached_worktree_git_state(path: &Path) -> WorktreeGitState {
+    if !path.is_dir() {
+        return WorktreeGitState::factless(WorktreeStateKind::Missing, wall_clock_ms());
+    }
+    let mut snapshot = WorktreeGitState::factless(WorktreeStateKind::Unknown, wall_clock_ms());
+    let mut spawn = false;
+    if let Ok(mut memo) = worktree_state_memo().lock() {
+        match memo.get_mut(path) {
+            Some(entry) => {
+                let refresh_lost = entry
+                    .refreshing_since
+                    .is_some_and(|since| since.elapsed() >= WORKTREE_STATE_REFRESH_STUCK);
+                if (entry.refreshing_since.is_none() || refresh_lost)
+                    && entry.checked.elapsed() >= WORKTREE_STATE_TTL
+                {
+                    entry.refreshing_since = Some(std::time::Instant::now());
+                    spawn = true;
+                }
+                snapshot = entry.snapshot.clone();
+            }
+            None => {
+                if memo.len() >= WORKTREE_STATE_MEMO_LIMIT {
+                    memo.clear();
+                }
+                memo.insert(
+                    path.to_path_buf(),
+                    WorktreeStateMemoEntry {
+                        snapshot: snapshot.clone(),
+                        checked: std::time::Instant::now(),
+                        refreshing_since: Some(std::time::Instant::now()),
+                    },
+                );
+                spawn = true;
+            }
+        }
+    }
+    if spawn {
+        let path = path.to_path_buf();
+        std::thread::spawn(move || {
+            let probed = probe_worktree_git_state(&path);
+            if let Ok(mut memo) = worktree_state_memo().lock() {
+                memo.insert(
+                    path,
+                    WorktreeStateMemoEntry {
+                        snapshot: probed,
+                        checked: std::time::Instant::now(),
+                        refreshing_since: None,
+                    },
+                );
+            }
+        });
+    }
+    snapshot
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2307,6 +2518,106 @@ mod tests {
         assert_eq!(found.untracked, 1);
         assert!(!found.safe_to_remove);
         assert!(found.safety.contains("local changes") || found.safety.contains("untracked"));
+    }
+
+    /// The serve-time prober's fact matrix: an uncommitted file reads
+    /// dirty; committing it reads clean but still unpushed (the commit
+    /// exists in no remote); a detached-free branch name rides along.
+    #[test]
+    fn worktree_git_state_probe_reports_dirty_and_unpushed() {
+        let tmp = init_repo();
+        let repo = repo_path(&tmp);
+        let wt = tmp.path().join("state-worktree");
+        let wt_str = wt.to_string_lossy().to_string();
+        git(&repo, &["worktree", "add", "-b", "state-probe", &wt_str, "main"]);
+        std::fs::write(wt.join("scratch.txt"), "local\n").unwrap();
+
+        let dirty = probe_and_memoize_worktree_git_state(&wt);
+        assert_eq!(dirty.kind, WorktreeStateKind::Dirty);
+        assert!(dirty.dirty);
+        assert!(dirty.unpushed, "a remoteless checkout is unpushed truth");
+        assert_eq!(dirty.branch.as_deref(), Some("state-probe"));
+        assert!(dirty.checked_ms > 0);
+
+        git(&wt, &["config", "user.email", "test@example.com"]);
+        git(&wt, &["config", "user.name", "Test User"]);
+        git(&wt, &["add", "scratch.txt"]);
+        git(&wt, &["commit", "-m", "scratch"]);
+        let committed = probe_and_memoize_worktree_git_state(&wt);
+        assert_eq!(committed.kind, WorktreeStateKind::Clean);
+        assert!(!committed.dirty);
+        assert!(
+            committed.unpushed,
+            "the commit exists only in this checkout"
+        );
+    }
+
+    /// The unpushed bit's negative: once a remote ref reaches HEAD, the
+    /// checkout stops claiming stranded commits.
+    #[test]
+    fn worktree_git_state_unpushed_clears_when_remote_has_head() {
+        let tmp = init_repo();
+        let repo = repo_path(&tmp);
+        let bare = tmp.path().join("origin.git");
+        git(tmp.path(), &["init", "--bare", &bare.to_string_lossy()]);
+        git(&repo, &["remote", "add", "origin", &bare.to_string_lossy()]);
+        git(&repo, &["push", "--quiet", "origin", "main"]);
+
+        let state = probe_and_memoize_worktree_git_state(&repo);
+        assert_eq!(state.kind, WorktreeStateKind::Clean);
+        assert!(!state.unpushed, "HEAD is on the remote — nothing stranded");
+        assert_eq!(state.ahead, 0);
+    }
+
+    /// Honest degradation: a gone path answers `Missing`, a plain
+    /// non-git dir answers `Unknown` — never a guessed clean, and no
+    /// fact fields claimed for either.
+    #[test]
+    fn worktree_git_state_degrades_missing_and_unknown() {
+        let tmp = tempfile::tempdir().unwrap();
+        let gone = tmp.path().join("never-created");
+        let missing = probe_and_memoize_worktree_git_state(&gone);
+        assert_eq!(missing.kind, WorktreeStateKind::Missing);
+        assert!(!missing.dirty && !missing.unpushed);
+
+        let plain = tmp.path().join("plain-dir");
+        std::fs::create_dir(&plain).unwrap();
+        let unknown = probe_and_memoize_worktree_git_state(&plain);
+        assert_eq!(unknown.kind, WorktreeStateKind::Unknown);
+        assert!(!unknown.dirty && !unknown.unpushed);
+    }
+
+    /// The serving path's contract: a warmed memo answers synchronously
+    /// with the probed facts; a gone path answers `Missing` without a
+    /// subprocess; first sight of a live path answers an honest
+    /// `Unknown` while the background probe runs.
+    #[test]
+    fn cached_worktree_git_state_serves_memo_and_degrades() {
+        let tmp = init_repo();
+        let repo = repo_path(&tmp);
+        let wt = tmp.path().join("cached-worktree");
+        let wt_str = wt.to_string_lossy().to_string();
+        git(&repo, &["worktree", "add", "-b", "cached-probe", &wt_str, "main"]);
+        std::fs::write(wt.join("scratch.txt"), "local\n").unwrap();
+
+        probe_and_memoize_worktree_git_state(&wt);
+        let served = cached_worktree_git_state(&wt);
+        assert_eq!(served.kind, WorktreeStateKind::Dirty);
+        assert!(served.dirty);
+
+        let gone = tmp.path().join("gone");
+        assert_eq!(
+            cached_worktree_git_state(&gone).kind,
+            WorktreeStateKind::Missing
+        );
+
+        let fresh = tmp.path().join("first-sight");
+        std::fs::create_dir(&fresh).unwrap();
+        assert_eq!(
+            cached_worktree_git_state(&fresh).kind,
+            WorktreeStateKind::Unknown,
+            "first sight is honest ignorance, never a blocking probe"
+        );
     }
 
     #[test]

--- a/static/app.html
+++ b/static/app.html
@@ -38416,7 +38416,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '25b978807f04d3e9';
+const INTENDANT_APP_BUILD = 'c4be8ba02b5a1684';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -62375,6 +62375,8 @@ function normalizeSessionWindowMeta(meta = {}) {
   // form may feed the cwd fallback below.
   const worktreeInfo = normalizeSessionWorktreeInfo(meta.worktree);
   if (worktreeInfo) out.worktree = worktreeInfo;
+  const worktreeState = normalizeSessionWorktreeState(meta.worktree_state || meta.worktreeState);
+  if (worktreeState) out.worktreeState = worktreeState;
   const worktreeCwdAlias = typeof meta.worktree === 'string' ? meta.worktree : '';
   const cwd = compactSessionText(meta.cwd || meta.workdir || meta.workDir || worktreeCwdAlias || project);
   if (cwd) {
@@ -62451,6 +62453,30 @@ function normalizeSessionWorktreeInfo(raw) {
   return info;
 }
 
+// Served worktree git state (grid envelope `worktree_state`,
+// worktree_inventory.rs's serve-time probe): the stranded-work axis —
+// dirty / unpushed / ahead — probed daemon-side so it outlives the
+// session's own vitals stream. `state` is the honest four-way
+// (clean/dirty/missing/unknown); the fact fields ride only when the
+// probe answered. The SPA consumes, never re-derives.
+function normalizeSessionWorktreeState(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const state = String(raw.state || '').toLowerCase();
+  if (!['clean', 'dirty', 'missing', 'unknown'].includes(state)) return null;
+  const out = { state };
+  if (state === 'clean' || state === 'dirty') {
+    out.dirty = raw.dirty === true;
+    out.unpushed = raw.unpushed === true;
+    const ahead = Number(raw.ahead);
+    if (Number.isFinite(ahead) && ahead > 0) out.ahead = ahead;
+  }
+  const branch = compactSessionText(raw.branch);
+  if (branch) out.branch = branch;
+  const checkedMs = Number(raw.checked_ms ?? raw.checkedMs);
+  if (Number.isFinite(checkedMs) && checkedMs > 0) out.checkedMs = checkedMs;
+  return out;
+}
+
 function sessionWindowMetadataSignature(meta = {}) {
   return [
     meta.name || '',
@@ -62460,6 +62486,11 @@ function sessionWindowMetadataSignature(meta = {}) {
     meta.cwd || '',
     meta.cwdLabel || '',
     meta.worktree ? `${meta.worktree.branch}${meta.worktree.path}${meta.worktree.baseBranch || ''}` : '',
+    // Facts only — checkedMs deliberately excluded so an unchanged tree
+    // re-probed every TTL never churns the signature into full renders.
+    meta.worktreeState
+      ? [meta.worktreeState.state, meta.worktreeState.dirty ? '1' : '0', meta.worktreeState.unpushed ? '1' : '0', meta.worktreeState.ahead || 0, meta.worktreeState.branch || ''].join('|')
+      : '',
     meta.source || '',
     meta.sourceLabel || '',
     meta.backendSource || '',
@@ -63384,6 +63415,20 @@ const VITALS_SYMBOLS = {
     },
     action: (v) => (v.path ? { label: 'Copy folder path', run: () => vitalsCopyText(v.path) } : null),
   },
+  // The daemon-probed stranded-work chip (grid envelope
+  // `worktree_state`): unlike the vitals-fed `dirty`/`unpushed` chips it
+  // outlives the session, so an interrupted or dead card still states
+  // that its checkout holds work that exists nowhere else. Shown only
+  // when something IS stranded (or the checkout is gone) — clean stays
+  // quiet, unknown claims nothing.
+  'worktree-state': {
+    label: 'Worktree state',
+    priority: 58,
+    icon: 'pencil',
+    chip: (v) => v.text,
+    factText: (v) => v.text,
+    explain: (v) => v.lines,
+  },
   branch: {
     label: 'Branch',
     priority: 30,
@@ -63718,7 +63763,7 @@ const VITALS_SYMBOLS = {
 // activity signal.
 const VITALS_SYMBOL_ORDER = [
   'health', 'activity', 'model', 'permissions', 'agenda-source',
-  'agenda-occurrence', 'agenda-attestation', 'sealed-inputs', 'boot', 'worktree', 'branch', 'dirty',
+  'agenda-occurrence', 'agenda-attestation', 'sealed-inputs', 'boot', 'worktree', 'worktree-state', 'branch', 'dirty',
   'divergence', 'parity', 'unpushed', 'primary-unpushed', 'cache-hit',
   'cache-ttl', 'limit',
 ];
@@ -63976,6 +64021,39 @@ function vitalsChipModels(vitals, meta, sessionId) {
     }, {
       severity: bootMeta.ghost ? 'warn' : '',
     });
+  }
+  const worktreeState = meta?.worktreeState && typeof meta.worktreeState === 'object'
+    ? meta.worktreeState
+    : null;
+  if (worktreeState) {
+    const stranded = [];
+    if (worktreeState.dirty) stranded.push('dirty');
+    if (worktreeState.unpushed) stranded.push('unpushed');
+    const gone = worktreeState.state === 'missing';
+    if (stranded.length || gone) {
+      const lines = [];
+      if (gone) {
+        lines.push('The checkout this session worked in is gone (removed or reclaimed).');
+      }
+      if (worktreeState.dirty) {
+        lines.push('Uncommitted changes are sitting in the worktree — work that exists nowhere else until committed.');
+      }
+      if (worktreeState.unpushed) {
+        lines.push(`Commits on ${worktreeState.branch ? `“${worktreeState.branch}”` : 'the worktree branch'} exist only on this machine — not pushed anywhere${Number(worktreeState.ahead) > 0 ? ` (${worktreeState.ahead} ahead of upstream)` : ''}.`);
+      }
+      lines.push('Probed by the daemon from the checkout itself, so it stays honest after the session ends.');
+      push('worktree-state', 'worktree-state', {
+        text: gone
+          ? '⧉ worktree gone'
+          : (stranded.length === 1 && worktreeState.dirty ? '⧉ dirty worktree'
+            : (stranded.length === 1 ? '⧉ unpushed worktree' : '⧉ dirty+unpushed')),
+        lines,
+      }, {
+        // Stranded work IS attention: elevate like the ghost chip. A
+        // gone checkout is a neutral fact — nothing left to strand.
+        severity: stranded.length ? 'warn' : '',
+      });
+    }
   }
 
   const git = vitals?.git && typeof vitals.git === 'object' ? vitals.git : null;
@@ -65783,6 +65861,7 @@ function sessionWindowMetaFromSession(session) {
     cwd: session.cwd || session.workdir || session.workDir,
     project_root: session.project_root,
     worktree: session.worktree,
+    worktree_state: session.worktree_state,
     source: session.source,
     source_label: session.backend_source_label || session.source_label || prettyAgentName(session.backend_source || session.source || '') || session.backend_source || session.source,
     backend_source: session.backend_source,
@@ -71955,6 +72034,14 @@ function sessionWindowPhaseDisplayLabel(sessionId, phase) {
       || null;
     return ghostTerminal?.outcome ? 'Ended' : 'Died';
   }
+  // The interrupted-arc card copy (display only): while the arc looks
+  // unconcluded the pill states the whole truth — interrupted MID-WORK,
+  // and resumable — instead of a bare "Interrupted". Ghost corpses
+  // above keep their death statement.
+  if (p === 'interrupted') {
+    const arc = sessionWindowInterruptedArcState(ghostSid);
+    if (arc && !arc.concluded) return 'Interrupted mid-work — resumable';
+  }
   const canDerive = typeof deriveSessionActivity === 'function'
     && typeof sessionWireActivity === 'function';
   if (canDerive && (p === 'idle' || p === 'done')
@@ -72128,23 +72215,12 @@ function updateSessionWindow(sessionId, meta = {}) {
   // how it ended (and where its lineage continued) instead of freezing on
   // a mid-execution look.
   renderSessionWindowTerminalNote(win, sid);
-  // Track AO safe-to-stop: the × affordance claims exactly what the
-  // machine knows — the served stop derivation for agenda-linked
-  // sessions; for linkless sessions, "safe" only as the ruled
-  // conjunction (idle ∧ no linkage), and a busy linkless session claims
-  // NOTHING (the default title stands).
+  // Track AO safe-to-stop + the interrupted-arc amendment: the ×
+  // affordance claims exactly what the machine knows. The matrix lives
+  // in sessionWindowCloseTitle (one testable surface, exposed through
+  // window.qa.closableClaim).
   if (win.close) {
-    const agendaOcc = ((sessionMetadataById.get(sid) || {}).agenda || {}).occurrence;
-    let closeTitle = 'Hide or stop session';
-    if (agendaOcc && agendaOcc.stop === 'kills_live_run') {
-      closeTitle = 'Stopping kills a live agenda run — the occurrence records failed';
-    } else if (agendaOcc && agendaOcc.stop === 'owed_work') {
-      closeTitle = 'Agenda work is still owed behind this session — stopping does not settle it';
-    } else if (agendaOcc && agendaOcc.stop === 'settled') {
-      closeTitle = 'No agenda-owed work — the linked occurrence is settled';
-    } else if (!agendaOcc && win.phase === 'idle') {
-      closeTitle = 'Idle · no agenda-owed work — stopping loses only this session’s context';
-    }
+    const closeTitle = sessionWindowCloseTitle(sid, win);
     if (win.close.title !== closeTitle) {
       win.close.title = closeTitle;
       win.close.setAttribute('aria-label', closeTitle);
@@ -72572,9 +72648,23 @@ function hideDoneSessionWindows() {
 //     rule.
 // A linked occurrence with no served stop claim, and any unrecognized
 // claim, stay not-closable: positive-only, absence claims nothing.
+//
+// INTERRUPTED-ARC AMENDMENT (2026-08-01, lex posterior over the ruled
+// conjunction's CLOSABLE application — stop-safety semantics unchanged):
+// "interrupted" stays quiet for STOP-safety (nothing live to kill) but
+// is no longer unconditional quiet-POSITIVE for the closable claim.
+// Close hides the card, and for an interrupted mid-arc session the card
+// is the last visible handle on stranded work — so an interrupted
+// window claims closable only on affirmative conclusion evidence: its
+// occurrence attested `achieved` AND no stranded-tree evidence (dirty /
+// unpushed worktree). Linkless sessions have no attestation lane, so an
+// interrupted linkless window never reads closable.
 function sessionWindowClosableClaim(claim = {}) {
   const stop = typeof claim.stop === 'string' ? claim.stop : '';
   if (stop === 'kills_live_run' || stop === 'owed_work') return false;
+  if (claim.interrupted) {
+    if (claim.attested !== 'achieved' || claim.worktreeStranded) return false;
+  }
   // An ABSENT phase is no claim (normalizeSessionPhase defaults '' to
   // 'idle', which would read wider than the ×'s raw win.phase === 'idle'
   // check — positive-only forbids that): a phase-less window is quiet
@@ -72584,6 +72674,74 @@ function sessionWindowClosableClaim(claim = {}) {
   if (stop === 'settled') return quiet;
   if (stop || claim.linked) return false;
   return quiet;
+}
+
+// The interrupted-arc state behind one session id: null unless the
+// window's phase (or the catalog row's durable status) says
+// interrupted; else the conclusion evidence the amendment weighs — the
+// occurrence's attestation outcome and the served worktree
+// strandedness. Every input is an already-served fact
+// (sessionMetadataById); nothing here re-derives.
+function sessionWindowInterruptedArcState(sessionId) {
+  const sid = String(sessionId || '').trim();
+  if (!sid) return null;
+  const win = sessionWindows.get(sid);
+  const meta = sessionMetadataById.get(sid) || {};
+  const rawPhase = (win && win.phase) || meta.phase || '';
+  const interrupted = (!!rawPhase && normalizeSessionPhase(rawPhase) === 'interrupted')
+    || String(meta.status || '') === 'interrupted';
+  if (!interrupted) return null;
+  const attested = String(meta.agenda?.occurrence?.attestation?.outcome || '');
+  const ws = meta.worktreeState && typeof meta.worktreeState === 'object'
+    ? meta.worktreeState
+    : null;
+  const worktreeStranded = !!(ws && (ws.dirty || ws.unpushed));
+  return {
+    attested,
+    worktreeStranded,
+    // For copy surfaces: '' = no worktree known, else the served
+    // four-way (missing/unknown degrade honestly — they veto nothing,
+    // the attestation arm alone decides).
+    worktreeState: ws ? (ws.state || '') : '',
+    concluded: attested === 'achieved' && !worktreeStranded,
+  };
+}
+
+// The × affordance's tooltip matrix, one testable surface (Track AO +
+// the interrupted-arc amendment): live agenda debt outranks everything;
+// the interrupted-arc statement whenever the arc looks unconcluded —
+// deliberately ABOVE the settled row, because "settled" names only the
+// agenda-debt axis and no longer implies an interrupted card is benign;
+// then the ruled settled and linkless-idle rows; a busy linkless
+// session claims NOTHING (the default title stands).
+function sessionWindowCloseTitle(sessionId, win) {
+  const sid = String(sessionId || '').trim();
+  const agendaOcc = ((sessionMetadataById.get(sid) || {}).agenda || {}).occurrence;
+  const arc = sessionWindowInterruptedArcState(sid);
+  if (agendaOcc && agendaOcc.stop === 'kills_live_run') {
+    return 'Stopping kills a live agenda run — the occurrence records failed';
+  }
+  if (agendaOcc && agendaOcc.stop === 'owed_work') {
+    return 'Agenda work is still owed behind this session — stopping does not settle it';
+  }
+  if (arc && !arc.concluded) {
+    const evidence = [];
+    if (arc.attested !== 'achieved') {
+      evidence.push(arc.attested
+        ? `attested “${arc.attested}”, not achieved`
+        : 'no achieved attestation');
+    }
+    if (arc.worktreeStranded) evidence.push('worktree holds uncommitted or unpushed work');
+    const settledNote = agendaOcc && agendaOcc.stop === 'settled' ? 'agenda debt settled, but ' : '';
+    return `Interrupted mid-work — resumable. Closing hides the last handle on it (${settledNote}${evidence.join('; ')})`;
+  }
+  if (agendaOcc && agendaOcc.stop === 'settled') {
+    return 'No agenda-owed work — the linked occurrence is settled';
+  }
+  if (!agendaOcc && win && win.phase === 'idle') {
+    return 'Idle · no agenda-owed work — stopping loses only this session’s context';
+  }
+  return 'Hide or stop session';
 }
 
 // The sid boundary over the pure claim above: every input is a fact some
@@ -72596,11 +72754,15 @@ function sessionWindowIsClosableAtAGlance(sessionId) {
   if (!win) return false;
   const meta = sessionMetadataById.get(sid) || {};
   const occ = (meta.agenda || {}).occurrence;
+  const arc = sessionWindowInterruptedArcState(sid);
   return sessionWindowClosableClaim({
     stop: (occ && occ.stop) || '',
     linked: !!meta.agenda,
     phase: win.phase || meta.phase || '',
     hardDone: sessionWindowHasHardDoneEvidence(sid),
+    interrupted: !!arc,
+    attested: arc ? arc.attested : '',
+    worktreeStranded: !!(arc && arc.worktreeStranded),
   });
 }
 
@@ -72615,7 +72777,39 @@ function sessionWindowIsClosableAtAGlance(sessionId) {
 // use; the readbacks are serializable snapshots (windowState's
 // followOutput/logAtBottom expose the jump-button state machine — QA-only
 // layout read, never on a hot path).
+// The closable-claim matrix frozen as executable vectors — the
+// interrupted-arc amendment's new states beside the ruled Track AO
+// rows. window.qa.closableClaim.vectors() runs them all; any
+// pass:false is a regression in the claim function itself.
+const CLOSABLE_CLAIM_QA_VECTORS = [
+  { name: 'settled + hard done stays closable', claim: { stop: 'settled', hardDone: true }, expect: true },
+  { name: 'settled while running stays suppressed', claim: { stop: 'settled', phase: 'running' }, expect: false },
+  { name: 'live agenda run vetoes', claim: { stop: 'kills_live_run', hardDone: true }, expect: false },
+  { name: 'owed work vetoes', claim: { stop: 'owed_work', hardDone: true }, expect: false },
+  { name: 'linked without a stop claim stays not-closable', claim: { linked: true, hardDone: true }, expect: false },
+  { name: 'linkless idle stays closable', claim: { phase: 'idle' }, expect: true },
+  { name: 'interrupted linkless never reads closable', claim: { hardDone: true, interrupted: true, attested: '' }, expect: false },
+  { name: 'interrupted settled without attestation is not closable', claim: { stop: 'settled', hardDone: true, interrupted: true, attested: '' }, expect: false },
+  { name: 'interrupted attested short of achieved is not closable', claim: { stop: 'settled', hardDone: true, interrupted: true, attested: 'partial' }, expect: false },
+  { name: 'interrupted achieved with a clean tree is closable', claim: { stop: 'settled', hardDone: true, interrupted: true, attested: 'achieved', worktreeStranded: false }, expect: true },
+  { name: 'interrupted achieved with a stranded tree is not closable', claim: { stop: 'settled', hardDone: true, interrupted: true, attested: 'achieved', worktreeStranded: true }, expect: false },
+];
+
 window.qa = Object.assign(window.qa || {}, {
+  closableClaim: {
+    evaluate: (claim) => sessionWindowClosableClaim(claim || {}),
+    atAGlance: (sessionId) => sessionWindowIsClosableAtAGlance(sessionId),
+    interruptedArc: (sessionId) => sessionWindowInterruptedArcState(sessionId),
+    closeTitle: (sessionId) => {
+      const sid = String(sessionId || '').trim();
+      const win = sid ? sessionWindows.get(sid) : null;
+      return win ? sessionWindowCloseTitle(sid, win) : '';
+    },
+    vectors: () => CLOSABLE_CLAIM_QA_VECTORS.map((vector) => {
+      const got = sessionWindowClosableClaim(vector.claim);
+      return { name: vector.name, expect: vector.expect, got, pass: got === vector.expect };
+    }),
+  },
   sessionWindowSweeps: {
     build: (sessionId, meta) => !!ensureSessionWindow(sessionId, meta || {}),
     setMinimized: (sessionId, minimized) => setSessionWindowMinimized(sessionId, !!minimized),

--- a/static/app/39-session-windows.js
+++ b/static/app/39-session-windows.js
@@ -830,6 +830,8 @@ function normalizeSessionWindowMeta(meta = {}) {
   // form may feed the cwd fallback below.
   const worktreeInfo = normalizeSessionWorktreeInfo(meta.worktree);
   if (worktreeInfo) out.worktree = worktreeInfo;
+  const worktreeState = normalizeSessionWorktreeState(meta.worktree_state || meta.worktreeState);
+  if (worktreeState) out.worktreeState = worktreeState;
   const worktreeCwdAlias = typeof meta.worktree === 'string' ? meta.worktree : '';
   const cwd = compactSessionText(meta.cwd || meta.workdir || meta.workDir || worktreeCwdAlias || project);
   if (cwd) {
@@ -906,6 +908,30 @@ function normalizeSessionWorktreeInfo(raw) {
   return info;
 }
 
+// Served worktree git state (grid envelope `worktree_state`,
+// worktree_inventory.rs's serve-time probe): the stranded-work axis —
+// dirty / unpushed / ahead — probed daemon-side so it outlives the
+// session's own vitals stream. `state` is the honest four-way
+// (clean/dirty/missing/unknown); the fact fields ride only when the
+// probe answered. The SPA consumes, never re-derives.
+function normalizeSessionWorktreeState(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const state = String(raw.state || '').toLowerCase();
+  if (!['clean', 'dirty', 'missing', 'unknown'].includes(state)) return null;
+  const out = { state };
+  if (state === 'clean' || state === 'dirty') {
+    out.dirty = raw.dirty === true;
+    out.unpushed = raw.unpushed === true;
+    const ahead = Number(raw.ahead);
+    if (Number.isFinite(ahead) && ahead > 0) out.ahead = ahead;
+  }
+  const branch = compactSessionText(raw.branch);
+  if (branch) out.branch = branch;
+  const checkedMs = Number(raw.checked_ms ?? raw.checkedMs);
+  if (Number.isFinite(checkedMs) && checkedMs > 0) out.checkedMs = checkedMs;
+  return out;
+}
+
 function sessionWindowMetadataSignature(meta = {}) {
   return [
     meta.name || '',
@@ -915,6 +941,11 @@ function sessionWindowMetadataSignature(meta = {}) {
     meta.cwd || '',
     meta.cwdLabel || '',
     meta.worktree ? `${meta.worktree.branch}${meta.worktree.path}${meta.worktree.baseBranch || ''}` : '',
+    // Facts only — checkedMs deliberately excluded so an unchanged tree
+    // re-probed every TTL never churns the signature into full renders.
+    meta.worktreeState
+      ? [meta.worktreeState.state, meta.worktreeState.dirty ? '1' : '0', meta.worktreeState.unpushed ? '1' : '0', meta.worktreeState.ahead || 0, meta.worktreeState.branch || ''].join('|')
+      : '',
     meta.source || '',
     meta.sourceLabel || '',
     meta.backendSource || '',
@@ -1839,6 +1870,20 @@ const VITALS_SYMBOLS = {
     },
     action: (v) => (v.path ? { label: 'Copy folder path', run: () => vitalsCopyText(v.path) } : null),
   },
+  // The daemon-probed stranded-work chip (grid envelope
+  // `worktree_state`): unlike the vitals-fed `dirty`/`unpushed` chips it
+  // outlives the session, so an interrupted or dead card still states
+  // that its checkout holds work that exists nowhere else. Shown only
+  // when something IS stranded (or the checkout is gone) — clean stays
+  // quiet, unknown claims nothing.
+  'worktree-state': {
+    label: 'Worktree state',
+    priority: 58,
+    icon: 'pencil',
+    chip: (v) => v.text,
+    factText: (v) => v.text,
+    explain: (v) => v.lines,
+  },
   branch: {
     label: 'Branch',
     priority: 30,
@@ -2173,7 +2218,7 @@ const VITALS_SYMBOLS = {
 // activity signal.
 const VITALS_SYMBOL_ORDER = [
   'health', 'activity', 'model', 'permissions', 'agenda-source',
-  'agenda-occurrence', 'agenda-attestation', 'sealed-inputs', 'boot', 'worktree', 'branch', 'dirty',
+  'agenda-occurrence', 'agenda-attestation', 'sealed-inputs', 'boot', 'worktree', 'worktree-state', 'branch', 'dirty',
   'divergence', 'parity', 'unpushed', 'primary-unpushed', 'cache-hit',
   'cache-ttl', 'limit',
 ];
@@ -2431,6 +2476,39 @@ function vitalsChipModels(vitals, meta, sessionId) {
     }, {
       severity: bootMeta.ghost ? 'warn' : '',
     });
+  }
+  const worktreeState = meta?.worktreeState && typeof meta.worktreeState === 'object'
+    ? meta.worktreeState
+    : null;
+  if (worktreeState) {
+    const stranded = [];
+    if (worktreeState.dirty) stranded.push('dirty');
+    if (worktreeState.unpushed) stranded.push('unpushed');
+    const gone = worktreeState.state === 'missing';
+    if (stranded.length || gone) {
+      const lines = [];
+      if (gone) {
+        lines.push('The checkout this session worked in is gone (removed or reclaimed).');
+      }
+      if (worktreeState.dirty) {
+        lines.push('Uncommitted changes are sitting in the worktree — work that exists nowhere else until committed.');
+      }
+      if (worktreeState.unpushed) {
+        lines.push(`Commits on ${worktreeState.branch ? `“${worktreeState.branch}”` : 'the worktree branch'} exist only on this machine — not pushed anywhere${Number(worktreeState.ahead) > 0 ? ` (${worktreeState.ahead} ahead of upstream)` : ''}.`);
+      }
+      lines.push('Probed by the daemon from the checkout itself, so it stays honest after the session ends.');
+      push('worktree-state', 'worktree-state', {
+        text: gone
+          ? '⧉ worktree gone'
+          : (stranded.length === 1 && worktreeState.dirty ? '⧉ dirty worktree'
+            : (stranded.length === 1 ? '⧉ unpushed worktree' : '⧉ dirty+unpushed')),
+        lines,
+      }, {
+        // Stranded work IS attention: elevate like the ghost chip. A
+        // gone checkout is a neutral fact — nothing left to strand.
+        severity: stranded.length ? 'warn' : '',
+      });
+    }
   }
 
   const git = vitals?.git && typeof vitals.git === 'object' ? vitals.git : null;
@@ -4238,6 +4316,7 @@ function sessionWindowMetaFromSession(session) {
     cwd: session.cwd || session.workdir || session.workDir,
     project_root: session.project_root,
     worktree: session.worktree,
+    worktree_state: session.worktree_state,
     source: session.source,
     source_label: session.backend_source_label || session.source_label || prettyAgentName(session.backend_source || session.source || '') || session.backend_source || session.source,
     backend_source: session.backend_source,

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -532,6 +532,14 @@ function sessionWindowPhaseDisplayLabel(sessionId, phase) {
       || null;
     return ghostTerminal?.outcome ? 'Ended' : 'Died';
   }
+  // The interrupted-arc card copy (display only): while the arc looks
+  // unconcluded the pill states the whole truth — interrupted MID-WORK,
+  // and resumable — instead of a bare "Interrupted". Ghost corpses
+  // above keep their death statement.
+  if (p === 'interrupted') {
+    const arc = sessionWindowInterruptedArcState(ghostSid);
+    if (arc && !arc.concluded) return 'Interrupted mid-work — resumable';
+  }
   const canDerive = typeof deriveSessionActivity === 'function'
     && typeof sessionWireActivity === 'function';
   if (canDerive && (p === 'idle' || p === 'done')
@@ -705,23 +713,12 @@ function updateSessionWindow(sessionId, meta = {}) {
   // how it ended (and where its lineage continued) instead of freezing on
   // a mid-execution look.
   renderSessionWindowTerminalNote(win, sid);
-  // Track AO safe-to-stop: the × affordance claims exactly what the
-  // machine knows — the served stop derivation for agenda-linked
-  // sessions; for linkless sessions, "safe" only as the ruled
-  // conjunction (idle ∧ no linkage), and a busy linkless session claims
-  // NOTHING (the default title stands).
+  // Track AO safe-to-stop + the interrupted-arc amendment: the ×
+  // affordance claims exactly what the machine knows. The matrix lives
+  // in sessionWindowCloseTitle (one testable surface, exposed through
+  // window.qa.closableClaim).
   if (win.close) {
-    const agendaOcc = ((sessionMetadataById.get(sid) || {}).agenda || {}).occurrence;
-    let closeTitle = 'Hide or stop session';
-    if (agendaOcc && agendaOcc.stop === 'kills_live_run') {
-      closeTitle = 'Stopping kills a live agenda run — the occurrence records failed';
-    } else if (agendaOcc && agendaOcc.stop === 'owed_work') {
-      closeTitle = 'Agenda work is still owed behind this session — stopping does not settle it';
-    } else if (agendaOcc && agendaOcc.stop === 'settled') {
-      closeTitle = 'No agenda-owed work — the linked occurrence is settled';
-    } else if (!agendaOcc && win.phase === 'idle') {
-      closeTitle = 'Idle · no agenda-owed work — stopping loses only this session’s context';
-    }
+    const closeTitle = sessionWindowCloseTitle(sid, win);
     if (win.close.title !== closeTitle) {
       win.close.title = closeTitle;
       win.close.setAttribute('aria-label', closeTitle);
@@ -1149,9 +1146,23 @@ function hideDoneSessionWindows() {
 //     rule.
 // A linked occurrence with no served stop claim, and any unrecognized
 // claim, stay not-closable: positive-only, absence claims nothing.
+//
+// INTERRUPTED-ARC AMENDMENT (2026-08-01, lex posterior over the ruled
+// conjunction's CLOSABLE application — stop-safety semantics unchanged):
+// "interrupted" stays quiet for STOP-safety (nothing live to kill) but
+// is no longer unconditional quiet-POSITIVE for the closable claim.
+// Close hides the card, and for an interrupted mid-arc session the card
+// is the last visible handle on stranded work — so an interrupted
+// window claims closable only on affirmative conclusion evidence: its
+// occurrence attested `achieved` AND no stranded-tree evidence (dirty /
+// unpushed worktree). Linkless sessions have no attestation lane, so an
+// interrupted linkless window never reads closable.
 function sessionWindowClosableClaim(claim = {}) {
   const stop = typeof claim.stop === 'string' ? claim.stop : '';
   if (stop === 'kills_live_run' || stop === 'owed_work') return false;
+  if (claim.interrupted) {
+    if (claim.attested !== 'achieved' || claim.worktreeStranded) return false;
+  }
   // An ABSENT phase is no claim (normalizeSessionPhase defaults '' to
   // 'idle', which would read wider than the ×'s raw win.phase === 'idle'
   // check — positive-only forbids that): a phase-less window is quiet
@@ -1161,6 +1172,74 @@ function sessionWindowClosableClaim(claim = {}) {
   if (stop === 'settled') return quiet;
   if (stop || claim.linked) return false;
   return quiet;
+}
+
+// The interrupted-arc state behind one session id: null unless the
+// window's phase (or the catalog row's durable status) says
+// interrupted; else the conclusion evidence the amendment weighs — the
+// occurrence's attestation outcome and the served worktree
+// strandedness. Every input is an already-served fact
+// (sessionMetadataById); nothing here re-derives.
+function sessionWindowInterruptedArcState(sessionId) {
+  const sid = String(sessionId || '').trim();
+  if (!sid) return null;
+  const win = sessionWindows.get(sid);
+  const meta = sessionMetadataById.get(sid) || {};
+  const rawPhase = (win && win.phase) || meta.phase || '';
+  const interrupted = (!!rawPhase && normalizeSessionPhase(rawPhase) === 'interrupted')
+    || String(meta.status || '') === 'interrupted';
+  if (!interrupted) return null;
+  const attested = String(meta.agenda?.occurrence?.attestation?.outcome || '');
+  const ws = meta.worktreeState && typeof meta.worktreeState === 'object'
+    ? meta.worktreeState
+    : null;
+  const worktreeStranded = !!(ws && (ws.dirty || ws.unpushed));
+  return {
+    attested,
+    worktreeStranded,
+    // For copy surfaces: '' = no worktree known, else the served
+    // four-way (missing/unknown degrade honestly — they veto nothing,
+    // the attestation arm alone decides).
+    worktreeState: ws ? (ws.state || '') : '',
+    concluded: attested === 'achieved' && !worktreeStranded,
+  };
+}
+
+// The × affordance's tooltip matrix, one testable surface (Track AO +
+// the interrupted-arc amendment): live agenda debt outranks everything;
+// the interrupted-arc statement whenever the arc looks unconcluded —
+// deliberately ABOVE the settled row, because "settled" names only the
+// agenda-debt axis and no longer implies an interrupted card is benign;
+// then the ruled settled and linkless-idle rows; a busy linkless
+// session claims NOTHING (the default title stands).
+function sessionWindowCloseTitle(sessionId, win) {
+  const sid = String(sessionId || '').trim();
+  const agendaOcc = ((sessionMetadataById.get(sid) || {}).agenda || {}).occurrence;
+  const arc = sessionWindowInterruptedArcState(sid);
+  if (agendaOcc && agendaOcc.stop === 'kills_live_run') {
+    return 'Stopping kills a live agenda run — the occurrence records failed';
+  }
+  if (agendaOcc && agendaOcc.stop === 'owed_work') {
+    return 'Agenda work is still owed behind this session — stopping does not settle it';
+  }
+  if (arc && !arc.concluded) {
+    const evidence = [];
+    if (arc.attested !== 'achieved') {
+      evidence.push(arc.attested
+        ? `attested “${arc.attested}”, not achieved`
+        : 'no achieved attestation');
+    }
+    if (arc.worktreeStranded) evidence.push('worktree holds uncommitted or unpushed work');
+    const settledNote = agendaOcc && agendaOcc.stop === 'settled' ? 'agenda debt settled, but ' : '';
+    return `Interrupted mid-work — resumable. Closing hides the last handle on it (${settledNote}${evidence.join('; ')})`;
+  }
+  if (agendaOcc && agendaOcc.stop === 'settled') {
+    return 'No agenda-owed work — the linked occurrence is settled';
+  }
+  if (!agendaOcc && win && win.phase === 'idle') {
+    return 'Idle · no agenda-owed work — stopping loses only this session’s context';
+  }
+  return 'Hide or stop session';
 }
 
 // The sid boundary over the pure claim above: every input is a fact some
@@ -1173,11 +1252,15 @@ function sessionWindowIsClosableAtAGlance(sessionId) {
   if (!win) return false;
   const meta = sessionMetadataById.get(sid) || {};
   const occ = (meta.agenda || {}).occurrence;
+  const arc = sessionWindowInterruptedArcState(sid);
   return sessionWindowClosableClaim({
     stop: (occ && occ.stop) || '',
     linked: !!meta.agenda,
     phase: win.phase || meta.phase || '',
     hardDone: sessionWindowHasHardDoneEvidence(sid),
+    interrupted: !!arc,
+    attested: arc ? arc.attested : '',
+    worktreeStranded: !!(arc && arc.worktreeStranded),
   });
 }
 
@@ -1192,7 +1275,39 @@ function sessionWindowIsClosableAtAGlance(sessionId) {
 // use; the readbacks are serializable snapshots (windowState's
 // followOutput/logAtBottom expose the jump-button state machine — QA-only
 // layout read, never on a hot path).
+// The closable-claim matrix frozen as executable vectors — the
+// interrupted-arc amendment's new states beside the ruled Track AO
+// rows. window.qa.closableClaim.vectors() runs them all; any
+// pass:false is a regression in the claim function itself.
+const CLOSABLE_CLAIM_QA_VECTORS = [
+  { name: 'settled + hard done stays closable', claim: { stop: 'settled', hardDone: true }, expect: true },
+  { name: 'settled while running stays suppressed', claim: { stop: 'settled', phase: 'running' }, expect: false },
+  { name: 'live agenda run vetoes', claim: { stop: 'kills_live_run', hardDone: true }, expect: false },
+  { name: 'owed work vetoes', claim: { stop: 'owed_work', hardDone: true }, expect: false },
+  { name: 'linked without a stop claim stays not-closable', claim: { linked: true, hardDone: true }, expect: false },
+  { name: 'linkless idle stays closable', claim: { phase: 'idle' }, expect: true },
+  { name: 'interrupted linkless never reads closable', claim: { hardDone: true, interrupted: true, attested: '' }, expect: false },
+  { name: 'interrupted settled without attestation is not closable', claim: { stop: 'settled', hardDone: true, interrupted: true, attested: '' }, expect: false },
+  { name: 'interrupted attested short of achieved is not closable', claim: { stop: 'settled', hardDone: true, interrupted: true, attested: 'partial' }, expect: false },
+  { name: 'interrupted achieved with a clean tree is closable', claim: { stop: 'settled', hardDone: true, interrupted: true, attested: 'achieved', worktreeStranded: false }, expect: true },
+  { name: 'interrupted achieved with a stranded tree is not closable', claim: { stop: 'settled', hardDone: true, interrupted: true, attested: 'achieved', worktreeStranded: true }, expect: false },
+];
+
 window.qa = Object.assign(window.qa || {}, {
+  closableClaim: {
+    evaluate: (claim) => sessionWindowClosableClaim(claim || {}),
+    atAGlance: (sessionId) => sessionWindowIsClosableAtAGlance(sessionId),
+    interruptedArc: (sessionId) => sessionWindowInterruptedArcState(sessionId),
+    closeTitle: (sessionId) => {
+      const sid = String(sessionId || '').trim();
+      const win = sid ? sessionWindows.get(sid) : null;
+      return win ? sessionWindowCloseTitle(sid, win) : '';
+    },
+    vectors: () => CLOSABLE_CLAIM_QA_VECTORS.map((vector) => {
+      const got = sessionWindowClosableClaim(vector.claim);
+      return { name: vector.name, expect: vector.expect, got, pass: got === vector.expect };
+    }),
+  },
   sessionWindowSweeps: {
     build: (sessionId, meta) => !!ensureSessionWindow(sessionId, meta || {}),
     setMinimized: (sessionId, minimized) => setSessionWindowMinimized(sessionId, !!minimized),


### PR DESCRIPTION
Implements agenda commission 01KYXEFWQRH7YB0H4B1RDV3P9B (interrupted-arc closability).

**Lex-posterior amendment note for the gate:** this amends the AO-ruled safe-to-stop conjunction's CLOSABLE application on fresh owner-specimen grounds (ff793ef1, 2026-07-31: interrupted mid-task + dirty worktree rendered bright-green closable). Stop-safety semantics are unchanged and pinned.

- **Closable claim** (41-session-window-actions.js): phase 'interrupted' stops counting as unconditional quiet-positive. Interrupted + unconcluded-arc evidence (no achieved attestation on its occurrence, or dirty/unpushed worktree) = NOT closable. Card pill renders 'Interrupted mid-work — resumable'; the x tooltip matrix is extracted into sessionWindowCloseTitle with interrupted-arc rows above the settled row.
- **Envelope worktree state** (grid_envelope.rs + worktree_inventory.rs): rows serve worktree_state {state: clean|dirty|missing|unknown, dirty, unpushed, ahead, branch, checked_ms} from a memoized, background-refreshed serve-time probe (never blocks the serving thread). Path resolution: recorded worktree linkage first, else cwd/project_root under a .worktrees directory — a main checkout never qualifies. Honest degradation: missing/unknown serve state-only.
- **Card chip** (39-session-windows.js): 'dirty worktree' / 'unpushed worktree' / 'worktree gone' chip, daemon-probed so it survives session death (unlike the vitals git chips).
- **Boot sweep audit** (commission_sweep.rs): the shared conjunction's blindness was completed-dressed transport endings — classify_commissions now emits CompletedUnattested for unattested completed runs on open items, and plan_sweep consults the seat's durable status: interrupted = LISTED in the needs-you lane (never woken — prior-boot by construction, the stale-stranding law); anything else stays settled. Armed-series continuity guard preserved.
- **QA**: window.qa.closableClaim {evaluate, atAGlance, interruptedArc, closeTitle, vectors} with an 11-vector matrix; Rust pins byte-pin the claim guard, the copy, and stop-safety invariance.

app.html regen + full battery to follow before ready.