### PR TITLE
external: a deferred mid-turn credential reload survives the turn's limit/terminal exit

### DIFF
--- a/src/bin/caller/external_mode.rs
+++ b/src/bin/caller/external_mode.rs
@@ -124,7 +124,11 @@ pub(crate) fn idle_external_pr_published_event(
 /// which drops it — the reload wants the work to continue on the fresh
 /// account), shut the old process down, and re-create the agent
 /// resume-attached to the same backend session id so the new process
-/// reads the fresh credential store. Queued `parked_follow_ups` stay in
+/// reads the fresh credential store. The park-cancel is also what heals
+/// a deferral swallowed by the turn's limit exit: the idle wait bounces
+/// the still-set flag here, so a park armed on the OLD account's window
+/// after a mid-turn reload is cancelled with its pending intact instead
+/// of waiting out the stale reset (card 01KZ0HVNCM). Queued `parked_follow_ups` stay in
 /// the loop untouched and flush through the normal preamble after the
 /// respawn. Returns `None` when the respawn failed — the old process is
 /// already gone, so the caller exits the loop honestly; on success,
@@ -300,11 +304,14 @@ pub(crate) const RELOAD_MIDTURN_CONTINUATION_TEXT: &str =
 /// Synthesized continuation after a credential-reload respawn:
 /// `Some(..)` only when the reload's own interrupt cut a live turn (the
 /// turn drain returned `Interrupted` with
-/// [`RELOAD_CREDENTIALS_INTERRUPT_REASON`]). The interrupted turn's
-/// driving message was already consumed mid-delivery, so nothing else
-/// re-drives the work after the respawn — the session would idle on the
-/// fresh account with the task half-done. Idle and between-turn reloads
-/// pass `false` (idle in, idle out), as does a turn that completed
+/// [`RELOAD_CREDENTIALS_INTERRUPT_REASON`] — primary or idle-observed;
+/// the cut turn owes, not the lane that observed it) or the deferral's
+/// turn died into a rescued terminal (round death / channel close with
+/// the flag still set). The interrupted turn's driving message was
+/// already consumed mid-delivery, so nothing else re-drives the work
+/// after the respawn — the session would idle on the fresh account with
+/// the task half-done. Truly idle and between-turn reloads pass `false`
+/// (nothing was cut — idle in, idle out), as does a turn that completed
 /// normally despite the request, or one whose interrupt belonged to the
 /// user (their stop wins). The message carries no steer/follow-up id, so
 /// id-keyed cancel matching can never drop it. Rides the shared
@@ -738,13 +745,22 @@ pub(crate) async fn run_external_agent_mode(
     // Reload-credentials handshake: the drain raises this when the request
     // arrives mid-turn (after interrupting the backend); the loop applies
     // the in-place respawn at the next safe point. Idle requests apply
-    // immediately in the idle listener below.
+    // immediately in the idle listener below. The idle wait bounces a
+    // still-set flag back to the safe point, and the terminal arms that
+    // bypass the drain's interrupt resolution (round death, channel
+    // close) stay resident instead of breaking — so a deferral swallowed
+    // by the turn's limit/terminal exit can never strand a session parked
+    // on the OLD account's window or die with the reload owed (the
+    // 2026-08-02 limit-exit race, card 01KZ0HVNCM).
     let backend_credentials_reload = std::sync::atomic::AtomicBool::new(false);
-    // Companion marker: the reload's own interrupt cut a live primary
-    // turn (the turn drain returned `Interrupted` with the reload
-    // reason), so the safe-point respawn must front-queue a synthesized
-    // continuation to re-drive the dropped work. Never set on the idle
-    // lane — idle in, idle out.
+    // Companion marker: the reload's own interrupt cut a live turn —
+    // primary or idle-observed (the turn drain returned `Interrupted`
+    // with the reload reason), or the deferral's turn died into a
+    // rescued terminal (round death / channel close with the flag still
+    // set) — so the safe-point respawn must front-queue a synthesized
+    // continuation to re-drive the dropped work. The cut turn owes, not
+    // the lane that observed it. Never set by the truly-idle listener
+    // (nothing was cut — idle in, idle out).
     let mut reload_interrupted_turn = false;
     let mut drain_config = DrainConfig {
         bus: &bus,
@@ -857,6 +873,20 @@ pub(crate) async fn run_external_agent_mode(
         let followup = match next_turn.take() {
             Some(turn) => turn,
             None => loop {
+                // A reload deferral raised mid-drain whose turn exited into
+                // a park or a rescued terminal lands here with the flag
+                // still set — the drain outcome that was supposed to carry
+                // it (`Interrupted` with the reload reason) was swallowed
+                // by the exit. Left unconsumed, a parked session waits out
+                // the OLD account's window while the fresh store sits
+                // unread (the 2026-08-02 limit-exit race, specimen
+                // 2c6ea80d, card 01KZ0HVNCM). Bounce to the loop's single
+                // safe point: it cancels a live park PRESERVING its
+                // pending re-send, respawns onto the fresh credentials,
+                // and the flush below delivers the owed work.
+                if backend_credentials_reload.load(std::sync::atomic::Ordering::SeqCst) {
+                    continue 'outer;
+                }
                 if limit_park.is_none() {
                     // Flush messages queued during a rate-limit park,
                     // oldest first, honoring cancels recorded while they
@@ -1504,6 +1534,33 @@ pub(crate) async fn run_external_agent_mode(
                                                     )
                                                     .await;
                                                     round = round.saturating_sub(1);
+                                                } else if backend_credentials_reload
+                                                    .load(std::sync::atomic::Ordering::SeqCst)
+                                                {
+                                                    // A deferred credential
+                                                    // reload outranks the
+                                                    // round-death terminal:
+                                                    // the pending respawn IS
+                                                    // the recovery (an
+                                                    // auth-shaped refusal is
+                                                    // exactly what the fresh
+                                                    // store may cure). Stay
+                                                    // resident; the idle
+                                                    // wait bounces to the
+                                                    // safe-point respawn.
+                                                    let line = reload_outranks_terminal_line(
+                                                        "the observed round failed before any turn completed",
+                                                        &reason,
+                                                    );
+                                                    slog(&session_log, |l| l.warn(&line));
+                                                    bus.send(AppEvent::LogEntry {
+                                                        session_id: live_session_id.clone(),
+                                                        level: "warn".to_string(),
+                                                        source: "Intendant".to_string(),
+                                                        content: line,
+                                                        turn: None,
+                                                    });
+                                                    round = round.saturating_sub(1);
                                                 } else {
                                                     // A backend-started round
                                                     // observed from idle died on
@@ -1692,6 +1749,13 @@ pub(crate) async fn run_external_agent_mode(
                                                 // honest terminal, never
                                                 // a park — mechanical
                                                 // retry re-flags forever.
+                                                // A pending credential
+                                                // reload does not rescue
+                                                // it either: respawn-and-
+                                                // redeliver into flagged
+                                                // bytes is the re-flag
+                                                // loop; the deferral dies
+                                                // with the loop.
                                                 stats.rounds = round;
                                                 let entry =
                                                     crate::safeguards_recast::RecastRef {
@@ -1776,7 +1840,20 @@ pub(crate) async fn run_external_agent_mode(
                                                 // is exhausted.
                                                 error_park_streak =
                                                     error_park_streak.saturating_add(1);
-                                                if error_park_attempts_exhausted(error_park_streak)
+                                                // A pending credential reload
+                                                // holds the suspension
+                                                // terminal open: park
+                                                // normally instead — the
+                                                // safe-point respawn cancels
+                                                // it preserving the
+                                                // delivery-aware pending and
+                                                // resets the streak like any
+                                                // explicit intervention.
+                                                if !backend_credentials_reload
+                                                    .load(std::sync::atomic::Ordering::SeqCst)
+                                                    && error_park_attempts_exhausted(
+                                                        error_park_streak,
+                                                    )
                                                 {
                                                     stats.rounds = round;
                                                     let line = error_park_exhausted_line(
@@ -1961,6 +2038,26 @@ pub(crate) async fn run_external_agent_mode(
                                             }
                                             DrainOutcome::Interrupted { reason } => {
                                                 stats.rounds = round;
+                                                // The reload's own interrupt
+                                                // cutting a LIVE observed
+                                                // round owes the same
+                                                // synthesized continuation
+                                                // as the primary lane — the
+                                                // cut turn owes, not the
+                                                // lane that observed it
+                                                // ("idle in, idle out"
+                                                // covers reloads landing on
+                                                // a truly idle session,
+                                                // where nothing was cut).
+                                                // The idle wait bounces the
+                                                // still-set flag to the
+                                                // safe point, which
+                                                // consumes this marker.
+                                                if reason
+                                                    == RELOAD_CREDENTIALS_INTERRUPT_REASON
+                                                {
+                                                    reload_interrupted_turn = true;
+                                                }
                                                 slog(&session_log, |l| {
                                                     l.info(&format!(
                                                         "External agent interrupted while observed from idle: {}",
@@ -2021,6 +2118,19 @@ pub(crate) async fn run_external_agent_mode(
                                                     .await;
                                                     round = round.saturating_sub(1);
                                                 } else {
+                                                    // A pending credential
+                                                    // reload deliberately
+                                                    // does NOT rescue this
+                                                    // arm: a Terminated that
+                                                    // reaches it with the
+                                                    // flag set can only be a
+                                                    // requested stop (the
+                                                    // drain converts a
+                                                    // backend death under a
+                                                    // pending interrupt to
+                                                    // `Interrupted`), and
+                                                    // the stop wins the
+                                                    // reload.
                                                     stats.rounds = round;
                                                     slog(&session_log, |l| {
                                                         l.info(&format!(
@@ -2073,6 +2183,32 @@ pub(crate) async fn run_external_agent_mode(
                                                             .waiting_turn_detail(agent.name()),
                                                     )
                                                     .await;
+                                                    round = round.saturating_sub(1);
+                                                } else if backend_credentials_reload
+                                                    .load(std::sync::atomic::Ordering::SeqCst)
+                                                {
+                                                    // Hard process death with
+                                                    // the reload deferral
+                                                    // pending: the respawn IS
+                                                    // the recovery. Gate the
+                                                    // closed channel and stay
+                                                    // resident; the safe
+                                                    // point swaps in the
+                                                    // fresh receiver and
+                                                    // re-opens the gate.
+                                                    event_channel_open = false;
+                                                    let line = reload_outranks_terminal_line(
+                                                        "the backend event channel closed",
+                                                        "",
+                                                    );
+                                                    slog(&session_log, |l| l.warn(&line));
+                                                    bus.send(AppEvent::LogEntry {
+                                                        session_id: live_session_id.clone(),
+                                                        level: "warn".to_string(),
+                                                        source: "Intendant".to_string(),
+                                                        content: line,
+                                                        turn: None,
+                                                    });
                                                     round = round.saturating_sub(1);
                                                 } else {
                                                     slog(&session_log, |l| {
@@ -3831,7 +3967,10 @@ pub(crate) async fn run_external_agent_mode(
                 // 2026-07-31 specimen 69c8535e COMPLETED at 95 turns and
                 // the death was invisible). The honest terminal is FAILED
                 // plus the safeguards attention surfaces; the remedy is
-                // the owner's fresh-session recast.
+                // the owner's fresh-session recast. A pending credential
+                // reload does not rescue it either: respawn-and-redeliver
+                // into flagged bytes is the re-flag loop; the deferral
+                // dies with the loop.
                 stats.rounds = round;
                 let entry = crate::safeguards_recast::RecastRef {
                     session_id: live_session_id.clone().unwrap_or_default(),
@@ -3896,6 +4035,34 @@ pub(crate) async fn run_external_agent_mode(
                 reason,
                 turns_in_round,
             } => {
+                if backend_credentials_reload.load(std::sync::atomic::Ordering::SeqCst) {
+                    // A deferred mid-turn credential reload outranks the
+                    // round-death terminal (the round-death classification
+                    // bypasses the drain's interrupt resolution, so the
+                    // deferral survives to here): the pending respawn IS
+                    // the recovery — an auth refusal is exactly what the
+                    // fresh store may cure. Roll the burned round back
+                    // like the limit arm and let the safe point respawn;
+                    // the synthesized continuation re-drives the cut work
+                    // (nudge shape — `turns_in_round` counts COMPLETED
+                    // turns, so the round may hold a STARTED turn a
+                    // verbatim re-send would double-run).
+                    reload_interrupted_turn = true;
+                    let line = reload_outranks_terminal_line(
+                        "the round failed before any turn completed",
+                        &reason,
+                    );
+                    slog(&session_log, |l| l.warn(&line));
+                    bus.send(AppEvent::LogEntry {
+                        session_id: live_session_id.clone(),
+                        level: "warn".to_string(),
+                        source: "Intendant".to_string(),
+                        content: line,
+                        turn: None,
+                    });
+                    round = round.saturating_sub(1);
+                    continue 'outer;
+                }
                 // The launch-refusal class: a fatal backend error ended the
                 // round before any turn ran (an invalid model pin, an auth
                 // refusal at spawn). The honest terminal is FAILED — the
@@ -4416,7 +4583,13 @@ pub(crate) async fn run_external_agent_mode(
                 // occurrences journal `failed` and count on the
                 // suspension streak) instead of waiting unattended.
                 error_park_streak = error_park_streak.saturating_add(1);
-                if error_park_attempts_exhausted(error_park_streak) {
+                // A pending credential reload holds the suspension terminal
+                // open: park normally instead — the safe-point respawn
+                // cancels the park preserving the delivery-aware pending
+                // and resets the streak like any explicit intervention.
+                if !backend_credentials_reload.load(std::sync::atomic::Ordering::SeqCst)
+                    && error_park_attempts_exhausted(error_park_streak)
+                {
                     stats.rounds = round;
                     let line =
                         error_park_exhausted_line(&reason, error_park_streak.saturating_sub(1));
@@ -4970,6 +5143,11 @@ pub(crate) async fn run_external_agent_mode(
                 }
             }
             DrainOutcome::Terminated { reason, exit_code } => {
+                // A pending credential reload deliberately does NOT rescue
+                // this arm: a Terminated that reaches it with the flag set
+                // can only be a requested stop (the drain converts a
+                // backend death under a pending interrupt to
+                // `Interrupted`), and the stop wins the reload.
                 stats.rounds = round;
                 let user_requested_stop =
                     matches!(reason.as_str(), "stopped by user" | "restarting session")
@@ -5043,6 +5221,27 @@ pub(crate) async fn run_external_agent_mode(
                 break;
             }
             DrainOutcome::ChannelClosed => {
+                if backend_credentials_reload.load(std::sync::atomic::Ordering::SeqCst) {
+                    // Hard process death with the reload deferral pending
+                    // (the channel-closed return bypasses the drain's
+                    // interrupt resolution): the respawn IS the recovery.
+                    // Roll the burned round back and let the safe point
+                    // respawn; the synthesized continuation re-drives the
+                    // cut work.
+                    reload_interrupted_turn = true;
+                    let line =
+                        reload_outranks_terminal_line("the backend event channel closed", "");
+                    slog(&session_log, |l| l.warn(&line));
+                    bus.send(AppEvent::LogEntry {
+                        session_id: live_session_id.clone(),
+                        level: "warn".to_string(),
+                        source: "Intendant".to_string(),
+                        content: line,
+                        turn: None,
+                    });
+                    round = round.saturating_sub(1);
+                    continue 'outer;
+                }
                 slog(&session_log, |l| {
                     l.info("External agent event channel closed")
                 });
@@ -5247,9 +5446,11 @@ mod tests {
 
     #[test]
     fn idle_sessions_get_no_synthesized_message() {
-        // Idle and between-turn reloads never arm the marker (the idle
-        // listener applies the respawn directly; no drain returned
-        // `Interrupted` with the reload reason): idle in, idle out.
+        // TRULY idle and between-turn reloads never arm the marker (the
+        // idle listener applies the respawn directly; nothing was cut).
+        // A reload whose interrupt cut a live OBSERVED round arms it like
+        // the primary lane — the cut turn owes, not the lane — but with
+        // no cut turn: idle in, idle out.
         assert!(synthesized_reload_continuation(false).is_none());
 
         // Adjacent interrupt reasons must not collide with the

--- a/src/bin/caller/external_mode.rs
+++ b/src/bin/caller/external_mode.rs
@@ -1547,7 +1547,11 @@ pub(crate) async fn run_external_agent_mode(
                                                     // store may cure). Stay
                                                     // resident; the idle
                                                     // wait bounces to the
-                                                    // safe-point respawn.
+                                                    // safe-point respawn,
+                                                    // and the continuation
+                                                    // re-drives the cut
+                                                    // observed turn.
+                                                    reload_interrupted_turn = true;
                                                     let line = reload_outranks_terminal_line(
                                                         "the observed round failed before any turn completed",
                                                         &reason,
@@ -2195,7 +2199,11 @@ pub(crate) async fn run_external_agent_mode(
                                                     // resident; the safe
                                                     // point swaps in the
                                                     // fresh receiver and
-                                                    // re-opens the gate.
+                                                    // re-opens the gate, and
+                                                    // the continuation
+                                                    // re-drives the cut
+                                                    // observed turn.
+                                                    reload_interrupted_turn = true;
                                                     event_channel_open = false;
                                                     let line = reload_outranks_terminal_line(
                                                         "the backend event channel closed",

--- a/src/bin/caller/external_supervision.rs
+++ b/src/bin/caller/external_supervision.rs
@@ -1649,6 +1649,28 @@ pub(crate) fn park_holds_through_terminal_line(
     )
 }
 
+/// The honest log row when a terminal classification lands while a
+/// deferred mid-turn credential reload is still pending and the reload
+/// outranks it (the 2026-08-02 limit-exit race, specimen 2c6ea80d: the
+/// reload's deferral was swallowed by the turn's exit and the session
+/// parked until the OLD account's 05:20 reset while the fresh store sat
+/// unread). The pending respawn IS the recovery — an auth-shaped round
+/// death is exactly what the fresh credentials may cure — so the session
+/// stays resident and the loop's safe point applies the reload instead
+/// of exiting.
+pub(crate) fn reload_outranks_terminal_line(classification: &str, reason: &str) -> String {
+    let reason = reason.trim();
+    let cause = if reason.is_empty() {
+        String::new()
+    } else {
+        format!(" ({reason})")
+    };
+    format!(
+        "Deferred credential reload outranks a backend terminal — {classification}{cause}; \
+         the session stays resident and respawns on the fresh credential store"
+    )
+}
+
 /// Re-arming a park over an already-armed one (a second rejection or
 /// round death while parked — the dying backend's death-rattle class)
 /// must not clobber the owed work: while parked nothing delivers user
@@ -2389,6 +2411,30 @@ mod tests {
             "Service-recovery pause holds through a backend terminal while parked — the \
              backend event channel closed; the session stays resident and resumes at the \
              park's wake"
+        );
+    }
+
+    /// The reload-outranks-terminal line: honest, greppable, and
+    /// truthful with and without a carried reason (the limit-exit race
+    /// rescue's log row, card 01KZ0HVNCM).
+    #[test]
+    fn reload_outranks_terminal_line_is_honest() {
+        let line = reload_outranks_terminal_line(
+            "the round failed before any turn completed",
+            "Claude Code auth refused",
+        );
+        assert_eq!(
+            line,
+            "Deferred credential reload outranks a backend terminal — the round failed \
+             before any turn completed (Claude Code auth refused); the session stays \
+             resident and respawns on the fresh credential store"
+        );
+        let quiet = reload_outranks_terminal_line("the backend event channel closed", "");
+        assert_eq!(
+            quiet,
+            "Deferred credential reload outranks a backend terminal — the backend event \
+             channel closed; the session stays resident and respawns on the fresh \
+             credential store"
         );
     }
 

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -9952,3 +9952,208 @@ async fn limit_park_survives_backend_death_and_resumes_at_reset() {
 
     child.kill().await.ok();
 }
+
+/// The mid-turn-reload swallowed-by-limit-exit race end to end (card
+/// 01KZ0HVNCM, specimen 2c6ea80d 2026-08-02): a reload-credentials
+/// request lands MID-TURN on a daemon-supervised claude-code session —
+/// the deferral lane interrupts the backend and defers the respawn to
+/// the turn's end — and the turn then exits on a rate-limit rejection
+/// whose reset sits an hour out (the OLD account's window). The deferred
+/// reload must survive that exit: the wrapper respawns resume-attached
+/// on the fresh credential store and the synthesized continuation
+/// re-drives the cut work immediately, instead of parking until the
+/// stale reset (the specimen parked 3h46m on an account the owner had
+/// already rotated away from, with the fresh store sitting unread).
+/// The turn is a backend-started round observed from idle — the exact
+/// specimen lane, where the pre-fix loop swallowed the deferral because
+/// only the top of the outer loop consumed it. Unix-only for the /bin/sh
+/// fake; run 2 is discriminated by `--resume` argv keying like the
+/// park-then-die e2e above.
+#[cfg(unix)]
+#[tokio::test]
+async fn midturn_reload_survives_limit_exit_and_respawns_on_fresh_credentials() {
+    use futures_util::SinkExt;
+    use std::os::unix::fs::PermissionsExt;
+
+    let rig = TestRig::new();
+    let script = serde_json::json!({ "profiles": [] });
+
+    // The fake claude. Run 1 (no `--resume`): answer the task turn
+    // cleanly, then start a SPONTANEOUS round (an assistant event while
+    // the wrapper idles — enters the observe drain and marks the round
+    // started), hold that turn open until the test's go-marker appears
+    // (the test writes it only after the reload deferral armed
+    // mid-turn), then exit the turn on a five_hour rejection resetting
+    // an hour out. Stays alive reading stdin — the specimen's backend
+    // survived its rejection; dying here would smear this into the
+    // park-then-die class instead. The `claimed` mkdir is a first-spawn
+    // mutex: create_session retries on a saturated boot could spawn a
+    // twin, and an unclaimed twin running the choreography would arm an
+    // honest park that breaks the no-park asserts — losers idle inert.
+    // Run 2 (`--resume`, the reload's respawn by construction): answer
+    // whatever arrives first — the synthesized continuation — with the
+    // proof text and stay alive.
+    let fake = rig.home.path().join("fake-claude.sh");
+    let go_marker = rig.home.path().join("reload-go");
+    let claim = rig.home.path().join("choreography-claim");
+    std::fs::write(
+        &fake,
+        format!(
+            concat!(
+                "#!/bin/sh\n",
+                "SID=\"21111111-2222-4333-8444-555555555555\"\n",
+                "resumed=0\n",
+                "for a in \"$@\"; do\n",
+                "  [ \"$a\" = \"--resume\" ] && resumed=1\n",
+                "done\n",
+                "read -r _line || exit 1\n",
+                "printf '{{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"%s\",\"model\":\"fake-sonnet\",\"permissionMode\":\"default\",\"tools\":[],\"cwd\":\".\"}}\\n' \"$SID\"\n",
+                "if [ \"$resumed\" = \"0\" ]; then\n",
+                "  printf '{{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"result\":\"turn one done\",\"session_id\":\"%s\"}}\\n' \"$SID\"\n",
+                "  /bin/sleep 1\n",
+                "  if ! /bin/mkdir {claim} 2>/dev/null; then\n",
+                "    while read -r _line; do :; done\n",
+                "    exit 0\n",
+                "  fi\n",
+                "  printf '{{\"type\":\"assistant\",\"message\":{{\"content\":[{{\"type\":\"text\",\"text\":\"observed work in flight\"}}]}},\"session_id\":\"%s\"}}\\n' \"$SID\"\n",
+                "  while [ ! -e {go} ]; do /bin/sleep 0.1; done\n",
+                "  RESET=$(( $(/bin/date +%s) + 3600 ))\n",
+                "  printf '{{\"type\":\"rate_limit_event\",\"rate_limit_info\":{{\"status\":\"rejected\",\"rateLimitType\":\"five_hour\",\"resetsAt\":%d}},\"session_id\":\"%s\"}}\\n' \"$RESET\" \"$SID\"\n",
+                "  printf '{{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":true,\"result\":\"You have hit your session limit\",\"session_id\":\"%s\"}}\\n' \"$SID\"\n",
+                "  while read -r _line; do :; done\n",
+                "  exit 0\n",
+                "fi\n",
+                "printf '{{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"result\":\"resumed on fresh credentials after the swallowed reload\",\"session_id\":\"%s\"}}\\n' \"$SID\"\n",
+                "while read -r _line; do :; done\n",
+            ),
+            claim = claim.display(),
+            go = go_marker.display(),
+        ),
+    )
+    .expect("write fake claude");
+    std::fs::set_permissions(&fake, std::fs::Permissions::from_mode(0o755))
+        .expect("chmod fake claude");
+
+    let client = reqwest::Client::new();
+    let mut daemon = spawn_daemon_on_rig(&client, rig, &script, false).await;
+    let (mut ws, _) = tokio_tungstenite::connect_async(format!(
+        "ws://127.0.0.1:{}/ws?token={}",
+        daemon.port,
+        daemon.loopback_token()
+    ))
+    .await
+    .expect("connect /ws");
+
+    // The very first control message can race daemon startup on a
+    // saturated box, so retry until session_started (the mkdir claim in
+    // the fake keeps a retry-spawned twin inert).
+    let mut started = None;
+    for _ in 0..6 {
+        ws.send(tokio_tungstenite::tungstenite::Message::Text(
+            serde_json::json!({
+                "action": "create_session",
+                "task": "midturn reload race task",
+                "agent": "claude-code",
+                "agent_command": daemon.rig.home.path().join("fake-claude.sh").to_string_lossy(),
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .expect("send claude-code create_session");
+        started = next_matching_ws_event(&mut ws, Duration::from_secs(30), |json| {
+            json.get("event").and_then(|v| v.as_str()) == Some("session_started")
+                && json
+                    .get("task")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|task| task.contains("midturn reload race"))
+        })
+        .await;
+        if started.is_some() {
+            break;
+        }
+    }
+    let started = started.unwrap_or_else(|| {
+        panic!(
+            "claude-code create_session never started; daemon log:\n{}",
+            daemon.log_tail()
+        )
+    });
+    let session_id = started
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .expect("session_started carries a session id")
+        .to_string();
+
+    // Phase 1: the spontaneous round is live in the observe drain.
+    poll_until(
+        "the backend-started round observed from idle",
+        RUN_TIMEOUT,
+        || async {
+            let logs = daemon.rig.session_logs();
+            logs.contains("observed work in flight").then_some(())
+        },
+        || tail(&daemon.rig.session_logs(), 4000),
+    )
+    .await;
+
+    // Phase 2: the reload lands MID-TURN — the deferral lane interrupts
+    // the backend and parks the respawn on the turn's end.
+    ws.send(tokio_tungstenite::tungstenite::Message::Text(
+        serde_json::json!({
+            "action": "reload_credentials",
+            "session_id": session_id,
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .expect("send reload_credentials");
+    poll_until(
+        "the mid-turn reload deferral",
+        RUN_TIMEOUT,
+        || async {
+            let logs = daemon.rig.session_logs();
+            logs.contains("Reload-credentials requested mid-turn").then_some(())
+        },
+        || tail(&daemon.rig.session_logs(), 4000),
+    )
+    .await;
+
+    // Phase 3: release the fake — the deferred turn now exits on the
+    // OLD account's five_hour rejection (reset an hour out).
+    std::fs::write(&go_marker, b"go").expect("write go marker");
+
+    // Phase 4: the deferral survives the limit exit — the wrapper
+    // respawns on the fresh store and the synthesized continuation
+    // re-drives the cut work to completion on run 2.
+    let logs = poll_until(
+        "the reload respawn and the delivered continuation",
+        RUN_TIMEOUT,
+        || async {
+            let logs = daemon.rig.session_logs();
+            (logs.contains("Credential reload complete")
+                && logs.contains("queued a continuation")
+                && logs.contains("resumed on fresh credentials after the swallowed reload"))
+            .then_some(logs)
+        },
+        || tail(&daemon.rig.session_logs(), 4000),
+    )
+    .await;
+
+    // The race's losing outcome never happens: no park on the old
+    // account's window — neither the in-memory arm's log row nor the
+    // durable meta marker the boot sweep would readopt.
+    assert!(
+        !logs.contains("Rate-limited — parked"),
+        "the deferred reload must preempt the stale-window park:\n{}",
+        tail(&logs, 4000)
+    );
+    let meta = park_meta_of(&daemon.rig);
+    assert!(
+        meta.is_none(),
+        "no durable park marker may survive the rescued exit: {meta:?}"
+    );
+
+    daemon.child.kill().await.ok();
+}

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -10114,7 +10114,8 @@ async fn midturn_reload_survives_limit_exit_and_respawns_on_fresh_credentials() 
         RUN_TIMEOUT,
         || async {
             let logs = daemon.rig.session_logs();
-            logs.contains("Reload-credentials requested mid-turn").then_some(())
+            logs.contains("Reload-credentials requested mid-turn")
+                .then_some(())
         },
         || tail(&daemon.rig.session_logs(), 4000),
     )


### PR DESCRIPTION
Fix for the mid-turn-reload swallowed-by-limit-exit race (agenda card 01KZ0HVNCMFXKSDMXB7ERS6CHM; sealed specimen report reload-resume-gap-2-2026-08-02, sha256 1c08534b…).

**The race (specimen 2c6ea80d, :8770 drainer, 2026-08-02 01:33):** a `ReloadCredentialsAll` fan-out landed mid-turn on a session working an idle-observed round. The #640 deferral lane set the reload flag and interrupted the backend — but the turn then exited on a five_hour rejection, the idle-observed limit arm parked the session on the OLD account's 05:20 reset, and the deferral flag was never consumed: the only consumer was the top of the outer loop, which the idle wait never re-enters. The session sat 3h46m on a window the owner had already rotated away from, holding the daemon's drain.

**Fix, composed with the existing lanes (no new respawn machinery):**
- The idle wait bounces a still-set deferral to the loop's single safe point; the existing `apply_backend_credentials_reload` park-cancel preserves a park's pending re-send before the respawn.
- Terminals that bypass the drain's interrupt resolution — round death (`TurnFailed`), channel close — stay resident when the deferral is pending instead of breaking, and the error park's suspension terminal holds open the same way (the respawn is the recovery; fresh credentials are exactly what an auth-shaped death may cure). Requested stops and safeguards terminals still win over the reload.
- A reload interrupt that cut a live OBSERVED round now owes the same synthesized continuation as the primary lane (the cut turn owes, not the lane that observed it). Truly idle reloads remain idle-in-idle-out.

**Race pinned by test:** `midturn_reload_survives_limit_exit_and_respawns_on_fresh_credentials` (e2e, fake-claude rig like the park-then-die e2e): deferral armed mid-observed-turn, turn exits on a rejection resetting an hour out; the session must respawn resume-attached on the fresh store and deliver the synthesized continuation — and must NOT arm the stale-window park (log row + durable meta both asserted absent). Plus unit pins for the new rescue log row.