### PR TITLE
Agenda: stamp-time annotations, spend-cap sheet field, and cap-refusal surfaces

### DIFF
--- a/automations/narrative-backfill/SKILL.md
+++ b/automations/narrative-backfill/SKILL.md
@@ -14,8 +14,16 @@ every skip, so re-runs digest only what is missing. Before stamping,
 decide the spend bound: the run refuses to digest until the owner has
 annotated the stamped item with a cost cap (see the mandate below),
 so the approve-click plus the cap annotation together are the spend
-authorization. Costs on subscription OAuth are ESTIMATES, never
-billed dollars.
+authorization — the Automate sheet's spend-cap field records the
+annotation at stamp time, and the owner can set or change it later in
+the stamped item's THREAD section or with `intendant ctl agenda
+annotate <item-id> 'NS CAP: $60'`. Asked about the cap in chat,
+answer with its surfaces instead of improvising: the cap lives as an
+owner-written 'NS CAP: $<amount>' annotation on the stamped item —
+set in the item's THREAD section on the dashboard or via that ctl
+line — and chat cannot bind it, because the run reads spend authority
+only from owner-attributed annotations on the item. Costs on
+subscription OAuth are ESTIMATES, never billed dollars.
 
 ## node: backfill
 
@@ -44,11 +52,26 @@ SPEND AUTHORITY (owner-set cap, fail-closed): the cumulative cost cap
 is an OWNER parameter, not part of this definition. Before any model
 call, read this item's annotations for the newest owner-written line
 'NS CAP: $<amount>' — the owner states it when approving this
-instance and may re-annotate to raise or lower it mid-arc. If no cap
-annotation exists: annotate this item 'waiting on owner cap —
-annotate NS CAP: $<amount> and re-run', then end the run without
-digesting; the manifest approval alone never authorizes unbounded
-spend. All dollar figures are ESTIMATES (API-equivalent arithmetic
+instance (the Automate sheet's spend-cap field records it at stamp
+time) and may re-annotate to raise or lower it mid-arc. If no cap
+annotation exists, refuse with a note that names both surfaces:
+annotate this item "waiting on owner cap — set one from the
+dashboard: open this stamped item and add a note in its THREAD
+section reading NS CAP: $<amount>; or from a shell: intendant ctl
+agenda annotate <item-id> 'NS CAP: $60' (any amount). Then re-run
+this action.", substituting this item's real id for <item-id> so the
+shell line is copy-pasteable. NEAR MISS: an owner note that plausibly
+states a cap but not in that exact form (prose like "cap it at sixty
+dollars", a bare "60" or "$60") authorizes NOTHING — never parse an
+amount out of prose; spend authority stays exact bytes — refuse
+instead with a note that QUOTES the near-miss verbatim and states the
+canonical line: annotate this item "waiting on owner cap — found your
+note <quoted verbatim>, but the cap must be the exact line NS CAP:
+$<amount> (e.g. NS CAP: $60). Add it as a new note in this item's
+THREAD section, or run: intendant ctl agenda annotate <item-id> 'NS
+CAP: $60'. Then re-run this action.", again substituting the real id.
+Either way end the run without digesting; the manifest approval alone
+never authorizes unbounded spend. All dollar figures are ESTIMATES (API-equivalent arithmetic
 serving the cap; journal cost fields stay labeled observed:false when
 provider telemetry is absent), NOT billed dollars. Auth mode (HOUSE
 RULE): Codex subscription OAuth ONLY — NEVER an API key or direct API

--- a/docs/src/agenda-and-memory.md
+++ b/docs/src/agenda-and-memory.md
@@ -1056,9 +1056,16 @@ pin) for the approval sheet; `GET /api/agenda/sealed/{sha256}`
 content-addressed and re-hashed against the pin, so a card revisited
 after "Later" renders exactly what was sealed. From the CLI,
 `ctl agenda stamp <name|file:…/SKILL.md> [--project DIR] [--at WHEN]
-[--every INTERVAL] [--suspend-after N] [--agent …]` rides the ordinary
-op lane (works from owner shells and supervised sessions alike);
-approval stays per-effect on the dashboard or `ctl agenda approve`.
+[--every INTERVAL] [--suspend-after N] [--note TEXT]… [--agent …]`
+rides the ordinary op lane (works from owner shells and supervised
+sessions alike); approval stays per-effect on the dashboard or
+`ctl agenda approve`. The stamp op's `annotations` field records
+owner notes on the instance at park time, attributed to the stamping
+caller exactly like the annotate op: they land on the annotation
+surface the fired mandates read — the hub for a workflow (whose
+nodes are directed to read the hub's annotations), the action's
+single item otherwise (the item an action mandate's annotation-read
+laws mean by "this item", e.g. the narrative-backfill spend cap).
 The dashboard's Automate sheet consumes exactly these surfaces: the
 picker renders every catalog entry as what it means — title,
 house/personal provenance chip, shape line, description; invalid and
@@ -1067,10 +1074,18 @@ selecting one previews it for reading (header, per-node executors and
 edges for workflows, the authored prose) with the **exact bytes a stamp
 seals** one explicit expander away, labeled with their sha256.
 Stamping is one explicit gesture for every kind: a pre-stamp summary
-states what will be sealed, parked, and proposed, and the Stamp button
-fires the stamp op — the sheet neither proposes nor approves
-client-side. After the stamp, the ordinary card (or the workflow
-approval sheet) carries the ceremony. Stamped manifests then render
+states what will be sealed, parked, and proposed — including the
+executor pins that will actually record (the definition's node pins
+when no explicit pick is made; "daemon defaults" only when neither
+exists) — and the Stamp button fires the stamp op — the sheet
+neither proposes nor approves client-side. The sheet also carries a
+"Note to the stamped item" input riding the stamp op's `annotations`
+field; when the selected definition's text demands a spend cap (the
+`NS CAP: $` convention), the input relabels as the spend-cap field
+and a bare typed amount records as the canonical `NS CAP: $<amount>`
+line — no human hand-formats spend-authority bytes. After the stamp,
+the ordinary card (or the workflow approval sheet) carries the
+ceremony. Stamped manifests then render
 their sealed pins on the item panel: a refs strip (locator + pin chip +
 expandable sealed view served from the sealed lane) with an expand-time
 drift chip — `GET /api/agenda/items/{id}/refs/drift` re-hashes manifest
