### PR TITLE
external-agent: backend respawns never silently kill a pending native ScheduleWakeup

### DIFF
--- a/src/bin/caller/boot_readopt.rs
+++ b/src/bin/caller/boot_readopt.rs
@@ -1000,6 +1000,131 @@ mod tests {
         .unwrap();
     }
 
+    fn write_meta_with_native_wakeup(
+        home: &Path,
+        session: &str,
+        status: &str,
+        native_wakeup: serde_json::Value,
+    ) {
+        let dir = logs_root(home).join(session);
+        std::fs::create_dir_all(&dir).unwrap();
+        let meta = serde_json::json!({
+            "session_id": session,
+            "created_at": "2026-07-28T00:00:00",
+            "status": status,
+            "native_wakeup": native_wakeup,
+        });
+        std::fs::write(
+            dir.join("session_meta.json"),
+            serde_json::to_string_pretty(&meta).unwrap(),
+        )
+        .unwrap();
+    }
+
+    /// The daemon-restart lost-timer pin (the "otherwise" branch of the
+    /// ScheduleWakeup respawn variant): a dead-boot session's pending
+    /// native-wakeup marker — live OR re-armed form — flips to its died
+    /// form under the daemon-restart cause; live wrappers, this boot's
+    /// era, and already-died markers stay untouched, and nothing
+    /// re-delivers a wake at boot (the lost-timer note rides the readopt
+    /// continuation instead).
+    #[test]
+    fn boot_pass_marks_dead_boot_native_wakeups_died() {
+        let home = tempfile::tempdir().unwrap();
+        write_meta_with_native_wakeup(
+            home.path(),
+            "sess-wakeup-dead",
+            "running",
+            serde_json::json!({
+                "armed_at_epoch": 100,
+                "fire_at_epoch": 880,
+                "prompt": "<<autonomous-loop-dynamic>>",
+            }),
+        );
+        write_meta_with_native_wakeup(
+            home.path(),
+            "sess-wakeup-rearmed-dead",
+            "running",
+            serde_json::json!({
+                "armed_at_epoch": 100,
+                "fire_at_epoch": 880,
+                "prompt": "carry on",
+                "rearmed_cause": "the credential-reload restart",
+            }),
+        );
+        write_meta_with_native_wakeup(
+            home.path(),
+            "sess-wakeup-live-wrapper",
+            "running",
+            serde_json::json!({
+                "armed_at_epoch": 100,
+                "fire_at_epoch": 880,
+                "prompt": "still mine",
+            }),
+        );
+        write_meta_with_native_wakeup(
+            home.path(),
+            "sess-wakeup-already-died",
+            "idle",
+            serde_json::json!({
+                "armed_at_epoch": 100,
+                "fire_at_epoch": 880,
+                "prompt": "old wake",
+                "died_cause": "the session end",
+                "died_at_epoch": 200,
+            }),
+        );
+        let bus = crate::event::EventBus::new();
+        let mut events = bus.subscribe();
+        let mut live = HashSet::new();
+        live.insert("sess-wakeup-live-wrapper".to_string());
+
+        let marked = mark_dead_wake_sources(home.path(), &live, |_| true, &bus);
+        assert_eq!(marked, 2, "the two dead pending wakeups mark");
+
+        let wakeup_of = |session: &str| -> crate::session_log::SessionNativeWakeupMeta {
+            serde_json::from_str::<SessionMeta>(
+                &std::fs::read_to_string(
+                    logs_root(home.path())
+                        .join(session)
+                        .join("session_meta.json"),
+                )
+                .unwrap(),
+            )
+            .unwrap()
+            .native_wakeup
+            .expect("marker present")
+        };
+        assert_eq!(
+            wakeup_of("sess-wakeup-dead").died_cause.as_deref(),
+            Some(crate::external_supervision::DAEMON_RESTART_CAUSE)
+        );
+        let rearmed = wakeup_of("sess-wakeup-rearmed-dead");
+        assert_eq!(
+            rearmed.died_cause.as_deref(),
+            Some(crate::external_supervision::DAEMON_RESTART_CAUSE),
+            "a wrapper-owned re-arm dies with the daemon that owned it"
+        );
+        assert_eq!(
+            rearmed.rearmed_cause.as_deref(),
+            Some("the credential-reload restart"),
+            "the re-arm history stays readable"
+        );
+        assert!(
+            wakeup_of("sess-wakeup-live-wrapper").died_cause.is_none(),
+            "live wrappers own their own state"
+        );
+        assert_eq!(
+            wakeup_of("sess-wakeup-already-died").died_cause.as_deref(),
+            Some("the session end"),
+            "the first, most specific cause stands"
+        );
+        assert!(
+            events.try_recv().is_err(),
+            "no bus emission for wakeup flips — the note rides the readopt nudge"
+        );
+    }
+
     /// The daemon-restart respawn class: a dead-boot session parked on
     /// background tasks (idle meta, live bg-park marker — NEVER a
     /// readopt candidate) gets its marker flipped to died-with-restart
@@ -1149,6 +1274,56 @@ mod tests {
             readopt_continuation_with_died_wake_sources(home.path(), "sess-absent", ResumeLens::MidWork),
             READOPT_CONTINUATION_TEXT,
             "no meta, no addendum"
+        );
+    }
+
+    /// The lost-wakeup note rides the same nudge: a died native-wakeup
+    /// marker appends the honest lost-timer note with the model's own
+    /// wake prompt; a still-pending marker adds nothing (its wake is
+    /// owed, not lost).
+    #[test]
+    fn readopt_continuation_carries_the_lost_wakeup_note() {
+        let home = tempfile::tempdir().unwrap();
+        write_meta_with_native_wakeup(
+            home.path(),
+            "sess-died-wakeup",
+            "running",
+            serde_json::json!({
+                "armed_at_epoch": 100,
+                "fire_at_epoch": 880,
+                "prompt": "<<autonomous-loop-dynamic>>",
+                "died_cause": "the daemon restart",
+                "died_at_epoch": 900,
+            }),
+        );
+        let text = readopt_continuation_with_died_wake_sources(
+            home.path(),
+            "sess-died-wakeup",
+            ResumeLens::MidWork,
+        );
+        assert!(text.starts_with(READOPT_CONTINUATION_TEXT), "{text}");
+        assert!(text.contains("native scheduled wakeup"), "{text}");
+        assert!(text.contains("the daemon restart"), "{text}");
+        assert!(text.contains("<<autonomous-loop-dynamic>>"), "{text}");
+
+        write_meta_with_native_wakeup(
+            home.path(),
+            "sess-pending-wakeup",
+            "running",
+            serde_json::json!({
+                "armed_at_epoch": 100,
+                "fire_at_epoch": 880,
+                "prompt": "still owed",
+            }),
+        );
+        assert_eq!(
+            readopt_continuation_with_died_wake_sources(
+                home.path(),
+                "sess-pending-wakeup",
+                ResumeLens::MidWork
+            ),
+            READOPT_CONTINUATION_TEXT,
+            "a pending wake is owed, not lost — no note"
         );
     }
 

--- a/src/bin/caller/boot_readopt.rs
+++ b/src/bin/caller/boot_readopt.rs
@@ -1271,7 +1271,11 @@ mod tests {
             "a live park adds nothing"
         );
         assert_eq!(
-            readopt_continuation_with_died_wake_sources(home.path(), "sess-absent", ResumeLens::MidWork),
+            readopt_continuation_with_died_wake_sources(
+                home.path(),
+                "sess-absent",
+                ResumeLens::MidWork
+            ),
             READOPT_CONTINUATION_TEXT,
             "no meta, no addendum"
         );

--- a/src/bin/caller/boot_readopt.rs
+++ b/src/bin/caller/boot_readopt.rs
@@ -419,21 +419,24 @@ fn scan_midwork_candidates(
     candidates
 }
 
-/// Daemon-restart honesty for parked background tasks (the fourth
+/// Daemon-restart honesty for a dead session's wake sources (the fourth
 /// respawn class): background tasks are OS children of the dead boot's
-/// backend processes, so every task a dead session was parked on died
-/// with that daemon — while the durable bg-park marker
-/// (`SessionMeta::bg_park`) survived, still claiming a live wait.
+/// backend processes and the harness `ScheduleWakeup` timer lived inside
+/// them, so every wake source a dead session was waiting on died with
+/// that daemon — while the durable markers (`SessionMeta::bg_park`,
+/// `SessionMeta::native_wakeup`) survived, still claiming a live wait.
 /// Flip each live marker to its died form under the named cause and
-/// publish the attention snapshot into THIS boot's vitals hub, so no
+/// publish the task attention snapshot into THIS boot's vitals hub, so no
 /// surface (grid chip, drain banner, session card) keeps waiting on a
-/// task that no longer exists. Same walk discipline as
+/// wake that no longer exists. Same walk discipline as
 /// [`scan_midwork_candidates`]: one era predicate parameter, live
 /// wrappers own their own state, unreadable metas skip. Nothing here
