### PR TITLE
drain map: widen past the presence holdout cap via the sibling doorway

### DIFF
--- a/docs/src/control-plane-and-daemon.md
+++ b/docs/src/control-plane-and-daemon.md
@@ -442,7 +442,13 @@ successor without kill-and-relaunch:
   the wait set is named, never silent: the status payload carries
   `holdouts` (each holding session's id, name, backend, phase, and its
   durable `limit_park` marker with the reset instant), the drainer's
-  presence record mirrors a capped row copy beside `session_count`, and
+  presence record mirrors a capped row copy beside `session_count`
+  (the record crosses the handover wire and never grows; when the cap
+  truncates it, a successor fetches the drainer's own uncapped
+  `holdouts` through the sibling doorway — loopback + the per-port
+  admission token — and widens its served drain map and status rows
+  with them, floor-first and under the same provable-liveness gate, so
+  no held session is invisible regardless of count), and
   the dashboard's drain banner speaks two grades: grade 1 tells the
   product event plainly ("Updating Intendant — your work continues",
   a portless "Open the updated dashboard →" doorway, "Waiting for the

--- a/src/bin/caller/handover/mod.rs
+++ b/src/bin/caller/handover/mod.rs
@@ -24,12 +24,20 @@
 
 mod lease;
 mod presence;
+mod sibling_wait_set;
 mod successor_exec;
 mod update_lane;
 mod update_watch;
 
 pub(crate) use lease::{read_lease_sidecar, BuildVersion, LeaseAttempt, SchedulerLease};
-pub(crate) use presence::{boot_id_is_live, read_presence_records, DaemonPresence, DrainHoldout};
+#[cfg(test)]
+pub(crate) use presence::PRESENCE_HOLDOUT_ROWS_CAP;
+pub(crate) use presence::{
+    boot_id_is_live, read_presence_records, sort_drain_holdout_rows, DaemonPresence, DrainHoldout,
+};
+#[cfg(test)]
+pub(crate) use sibling_wait_set::seed_for_tests as seed_sibling_wait_set_for_tests;
+pub(crate) use sibling_wait_set::{resolve_sibling_wait_set, sibling_record_truncated};
 pub(crate) use successor_exec::spawn_successor_exec_lane;
 pub(crate) use update_lane::{parse_channel_arg, spawn_update_lane, update_rendezvous_url};
 pub(crate) use update_watch::spawn_update_watch;
@@ -923,14 +931,35 @@ impl HandoverRuntime {
             },
             Err(_) => (false, None, None),
         };
+        let own_pid = std::process::id();
         let daemons: Vec<serde_json::Value> = read_presence_records(&self.state_root)
             .into_iter()
             .map(|record| {
                 let live = boot_id_is_live(&self.state_root, &record.boot_id);
+                // A live draining SIBLING's capped presence rows widen
+                // from its own uncapped wait set through the sibling
+                // doorway (card 01KZD84XEC): the successor-side banner
+                // names EVERY holdout, not the first 16 — display
+                // currency only, gated on the same provable liveness as
+                // the rows themselves; the on-disk record never grows.
+                let widened = (live && record.pid != own_pid && record.state == "draining")
+                    .then(|| sibling_wait_set::resolve_sibling_wait_set(&self.state_root, &record))
+                    .flatten()
+                    .map(|fetched| {
+                        sibling_wait_set::widen_holdout_rows(
+                            record.holdouts.as_deref().unwrap_or(&[]),
+                            &fetched,
+                        )
+                    });
                 let mut value =
                     serde_json::to_value(&record).unwrap_or_else(|_| serde_json::json!({}));
                 if let Some(obj) = value.as_object_mut() {
                     obj.insert("live".into(), live.into());
+                    if let Some(rows) = widened {
+                        if let Ok(rows) = serde_json::to_value(&rows) {
+                            obj.insert("holdouts".into(), rows);
+                        }
+                    }
                 }
                 value
             })
