### PR TITLE
ctl agenda schedule: --interactive flag parity with the propose_effect lane

### DIFF
--- a/docs/src/agenda-and-memory.md
+++ b/docs/src/agenda-and-memory.md
@@ -600,7 +600,8 @@ root, first-run time, and cadence for standing effects. Saving mints the
 revised manifest **through the one re-propose lane** (`propose_effect`,
 which now carries `interactive` like the other manifest fields — absent
 keeps the legacy autonomous bytes; older daemons refuse the new field by
-name): same effect lineage, new digest, prior approval void, and the
+name; `ctl agenda schedule --interactive` states the same shape from the
+CLI): same effect lineage, new digest, prior approval void, and the
 card's digest chip updates in place — an amber **revised** chip marks a
 digest that changed since the owner last looked (their own edits are
 pre-acknowledged; a stale Approve is refused by the daemon regardless,

--- a/skills/intendant-agenda/SKILL.md
+++ b/skills/intendant-agenda/SKILL.md
@@ -51,6 +51,7 @@ dashboard, attributed to your session.
 "$INTENDANT" ctl agenda patch 01KX --due +3d   # presentation edits (title/body/tags/due)
 "$INTENDANT" ctl agenda schedule 01KX --goal "Run the soak checks and summarize" --at +2d
 "$INTENDANT" ctl agenda schedule 01KX --goal "Weekly housekeeping pass" --at "+1d" --every 7d   # STANDING: one approval covers the series
+"$INTENDANT" ctl agenda schedule 01KX --goal "Sit with the owner on the release board" --at +1d --interactive   # owner-sitting: fires, opens with the goal, waits for the owner
 "$INTENDANT" ctl agenda withdraw 01KX --reason "superseded by the rewrite"   # take back a PENDING unapproved proposal (yours included); approved = owner's revoke-schedule
 "$INTENDANT" ctl agenda annotate 01KX "Tried the vendor API — still 403; evidence in run 88."
 "$INTENDANT" ctl agenda attest 01KX --occurrence 98eb14c2... --outcome partial --note "3 of 5 slices landed" --ref file:$HOME/handoff.md   # fired sessions: self-report your occurrence (rider names its id)
@@ -101,7 +102,9 @@ dashboard, attributed to your session.
 - **Scheduled sessions**: `schedule` proposes a session manifest on an
   item — at `--at`, the daemon spawns a normal supervised session with
   `--goal` as its task (never raw actions; add `--orchestrate` for the
-  orchestration shape). **Nothing fires until the owner approves the
+  orchestration shape, `--interactive` for the owner-sitting shape —
+  the fired session opens with the goal as the owner's message and
+  waits for them). **Nothing fires until the owner approves the
   manifest**, so propose and move on; the item badges the owner's
   attention rail. Approval is the owner's act alone (dashboard or an
   owner shell) — you may propose, but never attempt `approve` or

