### PR TITLE
Codex auth-lapse UX: named signed-out state + Vault sign-in routing instead of 401 stderr spam

### DIFF
--- a/crates/intendant-core/src/vitals.rs
+++ b/crates/intendant-core/src/vitals.rs
@@ -233,6 +233,23 @@ pub struct SessionActivityVitals {
     /// exactly when that list is non-empty.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub died_tasks_cause: Option<String>,
+    /// The named backend auth-failure state ("Codex is signed out — sign
+    /// in from the Vault tab"): published by the supervision seam when
+    /// the backend's own reported failure is auth-shaped (the 401 /
+    /// missing-credential family), never inferred from timing. Present
+    /// is an attention state — the raw failure lines stay in the
+    /// session log untouched; this is the one honest classification the
+    /// user-facing surfaces render instead. Cleared once the backend
+    /// demonstrably streams work again (the hub-side fold mirrors the
+    /// died-tasks rule).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_failure: Option<String>,
+    /// Canonical backend id (`"codex"`, `"claude-code"`, `"kimi"`,
+    /// `"pi"`) of the auth failure, so frontends can deep-link the
+    /// matching Vault sign-in card. Present exactly when `auth_failure`
+    /// is; absent when the failing backend could not be resolved.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_failure_backend: Option<String>,
 }
 
 /// Session configuration facts — model, reasoning effort, permission

--- a/src/bin/caller/external_agent/mod.rs
+++ b/src/bin/caller/external_agent/mod.rs
@@ -2730,8 +2730,12 @@ mod tests {
              www_authenticate_header: \"Bearer realm=\\\"OAuth\\\"\" })"
         ));
         // Generic transport failures are not the auth family.
-        assert!(!backend_auth_failure_line("failed to connect: connection refused"));
-        assert!(!backend_auth_failure_line("stream error: stream closed unexpectedly"));
+        assert!(!backend_auth_failure_line(
+            "failed to connect: connection refused"
+        ));
+        assert!(!backend_auth_failure_line(
+            "stream error: stream closed unexpectedly"
+        ));
         assert!(!backend_auth_failure_line("Round 1 complete (0 turns)"));
         // A 403 quota refusal is not a sign-in problem.
         assert!(!backend_auth_failure_line("HTTP error: 403 Forbidden"));

--- a/src/bin/caller/external_agent/mod.rs
+++ b/src/bin/caller/external_agent/mod.rs
@@ -436,6 +436,79 @@ pub(crate) fn stderr_line_level(line: &str) -> &'static str {
     }
 }
 
+/// The 401/auth family: does this backend-reported failure line mean the
+/// CLI's own credentials are absent, expired, or revoked? One classifier
+/// for every backend (the vocabulary is the union of what each CLI
+/// actually prints); the per-backend part of the surface is the copy in
+/// [`backend_auth_failure_copy`]. Deliberately needle-tight — a false
+/// positive here would rename a healthy round's error to "signed out",
+/// so generic transport noise ("failed to connect", "error") stays out.
+pub(crate) fn backend_auth_failure_line(line: &str) -> bool {
+    let lowered = line.to_ascii_lowercase();
+    // codex-cli's built-in MCP connectors log `AuthRequired` transport
+    // errors for every third-party connector (Linear, Asana, …) that
+    // isn't logged in, at every app-server spawn. That is churn about
+    // OTHER services' auth, never the backend's own — see
+    // `stderr_line_level`'s twin carve-out.
+    if lowered.contains("rmcp::transport::worker") {
+        return false;
+    }
+    // Observed vocabularies:
+    // - codex model-API websocket/HTTPS refusals: "401 Unauthorized" +
+    //   "Missing bearer or basic authentication in header" (specimen:
+    //   the 2026-08-07T00:00Z nightly, wss://…/v1/responses reconnect
+    //   storm ending "Round 1 complete (0 turns)").
+    // - codex CLI login status: "Not logged in".
+    // - Claude Code signed-out/expired: "Invalid API key · Please run
+    //   /login", "OAuth token has expired", and the Anthropic API's
+    //   "authentication_error" type.
+    lowered.contains("401 unauthorized")
+        || lowered.contains("missing bearer")
+        || lowered.contains("not logged in")
+        || lowered.contains("please run /login")
+        || lowered.contains("oauth token has expired")
+        || lowered.contains("invalid api key")
+        || lowered.contains("authentication_error")
+}
+
+/// The ONE named honest state for the auth family — per-backend
+/// vocabulary derived from the backend's display name, two flavors by
+/// what a credential-file probe found. `credential_file_missing` is
+/// `Some(true)` only when the CLI's on-disk login artifact is known
+/// absent (the sharpest message); `Some(false)`/`None` (file present, or
+/// out of stat's reach — Claude Code's macOS keychain) keep the
+/// signed-out flavor, which stays true for expired/revoked credentials
+/// behind an existing file.
+pub(crate) fn backend_auth_failure_copy(
+    display_name: &str,
+    credential_file_missing: Option<bool>,
+) -> String {
+    if credential_file_missing == Some(true) {
+        format!(
+            "{display_name} has no credentials on this daemon — sign in from the Vault tab, \
+             or renew its vault lease"
+        )
+    } else {
+        format!("{display_name} is signed out — sign in from the Vault tab")
+    }
+}
+
+/// Stat the backend CLI's own on-disk login artifact — the per-backend
+/// dispatch over the same probes `backend_availability` serves. `None`
+/// means the platform stores credentials out of stat's reach, so absence
+/// proves nothing. The probe reads the DAEMON's view of the home; a
+/// session running on a leased home is not distinguished here (the
+/// missing-file copy names the lease remedy alongside sign-in for
+/// exactly that reason).
+pub(crate) fn backend_local_login(backend: &AgentBackend, home: &Path) -> Option<bool> {
+    match backend {
+        AgentBackend::Codex => codex_local_login(home),
+        AgentBackend::ClaudeCode => claude_code_local_login(home),
+        AgentBackend::Kimi => kimi_local_login(home),
+        AgentBackend::Pi => pi_local_login(home),
+    }
+}
+
 /// Forward a spawned agent's stderr into the session activity stream as
 /// `AgentEvent::Log` entries. Every external backend previously inherited
 /// stderr into the daemon's own stderr, where nobody supervising from a
@@ -2617,6 +2690,98 @@ mod tests {
         assert_eq!(
             stderr_line_level("websocket handshake failed: 401 Unauthorized"),
             "error"
+        );
+    }
+
+    #[test]
+    fn auth_failure_line_classifies_the_401_family() {
+        // The live specimens from the 2026-08-07T00:00Z nightly (both the
+        // stderr and the wire-error shapes).
+        assert!(backend_auth_failure_line(
+            "[codex stderr] 2026-08-07T00:00:30.324066Z ERROR \
+             codex_api::endpoint::responses_websocket: failed to connect to websocket: \
+             HTTP error: 401 Unauthorized, url: wss://api.openai.com/v1/responses"
+        ));
+        assert!(backend_auth_failure_line(
+            "Reconnecting... 2/5\nunexpected status 401 Unauthorized: Missing bearer or basic \
+             authentication in header, url: wss://api.openai.com/v1/responses"
+        ));
+        // Codex login-status vocabulary.
+        assert!(backend_auth_failure_line("Not logged in"));
+        // Claude Code signed-out/expired vocabularies.
+        assert!(backend_auth_failure_line(
+            "Invalid API key \u{b7} Please run /login"
+        ));
+        assert!(backend_auth_failure_line(
+            "OAuth token has expired. Please obtain a new token or refresh your existing token."
+        ));
+        assert!(backend_auth_failure_line(
+            "{\"type\":\"error\",\"error\":{\"type\":\"authentication_error\"}}"
+        ));
+    }
+
+    #[test]
+    fn auth_failure_line_ignores_connector_churn_and_generic_noise() {
+        // rmcp MCP-connector churn mentions OTHER services' auth at every
+        // app-server spawn — never the backend's own credentials.
+        assert!(!backend_auth_failure_line(
+            "2026-08-07T00:00:27.021261Z ERROR rmcp::transport::worker: worker quit with \
+             fatal: Transport channel closed, when AuthRequired(AuthRequiredError { \
+             www_authenticate_header: \"Bearer realm=\\\"OAuth\\\"\" })"
+        ));
+        // Generic transport failures are not the auth family.
+        assert!(!backend_auth_failure_line("failed to connect: connection refused"));
+        assert!(!backend_auth_failure_line("stream error: stream closed unexpectedly"));
+        assert!(!backend_auth_failure_line("Round 1 complete (0 turns)"));
+        // A 403 quota refusal is not a sign-in problem.
+        assert!(!backend_auth_failure_line("HTTP error: 403 Forbidden"));
+    }
+
+    #[test]
+    fn auth_failure_copy_names_backend_and_flavor() {
+        // The named honest state, per-backend vocabulary from one
+        // builder (derive-don't-mirror): signed-out flavor when the
+        // credential file exists or is out of stat's reach…
+        assert_eq!(
+            backend_auth_failure_copy("Codex", Some(false)),
+            "Codex is signed out — sign in from the Vault tab"
+        );
+        assert_eq!(
+            backend_auth_failure_copy("Claude Code", None),
+            "Claude Code is signed out — sign in from the Vault tab"
+        );
+        // …and the sharper credential-file-missing flavor when the probe
+        // proves absence (the 2026-08-07T00:00Z nightly's actual state).
+        assert_eq!(
+            backend_auth_failure_copy("Codex", Some(true)),
+            "Codex has no credentials on this daemon — sign in from the Vault tab, or renew \
+             its vault lease"
+        );
+    }
+
+    #[test]
+    fn backend_local_login_dispatches_per_backend_probe() {
+        // Only the Claude Code arm is exercised directly: its probe reads
+        // no process environment, so the dispatch stays hermetic here.
+        // The env-honoring codex/kimi/pi probes carry their own `_in`
+        // injection tests.
+        let home = tempfile::tempdir().unwrap();
+        let expected_absent = if cfg!(target_os = "macos") {
+            // The macOS keychain keeps absence unprovable.
+            None
+        } else {
+            Some(false)
+        };
+        assert_eq!(
+            backend_local_login(&AgentBackend::ClaudeCode, home.path()),
+            expected_absent
+        );
+        let claude_dir = home.path().join(".claude");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        std::fs::write(claude_dir.join(".credentials.json"), "{}").unwrap();
+        assert_eq!(
+            backend_local_login(&AgentBackend::ClaudeCode, home.path()),
+            Some(true)
         );
     }
 

