### PR TITLE
macos-app: multi-predecessor drain honesty in the app supervisor (update-abstraction slice 5)

### DIFF
--- a/macos-app/BackendSupervisor.swift
+++ b/macos-app/BackendSupervisor.swift
@@ -70,11 +70,17 @@ final class BackendSupervisor {
     private let session: URLSession
 
     private var backendProcess: Process?
-    /// The swapped-out predecessor, draining toward its own exit (HS6/P3).
-    /// The swap NEVER terminates it — it serves its in-flight sessions and
-    /// exits at the last one (`app_supervisor_one_click_swaps_without_kill`);
-    /// only app quit tears it down along with everything else.
-    private var drainingProcess: Process?
+    /// The swapped-out predecessors, each draining toward its own exit
+    /// (HS6/P3). The swap NEVER terminates them — each serves its in-flight
+    /// sessions and exits at the last one
+    /// (`app_supervisor_one_click_swaps_without_kill`); only app quit tears
+    /// them down along with everything else. An array, not a single slot: a
+    /// chained swap (updating again while an elder still drains) appends
+    /// rather than displacing the elder from supervision (multi-predecessor
+    /// honesty). Deliberately uncapped — chained swaps are rare, each entry
+    /// self-exits and its termination handler removes it by identity, so
+    /// this is bookkeeping, not a queue.
+    private var drainingProcesses: [Process] = []
     private var swapInFlight = false
     private var healthTimer: Timer?
     private var healthProbeFailures = 0
@@ -269,12 +275,12 @@ final class BackendSupervisor {
                     NSLog("Drained predecessor exited (status \(proc.terminationStatus))")
                     self?.writeExitMarker(status: proc.terminationStatus,
                                           signalled: proc.terminationReason == .uncaughtSignal)
-                    if self?.drainingProcess === proc {
-                        self?.drainingProcess = nil
-                    }
+                    // Identity removal: each drainer clears exactly its own
+                    // entry, leaving still-draining siblings supervised.
+                    self?.drainingProcesses.removeAll { $0 === proc }
                 }
             }
-            drainingProcess = old
+            drainingProcesses.append(old)
         }
         backendProcess = successor
         port = newPort
