### PR TITLE
presence: honor typed task outcomes

### DIFF
--- a/src/bin/caller/peer/upcast.rs
+++ b/src/bin/caller/peer/upcast.rs
@@ -898,13 +898,12 @@ impl AppEventUpcaster {
                 session_id,
                 reason,
                 summary,
-                outcome: _,
+                outcome: task_outcome,
             } => {
-                let outcome = match reason.as_str() {
-                    "success" | "done" | "completed" => ActivityOutcome::Success,
-                    "cancelled" | "canceled" => ActivityOutcome::Cancelled,
-                    other => ActivityOutcome::Failed {
-                        message: other.to_string(),
+                let outcome = match task_outcome {
+                    crate::event::TaskOutcome::Completed => ActivityOutcome::Success,
+                    crate::event::TaskOutcome::Failed => ActivityOutcome::Failed {
+                        message: reason.clone(),
                     },
                 };
                 let mut out = vec![];
@@ -3923,20 +3922,23 @@ mod tests {
         assert_eq!(progress_id, start_id);
     }
 
-    /// A failing `TaskComplete` must propagate its failure outcome
-    /// to *both* the in-flight agent and the turn. Before the
-    /// outcome-threading fix, `close_pending_agent` hardcoded
-    /// `ActivityOutcome::Success`, so a failed task emitted a
-    /// Success ActivityCompleted for the agent and a Failed
-    /// ActivityCompleted for the turn — contradictory events in
-    /// the consumer's feed that would render as "the tool
-    /// succeeded but the turn it ran in failed." Verifies both
-    /// upcasters behave consistently on both failure and cancel.
+    /// `TaskComplete` must propagate its typed outcome to both the
+    /// in-flight agent and the turn. Reason text is descriptive and
+    /// cannot classify the terminal: failed externals routinely carry
+    /// prose such as "process closed stdout", while completed policy
+    /// exits may contain words such as "denied".
     #[test]
-    fn task_complete_failure_propagates_to_agent_and_turn() {
-        for (reason, expected) in &[("failed", "failed"), ("cancelled", "cancelled")] {
+    fn task_complete_uses_typed_outcome_for_agent_and_turn() {
+        for (reason, task_outcome, expected) in &[
+            ("success", crate::event::TaskOutcome::Failed, "failed"),
+            (
+                "Denied by user",
+                crate::event::TaskOutcome::Completed,
+                "success",
+            ),
+        ] {
             let mut u = AppEventUpcaster::new();
-            // Open turn + agent, then fail.
+            // Open turn + agent, then terminate it.
             let _ = u.upcast(&AppEvent::TurnStarted {
                 session_id: None,
                 turn: 4,
@@ -3955,7 +3957,7 @@ mod tests {
                 session_id: None,
                 reason: (*reason).to_string(),
                 summary: None,
-                outcome: crate::event::TaskOutcome::Completed,
+                outcome: *task_outcome,
             });
             let completions: Vec<_> = out
                 .iter()
@@ -3975,7 +3977,7 @@ mod tests {
             for (id, outcome) in &completions {
                 let outcome_matches = match (*expected, outcome) {
                     ("failed", ActivityOutcome::Failed { .. }) => true,
-                    ("cancelled", ActivityOutcome::Cancelled) => true,
+                    ("success", ActivityOutcome::Success) => true,
                     _ => false,
                 };
                 assert!(

--- a/src/bin/caller/presence.rs
+++ b/src/bin/caller/presence.rs
@@ -444,7 +444,8 @@ impl PresenceLayer {
         //   - completed / waiting_followup: a round just finished; this
         //     is exactly when the user types a follow-up, so accepting
         //     submit_task here is what unblocks follow-up dispatch
-        //   - "done: <reason>": TaskComplete-style terminal state
+        //   - "done: <reason>" / "failed: <reason>": TaskComplete-style
+        //     terminal states
         if let PresenceAction::SubmitTask(envelope) = action {
             let is_busy = {
                 let state = self.agent_state.lock().unwrap_or_else(|e| e.into_inner());
@@ -930,13 +931,24 @@ pub fn filter_event(event: &AppEvent, last_phase: &mut String) -> Option<Presenc
             }
         }
         AppEvent::TaskComplete {
-            reason, summary, ..
+            reason,
+            summary,
+            outcome,
+            ..
         } => {
             *last_phase = "done".to_string();
-            Some(PresenceEvent::TaskComplete {
-                reason: reason.clone(),
-                summary: summary.clone(),
-            })
+            match outcome {
+                crate::event::TaskOutcome::Completed => Some(PresenceEvent::TaskComplete {
+                    reason: reason.clone(),
+                    summary: summary.clone(),
+                }),
+                crate::event::TaskOutcome::Failed => Some(PresenceEvent::Error {
+                    message: match summary.as_deref().filter(|text| !text.trim().is_empty()) {
+                        Some(summary) => format!("Task failed ({reason}): {summary}"),
+                        None => format!("Task failed: {reason}"),
+                    },
+                }),
+            }
         }
         AppEvent::ApprovalRequired {
             id,
@@ -1249,6 +1261,7 @@ pub fn is_agent_idle(phase: &str) -> bool {
         phase,
         "" | "idle" | "waiting_for_task" | "waiting_followup" | "completed"
     ) || phase.starts_with("done")
+        || phase.starts_with("failed")
 }
 
 /// First `max_chars` characters of `s` as a borrowed slice (char-boundary
@@ -1297,9 +1310,15 @@ pub fn update_agent_state(event: &AppEvent, state: &Arc<Mutex<AgentStateSnapshot
             s.last_output_summary = truncate(&combined, 500);
         }
         AppEvent::TaskComplete {
-            reason, summary, ..
+            reason,
+            summary,
+            outcome,
+            ..
         } => {
-            s.phase = format!("done: {}", reason);
+            s.phase = match outcome {
+                crate::event::TaskOutcome::Completed => format!("done: {reason}"),
+                crate::event::TaskOutcome::Failed => format!("failed: {reason}"),
+            };
             if let Some(text) = summary {
                 s.last_task_result = Some(text.clone());
             }
@@ -1447,6 +1466,7 @@ mod tests {
         assert!(is_agent_idle("done"));
         assert!(is_agent_idle("done: signal"));
         assert!(is_agent_idle("done: max_turns"));
+        assert!(is_agent_idle("failed: wrapper process exited"));
         // Busy states must still be rejected.
         assert!(!is_agent_idle("thinking"));
         assert!(!is_agent_idle("running_agent"));
@@ -1540,6 +1560,25 @@ mod tests {
 
         let event = AppEvent::LoopError("oops".to_string());
         assert!(filter_event(&event, &mut last_phase).is_some());
+    }
+
+    #[test]
+    fn failed_task_complete_is_announced_as_failure() {
+        let mut last_phase = String::new();
+        let event = AppEvent::TaskComplete {
+            session_id: None,
+            reason: "Claude Code process closed stdout".to_string(),
+            summary: Some("recovery was exhausted".to_string()),
+            outcome: crate::event::TaskOutcome::Failed,
+        };
+
+        let filtered = filter_event(&event, &mut last_phase).expect("presence event");
+        assert_eq!(last_phase, "done");
+        assert!(matches!(
+            filtered,
+            PresenceEvent::Error { message }
+                if message == "Task failed (Claude Code process closed stdout): recovery was exhausted"
+        ));
     }
 
     #[test]
@@ -1752,6 +1791,20 @@ mod tests {
         {
             let s = state.lock().unwrap();
             assert_eq!(s.phase, "done: done_signal");
+        }
+
+        update_agent_state(
+            &AppEvent::TaskComplete {
+                session_id: None,
+                reason: "wrapper process exited".to_string(),
+                summary: None,
+                outcome: crate::event::TaskOutcome::Failed,
+            },
+            &state,
+        );
+        {
+            let s = state.lock().unwrap();
+            assert_eq!(s.phase, "failed: wrapper process exited");
         }
     }
 


### PR DESCRIPTION
## What changed

- Presence now uses the typed `TaskOutcome` when narrating terminal events, so failed external runs are announced as failures rather than task completion.
- Presence status records failed terminals honestly while still allowing a follow-up task.
- The peer activity upcaster now derives success/failure from `TaskOutcome` instead of free-form reason prose.
- Regression tests cover contradictory reason text and failed Presence events.

## Why

Agenda item `01KYB5CYXR1T6G410RD0WHB2KH` records the bug: killed external runs and exhausted recovery carried `TaskOutcome::Failed`, but two consumers discarded it and guessed completion from event shape or reason strings.

## Validation

- `cargo fmt --check`
- `git diff --check`
- GitHub checks passed: Ubuntu, macOS, Windows, check, WASM relevance, and fragment parity.

A provider-neutral remote-compute concurrency acceptance was also attempted. Distinct revisions correctly created two simultaneous Cloud worker tasks, while same-revision commands coalesced onto one acquisition. Both workers remained in active cold setup beyond the scheduler's 900-second attachment ceiling, so no remote Cargo command ran. That infrastructure finding is recorded on the existing cold-bootstrap agenda item; it is not a failure of this change, whose three-platform CI is green.
