### PR TITLE
remote compute: ctl remote verbs, work-triggered skill, schema off session toolsets, lane-down alarm

### DIFF
--- a/docs/src/codex-cloud-workers.md
+++ b/docs/src/codex-cloud-workers.md
@@ -413,19 +413,37 @@ resolver rather than guessing.
 ## Provider-neutral remote commands
 
 An acquired or explicitly attached worker can run a bounded, non-interactive
-command for any supervised agent backend. The public tool is named
-`remote_command`, not
-`codex_cloud_shell`: Codex, Claude Code, Kimi Code, Pi, and native Intendant
-sessions all receive the same job vocabulary in their compact/core tool
-profile. Codex Cloud is only the first host adapter.
+command for any session on the daemon's machine. The implementation is one
+daemon-side tool named `remote_command`, not `codex_cloud_shell` — Codex
+Cloud is only the first host adapter — and its delivery is the
+`intendant ctl remote` verb family plus the `intendant-remote-compute`
+skill: native Intendant sessions keep the built-in tool, while external
+supervised backends and unsupervised harness shells reach the same lane
+through ctl. The schema deliberately does not ride supervised MCP session
+toolsets (context rent; ratified 2026-08-07) — profile shaping only hides
+the listing, so the daemon surface keeps answering `tools/call` by name and
+`intendant ctl tools schema remote_command` still serves the contract.
 
-The tool has four operations: `start`, `status`, `wait`, and `cancel`.
-`start` returns immediately with a daemon-local job id; `status` polls it,
-`wait` waits for at most 60 seconds, and `cancel` terminates the worker
-process tree. Omitted `host` (or `host: "auto"`) reuses a live worker whose
-environment and exact Git revision match, or submits and enrolls one. An
-operator can still select an already-connected lease with
-`host: "cloud:<task-id>"`:
+The job vocabulary has four operations: `start`, `status`, `wait`, and
+`cancel`. `start` returns immediately with a daemon-local job id; `status`
+polls it, one `wait` operation waits for at most 60 seconds, and `cancel`
+terminates the worker process tree. Omitted host (`auto`) reuses a live
+worker whose environment and exact Git revision match, or submits and
+enrolls one. An operator can still select an already-connected lease with
+`--host cloud:<task-id>`:
+
+```bash
+git push origin feature/example
+intendant ctl remote start --branch feature/example --revision 0123456789abcdef \
+    -- cargo test -p intendant-core
+intendant ctl remote wait remote-<id> --for 1800
+```
+
+`ctl remote wait` chunks bounded server-side waits until the job is
+terminal or its `--for` budget is spent, prints the bounded remote
+stdout/stderr, and exits 0 only for a succeeded job; daemon refusals
+surface verbatim. The generic raw form remains for scripting the tool
+directly:
 
 ```bash
 intendant ctl tools call remote_command --args '{
@@ -436,9 +454,6 @@ intendant ctl tools call remote_command --args '{
   "require_clean": true,
   "timeout_s": 900
 }'
-
-intendant ctl tools call remote_command \
-  --args '{"op":"wait","job_id":"remote-...","wait_s":30}'
 ```
 
 An automatically acquired job remains in `acquiring` while a cold provider
@@ -454,13 +469,8 @@ the leader's task and deadline.
 Uncommitted or not-yet-pushed source uses an explicit working-tree snapshot:
 
 ```bash
-intendant ctl tools call remote_command --args '{
-  "op": "start",
-  "source": "working_tree",
-  "argv": ["cargo", "check", "--workspace"],
-  "cache": "durable_sccache",
-  "timeout_s": 900
-}'
+intendant ctl remote start --source working_tree --cache durable_sccache \
+    -- cargo check --workspace
 ```
 
 The contract is intentionally stricter than an interactive terminal:
@@ -634,13 +644,15 @@ enabling it does two bounded things.
    lane's own job.
 2. **Skill materialization.** While enabled AND ready, the shared
    `intendant-remote-compute` agent skill — the workflow teaching that used
-   to live in system prompts: prefer `remote_command` for heavy
-   platform-neutral work, never silently fall back to heavy local work,
+   to live in system prompts: route heavy platform-neutral work through
+   `intendant ctl remote`, never silently fall back to heavy local work,
    `working_tree` snapshots for iteration vs pushed `git_revision` for
    authoritative validation, honest cache expectations — is installed into
    `~/.agents/skills/` and `~/.claude/skills/` with plugin provenance
-   markers, so native, Codex, Claude Code, Kimi Code, and Pi sessions all
-   see it. Disabling (or losing readiness) sweeps exactly the
+   markers. Its description triggers on the WORK (a heavy platform-neutral
+   build/test/lint sweep about to run locally), not on tool possession, so
+   supervised backends, native sessions, and plain coding-harness sessions
+   all route through it. Disabling (or losing readiness) sweeps exactly the
    Intendant-managed copies; a user's same-named skill directory is never
    touched. Enable state lives under the daemon state root, survives
    restarts, and reconciles at every boot.
@@ -670,10 +682,14 @@ follow-up tool returns the acceptance receipt (parent turn, new turn ids)
 under the same fail-closed contract as the CLI verb.
 
 `remote_command` is different: it does not create provider work or ask Codex
-to reason. It spends shell authority on an attached compute host, so it is in
-the compact/core profile used by every supervised backend and is IAM-classed
-as `shell.spawn`. Claude Code, Kimi Code, Pi, and Codex therefore use the same
-attached Linux worker without changing which model is doing the reasoning.
+to reason. It spends shell authority on an attached compute host and is
+IAM-classed as `shell.spawn`. Since 2026-08-07 its schema no longer rides
+the compact/core profile either — supervised backends reach the lane through
+`"$INTENDANT" ctl remote` (their injected session token binds the call to
+their session, so job ownership and cache namespacing are unchanged), and
+the unprofiled daemon listing keeps serving the schema for ctl discovery.
+Claude Code, Kimi Code, Pi, and Codex therefore use the same attached Linux
+worker without changing which model is doing the reasoning.
 
 ## Environment bootstrap
 

--- a/docs/src/external-agent-orchestration.md
+++ b/docs/src/external-agent-orchestration.md
@@ -26,18 +26,23 @@ one in Intendant gives you:
   MCP server over the running gateway. Pi receives the same session-scoped
   authority through `$INTENDANT ctl`; this preserves Pi's intentionally small
   core instead of inventing a fake MCP integration.
-- **Provider-neutral remote compute.** The compact bootstrap advertises
-  `remote_command` to Codex, Claude Code, and Kimi Code; Pi reaches the same
-  job vocabulary through `$INTENDANT ctl tools call remote_command`. Host
-  `auto` reuses or acquires a matching Codex Cloud Linux worker, while
-  `source: working_tree` sends the backend's explicit uncommitted snapshot.
+- **Provider-neutral remote compute.** Every supervised backend reaches the
+  daemon's `remote_command` job vocabulary through
+  `"$INTENDANT" ctl remote start|status|wait|cancel` — the injected
+  session-scoped `INTENDANT_MCP_URL` binds the call to the session, so job
+  ownership and cache namespacing follow the session's recorded project
+  root. The schema deliberately no longer rides the compact MCP bootstrap
+  (context rent; ratified 2026-08-07): the daemon surface still serves the
+  tool by name, and native sessions keep their built-in twin. Host `auto`
+  reuses or acquires a matching Codex Cloud Linux worker, while
+  `--source working_tree` sends the backend's explicit uncommitted snapshot.
   Heavy platform-neutral builds and tests therefore move off the supervisor
   without changing which backend does the reasoning. Platform-specific CI
   remains authoritative, and the backend never silently falls back to a
   heavy local build when acquisition fails. The workflow *teaching* lives in
   the shared `intendant-remote-compute` agent skill, materialized for every
   backend only while the **Codex Cloud Remote Compute** plugin (dashboard →
-  Plugins; default off) is enabled and ready — the tool itself stays
+  Plugins; default off) is enabled and ready — the ctl lane itself stays
   available and self-describing either way.
 - **Presence & multi-session.** The supervised session is just another session on
   the [EventBus](./architecture.md); the [presence layer](./presence.md) narrates
@@ -333,12 +338,13 @@ own native capabilities where the upstream CLIs provide them.
   core profile keeps a small bootstrap surface: `get_status`, the shared-view
   tools, and the minimal display/CU path (`list_displays`, `grant_user_display`,
   `revoke_user_display`, `read_screen`, `take_screenshot`,
-  `execute_cu_actions`), plus `remote_command` for heavy platform-neutral
-  compute on an attached host, for managed **and** vanilla sessions; managed
-  context additionally exposes the managed-context/fission tools. Broad or
-  rare Intendant operations should be discovered lazily through
-  `intendant ctl --help`, `intendant ctl tools list`, and focused subcommand
-  help. Supervised Codex sessions receive
+  `execute_cu_actions`), for managed **and** vanilla sessions; managed
+  context additionally exposes the managed-context/fission tools. Heavy
+  platform-neutral compute rides `"$INTENDANT" ctl remote` rather than an
+  advertised MCP schema (the `remote_command` tool stays daemon-side and
+  callable by name). Broad or rare Intendant operations should be discovered
+  lazily through `intendant ctl --help`, `intendant ctl tools list`, and
+  focused subcommand help. Supervised Codex sessions receive
   `INTENDANT=/absolute/path/to/intendant`, `INTENDANT_MCP_URL`,
   `INTENDANT_SESSION_ID`, and `INTENDANT_MANAGED_CONTEXT`, so agent shells can
   run `"$INTENDANT" ctl ...` without relying on user PATH setup. Claude Code

