### PR TITLE
fix(remote-compute): make worker acquisition truthful

### DIFF
--- a/scripts/codex-cloud/setup.sh
+++ b/scripts/codex-cloud/setup.sh
@@ -84,7 +84,7 @@ install_prebuilt_sccache() {
   esac
 
   asset="sccache-v${SCCACHE_VERSION}-${target}.tar.gz"
-  sccache_tmp="$(mktemp -d)"
+  sccache_tmp="$(mktemp -d)" || return 1
   archive="$sccache_tmp/$asset"
   curl --fail --silent --show-error --location \
     --proto '=https' --tlsv1.2 \

--- a/scripts/codex-cloud/setup.sh
+++ b/scripts/codex-cloud/setup.sh
@@ -9,8 +9,29 @@ repo_root="${CODEX_CLOUD_REPO_ROOT:-$PWD}"
 # after install_downloaded_binary has returned, where a local would be
 # unbound under set -u (and the download would leak).
 downloaded=""
+sccache_tmp=""
 
 mkdir -p "$bin_dir" "$libexec_dir"
+export PATH="$bin_dir:$PATH"
+
+cleanup_downloads() {
+  rm -f "${downloaded:-}"
+  if [[ -n "${sccache_tmp:-}" && -d "$sccache_tmp" ]]; then
+    rm -rf -- "$sccache_tmp"
+  fi
+}
+trap cleanup_downloads EXIT
+
+file_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    echo "sha256sum or shasum is required to verify downloaded binaries" >&2
+    return 2
+  fi
+}
 
 install_downloaded_binary() {
   if [[ -z "${INTENDANT_CLOUD_BINARY_SHA256:-}" ]]; then
@@ -20,28 +41,85 @@ install_downloaded_binary() {
 
   local actual
   downloaded="$(mktemp)"
-  # EXIT, not RETURN: a set -e abort inside the function skips RETURN traps
-  # and would leak the download.
-  trap 'rm -f "${downloaded:-}"' EXIT
   curl --fail --silent --show-error --location \
     --proto '=https' --tlsv1.2 \
     "$INTENDANT_CLOUD_BINARY_URL" \
     --output "$downloaded"
 
-  if command -v sha256sum >/dev/null 2>&1; then
-    actual="$(sha256sum "$downloaded" | awk '{print $1}')"
-  elif command -v shasum >/dev/null 2>&1; then
-    actual="$(shasum -a 256 "$downloaded" | awk '{print $1}')"
-  else
-    echo "sha256sum or shasum is required to verify the Intendant binary" >&2
-    return 2
-  fi
+  actual="$(file_sha256 "$downloaded")"
 
   if [[ "$actual" != "$INTENDANT_CLOUD_BINARY_SHA256" ]]; then
     echo "Intendant binary checksum mismatch" >&2
     return 2
   fi
   install -m 0755 "$downloaded" "$bin_dir/intendant"
+}
+
+SCCACHE_VERSION="0.15.0"
+
+sccache_is_usable() {
+  local binary="$1"
+  local version major rest minor
+  version="$("$binary" --version 2>/dev/null | awk '{print $2}')"
+  version="${version#v}"
+  major="${version%%.*}"
+  rest="${version#*.}"
+  minor="${rest%%.*}"
+  [[ "$major" =~ ^[0-9]+$ && "$minor" =~ ^[0-9]+$ ]] \
+    && (( major > 0 || minor >= 14 ))
+}
+
+install_prebuilt_sccache() {
+  local target checksum asset archive actual extracted
+  case "$(uname -s):$(uname -m)" in
+    Linux:x86_64|Linux:amd64)
+      target="x86_64-unknown-linux-musl"
+      checksum="782d2b5dd7ae0a55ebe368ab258114d0928d019ac2d949ab85d5d02f3926709e"
+      ;;
+    Linux:aarch64|Linux:arm64)
+      target="aarch64-unknown-linux-musl"
+      checksum="3a6a3712b49da3d263bf2d30d702de4302793016019e800bfb81c0c69401d8f8"
+      ;;
+    *) return 1 ;;
+  esac
+
+  asset="sccache-v${SCCACHE_VERSION}-${target}.tar.gz"
+  sccache_tmp="$(mktemp -d)"
+  archive="$sccache_tmp/$asset"
+  curl --fail --silent --show-error --location \
+    --proto '=https' --tlsv1.2 \
+    "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/$asset" \
+    --output "$archive" || return 1
+  actual="$(file_sha256 "$archive")" || return 1
+  if [[ "$actual" != "$checksum" ]]; then
+    echo "sccache $SCCACHE_VERSION checksum mismatch for $target" >&2
+    return 1
+  fi
+  tar -xzf "$archive" -C "$sccache_tmp" || return 1
+  extracted="$sccache_tmp/sccache-v${SCCACHE_VERSION}-${target}/sccache"
+  [[ -f "$extracted" ]] || return 1
+  install -m 0755 "$extracted" "$bin_dir/sccache" || return 1
+  rm -rf -- "$sccache_tmp"
+  sccache_tmp=""
+  echo "installed checksum-verified sccache $SCCACHE_VERSION prebuilt for $target"
+}
+
+install_sccache() {
+  local existing
+  existing="$(command -v sccache || true)"
+  if [[ -n "$existing" ]] && sccache_is_usable "$existing"; then
+    echo "worker sccache prerequisite present ($("$existing" --version))"
+    return 0
+  fi
+  if install_prebuilt_sccache; then
+    return 0
+  fi
+  if ! command -v cargo >/dev/null 2>&1; then
+    echo "warning: no supported sccache prebuilt and cargo is unavailable" >&2
+    return 1
+  fi
+  echo "warning: prebuilt sccache unavailable; compiling pinned $SCCACHE_VERSION fallback" >&2
+  cargo install --locked --version "$SCCACHE_VERSION" --root "$install_root" sccache
 }
 
 build_checked_out_binary() {
@@ -56,6 +134,10 @@ build_checked_out_binary() {
   cargo build --locked --release --bin intendant --manifest-path "$repo_root/Cargo.toml"
   install -m 0755 "$repo_root/target/release/intendant" "$bin_dir/intendant"
 }
+
+if [[ "${INTENDANT_CLOUD_SKIP_SCCACHE:-0}" != "1" ]]; then
+  install_sccache || echo "warning: sccache installation failed; durable_sccache jobs will be unavailable" >&2
+fi
 
 if [[ -n "${INTENDANT_CLOUD_BINARY_URL:-}" ]]; then
   install_downloaded_binary

--- a/src/bin/caller/codex_cloud.rs
+++ b/src/bin/caller/codex_cloud.rs
@@ -42,7 +42,7 @@ impl ProviderLeaseState {
         }
     }
 
-    fn is_terminal(&self) -> bool {
+    pub(crate) fn is_terminal(&self) -> bool {
         matches!(self, Self::Finished | Self::Failed | Self::Cancelled)
     }
 }
@@ -207,6 +207,14 @@ pub fn warmth_label(warmth: Warmth) -> &'static str {
         Warmth::Unknown => "unknown",
         Warmth::ColdLikely => "cold",
     }