--- a/src/bin/caller/ctl.rs
+++ b/src/bin/caller/ctl.rs
@@ -2267,21 +2267,7 @@ async fn run_agenda(
             print_tool_response(response, config, None)?;
         }
         "schedule" => {
-            let mut value_flags = vec![
-                "--goal",
-                "--at",
-                "--every",
-                "--until",
-                "--max-occurrences",
-                "--suspend-after",
-                "--on-item-match",
-                "--project",
-                "--binding-ref",
-                "--source",
-            ];
-            value_flags.extend(AGENDA_LAUNCH_FLAGS);
-            let args =
-                parse_command_args(&raw[1..], &value_flags, &["--orchestrate", "--on-unblock"])?;
+            let args = agenda_schedule_parse(&raw[1..])?;
             let id = agenda_resolve_id(
                 client,
                 config,
@@ -2289,121 +2275,8 @@ async fn run_agenda(
                 "agenda schedule requires an item id (a unique prefix is enough)",
             )
             .await?;
-            let goal = args
-                .one("--goal")
-                .map(str::trim)
-                .filter(|g| !g.is_empty())
-                .ok_or_else(|| "agenda schedule requires --goal TEXT".to_string())?;
-            // Event triggers (Track T): fire on state, not at an instant.
-            let trigger = match (args.has("--on-unblock"), args.one("--on-item-match")) {
-                (true, Some(_)) => {
-                    return Err("pass --on-unblock OR --on-item-match, not both".to_string())
-                }
-                (true, None) => Some(serde_json::json!({ "kind": "on_unblock" })),
-                (false, Some(spec)) => {
-                    let (kind, tags) = spec.split_once(':').ok_or_else(|| {
-                        "--on-item-match takes KIND:TAG[,TAG...] (e.g. question:gate)".to_string()
-                    })?;
-                    let tags: Vec<Value> = tags
-                        .split(',')
-                        .map(str::trim)
-                        .filter(|tag| !tag.is_empty())
-                        .map(|tag| Value::String(tag.to_string()))
-                        .collect();
-                    Some(serde_json::json!({
-                        "kind": "on_item_match",
-                        "item_kind": kind.trim(),
-                        "tags": tags,
-                    }))
-                }
-                (false, None) => None,
-            };
-            if trigger.is_some() && args.one("--every").is_some() {
-                return Err(
-                    "a manifest is cadenced OR triggered: pass --every or a trigger flag, \
-                     not both"
-                        .to_string(),
-                );
-            }
-            let fire_at_ms = match args.one("--at") {
-                Some(at) => parse_due_ms(at)?,
-                // A triggered manifest's fire_at_ms is the ARM FLOOR —
-                // omitted means armed on approval.
-                None if trigger.is_some() => std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .map_err(|err| err.to_string())?
-                    .as_millis() as u64,
-                None => return Err("agenda schedule requires --at WHEN".to_string()),
-            };
-            let mut map = Map::new();
-            map.insert(
-                "op".to_string(),
-                Value::String("propose_effect".to_string()),
-            );
-            map.insert("id".to_string(), Value::String(id));
-            map.insert("goal".to_string(), Value::String(goal.to_string()));
-            map.insert("fire_at_ms".to_string(), Value::from(fire_at_ms));
-            if args.has("--orchestrate") {
-                map.insert("orchestrate".to_string(), Value::Bool(true));
-            }
-            // Standing cadence (G3-pre): declared INSIDE the digest-bound
-            // manifest, so one approval covers the series.
-            if let Some(every) = args.one("--every") {
-                let mut rec = Map::new();
-                rec.insert(
-                    "every_ms".to_string(),
-                    Value::from(parse_duration_ms(every)?),
-                );
-                if let Some(until) = args.one("--until") {
-                    rec.insert("until_ms".to_string(), Value::from(parse_due_ms(until)?));
-                }
-                if let Some(max) = args.one("--max-occurrences") {
-                    let max: u32 = max
-                        .parse()
-                        .map_err(|_| format!("--max-occurrences {max:?} is not a number"))?;
-                    rec.insert("max_occurrences".to_string(), Value::from(max));
-                }
-                if let Some(n) = args.one("--suspend-after") {
-                    let n: u32 = n
-                        .parse()
-                        .map_err(|_| format!("--suspend-after {n:?} is not a number"))?;
-                    rec.insert("suspend_after_failures".to_string(), Value::from(n));
-                }
-                map.insert("recurrence".to_string(), Value::Object(rec));
-            } else if args.one("--until").is_some()
-                || args.one("--max-occurrences").is_some()
-                || args.one("--suspend-after").is_some()
-            {
-                return Err(
-                    "--until/--max-occurrences/--suspend-after describe a standing cadence: \
-                     pass --every too"
-                        .to_string(),
-                );
-            }
-            let triggered = trigger.is_some();
-            if let Some(trigger) = trigger {
-                map.insert("trigger".to_string(), trigger);
-            }
-            // Explicit project pin (T3c): digest-bound on the manifest,
-            // so the approval covers WHERE the sessions run.
-            insert_string(&mut map, "project_root", args.one("--project"));
-            // Sealed refs: hash each --binding-ref at propose time — the
-            // pin states what THIS process read; the daemon verifies its
-            // own view at intake and re-verifies at every fire, so the
-            // approval digest covers the referenced content, not just
-            // the goal text.
-            let binding_refs = args
-                .all("--binding-ref")
-                .map(binding_ref_propose_value)
-                .collect::<Result<Vec<Value>, String>>()?;
-            if !binding_refs.is_empty() {
-                map.insert("binding_refs".to_string(), Value::Array(binding_refs));
-            }
-            insert_string(&mut map, "source", args.one("--source"));
-            // Executor pins (Track AU): the same launch vocabulary the
-            // start-now sheet records, digest-bound on the standing
-            // manifest — the owner approves WHO runs the goal.
-            insert_agenda_launch_config(&mut map, &args)?;
+            let map = agenda_schedule_propose_map(id, &args)?;
+            let triggered = map.contains_key("trigger");
             let response = call_tool(client, config, "agenda_op", Value::Object(map)).await?;
             let proposed_item = agenda_response_item(&response);
             print_tool_response(response, config, None)?;
@@ -3859,6 +3732,165 @@ fn build_dial_object(args: &CommandArgs) -> Result<Option<Value>, String> {
         return Ok(None);
     }
     Ok(Some(Value::Object(dial)))
+}
+
+/// Parse the `agenda schedule` argv — the verb's whole flag vocabulary
+/// in one place, so the flag→op tests exercise exactly the wiring the
+/// command uses.
+fn agenda_schedule_parse(raw: &[String]) -> Result<CommandArgs, String> {
+    let mut value_flags = vec![
+        "--goal",
+        "--at",
+        "--every",
+        "--until",
+        "--max-occurrences",
+        "--suspend-after",
+        "--on-item-match",
+        "--project",
+        "--binding-ref",
+        "--source",
+    ];
+    value_flags.extend(AGENDA_LAUNCH_FLAGS);
+    parse_command_args(
+        raw,
+        &value_flags,
+        &["--orchestrate", "--interactive", "--on-unblock"],
+    )
+}
+
+/// Build the `propose_effect` op body from the parsed `agenda schedule`
+/// flags — the flag→op mapping, extracted so the tests pin it. Only
+/// ctl-syntax contradictions (flag shapes, this-or-that flags that can't
+/// both serialize) are refused here; the daemon's intake owns the
+/// manifest grammar (cadence bounds, cadence-vs-trigger exclusivity,
+/// fireability) and its named refusals surface verbatim.
+fn agenda_schedule_propose_map(
+    id: String,
+    args: &CommandArgs,
+) -> Result<Map<String, Value>, String> {
+    let goal = args
+        .one("--goal")
+        .map(str::trim)
+        .filter(|g| !g.is_empty())
+        .ok_or_else(|| "agenda schedule requires --goal TEXT".to_string())?;
+    // Event triggers (Track T): fire on state, not at an instant.
+    let trigger = match (args.has("--on-unblock"), args.one("--on-item-match")) {
+        (true, Some(_)) => {
+            return Err("pass --on-unblock OR --on-item-match, not both".to_string());
+        }
+        (true, None) => Some(serde_json::json!({ "kind": "on_unblock" })),
+        (false, Some(spec)) => {
+            let (kind, tags) = spec.split_once(':').ok_or_else(|| {
+                "--on-item-match takes KIND:TAG[,TAG...] (e.g. question:gate)".to_string()
+            })?;
+            let tags: Vec<Value> = tags
+                .split(',')
+                .map(str::trim)
+                .filter(|tag| !tag.is_empty())
+                .map(|tag| Value::String(tag.to_string()))
+                .collect();
+            Some(serde_json::json!({
+                "kind": "on_item_match",
+                "item_kind": kind.trim(),
+                "tags": tags,
+            }))
+        }
+        (false, None) => None,
+    };
+    if trigger.is_some() && args.one("--every").is_some() {
+        return Err(
+            "a manifest is cadenced OR triggered: pass --every or a trigger flag, \
+             not both"
+                .to_string(),
+        );
+    }
+    let fire_at_ms = match args.one("--at") {
+        Some(at) => parse_due_ms(at)?,
+        // A triggered manifest's fire_at_ms is the ARM FLOOR —
+        // omitted means armed on approval.
+        None if trigger.is_some() => std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|err| err.to_string())?
+            .as_millis() as u64,
+        None => return Err("agenda schedule requires --at WHEN".to_string()),
+    };
+    let mut map = Map::new();
+    map.insert(
+        "op".to_string(),
+        Value::String("propose_effect".to_string()),
+    );
+    map.insert("id".to_string(), Value::String(id));
+    map.insert("goal".to_string(), Value::String(goal.to_string()));
+    map.insert("fire_at_ms".to_string(), Value::from(fire_at_ms));
+    if args.has("--orchestrate") {
+        map.insert("orchestrate".to_string(), Value::Bool(true));
+    }
+    // Session shape (the approval-time editor's toggle, PR #664): present
+    // rides `interactive: true` — the fired session opens with the goal
+    // as the owner's message and waits for them. Absent stays absent on
+    // the wire: the daemon defaults the legacy autonomous goal run, and
+    // the manifest keeps its absent-when-false byte shape.
+    if args.has("--interactive") {
+        map.insert("interactive".to_string(), Value::Bool(true));
+    }
+    // Standing cadence (G3-pre): declared INSIDE the digest-bound
+    // manifest, so one approval covers the series.
+    if let Some(every) = args.one("--every") {
+        let mut rec = Map::new();
+        rec.insert(
+            "every_ms".to_string(),
+            Value::from(parse_duration_ms(every)?),
+        );
+        if let Some(until) = args.one("--until") {
+            rec.insert("until_ms".to_string(), Value::from(parse_due_ms(until)?));
+        }
+        if let Some(max) = args.one("--max-occurrences") {
+            let max: u32 = max
+                .parse()
+                .map_err(|_| format!("--max-occurrences {max:?} is not a number"))?;
+            rec.insert("max_occurrences".to_string(), Value::from(max));
+        }
+        if let Some(n) = args.one("--suspend-after") {
+            let n: u32 = n
+                .parse()
+                .map_err(|_| format!("--suspend-after {n:?} is not a number"))?;
+            rec.insert("suspend_after_failures".to_string(), Value::from(n));
+        }
+        map.insert("recurrence".to_string(), Value::Object(rec));
+    } else if args.one("--until").is_some()
+        || args.one("--max-occurrences").is_some()
+        || args.one("--suspend-after").is_some()
+    {
+        return Err(
+            "--until/--max-occurrences/--suspend-after describe a standing cadence: \
+             pass --every too"
+                .to_string(),
+        );
+    }
+    if let Some(trigger) = trigger {
+        map.insert("trigger".to_string(), trigger);
+    }
+    // Explicit project pin (T3c): digest-bound on the manifest,
+    // so the approval covers WHERE the sessions run.
+    insert_string(&mut map, "project_root", args.one("--project"));
+    // Sealed refs: hash each --binding-ref at propose time — the
+    // pin states what THIS process read; the daemon verifies its
+    // own view at intake and re-verifies at every fire, so the
+    // approval digest covers the referenced content, not just
+    // the goal text.
+    let binding_refs = args
+        .all("--binding-ref")
+        .map(binding_ref_propose_value)
+        .collect::<Result<Vec<Value>, String>>()?;
+    if !binding_refs.is_empty() {
+        map.insert("binding_refs".to_string(), Value::Array(binding_refs));
+    }
+    insert_string(&mut map, "source", args.one("--source"));
+    // Executor pins (Track AU): the same launch vocabulary the
+    // start-now sheet records, digest-bound on the standing
+    // manifest — the owner approves WHO runs the goal.
+    insert_agenda_launch_config(&mut map, args)?;
+    Ok(map)
 }
 
 /// Resolve the first positional as an agenda item id, accepting any
