### PR TITLE
agenda: declared stamp-time parameters v1 (skills/plugins S2)

### DIFF
--- a/automations/narrative-backfill/SKILL.md
+++ b/automations/narrative-backfill/SKILL.md
@@ -31,6 +31,13 @@ subscription OAuth are ESTIMATES, never billed dollars.
 agent = "codex"
 model = "gpt-5.6-sol"
 effort = "xhigh"
+
+[parameters.cap]
+label = "Spend cap"
+required = true
+hint = "Cumulative cost ceiling for this arc; estimates, never billed dollars. Re-annotate the THREAD to steer it mid-arc."
+kind = "annotation"
+line = "NS CAP: $<value>"
 ```
 
 Narrative backfill run. MISSION: digest this machine's session

--- a/docs/src/agenda-and-memory.md
+++ b/docs/src/agenda-and-memory.md
@@ -1014,8 +1014,11 @@ title riding `metadata.title` — and the markdown body declares one
 `## node: <id>` section per node. Each section opens with a fenced
 `toml` config block (the machine schema: `title`, executor prefills
 `agent`/`model`/`effort`, `relies_on` edges, and for single-node
-definitions a `[cadence]` or `[trigger]` default), parsed with
-deny-unknown rigor; the prose after the block is the node's mandate.
+definitions a `[cadence]` or `[trigger]` default plus declared
+stamp-time `[parameters.<name>]` sub-tables — label, `required`,
+optional hint, `kind = "annotation"`, and a `line` template carrying
+`<value>` exactly once), parsed with deny-unknown rigor; the prose
+after the block is the node's mandate.
 Shape is **derived from arity** — one node is an *action*, 2..=8 nodes a
 *workflow* whose orientation prose above the first heading is the hub
 body. A definition directory is a valid Agent Skill, readable and
@@ -1078,12 +1081,19 @@ states what will be sealed, parked, and proposed — including the
 executor pins that will actually record (the definition's node pins
 when no explicit pick is made; "daemon defaults" only when neither
 exists) — and the Stamp button fires the stamp op — the sheet
-neither proposes nor approves client-side. The sheet also carries a
-"Note to the stamped item" input riding the stamp op's `annotations`
-field; when the selected definition's text demands a spend cap (the
-`NS CAP: $` convention), the input relabels as the spend-cap field
-and a bare typed amount records as the canonical `NS CAP: $<amount>`
-line — no human hand-formats spend-authority bytes. After the stamp,
+neither proposes nor approves client-side. The sheet renders one
+labeled input per parameter the selected definition **declares**
+(required ones marked, the declared hint as the help line): the typed
+value substitutes into the declared `line` template client-side, the
+pre-stamp summary shows the exact line that will record, and the
+lines ride the stamp op's `annotations` beside a generic
+"Note to the stamped item" input — no human hand-formats
+spend-authority bytes like the narrative-backfill `NS CAP: $<amount>`
+cap. The daemon is the enforcer: a stamp missing a `required`
+parameter refuses with a remedy naming the field, the sheet, and the
+ctl line, whatever client sent it (an empty sheet field is caught
+client-side as convenience); arriving lines matching no declared
+template pass through as ordinary notes. After the stamp,
 the ordinary card (or the workflow approval sheet) carries the
 ceremony. Stamped manifests then render
 their sealed pins on the item panel: a refs strip (locator + pin chip +
@@ -1530,8 +1540,10 @@ interrupted arc resumes from the journal; the live arc's standing
 resurrection cadence deliberately did not carry over). Its spend
 bound is an owner-set parameter, fail-closed: the run digests
 nothing until the owner has annotated the stamped item
-`NS CAP: $<amount>` — the Automate sheet's spend-cap field records
-the annotation at stamp time, and it can be set or changed later in
+`NS CAP: $<amount>` — declared as the required `[parameters.cap]`
+stamp-time parameter, so the Automate sheet's spend-cap field records
+the annotation at stamp time (a stamp arriving without it refuses
+with the remedy), and it can be set or changed later in
 the item's THREAD section or via
 `intendant ctl agenda annotate <item-id> 'NS CAP: $60'`. A run that
 finds no cap refuses with an annotation naming both of those

--- a/src/bin/caller/agenda/definitions.rs
+++ b/src/bin/caller/agenda/definitions.rs
@@ -863,14 +863,15 @@ pub(crate) fn parse_definition(
                 section.id
             ));
         }