+}
+
+/// Whether this daemon can dispatch remote-compute frames to the worker now.
+/// Provider warmth and setup-cache likelihood are deliberately separate: a
+/// task can still look warm to the provider while its home attachment is gone.
+pub(crate) fn lease_remote_compute_usable(lease: &WorkerLease) -> bool {
+    lease.attachment_state == AttachmentState::Connected
+        && crate::codex_cloud_attach::attachment_channel(&lease.task_id).is_some()
 }
 
 #[derive(Debug, Clone)]
@@ -532,38 +540,49 @@ async fn run_list(args: &[String]) -> Result<(), String> {
 fn print_lease_table(leases: &[WorkerLease]) {
     let now = now_unix_ms();
     println!(
-        "{:<38}  {:<10}  {:<13}  {:<8}  TITLE",
-        "TASK", "PROVIDER", "ATTACHMENT", "WARMTH"
+        "{:<38}  {:<10}  {:<13}  {:<8}  {:<8}  TITLE",
+        "TASK", "PROVIDER", "ATTACHMENT", "REMOTE", "CACHE"
     );
     for lease in leases {
         println!(
-            "{:<38}  {:<10}  {:<13}  {:<8}  {}",
+            "{:<38}  {:<10}  {:<13}  {:<8}  {:<8}  {}",
             lease.task_id,
             lease.provider_status,
             attachment_label(&lease.attachment_state),
+            remote_compute_label(lease_remote_compute_usable(lease)),
             warmth_label(lease_warmth(lease, now)),
             lease.title
         );
     }
 }
 
-/// Serialize leases with the derived warmth attached — computed on the
-/// daemon side so no frontend re-implements the heuristic.
+/// Serialize leases with independent provider-cache and live-attachment
+/// derivations so no frontend has to infer reachability from warmth.
 pub fn leases_json(leases: &[WorkerLease]) -> Vec<serde_json::Value> {
     let now = now_unix_ms();
     leases
         .iter()
-        .map(|lease| {
-            let mut value = serde_json::to_value(lease).unwrap_or(serde_json::Value::Null);
-            if let Some(map) = value.as_object_mut() {
-                map.insert(
-                    "warmth".to_string(),
-                    serde_json::Value::String(warmth_label(lease_warmth(lease, now)).to_string()),
-                );
-            }
-            value
-        })
+        .map(|lease| lease_json_at(lease, now))
         .collect()
+}
+
+fn lease_json(lease: &WorkerLease) -> serde_json::Value {
+    lease_json_at(lease, now_unix_ms())
+}
+
+fn lease_json_at(lease: &WorkerLease, now: u64) -> serde_json::Value {
+    let mut value = serde_json::to_value(lease).unwrap_or(serde_json::Value::Null);
+    if let Some(map) = value.as_object_mut() {
+        map.insert(
+            "warmth".to_string(),
+            serde_json::Value::String(warmth_label(lease_warmth(lease, now)).to_string()),
+        );
+        map.insert(
+            "remote_compute_usable".to_string(),
+            serde_json::Value::Bool(lease_remote_compute_usable(lease)),
+        );
+    }
+    value
 }
 
 fn transition_title(transition: &TerminalTransition) -> String {
@@ -579,7 +598,7 @@ fn transition_title(transition: &TerminalTransition) -> String {
 /// without a daemon the printed notice is the whole delivery. The store
 /// lock already guarantees each edge is observed once, so whoever observes
 /// it parks it.
-async fn announce_transitions(transitions: &[TerminalTransition]) {
+pub(crate) async fn announce_transitions(transitions: &[TerminalTransition]) {
     for transition in transitions {
         eprintln!(
             "[intendant] task {} is now {} — {}",
@@ -784,7 +803,7 @@ async fn run_status(args: &[String]) -> Result<(), String> {
         if json {
             println!(
                 "{}",
-                serde_json::to_string_pretty(&lease)
+                serde_json::to_string_pretty(&lease_json(&lease))
                     .map_err(|e| format!("serialize worker lease: {e}"))?
             );
         } else {
@@ -2585,7 +2604,11 @@ fn print_lease(lease: &WorkerLease) {
         attachment_label(&lease.attachment_state)
     );
     println!(
-        "  warmth: {}",
+        "  remote compute: {}",
+        remote_compute_label(lease_remote_compute_usable(lease))
+    );
+    println!(
+        "  provider cache: {}",
         warmth_label(lease_warmth(lease, now_unix_ms()))
     );
     if lease.turns_observed > 0 {
@@ -2637,6 +2660,14 @@ fn attachment_label(state: &AttachmentState) -> &'static str {
         AttachmentState::Connected => "connected",
         AttachmentState::Disconnected => "disconnected",
         AttachmentState::Expired => "expired",
+    }
+}
+
+fn remote_compute_label(usable: bool) -> &'static str {
+    if usable {
+        "usable"
+    } else {
+        "offline"
     }
 }
 
@@ -3037,6 +3068,14 @@ mod tests {
         let mut history = lease("task_e_hist");
         history.provider_state = ProviderLeaseState::Finished;
         assert_eq!(lease_warmth(&history, u64::MAX), Warmth::Unknown);
+
+        // Cache likelihood never implies that this daemon has a command
+        // transport. The two facts remain explicit in every JSON view.
+        done.attachment_state = AttachmentState::Expired;
+        done.last_terminal_at_unix_ms = Some(1_000);
+        let view = lease_json_at(&done, 1_001);
+        assert_eq!(view["warmth"], "warm");
+        assert_eq!(view["remote_compute_usable"], false);
     }
 
     #[test]

--- a/src/bin/caller/codex_cloud.rs
+++ b/src/bin/caller/codex_cloud.rs
@@ -3391,6 +3391,11 @@ EOF
     fn bootstrap_scripts_do_not_persist_credentials() {
         assert!(!SETUP_SCRIPT.contains("AUTH_KEY"));
         assert!(!SETUP_SCRIPT.contains("ENROLL_TOKEN"));
+        assert!(SETUP_SCRIPT.contains("SCCACHE_VERSION=\"0.15.0\""));
+        assert!(SETUP_SCRIPT
+            .contains("782d2b5dd7ae0a55ebe368ab258114d0928d019ac2d949ab85d5d02f3926709e"));
+        assert!(SETUP_SCRIPT
+            .contains("3a6a3712b49da3d263bf2d30d702de4302793016019e800bfb81c0c69401d8f8"));
         assert!(!MAINTENANCE_SCRIPT.contains("AUTH_KEY"));
         assert!(!MAINTENANCE_SCRIPT.contains("ENROLL_TOKEN"));
         assert!(WORKER_SCRIPT.contains("mktemp -d"));

--- a/src/bin/caller/codex_cloud_attach.rs
+++ b/src/bin/caller/codex_cloud_attach.rs
@@ -29,8 +29,9 @@ use std::time::Duration;
 use crate::codex_cloud::{record_attachment_state, state_path, AttachmentState, StoreLock};
 
 const BROKER_VERSION: u32 = 1;
-/// Enrollment tokens are delivery secrets for one attach ceremony:
-/// minutes, not hours.
+/// Default for a manual attach ceremony. Automatic acquisition extends its
+/// one-time token to the separately bounded cold-start deadline plus a small
+/// grace window; neither form is a durable credential.
 pub(crate) const DEFAULT_TOKEN_TTL_S: u64 = 900;
 /// The issued identity's record expiry (independent of cert validity —
 /// the record is what the gateway enforces on every connection).

--- a/src/bin/caller/mcp/tool_gate.rs
+++ b/src/bin/caller/mcp/tool_gate.rs
@@ -619,7 +619,7 @@ fn build_manual_http_tool_definitions() -> Vec<serde_json::Value> {
         "remote_command",
         manual_http_tool_definition!(
             "remote_command",
-            "Use this instead of local execution for heavy platform-neutral compilation and testing. Start, inspect, wait for, or cancel a provider-neutral remote command job. Start accepts argv (never a shell string), host auto by default (reuse/acquire Codex Cloud) or explicit cloud:<task-id>, source git_revision or an explicit working_tree snapshot, and optional durable_sccache. Git-revision jobs require expected_revision; working-tree jobs resolve a pinned base. Start returns immediately through acquiring/preparing/running states; status/wait returns bounded output and exact terminal/cache results. Keep only small OS-specific checks local.",
+            "Use this instead of local execution for heavy platform-neutral compilation and testing. Start, inspect, wait for, or cancel a provider-neutral remote command job. Start accepts argv (never a shell string), host auto by default (reuse/acquire Codex Cloud) or explicit cloud:<task-id>, an optional pushed branch hint, source git_revision or an explicit working_tree snapshot, and optional durable_sccache. Git-revision jobs require expected_revision; working-tree jobs resolve a pinned base. Start returns immediately with acquisition stage/task/deadline detail through preparing/running states; status/wait returns bounded output and exact terminal/cache results. Keep only small OS-specific checks local.",
             RemoteCommandParams
         ),
     );

--- a/src/bin/caller/mcp/tool_gate.rs
+++ b/src/bin/caller/mcp/tool_gate.rs
@@ -884,6 +884,10 @@ mod tests {
                 .as_deref(),
             "native remote_command description drifted from the MCP surface"
         );
+        assert!(
+            native.parameters["properties"]["branch"].is_object(),
+            "native remote_command schema must expose the owner-supplied branch hint"
+        );
     }
 
     #[test]

--- a/src/bin/caller/mcp/tool_params.rs
+++ b/src/bin/caller/mcp/tool_params.rs
@@ -183,6 +183,11 @@ pub enum RemoteCommandParams {
         /// available for operator-selected attachments.
         #[serde(default)]
         host: Option<String>,
+        /// Pushed provider branch that contains `expected_revision`. This is
+        /// useful for owner-triggered calls without a supervised project
+        /// root. The attached worker still has to report the exact revision.
+        #[serde(default)]
+        branch: Option<String>,
         /// Executable followed by its arguments. This is never parsed by a shell.
         argv: Vec<String>,
         /// Repository-relative working directory; omitted means repository root.

--- a/src/bin/caller/mcp/tools_remote_compute.rs
+++ b/src/bin/caller/mcp/tools_remote_compute.rs
@@ -4,7 +4,7 @@ use super::*;
 
 impl IntendantServer {
     #[tool(
-        description = "Use this instead of local execution for heavy platform-neutral compilation and testing. Start, inspect, wait for, or cancel a provider-neutral remote command job. Start accepts argv (never a shell string), host auto by default (reuse/acquire Codex Cloud) or explicit cloud:<task-id>, source git_revision or an explicit working_tree snapshot, and optional durable_sccache. Git-revision jobs require expected_revision; working-tree jobs resolve a pinned base. Start returns immediately through acquiring/preparing/running states; status/wait returns bounded output and exact terminal/cache results. Keep only small OS-specific checks local."
+        description = "Use this instead of local execution for heavy platform-neutral compilation and testing. Start, inspect, wait for, or cancel a provider-neutral remote command job. Start accepts argv (never a shell string), host auto by default (reuse/acquire Codex Cloud) or explicit cloud:<task-id>, an optional pushed branch hint, source git_revision or an explicit working_tree snapshot, and optional durable_sccache. Git-revision jobs require expected_revision; working-tree jobs resolve a pinned base. Start returns immediately with acquisition stage/task/deadline detail through preparing/running states; status/wait returns bounded output and exact terminal/cache results. Keep only small OS-specific checks local."
     )]
     pub(crate) async fn remote_command(
         &self,

--- a/src/bin/caller/remote_compute.rs
+++ b/src/bin/caller/remote_compute.rs
@@ -298,6 +298,40 @@ impl RemoteCommandState {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RemoteCommandAcquisitionStage {
+    CheckingForWorker,
+    SubmittingTask,
+    WaitingForWorker,
+    Attached,
+    ProviderEnded,
+    TimedOut,
+}
+
+/// Live detail for the provider-owned worker acquisition that precedes an
+/// automatic command. The command timeout starts only after this succeeds;
+/// this separate deadline bounds the potentially cold provider bootstrap.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct RemoteCommandAcquisitionView {
+    pub stage: RemoteCommandAcquisitionStage,
+    pub coalesced: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider_status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attachment_state: Option<crate::codex_cloud::AttachmentState>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_provider_error: Option<String>,
+    pub timeout_s: u64,
+    pub deadline_at_unix_ms: u64,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct RemoteCommandResult {
     pub state: RemoteCommandState,
@@ -371,6 +405,8 @@ pub(crate) struct RemoteCommandJobView {
     pub timeout_s: u64,
     pub source: RemoteSourceMode,
     pub cache: RemoteCacheMode,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub acquisition: Option<RemoteCommandAcquisitionView>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub snapshot_digest: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -545,6 +581,7 @@ async fn start_remote_command(
 
     let job_id = format!("remote-{}", uuid::Uuid::new_v4());
     let now = crate::codex_cloud::now_unix_ms();
+    let acquire_timeout_s = scheduler::acquire_timeout_s();
     let view = RemoteCommandJobView {
         job_id: job_id.clone(),
         host: requested_host.clone(),
@@ -563,6 +600,18 @@ async fn start_remote_command(
         timeout_s: spec.timeout_s,
         source: source_mode,
         cache: spec.cache,
+        acquisition: (requested_host == "auto").then(|| RemoteCommandAcquisitionView {
+            stage: RemoteCommandAcquisitionStage::CheckingForWorker,
+            coalesced: false,
+            branch: branch_hint.clone(),
+            task_id: None,
+            task_url: None,
+            provider_status: None,
+            attachment_state: None,
+            last_provider_error: None,
+            timeout_s: acquire_timeout_s,
+            deadline_at_unix_ms: now.saturating_add(acquire_timeout_s.saturating_mul(1000)),
+        }),
         snapshot_digest: snapshot.as_ref().map(|snapshot| snapshot.digest.clone()),
         snapshot_bytes: snapshot
             .as_ref()
@@ -582,6 +631,7 @@ async fn start_remote_command(
             cache_store,
             snapshot,
             branch_hint,
+            acquire_timeout_s,
         )
         .await
         {
@@ -604,9 +654,24 @@ async fn prepare_and_dispatch(
     cache_store: Option<cache_relay::HomeCacheStore>,
     snapshot: Option<source::HomeSourceSnapshot>,
     branch_hint: Option<String>,
+    acquire_timeout_s: u64,
 ) -> Result<(), String> {
     let host = if requested_host == "auto" {
-        let acquired = scheduler::acquire_worker(&spec.expected_revision, branch_hint).await?;
+        let progress_job_id = job_id.clone();
+        let observer: scheduler::AcquisitionObserver = Arc::new(move |progress| {
+            update_home_job(&progress_job_id, |job| {
+                if !job.state.is_terminal() {
+                    job.acquisition = Some(progress);
+                }
+            });
+        });
+        let acquired = scheduler::acquire_worker(
+            &spec.expected_revision,
+            branch_hint,
+            acquire_timeout_s,
+            observer,
+        )
+        .await?;
         acquired.host
     } else {
         requested_host
@@ -914,6 +979,7 @@ pub(crate) async fn execute_remote_command_operation(
     match params {
         crate::mcp::RemoteCommandParams::Start {
             host,
+            branch,
             argv,
             cwd,
             env,
@@ -923,7 +989,7 @@ pub(crate) async fn execute_remote_command_operation(
             cache,
             timeout_s,
         } => {
-            let (expected_revision, snapshot, branch_hint) = match source {
+            let (expected_revision, snapshot, derived_branch) = match source {
                 RemoteSourceMode::GitRevision => {
                     let revision = expected_revision
                         .map(|revision| revision.trim().to_string())
@@ -949,6 +1015,7 @@ pub(crate) async fn execute_remote_command_operation(
                     (base_revision, Some(snapshot), branch_hint)
                 }
             };
+            let branch_hint = scheduler::select_branch(branch, derived_branch)?;
             let DurableSccacheConfig {
                 cache_env,
                 cache_relay_token,
@@ -2191,6 +2258,7 @@ mod tests {
                 timeout_s: 10,
                 source: RemoteSourceMode::GitRevision,
                 cache: RemoteCacheMode::None,
+                acquisition: None,
                 snapshot_digest: None,
                 snapshot_bytes: None,
                 created_at_unix_ms: now,

--- a/src/bin/caller/remote_compute/scheduler.rs
+++ b/src/bin/caller/remote_compute/scheduler.rs
@@ -98,7 +98,7 @@ struct OwnedWorker {
     active_jobs: usize,
     generation: u64,
     retiring: bool,
-    created_at: Instant,
+    retire_retry_deadline: Instant,
 }
 
 static OWNED_WORKERS: OnceLock<Mutex<HashMap<String, OwnedWorker>>> = OnceLock::new();
@@ -364,7 +364,7 @@ async fn acquire_new_worker(
     // Ownership starts when this process creates the provider task, not only
     // after a successful attachment. A late attachment after our wait timeout
     // must still retire instead of becoming an unowned leak.
-    register_owned(&host);
+    register_owned(&host, timeout_s);
     let mut last_lease = cached_task_lease(&lease_store, &task_id).or(submitted.lease);
     let mut last_provider_error = None;
     flight.publish(acquisition_progress(
@@ -384,11 +384,6 @@ async fn acquire_new_worker(
         }
         let now = tokio::time::Instant::now();
         if now >= deadline {
-            match refresh_acquiring_task(&lease_store, key, &task_id).await {
-                Ok(Some(lease)) => last_lease = Some(lease),
-                Ok(None) => {}
-                Err(error) => last_provider_error = Some(concise_error(&error)),
-            }
             if let Some(lease) = last_lease.as_ref().filter(|lease| {
                 lease.provider_state.is_terminal()
                     && crate::codex_cloud_attach::attachment_channel(&task_id).is_none()
@@ -583,7 +578,7 @@ fn acquisition_timeout_error(
         .map(|url| format!(" Inspect {url}."))
         .unwrap_or_default();
     let refresh = provider_error
-        .map(|error| format!(" The final provider refresh also failed: {error}."))
+        .map(|error| format!(" The last provider refresh failed: {error}."))
         .unwrap_or_default();
     format!(
         "Codex Cloud worker {task_id} did not attach before the {timeout_s}s acquisition deadline{status}. Intendant did not cancel the provider task; it may still be finishing cold setup.{url}{refresh} If this environment intentionally needs longer, raise INTENDANT_REMOTE_COMPUTE_ACQUIRE_TIMEOUT_S (maximum {MAX_ACQUIRE_TIMEOUT_S}s)."
@@ -604,10 +599,14 @@ fn concise_error(error: &str) -> String {
     concise
 }
 
-fn register_owned(host: &str) {
+fn register_owned(host: &str, acquire_timeout_s: u64) {
     let mut workers = owned_workers()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
+    // An unbound enrollment may redeem at the very end of a cold acquisition.
+    // Keep retrying retirement until that latest possible identity has expired,
+    // rather than measuring only from provider task creation.
+    let retry_window_s = retire_retry_window_s(acquire_timeout_s);
     workers.insert(
         host.to_string(),
         OwnedWorker {
@@ -616,9 +615,15 @@ fn register_owned(host: &str) {
             active_jobs: 1,
             generation: 1,
             retiring: false,
-            created_at: Instant::now(),
+            retire_retry_deadline: Instant::now() + Duration::from_secs(retry_window_s),
         },
     );
+}
+
+fn retire_retry_window_s(acquire_timeout_s: u64) -> u64 {
+    enrollment_token_ttl_s(acquire_timeout_s)
+        .saturating_add(crate::codex_cloud_attach::DEFAULT_IDENTITY_TTL_S)
+        .saturating_add(60)
 }
 
 pub(super) struct WorkerUse {
@@ -731,11 +736,7 @@ fn schedule_retirement(host: String, generation: u64) {
                         let Some(worker) = workers.get_mut(&host) else {
                             return;
                         };
-                        if worker.created_at.elapsed()
-                            >= Duration::from_secs(
-                                crate::codex_cloud_attach::DEFAULT_IDENTITY_TTL_S + 60,
-                            )
-                        {
+                        if Instant::now() >= worker.retire_retry_deadline {
                             workers.remove(&host);
                             return;
                         }
@@ -847,6 +848,13 @@ mod tests {
         assert_eq!(
             enrollment_token_ttl_s(DEFAULT_ACQUIRE_TIMEOUT_S),
             DEFAULT_ACQUIRE_TIMEOUT_S + ENROLLMENT_TOKEN_GRACE_S
+        );
+        assert_eq!(
+            retire_retry_window_s(DEFAULT_ACQUIRE_TIMEOUT_S),
+            DEFAULT_ACQUIRE_TIMEOUT_S
+                + ENROLLMENT_TOKEN_GRACE_S
+                + crate::codex_cloud_attach::DEFAULT_IDENTITY_TTL_S
+                + 60
         );
     }
 }

--- a/src/bin/caller/remote_compute/scheduler.rs
+++ b/src/bin/caller/remote_compute/scheduler.rs
@@ -8,9 +8,18 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
-const DEFAULT_ACQUIRE_TIMEOUT_S: u64 = 180;
+use super::{RemoteCommandAcquisitionStage, RemoteCommandAcquisitionView};
+
+const DEFAULT_ACQUIRE_TIMEOUT_S: u64 = 3600;
+const MAX_ACQUIRE_TIMEOUT_S: u64 = 7200;
+const ENROLLMENT_TOKEN_GRACE_S: u64 = 300;
+const PROVIDER_REFRESH_INTERVAL_S: u64 = 60;
+const PROVIDER_REFRESH_TIMEOUT_S: u64 = 20;
 const DEFAULT_IDLE_TIMEOUT_S: u64 = 600;
 const REMOTE_WORKER_RETIRE_KIND: &str = "remote_worker_retire";
+
+pub(super) type AcquisitionObserver =
+    Arc<dyn Fn(RemoteCommandAcquisitionView) + Send + Sync + 'static>;
 
 #[derive(Debug, Clone)]
 pub(super) struct AcquiredWorker {
@@ -27,6 +36,55 @@ struct WorkerKey {
 struct AcquireFlight {
     result: Mutex<Option<Result<AcquiredWorker, String>>>,
     notify: tokio::sync::Notify,
+    progress: Mutex<Option<RemoteCommandAcquisitionView>>,
+    observers: Mutex<Vec<FlightObserver>>,
+}
+
+struct FlightObserver {
+    callback: AcquisitionObserver,
+    coalesced: bool,
+}
+
+impl AcquireFlight {
+    fn add_observer(&self, callback: AcquisitionObserver, coalesced: bool) {
+        let current = {
+            self.observers
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .push(FlightObserver {
+                    callback: Arc::clone(&callback),
+                    coalesced,
+                });
+            self.progress
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clone()
+        };
+        if let Some(mut current) = current {
+            current.coalesced = coalesced;
+            callback(current);
+        }
+    }
+
+    fn publish(&self, mut progress: RemoteCommandAcquisitionView) {
+        progress.coalesced = false;
+        *self
+            .progress
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(progress.clone());
+        let observers = self
+            .observers
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .iter()
+            .map(|observer| (Arc::clone(&observer.callback), observer.coalesced))
+            .collect::<Vec<_>>();
+        for (observer, coalesced) in observers {
+            let mut update = progress.clone();
+            update.coalesced = coalesced;
+            observer(update);
+        }
+    }
 }
 
 static FLIGHTS: OnceLock<Mutex<HashMap<WorkerKey, Arc<AcquireFlight>>>> = OnceLock::new();
@@ -49,20 +107,64 @@ fn owned_workers() -> &'static Mutex<HashMap<String, OwnedWorker>> {
     OWNED_WORKERS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+pub(super) fn acquire_timeout_s() -> u64 {
+    config_seconds(
+        "INTENDANT_REMOTE_COMPUTE_ACQUIRE_TIMEOUT_S",
+        DEFAULT_ACQUIRE_TIMEOUT_S,
+        10,
+        MAX_ACQUIRE_TIMEOUT_S,
+    )
+}
+
+pub(super) fn select_branch(
+    requested: Option<String>,
+    derived: Option<String>,
+) -> Result<Option<String>, String> {
+    let selected = requested
+        .or_else(|| optional_env("INTENDANT_REMOTE_COMPUTE_BRANCH"))
+        .or(derived);
+    selected
+        .as_deref()
+        .map(super::source::validate_provider_branch)
+        .transpose()
+}
+
 pub(super) async fn acquire_worker(
     expected_revision: &str,
-    branch_hint: Option<String>,
+    branch: Option<String>,
+    timeout_s: u64,
+    observer: AcquisitionObserver,
 ) -> Result<AcquiredWorker, String> {
     let environment = required_env("INTENDANT_CODEX_CLOUD_ENVIRONMENT")?;
     let revision = expected_revision.trim().to_ascii_lowercase();
-    let branch = optional_env("INTENDANT_REMOTE_COMPUTE_BRANCH").or(branch_hint);
     let key = WorkerKey {
         environment,
         revision,
         branch,
     };
+    let started_at_ms = crate::codex_cloud::now_unix_ms();
+    let deadline_at_unix_ms = started_at_ms.saturating_add(timeout_s.saturating_mul(1000));
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(timeout_s);
+    observer(acquisition_progress(
+        &key,
+        RemoteCommandAcquisitionStage::CheckingForWorker,
+        timeout_s,
+        deadline_at_unix_ms,
+        None,
+        None,
+        None,
+    ));
 
-    if let Some(worker) = matching_attached_worker(&key) {
+    if let Some((worker, lease)) = matching_attached_worker(&key) {
+        observer(acquisition_progress(
+            &key,
+            RemoteCommandAcquisitionStage::Attached,
+            timeout_s,
+            deadline_at_unix_ms,
+            Some(&lease),
+            Some(&lease.task_id),
+            None,
+        ));
         return Ok(worker);
     }
 
@@ -76,15 +178,19 @@ pub(super) async fn acquire_worker(
                 let flight = Arc::new(AcquireFlight {
                     result: Mutex::new(None),
                     notify: tokio::sync::Notify::new(),
+                    progress: Mutex::new(None),
+                    observers: Mutex::new(Vec::new()),
                 });
                 all.insert(key.clone(), Arc::clone(&flight));
                 (flight, true)
             }
         }
     };
+    flight.add_observer(observer, !leader);
 
     if leader {
-        let result = acquire_new_worker(&key).await;
+        let result =
+            acquire_new_worker(&key, timeout_s, deadline_at_unix_ms, deadline, &flight).await;
         *flight
             .result
             .lock()
@@ -111,7 +217,9 @@ pub(super) async fn acquire_worker(
     }
 }
 
-fn matching_attached_worker(key: &WorkerKey) -> Option<AcquiredWorker> {
+fn matching_attached_worker(
+    key: &WorkerKey,
+) -> Option<(AcquiredWorker, crate::codex_cloud::WorkerLease)> {
     crate::codex_cloud::cached_leases(&crate::codex_cloud::state_path())
         .ok()?
         .into_iter()
@@ -121,7 +229,7 @@ fn matching_attached_worker(key: &WorkerKey) -> Option<AcquiredWorker> {
                 crate::codex_cloud_attach::CLOUD_HOST_PREFIX,
                 lease.task_id
             );
-            lease.attachment_state == crate::codex_cloud::AttachmentState::Connected
+            crate::codex_cloud::lease_remote_compute_usable(lease)
                 && lease.environment_id.as_deref() == Some(key.environment.as_str())
                 && lease
                     .worker
@@ -132,22 +240,48 @@ fn matching_attached_worker(key: &WorkerKey) -> Option<AcquiredWorker> {
                             .to_ascii_lowercase()
                             .starts_with(key.revision.as_str())
                     })
-                && crate::codex_cloud_attach::attachment_channel(&lease.task_id).is_some()
                 && !worker_is_retiring(&host)
         })
-        .map(|lease| AcquiredWorker {
-            host: format!(
-                "{}{}",
-                crate::codex_cloud_attach::CLOUD_HOST_PREFIX,
-                lease.task_id
-            ),
+        .map(|lease| {
+            let worker = AcquiredWorker {
+                host: format!(
+                    "{}{}",
+                    crate::codex_cloud_attach::CLOUD_HOST_PREFIX,
+                    lease.task_id
+                ),
+            };
+            (worker, lease)
         })
 }
 
-async fn acquire_new_worker(key: &WorkerKey) -> Result<AcquiredWorker, String> {
-    if let Some(worker) = matching_attached_worker(key) {
+async fn acquire_new_worker(
+    key: &WorkerKey,
+    timeout_s: u64,
+    deadline_at_unix_ms: u64,
+    deadline: tokio::time::Instant,
+    flight: &AcquireFlight,
+) -> Result<AcquiredWorker, String> {
+    if let Some((worker, lease)) = matching_attached_worker(key) {
+        flight.publish(acquisition_progress(
+            key,
+            RemoteCommandAcquisitionStage::Attached,
+            timeout_s,
+            deadline_at_unix_ms,
+            Some(&lease),
+            Some(&lease.task_id),
+            None,
+        ));
         return Ok(worker);
     }
+    flight.publish(acquisition_progress(
+        key,
+        RemoteCommandAcquisitionStage::SubmittingTask,
+        timeout_s,
+        deadline_at_unix_ms,
+        None,
+        None,
+        None,
+    ));
     let home_url = crate::codex_cloud_attach::home_url_from(None)?;
     let tls_terminated_proxy = crate::codex_cloud_attach::tls_terminated_proxy_from_env();
     let server_fingerprint = if tls_terminated_proxy {
@@ -166,7 +300,7 @@ async fn acquire_new_worker(key: &WorkerKey) -> Result<AcquiredWorker, String> {
     let now_ms = crate::codex_cloud::now_unix_ms();
     let (token, _) = crate::codex_cloud_attach::mint_unbound_enrollment(
         &broker,
-        crate::codex_cloud_attach::DEFAULT_TOKEN_TTL_S,
+        enrollment_token_ttl_s(timeout_s),
         crate::codex_cloud_attach::DEFAULT_IDENTITY_TTL_S,
         now_ms,
     )?;
@@ -176,22 +310,42 @@ async fn acquire_new_worker(key: &WorkerKey) -> Result<AcquiredWorker, String> {
         &token,
         tls_terminated_proxy,
     );
-    let submitted = crate::codex_cloud::submit_task(
-        &lease_store,
-        crate::codex_cloud::SubmitTaskRequest {
-            environment: key.environment.clone(),
-            branch: key.branch.clone(),
-            attempts: 1,
-            title: Some(format!(
-                "Intendant remote worker {}",
-                &key.revision[..key.revision.len().min(12)]
-            )),
-            prompt,
-            probe: false,
-        },
+    let submitted = match tokio::time::timeout_at(
+        deadline,
+        crate::codex_cloud::submit_task(
+            &lease_store,
+            crate::codex_cloud::SubmitTaskRequest {
+                environment: key.environment.clone(),
+                branch: key.branch.clone(),
+                attempts: 1,
+                title: Some(format!(
+                    "Intendant remote worker {}",
+                    &key.revision[..key.revision.len().min(12)]
+                )),
+                prompt,
+                probe: false,
+            },
+        ),
     )
-    .await?;
-    let task_id = submitted.task_id.ok_or_else(|| {
+    .await
+    {
+        Ok(result) => result?,
+        Err(_) => {
+            flight.publish(acquisition_progress(
+                key,
+                RemoteCommandAcquisitionStage::TimedOut,
+                timeout_s,
+                deadline_at_unix_ms,
+                None,
+                None,
+                None,
+            ));
+            return Err(format!(
+                "Codex Cloud did not finish submitting a worker before the {timeout_s}s acquisition deadline"
+            ));
+        }
+    };
+    let task_id = submitted.task_id.clone().ok_or_else(|| {
         "Codex Cloud accepted the worker task but returned no task id; automatic attachment cannot bind it"
             .to_string()
     })?;
@@ -211,37 +365,126 @@ async fn acquire_new_worker(key: &WorkerKey) -> Result<AcquiredWorker, String> {
     // after a successful attachment. A late attachment after our wait timeout
     // must still retire instead of becoming an unowned leak.
     register_owned(&host);
-
-    let timeout = Duration::from_secs(config_seconds(
-        "INTENDANT_REMOTE_COMPUTE_ACQUIRE_TIMEOUT_S",
-        DEFAULT_ACQUIRE_TIMEOUT_S,
-        10,
-        900,
+    let mut last_lease = cached_task_lease(&lease_store, &task_id).or(submitted.lease);
+    let mut last_provider_error = None;
+    flight.publish(acquisition_progress(
+        key,
+        RemoteCommandAcquisitionStage::WaitingForWorker,
+        timeout_s,
+        deadline_at_unix_ms,
+        last_lease.as_ref(),
+        Some(&task_id),
+        None,
     ));
-    let deadline = tokio::time::Instant::now() + timeout;
+    let mut next_provider_refresh =
+        tokio::time::Instant::now() + Duration::from_secs(PROVIDER_REFRESH_INTERVAL_S);
     loop {
         if crate::codex_cloud_attach::attachment_channel(&task_id).is_some() {
             break;
         }
-        if tokio::time::Instant::now() >= deadline {
-            mark_idle(&host);
-            return Err(format!(
-                "Codex Cloud worker {task_id} did not attach within {}s; verify the environment bootstrap and network allowlist",
-                timeout.as_secs()
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            match refresh_acquiring_task(&lease_store, key, &task_id).await {
+                Ok(Some(lease)) => last_lease = Some(lease),
+                Ok(None) => {}
+                Err(error) => last_provider_error = Some(concise_error(&error)),
+            }
+            if let Some(lease) = last_lease.as_ref().filter(|lease| {
+                lease.provider_state.is_terminal()
+                    && crate::codex_cloud_attach::attachment_channel(&task_id).is_none()
+            }) {
+                flight.publish(acquisition_progress(
+                    key,
+                    RemoteCommandAcquisitionStage::ProviderEnded,
+                    timeout_s,
+                    deadline_at_unix_ms,
+                    Some(lease),
+                    Some(&task_id),
+                    last_provider_error.as_deref(),
+                ));
+                let error = provider_ended_error(&task_id, lease);
+                mark_idle(&host);
+                return Err(error);
+            }
+            flight.publish(acquisition_progress(
+                key,
+                RemoteCommandAcquisitionStage::TimedOut,
+                timeout_s,
+                deadline_at_unix_ms,
+                last_lease.as_ref(),
+                Some(&task_id),
+                last_provider_error.as_deref(),
             ));
+            mark_idle(&host);
+            return Err(acquisition_timeout_error(
+                &task_id,
+                timeout_s,
+                last_lease.as_ref(),
+                last_provider_error.as_deref(),
+            ));
+        }
+        if now >= next_provider_refresh {
+            match refresh_acquiring_task(&lease_store, key, &task_id).await {
+                Ok(Some(lease)) => {
+                    last_provider_error = None;
+                    let terminal = lease.provider_state.is_terminal();
+                    last_lease = Some(lease);
+                    flight.publish(acquisition_progress(
+                        key,
+                        if terminal {
+                            RemoteCommandAcquisitionStage::ProviderEnded
+                        } else {
+                            RemoteCommandAcquisitionStage::WaitingForWorker
+                        },
+                        timeout_s,
+                        deadline_at_unix_ms,
+                        last_lease.as_ref(),
+                        Some(&task_id),
+                        None,
+                    ));
+                    if terminal && crate::codex_cloud_attach::attachment_channel(&task_id).is_none()
+                    {
+                        mark_idle(&host);
+                        return Err(provider_ended_error(
+                            &task_id,
+                            last_lease.as_ref().expect("lease was just stored"),
+                        ));
+                    }
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    last_provider_error = Some(concise_error(&error));
+                    flight.publish(acquisition_progress(
+                        key,
+                        RemoteCommandAcquisitionStage::WaitingForWorker,
+                        timeout_s,
+                        deadline_at_unix_ms,
+                        last_lease.as_ref(),
+                        Some(&task_id),
+                        last_provider_error.as_deref(),
+                    ));
+                }
+            }
+            next_provider_refresh =
+                tokio::time::Instant::now() + Duration::from_secs(PROVIDER_REFRESH_INTERVAL_S);
         }
         tokio::time::sleep(Duration::from_millis(250)).await;
     }
 
-    let actual_revision = crate::codex_cloud::cached_leases(&lease_store)
-        .ok()
-        .and_then(|leases| {
-            leases
-                .into_iter()
-                .find(|lease| lease.task_id == task_id)
-                .and_then(|lease| lease.worker)
-                .and_then(|worker| worker.git_rev)
-        });
+    last_lease = cached_task_lease(&lease_store, &task_id).or(last_lease);
+    flight.publish(acquisition_progress(
+        key,
+        RemoteCommandAcquisitionStage::Attached,
+        timeout_s,
+        deadline_at_unix_ms,
+        last_lease.as_ref(),
+        Some(&task_id),
+        None,
+    ));
+    let actual_revision = last_lease
+        .as_ref()
+        .and_then(|lease| lease.worker.as_ref())
+        .and_then(|worker| worker.git_rev.clone());
     if actual_revision.as_deref().is_none_or(|actual| {
         !actual
             .to_ascii_lowercase()
@@ -257,6 +500,108 @@ async fn acquire_new_worker(key: &WorkerKey) -> Result<AcquiredWorker, String> {
 
     mark_idle(&host);
     Ok(AcquiredWorker { host })
+}
+
+fn acquisition_progress(
+    key: &WorkerKey,
+    stage: RemoteCommandAcquisitionStage,
+    timeout_s: u64,
+    deadline_at_unix_ms: u64,
+    lease: Option<&crate::codex_cloud::WorkerLease>,
+    task_id: Option<&str>,
+    last_provider_error: Option<&str>,
+) -> RemoteCommandAcquisitionView {
+    RemoteCommandAcquisitionView {
+        stage,
+        coalesced: false,
+        branch: key.branch.clone(),
+        task_id: task_id
+            .map(str::to_string)
+            .or_else(|| lease.map(|lease| lease.task_id.clone())),
+        task_url: lease.and_then(|lease| lease.task_url.clone()),
+        provider_status: lease.map(|lease| lease.provider_status.clone()),
+        attachment_state: lease.map(|lease| lease.attachment_state.clone()),
+        last_provider_error: last_provider_error.map(str::to_string),
+        timeout_s,
+        deadline_at_unix_ms,
+    }
+}
+
+fn cached_task_lease(
+    store_path: &std::path::Path,
+    task_id: &str,
+) -> Option<crate::codex_cloud::WorkerLease> {
+    crate::codex_cloud::cached_leases(store_path)
+        .ok()?
+        .into_iter()
+        .find(|lease| lease.task_id == task_id)
+}
+
+async fn refresh_acquiring_task(
+    store_path: &std::path::Path,
+    key: &WorkerKey,
+    task_id: &str,
+) -> Result<Option<crate::codex_cloud::WorkerLease>, String> {
+    let outcome = tokio::time::timeout(
+        Duration::from_secs(PROVIDER_REFRESH_TIMEOUT_S),
+        crate::codex_cloud::refresh_leases(store_path, Some(&key.environment), 20, None),
+    )
+    .await
+    .map_err(|_| format!("provider status refresh exceeded {PROVIDER_REFRESH_TIMEOUT_S}s"))??;
+    crate::codex_cloud::announce_transitions(&outcome.transitions).await;
+    Ok(outcome
+        .workers
+        .into_iter()
+        .chain(outcome.tracked_active)
+        .find(|lease| lease.task_id == task_id)
+        .or_else(|| cached_task_lease(store_path, task_id)))
+}
+
+fn provider_ended_error(task_id: &str, lease: &crate::codex_cloud::WorkerLease) -> String {
+    let url = lease
+        .task_url
+        .as_deref()
+        .map(|url| format!(" Inspect {url}."))
+        .unwrap_or_default();
+    format!(
+        "Codex Cloud task {task_id} reached provider status `{}` before its Intendant worker attached. The provider task has ended, so this is no longer a slow cold start.{url} Check the setup/maintenance output and the final attachment error.",
+        lease.provider_status
+    )
+}
+
+fn acquisition_timeout_error(
+    task_id: &str,
+    timeout_s: u64,
+    lease: Option<&crate::codex_cloud::WorkerLease>,
+    provider_error: Option<&str>,
+) -> String {
+    let status = lease
+        .map(|lease| format!("; last provider status was `{}`", lease.provider_status))
+        .unwrap_or_default();
+    let url = lease
+        .and_then(|lease| lease.task_url.as_deref())
+        .map(|url| format!(" Inspect {url}."))
+        .unwrap_or_default();
+    let refresh = provider_error
+        .map(|error| format!(" The final provider refresh also failed: {error}."))
+        .unwrap_or_default();
+    format!(
+        "Codex Cloud worker {task_id} did not attach before the {timeout_s}s acquisition deadline{status}. Intendant did not cancel the provider task; it may still be finishing cold setup.{url}{refresh} If this environment intentionally needs longer, raise INTENDANT_REMOTE_COMPUTE_ACQUIRE_TIMEOUT_S (maximum {MAX_ACQUIRE_TIMEOUT_S}s)."
+    )
+}
+
+fn enrollment_token_ttl_s(timeout_s: u64) -> u64 {
+    crate::codex_cloud_attach::DEFAULT_TOKEN_TTL_S
+        .max(timeout_s.saturating_add(ENROLLMENT_TOKEN_GRACE_S))
+}
+
+fn concise_error(error: &str) -> String {
+    const LIMIT: usize = 512;
+    let mut concise = error.trim().chars().take(LIMIT).collect::<String>();
+    if error.trim().chars().count() > LIMIT {
+        concise.push('…');
+    }
+    concise
 }
 
 fn register_owned(host: &str) {
@@ -482,5 +827,26 @@ mod tests {
         other = first.clone();
         other.branch = None;
         assert_ne!(first, other);
+    }
+
+    #[test]
+    fn explicit_branch_outranks_the_derived_hint() {
+        assert_eq!(
+            select_branch(Some("feature/owner-call".into()), Some("main".into())).unwrap(),
+            Some("feature/owner-call".into())
+        );
+        assert!(select_branch(Some("not..a-ref".into()), Some("main".into())).is_err());
+    }
+
+    #[test]
+    fn enrollment_token_outlives_the_cold_acquisition_window() {
+        assert_eq!(
+            enrollment_token_ttl_s(100),
+            crate::codex_cloud_attach::DEFAULT_TOKEN_TTL_S
+        );
+        assert_eq!(
+            enrollment_token_ttl_s(DEFAULT_ACQUIRE_TIMEOUT_S),
+            DEFAULT_ACQUIRE_TIMEOUT_S + ENROLLMENT_TOKEN_GRACE_S
+        );
     }
 }

--- a/src/bin/caller/remote_compute/scheduler.rs
+++ b/src/bin/caller/remote_compute/scheduler.rs
@@ -858,4 +858,56 @@ mod tests {
                 + 60
         );
     }
+
+    #[test]
+    fn coalesced_callers_receive_the_leaders_acquisition_progress() {
+        let flight = AcquireFlight {
+            result: Mutex::new(None),
+            notify: tokio::sync::Notify::new(),
+            progress: Mutex::new(None),
+            observers: Mutex::new(Vec::new()),
+        };
+        let leader_seen = Arc::new(Mutex::new(Vec::new()));
+        let follower_seen = Arc::new(Mutex::new(Vec::new()));
+        for (seen, coalesced) in [
+            (Arc::clone(&leader_seen), false),
+            (Arc::clone(&follower_seen), true),
+        ] {
+            flight.add_observer(
+                Arc::new(move |progress| {
+                    seen.lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner())
+                        .push(progress);
+                }),
+                coalesced,
+            );
+        }
+        let key = WorkerKey {
+            environment: "env-a".into(),
+            revision: "abc".into(),
+            branch: Some("feature/worker".into()),
+        };
+        flight.publish(acquisition_progress(
+            &key,
+            RemoteCommandAcquisitionStage::WaitingForWorker,
+            3_600,
+            99_000,
+            None,
+            Some("task_e_shared"),
+            None,
+        ));
+
+        let leader = leader_seen
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let follower = follower_seen
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        assert_eq!(leader.len(), 1);
+        assert_eq!(follower.len(), 1);
+        assert!(!leader[0].coalesced);
+        assert!(follower[0].coalesced);
+        assert_eq!(follower[0].task_id.as_deref(), Some("task_e_shared"));
+        assert_eq!(follower[0].deadline_at_unix_ms, 99_000);
+    }
 }

--- a/src/bin/caller/remote_compute/scheduler.rs
+++ b/src/bin/caller/remote_compute/scheduler.rs
@@ -13,6 +13,7 @@ use super::{RemoteCommandAcquisitionStage, RemoteCommandAcquisitionView};
 const DEFAULT_ACQUIRE_TIMEOUT_S: u64 = 3600;
 const MAX_ACQUIRE_TIMEOUT_S: u64 = 7200;
 const ENROLLMENT_TOKEN_GRACE_S: u64 = 300;
+const PROVIDER_INITIAL_REFRESH_S: u64 = 15;
 const PROVIDER_REFRESH_INTERVAL_S: u64 = 60;
 const PROVIDER_REFRESH_TIMEOUT_S: u64 = 20;
 const DEFAULT_IDLE_TIMEOUT_S: u64 = 600;
@@ -377,7 +378,7 @@ async fn acquire_new_worker(
         None,
     ));
     let mut next_provider_refresh =
-        tokio::time::Instant::now() + Duration::from_secs(PROVIDER_REFRESH_INTERVAL_S);
+        tokio::time::Instant::now() + Duration::from_secs(PROVIDER_INITIAL_REFRESH_S);
     loop {
         if crate::codex_cloud_attach::attachment_channel(&task_id).is_some() {
             break;

--- a/src/bin/caller/remote_compute/source.rs
+++ b/src/bin/caller/remote_compute/source.rs
@@ -314,6 +314,27 @@ pub(super) fn branch_for_revision(project_root: &Path, revision: &str) -> Option
     remote.starts_with(&expected).then_some(branch)
 }
 
+pub(super) fn validate_provider_branch(raw: &str) -> Result<String, String> {
+    let branch = raw.trim();
+    if branch.is_empty() || branch.len() > 255 || branch.starts_with('-') {
+        return Err("branch must be a valid pushed Git branch name".to_string());
+    }
+    let full_ref = format!("refs/heads/{branch}");
+    let valid = std::process::Command::new("git")
+        .args(["check-ref-format", &full_ref])
+        .env("GIT_OPTIONAL_LOCKS", "0")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map_err(|error| format!("validate provider branch with Git: {error}"))?
+        .success();
+    if !valid {
+        return Err("branch must be a valid pushed Git branch name".to_string());
+    }
+    Ok(branch.to_string())
+}
+
 fn git_stdout(cwd: &Path, args: &[&str], stdin: Option<&[u8]>) -> Result<Vec<u8>, String> {
     let mut command = std::process::Command::new("git");
     command
@@ -1268,6 +1289,17 @@ mod tests {
         let second = capture_working_tree(repo.path(), Some(&revision)).unwrap();
         assert_eq!(first.digest, second.digest);
         assert_eq!(first.archive.as_slice(), second.archive.as_slice());
+    }
+
+    #[test]
+    fn provider_branch_validation_uses_git_ref_rules() {
+        assert_eq!(
+            validate_provider_branch("feature/cloud-worker").unwrap(),
+            "feature/cloud-worker"
+        );
+        assert!(validate_provider_branch("-provider-option").is_err());
+        assert!(validate_provider_branch("feature..broken").is_err());
+        assert!(validate_provider_branch("refs/heads/").is_err());
     }
 
     #[tokio::test]

--- a/src/bin/caller/tools.rs
+++ b/src/bin/caller/tools.rs
@@ -583,7 +583,7 @@ fn build_built_in_tools() -> Vec<ToolDefinition> {
     // 18. remote_command (caller-handled, acquired/attached remote workers)
     tools.push(ToolDefinition {
         name: "remote_command".to_string(),
-        description: "Use this instead of local execution for heavy platform-neutral compilation and testing. Start, inspect, wait for, or cancel a provider-neutral remote command job. Start accepts argv (never a shell string), host auto by default (reuse/acquire Codex Cloud) or explicit cloud:<task-id>, source git_revision or an explicit working_tree snapshot, and optional durable_sccache. Git-revision jobs require expected_revision; working-tree jobs resolve a pinned base. Start returns immediately through acquiring/preparing/running states; status/wait returns bounded output and exact terminal/cache results. Keep only small OS-specific checks local.".to_string(),
+        description: "Use this instead of local execution for heavy platform-neutral compilation and testing. Start, inspect, wait for, or cancel a provider-neutral remote command job. Start accepts argv (never a shell string), host auto by default (reuse/acquire Codex Cloud) or explicit cloud:<task-id>, an optional pushed branch hint, source git_revision or an explicit working_tree snapshot, and optional durable_sccache. Git-revision jobs require expected_revision; working-tree jobs resolve a pinned base. Start returns immediately with acquisition stage/task/deadline detail through preparing/running states; status/wait returns bounded output and exact terminal/cache results. Keep only small OS-specific checks local.".to_string(),
         parameters: json!({
             "type": "object",
             "properties": {
@@ -595,6 +595,10 @@ fn build_built_in_tools() -> Vec<ToolDefinition> {
                 "host": {
                     "type": "string",
                     "description": "Omit or use auto to reuse/acquire a matching worker; cloud:<codex-task-id> selects an existing attachment."
+                },
+                "branch": {
+                    "type": "string",
+                    "description": "Optional pushed provider branch containing expected_revision; useful when no supervised project root can derive it."
                 },
                 "argv": {
                     "type": "array",


### PR DESCRIPTION
## Summary\n- extend automatic Codex Cloud acquisition to a one-hour cold-start window (configurable to two hours) and align the one-time enrollment token lifetime\n- expose acquisition stage, task/link, provider status, branch, coalescing, and deadline on remote-command jobs; refresh provider state and distinguish terminal setup failures from slow active setup\n- add an explicit pushed branch for owner-triggered remote commands while retaining the exact worker revision guard\n- report live remote-compute usability independently from provider/cache warmth\n- install checksum-pinned sccache 0.15.0 Linux prebuilts in the generated Cloud setup, with the pinned source build as fallback\n\n## Validation\n- \n- \n- \n- \n- verified the official x86_64 v0.15.0 archive layout and GitHub release digests\n- full cross-platform compile/test delegated to PR CI (this Mac is intentionally not carrying the heavy build)\n\n## Follow-up acceptance\nAfter landing and restarting the daemon from the landed binary, rerun two distinct-revision automatic jobs concurrently and confirm both task IDs/stages/deadlines are visible and both workers attach.