### PR TITLE
peers: pair and persist on projectless daemons (settings-root config fallback)

### DIFF
--- a/docs/src/control-plane-and-daemon.md
+++ b/docs/src/control-plane-and-daemon.md
@@ -348,6 +348,15 @@ shape for installed-app and service deployments, whose launch cwd (`$HOME`,
 `/Applications`, …) is an accident; CLI invocations keep cwd-as-project,
 which is correct for `intendant "task"` inside a repo.
 
+Daemon-scope state is exempt from that refusal. A projectless daemon loads
+its config from the settings root (`<state-root>/intendant.toml`), and the
+surfaces that *write* daemon-wide state resolve the same file through
+`project::daemon_config_root` — peer pairing (invite join, access-request
+completion) and manual peer persistence included — so pairing works and
+`[[peer]]` entries persist on the bundled app exactly as on a rooted
+daemon. Only project-scoped facilities (watcher, sandbox cwd scope,
+default session project) stay off.
+
 Ctrl+C in this mode is handled by the global signal handler installed in `main`
 (it marks the session interrupted and exits 130); the daemon loop deliberately
 does not also listen for it, to avoid racing two handlers.

--- a/docs/src/peer-federation.md
+++ b/docs/src/peer-federation.md
@@ -939,7 +939,11 @@ the connecting daemon:
 Joining from the dashboard writes or updates the local daemon's outbound
 `[[peer]]` entry in `intendant.toml`, stores the peer-issued client
 certificate/key in the local access cert store, and queues live registry
-registration so the daemon can connect without a restart.
+registration so the daemon can connect without a restart. On a projectless
+daemon (the bundled app's normal shape) the `[[peer]]` entry lands in the
+settings root's `intendant.toml` (`project::daemon_config_root`) — the
+same file boot hydration reads — so pairing is live *and* durable without
+the daemon ever having a project.
 
 The same flow is available from the CLI for headless peers or terminals:
 

--- a/src/bin/caller/project.rs
+++ b/src/bin/caller/project.rs
@@ -1340,6 +1340,20 @@ pub fn daemon_settings_config_root() -> PathBuf {
     crate::platform::intendant_home()
 }
 
+/// The root whose `intendant.toml` a daemon-scope write targets: the
+/// daemon's project root when it has one, else
+/// [`daemon_settings_config_root`] — the bundled app's normal projectless
+/// shape. Boot config substitution, the settings-save surface, and the
+/// Connect store already resolve this way; daemon-wide mutation surfaces
+/// (peer pairing, peer persistence) route through here so a projectless
+/// daemon never refuses a daemon-scope write with "project root not
+/// available".
+pub fn daemon_config_root(project_root: Option<&Path>) -> PathBuf {
+    project_root
+        .map(Path::to_path_buf)
+        .unwrap_or_else(daemon_settings_config_root)
+}
+
 /// Where a projectless daemon persists its Connect client config. Rooted
 /// daemons keep `[connect]` in the project's `intendant.toml`; a daemon
 /// with no project (the bundled app's normal shape) keeps Connect's
@@ -2187,6 +2201,15 @@ mod tests {
             "relay peer admission is owner-file opt-in only — no env override exists"
         );
         drop(guard);
+    }
+
+    #[test]
+    fn daemon_config_root_prefers_project_root_then_settings_root() {
+        let dir = tempfile::TempDir::new().unwrap();
+        assert_eq!(daemon_config_root(Some(dir.path())), dir.path());
+        // intendant_home() is OnceLock-cached, so both sides observe the
+        // same resolution — no env coordination needed.
+        assert_eq!(daemon_config_root(None), daemon_settings_config_root());
     }
 
     #[test]

