### PR TITLE
Update abstraction slice 1: live-holder doorway resolution + tokened doorways (+R-D1)

### DIFF
--- a/src/bin/caller/handover/mod.rs
+++ b/src/bin/caller/handover/mod.rs
@@ -1231,7 +1231,8 @@ mod tests {
             );
         }
         assert_eq!(
-            app.matches("async function withSiblingLoopbackToken").count(),
+            app.matches("async function withSiblingLoopbackToken")
+                .count(),
             1,
             "one shared sibling-token helper in the served bundle"
         );
@@ -1512,7 +1513,11 @@ mod tests {
         // still names A itself — the fallback names the live spare
         // rather than leaving callers with "pending".
         assert_eq!(a.request_drain(None), DrainRequest::Entered);
-        assert_eq!(a.successor_port(), Some(7002), "a live spare beats 'pending'");
+        assert_eq!(
+            a.successor_port(),
+            Some(7002),
+            "a live spare beats 'pending'"
+        );
 
         // B acquires: the sidecar arm names it.
         assert!(b.poll_acquire(0));
@@ -1534,7 +1539,11 @@ mod tests {
         // C crashes: the sidecar still names it, but a dead boot is not
         // a doorway either (B stays draining, so nothing is eligible).
         drop(c);
-        assert_eq!(a.successor_port(), None, "a crashed successor is not a doorway");
+        assert_eq!(
+            a.successor_port(),
+            None,
+            "a crashed successor is not a doorway"
+        );
     }
 
     /// The Q4 pin: a drainer that observes its successor gone — crashed

--- a/src/bin/caller/handover/mod.rs
+++ b/src/bin/caller/handover/mod.rs
@@ -724,12 +724,38 @@ impl HandoverRuntime {
         )
     }
 
-    /// The successor's port for `daemon_draining` refusal pointers, when
-    /// the sidecar already names one (None while the handoff is still in
-    /// flight — the refusal then says "successor pending").
+    /// The successor's port for `daemon_draining` refusal pointers — the
+    /// server-side mirror of the dashboard's `resolveLiveHolder` rule
+    /// (update-abstraction §5.1, refinement R-D1). The sidecar names the
+    /// most recent acquirer OR the most recent drainer during the
+    /// entry→acquisition window (6c), so its target counts only while
+    /// its presence is live and neither draining nor exited; otherwise a
+    /// live non-draining sibling is named (a spare accepts new work
+    /// immediately, and the freed lease lands on it within a poll).
+    /// None while nobody eligible exists — the refusal then says
+    /// "successor pending" rather than pointing callers into a drain.
     pub(crate) fn successor_port(&self) -> Option<u16> {
-        let sidecar = read_lease_sidecar(&self.state_root)?;
-        (sidecar.boot_id != self.boot_id).then_some(sidecar.port)
+        let records = read_presence_records(&self.state_root);
+        let eligible = |record: &presence::PresenceRecord| {
+            record.boot_id != self.boot_id
+                && record.state != "draining"
+                && record.state != "exited"
+                && boot_id_is_live(&self.state_root, &record.boot_id)
+        };
+        if let Some(sidecar) = read_lease_sidecar(&self.state_root) {
+            if sidecar.boot_id != self.boot_id
+                && records
+                    .iter()
+                    .find(|record| record.boot_id == sidecar.boot_id)
+                    .is_some_and(|record| eligible(record))
+            {
+                return Some(sidecar.port);
+            }
+        }
+        records
+            .iter()
+            .find(|record| eligible(record))
+            .map(|record| record.port)
     }
 
     /// The supervisor's drain wait set: served on the status surface
@@ -1037,6 +1063,73 @@ mod tests {
         }
     }
 
+    /// Update-abstraction slice 1 pin (intake §7, acceptance (a)): the
+    /// successor doorway resolves through the ONE live-holder rule —
+    /// the sidecar target only while its daemons entry is live and
+    /// neither draining nor exited (the 6c entry→acquisition window
+    /// where the sidecar names a drainer), with the hand-off candidate
+    /// rule as the fallback — and doorway clicks land authed through
+    /// the same-home sibling token map instead of on the named 401.
+    #[test]
+    fn doorway_resolves_live_holder_and_carries_the_sibling_token() {
+        let fragment = include_str!("../../../../static/app/ui2-handover.js");
+        for needle in [
+            // The resolver and its filter expression: never a doorway
+            // into a draining (or exited, or dead) sidecar target.
+            "function resolveLiveHolder",
+            "entry.live && entry.state !== 'draining' && entry.state !== 'exited'",
+            // The doorway consumes the resolver…
+            "const holder = resolveLiveHolder(body);",
+            // …with the shared hand-off candidate rule as its fallback.
+            "return handoverSuccessorCandidate(body,",
+            // The click-time token decoration (the fleet-links lane).
+            "withSiblingLoopbackToken(bare)",
+        ] {
+            assert!(
+                fragment.contains(needle),
+                "the successor doorway lost its live-holder resolution: {needle}"
+            );
+        }
+        // The legacy boot-id-only port read is gone — the resolver is
+        // the one source of doorway targets.
+        assert!(
+            !fragment.contains("handoverSuccessorPort"),
+            "the boot-id-only successor read must not come back beside the resolver"
+        );
+        // The helper lives in the identity fragment (lifted, shared —
+        // never duplicated back into the access panes).
+        let identity = include_str!("../../../../static/app/31-init-identity-fleet.js");
+        assert!(
+            identity.contains("async function withSiblingLoopbackToken"),
+            "the sibling token helper left the identity fragment"
+        );
+        let panes = include_str!("../../../../static/app/43-access-panes.js");
+        assert_eq!(
+            panes
+                .matches("async function withSiblingLoopbackToken")
+                .count(),
+            0,
+            "the sibling token helper must not be duplicated in the access panes"
+        );
+        // And the served bundle carries the whole wiring, exactly once.
+        let app = include_str!("../../../../static/app.html");
+        for needle in [
+            "function resolveLiveHolder",
+            "withSiblingLoopbackToken(bare)",
+            "async function withSiblingLoopbackToken",
+        ] {
+            assert!(
+                app.contains(needle),
+                "the dashboard bundle lost the doorway resolution wiring: {needle}"
+            );
+        }
+        assert_eq!(
+            app.matches("async function withSiblingLoopbackToken").count(),
+            1,
+            "one shared sibling-token helper in the served bundle"
+        );
+    }
+
     /// The Cmd/Ctrl-K palette's update verbs are pure affordance
     /// re-exposure — the emission-shape law: the chip module keeps the
     /// only swap emissions (one relay POST, one webview bridge, one
