### PR TITLE
Update lane: explicit cargo resolution for build children

### DIFF
--- a/src/bin/caller/handover/update_lane.rs
+++ b/src/bin/caller/handover/update_lane.rs
@@ -13,11 +13,15 @@
 //!   source-checkout stamp): a bounded behind-`origin/main` compare;
 //!   on click, `git pull --ff-only` + `cargo build` (or
 //!   `scripts/bundle-macos.sh` for the app shape) as supervised child
-//!   processes. The build rides the machine's rustc governor untouched
-//!   (the child env never sets `RUSTC_WRAPPER`, so the box-wide cargo
-//!   config wrapper stays engaged) and is HEADROOM-GATED: under memory
-//!   pressure the job refuses to start rather than joining an OOM
-//!   spiral.
+//!   processes. The toolchain is resolved explicitly for those build
+//!   children ([`resolve_build_cargo`]): a daemon born under launchd,
+//!   the packaged app, or a Windows service inherits the bare system
+//!   PATH with no `~/.cargo/bin`, so trusting the inherited PATH alone
+//!   127s the produce. The build rides the machine's rustc governor
+//!   untouched (the child env never sets `RUSTC_WRAPPER`, so the
+//!   box-wide cargo config wrapper stays engaged) and is
+//!   HEADROOM-GATED: under memory pressure the job refuses to start
+//!   rather than joining an OOM spiral.
 //! - **Consumer** (an installed release app with no source checkout):
 //!   the latest release manifest via the transparency-log ritual
 //!   (`hosted_verify::verify_hosted_release` — inclusion proof, signed
@@ -809,6 +813,142 @@ fn curated_env(extra: &[&str]) -> Vec<(String, String)> {
         .collect()
 }
 
