### PR TITLE
CI: repair Windows test portability and radar race

### DIFF
--- a/src/bin/caller/agenda/definitions.rs
+++ b/src/bin/caller/agenda/definitions.rs
@@ -1656,7 +1656,9 @@ mod tests {
         let err = resolve_definition(root.path(), "no-such").unwrap_err();
         assert!(err.contains("no definition named"), "{err}");
         // Explicit paths must be .../SKILL.md.
-        let err = resolve_definition(root.path(), "file:/tmp/definition.md").unwrap_err();
+        let wrong_name = root.path().join("definition.md");
+        let selector = format!("file:{}", wrong_name.display());
+        let err = resolve_definition(root.path(), &selector).unwrap_err();
         assert!(err.contains("SKILL.md"), "{err}");
     }
 
@@ -1666,7 +1668,10 @@ mod tests {
     /// parsed house definitions.
     #[test]
     fn docs_walkthrough_blocks_byte_match_the_house_files() {
-        let docs = include_str!("../../../../docs/src/agenda-and-memory.md");
+        // Actions checkout may materialize tracked text as CRLF on
+        // Windows. The prose comparison is line-oriented, so normalize
+        // the checkout representation before locating Markdown fences.
+        let docs = include_str!("../../../../docs/src/agenda-and-memory.md").replace("\r\n", "\n");
         let block_after = |header: &str| -> &str {
             let at = docs.find(header).expect("docs section header present");
             let open = docs[at..].find("```text\n").expect("fenced block") + at + 8;

--- a/src/bin/caller/agenda/store.rs
+++ b/src/bin/caller/agenda/store.rs
@@ -7519,9 +7519,13 @@ mod tests {
         assert_eq!(std::fs::read_to_string(&blob).unwrap(), embedded);
         let effect = &item.effects[0];
         assert_eq!(effect.manifest.binding_refs[0].sha256, outcome.sha256);
-        assert!(effect.manifest.binding_refs[0]
+        let locator_path = effect.manifest.binding_refs[0]
             .locator
-            .ends_with(".house/triage/SKILL.md"));
+            .strip_prefix(super::super::types::BINDING_REF_FILE_SCHEME)
+            .expect("file binding-ref scheme");
+        assert!(
+            Path::new(locator_path).ends_with(Path::new(".house").join("triage").join("SKILL.md"))
+        );
         // The cadence prefill rode the manifest through the ordinary
         // intake: weekly, suspend after 3.
         let recurrence = effect.manifest.recurrence.expect("cadenced action");
@@ -7714,12 +7718,13 @@ mod tests {
                 .contains("recurrence cadence floors at 15 minutes"),
             "{err}"
         );
-        let (_root, mut store) = stamp_rig();
+        let (root, mut store) = stamp_rig();
+        let missing_project = root.path().join("definitely-not-a-dir");
         let err = store
             .apply_stamp_command(
                 AgendaCommand::Stamp {
                     definition: "triage".into(),
-                    project_root: Some("/definitely/not/a/dir".into()),
+                    project_root: Some(missing_project.display().to_string()),
                     fire_at_ms: None,
                     every_ms: None,
                     suspend_after: None,
@@ -7738,11 +7743,12 @@ mod tests {
         // append-only history, nothing rolls back silently.
         let (_root3, store3) = {
             let (r, mut s) = stamp_rig();
+            let missing_project = r.path().join("definitely-not-a-dir");
             let _ = s
                 .apply_stamp_command(
                     AgendaCommand::Stamp {
                         definition: "triage".into(),
-                        project_root: Some("/definitely/not/a/dir".into()),
+                        project_root: Some(missing_project.display().to_string()),
                         fire_at_ms: None,
                         every_ms: None,
                         suspend_after: None,

--- a/src/bin/caller/external_agent/kimi_code/bridge.rs
+++ b/src/bin/caller/external_agent/kimi_code/bridge.rs
@@ -2126,7 +2126,9 @@ mod tests {
         assert_eq!(
             index[0]["sessionDir"],
             child
-                .join("sessions/wd/session_parent")
+                .join("sessions")
+                .join("wd")
+                .join("session_parent")
                 .to_string_lossy()
                 .as_ref()
         );
@@ -2506,7 +2508,9 @@ mod tests {
         assert_eq!(
             index[0]["sessionDir"],
             primary
-                .join("sessions/workspace/session")
+                .join("sessions")
+                .join("workspace")
+                .join("session")
                 .to_string_lossy()
                 .as_ref()
         );

--- a/src/bin/caller/remote_compute/source.rs
+++ b/src/bin/caller/remote_compute/source.rs
@@ -1195,6 +1195,9 @@ mod tests {
     fn base_repo() -> (tempfile::TempDir, String) {
         let dir = tempfile::tempdir().unwrap();
         git(dir.path(), &["init", "--quiet"]);
+        // Tests own the bytes they write. Do not let a machine-wide Git
+        // setting rewrite LF fixtures to CRLF in derived worktrees.
+        git(dir.path(), &["config", "core.autocrlf", "false"]);
         std::fs::write(dir.path().join("tracked.txt"), "base\n").unwrap();
         git(dir.path(), &["add", "tracked.txt"]);
         git(
@@ -1222,6 +1225,7 @@ mod tests {
             worker.path(),
             &["clone", "--quiet", home.path().to_str().unwrap(), "."],
         );
+        git(worker.path(), &["config", "core.autocrlf", "false"]);
 
         std::fs::write(home.path().join("tracked.txt"), "changed\n").unwrap();
         std::fs::write(home.path().join("new.txt"), "new\n").unwrap();
@@ -1310,6 +1314,7 @@ mod tests {
             worker.path(),
             &["clone", "--quiet", home.path().to_str().unwrap(), "."],
         );
+        git(worker.path(), &["config", "core.autocrlf", "false"]);
         std::fs::write(home.path().join("tracked.txt"), "remote\n").unwrap();
         let snapshot = capture_working_tree(home.path(), Some(&revision)).unwrap();
         let sources = WorkerSources::new(worker.path().to_path_buf()).unwrap();

--- a/src/bin/caller/session_vitals_restore.rs
+++ b/src/bin/caller/session_vitals_restore.rs
@@ -1064,10 +1064,11 @@ mod tests {
     }
 
     fn user_line(mode: &str, cwd: &str, ts: &str) -> String {
+        let cwd = serde_json::to_string(cwd).expect("fixture cwd encodes as JSON");
         format!(
             concat!(
                 r#"{{"parentUuid":null,"isSidechain":false,"type":"user","permissionMode":"{mode}","#,
-                r#""cwd":"{cwd}","sessionId":"cc-1","version":"2.1.217","timestamp":"{ts}","#,
+                r#""cwd":{cwd},"sessionId":"cc-1","version":"2.1.217","timestamp":"{ts}","#,
                 r#""message":{{"role":"user","content":"do the thing"}}}}"#,
             ),
             mode = mode,
@@ -1849,7 +1850,11 @@ mod tests {
                 ),
                 assistant_line("claude-fable-5", "max", "2026-07-22T07:10:00Z", false).replace(
                     "\"cwd\":\"/repo\"",
-                    &format!("\"cwd\":\"{}\"", worktree.display()),
+                    &format!(
+                        "\"cwd\":{}",
+                        serde_json::to_string(&worktree.to_string_lossy())
+                            .expect("fixture cwd encodes as JSON")
+                    ),
                 ),
             ]
             .join("\n")

--- a/src/bin/caller/terminal.rs
+++ b/src/bin/caller/terminal.rs
@@ -22,7 +22,7 @@
 use std::collections::{HashMap, VecDeque};
 use std::io::{Read, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex as StdMutex};
+use std::sync::{Arc, Mutex as StdMutex, Weak};
 use std::time::Duration;
 
 use portable_pty::{native_pty_system, CommandBuilder as PtyCommandBuilder, MasterPty, PtySize};
@@ -723,9 +723,9 @@ impl OutputHub {
     }
 }
 
-/// A single live PTY-backed shell session. Internally shared via `Arc` so
-/// the reader task and any number of attached listeners can hold a
-/// reference without lifetime gymnastics.
+/// A single live PTY-backed shell session. Callers share it via `Arc`;
+/// the blocking reader keeps only a `Weak` reference so it cannot pin a
+/// killed ConPTY whose output pipe remains open until the master drops.
 pub struct PtySession {
     master: StdMutex<Box<dyn MasterPty + Send>>,
     writer: StdMutex<Box<dyn Write + Send>>,
@@ -855,7 +855,7 @@ impl PtySession {
 
         // Reader: dedicated OS thread (portable_pty's reader is blocking).
         // Copies bytes into scrollback and fans out to listeners.
-        let session_clone = session.clone();
+        let session_clone = Arc::downgrade(&session);
         std::thread::spawn(move || {
             Self::reader_loop(session_clone, reader, child);
         });
@@ -974,7 +974,7 @@ impl PtySession {
     }
 
     fn reader_loop(
-        session: Arc<Self>,
+        session: Weak<Self>,
         mut reader: Box<dyn Read + Send>,
         mut child: Box<dyn portable_pty::Child + Send + Sync>,
     ) {
@@ -986,6 +986,9 @@ impl PtySession {
             match reader.read(&mut buf) {
                 Ok(0) => break,
                 Ok(n) => {
+                    let Some(session) = session.upgrade() else {
+                        break;
+                    };
                     let chunk = &buf[..n];
                     // Answer ConPTY's startup cursor-position query so the shell
                     // doesn't block waiting for it (Windows only; no-op on Unix
@@ -1016,11 +1019,9 @@ impl PtySession {
             Ok(s) => s.exit_code() as i32,
             Err(_) => -1,
         };
-        if let Ok(mut alive) = session.alive.lock() {
-            *alive = false;
+        if let Some(session) = session.upgrade() {
+            session.mark_exited(status);
         }
-        let mut hub = session.output.lock().unwrap_or_else(|e| e.into_inner());
-        hub.fan_out_exit(status);
     }
 
     /// Write bytes to the PTY stdin. Silently drops if the writer has
@@ -1063,6 +1064,26 @@ impl PtySession {
             .lock()
             .unwrap_or_else(|err| err.into_inner());
         let _ = killer.kill();
+        drop(killer);
+        // ConPTY may retain its output pipe until the master handle is
+        // dropped, so its reader is not a reliable exit notifier after a
+        // forced kill. Publish the forced exit here; the reader's later
+        // observation is deduplicated by `mark_exited`.
+        self.mark_exited(-1);
+    }
+
+    fn mark_exited(&self, status: i32) {
+        let transitioned = if let Ok(mut alive) = self.alive.lock() {
+            let transitioned = *alive;
+            *alive = false;
+            transitioned
+        } else {
+            false
+        };
+        if transitioned {
+            let mut hub = self.output.lock().unwrap_or_else(|e| e.into_inner());
+            hub.fan_out_exit(status);
+        }
     }
 
     pub fn shared(&self) -> bool {
@@ -1101,10 +1122,13 @@ impl PtySession {
 
 impl Drop for PtySession {
     fn drop(&mut self) {
-        // The session (registry entry + reader thread) is gone: wake every
-        // parked listener so `recv` drains what's queued and returns
-        // `None` — the same end-of-stream the old dropped-sender channels
-        // signalled.
+        // The reader is deliberately weak: the last registry/listener
+        // owner dropping must stop the child and close the master PTY,
+        // which in turn releases a blocked ConPTY read.
+        self.terminate();
+        // Wake every parked listener so `recv` drains what's queued and
+        // returns `None` — the same end-of-stream the old dropped-sender
+        // channels signalled.
         if let Ok(hub) = self.output.lock() {
             hub.detach_all();
         }

--- a/src/bin/caller/terminal.rs
+++ b/src/bin/caller/terminal.rs
@@ -1459,8 +1459,8 @@ impl TerminalRegistry {
         }
         if let Some(SessionSlot::Live(session)) = guard.remove(key) {
             // Writing EOF (Ctrl-D) to the shell's stdin tells it to exit
-            // cleanly; if it ignores, the session is simply dropped and
-            // the reader thread hits read error → broadcasts Exited.
+            // cleanly; if it ignores, dropping the final owner invokes
+            // the forced-termination fallback and releases the master PTY.
             session.write_input(&[0x04]);
         }
         true

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -5317,17 +5317,25 @@ async fn coordination_radar_block_injects_as_a_pure_tail_append() {
     // The radar's deduplicated note is one acceptance surface of the
     // overlap. The rail transition below separately proves that the
     // same tick's snapshot has reached the in-process delivery seam.
-    poll_until(
+    let radar_note_id = poll_until(
         "a radar note for the fixture overlap",
         RUN_TIMEOUT,
         || {
             let notes_dir = space_dir.join("messages").join("daemon");
+            let writer_id = writer_id.clone();
             async move {
                 std::fs::read_dir(&notes_dir)
                     .ok()?
                     .flatten()
-                    .find(|e| e.file_name().to_string_lossy().starts_with("rn-"))
-                    .map(|_| ())
+                    .find_map(|entry| {
+                        let name = entry.file_name().to_string_lossy().to_string();
+                        if !name.starts_with("rn-") {
+                            return None;
+                        }
+                        let doc = std::fs::read_to_string(entry.path()).ok()?;
+                        doc.contains(&format!("\nto: {writer_id}\n"))
+                            .then(|| name.trim_end_matches(".md").to_string())
+                    })
             }
         },
         &daemon_log,
@@ -5424,7 +5432,9 @@ async fn coordination_radar_block_injects_as_a_pure_tail_append() {
     assert!(second_messages.len() > first_messages.len());
     let expected_block = format!(
         "[System] coordination v1 space={space_key}\n\
-         sessions: 2 active, 0 stale — s-fake-a(native), s-fake-b(native)"
+         sessions: 1 active, 0 stale — s-fake-p(native)\n\
+         ! overlap shared/hot.rs — with s-fake-p (declared)\n\
+         messages: 1 unread — from daemon: {radar_note_id}"
     );
     let tail_message = second_messages.last().expect("non-empty request");
     assert_eq!(tail_message["role"].as_str(), Some("user"));

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -5290,21 +5290,33 @@ async fn coordination_radar_block_injects_as_a_pure_tail_append() {
         .to_string_lossy()
         .to_string();
 
-    // Two fixture declarations sharing a dirty path: the §2.7 pair
-    // overlap the radar flags. Written AFTER round 1, so round 1's
-    // request predates any coordination signal by construction.
-    for id in ["s-fake-a", "s-fake-b"] {
-        let doc = format!(
-            "---\nv: 1\nkind: session-declaration\nid: {id}\nbackend: native\ncreated_ms: 1\n---\n\
-             ## intent\noccupying the same space\n\n## dirty\n- shared/hot.rs\n"
-        );
-        std::fs::write(space_dir.join("sessions").join(format!("{id}.md")), doc)
-            .expect("write fixture declaration");
-    }
-    // The radar's deduplicated note write is the tick-completion proof:
-    // once an rn-* note exists, the same tick's snapshot publish (which
-    // follows the note writes) is microseconds behind — long past by
-    // the time the steer round-trips below.
+    // Give the real session and one fixture peer the same dirty path.
+    // Written AFTER round 1, so round 1's request predates any
+    // coordination signal by construction. Involving the real session
+    // also gives the test a post-publication rail event to await below.
+    let writer_id = format!("s-{session_id}");
+    let own_declaration = space_dir.join("sessions").join(format!("{writer_id}.md"));
+    let mut own_doc =
+        std::fs::read_to_string(&own_declaration).expect("read the session's declaration");
+    assert!(
+        !own_doc.contains("## dirty"),
+        "fixture expects a clean declaration"
+    );
+    own_doc.push_str("\n## dirty\n- shared/hot.rs\n");
+    std::fs::write(&own_declaration, own_doc).expect("add the session fixture path");
+    let peer_id = "s-fake-peer";
+    let peer_doc = format!(
+        "---\nv: 1\nkind: session-declaration\nid: {peer_id}\nbackend: native\ncreated_ms: 1\n---\n\
+         ## intent\noccupying the same space\n\n## dirty\n- shared/hot.rs\n"
+    );
+    std::fs::write(
+        space_dir.join("sessions").join(format!("{peer_id}.md")),
+        peer_doc,
+    )
+    .expect("write fixture peer declaration");
+    // The radar's deduplicated note is one acceptance surface of the
+    // overlap. The rail transition below separately proves that the
+    // same tick's snapshot has reached the in-process delivery seam.
     poll_until(
         "a radar note for the fixture overlap",
         RUN_TIMEOUT,
@@ -5321,6 +5333,22 @@ async fn coordination_radar_block_injects_as_a_pure_tail_append() {
         &daemon_log,
     )
     .await;
+
+    // Radar notes are written before the in-process snapshot publish.
+    // Await the real session's rail transition too: that event is emitted
+    // after publish, so round 2 cannot race the few instructions between
+    // the note rename and the state becoming visible to the agent loop.
+    let raised = next_matching_ws_event(&mut ws, RUN_TIMEOUT, |json| {
+        json.get("event").and_then(|v| v.as_str()) == Some("coordination_radar")
+            && json.get("session_id").and_then(|v| v.as_str()) == Some(session_id.as_str())
+            && json.get("state").and_then(|v| v.as_str()) == Some("raised")
+    })
+    .await
+    .unwrap_or_else(|| panic!("radar flag never raised:\n{}", daemon_log()));
+    assert_eq!(
+        raised.get("id").and_then(|v| v.as_str()),
+        Some(space_key.as_str())
+    );
 
     // Round 2 via the parked-steer fallback; the mock's own transcript
     // expectation gates on the injected block.

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -5430,18 +5430,26 @@ async fn coordination_radar_block_injects_as_a_pure_tail_append() {
     let second_messages: Vec<serde_json::Value> =
         serde_json::from_str(second).expect("second request parses");
     assert!(second_messages.len() > first_messages.len());
-    let expected_block = format!(
+    let expected_core = format!(
         "[System] coordination v1 space={space_key}\n\
          sessions: 1 active, 0 stale — s-fake-p(native)\n\
-         ! overlap shared/hot.rs — with s-fake-p (declared)\n\
-         messages: 1 unread — from daemon: {radar_note_id}"
+         ! overlap shared/hot.rs — with s-fake-p (declared)"
     );
+    // The tick scans before it writes its radar note, then publishes the
+    // scanned snapshot. A fast round 2 therefore sees the overlap but not
+    // the note until the next scan; a slower platform may see both. The
+    // note poll above proves the separate acceptance surface, while this
+    // byte proof admits exactly those two ruled renderings.
+    let expected_with_note =
+        format!("{expected_core}\nmessages: 1 unread — from daemon: {radar_note_id}");
     let tail_message = second_messages.last().expect("non-empty request");
     assert_eq!(tail_message["role"].as_str(), Some("user"));
-    assert_eq!(
-        tail_message["content"].as_str(),
-        Some(expected_block.as_str()),
-        "the §2.2 block is the NEW tail message"
+    let actual_block = tail_message["content"]
+        .as_str()
+        .expect("the new tail message has text content");
+    assert!(
+        actual_block == expected_core || actual_block == expected_with_note,
+        "the §2.2 block is the NEW tail message:\n{actual_block}"
     );
     assert!(
         !first_messages.iter().any(|m| m["content"]
@@ -5459,7 +5467,7 @@ async fn coordination_radar_block_injects_as_a_pure_tail_append() {
         .join(&session_id);
     let rows = parsed_session_rows(&log_dir);
     let messages = canonical_message_rows(&rows);
-    let block_row = user_message_row(&messages, &expected_block);
+    let block_row = user_message_row(&messages, actual_block);
     assert_eq!(
         msg_field(block_row, "provenance").as_str(),
         Some("system_injection"),


### PR DESCRIPTION
## What

- make agenda, Kimi, remote-source, and session-vitals fixtures portable across Windows path and line-ending rules
- stop the PTY reader from pinning a killed ConPTY and publish forced exits exactly once
- make the coordination-radar e2e wait for the post-publication rail event before steering round two

## Why

The Windows merge-group run exposed ten package-bin failures that the old multi-command PowerShell step had been masking. The original visible failure was a separate race: the test observed the radar-note file before the in-process snapshot was published.

This PR makes the suite itself portable and removes that race. PR #754 then makes future package-bin failures fail the workflow honestly.

## Validation

- `cargo fmt --all`
- `git diff --check`
- `cargo check -p intendant --bin intendant --tests`
- PR checks: full Ubuntu unit/clippy/e2e/smoke lane green; macOS and Windows fast checks green
- physical Windows 11 host: all ten package-bin tests that failed in run 30732087163 pass, including the ConPTY cancellation regression
