### PR TITLE
release: bump to 0.2.0-alpha.1; prerelease tags publish as GitHub prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -544,6 +544,15 @@ jobs:
           command -v gh > /dev/null || { echo "::error::gh CLI not found on the runner"; exit 1; }
           tag="$GITHUB_REF_NAME"
           zip_file="$(ls dist/Intendant-*.zip)"
+          # A semver pre-release identifier in the tag (v0.2.0-alpha.1)
+          # publishes as a GitHub prerelease: badged on the release page
+          # and never surfaced as the repository's "latest" release. The
+          # transparency log and the update lane's release check carry
+          # prereleases like any other tag build.
+          prerelease_flag=""
+          case "$tag" in
+            *-*) prerelease_flag="--prerelease" ;;
+          esac
           # Belt and suspenders behind the signing gate. A half-Apple
           # artifact never publishes; with the Apple lane engaged, neither
           # does an unsigned one. With the Apple lane dormant (lane D),
@@ -582,6 +591,10 @@ jobs:
             signing_note="This alpha is deliberately not Apple-signed (no Developer ID): the app archive keeps its explicit \`-unsigned-dev\` suffix and Gatekeeper will warn on first open. Authenticity rides the detached PGP signatures and the public transparency log — verify before opening."
           fi
           {
+            if [ -n "$prerelease_flag" ]; then
+              echo "> **Alpha prerelease.** Intendant is early software: interfaces, trust ceremonies, and defaults are still moving. Run it where rough edges are acceptable, and verify what you download."
+              echo
+            fi
             echo "Native macOS app: the \`macos-app/\` WKWebView wrapper bundling the release \`intendant\` and \`intendant-runtime\` binaries (Apple Silicon)."
             echo
             echo "$signing_note"
@@ -618,11 +631,15 @@ jobs:
           if gh release view "$tag" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
             gh release upload "$tag" dist/* --clobber --repo "$GITHUB_REPOSITORY"
           else
+            # $prerelease_flag is deliberately unquoted: empty for final
+            # releases, one flag for pre-release tags.
+            # shellcheck disable=SC2086
             gh release create "$tag" dist/* \
               --repo "$GITHUB_REPOSITORY" \
               --verify-tag \
               --title "Intendant $tag" \
-              --notes-file "$RUNNER_TEMP/release-notes.md"
+              --notes-file "$RUNNER_TEMP/release-notes.md" \
+              $prerelease_flag
           fi
 
       # Commit what was just published to the public transparency log:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "intendant"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 dependencies = [
  "accessibility-sys",
  "app-html-assembler",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 
 [package]
 name = "intendant"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 edition = "2021"
 license = "MIT"
 


### PR DESCRIPTION
Prepares the v0.2.0-alpha.1 tag (owner-requested: the release must read clearly as alpha).

- Cargo.toml/lock: 0.1.0 → 0.2.0-alpha.1 (the release workflow's version-identity gate requires the tag to match).
- release.yml: tags containing a pre-release identifier publish with `--prerelease` and the notes lead with an alpha banner. Verified: the update lane's `release_version_newer` triple-compare tolerates pre-release suffixes by design, `parse_version_line` takes the token whole, and connect's manifest validation accepts the version string.
- actionlint clean; version-line + release-compare tests green under the new version.