+/// Which curated-env tier a supervised child runs under.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ChildTier {
+    /// [`CHILD_ENV_BASE`] only (gpg, ditto).
+    Base,
+    /// Base + [`CHILD_ENV_GIT`].
+    Git,
+    /// Base + [`CHILD_ENV_BUILD`], with `cargo` resolved explicitly —
+    /// see [`resolve_build_cargo`].
+    Build,
+}
+
+impl ChildTier {
+    fn extras(self) -> &'static [&'static str] {
+        match self {
+            ChildTier::Base => &[],
+            ChildTier::Git => CHILD_ENV_GIT,
+            ChildTier::Build => CHILD_ENV_BUILD,
+        }
+    }
+}
+
+/// The build lane's toolchain refusal (string pinned by test). It
+/// replaces the story the owner actually saw — `bundle: bash exited
+/// exit status: 127`, the bundle script's bare `cargo` dying on a
+/// daemon whose inherited PATH never had a toolchain.
+const CARGO_MISSING_REFUSAL: &str =
+    "cargo was not found on the daemon's PATH or in ~/.cargo/bin — install rustup, or launch \
+     the daemon from a shell that has the toolchain";
+
+/// `cargo`'s file name on this platform (`cargo.exe` on Windows).
+fn cargo_file_name() -> String {
+    format!("cargo{}", std::env::consts::EXE_SUFFIX)
+}
+
+/// How the build lane found its toolchain (see [`resolve_build_cargo`]).
+#[derive(Debug, PartialEq, Eq)]
+enum CargoResolution {
+    /// `cargo` already resolves on the child PATH: spawn by name and
+    /// leave the curated env untouched — a daemon launched from a full
+    /// shell keeps byte-identical build children.
+    OnPath,
+    /// The child PATH misses; this absolute `…/bin/cargo` won. Direct
+    /// `cargo` spawns use it, and its bin dir is prepended to the child
+    /// PATH so the bundle script's bare `cargo` and the rustup shims
+    /// cargo re-execs resolve too.
+    Fallback(PathBuf),
+}
+
+/// Explicit toolchain resolution for build/bundle children.
+///
+/// A daemon born under launchd, the packaged app, or a Windows service
+/// task inherits the bare system PATH — no `~/.cargo/bin` — so trusting
+/// the inherited PATH alone made every produce click from such a daemon
+/// die as a bash 127 (bundle) or a spawn miss (direct `cargo`).
+/// Resolution order, first hit wins:
+///
+/// 1. the curated child PATH;
+/// 2. `$CARGO_HOME/bin` (when the daemon carries `CARGO_HOME`);
+/// 3. `<home>/.cargo/bin` — rustup's default install target
+///    (`%USERPROFILE%\.cargo\bin` on Windows via the platform home).
+///
+/// No hit anywhere is the named refusal, never a bare 127. Pure over
+/// the injected env/home/lookup — hermetic under test.
+fn resolve_build_cargo(
+    child_env: &[(String, String)],
+    home: &Path,
+    cargo_exists: &dyn Fn(&Path) -> bool,
+) -> Result<CargoResolution, String> {
+    let env_value = |name: &str| {
+        child_env
+            .iter()
+            .find(|(key, _)| key == name)
+            .map(|(_, value)| value.as_str())
+    };
+    let cargo = cargo_file_name();
+    if let Some(path) = env_value("PATH") {
+        for dir in std::env::split_paths(path) {
+            if !dir.as_os_str().is_empty() && cargo_exists(&dir.join(&cargo)) {
+                return Ok(CargoResolution::OnPath);
+            }
+        }
+    }
+    let fallback_bins = [
+        env_value("CARGO_HOME").map(|cargo_home| Path::new(cargo_home).join("bin")),
+        Some(home.join(".cargo").join("bin")),
+    ];
+    for bin in fallback_bins.into_iter().flatten() {
+        let candidate = bin.join(&cargo);
+        if cargo_exists(&candidate) {
+            return Ok(CargoResolution::Fallback(candidate));
+        }
+    }
+    Err(CARGO_MISSING_REFUSAL.to_string())
+}
+
+/// Finalize one build/bundle child's (program, env): on a PATH miss the
+/// winning fallback bin dir is prepended to the child PATH, and a
+/// direct `cargo` spawn gets the resolved absolute path; a PATH hit
+/// changes nothing. This is the REAL build branches' env construction —
+/// the mock rig lane rides the same seam.
+fn plan_build_child(
+    program: &str,
+    mut env: Vec<(String, String)>,
+    home: &Path,
+    cargo_exists: &dyn Fn(&Path) -> bool,
+) -> Result<(String, Vec<(String, String)>), String> {
+    match resolve_build_cargo(&env, home, cargo_exists)? {
+        CargoResolution::OnPath => Ok((program.to_string(), env)),
+        CargoResolution::Fallback(cargo) => {
+            let bin_dir = cargo
+                .parent()
+                .expect("a resolved …/bin/cargo has a parent")
+                .to_path_buf();
+            match env.iter_mut().find(|(name, _)| name == "PATH") {
+                Some((_, value)) => {
+                    let joined = std::env::join_paths(
+                        std::iter::once(bin_dir.clone()).chain(std::env::split_paths(value)),
+                    )
+                    .map_err(|err| {
+                        format!("prepending {} to the child PATH: {err}", bin_dir.display())
+                    })?;
+                    *value = joined.to_string_lossy().into_owned();
+                }
+                None => env.push(("PATH".to_string(), bin_dir.display().to_string())),
+            }
+            let program = if program == "cargo" {
+                cargo.display().to_string()
+            } else {
+                program.to_string()
+            };
+            Ok((program, env))
+        }
+    }
+}
+
 // ── Job + check state (rendered onto the handover status payload) ───
 
 #[derive(Debug, Clone)]