@@ -1259,6 +1352,47 @@ mod tests {
         drop(successor);
         assert!(!holder.poll_acquire(0), "Q4: no draining→active edge");
         assert!(!holder.is_holder());
+    }
+
+    /// R-D1 (update-abstraction §5.1): `successor_port` is the
+    /// server-side mirror of the dashboard's live-holder rule. The 6c
+    /// window — the shared sidecar naming a DRAINING (or dead) target
+    /// between one drain's entry and the next acquisition — must never
+    /// leak into a refusal pointer; a live non-draining sibling is
+    /// named instead when one exists, and "pending" (None) otherwise.
+    #[test]
+    fn successor_port_never_names_a_draining_or_dead_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = HandoverRuntime::initialize(dir.path(), 7001, 0);
+        let b = HandoverRuntime::initialize(dir.path(), 7002, 0);
+
+        // A drains while spare B has not acquired yet: the sidecar
+        // still names A itself — the fallback names the live spare
+        // rather than leaving callers with "pending".
+        assert_eq!(a.request_drain(None), DrainRequest::Entered);
+        assert_eq!(a.successor_port(), Some(7002), "a live spare beats 'pending'");
+
+        // B acquires: the sidecar arm names it.
+        assert!(b.poll_acquire(0));
+        assert_eq!(a.successor_port(), Some(7002));
+
+        // B drains before any C exists — the 6c window: the sidecar
+        // names B, draining. No pointer may follow it there.
+        assert_eq!(b.request_drain(None), DrainRequest::Entered);
+        assert_eq!(a.successor_port(), None, "never a doorway into a drain");
+        assert_eq!(b.successor_port(), None);
+
+        // C acquires: the sidecar self-heals and both drainers' pointers
+        // follow it.
+        let c = HandoverRuntime::initialize(dir.path(), 7003, 0);
+        assert_eq!(c.held_generation(), Some(3));
+        assert_eq!(a.successor_port(), Some(7003));
+        assert_eq!(b.successor_port(), Some(7003));
+
+        // C crashes: the sidecar still names it, but a dead boot is not
+        // a doorway either (B stays draining, so nothing is eligible).
+        drop(c);
+        assert_eq!(a.successor_port(), None, "a crashed successor is not a doorway");
     }
 
     /// The Q4 pin: a drainer that observes its successor gone — crashed

--- a/src/bin/caller/handover/mod.rs
+++ b/src/bin/caller/handover/mod.rs
@@ -747,7 +747,7 @@ impl HandoverRuntime {
                 && records
                     .iter()
                     .find(|record| record.boot_id == sidecar.boot_id)
-                    .is_some_and(|record| eligible(record))
+                    .is_some_and(&eligible)
             {
                 return Some(sidecar.port);
             }

--- a/static/app.html
+++ b/static/app.html
@@ -38753,7 +38753,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '288b5774a1741a8f';
+const INTENDANT_APP_BUILD = 'd7c7af998b8ac20a';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -38957,6 +38957,44 @@ function getLoopbackToken() {
     return bareFetch(input, init);
   };
 })();
