### PR TITLE
macos-app: wire standard Edit-menu key equivalents into the main menu

### DIFF
--- a/macos-app/main.swift
+++ b/macos-app/main.swift
@@ -375,6 +375,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
     /// The app historically had no menu bar because closing the window
     /// quit it. Now that the window is closable without stopping the
     /// daemon, Quit (Cmd+Q) and Close (Cmd+W) need menu items to exist.
+    ///
+    /// The Edit menu exists for its key equivalents: without one, macOS
+    /// routes no standard editing combos at all, so Cmd+C/V/X/A/Z were
+    /// dead inside the WKWebView dashboard. Every Edit action is a
+    /// nil-targeted standard selector, resolved down the responder chain
+    /// to the web view's focused content.
     func installMainMenu() {
         let mainMenu = NSMenu()
 
@@ -398,9 +404,47 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
         updateItem.target = self
         appMenu.addItem(NSMenuItem.separator())
         appMenu.addItem(
+            withTitle: "Hide Intendant",
+            action: #selector(NSApplication.hide(_:)),
+            keyEquivalent: "h"
+        )
+        let hideOthersItem = appMenu.addItem(
+            withTitle: "Hide Others",
+            action: #selector(NSApplication.hideOtherApplications(_:)),
+            keyEquivalent: "h"
+        )
+        hideOthersItem.keyEquivalentModifierMask = [.command, .option]
+        appMenu.addItem(
+            withTitle: "Show All",
+            action: #selector(NSApplication.unhideAllApplications(_:)),
+            keyEquivalent: ""
+        )
+        appMenu.addItem(NSMenuItem.separator())
+        appMenu.addItem(
             withTitle: "Quit Intendant (stops the daemon)",
             action: #selector(NSApplication.terminate(_:)),
             keyEquivalent: "q"
+        )
+
+        let editItem = NSMenuItem()
+        mainMenu.addItem(editItem)
+        let editMenu = NSMenu(title: "Edit")
+        editItem.submenu = editMenu
+        // Undo/Redo have no ObjC-visible Swift declaration to hang a
+        // #selector on (NSResponder picks them up informally), so the
+        // string form is the canonical spelling. The uppercase "Z" key
+        // equivalent means Shift+Cmd+Z.
+        editMenu.addItem(withTitle: "Undo", action: Selector(("undo:")), keyEquivalent: "z")
+        editMenu.addItem(withTitle: "Redo", action: Selector(("redo:")), keyEquivalent: "Z")
+        editMenu.addItem(NSMenuItem.separator())
+        editMenu.addItem(withTitle: "Cut", action: #selector(NSText.cut(_:)), keyEquivalent: "x")
+        editMenu.addItem(withTitle: "Copy", action: #selector(NSText.copy(_:)), keyEquivalent: "c")
+        editMenu.addItem(withTitle: "Paste", action: #selector(NSText.paste(_:)), keyEquivalent: "v")
+        editMenu.addItem(NSMenuItem.separator())
+        editMenu.addItem(
+            withTitle: "Select All",
+            action: #selector(NSText.selectAll(_:)),
+            keyEquivalent: "a"
         )
 
         let windowItem = NSMenuItem()


### PR DESCRIPTION
## Summary

The macOS wrapper's programmatic main menu had App and Window menus but no Edit menu, so macOS routed no standard editing key equivalents — cmd+C, cmd+V, cmd+X, cmd+A, and cmd+Z were dead inside the WKWebView dashboard (agenda card 01KZDRNRJS).

- Add an **Edit menu**: Undo (cmd+Z), Redo (shift+cmd+Z), Cut (cmd+X), Copy (cmd+C), Paste (cmd+V), Select All (cmd+A). All actions are nil-targeted standard selectors resolved down the responder chain to the web view's focused content.
- Fill in the **App menu's standard Hide group**: Hide Intendant (cmd+H), Hide Others (opt+cmd+H), Show All.
- The **Window menu is unchanged**: Close (cmd+W) still closes only the window while the daemon keeps running (`applicationShouldTerminateAfterLastWindowClosed` returns false; `windowWillClose` tears down the webview only), Minimize (cmd+M) as before, Quit (cmd+Q) remains the explicit stop-everything gesture.

## Testing

- `xcrun swiftc -typecheck macos-app/*.swift` — exit 0 (the diff is Swift-only; the cargo suites were skipped because no Rust is touched).
- Live key verification (combos reaching the WKWebView content and the dashboard composer) is a manual acceptance on the next app rebuild via `scripts/bundle-macos.sh`.