### PR TITLE
display: make the startup fps-flake class self-diagnosing in the metrics log

### DIFF
--- a/crates/intendant-display/src/aggregator.rs
+++ b/crates/intendant-display/src/aggregator.rs
@@ -825,6 +825,53 @@ pub fn compose_effective_wanted(
     effective
 }
 
+/// Render one policy vote set for the decision log line: members are
+/// listed in `current_rids` (spec) order for deterministic output, and
+/// members outside the current always-on bank (e.g. the federated RID
+/// in a demand set) are summarized as an off-bank count rather than
+/// silently dropped — the line must never under-report demand.
+fn fmt_rid_set(set: &HashSet<SimulcastRid>, current_rids: &[SimulcastRid]) -> String {
+    let mut parts: Vec<String> = current_rids
+        .iter()
+        .filter(|rid| set.contains(*rid))
+        .map(|rid| rid.as_str().to_string())
+        .collect();
+    let off_bank = set.iter().filter(|rid| !current_rids.contains(rid)).count();
+    if off_bank > 0 {
+        parts.push(format!("+{off_bank} off-bank"));
+    }
+    format!("{{{}}}", parts.join(","))
+}
+
+/// One-line explanation of a layer-policy tick that produced actions:
+/// the composed effective wanted set plus every input that shaped it
+/// (presence, the TWCC and RR policy votes, single-RID pins, and the
+/// demand bound). Logged by the coordinator alongside its
+/// `PauseLayer` / `ResumeLayer` emissions so the log answers *why* a
+/// layer paused, not just that it did — the startup-flake class of
+/// report ("stream degraded after boot") needs the vote vector to rule
+/// layer policy in or out without a reproduction.
+#[allow(clippy::too_many_arguments)] // mirror of the coordinator's compose inputs, not a bundle
+pub fn describe_layer_policy_decision(
+    presence_active: bool,
+    twcc_union: &HashSet<SimulcastRid>,
+    rr_union: &HashSet<SimulcastRid>,
+    pinned_layers: &HashSet<SimulcastRid>,
+    demanded_layers: &HashSet<SimulcastRid>,
+    effective: &HashSet<SimulcastRid>,
+    current_rids: &[SimulcastRid],
+) -> String {
+    format!(
+        "effective={} presence={} twcc={} rr={} pinned={} demanded={}",
+        fmt_rid_set(effective, current_rids),
+        if presence_active { "up" } else { "idle" },
+        fmt_rid_set(twcc_union, current_rids),
+        fmt_rid_set(rr_union, current_rids),
+        fmt_rid_set(pinned_layers, current_rids),
+        fmt_rid_set(demanded_layers, current_rids),
+    )
+}
+
 /// Probe for a simulcast layer's paused state (`None` = the pool does
 /// not know the layer). Shared by the coordinator signature and its
 /// callers, which would otherwise each spell the boxed-closure type.
