### PR TITLE
fix(dashboard): unfueled CTAs survive tunnel-primary postures with a late status frame

### DIFF
--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -3265,6 +3265,38 @@ mod tests {
         }
     }
 
+    /// The aggregate `fueled` flag rides EVERY status frame, for every
+    /// grant shape — deliberately presence-level (no settings.manage), and
+    /// in tunnel-primary postures (the packaged macOS app, hosted Connect)
+    /// it is the ONLY lane the SPA's unfueled empty-state CTAs can learn
+    /// the answer from. Shape-only assertion: the value depends on live
+    /// credentials, the presence of the boolean must not.
+    #[test]
+    fn status_carries_the_aggregate_fueled_flag_for_every_grant_shape() {
+        let mut rt = runtime();
+        for grant in [
+            DashboardControlGrant::TrustedLocal,
+            scoped_user_client_grant(),
+            DashboardControlGrant::Peer {
+                fingerprint: "aabbccdd".into(),
+                label: "peer".into(),
+                profile: "read-only-display".into(),
+                filesystem: Default::default(),
+                attributed: None,
+                identity_record: None,
+                iam_cert_dir: None,
+            },
+        ] {
+            rt.grant = grant;
+            let status = status_response_frame("s1".to_string(), &rt);
+            assert!(
+                status["result"]["fueled"].is_boolean(),
+                "status result missing the aggregate `fueled` boolean for {}",
+                status["result"]["grant_kind"]
+            );
+        }
+    }
+
     #[test]
     fn upload_start_authorizes_by_delivered_method_not_blanket_fs_write() {
         let file_operator = ControlRuntime {

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -6175,6 +6175,48 @@ mod tests {
         }
     }
 
+    /// In tunnel-primary postures (the packaged macOS app's mTLS bundle,
+    /// hosted Connect) the status frame's aggregate `fueled` flag is the
+    /// only lane the Activity empty state's unfueled CTAs can learn the
+    /// answer from — and the SPA's boot probe retires after ~40s, so the
+    /// status handler (50-control-transport.js handleOpen) must re-ask
+    /// the empty-state probe when the answer finally arrives. That
+    /// arrival hook is a plain call in a fragment, invisible to the type
+    /// system; pin it textually against the assembled app.html (the
+    /// sanctioned mirror-with-parity-test pattern) so deleting either
+    /// consumer fails the suite instead of shipping the 2026-08 packaged
+    /// -app regression again (unfueled daemon, bare "No activity yet",
+    /// no CTAs).
+    #[test]
+    fn unfueled_empty_state_reprobe_rides_tunnel_status() {
+        let app = include_str!("../../../../static/app.html");
+        let marker = "'[dashboard-control] status RPC ok'";
+        let from = app
+            .find(marker)
+            .expect("the local tunnel's status-RPC success log is gone from app.html")
+            + marker.len();
+        let rest = &app[from..];
+        let to = rest
+            .find("status RPC failed")
+            .expect("the local tunnel's status-RPC failure log is gone from app.html");
+        let then_block = &rest[..to];
+        for consumer in ["updateNewSessionFuelBanner", "refreshUnfueledEmptyState"] {
+            assert!(
+                then_block.contains(consumer),
+                "the tunnel status handler no longer notifies {consumer}; \
+                 tunnel-primary postures would lose their fueled-state \
+                 arrival hook (see the handleOpen comment in \
+                 static/app/50-control-transport.js)"
+            );
+        }
+        // And the empty-state probe itself still reads the aggregate flag
+        // the status frame carries (dispatch.rs pins the frame's side).
+        assert!(
+            app.contains("dashboardControlTransport?.lastStatus?.fueled"),
+            "the SPA no longer reads the status frame's aggregate `fueled` flag"
+        );
+    }
+
     /// The SPA's `daemonApi` facade mirrors the HTTP twins of its tunnel
     /// methods as `DAEMON_API_HTTP_MAP` (static/app/32-daemon-api.js). That
     /// copy can't derive from `gateway_routes::ROUTES`, so pin every entry

--- a/src/bin/caller/web_gateway/settings.rs
+++ b/src/bin/caller/web_gateway/settings.rs
@@ -1463,6 +1463,39 @@ pub(crate) async fn handle_external_agents(
 mod tests {
     use super::*;
 
+    /// Lane parity for the daemon's fueling truth: the aggregate
+    /// `fueled` boolean the dashboard-control status frame serves
+    /// ([`any_provider_credential_usable`]) must equal the OR of the
+    /// per-provider booleans `/api/api-key-status` serves
+    /// ([`get_api_key_status_json`]), and the per-provider key set must
+    /// stay derived from `PROVIDER_KEY_ENV_VARS` — one authoritative
+    /// list feeding both lanes, so the two surfaces cannot drift apart.
+    /// Assertions are relational (not absolute), so the test passes on
+    /// any machine state; the env lock serializes against tests that
+    /// mutate provider key variables mid-flight.
+    #[test]
+    fn aggregate_fueled_flag_matches_per_provider_key_status() {
+        let _env = crate::test_support::TEST_ENV_LOCK.blocking_lock();
+        let status: serde_json::Value = serde_json::from_str(&get_api_key_status_json())
+            .expect("api key status is a JSON object");
+        let map = status.as_object().expect("api key status is an object");
+        let expected_keys: std::collections::BTreeSet<String> = crate::provider::PROVIDER_KEY_ENV_VARS
+            .iter()
+            .map(|name| name.trim_end_matches("_API_KEY").to_ascii_lowercase())
+            .collect();
+        let actual_keys: std::collections::BTreeSet<String> = map.keys().cloned().collect();
+        assert_eq!(
+            actual_keys, expected_keys,
+            "per-provider status keys must derive from PROVIDER_KEY_ENV_VARS"
+        );
+        let any_per_provider = map.values().any(|value| value.as_bool() == Some(true));
+        assert_eq!(
+            any_provider_credential_usable(),
+            any_per_provider,
+            "the status frame's aggregate `fueled` and /api/api-key-status disagree"
+        );
+    }
+
     #[tokio::test]
     async fn settings_catalog_uses_the_signed_in_codex_account_cache() {
         let codex_home = tempfile::tempdir().unwrap();

--- a/src/bin/caller/web_gateway/settings.rs
+++ b/src/bin/caller/web_gateway/settings.rs
@@ -1479,10 +1479,11 @@ mod tests {
         let status: serde_json::Value = serde_json::from_str(&get_api_key_status_json())
             .expect("api key status is a JSON object");
         let map = status.as_object().expect("api key status is an object");
-        let expected_keys: std::collections::BTreeSet<String> = crate::provider::PROVIDER_KEY_ENV_VARS
-            .iter()
-            .map(|name| name.trim_end_matches("_API_KEY").to_ascii_lowercase())
-            .collect();
+        let expected_keys: std::collections::BTreeSet<String> =
+            crate::provider::PROVIDER_KEY_ENV_VARS
+                .iter()
+                .map(|name| name.trim_end_matches("_API_KEY").to_ascii_lowercase())
+                .collect();
         let actual_keys: std::collections::BTreeSet<String> = map.keys().cloned().collect();
         assert_eq!(
             actual_keys, expected_keys,

--- a/static/app.html
+++ b/static/app.html
@@ -39262,7 +39262,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'c7a0663fb7eeebcd';
+const INTENDANT_APP_BUILD = '4a1f43bfd0075d80';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -40011,40 +40011,48 @@ function applyExternalAgentAvailabilityToNewSessionPicker() {
   }
 }
 
-let unfueledCheckInFlight = false;
-async function refreshUnfueledEmptyState() {
-  if (unfueledCheckInFlight) return true;
-  unfueledCheckInFlight = true;
-  try {
-    // Freshest first: an active lease means fueled, and the lease list
-    // updates live as the vault grants/revokes (credentials.manage).
-    if (vaultLeaseState.supported === true && vaultLeaseState.leases.length > 0) {
-      applyUnfueledEmptyState(false);
+let unfueledCheckPromise = null;
+function refreshUnfueledEmptyState() {
+  // Concurrent callers share the in-flight check's REAL verdict. (This
+  // used to answer a fabricated `true` — "known" — while another check
+  // was in flight; when a vault-lease refresh overlapped one of the boot
+  // probe's attempts, scheduleUnfueledProbe read that lie as "answered"
+  // and retired its retry chain, leaving an unfueled daemon's Activity
+  // empty state permanently bare on slow first boots.)
+  if (unfueledCheckPromise) return unfueledCheckPromise;
+  unfueledCheckPromise = (async () => {
+    try {
+      // Freshest first: an active lease means fueled, and the lease list
+      // updates live as the vault grants/revokes (credentials.manage).
+      if (vaultLeaseState.supported === true && vaultLeaseState.leases.length > 0) {
+        applyUnfueledEmptyState(false);
+        return true;
+      }
+      // The status frame carries an aggregate `fueled` flag readable by
+      // every authorized binding; per-provider api_key_status needs
+      // settings.manage. Hosted Connect has no daemon-control binding in the
+      // default build.
+      const statusFueled = dashboardControlTransport?.lastStatus?.fueled;
+      if (typeof statusFueled === 'boolean') {
+        if (!statusFueled) await refreshExternalAgentAvailability();
+        applyUnfueledEmptyState(!statusFueled);
+        return true;
+      }
+      const keys = await fetchApiKeyStatus();
+      if (!keys || typeof keys !== 'object') return false;
+      const unfueled = !(keys.openai || keys.anthropic || keys.gemini);
+      if (unfueled) await refreshExternalAgentAvailability();
+      applyUnfueledEmptyState(unfueled);
       return true;
+    } catch {
+      // Unknown (transport not up yet, or a daemon predating the flag):
+      // keep the default copy rather than guessing.
+      return false;
+    } finally {
+      unfueledCheckPromise = null;
     }
-    // The status frame carries an aggregate `fueled` flag readable by
-    // every authorized binding; per-provider api_key_status needs
-    // settings.manage. Hosted Connect has no daemon-control binding in the
-    // default build.
-    const statusFueled = dashboardControlTransport?.lastStatus?.fueled;
-    if (typeof statusFueled === 'boolean') {
-      if (!statusFueled) await refreshExternalAgentAvailability();
-      applyUnfueledEmptyState(!statusFueled);
-      return true;
-    }
-    const keys = await fetchApiKeyStatus();
-    if (!keys || typeof keys !== 'object') return false;
-    const unfueled = !(keys.openai || keys.anthropic || keys.gemini);
-    if (unfueled) await refreshExternalAgentAvailability();
-    applyUnfueledEmptyState(unfueled);
-    return true;
-  } catch {
-    // Unknown (transport not up yet, or a daemon predating the flag):
-    // keep the default copy rather than guessing.
-    return false;
-  } finally {
-    unfueledCheckInFlight = false;
-  }
+  })();
+  return unfueledCheckPromise;
 }
 function applyUnfueledEmptyState(unfueled) {
   const empty = document.getElementById('log-empty-state');
@@ -115929,6 +115937,16 @@ class DashboardControlTransport {
         // The status frame carries the aggregate `fueled` flag the
         // New Session preflight banner derives from.
         if (typeof updateNewSessionFuelBanner === 'function') updateNewSessionFuelBanner();
+        // In tunnel-primary postures (the packaged macOS app, hosted
+        // Connect) this arrival is the first moment `fueled` is readable
+        // at all — and on a slow first boot it can land after the
+        // Activity empty state's boot probe expired its retries. Re-ask
+        // now so the unfueled CTAs can never miss a late answer.
+        // (Pinned by unfueled_empty_state_reprobe_rides_tunnel_status
+        // in dashboard_control/mod.rs.)
+        if (typeof refreshUnfueledEmptyState === 'function') {
+          refreshUnfueledEmptyState().catch(() => {});
+        }
       }
     }).catch(err => console.warn('[dashboard-control] status RPC failed', err));
     this.request('config').then(config => {

--- a/static/app/31-init-identity-fleet.js
+++ b/static/app/31-init-identity-fleet.js
@@ -762,40 +762,48 @@ function applyExternalAgentAvailabilityToNewSessionPicker() {
   }
 }
 
-let unfueledCheckInFlight = false;
-async function refreshUnfueledEmptyState() {
-  if (unfueledCheckInFlight) return true;
-  unfueledCheckInFlight = true;
-  try {
-    // Freshest first: an active lease means fueled, and the lease list
-    // updates live as the vault grants/revokes (credentials.manage).
-    if (vaultLeaseState.supported === true && vaultLeaseState.leases.length > 0) {
-      applyUnfueledEmptyState(false);
+let unfueledCheckPromise = null;
+function refreshUnfueledEmptyState() {
+  // Concurrent callers share the in-flight check's REAL verdict. (This
+  // used to answer a fabricated `true` — "known" — while another check
+  // was in flight; when a vault-lease refresh overlapped one of the boot
+  // probe's attempts, scheduleUnfueledProbe read that lie as "answered"
+  // and retired its retry chain, leaving an unfueled daemon's Activity
+  // empty state permanently bare on slow first boots.)
+  if (unfueledCheckPromise) return unfueledCheckPromise;
+  unfueledCheckPromise = (async () => {
+    try {
+      // Freshest first: an active lease means fueled, and the lease list
+      // updates live as the vault grants/revokes (credentials.manage).
+      if (vaultLeaseState.supported === true && vaultLeaseState.leases.length > 0) {
+        applyUnfueledEmptyState(false);
+        return true;
+      }
+      // The status frame carries an aggregate `fueled` flag readable by
+      // every authorized binding; per-provider api_key_status needs
+      // settings.manage. Hosted Connect has no daemon-control binding in the
+      // default build.
+      const statusFueled = dashboardControlTransport?.lastStatus?.fueled;
+      if (typeof statusFueled === 'boolean') {
+        if (!statusFueled) await refreshExternalAgentAvailability();
+        applyUnfueledEmptyState(!statusFueled);
+        return true;
+      }
+      const keys = await fetchApiKeyStatus();
+      if (!keys || typeof keys !== 'object') return false;
+      const unfueled = !(keys.openai || keys.anthropic || keys.gemini);
+      if (unfueled) await refreshExternalAgentAvailability();
+      applyUnfueledEmptyState(unfueled);
       return true;
+    } catch {
+      // Unknown (transport not up yet, or a daemon predating the flag):
+      // keep the default copy rather than guessing.
+      return false;
+    } finally {
+      unfueledCheckPromise = null;
     }
-    // The status frame carries an aggregate `fueled` flag readable by
-    // every authorized binding; per-provider api_key_status needs
-    // settings.manage. Hosted Connect has no daemon-control binding in the
-    // default build.
-    const statusFueled = dashboardControlTransport?.lastStatus?.fueled;
-    if (typeof statusFueled === 'boolean') {
-      if (!statusFueled) await refreshExternalAgentAvailability();
-      applyUnfueledEmptyState(!statusFueled);
-      return true;
-    }
-    const keys = await fetchApiKeyStatus();
-    if (!keys || typeof keys !== 'object') return false;
-    const unfueled = !(keys.openai || keys.anthropic || keys.gemini);
-    if (unfueled) await refreshExternalAgentAvailability();
-    applyUnfueledEmptyState(unfueled);
-    return true;
-  } catch {
-    // Unknown (transport not up yet, or a daemon predating the flag):
-    // keep the default copy rather than guessing.
-    return false;
-  } finally {
-    unfueledCheckInFlight = false;
-  }
+  })();
+  return unfueledCheckPromise;
 }
 function applyUnfueledEmptyState(unfueled) {
   const empty = document.getElementById('log-empty-state');

--- a/static/app/50-control-transport.js
+++ b/static/app/50-control-transport.js
@@ -195,6 +195,16 @@ class DashboardControlTransport {
         // The status frame carries the aggregate `fueled` flag the
         // New Session preflight banner derives from.
         if (typeof updateNewSessionFuelBanner === 'function') updateNewSessionFuelBanner();
+        // In tunnel-primary postures (the packaged macOS app, hosted
+        // Connect) this arrival is the first moment `fueled` is readable
+        // at all — and on a slow first boot it can land after the
+        // Activity empty state's boot probe expired its retries. Re-ask
+        // now so the unfueled CTAs can never miss a late answer.
+        // (Pinned by unfueled_empty_state_reprobe_rides_tunnel_status
+        // in dashboard_control/mod.rs.)
+        if (typeof refreshUnfueledEmptyState === 'function') {
+          refreshUnfueledEmptyState().catch(() => {});
+        }
       }
     }).catch(err => console.warn('[dashboard-control] status RPC failed', err));
     this.request('config').then(config => {


### PR DESCRIPTION
## Bug (owner-reported, live e2e on a fresh 4 GB MacBook, packaged macOS app)

With an unfueled daemon (no provider credentials), the dashboard Activity tab showed only a bare "No activity yet" — the designed empty-state CTAs ("Add API keys" / "Sign in an agent") never appeared. The owner's screenshots showed the empty state bare **while the tunnel was demonstrably live** (capacity chip rendering `capacity_state` events, mTLS Ready).

## Root cause

The aggregate `fueled` flag exists **only on the dashboard-control tunnel's `status` frame** (`status_response_frame`, `src/bin/caller/dashboard_control/dispatch.rs` — deliberately presence-level, no `settings.manage`). `/config` does not carry it, and the HTTP lane's only fueling surface (`GET /api/api-key-status`) is Settings-gated on both lanes by design.

The SPA reads that flag from exactly one place: the boot probe chain (`scheduleUnfueledProbe` → `refreshUnfueledEmptyState`, `static/app/31-init-identity-fleet.js`), which retires forever after 20 attempts (~40 s + call latency). In tunnel-primary postures (the packaged macOS app's mTLS bundle, hosted Connect):

1. Before the tunnel is up, layer 3 (`fetchApiKeyStatus`) can only fail or 403 — a delivered non-401 4xx is deliberately **neither** a failure **nor** a recovery for the owner-lane observer, so nothing re-arms.
2. On a slow first boot (this box was swap-storming — the capacity·defer chip is the tell), the tunnel connects **after** the chain expired.
3. The status frame lands in `dashboardControlTransport.lastStatus` with `fueled:false` — and **nothing ever reads it again**. The status handler only notified the New Session banner (`updateNewSessionFuelBanner`), never the Activity empty state.

A second, compounding defect: `refreshUnfueledEmptyState` answered a fabricated `true` ("known") to concurrent callers while a check was in flight, so a vault-lease refresh overlapping one boot-probe attempt silently killed the retry chain even earlier.

## Reproduced

Scratch keyless daemon (`INTENDANT_HOME` temp dir, scrubbed env, `INTENDANT_APP_HTML_PATH` override), headless Chrome with the wrapper's `window.__intendantPort`/`__intendantBackendTls` flags injected at document start, `/api/api-key-status` answering a delivered 403 and tunnel signaling blocked for 50 s:

| SPA | outcome |
|---|---|
| pre-fix | tunnel up at ~57 s, full status frame cached (`fueled:false`), empty state **bare through 150 s** — the owner's screenshot state |
| post-fix | CTAs appear at ~58 s, the moment the status RPC resolves |

Clean baselines (plain + wrapper postures, no interference) show CTAs in both, pre- and post-fix — which is why this shipped believed-working.

## Fix (SPA)

- `static/app/50-control-transport.js`: the tunnel status handler now re-asks `refreshUnfueledEmptyState()` beside the existing New Session banner hook — the arrival **is** the answer, so the empty state can never miss a late status frame.
- `static/app/31-init-identity-fleet.js`: concurrent `refreshUnfueledEmptyState` callers now share the in-flight check's real verdict (a shared promise) instead of a fabricated "known".

## Pins (daemon-side, so the lanes can't drift again)

- `status_carries_the_aggregate_fueled_flag_for_every_grant_shape` (dispatch.rs): every grant shape's status frame carries the boolean `fueled`.
- `aggregate_fueled_flag_matches_per_provider_key_status` (settings.rs): the aggregate equals the OR of `/api/api-key-status`'s per-provider booleans; key set pinned to `PROVIDER_KEY_ENV_VARS`. Relational assertions, hermetic-safe, under `TEST_ENV_LOCK`.
- `unfueled_empty_state_reprobe_rides_tunnel_status` (dashboard_control/mod.rs): the assembled `app.html`'s status handler keeps notifying both fueled-state consumers and the SPA keeps reading `lastStatus.fueled` (the sanctioned mirror-with-parity-test pattern).

`static/app.html` regenerated from the fragments via `app-html-assembler`.
