### PR TITLE
terminal: honest exited state with re-entry; overlap shell spawn with xterm load

### DIFF
--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -581,6 +581,16 @@ An embedded xterm.js terminal hosting an interactive **Shell** session on the
 daemon (or a selected peer). Session monitoring and control live in the
 Activity/Station tabs, not here.
 
+Entering the tab opens the PTY immediately — the shell's own startup runs
+while the lazily loaded xterm scripts fetch in parallel, with any output from
+that window buffered and replayed, so the first prompt is not serialized
+behind the script load. When the shell exits (Ctrl-D, `exit`, a crash) the
+pane says so with the exit status and offers the way back in: a **New shell**
+toolbar button, a press-Enter hint, and automatic re-open on the next visit
+to the tab. The daemon keeps the dead session's scrollback replayable until
+the next open replaces it with a fresh spawn (spawn rules apply — replacing
+requires `shell.spawn`, exactly like creating).
+
 ### Live display
 
 The Computer Use workspace combines a selected WebRTC stage with a live rail

--- a/src/bin/caller/terminal.rs
+++ b/src/bin/caller/terminal.rs
@@ -1578,6 +1578,70 @@ mod tests {
         expect_output(&mut rx2, Some("scroll_token_abc"), "scrollback replay").await;
     }
 
