### PR TITLE
agenda: pin the approve wake by test; document the honest approve-to-fire cadence

### DIFF
--- a/docs/src/agenda-and-memory.md
+++ b/docs/src/agenda-and-memory.md
@@ -465,6 +465,27 @@ revoke them. Revising a manifest changes the digest and voids the previous
 approval. The spawned session gets ordinary session authority; the approval
 does not bypass its sandbox, IAM, autonomy policy, or action approvals.
 
+**Approve-to-fire is event-driven, not polled (2026-08-01).** Every
+accepted agenda op funnels through one apply seam that both nudges the
+scheduler and broadcasts the change on the bus it selects over; the bus
+subscription queues, so an op landing mid-pass still forces the next
+pass instead of waiting out a sleep. Approving a manifest whose fire
+time already passed therefore dispatches in the same governed slot
+(milliseconds, then the stagger below under contention), and approving
+before the fire time fires at that instant itself — verified live to
+13 ms. The scheduler's 300 s safety tick is a no-signal backstop, never
+the operating cadence. What CAN honestly defer a fire: the governor's
+30 s slots under contention, the no-overlap rule while an occurrence of
+the same effect still runs, and daemon handover — a draining daemon
+stops firing while a successor acquires the freed lease (60 s poll), so
+an instant due inside that window lands right after acquisition. The
+apparent 10-minute approve-to-fire gap investigated 2026-08-01 was
+exactly these mechanics composed: fire-time floors still minutes in the
+future at approval plus a live handover window — the fires landed 13 ms
+and 4 ms after their floors, under the new holder, with the earlier
+same-evening batch (floors already past) firing the very second it was
+approved.
+
 **The spawn governor (2026-08-01): simultaneous fires stagger.** When
 several due occurrences would dispatch at once — eight approvals in seven
 seconds once fired eight seats in one second, pinning the daemon at 230%

--- a/src/bin/caller/agenda/handle.rs
+++ b/src/bin/caller/agenda/handle.rs
@@ -175,6 +175,14 @@ impl AgendaHandle {
     }
 
     /// Await the next plan-moving change (op applied or policy edited).
+    /// `notify_waiters` carries no permit, so only a PARKED waiter hears
+    /// it — but item ops are also broadcast as `AgendaChanged` on the
+    /// bus the scheduler selects over, and that subscription queues, so
+    /// an op landing mid-pass still wakes the next iteration (this is
+    /// what makes approve-to-fire event-driven — see the scheduler's
+    /// select). Policy edits ride the nudge alone: one landing exactly
+    /// inside a pass waits for the safety tick — accepted, the stakes
+    /// are presentation cadence only.
     pub(crate) async fn reminder_nudged(&self) {
         self.reminder_nudge.notified().await;
     }

