### PR TITLE
dashboard: auto-follow + carry across the daemon swap (update-abstraction slice 2)

### DIFF
--- a/src/bin/caller/handover/mod.rs
+++ b/src/bin/caller/handover/mod.rs
@@ -1245,6 +1245,172 @@ mod tests {
         );
     }
 
+    /// Update-abstraction slice 2 pin (intake §7, acceptance (b)): the
+    /// follow watch — armed exactly by the own-drain render branch,
+    /// resolving through the ONE live-holder rule (the doorway's — two
+    /// consumers, one rule, never a second), tokening through the
+    /// shared sibling map with R-A2's re-fetch-on-miss, probing the
+    /// target origin (no-cors HEAD), and moving the tab with
+    /// location.replace + the tokened URL + the carry fragment. The
+    /// packaged-app webview stands down; a relay surface gets honest
+    /// copy instead of a meaningless port substitution.
+    #[test]
+    fn spa_arms_the_follow_watch_on_own_drain() {
+        let fragment = include_str!("../../../../static/app/ui2-handover.js");
+        for needle in [
+            "function armFollowWatch",
+            "armFollowWatch(body);",
+            "function followWatchTick",
+            "function followSurfaceExclusion",
+            "siblingTokenForPort(followWatch.port)",
+            "mode: 'no-cors'",
+            "method: 'HEAD'",
+            "location.replace(url)",
+            "&carry=",
+            "Moving to the updated daemon…",
+            "if (document.hidden) {",
+            "FOLLOW_GRACE_MS",
+            "through a relay",
+            "if (followWatch.armed) disarmFollowWatch();",
+            "window.qa.followState",
+        ] {
+            assert!(
+                fragment.contains(needle),
+                "the follow watch lost its wiring: {needle}"
+            );
+        }
+        // ONE resolution rule, two consumers: the doorway and the watch
+        // tick both read the holder through resolveLiveHolder — a
+        // follow that resolved any other way could walk into a drain.
+        assert_eq!(
+            fragment
+                .matches("const holder = resolveLiveHolder(body);")
+                .count(),
+            2,
+            "doorway + follow tick both consume the one live-holder rule"
+        );
+    }
+
+    /// Slice 2 (b): the carry — capture-stripped from the hash before
+    /// the router or the session-windows reader evaluates (the ?token=
+    /// pattern applied to the fragment), seeded into the same persisted
+    /// keys this origin would have written itself, the pre-swap stamps
+    /// one-shot for the completion compare, and the legacy federation
+    /// bearer carried across the hop (R-A4 — per-origin storage never
+    /// follows an origin change by itself). R-A2's shared token helper
+    /// lives here too: the cached map is a resilience floor and a miss
+    /// re-fetches — which also heals the slice-1 doorway's
+    /// per-page-load cache (the ruling's N1 note) through the same
+    /// mechanism.
+    #[test]
+    fn follow_carry_capture_strips_and_seeds_the_landing() {
+        let identity = include_str!("../../../../static/app/31-init-identity-fleet.js");
+        for needle in [
+            "function captureFollowCarry",
+            "hash.indexOf('&carry=')",
+            "function applyFollowCarry",
+            "localStorage.setItem(SESSION_WINDOW_STATE_KEY, JSON.stringify({ windows }));",
+            "'intendant_settings_subtab'",
+            "'intendant_access_subtab'",
+            "setFederationToken(bearer)",
+            "function takeFollowArrivalStamps",
+            "input.value = draft;",
+            "function siblingTokenForPort",
+            "siblingLoopbackTokenMap(true)",
+            "followCarryApplied",
+        ] {
+            assert!(
+                identity.contains(needle),
+                "the carry capture/landing lost its wiring: {needle}"
+            );
+        }
+        // The sub-tab keys are literals here (the router's constants
+        // are TDZ at this fragment's eval) — parity-pinned to the
+        // router's declarations so a key rename cannot ship as drift.
+        let router = include_str!("../../../../static/app/48-router-settings.js");
+        assert!(
+            router.contains("= 'intendant_settings_subtab'"),
+            "the settings sub-tab key moved — update the carry literals"
+        );
+        assert!(
+            router.contains("= 'intendant_access_subtab'"),
+            "the access sub-tab key moved — update the carry literals"
+        );
+        // Served bundle: the whole wiring lands, each definition once.
+        let app = include_str!("../../../../static/app.html");
+        for needle in [
+            "function captureFollowCarry",
+            "function applyFollowCarry",
+            "function siblingTokenForPort",
+            "function armFollowWatch",
+        ] {
+            assert_eq!(
+                app.matches(needle).count(),
+                1,
+                "the served bundle must carry exactly one {needle}"
+            );
+        }
+    }
+
+    /// Slice 2 (b): the composer guard — any draft demotes the move to
+    /// a one-button consent ("Continue on the updated daemon"), R-A3's
+    /// over-cap loss is named in the consent copy BEFORE navigation
+    /// (never a post-hoc toast), the cap-drop lives at carry BUILD
+    /// time, and the guard reads the same input the reload nudges
+    /// already guard — one composer, one truth.
+    #[test]
+    fn follow_composer_guard_demotes_to_consent() {
+        let fragment = include_str!("../../../../static/app/ui2-handover.js");
+        for needle in [
+            "function composerDraftText",
+            "if (composerDraftText()) {",
+            "Continue on the updated daemon",
+            "too large to carry",
+            "Your composer draft moves with you.",
+            "function followDraftOverCap",
+            "if (encoded.length > FOLLOW_CARRY_CAP && blob.draft)",
+            "document.getElementById('new-session-input')",
+        ] {
+            assert!(
+                fragment.contains(needle),
+                "the composer guard lost its wiring: {needle}"
+            );
+        }
+    }
+
+    /// Slice 2 refinement R-A1: completion honesty compares the
+    /// git_sha AND built_at PAIR — a same-commit rebuild is a real
+    /// update on a dev box, and only a genuinely unchanged pair may be
+    /// narrated as "didn't change builds"; unreadable stamps get the
+    /// neutral line, never a claim.
+    #[test]
+    fn completion_honesty_compares_the_stamp_pair() {
+        let fragment = include_str!("../../../../static/app/ui2-handover.js");
+        for needle in [
+            "function followCompletionCheck",
+            "succ.git_sha !== pred.git_sha || succ.built_at !== pred.built_at",
+            "All set — running ",
+            "The restart didn't change builds.",
+            "Moved to the updated daemon.",
+        ] {
+            assert!(
+                fragment.contains(needle),
+                "the completion-honesty compare lost its wiring: {needle}"
+            );
+        }
+        // Both sides of the carry keep the stamps as pairs.
+        let identity = include_str!("../../../../static/app/31-init-identity-fleet.js");
+        for needle in [
+            "git_sha: str(value.git_sha, 128)",
+            "built_at: str(value.built_at, 128)",
+        ] {
+            assert!(
+                identity.contains(needle),
+                "the carried stamps lost the R-A1 pair: {needle}"
+            );
+        }
+    }
+
     /// The Cmd/Ctrl-K palette's update verbs are pure affordance
     /// re-exposure — the emission-shape law: the chip module keeps the
     /// only swap emissions (one relay POST, one webview bridge, one

--- a/static/app.html
+++ b/static/app.html
@@ -27857,6 +27857,43 @@ html.ui-v2 .handover-update-panel-link {
   text-decoration: underline;
   align-self: flex-start;
 }
