### PR TITLE
skills-internal: dev-fleet skill tier + dogfood-feedback meta-skill (repo-only, never shipped)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,8 @@ macos-app/      # native macOS WKWebView wrapper (built by scripts/bundle-macos.
 vendor/         # vortex-guest-tools (macOS Vortex Audio HAL plugin)
 scripts/        # setup-{linux,macos,windows}, setup-lan*, bundle-macos, validate-dashboard.cjs (dashboard/Station QA), …
 skills/         # agenda, memory, operating/log search, visual collaboration, calls, E2E guides
+plugins/        # bundled first-party plugin packages (skills materialized only while enabled — plugin_registry.rs)
+skills-internal/ # dev-fleet-only skills (symlinked by scripts/install-dev-skills.sh; NEVER embedded or installed by product code)
 docs/src/       # this project's mdBook — the deep reference (see the table above)
 SysPrompt*.md   # per-role system prompts (base, tools, user, orchestrator, research, implementation, presence, live audio)
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,8 @@ macos-app/      # native macOS WKWebView wrapper (built by scripts/bundle-macos.
 vendor/         # vortex-guest-tools (macOS Vortex Audio HAL plugin)
 scripts/        # setup-{linux,macos,windows}, setup-lan*, bundle-macos, validate-dashboard.cjs (dashboard/Station QA), …
 skills/         # agenda, memory, operating/log search, visual collaboration, calls, E2E guides
