### PR TITLE
macOS setup/bundle epilogues: path-independent launch instructions

### DIFF
--- a/scripts/bundle-macos.sh
+++ b/scripts/bundle-macos.sh
@@ -670,8 +670,12 @@ if [ "$INSTALL_APP" = "1" ]; then
 else
     echo "✅ Built: $APP (version $APP_VERSION; skipping install; set INSTALL_APP=1 to install)"
     echo ""
-    echo "Launch:"
-    echo "  open target/Intendant.app"
+    # Not `open -b` here: this branch never installed or registered the
+    # staged bundle, so the bundle id would resolve to whatever older copy
+    # LaunchServices knows about (or nothing). The absolute path launches
+    # exactly this build and works from any cwd.
+    echo "Launch (staged bundle, not installed):"
+    echo "  open \"$PROJECT_ROOT/$APP\""
 fi
 
 # Repeat a one-line pointer at the very end so the full warning can't be

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -572,9 +572,19 @@ run_install() {
         echo ""
     fi
 
+    # The launch instruction must work from any cwd — owners copy-paste it
+    # into a fresh shell long after this run (a relative target/ path fails
+    # from anywhere but the repo root). `open -b` resolves the installed
+    # bundle through LaunchServices; bundle-macos.sh installed it to
+    # /Applications above. No launch flags: the app wrapper always starts
+    # the daemon with the web dashboard on.
     echo "  IMPORTANT: Launch from the macOS GUI for audio to work:"
     echo ""
-    echo "    open target/Intendant.app --args --web"
+    echo "    open -b com.intendant.app"
+    echo ""
+    echo "  This works from any directory — the app is installed in"
+    echo "  /Applications and starts the daemon and web dashboard"
+    echo "  itself (no flags needed)."
     echo ""
     echo "  macOS requires GUI session for audio input. Do NOT run"
     echo "  from SSH — use the app bundle, Finder, or Terminal.app"


### PR DESCRIPTION
The setup-macos.sh closing epilogue told users to run `open target/Intendant.app --args --web`:

- The relative `target/` path fails from any cwd other than the repo root (hit live on a fresh box: `open` reports the file does not exist), and points at the staged bundle rather than the one the setup just installed — bundle-macos.sh installs to /Applications and deliberately unregisters the `target/` copy to keep LaunchServices unambiguous.
- The `--args --web` flags are redundant: the app wrapper (BackendSupervisor) composes `--web <port>` itself on every daemon spawn, so the dashboard is always on.

The epilogue now prints `open -b com.intendant.app` — the same form bundle-macos.sh already prints after install, which works from any directory — plus a short note that the app starts the daemon and dashboard itself.

bundle-macos.sh's build-only branch (`INSTALL_APP=0`) printed the same relative path; it now prints the absolute staged-bundle path (`open "$PROJECT_ROOT/$APP"`). `open -b` would be wrong in that branch: it never installs or registers the staged bundle, so the bundle id would resolve to whatever older copy LaunchServices knows about.

Validation: `bash -n` and shellcheck (0.11.0) clean on both scripts; no Rust test reads these scripts' content (e2e references are stub fixtures), so the scripts-only diff needs no binary test run.