--- a/src/bin/caller/agenda/scheduler.rs
+++ b/src/bin/caller/agenda/scheduler.rs
@@ -2258,7 +2258,13 @@ mod tests {
         // `notified().await` registration.
         tokio::task::yield_now().await;
         handle
-            .apply(AgendaCommand::ApproveEffect { id: item_id, digest }, owner())
+            .apply(
+                AgendaCommand::ApproveEffect {
+                    id: item_id,
+                    digest,
+                },
+                owner(),
+            )
             .unwrap();
         tokio::time::timeout(std::time::Duration::from_secs(60), waiter)
             .await

--- a/src/bin/caller/agenda/scheduler.rs
+++ b/src/bin/caller/agenda/scheduler.rs
@@ -358,6 +358,17 @@ pub(crate) fn spawn_reminder_scheduler(
             let sleep_for = next_wake_ms
                 .map(|wake| std::time::Duration::from_millis(wake.saturating_sub(now)))
                 .map_or(SAFETY_TICK, |until| until.min(SAFETY_TICK));
+            // Op latency is EVENT-DRIVEN, not polled: every accepted
+            // agenda op nudges (`AgendaHandle::apply`) AND broadcasts
+            // `AgendaChanged` into `events`, whose subscription queues —
+            // an op landing while a pass runs still forces the next
+            // iteration instead of waiting out the sleep. An approve on
+            // an already-due manifest therefore dispatches in the same
+            // governed slot, never at the next safety tick (pinned by
+            // `approve_on_a_due_effect_fires_without_a_cadence_pass`;
+            // the 2026-08-01 "10-minute approve-to-fire" read was floors
+            // still in the future plus a drain/handover window, not a
+            // missing wake). The tick is the no-signal backstop only.
             tokio::select! {
                 _ = handle.reminder_nudged() => {}
                 _ = tokio::time::sleep(sleep_for) => {}
@@ -2173,7 +2184,9 @@ mod tests {
         log.write_all(lines.as_bytes()).unwrap();
     }
 
-    fn approved_effect_item(handle: &AgendaHandle, fire_at_ms: u64) -> (String, String, String) {
+    /// Parks one item and proposes an UNAPPROVED manifest on it — the
+    /// approve-wake tests apply the approval themselves mid-flight.
+    fn proposed_effect_item(handle: &AgendaHandle, fire_at_ms: u64) -> (String, String, String) {
         let item = handle
             .apply(
                 AgendaCommand::Add {
@@ -2208,16 +2221,103 @@ mod tests {
             .unwrap();
         let digest = proposed.effects[0].digest.clone();
         let effect_id = proposed.effects[0].effect_id.clone();
+        (item.id, effect_id, digest)
+    }
+
+    fn approved_effect_item(handle: &AgendaHandle, fire_at_ms: u64) -> (String, String, String) {
+        let (item_id, effect_id, digest) = proposed_effect_item(handle, fire_at_ms);
         handle
             .apply(
                 AgendaCommand::ApproveEffect {
-                    id: item.id.clone(),
+                    id: item_id.clone(),
+                    digest: digest.clone(),
+                },
+                owner(),
+            )
+            .unwrap();
+        (item_id, effect_id, digest)
+    }
+
+    /// The approve wake, nudge leg (approve-to-fire latency, live find
+    /// 2026-08-01): an accepted `approve_effect` completes a parked
+    /// `reminder_nudged()` waiter — the scheduler is TOLD about an
+    /// approval, it never has to poll one up.
+    #[tokio::test(start_paused = true)]
+    async fn approve_effect_nudges_a_parked_waiter() {
+        let dir = tempfile::tempdir().unwrap();
+        let handle = handle_with_default_project(dir.path(), dir.path());
+        // Propose BEFORE parking: the propose op nudges too, and
+        // `notify_waiters` carries no permit — the waiter below must
+        // hear the approve itself, not a leftover.
+        let (item_id, _effect_id, digest) = proposed_effect_item(&handle, now_ms() - 60_000);
+        let waiter = {
+            let handle = handle.clone();
+            tokio::spawn(async move { handle.reminder_nudged().await })
+        };
+        // Current-thread runtime: one yield polls the waiter to its
+        // `notified().await` registration.
+        tokio::task::yield_now().await;
+        handle
+            .apply(AgendaCommand::ApproveEffect { id: item_id, digest }, owner())
+            .unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(60), waiter)
+            .await
+            .expect("approve_effect must nudge the scheduler waiter")
+            .unwrap();
+    }
+
+    /// The approve wake, loop leg (approve-to-fire latency, live find
+    /// 2026-08-01): the REAL scheduler loop, parked mid-sleep, converts
+    /// an `approve_effect` on an already-due manifest into a dispatch in
+    /// the same governed slot — never the next safety tick and never
+    /// some other op's pass. Paused-clock proof: virtual time advances
+    /// only while every task is idle, so a wake that waited for the
+    /// 300s tick would show as a ≥300s virtual jump; the working path
+    /// shows zero.
+    #[tokio::test(start_paused = true)]
+    async fn approve_on_a_due_effect_fires_without_a_cadence_pass() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let handle = handle_with_default_project(dir.path(), project.path());
+        let mut rx = handle.bus().subscribe();
+        let scheduler = spawn_reminder_scheduler(handle.clone(), None);
+        // Quiesce: auto-advance fires this sleep only once no task is
+        // runnable — the boot pass has run and the loop is parked.
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        // The proposal lands while the loop sleeps; unapproved manifests
+        // plan nothing, so the loop parks again for the full tick.
+        let (item_id, _effect_id, digest) = proposed_effect_item(&handle, now_ms() - 60_000);
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        let approved_at = tokio::time::Instant::now();
+        handle
+            .apply(
+                AgendaCommand::ApproveEffect {
+                    id: item_id.clone(),
                     digest,
                 },
                 owner(),
             )
             .unwrap();
-        (item.id, effect_id, proposed.effects[0].digest.clone())
+        let task = loop {
+            let event = tokio::time::timeout(std::time::Duration::from_secs(600), rx.recv())
+                .await
+                .expect("the approve never produced a dispatch — the wake is missing")
+                .expect("bus closed");
+            if let AppEvent::ControlCommand(ControlMsg::StartTask { task, .. }) = event {
+                break task;
+            }
+        };
+        let waited = approved_at.elapsed();
+        assert!(
+            waited < std::time::Duration::from_secs(5),
+            "the dispatch waited {waited:?} — a cadence pass fired it, not the approve wake \
+             (safety tick {SAFETY_TICK:?})"
+        );
+        assert!(
+            task.contains(&item_id),
+            "the dispatched task names its item: {task}"
+        );
+        scheduler.abort();
     }
 
     /// Parks one item and proposes+approves a sealed manifest on it —

--- a/src/bin/caller/agenda/scheduler.rs
+++ b/src/bin/caller/agenda/scheduler.rs
@@ -324,7 +324,7 @@ pub(crate) fn spawn_reminder_scheduler(
             handover.attach_scheduler();
         }
         let mut state = SchedulerState::default();
-        let mut events = handle.bus().subscribe();
+        let events = handle.bus().subscribe();
         // Boot recovery, scoped (Track HS2): a live co-homed daemon's
         // in-flight rows are spared; legacy rows and provably dead
         // writers fail-close exactly as before. The classification
@@ -339,67 +339,83 @@ pub(crate) fn spawn_reminder_scheduler(
         };
         state.readopt_watch = classification.watches;
         crate::boot_readopt::publish_agenda_readopt_seeds(classification.seeds);
-        loop {
-            let next_wake_ms =
-                run_pass(&handle, &mut journal, &mut state, handover.as_deref()).await;
-            let now = now_ms();
-            let retry_wake_ms = sweep_pending_dispatches(&handle, &mut journal, &mut state, now);
-            let lineage_wake_ms = sweep_lineage_pending(&handle, &mut journal, &mut state, now);
-            let readopt_wake_ms = sweep_readopt_watch(&handle, &mut journal, &mut state, now);
-            let next_wake_ms = [
-                next_wake_ms,
-                retry_wake_ms,
-                lineage_wake_ms,
-                readopt_wake_ms,
-            ]
-            .into_iter()
-            .flatten()
-            .min();
-            let sleep_for = next_wake_ms
-                .map(|wake| std::time::Duration::from_millis(wake.saturating_sub(now)))
-                .map_or(SAFETY_TICK, |until| until.min(SAFETY_TICK));
-            // Op latency is EVENT-DRIVEN, not polled: every accepted
-            // agenda op nudges (`AgendaHandle::apply`) AND broadcasts
-            // `AgendaChanged` into `events`, whose subscription queues —
-            // an op landing while a pass runs still forces the next
-            // iteration instead of waiting out the sleep. An approve on
-            // an already-due manifest therefore dispatches in the same
-            // governed slot, never at the next safety tick (pinned by
-            // `approve_on_a_due_effect_fires_without_a_cadence_pass`;
-            // the 2026-08-01 "10-minute approve-to-fire" read was floors
-            // still in the future plus a drain/handover window, not a
-            // missing wake). The tick is the no-signal backstop only.
-            tokio::select! {
-                _ = handle.reminder_nudged() => {}
-                _ = tokio::time::sleep(sleep_for) => {}
-                // Drain/takeover wake (Track HS3): entry must not wait
-                // out a sleep — the requester's flock acquire is gated on
-                // it. Pends forever without a runtime.
-                _ = async {
-                    match &handover {
-                        Some(runtime) => runtime.drain_wake().await,
-                        None => std::future::pending().await,
-                    }
-                } => {}
-                event = events.recv() => match event {
-                    Ok(event) => observe_event(&handle, &mut journal, &mut state, &event),
-                    Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
-                        // Receipts and terminal events cannot be reconstructed
-                        // from the broadcast stream. Apply the same fail-closed
-                        // terminal state as restart recovery so an occurrence
-                        // cannot remain excluded from planning indefinitely.
-                        let resolved =
-                            resolve_lagged_occurrences(&handle, &mut journal, &mut state);
-                        eprintln!(
-                            "[agenda] scheduler lagged on the event bus \
-                             (skipped {skipped}, resolved {resolved} in-flight occurrences)"
-                        );
-                    }
-                    Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
-                },
-            }
-        }
+        scheduler_loop(handle, handover, journal, state, events).await;
     })
+}
+
+/// The post-boot select loop, whole. Split from
+/// [`spawn_reminder_scheduler`] so the loop-leg wake test drives the
+/// REAL loop without the boot side of the task: boot recovery and the
+/// readopt-seed publish write a process-global slot, and a test driving
+/// them cross-talks the boot_readopt suite's own seed waits
+/// (hermeticity law — found live when the wake test skewed
+/// `dispatch_stagger_spaces_but_never_drops`).
+async fn scheduler_loop(
+    handle: Arc<AgendaHandle>,
+    handover: Option<Arc<crate::handover::HandoverRuntime>>,
+    mut journal: OccurrenceJournal,
+    mut state: SchedulerState,
+    mut events: tokio::sync::broadcast::Receiver<AppEvent>,
+) {
+    loop {
+        let next_wake_ms = run_pass(&handle, &mut journal, &mut state, handover.as_deref()).await;
+        let now = now_ms();
+        let retry_wake_ms = sweep_pending_dispatches(&handle, &mut journal, &mut state, now);
+        let lineage_wake_ms = sweep_lineage_pending(&handle, &mut journal, &mut state, now);
+        let readopt_wake_ms = sweep_readopt_watch(&handle, &mut journal, &mut state, now);
+        let next_wake_ms = [
+            next_wake_ms,
+            retry_wake_ms,
+            lineage_wake_ms,
+            readopt_wake_ms,
+        ]
+        .into_iter()
+        .flatten()
+        .min();
+        let sleep_for = next_wake_ms
+            .map(|wake| std::time::Duration::from_millis(wake.saturating_sub(now)))
+            .map_or(SAFETY_TICK, |until| until.min(SAFETY_TICK));
+        // Op latency is EVENT-DRIVEN, not polled: every accepted
+        // agenda op nudges (`AgendaHandle::apply`) AND broadcasts
+        // `AgendaChanged` into `events`, whose subscription queues —
+        // an op landing while a pass runs still forces the next
+        // iteration instead of waiting out the sleep. An approve on
+        // an already-due manifest therefore dispatches in the same
+        // governed slot, never at the next safety tick (pinned by
+        // `approve_on_a_due_effect_fires_without_a_cadence_pass`;
+        // the 2026-08-01 "10-minute approve-to-fire" read was floors
+        // still in the future plus a drain/handover window, not a
+        // missing wake). The tick is the no-signal backstop only.
+        tokio::select! {
+            _ = handle.reminder_nudged() => {}
+            _ = tokio::time::sleep(sleep_for) => {}
+            // Drain/takeover wake (Track HS3): entry must not wait
+            // out a sleep — the requester's flock acquire is gated on
+            // it. Pends forever without a runtime.
+            _ = async {
+                match &handover {
+                    Some(runtime) => runtime.drain_wake().await,
+                    None => std::future::pending().await,
+                }
+            } => {}
+            event = events.recv() => match event {
+                Ok(event) => observe_event(&handle, &mut journal, &mut state, &event),
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                    // Receipts and terminal events cannot be reconstructed
+                    // from the broadcast stream. Apply the same fail-closed
+                    // terminal state as restart recovery so an occurrence
+                    // cannot remain excluded from planning indefinitely.
+                    let resolved =
+                        resolve_lagged_occurrences(&handle, &mut journal, &mut state);
+                    eprintln!(
+                        "[agenda] scheduler lagged on the event bus \
+                         (skipped {skipped}, resolved {resolved} in-flight occurrences)"
+                    );
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
+            },
+        }
+    }
 }
 
 /// Which unresolved journal rows this daemon may fail-close (Track HS2,
@@ -2286,9 +2302,20 @@ mod tests {
         let project = tempfile::tempdir().unwrap();
         let handle = handle_with_default_project(dir.path(), project.path());
         let mut rx = handle.bus().subscribe();
-        let scheduler = spawn_reminder_scheduler(handle.clone(), None);
+        // Drive the REAL post-boot loop directly: `scheduler_loop` is
+        // everything `spawn_reminder_scheduler` runs after boot recovery
+        // — the boot side publishes a process-global readopt-seed slot,
+        // which a test must not touch (it cross-talks the boot_readopt
+        // suite's seed waits).
+        let scheduler = tokio::spawn(scheduler_loop(
+            handle.clone(),
+            None,
+            OccurrenceJournal::open(handle.dir()).unwrap(),
+            SchedulerState::default(),
+            handle.bus().subscribe(),
+        ));
         // Quiesce: auto-advance fires this sleep only once no task is
-        // runnable — the boot pass has run and the loop is parked.
+        // runnable — the first pass has run and the loop is parked.
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         // The proposal lands while the loop sleeps; unapproved manifests
         // plan nothing, so the loop parks again for the full tick.


### PR DESCRIPTION
Resolves the approve-to-fire latency card (agenda item 01KYZY2XSKMZW9W9RPMEEA06QV): traced the dashboard/tunnel Approve path end to end, reconstructed the 2026-08-01 incident from the durable ledgers, pinned the answer by test, and codified the honest cadence.

## The trace

HTTP `POST /api/agenda/op` and its tunnel twin `api_agenda_op` both funnel into `agenda_op_api_response` → `AgendaHandle::apply` — the same shared `Arc<AgendaHandle>` the scheduler holds (wired in `startup/wiring.rs`). `apply` appends to the store, broadcasts `AgendaChanged` on the bus, and calls `reminder_nudge.notify_waiters()`. The scheduler loop selects on **both** lanes; the bus subscription queues, so an op landing mid-pass still forces the next pass. **Approvals do trigger the wake — reading (a) of the card is false.**

## The incident, reconstructed from the ledgers

- The same evening's earlier batch (20:07:27–20:07:29 approvals, floors already past) fired **the same second** plus the governed 30 s ladder (prepared 20:07:27.578 / 20:07:57 / 20:08:27) — live proof of approve-while-due firing within the governed slot.
- The "delayed" quartet's floors were **propose + 15:00**, still 10–15 minutes in the future at approval (20:18–20:19). The fires landed **13 ms** (20:28:10.698 vs floor .685) and **4 ms** (20:33:29.442 vs floor .438) after their floors — floor-honoring precision, zero latency.
- A daemon handover ran invisibly inside the wait: the old holder (gen 22, boot 19:02:42) drained; the new daemon (boot 20:13:03) fired as gen 23 — and still hit the floors to the millisecond.

## The codification

- **Nudge-leg unit test**: an accepted `approve_effect` completes a parked `reminder_nudged()` waiter.
- **Loop-leg test** (paused clock, first test to drive the real `spawn_reminder_scheduler` loop): an approve on an already-due manifest dispatches with **zero virtual delay** — a wake that waited for the 300 s safety tick would show as a ≥300 s virtual jump, so the pin is structural, not timing-flaky.
- Docs (`agenda-and-memory.md`): the event-driven contract, plus the honest deferral list — governor 30 s slots under contention, the no-overlap rule, drain/handover windows (60 s lease poll); the safety tick is a no-signal backstop, never the operating cadence.
- Code comments at the scheduler select and `reminder_nudged` name the contract and the one accepted wrinkle (policy edits ride the nudge alone; one landing exactly mid-pass waits a tick — presentation-cadence stakes only).