### PR TITLE
bundle-macos: compare the signing keychain search-list entry by resolved path

### DIFF
--- a/scripts/bundle-macos.sh
+++ b/scripts/bundle-macos.sh
@@ -107,9 +107,22 @@ die() {
 # trusting the write, and name the remedy.
 require_keychain_in_search_list() {
     local keychain="$1"
-    if security list-keychains -d user | sed 's/^ *"//; s/"$//' | grep -qxF "$keychain"; then
-        return 0
-    fi
+    # The search list stores canonicalized paths — on macOS /var is a
+    # symlink to /private/var, so an entry written as
+    # ~/.intendant/signing.keychain-db lists back as
+    # /private/var/…/signing.keychain-db and a literal comparison against
+    # the $HOME spelling never matches (first fleet run of this preflight
+    # failed exactly there, 2026-08-02, on a correctly provisioned box).
+    # Compare resolved paths; when realpath is unavailable or fails, fall
+    # back to the raw spelling, which preserves the old exact-match check.
+    local resolved entry entry_resolved
+    resolved="$(realpath "$keychain" 2>/dev/null || echo "$keychain")"
+    while IFS= read -r entry; do
+        entry_resolved="$(realpath "$entry" 2>/dev/null || echo "$entry")"
+        if [ "$entry_resolved" = "$resolved" ] || [ "$entry" = "$keychain" ]; then
+            return 0
+        fi
+    done < <(security list-keychains -d user | sed 's/^ *"//; s/"$//')
     {
         echo "Error: signing keychain is not in the user keychain search list:"
         echo "  $keychain"


### PR DESCRIPTION
Unblocks the v0.2.0-alpha.1 tag build. The release dry-run's macos-app leg failed at the (post-v0.1.0, ec9c5e3c) keychain preflight on a box whose search list DOES contain the signing keychain — stored canonicalized as /private/var/…, compared literally against the $HOME spelling /var/…. Resolved-path comparison, with a raw-spelling fallback that preserves the old exact-match behavior where realpath is missing.

Validated end-to-end on the fleet runner account: the patched function against the live search list passes (`ONBOX-PASS`); `bash -n` clean. The Linux legs of the same dry-run were green, so this is the last blocker before tagging.