### PR TITLE
display: pixel-verify OS damage rects; exclude BGRX pad bytes from tile hashing

### DIFF
--- a/crates/intendant-display/src/capture/damage.rs
+++ b/crates/intendant-display/src/capture/damage.rs
@@ -8,11 +8,16 @@
 //! ## Capability tiers
 //!
 //! Damage backends advertise [`DamageCapability`] so the consumer can
-//! decide whether to trust per-tick dirty fractions or assume worst-case:
+//! decide how to obtain trustworthy dirty regions:
 //!
 //! - [`DamageCapability::OsLevel`] — backend uses real OS damage events
 //!   (X11 XDamage, macOS dirty rects when ScreenCaptureKit exposes them,
-//!   Wayland damage metadata). Dirty fraction is meaningful.
+//!   Wayland damage metadata). These rects locate change but
+//!   **over-report** (bounding boxes merge distant damage; compositing
+//!   WMs fire root-window damage on *repaints* of identical pixels), so
+//!   consumers pixel-verify them via
+//!   [`super::frame_diff::FrameDiffDamageTracker::verify_damage`]
+//!   before treating them as dirt.
 //! - [`DamageCapability::FrameDiff`] — backend computes damage by hashing
 //!   tiles and diffing against last-frame hashes. CPU-bound but works
 //!   anywhere. Dirty fraction is approximate (false negatives possible
