### PR TITLE
session catalog: held-by-live-drainer rows are never ghost on the successor

### DIFF
--- a/src/bin/caller/web_gateway/session_catalog/grid_envelope.rs
+++ b/src/bin/caller/web_gateway/session_catalog/grid_envelope.rs
@@ -77,13 +77,17 @@ pub(crate) struct GridEnvelopeJoins {
     /// Update-abstraction §3 (residual R4): session id → the draining
     /// co-homed sibling still RUNNING it, resolved once per build from
     /// presence (see [`resolve_drain_map`]). Empty when no live sibling
-    /// drains — the common case costs one directory read.
+    /// drains — the common case costs one directory read. Feeds both
+    /// the `boot.held_by` wire block and — the 01KZ8X8DWK amendment —
+    /// the era computation: a held row is never a ghost.
     drain_map: HashMap<String, DrainHold>,
 }
 
 /// One draining LIVE co-homed sibling's holdout claim on a session row —
-/// the `boot.held_by` wire block's source. Presence-derived and
-/// read-only (the F1 watershed law: this join never writes presence).
+/// the `boot.held_by` wire block's source and, per the 01KZ8X8DWK
+/// amendment, a current-era input in [`GridEnvelopeJoins::attach`].
+/// Presence-derived and read-only (the F1 watershed law: this join
+/// never writes presence).
 pub(crate) struct DrainHold {
     boot_id: String,
     port: u16,
@@ -296,15 +300,36 @@ impl GridEnvelopeJoins {
             return;
         };
         let live_wrapper = live.contains(session_id);
+        // A locally live wrapper outranks any sibling claim: double
+        // supervision never happens by design, so the local wrapper is
+        // the stronger truth and a sibling row is debris — only
+        // non-live rows consult the drain map.
+        let drain_hold = if live_wrapper {
+            None
+        } else {
+            self.drain_map.get(session_id)
+        };
         // Era: a live wrapper IS current-boot (a resumed pre-outage
-        // session belongs to the daemon driving it now); otherwise the
-        // transcript decides. `session.jsonl` mtime is rename-immune
-        // (meta rewrites don't touch it); the dir-mtime fallback for
+        // session belongs to the daemon driving it now) — and a session
+        // held by a provably live draining sibling counts the same way
+        // (card 01KZ8X8DWKS5EX69X3DZ585VWC, its gate-endorsed
+        // amendment of the slice-3 "join never touches era" doctrine):
+        // the drainer is the daemon driving it now, so the row is never
+        // a ghost however far its transcript predates this boot — the
+        // common takeover shape otherwise read a LIVE held session as
+        // preboot+ghost by arithmetic, and every ghost consumer folded
+        // it away as safe to close. The widening rides the SAME
+        // provable-liveness gate as the join itself (draining state,
+        // boot lock HELD — [`resolve_drain_map`]), so a stale sibling
+        // claim never suppresses ghost. Otherwise the transcript
+        // decides. `session.jsonl` mtime is rename-immune (meta
+        // rewrites don't touch it); the dir-mtime fallback for
         // transcript-less dirs can over-claim currency after any file
         // lands in the dir — the fail direction that never wrongly
         // claims safe-to-close.
-        let current =
-            live_wrapper || super::caches::session_activity_mtime_secs(dir) >= boot.start_secs;
+        let current = live_wrapper
+            || drain_hold.is_some()
+            || super::caches::session_activity_mtime_secs(dir) >= boot.start_secs;
         let ghost = !current && !live_wrapper;
         let mut boot_block = serde_json::json!({
             "era": if current { "current" } else { "preboot" },
@@ -323,27 +348,26 @@ impl GridEnvelopeJoins {
         // Update-abstraction §3 (residual R4): a session still RUNNING on
         // a draining live sibling carries `held_by` BESIDE the era
         // vocabulary (old SPAs ignore the field; `normalizeSessionBootEra`
-        // stays strict) — era/ghost above are untouched by this join. A
-        // locally live wrapper outranks any stale sibling claim: double
-        // supervision never happens by design, so the local wrapper is
-        // the stronger truth and the sibling row is debris.
-        if !live_wrapper {
-            if let Some(hold) = self.drain_map.get(session_id) {
-                let mut held_by = serde_json::json!({
-                    "boot_id": hold.boot_id,
-                    "port": hold.port,
-                    "version": serde_json::to_value(&hold.version)
-                        .unwrap_or(serde_json::Value::Null),
-                    "same_build": hold.same_build,
-                    "phase": hold.phase,
-                });
-                if let Some(park) = hold.limit_park.as_ref() {
-                    if let Ok(park) = serde_json::to_value(park) {
-                        held_by["limit_park"] = park;
-                    }
+        // stays two-value strict) — and since the 01KZ8X8DWK amendment
+        // the same provably live hold also feeds the era computation
+        // above (held ⇒ current/never-ghost), so the ghost-keyed
+        // dashboard folds and the "safe to close" copy can never hit a
+        // session a live drainer still runs.
+        if let Some(hold) = drain_hold {
+            let mut held_by = serde_json::json!({
+                "boot_id": hold.boot_id,
+                "port": hold.port,
+                "version": serde_json::to_value(&hold.version)
+                    .unwrap_or(serde_json::Value::Null),
+                "same_build": hold.same_build,
+                "phase": hold.phase,
+            });
+            if let Some(park) = hold.limit_park.as_ref() {
+                if let Ok(park) = serde_json::to_value(park) {
+                    held_by["limit_park"] = park;
                 }
-                boot_block["held_by"] = held_by;
             }
+            boot_block["held_by"] = held_by;
         }
         if ghost {
             match dead_row_lineage_tip(self.home.as_deref(), session_id, dir, self.lineage_epoch) {
@@ -696,9 +720,11 @@ mod tests {
     /// whose boot lock is HELD joins `boot.held_by` onto its holdout
     /// rows (port/phase/limit_park + the R-A1 build-stamp compare); a
     /// non-draining, non-live, exited, or own-pid record joins nothing;
-    /// a locally live wrapper outranks any sibling claim; and the
-    /// era/ghost vocabulary is byte-identical with and without the join
-    /// (the map only READS presence — F1 untouched).
+    /// and a locally live wrapper outranks any sibling claim. The map
+    /// only READS presence (F1 untouched); since the 01KZ8X8DWK
+    /// amendment the hold also feeds the era computation — that
+    /// invariant is pinned by `held_by_live_drainer_row_is_never_ghost`
+    /// below.
     #[test]
     fn held_by_matrix_joins_only_draining_live_siblings() {
         let sessions = tempfile::tempdir().unwrap();
@@ -749,21 +775,19 @@ mod tests {
         assert_eq!(row["boot"]["era"], "current");
         assert_eq!(row["boot"]["ghost"], false);
 
-        // Era honesty: strip held_by and the joined row is byte-identical
-        // to an un-joined attach — the field rides BESIDE the era
-        // vocabulary, never inside it.
-        let mut baseline = serde_json::json!({});
-        joins(Some(watershed), Some(&[]), None).attach(&mut baseline, "s1", &dir);
-        let mut joined = row.clone();
-        joined["boot"]
-            .as_object_mut()
-            .unwrap()
-            .remove("held_by")
-            .expect("held_by was attached");
-        assert_eq!(
-            joined, baseline,
-            "era/ghost outputs byte-identical; held_by is the only addition"
-        );
+        // RETIRED WITH CAUSE (2026-08-06): the slice-3 byte-identity pin
+        // stood here — strip held_by and the joined row had to be
+        // byte-identical to an un-joined attach ("the held_by join never
+        // touches era/ghost"). That doctrine is deliberately amended
+        // through gate 01KZ8X8DWZ's endorsement of card
+        // 01KZ8X8DWKS5EX69X3DZ585VWC: on a successor, a session a live
+        // drainer still runs read preboot+ghost — "safe to close" — by
+        // transcript arithmetic (the COMMON takeover shape), so the
+        // provably live hold now feeds the era computation on purpose.
+        // The amended invariant (held-by-live-drainer ⇒ current, never
+        // ghost) is pinned by `held_by_live_drainer_row_is_never_ghost`
+        // below, alongside the preserved fail direction: a hold that
+        // fails the liveness gate never suppresses ghost.
 
         // A session outside the holdout rows joins nothing.
         let other = attach_with(root.path(), &[], "s2");
@@ -853,6 +877,133 @@ mod tests {
         assert!(attach_with(root.path(), &[], "s1")["boot"]
             .get("held_by")
             .is_none());
+    }
+
+    /// The 01KZ8X8DWK amendment (endorsed through gate 01KZ8X8DWZ),
+    /// pinned: a session actively held by a PROVABLY LIVE draining
+    /// sibling is never a ghost, however far its transcript predates
+    /// this daemon's boot — the drainer is the daemon driving it now,
+    /// so the successor serves era:"current"/ghost:false with `held_by`
+    /// beside them (the common takeover shape: an idle parked session
+    /// across a hotswap). Every ghost consumer — the grid fold that hid
+    /// 17 of 22 held rows on a real hotswap, the "safe to close" brief
+    /// — keys on that served bit, so a held row can no longer fold away
+    /// or read safe to close. The fail direction survives the widening:
+    /// the era input rides the SAME provable-liveness gate as the join
+    /// (draining state + boot lock HELD), so a claim that fails the
+    /// gate never suppresses ghost.
+    #[test]
+    fn held_by_live_drainer_row_is_never_ghost() {
+        let sessions = tempfile::tempdir().unwrap();
+        let dir = session_dir_with_transcript(sessions.path(), "s1");
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        // The transcript predates the successor's boot — the shape that
+        // read preboot+ghost by arithmetic before the amendment.
+        let preboot_watershed = now_secs + 3_600;
+        let foreign_pid = std::process::id() + 1;
+        let elder_build =
+            serde_json::json!({"pkg": "0.0.0", "git_sha": "elder", "built_at": "elder-ts"});
+        let attach_with = |state_root: &Path, session_id: &str| {
+            let mut row = serde_json::json!({});
+            joins(Some(preboot_watershed), Some(&[]), None)
+                .with_drain_map_from(state_root)
+                .attach(&mut row, session_id, &dir);
+            row
+        };
+
+        // Held by a draining + provably live sibling → current, never
+        // ghost, the hold beside it — a normal held_by row the grid
+        // renders (chips + affordance gating key on held_by; the fold
+        // and the safe-to-close copy key on ghost).
+        let root = tempfile::tempdir().unwrap();
+        write_presence_record(
+            root.path(),
+            "boot-drainer",
+            foreign_pid,
+            8770,
+            "draining",
+            elder_build.clone(),
+            parked_holdout_rows("s1"),
+        );
+        let _drainer_lock = hold_boot_lock(root.path(), "boot-drainer");
+        let row = attach_with(root.path(), "s1");
+        assert_eq!(
+            row["boot"]["era"], "current",
+            "a held row belongs to the daemon driving it now"
+        );
+        assert_eq!(
+            row["boot"]["ghost"], false,
+            "held-by-live-drainer is never ghost — the grid must not fold it"
+        );
+        assert_eq!(
+            row["boot"]["live_wrapper"], false,
+            "the hold is a sibling claim, not a local wrapper"
+        );
+        assert_eq!(row["boot"]["held_by"]["boot_id"], "boot-drainer");
+        assert!(
+            row["boot"].get("lineage_tip").is_none(),
+            "a held row is not a dead row — the ghost-only lineage join stays off it"
+        );
+
+        // The same row WITHOUT the hold still reads preboot+ghost — the
+        // amendment widened exactly one input, not the arithmetic.
+        let bare = tempfile::tempdir().unwrap();
+        let row = attach_with(bare.path(), "s1");
+        assert_eq!(row["boot"]["era"], "preboot");
+        assert_eq!(row["boot"]["ghost"], true);
+
+        // Fail direction: the identical draining record whose boot lock
+        // is FREE (drainer dead) is a stale claim — it never suppresses
+        // ghost, and it joins no held_by.
+        let root = tempfile::tempdir().unwrap();
+        write_presence_record(
+            root.path(),
+            "boot-dead",
+            foreign_pid,
+            8771,
+            "draining",
+            elder_build.clone(),
+            parked_holdout_rows("s1"),
+        );
+        let row = attach_with(root.path(), "s1");
+        assert_eq!(
+            row["boot"]["era"], "preboot",
+            "a dead drainer's claim must not widen the era"
+        );
+        assert_eq!(
+            row["boot"]["ghost"], true,
+            "a stale sibling claim never suppresses ghost"
+        );
+        assert!(row["boot"].get("held_by").is_none());
+
+        // A live but NON-draining sibling likewise leaves the era alone.
+        let root = tempfile::tempdir().unwrap();
+        write_presence_record(
+            root.path(),
+            "boot-running",
+            foreign_pid,
+            8772,
+            "running",
+            elder_build,
+            parked_holdout_rows("s1"),
+        );
+        let _running_lock = hold_boot_lock(root.path(), "boot-running");
+        let row = attach_with(root.path(), "s1");
+        assert_eq!(row["boot"]["era"], "preboot");
+        assert_eq!(row["boot"]["ghost"], true);
+
+        // The SPA needle half of the acceptance: the safe-to-close brief
+        // stays keyed on the served ghost bit — held rows (never ghost)
+        // can therefore never wear that copy.
+        let fragment = include_str!("../../../../../static/app/39-session-windows.js");
+        assert!(
+            fragment
+                .contains("(v.ghost ? 'Ghost — pre-boot, nothing behind it; safe to close' : '')"),
+            "the safe-to-close brief must stay keyed on the served ghost bit"
+        );
     }
 
     fn envelope(

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -7230,15 +7230,17 @@ async fn drainer_exits_at_last_session_end() {
 }
 
 /// Update-abstraction slice 3 (§3 residual R4 + the owner-amended
-/// composer lane), acceptance (c)(e)(f): a drainer's parked-for-
-/// follow-ups session appears in the SUCCESSOR's catalog wearing
-/// `boot.held_by` — the drainer's boot/port, the R-A1 build compare
-/// (same binary here, so `same_build`), and the holdout phase — while
-/// the era/ghost vocabulary rides well-formed beside it (mid-drain the
-/// VALUE of era is a transcript-mtime-vs-successor-boot compare, i.e.
-/// a timing accident; the strict current/not-ghost claim is pinned at
-/// drain-clear, once the composer round has moved the transcript
-/// within the successor's boot). The holder-side
+/// composer lane), acceptance (c)(e)(f), amended by card 01KZ8X8DWK
+/// (gate 01KZ8X8DWZ's endorsement): a drainer's parked-for-follow-ups
+/// session appears in the SUCCESSOR's catalog wearing `boot.held_by` —
+/// the drainer's boot/port, the R-A1 build compare (same binary here,
+/// so `same_build`), and the holdout phase — and, since the amendment,
+/// era:"current"/ghost:false beside it however old the transcript
+/// reads: a provably live hold counts like a live wrapper in the era
+/// computation, so the held row is grid-visible (never ghost-folded,
+/// never branded safe to close) and the strict era claim is
+/// deterministic mid-drain again (#796 had moved it to drain-clear
+/// while mid-drain era was a boot-speed accident). The holder-side
 /// composer contract then runs end to end as the scripted tab: the
 /// sibling token map on the holder names the drainer's OWN admission
 /// token, a targeted `start_task` through the drainer's own gateway is
@@ -7336,20 +7338,21 @@ async fn held_by_rows_ride_the_successor_catalog_and_serve_the_composer_lane() {
 
     // (c) The successor's catalog carries the join while the drainer
     // still runs the session: held_by names the drainer, the R-A1
-    // compare reads same-build (one binary in the rig), and the era
-    // vocabulary rides WELL-FORMED beside it — but era's value is not
-    // pinned here. On the successor a non-live-wrapper row reads
-    // "current" iff the transcript moved at-or-after the successor's
-    // own presence registration (both truncated to epoch seconds), and
-    // this session last wrote at round one, BEFORE the successor
-    // spawned — so "current" holds only when those two instants alias
-    // into one epoch second. Pinning "current" made the leg a
-    // boot-speed coin toss (two merge-queue ejections in one night,
-    // mac + windows, 2026-08-05: era sat at "preboot"/ghost=true for
-    // the full 180s because the next transcript append — the composer
-    // round — is sequenced AFTER this poll). The strict era/ghost
-    // claim moves to the drain-clear poll below, where round two has
-    // provably moved the transcript within the successor's boot.
+    // compare reads same-build (one binary in the rig) — and the
+    // strict era claim RETURNS to this poll (the 01KZ8X8DWK
+    // amendment): a hold by a provably live drainer counts like a live
+    // wrapper in the era computation, so the held row serves
+    // current/not-ghost REGARDLESS of the transcript-mtime-vs-
+    // successor-registration compare that made pinning "current" here
+    // a boot-speed coin toss before the amendment (two merge-queue
+    // ejections in one night, mac + windows, 2026-08-05: era sat at
+    // "preboot"/ghost=true for the full 180s because the next
+    // transcript append — the composer round — is sequenced AFTER this
+    // poll; #796 then parked the strict claim at drain-clear).
+    // ghost:false is also the acceptance's grid-visibility bit: the
+    // dashboard folds ghost rows away and brands them "safe to close"
+    // (a real hotswap showed 5 of 22 sessions — the 17 held drainer
+    // rows hidden entirely), so a held row must never serve it.
     let mut headers_b = reqwest::header::HeaderMap::new();
     headers_b.insert(
         "x-intendant-loopback-token",
@@ -7401,7 +7404,6 @@ async fn held_by_rows_ride_the_successor_catalog_and_serve_the_composer_lane() {
             let row = held_row(&sessions, &sid)?;
             *last_served_row.lock().unwrap() = row.to_string();
             let held = row.pointer("/boot/held_by")?;
-            let era = row["boot"]["era"].as_str()?;
             (held["boot_id"] == holder_boot.as_str()
                 && held["port"] == port_a
                 && held["same_build"] == true
@@ -7409,15 +7411,16 @@ async fn held_by_rows_ride_the_successor_catalog_and_serve_the_composer_lane() {
                     .as_str()
                     .is_some_and(|phase| !phase.is_empty())
                 && row["boot"]["live_wrapper"] == false
-                && matches!(era, "current" | "preboot")
-                && row["boot"]["ghost"] == (era == "preboot"))
+                && row["boot"]["era"] == "current"
+                && row["boot"]["ghost"] == false)
                 .then_some(())
         },
         || {
-            // The era watershed compare, spelled out: era reads
-            // "current" iff the transcript mtime (secs) is >= the
-            // successor's presence-registration instant (its record's
-            // updated_ms / 1000).
+            // The era inputs, spelled out: a held row is current by the
+            // provably live hold (the 01KZ8X8DWK amendment); without a
+            // hold, era reads "current" iff the transcript mtime (secs)
+            // is >= the successor's presence-registration instant (its
+            // record's updated_ms / 1000).
             let transcript_mtime_secs = std::fs::metadata(&transcript_path)
                 .and_then(|meta| meta.modified())
                 .ok()
@@ -7557,12 +7560,13 @@ async fn held_by_rows_ride_the_successor_catalog_and_serve_the_composer_lane() {
 
     // The join self-clears: the drainer's boot lock freed, `live` reads
     // false, and the successor's rows drop held_by. The strict era
-    // claim lands HERE, where it is deterministic: round two appended
-    // to the transcript within the successor's boot, so a served boot
-    // block must read current/not-ghost — and requiring the block also
-    // keeps "held_by cleared" distinct from "boot block momentarily
-    // omitted" (the joins resolve per build; an unpublished registry
-    // omits the block entirely).
+    // claim stays pinned here WITHOUT the hold carrying it: round two
+    // appended to the transcript within the successor's boot, so the
+    // served boot block must read current/not-ghost on transcript
+    // arithmetic alone — and requiring the block also keeps "held_by
+    // cleared" distinct from "boot block momentarily omitted" (the
+    // joins resolve per build; an unpublished registry omits the block
+    // entirely).
     poll_until(
         "held_by clearing after the drainer exits",
         RUN_TIMEOUT,


### PR DESCRIPTION
On a successor daemon, a session actively held by a live draining sibling served `era:preboot` + `ghost:true` whenever its transcript predated the successor's boot — the common takeover case. The dashboard documents ghost as safe to close and folds ghost rows out of the grid, so after a real hotswap the unified drain view hid the held drainer sessions entirely (5 of 22 rows visible) and the visible copy called live sessions safe to close.

Change (per the endorsed re-scope of the slice-3 era doctrine, card 01KZ8X8DWKS5EX69X3DZ585VWC / gate 01KZ8X8DWZD6VHXQG40XTWRKGB):

- `grid_envelope.rs` attach: a drain-map hold counts like `live_wrapper` in the era computation — a held-by-a-live-drainer row serves `era:current`/`ghost:false` with `held_by` beside it. The widening rides the same provable-liveness gate the join already has (draining state + boot lock held), so a stale sibling claim never suppresses ghost.
- The slice-3 byte-identity pin ("the held_by join never touches era/ghost") is retired with cause in the same change — the doctrine is deliberately amended through the ruled gate, not drifted past. The amended invariant is pinned by the new `held_by_live_drainer_row_is_never_ghost` unit test (held ⇒ current/never ghost; no-hold and failed-liveness shapes keep preboot/ghost; the safe-to-close copy stays keyed on the served ghost bit).
- The e2e drain poll's strict era claim returns mid-drain (#796 had moved it to drain-clear while mid-drain era was a boot-speed accident; the fix makes it deterministic), extended with the grid-visibility assertion: the held row serves `ghost:false`, so the grid renders it as a normal held_by row instead of folding it.

No SPA changes: chips and affordance gating already key on `held_by`, and the fold/safe-to-close treatment keys on the served ghost bit this change corrects.