--- a/plugins/codex-cloud-remote-compute/skills/intendant-remote-compute/SKILL.md
+++ b/plugins/codex-cloud-remote-compute/skills/intendant-remote-compute/SKILL.md
@@ -1,21 +1,15 @@
 ---
 name: intendant-remote-compute
-description: In any Intendant-supervised native, Codex, Claude Code, Kimi Code, or Pi session where the remote_command tool is available, heavy platform-neutral development work — full compiles, broad test suites, workspace lint/clippy sweeps, benchmarks, code generation — MUST run through that tool instead of loading the local machine. Never silently fall back to heavy local work when the remote lane fails; report the failure or pick a genuinely cheap alternative. Cheap commands and small platform-specific checks stay local.
+description: In ANY session on a machine run by an Intendant daemon — a supervised native, Codex, Claude Code, Kimi Code, or Pi session, an unsupervised coding-harness session, or a subagent — heavy platform-neutral development work (full compiles, workspace builds, broad test suites, workspace lint/clippy sweeps, benchmarks, code generation) MUST be offloaded through Intendant's remote-compute lane instead of loading the local machine. The trigger is the WORK, not tool possession — if you are about to run a heavy build/check/clippy/test sweep locally, read this first; `intendant ctl remote` reaches the lane from every session kind. Never silently fall back to heavy local work when the remote lane fails; report the failure or pick a genuinely cheap alternative. Cheap commands, small platform-specific checks, and validation batteries that assert non-root permission behavior stay local.
 ---
-
-> Applicability check first: if the `remote_command` tool is not available
-> to you — as a native tool, or through `"$INTENDANT" ctl tools call
-> remote_command` under Intendant supervision — this skill does not apply:
-> you are not running under an Intendant daemon with the Remote Compute
-> plugin enabled. Say so if the task assumed otherwise, and work locally at
-> normal discretion.
 
 # Remote Compute: offload heavy work
 
 ## The rule
 
-- Heavy, platform-neutral work — full compiles, broad test runs, workspace
-  clippy, benchmarks, code generation — runs remotely via `remote_command`.
+- Heavy, platform-neutral work — full compiles, workspace builds, broad test
+  runs, workspace clippy, benchmarks, code generation — runs remotely
+  through the daemon's provider-neutral remote-compute lane.
 - Do NOT silently fall back to heavy local work if the cloud lane fails.
   Report the failure, or pick a genuinely cheap alternative (for example,
   `cargo check` on the one crate you touched).
@@ -23,21 +17,56 @@ description: In any Intendant-supervised native, Codex, Claude Code, Kimi Code, 
   small builds) and small platform-specific checks stay local. Platform CI
   remains authoritative for platform-only behavior and for final
   cross-platform confidence.
+- Remote workers run as root: test suites that assert non-root permission
+  or sandbox behavior (permission-injection tests, sandbox-denial
+  assertions) fail there, so a validation battery containing such tests
+  stays local — offload the platform-neutral compile/check/clippy volume
+  around it instead.
 
-## How to invoke
+## How to invoke — `intendant ctl remote` (every session kind)
 
-- Native Intendant sessions call the `remote_command` tool directly;
-  external backends under supervision reach the same lane with
-  `"$INTENDANT" ctl tools call remote_command`.
-- Always run from an isolated git worktree.
-- Omit the `host` argument so scheduling stays provider-neutral —
-  reusing or acquiring a matching worker is the daemon's job.
-- Iterate with `source: "working_tree"` (an explicit content-addressed
-  snapshot of your local changes); run final, authoritative validation
-  with `source: "git_revision"` plus a pushed `expected_revision`.
+The primary lane is the CLI verb family; it works from supervised sessions
+and plain harness/owner shells alike, with real flags instead of hand-built
+JSON:
+
+```bash
+git push origin my-branch    # the worker checks out a PUSHED revision
+"$INTENDANT" ctl remote start --branch my-branch --revision <sha> \
+    -- cargo clippy --workspace -- -D warnings
+"$INTENDANT" ctl remote wait remote-<id> --for 1800
+```
+
+- Resolve the CLI: supervised sessions receive `INTENDANT` (absolute
+  controller path) in their environment — use `"$INTENDANT" ctl remote …`.
+  Unsupervised shells use `intendant ctl remote …` against the local
+  daemon. `ctl remote --help` teaches every flag.
+- `start` returns the job id immediately; `wait JOB --for SECONDS` blocks
+  until the job is terminal (exit 0 only for success, remote output
+  printed), `status` polls once, `cancel` stops it. Refusals and failures
+  surface the daemon's words verbatim.
+- Identity rides the normal ctl lanes: inside a supervised session the
+  injected `INTENDANT_MCP_URL` binds your session, so the daemon resolves
+  your recorded project root (this is what `--cache durable_sccache`
+  namespaces by). Unsupervised callers run without a project root — omit
+  `--cache` and accept a cold build, and pass `--branch` explicitly.
+- Always run from an isolated git worktree, and omit `--host` so
+  scheduling stays provider-neutral — reusing or acquiring a matching
+  worker is the daemon's job.
+- Iterate with `--source working_tree` (an explicit content-addressed
+  snapshot of your local changes; needs a supervised session's project
+  root); run final, authoritative validation with the default
+  `git_revision` source plus a pushed `--revision`.
 - When the daemon cannot infer the supervised worktree's provider branch,
-  pass the pushed branch explicitly as `branch`. The worker must still report
-  the requested `expected_revision`; a branch name never weakens that guard.
+  pass the pushed branch explicitly as `--branch`. The worker must still
+  report the requested revision; a branch name never weakens that guard.
+
+Native Intendant sessions can call the built-in `remote_command` tool
+directly instead — the same job vocabulary (`op: start|status|wait|cancel`)
+behind the ctl verbs. External supervised backends no longer carry the MCP
+schema in their toolsets; `"$INTENDANT" ctl remote` is their lane.
+
+## What `--cache durable_sccache` honestly does
+
 - For Rust work that should reuse compile outputs after worker replacement,
   request `cache: "durable_sccache"`. The default authenticated relay needs no
   cloud credentials, but it namespaces its cache repository by the supervised
@@ -49,15 +78,15 @@ description: In any Intendant-supervised native, Codex, Claude Code, Kimi Code, 
 
 ## Waiting for an acquired worker
 
-- `start` returns immediately. Keep its `job_id`, then use `status` or repeated
-  `wait` calls (at most 60 seconds each) until the same job is terminal.
 - A job in `acquiring` may still be creating a cold worker. Read
-  `job.acquisition`: it names the stage, pushed branch, provider task id and
-  URL, provider and attachment states, deadline, coalescing, and the latest
-  provider-refresh error. Do not submit a duplicate merely because setup is
-  slow. Matching environment/revision/branch requests already coalesce.
+  `job.acquisition` (printed by `ctl remote status`/`wait`): it names the
+  stage, pushed branch, provider task id and URL, provider and attachment
+  states, deadline, coalescing, and the latest provider-refresh error. Do
+  not submit a duplicate merely because setup is slow. Matching
+  environment/revision/branch requests already coalesce.
 - Automatic acquisition allows one hour by default because a small cold worker
-  can take tens of minutes to prepare. A terminal provider task fails early. An
+  can take tens of minutes to prepare. Prefer one `ctl remote wait JOB
+  --for 3600` over resubmitting. A terminal provider task fails early. An
   acquisition timeout leaves the provider task running and reports its URL; do
   not claim that it was cancelled.
 
@@ -85,3 +114,17 @@ description: In any Intendant-supervised native, Codex, Claude Code, Kimi Code, 
   provider error when present, then continue with cheap local steps only.
   Escalate the lane failure rather than quietly running the expensive thing
   locally.
+- A "Not signed in" / signed-out failure means the provider lease died —
+  leases do not survive daemon restarts, so the lane is down for everyone
+  until it is re-armed from the Vault tab. The daemon parks one lane-down
+  agenda note on the first such failure per boot; say so in your report
+  rather than treating it as your session's private problem.
+
+## Provider plumbing (rarely needed)
+
+The lane's first host adapter is Codex Cloud. Worker-lease diagnosis and
+operator-side task management live on the `intendant codex-cloud` CLI
+family (`doctor`, `list`, `status`, `attach`, `pull`, …) and the
+`docs/src/codex-cloud-workers.md` chapter — reach for them only when the
+lane itself misbehaves; submitting and scheduling workers is the daemon's
+job, not yours.

--- a/skills/intendant-cli/SKILL.md
+++ b/skills/intendant-cli/SKILL.md
@@ -72,6 +72,7 @@ Useful groups:
 - `"$INTENDANT" ctl approval --help` and `"$INTENDANT" ctl input --help` for pending approval/input flows.
 - `"$INTENDANT" ctl context --help` for managed-context rewind/backout.
 - `"$INTENDANT" ctl controller --help` for controller-loop and restart controls.