+
+/* ── Follow watch (update-abstraction slice 2) ── */
+/* The grace toast: a small fixed notice above the chip dock — the move
+   is announced, never silent. Removed on navigation or disarm. */
+html.ui-v2 #handover-follow-toast {
+  position: fixed;
+  left: 50%;
+  bottom: 18px;
+  transform: translateX(-50%);
+  z-index: 9600;
+  padding: 8px 14px;
+  border-radius: 8px;
+  border: 1px solid var(--accent, #62a0ea);
+  background: var(--surface0, rgba(24, 24, 30, 0.92));
+  color: var(--text, #e6e6e6);
+  font-size: 12px;
+  pointer-events: none;
+}
+html.ui-v2 .handover-follow-consent {
+  margin-top: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: flex-start;
+}
+html.ui-v2 .handover-follow-continue {
+  padding: 4px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--accent, #62a0ea);
+  background: var(--surface0, rgba(24, 24, 30, 0.35));
+  color: var(--text, #e6e6e6);
+  font-size: 12px;
+  cursor: pointer;
+}
+html.ui-v2 .handover-follow-note {
+  margin-top: 4px;
+}
 /* ── static/app/ui2-grid.css ── */
 /* ── ui-v2 Activity Grid mode: lineage lanes + session-window re-skin ──
    All scoped html.ui-v2. Grid layout (ratified 2026-07-21, candidate B
@@ -38862,7 +38899,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '5fdc4d7413521562';
+const INTENDANT_APP_BUILD = '5efaa4e26a3a046c';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -39026,6 +39063,51 @@ const LOOPBACK_TOKEN_KEY = 'intendantLoopbackToken';
   }
 })();
 
+// ── Follow carry (update-abstraction §2.3) ──
+//
+// A drain auto-follow hops ORIGINS, so the predecessor tab's state
+// arrives explicitly: a `&carry=<base64 json>` suffix on the hash
+// (fragments never reach the server), holding the route, the open
+// session-window set, the two sub-tab choices, the composer draft, the
+// pre-swap build stamps for the completion-honesty compare, and — on
+// the legacy `[server.auth] bearer_token` posture (R-A4) — the bearer,
+// which is per-origin localStorage and would not follow the hop by
+// itself. The capture-strip pattern applies verbatim: decode, strip
+// from the visible URL, apply. Everything in the blob is data the
+// LINKING page could already put in a URL — the same trust class as
+// the `?token=` capture above (junk seeds break only this tab's own
+// state, loudly).
+let pendingFollowCarry = null;
+
+(function captureFollowCarry() {
+  try {
+    const hash = String(location.hash || '');
+    const at = hash.indexOf('&carry=');
+    if (at < 0) return;
+    const rest = hash.slice(at + '&carry='.length);
+    const end = rest.indexOf('&');
+    const encoded = end >= 0 ? rest.slice(0, end) : rest;
+    const cleanedHash =
+      hash.slice(0, at) + (end >= 0 ? rest.slice(end) : '');
+    // Strip the blob from the visible/bookmarkable URL before anything
+    // else can read it (the router parses location.hash later in this
+    // same module pass).
+    history.replaceState(
+      null,
+      '',
+      location.pathname + location.search + (cleanedHash === '#' ? '' : cleanedHash)
+    );
+    if (!encoded || encoded.length > 32768) return;
+    const binary = atob(encoded);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    const blob = JSON.parse(new TextDecoder().decode(bytes));
+    if (blob && typeof blob === 'object' && blob.v === 1) pendingFollowCarry = blob;
+  } catch {
+    /* malformed or oversized carry — land with this origin's own state */
+  }
+})();
+
 function getLoopbackToken() {
   try {
     return localStorage.getItem(LOOPBACK_TOKEN_KEY) || '';
@@ -39076,11 +39158,39 @@ function getLoopbackToken() {
 // owner-posture only; served per-request, never persisted) and opens
 // the sibling's own tokened URL so its page seeds its own origin.
 // Non-loopback and mTLS targets pass through untouched. Cached per
-// page load; a stale map (sibling rebooted) degrades to the bare URL
-// and the sibling's named 401 guidance. Shared: the Access fleet links
-// (43-access-panes) and the handover doorways (ui2-handover) both
-// route through this one helper.
+// page load, but the cache is a resilience floor, not the read of
+// record (R-A2): a port the cached map does not name triggers ONE
+// re-fetch — a successor that booted after the cache filled (the
+// doorway-click and follow-watch window) is found by the fresh map,
+// and only a genuinely unknown port degrades to the bare URL and the
+// sibling's named 401 guidance. Shared: the Access fleet links
+// (43-access-panes), the handover doorways, and the drain follow
+// watch (ui2-handover) all route through these helpers.
 let accessSiblingTokenMapPromise = null;
+
+function siblingLoopbackTokenMap(fresh) {
+  if (fresh || !accessSiblingTokenMapPromise) {
+    accessSiblingTokenMapPromise = fetch('/api/local-daemons/tokens')
+      .then(resp => (resp.ok ? resp.json() : { instances: [] }))
+      .catch(() => ({ instances: [] }));
+  }
+  return accessSiblingTokenMapPromise;
+}
+
+// The one token read: cached map first, ONE re-fetch on a miss (the
+// map served by a draining daemon keeps naming newcomers until it
+// exits). '' when the port stays unknown.
+async function siblingTokenForPort(port) {
+  const wanted = String(port || '');
+  if (!wanted) return '';
+  const lookup = map =>
+    ((map && map.instances) || []).find(inst => String(inst.port) === wanted);
+  let entry = lookup(await siblingLoopbackTokenMap(false));
+  if (!entry || !entry.token) {
+    entry = lookup(await siblingLoopbackTokenMap(true));
+  }
+  return (entry && entry.token) || '';
+}
 
 async function withSiblingLoopbackToken(rawUrl) {
   try {
@@ -39089,16 +39199,10 @@ async function withSiblingLoopbackToken(rawUrl) {
     const loopback =
       host === 'localhost' || host === '::1' || /^127(?:\.\d{1,3}){3}$/.test(host);
     if (!loopback || url.searchParams.has('token')) return rawUrl;
-    if (!accessSiblingTokenMapPromise) {
-      accessSiblingTokenMapPromise = fetch('/api/local-daemons/tokens')
-        .then(resp => (resp.ok ? resp.json() : { instances: [] }))
-        .catch(() => ({ instances: [] }));
-    }
-    const map = await accessSiblingTokenMapPromise;
     const port = url.port || (url.protocol === 'https:' ? '443' : '80');
-    const entry = (map.instances || []).find(inst => String(inst.port) === String(port));
-    if (!entry || !entry.token) return rawUrl;
-    url.searchParams.set('token', entry.token);
+    const token = await siblingTokenForPort(port);
+    if (!token) return rawUrl;
+    url.searchParams.set('token', token);
     return url.toString();
   } catch {
     return rawUrl;
@@ -40493,6 +40597,114 @@ async function accessFleetRefreshProvenance() {
   }
   if (changed) renderAccessAdminSummaries();
 }
+
+// ── Follow carry: apply on landing ──
+//
+// Runs at the tail of this fragment — before the session-windows
+// fragment reads its persisted state and before the router parses the
+// (already-stripped) hash — so a carried tab lands with its windows,
+// sub-tab choices, bearer, and draft where the predecessor tab had
+// them. The build stamps ride to the handover module for the
+// completion-honesty compare (R-A1). Bounded and typed field by field;
+// a hostile or garbled blob at worst seeds this tab's own display
+// state, exactly like any deep link.
+let followArrivalStamps = null;
+const followCarryApplied = { windows: 0, subtabs: 0, draft: false, bearer: false };
+
+// One-shot: the handover module takes the stamps for its first-payload
+// compare; a second read (or a carry-less load) sees null.
+function takeFollowArrivalStamps() {
+  const stamps = followArrivalStamps;
+  followArrivalStamps = null;
+  return stamps;
+}
+
+(function applyFollowCarry() {
+  const blob = pendingFollowCarry;
+  pendingFollowCarry = null;
+  if (!blob) return;
+  const str = (value, cap) =>
+    typeof value === 'string' && value.length <= cap ? value : '';
+  try {
+    // Open session-window SET: seed the persisted-state key this origin
+    // would have written itself; the normal restore path rebuilds the
+    // windows from THIS daemon's own catalog (only the set carries).
+    const windows = Array.isArray(blob.windows)
+      ? blob.windows
+          .slice(0, 8)
+          .map(record => ({
+            session_id: str(record && record.session_id, 128),
+            source: str(record && record.source, 64),
+          }))
+          .filter(record => record.session_id && record.source)
+      : [];
+    if (windows.length) {
+      localStorage.setItem(SESSION_WINDOW_STATE_KEY, JSON.stringify({ windows }));
+      followCarryApplied.windows = windows.length;
+    }
+    // The two sub-tab choices (48-router-settings reads these keys at
+    // its own eval, after this fragment; the daemon-side pin holds the
+    // literals in parity with the router's constants).
+    const subtabs = blob.subtabs && typeof blob.subtabs === 'object' ? blob.subtabs : {};
+    const settingsSubtab = str(subtabs.settings, 64);
+    const accessSubtab = str(subtabs.access, 64);
+    if (settingsSubtab) {
+      localStorage.setItem('intendant_settings_subtab', settingsSubtab);
+      followCarryApplied.subtabs++;
+    }
+    if (accessSubtab) {
+      localStorage.setItem('intendant_access_subtab', accessSubtab);
+      followCarryApplied.subtabs++;
+    }
+    // R-A4: the legacy federation bearer is per-origin storage — a
+    // carried one keeps the LAN-bearer posture working across the hop.
+    const bearer = str(blob.bearer, 512);
+    if (bearer) {
+      setFederationToken(bearer);
+      followCarryApplied.bearer = true;
+    }
+    // The composer draft (guarded follow: the user consented with the
+    // draft named). The input exists once the DOM is parsed; value
+    // assignment only — never markup.
+    const draft = str(blob.draft, 65536);
+    if (draft) {
+      const applyDraft = () => {
+        const input = document.getElementById('new-session-input');
+        if (!input || input.value.trim()) return;
+        input.value = draft;
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        followCarryApplied.draft = true;
+      };
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', applyDraft);
+      } else {
+        applyDraft();
+      }
+    }
+    // Pre-swap build stamps for the completion-honesty compare (R-A1:
+    // the PAIR — git_sha AND built_at — a same-sha rebuild is a real
+    // update on this box).
+    const stamps = blob.stamps && typeof blob.stamps === 'object' ? blob.stamps : null;
+    if (stamps) {
+      const pair = value =>
+        value && typeof value === 'object'
+          ? { git_sha: str(value.git_sha, 128), built_at: str(value.built_at, 128) }
+          : null;
+      followArrivalStamps = {
+        pred_boot: str(stamps.pred_boot, 128),
+        pred: pair(stamps.pred),
+        on_disk: pair(stamps.on_disk),
+      };
+    }
+  } catch {
+    /* storage unavailable — the tab still lands, just stateless */
+  }
+})();
+
+// QA readback for the headed follow scenario: what the landing applied.
+window.qa = Object.assign(window.qa || {}, {
+  followCarryApplied: () => ({ ...followCarryApplied }),
+});
 /* ── static/app/31b-hosted-control.js ── */
 // ── Hosted-control lease client ────────────────────────────────────────
 // The private key and lease live only in this module's tab memory. Reloading
@@ -106060,6 +106272,17 @@ async function memoryProposeFromForm(button) {
 // (maybeNudgeDaemonBoot), beside the config-lane chokepoint.
 // Elements are removed when nothing applies; transient poll failures
 // keep the last honest render rather than flapping.
+//   - THIS daemon draining, on a same-host direct browser surface: the
+//     follow watch (update-abstraction §2) — re-resolve the live holder,
+//     fetch its admission token through the same-home map, probe the
+//     target origin, then move the tab there with its state in a carry
+//     blob; hidden tabs move at once, visible tabs after a short grace
+//     toast, and a composer draft turns the move into a one-button
+//     consent. On landing, the carried build stamps drive the
+//     completion-honesty line (R-A1: the git_sha+built_at PAIR — a
+//     same-sha rebuild is a real update). The packaged app follows by
+//     itself (didSwapToPort) and relay-reached surfaces get honest copy
+//     instead — port substitution means nothing there.
 (() => {
   const HANDOVER_POLL_MS = 30000;
   let bannerEl = null;
@@ -106876,6 +107099,449 @@ async function memoryProposeFromForm(button) {
     return handoverSuccessorCandidate(body, update ? update.on_disk : null);
   }
 
+  // ── The follow watch (update-abstraction §2, slice 2) ──────────────
+  //
+  // A browser tab's origin IS host:port, so a drain hands its user an
+  // origin change the packaged app never sees (the app re-points its
+  // scheme handler). The watch closes that gap on same-host direct
+  // surfaces: while THIS daemon drains, keep re-resolving the live
+  // holder through resolveLiveHolder (never onto a draining daemon —
+  // 6c), keep the sibling token map fresh until the resolved target's
+  // token is in hand (R-A2: the pre-fetch is a resilience floor, the
+  // re-fetch is the read of record), probe the target origin until it
+  // answers (the BackendSupervisor readiness pattern), then
+  // location.replace onto the successor with ?token=, the route hash,
+  // and the carry blob. Hidden tabs move immediately; visible tabs get
+  // a short grace under a toast; a composer draft demotes the move to
+  // a one-button consent (R-A3: an over-cap draft names its loss
+  // BEFORE navigation, never after).
+  const FOLLOW_WATCH_TICK_MS = 2500;
+  const FOLLOW_GRACE_MS = 5000;
+  const FOLLOW_CARRY_CAP = 8192;
+  const FOLLOW_TOAST_TEXT = 'Moving to the updated daemon…';
+
+  const followWatch = {
+    armed: false,
+    // idle | watching | grace | consent | navigating
+    phase: 'idle',
+    excluded: '', // '' | 'app' | 'relay'
+    port: 0,
+    bootId: '',
+    token: '',
+    probed: false,
+    stamps: null,
+    misses: 0,
+    timer: null,
+    graceTimer: null,
+  };
+
+  // Where following cannot apply, said once at arm time. The packaged
+  // app's webview follows through its own supervisor (didSwapToPort re-
+  // points the origin-stable scheme handler) — the watch stands down
+  // silently there. A hosted-control relay surface reaches the daemon
+  // through a relay, so a host:port substitution is meaningless — the
+  // banner carries honest copy instead (§2.5; the durable fix is the
+  // parked canonical-port-rebind lane, not client-side substitution).
+  function followSurfaceExclusion() {
+    if (
+      window.__intendantAppSupervisor === true ||
+      (location.protocol !== 'http:' && location.protocol !== 'https:')
+    ) {
+      return 'app';
+    }
+    if (
+      (typeof hostedControlActive === 'function' && hostedControlActive()) ||
+      (typeof DASHBOARD_CONNECT_MODE !== 'undefined' && DASHBOARD_CONNECT_MODE)
+    ) {
+      return 'relay';
+    }
+    return '';
+  }
+
+  function composerDraftText() {
+    const input = document.getElementById('new-session-input');
+    return ((input && input.value) || '').trim();
+  }
+
+  // Pre-swap build stamps off the drainer's own payload: this daemon's
+  // presence entry (the running build) and the on-disk image, each as
+  // the git_sha+built_at PAIR (R-A1). They ride the carry so the
+  // landing page can say honestly whether the hop changed builds.
+  function captureFollowStamps(body) {
+    const pair = value =>
+      value && typeof value === 'object'
+        ? {
+            git_sha: String(value.git_sha || ''),
+            built_at: String(value.built_at || ''),
+          }
+        : null;
+    const own = (Array.isArray(body.daemons) ? body.daemons : []).find(
+      d => d && d.boot_id === body.boot_id
+    );
+    const stamps = { pred_boot: String(body.boot_id || '') };
+    const pred = pair(own && own.version);
+    if (pred) stamps.pred = pred;
+    const disk = pair(body.update && body.update.on_disk);
+    if (disk) stamps.on_disk = disk;
+    followWatch.stamps = stamps;
+  }
+
+  function followCarryEncode(blob) {
+    const bytes = new TextEncoder().encode(JSON.stringify(blob));
+    let binary = '';
+    for (let i = 0; i < bytes.length; i += 4096) {
+      binary += String.fromCharCode.apply(null, bytes.subarray(i, i + 4096));
+    }
+    return btoa(binary);
+  }
+
+  // The carry blob (§2.3): route, the open-session-window SET, the two
+  // sub-tab choices, the pre-swap stamps, the legacy federation bearer
+  // when one is configured (R-A4 — it is per-origin storage and would
+  // not survive the hop), and — on a consented follow — the composer
+  // draft. Capped: the draft drops first (its loss is named in the
+  // consent copy BEFORE navigation), then the window set.
+  function buildFollowCarry(includeDraft) {
+    try {
+      if (typeof flushPendingSessionWindowPersist === 'function') {
+        flushPendingSessionWindowPersist();
+      }
+    } catch (_) { /* persistence unavailable — carry what we can */ }
+    let windows = [];
+    try {
+      const persisted =
+        typeof readPersistedSessionWindowState === 'function'
+          ? readPersistedSessionWindowState()
+          : [];
+      windows = persisted
+        .map(record => ({
+          session_id: String((record && record.session_id) || ''),
+          source: String((record && record.source) || ''),
+        }))
+        .filter(record => record.session_id && record.source)
+        .slice(0, 8);
+    } catch (_) { /* no window set — the successor starts from its own */ }
+    const subtabs = {};
+    try {
+      const settings = localStorage.getItem('intendant_settings_subtab');
+      if (settings) subtabs.settings = settings;
+      const access = localStorage.getItem('intendant_access_subtab');
+      if (access) subtabs.access = access;
+    } catch (_) { /* storage unavailable */ }
+    const blob = {
+      v: 1,
+      route: (location.hash || '').replace(/^#/, ''),
+      windows,
+      subtabs,
+    };
+    const bearer =
+      typeof getFederationToken === 'function' ? getFederationToken() : '';
+    if (bearer) blob.bearer = bearer;
+    if (followWatch.stamps) blob.stamps = followWatch.stamps;
+    let droppedDraft = false;
+    if (includeDraft) {
+      const draft = composerDraftText();
+      if (draft) blob.draft = draft;
+    }
+    let encoded = followCarryEncode(blob);
+    if (encoded.length > FOLLOW_CARRY_CAP && blob.draft) {
+      delete blob.draft;
+      droppedDraft = true;
+      encoded = followCarryEncode(blob);
+    }
+    if (encoded.length > FOLLOW_CARRY_CAP) {
+      blob.windows = [];
+      encoded = followCarryEncode(blob);
+    }
+    return { encoded, droppedDraft };
+  }
+
+  // Would the current draft survive the carry cap? Decides the consent
+  // copy (R-A3): when it cannot, the loss is named on the banner BEFORE
+  // the user clicks — a post-hoc toast would be disclosure, not consent.
+  function followDraftOverCap() {
+    return composerDraftText() ? buildFollowCarry(true).droppedDraft : false;
+  }
+
+  let followToastEl = null;
+  function followToastShow(text) {
+    if (!followToastEl) {
+      followToastEl = document.createElement('div');
+      followToastEl.id = 'handover-follow-toast';
+      document.body.appendChild(followToastEl);
+    }
+    followToastEl.textContent = text;
+  }
+  function followToastClear() {
+    if (followToastEl) {
+      followToastEl.remove();
+      followToastEl = null;
+    }
+  }
+
+  function disarmFollowWatch() {
+    if (followWatch.timer) clearInterval(followWatch.timer);
+    if (followWatch.graceTimer) clearTimeout(followWatch.graceTimer);
+    followWatch.armed = false;
+    followWatch.phase = 'idle';
+    followWatch.excluded = '';
+    followWatch.port = 0;
+    followWatch.bootId = '';
+    followWatch.token = '';
+    followWatch.probed = false;
+    followWatch.misses = 0;
+    followWatch.timer = null;
+    followWatch.graceTimer = null;
+    followToastClear();
+  }
+
+  // The move itself: the successor's own tokened URL (the doorway's
+  // withSiblingLoopbackToken shape), the current route hash, and the
+  // carry appended INSIDE the fragment — fragments never reach the
+  // server, and the landing page capture-strips both the token and the
+  // carry before its router reads the hash. location.replace, not
+  // href: the drained origin must not linger as a back-button trap.
+  function performFollowNavigation(includeDraft) {
+    if (followWatch.phase === 'navigating') return;
+    followWatch.phase = 'navigating';
+    const carry = buildFollowCarry(includeDraft);
+    const hash =
+      location.hash && location.hash !== '#' ? location.hash : '#activity';
+    const query = followWatch.token
+      ? `?token=${encodeURIComponent(followWatch.token)}`
+      : '';
+    const url =
+      `${location.protocol}//${location.hostname}:${followWatch.port}/` +
+      `${query}${hash}&carry=${carry.encoded}`;
+    followToastShow(FOLLOW_TOAST_TEXT);
+    try {
+      location.replace(url);
+    } catch (_) {
+      followWatch.phase = 'watching';
+    }
+  }
+
+  // One watch tick: freshest payload from the drainer (it serves until
+  // exit), re-resolve, re-token, probe, then decide. A drainer that
+  // stops answering after the target was resolved+probed is the follow
+  // signal itself — the exit happened between polls.
+  async function followWatchTick() {
+    if (followWatch.phase === 'grace' || followWatch.phase === 'navigating') {
+      return;
+    }
+    let body = null;
+    try {
+      if (typeof daemonApi !== 'undefined' && daemonApi.availability('api_daemon_handover').ok) {
+        const resp = await daemonApi.request('api_daemon_handover', {});
+        if (resp && resp.ok) body = resp.body;
+      }
+    } catch (_) { /* drainer unreachable — counted below */ }
+    if (body && body.available !== false) {
+      if (!body.draining) {
+        // A non-draining answer on this origin is a NEW daemon already
+        // serving here (same-port successor): the boot nudge owns that
+        // path; the watch stands down.
+        disarmFollowWatch();
+        handoverRender(body);
+        return;
+      }
+      followWatch.misses = 0;
+      lastHandoverBody = body;
+      captureFollowStamps(body);
+      const holder = resolveLiveHolder(body);
+      const port = holder && Number(holder.port);
+      if (!holder || !Number.isFinite(port) || port <= 0) {
+        followWatch.port = 0;
+        followWatch.token = '';
+        followWatch.probed = false;
+        return;
+      }
+      if (followWatch.port !== port) {
+        // Resolution moved (a chained drain healed to a later
+        // successor): stale token and probe state go with it.
+        followWatch.port = port;
+        followWatch.bootId = String(holder.boot_id || '');
+        followWatch.token = '';
+        followWatch.probed = false;
+      }
+    } else {
+      followWatch.misses++;
+      if (!followWatch.port || followWatch.misses < 2) return;
+    }
+    if (!followWatch.port) return;
+    // R-A2: the token map is re-fetched, not only pre-fetched — the
+    // helper retries a fresh map when the cached one misses the port,
+    // and the drainer keeps serving the map until it exits. Loopback
+    // only: a LAN/mTLS surface authenticates by cert (or the carried
+    // bearer), and ?token= means nothing to it.
+    if (!followWatch.token && isLoopbackSurface()) {
+      try {
+        followWatch.token = await siblingTokenForPort(followWatch.port);
+      } catch (_) { /* map unreachable this tick — retried next tick */ }
+      if (!followWatch.token) return;
+    }
+    if (!followWatch.probed) {
+      const probed = await probeFollowTarget(followWatch.port);
+      if (!probed) return;
+      followWatch.probed = true;
+    }
+    decideFollowNow();
+  }
+
+  function isLoopbackSurface() {
+    const host = location.hostname.replace(/^\[|\]$/g, '').toLowerCase();
+    return (
+      host === 'localhost' || host === '::1' || /^127(?:\.\d{1,3}){3}$/.test(host)
+    );
+  }
+
+  // HEAD / against the successor origin (the BackendSupervisor
+  // readiness pattern, §2.1(c)): an opaque no-cors answer proves a
+  // listener; a network rejection means "not yet".
+  async function probeFollowTarget(port) {
+    try {
+      await fetch(`${location.protocol}//${location.hostname}:${port}/`, {
+        method: 'HEAD',
+        mode: 'no-cors',
+        cache: 'no-store',
+      });
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  // Target resolved, token in hand, origin answering — move, with the
+  // Q1-ruled posture: a composer draft always demotes to one-button
+  // consent (hidden or visible — a draft is never auto-lost); hidden
+  // tabs move at once; visible tabs get the grace toast.
+  function decideFollowNow() {
+    if (composerDraftText()) {
+      if (followWatch.phase !== 'consent') {
+        followWatch.phase = 'consent';
+        followToastClear();
+        if (lastHandoverBody) handoverRender(lastHandoverBody);
+      }
+      return;
+    }
+    if (document.hidden) {
+      performFollowNavigation(false);
+      return;
+    }
+    followWatch.phase = 'grace';
+    followToastShow(FOLLOW_TOAST_TEXT);
+    followWatch.graceTimer = setTimeout(() => {
+      followWatch.graceTimer = null;
+      // The grace window is exactly the time to start typing: re-check.
+      if (composerDraftText()) {
+        followWatch.phase = 'consent';
+        followToastClear();
+        if (lastHandoverBody) handoverRender(lastHandoverBody);
+        return;
+      }
+      performFollowNavigation(false);
+    }, FOLLOW_GRACE_MS);
+  }
+
+  function armFollowWatch(body) {
+    if (followWatch.armed) return;
+    followWatch.armed = true;
+    followWatch.excluded = followSurfaceExclusion();
+    captureFollowStamps(body);
+    if (followWatch.excluded) return;
+    followWatch.phase = 'watching';
+    // §2.1(a): pre-fetch the sibling token map while the drainer still
+    // serves it — a resilience floor under the per-tick re-fetch.
+    if (isLoopbackSurface()) {
+      try { siblingLoopbackTokenMap(false); } catch (_) { /* re-fetched per tick */ }
+    }
+    followWatch.timer = setInterval(followWatchTick, FOLLOW_WATCH_TICK_MS);
+    followWatchTick();
+  }
+
+  // The banner's follow section (draining branch): honest copy for the
+  // relay exclusion, the one-button consent when a draft holds the
+  // move, and the in-motion status line under grace.
+  function followBannerSection() {
+    if (!followWatch.armed) return null;
+    if (followWatch.excluded === 'relay') {
+      const note = document.createElement('div');
+      note.className = 'handover-banner-note handover-follow-note';
+      note.textContent =
+        'This surface reaches the daemon through a relay, so it cannot ' +
+        'follow the update to a new local address itself. Reopen the ' +
+        'dashboard from your usual entry point once the update completes.';
+      return note;
+    }
+    if (followWatch.excluded) return null;
+    if (followWatch.phase === 'consent') {
+      const wrap = document.createElement('div');
+      wrap.className = 'handover-follow-consent';
+      const note = document.createElement('div');
+      note.className = 'handover-banner-note';
+      note.textContent = followDraftOverCap()
+        ? 'Your composer draft is too large to carry — copy it first; continuing moves without it.'
+        : 'Your composer draft moves with you.';
+      wrap.appendChild(note);
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'handover-follow-continue';
+      btn.textContent = 'Continue on the updated daemon';
+      btn.addEventListener('click', () => performFollowNavigation(true));
+      wrap.appendChild(btn);
+      return wrap;
+    }
+    if (followWatch.phase === 'grace' || followWatch.phase === 'navigating') {
+      const note = document.createElement('div');
+      note.className = 'handover-banner-note handover-follow-note';
+      note.textContent = FOLLOW_TOAST_TEXT;
+      return note;
+    }
+    return null;
+  }
+
+  // ── Landing side: completion honesty (§2.4, R-A1) ──────────────────
+  //
+  // A carried arrival left its pre-swap stamps with the identity
+  // fragment; the first handover payload here names the build THIS
+  // daemon runs (its own presence entry). Compare the PAIR — git_sha
+  // AND built_at — because a rebuild of the same commit is a real
+  // update on a dev box, and only a genuinely unchanged pair may be
+  // narrated as "didn't change builds". Unreadable stamps get the
+  // neutral line, never a claim.
+  let followArrivalStamps =
+    typeof takeFollowArrivalStamps === 'function' ? takeFollowArrivalStamps() : null;
+
+  function followCompletionCheck(body) {
+    if (!followArrivalStamps || !body || body.available === false) return;
+    const arrival = followArrivalStamps;
+    followArrivalStamps = null;
+    if (typeof showControlToast !== 'function') return;
+    const own = (Array.isArray(body.daemons) ? body.daemons : []).find(
+      d => d && d.boot_id === body.boot_id
+    );
+    const version = own && own.version;
+    const succ = version
+      ? { git_sha: String(version.git_sha || ''), built_at: String(version.built_at || '') }
+      : null;
+    const pred = arrival.pred;
+    if (succ && succ.git_sha && pred && pred.git_sha) {
+      const changed =
+        succ.git_sha !== pred.git_sha || succ.built_at !== pred.built_at;
+      if (changed) {
+        const label = String((version && version.pkg) || '').trim();
+        showControlToast(
+          'success',
+          `All set — running ${label || succ.git_sha.slice(0, 10)}.`
+        );
+      } else {
+        showControlToast('info', "The restart didn't change builds.");
+      }
+    } else {
+      showControlToast('info', 'Moved to the updated daemon.');
+    }
+  }
+
   // Render at most this many holdout rows; the rest fold into an honest
   // "…and N more" (parked rows arrive sorted first from the daemon, so
   // the decisive parked-until facts survive the fold).
@@ -107008,22 +107674,35 @@ async function memoryProposeFromForm(button) {
     if (body.boot_id && typeof maybeNudgeDaemonBoot === 'function') {
       maybeNudgeDaemonBoot(body.boot_id);
     }
+    followCompletionCheck(body);
     handoverUpdateRender(body);
     handoverReleaseRender(body);
     if (body.draining) {
+      armFollowWatch(body);
       const holder = resolveLiveHolder(body);
       const el = handoverBanner();
       el.dataset.kind = 'draining';
       el.textContent = '';
       const key = bannerStateKey('draining', body.boot_id);
       const rows = Array.isArray(body.holdouts) ? body.holdouts : [];
-      if (bannerCollapsedNow(el, key)) {
+      // A pending consent (a draft holds the move) outranks the stored
+      // collapse: the one decision the user must see never hides in a
+      // pill.
+      if (followWatch.phase !== 'consent' && bannerCollapsedNow(el, key)) {
         bannerFillPill(el, key, rows.length
           ? `This daemon is draining — waiting on ${rows.length} in-flight session${rows.length === 1 ? '' : 's'}`
           : 'This daemon is draining — in-flight sessions are finishing');
         handoverBannerReserve();
         return;
       }
+      // Consent renders expanded even under a stored collapse — strip
+      // any pill affordances a previous collapsed render left behind.
+      el.classList.remove('collapsed');
+      el.onclick = null;
+      el.onkeydown = null;
+      el.removeAttribute('role');
+      el.removeAttribute('tabindex');
+      el.removeAttribute('title');
       el.appendChild(bannerCollapseButton(key, 'Collapse the drain banner to a pill'));
       const head = document.createElement('div');
       head.className = 'handover-banner-head';
@@ -107046,10 +107725,13 @@ async function memoryProposeFromForm(button) {
         none.textContent = 'No successor has acquired the lease yet.';
         el.appendChild(none);
       }
+      const followSection = followBannerSection();
+      if (followSection) el.appendChild(followSection);
       if (rows.length) el.appendChild(handoverHoldoutList(rows, rows.length));
       handoverBannerReserve();
       return;
     }
+    if (followWatch.armed) disarmFollowWatch();
     const others = Array.isArray(body.daemons)
       ? body.daemons.filter((d) => d && d.live && d.state === 'draining' && d.boot_id !== body.boot_id)
       : [];
@@ -107131,6 +107813,19 @@ async function memoryProposeFromForm(button) {
     render: (body) => { lastHandoverBody = body; handoverReleaseRender(body); },
     stateKey: releaseChipStateKey,
   };
+  // The follow watch's live state for the headed follow scenario
+  // (tests/skills/handover-follow): arming, phase transitions, the
+  // resolved target, and the exclusion verdict — token presence only,
+  // never the token itself.
+  window.qa.followState = () => ({
+    armed: followWatch.armed,
+    phase: followWatch.phase,
+    excluded: followWatch.excluded,
+    port: followWatch.port,
+    tokenHeld: Boolean(followWatch.token),
+    probed: followWatch.probed,
+    stamps: followWatch.stamps ? JSON.parse(JSON.stringify(followWatch.stamps)) : null,
+  });
 
   // The palette's dynamic entry, as data (ui2-chrome reads this by name
   // at event time): the SAME one-click affordance the chip is currently

--- a/static/app.html
+++ b/static/app.html
@@ -38899,7 +38899,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '5efaa4e26a3a046c';
+const INTENDANT_APP_BUILD = 'd6bd088769679ecd';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -107302,7 +107302,7 @@ async function memoryProposeFromForm(button) {
   // carry before its router reads the hash. location.replace, not
   // href: the drained origin must not linger as a back-button trap.
   function performFollowNavigation(includeDraft) {
-    if (followWatch.phase === 'navigating') return;
+    if (followWatch.phase === 'navigating' || !followWatch.port) return;
     followWatch.phase = 'navigating';
     const carry = buildFollowCarry(includeDraft);
     const hash =
@@ -107428,6 +107428,7 @@ async function memoryProposeFromForm(button) {
       performFollowNavigation(false);
       return;
     }
+    if (followWatch.phase === 'grace' || followWatch.phase === 'navigating') return;
     followWatch.phase = 'grace';
     followToastShow(FOLLOW_TOAST_TEXT);
     followWatch.graceTimer = setTimeout(() => {
@@ -107666,6 +107667,7 @@ async function memoryProposeFromForm(button) {
 
   function handoverRender(body) {
     if (!body || body.available === false) {
+      if (followWatch.armed) disarmFollowWatch();
       handoverClear();
       updateChipClear();
       releaseChipClear();
@@ -107826,6 +107828,13 @@ async function memoryProposeFromForm(button) {
     probed: followWatch.probed,
     stamps: followWatch.stamps ? JSON.parse(JSON.stringify(followWatch.stamps)) : null,
   });
+  // Test driver (the __testNudgeDaemonBoot precedent): the tokenless
+  // QA posture cannot walk the token+probe ladder, so the headed
+  // scenario forces the decision point to assert the guard/grace
+  // posture. Armed-only; production never calls it.
+  window.qa.__testFollowDecide = () => {
+    if (followWatch.armed && !followWatch.excluded) decideFollowNow();
+  };
 
   // The palette's dynamic entry, as data (ui2-chrome reads this by name
   // at event time): the SAME one-click affordance the chip is currently

--- a/static/app/31-init-identity-fleet.js
+++ b/static/app/31-init-identity-fleet.js
@@ -177,6 +177,51 @@ const LOOPBACK_TOKEN_KEY = 'intendantLoopbackToken';
   }
 })();
 
+// ── Follow carry (update-abstraction §2.3) ──
+//
+// A drain auto-follow hops ORIGINS, so the predecessor tab's state
+// arrives explicitly: a `&carry=<base64 json>` suffix on the hash
+// (fragments never reach the server), holding the route, the open
+// session-window set, the two sub-tab choices, the composer draft, the
+// pre-swap build stamps for the completion-honesty compare, and — on
+// the legacy `[server.auth] bearer_token` posture (R-A4) — the bearer,
+// which is per-origin localStorage and would not follow the hop by
+// itself. The capture-strip pattern applies verbatim: decode, strip
+// from the visible URL, apply. Everything in the blob is data the
+// LINKING page could already put in a URL — the same trust class as
+// the `?token=` capture above (junk seeds break only this tab's own
+// state, loudly).
+let pendingFollowCarry = null;
+
+(function captureFollowCarry() {
+  try {
+    const hash = String(location.hash || '');
+    const at = hash.indexOf('&carry=');
+    if (at < 0) return;
+    const rest = hash.slice(at + '&carry='.length);
+    const end = rest.indexOf('&');
+    const encoded = end >= 0 ? rest.slice(0, end) : rest;
+    const cleanedHash =
+      hash.slice(0, at) + (end >= 0 ? rest.slice(end) : '');
+    // Strip the blob from the visible/bookmarkable URL before anything
+    // else can read it (the router parses location.hash later in this
+    // same module pass).
+    history.replaceState(
+      null,
+      '',
+      location.pathname + location.search + (cleanedHash === '#' ? '' : cleanedHash)
+    );
+    if (!encoded || encoded.length > 32768) return;
+    const binary = atob(encoded);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    const blob = JSON.parse(new TextDecoder().decode(bytes));
+    if (blob && typeof blob === 'object' && blob.v === 1) pendingFollowCarry = blob;
+  } catch {
+    /* malformed or oversized carry — land with this origin's own state */
+  }
+})();
+
 function getLoopbackToken() {
   try {
     return localStorage.getItem(LOOPBACK_TOKEN_KEY) || '';
@@ -227,11 +272,39 @@ function getLoopbackToken() {
 // owner-posture only; served per-request, never persisted) and opens
 // the sibling's own tokened URL so its page seeds its own origin.
 // Non-loopback and mTLS targets pass through untouched. Cached per
-// page load; a stale map (sibling rebooted) degrades to the bare URL
-// and the sibling's named 401 guidance. Shared: the Access fleet links
-// (43-access-panes) and the handover doorways (ui2-handover) both
-// route through this one helper.
+// page load, but the cache is a resilience floor, not the read of
+// record (R-A2): a port the cached map does not name triggers ONE
+// re-fetch — a successor that booted after the cache filled (the
+// doorway-click and follow-watch window) is found by the fresh map,
+// and only a genuinely unknown port degrades to the bare URL and the
+// sibling's named 401 guidance. Shared: the Access fleet links
+// (43-access-panes), the handover doorways, and the drain follow
+// watch (ui2-handover) all route through these helpers.
 let accessSiblingTokenMapPromise = null;
+
+function siblingLoopbackTokenMap(fresh) {
+  if (fresh || !accessSiblingTokenMapPromise) {
+    accessSiblingTokenMapPromise = fetch('/api/local-daemons/tokens')
+      .then(resp => (resp.ok ? resp.json() : { instances: [] }))
+      .catch(() => ({ instances: [] }));
+  }
+  return accessSiblingTokenMapPromise;
+}
+
+// The one token read: cached map first, ONE re-fetch on a miss (the
+// map served by a draining daemon keeps naming newcomers until it
+// exits). '' when the port stays unknown.
+async function siblingTokenForPort(port) {
+  const wanted = String(port || '');
+  if (!wanted) return '';
+  const lookup = map =>
+    ((map && map.instances) || []).find(inst => String(inst.port) === wanted);
+  let entry = lookup(await siblingLoopbackTokenMap(false));
+  if (!entry || !entry.token) {
+    entry = lookup(await siblingLoopbackTokenMap(true));
+  }
+  return (entry && entry.token) || '';
+}
 
 async function withSiblingLoopbackToken(rawUrl) {
   try {
@@ -240,16 +313,10 @@ async function withSiblingLoopbackToken(rawUrl) {
     const loopback =
       host === 'localhost' || host === '::1' || /^127(?:\.\d{1,3}){3}$/.test(host);
     if (!loopback || url.searchParams.has('token')) return rawUrl;
-    if (!accessSiblingTokenMapPromise) {
-      accessSiblingTokenMapPromise = fetch('/api/local-daemons/tokens')
-        .then(resp => (resp.ok ? resp.json() : { instances: [] }))
-        .catch(() => ({ instances: [] }));
-    }
-    const map = await accessSiblingTokenMapPromise;
     const port = url.port || (url.protocol === 'https:' ? '443' : '80');
-    const entry = (map.instances || []).find(inst => String(inst.port) === String(port));
-    if (!entry || !entry.token) return rawUrl;
-    url.searchParams.set('token', entry.token);
+    const token = await siblingTokenForPort(port);
+    if (!token) return rawUrl;
+    url.searchParams.set('token', token);
     return url.toString();
   } catch {
     return rawUrl;
@@ -1644,3 +1711,111 @@ async function accessFleetRefreshProvenance() {
   }
   if (changed) renderAccessAdminSummaries();
 }
+
+// ── Follow carry: apply on landing ──
+//
+// Runs at the tail of this fragment — before the session-windows
+// fragment reads its persisted state and before the router parses the
+// (already-stripped) hash — so a carried tab lands with its windows,
+// sub-tab choices, bearer, and draft where the predecessor tab had
+// them. The build stamps ride to the handover module for the
+// completion-honesty compare (R-A1). Bounded and typed field by field;
+// a hostile or garbled blob at worst seeds this tab's own display
+// state, exactly like any deep link.
+let followArrivalStamps = null;
+const followCarryApplied = { windows: 0, subtabs: 0, draft: false, bearer: false };
+
+// One-shot: the handover module takes the stamps for its first-payload
+// compare; a second read (or a carry-less load) sees null.
+function takeFollowArrivalStamps() {
+  const stamps = followArrivalStamps;
+  followArrivalStamps = null;
+  return stamps;
+}
+
+(function applyFollowCarry() {
+  const blob = pendingFollowCarry;
+  pendingFollowCarry = null;
+  if (!blob) return;
+  const str = (value, cap) =>
+    typeof value === 'string' && value.length <= cap ? value : '';
+  try {
+    // Open session-window SET: seed the persisted-state key this origin
+    // would have written itself; the normal restore path rebuilds the
+    // windows from THIS daemon's own catalog (only the set carries).
+    const windows = Array.isArray(blob.windows)
+      ? blob.windows
+          .slice(0, 8)
+          .map(record => ({
+            session_id: str(record && record.session_id, 128),
+            source: str(record && record.source, 64),
+          }))
+          .filter(record => record.session_id && record.source)
+      : [];
+    if (windows.length) {
+      localStorage.setItem(SESSION_WINDOW_STATE_KEY, JSON.stringify({ windows }));
+      followCarryApplied.windows = windows.length;
+    }
+    // The two sub-tab choices (48-router-settings reads these keys at
+    // its own eval, after this fragment; the daemon-side pin holds the
+    // literals in parity with the router's constants).
+    const subtabs = blob.subtabs && typeof blob.subtabs === 'object' ? blob.subtabs : {};
+    const settingsSubtab = str(subtabs.settings, 64);
+    const accessSubtab = str(subtabs.access, 64);
+    if (settingsSubtab) {
+      localStorage.setItem('intendant_settings_subtab', settingsSubtab);
+      followCarryApplied.subtabs++;
+    }
+    if (accessSubtab) {
+      localStorage.setItem('intendant_access_subtab', accessSubtab);
+      followCarryApplied.subtabs++;
+    }
+    // R-A4: the legacy federation bearer is per-origin storage — a
+    // carried one keeps the LAN-bearer posture working across the hop.
+    const bearer = str(blob.bearer, 512);
+    if (bearer) {
+      setFederationToken(bearer);
+      followCarryApplied.bearer = true;
+    }
+    // The composer draft (guarded follow: the user consented with the
+    // draft named). The input exists once the DOM is parsed; value
+    // assignment only — never markup.
+    const draft = str(blob.draft, 65536);
+    if (draft) {
+      const applyDraft = () => {
+        const input = document.getElementById('new-session-input');
+        if (!input || input.value.trim()) return;
+        input.value = draft;
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        followCarryApplied.draft = true;
+      };
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', applyDraft);
+      } else {
+        applyDraft();
+      }
+    }
+    // Pre-swap build stamps for the completion-honesty compare (R-A1:
+    // the PAIR — git_sha AND built_at — a same-sha rebuild is a real
+    // update on this box).
+    const stamps = blob.stamps && typeof blob.stamps === 'object' ? blob.stamps : null;
+    if (stamps) {
+      const pair = value =>
+        value && typeof value === 'object'
+          ? { git_sha: str(value.git_sha, 128), built_at: str(value.built_at, 128) }
+          : null;
+      followArrivalStamps = {
+        pred_boot: str(stamps.pred_boot, 128),
+        pred: pair(stamps.pred),
+        on_disk: pair(stamps.on_disk),
+      };
+    }
+  } catch {
+    /* storage unavailable — the tab still lands, just stateless */
+  }
+})();
+
+// QA readback for the headed follow scenario: what the landing applied.
+window.qa = Object.assign(window.qa || {}, {
+  followCarryApplied: () => ({ ...followCarryApplied }),
+});

--- a/static/app/ui2-handover.css
+++ b/static/app/ui2-handover.css
@@ -385,3 +385,40 @@ html.ui-v2 .handover-update-panel-link {
   text-decoration: underline;
   align-self: flex-start;
 }
+
+/* ── Follow watch (update-abstraction slice 2) ── */
+/* The grace toast: a small fixed notice above the chip dock — the move
+   is announced, never silent. Removed on navigation or disarm. */
+html.ui-v2 #handover-follow-toast {
+  position: fixed;
+  left: 50%;
+  bottom: 18px;
+  transform: translateX(-50%);
+  z-index: 9600;
+  padding: 8px 14px;
+  border-radius: 8px;
+  border: 1px solid var(--accent, #62a0ea);
+  background: var(--surface0, rgba(24, 24, 30, 0.92));
+  color: var(--text, #e6e6e6);
+  font-size: 12px;
+  pointer-events: none;
+}
+html.ui-v2 .handover-follow-consent {
+  margin-top: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: flex-start;
+}
+html.ui-v2 .handover-follow-continue {
+  padding: 4px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--accent, #62a0ea);
+  background: var(--surface0, rgba(24, 24, 30, 0.35));
+  color: var(--text, #e6e6e6);
+  font-size: 12px;
+  cursor: pointer;
+}
+html.ui-v2 .handover-follow-note {
+  margin-top: 4px;
+}

--- a/static/app/ui2-handover.js
+++ b/static/app/ui2-handover.js
@@ -30,6 +30,17 @@
 // (maybeNudgeDaemonBoot), beside the config-lane chokepoint.
 // Elements are removed when nothing applies; transient poll failures
 // keep the last honest render rather than flapping.
+//   - THIS daemon draining, on a same-host direct browser surface: the
+//     follow watch (update-abstraction §2) — re-resolve the live holder,
+//     fetch its admission token through the same-home map, probe the
+//     target origin, then move the tab there with its state in a carry
+//     blob; hidden tabs move at once, visible tabs after a short grace
+//     toast, and a composer draft turns the move into a one-button
+//     consent. On landing, the carried build stamps drive the
+//     completion-honesty line (R-A1: the git_sha+built_at PAIR — a
+//     same-sha rebuild is a real update). The packaged app follows by
+//     itself (didSwapToPort) and relay-reached surfaces get honest copy
+//     instead — port substitution means nothing there.
 (() => {
   const HANDOVER_POLL_MS = 30000;
   let bannerEl = null;
@@ -846,6 +857,449 @@
     return handoverSuccessorCandidate(body, update ? update.on_disk : null);
   }
 
+  // ── The follow watch (update-abstraction §2, slice 2) ──────────────
+  //
+  // A browser tab's origin IS host:port, so a drain hands its user an
+  // origin change the packaged app never sees (the app re-points its
+  // scheme handler). The watch closes that gap on same-host direct
+  // surfaces: while THIS daemon drains, keep re-resolving the live
+  // holder through resolveLiveHolder (never onto a draining daemon —
+  // 6c), keep the sibling token map fresh until the resolved target's
+  // token is in hand (R-A2: the pre-fetch is a resilience floor, the
+  // re-fetch is the read of record), probe the target origin until it
+  // answers (the BackendSupervisor readiness pattern), then
+  // location.replace onto the successor with ?token=, the route hash,
+  // and the carry blob. Hidden tabs move immediately; visible tabs get
+  // a short grace under a toast; a composer draft demotes the move to
+  // a one-button consent (R-A3: an over-cap draft names its loss
+  // BEFORE navigation, never after).
+  const FOLLOW_WATCH_TICK_MS = 2500;
+  const FOLLOW_GRACE_MS = 5000;
+  const FOLLOW_CARRY_CAP = 8192;
+  const FOLLOW_TOAST_TEXT = 'Moving to the updated daemon…';
+
+  const followWatch = {
+    armed: false,
+    // idle | watching | grace | consent | navigating
+    phase: 'idle',
+    excluded: '', // '' | 'app' | 'relay'
+    port: 0,
+    bootId: '',
+    token: '',
+    probed: false,
+    stamps: null,
+    misses: 0,
+    timer: null,
+    graceTimer: null,
+  };
+
+  // Where following cannot apply, said once at arm time. The packaged
+  // app's webview follows through its own supervisor (didSwapToPort re-
+  // points the origin-stable scheme handler) — the watch stands down
+  // silently there. A hosted-control relay surface reaches the daemon
+  // through a relay, so a host:port substitution is meaningless — the
+  // banner carries honest copy instead (§2.5; the durable fix is the
+  // parked canonical-port-rebind lane, not client-side substitution).
+  function followSurfaceExclusion() {
+    if (
+      window.__intendantAppSupervisor === true ||
+      (location.protocol !== 'http:' && location.protocol !== 'https:')
+    ) {
+      return 'app';
+    }
+    if (
+      (typeof hostedControlActive === 'function' && hostedControlActive()) ||
+      (typeof DASHBOARD_CONNECT_MODE !== 'undefined' && DASHBOARD_CONNECT_MODE)
+    ) {
+      return 'relay';
+    }
+    return '';
+  }
+
+  function composerDraftText() {
+    const input = document.getElementById('new-session-input');
+    return ((input && input.value) || '').trim();
+  }
+
+  // Pre-swap build stamps off the drainer's own payload: this daemon's
+  // presence entry (the running build) and the on-disk image, each as
+  // the git_sha+built_at PAIR (R-A1). They ride the carry so the
+  // landing page can say honestly whether the hop changed builds.
+  function captureFollowStamps(body) {
+    const pair = value =>
+      value && typeof value === 'object'
+        ? {
+            git_sha: String(value.git_sha || ''),
+            built_at: String(value.built_at || ''),
+          }
+        : null;
+    const own = (Array.isArray(body.daemons) ? body.daemons : []).find(
+      d => d && d.boot_id === body.boot_id
+    );
+    const stamps = { pred_boot: String(body.boot_id || '') };
+    const pred = pair(own && own.version);
+    if (pred) stamps.pred = pred;
+    const disk = pair(body.update && body.update.on_disk);
+    if (disk) stamps.on_disk = disk;
+    followWatch.stamps = stamps;
+  }
+
+  function followCarryEncode(blob) {
+    const bytes = new TextEncoder().encode(JSON.stringify(blob));
+    let binary = '';
+    for (let i = 0; i < bytes.length; i += 4096) {
+      binary += String.fromCharCode.apply(null, bytes.subarray(i, i + 4096));
+    }
+    return btoa(binary);
+  }
+
+  // The carry blob (§2.3): route, the open-session-window SET, the two
+  // sub-tab choices, the pre-swap stamps, the legacy federation bearer
+  // when one is configured (R-A4 — it is per-origin storage and would
+  // not survive the hop), and — on a consented follow — the composer
+  // draft. Capped: the draft drops first (its loss is named in the
+  // consent copy BEFORE navigation), then the window set.
+  function buildFollowCarry(includeDraft) {
+    try {
+      if (typeof flushPendingSessionWindowPersist === 'function') {
+        flushPendingSessionWindowPersist();
+      }
+    } catch (_) { /* persistence unavailable — carry what we can */ }
+    let windows = [];
+    try {
+      const persisted =
+        typeof readPersistedSessionWindowState === 'function'
+          ? readPersistedSessionWindowState()
+          : [];
+      windows = persisted
+        .map(record => ({
+          session_id: String((record && record.session_id) || ''),
+          source: String((record && record.source) || ''),
+        }))
+        .filter(record => record.session_id && record.source)
+        .slice(0, 8);
+    } catch (_) { /* no window set — the successor starts from its own */ }
+    const subtabs = {};
+    try {
+      const settings = localStorage.getItem('intendant_settings_subtab');
+      if (settings) subtabs.settings = settings;
+      const access = localStorage.getItem('intendant_access_subtab');
+      if (access) subtabs.access = access;
+    } catch (_) { /* storage unavailable */ }
+    const blob = {
+      v: 1,
+      route: (location.hash || '').replace(/^#/, ''),
+      windows,
+      subtabs,
+    };
+    const bearer =
+      typeof getFederationToken === 'function' ? getFederationToken() : '';
+    if (bearer) blob.bearer = bearer;
+    if (followWatch.stamps) blob.stamps = followWatch.stamps;
+    let droppedDraft = false;
+    if (includeDraft) {
+      const draft = composerDraftText();
+      if (draft) blob.draft = draft;
+    }
+    let encoded = followCarryEncode(blob);
+    if (encoded.length > FOLLOW_CARRY_CAP && blob.draft) {
+      delete blob.draft;
+      droppedDraft = true;
+      encoded = followCarryEncode(blob);
+    }
+    if (encoded.length > FOLLOW_CARRY_CAP) {
+      blob.windows = [];
+      encoded = followCarryEncode(blob);
+    }
+    return { encoded, droppedDraft };
+  }
+
+  // Would the current draft survive the carry cap? Decides the consent
+  // copy (R-A3): when it cannot, the loss is named on the banner BEFORE
+  // the user clicks — a post-hoc toast would be disclosure, not consent.
+  function followDraftOverCap() {
+    return composerDraftText() ? buildFollowCarry(true).droppedDraft : false;
+  }
+
+  let followToastEl = null;
+  function followToastShow(text) {
+    if (!followToastEl) {
+      followToastEl = document.createElement('div');
+      followToastEl.id = 'handover-follow-toast';
+      document.body.appendChild(followToastEl);
+    }
+    followToastEl.textContent = text;
+  }
+  function followToastClear() {
+    if (followToastEl) {
+      followToastEl.remove();
+      followToastEl = null;
+    }
+  }
+
+  function disarmFollowWatch() {
+    if (followWatch.timer) clearInterval(followWatch.timer);
+    if (followWatch.graceTimer) clearTimeout(followWatch.graceTimer);
+    followWatch.armed = false;
+    followWatch.phase = 'idle';
+    followWatch.excluded = '';
+    followWatch.port = 0;
+    followWatch.bootId = '';
+    followWatch.token = '';
+    followWatch.probed = false;
+    followWatch.misses = 0;
+    followWatch.timer = null;
+    followWatch.graceTimer = null;
+    followToastClear();
+  }
+
+  // The move itself: the successor's own tokened URL (the doorway's
+  // withSiblingLoopbackToken shape), the current route hash, and the
+  // carry appended INSIDE the fragment — fragments never reach the
+  // server, and the landing page capture-strips both the token and the
+  // carry before its router reads the hash. location.replace, not
+  // href: the drained origin must not linger as a back-button trap.
+  function performFollowNavigation(includeDraft) {
+    if (followWatch.phase === 'navigating') return;
+    followWatch.phase = 'navigating';
+    const carry = buildFollowCarry(includeDraft);
+    const hash =
+      location.hash && location.hash !== '#' ? location.hash : '#activity';
+    const query = followWatch.token
+      ? `?token=${encodeURIComponent(followWatch.token)}`
+      : '';
+    const url =
+      `${location.protocol}//${location.hostname}:${followWatch.port}/` +
+      `${query}${hash}&carry=${carry.encoded}`;
+    followToastShow(FOLLOW_TOAST_TEXT);
+    try {
+      location.replace(url);
+    } catch (_) {
+      followWatch.phase = 'watching';
+    }
+  }
+
+  // One watch tick: freshest payload from the drainer (it serves until
+  // exit), re-resolve, re-token, probe, then decide. A drainer that
+  // stops answering after the target was resolved+probed is the follow
+  // signal itself — the exit happened between polls.
+  async function followWatchTick() {
+    if (followWatch.phase === 'grace' || followWatch.phase === 'navigating') {
+      return;
+    }
+    let body = null;
+    try {
+      if (typeof daemonApi !== 'undefined' && daemonApi.availability('api_daemon_handover').ok) {
+        const resp = await daemonApi.request('api_daemon_handover', {});
+        if (resp && resp.ok) body = resp.body;
+      }
+    } catch (_) { /* drainer unreachable — counted below */ }
+    if (body && body.available !== false) {
+      if (!body.draining) {
+        // A non-draining answer on this origin is a NEW daemon already
+        // serving here (same-port successor): the boot nudge owns that
+        // path; the watch stands down.
+        disarmFollowWatch();
+        handoverRender(body);
+        return;
+      }
+      followWatch.misses = 0;
+      lastHandoverBody = body;
+      captureFollowStamps(body);
+      const holder = resolveLiveHolder(body);
+      const port = holder && Number(holder.port);
+      if (!holder || !Number.isFinite(port) || port <= 0) {
+        followWatch.port = 0;
+        followWatch.token = '';
+        followWatch.probed = false;
+        return;
+      }
+      if (followWatch.port !== port) {
+        // Resolution moved (a chained drain healed to a later
+        // successor): stale token and probe state go with it.
+        followWatch.port = port;
+        followWatch.bootId = String(holder.boot_id || '');
+        followWatch.token = '';
+        followWatch.probed = false;
+      }
+    } else {
+      followWatch.misses++;
+      if (!followWatch.port || followWatch.misses < 2) return;
+    }
+    if (!followWatch.port) return;
+    // R-A2: the token map is re-fetched, not only pre-fetched — the
+    // helper retries a fresh map when the cached one misses the port,
+    // and the drainer keeps serving the map until it exits. Loopback
+    // only: a LAN/mTLS surface authenticates by cert (or the carried
+    // bearer), and ?token= means nothing to it.
+    if (!followWatch.token && isLoopbackSurface()) {
+      try {
+        followWatch.token = await siblingTokenForPort(followWatch.port);
+      } catch (_) { /* map unreachable this tick — retried next tick */ }
+      if (!followWatch.token) return;
+    }
+    if (!followWatch.probed) {
+      const probed = await probeFollowTarget(followWatch.port);
+      if (!probed) return;
+      followWatch.probed = true;
+    }
+    decideFollowNow();
+  }
+
+  function isLoopbackSurface() {
+    const host = location.hostname.replace(/^\[|\]$/g, '').toLowerCase();
+    return (
+      host === 'localhost' || host === '::1' || /^127(?:\.\d{1,3}){3}$/.test(host)
+    );
+  }
+
+  // HEAD / against the successor origin (the BackendSupervisor
+  // readiness pattern, §2.1(c)): an opaque no-cors answer proves a
+  // listener; a network rejection means "not yet".
+  async function probeFollowTarget(port) {
+    try {
+      await fetch(`${location.protocol}//${location.hostname}:${port}/`, {
+        method: 'HEAD',
+        mode: 'no-cors',
+        cache: 'no-store',
+      });
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  // Target resolved, token in hand, origin answering — move, with the
+  // Q1-ruled posture: a composer draft always demotes to one-button
+  // consent (hidden or visible — a draft is never auto-lost); hidden
+  // tabs move at once; visible tabs get the grace toast.
+  function decideFollowNow() {
+    if (composerDraftText()) {
+      if (followWatch.phase !== 'consent') {
+        followWatch.phase = 'consent';
+        followToastClear();
+        if (lastHandoverBody) handoverRender(lastHandoverBody);
+      }
+      return;
+    }
+    if (document.hidden) {
+      performFollowNavigation(false);
+      return;
+    }
+    followWatch.phase = 'grace';
+    followToastShow(FOLLOW_TOAST_TEXT);
+    followWatch.graceTimer = setTimeout(() => {
+      followWatch.graceTimer = null;
+      // The grace window is exactly the time to start typing: re-check.
+      if (composerDraftText()) {
+        followWatch.phase = 'consent';
+        followToastClear();
+        if (lastHandoverBody) handoverRender(lastHandoverBody);
+        return;
+      }
+      performFollowNavigation(false);
+    }, FOLLOW_GRACE_MS);
+  }
+
+  function armFollowWatch(body) {
+    if (followWatch.armed) return;
+    followWatch.armed = true;
+    followWatch.excluded = followSurfaceExclusion();
+    captureFollowStamps(body);
+    if (followWatch.excluded) return;
+    followWatch.phase = 'watching';
+    // §2.1(a): pre-fetch the sibling token map while the drainer still
+    // serves it — a resilience floor under the per-tick re-fetch.
+    if (isLoopbackSurface()) {
+      try { siblingLoopbackTokenMap(false); } catch (_) { /* re-fetched per tick */ }
+    }
+    followWatch.timer = setInterval(followWatchTick, FOLLOW_WATCH_TICK_MS);
+    followWatchTick();
+  }
+
+  // The banner's follow section (draining branch): honest copy for the
+  // relay exclusion, the one-button consent when a draft holds the
+  // move, and the in-motion status line under grace.
+  function followBannerSection() {
+    if (!followWatch.armed) return null;
+    if (followWatch.excluded === 'relay') {
+      const note = document.createElement('div');
+      note.className = 'handover-banner-note handover-follow-note';
+      note.textContent =
+        'This surface reaches the daemon through a relay, so it cannot ' +
+        'follow the update to a new local address itself. Reopen the ' +
+        'dashboard from your usual entry point once the update completes.';
+      return note;
+    }
+    if (followWatch.excluded) return null;
+    if (followWatch.phase === 'consent') {
+      const wrap = document.createElement('div');
+      wrap.className = 'handover-follow-consent';
+      const note = document.createElement('div');
+      note.className = 'handover-banner-note';
+      note.textContent = followDraftOverCap()
+        ? 'Your composer draft is too large to carry — copy it first; continuing moves without it.'
+        : 'Your composer draft moves with you.';
+      wrap.appendChild(note);
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'handover-follow-continue';
+      btn.textContent = 'Continue on the updated daemon';
+      btn.addEventListener('click', () => performFollowNavigation(true));
+      wrap.appendChild(btn);
+      return wrap;
+    }
+    if (followWatch.phase === 'grace' || followWatch.phase === 'navigating') {
+      const note = document.createElement('div');
+      note.className = 'handover-banner-note handover-follow-note';
+      note.textContent = FOLLOW_TOAST_TEXT;
+      return note;
+    }
+    return null;
+  }
+
+  // ── Landing side: completion honesty (§2.4, R-A1) ──────────────────
+  //
+  // A carried arrival left its pre-swap stamps with the identity
+  // fragment; the first handover payload here names the build THIS
+  // daemon runs (its own presence entry). Compare the PAIR — git_sha
+  // AND built_at — because a rebuild of the same commit is a real
+  // update on a dev box, and only a genuinely unchanged pair may be
+  // narrated as "didn't change builds". Unreadable stamps get the
+  // neutral line, never a claim.
+  let followArrivalStamps =
+    typeof takeFollowArrivalStamps === 'function' ? takeFollowArrivalStamps() : null;
+
+  function followCompletionCheck(body) {
+    if (!followArrivalStamps || !body || body.available === false) return;
+    const arrival = followArrivalStamps;
+    followArrivalStamps = null;
+    if (typeof showControlToast !== 'function') return;
+    const own = (Array.isArray(body.daemons) ? body.daemons : []).find(
+      d => d && d.boot_id === body.boot_id
+    );
+    const version = own && own.version;
+    const succ = version
+      ? { git_sha: String(version.git_sha || ''), built_at: String(version.built_at || '') }
+      : null;
+    const pred = arrival.pred;
+    if (succ && succ.git_sha && pred && pred.git_sha) {
+      const changed =
+        succ.git_sha !== pred.git_sha || succ.built_at !== pred.built_at;
+      if (changed) {
+        const label = String((version && version.pkg) || '').trim();
+        showControlToast(
+          'success',
+          `All set — running ${label || succ.git_sha.slice(0, 10)}.`
+        );
+      } else {
+        showControlToast('info', "The restart didn't change builds.");
+      }
+    } else {
+      showControlToast('info', 'Moved to the updated daemon.');
+    }
+  }
+
   // Render at most this many holdout rows; the rest fold into an honest
   // "…and N more" (parked rows arrive sorted first from the daemon, so
   // the decisive parked-until facts survive the fold).
@@ -978,22 +1432,35 @@
     if (body.boot_id && typeof maybeNudgeDaemonBoot === 'function') {
       maybeNudgeDaemonBoot(body.boot_id);
     }
+    followCompletionCheck(body);
     handoverUpdateRender(body);
     handoverReleaseRender(body);
     if (body.draining) {
+      armFollowWatch(body);
       const holder = resolveLiveHolder(body);
       const el = handoverBanner();
       el.dataset.kind = 'draining';
       el.textContent = '';
       const key = bannerStateKey('draining', body.boot_id);
       const rows = Array.isArray(body.holdouts) ? body.holdouts : [];
-      if (bannerCollapsedNow(el, key)) {
+      // A pending consent (a draft holds the move) outranks the stored
+      // collapse: the one decision the user must see never hides in a
+      // pill.
+      if (followWatch.phase !== 'consent' && bannerCollapsedNow(el, key)) {
         bannerFillPill(el, key, rows.length
           ? `This daemon is draining — waiting on ${rows.length} in-flight session${rows.length === 1 ? '' : 's'}`
           : 'This daemon is draining — in-flight sessions are finishing');
         handoverBannerReserve();
         return;
       }
+      // Consent renders expanded even under a stored collapse — strip
+      // any pill affordances a previous collapsed render left behind.
+      el.classList.remove('collapsed');
+      el.onclick = null;
+      el.onkeydown = null;
+      el.removeAttribute('role');
+      el.removeAttribute('tabindex');
+      el.removeAttribute('title');
       el.appendChild(bannerCollapseButton(key, 'Collapse the drain banner to a pill'));
       const head = document.createElement('div');
       head.className = 'handover-banner-head';
@@ -1016,10 +1483,13 @@
         none.textContent = 'No successor has acquired the lease yet.';
         el.appendChild(none);
       }
+      const followSection = followBannerSection();
+      if (followSection) el.appendChild(followSection);
       if (rows.length) el.appendChild(handoverHoldoutList(rows, rows.length));
       handoverBannerReserve();
       return;
     }
+    if (followWatch.armed) disarmFollowWatch();
     const others = Array.isArray(body.daemons)
       ? body.daemons.filter((d) => d && d.live && d.state === 'draining' && d.boot_id !== body.boot_id)
       : [];
@@ -1101,6 +1571,19 @@
     render: (body) => { lastHandoverBody = body; handoverReleaseRender(body); },
     stateKey: releaseChipStateKey,
   };
+  // The follow watch's live state for the headed follow scenario
+  // (tests/skills/handover-follow): arming, phase transitions, the
+  // resolved target, and the exclusion verdict — token presence only,
+  // never the token itself.
+  window.qa.followState = () => ({
+    armed: followWatch.armed,
+    phase: followWatch.phase,
+    excluded: followWatch.excluded,
+    port: followWatch.port,
+    tokenHeld: Boolean(followWatch.token),
+    probed: followWatch.probed,
+    stamps: followWatch.stamps ? JSON.parse(JSON.stringify(followWatch.stamps)) : null,
+  });
 
   // The palette's dynamic entry, as data (ui2-chrome reads this by name
   // at event time): the SAME one-click affordance the chip is currently

--- a/static/app/ui2-handover.js
+++ b/static/app/ui2-handover.js
@@ -1060,7 +1060,7 @@
   // carry before its router reads the hash. location.replace, not
   // href: the drained origin must not linger as a back-button trap.
   function performFollowNavigation(includeDraft) {
-    if (followWatch.phase === 'navigating') return;
+    if (followWatch.phase === 'navigating' || !followWatch.port) return;
     followWatch.phase = 'navigating';
     const carry = buildFollowCarry(includeDraft);
     const hash =
@@ -1186,6 +1186,7 @@
       performFollowNavigation(false);
       return;
     }
+    if (followWatch.phase === 'grace' || followWatch.phase === 'navigating') return;
     followWatch.phase = 'grace';
     followToastShow(FOLLOW_TOAST_TEXT);
     followWatch.graceTimer = setTimeout(() => {
@@ -1424,6 +1425,7 @@
 
   function handoverRender(body) {
     if (!body || body.available === false) {
+      if (followWatch.armed) disarmFollowWatch();
       handoverClear();
       updateChipClear();
       releaseChipClear();
@@ -1584,6 +1586,13 @@
     probed: followWatch.probed,
     stamps: followWatch.stamps ? JSON.parse(JSON.stringify(followWatch.stamps)) : null,
   });
+  // Test driver (the __testNudgeDaemonBoot precedent): the tokenless
+  // QA posture cannot walk the token+probe ladder, so the headed
+  // scenario forces the decision point to assert the guard/grace
+  // posture. Armed-only; production never calls it.
+  window.qa.__testFollowDecide = () => {
+    if (followWatch.armed && !followWatch.excluded) decideFollowNow();
+  };
 
   // The palette's dynamic entry, as data (ui2-chrome reads this by name
   // at event time): the SAME one-click affordance the chip is currently

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -7569,6 +7569,265 @@ async fn chained_drain_payload_resolves_only_live_non_draining_holder() {
     drop(daemon_b);
 }
 
+/// Update-abstraction slice 2, acceptance (a): the served follow
+/// contract, walked exactly as the scripted tab. While A drains with no
+/// successor (the entry→acquisition window), A's payload resolves
+/// NOBODY, and A's token map — the §2.1(a) pre-fetch — cannot name a
+/// successor that has not booted yet (R-A2's resilience floor). Once C
+/// boots and acquires, the re-fetched payload resolves :C, the
+/// RE-fetched map (the read of record) names C's own admission token,
+/// the target origin answers a probe, and the follow URL the watch
+/// builds — ?token= plus the route hash; the carry rides the fragment
+/// and never reaches the server — lands an authed 200 on C. Both ends
+/// of the completion-honesty compare ride the same payloads: each
+/// daemon's own presence entry names its build as the git_sha+built_at
+/// PAIR (R-A1's substrate).
+#[tokio::test]
+async fn follow_contract_carries_the_scripted_tab_to_the_successor() {
+    let rig = TestRig::new();
+    let barrier = rig.home.path().join("follow-barrier");
+    let script = handover_script(Some(&barrier));
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("http client");
+    let daemon_a = spawn_daemon_on_rig(&client, rig, &script, false).await;
+    let boot_a = lease_sidecar(&daemon_a.rig).expect("holder sidecar")["boot_id"]
+        .as_str()
+        .expect("boot id")
+        .to_string();
+
+    // A's holdout: a scheduled session parked on the file barrier keeps
+    // A alive — and draining, below — while the tab walks the contract.
+    let item_a = approve_manifest_at(
+        &daemon_a.rig,
+        daemon_a.port,
+        now_epoch_ms() + 1_500,
+        "follow-park-a",
+    )
+    .await;
+    poll_until(
+        "A's in-flight started row",
+        RUN_TIMEOUT,
+        || async {
+            journal_states_for_item(&daemon_a.rig, &item_a)
+                .contains(&"started".to_string())
+                .then_some(())
+        },
+        || daemon_a.log_tail(),
+    )
+    .await;
+
+    // Drain A with no successor running: the window opens.
+    let takeover = client
+        .post(format!(
+            "http://127.0.0.1:{}/api/daemon/takeover",
+            daemon_a.port
+        ))
+        .header(
+            "x-intendant-loopback-token",
+            rig_loopback_token(&daemon_a.rig, daemon_a.port),
+        )
+        .json(&serde_json::json!({ "requested_by": "follow e2e" }))
+        .send()
+        .await
+        .expect("takeover request reaches A");
+    assert!(
+        takeover.status().is_success(),
+        "drain request on A refused: {}",
+        takeover.status()
+    );
+    poll_until(
+        "the sidecar naming A draining",
+        RUN_TIMEOUT,
+        || async {
+            let sidecar = lease_sidecar(&daemon_a.rig)?;
+            (sidecar["boot_id"] == boot_a.as_str() && sidecar["state"] == "draining").then_some(())
+        },
+        || format!("sidecar: {:?}", lease_sidecar(&daemon_a.rig)),
+    )
+    .await;
+
+    // The scripted tab's mid-window reads. The payload: draining, this
+    // boot's own presence entry carrying the R-A1 stamp pair (the
+    // pre-swap capture the carry ships), and NO resolvable holder.
+    let a_client = daemon_a.authed_client();
+    let handover_url = format!("http://127.0.0.1:{}/api/daemon/handover", daemon_a.port);
+    let payload = http_get_json(&a_client, &handover_url)
+        .await
+        .expect("A's handover payload");
+    assert_eq!(payload["draining"], true, "{payload}");
+    let a_entry = payload["daemons"]
+        .as_array()
+        .and_then(|daemons| {
+            daemons
+                .iter()
+                .find(|d| d["boot_id"] == payload["boot_id"])
+                .cloned()
+        })
+        .expect("A's own presence entry in its payload");
+    for stamp in ["git_sha", "built_at"] {
+        assert!(
+            a_entry["version"][stamp]
+                .as_str()
+                .is_some_and(|value| !value.is_empty()),
+            "the pre-swap stamp pair rides the drainer's own entry: {a_entry}"
+        );
+    }
+    assert_eq!(
+        resolve_live_holder_port(&payload),
+        None,
+        "nobody resolvable during the window: {payload}"
+    );
+
+    // §2.1(a)'s pre-fetch, taken mid-window: a resilience floor that
+    // cannot name a successor that has not booted.
+    let tokens_url = format!(
+        "http://127.0.0.1:{}/api/local-daemons/tokens",
+        daemon_a.port
+    );
+    let prefetch = http_get_json(&a_client, &tokens_url)
+        .await
+        .expect("the drainer serves the token map mid-window");
+    let prefetched_ports: std::collections::HashSet<u64> = prefetch["instances"]
+        .as_array()
+        .map(|instances| {
+            instances
+                .iter()
+                .filter_map(|inst| inst["port"].as_u64())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // C boots plain — the freed lease lands on it.
+    let daemon_c = spawn_co_daemon(
+        &client,
+        &daemon_a.rig,
+        "daemon-c.log",
+        &[("INTENDANT_LEASE_POLL_MS", "500")],
+        &[],
+    )
+    .await;
+    poll_until(
+        "C acquiring the lease",
+        RUN_TIMEOUT,
+        || async {
+            let sidecar = lease_sidecar(&daemon_a.rig)?;
+            (sidecar["state"] == "active" && sidecar["boot_id"] != boot_a.as_str()).then_some(())
+        },
+        || format!("sidecar: {:?}", lease_sidecar(&daemon_a.rig)),
+    )
+    .await;
+    assert!(
+        !prefetched_ports.contains(&u64::from(daemon_c.port)),
+        "the pre-fetch predates C — only the re-fetch can name it: {prefetched_ports:?}"
+    );
+
+    // The watch's per-tick re-resolution reaches :C on a fresh payload.
+    poll_until(
+        "A's payload resolving :C",
+        RUN_TIMEOUT,
+        || async {
+            let payload = http_get_json(&a_client, &handover_url).await?;
+            (resolve_live_holder_port(&payload) == Some(daemon_c.port)).then_some(())
+        },
+        || format!("last sidecar: {:?}", lease_sidecar(&daemon_a.rig)),
+    )
+    .await;
+
+    // R-A2: the RE-fetched map is the read of record — it now names
+    // C's own admission token, still served by the DRAINING daemon.
+    let tokens = http_get_json(&a_client, &tokens_url)
+        .await
+        .expect("the drainer re-serves the token map");
+    let c_token = tokens["instances"]
+        .as_array()
+        .and_then(|instances| {
+            instances
+                .iter()
+                .find(|inst| inst["port"].as_u64() == Some(u64::from(daemon_c.port)))
+                .cloned()
+        })
+        .expect("the re-fetched map names the successor")["token"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string();
+    assert_eq!(
+        c_token,
+        rig_loopback_token(&daemon_a.rig, daemon_c.port),
+        "the map's token IS the successor's own admission token"
+    );
+
+    // §2.1(c)'s probe: the successor origin ANSWERS — any HTTP answer
+    // proves a listener (the browser probe is opaque no-cors; a named
+    // 401 on a tokenless read is still an answering daemon).
+    client
+        .get(format!("http://127.0.0.1:{}/", daemon_c.port))
+        .send()
+        .await
+        .expect("the successor origin answers the readiness probe");
+
+    // The follow URL the watch builds: ?token= plus the route hash and
+    // the carry (both fragment-side, never on the wire). Authed 200.
+    let follow = client
+        .get(format!(
+            "http://127.0.0.1:{}/?token={}",
+            daemon_c.port, c_token
+        ))
+        .send()
+        .await
+        .expect("the follow navigation reaches C");
+    assert!(
+        follow.status().is_success(),
+        "the follow lands authed on the successor: {}",
+        follow.status()
+    );
+
+    // The landing side's compare substrate: C's own payload names C's
+    // build as the same stamp pair, under a different boot.
+    let mut c_headers = reqwest::header::HeaderMap::new();
+    c_headers.insert(
+        "x-intendant-loopback-token",
+        rig_loopback_token(&daemon_a.rig, daemon_c.port)
+            .parse()
+            .expect("token header value"),
+    );
+    let c_client = reqwest::Client::builder()
+        .no_proxy()
+        .default_headers(c_headers)
+        .build()
+        .expect("authed client for C");
+    let c_payload = http_get_json(
+        &c_client,
+        &format!("http://127.0.0.1:{}/api/daemon/handover", daemon_c.port),
+    )
+    .await
+    .expect("C's handover payload");
+    assert_ne!(
+        c_payload["boot_id"], boot_a.as_str(),
+        "the landing is a different boot: {c_payload}"
+    );
+    let c_entry = c_payload["daemons"]
+        .as_array()
+        .and_then(|daemons| {
+            daemons
+                .iter()
+                .find(|d| d["boot_id"] == c_payload["boot_id"])
+                .cloned()
+        })
+        .expect("C's own presence entry in its payload");
+    for stamp in ["git_sha", "built_at"] {
+        assert!(
+            c_entry["version"][stamp]
+                .as_str()
+                .is_some_and(|value| !value.is_empty()),
+            "the landing-side stamp pair rides the successor's own entry: {c_entry}"
+        );
+    }
+
+    drop(daemon_c);
+}
+
 /// A probe-able fake "binary": a shell script printing exactly
 /// `build_info::version_line`'s shape with the given sha. Unix-only —
 /// the update watch execs it for `--version`.

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -7804,7 +7804,8 @@ async fn follow_contract_carries_the_scripted_tab_to_the_successor() {
     .await
     .expect("C's handover payload");
     assert_ne!(
-        c_payload["boot_id"], boot_a.as_str(),
+        c_payload["boot_id"],
+        boot_a.as_str(),
         "the landing is a different boot: {c_payload}"
     );
     let c_entry = c_payload["daemons"]

--- a/tests/skills/handover-follow/SKILL.md
+++ b/tests/skills/handover-follow/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: handover-follow
+description: Prove the drain follow watch in a real booted SPA — arming on own-drain, the composer-draft consent demotion (R-A3 over-cap copy BEFORE navigation), the grace toast, and the live two-daemon follow where a headed tab moves itself onto the successor with its state carried and lands with the honest completion line. NOT in CI — drives a real browser over CDP (probe leg) and a live co-homed drain the operator watches (follow leg).
+---
+
+# Drain follow watch — headed scenario
+
+**NOT in CI.** The e2e suite pins the served contract
+(`follow_contract_carries_the_scripted_tab_to_the_successor`) and the
+unit pins freeze the fragment wiring (`spa_arms_the_follow_watch_on_own_drain`
+and siblings in `src/bin/caller/handover/mod.rs`). This scenario is the
+operator battery's browser half: the follow watch running inside a real
+SPA — probe leg via `scripts/validate-dashboard.cjs` (headless CDP is
+fine), follow leg with a real co-homed drain and a tab that visibly
+moves (headed, eyes-on).
+
+Preconditions: current worktree binaries (`cargo build --bin intendant
+--bin intendant-runtime` — the validator rejects stale target binaries
+and never rebuilds), scratch `INTENDANT_HOME` for every daemon in the
+scenario (the follow watch reads real payloads; a real home would put
+owner state behind the probes), and `jq` for the follow leg's approval
+step.
+
+## Probe leg — arming, consent, grace (tokenless posture)
+
+One invocation, three probes. The tokenless validate-dashboard posture
+cannot fetch the authed handover payload or the sibling token map, so
+the probes feed synthetic bodies through `qa.handoverBanner.render`
+(the established tokenless-QA door), read `qa.followState()`, and force
+the decision point with `qa.__testFollowDecide()` (the
+`__testNudgeDaemonBoot` precedent) — the token+probe ladder itself is
+the follow leg's and the e2e leg's job. Each probe disarms via
+`render({available:false})` so nothing leaks between probes and no
+grace timer survives (a leaked timer is harmless anyway: an unresolved
+target refuses navigation by guard).
+
+```bash
+QAHOME=$(mktemp -d /tmp/follow-qa-home.XXXXXX)
+INTENDANT_HOME="$QAHOME" node scripts/validate-dashboard.cjs \
+  --launch-dashboard --port 8933 --dashboard-binary ./target/debug/intendant \
+  --wait-for-function "window.qa && window.qa.followState && window.qa.handoverBanner" \
+  --probe-json "followArm=(() => { const body = { boot_id: 'boot-drain', draining: true, daemons: [ { boot_id: 'boot-drain', port: 8933, state: 'draining', live: true, version: { pkg: '0.0.0-qa', git_sha: 'aaaaaaaaaa', built_at: '2026-01-01T00:00:00Z' } }, { boot_id: 'boot-succ', port: 65500, state: 'active', live: true, version: { pkg: '0.0.0-qa', git_sha: 'bbbbbbbbbb', built_at: '2026-01-02T00:00:00Z' } } ], sidecar: { boot_id: 'boot-succ', port: 65500, state: 'active' }, holdouts: [] }; window.qa.handoverBanner.render(body); const s = window.qa.followState(); const out = { armed: s.armed === true, watching: s.phase === 'watching', direct: s.excluded === '', stampPair: !!(s.stamps && s.stamps.pred && s.stamps.pred.git_sha === 'aaaaaaaaaa' && s.stamps.pred.built_at === '2026-01-01T00:00:00Z'), predBoot: !!(s.stamps && s.stamps.pred_boot === 'boot-drain') }; window.qa.handoverBanner.render({ available: false }); out.disarmed = window.qa.followState().armed === false; return out; })()" \
+  --probe-json "followConsent=(() => { const body = { boot_id: 'boot-drain', draining: true, daemons: [ { boot_id: 'boot-drain', port: 8933, state: 'draining', live: true, version: { pkg: '0.0.0-qa', git_sha: 'aaaaaaaaaa', built_at: '2026-01-01T00:00:00Z' } } ], sidecar: null, holdouts: [] }; const input = document.getElementById('new-session-input'); input.value = 'a draft the move must never clobber'; window.qa.handoverBanner.render(body); window.qa.__testFollowDecide(); const out = { consent: window.qa.followState().phase === 'consent' }; let section = document.querySelector('.handover-follow-consent'); out.button = !!(section && section.textContent.includes('Continue on the updated daemon')); out.carriesNamed = !!(section && section.textContent.includes('moves with you')); input.value = 'x'.repeat(20000); window.qa.handoverBanner.render(body); section = document.querySelector('.handover-follow-consent'); out.overCapNamedBeforeNavigation = !!(section && section.textContent.includes('too large to carry')); input.value = ''; window.qa.handoverBanner.render({ available: false }); out.disarmed = window.qa.followState().armed === false; return out; })()" \
+  --probe-json "followGrace=(() => { const body = { boot_id: 'boot-drain', draining: true, daemons: [ { boot_id: 'boot-drain', port: 8933, state: 'draining', live: true, version: { pkg: '0.0.0-qa', git_sha: 'aaaaaaaaaa', built_at: '2026-01-01T00:00:00Z' } } ], sidecar: null, holdouts: [] }; window.qa.handoverBanner.render(body); window.qa.__testFollowDecide(); const s = window.qa.followState(); const toast = document.getElementById('handover-follow-toast'); const out = { grace: s.phase === 'grace', toast: !!(toast && toast.textContent.includes('Moving to the updated daemon')) }; window.qa.handoverBanner.render({ available: false }); out.cleaned = !document.getElementById('handover-follow-toast') && window.qa.followState().armed === false; return out; })()"
+rm -rf "$QAHOME"
+```
+
+Expected: every probe field `true`. `followConsent` is the R-A3 bar —
+the over-cap loss is named in the consent section BEFORE any
+navigation, and the button label is the intake's verbatim "Continue on
+the updated daemon". `followGrace` proves the visible-tab posture: the
+decision lands in `grace` (never an immediate move) under the "Moving
+to the updated daemon…" toast.
+
+## Follow leg — the live two-daemon move (eyes-on)
+
+The real thing: a headed tab on a draining daemon moves itself onto the
+successor, authed, with its route carried — and, because both daemons
+run the SAME binary, the completion line must be the honest
+**"The restart didn't change builds."** (R-A1's pair-equality arm: the
+classic false-"updated" narration is exactly what this leg proves
+gone). Mock provider throughout — keyless, no API calls.
+
+```bash
+BIN=./target/debug/intendant
+HOME_RIG=$(mktemp -d /tmp/follow-live-home.XXXXXX)
+PROJ=$(mktemp -d /tmp/follow-live-proj.XXXXXX)
+touch "$PROJ/intendant.toml"
+cat > "$HOME_RIG/script.json" <<'EOF'
+{ "profiles": [
+  { "match": "handover rig follow-through",
+    "steps": [
+      { "content": "Working until released.", "wait_for_file": "BARRIER" },
+      { "content": "All work finished.",
+        "tool_calls": [{ "name": "signal_done", "arguments": { "message": "done" } }] } ] },
+  { "steps": [ { "content": "fallback", "tool_calls": [{ "name": "signal_done", "arguments": { "message": "unexpected" } }] } ] }
+] }
+EOF
+# The barrier placeholder must be the real path:
+python3 - "$HOME_RIG" <<'EOF'
+import json, sys, pathlib
+home = pathlib.Path(sys.argv[1])
+p = home / 'script.json'
+s = json.loads(p.read_text())
+s['profiles'][0]['steps'][0]['wait_for_file'] = str(home / 'barrier')
+p.write_text(json.dumps(s))
+EOF
+
+# 1. Daemon A (the predecessor), from the project root:
+cd "$PROJ" && INTENDANT_HOME="$HOME_RIG" PROVIDER=mock \
+  INTENDANT_MOCK_SCRIPT="$HOME_RIG/script.json" INTENDANT_LEASE_POLL_MS=500 \
+  "$OLDPWD/$BIN" --web 8934 --bind 127.0.0.1 --no-tls --no-tui --autonomy full & cd "$OLDPWD"
+
+# 2. Open A's dashboard IN A HEADED BROWSER via its tokened URL:
+sleep 3 && echo "open: http://127.0.0.1:8934/?token=$(cat "$HOME_RIG/.intendant/loopback-tokens/8934.token")"
+
+# 3. Park a holdout on A so the drain has something to wait on
+#    (add → schedule at +2s → approve with the exact digest):
+CTL() { env -u INTENDANT_SESSION_ID INTENDANT_HOME="$HOME_RIG" "$BIN" ctl --url "http://127.0.0.1:8934" "$@"; }
+ITEM=$(CTL --json agenda add "follow live park" --task | jq -r .item.id)
+CTL agenda schedule "${ITEM:0:10}" --goal "handover rig follow-through" --at +2s
+DIGEST=$(CTL --json agenda list --all | jq -r ".items[] | select(.id==\"$ITEM\") | .effects[0].digest")
+CTL agenda approve "${ITEM:0:10}" --digest "$DIGEST"
+sleep 5   # let the occurrence fire and park on the barrier
+
+# 4. Daemon C (the successor), co-homed:
+cd "$PROJ" && INTENDANT_HOME="$HOME_RIG" PROVIDER=mock \
+  INTENDANT_MOCK_SCRIPT="$HOME_RIG/script.json" INTENDANT_LEASE_POLL_MS=500 \
+  "$OLDPWD/$BIN" --web 8935 --bind 127.0.0.1 --no-tls --no-tui --autonomy full & cd "$OLDPWD"
+
+# 5. Drain A:
+curl -s -X POST "http://127.0.0.1:8934/api/daemon/takeover" \
+  -H "x-intendant-loopback-token: $(cat "$HOME_RIG/.intendant/loopback-tokens/8934.token")" \
+  -H 'Content-Type: application/json' -d '{"requested_by":"follow live leg"}'
+```
+
+Watch the tab (within one 30s handover poll, then a ~2.5s tick
+cadence):
+
+1. The drain banner appears, naming the parked holdout.
+2. The follow status/toast: "Moving to the updated daemon…" (about 5s,
+   the visible-tab grace).
+3. The tab **replaces itself onto `http://127.0.0.1:8935`**, lands
+   authed (no named-401 wall — the token rode the URL and stripped
+   itself), the route hash survives, and the completion toast reads
+   **"The restart didn't change builds."** — same binary on both ends,
+   said honestly.
+4. `qa.followCarryApplied()` in the landed tab's console reports what
+   the carry seeded (window records / sub-tabs / draft as exercised).
+5. Draft variant (repeat with text typed in the New Session composer
+   before step 5): no auto-move — the banner holds a one-button
+   "Continue on the updated daemon"; clicking moves and the draft
+   arrives in the successor's composer.
+
+Cleanup:
+
+```bash
+touch "$HOME_RIG/barrier"   # release the parked session; A exits after it finishes
+sleep 3; kill %1 %2 2>/dev/null; rm -rf "$HOME_RIG" "$PROJ"
+```
+
+Both daemons here are the same build, so this leg cannot show the
+"All set — running <version>." arm; the e2e leg pins the stamp-pair
+substrate and the unit pin freezes the compare expression — a live
+different-build follow happens naturally on the dev fleet's next real
+update and needs no rig.


### PR DESCRIPTION
## Update-abstraction slice 2 — auto-follow + carry (browser surfaces)

Implements intake §7 slice 2 (sealed: ~/update-abstraction-intake.md, sha256 ed4215e8…) with the ruling's four refinements: **R-A1** (completion honesty compares the git_sha+built_at STAMP PAIR, never sha alone), **R-A2** (the sibling token map is re-fetched, not only pre-fetched — and the same re-fetch-on-miss heals the slice-1 doorway's per-page-load cache, the ruling's N1 note, in this same change), **R-A3** (an over-cap composer draft names its loss BEFORE navigation — consent, not disclosure), **R-A4** (the legacy `[server.auth] bearer_token` posture: the bearer **rides the carry blob** — it is already a client-held per-origin secret and the capture-strip pattern applies verbatim; chosen over the honest-copy degrade so LAN-bearer surfaces keep working across the hop).

Composes with slice 1's landed substrate (resolveLiveHolder + tokened doorway, PR #751) — nothing duplicated: the follow watch consumes the same resolver (pinned: ONE rule, two consumers) and the same token helper.

### What ships
- **Follow watch** (ui2-handover.js): arms on own-drain; 2.5s tick re-fetches the drainer's payload, re-resolves the live holder (never onto a draining daemon — 6c), fetches the target's admission token via the shared map helper, probes the target origin (no-cors HEAD, the BackendSupervisor readiness pattern), then `location.replace` with `?token=`, the route hash, and the carry. A drainer that stops answering after the target was resolved+probed is itself the follow signal.
- **Carry blob** (§2.3): `#…&carry=<base64 json>` — route, open session-window SET, the two sub-tab keys, pre-swap build stamps, optional bearer (R-A4), optional consented draft; ~8KB cap, draft drops first. Landing side (31-init-identity-fleet.js) capture-strips it before the router/session-windows readers evaluate and seeds their own persisted keys — the successor rebuilds windows from its own catalog.
- **Q1 posture**: hidden tabs move immediately; visible tabs after a ~5s grace toast ('Moving to the updated daemon…'); any composer draft demotes to a one-button 'Continue on the updated daemon' consent (pending consent also outranks the banner's stored collapse).
- **Completion honesty** (§2.4 + R-A1): the landing page compares its own presence-entry stamps against the carried predecessor stamps as the PAIR; 'All set — running <version>.' only on a real change, 'The restart didn't change builds.' otherwise, neutral copy when stamps are unreadable.
- **Exclusions** (§2.5): packaged-app webview stands down silently (the app follows itself via didSwapToPort); hosted-relay surfaces get honest banner copy — port substitution means nothing there; canonical-port rebind stays the parked durable fix for cold bookmarks and relay surfaces.
- **QA**: `qa.followState` (token presence only, never the token), `qa.followCarryApplied`, and the `__testFollowDecide` driver (the `__testNudgeDaemonBoot` precedent).

### Acceptance (intake §7 slice 2, verbatim) — all four met
- **(a)** e2e `follow_contract_carries_the_scripted_tab_to_the_successor`: the served contract walked as the scripted tab — mid-window resolution None + the pre-fetch floor that cannot name an unbooted successor; after C acquires, re-resolution reaches :C, the RE-fetched map names C's own admission token (R-A2 pinned end to end), the origin answers the probe, the tokened follow URL lands an authed 200, and both payloads carry the stamp-pair compare substrate.
- **(b)** four fragment pins in `handover/mod.rs`: `spa_arms_the_follow_watch_on_own_drain`, `follow_carry_capture_strips_and_seeds_the_landing` (incl. the sub-tab literal parity pin and served-bundle exactly-once counts), `follow_composer_guard_demotes_to_consent` (R-A3), `completion_honesty_compares_the_stamp_pair` (R-A1).
- **(c)** `tests/skills/handover-follow/SKILL.md` — headed scenario, **NOT in CI** (stated in the doc): probe leg (validate-dashboard + qa.handoverBanner + qa.followState + __testFollowDecide) and the live two-daemon eyes-on follow leg whose same-binary completion line must read 'The restart didn't change builds.' **Probe leg executed live at this head**: `followArm`/`followConsent`/`followGrace` all-true, PASS, exit 0 (pipefail).
- **(d)** full local battery, bare exits all 0: `cargo fmt --check`; bins 5616+150+97; lib crates (6 packages); e2e **47/47** incl. the new leg; `cargo clippy --workspace -- -D warnings`.

### Trust posture
No new routes, no tunnel twins, no new authority: the follow is pure client-side navigation plus the existing owner-posture token map, consumed exactly as the fleet links already consume it. `gateway_routes.rs` untouched. The carry is the same trust class as the existing `?token=` capture — everything in it is data a linking page could already put in a URL; junk seeds break only the tab's own display state.

### Notes for the gate
- The relay exclusion is detected via `hostedControlActive()` ∪ `DASHBOARD_CONNECT_MODE` (the latter a build-time constant today — future-proofing, zero cost).
- Slice-3 seat (s-4ab14652) coordinated on the bus: disjoint fragments, disjoint pin files, e2e legs anchored apart; app.html conflicts resolve in fragments + assembler.