### PR TITLE
sessions: unified drain view — boot.held_by + promptable drainer rows (update-abstraction slice 3)

### DIFF
--- a/src/bin/caller/handover/mod.rs
+++ b/src/bin/caller/handover/mod.rs
@@ -28,7 +28,7 @@ mod successor_exec;
 mod update_lane;
 mod update_watch;
 
-pub(crate) use lease::{read_lease_sidecar, LeaseAttempt, SchedulerLease};
+pub(crate) use lease::{read_lease_sidecar, BuildVersion, LeaseAttempt, SchedulerLease};
 pub(crate) use presence::{boot_id_is_live, read_presence_records, DaemonPresence, DrainHoldout};
 pub(crate) use successor_exec::spawn_successor_exec_lane;
 pub(crate) use update_lane::{parse_channel_arg, spawn_update_lane, update_rendezvous_url};

--- a/src/bin/caller/web_gateway/session_catalog/grid_envelope.rs
+++ b/src/bin/caller/web_gateway/session_catalog/grid_envelope.rs
@@ -74,6 +74,66 @@ pub(crate) struct GridEnvelopeJoins {
     /// an unchanged index) and handed to every row's tip memo check —
     /// never re-derived per row.
     lineage_epoch: Option<u64>,
+    /// Update-abstraction §3 (residual R4): session id → the draining
+    /// co-homed sibling still RUNNING it, resolved once per build from
+    /// presence (see [`resolve_drain_map`]). Empty when no live sibling
+    /// drains — the common case costs one directory read.
+    drain_map: HashMap<String, DrainHold>,
+}
+
+/// One draining LIVE co-homed sibling's holdout claim on a session row —
+/// the `boot.held_by` wire block's source. Presence-derived and
+/// read-only (the F1 watershed law: this join never writes presence).
+pub(crate) struct DrainHold {
+    boot_id: String,
+    port: u16,
+    /// The sibling's build stamps, served for the mechanics reveal.
+    version: crate::handover::BuildVersion,
+    /// R-A1 build-stamp compare against THIS daemon's build (the whole
+    /// stamp — a rebuild of the same commit still reads different):
+    /// `false` = the sibling runs another build ("finishing on the
+    /// previous version"); `true` = same build, restart without update.
+    same_build: bool,
+    phase: String,
+    limit_park: Option<crate::session_log::SessionLimitParkMeta>,
+}
+
+/// The co-homed drain map: presence records that are DRAINING and
+/// provably live (the boot-lock probe — the same liveness truth
+/// `status_json` serves), excluding this process's own record, with
+/// their named holdout rows indexed by session id. Sessions beyond the
+/// presence holdout cap (16) get no entry — `session_count` keeps the
+/// full truth and the drain banner stays the aggregate surface. The
+/// join self-clears: a drainer's exit frees its boot lock, `live`
+/// reads false, and the map stops carrying it.
+fn resolve_drain_map(state_root: &Path) -> HashMap<String, DrainHold> {
+    let own_pid = std::process::id();
+    let current_build = crate::handover::BuildVersion::current();
+    let mut map = HashMap::new();
+    for record in crate::handover::read_presence_records(state_root) {
+        if record.pid == own_pid || record.state != "draining" {
+            continue;
+        }
+        let Some(holdouts) = record.holdouts.as_ref().filter(|rows| !rows.is_empty()) else {
+            continue;
+        };
+        if !crate::handover::boot_id_is_live(state_root, &record.boot_id) {
+            continue;
+        }
+        let same_build = record.version == current_build;
+        for holdout in holdouts {
+            map.entry(holdout.session_id.clone())
+                .or_insert_with(|| DrainHold {
+                    boot_id: record.boot_id.clone(),
+                    port: record.port,
+                    version: record.version.clone(),
+                    same_build,
+                    phase: holdout.phase.clone(),
+                    limit_park: holdout.limit_park.clone(),
+                });
+        }
+    }
+    map
 }
 
 impl GridEnvelopeJoins {
@@ -94,6 +154,7 @@ impl GridEnvelopeJoins {
             agenda,
             lineage_epoch: Some(crate::external_wrapper_index::lineage_epoch(home_path)),
             home: Some(home_path.to_path_buf()),
+            drain_map: resolve_drain_map(&state_root),
         }
     }
 
@@ -106,6 +167,7 @@ impl GridEnvelopeJoins {
             agenda: None,
             home: None,
             lineage_epoch: None,
+            drain_map: HashMap::new(),
         }
     }
 
@@ -127,7 +189,17 @@ impl GridEnvelopeJoins {
                 .as_deref()
                 .map(crate::external_wrapper_index::lineage_epoch),
             home,
+            drain_map: HashMap::new(),
         }
+    }
+
+    /// Test builder: resolve the co-homed drain map from a fixture state
+    /// root through the REAL resolver, so the unit matrix exercises its
+    /// filters (draining/live/own-pid) rather than a hand-built map.
+    #[cfg(test)]
+    pub(crate) fn with_drain_map_from(mut self, state_root: &Path) -> Self {
+        self.drain_map = resolve_drain_map(state_root);
+        self
     }
 
     /// Attach the envelope blocks to one intendant wrapper row.