+- `"$INTENDANT" ctl remote --help` for the **remote-compute lane** — offload heavy platform-neutral commands (workspace builds, broad tests, clippy sweeps) to an acquired remote worker: `ctl remote start [flags] -- CMD…`, then `wait|status|cancel`. When to offload, the honest carve-outs, and failure conduct live in the `intendant-remote-compute` skill.
 - `"$INTENDANT" ctl tools schema TOOL` and `"$INTENDANT" ctl tools call TOOL --args JSON` for rare or newly-added MCP tools.
 
 Prefer `--json` when the output will be inspected by an agent. Use `--session ID` when operating on a specific session. Use `--managed-context managed` for rewind/backout commands.

--- a/src/bin/caller/ctl.rs
+++ b/src/bin/caller/ctl.rs
@@ -44,6 +44,8 @@ struct CommandArgs {
     bools: BTreeSet<String>,
 }
 
+mod remote;
+
 pub async fn run(raw_args: Vec<String>) -> Result<(), String> {
     let (config, command) = parse_global_args(raw_args)?;
     let (mut config, command) = parse_output_flags(config, command);
@@ -116,6 +118,7 @@ pub async fn run(raw_args: Vec<String>) -> Result<(), String> {
         "settings" | "set" => run_settings(&client, &config, &command[1..]).await?,
         "session" | "sessions" => run_session(&client, &config, &command[1..]).await?,
         "task" => run_task(&client, &config, &command[1..]).await?,
+        "remote" => remote::run_remote(&client, &config, &command[1..]).await?,
         "agenda" => run_agenda(&client, &config, &command[1..]).await?,
         "memory" => run_memory(&client, &config, &command[1..]).await?,
         "controller" => run_controller(&client, &config, &command[1..]).await?,
@@ -5603,6 +5606,7 @@ Commands:\n\
   settings                  Autonomy and verbosity\n\
   session                   Session transcript notes (display-only, optional images)\n\
   task                      Start tasks\n\
+  remote                    Offload heavy platform-neutral commands to a remote worker\n\
   agenda                    The daemon's agenda: park, list, and resolve durable intent\n\
   memory                    Memory claims: propose, search, read\n\
   controller                Controller loop and restart controls\n\

--- a/src/bin/caller/ctl/remote.rs
+++ b/src/bin/caller/ctl/remote.rs
@@ -1,0 +1,701 @@
+//! `intendant ctl remote` — the ergonomic verb family over the daemon's
+//! provider-neutral `remote_command` tool.
+//!
+//! The lane's delivery is SKILL + CTL (2026-08-07 ratification): sessions
+//! learn WHEN to offload from the `intendant-remote-compute` skill and reach
+//! the daemon tool through these verbs instead of hand-building
+//! `tools call remote_command` JSON (the observed failure mode: an -32603
+//! "missing field argv" stumble mid-offload). Every verb maps real flags to
+//! the tool's op vocabulary, keeps daemon refusals verbatim, and exits
+//! nonzero for anything short of a succeeded job. Identity rides the normal
+//! ctl lanes: inside a supervised session the injected `INTENDANT_MCP_URL`
+//! token binds the session (its recorded project root namespaces
+//! `durable_sccache`); unsupervised loopback callers run unrestricted with
+//! no project root, so `--cache durable_sccache` fails early there by
+//! design.
+
+use super::{
+    call_tool, ensure_help, parse_command_args, print_json, single_text_content, CommandArgs,
+    Config,
+};
+use serde_json::{Map, Value};
+
+pub(super) async fn run_remote(
+    client: &reqwest::Client,
+    config: &Config,
+    raw: &[String],
+) -> Result<(), String> {
+    ensure_help(raw, help_remote)?;
+    if raw.is_empty() {
+        help_remote();
+        return Ok(());
+    }
+    match raw[0].as_str() {
+        "start" => {
+            let arguments = remote_start_args(&raw[1..])?;
+            let response = call_tool(client, config, "remote_command", arguments).await?;
+            let job = remote_job_from_response(&response)?;
+            if config.raw {
+                return print_json(&response);
+            }
+            if config.json {
+                return print_json(&job);
+            }
+            let job_id = job_field(&job, "job_id").unwrap_or("?");
+            println!(
+                "started remote job {job_id} (state {}, host {})",
+                job_field(&job, "state").unwrap_or("?"),
+                job_field(&job, "host").unwrap_or("?"),
+            );
+            println!("  wait:   intendant ctl remote wait {job_id} --for 1800");
+            println!("  status: intendant ctl remote status {job_id}");
+            println!("  cancel: intendant ctl remote cancel {job_id}");
+            Ok(())
+        }
+        "status" => {
+            let job_id = remote_job_id(&raw[1..], "status", &[])?;
+            let response = call_tool(
+                client,
+                config,
+                "remote_command",
+                serde_json::json!({ "op": "status", "job_id": job_id }),
+            )
+            .await?;
+            let job = remote_job_from_response(&response)?;
+            if config.raw {
+                return print_json(&response);
+            }
+            if config.json {
+                return print_json(&job);
+            }
+            print_job_report(&job);
+            Ok(())
+        }
+        "wait" => {
+            let args = parse_command_args(&raw[1..], &["--for"], &[])?;
+            let job_id = positional_job_id(&args, "wait")?;
+            let total_s = match args.one("--for") {
+                Some(value) => value
+                    .parse::<u64>()
+                    .map_err(|_| format!("--for {value:?} is not a number of seconds"))?,
+                None => DEFAULT_WAIT_FOR_S,
+            };
+            if total_s == 0 {
+                return Err("--for must be at least 1 second".to_string());
+            }
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(total_s);
+            let mut last_progress = String::new();
+            loop {
+                let remaining_s = deadline
+                    .saturating_duration_since(std::time::Instant::now())
+                    .as_secs();
+                if remaining_s == 0 {
+                    return Err(format!(
+                        "remote job {job_id} is not terminal after {total_s}s — the job keeps \
+                         running; re-run `intendant ctl remote wait {job_id}` or check \
+                         `intendant ctl remote status {job_id}`"
+                    ));
+                }
+                let response = call_tool(
+                    client,
+                    config,
+                    "remote_command",
+                    serde_json::json!({
+                        "op": "wait",
+                        "job_id": job_id,
+                        "wait_s": wait_chunk_s(remaining_s),
+                    }),
+                )
+                .await?;
+                let job = remote_job_from_response(&response)?;
+                let state = job_field(&job, "state").unwrap_or("?").to_string();
+                if state_is_terminal(&state) {
+                    if config.raw {
+                        return print_json(&response);
+                    }
+                    if config.json {
+                        print_json(&job)?;
+                    } else {
+                        print_job_report(&job);
+                    }
+                    return terminal_outcome(&job, &state);
+                }
+                // Progress heartbeat on stderr so scripts capturing stdout
+                // see only the final report.
+                let progress = progress_line(&job, &state);
+                if progress != last_progress {
+                    eprintln!("{progress} ({remaining_s}s left)");
+                    last_progress = progress;
+                }
+            }
+        }
+        "cancel" => {
+            let job_id = remote_job_id(&raw[1..], "cancel", &[])?;
+            let response = call_tool(
+                client,
+                config,
+                "remote_command",
+                serde_json::json!({ "op": "cancel", "job_id": job_id }),
+            )
+            .await?;
+            let job = remote_job_from_response(&response)?;
+            if config.raw {
+                return print_json(&response);
+            }
+            if config.json {
+                return print_json(&job);
+            }
+            print_job_report(&job);
+            Ok(())
+        }
+        other => Err(format!(
+            "unknown remote command '{other}'. Run `intendant ctl remote --help`."
+        )),
+    }
+}
+
+/// Default total wait budget for `remote wait`. Matches the tool's default
+/// command timeout; a cold acquisition can need more (`--for 3600`).
+const DEFAULT_WAIT_FOR_S: u64 = 900;
+
+/// One server-side `wait` op accepts 1-60 seconds; chunk the client budget.
+fn wait_chunk_s(remaining_s: u64) -> u64 {
+    remaining_s.clamp(1, 60)
+}
+
+/// Client-side terminal set. Pinned against
+/// `remote_compute::RemoteCommandState::is_terminal` by a unit test so the
+/// wait loop can never spin on a state the daemon considers finished.
+fn state_is_terminal(state: &str) -> bool {
+    matches!(state, "succeeded" | "failed" | "timed_out" | "cancelled")
+}
+
+/// Map the `remote start` argv to the tool's `op: start` arguments. The
+/// remote command itself comes after `--` (everything past the first `--`
+/// travels verbatim, later `--` included). Only ctl-syntax contradictions
+/// are refused here; the daemon's validation owns the job grammar and its
+/// named refusals surface verbatim.
+fn remote_start_args(raw: &[String]) -> Result<Value, String> {
+    let args = parse_command_args(
+        raw,
+        &[
+            "--host",
+            "--branch",
+            "--revision",
+            "--source",
+            "--cache",
+            "--cwd",
+            "--env",
+            "--timeout",
+        ],
+        &["--allow-dirty"],
+    )
+    .map_err(|error| {
+        format!("{error} (the remote command and its own flags go after `--`)")
+    })?;
+    if args.positional.is_empty() {
+        return Err(
+            "remote start requires the command after `--`, e.g. `intendant ctl remote start \
+             --revision SHA -- cargo check --workspace`"
+                .to_string(),
+        );
+    }
+    let mut map = Map::new();
+    map.insert("op".to_string(), Value::String("start".to_string()));
+    map.insert(
+        "argv".to_string(),
+        Value::Array(
+            args.positional
+                .iter()
+                .map(|arg| Value::String(arg.clone()))
+                .collect(),
+        ),
+    );
+    insert_flag_string(&mut map, "host", args.one("--host"));
+    insert_flag_string(&mut map, "branch", args.one("--branch"));
+    insert_flag_string(&mut map, "expected_revision", args.one("--revision"));
+    insert_flag_string(&mut map, "cwd", args.one("--cwd"));
+    if let Some(source) = args.one("--source") {
+        if !matches!(source, "git_revision" | "working_tree") {
+            return Err(format!(
+                "--source {source:?} is not a source mode (git_revision or working_tree)"
+            ));
+        }
+        map.insert("source".to_string(), Value::String(source.to_string()));
+    }
+    if let Some(cache) = args.one("--cache") {
+        if !matches!(cache, "none" | "durable_sccache") {
+            return Err(format!(
+                "--cache {cache:?} is not a cache mode (none or durable_sccache)"
+            ));
+        }
+        map.insert("cache".to_string(), Value::String(cache.to_string()));
+    }
+    let mut env = Map::new();
+    for entry in args.all("--env") {
+        let Some((key, value)) = entry.split_once('=') else {
+            return Err(format!("--env {entry:?} is not KEY=VALUE"));
+        };
+        if key.is_empty() {
+            return Err(format!("--env {entry:?} has an empty variable name"));
+        }
+        env.insert(key.to_string(), Value::String(value.to_string()));
+    }
+    if !env.is_empty() {
+        map.insert("env".to_string(), Value::Object(env));
+    }
+    if let Some(timeout) = args.one("--timeout") {
+        let timeout: u64 = timeout
+            .parse()
+            .map_err(|_| format!("--timeout {timeout:?} is not a number of seconds"))?;
+        map.insert("timeout_s".to_string(), Value::from(timeout));
+    }
+    if args.has("--allow-dirty") {
+        map.insert("require_clean".to_string(), Value::Bool(false));
+    }
+    Ok(Value::Object(map))
+}
+
+fn insert_flag_string(map: &mut Map<String, Value>, key: &str, value: Option<&str>) {
+    if let Some(value) = value {
+        map.insert(key.to_string(), Value::String(value.to_string()));
+    }
+}
+
+fn remote_job_id(raw: &[String], verb: &str, value_flags: &[&str]) -> Result<String, String> {
+    let args = parse_command_args(raw, value_flags, &[])?;
+    positional_job_id(&args, verb)
+}
+
+fn positional_job_id(args: &CommandArgs, verb: &str) -> Result<String, String> {
+    match args.positional.as_slice() {
+        [job_id] => Ok(job_id.clone()),
+        [] => Err(format!(
+            "remote {verb} requires the job id from `remote start` (remote-…)"
+        )),
+        more => Err(format!(
+            "remote {verb} takes exactly one job id, got {}",
+            more.len()
+        )),
+    }
+}
+
+/// Unwrap the tool's `{"ok": …}` envelope from the JSON-RPC response.
+/// Transport/IAM errors and `ok: false` refusals both surface verbatim —
+/// this lane never rewrites what the daemon said.
+fn remote_job_from_response(response: &Value) -> Result<Value, String> {
+    if let Some(error) = response.get("error") {
+        return Err(format!(
+            "MCP error: {}",
+            serde_json::to_string_pretty(error).unwrap_or_else(|_| error.to_string())
+        ));
+    }
+    let result = response
+        .get("result")
+        .ok_or_else(|| "JSON-RPC response missing result".to_string())?;
+    let text = single_text_content(result)
+        .ok_or_else(|| "remote_command result carried no text content".to_string())?;
+    let envelope: Value = serde_json::from_str(text)
+        .map_err(|_| format!("remote_command returned unparseable output: {text}"))?;
+    match envelope.get("ok").and_then(Value::as_bool) {
+        Some(true) => envelope
+            .get("job")
+            .cloned()
+            .ok_or_else(|| "remote_command ok response carried no job".to_string()),
+        Some(false) => Err(envelope
+            .get("error")
+            .and_then(Value::as_str)
+            .unwrap_or(text)
+            .to_string()),
+        None => Err(format!("remote_command returned unexpected output: {text}")),
+    }
+}
+
+fn job_field<'a>(job: &'a Value, key: &str) -> Option<&'a str> {
+    job.get(key).and_then(Value::as_str)
+}
+
+fn progress_line(job: &Value, state: &str) -> String {
+    let mut line = format!("remote job {} {state}", job_field(job, "job_id").unwrap_or("?"));
+    if let Some(acquisition) = job.get("acquisition") {
+        if let Some(stage) = acquisition.get("stage").and_then(Value::as_str) {
+            line.push_str(&format!(" ({stage}"));
+            if let Some(task) = acquisition.get("task_id").and_then(Value::as_str) {
+                line.push_str(&format!(", task {task}"));
+            }
+            line.push(')');
+        }
+    }
+    line
+}
+
+/// Human report for a job view: identity and state on the first line, then
+/// acquisition/result detail, then the bounded remote output. Stdout keeps
+/// the report; nothing here re-words daemon-reported errors.
+fn print_job_report(job: &Value) {
+    let mut head = format!(
+        "job {}  state={}  host={}",
+        job_field(job, "job_id").unwrap_or("?"),
+        job_field(job, "state").unwrap_or("?"),
+        job_field(job, "host").unwrap_or("?"),
+    );
+    if let Some(result) = job.get("result") {
+        if let Some(exit) = result.get("exit_code").and_then(Value::as_i64) {
+            head.push_str(&format!("  exit={exit}"));
+        }
+        if let Some(ms) = result.get("duration_ms").and_then(Value::as_u64) {
+            head.push_str(&format!("  duration={:.1}s", ms as f64 / 1000.0));
+        }
+    }
+    println!("{head}");
+    if let Some(acquisition) = job.get("acquisition") {
+        let stage = acquisition
+            .get("stage")
+            .and_then(Value::as_str)
+            .unwrap_or("?");
+        println!("  acquisition: {stage}");
+        if let Some(url) = acquisition.get("task_url").and_then(Value::as_str) {
+            println!("  task url: {url}");
+        }
+        if let Some(error) = acquisition
+            .get("last_provider_error")
+            .and_then(Value::as_str)
+        {
+            println!("  last provider error: {error}");
+        }
+    }
+    if let Some(result) = job.get("result") {
+        if let Some(cache) = result.get("cache") {
+            println!(
+                "  cache: {} hits+{} misses+{} writes+{} errors+{}",
+                cache.get("mode").and_then(Value::as_str).unwrap_or("?"),
+                cache.get("hits_delta").and_then(Value::as_u64).unwrap_or(0),
+                cache
+                    .get("misses_delta")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0),
+                cache
+                    .get("writes_delta")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0),
+                cache
+                    .get("errors_delta")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0),
+            );
+        }
+        for (name, truncated_key) in [("stdout", "stdout_truncated"), ("stderr", "stderr_truncated")]
+        {
+            let text = result.get(name).and_then(Value::as_str).unwrap_or("");
+            if !text.is_empty() {
+                let truncated = result
+                    .get(truncated_key)
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                let marker = if truncated { " (truncated)" } else { "" };
+                println!("--- {name}{marker} ---");
+                println!("{}", text.trim_end_matches('\n'));
+            }
+        }
+    }
+    if let Some(error) = job_field(job, "error") {
+        println!("error: {error}");
+    }
+}
+
+/// Exit mapping for a terminal job: only `succeeded` composes as success,
+/// so `ctl remote start … && ctl remote wait …` behaves like the local
+/// command would. The failure line carries the daemon's error verbatim.
+fn terminal_outcome(job: &Value, state: &str) -> Result<(), String> {
+    if state == "succeeded" {
+        return Ok(());
+    }
+    let error = job_field(job, "error")
+        .or_else(|| {
+            job.get("result")
+                .and_then(|result| result.get("error"))
+                .and_then(Value::as_str)
+        })
+        .unwrap_or("no error detail");
+    Err(format!(
+        "remote job {} {state}: {error}",
+        job_field(job, "job_id").unwrap_or("?")
+    ))
+}
+
+fn help_remote() {
+    println!(
+        "Usage:\n\
+  intendant ctl remote start [FLAGS] -- PROGRAM [ARGS...]\n\
+  intendant ctl remote status JOB_ID\n\
+  intendant ctl remote wait JOB_ID [--for SECONDS]\n\
+  intendant ctl remote cancel JOB_ID\n\
+\n\
+Run heavy platform-neutral work — workspace builds, broad test suites,\n\
+clippy sweeps, benchmarks — on an acquired remote worker instead of\n\
+loading this machine. This is the ergonomic form of the daemon's\n\
+remote_command tool (raw: intendant ctl tools call remote_command); the\n\
+daemon reuses or acquires a matching Codex Cloud worker, and scheduling\n\
+stays provider-neutral when --host is omitted. When to offload and when\n\
+to stay local: the intendant-remote-compute skill.\n\
+\n\
+start flags:\n\
+  --revision SHA     Pushed commit the worker must report (required for the\n\
+                     default git_revision source; optional base for\n\
+                     working_tree)\n\
+  --branch NAME      Pushed provider branch containing --revision; pass it\n\
+                     when no supervised project root can derive it\n\
+  --source MODE      git_revision (default) or working_tree (bounded\n\
+                     snapshot of your uncommitted changes; needs a\n\
+                     supervised session's project root)\n\
+  --cache MODE       none (default) or durable_sccache (namespaced by the\n\
+                     supervised session's project root; unsupervised\n\
+                     callers must omit it and accept a cold build)\n\
+  --cwd PATH         Repository-relative working directory\n\
+  --env KEY=VALUE    Explicit child environment additions (repeatable)\n\
+  --timeout SECONDS  Command timeout (default 900)\n\
+  --allow-dirty      Skip the clean-checkout refusal\n\
+  --host HOST        auto (default) or cloud:<codex-task-id>\n\
+\n\
+wait blocks until the job is terminal or --for SECONDS (default 900) is\n\
+spent, prints the bounded remote stdout/stderr, and exits 0 only for a\n\
+succeeded job. A cold worker can take tens of minutes to acquire: pass a\n\
+bigger --for (acquisition allows 3600s) instead of resubmitting — matching\n\
+requests coalesce onto one acquisition.\n\
+\n\
+Examples:\n\
+  git push origin my-branch\n\
+  intendant ctl remote start --branch my-branch --revision 0123abc \\\n\
+      -- cargo clippy --workspace -- -D warnings\n\
+  intendant ctl remote wait remote-1234abcd --for 1800\n\
+  intendant ctl remote start --source working_tree -- cargo check --workspace\n\
+  intendant ctl remote cancel remote-1234abcd\n\
+\n\
+Refusals and failures surface the daemon's words verbatim (acquisition\n\
+stage, provider task URL, signed-out state). Report a failed lane rather\n\
+than quietly running the expensive command locally."
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn strings(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|part| part.to_string()).collect()
+    }
+
+    #[test]
+    fn start_maps_every_flag_to_the_tool_vocabulary() {
+        let value = remote_start_args(&strings(&[
+            "--host",
+            "cloud:task_e_123",
+            "--branch",
+            "feature/x",
+            "--revision",
+            "0123abc",
+            "--source",
+            "git_revision",
+            "--cache",
+            "durable_sccache",
+            "--cwd",
+            "crates/intendant-core",
+            "--env",
+            "RUST_LOG=debug",
+            "--env",
+            "CARGO_PROFILE_DEV_DEBUG=0",
+            "--timeout",
+            "1200",
+            "--allow-dirty",
+            "--",
+            "cargo",
+            "clippy",
+            "--workspace",
+            "--",
+            "-D",
+            "warnings",
+        ]))
+        .expect("full flag set parses");
+        assert_eq!(value["op"], "start");
+        // Everything after the FIRST `--` is the argv, later `--` included.
+        assert_eq!(
+            value["argv"],
+            serde_json::json!(["cargo", "clippy", "--workspace", "--", "-D", "warnings"])
+        );
+        assert_eq!(value["host"], "cloud:task_e_123");
+        assert_eq!(value["branch"], "feature/x");
+        assert_eq!(value["expected_revision"], "0123abc");
+        assert_eq!(value["source"], "git_revision");
+        assert_eq!(value["cache"], "durable_sccache");
+        assert_eq!(value["cwd"], "crates/intendant-core");
+        assert_eq!(
+            value["env"],
+            serde_json::json!({"RUST_LOG": "debug", "CARGO_PROFILE_DEV_DEBUG": "0"})
+        );
+        assert_eq!(value["timeout_s"], 1200);
+        assert_eq!(value["require_clean"], false);
+    }
+
+    #[test]
+    fn start_omits_absent_flags_so_daemon_defaults_stay_authoritative() {
+        let value =
+            remote_start_args(&strings(&["--revision", "0123abc", "--", "cargo", "check"]))
+                .expect("minimal start parses");
+        let object = value.as_object().expect("object");
+        for absent in [
+            "host",
+            "branch",
+            "source",
+            "cache",
+            "cwd",
+            "env",
+            "timeout_s",
+            "require_clean",
+        ] {
+            assert!(
+                !object.contains_key(absent),
+                "{absent} must be absent when its flag is not passed"
+            );
+        }
+        assert_eq!(value["argv"], serde_json::json!(["cargo", "check"]));
+    }
+
+    #[test]
+    fn start_refusals_teach_the_double_dash_and_flag_shapes() {
+        // A remote command's own flag before `--` reads as an unknown ctl
+        // flag; the error teaches where the argv goes.
+        let error = remote_start_args(&strings(&["cargo", "clippy", "--workspace"]))
+            .expect_err("bare remote flags refuse");
+        assert!(error.contains("--workspace"), "{error}");
+        assert!(error.contains("after `--`"), "{error}");
+
+        let error = remote_start_args(&strings(&["--revision", "0123abc"]))
+            .expect_err("missing argv refuses");
+        assert!(error.contains("requires the command after `--`"), "{error}");
+
+        let error = remote_start_args(&strings(&["--source", "tarball", "--", "true"]))
+            .expect_err("bogus source refuses");
+        assert!(error.contains("git_revision or working_tree"), "{error}");
+
+        let error = remote_start_args(&strings(&["--cache", "s3", "--", "true"]))
+            .expect_err("bogus cache refuses");
+        assert!(error.contains("none or durable_sccache"), "{error}");
+
+        let error = remote_start_args(&strings(&["--env", "NOVALUE", "--", "true"]))
+            .expect_err("env without = refuses");
+        assert!(error.contains("KEY=VALUE"), "{error}");
+
+        let error = remote_start_args(&strings(&["--timeout", "soon", "--", "true"]))
+            .expect_err("non-numeric timeout refuses");
+        assert!(error.contains("not a number of seconds"), "{error}");
+    }
+
+    #[test]
+    fn job_id_positional_is_required_and_single() {
+        assert_eq!(
+            remote_job_id(&strings(&["remote-abc"]), "status", &[]).unwrap(),
+            "remote-abc"
+        );
+        let error = remote_job_id(&[], "status", &[]).expect_err("missing id refuses");
+        assert!(error.contains("requires the job id"), "{error}");
+        let error = remote_job_id(&strings(&["a", "b"]), "cancel", &[])
+            .expect_err("two ids refuse");
+        assert!(error.contains("exactly one job id"), "{error}");
+    }
+
+    #[test]
+    fn wait_chunks_stay_inside_the_tool_bounds() {
+        assert_eq!(wait_chunk_s(0), 1);
+        assert_eq!(wait_chunk_s(1), 1);
+        assert_eq!(wait_chunk_s(59), 59);
+        assert_eq!(wait_chunk_s(60), 60);
+        assert_eq!(wait_chunk_s(6_000), 60);
+    }
+
+    /// The client's terminal set must match the daemon's — a drifted set
+    /// would make `wait` spin forever on a finished job (or stop early on
+    /// a live one).
+    #[test]
+    fn client_terminal_set_matches_remote_command_state() {
+        use crate::remote_compute::RemoteCommandState as State;
+        for state in [
+            State::Acquiring,
+            State::Preparing,
+            State::Queued,
+            State::Running,
+            State::Cancelling,
+            State::Succeeded,
+            State::Failed,
+            State::TimedOut,
+            State::Cancelled,
+        ] {
+            let wire = serde_json::to_value(state).expect("serialize state");
+            let wire = wire.as_str().expect("state serializes as a string");
+            assert_eq!(
+                state_is_terminal(wire),
+                state.is_terminal(),
+                "terminal drift for {wire}"
+            );
+        }
+    }
+
+    fn rpc_result_with_text(text: &str) -> Value {
+        serde_json::json!({
+            "result": { "content": [ { "type": "text", "text": text } ] }
+        })
+    }
+
+    #[test]
+    fn envelope_surfaces_daemon_refusals_verbatim() {
+        let refusal = "durable_sccache through home requires a supervised project root";
+        let response =
+            rpc_result_with_text(&serde_json::json!({ "ok": false, "error": refusal }).to_string());
+        assert_eq!(
+            remote_job_from_response(&response).expect_err("refusal is an error"),
+            refusal,
+            "the daemon's words must pass through unrewritten"
+        );
+    }
+
+    #[test]
+    fn envelope_unwraps_the_job_and_flags_transport_errors() {
+        let response = rpc_result_with_text(
+            &serde_json::json!({ "ok": true, "job": { "job_id": "remote-1", "state": "acquiring" } })
+                .to_string(),
+        );
+        let job = remote_job_from_response(&response).expect("job unwraps");
+        assert_eq!(job["job_id"], "remote-1");
+
+        let error_response = serde_json::json!({ "error": { "code": -32603, "message": "denied" } });
+        let error = remote_job_from_response(&error_response).expect_err("MCP error surfaces");
+        assert!(error.contains("denied"), "{error}");
+
+        let junk = rpc_result_with_text("not json");
+        let error = remote_job_from_response(&junk).expect_err("junk refuses");
+        assert!(error.contains("unparseable"), "{error}");
+    }
+
+    #[test]
+    fn terminal_outcome_composes_like_the_local_command() {
+        let succeeded = serde_json::json!({ "job_id": "remote-1" });
+        assert!(terminal_outcome(&succeeded, "succeeded").is_ok());
+
+        let failed = serde_json::json!({
+            "job_id": "remote-2",
+            "result": { "error": "command exited with status exit status: 101" }
+        });
+        let error = terminal_outcome(&failed, "failed").expect_err("failed job errs");
+        assert!(
+            error.contains("command exited with status exit status: 101"),
+            "{error}"
+        );
+
+        let acquisition_dead = serde_json::json!({
+            "job_id": "remote-3",
+            "error": "\"codex\" exited with exit status: 1: Not signed in. Please run \
+                      'codex login'",
+        });
+        let error = terminal_outcome(&acquisition_dead, "failed").expect_err("dead lane errs");
+        assert!(error.contains("Not signed in"), "{error}");
+    }
+}