+
+// ── Same-home sibling loopback-token handoff ──
+//
+// Sibling daemons on THIS home refuse tokenless loopback like every
+// daemon, and this page holds only its own daemon's token (per-origin
+// storage). Opening a loopback sibling therefore asks the reached
+// daemon for its same-home instance map (/api/local-daemons/tokens —
+// owner-posture only; served per-request, never persisted) and opens
+// the sibling's own tokened URL so its page seeds its own origin.
+// Non-loopback and mTLS targets pass through untouched. Cached per
+// page load; a stale map (sibling rebooted) degrades to the bare URL
+// and the sibling's named 401 guidance. Shared: the Access fleet links
+// (43-access-panes) and the handover doorways (ui2-handover) both
+// route through this one helper.
+let accessSiblingTokenMapPromise = null;
+
+async function withSiblingLoopbackToken(rawUrl) {
+  try {
+    const url = new URL(rawUrl, location.href);
+    const host = url.hostname.replace(/^\[|\]$/g, '').toLowerCase();
+    const loopback =
+      host === 'localhost' || host === '::1' || /^127(?:\.\d{1,3}){3}$/.test(host);
+    if (!loopback || url.searchParams.has('token')) return rawUrl;
+    if (!accessSiblingTokenMapPromise) {
+      accessSiblingTokenMapPromise = fetch('/api/local-daemons/tokens')
+        .then(resp => (resp.ok ? resp.json() : { instances: [] }))
+        .catch(() => ({ instances: [] }));
+    }
+    const map = await accessSiblingTokenMapPromise;
+    const port = url.port || (url.protocol === 'https:' ? '443' : '80');
+    const entry = (map.instances || []).find(inst => String(inst.port) === String(port));
+    if (!entry || !entry.token) return rawUrl;
+    url.searchParams.set('token', entry.token);
+    return url.toString();
+  } catch {
+    return rawUrl;
+  }
+}
 
 function getFederationToken() {
   try {
@@ -81298,41 +81336,9 @@ function accessDiagnosticsCards() {
    request (never authority), and the target DAEMON decides via its
    local IAM. Roles get warmer colors the more they can do. */
 
-// ── Same-home sibling loopback-token handoff ──
-//
-// Sibling daemons on THIS home refuse tokenless loopback like every
-// daemon, and this page holds only its own daemon's token (per-origin
-// storage). Opening a loopback sibling therefore asks the reached
-// daemon for its same-home instance map (/api/local-daemons/tokens —
-// owner-posture only; served per-request, never persisted) and opens
-// the sibling's own tokened URL so its page seeds its own origin.
-// Non-loopback and mTLS targets pass through untouched. Cached per
-// page load; a stale map (sibling rebooted) degrades to the bare URL
-// and the sibling's named 401 guidance.
-let accessSiblingTokenMapPromise = null;
-
-async function withSiblingLoopbackToken(rawUrl) {
-  try {
-    const url = new URL(rawUrl, location.href);
-    const host = url.hostname.replace(/^\[|\]$/g, '').toLowerCase();
-    const loopback =
-      host === 'localhost' || host === '::1' || /^127(?:\.\d{1,3}){3}$/.test(host);
-    if (!loopback || url.searchParams.has('token')) return rawUrl;
-    if (!accessSiblingTokenMapPromise) {
-      accessSiblingTokenMapPromise = fetch('/api/local-daemons/tokens')
-        .then(resp => (resp.ok ? resp.json() : { instances: [] }))
-        .catch(() => ({ instances: [] }));
-    }
-    const map = await accessSiblingTokenMapPromise;
-    const port = url.port || (url.protocol === 'https:' ? '443' : '80');
-    const entry = (map.instances || []).find(inst => String(inst.port) === String(port));
-    if (!entry || !entry.token) return rawUrl;
-    url.searchParams.set('token', entry.token);
-    return url.toString();
-  } catch {
-    return rawUrl;
-  }
-}
+// The same-home sibling loopback-token handoff (withSiblingLoopbackToken)
+// lives in 31-init-identity-fleet.js beside the loopback-token machinery
+// it extends; the fleet links below and the handover doorways share it.
 
 const ACCESS_ROLE_META = {
   'role:root': { cls: 'role-root', warn: true, short: 'Full control of this daemon, including access administration.' },
@@ -105895,11 +105901,26 @@ async function memoryProposeFromForm(button) {
     return `${others.length} predecessor daemons are draining${finishing}`;
   }
 
-  function handoverSuccessorPort(body) {
+  // The §5.1 live-holder resolution rule (update-abstraction intake) —
+  // the ONE place a successor doorway target may come from. The lease
+  // sidecar names the most recent acquirer OR the most recent drainer
+  // during the entry→acquisition window (6c), so the sidecar target
+  // counts only while its daemons entry is live and neither draining
+  // nor exited; otherwise the hand-off candidate rule is the fallback
+  // (live, non-draining, on-disk build preferred). Null means "nobody
+  // yet": render the pending line, never a doorway into a drain.
+  function resolveLiveHolder(body) {
+    const daemons = Array.isArray(body && body.daemons) ? body.daemons : [];
     const sidecar = body && body.sidecar;
-    if (!sidecar || !body.boot_id || sidecar.boot_id === body.boot_id) return null;
-    const port = Number(sidecar.port);
-    return Number.isFinite(port) && port > 0 ? port : null;
+    if (sidecar && body.boot_id && sidecar.boot_id !== body.boot_id) {
+      const entry = daemons.find((d) => d && d.boot_id === sidecar.boot_id);
+      if (entry && entry.live && entry.state !== 'draining' && entry.state !== 'exited') {
+        const port = Number(entry.port);
+        if (Number.isFinite(port) && port > 0) return entry;
+      }
+    }
+    const update = body && body.update;
+    return handoverSuccessorCandidate(body, update ? update.on_disk : null);
   }
 
   // Render at most this many holdout rows; the rest fold into an honest
@@ -105999,14 +106020,28 @@ async function memoryProposeFromForm(button) {
   }
 
   // A real doorway to a co-homed daemon — same-host port substitution,
-  // like the old inline link, but rendered as a prominent element.
+  // like the old inline link, but rendered as a prominent element. On
+  // the loopback posture a sibling refuses tokenless pages, so the
+  // click decorates the URL through the same-home token map
+  // (withSiblingLoopbackToken, the fleet-links lane) and lands authed
+  // instead of on the named 401; non-loopback surfaces pass through
+  // untouched. Modifier/middle clicks keep their native semantics on
+  // the bare href.
   function handoverDaemonLink(port, label) {
     const link = document.createElement('a');
     link.className = 'handover-successor-link';
-    link.href = `${location.protocol}//${location.hostname}:${port}/`;
+    const bare = `${location.protocol}//${location.hostname}:${port}/`;
+    link.href = bare;
     link.target = '_blank';
     link.rel = 'noopener';
     link.textContent = label;
+    link.addEventListener('click', (ev) => {
+      if (ev.metaKey || ev.ctrlKey || ev.shiftKey || ev.altKey || ev.button !== 0) return;
+      ev.preventDefault();
+      Promise.resolve(withSiblingLoopbackToken(bare)).then((url) => {
+        window.open(url, '_blank', 'noopener');
+      });
+    });
     return link;
   }
 
@@ -106017,7 +106052,7 @@ async function memoryProposeFromForm(button) {
     }
     handoverUpdateRender(body);
     if (body.draining) {
-      const port = handoverSuccessorPort(body);
+      const holder = resolveLiveHolder(body);
       const el = handoverBanner();
       el.dataset.kind = 'draining';
       el.textContent = '';
@@ -106042,8 +106077,10 @@ async function memoryProposeFromForm(button) {
         : ' In-flight sessions finish here, then it exits.';
       head.appendChild(tail);
       el.appendChild(head);
-      if (port) {
-        el.appendChild(handoverDaemonLink(port, `Open the successor daemon (:${port}) →`));
+      if (holder) {
+        el.appendChild(
+          handoverDaemonLink(holder.port, `Open the successor daemon (:${holder.port}) →`)
+        );
       } else {
         const none = document.createElement('div');
         none.className = 'handover-banner-note';

--- a/static/app/31-init-identity-fleet.js
+++ b/static/app/31-init-identity-fleet.js
@@ -218,6 +218,44 @@ function getLoopbackToken() {
   };
 })();
 
+// ── Same-home sibling loopback-token handoff ──
+//
+// Sibling daemons on THIS home refuse tokenless loopback like every
+// daemon, and this page holds only its own daemon's token (per-origin
+// storage). Opening a loopback sibling therefore asks the reached
+// daemon for its same-home instance map (/api/local-daemons/tokens —
+// owner-posture only; served per-request, never persisted) and opens
+// the sibling's own tokened URL so its page seeds its own origin.
+// Non-loopback and mTLS targets pass through untouched. Cached per
+// page load; a stale map (sibling rebooted) degrades to the bare URL
+// and the sibling's named 401 guidance. Shared: the Access fleet links
+// (43-access-panes) and the handover doorways (ui2-handover) both
+// route through this one helper.
+let accessSiblingTokenMapPromise = null;
+
+async function withSiblingLoopbackToken(rawUrl) {
+  try {
+    const url = new URL(rawUrl, location.href);
+    const host = url.hostname.replace(/^\[|\]$/g, '').toLowerCase();
+    const loopback =
+      host === 'localhost' || host === '::1' || /^127(?:\.\d{1,3}){3}$/.test(host);
+    if (!loopback || url.searchParams.has('token')) return rawUrl;
+    if (!accessSiblingTokenMapPromise) {
+      accessSiblingTokenMapPromise = fetch('/api/local-daemons/tokens')
+        .then(resp => (resp.ok ? resp.json() : { instances: [] }))
+        .catch(() => ({ instances: [] }));
+    }
+    const map = await accessSiblingTokenMapPromise;
+    const port = url.port || (url.protocol === 'https:' ? '443' : '80');
+    const entry = (map.instances || []).find(inst => String(inst.port) === String(port));
+    if (!entry || !entry.token) return rawUrl;
+    url.searchParams.set('token', entry.token);
+    return url.toString();
+  } catch {
+    return rawUrl;
+  }
+}
+
 function getFederationToken() {
   try {
     return localStorage.getItem(FEDERATION_TOKEN_KEY) || '';

--- a/static/app/43-access-panes.js
+++ b/static/app/43-access-panes.js
@@ -3,41 +3,9 @@
    request (never authority), and the target DAEMON decides via its
    local IAM. Roles get warmer colors the more they can do. */
 
-// ── Same-home sibling loopback-token handoff ──
-//
-// Sibling daemons on THIS home refuse tokenless loopback like every
-// daemon, and this page holds only its own daemon's token (per-origin
-// storage). Opening a loopback sibling therefore asks the reached
-// daemon for its same-home instance map (/api/local-daemons/tokens —
-// owner-posture only; served per-request, never persisted) and opens
-// the sibling's own tokened URL so its page seeds its own origin.
-// Non-loopback and mTLS targets pass through untouched. Cached per
-// page load; a stale map (sibling rebooted) degrades to the bare URL
-// and the sibling's named 401 guidance.
-let accessSiblingTokenMapPromise = null;
-
-async function withSiblingLoopbackToken(rawUrl) {
-  try {
-    const url = new URL(rawUrl, location.href);
-    const host = url.hostname.replace(/^\[|\]$/g, '').toLowerCase();
-    const loopback =
-      host === 'localhost' || host === '::1' || /^127(?:\.\d{1,3}){3}$/.test(host);
-    if (!loopback || url.searchParams.has('token')) return rawUrl;
-    if (!accessSiblingTokenMapPromise) {
-      accessSiblingTokenMapPromise = fetch('/api/local-daemons/tokens')
-        .then(resp => (resp.ok ? resp.json() : { instances: [] }))
-        .catch(() => ({ instances: [] }));
-    }
-    const map = await accessSiblingTokenMapPromise;
-    const port = url.port || (url.protocol === 'https:' ? '443' : '80');
-    const entry = (map.instances || []).find(inst => String(inst.port) === String(port));
-    if (!entry || !entry.token) return rawUrl;
-    url.searchParams.set('token', entry.token);
-    return url.toString();
-  } catch {
-    return rawUrl;
-  }
-}
+// The same-home sibling loopback-token handoff (withSiblingLoopbackToken)
+// lives in 31-init-identity-fleet.js beside the loopback-token machinery
+// it extends; the fleet links below and the handover doorways share it.
 
 const ACCESS_ROLE_META = {
   'role:root': { cls: 'role-root', warn: true, short: 'Full control of this daemon, including access administration.' },

--- a/static/app/ui2-handover.js
+++ b/static/app/ui2-handover.js
@@ -513,11 +513,26 @@
     return `${others.length} predecessor daemons are draining${finishing}`;
   }
 
-  function handoverSuccessorPort(body) {
+  // The §5.1 live-holder resolution rule (update-abstraction intake) —
+  // the ONE place a successor doorway target may come from. The lease
+  // sidecar names the most recent acquirer OR the most recent drainer
+  // during the entry→acquisition window (6c), so the sidecar target
+  // counts only while its daemons entry is live and neither draining
+  // nor exited; otherwise the hand-off candidate rule is the fallback
+  // (live, non-draining, on-disk build preferred). Null means "nobody
+  // yet": render the pending line, never a doorway into a drain.
+  function resolveLiveHolder(body) {
+    const daemons = Array.isArray(body && body.daemons) ? body.daemons : [];
     const sidecar = body && body.sidecar;
-    if (!sidecar || !body.boot_id || sidecar.boot_id === body.boot_id) return null;
-    const port = Number(sidecar.port);
-    return Number.isFinite(port) && port > 0 ? port : null;
+    if (sidecar && body.boot_id && sidecar.boot_id !== body.boot_id) {
+      const entry = daemons.find((d) => d && d.boot_id === sidecar.boot_id);
+      if (entry && entry.live && entry.state !== 'draining' && entry.state !== 'exited') {
+        const port = Number(entry.port);
+        if (Number.isFinite(port) && port > 0) return entry;
+      }
+    }
+    const update = body && body.update;
+    return handoverSuccessorCandidate(body, update ? update.on_disk : null);
   }
 
   // Render at most this many holdout rows; the rest fold into an honest
@@ -617,14 +632,28 @@
   }
 
   // A real doorway to a co-homed daemon — same-host port substitution,
-  // like the old inline link, but rendered as a prominent element.
+  // like the old inline link, but rendered as a prominent element. On
+  // the loopback posture a sibling refuses tokenless pages, so the
+  // click decorates the URL through the same-home token map
+  // (withSiblingLoopbackToken, the fleet-links lane) and lands authed
+  // instead of on the named 401; non-loopback surfaces pass through
+  // untouched. Modifier/middle clicks keep their native semantics on
+  // the bare href.
   function handoverDaemonLink(port, label) {
     const link = document.createElement('a');
     link.className = 'handover-successor-link';
-    link.href = `${location.protocol}//${location.hostname}:${port}/`;
+    const bare = `${location.protocol}//${location.hostname}:${port}/`;
+    link.href = bare;
     link.target = '_blank';
     link.rel = 'noopener';
     link.textContent = label;
+    link.addEventListener('click', (ev) => {
+      if (ev.metaKey || ev.ctrlKey || ev.shiftKey || ev.altKey || ev.button !== 0) return;
+      ev.preventDefault();
+      Promise.resolve(withSiblingLoopbackToken(bare)).then((url) => {
+        window.open(url, '_blank', 'noopener');
+      });
+    });
     return link;
   }
 
@@ -635,7 +664,7 @@
     }
     handoverUpdateRender(body);
     if (body.draining) {
-      const port = handoverSuccessorPort(body);
+      const holder = resolveLiveHolder(body);
       const el = handoverBanner();
       el.dataset.kind = 'draining';
       el.textContent = '';
@@ -660,8 +689,10 @@
         : ' In-flight sessions finish here, then it exits.';
       head.appendChild(tail);
       el.appendChild(head);
-      if (port) {
-        el.appendChild(handoverDaemonLink(port, `Open the successor daemon (:${port}) →`));
+      if (holder) {
+        el.appendChild(
+          handoverDaemonLink(holder.port, `Open the successor daemon (:${holder.port}) →`)
+        );
       } else {
         const none = document.createElement('div');
         none.className = 'handover-banner-note';

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -7173,6 +7173,357 @@ async fn drainer_exits_at_last_session_end() {
     drop(daemon_b);
 }
 
+/// A mock script whose scheduled-session profile parks mid-turn on a
+/// long provider delay — the holdout that keeps each drainer in the
+/// three-daemon chain below alive (and draining) for the whole
+/// choreography. The 30s file-barrier bound is too tight for two
+/// takeovers plus a third boot on a slow runner, so the park is a
+/// plain delay; the sessions never complete inside the test and
+/// teardown kills the daemons.
+fn chain_park_script() -> serde_json::Value {
+    serde_json::json!({
+        "profiles": [
+            { "match": "handover rig follow-through",
+              "steps": [
+                { "content": "Working until the test ends.", "delay_ms": 600_000 },
+                { "content": "All work finished.",
+                  "tool_calls": [{ "name": "signal_done",
+                                   "arguments": { "message": "handover fire complete" } }] }
+              ] },
+            { "steps": [
+                { "content": "fallback profile (unexpected session)",
+                  "tool_calls": [{ "name": "signal_done",
+                                   "arguments": { "message": "unexpected session" } }] }
+            ]}
+        ]
+    })
+}
+
+/// The §5.1 live-holder resolution rule exactly as the dashboard's
+/// `resolveLiveHolder` applies it to a served handover payload: the
+/// sidecar target iff its daemons entry is live and neither draining
+/// nor exited; else the first live non-draining sibling; else none.
+/// (The SPA's on-disk-build preference needs no twin here — the rig
+/// runs one binary, so every candidate matches.)
+fn resolve_live_holder_port(body: &serde_json::Value) -> Option<u16> {
+    let daemons = body["daemons"].as_array().cloned().unwrap_or_default();
+    let self_boot = body["boot_id"].as_str().unwrap_or_default();
+    let eligible = |d: &serde_json::Value| {
+        d["live"] == true
+            && d["boot_id"].as_str().is_some_and(|boot| boot != self_boot)
+            && d["state"] != "draining"
+            && d["state"] != "exited"
+    };
+    let port_of = |d: &serde_json::Value| d["port"].as_u64().map(|p| p as u16);
+    if let Some(sidecar_boot) = body["sidecar"]["boot_id"].as_str() {
+        if sidecar_boot != self_boot {
+            if let Some(entry) = daemons.iter().find(|d| d["boot_id"] == sidecar_boot) {
+                if eligible(entry) {
+                    return port_of(entry);
+                }
+            }
+        }
+    }
+    daemons.iter().find(|d| eligible(d)).and_then(port_of)
+}
+
+/// Update-abstraction slice 1, acceptance (b): the three-daemon chain.
+/// A drains toward B, then B drains before any C exists — the 6c
+/// entry→acquisition window where the shared sidecar names a DRAINING
+/// daemon. A's served handover payload must let the §5.1 resolution
+/// rule refuse B during that window and reach C once C acquires; the
+/// drainer's `/api/local-daemons/tokens` must name the successor's own
+/// admission token, and that token must actually admit a doorway-shaped
+/// request (the tokened-doorway half). The drainers' refusal pointers
+/// (R-D1's server-side mirror) ride the same rule: "pending" during
+/// the window, `:C` after.
+#[tokio::test]
+async fn chained_drain_payload_resolves_only_live_non_draining_holder() {
+    let rig = TestRig::new();
+    let script = chain_park_script();
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("http client");
+    let daemon_a = spawn_daemon_on_rig(&client, rig, &script, false).await;
+    let boot_a = lease_sidecar(&daemon_a.rig).expect("holder sidecar")["boot_id"]
+        .as_str()
+        .expect("boot id")
+        .to_string();
+
+    // A fires a session that parks mid-turn: the holdout that keeps A
+    // alive (and draining, below) through the whole choreography.
+    let item_a = approve_manifest_at(
+        &daemon_a.rig,
+        daemon_a.port,
+        now_epoch_ms() + 1_500,
+        "chain-park-a",
+    )
+    .await;
+    poll_until(
+        "A's in-flight started row",
+        RUN_TIMEOUT,
+        || async {
+            journal_states_for_item(&daemon_a.rig, &item_a)
+                .contains(&"started".to_string())
+                .then_some(())
+        },
+        || daemon_a.log_tail(),
+    )
+    .await;
+
+    // B boots with --takeover: A drains, B acquires.
+    let daemon_b = spawn_co_daemon(
+        &client,
+        &daemon_a.rig,
+        "daemon-b.log",
+        &[("INTENDANT_LEASE_POLL_MS", "500")],
+        &["--takeover"],
+    )
+    .await;
+    poll_until(
+        "the lease transferring to B",
+        RUN_TIMEOUT,
+        || async {
+            let sidecar = lease_sidecar(&daemon_a.rig)?;
+            (sidecar["boot_id"] != boot_a.as_str() && sidecar["state"] == "active").then_some(())
+        },
+        || format!("sidecar: {:?}", lease_sidecar(&daemon_a.rig)),
+    )
+    .await;
+    let boot_b = lease_sidecar(&daemon_a.rig).expect("B sidecar")["boot_id"]
+        .as_str()
+        .expect("boot id")
+        .to_string();
+
+    // B — the holder now — fires its own parked session, so its drain
+    // below holds it alive too: a LIVE draining sibling (the intake's
+    // 6c shape), not a corpse.
+    let item_b = approve_manifest_at(
+        &daemon_a.rig,
+        daemon_b.port,
+        now_epoch_ms() + 1_500,
+        "chain-park-b",
+    )
+    .await;
+    poll_until(
+        "B's in-flight started row",
+        RUN_TIMEOUT,
+        || async {
+            journal_states_for_item(&daemon_a.rig, &item_b)
+                .contains(&"started".to_string())
+                .then_some(())
+        },
+        || format!("journal: {:?}", journal_rows(&daemon_a.rig)),
+    )
+    .await;
+
+    // Drain B with no successor running: the 6c window opens — the
+    // shared sidecar now names B, DRAINING, and nobody has acquired.
+    let takeover = client
+        .post(format!(
+            "http://127.0.0.1:{}/api/daemon/takeover",
+            daemon_b.port
+        ))
+        .header(
+            "x-intendant-loopback-token",
+            rig_loopback_token(&daemon_a.rig, daemon_b.port),
+        )
+        .json(&serde_json::json!({ "requested_by": "chain e2e" }))
+        .send()
+        .await
+        .expect("takeover request reaches B");
+    assert!(
+        takeover.status().is_success(),
+        "drain request on B refused: {}",
+        takeover.status()
+    );
+    poll_until(
+        "the sidecar naming B draining",
+        RUN_TIMEOUT,
+        || async {
+            let sidecar = lease_sidecar(&daemon_a.rig)?;
+            (sidecar["boot_id"] == boot_b.as_str() && sidecar["state"] == "draining").then_some(())
+        },
+        || format!("sidecar: {:?}", lease_sidecar(&daemon_a.rig)),
+    )
+    .await;
+
+    // A's served payload during the window: the sidecar names a
+    // draining daemon, the daemons array carries B live+draining, and
+    // the resolution rule refuses it — no doorway into a drain.
+    let a_client = daemon_a.authed_client();
+    let handover_url = format!("http://127.0.0.1:{}/api/daemon/handover", daemon_a.port);
+    let payload = http_get_json(&a_client, &handover_url)
+        .await
+        .expect("A's handover payload");
+    assert_eq!(payload["draining"], true, "{payload}");
+    assert_eq!(payload["sidecar"]["boot_id"], boot_b.as_str(), "{payload}");
+    assert_eq!(payload["sidecar"]["state"], "draining", "{payload}");
+    let b_entry = payload["daemons"]
+        .as_array()
+        .and_then(|daemons| {
+            daemons
+                .iter()
+                .find(|d| d["boot_id"] == boot_b.as_str())
+                .cloned()
+        })
+        .expect("B's presence entry in A's payload");
+    assert_eq!(
+        b_entry["live"], true,
+        "the window is a LIVE draining sibling: {b_entry}"
+    );
+    assert_eq!(b_entry["state"], "draining", "{b_entry}");
+    assert_eq!(
+        resolve_live_holder_port(&payload),
+        None,
+        "the rule must refuse a draining sidecar target: {payload}"
+    );
+
+    // R-D1's server-side mirror, observed end to end: A's refusal
+    // pointer says "pending" during the window — never ":B".
+    let probe = ctl_on_rig(
+        &daemon_a.rig,
+        daemon_a.port,
+        &["--json", "agenda", "add", "chain-refusal-probe", "--task"],
+    )
+    .await;
+    assert!(probe.status.success(), "{}", text_of(&probe));
+    let probe_id = stdout_json(&probe)["item"]["id"]
+        .as_str()
+        .expect("minted item id")
+        .to_string();
+    let refused = ctl_on_rig(
+        &daemon_a.rig,
+        daemon_a.port,
+        &["agenda", "start", &probe_id[..10]],
+    )
+    .await;
+    let refused_text = text_of(&refused);
+    assert!(
+        !refused.status.success() && refused_text.contains("daemon_draining"),
+        "start_now must refuse on the drainer: {refused_text}"
+    );
+    assert!(
+        refused_text.contains("has not acquired"),
+        "the window's refusal says pending, never a draining port: {refused_text}"
+    );
+    assert!(
+        !refused_text.contains(&format!(":{}", daemon_b.port)),
+        "the refusal must not point into B's drain: {refused_text}"
+    );
+
+    // C boots plain — the lease is already free, so boot-time
+    // acquisition takes it.
+    let daemon_c = spawn_co_daemon(
+        &client,
+        &daemon_a.rig,
+        "daemon-c.log",
+        &[("INTENDANT_LEASE_POLL_MS", "500")],
+        &[],
+    )
+    .await;
+    poll_until(
+        "C acquiring the lease",
+        RUN_TIMEOUT,
+        || async {
+            let sidecar = lease_sidecar(&daemon_a.rig)?;
+            (sidecar["state"] == "active"
+                && sidecar["boot_id"] != boot_a.as_str()
+                && sidecar["boot_id"] != boot_b.as_str())
+            .then_some(())
+        },
+        || format!("sidecar: {:?}", lease_sidecar(&daemon_a.rig)),
+    )
+    .await;
+
+    // A's payload now reaches C through the rule (the sidecar arm:
+    // live, non-draining) while B still shows live+draining beside it —
+    // the daemons array carries the multi-predecessor truth.
+    let payload = http_get_json(&a_client, &handover_url)
+        .await
+        .expect("A's handover payload after C acquired");
+    assert_eq!(
+        resolve_live_holder_port(&payload),
+        Some(daemon_c.port),
+        "the rule reaches C once C acquires: {payload}"
+    );
+    let b_entry = payload["daemons"]
+        .as_array()
+        .and_then(|daemons| {
+            daemons
+                .iter()
+                .find(|d| d["boot_id"] == boot_b.as_str())
+                .cloned()
+        })
+        .expect("B's presence entry beside C");
+    assert_eq!(b_entry["live"], true, "{b_entry}");
+    assert_eq!(b_entry["state"], "draining", "{b_entry}");
+
+    // …and A's refusal pointer follows the healed sidecar to C.
+    let redirected = ctl_on_rig(
+        &daemon_a.rig,
+        daemon_a.port,
+        &["agenda", "start", &probe_id[..10]],
+    )
+    .await;
+    let redirected_text = text_of(&redirected);
+    assert!(
+        !redirected.status.success()
+            && redirected_text.contains(&format!("(:{})", daemon_c.port)),
+        "the refusal pointer names C once C acquires: {redirected_text}"
+    );
+
+    // The tokened doorway's map: the DRAINER serves the same-home
+    // instance map, it names the successor's own admission token, and
+    // that token admits a doorway-shaped request (the URL
+    // `withSiblingLoopbackToken` builds).
+    let tokens = http_get_json(
+        &a_client,
+        &format!(
+            "http://127.0.0.1:{}/api/local-daemons/tokens",
+            daemon_a.port
+        ),
+    )
+    .await
+    .expect("the drainer serves the token map");
+    let c_entry = tokens["instances"]
+        .as_array()
+        .and_then(|instances| {
+            instances
+                .iter()
+                .find(|inst| inst["port"].as_u64() == Some(u64::from(daemon_c.port)))
+                .cloned()
+        })
+        .expect("the successor appears in the drainer's token map");
+    let c_token = c_entry["token"].as_str().unwrap_or_default().to_string();
+    assert!(
+        !c_token.is_empty(),
+        "the successor's entry carries its token: {tokens}"
+    );
+    assert_eq!(
+        c_token,
+        rig_loopback_token(&daemon_a.rig, daemon_c.port),
+        "the map's token IS the successor's own admission token"
+    );
+    let doorway = client
+        .get(format!(
+            "http://127.0.0.1:{}/?token={}",
+            daemon_c.port, c_token
+        ))
+        .send()
+        .await
+        .expect("doorway request reaches C");
+    assert!(
+        doorway.status().is_success(),
+        "the tokened doorway lands authed on C: {}",
+        doorway.status()
+    );
+
+    drop(daemon_c);
+    drop(daemon_b);
+}
+
 /// A probe-able fake "binary": a shell script printing exactly
 /// `build_info::version_line`'s shape with the given sha. Unix-only —
 /// the update watch execs it for `--version`.

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -7469,8 +7469,7 @@ async fn chained_drain_payload_resolves_only_live_non_draining_holder() {
     .await;
     let redirected_text = text_of(&redirected);
     assert!(
-        !redirected.status.success()
-            && redirected_text.contains(&format!("(:{})", daemon_c.port)),
+        !redirected.status.success() && redirected_text.contains(&format!("(:{})", daemon_c.port)),
         "the refusal pointer names C once C acquires: {redirected_text}"
     );
 


### PR DESCRIPTION
Implements **update-abstraction slice 1** per the sealed intake (§7 slice 1, ruled PASS 2026-08-01) and its ruling tail, from commission card 01KZ0189S8R1PABK9ZXX2CWZSN.

## What changes

- **`resolveLiveHolder(body)`** (ui2-handover.js): the §5.1 rule — prefer the lease-sidecar target **iff its daemons entry is `live && state !== 'draining' && state !== 'exited'`**; else fall back to the existing hand-off candidate rule (`handoverSuccessorCandidate`: live, non-draining, on-disk build preferred); else null. The drain banner's successor doorway now consumes this resolver, so the 6c entry→acquisition window (sidecar naming the most recent **drainer**) can never render a doorway into a drain — it renders the honest "No successor has acquired the lease yet." instead.
- **Tokened doorways**: `handoverDaemonLink` (successor *and* predecessor doorways) decorates the URL at click time through the same-home sibling token map (`withSiblingLoopbackToken`), so on the loopback posture the click lands authed instead of on the named 401. The helper is **lifted** from `43-access-panes.js` into `31-init-identity-fleet.js` beside the loopback-token machinery it extends (shared with the Access fleet links — never duplicated). Modifier/middle clicks keep native semantics on the bare href.
- **R-D1 — implemented** (not deferred): `HandoverRuntime::successor_port()` is now the server-side mirror of the same rule for `daemon_draining` refusal pointers — the sidecar target is presence-consulted (live, not draining/exited) before being named; a live non-draining sibling is the fallback; None ("successor pending") otherwise. Scope note: the mirror carries the *eligibility* rule; the on-disk-build **preference** stays client-side where `update.on_disk` is at hand — it is a doorway product refinement, not a refusal-pointer concern (any live non-draining daemon serves refused work equally).

## Acceptance mapping (gate criteria, intake §7 slice 1)

- **(a) fragment needle pins, same commit**: `doorway_resolves_live_holder_and_carries_the_sibling_token` pins the resolver, the filter expression (`entry.live && entry.state !== 'draining' && entry.state !== 'exited'`), the doorway consumption, the fallback composition, the click-time token decoration, the lift (helper present in 31, absent from 43, exactly once in the served bundle), and the removal of the boot-id-only `handoverSuccessorPort`. `successor_port_never_names_a_draining_or_dead_target` pins the server mirror across the full 6c chain (spare fallback → sidecar arm → draining window → healed sidecar → crashed successor).
- **(b) e2e three-daemon chain leg**: `chained_drain_payload_resolves_only_live_non_draining_holder` (spawn_co_daemon ×3, `INTENDANT_LEASE_POLL_MS=500`, the :6835/:6921 rig family) — A drains toward B; B drains with no successor (the 6c window, held open by parked holdout sessions on both drainers): A's served payload carries sidecar={B, draining} with B live+draining in the daemons array and the resolution rule refuses it; C boots, acquires, and the same payload lets the rule reach C while B still shows live+draining beside it. `/api/local-daemons/tokens` on the drainer names the successor's own admission token, and the token admits the exact doorway URL shape (`/?token=…` → 200). The drainers' refusal pointers ride the mirror end to end: "has not acquired" during the window (never :B), "(:C)" after. Holdouts park on a long provider delay rather than the 30s-bounded file barrier — two takeovers plus a third boot don't fit under 30s on a slow runner.
- **(c) full local battery**: bins + lib crates + e2e + workspace clippy -D warnings + fmt --check — results will be posted on this PR before it leaves draft.

## Bindings held

No new authority: the doorway stays client navigation; the token map route (`/api/local-daemons/tokens`, owner-posture, CredentialsManage class) is consumed exactly as the fleet links already consume it; no tunnel twins added (P3(b) intact). Era vocabulary untouched. F1 (presence watershed) untouched — `successor_port` only reads presence.