### PR TITLE
Agenda: owed completions join the needs-you rail; blocked chips name their remedy

### DIFF
--- a/docs/src/agenda-and-memory.md
+++ b/docs/src/agenda-and-memory.md
@@ -217,19 +217,42 @@ ruling below) — never stored in the ledger, and never a notification
 trigger: the reminder lane remains the only thing that fires. The chip
 explains itself at every depth: its tip and its tap name each gate —
 every uncleared blocker, every unsatisfied prerequisite by title with
-live status — and each named prerequisite is a door to its own card.
-A prerequisite that is still open but whose scheduled session's last
-run **completed with a self-reported `achieved`** renders as the
-actionable wait it is — "delivered · awaiting Complete" (sky, the
+live status ("waiting on: *title*") and, where the release is the
+target's completion, the named gesture ("complete it to proceed") —
+and each named prerequisite is a door to its own card. A prerequisite
+the daemon serves as **owed completion** (below) renders as the
+actionable wait it is — "finished and awaiting Complete" (sky, the
 self-report hue) — distinct from genuinely in-flight work; calm depth
 folds only the in-flight waits (a chip tap unfolds them), while stated
-blockers and delivered waits always render. All of it stays advisory:
+blockers and finished waits always render. All of it stays advisory:
 blocked gates neither approval nor firing. Beside the flag, both
 serving grains carry the **`blocked_on` decoration**: the named causes
 (each uncleared blocker's criterion; each unsatisfied prerequisite's
-live title and status), stamped at the serving seam beside the effects'
-fireability verdicts like `next_fire_ms`, never folded from ops — the
-served truth the approve-surface confirms below derive from.
+live title and status, plus `target_completable` when the open target
+itself only awaits the owner's tap), stamped at the serving seam beside
+the effects' fireability verdicts like `next_fire_ms`, never folded
+from ops — the served truth the approve-surface confirms below derive
+from.
+
+**Owed completions surface on the needs-you rail.** The complement of
+blocked (owner finding #10): a card whose work fully finished but whose
+Complete tap never landed used to sit invisible — approvals and
+questions surfaced, finished-awaiting-Complete never did — while its
+`relies_on` dependents stayed silently blocked. The daemon now serves
+one **`completable`** classification (summary flag + full-grain
+decoration, `item_owed_completion` at the serving seam): the item is
+open and not a question, some live effect's latest occurrence reached
+terminal `completed` with a self-reported `achieved` (unattested or
+partial never counts), every effect is settled (nothing pending review,
+nothing standing — a recurrence or trigger manifest is a live
+automation, never "finished" — nothing armed or in flight), no open
+question references it over the `relates_to` union (the steward-gate
+shape), and nothing blocks it. Those cards join the dashboard's
+needs-you lens as their own **Complete** class ("finished — tap
+Complete"), count into the lens badge, and mark dependents' blocked
+chips — one served classification behind all three, never a client
+re-derivation. Visibility only, by scope: the Complete tap stays the
+owner's; no machinery completes on the verdict.
 
 **Blocked never gates approval — advisory plus confirm.** Blocked-state
 is bookkeeping that lags reality in both directions (a finished

--- a/src/bin/caller/agenda/ask.rs
+++ b/src/bin/caller/agenda/ask.rs
@@ -351,6 +351,7 @@ mod tests {
             deferred_until: None,
             watched_by: None,
             blocked_on: None,
+            completable: false,
         }
     }
 

--- a/src/bin/caller/agenda/handle.rs
+++ b/src/bin/caller/agenda/handle.rs
@@ -1129,20 +1129,28 @@ impl AgendaHandle {
         // confirm from this, never from a client-side join. Advisory by
         // doctrine: it names, it never gates (the fireability stamp is
         // what withholds Approve; this one only makes the confirm
-        // honest). Compute-then-stamp like the planner views: the
-        // universe borrow ends before the mutable pass.
-        let blocked_views: Vec<Option<Vec<super::types::AgendaBlockedOn>>> = {
+        // honest). The same pass stamps the OWED-COMPLETION verdict
+        // (`completable` — [`super::summary::item_owed_completion`]),
+        // so event-lane copies carry the needs-you rail's Complete
+        // classification as fresh as their blocked causes. Compute-
+        // then-stamp like the planner views: the universe borrow ends
+        // before the mutable pass.
+        let blocked_views: Vec<(Option<Vec<super::types::AgendaBlockedOn>>, bool)> = {
             let universe: &[AgendaItem] = context.unwrap_or(items);
             items
                 .iter()
                 .map(|item| {
                     let causes = super::summary::blocked_on(universe, item);
-                    (!causes.is_empty()).then_some(causes)
+                    (
+                        (!causes.is_empty()).then_some(causes),
+                        super::summary::item_owed_completion(universe, item),
+                    )
                 })
                 .collect()
         };
-        for (item, causes) in items.iter_mut().zip(blocked_views) {
+        for (item, (causes, completable)) in items.iter_mut().zip(blocked_views) {
             item.blocked_on = causes;
+            item.completable = completable;
         }
     }
 

--- a/src/bin/caller/agenda/reminders.rs
+++ b/src/bin/caller/agenda/reminders.rs
@@ -2116,6 +2116,7 @@ mod tests {
             deferred_until: None,
             watched_by: None,
             blocked_on: None,
+            completable: false,
         }
     }
 

--- a/src/bin/caller/agenda/summary.rs
+++ b/src/bin/caller/agenda/summary.rs
@@ -187,6 +187,11 @@ pub(crate) struct AgendaItemSummary {
     /// Cross-item serving-seam flag: the un-triaged frontier (the
     /// triage mandate's declared scope; see [`item_in_frontier`]).
     pub(crate) frontier: bool,
+    /// Cross-item serving-seam flag: OWED COMPLETION
+    /// ([`item_owed_completion`]) — the work is fully finished and only
+    /// the owner's Complete tap remains. Drives the needs-you rail's
+    /// Complete class and its badge count; the SPA never re-derives it.
+    pub(crate) completable: bool,
     /// The triage mandate's rank/note convention, derived once here
     /// (newest `triage`-source annotation; "rank N" names the rank).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -526,6 +531,7 @@ fn summarize_one(all: &[AgendaItem], item: &AgendaItem, watermark: u64) -> Agend
         blocked: !blocked_causes.is_empty(),
         blocked_on: (!blocked_causes.is_empty()).then_some(blocked_causes),
         frontier: item_in_frontier(item, watermark),
+        completable: item_owed_completion(all, item),
         triage: triage_info(item),
         children: None,
     }
@@ -591,10 +597,27 @@ pub(crate) fn item_is_blocked(all: &[AgendaItem], item: &AgendaItem) -> bool {
 /// name, they never gate). Empty exactly when the item is not blocked.
 /// Blocker entries name the uncleared criterion; dependency entries name
 /// the target's live title and status (`open`, `retired` — which does
-/// not satisfy, `missing` — absent from the fold, named by id).
+/// not satisfy, `missing` — absent from the fold, named by id) plus the
+/// owed-completion marker (`target_completable`) when the open target
+/// itself only awaits the owner's Complete tap — the remedy the blocked
+/// chip names.
 pub(crate) fn blocked_on(
     all: &[AgendaItem],
     item: &AgendaItem,
+) -> Vec<super::types::AgendaBlockedOn> {
+    blocked_causes(all, item, true)
+}
+
+/// The shared core behind [`blocked_on`] and the owed-completion
+/// predicate's not-blocked clause. `mark_completable` stamps each open
+/// dependency target's [`item_owed_completion`] verdict onto the cause;
+/// the predicate itself passes `false`, which is what keeps the mutual
+/// derivation finite (a dependency cycle would otherwise recurse: cause
+/// → target completable? → target blocked? → target's causes → …).
+fn blocked_causes(
+    all: &[AgendaItem],
+    item: &AgendaItem,
+    mark_completable: bool,
 ) -> Vec<super::types::AgendaBlockedOn> {
     if item.status != AgendaStatus::Open {
         return Vec::new();
@@ -607,16 +630,21 @@ pub(crate) fn blocked_on(
             target_id: None,
             target_status: None,
             blocker_id: Some(blocker.blocker_id.clone()),
+            target_completable: false,
         });
     }
     for edge in &item.relies_on {
         let target = all.iter().find(|candidate| candidate.id == edge.target_id);
-        let (title, status) = match target {
-            None => (edge.target_id.clone(), "missing"),
+        let (title, status, target_completable) = match target {
+            None => (edge.target_id.clone(), "missing", false),
             Some(target) => match target.status {
                 AgendaStatus::Done => continue,
-                AgendaStatus::Retired => (target.title.clone(), "retired"),
-                AgendaStatus::Open => (target.title.clone(), "open"),
+                AgendaStatus::Retired => (target.title.clone(), "retired", false),
+                AgendaStatus::Open => (
+                    target.title.clone(),
+                    "open",
+                    mark_completable && item_owed_completion(all, target),
+                ),
             },
         };
         causes.push(super::types::AgendaBlockedOn {
@@ -625,9 +653,90 @@ pub(crate) fn blocked_on(
             target_id: Some(edge.target_id.clone()),
             target_status: Some(status.to_string()),
             blocker_id: None,
+            target_completable,
         });
     }
     causes
+}
+
+/// OWED COMPLETION — the one daemon-side classification behind the
+/// needs-you rail's "finished — tap Complete" class, its badge count,
+/// and the blocked chip's "finished and awaiting Complete" target
+/// state (owner finding #10 family). True exactly when the item's work
+/// is fully finished and only the owner's Complete tap remains, derived
+/// from served facts alone:
+///
+/// - the item is OPEN and not a question (a question's owner gesture is
+///   Answer — it already has its own rail class);
+/// - some live (non-withdrawn) effect's latest occurrence ran to
+///   terminal `completed` AND the fired session self-reported
+///   `achieved` (unattested or partial never counts as finished — the
+///   Track AO absence law);
+/// - every effect is SETTLED: withdrawn husks aside, each is an
+///   approved ONE-SHOT whose firing reached terminal `completed` —
+///   nothing pending review (a live unapproved revision is an Approve
+///   decision, not a finished card), nothing standing (a recurrence or
+///   trigger manifest keeps watch; its item is a live automation, never
+///   "finished"), nothing still armed or in flight;
+/// - no OPEN question references the item over the undirected
+///   `relates_to` union (the steward-gate shape: a pending gate
+///   question means the verdict — and possibly a fix — is still owed;
+///   display-only, adjacency still evaluates/blocks/fires nothing);
+/// - nothing blocks the item itself (an uncleared blocker or unmet
+///   prerequisite contradicts "fully finished" — the blocked chip owns
+///   that story).
+///
+/// VISIBILITY ONLY: no machinery completes on this verdict — the tap
+/// stays the owner's. Effects-less items never qualify: the only
+/// terminal-success evidence in served data is an attested occurrence.
+pub(crate) fn item_owed_completion(all: &[AgendaItem], item: &AgendaItem) -> bool {
+    if item.status != AgendaStatus::Open || item.kind == AgendaKind::Question {
+        return false;
+    }
+    let achieved = item.effects.iter().any(|effect| {
+        effect.withdrawn.is_none()
+            && effect.last_run.as_ref().is_some_and(|run| {
+                run.state == "completed"
+                    && run.attestation.as_ref().is_some_and(|att| {
+                        att.outcome == super::types::AttestationOutcome::Achieved
+                    })
+            })
+    });
+    if !achieved {
+        return false;
+    }
+    let all_settled = item.effects.iter().all(|effect| {
+        if effect.withdrawn.is_some() {
+            return true; // fired-history husk — never pending, never planned
+        }
+        effect.approval.is_some()
+            && effect.manifest.recurrence.is_none()
+            && effect.manifest.trigger.is_none()
+            && effect
+                .last_run
+                .as_ref()
+                .is_some_and(|run| run.state == "completed")
+    });
+    if !all_settled {
+        return false;
+    }
+    let gated = all.iter().any(|other| {
+        other.id != item.id
+            && other.kind == AgendaKind::Question
+            && other.status == AgendaStatus::Open
+            && (other
+                .relates_to
+                .iter()
+                .any(|edge| edge.target_id == item.id)
+                || item
+                    .relates_to
+                    .iter()
+                    .any(|edge| edge.target_id == other.id))
+    });
+    if gated {
+        return false;
+    }
+    blocked_causes(all, item, false).is_empty()
 }
 
 /// The triage rank/note convention (the mandate's declared "rank N"
@@ -1135,6 +1244,7 @@ mod tests {
             deferred_until: None,
             watched_by: None,
             blocked_on: None,
+            completable: false,
         }
     }
 
@@ -1216,5 +1326,306 @@ mod tests {
             blocked_on(&all, &done_item).is_empty(),
             "non-open items never derive blocked causes"
         );
+    }
+
+    /// One settled ONE-SHOT effect whose firing completed and
+    /// self-reported achieved — the qualifying shape behind
+    /// [`item_owed_completion`].
+    fn achieved_effect() -> super::super::types::AgendaEffect {
+        super::super::types::AgendaEffect {
+            effect_id: "ef-1".into(),
+            manifest: super::super::types::SessionManifest {
+                goal: "do the thing".into(),
+                fire_at_ms: 1,
+                orchestrate: false,
+                interactive: false,
+                project_root: None,
+                agent_config: None,
+                recurrence: None,
+                trigger: None,
+                binding_refs: Vec::new(),
+            },
+            digest: "d1".into(),
+            proposed_ms: 1,
+            proposed_principal: None,
+            proposed_session_id: None,
+            proposed_kind: None,
+            approval: Some(super::super::types::AgendaApproval {
+                digest: "d1".into(),
+                at_ms: 2,
+                principal: None,
+                kind: None,
+            }),
+            withdrawn: None,
+            last_run: Some(super::super::types::AgendaRun {
+                occurrence_id: "occ-1".into(),
+                state: "completed".into(),
+                session_id: Some("sess-1".into()),
+                at_ms: 3,
+                note: None,
+                attestation: Some(super::super::types::AgendaAttestation {
+                    outcome: super::super::types::AttestationOutcome::Achieved,
+                    note: None,
+                    refs: Vec::new(),
+                    at_ms: 3,
+                    session_id: Some("sess-1".into()),
+                }),
+            }),
+            consecutive_failures: 0,
+            requested: Vec::new(),
+            next_fire_ms: None,
+            last_run_attempt: None,
+            fireability_refusal: None,
+        }
+    }
+
+    fn rel(target_id: &str) -> super::super::types::AgendaRelation {
+        super::super::types::AgendaRelation {
+            target_id: target_id.into(),
+            link_kind: None,
+            added_ms: 1,
+            principal: None,
+            session_id: None,
+            kind: None,
+            source: None,
+        }
+    }
+
+    /// The OWED-COMPLETION predicate (owner finding #10 family): the
+    /// one daemon-side classification behind the needs-you rail's
+    /// Complete class, its badge count, and the blocked chip's
+    /// finished-target state. The qualifying shape passes; every named
+    /// disqualifier — non-open, question kind, no effects, unattested
+    /// or partial outcomes, a pending approvable revision, a standing
+    /// recurrence/trigger manifest, an in-flight run, a withdrawn-only
+    /// history, an open gate question on the relates_to union (either
+    /// side), an uncleared blocker, an unmet prerequisite — flips it
+    /// off. The served summary flag IS the predicate.
+    #[test]
+    fn owed_completion_predicate_names_its_disqualifiers() {
+        let mut finished = bare("01FINISHED", "seat card", AgendaStatus::Open);
+        finished.effects = vec![achieved_effect()];
+        let all = vec![finished.clone()];
+        assert!(
+            item_owed_completion(&all, &finished),
+            "open task + settled achieved one-shot = owed completion"
+        );
+        let summary = &summarize(&all, &all)[0];
+        assert!(
+            summary.completable,
+            "the served summary flag IS the predicate"
+        );
+
+        // Lifecycle and kind disqualifiers.
+        let mut done = finished.clone();
+        done.status = AgendaStatus::Done;
+        assert!(!item_owed_completion(&all, &done), "done needs no tap");
+        let mut question = finished.clone();
+        question.kind = AgendaKind::Question;
+        assert!(
+            !item_owed_completion(&all, &question),
+            "a question's owner gesture is Answer, not Complete"
+        );
+        let mut effectless = finished.clone();
+        effectless.effects = Vec::new();
+        assert!(
+            !item_owed_completion(&all, &effectless),
+            "no occurrence evidence — never classified finished"
+        );
+
+        // Run-outcome disqualifiers (the Track AO absence law).
+        let mut unattested = finished.clone();
+        unattested.effects[0].last_run.as_mut().unwrap().attestation = None;
+        assert!(
+            !item_owed_completion(&all, &unattested),
+            "unattested is never synthesized into achieved"
+        );
+        let mut partial = finished.clone();
+        partial.effects[0]
+            .last_run
+            .as_mut()
+            .unwrap()
+            .attestation
+            .as_mut()
+            .unwrap()
+            .outcome = super::super::types::AttestationOutcome::Partial;
+        assert!(!item_owed_completion(&all, &partial), "partial is not done");
+        let mut running = finished.clone();
+        running.effects[0].last_run.as_mut().unwrap().state = "started".into();
+        assert!(
+            !item_owed_completion(&all, &running),
+            "an in-flight run is not finished"
+        );
+
+        // Effect-shape disqualifiers.
+        let mut pending = finished.clone();
+        pending.effects[0].approval = None;
+        assert!(
+            !item_owed_completion(&all, &pending),
+            "a pending approvable revision is an Approve decision, not a finished card"
+        );
+        let mut standing = finished.clone();
+        standing.effects[0].manifest.recurrence = Some(super::super::types::RecurrenceSpec {
+            every_ms: 86_400_000,
+            until_ms: None,
+            max_occurrences: None,
+            suspend_after_failures: None,
+        });
+        assert!(
+            !item_owed_completion(&all, &standing),
+            "a standing series is a live automation, never finished"
+        );
+        let mut triggered = finished.clone();
+        triggered.effects[0].manifest.trigger = Some(super::super::types::TriggerSpec::OnUnblock);
+        assert!(
+            !item_owed_completion(&all, &triggered),
+            "a trigger manifest keeps watch — not finished"
+        );
+        let mut husk_only = finished.clone();
+        husk_only.effects[0].withdrawn = Some(super::super::types::AgendaWithdrawal {
+            at_ms: 9,
+            principal: None,
+            session_id: None,
+            kind: None,
+            reason: None,
+        });
+        assert!(
+            !item_owed_completion(&all, &husk_only),
+            "a withdrawn husk's history is not live finished work"
+        );
+
+        // Gate questions on the undirected relates_to union.
+        let mut gate = bare("01GATE", "Gate: seat verification", AgendaStatus::Open);
+        gate.kind = AgendaKind::Question;
+        gate.relates_to = vec![rel("01FINISHED")];
+        let gated = vec![finished.clone(), gate.clone()];
+        assert!(
+            !item_owed_completion(&gated, &finished),
+            "an open gate question referencing the item keeps it out"
+        );
+        let mut ruled = gate.clone();
+        ruled.status = AgendaStatus::Done;
+        let ruled_all = vec![finished.clone(), ruled];
+        assert!(
+            item_owed_completion(&ruled_all, &finished),
+            "an answered gate releases the classification"
+        );
+        let mut pointing = finished.clone();
+        pointing.relates_to = vec![rel("01GATE2")];
+        let mut gate2 = bare("01GATE2", "Gate: other side", AgendaStatus::Open);
+        gate2.kind = AgendaKind::Question;
+        let gated2 = vec![pointing.clone(), gate2];
+        assert!(
+            !item_owed_completion(&gated2, &pointing),
+            "the union covers edges stored on the item's side too"
+        );
+
+        // Blocked contradicts finished.
+        let mut blocked_item = finished.clone();
+        blocked_item.blockers = vec![super::super::types::AgendaBlocker {
+            blocker_id: "bk-1".into(),
+            criterion: "owner sign-off".into(),
+            set_ms: 1,
+            principal: None,
+            session_id: None,
+            kind: None,
+            source: None,
+            cleared: None,
+        }];
+        assert!(
+            !item_owed_completion(&all, &blocked_item),
+            "an uncleared blocker contradicts fully-finished"
+        );
+        let mut dependent_shape = finished.clone();
+        dependent_shape.relies_on = vec![dep("01PREREQ")];
+        let prereq = bare("01PREREQ", "prerequisite", AgendaStatus::Open);
+        let dep_all = vec![dependent_shape.clone(), prereq];
+        assert!(
+            !item_owed_completion(&dep_all, &dependent_shape),
+            "an unmet prerequisite contradicts fully-finished"
+        );
+    }
+
+    /// The blocked chip's remedy state ([b] of the finding): a
+    /// dependent's `blocked_on` cause carries `target_completable`
+    /// exactly when the open target satisfies [`item_owed_completion`]
+    /// — one classification, stamped at the serving seam. A dependency
+    /// cycle stays finite: the predicate's own not-blocked clause never
+    /// re-stamps.
+    #[test]
+    fn blocked_on_marks_completable_targets() {
+        let mut target = bare("01TARGET", "finished prerequisite", AgendaStatus::Open);
+        target.effects = vec![achieved_effect()];
+        let plain = bare("01PLAIN", "still open prerequisite", AgendaStatus::Open);
+        let mut dependent = bare("01DEP", "dependent", AgendaStatus::Open);
+        dependent.relies_on = vec![dep("01TARGET"), dep("01PLAIN")];
+        let all = vec![target, plain, dependent.clone()];
+
+        let causes = blocked_on(&all, &dependent);
+        assert_eq!(causes.len(), 2);
+        assert_eq!(causes[0].target_id.as_deref(), Some("01TARGET"));
+        assert!(
+            causes[0].target_completable,
+            "a finished-awaiting-Complete target is marked on the cause"
+        );
+        assert_eq!(causes[1].target_id.as_deref(), Some("01PLAIN"));
+        assert!(!causes[1].target_completable);
+        let wire = serde_json::to_value(&causes).unwrap();
+        assert_eq!(wire[0]["target_completable"], true);
+        assert!(
+            wire[1].get("target_completable").is_none(),
+            "absent-on-the-wire when false (additive field)"
+        );
+
+        // Cycle safety: mutually dependent achieved items derive without
+        // recursion and neither reads completable (both stay blocked).
+        let mut a = bare("01CYCA", "a", AgendaStatus::Open);
+        a.effects = vec![achieved_effect()];
+        a.relies_on = vec![dep("01CYCB")];
+        let mut b = bare("01CYCB", "b", AgendaStatus::Open);
+        b.effects = vec![achieved_effect()];
+        b.relies_on = vec![dep("01CYCA")];
+        let cyc = vec![a.clone(), b];
+        let causes = blocked_on(&cyc, &a);
+        assert_eq!(causes.len(), 1);
+        assert!(
+            !causes[0].target_completable,
+            "a blocked target is not owed completion"
+        );
+        assert!(!item_owed_completion(&cyc, &a));
+    }
+
+    /// Rail-class parity (derive-don't-mirror, the awaiting-pickup
+    /// pattern): the dashboard's Complete class, its badge count, the
+    /// card chip, the blocked-row remedy copy, and the dependents
+    /// live-repaint wiring all render from the SERVED classification —
+    /// pinned against the built SPA so a vocabulary change that forgets
+    /// the frontend fails here instead of shipping as drift.
+    #[test]
+    fn owed_completion_surfaces_are_pinned_in_app_html() {
+        let app = include_str!("../../../../static/app.html");
+        for marker in [
+            // The Now-lens class + badge derive from the served flag.
+            ".filter((x) => x.completable === true)",
+            "label: 'Complete',",
+            "if (x.completable === true) needs.add(x.id);",
+            // The card chip names the finding's gesture.
+            "'finished — tap Complete'",
+            // The blocked chip: remedy copy + served target state.
+            "— complete it to proceed",
+            "'finished and awaiting Complete'",
+            "'finished · awaiting Complete'",
+            "served.target_completable === true",
+            // The [c] dependents repaint lane is wired into the event
+            // path, and adoption reads the served decoration fresh.
+            "agendaDependentsRepull(prior, row);",
+            "function agendaDependentsRepull",
+            "completable: full.completable === true,",
+        ] {
+            assert!(
+                app.contains(marker),
+                "app.html lost the owed-completion marker {marker:?}"
+            );
+        }
     }
 }

--- a/src/bin/caller/agenda/types.rs
+++ b/src/bin/caller/agenda/types.rs
@@ -817,6 +817,21 @@ pub struct AgendaItem {
     /// in the fold product, never folded from ops, never stored.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) blocked_on: Option<Vec<AgendaBlockedOn>>,
+    /// Display-only serving-seam decoration (the `next_fire_ms`
+    /// pattern): the OWED-COMPLETION classification
+    /// ([`super::summary::item_owed_completion`]) — this open item's
+    /// work is fully finished (a one-shot effect ran to terminal
+    /// completion and the fired session self-reported achieved, nothing
+    /// is pending review or standing watch, no open question references
+    /// it, nothing blocks it) and only the owner's Complete tap
+    /// remains. Drives the needs-you rail's Complete class and its
+    /// badge count — one daemon-side classification, derived everywhere
+    /// else. VISIBILITY ONLY by scope: no machinery completes on it —
+    /// the tap stays the owner's. Absent-on-the-wire when false; always
+    /// `false` in the fold product, never folded from ops, never
+    /// stored.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub(crate) completable: bool,
 }
 
 /// The automation claiming an open item (the `watched_by` decoration):
@@ -866,6 +881,15 @@ pub struct AgendaBlockedOn {
     /// blocker lane: the uncleared blocker's stable id.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) blocker_id: Option<String>,
+    /// relies_on lane: the open target is itself in the OWED-COMPLETION
+    /// state ([`super::summary::item_owed_completion`] — finished and
+    /// awaiting the owner's Complete tap), so the dependent's blocked
+    /// chip can say so and name the tap as the unblocking gesture. The
+    /// SAME classification that drives the needs-you rail's Complete
+    /// class — derived once at the serving seam, never a second
+    /// predicate. Absent-on-the-wire when false.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub(crate) target_completable: bool,
 }
 
 /// One attributed note on an item (F2 `annotate` fold view). Attribution
@@ -1955,6 +1979,7 @@ pub(crate) fn apply_op(
                     deferred_until: None,
                     watched_by: None,
                     blocked_on: None,
+                    completable: false,
                 },
             );
             None

--- a/src/bin/caller/agenda/working_set.rs
+++ b/src/bin/caller/agenda/working_set.rs
@@ -170,6 +170,7 @@ mod tests {
             deferred_until: None,
             watched_by: None,
             blocked_on: None,
+            completable: false,
         }
     }
 

--- a/src/bin/caller/web_gateway/static_assets.rs
+++ b/src/bin/caller/web_gateway/static_assets.rs
@@ -1271,15 +1271,22 @@ mod tests {
             !cards.contains("agendaChipHtml('blocked'"),
             "no surface renders the old say-nothing blocked chip"
         );
-        // The delivered derivation reads the served run + attestation
-        // truth (summary.rs serves both at list grain).
+        // The delivered judgment reads the SERVED owed-completion
+        // classification (summary.rs `item_owed_completion`, served as
+        // the target row's `completable` flag and the blocked_on
+        // causes' `target_completable`) — the old client re-derivation
+        // from run + attestation is deleted (derive-don't-mirror).
         assert!(
-            shared.contains("run.state === 'completed' && run.attestation")
-                && shared.contains("run.attestation.outcome === 'achieved'"),
-            "delivered-awaiting-Complete = completed AND self-reported achieved"
+            shared.contains("target.completable === true")
+                && shared.contains("served.target_completable === true"),
+            "delivered-awaiting-Complete reads the served classification"
         );
         assert!(
-            shared.contains("'delivered · awaiting Complete'"),
+            !shared.contains("&& run.attestation.outcome === 'achieved'"),
+            "no client-side re-derivation of the owed-completion predicate"
+        );
+        assert!(
+            shared.contains("'finished · awaiting Complete'"),
             "the all-delivered chip face names the actionable wait"
         );
         // Both the card rows and the inspector's Blocked-on section read

--- a/static/app.html
+++ b/static/app.html
@@ -39165,7 +39165,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'd6da0ead327df05e';
+const INTENDANT_APP_BUILD = 'fbefe0551640bc87';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -95718,17 +95718,23 @@ function agendaFullItemFor(id) {
 // Adopt a FULL item arriving outside the summary feed (the
 // `agenda_changed` event lane, op-response merges): file it in the
 // full-item cache, and shape a summary-compatible row for the list —
-// slim derivations only (counts), never predicate re-derivation. The
-// served flags (blocked/frontier/triage) carry over from the replaced
-// summary row and AGE until the next summary pull refreshes them — the
-// ruled Q4 decoration-freshness contract; a brand-new item wears no
-// flags until first summarized.
+// slim derivations only (counts), never predicate re-derivation.
+// Blocked and owed-completion arrive FRESH on every decorated full
+// copy — `blocked_on` is present exactly when the daemon judges the
+// open item blocked, and `completable` rides the DTO — so the row
+// adopts them instead of aging the replaced summary's flags. The
+// remaining served flags (frontier/triage) need the fold watermark the
+// full grain doesn't carry: they carry over and AGE until the next
+// summary pull refreshes them — the ruled Q4 decoration-freshness
+// contract; a brand-new item wears none until first summarized.
 function agendaAdoptFullItem(full) {
   agendaFullItems.set(full.id, full);
   const prior = agendaFindItem(full.id);
   const row = Object.assign({}, full, {
     annotations_count: Array.isArray(full.annotations) ? full.annotations.length : 0,
-    blocked: prior ? prior.blocked : undefined,
+    blocked: full.status === 'open'
+      && Array.isArray(full.blocked_on) && full.blocked_on.length > 0,
+    completable: full.completable === true,
     frontier: prior ? prior.frontier : undefined,
     triage: prior ? prior.triage : undefined,
   });
@@ -95909,14 +95915,18 @@ window.qa = Object.assign(window.qa || {}, {
   },
   // The synthetic depth × derivation matrix: fixture prerequisites in a
   // local fold (never the live store) driven through the exact renderer
-  // derivations — the delivered distinction, the fold matrix, the
-  // honest out-of-window degrade, and the chip face for each shape.
+  // derivations — the SERVED owed-completion adoption (a target reads
+  // delivered from its served `completable` flag or the dependent's
+  // served `blocked_on` cause, never a client re-derivation: the
+  // partial/unattested fixtures carry runs but no flag and stay
+  // waiting), the fold matrix, the honest out-of-window degrades, and
+  // the chip face for each shape.
   agendaBlockedVectors() {
     const fold = new Map();
     const put = (it) => fold.set(it.id, it);
     put({ id: 'P-run', title: 'running prerequisite', status: 'open',
       effects: [{ manifest: { fire_at_ms: 1 }, last_run: { state: 'started', at_ms: 1 } }] });
-    put({ id: 'P-delivered', title: 'delivered prerequisite', status: 'open',
+    put({ id: 'P-delivered', title: 'delivered prerequisite', status: 'open', completable: true,
       effects: [{ manifest: { fire_at_ms: 1 }, approval: { digest: 'd', at_ms: 1 },
         last_run: { state: 'completed', at_ms: 1, attestation: { outcome: 'achieved' } } }] });
     put({ id: 'P-partial', title: 'partially delivered prerequisite', status: 'open',
@@ -95942,6 +95952,10 @@ window.qa = Object.assign(window.qa || {}, {
       retired_prereq: item({ relies_on: [{ target_id: 'P-retired' }] }),
       outside_window_while_blocked: item({ relies_on: [{ target_id: '01GONE' }] }),
       outside_window_unblocked: item({ blocked: false, relies_on: [{ target_id: '01GONE' }] }),
+      outside_window_served_completable: item({
+        relies_on: [{ target_id: '01GONE2' }],
+        blocked_on: [{ cause: 'relies_on', target_id: '01GONE2',
+          title: 'archived but finished', target_status: 'open', target_completable: true }] }),
       served_flag_without_visible_gate: item({}),
     };
     return Object.fromEntries(Object.entries(cases).map(([name, fixture]) => {
@@ -96091,10 +96105,12 @@ function agendaObserveServerMessage(d) {
     if (document.getElementById('ui2-agenda-card') || agendaTabVisible()) agendaRefresh();
     return;
   }
+  const prior = agendaFindItem(d.item.id);
   const row = agendaAdoptFullItem(d.item);
   const at = agendaItems.findIndex((item) => item.id === d.item.id);
   if (at >= 0) agendaItems[at] = row;
   else agendaItems.push(row);
+  agendaDependentsRepull(prior, row);
   if (d.counts) agendaCounts = d.counts;
   // Track AS S3: the event names its producing op — advance the resume
   // cursor past it. max() because a delta pull may already sit ahead.
@@ -96108,6 +96124,34 @@ function agendaObserveServerMessage(d) {
     (id) => !(id in agendaSessions) && !agendaSessionLookupsAttempted.has(id));
   if (unresolved) agendaRefresh();
   agendaRenderAll();
+}
+
+// The live-repaint lane for DEPENDENTS (owner finding #10 family): an
+// `agenda_changed` event carries only the changed item, but that item's
+// status and owed-completion state feed OTHER rows' served verdicts —
+// a dependent's blocked chip, its Complete rail class. The since_seq
+// heal can't refresh those rows (their ops never moved), so a change
+// that can move a dependent's verdict schedules ONE coalesced full
+// summary re-pull: the whole visible list repaints from fresh served
+// flags. Whole-list by choice — per-row surgery would mean re-deriving
+// the daemon's predicates client-side, and the summary pull is the
+// blessed freshness affordance (the ruled Q4 contract).
+let agendaDepsRepullTimer = null;
+function agendaDependentsRepull(prior, next) {
+  if (!next || !Array.isArray(agendaItems)) return;
+  const moved = !prior
+    || prior.status !== next.status
+    || (prior.completable === true) !== (next.completable === true);
+  if (!moved) return;
+  const hasDependents = agendaItems.some((row) => row.id !== next.id
+    && (row.relies_on || []).some((link) => link.target_id === next.id));
+  if (!hasDependents) return;
+  if (agendaDepsRepullTimer) return;
+  agendaDepsRepullTimer = setTimeout(() => {
+    agendaDepsRepullTimer = null;
+    agendaLastFullPullAt = Date.now();
+    agendaRefresh().catch((e) => console.warn('[agenda] dependents re-pull failed', e));
+  }, 250);
 }
 
 // Every session id an item's attribution views reference (provenance,
@@ -96303,18 +96347,27 @@ function agendaBlockedLine(item) {
 // per-gate rows, and the inspector's Blocked-on section: each
 // `relies_on` link joined client-side against the loaded window
 // (summaries already serve `relies_on[].target_id`, uncleared
-// `blockers`, and `effects[].last_run.attestation` — no second
-// server-side join). `kind` vocabulary:
+// `blockers`, and `effects[].last_run` for the live-status garnish),
+// with the SERVED facts as the authority: the target row's
+// `completable` flag (the daemon's owed-completion classification —
+// never re-derived here) and, when the target sits outside the live
+// window, the item's own served `blocked_on` decoration (title,
+// status, completable per cause, computed against the full ledger).
+// `kind` vocabulary:
 //   'satisfied'  target done — the link no longer waits
-//   'delivered'  target open, but its effect's last run COMPLETED and
-//                the session self-reported achieved — everything ran;
-//                only the owner's Complete tap is missing (an
-//                actionable wait, distinct from in-flight work)
+//   'delivered'  target open but SERVED completable — everything ran
+//                and self-reported achieved; only the owner's Complete
+//                tap is missing (an actionable wait, distinct from
+//                in-flight work)
 //   'waiting'    target open — genuinely in flight or parked; `status`
-//                carries the live word from the effect derivation
+//                carries the live word from the effect derivation, and
+//                `remedy` marks the rows whose unblocking gesture is
+//                completing the target (in-flight rows carry none —
+//                the run is already doing the work)
 //   'retired'    target retired — the link needs review
 //   'unknown'    target outside the live window while the served
-//                verdict says blocked — id-only, degrade honestly
+//                verdict says blocked and no served cause names it —
+//                id-only, degrade honestly
 // A target absent from the window on an UNBLOCKED item is provably
 // done (the daemon's verdict is computed against the full ledger), so
 // it reads satisfied — never the old "missing — review" lie.
@@ -96326,9 +96379,34 @@ function agendaPrereqStates(item, findItem) {
   const blocked = item.blocked !== undefined
     ? item.blocked === true
     : ((find(item.id) || {}).blocked === true);
+  const servedCauses = Array.isArray(item.blocked_on) ? item.blocked_on : [];
+  const servedCause = (id) => servedCauses.find(
+    (c) => c.cause === 'relies_on' && c.target_id === id) || null;
   return (item.relies_on || []).map((link) => {
     const target = find(link.target_id) || null;
+    const served = servedCause(link.target_id);
     if (!target) {
+      if (served) {
+        // Outside the live window, but the served decoration names it:
+        // render the daemon's title/status/completable — never id-only
+        // when served facts exist.
+        const base = { id: link.target_id, target: null, title: served.title || link.target_id };
+        if (served.target_completable === true) {
+          return { ...base, kind: 'delivered', status: 'finished and awaiting Complete',
+            tone: 'sky',
+            detail: 'It ran to completion and self-reported achieved (not verified) — open it and Mark done (Complete) to release this wait.' };
+        }
+        if (served.target_status === 'retired') {
+          return { ...base, kind: 'retired', status: 'retired — review', tone: 'amber',
+            detail: 'A retired prerequisite never silently satisfies the link — drop it or reopen the target.' };
+        }
+        if (served.target_status === 'missing') {
+          return { ...base, kind: 'unknown', tone: 'neutral', status: 'missing from the ledger',
+            detail: 'The daemon finds no item with this id — drop the link or restore the target.' };
+        }
+        return { ...base, kind: 'waiting', status: 'still open', tone: 'neutral', remedy: true,
+          detail: 'Open beyond this live window — completing it releases this wait.' };
+      }
       const short = `${String(link.target_id).slice(0, 10)}…`;
       return blocked
         ? { id: link.target_id, target: null, title: short, kind: 'unknown',
@@ -96347,18 +96425,22 @@ function agendaPrereqStates(item, findItem) {
         detail: 'A retired prerequisite never silently satisfies the link — drop it or reopen the target.' };
     }
     const run = ((target.effects || [])[0] || {}).last_run || null;
-    if (run && run.state === 'completed' && run.attestation
-      && run.attestation.outcome === 'achieved') {
-      return { ...base, kind: 'delivered', status: 'delivered — awaiting Complete',
+    // OWED COMPLETION is SERVED (the daemon's one classification —
+    // derive-don't-mirror): the target row's flag, or the served cause
+    // when the row's copy predates the flag. The old client re-derivation
+    // (completed run + achieved attestation) is deleted.
+    if (target.completable === true || (served && served.target_completable === true)) {
+      return { ...base, kind: 'delivered', status: 'finished and awaiting Complete',
         tone: 'sky',
-        detail: `Ran ${agendaRelTime(run.at_ms)}, completed, self-reported achieved (not verified) — open it and Mark done to release this wait.` };
+        detail: `${run ? `Ran ${agendaRelTime(run.at_ms)}, completed, ` : 'It ran to completion and '}self-reported achieved (not verified) — open it and Mark done (Complete) to release this wait.` };
     }
     const st = agendaEffectState(target);
     let status = 'still open';
     let tone = 'neutral';
+    let inFlight = false;
     if (st) {
-      if (st.kind === 'running') { status = 'running now'; tone = 'iris'; }
-      else if (st.kind === 'ready') { status = 'fires momentarily'; tone = 'iris'; }
+      if (st.kind === 'running') { status = 'running now'; tone = 'iris'; inFlight = true; }
+      else if (st.kind === 'ready') { status = 'fires momentarily'; tone = 'iris'; inFlight = true; }
       else if (st.kind === 'waiting') status = 'waiting on its own prerequisites';
       else if (st.kind === 'watching') status = 'watching for matches';
       else if (st.kind === 'pending') { status = 'awaiting approval'; tone = 'amber'; }
@@ -96372,7 +96454,7 @@ function agendaPrereqStates(item, findItem) {
           ? `ran — self-reported ${run.attestation.outcome}` : 'ran — no self-report yet';
       } else if (run && run.state === 'failed') { status = 'last run failed'; tone = 'amber'; }
     }
-    return { ...base, kind: 'waiting', status, tone };
+    return { ...base, kind: 'waiting', status, tone, remedy: !inFlight };
   });
 }
 
@@ -96403,22 +96485,24 @@ function agendaBlockedExplain(item, findItem) {
 }
 
 // The chip face: 'blocked' (rose) — or, when every unsatisfied
-// prerequisite is delivered-and-attested and no blocker is stated,
-// 'delivered · awaiting Complete' (sky, the achieved self-report hue —
+// prerequisite is served owed-completion and no blocker is stated,
+// 'finished · awaiting Complete' (sky, the achieved self-report hue —
 // never transport green; the 'answered · awaiting pickup' twin). Pure
 // spec; the cards render it.
 function agendaBlockedChipSpec(explain) {
   return explain.allDelivered
-    ? { label: 'delivered · awaiting Complete', tone: 'sky' }
+    ? { label: 'finished · awaiting Complete', tone: 'sky' }
     : { label: 'blocked', tone: 'rose' };
 }
 
 // The chip's hover lane (the tap reveal is the primary — no
-// hover-only): one line per gate, every depth.
+// hover-only): one line per gate, every depth, each naming its
+// unblocking gesture where one exists.
 function agendaBlockedTip(explain) {
   const lines = [];
   explain.blockers.forEach((b) => lines.push(`waiting on: “${b.criterion}”`));
-  explain.prereqs.forEach((p) => lines.push(`waits on “${p.title}” — ${p.status}`));
+  explain.prereqs.forEach((p) => lines.push(
+    `waiting on: “${p.title}” — ${p.status}${p.remedy ? ' — complete it to proceed' : ''}`));
   if (explain.unexplained) {
     lines.push('The daemon judges this blocked, but no gate is visible in this window — it may have just changed.');
   }
@@ -98806,6 +98890,13 @@ function agendaLensGroupsNow() {
     const st = agendaEffectState(x);
     return x.status === 'open' && st && st.kind === 'pending';
   }));
+  // OWED COMPLETIONS (owner finding #10): the daemon-served
+  // classification (`completable` — one predicate drives this class,
+  // the lens badge, and the blocked chips' target state; the client
+  // never re-derives it). Freshest finished-work first.
+  const complete = take(pool
+    .filter((x) => x.completable === true)
+    .sort((a, b) => (b.updated_ms || 0) - (a.updated_ms || 0)));
   const suspended = take(pool.filter((x) => {
     const st = agendaEffectState(x);
     return st && st.kind === 'suspended';
@@ -98833,6 +98924,13 @@ function agendaLensGroupsNow() {
       label: 'Approve',
       hint: 'proposed session manifests — nothing fires without you; approval binds the exact digest',
       rows: approve.map((x) => ({ item: x })),
+    });
+  }
+  if (complete.length) {
+    groups.push({
+      label: 'Complete',
+      hint: 'finished — every planned run completed and self-reported achieved; only your Complete tap remains, and anything waiting on these cards unblocks when it lands',
+      rows: complete.map((x) => ({ item: x })),
     });
   }
   if (suspended.length) {
@@ -99063,6 +99161,8 @@ function agendaLensGroupsArchive() {
 // Distinct items the "Needs you" lens would show — the lens badge.
 // Watched questions (an armed automation covers them — daemon-derived
 // watched_by) are machinery's inbox and never count as needing you.
+// Owed completions ride the served `completable` classification — the
+// same daemon predicate that builds the Complete rail class.
 function agendaNeedsYouCount() {
   const needs = new Set();
   (agendaItems || []).forEach((x) => {
@@ -99070,6 +99170,7 @@ function agendaNeedsYouCount() {
     if (x.kind === 'question' && x.status === 'open' && !x.dismissed
       && !x.watched_by) needs.add(x.id);
     if (x.status === 'open' && st && st.kind === 'pending') needs.add(x.id);
+    if (x.completable === true) needs.add(x.id);
     if (st && st.kind === 'suspended') needs.add(x.id);
     if (x.status === 'open' && x.due_ms && x.due_ms < Date.now()) needs.add(x.id);
     if (x.status === 'open' && agendaTriageInfo(x)) needs.add(x.id);
@@ -99101,8 +99202,8 @@ const agendaBlockedOpen = new Set();
 // The blocked chip is a BUTTON (house law: every symbol self-explains
 // on tap — no hover-only): the tip names each gate, the tap unfolds
 // the per-gate rows under the card at any depth. When every
-// unsatisfied prerequisite is delivered-and-attested the face stops
-// crying wolf: 'delivered · awaiting Complete' (sky), nothing is
+// unsatisfied prerequisite is served owed-completion the face stops
+// crying wolf: 'finished · awaiting Complete' (sky), nothing is
 // stuck — only Complete taps are missing.
 function agendaBlockedChipHtml(item) {
   const explain = agendaBlockedExplain(item);
@@ -99111,17 +99212,26 @@ function agendaBlockedChipHtml(item) {
     title="${escapeHtml(agendaBlockedTip(explain))}">${escapeHtml(spec.label)}</button>`;
 }
 
+// One prerequisite gate row: the linked target ("waiting on: <title>" —
+// the link opens that card's pane), its live-status chip, and its named
+// unblocking gesture — "complete it to proceed" on waits whose release
+// is the target's completion, the Review-and-complete door on targets
+// the daemon serves as finished-and-awaiting-Complete. In-flight waits
+// name no gesture: the run is already doing the work.
 function agendaBlockedPrereqRowHtml(p) {
   const chip = agendaChipHtml(p.status, p.tone,
     p.detail || 'Live status, derived at render — advisory; it gates nothing');
   const name = p.target
-    ? `<a class="ag2-blk-link" data-open-item="${escapeHtml(p.id)}">waits on “${escapeHtml(p.title)}”</a>`
-    : `<span>waits on ${escapeHtml(p.title)}</span>`;
-  const go = p.kind === 'delivered'
-    ? `<button type="button" class="ag2-btn ghost ag2-blk-go" data-open-item="${escapeHtml(p.id)}"
-        title="Opens the delivered prerequisite — its Mark done is the tap that releases this wait">Review &amp; complete ›</button>`
+    ? `<a class="ag2-blk-link" data-open-item="${escapeHtml(p.id)}">waiting on: “${escapeHtml(p.title)}”</a>`
+    : `<span>waiting on: ${escapeHtml(p.title)}</span>`;
+  const remedy = p.kind === 'waiting' && p.remedy
+    ? '<span class="ag2-blk-hint">— complete it to proceed</span>'
     : '';
-  return `<div class="ag2-blk-row${p.kind === 'delivered' ? ' delivered' : ''}">${chip}${name}${go}</div>`;
+  const go = p.kind === 'delivered' && p.target
+    ? `<button type="button" class="ag2-btn ghost ag2-blk-go" data-open-item="${escapeHtml(p.id)}"
+        title="Opens the finished prerequisite — its Mark done (Complete) is the tap that releases this wait">Review &amp; complete ›</button>`
+    : '';
+  return `<div class="ag2-blk-row${p.kind === 'delivered' ? ' delivered' : ''}">${chip}${name}${remedy}${go}</div>`;
 }
 
 // The card's per-gate rows (replacing the old single-line first-gate
@@ -99206,6 +99316,14 @@ function agendaCardChips(item) {
   }
   if (agendaItemIsBlocked(item)) {
     chips.push(agendaBlockedChipHtml(item));
+  }
+  // OWED COMPLETION (served classification, finding #10 — mutually
+  // exclusive with blocked by construction): the work is fully
+  // finished; only your Complete tap remains. The status circle is the
+  // tap; dependents waiting on this card unblock when it lands.
+  if (item.status === 'open' && item.completable === true) {
+    chips.push(agendaChipHtml('finished — tap Complete', 'sky',
+      'Every planned run completed and the session self-reported achieved (not verified). Mark done — the status circle — completes it; anything waiting on this card unblocks.'));
   }
   // Tier-1 PR join chips (render-time only — never stored, never ops):
   // draft state and rename divergence come from the scanner's last
@@ -101018,20 +101136,24 @@ function agendaInspGatesHtml(item) {
     </div>`;
   });
   // The shared per-prerequisite judgment (ui2-agenda.js): live status
-  // on every link — the delivered-awaiting-Complete distinction, the
-  // in-flight word, and the honest out-of-window degrade (an absent
-  // target on an unblocked item is provably done, never "missing").
+  // on every link — the served finished-and-awaiting-Complete
+  // distinction, the in-flight word, the named unblocking gesture, and
+  // the honest out-of-window degrade (an absent target on an unblocked
+  // item is provably done, never "missing").
   const deps = agendaPrereqStates(item).map((p) => {
-    const go = p.kind === 'delivered'
+    const go = p.kind === 'delivered' && p.target
       ? `<button type="button" class="ag2-btn ghost ag2-blk-go" data-open-item="${escapeHtml(p.id)}"
-          title="Opens the delivered prerequisite — its Mark done is the tap that releases this wait">Review &amp; complete ›</button>`
+          title="Opens the finished prerequisite — its Mark done (Complete) is the tap that releases this wait">Review &amp; complete ›</button>`
+      : '';
+    const remedy = p.kind === 'waiting' && p.remedy
+      ? '<span class="ag2-hint">— complete it to proceed</span>'
       : '';
     return `<div class="ag2-insp-dep${p.kind === 'delivered' ? ' delivered' : ''}">
       ${agendaChipHtml(p.status, p.tone, p.detail)}
       ${p.target
-    ? `<a class="ag2-insp-deplink" data-open-item="${escapeHtml(p.id)}">waits on “${escapeHtml(p.title)}”</a>`
-    : `<span class="ag2-insp-deplink">waits on ${escapeHtml(p.title)}</span>`}
-      ${go}
+    ? `<a class="ag2-insp-deplink" data-open-item="${escapeHtml(p.id)}">waiting on: “${escapeHtml(p.title)}”</a>`
+    : `<span class="ag2-insp-deplink">waiting on: ${escapeHtml(p.title)}</span>`}
+      ${remedy}${go}
       <button type="button" class="ag2-x" data-remove-dep="${escapeHtml(p.id)}" title="Drop the link (the log keeps history)">×</button>
     </div>`;
   });
@@ -103745,6 +103867,7 @@ function agendaGraphBuild() {
       const st = agendaEffectState(x);
       const attn = x.status === 'open' && (
         agendaItemIsBlocked(x)
+        || x.completable === true
         || (x.kind === 'question' && !x.answer && !x.dismissed)
         || (st && (st.kind === 'pending' || st.kind === 'suspended'))
         || (x.due_ms && x.due_ms < now));

--- a/static/app/ui2-agenda-cards.js
+++ b/static/app/ui2-agenda-cards.js
@@ -497,6 +497,13 @@ function agendaLensGroupsNow() {
     const st = agendaEffectState(x);
     return x.status === 'open' && st && st.kind === 'pending';
   }));
+  // OWED COMPLETIONS (owner finding #10): the daemon-served
+  // classification (`completable` — one predicate drives this class,
+  // the lens badge, and the blocked chips' target state; the client
+  // never re-derives it). Freshest finished-work first.
+  const complete = take(pool
+    .filter((x) => x.completable === true)
+    .sort((a, b) => (b.updated_ms || 0) - (a.updated_ms || 0)));
   const suspended = take(pool.filter((x) => {
     const st = agendaEffectState(x);
     return st && st.kind === 'suspended';
@@ -524,6 +531,13 @@ function agendaLensGroupsNow() {
       label: 'Approve',
       hint: 'proposed session manifests — nothing fires without you; approval binds the exact digest',
       rows: approve.map((x) => ({ item: x })),
+    });
+  }
+  if (complete.length) {
+    groups.push({
+      label: 'Complete',
+      hint: 'finished — every planned run completed and self-reported achieved; only your Complete tap remains, and anything waiting on these cards unblocks when it lands',
+      rows: complete.map((x) => ({ item: x })),
     });
   }
   if (suspended.length) {
@@ -754,6 +768,8 @@ function agendaLensGroupsArchive() {
 // Distinct items the "Needs you" lens would show — the lens badge.
 // Watched questions (an armed automation covers them — daemon-derived
 // watched_by) are machinery's inbox and never count as needing you.
+// Owed completions ride the served `completable` classification — the
+// same daemon predicate that builds the Complete rail class.
 function agendaNeedsYouCount() {
   const needs = new Set();
   (agendaItems || []).forEach((x) => {
@@ -761,6 +777,7 @@ function agendaNeedsYouCount() {
     if (x.kind === 'question' && x.status === 'open' && !x.dismissed
       && !x.watched_by) needs.add(x.id);
     if (x.status === 'open' && st && st.kind === 'pending') needs.add(x.id);
+    if (x.completable === true) needs.add(x.id);
     if (st && st.kind === 'suspended') needs.add(x.id);
     if (x.status === 'open' && x.due_ms && x.due_ms < Date.now()) needs.add(x.id);
     if (x.status === 'open' && agendaTriageInfo(x)) needs.add(x.id);
@@ -792,8 +809,8 @@ const agendaBlockedOpen = new Set();
 // The blocked chip is a BUTTON (house law: every symbol self-explains
 // on tap — no hover-only): the tip names each gate, the tap unfolds
 // the per-gate rows under the card at any depth. When every
-// unsatisfied prerequisite is delivered-and-attested the face stops
-// crying wolf: 'delivered · awaiting Complete' (sky), nothing is
+// unsatisfied prerequisite is served owed-completion the face stops
+// crying wolf: 'finished · awaiting Complete' (sky), nothing is
 // stuck — only Complete taps are missing.
 function agendaBlockedChipHtml(item) {
   const explain = agendaBlockedExplain(item);
@@ -802,17 +819,26 @@ function agendaBlockedChipHtml(item) {
     title="${escapeHtml(agendaBlockedTip(explain))}">${escapeHtml(spec.label)}</button>`;
 }
 
+// One prerequisite gate row: the linked target ("waiting on: <title>" —
+// the link opens that card's pane), its live-status chip, and its named
+// unblocking gesture — "complete it to proceed" on waits whose release
+// is the target's completion, the Review-and-complete door on targets
+// the daemon serves as finished-and-awaiting-Complete. In-flight waits
+// name no gesture: the run is already doing the work.
 function agendaBlockedPrereqRowHtml(p) {
   const chip = agendaChipHtml(p.status, p.tone,
     p.detail || 'Live status, derived at render — advisory; it gates nothing');
   const name = p.target
-    ? `<a class="ag2-blk-link" data-open-item="${escapeHtml(p.id)}">waits on “${escapeHtml(p.title)}”</a>`
-    : `<span>waits on ${escapeHtml(p.title)}</span>`;
-  const go = p.kind === 'delivered'
-    ? `<button type="button" class="ag2-btn ghost ag2-blk-go" data-open-item="${escapeHtml(p.id)}"
-        title="Opens the delivered prerequisite — its Mark done is the tap that releases this wait">Review &amp; complete ›</button>`
+    ? `<a class="ag2-blk-link" data-open-item="${escapeHtml(p.id)}">waiting on: “${escapeHtml(p.title)}”</a>`
+    : `<span>waiting on: ${escapeHtml(p.title)}</span>`;
+  const remedy = p.kind === 'waiting' && p.remedy
+    ? '<span class="ag2-blk-hint">— complete it to proceed</span>'
     : '';
-  return `<div class="ag2-blk-row${p.kind === 'delivered' ? ' delivered' : ''}">${chip}${name}${go}</div>`;
+  const go = p.kind === 'delivered' && p.target
+    ? `<button type="button" class="ag2-btn ghost ag2-blk-go" data-open-item="${escapeHtml(p.id)}"
+        title="Opens the finished prerequisite — its Mark done (Complete) is the tap that releases this wait">Review &amp; complete ›</button>`
+    : '';
+  return `<div class="ag2-blk-row${p.kind === 'delivered' ? ' delivered' : ''}">${chip}${name}${remedy}${go}</div>`;
 }
 
 // The card's per-gate rows (replacing the old single-line first-gate
@@ -897,6 +923,14 @@ function agendaCardChips(item) {
   }
   if (agendaItemIsBlocked(item)) {
     chips.push(agendaBlockedChipHtml(item));
+  }
+  // OWED COMPLETION (served classification, finding #10 — mutually
+  // exclusive with blocked by construction): the work is fully
+  // finished; only your Complete tap remains. The status circle is the
+  // tap; dependents waiting on this card unblock when it lands.
+  if (item.status === 'open' && item.completable === true) {
+    chips.push(agendaChipHtml('finished — tap Complete', 'sky',
+      'Every planned run completed and the session self-reported achieved (not verified). Mark done — the status circle — completes it; anything waiting on this card unblocks.'));
   }
   // Tier-1 PR join chips (render-time only — never stored, never ops):
   // draft state and rename divergence come from the scanner's last

--- a/static/app/ui2-agenda-graph.js
+++ b/static/app/ui2-agenda-graph.js
@@ -1126,6 +1126,7 @@ function agendaGraphBuild() {
       const st = agendaEffectState(x);
       const attn = x.status === 'open' && (
         agendaItemIsBlocked(x)
+        || x.completable === true
         || (x.kind === 'question' && !x.answer && !x.dismissed)
         || (st && (st.kind === 'pending' || st.kind === 'suspended'))
         || (x.due_ms && x.due_ms < now));

--- a/static/app/ui2-agenda-inspector.js
+++ b/static/app/ui2-agenda-inspector.js
@@ -727,20 +727,24 @@ function agendaInspGatesHtml(item) {
     </div>`;
   });
   // The shared per-prerequisite judgment (ui2-agenda.js): live status
-  // on every link — the delivered-awaiting-Complete distinction, the
-  // in-flight word, and the honest out-of-window degrade (an absent
-  // target on an unblocked item is provably done, never "missing").
+  // on every link — the served finished-and-awaiting-Complete
+  // distinction, the in-flight word, the named unblocking gesture, and
+  // the honest out-of-window degrade (an absent target on an unblocked
+  // item is provably done, never "missing").
   const deps = agendaPrereqStates(item).map((p) => {
-    const go = p.kind === 'delivered'
+    const go = p.kind === 'delivered' && p.target
       ? `<button type="button" class="ag2-btn ghost ag2-blk-go" data-open-item="${escapeHtml(p.id)}"
-          title="Opens the delivered prerequisite — its Mark done is the tap that releases this wait">Review &amp; complete ›</button>`
+          title="Opens the finished prerequisite — its Mark done (Complete) is the tap that releases this wait">Review &amp; complete ›</button>`
+      : '';
+    const remedy = p.kind === 'waiting' && p.remedy
+      ? '<span class="ag2-hint">— complete it to proceed</span>'
       : '';
     return `<div class="ag2-insp-dep${p.kind === 'delivered' ? ' delivered' : ''}">
       ${agendaChipHtml(p.status, p.tone, p.detail)}
       ${p.target
-    ? `<a class="ag2-insp-deplink" data-open-item="${escapeHtml(p.id)}">waits on “${escapeHtml(p.title)}”</a>`
-    : `<span class="ag2-insp-deplink">waits on ${escapeHtml(p.title)}</span>`}
-      ${go}
+    ? `<a class="ag2-insp-deplink" data-open-item="${escapeHtml(p.id)}">waiting on: “${escapeHtml(p.title)}”</a>`
+    : `<span class="ag2-insp-deplink">waiting on: ${escapeHtml(p.title)}</span>`}
+      ${remedy}${go}
       <button type="button" class="ag2-x" data-remove-dep="${escapeHtml(p.id)}" title="Drop the link (the log keeps history)">×</button>
     </div>`;
   });

--- a/static/app/ui2-agenda.js
+++ b/static/app/ui2-agenda.js
@@ -255,17 +255,23 @@ function agendaFullItemFor(id) {
 // Adopt a FULL item arriving outside the summary feed (the
 // `agenda_changed` event lane, op-response merges): file it in the
 // full-item cache, and shape a summary-compatible row for the list —
-// slim derivations only (counts), never predicate re-derivation. The
-// served flags (blocked/frontier/triage) carry over from the replaced
-// summary row and AGE until the next summary pull refreshes them — the
-// ruled Q4 decoration-freshness contract; a brand-new item wears no
-// flags until first summarized.
+// slim derivations only (counts), never predicate re-derivation.
+// Blocked and owed-completion arrive FRESH on every decorated full
+// copy — `blocked_on` is present exactly when the daemon judges the
+// open item blocked, and `completable` rides the DTO — so the row
+// adopts them instead of aging the replaced summary's flags. The
+// remaining served flags (frontier/triage) need the fold watermark the
+// full grain doesn't carry: they carry over and AGE until the next
+// summary pull refreshes them — the ruled Q4 decoration-freshness
+// contract; a brand-new item wears none until first summarized.
 function agendaAdoptFullItem(full) {
   agendaFullItems.set(full.id, full);
   const prior = agendaFindItem(full.id);
   const row = Object.assign({}, full, {
     annotations_count: Array.isArray(full.annotations) ? full.annotations.length : 0,
-    blocked: prior ? prior.blocked : undefined,
+    blocked: full.status === 'open'
+      && Array.isArray(full.blocked_on) && full.blocked_on.length > 0,
+    completable: full.completable === true,
     frontier: prior ? prior.frontier : undefined,
     triage: prior ? prior.triage : undefined,
   });
@@ -446,14 +452,18 @@ window.qa = Object.assign(window.qa || {}, {
   },
   // The synthetic depth × derivation matrix: fixture prerequisites in a
   // local fold (never the live store) driven through the exact renderer
-  // derivations — the delivered distinction, the fold matrix, the
-  // honest out-of-window degrade, and the chip face for each shape.
+  // derivations — the SERVED owed-completion adoption (a target reads
+  // delivered from its served `completable` flag or the dependent's
+  // served `blocked_on` cause, never a client re-derivation: the
+  // partial/unattested fixtures carry runs but no flag and stay
+  // waiting), the fold matrix, the honest out-of-window degrades, and
+  // the chip face for each shape.
   agendaBlockedVectors() {
     const fold = new Map();
     const put = (it) => fold.set(it.id, it);
     put({ id: 'P-run', title: 'running prerequisite', status: 'open',
       effects: [{ manifest: { fire_at_ms: 1 }, last_run: { state: 'started', at_ms: 1 } }] });
-    put({ id: 'P-delivered', title: 'delivered prerequisite', status: 'open',
+    put({ id: 'P-delivered', title: 'delivered prerequisite', status: 'open', completable: true,
       effects: [{ manifest: { fire_at_ms: 1 }, approval: { digest: 'd', at_ms: 1 },
         last_run: { state: 'completed', at_ms: 1, attestation: { outcome: 'achieved' } } }] });
     put({ id: 'P-partial', title: 'partially delivered prerequisite', status: 'open',
@@ -479,6 +489,10 @@ window.qa = Object.assign(window.qa || {}, {
       retired_prereq: item({ relies_on: [{ target_id: 'P-retired' }] }),
       outside_window_while_blocked: item({ relies_on: [{ target_id: '01GONE' }] }),
       outside_window_unblocked: item({ blocked: false, relies_on: [{ target_id: '01GONE' }] }),
+      outside_window_served_completable: item({
+        relies_on: [{ target_id: '01GONE2' }],
+        blocked_on: [{ cause: 'relies_on', target_id: '01GONE2',
+          title: 'archived but finished', target_status: 'open', target_completable: true }] }),
       served_flag_without_visible_gate: item({}),
     };
     return Object.fromEntries(Object.entries(cases).map(([name, fixture]) => {
@@ -628,10 +642,12 @@ function agendaObserveServerMessage(d) {
     if (document.getElementById('ui2-agenda-card') || agendaTabVisible()) agendaRefresh();
     return;
   }
+  const prior = agendaFindItem(d.item.id);
   const row = agendaAdoptFullItem(d.item);
   const at = agendaItems.findIndex((item) => item.id === d.item.id);
   if (at >= 0) agendaItems[at] = row;
   else agendaItems.push(row);
+  agendaDependentsRepull(prior, row);
   if (d.counts) agendaCounts = d.counts;
   // Track AS S3: the event names its producing op — advance the resume
   // cursor past it. max() because a delta pull may already sit ahead.
@@ -645,6 +661,34 @@ function agendaObserveServerMessage(d) {
     (id) => !(id in agendaSessions) && !agendaSessionLookupsAttempted.has(id));
   if (unresolved) agendaRefresh();
   agendaRenderAll();
+}
+
+// The live-repaint lane for DEPENDENTS (owner finding #10 family): an
+// `agenda_changed` event carries only the changed item, but that item's
+// status and owed-completion state feed OTHER rows' served verdicts —
+// a dependent's blocked chip, its Complete rail class. The since_seq
+// heal can't refresh those rows (their ops never moved), so a change
+// that can move a dependent's verdict schedules ONE coalesced full
+// summary re-pull: the whole visible list repaints from fresh served
+// flags. Whole-list by choice — per-row surgery would mean re-deriving
+// the daemon's predicates client-side, and the summary pull is the
+// blessed freshness affordance (the ruled Q4 contract).
+let agendaDepsRepullTimer = null;
+function agendaDependentsRepull(prior, next) {
+  if (!next || !Array.isArray(agendaItems)) return;
+  const moved = !prior
+    || prior.status !== next.status
+    || (prior.completable === true) !== (next.completable === true);
+  if (!moved) return;
+  const hasDependents = agendaItems.some((row) => row.id !== next.id
+    && (row.relies_on || []).some((link) => link.target_id === next.id));
+  if (!hasDependents) return;
+  if (agendaDepsRepullTimer) return;
+  agendaDepsRepullTimer = setTimeout(() => {
+    agendaDepsRepullTimer = null;
+    agendaLastFullPullAt = Date.now();
+    agendaRefresh().catch((e) => console.warn('[agenda] dependents re-pull failed', e));
+  }, 250);
 }
 
 // Every session id an item's attribution views reference (provenance,
@@ -840,18 +884,27 @@ function agendaBlockedLine(item) {
 // per-gate rows, and the inspector's Blocked-on section: each
 // `relies_on` link joined client-side against the loaded window
 // (summaries already serve `relies_on[].target_id`, uncleared
-// `blockers`, and `effects[].last_run.attestation` — no second
-// server-side join). `kind` vocabulary:
+// `blockers`, and `effects[].last_run` for the live-status garnish),
+// with the SERVED facts as the authority: the target row's
+// `completable` flag (the daemon's owed-completion classification —
+// never re-derived here) and, when the target sits outside the live
+// window, the item's own served `blocked_on` decoration (title,
+// status, completable per cause, computed against the full ledger).
+// `kind` vocabulary:
 //   'satisfied'  target done — the link no longer waits
-//   'delivered'  target open, but its effect's last run COMPLETED and
-//                the session self-reported achieved — everything ran;
-//                only the owner's Complete tap is missing (an
-//                actionable wait, distinct from in-flight work)
+//   'delivered'  target open but SERVED completable — everything ran
+//                and self-reported achieved; only the owner's Complete
+//                tap is missing (an actionable wait, distinct from
+//                in-flight work)
 //   'waiting'    target open — genuinely in flight or parked; `status`
-//                carries the live word from the effect derivation
+//                carries the live word from the effect derivation, and
+//                `remedy` marks the rows whose unblocking gesture is
+//                completing the target (in-flight rows carry none —
+//                the run is already doing the work)
 //   'retired'    target retired — the link needs review
 //   'unknown'    target outside the live window while the served
-//                verdict says blocked — id-only, degrade honestly
+//                verdict says blocked and no served cause names it —
+//                id-only, degrade honestly
 // A target absent from the window on an UNBLOCKED item is provably
 // done (the daemon's verdict is computed against the full ledger), so
 // it reads satisfied — never the old "missing — review" lie.
@@ -863,9 +916,34 @@ function agendaPrereqStates(item, findItem) {
   const blocked = item.blocked !== undefined
     ? item.blocked === true
     : ((find(item.id) || {}).blocked === true);
+  const servedCauses = Array.isArray(item.blocked_on) ? item.blocked_on : [];
+  const servedCause = (id) => servedCauses.find(
+    (c) => c.cause === 'relies_on' && c.target_id === id) || null;
   return (item.relies_on || []).map((link) => {
     const target = find(link.target_id) || null;
+    const served = servedCause(link.target_id);
     if (!target) {
+      if (served) {
+        // Outside the live window, but the served decoration names it:
+        // render the daemon's title/status/completable — never id-only
+        // when served facts exist.
+        const base = { id: link.target_id, target: null, title: served.title || link.target_id };
+        if (served.target_completable === true) {
+          return { ...base, kind: 'delivered', status: 'finished and awaiting Complete',
+            tone: 'sky',
+            detail: 'It ran to completion and self-reported achieved (not verified) — open it and Mark done (Complete) to release this wait.' };
+        }
+        if (served.target_status === 'retired') {
+          return { ...base, kind: 'retired', status: 'retired — review', tone: 'amber',
+            detail: 'A retired prerequisite never silently satisfies the link — drop it or reopen the target.' };
+        }
+        if (served.target_status === 'missing') {
+          return { ...base, kind: 'unknown', tone: 'neutral', status: 'missing from the ledger',
+            detail: 'The daemon finds no item with this id — drop the link or restore the target.' };
+        }
+        return { ...base, kind: 'waiting', status: 'still open', tone: 'neutral', remedy: true,
+          detail: 'Open beyond this live window — completing it releases this wait.' };
+      }
       const short = `${String(link.target_id).slice(0, 10)}…`;
       return blocked
         ? { id: link.target_id, target: null, title: short, kind: 'unknown',
@@ -884,18 +962,22 @@ function agendaPrereqStates(item, findItem) {
         detail: 'A retired prerequisite never silently satisfies the link — drop it or reopen the target.' };
     }
     const run = ((target.effects || [])[0] || {}).last_run || null;
-    if (run && run.state === 'completed' && run.attestation
-      && run.attestation.outcome === 'achieved') {
-      return { ...base, kind: 'delivered', status: 'delivered — awaiting Complete',
+    // OWED COMPLETION is SERVED (the daemon's one classification —
+    // derive-don't-mirror): the target row's flag, or the served cause
+    // when the row's copy predates the flag. The old client re-derivation
+    // (completed run + achieved attestation) is deleted.
+    if (target.completable === true || (served && served.target_completable === true)) {
+      return { ...base, kind: 'delivered', status: 'finished and awaiting Complete',
         tone: 'sky',
-        detail: `Ran ${agendaRelTime(run.at_ms)}, completed, self-reported achieved (not verified) — open it and Mark done to release this wait.` };
+        detail: `${run ? `Ran ${agendaRelTime(run.at_ms)}, completed, ` : 'It ran to completion and '}self-reported achieved (not verified) — open it and Mark done (Complete) to release this wait.` };
     }
     const st = agendaEffectState(target);
     let status = 'still open';
     let tone = 'neutral';
+    let inFlight = false;
     if (st) {
-      if (st.kind === 'running') { status = 'running now'; tone = 'iris'; }
-      else if (st.kind === 'ready') { status = 'fires momentarily'; tone = 'iris'; }
+      if (st.kind === 'running') { status = 'running now'; tone = 'iris'; inFlight = true; }
+      else if (st.kind === 'ready') { status = 'fires momentarily'; tone = 'iris'; inFlight = true; }
       else if (st.kind === 'waiting') status = 'waiting on its own prerequisites';
       else if (st.kind === 'watching') status = 'watching for matches';
       else if (st.kind === 'pending') { status = 'awaiting approval'; tone = 'amber'; }
@@ -909,7 +991,7 @@ function agendaPrereqStates(item, findItem) {
           ? `ran — self-reported ${run.attestation.outcome}` : 'ran — no self-report yet';
       } else if (run && run.state === 'failed') { status = 'last run failed'; tone = 'amber'; }
     }
-    return { ...base, kind: 'waiting', status, tone };
+    return { ...base, kind: 'waiting', status, tone, remedy: !inFlight };
   });
 }
 
@@ -940,22 +1022,24 @@ function agendaBlockedExplain(item, findItem) {
 }
 
 // The chip face: 'blocked' (rose) — or, when every unsatisfied
-// prerequisite is delivered-and-attested and no blocker is stated,
-// 'delivered · awaiting Complete' (sky, the achieved self-report hue —
+// prerequisite is served owed-completion and no blocker is stated,
+// 'finished · awaiting Complete' (sky, the achieved self-report hue —
 // never transport green; the 'answered · awaiting pickup' twin). Pure
 // spec; the cards render it.
 function agendaBlockedChipSpec(explain) {
   return explain.allDelivered
-    ? { label: 'delivered · awaiting Complete', tone: 'sky' }
+    ? { label: 'finished · awaiting Complete', tone: 'sky' }
     : { label: 'blocked', tone: 'rose' };
 }
 
 // The chip's hover lane (the tap reveal is the primary — no
-// hover-only): one line per gate, every depth.
+// hover-only): one line per gate, every depth, each naming its
+// unblocking gesture where one exists.
 function agendaBlockedTip(explain) {
   const lines = [];
   explain.blockers.forEach((b) => lines.push(`waiting on: “${b.criterion}”`));
-  explain.prereqs.forEach((p) => lines.push(`waits on “${p.title}” — ${p.status}`));
+  explain.prereqs.forEach((p) => lines.push(
+    `waiting on: “${p.title}” — ${p.status}${p.remedy ? ' — complete it to proceed' : ''}`));
   if (explain.unexplained) {
     lines.push('The daemon judges this blocked, but no gate is visible in this window — it may have just changed.');
   }


### PR DESCRIPTION
## What

Owner finding #10 family (steward card 01KZBJWWPFPWBKS72XE6Q64F9H): fully-finished cards awaiting the owner's Complete tap were invisible — the needs-you lens showed approvals and questions but never finished work, so a done-and-attested card could sit unsealed for a day while silently blocking its dependents; and the dependent's blocked chip named no remedy.

## The served classification (disclosed predicate)

One daemon-side predicate, `item_owed_completion` (src/bin/caller/agenda/summary.rs), derived from served facts only. An item is **owed completion** exactly when:

- it is **open** and **not a question** (a question's owner gesture is Answer — already its own rail class);
- some live (non-withdrawn) effect's latest occurrence reached terminal `completed` **and** the fired session self-reported `achieved` (unattested or partial never counts — the Track AO absence law);
- **every** effect is settled: withdrawn husks aside, each is an approved **one-shot** whose firing reached terminal `completed` — nothing pending review, nothing standing (a recurrence or trigger manifest is a live automation, never "finished"), nothing armed or in flight;
- no **open question** references the item over the undirected `relates_to` union (the steward-gate shape; display-only — adjacency still evaluates/blocks/fires nothing);
- nothing **blocks** the item itself (an uncleared blocker or unmet prerequisite contradicts "fully finished").

Scope notes: effects-less items never qualify (the only terminal-success evidence in served data is an attested occurrence); spent standing series are conservatively excluded (their spent-ness needs planner/journal math, and a standing card is an automation carrier, not a finished seat card).

Served three ways from the one implementation (derive-don't-mirror): the summary flag `completable` (beside `blocked`/`frontier`), the full-grain `completable` decoration (the `next_fire_ms` pattern — absent-on-the-wire when false, so event-lane copies carry it fresh), and `blocked_on[].target_completable` on dependents' causes.

## Dashboard

- **[a] Rail class**: the Now lens gains a **Complete** group (between Approve and Suspended) filtered on the served flag; the lens badge and the graph lens's attention gravity count the same flag; open completable cards wear a `finished — tap Complete` chip. The tap is the existing status-circle Mark done — no new completion authority.
- **[b] Blocked chips name their remedy**: per-gate rows now read "waiting on: *title*" (linked — opens that card's pane) with "— complete it to proceed" on waits whose release is the target's completion (in-flight runs name no gesture — the run is doing the work), and "finished and awaiting Complete" + the Review & complete door when the daemon serves the target as owed completion. The client's old completed+achieved re-derivation is deleted — the delivered judgment reads the served flags (target row `completable`, or the served `blocked_on` cause for out-of-window targets, which also upgrades the old id-only degrade to served title/status).
- **[c] Live-repaint defect**: an `agenda_changed` event carries only the changed item, and the since-seq heal can't refresh untouched dependents (their ops never moved) — so a dependent's blocked chip persisted until reload when its target completed. Now: (1) event-adopted rows read `blocked` (blocked_on presence) and `completable` fresh from the served decoration instead of aging the replaced summary's flags; (2) a status/completable move on an item with loaded dependents schedules one coalesced (250 ms) **full summary re-pull** — a whole-visible-list repaint, chosen over per-row surgery because per-row would mean re-deriving the daemon's cross-item predicates client-side; the summary pull is the ruled Q4 freshness affordance.

## Pins ([d])

- `owed_completion_predicate_names_its_disqualifiers` — the predicate unit test (every clause has a named flip-off, and the served summary flag is asserted to BE the predicate);
- `blocked_on_marks_completable_targets` — the cause stamping, additive wire shape, and dependency-cycle finiteness;
- `owed_completion_surfaces_are_pinned_in_app_html` — rail-class parity + chip-copy needles (`finished — tap Complete`, `complete it to proceed`, `finished and awaiting Complete`) + the [c] repaint wiring needles, in the awaiting-pickup parity pattern.
- A live browser repaint assertion is not feasible in CI (the SPA probe harness `scripts/validate-dashboard.cjs` is out of CI and needs a live daemon); the repaint lane is pinned by needle and its inputs by the unit tests, and the QA vectors (`window.qa.agendaBlockedVectors`) now exercise the served-flag adoption including the out-of-window served-completable shape.

Docs: `docs/src/agenda-and-memory.md` blocked-presentation section updated + a new owed-completions paragraph.