--- a/src/bin/caller/ctl/remote.rs
+++ b/src/bin/caller/ctl/remote.rs
@@ -190,9 +190,7 @@ fn remote_start_args(raw: &[String]) -> Result<Value, String> {
         ],
         &["--allow-dirty"],
     )
-    .map_err(|error| {
-        format!("{error} (the remote command and its own flags go after `--`)")
-    })?;
+    .map_err(|error| format!("{error} (the remote command and its own flags go after `--`)"))?;
     if args.positional.is_empty() {
         return Err(
             "remote start requires the command after `--`, e.g. `intendant ctl remote start \
@@ -316,7 +314,10 @@ fn job_field<'a>(job: &'a Value, key: &str) -> Option<&'a str> {
 }
 
 fn progress_line(job: &Value, state: &str) -> String {
-    let mut line = format!("remote job {} {state}", job_field(job, "job_id").unwrap_or("?"));
+    let mut line = format!(
+        "remote job {} {state}",
+        job_field(job, "job_id").unwrap_or("?")
+    );
     if let Some(acquisition) = job.get("acquisition") {
         if let Some(stage) = acquisition.get("stage").and_then(Value::as_str) {
             line.push_str(&format!(" ({stage}"));
@@ -384,8 +385,10 @@ fn print_job_report(job: &Value) {
                     .unwrap_or(0),
             );
         }
-        for (name, truncated_key) in [("stdout", "stdout_truncated"), ("stderr", "stderr_truncated")]
-        {
+        for (name, truncated_key) in [
+            ("stdout", "stdout_truncated"),
+            ("stderr", "stderr_truncated"),
+        ] {
             let text = result.get(name).and_then(Value::as_str).unwrap_or("");
             if !text.is_empty() {
                 let truncated = result
@@ -538,9 +541,8 @@ mod tests {
 
     #[test]
     fn start_omits_absent_flags_so_daemon_defaults_stay_authoritative() {
-        let value =
-            remote_start_args(&strings(&["--revision", "0123abc", "--", "cargo", "check"]))
-                .expect("minimal start parses");
+        let value = remote_start_args(&strings(&["--revision", "0123abc", "--", "cargo", "check"]))
+            .expect("minimal start parses");
         let object = value.as_object().expect("object");
         for absent in [
             "host",
@@ -598,8 +600,8 @@ mod tests {
         );
         let error = remote_job_id(&[], "status", &[]).expect_err("missing id refuses");
         assert!(error.contains("requires the job id"), "{error}");
-        let error = remote_job_id(&strings(&["a", "b"]), "cancel", &[])
-            .expect_err("two ids refuse");
+        let error =
+            remote_job_id(&strings(&["a", "b"]), "cancel", &[]).expect_err("two ids refuse");
         assert!(error.contains("exactly one job id"), "{error}");
     }
 
@@ -666,7 +668,8 @@ mod tests {
         let job = remote_job_from_response(&response).expect("job unwraps");
         assert_eq!(job["job_id"], "remote-1");
 
-        let error_response = serde_json::json!({ "error": { "code": -32603, "message": "denied" } });
+        let error_response =
+            serde_json::json!({ "error": { "code": -32603, "message": "denied" } });
         let error = remote_job_from_response(&error_response).expect_err("MCP error surfaces");
         assert!(error.contains("denied"), "{error}");
 

--- a/src/bin/caller/external_agent/mod.rs
+++ b/src/bin/caller/external_agent/mod.rs
@@ -459,12 +459,16 @@ pub(crate) fn backend_auth_failure_line(line: &str) -> bool {
     //   the 2026-08-07T00:00Z nightly, wss://…/v1/responses reconnect
     //   storm ending "Round 1 complete (0 turns)").
     // - codex CLI login status: "Not logged in".
+    // - codex CLI cloud-tasks refusal: "Not signed in. Please run 'codex
+    //   login'" (specimen: the 2026-08-06 remote_command acquisition
+    //   failure — job remote-83075e26 — after the boot lease sweep).
     // - Claude Code signed-out/expired: "Invalid API key · Please run
     //   /login", "OAuth token has expired", and the Anthropic API's
     //   "authentication_error" type.
     lowered.contains("401 unauthorized")
         || lowered.contains("missing bearer")
         || lowered.contains("not logged in")
+        || lowered.contains("not signed in")
         || lowered.contains("please run /login")
         || lowered.contains("oauth token has expired")
         || lowered.contains("invalid api key")
@@ -2708,6 +2712,12 @@ mod tests {
         ));
         // Codex login-status vocabulary.
         assert!(backend_auth_failure_line("Not logged in"));
+        // Codex cloud-tasks refusal — the remote-compute acquisition
+        // failure shape after a boot lease sweep (job remote-83075e26).
+        assert!(backend_auth_failure_line(
+            "\"codex\" exited with exit status: 1: Not signed in. Please run 'codex login' \
+             to authenticate."
+        ));
         // Claude Code signed-out/expired vocabularies.
         assert!(backend_auth_failure_line(
             "Invalid API key \u{b7} Please run /login"

--- a/src/bin/caller/mcp/tool_gate.rs
+++ b/src/bin/caller/mcp/tool_gate.rs
@@ -155,10 +155,19 @@ pub(crate) fn tool_allowed_for_profile(
                     | "take_screenshot"
                     | "read_screen"
                     | "execute_cu_actions"
-                    // Heavy build/test work should leave the daemon host.
-                    // This one provider-neutral job vocabulary is compact
-                    // enough to advertise to every supervised backend.
-                    | "remote_command"
+                    // remote_command deliberately does NOT ride here
+                    // (2026-08-07 ratification): its schema was the
+                    // largest single item in this bootstrap set while the
+                    // lifetime consumer count stayed near zero — context
+                    // rent, the house doctrine (prefer `intendant ctl` to
+                    // keep model context small). Supervised backends reach
+                    // the same lane, with the same session-bound identity,
+                    // through `"$INTENDANT" ctl remote …`; the daemon MCP
+                    // surface still serves the tool by name (profile
+                    // shaping never gates calls — see mcp_tool_operation's
+                    // doc), and the `intendant-remote-compute` skill is
+                    // the delivery that teaches when to offload.
+                    //
                     // The per-layer CU diagnosis for when those calls fail
                     // (grant held but an OS permission still blocking).
                     | "display_readiness"
@@ -844,39 +853,54 @@ mod tests {
         );
     }
 
+    /// The 2026-08-07 ratification: the remote-compute lane's delivery is
+    /// SKILL + `intendant ctl remote`, so the `remote_command` schema stops
+    /// riding supervised session toolsets (context rent) while the daemon
+    /// tool surface stays — ctl discovery (unprofiled tools/list) and
+    /// call-by-name keep answering, the IAM class is unchanged, and native
+    /// sessions keep their built-in tool (a native built-in is not an MCP
+    /// schema in a backend's context).
     #[test]
-    fn remote_command_is_core_provider_neutral_and_shell_gated() {
+    fn remote_command_stays_off_session_toolsets_but_on_the_daemon_surface() {
         use crate::peer::access_policy::PeerOperation;
 
+        // Every supervised-backend profile hides the schema now…
         for profile in [
-            None,
-            Some("full"),
             Some("core"),
             Some("codex-core"),
             Some("cli"),
             Some("minimal"),
+            Some("screen"),
+            Some("display"),
+            Some("managed"),
+            Some("managed-context"),
         ] {
             assert!(
-                tool_allowed_for_profile("remote_command", false, profile),
-                "remote_command must be available to every supervised-agent profile ({profile:?})"
+                !tool_allowed_for_profile("remote_command", true, profile),
+                "remote_command must stay out of supervised session toolsets ({profile:?}); \
+                 supervised backends reach the lane through `intendant ctl remote`"
             );
         }
-        assert!(!tool_allowed_for_profile(
-            "remote_command",
-            false,
-            Some("display")
-        ));
+        // …while the unprofiled listing (the `intendant ctl tools` discovery
+        // surface) and the explicit full profile keep serving it.
+        for profile in [None, Some("full")] {
+            assert!(
+                tool_allowed_for_profile("remote_command", false, profile),
+                "remote_command must stay on the daemon surface ({profile:?}) so \
+                 `ctl tools schema remote_command` and `ctl remote` keep answering"
+            );
+        }
         assert_eq!(
             mcp_tool_operation("remote_command"),
             PeerOperation::ShellSpawn
         );
 
-        let mut core = Vec::new();
-        append_manual_http_tool_definitions(&mut core, false, Some("core"));
-        let definition = core
+        let mut unprofiled = Vec::new();
+        append_manual_http_tool_definitions(&mut unprofiled, false, None);
+        let definition = unprofiled
             .iter()
             .find(|tool| tool["name"] == "remote_command")
-            .expect("remote_command must have a core HTTP definition");
+            .expect("remote_command must keep its HTTP definition for ctl discovery");
         assert_eq!(
             definition["description"].as_str(),
             IntendantServer::remote_command_tool_attr()
@@ -884,10 +908,16 @@ mod tests {
                 .as_deref(),
             "remote_command manual HTTP description drifted from its #[tool] attribute"
         );
+        let mut core = Vec::new();
+        append_manual_http_tool_definitions(&mut core, true, Some("core"));
+        assert!(
+            !core.iter().any(|tool| tool["name"] == "remote_command"),
+            "the core profile's tools/list must not carry the remote_command schema"
+        );
         let native = crate::tools::all_tools()
             .into_iter()
             .find(|tool| tool.name == "remote_command")
-            .expect("native agents must receive remote_command");
+            .expect("native sessions keep the built-in remote_command tool");
         assert_eq!(
             Some(native.description.as_str()),
             IntendantServer::remote_command_tool_attr()

--- a/src/bin/caller/plugin_registry.rs
+++ b/src/bin/caller/plugin_registry.rs
@@ -46,8 +46,9 @@ pub(crate) const BUNDLED_PLUGINS: &[BundledPlugin] = &[BundledPlugin {
     display_name: "Codex Cloud Remote Compute",
     summary: "Offload heavy platform-neutral development work (builds, broad \
               tests, lint, benchmarks, codegen) to Codex Cloud workers through \
-              the provider-neutral remote_command lane. Enabling activates a \
-              shared agent skill for every supervised backend.",
+              the provider-neutral remote-compute lane (`intendant ctl \
+              remote`). Enabling activates a shared agent skill for every \
+              session kind on this machine.",
     skills: &[BuiltinSkill {
         name: "intendant-remote-compute",
         skill_md: include_str!(

--- a/src/bin/caller/remote_compute.rs
+++ b/src/bin/caller/remote_compute.rs
@@ -1002,17 +1002,13 @@ const LANE_DOWN_BODY: &str = "remote_command acquisition failed because the prov
      signed-out acquisition failure is annotated here.";
 
 /// One alarm per daemon boot (process lifetime), never per attempt.
-static LANE_AUTH_ALARMED: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
+static LANE_AUTH_ALARMED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
 /// Decide whether `error` is the auth family AND this boot has not alarmed
 /// yet. Non-auth failures (no worker available, detached host, timeout)
 /// never latch — the first *signed-out* failure must still alarm even if
 /// an unrelated failure came earlier.
-fn should_alarm_lane_auth_failure(
-    error: &str,
-    latch: &std::sync::atomic::AtomicBool,
-) -> bool {
+fn should_alarm_lane_auth_failure(error: &str, latch: &std::sync::atomic::AtomicBool) -> bool {
     if !crate::external_agent::backend_auth_failure_line(error) {
         return false;
     }
@@ -1056,10 +1052,7 @@ fn lane_down_notification(copy: &str, now_ms: u64) -> crate::event::AppEvent {
 /// ULID order) and append `text`, skipping an identical consecutive
 /// annotation so a crash-looping daemon never stacks copies of the same
 /// facts. Mirrors the safeguards needs-recast parking contract.
-fn park_lane_down(
-    handle: &crate::agenda::AgendaHandle,
-    text: String,
-) -> Result<String, String> {
+fn park_lane_down(handle: &crate::agenda::AgendaHandle, text: String) -> Result<String, String> {
     use crate::agenda::{AgendaActor, AgendaCommand, AgendaItem, AgendaKind, AgendaStatus};
     let snapshot = handle.snapshot();
     let mut anchors: Vec<&AgendaItem> = snapshot
@@ -1133,9 +1126,10 @@ fn note_remote_command_failure(error: &str) {
             if let Err(err) = park_lane_down(&handle, lane_down_annotation(&copy, error)) {
                 eprintln!("[remote-compute] {err} — the notification carries the facts");
             }
-            handle
-                .bus()
-                .send(lane_down_notification(&copy, crate::codex_cloud::now_unix_ms()));
+            handle.bus().send(lane_down_notification(
+                &copy,
+                crate::codex_cloud::now_unix_ms(),
+            ));
         }
         None => eprintln!(
             "[remote-compute] lane down ({copy}) but no agenda handle is published — \

--- a/src/bin/caller/remote_compute.rs
+++ b/src/bin/caller/remote_compute.rs
@@ -635,6 +635,12 @@ async fn start_remote_command(
         )
         .await
         {
+            // Lease-death visibility: a signed-out provider fails every
+            // acquisition after a daemon boot (the custody startup sweep
+            // removes leases), and before 2026-08-07 that death was
+            // visible only inside the one session that tried. Alarm ONCE
+            // per boot, never per attempt.
+            note_remote_command_failure(&error);
             update_home_job(&job_id, |job| {
                 if !job.state.is_terminal() {
                     job.state = RemoteCommandState::Failed;
@@ -969,6 +975,173 @@ async fn send_home_frame(sender: &mpsc::Sender<String>, frame: String) -> Result
     .await
     .map_err(|_| ())?
     .map_err(|_| ())
+}
+
+// ── Lane-down visibility ─────────────────────────────────────────────
+//
+// The custody startup sweep removes provider leases at every daemon boot
+// (`lease_home_removed`), so a lane that was healthy yesterday fails every
+// acquisition today with the signed-out shape — and until 2026-08-07 that
+// death surfaced nowhere but the failing caller's own tool result (the
+// 08-06 specimen: a seat got "Not signed in", then silently ran 43 minutes
+// of local battery). On the FIRST auth-shaped failure per boot the daemon
+// parks one durable agenda note and sends one attention-class
+// notification; classification and copy ride the shared #809 auth-family
+// register (`external_agent::backend_auth_failure_line` / `_copy`).
+
+/// Tag on THE durable lane-down agenda item (find-or-create, like the
+/// safeguards needs-recast anchor — restarts annotate one item instead of
+/// stacking new ones).
+const LANE_DOWN_TAG: &str = "remote-compute-lane";
+const LANE_DOWN_SOURCE: &str = "remote-compute lane";
+const LANE_DOWN_TITLE: &str = "Remote-compute lane down: provider signed out";
+const LANE_DOWN_BODY: &str = "remote_command acquisition failed because the provider CLI is \
+     signed out. Leases do not survive daemon restarts (custody startup sweep), so after every \
+     boot the lane stays down — and every remote_command job fails at acquisition — until the \
+     provider is signed in again or its lease is re-armed from the Vault tab. Each boot's first \
+     signed-out acquisition failure is annotated here.";
+
+/// One alarm per daemon boot (process lifetime), never per attempt.
+static LANE_AUTH_ALARMED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Decide whether `error` is the auth family AND this boot has not alarmed
+/// yet. Non-auth failures (no worker available, detached host, timeout)
+/// never latch — the first *signed-out* failure must still alarm even if
+/// an unrelated failure came earlier.
+fn should_alarm_lane_auth_failure(
+    error: &str,
+    latch: &std::sync::atomic::AtomicBool,
+) -> bool {
+    if !crate::external_agent::backend_auth_failure_line(error) {
+        return false;
+    }
+    !latch.swap(true, std::sync::atomic::Ordering::SeqCst)
+}
+
+/// The one named honest copy for the lane, composed from the #809
+/// auth-family register: Codex is the lane's host-adapter CLI, and the
+/// credential-file probe picks the sharper "no credentials" flavor when it
+/// can prove absence.
+fn lane_down_copy(credential_file_missing: Option<bool>) -> String {
+    crate::external_agent::backend_auth_failure_copy("Codex", credential_file_missing)
+}
+
+/// The durable annotation for THE lane-down item: named state, standing
+/// consequence, and the daemon's error verbatim.
+fn lane_down_annotation(copy: &str, error: &str) -> String {
+    format!(
+        "{copy}. First signed-out remote_command acquisition failure since this daemon booted; \
+         every remote_command job fails at acquisition until the lane is re-armed. Error: {error}"
+    )
+}
+
+/// The attention-class notification (dashboard toast + tab badge + hidden-tab
+/// browser notification) for the same state.
+fn lane_down_notification(copy: &str, now_ms: u64) -> crate::event::AppEvent {
+    crate::event::AppEvent::UserNotification {
+        session_id: None,
+        id: "remote-compute-lane-auth".to_string(),
+        title: Some(LANE_DOWN_TITLE.to_string()),
+        text: format!(
+            "{copy}. Remote-compute jobs fail at acquisition until it is re-armed — provider \
+             leases do not survive daemon restarts."
+        ),
+        urgency: crate::types::NotificationUrgency::Attention,
+        ts: now_ms,
+    }
+}
+
+/// Find or create THE lane-down item (oldest open item carrying the tag —
+/// ULID order) and append `text`, skipping an identical consecutive
+/// annotation so a crash-looping daemon never stacks copies of the same
+/// facts. Mirrors the safeguards needs-recast parking contract.
+fn park_lane_down(
+    handle: &crate::agenda::AgendaHandle,
+    text: String,
+) -> Result<String, String> {
+    use crate::agenda::{AgendaActor, AgendaCommand, AgendaItem, AgendaKind, AgendaStatus};
+    let snapshot = handle.snapshot();
+    let mut anchors: Vec<&AgendaItem> = snapshot
+        .iter()
+        .filter(|item| {
+            item.status == AgendaStatus::Open && item.tags.iter().any(|tag| tag == LANE_DOWN_TAG)
+        })
+        .collect();
+    anchors.sort_by(|a, b| a.id.cmp(&b.id));
+    let item_id = match anchors.first() {
+        Some(item) => {
+            if item
+                .annotations
+                .last()
+                .is_some_and(|note| note.text == text)
+            {
+                return Ok(item.id.clone());
+            }
+            item.id.clone()
+        }
+        None => {
+            handle
+                .apply(
+                    AgendaCommand::Add {
+                        kind: AgendaKind::Note,
+                        title: LANE_DOWN_TITLE.to_string(),
+                        body: LANE_DOWN_BODY.to_string(),
+                        tags: vec![LANE_DOWN_TAG.to_string()],
+                        due_ms: None,
+                        source: Some(LANE_DOWN_SOURCE.to_string()),
+                        refs: Vec::new(),
+                    },
+                    Some(AgendaActor::daemon()),
+                )
+                .map_err(|err| format!("park remote-compute lane-down note: {err}"))?
+                .id
+        }
+    };
+    handle
+        .apply(
+            AgendaCommand::Annotate {
+                id: item_id.clone(),
+                text,
+                source: Some(LANE_DOWN_SOURCE.to_string()),
+            },
+            Some(AgendaActor::daemon()),
+        )
+        .map_err(|err| format!("annotate remote-compute lane-down note: {err}"))?;
+    Ok(item_id)
+}
+
+/// Boot-once alarm entry, called from the acquisition failure record. The
+/// durable agenda note plus the attention notification are the whole
+/// visible surface; a missing agenda handle degrades to stderr, and a
+/// parking failure never swallows the notification (the safeguards-lane
+/// degradation contract).
+fn note_remote_command_failure(error: &str) {
+    if !should_alarm_lane_auth_failure(error, &LANE_AUTH_ALARMED) {
+        return;
+    }
+    // Transport edge: the probe stats the daemon's view of the home; the
+    // classifier and copy stay pure and hermetically tested.
+    let credential_file_missing = crate::external_agent::backend_local_login(
+        &crate::external_agent::AgentBackend::Codex,
+        &crate::platform::home_dir(),
+    )
+    .map(|present| !present);
+    let copy = lane_down_copy(credential_file_missing);
+    match crate::agenda::published_agenda_handle() {
+        Some(handle) => {
+            if let Err(err) = park_lane_down(&handle, lane_down_annotation(&copy, error)) {
+                eprintln!("[remote-compute] {err} — the notification carries the facts");
+            }
+            handle
+                .bus()
+                .send(lane_down_notification(&copy, crate::codex_cloud::now_unix_ms()));
+        }
+        None => eprintln!(
+            "[remote-compute] lane down ({copy}) but no agenda handle is published — \
+             not parked. Error: {error}"
+        ),
+    }
 }
 
 pub(crate) async fn execute_remote_command_operation(
@@ -2027,6 +2200,112 @@ fn elapsed_ms(started: Instant) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── Lane-down visibility pins ──
+
+    /// The per-boot latch: only the auth family alarms, exactly once, and
+    /// an earlier non-auth failure must not consume the boot's one alarm.
+    #[test]
+    fn lane_auth_alarm_fires_once_per_boot_for_the_auth_family_only() {
+        let latch = std::sync::atomic::AtomicBool::new(false);
+        // Non-auth acquisition failures never alarm and never latch.
+        assert!(!should_alarm_lane_auth_failure(
+            "remote host cloud:x has no live attachment",
+            &latch
+        ));
+        assert!(!should_alarm_lane_auth_failure(
+            "acquisition timed out after 3600s",
+            &latch
+        ));
+        // The 08-06 specimen (job remote-83075e26) alarms — once.
+        let specimen = "\"codex\" exited with exit status: 1: Not signed in. Please run \
+                        'codex login' to authenticate.";
+        assert!(should_alarm_lane_auth_failure(specimen, &latch));
+        assert!(
+            !should_alarm_lane_auth_failure(specimen, &latch),
+            "the second attempt of the boot must stay silent"
+        );
+        assert!(!should_alarm_lane_auth_failure(
+            "401 Unauthorized: Missing bearer or basic authentication in header",
+            &latch
+        ));
+    }
+
+    /// The composed surfaces: named honest copy (the shared #809
+    /// register), verbatim error in the durable annotation, attention
+    /// urgency and a stable id on the notification.
+    #[test]
+    fn lane_down_surfaces_carry_the_named_state_and_the_verbatim_error() {
+        assert_eq!(
+            lane_down_copy(Some(false)),
+            "Codex is signed out — sign in from the Vault tab"
+        );
+        assert_eq!(
+            lane_down_copy(Some(true)),
+            "Codex has no credentials on this daemon — sign in from the Vault tab, or renew \
+             its vault lease"
+        );
+
+        let error = "\"codex\" exited with exit status: 1: Not signed in.";
+        let annotation = lane_down_annotation(&lane_down_copy(None), error);
+        assert!(annotation.contains("Codex is signed out"), "{annotation}");
+        assert!(annotation.contains(error), "{annotation}");
+        assert!(
+            annotation.contains("until the lane is re-armed"),
+            "{annotation}"
+        );
+
+        let crate::event::AppEvent::UserNotification {
+            session_id,
+            id,
+            title,
+            text,
+            urgency,
+            ts,
+        } = lane_down_notification(&lane_down_copy(None), 1234)
+        else {
+            panic!("notification shape");
+        };
+        assert_eq!(session_id, None);
+        assert_eq!(id, "remote-compute-lane-auth");
+        assert_eq!(title.as_deref(), Some(LANE_DOWN_TITLE));
+        assert!(text.contains("Codex is signed out"), "{text}");
+        assert!(
+            text.contains("leases do not survive daemon restarts"),
+            "{text}"
+        );
+        assert_eq!(urgency, crate::types::NotificationUrgency::Attention);
+        assert_eq!(ts, 1234);
+    }
+
+    /// The durable note is find-or-create: one tagged item across boots,
+    /// identical consecutive annotations collapse, and a distinct
+    /// annotation appends to the SAME item instead of minting a sibling.
+    #[test]
+    fn lane_down_parks_one_item_and_deduplicates_annotations() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = crate::agenda::AgendaStore::open(dir.path()).expect("open store");
+        let handle =
+            crate::agenda::AgendaHandle::new(store, crate::event::EventBus::new(), dir.path());
+
+        let first = park_lane_down(&handle, "boot one: signed out".to_string()).unwrap();
+        let again = park_lane_down(&handle, "boot one: signed out".to_string()).unwrap();
+        assert_eq!(first, again, "identical consecutive annotation collapses");
+        let second = park_lane_down(&handle, "boot two: signed out".to_string()).unwrap();
+        assert_eq!(first, second, "later boots annotate the same open item");
+
+        let snapshot = handle.snapshot();
+        let items: Vec<_> = snapshot
+            .iter()
+            .filter(|item| item.tags.iter().any(|tag| tag == LANE_DOWN_TAG))
+            .collect();
+        assert_eq!(items.len(), 1, "exactly one lane-down item exists");
+        let item = items[0];
+        assert_eq!(item.title, LANE_DOWN_TITLE);
+        assert_eq!(item.annotations.len(), 2, "{:#?}", item.annotations);
+        assert_eq!(item.annotations[0].text, "boot one: signed out");
+        assert_eq!(item.annotations[1].text, "boot two: signed out");
+    }
 
     fn git(repo: &Path, args: &[&str]) -> String {
         let output = std::process::Command::new("git")


### PR DESCRIPTION
The remote-compute lane's delivery becomes skill + CLI.

**`intendant ctl remote` verb family** — `start|status|wait|cancel` wrap the daemon's `remote_command` tool with real flags (`--revision`, `--branch`, `--source`, `--cache`, `--env`, `--timeout`, `--allow-dirty`, argv after `--`) instead of hand-built `tools call` JSON. Daemon refusals surface verbatim; `wait JOB --for SECONDS` chunks bounded server-side waits until terminal, prints the bounded remote output, and exits 0 only for a succeeded job so `start && wait` composes like the local command. Parse/map seams are pure and unit-pinned, including a parity pin of the client terminal-state set against `RemoteCommandState::is_terminal`.

**Skill rewrite** (`intendant-remote-compute`) — the description now triggers on the WORK (a heavy platform-neutral build/test/clippy sweep about to run locally) for every session kind, instead of self-scoping to sessions "where the remote_command tool is available" (which read the heaviest compilers out of the skill entirely). The body teaches the ctl lane first, the native tool second, and keeps the honest carve-outs: root-sensitive validation batteries stay local, never silently fall back to heavy local work, the durable-sccache supervised-root paragraph unchanged.

**MCP toolset narrowing** — the `remote_command` schema no longer rides supervised session toolsets (`tool_profile=core`): it was the largest schema in the bootstrap set with near-zero lifetime consumers, and every supervised backend reaches the identical lane with identical session-bound identity through `"$INTENDANT" ctl remote`. Profile shaping only hides the listing — the daemon keeps serving `tools/call remote_command` by name, the unprofiled listing (`ctl tools schema`) still carries the definition, and native sessions keep their built-in tool. The gate test now pins the new law; docs chapters updated to match.

**Lane-down visibility** — provider leases do not survive daemon restarts, so after every boot the lane fails acquisition with a signed-out provider and, until now, that death surfaced nowhere except the failing caller's own tool result. On the first auth-shaped acquisition failure per boot the daemon parks one durable find-or-create agenda note (annotations dedupe across crash loops) and sends one attention-class notification, composed through the shared backend-auth classifier/copy register; the classifier gains the codex cloud-tasks "Not signed in" vocabulary. Pinned: per-boot latch, auth-family-only trigger, notification/annotation shapes, single-item parking.