+    /// Drain `rx` until the shell's `Exited` event arrives, returning its
+    /// status. Panics loudly on deadline or channel close.
+    async fn expect_exited(rx: &mut TerminalListener, phase: &str) -> i32 {
+        let deadline = tokio::time::Instant::now() + OUTPUT_BUDGET;
+        loop {
+            match tokio::time::timeout_at(deadline, rx.recv()).await {
+                Ok(Some(TerminalEvent::Output(_))) => {}
+                Ok(Some(TerminalEvent::Exited { status })) => return status,
+                Ok(None) => panic!("{phase}: event channel closed before Exited"),
+                Err(_) => panic!("{phase}: no Exited within {OUTPUT_BUDGET:?}"),
+            }
+        }
+    }
+
+    /// The Ctrl-D / `exit` lifecycle the dashboard depends on: a session
+    /// whose shell exited stays visible (scrollback replayable) but is
+    /// REPLACED by the next open of the same key with a fresh, working
+    /// shell — the way back into a terminal after the old one dies.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn exited_session_is_replaced_by_next_open() {
+        let registry = TerminalRegistry::new(std::env::temp_dir());
+        let key = TerminalKey::local("respawn-after-exit");
+        let (first, created) = registry
+            .open_or_attach(key.clone(), 80, 24, &TerminalActor::Root, spawn_all())
+            .await
+            .unwrap();
+        assert!(created);
+        let mut rx = first.attach();
+        // Wait for the shell to paint before typing (startup can flush
+        // pending input — see open_attach_write_and_receive_output).
+        expect_output(&mut rx, None, "first shell startup").await;
+        first.write_input(b"exit\r");
+        expect_exited(&mut rx, "first shell exit").await;
+        assert!(!first.is_alive());
+
+        // Dead but still visible: the scrollback stays replayable until
+        // something replaces the session.
+        assert!(registry
+            .get_visible(&key, &TerminalActor::Root)
+            .await
+            .is_some());
+
+        // The next open of the same key replaces the dead session with a
+        // fresh spawn (replacement follows spawn rules, so `created`).
+        let (second, respawned) = registry
+            .open_or_attach(key.clone(), 80, 24, &TerminalActor::Root, spawn_all())
+            .await
+            .unwrap();
+        assert!(respawned, "a dead session must be replaced, not attached");
+        assert!(
+            !Arc::ptr_eq(&first, &second),
+            "the replacement is a new session"
+        );
+        assert!(second.is_alive());
+        assert_eq!(registry.len().await, 1);
+
+        // And the replacement is a working shell, not a husk.
+        let mut rx2 = second.attach();
+        expect_output(&mut rx2, None, "respawned shell startup").await;
+        second.write_input(b"echo respawn_ok_5173\r");
+        expect_output(&mut rx2, Some("respawn_ok_5173"), "respawned echo").await;
+        registry.close_visible(&key, &TerminalActor::Root).await;
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn open_or_attach_reuses_live_session() {
         let registry = TerminalRegistry::new(std::env::temp_dir());

--- a/src/bin/caller/web_gateway/static_assets.rs
+++ b/src/bin/caller/web_gateway/static_assets.rs
@@ -721,6 +721,36 @@ mod tests {
         assert!(text.ends_with("self.onmessage=null;\n"));
     }
 
+    /// The Terminal tab's honest exited lifecycle: when the shell dies
+    /// (Ctrl-D, `exit`, crash) the pane must SAY so — with the status —
+    /// and offer a visible way back in (the toolbar's New shell button
+    /// plus the in-terminal hint); and output racing the lazy xterm load
+    /// must be buffered, never dropped (the open is sent before the
+    /// scripts finish so shell startup overlaps the fetch). If a needle
+    /// disappears, the dashboard has regrown the dead-end or the blank
+    /// first paint these pinned away — restore the affordance, don't
+    /// widen the test.
+    #[test]
+    fn terminal_exited_reentry_and_early_open_are_pinned() {
+        assert_eq!(
+            APP_HTML.matches("id=\"shell-restart-btn\"").count(),
+            1,
+            "the Terminal toolbar must carry exactly one New shell re-entry button"
+        );
+        assert!(
+            APP_HTML.contains("[shell exited with status ${status}]"),
+            "the exited state must name the shell's exit status"
+        );
+        assert!(
+            APP_HTML.contains("[press Enter to start a new shell]"),
+            "the exited state must tell the user how to get a shell back"
+        );
+        assert!(
+            APP_HTML.contains("bufferPreInitShellEvent"),
+            "shell output arriving before xterm loads must be buffered, not dropped"
+        );
+    }
+
     /// Agent-authored question-preview HTML must only ever render inside
     /// a sandboxed iframe with an opaque origin. Dashboard authentication
     /// is ambient (mTLS client cert → IAM principal), so a same-origin

--- a/static/app.html
+++ b/static/app.html
@@ -10961,7 +10961,8 @@ html.ui-v2[data-theme="light"] .control-toast {
   padding: 4px 8px;
 }
 
-.shell-share-btn {
+.shell-share-btn,
+.shell-restart-btn {
   background: var(--bg-tertiary, #2a2a2e);
   color: var(--text-secondary, #b8b8bc);
   border: 1px solid var(--border-color, #3a3a3e);
@@ -10971,7 +10972,8 @@ html.ui-v2[data-theme="light"] .control-toast {
   cursor: pointer;
 }
 
-.shell-share-btn:hover {
+.shell-share-btn:hover,
+.shell-restart-btn:hover {
   color: var(--text-primary, #e8e8ec);
 }
 
@@ -16131,7 +16133,8 @@ html.ui-v2 .shell-host-status.error { color: var(--rose); }
 html.ui-v2 .shell-host-status.warn { color: var(--amber); }
 html.ui-v2 .shell-host-status.ok { color: var(--green); }
 
-html.ui-v2 .shell-share-btn {
+html.ui-v2 .shell-share-btn,
+html.ui-v2 .shell-restart-btn {
   min-height: 32px; /* match the 32px Target select — one control height per row */
   padding: 6px 12px;
   border: 1px solid var(--line);
@@ -16141,7 +16144,8 @@ html.ui-v2 .shell-share-btn {
   font: 600 12px var(--sans);
   transition: background var(--t-fast), border-color var(--t-fast), color var(--t-fast);
 }
-html.ui-v2 .shell-share-btn:hover {
+html.ui-v2 .shell-share-btn:hover,
+html.ui-v2 .shell-restart-btn:hover {
   background: var(--surface-2);
   border-color: var(--line-2);
   color: var(--text);
@@ -16150,6 +16154,17 @@ html.ui-v2 .shell-share-btn.is-shared {
   background: rgba(var(--green-rgb), .12);
   border-color: rgba(var(--green-rgb), .26);
   color: var(--green);
+}
+/* The re-entry affordance is the exited pane's one live control — accent
+   it so a dead terminal visibly offers the way back in. */
+html.ui-v2 .shell-restart-btn {
+  border-color: rgba(var(--iris-rgb), .38);
+  color: var(--iris);
+}
+html.ui-v2 .shell-restart-btn:hover {
+  background: rgba(var(--iris-rgb), .12);
+  border-color: rgba(var(--iris-rgb), .55);
+  color: var(--iris-2);
 }
 
 html.ui-v2 #tab-terminal .shell-toolbar .target-summary {
@@ -33634,6 +33649,7 @@ html.ui-v2 .daemon-relay-note {
             <label for="shell-host-select">Target</label>
             <select id="shell-host-select" title="Shell target"></select>
             <span class="shell-host-status" id="shell-host-status"></span>
+            <button id="shell-restart-btn" class="shell-restart-btn hidden" title="Start a fresh shell session">New shell</button>
             <button id="shell-share-btn" class="shell-share-btn hidden" title="Share this shell session so scoped collaborators (terminal.view / terminal.write) can attach">Share</button>
             <div id="shell-target-summary" class="target-summary" aria-live="polite"></div>
           </div>
@@ -38753,7 +38769,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '288b5774a1741a8f';
+const INTENDANT_APP_BUILD = '4566736e5019a6c1';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -46746,6 +46762,16 @@ let shellQueuedInput = '';
 let shellWaitingNoticeShown = false;
 let shellPendingResize = null;
 const SHELL_QUEUED_INPUT_MAX_BYTES = 64 * 1024;
+// Whether the toolbar's "New shell" re-entry affordance is showing (the
+// shell exited or the open errored; a sent open clears it).
+let shellRestartOffered = false;
+// Shell events (output/exit) that arrived before xterm.js finished
+// loading: the open frame is sent the moment the Terminal tab is entered
+// so the PTY's startup overlaps the script fetch, and nothing from that
+// window may be dropped. Bounded; oldest output falls off first.
+let shellPreInitEvents = [];
+let shellPreInitEventBytes = 0;
+const SHELL_PRE_INIT_MAX_BYTES = 512 * 1024;
 let activeTermSubtab = 'shell';
 
 // Files editor state. Declared here, far above the editor's functions,
@@ -83955,6 +83981,11 @@ function resetShellConnectionStateForHostChange() {
   shellPendingResize = null;
   shellOutputQueue = [];
   shellOutputQueuedBytes = 0;
+  // Buffered pre-init output belongs to the previous host; the exited/
+  // retry affordance does too.
+  shellPreInitEvents = [];
+  shellPreInitEventBytes = 0;
+  offerShellRestart(false);
 }
 
 function refreshShellHostOptions() {
@@ -84025,7 +84056,10 @@ function setShellHost(hostId) {
 // Called when the server sends {"t":"terminal_output", "data":"<base64>"}
 // for this host/terminal pair.
 function handleShellOutput(base64data) {
-  if (!shellTerm) return;
+  if (!shellTerm) {
+    bufferPreInitShellEvent({ kind: 'output', data: base64data });
+    return;
+  }
   const bytes = base64ToBytes(base64data);
   shellOutputQueue.push(bytes);
   shellOutputQueuedBytes += bytes.byteLength;
@@ -84063,21 +84097,72 @@ function flushShellOutput() {
   shellTerm.write(merged);
 }
 
+// ── Pre-init event buffer ──
+// initShell sends terminal_open before the xterm scripts have loaded (the
+// PTY's shell startup then overlaps the fetch). Output or an exit landing
+// in that window is held here — bounded, oldest output dropped first —
+// and replayed into xterm by initShell's start().
+function bufferPreInitShellEvent(evt) {
+  if (evt.kind === 'output') shellPreInitEventBytes += evt.data.length;
+  shellPreInitEvents.push(evt);
+  while (shellPreInitEventBytes > SHELL_PRE_INIT_MAX_BYTES && shellPreInitEvents.length > 1) {
+    const dropped = shellPreInitEvents.shift();
+    if (dropped.kind === 'output') shellPreInitEventBytes -= dropped.data.length;
+  }
+}
+
+function flushPreInitShellEvents() {
+  if (!shellTerm || shellPreInitEvents.length === 0) return;
+  const events = shellPreInitEvents;
+  shellPreInitEvents = [];
+  shellPreInitEventBytes = 0;
+  for (const evt of events) {
+    if (evt.kind === 'output') handleShellOutput(evt.data);
+    else if (evt.kind === 'exited') handleShellExited(evt.status);
+  }
+}
+
 function handleShellExited(status) {
-  if (!shellTerm) return;
+  if (!shellTerm) {
+    bufferPreInitShellEvent({ kind: 'exited', status });
+    return;
+  }
   flushShellOutput();
   shellTerm.write(`\r\n\x1b[33m[shell exited with status ${status}]\x1b[0m\r\n`);
-  setShellHostStatus(`Shell exited on ${shellHostLabel()}`, 'warn');
+  shellTerm.write('\x1b[90m[press Enter to start a new shell]\x1b[0m\r\n');
+  setShellHostStatus(`Shell exited (status ${status}) on ${shellHostLabel()}`, 'warn');
   shellOpenSent = false;
   shellOpenAcked = false;
   shellQueuedInput = '';
   shellWaitingNoticeShown = false;
+  offerShellRestart(true);
+}
+
+// ── Shell re-entry (exited state) ──
+// The dead session stays replayable server-side until the next open
+// replaces it with a fresh spawn (terminal.rs open_or_attach). Typing has
+// always re-opened; the button and the in-terminal hint make the way back
+// in visible instead of a hidden gesture.
+function offerShellRestart(on) {
+  shellRestartOffered = !!on;
+  const btn = document.getElementById('shell-restart-btn');
+  if (btn) btn.classList.toggle('hidden', !shellRestartOffered);
+}
+
+function restartShellSession() {
+  if (!shellInitialized) {
+    initShell();
+    return;
+  }
+  openShellSessionIfPossible();
+  if (shellTerm) shellTerm.focus();
 }
 
 function handleShellOpened(ack) {
   shellOpenSent = true;
   shellOpenAcked = true;
   shellWaitingNoticeShown = false;
+  offerShellRestart(false);
   shellShared = !!(ack && ack.shared);
   shellCanShare = !!(ack && ack.can_share);
   renderShellShareState();
@@ -84128,6 +84213,9 @@ function handleShellError(error) {
     const message = String(error || 'shell unavailable');
     shellTerm.write(`\r\n\x1b[31m[shell error: ${message}]\x1b[0m\r\n`);
   }
+  // The open failed or the session broke: the button doubles as the
+  // visible retry (clicking sends a fresh terminal_open).
+  offerShellRestart(true);
 }
 
 function showShellWaitingNotice() {
@@ -84577,13 +84665,18 @@ function queueShellInput(bytes) {
 }
 
 function openShellSessionIfPossible(force = false) {
-  if (!shellTerm) return false;
+  // shellInitialized (not shellTerm): the open is sent as soon as the
+  // Terminal tab is entered, before the xterm scripts finish loading —
+  // shellOpenFrame falls back to 80x24 and the post-ack resize corrects.
+  if (!shellInitialized) return false;
   if (shellOpenSent && !force) return true;
   const sent = sendShellMessage(shellOpenFrame());
   if (sent) {
     shellOpenSent = true;
     shellOpenAcked = false;
     shellWaitingNoticeShown = false;
+    offerShellRestart(false);
+    setShellHostStatus(`Connecting to ${shellHostLabel()}…`, '');
     return true;
   }
   shellOpenSent = false;
@@ -84593,7 +84686,7 @@ function openShellSessionIfPossible(force = false) {
 
 function maybeOpenShellAfterTransportReady() {
   if (activeTab !== 'terminal' || activeTermSubtab !== 'shell') return;
-  if (!shellInitialized || !shellTerm || shellOpenSent) return;
+  if (!shellInitialized || shellOpenSent) return;
   openShellSessionIfPossible();
 }
 
@@ -84708,6 +84801,15 @@ function initShell() {
   // Ensure the xterm.js stylesheet is active.
   document.getElementById('xterm-css').removeAttribute('disabled');
 
+  // Ask the server to open (or reattach to) the session NOW, before the
+  // xterm scripts load, so the shell's own startup (login rc files are
+  // the slow part) overlaps the fetch instead of following it. Output
+  // that beats the scripts lands in the pre-init buffer and replays in
+  // start(). In Connect mode the dashboard-control tunnel may still be
+  // negotiating; if so, this is retried from
+  // dashboardUpdateTransportStatus() once terminal frames are ready.
+  openShellSessionIfPossible();
+
   const start = () => {
     // Theme from the design tokens (blinking block cursor per the
     // design); `|| undefined` keeps xterm's built-in default as the net
@@ -84781,31 +84883,41 @@ function initShell() {
       }
     }).observe(document.getElementById('shell-container'));
 
-    // Ask the server to open (or reattach to) the session. In Connect mode the
-    // dashboard-control tunnel may still be negotiating; if so, this is retried
-    // from dashboardUpdateTransportStatus() once terminal frames are ready.
+    // Replay everything the early open produced while the scripts loaded,
+    // then re-ask in case the early send found no transport (no-op when
+    // the open is already in flight or acked).
+    flushPreInitShellEvents();
     openShellSessionIfPossible();
   };
 
   // If xterm.js is already loaded, start immediately. Otherwise load the
-  // vendored copies (embedded static assets — no external fetch) and start.
+  // vendored copies (embedded static assets — no external fetch) in
+  // PARALLEL — the fit addon's UMD wrapper only touches Terminal when an
+  // addon instance is loaded, not at parse time — and start once both are
+  // in.
   if (typeof Terminal !== 'undefined' && typeof FitAddon !== 'undefined') {
     start();
     return;
   }
-  const script = document.createElement('script');
-  script.src = '/xterm.min.js';
-  script.onload = () => {
-    const fitScript = document.createElement('script');
-    fitScript.src = '/xterm-addon-fit.min.js';
-    fitScript.onload = start;
-    document.head.appendChild(fitScript);
+  let scriptsRemaining = 2;
+  const scriptArrived = () => {
+    scriptsRemaining -= 1;
+    if (scriptsRemaining === 0) start();
   };
-  document.head.appendChild(script);
+  for (const src of ['/xterm.min.js', '/xterm-addon-fit.min.js']) {
+    const script = document.createElement('script');
+    script.src = src;
+    script.onload = scriptArrived;
+    document.head.appendChild(script);
+  }
 }
 
 function switchTerminalSubtab(name) {
   if (activeTermSubtab === name) {
+    // Re-entering the already-active Shell sub-tab: if the shell exited
+    // while the user was away, this is the respawn seam (no-op when a
+    // session is already open).
+    if (name === 'shell' && shellInitialized) openShellSessionIfPossible();
     syncTerminalPaneAccessibility();
     return;
   }
@@ -84984,6 +85096,7 @@ document.addEventListener('DOMContentLoaded', wireShellKeybar);
 document.addEventListener('DOMContentLoaded', () => {
   syncTerminalPaneAccessibility();
   refreshShellHostOptions();
+  document.getElementById('shell-restart-btn')?.addEventListener('click', restartShellSession);
 });
 document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('[data-shared-view-close]').forEach(btn => {
@@ -107589,6 +107702,9 @@ function switchTab(tabId) {
   if (tabId === 'terminal') {
     if (activeTermSubtab === 'shell') {
       if (!shellInitialized) initShell();
+      // Revisit seam: if the shell exited while the tab was hidden, this
+      // spawns a fresh one (no-op when a session is already open).
+      else openShellSessionIfPossible();
       if (shellTerm) requestAnimationFrame(() => shellFitAddon && shellFitAddon.fit());
     }
     syncTerminalPaneAccessibility();

--- a/static/app/13-styles-sessions-terminal.css
+++ b/static/app/13-styles-sessions-terminal.css
@@ -3250,7 +3250,8 @@ html.ui-v2[data-theme="light"] .control-toast {
   padding: 4px 8px;
 }
 
-.shell-share-btn {
+.shell-share-btn,
+.shell-restart-btn {
   background: var(--bg-tertiary, #2a2a2e);
   color: var(--text-secondary, #b8b8bc);
   border: 1px solid var(--border-color, #3a3a3e);
@@ -3260,7 +3261,8 @@ html.ui-v2[data-theme="light"] .control-toast {
   cursor: pointer;
 }
 
-.shell-share-btn:hover {
+.shell-share-btn:hover,
+.shell-restart-btn:hover {
   color: var(--text-primary, #e8e8ec);
 }
 

--- a/static/app/20-shell.html
+++ b/static/app/20-shell.html
@@ -1238,6 +1238,7 @@
             <label for="shell-host-select">Target</label>
             <select id="shell-host-select" title="Shell target"></select>
             <span class="shell-host-status" id="shell-host-status"></span>
+            <button id="shell-restart-btn" class="shell-restart-btn hidden" title="Start a fresh shell session">New shell</button>
             <button id="shell-share-btn" class="shell-share-btn hidden" title="Share this shell session so scoped collaborators (terminal.view / terminal.write) can attach">Share</button>
             <div id="shell-target-summary" class="target-summary" aria-live="polite"></div>
           </div>

--- a/static/app/32-vault-custody.js
+++ b/static/app/32-vault-custody.js
@@ -4180,6 +4180,16 @@ let shellQueuedInput = '';
 let shellWaitingNoticeShown = false;
 let shellPendingResize = null;
 const SHELL_QUEUED_INPUT_MAX_BYTES = 64 * 1024;
+// Whether the toolbar's "New shell" re-entry affordance is showing (the
+// shell exited or the open errored; a sent open clears it).
+let shellRestartOffered = false;
+// Shell events (output/exit) that arrived before xterm.js finished
+// loading: the open frame is sent the moment the Terminal tab is entered
+// so the PTY's startup overlaps the script fetch, and nothing from that
+// window may be dropped. Bounded; oldest output falls off first.
+let shellPreInitEvents = [];
+let shellPreInitEventBytes = 0;
+const SHELL_PRE_INIT_MAX_BYTES = 512 * 1024;
 let activeTermSubtab = 'shell';
 
 // Files editor state. Declared here, far above the editor's functions,

--- a/static/app/43-access-panes.js
+++ b/static/app/43-access-panes.js
@@ -2660,6 +2660,11 @@ function resetShellConnectionStateForHostChange() {
   shellPendingResize = null;
   shellOutputQueue = [];
   shellOutputQueuedBytes = 0;
+  // Buffered pre-init output belongs to the previous host; the exited/
+  // retry affordance does too.
+  shellPreInitEvents = [];
+  shellPreInitEventBytes = 0;
+  offerShellRestart(false);
 }
 
 function refreshShellHostOptions() {

--- a/static/app/44-shell-frames.js
+++ b/static/app/44-shell-frames.js
@@ -2,7 +2,10 @@
 // Called when the server sends {"t":"terminal_output", "data":"<base64>"}
 // for this host/terminal pair.
 function handleShellOutput(base64data) {
-  if (!shellTerm) return;
+  if (!shellTerm) {
+    bufferPreInitShellEvent({ kind: 'output', data: base64data });
+    return;
+  }
   const bytes = base64ToBytes(base64data);
   shellOutputQueue.push(bytes);
   shellOutputQueuedBytes += bytes.byteLength;
@@ -40,21 +43,72 @@ function flushShellOutput() {
   shellTerm.write(merged);
 }
 
+// ── Pre-init event buffer ──
+// initShell sends terminal_open before the xterm scripts have loaded (the
+// PTY's shell startup then overlaps the fetch). Output or an exit landing
+// in that window is held here — bounded, oldest output dropped first —
+// and replayed into xterm by initShell's start().
+function bufferPreInitShellEvent(evt) {
+  if (evt.kind === 'output') shellPreInitEventBytes += evt.data.length;
+  shellPreInitEvents.push(evt);
+  while (shellPreInitEventBytes > SHELL_PRE_INIT_MAX_BYTES && shellPreInitEvents.length > 1) {
+    const dropped = shellPreInitEvents.shift();
+    if (dropped.kind === 'output') shellPreInitEventBytes -= dropped.data.length;
+  }
+}
+
+function flushPreInitShellEvents() {
+  if (!shellTerm || shellPreInitEvents.length === 0) return;
+  const events = shellPreInitEvents;
+  shellPreInitEvents = [];
+  shellPreInitEventBytes = 0;
+  for (const evt of events) {
+    if (evt.kind === 'output') handleShellOutput(evt.data);
+    else if (evt.kind === 'exited') handleShellExited(evt.status);
+  }
+}
+
 function handleShellExited(status) {
-  if (!shellTerm) return;
+  if (!shellTerm) {
+    bufferPreInitShellEvent({ kind: 'exited', status });
+    return;
+  }
   flushShellOutput();
   shellTerm.write(`\r\n\x1b[33m[shell exited with status ${status}]\x1b[0m\r\n`);
-  setShellHostStatus(`Shell exited on ${shellHostLabel()}`, 'warn');
+  shellTerm.write('\x1b[90m[press Enter to start a new shell]\x1b[0m\r\n');
+  setShellHostStatus(`Shell exited (status ${status}) on ${shellHostLabel()}`, 'warn');
   shellOpenSent = false;
   shellOpenAcked = false;
   shellQueuedInput = '';
   shellWaitingNoticeShown = false;
+  offerShellRestart(true);
+}
+
+// ── Shell re-entry (exited state) ──
+// The dead session stays replayable server-side until the next open
+// replaces it with a fresh spawn (terminal.rs open_or_attach). Typing has
+// always re-opened; the button and the in-terminal hint make the way back
+// in visible instead of a hidden gesture.
+function offerShellRestart(on) {
+  shellRestartOffered = !!on;
+  const btn = document.getElementById('shell-restart-btn');
+  if (btn) btn.classList.toggle('hidden', !shellRestartOffered);
+}
+
+function restartShellSession() {
+  if (!shellInitialized) {
+    initShell();
+    return;
+  }
+  openShellSessionIfPossible();
+  if (shellTerm) shellTerm.focus();
 }
 
 function handleShellOpened(ack) {
   shellOpenSent = true;
   shellOpenAcked = true;
   shellWaitingNoticeShown = false;
+  offerShellRestart(false);
   shellShared = !!(ack && ack.shared);
   shellCanShare = !!(ack && ack.can_share);
   renderShellShareState();
@@ -105,6 +159,9 @@ function handleShellError(error) {
     const message = String(error || 'shell unavailable');
     shellTerm.write(`\r\n\x1b[31m[shell error: ${message}]\x1b[0m\r\n`);
   }
+  // The open failed or the session broke: the button doubles as the
+  // visible retry (clicking sends a fresh terminal_open).
+  offerShellRestart(true);
 }
 
 function showShellWaitingNotice() {
@@ -554,13 +611,18 @@ function queueShellInput(bytes) {
 }
 
 function openShellSessionIfPossible(force = false) {
-  if (!shellTerm) return false;
+  // shellInitialized (not shellTerm): the open is sent as soon as the
+  // Terminal tab is entered, before the xterm scripts finish loading —
+  // shellOpenFrame falls back to 80x24 and the post-ack resize corrects.
+  if (!shellInitialized) return false;
   if (shellOpenSent && !force) return true;
   const sent = sendShellMessage(shellOpenFrame());
   if (sent) {
     shellOpenSent = true;
     shellOpenAcked = false;
     shellWaitingNoticeShown = false;
+    offerShellRestart(false);
+    setShellHostStatus(`Connecting to ${shellHostLabel()}…`, '');
     return true;
   }
   shellOpenSent = false;
@@ -570,7 +632,7 @@ function openShellSessionIfPossible(force = false) {
 
 function maybeOpenShellAfterTransportReady() {
   if (activeTab !== 'terminal' || activeTermSubtab !== 'shell') return;
-  if (!shellInitialized || !shellTerm || shellOpenSent) return;
+  if (!shellInitialized || shellOpenSent) return;
   openShellSessionIfPossible();
 }
 
@@ -685,6 +747,15 @@ function initShell() {
   // Ensure the xterm.js stylesheet is active.
   document.getElementById('xterm-css').removeAttribute('disabled');
 
+  // Ask the server to open (or reattach to) the session NOW, before the
+  // xterm scripts load, so the shell's own startup (login rc files are
+  // the slow part) overlaps the fetch instead of following it. Output
+  // that beats the scripts lands in the pre-init buffer and replays in
+  // start(). In Connect mode the dashboard-control tunnel may still be
+  // negotiating; if so, this is retried from
+  // dashboardUpdateTransportStatus() once terminal frames are ready.
+  openShellSessionIfPossible();
+
   const start = () => {
     // Theme from the design tokens (blinking block cursor per the
     // design); `|| undefined` keeps xterm's built-in default as the net
@@ -758,31 +829,41 @@ function initShell() {
       }
     }).observe(document.getElementById('shell-container'));
 
-    // Ask the server to open (or reattach to) the session. In Connect mode the
-    // dashboard-control tunnel may still be negotiating; if so, this is retried
-    // from dashboardUpdateTransportStatus() once terminal frames are ready.
+    // Replay everything the early open produced while the scripts loaded,
+    // then re-ask in case the early send found no transport (no-op when
+    // the open is already in flight or acked).
+    flushPreInitShellEvents();
     openShellSessionIfPossible();
   };
 
   // If xterm.js is already loaded, start immediately. Otherwise load the
-  // vendored copies (embedded static assets — no external fetch) and start.
+  // vendored copies (embedded static assets — no external fetch) in
+  // PARALLEL — the fit addon's UMD wrapper only touches Terminal when an
+  // addon instance is loaded, not at parse time — and start once both are
+  // in.
   if (typeof Terminal !== 'undefined' && typeof FitAddon !== 'undefined') {
     start();
     return;
   }
-  const script = document.createElement('script');
-  script.src = '/xterm.min.js';
-  script.onload = () => {
-    const fitScript = document.createElement('script');
-    fitScript.src = '/xterm-addon-fit.min.js';
-    fitScript.onload = start;
-    document.head.appendChild(fitScript);
+  let scriptsRemaining = 2;
+  const scriptArrived = () => {
+    scriptsRemaining -= 1;
+    if (scriptsRemaining === 0) start();
   };
-  document.head.appendChild(script);
+  for (const src of ['/xterm.min.js', '/xterm-addon-fit.min.js']) {
+    const script = document.createElement('script');
+    script.src = src;
+    script.onload = scriptArrived;
+    document.head.appendChild(script);
+  }
 }
 
 function switchTerminalSubtab(name) {
   if (activeTermSubtab === name) {
+    // Re-entering the already-active Shell sub-tab: if the shell exited
+    // while the user was away, this is the respawn seam (no-op when a
+    // session is already open).
+    if (name === 'shell' && shellInitialized) openShellSessionIfPossible();
     syncTerminalPaneAccessibility();
     return;
   }
@@ -961,6 +1042,7 @@ document.addEventListener('DOMContentLoaded', wireShellKeybar);
 document.addEventListener('DOMContentLoaded', () => {
   syncTerminalPaneAccessibility();
   refreshShellHostOptions();
+  document.getElementById('shell-restart-btn')?.addEventListener('click', restartShellSession);
 });
 document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('[data-shared-view-close]').forEach(btn => {

--- a/static/app/48-router-settings.js
+++ b/static/app/48-router-settings.js
@@ -274,6 +274,9 @@ function switchTab(tabId) {
   if (tabId === 'terminal') {
     if (activeTermSubtab === 'shell') {
       if (!shellInitialized) initShell();
+      // Revisit seam: if the shell exited while the tab was hidden, this
+      // spawns a fresh one (no-op when a session is already open).
+      else openShellSessionIfPossible();
       if (shellTerm) requestAnimationFrame(() => shellFitAddon && shellFitAddon.fit());
     }
     syncTerminalPaneAccessibility();

--- a/static/app/ui2-terminal-files.css
+++ b/static/app/ui2-terminal-files.css
@@ -100,7 +100,8 @@ html.ui-v2 .shell-host-status.error { color: var(--rose); }
 html.ui-v2 .shell-host-status.warn { color: var(--amber); }
 html.ui-v2 .shell-host-status.ok { color: var(--green); }
 
-html.ui-v2 .shell-share-btn {
+html.ui-v2 .shell-share-btn,
+html.ui-v2 .shell-restart-btn {
   min-height: 32px; /* match the 32px Target select — one control height per row */
   padding: 6px 12px;
   border: 1px solid var(--line);
@@ -110,7 +111,8 @@ html.ui-v2 .shell-share-btn {
   font: 600 12px var(--sans);
   transition: background var(--t-fast), border-color var(--t-fast), color var(--t-fast);
 }
-html.ui-v2 .shell-share-btn:hover {
+html.ui-v2 .shell-share-btn:hover,
+html.ui-v2 .shell-restart-btn:hover {
   background: var(--surface-2);
   border-color: var(--line-2);
   color: var(--text);
@@ -119,6 +121,17 @@ html.ui-v2 .shell-share-btn.is-shared {
   background: rgba(var(--green-rgb), .12);
   border-color: rgba(var(--green-rgb), .26);
   color: var(--green);
+}
+/* The re-entry affordance is the exited pane's one live control — accent
+   it so a dead terminal visibly offers the way back in. */
+html.ui-v2 .shell-restart-btn {
+  border-color: rgba(var(--iris-rgb), .38);
+  color: var(--iris);
+}
+html.ui-v2 .shell-restart-btn:hover {
+  background: rgba(var(--iris-rgb), .12);
+  border-color: rgba(var(--iris-rgb), .55);
+  color: var(--iris-2);
 }
 
 html.ui-v2 #tab-terminal .shell-toolbar .target-summary {


### PR DESCRIPTION
The Terminal tab had two owner-reported defects:

- Slow first paint: initShell loaded xterm.min.js then the fit addon
  serially, and only then sent terminal_open — so the login shell's rc
  startup ran strictly after the script fetch, with a blank pane and an
  empty status line throughout. The open now goes out the moment the tab
  is entered (80x24 until the post-ack resize), the two vendored scripts
  load in parallel, output racing the scripts lands in a bounded
  pre-init buffer that replays into xterm, and the status line says
  Connecting immediately.

- Dead end after Ctrl-D: the registry has always replaced dead sessions
  on the next open, and typing quietly re-opened, but nothing said so —
  the pane looked permanently dead and revisiting the tab never
  re-opened. The exited state now names the exit status, prints a
  press-Enter hint, and shows an accented New shell button; re-entering
  the tab (or sub-tab) re-opens automatically, and the button doubles as
  the retry affordance after terminal_error.

Pinned by a registry lifecycle test (exited session replaced by a fresh
working spawn on the same key) and APP_HTML needle assertions on the
re-entry affordance and the pre-init buffer.
