### PR TITLE
vocabulary(handover): grade-1 copy + shared Advanced fold (update-abstraction slice 4)

### DIFF
--- a/docs/src/control-plane-and-daemon.md
+++ b/docs/src/control-plane-and-daemon.md
@@ -443,13 +443,20 @@ successor without kill-and-relaunch:
   `holdouts` (each holding session's id, name, backend, phase, and its
   durable `limit_park` marker with the reset instant), the drainer's
   presence record mirrors a capped row copy beside `session_count`, and
-  the dashboard's drain banner lists WHO holds and until WHEN under a
-  prominent doorway to the successor. Both banner kinds (this daemon
-  draining; a predecessor draining) dock in a strip under the oversight
-  bar — never over the tab chrome — and collapse to a one-line pill
-  persisted per (kind, boot id): an unseen fact expands once, and no
-  dismiss exists while the fact is true, mirroring the update chip's
-  standing-fact pattern. If the successor dies while the
+  the dashboard's drain banner speaks two grades: grade 1 tells the
+  product event plainly ("Updating Intendant — your work continues",
+  a portless "Open the updated dashboard →" doorway, "Waiting for the
+  updated daemon to start…" while no successor serves), while the
+  mechanics — the drain/lease story, the ported doorway, and the WHO
+  holds / until WHEN wait-set rows — live verbatim under a sticky
+  Advanced fold shared by every handover surface. Both banner kinds
+  (this daemon draining; a predecessor draining) dock in a strip under
+  the oversight bar — never over the tab chrome — and collapse to a
+  one-line pill persisted per (kind, boot id): an unseen fact expands
+  once, and no dismiss exists while the fact is true, mirroring the
+  update chip's standing-fact pattern. The drain-entry notification
+  layers the same two grades into its one body — the grade-1 event,
+  then the mechanics sentence after a line break. If the successor dies while the
   drainer still drains, ONE loud notification says standing automations
   are paused until someone relaunches or takes over — the drainer never
   reclaims the lease.
@@ -469,9 +476,13 @@ successor without kill-and-relaunch:
   drainer that exited while the successor was down, or crashed
   mid-drain, is still adjudicated. The summary notification names the
   predecessor, so a handover pickup reads apart from crash recovery.
-  While the predecessor still drains, the successor-side banner names
-  the spared set ("N sessions still finishing there", with the same
-  holdout rows), one section per draining co-homed daemon.
+  While the predecessor still drains, the successor-side banner tells
+  the grade-1 story ("Finishing up (N tasks) on the previous version",
+  counts summed across however many daemons still finish); the
+  mechanics — one section per draining co-homed daemon, its port, and
+  its named holdout rows ("N sessions still finishing there") — sit
+  under the banner's Advanced fold, which shares one sticky open-state
+  key across every handover surface.
 
 `intendant ctl status` shows the whole story under `scheduler_lease`
 (role, drain state, and every co-homed boot with probed liveness).

--- a/macos-app/main.swift
+++ b/macos-app/main.swift
@@ -301,6 +301,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
     var backendSupervisor: BackendSupervisor!
     var port: Int = 8765
     let portSearchLimit = 20
+    /// Q6 (update-abstraction §4.4): while this app supervises a
+    /// single-instance daemon, the port is an implementation detail —
+    /// the window is just "Intendant", including across one-click
+    /// update swaps. The suffix survives only when the app launched
+    /// into a shared-host topology (its preferred port was already
+    /// taken — the manual multi-instance case), where it is
+    /// load-bearing disambiguation between co-homed instances.
+    var sharedHostTopology = false
+
+    func windowTitle(for port: Int) -> String {
+        sharedHostTopology ? "Intendant (port \(port))" : "Intendant"
+    }
     var launchPlan: BackendLaunchPlan!
     var backendSession: URLSession!
     var backendTrustDelegate: BackendTrustDelegate?
@@ -338,6 +350,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
             port = availablePort
             if port != preferredPort {
                 NSLog("Port \(preferredPort) in use — using port \(port)")
+                sharedHostTopology = true
             }
         } else {
             let lastPort = preferredPort + portSearchLimit - 1
@@ -910,7 +923,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
         if let controller = webView?.configuration.userContentController {
             installUserScripts(controller, port: newPort)
         }
-        window?.title = newPort == 8765 ? "Intendant" : "Intendant (port \(newPort))"
+        // Q6: an app-supervised swap never renames the window — the
+        // fresh port is the supervisor's own mechanics. The suffix
+        // stays only for shared-host topologies (set at launch).
+        window?.title = windowTitle(for: newPort)
         if dashboardActive {
             dashboardActive = false
             activateDashboard()
@@ -1020,7 +1036,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
             backing: .buffered,
             defer: false
         )
-        window.title = port == 8765 ? "Intendant" : "Intendant (port \(port))"
+        window.title = windowTitle(for: port)
         window.contentView = webView
         window.minSize = NSSize(width: 600, height: 400)
         // ARC owns the window through `self.window`; the default

--- a/src/bin/caller/handover/mod.rs
+++ b/src/bin/caller/handover/mod.rs
@@ -155,6 +155,18 @@ struct SwapResult {
 /// wrapper is gone or wedged — the chip re-enables instead of spinning.
 const SWAP_REQUEST_TTL_MS: u64 = 90_000;
 
+/// The drain-entry notification's two layers (update-abstraction §4,
+/// Q8 ruling): OS notification surfaces have no Advanced fold, so the
+/// one body carries the grade-1 product event first and the mechanics
+/// sentence after a line break. The grade-1 half is held to the
+/// negative vocabulary law (no ports, boot ids, lease/drain words —
+/// see `grade_one_vocabulary_is_pinned_and_never_names_the_mechanics`);
+/// the mechanics half deliberately is not.
+const DRAIN_NOTIFICATION_GRADE1: &str =
+    "Updating Intendant — sessions are finishing on the previous version";
+const DRAIN_NOTIFICATION_MECHANICS: &str =
+    "standing automations handed off; in-flight sessions finish here, then this daemon exits";
+
 /// Refusals for [`HandoverRuntime::request_update_swap`], each an honest
 /// sentence for the requesting surface.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -760,12 +772,14 @@ impl HandoverRuntime {
         // its zero-session exit waited on the next unrelated bus
         // event). The event also lands on the supervisor's observation
         // lane, which re-evaluates the drain exit condition — covering
-        // zero-sessions-at-entry on both paths.
+        // zero-sessions-at-entry on both paths. Copy is the Q8 layered
+        // one-body shape (update-abstraction §4): OS notification
+        // surfaces have no Advanced fold, so the grade-1 product event
+        // leads and the mechanics sentence follows after a line break.
         self.notify_user(
             "handover-draining",
-            Some("Daemon draining"),
-            "standing automations handed off; in-flight sessions finish here, \
-             then this daemon exits",
+            Some("Updating Intendant"),
+            &format!("{DRAIN_NOTIFICATION_GRADE1}\n{DRAIN_NOTIFICATION_MECHANICS}"),
             crate::types::NotificationUrgency::Attention,
         );
     }
@@ -1148,33 +1162,184 @@ fn write_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
 mod tests {
     use super::*;
 
-    /// Commission pin (drain holdout honesty): the shipped dashboard
-    /// bundle carries the banner wiring — the named wait set, the
-    /// parked-until rendering, the prominent successor doorway, the
-    /// per-predecessor sections, and the tokenless QA hook — so the
-    /// honest banner cannot be silently gutted from the SPA (the HS6
-    /// artifact-scan pattern).
+    /// Commission pin (drain holdout honesty), re-pinned BOTH-GRADE by
+    /// update-abstraction slice 4 (§4.3): the shipped dashboard bundle
+    /// carries the banner wiring in two grades — grade 1's product
+    /// story (plain, portless), and INSIDE the shared Advanced fold
+    /// the verbatim mechanics: the named wait set, the parked-until
+    /// rendering, the ported successor doorway, the per-predecessor
+    /// sections — plus the tokenless QA hook. Source-scan reach, per
+    /// the HS6 artifact-scan pattern: the fold NESTING is the
+    /// fragment's structure (probe-verified in the operator battery);
+    /// this pin keeps either grade's strings and the fold machinery
+    /// from being gutted silently.
     #[test]
     fn spa_carries_the_drain_holdout_banner() {
         let app = include_str!("../../../../static/app.html");
         for needle in [
+            // Structure: the wait set, the doorway class, the wire
+            // read, and the QA hook.
             "handover-holdouts",
             "handover-holdout-list",
             "handover-successor-link",
-            "Open the successor daemon",
             "rate-limit parked until",
             "reset time unknown",
+            "body.holdouts",
+            "qa.handoverBanner",
+            // Grade 1 — the §4.1 product story on both banner kinds.
+            "Updating Intendant — your work continues.",
+            "Waiting for the updated daemon to start…",
+            "Open the updated dashboard →",
+            "on the previous version",
+            "Everything continues here once that work finishes.",
+            // Grade 2 — the mechanics, verbatim, behind the ONE shared
+            // sticky fold key (Q7).
+            "'handover-advanced-open'",
+            "handoverAdvancedFold",
+            "This daemon is draining.",
+            "Open the successor daemon",
             "No successor has acquired the lease yet.",
             "still finishing there",
             "Mid-work sessions it releases are picked up here when it exits.",
-            "body.holdouts",
-            "qa.handoverBanner",
         ] {
             assert!(
                 app.contains(needle),
                 "the dashboard bundle lost the drain-holdout banner wiring: {needle}"
             );
         }
+        // The fold is SHARED: three surfaces (own-drain banner,
+        // predecessor sections, update chip) build it through the one
+        // helper keyed on the one stored choice.
+        let fragment = include_str!("../../../../static/app/ui2-handover.js");
+        assert!(fragment.contains("function handoverAdvancedFold"));
+        assert_eq!(
+            fragment.matches("= handoverAdvancedFold();").count(),
+            3,
+            "banner + predecessor sections + update chip all ride the one shared fold"
+        );
+        assert_eq!(
+            fragment.matches("'handover-advanced-open'").count(),
+            1,
+            "one stored key — the Q7 stance, never per-surface copies"
+        );
+    }
+
+    /// Update-abstraction slice 4, the NEGATIVE grade-1 vocabulary pin
+    /// (intake §4.3): every grade-1 string — across the banner, the
+    /// predecessor story, the update chip, the follow/completion lines,
+    /// the held-by chips, and the drain notification's grade-1 lead —
+    /// is present in its owning surface AND matches none of the
+    /// mechanics class `/(port\s|:\d{4}|boot[_ ]id|lease|drain|
+    /// predecessor|successor)/i`. Grep-terminating: mechanics leaking
+    /// into grade 1 fails here mechanically, whatever the wording.
+    /// (Template needles pin the static copy; their interpolations are
+    /// task counts and the plural 's' only. The sibling-lane error
+    /// toasts in 54-session-lifecycle deliberately stay out: they name
+    /// the port for actionability — slice-3's ruled error-lane copy,
+    /// not grade-1 narration.)
+    #[test]
+    fn grade_one_vocabulary_is_pinned_and_never_names_the_mechanics() {
+        let handover = include_str!("../../../../static/app/ui2-handover.js");
+        let windows = include_str!("../../../../static/app/39-session-windows.js");
+        let cards = include_str!("../../../../static/app/57a-sessions-list.js");
+        let actions = include_str!("../../../../static/app/41-session-window-actions.js");
+        let cases: &[(&str, &str, &[&str])] = &[
+            (
+                "ui2-handover.js",
+                handover,
+                &[
+                    // Own-drain banner: lead, tails, pill, waiting
+                    // state, portless doorway.
+                    "Updating Intendant — your work continues.",
+                    "Updating Intendant — finishing up (",
+                    ") here, then the updated daemon takes over.",
+                    " Wrapping up here, then the updated daemon takes over.",
+                    "Waiting for the updated daemon to start…",
+                    "Open the updated dashboard →",
+                    // Predecessor story (§5.3, one line for N daemons)
+                    // + the continuation promise.
+                    "Finishing up (",
+                    "on the previous version",
+                    "on the previous daemon",
+                    "Everything continues here once that work finishes.",
+                    // Update chip.
+                    "Update ready",
+                    "A newer build of Intendant is ready to install.",
+                    // Follow + consent (slice 2's grade-1 lines).
+                    "Moving to the updated daemon…",
+                    "Continue on the updated daemon",
+                    "Your composer draft moves with you.",
+                    // Completion honesty (§4.1 app states).
+                    "All set — running ",
+                    "The restart didn't change builds.",
+                    "Moved to the updated daemon.",
+                ],
+            ),
+            (
+                "39-session-windows.js",
+                windows,
+                &[
+                    "finishing on the previous version",
+                    "finishing on the previous daemon",
+                ],
+            ),
+            (
+                "57a-sessions-list.js",
+                cards,
+                &[
+                    "finishing on the previous version",
+                    "finishing on the previous daemon",
+                ],
+            ),
+            (
+                "41-session-window-actions.js",
+                actions,
+                &["Still finishing on the previous version — it continues here when done."],
+            ),
+        ];
+        let banned =
+            regex::Regex::new(r"(?i)(port\s|:\d{4}|boot[_ ]id|lease|drain|predecessor|successor)")
+                .expect("the mechanics class compiles");
+        for (fragment_name, fragment, needles) in cases {
+            for needle in *needles {
+                assert!(
+                    fragment.contains(needle),
+                    "{fragment_name} lost the grade-1 string: {needle}"
+                );
+                assert!(
+                    !banned.is_match(needle),
+                    "grade-1 string names the mechanics ({fragment_name}): {needle}"
+                );
+            }
+        }
+        // The notification's grade-1 lead obeys the same law. (Its
+        // mechanics half is exempt by design — Q8's layered one-body
+        // shape has no fold to hide behind — and is pinned verbatim by
+        // `inline_drain_entry_emits_the_owner_notification`.)
+        assert!(
+            !banned.is_match(DRAIN_NOTIFICATION_GRADE1),
+            "the drain notification's grade-1 lead names the mechanics"
+        );
+        // Q6: the window-title rule — the packaged app is just
+        // "Intendant" while it supervises a single-instance daemon; the
+        // port suffix survives only for shared-host topologies, where
+        // it is load-bearing disambiguation.
+        let app_layer = include_str!("../../../../macos-app/main.swift");
+        for needle in [
+            "var sharedHostTopology = false",
+            "func windowTitle(for port: Int) -> String",
+            "window?.title = windowTitle(for: newPort)",
+            "window.title = windowTitle(for: port)",
+        ] {
+            assert!(
+                app_layer.contains(needle),
+                "the app layer lost the Q6 window-title rule: {needle}"
+            );
+        }
+        assert!(
+            !app_layer.contains("newPort == 8765"),
+            "the swap site must keep the topology rule, not a port special-case"
+        );
     }
 
     /// Update-abstraction slice 1 pin (intake §7, acceptance (a)): the
@@ -1427,10 +1592,34 @@ mod tests {
         let chip = include_str!("../../../../static/app/ui2-handover.js");
         let lane = include_str!("../../../../static/app/ui2-update-lane.js");
         // Both entries exist and their labels carry 'update' — the
-        // palette matches labels only (users type what they see).
+        // palette matches labels first (users type what they see).
         assert!(chrome.contains("label: 'Check for updates'"));
         assert!(chrome.contains("updateChipSurface.paletteEntry"));
         assert!(chrome.contains("window.qa.paletteUpdateActions"));
+        // Slice-4 owner-directed additions: the PURE destination — a
+        // Go-to row that routes to the Daemon update card and fires no
+        // check POST (the wire-shape bans below stay the structural
+        // proof) — and the generic keywords lane, populated once for
+        // the whole update family so the synonyms users actually type
+        // ("release", "hotswap") find these entries.
+        assert!(chrome.contains("label: 'Daemon update'"));
+        assert!(chrome.contains("anchor: 'update-lane-card'"));
+        assert!(chrome.contains("const UI2_UPDATE_KEYWORDS"));
+        for synonym in ["'release'", "'channel'", "'upgrade'", "'hotswap'", "'swap'"] {
+            assert!(
+                chrome.contains(synonym),
+                "the update keyword family lost {synonym}"
+            );
+        }
+        assert_eq!(
+            chrome.matches("keywords: UI2_UPDATE_KEYWORDS").count(),
+            3,
+            "one keyword list, three carriers: destination + check action + dynamic entry"
+        );
+        assert!(
+            chrome.contains("item.keywords.some("),
+            "the palette lost the generic keyword matching lane"
+        );
         // The chip module serves the dynamic entry; its labels state
         // the live arm (install / installing / hand off), and its
         // suppression rule is the chip's own.
@@ -1811,9 +2000,24 @@ mod tests {
         assert_eq!(runtime.request_drain(None), DrainRequest::Entered);
         let mut saw_draining_notification = false;
         while let Ok(event) = events.try_recv() {
-            if let crate::event::AppEvent::UserNotification { id, urgency, .. } = event {
+            if let crate::event::AppEvent::UserNotification {
+                id,
+                title,
+                text,
+                urgency,
+                ..
+            } = event
+            {
                 if id == "handover-draining" {
                     assert_eq!(urgency, crate::types::NotificationUrgency::Attention);
+                    // Q8's layered one-body shape: the grade-1 product
+                    // event leads, the mechanics sentence follows after
+                    // a line break — never one grade without the other.
+                    assert_eq!(title.as_deref(), Some("Updating Intendant"));
+                    let (lead, mechanics) =
+                        text.split_once('\n').expect("the body carries both grades");
+                    assert_eq!(lead, DRAIN_NOTIFICATION_GRADE1);
+                    assert_eq!(mechanics, DRAIN_NOTIFICATION_MECHANICS);
                     saw_draining_notification = true;
                 }
             }

--- a/src/bin/caller/web_gateway/session_catalog/grid_envelope.rs
+++ b/src/bin/caller/web_gateway/session_catalog/grid_envelope.rs
@@ -1124,6 +1124,11 @@ mod tests {
             "/api/local-daemons/tokens",
             "action: 'start_task', task: text, session_id: sid",
             "is gone — this session can't take messages there anymore",
+            // Slice-3 ruling N2, folded into slice 4's re-pin pass: the
+            // unreachable branch's distinctive prefix gets its own
+            // needle — without it that branch alone could vanish while
+            // the shared tail below still matched the gone branch.
+            "Could not reach the previous daemon",
             "continues here when the handover completes",
         ] {
             assert!(

--- a/static/app.html
+++ b/static/app.html
@@ -27902,6 +27902,20 @@ html.ui-v2 .update-lane-advanced > summary {
   font-size: 11px;
   color: var(--muted, #7e8896);
 }
+/* The shared grade-2 fold (update-abstraction §4): mechanics under one
+   sticky "Advanced" disclosure on the banner, the predecessor
+   sections, and the update chip alike. */
+html.ui-v2 .handover-advanced {
+  margin-top: 6px;
+}
+html.ui-v2 .handover-advanced > summary {
+  cursor: pointer;
+  font-size: 11px;
+  color: var(--muted, #7e8896);
+}
+html.ui-v2 .handover-advanced[open] > summary {
+  margin-bottom: 4px;
+}
 html.ui-v2 .update-lane-swap:not(:empty) {
   margin-top: 10px;
   padding: 8px 10px;
@@ -36549,6 +36563,12 @@ const UI2_NAV_GROUPS = [
 
 const UI2_TAB_TITLES = {};
 
+// The update family's palette synonyms — what users type when they mean
+// the update lane without knowing its labels ("release", "hotswap").
+// Rides the generic `keywords` field palette entries may carry; the
+// palette stays a what-you-see label matcher first.
+const UI2_UPDATE_KEYWORDS = ['update', 'release', 'channel', 'upgrade', 'hotswap', 'swap'];
+
 function ui2BuildNav() {
   const groupsHost = document.getElementById('ui2-nav-groups');
   if (!groupsHost) return;
@@ -37229,6 +37249,7 @@ function ui2PaletteActionEntries(q) {
       entries.push({
         section: 'Actions', icon: 'daemon', label: String(served.label),
         inert: served.busy === true,
+        keywords: UI2_UPDATE_KEYWORDS,
         run: () => { try { served.run(); } catch (e) { console.warn('[ui2] update action failed', e); } },
       });
     }
@@ -37237,6 +37258,7 @@ function ui2PaletteActionEntries(q) {
   if (updateLane && typeof updateLane.check === 'function') {
     entries.push({
       section: 'Actions', icon: 'daemon', label: 'Check for updates',
+      keywords: UI2_UPDATE_KEYWORDS,
       run: () => {
         routeTo('access', 'daemons');
         try { updateLane.check(); } catch (e) { console.warn('[ui2] update check failed', e); }
@@ -37264,13 +37286,29 @@ function ui2PaletteEntries(q) {
       entries.push(item);
     }
   }
-  // Label-only matching for labeled entries: users type what they SEE
+  // The update lane's pure destination (owner-directed, 2026-08-04):
+  // goes to the Daemon update card and fires NOTHING — the "Check for
+  // updates" action beside it stays the consent POST. Palette-only (no
+  // nav-rail seat): a Go-to row, not a machine surface of its own.
+  entries.push({
+    label: 'Daemon update', icon: 'daemon',
+    route: ['access', 'daemons'], anchor: 'update-lane-card',
+    keywords: UI2_UPDATE_KEYWORDS,
+  });
+  // Label matching for labeled entries: users type what they SEE
   // (id matching surprised — "sta" surfaced Usage via its internal id).
-  // `matchless` entries carry the query themselves (sessions already
-  // matched; the deep-search verb embeds it).
-  const filtered = entries.filter((item) => !query || item.label.toLowerCase().includes(query));
+  // An entry may also carry an explicit `keywords` alias list — the
+  // deliberate synonyms lane (generic; the update family populates it)
+  // — matched the same substring way. `matchless` entries carry the
+  // query themselves (sessions already matched; the deep-search verb
+  // embeds it).
+  const matchesQuery = (item) => !query
+    || item.label.toLowerCase().includes(query)
+    || (Array.isArray(item.keywords)
+        && item.keywords.some((k) => String(k).toLowerCase().includes(query)));
+  const filtered = entries.filter(matchesQuery);
   const actions = ui2PaletteActionEntries(q)
-    .filter((item) => item.matchless || !query || item.label.toLowerCase().includes(query));
+    .filter((item) => item.matchless || matchesQuery(item));
   // Agenda section (lens destinations + item hits): provided by
   // ui2-agenda-hood.js under this fragment's convention — cross-fragment
   // state is read by name at event time with a typeof guard, so the
@@ -37351,7 +37389,15 @@ function ui2PaletteGo(item) {
     return;
   }
   if (item.tab) routeTo(item.tab);
-  else if (item.route) routeTo(item.route[0], item.route[1]);
+  else if (item.route) {
+    routeTo(item.route[0], item.route[1]);
+    // Destination entries may name an in-pane anchor: pure scroll,
+    // never an action.
+    if (item.anchor) {
+      const anchorEl = document.getElementById(item.anchor);
+      if (anchorEl) anchorEl.scrollIntoView({ block: 'start' });
+    }
+  }
 }
 
 function ui2PaletteOpen() {
@@ -38975,7 +39021,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'c1e4676e0471e66e';
+const INTENDANT_APP_BUILD = '04be4e3a4dd9871c';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -106502,6 +106548,15 @@ async function memoryProposeFromForm(button) {
 //     same-sha rebuild is a real update). The packaged app follows by
 //     itself (didSwapToPort) and relay-reached surfaces get honest copy
 //     instead — port substitution means nothing there.
+// Vocabulary (update-abstraction §4, slice 4): every surface here
+// speaks TWO GRADES. Grade 1, the default, tells the product event in
+// plain words — "Updating Intendant — your work continues." — and
+// never names ports, boot ids, lease state, or drain mechanics (the
+// negative vocabulary pin makes that mechanical). Grade 2 is the full
+// mechanics copy, verbatim, inside a per-surface <details> fold that
+// persists under ONE shared key across the handover surfaces (Q7):
+// open the mechanics once and the banner, the predecessor sections,
+// and the update chip all stay open to them.
 (() => {
   const HANDOVER_POLL_MS = 30000;
   let bannerEl = null;
@@ -106970,9 +107025,11 @@ async function memoryProposeFromForm(button) {
     head.appendChild(collapse);
     el.appendChild(head);
     if (disk) {
-      strong.textContent = 'Update on disk';
+      // Grade 1: the product fact; the commit/built/running provenance
+      // is grade-2 mechanics under the shared fold below.
+      strong.textContent = 'Update ready';
       el.appendChild(document.createTextNode(
-        `commit ${disk.git_sha || '?'} · built ${disk.built_at || '?'} — running ${running.git_sha || '?'}`
+        'A newer build of Intendant is ready to install.'
       ));
       if (update.honesty) {
         const honesty = document.createElement('div');
@@ -107004,6 +107061,16 @@ async function memoryProposeFromForm(button) {
       el.appendChild(pending);
     }
     el.appendChild(handoverUpdateActions(body, disk));
+    // Grade 2 — both builds' provenance, verbatim, inside the shared
+    // fold (the banner's key: mechanics open together everywhere).
+    if (disk) {
+      const fold = handoverAdvancedFold();
+      const mech = document.createElement('div');
+      mech.className = 'handover-update-note';
+      mech.textContent = `commit ${disk.git_sha || '?'} · built ${disk.built_at || '?'} — running ${running.git_sha || '?'}`;
+      fold.appendChild(mech);
+      el.appendChild(fold);
+    }
     // The pill expands into the full update panel: the chip stays the
     // standing fact; channels, checks, and builds live there.
     if (typeof routeTo === 'function') {
@@ -107279,21 +107346,64 @@ async function memoryProposeFromForm(button) {
     return collapse;
   }
 
-  // The predecessor pill's one line, honest about what is known: the
-  // port when there is one predecessor, the summed still-finishing
-  // count only when every predecessor reports one.
-  function bannerPredecessorPill(others) {
+  // ── The two-grade vocabulary (update-abstraction §4, slice 4) ──────
+  // Grade 2 lives inside a <details> fold persisted under ONE shared
+  // key (Q7): "show me the mechanics" is a stance, not a per-surface
+  // choice — the banner, the predecessor sections, and the update chip
+  // all honor it together. (The update panel's Dev-channel fold keeps
+  // its own key: that one selects a channel, it does not disclose
+  // mechanics.)
+  const HANDOVER_ADVANCED_KEY = 'handover-advanced-open';
+  function handoverAdvancedStored() {
+    try { return localStorage.getItem(HANDOVER_ADVANCED_KEY) === '1'; } catch (_) { return false; }
+  }
+  function handoverAdvancedStore(open) {
+    try {
+      if (open) localStorage.setItem(HANDOVER_ADVANCED_KEY, '1');
+      else localStorage.removeItem(HANDOVER_ADVANCED_KEY);
+    } catch (_) { /* storage unavailable — the fold lives for this page only */ }
+  }
+  function handoverAdvancedFold() {
+    const fold = document.createElement('details');
+    fold.className = 'handover-advanced';
+    if (handoverAdvancedStored()) fold.open = true;
+    fold.addEventListener('toggle', () => handoverAdvancedStore(fold.open));
+    const summary = document.createElement('summary');
+    summary.textContent = 'Advanced';
+    fold.appendChild(summary);
+    return fold;
+  }
+
+  function handoverTaskCount(n) {
+    return `${n} task${n === 1 ? '' : 's'}`;
+  }
+
+  // The grade-1 predecessor story (§5.3): N draining siblings fold into
+  // ONE line. The count sums session_count when every sibling reports
+  // one, and stays silent when any does not — never a guessed number.
+  // The version/daemon split is the slice-3 honesty precedent carried
+  // over (R-A1's stamp-pair law: git_sha AND built_at — a same-commit
+  // rebuild is a different build): only when EVERY draining sibling
+  // provably runs this daemon's own build does the story say "the
+  // previous daemon" instead of narrating an update that never was.
+  function predecessorStoryLine(body, others) {
     const counts = others.map((d) => Number(d && d.session_count));
     const total = counts.every((n) => Number.isFinite(n) && n >= 0)
       ? counts.reduce((a, b) => a + b, 0)
       : null;
-    const finishing = total === null ? '' : ` — ${total} session${total === 1 ? '' : 's'} finishing`;
-    if (others.length === 1) {
-      const port = Number(others[0] && others[0].port);
-      const where = Number.isFinite(port) && port > 0 ? ` on :${port}` : '';
-      return `A predecessor daemon is draining${where}${finishing}`;
-    }
-    return `${others.length} predecessor daemons are draining${finishing}`;
+    const pair = (v) => (v && typeof v === 'object' && v.git_sha)
+      ? `${v.git_sha}@${v.built_at || ''}`
+      : '';
+    const own = (Array.isArray(body.daemons) ? body.daemons : []).find(
+      (d) => d && d.boot_id === body.boot_id
+    );
+    const ownPair = pair(own && own.version);
+    const sameBuild = Boolean(ownPair)
+      && others.every((d) => pair(d && d.version) === ownPair);
+    const where = sameBuild ? 'on the previous daemon' : 'on the previous version';
+    return total === null
+      ? `Finishing up ${where}`
+      : `Finishing up (${handoverTaskCount(total)}) ${where}`;
   }
 
   // The §5.1 live-holder resolution rule (update-abstraction intake) —
@@ -107911,8 +108021,8 @@ async function memoryProposeFromForm(button) {
       // pill.
       if (followWatch.phase !== 'consent' && bannerCollapsedNow(el, key)) {
         bannerFillPill(el, key, rows.length
-          ? `This daemon is draining — waiting on ${rows.length} in-flight session${rows.length === 1 ? '' : 's'}`
-          : 'This daemon is draining — in-flight sessions are finishing');
+          ? `Updating Intendant — finishing up (${handoverTaskCount(rows.length)})`
+          : 'Updating Intendant — your work continues');
         handoverBannerReserve();
         return;
       }
@@ -107924,31 +108034,52 @@ async function memoryProposeFromForm(button) {
       el.removeAttribute('role');
       el.removeAttribute('tabindex');
       el.removeAttribute('title');
-      el.appendChild(bannerCollapseButton(key, 'Collapse the drain banner to a pill'));
+      el.appendChild(bannerCollapseButton(key, 'Collapse the update banner to a pill'));
+      // Grade 1: the product event, plain — the port stays in the
+      // doorway's href and inside Advanced (§4.2).
       const head = document.createElement('div');
       head.className = 'handover-banner-head';
       const lead = document.createElement('strong');
-      lead.textContent = 'This daemon is draining.';
+      lead.textContent = 'Updating Intendant — your work continues.';
       head.appendChild(lead);
       const tail = document.createElement('span');
       tail.textContent = rows.length
-        ? ` Waiting on ${rows.length} in-flight session${rows.length === 1 ? '' : 's'}, then it exits.`
-        : ' In-flight sessions finish here, then it exits.';
+        ? ` Finishing up (${handoverTaskCount(rows.length)}) here, then the updated daemon takes over.`
+        : ' Wrapping up here, then the updated daemon takes over.';
       head.appendChild(tail);
       el.appendChild(head);
       if (holder) {
-        el.appendChild(
-          handoverDaemonLink(holder.port, `Open the successor daemon (:${holder.port}) →`)
-        );
+        el.appendChild(handoverDaemonLink(holder.port, 'Open the updated dashboard →'));
       } else {
         const none = document.createElement('div');
         none.className = 'handover-banner-note';
-        none.textContent = 'No successor has acquired the lease yet.';
+        none.textContent = 'Waiting for the updated daemon to start…';
         el.appendChild(none);
       }
       const followSection = followBannerSection();
       if (followSection) el.appendChild(followSection);
-      if (rows.length) el.appendChild(handoverHoldoutList(rows, rows.length));
+      // Grade 2 — the mechanics, verbatim, inside the shared fold: the
+      // lease story, the ported doorway, and the named wait set with
+      // its phases.
+      const fold = handoverAdvancedFold();
+      const mech = document.createElement('div');
+      mech.className = 'handover-banner-note';
+      mech.textContent = 'This daemon is draining.' + (rows.length
+        ? ` Waiting on ${rows.length} in-flight session${rows.length === 1 ? '' : 's'}, then it exits.`
+        : ' In-flight sessions finish here, then it exits.');
+      fold.appendChild(mech);
+      if (holder) {
+        fold.appendChild(
+          handoverDaemonLink(holder.port, `Open the successor daemon (:${holder.port}) →`)
+        );
+      } else {
+        const pending = document.createElement('div');
+        pending.className = 'handover-banner-note';
+        pending.textContent = 'No successor has acquired the lease yet.';
+        fold.appendChild(pending);
+      }
+      if (rows.length) fold.appendChild(handoverHoldoutList(rows, rows.length));
+      el.appendChild(fold);
       handoverBannerReserve();
       return;
     }
@@ -107965,36 +108096,54 @@ async function memoryProposeFromForm(button) {
       // once; the same set stays as the owner left it.
       const key = bannerStateKey('predecessor',
         others.map((d) => String((d && d.boot_id) || 'unknown')).sort().join('+'));
+      const story = predecessorStoryLine(body, others);
       if (bannerCollapsedNow(el, key)) {
-        bannerFillPill(el, key, bannerPredecessorPill(others));
+        bannerFillPill(el, key, story);
         handoverBannerReserve();
         return;
       }
-      el.appendChild(bannerCollapseButton(key, 'Collapse the predecessor banner to a pill'));
+      el.appendChild(bannerCollapseButton(key, 'Collapse the finishing-up banner to a pill'));
+      // Grade 1: one story for however many daemons still finish (§5.3)
+      // — the counts fold into one number, the ports stay in Advanced.
+      const head = document.createElement('div');
+      head.className = 'handover-banner-head';
+      const lead = document.createElement('strong');
+      lead.textContent = `${story}.`;
+      head.appendChild(lead);
+      el.appendChild(head);
+      const promise = document.createElement('div');
+      promise.className = 'handover-banner-note';
+      promise.textContent = 'Everything continues here once that work finishes.';
+      el.appendChild(promise);
+      // Grade 2 — the #729 per-daemon enumeration, verbatim, inside the
+      // shared fold: one section per draining co-homed daemon, its
+      // port, its doorway, and its named holdout rows.
+      const fold = handoverAdvancedFold();
       others.forEach((d) => {
         const port = Number(d.port);
         const count = Number(d.session_count);
         const section = document.createElement('div');
         section.className = 'handover-predecessor';
-        const head = document.createElement('div');
-        head.className = 'handover-banner-head';
-        const lead = document.createElement('span');
-        lead.textContent = `A predecessor daemon is draining${Number.isFinite(port) ? ` on :${port}` : ''}`
+        const mech = document.createElement('div');
+        mech.className = 'handover-banner-head';
+        const line = document.createElement('span');
+        line.textContent = `A predecessor daemon is draining${Number.isFinite(port) ? ` on :${port}` : ''}`
           + `${Number.isFinite(count) ? ` — ${count} session${count === 1 ? '' : 's'} still finishing there` : ''}.`;
-        head.appendChild(lead);
+        mech.appendChild(line);
         if (Number.isFinite(port) && port > 0) {
-          head.appendChild(document.createTextNode(' '));
-          head.appendChild(handoverDaemonLink(port, `Open :${port} →`));
+          mech.appendChild(document.createTextNode(' '));
+          mech.appendChild(handoverDaemonLink(port, `Open :${port} →`));
         }
-        section.appendChild(head);
+        section.appendChild(mech);
         const rows = Array.isArray(d.holdouts) ? d.holdouts : [];
         if (rows.length) section.appendChild(handoverHoldoutList(rows, count));
         const note = document.createElement('div');
         note.className = 'handover-banner-note';
         note.textContent = 'Mid-work sessions it releases are picked up here when it exits.';
         section.appendChild(note);
-        el.appendChild(section);
+        fold.appendChild(section);
       });
+      el.appendChild(fold);
       handoverBannerReserve();
       return;
     }

--- a/static/app/ui2-chrome.js
+++ b/static/app/ui2-chrome.js
@@ -43,6 +43,12 @@ const UI2_NAV_GROUPS = [
 
 const UI2_TAB_TITLES = {};
 
+// The update family's palette synonyms — what users type when they mean
+// the update lane without knowing its labels ("release", "hotswap").
+// Rides the generic `keywords` field palette entries may carry; the
+// palette stays a what-you-see label matcher first.
+const UI2_UPDATE_KEYWORDS = ['update', 'release', 'channel', 'upgrade', 'hotswap', 'swap'];
+
 function ui2BuildNav() {
   const groupsHost = document.getElementById('ui2-nav-groups');
   if (!groupsHost) return;
@@ -723,6 +729,7 @@ function ui2PaletteActionEntries(q) {
       entries.push({
         section: 'Actions', icon: 'daemon', label: String(served.label),
         inert: served.busy === true,
+        keywords: UI2_UPDATE_KEYWORDS,
         run: () => { try { served.run(); } catch (e) { console.warn('[ui2] update action failed', e); } },
       });
     }
@@ -731,6 +738,7 @@ function ui2PaletteActionEntries(q) {
   if (updateLane && typeof updateLane.check === 'function') {
     entries.push({
       section: 'Actions', icon: 'daemon', label: 'Check for updates',
+      keywords: UI2_UPDATE_KEYWORDS,
       run: () => {
         routeTo('access', 'daemons');
         try { updateLane.check(); } catch (e) { console.warn('[ui2] update check failed', e); }
@@ -758,13 +766,29 @@ function ui2PaletteEntries(q) {
       entries.push(item);
     }
   }
-  // Label-only matching for labeled entries: users type what they SEE
+  // The update lane's pure destination (owner-directed, 2026-08-04):
+  // goes to the Daemon update card and fires NOTHING — the "Check for
+  // updates" action beside it stays the consent POST. Palette-only (no
+  // nav-rail seat): a Go-to row, not a machine surface of its own.
+  entries.push({
+    label: 'Daemon update', icon: 'daemon',
+    route: ['access', 'daemons'], anchor: 'update-lane-card',
+    keywords: UI2_UPDATE_KEYWORDS,
+  });
+  // Label matching for labeled entries: users type what they SEE
   // (id matching surprised — "sta" surfaced Usage via its internal id).
-  // `matchless` entries carry the query themselves (sessions already
-  // matched; the deep-search verb embeds it).
-  const filtered = entries.filter((item) => !query || item.label.toLowerCase().includes(query));
+  // An entry may also carry an explicit `keywords` alias list — the
+  // deliberate synonyms lane (generic; the update family populates it)
+  // — matched the same substring way. `matchless` entries carry the
+  // query themselves (sessions already matched; the deep-search verb
+  // embeds it).
+  const matchesQuery = (item) => !query
+    || item.label.toLowerCase().includes(query)
+    || (Array.isArray(item.keywords)
+        && item.keywords.some((k) => String(k).toLowerCase().includes(query)));
+  const filtered = entries.filter(matchesQuery);
   const actions = ui2PaletteActionEntries(q)
-    .filter((item) => item.matchless || !query || item.label.toLowerCase().includes(query));
+    .filter((item) => item.matchless || matchesQuery(item));
   // Agenda section (lens destinations + item hits): provided by
   // ui2-agenda-hood.js under this fragment's convention — cross-fragment
   // state is read by name at event time with a typeof guard, so the
@@ -845,7 +869,15 @@ function ui2PaletteGo(item) {
     return;
   }
   if (item.tab) routeTo(item.tab);
-  else if (item.route) routeTo(item.route[0], item.route[1]);
+  else if (item.route) {
+    routeTo(item.route[0], item.route[1]);
+    // Destination entries may name an in-pane anchor: pure scroll,
+    // never an action.
+    if (item.anchor) {
+      const anchorEl = document.getElementById(item.anchor);
+      if (anchorEl) anchorEl.scrollIntoView({ block: 'start' });
+    }
+  }
 }
 
 function ui2PaletteOpen() {

--- a/static/app/ui2-handover.css
+++ b/static/app/ui2-handover.css
@@ -354,6 +354,20 @@ html.ui-v2 .update-lane-advanced > summary {
   font-size: 11px;
   color: var(--muted, #7e8896);
 }
+/* The shared grade-2 fold (update-abstraction §4): mechanics under one
+   sticky "Advanced" disclosure on the banner, the predecessor
+   sections, and the update chip alike. */
+html.ui-v2 .handover-advanced {
+  margin-top: 6px;
+}
+html.ui-v2 .handover-advanced > summary {
+  cursor: pointer;
+  font-size: 11px;
+  color: var(--muted, #7e8896);
+}
+html.ui-v2 .handover-advanced[open] > summary {
+  margin-bottom: 4px;
+}
 html.ui-v2 .update-lane-swap:not(:empty) {
   margin-top: 10px;
   padding: 8px 10px;

--- a/static/app/ui2-handover.js
+++ b/static/app/ui2-handover.js
@@ -41,6 +41,15 @@
 //     same-sha rebuild is a real update). The packaged app follows by
 //     itself (didSwapToPort) and relay-reached surfaces get honest copy
 //     instead — port substitution means nothing there.
+// Vocabulary (update-abstraction §4, slice 4): every surface here
+// speaks TWO GRADES. Grade 1, the default, tells the product event in
+// plain words — "Updating Intendant — your work continues." — and
+// never names ports, boot ids, lease state, or drain mechanics (the
+// negative vocabulary pin makes that mechanical). Grade 2 is the full
+// mechanics copy, verbatim, inside a per-surface <details> fold that
+// persists under ONE shared key across the handover surfaces (Q7):
+// open the mechanics once and the banner, the predecessor sections,
+// and the update chip all stay open to them.
 (() => {
   const HANDOVER_POLL_MS = 30000;
   let bannerEl = null;
@@ -509,9 +518,11 @@
     head.appendChild(collapse);
     el.appendChild(head);
     if (disk) {
-      strong.textContent = 'Update on disk';
+      // Grade 1: the product fact; the commit/built/running provenance
+      // is grade-2 mechanics under the shared fold below.
+      strong.textContent = 'Update ready';
       el.appendChild(document.createTextNode(
-        `commit ${disk.git_sha || '?'} · built ${disk.built_at || '?'} — running ${running.git_sha || '?'}`
+        'A newer build of Intendant is ready to install.'
       ));
       if (update.honesty) {
         const honesty = document.createElement('div');
@@ -543,6 +554,16 @@
       el.appendChild(pending);
     }
     el.appendChild(handoverUpdateActions(body, disk));
+    // Grade 2 — both builds' provenance, verbatim, inside the shared
+    // fold (the banner's key: mechanics open together everywhere).
+    if (disk) {
+      const fold = handoverAdvancedFold();
+      const mech = document.createElement('div');
+      mech.className = 'handover-update-note';
+      mech.textContent = `commit ${disk.git_sha || '?'} · built ${disk.built_at || '?'} — running ${running.git_sha || '?'}`;
+      fold.appendChild(mech);
+      el.appendChild(fold);
+    }
     // The pill expands into the full update panel: the chip stays the
     // standing fact; channels, checks, and builds live there.
     if (typeof routeTo === 'function') {
@@ -818,21 +839,64 @@
     return collapse;
   }
 
-  // The predecessor pill's one line, honest about what is known: the
-  // port when there is one predecessor, the summed still-finishing
-  // count only when every predecessor reports one.
-  function bannerPredecessorPill(others) {
+  // ── The two-grade vocabulary (update-abstraction §4, slice 4) ──────
+  // Grade 2 lives inside a <details> fold persisted under ONE shared
+  // key (Q7): "show me the mechanics" is a stance, not a per-surface
+  // choice — the banner, the predecessor sections, and the update chip
+  // all honor it together. (The update panel's Dev-channel fold keeps
+  // its own key: that one selects a channel, it does not disclose
+  // mechanics.)
+  const HANDOVER_ADVANCED_KEY = 'handover-advanced-open';
+  function handoverAdvancedStored() {
+    try { return localStorage.getItem(HANDOVER_ADVANCED_KEY) === '1'; } catch (_) { return false; }
+  }
+  function handoverAdvancedStore(open) {
+    try {
+      if (open) localStorage.setItem(HANDOVER_ADVANCED_KEY, '1');
+      else localStorage.removeItem(HANDOVER_ADVANCED_KEY);
+    } catch (_) { /* storage unavailable — the fold lives for this page only */ }
+  }
+  function handoverAdvancedFold() {
+    const fold = document.createElement('details');
+    fold.className = 'handover-advanced';
+    if (handoverAdvancedStored()) fold.open = true;
+    fold.addEventListener('toggle', () => handoverAdvancedStore(fold.open));
+    const summary = document.createElement('summary');
+    summary.textContent = 'Advanced';
+    fold.appendChild(summary);
+    return fold;
+  }
+
+  function handoverTaskCount(n) {
+    return `${n} task${n === 1 ? '' : 's'}`;
+  }
+
+  // The grade-1 predecessor story (§5.3): N draining siblings fold into
+  // ONE line. The count sums session_count when every sibling reports
+  // one, and stays silent when any does not — never a guessed number.
+  // The version/daemon split is the slice-3 honesty precedent carried
+  // over (R-A1's stamp-pair law: git_sha AND built_at — a same-commit
+  // rebuild is a different build): only when EVERY draining sibling
+  // provably runs this daemon's own build does the story say "the
+  // previous daemon" instead of narrating an update that never was.
+  function predecessorStoryLine(body, others) {
     const counts = others.map((d) => Number(d && d.session_count));
     const total = counts.every((n) => Number.isFinite(n) && n >= 0)
       ? counts.reduce((a, b) => a + b, 0)
       : null;
-    const finishing = total === null ? '' : ` — ${total} session${total === 1 ? '' : 's'} finishing`;
-    if (others.length === 1) {
-      const port = Number(others[0] && others[0].port);
-      const where = Number.isFinite(port) && port > 0 ? ` on :${port}` : '';
-      return `A predecessor daemon is draining${where}${finishing}`;
-    }
-    return `${others.length} predecessor daemons are draining${finishing}`;
+    const pair = (v) => (v && typeof v === 'object' && v.git_sha)
+      ? `${v.git_sha}@${v.built_at || ''}`
+      : '';
+    const own = (Array.isArray(body.daemons) ? body.daemons : []).find(
+      (d) => d && d.boot_id === body.boot_id
+    );
+    const ownPair = pair(own && own.version);
+    const sameBuild = Boolean(ownPair)
+      && others.every((d) => pair(d && d.version) === ownPair);
+    const where = sameBuild ? 'on the previous daemon' : 'on the previous version';
+    return total === null
+      ? `Finishing up ${where}`
+      : `Finishing up (${handoverTaskCount(total)}) ${where}`;
   }
 
   // The §5.1 live-holder resolution rule (update-abstraction intake) —
@@ -1450,8 +1514,8 @@
       // pill.
       if (followWatch.phase !== 'consent' && bannerCollapsedNow(el, key)) {
         bannerFillPill(el, key, rows.length
-          ? `This daemon is draining — waiting on ${rows.length} in-flight session${rows.length === 1 ? '' : 's'}`
-          : 'This daemon is draining — in-flight sessions are finishing');
+          ? `Updating Intendant — finishing up (${handoverTaskCount(rows.length)})`
+          : 'Updating Intendant — your work continues');
         handoverBannerReserve();
         return;
       }
@@ -1463,31 +1527,52 @@
       el.removeAttribute('role');
       el.removeAttribute('tabindex');
       el.removeAttribute('title');
-      el.appendChild(bannerCollapseButton(key, 'Collapse the drain banner to a pill'));
+      el.appendChild(bannerCollapseButton(key, 'Collapse the update banner to a pill'));
+      // Grade 1: the product event, plain — the port stays in the
+      // doorway's href and inside Advanced (§4.2).
       const head = document.createElement('div');
       head.className = 'handover-banner-head';
       const lead = document.createElement('strong');
-      lead.textContent = 'This daemon is draining.';
+      lead.textContent = 'Updating Intendant — your work continues.';
       head.appendChild(lead);
       const tail = document.createElement('span');
       tail.textContent = rows.length
-        ? ` Waiting on ${rows.length} in-flight session${rows.length === 1 ? '' : 's'}, then it exits.`
-        : ' In-flight sessions finish here, then it exits.';
+        ? ` Finishing up (${handoverTaskCount(rows.length)}) here, then the updated daemon takes over.`
+        : ' Wrapping up here, then the updated daemon takes over.';
       head.appendChild(tail);
       el.appendChild(head);
       if (holder) {
-        el.appendChild(
-          handoverDaemonLink(holder.port, `Open the successor daemon (:${holder.port}) →`)
-        );
+        el.appendChild(handoverDaemonLink(holder.port, 'Open the updated dashboard →'));
       } else {
         const none = document.createElement('div');
         none.className = 'handover-banner-note';
-        none.textContent = 'No successor has acquired the lease yet.';
+        none.textContent = 'Waiting for the updated daemon to start…';
         el.appendChild(none);
       }
       const followSection = followBannerSection();
       if (followSection) el.appendChild(followSection);
-      if (rows.length) el.appendChild(handoverHoldoutList(rows, rows.length));
+      // Grade 2 — the mechanics, verbatim, inside the shared fold: the
+      // lease story, the ported doorway, and the named wait set with
+      // its phases.
+      const fold = handoverAdvancedFold();
+      const mech = document.createElement('div');
+      mech.className = 'handover-banner-note';
+      mech.textContent = 'This daemon is draining.' + (rows.length
+        ? ` Waiting on ${rows.length} in-flight session${rows.length === 1 ? '' : 's'}, then it exits.`
+        : ' In-flight sessions finish here, then it exits.');
+      fold.appendChild(mech);
+      if (holder) {
+        fold.appendChild(
+          handoverDaemonLink(holder.port, `Open the successor daemon (:${holder.port}) →`)
+        );
+      } else {
+        const pending = document.createElement('div');
+        pending.className = 'handover-banner-note';
+        pending.textContent = 'No successor has acquired the lease yet.';
+        fold.appendChild(pending);
+      }
+      if (rows.length) fold.appendChild(handoverHoldoutList(rows, rows.length));
+      el.appendChild(fold);
       handoverBannerReserve();
       return;
     }
@@ -1504,36 +1589,54 @@
       // once; the same set stays as the owner left it.
       const key = bannerStateKey('predecessor',
         others.map((d) => String((d && d.boot_id) || 'unknown')).sort().join('+'));
+      const story = predecessorStoryLine(body, others);
       if (bannerCollapsedNow(el, key)) {
-        bannerFillPill(el, key, bannerPredecessorPill(others));
+        bannerFillPill(el, key, story);
         handoverBannerReserve();
         return;
       }
-      el.appendChild(bannerCollapseButton(key, 'Collapse the predecessor banner to a pill'));
+      el.appendChild(bannerCollapseButton(key, 'Collapse the finishing-up banner to a pill'));
+      // Grade 1: one story for however many daemons still finish (§5.3)
+      // — the counts fold into one number, the ports stay in Advanced.
+      const head = document.createElement('div');
+      head.className = 'handover-banner-head';
+      const lead = document.createElement('strong');
+      lead.textContent = `${story}.`;
+      head.appendChild(lead);
+      el.appendChild(head);
+      const promise = document.createElement('div');
+      promise.className = 'handover-banner-note';
+      promise.textContent = 'Everything continues here once that work finishes.';
+      el.appendChild(promise);
+      // Grade 2 — the #729 per-daemon enumeration, verbatim, inside the
+      // shared fold: one section per draining co-homed daemon, its
+      // port, its doorway, and its named holdout rows.
+      const fold = handoverAdvancedFold();
       others.forEach((d) => {
         const port = Number(d.port);
         const count = Number(d.session_count);
         const section = document.createElement('div');
         section.className = 'handover-predecessor';
-        const head = document.createElement('div');
-        head.className = 'handover-banner-head';
-        const lead = document.createElement('span');
-        lead.textContent = `A predecessor daemon is draining${Number.isFinite(port) ? ` on :${port}` : ''}`
+        const mech = document.createElement('div');
+        mech.className = 'handover-banner-head';
+        const line = document.createElement('span');
+        line.textContent = `A predecessor daemon is draining${Number.isFinite(port) ? ` on :${port}` : ''}`
           + `${Number.isFinite(count) ? ` — ${count} session${count === 1 ? '' : 's'} still finishing there` : ''}.`;
-        head.appendChild(lead);
+        mech.appendChild(line);
         if (Number.isFinite(port) && port > 0) {
-          head.appendChild(document.createTextNode(' '));
-          head.appendChild(handoverDaemonLink(port, `Open :${port} →`));
+          mech.appendChild(document.createTextNode(' '));
+          mech.appendChild(handoverDaemonLink(port, `Open :${port} →`));
         }
-        section.appendChild(head);
+        section.appendChild(mech);
         const rows = Array.isArray(d.holdouts) ? d.holdouts : [];
         if (rows.length) section.appendChild(handoverHoldoutList(rows, count));
         const note = document.createElement('div');
         note.className = 'handover-banner-note';
         note.textContent = 'Mid-work sessions it releases are picked up here when it exits.';
         section.appendChild(note);
-        el.appendChild(section);
+        fold.appendChild(section);
       });
+      el.appendChild(fold);
       handoverBannerReserve();
       return;
     }

--- a/tests/skills/handover-follow/SKILL.md
+++ b/tests/skills/handover-follow/SKILL.md
@@ -117,7 +117,10 @@ curl -s -X POST "http://127.0.0.1:8934/api/daemon/takeover" \
 Watch the tab (within one 30s handover poll, then a ~2.5s tick
 cadence):
 
-1. The drain banner appears, naming the parked holdout.
+1. The drain banner appears with the grade-1 story ("Updating
+   Intendant — your work continues."); the parked holdout's named row
+   sits under the banner's **Advanced** fold (shared sticky key —
+   opening it once keeps every handover surface's mechanics open).
 2. The follow status/toast: "Moving to the updated daemon…" (about 5s,
    the visible-tab grace).
 3. The tab **replaces itself onto `http://127.0.0.1:8935`**, lands


### PR DESCRIPTION
Update-abstraction **slice 4 — the vocabulary layer** (intake §4 surface C, §7 slice 4, rulings Q6/Q7/Q8), plus one **owner-directed palette addition (2026-08-04)** disclosed below. Final slice of the ratified 5-slice plan.

## Grade 1 + the shared Advanced fold

Every handover surface now speaks two grades. Grade 1, the default, tells the product event plainly; grade 2 is the previous mechanics copy, verbatim, inside a `<details>` fold persisted under **one** shared key (`handover-advanced-open`, Q7) — open the mechanics once and the drain banner, the predecessor sections, and the update chip all stay open to them.

- **Own-drain banner**: "Updating Intendant — your work continues." + "Finishing up (N tasks) here, then the updated daemon takes over." Doorway is portless ("Open the updated dashboard →", §4.2 — the port stays in the href and in Advanced); the no-successor state reads "Waiting for the updated daemon to start…". Fold: the drain/lease story, the ported doorway, the named wait set with phases.
- **Predecessor sections**: one grade-1 story for N draining daemons (§5.3) — "Finishing up (K tasks) on the previous version." with counts summed across siblings (silent when any count is unknown), plus "Everything continues here once that work finishes." Fold: the per-daemon enumeration verbatim (ports, doorways, holdout rows).
- **Pills** (collapsed banners) carry the same grade-1 strings.
- **Update chip**: "Update ready" + "A newer build of Intendant is ready to install."; the commit/built/running provenance line moves into the fold. Action labels, the pinned installs-alongside honesty sentence (still exactly 4 served surfaces), and the panel's own mechanics are unchanged.
- **Drain-entry notification** (Q8): one body, two layers — the grade-1 lead ("Updating Intendant — sessions are finishing on the previous version") then the mechanics sentence after a line break; title "Updating Intendant". OS surfaces have no fold, so layering is the ruled compromise.
- **App window title** (Q6): "Intendant" while the app supervises a single-instance daemon — including across one-click swaps (the swap site's port special-case is gone). The port suffix survives only when the app launched into a shared-host topology (its preferred port was already taken), where it is load-bearing disambiguation. `xcrun swiftc -typecheck macos-app/*.swift` exits 0.

## Pins — re-pinned in the same commit (§4.3)

- `spa_carries_the_drain_holdout_banner` re-pinned **both-grade**: grade-1 needles + mechanics needles + the shared-fold machinery (one helper, three call sites, one stored key). Source-scan reach stated in the test doc, per the established artifact-scan pattern.
- **New negative pin** `grade_one_vocabulary_is_pinned_and_never_names_the_mechanics`: every grade-1 string (banner, predecessor story, chip, follow/consent, completion states, the slice-3 held-by chip strings in fragments 39/57a/41, and the notification's grade-1 lead) is asserted present in its owning fragment AND matched against the intake's mechanics class `/(port\s|:\d{4}|boot[_ ]id|lease|drain|predecessor|successor)/i` — grep-terminating. It also pins the Q6 window-title rule.
- `inline_drain_entry_emits_the_owner_notification` now asserts the Q8 layered body verbatim (title, lead, `\n`, mechanics).
- Slice-3 ruling **N2** folded in: the unreachable-branch prefix "Could not reach the previous daemon" joins the 54-session-lifecycle needle set in `grid_envelope_wire_reaches_the_fragment`.
- `empty_states_never_instruct_cli` untouched and green (acceptance (b)).
- Docs: `control-plane-and-daemon.md` banner/notification prose updated to the two-grade shape in the same commit.

## Acceptance (c) — e2e needles

Audited: no e2e leg pins SPA banner copy — the drain/handover legs assert wire truth (presence rows, payload fields, refusal pointers), and `ctl` refusal strings stay fully mechanical per §4.2. There were no e2e copy needles to move; the copy pins live in the unit needle sets above, which run in the same battery.

## Owner-directed palette addition (2026-08-04 — not in the sealed intake; disclosed as directed)

- **[a]** A side-effect-free **destination** entry "Daemon update": a Go-to row that routes to Access → Daemons and scrolls to `#update-lane-card` with **no** check POST (the existing structural pin proves ui2-chrome carries none of the update wire shapes). Implemented as a palette-only destination with a generic `anchor` field (route + in-pane scroll), not a nav-rail seat.
- **[b]** A generic `keywords` alias lane on palette entries — label matching stays primary; an entry may carry explicit synonyms, matched the same substring way. Populated once (`UI2_UPDATE_KEYWORDS`) for the three update entries: release, channel, upgrade, hotswap, swap.
- **[c]** The dynamic one-click entry and the "Check for updates" action are behaviorally unchanged (they gain keywords only).
- Pinned in `palette_reexposes_update_affordances_through_one_emitter`: destination + anchor + the keyword family + exactly three carriers + the matcher lane, with the existing wire-shape bans unchanged.

## Judgment calls

1. **Predecessor story same-build split**: "on the previous daemon" only when every draining sibling provably runs this daemon's own build (whole stamp pair — git_sha AND built_at), else the intake's committed "on the previous version". Carries the slice-3 (g) honesty precedent so the banner never contradicts the held-by chips beside it; unknown stamps take the committed default.
2. **Notification title** changed to "Updating Intendant": Q8 named only the body, but a title saying "Daemon draining" would leak mechanics on the one surface with no fold; the ruled body string is kept verbatim as the lead.
3. **Topology detection for Q6** = forced-off-preferred-port at launch: boot behavior is byte-identical to today (default port → "Intendant"; occupied → suffix); only the app-supervised swap path changes, meeting the ruled bar (app-supervised single-instance shows "Intendant").
4. **Negative-pin scope**: the sibling-lane error toasts in 54-session-lifecycle stay out of the grade-1 list — they name the port for actionability and were ruled as shipped with slice 3 (error lane, not narration). The release-lane copy likewise keeps "release" as its product word; it is not part of the grade-1 handover needle set.
5. **Collapsed chip pill** keeps its per-sha identity label (`Update · <sha>`), and hover titles keep mechanics — the slice-3 explainer-pane/title precedent.
6. The per-sha **"Update on disk" Info notification** (update watch) is unchanged: Q8 names the drain-entry Attention notification only.

## Battery (all exits captured bare)

- `cargo fmt --check` — exit 0
- `cargo test -p intendant --bins` — exit 0 (5644 + 150 + 97 passed)
- `cargo clippy --workspace -- -D warnings` — exit 0
- `cargo test -p intendant --test e2e` — exit 0 (48 passed)
- `xcrun swiftc -typecheck macos-app/*.swift` — exit 0
- Re-run in full on the merged tree after reconciling with main (sole conflict: generated `static/app.html`, resolved by regenerating with `cargo run -p app-html-assembler` per the standing rule).

Note: one pre-existing lease-liveness test (`dropped_runtime_releases_lease_and_liveness`) flaked twice under parallel load in early local runs, passes in isolation and single-threaded (module 69/69), is untouched by this diff, and was green in both full battery runs.
