### PR TITLE
release: bump to v0.2.0-alpha.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "intendant"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "accessibility-sys",
  "app-html-assembler",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 
 [package]
 name = "intendant"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 edition = "2021"
 license = "MIT"
 


### PR DESCRIPTION
## What changed

- Bump the Intendant package and lockfile version from `0.2.0-alpha.2` to `0.2.0-alpha.3`.

## Why

Publish the Codex Cloud automatic-acquisition fix merged in #774 so the pinned Linux worker and the home daemon can both run the corrected authenticated-hello provenance sequencing.

## Validation

- `cargo metadata --no-deps --format-version 1` reports `0.2.0-alpha.3`.
- `git diff --check` passes.
- The underlying scheduler fix passed its Linux Cloud regression test and all merge-group checks in #774.