### PR TITLE
dashboard: compact dismissible peer shared-view chips on Activity

### DIFF
--- a/static/app.html
+++ b/static/app.html
@@ -21789,16 +21789,92 @@ html.ui-v2 .shared-view-close {
 }
 html.ui-v2 .shared-view-close:hover { color: var(--text); }
 
-/* — federated peer shared-view banners (Activity log pane) — */
+/* — federated peer shared-view chips (Activity log pane): one slim,
+   locally-dismissible single-line row per announcing peer — */
 html.ui-v2 .peer-shared-view-banners {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 4px;
   margin: 8px 12px 0;
   flex-shrink: 0;
 }
 html.ui-v2 .peer-shared-view-banners.hidden { display: none; }
-html.ui-v2 .peer-shared-view-banner { padding: 6px 12px; }
+html.ui-v2 .peer-shared-view-chip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  padding: 3px 6px 3px 10px;
+  border: 1px solid rgba(var(--iris-rgb), .28);
+  border-radius: var(--r-pill);
+  background: linear-gradient(180deg, rgba(var(--iris-rgb), .09), rgba(var(--iris-rgb), .03)), var(--surface);
+  color: var(--text-2);
+  font-size: 11.5px;
+  line-height: 1.4;
+}
+html.ui-v2 .peer-chip-host {
+  flex-shrink: 0;
+  max-width: 16ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--mono);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--iris-2);
+}
+html.ui-v2 .peer-chip-what {
+  flex-shrink: 0;
+  white-space: nowrap;
+  font-weight: 600;
+}
+html.ui-v2 .peer-chip-reason {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-3);
+}
+html.ui-v2 .peer-chip-open,
+html.ui-v2 .peer-chip-dismiss {
+  flex-shrink: 0;
+  border-radius: var(--r-pill);
+  cursor: pointer;
+  font: inherit;
+  line-height: 1;
+  transition: background var(--t-fast), color var(--t-fast);
+}
+html.ui-v2 .peer-chip-open {
+  padding: 2px 10px;
+  border: 1px solid rgba(var(--iris-rgb), .4);
+  background: rgba(var(--iris-rgb), .12);
+  color: var(--iris-2);
+  font-size: 10.5px;
+  font-weight: 700;
+}
+html.ui-v2 .peer-chip-open:hover {
+  background: rgba(var(--iris-rgb), .22);
+  color: var(--text);
+}
+html.ui-v2 .peer-chip-dismiss {
+  padding: 2px 7px;
+  border: 0;
+  background: transparent;
+  color: var(--text-3);
+  font-size: 13px;
+}
+html.ui-v2 .peer-chip-dismiss:hover {
+  background: rgba(var(--rose-rgb), .12);
+  color: var(--text);
+}
+html.ui-v2 .peer-chip-open:focus-visible,
+html.ui-v2 .peer-chip-dismiss:focus-visible {
+  outline: 2px solid var(--iris);
+  outline-offset: 1px;
+}
 
 /* — empty state — */
 html.ui-v2 .log-empty-overlay { background: transparent; }
@@ -38899,7 +38975,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'd6bd088769679ecd';
+const INTENDANT_APP_BUILD = '3034fc0bbb3e9f92';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -88770,8 +88846,8 @@ function updateSharedViewBanner() {
 }
 
 // ── Peer shared-view banners ────────────────────────────────────────────
-// One banner per federated peer whose agent currently presents a shared
-// view ("look here"), derived from the daemons snapshot
+// One compact, dismissible chip per federated peer whose agent currently
+// presents a shared view ("look here"), derived from the daemons snapshot
 // (PeerSnapshot.shared_view — folded daemon-side, hide retires it to
 // null, every change arrives as a peer_state_changed push). Rendered
 // into #peer-shared-view-banners on the Activity log pane by