--- a/src/bin/caller/external_agent/mod.rs
+++ b/src/bin/caller/external_agent/mod.rs
@@ -3078,6 +3078,40 @@ mod tests {
         }
     }
 
+    /// The classified auth-failure surface, daemon → dashboard: the wire
+    /// fields this module's classifier feeds (`authFailure` /
+    /// `authFailureBackend` via the activity attention), the derived
+    /// `signed-out` display state, and the Vault routing — the per-card
+    /// deep-link anchor plus the `focusVaultAgentSignin(backendId)`
+    /// resolver that maps a canonical backend id to its sign-in card
+    /// through each provider spec's own `sessionKind` (derive-don't-
+    /// mirror). A bundle that loses any of these strands the named
+    /// state or dead-ends its button.
+    #[test]
+    fn spa_signed_out_state_routes_to_the_vault_signin_card() {
+        let app = include_str!("../../../../static/app.html");
+        for needle in [
+            // The derive + display state.
+            "activity.authFailure",
+            "activity.authFailureBackend",
+            "'signed-out'",
+            "⚠ Signed out",
+            // The one-tap remedy on the chip.
+            "label: 'Sign in from the Vault tab'",
+            "focusVaultAgentSignin(v.authBackend",
+            // The routing: backend id → provider card via sessionKind,
+            // and the per-card anchor the resolver scrolls to.
+            "function focusVaultAgentSignin(backendId)",
+            ".sessionKind === backendId",
+            "agent-signin-card-${provider}",
+        ] {
+            assert!(
+                app.contains(needle),
+                "the dashboard bundle lost the signed-out state wiring: {needle}"
+            );
+        }
+    }
+
     #[test]
     fn canonical_thread_ids_match_backend_capabilities() {
         assert!(AgentBackend::Codex.thread_id_is_canonical("019e37cf-34ad-7b08-8a1e-7ad5086eb39f"));

--- a/src/bin/caller/external_events.rs
+++ b/src/bin/caller/external_events.rs
@@ -332,6 +332,12 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
     // condition → `TransientRoundDeath`; permanent at zero turns →
     // `TurnFailed`; permanent after real work → the completion shape.
     let mut pending_fatal_round_error: Option<FatalRoundError> = None;
+    // Classify-once latch for the backend auth-failure family (the named
+    // "signed out — sign in from the Vault tab" state): a 401 reconnect
+    // storm spans many Log/BackendError events but the honest state is
+    // published exactly once per round; the latched copy also names the
+    // round outcome when the fatal cause is auth-shaped.
+    let mut backend_auth_noticed: Option<String> = None;
     let mut managed_context_rewind_only_pressure: Option<ManagedContextRewindOnlyPressure> = None;
     let mut managed_context_pressure_interrupt_sent = false;
     let managed_context_density_steer_suppressed = managed_context_recovery_kickstart
@@ -1607,6 +1613,10 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                 emit_external_session_goal(config, event_thread_id.clone(), None);
             }
             external_agent::AgentEvent::Log { level, message } => {
+                // Log truth first: every raw line (the 401 storms
+                // included) flows to the session log untouched…
+                let auth_shaped =
+                    event_is_primary && external_agent::backend_auth_failure_line(&message);
                 slog(config.session_log, |l| match level.as_str() {
                     "warn" => l.warn(&message),
                     "error" => l.error(&message),
@@ -1622,6 +1632,19 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                     content: message,
                     turn: None,
                 });
+                // …then the classification changes only the user-facing
+                // state: one named honest row + the sticky signed-out
+                // attention chip, per round.
+                if auth_shaped {
+                    note_backend_auth_failure(
+                        config.bus,
+                        config.session_log,
+                        &config.session_id,
+                        external_backend_of_config(config).as_ref(),
+                        agent.name(),
+                        &mut backend_auth_noticed,
+                    );
+                }
             }
             external_agent::AgentEvent::BackendError {
                 message,
@@ -1663,15 +1686,37 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                         l.error(&content);
                     }
                 });
+                // The auth family (401 / missing credentials) classifies
+                // to the ONE named honest state — emitted once per round,
+                // and it becomes the round's cause instead of the raw
+                // provider refusal, so the terminal reads "Codex is
+                // signed out — sign in from the Vault tab" rather than a
+                // reconnect-counter line. The raw content is already in
+                // the log rows above.
+                if event_is_primary && external_agent::backend_auth_failure_line(&message) {
+                    note_backend_auth_failure(
+                        config.bus,
+                        config.session_log,
+                        &config.session_id,
+                        external_backend_of_config(config).as_ref(),
+                        agent.name(),
+                        &mut backend_auth_noticed,
+                    );
+                }
                 // A fatal error the wrapper deems unrecoverable is the
                 // round's honest cause; recoverable ones resolve through
-                // the recovery precedence at the exit instead. The raw
-                // adapter message rides along so the error's own
-                // synthesized turn completion can be told apart from a
-                // real one.
+                // the recovery precedence at the exit instead. When the
+                // round already classified an auth failure, the latched
+                // named state IS the cause — the storm's final line (an
+                // `(other)` giving-up error) is its tail, not a new
+                // story. The raw adapter message rides along so the
+                // error's own synthesized turn completion can be told
+                // apart from a real one.
                 let fatal_round_error = (!will_retry && event_is_primary && !recovery_required)
                     .then(|| FatalRoundError {
-                        reason: content.clone(),
+                        reason: backend_auth_noticed
+                            .clone()
+                            .unwrap_or_else(|| content.clone()),
                         raw_message: message.clone(),
                     });
                 config.bus.send(AppEvent::LogEntry {
@@ -2752,20 +2797,22 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                     });
                 }
                 // A REAL completion inside the grace window supersedes a
-                // buffered fatal cause — the turn did land after all. The
-                // guard: an error result's own synthesized completion
-                // (Claude Code pushes `TurnCompleted` carrying the SAME
-                // result text right after the fatal `BackendError`, one
-                // wire line) is the error restated, not a recovery — it
-                // must leave the cause standing or the round-outcome
-                // classification never sees it (the 2026-07-29 specimens'
-                // exact silent path) and the zero-turn TurnFailed pin
-                // stays unreachable on the CC wire.
-                let completion_is_the_error_itself = pending_fatal_round_error
-                    .as_ref()
-                    .is_some_and(|fatal| message.as_deref() == Some(fatal.raw_message.as_str()));
+                // buffered fatal cause — the turn did land after all.
+                // Two shapes leave the cause standing (the rule is
+                // `real_completion_supersedes_fatal`, pinned in
+                // external_supervision's tests): the error's own
+                // synthesized completion (Claude Code restates the fatal
+                // result text as `TurnCompleted` — the 2026-07-29
+                // specimens' silent path), and a completion that landed
+                // NOTHING (codex's app-server exhausting its 401 retries
+                // and emitting a plain empty `turn/completed` — the
+                // 2026-08-07T00:00Z nightly's success-shaped terminal
+                // over a signed-out backend).
+                let fatal_superseded = pending_fatal_round_error.as_ref().is_none_or(|fatal| {
+                    real_completion_supersedes_fatal(fatal, message.as_deref(), turns_in_round)
+                });
                 pending_turn_completion = Some((message, turns_in_round));