@@ -398,13 +404,14 @@ final class BackendSupervisor {
 
     /// Quit teardown: kill the children on purpose without letting exit
     /// handlers paint a crash screen or schedule a restart mid-teardown.
-    /// Quit is the explicit "stop everything" gesture, so a mid-drain
+    /// Quit is the explicit "stop everything" gesture, so every mid-drain
     /// predecessor goes down with the promoted successor.
     func shutdown() {
         isTerminating = true
         backendAutoRestartTimer?.invalidate()
         healthTimer?.invalidate()
-        let children = [backendProcess, drainingProcess].compactMap { $0 }.filter { $0.isRunning }
+        // Quit sweep: the current backend plus every draining predecessor.
+        let children = ([backendProcess].compactMap { $0 } + drainingProcesses).filter { $0.isRunning }
         guard !children.isEmpty else { return }
         for proc in children {
             proc.terminationHandler = nil

--- a/src/bin/caller/handover/mod.rs
+++ b/src/bin/caller/handover/mod.rs
@@ -1743,7 +1743,7 @@ mod tests {
     /// pin keeps the machinery and its load-bearing markers from being
     /// gutted silently). The app supervisor's one-click swap exists,
     /// follows the intake's spawn → readiness → swap → drain order, and
-    /// parks the predecessor in a draining slot the swap never
+    /// parks each predecessor in the draining array the swap never
     /// terminates; the app layer re-points the webview on
     /// `didSwapToPort` and the SPA marker gates the one-click button.
     #[test]
@@ -1752,6 +1752,15 @@ mod tests {
         for needle in [
             "func beginUpdateSwap",
             "drainingProcess",
+            // Update-abstraction slice 5 (intake 6a, multi-predecessor
+            // honesty): the draining slot is an ARRAY — a chained swap
+            // appends instead of displacing the elder from supervision,
+            // each termination handler removes exactly its own entry by
+            // identity, and the quit sweep tears down every drainer
+            // alongside the promoted successor.
+            "drainingProcesses: [Process]",
+            "drainingProcesses.removeAll { $0 === proc }",
+            "+ drainingProcesses)",
             // The intake's ordering marker (comment-wrapped in source).
             "spawn → readiness",
             "swap → drain",


### PR DESCRIPTION
Update-abstraction **slice 5** (intake §7 slice 5; the gate ruling at the intake tail ratified the slice plan with slice-5 acceptance unchanged — intake sha256 `03231c76f7aa82d9bc91c9602a9b026b083f6bfa8454e41618cbae105fd25509`, sealed copy under `~/.intendant/agenda/blobs/`). Fired from agenda item `01KZ0189VVN514VE3HTCWW6F6A`. Composes with the in-flight slice-1 seat — touch surfaces are disjoint (this PR: `macos-app/BackendSupervisor.swift` + the needle test at the tail of `src/bin/caller/handover/mod.rs`, test module only).

## What

A chained one-click update swap (updating again while an elder predecessor still drains) overwrote the app supervisor's single `drainingProcess` slot: the displaced elder left supervision, and `shutdown()`'s pair-only teardown stranded it across app Quit — against Quit's documented stop-everything intent (intake §5, sub-part 6a).

- `drainingProcesses: [Process]` replaces the single slot; `promoteSuccessor` **appends** the swapped-out predecessor instead of displacing the elder.
- Each drainer's termination handler removes **exactly its own entry by identity** (`removeAll { $0 === proc }`), leaving still-draining siblings supervised.
- `shutdown()` sweeps the current backend **plus every draining predecessor** (`[backendProcess].compactMap { $0 } + drainingProcesses`), restoring Quit's stop-everything semantics.
- No artificial cap — chained swaps are rare and each elder self-exits; the array is bookkeeping, not a queue (as ratified).
- `didSwapToPort` contract unchanged; no delegate or API surface touched.

## Terminating acceptance (gate criteria verbatim)

- **(a) Swift typecheck:** `xcrun swiftc -typecheck macos-app/*.swift` — swiftc's **own** exit captured directly (bare invocation, `$?` immediately after; no pipeline): **exit 0**.
- **(b) Needle set extended:** `app_supervisor_one_click_swaps_without_kill` gains the array declaration (`drainingProcesses: [Process]`), the identity-removal expression (`drainingProcesses.removeAll { $0 === proc }`), and the quit-sweep marker (`+ drainingProcesses)`). Source-scan reach, stated honestly per the P3 pin-4 precedent — no Swift test harness exists and CI never builds the app.
- **(c) Manual chained-swap checklist** — see below; **operator-run, stated as such**.
- **(d) Battery:** keyless battery + workspace clippy `-D warnings` + `cargo fmt --check`, unmasked exits — results in the battery section below.

## Operator-run chained-swap checklist (manual — NOT CI-provable)

This checklist is **operator-run on a packaged build** (`scripts/bundle-macos.sh`); CI never builds or launches the macOS app, so this is the honest verification reach for the behavioral half:

1. Launch the app with an updated on-disk daemon binary available for swap; confirm the dashboard loads and `ps` shows **one** `intendant-bin` child.
2. **Swap 1:** trigger the one-click update swap with at least one in-flight session on the old daemon (so it drains rather than exiting immediately); confirm the webview re-points (`didSwapToPort`) and `ps` shows **two** `intendant-bin` children (promoted successor + drainer A).
3. **Swap 2, chained, while A still drains:** trigger the swap again (again with an in-flight session holding B open); confirm `ps` shows **three** `intendant-bin` children (successor + drainers A and B) — the elder A stays supervised instead of being displaced from the slot.
4. **Quit** the app: `ps` shows **zero** `intendant-bin` children — the quit sweep covers the promoted successor and every drainer.

## Battery (worktree, own target/) — GREEN

Each step's exit code captured directly (bare invocation, `$?` read immediately; no pipes), fail-fast:

- `cargo fmt --check` — **exit 0**
- `cargo test -p intendant --bins` — **exit 0** (includes `handover::tests::app_supervisor_one_click_swaps_without_kill ... ok` with the extended needle set)
- `cargo test -p intendant-core -p intendant-custody -p intendant-display -p intendant-platform -p owner-plane-core -p owner-plane-reducer` — **exit 0**
- `cargo test -p intendant --test e2e` — **exit 0**
- `cargo clippy --workspace -- -D warnings` — **exit 0**
