### PR TITLE
peer display: H.264 fallback after the VP8 pin so Windows peers can answer

### DIFF
--- a/static/app.html
+++ b/static/app.html
@@ -38862,7 +38862,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'a74487d80a282faa';
+const INTENDANT_APP_BUILD = 'b7f20b39b3a92bf6';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -117918,7 +117918,9 @@ const PEER_DISPLAY_POLICY = {
     return pcConfig;
   },
 
-  // **#67 (federated VP8 A/B)**: pin codec preference to VP8 only.
+  // **#67 (federated VP8 A/B)**: prefer VP8 (H.264 trails as the
+  // only-codec fallback for peers that cannot encode VP8 at all — see
+  // the default arm below).
   // Distinct from the local DisplaySlot path (#58) which deliberately
   // lets WKWebView default H.264 first to get the hardware-accelerated
   // VideoToolbox encoder on the macOS Mac viewing its own display.
@@ -117991,18 +117993,30 @@ const PEER_DISPLAY_POLICY = {
           'leaving codec order at browser default');
       }
     } else if (videoTransceiver && typeof videoTransceiver.setCodecPreferences === 'function') {
+      // Default order: VP8 first (the #67 loss-resilience preference —
+      // any peer that CAN encode VP8 answers VP8, exactly as the old
+      // VP8-only pin produced), then H.264 as a trailing fallback.
+      // The fallback exists for peers whose encoder pool has no VP8
+      // at all — every Windows peer (Media Foundation is H.264-only)
+      // — which the VP8-only pin hard-failed with NoCompatibleCodec:
+      // the peer never answered and the viewer surfaced the misleading
+      // no-track watchdog ("may need a capture grant"). Observed live
+      // against a Windows 11 peer, 2026-08-02.
       const caps = (typeof RTCRtpReceiver !== 'undefined' && RTCRtpReceiver.getCapabilities)
         ? RTCRtpReceiver.getCapabilities('video')
         : null;
-      const vp8 = caps && caps.codecs
-        ? caps.codecs.filter(c => c.mimeType && c.mimeType.toLowerCase() === 'video/vp8')
-        : [];
+      const allCodecs = caps && caps.codecs ? caps.codecs : [];
+      const mime = (c) => (c && c.mimeType ? c.mimeType.toLowerCase() : '');
+      const vp8 = allCodecs.filter(c => mime(c) === 'video/vp8');
+      const h264 = allCodecs.filter(c => mime(c) === 'video/h264');
       if (vp8.length > 0) {
         try {
-          videoTransceiver.setCodecPreferences(vp8);
-          log('info', `codec preference pinned to VP8 (${vp8.length} variant(s))`);
+          videoTransceiver.setCodecPreferences(vp8.concat(h264));
+          log('info',
+            `codec preference pinned to VP8 (${vp8.length} variant(s)) ` +
+            `with H.264 fallback (${h264.length} variant(s))`);
         } catch (e) {
-          log('warn', `setCodecPreferences(VP8) failed: ${e.message} — falling back to browser default`);
+          log('warn', `setCodecPreferences(VP8+H264) failed: ${e.message} — falling back to browser default`);
         }
       } else {
         log('warn', 'no VP8 in RTCRtpReceiver capabilities — leaving codec order at browser default');

--- a/static/app/52-peer-display.js
+++ b/static/app/52-peer-display.js
@@ -59,7 +59,9 @@ const PEER_DISPLAY_POLICY = {
     return pcConfig;
   },
 
-  // **#67 (federated VP8 A/B)**: pin codec preference to VP8 only.
+  // **#67 (federated VP8 A/B)**: prefer VP8 (H.264 trails as the
+  // only-codec fallback for peers that cannot encode VP8 at all — see
+  // the default arm below).
   // Distinct from the local DisplaySlot path (#58) which deliberately
   // lets WKWebView default H.264 first to get the hardware-accelerated
   // VideoToolbox encoder on the macOS Mac viewing its own display.
@@ -132,18 +134,30 @@ const PEER_DISPLAY_POLICY = {
           'leaving codec order at browser default');
       }
     } else if (videoTransceiver && typeof videoTransceiver.setCodecPreferences === 'function') {
+      // Default order: VP8 first (the #67 loss-resilience preference —
+      // any peer that CAN encode VP8 answers VP8, exactly as the old
+      // VP8-only pin produced), then H.264 as a trailing fallback.
+      // The fallback exists for peers whose encoder pool has no VP8
+      // at all — every Windows peer (Media Foundation is H.264-only)
+      // — which the VP8-only pin hard-failed with NoCompatibleCodec:
+      // the peer never answered and the viewer surfaced the misleading
+      // no-track watchdog ("may need a capture grant"). Observed live
+      // against a Windows 11 peer, 2026-08-02.
       const caps = (typeof RTCRtpReceiver !== 'undefined' && RTCRtpReceiver.getCapabilities)
         ? RTCRtpReceiver.getCapabilities('video')
         : null;
-      const vp8 = caps && caps.codecs
-        ? caps.codecs.filter(c => c.mimeType && c.mimeType.toLowerCase() === 'video/vp8')
-        : [];
+      const allCodecs = caps && caps.codecs ? caps.codecs : [];
+      const mime = (c) => (c && c.mimeType ? c.mimeType.toLowerCase() : '');
+      const vp8 = allCodecs.filter(c => mime(c) === 'video/vp8');
+      const h264 = allCodecs.filter(c => mime(c) === 'video/h264');
       if (vp8.length > 0) {
         try {
-          videoTransceiver.setCodecPreferences(vp8);
-          log('info', `codec preference pinned to VP8 (${vp8.length} variant(s))`);
+          videoTransceiver.setCodecPreferences(vp8.concat(h264));
+          log('info',
+            `codec preference pinned to VP8 (${vp8.length} variant(s)) ` +
+            `with H.264 fallback (${h264.length} variant(s))`);
         } catch (e) {
-          log('warn', `setCodecPreferences(VP8) failed: ${e.message} — falling back to browser default`);
+          log('warn', `setCodecPreferences(VP8+H264) failed: ${e.message} — falling back to browser default`);
         }
       } else {
         log('warn', 'no VP8 in RTCRtpReceiver capabilities — leaving codec order at browser default');


### PR DESCRIPTION
The federated viewer's #67 VP8-only codec pin makes any H.264-only peer (all Windows peers — Media Foundation) fail subscription with NoCompatibleCodec: the peer never answers and the viewer surfaces the misleading no-track watchdog ('its display may need a capture grant'). Diagnosed live against a Windows 11 peer by observing its event bus during a headless-driven open: `pool-mode subscribe failed for peer prefs [Vp8]: NoCompatibleCodec`.

Default codec preference becomes **VP8 first, H.264 trailing** — identical outcome for every VP8-capable peer (Linux answers VP8 as before), and H.264-only peers can finally answer. `federation_allow_h264` still forces H.264-first. Verified against the real Windows peer with a worktree-built daemon: offer answered (sdp_len=2107), pane Connected, tile lane rendering.