### PR TITLE
test: repair honest Windows package failures

### DIFF
--- a/src/bin/caller/connect_rendezvous.rs
+++ b/src/bin/caller/connect_rendezvous.rs
@@ -2470,7 +2470,24 @@ mod tests {
         for _ in 0..8 {
             let cert_dir = dir.path().to_path_buf();
             workers.push(std::thread::spawn(move || {
-                next_dns_mutation_unix_ms_in(&cert_dir, 1_000).unwrap()
+                // Eight intentionally simultaneous durable fsyncs can exceed
+                // the authority store's two-second fail-closed wait on a busy
+                // Windows filesystem. A timeout promises that no state was
+                // changed, so retry it while preserving the production lock
+                // budget; any other error remains an immediate failure.
+                let deadline = std::time::Instant::now() + Duration::from_secs(30);
+                loop {
+                    match next_dns_mutation_unix_ms_in(&cert_dir, 1_000) {
+                        Ok(issued) => break issued,
+                        Err(error)
+                            if error.starts_with("timed out after ")
+                                && std::time::Instant::now() < deadline =>
+                        {
+                            std::thread::yield_now();
+                        }
+                        Err(error) => panic!("DNS mutation clock allocation failed: {error}"),
+                    }
+                }
             }));
         }
         let mut issued = workers

--- a/src/bin/caller/terminal.rs
+++ b/src/bin/caller/terminal.rs
@@ -724,8 +724,9 @@ impl OutputHub {
 }
 
 /// A single live PTY-backed shell session. Callers share it via `Arc`;
-/// the blocking reader keeps only a `Weak` reference so it cannot pin a
-/// killed ConPTY whose output pipe remains open until the master drops.
+/// the blocking reader and child-exit waiter keep only `Weak` references so
+/// neither can pin a killed ConPTY whose output pipe remains open until the
+/// master drops.
 pub struct PtySession {
     master: StdMutex<Box<dyn MasterPty + Send>>,
     writer: StdMutex<Box<dyn Write + Send>>,
@@ -853,12 +854,33 @@ impl PtySession {
             shared: std::sync::atomic::AtomicBool::new(shared),
         });
 
-        // Reader: dedicated OS thread (portable_pty's reader is blocking).
-        // Copies bytes into scrollback and fans out to listeners.
-        let session_clone = Arc::downgrade(&session);
-        std::thread::spawn(move || {
-            Self::reader_loop(session_clone, reader, child);
-        });
+        // portable_pty's reader and child wait are both blocking. On Windows,
+        // ConPTY can retain the output pipe after an orderly shell exit while
+        // this session still owns the master handle, so waiting for EOF before
+        // waiting for the child loses the exit forever. Monitor the child on a
+        // separate thread there; both threads are weak owners, so Drop can
+        // still kill the child and release the master. Unix keeps the original
+        // drain-before-exit ordering, where PTY EOF is reliable and guarantees
+        // all final output precedes Exited.
+        #[cfg(windows)]
+        {
+            let reader_session = Arc::downgrade(&session);
+            std::thread::spawn(move || {
+                Self::reader_loop(&reader_session, reader);
+            });
+            let exit_session = Arc::downgrade(&session);
+            std::thread::spawn(move || {
+                Self::wait_for_child(exit_session, child);
+            });
+        }
+        #[cfg(not(windows))]
+        {
+            let session_clone = Arc::downgrade(&session);
+            std::thread::spawn(move || {
+                Self::reader_loop(&session_clone, reader);
+                Self::wait_for_child(session_clone, child);
+            });
+        }
 
         Ok(session)
     }
@@ -973,11 +995,7 @@ impl PtySession {
         }
     }
 
-    fn reader_loop(
-        session: Weak<Self>,
-        mut reader: Box<dyn Read + Send>,
-        mut child: Box<dyn portable_pty::Child + Send + Sync>,
-    ) {
+    fn reader_loop(session: &Weak<Self>, mut reader: Box<dyn Read + Send>) {
         // 64 KiB reads: bulk shell output at 4 KiB paid 16× the syscalls,
         // and the per-read Vec was pure overhead — `fan_out` copies into
         // each listener's queue itself.
@@ -1012,9 +1030,11 @@ impl PtySession {
                 Err(_) => break,
             }
         }
+    }
 
-        // Shell exited. Capture exit status if available and notify
-        // listeners so the UI can mark the session as closed.
+    /// Wait for the shell process independently of ConPTY output EOF and
+    /// notify listeners exactly once when it exits.
+    fn wait_for_child(session: Weak<Self>, mut child: Box<dyn portable_pty::Child + Send + Sync>) {
         let status = match child.wait() {
             Ok(s) => s.exit_code() as i32,
             Err(_) => -1,


### PR DESCRIPTION
## What

- monitor the Windows PTY child independently of ConPTY output EOF so an orderly PowerShell exit publishes `Exited`
- retain the existing Unix drain-before-exit ordering
- let the DNS mutation-clock stress test retry only the authority lock timeout that explicitly guarantees no state change

## Why

PR #754 split the package-bin and library Cargo commands and exposed two additional failures that the old PowerShell step had hidden: the new terminal re-entry test could wait forever on a ConPTY pipe, and eight simultaneous durable DNS-clock writes could exhaust the production two-second fail-closed lock budget on the loaded Windows filesystem.

## Validation

- `cargo fmt --all`
- `git diff --check`
- PR checks green on Windows, macOS, Ubuntu, integrity, app assembly, and WASM relevance
- physical Windows 11 host under SYSTEM: both exact regressions passed twice; latest DNS 0.10s, terminal exit/reopen 0.49s
