### PR TITLE
Link-aware ladder for the federated H.264 layer

### DIFF
--- a/crates/intendant-display/src/aggregator.rs
+++ b/crates/intendant-display/src/aggregator.rs
@@ -865,6 +865,87 @@ pub type OnDemandPauseProbe = Box<dyn Fn(&EncoderId) -> Option<bool> + Send + Sy
 /// Apply a pause (`true`) / resume (`false`) to one on-demand slot.
 pub type OnDemandPauseAction = Box<dyn Fn(&EncoderId, bool) + Send + Sync>;
 
+/// ── Federated H.264 link-aware ladder ─────────────────────────────
+///
+/// The federated slot spawns at the loss-safe Quarter rung
+/// ([`crate::encode::pool::FederatedRung`]); this policy steps it up
+/// only after the link has proven healthy for a sustained window, and
+/// back down the moment loss pressure appears. Health is read from the
+/// same per-peer aggregate-TWCC cascade the pause policies use:
+/// a fed-holder peer counts healthy only in
+/// [`AggregateLayerCapacity::AllUpperWanted`] — a missing TWCC entry
+/// (no feedback yet: video paused for tiles, or a fresh peer) counts
+/// UNhealthy, so the ladder can only climb while video actually flows
+/// and decays back toward Quarter across idle/tile stretches. With no
+/// fed holders at all the rung snaps back to Quarter so the next
+/// viewer starts safe.
+pub const FEDERATED_UPGRADE_HEALTHY: Duration = Duration::from_secs(10);
+/// Minimum spacing between rung changes (both directions) — an
+/// eviction/rebuild per change is cheap but not free, and flapping
+/// resolutions look worse than either shape.
+pub const FEDERATED_LADDER_DWELL: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone, Copy)]
+pub struct FederatedLadderState {
+    pub rung: crate::encode::pool::FederatedRung,
+    healthy_since: Option<Instant>,
+    last_change: Option<Instant>,
+}
+
+impl Default for FederatedLadderState {
+    fn default() -> Self {
+        Self {
+            rung: crate::encode::pool::FederatedRung::Quarter,
+            healthy_since: None,
+            last_change: None,
+        }
+    }
+}
+
+/// Advance the ladder one tick. Returns `Some(rung)` when the caller
+/// should apply a re-spec (the state's rung has already moved).
+pub fn advance_federated_ladder(
+    state: &mut FederatedLadderState,
+    any_fed_holder: bool,
+    all_holders_healthy: bool,
+    now: Instant,
+) -> Option<crate::encode::pool::FederatedRung> {
+    use crate::encode::pool::FederatedRung;
+    let dwell_ok = state
+        .last_change
+        .is_none_or(|at| now.duration_since(at) >= FEDERATED_LADDER_DWELL);
+    if !any_fed_holder {
+        state.healthy_since = None;
+        if state.rung != FederatedRung::Quarter {
+            state.rung = FederatedRung::Quarter;
+            state.last_change = Some(now);
+            return Some(state.rung);
+        }
+        return None;
+    }
+    if all_holders_healthy {
+        let since = *state.healthy_since.get_or_insert(now);
+        if state.rung != FederatedRung::Full
+            && dwell_ok
+            && now.duration_since(since) >= FEDERATED_UPGRADE_HEALTHY
+        {
+            state.rung = state.rung.up();
+            state.last_change = Some(now);
+            state.healthy_since = Some(now);
+            return Some(state.rung);
+        }
+        None
+    } else {
+        state.healthy_since = None;
+        if state.rung != FederatedRung::Quarter && dwell_ok {
+            state.rung = state.rung.down();
+            state.last_change = Some(now);
+            return Some(state.rung);
+        }
+        None
+    }
+}
+
 /// Per-peer facts the standby reconcile needs, snapshotted while the
 /// coordinator holds the peers read guard (so the reconcile itself runs
 /// lock-free).