-        let mut parameters: Vec<DefinitionParameter> = Vec::new();
-        for (param_name, param) in config.parameters.unwrap_or_default() {
-            if parameters.len() == MAX_NODE_PARAMETERS {
-                return Err(format!(
-                    "node `{}` declares more than {MAX_NODE_PARAMETERS} parameters",
-                    section.id
-                ));
-            }
+        let declared = config.parameters.unwrap_or_default();
+        if declared.len() > MAX_NODE_PARAMETERS {
+            return Err(format!(
+                "node `{}` declares more than {MAX_NODE_PARAMETERS} parameters",
+                section.id
+            ));
+        }
+        let mut parameters: Vec<DefinitionParameter> = Vec::with_capacity(declared.len());
+        for (param_name, param) in declared {
             if !valid_slug(&param_name) {
                 return Err(format!(
                     "parameter name {param_name:?} violates the slug grammar (lowercase \
@@ -1547,10 +1548,14 @@ mod tests {
                  [parameters.two]\nlabel = \"Two\"\nkind = \"annotation\"\nline = \"{b}\"\n"
             );
             let err = parse_definition(&action(&config, "P."), "sample").unwrap_err();
-            assert!(err.contains("overlapping line templates"), "{a:?}/{b:?}: {err}");
+            assert!(
+                err.contains("overlapping line templates"),
+                "{a:?}/{b:?}: {err}"
+            );
             assert!(err.contains("`one`") && err.contains("`two`"), "{err}");
         }
-        let disjoint = "[parameters.one]\nlabel = \"One\"\nkind = \"annotation\"\nline = \"A: <value>\"\n\
+        let disjoint =
+            "[parameters.one]\nlabel = \"One\"\nkind = \"annotation\"\nline = \"A: <value>\"\n\
              [parameters.two]\nlabel = \"Two\"\nkind = \"annotation\"\nline = \"B: <value>\"\n";
         let def = parse_definition(&action(disjoint, "P."), "sample").unwrap();
         assert_eq!(def.nodes[0].parameters.len(), 2);

--- a/src/bin/caller/agenda/definitions.rs
+++ b/src/bin/caller/agenda/definitions.rs
@@ -28,6 +28,18 @@ use std::path::{Path, PathBuf};
 /// registry bound, promoted).
 pub(crate) const MAX_DEFINITION_NODES: usize = 8;
 
+/// Declared-parameter rails (skills/plugins unification §4b): at most 8
+/// parameters per definition, labels ≤80 chars, line templates ≤240
+/// chars (the annotation-quote convention's scale).
+const MAX_NODE_PARAMETERS: usize = 8;
+const MAX_PARAMETER_LABEL_CHARS: usize = 80;
+const MAX_PARAMETER_LINE_CHARS: usize = 240;
+
+/// The substitution slot a parameter's line template carries exactly
+/// once — the sheet and ctl replace it with the typed value; the raw
+/// template with the literal placeholder substitutes nothing.
+pub(crate) const PARAMETER_VALUE_PLACEHOLDER: &str = "<value>";
+
 /// The agentskills.io spec's frontmatter vocabulary — the ONLY top-level
 /// keys a definition may carry (Amendment A1: spec fields only).
 const SPEC_FRONTMATTER_KEYS: &[&str] = &[
@@ -123,6 +135,55 @@ pub(crate) struct DefinitionTrigger {
     pub(crate) tags: Vec<String>,
 }
 
+/// One declared stamp-time parameter (`[parameters.<name>]` in an
+/// action's node config block): a *guaranteed, canonically-formatted,
+/// owner-attributed annotation at stamp time* — nothing more. The value
+/// rides the stamp op's `annotations` lines; what it MEANS is decided by
+/// the sealed mandate's own prose (e.g. the narrative-backfill cap law),
+/// and execution authority still flows only from the per-effect
+/// approval digest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DefinitionParameter {
+    /// The `[parameters.<name>]` key — slug grammar, name-sorted.
+    pub(crate) name: String,
+    /// The Automate sheet's field label.
+    pub(crate) label: String,
+    /// Refuse the stamp when no arriving line satisfies this parameter.
+    pub(crate) required: bool,
+    /// The field's help line on the sheet.
+    pub(crate) hint: Option<String>,
+    /// The annotation line template, carrying `<value>` exactly once.
+    pub(crate) line: String,
+}
+
+impl DefinitionParameter {
+    /// The fixed-string anchors around the template's one `<value>`
+    /// slot — validation guarantees exactly one occurrence, so matching
+    /// is deterministic by construction (refinement R1).
+    pub(crate) fn anchors(&self) -> (&str, &str) {
+        let at = self
+            .line
+            .find(PARAMETER_VALUE_PLACEHOLDER)
+            .expect("validated: template carries the placeholder exactly once");
+        (
+            &self.line[..at],
+            &self.line[at + PARAMETER_VALUE_PLACEHOLDER.len()..],
+        )
+    }
+
+    /// R1 satisfaction: the line exactly matches the template with
+    /// `<value>` replaced by a NON-EMPTY segment. The raw template with
+    /// the literal placeholder is NOT satisfaction, and a line matching
+    /// no template is an ordinary note — callers never refuse it.
+    pub(crate) fn matches(&self, line: &str) -> bool {
+        let (prefix, suffix) = self.anchors();
+        line.len() > prefix.len() + suffix.len()
+            && line.starts_with(prefix)
+            && line.ends_with(suffix)
+            && line != self.line
+    }
+}
+
 /// One parsed node: id from its `## node: <id>` heading, machine config
 /// from the fenced toml block opening the section, goal prose after it.
 #[derive(Debug, Clone)]
@@ -137,6 +198,9 @@ pub(crate) struct DefinitionNode {
     pub(crate) project_root: Option<String>,
     pub(crate) cadence: Option<DefinitionCadence>,
     pub(crate) trigger: Option<DefinitionTrigger>,
+    /// Declared stamp-time parameters, name-sorted (action-only in v1;
+    /// the parser refuses `[parameters.*]` on workflow nodes).
+    pub(crate) parameters: Vec<DefinitionParameter>,
 }
 
 impl DefinitionNode {
@@ -329,6 +393,22 @@ pub(crate) fn resolve_definition(
 
 // ---- The served catalog (slice 2) ----
 
+/// One declared parameter's catalog surface — everything the Automate
+/// sheet needs to render the field, substitute the typed value into the
+/// line template, and show the exact line the stamp will record.
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct CatalogParameter {
+    pub(crate) name: String,
+    pub(crate) label: String,
+    pub(crate) required: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) hint: Option<String>,
+    /// v1's one kind, `"annotation"` — served so a future kind is wire
+    /// vocabulary a sheet can dispatch on, never a silent guess.
+    pub(crate) kind: &'static str,
+    pub(crate) line: String,
+}
+
 /// One node's catalog surface — the Automate sheet's prefill material.
 #[derive(Debug, Clone, serde::Serialize)]
 pub(crate) struct CatalogNode {
@@ -350,6 +430,8 @@ pub(crate) struct CatalogNode {
     pub(crate) trigger_kind: Option<super::types::AgendaKind>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub(crate) trigger_tags: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(crate) parameters: Vec<CatalogParameter>,
 }
 
 /// One catalog entry: a discovered definition with its validation state.
@@ -501,6 +583,18 @@ fn catalog_entry(
                         .as_ref()
                         .map(|t| t.tags.clone())
                         .unwrap_or_default(),
+                    parameters: node
+                        .parameters
+                        .iter()
+                        .map(|p| CatalogParameter {
+                            name: p.name.clone(),
+                            label: p.label.clone(),
+                            required: p.required,
+                            hint: p.hint.clone(),
+                            kind: "annotation",
+                            line: p.line.clone(),
+                        })
+                        .collect(),
                 })
                 .collect(),
             text,
@@ -527,6 +621,24 @@ struct NodeConfigToml {
     project_root: Option<String>,
     cadence: Option<CadenceToml>,
     trigger: Option<TriggerToml>,
+    parameters: Option<std::collections::BTreeMap<String, ParameterToml>>,
+}
+
+/// One `[parameters.<name>]` sub-table (skills/plugins unification §4b).
+/// Deny-unknown like every config shape: an unknown key refuses the
+/// definition by name instead of silently riding as prose.
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ParameterToml {
+    label: String,
+    #[serde(default)]
+    required: bool,
+    hint: Option<String>,
+    /// v1 accepts exactly `"annotation"`; unknown kinds refuse by name —
+    /// future kinds are new vocabulary, never silent passthrough.
+    kind: String,
+    /// The annotation line template; must carry `<value>` exactly once.
+    line: String,
 }
 
 #[derive(serde::Deserialize)]
@@ -751,6 +863,76 @@ pub(crate) fn parse_definition(
                 section.id
             ));
         }
+        let mut parameters: Vec<DefinitionParameter> = Vec::new();
+        for (param_name, param) in config.parameters.unwrap_or_default() {
+            if parameters.len() == MAX_NODE_PARAMETERS {
+                return Err(format!(
+                    "node `{}` declares more than {MAX_NODE_PARAMETERS} parameters",
+                    section.id
+                ));
+            }
+            if !valid_slug(&param_name) {
+                return Err(format!(
+                    "parameter name {param_name:?} violates the slug grammar (lowercase \
+                     alphanumerics, single interior hyphens)"
+                ));
+            }
+            let label_chars = param.label.trim().chars().count();
+            if label_chars == 0 || param.label.chars().count() > MAX_PARAMETER_LABEL_CHARS {
+                return Err(format!(
+                    "parameter `{param_name}` label must be 1..={MAX_PARAMETER_LABEL_CHARS} \
+                     characters"
+                ));
+            }
+            if param.kind != "annotation" {
+                return Err(format!(
+                    "parameter `{param_name}` kind {:?} is not v1 vocabulary — the one \
+                     kind is \"annotation\" (future kinds are new vocabulary, never \
+                     silent passthrough)",
+                    param.kind
+                ));
+            }
+            let line = param.line.trim().to_string();
+            if line.matches(PARAMETER_VALUE_PLACEHOLDER).count() != 1 {
+                return Err(format!(
+                    "parameter `{param_name}` line template must contain \
+                     {PARAMETER_VALUE_PLACEHOLDER} exactly once (got {:?})",
+                    param.line
+                ));
+            }
+            if line.chars().count() > MAX_PARAMETER_LINE_CHARS {
+                return Err(format!(
+                    "parameter `{param_name}` line template exceeds \
+                     {MAX_PARAMETER_LINE_CHARS} characters"
+                ));
+            }
+            parameters.push(DefinitionParameter {
+                name: param_name,
+                label: param.label,
+                required: param.required,
+                hint: param.hint,
+                line,
+            });
+        }
+        // Refinement R1(c): matching stays deterministic by construction —
+        // two templates one line could satisfy simultaneously (identical,
+        // or one's anchors subsuming the other's) refuse at validation.
+        for i in 0..parameters.len() {
+            for j in (i + 1)..parameters.len() {
+                let (a, b) = (&parameters[i], &parameters[j]);
+                let ((ap, asx), (bp, bsx)) = (a.anchors(), b.anchors());
+                if (ap.starts_with(bp) || bp.starts_with(ap))
+                    && (asx.ends_with(bsx) || bsx.ends_with(asx))
+                {
+                    return Err(format!(
+                        "node `{}`: parameters `{}` and `{}` have overlapping line \
+                         templates — one arriving line could satisfy both, so \
+                         matching would not be deterministic",
+                        section.id, a.name, b.name
+                    ));
+                }
+            }
+        }
         nodes.push(DefinitionNode {
             title: config
                 .title
@@ -765,6 +947,7 @@ pub(crate) fn parse_definition(
             project_root: config.project_root,
             cadence,
             trigger,
+            parameters,
         });
     }
 
@@ -786,6 +969,17 @@ pub(crate) fn parse_definition(
                 return Err(format!(
                     "workflow node `{}` declares cadence/trigger — workflow nodes fire \
                      on_unblock; entry triggers are future vocabulary",
+                    node.id
+                ));
+            }
+            // Same ruled-absence pattern for declared parameters: every
+            // named use case is an action, and workflow-level parameter
+            // routing (which node's item carries the annotation? the
+            // hub?) deserves its own ruling rather than a guess.
+            if !node.parameters.is_empty() {
+                return Err(format!(
+                    "workflow node `{}` declares [parameters.*] — v1 parameters are \
+                     action-only; workflow parameter routing is future vocabulary",
                     node.id
                 ));
             }
@@ -1230,6 +1424,199 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.contains("claude-code and codex"), "{err}");
+    }
+
+    /// Skills/plugins S2 (§4b): `[parameters.<name>]` sub-tables parse
+    /// with the house deny-unknown rigor and every stated rail — slug
+    /// names, label 1..=80, kind exactly "annotation" (unknown kinds
+    /// refuse BY NAME), `<value>` exactly once, line ≤240, at most 8 per
+    /// definition — and an old-format definition parses unchanged.
+    #[test]
+    fn declared_parameters_validate_with_deny_unknown_rigor() {
+        let cap = "[parameters.cap]\nlabel = \"Spend cap\"\nrequired = true\nhint = \"ceiling\"\nkind = \"annotation\"\nline = \"NS CAP: $<value>\"\n";
+        let def = parse_definition(&action(cap, "P."), "sample").unwrap();
+        assert_eq!(
+            def.nodes[0].parameters,
+            vec![DefinitionParameter {
+                name: "cap".into(),
+                label: "Spend cap".into(),
+                required: true,
+                hint: Some("ceiling".into()),
+                line: "NS CAP: $<value>".into(),
+            }]
+        );
+
+        // Old format: no `parameters` key parses exactly as before.
+        let def = parse_definition(&action("", "P."), "sample").unwrap();
+        assert!(def.nodes[0].parameters.is_empty());
+
+        // `required` defaults false; `hint` is optional.
+        let minimal = "[parameters.scope]\nlabel = \"Scope\"\nkind = \"annotation\"\nline = \"SCOPE: <value>\"\n";
+        let def = parse_definition(&action(minimal, "P."), "sample").unwrap();
+        assert!(!def.nodes[0].parameters[0].required);
+        assert!(def.nodes[0].parameters[0].hint.is_none());
+
+        // Unknown kinds refuse by name — future kinds are new
+        // vocabulary, never silent passthrough.
+        let err = parse_definition(
+            &action(
+                "[parameters.x]\nlabel = \"X\"\nkind = \"wire-field\"\nline = \"X: <value>\"\n",
+                "P.",
+            ),
+            "sample",
+        )
+        .unwrap_err();
+        assert!(err.contains("\"wire-field\""), "{err}");
+        assert!(err.contains("annotation"), "{err}");
+
+        // Unknown keys inside the sub-table refuse by name.
+        let err = parse_definition(
+            &action(
+                "[parameters.x]\nlabel = \"X\"\nkind = \"annotation\"\nline = \"X: <value>\"\ndefault = \"60\"\n",
+                "P.",
+            ),
+            "sample",
+        )
+        .unwrap_err();
+        assert!(err.contains("default"), "{err}");
+
+        // The placeholder appears exactly once — zero or two refuse.
+        for line in ["X: value", "X: <value> <value>"] {
+            let config = format!(
+                "[parameters.x]\nlabel = \"X\"\nkind = \"annotation\"\nline = \"{line}\"\n"
+            );
+            let err = parse_definition(&action(&config, "P."), "sample").unwrap_err();
+            assert!(err.contains("exactly once"), "{line:?}: {err}");
+        }
+
+        // Label bounds: empty and >80 chars refuse.
+        for label in [String::from(" "), "x".repeat(81)] {
+            let config = format!(
+                "[parameters.x]\nlabel = \"{label}\"\nkind = \"annotation\"\nline = \"X: <value>\"\n"
+            );
+            let err = parse_definition(&action(&config, "P."), "sample").unwrap_err();
+            assert!(err.contains("label must be 1..=80"), "{err}");
+        }
+
+        // Line template bound: >240 chars refuse.
+        let config = format!(
+            "[parameters.x]\nlabel = \"X\"\nkind = \"annotation\"\nline = \"{}<value>\"\n",
+            "x".repeat(241)
+        );
+        let err = parse_definition(&action(&config, "P."), "sample").unwrap_err();
+        assert!(err.contains("exceeds 240"), "{err}");
+
+        // Parameter names obey the slug grammar.
+        let err = parse_definition(
+            &action(
+                "[parameters.\"Bad Name\"]\nlabel = \"X\"\nkind = \"annotation\"\nline = \"X: <value>\"\n",
+                "P.",
+            ),
+            "sample",
+        )
+        .unwrap_err();
+        assert!(err.contains("slug grammar"), "{err}");
+
+        // At most 8 parameters per definition.
+        let mut config = String::new();
+        for i in 0..9 {
+            config.push_str(&format!(
+                "[parameters.p{i}]\nlabel = \"P{i}\"\nkind = \"annotation\"\nline = \"P{i}: <value>\"\n"
+            ));
+        }
+        let err = parse_definition(&action(&config, "P."), "sample").unwrap_err();
+        assert!(err.contains("more than 8 parameters"), "{err}");
+
+        // The action-only rail (the R3 ruled-absence pattern): a
+        // workflow node declaring [parameters.*] refuses by name.
+        let doc = "---\nname: x\ndescription: d\n---\n\nO.\n\n## node: a\n\n```toml\n[parameters.cap]\nlabel = \"Cap\"\nkind = \"annotation\"\nline = \"CAP: <value>\"\n```\n\nA.\n\n## node: b\n\n```toml\n```\n\nB.\n";
+        let err = parse_definition(doc, "x").unwrap_err();
+        assert!(err.contains("workflow node `a`"), "{err}");
+        assert!(err.contains("action-only"), "{err}");
+
+        // Refinement R1(c): templates one line could satisfy
+        // simultaneously refuse at validation — identical, and
+        // anchor-subsuming pairs alike; disjoint anchors coexist.
+        for (a, b) in [
+            ("CAP: $<value>", "CAP: $<value>"),
+            ("CAP: $<value>", "CAP: <value>"),
+            ("NS CAP: $<value>", "NS <value> extra"),
+        ] {
+            let config = format!(
+                "[parameters.one]\nlabel = \"One\"\nkind = \"annotation\"\nline = \"{a}\"\n\
+                 [parameters.two]\nlabel = \"Two\"\nkind = \"annotation\"\nline = \"{b}\"\n"
+            );
+            let err = parse_definition(&action(&config, "P."), "sample").unwrap_err();
+            assert!(err.contains("overlapping line templates"), "{a:?}/{b:?}: {err}");
+            assert!(err.contains("`one`") && err.contains("`two`"), "{err}");
+        }
+        let disjoint = "[parameters.one]\nlabel = \"One\"\nkind = \"annotation\"\nline = \"A: <value>\"\n\
+             [parameters.two]\nlabel = \"Two\"\nkind = \"annotation\"\nline = \"B: <value>\"\n";
+        let def = parse_definition(&action(disjoint, "P."), "sample").unwrap();
+        assert_eq!(def.nodes[0].parameters.len(), 2);
+    }
+
+    /// Refinement R1(a): satisfaction is the template with `<value>`
+    /// replaced by a NON-EMPTY segment — fixed-string anchors on both
+    /// sides, and the raw template with the literal placeholder
+    /// satisfies nothing.
+    #[test]
+    fn parameter_matching_is_anchored_and_deterministic() {
+        let param = DefinitionParameter {
+            name: "cap".into(),
+            label: "Spend cap".into(),
+            required: true,
+            hint: None,
+            line: "NS CAP: $<value>".into(),
+        };
+        assert!(param.matches("NS CAP: $60"));
+        assert!(param.matches("NS CAP: $60.50"));
+        // The literal placeholder substitutes nothing.
+        assert!(!param.matches("NS CAP: $<value>"));
+        // An empty segment satisfies nothing.
+        assert!(!param.matches("NS CAP: $"));
+        // Anchors are exact — prefix and suffix both bind.
+        assert!(!param.matches("CAP: $60"));
+        assert!(!param.matches("ns cap: $60"));
+        assert!(!param.matches("a NS CAP: $60"));
+
+        let suffixed = DefinitionParameter {
+            line: "cap <value> end".into(),
+            ..param
+        };
+        assert!(suffixed.matches("cap 60 end"));
+        assert!(!suffixed.matches("cap  end"));
+        assert!(!suffixed.matches("cap 60 end."));
+    }
+
+    /// §4c: the catalog serves declared parameters on the node,
+    /// skip-if-empty — the Automate sheet renders served data only.
+    #[test]
+    fn catalog_serves_declared_parameters_skip_if_empty() {
+        let root = tempfile::tempdir().unwrap();
+        materialize_house_definitions(root.path()).unwrap();
+        let catalog = definition_catalog(root.path());
+        let backfill = catalog
+            .iter()
+            .find(|e| e.name == "narrative-backfill")
+            .unwrap();
+        let node = serde_json::to_value(&backfill.nodes[0]).unwrap();
+        assert_eq!(
+            node["parameters"],
+            serde_json::json!([{
+                "name": "cap",
+                "label": "Spend cap",
+                "required": true,
+                "hint": "Cumulative cost ceiling for this arc; estimates, never billed \
+                         dollars. Re-annotate the THREAD to steer it mid-arc.",
+                "kind": "annotation",
+                "line": "NS CAP: $<value>",
+            }])
+        );
+        // Skip-if-empty: a parameterless node serializes no key at all.
+        let triage = catalog.iter().find(|e| e.name == "triage").unwrap();
+        let node = serde_json::to_value(&triage.nodes[0]).unwrap();
+        assert!(node.get("parameters").is_none(), "{node}");
     }
 
     #[test]

