### PR TITLE
Windows install-flow hardening: window-vanish fix, cert auto-import, tokened-URL auto-open

### DIFF
--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -46,6 +46,19 @@ stopping to name the command for you to run. Rust and the native build
 dependencies follow the same law via the per-OS setup scripts from the
 cloned tree.
 
+The install ends concretely, not silently: once the daemon reports ready, the
+installer prints the dashboard's tokened loopback owner URL (`intendant ctl
+dashboard-url` reprints it any time; the token rotates each boot) and opens it
+in a browser where a GUI opener exists. On Windows, `install.ps1` additionally
+imports the generated access certificates into the user's certificate stores
+(the root import asks for consent; a declined dialog costs only browser mTLS —
+the tokened URL still works), puts the binaries on the user PATH, and creates
+Desktop/Start-menu shortcuts that start the daemon when needed and open the
+fresh tokened dashboard, preferring an Edge app-mode window. Failures pause on
+screen instead of closing the window, and without `-Service` the daemon runs
+in its own console window — closing that window stops it, and nothing
+restarts it at logon.
+
 For reproducibility, pin the tag instead of `latest`:
 `…/releases/download/v0.1.0/install.sh`. Release assets are immutable, and a
 stamped installer double-checks itself: it prints its release identity
@@ -77,10 +90,10 @@ Pick your rung of the trust ladder honestly:
 `https://intendant.dev/install.sh` survives only as a **non-canonical**
 convenience: it answers with a redirect (HTTP 302) to the release asset and
 never a script body — script against the GitHub URL, not the pretty one.
