### PR TITLE
Fix the park-then-die race: an armed limit park now outranks the terminal break

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -170,6 +170,12 @@ startup.
 | `INTENDANT_LOG_MESSAGES_JSON` | unset (off) | Write the per-turn full-conversation dump `turns/turn_NNN_messages.json`. Off by default — the context snapshot already archives the exact provider request. The dump is still written automatically, gate or no gate, when a provider cannot produce a request snapshot (mock/custom providers), so every turn keeps at least one exact input record |
 | `INTENDANT_CONTEXT_SNAPSHOT_KEEP_ALL` | unset (rotate) | Keep every per-turn context-snapshot sidecar instead of rotating to the latest one per (source, session id) stream. Debugging aid — latest-only rotation is what keeps per-session context disk O(1) instead of O(turns × context) |
 
+### Rate-limit park tuning
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `INTENDANT_LIMIT_PARK_JITTER_SECS` | unset (random 30–90) | Fixed jitter added to a rate-limit park's wake time, clamped to the 90s band maximum, replacing the random fleet-anti-stampede draw. An unparsable value keeps the random draw. The e2e suite pins the park wake-and-resume arc with `0`; setting it fleet-wide deliberately flattens the stampede protection |
+
 ### Process-plumbing variables
 
 Sub-agents no longer travel through the environment — they are supervised

--- a/src/bin/caller/boot_readopt.rs
+++ b/src/bin/caller/boot_readopt.rs
@@ -1219,7 +1219,12 @@ mod tests {
             })
         };
         write_meta(home.path(), "sess-race-resident", "running", armed_park());
-        write_meta(home.path(), "sess-race-backstop", "interrupted", armed_park());
+        write_meta(
+            home.path(),
+            "sess-race-backstop",
+            "interrupted",
+            armed_park(),
+        );
         write_meta(home.path(), "sess-prefix-strand", "completed", armed_park());
 
         let candidates = scan_store_candidates(home.path(), u64::MAX, &HashSet::new());

--- a/src/bin/caller/boot_readopt.rs
+++ b/src/bin/caller/boot_readopt.rs
@@ -252,7 +252,12 @@ pub(crate) struct ReadoptDispatch {
 /// drift): `running` (the daemon died with the turn in flight) and
 /// `interrupted` (a signal shutdown marked it on the way down) are
 /// mid-turn; a pending limit park is parked work; everything else is
-/// idle-in-idle-out.
+/// idle-in-idle-out. The `completed` exclusion on the park class is
+/// backed by session_end's park-then-die backstop: a session can no
+/// longer END as "completed" while its park marker owes pending work
+/// (session_end stamps "interrupted" over a stranded marker instead),
+/// so "completed" genuinely means no owed park — the exclusion guards
+/// against pre-backstop metas, not live strands.
 pub(crate) fn midwork_class(meta: &SessionMeta) -> Option<MidWorkClass> {
     let status = meta.status.as_deref().unwrap_or("");
     if matches!(status, "running" | "interrupted") {
@@ -1185,6 +1190,54 @@ mod tests {
         assert!(
             candidates.is_empty(),
             "idle/done sessions stay down: {candidates:?}"
+        );
+    }
+
+    /// Daemon-restart survival for the park-then-die race (card
+    /// 01KZ07Q0PX, specimen e883a2db): every durable shape the race can
+    /// leave behind is a boot readopt candidate.
+    ///
+    /// - The RESIDENT hold (the fix's primary lane): the session stays
+    ///   alive with the park armed, meta still carrying the last turn's
+    ///   "running" status plus the pending park — a daemon death
+    ///   mid-hold must enumerate it.
+    /// - The session_end backstop: a loop that nonetheless ends over a
+    ///   stranded pending park is stamped "interrupted", never
+    ///   "completed" — that shape must enumerate too.
+    /// - The pre-fix strand ("completed" + pending park, the literal
+    ///   b366d359 on-disk shape) stays EXCLUDED: session_end can no
+    ///   longer mint it, and historical strands were resolved by hand —
+    ///   resurrecting every old contradiction on each boot would be the
+    ///   new bug.
+    #[test]
+    fn park_then_die_race_metas_are_boot_candidates() {
+        let home = tempfile::tempdir().unwrap();
+        let armed_park = || {
+            Some(SessionLimitParkMeta {
+                resets_at_epoch: Some(now_secs() + 3600),
+                has_pending: true,
+            })
+        };
+        write_meta(home.path(), "sess-race-resident", "running", armed_park());
+        write_meta(home.path(), "sess-race-backstop", "interrupted", armed_park());
+        write_meta(home.path(), "sess-prefix-strand", "completed", armed_park());
+
+        let candidates = scan_store_candidates(home.path(), u64::MAX, &HashSet::new());
+        let ids: Vec<&str> = candidates
+            .iter()
+            .map(|candidate| candidate.session_id.as_str())
+            .collect();
+        assert!(
+            ids.contains(&"sess-race-resident"),
+            "a daemon death mid-hold leaves a readoptable meta: {ids:?}"
+        );
+        assert!(
+            ids.contains(&"sess-race-backstop"),
+            "the session_end backstop's interrupted stamp is readoptable: {ids:?}"
+        );
+        assert!(
+            !ids.contains(&"sess-prefix-strand"),
+            "pre-backstop completed strands stay excluded: {ids:?}"
         );
     }
 

--- a/src/bin/caller/external_mode.rs
+++ b/src/bin/caller/external_mode.rs
@@ -185,10 +185,6 @@ async fn apply_backend_credentials_reload(
             "{noun} cancelled for the credential reload — parked messages deliver after the respawn",
         ));
     }
-    let resume_id = stats
-        .announced_native_session_id
-        .clone()
-        .or_else(|| drain_config.backend_thread_id.clone());
     // The restart kills the old process's background children before the
     // fresh process exists: flip any parked-on tasks to died-with-restart
     // NOW, with this class's name, so the park never outlives its wake.
@@ -204,27 +200,20 @@ async fn apply_backend_credentials_reload(
         backend
     ));
     progress(crate::event::CredentialReloadProgress::Respawning);
