### PR TITLE
dashboard: hoist the daemons-list render signature per the deep-link TDZ rule

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -573,17 +573,38 @@ jobs:
       # Deep-link boots evaluate later-fragment code during script
       # evaluation (the deep-link TDZ class — a let/const declared in a
       # late fragment but reached from the fragment-48 route apply dies
-      # with "Cannot access before initialization"). #stats and #files
-      # are the two tabs that have regressed this way; boot each one.
+      # with "Cannot access before initialization"). #stats, #files, and
+      # #access/daemons are the tabs that have regressed this way; boot
+      # each one. The last leg additionally rides a follow-carry blob
+      # (`&carry=<base64 json>` — the drain auto-follow's cross-origin
+      # state handoff, 31-init-identity-fleet.js): a hotswap lands the
+      # successor tab on the predecessor's route at module-eval time, so
+      # the carry parse + strip + route apply must boot clean too (the
+      # 2026-08-07 owner-reported module death arrived on exactly this
+      # vector).
       - name: dashboard-boot smoke (deep links)
         if: runner.os == 'Linux' && steps.relevance_unix.outputs.relevant != 'false'
         shell: bash
         run: |
-          for hash in stats files; do
+          for hash in stats files access/daemons; do
             node scripts/smoke-dashboard-boot.cjs \
               --url "http://127.0.0.1:${{ steps.daemon.outputs.port }}/?token=${{ steps.daemon.outputs.token }}#$hash" \
               --artifact-dir "${{ steps.daemon.outputs.rig }}/artifacts"
           done
+          carry=$(node -e 'console.log(Buffer.from(JSON.stringify({
+            v: 1,
+            route: "access/daemons",
+            windows: [],
+            subtabs: { access: "daemons" },
+            stamps: {
+              pred_boot: "ci-boot-probe",
+              pred: { git_sha: "0000000000000000", built_at: "1970-01-01T00:00:00Z" },
+              on_disk: { git_sha: "1111111111111111", built_at: "1970-01-01T00:00:01Z" },
+            },
+          })).toString("base64"))')
+          node scripts/smoke-dashboard-boot.cjs \
+            --url "http://127.0.0.1:${{ steps.daemon.outputs.port }}/?token=${{ steps.daemon.outputs.token }}#access/daemons&carry=$carry" \
+            --artifact-dir "${{ steps.daemon.outputs.rig }}/artifacts"
 
       - name: Stop daemon (dashboard-boot)
         if: always() && steps.daemon.outputs.pid != ''

--- a/static/app.html
+++ b/static/app.html
@@ -39165,7 +39165,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'fbefe0551640bc87';
+const INTENDANT_APP_BUILD = 'cdbf8e9731861dc4';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -40452,6 +40452,12 @@ const statsUsageCorpusFetchedAt = new Map(); // hostId -> last real fetch (ms)
 let dashboardControlAutoFallback = false;
 let dashboardLegacyWsConnected = false;
 let dashboardLegacyWsEverConnected = false;
+// Deep-link TDZ rule, #access/daemons instance: fragment 48's route apply
+// runs switchTab('access') → renderDaemonsList() → renderDaemonsListTail()
+// during script evaluation, before fragment 50's top-level declarations
+// initialize. The host-options render signature (see renderDaemonsListTail
+// in 50-control-transport.js) therefore lives here with the early state.
+let daemonsListHostOptionsSig = null;
 let filesTransferDbPromise = null;
 const FILES_TRANSFER_STATE_KEY = 'intendant.files.transfers.v2';
 const FILES_TRANSFER_DB_NAME = 'intendant-files-transfers-v2';