-                if !completion_is_the_error_itself {
+                if fatal_superseded {
                     pending_fatal_round_error = None;
                 }
                 if active_side_turns.is_empty() {

--- a/src/bin/caller/external_events.rs
+++ b/src/bin/caller/external_events.rs
@@ -3734,6 +3734,140 @@ mod tests {
         }
     }
 
+    /// The 2026-08-07T00:00Z specimen wire shape (the nightly codex
+    /// digest, session 423b1400): a signed-out backend retries its 401s
+    /// on stderr and as retryable `BackendError`s, gives up with a fatal
+    /// `(other)` error, then the app-server emits a plain EMPTY
+    /// `turn/completed` — which previously washed out the fatal and
+    /// ended the round "Round 1 complete (0 turns)" over a dead backend.
+    /// The drain must classify the auth family once (the named
+    /// signed-out state), keep the fatal through the landed-nothing
+    /// completion, and fail the zero-turn round with the NAMED reason.
+    /// `agent_source` deliberately does not resolve to a backend so the
+    /// credential-file probe (a real-home stat, transport-edge only)
+    /// never runs in the test.
+    #[tokio::test]
+    async fn auth_storm_with_empty_completion_fails_the_round_with_the_named_state() {
+        let bus = EventBus::new();
+        let mut bus_rx_for_drain = bus.subscribe();
+        let dir = tempfile::tempdir().unwrap();
+        let log_dir = dir.path().join("session");
+        let session_log: SharedSessionLog = Arc::new(Mutex::new(
+            session_log::SessionLog::open(log_dir.clone()).unwrap(),
+        ));
+        let approval_registry: event::ApprovalRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let context_injection: event::ContextInjectionQueue = Arc::new(Mutex::new(Vec::new()));
+        let autonomy = autonomy::shared_autonomy(AutonomyState::default());
+        let config = DrainConfig {
+            bus: &bus,
+            web_port: None,
+            session_id: Some("codex-session".to_string()),
+            alias_session_id: None,
+            backend_thread_id: Some("codex-session".to_string()),
+            autonomy,
+            session_log: &session_log,
+            project_root: dir.path(),
+            log_dir: &log_dir,
+            approval_registry: &approval_registry,
+            json_approval: None,
+            agent_source: Some("worker".to_string()),
+            suppress_agent_started: false,
+            persist_model_responses_inline: true,
+            headless: true,
+            context_injection: &context_injection,
+            reload_credentials: None,
+            coordination_declaration: None,
+        };
+        let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
+        // The storm: a stderr row, a retryable wire error, the fatal
+        // giving-up error, then the empty completion.
+        event_tx
+            .send(external_agent::AgentEvent::Log {
+                level: "error".to_string(),
+                message: "[codex stderr] ERROR codex_api::endpoint::responses_websocket: \
+                          failed to connect to websocket: HTTP error: 401 Unauthorized, \
+                          url: wss://api.openai.com/v1/responses"
+                    .to_string(),
+            })
+            .unwrap();
+        event_tx
+            .send(external_agent::AgentEvent::BackendError {
+                message: "Reconnecting... 2/5\nunexpected status 401 Unauthorized: Missing \
+                          bearer or basic authentication in header"
+                    .to_string(),
+                code: Some("responseStreamDisconnected".to_string()),
+                details: None,
+                will_retry: true,
+                likely_generation_starvation: false,
+                recovery_hint: None,
+            })
+            .unwrap();
+        event_tx
+            .send(external_agent::AgentEvent::BackendError {
+                message: "unexpected status 401 Unauthorized: Missing bearer or basic \
+                          authentication in header"
+                    .to_string(),
+                code: Some("other".to_string()),
+                details: None,
+                will_retry: false,
+                likely_generation_starvation: false,
+                recovery_hint: None,
+            })
+            .unwrap();
+        event_tx
+            .send(external_agent::AgentEvent::TurnCompleted { message: None })
+            .unwrap();
+        drop(event_tx);
+
+        let interrupts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let steers = Arc::new(Mutex::new(Vec::new()));
+        let mut agent: Box<dyn external_agent::ExternalAgent> = Box::new(ManagedDrainTestAgent {
+            interrupts: interrupts.clone(),
+            steers: steers.clone(),
+        });
+        let mut stats = LoopStats::default();
+        let mut diff_tracker = ExternalDiffDeltaTracker::default();
+        let mut pending_runtime_steers = std::collections::VecDeque::new();
+        let mut handled_steer_ids = std::collections::HashSet::new();
+        let mut cancelled_follow_ups = HashSet::new();
+        let mut dedupe = CodexThreadActionDedupe::default();
+
+        let outcome = drain_external_agent_events(
+            &mut agent,
+            &mut event_rx,
+            &mut bus_rx_for_drain,
+            &config,
+            &mut stats,
+            &mut diff_tracker,
+            &mut pending_runtime_steers,
+            &mut handled_steer_ids,
+            &mut cancelled_follow_ups,
+            &mut dedupe,
+            None,
+            None,
+            false,
+            false,
+            false,
+        )
+        .await;
+        match outcome {
+            DrainOutcome::TurnFailed {
+                reason,
+                turns_in_round,
+            } => {
+                assert_eq!(turns_in_round, 0);
+                assert_eq!(
+                    reason, "Codex is signed out — sign in from the Vault tab",
+                    "the round's cause is the named honest state"
+                );
+            }
+            other => panic!(
+                "the auth storm's empty completion must not complete the round, got {}",
+                drain_outcome_name(&other)
+            ),
+        }
+    }
+
     /// The 2026-07-29 specimen wire shape (sessions 24f01636/13e53300,
     /// commission seats killed by provider API-500s): Claude Code ends
     /// an errored turn by emitting the fatal `BackendError` AND a

--- a/src/bin/caller/external_mode.rs
+++ b/src/bin/caller/external_mode.rs
@@ -819,6 +819,14 @@ pub(crate) async fn run_external_agent_mode(
     // past the bounded widening schedule the session suspends visibly
     // instead of parking again.
     let mut error_park_streak: u32 = 0;
+    // Classify-once latch for auth-shaped failure lines observed on the
+    // IDLE lane (the between-rounds twin of the drain's own per-round
+    // latch): a signed-out backend's stderr keeps arriving after the
+    // round ends — an app-server respawn re-prints its 401s — and the
+    // named honest state is published once per supervised session from
+    // this lane, not per line. The sticky vitals chip carries the state
+    // regardless; re-emission would add rows, not truth.
+    let mut idle_backend_auth_noticed: Option<String> = None;
     let mut parked_follow_ups: std::collections::VecDeque<FollowUpMessage> =
         std::collections::VecDeque::new();
     let mut managed_context_recovery_kickstarts_without_rewind = 0u8;
@@ -1581,6 +1589,14 @@ pub(crate) async fn run_external_agent_mode(
                                     // tools, plan/diff updates, turn completion) may fall
                                     // through to the observe drain below.
                                     external_agent::AgentEvent::Log { level, message } => {
+                                        // Log truth first (raw line kept),
+                                        // then the auth-family
+                                        // classification — the one named
+                                        // honest state instead of letting
+                                        // an idle 401 storm speak only in
+                                        // raw stderr rows.
+                                        let auth_shaped =
+                                            external_agent::backend_auth_failure_line(&message);
                                         slog(&session_log, |l| match level.as_str() {
                                             "warn" => l.warn(&message),
                                             "error" => l.error(&message),
@@ -1596,6 +1612,16 @@ pub(crate) async fn run_external_agent_mode(
                                             content: message,
                                             turn: None,
                                         });
+                                        if auth_shaped {
+                                            note_backend_auth_failure(
+                                                &bus,
+                                                &session_log,
+                                                &drain_config.session_id,
+                                                Some(&backend),
+                                                agent.name(),
+                                                &mut idle_backend_auth_noticed,
+                                            );
+                                        }
                                     }
                                     external_agent::AgentEvent::Usage { usage } => {
                                         bus.send(AppEvent::UsageSnapshot {
@@ -1736,6 +1762,16 @@ pub(crate) async fn run_external_agent_mode(
                                             content,
                                             turn: None,
                                         });
+                                        if external_agent::backend_auth_failure_line(&message) {
+                                            note_backend_auth_failure(
+                                                &bus,
+                                                &session_log,
+                                                &drain_config.session_id,
+                                                Some(&backend),
+                                                agent.name(),
+                                                &mut idle_backend_auth_noticed,
+                                            );
+                                        }
                                     }
                                     other => {
                                         let event_targets_primary = scoped_event_targets_config(

--- a/src/bin/caller/external_supervision.rs
+++ b/src/bin/caller/external_supervision.rs
@@ -2010,8 +2010,14 @@ pub(crate) fn note_backend_auth_failure(
             crate::external_agent::backend_local_login(backend, &platform::home_dir())
         })
         .map(|present| !present);
+    // The copy speaks in the backend's display vocabulary ("Codex",
+    // "Claude Code"), not the wire id — `display_name` is the fallback
+    // for lanes whose source never resolved to a known backend.
+    let display_name = backend
+        .map(|backend| backend.to_string())
+        .unwrap_or_else(|| display_name.to_string());
     let copy =
-        crate::external_agent::backend_auth_failure_copy(display_name, credential_file_missing);
+        crate::external_agent::backend_auth_failure_copy(&display_name, credential_file_missing);
     *noticed = Some(copy.clone());
     slog(session_log, |l| l.error(&copy));
     bus.send(AppEvent::LogEntry {

--- a/src/bin/caller/external_supervision.rs
+++ b/src/bin/caller/external_supervision.rs
@@ -1951,7 +1951,88 @@ pub(crate) fn died_tasks_attention_activity(
         background_tasks: Vec::new(),
         died_background_tasks,
         died_tasks_cause: Some(cause.to_string()),
+        auth_failure: None,
+        auth_failure_backend: None,
     }
+}
+
+/// The auth-failure attention snapshot — `died_tasks_attention_activity`'s
+/// auth twin: `Idle` is the honest machine-free state claim (this seam
+/// observed classified failure lines, not wire activity), and the auth
+/// fields are what make it an attention state on every vitals mirror.
+/// Carried across later machine publishes by
+/// `session_activity::fold_backend_auth_attention` until the backend
+/// demonstrably streams work again.
+pub(crate) fn backend_auth_failure_attention_activity(
+    copy: String,
+    backend_id: Option<String>,
+    now_epoch: u64,
+) -> crate::types::SessionActivityVitals {
+    crate::types::SessionActivityVitals {
+        state: crate::types::SessionActivityState::Idle,
+        since_epoch: now_epoch,
+        last_stream_byte_epoch: now_epoch,
+        stalled_after_seconds: None,
+        resets_at_epoch: None,
+        background_tasks: Vec::new(),
+        died_background_tasks: Vec::new(),
+        died_tasks_cause: None,
+        auth_failure: Some(copy),
+        auth_failure_backend: backend_id,
+    }
+}
+
+/// Classify-once emitter for the backend auth-failure family (the
+/// 2026-08-07T00:00Z nightly's fix): the raw 401/credential lines keep
+/// flowing to the session LOG untouched — log truth — while the
+/// user-facing surfaces get ONE named honest state ("Codex is signed out
+/// — sign in from the Vault tab"; credential-file-missing flavor when the
+/// probe can prove absence). Emits one error log row in Intendant's
+/// voice plus the sticky attention snapshot for the session chip, and
+/// latches the copy in `noticed` — the caller's per-lane dedup — so a
+/// reconnect storm classifies exactly once. Returns the latched copy for
+/// callers that also carry it into the round outcome.
+pub(crate) fn note_backend_auth_failure(
+    bus: &EventBus,
+    session_log: &SharedSessionLog,
+    live_session_id: &Option<String>,
+    backend: Option<&crate::external_agent::AgentBackend>,
+    display_name: &str,
+    noticed: &mut Option<String>,
+) -> String {
+    if let Some(copy) = noticed.as_ref() {
+        return copy.clone();
+    }
+    // Transport edge: the probe stats the daemon's view of the home; the
+    // classifier and copy stay pure and hermetically tested.
+    let credential_file_missing = backend
+        .and_then(|backend| {
+            crate::external_agent::backend_local_login(backend, &platform::home_dir())
+        })
+        .map(|present| !present);
+    let copy =
+        crate::external_agent::backend_auth_failure_copy(display_name, credential_file_missing);
+    *noticed = Some(copy.clone());
+    slog(session_log, |l| l.error(&copy));
+    bus.send(AppEvent::LogEntry {
+        session_id: live_session_id.clone(),
+        level: "error".to_string(),
+        source: "Intendant".to_string(),
+        content: copy.clone(),
+        turn: None,
+    });
+    bus.send(AppEvent::SessionActivity {
+        session_id: live_session_id.clone(),
+        activity: backend_auth_failure_attention_activity(
+            copy.clone(),
+            backend.map(|backend| backend.as_short_str().to_string()),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0),
+        ),
+    });
+    copy
 }
 
 /// The re-run OFFER a respawn lane appends to a continuation nudge it
@@ -2341,6 +2422,29 @@ pub(crate) struct FatalRoundError {
     pub(crate) raw_message: String,
 }
 
+/// Whether a REAL turn completion arriving inside the post-turn grace
+/// window supersedes a buffered fatal cause. Two shapes must leave the
+/// cause standing: the error's OWN synthesized completion (Claude Code
+/// restates the fatal result text as `TurnCompleted`, one wire line —
+/// the 2026-07-29 specimens), and a completion that landed NOTHING (no
+/// message text, zero completed turns) — the backend giving the turn up,
+/// not recovering from it. The codex 401 reconnect storm is the second
+/// shape live: the app-server exhausts its retries and emits a plain
+/// empty `turn/completed`, which used to wash out the fatal and end the
+/// round "Round 1 complete (0 turns)" — a success-shaped terminal over a
+/// signed-out backend (the 2026-08-07T00:00Z nightly). Real work — any
+/// message text or a completed turn — supersedes as before.
+pub(crate) fn real_completion_supersedes_fatal(
+    fatal: &FatalRoundError,
+    message: Option<&str>,
+    turns_in_round: usize,
+) -> bool {
+    let completion_is_the_error_itself = message == Some(fatal.raw_message.as_str());
+    let landed_nothing =
+        turns_in_round == 0 && message.is_none_or(|message| message.trim().is_empty());
+    !completion_is_the_error_itself && !landed_nothing
+}
+
 /// First line of a (possibly multi-line, JSON-bearing) backend error,
 /// truncated for one-row announcements. The full cause is already in the
 /// session log as the drain's own error row.
@@ -2547,6 +2651,43 @@ pub(crate) fn shared_codex_config_from_project(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The grace-window supersede rule: which REAL turn completions wash
+    /// out a buffered fatal cause. The two keep-the-cause shapes are the
+    /// CC error echo (same text restated as the completion) and the
+    /// landed-nothing giving-up completion (the codex 401-storm shape:
+    /// empty `turn/completed`, zero turns — previously "Round 1 complete
+    /// (0 turns)" over a signed-out backend).
+    #[test]
+    fn real_completion_supersede_rule_keeps_echoes_and_empty_giveups() {
+        let fatal = FatalRoundError {
+            reason: "Codex is signed out — sign in from the Vault tab".to_string(),
+            raw_message: "unexpected status 401 Unauthorized: Missing bearer or basic \
+                          authentication in header"
+                .to_string(),
+        };
+        // The error's own synthesized completion (CC restates the text).
+        assert!(!real_completion_supersedes_fatal(
+            &fatal,
+            Some(
+                "unexpected status 401 Unauthorized: Missing bearer or basic authentication \
+                 in header"
+            ),
+            0
+        ));
+        // The landed-nothing shapes: no message at zero turns (codex's
+        // empty giving-up completion), and a whitespace-only message.
+        assert!(!real_completion_supersedes_fatal(&fatal, None, 0));
+        assert!(!real_completion_supersedes_fatal(&fatal, Some("  "), 0));
+        // Real work supersedes: message text, or completed turns even
+        // without one (tool-only rounds report no closing message).
+        assert!(real_completion_supersedes_fatal(
+            &fatal,
+            Some("recovered and answered"),
+            0
+        ));
+        assert!(real_completion_supersedes_fatal(&fatal, None, 3));
+    }
 
     /// The park-then-die hold line: honest, greppable, and truthful with
     /// and without a carried reason.

--- a/src/bin/caller/session_activity.rs
+++ b/src/bin/caller/session_activity.rs
@@ -268,6 +268,12 @@ impl ActivityMachine {
             // and any later publish from a live machine clears it.
             died_background_tasks: Vec::new(),
             died_tasks_cause: None,
+            // Same doctrine for the auth-failure attention: published by
+            // the supervision drain that classified the backend's own
+            // failure lines (`external_supervision::note_backend_auth_failure`),
+            // carried hub-side by `fold_backend_auth_attention`.
+            auth_failure: None,
+            auth_failure_backend: None,
         }
     }
 
@@ -308,6 +314,40 @@ pub(crate) fn fold_died_tasks_attention(
             if !prev.died_background_tasks.is_empty() {
                 next.died_background_tasks = prev.died_background_tasks.clone();
                 next.died_tasks_cause = prev.died_tasks_cause.clone();
+            }
+        }
+    }
+    next
+}
+
+/// Hub-side sticky fold for the backend auth-failure attention fields
+/// (`auth_failure` / `auth_failure_backend`), the died-tasks fold's auth
+/// twin with one deliberate difference: the failing round itself keeps
+/// publishing turn states (`awaiting-api` while the CLI retries its 401s,
+/// then `idle` when the empty round settles), so quiet turn phases must
+/// not erase the claim either — only STREAMED work does. Response or
+/// reasoning bytes and running tools are possible only past the
+/// provider's auth gate, so those states are the demonstrable-recovery
+/// evidence; `awaiting-api`/`rate-limited`/`idle`/`stalled` publishes
+/// carry the attention forward. A retried sign-in shows as one honest
+/// signed-out chip until the backend actually streams again.
+pub(crate) fn fold_backend_auth_attention(
+    prev: Option<&SessionActivityVitals>,
+    mut next: SessionActivityVitals,
+) -> SessionActivityVitals {
+    if next.auth_failure.is_none()
+        && !matches!(
+            next.state,
+            SessionActivityState::Reasoning
+                | SessionActivityState::Responding
+                | SessionActivityState::ToolRunning
+                | SessionActivityState::ParkedOnTasks
+        )
+    {
+        if let Some(prev) = prev {
+            if prev.auth_failure.is_some() {
+                next.auth_failure = prev.auth_failure.clone();
+                next.auth_failure_backend = prev.auth_failure_backend.clone();
             }
         }
     }
@@ -775,6 +815,79 @@ mod tests {
         assert_eq!(folded, idle2);
     }
 
+    /// The auth twin's fold: the signed-out attention survives the
+    /// failing round's own quiet phases (awaiting-api while the CLI
+    /// retries its 401s, the idle settle, a rate-limit claim) and clears
+    /// only on STREAMED work — bytes past the provider's auth gate.
+    #[test]
+    fn auth_attention_folds_sticky_through_quiet_phases_and_clears_on_streamed_work() {
+        let signed_out = SessionActivityVitals {
+            state: SessionActivityState::Idle,
+            since_epoch: 100,
+            auth_failure: Some("Codex is signed out — sign in from the Vault tab".into()),
+            auth_failure_backend: Some("codex".into()),
+            ..Default::default()
+        };
+        // Quiet phases carry the claim: idle, stalled, awaiting-api (a
+        // retry round that has not proven auth yet).
+        for state in [
+            SessionActivityState::Idle,
+            SessionActivityState::Stalled,
+            SessionActivityState::AwaitingApi,
+            SessionActivityState::RateLimited,
+        ] {
+            let next = SessionActivityVitals {
+                state,
+                since_epoch: 200,
+                ..Default::default()
+            };
+            let folded = fold_backend_auth_attention(Some(&signed_out), next);
+            assert_eq!(
+                folded.auth_failure.as_deref(),
+                Some("Codex is signed out — sign in from the Vault tab"),
+                "{state:?} must carry the auth attention"
+            );
+            assert_eq!(folded.auth_failure_backend.as_deref(), Some("codex"));
+        }
+
+        // Streamed work — possible only past the auth gate — clears it.
+        for state in [
+            SessionActivityState::Reasoning,
+            SessionActivityState::Responding,
+            SessionActivityState::ToolRunning,
+            SessionActivityState::ParkedOnTasks,
+        ] {
+            let next = SessionActivityVitals {
+                state,
+                since_epoch: 300,
+                ..Default::default()
+            };
+            let folded = fold_backend_auth_attention(Some(&signed_out), next);
+            assert!(
+                folded.auth_failure.is_none(),
+                "{state:?} is demonstrable recovery"
+            );
+            assert!(folded.auth_failure_backend.is_none());
+        }
+
+        // A fresh claim in `next` wins over the carried one.
+        let refreshed = SessionActivityVitals {
+            state: SessionActivityState::Idle,
+            auth_failure: Some("Codex has no credentials on this daemon — sign in from the \
+                                Vault tab, or renew its vault lease"
+                .into()),
+            auth_failure_backend: Some("codex".into()),
+            ..Default::default()
+        };
+        let folded = fold_backend_auth_attention(Some(&signed_out), refreshed.clone());
+        assert_eq!(folded.auth_failure, refreshed.auth_failure);
+
+        // No previous attention → pass-through.
+        let idle = SessionActivityVitals::default();
+        let folded = fold_backend_auth_attention(None, idle.clone());
+        assert_eq!(folded, idle);
+    }
+
     #[test]
     fn wire_shape_serializes_kebab_states_and_camel_fields() {
         // The dashboard consumes these exact strings; pin them.
@@ -787,6 +900,8 @@ mod tests {
             background_tasks: vec!["cargo test".into()],
             died_background_tasks: Vec::new(),
             died_tasks_cause: None,
+            auth_failure: None,
+            auth_failure_backend: None,
         };
         let json = serde_json::to_string(&activity).expect("serializes");
         assert!(json.contains("\"state\":\"tool-running\""), "{json}");
@@ -802,6 +917,7 @@ mod tests {
         assert!(!quiet.contains("backgroundTasks"), "{quiet}");
         assert!(!quiet.contains("diedBackgroundTasks"), "{quiet}");
         assert!(!quiet.contains("diedTasksCause"), "{quiet}");
+        assert!(!quiet.contains("authFailure"), "{quiet}");
         // The died-with-restart attention snapshot's wire spelling is
         // what the dashboard keys the attention state on; pin it.
         let died = serde_json::to_string(&SessionActivityVitals {
@@ -817,6 +933,23 @@ mod tests {
         assert!(
             died.contains("\"diedTasksCause\":\"the credential-reload restart\""),
             "{died}"
+        );
+        // The auth-failure attention's wire spelling — the dashboard
+        // derives the `signed-out` display state from these; pin them.
+        let signed_out = serde_json::to_string(&SessionActivityVitals {
+            auth_failure: Some("Codex is signed out — sign in from the Vault tab".into()),
+            auth_failure_backend: Some("codex".into()),
+            ..SessionActivityVitals::default()
+        })
+        .expect("serializes");
+        assert!(
+            signed_out
+                .contains("\"authFailure\":\"Codex is signed out — sign in from the Vault tab\""),
+            "{signed_out}"
+        );
+        assert!(
+            signed_out.contains("\"authFailureBackend\":\"codex\""),
+            "{signed_out}"
         );
         for state in [
             SessionActivityState::Reasoning,

--- a/src/bin/caller/session_activity.rs
+++ b/src/bin/caller/session_activity.rs
@@ -873,9 +873,11 @@ mod tests {
         // A fresh claim in `next` wins over the carried one.
         let refreshed = SessionActivityVitals {
             state: SessionActivityState::Idle,
-            auth_failure: Some("Codex has no credentials on this daemon — sign in from the \
+            auth_failure: Some(
+                "Codex has no credentials on this daemon — sign in from the \
                                 Vault tab, or renew its vault lease"
-                .into()),
+                    .into(),
+            ),
             auth_failure_backend: Some("codex".into()),
             ..Default::default()
         };

--- a/src/bin/caller/session_vitals.rs
+++ b/src/bin/caller/session_vitals.rs
@@ -4872,6 +4872,10 @@ mod tests {
             "stalledAfterSeconds",
             "effort",
             "backgroundTasks",
+            // The classified backend auth-failure attention (the named
+            // "signed out — sign in from the Vault tab" state).
+            "authFailure",
+            "authFailureBackend",
             "model",
             "permissionMode",
             "permissionKind",
@@ -4902,7 +4906,8 @@ mod tests {
             );
         }
         // The wire spellings of the activity states the catalog renders —
-        // and the derived-only `stalled` — must all be explained.
+        // and the derived-only `stalled` / `died-tasks` / `signed-out` —
+        // must all be explained.
         for state in [
             "reasoning",
             "responding",
@@ -4911,6 +4916,8 @@ mod tests {
             "parked-on-tasks",
             "rate-limited",
             "stalled",
+            "died-tasks",
+            "signed-out",
         ] {
             assert!(
                 catalog.contains(state),

--- a/src/bin/caller/session_vitals.rs
+++ b/src/bin/caller/session_vitals.rs
@@ -1377,14 +1377,22 @@ pub(crate) fn spawn_cache_vitals_listener(
                     activity,
                 }) => {
                     hub.apply(&session_id, |vitals| {
-                        // Sticky died-with-restart attention: a respawned
-                        // backend's fresh machine settling to idle knows
-                        // nothing of its predecessor's task deaths; only
-                        // demonstrable work clears the attention fields
-                        // (see `session_activity::fold_died_tasks_attention`).
-                        vitals.activity = Some(crate::session_activity::fold_died_tasks_attention(
+                        // Sticky attention folds: a respawned backend's
+                        // fresh machine settling to idle knows nothing of
+                        // its predecessor's task deaths, and a failing
+                        // round's own turn-state publishes know nothing
+                        // of the classified auth failure; only
+                        // demonstrable work clears each family's fields
+                        // (see `session_activity::fold_died_tasks_attention`
+                        // / `fold_backend_auth_attention` for the
+                        // per-family evidence rules).
+                        let folded = crate::session_activity::fold_died_tasks_attention(
                             vitals.activity.as_ref(),
                             activity,
+                        );
+                        vitals.activity = Some(crate::session_activity::fold_backend_auth_attention(
+                            vitals.activity.as_ref(),
+                            folded,
                         ));
                     });
                 }

--- a/src/bin/caller/session_vitals.rs
+++ b/src/bin/caller/session_vitals.rs
@@ -1390,10 +1390,11 @@ pub(crate) fn spawn_cache_vitals_listener(
                             vitals.activity.as_ref(),
                             activity,
                         );
-                        vitals.activity = Some(crate::session_activity::fold_backend_auth_attention(
-                            vitals.activity.as_ref(),
-                            folded,
-                        ));
+                        vitals.activity =
+                            Some(crate::session_activity::fold_backend_auth_attention(
+                                vitals.activity.as_ref(),
+                                folded,
+                            ));
                     });
                 }
                 Ok(AppEvent::SessionConfigFacts {

--- a/static/app.html
+++ b/static/app.html
@@ -39165,7 +39165,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'fbefe0551640bc87';
+const INTENDANT_APP_BUILD = '2daf5738b898cf91';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -45587,6 +45587,9 @@ function agentSigninProviderCard(provider) {
   const state = agentSigninState[provider];
   const card = document.createElement('div');
   card.className = `vault-card agent-signin agent-signin-${provider}`;
+  // Deep-link anchor: the signed-out attention state's "Sign in from the
+  // Vault tab" action (focusVaultAgentSignin) scrolls to this exact card.
+  card.id = `agent-signin-card-${provider}`;
 
   const note = (text, cls = 'vault-note') => {
     const el = document.createElement('div');
@@ -64499,6 +64502,30 @@ function deriveSessionActivity(activity, nowSec = Date.now() / 1000) {
   if (!activity || typeof activity !== 'object') return null;
   const state = String(activity.state || 'idle').trim();
   const since = Number(activity.sinceEpoch) || 0;
+  // The classified backend auth failure (wire `authFailure` +
+  // `authFailureBackend`): the daemon publishes the ONE named honest
+  // state ("Codex is signed out — sign in from the Vault tab") when the
+  // backend's own failure lines are auth-shaped, and the hub's sticky
+  // fold clears it only once the backend demonstrably streams again —
+  // so whenever the field is present, `signed-out` outranks the quiet
+  // state it rides (idle, stalled, awaiting-api): those are the storm's
+  // phases, not the story.
+  const authFailure = String(activity.authFailure || '').trim();
+  if (authFailure) {
+    return {
+      state: 'signed-out',
+      rawState: state,
+      elapsed: since ? Math.max(0, nowSec - since) : 0,
+      quiet: 0,
+      hasHeartbeat: false,
+      resetsAtEpoch: 0,
+      backgroundTasks: [],
+      diedTasks: [],
+      diedCause: '',
+      authFailure,
+      authBackend: String(activity.authFailureBackend || '').trim(),
+    };
+  }
   // Background tasks that DIED with a backend restart (wire
   // `diedBackgroundTasks` + `diedTasksCause`): the daemon publishes them
   // on an honest `idle` (nothing is running), and the dashboard derives
@@ -64520,6 +64547,8 @@ function deriveSessionActivity(activity, nowSec = Date.now() / 1000) {
       backgroundTasks: [],
       diedTasks,
       diedCause: String(activity.diedTasksCause || '').trim() || 'a backend restart',
+      authFailure: '',
+      authBackend: '',
     };
   }
   const lastByte = Number(activity.lastStreamByteEpoch) || 0;
@@ -64542,6 +64571,8 @@ function deriveSessionActivity(activity, nowSec = Date.now() / 1000) {
       : [],
     diedTasks: [],
     diedCause: '',
+    authFailure: '',
+    authBackend: '',
   };
 }
 
@@ -64570,6 +64601,7 @@ const ACTIVITY_STATE_LABELS = {
   'rate-limited': 'Rate-limited',
   stalled: 'Stalled',
   'died-tasks': 'Task died',
+  'signed-out': 'Signed out',
 };
 
 // Status-pill label for a parked session: plain words, with the count the
@@ -64591,6 +64623,14 @@ function sessionDiedTasksPillLabel(act) {
   if (!act || act.state !== 'died-tasks') return '';
   const n = (act.diedTasks || []).length;
   return n === 1 ? 'Task died with restart' : `${n} tasks died with restart`;
+}
+
+// Status-pill label for the classified auth-failure attention state: the
+// backend is signed out and the remedy is one tap away on the activity
+// chip — the pill names the problem instead of a bare "Idle".
+function sessionSignedOutPillLabel(act) {
+  if (!act || act.state !== 'signed-out') return '';
+  return 'Signed out';
 }
 
 function formatActivityElapsed(seconds) {
@@ -64782,6 +64822,7 @@ const VITALS_SYMBOLS = {
       stalled: 'clock',
       'rate-limited': 'slash',
       'died-tasks': 'triangle',
+      'signed-out': 'triangle',
     }[v.state] || 'clock'),
     chip: (v) => {
       if (v.state === 'reasoning') return `🧠 Thinking${v.effort ? ` · ${v.effort}` : ''} · ${v.elapsedText}`;
@@ -64796,6 +64837,7 @@ const VITALS_SYMBOLS = {
           ? `⚠ Task died · ${v.diedCause}`
           : `⚠ ${v.diedCount} tasks died · ${v.diedCause}`;
       }
+      if (v.state === 'signed-out') return '⚠ Signed out';
       return `${ACTIVITY_STATE_LABELS[v.state] || v.state} · ${v.elapsedText}`;
     },
     explain: (v) => {
@@ -64857,6 +64899,12 @@ const VITALS_SYMBOLS = {
         );
         return lines;
       }
+      if (v.state === 'signed-out') {
+        return [
+          v.authFailure || 'This agent’s backend is signed out — sign in from the Vault tab.',
+          'The raw failure lines are in the session log; nothing will work until the account is signed in again (or its vault lease renewed).',
+        ];
+      }
       return [`The model reports “${v.state}”.`];
     },
     // Short attention phrase for the health verdict's culprit list —
@@ -64869,12 +64917,20 @@ const VITALS_SYMBOLS = {
           ? `A background task died with ${v.diedCause} — re-run is one tap away`
           : `${v.diedCount} background tasks died with ${v.diedCause} — re-run is one tap away`;
       }
+      if (v.state === 'signed-out') return v.authFailure || 'Backend signed out — sign in from the Vault tab';
       return '';
     },
     // The one-tap re-run: an OWNER action that asks the session (a
     // normal follow-up through the existing lane) — the daemon never
-    // re-executes a died command itself.
+    // re-executes a died command itself. The signed-out state's one tap
+    // routes to the Vault sign-in card instead (the classified remedy).
     action: (v, sessionId) => {
+      if (v.state === 'signed-out') {
+        return {
+          label: 'Sign in from the Vault tab',
+          run: () => focusVaultAgentSignin(v.authBackend || undefined),
+        };
+      }
       if (v.state !== 'died-tasks' || !(v.diedTasks || []).length) return null;
       return {
         label: v.diedCount === 1 ? 'Ask the session to re-run it' : 'Ask the session to re-run them',
@@ -65494,15 +65550,18 @@ function vitalsChipModels(vitals, meta, sessionId) {
       diedTasks: act.diedTasks || [],
       diedCount: (act.diedTasks || []).length,
       diedCause: act.diedCause || '',
+      authFailure: act.authFailure || '',
+      authBackend: act.authBackend || '',
     }, {
       // Calm while genuinely working (parked included — waiting on its
       // own background work is normal); attention (health dot) for
-      // stalled, rate-limited, and died-tasks — the states that mean
-      // "waiting on something other than the model's own work" (and for
-      // died-tasks, a wait that already ended without its work).
-      severity: act.state === 'stalled' || act.state === 'rate-limited' || act.state === 'died-tasks' ? 'warn' : '',
+      // stalled, rate-limited, died-tasks, and signed-out — the states
+      // that mean "waiting on something other than the model's own
+      // work" (and for died-tasks/signed-out, a wait that will not end
+      // by itself).
+      severity: act.state === 'stalled' || act.state === 'rate-limited' || act.state === 'died-tasks' || act.state === 'signed-out' ? 'warn' : '',
       ticking: true,
-      sig: `${act.state}|${factsEffort}|${act.hasHeartbeat ? 1 : 0}|${act.backgroundTasks.join(';')}|${(act.diedTasks || []).join(';')}|${act.diedCause || ''}`,
+      sig: `${act.state}|${factsEffort}|${act.hasHeartbeat ? 1 : 0}|${act.backgroundTasks.join(';')}|${(act.diedTasks || []).join(';')}|${act.diedCause || ''}|${act.authFailure || ''}`,
     });
   }
 
@@ -73693,6 +73752,12 @@ function sessionWindowPhaseDisplayLabel(sessionId, phase) {
       if (typeof sessionDiedTasksPillLabel === 'function') {
         const died = sessionDiedTasksPillLabel(act);
         if (died) return died;
+      }
+      // The classified auth failure: "Signed out" instead of a bare
+      // "Idle" — the Vault sign-in remedy is one tap away on the chip.
+      if (typeof sessionSignedOutPillLabel === 'function') {
+        const signedOut = sessionSignedOutPillLabel(act);
+        if (signedOut) return signedOut;
       }
     }
   }
@@ -110862,9 +110927,26 @@ window.focusSettingsApiKeys = focusSettingsApiKeys;
 // coding-agent CLI into its subscription account is a first-class
 // alternative to adding a provider API key. Bridged onto window like
 // focusSettingsApiKeys, for inline handlers and the validate harness.
-function focusVaultAgentSignin() {
+// `backendId` (optional) is the daemon's canonical backend id ("codex",
+// "claude-code", "kimi") — resolved to the matching sign-in card via
+// each provider spec's own `sessionKind` (derive-don't-mirror; the
+// signed-out attention state passes `authFailureBackend` through here).
+// Unknown/absent ids keep the section-head landing.
+function focusVaultAgentSignin(backendId) {
   routeTo('vault');
   requestAnimationFrame(() => {
+    // Resolve inside the rAF: the pane is display:none until switchTab
+    // runs, and the cards rebuild on every render.
+    if (backendId && typeof AGENT_SIGNIN_PROVIDERS === 'object') {
+      const provider = Object.keys(AGENT_SIGNIN_PROVIDERS).find(
+        key => AGENT_SIGNIN_PROVIDERS[key]?.sessionKind === backendId,
+      );
+      const card = provider && document.getElementById(`agent-signin-card-${provider}`);
+      if (card?.scrollIntoView) {
+        card.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        return;
+      }
+    }
     // Scroll to the section head so its title stays visible (the head is
     // the sign-in mount's previous sibling after the ui-v2 adoption).
     const section = document.getElementById('agent-signin-section');

--- a/static/app/32-vault-custody.js
+++ b/static/app/32-vault-custody.js
@@ -2285,6 +2285,9 @@ function agentSigninProviderCard(provider) {
   const state = agentSigninState[provider];
   const card = document.createElement('div');
   card.className = `vault-card agent-signin agent-signin-${provider}`;
+  // Deep-link anchor: the signed-out attention state's "Sign in from the
+  // Vault tab" action (focusVaultAgentSignin) scrolls to this exact card.
+  card.id = `agent-signin-card-${provider}`;
 
   const note = (text, cls = 'vault-note') => {
     const el = document.createElement('div');

--- a/static/app/39-session-windows.js
+++ b/static/app/39-session-windows.js
@@ -1610,6 +1610,30 @@ function deriveSessionActivity(activity, nowSec = Date.now() / 1000) {
   if (!activity || typeof activity !== 'object') return null;
   const state = String(activity.state || 'idle').trim();
   const since = Number(activity.sinceEpoch) || 0;
+  // The classified backend auth failure (wire `authFailure` +
+  // `authFailureBackend`): the daemon publishes the ONE named honest
+  // state ("Codex is signed out — sign in from the Vault tab") when the
+  // backend's own failure lines are auth-shaped, and the hub's sticky
+  // fold clears it only once the backend demonstrably streams again —
+  // so whenever the field is present, `signed-out` outranks the quiet
+  // state it rides (idle, stalled, awaiting-api): those are the storm's
+  // phases, not the story.
+  const authFailure = String(activity.authFailure || '').trim();
+  if (authFailure) {
+    return {
+      state: 'signed-out',
+      rawState: state,
+      elapsed: since ? Math.max(0, nowSec - since) : 0,
+      quiet: 0,
+      hasHeartbeat: false,
+      resetsAtEpoch: 0,
+      backgroundTasks: [],
+      diedTasks: [],
+      diedCause: '',
+      authFailure,
+      authBackend: String(activity.authFailureBackend || '').trim(),
+    };
+  }
   // Background tasks that DIED with a backend restart (wire
   // `diedBackgroundTasks` + `diedTasksCause`): the daemon publishes them
   // on an honest `idle` (nothing is running), and the dashboard derives
@@ -1631,6 +1655,8 @@ function deriveSessionActivity(activity, nowSec = Date.now() / 1000) {
       backgroundTasks: [],
       diedTasks,
       diedCause: String(activity.diedTasksCause || '').trim() || 'a backend restart',
+      authFailure: '',
+      authBackend: '',
     };
   }
   const lastByte = Number(activity.lastStreamByteEpoch) || 0;
@@ -1653,6 +1679,8 @@ function deriveSessionActivity(activity, nowSec = Date.now() / 1000) {
       : [],
     diedTasks: [],
     diedCause: '',
+    authFailure: '',
+    authBackend: '',
   };
 }
 
@@ -1681,6 +1709,7 @@ const ACTIVITY_STATE_LABELS = {
   'rate-limited': 'Rate-limited',
   stalled: 'Stalled',
   'died-tasks': 'Task died',
+  'signed-out': 'Signed out',
 };
 
 // Status-pill label for a parked session: plain words, with the count the
@@ -1702,6 +1731,14 @@ function sessionDiedTasksPillLabel(act) {
   if (!act || act.state !== 'died-tasks') return '';
   const n = (act.diedTasks || []).length;
   return n === 1 ? 'Task died with restart' : `${n} tasks died with restart`;
+}
+
+// Status-pill label for the classified auth-failure attention state: the
+// backend is signed out and the remedy is one tap away on the activity
+// chip — the pill names the problem instead of a bare "Idle".
+function sessionSignedOutPillLabel(act) {
+  if (!act || act.state !== 'signed-out') return '';
+  return 'Signed out';
 }
 
 function formatActivityElapsed(seconds) {
@@ -1893,6 +1930,7 @@ const VITALS_SYMBOLS = {
       stalled: 'clock',
       'rate-limited': 'slash',
       'died-tasks': 'triangle',
+      'signed-out': 'triangle',
     }[v.state] || 'clock'),
     chip: (v) => {
       if (v.state === 'reasoning') return `🧠 Thinking${v.effort ? ` · ${v.effort}` : ''} · ${v.elapsedText}`;
@@ -1907,6 +1945,7 @@ const VITALS_SYMBOLS = {
           ? `⚠ Task died · ${v.diedCause}`
           : `⚠ ${v.diedCount} tasks died · ${v.diedCause}`;
       }
+      if (v.state === 'signed-out') return '⚠ Signed out';
       return `${ACTIVITY_STATE_LABELS[v.state] || v.state} · ${v.elapsedText}`;
     },
     explain: (v) => {
@@ -1968,6 +2007,12 @@ const VITALS_SYMBOLS = {
         );
         return lines;
       }
+      if (v.state === 'signed-out') {
+        return [
+          v.authFailure || 'This agent’s backend is signed out — sign in from the Vault tab.',
+          'The raw failure lines are in the session log; nothing will work until the account is signed in again (or its vault lease renewed).',
+        ];
+      }
       return [`The model reports “${v.state}”.`];
     },
     // Short attention phrase for the health verdict's culprit list —
@@ -1980,12 +2025,20 @@ const VITALS_SYMBOLS = {
           ? `A background task died with ${v.diedCause} — re-run is one tap away`
           : `${v.diedCount} background tasks died with ${v.diedCause} — re-run is one tap away`;
       }
+      if (v.state === 'signed-out') return v.authFailure || 'Backend signed out — sign in from the Vault tab';
       return '';
     },
     // The one-tap re-run: an OWNER action that asks the session (a
     // normal follow-up through the existing lane) — the daemon never
-    // re-executes a died command itself.
+    // re-executes a died command itself. The signed-out state's one tap
+    // routes to the Vault sign-in card instead (the classified remedy).
     action: (v, sessionId) => {
+      if (v.state === 'signed-out') {
+        return {
+          label: 'Sign in from the Vault tab',
+          run: () => focusVaultAgentSignin(v.authBackend || undefined),
+        };
+      }
       if (v.state !== 'died-tasks' || !(v.diedTasks || []).length) return null;
       return {
         label: v.diedCount === 1 ? 'Ask the session to re-run it' : 'Ask the session to re-run them',
@@ -2605,15 +2658,18 @@ function vitalsChipModels(vitals, meta, sessionId) {
       diedTasks: act.diedTasks || [],
       diedCount: (act.diedTasks || []).length,
       diedCause: act.diedCause || '',
+      authFailure: act.authFailure || '',
+      authBackend: act.authBackend || '',
     }, {
       // Calm while genuinely working (parked included — waiting on its
       // own background work is normal); attention (health dot) for
-      // stalled, rate-limited, and died-tasks — the states that mean
-      // "waiting on something other than the model's own work" (and for
-      // died-tasks, a wait that already ended without its work).
-      severity: act.state === 'stalled' || act.state === 'rate-limited' || act.state === 'died-tasks' ? 'warn' : '',
+      // stalled, rate-limited, died-tasks, and signed-out — the states
+      // that mean "waiting on something other than the model's own
+      // work" (and for died-tasks/signed-out, a wait that will not end
+      // by itself).
+      severity: act.state === 'stalled' || act.state === 'rate-limited' || act.state === 'died-tasks' || act.state === 'signed-out' ? 'warn' : '',
       ticking: true,
-      sig: `${act.state}|${factsEffort}|${act.hasHeartbeat ? 1 : 0}|${act.backgroundTasks.join(';')}|${(act.diedTasks || []).join(';')}|${act.diedCause || ''}`,
+      sig: `${act.state}|${factsEffort}|${act.hasHeartbeat ? 1 : 0}|${act.backgroundTasks.join(';')}|${(act.diedTasks || []).join(';')}|${act.diedCause || ''}|${act.authFailure || ''}`,
     });
   }
 

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -572,6 +572,12 @@ function sessionWindowPhaseDisplayLabel(sessionId, phase) {
         const died = sessionDiedTasksPillLabel(act);
         if (died) return died;
       }
+      // The classified auth failure: "Signed out" instead of a bare
+      // "Idle" — the Vault sign-in remedy is one tap away on the chip.
+      if (typeof sessionSignedOutPillLabel === 'function') {
+        const signedOut = sessionSignedOutPillLabel(act);
+        if (signedOut) return signedOut;
+      }
     }
   }
   if (isAgentActivePhase(p) && canDerive) {

--- a/static/app/48-router-settings.js
+++ b/static/app/48-router-settings.js
@@ -670,9 +670,26 @@ window.focusSettingsApiKeys = focusSettingsApiKeys;
 // coding-agent CLI into its subscription account is a first-class
 // alternative to adding a provider API key. Bridged onto window like
 // focusSettingsApiKeys, for inline handlers and the validate harness.
-function focusVaultAgentSignin() {
+// `backendId` (optional) is the daemon's canonical backend id ("codex",
+// "claude-code", "kimi") — resolved to the matching sign-in card via
+// each provider spec's own `sessionKind` (derive-don't-mirror; the
+// signed-out attention state passes `authFailureBackend` through here).
+// Unknown/absent ids keep the section-head landing.
+function focusVaultAgentSignin(backendId) {
   routeTo('vault');
   requestAnimationFrame(() => {
+    // Resolve inside the rAF: the pane is display:none until switchTab
+    // runs, and the cards rebuild on every render.
+    if (backendId && typeof AGENT_SIGNIN_PROVIDERS === 'object') {
+      const provider = Object.keys(AGENT_SIGNIN_PROVIDERS).find(
+        key => AGENT_SIGNIN_PROVIDERS[key]?.sessionKind === backendId,
+      );
+      const card = provider && document.getElementById(`agent-signin-card-${provider}`);
+      if (card?.scrollIntoView) {
+        card.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        return;
+      }
+    }
     // Scroll to the section head so its title stays visible (the head is
     // the sign-in mount's previous sibling after the ui-v2 adoption).
     const section = document.getElementById('agent-signin-section');

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -10385,3 +10385,91 @@ async fn capacity_bound_refuses_forks_and_queues_creates_until_headroom() {
         .to_string();
     complete_and_stop_session(&mut ws, &queued_id, &daemon_log).await;
 }
+
+/// The auth-lapse classification end to end (card 01KZCSD1972XYH1PVKZ9A91WN9,
+/// the 2026-08-07T00:00Z nightly): a fake claude whose only output is an
+/// auth-shaped failure — a 401 stderr line plus the error result envelope —
+/// must surface the ONE named honest state ("… sign in from the Vault tab",
+/// with the credential-file-missing flavor where the probe can prove
+/// absence) while the raw lines keep flowing to the session log, and the
+/// zero-turn round must end FAILED with the named reason instead of a
+/// success-shaped completion. Unix-only for the /bin/sh fake; the
+/// classifier, copy, fold, and supersede rules carry platform-neutral
+/// unit pins.
+#[cfg(unix)]
+#[tokio::test]
+async fn backend_auth_failure_classifies_to_the_named_signed_out_state() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let rig = TestRig::new();
+    rig.write_script(&serde_json::json!({ "profiles": [] }));
+
+    // The fake claude: answer the first turn with a 401 stderr line (the
+    // reconnect-storm shape) and the auth-error result envelope, then
+    // stay alive reading stdin — the round must die on the CLASSIFIED
+    // fatal through the grace path, not on a process-exit terminal
+    // racing it.
+    let fake = rig.home.path().join("fake-claude.sh");
+    std::fs::write(
+        &fake,
+        concat!(
+            "#!/bin/sh\n",
+            "SID=\"21111111-2222-4333-8444-555555555555\"\n",
+            "read -r _line || exit 1\n",
+            "printf '{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"%s\",\"model\":\"fake-sonnet\",\"permissionMode\":\"default\",\"tools\":[],\"cwd\":\".\"}\\n' \"$SID\"\n",
+            "echo 'failed to connect to websocket: HTTP error: 401 Unauthorized, url: wss://api.example.com/v1/responses' >&2\n",
+            "printf '{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":true,\"result\":\"unexpected status 401 Unauthorized: Missing bearer or basic authentication in header\",\"session_id\":\"%s\"}\\n' \"$SID\"\n",
+            "while read -r _line; do :; done\n",
+        ),
+    )
+    .expect("write fake claude");
+    std::fs::set_permissions(&fake, std::fs::Permissions::from_mode(0o755))
+        .expect("chmod fake claude");
+
+    std::fs::write(
+        rig.project.path().join("intendant.toml"),
+        format!("[agent.claude_code]\ncommand = \"{}\"\n", fake.display()),
+    )
+    .expect("write project config");
+
+    let mut cmd = rig.command();
+    cmd.stdin(Stdio::piped()).args([
+        "--no-web",
+        "--json",
+        "--agent",
+        "claude-code",
+        "auth lapse task",
+    ]);
+    let mut child = cmd.spawn().expect("spawn intendant");
+    let _stdin = child.stdin.take().expect("piped stdin");
+
+    let logs = poll_until(
+        "the named signed-out state and the failed terminal",
+        RUN_TIMEOUT,
+        || async {
+            let logs = rig.session_logs();
+            (logs.contains("sign in from the Vault tab")
+                && logs.contains("External agent round failed before any turn completed"))
+            .then_some(logs)
+        },
+        || tail(&rig.session_logs(), 4000),
+    )
+    .await;
+
+    // Log truth untouched: the raw 401 lines (stderr and the wire error)
+    // still flow to the session log alongside the classification.
+    assert!(
+        logs.contains("401 Unauthorized"),
+        "raw auth lines must stay in the session log:\n{}",
+        tail(&logs, 4000)
+    );
+    // The named copy is the round's honest cause (not the raw refusal):
+    // the failed-terminal row carries it.
+    assert!(
+        logs.contains("External agent round failed before any turn completed: Claude Code"),
+        "the failed terminal must carry the named signed-out reason:\n{}",
+        tail(&logs, 4000)
+    );
+
+    child.kill().await.ok();
+}


### PR DESCRIPTION
A nightly codex session that fired with lapsed credentials surfaced only raw stderr — 15+ repeated `401 Unauthorized … wss://api.openai.com/v1/responses` reconnect lines — and then ended with a success-shaped `Round 1 complete (0 turns)`. Nothing named the actual problem or the remedy. (Card 01KZCSD1972XYH1PVKZ9A91WN9.)

## The classification (one classifier, per-backend vocabulary)

- `backend_auth_failure_line` (external_agent/mod.rs): the 401/auth needle family — `401 Unauthorized`, `Missing bearer`, `Not logged in`, `Please run /login`, `OAuth token has expired`, `invalid api key`, `authentication_error` — with the rmcp MCP-connector churn explicitly excluded (those `AuthRequired` lines are about third-party connectors, never the backend's own auth).
- `backend_auth_failure_copy`: the ONE named honest state, in the backend's display vocabulary — `Codex is signed out — sign in from the Vault tab`, with the sharper credential-file-missing flavor (`… has no credentials on this daemon — sign in from the Vault tab, or renew its vault lease`) when the per-backend on-disk probe (`backend_local_login`) can prove absence.
- `note_backend_auth_failure` (external_supervision.rs): classify-once emitter, latched per lane — one error row in Intendant's voice plus a sticky `authFailure`/`authFailureBackend` activity attention (the died-tasks pattern). Wired into both drains' `Log` and `BackendError` arms (external_events.rs primary; external_mode.rs idle). **The raw stderr/wire lines keep flowing to the session log untouched** — the classification changes only the user-facing state.
- Round honesty: `real_completion_supersedes_fatal` — the app-server's empty giving-up `turn/completed` (no message, zero turns) no longer washes out the buffered fatal cause, so the zero-turn auth round ends `TurnFailed` with the named reason (feeding the agenda scheduler's failure streaks) instead of a DoneSignal. When the round classified an auth failure, the fatal's reason IS the named state.
- Sticky fold: `fold_backend_auth_attention` carries the attention through the storm's own quiet phases (awaiting-api retries, idle settle, rate-limited) and clears it only on streamed work — bytes past the provider's auth gate.

## The button

- The dashboard derives a `signed-out` activity state from `authFailure` (chip `⚠ Signed out`, status pill, health culprit, explainer carrying the full copy), whose one-tap action is **Sign in from the Vault tab** → `focusVaultAgentSignin(backendId)`.
- The helper now resolves the exact sign-in card: backend id → provider via each spec's own `sessionKind` (derive-don't-mirror), scrolling to the new per-card anchors (`agent-signin-card-<provider>`), falling back to the section head. Existing callers keep the section-head behavior.
- Fragments only; `static/app.html` regenerated by the assembler.

## Backend coverage and stated boundaries

- **Codex, Claude Code, Pi**: fully covered — all three share `spawn_stderr_forwarder` and the drains' `BackendError` arm, so one classifier serves them.
- **Kimi**: partial by design of its adapter — Kimi drains stderr silently (`drain_silently`) and its websocket driver emits generic `BackendError`s; the classification applies to those errors only when their text carries the auth needles. Giving Kimi a stderr seam is its own change and out of scope here.
- **Pre-flight rider (lease lapsing before a schedule's next fire)**: not taken. The seams are not cheap — `credential_watch`'s per-lane rules run only while NO lease is active (the exact complement of the rider's precondition), lease expiry has no read-only accessor (`status_entries` takes the store lock and sweeps as a side effect), and next-fire times exist only through the agenda's decorated serving reads. It would be a new watch lane plus a new lease API, and the incident this card came from was not lease-shaped (see below). Stated here rather than forced.
- The credential-file probe reads the daemon's view of the home; a session running on a leased home is not distinguished — the missing-file copy names the lease remedy alongside sign-in for exactly that reason.

## Pins

- Unit: classifier vocabulary (positive specimens + churn/noise negatives), both copy flavors, probe dispatch, the sticky fold (carry/clear per state), the supersede rule, wire spellings (`authFailure`/`authFailureBackend`).
- Drain-level: the full storm shape — stderr row, retryable 401, fatal `(other)`, empty completion — drains `TurnFailed` with the named reason.
- Parity: the vitals-catalog test now pins `authFailure`/`authFailureBackend` and the `signed-out`/`died-tasks` states; a needle test freezes the SPA wiring (derive, action label, `focusVaultAgentSignin(backendId)`, `sessionKind` resolution, card anchors).
- e2e (`backend_auth_failure_classifies_to_the_named_signed_out_state`): a fake claude emitting a 401 stderr line + the auth-error result envelope must yield the named state, keep the raw lines in the log, and end the round failed with the named reason. The scripted mock provider covers native sessions only, so the external-agent shape rides the fake-CLI substrate instead.

## Root cause of the triggering incident (evidence summary)

The custody/lease trail on the affected machine shows no `oauth:codex` lease was ever granted; the recurring `lease_home_removed` events are startup sweeps of the daemon's private leased-home directory, which by code cannot touch `~/.codex/auth.json` (lease materialization is confined to the state root, verified empirically: a restart sweep was followed seconds later by a working codex session). The credential file disappeared outside the daemon — codex's own login log shows a device-code login flow started and abandoned before the first failing fire, with no token exchange after it. So: not lease-lapse cleanup, not an Intendant logout path (none exists for that file). The classification here is the fix for the surface; the file's removal was CLI-side.
