### PR TITLE
release: pinned Linux worker binaries + enrollment attachment-protocol hello

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,16 @@
-name: macOS app release
+name: release
 
-# Builds, signs, notarizes, and publishes the native macOS app
-# (the macos-app/ WKWebView wrapper bundling the release `intendant` +
-# `intendant-runtime` binaries) via scripts/bundle-macos.sh.
+# Builds, signs, and publishes the release artifacts:
+#  - the native macOS app (the macos-app/ WKWebView wrapper bundling the
+#    release `intendant` + `intendant-runtime` binaries) via
+#    scripts/bundle-macos.sh, built/signed/notarized on the fleet Mac;
+#  - standalone Linux `intendant` binaries (x86_64 + aarch64), the
+#    checksum-pinned fast path for Codex Cloud / remote-compute workers
+#    (scripts/codex-cloud/setup.sh's INTENDANT_CLOUD_BINARY_URL lane;
+#    docs/src/codex-cloud-workers.md, "Environment bootstrap");
+#  - the release-pinned install scripts.
+# Every published asset is PGP-signed and committed to the public
+# transparency log by the same steps, whichever job built it.
 #
 # Triggers are version tags (v*) and manual dispatch ONLY — deliberately
 # never pull_request or merge_group, so this workflow can never gate the
@@ -87,12 +95,69 @@ permissions:
 
 # One release build at a time per ref; never cancel a half-published release.
 concurrency:
-  group: macos-release-${{ github.ref }}
+  group: release-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
+  # Standalone Linux binaries: the checksum-pinned worker fast path.
+  # Built on GitHub-hosted runners deliberately — an ephemeral image with
+  # a known library baseline (the glibc + system libs of ubuntu-24.04,
+  # the same image the fork-PR CI legs prove the tree builds on) rather
+  # than a long-lived fleet box; per-arch native runners, so no cross
+  # toolchain. The binaries flow into the macos-app job's dist/, where
+  # the PGP sign, publish, and transparency-log steps cover them exactly
+  # like the app archive and installers.
+  linux-binaries:
+    name: linux-binaries (${{ matrix.target }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-24.04
+            asset: intendant-linux-x86_64
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+            asset: intendant-linux-aarch64
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # The build-time subset of scripts/setup-linux.sh's APT_PACKAGES the
+      # hosted CI legs install (windows.yml carries the canonical comment
+      # on why exactly these).
+      - name: Install Linux build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            pkg-config libclang-dev libvpx-dev libpipewire-0.3-dev \
+            libxcb1-dev libxcb-shm0-dev libxcb-randr0-dev
+
+      - name: Build release binary
+        run: cargo build --release --locked --bin intendant
+
+      - name: Stage asset
+        run: |
+          set -euo pipefail
+          mkdir -p out
+          cp target/release/intendant "out/${{ matrix.asset }}"
+          (cd out && sha256sum "${{ matrix.asset }}" > "${{ matrix.asset }}.sha256")
+          ls -l out
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ matrix.asset }}
+          path: out/*
+          if-no-files-found: error
+
   macos-app:
     name: macos-app
+    # The whole release publishes or none of it does: a red Linux leg must
+    # stop the publish/transparency steps, which all live in this job.
+    needs: linux-binaries
     # Tags and manual dispatch only exist on trusted refs, so this always
     # runs on the fleet Mac (same label windows.yml places its macOS leg on);
     # there is no fork-PR path to route to hosted runners.
@@ -409,6 +474,31 @@ jobs:
           (cd dist && shasum -a 256 install.ps1 > install.ps1.sha256)
           ls -l dist
 
+      # Pull the Linux worker binaries into dist/ so the PGP sign,
+      # publish, and transparency-log steps below cover them exactly like
+      # the app archive and installers.
+      - name: Collect Linux release binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: intendant-linux-*
+          path: dist
+          merge-multiple: true
+
+      # Re-verify the staged checksums: proves the artifact transport
+      # delivered the built bytes AND that each .sha256 verifies by name
+      # from inside dist/ — the exact ritual the release notes document.
+      - name: Verify collected Linux binaries
+        shell: bash
+        run: |
+          set -euo pipefail
+          for asset in intendant-linux-x86_64 intendant-linux-aarch64; do
+            if [ ! -f "dist/$asset" ]; then
+              echo "::error::dist/$asset missing after artifact download"
+              exit 1
+            fi
+            (cd dist && shasum -a 256 -c "$asset.sha256")
+          done
+
       # Every artifact that will publish gets a detached armored signature
       # from the release signing subkey; the repo-committed public key is
       # staged beside them byte-identically; and every signature is
@@ -518,6 +608,12 @@ jobs:
             echo '```'
             cat dist/*.sha256
             echo '```'
+            echo
+            echo "**Linux worker binaries (Codex Cloud / remote compute):** standalone \`intendant\` binaries for x86_64 and aarch64 glibc Linux (built on ubuntu-24.04; they need that image's library baseline at runtime — glibc 2.39+, libvpx, libpipewire, libxcb). They exist for the checksum-pinned worker bootstrap fast path; configure the Codex Cloud environment with:"
+            echo '```'
+            echo "INTENDANT_CLOUD_BINARY_URL=https://github.com/$GITHUB_REPOSITORY/releases/download/$tag/intendant-linux-x86_64"
+            echo "INTENDANT_CLOUD_BINARY_SHA256=$(awk '{print $1}' dist/intendant-linux-x86_64.sha256)"
+            echo '```'
           } > "$RUNNER_TEMP/release-notes.md"
           if gh release view "$tag" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
             gh release upload "$tag" dist/* --clobber --repo "$GITHUB_REPOSITORY"
@@ -579,7 +675,7 @@ jobs:
           print(json.dumps({
               "tag": tag,
               "version": tag.removeprefix("v"),
-              "platforms": ["macos-arm64"],
+              "platforms": ["macos-arm64", "linux-x86_64", "linux-aarch64"],
               "pgp_fingerprint": fingerprint,
               "artifacts": artifacts,
           }, indent=2))
@@ -600,6 +696,6 @@ jobs:
         if: github.ref_type != 'tag'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: intendant-macos-app
+          name: intendant-release-dist
           path: dist/*
           if-no-files-found: error

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -438,7 +438,7 @@ the name key, `runner` is the fleet placement):
 - **`audit.yml`** — `cargo audit` on push/PR plus a weekly cron (Mondays 08:00 UTC). Advisory only — new upstream advisories must not block unrelated landings.
 - **`codeql.yml`** — build-free Rust + Actions analysis on relevant `main` pushes and a weekly cron (Mondays 09:00 UTC). Advisory and GitHub-hosted; never a merge-queue requirement.
 - **`docs.yml`** — mdBook (`docs/`) deploy to GitHub Pages on push to `main`.
-- **`release.yml`** — macOS app build/sign/notarize/publish plus transparency-log hash submission on `v*` tags or manual dispatch. Tag releases fail closed without signing credentials; a manual credential-less run emits an explicitly `-unsigned-dev` dry-run artifact. Not a merge-queue requirement.
+- **`release.yml`** — release lane on `v*` tags or manual dispatch: macOS app build/sign/notarize/publish, standalone Linux worker binaries (x86_64 + aarch64, the Codex Cloud `INTENDANT_CLOUD_BINARY_URL` fast path, built on hosted runners), and transparency-log hash submission covering every asset. Tag releases fail closed without signing credentials; a manual credential-less run emits an explicitly `-unsigned-dev` dry-run artifact. Not a merge-queue requirement.
 
 The `tests/skills/` scenarios that need real API calls or a display (the live
 haiku claude-code-e2e, browser/Station probes, the peer smoke's `--browser` leg)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,7 +438,7 @@ the name key, `runner` is the fleet placement):
 - **`audit.yml`** — `cargo audit` on push/PR plus a weekly cron (Mondays 08:00 UTC). Advisory only — new upstream advisories must not block unrelated landings.
 - **`codeql.yml`** — build-free Rust + Actions analysis on relevant `main` pushes and a weekly cron (Mondays 09:00 UTC). Advisory and GitHub-hosted; never a merge-queue requirement.
 - **`docs.yml`** — mdBook (`docs/`) deploy to GitHub Pages on push to `main`.
-- **`release.yml`** — macOS app build/sign/notarize/publish plus transparency-log hash submission on `v*` tags or manual dispatch. Tag releases fail closed without signing credentials; a manual credential-less run emits an explicitly `-unsigned-dev` dry-run artifact. Not a merge-queue requirement.
+- **`release.yml`** — release lane on `v*` tags or manual dispatch: macOS app build/sign/notarize/publish, standalone Linux worker binaries (x86_64 + aarch64, the Codex Cloud `INTENDANT_CLOUD_BINARY_URL` fast path, built on hosted runners), and transparency-log hash submission covering every asset. Tag releases fail closed without signing credentials; a manual credential-less run emits an explicitly `-unsigned-dev` dry-run artifact. Not a merge-queue requirement.
 
 The `tests/skills/` scenarios that need real API calls or a display (the live
 haiku claude-code-e2e, browser/Station probes, the peer smoke's `--browser` leg)

--- a/docs/src/codex-cloud-workers.md
+++ b/docs/src/codex-cloud-workers.md
@@ -695,6 +695,46 @@ Cloud environment settings. They are intentionally split by lifecycle:
    directory), then `exec`s the supplied foreground command without shell
    re-parsing.
 
+### Pinned binary fast path (recommended)
+
+Building the release binary from source is the slow half of a cold worker:
+on an observed two-vCPU lease it consumed most of the first turn (14m41s to
+provider-ready, 2026-08-02), while a checksum-pinned download attaches well
+inside it. Every tagged release publishes standalone Linux binaries as
+PGP-signed, transparency-logged assets — `intendant-linux-x86_64` and
+`intendant-linux-aarch64` — and the release notes carry the ready-made pin
+block (v0.1.0 predates these assets; pin a newer release):
+
+```
+INTENDANT_CLOUD_BINARY_URL=https://github.com/intendant-dev/Intendant/releases/download/<tag>/intendant-linux-x86_64
+INTENDANT_CLOUD_BINARY_SHA256=<from the release notes or the .sha256 asset>
+```
+
+Set both in the Codex Cloud environment (setup-time configuration, not
+secrets). Take the SHA-256 from a release you have verified — `gpg
+--verify` against the committed `RELEASE-SIGNING-KEY.asc` and `intendant
+hosted-verify --releases <tag>` check every asset against its detached
+signature and the public transparency log (see
+[Verifying a release](./getting-started.md#verifying-a-release)); the hash
+pin is what the container itself enforces. `setup.sh` refuses a mismatched
+download, and a binary that cannot start fails the bootstrap loudly (the
+trailing `codex-cloud --help` probe) instead of silently rebuilding.
+
+Two honest bounds. The assets are built on `ubuntu-24.04` and need that
+image's library baseline at runtime — glibc 2.39+, libvpx, libpipewire,
+libxcb; the Codex universal image satisfies it, and an older container
+keeps the source-build path by leaving the pin unset. And the pin is a
+*compatibility* choice, not only a speed one: a source-built worker runs
+whatever revision the task checked out, so its attachment agent floats
+with the branch under test, while a pinned asset keeps the attachment
+agent deterministic per environment and tracking the home daemon's
+release. A worker whose attachment protocol has drifted fails enrollment
+with the remedy in the error text (`unsupported enrollment request
+version N: this daemon speaks M — repin INTENDANT_CLOUD_BINARY_URL/_SHA256
+to a matching release, or rebuild the worker from source`), and the
+enrollment fingerprint records the worker binary's version, commit, and
+target, so `status` shows what actually attached (`worker binary:` line).
+
 For sccache, setup reuses any installed version 0.14 or newer. Otherwise it
 downloads the pinned 0.15.0 official Linux musl archive for x86_64 or aarch64,
 verifies its hard-coded SHA-256, and installs the single binary; compiling the

--- a/scripts/codex-cloud/setup.sh
+++ b/scripts/codex-cloud/setup.sh
@@ -39,6 +39,17 @@ install_downloaded_binary() {
     return 2
   fi
 
+  # Cached resumes re-run setup through maintenance.sh: when the installed
+  # binary already hashes to the pin, the download is pure waste.
+  if [[ -x "$bin_dir/intendant" ]]; then
+    local existing
+    existing="$(file_sha256 "$bin_dir/intendant")" || existing=""
+    if [[ "$existing" == "$INTENDANT_CLOUD_BINARY_SHA256" ]]; then
+      echo "pinned Intendant binary already installed (sha256 match)"
+      return 0
+    fi
+  fi
+
   local actual
   downloaded="$(mktemp)"
   curl --fail --silent --show-error --location \
@@ -169,5 +180,8 @@ if [[ ! -f "$script_root/run-worker.sh" ]]; then
 fi
 install -m 0755 "$script_root/run-worker.sh" "$libexec_dir/run-worker.sh"
 
-"$bin_dir/intendant" codex-cloud --help >/dev/null
+if ! "$bin_dir/intendant" codex-cloud --help >/dev/null; then
+  echo "installed Intendant binary failed to run. If it came from INTENDANT_CLOUD_BINARY_URL, this container is likely older than the asset's ubuntu-24.04 library baseline (glibc 2.39+, libvpx, libpipewire, libxcb) — unset the pin to build from source instead." >&2
+  exit 2
+fi
 echo "Intendant Codex Cloud bootstrap installed at $bin_dir/intendant"

--- a/src/bin/caller/codex_cloud.rs
+++ b/src/bin/caller/codex_cloud.rs
@@ -133,6 +133,17 @@ pub struct WorkerFingerprint {
     pub git_rev: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rustc: Option<String>,
+    /// Provenance of the worker's own Intendant binary, filled by the
+    /// running worker agent at enrollment. Probe-script fingerprints
+    /// measure the environment, not the binary, and leave these absent.
+    /// Distinct from `git_rev` (the checkout's HEAD): a release-asset
+    /// worker binary runs source at a different revision than its own.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub intendant_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub intendant_git_sha: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub intendant_target: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cpus: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -973,6 +984,9 @@ pub(crate) fn parse_probe_fingerprint(diff_text: &str) -> Option<WorkerFingerpri
             unix_ms: num("unix_ms"),
             git_rev: text("git_rev"),
             rustc: text("rustc"),
+            intendant_version: text("intendant_version"),
+            intendant_git_sha: text("intendant_git_sha"),
+            intendant_target: text("intendant_target"),
             cpus: num("cpus"),
             mem_kb: num("mem_kb"),
             collected_at_unix_ms: now_unix_ms(),
@@ -2624,6 +2638,13 @@ fn print_lease(lease: &WorkerLease) {
             "  worker: {}{boot}",
             worker.hostname.as_deref().unwrap_or("unknown-host")
         );
+        if let Some(version) = worker.intendant_version.as_deref() {
+            println!(
+                "  worker binary: {version} (commit {}, {})",
+                worker.intendant_git_sha.as_deref().unwrap_or("unknown"),
+                worker.intendant_target.as_deref().unwrap_or("unknown"),
+            );
+        }
     }
     if lease.cold_replacements_observed > 0 {
         println!(
@@ -3900,6 +3921,9 @@ index 0000000..ce01362\n\
             unix_ms: None,
             git_rev: None,
             rustc: None,
+            intendant_version: None,
+            intendant_git_sha: None,
+            intendant_target: None,
             cpus: None,
             mem_kb: None,
             collected_at_unix_ms: 1,
@@ -3917,6 +3941,9 @@ index 0000000..ce01362\n\
             unix_ms: None,
             git_rev: None,
             rustc: None,
+            intendant_version: None,
+            intendant_git_sha: None,
+            intendant_target: None,
             cpus: None,
             mem_kb: None,
             collected_at_unix_ms: 1,

--- a/src/bin/caller/codex_cloud_attach.rs
+++ b/src/bin/caller/codex_cloud_attach.rs
@@ -561,6 +561,16 @@ pub(crate) fn enroll_rate_ok(source: &str, now_ms: u64) -> bool {
     true
 }
 
+/// Version of the whole home↔worker attachment contract: the enroll body,
+/// the WebSocket hello/proof ceremony, and the closed frame vocabulary in
+/// both directions. Additive changes (new optional fingerprint fields, new
+/// reply kinds the other end drops) do NOT bump it; bump it on any change
+/// an older binary on the other end would misread. This is the number a
+/// release-asset worker pins: `redeem_enrollment`'s refusal string is the
+/// exact text such a worker surfaces as its enrollment failure, so keep it
+/// actionable (it must name the environment repin).
+pub const ATTACHMENT_PROTOCOL_VERSION: u32 = 1;
+
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct EnrollRequest {
@@ -606,9 +616,9 @@ pub fn redeem_enrollment(
     request: &EnrollRequest,
     now_ms: u64,
 ) -> Result<EnrollResponse, String> {
-    if request.version != 1 {
+    if request.version != ATTACHMENT_PROTOCOL_VERSION {
         return Err(format!(
-            "unsupported enrollment request version {}",
+            "unsupported enrollment request version {}: this daemon speaks {ATTACHMENT_PROTOCOL_VERSION} — repin INTENDANT_CLOUD_BINARY_URL/_SHA256 to a matching release, or rebuild the worker from source",
             request.version
         ));
     }
@@ -678,7 +688,7 @@ pub fn redeem_enrollment(
         record_worker_json(lease_store_path, &task_id, worker);
     }
     Ok(EnrollResponse {
-        version: 1,
+        version: ATTACHMENT_PROTOCOL_VERSION,
         task_id,
         profile: profile.to_string(),
         client_cert_pem: cert_pem,
@@ -1308,7 +1318,7 @@ pub async fn run_agent(args: &[String]) -> Result<(), String> {
     .map_err(|e| format!("build enroll HTTP client: {e}"))?;
     let worker_fingerprint = collect_worker_fingerprint(crate::codex_cloud::now_unix_ms());
     let enrollment_payload = serde_json::to_vec(&serde_json::json!({
-        "version": 1,
+        "version": ATTACHMENT_PROTOCOL_VERSION,
         "token": &token,
         "public_key_pem": key_pair.public_key_pem(),
         "worker": &worker_fingerprint,
@@ -1768,6 +1778,9 @@ fn collect_worker_fingerprint(now_ms: u64) -> crate::codex_cloud::WorkerFingerpr
             })
             .filter(|revision| !revision.is_empty()),
         rustc: None,
+        intendant_version: Some(crate::build_info::pkg_version().to_string()),
+        intendant_git_sha: Some(crate::build_info::git_sha().to_string()),
+        intendant_target: Some(crate::build_info::target_triple().to_string()),
         cpus: std::thread::available_parallelism()
             .ok()
             .map(|count| count.get() as u64),
@@ -2514,6 +2527,63 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.contains("not found"), "{err}");
+    }
+
+    #[test]
+    fn enrollment_refuses_version_drift_with_repin_guidance() {
+        // The version gate fires before any filesystem or token work, so
+        // placeholder roots prove no side effect can precede the refusal.
+        let err = redeem_enrollment(
+            Path::new("unused-cert-dir"),
+            Path::new("unused-lease-store"),
+            &EnrollRequest {
+                version: ATTACHMENT_PROTOCOL_VERSION + 1,
+                token: "irrelevant".into(),
+                public_key_pem: String::new(),
+                worker: None,
+            },
+            5_000,
+        )
+        .unwrap_err();
+        // A pinned release-asset worker surfaces this string as its
+        // enrollment failure: it must name both versions and the repin.
+        let refused = format!(
+            "unsupported enrollment request version {}",
+            ATTACHMENT_PROTOCOL_VERSION + 1
+        );
+        assert!(err.contains(&refused), "{err}");
+        assert!(
+            err.contains(&format!("speaks {ATTACHMENT_PROTOCOL_VERSION}")),
+            "{err}"
+        );
+        assert!(err.contains("INTENDANT_CLOUD_BINARY_URL"), "{err}");
+    }
+
+    #[test]
+    fn collected_fingerprint_carries_binary_provenance() {
+        let fingerprint = collect_worker_fingerprint(1_234);
+        assert_eq!(
+            fingerprint.intendant_version.as_deref(),
+            Some(env!("CARGO_PKG_VERSION"))
+        );
+        assert!(fingerprint.intendant_git_sha.is_some());
+        assert!(fingerprint.intendant_target.is_some());
+    }
+
+    #[test]
+    fn fingerprint_parse_tolerates_newer_worker_fields() {
+        // An older home receiving a newer worker's enrollment fingerprint
+        // must record what it knows and ignore the rest — the additive
+        // half of the ATTACHMENT_PROTOCOL_VERSION contract.
+        let fingerprint =
+            serde_json::from_value::<crate::codex_cloud::WorkerFingerprint>(serde_json::json!({
+                "hostname": "worker-a",
+                "intendant_version": "9.9.9",
+                "field_from_the_future": {"nested": true},
+            }))
+            .expect("unknown fingerprint fields must never fail the parse");
+        assert_eq!(fingerprint.hostname.as_deref(), Some("worker-a"));
+        assert_eq!(fingerprint.intendant_version.as_deref(), Some("9.9.9"));
     }
 
     #[test]


### PR DESCRIPTION
Works agenda item 01KZ0HWYF69W8ARG3JCZAGCHFH (Codex Cloud cold acquisition must attach before the provider turn ends). The remaining cold bottleneck was setup.sh compiling the full release binary on a two-vCPU worker (14m41s observed); the ratified direction is the release-asset fast path first, with the dedicated intendant-worker binary parked as phase 2.

## What this does

- **release.yml**: new `linux-binaries` matrix job (x86_64 on ubuntu-24.04, aarch64 on ubuntu-24.04-arm) building `intendant` with `--release --locked`; artifacts flow into the macos-app job's `dist/`, so the existing PGP sign, publish, and transparency-log steps cover them exactly like the app archive and installers. A verify step re-checks the staged checksums; the release notes print the ready-made `INTENDANT_CLOUD_BINARY_URL/_SHA256` pin block; the logged manifest's `platforms` gains the two Linux labels. Connect's submission gate needs no change (artifact limit 256, .asc pairing satisfied by the sign script).
- **Enrollment compatibility contract**: `ATTACHMENT_PROTOCOL_VERSION` (= the existing enroll `version` field) documents the bump law; version drift is refused with the repin remedy in the error text (a pinned worker surfaces exactly that string). The worker's enrollment fingerprint now records its binary's version / commit / target triple via `build_info`, tolerated in both deploy directions (older home ignores unknown fingerprint fields; older worker simply omits them), and `codex-cloud status` renders a `worker binary:` line.
- **setup.sh**: cached resumes skip the download when the installed binary already hashes to the pin; the trailing run-probe failure now names the ubuntu-24.04 library-baseline remedy instead of dying on a bare linker error.
- **Docs**: new "Pinned binary fast path" section in codex-cloud-workers.md; CLAUDE.md/AGENTS.md release-lane line updated (byte parity kept).

## Test plan

- `cargo check --bin intendant` green in the worktree.
- New tests: version-drift refusal names both versions + the repin; collected fingerprint carries binary provenance; fingerprint parse tolerates newer-worker fields; existing same-boot/cold-replacement tests extended for the new fields.
- `actionlint` clean on the edited workflow; `cargo fmt --check` clean.
- Full local battery (bins tests, lib crates, clippy) before ready.

Acceptance (the item's genuinely-uncached two-vCPU run, two concurrent revisions, and the 3600s default after removing the stale supervisor override) needs the first release that actually publishes these assets — staged separately.