@@ -955,6 +1036,7 @@ pub fn spawn_layer_policy_coordinator(
     is_layer_paused: LayerPauseProbe,
     on_action: Box<dyn Fn(CapacityAction) + Send + Sync>,
     on_demand: OnDemandStandbyHooks,
+    on_federated_respec: Box<dyn Fn(crate::encode::pool::FederatedRung) + Send + Sync>,
     demand_kick: Arc<Notify>,
     config: CapacityPolicyConfig,
     shutdown: CancellationToken,
@@ -967,6 +1049,9 @@ pub fn spawn_layer_policy_coordinator(
         // coordinator (not per-peer) because presence is a
         // display-level property.
         let mut presence_state = AggregatorState::Active;
+
+        // Federated H.264 link-aware ladder (see advance_federated_ladder).
+        let mut federated_ladder = FederatedLadderState::default();
 
         // Aggregate TWCC: one cascade state per peer.
         let mut twcc_state: HashMap<PeerId, AggregateLayerCapacity> = HashMap::new();
@@ -1039,19 +1124,24 @@ pub fn spawn_layer_policy_coordinator(
                 prev_measurement_count.retain(|(pid, _), _| current_peers.contains_key(pid));
             }
 
-            let peer_ids: Vec<PeerId> = current_peers.keys().cloned().collect();
             // Per-peer demand facts under the read guard: standby
             // flag + frozen codec/RID identity. Pinned, demanded,
-            // and the on-demand reconcile below all derive from
-            // this one walk.
-            let peer_demand: Vec<PeerDemandSnapshot> = current_peers
-                .values()
-                .map(|peer| PeerDemandSnapshot {
-                    video_standby: peer.video_standby(),
-                    active_codec: peer.active_codec(),
-                    active_rids: peer.active_rids().to_vec(),
+            // the on-demand reconcile, and the federated ladder all
+            // derive from this one walk — ids and snapshots come from
+            // the SAME iteration so zipping them stays sound.
+            let (peer_ids, peer_demand): (Vec<PeerId>, Vec<PeerDemandSnapshot>) = current_peers
+                .iter()
+                .map(|(id, peer)| {
+                    (
+                        *id,
+                        PeerDemandSnapshot {
+                            video_standby: peer.video_standby(),
+                            active_codec: peer.active_codec(),
+                            active_rids: peer.active_rids().to_vec(),
+                        },
+                    )
                 })
-                .collect();
+                .unzip();
             drop(current_peers);
             // #57: per-tick pinned-layer set. Each peer with
             // exactly one negotiated RID contributes that RID
@@ -1140,6 +1230,37 @@ pub fn spawn_layer_policy_coordinator(
                 }
                 aggregate_wanted_layers(per_peer)
             };
+
+            // ---- Federated H.264 ladder ----
+            // Health = the freshly-advanced aggregate-TWCC cascade:
+            // a fed holder counts healthy only at AllUpperWanted, and
+            // a missing entry (no feedback yet) counts unhealthy.
+            {
+                let fed_rid = SimulcastRid::federated();
+                let mut any_fed_holder = false;
+                let mut all_holders_healthy = true;
+                for (pid, demand) in peer_ids.iter().zip(peer_demand.iter()) {
+                    if demand.active_codec == crate::encode::pool::CodecKind::H264
+                        && demand.active_rids.contains(&fed_rid)
+                    {
+                        any_fed_holder = true;
+                        if !matches!(
+                            twcc_state.get(pid),
+                            Some(AggregateLayerCapacity::AllUpperWanted)
+                        ) {
+                            all_holders_healthy = false;
+                        }
+                    }
+                }
+                if let Some(rung) = advance_federated_ladder(
+                    &mut federated_ladder,
+                    any_fed_holder,
+                    all_holders_healthy,
+                    now,
+                ) {
+                    (on_federated_respec)(rung);
+                }
+            }
 
             // ---- Per-RID RR vote ----
             // Same shape: no peers → no restriction. Per-peer
@@ -2781,6 +2902,56 @@ mod tests {
         assert!(rec.actions.lock().unwrap().is_empty());
     }
 
+    // ----- federated H.264 ladder -----
+
+    #[test]
+    fn federated_ladder_climbs_on_health_drops_on_loss_resets_without_holders() {
+        use crate::encode::pool::FederatedRung;
+        let mut st = FederatedLadderState::default();
+        let t0 = Instant::now();
+
+        // Healthy but not sustained: no change.
+        assert_eq!(advance_federated_ladder(&mut st, true, true, t0), None);
+        assert_eq!(
+            advance_federated_ladder(&mut st, true, true, t0 + FEDERATED_UPGRADE_HEALTHY / 2),
+            None
+        );
+        // Sustained healthy: one rung up.
+        let t1 = t0 + FEDERATED_UPGRADE_HEALTHY;
+        assert_eq!(
+            advance_federated_ladder(&mut st, true, true, t1),
+            Some(FederatedRung::Half)
+        );
+        // Dwell blocks an immediate second step even when healthy long.
+        assert_eq!(
+            advance_federated_ladder(&mut st, true, true, t1 + Duration::from_secs(1)),
+            None
+        );
+        // Next sustained window: Full; then no further ups.
+        let t2 = t1 + FEDERATED_UPGRADE_HEALTHY;
+        assert_eq!(
+            advance_federated_ladder(&mut st, true, true, t2),
+            Some(FederatedRung::Full)
+        );
+        assert_eq!(
+            advance_federated_ladder(&mut st, true, true, t2 + FEDERATED_UPGRADE_HEALTHY),
+            None
+        );
+        // Loss: down one rung once dwell allows.
+        let t3 = t2 + FEDERATED_UPGRADE_HEALTHY + FEDERATED_LADDER_DWELL;
+        assert_eq!(
+            advance_federated_ladder(&mut st, true, false, t3),
+            Some(FederatedRung::Half)
+        );
+        // No holders: snap back to Quarter (once dwell allows).
+        let t4 = t3 + FEDERATED_LADDER_DWELL;
+        assert_eq!(
+            advance_federated_ladder(&mut st, false, true, t4),
+            Some(FederatedRung::Quarter)
+        );
+        assert_eq!(advance_federated_ladder(&mut st, false, true, t4), None);
+    }
+
     // ----- tile-standby: coordinator demand mask -----
 
     /// End-to-end through the spawned coordinator: a tile-standby peer
@@ -2826,6 +2997,7 @@ mod tests {
             is_layer_paused,
             on_action,
             inert_on_demand_hooks(),
+            Box::new(|_| {}),
             Arc::clone(&kick),
             CapacityPolicyConfig::default(),
             shutdown.clone(),
@@ -2931,6 +3103,7 @@ mod tests {
             is_layer_paused,
             on_action,
             inert_on_demand_hooks(),
+            Box::new(|_| {}),
             Arc::new(Notify::new()),
             CapacityPolicyConfig::default(),
             shutdown.clone(),
@@ -3036,6 +3209,7 @@ mod tests {
             is_layer_paused,
             on_action,
             inert_on_demand_hooks(),
+            Box::new(|_| {}),
             Arc::new(Notify::new()),
             CapacityPolicyConfig::default(),
             shutdown.clone(),

--- a/crates/intendant-display/src/encode/pool/mod.rs
+++ b/crates/intendant-display/src/encode/pool/mod.rs
@@ -146,7 +146,7 @@
 use crate::{visual_marker, EncodedFrame};
 use std::collections::HashMap;
 use std::fmt;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex as StdMutex, RwLock as StdRwLock};
 use std::time::{Duration, Instant};
 use tokio::sync::broadcast;
@@ -204,6 +204,10 @@ pub(crate) struct EncoderPoolInner {
     /// (decrement + zero-check + cancel) so a blocking `.lock()` is
     /// acceptable even from async callers.
     on_demand: StdMutex<HashMap<EncoderId, OnDemandSlot>>,
+    /// Current [`FederatedRung`] for the federated H.264 slot
+    /// (`FederatedRung::as_u8` encoding). Read at slot construction;
+    /// stepped by [`EncoderPool::respec_federated`].
+    federated_rung: AtomicU8,
 
     /// Coalesces PLI/FIR across viewers per `(codec, rid)`.
     keyframe_coalescer: KeyframeCoalescer,
@@ -434,6 +438,7 @@ impl EncoderPool {
             inner: Arc::new(EncoderPoolInner {
                 always_on: StdRwLock::new(always_on),
                 on_demand: StdMutex::new(HashMap::new()),
+                federated_rung: AtomicU8::new(FederatedRung::Quarter.as_u8()),
                 keyframe_coalescer: KeyframeCoalescer::new(),
                 i420_tx,
                 duration_ms,
@@ -901,7 +906,8 @@ impl EncoderPool {
                     // at function entry — same gen, same dims,
                     // checked together by pass 3.
                     let layer = if federated_h264 {
-                        LayerSpec::single_federated(
+                        LayerSpec::single_federated_at(
+                            self.federated_rung(),
                             source_at_start.width,
                             source_at_start.height,
                             self.inner.framerate,
@@ -1200,6 +1206,41 @@ impl EncoderPool {
             .filter(|(_, slot)| slot.refcount > 0)
             .map(|(id, _)| id.clone())
             .collect()
+    }
+
+    /// Current rung of the federated H.264 slot's link-aware ladder.
+    pub fn federated_rung(&self) -> FederatedRung {
+        FederatedRung::from_u8(self.inner.federated_rung.load(Ordering::Relaxed))
+    }
+
+    /// Step the federated H.264 slot to `rung`. No-op when unchanged.
+    /// On change, the current `(H264, fed)` slot (if any) is EVICTED —
+    /// its encoder cancelled and its map entry removed — so subscribers
+    /// observe `RecvError::Closed` and the pool-frame-intake reconnect
+    /// resubscribes into a fresh slot built at the new rung (the same
+    /// rebuild lane `on_resize` uses for on-demand slots; stale leases
+    /// release against their recorded generation and are ignored).
+    /// Returns `true` when a change was applied.
+    pub fn respec_federated(&self, rung: FederatedRung) -> bool {
+        let prev = self.inner.federated_rung.swap(rung.as_u8(), Ordering::Relaxed);
+        if prev == rung.as_u8() {
+            return false;
+        }
+        let id = EncoderId::new(CodecKind::H264, SimulcastRid::federated());
+        let evicted = self.inner.on_demand.lock().unwrap().remove(&id);
+        if let Some(slot) = evicted {
+            slot.handle.shutdown.cancel();
+            eprintln!(
+                "[encoder/pool] federated ladder {} -> {:?}: re-spec {} by eviction",
+                prev, rung, id,
+            );
+        } else {
+            eprintln!(
+                "[encoder/pool] federated ladder {} -> {:?} (no live slot; next subscribe builds it)",
+                prev, rung,
+            );
+        }
+        true
     }
 
     /// **Phase 4d.0**: pause one encoder slot, identified by

--- a/crates/intendant-display/src/encode/pool/mod.rs
+++ b/crates/intendant-display/src/encode/pool/mod.rs
@@ -146,7 +146,7 @@
 use crate::{visual_marker, EncodedFrame};
 use std::collections::HashMap;
 use std::fmt;
-use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex as StdMutex, RwLock as StdRwLock};
 use std::time::{Duration, Instant};
 use tokio::sync::broadcast;
@@ -1222,7 +1222,10 @@ impl EncoderPool {
     /// release against their recorded generation and are ignored).
     /// Returns `true` when a change was applied.
     pub fn respec_federated(&self, rung: FederatedRung) -> bool {
-        let prev = self.inner.federated_rung.swap(rung.as_u8(), Ordering::Relaxed);
+        let prev = self
+            .inner
+            .federated_rung
+            .swap(rung.as_u8(), Ordering::Relaxed);
         if prev == rung.as_u8() {
             return false;
         }
@@ -3285,6 +3288,28 @@ mod tests {
             pool.on_demand_refcount(CodecKind::H264, SimulcastRid::federated()),
             Some(1),
         );
+    }
+
+    /// respec_federated evicts the live fed slot so reconnecting
+    /// subscribers rebuild it at the new rung; unchanged rungs no-op.
+    #[tokio::test]
+    async fn respec_federated_evicts_and_rebuilds_at_new_rung() {
+        use super::types::FederatedRung;
+        let pool = EncoderPool::new(640, 360, 30, |_, _| vec![], None);
+        let prefs = PeerCodecPreferences::new_federated(vec![CodecKind::H264]);
+        let (subs, _lease) = pool.subscribe(&prefs).expect("subscribe");
+        assert_eq!(subs[0].layer.width, 160, "quarter of 640");
+        assert!(!pool.respec_federated(FederatedRung::Quarter), "no-op");
+        assert!(pool.respec_federated(FederatedRung::Half));
+        assert_eq!(pool.federated_rung(), FederatedRung::Half);
+        assert_eq!(
+            pool.on_demand_refcount(CodecKind::H264, SimulcastRid::federated()),
+            None,
+            "old slot evicted"
+        );
+        let (subs2, _lease2) = pool.subscribe(&prefs).expect("resubscribe");
+        assert_eq!(subs2[0].layer.width, 320, "half of 640");
+        assert_eq!(subs2[0].layer.target_bitrate_kbps, 1000);
     }
 
     /// Windows twin of the fed-slot contract: H.264 is the always-on

--- a/crates/intendant-display/src/encode/pool/types.rs
+++ b/crates/intendant-display/src/encode/pool/types.rs
@@ -276,6 +276,75 @@ pub const MIN_LAYER_DIM: u32 = 16;
 /// produces the un-reassemblable seed IDR this layer exists to avoid.
 pub const FEDERATED_H264_BITRATE_KBPS: u32 = 250;
 
+/// Link-aware ladder for the federated H.264 slot. The slot always
+/// STARTS at [`FederatedRung::Quarter`] (the loss-safe #67 shape) and
+/// the layer-policy coordinator steps it up on sustained-healthy links
+/// / back down on loss — see `advance_federated_ladder` in the
+/// aggregator. A rung change re-specs the slot by eviction: the encoder
+/// handle is cancelled, subscribers observe `RecvError::Closed`, and
+/// the pool-frame-intake reconnect resubscribes into a fresh slot built
+/// at the new rung (the same rebuild lane `on_resize` uses for
+/// on-demand slots). H.264 mid-stream resolution changes are fine for
+/// browsers — the new SPS/PPS ride the forced join keyframe.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum FederatedRung {
+    /// Quarter resolution @ [`FEDERATED_H264_BITRATE_KBPS`] — the
+    /// loss-resilient floor and the spawn default.
+    Quarter,
+    /// Half resolution @ 1000 kbps.
+    Half,
+    /// Full resolution @ 2500 kbps (the [`LayerSpec::single`] cap).
+    Full,
+}
+
+impl FederatedRung {
+    pub fn as_u8(self) -> u8 {
+        match self {
+            Self::Quarter => 0,
+            Self::Half => 1,
+            Self::Full => 2,
+        }
+    }
+
+    pub fn from_u8(v: u8) -> Self {
+        match v {
+            0 => Self::Quarter,
+            1 => Self::Half,
+            _ => Self::Full,
+        }
+    }
+
+    pub fn up(self) -> Self {
+        match self {
+            Self::Quarter => Self::Half,
+            Self::Half | Self::Full => Self::Full,
+        }
+    }
+
+    pub fn down(self) -> Self {
+        match self {
+            Self::Full => Self::Half,
+            Self::Half | Self::Quarter => Self::Quarter,
+        }
+    }
+
+    fn divisor(self) -> u32 {
+        match self {
+            Self::Quarter => 4,
+            Self::Half => 2,
+            Self::Full => 1,
+        }
+    }
+
+    fn bitrate_kbps(self) -> u32 {
+        match self {
+            Self::Quarter => FEDERATED_H264_BITRATE_KBPS,
+            Self::Half => 1000,
+            Self::Full => 2500,
+        }
+    }
+}
+
 /// Normalize a `(width, height)` pair to the constraints both
 /// VP8 encoder construction and [`crate::encode::downscale_i420`] require:
 ///
@@ -409,18 +478,29 @@ impl LayerSpec {
     /// a federated peer that negotiated H.264 must get *a* stream, never
     /// an empty layer set.
     pub fn single_federated(source_w: u32, source_h: u32, framerate: u32) -> LayerSpec {
-        // Quarter resolution, same even / MIN_LAYER_DIM normalization as
-        // the VP8 quarter floor. Fall back to normalized source dims if
-        // the quarter is too small to encode, and finally to the raw
-        // source so we always return an encodable layer.
-        let (width, height) = normalize_layer_dims(source_w / 4, source_h / 4)
+        Self::single_federated_at(FederatedRung::Quarter, source_w, source_h, framerate)
+    }
+
+    /// Rung-selected federated layer (see [`FederatedRung`]): the
+    /// rung's divisor with the same even / MIN_LAYER_DIM normalization
+    /// as the VP8 quarter floor. Fall back to normalized source dims if
+    /// the divided shape is too small to encode, and finally to the raw
+    /// source so we always return an encodable layer.
+    pub fn single_federated_at(
+        rung: FederatedRung,
+        source_w: u32,
+        source_h: u32,
+        framerate: u32,
+    ) -> LayerSpec {
+        let d = rung.divisor();
+        let (width, height) = normalize_layer_dims(source_w / d, source_h / d)
             .or_else(|| normalize_layer_dims(source_w, source_h))
             .unwrap_or((source_w, source_h));
         LayerSpec {
             rid: SimulcastRid::federated(),
             width,
             height,
-            target_bitrate_kbps: FEDERATED_H264_BITRATE_KBPS,
+            target_bitrate_kbps: rung.bitrate_kbps(),
             framerate,
         }
     }

--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -2162,12 +2162,16 @@ impl DisplaySession {
                 }
             }),
         };
+        let pool_for_federated_respec = Arc::clone(&pool_arc);
         let layer_policy_task = aggregator::spawn_layer_policy_coordinator(
             Arc::clone(&self.peers),
             get_current_rids,
             is_layer_paused,
             on_action,
             on_demand_hooks,
+            Box::new(move |rung| {
+                pool_for_federated_respec.respec_federated(rung);
+            }),
             Arc::clone(&self.layer_policy_kick),
             aggregator::CapacityPolicyConfig::default(),
             self.shutdown.clone(),


### PR DESCRIPTION
Follow-up to #777: the federated H.264 slot no longer sits at quarter-resolution/250kbps forever. It still SPAWNS at that loss-safe shape, and the layer-policy coordinator now steps it half → full after the link has proven healthy (every fed-holder peer's aggregate-TWCC cascade at AllUpperWanted for a sustained 10s; missing feedback counts unhealthy), steps down immediately under loss pressure, holds a 5s dwell between changes, and snaps back to quarter when the last federated viewer leaves. Rung changes re-spec by eviction: the encoder handle is cancelled, subscribers observe Closed, and the existing pool-frame-intake reconnect rebuilds the slot at the new shape — the same rebuild lane on_resize already uses (H.264 mid-stream resolution changes ride the forced join keyframe).

Ladder policy is a pure function with a unit test; the pool respec has an eviction/rebuild test; 574 display-crate tests + full bins battery green.
