### PR TITLE
sessions: parked-task respawn honesty — died-with-restart marking, re-run offer, drain releasability

### DIFF
--- a/crates/intendant-core/src/vitals.rs
+++ b/crates/intendant-core/src/vitals.rs
@@ -219,6 +219,20 @@ pub struct SessionActivityVitals {
     /// on backends without background primitives is simply always.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub background_tasks: Vec<String>,
+    /// Short descriptions of background tasks that DIED with a backend
+    /// restart while the session was parked on them (they were children
+    /// of the replaced backend process). Non-empty is an attention
+    /// state: the wait is over, nothing was re-run automatically
+    /// (commands are not known idempotent), and re-running is an owner
+    /// decision. Cleared by the next activity publish once the session
+    /// works again.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub died_background_tasks: Vec<String>,
+    /// The named restart that killed `died_background_tasks` (e.g.
+    /// "the credential-reload restart", "the daemon restart"). Present
+    /// exactly when that list is non-empty.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub died_tasks_cause: Option<String>,
 }
 
 /// Session configuration facts — model, reasoning effort, permission

--- a/docs/src/external-agent-orchestration.md
+++ b/docs/src/external-agent-orchestration.md
@@ -1195,6 +1195,53 @@ owner — instead of waiting unattended; the persistent daemon lane reports the
 outage on the error/presence surfaces and stops parking until the next user
 message re-drives it.
 
+## Parked-task Respawn Honesty (died-with-restart)
+
+A session whose turn ends with armed background commands **parks on them**
+(`parked-on-tasks` activity; the wake is the backend's own
+`task_notification`). Those commands are OS children of the backend process,
+so they die with **every** respawn class — credential reload,
+service-recovery restart, rate-limit restart, daemon restart — while the
+parked claim is session-state and survives. Untreated, that is a
+forever-park waiting on a dead wake (and an accidental drain holdout). The
+honesty machinery:
+
+- **The registry never silently forgets running tasks.** At every seam
+  where the old process objectively dies, its running records flip to a
+  retained `died-with-restart` status with a named cause
+  (`background_tasks::mark_running_died_with_restart`): the
+  credential-reload respawn pre-marks with its own name, the park arms mark
+  when the backend's confirmed-exit probe says the process is gone (an
+  API-500 against a live process marks nothing — the park stays honest),
+  the adapter's shutdown/Drop/re-adoption seams are generic backstops, and
+  the boot + released-predecessor passes stamp `the daemon restart` on
+  dead-boot live parks. Kimi is deliberately exempt: its tasks are
+  server-side and survive a client respawn.
+- **The park flips to an honest attention state.** The marking seam
+  publishes a corrected activity snapshot — state `idle` (the wire truth)
+  with `diedBackgroundTasks`/`diedTasksCause` — sticky in the vitals hub
+  until the session demonstrably works again; the durable
+  `SessionMeta.bg_park` marker shadows the claim across daemon restarts
+  (live form stamped while parked, died form with the cause, cleared on
+  any turn-state publish). The dashboard derives a `died-tasks` display
+  state from it: attention chip, per-task detail, the killing restart
+  named on the inspector rows, and a status pill that says "task died
+  with restart" instead of "Parked"/"Idle".
+- **Re-running is an owner decision — never automatic** (commands are not
+  known idempotent; pinned by
+  `died_with_restart_marking_never_arms_delivery`). The re-run OFFER rides
+  only continuation nudges a lane already sends (the reload continuation,
+  the parks' delivery-aware resume nudges, readopt continuations —
+  `died_tasks_nudge_addendum`, appended only to the synthesized nudge,
+  never to a verbatim re-send of the owner's message, and never minted on
+  its own); the session card's activity chip carries a one-tap "ask the
+  session to re-run it" that sends a normal follow-up through the
+  existing lane.
+- **Drain interplay:** an idle session whose only hold is a died park is
+  releasable (`session_holds_drain` — its wait is on nobody, and the
+  durable marker survives to the successor), while a LIVE bg-park holdout
+  names its tasks on the drain wait set's rows.
+
 ## Dashboard and Station parity
 
 The per-session dashboard features (Activity → Timeline agent windows and the

--- a/src/bin/caller/background_tasks.rs
+++ b/src/bin/caller/background_tasks.rs
@@ -729,7 +729,13 @@ mod tests {
         let sid = "session-respawn";
         reg.record_started(sid, "task-live", "toolu_live", "cargo test battery", 100);
         reg.record_started(sid, "task-done", "toolu_done", "quick job", 101);
-        reg.record_finished(sid, "toolu_done", BackgroundTaskStatus::Completed, None, 102);
+        reg.record_finished(
+            sid,
+            "toolu_done",
+            BackgroundTaskStatus::Completed,
+            None,
+            102,
+        );
 
         let died = reg.mark_running_died_with_restart(sid, "the credential-reload restart", 160);
         assert_eq!(died.len(), 1, "only running records flip");

--- a/src/bin/caller/background_tasks.rs
+++ b/src/bin/caller/background_tasks.rs
@@ -35,6 +35,13 @@ pub(crate) enum BackgroundTaskStatus {
     Failed,
     /// Killed / cancelled / interrupted (e.g. a TaskStop).
     Stopped,
+    /// The backend process that supervised the task went away (respawn,
+    /// shutdown, restart) while the task was still running — the task was
+    /// its OS child, so it died with it and no notification will ever
+    /// arrive. `BackgroundTaskRecord::died_cause` names the restart.
+    /// Terminal, and never entered from wire words: only the supervision
+    /// seams that observed the process die mark it.
+    DiedWithRestart,
 }
 
 impl BackgroundTaskStatus {
@@ -44,6 +51,7 @@ impl BackgroundTaskStatus {
             BackgroundTaskStatus::Completed => "completed",
             BackgroundTaskStatus::Failed => "failed",
             BackgroundTaskStatus::Stopped => "stopped",
+            BackgroundTaskStatus::DiedWithRestart => "died-with-restart",
         }
     }
 
@@ -85,6 +93,10 @@ pub(crate) struct BackgroundTaskRecord {
     pub(crate) inline_output: Option<Vec<u8>>,
     /// Authoritative total byte count when the backend reports one.
     pub(crate) output_size_bytes: Option<u64>,
+    /// The named restart that killed the task, present exactly when
+    /// `status` is [`BackgroundTaskStatus::DiedWithRestart`] (e.g. "the
+    /// credential-reload restart", "the daemon restart").
+    pub(crate) died_cause: Option<String>,
 }
 
 /// Hard ceiling for one retained inline output preview. It matches the
@@ -217,6 +229,7 @@ impl Registry {
             output_file: None,
             inline_output: None,
             output_size_bytes: None,
+            died_cause: None,
         });
         self.evict_stale_sessions();
     }
@@ -298,9 +311,13 @@ impl Registry {
                 record.output_file = Some(path);
             }
         }
-        // Retention: keep every running record; drop the oldest finished
-        // ones (finishes land in wire order, so list order is age order)
-        // past the bound.
+        Self::trim_finished(entry);
+    }
+
+    /// Retention: keep every running record; drop the oldest finished
+    /// ones (finishes land in wire order, so list order is age order)
+    /// past the bound.
+    fn trim_finished(entry: &mut SessionTasks) {
         let finished = entry
             .records
             .iter()
@@ -317,6 +334,44 @@ impl Registry {
                 }
             });
         }
+    }
+
+    /// A backend restart killed the session's still-running background
+    /// tasks (they were children of the replaced process): flip every
+    /// running record to [`BackgroundTaskStatus::DiedWithRestart`] with
+    /// the named cause and return the flipped records, newest state
+    /// first-hand — the supervision seam that observed the process die
+    /// calls this, then surfaces the honest attention state from the
+    /// returned rows. Records are RETAINED (bounded like any finished
+    /// record): a died task is history the owner can still inspect and
+    /// choose to re-run, unlike a running claim nobody can confirm.
+    /// Sessions with nothing running return empty and stay untouched, so
+    /// pre-marked respawn seams compose with the generic shutdown
+    /// backstop without double-marking.
+    pub(crate) fn mark_running_died_with_restart(
+        &mut self,
+        session_id: &str,
+        cause: &str,
+        died_at_epoch: u64,
+    ) -> Vec<BackgroundTaskRecord> {
+        let Some(entry) = self.sessions.get_mut(session_id.trim()) else {
+            return Vec::new();
+        };
+        let mut died = Vec::new();
+        for record in entry
+            .records
+            .iter_mut()
+            .filter(|record| record.status == BackgroundTaskStatus::Running)
+        {
+            record.status = BackgroundTaskStatus::DiedWithRestart;
+            record.ended_at_epoch = Some(died_at_epoch);
+            record.died_cause = Some(cause.to_string());
+            died.push(record.clone());
+        }
+        if !died.is_empty() {
+            Self::trim_finished(entry);
+        }
+        died
     }
 
     /// Forget a session's records — the wrapper shut down, or a fresh
@@ -444,6 +499,14 @@ pub(crate) fn record_finished(
 
 pub(crate) fn clear_session(session_id: &str) {
     global().clear_session(session_id);
+}
+
+pub(crate) fn mark_running_died_with_restart(
+    session_id: &str,
+    cause: &str,
+    died_at_epoch: u64,
+) -> Vec<BackgroundTaskRecord> {
+    global().mark_running_died_with_restart(session_id, cause, died_at_epoch)
 }
 
 pub(crate) fn tasks_for_session(session_id: &str) -> Vec<BackgroundTaskRecord> {
@@ -658,6 +721,50 @@ mod tests {
                 .is_none(),
             "a newline before any path text means no path on the marker line"
         );
+    }
+
+    #[test]
+    fn died_with_restart_flips_running_only_names_the_cause_and_retains() {
+        let mut reg = Registry::new();
+        let sid = "session-respawn";
+        reg.record_started(sid, "task-live", "toolu_live", "cargo test battery", 100);
+        reg.record_started(sid, "task-done", "toolu_done", "quick job", 101);
+        reg.record_finished(sid, "toolu_done", BackgroundTaskStatus::Completed, None, 102);
+
+        let died = reg.mark_running_died_with_restart(sid, "the credential-reload restart", 160);
+        assert_eq!(died.len(), 1, "only running records flip");
+        assert_eq!(died[0].task_id, "task-live");
+        assert_eq!(died[0].status, BackgroundTaskStatus::DiedWithRestart);
+        assert_eq!(
+            died[0].died_cause.as_deref(),
+            Some("the credential-reload restart")
+        );
+        assert_eq!(died[0].ended_at_epoch, Some(160));
+
+        // The record is RETAINED for the inspector/re-run affordance —
+        // that retention is the whole point of marking over clearing.
+        let kept = reg.find_task(sid, "task-live").expect("died row retained");
+        assert_eq!(kept.status, BackgroundTaskStatus::DiedWithRestart);
+        // Finished records never flip or gain a cause.
+        let done = reg.find_task(sid, "task-done").expect("finished retained");
+        assert_eq!(done.status, BackgroundTaskStatus::Completed);
+        assert!(done.died_cause.is_none());
+
+        // Idempotent: a second (generic backstop) mark finds nothing
+        // running and returns empty without churning the named cause.
+        assert!(reg
+            .mark_running_died_with_restart(sid, "the backend shutdown", 170)
+            .is_empty());
+        let kept = reg.find_task(sid, "task-live").expect("still retained");
+        assert_eq!(
+            kept.died_cause.as_deref(),
+            Some("the credential-reload restart"),
+            "the first, most specific cause stands"
+        );
+        // Unknown sessions mark nothing.
+        assert!(reg
+            .mark_running_died_with_restart("session-unknown", "x", 1)
+            .is_empty());
     }
 
     #[test]

--- a/src/bin/caller/boot_readopt.rs
+++ b/src/bin/caller/boot_readopt.rs
@@ -413,6 +413,86 @@ fn scan_midwork_candidates(
     candidates
 }
 
+/// Daemon-restart honesty for parked background tasks (the fourth
+/// respawn class): background tasks are OS children of the dead boot's
+/// backend processes, so every task a dead session was parked on died
+/// with that daemon — while the durable bg-park marker
+/// (`SessionMeta::bg_park`) survived, still claiming a live wait.
+/// Flip each live marker to its died form under the named cause and
+/// publish the attention snapshot into THIS boot's vitals hub, so no
+/// surface (grid chip, drain banner, session card) keeps waiting on a
+/// task that no longer exists. Same walk discipline as
+/// [`scan_midwork_candidates`]: one era predicate parameter, live
+/// wrappers own their own state, unreadable metas skip. Nothing here
+/// re-runs a command — re-running is an owner decision (the session
+/// card's one-tap re-run; readopted candidates additionally get the
+/// offer on the continuation nudge they already receive).
+fn mark_dead_bg_parks(
+    home: &Path,
+    live_wrapper_ids: &HashSet<String>,
+    era_keeps: impl Fn(u64) -> bool,
+    bus: &EventBus,
+) -> usize {
+    let logs_dir = crate::platform::intendant_home_in(home).join("logs");
+    let Ok(entries) = std::fs::read_dir(&logs_dir) else {
+        return 0;
+    };
+    let mut marked = 0usize;
+    for entry in entries.flatten() {
+        let dir = entry.path();
+        if !dir.is_dir() {
+            continue;
+        }
+        let Ok(raw) = std::fs::read_to_string(dir.join("session_meta.json")) else {
+            continue;
+        };
+        let Ok(mut meta) = serde_json::from_str::<SessionMeta>(&raw) else {
+            continue;
+        };
+        let session_id = meta.session_id.trim().to_string();
+        if session_id.is_empty() || live_wrapper_ids.contains(&session_id) {
+            continue;
+        }
+        if !era_keeps(activity_mtime_secs(&dir)) {
+            continue;
+        }
+        let Some(park) = meta.bg_park.as_mut() else {
+            continue;
+        };
+        if park.died_cause.is_some() {
+            // Already stamped (an earlier boot's pass, or the wrapper's
+            // own respawn seam) — the first, most specific cause stands.
+            continue;
+        }
+        let now_epoch = crate::session_activity::epoch_seconds();
+        park.died_cause = Some(crate::external_supervision::DAEMON_RESTART_CAUSE.to_string());
+        park.died_at_epoch = Some(now_epoch);
+        let tasks = park.tasks.clone();
+        let Ok(json) = serde_json::to_string_pretty(&meta) else {
+            continue;
+        };
+        if crate::session_log::write_session_meta_atomic(&dir, &json).is_err() {
+            continue;
+        }
+        eprintln!(
+            "[readopt] {}: {} background task(s) the session was parked on died with the daemon \
+             restart — marked died-with-restart; nothing is re-run automatically",
+            short_id(&session_id),
+            tasks.len(),
+        );
+        bus.send(AppEvent::SessionActivity {
+            session_id: Some(session_id),
+            activity: crate::external_supervision::died_tasks_attention_activity(
+                tasks,
+                crate::external_supervision::DAEMON_RESTART_CAUSE,
+                now_epoch,
+            ),
+        });
+        marked += 1;
+    }
+    marked
+}
+
 /// Merge the agenda seeds into the store scan, deduplicating by session
 /// id (a scheduled session that was also mid-turn or parked is ONE
 /// candidate; the agenda class wins the label and carries suspension).
@@ -632,7 +712,11 @@ pub(crate) fn decide_candidate_with_lens(
         session_id: resume_conversation,
         resume_id: None,
         project_root: project_root.map(|root| root.to_string_lossy().to_string()),
-        task: Some(lens.continuation_text().to_string()),
+        task: Some(readopt_continuation_with_died_tasks(
+            home,
+            &candidate.session_id,
+            lens,
+        )),
         direct: None,
         attachments: Vec::new(),
         fork: false,
@@ -644,6 +728,30 @@ pub(crate) fn decide_candidate_with_lens(
         codex_managed_context: None,
         codex_context_archive: None,
     }))
