### PR TITLE
Dashboard: stale loopback-token honesty banner, unfueled-probe re-arm, sign-in pre-flight

### DIFF
--- a/src/bin/caller/external_agent/mod.rs
+++ b/src/bin/caller/external_agent/mod.rs
@@ -2880,6 +2880,28 @@ mod tests {
         }
     }
 
+    /// The sign-in cards' machine pre-flight consumes GET
+    /// /api/external-agents (`backend_availability_json` above): a
+    /// backend the daemon reports `installed: false` renders as the
+    /// muted not-installed card whose copy names the CLI looked for,
+    /// instead of a Start button that can only fail after the click.
+    /// Pin the SPA wiring by needle (the artifact-scan pattern).
+    #[test]
+    fn spa_signin_cards_preflight_missing_clis() {
+        let app = include_str!("../../../../static/app.html");
+        for needle in [
+            "function agentSigninMissingAvailability",
+            "installed === false",
+            "agent-signin-missing",
+            "was not found on the daemon host",
+        ] {
+            assert!(
+                app.contains(needle),
+                "the dashboard bundle lost the sign-in not-installed pre-flight: {needle}"
+            );
+        }
+    }
+
     #[test]
     fn canonical_thread_ids_match_backend_capabilities() {
         assert!(AgentBackend::Codex.thread_id_is_canonical("019e37cf-34ad-7b08-8a1e-7ad5086eb39f"));

--- a/src/bin/caller/loopback_token.rs
+++ b/src/bin/caller/loopback_token.rs
@@ -387,6 +387,36 @@ mod tests {
         assert!(message.contains("trust-architecture.md"));
     }
 
+    /// The dashboard's stale-token honesty surface: the served bundle
+    /// detects this refusal by a marker in its error text and raises a
+    /// named banner pointing at `intendant ctl dashboard-url`, so the
+    /// server copy and the SPA needle must not drift apart (the
+    /// `spa_offers_reload_on_boot_id_change` artifact-scan pattern).
+    #[test]
+    fn spa_surfaces_the_stale_token_refusal() {
+        let marker = "per-boot admission token";
+        assert!(
+            refusal_error_message().contains(marker),
+            "the refusal copy lost the marker the dashboard detects"
+        );
+        let app = include_str!("../../../static/app.html");
+        for needle in [
+            // The detection marker, at the shared fetch chokepoint…
+            "LOOPBACK_STALE_TOKEN_MARKER = 'per-boot admission token'",
+            "function observeOwnerLaneApiOutcome",
+            // …the banner element with its actionable reopen copy…
+            "ui-loopback-token-banner",
+            "intendant ctl dashboard-url",
+            // …and the lane-recovery re-arm of the empty-state probe.
+            "function noteOwnerLaneApiSuccess",
+        ] {
+            assert!(
+                app.contains(needle),
+                "the dashboard bundle lost the stale-token banner wiring: {needle}"
+            );
+        }
+    }
+
     #[test]
     fn tokened_url_targets_loopback_and_carries_the_token() {
         let url = tokened_dashboard_url("https", 8765);

--- a/static/app.html
+++ b/static/app.html
@@ -873,11 +873,12 @@ html {
   vertical-align: middle;
 }
 
-/* Stale-build / daemon-boot reload nudges + event-lane staleness banner:
-   slim fixed strips at the top of the viewport, above everything, never
-   blocking. */
+/* Stale-build / daemon-boot reload nudges + event-lane staleness and
+   stale-admission-token banners: slim fixed strips at the top of the
+   viewport, above everything, never blocking. */
 #ui-stale-build-banner,
 #ui-daemon-boot-banner,
+#ui-loopback-token-banner,
 #ui-event-lane-banner {
   position: fixed;
   top: 8px;
@@ -896,7 +897,8 @@ html {
   box-shadow: 0 4px 18px rgba(0, 0, 0, 0.35);
 }
 #ui-stale-build-banner button,
-#ui-daemon-boot-banner button {
+#ui-daemon-boot-banner button,
+#ui-loopback-token-banner button {
   border: 1px solid var(--blue);
   background: transparent;
   color: var(--blue);
@@ -905,8 +907,13 @@ html {
   font-size: 12px;
   cursor: pointer;
 }
-#ui-event-lane-banner {
+#ui-event-lane-banner,
+#ui-loopback-token-banner {
   border-color: var(--yellow, #f9e2af);
+}
+#ui-loopback-token-banner code {
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 11.5px;
 }
 /* ── static/app/11-styles-access-files.css ── */
 /* ── Access redesign components (.acc-*) ──
@@ -17955,6 +17962,12 @@ html.ui-v2 #agent-signin-section {
 html.ui-v2 #agent-signin-section .agent-signin + .agent-signin {
   border-top: 1px solid var(--line);
   padding-top: 18px;
+}
+/* Not-installed pre-flight: the card stays visible but reads muted —
+   its copy names the CLI the daemon looked for, and nothing renders to
+   click until it exists. */
+html.ui-v2 #agent-signin-section .agent-signin.agent-signin-missing {
+  opacity: .55;
 }
 html.ui-v2 #agent-signin-section .vault-card {
   border: 0;