@@ -1515,10 +1530,17 @@ interrupted arc resumes from the journal; the live arc's standing
 resurrection cadence deliberately did not carry over). Its spend
 bound is an owner-set parameter, fail-closed: the run digests
 nothing until the owner has annotated the stamped item
-`NS CAP: $<amount>`, and re-annotating steers the cap mid-arc the
-way the live arc's owner did; on subscription OAuth every figure is
-an API-equivalent ESTIMATE, never billed dollars. The definition's
-orientation:
+`NS CAP: $<amount>` — the Automate sheet's spend-cap field records
+the annotation at stamp time, and it can be set or changed later in
+the item's THREAD section or via
+`intendant ctl agenda annotate <item-id> 'NS CAP: $60'`. A run that
+finds no cap refuses with an annotation naming both of those
+surfaces; a near-miss note that states a cap in prose is QUOTED
+verbatim in the refusal beside the canonical line to write — never
+parsed for an amount, so spend authority stays exact bytes.
+Re-annotating steers the cap mid-arc the way the live arc's owner
+did; on subscription OAuth every figure is an API-equivalent
+ESTIMATE, never billed dollars. The definition's orientation:
 
 ```text
 The bootstrap stage of the narrative-synthesis cycle: run once at
@@ -1528,8 +1550,16 @@ every skip, so re-runs digest only what is missing. Before stamping,
 decide the spend bound: the run refuses to digest until the owner has
 annotated the stamped item with a cost cap (see the mandate below),
 so the approve-click plus the cap annotation together are the spend
-authorization. Costs on subscription OAuth are ESTIMATES, never
-billed dollars.
+authorization — the Automate sheet's spend-cap field records the
+annotation at stamp time, and the owner can set or change it later in
+the stamped item's THREAD section or with `intendant ctl agenda
+annotate <item-id> 'NS CAP: $60'`. Asked about the cap in chat,
+answer with its surfaces instead of improvising: the cap lives as an
+owner-written 'NS CAP: $<amount>' annotation on the stamped item —
+set in the item's THREAD section on the dashboard or via that ctl
+line — and chat cannot bind it, because the run reads spend authority
+only from owner-attributed annotations on the item. Costs on
+subscription OAuth are ESTIMATES, never billed dollars.
 ```
 
 The mandate (byte-pinned to the definition file):
@@ -1554,11 +1584,26 @@ SPEND AUTHORITY (owner-set cap, fail-closed): the cumulative cost cap
 is an OWNER parameter, not part of this definition. Before any model
 call, read this item's annotations for the newest owner-written line
 'NS CAP: $<amount>' — the owner states it when approving this