@@ -66,8 +71,9 @@ impl fmt::Display for Rect {
 /// Capability tier of a damage backend. See module docs.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum DamageCapability {
-    /// OS reports damage events directly (X11 XDamage, etc.). Dirty
-    /// fraction reported per poll is trustworthy.
+    /// OS reports damage events directly (X11 XDamage, etc.). Rects
+    /// locate change but over-report — consumers pixel-verify them
+    /// before deriving dirty tiles or fractions (see module docs).
     #[allow(dead_code)]
     OsLevel,
     /// Damage computed from frame-diff (tile hashing). Approximate;

--- a/crates/intendant-display/src/capture/frame_diff.rs
+++ b/crates/intendant-display/src/capture/frame_diff.rs
@@ -1,10 +1,22 @@
-//! Frame-diff damage tracking for platforms without OS damage events.
+//! Pixel-truth change detection for tile streaming.
 //!
-//! This is a D-4 fallback behind XDamage / future platform-native
-//! damage. It hashes every tile of the captured frame and emits tile
-//! rects whose hash changed since the previous frame. That is CPU-bound
-//! compared with OS damage, but it keeps the dirty-region architecture
-//! usable on platforms whose capture APIs do not expose dirty rects yet.
+//! Two consumers share the per-tile hash baseline this tracker keeps:
+//!
+//! - **Frame-diff mode** ([`FrameDiffDamageTracker::diff_frame`]) — the
+//!   fallback for platforms without per-frame damage metadata: hash
+//!   every tile of the captured frame and emit tile rects whose hash
+//!   changed since the previous diff. CPU-bound but works anywhere.
+//! - **Damage verification** ([`FrameDiffDamageTracker::verify_damage`])
+//!   — platform damage metadata (XDamage events, SCK dirty rects) tells
+//!   the pipeline *where to look*, never *what changed*: OS damage
+//!   over-reports by design (bounding boxes merge distant damage), and
+//!   under a compositing WM root-window XDamage fires on *repaints*,
+//!   not pixel change — GNOME Shell's clock tick reports an
+//!   up-to-full-root box every second over pixel-identical content.
+//!   Verification hashes only the tiles inside the reported rects and
+//!   keeps the ones whose content really changed, so a phantom
+//!   full-screen report costs one hash pass instead of a full-screen
+//!   re-encode (and a video-fallback flap).
 
 use super::super::tile::grid::{TileGrid, TileId};
 use super::super::{Frame, FrameFormat};
@@ -12,6 +24,16 @@ use super::damage::Rect;
 
 const FNV_OFFSET: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x100000001b3;
+
+/// Clears byte 3 of each of the two packed 4-byte pixels in a
+/// little-endian `u64` word. Byte 3 is alpha on alpha-carrying sources
+/// and **undefined padding** on 24-bit-depth X11 captures (BGRX/RGBX):
+/// the server writes whatever it likes there, so two captures of
+/// identical screen content can differ in those bytes — hashing them
+/// minted phantom tile dirt. Screens are opaque (no capture source
+/// renders alpha variation), so the channel is excluded from change
+/// detection everywhere rather than per-backend.
+const PIXEL_HASH_MASK: u64 = 0x00FF_FFFF_00FF_FFFF;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FrameDiffError {
@@ -53,20 +75,26 @@ impl FrameDiffDamageTracker {
         }
     }
 
-    pub fn diff_frame(&mut self, frame: &Frame) -> Result<Vec<Rect>, FrameDiffError> {
+    /// Validate the frame and (re)size per-tile hash state for its
+    /// geometry. After a geometry change `self.has_baseline` is false
+    /// until a full hash pass completes.
+    fn prepare_grid(&mut self, frame: &Frame) -> Result<TileGrid, FrameDiffError> {
         validate_frame(frame)?;
         let grid = TileGrid::new(frame.width, frame.height, self.tile_size_px)
             .ok_or(FrameDiffError::InvalidGeometry)?;
         let geometry = (frame.width, frame.height, frame.stride, frame.format);
-        let geometry_changed = self.last_geometry != Some(geometry);
-        if geometry_changed {
+        if self.last_geometry != Some(geometry) {
             self.last_hashes.clear();
             self.last_hashes
                 .resize(grid.width_tiles as usize * grid.height_tiles as usize, 0);
             self.has_baseline = false;
             self.last_geometry = Some(geometry);
         }
+        Ok(grid)
+    }
 
+    pub fn diff_frame(&mut self, frame: &Frame) -> Result<Vec<Rect>, FrameDiffError> {
+        let grid = self.prepare_grid(frame)?;
         let mut dirty = Vec::new();
         for ty in 0..grid.height_tiles {
             for tx in 0..grid.width_tiles {
@@ -81,6 +109,51 @@ impl FrameDiffDamageTracker {
             }
         }
         self.has_baseline = true;
+        Ok(dirty)
+    }
+
+    /// Pixel-verify externally reported damage instead of trusting it.
+    ///
+    /// `candidates` (OS damage events, in-frame dirty rects) name where
+    /// to look; only tiles inside them whose content hash actually
+    /// changed since this tracker last saw them are returned. See the
+    /// module docs for why reported damage must never be trusted as
+    /// dirt directly.
+    ///
+    /// The first call (and the first after any geometry change) has no
+    /// baseline to verify against: it hashes the whole frame to
+    /// establish one and returns the candidate tiles unverified —
+    /// dropping them instead would strand a real change until the
+    /// periodic snapshot re-anchor.
+    pub fn verify_damage(
+        &mut self,
+        frame: &Frame,
+        candidates: &[Rect],
+    ) -> Result<Vec<Rect>, FrameDiffError> {
+        let grid = self.prepare_grid(frame)?;
+        let candidate_tiles = grid.dirty_tiles(candidates);
+        if !self.has_baseline {
+            for ty in 0..grid.height_tiles {
+                for tx in 0..grid.width_tiles {
+                    let idx = ty as usize * grid.width_tiles as usize + tx as usize;
+                    self.last_hashes[idx] = hash_tile(frame, &grid, TileId::new(tx, ty))?;
+                }
+            }
+            self.has_baseline = true;
+            return Ok(candidate_tiles
+                .into_iter()
+                .map(|tile| tile_rect(&grid, tile))
+                .collect());
+        }
+        let mut dirty = Vec::new();
+        for tile in candidate_tiles {
+            let hash = hash_tile(frame, &grid, tile)?;
+            let idx = tile.y as usize * grid.width_tiles as usize + tile.x as usize;
+            if self.last_hashes[idx] != hash {
+                self.last_hashes[idx] = hash;
+                dirty.push(tile_rect(&grid, tile));
+            }
+        }
         Ok(dirty)
     }
 }
@@ -110,24 +183,30 @@ fn hash_tile(frame: &Frame, grid: &TileGrid, tile: TileId) -> Result<u64, FrameD
     // dependent multiplies over the same pixels. This changes the hash
     // *values* relative to byte-wise FNV, which is fine — hashes are
     // only ever compared against hashes of the previous frame computed
-    // by the same code in the same process.
+    // by the same code in the same process. Each word is two packed
+    // pixels; [`PIXEL_HASH_MASK`] drops their byte-3 channel (alpha /
+    // undefined BGRX padding) from change detection. `from_le_bytes`
+    // (not `ne`) keeps the mask ↔ byte-lane pairing fixed regardless of
+    // host endianness.
     let mut hash = FNV_OFFSET;
     for y in 0..copy_h {
         let row_start = (start_y as usize + y) * frame.stride as usize + start_x as usize * 4;
         let row = &frame.data[row_start..row_start + copy_w * 4];
         let mut words = row.chunks_exact(8);
         for w in words.by_ref() {
-            // Native endianness: the hash never leaves this process.
-            hash ^= u64::from_ne_bytes(w.try_into().expect("chunks_exact(8) yields 8 bytes"));
+            hash ^= u64::from_le_bytes(w.try_into().expect("chunks_exact(8) yields 8 bytes"))
+                & PIXEL_HASH_MASK;
             hash = hash.wrapping_mul(FNV_PRIME);
         }
         let rem = words.remainder();
         if !rem.is_empty() {
-            // Tail (row byte width not a multiple of 8): zero-pad into
-            // one final word. Rows of equal content still hash equal.
+            // Tail (odd pixel count: rows are always 4-byte multiples,
+            // so this is one trailing pixel): zero-pad into one final
+            // word — the mask keeps the zeroed upper lane at zero, so
+            // rows of equal content still hash equal.
             let mut tail = [0u8; 8];
             tail[..rem.len()].copy_from_slice(rem);
-            hash ^= u64::from_ne_bytes(tail);
+            hash ^= u64::from_le_bytes(tail) & PIXEL_HASH_MASK;
             hash = hash.wrapping_mul(FNV_PRIME);
         }
     }
@@ -181,6 +260,30 @@ mod tests {
         assert!(t.diff_frame(&f).unwrap().is_empty());
     }
 
+    /// X11 24-bit-depth captures are BGRX: byte 3 of every pixel is
+    /// *undefined padding* the server may fill differently between two
+    /// captures of identical screen content. Change detection must not
+    /// read it — two frames whose B/G/R planes match are the same frame.
+    #[test]
+    fn padding_byte_only_change_yields_no_dirty_rects() {
+        let mut t = FrameDiffDamageTracker::new(2);
+        let mut data = vec![7u8; 4 * 4 * 4];
+        for px in data.chunks_exact_mut(4) {
+            px[3] = 0xAA;
+        }
+        assert_eq!(
+            t.diff_frame(&frame(data.clone(), 4, 4, 16)).unwrap().len(),
+            4
+        );
+        for px in data.chunks_exact_mut(4) {
+            px[3] = 0x55;
+        }
+        assert!(
+            t.diff_frame(&frame(data, 4, 4, 16)).unwrap().is_empty(),
+            "pad-byte-only differences must not mint dirty tiles"
+        );
+    }
+
     #[test]
     fn one_pixel_change_marks_owning_tile_only() {
         let mut t = FrameDiffDamageTracker::new(2);
@@ -218,5 +321,147 @@ mod tests {
         assert_eq!(t.diff_frame(&f), Err(FrameDiffError::InvalidGeometry));
         let f = frame(vec![0; 4], 2, 2, 8);
         assert_eq!(t.diff_frame(&f), Err(FrameDiffError::SourceTooSmall));
+        assert_eq!(
+            t.verify_damage(&frame(vec![0; 4], 2, 2, 4), &[Rect::new(0, 0, 2, 2)]),
+            Err(FrameDiffError::InvalidGeometry)
+        );
+    }
+
+    const FULL_4X4: Rect = Rect {
+        x: 0,
+        y: 0,
+        width: 4,
+        height: 4,
+    };
+
+    #[test]
+    fn verify_damage_first_pass_trusts_candidates_and_baselines() {
+        let mut t = FrameDiffDamageTracker::new(2);
+        let f = frame(vec![9; 4 * 4 * 4], 4, 4, 16);
+        // No baseline yet: the reported damage is passed through once…
+        assert_eq!(t.verify_damage(&f, &[FULL_4X4]).unwrap().len(), 4);
+        // …and the very same phantom report over identical pixels is
+        // pruned on every later pass (the live X11 compositor shape).
+        assert!(t.verify_damage(&f, &[FULL_4X4]).unwrap().is_empty());
+        assert!(t.verify_damage(&f, &[FULL_4X4]).unwrap().is_empty());
+    }
+
+    #[test]
+    fn verify_damage_confirms_only_actually_changed_tiles() {
+        let mut t = FrameDiffDamageTracker::new(2);
+        let mut data = vec![0u8; 4 * 4 * 4];
+        let _ = t
+            .verify_damage(&frame(data.clone(), 4, 4, 16), &[FULL_4X4])
+            .unwrap();
+        // Pixel at (3, 1) belongs to tile (1, 0); the OS still shouts
+        // "everything changed".
+        data[16 + 3 * 4] = 255;
+        let dirty = t
+            .verify_damage(&frame(data, 4, 4, 16), &[FULL_4X4])
+            .unwrap();
+        assert_eq!(dirty, vec![Rect::new(2, 0, 2, 2)]);
+    }
+
+    #[test]
+    fn verify_damage_ignores_padding_byte_changes() {
+        let mut t = FrameDiffDamageTracker::new(2);
+        let mut data = vec![3u8; 4 * 4 * 4];
+        let _ = t
+            .verify_damage(&frame(data.clone(), 4, 4, 16), &[FULL_4X4])
+            .unwrap();
+        for px in data.chunks_exact_mut(4) {
+            px[3] = 0xEE;
+        }
+        assert!(t
+            .verify_damage(&frame(data, 4, 4, 16), &[FULL_4X4])
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn verify_damage_outside_candidates_stays_stale_until_claimed() {
+        let mut t = FrameDiffDamageTracker::new(2);
+        let mut data = vec![0u8; 4 * 4 * 4];
+        let _ = t
+            .verify_damage(&frame(data.clone(), 4, 4, 16), &[FULL_4X4])
+            .unwrap();
+        // Pixel (0, 2) → tile (0, 1) changes, but damage only claims
+        // tile (1, 0): nothing to report this tick…
+        data[2 * 16] = 200;
+        let f = frame(data, 4, 4, 16);
+        assert!(t
+            .verify_damage(&f, &[Rect::new(2, 0, 2, 2)])
+            .unwrap()
+            .is_empty());
+        // …and the unclaimed tile's baseline did not advance, so the
+        // change is reported the moment damage finally covers it, and
+        // exactly once.
+        assert_eq!(
+            t.verify_damage(&f, &[Rect::new(0, 2, 2, 2)]).unwrap(),
+            vec![Rect::new(0, 2, 2, 2)]
+        );
+        assert!(t
+            .verify_damage(&f, &[Rect::new(0, 2, 2, 2)])
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn verify_damage_reports_reverted_content() {
+        let mut t = FrameDiffDamageTracker::new(2);
+        let clean = vec![0u8; 4 * 4 * 4];
+        let mut inked = clean.clone();
+        inked[0] = 255;
+        let _ = t
+            .verify_damage(&frame(clean.clone(), 4, 4, 16), &[FULL_4X4])
+            .unwrap();
+        assert_eq!(
+            t.verify_damage(&frame(inked, 4, 4, 16), &[FULL_4X4])
+                .unwrap()
+                .len(),
+            1
+        );
+        // Reverting to the original content is a change from the
+        // last-verified state and must repaint.
+        assert_eq!(
+            t.verify_damage(&frame(clean, 4, 4, 16), &[FULL_4X4])
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn verify_damage_geometry_change_rebaselines() {
+        let mut t = FrameDiffDamageTracker::new(2);
+        let _ = t
+            .verify_damage(&frame(vec![0; 4 * 4 * 4], 4, 4, 16), &[FULL_4X4])
+            .unwrap();
+        // New geometry: trust pass again, then verified.
+        let f6 = frame(vec![0; 6 * 4 * 4], 6, 4, 24);
+        let full6 = Rect::new(0, 0, 6, 4);
+        assert_eq!(t.verify_damage(&f6, &[full6]).unwrap().len(), 6);
+        assert!(t.verify_damage(&f6, &[full6]).unwrap().is_empty());
+    }
+
+    #[test]
+    fn verify_damage_empty_candidates_report_nothing() {
+        let mut t = FrameDiffDamageTracker::new(2);
+        let f = frame(vec![1; 4 * 4 * 4], 4, 4, 16);
+        assert!(t.verify_damage(&f, &[]).unwrap().is_empty());
+        assert!(t.verify_damage(&f, &[]).unwrap().is_empty());
+    }
+
+    #[test]
+    fn verify_and_full_diff_share_one_baseline() {
+        let mut t = FrameDiffDamageTracker::new(2);
+        let f = frame(vec![3; 4 * 4 * 4], 4, 4, 16);
+        // A full diff establishes the baseline…
+        assert_eq!(t.diff_frame(&f).unwrap().len(), 4);
+        // …so verification needs no trust pass of its own…
+        assert!(t.verify_damage(&f, &[FULL_4X4]).unwrap().is_empty());
+        // …and per-frame mode mixing (the macOS per-frame degrade
+        // path) keeps one coherent baseline in both directions.
+        assert!(t.diff_frame(&f).unwrap().is_empty());
     }
 }

--- a/crates/intendant-display/src/capture/x11_damage.rs
+++ b/crates/intendant-display/src/capture/x11_damage.rs
@@ -15,6 +15,23 @@
 //! many tile re-encodes per frame — that decision is empirical and
 //! belongs to the integration slice, not D-1.
 //!
+//! ## These rects are candidates, not truth
+//!
+//! Under a compositing WM (GNOME Shell/Mutter, KWin, …) root-window
+//! damage fires on compositor *repaints*, not pixel change: observed
+//! live (2026-08-02, GNOME X11), an on-screen clock repainting
+//! pixel-identical content reported an up-to-full-root bounding box
+//! about once a second, and any small real change did the same —
+//! trusted as dirt, that flooded the tile lane with full-screen deltas
+//! and flapped the tile↔video fallback policy. Even without a
+//! compositor, one BoundingBox event merges two distant small damages
+//! into a near-full-screen box, and RawRectangles would not fix the
+//! repaint-without-change class. The tile consumers therefore
+//! pixel-verify every reported rect
+//! ([`super::frame_diff::FrameDiffDamageTracker::verify_damage`])
+//! before it becomes tile dirt; this backend stays a cheap *where to
+//! look* signal.
+//!
 //! ## Why this connection is independent of the XShm capture connection
 //!
 //! XDamage subscriptions are per-X11-connection. Sharing a connection

--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -1404,8 +1404,17 @@ fn all_tile_ids(grid: &tile::grid::TileGrid) -> Vec<tile::grid::TileId> {
 /// diff runs, so a change landing on a skipped frame is caught by the
 /// next diff.
 ///
-/// Rect mode (in-frame dirty rects or OS damage events): the collected
-/// rects are returned as reported.
+/// Rect mode (in-frame dirty rects or OS damage events): platform
+/// damage metadata says where to *look*, never what changed — OS
+/// damage over-reports by design, and under a compositing WM
+/// root-window XDamage degenerates to full-root bounding boxes over
+/// pixel-identical content (see
+/// [`capture::frame_diff::FrameDiffDamageTracker::verify_damage`]).
+/// The collected rects are pixel-verified against the tracker's tile
+/// baseline; only tiles that really changed survive. Verification
+/// errors fail open to the rects as reported: over-encoding is
+/// recoverable, a dropped real change would stay stale until the
+/// periodic snapshot.
 ///
 /// `tracker_slot` round-trips the tracker through the blocking task
 /// (moved in, moved back out). A cancelled/panicked task loses it; the
@@ -1442,6 +1451,33 @@ async fn resolve_tile_tick_damage(
             }
             Err(e) => {
                 eprintln!("{log_prefix} display {display_id} frame-diff task failed: {e}");
+            }
+        }
+    } else if !collected.is_empty() {
+        let tracker = tracker_slot.take().unwrap_or_else(|| {
+            capture::frame_diff::FrameDiffDamageTracker::new(TILE_STREAM_TILE_SIZE_PX)
+        });
+        let verify_result = tokio::task::spawn_blocking({
+            let frame = Arc::clone(frame);
+            let candidates = collected.clone();
+            move || {
+                let mut tracker = tracker;
+                let verified = tracker.verify_damage(&frame, &candidates);
+                (tracker, verified)
+            }
+        })
+        .await;
+        match verify_result {
+            Ok((tracker, Ok(verified))) => {
+                *tracker_slot = Some(tracker);
+                collected = verified;
+            }
+            Ok((tracker, Err(e))) => {
+                *tracker_slot = Some(tracker);
+                eprintln!("{log_prefix} display {display_id} damage verify failed: {e}");
+            }
+            Err(e) => {
+                eprintln!("{log_prefix} display {display_id} damage verify task failed: {e}");
             }
         }
     }
@@ -4723,6 +4759,86 @@ mod tests {
         let counters = Arc::new(DisplayMetricsCounters::new());
         counters.peer_count.store(1, Ordering::Relaxed);
         (peers, tile_subscribers, tile_gauge, counters, peer)
+    }
+
+    fn diff_test_frame(w: u32, h: u32, data: Vec<u8>) -> Arc<Frame> {
+        Arc::new(Frame {
+            data,
+            format: FrameFormat::Bgra,
+            width: w,
+            height: h,
+            stride: w * 4,
+            timestamp: Instant::now(),
+            dirty_rects: None,
+        })
+    }
+
+    /// The live X11 phantom-dirt shape: under a compositing WM the root
+    /// window's XDamage fires on *repaints*, not pixel changes — GNOME
+    /// Shell's clock actor repainting identical pixels reports a huge
+    /// (up to full-root) bounding box every second. Damage rects are
+    /// candidates, not truth: the tile path must pixel-verify them, so
+    /// an identical frame verifies to zero dirt, a pad-byte-only frame
+    /// (undefined BGRX byte 3) verifies to zero dirt, and a small real
+    /// change verifies to its own tiles' fraction — never 1.0.
+    #[tokio::test]
+    async fn os_damage_rects_are_pixel_verified_before_tile_dirt() {
+        let w = 256u32;
+        let h = 128u32; // 4×2 tiles at 64px → 8 total
+        let full = capture::damage::Rect::new(0, 0, w, h);
+        let grid = tile::grid::TileGrid::new(w, h, TILE_STREAM_TILE_SIZE_PX).expect("grid");
+        let mut tracker = Some(capture::frame_diff::FrameDiffDamageTracker::new(
+            TILE_STREAM_TILE_SIZE_PX,
+        ));
+        let fraction =
+            |rects: &Vec<capture::damage::Rect>| grid.dirty_fraction(grid.dirty_tiles(rects).len());
+        let base = vec![0x40u8; (w * h * 4) as usize];
+
+        // Tick 1: no baseline exists yet, so the reported damage is
+        // trusted once while the baseline is established.
+        let f0 = diff_test_frame(w, h, base.clone());
+        let _ = resolve_tile_tick_damage(&f0, vec![full], false, &mut tracker, 0, "[test]").await;
+
+        // Pixel-identical frame + full-screen damage report → no dirt.
+        let f1 = diff_test_frame(w, h, base.clone());
+        let out = resolve_tile_tick_damage(&f1, vec![full], false, &mut tracker, 0, "[test]").await;
+        assert_eq!(
+            fraction(&out),
+            0.0,
+            "phantom full-screen damage over identical pixels must verify to zero dirt"
+        );
+
+        // Identical except every pixel's pad byte → still no dirt.
+        let mut padded = base.clone();
+        for px in padded.chunks_exact_mut(4) {
+            px[3] = 0x77;
+        }
+        let f2 = diff_test_frame(w, h, padded);
+        let out = resolve_tile_tick_damage(&f2, vec![full], false, &mut tracker, 0, "[test]").await;
+        assert_eq!(
+            fraction(&out),
+            0.0,
+            "pad-byte-only differences must verify to zero dirt"
+        );
+
+        // One 8×8 region really changed (inside tile (1, 0)) while the
+        // OS still over-reports full-screen damage → exactly that
+        // tile's fraction, never 1.0.
+        let mut changed = base.clone();
+        for y in 10..18usize {
+            for x in 70..78usize {
+                changed[(y * w as usize + x) * 4] = 0xFF;
+            }
+        }
+        let f3 = diff_test_frame(w, h, changed);
+        let out = resolve_tile_tick_damage(&f3, vec![full], false, &mut tracker, 0, "[test]").await;
+        let dirty = grid.dirty_tiles(&out);
+        assert_eq!(
+            dirty.into_iter().collect::<Vec<_>>(),
+            vec![tile::grid::TileId::new(1, 0)],
+            "a small real change must verify to exactly its owning tile"
+        );
+        assert!((fraction(&out) - 1.0 / 8.0).abs() < f32::EPSILON);
     }
 
     #[tokio::test]

--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -1391,6 +1391,63 @@ fn all_tile_ids(grid: &tile::grid::TileGrid) -> Vec<tile::grid::TileId> {
     out
 }
 
+/// Resolve the final dirty rects for one allowed delta tick from the
+/// damage collected since the last tick. Shared by the WebRTC tile
+/// bridge and the socket tile stream so both lanes make identical
+/// dirt decisions.
+///
+/// Frame-diff mode (`uses_frame_diff` — the platforms without a
+/// per-frame damage source): hash every tile of the frame against the
+/// tracker's baseline. This walks the whole frame, so it runs on the
+/// blocking pool, never inline on the runtime, and only on allowed
+/// ticks. Skipping frames is safe: the baseline only advances when a
+/// diff runs, so a change landing on a skipped frame is caught by the
+/// next diff.
+///
+/// Rect mode (in-frame dirty rects or OS damage events): the collected
+/// rects are returned as reported.
+///
+/// `tracker_slot` round-trips the tracker through the blocking task
+/// (moved in, moved back out). A cancelled/panicked task loses it; the
+/// replacement re-baselines on the next tick.
+async fn resolve_tile_tick_damage(
+    frame: &Arc<Frame>,
+    mut collected: Vec<capture::damage::Rect>,
+    uses_frame_diff: bool,
+    tracker_slot: &mut Option<capture::frame_diff::FrameDiffDamageTracker>,
+    display_id: u32,
+    log_prefix: &'static str,
+) -> Vec<capture::damage::Rect> {
+    if uses_frame_diff {
+        let tracker = tracker_slot.take().unwrap_or_else(|| {
+            capture::frame_diff::FrameDiffDamageTracker::new(TILE_STREAM_TILE_SIZE_PX)
+        });
+        let diff_result = tokio::task::spawn_blocking({
+            let frame = Arc::clone(frame);
+            move || {
+                let mut tracker = tracker;
+                let rects = tracker.diff_frame(&frame);
+                (tracker, rects)
+            }
+        })
+        .await;
+        match diff_result {
+            Ok((tracker, Ok(diff_rects))) => {
+                *tracker_slot = Some(tracker);
+                collected.extend(diff_rects);
+            }
+            Ok((tracker, Err(e))) => {
+                *tracker_slot = Some(tracker);
+                eprintln!("{log_prefix} display {display_id} frame-diff failed: {e}");
+            }
+            Err(e) => {
+                eprintln!("{log_prefix} display {display_id} frame-diff task failed: {e}");
+            }
+        }
+    }
+    collected
+}
+
 fn encode_tile_records(
     frame: &Frame,
     tiles: Vec<tile::grid::TileId>,
@@ -3370,55 +3427,15 @@ impl DisplaySession {
                         }
                         last_delta_tick_at = Some(now);
 
-                        let mut rects = std::mem::take(&mut pending_rects);
-
-                        // Frame-diff fallback (macOS/Windows/Wayland —
-                        // the platforms without an OS damage source):
-                        // hash every tile of the frame and diff against
-                        // the previous baseline. This walks the whole
-                        // frame, so it runs on the blocking pool, never
-                        // inline on the runtime, and only on allowed
-                        // ticks. Skipping frames is safe: the baseline
-                        // only advances when a diff runs, so a change
-                        // landing on a skipped frame is caught by the
-                        // next diff.
-                        if uses_frame_diff {
-                            let tracker = frame_diff.take().unwrap_or_else(|| {
-                                capture::frame_diff::FrameDiffDamageTracker::new(
-                                    TILE_STREAM_TILE_SIZE_PX,
-                                )
-                            });
-                            let diff_result = tokio::task::spawn_blocking({
-                                let frame = Arc::clone(&frame);
-                                move || {
-                                    let mut tracker = tracker;
-                                    let rects = tracker.diff_frame(&frame);
-                                    (tracker, rects)
-                                }
-                            })
-                            .await;
-                            match diff_result {
-                                Ok((tracker, Ok(diff_rects))) => {
-                                    frame_diff = Some(tracker);
-                                    rects.extend(diff_rects);
-                                }
-                                Ok((tracker, Err(e))) => {
-                                    frame_diff = Some(tracker);
-                                    eprintln!(
-                                        "[display/tile] display {display_id} frame-diff failed: {e}"
-                                    );
-                                }
-                                Err(e) => {
-                                    // Tracker lost with the cancelled/
-                                    // panicked task; the replacement
-                                    // re-baselines (all tiles dirty) on
-                                    // the next allowed tick.
-                                    eprintln!(
-                                        "[display/tile] display {display_id} frame-diff task failed: {e}"
-                                    );
-                                }
-                            }
-                        }
+                        let mut rects = resolve_tile_tick_damage(
+                            &frame,
+                            std::mem::take(&mut pending_rects),
+                            uses_frame_diff,
+                            &mut frame_diff,
+                            display_id,
+                            "[display/tile]",
+                        )
+                        .await;
 
                         let policy_dirty = next_grid.dirty_tiles(&rects);
                         let dirty_fraction = next_grid.dirty_fraction(policy_dirty.len());

--- a/crates/intendant-display/src/tile_socket.rs
+++ b/crates/intendant-display/src/tile_socket.rs
@@ -205,38 +205,15 @@ impl DisplaySession {
                 }
                 last_delta_tick_at = Some(now);
 
-                let mut rects = std::mem::take(&mut pending_rects);
-                if uses_frame_diff {
-                    let tracker = frame_diff.take().unwrap_or_else(|| {
-                        capture::frame_diff::FrameDiffDamageTracker::new(TILE_STREAM_TILE_SIZE_PX)
-                    });
-                    let diff_result = tokio::task::spawn_blocking({
-                        let frame = Arc::clone(&frame);
-                        move || {
-                            let mut tracker = tracker;
-                            let rects = tracker.diff_frame(&frame);
-                            (tracker, rects)
-                        }
-                    })
-                    .await;
-                    match diff_result {
-                        Ok((tracker, Ok(diff_rects))) => {
-                            frame_diff = Some(tracker);
-                            rects.extend(diff_rects);
-                        }
-                        Ok((tracker, Err(e))) => {
-                            frame_diff = Some(tracker);
-                            eprintln!(
-                                "[display/tile-socket] display {display_id} frame-diff failed: {e}"
-                            );
-                        }
-                        Err(e) => {
-                            eprintln!(
-                                "[display/tile-socket] display {display_id} frame-diff task failed: {e}"
-                            );
-                        }
-                    }
-                }
+                let rects = crate::resolve_tile_tick_damage(
+                    &frame,
+                    std::mem::take(&mut pending_rects),
+                    uses_frame_diff,
+                    &mut frame_diff,
+                    display_id,
+                    "[display/tile-socket]",
+                )
+                .await;
 
                 if rects.is_empty() {
                     continue;

--- a/docs/src/display-pipeline.md
+++ b/docs/src/display-pipeline.md
@@ -330,21 +330,33 @@ per-tile staleness check.
 ### Tiles, damage, and fallback
 
 - **Tiles** are **64×64 px** (`TILE_STREAM_TILE_SIZE_PX`).
-- **Damage** comes from platform metadata when possible. On **X11**, XDamage
-  (`crates/intendant-display/src/capture/x11_damage.rs`) reports real OS-level
-  dirty rects
-  (`ReportLevel::BoundingBox`). On **macOS**, ScreenCaptureKit dirty rect
+- **Damage** comes from platform metadata when possible — as *candidates*,
+  not truth. On **X11**, XDamage
+  (`crates/intendant-display/src/capture/x11_damage.rs`) reports OS-level
+  dirty rects (`ReportLevel::BoundingBox`); under a compositing WM these
+  degenerate badly — the compositor repaints (and XDamage fires on repaints,
+  not pixel change), so a GNOME Shell clock tick reports an up-to-full-root
+  bounding box every second over pixel-identical content. On **macOS**,
+  ScreenCaptureKit dirty rect
   extraction is **on by default** (`INTENDANT_MACOS_SCK_DIRTY_RECTS=0` is the
   opt-out escape hatch): frames carry SCK's native dirty rects, a frame whose
   sample lacks the attachment ships a conservative full-frame rect (the
   Chromium missing-attachment rule), and the composited cursor
   (`shows_cursor(true)`) is content change inside the same pipeline that mints
-  the rects — so the X11 hardware-cursor hazard does not transfer. Other paths
-  use a CPU-bound **frame-diff fallback**
+  the rects — so the X11 hardware-cursor hazard does not transfer. Reported
+  rects are therefore **pixel-verified** before they become tile dirt
+  (`FrameDiffDamageTracker::verify_damage`): only tiles inside the rects whose
+  content hash actually changed since the tracker last saw them survive, so a
+  repaint of identical pixels produces zero dirty tiles (and cannot flap the
+  video-fallback policy below). Platforms without per-frame damage metadata
+  use the CPU-bound **frame-diff fallback**
   (`crates/intendant-display/src/capture/frame_diff.rs`) that hashes every
   tile and emits the ones whose hash changed. A damage backend reporting
   `DamageCapability::None` means no platform damage metadata is active; the
-  bridge still runs that CPU frame-diff fallback.
+  bridge still runs that CPU frame-diff fallback. In every mode the hash
+  skips byte 3 of each pixel — alpha on alpha-carrying sources, *undefined
+  padding* on 24-bit-depth X11 BGRX captures — so pad-byte noise can't mint
+  phantom dirt either.
 - **Tile ↔ video fallback policy**
   (`crates/intendant-display/src/tile/policy.rs`) switches to
   whole-frame video on high-motion content and back to tiles when motion subsides,


### PR DESCRIPTION
## Problem

On a live X11 GNOME desktop, federated viewing was unusable: the daemon logged full-screen tile dirt (`tile=dirty ... 1.000`) alternating with 0.000, `fallback_to_video dirty_fraction=1.000` immediately followed by `fallback_to_tile dirty_fraction=0.000`, ~6.6 Mbps of phantom tile deltas plus snapshot bursts, tile-delta backpressure flapping, and a viewer rendering 0 fps at ~7 Mbps received. Ground truth captures of the same screen were pixel-identical (or 0.7% changed with one small terminal ticking).

## Root cause

The tile lanes trusted OS damage rects as dirt. Under a compositing WM, root-window XDamage fires on compositor repaints, not pixel change: a shell clock repainting pixel-identical content reports an up-to-full-root `BoundingBox` about once a second, and any small real change does the same. Each trusted event became a full-grid delta (at 1920x1080 with 64px tiles, 510/510 tiles = fraction 1.000 -- the observed `1r/510t/1.000` shape) and drove the tile/video policy into permanent flapping. A second latent hazard in the same path: the tile hash folded byte 3 of every pixel, which on 24-bit-depth X11 BGRX captures is undefined padding the server may vary between captures of identical content.

(The suspected per-event dirty-fraction denominator defect does not exist in this tree: every fraction is `dirty_tiles / TileGrid::total_tiles()` with the grid built from frame dimensions at `TILE_STREAM_TILE_SIZE_PX = 64` -- pinned by `grid.rs` tests and now also by the new resolver test, which asserts a small change verifies to exactly its owning tile's fraction, never 1.0.)

## Fix

- Damage metadata now says where to look, never what changed: the shared `resolve_tile_tick_damage` helper (extracted from the WebRTC bridge and socket tile lanes, which had duplicated the logic) pixel-verifies collected rects through `FrameDiffDamageTracker::verify_damage` -- only tiles inside the reported rects whose content hash actually changed survive. First tick after construction/geometry change trusts the rects once while establishing the full baseline (dropping them would strand real changes until the periodic snapshot); verification errors fail open to the rects as reported.
- The tile hash now masks byte 3 of each packed pixel (alpha on alpha-carrying sources, undefined padding on BGRX) via an explicit little-endian word mask, in both frame-diff and verification modes.
- Docs updated where they asserted the old trust model (`DamageCapability::OsLevel`, `x11_damage.rs`, `docs/src/display-pipeline.md`).

Thresholds in `tile/policy.rs` are untouched.

## Tests

Failing-first (both reproduced the live symptom before the fix, verified in a pre-fix run):
- `os_damage_rects_are_pixel_verified_before_tile_dirt` -- frame sequence through the resolution path with full-screen damage reports: identical frame -> fraction 0.0 (failed pre-fix with `left: 1.0`), pad-byte-only frame -> 0.0, one 8x8 changed region -> exactly its owning tile (fraction 1/8, never 1.0).
- `padding_byte_only_change_yields_no_dirty_rects` -- pad-byte flip minted 4/4 dirty tiles pre-fix.

Plus 8 unit tests on `verify_damage`: trust-once baseline establishment, phantom pruning, real-change confirmation inside over-reported rects, unclaimed-tile staleness until claimed, revert repaints, geometry-change rebaseline, empty candidates, and frame-diff/verify baseline coherence.

Battery: `cargo test -p intendant --bins`, lib-crate suite (core/custody/display/platform/owner-plane), headless e2e (synthetic display path, 47/47), `cargo clippy --workspace -- -D warnings`, `cargo fmt --check` -- all green.