@@ -1016,22 +1156,33 @@ impl UpdateLane {
     /// Run one supervised child: curated env, bounded runtime, stdout+
     /// stderr streamed line-by-line into the job log as they happen
     /// (ordinary visibility), kill-on-drop. Returns the captured stdout
-    /// on success.
+    /// on success. [`ChildTier::Build`] children additionally get the
+    /// explicit toolchain resolution ([`plan_build_child`]) — the
+    /// shared seam every produce branch's build child spawns through.
     async fn run_child(
         self: &Arc<Self>,
         label: &str,
         program: &str,
         args: Vec<String>,
         cwd: Option<&Path>,
-        extra_env: &[&str],
+        tier: ChildTier,
         timeout: std::time::Duration,
     ) -> Result<String, String> {
+        let env = curated_env(tier.extras());
+        let (program, env) = if tier == ChildTier::Build {
+            plan_build_child(program, env, &crate::platform::home_dir(), &|candidate| {
+                candidate.is_file()
+            })
+            .map_err(|err| format!("{label}: {err}"))?
+        } else {
+            (program.to_string(), env)
+        };
         self.job_log(format!("$ {program} {}", args.join(" ")));
-        let mut command = tokio::process::Command::new(program);
+        let mut command = tokio::process::Command::new(&program);
         command
             .args(&args)
             .env_clear()
-            .envs(curated_env(extra_env))
+            .envs(env)
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
@@ -1246,7 +1397,7 @@ impl UpdateLane {
             "git",
             argv,
             None,
-            CHILD_ENV_GIT,
+            ChildTier::Git,
             GIT_TIMEOUT,
         )
         .await
@@ -1362,7 +1513,7 @@ impl UpdateLane {
                 "bash",
                 vec!["scripts/bundle-macos.sh".to_string()],
                 Some(repo_root),
-                CHILD_ENV_BUILD,
+                ChildTier::Build,
                 BUILD_TIMEOUT,
             )
             .await?;
@@ -1402,7 +1553,7 @@ impl UpdateLane {
                     "bash",
                     vec![mock_build],
                     Some(repo_root),
-                    CHILD_ENV_BUILD,
+                    ChildTier::Build,
                     BUILD_TIMEOUT,
                 )
                 .await
@@ -1422,7 +1573,7 @@ impl UpdateLane {
                     .map(|arg| arg.to_string())
                     .collect(),
                     Some(repo_root),
-                    CHILD_ENV_BUILD,
+                    ChildTier::Build,
                     BUILD_TIMEOUT,
                 )
                 .await
@@ -1518,7 +1669,7 @@ impl UpdateLane {
                 unpack_dir.display().to_string(),
             ],
             None,
-            &[],
+            ChildTier::Base,
             UNPACK_TIMEOUT,
         )
         .await?;
@@ -1602,7 +1753,7 @@ impl UpdateLane {
                 key_path.display().to_string(),
             ],
             None,
-            &[],
+            ChildTier::Base,
             GPG_TIMEOUT,
         )
         .await
@@ -1627,7 +1778,7 @@ impl UpdateLane {
                     artifact.display().to_string(),
                 ],
                 None,
-                &[],
+                ChildTier::Base,
                 GPG_TIMEOUT,
             )
             .await;
