### PR TITLE
mcp: don't double the create-failed prefix on create_virtual_display

### DIFF
--- a/src/bin/caller/mcp/tools_display.rs
+++ b/src/bin/caller/mcp/tools_display.rs
@@ -191,6 +191,13 @@ impl IntendantServer {
                 Ok(Ok(AppEvent::DisplayCaptureLost { display_id, reason }))
                     if !known.contains(&display_id) =>
                 {
+                    // The handler's failure reasons already carry this
+                    // prefix (virtual_display.rs phrases them for the
+                    // dashboard's capture-lost surface); only bare
+                    // reasons need it added.
+                    if reason.starts_with("virtual display create failed") {
+                        return reason;
+                    }
                     return format!("virtual display create failed: {reason}");
                 }
                 Ok(Ok(_)) => continue,


### PR DESCRIPTION
The virtual-display handler's failure reasons already carry the "virtual display create failed:" prefix (phrased for the dashboard's capture-lost surface), so the MCP tool's own prefix doubled it — observed live on the Windows clear-error path. Bare reasons still get the prefix added.