--- a/src/bin/caller/startup/daemon.rs
+++ b/src/bin/caller/startup/daemon.rs
@@ -125,9 +125,7 @@ pub(crate) async fn run_daemon(
     let shared_codex_config = shared_codex_config_from_project(project);
     let shared_claude_config = shared_claude_config_from_project(project);
     let shared_kimi_config = shared_kimi_config_from_project(project);
-    let settings_root = project_root
-        .clone()
-        .unwrap_or_else(project::daemon_settings_config_root);
+    let settings_root = project::daemon_config_root(project_root.as_deref());
     let _control_plane_handle = control_plane::spawn(control_plane::ControlPlaneState {
         autonomy: autonomy.clone(),
         external_agent: shared_external_agent.clone(),

--- a/src/bin/caller/startup/wiring.rs
+++ b/src/bin/caller/startup/wiring.rs
@@ -279,9 +279,7 @@ pub(crate) fn spawn_mode_web_gateway(
     config.external_agent = initial_agent_backend
         .as_ref()
         .map(|backend| backend.as_short_str().to_string());
-    let settings_root = project_root
-        .clone()
-        .unwrap_or_else(crate::project::daemon_settings_config_root);
+    let settings_root = crate::project::daemon_config_root(project_root.as_deref());
     let codex_home = crate::session_config::effective_codex_home().map(PathBuf::from);
     let shared_session = Arc::new(tokio::sync::RwLock::new(web_gateway::ActiveSessionState {
         daemon_session_id: session_log_id(session_log),
@@ -439,9 +437,7 @@ pub(crate) fn spawn_mode_web_gateway(
             // watch list exists; under the scheduler lease (Track HS2)
             // it runs on the holder only. Detaches on drop like its
             // siblings.
-            let scanner_settings_root = project_root
-                .clone()
-                .unwrap_or_else(crate::project::daemon_settings_config_root);
+            let scanner_settings_root = crate::project::daemon_config_root(project_root.as_deref());
             let _pr_scanner = crate::github_pr::scanner::spawn_scanner(
                 handle.clone(),
                 scanner_settings_root,

--- a/src/bin/caller/web_gateway/routes_peers.rs
+++ b/src/bin/caller/web_gateway/routes_peers.rs
@@ -429,16 +429,10 @@ pub(crate) async fn peers_add(
             let mut persisted = false;
             let mut config_path = None;
             if req.persist {
-                let Some(project_root) = project_root else {
-                    return (
-                        500,
-                        serde_json::json!({
-                            "error": "peer added for this run, but project root is unavailable for persistence"
-                        })
-                        .to_string(),
-                    );
-                };
-                match persist_manual_peer(project_root, &req, label_override) {
+                // Projectless daemons (the bundled app) persist into the
+                // settings-root config that boot hydration reads.
+                let persist_root = crate::project::daemon_config_root(project_root);
+                match persist_manual_peer(&persist_root, &req, label_override) {
                     Ok(path) => {
                         persisted = true;
                         config_path = Some(path.to_string_lossy().into_owned());
@@ -677,13 +671,10 @@ pub(crate) async fn peers_pairing_request_access_poll(
             );
         }
     };
-    let Some(project_root) = project_root else {
-        return (
-            503,
-            serde_json::json!({"error": "project root not available"}).to_string(),
-        );
-    };
-    let mut project = match crate::project::Project::from_root(project_root.to_path_buf()) {
+    // Projectless daemons (the bundled app) write the daemon-scope
+    // config at the settings root — the same file boot hydration reads.
+    let config_root = crate::project::daemon_config_root(project_root);
+    let mut project = match crate::project::Project::from_root(config_root) {
         Ok(project) => project,
         Err(e) => return (500, serde_json::json!({"error": e.to_string()}).to_string()),
     };
@@ -918,12 +909,6 @@ pub(crate) async fn peers_pairing_join(
             serde_json::json!({"error": "invite is required"}).to_string(),
         );
     }
-    let Some(project_root) = project_root else {
-        return (
-            503,
-            serde_json::json!({"error": "project root not available"}).to_string(),
-        );
-    };
 
     let invite = match crate::peer::pairing::decode_invite(req.invite.trim()) {
         Ok(invite) => invite,
@@ -941,7 +926,10 @@ pub(crate) async fn peers_pairing_join(
         .map(|fp| vec![fp])
         .unwrap_or_default();
 
-    let mut project = match crate::project::Project::from_root(project_root.to_path_buf()) {
+    // Projectless daemons (the bundled app) write the daemon-scope
+    // config at the settings root — the same file boot hydration reads.
+    let config_root = crate::project::daemon_config_root(project_root);
+    let mut project = match crate::project::Project::from_root(config_root) {
         Ok(project) => project,
         Err(e) => return (500, serde_json::json!({"error": e.to_string()}).to_string()),
     };
@@ -3023,6 +3011,42 @@ mod tests {
         assert_eq!(status, 400);
         assert!(response.contains("invalid peer invite encoding"));
         assert!(!response.contains("Config error"));
+    }
+
+    #[tokio::test]
+    async fn test_api_peers_pairing_join_projectless_daemon_reaches_invite_decode() {
+        // A projectless daemon (the bundled app's normal shape) must not
+        // refuse pairing with a "project root not available" 503: the
+        // daemon-scope config root fallback engages instead, so a bad
+        // invite fails as a bad invite. The write path itself is
+        // join_peer_invite's, covered with injected roots in peer::pairing.
+        let (log_tx, _log_rx) = tokio::sync::mpsc::channel::<crate::peer::EnqueuedPeerEvent>(8);
+        let registry = crate::peer::PeerRegistry::new(log_tx);
+        let body = serde_json::json!({"invite": "not an intendant invite"}).to_string();
+
+        let (status, response) = peers_pairing_join(&registry, None, &body).await;
+
+        assert_eq!(status, 400);
+        assert!(response.contains("invalid peer invite encoding"));
+        assert!(!response.contains("project root"));
+    }
+
+    #[tokio::test]
+    async fn test_api_peers_pairing_request_poll_projectless_daemon_resolves_settings_root() {
+        // Same policy on the doorbell-completion route: a missing project
+        // root resolves to the daemon settings root (hermetic under test —
+        // intendant_home's per-process test root), and the injected
+        // cert_dir holding no such request is the error the route must
+        // reach — not a 503.
+        let cert_dir = tempfile::TempDir::new().unwrap();
+        let body = serde_json::json!({"request_id": "req-zzzz"}).to_string();
+
+        let (status, response) =
+            peers_pairing_request_access_poll(None, None, cert_dir.path(), &body).await;
+
+        assert_eq!(status, 400);
+        assert!(response.contains("outgoing access request not found"));
+        assert!(!response.contains("project root"));
     }
 
     #[test]


### PR DESCRIPTION
A projectless daemon (the bundled macOS app's normal shape — launched from $HOME with no project marker) refused peer pairing outright: `POST /api/peers/pairing/join` and the access-request completion returned 503 `project root not available`, and a manual peer add could not persist. Boot config substitution, settings save, and the Connect store already fall back to the daemon settings root; the pairing family was the unpatched straggler, so the packaged app could not pair with fleet peers at all (hit live on 2026-08-02 while wiring two fleet boxes as peers).

This names the resolution once — `project::daemon_config_root`: the project root when the daemon has one, else `daemon_settings_config_root()` — and routes the three peer surfaces through it (invite join, access-request completion, manual persist). The `[[peer]]` entry lands in the settings root's `intendant.toml`, exactly the file a projectless daemon's boot hydration reads, so pairing becomes both live (the join's registry registration already carries the explicit client identity) and durable across restarts. The three existing inline `unwrap_or_else(daemon_settings_config_root)` sites adopt the named helper.

Tests: projectless join reaches invite decode instead of 503; projectless access-poll resolves the settings root and reaches the real not-found error; `daemon_config_root` unit test. Docs updated in control-plane-and-daemon.md (projectless section) and peer-federation.md (pairing section).