--- a/src/bin/caller/agenda/store.rs
+++ b/src/bin/caller/agenda/store.rs
@@ -7921,7 +7921,10 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["NS CAP: $60", "context: adoption bootstrap"]
         );
-        assert!(item.annotations.iter().all(|a| a.principal.as_deref() == Some("owner")));
+        assert!(item
+            .annotations
+            .iter()
+            .all(|a| a.principal.as_deref() == Some("owner")));
         let effect = item.effects.first().expect("proposed manifest");
         assert!(effect.approval.is_none(), "stamping approves nothing");
         assert_eq!(effect.manifest.binding_refs.len(), 1);

--- a/src/bin/caller/agenda/store.rs
+++ b/src/bin/caller/agenda/store.rs
@@ -1118,6 +1118,34 @@ impl AgendaStore {
                 )));
             }
         }
+        // Declared-parameter enforcement (skills/plugins S2, refinement
+        // R1): a required parameter is satisfied only by an arriving
+        // stamp-time line that exactly matches its template with
+        // `<value>` replaced by a NON-EMPTY segment — the raw template
+        // with the literal placeholder satisfies nothing. Lines matching
+        // no declared template pass through as ordinary notes, never
+        // refused (v0's generic note lane survives byte-unchanged).
+        // Parameters are action-only, so the nodes' declarations are the
+        // definition's; the client-side sheet check is convenience — this
+        // refusal is the wall.
+        for param in def.nodes.iter().flat_map(|n| n.parameters.iter()) {
+            if !param.required
+                || stamp
+                    .annotations
+                    .iter()
+                    .any(|note| param.matches(note.trim()))
+            {
+                continue;
+            }
+            return Err(AgendaError::Invalid(format!(
+                "definition {}: required parameter `{}` ({:?}) is missing — fill the \
+                 {:?} field on the Automate sheet, or stamp from a shell: intendant \
+                 ctl agenda stamp {} --note '{}' with your value in place of <value>. \
+                 The stamp records that exact line, attributed to you, in the stamped \
+                 item's THREAD section — the surface this definition's mandate reads",
+                def.name, param.name, param.label, param.label, stamp.definition, param.line
+            )));
+        }
         let fire_at_ms = stamp.fire_at_ms.unwrap_or(now_ms);
 
         // Park the instance graph (today's stamp topologies, verbatim):