@@ -118075,7 +118081,9 @@ async function fetchRemoteAgentCard(baseUrl) {
 // its own signature for the list; the pickers' inputs (id/label/connected)
 // get a dedicated one so a mid-row change (e.g. version skew) doesn't churn
 // the selects.
-let daemonsListHostOptionsSig = null;
+// (daemonsListHostOptionsSig is declared in 31-init-identity-fleet.js with
+// the early state: an #access deep link reaches renderDaemonsListTail during
+// script evaluation — the deep-link TDZ rule.)
 
 function daemonsListHostOptionsSignature() {
   return JSON.stringify([

--- a/static/app/31-init-identity-fleet.js
+++ b/static/app/31-init-identity-fleet.js
@@ -1300,6 +1300,12 @@ const statsUsageCorpusFetchedAt = new Map(); // hostId -> last real fetch (ms)
 let dashboardControlAutoFallback = false;
 let dashboardLegacyWsConnected = false;
 let dashboardLegacyWsEverConnected = false;
+// Deep-link TDZ rule, #access/daemons instance: fragment 48's route apply
+// runs switchTab('access') → renderDaemonsList() → renderDaemonsListTail()
+// during script evaluation, before fragment 50's top-level declarations
+// initialize. The host-options render signature (see renderDaemonsListTail
+// in 50-control-transport.js) therefore lives here with the early state.
+let daemonsListHostOptionsSig = null;
 let filesTransferDbPromise = null;
 const FILES_TRANSFER_STATE_KEY = 'intendant.files.transfers.v2';
 const FILES_TRANSFER_DB_NAME = 'intendant-files-transfers-v2';

--- a/static/app/50-control-transport.js
+++ b/static/app/50-control-transport.js
@@ -2896,7 +2896,9 @@ async function fetchRemoteAgentCard(baseUrl) {
 // its own signature for the list; the pickers' inputs (id/label/connected)
 // get a dedicated one so a mid-row change (e.g. version skew) doesn't churn
 // the selects.
-let daemonsListHostOptionsSig = null;
+// (daemonsListHostOptionsSig is declared in 31-init-identity-fleet.js with
+// the early state: an #access deep link reaches renderDaemonsListTail during
+// script evaluation — the deep-link TDZ rule.)
 
 function daemonsListHostOptionsSignature() {
   return JSON.stringify([


### PR DESCRIPTION
## What

Booting the dashboard on `#access/daemons` (any deep link to the Access tab, including the drain auto-follow's `#access/daemons&carry=<base64>` landing) killed the whole SPA at module init:

```
[module-death] First error: Cannot access 'daemonsListHostOptionsSig' before initialization
```

## Why

The assembled dashboard is one `<script type="module">`, so fragment 48's initial route apply runs during script evaluation (`document.readyState` is already `interactive` for module scripts). On an `#access` deep link that eval-time boot runs `applyCurrentRoute()` → `switchTab('access')` → `renderDaemonsList()` → `renderDaemonsListTail()`, whose host-options render guard reads `daemonsListHostOptionsSig` — a top-level `let` declared in fragment 50, which has not evaluated yet: TDZ ReferenceError, and every fragment after the throw stays dead.

The binding was added 2026-07-15 with the render-signature guard and missed the documented deep-link TDZ rule (manifest.txt, 48b header). Latent since then — reproduced on both the current tree and its predecessor build — but the update-lane auto-follow made the trigger routine: a hotswap now lands the successor tab on whatever route the owner was viewing, at module-eval time, carry-seeded to Access → Daemons.

## Fix

Hoist the binding into fragment 31's early-state block, next to the existing stats/control-lane deep-link hoists, with a pointer comment left at the fragment-50 site. One line of behavior change; verified that the whole eval-time render chain is TDZ-clean after it (module completes, `__intendantModuleAlive` true, boot assertions pass on `#access/daemons` and on the carry variant).

## CI

The Linux dashboard-boot probe stayed green because its deep-link legs boot only `#stats` and `#files` (the previously-regressed vectors) — `#access/daemons` was not in the list, and the assembler's static eval-order lint only rejects *direct* top-level references to later-fragment bindings, not reads reached through a hoisted function call. Extended the deep-link legs with `#access/daemons` plus a follow-carry variant (synthesized v1 carry blob), so both the route and the carry parse/strip/apply path now fail the Linux leg on any module death.