@@ -247,6 +319,31 @@ impl GridEnvelopeJoins {
         // the winning row's terminal is the one the card states.
         if let Some(terminal) = row.get("terminal").filter(|value| value.is_object()) {
             boot_block["terminal"] = terminal.clone();
+        }
+        // Update-abstraction §3 (residual R4): a session still RUNNING on
+        // a draining live sibling carries `held_by` BESIDE the era
+        // vocabulary (old SPAs ignore the field; `normalizeSessionBootEra`
+        // stays strict) — era/ghost above are untouched by this join. A
+        // locally live wrapper outranks any stale sibling claim: double
+        // supervision never happens by design, so the local wrapper is
+        // the stronger truth and the sibling row is debris.
+        if !live_wrapper {
+            if let Some(hold) = self.drain_map.get(session_id) {
+                let mut held_by = serde_json::json!({
+                    "boot_id": hold.boot_id,
+                    "port": hold.port,
+                    "version": serde_json::to_value(&hold.version)
+                        .unwrap_or(serde_json::Value::Null),
+                    "same_build": hold.same_build,
+                    "phase": hold.phase,
+                });
+                if let Some(park) = hold.limit_park.as_ref() {
+                    if let Ok(park) = serde_json::to_value(park) {
+                        held_by["limit_park"] = park;
+                    }
+                }
+                boot_block["held_by"] = held_by;
+            }
         }
         if ghost {
             match dead_row_lineage_tip(self.home.as_deref(), session_id, dir, self.lineage_epoch) {
@@ -541,6 +638,223 @@ mod tests {
         assert!(row.get("boot").is_none());
     }
 
+    /// Fixture presence: a full record (state/version/holdouts) under a
+    /// FOREIGN pid by default — the drain map excludes own-pid records.
+    fn write_presence_record(
+        state_root: &Path,
+        boot_id: &str,
+        pid: u32,
+        port: u16,
+        state: &str,
+        version: serde_json::Value,
+        holdouts: serde_json::Value,
+    ) {
+        let dir = state_root.join("daemons");
+        std::fs::create_dir_all(&dir).unwrap();
+        let record = serde_json::json!({
+            "v": 1,
+            "boot_id": boot_id,
+            "pid": pid,
+            "port": port,
+            "version": version,
+            "state": state,
+            "session_count": 1,
+            "holdouts": holdouts,
+            "updated_ms": 5_000,
+        });
+        std::fs::write(dir.join(format!("{boot_id}.json")), record.to_string()).unwrap();
+    }
+
+    /// Hold `boot_id`'s presence lock from this process. flock/LockFileEx
+    /// deny per file description, so the drain map's probe sees exactly
+    /// what it would against another live daemon.
+    fn hold_boot_lock(state_root: &Path, boot_id: &str) -> std::fs::File {
+        let dir = state_root.join("daemons");
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(dir.join(format!("{boot_id}.lock")))
+            .unwrap();
+        file.try_lock().unwrap();
+        file
+    }
+
+    fn parked_holdout_rows(session_id: &str) -> serde_json::Value {
+        serde_json::json!([{
+            "session_id": session_id,
+            "source": "claude-code",
+            "name": "seat",
+            "phase": "waiting_rate_limit",
+            "limit_park": { "resets_at_epoch": 1_754_000_000u64, "has_pending": true },
+        }])
+    }
+
+    /// Slice-3 acceptance (a), the drain-map matrix: a DRAINING sibling
+    /// whose boot lock is HELD joins `boot.held_by` onto its holdout
+    /// rows (port/phase/limit_park + the R-A1 build-stamp compare); a
+    /// non-draining, non-live, exited, or own-pid record joins nothing;
+    /// a locally live wrapper outranks any sibling claim; and the
+    /// era/ghost vocabulary is byte-identical with and without the join
+    /// (the map only READS presence — F1 untouched).
+    #[test]
+    fn held_by_matrix_joins_only_draining_live_siblings() {
+        let sessions = tempfile::tempdir().unwrap();
+        let dir = session_dir_with_transcript(sessions.path(), "s1");
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let watershed = now_secs.saturating_sub(3_600);
+        let foreign_pid = std::process::id() + 1;
+        let elder_build =
+            serde_json::json!({"pkg": "0.0.0", "git_sha": "elder", "built_at": "elder-ts"});
+        let attach_with = |state_root: &Path, live: &[&str], session_id: &str| {
+            let mut row = serde_json::json!({});
+            joins(Some(watershed), Some(live), None)
+                .with_drain_map_from(state_root)
+                .attach(&mut row, session_id, &dir);
+            row
+        };
+
+        // Draining + provably live sibling → the whole held_by block.
+        let root = tempfile::tempdir().unwrap();
+        write_presence_record(
+            root.path(),
+            "boot-drainer",
+            foreign_pid,
+            8770,
+            "draining",
+            elder_build.clone(),
+            parked_holdout_rows("s1"),
+        );
+        let _drainer_lock = hold_boot_lock(root.path(), "boot-drainer");
+        let row = attach_with(root.path(), &[], "s1");
+        let held = &row["boot"]["held_by"];
+        assert_eq!(held["boot_id"], "boot-drainer");
+        assert_eq!(held["port"], 8770);
+        assert_eq!(held["phase"], "waiting_rate_limit");
+        assert_eq!(
+            held["limit_park"]["resets_at_epoch"], 1_754_000_000_u64,
+            "the parked-until instant rides the block — the decisive fact"
+        );
+        assert_eq!(
+            held["same_build"], false,
+            "fixture build differs from this binary (the R-A1 stamp compare)"
+        );
+        assert_eq!(held["version"]["git_sha"], "elder");
+        assert_eq!(held["version"]["built_at"], "elder-ts");
+        assert_eq!(row["boot"]["era"], "current");
+        assert_eq!(row["boot"]["ghost"], false);
+
+        // Era honesty: strip held_by and the joined row is byte-identical
+        // to an un-joined attach — the field rides BESIDE the era
+        // vocabulary, never inside it.
+        let mut baseline = serde_json::json!({});
+        joins(Some(watershed), Some(&[]), None).attach(&mut baseline, "s1", &dir);
+        let mut joined = row.clone();
+        joined["boot"]
+            .as_object_mut()
+            .unwrap()
+            .remove("held_by")
+            .expect("held_by was attached");
+        assert_eq!(
+            joined, baseline,
+            "era/ghost outputs byte-identical; held_by is the only addition"
+        );
+
+        // A session outside the holdout rows joins nothing.
+        let other = attach_with(root.path(), &[], "s2");
+        assert!(other["boot"].get("held_by").is_none());
+
+        // A locally live wrapper outranks a (stale) sibling claim.
+        let live_row = attach_with(root.path(), &["s1"], "s1");
+        assert_eq!(live_row["boot"]["live_wrapper"], true);
+        assert!(live_row["boot"].get("held_by").is_none());
+
+        // Same-build sibling → the compare says restart, not update.
+        let root = tempfile::tempdir().unwrap();
+        write_presence_record(
+            root.path(),
+            "boot-twin",
+            foreign_pid,
+            8771,
+            "draining",
+            serde_json::to_value(crate::handover::BuildVersion::current()).unwrap(),
+            parked_holdout_rows("s1"),
+        );
+        let _twin_lock = hold_boot_lock(root.path(), "boot-twin");
+        assert_eq!(
+            attach_with(root.path(), &[], "s1")["boot"]["held_by"]["same_build"],
+            true
+        );
+
+        // Non-draining (running) live sibling → absent.
+        let root = tempfile::tempdir().unwrap();
+        write_presence_record(
+            root.path(),
+            "boot-running",
+            foreign_pid,
+            8772,
+            "running",
+            elder_build.clone(),
+            parked_holdout_rows("s1"),
+        );
+        let _running_lock = hold_boot_lock(root.path(), "boot-running");
+        assert!(attach_with(root.path(), &[], "s1")["boot"]
+            .get("held_by")
+            .is_none());
+
+        // Draining but provably dead (takeable/absent lock) → absent.
+        let root = tempfile::tempdir().unwrap();
+        write_presence_record(
+            root.path(),
+            "boot-dead",
+            foreign_pid,
+            8773,
+            "draining",
+            elder_build.clone(),
+            parked_holdout_rows("s1"),
+        );
+        assert!(attach_with(root.path(), &[], "s1")["boot"]
+            .get("held_by")
+            .is_none());
+
+        // Exited (lock still held on the way out) → absent.
+        let root = tempfile::tempdir().unwrap();
+        write_presence_record(
+            root.path(),
+            "boot-exited",
+            foreign_pid,
+            8774,
+            "exited",
+            elder_build.clone(),
+            parked_holdout_rows("s1"),
+        );
+        let _exited_lock = hold_boot_lock(root.path(), "boot-exited");
+        assert!(attach_with(root.path(), &[], "s1")["boot"]
+            .get("held_by")
+            .is_none());
+
+        // This process's own record never claims its own rows.
+        let root = tempfile::tempdir().unwrap();
+        write_presence_record(
+            root.path(),
+            "boot-self",
+            std::process::id(),
+            8775,
+            "draining",
+            elder_build,
+            parked_holdout_rows("s1"),
+        );
+        let _self_lock = hold_boot_lock(root.path(), "boot-self");
+        assert!(attach_with(root.path(), &[], "s1")["boot"]
+            .get("held_by")
+            .is_none());
+    }
+
     fn envelope(
         state: crate::agenda::OccurrenceState,
         lineage_role: crate::agenda::SessionLineageRole,
@@ -744,6 +1058,18 @@ mod tests {
             "worktree_state",
             "normalizeSessionWorktreeState(",
             "'worktree-state'",
+            // Update-abstraction §3 (R4): the drain-map claim — wire
+            // name, normalize seam, chip id, and the old-build
+            // indicator (acceptance (b)+(g): the R-A1 same_build
+            // compare splits the grade-1 copy).
+            "held_by",
+            "normalizeSessionHeldBy(",
+            "sessionWindowHeldBy(",
+            "'held-by'",
+            "same_build",
+            "sameBuild",
+            "finishing on the previous version",
+            "finishing on the previous daemon",
         ] {
             assert!(
                 fragment.contains(needle),
@@ -762,6 +1088,49 @@ mod tests {
             styles.contains(".session-window.session-window-ghost"),
             "the stylesheet lost the ghost window treatment"
         );
+        // Slice-3 affordance gating + the amended composer lane: the
+        // window-action gate consults the shared held_by lookup; the
+        // sessions-tab card wears the chip and gates resume; the
+        // composer routes held targets to the sibling's own gateway
+        // through the sibling token map, and the sibling-gone refusal
+        // stays honest and named (acceptance (f)'s copy pin).
+        for needle in [
+            "sessionWindowHeldBy(",
+            "HELD_BY_SAFE_OPS",
+            "Still finishing on the previous version",
+        ] {
+            assert!(
+                actions.contains(needle),
+                "the actions fragment lost the held_by affordance gate: {needle}"
+            );
+        }
+        let cards = include_str!("../../../../../static/app/57a-sessions-list.js");
+        for needle in [
+            "sc-held-by-chip",
+            "held_by",
+            "same_build",
+            "finishing on the previous version",
+            "finishing on the previous daemon",
+        ] {
+            assert!(
+                cards.contains(needle),
+                "the sessions-tab card lost its held_by treatment: {needle}"
+            );
+        }
+        let lifecycle = include_str!("../../../../../static/app/54-session-lifecycle.js");
+        for needle in [
+            "dispatchHeldBySessionFollowUp(",
+            "siblingDaemonStartTask(",
+            "/api/local-daemons/tokens",
+            "action: 'start_task', task: text, session_id: sid",
+            "is gone — this session can't take messages there anymore",
+            "continues here when the handover completes",
+        ] {
+            assert!(
+                lifecycle.contains(needle),
+                "the composer lost the held_by sibling lane: {needle}"
+            );
+        }
     }
 
     /// The join the original matrix missed (the 2026-07-28 ghost-flag

--- a/static/app.html
+++ b/static/app.html
@@ -38862,7 +38862,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '5fdc4d7413521562';
+const INTENDANT_APP_BUILD = 'f6e1bef802ccd6cb';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -62871,7 +62871,57 @@ function normalizeSessionBootEra(raw) {
   if (terminal) out.terminal = terminal;
   const continuedAs = normalizeSessionContinuedAs(raw.continued_as || raw.continuedAs);
   if (continuedAs) out.continuedAs = continuedAs;
+  // Update-abstraction §3 (R4): the drain-map claim rides BESIDE the era
+  // vocabulary — a session still FINISHING on a draining co-homed
+  // sibling daemon (never a new era value; the strictness above stands).
+  const heldBy = normalizeSessionHeldBy(raw.held_by || raw.heldBy);
+  if (heldBy) out.heldBy = heldBy;
   return out;
+}
+
+// boot.held_by: which draining sibling daemon still RUNS this session,
+// on what build (same_build = the daemon's R-A1 stamp compare against
+// itself), in what phase, parked until when. Sessions are never moved
+// mid-flight — this is display truth plus the composer's routing key.
+function normalizeSessionHeldBy(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const port = Number(raw.port);
+  if (!Number.isFinite(port) || port <= 0) return null;
+  const out = {
+    port,
+    sameBuild: raw.same_build === true || raw.sameBuild === true,
+  };
+  const bootId = compactSessionText(raw.boot_id || raw.bootId);
+  if (bootId) out.bootId = bootId;
+  const phase = compactSessionText(raw.phase);
+  if (phase) out.phase = phase;
+  const version = raw.version;
+  if (version && typeof version === 'object') {
+    const gitSha = compactSessionText(version.git_sha || version.gitSha);
+    const builtAt = compactSessionText(version.built_at || version.builtAt);
+    if (gitSha || builtAt) {
+      out.version = {};
+      if (gitSha) out.version.gitSha = gitSha;
+      if (builtAt) out.version.builtAt = builtAt;
+    }
+  }
+  const park = raw.limit_park || raw.limitPark;
+  if (park && typeof park === 'object') {
+    const resetsAtEpoch = Number(park.resets_at_epoch ?? park.resetsAtEpoch);
+    if (Number.isFinite(resetsAtEpoch) && resetsAtEpoch > 0) {
+      out.limitPark = { resetsAtEpoch };
+    }
+  }
+  return out;
+}
+
+// The held_by claim behind a session id, from the merged window metadata
+// — the composer and the window-action gate share this one lookup.
+function sessionWindowHeldBy(sessionId) {
+  const sid = String(sessionId || '').trim();
+  if (!sid) return null;
+  const boot = (sessionMetadataById.get(sid) || {}).boot;
+  return boot && boot.heldBy ? boot.heldBy : null;
 }
 
 // Dir-local terminal facts served on the row (and lifted into the boot
@@ -63318,7 +63368,7 @@ function sessionWindowMetadataSignature(meta = {}) {
       ].join('|')
       : '',
     meta.boot
-      ? `${meta.boot.era}|${meta.boot.liveWrapper ? '1' : '0'}|${meta.boot.ghost ? '1' : '0'}|${meta.boot.sourceSessionId || ''}|${meta.boot.lineageTip === undefined ? '' : (meta.boot.lineageTip ? '1' : '0')}|${meta.boot.continuedAs ? `${meta.boot.continuedAs.sessionId || ''}:${meta.boot.continuedAs.backendSessionId || ''}:${meta.boot.continuedAs.live ? '1' : '0'}` : ''}|${sessionTerminalFactsSignature(meta.boot.terminal)}`
+      ? `${meta.boot.era}|${meta.boot.liveWrapper ? '1' : '0'}|${meta.boot.ghost ? '1' : '0'}|${meta.boot.sourceSessionId || ''}|${meta.boot.lineageTip === undefined ? '' : (meta.boot.lineageTip ? '1' : '0')}|${meta.boot.continuedAs ? `${meta.boot.continuedAs.sessionId || ''}:${meta.boot.continuedAs.backendSessionId || ''}:${meta.boot.continuedAs.live ? '1' : '0'}` : ''}|${sessionTerminalFactsSignature(meta.boot.terminal)}|${meta.boot.heldBy ? `${meta.boot.heldBy.port}:${meta.boot.heldBy.phase || ''}:${meta.boot.heldBy.sameBuild ? '1' : '0'}:${meta.boot.heldBy.limitPark ? meta.boot.heldBy.limitPark.resetsAtEpoch : ''}` : ''}`
       : '',
     sessionTerminalFactsSignature(meta.terminal),
     meta.updatedAt || '',
@@ -64617,6 +64667,38 @@ const VITALS_SYMBOLS = {
     },
     brief: (v) => (v.ghost ? 'Ghost — pre-boot, nothing behind it; safe to close' : ''),
   },
+  // Update-abstraction §3 (R4): a session still FINISHING on a draining
+  // sibling daemon. Chip copy is grade-1 (the product event — never a
+  // port, boot id, or drain word); the explainer pane is the mechanics
+  // reveal. The old-build indicator is the copy split itself: a
+  // different build (the daemon's R-A1 stamp compare) reads "previous
+  // version", the same build reads "previous daemon".
+  'held-by': {
+    label: 'Previous daemon',
+    priority: 26,
+    icon: 'clock',
+    chip: (v) => (v.sameBuild
+      ? '⏳ finishing on the previous daemon'
+      : '⏳ finishing on the previous version'),
+    explain: (v) => {
+      const lines = [
+        v.sameBuild
+          ? 'This session is still running on the previous daemon process — the same build as the one serving this dashboard.'
+          : 'This session is still running on the previous daemon, which runs a different (older) build than the one serving this dashboard.',
+        'It keeps working there until it finishes, then continues here — sessions are never moved mid-flight.',
+        'Messages you send route to it where it runs; other actions wait until it moves here.',
+      ];
+      lines.push(`Held by :${v.port}${v.bootId ? ` — boot ${v.bootId}` : ''}${v.phase ? ` — ${v.phase}` : ''}`);
+      if (v.gitSha || v.builtAt) {
+        lines.push(`Its build: ${[v.gitSha ? `commit ${v.gitSha}` : '', v.builtAt ? `built ${v.builtAt}` : ''].filter(Boolean).join(' · ')}`);
+      }
+      if (v.parkedUntil) {
+        lines.push(`Rate-limit parked until ${formatLimitResetWallClock(v.parkedUntil)}.`);
+      }
+      return lines;
+    },
+    brief: (v) => (v.sameBuild ? 'Finishing on the previous daemon' : 'Finishing on the previous version'),
+  },
 };
 
 // Fixed display order for chips and the glossary (semantic, not priority:
@@ -64625,7 +64707,7 @@ const VITALS_SYMBOLS = {
 // activity signal.
 const VITALS_SYMBOL_ORDER = [
   'health', 'activity', 'model', 'permissions', 'agenda-source',
-  'agenda-occurrence', 'agenda-attestation', 'sealed-inputs', 'boot', 'worktree', 'worktree-state', 'branch', 'dirty',
+  'agenda-occurrence', 'agenda-attestation', 'sealed-inputs', 'held-by', 'boot', 'worktree', 'worktree-state', 'branch', 'dirty',
   'divergence', 'parity', 'unpushed', 'primary-unpushed', 'cache-hit',
   'cache-ttl', 'limit',
 ];
@@ -64886,6 +64968,17 @@ function vitalsChipModels(vitals, meta, sessionId) {
       ghost: bootMeta.ghost === true,
     }, {
       severity: bootMeta.ghost ? 'warn' : '',
+    });
+  }
+  if (bootMeta?.heldBy) {
+    push('held-by', 'held-by', {
+      port: bootMeta.heldBy.port,
+      bootId: bootMeta.heldBy.bootId || '',
+      phase: bootMeta.heldBy.phase || '',
+      sameBuild: bootMeta.heldBy.sameBuild === true,
+      gitSha: bootMeta.heldBy.version?.gitSha || '',
+      builtAt: bootMeta.heldBy.version?.builtAt || '',
+      parkedUntil: bootMeta.heldBy.limitPark?.resetsAtEpoch || 0,
     });
   }
   const worktreeState = meta?.worktreeState && typeof meta.worktreeState === 'object'
@@ -72394,6 +72487,20 @@ function attachSessionWindowAction(sessionId) {
 function runSessionWindowAction(sessionId, op) {
   const sid = String(sessionId || '').trim();
   if (!sid) return;
+  // Update-abstraction §3 (R4) affordance gate: a held_by row's session
+  // is LIVE on a draining sibling daemon — process-shaped actions here
+  // (stop/restart/attach/delegate/thread ops) would target a wrapper
+  // this daemon doesn't hold. Meta-shaped actions stay (allowlist, so a
+  // new write op defaults gated). The composer routes to the sibling
+  // (54-session-lifecycle); everything else waits until the session
+  // moves here. The supervisor's own drop remains the backstop — this
+  // gate is display honesty, not authority.
+  const HELD_BY_SAFE_OPS = ['copy-session-id', 'rename-session', 'configure-launch'];
+  if (!HELD_BY_SAFE_OPS.includes(op)
+      && typeof sessionWindowHeldBy === 'function' && sessionWindowHeldBy(sid)) {
+    showControlToast('info', 'Still finishing on the previous version — it continues here when done. Messages route to it; other actions wait.');
+    return;
+  }
   if (op === 'copy-session-id') {
     copyTextToClipboard(sid)
       .then(() => showControlToast('success', `Copied session ID ${shortSessionId(sid)}`))
@@ -125392,6 +125499,97 @@ function dispatchPeerTaskText(peerTarget, text) {
   return true;
 }
 
+// ── The held_by composer lane (update-abstraction slice 3, owner
+//    amendment) ──
+//
+// A held_by row's session still RUNS on a draining co-homed sibling
+// daemon — monitors and subagents live in ITS process, and the drain
+// exists to protect them, so the session is never reattached here.
+// Instead a targeted message routes to the sibling daemon's OWN
+// gateway: its drain gate refuses only session-CREATING intents, and a
+// targeted start_task at an existing session is served by design. The
+// admission token comes from the same-home sibling token map
+// (/api/local-daemons/tokens, slice 1's substrate) — fetched FRESH per
+// send, so the doorway cache's staleness class (slice-1 N1) cannot
+// misroute a message; sends are rare and the map read is cheap. The
+// send rides the sibling's legacy /ws lane — the same ControlMsg intent
+// stream this dashboard uses on its own daemon; no new route, no new
+// authority, the loopback-admission trust class throughout.
+async function siblingDaemonStartTask(port, msg) {
+  const resp = await fetch('/api/local-daemons/tokens');
+  if (!resp.ok) throw new Error('the sibling token map is unavailable');
+  const map = await resp.json().catch(() => ({ instances: [] }));
+  const entry = (map.instances || []).find((inst) => String(inst.port) === String(port));
+  if (!entry || !entry.token) {
+    const gone = new Error('gone');
+    gone.siblingGone = true;
+    throw gone;
+  }
+  const scheme = entry.scheme === 'https' ? 'wss' : 'ws';
+  const url = `${scheme}://${location.hostname}:${port}/ws?token=${encodeURIComponent(entry.token)}`;
+  await new Promise((resolve, reject) => {
+    let settled = false;
+    let ws;
+    const fail = (why) => {
+      if (settled) return;
+      settled = true;
+      try { if (ws) ws.close(); } catch (_) { /* already closed */ }
+      reject(new Error(why));
+    };
+    try {
+      ws = new WebSocket(url);
+    } catch (err) {
+      fail(err && err.message ? err.message : 'could not open the connection');
+      return;
+    }
+    const timer = setTimeout(() => fail('no answer'), 8000);
+    ws.onopen = () => {
+      try {
+        ws.send(JSON.stringify(msg));
+      } catch (err) {
+        clearTimeout(timer);
+        fail(err && err.message ? err.message : 'send failed');
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      // Queued frames flush before the close handshake completes.
+      setTimeout(() => { try { ws.close(); } catch (_) { /* gone */ } }, 250);
+      resolve();
+    };
+    ws.onerror = () => { clearTimeout(timer); fail('unreachable'); };
+    ws.onclose = () => { clearTimeout(timer); fail('closed before the send'); };
+  });
+}
+
+// Composer routing for a held_by target: deliver the text as a targeted
+// start_task to the draining sibling that still runs the session.
+// Delivery bookkeeping (steer rows, pending follow-ups) stays OFF this
+// lane — those track via this daemon's event stream, which the
+// sibling's session never feeds; the reply lands in the session's
+// transcript on shared disk instead, and the toast says so. When the
+// sibling is gone the refusal is honest and named: the session isn't
+// reachable there anymore and moves here when the handover completes.
+function dispatchHeldBySessionFollowUp(sid, heldBy, text) {
+  const port = Number(heldBy && heldBy.port);
+  if (!Number.isFinite(port) || port <= 0) return false;
+  if (pendingAttachments.length > 0) {
+    showControlToast('error', 'Attachments cannot ride to the previous daemon — remove them or wait until the session continues here.');
+    return false;
+  }
+  siblingDaemonStartTask(port, { action: 'start_task', task: text, session_id: sid })
+    .then(() => {
+      showControlToast('info', `Sent to ${shortSessionId(sid)} on the previous daemon — the reply lands in its transcript here.`);
+    })
+    .catch((err) => {
+      const gone = !!(err && err.siblingGone);
+      showControlToast('error', gone
+        ? `The previous daemon (:${port}) is gone — this session can't take messages there anymore. It continues here when the handover completes.`
+        : `Could not reach the previous daemon (:${port})${err && err.message ? ` (${err.message})` : ''} — it may have just exited. The session continues here when the handover completes.`);
+    });
+  return true;
+}
+
 // One-tap re-run for background tasks that died with a backend restart
 // (the activity chip's died-tasks action): an OWNER action that asks the
 // session to re-run them — a normal follow-up through the existing
@@ -125432,6 +125630,15 @@ function dispatchTaskText(text, options = {}) {
   const attachmentReceipt = pendingAttachments.slice();
   const direct = document.getElementById('direct-mode-toggle')?.checked || false;
   const targetSessionId = resolvePromptTargetSessionId();
+  // A held_by target routes to the draining sibling that still runs it
+  // (the owner-amended promptable lane). Both composer paths funnel
+  // through here — the steer branch never fires for held rows (steer-
+  // active needs live local turn events, which a sibling-held session
+  // never emits on this daemon).
+  const heldByTarget = targetSessionId && typeof sessionWindowHeldBy === 'function'
+    ? sessionWindowHeldBy(targetSessionId)
+    : null;
+  if (heldByTarget) return dispatchHeldBySessionFollowUp(targetSessionId, heldByTarget, text);
   const msg = targetSessionId
     ? { action: 'start_task', task: text, session_id: targetSessionId }
     : { action: 'create_session', task: text };
@@ -135501,6 +135708,25 @@ function buildSessionCard(m, derived, ctx) {
     top.appendChild(badge);
   }
 
+  // Update-abstraction §3 (R4): a session still FINISHING on a draining
+  // sibling daemon wears its origin — grade-1 chip text (the old-build
+  // indicator is the copy split, per the daemon's R-A1 stamp compare);
+  // the title carries the mechanics.
+  const heldBy = s.boot && typeof s.boot === 'object'
+    && s.boot.held_by && typeof s.boot.held_by === 'object'
+    ? s.boot.held_by : null;
+  if (heldBy) {
+    const chip = document.createElement('span');
+    chip.className = 'ui-chip info sc-held-by-chip';
+    chip.textContent = heldBy.same_build === true
+      ? 'finishing on the previous daemon'
+      : 'finishing on the previous version';
+    chip.title = `Still running on the previous daemon (:${heldBy.port}`
+      + `${heldBy.boot_id ? `, boot ${heldBy.boot_id}` : ''}`
+      + `${heldBy.phase ? `, ${heldBy.phase}` : ''}) — messages route there; it continues here when done.`;
+    top.appendChild(chip);
+  }
+
   main.appendChild(top);
 
   // Task
@@ -135662,7 +135888,11 @@ function buildSessionCard(m, derived, ctx) {
     const actions = document.createElement('div');
     actions.className = 'sc-actions';
 
-    if (s.can_resume !== false) {
+    // A held_by row's session is LIVE on the draining sibling — resuming
+    // here would mint a competing wrapper for a session that never
+    // ended (the specimen-5 write-side blindness). It moves here on its
+    // own when done; the chip says so.
+    if (s.can_resume !== false && !heldBy) {
       const resumeBtn = document.createElement('button');
       resumeBtn.className = 'ui-btn sc-resume-btn';
       resumeBtn.textContent = 'Resume session';
@@ -135746,7 +135976,9 @@ function buildSessionCard(m, derived, ctx) {
         const hasMedia = (s.recordings || 0) > 0 || (s.frames_bytes || 0) > 0;
         if (hasMedia) addItem('Delete all media', 'media', (s.recording_bytes || 0) + (s.frames_bytes || 0));
         if ((s.turns_bytes || 0) > 0) addItem('Delete turn data', 'turns', s.turns_bytes);
-        if (!isCurrent) addItem(sessionDeleteLabel, 'session', sessionDeleteBytes, true);
+        // No whole-session delete while a draining sibling still runs it
+        // (same reasoning as the current-session guard: live work).
+        if (!isCurrent && !heldBy) addItem(sessionDeleteLabel, 'session', sessionDeleteBytes, true);
 
         if (menu.children.length > 0) {
           actions.appendChild(menu);

--- a/static/app/39-session-windows.js
+++ b/static/app/39-session-windows.js
@@ -618,7 +618,57 @@ function normalizeSessionBootEra(raw) {
   if (terminal) out.terminal = terminal;
   const continuedAs = normalizeSessionContinuedAs(raw.continued_as || raw.continuedAs);
   if (continuedAs) out.continuedAs = continuedAs;
+  // Update-abstraction §3 (R4): the drain-map claim rides BESIDE the era
+  // vocabulary — a session still FINISHING on a draining co-homed
+  // sibling daemon (never a new era value; the strictness above stands).
+  const heldBy = normalizeSessionHeldBy(raw.held_by || raw.heldBy);
+  if (heldBy) out.heldBy = heldBy;
   return out;
+}
+
+// boot.held_by: which draining sibling daemon still RUNS this session,
+// on what build (same_build = the daemon's R-A1 stamp compare against
+// itself), in what phase, parked until when. Sessions are never moved
+// mid-flight — this is display truth plus the composer's routing key.
+function normalizeSessionHeldBy(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const port = Number(raw.port);
+  if (!Number.isFinite(port) || port <= 0) return null;
+  const out = {
+    port,
+    sameBuild: raw.same_build === true || raw.sameBuild === true,
+  };
+  const bootId = compactSessionText(raw.boot_id || raw.bootId);
+  if (bootId) out.bootId = bootId;
+  const phase = compactSessionText(raw.phase);
+  if (phase) out.phase = phase;
+  const version = raw.version;
+  if (version && typeof version === 'object') {
+    const gitSha = compactSessionText(version.git_sha || version.gitSha);
+    const builtAt = compactSessionText(version.built_at || version.builtAt);
+    if (gitSha || builtAt) {
+      out.version = {};
+      if (gitSha) out.version.gitSha = gitSha;
+      if (builtAt) out.version.builtAt = builtAt;
+    }
+  }
+  const park = raw.limit_park || raw.limitPark;
+  if (park && typeof park === 'object') {
+    const resetsAtEpoch = Number(park.resets_at_epoch ?? park.resetsAtEpoch);
+    if (Number.isFinite(resetsAtEpoch) && resetsAtEpoch > 0) {
+      out.limitPark = { resetsAtEpoch };
+    }
+  }
+  return out;
+}
+
+// The held_by claim behind a session id, from the merged window metadata
+// — the composer and the window-action gate share this one lookup.
+function sessionWindowHeldBy(sessionId) {
+  const sid = String(sessionId || '').trim();
+  if (!sid) return null;
+  const boot = (sessionMetadataById.get(sid) || {}).boot;
+  return boot && boot.heldBy ? boot.heldBy : null;
 }
 
 // Dir-local terminal facts served on the row (and lifted into the boot
@@ -1065,7 +1115,7 @@ function sessionWindowMetadataSignature(meta = {}) {
       ].join('|')
       : '',
     meta.boot
-      ? `${meta.boot.era}|${meta.boot.liveWrapper ? '1' : '0'}|${meta.boot.ghost ? '1' : '0'}|${meta.boot.sourceSessionId || ''}|${meta.boot.lineageTip === undefined ? '' : (meta.boot.lineageTip ? '1' : '0')}|${meta.boot.continuedAs ? `${meta.boot.continuedAs.sessionId || ''}:${meta.boot.continuedAs.backendSessionId || ''}:${meta.boot.continuedAs.live ? '1' : '0'}` : ''}|${sessionTerminalFactsSignature(meta.boot.terminal)}`
+      ? `${meta.boot.era}|${meta.boot.liveWrapper ? '1' : '0'}|${meta.boot.ghost ? '1' : '0'}|${meta.boot.sourceSessionId || ''}|${meta.boot.lineageTip === undefined ? '' : (meta.boot.lineageTip ? '1' : '0')}|${meta.boot.continuedAs ? `${meta.boot.continuedAs.sessionId || ''}:${meta.boot.continuedAs.backendSessionId || ''}:${meta.boot.continuedAs.live ? '1' : '0'}` : ''}|${sessionTerminalFactsSignature(meta.boot.terminal)}|${meta.boot.heldBy ? `${meta.boot.heldBy.port}:${meta.boot.heldBy.phase || ''}:${meta.boot.heldBy.sameBuild ? '1' : '0'}:${meta.boot.heldBy.limitPark ? meta.boot.heldBy.limitPark.resetsAtEpoch : ''}` : ''}`
       : '',
     sessionTerminalFactsSignature(meta.terminal),
     meta.updatedAt || '',
@@ -2364,6 +2414,38 @@ const VITALS_SYMBOLS = {
     },
     brief: (v) => (v.ghost ? 'Ghost — pre-boot, nothing behind it; safe to close' : ''),
   },
+  // Update-abstraction §3 (R4): a session still FINISHING on a draining
+  // sibling daemon. Chip copy is grade-1 (the product event — never a
+  // port, boot id, or drain word); the explainer pane is the mechanics
+  // reveal. The old-build indicator is the copy split itself: a
+  // different build (the daemon's R-A1 stamp compare) reads "previous
+  // version", the same build reads "previous daemon".
+  'held-by': {
+    label: 'Previous daemon',
+    priority: 26,
+    icon: 'clock',
+    chip: (v) => (v.sameBuild
+      ? '⏳ finishing on the previous daemon'
+      : '⏳ finishing on the previous version'),
+    explain: (v) => {
+      const lines = [
+        v.sameBuild
+          ? 'This session is still running on the previous daemon process — the same build as the one serving this dashboard.'
+          : 'This session is still running on the previous daemon, which runs a different (older) build than the one serving this dashboard.',
+        'It keeps working there until it finishes, then continues here — sessions are never moved mid-flight.',
+        'Messages you send route to it where it runs; other actions wait until it moves here.',
+      ];
+      lines.push(`Held by :${v.port}${v.bootId ? ` — boot ${v.bootId}` : ''}${v.phase ? ` — ${v.phase}` : ''}`);
+      if (v.gitSha || v.builtAt) {
+        lines.push(`Its build: ${[v.gitSha ? `commit ${v.gitSha}` : '', v.builtAt ? `built ${v.builtAt}` : ''].filter(Boolean).join(' · ')}`);
+      }
+      if (v.parkedUntil) {
+        lines.push(`Rate-limit parked until ${formatLimitResetWallClock(v.parkedUntil)}.`);
+      }
+      return lines;
+    },
+    brief: (v) => (v.sameBuild ? 'Finishing on the previous daemon' : 'Finishing on the previous version'),
+  },
 };
 
 // Fixed display order for chips and the glossary (semantic, not priority:
@@ -2372,7 +2454,7 @@ const VITALS_SYMBOLS = {
 // activity signal.
 const VITALS_SYMBOL_ORDER = [
   'health', 'activity', 'model', 'permissions', 'agenda-source',
-  'agenda-occurrence', 'agenda-attestation', 'sealed-inputs', 'boot', 'worktree', 'worktree-state', 'branch', 'dirty',
+  'agenda-occurrence', 'agenda-attestation', 'sealed-inputs', 'held-by', 'boot', 'worktree', 'worktree-state', 'branch', 'dirty',
   'divergence', 'parity', 'unpushed', 'primary-unpushed', 'cache-hit',
   'cache-ttl', 'limit',
 ];
@@ -2633,6 +2715,17 @@ function vitalsChipModels(vitals, meta, sessionId) {
       ghost: bootMeta.ghost === true,
     }, {
       severity: bootMeta.ghost ? 'warn' : '',
+    });
+  }
+  if (bootMeta?.heldBy) {
+    push('held-by', 'held-by', {
+      port: bootMeta.heldBy.port,
+      bootId: bootMeta.heldBy.bootId || '',
+      phase: bootMeta.heldBy.phase || '',
+      sameBuild: bootMeta.heldBy.sameBuild === true,
+      gitSha: bootMeta.heldBy.version?.gitSha || '',
+      builtAt: bootMeta.heldBy.version?.builtAt || '',
+      parkedUntil: bootMeta.heldBy.limitPark?.resetsAtEpoch || 0,
     });
   }
   const worktreeState = meta?.worktreeState && typeof meta.worktreeState === 'object'

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -1,6 +1,20 @@
 function runSessionWindowAction(sessionId, op) {
   const sid = String(sessionId || '').trim();
   if (!sid) return;
+  // Update-abstraction §3 (R4) affordance gate: a held_by row's session
+  // is LIVE on a draining sibling daemon — process-shaped actions here
+  // (stop/restart/attach/delegate/thread ops) would target a wrapper
+  // this daemon doesn't hold. Meta-shaped actions stay (allowlist, so a
+  // new write op defaults gated). The composer routes to the sibling
+  // (54-session-lifecycle); everything else waits until the session
+  // moves here. The supervisor's own drop remains the backstop — this
+  // gate is display honesty, not authority.
+  const HELD_BY_SAFE_OPS = ['copy-session-id', 'rename-session', 'configure-launch'];
+  if (!HELD_BY_SAFE_OPS.includes(op)
+      && typeof sessionWindowHeldBy === 'function' && sessionWindowHeldBy(sid)) {
+    showControlToast('info', 'Still finishing on the previous version — it continues here when done. Messages route to it; other actions wait.');
+    return;
+  }
   if (op === 'copy-session-id') {
     copyTextToClipboard(sid)
       .then(() => showControlToast('success', `Copied session ID ${shortSessionId(sid)}`))

--- a/static/app/54-session-lifecycle.js
+++ b/static/app/54-session-lifecycle.js
@@ -794,6 +794,97 @@ function dispatchPeerTaskText(peerTarget, text) {
   return true;
 }
 
+// ── The held_by composer lane (update-abstraction slice 3, owner
+//    amendment) ──
+//
+// A held_by row's session still RUNS on a draining co-homed sibling
+// daemon — monitors and subagents live in ITS process, and the drain
+// exists to protect them, so the session is never reattached here.
+// Instead a targeted message routes to the sibling daemon's OWN
+// gateway: its drain gate refuses only session-CREATING intents, and a
+// targeted start_task at an existing session is served by design. The
+// admission token comes from the same-home sibling token map
+// (/api/local-daemons/tokens, slice 1's substrate) — fetched FRESH per
+// send, so the doorway cache's staleness class (slice-1 N1) cannot
+// misroute a message; sends are rare and the map read is cheap. The
+// send rides the sibling's legacy /ws lane — the same ControlMsg intent
+// stream this dashboard uses on its own daemon; no new route, no new
+// authority, the loopback-admission trust class throughout.
+async function siblingDaemonStartTask(port, msg) {
+  const resp = await fetch('/api/local-daemons/tokens');
+  if (!resp.ok) throw new Error('the sibling token map is unavailable');
+  const map = await resp.json().catch(() => ({ instances: [] }));
+  const entry = (map.instances || []).find((inst) => String(inst.port) === String(port));
+  if (!entry || !entry.token) {
+    const gone = new Error('gone');
+    gone.siblingGone = true;
+    throw gone;
+  }
+  const scheme = entry.scheme === 'https' ? 'wss' : 'ws';
+  const url = `${scheme}://${location.hostname}:${port}/ws?token=${encodeURIComponent(entry.token)}`;
+  await new Promise((resolve, reject) => {
+    let settled = false;
+    let ws;
+    const fail = (why) => {
+      if (settled) return;
+      settled = true;
+      try { if (ws) ws.close(); } catch (_) { /* already closed */ }
+      reject(new Error(why));
+    };
+    try {
+      ws = new WebSocket(url);
+    } catch (err) {
+      fail(err && err.message ? err.message : 'could not open the connection');
+      return;
+    }
+    const timer = setTimeout(() => fail('no answer'), 8000);
+    ws.onopen = () => {
+      try {
+        ws.send(JSON.stringify(msg));
+      } catch (err) {
+        clearTimeout(timer);
+        fail(err && err.message ? err.message : 'send failed');
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      // Queued frames flush before the close handshake completes.
+      setTimeout(() => { try { ws.close(); } catch (_) { /* gone */ } }, 250);
+      resolve();
+    };
+    ws.onerror = () => { clearTimeout(timer); fail('unreachable'); };
+    ws.onclose = () => { clearTimeout(timer); fail('closed before the send'); };
+  });
+}
+
+// Composer routing for a held_by target: deliver the text as a targeted
+// start_task to the draining sibling that still runs the session.
+// Delivery bookkeeping (steer rows, pending follow-ups) stays OFF this
+// lane — those track via this daemon's event stream, which the
+// sibling's session never feeds; the reply lands in the session's
+// transcript on shared disk instead, and the toast says so. When the
+// sibling is gone the refusal is honest and named: the session isn't
+// reachable there anymore and moves here when the handover completes.
+function dispatchHeldBySessionFollowUp(sid, heldBy, text) {
+  const port = Number(heldBy && heldBy.port);
+  if (!Number.isFinite(port) || port <= 0) return false;
+  if (pendingAttachments.length > 0) {
+    showControlToast('error', 'Attachments cannot ride to the previous daemon — remove them or wait until the session continues here.');
+    return false;
+  }
+  siblingDaemonStartTask(port, { action: 'start_task', task: text, session_id: sid })
+    .then(() => {
+      showControlToast('info', `Sent to ${shortSessionId(sid)} on the previous daemon — the reply lands in its transcript here.`);
+    })
+    .catch((err) => {
+      const gone = !!(err && err.siblingGone);
+      showControlToast('error', gone
+        ? `The previous daemon (:${port}) is gone — this session can't take messages there anymore. It continues here when the handover completes.`
+        : `Could not reach the previous daemon (:${port})${err && err.message ? ` (${err.message})` : ''} — it may have just exited. The session continues here when the handover completes.`);
+    });
+  return true;
+}
+
 // One-tap re-run for background tasks that died with a backend restart
 // (the activity chip's died-tasks action): an OWNER action that asks the
 // session to re-run them — a normal follow-up through the existing
@@ -834,6 +925,15 @@ function dispatchTaskText(text, options = {}) {
   const attachmentReceipt = pendingAttachments.slice();
   const direct = document.getElementById('direct-mode-toggle')?.checked || false;
   const targetSessionId = resolvePromptTargetSessionId();
+  // A held_by target routes to the draining sibling that still runs it
+  // (the owner-amended promptable lane). Both composer paths funnel
+  // through here — the steer branch never fires for held rows (steer-
+  // active needs live local turn events, which a sibling-held session
+  // never emits on this daemon).
+  const heldByTarget = targetSessionId && typeof sessionWindowHeldBy === 'function'
+    ? sessionWindowHeldBy(targetSessionId)
+    : null;
+  if (heldByTarget) return dispatchHeldBySessionFollowUp(targetSessionId, heldByTarget, text);
   const msg = targetSessionId
     ? { action: 'start_task', task: text, session_id: targetSessionId }
     : { action: 'create_session', task: text };

--- a/static/app/57a-sessions-list.js
+++ b/static/app/57a-sessions-list.js
@@ -762,6 +762,25 @@ function buildSessionCard(m, derived, ctx) {
     top.appendChild(badge);
   }
 
+  // Update-abstraction §3 (R4): a session still FINISHING on a draining
+  // sibling daemon wears its origin — grade-1 chip text (the old-build
+  // indicator is the copy split, per the daemon's R-A1 stamp compare);
+  // the title carries the mechanics.
+  const heldBy = s.boot && typeof s.boot === 'object'
+    && s.boot.held_by && typeof s.boot.held_by === 'object'
+    ? s.boot.held_by : null;
+  if (heldBy) {
+    const chip = document.createElement('span');
+    chip.className = 'ui-chip info sc-held-by-chip';
+    chip.textContent = heldBy.same_build === true
+      ? 'finishing on the previous daemon'
+      : 'finishing on the previous version';
+    chip.title = `Still running on the previous daemon (:${heldBy.port}`
+      + `${heldBy.boot_id ? `, boot ${heldBy.boot_id}` : ''}`
+      + `${heldBy.phase ? `, ${heldBy.phase}` : ''}) — messages route there; it continues here when done.`;
+    top.appendChild(chip);
+  }
+
   main.appendChild(top);
 
   // Task
@@ -923,7 +942,11 @@ function buildSessionCard(m, derived, ctx) {
     const actions = document.createElement('div');
     actions.className = 'sc-actions';
 
-    if (s.can_resume !== false) {
+    // A held_by row's session is LIVE on the draining sibling — resuming
+    // here would mint a competing wrapper for a session that never
+    // ended (the specimen-5 write-side blindness). It moves here on its
+    // own when done; the chip says so.
+    if (s.can_resume !== false && !heldBy) {
       const resumeBtn = document.createElement('button');
       resumeBtn.className = 'ui-btn sc-resume-btn';
       resumeBtn.textContent = 'Resume session';
@@ -1007,7 +1030,9 @@ function buildSessionCard(m, derived, ctx) {
         const hasMedia = (s.recordings || 0) > 0 || (s.frames_bytes || 0) > 0;
         if (hasMedia) addItem('Delete all media', 'media', (s.recording_bytes || 0) + (s.frames_bytes || 0));
         if ((s.turns_bytes || 0) > 0) addItem('Delete turn data', 'turns', s.turns_bytes);
-        if (!isCurrent) addItem(sessionDeleteLabel, 'session', sessionDeleteBytes, true);
+        // No whole-session delete while a draining sibling still runs it
+        // (same reasoning as the current-session guard: live work).
+        if (!isCurrent && !heldBy) addItem(sessionDeleteLabel, 'session', sessionDeleteBytes, true);
 
         if (menu.children.length > 0) {
           actions.appendChild(menu);

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -7274,12 +7274,15 @@ async fn held_by_rows_ride_the_successor_catalog_and_serve_the_composer_lane() {
     ))
     .await
     .expect("connect drainer websocket");
-    let started = ctl(&daemon_a, &["task", "start", "--task", "drain composer target"]).await;
+    let started = ctl(
+        &daemon_a,
+        &["task", "start", "--task", "drain composer target"],
+    )
+    .await;
     assert!(started.status.success(), "{}", text_of(&started));
     let session_started = next_matching_ws_event(&mut ws_a, RUN_TIMEOUT, |json| {
         json.get("event").and_then(serde_json::Value::as_str) == Some("session_started")
-            && json.get("task").and_then(serde_json::Value::as_str)
-                == Some("drain composer target")
+            && json.get("task").and_then(serde_json::Value::as_str) == Some("drain composer target")
     })
     .await
     .unwrap_or_else(|| panic!("held session never started:\n{}", daemon_a.log_tail()));
@@ -7344,15 +7347,19 @@ async fn held_by_rows_ride_the_successor_catalog_and_serve_the_composer_lane() {
         "the successor serving held_by on the drained row",
         RUN_TIMEOUT,
         || async {
-            let sessions =
-                http_get_json(&client_b, &format!("http://127.0.0.1:{port_b}/api/sessions"))
-                    .await?;
+            let sessions = http_get_json(
+                &client_b,
+                &format!("http://127.0.0.1:{port_b}/api/sessions"),
+            )
+            .await?;
             let row = held_row(&sessions, &sid)?;
             let held = row.pointer("/boot/held_by")?;
             (held["boot_id"] == holder_boot.as_str()
                 && held["port"] == port_a
                 && held["same_build"] == true
-                && held["phase"].as_str().is_some_and(|phase| !phase.is_empty())
+                && held["phase"]
+                    .as_str()
+                    .is_some_and(|phase| !phase.is_empty())
                 && row["boot"]["era"] == "current"
                 && row["boot"]["ghost"] == false)
                 .then_some(())
@@ -7474,9 +7481,11 @@ async fn held_by_rows_ride_the_successor_catalog_and_serve_the_composer_lane() {
         "held_by clearing after the drainer exits",
         RUN_TIMEOUT,
         || async {
-            let sessions =
-                http_get_json(&client_b, &format!("http://127.0.0.1:{port_b}/api/sessions"))
-                    .await?;
+            let sessions = http_get_json(
+                &client_b,
+                &format!("http://127.0.0.1:{port_b}/api/sessions"),
+            )
+            .await?;
             let row = held_row(&sessions, &sid)?;
             row.pointer("/boot/held_by").is_none().then_some(())
         },
@@ -7488,9 +7497,10 @@ async fn held_by_rows_ride_the_successor_catalog_and_serve_the_composer_lane() {
     // drainer's gateway no longer answers (its stale token file may
     // keep the map row — as-found-on-disk semantics — but the port
     // refusing is the truth the honest refusal names).
-    let refused =
-        tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{port_a}/ws?token={drainer_token}"))
-            .await;
+    let refused = tokio_tungstenite::connect_async(format!(
+        "ws://127.0.0.1:{port_a}/ws?token={drainer_token}"
+    ))
+    .await;
     assert!(
         refused.is_err(),
         "the exited drainer's gateway must not answer the composer lane"

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -7219,6 +7219,285 @@ async fn drainer_exits_at_last_session_end() {
     drop(daemon_b);
 }
 
+/// Update-abstraction slice 3 (§3 residual R4 + the owner-amended
+/// composer lane), acceptance (c)(e)(f): a drainer's parked-for-
+/// follow-ups session appears in the SUCCESSOR's catalog wearing
+/// `boot.held_by` — the drainer's boot/port, the R-A1 build compare
+/// (same binary here, so `same_build`), and the holdout phase — while
+/// the era/ghost vocabulary stays untouched beside it. The holder-side
+/// composer contract then runs end to end as the scripted tab: the
+/// sibling token map on the holder names the drainer's OWN admission
+/// token, a targeted `start_task` through the drainer's own gateway is
+/// SERVED during drain (the gate refuses only session-creating
+/// intents), the held session ANSWERS on the drainer (never
+/// reattached), and the reply reads back through the successor's
+/// served view of shared disk (the Q5 disk-tail posture). After the
+/// drainer's last session ends and it exits on its own, the join
+/// self-clears, and the sibling lane's refusal constituent is honest
+/// and named: the drainer's gateway stops answering — the class the
+/// SPA's refusal copy renders.
+#[tokio::test]
+async fn held_by_rows_ride_the_successor_catalog_and_serve_the_composer_lane() {
+    use futures_util::SinkExt;
+    let script = serde_json::json!({
+        "profiles": [
+            { "match": "drain composer target",
+              "steps": [
+                { "content": "turn one done — parked for follow-ups." },
+                { "content": "composer reply delivered through the drain." }
+              ] },
+            { "steps": [
+                { "content": "fallback profile (unexpected session)",
+                  "tool_calls": [{ "name": "signal_done",
+                                   "arguments": { "message": "unexpected session" } }] }
+            ]}
+        ]
+    });
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("http client");
+    let rig = TestRig::new();
+    let mut daemon_a = spawn_daemon_on_rig(&client, rig, &script, false).await;
+    let port_a = daemon_a.port;
+    let holder_boot = lease_sidecar(&daemon_a.rig).expect("holder sidecar")["boot_id"]
+        .as_str()
+        .expect("boot id")
+        .to_string();
+
+    // The held session: a managed session on A that completes round one
+    // and PARKS for follow-ups — alive, so it holds the coming drain.
+    let (mut ws_a, _) = tokio_tungstenite::connect_async(format!(
+        "ws://127.0.0.1:{}/ws?token={}",
+        port_a,
+        rig_loopback_token(&daemon_a.rig, port_a)
+    ))
+    .await
+    .expect("connect drainer websocket");
+    let started = ctl(&daemon_a, &["task", "start", "--task", "drain composer target"]).await;
+    assert!(started.status.success(), "{}", text_of(&started));
+    let session_started = next_matching_ws_event(&mut ws_a, RUN_TIMEOUT, |json| {
+        json.get("event").and_then(serde_json::Value::as_str) == Some("session_started")
+            && json.get("task").and_then(serde_json::Value::as_str)
+                == Some("drain composer target")
+    })
+    .await
+    .unwrap_or_else(|| panic!("held session never started:\n{}", daemon_a.log_tail()));
+    let sid = session_started
+        .get("session_id")
+        .and_then(serde_json::Value::as_str)
+        .expect("held session id")
+        .to_string();
+    next_matching_ws_event(&mut ws_a, RUN_TIMEOUT, |json| {
+        json.get("event").and_then(serde_json::Value::as_str) == Some("round_complete")
+            && json.get("session_id").and_then(serde_json::Value::as_str) == Some(sid.as_str())
+    })
+    .await
+    .unwrap_or_else(|| panic!("round one never completed:\n{}", daemon_a.log_tail()));
+
+    // The successor boots with --takeover: the lease transfers, A drains.
+    let daemon_b = spawn_co_daemon(
+        &client,
+        &daemon_a.rig,
+        "daemon-b.log",
+        &[("INTENDANT_LEASE_POLL_MS", "500")],
+        &["--takeover"],
+    )
+    .await;
+    let port_b = daemon_b.port;
+    poll_until(
+        "the lease transferring to the successor",
+        RUN_TIMEOUT,
+        || async {
+            let sidecar = lease_sidecar(&daemon_a.rig)?;
+            (sidecar["boot_id"] != holder_boot.as_str() && sidecar["state"] == "active")
+                .then_some(())
+        },
+        || format!("sidecar: {:?}", lease_sidecar(&daemon_a.rig)),
+    )
+    .await;
+
+    // (c) The successor's catalog carries the join while the drainer
+    // still runs the session: held_by names the drainer, the R-A1
+    // compare reads same-build (one binary in the rig), and the era
+    // vocabulary is untouched beside it.
+    let mut headers_b = reqwest::header::HeaderMap::new();
+    headers_b.insert(
+        "x-intendant-loopback-token",
+        rig_loopback_token(&daemon_a.rig, port_b)
+            .parse()
+            .expect("token header value"),
+    );
+    let client_b = reqwest::Client::builder()
+        .no_proxy()
+        .default_headers(headers_b)
+        .build()
+        .expect("successor-authed client");
+    let held_row = |sessions: &serde_json::Value, sid: &str| -> Option<serde_json::Value> {
+        sessions["sessions"]
+            .as_array()?
+            .iter()
+            .find(|row| row["session_id"] == sid)
+            .cloned()
+    };
+    poll_until(
+        "the successor serving held_by on the drained row",
+        RUN_TIMEOUT,
+        || async {
+            let sessions =
+                http_get_json(&client_b, &format!("http://127.0.0.1:{port_b}/api/sessions"))
+                    .await?;
+            let row = held_row(&sessions, &sid)?;
+            let held = row.pointer("/boot/held_by")?;
+            (held["boot_id"] == holder_boot.as_str()
+                && held["port"] == port_a
+                && held["same_build"] == true
+                && held["phase"].as_str().is_some_and(|phase| !phase.is_empty())
+                && row["boot"]["era"] == "current"
+                && row["boot"]["ghost"] == false)
+                .then_some(())
+        },
+        || {
+            format!(
+                "--- A tail ---\n{}\n--- B presence view ---\n{:?}",
+                daemon_a.log_tail(),
+                lease_sidecar(&daemon_a.rig)
+            )
+        },
+    )
+    .await;
+
+    // (e) The composer contract, as the scripted tab: the sibling token
+    // map on the HOLDER names the drainer's OWN admission token…
+    let tokens = http_get_json(
+        &client_b,
+        &format!("http://127.0.0.1:{port_b}/api/local-daemons/tokens"),
+    )
+    .await
+    .expect("sibling token map");
+    let drainer_token = tokens["instances"]
+        .as_array()
+        .expect("token map instances")
+        .iter()
+        .find(|inst| inst["port"] == port_a)
+        .and_then(|inst| inst["token"].as_str())
+        .expect("the drainer's instance rides the map")
+        .to_string();
+    assert_eq!(
+        drainer_token,
+        rig_loopback_token(&daemon_a.rig, port_a),
+        "the map serves the drainer's own admission token"
+    );
+
+    // …and a targeted start_task through the drainer's own gateway is
+    // SERVED mid-drain — the drain gate refuses only session-creating
+    // intents. The send is exactly the dashboard lane's frame.
+    let (mut ws_tab, _) = tokio_tungstenite::connect_async(format!(
+        "ws://127.0.0.1:{port_a}/ws?token={drainer_token}"
+    ))
+    .await
+    .expect("the map token admits the drainer's gateway");
+    ws_tab
+        .send(tokio_tungstenite::tungstenite::Message::Text(
+            serde_json::json!({
+                "action": "start_task",
+                "task": "composer follow-up through the drain",
+                "session_id": sid,
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .expect("send the composer follow-up");
+
+    // The held session answers ON the drainer (round two, no reattach)…
+    next_matching_ws_event(&mut ws_a, RUN_TIMEOUT, |json| {
+        json.get("event").and_then(serde_json::Value::as_str) == Some("round_complete")
+            && json.get("session_id").and_then(serde_json::Value::as_str) == Some(sid.as_str())
+    })
+    .await
+    .unwrap_or_else(|| {
+        panic!(
+            "the composer follow-up never ran on the drainer:\n{}",
+            daemon_a.log_tail()
+        )
+    });
+
+    // …and the reply reads back through the SUCCESSOR's served view of
+    // shared disk (Q5's disk-tail posture — the holder dashboard shows
+    // the answer without any cross-daemon proxying).
+    poll_until(
+        "the reply landing in the successor-served transcript",
+        RUN_TIMEOUT,
+        || async {
+            let detail = http_get_json(
+                &client_b,
+                &format!("http://127.0.0.1:{port_b}/api/session/{sid}"),
+            )
+            .await?;
+            serde_json::to_string(&detail)
+                .ok()?
+                .contains("composer reply delivered through the drain")
+                .then_some(())
+        },
+        || daemon_a.log_tail(),
+    )
+    .await;
+
+    // The held session ends through the drainer's own lane (stop is not
+    // session-creating), the drain completes, and the drainer exits on
+    // its own.
+    ws_tab
+        .send(tokio_tungstenite::tungstenite::Message::Text(
+            serde_json::json!({
+                "action": "stop_session",
+                "session_id": sid,
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .expect("send stop_session to the drainer");
+    let exited = tokio::time::timeout(Duration::from_secs(60), daemon_a.child.wait())
+        .await
+        .expect("the drained daemon must exit after its last session ends")
+        .expect("collect drainer exit status");
+    assert!(
+        exited.success(),
+        "graceful drain exit, not a crash: {exited:?}\n{}",
+        daemon_a.log_tail()
+    );
+
+    // The join self-clears: the drainer's boot lock freed, `live` reads
+    // false, and the successor's rows drop held_by.
+    poll_until(
+        "held_by clearing after the drainer exits",
+        RUN_TIMEOUT,
+        || async {
+            let sessions =
+                http_get_json(&client_b, &format!("http://127.0.0.1:{port_b}/api/sessions"))
+                    .await?;
+            let row = held_row(&sessions, &sid)?;
+            row.pointer("/boot/held_by").is_none().then_some(())
+        },
+        || daemon_a.log_tail(),
+    )
+    .await;
+
+    // (f) The refusal constituent the SPA's named copy renders: the
+    // drainer's gateway no longer answers (its stale token file may
+    // keep the map row — as-found-on-disk semantics — but the port
+    // refusing is the truth the honest refusal names).
+    let refused =
+        tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{port_a}/ws?token={drainer_token}"))
+            .await;
+    assert!(
+        refused.is_err(),
+        "the exited drainer's gateway must not answer the composer lane"
+    );
+    drop(daemon_b);
+}
+
 /// A mock script whose scheduled-session profile parks mid-turn on a
 /// long provider delay — the holdout that keeps each drainer in the
 /// three-daemon chain below alive (and draining) for the whole

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -7337,12 +7337,24 @@ async fn held_by_rows_ride_the_successor_catalog_and_serve_the_composer_lane() {
         .build()
         .expect("successor-authed client");
     let held_row = |sessions: &serde_json::Value, sid: &str| -> Option<serde_json::Value> {
+        // The plain GET serves a bare row array; the stream lane nests
+        // rows under "sessions" — accept both like the catalog's other
+        // e2e consumers.
         sessions["sessions"]
-            .as_array()?
+            .as_array()
+            .or_else(|| sessions.as_array())?
             .iter()
             .find(|row| row["session_id"] == sid)
             .cloned()
     };
+    let drainer_presence_path = daemon_a
+        .rig
+        .home
+        .path()
+        .join(".intendant")
+        .join("daemons")
+        .join(format!("{holder_boot}.json"));
+    let last_served_row = std::sync::Mutex::new(String::from("(row never served)"));
     poll_until(
         "the successor serving held_by on the drained row",
         RUN_TIMEOUT,
@@ -7353,6 +7365,7 @@ async fn held_by_rows_ride_the_successor_catalog_and_serve_the_composer_lane() {
             )
             .await?;
             let row = held_row(&sessions, &sid)?;
+            *last_served_row.lock().unwrap() = row.to_string();
             let held = row.pointer("/boot/held_by")?;
             (held["boot_id"] == holder_boot.as_str()
                 && held["port"] == port_a
@@ -7366,9 +7379,10 @@ async fn held_by_rows_ride_the_successor_catalog_and_serve_the_composer_lane() {
         },
         || {
             format!(
-                "--- A tail ---\n{}\n--- B presence view ---\n{:?}",
-                daemon_a.log_tail(),
-                lease_sidecar(&daemon_a.rig)
+                "--- drainer presence record ---\n{}\n--- last served row ---\n{}\n--- A tail ---\n{}",
+                std::fs::read_to_string(&drainer_presence_path).unwrap_or_default(),
+                last_served_row.lock().unwrap(),
+                daemon_a.log_tail()
             )
         },
     )


### PR DESCRIPTION
Update-abstraction **slice 3** (sealed intake §7 slice-3, Surface B ruling) **plus the owner amendment** ratified on commission card `01KZ0P7CBSE7Q4HFMS3RG7726F`: the unified session view, and the promptable-drainer-rows composer lane.

## What ships

**Server (`grid_envelope.rs`)** — `GridEnvelopeJoins::resolve` gains the co-homed drain map: presence records that are `draining` AND provably live (the same boot-lock probe `status_json` serves), own-pid excluded, holdout rows indexed by session id. A matching catalog row serves `boot.held_by = {boot_id, port, version {pkg, git_sha, built_at}, same_build, phase, limit_park}` **beside** the era vocabulary (`normalizeSessionBootEra` strictness untouched; old SPAs degrade to today's rendering). `same_build` is the daemon's own R-A1 **stamp-pair** compare (git_sha + built_at + pkg — a rebuild of the same commit reads different). Read-only throughout: the join never writes presence — **F1 untouched**. Cap semantics as ruled: rows beyond the 16-row presence mirror get no chip; `session_count` keeps the aggregate truth on the banner. The join self-clears when the drainer's boot lock frees.

**SPA** — grid windows wear a grade-1 `held-by` vitals chip; the **old-build indicator is the copy split**: `same_build:false` → “finishing on the previous version”, `same_build:true` → “finishing on the previous daemon” (honest about a restart that changed nothing). The vitals explainer pane is the mechanics reveal (`:port`, boot id, phase, build stamps, parked-until via the fragment's own locale formatters). Sessions-tab cards get the same chip at the `sc-current-badge` anchor — their first origin chip — with **Resume and whole-session Delete gated** while held (the specimen-5 write-side blindness). Window process-ops (stop/restart/attach/delegate/thread actions) gate at one allowlist chokepoint with grade-1 copy; meta ops (copy id, rename, configure) stay.

**The owner-amended composer lane** — a held row's composer target routes the message to the draining sibling's **own gateway**: fresh per-send read of the sibling token map (`/api/local-daemons/tokens` — slice 1's substrate; fresh read so the doorway cache's staleness class, slice-1 N1, cannot misroute), then a targeted `start_task` frame over the sibling's own `/ws` intent lane — **the drain gate refuses only session-creating intents; targeted `start_task` is served by design**. Sessions are **never reattached**: monitors and subagents live in the drainer's process; this lane talks TO the session where it lives. When the sibling is gone the refusal is honest and named (no token served / gateway unreachable → “The previous daemon (:port) … continues here when the handover completes”), both branches fragment-pinned.

> **Ruled-R4 extension, stated per the commission:** the sealed intake's Surface-B ruling accepted a *read-only* unified view. The composer lane deliberately **extends ruled R4 at owner direction** (owner amendment, 2026-08-02 ~20:30 ET chat, ratification riding the card's Approve) — the slice gate rules the composition; *lex posterior*, the owner's ratification outranks the earlier read-only bound.

> **V1 honesty boundary, restated as the ruling requires:** everything else here is SPA affordance gating with the supervisor's existing drop as backstop — display honesty, not authority. The R5 dispatch-honesty lane (void acks, id-dialect resolution, target-loss-on-send) stays its own commissioned lane on card `01KYXFKWBG`. Delivery bookkeeping (steer rows, pending follow-ups) deliberately stays OFF the sibling lane — those track via this daemon's event stream, which the sibling's session never feeds; the reply lands in the transcript from shared disk (the Q5 disk-tail posture) and the toast says so.

## Terminating acceptance

- **(a)** `held_by_matrix_joins_only_draining_live_siblings` — draining-live sibling holdout → `held_by` present with port/phase/limit_park (+ both `same_build` arms); running / dead-lock / exited / own-pid records → absent; a locally live wrapper outranks a stale claim; **era/ghost outputs byte-identical** with and without the join (strip `held_by` → deep-equal against an un-joined attach), plus every pre-existing matrix case unchanged.
- **(b)** `grid_envelope_wire_reaches_the_fragment` gains the `held_by` needles (wire name, normalize seam, chip id, `same_build`/`sameBuild`) across 39/41/54/57a.
- **(c)(e)(f)** `held_by_rows_ride_the_successor_catalog_and_serve_the_composer_lane` — successor's `/api/sessions` rows carry `held_by` while the drainer holds a parked session; the sibling token map names the drainer's own admission token; a targeted `start_task` through the drainer's gateway delivers mid-drain and the session **answers** (reply read back through the successor's served view of shared disk); after the drainer exits: join self-clears + the gateway refuses (the named class the SPA copy renders).
- **(g)** old-build indicator pinned by needle (“finishing on the previous version” / “finishing on the previous daemon” + `same_build`/`sameBuild` consumption).
- **(d)** battery GREEN with unmasked bare exits (02:24–02:32Z, head `0b4da914`): `cargo fmt --check` 0 · `cargo test -p intendant --bins` 0 (5860 passed) · the six lib crates 0 (14 suites) · `cargo test -p intendant --test e2e` 0 (**47/47**, the new leg included) · `cargo clippy --workspace -- -D warnings` 0.

## Judgment calls (disclosed for the gate)

1. **Sibling transport = the drainer's legacy `/ws` intent lane** (one frame, open→send→close). No HTTP row exists for session control messages by design (`api_session_control_msg` is the WS-twin residue), and adding one would be new surface — the WS lane is the same ControlMsg intent stream this dashboard already uses on its own daemon, under the same loopback-admission trust class. No new routes, no tunnel twins, no new authority.
2. **Fresh token-map read per send** instead of the doorway's per-page-load cache — implements slice-1 N1's invalidate-on-miss concern for this lane outright (sends are rare; the map read is cheap and `no-store`), and yields the sibling's scheme for ws/wss.
3. **Parked-until rendering** reuses the vitals fragment's own locale formatters (`formatLimitResetWallClock`) — the `handoverParkedUntil` approach without lifting across the slice-2-hot `ui2-handover.js` IIFE.
4. **Server-side `same_build`** rather than an SPA-side stamp compare — one truth, no mirrored compare rule, old SPAs unaffected.
5. **Sessions-card affordance translation:** this surface's write affordances are Resume and whole-session Delete; both gate while held (media/turn-data deletes stay). The grid window's composer/send/stop clause translates to the op-allowlist chokepoint in 41.

Scope note: `handover/mod.rs` is touched on exactly one line (the `lease::` re-export list gains `BuildVersion`) — disjoint from slice-2 #781's hunks by construction.

Sealed intake: `/Users/vm/update-abstraction-intake.md` sha256 `ed4215e8…` (binding ref verified at fire).