@@ -1054,6 +1101,7 @@ pub fn reconcile_on_demand_standby(hooks: &OnDemandStandbyHooks, peers: &[PeerDe
 /// Returned `JoinHandle` exits cleanly on `shutdown.cancelled()`.
 #[allow(clippy::too_many_arguments)] // injected-dependency seam: each param is a distinct policy input, not a bundle
 pub fn spawn_layer_policy_coordinator(
+    display_id: u32,
     peers: Arc<RwLock<HashMap<PeerId, Arc<WebRtcPeer>>>>,
     get_current_rids: Box<dyn Fn() -> Vec<SimulcastRid> + Send + Sync>,
     is_layer_paused: LayerPauseProbe,
@@ -1339,6 +1387,24 @@ pub fn spawn_layer_policy_coordinator(
                 .collect();
 
             let actions = diff_wanted_aggregate(&actual_active, &effective_wanted, &current_rids);
+            if !actions.is_empty() {
+                // Explain WHY alongside the PauseLayer/ResumeLayer lines
+                // the actions are about to emit. Logged only on ticks
+                // that change pool state, so steady state stays silent.
+                eprintln!(
+                    "[layer-policy] display {} decision: {}",
+                    display_id,
+                    describe_layer_policy_decision(
+                        presence_active,
+                        &twcc_union,
+                        &rr_union,
+                        &pinned_layers,
+                        &demanded_layers,
+                        &effective_wanted,
+                        &current_rids,
+                    ),
+                );
+            }
             for action in actions {
                 on_action(action);
             }
@@ -1349,6 +1415,46 @@ pub fn spawn_layer_policy_coordinator(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ----- Decision-line rendering ------------------------------------------
+
+    /// The `[layer-policy] decision:` explanation renders every vote set
+    /// in spec (`current_rids`) order — deterministic across runs — and
+    /// summarizes members outside the always-on bank (the federated RID
+    /// in a demand set) as an off-bank count instead of dropping them.
+    #[test]
+    fn describe_layer_policy_decision_renders_deterministically() {
+        let current = vec![
+            SimulcastRid::full(),
+            SimulcastRid::half(),
+            SimulcastRid::quarter(),
+        ];
+        let all: HashSet<SimulcastRid> = current.iter().cloned().collect();
+        let mut demanded: HashSet<SimulcastRid> = HashSet::new();
+        demanded.insert(SimulcastRid::full());
+        demanded.insert(SimulcastRid::federated());
+        let mut effective: HashSet<SimulcastRid> = HashSet::new();
+        effective.insert(SimulcastRid::full());
+        let pinned: HashSet<SimulcastRid> = [SimulcastRid::full()].into_iter().collect();
+
+        let line = describe_layer_policy_decision(
+            true, &all, &all, &pinned, &demanded, &effective, &current,
+        );
+        assert_eq!(
+            line,
+            "effective={f} presence=up twcc={f,h,q} rr={f,h,q} \
+             pinned={f} demanded={f,+1 off-bank}"
+        );
+
+        // Zero-peer idle pause: empty effective, presence down.
+        let empty: HashSet<SimulcastRid> = HashSet::new();
+        let line =
+            describe_layer_policy_decision(false, &all, &all, &empty, &empty, &empty, &current);
+        assert_eq!(
+            line,
+            "effective={} presence=idle twcc={f,h,q} rr={f,h,q} pinned={} demanded={}"
+        );
+    }
 
     // ----- Pure transition tests --------------------------------------------
 
@@ -3011,6 +3117,7 @@ mod tests {
         let kick = Arc::new(Notify::new());
         let shutdown = CancellationToken::new();
         let handle = spawn_layer_policy_coordinator(
+            0,
             Arc::clone(&peers),
             get_current_rids,
             is_layer_paused,
@@ -3117,6 +3224,7 @@ mod tests {
 
         let shutdown = CancellationToken::new();
         let handle = spawn_layer_policy_coordinator(
+            0,
             Arc::clone(&peers),
             get_current_rids,
             is_layer_paused,
@@ -3223,6 +3331,7 @@ mod tests {
 
         let shutdown = CancellationToken::new();
         let handle = spawn_layer_policy_coordinator(
+            0,
             Arc::clone(&peers),
             get_current_rids,
             is_layer_paused,

--- a/crates/intendant-display/src/encode/pool/mod.rs
+++ b/crates/intendant-display/src/encode/pool/mod.rs
@@ -1187,6 +1187,24 @@ impl EncoderPool {
             .collect()
     }
 
+    /// RIDs of always-on [`BASELINE_CODEC`] layers currently paused, in
+    /// spec order. Observability accessor for the session metrics
+    /// snapshot (`paused_layers` in `DisplayMetricsSnapshot`): the
+    /// paused set at a point in time is the layer-policy fact a
+    /// degraded-stream log needs alongside fps rates. Same
+    /// return-a-`Vec` rationale as [`Self::always_on_ids`] — callers
+    /// never hold the `always_on` read lock.
+    pub fn paused_baseline_rids(&self) -> Vec<String> {
+        self.inner
+            .always_on
+            .read()
+            .unwrap()
+            .iter()
+            .filter(|h| h.id.codec == BASELINE_CODEC && h.paused.load(Ordering::SeqCst))
+            .map(|h| h.id.rid.to_string())
+            .collect()
+    }
+
     /// Snapshot the on-demand encoder IDs that currently have at least
     /// one subscriber (`refcount > 0`) — the same active-encoder
     /// universe [`Self::request_keyframe_all`] targets on the on-demand
@@ -3598,6 +3616,37 @@ mod tests {
             pool.has_active_consumer(),
             "a single resumed layer re-establishes demand"
         );
+    }
+
+    /// `paused_baseline_rids` — the metrics snapshot's paused-layer
+    /// probe: names exactly the paused always-on [`BASELINE_CODEC`]
+    /// layers, in spec order, tracking pause/resume live. (On Windows,
+    /// where the baseline codec is H.264, a VP8 pool contributes
+    /// nothing — the accessor reports only baseline-bank state.)
+    #[tokio::test]
+    async fn pool_paused_baseline_rids_tracks_pause_state() {
+        let pool = EncoderPool::new(64, 64, 30, |w, h| LayerSpec::vp8_simulcast(w, h, 30), None);
+        assert!(
+            pool.paused_baseline_rids().is_empty(),
+            "nothing paused at construction"
+        );
+
+        pool.pause_layer(CodecKind::Vp8, SimulcastRid::quarter());
+        pool.pause_layer(CodecKind::Vp8, SimulcastRid::half());
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            // Spec order (f, h, q), not pause order.
+            assert_eq!(pool.paused_baseline_rids(), vec!["h", "q"]);
+            pool.resume_layer(CodecKind::Vp8, SimulcastRid::half());
+            assert_eq!(pool.paused_baseline_rids(), vec!["q"]);
+        }
+        #[cfg(target_os = "windows")]
+        {
+            // VP8 is not the Windows baseline codec: paused VP8 layers
+            // are not baseline-bank state.
+            assert!(pool.paused_baseline_rids().is_empty());
+        }
     }
 
     /// Tile-standby contract on the on-demand side: a paused on-demand

--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -659,8 +659,13 @@ pub type PeerId = u64;
 pub enum DisplayEvent {
     /// The capture backend stopped without a clean shutdown.
     CaptureLost { display_id: u32, reason: String },
-    /// Periodic metrics snapshot from `spawn_metrics_logger`.
-    Metrics { snapshot: DisplayMetricsSnapshot },
+    /// Periodic metrics snapshot from `spawn_metrics_logger`. Boxed:
+    /// the snapshot dwarfs the other variants (clippy
+    /// `large_enum_variant`), and every other event would otherwise
+    /// pay its footprint on the channel.
+    Metrics {
+        snapshot: Box<DisplayMetricsSnapshot>,
+    },
     /// The source changed resolution; encoders were recreated.
     Resize {
         display_id: u32,
@@ -2605,7 +2610,9 @@ impl DisplaySession {
                             last_state = Some(state);
                         }
                         if let Some(ref events) = events {
-                            let _ = events.send(DisplayEvent::Metrics { snapshot: m });
+                            let _ = events.send(DisplayEvent::Metrics {
+                                snapshot: Box::new(m),
+                            });
                         }
                     }
                 }

--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -678,6 +678,28 @@ pub struct DisplayMetricsCounters {
     pub capture_frames: AtomicU64,
     /// Frames dropped at the broadcast send (no subscribers or lagging).
     pub capture_drops: AtomicU64,
+    /// Of `capture_frames`, the deliveries the backend explicitly marked
+    /// as "content unchanged" (empty dirty-rect set — ScreenCaptureKit's
+    /// `Idle` status frames are the canonical source). Splitting these
+    /// out is what lets a low `capture_fps` window be classified from
+    /// the log: a mostly-idle desktop shows low capture with the
+    /// remainder here, while "source starved/throttled" shows low
+    /// capture with zero idle deliveries. Backends that never annotate
+    /// dirty rects contribute nothing (their frames all count as
+    /// content).
+    pub capture_idle_frames: AtomicU64,
+    /// Frames the platform capture producer built but could not enqueue
+    /// because the bounded backend→bridge channel was full (the
+    /// `try_send` drop-on-full contract in [`DisplayBackend::start_capture`]).
+    /// This is the *before-the-bridge* drop point that `capture_frames`
+    /// (counted at the bridge) never sees — without it, "the source
+    /// delivered at full rate but the consumer was starved" is
+    /// indistinguishable from "the source delivered slowly".
+    ///
+    /// `Arc<AtomicU64>` so [`DisplaySession::start`] can hand the same
+    /// counter to the backend via
+    /// [`DisplayBackend::install_capture_frame_drop_counter`].
+    pub capture_backend_drops: Arc<AtomicU64>,
 
     /// Total frames successfully VP8-encoded.
     pub encode_frames: AtomicU64,
@@ -709,6 +731,21 @@ pub struct DisplayMetricsCounters {
     /// idle-cost gate is observable (and unit-testable) without exposing
     /// bridge internals.
     pub pool_feed_conversions: AtomicU64,
+    /// Pool-feed pushes forwarded because the I420 buffer changed since
+    /// the last send (fresh capture content). See
+    /// [`pool_feed_push_reason`] for the gate taxonomy.
+    pub pool_feed_push_changed: AtomicU64,
+    /// Pool-feed pushes forwarded by the 1 Hz idle heartbeat — a
+    /// **re-push of the previous buffer with its original arrival
+    /// stamp**, so each one re-encodes stale content and drags
+    /// `encode_freshness_avg_ms` up by design. This counter is what
+    /// makes "encode_fps exceeds capture_fps and freshness looks awful"
+    /// self-explaining on an idle desktop instead of reading like an
+    /// encoder stall.
+    pub pool_feed_push_heartbeat: AtomicU64,
+    /// Pool-feed pushes forwarded by an open peer-join burst window
+    /// (encoder clocked through to a keyframe after attach).
+    pub pool_feed_push_burst: AtomicU64,
 
     /// Tile-stream damage samples processed in the current metrics window.
     pub tile_damage_samples: AtomicU64,
@@ -753,12 +790,17 @@ impl DisplayMetricsCounters {
         Self {
             capture_frames: AtomicU64::new(0),
             capture_drops: AtomicU64::new(0),
+            capture_idle_frames: AtomicU64::new(0),
+            capture_backend_drops: Arc::new(AtomicU64::new(0)),
             encode_frames: AtomicU64::new(0),
             encode_drops: AtomicU64::new(0),
             encode_freshness_us_sum: AtomicU64::new(0),
             peer_drops: Arc::new(AtomicU64::new(0)),
             peer_count: AtomicU64::new(0),
             pool_feed_conversions: AtomicU64::new(0),
+            pool_feed_push_changed: AtomicU64::new(0),
+            pool_feed_push_heartbeat: AtomicU64::new(0),
+            pool_feed_push_burst: AtomicU64::new(0),
             tile_damage_samples: AtomicU64::new(0),
             tile_dirty_rects: AtomicU64::new(0),
             tile_dirty_tiles: AtomicU64::new(0),
@@ -809,6 +851,100 @@ impl DisplayMetricsCounters {
     }
 }
 
+/// How the capture bridge classifies one delivered [`Frame`] for the
+/// idle/content split (see
+/// [`DisplayMetricsCounters::capture_idle_frames`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CapturedFrameKind {
+    /// The backend reported content change for this frame (non-empty
+    /// dirty rects), or did not annotate damage at all (`None` — the
+    /// conservative default: unknown damage counts as content).
+    Content,
+    /// The backend explicitly reported "nothing changed" (`Some` with an
+    /// empty rect set — ScreenCaptureKit's `Idle` status verdict).
+    Idle,
+}
+
+/// Classify a captured frame's damage annotation for the metrics split.
+pub fn captured_frame_kind(dirty_rects: Option<&[capture::damage::Rect]>) -> CapturedFrameKind {
+    match dirty_rects {
+        Some([]) => CapturedFrameKind::Idle,
+        _ => CapturedFrameKind::Content,
+    }
+}
+
+/// Which gate let one pool-feed forward through (see the bridge's
+/// changed / heartbeat / burst decision in
+/// `DisplaySession::spawn_pool_feed_bridge`). Precedence mirrors the
+/// semantic weight of the gates: fresh content > idle heartbeat > join
+/// burst — a push that qualifies under several gates is attributed to
+/// the strongest one so the counters partition the pushes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PoolFeedPushReason {
+    /// A fresher I420 buffer than last sent (real captured change).
+    Changed,
+    /// The 1 Hz idle heartbeat re-pushing the previous buffer (stale
+    /// re-encode by design; carries the original arrival stamp).
+    Heartbeat,
+    /// An open peer-join burst window clocking the encoder to a
+    /// keyframe.
+    Burst,
+}
+
+/// The pool-feed bridge's forward gate as a pure decision: `None` =
+/// nothing to forward this tick.
+pub fn pool_feed_push_reason(
+    changed: bool,
+    heartbeat_due: bool,
+    in_burst: bool,
+) -> Option<PoolFeedPushReason> {
+    if changed {
+        Some(PoolFeedPushReason::Changed)
+    } else if heartbeat_due {
+        Some(PoolFeedPushReason::Heartbeat)
+    } else if in_burst {
+        Some(PoolFeedPushReason::Burst)
+    } else {
+        None
+    }
+}
+
+/// Coarse capture-rate bucket for the pipeline-state fingerprint: the
+/// startup-flake triage question is "was the source delivering nothing,
+/// a trickle, or full rate", not the exact fps (which the metrics line
+/// already carries). Boundaries: < 0.5 fps = `none`, < 10 fps =
+/// `trickle`, otherwise `full`.
+pub fn capture_rate_bucket(fps: f64) -> &'static str {
+    if fps < 0.5 {
+        "none"
+    } else if fps < 10.0 {
+        "trickle"
+    } else {
+        "full"
+    }
+}
+
+/// The per-display pipeline-state fingerprint logged by
+/// [`DisplaySession::spawn_metrics_logger`] whenever it changes between
+/// metrics ticks (`[display/pipeline-state]`). Deliberately built from
+/// *classifications*, not raw counts, so ordinary frame-count jitter
+/// never flaps it: capture bucket, the paused always-on layers, whether
+/// the pool has an active consumer, and whether the backend reported
+/// pre-bridge drops in the window.
+pub fn pipeline_state_fingerprint(snapshot: &DisplayMetricsSnapshot) -> String {
+    format!(
+        "capture={} paused=[{}] consumer={} backend_drops={}",
+        capture_rate_bucket(snapshot.capture_fps),
+        snapshot.paused_layers.join(","),
+        if snapshot.active_consumer { 1 } else { 0 },
+        match snapshot.capture_backend_drops {
+            None => "n/a",
+            Some(0) => "no",
+            Some(_) => "yes",
+        },
+    )
+}
+
 /// A point-in-time snapshot of display pipeline metrics, suitable for
 /// serialisation and logging.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -816,12 +952,49 @@ pub struct DisplayMetricsSnapshot {
     pub display_id: u32,
     pub capture_fps: f64,
     pub capture_drops: u64,
+    /// Idle-verdict deliveries per second (see
+    /// [`DisplayMetricsCounters::capture_idle_frames`]). Subset of
+    /// `capture_fps`.
+    #[serde(default)]
+    pub capture_idle_fps: f64,
+    /// Pre-bridge backend drops in the window (`None` = this backend has
+    /// not wired the drop counter, so absence of drops is *unknown*, not
+    /// zero — rendered as `n/a` in the log line).
+    #[serde(default)]
+    pub capture_backend_drops: Option<u64>,
     pub encode_fps: f64,
     pub encode_freshness_avg_ms: f64,
     pub encode_drops: u64,
     pub peer_count: u64,
     pub peer_drops: u64,
     pub resolution: (u32, u32),
+    /// Seconds since the owning session was created. 0 when the snapshot
+    /// was built outside a session (bare `from_counters` callers).
+    #[serde(default)]
+    pub uptime_secs: u64,
+    /// Pool-feed pushes attributed to fresh content in the window.
+    #[serde(default)]
+    pub pool_feed_pushes_changed: u64,
+    /// Pool-feed pushes attributed to the 1 Hz idle heartbeat (stale
+    /// re-encodes by design — each carries its original arrival stamp,
+    /// so a heartbeat-dominated window legitimately shows
+    /// `encode_fps > capture_fps` with high freshness).
+    #[serde(default)]
+    pub pool_feed_pushes_heartbeat: u64,
+    /// Pool-feed pushes attributed to a peer-join burst window.
+    #[serde(default)]
+    pub pool_feed_pushes_burst: u64,
+    /// RIDs of always-on baseline layers currently paused by the layer
+    /// policy, in spec order. Empty when nothing is paused (or the pool
+    /// is not constructed yet).
+    #[serde(default)]
+    pub paused_layers: Vec<String>,
+    /// Whether the encoder pool had at least one active (unpaused,
+    /// subscribed) consumer at snapshot time — the pool-feed bridge's F2
+    /// idle gate. `false` explains a window with zero conversions and
+    /// zero encodes without implicating capture.
+    #[serde(default)]
+    pub active_consumer: bool,
     pub tile_damage_samples: u64,
     pub tile_dirty_rects: u64,
     pub tile_dirty_tiles: u64,
@@ -846,6 +1019,11 @@ impl DisplayMetricsSnapshot {
     ) -> Self {
         let capture_frames = counters.capture_frames.swap(0, Ordering::Relaxed);
         let capture_drops = counters.capture_drops.swap(0, Ordering::Relaxed);
+        let capture_idle_frames = counters.capture_idle_frames.swap(0, Ordering::Relaxed);
+        let capture_backend_drops = counters.capture_backend_drops.swap(0, Ordering::Relaxed);
+        let pool_feed_push_changed = counters.pool_feed_push_changed.swap(0, Ordering::Relaxed);
+        let pool_feed_push_heartbeat = counters.pool_feed_push_heartbeat.swap(0, Ordering::Relaxed);
+        let pool_feed_push_burst = counters.pool_feed_push_burst.swap(0, Ordering::Relaxed);
         let encode_frames = counters.encode_frames.swap(0, Ordering::Relaxed);
         let encode_drops = counters.encode_drops.swap(0, Ordering::Relaxed);
         let encode_freshness_us = counters.encode_freshness_us_sum.swap(0, Ordering::Relaxed);
@@ -882,12 +1060,23 @@ impl DisplayMetricsSnapshot {
             display_id,
             capture_fps: capture_frames as f64 / elapsed_secs,
             capture_drops,
+            capture_idle_fps: capture_idle_frames as f64 / elapsed_secs,
+            // `Some` here because the counter itself always exists; the
+            // session-level `metrics()` downgrades to `None` when the
+            // backend never acknowledged the install (unwired = unknown).
+            capture_backend_drops: Some(capture_backend_drops),
             encode_fps: encode_frames as f64 / elapsed_secs,
             encode_freshness_avg_ms,
             encode_drops,
             peer_count,
             peer_drops,
             resolution,
+            uptime_secs: 0,
+            pool_feed_pushes_changed: pool_feed_push_changed,
+            pool_feed_pushes_heartbeat: pool_feed_push_heartbeat,
+            pool_feed_pushes_burst: pool_feed_push_burst,
+            paused_layers: Vec::new(),
+            active_consumer: false,
             tile_damage_samples,
             tile_dirty_rects,
             tile_dirty_tiles,
@@ -1015,6 +1204,30 @@ pub trait DisplayBackend: Send + Sync + 'static {
         let _ = probe;
     }
 
+    /// Install the shared counter for frames the capture producer built
+    /// but dropped at the bounded channel's `try_send` (the drop-on-full
+    /// contract in [`Self::start_capture`]). Purely observational — the
+    /// drop behavior itself is unchanged; the counter is what lets a
+    /// metrics window distinguish "the source delivered slowly" from
+    /// "the source delivered at rate but the consumer was starved"
+    /// (the two are otherwise identical in bridge-side `capture_fps`).
+    ///
+    /// Returns `true` when the backend wires the counter to its drop
+    /// site; the default ignores it and returns `false`, which the
+    /// session reports as `bdrops=n/a` (unknown) rather than a
+    /// misleading zero. Wired: ScreenCaptureKit (macOS) and the
+    /// synthetic test backend. The remaining `try_send` backends
+    /// (X11, Wayland/PipeWire, Windows DXGI) are mechanical follow-ups:
+    /// route this counter to their capture loop's send site and return
+    /// `true`.
+    ///
+    /// Install before [`Self::start_capture`]; like the demand probe,
+    /// the installed counter applies to sessions started afterwards.
+    fn install_capture_frame_drop_counter(&self, counter: Arc<AtomicU64>) -> bool {
+        let _ = counter;
+        false
+    }
+
     /// Inject a browser input event into the display.
     async fn inject_input(&self, event: InputEvent) -> Result<(), CallerError>;
 
@@ -1074,6 +1287,12 @@ pub struct DisplaySession {
     capture_handle: Mutex<Option<JoinHandle<()>>>,
     shutdown: CancellationToken,
     counters: Arc<DisplayMetricsCounters>,
+    /// Whether the backend acknowledged
+    /// [`DisplayBackend::install_capture_frame_drop_counter`] during
+    /// [`Self::start`]. `false` = backend never wired it, so
+    /// [`Self::metrics`] reports pre-bridge drops as unknown (`None`)
+    /// instead of a misleading zero.
+    backend_drop_counter_wired: AtomicBool,
     /// Instant used as the epoch for rate computations.
     metrics_epoch: Mutex<Instant>,
     /// Clipboard monitor for bidirectional clipboard sync.
@@ -1771,6 +1990,7 @@ impl DisplaySession {
             capture_handle: Mutex::new(None),
             shutdown: CancellationToken::new(),
             counters: Arc::new(DisplayMetricsCounters::new()),
+            backend_drop_counter_wired: AtomicBool::new(false),
             metrics_epoch: Mutex::new(Instant::now()),
             clipboard_monitor: Arc::new(clipboard::ClipboardMonitor::new()),
             clipboard_handle: Mutex::new(None),
@@ -1864,6 +2084,16 @@ impl DisplaySession {
         >,
         events: Option<DisplayEventSender>,
     ) -> Result<(), CallerError> {
+        // Observability: hand the backend the pre-bridge drop counter
+        // before capture starts so its very first session is covered.
+        // Backends that don't wire it return false and the metrics
+        // report the drop count as unknown (`bdrops=n/a`).
+        let drop_counter_wired = self
+            .backend
+            .install_capture_frame_drop_counter(Arc::clone(&self.counters.capture_backend_drops));
+        self.backend_drop_counter_wired
+            .store(drop_counter_wired, Ordering::Relaxed);
+
         let mut capture_rx = self.backend.start_capture(fps).await?;
 
         // Source resolution is resolved AFTER `start_capture` because
@@ -1946,6 +2176,13 @@ impl DisplaySession {
                             break;
                         };
                         cap_counters.capture_frames.fetch_add(1, Ordering::Relaxed);
+                        if captured_frame_kind(frame.dirty_rects.as_deref())
+                            == CapturedFrameKind::Idle
+                        {
+                            cap_counters
+                                .capture_idle_frames
+                                .fetch_add(1, Ordering::Relaxed);
+                        }
                         let arc_frame = Arc::new(frame);
                         *latest.write().await = Some(Arc::clone(&arc_frame));
                         // If no subscribers, the send fails -- count as a drop.
@@ -2116,6 +2353,7 @@ impl DisplaySession {
             pool_for_query.is_layer_paused(encode::pool::BASELINE_CODEC, rid.clone())
         });
         let pool_for_action = Arc::clone(&pool_arc);
+        let action_display_id = self.display_id;
         let on_action: Box<dyn Fn(aggregator::CapacityAction) + Send + Sync> =
             Box::new(move |action| {
                 // Operational observability: one line per layer-policy
@@ -2123,13 +2361,19 @@ impl DisplaySession {
                 // events per drop+recover cycle: pause top, pause mid,
                 // resume mid, resume top) plus presence transitions.
                 // Format mirrors the action variant for grep-ability:
-                // `[layer-policy] PauseLayer(<rid>)` / `ResumeLayer(<rid>)`.
+                // `[layer-policy] display <id>: PauseLayer(<rid>)` /
+                // `ResumeLayer(<rid>)`; the coordinator logs the vote
+                // vector behind the burst on its own `decision:` line.
                 match &action {
                     aggregator::CapacityAction::PauseLayer(rid) => {
-                        eprintln!("[layer-policy] PauseLayer({rid:?})");
+                        eprintln!(
+                            "[layer-policy] display {action_display_id}: PauseLayer({rid:?})"
+                        );
                     }
                     aggregator::CapacityAction::ResumeLayer(rid) => {
-                        eprintln!("[layer-policy] ResumeLayer({rid:?})");
+                        eprintln!(
+                            "[layer-policy] display {action_display_id}: ResumeLayer({rid:?})"
+                        );
                     }
                 }
                 match action {
@@ -2164,6 +2408,7 @@ impl DisplaySession {
         };
         let pool_for_federated_respec = Arc::clone(&pool_arc);
         let layer_policy_task = aggregator::spawn_layer_policy_coordinator(
+            self.display_id,
             Arc::clone(&self.peers),
             get_current_rids,
             is_layer_paused,
@@ -2260,13 +2505,24 @@ impl DisplaySession {
     /// `metrics()` (or since `start()` if this is the first call).
     pub async fn metrics(&self) -> DisplayMetricsSnapshot {
         let mut epoch = self.metrics_epoch.lock().await;
-        let snap = DisplayMetricsSnapshot::from_counters(
+        let mut snap = DisplayMetricsSnapshot::from_counters(
             &self.counters,
             self.display_id,
             self.backend.resolution(),
             &epoch,
         );
         *epoch = Instant::now();
+        snap.uptime_secs = self.session_epoch.elapsed().as_secs();
+        // Unwired backend = the pre-bridge drop count is unknown, not
+        // zero; `from_counters` filled `Some(n)` from the (never
+        // incremented) counter, so downgrade honestly.
+        if !self.backend_drop_counter_wired.load(Ordering::Relaxed) {
+            snap.capture_backend_drops = None;
+        }
+        if let Some(pool) = self.pool.get() {
+            snap.paused_layers = pool.paused_baseline_rids();
+            snap.active_consumer = pool.has_active_consumer();
+        }
         snap
     }
 
@@ -2285,6 +2541,10 @@ impl DisplaySession {
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
             // Skip the immediate first tick.
             interval.tick().await;
+            // Last logged pipeline-state fingerprint; the state line
+            // below fires only on change, so it is rate-limited to at
+            // most one line per 30 s tick by construction.
+            let mut last_state: Option<String> = None;
             loop {
                 tokio::select! {
                     _ = shutdown.cancelled() => break,
@@ -2294,7 +2554,8 @@ impl DisplaySession {
                             "[display/metrics] id={} capture={:.1}fps encode={:.1}fps \
                              drops=cap:{}/enc:{}/peer:{} peers={} freshness_avg={:.1}ms res={}x{} \
                              tile=dirty:{}r/{}t/{:.3} delta={:.1}fps/{:.1}kbps/{}rec/skips:{} \
-                             snap={}f/{:.1}kbps/{}rec",
+                             snap={}f/{:.1}kbps/{}rec up={}s idle={:.1}fps bdrops={} \
+                             push=c{}/h{}/b{} paused=[{}] consumer={}",
                             m.display_id,
                             m.capture_fps,
                             m.encode_fps,
@@ -2315,7 +2576,34 @@ impl DisplaySession {
                             m.tile_snapshot_frames,
                             m.tile_snapshot_kbps,
                             m.tile_snapshot_records,
+                            m.uptime_secs,
+                            m.capture_idle_fps,
+                            match m.capture_backend_drops {
+                                None => "n/a".to_string(),
+                                Some(n) => n.to_string(),
+                            },
+                            m.pool_feed_pushes_changed,
+                            m.pool_feed_pushes_heartbeat,
+                            m.pool_feed_pushes_burst,
+                            m.paused_layers.join(","),
+                            if m.active_consumer { 1 } else { 0 },
                         );
+                        // Startup-flake observability: name the pipeline's
+                        // throttle state whenever its classification
+                        // changes, so a degraded boot window and its
+                        // self-heal edge are explicit in the log instead
+                        // of inferred from fps deltas 30 s apart.
+                        let state = pipeline_state_fingerprint(&m);
+                        if last_state.as_deref() != Some(state.as_str()) {
+                            eprintln!(
+                                "[display/pipeline-state] id={} {} (was: {}) up={}s",
+                                m.display_id,
+                                state,
+                                last_state.as_deref().unwrap_or("<start>"),
+                                m.uptime_secs,
+                            );
+                            last_state = Some(state);
+                        }
                         if let Some(ref events) = events {
                             let _ = events.send(DisplayEvent::Metrics { snapshot: m });
                         }
@@ -4055,9 +4343,11 @@ impl DisplaySession {
                         let changed = last_sent_gen != Some(generation);
                         let heartbeat_due =
                             last_send_at.elapsed() >= IDLE_HEARTBEAT;
-                        if !(changed || heartbeat_due || in_burst) {
+                        let Some(push_reason) =
+                            pool_feed_push_reason(changed, heartbeat_due, in_burst)
+                        else {
                             continue;
-                        }
+                        };
 
                         let visual_marker_value =
                             if marker_flag.load(Ordering::Relaxed) {
@@ -4107,6 +4397,12 @@ impl DisplaySession {
                             arrived,
                             visual_marker_value,
                         );
+                        match push_reason {
+                            PoolFeedPushReason::Changed => &counters.pool_feed_push_changed,
+                            PoolFeedPushReason::Heartbeat => &counters.pool_feed_push_heartbeat,
+                            PoolFeedPushReason::Burst => &counters.pool_feed_push_burst,
+                        }
+                        .fetch_add(1, Ordering::Relaxed);
                         last_sent_gen = Some(generation);
                         last_send_at = Instant::now();
                     }
@@ -5158,11 +5454,16 @@ mod tests {
         let c = DisplayMetricsCounters::new();
         assert_eq!(c.capture_frames.load(Ordering::Relaxed), 0);
         assert_eq!(c.capture_drops.load(Ordering::Relaxed), 0);
+        assert_eq!(c.capture_idle_frames.load(Ordering::Relaxed), 0);
+        assert_eq!(c.capture_backend_drops.load(Ordering::Relaxed), 0);
         assert_eq!(c.encode_frames.load(Ordering::Relaxed), 0);
         assert_eq!(c.encode_drops.load(Ordering::Relaxed), 0);
         assert_eq!(c.encode_freshness_us_sum.load(Ordering::Relaxed), 0);
         assert_eq!(c.peer_drops.load(Ordering::Relaxed), 0);
         assert_eq!(c.peer_count.load(Ordering::Relaxed), 0);
+        assert_eq!(c.pool_feed_push_changed.load(Ordering::Relaxed), 0);
+        assert_eq!(c.pool_feed_push_heartbeat.load(Ordering::Relaxed), 0);
+        assert_eq!(c.pool_feed_push_burst.load(Ordering::Relaxed), 0);
     }
 
     #[test]
@@ -5172,6 +5473,11 @@ mod tests {
         // 3 peer drops over the window.
         c.capture_frames.store(150, Ordering::Relaxed);
         c.capture_drops.store(2, Ordering::Relaxed);
+        c.capture_idle_frames.store(50, Ordering::Relaxed);
+        c.capture_backend_drops.store(4, Ordering::Relaxed);
+        c.pool_feed_push_changed.store(90, Ordering::Relaxed);
+        c.pool_feed_push_heartbeat.store(5, Ordering::Relaxed);
+        c.pool_feed_push_burst.store(7, Ordering::Relaxed);
         c.encode_frames.store(140, Ordering::Relaxed);
         c.encode_drops.store(1, Ordering::Relaxed);
         // 140 frames * 5000us avg = 700_000us total
@@ -5193,6 +5499,18 @@ mod tests {
         // ~30 fps capture (150 / 5s)
         assert!((snap.capture_fps - 30.0).abs() < 1.0);
         assert_eq!(snap.capture_drops, 2);
+        // ~10 fps idle-verdict deliveries (50 / 5s)
+        assert!((snap.capture_idle_fps - 10.0).abs() < 1.0);
+        // Bare from_counters reports the raw counter as Some — only the
+        // session-level metrics() knows whether the backend wired it.
+        assert_eq!(snap.capture_backend_drops, Some(4));
+        assert_eq!(snap.pool_feed_pushes_changed, 90);
+        assert_eq!(snap.pool_feed_pushes_heartbeat, 5);
+        assert_eq!(snap.pool_feed_pushes_burst, 7);
+        // Session-level facts default until metrics() fills them.
+        assert_eq!(snap.uptime_secs, 0);
+        assert!(snap.paused_layers.is_empty());
+        assert!(!snap.active_consumer);
         // ~28 fps encode (140 / 5s)
         assert!((snap.encode_fps - 28.0).abs() < 1.0);
         assert_eq!(snap.encode_drops, 1);
@@ -5214,6 +5532,11 @@ mod tests {
 
         // Counters should be reset after snapshot (except peer_count which is gauge).
         assert_eq!(c.capture_frames.load(Ordering::Relaxed), 0);
+        assert_eq!(c.capture_idle_frames.load(Ordering::Relaxed), 0);
+        assert_eq!(c.capture_backend_drops.load(Ordering::Relaxed), 0);
+        assert_eq!(c.pool_feed_push_changed.load(Ordering::Relaxed), 0);
+        assert_eq!(c.pool_feed_push_heartbeat.load(Ordering::Relaxed), 0);
+        assert_eq!(c.pool_feed_push_burst.load(Ordering::Relaxed), 0);
         assert_eq!(c.encode_frames.load(Ordering::Relaxed), 0);
         assert_eq!(c.tile_delta_records.load(Ordering::Relaxed), 0);
         assert_eq!(c.tile_snapshot_records.load(Ordering::Relaxed), 0);
@@ -5236,12 +5559,20 @@ mod tests {
             display_id: 1,
             capture_fps: 30.0,
             capture_drops: 5,
+            capture_idle_fps: 1.5,
+            capture_backend_drops: Some(3),
             encode_fps: 28.5,
             encode_freshness_avg_ms: 4.2,
             encode_drops: 2,
             peer_count: 1,
             peer_drops: 0,
             resolution: (1920, 1080),
+            uptime_secs: 42,
+            pool_feed_pushes_changed: 20,
+            pool_feed_pushes_heartbeat: 8,
+            pool_feed_pushes_burst: 2,
+            paused_layers: vec!["h".to_string(), "q".to_string()],
+            active_consumer: true,
             tile_damage_samples: 3,
             tile_dirty_rects: 4,
             tile_dirty_tiles: 5,
@@ -5259,6 +5590,144 @@ mod tests {
         assert!(json.contains("\"capture_fps\":30.0"));
         assert!(json.contains("\"encode_drops\":2"));
         assert!(json.contains("\"tile_delta_records\":7"));
+        assert!(json.contains("\"capture_idle_fps\":1.5"));
+        assert!(json.contains("\"capture_backend_drops\":3"));
+        assert!(json.contains("\"uptime_secs\":42"));
+        assert!(json.contains("\"pool_feed_pushes_heartbeat\":8"));
+        assert!(json.contains("\"paused_layers\":[\"h\",\"q\"]"));
+        assert!(json.contains("\"active_consumer\":true"));
+    }
+
+    /// Snapshots serialized before the startup-flake observability fields
+    /// existed (and any external producer still emitting the old shape)
+    /// must keep deserializing — every added field is `#[serde(default)]`.
+    #[test]
+    fn metrics_snapshot_deserializes_pre_observability_shape() {
+        let old_json = r#"{
+            "display_id": 7,
+            "capture_fps": 29.0,
+            "capture_drops": 0,
+            "encode_fps": 28.0,
+            "encode_freshness_avg_ms": 18.0,
+            "encode_drops": 0,
+            "peer_count": 1,
+            "peer_drops": 0,
+            "resolution": [1024, 640],
+            "tile_damage_samples": 0,
+            "tile_dirty_rects": 0,
+            "tile_dirty_tiles": 0,
+            "tile_dirty_fraction_avg": 0.0,
+            "tile_delta_cadence_skips": 0,
+            "tile_delta_records": 0,
+            "tile_delta_fps": 0.0,
+            "tile_delta_kbps": 0.0,
+            "tile_snapshot_records": 0,
+            "tile_snapshot_frames": 0,
+            "tile_snapshot_kbps": 0.0
+        }"#;
+        let snap: DisplayMetricsSnapshot = serde_json::from_str(old_json).unwrap();
+        assert_eq!(snap.display_id, 7);
+        assert!((snap.capture_idle_fps - 0.0).abs() < f64::EPSILON);
+        assert_eq!(snap.capture_backend_drops, None);
+        assert_eq!(snap.uptime_secs, 0);
+        assert_eq!(snap.pool_feed_pushes_changed, 0);
+        assert!(snap.paused_layers.is_empty());
+        assert!(!snap.active_consumer);
+    }
+
+    // -----------------------------------------------------------------------
+    // Startup-flake observability: pure classification helpers
+    // -----------------------------------------------------------------------
+
+    /// Damage-annotation classification: an explicit empty rect set is
+    /// the backend's "nothing changed" verdict (SCK `Idle`); rects or a
+    /// missing annotation count as content (conservative default).
+    #[test]
+    fn captured_frame_kind_classifies_idle_vs_content() {
+        assert_eq!(captured_frame_kind(None), CapturedFrameKind::Content);
+        assert_eq!(captured_frame_kind(Some(&[])), CapturedFrameKind::Idle);
+        let rects = [capture::damage::Rect::new(0, 0, 8, 8)];
+        assert_eq!(
+            captured_frame_kind(Some(&rects)),
+            CapturedFrameKind::Content
+        );
+    }
+
+    /// Push-reason attribution partitions the pushes: fresh content wins
+    /// over the heartbeat, the heartbeat over the burst, and no open
+    /// gate means no push.
+    #[test]
+    fn pool_feed_push_reason_precedence() {
+        assert_eq!(pool_feed_push_reason(false, false, false), None);
+        assert_eq!(
+            pool_feed_push_reason(true, true, true),
+            Some(PoolFeedPushReason::Changed)
+        );
+        assert_eq!(
+            pool_feed_push_reason(false, true, true),
+            Some(PoolFeedPushReason::Heartbeat)
+        );
+        assert_eq!(
+            pool_feed_push_reason(false, false, true),
+            Some(PoolFeedPushReason::Burst)
+        );
+    }
+
+    #[test]
+    fn capture_rate_bucket_boundaries() {
+        assert_eq!(capture_rate_bucket(0.0), "none");
+        assert_eq!(capture_rate_bucket(0.49), "none");
+        assert_eq!(capture_rate_bucket(0.5), "trickle");
+        assert_eq!(capture_rate_bucket(4.0), "trickle");
+        assert_eq!(capture_rate_bucket(9.99), "trickle");
+        assert_eq!(capture_rate_bucket(10.0), "full");
+        assert_eq!(capture_rate_bucket(29.2), "full");
+    }
+
+    /// The pipeline-state fingerprint is built from classifications, not
+    /// raw counts: fps jitter within a bucket and varying (non-zero)
+    /// drop counts must not flap it, while a bucket change, a pause-set
+    /// change, a consumer change, or drops appearing must.
+    #[test]
+    fn pipeline_state_fingerprint_tracks_classifications_not_counts() {
+        let mut snap = DisplayMetricsSnapshot::from_counters(
+            &DisplayMetricsCounters::new(),
+            0,
+            (1024, 640),
+            &(Instant::now() - std::time::Duration::from_secs(5)),
+        );
+        snap.capture_fps = 3.2;
+        snap.capture_backend_drops = None;
+        snap.paused_layers = vec!["h".into(), "q".into()];
+        snap.active_consumer = true;
+        let degraded = pipeline_state_fingerprint(&snap);
+        assert_eq!(
+            degraded,
+            "capture=trickle paused=[h,q] consumer=1 backend_drops=n/a"
+        );
+
+        // Within-bucket jitter: identical fingerprint.
+        snap.capture_fps = 5.9;
+        assert_eq!(pipeline_state_fingerprint(&snap), degraded);
+
+        // Wired-but-zero drops render as "no", non-zero as "yes", and
+        // the count itself does not appear (so 3 → 7 cannot flap it).
+        snap.capture_backend_drops = Some(0);
+        let no_drops = pipeline_state_fingerprint(&snap);
+        assert!(no_drops.ends_with("backend_drops=no"));
+        snap.capture_backend_drops = Some(3);
+        let some_drops = pipeline_state_fingerprint(&snap);
+        assert!(some_drops.ends_with("backend_drops=yes"));
+        snap.capture_backend_drops = Some(7);
+        assert_eq!(pipeline_state_fingerprint(&snap), some_drops);
+
+        // The self-heal edge: bucket flips to full.
+        snap.capture_backend_drops = None;
+        snap.capture_fps = 29.2;
+        assert_eq!(
+            pipeline_state_fingerprint(&snap),
+            "capture=full paused=[h,q] consumer=1 backend_drops=n/a"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/crates/intendant-display/src/macos.rs
+++ b/crates/intendant-display/src/macos.rs
@@ -29,7 +29,7 @@ use screencapturekit::cg::CGRect as ScRect;
 use screencapturekit::cm::{CMTime, SCFrameStatus};
 use screencapturekit::cv::CVPixelBufferLockFlags;
 use screencapturekit::prelude::*;
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex as StdMutex, RwLock};
 use tokio::sync::{mpsc, Mutex};
 
@@ -116,6 +116,13 @@ pub struct MacOSBackend {
     height: Arc<AtomicU32>,
     input_geometry: Arc<RwLock<InputGeometry>>,
     target: CaptureTarget,
+    /// Observability slot for pre-bridge frame drops (see
+    /// [`super::DisplayBackend::install_capture_frame_drop_counter`]).
+    /// The SCK output handler clones the installed counter at
+    /// `start_capture` time and bumps it whenever `try_send` fails
+    /// with `Full` — the silent drop point that otherwise makes
+    /// "SCK delivered but the consumer was starved" invisible.
+    drop_counter: Arc<StdMutex<Option<Arc<AtomicU64>>>>,
 }
 
 impl Default for MacOSBackend {
@@ -138,6 +145,7 @@ impl MacOSBackend {
             height: Arc::new(AtomicU32::new(0)),
             input_geometry: Arc::new(RwLock::new(InputGeometry::from_frame_size(0, 0))),
             target,
+            drop_counter: Arc::new(StdMutex::new(None)),
         }
     }
 
@@ -743,6 +751,14 @@ impl DisplayBackend for MacOSBackend {
 
         let handler_slot = Arc::clone(&frame_slot);
         let handler_shutdown = Arc::clone(&shutdown_flag);
+        // Snapshot the installed drop counter for this session's handler.
+        // Cloned out here (not read per callback) so the handler never
+        // takes the backend-level lock on the SCK delivery queue.
+        let handler_drop_counter = self
+            .drop_counter
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
         // Share width/height atomics with the output handler so it can
         // update them when ScreenCaptureKit delivers frames at a different
         // resolution (e.g. Retina scale change, resolution switch).
@@ -831,13 +847,19 @@ impl DisplayBackend for MacOSBackend {
                 // the slot under the same lock, so once it returns no
                 // callback can slip another frame into the channel.
                 // Backpressure: `try_send` drops the frame if the channel
-                // is full.
+                // is full — counted (Full only; a Closed send during
+                // teardown is not a drop under pressure) so metrics can
+                // tell a starved consumer from a slow source.
                 if let Some(tx) = handler_slot
                     .lock()
                     .unwrap_or_else(|e| e.into_inner())
                     .as_ref()
                 {
-                    let _ = tx.try_send(frame);
+                    if let Err(mpsc::error::TrySendError::Full(_)) = tx.try_send(frame) {
+                        if let Some(counter) = &handler_drop_counter {
+                            counter.fetch_add(1, Ordering::Relaxed);
+                        }
+                    }
                 }
             },
             SCStreamOutputType::Screen,
@@ -1000,6 +1022,11 @@ impl DisplayBackend for MacOSBackend {
             }
         }
         Ok(())
+    }
+
+    fn install_capture_frame_drop_counter(&self, counter: Arc<AtomicU64>) -> bool {
+        *self.drop_counter.lock().unwrap_or_else(|e| e.into_inner()) = Some(counter);
+        true
     }
 
     fn resolution(&self) -> (u32, u32) {

--- a/crates/intendant-display/src/synthetic.rs
+++ b/crates/intendant-display/src/synthetic.rs
@@ -43,8 +43,8 @@ use super::capture::pacing::{self, DemandProbeSlot};
 use super::{DisplayBackend, DisplayInfo, DisplayInfoKind, Frame, FrameFormat, InputEvent};
 use async_trait::async_trait;
 use intendant_core::error::CallerError;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Instant;
 use tokio::sync::{mpsc, Mutex};
 
@@ -119,6 +119,12 @@ pub struct SyntheticBackend {
     /// lets CI exercise the pacing contract (keepalive on demand drop,
     /// full rate + wake on demand restore) without a real display.
     demand: Arc<DemandProbeSlot>,
+    /// Pre-bridge drop counter slot (see
+    /// [`DisplayBackend::install_capture_frame_drop_counter`]); the
+    /// producer thread bumps the installed counter on every
+    /// `try_send` `Full` drop. Wired here so the drop-counter contract
+    /// has a hermetic, OS-free test backend.
+    drop_counter: Arc<StdMutex<Option<Arc<AtomicU64>>>>,
 }
 
 impl SyntheticBackend {
@@ -127,6 +133,7 @@ impl SyntheticBackend {
             capture: Mutex::new(None),
             shutdown: Arc::new(AtomicBool::new(false)),
             demand: Arc::new(DemandProbeSlot::new()),
+            drop_counter: Arc::new(StdMutex::new(None)),
         }
     }
 
@@ -228,6 +235,12 @@ impl DisplayBackend for SyntheticBackend {
         let (tx, rx) = mpsc::channel::<Frame>(4);
         let shutdown = Arc::clone(&self.shutdown);
         let demand = Arc::clone(&self.demand);
+        // Snapshot the installed drop counter for this session's producer.
+        let drop_counter = self
+            .drop_counter
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
         let interval = std::time::Duration::from_millis(1000 / u64::from(fps.clamp(1, MAX_FPS)));
 
         // The producer owns `tx` (the channel's only sender): thread exit IS
@@ -241,8 +254,15 @@ impl DisplayBackend for SyntheticBackend {
                     break;
                 }
                 let start = Instant::now();
-                // Bounded channel, drop-on-full per the capture contract.
-                let _ = tx.try_send(synthetic_frame(&base, frame_index));
+                // Bounded channel, drop-on-full per the capture contract —
+                // Full drops counted for the pre-bridge drop metric.
+                if let Err(mpsc::error::TrySendError::Full(_)) =
+                    tx.try_send(synthetic_frame(&base, frame_index))
+                {
+                    if let Some(counter) = &drop_counter {
+                        counter.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
                 frame_index += 1;
                 // Demand-aware pacing, same contract as the X11 loops:
                 // full fps with demand, 1 fps keepalive without, and a
@@ -275,6 +295,11 @@ impl DisplayBackend for SyntheticBackend {
 
     fn set_capture_demand_probe(&self, probe: pacing::CaptureDemandProbe) {
         self.demand.install(probe);
+    }
+
+    fn install_capture_frame_drop_counter(&self, counter: Arc<AtomicU64>) -> bool {
+        *self.drop_counter.lock().unwrap_or_else(|e| e.into_inner()) = Some(counter);
+        true
     }
 
     async fn inject_input(&self, _event: InputEvent) -> Result<(), CallerError> {
@@ -379,6 +404,34 @@ mod tests {
             .expect("frame within 5s of restart")
             .expect("fresh channel open");
         backend.stop_capture().await;
+    }
+
+    /// The pre-bridge drop counter contract: an installed counter is
+    /// bumped when the producer drops a frame at the full bounded
+    /// channel, and installing at all makes the backend report itself
+    /// wired (`true`). Hermetic — no OS capture; the producer is a pure
+    /// test-card thread whose channel simply isn't drained.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn drop_counter_counts_try_send_full_drops() {
+        let backend = SyntheticBackend::new();
+        let drops = Arc::new(AtomicU64::new(0));
+        assert!(
+            backend.install_capture_frame_drop_counter(Arc::clone(&drops)),
+            "synthetic backend must report the drop counter as wired"
+        );
+
+        // Never drain the receiver: the channel (capacity 4) fills and
+        // every further send is a Full drop.
+        let _rx = backend.start_capture(30).await.expect("start");
+        let deadline = Instant::now() + std::time::Duration::from_secs(10);
+        while drops.load(Ordering::SeqCst) == 0 && Instant::now() < deadline {
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        backend.stop_capture().await;
+        assert!(
+            drops.load(Ordering::SeqCst) > 0,
+            "producer must count Full drops while the channel goes undrained"
+        );
     }
 
     /// The real-OS backends get this treatment `#[ignore]`d on operator

--- a/src/bin/caller/display_glue.rs
+++ b/src/bin/caller/display_glue.rs
@@ -26,9 +26,9 @@ pub(crate) fn display_event_forwarder(bus: EventBus) -> display::DisplayEventSen
                 display::DisplayEvent::CaptureLost { display_id, reason } => {
                     AppEvent::DisplayCaptureLost { display_id, reason }
                 }
-                display::DisplayEvent::Metrics { snapshot } => {
-                    AppEvent::DisplayMetrics { snapshot }
-                }
+                display::DisplayEvent::Metrics { snapshot } => AppEvent::DisplayMetrics {
+                    snapshot: *snapshot,
+                },
                 display::DisplayEvent::Resize {
                     display_id,
                     width,


### PR DESCRIPTION
## Problem

A recurring startup flake: after a daemon boot, a watched display pane can run at ~3-6 fps for tens of minutes, then self-heal to a steady ~29 fps. Reading tonight's occurrence out of the daemon log classified it as **capture-side** — capture fps itself was low with encode tracking it, zero drops everywhere, TWCC clean, and the layer policy resumed the viewer's rid at attach and never touched it again — but the log could not separate the two remaining sub-causes:

- a genuinely idle source (damage-driven ScreenCaptureKit delivers frames only on content change), vs
- a starved consumer (the platform capture handler's bounded-channel `try_send` drop is silent and uncounted, so "SCK delivered at rate but frames were dropped pre-bridge" is invisible).

The degraded window also *reads* misleadingly: the pool-feed bridge's 1 Hz idle heartbeat re-pushes the previous I420 buffer with its **original** arrival stamp, so idle windows legitimately show `encode_fps > capture_fps` with hundreds-of-ms `freshness_avg` — which looks like an encoder stall unless you know the gate. And the `[layer-policy] PauseLayer/ResumeLayer` lines carry no display id and no reason.

## Change (observability only — no behavior changes)

- **Idle/content split at the capture bridge**: count deliveries whose damage annotation is an explicit empty set (SCK `Idle` verdict) separately (`capture_idle_fps`).
- **Pre-bridge backend drops**: new default-no-op `DisplayBackend::install_capture_frame_drop_counter` seam; wired for ScreenCaptureKit (macOS) and the synthetic backend. Unwired backends report `bdrops=n/a` (unknown, never a misleading zero). X11/Wayland/Windows wiring is a mechanical follow-up.
- **Push attribution**: every pool-feed forward is attributed to its gate — `changed` / `heartbeat` / `burst` — so heartbeat-dominated windows are explicit in the log.
- **Enriched 30 s `[display/metrics]` line** (+ `DisplayMetricsSnapshot`, all additive `serde(default)` fields): `up=`, `idle=`, `bdrops=`, `push=c/h/b`, `paused=[...]`, `consumer=`.
- **`[display/pipeline-state]` transition line**: logged when the coarse fingerprint (capture bucket none/trickle/full, paused rid set, active-consumer, drops-presence) changes between metrics ticks — the degraded onset and the self-heal edge become explicit log events. Rate-limited to at most one line per 30 s tick by construction.
- **Layer-policy decisions explain themselves**: on any tick that emits pause/resume actions, the coordinator logs the composed vote vector (`effective/presence/twcc/rr/pinned/demanded`), and the action lines now carry the display id.

## Tests

Hermetic unit tests for: frame-kind classification, push-reason precedence, capture-rate buckets, fingerprint stability (count jitter never flaps it; bucket/pause/consumer/drop-presence changes do), snapshot rate math + counter resets, serde compat (pre-change JSON still deserializes; new fields serialize), the pool's `paused_baseline_rids` accessor, decision-line rendering (spec-order, off-bank summarization), and the synthetic backend's drop counter (`Full` drops counted while undrained).