-/// re-runs a command — re-running is an owner decision (the session
-/// card's one-tap re-run; readopted candidates additionally get the
-/// offer on the continuation nudge they already receive).
-fn mark_dead_bg_parks(
+/// re-runs a command or re-delivers a wake — re-running is an owner
+/// decision, and the lost-timer note rides the continuation nudge
+/// readopted candidates already receive
+/// ([`readopt_continuation_with_died_wake_sources`]). Returns the count
+/// of sessions whose markers flipped.
+fn mark_dead_wake_sources(
     home: &Path,
     live_wrapper_ids: &HashSet<String>,
     era_keeps: impl Fn(u64) -> bool,
@@ -462,38 +465,62 @@ fn mark_dead_bg_parks(
         if !era_keeps(activity_mtime_secs(&dir)) {
             continue;
         }
-        let Some(park) = meta.bg_park.as_mut() else {
-            continue;
-        };
-        if park.died_cause.is_some() {
-            // Already stamped (an earlier boot's pass, or the wrapper's
-            // own respawn seam) — the first, most specific cause stands.
+        let now_epoch = crate::session_activity::epoch_seconds();
+        // Both wake sources flip in the one walk; an already-stamped
+        // marker (an earlier boot's pass, or the wrapper's own respawn
+        // seam) keeps its first, most specific cause.
+        let mut died_tasks: Option<Vec<String>> = None;
+        if let Some(park) = meta.bg_park.as_mut() {
+            if park.died_cause.is_none() {
+                park.died_cause =
+                    Some(crate::external_supervision::DAEMON_RESTART_CAUSE.to_string());
+                park.died_at_epoch = Some(now_epoch);
+                died_tasks = Some(park.tasks.clone());
+            }
+        }
+        let mut died_wakeup_fire_at: Option<u64> = None;
+        if let Some(wakeup) = meta.native_wakeup.as_mut() {
+            if wakeup.died_cause.is_none() {
+                wakeup.died_cause =
+                    Some(crate::external_supervision::DAEMON_RESTART_CAUSE.to_string());
+                wakeup.died_at_epoch = Some(now_epoch);
+                died_wakeup_fire_at = Some(wakeup.fire_at_epoch);
+            }
+        }
+        if died_tasks.is_none() && died_wakeup_fire_at.is_none() {
             continue;
         }
-        let now_epoch = crate::session_activity::epoch_seconds();
-        park.died_cause = Some(crate::external_supervision::DAEMON_RESTART_CAUSE.to_string());
-        park.died_at_epoch = Some(now_epoch);
-        let tasks = park.tasks.clone();
         let Ok(json) = serde_json::to_string_pretty(&meta) else {
             continue;
         };
         if crate::session_log::write_session_meta_atomic(&dir, &json).is_err() {
             continue;
         }
-        eprintln!(
-            "[readopt] {}: {} background task(s) the session was parked on died with the daemon \
-             restart — marked died-with-restart; nothing is re-run automatically",
-            short_id(&session_id),
-            tasks.len(),
-        );
-        bus.send(AppEvent::SessionActivity {
-            session_id: Some(session_id),
-            activity: crate::external_supervision::died_tasks_attention_activity(
-                tasks,
-                crate::external_supervision::DAEMON_RESTART_CAUSE,
-                now_epoch,
-            ),
-        });
+        if let Some(fire_at) = died_wakeup_fire_at {
+            eprintln!(
+                "[readopt] {}: the session's native scheduled wakeup ({}) died with the \
+                 daemon restart — marked; the readopt continuation carries the lost-timer \
+                 note",
+                short_id(&session_id),
+                crate::native_wakeup::due_phrase(fire_at, now_epoch),
+            );
+        }
+        if let Some(tasks) = died_tasks {
+            eprintln!(
+                "[readopt] {}: {} background task(s) the session was parked on died with the daemon \
+                 restart — marked died-with-restart; nothing is re-run automatically",
+                short_id(&session_id),
+                tasks.len(),
+            );
+            bus.send(AppEvent::SessionActivity {
+                session_id: Some(session_id),
+                activity: crate::external_supervision::died_tasks_attention_activity(
+                    tasks,
+                    crate::external_supervision::DAEMON_RESTART_CAUSE,
+                    now_epoch,
+                ),
+            });
+        }
         marked += 1;
     }
     marked
@@ -718,7 +745,7 @@ pub(crate) fn decide_candidate_with_lens(
         session_id: resume_conversation,
         resume_id: None,
         project_root: project_root.map(|root| root.to_string_lossy().to_string()),
-        task: Some(readopt_continuation_with_died_tasks(
+        task: Some(readopt_continuation_with_died_wake_sources(
             home,
             &candidate.session_id,
             lens,
@@ -737,24 +764,36 @@ pub(crate) fn decide_candidate_with_lens(
 }
 
 /// The lens's continuation nudge, extended with the died-task re-run
-/// OFFER when the restart killed background tasks the candidate was
-/// parked on ([`mark_dead_bg_parks`] stamped the durable marker before
-/// dispatch). The #644 composition law: the offer only ever rides a
-/// nudge the lane already sends — never a minted message — and nothing
-/// here re-executes a command.
-fn readopt_continuation_with_died_tasks(
+/// OFFER and/or the lost-wakeup note when the restart killed wake
+/// sources the candidate was waiting on ([`mark_dead_wake_sources`]
+/// stamped the durable markers before dispatch). The #644 composition
+/// law: the notes only ever ride a nudge the lane already sends — never
+/// a minted message — and nothing here re-executes a command or
+/// re-delivers a wake.
+fn readopt_continuation_with_died_wake_sources(
     home: &Path,
     candidate_id: &str,
     lens: ResumeLens,
 ) -> String {
     let mut text = lens.continuation_text().to_string();
-    if let Some(park) = session_meta_for(home, candidate_id).and_then(|meta| meta.bg_park) {
+    let Some(meta) = session_meta_for(home, candidate_id) else {
+        return text;
+    };
+    if let Some(park) = meta.bg_park {
         if let Some(cause) = park.died_cause.as_deref() {
             if let Some(addendum) =
                 crate::external_supervision::died_tasks_nudge_addendum(&park.tasks, cause)
             {
                 text.push_str(&addendum);
             }
+        }
+    }
+    if let Some(wakeup) = meta.native_wakeup.as_ref() {
+        if let Some(addendum) = crate::external_supervision::died_wakeup_nudge_addendum(
+            wakeup,
+            crate::session_activity::epoch_seconds(),
+        ) {
+            text.push_str(&addendum);
         }
     }
     text
@@ -996,7 +1035,7 @@ mod tests {
         let mut live = HashSet::new();
         live.insert("sess-live-wrapper".to_string());
 
-        let marked = mark_dead_bg_parks(home.path(), &live, |_| true, &bus);
+        let marked = mark_dead_wake_sources(home.path(), &live, |_| true, &bus);
         assert_eq!(marked, 1, "exactly the dead parked session marks");
 
         let park_of = |session: &str| -> crate::session_log::SessionBgParkMeta {
@@ -1059,7 +1098,7 @@ mod tests {
             serde_json::json!({ "tasks": ["fresh work"] }),
         );
         assert_eq!(
-            mark_dead_bg_parks(home.path(), &live, |_| false, &bus),
+            mark_dead_wake_sources(home.path(), &live, |_| false, &bus),
             0,
             "the era predicate gates everything"
         );
@@ -1082,7 +1121,7 @@ mod tests {
                 "died_at_epoch": 100,
             }),
         );
-        let text = readopt_continuation_with_died_tasks(
+        let text = readopt_continuation_with_died_wake_sources(
             home.path(),
             "sess-died-park",
             ResumeLens::MidWork,
@@ -1098,7 +1137,7 @@ mod tests {
             serde_json::json!({ "tasks": ["still running elsewhere"] }),
         );
         assert_eq!(
-            readopt_continuation_with_died_tasks(
+            readopt_continuation_with_died_wake_sources(
                 home.path(),
                 "sess-live-park",
                 ResumeLens::MidWork
@@ -1107,7 +1146,7 @@ mod tests {
             "a live park adds nothing"
         );
         assert_eq!(
-            readopt_continuation_with_died_tasks(home.path(), "sess-absent", ResumeLens::MidWork),
+            readopt_continuation_with_died_wake_sources(home.path(), "sess-absent", ResumeLens::MidWork),
             READOPT_CONTINUATION_TEXT,
             "no meta, no addendum"
         );
@@ -2185,7 +2224,7 @@ pub(crate) async fn run_boot_readopt_pass(
     // tasks get their died-with-restart marking whether or not they
     // become candidates below (a parked-only session never does — its
     // meta reads idle — and exactly that shape was the forever-park).
-    mark_dead_bg_parks(
+    mark_dead_wake_sources(
         &home,
         &live,
         |activity_secs| activity_secs < watershed,
@@ -2659,7 +2698,7 @@ async fn run_released_readopt_pass(
     // predecessor's backend processes took their background children
     // with them, and a released parked-only session never becomes a
     // candidate below.
-    mark_dead_bg_parks(
+    mark_dead_wake_sources(
         home,
         live,
         |activity_secs| activity_secs <= released_before_secs,

--- a/src/bin/caller/external_agent/claude_code.rs
+++ b/src/bin/caller/external_agent/claude_code.rs
@@ -496,6 +496,52 @@ impl CcShared {
 /// `notebook_path`. Feeds `AgentEvent::FileActivity` for the git-vitals
 /// activity-locus tracker (the Codex `fileChange` twin) — structural wire
 /// fields only, never derived from a rendered preview.
+/// Observe a main-thread `ScheduleWakeup` tool_use — the Claude Code
+/// harness's self-pacing loop timer, which lives inside the CC process
+/// and dies with every backend respawn. Records the wire-proven pending
+/// state in the [`crate::native_wakeup`] registry and returns the
+/// durable-marker statement to emit (`Some(Some(_))` = armed/replaced,
+/// `Some(None)` = the model stopped its loop, `None` = nothing
+/// observable: no announced session id yet or an unparseable input).
+/// Observation only — the call still renders as an ordinary tool row.
+fn schedule_wakeup_marker_observation(
+    session_id: Option<&str>,
+    tool_use_id: &str,
+    input: &serde_json::Value,
+) -> Option<Option<crate::session_log::SessionNativeWakeupMeta>> {
+    let session_id = session_id.map(str::trim).filter(|s| !s.is_empty())?;
+    if input.get("stop").and_then(|v| v.as_bool()) == Some(true) {
+        crate::native_wakeup::record_stopped(session_id);
+        return Some(None);
+    }
+    // The wire schema says number; accept a float and round rather than
+    // discarding a real arm over a fractional delay.
+    let delay = input
+        .get("delaySeconds")
+        .and_then(|v| v.as_f64())
+        .filter(|d| d.is_finite() && *d > 0.0)?;
+    let delay = crate::native_wakeup::clamp_delay_seconds(delay.round() as u64);
+    let now_epoch = crate::session_activity::epoch_seconds();
+    let record = crate::native_wakeup::NativeWakeupRecord {
+        armed_at_epoch: now_epoch,
+        fire_at_epoch: now_epoch + delay,
+        prompt: crate::native_wakeup::bounded_prompt(
+            input.get("prompt").and_then(|v| v.as_str()).unwrap_or(""),
+        ),
+        reason: input
+            .get("reason")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string),
+        tool_use_id: tool_use_id.to_string(),
+        rearmed_cause: None,
+    };
+    let meta = record.to_meta();
+    crate::native_wakeup::record_armed(session_id, record);
+    Some(Some(meta))
+}
+
 fn cc_write_tool_paths(tool_name: &str, input: &serde_json::Value) -> Vec<String> {
     if !matches!(tool_name, "Write" | "Edit" | "NotebookEdit") {
         return Vec::new();
@@ -1824,6 +1870,33 @@ impl CcReader {
                 "a backend restart",
                 now_epoch,
             );
+            // An id CHANGE on this live reader: the arming process (and
+            // its harness ScheduleWakeup timer) continues — only the key
+            // rotated. Follow it, unlike the background-task records
+            // above, whose OS children genuinely do not survive.
+            crate::native_wakeup::migrate(previous, id);
+        } else if let Some(taken) = crate::native_wakeup::take_over_at_respawn(id, "a backend restart")
+        {
+            // Fresh adoption of the id by THIS reader with a pending
+            // harness-owned wakeup still on record: the process that
+            // armed it is gone (a resumed CLI restores no timers), and
+            // no supervision seam claimed the record first — the orphan
+            // case (a re-dispatched session whose previous wrapper died
+            // un-seamed). Take delivery over here, exactly like the
+            // seams do, so the wake is re-armed instead of silently
+            // lost.
+            out.events.push(AgentEvent::Log {
+                level: "info".to_string(),
+                message: format!(
+                    "⏰ A pending native scheduled wakeup from the previous backend process \
+                     was re-armed by Intendant ({}) — the fresh process restores no \
+                     harness timers",
+                    crate::native_wakeup::due_phrase(taken.fire_at_epoch, now_epoch),
+                ),
+            });
+            out.events.push(AgentEvent::NativeWakeupMarker {
+                marker: Some(taken.to_meta()),
+            });
         }
         crate::background_tasks::mark_running_died_with_restart(id, "a backend restart", now_epoch);
         self.announced_session_id = Some(id.to_string());
@@ -2598,6 +2671,21 @@ impl CcReader {
                                 entries: fold.entries(),
                             });
                             continue;
+                        }
+                    }
+                    // A main-thread ScheduleWakeup is the harness's loop
+                    // timer: record its pending state (arm / replace /
+                    // stop) so the respawn seams can tell a killed timer
+                    // from plain idleness, and mirror the durable marker
+                    // through the drain. Observation only — the call
+                    // falls through and renders as a normal tool row.
+                    if tool_name == "ScheduleWakeup" && child_scope.is_none() {
+                        if let Some(marker) = schedule_wakeup_marker_observation(
+                            self.announced_session_id.as_deref(),
+                            &tool_id,
+                            &input,
+                        ) {
+                            out.events.push(AgentEvent::NativeWakeupMarker { marker });
                         }
                     }
                     if !tool_id.is_empty() {

--- a/src/bin/caller/external_agent/claude_code.rs
+++ b/src/bin/caller/external_agent/claude_code.rs
@@ -5328,6 +5328,155 @@ mod tests {
         assert_eq!(last_activity(&out).unwrap().state, S::Idle);
     }
 
+    /// The wakeup registry (`crate::native_wakeup`) mirrors the harness
+    /// `ScheduleWakeup` lifecycle from the wire: a main-thread arm
+    /// records (and re-records — the harness keeps one timer) with the
+    /// durable-marker event alongside the ordinary tool row; `stop:
+    /// true` clears both; child-scoped and unparseable calls say
+    /// nothing; a live reader's id rotation migrates the record with the
+    /// process. A FRESH reader adopting an id with a harness-owned
+    /// record still pending takes delivery over (the orphan case: the
+    /// arming process is gone and no supervision seam claimed it), and a
+    /// later fresh adoption leaves the wrapper-owned record alone.
+    /// Session ids unique to this test: the registry is process-global.
+    #[test]
+    fn schedule_wakeup_registry_mirrors_arm_stop_rotation_and_orphan_adoption() {
+        let sid = "cc-swk-parser-0001";
+        let sid2 = "cc-swk-parser-0001-rotated";
+        crate::native_wakeup::consume(sid);
+        crate::native_wakeup::consume(sid2);
+        let markers = |out: &CcLineOutcome| -> Vec<
+            Option<crate::session_log::SessionNativeWakeupMeta>,
+        > {
+            out.events
+                .iter()
+                .filter_map(|e| match e {
+                    AgentEvent::NativeWakeupMarker { marker } => Some(marker.clone()),
+                    _ => None,
+                })
+                .collect()
+        };
+        let mut reader = test_reader();
+
+        // Arm: registry + marker event + the ordinary tool row.
+        let out = reader.process_line(&format!(
+            r#"{{"type":"assistant","message":{{"content":[{{"type":"tool_use","id":"toolu_swk1","name":"ScheduleWakeup","input":{{"delaySeconds":780,"prompt":"<<autonomous-loop-dynamic>>","reason":"pace the loop"}}}}]}},"session_id":"{sid}"}}"#
+        ));
+        let record = crate::native_wakeup::pending_for(sid).expect("armed");
+        assert_eq!(record.fire_at_epoch - record.armed_at_epoch, 780);
+        assert_eq!(record.prompt, "<<autonomous-loop-dynamic>>");
+        assert_eq!(record.reason.as_deref(), Some("pace the loop"));
+        assert!(record.rearmed_cause.is_none(), "harness-owned while alive");
+        let armed_markers = markers(&out);
+        assert_eq!(armed_markers.len(), 1);
+        assert_eq!(
+            armed_markers[0].as_ref().expect("armed form").fire_at_epoch,
+            record.fire_at_epoch
+        );
+        assert!(
+            out.events.iter().any(|e| matches!(
+                e,
+                AgentEvent::ToolStarted { tool_name, .. } if tool_name == "ScheduleWakeup"
+            )),
+            "observation only — the call still renders as a tool row"
+        );
+
+        // Replace: the harness keeps one timer.
+        let out = reader.process_line(&format!(
+            r#"{{"type":"assistant","message":{{"content":[{{"type":"tool_use","id":"toolu_swk2","name":"ScheduleWakeup","input":{{"delaySeconds":1200,"prompt":"next pass"}}}}]}},"session_id":"{sid}"}}"#
+        ));
+        assert_eq!(markers(&out).len(), 1);
+        let record = crate::native_wakeup::pending_for(sid).expect("replaced");
+        assert_eq!(record.fire_at_epoch - record.armed_at_epoch, 1200);
+        assert_eq!(record.prompt, "next pass");
+
+        // Child-scoped and unparseable arms say nothing.
+        let out = reader.process_line(&format!(
+            r#"{{"type":"assistant","parent_tool_use_id":"spawn-1","message":{{"content":[{{"type":"tool_use","id":"toolu_swk3","name":"ScheduleWakeup","input":{{"delaySeconds":60,"prompt":"child"}}}}]}},"session_id":"{sid}"}}"#
+        ));
+        assert!(
+            markers(&out).is_empty(),
+            "child-scoped: not the main thread's timer"
+        );
+        let out = reader.process_line(&format!(
+            r#"{{"type":"assistant","message":{{"content":[{{"type":"tool_use","id":"toolu_swk4","name":"ScheduleWakeup","input":{{"prompt":"no delay"}}}}]}},"session_id":"{sid}"}}"#
+        ));
+        assert!(markers(&out).is_empty(), "no delay, no stop: unparseable");
+        assert_eq!(
+            crate::native_wakeup::pending_for(sid).unwrap().prompt,
+            "next pass",
+            "the record is untouched"
+        );
+
+        // A live reader's id rotation migrates the record with the
+        // process — the timer lives in the process, not the key.
+        reader.process_line(&format!(
+            r#"{{"type":"assistant","message":{{"content":[]}},"session_id":"{sid2}"}}"#
+        ));
+        assert!(
+            crate::native_wakeup::pending_for(sid).is_none(),
+            "followed the rotation"
+        );
+        assert_eq!(
+            crate::native_wakeup::pending_for(sid2).unwrap().prompt,
+            "next pass"
+        );
+
+        // Stop clears registry and marker (under the rotated id).
+        let out = reader.process_line(&format!(
+            r#"{{"type":"assistant","message":{{"content":[{{"type":"tool_use","id":"toolu_swk5","name":"ScheduleWakeup","input":{{"stop":true}}}}]}},"session_id":"{sid2}"}}"#
+        ));
+        assert_eq!(markers(&out), vec![None]);
+        assert!(crate::native_wakeup::pending_for(sid2).is_none());
+
+        // Orphan adoption: a fresh reader adopting the id with a
+        // harness-owned record pending takes delivery over.
+        crate::native_wakeup::record_armed(
+            sid,
+            crate::native_wakeup::NativeWakeupRecord {
+                armed_at_epoch: 100,
+                fire_at_epoch: 880,
+                prompt: "orphaned wake".into(),
+                reason: None,
+                tool_use_id: "toolu_prev".into(),
+                rearmed_cause: None,
+            },
+        );
+        let mut fresh = test_reader();
+        let out = fresh.process_line(&format!(
+            r#"{{"type":"assistant","message":{{"content":[]}},"session_id":"{sid}"}}"#
+        ));
+        let taken = crate::native_wakeup::pending_for(sid).expect("record survives adoption");
+        assert_eq!(taken.rearmed_cause.as_deref(), Some("a backend restart"));
+        let adoption_markers = markers(&out);
+        assert_eq!(adoption_markers.len(), 1);
+        assert_eq!(
+            adoption_markers[0]
+                .as_ref()
+                .unwrap()
+                .rearmed_cause
+                .as_deref(),
+            Some("a backend restart")
+        );
+        assert!(
+            out.events.iter().any(|e| matches!(
+                e,
+                AgentEvent::Log { message, .. } if message.contains("re-armed by Intendant")
+            )),
+            "the takeover announces"
+        );
+
+        // A wrapper-owned record is left alone by yet another fresh
+        // adoption — the supervising loop owns delivery now.
+        let mut third = test_reader();
+        let out = third.process_line(&format!(
+            r#"{{"type":"assistant","message":{{"content":[]}},"session_id":"{sid}"}}"#
+        ));
+        assert!(markers(&out).is_empty(), "already wrapper-owned: silent");
+        assert!(crate::native_wakeup::pending_for(sid).is_some());
+        crate::native_wakeup::consume(sid);
+    }
+
     /// The inspector registry (`crate::background_tasks`) mirrors the
     /// armed lifecycle with the wire's output-path statements: the
     /// launch-ack TEXT announces the path while running (the probed

--- a/src/bin/caller/external_agent/claude_code.rs
+++ b/src/bin/caller/external_agent/claude_code.rs
@@ -1875,7 +1875,8 @@ impl CcReader {
             // rotated. Follow it, unlike the background-task records
             // above, whose OS children genuinely do not survive.
             crate::native_wakeup::migrate(previous, id);
-        } else if let Some(taken) = crate::native_wakeup::take_over_at_respawn(id, "a backend restart")
+        } else if let Some(taken) =
+            crate::native_wakeup::take_over_at_respawn(id, "a backend restart")
         {
             // Fresh adoption of the id by THIS reader with a pending
             // harness-owned wakeup still on record: the process that
@@ -5345,17 +5346,16 @@ mod tests {
         let sid2 = "cc-swk-parser-0001-rotated";
         crate::native_wakeup::consume(sid);
         crate::native_wakeup::consume(sid2);
-        let markers = |out: &CcLineOutcome| -> Vec<
-            Option<crate::session_log::SessionNativeWakeupMeta>,
-        > {
-            out.events
-                .iter()
-                .filter_map(|e| match e {
-                    AgentEvent::NativeWakeupMarker { marker } => Some(marker.clone()),
-                    _ => None,
-                })
-                .collect()
-        };
+        let markers =
+            |out: &CcLineOutcome| -> Vec<Option<crate::session_log::SessionNativeWakeupMeta>> {
+                out.events
+                    .iter()
+                    .filter_map(|e| match e {
+                        AgentEvent::NativeWakeupMarker { marker } => Some(marker.clone()),
+                        _ => None,
+                    })
+                    .collect()
+            };
         let mut reader = test_reader();
 
         // Arm: registry + marker event + the ordinary tool row.

--- a/src/bin/caller/external_agent/mod.rs
+++ b/src/bin/caller/external_agent/mod.rs
@@ -1372,6 +1372,17 @@ pub enum AgentEvent {
     ConfigFacts {
         facts: crate::types::SessionConfigVitals,
     },
+    /// The adapter's statement of the session's pending native scheduled
+    /// wakeup (Claude Code's harness `ScheduleWakeup` timer), shaped as
+    /// the durable marker: `Some` on an observed arm or the adapter-level
+    /// takeover of an orphaned record, `None` when the model stopped its
+    /// loop (`stop: true`). Drains mirror it into
+    /// `SessionMeta::native_wakeup` — the marker the respawn seams, the
+    /// exit backstop, and the boot pass adjudicate. Ambient bookkeeping —
+    /// implies no turn.
+    NativeWakeupMarker {
+        marker: Option<crate::session_log::SessionNativeWakeupMeta>,
+    },
     /// Informational backend event that should be written to the activity log.
     Log { level: String, message: String },
     /// Latest external-agent goal state for a thread.

--- a/src/bin/caller/external_events.rs
+++ b/src/bin/caller/external_events.rs
@@ -1573,6 +1573,13 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                     facts,
                 });
             }
+            external_agent::AgentEvent::NativeWakeupMarker { marker } => {
+                // The adapter's wire-proven pending-wakeup statement →
+                // the durable marker the respawn seams, the exit
+                // backstop, and the boot pass adjudicate. Pure
+                // bookkeeping.
+                slog(config.session_log, |l| l.set_native_wakeup(marker));
+            }
             external_agent::AgentEvent::GoalUpdated { goal } => {
                 emit_external_session_goal(config, event_thread_id.clone(), Some(goal));
             }

--- a/src/bin/caller/external_mode.rs
+++ b/src/bin/caller/external_mode.rs
@@ -5387,6 +5387,99 @@ pub(crate) async fn run_external_agent_mode(
 mod tests {
     use super::*;
 
+    /// The delivered wake is honest about its mechanism and carries the
+    /// model's own prompt — plus the re-arm reminder, since the harness
+    /// timer the model thinks it holds is gone. Empty prompts are said,
+    /// not omitted; an unflipped record names the generic restart.
+    #[test]
+    fn native_wakeup_delivery_message_is_honest_and_carries_the_prompt() {
+        let record = crate::native_wakeup::NativeWakeupRecord {
+            armed_at_epoch: 100,
+            fire_at_epoch: 880,
+            prompt: "<<autonomous-loop-dynamic>>".into(),
+            reason: Some("watching the queue".into()),
+            tool_use_id: "toolu_wk".into(),
+            rearmed_cause: Some(CREDENTIAL_RELOAD_RESTART_CAUSE.into()),
+        };
+        let message = native_wakeup_delivery_message(&record, 900);
+        assert!(message.text.contains("Scheduled wakeup"), "{}", message.text);
+        assert!(
+            message.text.contains(CREDENTIAL_RELOAD_RESTART_CAUSE),
+            "{}",
+            message.text
+        );
+        assert!(
+            message.text.contains("<<autonomous-loop-dynamic>>"),
+            "{}",
+            message.text
+        );
+        assert!(
+            message.text.contains("watching the queue"),
+            "{}",
+            message.text
+        );
+        assert!(
+            message.text.contains("re-arm your next wakeup"),
+            "{}",
+            message.text
+        );
+        assert!(
+            message.steer_id.is_none() && message.follow_up_id.is_none(),
+            "no id-keyed cancel matching can drop the wake"
+        );
+
+        let bare = crate::native_wakeup::NativeWakeupRecord {
+            prompt: String::new(),
+            reason: None,
+            rearmed_cause: None,
+            ..record
+        };
+        let message = native_wakeup_delivery_message(&bare, 900);
+        assert!(
+            message.text.contains("(the arm carried no prompt)"),
+            "{}",
+            message.text
+        );
+        assert!(message.text.contains("a backend restart"), "{}", message.text);
+    }
+
+    /// The deadline arm's instant: a future due time sleeps toward it, a
+    /// past one fires immediately, and the disabled branch type-checks
+    /// on "now" (the limit-park arm's exact pattern).
+    #[test]
+    fn native_wakeup_deadline_maps_due_times_to_instants() {
+        let now_epoch = crate::session_activity::epoch_seconds();
+        let record = |fire_at: u64| {
+            Some(crate::native_wakeup::NativeWakeupRecord {
+                armed_at_epoch: now_epoch,
+                fire_at_epoch: fire_at,
+                prompt: "x".into(),
+                reason: None,
+                tool_use_id: "t".into(),
+                rearmed_cause: None,
+            })
+        };
+        let now = tokio::time::Instant::now();
+        let future = native_wakeup_deadline(&record(now_epoch + 600));
+        let remaining = future.duration_since(now);
+        assert!(
+            remaining >= std::time::Duration::from_secs(590)
+                && remaining <= std::time::Duration::from_secs(610),
+            "future due time sleeps toward it ({remaining:?})"
+        );
+        assert!(
+            native_wakeup_deadline(&record(now_epoch.saturating_sub(600)))
+                .duration_since(now)
+                < std::time::Duration::from_secs(2),
+            "past due time fires immediately"
+        );
+        assert!(
+            native_wakeup_deadline(&None).duration_since(now)
+                < std::time::Duration::from_secs(2),
+            "disabled branch reads as now"
+        );
+    }
+
     #[test]
     fn idle_cwd_announcement_is_housekeeping_for_the_primary_session() {
         let session_id = Some("session-main".to_string());

--- a/src/bin/caller/external_mode.rs
+++ b/src/bin/caller/external_mode.rs
@@ -132,7 +132,10 @@ pub(crate) fn idle_external_pr_published_event(
 /// killed (they were the old process's children —
 /// [`mark_parked_tasks_died_with_restart`] flipped their records and
 /// published the attention state before the shutdown), so the caller's
-/// continuation can carry the re-run offer.
+/// continuation can carry the re-run offer. The same call re-arms a
+/// pending native scheduled wakeup wrapper-side
+/// ([`take_over_native_wakeup_at_respawn`]) — the harness timer dies
+/// with the old process, and the resumed CLI restores none.
 #[allow(clippy::too_many_arguments)]
 async fn apply_backend_credentials_reload(
     backend: &external_agent::AgentBackend,
@@ -288,6 +291,56 @@ async fn respawn_external_backend_in_place(
 /// The named cause stamped on background tasks the credential-reload
 /// respawn kills (see [`mark_parked_tasks_died_with_restart`]).
 pub(crate) const CREDENTIAL_RELOAD_RESTART_CAUSE: &str = "the credential-reload restart";
+
+/// The wake message the supervising loop delivers when a re-armed native
+/// scheduled wakeup fires ([`crate::native_wakeup`]): honest about the
+/// mechanism — the harness's own `ScheduleWakeup` timer died with the
+/// named backend restart and Intendant re-armed it — and carrying the
+/// model's own wake prompt, so the loop the model was pacing continues
+/// as if the harness had fired. Pure; the clock is injected for tests.
+pub(crate) fn native_wakeup_delivery_message(
+    record: &crate::native_wakeup::NativeWakeupRecord,
+    now_epoch: u64,
+) -> FollowUpMessage {
+    let cause = record
+        .rearmed_cause
+        .as_deref()
+        .unwrap_or("a backend restart");
+    let reason = record
+        .reason
+        .as_deref()
+        .map(|r| format!(" Your stated reason for the delay: {r}."))
+        .unwrap_or_default();
+    let prompt = if record.prompt.trim().is_empty() {
+        "(the arm carried no prompt)".to_string()
+    } else {
+        record.prompt.clone()
+    };
+    FollowUpMessage::text(format!(
+        "⏰ Scheduled wakeup ({}). Your ScheduleWakeup timer did not survive {cause}, so \
+         Intendant re-armed it and is delivering the wake itself — re-arm your next wakeup \
+         as usual if you still want the cadence.{reason} Original wakeup prompt:\n{prompt}",
+        crate::native_wakeup::due_phrase(record.fire_at_epoch, now_epoch),
+    ))
+}
+
+/// Deadline instant for the idle select's native-wakeup arm: the due
+/// time as a tokio instant (an already-due record reads as "now" and the
+/// arm fires immediately). `now` when nothing pends — the arm is
+/// guard-disabled then and the value merely type-checks the disabled
+/// branch, the limit-park arm's exact pattern.
+fn native_wakeup_deadline(
+    pending: &Option<crate::native_wakeup::NativeWakeupRecord>,
+) -> tokio::time::Instant {
+    let now = tokio::time::Instant::now();
+    match pending {
+        Some(record) => {
+            let now_epoch = crate::session_activity::epoch_seconds();
+            now + std::time::Duration::from_secs(record.fire_at_epoch.saturating_sub(now_epoch))
+        }
+        None => now,
+    }
+}
 
 /// The follow-up text synthesized when a credential reload's own
 /// interrupt cut a live turn. Resume-attach keeps the conversation
@@ -886,6 +939,17 @@ pub(crate) async fn run_external_agent_mode(
                 {
                     break FollowUpMessage::text(String::new());
                 }
+                // Pending native scheduled wakeup ([`crate::native_wakeup`]),
+                // peeked per iteration — every drained event re-enters this
+                // loop, so a fresh arm/replace/stop from the backend is
+                // re-read before the next wait. The deadline arm below
+                // retires a harness-owned record whose due time passes with
+                // the backend alive (the harness owns that fire) and
+                // delivers a wrapper-owned one.
+                let pending_native_wakeup = stats
+                    .announced_native_session_id
+                    .as_deref()
+                    .and_then(crate::native_wakeup::pending_for);
                 tokio::select! {
                     maybe_intent = external_intent_rx.recv(), if external_intent_open => {
                         match maybe_intent {
@@ -1078,6 +1142,139 @@ pub(crate) async fn run_external_agent_mode(
                             );
                         }
                     }
+                    // Native-wakeup deadline (see the peek above). A
+                    // harness-owned record whose due time passes with the
+                    // backend process alive is retired — the harness owns
+                    // that fire, and a record outliving its moment would
+                    // make a later respawn re-deliver a wake the model
+                    // already got. A wrapper-owned record delivers: the
+                    // wake respawns a confirmed-dead backend first (the
+                    // park-wake pattern above) and queues behind a live
+                    // limit park instead of burning against a rejected
+                    // backend.
+                    _ = tokio::time::sleep_until(
+                        native_wakeup_deadline(&pending_native_wakeup)
+                    ), if pending_native_wakeup.is_some() => {
+                        let record = pending_native_wakeup.expect("branch guarded by is_some");
+                        let session_key = stats
+                            .announced_native_session_id
+                            .clone()
+                            .unwrap_or_default();
+                        let now_epoch = crate::session_activity::epoch_seconds();
+                        if record.rearmed_cause.is_none() {
+                            if !agent.next_round_reads_fresh_credentials() {
+                                // Alive through the deadline: the harness
+                                // owns this fire (its wake turn, if any,
+                                // arrives as ordinary backend activity).
+                                crate::native_wakeup::consume(&session_key);
+                                slog(&session_log, |l| {
+                                    l.debug(
+                                        "Native scheduled wakeup deadline passed with the backend process alive — the harness owns that fire; the wrapper record is retired",
+                                    )
+                                });
+                                slog(&session_log, |l| l.set_native_wakeup(None));
+                                continue;
+                            }
+                            // Confirmed dead with the record still
+                            // harness-owned: this death reached no respawn
+                            // seam (the narrow idle-death window) — take
+                            // the timer over now and deliver below.
+                            take_over_native_wakeup_at_respawn(
+                                &bus,
+                                &session_log,
+                                &live_session_id,
+                                &session_key,
+                                "the backend exit",
+                                now_epoch,
+                            );
+                        }
+                        // Re-take from the registry: the takeover above
+                        // (or an earlier seam's) rewrote the record with
+                        // its wrapper-owned cause — the peeked copy is
+                        // stale.
+                        let Some(record) = crate::native_wakeup::consume(&session_key) else {
+                            continue;
+                        };
+                        if limit_park.is_some() {
+                            let line = format!(
+                                "⏰ The re-armed native scheduled wakeup fired during a park ({}) — queued; it delivers at the park's wake",
+                                crate::native_wakeup::due_phrase(record.fire_at_epoch, now_epoch),
+                            );
+                            slog(&session_log, |l| l.info(&line));
+                            bus.send(AppEvent::LogEntry {
+                                session_id: live_session_id.clone(),
+                                level: "info".to_string(),
+                                source: "Intendant".to_string(),
+                                content: line,
+                                turn: None,
+                            });
+                            parked_follow_ups
+                                .push_back(native_wakeup_delivery_message(&record, now_epoch));
+                            slog(&session_log, |l| l.set_native_wakeup(None));
+                            continue;
+                        }
+                        if agent.next_round_reads_fresh_credentials() {
+                            match respawn_external_backend_in_place(
+                                &backend,
+                                &project,
+                                web_port,
+                                &intendant_session_id,
+                                &session_agent_config,
+                                &stats,
+                                &mut agent,
+                                &mut event_rx,
+                                &mut drain_config,
+                            )
+                            .await
+                            {
+                                Ok(()) => {
+                                    event_channel_open = true;
+                                    let line = format!(
+                                        "The re-armed native wakeup elapsed with the backend gone — respawned {} resume-attached to deliver the wake",
+                                        backend
+                                    );
+                                    slog(&session_log, |l| l.info(&line));
+                                    bus.send(AppEvent::LogEntry {
+                                        session_id: live_session_id.clone(),
+                                        level: "info".to_string(),
+                                        source: "Intendant".to_string(),
+                                        content: line,
+                                        turn: None,
+                                    });
+                                }
+                                Err(e) => {
+                                    let line = format!(
+                                        "The re-armed native wakeup elapsed, but the dead backend could not be respawned: {e}"
+                                    );
+                                    slog(&session_log, |l| l.error(&line));
+                                    let mut died = record.to_meta();
+                                    died.died_cause =
+                                        Some("the failed respawn at the wake".to_string());
+                                    died.died_at_epoch = Some(now_epoch);
+                                    slog(&session_log, |l| {
+                                        l.set_native_wakeup(Some(died))
+                                    });
+                                    bus.send(AppEvent::LoopError(line.clone()));
+                                    stats.terminal_outcome = Some(line);
+                                    break 'outer;
+                                }
+                            }
+                        }
+                        let line = format!(
+                            "⏰ Delivering the re-armed native scheduled wakeup ({})",
+                            crate::native_wakeup::due_phrase(record.fire_at_epoch, now_epoch),
+                        );
+                        slog(&session_log, |l| l.info(&line));
+                        bus.send(AppEvent::LogEntry {
+                            session_id: live_session_id.clone(),
+                            level: "info".to_string(),
+                            source: "Intendant".to_string(),
+                            content: line,
+                            turn: None,
+                        });
+                        slog(&session_log, |l| l.set_native_wakeup(None));
+                        break native_wakeup_delivery_message(&record, now_epoch);
+                    }
                     maybe_event = event_rx.recv(), if event_channel_open => {
                         match maybe_event {
                             Some(event) => {
@@ -1269,6 +1466,17 @@ pub(crate) async fn run_external_agent_mode(
                                         bus.send(AppEvent::SessionConfigFacts {
                                             session_id: drain_config.session_id.clone(),
                                             facts,
+                                        });
+                                    }
+                                    // Ambient like ActivityUpdate: the
+                                    // adapter's pending-wakeup statement
+                                    // mirrors into the durable marker and
+                                    // must never open an observe round.
+                                    external_agent::AgentEvent::NativeWakeupMarker {
+                                        marker,
+                                    } => {
+                                        slog(&session_log, |l| {
+                                            l.set_native_wakeup(marker)
                                         });
                                     }
                                     external_agent::AgentEvent::CwdAnnounced { cwd } => {
@@ -5116,6 +5324,46 @@ pub(crate) async fn run_external_agent_mode(
             slog(&session_log, |l| {
                 l.info(&format!("{noun} cancelled — {detail}"))
             });
+        }
+    }
+
+    // The wakeup twin of the park backstop above: the loop is ending with
+    // the session's native scheduled wakeup still on record — the
+    // in-memory registry entry is about to lose the only lane that could
+    // deliver it. Flip the durable marker to its died form (the honest
+    // lost-timer statement: nothing will deliver it, and re-arming is the
+    // resumed session's decision) — except at the daemon-teardown exit,
+    // where the marker survives untouched as the boot pass's trace,
+    // exactly like the limit park's.
+    if let Some(record) = stats
+        .announced_native_session_id
+        .as_deref()
+        .and_then(crate::native_wakeup::consume)
+    {
+        let now_epoch = crate::session_activity::epoch_seconds();
+        let due = crate::native_wakeup::due_phrase(record.fire_at_epoch, now_epoch);
+        let detail = stats
+            .terminal_outcome
+            .clone()
+            .unwrap_or_else(|| "the session ended".to_string());
+        if daemon_teardown_exit {
+            slog(&session_log, |l| {
+                l.warn(&format!(
+                    "A native scheduled wakeup ({due}) is still pending at the \
+                     daemon-teardown exit — the durable marker survives for the boot pass"
+                ))
+            });
+        } else {
+            slog(&session_log, |l| {
+                l.warn(&format!(
+                    "⚠ The session's native scheduled wakeup ({due}) was lost with the \
+                     session end ({detail}) — nothing will deliver it"
+                ))
+            });
+            let mut died = record.to_meta();
+            died.died_cause = Some("the session end".to_string());
+            died.died_at_epoch = Some(now_epoch);
+            slog(&session_log, |l| l.set_native_wakeup(Some(died)));
         }
     }
 

--- a/src/bin/caller/external_mode.rs
+++ b/src/bin/caller/external_mode.rs
@@ -5402,7 +5402,11 @@ mod tests {
             rearmed_cause: Some(CREDENTIAL_RELOAD_RESTART_CAUSE.into()),
         };
         let message = native_wakeup_delivery_message(&record, 900);
-        assert!(message.text.contains("Scheduled wakeup"), "{}", message.text);
+        assert!(
+            message.text.contains("Scheduled wakeup"),
+            "{}",
+            message.text
+        );
         assert!(
             message.text.contains(CREDENTIAL_RELOAD_RESTART_CAUSE),
             "{}",
@@ -5440,7 +5444,11 @@ mod tests {
             "{}",
             message.text
         );
-        assert!(message.text.contains("a backend restart"), "{}", message.text);
+        assert!(
+            message.text.contains("a backend restart"),
+            "{}",
+            message.text
+        );
     }
 
     /// The deadline arm's instant: a future due time sleeps toward it, a
@@ -5468,14 +5476,12 @@ mod tests {
             "future due time sleeps toward it ({remaining:?})"
         );
         assert!(
-            native_wakeup_deadline(&record(now_epoch.saturating_sub(600)))
-                .duration_since(now)
+            native_wakeup_deadline(&record(now_epoch.saturating_sub(600))).duration_since(now)
                 < std::time::Duration::from_secs(2),
             "past due time fires immediately"
         );
         assert!(
-            native_wakeup_deadline(&None).duration_since(now)
-                < std::time::Duration::from_secs(2),
+            native_wakeup_deadline(&None).duration_since(now) < std::time::Duration::from_secs(2),
             "disabled branch reads as now"
         );
     }

--- a/src/bin/caller/external_supervision.rs
+++ b/src/bin/caller/external_supervision.rs
@@ -2670,6 +2670,135 @@ mod tests {
         crate::background_tasks::clear_session(sid);
     }
 
+    /// THE re-arm pin for the ScheduleWakeup respawn variant (the
+    /// 2026-08-01 specimen: a session parked on NOTHING but its harness
+    /// timer): the marking seam takes a pending native wakeup over even
+    /// when zero background tasks died — the registry record flips
+    /// wrapper-owned under the named cause, the durable marker mirrors
+    /// the re-armed form, and the one surface is a log row. No delivery
+    /// is armed here: the supervising loop's deadline arm owns the wake.
+    /// Later seams find the record already wrapper-owned and stay silent
+    /// (the first, most specific cause stands).
+    #[test]
+    fn native_wakeup_takeover_rearms_without_died_tasks() {
+        let sid = "cc-wakeup-takeover-session";
+        crate::native_wakeup::record_armed(
+            sid,
+            crate::native_wakeup::NativeWakeupRecord {
+                armed_at_epoch: 100,
+                fire_at_epoch: 880,
+                prompt: "<<autonomous-loop-dynamic>>".into(),
+                reason: Some("watching the merge queue".into()),
+                tool_use_id: "toolu_wk1".into(),
+                rearmed_cause: None,
+            },
+        );
+        let bus = EventBus::new();
+        let mut rx = bus.subscribe();
+        let dir = tempfile::tempdir().unwrap();
+        let log = std::sync::Arc::new(std::sync::Mutex::new(
+            session_log::SessionLog::open(dir.path().join("s")).unwrap(),
+        ));
+        slog(&log, |l| l.write_meta(None, Some("seat")));
+
+        let descs = mark_parked_tasks_died_with_restart(
+            &bus,
+            &log,
+            &Some("wrapper-wk".to_string()),
+            Some(sid),
+            SERVICE_RECOVERY_RESTART_CAUSE,
+        );
+        assert!(descs.is_empty(), "no background tasks died");
+
+        let record = crate::native_wakeup::pending_for(sid).expect("record retained");
+        assert_eq!(
+            record.rearmed_cause.as_deref(),
+            Some(SERVICE_RECOVERY_RESTART_CAUSE)
+        );
+
+        let meta_path = log.lock().unwrap().dir().join("session_meta.json");
+        let meta: session_log::SessionMeta =
+            serde_json::from_str(&std::fs::read_to_string(meta_path).unwrap()).unwrap();
+        let marker = meta.native_wakeup.expect("re-armed marker stamped");
+        assert_eq!(
+            marker.rearmed_cause.as_deref(),
+            Some(SERVICE_RECOVERY_RESTART_CAUSE)
+        );
+        assert!(marker.died_cause.is_none(), "re-armed, not lost");
+        assert_eq!(marker.fire_at_epoch, 880);
+        assert_eq!(marker.prompt, "<<autonomous-loop-dynamic>>");
+
+        // Surfaces only: exactly the one info row, nothing
+        // dispatch-shaped (the no-auto-delivery law shared with the
+        // died-tasks pin above — delivery belongs to the loop's arm).
+        let mut saw_rearm_line = false;
+        while let Ok(event) = rx.try_recv() {
+            match event {
+                AppEvent::LogEntry { content, level, .. } => {
+                    assert_eq!(level, "info");
+                    assert!(content.contains("re-armed"), "{content}");
+                    assert!(content.contains(SERVICE_RECOVERY_RESTART_CAUSE), "{content}");
+                    saw_rearm_line = true;
+                }
+                other => panic!("wakeup takeover emitted a non-surface event: {other:?}"),
+            }
+        }
+        assert!(saw_rearm_line, "the re-arm announces itself");
+
+        // Idempotent across later seams: first cause stands, no
+        // re-announce.
+        let again = mark_parked_tasks_died_with_restart(
+            &bus,
+            &log,
+            &Some("wrapper-wk".to_string()),
+            Some(sid),
+            RATE_LIMIT_RESTART_CAUSE,
+        );
+        assert!(again.is_empty());
+        assert!(rx.try_recv().is_err(), "already wrapper-owned: silent");
+        assert_eq!(
+            crate::native_wakeup::pending_for(sid)
+                .unwrap()
+                .rearmed_cause
+                .as_deref(),
+            Some(SERVICE_RECOVERY_RESTART_CAUSE)
+        );
+        crate::native_wakeup::consume(sid);
+    }
+
+    /// The lost-timer note composes like the died-task offer: nothing
+    /// without a died cause (a pending or re-armed wake is not lost),
+    /// text-only with one — carrying the cause, the model's own wake
+    /// prompt, and the stated reason.
+    #[test]
+    fn died_wakeup_addendum_only_speaks_for_lost_timers() {
+        let mut meta = session_log::SessionNativeWakeupMeta {
+            armed_at_epoch: 100,
+            fire_at_epoch: 880,
+            prompt: "<<autonomous-loop-dynamic>>".into(),
+            reason: Some("queue watch".into()),
+            rearmed_cause: None,
+            died_cause: None,
+            died_at_epoch: None,
+        };
+        assert!(died_wakeup_nudge_addendum(&meta, 900).is_none());
+
+        meta.died_cause = Some(DAEMON_RESTART_CAUSE.into());
+        let note = died_wakeup_nudge_addendum(&meta, 900).expect("note");
+        assert!(note.contains(DAEMON_RESTART_CAUSE), "{note}");
+        assert!(note.contains("<<autonomous-loop-dynamic>>"), "{note}");
+        assert!(note.contains("NOT re-armed"), "{note}");
+        assert!(note.contains("(reason: queue watch)"), "{note}");
+
+        // An empty prompt is said, not omitted.
+        meta.prompt = String::new();
+        assert!(
+            died_wakeup_nudge_addendum(&meta, 900)
+                .unwrap()
+                .contains("(empty)")
+        );
+    }
+
     /// The durable bg-park marker follows the activity claims: parked
     /// stamps the live form, quiet idle clears only a live marker (a
     /// died statement survives a respawned backend settling), and any

--- a/src/bin/caller/external_supervision.rs
+++ b/src/bin/caller/external_supervision.rs
@@ -1771,6 +1771,11 @@ pub(crate) fn delivery_aware_park_pending(
 /// re-arms delivery: commands are not known idempotent, so re-running is
 /// an owner decision — the session card's one-tap re-run, or the model
 /// deciding after an owner-visible nudge.
+///
+/// The same confirmed death also reconciles the session's pending native
+/// scheduled wakeup ([`take_over_native_wakeup_at_respawn`]) — the one
+/// wake source that IS re-armed across the respawn, because delivering a
+/// recorded wake prompt executes nothing.
 pub(crate) fn mark_parked_tasks_died_with_restart(
     bus: &EventBus,
     session_log: &SharedSessionLog,
@@ -1783,6 +1788,17 @@ pub(crate) fn mark_parked_tasks_died_with_restart(
         return Vec::new();
     };
     let now_epoch = crate::session_activity::epoch_seconds();
+    // The same confirmed death also killed the harness's own ScheduleWakeup
+    // timer — reconcile it BEFORE the task early-return: the wakeup class's
+    // specimen was parked on nothing but its timer (zero background tasks).
+    take_over_native_wakeup_at_respawn(
+        bus,
+        session_log,
+        live_session_id,
+        backend_session_id,
+        cause,
+        now_epoch,
+    );
     let died = crate::background_tasks::mark_running_died_with_restart(
         backend_session_id,
         cause,
@@ -1828,6 +1844,73 @@ pub(crate) fn mark_parked_tasks_died_with_restart(
         activity: died_tasks_attention_activity(descs.clone(), cause, now_epoch),
     });
     descs
+}
+
+/// The respawn-seam half of the native-wakeup takeover
+/// ([`crate::native_wakeup`]): the confirmed backend death that killed
+/// the parked background tasks above also killed the harness's own
+/// `ScheduleWakeup` timer, so a still-pending record flips wrapper-owned
+/// here under the named cause — the supervising loop's idle deadline arm
+/// then delivers the wake at its due time. Announces the re-arm and
+/// stamps the durable marker's re-armed form. Unlike background tasks —
+/// commands, never re-run automatically — re-arming a timer is safe:
+/// delivering the recorded wake prompt executes nothing. Idempotent: the
+/// first seam to flip announces; later seams find the record already
+/// wrapper-owned and say nothing.
+pub(crate) fn take_over_native_wakeup_at_respawn(
+    bus: &EventBus,
+    session_log: &SharedSessionLog,
+    live_session_id: &Option<String>,
+    backend_session_id: &str,
+    cause: &str,
+    now_epoch: u64,
+) -> Option<crate::native_wakeup::NativeWakeupRecord> {
+    let taken = crate::native_wakeup::take_over_at_respawn(backend_session_id, cause)?;
+    let line = format!(
+        "⏰ The backend's native scheduled wakeup ({}) survived {cause}: Intendant re-armed \
+         it and delivers the wake at its due time",
+        crate::native_wakeup::due_phrase(taken.fire_at_epoch, now_epoch),
+    );
+    slog(session_log, |l| l.info(&line));
+    bus.send(AppEvent::LogEntry {
+        session_id: live_session_id.clone(),
+        level: "info".to_string(),
+        source: "Intendant".to_string(),
+        content: line,
+        turn: None,
+    });
+    slog(session_log, |l| {
+        l.set_native_wakeup(Some(taken.to_meta()))
+    });
+    Some(taken)
+}
+
+/// The lost-timer note a delivery lane appends to a continuation it
+/// ALREADY sends (the #644 composition law — never a minted message):
+/// the session's native scheduled wakeup died with no re-arm possible
+/// (`died_cause` set — daemon restart, session end), so the model must
+/// re-arm its own cadence if it still wants one. Carries the original
+/// wake prompt (bounded at record time) so nothing is silently lost.
+pub(crate) fn died_wakeup_nudge_addendum(
+    meta: &crate::session_log::SessionNativeWakeupMeta,
+    now_epoch: u64,
+) -> Option<String> {
+    let cause = meta.died_cause.as_deref()?;
+    let reason = meta
+        .reason
+        .as_deref()
+        .map(|r| format!(" (reason: {r})"))
+        .unwrap_or_default();
+    let prompt = if meta.prompt.trim().is_empty() {
+        "(empty)".to_string()
+    } else {
+        meta.prompt.clone()
+    };
+    Some(format!(
+        " Note: your native scheduled wakeup ({}){reason} died with {cause} and was NOT \
+         re-armed — re-arm it if you still need the cadence. Its wake prompt was: {prompt}",
+        crate::native_wakeup::due_phrase(meta.fire_at_epoch, now_epoch),
+    ))
 }
 
 /// The honest between-turn snapshot after a respawn killed the parked

--- a/src/bin/caller/external_supervision.rs
+++ b/src/bin/caller/external_supervision.rs
@@ -1879,9 +1879,7 @@ pub(crate) fn take_over_native_wakeup_at_respawn(
         content: line,
         turn: None,
     });
-    slog(session_log, |l| {
-        l.set_native_wakeup(Some(taken.to_meta()))
-    });
+    slog(session_log, |l| l.set_native_wakeup(Some(taken.to_meta())));
     Some(taken)
 }
 
@@ -2737,7 +2735,10 @@ mod tests {
                 AppEvent::LogEntry { content, level, .. } => {
                     assert_eq!(level, "info");
                     assert!(content.contains("re-armed"), "{content}");
-                    assert!(content.contains(SERVICE_RECOVERY_RESTART_CAUSE), "{content}");
+                    assert!(
+                        content.contains(SERVICE_RECOVERY_RESTART_CAUSE),
+                        "{content}"
+                    );
                     saw_rearm_line = true;
                 }
                 other => panic!("wakeup takeover emitted a non-surface event: {other:?}"),
@@ -2792,11 +2793,9 @@ mod tests {
 
         // An empty prompt is said, not omitted.
         meta.prompt = String::new();
-        assert!(
-            died_wakeup_nudge_addendum(&meta, 900)
-                .unwrap()
-                .contains("(empty)")
-        );
+        assert!(died_wakeup_nudge_addendum(&meta, 900)
+            .unwrap()
+            .contains("(empty)"));
     }
 
     /// The durable bg-park marker follows the activity claims: parked

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -74,6 +74,7 @@ mod mcp;
 mod mcp_client;
 mod memory;
 mod message_search;
+mod native_wakeup;
 mod openai_chatgpt_auth;
 mod peer;
 mod peer_file_transfer;

--- a/src/bin/caller/native_wakeup.rs
+++ b/src/bin/caller/native_wakeup.rs
@@ -85,6 +85,59 @@ pub(crate) fn clamp_delay_seconds(delay: u64) -> u64 {
     delay.clamp(MIN_DELAY_SECONDS, MAX_DELAY_SECONDS)
 }
 
+/// Human phrase for a wakeup's due time: the shared reset-phrase shape
+/// while the wake is still ahead ("due 4:00 PM (in ~2h 5m)"), an honest
+/// past form once it isn't ("was due 4:00 PM (~13m ago)" — a wake being
+/// delivered late because the backend was down at the due time).
+pub(crate) fn due_phrase(fire_at_epoch: u64, now_epoch: u64) -> String {
+    if fire_at_epoch > now_epoch {
+        return crate::external_agent::limit_reset_phrase_verb(
+            "due",
+            Some(fire_at_epoch),
+            now_epoch,
+        );
+    }
+    let overdue = now_epoch - fire_at_epoch;
+    let ago = if overdue < 60 {
+        format!("~{overdue}s ago")
+    } else if overdue < 3600 {
+        format!("~{}m ago", overdue.div_ceil(60))
+    } else {
+        format!("~{}h {}m ago", overdue / 3600, (overdue % 3600) / 60)
+    };
+    use chrono::TimeZone;
+    let absolute = chrono::Local
+        .timestamp_opt(fire_at_epoch as i64, 0)
+        .single()
+        .map(|dt| {
+            if overdue >= 24 * 3600 {
+                dt.format("%b %-d, %-I:%M %p").to_string()
+            } else {
+                dt.format("%-I:%M %p").to_string()
+            }
+        });
+    match absolute {
+        Some(absolute) => format!("was due {absolute} ({ago})"),
+        None => format!("was due {ago}"),
+    }
+}
+
+impl NativeWakeupRecord {
+    /// The durable-marker form of this record (pending — the died fields
+    /// are the exit/boot lanes' statements, never the registry's).
+    pub(crate) fn to_meta(&self) -> crate::session_log::SessionNativeWakeupMeta {
+        crate::session_log::SessionNativeWakeupMeta {
+            armed_at_epoch: self.armed_at_epoch,
+            fire_at_epoch: self.fire_at_epoch,
+            prompt: self.prompt.clone(),
+            reason: self.reason.clone(),
+            rearmed_cause: self.rearmed_cause.clone(),
+            died_cause: None,
+            died_at_epoch: None,
+        }
+    }
+}
+
 /// Bound a wake prompt for retention (registry and durable marker).
 pub(crate) fn bounded_prompt(prompt: &str) -> String {
     if prompt.chars().count() <= PROMPT_RETAINED_CHARS {

--- a/src/bin/caller/native_wakeup.rs
+++ b/src/bin/caller/native_wakeup.rs
@@ -320,7 +320,9 @@ mod tests {
     #[test]
     fn take_over_flips_once_and_first_cause_stands() {
         let mut reg = Registry::new();
-        assert!(reg.take_over_at_respawn("s1", "the daemon restart").is_none());
+        assert!(reg
+            .take_over_at_respawn("s1", "the daemon restart")
+            .is_none());
         reg.record_armed("s1", record(1000));
         let flipped = reg
             .take_over_at_respawn("s1", "the credential-reload restart")
@@ -331,7 +333,9 @@ mod tests {
         );
         // Second seam finds it already wrapper-owned: no re-announce, the
         // first, most specific cause stands.
-        assert!(reg.take_over_at_respawn("s1", "the rate-limit restart").is_none());
+        assert!(reg
+            .take_over_at_respawn("s1", "the rate-limit restart")
+            .is_none());
         assert_eq!(
             reg.pending_for("s1").unwrap().rearmed_cause.as_deref(),
             Some("the credential-reload restart")

--- a/src/bin/caller/native_wakeup.rs
+++ b/src/bin/caller/native_wakeup.rs
@@ -1,0 +1,329 @@
+//! Live registry of backend-native scheduled wakeups, per session — the
+//! wake-source twin of [`crate::background_tasks`] for the respawn-orphan
+//! class.
+//!
+//! Claude Code's harness serves the model a `ScheduleWakeup` tool (the
+//! self-pacing loop timer: "wake me in N seconds with this prompt"). That
+//! timer lives INSIDE the backend process, so every backend respawn class
+//! (credential reload, rate-limit restart, service-recovery restart,
+//! daemon restart) kills it while the session's idle state survives — the
+//! 2026-08-01 specimen idled forever after a credential reload because
+//! nothing knew its 22:17 wakeup had died at 22:05. The adapter records
+//! only what its own wire proves: a main-thread `ScheduleWakeup` tool_use
+//! arms (or, with `stop: true`, clears) the session's one pending record.
+//!
+//! Ownership handoff is the point of the registry. While the arming
+//! process lives, the harness owns the fire and the record is bookkeeping
+//! (the supervising loop retires it when the deadline passes with the
+//! process alive — the harness had its chance, and any turn it woke is
+//! ordinary observed activity). When a respawn seam confirms the process
+//! died with the record still pending, [`take_over_at_respawn`] flips it
+//! to wrapper-owned: the supervising loop's deadline arm then delivers
+//! the wake itself at the original due time (immediately when the due
+//! time already passed while the backend was down). Unlike background
+//! tasks — commands that are never re-run automatically — re-arming a
+//! timer is safe: delivering the recorded wake prompt executes nothing.
+//!
+//! Keys are the backend-native session id (the id stamped on every wire
+//! line, stable across resumes), exactly like the background-task
+//! registry. The durable half lives on `SessionMeta::native_wakeup`
+//! (stamped by the drains and the supervision seams), which is how the
+//! boot pass tells a wakeup the daemon restart killed from silence.
+//!
+//! Core operations live on [`Registry`] (tests drive local instances —
+//! the process global is shared); the `pub(crate)` free functions are the
+//! global's transport edge.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+/// Ceiling for a retained wake prompt. Prompts past it are truncated with
+/// [`PROMPT_TRUNCATION_SUFFIX`] — the wake still delivers, honestly
+/// marked, and the durable marker stays one bounded meta field instead of
+/// an unbounded transcript copy.
+pub(crate) const PROMPT_RETAINED_CHARS: usize = 4000;
+
+/// Appended to a prompt cut at [`PROMPT_RETAINED_CHARS`].
+pub(crate) const PROMPT_TRUNCATION_SUFFIX: &str = " …[truncated by Intendant]";
+
+/// The harness clamps `delaySeconds` to this range before arming; mirror
+/// it so a wire value outside the range reads as what the harness will
+/// actually do, not as junk to discard.
+const MIN_DELAY_SECONDS: u64 = 60;
+const MAX_DELAY_SECONDS: u64 = 3600;
+
+/// Sessions retained in the registry. One pending record per session;
+/// eviction removes the least-recently-touched record when the cap is
+/// hit. A record normally leaves by consumption (fired, stopped,
+/// delivered, or surfaced at exit) — the cap only bounds sessions whose
+/// wrapper vanished without reaching any seam.
+const SESSIONS_RETAINED: usize = 128;
+
+/// One pending native scheduled wakeup, from the backend's own tool_use.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NativeWakeupRecord {
+    /// Epoch seconds the arm was observed on the wire.
+    pub(crate) armed_at_epoch: u64,
+    /// Epoch seconds the wake is due (`armed_at` + the clamped delay).
+    pub(crate) fire_at_epoch: u64,
+    /// The wake prompt the model asked to receive, bounded at
+    /// [`PROMPT_RETAINED_CHARS`].
+    pub(crate) prompt: String,
+    /// The model's stated reason for the chosen delay, when present.
+    pub(crate) reason: Option<String>,
+    /// The arming tool_use id (correlation/debug only).
+    pub(crate) tool_use_id: String,
+    /// `Some(cause)` once a respawn seam confirmed the arming process
+    /// died and the supervising wrapper took delivery over; the named
+    /// cause is the restart class (e.g. "the credential-reload
+    /// restart"). `None` = the harness still owns the fire.
+    pub(crate) rearmed_cause: Option<String>,
+}
+
+/// Clamp a wire `delaySeconds` to the harness's documented arming range.
+pub(crate) fn clamp_delay_seconds(delay: u64) -> u64 {
+    delay.clamp(MIN_DELAY_SECONDS, MAX_DELAY_SECONDS)
+}
+
+/// Bound a wake prompt for retention (registry and durable marker).
+pub(crate) fn bounded_prompt(prompt: &str) -> String {
+    if prompt.chars().count() <= PROMPT_RETAINED_CHARS {
+        return prompt.to_string();
+    }
+    let mut bounded: String = prompt.chars().take(PROMPT_RETAINED_CHARS).collect();
+    bounded.push_str(PROMPT_TRUNCATION_SUFFIX);
+    bounded
+}
+
+struct SessionWakeup {
+    record: NativeWakeupRecord,
+    /// Monotonic touch counter value at last update (eviction order).
+    touched: u64,
+}
+
+/// The wakeup store proper. All mutation and lookup semantics live here;
+/// the module's free functions apply them to the process global.
+pub(crate) struct Registry {
+    sessions: HashMap<String, SessionWakeup>,
+    /// Monotonic counter backing `SessionWakeup::touched`.
+    clock: u64,
+}
+
+impl Registry {
+    pub(crate) fn new() -> Self {
+        Self {
+            sessions: HashMap::new(),
+            clock: 0,
+        }
+    }
+
+    fn next_clock(&mut self) -> u64 {
+        self.clock += 1;
+        self.clock
+    }
+
+    fn evict_if_needed(&mut self) {
+        while self.sessions.len() > SESSIONS_RETAINED {
+            let Some(oldest) = self
+                .sessions
+                .iter()
+                .min_by_key(|(_, entry)| entry.touched)
+                .map(|(id, _)| id.clone())
+            else {
+                return;
+            };
+            self.sessions.remove(&oldest);
+        }
+    }
+
+    /// Arm (or replace — the harness keeps one timer) the session's
+    /// pending record.
+    pub(crate) fn record_armed(&mut self, session_id: &str, record: NativeWakeupRecord) {
+        let touched = self.next_clock();
+        self.sessions
+            .insert(session_id.to_string(), SessionWakeup { record, touched });
+        self.evict_if_needed();
+    }
+
+    /// `stop: true` — the model ended its loop; nothing pends.
+    pub(crate) fn record_stopped(&mut self, session_id: &str) -> bool {
+        self.sessions.remove(session_id).is_some()
+    }
+
+    /// The session's pending record, if any.
+    pub(crate) fn pending_for(&self, session_id: &str) -> Option<NativeWakeupRecord> {
+        self.sessions
+            .get(session_id)
+            .map(|entry| entry.record.clone())
+    }
+
+    /// Remove and return the pending record (delivered, consumed by the
+    /// live harness at its deadline, or surfaced at session end).
+    pub(crate) fn consume(&mut self, session_id: &str) -> Option<NativeWakeupRecord> {
+        self.sessions.remove(session_id).map(|entry| entry.record)
+    }
+
+    /// A respawn seam confirmed the arming process died with this record
+    /// still pending: flip it wrapper-owned under the named cause and
+    /// return the flipped record so the seam can announce the re-arm and
+    /// stamp the durable marker. Idempotent — an already wrapper-owned
+    /// record keeps its first, most specific cause and returns `None`
+    /// (the seam that flipped it already announced).
+    pub(crate) fn take_over_at_respawn(
+        &mut self,
+        session_id: &str,
+        cause: &str,
+    ) -> Option<NativeWakeupRecord> {
+        let touched = self.next_clock();
+        let entry = self.sessions.get_mut(session_id)?;
+        if entry.record.rearmed_cause.is_some() {
+            return None;
+        }
+        entry.record.rearmed_cause = Some(cause.to_string());
+        entry.touched = touched;
+        Some(entry.record.clone())
+    }
+
+    /// The backend rotated its native session id on a LIVE reader (the
+    /// arming process continues; only the key changed): move the record
+    /// so the timer keeps its observer. A record already under the new
+    /// id (should not happen — one process, one timer) is replaced.
+    pub(crate) fn migrate(&mut self, old_session_id: &str, new_session_id: &str) {
+        if old_session_id == new_session_id {
+            return;
+        }
+        if let Some(entry) = self.sessions.remove(old_session_id) {
+            self.sessions.insert(new_session_id.to_string(), entry);
+        }
+    }
+}
+
+fn global() -> &'static Mutex<Registry> {
+    static GLOBAL: OnceLock<Mutex<Registry>> = OnceLock::new();
+    GLOBAL.get_or_init(|| Mutex::new(Registry::new()))
+}
+
+fn with_global<T>(f: impl FnOnce(&mut Registry) -> T) -> T {
+    let mut registry = global().lock().unwrap_or_else(|e| e.into_inner());
+    f(&mut registry)
+}
+
+pub(crate) fn record_armed(session_id: &str, record: NativeWakeupRecord) {
+    with_global(|r| r.record_armed(session_id, record));
+}
+
+pub(crate) fn record_stopped(session_id: &str) -> bool {
+    with_global(|r| r.record_stopped(session_id))
+}
+
+pub(crate) fn pending_for(session_id: &str) -> Option<NativeWakeupRecord> {
+    with_global(|r| r.pending_for(session_id))
+}
+
+pub(crate) fn consume(session_id: &str) -> Option<NativeWakeupRecord> {
+    with_global(|r| r.consume(session_id))
+}
+
+pub(crate) fn take_over_at_respawn(session_id: &str, cause: &str) -> Option<NativeWakeupRecord> {
+    with_global(|r| r.take_over_at_respawn(session_id, cause))
+}
+
+pub(crate) fn migrate(old_session_id: &str, new_session_id: &str) {
+    with_global(|r| r.migrate(old_session_id, new_session_id));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(fire_at: u64) -> NativeWakeupRecord {
+        NativeWakeupRecord {
+            armed_at_epoch: fire_at.saturating_sub(600),
+            fire_at_epoch: fire_at,
+            prompt: "<<autonomous-loop-dynamic>>".to_string(),
+            reason: Some("watching CI".to_string()),
+            tool_use_id: "toolu_01test".to_string(),
+            rearmed_cause: None,
+        }
+    }
+
+    #[test]
+    fn arm_replace_stop_consume_lifecycle() {
+        let mut reg = Registry::new();
+        assert!(reg.pending_for("s1").is_none());
+        reg.record_armed("s1", record(1000));
+        assert_eq!(reg.pending_for("s1").unwrap().fire_at_epoch, 1000);
+        // The harness keeps one timer: a new arm replaces the record.
+        reg.record_armed("s1", record(2000));
+        assert_eq!(reg.pending_for("s1").unwrap().fire_at_epoch, 2000);
+        assert!(reg.record_stopped("s1"));
+        assert!(!reg.record_stopped("s1"));
+        assert!(reg.pending_for("s1").is_none());
+        reg.record_armed("s1", record(3000));
+        assert_eq!(reg.consume("s1").unwrap().fire_at_epoch, 3000);
+        assert!(reg.pending_for("s1").is_none());
+    }
+
+    #[test]
+    fn take_over_flips_once_and_first_cause_stands() {
+        let mut reg = Registry::new();
+        assert!(reg.take_over_at_respawn("s1", "the daemon restart").is_none());
+        reg.record_armed("s1", record(1000));
+        let flipped = reg
+            .take_over_at_respawn("s1", "the credential-reload restart")
+            .expect("pending record flips");
+        assert_eq!(
+            flipped.rearmed_cause.as_deref(),
+            Some("the credential-reload restart")
+        );
+        // Second seam finds it already wrapper-owned: no re-announce, the
+        // first, most specific cause stands.
+        assert!(reg.take_over_at_respawn("s1", "the rate-limit restart").is_none());
+        assert_eq!(
+            reg.pending_for("s1").unwrap().rearmed_cause.as_deref(),
+            Some("the credential-reload restart")
+        );
+    }
+
+    #[test]
+    fn migrate_follows_a_live_reader_id_rotation() {
+        let mut reg = Registry::new();
+        reg.record_armed("old", record(1000));
+        reg.migrate("old", "new");
+        assert!(reg.pending_for("old").is_none());
+        assert_eq!(reg.pending_for("new").unwrap().fire_at_epoch, 1000);
+        // Same-id migration is a no-op, never a drop.
+        reg.migrate("new", "new");
+        assert!(reg.pending_for("new").is_some());
+    }
+
+    #[test]
+    fn eviction_bounds_abandoned_sessions() {
+        let mut reg = Registry::new();
+        for i in 0..(SESSIONS_RETAINED + 8) {
+            reg.record_armed(&format!("s{i}"), record(1000 + i as u64));
+        }
+        assert!(reg.sessions.len() <= SESSIONS_RETAINED);
+        // Oldest-touched left first.
+        assert!(reg.pending_for("s0").is_none());
+        assert!(reg
+            .pending_for(&format!("s{}", SESSIONS_RETAINED + 7))
+            .is_some());
+    }
+
+    #[test]
+    fn delay_clamp_and_prompt_bound() {
+        assert_eq!(clamp_delay_seconds(5), 60);
+        assert_eq!(clamp_delay_seconds(780), 780);
+        assert_eq!(clamp_delay_seconds(90000), 3600);
+        let short = bounded_prompt("wake");
+        assert_eq!(short, "wake");
+        let long: String = "x".repeat(PROMPT_RETAINED_CHARS + 10);
+        let bounded = bounded_prompt(&long);
+        assert!(bounded.ends_with(PROMPT_TRUNCATION_SUFFIX));
+        assert_eq!(
+            bounded.chars().count(),
+            PROMPT_RETAINED_CHARS + PROMPT_TRUNCATION_SUFFIX.chars().count()
+        );
+    }
+}

--- a/src/bin/caller/run_modes.rs
+++ b/src/bin/caller/run_modes.rs
@@ -2120,6 +2120,14 @@ pub(crate) async fn run_with_presence(
                             activity,
                         });
                     }
+                    // Ambient: the durable pending-wakeup marker stays
+                    // honest in this lane too, though wrapper-side
+                    // re-delivery is the supervised external-mode loop's
+                    // lane — a wakeup lost here surfaces through the
+                    // exit backstop and the boot pass instead.
+                    external_agent::AgentEvent::NativeWakeupMarker { marker } => {
+                        slog(&session_log, |l| l.set_native_wakeup(marker));
+                    }
                     external_agent::AgentEvent::ConfigFacts { facts } => {
                         bus.send(AppEvent::SessionConfigFacts {
                             session_id: session_log_id(&session_log),

--- a/src/bin/caller/session_log/mod.rs
+++ b/src/bin/caller/session_log/mod.rs
@@ -2080,6 +2080,54 @@ mod tests {
         assert!(read().bg_park.is_none(), "real work clears everything");
     }
 
+    /// The native-wakeup marker obeys the bg-park law: it survives every
+    /// meta rewrite (a respawn's `write_meta` mid-pend must not drop a
+    /// pending wake or erase a lost-timer statement); only the wakeup
+    /// lanes touch it, via `set_native_wakeup`.
+    #[test]
+    fn native_wakeup_marker_survives_meta_rewrites() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_dir = dir.path().join("session");
+        let log = SessionLog::open(log_dir.clone()).unwrap();
+        log.write_meta(Some(Path::new("/tmp/project")), Some("task"));
+        let read = || -> SessionMeta {
+            serde_json::from_str(&fs::read_to_string(log_dir.join("session_meta.json")).unwrap())
+                .unwrap()
+        };
+
+        log.set_native_wakeup(Some(SessionNativeWakeupMeta {
+            armed_at_epoch: 100,
+            fire_at_epoch: 880,
+            prompt: "<<autonomous-loop-dynamic>>".into(),
+            reason: Some("queue watch".into()),
+            rearmed_cause: None,
+            died_cause: None,
+            died_at_epoch: None,
+        }));
+        log.write_meta(Some(Path::new("/tmp/project")), Some("task again"));
+        let marker = read()
+            .native_wakeup
+            .expect("a meta rewrite must not drop the pending wake");
+        assert_eq!(marker.fire_at_epoch, 880);
+        assert_eq!(marker.prompt, "<<autonomous-loop-dynamic>>");
+
+        // The died statement also survives rewrites, until a lane clears it.
+        log.set_native_wakeup(Some(SessionNativeWakeupMeta {
+            died_cause: Some("the daemon restart".into()),
+            died_at_epoch: Some(900),
+            ..marker
+        }));
+        log.write_meta(Some(Path::new("/tmp/project")), Some("task"));
+        let died = read().native_wakeup.expect("died statement survives");
+        assert_eq!(died.died_cause.as_deref(), Some("the daemon restart"));
+
+        log.set_native_wakeup(None);
+        assert!(
+            read().native_wakeup.is_none(),
+            "delivery/retirement clears it"
+        );
+    }
+
     #[test]
     fn write_meta_creates_file() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/bin/caller/session_log/mod.rs
+++ b/src/bin/caller/session_log/mod.rs
@@ -745,6 +745,7 @@ impl SessionLog {
             existing_limit_park,
             existing_safeguards_flag,
             existing_bg_park,
+            existing_native_wakeup,
         ) = existing
             .map(|meta| {
                 (
@@ -753,9 +754,10 @@ impl SessionLog {
                     meta.limit_park,
                     meta.safeguards_flag,
                     meta.bg_park,
+                    meta.native_wakeup,
                 )
             })
-            .unwrap_or((None, None, None, None, None));
+            .unwrap_or((None, None, None, None, None, None));
         let meta = SessionMeta {
             session_id: self.session_id.clone(),
             created_at: Local::now().format("%Y-%m-%dT%H:%M:%S").to_string(),
@@ -781,6 +783,11 @@ impl SessionLog {
             // limit_park): a respawn's meta rewrite must not silently
             // release a wait — or erase a died-with-restart statement.
             bg_park: existing_bg_park,
+            // Same law: only the wakeup lanes (arm/stop/deliver/retire,
+            // the respawn takeover, the exit backstop, the boot pass)
+            // touch the marker — a meta rewrite must not drop a pending
+            // wake or erase a lost-timer statement.
+            native_wakeup: existing_native_wakeup,
         };
         if let Ok(json) = serde_json::to_string_pretty(&meta) {
             if let Err(e) = write_session_meta_atomic(&self.dir, &json) {
@@ -2017,6 +2024,7 @@ mod tests {
             limit_park: None,
             safeguards_flag: None,
             bg_park: None,
+            native_wakeup: None,
         };
         fs::write(
             log_dir.join("session_meta.json"),
@@ -2173,6 +2181,7 @@ mod tests {
             limit_park: None,
             safeguards_flag: None,
             bg_park: None,
+            native_wakeup: None,
         };
         fs::write(
             s1_dir.join("session_meta.json"),
@@ -2197,6 +2206,7 @@ mod tests {
             limit_park: None,
             safeguards_flag: None,
             bg_park: None,
+            native_wakeup: None,
         };
         fs::write(
             s2_dir.join("session_meta.json"),
@@ -2262,6 +2272,7 @@ mod tests {
             limit_park: None,
             safeguards_flag: None,
             bg_park: None,
+            native_wakeup: None,
         };
         fs::write(
             log_dir.join("session_meta.json"),

--- a/src/bin/caller/session_log/mod.rs
+++ b/src/bin/caller/session_log/mod.rs
@@ -138,6 +138,18 @@ pub struct SessionMeta {
     /// lack it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bg_park: Option<SessionBgParkMeta>,
+    /// Durable trace of a pending backend-native scheduled wakeup (the
+    /// Claude Code harness `ScheduleWakeup` timer): stamped while the
+    /// model's self-scheduled wake is pending, updated to its re-armed
+    /// form when a respawn seam hands delivery to the supervising
+    /// wrapper, flipped to its died form when nothing can deliver it
+    /// (session end, daemon restart), and cleared when it fires or the
+    /// model stops its loop. The timer lives inside the backend process
+    /// and dies with EVERY respawn while this marker survives — it is
+    /// how the boot pass tells a wakeup the daemon restart killed from
+    /// plain idleness. Additive: metas written before 2026-08 lack it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub native_wakeup: Option<SessionNativeWakeupMeta>,
 }
 
 /// A provider-safeguards flag recorded durably (see
@@ -165,6 +177,38 @@ pub struct SessionBgParkMeta {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub died_cause: Option<String>,
     /// Epoch seconds the tasks died, present with `died_cause`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub died_at_epoch: Option<u64>,
+}
+
+/// A pending backend-native scheduled wakeup recorded durably (see
+/// [`SessionMeta::native_wakeup`]).
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct SessionNativeWakeupMeta {
+    /// Epoch seconds the arm was observed on the wire.
+    pub armed_at_epoch: u64,
+    /// Epoch seconds the wake is due.
+    pub fire_at_epoch: u64,
+    /// The wake prompt the model asked to receive (bounded by the
+    /// producer — display and re-delivery data, never a command).
+    pub prompt: String,
+    /// The model's stated reason for the chosen delay, when present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// The named restart the timer did not survive in its harness form —
+    /// `Some` means the supervising wrapper re-armed it and owns
+    /// delivery at the due time. `None` = the backend harness still owns
+    /// the fire.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rearmed_cause: Option<String>,
+    /// The named end that killed the wakeup with no re-arm possible —
+    /// `Some` flips the marker from "pending" to the honest lost-timer
+    /// statement (nothing will deliver it; re-arming is the model's or
+    /// owner's decision on resume). `None` = the wake is still owed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub died_cause: Option<String>,
+    /// Epoch seconds the timer was declared lost, present with
+    /// `died_cause`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub died_at_epoch: Option<u64>,
 }
@@ -832,6 +876,28 @@ impl SessionLog {
             return;
         }
         meta.bg_park = None;
+        if let Ok(json) = serde_json::to_string_pretty(&meta) {
+            if let Err(e) = write_session_meta_atomic(&self.dir, &json) {
+                eprintln!("session_log: failed to write session_meta.json: {}", e);
+            }
+        }
+    }
+
+    /// Record (or clear) the durable native-wakeup marker in
+    /// `session_meta.json` (see [`SessionMeta::native_wakeup`]). Missing
+    /// or unreadable meta is a quiet no-op, like [`Self::set_limit_park`].
+    pub fn set_native_wakeup(&self, wakeup: Option<SessionNativeWakeupMeta>) {
+        let meta_path = self.dir.join("session_meta.json");
+        let Some(mut meta) = fs::read_to_string(&meta_path)
+            .ok()
+            .and_then(|raw| serde_json::from_str::<SessionMeta>(&raw).ok())
+        else {
+            return;
+        };
+        if meta.native_wakeup == wakeup {
+            return;
+        }
+        meta.native_wakeup = wakeup;
         if let Ok(json) = serde_json::to_string_pretty(&meta) {
             if let Err(e) = write_session_meta_atomic(&self.dir, &json) {
                 eprintln!("session_log: failed to write session_meta.json: {}", e);

--- a/src/bin/caller/session_vitals.rs
+++ b/src/bin/caller/session_vitals.rs
@@ -3201,6 +3201,7 @@ mod tests {
             limit_park: None,
             safeguards_flag: None,
             bg_park: None,
+            native_wakeup: None,
         };
         let meta_path = dir.join("session_meta.json");
         std::fs::write(&meta_path, serde_json::to_string_pretty(&meta).unwrap()).unwrap();

--- a/src/bin/caller/thread_actions.rs
+++ b/src/bin/caller/thread_actions.rs
@@ -4603,12 +4603,15 @@ pub(crate) fn handle_idle_codex_subagent_event(
         external_agent::AgentEvent::GoalCleared => {
             emit_external_session_goal(config, Some(child_thread_id), None);
         }
+        // NativeWakeupMarker is emitted for the main thread only — a
+        // child-scoped copy would be an adapter bug, never marker truth.
         external_agent::AgentEvent::PlanUpdate { .. }
         | external_agent::AgentEvent::ApprovalRequest { .. }
         | external_agent::AgentEvent::FileApprovalRequest { .. }
         | external_agent::AgentEvent::UserQuestionRequest { .. }
         | external_agent::AgentEvent::DiffUpdated { .. }
         | external_agent::AgentEvent::Terminated { .. }
+        | external_agent::AgentEvent::NativeWakeupMarker { .. }
         | external_agent::AgentEvent::Scoped { .. } => {}
     }
 }


### PR DESCRIPTION
Closes the ScheduleWakeup respawn variant of the respawn-orphan class (agenda card 01KZ0BMB9CF9732567K2MMNG4M; sealed specimen: the 2026-08-01 reload-resume gap report, sha256 f64a905e…, session 0f00397f — a CC-native ScheduleWakeup timer armed 22:03:51 for 22:17 died silently in the 22:05 credential-reload respawn; the resumed process restored no timers and the session idled forever).

Extends the #744 died-with-restart lane so backend respawns never silently kill a session's pending native scheduled wakeup — re-arm where recoverable, honest lost-timer notification otherwise, both pinned by test.

**Observe (wire truth)** — the CC adapter records main-thread `ScheduleWakeup` tool_use arms in `src/bin/caller/native_wakeup.rs` (the wake-source twin of the background-task registry: one record per backend session; replace on re-arm, clear on `stop: true`, migrate on a live reader's id rotation) and mirrors a durable `SessionMeta.native_wakeup` marker through the drains. The marker obeys the bg-park law: meta rewrites preserve it; only the wakeup lanes touch it.

**Re-arm across the respawn (recoverable)** — `mark_parked_tasks_died_with_restart` — already called at every confirmed-death respawn seam (credential reload, rate-limit restart, service-recovery restart, park-arm classes) — now also flips a pending record wrapper-owned via `take_over_native_wakeup_at_respawn`, hoisted before the zero-died-tasks early return (the specimen was parked on nothing but its timer). The supervised loop's new idle deadline arm delivers the wake at the original due time: respawn-first when the backend is confirmed dead (the park-wake pattern), queued behind a live limit park, delivered late with an honest "was due …" phrase when the due time passed while the backend was down. A harness-owned record whose deadline passes with the process alive is retired — the harness owned that fire; no double-wake. The adapter's fresh-adoption seam (`capture_session_id`) additionally takes over orphaned records no supervision seam claimed.

**Honest lost-timer notification (otherwise)** — the exit backstop flips the marker died with the session-end cause (daemon-teardown exits leave it for the boot pass, the limit-park law); the boot walk (`mark_dead_wake_sources`, extending the #744 bg-park walk) flips daemon-restart losses; the readopt continuation carries the lost-wakeup note with the model's own wake prompt (`died_wakeup_nudge_addendum`, the #644 composition law — the note only rides a nudge the lane already sends).

**Pins** (13 new): registry lifecycle + takeover idempotence + eviction; parser arm/replace/stop/rotation/orphan-adoption (still renders as a tool row); THE zero-died-tasks re-arm pin (surfaces only — no delivery armed at the seam); the boot died-flip pin (pending and re-armed forms flip, died forms and live wrappers stand); the readopt note pin; the meta-rewrite preservation pin; delivery-message and deadline builders. All adjacent #744 pins unchanged and green.

**Named bounds** (for the gate): (1) wrapper-side delivery lives in the supervised external-mode loop; the persistent-daemon lane stamps the honest marker and surfaces losses at exit/boot instead of delivering — the same bound the park-then-die ruling accepted for that lane. (2) A deadline passing mid-turn with a mid-turn backend death is covered by the mid-turn continuation lanes, not a wake re-delivery (the loop-pacing model re-arms at turn end). (3) A backend crash while idle with no park still ends the session (the landed Terminated-arm behavior); the exit backstop makes the wakeup loss loud rather than extending the park-then-die hold lanes to wakeups. (4) No dashboard vitals chip for wakeups in this PR — the owner-visible surfaces are the log lines, the durable marker, and the readopt note.
