### PR TITLE
skills/plugins unification S6: docs + reconciliation sweep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,7 +164,8 @@ macos-app/      # native macOS WKWebView wrapper (built by scripts/bundle-macos.
 vendor/         # vortex-guest-tools (macOS Vortex Audio HAL plugin)
 scripts/        # setup-{linux,macos,windows}, setup-lan*, bundle-macos, validate-dashboard.cjs (dashboard/Station QA), …
 skills/         # agenda, memory, operating/log search, visual collaboration, calls, E2E guides
-plugins/        # bundled first-party plugin packages (skills materialized only while enabled — plugin_registry.rs)
+plugins/        # bundled first-party plugin packages (payload skills materialize only while enabled — plugin_registry.rs); plugins, skills (incl. per-skill disable + user-added), and automation definitions are owner-managed from the dashboard's Plugins & Skills tab
+automations/    # house automation definitions (sealed SKILL.md files the Automate sheet stamps — agenda/definitions.rs; personal/dashboard-added copies live under <state root>/automations/)
 skills-internal/ # dev-fleet-only skills (symlinked by scripts/install-dev-skills.sh; NEVER embedded or installed by product code)
 docs/src/       # this project's mdBook — the deep reference (see the table above)
 SysPrompt*.md   # per-role system prompts (base, tools, user, orchestrator, research, implementation, presence, live audio)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,8 @@ macos-app/      # native macOS WKWebView wrapper (built by scripts/bundle-macos.
 vendor/         # vortex-guest-tools (macOS Vortex Audio HAL plugin)
 scripts/        # setup-{linux,macos,windows}, setup-lan*, bundle-macos, validate-dashboard.cjs (dashboard/Station QA), …
 skills/         # agenda, memory, operating/log search, visual collaboration, calls, E2E guides
-plugins/        # bundled first-party plugin packages (skills materialized only while enabled — plugin_registry.rs)
+plugins/        # bundled first-party plugin packages (payload skills materialize only while enabled — plugin_registry.rs); plugins, skills (incl. per-skill disable + user-added), and automation definitions are owner-managed from the dashboard's Plugins & Skills tab
+automations/    # house automation definitions (sealed SKILL.md files the Automate sheet stamps — agenda/definitions.rs; personal/dashboard-added copies live under <state root>/automations/)
 skills-internal/ # dev-fleet-only skills (symlinked by scripts/install-dev-skills.sh; NEVER embedded or installed by product code)
 docs/src/       # this project's mdBook — the deep reference (see the table above)
 SysPrompt*.md   # per-role system prompts (base, tools, user, orchestrator, research, implementation, presence, live audio)

--- a/automations/narrative-backfill/SKILL.md
+++ b/automations/narrative-backfill/SKILL.md
@@ -35,7 +35,7 @@ effort = "xhigh"
 [parameters.cap]
 label = "Spend cap"
 required = true
-hint = "Cumulative cost ceiling for this arc; estimates, never billed dollars. Re-annotate the THREAD to steer it mid-arc."
+hint = "Amount only — the $ is already in the line (60, not $60). Cumulative cost ceiling for this arc; estimates, never billed dollars. Re-annotate the THREAD to steer it mid-arc."
 kind = "annotation"
 line = "NS CAP: $<value>"
 ```

--- a/docs/src/agenda-and-memory.md
+++ b/docs/src/agenda-and-memory.md
@@ -1030,7 +1030,13 @@ tooltip, and degrades to the raw truncated id whenever nothing resolves
 The shipped mandates and workflows below are **definitions** — one
 agentskills.io-conforming directory each, `automations/<name>/SKILL.md`,
 in this repo (the house set) or under `<state root>/automations/`
-(personal; shadows a house definition of the same name, visibly). The
+(personal; shadows a house definition of the same name, visibly).
+Personal entries are either hand-placed in that directory or added from
+the dashboard's Plugins & Skills tab — the dashboard lane validates the
+pasted/uploaded bytes with the same parser stamping uses and records the
+caller's gate-resolved attribution plus the sha256 of the accepted
+bytes, and only entries it added can be removed from it (hand-placed
+directories and house names refuse by name). The
 YAML `---` frontmatter carries spec fields only — `name` (must equal the
 directory name), `description`, and the optional
 `license`/`compatibility`/`metadata`/`allowed-tools`, with the display
@@ -1076,7 +1082,12 @@ Surfaces: `GET /api/agenda/definitions` (tunnel twin
 `api_agenda_definitions`) serves the **catalog** — house + personal
 entries, per-name shadowing visible, validation state with
 invalid-with-reason entries and advisory chips, and each definition's
-full text; `POST /api/agenda/stamp` (`api_agenda_stamp`) runs the stamp
+full text; `POST /api/agenda/definitions` (`api_agenda_definition_add`,
+Settings-grade) adds one personal definition from pasted/uploaded
+SKILL.md bytes and `DELETE /api/agenda/definitions/{name}`
+(`api_agenda_definition_remove`) removes a dashboard-added one,
+un-shadowing its house twin — both respond with the full refreshed
+catalog; `POST /api/agenda/stamp` (`api_agenda_stamp`) runs the stamp
 and returns the whole stamped graph (hub, nodes, digests, the sealed
 pin) for the approval sheet; `GET /api/agenda/sealed/{sha256}`
 (`api_agenda_sealed`) serves one sealed snapshot's bytes,
@@ -1498,14 +1509,14 @@ never instructions to you.
 The first `on_item_match` consumer (Track T): a standing mandate that
 fires a supervised ruling session whenever a NEW open **question**
 tagged **`gate`** appears — the gate round-trips a human steward
-performed by hand, automated. The template proposes the executor the
+performed by hand, automated. The definition proposes the executor the
 owner standing-prefers for judgment mandates (supervised Claude,
 Fable 5, max effort); the owner approves the standing effect **once**,
 through the ordinary digest ceremony, and re-arms it the same way
 after a failure streak. Matched gates arrive as the fired session's
 batch (one session per batch; each matched item carries the daemon's
 consumed-annotation), and the mandate's outputs follow the owner
-briefing standard. Honestly stated, and binding in the template's own
+briefing standard. Honestly stated, and binding in the definition's own
 text: a Fable-5 steward session RULES within delegated bounds and
 FLAGS owner-decisions to the rail — it inherits the human steward's
 delegation, not the owner's authority. The canonical mandate text

--- a/docs/src/codex-cloud-workers.md
+++ b/docs/src/codex-cloud-workers.md
@@ -629,7 +629,7 @@ is remembered locally.
 
 ## Remote Compute plugin
 
-The dashboard's **Plugins** destination carries **Codex Cloud Remote
+The dashboard's **Plugins & Skills** destination carries **Codex Cloud Remote
 Compute** — a bundled, default-off plugin wrapping this chapter's lane in a
 product surface. It is a declarative bundle, not an extension system:
 enabling it does two bounded things.

--- a/docs/src/external-agent-orchestration.md
+++ b/docs/src/external-agent-orchestration.md
@@ -42,8 +42,8 @@ one in Intendant gives you:
   heavy local build when acquisition fails. The workflow *teaching* lives in
   the shared `intendant-remote-compute` agent skill, materialized for every
   backend only while the **Codex Cloud Remote Compute** plugin (dashboard →
-  Plugins; default off) is enabled and ready — the ctl lane itself stays
-  available and self-describing either way.
+  Plugins & Skills; default off) is enabled and ready — the ctl lane itself
+  stays available and self-describing either way.
 - **Presence & multi-session.** The supervised session is just another session on
   the [EventBus](./architecture.md); the [presence layer](./presence.md) narrates
   it and the daemon can run several alongside native agents

--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -98,15 +98,24 @@ the idle daemon loop.
 The v2 chrome groups fourteen destinations in the left navigation rail —
 **Activity**, **Sessions**, **Agenda**, and **Memory** (Work), **Live display**
 and **Station** (Watch), **Terminal** and **Files** (Machine), **Usage**
-(Insight), **Access** and **Vault** (Trust), **Settings**, **Plugins**, and
-**Debug** (System). The oversight bar on top carries the phase pill, stop control,
+(Insight), **Access** and **Vault** (Trust), **Settings**, **Plugins & Skills**,
+and **Debug** (System). The oversight bar on top carries the phase pill, stop control,
 context meter, transport state, and the ⌘K command palette. Activity's own
 header carries its five-view switch and Timeline-only session/layout controls;
 the composer — the global task input — docks at the bottom
 and reaches the daemon from any destination. New events arriving while you are
 elsewhere raise a badge on the rail item.
 
-**Plugins** (System) is the bundled-plugin catalog: first-party, default-off
+**Plugins & Skills** (System; the tab id stays `#plugins`, so deep links and
+routes are unchanged) is the unified management surface for everything this
+daemon teaches its agents — three daemon-derived sections: bundled plugins,
+the skill catalog, and the automation-definition catalog. There are no
+per-skill settings to find here: a skill is prose, so its whole
+configuration is whether it is active; a plugin's real knobs are the
+environment and config its readiness fixes name (outside the dashboard);
+an automation definition takes its configuration at stamp time, through
+the fields and knobs the Automate sheet renders from what it declares.
+The **Plugins** section is the bundled-plugin catalog: first-party, default-off
 capabilities — V1 ships **Codex Cloud Remote Compute** — rendered as
 host-owned cards whose lifecycle state (Available / Needs setup / Enabled /
 Setup failed), readiness layers with named fixes, and per-skill install facts