@@ -1854,6 +1883,114 @@ mod tests {
         assert_eq!(daemons.len(), 1);
         assert_eq!(daemons[0]["boot_id"], runtime.boot_id());
         assert_eq!(daemons[0]["live"], true);
+    }
+
+    /// Card 01KZD84XEC: the status surface's `daemons` list widens a
+    /// live draining sibling's capped holdout rows from the cached
+    /// sibling-doorway fetch — the successor-side banner can then name
+    /// EVERY holdout — while the on-disk presence record keeps the cap
+    /// (it crosses the handover wire and never grows) and
+    /// `session_count` stays the untouched full truth. Display currency
+    /// only, gated on provable liveness: a dead sibling's entry serves
+    /// exactly its capped floor.
+    #[test]
+    fn status_json_widens_a_live_draining_siblings_capped_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let runtime = HandoverRuntime::initialize(dir.path(), 8765, 0);
+        let cap = presence::PRESENCE_HOLDOUT_ROWS_CAP;
+        let full = cap + 2;
+
+        // A foreign draining sibling: the record itemizes only the cap.
+        let daemons_dir = dir.path().join(presence::DAEMONS_DIR);
+        let rows: Vec<serde_json::Value> = (0..cap)
+            .map(|n| {
+                serde_json::json!({
+                    "session_id": format!("sess-{n:02}"),
+                    "source": "intendant",
+                    "phase": "idle",
+                })
+            })
+            .collect();
+        std::fs::write(
+            daemons_dir.join("boot-sib.json"),
+            serde_json::json!({
+                "v": 1,
+                "boot_id": "boot-sib",
+                "pid": std::process::id() + 1,
+                "port": 8770,
+                "version": {"pkg": "0.0.0", "git_sha": "sib", "built_at": "sib-ts"},
+                "state": "draining",
+                "session_count": full as u64,
+                "holdouts": rows,
+                "updated_ms": 5_000,
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let sibling_lock = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(daemons_dir.join("boot-sib.lock"))
+            .unwrap();
+        sibling_lock.try_lock().unwrap();
+        let fetched: Vec<DrainHoldout> = (0..full)
+            .map(|n| {
+                serde_json::from_value(serde_json::json!({
+                    "session_id": format!("sess-{n:02}"),
+                    "source": "intendant",
+                    "phase": "idle",
+                }))
+                .unwrap()
+            })
+            .collect();
+        seed_sibling_wait_set_for_tests(dir.path(), "boot-sib", fetched);
+
+        let status = runtime.status_json();
+        let entry = status["daemons"]
+            .as_array()
+            .expect("daemons array")
+            .iter()
+            .find(|daemon| daemon["boot_id"] == "boot-sib")
+            .cloned()
+            .expect("the sibling's entry");
+        assert_eq!(entry["live"], true);
+        assert_eq!(
+            entry["holdouts"].as_array().map(Vec::len),
+            Some(full),
+            "the served entry names every holdout, past the cap"
+        );
+        assert_eq!(
+            entry["session_count"], full as u64,
+            "the full count stays the untouched truth beside the rows"
+        );
+        let on_disk: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(daemons_dir.join("boot-sib.json")).unwrap())
+                .unwrap();
+        assert_eq!(
+            on_disk["holdouts"].as_array().map(Vec::len),
+            Some(cap),
+            "the presence record itself never grows — it crosses the handover wire"
+        );
+
+        // The sibling dies (lock freed): the cached fetch is inert — the
+        // entry serves exactly the capped floor again, marked not live.
+        drop(sibling_lock);
+        let status = runtime.status_json();
+        let entry = status["daemons"]
+            .as_array()
+            .expect("daemons array")
+            .iter()
+            .find(|daemon| daemon["boot_id"] == "boot-sib")
+            .cloned()
+            .expect("the sibling's entry");
+        assert_eq!(entry["live"], false);
+        assert_eq!(
+            entry["holdouts"].as_array().map(Vec::len),
+            Some(cap),
+            "a dead sibling's cached rows never widen its entry"
+        );
     }
 
     #[test]

--- a/src/bin/caller/handover/presence.rs
+++ b/src/bin/caller/handover/presence.rs
@@ -61,8 +61,27 @@ pub(crate) struct DrainHoldout {
 /// Presence-record cap on mirrored holdout rows: the record is a small
 /// display file read by every co-homed boot's status pass, and
 /// `session_count` carries the full truth — truncated renders say "and
-/// N more" from the difference.
+/// N more" from the difference. Successors widen past the cap through
+/// the sibling doorway ([`super::sibling_wait_set`]); the record itself
+/// crosses the handover wire and never grows.
 pub(crate) const PRESENCE_HOLDOUT_ROWS_CAP: usize = 16;
+
+/// The ONE holdout ordering rule, shared by every producer of a holdout
+/// row list (the supervisor's wait-set report, the sibling-doorway
+/// widening): parked rows first with the earliest reset leading — capped
+/// renders keep the decisive parked-until facts — then id order for
+/// stable rendering.
+pub(crate) fn sort_drain_holdout_rows(rows: &mut [DrainHoldout]) {
+    let park_key = |row: &DrainHoldout| match &row.limit_park {
+        Some(park) => (0u8, park.resets_at_epoch.unwrap_or(u64::MAX)),
+        None => (1u8, 0),
+    };
+    rows.sort_by(|a, b| {
+        park_key(a)
+            .cmp(&park_key(b))
+            .then_with(|| a.session_id.cmp(&b.session_id))
+    });
+}
 
 /// `<boot_id>.json` — one daemon boot's self-description.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/bin/caller/handover/sibling_wait_set.rs
+++ b/src/bin/caller/handover/sibling_wait_set.rs
@@ -1,0 +1,390 @@
+//! Successor-side widening of a draining sibling's named wait set past
+//! the presence cap (card 01KZD84XEC, the 17-of-22 night's tail): the
+//! presence record itemizes at most [`super::presence::PRESENCE_HOLDOUT_ROWS_CAP`]
+//! holdout rows — it crosses the handover wire and deliberately does
+//! NOT grow — so on a >cap takeover the successor's drain map covered
+//! only the first 16 sessions and rows past the cap still read
+//! preboot/ghost. The fix rides the sibling doorway the takeover lane
+//! already uses (loopback + the drainer's per-port admission token from
+//! the shared state root): fetch the DRAINER'S OWN uncapped wait set —
+//! `GET /api/daemon/handover`, whose top-level `holdouts` block is the
+//! drainer's authoritative, deliberately uncapped self-report from the
+//! same live supervisor registry its catalog rows derive from — cache
+//! it per (state root, boot), and let the drain-map and status
+//! consumers widen the capped presence rows with it.
+//!
+//! Trust posture, in order:
+//! - **The presence rows are the FLOOR.** They arrive instantly by disk
+//!   read (the fast-path hint at boot) and win on per-session conflict;
+//!   the fetched set only ever ADDS sessions the cap hid. A fetch that
+//!   never lands, fails, or ages out degrades to exactly the floor —
+//!   never less than the presence lane alone.
+//! - **The provable-liveness gate is consume-side and presence-locked.**
+//!   Consumers call [`resolve_sibling_wait_set`] only for a record that
+//!   passes the same gate as the presence rows themselves (draining
+//!   state + boot lock HELD, probed at serve time), and the fetch task
+//!   re-checks that gate before any network. A cached claim from a
+//!   now-dead drainer is therefore inert: the serve-time probe fails
+//!   and the whole sibling's rows — floor and fetched alike — drop.
+//! - **Admission is verified.** A response is cached only when the
+//!   answering daemon names the expected `boot_id` and self-reports
+//!   `draining` — a port re-used by some other process cannot inject
+//!   rows.
+//!
+//! Fetches are scheduled from sync serve paths onto the ambient tokio
+//! runtime (catalog builds run on `spawn_blocking` threads, which keep
+//! the runtime context); without a runtime — plain unit tests — nothing
+//! is scheduled and consumers serve the floor, deterministically.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use super::presence::{sort_drain_holdout_rows, DrainHoldout, PresenceRecord};
+
+/// Spacing between fetch attempts against one sibling — the wait set
+/// shrinks as the drain progresses, so cached rows refresh on this
+/// beat while a drain surface keeps polling.
+const REFRESH_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Stale-while-revalidate bound: fetched rows older than this stop
+/// serving (degrade to the presence floor) rather than over-claim a
+/// wait set the drainer stopped answering about a minute ago. The
+/// consume-side liveness gate already drops a DEAD drainer instantly;
+/// this bound is about a live-but-unreachable one.
+const SERVE_MAX_AGE: Duration = Duration::from_secs(60);
+
+/// The doorway fetch is loopback to a live co-homed daemon — tight.
+const FETCH_TIMEOUT: Duration = Duration::from_secs(4);
+
+/// One sibling's cached fetch state.
+#[derive(Default)]
+struct Entry {
+    /// The last admitted uncapped wait set and when it landed.
+    rows: Option<(Vec<DrainHoldout>, Instant)>,
+    /// Last attempt start — success or failure — for the retry beat.
+    last_attempt: Option<Instant>,
+    /// A fetch task is in flight; do not stack another.
+    in_flight: bool,
+}
+
+/// Cache keyed by (state root, boot id): one daemon process serves one
+/// home, but tests run many fixture homes through one process and a
+/// boot id must never leak across them.
+fn cache() -> &'static Mutex<HashMap<(PathBuf, String), Entry>> {
+    static CACHE: OnceLock<Mutex<HashMap<(PathBuf, String), Entry>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Did the presence cap (or a pre-holdouts-era record) truncate this
+/// record's named rows? `session_count` carries the full truth; absent
+/// count means truncation cannot be established (floor-only, as today).
+pub(crate) fn sibling_record_truncated(record: &PresenceRecord) -> bool {
+    let floor = record.holdouts.as_ref().map_or(0, Vec::len);
+    record
+        .session_count
+        .is_some_and(|count| count as usize > floor)
+}
+
+/// The fetched uncapped wait set for a draining live sibling, or `None`
+/// when the record is not truncated (the floor is already whole), no
+/// admitted fetch is in hand, or the last one aged out. Schedules a
+/// background refresh on the ambient runtime when due. The CALLER holds
+/// the liveness gate: only invoke for a record that reads `draining`
+/// with its boot lock probed HELD at serve time.
+pub(crate) fn resolve_sibling_wait_set(
+    state_root: &Path,
+    record: &PresenceRecord,
+) -> Option<Vec<DrainHoldout>> {
+    if !sibling_record_truncated(record) {
+        return None;
+    }
+    let key = (state_root.to_path_buf(), record.boot_id.clone());
+    let mut cache = match cache().lock() {
+        Ok(cache) => cache,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let entry = cache.entry(key).or_default();
+    let fresh = entry
+        .rows
+        .as_ref()
+        .is_some_and(|(_, at)| at.elapsed() < REFRESH_INTERVAL);
+    let attempted_recently = entry
+        .last_attempt
+        .is_some_and(|at| at.elapsed() < REFRESH_INTERVAL);
+    if !fresh && !entry.in_flight && !attempted_recently {
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            entry.in_flight = true;
+            entry.last_attempt = Some(Instant::now());
+            handle.spawn(fetch_sibling_wait_set(
+                state_root.to_path_buf(),
+                record.boot_id.clone(),
+                record.port,
+            ));
+        }
+    }
+    entry
+        .rows
+        .as_ref()
+        .filter(|(_, at)| at.elapsed() <= SERVE_MAX_AGE)
+        .map(|(rows, _)| rows.clone())
+}
+
+/// Union: the presence floor verbatim (it wins on per-session conflict
+/// — it is the disk-fresh copy rewritten per supervisor event), plus
+/// every fetched session the cap hid, in the ONE holdout ordering rule
+/// (parked rows first, earliest reset leading).
+pub(crate) fn widen_holdout_rows(
+    floor: &[DrainHoldout],
+    fetched: &[DrainHoldout],
+) -> Vec<DrainHoldout> {
+    let mut rows: Vec<DrainHoldout> = floor.to_vec();
+    let seen: HashSet<&str> = floor.iter().map(|row| row.session_id.as_str()).collect();
+    rows.extend(
+        fetched
+            .iter()
+            .filter(|row| !seen.contains(row.session_id.as_str()))
+            .cloned(),
+    );
+    sort_drain_holdout_rows(&mut rows);
+    rows
+}
+
+/// The background doorway fetch. Bounded and infallible: every failure
+/// path just leaves the cache as it was (the consumers keep serving the
+/// presence floor) and the retry beat tries again.
+async fn fetch_sibling_wait_set(state_root: PathBuf, boot_id: String, port: u16) {
+    let rows = fetch_uncapped_holdouts(&state_root, &boot_id, port).await;
+    let changed = {
+        let mut cache = match cache().lock() {
+            Ok(cache) => cache,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let entry = cache.entry((state_root, boot_id)).or_default();
+        entry.in_flight = false;
+        match rows {
+            Some(rows) => {
+                let changed = entry.rows.as_ref().map(|(prior, _)| prior) != Some(&rows);
+                entry.rows = Some((rows, Instant::now()));
+                changed
+            }
+            // Failure: keep any prior rows (stale-while-revalidate up to
+            // SERVE_MAX_AGE); the floor is the fallback after that.
+            None => false,
+        }
+    };
+    if changed {
+        // The list responses are cached ~30s; a landed (or moved) wait
+        // set must reach the grid on its next poll, not a TTL later.
+        crate::web_gateway::invalidate_session_list_response_caches();
+    }
+}
+
+/// GET the sibling's `/api/daemon/handover` over the loopback doorway
+/// and admit its uncapped `holdouts` block. `None` = do not admit
+/// (unreachable, refused, wrong daemon, not draining, unparseable).
+async fn fetch_uncapped_holdouts(
+    state_root: &Path,
+    boot_id: &str,
+    port: u16,
+) -> Option<Vec<DrainHoldout>> {
+    // Re-check the liveness gate from disk before any network: a dead
+    // or no-longer-draining drainer is never fetched, however stale the
+    // scheduling snapshot was.
+    let still_draining = super::read_presence_records(state_root)
+        .into_iter()
+        .any(|record| record.boot_id == boot_id && record.state == "draining");
+    if !still_draining || !super::boot_id_is_live(state_root, boot_id) {
+        return None;
+    }
+    // The sibling doorway: the drainer's scheme sidecar + per-port
+    // admission token from the shared state root — the same same-user
+    // trust class the takeover POST rides.
+    let scheme = std::fs::read_to_string(crate::loopback_token::loopback_sidecar_path(
+        state_root, port,
+    ))
+    .ok()
+    .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+    .and_then(|meta| meta.get("scheme")?.as_str().map(str::to_string))
+    .unwrap_or_else(|| "http".to_string());
+    let token =
+        std::fs::read_to_string(crate::loopback_token::loopback_token_path(state_root, port))
+            .map(|raw| raw.trim().to_string())
+            .unwrap_or_default();
+    // Loopback may serve the daemon's self-signed TLS cert: the per-port
+    // admission token is the authority on this lane, not WebPKI.
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .danger_accept_invalid_certs(true)
+        .timeout(FETCH_TIMEOUT)
+        .build()
+        .ok()?;
+    let response = client
+        .get(format!("{scheme}://127.0.0.1:{port}/api/daemon/handover"))
+        .header(crate::loopback_token::LOOPBACK_TOKEN_HEADER, token)
+        .send()
+        .await
+        .ok()?;
+    if !response.status().is_success() {
+        return None;
+    }
+    let body: serde_json::Value = response.json().await.ok()?;
+    // Admission: the answering daemon must BE the expected sibling and
+    // self-report draining — a re-used port cannot inject rows.
+    if body.get("boot_id").and_then(|value| value.as_str()) != Some(boot_id)
+        || body.get("draining").and_then(|value| value.as_bool()) != Some(true)
+    {
+        return None;
+    }
+    serde_json::from_value::<Vec<DrainHoldout>>(body.get("holdouts")?.clone()).ok()
+}
+
+/// Test seam: plant an admitted fetch result as if the doorway fetch
+/// just landed. Keyed like production — a fixture home's seed can never
+/// bleed into another test's.
+#[cfg(test)]
+pub(crate) fn seed_for_tests(state_root: &Path, boot_id: &str, rows: Vec<DrainHoldout>) {
+    let mut cache = match cache().lock() {
+        Ok(cache) => cache,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    cache.insert(
+        (state_root.to_path_buf(), boot_id.to_string()),
+        Entry {
+            rows: Some((rows, Instant::now())),
+            last_attempt: Some(Instant::now()),
+            in_flight: false,
+        },
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(session_count: Option<u64>, holdout_rows: usize) -> PresenceRecord {
+        serde_json::from_value(serde_json::json!({
+            "v": 1,
+            "boot_id": "boot-x",
+            "pid": std::process::id() + 1,
+            "port": 8899,
+            "version": {"pkg": "0.0.0", "git_sha": "x", "built_at": "x"},
+            "state": "draining",
+            "session_count": session_count,
+            "holdouts": (0..holdout_rows).map(|n| serde_json::json!({
+                "session_id": format!("sess-{n:02}"),
+                "source": "intendant",
+                "phase": "idle",
+            })).collect::<Vec<_>>(),
+            "updated_ms": 5_000,
+        }))
+        .expect("fixture record")
+    }
+
+    #[test]
+    fn truncation_reads_count_against_named_rows() {
+        // Count exceeds the named rows: the cap (or a pre-holdouts-era
+        // record) hid sessions.
+        assert!(sibling_record_truncated(&record(Some(18), 16)));
+        assert!(sibling_record_truncated(&record(Some(2), 0)));
+        // Whole floor: nothing to widen.
+        assert!(!sibling_record_truncated(&record(Some(16), 16)));
+        assert!(!sibling_record_truncated(&record(Some(3), 3)));
+        // No count: truncation cannot be established — floor-only.
+        assert!(!sibling_record_truncated(&record(None, 16)));
+    }
+
+    #[test]
+    fn untruncated_record_never_consults_or_schedules() {
+        let root = tempfile::tempdir().unwrap();
+        // Even with rows seeded under this key, a whole floor asks for
+        // no widening at all.
+        seed_for_tests(root.path(), "boot-x", vec![holdout("sess-99", "running")]);
+        assert_eq!(
+            resolve_sibling_wait_set(root.path(), &record(Some(3), 3)),
+            None
+        );
+    }
+
+    #[test]
+    fn truncated_record_serves_seeded_rows_and_fails_open_without_them() {
+        let root = tempfile::tempdir().unwrap();
+        // Fail-open: truncated but nothing fetched (and no runtime here
+        // to schedule one) — the consumer keeps the presence floor.
+        assert_eq!(
+            resolve_sibling_wait_set(root.path(), &record(Some(18), 16)),
+            None
+        );
+        let full: Vec<DrainHoldout> = (0..18)
+            .map(|n| holdout(&format!("sess-{n:02}"), "idle"))
+            .collect();
+        seed_for_tests(root.path(), "boot-x", full.clone());
+        assert_eq!(
+            resolve_sibling_wait_set(root.path(), &record(Some(18), 16)),
+            Some(full),
+        );
+        // Another home's identical boot id sees nothing — the key is
+        // (state root, boot id).
+        let other = tempfile::tempdir().unwrap();
+        assert_eq!(
+            resolve_sibling_wait_set(other.path(), &record(Some(18), 16)),
+            None
+        );
+    }
+
+    fn holdout(session_id: &str, phase: &str) -> DrainHoldout {
+        DrainHoldout {
+            session_id: session_id.to_string(),
+            source: "intendant".to_string(),
+            name: None,
+            phase: phase.to_string(),
+            limit_park: None,
+            bg_park: None,
+        }
+    }
+
+    #[test]
+    fn widen_keeps_floor_rows_verbatim_and_adds_hidden_sessions() {
+        let mut parked = holdout("sess-b", "waiting_rate_limit");
+        parked.limit_park = Some(crate::session_log::SessionLimitParkMeta {
+            resets_at_epoch: Some(1_754_000_000),
+            has_pending: true,
+        });
+        let floor = vec![holdout("sess-a", "running"), holdout("sess-c", "idle")];
+        // The fetched copy disagrees about sess-a's phase (it is a few
+        // seconds staler than the per-event presence mirror): the floor
+        // wins. sess-b and sess-d are the cap-hidden additions.
+        let fetched = vec![
+            holdout("sess-a", "idle"),
+            parked.clone(),
+            holdout("sess-d", "running"),
+        ];
+        let widened = widen_holdout_rows(&floor, &fetched);
+        assert_eq!(
+            widened
+                .iter()
+                .map(|row| row.session_id.as_str())
+                .collect::<Vec<_>>(),
+            // The one ordering rule: parked first, then id order.
+            vec!["sess-b", "sess-a", "sess-c", "sess-d"],
+        );
+        assert_eq!(
+            widened
+                .iter()
+                .find(|row| row.session_id == "sess-a")
+                .map(|row| row.phase.as_str()),
+            Some("running"),
+            "the presence floor wins on per-session conflict"
+        );
+        // Degenerate shapes stay honest.
+        assert_eq!(widen_holdout_rows(&[], &[]), Vec::<DrainHoldout>::new());
+        assert_eq!(
+            widen_holdout_rows(&floor, &[])
+                .iter()
+                .map(|row| row.session_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["sess-a", "sess-c"],
+        );
+    }
+}

--- a/src/bin/caller/session_supervisor/mod.rs
+++ b/src/bin/caller/session_supervisor/mod.rs
@@ -1089,9 +1089,10 @@ pub(crate) fn session_holds_drain(phase: &str, died_park: bool) -> bool {
 /// durable limit-park marker resolved from its `session_meta.json` —
 /// "parked until T" is decisive information (an in-memory park can hold
 /// the drain for hours), so the reset instant must reach every surface
-/// that renders the drain. Parked rows sort first (earliest reset
-/// leading) so capped renders keep the decisive ones; the rest keep id
-/// order for stable rendering.
+/// that renders the drain. Ordered by the ONE shared holdout rule
+/// ([`crate::handover::sort_drain_holdout_rows`]): parked rows first
+/// (earliest reset leading) so capped renders keep the decisive ones,
+/// then id order for stable rendering.
 fn drain_holdout_rows(
     holding: &[(String, String, Option<String>, String, PathBuf)],
 ) -> Vec<crate::handover::DrainHoldout> {
@@ -1112,15 +1113,7 @@ fn drain_holdout_rows(
             }
         })
         .collect();
-    let park_key = |row: &crate::handover::DrainHoldout| match &row.limit_park {
-        Some(park) => (0u8, park.resets_at_epoch.unwrap_or(u64::MAX)),
-        None => (1u8, 0),
-    };
-    rows.sort_by(|a, b| {
-        park_key(a)
-            .cmp(&park_key(b))
-            .then_with(|| a.session_id.cmp(&b.session_id))
-    });
+    crate::handover::sort_drain_holdout_rows(&mut rows);
     rows
 }
 

--- a/src/bin/caller/web_gateway/session_catalog/grid_envelope.rs
+++ b/src/bin/caller/web_gateway/session_catalog/grid_envelope.rs
@@ -76,7 +76,8 @@ pub(crate) struct GridEnvelopeJoins {
     lineage_epoch: Option<u64>,
     /// Update-abstraction §3 (residual R4): session id → the draining
     /// co-homed sibling still RUNNING it, resolved once per build from
-    /// presence (see [`resolve_drain_map`]). Empty when no live sibling
+    /// presence, widened past the presence cap through the sibling
+    /// doorway (see [`resolve_drain_map`]). Empty when no live sibling
     /// drains — the common case costs one directory read. Feeds both
     /// the `boot.held_by` wire block and — the 01KZ8X8DWK amendment —
     /// the era computation: a held row is never a ghost.
@@ -105,11 +106,18 @@ pub(crate) struct DrainHold {
 /// The co-homed drain map: presence records that are DRAINING and
 /// provably live (the boot-lock probe — the same liveness truth
 /// `status_json` serves), excluding this process's own record, with
-/// their named holdout rows indexed by session id. Sessions beyond the
-/// presence holdout cap (16) get no entry — `session_count` keeps the
-/// full truth and the drain banner stays the aggregate surface. The
-/// join self-clears: a drainer's exit frees its boot lock, `live`
-/// reads false, and the map stops carrying it.
+/// their named holdout rows indexed by session id. The capped presence
+/// rows are the FLOOR (instant, disk-read, first insert wins); when the
+/// cap truncated them (`session_count` keeps the full truth), the
+/// drainer's OWN uncapped wait set — fetched through the sibling
+/// doorway and cached ([`crate::handover::resolve_sibling_wait_set`],
+/// card 01KZD84XEC) — widens the map so no held session is invisible
+/// regardless of count. Until that fetch lands, or if it fails, the map
+/// serves exactly the floor — never less than the presence lane alone.
+/// Both lanes ride the SAME serve-time liveness gate, so a cached claim
+/// from a dead drainer is inert. The join self-clears: a drainer's exit
+/// frees its boot lock, `live` reads false, and the map stops carrying
+/// it — floor and fetched rows alike.
 fn resolve_drain_map(state_root: &Path) -> HashMap<String, DrainHold> {
     let own_pid = std::process::id();
     let current_build = crate::handover::BuildVersion::current();
@@ -118,14 +126,20 @@ fn resolve_drain_map(state_root: &Path) -> HashMap<String, DrainHold> {
         if record.pid == own_pid || record.state != "draining" {
             continue;
         }
-        let Some(holdouts) = record.holdouts.as_ref().filter(|rows| !rows.is_empty()) else {
+        let floor = record.holdouts.clone().unwrap_or_default();
+        let truncated = crate::handover::sibling_record_truncated(&record);
+        if floor.is_empty() && !truncated {
             continue;
-        };
+        }
         if !crate::handover::boot_id_is_live(state_root, &record.boot_id) {
             continue;
         }
         let same_build = record.version == current_build;
-        for holdout in holdouts {
+        let fetched = truncated
+            .then(|| crate::handover::resolve_sibling_wait_set(state_root, &record))
+            .flatten()
+            .unwrap_or_default();
+        for holdout in floor.iter().chain(fetched.iter()) {
             map.entry(holdout.session_id.clone())
                 .or_insert_with(|| DrainHold {
                     boot_id: record.boot_id.clone(),
@@ -1004,6 +1018,171 @@ mod tests {
                 .contains("(v.ghost ? 'Ghost — pre-boot, nothing behind it; safe to close' : '')"),
             "the safe-to-close brief must stay keyed on the served ghost bit"
         );
+    }
+
+    /// [`write_presence_record`] with an explicit `session_count` — the
+    /// truncation input for the sibling-doorway widening tests.
+    #[allow(clippy::too_many_arguments)]
+    fn write_presence_record_counted(
+        state_root: &Path,
+        boot_id: &str,
+        pid: u32,
+        port: u16,
+        state: &str,
+        version: serde_json::Value,
+        session_count: u64,
+        holdouts: serde_json::Value,
+    ) {
+        let dir = state_root.join("daemons");
+        std::fs::create_dir_all(&dir).unwrap();
+        let record = serde_json::json!({
+            "v": 1,
+            "boot_id": boot_id,
+            "pid": pid,
+            "port": port,
+            "version": version,
+            "state": state,
+            "session_count": session_count,
+            "holdouts": holdouts,
+            "updated_ms": 5_000,
+        });
+        std::fs::write(dir.join(format!("{boot_id}.json")), record.to_string()).unwrap();
+    }
+
+    fn bulk_holdout_rows(count: usize, phase: &str) -> serde_json::Value {
+        (0..count)
+            .map(|n| {
+                serde_json::json!({
+                    "session_id": format!("sess-{n:02}"),
+                    "source": "intendant",
+                    "phase": phase,
+                })
+            })
+            .collect()
+    }
+
+    fn bulk_holdouts(count: usize, phase: &str) -> Vec<crate::handover::DrainHoldout> {
+        serde_json::from_value(bulk_holdout_rows(count, phase)).unwrap()
+    }
+
+    /// Card 01KZD84XEC (the 17-of-22 night's tail): the presence cap
+    /// truncates a big drain's named rows, and before the widening every
+    /// session past the cap read preboot/ghost on the successor — the
+    /// #812 never-ghost fix covered only the itemized 16. The drain map
+    /// now widens from the drainer's own uncapped wait set (the sibling
+    /// doorway's cached fetch): a beyond-cap session serves the full
+    /// held_by block and never ghosts, exactly like a floor row. The
+    /// floor stays the fast path AND the winner on per-session conflict;
+    /// without a landed fetch the map serves exactly the floor
+    /// (fail-open — never worse than the presence lane alone).
+    #[test]
+    fn drain_map_widens_past_presence_cap_through_the_sibling_doorway() {
+        let sessions = tempfile::tempdir().unwrap();
+        let beyond = "sess-17";
+        let dir = session_dir_with_transcript(sessions.path(), beyond);
+        let floor_dir = session_dir_with_transcript(sessions.path(), "sess-00");
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        // Transcripts predate the successor's boot: ghost by arithmetic
+        // unless a live hold claims the row.
+        let preboot_watershed = now_secs + 3_600;
+        let foreign_pid = std::process::id() + 1;
+        let elder_build =
+            serde_json::json!({"pkg": "0.0.0", "git_sha": "elder", "built_at": "elder-ts"});
+        let attach_with = |state_root: &Path, session_id: &str, dir: &Path| {
+            let mut row = serde_json::json!({});
+            joins(Some(preboot_watershed), Some(&[]), None)
+                .with_drain_map_from(state_root)
+                .attach(&mut row, session_id, dir);
+            row
+        };
+        let cap = crate::handover::PRESENCE_HOLDOUT_ROWS_CAP;
+
+        // A drainer holding cap+2 sessions: the record itemizes only the
+        // cap; the doorway fetch (seeded as landed) names all 18.
+        let root = tempfile::tempdir().unwrap();
+        write_presence_record_counted(
+            root.path(),
+            "boot-big-drainer",
+            foreign_pid,
+            8770,
+            "draining",
+            elder_build.clone(),
+            (cap + 2) as u64,
+            bulk_holdout_rows(cap, "idle"),
+        );
+        let _lock = hold_boot_lock(root.path(), "boot-big-drainer");
+        // Fail-open FIRST (same fixture, nothing fetched yet): the floor
+        // row is held, the beyond-cap row still ghosts — never LESS than
+        // the presence lane alone, and nothing better until the fetch
+        // truly lands.
+        let row = attach_with(root.path(), "sess-00", &floor_dir);
+        assert_eq!(row["boot"]["held_by"]["boot_id"], "boot-big-drainer");
+        assert_eq!(row["boot"]["ghost"], false);
+        let row = attach_with(root.path(), beyond, &dir);
+        assert!(
+            row["boot"].get("held_by").is_none(),
+            "no fetch landed: the beyond-cap row has no claim to ride"
+        );
+        assert_eq!(row["boot"]["ghost"], true);
+
+        // The fetch lands (seeded): every session gains the claim. The
+        // fetched copy disagrees about a floor session's phase — the
+        // disk-fresh floor wins.
+        crate::handover::seed_sibling_wait_set_for_tests(
+            root.path(),
+            "boot-big-drainer",
+            bulk_holdouts(cap + 2, "running"),
+        );
+        let row = attach_with(root.path(), beyond, &dir);
+        let held = &row["boot"]["held_by"];
+        assert_eq!(held["boot_id"], "boot-big-drainer");
+        assert_eq!(held["port"], 8770);
+        assert_eq!(held["phase"], "running");
+        assert_eq!(
+            row["boot"]["era"], "current",
+            "a beyond-cap held row belongs to the daemon driving it now"
+        );
+        assert_eq!(
+            row["boot"]["ghost"], false,
+            "the never-ghost-on-held invariant extends past the cap"
+        );
+        let row = attach_with(root.path(), "sess-00", &floor_dir);
+        assert_eq!(
+            row["boot"]["held_by"]["phase"], "idle",
+            "the presence floor wins on per-session conflict"
+        );
+
+        // The liveness gate is consume-side and covers the CACHE: the
+        // identical truncated record with a seeded fetch but a FREE boot
+        // lock (drainer dead) serves nothing — a cached claim can never
+        // resurrect a dead drainer or suppress ghost.
+        let root = tempfile::tempdir().unwrap();
+        write_presence_record_counted(
+            root.path(),
+            "boot-dead-big",
+            foreign_pid,
+            8771,
+            "draining",
+            elder_build,
+            (cap + 2) as u64,
+            bulk_holdout_rows(cap, "idle"),
+        );
+        crate::handover::seed_sibling_wait_set_for_tests(
+            root.path(),
+            "boot-dead-big",
+            bulk_holdouts(cap + 2, "running"),
+        );
+        let row = attach_with(root.path(), beyond, &dir);
+        assert!(row["boot"].get("held_by").is_none());
+        assert_eq!(
+            row["boot"]["ghost"], true,
+            "a dead sibling's cached rows never suppress ghost"
+        );
+        let row = attach_with(root.path(), "sess-00", &floor_dir);
+        assert!(row["boot"].get("held_by").is_none());
     }
 
     fn envelope(

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -7617,9 +7617,12 @@ async fn held_by_rows_ride_the_successor_catalog_and_serve_the_composer_lane() {
 /// - the on-disk presence record still itemizes only the cap (it never
 ///   grows);
 /// - the claim self-clears with the drainer's death: floor and fetched
-///   rows alike drop the instant the boot lock frees, and the beyond-cap
-///   row reads ghost again (a dead sibling's cached rows never suppress
-///   ghost).
+///   rows alike drop the instant the boot lock frees — the beyond-cap
+///   row loses held_by with no wrapper behind it, and a dead sibling's
+///   cached rows never resurrect the claim (the strict never-suppress-
+///   ghost direction is unit-pinned where fixture mtimes are
+///   controlled; here the drain-entry transcript notice honestly lands
+///   inside the successor's era).
 /// The 18 sessions are deliberately CHEAP (the e2e footprint law): one
 /// scripted mock turn each, then parked idle for follow-ups — an idle
 /// session holds the drain, needs no barrier or timer, and its store is
@@ -7646,9 +7649,28 @@ async fn drain_map_widens_past_presence_cap_on_the_successor() {
         .build()
         .expect("http client");
     let rig = TestRig::new();
-    let mut daemon_a = spawn_daemon_on_rig(&client, rig, &script, false).await;
+    std::fs::write(rig.project.path().join("intendant.toml"), "").expect("project marker");
+    rig.write_script(&script);
+    // The drainer boots first (a free lease makes it the holder), with
+    // the resident bound raised explicitly: the default is RAM-derived
+    // (one per GiB — 16 on a 16 GiB box), which would capacity-queue the
+    // sessions past the cap and starve the fixture on exactly the boxes
+    // it must run on. The env override reads no host state.
+    let mut daemon_a = spawn_co_daemon(
+        &client,
+        &rig,
+        "daemon-a.log",
+        &[("INTENDANT_CAPACITY_MAX_RESIDENT", "64")],
+        &[],
+    )
+    .await;
     let port_a = daemon_a.port;
-    let holder_boot = lease_sidecar(&daemon_a.rig).expect("holder sidecar")["boot_id"]
+    let a_log = || {
+        std::fs::read_to_string(rig.home.path().join("daemon-a.log"))
+            .map(|log| tail(&log, 3000))
+            .unwrap_or_default()
+    };
+    let holder_boot = lease_sidecar(&rig).expect("holder sidecar")["boot_id"]
         .as_str()
         .expect("boot id")
         .to_string();
@@ -7660,13 +7682,13 @@ async fn drain_map_widens_past_presence_cap_on_the_successor() {
     let (mut ws_a, _) = tokio_tungstenite::connect_async(format!(
         "ws://127.0.0.1:{}/ws?token={}",
         port_a,
-        rig_loopback_token(&daemon_a.rig, port_a)
+        rig_loopback_token(&rig, port_a)
     ))
     .await
     .expect("connect drainer websocket");
     for n in 0..FULL {
         let task = format!("bulk hold {n:02}");
-        let started = ctl(&daemon_a, &["task", "start", "--task", &task]).await;
+        let started = ctl_on_rig(&rig, port_a, &["task", "start", "--task", &task]).await;
         assert!(started.status.success(), "{}", text_of(&started));
     }
     let mut held_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
@@ -7684,7 +7706,7 @@ async fn drain_map_widens_past_presence_cap_on_the_successor() {
                 "held sessions never settled ({} started, {} completed):\n{}",
                 held_ids.len(),
                 completed.len(),
-                daemon_a.log_tail()
+                a_log()
             )
         });
         let Some(sid) = event.get("session_id").and_then(serde_json::Value::as_str) else {
@@ -7709,7 +7731,7 @@ async fn drain_map_widens_past_presence_cap_on_the_successor() {
     // The successor boots with --takeover: the lease transfers, A drains.
     let daemon_b = spawn_co_daemon(
         &client,
-        &daemon_a.rig,
+        &rig,
         "daemon-b.log",
         &[("INTENDANT_LEASE_POLL_MS", "500")],
         &["--takeover"],
@@ -7720,18 +7742,17 @@ async fn drain_map_widens_past_presence_cap_on_the_successor() {
         "the lease transferring to the successor",
         RUN_TIMEOUT,
         || async {
-            let sidecar = lease_sidecar(&daemon_a.rig)?;
+            let sidecar = lease_sidecar(&rig)?;
             (sidecar["boot_id"] != holder_boot.as_str() && sidecar["state"] == "active")
                 .then_some(())
         },
-        || format!("sidecar: {:?}", lease_sidecar(&daemon_a.rig)),
+        || format!("sidecar: {:?}", lease_sidecar(&rig)),
     )
     .await;
 
     // The drainer's presence record: draining, the FULL count, and
     // exactly the capped rows — the record never grows past the cap.
-    let drainer_presence_path = daemon_a
-        .rig
+    let drainer_presence_path = rig
         .home
         .path()
         .join(".intendant")
@@ -7754,7 +7775,7 @@ async fn drain_map_widens_past_presence_cap_on_the_successor() {
             format!(
                 "--- drainer presence record ---\n{}\n--- A tail ---\n{}",
                 std::fs::read_to_string(&drainer_presence_path).unwrap_or_default(),
-                daemon_a.log_tail()
+                a_log()
             )
         },
     )
@@ -7785,7 +7806,7 @@ async fn drain_map_widens_past_presence_cap_on_the_successor() {
     let mut headers_b = reqwest::header::HeaderMap::new();
     headers_b.insert(
         "x-intendant-loopback-token",
-        rig_loopback_token(&daemon_a.rig, port_b)
+        rig_loopback_token(&rig, port_b)
             .parse()
             .expect("token header value"),
     );
@@ -7833,7 +7854,7 @@ async fn drain_map_widens_past_presence_cap_on_the_successor() {
                 "--- last failing row ---\n{}\n--- drainer presence ---\n{}\n--- A tail ---\n{}",
                 last_diag.lock().unwrap(),
                 std::fs::read_to_string(&drainer_presence_path).unwrap_or_default(),
-                daemon_a.log_tail()
+                a_log()
             )
         },
     )
@@ -7865,7 +7886,7 @@ async fn drain_map_widens_past_presence_cap_on_the_successor() {
             format!(
                 "--- drainer presence ---\n{}\n--- A tail ---\n{}",
                 std::fs::read_to_string(&drainer_presence_path).unwrap_or_default(),
-                daemon_a.log_tail()
+                a_log()
             )
         },
     )
@@ -7883,10 +7904,18 @@ async fn drain_map_widens_past_presence_cap_on_the_successor() {
 
     // Pin 4 — self-clear: kill the drainer. Its boot lock frees, the
     // serve-time liveness gate fails, and the cached doorway rows are
-    // inert — the beyond-cap row loses the claim and reads ghost again
-    // (idle sessions are never readopted: idle in, idle out).
-    daemon_a.child.kill().await.expect("kill the drainer");
+    // inert — the beyond-cap row loses the held_by claim entirely, and
+    // no wrapper stands behind it (idle released sessions are
+    // adjudicated left-dead, never readopted). The row then reads by
+    // the ordinary transcript arithmetic — here "current", HONESTLY:
+    // the drain-entry bus notice appended to every held transcript
+    // during the takeover, inside the successor's era (the strict
+    // dead-claim-never-suppresses-ghost direction is unit-pinned in
+    // grid_envelope, where fixture mtimes really predate the
+    // watershed).
+    daemon_a._child.kill().await.expect("kill the drainer");
     let dead_probe = beyond_cap[0].clone();
+    let last_dead_row = std::sync::Mutex::new(String::from("(row never served)"));
     poll_until(
         "the dead drainer's claim clearing from the successor catalog",
         RUN_TIMEOUT,
@@ -7897,12 +7926,21 @@ async fn drain_map_widens_past_presence_cap_on_the_successor() {
             )
             .await?;
             let row = row_of(&sessions, &dead_probe)?;
-            (row.pointer("/boot/held_by").is_none() && row["boot"]["ghost"] == true).then_some(())
+            *last_dead_row.lock().unwrap() = row.to_string();
+            (row.pointer("/boot/held_by").is_none() && row["boot"]["live_wrapper"] == false)
+                .then_some(())
         },
         || {
             format!(
-                "--- drainer presence ---\n{}",
-                std::fs::read_to_string(&drainer_presence_path).unwrap_or_default()
+                "--- drainer boot lock held (test-side probe) ---\n{}\n\
+                 --- last served row ({dead_probe}) ---\n{}\n\
+                 --- drainer presence ---\n{}\n--- B tail ---\n{}",
+                boot_lock_is_held(&rig, &holder_boot),
+                last_dead_row.lock().unwrap(),
+                std::fs::read_to_string(&drainer_presence_path).unwrap_or_default(),
+                std::fs::read_to_string(rig.home.path().join("daemon-b.log"))
+                    .map(|log| tail(&log, 3000))
+                    .unwrap_or_default(),
             )
         },
     )

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -7601,6 +7601,315 @@ async fn held_by_rows_ride_the_successor_catalog_and_serve_the_composer_lane() {
     drop(daemon_b);
 }
 
+/// Card 01KZD84XEC (the 17-of-22 night's tail): a takeover from a
+/// drainer holding MORE sessions than the presence holdout cap (16).
+/// The presence record deliberately keeps the cap — it crosses the
+/// handover wire — so the successor derives the rest from the DRAINER'S
+/// OWN uncapped wait set through the sibling doorway (loopback + the
+/// drainer's admission token, `GET /api/daemon/handover`). Pins:
+/// - every draining sibling session appears in the successor catalog
+///   regardless of count — all 18 rows serve `boot.held_by` +
+///   era:"current"/ghost:false, the two beyond-cap rows included (the
+///   #812 never-ghost fix extended past the cap);
+/// - the successor's served handover status names all 18 holdouts on
+///   the drainer's daemons entry (the banner list's source) while
+///   `session_count` stays the untouched full truth;
+/// - the on-disk presence record still itemizes only the cap (it never
+///   grows);
+/// - the claim self-clears with the drainer's death: floor and fetched
+///   rows alike drop the instant the boot lock frees, and the beyond-cap
+///   row reads ghost again (a dead sibling's cached rows never suppress
+///   ghost).
+/// The 18 sessions are deliberately CHEAP (the e2e footprint law): one
+/// scripted mock turn each, then parked idle for follow-ups — an idle
+/// session holds the drain, needs no barrier or timer, and its store is
+/// a few hundred bytes of transcript.
+#[tokio::test]
+async fn drain_map_widens_past_presence_cap_on_the_successor() {
+    const PRESENCE_CAP: usize = 16; // handover::presence::PRESENCE_HOLDOUT_ROWS_CAP
+    const FULL: usize = PRESENCE_CAP + 2;
+    let script = serde_json::json!({
+        "profiles": [
+            { "match": "bulk hold",
+              "steps": [
+                { "content": "turn one done — parked for follow-ups." }
+              ] },
+            { "steps": [
+                { "content": "fallback profile (unexpected session)",
+                  "tool_calls": [{ "name": "signal_done",
+                                   "arguments": { "message": "unexpected session" } }] }
+            ]}
+        ]
+    });
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("http client");
+    let rig = TestRig::new();
+    let mut daemon_a = spawn_daemon_on_rig(&client, rig, &script, false).await;
+    let port_a = daemon_a.port;
+    let holder_boot = lease_sidecar(&daemon_a.rig).expect("holder sidecar")["boot_id"]
+        .as_str()
+        .expect("boot id")
+        .to_string();
+
+    // 18 cheap held sessions: each does one mock turn and parks idle —
+    // alive, so each holds the coming drain. Every profile instance is
+    // per-session (provider selection constructs one per loop), so one
+    // "bulk hold" profile serves them all.
+    let (mut ws_a, _) = tokio_tungstenite::connect_async(format!(
+        "ws://127.0.0.1:{}/ws?token={}",
+        port_a,
+        rig_loopback_token(&daemon_a.rig, port_a)
+    ))
+    .await
+    .expect("connect drainer websocket");
+    for n in 0..FULL {
+        let task = format!("bulk hold {n:02}");
+        let started = ctl(&daemon_a, &["task", "start", "--task", &task]).await;
+        assert!(started.status.success(), "{}", text_of(&started));
+    }
+    let mut held_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut completed: std::collections::HashSet<String> = std::collections::HashSet::new();
+    while held_ids.len() < FULL || completed.len() < FULL {
+        let event = next_matching_ws_event(&mut ws_a, RUN_TIMEOUT, |json| {
+            matches!(
+                json.get("event").and_then(serde_json::Value::as_str),
+                Some("session_started") | Some("round_complete")
+            )
+        })
+        .await
+        .unwrap_or_else(|| {
+            panic!(
+                "held sessions never settled ({} started, {} completed):\n{}",
+                held_ids.len(),
+                completed.len(),
+                daemon_a.log_tail()
+            )
+        });
+        let Some(sid) = event.get("session_id").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        match event.get("event").and_then(serde_json::Value::as_str) {
+            Some("session_started")
+                if event
+                    .get("task")
+                    .and_then(serde_json::Value::as_str)
+                    .is_some_and(|task| task.starts_with("bulk hold")) =>
+            {
+                held_ids.insert(sid.to_string());
+            }
+            Some("round_complete") if held_ids.contains(sid) => {
+                completed.insert(sid.to_string());
+            }
+            _ => {}
+        }
+    }
+
+    // The successor boots with --takeover: the lease transfers, A drains.
+    let daemon_b = spawn_co_daemon(
+        &client,
+        &daemon_a.rig,
+        "daemon-b.log",
+        &[("INTENDANT_LEASE_POLL_MS", "500")],
+        &["--takeover"],
+    )
+    .await;
+    let port_b = daemon_b.port;
+    poll_until(
+        "the lease transferring to the successor",
+        RUN_TIMEOUT,
+        || async {
+            let sidecar = lease_sidecar(&daemon_a.rig)?;
+            (sidecar["boot_id"] != holder_boot.as_str() && sidecar["state"] == "active")
+                .then_some(())
+        },
+        || format!("sidecar: {:?}", lease_sidecar(&daemon_a.rig)),
+    )
+    .await;
+
+    // The drainer's presence record: draining, the FULL count, and
+    // exactly the capped rows — the record never grows past the cap.
+    let drainer_presence_path = daemon_a
+        .rig
+        .home
+        .path()
+        .join(".intendant")
+        .join("daemons")
+        .join(format!("{holder_boot}.json"));
+    let read_presence = || -> Option<serde_json::Value> {
+        serde_json::from_slice(&std::fs::read(&drainer_presence_path).ok()?).ok()
+    };
+    poll_until(
+        "the drainer's presence reporting the full drain wait set",
+        RUN_TIMEOUT,
+        || async {
+            let presence = read_presence()?;
+            (presence["state"] == "draining"
+                && presence["session_count"] == FULL as u64
+                && presence["holdouts"].as_array().map(Vec::len) == Some(PRESENCE_CAP))
+            .then_some(())
+        },
+        || {
+            format!(
+                "--- drainer presence record ---\n{}\n--- A tail ---\n{}",
+                std::fs::read_to_string(&drainer_presence_path).unwrap_or_default(),
+                daemon_a.log_tail()
+            )
+        },
+    )
+    .await;
+    let floor_ids: std::collections::HashSet<String> = read_presence()
+        .and_then(|presence| {
+            Some(
+                presence["holdouts"]
+                    .as_array()?
+                    .iter()
+                    .filter_map(|row| row["session_id"].as_str().map(str::to_string))
+                    .collect(),
+            )
+        })
+        .expect("itemized floor rows");
+    let beyond_cap: Vec<String> = held_ids.difference(&floor_ids).cloned().collect();
+    assert_eq!(
+        beyond_cap.len(),
+        FULL - PRESENCE_CAP,
+        "the cap hid exactly the beyond-cap sessions"
+    );
+
+    // Pin 1 — the successor catalog: EVERY held session serves the
+    // held_by claim with era current / ghost false, the beyond-cap rows
+    // included. Until the doorway fetch lands the successor legitimately
+    // serves only the 16 floor rows (the fast-path hint) — the poll
+    // crosses exactly when the fetched wait set widens the map.
+    let mut headers_b = reqwest::header::HeaderMap::new();
+    headers_b.insert(
+        "x-intendant-loopback-token",
+        rig_loopback_token(&daemon_a.rig, port_b)
+            .parse()
+            .expect("token header value"),
+    );
+    let client_b = reqwest::Client::builder()
+        .no_proxy()
+        .default_headers(headers_b)
+        .build()
+        .expect("successor-authed client");
+    let row_of = |sessions: &serde_json::Value, sid: &str| -> Option<serde_json::Value> {
+        sessions["sessions"]
+            .as_array()
+            .or_else(|| sessions.as_array())?
+            .iter()
+            .find(|row| row["session_id"] == sid)
+            .cloned()
+    };
+    let last_diag = std::sync::Mutex::new(String::from("(no row served yet)"));
+    poll_until(
+        "the successor serving held_by on every row past the cap",
+        RUN_TIMEOUT,
+        || async {
+            let sessions = http_get_json(
+                &client_b,
+                &format!("http://127.0.0.1:{port_b}/api/sessions"),
+            )
+            .await?;
+            for sid in &held_ids {
+                let Some(row) = row_of(&sessions, sid) else {
+                    *last_diag.lock().unwrap() = format!("row {sid} missing from the catalog");
+                    return None;
+                };
+                let held = row.pointer("/boot/held_by").cloned().unwrap_or_default();
+                if held["boot_id"] != holder_boot.as_str()
+                    || row["boot"]["ghost"] != false
+                    || row["boot"]["era"] != "current"
+                {
+                    *last_diag.lock().unwrap() = format!("row {sid}: {row}");
+                    return None;
+                }
+            }
+            Some(())
+        },
+        || {
+            format!(
+                "--- last failing row ---\n{}\n--- drainer presence ---\n{}\n--- A tail ---\n{}",
+                last_diag.lock().unwrap(),
+                std::fs::read_to_string(&drainer_presence_path).unwrap_or_default(),
+                daemon_a.log_tail()
+            )
+        },
+    )
+    .await;
+
+    // Pin 2 — the successor's served handover status (the banner list's
+    // source): the drainer's daemons entry names all 18 holdouts while
+    // session_count stays the full truth beside them.
+    poll_until(
+        "the successor's handover status widening the drainer's rows",
+        RUN_TIMEOUT,
+        || async {
+            let status = http_get_json(
+                &client_b,
+                &format!("http://127.0.0.1:{port_b}/api/daemon/handover"),
+            )
+            .await?;
+            let entry = status["daemons"]
+                .as_array()?
+                .iter()
+                .find(|daemon| daemon["boot_id"] == holder_boot.as_str())
+                .cloned()?;
+            (entry["live"] == true
+                && entry["session_count"] == FULL as u64
+                && entry["holdouts"].as_array().map(Vec::len) == Some(FULL))
+            .then_some(())
+        },
+        || {
+            format!(
+                "--- drainer presence ---\n{}\n--- A tail ---\n{}",
+                std::fs::read_to_string(&drainer_presence_path).unwrap_or_default(),
+                daemon_a.log_tail()
+            )
+        },
+    )
+    .await;
+
+    // Pin 3 — the record itself still itemizes only the cap: the
+    // widening is a served join, never presence growth.
+    assert_eq!(
+        read_presence().expect("drainer presence")["holdouts"]
+            .as_array()
+            .map(Vec::len),
+        Some(PRESENCE_CAP),
+        "the on-disk presence record never grows past the cap"
+    );
+
+    // Pin 4 — self-clear: kill the drainer. Its boot lock frees, the
+    // serve-time liveness gate fails, and the cached doorway rows are
+    // inert — the beyond-cap row loses the claim and reads ghost again
+    // (idle sessions are never readopted: idle in, idle out).
+    daemon_a.child.kill().await.expect("kill the drainer");
+    let dead_probe = beyond_cap[0].clone();
+    poll_until(
+        "the dead drainer's claim clearing from the successor catalog",
+        RUN_TIMEOUT,
+        || async {
+            let sessions = http_get_json(
+                &client_b,
+                &format!("http://127.0.0.1:{port_b}/api/sessions"),
+            )
+            .await?;
+            let row = row_of(&sessions, &dead_probe)?;
+            (row.pointer("/boot/held_by").is_none() && row["boot"]["ghost"] == true).then_some(())
+        },
+        || {
+            format!(
+                "--- drainer presence ---\n{}",
+                std::fs::read_to_string(&drainer_presence_path).unwrap_or_default()
+            )
+        },
+    )
+    .await;
+    drop(daemon_b);
+}
+
 /// A mock script whose scheduled-session profile parks mid-turn on a
 /// long provider delay — the holdout that keeps each drainer in the
 /// three-daemon chain below alive (and draining) for the whole


### PR DESCRIPTION
A draining daemon's presence record itemizes at most 16 holdout rows (the record crosses the handover wire and never grows), so on a >16-session takeover the successor's drain map covered only the first 16 — rows past the cap still read preboot/ghost and folded away even after #812; the real 22-session takeover left 5 sessions visible only as the #813 honesty note.

This derives the remainder from the drainer's own uncapped wait set through the sibling doorway:

- When a draining live sibling's `session_count` exceeds its itemized rows, the successor fetches the drainer's `GET /api/daemon/handover` over loopback with the drainer's per-port admission token from the shared state root — the same trust class the takeover POST rides. The response's top-level `holdouts` block is the drainer's deliberately uncapped self-report from the same live supervisor registry its catalog derives from. Admission requires the answer to name the expected `boot_id` and self-report `draining`.
- Results cache per (state root, boot id) with a 5s refresh beat, 60s serve bound, and a 4s fetch timeout; a landed change invalidates the session-list response caches so the widened map reaches the grid on the next poll instead of a TTL later.
- The capped presence rows stay the fast-path floor (instant banner counts at boot) and win on per-session conflict; the fetched set only adds sessions the cap hid. A failed or unlanded fetch degrades to exactly the floor — never less than today.
- Both lanes ride the same serve-time provable-liveness gate (draining state + boot lock held), so a cached claim from a dead drainer is inert and the join still self-clears on drainer exit.
- The successor's served handover status widens the drainer's `daemons` entry the same way, so the drain-banner list names every holdout; `session_count` stays the untouched full truth and the on-disk presence record never grows.
- The holdout ordering rule (parked first, earliest reset leading) moves to `handover::presence` beside the type, shared by the supervisor's report and the widening.

Tests:
- unit: truncation predicate, floor-wins union + one ordering rule, fail-open without a landed fetch, cache keyed per home, dead-sibling cache inertness (drain map + status surface), status widening with the record still capped on disk.
- e2e: an 18-session takeover — every held session appears in the successor catalog regardless of count (`held_by` + era current/ghost false past the cap), the widened status rows behind the banner, the never-growing record, and the self-clear on drainer death. The 18 held sessions are deliberately cheap: one scripted mock turn each, then parked idle.