-    if let Err(e) = agent.shutdown().await {
-        slog(session_log, |l| {
-            l.warn(&format!("Backend shutdown before credential reload: {e}"))
-        });
-    }
-    match create_external_agent(
+    match respawn_external_backend_in_place(
         backend,
         project,
-        session_log,
         web_port,
-        resume_id,
-        intendant_session_id.clone(),
-        session_agent_config.codex_service_tier.clone(),
-        session_agent_config.codex_home.clone(),
+        intendant_session_id,
+        session_agent_config,
+        stats,
+        agent,
+        event_rx,
+        drain_config,
     )
     .await
     {
-        Ok((new_agent, new_thread, new_event_rx)) => {
-            *agent = new_agent;
-            *event_rx = new_event_rx;
-            drain_config.backend_thread_id = Some(new_thread.thread_id.clone());
+        Ok(()) => {
             announce(
                 "Credential reload complete — the backend restarted on the fresh credential store",
             );
@@ -244,6 +233,54 @@ async fn apply_backend_credentials_reload(
             None
         }
     }
+}
+
+/// In-place backend respawn shared by the credential-reload lane and the
+/// park-wake lane: shut the old process down (a no-op when it already
+/// exited), re-create the agent resume-attached to the same backend
+/// session id, and swap the loop's live handles (agent, event stream,
+/// thread id). The caller owns the surrounding announcements and any
+/// park/queue bookkeeping — and must re-open its event-channel gate,
+/// since the swapped-in receiver is live again. `Err` carries the create
+/// failure; the old process is already gone then, so callers exit their
+/// lane honestly.
+#[allow(clippy::too_many_arguments)]
+async fn respawn_external_backend_in_place(
+    backend: &external_agent::AgentBackend,
+    project: &Project,
+    web_port: Option<u16>,
+    intendant_session_id: &Option<String>,
+    session_agent_config: &session_config::SessionAgentConfig,
+    stats: &LoopStats,
+    agent: &mut Box<dyn external_agent::ExternalAgent>,
+    event_rx: &mut tokio::sync::mpsc::UnboundedReceiver<external_agent::AgentEvent>,
+    drain_config: &mut DrainConfig<'_>,
+) -> Result<(), CallerError> {
+    let session_log = drain_config.session_log;
+    let resume_id = stats
+        .announced_native_session_id
+        .clone()
+        .or_else(|| drain_config.backend_thread_id.clone());
+    if let Err(e) = agent.shutdown().await {
+        slog(session_log, |l| {
+            l.warn(&format!("Backend shutdown before respawn: {e}"))
+        });
+    }
+    let (new_agent, new_thread, new_event_rx) = create_external_agent(
+        backend,
+        project,
+        session_log,
+        web_port,
+        resume_id,
+        intendant_session_id.clone(),
+        session_agent_config.codex_service_tier.clone(),
+        session_agent_config.codex_home.clone(),
+    )
+    .await?;
+    *agent = new_agent;
+    *event_rx = new_event_rx;
+    drain_config.backend_thread_id = Some(new_thread.thread_id.clone());
+    Ok(())
 }
 
 /// The named cause stamped on background tasks the credential-reload
@@ -622,6 +659,20 @@ pub(crate) async fn run_external_agent_mode(
     // the wire carries no reset time) and clears on any completed turn.
     let mut limit_park: Option<LimitParkState> = None;
     let mut limit_park_streak: u32 = 0;
+    // Whether the backend event channel still has a live sender. A park
+    // with owed work now holds through the backend's death (the
+    // park-then-die reconciliation), and a dead process's channel closes
+    // moments later — an ungated `recv()` on the closed channel would
+    // spin the idle select. Closed-while-parked flips this gate off; the
+    // respawn lanes (credential reload, park wake) flip it back on when
+    // they swap in a fresh receiver.
+    let mut event_channel_open = true;
+    // The event-bus-closed exit is the daemon tearing down, not this
+    // session's story ending: the exit backstop below must then leave the
+    // durable limit-park marker in place as the boot auto-readopt trace
+    // (exactly like a hard daemon death that never reaches the backstop),
+    // instead of cancelling the park like a deliberate session end.
+    let mut daemon_teardown_exit = false;
     // Consecutive transient-service-condition round deaths (the error
     // park's recovery-attempt counter): +1 each death, reset by a
     // completed turn or an explicit intervention (interrupt, reload) —
@@ -767,6 +818,7 @@ pub(crate) async fn run_external_agent_mode(
                     Some("credential reload could not respawn the backend".to_string());
                 break 'outer;
             };
+            event_channel_open = true;
             // When the reload's own interrupt cut the live turn, the
             // turn's driving message was consumed mid-delivery — nothing
             // re-drives it after the respawn, so the session would idle
@@ -912,6 +964,67 @@ pub(crate) async fn run_external_agent_mode(
                                     &pending,
                                 ) =>
                             {
+                                // A park can hold through the backend's own
+                                // death (the park-then-die reconciliation):
+                                // a wake that owes a delivery must respawn
+                                // a confirmed-dead backend resume-attached
+                                // FIRST, or the re-send would fail into the
+                                // dead process's stdin. The probe is
+                                // per-backend honest — only a confirmed
+                                // exit (or no process at all) answers true,
+                                // so a live backend is never replaced;
+                                // backends without the probe (everything
+                                // but Claude Code today) keep the direct
+                                // send, whose failure surfaces loudly
+                                // through the delivery lane.
+                                if agent.next_round_reads_fresh_credentials() {
+                                    match respawn_external_backend_in_place(
+                                        &backend,
+                                        &project,
+                                        web_port,
+                                        &intendant_session_id,
+                                        &session_agent_config,
+                                        &stats,
+                                        &mut agent,
+                                        &mut event_rx,
+                                        &mut drain_config,
+                                    )
+                                    .await
+                                    {
+                                        Ok(()) => {
+                                            event_channel_open = true;
+                                            let line = format!(
+                                                "{noun} elapsed with the backend gone — respawned {} resume-attached to deliver the parked message",
+                                                backend
+                                            );
+                                            slog(&session_log, |l| l.info(&line));
+                                            bus.send(AppEvent::LogEntry {
+                                                session_id: live_session_id.clone(),
+                                                level: "info".to_string(),
+                                                source: "Intendant".to_string(),
+                                                content: line,
+                                                turn: None,
+                                            });
+                                        }
+                                        Err(e) => {
+                                            let line = format!(
+                                                "{noun} elapsed, but the dead backend could not be respawned: {e}"
+                                            );
+                                            slog(&session_log, |l| l.error(&line));
+                                            emit_follow_up_status(
+                                                &bus,
+                                                live_session_id.as_deref(),
+                                                &pending.follow_up_id,
+                                                Some(&pending.text),
+                                                "failed",
+                                                Some("the backend could not be respawned at the park's wake"),
+                                            );
+                                            bus.send(AppEvent::LoopError(line.clone()));
+                                            stats.terminal_outcome = Some(line);
+                                            break 'outer;
+                                        }
+                                    }
+                                }
                                 let line = format!(
                                     "{noun} elapsed — re-sending the parked message"
                                 );
@@ -963,7 +1076,7 @@ pub(crate) async fn run_external_agent_mode(
                             );
                         }
                     }
-                    maybe_event = event_rx.recv() => {
+                    maybe_event = event_rx.recv(), if event_channel_open => {
                         match maybe_event {
                             Some(event) => {
                                 let (event_thread_id, event_turn_id, event) = event.into_scope();
@@ -1306,38 +1419,93 @@ pub(crate) async fn run_external_agent_mode(
                                                 reason,
                                                 turns_in_round,
                                             } => {
-                                                // A backend-started round
-                                                // observed from idle died on
-                                                // a fatal error before any
-                                                // turn ran: fail honestly,
-                                                // like the primary loop.
-                                                stats.rounds = round;
-                                                slog(&session_log, |l| {
-                                                    l.error(&format!(
-                                                        "External agent round failed before any turn completed while observed from idle: {reason}"
-                                                    ))
-                                                });
-                                                record_external_round_inline(
-                                                    &session_log,
-                                                    persist_model_responses_inline,
-                                                    round,
-                                                    turns_in_round,
-                                                );
-                                                bus.send(AppEvent::RoundComplete {
-                                                    session_id: live_session_id.clone(),
-                                                    round,
-                                                    turns_in_round,
-                                                    native_message_count: None,
-                                                    project_root: round_session_root.clone(),
-                                                });
-                                                bus.send(AppEvent::TaskComplete {
-                                                    session_id: live_session_id.clone(),
-                                                    reason: reason.clone(),
-                                                    summary: None,
-                                                    outcome: crate::event::TaskOutcome::Failed,
-                                                });
-                                                stats.terminal_outcome = Some(reason);
-                                                break 'outer;
+                                                if let Some(park) = limit_park
+                                                    .as_ref()
+                                                    .filter(|park| park.pending.is_some())
+                                                {
+                                                    // Park-then-die
+                                                    // reconciliation
+                                                    // (2026-08-01 specimen
+                                                    // e883a2db): this failed
+                                                    // spontaneous round is
+                                                    // usually the dying
+                                                    // backend's death rattle
+                                                    // from the very
+                                                    // rejection that armed
+                                                    // the park seconds
+                                                    // earlier — breaking
+                                                    // here destroyed the
+                                                    // in-memory wake while
+                                                    // the durable meta kept
+                                                    // advertising owed work.
+                                                    // The armed park with
+                                                    // pending outranks the
+                                                    // terminal: stay
+                                                    // resident, roll the
+                                                    // round back like the
+                                                    // limit arm, restore the
+                                                    // waiting status the
+                                                    // round's "running"
+                                                    // claim overwrote.
+                                                    let line =
+                                                        park_holds_through_terminal_line(
+                                                            park.kind,
+                                                            "the observed round failed before any turn completed",
+                                                            &reason,
+                                                        );
+                                                    slog(&session_log, |l| l.warn(&line));
+                                                    bus.send(AppEvent::LogEntry {
+                                                        session_id: live_session_id.clone(),
+                                                        level: "warn".to_string(),
+                                                        source: "Intendant".to_string(),
+                                                        content: line,
+                                                        turn: None,
+                                                    });
+                                                    emit_external_turn_status(
+                                                        &bus,
+                                                        &autonomy,
+                                                        live_session_id.as_deref(),
+                                                        round,
+                                                        park.kind.waiting_turn_status(),
+                                                        park.kind
+                                                            .waiting_turn_detail(agent.name()),
+                                                    )
+                                                    .await;
+                                                    round = round.saturating_sub(1);
+                                                } else {
+                                                    // A backend-started round
+                                                    // observed from idle died on
+                                                    // a fatal error before any
+                                                    // turn ran: fail honestly,
+                                                    // like the primary loop.
+                                                    stats.rounds = round;
+                                                    slog(&session_log, |l| {
+                                                        l.error(&format!(
+                                                            "External agent round failed before any turn completed while observed from idle: {reason}"
+                                                        ))
+                                                    });
+                                                    record_external_round_inline(
+                                                        &session_log,
+                                                        persist_model_responses_inline,
+                                                        round,
+                                                        turns_in_round,
+                                                    );
+                                                    bus.send(AppEvent::RoundComplete {
+                                                        session_id: live_session_id.clone(),
+                                                        round,
+                                                        turns_in_round,
+                                                        native_message_count: None,
+                                                        project_root: round_session_root.clone(),
+                                                    });
+                                                    bus.send(AppEvent::TaskComplete {
+                                                        session_id: live_session_id.clone(),
+                                                        reason: reason.clone(),
+                                                        summary: None,
+                                                        outcome: crate::event::TaskOutcome::Failed,
+                                                    });
+                                                    stats.terminal_outcome = Some(reason);
+                                                    break 'outer;
+                                                }
                                             }
                                             DrainOutcome::TurnCompleted {
                                                 message,
@@ -1416,7 +1584,7 @@ pub(crate) async fn run_external_agent_mode(
                                                         RATE_LIMIT_RESTART_CAUSE,
                                                         turn_had_started,
                                                     );
-                                                let (mut park, park_line) =
+                                                let (mut park, mut park_line) =
                                                     backend_started_limit_park(
                                                         resets_at_epoch,
                                                         tokio::time::Instant::now(),
@@ -1425,6 +1593,25 @@ pub(crate) async fn run_external_agent_mode(
                                                         limit_park_jitter_secs(),
                                                         turn_had_started,
                                                     );
+                                                // A rejection landing while
+                                                // already parked (the death
+                                                // rattle held by the
+                                                // reconciliation above)
+                                                // re-arms with a fresh wake
+                                                // clock but must not
+                                                // clobber the owed pending
+                                                // — restate the line with
+                                                // the truthful pending-ness.
+                                                if inherit_owed_pending(
+                                                    limit_park.take(),
+                                                    &mut park,
+                                                ) {
+                                                    park_line = limit_park_log_line(
+                                                        resets_at_epoch,
+                                                        crate::session_activity::epoch_seconds(),
+                                                        true,
+                                                    );
+                                                }
                                                 if let (Some(pending), Some(addendum)) =
                                                     (park.pending.as_mut(), died_addendum)
                                                 {
@@ -1444,11 +1631,8 @@ pub(crate) async fn run_external_agent_mode(
                                                     &autonomy,
                                                     live_session_id.as_deref(),
                                                     round.saturating_add(1),
-                                                    "waiting-rate-limit",
-                                                    format!(
-                                                        "{} rate-limited; parked until the limit resets",
-                                                        agent.name()
-                                                    ),
+                                                    park.kind.waiting_turn_status(),
+                                                    park.kind.waiting_turn_detail(agent.name()),
                                                 )
                                                 .await;
                                                 limit_park = Some(park);
@@ -1611,15 +1795,38 @@ pub(crate) async fn run_external_agent_mode(
                                                         SERVICE_RECOVERY_RESTART_CAUSE,
                                                         turn_had_started,
                                                     );
-                                                let (mut park, park_line) =
+                                                let error_park_jitter =
+                                                    error_park_jitter_secs();
+                                                let (mut park, mut park_line) =
                                                     transient_round_death_error_park(
                                                         &reason,
                                                         tokio::time::Instant::now(),
                                                         error_park_streak,
-                                                        error_park_jitter_secs(),
+                                                        error_park_jitter,
                                                         turn_had_started,
                                                         None,
                                                     );
+                                                // A round death landing
+                                                // while already parked
+                                                // re-arms on the recovery
+                                                // schedule but must not
+                                                // clobber the owed pending
+                                                // — restate the line with
+                                                // the truthful pending-ness.
+                                                if inherit_owed_pending(
+                                                    limit_park.take(),
+                                                    &mut park,
+                                                ) {
+                                                    park_line = error_park_log_line(
+                                                        &reason,
+                                                        error_park_streak,
+                                                        error_park_delay(
+                                                            error_park_streak,
+                                                            error_park_jitter,
+                                                        ),
+                                                        true,
+                                                    );
+                                                }
                                                 if let (Some(pending), Some(addendum)) =
                                                     (park.pending.as_mut(), died_addendum)
                                                 {
@@ -1639,11 +1846,8 @@ pub(crate) async fn run_external_agent_mode(
                                                     &autonomy,
                                                     live_session_id.as_deref(),
                                                     round.saturating_add(1),
-                                                    "waiting-service-recovery",
-                                                    format!(
-                                                        "{} waiting out a temporary service condition; parked for recovery",
-                                                        agent.name()
-                                                    ),
+                                                    park.kind.waiting_turn_status(),
+                                                    park.kind.waiting_turn_detail(agent.name()),
                                                 )
                                                 .await;
                                                 limit_park = Some(park);
@@ -1746,33 +1950,109 @@ pub(crate) async fn run_external_agent_mode(
                                                 });
                                             }
                                             DrainOutcome::Terminated { reason, exit_code } => {
-                                                stats.rounds = round;
-                                                slog(&session_log, |l| {
-                                                    l.info(&format!(
-                                                        "External agent terminated while observed from idle: {} (exit code: {:?})",
-                                                        reason,
-                                                        exit_code
-                                                    ))
-                                                });
-                                                bus.send(AppEvent::TaskComplete {
-                                                    session_id: live_session_id.clone(),
-                                                    reason: reason.clone(),
-                                                    summary: stats.last_response.clone(),
-                                                    outcome: crate::event::TaskOutcome::Failed,
-                                                });
-                                                stats.terminal_outcome = Some(reason);
-                                                break 'outer;
+                                                if let Some(park) = limit_park
+                                                    .as_ref()
+                                                    .filter(|park| park.pending.is_some())
+                                                {
+                                                    // Park-then-die: the
+                                                    // process dying while a
+                                                    // park owes work is the
+                                                    // expected shape of a
+                                                    // limit that killed its
+                                                    // backend — the park
+                                                    // outranks the terminal
+                                                    // and the wake respawns
+                                                    // before delivering.
+                                                    let line =
+                                                        park_holds_through_terminal_line(
+                                                            park.kind,
+                                                            "the backend process terminated",
+                                                            &reason,
+                                                        );
+                                                    slog(&session_log, |l| l.warn(&line));
+                                                    bus.send(AppEvent::LogEntry {
+                                                        session_id: live_session_id.clone(),
+                                                        level: "warn".to_string(),
+                                                        source: "Intendant".to_string(),
+                                                        content: line,
+                                                        turn: None,
+                                                    });
+                                                    emit_external_turn_status(
+                                                        &bus,
+                                                        &autonomy,
+                                                        live_session_id.as_deref(),
+                                                        round,
+                                                        park.kind.waiting_turn_status(),
+                                                        park.kind
+                                                            .waiting_turn_detail(agent.name()),
+                                                    )
+                                                    .await;
+                                                    round = round.saturating_sub(1);
+                                                } else {
+                                                    stats.rounds = round;
+                                                    slog(&session_log, |l| {
+                                                        l.info(&format!(
+                                                            "External agent terminated while observed from idle: {} (exit code: {:?})",
+                                                            reason,
+                                                            exit_code
+                                                        ))
+                                                    });
+                                                    bus.send(AppEvent::TaskComplete {
+                                                        session_id: live_session_id.clone(),
+                                                        reason: reason.clone(),
+                                                        summary: stats.last_response.clone(),
+                                                        outcome: crate::event::TaskOutcome::Failed,
+                                                    });
+                                                    stats.terminal_outcome = Some(reason);
+                                                    break 'outer;
+                                                }
                                             }
                                             DrainOutcome::ChannelClosed => {
-                                                slog(&session_log, |l| {
-                                                    l.info(
-                                                        "External agent event channel closed while observed from idle",
+                                                if let Some(park) = limit_park
+                                                    .as_ref()
+                                                    .filter(|park| park.pending.is_some())
+                                                {
+                                                    // Park-then-die: gate
+                                                    // the closed channel and
+                                                    // stay resident (see the
+                                                    // idle recv arm's twin).
+                                                    event_channel_open = false;
+                                                    let line =
+                                                        park_holds_through_terminal_line(
+                                                            park.kind,
+                                                            "the backend event channel closed",
+                                                            "",
+                                                        );
+                                                    slog(&session_log, |l| l.warn(&line));
+                                                    bus.send(AppEvent::LogEntry {
+                                                        session_id: live_session_id.clone(),
+                                                        level: "warn".to_string(),
+                                                        source: "Intendant".to_string(),
+                                                        content: line,
+                                                        turn: None,
+                                                    });
+                                                    emit_external_turn_status(
+                                                        &bus,
+                                                        &autonomy,
+                                                        live_session_id.as_deref(),
+                                                        round,
+                                                        park.kind.waiting_turn_status(),
+                                                        park.kind
+                                                            .waiting_turn_detail(agent.name()),
                                                     )
-                                                });
-                                                stats.terminal_outcome = Some(
-                                                    "external agent event channel closed".to_string(),
-                                                );
-                                                break 'outer;
+                                                    .await;
+                                                    round = round.saturating_sub(1);
+                                                } else {
+                                                    slog(&session_log, |l| {
+                                                        l.info(
+                                                            "External agent event channel closed while observed from idle",
+                                                        )
+                                                    });
+                                                    stats.terminal_outcome = Some(
+                                                        "external agent event channel closed".to_string(),
+                                                    );
+                                                    break 'outer;
+                                                }
                                             }
                                         }
                                     }
@@ -1780,12 +2060,40 @@ pub(crate) async fn run_external_agent_mode(
                                 continue;
                             }
                             None => {
-                                slog(&session_log, |l| {
-                                    l.info("External agent event channel closed, exiting")
-                                });
-                                stats.terminal_outcome =
-                                    Some("external agent event channel closed".to_string());
-                                break 'outer;
+                                if let Some(park) =
+                                    limit_park.as_ref().filter(|park| park.pending.is_some())
+                                {
+                                    // Park-then-die reconciliation: the
+                                    // dead backend's channel closing is
+                                    // the death rattle's quiet sibling —
+                                    // the armed park with owed work
+                                    // outranks it. Gate the closed
+                                    // channel (an ungated recv() would
+                                    // spin this select) and stay
+                                    // resident; the wake respawns the
+                                    // backend before delivering.
+                                    event_channel_open = false;
+                                    let line = park_holds_through_terminal_line(
+                                        park.kind,
+                                        "the backend event channel closed",
+                                        "",
+                                    );
+                                    slog(&session_log, |l| l.warn(&line));
+                                    bus.send(AppEvent::LogEntry {
+                                        session_id: live_session_id.clone(),
+                                        level: "warn".to_string(),
+                                        source: "Intendant".to_string(),
+                                        content: line,
+                                        turn: None,
+                                    });
+                                } else {
+                                    slog(&session_log, |l| {
+                                        l.info("External agent event channel closed, exiting")
+                                    });
+                                    stats.terminal_outcome =
+                                        Some("external agent event channel closed".to_string());
+                                    break 'outer;
+                                }
                             }
                         }
                     }
@@ -2229,11 +2537,13 @@ pub(crate) async fn run_external_agent_mode(
                                     );
                                     break 'outer;
                                 }
+                                event_channel_open = true;
                             }
                             Ok(_) => continue,
                             Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
                             Err(tokio::sync::broadcast::error::RecvError::Closed) => {
                                 slog(&session_log, |l| l.info("Event bus closed, exiting"));
+                                daemon_teardown_exit = true;
                                 stats.terminal_outcome = Some("event bus closed".to_string());
                                 break 'outer;
                             }
@@ -4714,6 +5024,66 @@ pub(crate) async fn run_external_agent_mode(
                 stats.terminal_outcome = Some("external agent event channel closed".to_string());
                 break;
             }
+        }
+    }
+
+    // Park-then-die reconciliation, the exit side: the loop is ending
+    // while a park is still ARMED (a deliberate stop, session removal,
+    // safeguards terminal, recovery-required, …). Consume the park
+    // honestly — surface the owed message as undelivered and clear the
+    // durable marker so the boot sweep never resurrects a deliberately
+    // ended session — and say so in the terminal outcome, so the summary
+    // never reads clean over stranded work. The one exception is the
+    // daemon-teardown exit (event bus closed): the daemon is dying, not
+    // this session's story — the marker survives as the boot
+    // auto-readopt trace, exactly like a hard daemon death that never
+    // reaches this line at all.
+    if let Some(park) = limit_park.take() {
+        let noun = park.kind.noun();
+        let detail = stats
+            .terminal_outcome
+            .clone()
+            .unwrap_or_else(|| "the session ended".to_string());
+        let had_pending = park.pending.is_some();
+        if daemon_teardown_exit {
+            // The marker (and its owed pending) survives for the boot
+            // readopt pass; the meta write stays untouched and session_end
+            // refuses the clean completion over it.
+            slog(&session_log, |l| {
+                l.warn(&format!(
+                    "{noun} still armed at the daemon-teardown exit — the durable marker \
+                     survives for the boot readopt pass"
+                ))
+            });
+            if had_pending {
+                stats.terminal_outcome = Some(format!(
+                    "{detail}; a {} with pending work was still armed — its durable \
+                     marker survives for the boot readopt pass",
+                    noun.to_lowercase()
+                ));
+            }
+        } else {
+            if let Some(pending) = park.pending {
+                emit_follow_up_status(
+                    &bus,
+                    live_session_id.as_deref(),
+                    &pending.follow_up_id,
+                    Some(&pending.text),
+                    "failed",
+                    Some(&format!(
+                        "{noun} was still armed when the session ended ({detail})"
+                    )),
+                );
+                stats.terminal_outcome = Some(format!(
+                    "{detail}; a {} with pending work was still armed at session end \
+                     (its owed message was surfaced as undelivered)",
+                    noun.to_lowercase()
+                ));
+            }
+            slog(&session_log, |l| l.set_limit_park(None));
+            slog(&session_log, |l| {
+                l.info(&format!("{noun} cancelled — {detail}"))
+            });
         }
     }
 

--- a/src/bin/caller/external_mode.rs
+++ b/src/bin/caller/external_mode.rs
@@ -150,10 +150,14 @@ async fn apply_backend_credentials_reload(
     drain_config: &mut DrainConfig<'_>,
 ) -> Option<Vec<String>> {
     let session_log = drain_config.session_log;
+    // Hoisted out of `drain_config` so the closures below don't hold a
+    // borrow across the in-place respawn, which needs `&mut drain_config`.
+    let bus = drain_config.bus;
+    let reload_session_id = drain_config.session_id.clone();
     let announce = |line: &str| {
         slog(session_log, |l| l.info(line));
-        drain_config.bus.send(AppEvent::LogEntry {
-            session_id: drain_config.session_id.clone(),
+        bus.send(AppEvent::LogEntry {
+            session_id: reload_session_id.clone(),
             level: "info".to_string(),
             source: "Intendant".to_string(),
             content: line.to_string(),
@@ -164,12 +168,10 @@ async fn apply_backend_credentials_reload(
     // per-session reload lifecycle from these, so the Vault card's chips
     // track the daemon's actual progress instead of client-side memory.
     let progress = |progress: crate::event::CredentialReloadProgress| {
-        drain_config
-            .bus
-            .send(AppEvent::BackendCredentialsReloadProgress {
-                session_id: drain_config.session_id.clone(),
-                progress,
-            });
+        bus.send(AppEvent::BackendCredentialsReloadProgress {
+            session_id: reload_session_id.clone(),
+            progress,
+        });
     };
     if let Some(park) = limit_park.take() {
         *limit_park_streak = 0;
@@ -1166,16 +1168,46 @@ pub(crate) async fn run_external_agent_mode(
                                         );
                                     }
                                     external_agent::AgentEvent::Terminated { reason, exit_code } => {
-                                        let message = format!(
-                                            "{} terminated while idle: {} (exit code: {:?})",
-                                            agent.name(),
-                                            reason,
-                                            exit_code
-                                        );
-                                        slog(&session_log, |l| l.warn(&message));
-                                        bus.send(AppEvent::LoopError(message));
-                                        stats.terminal_outcome = Some(reason);
-                                        break 'outer;
+                                        if let Some(park) = limit_park
+                                            .as_ref()
+                                            .filter(|park| park.pending.is_some())
+                                        {
+                                            // Park-then-die reconciliation:
+                                            // the backend announcing its own
+                                            // death right after a rejection
+                                            // armed the park (the specimen's
+                                            // process-exit shape) must not
+                                            // end the session that promised
+                                            // to resume the owed work — the
+                                            // park stands; the wake respawns
+                                            // before delivering. The
+                                            // channel's subsequent close is
+                                            // held by the gated recv arm.
+                                            let line = park_holds_through_terminal_line(
+                                                park.kind,
+                                                "the backend process terminated while idle",
+                                                &reason,
+                                            );
+                                            slog(&session_log, |l| l.warn(&line));
+                                            bus.send(AppEvent::LogEntry {
+                                                session_id: drain_config.session_id.clone(),
+                                                level: "warn".to_string(),
+                                                source: "Intendant".to_string(),
+                                                content: line,
+                                                turn: None,
+                                            });
+                                        } else {
+                                            let message = format!(
+                                                "{} terminated while idle: {} (exit code: {:?})",
+                                                agent.name(),
+                                                reason,
+                                                exit_code
+                                            );
+                                            slog(&session_log, |l| l.warn(&message));
+                                            bus.send(AppEvent::LoopError(message));
+                                            stats.terminal_outcome = Some(reason);
+                                            break 'outer;
+                                        }
                                     }
                                     // Ambient diagnostics are not evidence of a
                                     // backend-initiated turn. Recording them inline and

--- a/src/bin/caller/external_supervision.rs
+++ b/src/bin/caller/external_supervision.rs
@@ -1509,8 +1509,18 @@ const LIMIT_PARK_MAX_SECS: u64 = 6 * 3600;
 
 /// Random park jitter in the fleet-safe band. Tests inject their own
 /// value into [`limit_park_delay`] instead of calling this.
+/// `INTENDANT_LIMIT_PARK_JITTER_SECS` overrides the draw (clamped to the
+/// band's max) — the e2e suite pins the park's wake-and-resume arc with
+/// it, and an operator can flatten the fleet-safety jitter deliberately;
+/// an unparsable value keeps the random draw.
 pub(crate) fn limit_park_jitter_secs() -> u64 {
     use rand::Rng;
+    if let Some(forced) = std::env::var("INTENDANT_LIMIT_PARK_JITTER_SECS")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+    {
+        return forced.min(LIMIT_PARK_JITTER_MAX_SECS);
+    }
     rand::thread_rng().gen_range(LIMIT_PARK_JITTER_MIN_SECS..=LIMIT_PARK_JITTER_MAX_SECS)
 }
 
@@ -1584,6 +1594,79 @@ impl ParkKind {
                 "waiting out a service condition; delivers when the recovery pause elapses"
             }
         }
+    }
+
+    /// The turn-status name emitted while this park kind holds the lane
+    /// (the dashboard's waiting chip) — the arm sites and the
+    /// held-through-terminal re-emits share it, so a hold can restore
+    /// the exact status the observed round's "running" claim overwrote.
+    pub(crate) fn waiting_turn_status(&self) -> &'static str {
+        match self {
+            ParkKind::ProviderLimit => "waiting-rate-limit",
+            ParkKind::ServiceCondition => "waiting-service-recovery",
+        }
+    }
+
+    /// The turn-status detail line paired with
+    /// [`Self::waiting_turn_status`].
+    pub(crate) fn waiting_turn_detail(&self, agent_name: &str) -> String {
+        match self {
+            ParkKind::ProviderLimit => {
+                format!("{agent_name} rate-limited; parked until the limit resets")
+            }
+            ParkKind::ServiceCondition => format!(
+                "{agent_name} waiting out a temporary service condition; parked for recovery"
+            ),
+        }
+    }
+}
+
+/// The honest log row when a terminal classification lands while a park
+/// with owed work is armed and the park outranks it — the park-then-die
+/// reconciliation (2026-08-01 specimen e883a2db: a five_hour rejection
+/// armed the park at 22:34:30.897 and the dying backend's exit was
+/// classified a fatal round failure 1.5s later, whose `break` destroyed
+/// the in-memory wake while the durable meta kept advertising
+/// `has_pending: true` — a silent forever-strand). The classification is
+/// usually the same rejection's death rattle; holding residence keeps
+/// the armed wake, which respawns a confirmed-dead backend before
+/// delivering.
+pub(crate) fn park_holds_through_terminal_line(
+    kind: ParkKind,
+    classification: &str,
+    reason: &str,
+) -> String {
+    let reason = reason.trim();
+    let cause = if reason.is_empty() {
+        String::new()
+    } else {
+        format!(" ({reason})")
+    };
+    format!(
+        "{} holds through a backend terminal while parked — {classification}{cause}; \
+         the session stays resident and resumes at the park's wake",
+        kind.noun()
+    )
+}
+
+/// Re-arming a park over an already-armed one (a second rejection or
+/// round death while parked — the dying backend's death-rattle class)
+/// must not clobber the owed work: while parked nothing delivers user
+/// input, so the previous park's pending is still the owed re-send and
+/// strictly outranks a replacement arm's synthesized resume nudge. The
+/// fresh wake clock always wins; only the pending is preserved. Returns
+/// whether an owed pending carried over, so the caller can re-state the
+/// arm line with the truthful pending-ness.
+pub(crate) fn inherit_owed_pending(
+    previous: Option<LimitParkState>,
+    park: &mut LimitParkState,
+) -> bool {
+    match previous.and_then(|prev| prev.pending) {
+        Some(owed) => {
+            park.pending = Some(owed);
+            true
+        }
+        None => false,
     }
 }
 
@@ -2280,6 +2363,121 @@ pub(crate) fn shared_codex_config_from_project(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The park-then-die hold line: honest, greppable, and truthful with
+    /// and without a carried reason.
+    #[test]
+    fn park_holds_through_terminal_line_is_honest() {
+        let line = park_holds_through_terminal_line(
+            ParkKind::ProviderLimit,
+            "the observed round failed before any turn completed",
+            "You've hit your session limit · resets 1:40am",
+        );
+        assert_eq!(
+            line,
+            "Rate-limit park holds through a backend terminal while parked — the observed \
+             round failed before any turn completed (You've hit your session limit · resets \
+             1:40am); the session stays resident and resumes at the park's wake"
+        );
+        let quiet = park_holds_through_terminal_line(
+            ParkKind::ServiceCondition,
+            "the backend event channel closed",
+            "",
+        );
+        assert_eq!(
+            quiet,
+            "Service-recovery pause holds through a backend terminal while parked — the \
+             backend event channel closed; the session stays resident and resumes at the \
+             park's wake"
+        );
+    }
+
+    /// Re-arming over an armed park inherits the owed pending: while
+    /// parked nothing delivers user input, so the earlier park's pending
+    /// is still the owed work and outranks a replacement arm's
+    /// synthesized nudge (or its absence).
+    #[test]
+    fn inherit_owed_pending_preserves_the_owed_message() {
+        let owed = FollowUpMessage::text("the owed re-send".to_string())
+            .with_follow_up_id(Some("f-owed".to_string()));
+        let previous = LimitParkState {
+            resume_at: tokio::time::Instant::now(),
+            pending: Some(owed),
+            kind: ParkKind::ProviderLimit,
+        };
+
+        // Replacement armed with only a synthesized nudge: the owed
+        // message wins.
+        let (mut park, _) = backend_started_limit_park(
+            Some(2_000_000_000),
+            tokio::time::Instant::now(),
+            1_999_999_000,
+            1,
+            0,
+            true,
+        );
+        assert!(park.pending.is_some(), "nudge-armed replacement");
+        assert!(inherit_owed_pending(Some(previous), &mut park));
+        let pending = park.pending.expect("owed pending inherited");
+        assert_eq!(pending.text, "the owed re-send");
+        assert_eq!(pending.follow_up_id.as_deref(), Some("f-owed"));
+
+        // No previous park: the replacement keeps its own pending.
+        let (mut park, _) = backend_started_limit_park(
+            Some(2_000_000_000),
+            tokio::time::Instant::now(),
+            1_999_999_000,
+            1,
+            0,
+            true,
+        );
+        assert!(!inherit_owed_pending(None, &mut park));
+        assert_eq!(
+            park.pending.map(|p| p.text),
+            Some(LIMIT_MIDTURN_CONTINUATION_TEXT.to_string())
+        );
+
+        // Previous park without pending: nothing carries over, the
+        // pending-less replacement stays pending-less.
+        let pending_less = LimitParkState {
+            resume_at: tokio::time::Instant::now(),
+            pending: None,
+            kind: ParkKind::ProviderLimit,
+        };
+        let (mut park, _) = backend_started_limit_park(
+            Some(2_000_000_000),
+            tokio::time::Instant::now(),
+            1_999_999_000,
+            1,
+            0,
+            false,
+        );
+        assert!(park.pending.is_none());
+        assert!(!inherit_owed_pending(Some(pending_less), &mut park));
+        assert!(park.pending.is_none());
+    }
+
+    /// The waiting-status vocabulary is shared by the arm sites and the
+    /// held-through-terminal re-emits — one source, no drift.
+    #[test]
+    fn waiting_turn_status_vocabulary_is_pinned() {
+        assert_eq!(
+            ParkKind::ProviderLimit.waiting_turn_status(),
+            "waiting-rate-limit"
+        );
+        assert_eq!(
+            ParkKind::ServiceCondition.waiting_turn_status(),
+            "waiting-service-recovery"
+        );
+        assert_eq!(
+            ParkKind::ProviderLimit.waiting_turn_detail("claude-code"),
+            "claude-code rate-limited; parked until the limit resets"
+        );
+        assert_eq!(
+            ParkKind::ServiceCondition.waiting_turn_detail("claude-code"),
+            "claude-code waiting out a temporary service condition; parked for recovery"
+        );
+    }
 
     /// THE no-auto-re-execution pin for the died-with-restart class: the
     /// marking seam flips registry records and publishes SURFACES only —

--- a/src/bin/caller/session_log/bus_events.rs
+++ b/src/bin/caller/session_log/bus_events.rs
@@ -2043,12 +2043,31 @@ impl SessionLog {
         // teardown the kill itself triggers reaches this write, and that
         // marker is what the next boot's readopt scan reads — a kill must
         // never be rewritten as a clean completion (a real new turn
-        // re-stamps "running" via write_meta first).
+        // re-stamps "running" via write_meta first). An armed limit park
+        // with pending work equally refuses the clean completion: the
+        // wrapper's exit paths cancel any park they consume (clearing the
+        // marker before this write), so a still-pending park here means
+        // the session died with owed work the park promised to resume —
+        // stamping "completed" would hide it from the boot readopt scan's
+        // completed-status exclusion forever (the 2026-08-01 park-then-die
+        // specimen, session e883a2db). "interrupted" is the established
+        // ended-with-work-owed status every recovery reader already honors.
         let meta_path = self.dir.join("session_meta.json");
         if let Ok(meta_str) = fs::read_to_string(&meta_path) {
             if let Ok(mut meta) = serde_json::from_str::<SessionMeta>(&meta_str) {
                 if meta.status.as_deref() != Some("interrupted") {
-                    meta.status = Some("completed".to_string());
+                    let stranded_park = meta
+                        .limit_park
+                        .as_ref()
+                        .is_some_and(|park| park.has_pending);
+                    meta.status = Some(
+                        if stranded_park {
+                            "interrupted"
+                        } else {
+                            "completed"
+                        }
+                        .to_string(),
+                    );
                 }
                 meta.last_turn = Some(total_turns);
                 meta.rounds = rounds;
@@ -2541,6 +2560,94 @@ mod tests {
                 .unwrap();
         assert_eq!(meta.status.as_deref(), Some("completed"));
         assert_eq!(meta.last_turn, Some(3));
+    }
+
+    /// The park-then-die backstop (2026-08-01 specimen e883a2db): a
+    /// session ending while its durable limit-park marker still owes
+    /// pending work must NOT be stamped "completed" — that status hides
+    /// the park from the boot readopt scan's completed-status exclusion
+    /// forever. session_end stamps the established "interrupted"
+    /// (ended-with-work-owed) status instead, keeping the session a
+    /// mid-work readopt candidate after a daemon restart.
+    #[test]
+    fn write_summary_never_stamps_completed_over_pending_park() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_dir = dir.path().join("session");
+        let mut log = SessionLog::open(log_dir.clone()).unwrap();
+        log.write_meta(Some(Path::new("/tmp")), Some("task"));
+        log.set_limit_park(Some(crate::session_log::SessionLimitParkMeta {
+            resets_at_epoch: Some(1_785_649_200),
+            has_pending: true,
+        }));
+        log.write_summary(
+            "task",
+            "External agent round failed before any turn completed",
+            0,
+        );
+        drop(log);
+
+        let meta: SessionMeta =
+            serde_json::from_str(&fs::read_to_string(log_dir.join("session_meta.json")).unwrap())
+                .unwrap();
+        assert_eq!(
+            meta.status.as_deref(),
+            Some("interrupted"),
+            "an armed pending park must survive session_end as an \
+             ended-with-work-owed status, never a clean completion"
+        );
+        // The marker itself survives the rewrite — the boot sweep reads it.
+        assert_eq!(
+            meta.limit_park,
+            Some(crate::session_log::SessionLimitParkMeta {
+                resets_at_epoch: Some(1_785_649_200),
+                has_pending: true,
+            })
+        );
+    }
+
+    /// A pending-less park (timer armed, no work owed) does not block the
+    /// clean completion — only owed work refuses "completed".
+    #[test]
+    fn write_summary_completes_over_pending_less_park() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_dir = dir.path().join("session");
+        let mut log = SessionLog::open(log_dir.clone()).unwrap();
+        log.write_meta(Some(Path::new("/tmp")), Some("task"));
+        log.set_limit_park(Some(crate::session_log::SessionLimitParkMeta {
+            resets_at_epoch: Some(1_785_649_200),
+            has_pending: false,
+        }));
+        log.write_summary("task", "completed", 2);
+        drop(log);
+
+        let meta: SessionMeta =
+            serde_json::from_str(&fs::read_to_string(log_dir.join("session_meta.json")).unwrap())
+                .unwrap();
+        assert_eq!(meta.status.as_deref(), Some("completed"));
+    }
+
+    /// A park the wrapper cancelled (marker cleared) before session_end
+    /// keeps today's clean completion — the backstop only engages on a
+    /// stranded marker.
+    #[test]
+    fn write_summary_completes_after_park_cleared() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_dir = dir.path().join("session");
+        let mut log = SessionLog::open(log_dir.clone()).unwrap();
+        log.write_meta(Some(Path::new("/tmp")), Some("task"));
+        log.set_limit_park(Some(crate::session_log::SessionLimitParkMeta {
+            resets_at_epoch: None,
+            has_pending: true,
+        }));
+        log.set_limit_park(None);
+        log.write_summary("task", "completed", 4);
+        drop(log);
+
+        let meta: SessionMeta =
+            serde_json::from_str(&fs::read_to_string(log_dir.join("session_meta.json")).unwrap())
+                .unwrap();
+        assert_eq!(meta.status.as_deref(), Some("completed"));
+        assert_eq!(meta.limit_park, None);
     }
 
     #[test]

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -8399,7 +8399,7 @@ async fn limit_park_survives_backend_death_and_resumes_at_reset() {
         RUN_TIMEOUT,
         || async {
             let logs = rig.session_logs();
-            (logs.contains("respawned claude-code resume-attached to deliver the parked message")
+            (logs.contains("resume-attached to deliver the parked message")
                 && logs.contains("elapsed — re-sending the parked message")
                 && logs.contains("resumed after the park wake"))
             .then_some(())

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -8305,33 +8305,40 @@ async fn limit_park_survives_backend_death_and_resumes_at_reset() {
     let rig = TestRig::new();
     rig.write_script(&serde_json::json!({ "profiles": [] }));
 
-    // The fake claude: run 1 waits for the first user message, announces
-    // a rejected five_hour window resetting ~15s out, ends the turn with
-    // the limit-text error result, and exits — the death rattle. Run 2
-    // (the wake's resume-attached respawn; the marker file
-    // discriminates) answers the parked re-send with a clean result and
-    // stays alive reading stdin. The reset clock starts only after the
-    // wrapper is fully up and delivering, so the 15s window prices in a
-    // loaded CI box: only the wrapper's own line-drain sits between the
-    // fake's emit and the park arming.
+    // The fake claude: the FIRST spawn (no `--resume` argv — the session's
+    // fresh backend) waits for the first user message, announces a
+    // rejected five_hour window resetting ~15s out, ends the turn with
+    // the limit-text error result, and exits — the death rattle. The
+    // wake's respawn carries `--resume <id>` (resume-attached by
+    // construction), and that argv discriminates run 2: answer the parked
+    // re-send with a clean result and stay alive reading stdin. Argv
+    // keying over a marker file is deliberate: it needs no external
+    // binaries and no filesystem state, so a platform's extra probe spawn
+    // of the command (observed on the Linux leg, where a marker-file
+    // discriminator was consumed before the session's real spawn) cannot
+    // desynchronize the runs — a stdin-less probe dies at `read` with
+    // zero side effects. The reset clock starts only after the wrapper is
+    // fully up and delivering, so the 15s window prices in a loaded CI
+    // box: only the wrapper's own line-drain sits between the fake's emit
+    // and the park arming.
     let fake = rig.home.path().join("fake-claude.sh");
     std::fs::write(
         &fake,
         concat!(
             "#!/bin/sh\n",
             "SID=\"11111111-2222-4333-8444-555555555555\"\n",
-            "MARKER=\"$(dirname \"$0\")/fake-claude-ran-once\"\n",
-            "if [ ! -f \"$MARKER\" ]; then\n",
-            "  : > \"$MARKER\"\n",
-            "  read -r _line || exit 1\n",
-            "  printf '{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"%s\",\"model\":\"fake-sonnet\",\"permissionMode\":\"default\",\"tools\":[],\"cwd\":\".\"}\\n' \"$SID\"\n",
+            "resumed=0\n",
+            "for a in \"$@\"; do\n",
+            "  [ \"$a\" = \"--resume\" ] && resumed=1\n",
+            "done\n",
+            "read -r _line || exit 1\n",
+            "printf '{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"%s\",\"model\":\"fake-sonnet\",\"permissionMode\":\"default\",\"tools\":[],\"cwd\":\".\"}\\n' \"$SID\"\n",
+            "if [ \"$resumed\" = \"0\" ]; then\n",
             "  RESET=$(( $(/bin/date +%s) + 15 ))\n",
             "  printf '{\"type\":\"rate_limit_event\",\"rate_limit_info\":{\"status\":\"rejected\",\"rateLimitType\":\"five_hour\",\"resetsAt\":%d},\"session_id\":\"%s\"}\\n' \"$RESET\" \"$SID\"\n",
             "  printf '{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":true,\"result\":\"You have hit your session limit\",\"session_id\":\"%s\"}\\n' \"$SID\"\n",
             "  exit 1\n",
             "fi\n",
-            "read -r _line || exit 1\n",
-            "printf '{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"%s\",\"model\":\"fake-sonnet\",\"permissionMode\":\"default\",\"tools\":[],\"cwd\":\".\"}\\n' \"$SID\"\n",
             "printf '{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"result\":\"resumed after the park wake\",\"session_id\":\"%s\"}\\n' \"$SID\"\n",
             "while read -r _line; do :; done\n",
         ),

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -8269,3 +8269,151 @@ fn boot_lock_is_held(rig: &TestRig, boot_id: &str) -> bool {
         Err(std::fs::TryLockError::Error(_)) => true,
     }
 }
+
+/// The first session meta under the rig's store carrying a limit-park
+/// marker (parsed as raw JSON — the e2e asserts on-disk bytes, not
+/// internal types).
+#[cfg(unix)]
+fn park_meta_of(rig: &TestRig) -> Option<serde_json::Value> {
+    let logs_dir = rig.home.path().join(".intendant").join("logs");
+    for entry in std::fs::read_dir(logs_dir).ok()?.flatten() {
+        if let Ok(raw) = std::fs::read_to_string(entry.path().join("session_meta.json")) {
+            if let Ok(meta) = serde_json::from_str::<serde_json::Value>(&raw) {
+                if meta.get("limit_park").is_some_and(|park| !park.is_null()) {
+                    return Some(meta);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// The park-then-die race end to end (card 01KZ07Q0PX, specimen e883a2db
+/// 2026-08-01): a fake claude binary rejects the first turn on a rate
+/// limit and DIES with the rejection. The armed park must hold the
+/// session resident through the backend terminal, leave the
+/// daemon-restart-survivable meta on disk while parked (the exact
+/// predicate the boot sweep's `midwork_class` candidates on), and at the
+/// reset respawn the backend resume-attached and deliver the parked
+/// re-send to completion. Unix-only for the /bin/sh fake; the underlying
+/// seams carry platform-neutral unit pins.
+#[cfg(unix)]
+#[tokio::test]
+async fn limit_park_survives_backend_death_and_resumes_at_reset() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let rig = TestRig::new();
+    rig.write_script(&serde_json::json!({ "profiles": [] }));
+
+    // The fake claude: run 1 waits for the first user message, announces
+    // a rejected five_hour window resetting ~15s out, ends the turn with
+    // the limit-text error result, and exits — the death rattle. Run 2
+    // (the wake's resume-attached respawn; the marker file
+    // discriminates) answers the parked re-send with a clean result and
+    // stays alive reading stdin. The reset clock starts only after the
+    // wrapper is fully up and delivering, so the 15s window prices in a
+    // loaded CI box: only the wrapper's own line-drain sits between the
+    // fake's emit and the park arming.
+    let fake = rig.home.path().join("fake-claude.sh");
+    std::fs::write(
+        &fake,
+        concat!(
+            "#!/bin/sh\n",
+            "SID=\"11111111-2222-4333-8444-555555555555\"\n",
+            "MARKER=\"$(dirname \"$0\")/fake-claude-ran-once\"\n",
+            "if [ ! -f \"$MARKER\" ]; then\n",
+            "  : > \"$MARKER\"\n",
+            "  read -r _line || exit 1\n",
+            "  printf '{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"%s\",\"model\":\"fake-sonnet\",\"permissionMode\":\"default\",\"tools\":[],\"cwd\":\".\"}\\n' \"$SID\"\n",
+            "  RESET=$(( $(/bin/date +%s) + 15 ))\n",
+            "  printf '{\"type\":\"rate_limit_event\",\"rate_limit_info\":{\"status\":\"rejected\",\"rateLimitType\":\"five_hour\",\"resetsAt\":%d},\"session_id\":\"%s\"}\\n' \"$RESET\" \"$SID\"\n",
+            "  printf '{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":true,\"result\":\"You have hit your session limit\",\"session_id\":\"%s\"}\\n' \"$SID\"\n",
+            "  exit 1\n",
+            "fi\n",
+            "read -r _line || exit 1\n",
+            "printf '{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"%s\",\"model\":\"fake-sonnet\",\"permissionMode\":\"default\",\"tools\":[],\"cwd\":\".\"}\\n' \"$SID\"\n",
+            "printf '{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"result\":\"resumed after the park wake\",\"session_id\":\"%s\"}\\n' \"$SID\"\n",
+            "while read -r _line; do :; done\n",
+        ),
+    )
+    .expect("write fake claude");
+    std::fs::set_permissions(&fake, std::fs::Permissions::from_mode(0o755))
+        .expect("chmod fake claude");
+
+    std::fs::write(
+        rig.project.path().join("intendant.toml"),
+        format!("[agent.claude_code]\ncommand = \"{}\"\n", fake.display()),
+    )
+    .expect("write project config");
+
+    let mut cmd = rig.command();
+    cmd.env("INTENDANT_LIMIT_PARK_JITTER_SECS", "0")
+        .stdin(Stdio::piped())
+        .args([
+            "--no-web",
+            "--json",
+            "--agent",
+            "claude-code",
+            "park race task",
+        ]);
+    let mut child = cmd.spawn().expect("spawn intendant");
+    // Hold stdin open for the whole run: the --json stdin reader owns a
+    // follow-up sender, so the parked idle wait survives instead of
+    // ending on a closed follow-up channel.
+    let _stdin = child.stdin.take().expect("piped stdin");
+
+    // Phase 1: the park arms and then HOLDS through the backend's death
+    // (the terminal classification differs by which death signal lands —
+    // Terminated event or channel close — and the shared hold line
+    // covers both).
+    let logs = poll_until(
+        "the armed park holding through the backend terminal",
+        RUN_TIMEOUT,
+        || async {
+            let logs = rig.session_logs();
+            (logs.contains("Rate-limited — parked")
+                && logs.contains("holds through a backend terminal while parked"))
+            .then_some(logs)
+        },
+        || tail(&rig.session_logs(), 4000),
+    )
+    .await;
+    assert!(
+        !logs.contains("session_end"),
+        "the session must stay resident while parked:\n{}",
+        tail(&logs, 4000)
+    );
+
+    // The daemon-restart-survival shape, read mid-park exactly as a boot
+    // sweep would: the durable meta advertises the pending park under a
+    // non-completed status (`midwork_class`'s candidate predicate, pinned
+    // in boot_readopt's unit tests against these same bytes).
+    let meta = park_meta_of(&rig).expect("a session meta with a limit park");
+    assert_eq!(meta["limit_park"]["has_pending"], true, "meta: {meta}");
+    assert_ne!(meta["status"], "completed", "meta: {meta}");
+
+    // Phase 2: the wake respawns the dead backend resume-attached and
+    // the parked re-send completes on the fresh process.
+    poll_until(
+        "the wake respawn and the delivered parked message",
+        RUN_TIMEOUT,
+        || async {
+            let logs = rig.session_logs();
+            (logs.contains(
+                "respawned claude-code resume-attached to deliver the parked message",
+            ) && logs.contains("elapsed — re-sending the parked message")
+                && logs.contains("resumed after the park wake"))
+            .then_some(())
+        },
+        || tail(&rig.session_logs(), 4000),
+    )
+    .await;
+    // The delivered wake released the park: the durable marker is gone.
+    let meta = park_meta_of(&rig);
+    assert!(
+        meta.is_none(),
+        "the delivered wake clears the durable park marker: {meta:?}"
+    );
+
+    child.kill().await.ok();
+}

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -8399,9 +8399,8 @@ async fn limit_park_survives_backend_death_and_resumes_at_reset() {
         RUN_TIMEOUT,
         || async {
             let logs = rig.session_logs();
-            (logs.contains(
-                "respawned claude-code resume-attached to deliver the parked message",
-            ) && logs.contains("elapsed — re-sending the parked message")
+            (logs.contains("respawned claude-code resume-attached to deliver the parked message")
+                && logs.contains("elapsed — re-sending the parked message")
                 && logs.contains("resumed after the park wake"))
             .then_some(())
         },


### PR DESCRIPTION
A limit park armed with pending work was silently stranded when the same exit's terminal classification broke the supervision loop: session_end stamped `status: "completed"` over `limit_park.has_pending: true`, nothing fired at the reset, and the boot sweep's completed-status exclusion made the strand permanent. Specimen: session e883a2db, 2026-08-01 22:34:30.897 park armed → 22:34:32.385 session_end (card 01KZ07Q0PXMNE37AZDZCKPHF5D; sealed report reload-resume-gap-2026-08-01).

**The fix (the card's option a — the armed park outranks the terminal break — plus a durable backstop):**

- **Hold arms** (`external_mode.rs`): a park owing pending work now outranks every backend death-rattle terminal — the observed-from-idle `TurnFailed` / `Terminated` / `ChannelClosed` outcomes, the **direct idle `AgentEvent::Terminated` arm** (a third killer lane the race e2e caught live: park armed at +0.03s, cancelled by process-stdout-close at +0.05s), and the idle `event_rx` → `None` close. The session stays resident, logs the honest hold line, restores the waiting turn status, rolls the round back, and gates the closed event channel so the idle select cannot spin. (On the specimen's binary the killer was TurnFailed; on current main the reader folds the death rattle into `TurnLimitRejected`, so the live killers are the Terminated/channel-close paths — all covered.)
- **Wake respawn**: a park wake that owes a delivery respawns a confirmed-dead backend resume-attached first (`next_round_reads_fresh_credentials` — per-backend honest, only Claude Code implements the probe; other backends keep the direct send whose failure surfaces loudly) via the respawn core extracted from the credential-reload lane; a respawn failure surfaces the pending as failed and ends the session loudly.
- **Owed-pending inheritance**: re-park arms (a second rejection / round death while parked) inherit the earlier park's owed pending instead of clobbering it, and restate the arm line truthfully.
- **Exit backstop**: any loop exit still holding an armed park consumes it honestly — pending surfaced as undelivered, durable marker cleared (deliberate stops: user stop, session removal, safeguards, recovery-required, error-schedule exhaustion) or preserved (the event-bus-closed daemon-teardown exit keeps it as the boot readopt trace), and the terminal outcome names the stranded-park fact.
- **session_end honesty** (`session_log/bus_events.rs`): the meta rewrite refuses to stamp "completed" over an armed pending park — it writes "interrupted", the established ended-with-work-owed status `midwork_class` already classifies as a boot readopt candidate; the classifier's completed-exclusion comment now records that invariant.

**Tests** (all green locally: bins 5537+150+97, libs, e2e 44/44, clippy `-D warnings`, fmt — explicit per-step exits):
- `limit_park_survives_backend_death_and_resumes_at_reset` (e2e, unix): a fake claude rejects turn 1 on a `five_hour` rejection and dies; pins the hold (no session_end while parked), the mid-park durable meta carrying the boot-sweep candidate predicate (daemon-restart survival), then the wake respawn + parked re-send completing on the fresh process — deterministic via `INTENDANT_LIMIT_PARK_JITTER_SECS` (documented in configuration.md).
- `park_then_die_race_metas_are_boot_candidates` (boot_readopt): every durable shape the race leaves is a scan candidate (resident-hold meta under daemon death; the backstop's interrupted stamp); the pre-fix completed strand stays deliberately excluded.
- `write_summary_never_stamps_completed_over_pending_park` + pending-less + cleared-park twins (session_end honesty).
- Hold-line wording, owed-pending inheritance, waiting-status vocabulary pins (external_supervision).

**Lane analysis**: the persistent daemon lane (`run_modes.rs`) reconciles differently by construction — its spontaneous-round terminals keep the loop alive, and its `Terminated` handler deliberately cancels the park and detaches ("the parked re-send targeted the dead conversation"); no change there. The shared session_end backstop protects both lanes. Pending-less parks (no owed work) deliberately keep today's terminal behavior.

**Adjacent gap flagged, not fixed here**: queued `parked_follow_ups` are surfaced at safeguards terminals but still vanish silently at other terminal breaks (pre-existing; orthogonal to the armed-park promise this PR reconciles).