@@ -7826,6 +7854,108 @@ mod tests {
         );
     }
 
+    /// Skills/plugins S2, refinement R1: `apply_stamp` enforces declared
+    /// parameters on the v0 annotation-lines lane. A required parameter
+    /// with no satisfying line refuses the whole stamp BEFORE anything
+    /// parks, naming the field, the sheet, and the THREAD/ctl remedy;
+    /// the raw template with the literal `<value>` placeholder is NOT
+    /// satisfaction; and lines matching no declared template pass
+    /// through as ordinary notes, never refused.
+    #[test]
+    fn stamp_enforces_required_declared_parameters() {
+        // Empty-cap stamp: the two-surfaces refusal, nothing parked.
+        let (_root, mut store) = stamp_rig();
+        let err = store
+            .apply_stamp_command(stamp_cmd("narrative-backfill"), owner(), 5000)
+            .unwrap_err();
+        let msg = err.to_string();
+        for fragment in [
+            "required parameter `cap`",
+            "\"Spend cap\"",
+            "Automate sheet",
+            "intendant ctl agenda stamp narrative-backfill --note 'NS CAP: $<value>'",
+            "THREAD section",
+        ] {
+            assert!(msg.contains(fragment), "refusal lost {fragment:?}: {msg}");
+        }
+        assert!(
+            store.snapshot().is_empty(),
+            "nothing parks on a refused required parameter"
+        );
+
+        // The raw template satisfies nothing (R1a): the literal
+        // placeholder is not a value.
+        let (_root2, mut store2) = stamp_rig();
+        let err = store2
+            .apply_stamp_command(
+                stamp_cmd_with_notes("narrative-backfill", &["NS CAP: $<value>"]),
+                owner(),
+                5000,
+            )
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("required parameter `cap`"),
+            "{err}"
+        );
+
+        // A satisfying line stamps; a free-form note beside it passes
+        // through as an ordinary v0 note (R1b) — and the instance is
+        // armable: the manifest is proposed with the definition sealed,
+        // so a fired run reads the exact cap bytes from the THREAD.
+        let (_root3, mut store3) = stamp_rig();
+        let outcome = store3
+            .apply_stamp_command(
+                stamp_cmd_with_notes(
+                    "narrative-backfill",
+                    &["NS CAP: $60", "context: adoption bootstrap"],
+                ),
+                owner(),
+                5000,
+            )
+            .unwrap();
+        let item = &outcome.nodes[0].item;
+        assert_eq!(
+            item.annotations
+                .iter()
+                .map(|a| a.text.as_str())
+                .collect::<Vec<_>>(),
+            vec!["NS CAP: $60", "context: adoption bootstrap"]
+        );
+        assert!(item.annotations.iter().all(|a| a.principal.as_deref() == Some("owner")));
+        let effect = item.effects.first().expect("proposed manifest");
+        assert!(effect.approval.is_none(), "stamping approves nothing");
+        assert_eq!(effect.manifest.binding_refs.len(), 1);
+    }
+
+    /// Skills/plugins S2, refinement R2: recorded parameter annotations
+    /// carry the STAMP'S gate-resolved attribution, never a synthesized
+    /// owner — a non-owner principal stamping via an agent lane records
+    /// non-owner attribution, so the cap mandate's owner-written-only
+    /// read keeps refusing, fail-closed.
+    #[test]
+    fn stamp_parameter_annotations_carry_the_stamp_actor_attribution() {
+        let (_root, mut store) = stamp_rig();
+        let agent = Some(AgendaActor {
+            principal: Some("principal:agent-session:sess-7".into()),
+            session_id: Some("sess-7".into()),
+            kind: Some("agent_session".into()),
+        });
+        let outcome = store
+            .apply_stamp_command(
+                stamp_cmd_with_notes("narrative-backfill", &["NS CAP: $60"]),
+                agent,
+                5000,
+            )
+            .unwrap();
+        let note = &outcome.nodes[0].item.annotations[0];
+        assert_eq!(note.text, "NS CAP: $60");
+        assert_eq!(
+            note.principal.as_deref(),
+            Some("principal:agent-session:sess-7"),
+            "the recorded attribution is the stamp actor's, never synthesized"
+        );
+    }
+
     /// Steward N1 (slice-1 gate): the deleted registry invariants used
     /// to check at CI time that shipped defaults respect the intake
     /// floors; under one-authority that check moved to stamp time — so