@@ -5981,7 +6013,10 @@ fn help_agenda() {
   intendant ctl agenda reopen ID_PREFIX [--source LABEL]\n\
   intendant ctl agenda retire ID_PREFIX [--source LABEL]\n\
   intendant ctl agenda patch ID_PREFIX [--title TEXT] [--body TEXT] [--tag TAG]... [--clear-tags] [--due WHEN|--clear-due] [--source LABEL]\n\
-  intendant ctl agenda schedule ID_PREFIX --goal TEXT --at WHEN [--orchestrate]\n\
+  intendant ctl agenda schedule ID_PREFIX --goal TEXT --at WHEN [--orchestrate] [--interactive]\n\
+      # --interactive fires the owner-sitting shape: the session opens with the goal as the\n\
+      # owner's message and WAITS for them — e.g. --goal \"Sit with me on the release board\"\n\
+      # --at 07:30 --interactive; omitted = the autonomous goal run with write-back\n\
       [--every INTERVAL [--until WHEN] [--max-occurrences N] [--suspend-after N]] [--source LABEL]\n\
       [--on-unblock | --on-item-match KIND:TAG[,TAG...]]   # event trigger: fires on state, not\n\
       # at an instant — cadence OR trigger, never both; --at then defaults to now (the arm floor).\n\
@@ -6078,7 +6113,11 @@ Typed or not, nothing derives or fires from adjacency. `list\n\
 derived at print time.\n\
 \n\
 `schedule` proposes a session manifest on an item: at WHEN, spawn a normal\n\
-supervised session with that goal (never raw actions). --every INTERVAL\n\
+supervised session with that goal (never raw actions). --interactive pins\n\
+the session SHAPE on the digest-bound manifest: the fired session opens\n\
+with the goal as the owner's message and waits for them (omitted = the\n\
+autonomous goal run) — the approval covers HOW it runs, so flipping the\n\
+shape voids it like any other revision. --every INTERVAL\n\
 (45m/2h/7d/1w; floor 15m) declares a STANDING cadence inside the\n\
 digest-bound manifest: ONE approval covers every occurrence until revoked,\n\
 --until/--max-occurrences end the series, and --suspend-after N (default 3)\n\
@@ -6354,6 +6393,56 @@ mod tests {
             binding_ref_propose_value(&format!("file:{}", dir.path().join("missing.md").display()))
                 .unwrap_err();
         assert!(err.contains("not readable"), "{err}");
+    }
+
+    /// `schedule --interactive` → `propose_effect.interactive: true` (the
+    /// owner-sitting shape the manifest has carried since PR #664); absent
+    /// stays absent-on-the-wire, so a shape-less propose keeps the legacy
+    /// autonomous byte shape and the daemon's goal-run default applies.
+    /// The shape composes with the standing-cadence flags — the daemon's
+    /// intake is the one manifest-grammar authority and it accepts an
+    /// interactive series — so the CLI invents no exclusivity here.
+    #[test]
+    fn schedule_interactive_flag_maps_to_propose_effect_shape() {
+        let parsed = agenda_schedule_parse(&args(&[
+            "01KX",
+            "--goal",
+            "Sit with the owner on the release board",
+            "--at",
+            "1800000000000",
+            "--interactive",
+            "--every",
+            "7d",
+        ]))
+        .unwrap();
+        let map = agenda_schedule_propose_map("01KX".into(), &parsed).unwrap();
+        assert_eq!(
+            map.get("op").and_then(Value::as_str),
+            Some("propose_effect")
+        );
+        assert_eq!(map.get("interactive"), Some(&Value::Bool(true)));
+        assert!(
+            map.get("recurrence").is_some(),
+            "the shape composes with a standing cadence"
+        );
+
+        let legacy = agenda_schedule_parse(&args(&[
+            "01KX",
+            "--goal",
+            "Run the soak checks",
+            "--at",
+            "1800000000000",
+        ]))
+        .unwrap();
+        let map = agenda_schedule_propose_map("01KX".into(), &legacy).unwrap();
+        assert!(
+            !map.contains_key("interactive"),
+            "absent flag stays absent on the wire (legacy goal-run bytes)"
+        );
+        assert_eq!(
+            map.get("fire_at_ms"),
+            Some(&Value::from(1_800_000_000_000u64))
+        );
     }
 
     /// The read verbs' `/api` URL assembly: origin derived from the

--- a/src/bin/caller/ctl.rs
+++ b/src/bin/caller/ctl.rs
@@ -6016,7 +6016,7 @@ fn help_agenda() {
   intendant ctl agenda schedule ID_PREFIX --goal TEXT --at WHEN [--orchestrate] [--interactive]\n\
       # --interactive fires the owner-sitting shape: the session opens with the goal as the\n\
       # owner's message and WAITS for them — e.g. --goal \"Sit with me on the release board\"\n\
-      # --at 07:30 --interactive; omitted = the autonomous goal run with write-back\n\
+      # --at +1d --interactive; omitted = the autonomous goal run with write-back\n\
       [--every INTERVAL [--until WHEN] [--max-occurrences N] [--suspend-after N]] [--source LABEL]\n\
       [--on-unblock | --on-item-match KIND:TAG[,TAG...]]   # event trigger: fires on state, not\n\
       # at an instant — cadence OR trigger, never both; --at then defaults to now (the arm floor).\n\

--- a/static/app.html
+++ b/static/app.html
@@ -39165,7 +39165,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '1c615d0ee4fe17c4';
+const INTENDANT_APP_BUILD = 'c24f8ae46bbe07e8';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -101082,7 +101082,8 @@ function agendaInspEffectHtml(item) {
     if (st.kind === 'pending') {
       A('Approve this exact plan', 'eff-approve', 'prim',
         `Binds digest ${agendaShortDigest(e.digest)} — any edit voids it`);
-      A('Edit schedule…', 'sched');
+      A('Edit plan…', 'sched', '',
+        'The full plan — goal, schedule, shape, executor, project, sealed refs. Saving mints a new digest for you to approve');
       A('Decline', 'eff-withdraw', 'danger',
         'Withdraws this proposal — it stops asking for approval; the item and its history stay. Propose again anytime');
     } else if (['armed', 'watching', 'waiting', 'ready'].includes(st.kind)) {

--- a/static/app/ui2-agenda-inspector.js
+++ b/static/app/ui2-agenda-inspector.js
@@ -602,7 +602,8 @@ function agendaInspEffectHtml(item) {
     if (st.kind === 'pending') {
       A('Approve this exact plan', 'eff-approve', 'prim',
         `Binds digest ${agendaShortDigest(e.digest)} — any edit voids it`);
-      A('Edit schedule…', 'sched');
+      A('Edit plan…', 'sched', '',
+        'The full plan — goal, schedule, shape, executor, project, sealed refs. Saving mints a new digest for you to approve');
       A('Decline', 'eff-withdraw', 'danger',
         'Withdraws this proposal — it stops asking for approval; the item and its history stay. Propose again anytime');
     } else if (['armed', 'watching', 'waiting', 'ready'].includes(st.kind)) {


### PR DESCRIPTION
Closes the CLI parity gap on agenda card 01KYRZ6RTMTPXW: `ctl agenda schedule` gains `--interactive`, the manifest shape the `propose_effect` lane (and the dashboard edit sheet) has carried since #664 but the CLI could not express — a scheduled fires-and-waits-for-the-owner manifest previously required hand-built raw `agenda_op` JSON.

- `--interactive` on `ctl agenda schedule`: present rides `interactive: true` on the `propose_effect` op; absent stays absent-on-the-wire, keeping the legacy autonomous byte shape (the daemon defaults the goal run). No client-side grammar is invented: the daemon's intake stays the one manifest-grammar authority (cadence bounds, cadence-vs-trigger exclusivity, fireability) and its named refusals surface verbatim. The shape composes with `--every`/trigger flags, as the intake allows.
- The schedule arm's argv spec and flag-to-op mapping are extracted into `agenda_schedule_parse` / `agenda_schedule_propose_map` (logic unchanged apart from the new flag) so the mapping is unit-testable; a new test pins present-to-true, absent-stays-absent, and cadence composition.
- Help text teaches the flag in both the usage block (with a concrete example) and the `schedule` prose paragraph; `skills/intendant-agenda/SKILL.md` gains the owner-sitting example line and the shape parenthetical in its scheduled-sessions bullet.
- Rider from the card's annotations (owner-hit 2026-07-30): the agenda inspector's pending-state `Edit schedule…` button is renamed `Edit plan…` with a tooltip naming what the sheet round-trips since #664 (goal, schedule, shape, executor, project, sealed refs). Fragment edited; `static/app.html` regenerated by the assembler.
- One-line docs touch in `docs/src/agenda-and-memory.md` pointing the approval-time-editor paragraph at the new CLI lane.
