### PR TITLE
skills: durable_sccache supervised-root requirement, agenda floor-check ordering, codex-cloud log caution

### DIFF
--- a/plugins/codex-cloud-remote-compute/skills/intendant-remote-compute/SKILL.md
+++ b/plugins/codex-cloud-remote-compute/skills/intendant-remote-compute/SKILL.md
@@ -40,7 +40,12 @@ description: In any Intendant-supervised native, Codex, Claude Code, Kimi Code, 
   the requested `expected_revision`; a branch name never weakens that guard.
 - For Rust work that should reuse compile outputs after worker replacement,
   request `cache: "durable_sccache"`. The default authenticated relay needs no
-  cloud credentials; the job fails early if sccache or the relay is unavailable.
+  cloud credentials, but it namespaces its cache repository by the supervised
+  session's project root — an unsupervised call (e.g. an owner-shell acceptance
+  run) has none and fails early with "durable_sccache through home requires a
+  supervised project root". Run such calls from a supervised session, or omit
+  `cache` (the `none` default) and accept a cold build. The job also fails
+  early if sccache or the relay is unavailable.
 
 ## Waiting for an acquired worker
 

--- a/skills/intendant-agenda/SKILL.md
+++ b/skills/intendant-agenda/SKILL.md
@@ -112,7 +112,16 @@ dashboard, attributed to your session.
   thread), leaves fired history untouched, and refuses on an approved
   manifest. Approval binds the exact manifest
   digest, so revising the manifest (re-running `schedule`) voids any
-  approval. The outcome writes back to the item (`effects[].last_run`
+  approval. Manifests are floor-checked fail-closed at BOTH propose
+  and approve (fire time plus a 12h staleness bound): once a
+  manifest's window has passed, its old digest can never be
+  (re-)approved. So when one needs re-review or restoration — a
+  crash-stranded approved manifest, a stale pending card — check the
+  floor FIRST: if it is past, re-run `schedule` with a fresh `--at`
+  and let the owner approve the NEW digest. Never rely on a
+  revoke-then-re-approve pair against the old digest; the approve leg
+  refuses on the stale floor and strands the effect unapproved
+  mid-pair. The outcome writes back to the item (`effects[].last_run`
   in `list --json`: state, session id, note) — check it next session.
   If the goal depends on a file (a brief, a rider), seal it:
   `--binding-ref file:PATH` (repeatable) sha256-pins the content at

--- a/skills/intendant-log-search/SKILL.md
+++ b/skills/intendant-log-search/SKILL.md
@@ -101,3 +101,10 @@ For Codex, inspect `session_agent_config.json` for `codex_home`; otherwise use `
 - Do not search only `session_meta.json` or summaries. Dashboard deep search scans full log files and full JSON string fields because useful evidence often lives in `message`, `data`, or backend-native JSONL.
 - For exact context, prefer `context_snapshot` files over dashboard previews. Large raw context can be summarized or omitted from replay. Only the LATEST sidecar per (source, session id) stream is retained on disk (rotation; `INTENDANT_CONTEXT_SNAPSHOT_KEEP_ALL=1` archives all) — historical `context_snapshot` rows keep their metadata but their files are gone, and `exact_replay_available` on replayed rows reflects disk truth. Selecting the newest `context_snapshot` row (`... | tail -1`) still resolves to a real file.
 - `turns/turn_NNN_messages.json` is debug-only (`INTENDANT_LOG_MESSAGES_JSON=1`); expect it to be absent in normal sessions except where the provider produced no context snapshot (then it is written as the only exact input record).
+- Codex Cloud remote-compute tasks: the state root and `intendant codex-cloud
+  status` carry only the local lease and terminal job state. The provider-side
+  assistant/tool output is NOT on disk, and a raw authenticated task-detail
+  response embeds the task prompt — which can carry a one-time worker
+  enrollment secret. Do not hand-roll that request during log investigation;
+  report the terminal state and the task URL instead (a redacted recovery
+  verb is a named product gap).


### PR DESCRIPTION
Three skill-text edits from the 2026-08-06 skill-feedback dogfooding triage (the skills-only slice; the `--interactive` teaching rides its own PR with the flag).

- **intendant-remote-compute** (`plugins/codex-cloud-remote-compute/skills/intendant-remote-compute/SKILL.md`): the cache bullet now teaches that the default `durable_sccache` transport namespaces its cache repository by the supervised session's project root — an unsupervised call (e.g. an owner-shell acceptance run) has none and fails early with the exact error `remote_compute.rs` raises — and names the honest fallback: run from a supervised session, or omit `cache` (the `none` default) and accept a cold build.
- **intendant-agenda** (`skills/intendant-agenda/SKILL.md`): the scheduled-sessions bullet now teaches the fireability floor law — manifests are floor-checked fail-closed at BOTH propose and approve (fire time plus the 12h staleness bound), so a manifest needing re-review or restoration gets the floor check FIRST: stale means re-run `schedule` with a fresh `--at` and let the owner approve the NEW digest, never a revoke-then-re-approve pair against the old digest (the approve leg refuses on the stale floor and strands the effect unapproved mid-pair).
- **intendant-log-search** (`skills/intendant-log-search/SKILL.md`): new Cautions bullet — Codex Cloud remote-compute task output is not on disk, and a raw authenticated task-detail response embeds the task prompt, which can carry a one-time worker enrollment secret; report the terminal state and the task URL instead of hand-rolling that request (a redacted recovery verb is a named product gap).

All three claims verified against the code (`remote_compute.rs` `durable_sccache_config`, `agenda/fireability.rs` `validate_floor` + the 12h default in `agenda/reminders.rs`, `codex_cloud.rs` verb surface). The skill bytes are embedded via `include_str!` (builtin_skills.rs, plugin_registry.rs), so the shipped catalog follows this landing; no test pins any fragment of the touched paragraphs.

Reach: skills ship via the repo checkout — these paragraphs are live for daemons built at or past this landing.