@@ -7834,10 +7964,22 @@ mod tests {
     /// again instead of failing at the owner's first stamp.
     #[test]
     fn house_definitions_stamp_through_the_real_intake() {
-        for (name, _) in super::super::definitions::HOUSE_DEFINITIONS {
+        for (name, content) in super::super::definitions::HOUSE_DEFINITIONS {
             let (_root, mut store) = stamp_rig();
+            // A required declared parameter refuses a bare stamp by
+            // design (skills/plugins S2), so satisfy each with a
+            // specimen line — the same substitution the sheet performs.
+            let def = super::super::definitions::parse_definition(content, name).unwrap();
+            let notes: Vec<String> = def
+                .nodes
+                .iter()
+                .flat_map(|n| n.parameters.iter())
+                .filter(|p| p.required)
+                .map(|p| p.line.replace("<value>", "60"))
+                .collect();
+            let notes: Vec<&str> = notes.iter().map(String::as_str).collect();
             let outcome = store
-                .apply_stamp_command(stamp_cmd(name), owner(), 5000)
+                .apply_stamp_command(stamp_cmd_with_notes(name, &notes), owner(), 5000)
                 .unwrap_or_else(|err| panic!("house definition {name} refused at stamp: {err}"));
             assert!(!outcome.nodes.is_empty(), "{name} stamped no nodes");
             for node in &outcome.nodes {
@@ -7858,7 +8000,11 @@ mod tests {
         // three-lane weekly chain with the owner-directed executor stack.
         let (_root, mut store) = stamp_rig();
         let outcome = store
-            .apply_stamp_command(stamp_cmd("narrative-backfill"), owner(), 5000)
+            .apply_stamp_command(
+                stamp_cmd_with_notes("narrative-backfill", &["NS CAP: $60"]),
+                owner(),
+                5000,
+            )
             .unwrap();
         assert!(outcome.hub.is_none(), "the bootstrap is an action");
         let effect = &outcome.nodes[0].item.effects[0];

--- a/src/bin/caller/web_gateway/static_assets.rs
+++ b/src/bin/caller/web_gateway/static_assets.rs
@@ -893,28 +893,45 @@ mod tests {
         assert!(sheet.contains("shadowed by a personal definition of the same name"));
     }
 
-    /// Card 01KZ8PK1FD: the automate sheet's stamp-time note lane. The
-    /// note input rides the stamp op's `annotations`; for a
-    /// cap-demanding definition it is the spend-cap field whose bare
-    /// typed amount canonicalizes client-side to the exact
-    /// `NS CAP: $<amount>` bytes the mandate greps for — no human
-    /// hand-formats spend authority. And the executor summary stays
-    /// honest: it names the definition's node pins instead of claiming
-    /// "daemon defaults" when pins exist.
+    /// Skills/plugins S2 (sealed intake d56f4ebf, §4c): the automate
+    /// sheet renders DECLARED parameters served on the catalog node —
+    /// v0's prose-sniffing cap heuristic (card 01KZ8PK1FD) is replaced
+    /// by declared data. The typed value substitutes into the declared
+    /// line template client-side (the machine writes the canonical
+    /// bytes), the pre-stamp summary shows the exact substituted line,
+    /// the empty-required gate is client convenience beside the daemon's
+    /// refusal, and every line rides the stamp op's `annotations` beside
+    /// the surviving generic note lane. The v0 copy laws carry over: the
+    /// annotation surface is named THREAD, and the executor summary
+    /// names the definition's node pins instead of claiming "daemon
+    /// defaults" when pins exist.
     #[test]
-    fn automate_sheet_note_field_canonicalizes_spend_caps() {
+    fn automate_sheet_renders_declared_parameters() {
         let sheet = include_str!("../../../../static/app/ui2-agenda.js");
         assert!(
-            sheet.contains("function agendaStampCapDemanded"),
-            "the sheet must detect cap-demanding definitions from their served text"
+            sheet.contains("function agendaStampDeclaredParams"),
+            "the sheet must render the parameters the catalog declares"
         );
         assert!(
-            sheet.contains("NS CAP: $${bare}"),
-            "a bare typed amount must canonicalize to the exact NS CAP: $<amount> bytes"
+            !sheet.contains("agendaStampCapDemanded"),
+            "the v0 prose-sniffing cap heuristic is replaced by declared data (S2)"
         );
         assert!(
-            sheet.contains("overrides.annotations = [noteText]"),
-            "the note must ride the stamp op's annotations field"
+            sheet.contains(".replace('<value>', () => value)"),
+            "the typed value must substitute into the declared template verbatim"
+        );
+        assert!(
+            sheet.contains("record ${param.label || param.name} in the item’s THREAD: ${line}"),
+            "the pre-stamp summary must show the exact substituted line"
+        );
+        assert!(
+            sheet.contains("Fill the required ${param.label || param.name} field"),
+            "an empty required parameter must refuse client-side (convenience; \
+             the daemon op is the wall)"
+        );
+        assert!(
+            sheet.contains("overrides.annotations = annotations"),
+            "parameter lines and the note must ride the stamp op's annotations field"
         );
         // Copy law: the user-facing name for the annotation surface is
         // THREAD (the UI's label), never the internal inspector name.
@@ -922,8 +939,8 @@ mod tests {
             sheet.contains("THREAD section"),
             "note copy must name the THREAD section"
         );
-        // Executor honesty (the sheet-summary half of the card): the
-        // definition's node pins are named when no explicit pick is
+        // Executor honesty (the sheet-summary half of card 01KZ8PK1FD):
+        // the definition's node pins are named when no explicit pick is
         // made — the stamp lane's actual fallback.
         assert!(
             sheet.contains("the definition’s node pins, recorded on the manifest"),

--- a/static/app.html
+++ b/static/app.html
@@ -39165,7 +39165,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '5bd060172a081bb9';
+const INTENDANT_APP_BUILD = 'c690396905cbab70';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -97738,24 +97738,25 @@ const AGENDA_AUTOMATION_CADENCES = [
   { label: 'Every 30 days', ms: 30 * 24 * 60 * 60 * 1000 },
 ];
 
-// Cap-demanding definitions (the narrative-backfill class): the
-// definition's own text carries the owner-cap annotation convention,
-// so the sheet's note input doubles as the spend-cap lane for it.
-function agendaStampCapDemanded(entry) {
-  return !!(entry && typeof entry.text === 'string' && entry.text.includes('NS CAP: $'));
+// The declared stamp-time parameters of the selected entry (the catalog
+// serves them on the node, skip-if-empty): the sheet renders exactly
+// what the daemon declared — no client-side parameter vocabulary, no
+// prose sniffing. Parameters are action-only in v1, so at most the
+// single node carries them.
+function agendaStampDeclaredParams(entry) {
+  const node = entry && entry.nodes && entry.nodes[0];
+  return (node && Array.isArray(node.parameters)) ? node.parameters : [];
 }
 
-// Spend-authority bytes are exact: a bare amount typed into the cap
-// field canonicalizes to `NS CAP: $<amount>` here, so no human ever
-// hand-formats the line the mandate greps for. Anything else passes
-// through verbatim — an already-canonical line stays untouched, and
-// free text stays an ordinary note (the mandate's near-miss refusal
-// quotes it back kindly instead of parsing amounts out of prose).
-function agendaStampNoteText(entry, raw) {
-  const text = String(raw || '').trim();
-  if (!text || !agendaStampCapDemanded(entry)) return text;
-  const bare = text.startsWith('$') ? text.slice(1).trim() : text;
-  return /^\d+(\.\d+)?$/.test(bare) ? `NS CAP: $${bare}` : text;
+// The exact annotation line a typed parameter value records: the
+// declared template with its one `<value>` slot substituted verbatim
+// (function replacement so `$`-patterns in the value never expand) —
+// the machine writes the canonical bytes, no human hand-formats
+// spend-authority lines like `NS CAP: $<amount>`.
+function agendaStampParamLine(param, raw) {
+  const value = String(raw || '').trim();
+  if (!value) return '';
+  return String(param.line || '').replace('<value>', () => value);
 }
 
 // `preselect` (optional) names a definition to open on — the Plugins &
@@ -97922,13 +97923,42 @@ function agendaOpenAutomationSheet(anchor, preselect) {
       });
   }
 
+  // Declared parameters (skills/plugins S2): one labeled input per
+  // parameter the selected definition declares in its node config block
+  // — required ones marked, the declared hint as the help line. Typed
+  // values substitute into the declared line templates and ride the
+  // stamp op's annotations beside the generic note; the daemon refuses
+  // a stamp missing a required parameter, so the sheet's empty-required
+  // gate below is convenience, never the wall.
+  const paramsBox = agendaStartSheetEl('div', 'agsx-params');
+  panel.appendChild(paramsBox);
+  const paramInputs = new Map(); // parameter name -> its input element
+  const renderParamRows = () => {
+    paramsBox.textContent = '';
+    paramInputs.clear();
+    for (const param of agendaStampDeclaredParams(entry)) {
+      const row = agendaStartSheetEl('div', 'ags-config-row');
+      const label = agendaStartSheetEl('label', 'ags-label',
+        `${param.label || param.name}${param.required ? ' (required)' : ''}`);
+      label.setAttribute('for', `agsx-param-${param.name}`);
+      row.appendChild(label);
+      const input = document.createElement('input');
+      input.type = 'text';
+      input.id = `agsx-param-${param.name}`;
+      input.addEventListener('input', renderSummary);
+      row.appendChild(input);
+      row.appendChild(agendaStartSheetEl('div', 'ags-hint', param.hint
+        || `recorded as ${param.line} in the stamped item’s THREAD section`));
+      paramsBox.appendChild(row);
+      paramInputs.set(param.name, input);
+    }
+  };
+
   // Note to the stamped item: one optional owner note recorded AT PARK
   // on the annotation surface the fired mandates read (a workflow's
-  // hub, an action's item), attributed to whoever stamps. When the
-  // selected definition demands a spend cap, this input IS the cap
-  // lane — a bare amount canonicalizes to `NS CAP: $<amount>` at
-  // submit (agendaStampNoteText), so nobody hand-formats authority
-  // bytes; renderSelection relabels the row per definition.
+  // hub, an action's item), attributed to whoever stamps. Always the
+  // generic lane — a definition that wants a formatted value declares a
+  // parameter for it, rendered above.
   const noteRow = agendaStartSheetEl('div', 'ags-config-row');
   const noteLabel = agendaStartSheetEl('label', 'ags-label', 'Note');
   noteLabel.setAttribute('for', 'agsx-note');
@@ -97936,9 +97966,10 @@ function agendaOpenAutomationSheet(anchor, preselect) {
   const note = document.createElement('input');
   note.type = 'text';
   note.id = 'agsx-note';
+  note.placeholder = 'optional note to the stamped item';
   noteRow.appendChild(note);
-  const noteHint = agendaStartSheetEl('div', 'ags-hint', '');
-  noteRow.appendChild(noteHint);
+  noteRow.appendChild(agendaStartSheetEl('div', 'ags-hint',
+    'optional — recorded with your attribution in the stamped item’s THREAD section'));
   panel.appendChild(noteRow);
 
   // Pre-stamp summary: exactly what the Stamp gesture will seal, park,
@@ -97963,7 +97994,7 @@ function agendaOpenAutomationSheet(anchor, preselect) {
   stampBtn.type = 'button';
   stampBtn.title = 'Seals the definition, parks the item(s), proposes the manifest(s) — approves nothing';
   stampBtn.addEventListener('click', () => agendaAutomationSheetSubmit(
-    { entry: () => entry, cadence, fire, suspend, project, note, configState, error, stampBtn }));
+    { entry: () => entry, cadence, fire, suspend, project, note, paramInputs, configState, error, stampBtn }));
   foot.appendChild(cancel);
   foot.appendChild(stampBtn);
   panel.appendChild(foot);
@@ -98068,7 +98099,23 @@ function agendaOpenAutomationSheet(anchor, preselect) {
         .map((n) => `${n.title || n.id}: ${nodeExecutorLabel(n)}`).join('; ');
       add(`per-node executors are the definition’s pins — ${rows} · project: ${project.value.trim() || 'daemon default'}`);
     }
-    const noteText = agendaStampNoteText(entry, note.value);
+    // Declared parameters: the EXACT substituted line each value will
+    // record — the gesture is never a surprise — and the empty-required
+    // gate mirrored onto the button (convenience; the daemon op is the
+    // wall).
+    let requiredEmpty = false;
+    for (const param of agendaStampDeclaredParams(entry)) {
+      const input = paramInputs.get(param.name);
+      const line = agendaStampParamLine(param, input ? input.value : '');
+      if (line) {
+        add(`record ${param.label || param.name} in the item’s THREAD: ${line}`);
+      } else if (param.required) {
+        requiredEmpty = true;
+        add(`required: fill the ${param.label || param.name} field to stamp`);
+      }
+    }
+    stampBtn.disabled = !entry || requiredEmpty;
+    const noteText = String(note.value || '').trim();
     if (noteText) {
       add(`annotate the stamped ${kind === 'workflow' ? 'hub' : 'item'} with your note: ${noteText}`);
     }
@@ -98087,15 +98134,9 @@ function agendaOpenAutomationSheet(anchor, preselect) {
     suspendRow.hidden = kind !== 'action';
     config.hidden = !kind || kind === 'workflow';
     noteRow.hidden = !kind;
-    // The note input is definition-aware: for a cap-demanding
-    // definition it is the spend-cap field — labeled as such, hinting
-    // the canonical form, canonicalizing a bare amount at submit.
-    const capField = agendaStampCapDemanded(entry);
-    noteLabel.textContent = capField ? 'Spend cap' : 'Note';
-    note.placeholder = capField ? '60' : 'optional note to the stamped item';
-    noteHint.textContent = capField
-      ? 'this definition reads an owner-set cap from the stamped item — type the amount; recorded as the canonical annotation NS CAP: $<amount> in the item’s THREAD section'
-      : 'optional — recorded with your attribution in the stamped item’s THREAD section';
+    // Parameter fields are the daemon's declarations, re-rendered per
+    // selection; the note input stays the generic lane for every kind.
+    renderParamRows();
     stampBtn.disabled = !entry;
     if (entry && kind === 'action') {
       const prefill = (entry.nodes && entry.nodes[0]) || {};
@@ -98207,13 +98248,29 @@ async function agendaAutomationSheetSubmit(form) {
     const everyMs = Number(form.cadence.value);
     if (Number.isFinite(everyMs) && everyMs > 0) overrides.every_ms = everyMs;
   }
-  // The stamp-time note rides the stamp op for every kind: the daemon
-  // records it owner-attributed on the annotation surface the fired
-  // mandates read (a workflow's hub, an action's item). A bare amount
-  // in a cap-demanding definition's field was canonicalized to the
-  // exact `NS CAP: $<amount>` bytes above the wire, never by hand.
-  const noteText = form.note ? agendaStampNoteText(entry, form.note.value) : '';
-  if (noteText) overrides.annotations = [noteText];
+  // Declared parameters + the stamp-time note ride the stamp op's
+  // annotations: the daemon records each line on the annotation surface
+  // the fired mandates read (a workflow's hub, an action's item),
+  // attributed to whoever stamps. A parameter value substitutes into
+  // its declared template client-side — the machine writes the
+  // canonical bytes, never a hand-formatted authority line. The
+  // empty-required check here is convenience only; the daemon refuses a
+  // stamp missing a required parameter either way.
+  const annotations = [];
+  for (const param of agendaStampDeclaredParams(entry)) {
+    const input = form.paramInputs && form.paramInputs.get(param.name);
+    const line = agendaStampParamLine(param, input ? input.value : '');
+    if (line) {
+      annotations.push(line);
+    } else if (param.required) {
+      showError(`Fill the required ${param.label || param.name} field before stamping.`);
+      if (input) input.focus();
+      return;
+    }
+  }
+  const noteText = form.note ? String(form.note.value || '').trim() : '';
+  if (noteText) annotations.push(noteText);
+  if (annotations.length) overrides.annotations = annotations;
   form.stampBtn.disabled = true;
   try {
     // THE stamp gesture — the only place this sheet stamps. One

--- a/static/app.html
+++ b/static/app.html
@@ -39165,7 +39165,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'c690396905cbab70';
+const INTENDANT_APP_BUILD = 'd6da0ead327df05e';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -97749,7 +97749,7 @@ function agendaStampDeclaredParams(entry) {
 }
 
 // The exact annotation line a typed parameter value records: the
-// declared template with its one `<value>` slot substituted verbatim
+// declared line with its one `<value>` slot substituted verbatim
 // (function replacement so `$`-patterns in the value never expand) —
 // the machine writes the canonical bytes, no human hand-formats
 // spend-authority lines like `NS CAP: $<amount>`.
@@ -97926,7 +97926,7 @@ function agendaOpenAutomationSheet(anchor, preselect) {
   // Declared parameters (skills/plugins S2): one labeled input per
   // parameter the selected definition declares in its node config block
   // — required ones marked, the declared hint as the help line. Typed
-  // values substitute into the declared line templates and ride the
+  // values substitute into the declared line shapes and ride the
   // stamp op's annotations beside the generic note; the daemon refuses
   // a stamp missing a required parameter, so the sheet's empty-required
   // gate below is convenience, never the wall.
@@ -97934,6 +97934,11 @@ function agendaOpenAutomationSheet(anchor, preselect) {
   panel.appendChild(paramsBox);
   const paramInputs = new Map(); // parameter name -> its input element
   const renderParamRows = () => {
+    // Re-renders ride selection changes AND the catalog-refresh
+    // callback — carry typed values across by name so a refresh never
+    // eats a half-filled field.
+    const prior = new Map();
+    for (const [name, input] of paramInputs) prior.set(name, input.value);
     paramsBox.textContent = '';
     paramInputs.clear();
     for (const param of agendaStampDeclaredParams(entry)) {
@@ -97945,6 +97950,7 @@ function agendaOpenAutomationSheet(anchor, preselect) {
       const input = document.createElement('input');
       input.type = 'text';
       input.id = `agsx-param-${param.name}`;
+      if (prior.has(param.name)) input.value = prior.get(param.name);
       input.addEventListener('input', renderSummary);
       row.appendChild(input);
       row.appendChild(agendaStartSheetEl('div', 'ags-hint', param.hint
@@ -98252,7 +98258,7 @@ async function agendaAutomationSheetSubmit(form) {
   // annotations: the daemon records each line on the annotation surface
   // the fired mandates read (a workflow's hub, an action's item),
   // attributed to whoever stamps. A parameter value substitutes into
-  // its declared template client-side — the machine writes the
+  // its declared line client-side — the machine writes the
   // canonical bytes, never a hand-formatted authority line. The
   // empty-required check here is convenience only; the daemon refuses a
   // stamp missing a required parameter either way.

--- a/static/app/ui2-agenda.js
+++ b/static/app/ui2-agenda.js
@@ -2275,24 +2275,25 @@ const AGENDA_AUTOMATION_CADENCES = [
   { label: 'Every 30 days', ms: 30 * 24 * 60 * 60 * 1000 },
 ];
 
-// Cap-demanding definitions (the narrative-backfill class): the
-// definition's own text carries the owner-cap annotation convention,
-// so the sheet's note input doubles as the spend-cap lane for it.
-function agendaStampCapDemanded(entry) {
-  return !!(entry && typeof entry.text === 'string' && entry.text.includes('NS CAP: $'));
+// The declared stamp-time parameters of the selected entry (the catalog
+// serves them on the node, skip-if-empty): the sheet renders exactly
+// what the daemon declared — no client-side parameter vocabulary, no
+// prose sniffing. Parameters are action-only in v1, so at most the
+// single node carries them.
+function agendaStampDeclaredParams(entry) {
+  const node = entry && entry.nodes && entry.nodes[0];
+  return (node && Array.isArray(node.parameters)) ? node.parameters : [];
 }
 
-// Spend-authority bytes are exact: a bare amount typed into the cap
-// field canonicalizes to `NS CAP: $<amount>` here, so no human ever
-// hand-formats the line the mandate greps for. Anything else passes
-// through verbatim — an already-canonical line stays untouched, and
-// free text stays an ordinary note (the mandate's near-miss refusal
-// quotes it back kindly instead of parsing amounts out of prose).
-function agendaStampNoteText(entry, raw) {
-  const text = String(raw || '').trim();
-  if (!text || !agendaStampCapDemanded(entry)) return text;
-  const bare = text.startsWith('$') ? text.slice(1).trim() : text;
-  return /^\d+(\.\d+)?$/.test(bare) ? `NS CAP: $${bare}` : text;
+// The exact annotation line a typed parameter value records: the
+// declared template with its one `<value>` slot substituted verbatim
+// (function replacement so `$`-patterns in the value never expand) —
+// the machine writes the canonical bytes, no human hand-formats
+// spend-authority lines like `NS CAP: $<amount>`.
+function agendaStampParamLine(param, raw) {
+  const value = String(raw || '').trim();
+  if (!value) return '';
+  return String(param.line || '').replace('<value>', () => value);
 }
 
 // `preselect` (optional) names a definition to open on — the Plugins &
@@ -2459,13 +2460,42 @@ function agendaOpenAutomationSheet(anchor, preselect) {
       });
   }
 
+  // Declared parameters (skills/plugins S2): one labeled input per
+  // parameter the selected definition declares in its node config block
+  // — required ones marked, the declared hint as the help line. Typed
+  // values substitute into the declared line templates and ride the
+  // stamp op's annotations beside the generic note; the daemon refuses
+  // a stamp missing a required parameter, so the sheet's empty-required
+  // gate below is convenience, never the wall.
+  const paramsBox = agendaStartSheetEl('div', 'agsx-params');
+  panel.appendChild(paramsBox);
+  const paramInputs = new Map(); // parameter name -> its input element
+  const renderParamRows = () => {
+    paramsBox.textContent = '';
+    paramInputs.clear();
+    for (const param of agendaStampDeclaredParams(entry)) {
+      const row = agendaStartSheetEl('div', 'ags-config-row');
+      const label = agendaStartSheetEl('label', 'ags-label',
+        `${param.label || param.name}${param.required ? ' (required)' : ''}`);
+      label.setAttribute('for', `agsx-param-${param.name}`);
+      row.appendChild(label);
+      const input = document.createElement('input');
+      input.type = 'text';
+      input.id = `agsx-param-${param.name}`;
+      input.addEventListener('input', renderSummary);
+      row.appendChild(input);
+      row.appendChild(agendaStartSheetEl('div', 'ags-hint', param.hint
+        || `recorded as ${param.line} in the stamped item’s THREAD section`));
+      paramsBox.appendChild(row);
+      paramInputs.set(param.name, input);
+    }
+  };
+
   // Note to the stamped item: one optional owner note recorded AT PARK
   // on the annotation surface the fired mandates read (a workflow's
-  // hub, an action's item), attributed to whoever stamps. When the
-  // selected definition demands a spend cap, this input IS the cap
-  // lane — a bare amount canonicalizes to `NS CAP: $<amount>` at
-  // submit (agendaStampNoteText), so nobody hand-formats authority
-  // bytes; renderSelection relabels the row per definition.
+  // hub, an action's item), attributed to whoever stamps. Always the
+  // generic lane — a definition that wants a formatted value declares a
+  // parameter for it, rendered above.
   const noteRow = agendaStartSheetEl('div', 'ags-config-row');
   const noteLabel = agendaStartSheetEl('label', 'ags-label', 'Note');
   noteLabel.setAttribute('for', 'agsx-note');
@@ -2473,9 +2503,10 @@ function agendaOpenAutomationSheet(anchor, preselect) {
   const note = document.createElement('input');
   note.type = 'text';
   note.id = 'agsx-note';
+  note.placeholder = 'optional note to the stamped item';
   noteRow.appendChild(note);
-  const noteHint = agendaStartSheetEl('div', 'ags-hint', '');
-  noteRow.appendChild(noteHint);
+  noteRow.appendChild(agendaStartSheetEl('div', 'ags-hint',
+    'optional — recorded with your attribution in the stamped item’s THREAD section'));
   panel.appendChild(noteRow);
 
   // Pre-stamp summary: exactly what the Stamp gesture will seal, park,
@@ -2500,7 +2531,7 @@ function agendaOpenAutomationSheet(anchor, preselect) {
   stampBtn.type = 'button';
   stampBtn.title = 'Seals the definition, parks the item(s), proposes the manifest(s) — approves nothing';
   stampBtn.addEventListener('click', () => agendaAutomationSheetSubmit(
-    { entry: () => entry, cadence, fire, suspend, project, note, configState, error, stampBtn }));
+    { entry: () => entry, cadence, fire, suspend, project, note, paramInputs, configState, error, stampBtn }));
   foot.appendChild(cancel);
   foot.appendChild(stampBtn);
   panel.appendChild(foot);
@@ -2605,7 +2636,23 @@ function agendaOpenAutomationSheet(anchor, preselect) {
         .map((n) => `${n.title || n.id}: ${nodeExecutorLabel(n)}`).join('; ');
       add(`per-node executors are the definition’s pins — ${rows} · project: ${project.value.trim() || 'daemon default'}`);
     }
-    const noteText = agendaStampNoteText(entry, note.value);
+    // Declared parameters: the EXACT substituted line each value will
+    // record — the gesture is never a surprise — and the empty-required
+    // gate mirrored onto the button (convenience; the daemon op is the
+    // wall).
+    let requiredEmpty = false;
+    for (const param of agendaStampDeclaredParams(entry)) {
+      const input = paramInputs.get(param.name);
+      const line = agendaStampParamLine(param, input ? input.value : '');
+      if (line) {
+        add(`record ${param.label || param.name} in the item’s THREAD: ${line}`);
+      } else if (param.required) {
+        requiredEmpty = true;
+        add(`required: fill the ${param.label || param.name} field to stamp`);
+      }
+    }
+    stampBtn.disabled = !entry || requiredEmpty;
+    const noteText = String(note.value || '').trim();
     if (noteText) {
       add(`annotate the stamped ${kind === 'workflow' ? 'hub' : 'item'} with your note: ${noteText}`);
     }
@@ -2624,15 +2671,9 @@ function agendaOpenAutomationSheet(anchor, preselect) {
     suspendRow.hidden = kind !== 'action';
     config.hidden = !kind || kind === 'workflow';
     noteRow.hidden = !kind;
-    // The note input is definition-aware: for a cap-demanding
-    // definition it is the spend-cap field — labeled as such, hinting
-    // the canonical form, canonicalizing a bare amount at submit.
-    const capField = agendaStampCapDemanded(entry);
-    noteLabel.textContent = capField ? 'Spend cap' : 'Note';
-    note.placeholder = capField ? '60' : 'optional note to the stamped item';
-    noteHint.textContent = capField
-      ? 'this definition reads an owner-set cap from the stamped item — type the amount; recorded as the canonical annotation NS CAP: $<amount> in the item’s THREAD section'
-      : 'optional — recorded with your attribution in the stamped item’s THREAD section';
+    // Parameter fields are the daemon's declarations, re-rendered per
+    // selection; the note input stays the generic lane for every kind.
+    renderParamRows();
     stampBtn.disabled = !entry;
     if (entry && kind === 'action') {
       const prefill = (entry.nodes && entry.nodes[0]) || {};
@@ -2744,13 +2785,29 @@ async function agendaAutomationSheetSubmit(form) {
     const everyMs = Number(form.cadence.value);
     if (Number.isFinite(everyMs) && everyMs > 0) overrides.every_ms = everyMs;
   }
-  // The stamp-time note rides the stamp op for every kind: the daemon
-  // records it owner-attributed on the annotation surface the fired
-  // mandates read (a workflow's hub, an action's item). A bare amount
-  // in a cap-demanding definition's field was canonicalized to the
-  // exact `NS CAP: $<amount>` bytes above the wire, never by hand.
-  const noteText = form.note ? agendaStampNoteText(entry, form.note.value) : '';
-  if (noteText) overrides.annotations = [noteText];
+  // Declared parameters + the stamp-time note ride the stamp op's
+  // annotations: the daemon records each line on the annotation surface
+  // the fired mandates read (a workflow's hub, an action's item),
+  // attributed to whoever stamps. A parameter value substitutes into
+  // its declared template client-side — the machine writes the
+  // canonical bytes, never a hand-formatted authority line. The
+  // empty-required check here is convenience only; the daemon refuses a
+  // stamp missing a required parameter either way.
+  const annotations = [];
+  for (const param of agendaStampDeclaredParams(entry)) {
+    const input = form.paramInputs && form.paramInputs.get(param.name);
+    const line = agendaStampParamLine(param, input ? input.value : '');
+    if (line) {
+      annotations.push(line);
+    } else if (param.required) {
+      showError(`Fill the required ${param.label || param.name} field before stamping.`);
+      if (input) input.focus();
+      return;
+    }
+  }
+  const noteText = form.note ? String(form.note.value || '').trim() : '';
+  if (noteText) annotations.push(noteText);
+  if (annotations.length) overrides.annotations = annotations;
   form.stampBtn.disabled = true;
   try {
     // THE stamp gesture — the only place this sheet stamps. One

--- a/static/app/ui2-agenda.js
+++ b/static/app/ui2-agenda.js
@@ -2286,7 +2286,7 @@ function agendaStampDeclaredParams(entry) {
 }
 
 // The exact annotation line a typed parameter value records: the
-// declared template with its one `<value>` slot substituted verbatim
+// declared line with its one `<value>` slot substituted verbatim
 // (function replacement so `$`-patterns in the value never expand) —
 // the machine writes the canonical bytes, no human hand-formats
 // spend-authority lines like `NS CAP: $<amount>`.
@@ -2463,7 +2463,7 @@ function agendaOpenAutomationSheet(anchor, preselect) {
   // Declared parameters (skills/plugins S2): one labeled input per
   // parameter the selected definition declares in its node config block
   // — required ones marked, the declared hint as the help line. Typed
-  // values substitute into the declared line templates and ride the
+  // values substitute into the declared line shapes and ride the
   // stamp op's annotations beside the generic note; the daemon refuses
   // a stamp missing a required parameter, so the sheet's empty-required
   // gate below is convenience, never the wall.
@@ -2471,6 +2471,11 @@ function agendaOpenAutomationSheet(anchor, preselect) {
   panel.appendChild(paramsBox);
   const paramInputs = new Map(); // parameter name -> its input element
   const renderParamRows = () => {
+    // Re-renders ride selection changes AND the catalog-refresh
+    // callback — carry typed values across by name so a refresh never
+    // eats a half-filled field.
+    const prior = new Map();
+    for (const [name, input] of paramInputs) prior.set(name, input.value);
     paramsBox.textContent = '';
     paramInputs.clear();
     for (const param of agendaStampDeclaredParams(entry)) {
@@ -2482,6 +2487,7 @@ function agendaOpenAutomationSheet(anchor, preselect) {
       const input = document.createElement('input');
       input.type = 'text';
       input.id = `agsx-param-${param.name}`;
+      if (prior.has(param.name)) input.value = prior.get(param.name);
       input.addEventListener('input', renderSummary);
       row.appendChild(input);
       row.appendChild(agendaStartSheetEl('div', 'ags-hint', param.hint
@@ -2789,7 +2795,7 @@ async function agendaAutomationSheetSubmit(form) {
   // annotations: the daemon records each line on the annotation surface
   // the fired mandates read (a workflow's hub, an action's item),
   // attributed to whoever stamps. A parameter value substitutes into
-  // its declared template client-side — the machine writes the
+  // its declared line client-side — the machine writes the
   // canonical bytes, never a hand-formatted authority line. The
   // empty-required check here is convenience only; the daemon refuses a
   // stamp missing a required parameter either way.


### PR DESCRIPTION
[parameters.<name>] sub-tables in action node config blocks — label,
required (default false), hint, kind="annotation", and a line template
carrying <value> exactly once — parsed with deny-unknown rigor: slug
names, at most 8 per definition, label <=80 chars, line <=240 chars,
unknown kinds refused by name, workflow nodes refuse the vocabulary
(the R3 ruled-absence pattern), and templates one line could satisfy
simultaneously refuse at validation so matching stays deterministic.

Served on CatalogNode.parameters skip-if-empty. The Automate sheet
renders one labeled input per declared parameter (required marked,
declared hint as the help line), substitutes the typed value into the
line template client-side, shows the exact substituted line in the
pre-stamp summary, gates Stamp on empty required fields (convenience),
and sends the lines through the stamp op's annotations beside the
generic note — v0's prose-sniffing cap heuristic is replaced by the
declared data.

apply_stamp is the wall: a required parameter is satisfied only by an
arriving stamp-time line exactly matching its template with <value>
replaced by a non-empty segment (the raw template satisfies nothing);
the refusal names the field, the sheet, and the THREAD/ctl remedy; and
lines matching no declared template pass through as ordinary notes,
never refused. Recorded values carry the stamp's gate-resolved
attribution (pinned by test).

narrative-backfill declares the required [parameters.cap] as a
config-block-only edit — orientation/goal byte-pins and the law
fragments stay green; the docs stamp-lane prose co-updates.

Sealed basis: the ruled skills/plugins intake (sha d56f4ebf) §4 + the
RULING's S2 checklist + refinements R1/R2; v0 substrate = PR #795.