@@ -115,8 +124,11 @@ skill for every supervised backend and the response reports exactly what the
 installer did; disabling removes only Intendant-managed copies. Plugins here
 ship no dashboard code, hooks, or frames (a plugin ecosystem is the stated
 direction, but today's catalog is bundled first-party only) — see the
-Remote Compute plugin section of the Codex Cloud workers chapter. The tab also
-renders the unified skill catalog (`GET /api/skills`): builtin rows carry a
+Remote Compute plugin section of the Codex Cloud workers chapter. The
+**Skills** section renders the unified skill catalog (`GET /api/skills`) —
+every skill the daemon manages, builtin, plugin-carried, or user-added,
+with provenance, trust posture, and per-root install facts, never a
+directory enumeration: builtin rows carry a
 deactivate/re-enable toggle (`POST /api/skills/{name}`) backed by a persisted
 disabled-set the installer re-applies on every materialization pass over both
 global roots — a deactivated skill cannot resurrect on restart or rebuild, its
@@ -134,24 +146,28 @@ the recorded sha, toggle through the same disabled-set (re-enable re-verifies
 the library bytes against the recorded sha and refuses a drifted copy by
 name), and carry the Remove door (`DELETE /api/skills/{name}`) that deletes
 the library entry and sweeps the marked copies from both roots in-request —
-never an unmarked user-owned twin. The **Automation templates** section
+never an unmarked user-owned twin. The **Automation definitions** section
 renders the served definition catalog — the same shared frontend derivation
 the Automate sheet's picker reads, so the two surfaces can never skew — with
 per-row provenance, trust-posture lines, and shadow state verbatim: house
-templates ship in the binary, read-only rows with no remove door, and the
-**template add sheet** (`POST /api/agenda/definitions`, Settings-grade, same
+definitions ship in the binary, read-only rows with no remove door, and the
+**definition add sheet** (`POST /api/agenda/definitions`, Settings-grade, same
 paste/upload-only lanes and 64 KiB cap as the skill add) writes a personal
 definition into `<state_root>/automations/<name>/` — validated by the real
 definition parser, so a file the stamp would refuse refuses at add with the
 parser's own error — recording gate-resolved attribution plus the sha256 of
-the accepted bytes in the `templates` registry family. A personal template
+the accepted bytes in the `templates` registry family. A personal definition
 taking a house name shadows it visibly (both rows list; "shadows house · your
 copy resolves first"), `DELETE /api/agenda/definitions/{name}` removes only
 dashboard-added entries (house names and hand-placed personal directories
 refuse by name) and un-shadows the house twin in the same response, and a
 hand-edited library copy renders `library: stale` — the attribution no longer
 covers the bytes; stamping still seals whatever the file holds, under its own
-approval ceremony.
+approval ceremony. Each valid row's **Automate…** opens the agenda's
+existing Automate sheet preselected — one stamp lane, no duplicate knobs —
+where the sheet renders one labeled input per stamp-time parameter the
+definition declares (the agenda chapter's declared-parameters coverage);
+nothing here re-implements stamping or approval.
 
 On content-heavy destinations the composer can collapse to a compact pill and
 expand in place; each tab remembers its own state. Its target switcher can move
@@ -2097,8 +2113,8 @@ response omits the header.
 | GET | `/api/agenda/occurrences` | AgendaRead | own origin | none | Raw occurrence-journal page (since/item/limit cursor; unknown records served verbatim) |
 | POST | `/api/agenda/op` | AgendaWrite | own origin | ≤ 16 MiB | Apply one agenda command (add, ask, answer, patch, transitions, or scheduled-session propose/approve/revoke/withdraw) |
 | GET | `/api/agenda/definitions` | AgendaRead | own origin | none | Automation-definition catalog (house + personal, validation state, full text) |
-| POST | `/api/agenda/definitions` | Settings | own origin | ≤ 64 KiB | Add one personal automation template from pasted/uploaded SKILL.md bytes (validated by the real definition parser; records attribution + sha256; a house name shadows visibly) |
-| DELETE | `/api/agenda/definitions/{name}` | Settings | own origin | none | Remove one dashboard-added personal template (deletes the library entry + record; un-shadows the house twin; house/hand-placed names refuse by name) |
+| POST | `/api/agenda/definitions` | Settings | own origin | ≤ 64 KiB | Add one personal automation definition from pasted/uploaded SKILL.md bytes (validated by the real definition parser; records attribution + sha256; a house name shadows visibly) |
+| DELETE | `/api/agenda/definitions/{name}` | Settings | own origin | none | Remove one dashboard-added personal definition (deletes the library entry + record; un-shadows the house twin; house/hand-placed names refuse by name) |
 | GET | `/api/agenda/sealed/{sha256}` | AgendaRead | own origin | none | One sealed binding-ref snapshot by sha256 pin (read-only, content-addressed) |
 | POST | `/api/agenda/stamp` | AgendaWrite | own origin | bounded | Stamp an automation definition (park + propose the instance graph; never approves) |
 | POST | `/api/daemon/takeover` | Settings | own origin | ≤ 4 KiB | Request drain of this daemon (handover): the scheduler lease frees for a successor; in-flight sessions finish here |

--- a/skills-internal/README.md
+++ b/skills-internal/README.md
@@ -2,12 +2,13 @@
 
 Dev-fleet-only agent skills: in the public repo, outside the product.
 
-The four skill tiers:
+The five skill tiers:
 
 | Tier | Embedded in binary | Installed |
 |---|---|---|
-| `skills/` | yes (`builtin_skills.rs`, byte-pinned) | unconditionally, both global roots |
+| `skills/` | yes (`builtin_skills.rs`, byte-pinned) | both global roots, minus the owner's persisted disabled-set (dashboard deactivate/re-enable) |
 | `plugins/<name>/skills/` | yes (`plugin_registry.rs`) | materialized only while the plugin is enabled and ready |
+| `<state root>/skills/` (user library) | no — dashboard-added bytes, recorded with attribution + sha256 (`user_skills.rs`) | both global roots while enabled, marked `source: user (dashboard-added)`; removable from the dashboard |
 | `skills-internal/` (this tier) | **never** | dev-machine opt-in only |
 | `tests/skills/` | no | never (operator E2E briefs) |
 

--- a/src/bin/caller/agenda/definitions.rs
+++ b/src/bin/caller/agenda/definitions.rs
@@ -521,21 +521,21 @@ fn template_trust_posture(
 ) -> String {
     let mut posture = match provenance {
         DefinitionProvenance::House => {
-            "House template · ships in this daemon's binary, read-only here; adding a \
-             personal template of the same name shadows it."
+            "House definition · ships in this daemon's binary, read-only here; adding a \
+             personal definition of the same name shadows it."
         }
         DefinitionProvenance::Personal if recorded => {
-            "Personal template · added from the dashboard, attributed on this row."
+            "Personal definition · added from the dashboard, attributed on this row."
         }
         DefinitionProvenance::Personal => {
-            "Personal template · hand-placed in this daemon's library, managed by hand."
+            "Personal definition · hand-placed in this daemon's library, managed by hand."
         }
-        DefinitionProvenance::Path => "Explicit file path outside the template libraries.",
+        DefinitionProvenance::Path => "Explicit file path outside the definition libraries.",
     }
     .to_string();
     if shadows_house {
         posture
-            .push_str(" Shadows the house template of the same name — your copy resolves first.");
+            .push_str(" Shadows the house definition of the same name — your copy resolves first.");
     }
     posture.push_str(" Stamping seals the file; firings execute the sealed bytes.");
     posture
@@ -615,7 +615,7 @@ pub(crate) fn definition_catalog(state_root: &Path) -> Vec<DefinitionCatalogEntr
             library: Some("missing"),
             valid: false,
             reason: Some(
-                "the recorded personal template has no SKILL.md on disk — remove the \
+                "the recorded personal definition has no SKILL.md on disk — remove the \
                  entry (or add the definition again)"
                     .to_string(),
             ),
@@ -1761,7 +1761,8 @@ mod tests {
                 "name": "cap",
                 "label": "Spend cap",
                 "required": true,
-                "hint": "Cumulative cost ceiling for this arc; estimates, never billed \
+                "hint": "Amount only — the $ is already in the line (60, not $60). \
+                         Cumulative cost ceiling for this arc; estimates, never billed \
                          dollars. Re-annotate the THREAD to steer it mid-arc.",
                 "kind": "annotation",
                 "line": "NS CAP: $<value>",

--- a/src/bin/caller/agenda/handle.rs
+++ b/src/bin/caller/agenda/handle.rs
@@ -521,7 +521,7 @@ impl AgendaHandle {
         }
     }
 
-    /// Add one dashboard-added personal template (S5) against the SAME
+    /// Add one dashboard-added personal definition (S5) against the SAME
     /// state root the catalog reads and the stamp lane resolves —
     /// validation, collision walls, and registration live in
     /// [`crate::user_templates`].
@@ -539,7 +539,7 @@ impl AgendaHandle {
         crate::user_templates::add_user_template_in(state_root, name, skill_md, added_by)
     }
 
-    /// Remove one dashboard-added personal template (S5). Refusals are
+    /// Remove one dashboard-added personal definition (S5). Refusals are
     /// per-kind and named; house bytes and hand-placed directories are
     /// never touched.
     pub(crate) fn remove_personal_definition(

--- a/src/bin/caller/ctl.rs
+++ b/src/bin/caller/ctl.rs
@@ -3284,7 +3284,7 @@ fn agenda_triage_watermark(all_items: &[Value]) -> u64 {
 /// chip; the daemon kind is gate-derived and stronger.
 /// The dashboard twin is `agendaFrontierPredicate()` in
 /// `static/app/ui2-agenda-cards.js`; the definition also lives in
-/// `docs/src/agenda-and-memory.md` and the triage mandate template —
+/// `docs/src/agenda-and-memory.md` and the triage definition's mandate —
 /// the four expressions move together.
 fn agenda_item_in_frontier(item: &Value, triage_watermark: u64) -> bool {
     if item.get("status").and_then(Value::as_str) != Some("open") || agenda_summary_tagged(item) {

--- a/src/bin/caller/gateway_routes.rs
+++ b/src/bin/caller/gateway_routes.rs
@@ -442,11 +442,11 @@ pub(crate) enum RouteHandlerId {
     /// The automation-definition catalog (Track AW: house + personal
     /// libraries, validation state, full text).
     AgendaDefinitions,
-    /// Add one personal automation template into the automations library
-    /// (S5: validated by the real definition parser; attributed +
+    /// Add one personal automation definition into the automations
+    /// library (S5: validated by the real definition parser; attributed +
     /// sha256-sealed in the templates registry).
     AgendaDefinitionAdd,
-    /// Remove one dashboard-added personal template (un-shadows a house
+    /// Remove one dashboard-added personal definition (un-shadows a house
     /// twin; house bytes and hand-placed directories refuse by name).
     AgendaDefinitionRemove,
     /// One sealed binding-ref snapshot's bytes by sha256 pin (read-only,
@@ -1224,7 +1224,7 @@ pub(crate) static ROUTES: &[Route] = &[
         "Automation-definition catalog (house + personal, validation state, full text)",
     )
     .with_tunnel(tunnel_method("api_agenda_definitions")),
-    // Add one personal automation template (skills/plugins unification
+    // Add one personal automation definition (skills/plugins unification
     // S5). The S4 user-skill add lane retargeted at the automations
     // library: Settings-grade (hosted provenance `role:none` never
     // reaches it), pasted/uploaded SKILL.md bytes are the ONLY input
@@ -1242,10 +1242,10 @@ pub(crate) static ROUTES: &[Route] = &[
         PeerOperation::Settings,
         BodyPolicy::Capped(crate::user_templates::ADD_BODY_CAP_BYTES),
         RouteHandlerId::AgendaDefinitionAdd,
-        "Add one personal automation template from pasted/uploaded SKILL.md bytes (validated by the real definition parser; records attribution + sha256; a house name shadows visibly)",
+        "Add one personal automation definition from pasted/uploaded SKILL.md bytes (validated by the real definition parser; records attribution + sha256; a house name shadows visibly)",
     )
     .with_tunnel(tunnel_method("api_agenda_definition_add")),
-    // Remove one dashboard-added personal template (S5): deletes the
+    // Remove one dashboard-added personal definition (S5): deletes the
     // library directory + registry record — never house bytes (they live
     // under `.house/` and removal un-shadows back to them), never a
     // hand-placed personal directory (no record ⇒ named refusal toward
@@ -1256,7 +1256,7 @@ pub(crate) static ROUTES: &[Route] = &[
         PeerOperation::Settings,
         BodyPolicy::None,
         RouteHandlerId::AgendaDefinitionRemove,
-        "Remove one dashboard-added personal template (deletes the library entry + record; un-shadows the house twin; house/hand-placed names refuse by name)",
+        "Remove one dashboard-added personal definition (deletes the library entry + record; un-shadows the house twin; house/hand-placed names refuse by name)",
     )
     .with_tunnel(tunnel_method("api_agenda_definition_remove")),
     // Sealed binding-ref snapshots (Track AW): the read lane behind

--- a/src/bin/caller/user_templates.rs
+++ b/src/bin/caller/user_templates.rs
@@ -1,4 +1,4 @@
-//! The dashboard-added PERSONAL automation templates (skills/plugins
+//! The dashboard-added PERSONAL automation definitions (skills/plugins
 //! unification S5): the S4 user-skill lane retargeted at the automation
 //! library — `<state_root>/automations/<name>/SKILL.md`, the exact home
 //! the documented shadow-resolution order already reads
@@ -12,11 +12,11 @@
 //! stamp resolves through (deny-unknown config blocks, spec frontmatter,
 //! node arity, the whole set) — so a definition that would refuse at
 //! stamp time refuses at ADD time with the parser's own error. The add
-//! executes nothing and arms nothing: a template does nothing until
+//! executes nothing and arms nothing: a definition does nothing until
 //! stamped, and stamping still seals the file under an approval digest
 //! through the untouched stamp lane (intake §5.1).
 //!
-//! **House templates stay sealed.** The embedded house set lives under
+//! **House definitions stay sealed.** The embedded house set lives under
 //! `automations/.house/` and is never written here; adding a personal
 //! definition under a house NAME is the documented override mechanism —
 //! it shadows the house twin visibly (the catalog lists both) and
@@ -59,7 +59,7 @@ pub(crate) fn user_template_md_path_in(state_root: &Path, name: &str) -> PathBuf
         .join("SKILL.md")
 }
 
-/// Add one personal template: cap + slug walls, then the REAL definition
+/// Add one personal definition: cap + slug walls, then the REAL definition
 /// intake ([`crate::agenda::parse_definition`] — its error verbatim),
 /// then the collision walls (an existing record refuses remove-first; a
 /// hand-placed directory refuses fail-closed; a HOUSE name is the one
@@ -77,7 +77,7 @@ pub(crate) fn add_user_template_in(
     if skill_md.len() > ADD_BODY_CAP_BYTES {
         return Err(UserSkillRefusal::Invalid {
             message: format!(
-                "definition SKILL.md is {} bytes — the template cap is {} KiB",
+                "definition SKILL.md is {} bytes — the definition cap is {} KiB",
                 skill_md.len(),
                 ADD_BODY_CAP_BYTES / 1024
             ),
@@ -86,7 +86,7 @@ pub(crate) fn add_user_template_in(
     if !crate::agenda::valid_slug(name) {
         return Err(UserSkillRefusal::Invalid {
             message: format!(
-                "template name {name:?} violates the slug grammar (1..=64 lowercase \
+                "definition name {name:?} violates the slug grammar (1..=64 lowercase \
                  alphanumerics with single interior hyphens)"
             ),
         });
@@ -101,7 +101,7 @@ pub(crate) fn add_user_template_in(
     {
         return Err(UserSkillRefusal::NameCollision {
             message: format!(
-                "a personal template named '{name}' already exists — remove it first to \
+                "a personal definition named '{name}' already exists — remove it first to \
                  replace its bytes"
             ),
         });
@@ -173,15 +173,15 @@ pub(crate) fn remove_user_template_in(
         if crate::agenda::is_house_definition_name(name) {
             return Err(UserSkillRefusal::WrongLane {
                 message: format!(
-                    "house template '{name}' ships in the binary — there is nothing to \
-                     remove; add a personal template of the same name to shadow it instead"
+                    "house definition '{name}' ships in the binary — there is nothing to \
+                     remove; add a personal definition of the same name to shadow it instead"
                 ),
             });
         }
         return Err(UserSkillRefusal::UnknownSkill {
             message: format!(
-                "unknown template '{name}' — not a house definition or a dashboard-added \
-                 personal template"
+                "unknown definition '{name}' — not a house definition or a dashboard-added \
+                 personal one"
             ),
         });
     };
@@ -318,7 +318,7 @@ mod tests {
             add_user_template_in(root, "Bad_Slug", &action_md("bad-slug"), stamp("p")).unwrap_err();
         assert_eq!(
             refusal.message(),
-            "template name \"Bad_Slug\" violates the slug grammar (1..=64 lowercase \
+            "definition name \"Bad_Slug\" violates the slug grammar (1..=64 lowercase \
              alphanumerics with single interior hyphens)"
         );
         let oversized = format!("{}{}", action_md("big"), "x".repeat(ADD_BODY_CAP_BYTES));
@@ -326,7 +326,7 @@ mod tests {
         assert_eq!(
             refusal.message(),
             format!(
-                "definition SKILL.md is {} bytes — the template cap is 64 KiB",
+                "definition SKILL.md is {} bytes — the definition cap is 64 KiB",
                 oversized.len()
             )
         );
@@ -349,7 +349,7 @@ mod tests {
             add_user_template_in(root, "mine", &action_md("mine"), stamp("p")).unwrap_err();
         assert_eq!(
             refusal.message(),
-            "a personal template named 'mine' already exists — remove it first to \
+            "a personal definition named 'mine' already exists — remove it first to \
              replace its bytes"
         );
         assert_eq!(refusal.http_status(), 409);
@@ -415,8 +415,8 @@ mod tests {
         let refusal = remove_user_template_in(root, "triage").unwrap_err();
         assert_eq!(
             refusal.message(),
-            "house template 'triage' ships in the binary — there is nothing to \
-             remove; add a personal template of the same name to shadow it instead"
+            "house definition 'triage' ships in the binary — there is nothing to \
+             remove; add a personal definition of the same name to shadow it instead"
         );
         assert_eq!(refusal.http_status(), 409);
 
@@ -447,8 +447,8 @@ mod tests {
         let refusal = remove_user_template_in(root, "no-such").unwrap_err();
         assert_eq!(
             refusal.message(),
-            "unknown template 'no-such' — not a house definition or a dashboard-added \
-             personal template"
+            "unknown definition 'no-such' — not a house definition or a dashboard-added \
+             personal one"
         );
         assert_eq!(refusal.http_status(), 404);
     }

--- a/src/bin/caller/web_gateway/routes_agenda.rs
+++ b/src/bin/caller/web_gateway/routes_agenda.rs
@@ -498,7 +498,7 @@ pub(crate) async fn agenda_definition_add_api_response(
         return ApiResponse::json_error(
             413,
             format!(
-                "request body exceeds the {} KiB template cap",
+                "request body exceeds the {} KiB definition cap",
                 crate::user_templates::ADD_BODY_CAP_BYTES / 1024
             ),
         );
@@ -506,7 +506,7 @@ pub(crate) async fn agenda_definition_add_api_response(
     let request: AddTemplateBody = match serde_json::from_str(body_text) {
         Ok(request) => request,
         Err(error) => {
-            return ApiResponse::json_error(400, format!("invalid template request: {error}"))
+            return ApiResponse::json_error(400, format!("invalid definition request: {error}"))
         }
     };
     let Some(agenda) = agenda_handle(mcp_server).await else {

--- a/static/app.html
+++ b/static/app.html
@@ -27538,7 +27538,7 @@ html.ui-v2 .memory-judge-strip select {
 /* ── static/app/ui2-plugins.css ── */
 /* Plugins & Skills tab (System; pane id #tab-plugins is permanent): the
    bundled-plugin catalog plus the unified skill catalog and the
-   automation-template catalog. Cards and rows are host-owned; every
+   automation-definition catalog. Cards and rows are host-owned; every
    state/readiness/install fact derives from the daemon bodies. Styles
    reuse the shared ui-* components (.ui-card, .ui-btn, .ui-chip,
    .ui-empty, .ui-explainer) and the v2 token palette. */
@@ -27589,7 +27589,7 @@ html.ui-v2 .plugin-skill-row {
 
 html.ui-v2 .plugin-install-note { font-size: 12.5px; color: var(--text-3); }
 
-/* ── Sections (Plugins / Skills / Automation templates) ─────────────── */
+/* ── Sections (Plugins / Skills / Automation definitions) ───────────── */
 
 html.ui-v2 .plugins-section { display: flex; flex-direction: column; gap: 10px; }
 html.ui-v2 .plugins-section .ui-section-title { margin: 6px 0 0; }
@@ -32885,10 +32885,10 @@ html.ui-v2 .daemon-relay-note {
          and the manifest TDZ rule key on it; only the visible label moved
          to "Plugins & Skills"). Three daemon-derived sections: bundled
          plugins (/api/plugins), the unified skill catalog (/api/skills),
-         and the automation-template catalog (/api/agenda/definitions). -->
+         and the automation-definition catalog (/api/agenda/definitions). -->
     <div id="tab-plugins" class="tab-pane">
       <div class="plugins-wrap">
-        <div class="plugins-intro">Optional bundled capabilities and agent skills. Bundled plugins ship no third-party code; skills are instructions — a skill you add here installs machine-wide for every backend and every project on this machine, and can be deactivated or removed below.</div>
+        <div class="plugins-intro">Optional bundled capabilities and agent skills. Bundled plugins ship no third-party code; skills are instructions — a skill you add here installs machine-wide for every backend and every project on this machine, and can be deactivated or removed below. There are no per-skill settings: a skill is prose, and its whole configuration is whether it is active. A plugin's real knobs are the environment and config its readiness checks name, outside this page; an automation definition takes its configuration at stamp time, through the fields and knobs the Automate sheet renders from what the definition declares.</div>
         <section class="plugins-section">
           <h3 class="ui-section-title">Plugins</h3>
           <div id="plugins-status" class="plugins-status"></div>
@@ -32902,8 +32902,8 @@ html.ui-v2 .daemon-relay-note {
           <div id="skills-list"></div>
         </section>
         <section class="plugins-section">
-          <h3 class="ui-section-title">Automation templates</h3>
-          <div class="plugins-section-sub">Sealed automation definitions. House templates ship in the binary, read-only; a template you add here joins the personal library — and if it takes a house name, your copy shadows the house one until you remove it. Stamping seals the file — firings execute the sealed bytes, and nothing runs until each proposed manifest is approved on its card.</div>
+          <h3 class="ui-section-title">Automation definitions</h3>
+          <div class="plugins-section-sub">SKILL.md files the Automate sheet stamps into automations. House definitions ship in the binary, read-only; a definition you add here joins the personal library — and if it takes a house name, your copy shadows the house one until you remove it. Stamping seals the file — firings execute the sealed bytes, and nothing runs until each proposed manifest is approved on its card.</div>
           <div id="templates-status" class="plugins-status"></div>
           <div id="template-add-slot"></div>
           <div id="templates-list"></div>
@@ -39272,7 +39272,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '90e0758c6f18d0d8';
+const INTENDANT_APP_BUILD = '89f0818a4a3c7497';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -110326,15 +110326,15 @@ window.submitCloudTask = submitCloudTask;
 //      (DELETE /api/skills/{name}, api_skill_remove: library entry
 //      deleted, both roots swept in-request); their attribution
 //      ("Added by …") and recorded sha256 render from the served body.
-//   3. Automation templates — the served definition catalog rendered
+//   3. Automation definitions — the served definition catalog rendered
 //      from the ONE shared derivation: ui2-agenda.js's
 //      agendaDefinitionCatalog lane, the same cache the Automate sheet's
 //      picker reads (this section keeps no second copy, so the two can
 //      never skew). Provenance / shadowed / invalid state, trust-posture
 //      lines, and dashboard-added attribution all render the daemon body
 //      verbatim, with Automate… opening the EXISTING agenda stamp sheet
-//      preselected — no second stamp lane. S5 personal templates: an
-//      availability-gated "Add template" sheet posts pasted or uploaded
+//      preselected — no second stamp lane. S5 personal definitions: an
+//      availability-gated "Add definition" sheet posts pasted or uploaded
 //      definition SKILL.md bytes to POST /api/agenda/definitions
 //      (api_agenda_definition_add) — the daemon validates with the REAL
 //      definition parser (a file the stamp would refuse refuses at add,
@@ -110371,7 +110371,7 @@ let skillAddError = '';      // the daemon's refusal, rendered verbatim
 let templatesAvailability = ''; // read-lane unavailability copy ('' when readable)
 let templatesError = '';        // mutation-lane failures, rendered verbatim
 let templatesNotice = '';       // one-line success note (add/remove)
-let templatesBusy = {};         // template name -> true while a remove runs
+let templatesBusy = {};         // definition name -> true while a remove runs
 let templateAddOpen = false;    // the add sheet is expanded
 let templateAddBusy = false;    // an add request is in flight
 let templateAddError = '';      // the daemon's refusal, rendered verbatim
@@ -110919,7 +110919,7 @@ function renderSkillsSection() {
   });
 }
 
-// ── Automation templates section ───────────────────────────────────────
+// ── Automation definitions section ─────────────────────────────────────
 //
 // ONE derivation: this section reads the SAME module-level catalog the
 // Automate sheet's picker reads (agendaDefinitionCatalog +
@@ -110932,9 +110932,9 @@ function loadTemplatesSection() {
   const avail = daemonApi.availability('api_agenda_definitions');
   if (!avail.ok) {
     templatesAvailability = avail.reason === 'denied'
-      ? "This session's role can't read the automation-template catalog."
+      ? "This session's role can't read the automation-definition catalog."
       : avail.reason === 'unsupported'
-        ? 'This daemon predates the automation-template catalog.'
+        ? 'This daemon predates the automation-definition catalog.'
         : 'Daemon connection not ready yet.';
     renderTemplatesSection();
     return;
@@ -110954,7 +110954,7 @@ function templateRowHtml(d) {
   // the sheet would refuse.
   const chips = [`<span class="ui-chip"${d.trust_posture ? ` title="${escapeHtml(d.trust_posture)}"` : ''}>${escapeHtml(String(d.provenance || ''))}</span>`];
   if (d.shadowed) chips.push('<span class="ui-chip warn">shadowed</span>');
-  if (d.shadows_house) chips.push('<span class="ui-chip" title="A house template of the same name ships in the binary — your copy resolves first">shadows house</span>');
+  if (d.shadows_house) chips.push('<span class="ui-chip" title="A house definition of the same name ships in the binary — your copy resolves first">shadows house</span>');
   if (!d.valid) chips.push('<span class="ui-chip warn">invalid</span>');
   if (d.library && d.library !== 'ok') {
     chips.push(`<span class="ui-chip warn" title="The library file no longer matches the sha256 recorded at add time — the attribution below no longer covers these bytes; remove and re-add to re-attest">library: ${escapeHtml(String(d.library))}</span>`);
@@ -110971,7 +110971,7 @@ function templateRowHtml(d) {
   // hand-placed personal rows never get one.
   const removeAvail = daemonApi.availability('api_agenda_definition_remove');
   const removeBtn = d.removable && removeAvail.ok
-    ? `<button type="button" class="ui-btn template-remove" data-template-remove="${escapeHtml(d.name)}"${busy ? ' disabled' : ''} title="Delete this template from the daemon's personal library${d.shadows_house ? ' (the house template of the same name resolves again)' : ''}">Remove</button>`
+    ? `<button type="button" class="ui-btn template-remove" data-template-remove="${escapeHtml(d.name)}"${busy ? ' disabled' : ''} title="Delete this definition from the daemon's personal library${d.shadows_house ? ' (the house definition of the same name resolves again)' : ''}">Remove</button>`
     : '';
   const kindLine = typeof agendaDefinitionKindLine === 'function' ? agendaDefinitionKindLine(d) : '';
   const desc = d.description
@@ -111003,7 +111003,7 @@ function templateRowHtml(d) {
   </div>`;
 }
 
-// ── S5: the personal-template add sheet (paste / upload only) ──────────
+// ── S5: the personal-definition add sheet (paste / upload only) ────────
 //
 // Rendered into #template-add-slot only when the daemon supports AND
 // this role may call api_agenda_definition_add. Same two inputs as the
@@ -111021,15 +111021,15 @@ function renderTemplateAddSlot() {
     return;
   }
   if (!templateAddOpen) {
-    slot.innerHTML = '<button type="button" class="ui-btn" id="template-add-open">Add template…</button>';
+    slot.innerHTML = '<button type="button" class="ui-btn" id="template-add-open">Add definition…</button>';
     const open = document.getElementById('template-add-open');
     if (open) open.onclick = () => { templateAddOpen = true; templateAddError = ''; renderTemplateAddSlot(); };
     return;
   }
   slot.innerHTML = `<div class="ui-card skill-add-card">
-    <div class="skill-add-head">Add an automation template</div>
-    <div class="skill-add-explainer">Paste a definition SKILL.md (YAML frontmatter with <code>name</code> and <code>description</code>, then one <code>## node: &lt;id&gt;</code> section per node) or upload the file. It joins this daemon's personal library; giving it a house template's name shadows that template until you remove yours. It does nothing until stamped — stamping seals the file and every firing still needs its approved manifest.</div>
-    <label class="skill-add-label">Template name (slug — must equal the frontmatter name)
+    <div class="skill-add-head">Add an automation definition</div>
+    <div class="skill-add-explainer">Paste a definition SKILL.md (YAML frontmatter with <code>name</code> and <code>description</code>, then one <code>## node: &lt;id&gt;</code> section per node) or upload the file. It joins this daemon's personal library; giving it a house definition's name shadows that definition until you remove yours. It does nothing until stamped — stamping seals the file and every firing still needs its approved manifest.</div>
+    <label class="skill-add-label">Definition name (slug — must equal the frontmatter name)
       <input type="text" id="template-add-name" class="skill-add-input" placeholder="my-automation" autocomplete="off" spellcheck="false">
     </label>
     <label class="skill-add-label">Definition SKILL.md
@@ -111039,7 +111039,7 @@ function renderTemplateAddSlot() {
       <label class="ui-btn skill-add-upload">Upload SKILL.md<input type="file" id="template-add-file" accept=".md,text/markdown,text/plain" hidden></label>
       <span class="skill-add-spacer"></span>
       <button type="button" class="ui-btn" id="template-add-cancel">Cancel</button>
-      <button type="button" class="ui-btn primary" id="template-add-submit"${templateAddBusy ? ' disabled' : ''}>${templateAddBusy ? 'Adding…' : 'Add template'}</button>
+      <button type="button" class="ui-btn primary" id="template-add-submit"${templateAddBusy ? ' disabled' : ''}>${templateAddBusy ? 'Adding…' : 'Add definition'}</button>
     </div>
     <div class="skill-add-status${templateAddError ? ' plugins-status-error' : ''}">${escapeHtml(templateAddError)}</div>
   </div>`;
@@ -111081,13 +111081,13 @@ async function templateAddSubmit(name, skillMd) {
   const avail = daemonApi.availability('api_agenda_definition_add');
   if (!avail.ok) {
     templateAddError = avail.reason === 'denied'
-      ? "This session's role can't add templates."
-      : 'Adding templates is unavailable on this daemon.';
+      ? "This session's role can't add definitions."
+      : 'Adding definitions is unavailable on this daemon.';
     renderTemplateAddSlot();
     return;
   }
   if (!name || !skillMd.trim()) {
-    templateAddError = 'Both the template name and the definition SKILL.md are required.';
+    templateAddError = 'Both the definition name and the definition SKILL.md are required.';
     renderTemplateAddSlot();
     return;
   }
@@ -111103,10 +111103,10 @@ async function templateAddSubmit(name, skillMd) {
       templateAddOpen = false;
       templateAddError = '';
       const shadowed = Boolean(resp.body.template && resp.body.template.shadows_house);
-      templatesNotice = `Added '${name}' to the personal library — ready to stamp from the Automate sheet.${shadowed ? ' It shadows the house template of the same name.' : ''}`;
+      templatesNotice = `Added '${name}' to the personal library — ready to stamp from the Automate sheet.${shadowed ? ' It shadows the house definition of the same name.' : ''}`;
       templatesError = '';
     } else {
-      templateAddError = (resp.body && resp.body.error) || `template add failed (${resp.status})`;
+      templateAddError = (resp.body && resp.body.error) || `definition add failed (${resp.status})`;
     }
   } catch (e) {
     templateAddError = String((e && e.message) || e);
@@ -111116,7 +111116,7 @@ async function templateAddSubmit(name, skillMd) {
   renderTemplatesSection();
 }
 
-// Remove one dashboard-added template (the daemon declared the row
+// Remove one dashboard-added definition (the daemon declared the row
 // removable). Refusals (house / hand-placed / unknown) render verbatim;
 // the response's refreshed catalog shows the un-shadowed house twin.
 async function templateRemove(name) {
@@ -111124,19 +111124,19 @@ async function templateRemove(name) {
   const avail = daemonApi.availability('api_agenda_definition_remove');
   if (!avail.ok) {
     templatesError = avail.reason === 'denied'
-      ? "This session's role can't remove templates."
-      : 'Removing templates is unavailable on this daemon.';
+      ? "This session's role can't remove definitions."
+      : 'Removing definitions is unavailable on this daemon.';
     renderTemplatesSection();
     return;
   }
   const row = (agendaDefinitionCatalog || []).find(d => d && d.name === name && d.provenance === 'personal');
   const unshadow = row && row.shadows_house
-    ? ' The house template of the same name resolves again.'
+    ? ' The house definition of the same name resolves again.'
     : '';
-  const message = `Remove '${name}' from the daemon's personal template library? Already-stamped automations keep executing their sealed copies.${unshadow}`;
+  const message = `Remove '${name}' from the daemon's personal library? Already-stamped automations keep executing their sealed copies.${unshadow}`;
   const confirmed = typeof showDashboardConfirm === 'function'
     ? (await showDashboardConfirm({
-        title: 'Remove this template?',
+        title: 'Remove this definition?',
         message,
         confirmLabel: 'Remove',
         cancelLabel: 'Keep it',
@@ -111153,7 +111153,7 @@ async function templateRemove(name) {
       templatesNotice = `Removed '${name}' from the personal library.${unshadow}`;
       templatesError = '';
     } else {
-      templatesError = (resp.body && resp.body.error) || `template remove failed (${resp.status})`;
+      templatesError = (resp.body && resp.body.error) || `definition remove failed (${resp.status})`;
     }
   } catch (e) {
     templatesError = String((e && e.message) || e);
@@ -111176,11 +111176,11 @@ function renderTemplatesSection() {
   if (!list) return;
   const rows = agendaDefinitionCatalog;
   if (!rows && !error) {
-    list.innerHTML = '<div class="ui-explainer">Loading template catalog…</div>';
+    list.innerHTML = '<div class="ui-explainer">Loading definition catalog…</div>';
     return;
   }
   if (!rows || !rows.length) {
-    list.innerHTML = error ? '' : '<div class="ui-empty"><div class="ui-empty-title">No automation templates</div><div class="ui-empty-hint">This daemon serves no definitions.</div></div>';
+    list.innerHTML = error ? '' : '<div class="ui-empty"><div class="ui-empty-title">No automation definitions</div><div class="ui-empty-hint">This daemon serves no definitions.</div></div>';
     return;
   }
   list.innerHTML = rows.map(templateRowHtml).join('');

--- a/static/app/20-shell.html
+++ b/static/app/20-shell.html
@@ -86,10 +86,10 @@
          and the manifest TDZ rule key on it; only the visible label moved
          to "Plugins & Skills"). Three daemon-derived sections: bundled
          plugins (/api/plugins), the unified skill catalog (/api/skills),
-         and the automation-template catalog (/api/agenda/definitions). -->
+         and the automation-definition catalog (/api/agenda/definitions). -->
     <div id="tab-plugins" class="tab-pane">
       <div class="plugins-wrap">
-        <div class="plugins-intro">Optional bundled capabilities and agent skills. Bundled plugins ship no third-party code; skills are instructions — a skill you add here installs machine-wide for every backend and every project on this machine, and can be deactivated or removed below.</div>
+        <div class="plugins-intro">Optional bundled capabilities and agent skills. Bundled plugins ship no third-party code; skills are instructions — a skill you add here installs machine-wide for every backend and every project on this machine, and can be deactivated or removed below. There are no per-skill settings: a skill is prose, and its whole configuration is whether it is active. A plugin's real knobs are the environment and config its readiness checks name, outside this page; an automation definition takes its configuration at stamp time, through the fields and knobs the Automate sheet renders from what the definition declares.</div>
         <section class="plugins-section">
           <h3 class="ui-section-title">Plugins</h3>
           <div id="plugins-status" class="plugins-status"></div>
@@ -103,8 +103,8 @@
           <div id="skills-list"></div>
         </section>
         <section class="plugins-section">
-          <h3 class="ui-section-title">Automation templates</h3>
-          <div class="plugins-section-sub">Sealed automation definitions. House templates ship in the binary, read-only; a template you add here joins the personal library — and if it takes a house name, your copy shadows the house one until you remove it. Stamping seals the file — firings execute the sealed bytes, and nothing runs until each proposed manifest is approved on its card.</div>
+          <h3 class="ui-section-title">Automation definitions</h3>
+          <div class="plugins-section-sub">SKILL.md files the Automate sheet stamps into automations. House definitions ship in the binary, read-only; a definition you add here joins the personal library — and if it takes a house name, your copy shadows the house one until you remove it. Stamping seals the file — firings execute the sealed bytes, and nothing runs until each proposed manifest is approved on its card.</div>
           <div id="templates-status" class="plugins-status"></div>
           <div id="template-add-slot"></div>
           <div id="templates-list"></div>

--- a/static/app/ui2-plugins.css
+++ b/static/app/ui2-plugins.css
@@ -1,6 +1,6 @@
 /* Plugins & Skills tab (System; pane id #tab-plugins is permanent): the
    bundled-plugin catalog plus the unified skill catalog and the
-   automation-template catalog. Cards and rows are host-owned; every
+   automation-definition catalog. Cards and rows are host-owned; every
    state/readiness/install fact derives from the daemon bodies. Styles
    reuse the shared ui-* components (.ui-card, .ui-btn, .ui-chip,
    .ui-empty, .ui-explainer) and the v2 token palette. */
@@ -51,7 +51,7 @@ html.ui-v2 .plugin-skill-row {
 
 html.ui-v2 .plugin-install-note { font-size: 12.5px; color: var(--text-3); }
 
-/* ── Sections (Plugins / Skills / Automation templates) ─────────────── */
+/* ── Sections (Plugins / Skills / Automation definitions) ───────────── */
 
 html.ui-v2 .plugins-section { display: flex; flex-direction: column; gap: 10px; }
 html.ui-v2 .plugins-section .ui-section-title { margin: 6px 0 0; }

--- a/static/app/ui2-plugins.js
+++ b/static/app/ui2-plugins.js
@@ -33,15 +33,15 @@
 //      (DELETE /api/skills/{name}, api_skill_remove: library entry
 //      deleted, both roots swept in-request); their attribution
 //      ("Added by …") and recorded sha256 render from the served body.
-//   3. Automation templates — the served definition catalog rendered
+//   3. Automation definitions — the served definition catalog rendered
 //      from the ONE shared derivation: ui2-agenda.js's
 //      agendaDefinitionCatalog lane, the same cache the Automate sheet's
 //      picker reads (this section keeps no second copy, so the two can
 //      never skew). Provenance / shadowed / invalid state, trust-posture
 //      lines, and dashboard-added attribution all render the daemon body
 //      verbatim, with Automate… opening the EXISTING agenda stamp sheet
-//      preselected — no second stamp lane. S5 personal templates: an
-//      availability-gated "Add template" sheet posts pasted or uploaded
+//      preselected — no second stamp lane. S5 personal definitions: an
+//      availability-gated "Add definition" sheet posts pasted or uploaded
 //      definition SKILL.md bytes to POST /api/agenda/definitions
 //      (api_agenda_definition_add) — the daemon validates with the REAL
 //      definition parser (a file the stamp would refuse refuses at add,
@@ -78,7 +78,7 @@ let skillAddError = '';      // the daemon's refusal, rendered verbatim
 let templatesAvailability = ''; // read-lane unavailability copy ('' when readable)
 let templatesError = '';        // mutation-lane failures, rendered verbatim
 let templatesNotice = '';       // one-line success note (add/remove)
-let templatesBusy = {};         // template name -> true while a remove runs
+let templatesBusy = {};         // definition name -> true while a remove runs
 let templateAddOpen = false;    // the add sheet is expanded
 let templateAddBusy = false;    // an add request is in flight
 let templateAddError = '';      // the daemon's refusal, rendered verbatim
@@ -626,7 +626,7 @@ function renderSkillsSection() {
   });
 }
 
-// ── Automation templates section ───────────────────────────────────────
+// ── Automation definitions section ─────────────────────────────────────
 //
 // ONE derivation: this section reads the SAME module-level catalog the
 // Automate sheet's picker reads (agendaDefinitionCatalog +
@@ -639,9 +639,9 @@ function loadTemplatesSection() {
   const avail = daemonApi.availability('api_agenda_definitions');
   if (!avail.ok) {
     templatesAvailability = avail.reason === 'denied'
-      ? "This session's role can't read the automation-template catalog."
+      ? "This session's role can't read the automation-definition catalog."
       : avail.reason === 'unsupported'
-        ? 'This daemon predates the automation-template catalog.'
+        ? 'This daemon predates the automation-definition catalog.'
         : 'Daemon connection not ready yet.';
     renderTemplatesSection();
     return;
@@ -661,7 +661,7 @@ function templateRowHtml(d) {
   // the sheet would refuse.
   const chips = [`<span class="ui-chip"${d.trust_posture ? ` title="${escapeHtml(d.trust_posture)}"` : ''}>${escapeHtml(String(d.provenance || ''))}</span>`];
   if (d.shadowed) chips.push('<span class="ui-chip warn">shadowed</span>');
-  if (d.shadows_house) chips.push('<span class="ui-chip" title="A house template of the same name ships in the binary — your copy resolves first">shadows house</span>');
+  if (d.shadows_house) chips.push('<span class="ui-chip" title="A house definition of the same name ships in the binary — your copy resolves first">shadows house</span>');
   if (!d.valid) chips.push('<span class="ui-chip warn">invalid</span>');
   if (d.library && d.library !== 'ok') {
     chips.push(`<span class="ui-chip warn" title="The library file no longer matches the sha256 recorded at add time — the attribution below no longer covers these bytes; remove and re-add to re-attest">library: ${escapeHtml(String(d.library))}</span>`);
@@ -678,7 +678,7 @@ function templateRowHtml(d) {
   // hand-placed personal rows never get one.
   const removeAvail = daemonApi.availability('api_agenda_definition_remove');
   const removeBtn = d.removable && removeAvail.ok
-    ? `<button type="button" class="ui-btn template-remove" data-template-remove="${escapeHtml(d.name)}"${busy ? ' disabled' : ''} title="Delete this template from the daemon's personal library${d.shadows_house ? ' (the house template of the same name resolves again)' : ''}">Remove</button>`
+    ? `<button type="button" class="ui-btn template-remove" data-template-remove="${escapeHtml(d.name)}"${busy ? ' disabled' : ''} title="Delete this definition from the daemon's personal library${d.shadows_house ? ' (the house definition of the same name resolves again)' : ''}">Remove</button>`
     : '';
   const kindLine = typeof agendaDefinitionKindLine === 'function' ? agendaDefinitionKindLine(d) : '';
   const desc = d.description
@@ -710,7 +710,7 @@ function templateRowHtml(d) {
   </div>`;
 }
 
-// ── S5: the personal-template add sheet (paste / upload only) ──────────
+// ── S5: the personal-definition add sheet (paste / upload only) ────────
 //
 // Rendered into #template-add-slot only when the daemon supports AND
 // this role may call api_agenda_definition_add. Same two inputs as the
@@ -728,15 +728,15 @@ function renderTemplateAddSlot() {
     return;
   }
   if (!templateAddOpen) {
-    slot.innerHTML = '<button type="button" class="ui-btn" id="template-add-open">Add template…</button>';
+    slot.innerHTML = '<button type="button" class="ui-btn" id="template-add-open">Add definition…</button>';
     const open = document.getElementById('template-add-open');
     if (open) open.onclick = () => { templateAddOpen = true; templateAddError = ''; renderTemplateAddSlot(); };
     return;
   }
   slot.innerHTML = `<div class="ui-card skill-add-card">
-    <div class="skill-add-head">Add an automation template</div>
-    <div class="skill-add-explainer">Paste a definition SKILL.md (YAML frontmatter with <code>name</code> and <code>description</code>, then one <code>## node: &lt;id&gt;</code> section per node) or upload the file. It joins this daemon's personal library; giving it a house template's name shadows that template until you remove yours. It does nothing until stamped — stamping seals the file and every firing still needs its approved manifest.</div>
-    <label class="skill-add-label">Template name (slug — must equal the frontmatter name)
+    <div class="skill-add-head">Add an automation definition</div>
+    <div class="skill-add-explainer">Paste a definition SKILL.md (YAML frontmatter with <code>name</code> and <code>description</code>, then one <code>## node: &lt;id&gt;</code> section per node) or upload the file. It joins this daemon's personal library; giving it a house definition's name shadows that definition until you remove yours. It does nothing until stamped — stamping seals the file and every firing still needs its approved manifest.</div>
+    <label class="skill-add-label">Definition name (slug — must equal the frontmatter name)
       <input type="text" id="template-add-name" class="skill-add-input" placeholder="my-automation" autocomplete="off" spellcheck="false">
     </label>
     <label class="skill-add-label">Definition SKILL.md
@@ -746,7 +746,7 @@ function renderTemplateAddSlot() {
       <label class="ui-btn skill-add-upload">Upload SKILL.md<input type="file" id="template-add-file" accept=".md,text/markdown,text/plain" hidden></label>
       <span class="skill-add-spacer"></span>
       <button type="button" class="ui-btn" id="template-add-cancel">Cancel</button>
-      <button type="button" class="ui-btn primary" id="template-add-submit"${templateAddBusy ? ' disabled' : ''}>${templateAddBusy ? 'Adding…' : 'Add template'}</button>
+      <button type="button" class="ui-btn primary" id="template-add-submit"${templateAddBusy ? ' disabled' : ''}>${templateAddBusy ? 'Adding…' : 'Add definition'}</button>
     </div>
     <div class="skill-add-status${templateAddError ? ' plugins-status-error' : ''}">${escapeHtml(templateAddError)}</div>
   </div>`;
@@ -788,13 +788,13 @@ async function templateAddSubmit(name, skillMd) {
   const avail = daemonApi.availability('api_agenda_definition_add');
   if (!avail.ok) {
     templateAddError = avail.reason === 'denied'
-      ? "This session's role can't add templates."
-      : 'Adding templates is unavailable on this daemon.';
+      ? "This session's role can't add definitions."
+      : 'Adding definitions is unavailable on this daemon.';
     renderTemplateAddSlot();
     return;
   }
   if (!name || !skillMd.trim()) {
-    templateAddError = 'Both the template name and the definition SKILL.md are required.';
+    templateAddError = 'Both the definition name and the definition SKILL.md are required.';
     renderTemplateAddSlot();
     return;
   }
@@ -810,10 +810,10 @@ async function templateAddSubmit(name, skillMd) {
       templateAddOpen = false;
       templateAddError = '';
       const shadowed = Boolean(resp.body.template && resp.body.template.shadows_house);
-      templatesNotice = `Added '${name}' to the personal library — ready to stamp from the Automate sheet.${shadowed ? ' It shadows the house template of the same name.' : ''}`;
+      templatesNotice = `Added '${name}' to the personal library — ready to stamp from the Automate sheet.${shadowed ? ' It shadows the house definition of the same name.' : ''}`;
       templatesError = '';
     } else {
-      templateAddError = (resp.body && resp.body.error) || `template add failed (${resp.status})`;
+      templateAddError = (resp.body && resp.body.error) || `definition add failed (${resp.status})`;
     }
   } catch (e) {
     templateAddError = String((e && e.message) || e);
@@ -823,7 +823,7 @@ async function templateAddSubmit(name, skillMd) {
   renderTemplatesSection();
 }
 
-// Remove one dashboard-added template (the daemon declared the row
+// Remove one dashboard-added definition (the daemon declared the row
 // removable). Refusals (house / hand-placed / unknown) render verbatim;
 // the response's refreshed catalog shows the un-shadowed house twin.
 async function templateRemove(name) {
@@ -831,19 +831,19 @@ async function templateRemove(name) {
   const avail = daemonApi.availability('api_agenda_definition_remove');
   if (!avail.ok) {
     templatesError = avail.reason === 'denied'
-      ? "This session's role can't remove templates."
-      : 'Removing templates is unavailable on this daemon.';
+      ? "This session's role can't remove definitions."
+      : 'Removing definitions is unavailable on this daemon.';
     renderTemplatesSection();
     return;
   }
   const row = (agendaDefinitionCatalog || []).find(d => d && d.name === name && d.provenance === 'personal');
   const unshadow = row && row.shadows_house
-    ? ' The house template of the same name resolves again.'
+    ? ' The house definition of the same name resolves again.'
     : '';
-  const message = `Remove '${name}' from the daemon's personal template library? Already-stamped automations keep executing their sealed copies.${unshadow}`;
+  const message = `Remove '${name}' from the daemon's personal library? Already-stamped automations keep executing their sealed copies.${unshadow}`;
   const confirmed = typeof showDashboardConfirm === 'function'
     ? (await showDashboardConfirm({
-        title: 'Remove this template?',
+        title: 'Remove this definition?',
         message,
         confirmLabel: 'Remove',
         cancelLabel: 'Keep it',
@@ -860,7 +860,7 @@ async function templateRemove(name) {
       templatesNotice = `Removed '${name}' from the personal library.${unshadow}`;
       templatesError = '';
     } else {
-      templatesError = (resp.body && resp.body.error) || `template remove failed (${resp.status})`;
+      templatesError = (resp.body && resp.body.error) || `definition remove failed (${resp.status})`;
     }
   } catch (e) {
     templatesError = String((e && e.message) || e);
@@ -883,11 +883,11 @@ function renderTemplatesSection() {
   if (!list) return;
   const rows = agendaDefinitionCatalog;
   if (!rows && !error) {
-    list.innerHTML = '<div class="ui-explainer">Loading template catalog…</div>';
+    list.innerHTML = '<div class="ui-explainer">Loading definition catalog…</div>';
     return;
   }
   if (!rows || !rows.length) {
-    list.innerHTML = error ? '' : '<div class="ui-empty"><div class="ui-empty-title">No automation templates</div><div class="ui-empty-hint">This daemon serves no definitions.</div></div>';
+    list.innerHTML = error ? '' : '<div class="ui-empty"><div class="ui-empty-title">No automation definitions</div><div class="ui-empty-hint">This daemon serves no definitions.</div></div>';
     return;
   }
   list.innerHTML = rows.map(templateRowHtml).join('');


### PR DESCRIPTION
Closes the unification (S1 #805, S2 #807, S3 #816, S4 #819, S5 #824)
with the docs and copy reconciliation:

- web-dashboard: the Plugins & Skills tab described as landed — the
  unified three-section surface, per-skill deactivate/re-enable, the
  user skill library (paste/upload, sha-sealed), personal definition
  add/remove, and the Automate sheet's declared-parameter fields; nav
  label updated; endpoint-table rows follow the route descriptions.
- agenda-and-memory: the definitions chapter's surfaces gain the S5
  add/remove routes and the dashboard-added personal provenance; the
  steward-gate section speaks the ratified word.
- One visible word for definition files (the S1 gate's named residue):
  the tab section, add sheet, notices, served trust-posture lines, and
  daemon refusals all say 'definition'; 'template' survives only in
  wire and internal names (the templates registry family, DOM ids,
  route/tunnel ids, module names).
- narrative-backfill cap hint teaches 'Amount only — the $ is already
  in the line' (the S2 gate's named residue N2); the catalog pin is
  co-updated.
- Pane copy: the per-skill-configuration honesty paragraph (intake
  section 2d) lands in the Plugins & Skills intro — a skill is prose,
  plugin knobs live outside the dashboard, definitions configure at
  stamp time.
- skills-internal/README: the tier table gains the user-library tier
  and the builtin row reflects the persisted disabled-set.
- CLAUDE.md/AGENTS.md: plugins line reflects dashboard manageability;
  automations/ line added (byte-parity cp same commit).