-While no `v*` release has been published yet (the current state of this
-alpha), the asset URL 404s; until the first release, clone and build from
-source — the [prerequisites and build steps below](#prerequisites) are
-exactly what the installer automates.
+The first `v*` releases are published, so the asset URLs above resolve;
+cloning and building from source stays fully supported — the
+[prerequisites and build steps below](#prerequisites) are exactly what the
+installer automates.
 
 What happens next is the whole story in four steps:
 
@@ -741,7 +754,14 @@ To be explicit about the default, pass `--mtls`:
 
 `--mtls` verifies browser/client certificates against the installed Intendant
 access CA (`ca.crt`) unless `--mtls-ca` or `[server.mtls] ca` overrides it.
-Clients without the installed client identity cannot complete the TLS handshake.
+Client authentication is *optional at the TLS layer* (`OptionalCa`): a client
+without the installed identity still completes the handshake, but dashboard
+authority outside a direct loopback connection is refused without a verified
+client certificate. The one certless owner lane is deliberate and local — a
+direct loopback request presenting the daemon's per-boot admission token.
+`intendant ctl dashboard-url` prints that URL
+(`https://127.0.0.1:<port>/?token=…`), the install scripts open it at the end
+of a fresh install, and the token rotates every daemon boot.
 If access certs are missing, startup fails closed with setup guidance. Use
 `--no-tls` only when you intentionally want plain HTTP for local/programmatic
 debugging. Prefer `--no-tls --bind 127.0.0.1`; wildcard plaintext refuses

--- a/docs/src/windows-support.md
+++ b/docs/src/windows-support.md
@@ -294,7 +294,10 @@ than a panic or silent no-op.
   the same pure-Rust CA/server/client generation and owner-IAM seeding as Unix,
   then prints exact PowerShell commands to import the CA into
   `Cert:\CurrentUser\Root` and the client identity into
-  `Cert:\CurrentUser\My`; it does not start a server. `serve-certs` returns an
+  `Cert:\CurrentUser\My`; it does not start a server. `install.ps1` runs those
+  imports automatically at the end of a fresh install (the root import shows
+  Windows' consent dialog; declining costs only browser mTLS — the tokened
+  loopback URL still grants the local dashboard). `serve-certs` returns an
   explicit unsupported/manual-import error. Remote phone/browser enrollment
   can be run from a macOS/Linux anchor. A generic HTTPS reverse proxy is not an
   authentication substitute: if it terminates into daemon loopback it becomes

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -24,6 +24,17 @@
     scripts/setup-windows.ps1 from the cloned repo -- run automatically
     when this shell is elevated, otherwise checked and reported.
 
+    The install finishes concretely: it generates the per-user dashboard
+    access certificates and imports them into this user's certificate
+    stores (CurrentUser\Root + CurrentUser\My; Windows asks for
+    confirmation on the root import), adds the binaries to the user
+    PATH, creates Desktop and Start-menu shortcuts that open the
+    dashboard (starting the daemon first when needed), prints a success
+    block with the tokened dashboard URL, and opens that URL in the
+    default browser. Without -Service the daemon runs in its own console
+    window: closing that window stops it, and nothing restarts it at
+    logon -- -Service installs the Task Scheduler entry that does.
+
 .PARAMETER Connect
     Rendezvous URL to register with for discovery. Default: the
     INTENDANT_CONNECT_RENDEZVOUS_URL environment variable, else none
@@ -79,7 +90,20 @@ $InstallerReleaseTag = ""
 $InstallerReleaseCommit = ""
 
 function Say([string]$Message) { Write-Host "[intendant install] $Message" -ForegroundColor White }
-function Fail([string]$Message) { Write-Host "[intendant install] $Message" -ForegroundColor Red; exit 1 }
+function Fail([string]$Message) {
+    Write-Host "[intendant install] $Message" -ForegroundColor Red
+    # Keep the failure on screen: when this console exists only for the
+    # install, ending the script would take the diagnostics with it.
+    if (-not [Console]::IsInputRedirected) {
+        Read-Host "Press Enter to close" | Out-Null
+    }
+    # throw, never `exit`: the documented one-liner runs this script as a
+    # scriptblock inside the user's own PowerShell session, where `exit`
+    # terminates that whole session -- the window vanishes with every
+    # line of output. A terminating error stops the install and leaves
+    # the session (and the transcript) alive.
+    throw "intendant install failed: $Message"
+}
 
 # -- Identity banner --
 # Say what this copy IS before doing anything else.
@@ -216,6 +240,165 @@ cargo build --release --locked
 if ($LASTEXITCODE -ne 0) { Fail "cargo build failed" }
 $daemonExe = Join-Path $InstallDir "target\release\intendant.exe"
 
+# -- Dashboard access certs + Windows certificate-store import --
+# The dashboard defaults to mTLS. Generate the per-user access material
+# now (setup is idempotent -- existing material is kept, never
+# regenerated) and then actually run the CurrentUser imports that
+# `intendant access setup` prints as copy/paste commands, instead of
+# leaving them as homework. Every step degrades softly: the dashboard
+# stays fully reachable certless from this machine through the per-boot
+# tokened loopback URL, so a declined root-trust dialog or a missing pki
+# module costs browser mTLS enrollment, never the install.
+Say "generating dashboard access certificates (intendant access setup)"
+& $daemonExe access setup
+if ($LASTEXITCODE -ne 0) {
+    Say "note: access setup did not complete -- continuing; the tokened loopback URL still grants this machine's dashboard. Re-run '$daemonExe' access setup later for browser mTLS enrollment."
+} else {
+    # Same resolution as the daemon's Windows access backend
+    # (src/bin/caller/access/backend.rs: dirs::data_dir()/intendant/access-certs).
+    $certDir = Join-Path ([Environment]::GetFolderPath("ApplicationData")) "intendant\access-certs"
+    $caPath = Join-Path $certDir "ca.crt"
+    $p12Path = Join-Path $certDir "client.p12"
+    $passPath = Join-Path $certDir "p12_password"
+    $pkiReady = (Get-Command Import-Certificate -ErrorAction SilentlyContinue) -and
+        (Get-Command Import-PfxCertificate -ErrorAction SilentlyContinue)
+    if ((Test-Path $caPath) -and (Test-Path $p12Path) -and (Test-Path $passPath) -and $pkiReady) {
+        try {
+            $caCert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($caPath)
+            if (Test-Path ("Cert:\CurrentUser\Root\" + $caCert.Thumbprint)) {
+                Say "access CA already trusted by this user -- skipping the root import"
+            } else {
+                Say "importing the access CA into Cert:\CurrentUser\Root -- Windows will ask you to confirm trusting it"
+                Import-Certificate -FilePath $caPath -CertStoreLocation "Cert:\CurrentUser\Root" | Out-Null
+            }
+            $pfxPassword = ConvertTo-SecureString -String ((Get-Content -Raw -LiteralPath $passPath).Trim()) -AsPlainText -Force
+            Import-PfxCertificate -FilePath $p12Path -CertStoreLocation "Cert:\CurrentUser\My" -Password $pfxPassword | Out-Null
+            Remove-Variable pfxPassword
+            Say "browser client identity imported (Cert:\CurrentUser\My) -- restart Edge/Chrome before relying on mTLS"
+        } catch {
+            Say "note: certificate import did not complete ($($_.Exception.Message)). The tokened loopback URL still works; 'intendant access setup' re-prints the manual import commands."
+        }
+    } else {
+        Say "note: skipping the certificate-store import (generated material or the pki module is unavailable); 'intendant access setup' prints the manual commands."
+    }
+}
+
+# -- User PATH --
+# install.sh symlinks the binaries into ~/.local/bin; the Windows twin
+# appends the release directory to the *user* PATH (no elevation needed,
+# and in-place rebuilds keep working). The current session gets it too.
+$releaseDir = Join-Path $InstallDir "target\release"
+$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if (-not $userPath) { $userPath = "" }
+$alreadyOnPath = $false
+foreach ($entry in ($userPath -split ";")) {
+    if ($entry.TrimEnd("\") -ieq $releaseDir.TrimEnd("\")) { $alreadyOnPath = $true; break }
+}
+if ($alreadyOnPath) {
+    Say "user PATH already carries $releaseDir"
+} else {
+    [Environment]::SetEnvironmentVariable("Path", ($userPath.TrimEnd(";") + ";" + $releaseDir).TrimStart(";"), "User")
+    Say "added $releaseDir to the user PATH -- new terminals can run plain: intendant"
+}
+if (($env:Path -split ";") -notcontains $releaseDir) { $env:Path = $env:Path + ";" + $releaseDir }
+
+# -- Launcher + shortcuts --
+# The dashboard URL carries a per-boot admission token, so a shortcut
+# frozen at install time would go stale at the first daemon restart. The
+# Desktop / Start-menu shortcuts instead run a small generated launcher:
+# it (re)starts the daemon when nothing is listening, reads the fresh
+# tokened URL via `ctl dashboard-url`, and prefers an Edge app-mode
+# window for an installed-app feel (default browser otherwise).
+$launcherDir = Join-Path $env:LOCALAPPDATA "Intendant"
+New-Item -ItemType Directory -Force -Path $launcherDir | Out-Null
+$launcherPath = Join-Path $launcherDir "launch-intendant.ps1"
+$connectBake = ""
+if ($Connect) {
+    $connectBake = "`$env:INTENDANT_CONNECT_RENDEZVOUS_URL = '" + ($Connect -replace "'", "''") + "'"
+    if ($DaemonId) {
+        $connectBake = $connectBake + [Environment]::NewLine +
+            "`$env:INTENDANT_CONNECT_DAEMON_ID = '" + ($DaemonId -replace "'", "''") + "'"
+    }
+}
+$launcher = @'
+# Generated by install.ps1. Opens the Intendant dashboard, starting the
+# daemon first when it is not already running. The dashboard URL carries
+# a per-boot loopback admission token, so it is read fresh on every
+# click (intendant ctl dashboard-url) and never stored in this file.
+$exe = '__DAEMON_EXE__'
+__CONNECT_ENV__
+function Get-DashboardUrl {
+    $line = (& $exe ctl dashboard-url 2>$null | Select-Object -First 1)
+    if ($LASTEXITCODE -ne 0 -or -not $line) { return $null }
+    $url = "$line".Trim()
+    # The token sidecar can outlive a dead daemon (reboot, power loss):
+    # trust the URL only when its port actually accepts connections.
+    $port = 8765
+    if ($url -match ':(\d+)/') { $port = [int]$Matches[1] }
+    $client = New-Object System.Net.Sockets.TcpClient
+    try {
+        if ($client.ConnectAsync("127.0.0.1", $port).Wait(1500) -and $client.Connected) { return $url }
+        return $null
+    } catch {
+        return $null
+    } finally {
+        $client.Close()
+    }
+}
+$url = Get-DashboardUrl
+if (-not $url) {
+    Write-Host "Starting the Intendant daemon -- its logs live in the window this opens; closing that window stops it."
+    Start-Process -FilePath $exe -ArgumentList '--no-tui' -WorkingDirectory '__INSTALL_DIR__'
+    foreach ($i in 1..60) {
+        Start-Sleep -Seconds 2
+        $url = Get-DashboardUrl
+        if ($url) { break }
+    }
+}
+if (-not $url) {
+    Write-Host "The dashboard did not come up in time. Check the daemon window, then run: intendant ctl dashboard-url" -ForegroundColor Red
+    if (-not [Console]::IsInputRedirected) { Read-Host "Press Enter to close" | Out-Null }
+    return
+}
+$edgeExe = $null
+$edgeCmd = Get-Command msedge.exe -ErrorAction SilentlyContinue
+if ($edgeCmd) { $edgeExe = $edgeCmd.Source }
+if (-not $edgeExe) {
+    foreach ($root in @(${env:ProgramFiles(x86)}, $env:ProgramFiles, $env:LOCALAPPDATA)) {
+        if (-not $root) { continue }
+        $candidate = Join-Path $root "Microsoft\Edge\Application\msedge.exe"
+        if (Test-Path $candidate) { $edgeExe = $candidate; break }
+    }
+}
+if ($edgeExe) {
+    Start-Process -FilePath $edgeExe -ArgumentList ('--app=' + $url)
+} else {
+    Start-Process $url
+}
+'@
+$launcher = $launcher.Replace("__DAEMON_EXE__", ($daemonExe -replace "'", "''"))
+$launcher = $launcher.Replace("__INSTALL_DIR__", ($InstallDir -replace "'", "''"))
+$launcher = $launcher.Replace("__CONNECT_ENV__", $connectBake)
+Set-Content -LiteralPath $launcherPath -Value $launcher -Encoding ASCII
+
+function New-DashboardShortcut([string]$LnkPath) {
+    $shell = New-Object -ComObject WScript.Shell
+    $lnk = $shell.CreateShortcut($LnkPath)
+    $lnk.TargetPath = "powershell.exe"
+    $lnk.Arguments = "-NoProfile -ExecutionPolicy Bypass -File `"$launcherPath`""
+    $lnk.WorkingDirectory = $launcherDir
+    $lnk.Description = "Open the Intendant dashboard (starts the daemon when needed)"
+    $lnk.IconLocation = "$daemonExe,0"
+    $lnk.Save()
+}
+try {
+    New-DashboardShortcut (Join-Path ([Environment]::GetFolderPath("Desktop")) "Intendant.lnk")
+    New-DashboardShortcut (Join-Path ([Environment]::GetFolderPath("Programs")) "Intendant.lnk")
+    Say "created Desktop and Start-menu shortcuts: Intendant"
+} catch {
+    Say "note: shortcut creation failed ($($_.Exception.Message)) -- run the launcher directly: $launcherPath"
+}
+
 # -- Launch --
 $daemonArgs = @("--no-tui")
 if ($Connect) {
@@ -239,11 +422,95 @@ if ($Service) {
     $installArgs += $daemonArgs
     & $daemonExe @installArgs
     if ($LASTEXITCODE -ne 0) { Fail "service install failed" }
-} elseif ($NoRun) {
-    Say "done. Start it with:"
-    Say "  `"$daemonExe`" $($daemonArgs -join ' ')"
+} elseif (-not $NoRun) {
+    # The daemon gets its own console window: this installer window stays
+    # free to wait for readiness and report the outcome, and under the
+    # one-liner the user's own session survives both. Start-Process
+    # children inherit the INTENDANT_CONNECT_* env set above.
+    Say "starting the daemon in its own window -- its one-time Connect code links discovery only and grants no access. Establish owner through this machine's local console or direct mTLS."
+    Start-Process -FilePath $daemonExe -ArgumentList $daemonArgs -WorkingDirectory $InstallDir
+}
+
+# -- Readiness + tokened dashboard URL --
+# `ctl dashboard-url` prints this boot's loopback owner URL
+# (https://127.0.0.1:<port>/?token=...) once the gateway is up: certless
+# and local-only by design, with the token rotating every daemon boot.
+function Get-TokenedDashboardUrl {
+    # Shield the probe: under $ErrorActionPreference = "Stop", Windows
+    # PowerShell 5.1 can escalate redirected native stderr (the expected
+    # "daemon not up yet" noise) into a terminating error.
+    $prevEap = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        $line = (& $daemonExe ctl dashboard-url 2>$null | Select-Object -First 1)
+        if ($LASTEXITCODE -eq 0 -and $line) { return "$line".Trim() }
+        return $null
+    } catch {
+        return $null
+    } finally {
+        $ErrorActionPreference = $prevEap
+    }
+}
+$dashUrl = $null
+if (-not $NoRun) {
+    Say "waiting for the dashboard to come up..."
+    foreach ($i in 1..60) {
+        Start-Sleep -Seconds 2
+        $dashUrl = Get-TokenedDashboardUrl
+        if ($dashUrl) { break }
+    }
+    if (-not $dashUrl) {
+        Say "note: the dashboard did not report ready within 120s -- check the daemon window (or the service log above); print the URL any time with: intendant ctl dashboard-url"
+    }
+}
+
+# -- Done --
+$stateRoot = Join-Path $HOME ".intendant"
+Write-Host ""
+Write-Host "============================================================"
+Write-Host "  Intendant is installed"
+Write-Host "============================================================"
+Write-Host "  Checkout:   $InstallDir"
+Write-Host "  Binary:     $daemonExe"
+Write-Host "              (new terminals can run plain: intendant)"
+Write-Host "  Shortcuts:  Desktop + Start menu -- 'Intendant' starts the"
+Write-Host "              daemon when needed and opens the dashboard"
+if ($dashUrl) {
+    Write-Host "  Dashboard:  $dashUrl"
+    Write-Host "              (this machine's owner URL; its token rotates each"
+    Write-Host "              daemon boot -- reprint with: intendant ctl dashboard-url)"
+}
+if ($Service) {
+    if ($NoRun) {
+        Write-Host "  Daemon:     Task Scheduler entry installed, not started (-NoRun);"
+        Write-Host "              it starts at the next $(if ($elevated) { "boot" } else { "logon" }). Status: intendant service status"
+    } else {
+        Write-Host "  Daemon:     running under Task Scheduler and restarting on"
+        Write-Host "              failure (claim code / logs: the line printed above)"
+    }
+    Write-Host "  Logs:       the service log named above; session logs under"
+    Write-Host "              $stateRoot\logs"
 } else {
-    Say "starting the daemon -- its one-time Connect code links discovery only and grants no access. Establish owner through this machine's local console or direct mTLS."
-    & $daemonExe @daemonArgs
-    exit $LASTEXITCODE
+    if ($NoRun) {
+        Write-Host "  Daemon:     not started (-NoRun). Start it with the desktop"
+        Write-Host "              shortcut, or: `"$daemonExe`" $($daemonArgs -join ' ')"
+    } else {
+        Write-Host "  Daemon:     running in its own console window. Closing that"
+        Write-Host "              window stops it; nothing restarts it at logon."
+        Write-Host "              Always-on instead:  intendant service install --now"
+        Write-Host "              (unelevated = logon task, elevated = at-boot service)"
+    }
+    Write-Host "  Logs:       the daemon window; session logs under"
+    Write-Host "              $stateRoot\logs"
+}
+Write-Host "============================================================"
+Write-Host ""
+
+if ($dashUrl) {
+    Say "opening the dashboard in your default browser..."
+    try {
+        Start-Process $dashUrl
+    } catch {
+        Say "note: no browser could be opened here -- open the Dashboard URL above yourself."
+    }
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -260,8 +260,7 @@ if ($LASTEXITCODE -ne 0) {
     $caPath = Join-Path $certDir "ca.crt"
     $p12Path = Join-Path $certDir "client.p12"
     $passPath = Join-Path $certDir "p12_password"
-    $pkiReady = (Get-Command Import-Certificate -ErrorAction SilentlyContinue) -and
-        (Get-Command Import-PfxCertificate -ErrorAction SilentlyContinue)
+    $pkiReady = ((Get-Command Import-Certificate -ErrorAction SilentlyContinue) -and (Get-Command Import-PfxCertificate -ErrorAction SilentlyContinue))
     if ((Test-Path $caPath) -and (Test-Path $p12Path) -and (Test-Path $passPath) -and $pkiReady) {
         try {
             $caCert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($caPath)
@@ -316,8 +315,7 @@ $connectBake = ""
 if ($Connect) {
     $connectBake = "`$env:INTENDANT_CONNECT_RENDEZVOUS_URL = '" + ($Connect -replace "'", "''") + "'"
     if ($DaemonId) {
-        $connectBake = $connectBake + [Environment]::NewLine +
-            "`$env:INTENDANT_CONNECT_DAEMON_ID = '" + ($DaemonId -replace "'", "''") + "'"
+        $connectBake = $connectBake + [Environment]::NewLine + "`$env:INTENDANT_CONNECT_DAEMON_ID = '" + ($DaemonId -replace "'", "''") + "'"
     }
 }
 $launcher = @'
@@ -328,9 +326,12 @@ $launcher = @'
 $exe = '__DAEMON_EXE__'
 __CONNECT_ENV__
 function Get-DashboardUrl {
-    $line = (& $exe ctl dashboard-url 2>$null | Select-Object -First 1)
-    if ($LASTEXITCODE -ne 0 -or -not $line) { return $null }
-    $url = "$line".Trim()
+    # Collect all output (it is one line) instead of piping into
+    # Select-Object -First: an early pipeline stop can kill the probe
+    # before it exits and leave $LASTEXITCODE stale.
+    $out = @(& $exe ctl dashboard-url 2>$null)
+    if ($LASTEXITCODE -ne 0 -or $out.Count -eq 0 -or -not $out[0]) { return $null }
+    $url = "$($out[0])".Trim()
     # The token sidecar can outlive a dead daemon (reboot, power loss):
     # trust the URL only when its port actually accepts connections.
     $port = 8765
@@ -442,8 +443,10 @@ function Get-TokenedDashboardUrl {
     $prevEap = $ErrorActionPreference
     $ErrorActionPreference = "Continue"
     try {
-        $line = (& $daemonExe ctl dashboard-url 2>$null | Select-Object -First 1)
-        if ($LASTEXITCODE -eq 0 -and $line) { return "$line".Trim() }
+        # @(...) instead of `| Select-Object -First 1`: an early pipeline
+        # stop can kill the probe mid-run and leave $LASTEXITCODE stale.
+        $out = @(& $daemonExe ctl dashboard-url 2>$null)
+        if ($LASTEXITCODE -eq 0 -and $out.Count -gt 0 -and $out[0]) { return "$($out[0])".Trim() }
         return $null
     } catch {
         return $null

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -261,6 +261,33 @@ else
   say "note: no --connect rendezvous URL — the daemon will not publish a discovery route (its local dashboard still works)."
 fi
 
+# Auto-open the dashboard once the daemon reports ready (install.ps1
+# twin). `ctl dashboard-url` prints this boot's tokened loopback owner
+# URL — certless, local-only, token rotating each boot — so the first
+# dashboard needs no certificate enrollment. Backgrounded because the
+# launches below `exec`; a subshell survives that. Only attempted where
+# a GUI opener exists: a headless SSH box skips it silently, and the
+# URL is reprintable any time with `intendant ctl dashboard-url`.
+spawn_dashboard_opener() {
+  OPENER=""
+  if command -v open >/dev/null 2>&1; then OPENER="open"
+  elif command -v xdg-open >/dev/null 2>&1; then OPENER="xdg-open"
+  else return 0; fi
+  (
+    tries=0
+    while [ "$tries" -lt 60 ]; do
+      sleep 2
+      URL="$("$INSTALL_DIR/target/release/intendant" ctl dashboard-url 2>/dev/null || true)"
+      if [ -n "$URL" ]; then
+        say "dashboard ready: $URL (token rotates each boot; reprint with: intendant ctl dashboard-url)"
+        "$OPENER" "$URL" >/dev/null 2>&1 || true
+        exit 0
+      fi
+      tries=$((tries + 1))
+    done
+  ) &
+}
+
 if [ "$SERVICE" = "1" ]; then
   # A daemon on a rented box must outlive this SSH session and restart
   # on failure. The binary itself picks the platform's supervisor
@@ -268,12 +295,14 @@ if [ "$SERVICE" = "1" ]; then
   # where the one-time claim code lands. The INTENDANT_CONNECT_* exports above
   # are captured into the service definition.
   if [ "$RUN" = "1" ]; then
+    spawn_dashboard_opener
     exec "$INSTALL_DIR/target/release/intendant" service install --now -- "$@"
   else
     exec "$INSTALL_DIR/target/release/intendant" service install -- "$@"
   fi
 elif [ "$RUN" = "1" ]; then
   say "starting the daemon — its one-time Connect code links discovery only and grants no access. Establish owner through this machine's local console or direct mTLS."
+  spawn_dashboard_opener
   exec "$INSTALL_DIR/target/release/intendant" "$@"
 else
   say "done. Start it with:"

--- a/scripts/validate-connect-hosted-mvp.cjs
+++ b/scripts/validate-connect-hosted-mvp.cjs
@@ -321,7 +321,7 @@ async function main() {
     }, daemonLogs);
 
     await waitFor(
-      () => daemonLogs.join('').includes(`Dashboard: https://0.0.0.0:${options.daemonPort}`),
+      () => daemonLogs.join('').includes(`Dashboard: https://127.0.0.1:${options.daemonPort}`),
       START_TIMEOUT_MS,
       'daemon web startup'
     );

--- a/scripts/validate-connect-rendezvous.cjs
+++ b/scripts/validate-connect-rendezvous.cjs
@@ -1475,7 +1475,7 @@ async function main() {
 
   let browser;
   try {
-    await waitFor(() => daemonLogs.join('').includes(`Dashboard: https://0.0.0.0:${options.daemonPort}`), START_TIMEOUT_MS, 'daemon web startup');
+    await waitFor(() => daemonLogs.join('').includes(`Dashboard: https://127.0.0.1:${options.daemonPort}`), START_TIMEOUT_MS, 'daemon web startup');
     const daemonNoAuthStatus = await httpStatus(`http://127.0.0.1:${options.rendezvousPort}/api/daemon/next?daemon_id=${encodeURIComponent(options.daemonId)}&timeout_ms=1`);
     assert.strictEqual(daemonNoAuthStatus, 401, `/api/daemon/next without bearer returned ${daemonNoAuthStatus}`);
     const registeredStatus = await waitFor(async () => {

--- a/src/bin/caller/startup/web.rs
+++ b/src/bin/caller/startup/web.rs
@@ -218,9 +218,21 @@ pub(crate) fn build_web_tls_acceptor(
                 })?;
                 match provisioned {
                     Some(cert_dir) => {
+                        // serve-certs (the strict HTTPS enrollment server) is
+                        // Unix-only; the Windows enrollment lane is the
+                        // CurrentUser cert-store import whose exact commands
+                        // `intendant access setup` (re)prints — pointing a
+                        // Windows first boot at serve-certs is a dead end.
+                        let enroll_hint = if cfg!(windows) {
+                            "enroll this user's browser with the PowerShell import \
+                             commands `intendant access setup` prints (serve-certs \
+                             is Unix-only)"
+                        } else {
+                            "enroll a browser with `intendant access serve-certs`"
+                        };
                         eprintln!(
                             "[access] first boot: generated dashboard access certificates \
-                             in {} — enroll a browser with `intendant access serve-certs`; \
+                             in {} — {enroll_hint}; \
                              the Connect claim flow is discovery-only",
                             cert_dir.display()
                         );
@@ -464,9 +476,14 @@ pub(crate) fn dashboard_display_url(
 
 pub(crate) fn dashboard_display_host(web_bind: Option<IpAddr>) -> String {
     match web_bind {
-        Some(IpAddr::V4(ip)) => ip.to_string(),
-        Some(IpAddr::V6(ip)) => format!("[{ip}]"),
-        None => "0.0.0.0".to_string(),
+        Some(IpAddr::V4(ip)) if !ip.is_unspecified() => ip.to_string(),
+        Some(IpAddr::V6(ip)) if !ip.is_unspecified() => format!("[{ip}]"),
+        // A wildcard bind (the default) listens on every interface, but
+        // "https://0.0.0.0:8765" is not a URL a browser opens — print the
+        // loopback form that actually works from the daemon's own machine.
+        // Display-only: the bind address itself is resolved elsewhere.
+        Some(IpAddr::V6(_)) => "[::1]".to_string(),
+        Some(IpAddr::V4(_)) | None => "127.0.0.1".to_string(),
     }
 }
 
@@ -619,6 +636,32 @@ mod tests {
         assert_ne!(port2, 0);
         assert_ne!(port2, port);
         drop((listener, listener2));
+    }
+
+    #[test]
+    fn dashboard_display_host_prints_pasteable_loopback_for_wildcard_binds() {
+        // The default bind is wildcard: the printed Dashboard URL must be
+        // one a browser on this machine can open, and "https://0.0.0.0"
+        // is not. Explicit interface binds keep printing their address.
+        assert_eq!(dashboard_display_host(None), "127.0.0.1");
+        assert_eq!(
+            dashboard_display_host(Some("0.0.0.0".parse().unwrap())),
+            "127.0.0.1"
+        );
+        assert_eq!(dashboard_display_host(Some("::".parse().unwrap())), "[::1]");
+        assert_eq!(
+            dashboard_display_host(Some("192.168.1.5".parse().unwrap())),
+            "192.168.1.5"
+        );
+        assert_eq!(
+            dashboard_display_host(Some("fd00::5".parse().unwrap())),
+            "[fd00::5]"
+        );
+        let no_tls: Option<tokio_rustls::TlsAcceptor> = None;
+        assert_eq!(
+            dashboard_display_url(&no_tls, 8765, None),
+            "http://127.0.0.1:8765"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Owner Windows-e2e finding 2: after the "machine I'm on now" install, the terminal vanished with all output, there were no next steps, and the dashboard looked "broken" without certs. Agenda card `01KZ7ZWKF05Y0HF8BV6R2135Q8`, items 1-9.

**install.ps1** (the bulk):
1. **Window-vanish fix** — `Fail()` used `exit 1` and the run tail `exit $LASTEXITCODE`; under the documented one-liner the script is a scriptblock in the user's own session, so `exit` closed the window and wiped every diagnostic. Failures now pause (`Read-Host`, skipped when input is redirected) and `throw`; the success path never exits the session.
2. **End-of-run success block** — checkout, binary, shortcuts, the tokened dashboard URL, per-mode daemon status, log paths, restart/always-on instructions.
3. **Auto-open after readiness** — polls `intendant ctl dashboard-url` (up to 120s), then `Start-Process` on the tokened loopback owner URL. install.sh gets the twin (backgrounded poll + `open`/`xdg-open` where a GUI opener exists; survives the `exec`).
4. **Cert auto-import** — runs `intendant access setup` (idempotent) and then executes the CurrentUser imports setup previously printed as homework: CA → `Cert:\CurrentUser\Root` (thumbprint pre-check so the consent dialog fires once), `client.p12` + `p12_password` → `Cert:\CurrentUser\My`. Every step soft-fails to the tokened loopback lane.
5. **User PATH + Desktop/Start-menu shortcuts**.
6. **Persistence stated honestly** — the laptop default stays foreground (now in its own console window, so the installer window and one-liner session survive); the success block says plainly that closing that window stops the daemon and nothing restarts it at logon, and names `intendant service install --now` (unelevated = logon task, elevated = at-boot) for always-on.
8. **Edge app-mode** — the shortcuts run a generated launcher (`%LOCALAPPDATA%\Intendant\launch-intendant.ps1`) that re-reads the fresh per-boot token via `ctl dashboard-url` on every click (a static URL would go stale), TCP-probes the port (the token sidecar can outlive a dead daemon across reboots), starts the daemon when nothing listens, and prefers `msedge --app=`; falls back to the default browser.

**Rust + docs** (following commits): platform-aware first-boot hint (no `serve-certs` on Windows), `127.0.0.1` instead of `0.0.0.0` in the printed dashboard URL, and the getting-started.md:744 doc-lag fix (certless clients *do* complete the handshake — client auth is `OptionalCa`; the loopback token lane is the certless owner path).

## Ships when

**install.ps1 / install.sh are release assets** — the canonical copies are stamped and attached per tag, so this fix reaches users at the **next `v*` tag**, not on merge. (The repo copies are the unstamped source.)

## Constraints honored

- install.ps1 stays **pure ASCII** (release.yml strict-decodes it at stamp time; Windows PowerShell 5.1 BOM-less ANSI pin) and PS 5.1-safe (no ternaries/null-coalescing; native-stderr redirection shielded under `$ErrorActionPreference = "Stop"`).
- PSScriptAnalyzer unavailable on this box (no pwsh) — careful line-by-line review instead, per the card.