@@ -88779,6 +88855,16 @@ function updateSharedViewBanner() {
 // announcement also routes to Activity like the local shared-view
 // handler does.
 const peerSharedViewLastSig = new Map();
+// Browser-local dismissals: host_id → the dismissed announcement
+// signature. Purely this-tab UI state — the daemon-side fold and the
+// Live peer display row are untouched. A genuinely new announcement
+// (any signature change) re-surfaces the chip, and hide/disconnect
+// drops the host from all three maps, so a fresh show after a hide
+// re-surfaces it too.
+const peerSharedViewDismissed = new Map();
+// host_id → epoch ms when the current signature was first seen (feeds
+// the chip tooltip; the wire fold carries no timestamp).
+const peerSharedViewSeenAt = new Map();
 
 function peerSharedViewSignature(view) {
   return [view.action || '', view.display_id ?? '', view.display_target || '',
@@ -88794,13 +88880,24 @@ function renderPeerSharedViewBanners() {
   let newArrival = false;
   const liveHosts = new Set(rows.map(d => d.host_id));
   for (const host of Array.from(peerSharedViewLastSig.keys())) {
-    if (!liveHosts.has(host)) peerSharedViewLastSig.delete(host);
+    if (!liveHosts.has(host)) {
+      peerSharedViewLastSig.delete(host);
+      peerSharedViewDismissed.delete(host);
+      peerSharedViewSeenAt.delete(host);
+    }
   }
   const frag = document.createDocumentFragment();
+  let shown = 0;
   for (const d of rows) {
     const view = d.shared_view;
+    const sig = peerSharedViewSignature(view);
     if (!peerSharedViewLastSig.has(d.host_id)) newArrival = true;
-    peerSharedViewLastSig.set(d.host_id, peerSharedViewSignature(view));
+    if (peerSharedViewLastSig.get(d.host_id) !== sig) {
+      peerSharedViewSeenAt.set(d.host_id, Date.now());
+    }
+    peerSharedViewLastSig.set(d.host_id, sig);
+    if (peerSharedViewDismissed.get(d.host_id) === sig) continue;
+    peerSharedViewDismissed.delete(d.host_id);
     const name = (typeof compactSessionText === 'function'
       ? compactSessionText(d.label || d.host_id)
       : (d.label || d.host_id)) || d.host_id;
@@ -88813,20 +88910,27 @@ function renderPeerSharedViewBanners() {
         : action === 'capture' ? 'Captured'
           : 'Viewing';
     const detail = view.reason || view.note || '';
-    const banner = document.createElement('div');
-    banner.className = 'shared-view-banner peer-shared-view-banner';
-    banner.setAttribute('role', 'status');
-    const kicker = document.createElement('span');
-    kicker.className = 'shared-view-kicker';
-    kicker.textContent = `Peer · ${name}`;
-    const message = document.createElement('span');
-    message.className = 'shared-view-message';
-    message.textContent = detail ? `${verb} ${target}: ${detail}` : `${verb} ${target}`;
-    const actions = document.createElement('span');
-    actions.className = 'shared-view-actions';
+    const seenAt = peerSharedViewSeenAt.get(d.host_id);
+    const seen = seenAt
+      ? new Date(seenAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+      : '';
+    const chip = document.createElement('div');
+    chip.className = 'peer-shared-view-chip';
+    chip.setAttribute('role', 'status');
+    chip.title = `${name} — ${verb} ${target}${detail ? `: ${detail}` : ''}`
+      + (seen ? ` (since ${seen})` : '');
+    const host = document.createElement('span');
+    host.className = 'peer-chip-host';
+    host.textContent = name;
+    const what = document.createElement('span');
+    what.className = 'peer-chip-what';
+    what.textContent = `${verb} ${target}`;
+    const reason = document.createElement('span');
+    reason.className = 'peer-chip-reason';
+    reason.textContent = detail;
     const open = document.createElement('button');
     open.type = 'button';
-    open.className = 'shared-view-action';
+    open.className = 'peer-chip-open';
     open.textContent = 'Open';
     open.title = `Watch this display live on ${name}`;
     open.addEventListener('click', () => {
@@ -88835,14 +88939,22 @@ function renderPeerSharedViewBanners() {
         window.selectLivePeerDisplay(d.host_id, view.display_id ?? null);
       }
     });
-    actions.appendChild(open);
-    banner.appendChild(kicker);
-    banner.appendChild(message);
-    banner.appendChild(actions);
-    frag.appendChild(banner);
+    const dismiss = document.createElement('button');
+    dismiss.type = 'button';
+    dismiss.className = 'peer-chip-dismiss';
+    dismiss.textContent = '×';
+    dismiss.title = 'Dismiss (this browser only)';
+    dismiss.setAttribute('aria-label', `Dismiss shared-view notice from ${name}`);
+    dismiss.addEventListener('click', () => {
+      peerSharedViewDismissed.set(d.host_id, sig);
+      renderPeerSharedViewBanners();
+    });
+    chip.append(host, what, reason, open, dismiss);
+    frag.appendChild(chip);
+    shown += 1;
   }
   container.replaceChildren(frag);
-  container.classList.toggle('hidden', rows.length === 0);
+  container.classList.toggle('hidden', shown === 0);
   if (newArrival
       && activeTab !== 'displays'
       && (activeTab !== 'activity' || activeActivitySubtab !== 'log')) {

--- a/static/app.html
+++ b/static/app.html
@@ -38975,11 +38975,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-<<<<<<< HEAD
-const INTENDANT_APP_BUILD = '3034fc0bbb3e9f92';
-=======
-const INTENDANT_APP_BUILD = 'fd521e552dc222ae';
->>>>>>> origin/main
+const INTENDANT_APP_BUILD = 'f4bf134aaeab2491';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {

--- a/static/app/45-displays-webrtc.js
+++ b/static/app/45-displays-webrtc.js
@@ -2101,8 +2101,8 @@ function updateSharedViewBanner() {
 }
 
 // ── Peer shared-view banners ────────────────────────────────────────────
-// One banner per federated peer whose agent currently presents a shared
-// view ("look here"), derived from the daemons snapshot
+// One compact, dismissible chip per federated peer whose agent currently
+// presents a shared view ("look here"), derived from the daemons snapshot
 // (PeerSnapshot.shared_view — folded daemon-side, hide retires it to
 // null, every change arrives as a peer_state_changed push). Rendered
 // into #peer-shared-view-banners on the Activity log pane by
@@ -2110,6 +2110,16 @@ function updateSharedViewBanner() {
 // announcement also routes to Activity like the local shared-view
 // handler does.
 const peerSharedViewLastSig = new Map();
+// Browser-local dismissals: host_id → the dismissed announcement
+// signature. Purely this-tab UI state — the daemon-side fold and the
+// Live peer display row are untouched. A genuinely new announcement
+// (any signature change) re-surfaces the chip, and hide/disconnect
+// drops the host from all three maps, so a fresh show after a hide
+// re-surfaces it too.
+const peerSharedViewDismissed = new Map();
+// host_id → epoch ms when the current signature was first seen (feeds
+// the chip tooltip; the wire fold carries no timestamp).
+const peerSharedViewSeenAt = new Map();
 
 function peerSharedViewSignature(view) {
   return [view.action || '', view.display_id ?? '', view.display_target || '',
@@ -2125,13 +2135,24 @@ function renderPeerSharedViewBanners() {
   let newArrival = false;
   const liveHosts = new Set(rows.map(d => d.host_id));
   for (const host of Array.from(peerSharedViewLastSig.keys())) {
-    if (!liveHosts.has(host)) peerSharedViewLastSig.delete(host);
+    if (!liveHosts.has(host)) {
+      peerSharedViewLastSig.delete(host);
+      peerSharedViewDismissed.delete(host);
+      peerSharedViewSeenAt.delete(host);
+    }
   }
   const frag = document.createDocumentFragment();
+  let shown = 0;
   for (const d of rows) {
     const view = d.shared_view;
+    const sig = peerSharedViewSignature(view);
     if (!peerSharedViewLastSig.has(d.host_id)) newArrival = true;
-    peerSharedViewLastSig.set(d.host_id, peerSharedViewSignature(view));
+    if (peerSharedViewLastSig.get(d.host_id) !== sig) {
+      peerSharedViewSeenAt.set(d.host_id, Date.now());
+    }
+    peerSharedViewLastSig.set(d.host_id, sig);
+    if (peerSharedViewDismissed.get(d.host_id) === sig) continue;
+    peerSharedViewDismissed.delete(d.host_id);
     const name = (typeof compactSessionText === 'function'
       ? compactSessionText(d.label || d.host_id)
       : (d.label || d.host_id)) || d.host_id;
@@ -2144,20 +2165,27 @@ function renderPeerSharedViewBanners() {
         : action === 'capture' ? 'Captured'
           : 'Viewing';
     const detail = view.reason || view.note || '';
-    const banner = document.createElement('div');
-    banner.className = 'shared-view-banner peer-shared-view-banner';
-    banner.setAttribute('role', 'status');
-    const kicker = document.createElement('span');
-    kicker.className = 'shared-view-kicker';
-    kicker.textContent = `Peer · ${name}`;
-    const message = document.createElement('span');
-    message.className = 'shared-view-message';
-    message.textContent = detail ? `${verb} ${target}: ${detail}` : `${verb} ${target}`;
-    const actions = document.createElement('span');
-    actions.className = 'shared-view-actions';
+    const seenAt = peerSharedViewSeenAt.get(d.host_id);
+    const seen = seenAt
+      ? new Date(seenAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+      : '';
+    const chip = document.createElement('div');
+    chip.className = 'peer-shared-view-chip';
+    chip.setAttribute('role', 'status');
+    chip.title = `${name} — ${verb} ${target}${detail ? `: ${detail}` : ''}`
+      + (seen ? ` (since ${seen})` : '');
+    const host = document.createElement('span');
+    host.className = 'peer-chip-host';
+    host.textContent = name;
+    const what = document.createElement('span');
+    what.className = 'peer-chip-what';
+    what.textContent = `${verb} ${target}`;
+    const reason = document.createElement('span');
+    reason.className = 'peer-chip-reason';
+    reason.textContent = detail;
     const open = document.createElement('button');
     open.type = 'button';
-    open.className = 'shared-view-action';
+    open.className = 'peer-chip-open';
     open.textContent = 'Open';
     open.title = `Watch this display live on ${name}`;
     open.addEventListener('click', () => {
@@ -2166,14 +2194,22 @@ function renderPeerSharedViewBanners() {
         window.selectLivePeerDisplay(d.host_id, view.display_id ?? null);
       }
     });
-    actions.appendChild(open);
-    banner.appendChild(kicker);
-    banner.appendChild(message);
-    banner.appendChild(actions);
-    frag.appendChild(banner);
+    const dismiss = document.createElement('button');
+    dismiss.type = 'button';
+    dismiss.className = 'peer-chip-dismiss';
+    dismiss.textContent = '×';
+    dismiss.title = 'Dismiss (this browser only)';
+    dismiss.setAttribute('aria-label', `Dismiss shared-view notice from ${name}`);
+    dismiss.addEventListener('click', () => {
+      peerSharedViewDismissed.set(d.host_id, sig);
+      renderPeerSharedViewBanners();
+    });
+    chip.append(host, what, reason, open, dismiss);
+    frag.appendChild(chip);
+    shown += 1;
   }
   container.replaceChildren(frag);
-  container.classList.toggle('hidden', rows.length === 0);
+  container.classList.toggle('hidden', shown === 0);
   if (newArrival
       && activeTab !== 'displays'
       && (activeTab !== 'activity' || activeActivitySubtab !== 'log')) {

--- a/static/app/ui2-activity.css
+++ b/static/app/ui2-activity.css
@@ -1410,16 +1410,92 @@ html.ui-v2 .shared-view-close {
 }
 html.ui-v2 .shared-view-close:hover { color: var(--text); }
 
-/* — federated peer shared-view banners (Activity log pane) — */
+/* — federated peer shared-view chips (Activity log pane): one slim,
+   locally-dismissible single-line row per announcing peer — */
 html.ui-v2 .peer-shared-view-banners {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 4px;
   margin: 8px 12px 0;
   flex-shrink: 0;
 }
 html.ui-v2 .peer-shared-view-banners.hidden { display: none; }
-html.ui-v2 .peer-shared-view-banner { padding: 6px 12px; }
+html.ui-v2 .peer-shared-view-chip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  padding: 3px 6px 3px 10px;
+  border: 1px solid rgba(var(--iris-rgb), .28);
+  border-radius: var(--r-pill);
+  background: linear-gradient(180deg, rgba(var(--iris-rgb), .09), rgba(var(--iris-rgb), .03)), var(--surface);
+  color: var(--text-2);
+  font-size: 11.5px;
+  line-height: 1.4;
+}
+html.ui-v2 .peer-chip-host {
+  flex-shrink: 0;
+  max-width: 16ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--mono);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--iris-2);
+}
+html.ui-v2 .peer-chip-what {
+  flex-shrink: 0;
+  white-space: nowrap;
+  font-weight: 600;
+}
+html.ui-v2 .peer-chip-reason {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-3);
+}
+html.ui-v2 .peer-chip-open,
+html.ui-v2 .peer-chip-dismiss {
+  flex-shrink: 0;
+  border-radius: var(--r-pill);
+  cursor: pointer;
+  font: inherit;
+  line-height: 1;
+  transition: background var(--t-fast), color var(--t-fast);
+}
+html.ui-v2 .peer-chip-open {
+  padding: 2px 10px;
+  border: 1px solid rgba(var(--iris-rgb), .4);
+  background: rgba(var(--iris-rgb), .12);
+  color: var(--iris-2);
+  font-size: 10.5px;
+  font-weight: 700;
+}
+html.ui-v2 .peer-chip-open:hover {
+  background: rgba(var(--iris-rgb), .22);
+  color: var(--text);
+}
+html.ui-v2 .peer-chip-dismiss {
+  padding: 2px 7px;
+  border: 0;
+  background: transparent;
+  color: var(--text-3);
+  font-size: 13px;
+}
+html.ui-v2 .peer-chip-dismiss:hover {
+  background: rgba(var(--rose-rgb), .12);
+  color: var(--text);
+}
+html.ui-v2 .peer-chip-open:focus-visible,
+html.ui-v2 .peer-chip-dismiss:focus-visible {
+  outline: 2px solid var(--iris);
+  outline-offset: 1px;
+}
 
 /* — empty state — */
 html.ui-v2 .log-empty-overlay { background: transparent; }


### PR DESCRIPTION
The Activity pane's federated peer shared-view banners were oversized, info-poor, and undismissable — several announcing peers could dominate the tab. This replaces each banner with a slim single-line chip: peer label, action + display id, reason truncated with the full text and first-seen time in the tooltip, an Open button (unchanged routing to the Live peer display pane), and a per-chip dismiss.

- Dismiss is browser-local UI state only: it never touches the daemon-side fold or the Live peer display row. A genuinely new announcement (any signature change) re-surfaces the chip, and hide/disconnect clears the local state so a fresh show re-surfaces it too.
- The fold-driven lifecycle is otherwise unchanged (banner set still derives from PeerSnapshot.shared_view; first announcement still routes to Activity).
- The chip CSS family is self-contained in ui2-activity.css under html.ui-v2; the generic shared-view-banner family remains untouched for the local banners. #peer-shared-view-banners keeps its id.
- Buttons keep a11y basics: real buttons, aria-label on dismiss, focus-visible outlines.

static/app.html regenerated via app-html-assembler from the two fragment edits.