+}
+
+/// The lens's continuation nudge, extended with the died-task re-run
+/// OFFER when the restart killed background tasks the candidate was
+/// parked on ([`mark_dead_bg_parks`] stamped the durable marker before
+/// dispatch). The #644 composition law: the offer only ever rides a
+/// nudge the lane already sends — never a minted message — and nothing
+/// here re-executes a command.
+fn readopt_continuation_with_died_tasks(
+    home: &Path,
+    candidate_id: &str,
+    lens: ResumeLens,
+) -> String {
+    let mut text = lens.continuation_text().to_string();
+    if let Some(park) = session_meta_for(home, candidate_id).and_then(|meta| meta.bg_park) {
+        if let Some(cause) = park.died_cause.as_deref() {
+            if let Some(addendum) =
+                crate::external_supervision::died_tasks_nudge_addendum(&park.tasks, cause)
+            {
+                text.push_str(&addendum);
+            }
+        }
+    }
+    text
 }
 
 fn short_id(id: &str) -> &str {
@@ -1841,6 +1949,16 @@ pub(crate) async fn run_boot_readopt_pass(
     let live: HashSet<String> = crate::session_supervisor::published_live_session_registry()
         .and_then(|registry| registry.live_wrapper_ids())
         .unwrap_or_default();
+    // Honesty precedes recovery: dead sessions parked on background
+    // tasks get their died-with-restart marking whether or not they
+    // become candidates below (a parked-only session never does — its
+    // meta reads idle — and exactly that shape was the forever-park).
+    mark_dead_bg_parks(
+        &home,
+        &live,
+        |activity_secs| activity_secs < watershed,
+        &bus,
+    );
     let store = scan_store_candidates(&home, watershed, &live);
     let mut candidates = merge_candidates(&seeds, store);
     // Merged agenda-only seeds carry no activity line yet — resolve it
@@ -2299,6 +2417,16 @@ async fn run_released_readopt_pass(
     released_before_secs: u64,
     live: &HashSet<String>,
 ) {
+    // Honesty precedes recovery, same as the boot pass: the exited
+    // predecessor's backend processes took their background children
+    // with them, and a released parked-only session never becomes a
+    // candidate below.
+    mark_dead_bg_parks(
+        home,
+        live,
+        |activity_secs| activity_secs <= released_before_secs,
+        bus,
+    );
     let candidates = scan_released_candidates(home, released_before_secs, live);
     if candidates.is_empty() {
         eprintln!(

--- a/src/bin/caller/boot_readopt.rs
+++ b/src/bin/caller/boot_readopt.rs
@@ -1076,8 +1076,11 @@ mod tests {
                 "died_at_epoch": 100,
             }),
         );
-        let text =
-            readopt_continuation_with_died_tasks(home.path(), "sess-died-park", ResumeLens::MidWork);
+        let text = readopt_continuation_with_died_tasks(
+            home.path(),
+            "sess-died-park",
+            ResumeLens::MidWork,
+        );
         assert!(text.starts_with(READOPT_CONTINUATION_TEXT), "{text}");
         assert!(text.contains("cargo test battery"), "{text}");
         assert!(text.contains("NOT re-run automatically"), "{text}");

--- a/src/bin/caller/boot_readopt.rs
+++ b/src/bin/caller/boot_readopt.rs
@@ -934,6 +934,176 @@ mod tests {
         crate::session_activity::epoch_seconds()
     }
 
+    fn write_meta_with_bg_park(
+        home: &Path,
+        session: &str,
+        status: &str,
+        bg_park: serde_json::Value,
+    ) {
+        let dir = logs_root(home).join(session);
+        std::fs::create_dir_all(&dir).unwrap();
+        let meta = serde_json::json!({
+            "session_id": session,
+            "created_at": "2026-07-28T00:00:00",
+            "status": status,
+            "bg_park": bg_park,
+        });
+        std::fs::write(
+            dir.join("session_meta.json"),
+            serde_json::to_string_pretty(&meta).unwrap(),
+        )
+        .unwrap();
+    }
+
+    /// The daemon-restart respawn class: a dead-boot session parked on
+    /// background tasks (idle meta, live bg-park marker — NEVER a
+    /// readopt candidate) gets its marker flipped to died-with-restart
+    /// and the attention snapshot published; live wrappers, this boot's
+    /// era, and already-died markers stay untouched. Nothing dispatches.
+    #[test]
+    fn boot_pass_marks_dead_boot_bg_parks_died() {
+        let home = tempfile::tempdir().unwrap();
+        write_meta_with_bg_park(
+            home.path(),
+            "sess-parked-dead",
+            "idle",
+            serde_json::json!({ "tasks": ["cargo test battery"] }),
+        );
+        write_meta_with_bg_park(
+            home.path(),
+            "sess-live-wrapper",
+            "idle",
+            serde_json::json!({ "tasks": ["still mine"] }),
+        );
+        write_meta_with_bg_park(
+            home.path(),
+            "sess-already-died",
+            "idle",
+            serde_json::json!({
+                "tasks": ["old battery"],
+                "died_cause": "the credential-reload restart",
+                "died_at_epoch": 50,
+            }),
+        );
+        let bus = crate::event::EventBus::new();
+        let mut events = bus.subscribe();
+        let mut live = HashSet::new();
+        live.insert("sess-live-wrapper".to_string());
+
+        let marked = mark_dead_bg_parks(home.path(), &live, |_| true, &bus);
+        assert_eq!(marked, 1, "exactly the dead parked session marks");
+
+        let park_of = |session: &str| -> crate::session_log::SessionBgParkMeta {
+            serde_json::from_str::<SessionMeta>(
+                &std::fs::read_to_string(
+                    logs_root(home.path())
+                        .join(session)
+                        .join("session_meta.json"),
+                )
+                .unwrap(),
+            )
+            .unwrap()
+            .bg_park
+            .expect("marker present")
+        };
+        assert_eq!(
+            park_of("sess-parked-dead").died_cause.as_deref(),
+            Some(crate::external_supervision::DAEMON_RESTART_CAUSE)
+        );
+        assert!(
+            park_of("sess-live-wrapper").died_cause.is_none(),
+            "live wrappers own their own state"
+        );
+        assert_eq!(
+            park_of("sess-already-died").died_cause.as_deref(),
+            Some("the credential-reload restart"),
+            "the first, most specific cause stands"
+        );
+
+        // The one bus emission is the attention snapshot — never a
+        // dispatch (no automatic re-execution at boot either).
+        let mut activity_seen = 0;
+        while let Ok(event) = events.try_recv() {
+            match event {
+                AppEvent::SessionActivity {
+                    session_id,
+                    activity,
+                } => {
+                    activity_seen += 1;
+                    assert_eq!(session_id.as_deref(), Some("sess-parked-dead"));
+                    assert_eq!(
+                        activity.died_background_tasks,
+                        vec!["cargo test battery".to_string()]
+                    );
+                    assert_eq!(
+                        activity.died_tasks_cause.as_deref(),
+                        Some(crate::external_supervision::DAEMON_RESTART_CAUSE)
+                    );
+                }
+                other => panic!("boot bg-park marking emitted {other:?}"),
+            }
+        }
+        assert_eq!(activity_seen, 1);
+
+        // Era line: a session the predicate excludes stays untouched.
+        write_meta_with_bg_park(
+            home.path(),
+            "sess-this-boot",
+            "idle",
+            serde_json::json!({ "tasks": ["fresh work"] }),
+        );
+        assert_eq!(
+            mark_dead_bg_parks(home.path(), &live, |_| false, &bus),
+            0,
+            "the era predicate gates everything"
+        );
+        assert!(park_of("sess-this-boot").died_cause.is_none());
+    }
+
+    /// Readopted candidates carry the died-task re-run OFFER on the
+    /// continuation nudge they already receive — and only then: no died
+    /// marker (or a live park) leaves the nudge untouched.
+    #[test]
+    fn readopt_continuation_carries_the_died_task_offer() {
+        let home = tempfile::tempdir().unwrap();
+        write_meta_with_bg_park(
+            home.path(),
+            "sess-died-park",
+            "running",
+            serde_json::json!({
+                "tasks": ["cargo test battery"],
+                "died_cause": "the daemon restart",
+                "died_at_epoch": 100,
+            }),
+        );
+        let text =
+            readopt_continuation_with_died_tasks(home.path(), "sess-died-park", ResumeLens::MidWork);
+        assert!(text.starts_with(READOPT_CONTINUATION_TEXT), "{text}");
+        assert!(text.contains("cargo test battery"), "{text}");
+        assert!(text.contains("NOT re-run automatically"), "{text}");
+
+        write_meta_with_bg_park(
+            home.path(),
+            "sess-live-park",
+            "running",
+            serde_json::json!({ "tasks": ["still running elsewhere"] }),
+        );
+        assert_eq!(
+            readopt_continuation_with_died_tasks(
+                home.path(),
+                "sess-live-park",
+                ResumeLens::MidWork
+            ),
+            READOPT_CONTINUATION_TEXT,
+            "a live park adds nothing"
+        );
+        assert_eq!(
+            readopt_continuation_with_died_tasks(home.path(), "sess-absent", ResumeLens::MidWork),
+            READOPT_CONTINUATION_TEXT,
+            "no meta, no addendum"
+        );
+    }
+
     /// The enumeration takes only the DEAD boot's mid-work sessions:
     /// a mid-turn (`running`) meta and a parked-with-pending meta are
     /// candidates when their activity predates the boot watershed, and

--- a/src/bin/caller/external_agent/claude_code.rs
+++ b/src/bin/caller/external_agent/claude_code.rs
@@ -1806,17 +1806,26 @@ impl CcReader {
         if self.announced_session_id.as_deref() == Some(id) {
             return;
         }
-        // Fresh adoption of an id by THIS reader: inspector-registry
-        // records under it belong to a previous process's background
-        // children (a resumed CLI does not own them — their task events
-        // will never arrive here), and on an id CHANGE the old id's
-        // records lose their observer the same way. Clear both sides;
-        // this precedes any arm this reader performs, since adoption
-        // happens before the line's handler runs.
+        // Fresh adoption of an id by THIS reader: still-running
+        // inspector-registry records under it belong to a previous
+        // process's background children (a resumed CLI does not own them
+        // — their task events will never arrive here), and on an id
+        // CHANGE the old id's records lose their observer the same way.
+        // Flip them to died-with-restart instead of clearing: terminal
+        // rows are history the owner can still inspect and re-run, and
+        // the wrapper's respawn seams usually pre-marked them with the
+        // specific restart cause (this generic mark then finds nothing
+        // running). Precedes any arm this reader performs, since
+        // adoption happens before the line's handler runs.
+        let now_epoch = crate::session_activity::epoch_seconds();
         if let Some(previous) = self.announced_session_id.as_deref() {
-            crate::background_tasks::clear_session(previous);
+            crate::background_tasks::mark_running_died_with_restart(
+                previous,
+                "a backend restart",
+                now_epoch,
+            );
         }
-        crate::background_tasks::clear_session(id);
+        crate::background_tasks::mark_running_died_with_restart(id, "a backend restart", now_epoch);
         self.announced_session_id = Some(id.to_string());
         self.shared.set_session_id(id);
         out.events.push(AgentEvent::NativeSessionId {
@@ -4638,11 +4647,18 @@ impl ExternalAgent for ClaudeCodeAgent {
     }
 
     async fn shutdown(&mut self) -> Result<(), CallerError> {
-        // The CLI (and its supervision of background commands) is going
-        // away: nobody will confirm task state again, so the inspector
-        // registry must not keep claiming it.
+        // The CLI is going away and its background commands die with it:
+        // flip any still-running inspector records to died-with-restart
+        // (retained history — the owner can still inspect and choose to
+        // re-run) instead of claiming a running state nobody will ever
+        // confirm again. Respawn seams that know the specific restart
+        // pre-marked with its name; this generic mark is the backstop.
         if let Some(session) = self.shared.session_id() {
-            crate::background_tasks::clear_session(&session);
+            crate::background_tasks::mark_running_died_with_restart(
+                &session,
+                "the backend shutdown",
+                crate::session_activity::epoch_seconds(),
+            );
         }
         if let Some(handle) = self.reader_handle.take() {
             handle.abort();
@@ -4670,10 +4686,15 @@ impl ExternalAgent for ClaudeCodeAgent {
 
 impl Drop for ClaudeCodeAgent {
     fn drop(&mut self) {
-        // Backstop for the shutdown-path clear (drop without shutdown):
-        // a dead wrapper's inspector records claim knowledge nobody has.
+        // Backstop for the shutdown-path mark (drop without shutdown):
+        // a dead wrapper's still-running inspector records claim
+        // knowledge nobody has — flip them, keep the history.
         if let Some(session) = self.shared.session_id() {
-            crate::background_tasks::clear_session(&session);
+            crate::background_tasks::mark_running_died_with_restart(
+                &session,
+                "the backend shutdown",
+                crate::session_activity::epoch_seconds(),
+            );
         }
         if let Some(ref mut child) = self.child {
             let child_pid = child.id();

--- a/src/bin/caller/external_agent/claude_code.rs
+++ b/src/bin/caller/external_agent/claude_code.rs
@@ -5332,15 +5332,29 @@ mod tests {
             Some(std::path::Path::new(&structured_path))
         );
 
-        // A fresh reader adopting the same backend id clears the records.
+        // A fresh reader adopting the same backend id does not own the
+        // previous process's background children — but it no longer
+        // FORGETS them either: still-running records flip to
+        // died-with-restart (retained history the owner can inspect and
+        // choose to re-run; the wrapper's respawn seams usually pre-mark
+        // with the specific restart cause), and finished records stay as
+        // they were.
         let mut resumed = test_reader();
         resumed.process_line(&format!(
             r#"{{"type":"system","subtype":"init","session_id":"{sid}"}}"#,
         ));
+        let survived = background_tasks::find_task(sid, "breg2")
+            .expect("the running record is retained, flipped — never cleared");
+        assert_eq!(survived.status, BackgroundTaskStatus::DiedWithRestart);
+        assert_eq!(survived.died_cause.as_deref(), Some("a backend restart"));
+        assert!(survived.ended_at_epoch.is_some());
+        let done = background_tasks::find_task(sid, "breg1").expect("finished record retained");
+        assert_eq!(done.status, BackgroundTaskStatus::Completed);
         assert!(
-            !background_tasks::session_known(sid),
-            "re-adoption clears a previous process's records"
+            done.died_cause.is_none(),
+            "finished records never gain a cause"
         );
+        background_tasks::clear_session(sid);
     }
 
     /// The `system:init` `cwd` echo emits ONE `CwdAnnounced` per distinct

--- a/src/bin/caller/external_events.rs
+++ b/src/bin/caller/external_events.rs
@@ -1556,7 +1556,10 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                 // Wire-fact activity snapshot → the vitals hub (keyed like
                 // usage; the hub's identity aliasing folds it into the
                 // session's one entry). Pure bookkeeping — never opens or
-                // completes a turn.
+                // completes a turn. The durable bg-park marker shadows the
+                // claim (parked stamps it, working clears it) so a dead
+                // boot can still tell a live wait from a dead one.
+                stamp_bg_park_marker_from_activity(config.session_log, &activity);
                 config.bus.send(AppEvent::SessionActivity {
                     session_id: config.session_id.clone(),
                     activity,

--- a/src/bin/caller/external_mode.rs
+++ b/src/bin/caller/external_mode.rs
@@ -126,8 +126,13 @@ pub(crate) fn idle_external_pr_published_event(
 /// resume-attached to the same backend session id so the new process
 /// reads the fresh credential store. Queued `parked_follow_ups` stay in
 /// the loop untouched and flush through the normal preamble after the
-/// respawn. Returns `false` when the respawn failed — the old process is
-/// already gone, so the caller exits the loop honestly.
+/// respawn. Returns `None` when the respawn failed — the old process is
+/// already gone, so the caller exits the loop honestly; on success,
+/// returns the descriptions of parked background tasks the restart
+/// killed (they were the old process's children —
+/// [`mark_parked_tasks_died_with_restart`] flipped their records and
+/// published the attention state before the shutdown), so the caller's
+/// continuation can carry the re-run offer.
 #[allow(clippy::too_many_arguments)]
 async fn apply_backend_credentials_reload(
     backend: &external_agent::AgentBackend,
@@ -143,7 +148,7 @@ async fn apply_backend_credentials_reload(
     agent: &mut Box<dyn external_agent::ExternalAgent>,
     event_rx: &mut tokio::sync::mpsc::UnboundedReceiver<external_agent::AgentEvent>,
     drain_config: &mut DrainConfig<'_>,
-) -> bool {
+) -> Option<Vec<String>> {
     let session_log = drain_config.session_log;
     let announce = |line: &str| {
         slog(session_log, |l| l.info(line));
@@ -184,6 +189,16 @@ async fn apply_backend_credentials_reload(
         .announced_native_session_id
         .clone()
         .or_else(|| drain_config.backend_thread_id.clone());
+    // The restart kills the old process's background children before the
+    // fresh process exists: flip any parked-on tasks to died-with-restart
+    // NOW, with this class's name, so the park never outlives its wake.
+    let died_task_descs = mark_parked_tasks_died_with_restart(
+        drain_config.bus,
+        session_log,
+        &drain_config.session_id,
+        stats.announced_native_session_id.as_deref(),
+        CREDENTIAL_RELOAD_RESTART_CAUSE,
+    );
     announce(&format!(
         "Reloading credentials: restarting {} resume-attached to its backend session",
         backend
@@ -214,7 +229,7 @@ async fn apply_backend_credentials_reload(
                 "Credential reload complete — the backend restarted on the fresh credential store",
             );
             progress(crate::event::CredentialReloadProgress::Done);
-            true
+            Some(died_task_descs)
         }
         Err(e) => {
             let line = format!(
@@ -226,10 +241,14 @@ async fn apply_backend_credentials_reload(
                 error: format!("could not respawn {backend}: {e}"),
             });
             drain_config.bus.send(AppEvent::LoopError(line));
-            false
+            None
         }
     }
 }
+
+/// The named cause stamped on background tasks the credential-reload
+/// respawn kills (see [`mark_parked_tasks_died_with_restart`]).
+pub(crate) const CREDENTIAL_RELOAD_RESTART_CAUSE: &str = "the credential-reload restart";
 
 /// The follow-up text synthesized when a credential reload's own
 /// interrupt cut a live turn. Resume-attach keeps the conversation
@@ -727,7 +746,7 @@ pub(crate) async fn run_external_agent_mode(
         // backend and returned; the respawn precedes any queued turn so
         // the next delivery runs on the fresh credential store.
         if backend_credentials_reload.swap(false, std::sync::atomic::Ordering::SeqCst) {
-            if !apply_backend_credentials_reload(
+            let Some(reload_died_task_descs) = apply_backend_credentials_reload(
                 &backend,
                 &project,
                 web_port,
@@ -743,21 +762,32 @@ pub(crate) async fn run_external_agent_mode(
                 &mut drain_config,
             )
             .await
-            {
+            else {
                 stats.terminal_outcome =
                     Some("credential reload could not respawn the backend".to_string());
                 break 'outer;
-            }
+            };
             // When the reload's own interrupt cut the live turn, the
             // turn's driving message was consumed mid-delivery — nothing
             // re-drives it after the respawn, so the session would idle
             // on the fresh account with the work half-done. Mirror the
             // rate-limit park's pending preservation: front-queue a
             // synthesized continuation so the flush below re-drives the
-            // interrupted work ahead of anything queued behind it.
-            if let Some(continuation) =
+            // interrupted work ahead of anything queued behind it. When
+            // the restart also killed parked background tasks, the
+            // continuation carries the re-run OFFER (and only an already
+            // owed continuation does — a between-rounds park mints no
+            // nudge; its surfaces are the attention state and the session
+            // card's one-tap re-run).
+            if let Some(mut continuation) =
                 synthesized_reload_continuation(std::mem::take(&mut reload_interrupted_turn))
             {
+                if let Some(addendum) = died_tasks_nudge_addendum(
+                    &reload_died_task_descs,
+                    CREDENTIAL_RELOAD_RESTART_CAUSE,
+                ) {
+                    continuation.text.push_str(&addendum);
+                }
                 parked_follow_ups.push_front(continuation);
                 let line = "Credential reload interrupted the previous turn — queued a continuation so the work resumes on the fresh account";
                 slog(&session_log, |l| l.info(line));
@@ -1081,6 +1111,10 @@ pub(crate) async fn run_external_agent_mode(
                                     // snapshot implies no turn and must not
                                     // open a spontaneous round).
                                     external_agent::AgentEvent::ActivityUpdate { activity } => {
+                                        stamp_bg_park_marker_from_activity(
+                                            &session_log,
+                                            &activity,
+                                        );
                                         bus.send(AppEvent::SessionActivity {
                                             session_id: drain_config.session_id.clone(),
                                             activity,
@@ -1363,7 +1397,26 @@ pub(crate) async fn run_external_agent_mode(
                                                 round = round.saturating_sub(1);
                                                 limit_park_streak =
                                                     limit_park_streak.saturating_add(1);
-                                                let (park, park_line) =
+                                                // Confirmed-exit gated:
+                                                // a limit that killed
+                                                // the process killed its
+                                                // background children;
+                                                // the resume nudge then
+                                                // carries the re-run
+                                                // offer.
+                                                let died_addendum =
+                                                    mark_died_tasks_at_park_arm(
+                                                        &mut agent,
+                                                        &bus,
+                                                        &session_log,
+                                                        &live_session_id,
+                                                        stats
+                                                            .announced_native_session_id
+                                                            .as_deref(),
+                                                        RATE_LIMIT_RESTART_CAUSE,
+                                                        turn_had_started,
+                                                    );
+                                                let (mut park, park_line) =
                                                     backend_started_limit_park(
                                                         resets_at_epoch,
                                                         tokio::time::Instant::now(),
@@ -1372,6 +1425,11 @@ pub(crate) async fn run_external_agent_mode(
                                                         limit_park_jitter_secs(),
                                                         turn_had_started,
                                                     );
+                                                if let (Some(pending), Some(addendum)) =
+                                                    (park.pending.as_mut(), died_addendum)
+                                                {
+                                                    pending.text.push_str(&addendum);
+                                                }
                                                 let has_pending = park.pending.is_some();
                                                 slog(&session_log, |l| l.warn(&park_line));
                                                 bus.send(AppEvent::LogEntry {
@@ -1533,7 +1591,27 @@ pub(crate) async fn run_external_agent_mode(
                                                     break 'outer;
                                                 }
                                                 round = round.saturating_sub(1);
-                                                let (park, park_line) =
+                                                // A spontaneous round's
+                                                // death that took the
+                                                // process took its
+                                                // background children
+                                                // too (confirmed-exit
+                                                // gated); the resume
+                                                // nudge carries the
+                                                // re-run offer.
+                                                let died_addendum =
+                                                    mark_died_tasks_at_park_arm(
+                                                        &mut agent,
+                                                        &bus,
+                                                        &session_log,
+                                                        &live_session_id,
+                                                        stats
+                                                            .announced_native_session_id
+                                                            .as_deref(),
+                                                        SERVICE_RECOVERY_RESTART_CAUSE,
+                                                        turn_had_started,
+                                                    );
+                                                let (mut park, park_line) =
                                                     transient_round_death_error_park(
                                                         &reason,
                                                         tokio::time::Instant::now(),
@@ -1542,6 +1620,11 @@ pub(crate) async fn run_external_agent_mode(
                                                         turn_had_started,
                                                         None,
                                                     );
+                                                if let (Some(pending), Some(addendum)) =
+                                                    (park.pending.as_mut(), died_addendum)
+                                                {
+                                                    pending.text.push_str(&addendum);
+                                                }
                                                 let has_pending = park.pending.is_some();
                                                 slog(&session_log, |l| l.warn(&park_line));
                                                 bus.send(AppEvent::LogEntry {
@@ -2116,9 +2199,13 @@ pub(crate) async fn run_external_agent_mode(
                                 // right away (the park cancel inside
                                 // preserves the pending re-send; queued
                                 // messages flush through the preamble).
+                                // No continuation is owed from idle, so
+                                // tasks the restart killed surface through
+                                // the attention state the respawn already
+                                // published — never a minted nudge.
                                 backend_credentials_reload
                                     .store(false, std::sync::atomic::Ordering::SeqCst);
-                                if !apply_backend_credentials_reload(
+                                if apply_backend_credentials_reload(
                                     &backend,
                                     &project,
                                     web_port,
@@ -2134,6 +2221,7 @@ pub(crate) async fn run_external_agent_mode(
                                     &mut drain_config,
                                 )
                                 .await
+                                .is_none()
                                 {
                                     stats.terminal_outcome = Some(
                                         "credential reload could not respawn the backend"
@@ -3935,11 +4023,28 @@ pub(crate) async fn run_external_agent_mode(
                         turn: None,
                     });
                 }
+                // A limit-killed backend process took its background
+                // children with it (confirmed-exit gated: a mere
+                // rejection against a live process marks nothing) — the
+                // resume nudge then carries the re-run offer.
+                let died_addendum = mark_died_tasks_at_park_arm(
+                    &mut agent,
+                    &bus,
+                    &session_log,
+                    &live_session_id,
+                    stats.announced_native_session_id.as_deref(),
+                    RATE_LIMIT_RESTART_CAUSE,
+                    turn_had_started,
+                );
                 let mut pending = active_followup_for_rewind_replay.clone();
                 pending.text = merged.clone();
+                let mut parked_pending = limit_park_pending(pending, turn_had_started);
+                if let Some(addendum) = died_addendum {
+                    parked_pending.text.push_str(&addendum);
+                }
                 limit_park = Some(LimitParkState {
                     resume_at: tokio::time::Instant::now() + delay,
-                    pending: Some(limit_park_pending(pending, turn_had_started)),
+                    pending: Some(parked_pending),
                     kind: ParkKind::ProviderLimit,
                 });
                 // Durable park marker: the in-memory park dies with the
@@ -3997,9 +4102,22 @@ pub(crate) async fn run_external_agent_mode(
                     break;
                 }
                 round = round.saturating_sub(1);
+                // A round death that took the backend process also took
+                // its background children (confirmed-exit gated — an
+                // API-500 against a live process marks nothing); the
+                // resume nudge then carries the re-run offer.
+                let died_addendum = mark_died_tasks_at_park_arm(
+                    &mut agent,
+                    &bus,
+                    &session_log,
+                    &live_session_id,
+                    stats.announced_native_session_id.as_deref(),
+                    SERVICE_RECOVERY_RESTART_CAUSE,
+                    turn_had_started,
+                );
                 let mut pending = active_followup_for_rewind_replay.clone();
                 pending.text = merged.clone();
-                let (park, park_line) = transient_round_death_error_park(
+                let (mut park, park_line) = transient_round_death_error_park(
                     &reason,
                     tokio::time::Instant::now(),
                     error_park_streak,
@@ -4007,6 +4125,9 @@ pub(crate) async fn run_external_agent_mode(
                     turn_had_started,
                     Some(pending),
                 );
+                if let (Some(pending), Some(addendum)) = (park.pending.as_mut(), died_addendum) {
+                    pending.text.push_str(&addendum);
+                }
                 let has_pending = park.pending.is_some();
                 slog(&session_log, |l| l.warn(&park_line));
                 bus.send(AppEvent::LogEntry {

--- a/src/bin/caller/external_supervision.rs
+++ b/src/bin/caller/external_supervision.rs
@@ -1671,6 +1671,206 @@ pub(crate) fn delivery_aware_park_pending(
     }
 }
 
+/// A backend respawn class killed this session's still-running background
+/// tasks (they were OS children of the replaced backend process, and the
+/// replacement does not inherit them). Flip their registry records to
+/// died-with-restart under the named cause, stamp the durable bg-park
+/// marker's died form, log the honest line, and publish the attention
+/// activity snapshot that replaces the stale `parked-on-tasks` claim —
+/// the park marker is session-state and survives every respawn class
+/// (credential reload, service-recovery restart, rate-limit restart,
+/// daemon restart) while the tasks never do, and until this seam nothing
+/// reconciled the two: a forever-park waiting on a dead wake.
+///
+/// Returns the died tasks' descriptions so a respawn lane that ALREADY
+/// sends a delivery-aware continuation can carry the re-run offer on it
+/// ([`died_tasks_nudge_addendum`]). NOTHING here re-executes a command or
+/// re-arms delivery: commands are not known idempotent, so re-running is
+/// an owner decision — the session card's one-tap re-run, or the model
+/// deciding after an owner-visible nudge.
+pub(crate) fn mark_parked_tasks_died_with_restart(
+    bus: &EventBus,
+    session_log: &SharedSessionLog,
+    live_session_id: &Option<String>,
+    backend_session_id: Option<&str>,
+    cause: &str,
+) -> Vec<String> {
+    let Some(backend_session_id) = backend_session_id.map(str::trim).filter(|s| !s.is_empty())
+    else {
+        return Vec::new();
+    };
+    let now_epoch = crate::session_activity::epoch_seconds();
+    let died = crate::background_tasks::mark_running_died_with_restart(
+        backend_session_id,
+        cause,
+        now_epoch,
+    );
+    if died.is_empty() {
+        return Vec::new();
+    }
+    let descs: Vec<String> = died
+        .iter()
+        .map(|record| record.description.clone())
+        .collect();
+    let line = format!(
+        "⚠ {} background task{} died with {cause} — nothing is re-run automatically: {}",
+        descs.len(),
+        if descs.len() == 1 { "" } else { "s" },
+        descs.join("; "),
+    );
+    slog(session_log, |l| l.warn(&line));
+    bus.send(AppEvent::LogEntry {
+        session_id: live_session_id.clone(),
+        level: "warn".to_string(),
+        source: "Intendant".to_string(),
+        content: line,
+        turn: None,
+    });
+    // Durable half: the boot pass and the drain wait set read this
+    // marker, so a died park stays adjudicable after the daemon itself
+    // restarts. Cleared when the session works again (the live-park
+    // stamping seam observes any non-parked activity).
+    slog(session_log, |l| {
+        l.set_bg_park(Some(session_log::SessionBgParkMeta {
+            tasks: descs.clone(),
+            died_cause: Some(cause.to_string()),
+            died_at_epoch: Some(now_epoch),
+        }))
+    });
+    // Live half: replace the stale parked claim on every surface that
+    // mirrors the vitals hub. The next publish from a live activity
+    // machine (a resumed turn) clears the attention state.
+    bus.send(AppEvent::SessionActivity {
+        session_id: live_session_id.clone(),
+        activity: died_tasks_attention_activity(descs.clone(), cause, now_epoch),
+    });
+    descs
+}
+
+/// The honest between-turn snapshot after a respawn killed the parked
+/// tasks: no turn running, no live tasks — died ones, with the named
+/// cause. `Idle` is the truthful state (nothing is happening); the died
+/// fields are what make it an attention state on the dashboard.
+pub(crate) fn died_tasks_attention_activity(
+    died_background_tasks: Vec<String>,
+    cause: &str,
+    now_epoch: u64,
+) -> crate::types::SessionActivityVitals {
+    crate::types::SessionActivityVitals {
+        state: crate::types::SessionActivityState::Idle,
+        since_epoch: now_epoch,
+        last_stream_byte_epoch: now_epoch,
+        stalled_after_seconds: None,
+        resets_at_epoch: None,
+        background_tasks: Vec::new(),
+        died_background_tasks,
+        died_tasks_cause: Some(cause.to_string()),
+    }
+}
+
+/// The re-run OFFER a respawn lane appends to a continuation nudge it
+/// ALREADY sends (#644's delivery-aware machinery — never a second lane):
+/// `None` when no tasks died, and never a message of its own — a respawn
+/// that owes the model no continuation keeps owing none (the attention
+/// state and the session card's one-tap re-run are the surfaces then),
+/// and a verbatim re-send of the owner's message is never mutated. Text
+/// only; the daemon never re-executes the command itself.
+pub(crate) fn died_tasks_nudge_addendum(descs: &[String], cause: &str) -> Option<String> {
+    match descs {
+        [] => None,
+        [desc] => Some(format!(
+            " Note: the background task you were waiting on (\"{desc}\") died with {cause} and \
+             was NOT re-run automatically (commands are not known idempotent) — re-run it \
+             yourself if the work still needs it."
+        )),
+        many => Some(format!(
+            " Note: {} background tasks you were waiting on died with {cause} and were NOT \
+             re-run automatically (commands are not known idempotent): {}. Re-run them yourself \
+             if the work still needs them.",
+            many.len(),
+            many.join("; "),
+        )),
+    }
+}
+
+/// Keep the durable bg-park marker (`SessionMeta::bg_park`) mirroring
+/// the backend's own activity claims — the write side of the marker the
+/// boot pass and the drain wait set adjudicate from. A parked-on-tasks
+/// claim stamps the live form; any turn state clears the marker (the
+/// session demonstrably works again — this is also what resolves a
+/// died-with-restart attention state); a quiet idle clears only a LIVE
+/// marker, never a died one (a respawned backend settling through an
+/// empty round must not erase the statement that its predecessor's
+/// tasks died).
+pub(crate) fn stamp_bg_park_marker_from_activity(
+    session_log: &SharedSessionLog,
+    activity: &crate::types::SessionActivityVitals,
+) {
+    use crate::types::SessionActivityState as S;
+    match activity.state {
+        S::ParkedOnTasks => slog(session_log, |l| {
+            l.set_bg_park(Some(session_log::SessionBgParkMeta {
+                tasks: activity.background_tasks.clone(),
+                died_cause: None,
+                died_at_epoch: None,
+            }))
+        }),
+        S::Idle | S::Stalled => slog(session_log, |l| l.clear_bg_park_if_live()),
+        S::AwaitingApi | S::Reasoning | S::Responding | S::ToolRunning | S::RateLimited => {
+            slog(session_log, |l| l.set_bg_park(None))
+        }
+    }
+}
+
+/// The named cause stamped on background tasks a service-condition
+/// round death took with the backend process (the error park's respawn
+/// class — the replacement process spawns at the park's wake).
+pub(crate) const SERVICE_RECOVERY_RESTART_CAUSE: &str = "the service-recovery restart";
+
+/// The named cause stamped on background tasks that died with a
+/// limit-killed backend process (the rate-limit park's respawn class).
+pub(crate) const RATE_LIMIT_RESTART_CAUSE: &str = "the rate-limit restart";
+
+/// The named cause stamped on background tasks that died with the whole
+/// daemon (the boot pass's respawn class — every backend process was a
+/// child of the dead boot).
+pub(crate) const DAEMON_RESTART_CAUSE: &str = "the daemon restart";
+
+/// Park-arm composition of [`mark_parked_tasks_died_with_restart`]: a
+/// round death may or may not have taken the backend process with it —
+/// an API-500 against a live process leaves its background children
+/// running and the park honest, so marking is gated on the backend's own
+/// confirmed-exit probe (`next_round_reads_fresh_credentials`: true
+/// exactly when no live backend process remains; backends without the
+/// probe never mark here). Returns the re-run addendum for the park's
+/// pending exactly when that pending is the synthesized resume nudge
+/// (`turn_had_started`) — a verbatim re-send of the owner's own message
+/// is never mutated, and no nudge is ever minted for this.
+pub(crate) fn mark_died_tasks_at_park_arm(
+    agent: &mut Box<dyn external_agent::ExternalAgent>,
+    bus: &EventBus,
+    session_log: &SharedSessionLog,
+    live_session_id: &Option<String>,
+    backend_session_id: Option<&str>,
+    cause: &str,
+    turn_had_started: bool,
+) -> Option<String> {
+    if !agent.next_round_reads_fresh_credentials() {
+        return None;
+    }
+    let descs = mark_parked_tasks_died_with_restart(
+        bus,
+        session_log,
+        live_session_id,
+        backend_session_id,
+        cause,
+    );
+    if !turn_had_started {
+        return None;
+    }
+    died_tasks_nudge_addendum(&descs, cause)
+}
+
 /// The session-log/activity row announcing a park. One place so the two
 /// lanes (persistent daemon lane and the supervised external-mode lane)
 /// cannot drift. `has_pending` says whether a rejected message will be

--- a/src/bin/caller/external_supervision.rs
+++ b/src/bin/caller/external_supervision.rs
@@ -2281,6 +2281,167 @@ pub(crate) fn shared_codex_config_from_project(
 mod tests {
     use super::*;
 
+    /// THE no-auto-re-execution pin for the died-with-restart class: the
+    /// marking seam flips registry records and publishes SURFACES only —
+    /// a log row and the honest activity snapshot. It never emits a
+    /// dispatch-shaped event, never constructs a FollowUpMessage, and the
+    /// re-run OFFER composer mints nothing on its own (`None` without
+    /// died tasks; text-only with them). Anyone adding a re-run lane for
+    /// this class must delete this pin first.
+    #[test]
+    fn died_with_restart_marking_never_arms_delivery() {
+        let sid = "cc-died-pin-session";
+        crate::background_tasks::clear_session(sid);
+        crate::background_tasks::record_started(sid, "task-1", "toolu_1", "cargo test battery", 100);
+        let bus = EventBus::new();
+        let mut rx = bus.subscribe();
+        let dir = tempfile::tempdir().unwrap();
+        let log = std::sync::Arc::new(std::sync::Mutex::new(
+            session_log::SessionLog::open(dir.path().join("s")).unwrap(),
+        ));
+        slog(&log, |l| l.write_meta(None, Some("seat")));
+
+        let descs = mark_parked_tasks_died_with_restart(
+            &bus,
+            &log,
+            &Some("wrapper-1".to_string()),
+            Some(sid),
+            SERVICE_RECOVERY_RESTART_CAUSE,
+        );
+        assert_eq!(descs, vec!["cargo test battery".to_string()]);
+
+        // The registry flipped with the named cause and RETAINED the row.
+        let task = crate::background_tasks::find_task(sid, "task-1").expect("retained");
+        assert_eq!(
+            task.status,
+            crate::background_tasks::BackgroundTaskStatus::DiedWithRestart
+        );
+        assert_eq!(task.died_cause.as_deref(), Some(SERVICE_RECOVERY_RESTART_CAUSE));
+
+        // The durable marker flipped to its died form.
+        let meta_park = log
+            .lock()
+            .unwrap()
+            .dir()
+            .join("session_meta.json");
+        let meta: session_log::SessionMeta =
+            serde_json::from_str(&std::fs::read_to_string(meta_park).unwrap()).unwrap();
+        let park = meta.bg_park.expect("died marker stamped");
+        assert_eq!(park.died_cause.as_deref(), Some(SERVICE_RECOVERY_RESTART_CAUSE));
+        assert_eq!(park.tasks, vec!["cargo test battery".to_string()]);
+
+        // THE PIN: the bus carries surfaces only. No follow-up, steer,
+        // task-start, or any other dispatch-shaped event exists on it.
+        let mut saw_log = false;
+        let mut saw_activity = false;
+        while let Ok(event) = rx.try_recv() {
+            match event {
+                AppEvent::LogEntry { .. } => saw_log = true,
+                AppEvent::SessionActivity { activity, .. } => {
+                    saw_activity = true;
+                    assert_eq!(
+                        activity.died_background_tasks,
+                        vec!["cargo test battery".to_string()]
+                    );
+                    assert_eq!(
+                        activity.died_tasks_cause.as_deref(),
+                        Some(SERVICE_RECOVERY_RESTART_CAUSE)
+                    );
+                    assert_eq!(activity.state, crate::types::SessionActivityState::Idle);
+                    assert!(activity.background_tasks.is_empty());
+                }
+                other => panic!(
+                    "died-with-restart marking emitted a non-surface event: {other:?} — \
+                     no automatic re-execution lane may exist for this class"
+                ),
+            }
+        }
+        assert!(saw_log && saw_activity, "both surfaces publish");
+
+        // The offer composer never mints a message of its own.
+        assert!(died_tasks_nudge_addendum(&[], SERVICE_RECOVERY_RESTART_CAUSE).is_none());
+        let one = died_tasks_nudge_addendum(
+            &["cargo test battery".to_string()],
+            SERVICE_RECOVERY_RESTART_CAUSE,
+        )
+        .expect("addendum text");
+        assert!(one.contains("NOT re-run automatically"), "{one}");
+        assert!(one.contains(SERVICE_RECOVERY_RESTART_CAUSE), "{one}");
+
+        // Marking with nothing running is silent — no surfaces, no churn.
+        let again = mark_parked_tasks_died_with_restart(
+            &bus,
+            &log,
+            &Some("wrapper-1".to_string()),
+            Some(sid),
+            RATE_LIMIT_RESTART_CAUSE,
+        );
+        assert!(again.is_empty());
+        assert!(rx.try_recv().is_err(), "no re-mark, no surfaces");
+        crate::background_tasks::clear_session(sid);
+    }
+
+    /// The durable bg-park marker follows the activity claims: parked
+    /// stamps the live form, quiet idle clears only a live marker (a
+    /// died statement survives a respawned backend settling), and any
+    /// turn state clears everything — work demonstrably resumed.
+    #[test]
+    fn bg_park_marker_follows_activity_claims() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = std::sync::Arc::new(std::sync::Mutex::new(
+            session_log::SessionLog::open(dir.path().join("s")).unwrap(),
+        ));
+        slog(&log, |l| l.write_meta(None, Some("seat")));
+        let meta_path = { log.lock().unwrap().dir().join("session_meta.json") };
+        let read_park = || -> Option<session_log::SessionBgParkMeta> {
+            serde_json::from_str::<session_log::SessionMeta>(
+                &std::fs::read_to_string(&meta_path).unwrap(),
+            )
+            .unwrap()
+            .bg_park
+        };
+        let activity = |state: crate::types::SessionActivityState,
+                        tasks: Vec<String>|
+         -> crate::types::SessionActivityVitals {
+            crate::types::SessionActivityVitals {
+                state,
+                background_tasks: tasks,
+                ..Default::default()
+            }
+        };
+        use crate::types::SessionActivityState as S;
+
+        // Parked claim stamps the live marker.
+        stamp_bg_park_marker_from_activity(
+            &log,
+            &activity(S::ParkedOnTasks, vec!["cargo test".into()]),
+        );
+        let park = read_park().expect("live marker");
+        assert!(park.died_cause.is_none());
+        assert_eq!(park.tasks, vec!["cargo test".to_string()]);
+
+        // Quiet idle clears the LIVE marker (tasks drained normally).
+        stamp_bg_park_marker_from_activity(&log, &activity(S::Idle, Vec::new()));
+        assert!(read_park().is_none());
+
+        // A died statement survives quiet idle settling…
+        slog(&log, |l| {
+            l.set_bg_park(Some(session_log::SessionBgParkMeta {
+                tasks: vec!["cargo test".into()],
+                died_cause: Some(DAEMON_RESTART_CAUSE.to_string()),
+                died_at_epoch: Some(100),
+            }))
+        });
+        stamp_bg_park_marker_from_activity(&log, &activity(S::Idle, Vec::new()));
+        assert!(
+            read_park().is_some_and(|p| p.died_cause.is_some()),
+            "idle settling never erases the died statement"
+        );
+        // …and clears on demonstrable work.
+        stamp_bg_park_marker_from_activity(&log, &activity(S::AwaitingApi, Vec::new()));
+        assert!(read_park().is_none(), "a turn state resolves the attention");
+    }
+
     fn rejected_park_message() -> FollowUpMessage {
         let mut rejected = FollowUpMessage::text("the whole goal, re-merged".to_string());
         rejected.follow_up_id = Some("f-goal".to_string());

--- a/src/bin/caller/external_supervision.rs
+++ b/src/bin/caller/external_supervision.rs
@@ -2292,7 +2292,13 @@ mod tests {
     fn died_with_restart_marking_never_arms_delivery() {
         let sid = "cc-died-pin-session";
         crate::background_tasks::clear_session(sid);
-        crate::background_tasks::record_started(sid, "task-1", "toolu_1", "cargo test battery", 100);
+        crate::background_tasks::record_started(
+            sid,
+            "task-1",
+            "toolu_1",
+            "cargo test battery",
+            100,
+        );
         let bus = EventBus::new();
         let mut rx = bus.subscribe();
         let dir = tempfile::tempdir().unwrap();
@@ -2316,18 +2322,20 @@ mod tests {
             task.status,
             crate::background_tasks::BackgroundTaskStatus::DiedWithRestart
         );
-        assert_eq!(task.died_cause.as_deref(), Some(SERVICE_RECOVERY_RESTART_CAUSE));
+        assert_eq!(
+            task.died_cause.as_deref(),
+            Some(SERVICE_RECOVERY_RESTART_CAUSE)
+        );
 
         // The durable marker flipped to its died form.
-        let meta_park = log
-            .lock()
-            .unwrap()
-            .dir()
-            .join("session_meta.json");
+        let meta_park = log.lock().unwrap().dir().join("session_meta.json");
         let meta: session_log::SessionMeta =
             serde_json::from_str(&std::fs::read_to_string(meta_park).unwrap()).unwrap();
         let park = meta.bg_park.expect("died marker stamped");
-        assert_eq!(park.died_cause.as_deref(), Some(SERVICE_RECOVERY_RESTART_CAUSE));
+        assert_eq!(
+            park.died_cause.as_deref(),
+            Some(SERVICE_RECOVERY_RESTART_CAUSE)
+        );
         assert_eq!(park.tasks, vec!["cargo test battery".to_string()]);
 
         // THE PIN: the bus carries surfaces only. No follow-up, steer,

--- a/src/bin/caller/handover/presence.rs
+++ b/src/bin/caller/handover/presence.rs
@@ -49,6 +49,13 @@ pub(crate) struct DrainHoldout {
     pub(crate) phase: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) limit_park: Option<crate::session_log::SessionLimitParkMeta>,
+    /// The session's durable background-task-park marker, when set: a
+    /// live one names the tasks an idle holdout is honestly waiting on;
+    /// a died one never appears here (died-park idle sessions are
+    /// releasable and leave the wait set). Additive: rows written before
+    /// 2026-08 lack it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) bg_park: Option<crate::session_log::SessionBgParkMeta>,
 }
 
 /// Presence-record cap on mirrored holdout rows: the record is a small
@@ -342,6 +349,7 @@ mod tests {
                 resets_at_epoch: Some(1_754_000_000),
                 has_pending: true,
             }),
+            bg_park: None,
         };
         presence.update_state("draining").unwrap();
         presence
@@ -394,6 +402,7 @@ mod tests {
                 name: None,
                 phase: "running".to_string(),
                 limit_park: None,
+                bg_park: None,
             })
             .collect();
         presence

--- a/src/bin/caller/run_modes.rs
+++ b/src/bin/caller/run_modes.rs
@@ -2377,7 +2377,20 @@ pub(crate) async fn run_with_presence(
                                     // it at reset.
                                     persistent_limit_park_streak =
                                         persistent_limit_park_streak.saturating_add(1);
-                                    let (park, park_line) = backend_started_limit_park(
+                                    // Confirmed-exit gated: a limit that
+                                    // killed the process killed its
+                                    // background children; the resume
+                                    // nudge then carries the re-run offer.
+                                    let died_addendum = mark_died_tasks_at_park_arm(
+                                        agent,
+                                        &bus,
+                                        &session_log,
+                                        &session_log_id(&session_log),
+                                        persistent_thread.as_ref().map(|t| t.thread_id.as_str()),
+                                        RATE_LIMIT_RESTART_CAUSE,
+                                        turn_had_started,
+                                    );
+                                    let (mut park, park_line) = backend_started_limit_park(
                                         resets_at_epoch,
                                         tokio::time::Instant::now(),
                                         crate::session_activity::epoch_seconds(),
@@ -2385,6 +2398,11 @@ pub(crate) async fn run_with_presence(
                                         limit_park_jitter_secs(),
                                         turn_had_started,
                                     );
+                                    if let (Some(pending), Some(addendum)) =
+                                        (park.pending.as_mut(), died_addendum)
+                                    {
+                                        pending.text.push_str(&addendum);
+                                    }
                                     slog(&session_log, |l| l.warn(&park_line));
                                     bus.send(AppEvent::LogEntry {
                                         session_id: session_log_id(&session_log),
@@ -2494,7 +2512,23 @@ pub(crate) async fn run_with_presence(
                                             turn: None,
                                         });
                                     } else {
-                                        let (park, park_line) = transient_round_death_error_park(
+                                        // Confirmed-exit gated: a round
+                                        // death that took the process
+                                        // took its background children;
+                                        // the resume nudge then carries
+                                        // the re-run offer.
+                                        let died_addendum = mark_died_tasks_at_park_arm(
+                                            agent,
+                                            &bus,
+                                            &session_log,
+                                            &session_log_id(&session_log),
+                                            persistent_thread
+                                                .as_ref()
+                                                .map(|t| t.thread_id.as_str()),
+                                            SERVICE_RECOVERY_RESTART_CAUSE,
+                                            turn_had_started,
+                                        );
+                                        let (mut park, park_line) = transient_round_death_error_park(
                                             &reason,
                                             tokio::time::Instant::now(),
                                             persistent_error_park_streak,
@@ -2502,6 +2536,11 @@ pub(crate) async fn run_with_presence(
                                             turn_had_started,
                                             None,
                                         );
+                                        if let (Some(pending), Some(addendum)) =
+                                            (park.pending.as_mut(), died_addendum)
+                                        {
+                                            pending.text.push_str(&addendum);
+                                        }
                                         slog(&session_log, |l| l.warn(&park_line));
                                         bus.send(AppEvent::LogEntry {
                                             session_id: session_log_id(&session_log),

--- a/src/bin/caller/run_modes.rs
+++ b/src/bin/caller/run_modes.rs
@@ -2528,14 +2528,15 @@ pub(crate) async fn run_with_presence(
                                             SERVICE_RECOVERY_RESTART_CAUSE,
                                             turn_had_started,
                                         );
-                                        let (mut park, park_line) = transient_round_death_error_park(
-                                            &reason,
-                                            tokio::time::Instant::now(),
-                                            persistent_error_park_streak,
-                                            error_park_jitter_secs(),
-                                            turn_had_started,
-                                            None,
-                                        );
+                                        let (mut park, park_line) =
+                                            transient_round_death_error_park(
+                                                &reason,
+                                                tokio::time::Instant::now(),
+                                                persistent_error_park_streak,
+                                                error_park_jitter_secs(),
+                                                turn_had_started,
+                                                None,
+                                            );
                                         if let (Some(pending), Some(addendum)) =
                                             (park.pending.as_mut(), died_addendum)
                                         {

--- a/src/bin/caller/session_activity.rs
+++ b/src/bin/caller/session_activity.rs
@@ -723,6 +723,58 @@ mod tests {
         assert!(m.observe(Obs::TurnDispatched, 70).is_some());
     }
 
+    /// The hub-side sticky fold: died-with-restart attention fields
+    /// survive a fresh machine's quiet idle publishes (the respawned
+    /// backend knows nothing of its predecessor's deaths) and clear on
+    /// demonstrable work — any turn state, or a new tasks claim.
+    #[test]
+    fn died_attention_folds_sticky_across_idle_and_clears_on_work() {
+        let died = SessionActivityVitals {
+            state: SessionActivityState::Idle,
+            since_epoch: 100,
+            died_background_tasks: vec!["cargo test".into()],
+            died_tasks_cause: Some("the credential-reload restart".into()),
+            ..Default::default()
+        };
+        // A later quiet idle keeps the attention fields.
+        let idle = SessionActivityVitals {
+            state: SessionActivityState::Idle,
+            since_epoch: 200,
+            ..Default::default()
+        };
+        let folded = fold_died_tasks_attention(Some(&died), idle);
+        assert_eq!(folded.died_background_tasks, vec!["cargo test".to_string()]);
+        assert_eq!(
+            folded.died_tasks_cause.as_deref(),
+            Some("the credential-reload restart")
+        );
+        assert_eq!(folded.since_epoch, 200, "only the died fields stick");
+
+        // A turn state clears them — the session works again.
+        let working = SessionActivityVitals {
+            state: SessionActivityState::AwaitingApi,
+            since_epoch: 300,
+            ..Default::default()
+        };
+        let folded = fold_died_tasks_attention(Some(&died), working);
+        assert!(folded.died_background_tasks.is_empty());
+        assert!(folded.died_tasks_cause.is_none());
+
+        // A fresh parked claim (new tasks armed — a turn ran) clears too.
+        let parked = SessionActivityVitals {
+            state: SessionActivityState::ParkedOnTasks,
+            background_tasks: vec!["new job".into()],
+            ..Default::default()
+        };
+        let folded = fold_died_tasks_attention(Some(&died), parked);
+        assert!(folded.died_background_tasks.is_empty());
+
+        // No previous attention → pass-through.
+        let idle2 = SessionActivityVitals::default();
+        let folded = fold_died_tasks_attention(None, idle2.clone());
+        assert_eq!(folded, idle2);
+    }
+
     #[test]
     fn wire_shape_serializes_kebab_states_and_camel_fields() {
         // The dashboard consumes these exact strings; pin them.

--- a/src/bin/caller/session_activity.rs
+++ b/src/bin/caller/session_activity.rs
@@ -261,6 +261,13 @@ impl ActivityMachine {
             stalled_after_seconds: stall_armed.then_some(STALL_AFTER_SECS),
             resets_at_epoch: self.resets_at_epoch,
             background_tasks: self.background_tasks.clone(),
+            // The machine only ever claims live wire facts; the
+            // died-with-restart attention snapshot is published by the
+            // supervision seam that observed the process die
+            // (`external_supervision::mark_parked_tasks_died_with_restart`),
+            // and any later publish from a live machine clears it.
+            died_background_tasks: Vec::new(),
+            died_tasks_cause: None,
         }
     }
 
@@ -275,7 +282,39 @@ impl ActivityMachine {
     pub(crate) fn effective_state(&self, now_epoch: u64) -> SessionActivityState {
         effective_activity_state(&self.snapshot(), now_epoch)
     }
+}
 
+/// Hub-side sticky fold for the died-with-restart attention fields
+/// (`died_background_tasks` / `died_tasks_cause`): the attention snapshot
+/// is published machine-externally by the supervision seam that observed
+/// the backend die, while every LATER publish comes from the respawned
+/// backend's fresh machine, which knows nothing of the deaths. A fresh
+/// machine settling quietly to idle (the respawned CLI's empty round)
+/// must not erase the attention state — only demonstrable work does: any
+/// turn-state publish, or a new parked/tasks claim (arming tasks takes a
+/// turn). Mirrors `SessionLog::clear_bg_park_if_live` on the durable
+/// side; the two carriers resolve on the same evidence.
+pub(crate) fn fold_died_tasks_attention(
+    prev: Option<&SessionActivityVitals>,
+    mut next: SessionActivityVitals,
+) -> SessionActivityVitals {
+    if next.died_background_tasks.is_empty()
+        && matches!(
+            next.state,
+            SessionActivityState::Idle | SessionActivityState::Stalled
+        )
+    {
+        if let Some(prev) = prev {
+            if !prev.died_background_tasks.is_empty() {
+                next.died_background_tasks = prev.died_background_tasks.clone();
+                next.died_tasks_cause = prev.died_tasks_cause.clone();
+            }
+        }
+    }
+    next
+}
+
+impl ActivityMachine {
     fn maybe_publish(&mut self) -> Option<SessionActivityVitals> {
         let next = self.snapshot();
         let changed = match self.published.as_ref() {
@@ -694,6 +733,8 @@ mod tests {
             stalled_after_seconds: Some(20),
             resets_at_epoch: None,
             background_tasks: vec!["cargo test".into()],
+            died_background_tasks: Vec::new(),
+            died_tasks_cause: None,
         };
         let json = serde_json::to_string(&activity).expect("serializes");
         assert!(json.contains("\"state\":\"tool-running\""), "{json}");
@@ -704,9 +745,27 @@ mod tests {
             json.contains("\"backgroundTasks\":[\"cargo test\"]"),
             "{json}"
         );
-        // An empty task list stays off the wire entirely.
+        // An empty task list stays off the wire entirely — died fields too.
         let quiet = serde_json::to_string(&SessionActivityVitals::default()).expect("serializes");
         assert!(!quiet.contains("backgroundTasks"), "{quiet}");
+        assert!(!quiet.contains("diedBackgroundTasks"), "{quiet}");
+        assert!(!quiet.contains("diedTasksCause"), "{quiet}");
+        // The died-with-restart attention snapshot's wire spelling is
+        // what the dashboard keys the attention state on; pin it.
+        let died = serde_json::to_string(&SessionActivityVitals {
+            died_background_tasks: vec!["cargo test".into()],
+            died_tasks_cause: Some("the credential-reload restart".into()),
+            ..SessionActivityVitals::default()
+        })
+        .expect("serializes");
+        assert!(
+            died.contains("\"diedBackgroundTasks\":[\"cargo test\"]"),
+            "{died}"
+        );
+        assert!(
+            died.contains("\"diedTasksCause\":\"the credential-reload restart\""),
+            "{died}"
+        );
         for state in [
             SessionActivityState::Reasoning,
             SessionActivityState::Responding,

--- a/src/bin/caller/session_log/mod.rs
+++ b/src/bin/caller/session_log/mod.rs
@@ -127,6 +127,17 @@ pub struct SessionMeta {
     /// Additive: metas written before 2026-08 lack it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub safeguards_flag: Option<SessionSafeguardsFlagMeta>,
+    /// Durable trace of a park on backend-announced background tasks:
+    /// written while the session waits between turns on running tasks,
+    /// flipped to its died form when a backend restart kills them, and
+    /// cleared when the session works again (tasks drained or a new turn
+    /// ran). The tasks are OS children of the backend process, so they
+    /// die with EVERY respawn while this session-state marker survives —
+    /// this marker is how the boot pass and the drain wait set tell a
+    /// live wait from a dead one. Additive: metas written before 2026-08
+    /// lack it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bg_park: Option<SessionBgParkMeta>,
 }
 
 /// A provider-safeguards flag recorded durably (see
@@ -138,6 +149,24 @@ pub struct SessionSafeguardsFlagMeta {
     /// First line of the formatted cause, truncated for one-row surfaces
     /// (the full text is in the session log's error row).
     pub reason_preview: String,
+}
+
+/// A park on running background tasks recorded durably (see
+/// [`SessionMeta::bg_park`]).
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct SessionBgParkMeta {
+    /// Short descriptions of the tasks the park waits on (bounded by the
+    /// producer; display data, never commands).
+    pub tasks: Vec<String>,
+    /// The named restart that killed the tasks — `Some` flips the marker
+    /// from "waiting on live work" to the died-with-restart attention
+    /// state (nothing is re-run automatically; re-running is an owner
+    /// decision). `None` = the park is live.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub died_cause: Option<String>,
+    /// Epoch seconds the tasks died, present with `died_cause`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub died_at_epoch: Option<u64>,
 }
 
 /// A parked rate-limit wait recorded durably (see
@@ -666,17 +695,23 @@ impl SessionLog {
         let existing = fs::read_to_string(self.dir.join("session_meta.json"))
             .ok()
             .and_then(|raw| serde_json::from_str::<SessionMeta>(&raw).ok());
-        let (existing_name, existing_worktree, existing_limit_park, existing_safeguards_flag) =
-            existing
-                .map(|meta| {
-                    (
-                        meta.name,
-                        meta.worktree,
-                        meta.limit_park,
-                        meta.safeguards_flag,
-                    )
-                })
-                .unwrap_or((None, None, None, None));
+        let (
+            existing_name,
+            existing_worktree,
+            existing_limit_park,
+            existing_safeguards_flag,
+            existing_bg_park,
+        ) = existing
+            .map(|meta| {
+                (
+                    meta.name,
+                    meta.worktree,
+                    meta.limit_park,
+                    meta.safeguards_flag,
+                    meta.bg_park,
+                )
+            })
+            .unwrap_or((None, None, None, None, None));
         let meta = SessionMeta {
             session_id: self.session_id.clone(),
             created_at: Local::now().format("%Y-%m-%dT%H:%M:%S").to_string(),
@@ -698,6 +733,10 @@ impl SessionLog {
             // The safeguards flag is terminal for the conversation — no
             // meta rewrite may ever drop it.
             safeguards_flag: existing_safeguards_flag,
+            // Park transitions alone touch the marker (same law as
+            // limit_park): a respawn's meta rewrite must not silently
+            // release a wait — or erase a died-with-restart statement.
+            bg_park: existing_bg_park,
         };
         if let Ok(json) = serde_json::to_string_pretty(&meta) {
             if let Err(e) = write_session_meta_atomic(&self.dir, &json) {
@@ -744,6 +783,55 @@ impl SessionLog {
             return;
         }
         meta.limit_park = park;
+        if let Ok(json) = serde_json::to_string_pretty(&meta) {
+            if let Err(e) = write_session_meta_atomic(&self.dir, &json) {
+                eprintln!("session_log: failed to write session_meta.json: {}", e);
+            }
+        }
+    }
+
+    /// Record (or clear) the durable background-task-park marker in
+    /// `session_meta.json` (see [`SessionMeta::bg_park`]). Missing or
+    /// unreadable meta is a quiet no-op, like [`Self::set_limit_park`].
+    pub fn set_bg_park(&self, park: Option<SessionBgParkMeta>) {
+        let meta_path = self.dir.join("session_meta.json");
+        let Some(mut meta) = fs::read_to_string(&meta_path)
+            .ok()
+            .and_then(|raw| serde_json::from_str::<SessionMeta>(&raw).ok())
+        else {
+            return;
+        };
+        if meta.bg_park == park {
+            return;
+        }
+        meta.bg_park = park;
+        if let Ok(json) = serde_json::to_string_pretty(&meta) {
+            if let Err(e) = write_session_meta_atomic(&self.dir, &json) {
+                eprintln!("session_log: failed to write session_meta.json: {}", e);
+            }
+        }
+    }
+
+    /// Clear the bg-park marker unless it records a died-with-restart
+    /// statement: activity settling quietly to idle (a respawned
+    /// backend's empty round) must not erase the attention state — only
+    /// real work does, via `set_bg_park(None)` on a turn-state publish.
+    pub fn clear_bg_park_if_live(&self) {
+        let meta_path = self.dir.join("session_meta.json");
+        let Some(mut meta) = fs::read_to_string(&meta_path)
+            .ok()
+            .and_then(|raw| serde_json::from_str::<SessionMeta>(&raw).ok())
+        else {
+            return;
+        };
+        if !meta
+            .bg_park
+            .as_ref()
+            .is_some_and(|park| park.died_cause.is_none())
+        {
+            return;
+        }
+        meta.bg_park = None;
         if let Ok(json) = serde_json::to_string_pretty(&meta) {
             if let Err(e) = write_session_meta_atomic(&self.dir, &json) {
                 eprintln!("session_log: failed to write session_meta.json: {}", e);
@@ -1862,6 +1950,7 @@ mod tests {
             worktree: None,
             limit_park: None,
             safeguards_flag: None,
+            bg_park: None,
         };
         fs::write(
             log_dir.join("session_meta.json"),
@@ -1973,6 +2062,7 @@ mod tests {
             worktree: None,
             limit_park: None,
             safeguards_flag: None,
+            bg_park: None,
         };
         fs::write(
             s1_dir.join("session_meta.json"),
@@ -1996,6 +2086,7 @@ mod tests {
             worktree: None,
             limit_park: None,
             safeguards_flag: None,
+            bg_park: None,
         };
         fs::write(
             s2_dir.join("session_meta.json"),
@@ -2060,6 +2151,7 @@ mod tests {
             worktree: None,
             limit_park: None,
             safeguards_flag: None,
+            bg_park: None,
         };
         fs::write(
             log_dir.join("session_meta.json"),

--- a/src/bin/caller/session_log/mod.rs
+++ b/src/bin/caller/session_log/mod.rs
@@ -824,10 +824,10 @@ impl SessionLog {
         else {
             return;
         };
-        if !meta
+        if meta
             .bg_park
             .as_ref()
-            .is_some_and(|park| park.died_cause.is_none())
+            .is_none_or(|park| park.died_cause.is_some())
         {
             return;
         }

--- a/src/bin/caller/session_log/mod.rs
+++ b/src/bin/caller/session_log/mod.rs
@@ -1962,6 +1962,50 @@ mod tests {
         assert_eq!(log.session_id(), "test-session-123");
     }
 
+    /// The bg-park marker survives every meta rewrite (the same law as
+    /// `limit_park` — a credential-reload respawn's `write_meta` mid-park
+    /// must not silently release the wait or erase a died-with-restart
+    /// statement), and `clear_bg_park_if_live` clears only the live form.
+    #[test]
+    fn bg_park_marker_survives_meta_rewrites_and_died_form_outlives_idle() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_dir = dir.path().join("session");
+        let log = SessionLog::open(log_dir.clone()).unwrap();
+        log.write_meta(Some(Path::new("/tmp/project")), Some("task"));
+        let read = || -> SessionMeta {
+            serde_json::from_str(&fs::read_to_string(log_dir.join("session_meta.json")).unwrap())
+                .unwrap()
+        };
+
+        log.set_bg_park(Some(SessionBgParkMeta {
+            tasks: vec!["cargo test battery".into()],
+            died_cause: None,
+            died_at_epoch: None,
+        }));
+        log.write_meta(Some(Path::new("/tmp/project")), Some("task again"));
+        assert!(
+            read().bg_park.is_some(),
+            "a meta rewrite must not release the park"
+        );
+
+        log.clear_bg_park_if_live();
+        assert!(read().bg_park.is_none(), "idle clears a LIVE marker");
+
+        log.set_bg_park(Some(SessionBgParkMeta {
+            tasks: vec!["cargo test battery".into()],
+            died_cause: Some("the daemon restart".into()),
+            died_at_epoch: Some(100),
+        }));
+        log.write_meta(Some(Path::new("/tmp/project")), Some("task"));
+        log.clear_bg_park_if_live();
+        let park = read().bg_park.expect("died statement survives");
+        assert_eq!(park.died_cause.as_deref(), Some("the daemon restart"));
+        assert_eq!(park.died_at_epoch, Some(100));
+
+        log.set_bg_park(None);
+        assert!(read().bg_park.is_none(), "real work clears everything");
+    }
+
     #[test]
     fn write_meta_creates_file() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/bin/caller/session_supervisor/mod.rs
+++ b/src/bin/caller/session_supervisor/mod.rs
@@ -198,6 +198,15 @@ pub(crate) struct SupervisorState {
     /// The fallback responder defers to the advertising loop for exactly
     /// these ops instead of false-rejecting non-external sessions.
     advertised_thread_actions: HashMap<String, std::collections::HashSet<String>>,
+    /// Sessions whose background-task park DIED with a backend restart
+    /// (`SessionActivity` publishes with non-empty died fields) — the
+    /// honest attention state. An idle member no longer holds the drain:
+    /// its wait is on nobody (the tasks are dead, re-running is an owner
+    /// decision the successor daemon serves just as well), so counting it
+    /// as held work would strand the drain behind a wait that can never
+    /// end. Membership clears when the session demonstrably works again
+    /// (any activity publish without died fields).
+    died_park_sessions: std::collections::HashSet<String>,
     /// Peer-delegation dedup ledger: delegation id → the session the
     /// task was dispatched as. A `StartTask` re-sent with an
     /// already-recorded `delegation_id` (the delegating daemon's
@@ -611,6 +620,7 @@ impl SupervisorState {
     fn remove_session(&mut self, session_id: &str) -> Option<(String, ManagedSession)> {
         let canonical = self.resolve_session_id(session_id)?;
         let removed = self.sessions.remove(&canonical)?;
+        self.died_park_sessions.remove(&canonical);
         self.session_aliases
             .retain(|alias, target| alias != &canonical && target != &canonical);
         self.related_sessions
@@ -927,23 +937,34 @@ impl SessionSupervisor {
         if !runtime.is_draining() {
             return false;
         }
-        let holding: Vec<(String, String, Option<String>, String, PathBuf)> = self
-            .state
-            .lock()
-            .await
-            .sessions
-            .values()
-            .filter(|session| session.phase != "done")
-            .map(|session| {
-                (
-                    session.session_id.clone(),
-                    session.source.clone(),
-                    session.name.clone(),
-                    session.phase.clone(),
-                    session.session_dir.clone(),
-                )
-            })
-            .collect();
+        let holding: Vec<(String, String, Option<String>, String, PathBuf)> = {
+            let state = self.state.lock().await;
+            state
+                .sessions
+                .values()
+                .filter(|session| {
+                    // A session whose ONLY hold is a died-with-restart
+                    // park is releasable: its wait is on tasks that no
+                    // longer exist, and re-running them is an owner
+                    // decision the successor daemon serves just as well
+                    // (the durable bg_park marker survives the exit).
+                    // Any other phase — an approval, a live turn, an
+                    // interrupt — still holds like before.
+                    session.phase != "done"
+                        && !(session.phase == "idle"
+                            && state.died_park_sessions.contains(&session.session_id))
+                })
+                .map(|session| {
+                    (
+                        session.session_id.clone(),
+                        session.source.clone(),
+                        session.name.clone(),
+                        session.phase.clone(),
+                        session.session_dir.clone(),
+                    )
+                })
+                .collect()
+        };
         // Rebuild + report the named rows only when the set moved or the
         // refresh beat elapsed: this check runs per bus event, and the
         // marker resolution reads each holding session's durable meta.
@@ -1055,16 +1076,19 @@ fn drain_holdout_rows(
     let mut rows: Vec<crate::handover::DrainHoldout> = holding
         .iter()
         .map(|(session_id, source, name, phase, session_dir)| {
-            let limit_park = std::fs::read_to_string(session_dir.join("session_meta.json"))
+            let meta = std::fs::read_to_string(session_dir.join("session_meta.json"))
                 .ok()
-                .and_then(|raw| serde_json::from_str::<session_log::SessionMeta>(&raw).ok())
-                .and_then(|meta| meta.limit_park);
+                .and_then(|raw| serde_json::from_str::<session_log::SessionMeta>(&raw).ok());
+            let (limit_park, bg_park) = meta
+                .map(|meta| (meta.limit_park, meta.bg_park))
+                .unwrap_or((None, None));
             crate::handover::DrainHoldout {
                 session_id: session_id.clone(),
                 source: source.clone(),
                 name: name.clone(),
                 phase: normalize_supervisor_phase(phase),
                 limit_park,
+                bg_park,
             }
         })
         .collect();

--- a/src/bin/caller/session_supervisor/mod.rs
+++ b/src/bin/caller/session_supervisor/mod.rs
@@ -1200,9 +1200,10 @@ mod tests {
         let supervisor = test_supervisor(PathBuf::from("/tmp/project"), EventBus::new());
         {
             let mut state = supervisor.state.lock().await;
-            state
-                .sessions
-                .insert("s-died".to_string(), managed_session("s-died", "claude-code"));
+            state.sessions.insert(
+                "s-died".to_string(),
+                managed_session("s-died", "claude-code"),
+            );
         }
         let died = crate::types::SessionActivityVitals {
             died_background_tasks: vec!["cargo test battery".into()],
@@ -1241,12 +1242,7 @@ mod tests {
                 activity: crate::types::SessionActivityVitals::default(),
             })
             .await;
-        assert!(supervisor
-            .state
-            .lock()
-            .await
-            .died_park_sessions
-            .is_empty());
+        assert!(supervisor.state.lock().await.died_park_sessions.is_empty());
     }
 
     pub(crate) fn managed_session(id: &str, source: &str) -> ManagedSession {

--- a/src/bin/caller/session_supervisor/mod.rs
+++ b/src/bin/caller/session_supervisor/mod.rs
@@ -943,16 +943,10 @@ impl SessionSupervisor {
                 .sessions
                 .values()
                 .filter(|session| {
-                    // A session whose ONLY hold is a died-with-restart
-                    // park is releasable: its wait is on tasks that no
-                    // longer exist, and re-running them is an owner
-                    // decision the successor daemon serves just as well
-                    // (the durable bg_park marker survives the exit).
-                    // Any other phase — an approval, a live turn, an
-                    // interrupt — still holds like before.
-                    session.phase != "done"
-                        && !(session.phase == "idle"
-                            && state.died_park_sessions.contains(&session.session_id))
+                    session_holds_drain(
+                        &session.phase,
+                        state.died_park_sessions.contains(&session.session_id),
+                    )
                 })
                 .map(|session| {
                     (
@@ -1063,6 +1057,19 @@ impl SessionSupervisor {
     }
 }
 
+/// The one drain-hold rule ([`SessionSupervisor::drain_exit_ready`]'s
+/// filter): holding work is any phase but `done` — EXCEPT an idle
+/// session whose background-task park DIED with a backend restart
+/// (`died_park`). Its wait is on tasks that no longer exist; re-running
+/// them is an owner decision the successor daemon serves just as well
+/// (the durable `bg_park` marker survives the exit), so counting it as
+/// held work would strand the drain behind a wait that can never end.
+/// Any other phase — an approval, a live turn, an interrupt — holds
+/// regardless of the died mark.
+pub(crate) fn session_holds_drain(phase: &str, died_park: bool) -> bool {
+    phase != "done" && !(phase == "idle" && died_park)
+}
+
 /// The named drain wait set: one row per holding session, with the
 /// durable limit-park marker resolved from its `session_meta.json` —
 /// "parked until T" is decisive information (an in-memory park can hold
@@ -1145,6 +1152,102 @@ pub(crate) fn short_session(session_id: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The drain wait-set arithmetic with a died-park member (the
+    /// parked-task respawn honesty card's pin): an idle session whose
+    /// bg park died is RELEASABLE — every other hold stands, including
+    /// a died-marked session that still owes an approval or a turn.
+    #[test]
+    fn drain_holding_arithmetic_releases_only_the_died_park_idle() {
+        // (phase, died_park, holds)
+        for (phase, died_park, holds) in [
+            ("done", false, false),
+            ("done", true, false),
+            ("idle", false, true),
+            ("idle", true, false), // the died park: its wait is on nobody
+            ("running", false, true),
+            ("running", true, true), // mid-turn work holds regardless
+            ("waiting_approval", true, true),
+            ("waiting_human", true, true),
+            ("interrupted", true, true),
+        ] {
+            assert_eq!(
+                session_holds_drain(phase, died_park),
+                holds,
+                "phase={phase} died_park={died_park}"
+            );
+        }
+        // Arithmetic over a mixed set: one done, one live idle, one
+        // died-park idle, one died-marked approval-waiter → 2 hold.
+        let sessions = [
+            ("done", false),
+            ("idle", false),
+            ("idle", true),
+            ("waiting_approval", true),
+        ];
+        let holding = sessions
+            .iter()
+            .filter(|(phase, died)| session_holds_drain(phase, *died))
+            .count();
+        assert_eq!(holding, 2);
+    }
+
+    /// Died-park membership follows the activity carrier: non-empty
+    /// died fields set it (managed sessions only), any later publish
+    /// without them clears it, and removal purges it.
+    #[tokio::test]
+    async fn died_park_membership_follows_session_activity() {
+        let supervisor = test_supervisor(PathBuf::from("/tmp/project"), EventBus::new());
+        {
+            let mut state = supervisor.state.lock().await;
+            state
+                .sessions
+                .insert("s-died".to_string(), managed_session("s-died", "claude-code"));
+        }
+        let died = crate::types::SessionActivityVitals {
+            died_background_tasks: vec!["cargo test battery".into()],
+            died_tasks_cause: Some("the credential-reload restart".into()),
+            ..Default::default()
+        };
+        supervisor
+            .observe_lifecycle_event(&AppEvent::SessionActivity {
+                session_id: Some("s-died".into()),
+                activity: died.clone(),
+            })
+            .await;
+        assert!(supervisor
+            .state
+            .lock()
+            .await
+            .died_park_sessions
+            .contains("s-died"));
+        // A foreign session's died fields never grow the set.
+        supervisor
+            .observe_lifecycle_event(&AppEvent::SessionActivity {
+                session_id: Some("s-foreign".into()),
+                activity: died,
+            })
+            .await;
+        assert!(!supervisor
+            .state
+            .lock()
+            .await
+            .died_park_sessions
+            .contains("s-foreign"));
+        // Work resumes (any publish without died fields) → cleared.
+        supervisor
+            .observe_lifecycle_event(&AppEvent::SessionActivity {
+                session_id: Some("s-died".into()),
+                activity: crate::types::SessionActivityVitals::default(),
+            })
+            .await;
+        assert!(supervisor
+            .state
+            .lock()
+            .await
+            .died_park_sessions
+            .is_empty());
+    }
 
     pub(crate) fn managed_session(id: &str, source: &str) -> ManagedSession {
         let (tx, _rx) = mpsc::channel(1);

--- a/src/bin/caller/session_supervisor/registry.rs
+++ b/src/bin/caller/session_supervisor/registry.rs
@@ -60,8 +60,11 @@ impl SessionSupervisor {
                 // mark the session's park as dead (releasable for the
                 // drain while idle); any publish without them means the
                 // session works again and clears the mark.
-                self.update_session_died_park(session_id, !activity.died_background_tasks.is_empty())
-                    .await;
+                self.update_session_died_park(
+                    session_id,
+                    !activity.died_background_tasks.is_empty(),
+                )
+                .await;
             }
             AppEvent::BackendCredentialsReloadProgress {
                 session_id,

--- a/src/bin/caller/session_supervisor/registry.rs
+++ b/src/bin/caller/session_supervisor/registry.rs
@@ -51,6 +51,18 @@ impl SessionSupervisor {
             } => {
                 self.update_session_phase(Some(session_id), phase).await;
             }
+            AppEvent::SessionActivity {
+                session_id: Some(session_id),
+                activity,
+            } => {
+                // The died-with-restart attention state, derived from the
+                // one carrier every surface reads: non-empty died fields
+                // mark the session's park as dead (releasable for the
+                // drain while idle); any publish without them means the
+                // session works again and clears the mark.
+                self.update_session_died_park(session_id, !activity.died_background_tasks.is_empty())
+                    .await;
+            }
             AppEvent::BackendCredentialsReloadProgress {
                 session_id,
                 progress,
@@ -104,6 +116,25 @@ impl SessionSupervisor {
         state.related_sessions.remove(session_id);
         state.known_external_sessions.remove(session_id);
         state.advertised_thread_actions.remove(session_id);
+    }
+
+    /// Track died-park membership (see `SupervisorState::died_park_sessions`).
+    /// Explicit targets only, resolved through aliases like phase updates;
+    /// entries are added only for sessions this supervisor manages (a
+    /// foreign session's vitals must not grow the set), and removal is
+    /// unconditional (a resumed session clears its mark even mid-rename).
+    pub(crate) async fn update_session_died_park(&self, session_id: &str, died_park: bool) {
+        let mut state = self.state.lock().await;
+        let Some(target_id) = state.resolve_session_id(session_id) else {
+            return;
+        };
+        if died_park {
+            if state.sessions.contains_key(&target_id) {
+                state.died_park_sessions.insert(target_id);
+            }
+        } else {
+            state.died_park_sessions.remove(&target_id);
+        }
     }
 
     pub(crate) async fn update_session_phase(&self, session_id: Option<&str>, phase: &str) {

--- a/src/bin/caller/session_vitals.rs
+++ b/src/bin/caller/session_vitals.rs
@@ -1376,7 +1376,17 @@ pub(crate) fn spawn_cache_vitals_listener(
                     session_id: Some(session_id),
                     activity,
                 }) => {
-                    hub.apply(&session_id, |vitals| vitals.activity = Some(activity));
+                    hub.apply(&session_id, |vitals| {
+                        // Sticky died-with-restart attention: a respawned
+                        // backend's fresh machine settling to idle knows
+                        // nothing of its predecessor's task deaths; only
+                        // demonstrable work clears the attention fields
+                        // (see `session_activity::fold_died_tasks_attention`).
+                        vitals.activity = Some(crate::session_activity::fold_died_tasks_attention(
+                            vitals.activity.as_ref(),
+                            activity,
+                        ));
+                    });
                 }
                 Ok(AppEvent::SessionConfigFacts {
                     session_id: Some(session_id),
@@ -3190,6 +3200,7 @@ mod tests {
             }),
             limit_park: None,
             safeguards_flag: None,
+            bg_park: None,
         };
         let meta_path = dir.join("session_meta.json");
         std::fs::write(&meta_path, serde_json::to_string_pretty(&meta).unwrap()).unwrap();

--- a/src/bin/caller/session_vitals.rs
+++ b/src/bin/caller/session_vitals.rs
@@ -4650,6 +4650,77 @@ mod tests {
             "activity writes must not blank other sections"
         );
 
+        // The died-with-restart attention is sticky across a fresh
+        // machine's quiet idle publish (the respawned backend knows
+        // nothing of its predecessor's task deaths) and clears on a
+        // turn-state publish — the hub twin of the durable marker's
+        // lifecycle.
+        bus.send(AppEvent::SessionActivity {
+            session_id: Some("s9".into()),
+            activity: crate::types::SessionActivityVitals {
+                state: crate::types::SessionActivityState::Idle,
+                since_epoch: 150,
+                died_background_tasks: vec!["cargo test battery".into()],
+                died_tasks_cause: Some("the credential-reload restart".into()),
+                ..Default::default()
+            },
+        });
+        bus.send(AppEvent::SessionActivity {
+            session_id: Some("s9".into()),
+            activity: crate::types::SessionActivityVitals {
+                state: crate::types::SessionActivityState::Idle,
+                since_epoch: 160,
+                ..Default::default()
+            },
+        });
+        let vitals = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                if let Ok(AppEvent::SessionVitals { session_id, vitals }) = rx.recv().await {
+                    if session_id == "s9"
+                        && vitals.activity.as_ref().map(|a| a.since_epoch) == Some(160)
+                    {
+                        return vitals;
+                    }
+                }
+            }
+        })
+        .await
+        .expect("listener folds the quiet idle");
+        let act = vitals.activity.as_ref().expect("activity present");
+        assert_eq!(
+            act.died_background_tasks,
+            vec!["cargo test battery".to_string()],
+            "quiet idle keeps the attention fields"
+        );
+        bus.send(AppEvent::SessionActivity {
+            session_id: Some("s9".into()),
+            activity: crate::types::SessionActivityVitals {
+                state: crate::types::SessionActivityState::AwaitingApi,
+                since_epoch: 170,
+                ..Default::default()
+            },
+        });
+        let vitals = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                if let Ok(AppEvent::SessionVitals { session_id, vitals }) = rx.recv().await {
+                    if session_id == "s9"
+                        && vitals.activity.as_ref().map(|a| a.since_epoch) == Some(170)
+                    {
+                        return vitals;
+                    }
+                }
+            }
+        })
+        .await
+        .expect("listener folds the turn state");
+        assert!(
+            vitals
+                .activity
+                .as_ref()
+                .is_some_and(|a| a.died_background_tasks.is_empty()),
+            "demonstrable work clears the attention fields"
+        );
+
         // Id-less snapshots (a native loop without a session id) are
         // skipped, not folded under an empty key.
         bus.send(AppEvent::SessionActivity {

--- a/src/bin/caller/web_gateway/routes_background_tasks.rs
+++ b/src/bin/caller/web_gateway/routes_background_tasks.rs
@@ -109,6 +109,12 @@ fn task_json(record: &BackgroundTaskRecord) -> serde_json::Value {
     }
     (record.status == BackgroundTaskStatus::Running)
         .then(|| task["running"] = serde_json::json!(true));
+    // The honest restart statement: which restart killed the task. Present
+    // exactly on died-with-restart rows, so the inspector can say why the
+    // wait ended instead of the row just vanishing.
+    if let Some(cause) = record.died_cause.as_deref() {
+        task["diedCause"] = serde_json::json!(cause);
+    }
     task
 }
 

--- a/src/bin/caller/web_gateway/static_assets.rs
+++ b/src/bin/caller/web_gateway/static_assets.rs
@@ -1089,6 +1089,57 @@ mod tests {
         );
     }
 
+    /// Parked-task respawn honesty (the died-with-restart class): the
+    /// dashboard derives the attention state from the wire's died
+    /// fields, never invents a parked count the registry doesn't vouch
+    /// for (the post-respawn unknown-task "Parked · 1 task" latch), and
+    /// the one-tap re-run is an OWNER-tapped follow-up through the
+    /// existing lane — the copy states that nothing re-runs
+    /// automatically. These needles hold the fragments to it.
+    #[test]
+    fn died_tasks_attention_is_derived_offered_and_never_auto_rerun() {
+        let windows = include_str!("../../../../static/app/39-session-windows.js");
+        let actions = include_str!("../../../../static/app/41-session-window-actions.js");
+        let lifecycle = include_str!("../../../../static/app/54-session-lifecycle.js");
+        let handover = include_str!("../../../../static/app/ui2-handover.js");
+        assert!(
+            windows.contains("diedBackgroundTasks"),
+            "the attention state derives from the wire's died fields"
+        );
+        assert!(
+            windows.contains("state: 'died-tasks'"),
+            "died tasks derive a display state (like stalled), producers never send it"
+        );
+        assert!(
+            windows.contains("Nothing was re-run automatically"),
+            "the explainer states the no-auto-rerun law"
+        );
+        assert!(
+            windows.contains("const n = (act.backgroundTasks || []).length;\n  if (!n) return '';"),
+            "a parked claim with no vouched tasks renders NO parked pill (the unknown-task latch)"
+        );
+        assert!(
+            windows.contains("sendDiedTaskRerun(sessionId, v.diedTasks, v.diedCause)"),
+            "the one-tap re-run rides the activity chip action"
+        );
+        assert!(
+            lifecycle.contains("function sendDiedTaskRerun"),
+            "the tap sends a normal follow-up through the existing start_task lane"
+        );
+        assert!(
+            lifecycle.contains("not re-run automatically"),
+            "the composed follow-up tells the model the daemon re-ran nothing"
+        );
+        assert!(
+            actions.contains("sessionDiedTasksPillLabel"),
+            "the status pill states the died ending instead of a bare Idle"
+        );
+        assert!(
+            handover.contains("parked on a background task"),
+            "a live bg-park holdout says what the idle session waits on"
+        );
+    }
+
     #[test]
     fn blocked_chip_explains_every_gate_and_the_delivered_wait() {
         let cards = include_str!("../../../../static/app/ui2-agenda-cards.js");

--- a/static/app.html
+++ b/static/app.html
@@ -38416,7 +38416,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '25b978807f04d3e9';
+const INTENDANT_APP_BUILD = '059a967802525d51';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -62992,8 +62992,30 @@ function vitalsLimitLabelShort(label) {
 function deriveSessionActivity(activity, nowSec = Date.now() / 1000) {
   if (!activity || typeof activity !== 'object') return null;
   const state = String(activity.state || 'idle').trim();
-  if (!state || state === 'idle') return null;
   const since = Number(activity.sinceEpoch) || 0;
+  // Background tasks that DIED with a backend restart (wire
+  // `diedBackgroundTasks` + `diedTasksCause`): the daemon publishes them
+  // on an honest `idle` (nothing is running), and the dashboard derives
+  // the attention presentation — like `stalled`, a display state the
+  // producer never sends. Non-idle states ignore the fields: a working
+  // session has already resolved the attention.
+  const diedTasks = Array.isArray(activity.diedBackgroundTasks)
+    ? activity.diedBackgroundTasks.map((t) => String(t || '').trim()).filter(Boolean)
+    : [];
+  if (!state || state === 'idle') {
+    if (!diedTasks.length) return null;
+    return {
+      state: 'died-tasks',
+      rawState: state,
+      elapsed: since ? Math.max(0, nowSec - since) : 0,
+      quiet: 0,
+      hasHeartbeat: false,
+      resetsAtEpoch: 0,
+      backgroundTasks: [],
+      diedTasks,
+      diedCause: String(activity.diedTasksCause || '').trim() || 'a backend restart',
+    };
+  }
   const lastByte = Number(activity.lastStreamByteEpoch) || 0;
   const threshold = Number(activity.stalledAfterSeconds) || 0;
   const quiet = lastByte ? Math.max(0, nowSec - lastByte) : 0;
@@ -63012,6 +63034,8 @@ function deriveSessionActivity(activity, nowSec = Date.now() / 1000) {
     backgroundTasks: Array.isArray(activity.backgroundTasks)
       ? activity.backgroundTasks.map((t) => String(t || '').trim()).filter(Boolean)
       : [],
+    diedTasks: [],
+    diedCause: '',
   };
 }
 
@@ -63039,15 +63063,28 @@ const ACTIVITY_STATE_LABELS = {
   'parked-on-tasks': 'Parked',
   'rate-limited': 'Rate-limited',
   stalled: 'Stalled',
+  'died-tasks': 'Task died',
 };
 
 // Status-pill label for a parked session: plain words, with the count the
-// wire vouches for. Shared by the pill upgrade and anything else that
-// needs the one-line parked phrasing.
+// wire vouches for — and ONLY what it vouches for: a parked claim whose
+// task list is empty (a stale marker whose tasks the registry no longer
+// knows) renders nothing rather than inventing "1 task" (the
+// post-respawn unknown-task latch).
 function sessionParkedPillLabel(act) {
   if (!act || act.state !== 'parked-on-tasks') return '';
-  const n = (act.backgroundTasks || []).length || 1;
+  const n = (act.backgroundTasks || []).length;
+  if (!n) return '';
   return `Parked · ${n} task${n === 1 ? '' : 's'}`;
+}
+
+// Status-pill label for the died-with-restart attention state: the wait
+// is over and an owner decision is pending, so the pill says so instead
+// of "Parked" or a bare "Idle".
+function sessionDiedTasksPillLabel(act) {
+  if (!act || act.state !== 'died-tasks') return '';
+  const n = (act.diedTasks || []).length;
+  return n === 1 ? 'Task died with restart' : `${n} tasks died with restart`;
 }
 
 function formatActivityElapsed(seconds) {
@@ -63238,6 +63275,7 @@ const VITALS_SYMBOLS = {
       'parked-on-tasks': 'pause',
       stalled: 'clock',
       'rate-limited': 'slash',
+      'died-tasks': 'triangle',
     }[v.state] || 'clock'),
     chip: (v) => {
       if (v.state === 'reasoning') return `🧠 Thinking${v.effort ? ` · ${v.effort}` : ''} · ${v.elapsedText}`;
@@ -63247,6 +63285,11 @@ const VITALS_SYMBOLS = {
       if (v.state === 'parked-on-tasks') return `⏸ Parked · ${v.bgCount} task${v.bgCount === 1 ? '' : 's'} · ${v.elapsedText}`;
       if (v.state === 'stalled') return `⚠ Stalled · quiet ${v.quietText}`;
       if (v.state === 'rate-limited') return `⛔ Rate-limited${v.reset ? ` · resets in ${v.reset}` : ''}`;
+      if (v.state === 'died-tasks') {
+        return v.diedCount === 1
+          ? `⚠ Task died · ${v.diedCause}`
+          : `⚠ ${v.diedCount} tasks died · ${v.diedCause}`;
+      }
       return `${ACTIVITY_STATE_LABELS[v.state] || v.state} · ${v.elapsedText}`;
     },
     explain: (v) => {
@@ -63293,6 +63336,21 @@ const VITALS_SYMBOLS = {
           'Nothing is broken: the session continues on its own once the window resets.',
         ];
       }
+      if (v.state === 'died-tasks') {
+        const n = v.diedCount;
+        const lines = [
+          n === 1
+            ? `This session was parked waiting on a background task, but the backend restarted (${v.diedCause}) and the task died with it — the wait was never going to end:`
+            : `This session was parked waiting on ${n} background tasks, but the backend restarted (${v.diedCause}) and they died with it — the wait was never going to end:`,
+        ];
+        for (const task of v.diedTasks || []) lines.push(`• ${task}`);
+        lines.push(
+          n === 1
+            ? 'Nothing was re-run automatically (commands are not known safe to repeat). Use “Ask the session to re-run it” below if the work still needs it, or ignore this if it doesn’t.'
+            : 'Nothing was re-run automatically (commands are not known safe to repeat). Use “Ask the session to re-run them” below if the work still needs them, or ignore this if it doesn’t.'
+        );
+        return lines;
+      }
       return [`The model reports “${v.state}”.`];
     },
     // Short attention phrase for the health verdict's culprit list —
@@ -63300,7 +63358,22 @@ const VITALS_SYMBOLS = {
     brief: (v) => {
       if (v.state === 'rate-limited') return `Rate-limited${v.reset ? ` — resets in ~${v.reset}` : ''}`;
       if (v.state === 'stalled') return `Model stalled — nothing received for ${v.quietText}`;
+      if (v.state === 'died-tasks') {
+        return v.diedCount === 1
+          ? `A background task died with ${v.diedCause} — re-run is one tap away`
+          : `${v.diedCount} background tasks died with ${v.diedCause} — re-run is one tap away`;
+      }
       return '';
+    },
+    // The one-tap re-run: an OWNER action that asks the session (a
+    // normal follow-up through the existing lane) — the daemon never
+    // re-executes a died command itself.
+    action: (v, sessionId) => {
+      if (v.state !== 'died-tasks' || !(v.diedTasks || []).length) return null;
+      return {
+        label: v.diedCount === 1 ? 'Ask the session to re-run it' : 'Ask the session to re-run them',
+        run: () => sendDiedTaskRerun(sessionId, v.diedTasks, v.diedCause),
+      };
     },
   },
   // ── Session facts (wire `config` section: model, effort,
@@ -63866,14 +63939,18 @@ function vitalsChipModels(vitals, meta, sessionId) {
       reset: act.resetsAtEpoch ? formatLimitResetExact(act.resetsAtEpoch) : '',
       bgTasks: act.backgroundTasks,
       bgCount: act.backgroundTasks.length,
+      diedTasks: act.diedTasks || [],
+      diedCount: (act.diedTasks || []).length,
+      diedCause: act.diedCause || '',
     }, {
       // Calm while genuinely working (parked included — waiting on its
-      // own background work is normal); attention (health dot) only for
-      // stalled and rate-limited — the two states that mean "waiting on
-      // something other than the model's own work".
-      severity: act.state === 'stalled' || act.state === 'rate-limited' ? 'warn' : '',
+      // own background work is normal); attention (health dot) for
+      // stalled, rate-limited, and died-tasks — the states that mean
+      // "waiting on something other than the model's own work" (and for
+      // died-tasks, a wait that already ended without its work).
+      severity: act.state === 'stalled' || act.state === 'rate-limited' || act.state === 'died-tasks' ? 'warn' : '',
       ticking: true,
-      sig: `${act.state}|${factsEffort}|${act.hasHeartbeat ? 1 : 0}|${act.backgroundTasks.join(';')}`,
+      sig: `${act.state}|${factsEffort}|${act.hasHeartbeat ? 1 : 0}|${act.backgroundTasks.join(';')}|${(act.diedTasks || []).join(';')}|${act.diedCause || ''}`,
     });
   }
 
@@ -65020,10 +65097,15 @@ async function appendSessionBackgroundTaskRows(sessionId, panel, container = pan
     const status = String(task.status || '');
     const started = Number(task.startedAtEpoch) || 0;
     const ended = Number(task.endedAtEpoch) || 0;
-    // Running rows show elapsed-so-far; finished rows their outcome.
+    // Running rows show elapsed-so-far; finished rows their outcome. A
+    // died-with-restart row names the restart that killed it (the wire's
+    // `diedCause`) — the honest ending, never a bare status word.
+    const diedCause = String(task.diedCause || '').trim();
     const meta = status === 'running'
       ? (started ? `running · ${formatActivityElapsed(nowSec - started)}` : 'running')
-      : `${status}${started && ended ? ` · ${formatActivityElapsed(ended - started)}` : ''}`;
+      : status === 'died-with-restart' && diedCause
+        ? `died with ${diedCause}${started && ended ? ` · after ${formatActivityElapsed(ended - started)}` : ''}`
+        : `${status}${started && ended ? ` · ${formatActivityElapsed(ended - started)}` : ''}`;
     row.appendChild(desc);
     row.appendChild(vxEl('span', 'vx-bgtask-meta', meta));
     if (task.hasOutput && task.taskId) {
@@ -71963,8 +72045,16 @@ function sessionWindowPhaseDisplayLabel(sessionId, phase) {
       ? sessionWindows.get(String(sessionId || '').trim())
       : null;
     if (!win?.ended) {
-      const parked = sessionParkedPillLabel(deriveSessionActivity(sessionWireActivity(sessionId)));
+      const act = deriveSessionActivity(sessionWireActivity(sessionId));
+      const parked = sessionParkedPillLabel(act);
       if (parked) return parked;
+      // The wait's honest ending: tasks the park rode died with a
+      // backend restart — say so instead of a bare "Idle" (the re-run
+      // decision is the owner's, one tap away on the activity chip).
+      if (typeof sessionDiedTasksPillLabel === 'function') {
+        const died = sessionDiedTasksPillLabel(act);
+        if (died) return died;
+      }
     }
   }
   if (isAgentActivePhase(p) && canDerive) {
@@ -105010,7 +105100,10 @@ async function memoryProposeFromForm(button) {
 
   // Owner-facing state words. A limit-parked holdout leads with the
   // parked-until instant — the decisive fact (the park can hold the
-  // drain for hours). Unknown phases pass through rather than lie.
+  // drain for hours). A live background-task park says what the idle
+  // session actually waits on (a DIED park never reaches this list —
+  // those sessions are releasable and leave the wait set). Unknown
+  // phases pass through rather than lie.
   function handoverHoldoutState(holdout) {
     const park = holdout && holdout.limit_park;
     if (park) {
@@ -105018,6 +105111,13 @@ async function memoryProposeFromForm(button) {
       return until
         ? `rate-limit parked until ${until}`
         : 'rate-limit parked — reset time unknown';
+    }
+    const bgPark = holdout && holdout.bg_park;
+    if (bgPark && !bgPark.died_cause) {
+      const n = Array.isArray(bgPark.tasks) ? bgPark.tasks.length : 0;
+      return n === 1
+        ? 'parked on a background task'
+        : `parked on ${n || 'its'} background tasks`;
     }
     const phase = String((holdout && holdout.phase) || '');
     switch (phase) {
@@ -123167,6 +123267,35 @@ function dispatchPeerTaskText(peerTarget, text) {
       .request('api_peer_task', { peer_id: peerTarget.hostId, instructions: text })
       .then(resp => done(resp, 'Task delegated to'))
       .catch(fail);
+  }
+  return true;
+}
+
+// One-tap re-run for background tasks that died with a backend restart
+// (the activity chip's died-tasks action): an OWNER action that asks the
+// session to re-run them — a normal follow-up through the existing
+// start_task lane with full status tracking, never a daemon-side
+// re-execution (commands are not known idempotent, so nothing re-runs
+// without exactly this tap).
+function sendDiedTaskRerun(sessionId, tasks, cause) {
+  const sid = String(sessionId || '').trim();
+  const list = (Array.isArray(tasks) ? tasks : [])
+    .map((t) => String(t || '').trim())
+    .filter(Boolean);
+  if (!sid || !list.length) return false;
+  const why = String(cause || '').trim() || 'a backend restart';
+  const what = list.length === 1
+    ? `the background task that died with ${why}: “${list[0]}”`
+    : `these ${list.length} background tasks that died with ${why}: ${list.map((t) => `“${t}”`).join('; ')}`;
+  const text = `Please re-run ${what}. ${list.length === 1 ? 'It was' : 'They were'} not re-run automatically. Skip anything already covered by later work.`;
+  const id = nextFollowUpId();
+  const msg = { action: 'start_task', task: text, session_id: sid, follow_up_id: id };
+  rememberPendingFollowUp(id, { sessionId: sid, text, direct: false, attachments: [] });
+  onSteerStatusUpdate(id, text, 'pending', null, { sessionId: sid });
+  if (!dispatchSessionControlMsg(msg)) return false;
+  markSessionWindowPendingActive(sid);
+  if (typeof showControlToast === 'function') {
+    showControlToast('info', `Asked session ${shortSessionId(sid)} to re-run ${list.length === 1 ? 'the died task' : `${list.length} died tasks`}.`);
   }
   return true;
 }

--- a/static/app/39-session-windows.js
+++ b/static/app/39-session-windows.js
@@ -1447,8 +1447,30 @@ function vitalsLimitLabelShort(label) {
 function deriveSessionActivity(activity, nowSec = Date.now() / 1000) {
   if (!activity || typeof activity !== 'object') return null;
   const state = String(activity.state || 'idle').trim();
-  if (!state || state === 'idle') return null;
   const since = Number(activity.sinceEpoch) || 0;
+  // Background tasks that DIED with a backend restart (wire
+  // `diedBackgroundTasks` + `diedTasksCause`): the daemon publishes them
+  // on an honest `idle` (nothing is running), and the dashboard derives
+  // the attention presentation — like `stalled`, a display state the
+  // producer never sends. Non-idle states ignore the fields: a working
+  // session has already resolved the attention.
+  const diedTasks = Array.isArray(activity.diedBackgroundTasks)
+    ? activity.diedBackgroundTasks.map((t) => String(t || '').trim()).filter(Boolean)
+    : [];
+  if (!state || state === 'idle') {
+    if (!diedTasks.length) return null;
+    return {
+      state: 'died-tasks',
+      rawState: state,
+      elapsed: since ? Math.max(0, nowSec - since) : 0,
+      quiet: 0,
+      hasHeartbeat: false,
+      resetsAtEpoch: 0,
+      backgroundTasks: [],
+      diedTasks,
+      diedCause: String(activity.diedTasksCause || '').trim() || 'a backend restart',
+    };
+  }
   const lastByte = Number(activity.lastStreamByteEpoch) || 0;
   const threshold = Number(activity.stalledAfterSeconds) || 0;
   const quiet = lastByte ? Math.max(0, nowSec - lastByte) : 0;
@@ -1467,6 +1489,8 @@ function deriveSessionActivity(activity, nowSec = Date.now() / 1000) {
     backgroundTasks: Array.isArray(activity.backgroundTasks)
       ? activity.backgroundTasks.map((t) => String(t || '').trim()).filter(Boolean)
       : [],
+    diedTasks: [],
+    diedCause: '',
   };
 }
 
@@ -1494,15 +1518,28 @@ const ACTIVITY_STATE_LABELS = {
   'parked-on-tasks': 'Parked',
   'rate-limited': 'Rate-limited',
   stalled: 'Stalled',
+  'died-tasks': 'Task died',
 };
 
 // Status-pill label for a parked session: plain words, with the count the
-// wire vouches for. Shared by the pill upgrade and anything else that
-// needs the one-line parked phrasing.
+// wire vouches for — and ONLY what it vouches for: a parked claim whose
+// task list is empty (a stale marker whose tasks the registry no longer
+// knows) renders nothing rather than inventing "1 task" (the
+// post-respawn unknown-task latch).
 function sessionParkedPillLabel(act) {
   if (!act || act.state !== 'parked-on-tasks') return '';
-  const n = (act.backgroundTasks || []).length || 1;
+  const n = (act.backgroundTasks || []).length;
+  if (!n) return '';
   return `Parked · ${n} task${n === 1 ? '' : 's'}`;
+}
+
+// Status-pill label for the died-with-restart attention state: the wait
+// is over and an owner decision is pending, so the pill says so instead
+// of "Parked" or a bare "Idle".
+function sessionDiedTasksPillLabel(act) {
+  if (!act || act.state !== 'died-tasks') return '';
+  const n = (act.diedTasks || []).length;
+  return n === 1 ? 'Task died with restart' : `${n} tasks died with restart`;
 }
 
 function formatActivityElapsed(seconds) {
@@ -1693,6 +1730,7 @@ const VITALS_SYMBOLS = {
       'parked-on-tasks': 'pause',
       stalled: 'clock',
       'rate-limited': 'slash',
+      'died-tasks': 'triangle',
     }[v.state] || 'clock'),
     chip: (v) => {
       if (v.state === 'reasoning') return `🧠 Thinking${v.effort ? ` · ${v.effort}` : ''} · ${v.elapsedText}`;
@@ -1702,6 +1740,11 @@ const VITALS_SYMBOLS = {
       if (v.state === 'parked-on-tasks') return `⏸ Parked · ${v.bgCount} task${v.bgCount === 1 ? '' : 's'} · ${v.elapsedText}`;
       if (v.state === 'stalled') return `⚠ Stalled · quiet ${v.quietText}`;
       if (v.state === 'rate-limited') return `⛔ Rate-limited${v.reset ? ` · resets in ${v.reset}` : ''}`;
+      if (v.state === 'died-tasks') {
+        return v.diedCount === 1
+          ? `⚠ Task died · ${v.diedCause}`
+          : `⚠ ${v.diedCount} tasks died · ${v.diedCause}`;
+      }
       return `${ACTIVITY_STATE_LABELS[v.state] || v.state} · ${v.elapsedText}`;
     },
     explain: (v) => {
@@ -1748,6 +1791,21 @@ const VITALS_SYMBOLS = {
           'Nothing is broken: the session continues on its own once the window resets.',
         ];
       }
+      if (v.state === 'died-tasks') {
+        const n = v.diedCount;
+        const lines = [
+          n === 1
+            ? `This session was parked waiting on a background task, but the backend restarted (${v.diedCause}) and the task died with it — the wait was never going to end:`
+            : `This session was parked waiting on ${n} background tasks, but the backend restarted (${v.diedCause}) and they died with it — the wait was never going to end:`,
+        ];
+        for (const task of v.diedTasks || []) lines.push(`• ${task}`);
+        lines.push(
+          n === 1
+            ? 'Nothing was re-run automatically (commands are not known safe to repeat). Use “Ask the session to re-run it” below if the work still needs it, or ignore this if it doesn’t.'
+            : 'Nothing was re-run automatically (commands are not known safe to repeat). Use “Ask the session to re-run them” below if the work still needs them, or ignore this if it doesn’t.'
+        );
+        return lines;
+      }
       return [`The model reports “${v.state}”.`];
     },
     // Short attention phrase for the health verdict's culprit list —
@@ -1755,7 +1813,22 @@ const VITALS_SYMBOLS = {
     brief: (v) => {
       if (v.state === 'rate-limited') return `Rate-limited${v.reset ? ` — resets in ~${v.reset}` : ''}`;
       if (v.state === 'stalled') return `Model stalled — nothing received for ${v.quietText}`;
+      if (v.state === 'died-tasks') {
+        return v.diedCount === 1
+          ? `A background task died with ${v.diedCause} — re-run is one tap away`
+          : `${v.diedCount} background tasks died with ${v.diedCause} — re-run is one tap away`;
+      }
       return '';
+    },
+    // The one-tap re-run: an OWNER action that asks the session (a
+    // normal follow-up through the existing lane) — the daemon never
+    // re-executes a died command itself.
+    action: (v, sessionId) => {
+      if (v.state !== 'died-tasks' || !(v.diedTasks || []).length) return null;
+      return {
+        label: v.diedCount === 1 ? 'Ask the session to re-run it' : 'Ask the session to re-run them',
+        run: () => sendDiedTaskRerun(sessionId, v.diedTasks, v.diedCause),
+      };
     },
   },
   // ── Session facts (wire `config` section: model, effort,
@@ -2321,14 +2394,18 @@ function vitalsChipModels(vitals, meta, sessionId) {
       reset: act.resetsAtEpoch ? formatLimitResetExact(act.resetsAtEpoch) : '',
       bgTasks: act.backgroundTasks,
       bgCount: act.backgroundTasks.length,
+      diedTasks: act.diedTasks || [],
+      diedCount: (act.diedTasks || []).length,
+      diedCause: act.diedCause || '',
     }, {
       // Calm while genuinely working (parked included — waiting on its
-      // own background work is normal); attention (health dot) only for
-      // stalled and rate-limited — the two states that mean "waiting on
-      // something other than the model's own work".
-      severity: act.state === 'stalled' || act.state === 'rate-limited' ? 'warn' : '',
+      // own background work is normal); attention (health dot) for
+      // stalled, rate-limited, and died-tasks — the states that mean
+      // "waiting on something other than the model's own work" (and for
+      // died-tasks, a wait that already ended without its work).
+      severity: act.state === 'stalled' || act.state === 'rate-limited' || act.state === 'died-tasks' ? 'warn' : '',
       ticking: true,
-      sig: `${act.state}|${factsEffort}|${act.hasHeartbeat ? 1 : 0}|${act.backgroundTasks.join(';')}`,
+      sig: `${act.state}|${factsEffort}|${act.hasHeartbeat ? 1 : 0}|${act.backgroundTasks.join(';')}|${(act.diedTasks || []).join(';')}|${act.diedCause || ''}`,
     });
   }
 
@@ -3475,10 +3552,15 @@ async function appendSessionBackgroundTaskRows(sessionId, panel, container = pan
     const status = String(task.status || '');
     const started = Number(task.startedAtEpoch) || 0;
     const ended = Number(task.endedAtEpoch) || 0;
-    // Running rows show elapsed-so-far; finished rows their outcome.
+    // Running rows show elapsed-so-far; finished rows their outcome. A
+    // died-with-restart row names the restart that killed it (the wire's
+    // `diedCause`) — the honest ending, never a bare status word.
+    const diedCause = String(task.diedCause || '').trim();
     const meta = status === 'running'
       ? (started ? `running · ${formatActivityElapsed(nowSec - started)}` : 'running')
-      : `${status}${started && ended ? ` · ${formatActivityElapsed(ended - started)}` : ''}`;
+      : status === 'died-with-restart' && diedCause
+        ? `died with ${diedCause}${started && ended ? ` · after ${formatActivityElapsed(ended - started)}` : ''}`
+        : `${status}${started && ended ? ` · ${formatActivityElapsed(ended - started)}` : ''}`;
     row.appendChild(desc);
     row.appendChild(vxEl('span', 'vx-bgtask-meta', meta));
     if (task.hasOutput && task.taskId) {

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -540,8 +540,16 @@ function sessionWindowPhaseDisplayLabel(sessionId, phase) {
       ? sessionWindows.get(String(sessionId || '').trim())
       : null;
     if (!win?.ended) {
-      const parked = sessionParkedPillLabel(deriveSessionActivity(sessionWireActivity(sessionId)));
+      const act = deriveSessionActivity(sessionWireActivity(sessionId));
+      const parked = sessionParkedPillLabel(act);
       if (parked) return parked;
+      // The wait's honest ending: tasks the park rode died with a
+      // backend restart — say so instead of a bare "Idle" (the re-run
+      // decision is the owner's, one tap away on the activity chip).
+      if (typeof sessionDiedTasksPillLabel === 'function') {
+        const died = sessionDiedTasksPillLabel(act);
+        if (died) return died;
+      }
     }
   }
   if (isAgentActivePhase(p) && canDerive) {

--- a/static/app/54-session-lifecycle.js
+++ b/static/app/54-session-lifecycle.js
@@ -794,6 +794,35 @@ function dispatchPeerTaskText(peerTarget, text) {
   return true;
 }
 
+// One-tap re-run for background tasks that died with a backend restart
+// (the activity chip's died-tasks action): an OWNER action that asks the
+// session to re-run them — a normal follow-up through the existing
+// start_task lane with full status tracking, never a daemon-side
+// re-execution (commands are not known idempotent, so nothing re-runs
+// without exactly this tap).
+function sendDiedTaskRerun(sessionId, tasks, cause) {
+  const sid = String(sessionId || '').trim();
+  const list = (Array.isArray(tasks) ? tasks : [])
+    .map((t) => String(t || '').trim())
+    .filter(Boolean);
+  if (!sid || !list.length) return false;
+  const why = String(cause || '').trim() || 'a backend restart';
+  const what = list.length === 1
+    ? `the background task that died with ${why}: “${list[0]}”`
+    : `these ${list.length} background tasks that died with ${why}: ${list.map((t) => `“${t}”`).join('; ')}`;
+  const text = `Please re-run ${what}. ${list.length === 1 ? 'It was' : 'They were'} not re-run automatically. Skip anything already covered by later work.`;
+  const id = nextFollowUpId();
+  const msg = { action: 'start_task', task: text, session_id: sid, follow_up_id: id };
+  rememberPendingFollowUp(id, { sessionId: sid, text, direct: false, attachments: [] });
+  onSteerStatusUpdate(id, text, 'pending', null, { sessionId: sid });
+  if (!dispatchSessionControlMsg(msg)) return false;
+  markSessionWindowPendingActive(sid);
+  if (typeof showControlToast === 'function') {
+    showControlToast('info', `Asked session ${shortSessionId(sid)} to re-run ${list.length === 1 ? 'the died task' : `${list.length} died tasks`}.`);
+  }
+  return true;
+}
+
 function dispatchTaskText(text, options = {}) {
   if (!app) return false;
   text = String(text || '').trim();

--- a/static/app/ui2-handover.js
+++ b/static/app/ui2-handover.js
@@ -400,7 +400,10 @@
 
   // Owner-facing state words. A limit-parked holdout leads with the
   // parked-until instant — the decisive fact (the park can hold the
-  // drain for hours). Unknown phases pass through rather than lie.
+  // drain for hours). A live background-task park says what the idle
+  // session actually waits on (a DIED park never reaches this list —
+  // those sessions are releasable and leave the wait set). Unknown
+  // phases pass through rather than lie.
   function handoverHoldoutState(holdout) {
     const park = holdout && holdout.limit_park;
     if (park) {
@@ -408,6 +411,13 @@
       return until
         ? `rate-limit parked until ${until}`
         : 'rate-limit parked — reset time unknown';
+    }
+    const bgPark = holdout && holdout.bg_park;
+    if (bgPark && !bgPark.died_cause) {
+      const n = Array.isArray(bgPark.tasks) ? bgPark.tasks.length : 0;
+      return n === 1
+        ? 'parked on a background task'
+        : `parked on ${n || 'its'} background tasks`;
     }
     const phase = String((holdout && holdout.phase) || '');
     switch (phase) {


### PR DESCRIPTION
Fired from agenda card 01KYZTKZQAK25A8ZKHKPZJMVP3 (parked-task respawn honesty; the body is the brief).

Background tasks are OS children of the backend process and die with every respawn class, while park markers are session-state and survive — the third live specimen of the family (session fcbedd48) sat parked 40+ minutes on a battery the credential-reload respawn had killed, read as stuck, and held the drain on :8767.

**The card's five points, all landed here:**

1. **Died-with-restart marking at every respawn class.** The background-task registry never silently forgets running tasks: they flip to a retained `died-with-restart` status with a named cause (`mark_running_died_with_restart`). Specific causes at the seams that know them — the credential-reload respawn (pre-shutdown, both call sites), the error-park and rate-limit park arms in both lanes (external_mode + the run_modes persistent lane), gated on the backend's confirmed-exit probe so an API-500 against a live process marks nothing and the park stays honest, and the boot + released-predecessor passes (`the daemon restart`) — with generic backstops in the CC adapter's shutdown/Drop/re-adoption. Kimi is deliberately exempt: its tasks are server-side and survive a client respawn.
2. **Honest attention state + one-tap re-run, never a second lane.** The marking seam publishes a corrected activity snapshot (wire-honest `idle` + `diedBackgroundTasks`/`diedTasksCause`), sticky in the vitals hub until demonstrable work (`fold_died_tasks_attention`); the durable `SessionMeta.bg_park` marker shadows the claim across daemon restarts (live while parked, died with the cause, cleared on turn states — preserved by every meta rewrite). The SPA derives a `died-tasks` display state: warn-severity chip, per-task explainer, a status pill that says "task died with restart", the killing restart named on inspector rows, and a one-tap "ask the session to re-run it" that sends an owner follow-up through the existing start_task lane. The re-run OFFER rides only continuation nudges the #644 delivery-aware lane already sends (reload continuation, park resume nudges — synthesized-nudge-only, never a verbatim owner message — and readopt continuations). **No automatic re-execution anywhere**, pinned by `died_with_restart_marking_never_arms_delivery` (surfaces-only bus emission) and the boot-pass twin.
3. **bg-count chips derive from live registry state** (the error-park R5 display latch): every activity claim is registry-synced at emission, and `sessionParkedPillLabel` stops flooring an unvouched parked claim to "1 task" — no tasks vouched, no parked pill.
4. **Drain interplay (#729):** `session_holds_drain` releases an idle session whose only hold is a died park (its wait is on nobody; the durable marker survives to the successor); the supervisor derives died-park membership from the one activity carrier; live bg-parks ride the `DrainHoldout` rows so the wait line says what an idle holdout actually waits on ("parked on a background task").
5. **Pinned tests** (all green in the keyless battery: 5,497+150+97 bins, 41 e2e, workspace clippy -D warnings, fmt --check — per-step unmasked exits): registry flip semantics + idempotent re-mark; no-auto-rerun; drain arithmetic with a died-park member; died-park membership lifecycle; meta rewrite preservation + died-outlives-idle; hub sticky fold; boot pass marks-and-never-dispatches; readopt offer only on a died marker; adapter re-adoption retains-and-flips; SPA fragment needles.

Docs: a "Parked-task Respawn Honesty" section in `docs/src/external-agent-orchestration.md`.