@@ -38975,7 +38988,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'c1e4676e0471e66e';
+const INTENDANT_APP_BUILD = 'd8455c38ebdcf84c';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -39081,6 +39094,10 @@ window.qa = Object.assign(window.qa || {}, {
   buildInfo: () => ({ build: INTENDANT_APP_BUILD, nudged: staleBuildNudged }),
   bootInfo: () => ({ bootId: daemonBootId, nudged: daemonBootNudged }),
   tabId: () => INTENDANT_TAB_ID,
+  loopbackLaneInfo: () => ({
+    staleTokenNudged: loopbackTokenStaleNudged,
+    failStreak: ownerLaneApiFailStreak,
+  }),
   __testNudgeStaleBuild: (v) => maybeNudgeStaleBuild(v),
   __testNudgeDaemonBoot: (v) => maybeNudgeDaemonBoot(v),
 });
@@ -39192,6 +39209,93 @@ function getLoopbackToken() {
   }
 }
 
+// ── Owner-lane API outcome watch ──
+//
+// Static assets are authority-free, so a tab holding a stale per-boot
+// admission token still loads while every owner-lane /api call bounces
+// off the daemon's NAMED 401 — without a surface the page just looks
+// empty. Every /api HTTP call funnels through the wrapped window.fetch
+// below (the facade's HTTP adapters, authedFetch, and bare call sites
+// alike), so ONE observer there does two honest things:
+//   - the named admission-token refusal raises a once-per-page,
+//     dismissible banner telling the owner how to reopen the tab;
+//   - the first delivered-OK response after a failure streak re-runs
+//     the unfueled empty-state probe, which otherwise retires forever
+//     after its ~40s boot window (recovery cases: the daemon came up
+//     after the probe gave up, or a freshly tokened tab re-seeded this
+//     origin's storage and the stale tab's calls started landing).
+// The marker below must match the server's refusal copy —
+// loopback_token.rs pins both sides.
+const LOOPBACK_STALE_TOKEN_MARKER = 'per-boot admission token';
+let loopbackTokenStaleNudged = false;
+let ownerLaneApiFailStreak = 0;
+
+function maybeShowStaleLoopbackTokenBanner() {
+  if (loopbackTokenStaleNudged) return;
+  loopbackTokenStaleNudged = true;
+  console.warn(
+    '[dashboard] the daemon refused this tab\'s loopback admission token '
+    + '(tokens rotate every daemon boot) — reopen via `intendant ctl dashboard-url`'
+  );
+  const banner = document.createElement('div');
+  banner.id = 'ui-loopback-token-banner';
+  const text = document.createElement('span');
+  text.textContent =
+    'This tab\'s admission token is stale, so the daemon is refusing its API '
+    + 'calls. Reopen the dashboard with ';
+  const cmd = document.createElement('code');
+  cmd.textContent = 'intendant ctl dashboard-url';
+  text.appendChild(cmd);
+  text.appendChild(document.createTextNode(' (or from the app).'));
+  const btn = document.createElement('button');
+  btn.textContent = 'Dismiss';
+  btn.addEventListener('click', () => banner.remove());
+  banner.appendChild(text);
+  banner.appendChild(btn);
+  document.body.appendChild(banner);
+}
+
+function noteOwnerLaneApiFailure() {
+  ownerLaneApiFailStreak += 1;
+}
+
+function noteOwnerLaneApiSuccess() {
+  if (ownerLaneApiFailStreak === 0) return;
+  ownerLaneApiFailStreak = 0;
+  // The lane just proved itself after refusals/outages — re-ask the
+  // empty-state probe, whose own retries may have long expired.
+  refreshUnfueledEmptyState().catch(() => {});
+}
+
+// Never alters the caller's promise: observation only. A delivered
+// non-401 4xx is a per-route verdict on a WORKING lane — neither a
+// failure nor a recovery.
+function observeOwnerLaneApiOutcome(fetchPromise) {
+  fetchPromise.then(resp => {
+    try {
+      if (!resp) return;
+      if (resp.ok) {
+        noteOwnerLaneApiSuccess();
+      } else if (resp.status === 401) {
+        noteOwnerLaneApiFailure();
+        if (!loopbackTokenStaleNudged) {
+          resp.clone().json().then(body => {
+            if (String(body?.error || '').includes(LOOPBACK_STALE_TOKEN_MARKER)) {
+              maybeShowStaleLoopbackTokenBanner();
+            }
+          }).catch(() => {});
+        }
+      } else if (resp.status >= 500) {
+        noteOwnerLaneApiFailure();
+      }
+    } catch {
+      /* observation is best-effort */
+    }
+  }, () => {
+    noteOwnerLaneApiFailure();
+  });
+}
+
 // Attach the loopback token to every same-origin request. Cross-cutting
 // by design — the token is transport admission, not per-call auth — and
 // deliberately installed BEFORE the hosted-control (31b), multihost