+plugins/        # bundled first-party plugin packages (skills materialized only while enabled — plugin_registry.rs)
+skills-internal/ # dev-fleet-only skills (symlinked by scripts/install-dev-skills.sh; NEVER embedded or installed by product code)
 docs/src/       # this project's mdBook — the deep reference (see the table above)
 SysPrompt*.md   # per-role system prompts (base, tools, user, orchestrator, research, implementation, presence, live audio)
 ```

--- a/scripts/install-dev-skills.sh
+++ b/scripts/install-dev-skills.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Symlink every skills-internal/<name> into the global agent-skills roots
+# (~/.agents/skills and ~/.claude/skills). Dev-machine opt-in tooling only:
+# the daemon and product code never run this and never embed these skills,
+# and the daemon-side installer treats symlinks as user-owned (never
+# followed, replaced, or swept) — so these links are invisible to product
+# behavior. See skills-internal/README.md.
+#
+# Links always point at the MAIN checkout's skills-internal/, resolved via
+# git's common dir even when this script runs from a worktree copy —
+# landed changes go live through the link, and worktree paths would
+# dangle once the worktree is reclaimed.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+common_dir="$(git -C "$script_dir" rev-parse --git-common-dir)"
+case "$common_dir" in
+  /*) : ;;
+  *) common_dir="$script_dir/$common_dir" ;;
+esac
+main_root="$(cd "$(dirname "$common_dir")" && pwd)"
+src="$main_root/skills-internal"
+if [ ! -d "$src" ]; then
+  echo "error: $src not found (has skills-internal/ landed on the main checkout?)" >&2
+  exit 1
+fi
+
+for root in "$HOME/.agents/skills" "$HOME/.claude/skills"; do
+  mkdir -p "$root"
+  # Prune links we own that no longer resolve (retired internal skills).
+  for link in "$root"/*; do
+    [ -L "$link" ] || continue
+    case "$(readlink "$link")" in
+      "$src"/*) [ -e "$link" ] || { rm "$link"; echo "pruned $link"; } ;;
+    esac
+  done
+  for dir in "$src"/*/; do
+    name="$(basename "$dir")"
+    [ -f "$dir/SKILL.md" ] || continue
+    dest="$root/$name"
+    if [ -L "$dest" ]; then
+      [ "$(readlink "$dest")" = "$src/$name" ] && continue
+      rm "$dest"
+    elif [ -e "$dest" ]; then
+      echo "skip $dest: exists and is not a symlink (user-owned; remove it yourself to adopt the repo copy)" >&2
+      continue
+    fi
+    ln -s "$src/$name" "$dest"
+    echo "linked $dest -> $src/$name"
+  done
+done
+echo "dev skills installed (symlinked from $src)"

--- a/skills-internal/README.md
+++ b/skills-internal/README.md
@@ -1,0 +1,39 @@
+# skills-internal/
+
+Dev-fleet-only agent skills: in the public repo, outside the product.
+
+The four skill tiers:
+
+| Tier | Embedded in binary | Installed |
+|---|---|---|
+| `skills/` | yes (`builtin_skills.rs`, byte-pinned) | unconditionally, both global roots |
+| `plugins/<name>/skills/` | yes (`plugin_registry.rs`) | materialized only while the plugin is enabled and ready |
+| `skills-internal/` (this tier) | **never** | dev-machine opt-in only |
+| `tests/skills/` | no | never (operator E2E briefs) |
+
+Activation is per dev machine and explicit:
+
+```bash
+bash scripts/install-dev-skills.sh
+```
+
+The script symlinks each skill here from the MAIN checkout into
+`~/.agents/skills` and `~/.claude/skills`. The daemon's installer treats
+symlinks as user-owned — never followed, replaced, or swept — so these
+links are invisible to product behavior, and landed changes go live
+through the link with no reinstall.
+
+Rules for skills in this tier:
+
+- **Never** reference one from `builtin_skills.rs`, `plugin_registry.rs`,
+  or any product code path. A unit test
+  (`plugin_registry.rs`: `internal_skills_stay_disjoint_from_shipped_names_and_parse`)
+  enforces name disjointness from every shipped skill — a collision would
+  silently block the shipped copy's install on dev machines.
+- **Public-repo scrub law applies to skill text**: no machine names,
+  addresses, environment ids, credentials, or daemon-local ids (agenda or
+  hub ULIDs). Reference agenda hubs by TAG and resolve at runtime.
+- Frontmatter `name` must equal the directory name; the `description`
+  carries the trigger (it is the ambient catalog line).
+- Keep each skill self-contained and small; this tier documents fleet
+  practice, it does not ship features.

--- a/skills-internal/skill-dogfood-feedback/SKILL.md
+++ b/skills-internal/skill-dogfood-feedback/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: skill-dogfood-feedback
+description: Dev-fleet internal skill — after using any Intendant skill (agenda, cli, coordination, log-search, memory, remote-compute, …), park concise feedback on the daemon agenda ONLY when something exceptional happened — the skill misled you, lacked a verb or recipe you needed, forced a workaround, or notably carried the task. Never report routine successful use. Feedback lands under the skill-feedback hub (resolved by tag, created if missing); main sessions only — subagents never park agenda items.
+compatibility: Dev machines only — symlinked by scripts/install-dev-skills.sh from a repo checkout, never embedded in the binary or installed for users. Requires a reachable Intendant daemon.
+---
+
+> Resolve the CLI first:
+>
+> ```bash
+> INTENDANT="${INTENDANT:-$(command -v intendant || cat "${INTENDANT_HOME:-$HOME/.intendant}/cli-path" 2>/dev/null || echo intendant)}"
+> ```
+>
+> If nothing resolves, Intendant is not on this machine — this skill does
+> not apply. This is an internal dev-fleet skill: if you are not working on
+> the Intendant project itself, it also does not apply.
+
+# Dogfood feedback on Intendant skills
+
+The shipped skills are product surfaces; the fleet using them all day is
+the cheapest QA it will ever have. This skill turns exceptional moments
+into durable, deduplicated feedback the owner can act on — without
+drowning the agenda in routine.
+
+## When to park (exceptions only — protect the signal)
+
+- The skill's instructions **misled you** or contradicted current code.
+- You needed a **verb, flag, or recipe the skill does not teach**.
+- You **worked around** the skill instead of through it.
+- The skill **notably carried a task** — say what carried it, so it is
+  kept through future rewrites.
+
+Routine successful use is NOT feedback. If nothing exceptional happened,
+park nothing.
+
+## How
+
+1. Find the hub by TAG — never hard-code an id; ids are daemon-local:
+
+   ```bash
+   "$INTENDANT" ctl agenda list --all | grep "#skill-feedback" | head -3
+   ```
+
+   If no hub exists yet, create it once:
+
+   ```bash
+   "$INTENDANT" ctl agenda add "Skill feedback (dogfood)" --note \
+     --tag skill-feedback --tag hub \
+     --body "Exception-based feedback on the shipped Intendant skills, parked by dev-fleet sessions. One item per distinct friction; dedupe by annotating."
+   ```
+
+2. Dedupe before adding — list the hub's subtree and scan titles:
+
+   ```bash
+   "$INTENDANT" ctl agenda list --under <hub-id>
+   ```
+
+   Same friction already parked → `ctl agenda annotate <id> "…"` with your
+   occurrence and any new evidence. Only a genuinely new friction gets a
+   new item.
+
+3. New item: one distinct friction per item, tagged with the skill's name,
+   filed under the hub:
+
+   ```bash
+   "$INTENDANT" ctl agenda add "<skill>: <one-line friction>" --note \
+     --tag skill-feedback --tag <skill-name> \
+     --body "What happened; what the skill said; what was actually needed. Evidence: session id / file ref."
+   "$INTENDANT" ctl agenda place <new-id> --under <hub-id>
+   ```
+
+## Rules
+
+- **Main sessions only.** Subagents surface findings to their parent
+  instead of writing the agenda.
+- **Write clean bodies.** Feedback text gets quoted into fixes and PRs in
+  a public repo: no machine names, addresses, environment ids,
+  credentials, or pasted secrets — reference sessions and files by id and
+  path.
+- **Feedback is not a fix.** Never edit a shipped skill from a feedback
+  impulse; park first, and let fixes ride normal reviewed slices.
+- Completing or retiring feedback items is the owner's call, not yours.

--- a/src/bin/caller/plugin_registry.rs
+++ b/src/bin/caller/plugin_registry.rs
@@ -538,6 +538,59 @@ mod tests {
         }
     }
 
+    /// The dev-only `skills-internal/` tier must stay disjoint from every
+    /// shipped skill name: `scripts/install-dev-skills.sh` symlinks those
+    /// into the same global roots, and the daemon installer skips
+    /// user-owned entries — so a name collision would silently block the
+    /// shipped copy's install on every dev machine. Also pins hygiene:
+    /// each internal SKILL.md parses and its frontmatter name equals the
+    /// directory.
+    #[test]
+    fn internal_skills_stay_disjoint_from_shipped_names_and_parse() {
+        let internal_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("skills-internal");
+        let mut shipped = BTreeSet::new();
+        for builtin in crate::builtin_skills::BUILTIN_SKILLS {
+            shipped.insert(builtin.name);
+        }
+        for plugin in BUNDLED_PLUGINS {
+            for skill in plugin.skills {
+                shipped.insert(skill.name);
+            }
+        }
+        let mut seen_any = false;
+        for entry in std::fs::read_dir(&internal_root)
+            .expect("skills-internal/ readable")
+            .flatten()
+        {
+            let skill_md = entry.path().join("SKILL.md");
+            if !skill_md.is_file() {
+                continue;
+            }
+            seen_any = true;
+            let name = entry.file_name().to_string_lossy().into_owned();
+            assert!(
+                !shipped.contains(name.as_str()),
+                "skills-internal/{name} collides with a shipped skill — the \
+                 dev symlink would block the daemon install of the shipped copy"
+            );
+            let body = std::fs::read_to_string(&skill_md).expect("internal SKILL.md readable");
+            let (config, _) =
+                intendant_core::skills::parse_skill_md(&body, Path::new(name.as_str()))
+                    .unwrap_or_else(|error| {
+                        panic!("skills-internal/{name}/SKILL.md does not parse: {error}")
+                    });
+            assert_eq!(
+                config.name, name,
+                "frontmatter name must match the directory"
+            );
+            assert!(
+                !config.description.trim().is_empty(),
+                "internal skill description must carry its trigger"
+            );
+        }
+        assert!(seen_any, "skills-internal/ holds at least one skill");
+    }
+
     #[test]
     fn enable_state_round_trips_and_preserves_foreign_ids() {
         let tmp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Implements agenda 01KZ04FQD71M4ECA8V6H8Y3RDC (owner-ratified follow-up to #745): an in-repo internal overlay for dev-fleet skills, outside the product distribution boundary.

- skills-internal/ tier: in the public repo, never embedded in the binary, never installed by the daemon or any product code. Per-machine opt-in via scripts/install-dev-skills.sh (symlinks from the MAIN checkout; the daemon-side installer treats symlinks as user-owned and never follows, replaces, or sweeps them).
- First internal skill: skill-dogfood-feedback — exception-based feedback on the shipped Intendant skills, parked under a tag-resolved agenda hub, deduped by annotation, main sessions only. Scrub-law-clean text (no machine names, ids, or ULIDs).
- Guard test in plugin_registry tests: skills-internal/ names disjoint from builtin and plugin skill names; SKILL.md parses; frontmatter name == directory.
- CLAUDE.md + AGENTS.md (byte-synced): plugins/ and skills-internal/ documented in the repository layout tree.

No product code paths change; the only .rs delta is the new unit test.