@@ -2127,6 +2278,174 @@ mod tests {
         assert!(folded[0].starts_with("abc1234 "), "truncated, not mangled");
 
         assert!(fold_shortlog("\n  \n").is_empty(), "blank lines drop out");
+    }
+
+    // ── The build lane's explicit toolchain resolution ──
+
+    fn env_of(pairs: &[(&str, &str)]) -> Vec<(String, String)> {
+        pairs
+            .iter()
+            .map(|(name, value)| (name.to_string(), value.to_string()))
+            .collect()
+    }
+
+    /// Injected filesystem lookup — the resolution seam is pure and
+    /// never scans a real HOME under test.
+    fn exists_in(present: &[PathBuf]) -> impl Fn(&Path) -> bool + '_ {
+        move |candidate: &Path| present.iter().any(|path| path.as_path() == candidate)
+    }
+
+    /// Steward card 01KZ8YN35TVRKTEHD6HK6G3XVE resolution order, leg 1:
+    /// a PATH hit wins, and the child spawns exactly as before — bare
+    /// name, curated env byte-identical (full-shell daemons keep
+    /// today's behavior even when CARGO_HOME and a home install also
+    /// exist).
+    #[test]
+    fn build_toolchain_path_hit_keeps_children_byte_identical() {
+        let cargo = cargo_file_name();
+        let shell_bin = PathBuf::from("shell").join("bin");
+        let cargo_home = PathBuf::from("cargo-home");
+        let home = PathBuf::from("home");
+        let path_value = std::env::join_paths([shell_bin.clone()])
+            .expect("join PATH")
+            .to_string_lossy()
+            .into_owned();
+        let env = vec![
+            ("PATH".to_string(), path_value),
+            ("CARGO_HOME".to_string(), cargo_home.display().to_string()),
+        ];
+        let present = [
+            shell_bin.join(&cargo),
+            cargo_home.join("bin").join(&cargo),
+            home.join(".cargo").join("bin").join(&cargo),
+        ];
+        let (program, planned) =
+            plan_build_child("cargo", env.clone(), &home, &exists_in(&present))
+                .expect("a PATH hit resolves");
+        assert_eq!(program, "cargo", "a PATH hit spawns by name");
+        assert_eq!(planned, env, "…and leaves the curated env untouched");
+    }
+
+    /// Resolution order, leg 2: on a PATH miss, `$CARGO_HOME/bin`
+    /// outranks the home fallback; the direct spawn gets the absolute
+    /// path and the child PATH leads with the winning bin dir.
+    #[test]
+    fn build_toolchain_cargo_home_outranks_home_fallback() {
+        let cargo = cargo_file_name();
+        let shell_bin = PathBuf::from("shell").join("bin");
+        let cargo_home = PathBuf::from("cargo-home");
+        let home = PathBuf::from("home");
+        let path_value = std::env::join_paths([shell_bin.clone()])
+            .expect("join PATH")
+            .to_string_lossy()
+            .into_owned();
+        let env = vec![
+            ("PATH".to_string(), path_value),
+            ("CARGO_HOME".to_string(), cargo_home.display().to_string()),
+        ];
+        let present = [
+            cargo_home.join("bin").join(&cargo),
+            home.join(".cargo").join("bin").join(&cargo),
+        ];
+        let (program, planned) = plan_build_child("cargo", env, &home, &exists_in(&present))
+            .expect("the CARGO_HOME fallback resolves");
+        assert_eq!(
+            program,
+            cargo_home.join("bin").join(&cargo).display().to_string(),
+            "the direct spawn uses the resolved absolute cargo"
+        );
+        let expected_path = std::env::join_paths([cargo_home.join("bin"), shell_bin])
+            .expect("join expected PATH")
+            .to_string_lossy()
+            .into_owned();
+        let path = planned
+            .iter()
+            .find(|(name, _)| name == "PATH")
+            .map(|(_, value)| value.as_str())
+            .expect("PATH rides the plan");
+        assert_eq!(path, expected_path, "the winning bin dir leads the PATH");
+    }
+
+    /// The live defect's exact shape (unit-level simulation of the
+    /// launchd env — the box's app-born daemon carries this PATH
+    /// verbatim, no CARGO_HOME): resolution must land on
+    /// `$HOME/.cargo/bin/cargo`, and the bundle child (`bash`, whose
+    /// script says bare `cargo`) must get the same prepended PATH.
+    #[cfg(unix)]
+    #[test]
+    fn launchd_daemon_resolves_home_cargo_and_prepends_the_bin_dir() {
+        let launchd_path = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin";
+        let env = env_of(&[("PATH", launchd_path), ("HOME", "/Users/owner")]);
+        let home = PathBuf::from("/Users/owner");
+        let present = [PathBuf::from("/Users/owner/.cargo/bin/cargo")];
+
+        let (program, planned) =
+            plan_build_child("cargo", env.clone(), &home, &exists_in(&present))
+                .expect("the home fallback resolves");
+        assert_eq!(program, "/Users/owner/.cargo/bin/cargo");
+        let path = planned
+            .iter()
+            .find(|(name, _)| name == "PATH")
+            .map(|(_, value)| value.as_str())
+            .expect("PATH rides the plan");
+        assert_eq!(
+            path,
+            "/Users/owner/.cargo/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+        );
+
+        let (program, planned) = plan_build_child("bash", env, &home, &exists_in(&present))
+            .expect("the bundle child resolves the same toolchain");
+        assert_eq!(program, "bash", "only direct cargo spawns are rewritten");
+        let path = planned
+            .iter()
+            .find(|(name, _)| name == "PATH")
+            .map(|(_, value)| value.as_str())
+            .expect("PATH rides the plan");
+        assert!(
+            path.starts_with("/Users/owner/.cargo/bin:"),
+            "the bundle script's bare `cargo` resolves via the prepend: {path}"
+        );
+    }
+
+    /// The Windows twin: a schtasks/service-born daemon's PATH lacks
+    /// cargo identically; resolution lands on
+    /// `%USERPROFILE%\.cargo\bin\cargo.exe` via the platform home.
+    #[cfg(windows)]
+    #[test]
+    fn windows_service_daemon_resolves_userprofile_cargo() {
+        let env = env_of(&[("PATH", "C:\\Windows\\system32;C:\\Windows")]);
+        let home = PathBuf::from("C:\\Users\\owner");
+        let present = [PathBuf::from("C:\\Users\\owner\\.cargo\\bin\\cargo.exe")];
+        let (program, planned) = plan_build_child("cargo", env, &home, &exists_in(&present))
+            .expect("the USERPROFILE fallback resolves");
+        assert_eq!(program, "C:\\Users\\owner\\.cargo\\bin\\cargo.exe");
+        let path = planned
+            .iter()
+            .find(|(name, _)| name == "PATH")
+            .map(|(_, value)| value.as_str())
+            .expect("PATH rides the plan");
+        assert_eq!(
+            path,
+            "C:\\Users\\owner\\.cargo\\bin;C:\\Windows\\system32;C:\\Windows"
+        );
+    }
+
+    /// No toolchain anywhere = the NAMED refusal (string pinned here),
+    /// never the bare `bash exited exit status: 127` the owner saw.
+    #[test]
+    fn toolchainless_daemon_gets_the_named_refusal_not_a_bare_127() {
+        let path_value = std::env::join_paths([PathBuf::from("system").join("bin")])
+            .expect("join PATH")
+            .to_string_lossy()
+            .into_owned();
+        let env = vec![("PATH".to_string(), path_value)];
+        let err = plan_build_child("cargo", env, &PathBuf::from("home"), &exists_in(&[]))
+            .expect_err("nothing resolves");
+        assert_eq!(
+            err,
+            "cargo was not found on the daemon's PATH or in ~/.cargo/bin — install rustup, \
+             or launch the daemon from a shell that has the toolchain"
+        );
     }
 
     // ── The channel vocabulary (the front door) ──

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -8831,6 +8831,235 @@ async fn update_lane_source_click_produces_artifact_and_chips() {
     assert_eq!(body["draining"], false);
 }
 
+/// Steward card 01KZ8YN35TVRKTEHD6HK6G3XVE: a daemon born under
+/// launchd, the packaged app, or a Windows service inherits the bare
+/// system PATH — no `~/.cargo/bin` — and the produce click died as
+/// `bundle: bash exited exit status: 127` (bundle) or a bare spawn
+/// miss (direct `cargo`). The sibling leg's mock_build_override stands
+/// in for the build child, which is exactly why CI never saw it; this
+/// leg drives the REAL (non-mock) build branch under that env shape —
+/// PATH scrubbed of every cargo-bearing dir, CARGO_HOME pointing
+/// nowhere — so the lane must resolve `$HOME/.cargo/bin/cargo` and
+/// prepend its bin dir to the child PATH. Act one, before the fake
+/// toolchain exists, pins the NAMED refusal that replaces the bare
+/// 127. Unix-gated like its siblings (shebang-exec fakes).
+#[cfg(unix)]
+#[tokio::test]
+async fn update_lane_produce_resolves_cargo_for_bare_path_daemons() {
+    use std::os::unix::fs::PermissionsExt;
+    let client = reqwest::Client::new();
+    let rig = TestRig::new();
+    std::fs::write(rig.project.path().join("intendant.toml"), "")
+        .expect("mark the rig's project root");
+    rig.write_script(&serde_json::json!({ "profiles": [] }));
+
+    // The buildable-checkout fixture with a real origin (the produce's
+    // pull leg is real; origin holds the same commit, so the pull is a
+    // no-op fast-forward).
+    let origin = rig.home.path().join("origin.git");
+    std::fs::create_dir_all(&origin).expect("origin dir");
+    fixture_git(&origin, &["init", "--bare", "--initial-branch=main", "."]);
+    let checkout = rig.home.path().join("checkout");
+    fixture_git(
+        rig.home.path(),
+        &["clone", origin.to_str().expect("utf8"), "checkout"],
+    );
+    std::fs::write(checkout.join("Cargo.toml"), "[workspace]\n").expect("seed Cargo.toml");
+    std::fs::write(checkout.join(".gitignore"), "/target\n").expect("seed gitignore");
+    std::fs::create_dir_all(checkout.join("scripts")).expect("seed scripts dir");
+    std::fs::write(
+        checkout.join("scripts").join("bundle-macos.sh"),
+        "#!/bin/bash\n",
+    )
+    .expect("seed bundle script");
+    fixture_git(&checkout, &["add", "."]);
+    fixture_git(&checkout, &["commit", "-m", "commit A"]);
+    fixture_git(&checkout, &["push", "origin", "main"]);
+    let watched = checkout.join("target").join("release").join("intendant");
+    std::fs::create_dir_all(watched.parent().expect("target dir")).expect("target dirs");
+    write_fake_watched_binary(&watched, "fakesha1");
+
+    // The launchd/service shape, deterministically: drop every PATH dir
+    // holding a cargo (the test process runs under `cargo test`, so the
+    // inherited PATH has at least one) — git and bash keep resolving —
+    // and point CARGO_HOME at nothing.
+    let scrubbed_path = std::env::join_paths(
+        std::env::split_paths(&std::env::var_os("PATH").expect("test PATH"))
+            .filter(|dir| !dir.join("cargo").is_file()),
+    )
+    .expect("join scrubbed PATH")
+    .to_string_lossy()
+    .into_owned();
+    let no_cargo_home = rig.home.path().join("no-cargo-home");
+
+    let daemon = spawn_co_daemon(
+        &client,
+        &rig,
+        "daemon.log",
+        &[
+            (
+                "INTENDANT_UPDATE_WATCH_PATH",
+                watched.to_str().expect("utf8 rig path"),
+            ),
+            ("INTENDANT_UPDATE_LANE_HEADROOM", "ok"),
+            ("PATH", scrubbed_path.as_str()),
+            ("CARGO_HOME", no_cargo_home.to_str().expect("utf8 rig path")),
+        ],
+        &[],
+    )
+    .await;
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(
+        "x-intendant-loopback-token",
+        rig_loopback_token(&rig, daemon.port)
+            .parse()
+            .expect("token header value"),
+    );
+    let authed = reqwest::Client::builder()
+        .default_headers(headers)
+        .build()
+        .expect("build token-authed client");
+    let base = format!("http://127.0.0.1:{}", daemon.port);
+    let status_url = format!("{base}/api/daemon/handover");
+    let produce_url = format!("{base}/api/daemon/update-lane/produce");
+
+    let body = http_get_json(&authed, &status_url)
+        .await
+        .expect("handover status body");
+    assert_eq!(body["update_lane"]["flavor"], "source", "{body}");
+
+    // Act one: no toolchain anywhere — the job fails with the NAMED
+    // refusal, never a bash 127.
+    let produce: serde_json::Value = authed
+        .post(&produce_url)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .expect("POST update-lane produce")
+        .error_for_status()
+        .expect("produce accepted")
+        .json()
+        .await
+        .expect("produce body");
+    assert_eq!(produce["started"], true, "{produce}");
+    let body = poll_until(
+        "the toolchainless produce refusing by name",
+        RUN_TIMEOUT,
+        || async {
+            let body = http_get_json(&authed, &status_url).await?;
+            (body["update_lane"]["job"]["ok"] == false).then_some(body)
+        },
+        || {
+            std::fs::read_to_string(rig.home.path().join("daemon.log"))
+                .map(|log| tail(&log, 4000))
+                .unwrap_or_default()
+        },
+    )
+    .await;
+    let error = body["update_lane"]["job"]["error"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(
+        error.contains("cargo was not found on the daemon's PATH or in ~/.cargo/bin"),
+        "the refusal names the miss: {body}"
+    );
+    assert!(error.contains("install rustup"), "…and the remedy: {body}");
+
+    // Act two: rustup's default install target appears — a fake cargo
+    // that records the PATH it was spawned with, then lands the
+    // artifact exactly where a real build would.
+    let cargo_bin = rig.home.path().join(".cargo").join("bin");
+    std::fs::create_dir_all(&cargo_bin).expect("fake cargo bin dir");
+    let path_dump = rig.home.path().join("fake-cargo-path.txt");
+    let fake_cargo = cargo_bin.join("cargo");
+    std::fs::write(
+        &fake_cargo,
+        format!(
+            "#!/bin/bash\nprintf '%s' \"$PATH\" > '{dump}'\n\
+             mkdir -p target/release\ncat > target/release/intendant << 'FAKE'\n#!/bin/sh\n\
+             echo \"intendant 9.9.10 (commit fakesha2, built 2026-08-05T00:00:00Z, \
+             e2e-fake-triple)\"\nFAKE\nchmod +x target/release/intendant\n",
+            dump = path_dump.display()
+        ),
+    )
+    .expect("write fake cargo");
+    std::fs::set_permissions(&fake_cargo, std::fs::Permissions::from_mode(0o755))
+        .expect("mark fake cargo executable");
+
+    // Re-click (poll: the finished job releases its running flag just
+    // after the outcome lands, so the first re-click can race a 409).
+    let produce = poll_until(
+        "the second produce click arming",
+        RUN_TIMEOUT,
+        || async {
+            let response = authed
+                .post(&produce_url)
+                .json(&serde_json::json!({}))
+                .send()
+                .await
+                .ok()?;
+            if !response.status().is_success() {
+                return None;
+            }
+            let body: serde_json::Value = response.json().await.ok()?;
+            (body["started"] == true).then_some(body)
+        },
+        || {
+            std::fs::read_to_string(rig.home.path().join("daemon.log"))
+                .map(|log| tail(&log, 4000))
+                .unwrap_or_default()
+        },
+    )
+    .await;
+    assert_eq!(produce["started"], true, "{produce}");
+    let body = poll_until(
+        "the produce job finishing ok via the resolved cargo",
+        RUN_TIMEOUT,
+        || async {
+            let body = http_get_json(&authed, &status_url).await?;
+            (body["update_lane"]["job"]["ok"] == true).then_some(body)
+        },
+        || {
+            std::fs::read_to_string(rig.home.path().join("daemon.log"))
+                .map(|log| tail(&log, 4000))
+                .unwrap_or_default()
+        },
+    )
+    .await;
+    assert!(
+        body["update_lane"]["job"]["detail"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("fakesha2"),
+        "the job reports the produced commit: {body}"
+    );
+
+    // The needles the mock lane could never carry: the REAL branch's
+    // direct spawn used the resolved absolute cargo…
+    let log_tail = body["update_lane"]["job"]["log_tail"]
+        .as_array()
+        .expect("job log tail")
+        .iter()
+        .filter_map(|line| line.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        log_tail.contains(&format!("$ {} build --release", fake_cargo.display())),
+        "the direct spawn used the resolved absolute cargo: {log_tail}"
+    );
+    // …and its spawn env carried the prepended bin dir (what the bundle
+    // script's bare `cargo` and the rustup shims resolve with).
+    let child_path = std::fs::read_to_string(&path_dump).expect("fake cargo PATH dump");
+    assert!(
+        child_path.starts_with(&format!("{}:", cargo_bin.display())),
+        "the build child's PATH leads with the resolved bin dir: {child_path}"
+    );
+    assert!(
+        child_path.ends_with(&scrubbed_path),
+        "…prepended to, not replacing, the curated PATH: {child_path}"
+    );
+}
+
 /// The release-availability surface (the slice-6 amendment card): a
 /// releases-channel check that verifies a NEWER release promotes the
 /// fact onto the handover payload as the DISTINCT `release_update`

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -8838,7 +8838,7 @@ async fn update_lane_source_click_produces_artifact_and_chips() {
 /// miss (direct `cargo`). The sibling leg's mock_build_override stands
 /// in for the build child, which is exactly why CI never saw it; this
 /// leg drives the REAL (non-mock) build branch under that env shape —
-/// PATH scrubbed of every cargo-bearing dir, CARGO_HOME pointing
+/// a fixture PATH carrying git/bash but no cargo, CARGO_HOME pointing
 /// nowhere — so the lane must resolve `$HOME/.cargo/bin/cargo` and
 /// prepend its bin dir to the child PATH. Act one, before the fake
 /// toolchain exists, pins the NAMED refusal that replaces the bare
@@ -8879,17 +8879,22 @@ async fn update_lane_produce_resolves_cargo_for_bare_path_daemons() {
     std::fs::create_dir_all(watched.parent().expect("target dir")).expect("target dirs");
     write_fake_watched_binary(&watched, "fakesha1");
 
-    // The launchd/service shape, deterministically: drop every PATH dir
-    // holding a cargo (the test process runs under `cargo test`, so the
-    // inherited PATH has at least one) — git and bash keep resolving —
-    // and point CARGO_HOME at nothing.
-    let scrubbed_path = std::env::join_paths(
-        std::env::split_paths(&std::env::var_os("PATH").expect("test PATH"))
-            .filter(|dir| !dir.join("cargo").is_file()),
-    )
-    .expect("join scrubbed PATH")
-    .to_string_lossy()
-    .into_owned();
+    // The launchd/service shape, deterministically: the daemon's PATH
+    // becomes a single fixture dir carrying exactly the tools this flow
+    // and its fakes need — git, bash, mkdir, cat, chmod — and no cargo.
+    // (Filtering cargo-bearing dirs out of the inherited PATH is not
+    // enough: a distro cargo in /usr/bin would drop git with it.)
+    // CARGO_HOME points at nothing.
+    let tool_bin = rig.home.path().join("tool-bin");
+    std::fs::create_dir_all(&tool_bin).expect("fixture tool bin");
+    for tool in ["git", "bash", "mkdir", "cat", "chmod"] {
+        let source = std::env::split_paths(&std::env::var_os("PATH").expect("test PATH"))
+            .map(|dir| dir.join(tool))
+            .find(|candidate| candidate.is_file())
+            .unwrap_or_else(|| panic!("{tool} not found on the test PATH"));
+        std::os::unix::fs::symlink(&source, tool_bin.join(tool)).expect("symlink fixture tool");
+    }
+    let bare_path = tool_bin.display().to_string();
     let no_cargo_home = rig.home.path().join("no-cargo-home");
 
     let daemon = spawn_co_daemon(
@@ -8902,7 +8907,7 @@ async fn update_lane_produce_resolves_cargo_for_bare_path_daemons() {
                 watched.to_str().expect("utf8 rig path"),
             ),
             ("INTENDANT_UPDATE_LANE_HEADROOM", "ok"),
-            ("PATH", scrubbed_path.as_str()),
+            ("PATH", bare_path.as_str()),
             ("CARGO_HOME", no_cargo_home.to_str().expect("utf8 rig path")),
         ],
         &[],
@@ -9048,14 +9053,18 @@ async fn update_lane_produce_resolves_cargo_for_bare_path_daemons() {
         "the direct spawn used the resolved absolute cargo: {log_tail}"
     );
     // …and its spawn env carried the prepended bin dir (what the bundle
-    // script's bare `cargo` and the rustup shims resolve with).
+    // script's bare `cargo` and the rustup shims resolve with),
+    // prepended to — not replacing — the curated PATH. The daemon's own
+    // boot prepends existing tool dirs (`ensure_tool_paths`: Homebrew
+    // prefixes on macOS — deliberately never `~/.cargo/bin`), so the
+    // pin is head + tail, not the exact middle.
     let child_path = std::fs::read_to_string(&path_dump).expect("fake cargo PATH dump");
     assert!(
         child_path.starts_with(&format!("{}:", cargo_bin.display())),
         "the build child's PATH leads with the resolved bin dir: {child_path}"
     );
     assert!(
-        child_path.ends_with(&scrubbed_path),
+        child_path.ends_with(&format!(":{bare_path}")),
         "…prepended to, not replacing, the curated PATH: {child_path}"
     );
 }


### PR DESCRIPTION
The dashboard's "Pull & build from main" produce fails with `bundle: bash exited exit status: 127` on a daemon launched by the app or a service manager: such a daemon inherits the bare system PATH (no `~/.cargo/bin`), the update lane passed that PATH verbatim to its build children, and the bundle script's bare `cargo` (and the direct `cargo` spawn on plain-binary installs) could not resolve. The mock build override in the e2e rig is why CI never exercised the real spawn.

This resolves the toolchain explicitly at the shared supervised-child spawn seam, for build-tier children only (the curated env allowlist is unchanged):

- a PATH hit wins and keeps the child spawn byte-identical to today;
- otherwise `$CARGO_HOME/bin/cargo`, then `<home>/.cargo/bin/cargo` (`%USERPROFILE%\.cargo\bin\cargo.exe` on Windows via the platform home helper); the direct `cargo` spawn uses the resolved absolute path and the winning bin dir is prepended to the child PATH so the bundle script's bare `cargo` and the rustup shims cargo re-execs resolve too;
- no hit anywhere is a named refusal ("cargo was not found on the daemon's PATH or in ~/.cargo/bin — install rustup, or launch the daemon from a shell that has the toolchain") instead of the bare 127.

Pins: unit tests on the resolution order and the refusal string through a pure injected-lookup seam (macOS launchd shape and the Windows service twin included), plus a new e2e leg that drives the real (non-mock) build branch under a cargo-scrubbed PATH and asserts the resolved absolute spawn and the prepended child PATH.