-instance and may re-annotate to raise or lower it mid-arc. If no cap
-annotation exists: annotate this item 'waiting on owner cap —
-annotate NS CAP: $<amount> and re-run', then end the run without
-digesting; the manifest approval alone never authorizes unbounded
-spend. All dollar figures are ESTIMATES (API-equivalent arithmetic
+instance (the Automate sheet's spend-cap field records it at stamp
+time) and may re-annotate to raise or lower it mid-arc. If no cap
+annotation exists, refuse with a note that names both surfaces:
+annotate this item "waiting on owner cap — set one from the
+dashboard: open this stamped item and add a note in its THREAD
+section reading NS CAP: $<amount>; or from a shell: intendant ctl
+agenda annotate <item-id> 'NS CAP: $60' (any amount). Then re-run
+this action.", substituting this item's real id for <item-id> so the
+shell line is copy-pasteable. NEAR MISS: an owner note that plausibly
+states a cap but not in that exact form (prose like "cap it at sixty
+dollars", a bare "60" or "$60") authorizes NOTHING — never parse an
+amount out of prose; spend authority stays exact bytes — refuse
+instead with a note that QUOTES the near-miss verbatim and states the
+canonical line: annotate this item "waiting on owner cap — found your
+note <quoted verbatim>, but the cap must be the exact line NS CAP:
+$<amount> (e.g. NS CAP: $60). Add it as a new note in this item's
+THREAD section, or run: intendant ctl agenda annotate <item-id> 'NS
+CAP: $60'. Then re-run this action.", again substituting the real id.
+Either way end the run without digesting; the manifest approval alone
+never authorizes unbounded spend. All dollar figures are ESTIMATES (API-equivalent arithmetic
 serving the cap; journal cost fields stay labeled observed:false when
 provider telemetry is absent), NOT billed dollars. Auth mode (HOUSE
 RULE): Codex subscription OAuth ONLY — NEVER an API key or direct API

--- a/src/bin/caller/agenda/definitions.rs
+++ b/src/bin/caller/agenda/definitions.rs
@@ -1333,6 +1333,19 @@ mod tests {
         // narrative-backfill: the backfill arc's dispatch/quota/patience/
         // never-detach/cap discipline, translated one-shot.
         let backfill = by_name("narrative-backfill");
+        // The orientation's cap-surface guidance (card 01KZ8PK1FD): the
+        // stamp-time field, the two owner surfaces by name, and the
+        // scripted chat answer — chat never binds spend authority.
+        carries(
+            &backfill.orientation,
+            "narrative-backfill orientation",
+            &[
+                "the Automate sheet's spend-cap field records the annotation at stamp time",
+                "intendant ctl agenda annotate <item-id> 'NS CAP: $60'",
+                "chat cannot bind it, because the run reads spend authority only from \
+                 owner-attributed annotations on the item",
+            ],
+        );
         carries(
             &backfill.nodes[0].goal,
             "narrative-backfill",
@@ -1361,6 +1374,14 @@ mod tests {
                 "NS CAP: $<amount>",
                 "STOP REFILLING, wait out attached workers",
                 "NS CAP REACHED",
+                // The cap refusal names BOTH owner surfaces and stays
+                // copy-pasteable; near-misses are quoted back verbatim,
+                // never parsed for amounts (card 01KZ8PK1FD).
+                "add a note in its THREAD section reading NS CAP: $<amount>",
+                "intendant ctl agenda annotate <item-id> 'NS CAP: $60'",
+                "substituting this item's real id for <item-id>",
+                "never parse an amount out of prose; spend authority stays exact bytes",
+                "QUOTES the near-miss verbatim",
                 // Enumeration + digest + journal discipline.
                 "(newest_mtime_ms,total_bytes)",
                 "idle >6h",

--- a/src/bin/caller/agenda/handle.rs
+++ b/src/bin/caller/agenda/handle.rs
@@ -2094,6 +2094,7 @@ mod tests {
                     every_ms: None,
                     suspend_after: None,
                     agent_config: None,
+                    annotations: Vec::new(),
                     source: None,
                 },
                 actor("agent_session", Some("sess-1")),

--- a/src/bin/caller/agenda/store.rs
+++ b/src/bin/caller/agenda/store.rs
@@ -7651,8 +7651,14 @@ mod tests {
         let err = store3
             .apply_stamp_command(stamp_cmd_with_notes("triage", &["  "]), owner(), 5000)
             .unwrap_err();
-        assert!(err.to_string().contains("stamp note must not be empty"), "{err}");
-        assert!(store3.snapshot().is_empty(), "nothing parks on a refused note");
+        assert!(
+            err.to_string().contains("stamp note must not be empty"),
+            "{err}"
+        );
+        assert!(
+            store3.snapshot().is_empty(),
+            "nothing parks on a refused note"
+        );
     }
 
     /// Steward N1 (slice-1 gate): the deleted registry invariants used

--- a/src/bin/caller/agenda/store.rs
+++ b/src/bin/caller/agenda/store.rs
@@ -1099,6 +1099,25 @@ impl AgendaStore {
                     .into(),
             ));
         }
+        // Stamp-time notes validate BEFORE anything parks: these are the
+        // annotate intake's own bounds, run early so a bad note is a
+        // whole-stamp refusal instead of a parked prefix.
+        if stamp.annotations.len() > MAX_ANNOTATIONS_PER_ITEM {
+            return Err(AgendaError::Invalid(format!(
+                "more than {MAX_ANNOTATIONS_PER_ITEM} stamp notes"
+            )));
+        }
+        for note in &stamp.annotations {
+            let note = note.trim();
+            if note.is_empty() {
+                return Err(AgendaError::Invalid("stamp note must not be empty".into()));
+            }
+            if note.len() > MAX_BODY_BYTES {
+                return Err(AgendaError::Invalid(format!(
+                    "stamp note exceeds {MAX_BODY_BYTES} bytes"
+                )));
+            }
+        }
         let fire_at_ms = stamp.fire_at_ms.unwrap_or(now_ms);
 
         // Park the instance graph (today's stamp topologies, verbatim):
@@ -1141,6 +1160,30 @@ impl AgendaStore {
                 self.apply_place(&item.id, &hub.id, actor.clone(), source.clone(), now_ms)?;
             }
             parked.push((node.id.clone(), title, item.id));
+        }
+        // Stamp-time owner notes land on the annotation surface the fired
+        // mandates read: the hub for a workflow (its nodes are directed
+        // to read the hub's annotations — the narrative-pyramid context
+        // pickup), the action's single item otherwise ("this item" in an
+        // action's own laws, e.g. the narrative-backfill NS CAP spend
+        // cap). Ordinary annotate ops through the ordinary intake, so
+        // the stamp's gate-resolved attribution rides each note — an
+        // owner-submitted sheet lands owner-attributed annotations,
+        // exactly what an owner-parameter law requires.
+        let note_target = hub
+            .as_ref()
+            .map(|h| h.id.clone())
+            .unwrap_or_else(|| parked[0].2.clone());
+        for note in &stamp.annotations {
+            let op = self.command_to_op(
+                AgendaCommand::Annotate {
+                    id: note_target.clone(),
+                    text: note.clone(),
+                    source: None,
+                },
+                now_ms,
+            )?;
+            self.append_op(op, actor.clone(), source.clone(), now_ms)?;
         }
         let item_of = |parked: &[(String, String, String)], node_id: &str| -> String {
             parked
@@ -2641,6 +2684,7 @@ struct StampFields {
     every_ms: Option<u64>,
     suspend_after: Option<u32>,
     agent_config: Option<Box<crate::event::AgentLaunchConfig>>,
+    annotations: Vec<String>,
 }
 
 impl StampFields {
@@ -2652,6 +2696,7 @@ impl StampFields {
             every_ms,
             suspend_after,
             agent_config,
+            annotations,
             source: _,
         } = cmd
         else {
@@ -2666,6 +2711,7 @@ impl StampFields {
             every_ms,
             suspend_after,
             agent_config,
+            annotations,
         })
     }
 }
@@ -7377,6 +7423,10 @@ mod tests {
     }
 
     fn stamp_cmd(definition: &str) -> AgendaCommand {
+        stamp_cmd_with_notes(definition, &[])
+    }
+
+    fn stamp_cmd_with_notes(definition: &str, notes: &[&str]) -> AgendaCommand {
         AgendaCommand::Stamp {
             definition: definition.to_string(),
             project_root: None,
@@ -7384,6 +7434,7 @@ mod tests {
             every_ms: None,
             suspend_after: None,
             agent_config: None,
+            annotations: notes.iter().map(|n| n.to_string()).collect(),
             source: None,
         }
     }
@@ -7554,6 +7605,56 @@ mod tests {
         assert_eq!(std::fs::read_to_string(&blob).unwrap(), embedded);
     }
 
+    /// Card 01KZ8PK1FD: stamp-time notes land on the annotation surface
+    /// the fired mandates read — an action's single item ("this item" in
+    /// its own laws, e.g. the narrative-backfill NS CAP spend cap), a
+    /// workflow's hub (whose nodes are directed to read the hub's
+    /// annotations) — attributed to the stamping actor, so an
+    /// owner-submitted sheet lands the owner-written line the cap law
+    /// greps for. Bad notes refuse by name BEFORE anything parks.
+    #[test]
+    fn stamp_notes_land_owner_attributed_on_the_surface_the_mandate_reads() {
+        // Action: the note lands on the single parked item, and the
+        // returned outcome already carries it.
+        let (_root, mut store) = stamp_rig();
+        let outcome = store
+            .apply_stamp_command(
+                stamp_cmd_with_notes("narrative-backfill", &["NS CAP: $60"]),
+                owner(),
+                5000,
+            )
+            .unwrap();
+        assert!(outcome.hub.is_none());
+        let item = &outcome.nodes[0].item;
+        assert_eq!(item.annotations.len(), 1);
+        assert_eq!(item.annotations[0].text, "NS CAP: $60");
+        assert_eq!(item.annotations[0].principal.as_deref(), Some("owner"));
+
+        // Workflow: the note lands on the hub — the instance-wide
+        // surface — never duplicated across node items.
+        let (_root2, mut store2) = stamp_rig();
+        let outcome = store2
+            .apply_stamp_command(
+                stamp_cmd_with_notes("fix-task", &["scope: the flaky e2e leg only"]),
+                owner(),
+                5000,
+            )
+            .unwrap();
+        let hub = outcome.hub.as_ref().expect("workflow hub");
+        assert_eq!(hub.annotations.len(), 1);
+        assert_eq!(hub.annotations[0].text, "scope: the flaky e2e leg only");
+        assert_eq!(hub.annotations[0].principal.as_deref(), Some("owner"));
+        assert!(outcome.nodes.iter().all(|n| n.item.annotations.is_empty()));
+
+        // Refusals are whole-stamp and early: a blank note parks nothing.
+        let (_root3, mut store3) = stamp_rig();
+        let err = store3
+            .apply_stamp_command(stamp_cmd_with_notes("triage", &["  "]), owner(), 5000)
+            .unwrap_err();
+        assert!(err.to_string().contains("stamp note must not be empty"), "{err}");
+        assert!(store3.snapshot().is_empty(), "nothing parks on a refused note");
+    }
+
     /// Steward N1 (slice-1 gate): the deleted registry invariants used
     /// to check at CI time that shipped defaults respect the intake
     /// floors; under one-authority that check moved to stamp time — so
@@ -7707,6 +7808,7 @@ mod tests {
                     every_ms: Some(60_000),
                     suspend_after: None,
                     agent_config: None,
+                    annotations: Vec::new(),
                     source: None,
                 },
                 owner(),
@@ -7729,6 +7831,7 @@ mod tests {
                     every_ms: None,
                     suspend_after: None,
                     agent_config: None,
+                    annotations: Vec::new(),
                     source: None,
                 },
                 owner(),
@@ -7753,6 +7856,7 @@ mod tests {
                         every_ms: None,
                         suspend_after: None,
                         agent_config: None,
+                        annotations: Vec::new(),
                         source: None,
                     },
                     owner(),
@@ -7777,6 +7881,7 @@ mod tests {
                     every_ms: Some(3_600_000),
                     suspend_after: None,
                     agent_config: None,
+                    annotations: Vec::new(),
                     source: None,
                 },
                 owner(),
@@ -7813,6 +7918,7 @@ mod tests {
                     every_ms: None,
                     suspend_after: None,
                     agent_config: Some(Box::new(over)),
+                    annotations: Vec::new(),
                     source: None,
                 },
                 owner(),

--- a/src/bin/caller/agenda/types.rs
+++ b/src/bin/caller/agenda/types.rs
@@ -1313,6 +1313,14 @@ pub enum AgendaCommand {
         /// wholesale when non-empty).
         #[serde(default, skip_serializing_if = "Option::is_none")]
         agent_config: Option<Box<crate::event::AgentLaunchConfig>>,
+        /// Stamp-time owner notes, recorded at park on the annotation
+        /// surface the fired mandates read (the hub for a workflow, the
+        /// action's single item otherwise) with the stamp's gate-resolved
+        /// attribution — the lane an owner-parameter annotation (e.g. the
+        /// narrative-backfill `NS CAP: $<amount>` spend cap) rides so the
+        /// approve-click and the parameter land together.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        annotations: Vec<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         source: Option<String>,
     },

--- a/src/bin/caller/ctl.rs
+++ b/src/bin/caller/ctl.rs
@@ -2417,6 +2417,7 @@ async fn run_agenda(
                 "--at",
                 "--every",
                 "--suspend-after",
+                "--note",
                 "--source",
             ];
             value_flags.extend(AGENDA_LAUNCH_FLAGS);
@@ -2451,6 +2452,17 @@ async fn run_agenda(
                     .parse()
                     .map_err(|_| format!("--suspend-after {n:?} is not a number"))?;
                 map.insert("suspend_after".to_string(), Value::from(n));
+            }
+            // Stamp-time owner notes (repeatable): recorded on the stamped
+            // instance's annotation surface with this caller's
+            // attribution — e.g. --note 'NS CAP: $60' rides the exact
+            // spend-authority bytes the narrative-backfill mandate reads.
+            let notes: Vec<Value> = args
+                .all("--note")
+                .map(|n| Value::String(n.to_string()))
+                .collect();
+            if !notes.is_empty() {
+                map.insert("annotations".to_string(), Value::Array(notes));
             }
             insert_string(&mut map, "project_root", args.one("--project"));
             insert_string(&mut map, "source", args.one("--source"));
@@ -5880,6 +5892,9 @@ fn help_agenda() {
       # validates + seals the file, parks the instance graph, and proposes one manifest\n\
       # per node with the definition pinned as a binding ref — approves NOTHING; cadence/\n\
       # executor overrides apply to single-node actions only\n\
+      [--note TEXT]...   # stamp-time owner notes, recorded with your attribution on the\n\
+      # annotation surface the fired mandates read (a workflow's hub, an action's item) —\n\
+      # e.g. --note 'NS CAP: $60' sets the narrative-backfill spend cap at park\n\
       [--agent BACKEND] [--claude-model M] [--claude-effort E]\n\
       [--codex-model M] [--codex-reasoning-effort E] [--kimi-model M] [--kimi-thinking T]\n\
   intendant ctl agenda approve ID_PREFIX [--digest HEX]   # a blocked item approves fine —\n\

--- a/src/bin/caller/web_gateway/routes_agenda.rs
+++ b/src/bin/caller/web_gateway/routes_agenda.rs
@@ -536,6 +536,11 @@ struct StampRequest {
     suspend_after: Option<u32>,
     #[serde(default)]
     agent_config: Option<Box<crate::event::AgentLaunchConfig>>,
+    /// Stamp-time owner notes — recorded on the stamped instance's
+    /// annotation surface with the caller's gate-resolved attribution
+    /// (the sheet's note / spend-cap field rides this).
+    #[serde(default)]
+    annotations: Vec<String>,
     #[serde(default)]
     source: Option<String>,
 }
@@ -568,6 +573,7 @@ pub(crate) async fn agenda_stamp_api_response(
         every_ms: request.every_ms,
         suspend_after: request.suspend_after,
         agent_config: request.agent_config,
+        annotations: request.annotations,
         source: request.source,
     };
     match agenda.stamp(cmd, actor) {

--- a/src/bin/caller/web_gateway/static_assets.rs
+++ b/src/bin/caller/web_gateway/static_assets.rs
@@ -893,6 +893,44 @@ mod tests {
         assert!(sheet.contains("shadowed by a personal definition of the same name"));
     }
 
+    /// Card 01KZ8PK1FD: the automate sheet's stamp-time note lane. The
+    /// note input rides the stamp op's `annotations`; for a
+    /// cap-demanding definition it is the spend-cap field whose bare
+    /// typed amount canonicalizes client-side to the exact
+    /// `NS CAP: $<amount>` bytes the mandate greps for — no human
+    /// hand-formats spend authority. And the executor summary stays
+    /// honest: it names the definition's node pins instead of claiming
+    /// "daemon defaults" when pins exist.
+    #[test]
+    fn automate_sheet_note_field_canonicalizes_spend_caps() {
+        let sheet = include_str!("../../../../static/app/ui2-agenda.js");
+        assert!(
+            sheet.contains("function agendaStampCapDemanded"),
+            "the sheet must detect cap-demanding definitions from their served text"
+        );
+        assert!(
+            sheet.contains("NS CAP: $${bare}"),
+            "a bare typed amount must canonicalize to the exact NS CAP: $<amount> bytes"
+        );
+        assert!(
+            sheet.contains("overrides.annotations = [noteText]"),
+            "the note must ride the stamp op's annotations field"
+        );
+        // Copy law: the user-facing name for the annotation surface is
+        // THREAD (the UI's label), never the internal inspector name.
+        assert!(
+            sheet.contains("THREAD section"),
+            "note copy must name the THREAD section"
+        );
+        // Executor honesty (the sheet-summary half of the card): the
+        // definition's node pins are named when no explicit pick is
+        // made — the stamp lane's actual fallback.
+        assert!(
+            sheet.contains("the definition’s node pins, recorded on the manifest"),
+            "the pre-stamp summary must show the definition's node pins"
+        );
+    }
+
     /// Track AW, the workflow half of the emission-shape law,
     /// retargeted to the generic flow (its registry-era twin,
     /// workflow_approval_sheet_approves_only_in_the_owner_confirm_lane,

--- a/static/app.html
+++ b/static/app.html
@@ -39034,7 +39034,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '97741fe8f2f66b04';
+const INTENDANT_APP_BUILD = '81575fa84a48273a';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -97593,6 +97593,26 @@ const AGENDA_AUTOMATION_CADENCES = [
   { label: 'Every 30 days', ms: 30 * 24 * 60 * 60 * 1000 },
 ];
 
+// Cap-demanding definitions (the narrative-backfill class): the
+// definition's own text carries the owner-cap annotation convention,
+// so the sheet's note input doubles as the spend-cap lane for it.
+function agendaStampCapDemanded(entry) {
+  return !!(entry && typeof entry.text === 'string' && entry.text.includes('NS CAP: $'));
+}
+
+// Spend-authority bytes are exact: a bare amount typed into the cap
+// field canonicalizes to `NS CAP: $<amount>` here, so no human ever
+// hand-formats the line the mandate greps for. Anything else passes
+// through verbatim — an already-canonical line stays untouched, and
+// free text stays an ordinary note (the mandate's near-miss refusal
+// quotes it back kindly instead of parsing amounts out of prose).
+function agendaStampNoteText(entry, raw) {
+  const text = String(raw || '').trim();
+  if (!text || !agendaStampCapDemanded(entry)) return text;
+  const bare = text.startsWith('$') ? text.slice(1).trim() : text;
+  return /^\d+(\.\d+)?$/.test(bare) ? `NS CAP: $${bare}` : text;
+}
+
 function agendaOpenAutomationSheet(anchor) {
   const host = agendaEnsureAutomationSheet();
   const panel = host.querySelector('.ags-panel');
@@ -97752,6 +97772,25 @@ function agendaOpenAutomationSheet(anchor) {
       });
   }
 
+  // Note to the stamped item: one optional owner note recorded AT PARK
+  // on the annotation surface the fired mandates read (a workflow's
+  // hub, an action's item), attributed to whoever stamps. When the
+  // selected definition demands a spend cap, this input IS the cap
+  // lane — a bare amount canonicalizes to `NS CAP: $<amount>` at
+  // submit (agendaStampNoteText), so nobody hand-formats authority
+  // bytes; renderSelection relabels the row per definition.
+  const noteRow = agendaStartSheetEl('div', 'ags-config-row');
+  const noteLabel = agendaStartSheetEl('label', 'ags-label', 'Note');
+  noteLabel.setAttribute('for', 'agsx-note');
+  noteRow.appendChild(noteLabel);
+  const note = document.createElement('input');
+  note.type = 'text';
+  note.id = 'agsx-note';
+  noteRow.appendChild(note);
+  const noteHint = agendaStartSheetEl('div', 'ags-hint', '');
+  noteRow.appendChild(noteHint);
+  panel.appendChild(noteRow);
+
   // Pre-stamp summary: exactly what the Stamp gesture will seal, park,
   // and propose — rendered before the button, re-rendered as the
   // controls change, so the gesture is never a surprise.
@@ -97774,7 +97813,7 @@ function agendaOpenAutomationSheet(anchor) {
   stampBtn.type = 'button';
   stampBtn.title = 'Seals the definition, parks the item(s), proposes the manifest(s) — approves nothing';
   stampBtn.addEventListener('click', () => agendaAutomationSheetSubmit(
-    { entry: () => entry, cadence, fire, suspend, project, configState, error, stampBtn }));
+    { entry: () => entry, cadence, fire, suspend, project, note, configState, error, stampBtn }));
   foot.appendChild(cancel);
   foot.appendChild(stampBtn);
   panel.appendChild(foot);
@@ -97862,9 +97901,26 @@ function agendaOpenAutomationSheet(anchor) {
       if (configState.backendOverride) picks.push(configState.backendOverride);
       if (configState.modelSel && configState.modelSel.value) picks.push(configState.modelSel.value);
       if (configState.effortSel && configState.effortSel.value) picks.push(configState.effortSel.value);
-      add(`executor: ${picks.length ? `${picks.join(' · ')} — recorded on the manifest` : 'daemon defaults'} · project: ${project.value.trim() || 'daemon default'}`);
+      // Executor honesty: untouched controls record the DEFINITION'S
+      // node pins (the stamp lane's actual fallback), so say those —
+      // "daemon defaults" only when neither picks nor pins exist.
+      const pinned = nodeExecutorLabel((entry.nodes && entry.nodes[0]) || {});
+      const executor = picks.length
+        ? `${picks.join(' · ')} — your picks, recorded on the manifest${pinned !== 'daemon default' ? ' (replacing the definition’s pins)' : ''}`
+        : (pinned !== 'daemon default'
+          ? `${pinned} — the definition’s node pins, recorded on the manifest`
+          : 'daemon defaults');
+      add(`executor: ${executor} · project: ${project.value.trim() || 'daemon default'}`);
     } else {
-      add(`per-node executors and edges come from the definition · project: ${project.value.trim() || 'daemon default'}`);
+      // Per-node honesty for workflows: the pins each manifest will
+      // actually record, node by node — never a vague deferral.
+      const rows = (entry.nodes || [])
+        .map((n) => `${n.title || n.id}: ${nodeExecutorLabel(n)}`).join('; ');
+      add(`per-node executors are the definition’s pins — ${rows} · project: ${project.value.trim() || 'daemon default'}`);
+    }
+    const noteText = agendaStampNoteText(entry, note.value);
+    if (noteText) {
+      add(`annotate the stamped ${kind === 'workflow' ? 'hub' : 'item'} with your note: ${noteText}`);
     }
   };
 
@@ -97880,6 +97936,16 @@ function agendaOpenAutomationSheet(anchor) {
     fireRow.hidden = kind !== 'action';
     suspendRow.hidden = kind !== 'action';
     config.hidden = !kind || kind === 'workflow';
+    noteRow.hidden = !kind;
+    // The note input is definition-aware: for a cap-demanding
+    // definition it is the spend-cap field — labeled as such, hinting
+    // the canonical form, canonicalizing a bare amount at submit.
+    const capField = agendaStampCapDemanded(entry);
+    noteLabel.textContent = capField ? 'Spend cap' : 'Note';
+    note.placeholder = capField ? '60' : 'optional note to the stamped item';
+    noteHint.textContent = capField
+      ? 'this definition reads an owner-set cap from the stamped item — type the amount; recorded as the canonical annotation NS CAP: $<amount> in the item’s THREAD section'
+      : 'optional — recorded with your attribution in the stamped item’s THREAD section';
     stampBtn.disabled = !entry;
     if (entry && kind === 'action') {
       const prefill = (entry.nodes && entry.nodes[0]) || {};
@@ -97902,7 +97968,7 @@ function agendaOpenAutomationSheet(anchor) {
   // The summary mirrors the controls live — a stale promise line would
   // be worse than none.
   for (const [control, event] of [[cadence, 'change'], [fire, 'change'],
-    [suspend, 'input'], [project, 'input'], [config, 'change']]) {
+    [suspend, 'input'], [project, 'input'], [note, 'input'], [config, 'change']]) {
     control.addEventListener(event, renderSummary);
   }
 
@@ -97991,6 +98057,13 @@ async function agendaAutomationSheetSubmit(form) {
     const everyMs = Number(form.cadence.value);
     if (Number.isFinite(everyMs) && everyMs > 0) overrides.every_ms = everyMs;
   }
+  // The stamp-time note rides the stamp op for every kind: the daemon
+  // records it owner-attributed on the annotation surface the fired
+  // mandates read (a workflow's hub, an action's item). A bare amount
+  // in a cap-demanding definition's field was canonicalized to the
+  // exact `NS CAP: $<amount>` bytes above the wire, never by hand.
+  const noteText = form.note ? agendaStampNoteText(entry, form.note.value) : '';
+  if (noteText) overrides.annotations = [noteText];
   form.stampBtn.disabled = true;
   try {
     // THE stamp gesture — the only place this sheet stamps. One

--- a/static/app/ui2-agenda.js
+++ b/static/app/ui2-agenda.js
@@ -2275,6 +2275,26 @@ const AGENDA_AUTOMATION_CADENCES = [
   { label: 'Every 30 days', ms: 30 * 24 * 60 * 60 * 1000 },
 ];
 
+// Cap-demanding definitions (the narrative-backfill class): the
+// definition's own text carries the owner-cap annotation convention,
+// so the sheet's note input doubles as the spend-cap lane for it.
+function agendaStampCapDemanded(entry) {
+  return !!(entry && typeof entry.text === 'string' && entry.text.includes('NS CAP: $'));
+}
+
+// Spend-authority bytes are exact: a bare amount typed into the cap
+// field canonicalizes to `NS CAP: $<amount>` here, so no human ever
+// hand-formats the line the mandate greps for. Anything else passes
+// through verbatim — an already-canonical line stays untouched, and
+// free text stays an ordinary note (the mandate's near-miss refusal
+// quotes it back kindly instead of parsing amounts out of prose).
+function agendaStampNoteText(entry, raw) {
+  const text = String(raw || '').trim();
+  if (!text || !agendaStampCapDemanded(entry)) return text;
+  const bare = text.startsWith('$') ? text.slice(1).trim() : text;
+  return /^\d+(\.\d+)?$/.test(bare) ? `NS CAP: $${bare}` : text;
+}
+
 function agendaOpenAutomationSheet(anchor) {
   const host = agendaEnsureAutomationSheet();
   const panel = host.querySelector('.ags-panel');
@@ -2434,6 +2454,25 @@ function agendaOpenAutomationSheet(anchor) {
       });
   }
 
+  // Note to the stamped item: one optional owner note recorded AT PARK
+  // on the annotation surface the fired mandates read (a workflow's
+  // hub, an action's item), attributed to whoever stamps. When the
+  // selected definition demands a spend cap, this input IS the cap
+  // lane — a bare amount canonicalizes to `NS CAP: $<amount>` at
+  // submit (agendaStampNoteText), so nobody hand-formats authority
+  // bytes; renderSelection relabels the row per definition.
+  const noteRow = agendaStartSheetEl('div', 'ags-config-row');
+  const noteLabel = agendaStartSheetEl('label', 'ags-label', 'Note');
+  noteLabel.setAttribute('for', 'agsx-note');
+  noteRow.appendChild(noteLabel);
+  const note = document.createElement('input');
+  note.type = 'text';
+  note.id = 'agsx-note';
+  noteRow.appendChild(note);
+  const noteHint = agendaStartSheetEl('div', 'ags-hint', '');
+  noteRow.appendChild(noteHint);
+  panel.appendChild(noteRow);
+
   // Pre-stamp summary: exactly what the Stamp gesture will seal, park,
   // and propose — rendered before the button, re-rendered as the
   // controls change, so the gesture is never a surprise.
@@ -2456,7 +2495,7 @@ function agendaOpenAutomationSheet(anchor) {
   stampBtn.type = 'button';
   stampBtn.title = 'Seals the definition, parks the item(s), proposes the manifest(s) — approves nothing';
   stampBtn.addEventListener('click', () => agendaAutomationSheetSubmit(
-    { entry: () => entry, cadence, fire, suspend, project, configState, error, stampBtn }));
+    { entry: () => entry, cadence, fire, suspend, project, note, configState, error, stampBtn }));
   foot.appendChild(cancel);
   foot.appendChild(stampBtn);
   panel.appendChild(foot);
@@ -2544,9 +2583,26 @@ function agendaOpenAutomationSheet(anchor) {
       if (configState.backendOverride) picks.push(configState.backendOverride);
       if (configState.modelSel && configState.modelSel.value) picks.push(configState.modelSel.value);
       if (configState.effortSel && configState.effortSel.value) picks.push(configState.effortSel.value);
-      add(`executor: ${picks.length ? `${picks.join(' · ')} — recorded on the manifest` : 'daemon defaults'} · project: ${project.value.trim() || 'daemon default'}`);
+      // Executor honesty: untouched controls record the DEFINITION'S
+      // node pins (the stamp lane's actual fallback), so say those —
+      // "daemon defaults" only when neither picks nor pins exist.
+      const pinned = nodeExecutorLabel((entry.nodes && entry.nodes[0]) || {});
+      const executor = picks.length
+        ? `${picks.join(' · ')} — your picks, recorded on the manifest${pinned !== 'daemon default' ? ' (replacing the definition’s pins)' : ''}`
+        : (pinned !== 'daemon default'
+          ? `${pinned} — the definition’s node pins, recorded on the manifest`
+          : 'daemon defaults');
+      add(`executor: ${executor} · project: ${project.value.trim() || 'daemon default'}`);
     } else {
-      add(`per-node executors and edges come from the definition · project: ${project.value.trim() || 'daemon default'}`);
+      // Per-node honesty for workflows: the pins each manifest will
+      // actually record, node by node — never a vague deferral.
+      const rows = (entry.nodes || [])
+        .map((n) => `${n.title || n.id}: ${nodeExecutorLabel(n)}`).join('; ');
+      add(`per-node executors are the definition’s pins — ${rows} · project: ${project.value.trim() || 'daemon default'}`);
+    }
+    const noteText = agendaStampNoteText(entry, note.value);
+    if (noteText) {
+      add(`annotate the stamped ${kind === 'workflow' ? 'hub' : 'item'} with your note: ${noteText}`);
     }
   };
 
@@ -2562,6 +2618,16 @@ function agendaOpenAutomationSheet(anchor) {
     fireRow.hidden = kind !== 'action';
     suspendRow.hidden = kind !== 'action';
     config.hidden = !kind || kind === 'workflow';
+    noteRow.hidden = !kind;
+    // The note input is definition-aware: for a cap-demanding
+    // definition it is the spend-cap field — labeled as such, hinting
+    // the canonical form, canonicalizing a bare amount at submit.
+    const capField = agendaStampCapDemanded(entry);
+    noteLabel.textContent = capField ? 'Spend cap' : 'Note';
+    note.placeholder = capField ? '60' : 'optional note to the stamped item';
+    noteHint.textContent = capField
+      ? 'this definition reads an owner-set cap from the stamped item — type the amount; recorded as the canonical annotation NS CAP: $<amount> in the item’s THREAD section'
+      : 'optional — recorded with your attribution in the stamped item’s THREAD section';
     stampBtn.disabled = !entry;
     if (entry && kind === 'action') {
       const prefill = (entry.nodes && entry.nodes[0]) || {};
@@ -2584,7 +2650,7 @@ function agendaOpenAutomationSheet(anchor) {
   // The summary mirrors the controls live — a stale promise line would
   // be worse than none.
   for (const [control, event] of [[cadence, 'change'], [fire, 'change'],
-    [suspend, 'input'], [project, 'input'], [config, 'change']]) {
+    [suspend, 'input'], [project, 'input'], [note, 'input'], [config, 'change']]) {
     control.addEventListener(event, renderSummary);
   }
 
@@ -2673,6 +2739,13 @@ async function agendaAutomationSheetSubmit(form) {
     const everyMs = Number(form.cadence.value);
     if (Number.isFinite(everyMs) && everyMs > 0) overrides.every_ms = everyMs;
   }
+  // The stamp-time note rides the stamp op for every kind: the daemon
+  // records it owner-attributed on the annotation surface the fired
+  // mandates read (a workflow's hub, an action's item). A bare amount
+  // in a cap-demanding definition's field was canonicalized to the
+  // exact `NS CAP: $<amount>` bytes above the wire, never by hand.
+  const noteText = form.note ? agendaStampNoteText(entry, form.note.value) : '';
+  if (noteText) overrides.annotations = [noteText];
   form.stampBtn.disabled = true;
   try {
     // THE stamp gesture — the only place this sheet stamps. One


### PR DESCRIPTION
The narrative-backfill definition's spend cap is an owner parameter read exclusively from owner-attributed annotations on the stamped item — but nothing could record that annotation at stamp time, the scripted refusal named the action without naming any surface, and the Automate sheet's summary printed "executor: daemon defaults" while the stamp actually pinned the definition's node executors. A first-time user stamping the definition hit a dead end.

Three fixes:

- **Refusal + law text amendment** (`automations/narrative-backfill/SKILL.md`, the sealed house definition): the scripted no-cap refusal now names both owner surfaces — the stamped item's THREAD section on the dashboard, and the exact copy-pasteable CLI line (`intendant ctl agenda annotate <item-id> 'NS CAP: $60'`, real id substituted). A new NEAR MISS clause covers owner notes that state a cap in prose: the refusal quotes the note verbatim beside the canonical line to write, and never parses amounts out of prose — spend authority stays exact bytes. The orientation gains one sentence scripting the in-chat answer (where the cap lives; why a chat message cannot bind it). The pinned law fragments (`ns_definitions_carry_the_live_laws_verbatim`) and the byte-pinned docs blocks (`docs/src/agenda-and-memory.md`) are co-updated in the same commit. Siblings checked: session-digest (approve-click + suspension breaker) and narrative-pyramid (ruled product caps) carry no owner-annotation cap lane, so no amendment there.
- **Stamp-time annotations**: `AgendaCommand::Stamp` / `StampFields` / the `/api/agenda/stamp` body gain `annotations: Vec<String>`, recorded at park through the ordinary annotate intake with the caller's gate-resolved attribution — on the hub for a workflow (the instance-wide surface its nodes are directed to read) and on the action's single item otherwise (the item an action mandate's annotation-read laws mean by "this item"). Notes validate before anything parks, so a bad note is a whole-stamp refusal, not a parked prefix. `ctl agenda stamp` grows a repeatable `--note` flag. The Automate sheet gains a "Note to the stamped item" input; for a definition whose text demands a cap (the `NS CAP: $` convention) it relabels as the spend-cap field, hints the canonical form, and canonicalizes a bare typed amount to the exact `NS CAP: $<amount>` bytes — nobody hand-formats spend authority.
- **Executor-summary honesty**: the pre-stamp summary now shows the definition's node pins when no explicit pick is made (and per-node pins for workflows); "daemon defaults" appears only when neither picks nor pins exist. Explicit picks are labeled as replacing the definition's pins, which is what the stamp records.

Tests: stamp notes recorded + owner-attributed on the right surface (action item vs workflow hub) + early refusal; new pinned fragments for the refusal surfaces, near-miss law, and chat script; docs blocks re-pinned; a sheet needle test for the cap-field canonicalization, THREAD copy, and executor honesty.

Flag, not shipped: the mandate's "NEVER: create agenda items" law is intact — the refusal still lands only in the item's THREAD (which does not badge the attention rail). If discoverability of the no-cap refusal still matters after the stamp-time field, a deliberate carve-out letting the fired run park one owner question would be a separate decision.