@@ -39221,7 +39325,21 @@ function getLoopbackToken() {
     } catch {
       /* malformed input — fall through to the bare call untouched */
     }
-    return bareFetch(input, init);
+    const result = bareFetch(input, init);
+    try {
+      const url =
+        typeof input === 'string' ? input : (input && input.url) || '';
+      const path = url.startsWith(location.origin)
+        ? url.slice(location.origin.length)
+        : url;
+      // Same-origin owner-lane calls only: a fleet daemon's absolute
+      // origin never matches, so ITS refusals cannot raise THIS tab's
+      // banner or count against this lane's streak.
+      if (path.startsWith('/api/')) observeOwnerLaneApiOutcome(result);
+    } catch {
+      /* observation is best-effort; the caller's promise is untouched */
+    }
+    return result;
   };
 })();
 
@@ -44890,9 +45008,12 @@ async function agentSigninStart(provider) {
   const state = agentSigninState[provider];
   if (state.busy) return;
   state.busy = true;
-  state.lastError = '';
-  renderAgentSigninSection();
+  // Everything after the latch runs under one try/finally: a throw
+  // anywhere — the pre-flight render included — must release `busy`,
+  // or the guard above mutes the button for the rest of the page load.
   try {
+    state.lastError = '';
+    renderAgentSigninSection();
     const resp = await daemonApi.request(spec.startMethod, { ...spec.startParams });
     if (resp.ok) {
       state.status = resp.body?.status || state.status;
@@ -44914,9 +45035,11 @@ async function agentSigninSubmitCode(provider, code) {
   const state = agentSigninState[provider];
   if (!spec.codeMethod || state.busy) return;
   state.busy = true;
-  state.lastError = '';
-  renderAgentSigninSection();
+  // Same latch discipline as agentSigninStart: one try/finally spans
+  // everything after busy=true, so no render throw can strand it.
   try {
+    state.lastError = '';
+    renderAgentSigninSection();
     const resp = await daemonApi.request(spec.codeMethod, { code });
     if (resp.ok) {
       if (state.status) state.status.phase = 'verifying';
@@ -45237,6 +45360,23 @@ function agentSigninWatchNotes(status, note) {
   }
 }
 
+/* Pre-flight honesty for the sign-in cards: GET /api/external-agents
+   already reports whether each backend's CLI resolves on the daemon
+   host (`installed`, plus the command it looked for) — consume it so a
+   missing CLI mutes its card with copy naming the binary instead of a
+   Start button that can only fail after the click. `installed === false`
+   is the ONLY muting verdict; unknown availability (probe not landed
+   yet, an older daemon without the field) keeps the card live. The
+   provider's `sessionKind` IS the backend id (AgentBackend::
+   as_short_str — the same vocabulary the availability rows serve). */
+function agentSigninMissingAvailability(spec) {
+  if (!Array.isArray(externalAgentAvailability)) return null;
+  const entry = externalAgentAvailability.find(
+    agent => agent && agent.id === spec.sessionKind
+  );
+  return entry && entry.installed === false ? entry : null;
+}
+
 function renderAgentSigninSection() {
   const mount = document.getElementById('agent-signin-section');
   if (!mount) return;
@@ -45246,6 +45386,15 @@ function renderAgentSigninSection() {
     document.activeElement.matches('input, textarea, select')
   ) {
     return;
+  }
+  // The not-installed pre-flight reads the shared availability probe:
+  // ask once while this page hasn't heard yet, repaint when it lands.
+  // A failed probe resolves null and does NOT re-render, so there is
+  // no fetch/render loop — the next user-driven render retries.
+  if (externalAgentAvailability === null) {
+    refreshExternalAgentAvailability().then(list => {
+      if (Array.isArray(list)) renderAgentSigninSection();
+    });
   }
   mount.innerHTML = '';
   for (const provider of Object.keys(AGENT_SIGNIN_PROVIDERS)) {
@@ -45294,6 +45443,23 @@ function agentSigninProviderCard(provider) {
   }
   if (avail.reason === 'unsupported') {
     note(spec.unsupportedNote);
+    return card;
+  }
+
+  // Machine pre-flight: a backend the daemon reports uninstalled can
+  // only click-then-fail — mute the card and name what was looked for.
+  const missing = agentSigninMissingAvailability(spec);
+  if (missing) {
+    card.classList.add('agent-signin-missing');
+    const chip = document.createElement('span');
+    chip.className = 'vault-chip';
+    chip.textContent = 'not installed';
+    head.appendChild(chip);
+    note(
+      `The ${spec.label} CLI (${missing.command || spec.sessionKind}) ` +
+        'was not found on the daemon host, so there is no account to sign ' +
+        'in yet. Install it on the daemon machine, then sign in from here.'
+    );
     return card;
   }
 

--- a/static/app/10-styles-shell.css
+++ b/static/app/10-styles-shell.css
@@ -797,11 +797,12 @@ html {
   vertical-align: middle;
 }
 
-/* Stale-build / daemon-boot reload nudges + event-lane staleness banner:
-   slim fixed strips at the top of the viewport, above everything, never
-   blocking. */
+/* Stale-build / daemon-boot reload nudges + event-lane staleness and
+   stale-admission-token banners: slim fixed strips at the top of the
+   viewport, above everything, never blocking. */
 #ui-stale-build-banner,
 #ui-daemon-boot-banner,
+#ui-loopback-token-banner,
 #ui-event-lane-banner {
   position: fixed;
   top: 8px;
@@ -820,7 +821,8 @@ html {
   box-shadow: 0 4px 18px rgba(0, 0, 0, 0.35);
 }
 #ui-stale-build-banner button,
-#ui-daemon-boot-banner button {
+#ui-daemon-boot-banner button,
+#ui-loopback-token-banner button {
   border: 1px solid var(--blue);
   background: transparent;
   color: var(--blue);
@@ -829,6 +831,11 @@ html {
   font-size: 12px;
   cursor: pointer;
 }
-#ui-event-lane-banner {
+#ui-event-lane-banner,
+#ui-loopback-token-banner {
   border-color: var(--yellow, #f9e2af);
+}
+#ui-loopback-token-banner code {
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 11.5px;
 }

--- a/static/app/31-init-identity-fleet.js
+++ b/static/app/31-init-identity-fleet.js
@@ -119,6 +119,10 @@ window.qa = Object.assign(window.qa || {}, {
   buildInfo: () => ({ build: INTENDANT_APP_BUILD, nudged: staleBuildNudged }),
   bootInfo: () => ({ bootId: daemonBootId, nudged: daemonBootNudged }),
   tabId: () => INTENDANT_TAB_ID,
+  loopbackLaneInfo: () => ({
+    staleTokenNudged: loopbackTokenStaleNudged,
+    failStreak: ownerLaneApiFailStreak,
+  }),
   __testNudgeStaleBuild: (v) => maybeNudgeStaleBuild(v),
   __testNudgeDaemonBoot: (v) => maybeNudgeDaemonBoot(v),
 });
@@ -230,6 +234,93 @@ function getLoopbackToken() {
   }
 }
 
+// ── Owner-lane API outcome watch ──
+//
+// Static assets are authority-free, so a tab holding a stale per-boot
+// admission token still loads while every owner-lane /api call bounces
+// off the daemon's NAMED 401 — without a surface the page just looks
+// empty. Every /api HTTP call funnels through the wrapped window.fetch
+// below (the facade's HTTP adapters, authedFetch, and bare call sites
+// alike), so ONE observer there does two honest things:
+//   - the named admission-token refusal raises a once-per-page,
+//     dismissible banner telling the owner how to reopen the tab;
+//   - the first delivered-OK response after a failure streak re-runs
+//     the unfueled empty-state probe, which otherwise retires forever
+//     after its ~40s boot window (recovery cases: the daemon came up
+//     after the probe gave up, or a freshly tokened tab re-seeded this
+//     origin's storage and the stale tab's calls started landing).
+// The marker below must match the server's refusal copy —
+// loopback_token.rs pins both sides.
+const LOOPBACK_STALE_TOKEN_MARKER = 'per-boot admission token';
+let loopbackTokenStaleNudged = false;
+let ownerLaneApiFailStreak = 0;
+
+function maybeShowStaleLoopbackTokenBanner() {
+  if (loopbackTokenStaleNudged) return;
+  loopbackTokenStaleNudged = true;
+  console.warn(
+    '[dashboard] the daemon refused this tab\'s loopback admission token '
+    + '(tokens rotate every daemon boot) — reopen via `intendant ctl dashboard-url`'
+  );
+  const banner = document.createElement('div');
+  banner.id = 'ui-loopback-token-banner';
+  const text = document.createElement('span');
+  text.textContent =
+    'This tab\'s admission token is stale, so the daemon is refusing its API '
+    + 'calls. Reopen the dashboard with ';
+  const cmd = document.createElement('code');
+  cmd.textContent = 'intendant ctl dashboard-url';
+  text.appendChild(cmd);
+  text.appendChild(document.createTextNode(' (or from the app).'));
+  const btn = document.createElement('button');
+  btn.textContent = 'Dismiss';
+  btn.addEventListener('click', () => banner.remove());
+  banner.appendChild(text);
+  banner.appendChild(btn);
+  document.body.appendChild(banner);
+}
+
+function noteOwnerLaneApiFailure() {
+  ownerLaneApiFailStreak += 1;
+}
+
+function noteOwnerLaneApiSuccess() {
+  if (ownerLaneApiFailStreak === 0) return;
+  ownerLaneApiFailStreak = 0;
+  // The lane just proved itself after refusals/outages — re-ask the
+  // empty-state probe, whose own retries may have long expired.
+  refreshUnfueledEmptyState().catch(() => {});
+}
+
+// Never alters the caller's promise: observation only. A delivered
+// non-401 4xx is a per-route verdict on a WORKING lane — neither a
+// failure nor a recovery.
+function observeOwnerLaneApiOutcome(fetchPromise) {
+  fetchPromise.then(resp => {
+    try {
+      if (!resp) return;
+      if (resp.ok) {
+        noteOwnerLaneApiSuccess();
+      } else if (resp.status === 401) {
+        noteOwnerLaneApiFailure();
+        if (!loopbackTokenStaleNudged) {
+          resp.clone().json().then(body => {
+            if (String(body?.error || '').includes(LOOPBACK_STALE_TOKEN_MARKER)) {
+              maybeShowStaleLoopbackTokenBanner();
+            }
+          }).catch(() => {});
+        }
+      } else if (resp.status >= 500) {
+        noteOwnerLaneApiFailure();
+      }
+    } catch {
+      /* observation is best-effort */
+    }
+  }, () => {
+    noteOwnerLaneApiFailure();
+  });
+}
+
 // Attach the loopback token to every same-origin request. Cross-cutting
 // by design — the token is transport admission, not per-call auth — and
 // deliberately installed BEFORE the hosted-control (31b), multihost
@@ -259,7 +350,21 @@ function getLoopbackToken() {
     } catch {
       /* malformed input — fall through to the bare call untouched */
     }
-    return bareFetch(input, init);
+    const result = bareFetch(input, init);
+    try {
+      const url =
+        typeof input === 'string' ? input : (input && input.url) || '';
+      const path = url.startsWith(location.origin)
+        ? url.slice(location.origin.length)
+        : url;
+      // Same-origin owner-lane calls only: a fleet daemon's absolute
+      // origin never matches, so ITS refusals cannot raise THIS tab's
+      // banner or count against this lane's streak.
+      if (path.startsWith('/api/')) observeOwnerLaneApiOutcome(result);
+    } catch {
+      /* observation is best-effort; the caller's promise is untouched */
+    }
+    return result;
   };
 })();
 

--- a/static/app/32-vault-custody.js
+++ b/static/app/32-vault-custody.js
@@ -1885,9 +1885,12 @@ async function agentSigninStart(provider) {
   const state = agentSigninState[provider];
   if (state.busy) return;
   state.busy = true;
-  state.lastError = '';
-  renderAgentSigninSection();
+  // Everything after the latch runs under one try/finally: a throw
+  // anywhere — the pre-flight render included — must release `busy`,
+  // or the guard above mutes the button for the rest of the page load.
   try {
+    state.lastError = '';
+    renderAgentSigninSection();
     const resp = await daemonApi.request(spec.startMethod, { ...spec.startParams });
     if (resp.ok) {
       state.status = resp.body?.status || state.status;
@@ -1909,9 +1912,11 @@ async function agentSigninSubmitCode(provider, code) {
   const state = agentSigninState[provider];
   if (!spec.codeMethod || state.busy) return;
   state.busy = true;
-  state.lastError = '';
-  renderAgentSigninSection();
+  // Same latch discipline as agentSigninStart: one try/finally spans
+  // everything after busy=true, so no render throw can strand it.
   try {
+    state.lastError = '';
+    renderAgentSigninSection();
     const resp = await daemonApi.request(spec.codeMethod, { code });
     if (resp.ok) {
       if (state.status) state.status.phase = 'verifying';
@@ -2232,6 +2237,23 @@ function agentSigninWatchNotes(status, note) {
   }
 }
 
+/* Pre-flight honesty for the sign-in cards: GET /api/external-agents
+   already reports whether each backend's CLI resolves on the daemon
+   host (`installed`, plus the command it looked for) — consume it so a
+   missing CLI mutes its card with copy naming the binary instead of a
+   Start button that can only fail after the click. `installed === false`
+   is the ONLY muting verdict; unknown availability (probe not landed
+   yet, an older daemon without the field) keeps the card live. The
+   provider's `sessionKind` IS the backend id (AgentBackend::
+   as_short_str — the same vocabulary the availability rows serve). */
+function agentSigninMissingAvailability(spec) {
+  if (!Array.isArray(externalAgentAvailability)) return null;
+  const entry = externalAgentAvailability.find(
+    agent => agent && agent.id === spec.sessionKind
+  );
+  return entry && entry.installed === false ? entry : null;
+}
+
 function renderAgentSigninSection() {
   const mount = document.getElementById('agent-signin-section');
   if (!mount) return;
@@ -2241,6 +2263,15 @@ function renderAgentSigninSection() {
     document.activeElement.matches('input, textarea, select')
   ) {
     return;
+  }
+  // The not-installed pre-flight reads the shared availability probe:
+  // ask once while this page hasn't heard yet, repaint when it lands.
+  // A failed probe resolves null and does NOT re-render, so there is
+  // no fetch/render loop — the next user-driven render retries.
+  if (externalAgentAvailability === null) {
+    refreshExternalAgentAvailability().then(list => {
+      if (Array.isArray(list)) renderAgentSigninSection();
+    });
   }
   mount.innerHTML = '';
   for (const provider of Object.keys(AGENT_SIGNIN_PROVIDERS)) {
@@ -2289,6 +2320,23 @@ function agentSigninProviderCard(provider) {
   }
   if (avail.reason === 'unsupported') {
     note(spec.unsupportedNote);
+    return card;
+  }
+
+  // Machine pre-flight: a backend the daemon reports uninstalled can
+  // only click-then-fail — mute the card and name what was looked for.
+  const missing = agentSigninMissingAvailability(spec);
+  if (missing) {
+    card.classList.add('agent-signin-missing');
+    const chip = document.createElement('span');
+    chip.className = 'vault-chip';
+    chip.textContent = 'not installed';
+    head.appendChild(chip);
+    note(
+      `The ${spec.label} CLI (${missing.command || spec.sessionKind}) ` +
+        'was not found on the daemon host, so there is no account to sign ' +
+        'in yet. Install it on the daemon machine, then sign in from here.'
+    );
     return card;
   }
 

--- a/static/app/ui2-vault.css
+++ b/static/app/ui2-vault.css
@@ -612,6 +612,12 @@ html.ui-v2 #agent-signin-section .agent-signin + .agent-signin {
   border-top: 1px solid var(--line);
   padding-top: 18px;
 }
+/* Not-installed pre-flight: the card stays visible but reads muted —
+   its copy names the CLI the daemon looked for, and nothing renders to
+   click until it exists. */
+html.ui-v2 #agent-signin-section .agent-signin.agent-signin-missing {
+  opacity: .55;
+}
 html.ui-v2 #agent-signin-section .vault-card {
   border: 0;
   border-radius: 0;


### PR DESCRIPTION
Fixes three quiet-failure classes in the dashboard SPA:

**Stale admission-token honesty.** The per-boot loopback admission token rotates on every daemon boot and seeds only from a `?token=` open, so a long-lived tab silently loses its owner lane: static assets are authority-free, the page loads, and every /api call bounces off the daemon's named 401 with no surface showing it. The wrapped `window.fetch` (the chokepoint every /api HTTP call already funnels through — the daemonApi facade's HTTP adapters, `authedFetch`, and bare call sites alike) now observes owner-lane responses: the named admission-token refusal raises a once-per-page, dismissible banner telling the user to reopen the dashboard via `intendant ctl dashboard-url` (or the app). Detection matches the refusal copy's marker, pinned on both sides by a `loopback_token.rs` test.

**Unfueled-probe re-arm on lane recovery.** The empty-state fueling probe retried 20×2s and then gave up for the rest of the page's life; the only re-trigger was a vault-lease refresh. The same fetch observer now tracks a failure streak (network errors, admission 401s, 5xx — delivered per-route 4xx stay neutral) and the first delivered-OK /api response after a streak re-runs `refreshUnfueledEmptyState`, so a tab that outlived a daemon outage or re-seeded its token heals its empty-state copy instead of keeping stale guidance.

**Sign-in card fixes.** `agentSigninStart` (and its sibling `agentSigninSubmitCode`) ran `renderAgentSigninSection()` between `state.busy = true` and the try block — one render throw stranded the latch and permanently muted the button. Everything after the latch now runs under one try/finally. The provider cards also pre-flight `GET /api/external-agents`: a backend the daemon reports `installed: false` renders a muted not-installed card naming the CLI it looked for, instead of a Start button that can only fail after the click; unknown availability keeps the card live.

Both new surfaces are pinned by artifact needle following the existing `spa_offers_reload_on_boot_id_change` pattern (`spa_surfaces_the_stale_token_refusal` in `loopback_token.rs`, `spa_signin_cards_preflight_missing_clis` in `external_agent/mod.rs`). `static/app.html` regenerated via `app-html-assembler`.