### PR TITLE
capacity: corroborated macOS warn-defer, honest stage reasons, staging knob

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -347,16 +347,22 @@ honest named positions (forks, delegation-tagged scheduled fires, and
 sub-agent spawns refuse with the bound named; their retry custody stays
 with the caller) and fire when headroom returns; under the **park**
 stage the longest-idle root sessions additionally carry a visible
-parked chip — a census, never a kill. The current view rides
-`get_status` (`capacity`) and the dashboard's oversight-bar chip.
-Fail-open: a missing or failing probe reads as "no signal" (staging
-idles; the count bound still applies), and disabling the section is
-exactly pre-slice behavior.
+parked chip — a census, never a kill. On macOS, pressure-**warn** alone
+never stages — warn is a chronic state on healthy-busy Macs; it defers
+only when corroborated by elevated compressor occupancy or low
+available memory, while **critical** parks on its own. The current view
+rides `get_status` (`capacity`) and the dashboard's oversight-bar chip,
+and carries honest `reasons` strings naming the firing signal(s) — the
+same strings capacity refusals and queue notices quote. Fail-open: a
+missing or failing probe reads as "no signal" (staging idles; the count
+bound still applies), and disabling the section is exactly pre-slice
+behavior.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `enabled` | bool | `true` | `false` disables the capacity controller entirely: no probe, no staging, no admission bound |
 | `max_resident_sessions` | int | derived | Resident-session bound. Default derives one session per GiB of physical memory, clamped 8..=64 (32 when memory size is unreadable). `INTENDANT_CAPACITY_MAX_RESIDENT` overrides the derivation (not this key) |
+| `staging` | string | `"normal"` | Staging aggressiveness — one coarse knob: `normal` (defer and park per the watermarks), `defer-only` (pressure signals cap at defer — admissions queue, nothing parks), `off` (pressure staging disabled; the resident-session bound still gates). Unrecognized values read as `normal`. `INTENDANT_CAPACITY_STAGING` fills in when this key is unset |
 
 ### `[readopt]`
 

--- a/src/bin/caller/capacity.rs
+++ b/src/bin/caller/capacity.rs
@@ -999,7 +999,10 @@ mod tests {
         assert_eq!(resolve_staging(None, Some("off")), StagingMode::Off);
         assert_eq!(resolve_staging(Some("nope"), Some("off")), StagingMode::Off);
         // Garbage everywhere reads as the default.
-        assert_eq!(resolve_staging(Some("nope"), Some("also-nope")), StagingMode::Normal);
+        assert_eq!(
+            resolve_staging(Some("nope"), Some("also-nope")),
+            StagingMode::Normal
+        );
         assert_eq!(resolve_staging(None, Some("")), StagingMode::Normal);
     }
 

--- a/src/bin/caller/capacity.rs
+++ b/src/bin/caller/capacity.rs
@@ -69,10 +69,17 @@ const VIEW_QUEUE_ROWS_CAP: usize = 16;
 // strictly tighter than defer thresholds per signal (the staging-order
 // invariant, pinned by test below).
 //
-// macOS: the kernel pressure level alone under-fires (it never reached
-// critical during the freeze) — the compressor fraction is the loud
-// magnitude signal (1.4 GiB healthy-busy → 5.3–6.6 GiB of a 16 GiB guest
-// collapsing). "Available" reads healthy on a thrashing Mac (reclaimable
+// macOS: the kernel pressure level alone under-fires at the top (it
+// never reached critical during the 07-29 freeze) and over-fires at the
+// bottom (warn is a chronic state on healthy-busy Macs — a perfectly
+// workable 24 GB box sat in warn while admissions refused on it,
+// 2026-08-11). The compressor fraction is the loud magnitude signal
+// (1.4 GiB healthy-busy → 5.3–6.6 GiB of a 16 GiB guest collapsing). So
+// pressure-warn NEVER stages alone: it defers only when corroborated by
+// a second signal ([`macos_warn_corroboration`]) — the compressor past
+// [`MACOS_WARN_COMPRESSOR_CORROBORATION`], or the available fraction
+// already under its own defer watermark — while critical still parks on
+// its own. "Available" reads healthy on a thrashing Mac (reclaimable
 // file pages), so the available fraction is a universal backstop only.
 const AVAILABLE_FRAC_DEFER: f64 = 0.10;
 const AVAILABLE_FRAC_PARK: f64 = 0.05;
@@ -80,6 +87,15 @@ const MACOS_PRESSURE_DEFER: u32 = 2; // memorystatus warn
 const MACOS_PRESSURE_PARK: u32 = 4; // memorystatus critical
 const COMPRESSOR_FRAC_DEFER: f64 = 0.25;
 const COMPRESSOR_FRAC_PARK: f64 = 0.35;
+/// Corroboration floor for macOS pressure-warn: warn alone is routine on
+/// a healthy-busy Mac, so it only defers when the compressor — the 07-29
+/// freeze's loud discriminator (~9% of RAM healthy-busy vs 33–41%
+/// collapsing) — is already elevated past this floor. 0.15 sits well
+/// above the healthy-busy compressor band and well under
+/// [`COMPRESSOR_FRAC_DEFER`]: warn plus a swelling-but-not-yet-loud
+/// compressor is the earliest honest two-signal distress, without letting
+/// chronic warn re-become a solo trigger.
+const MACOS_WARN_COMPRESSOR_CORROBORATION: f64 = 0.15;
 const PSI_SOME_AVG10_DEFER: f64 = 10.0;
 const PSI_SOME_AVG10_PARK: f64 = 40.0; // the fleet watchdog's pause line
 const PSI_FULL_AVG10_PARK: f64 = 5.0;
@@ -105,57 +121,162 @@ impl CapacityStage {
     }
 }
 
-/// Raw (pre-hysteresis) stage for one sample: the worst stage any present
-/// signal calls for. Absent signals contribute nothing — policy applies
-/// only to what the host actually reports.
-pub(crate) fn raw_stage(sample: &MemorySample) -> CapacityStage {
+/// The second signal that lets a macOS pressure-warn reading stage at
+/// all: the compressor already past the corroboration floor (named with
+/// its reading), or the available fraction already under its own defer
+/// watermark. `None` = uncorroborated — warn alone stays [`CapacityStage::Normal`].
+fn macos_warn_corroboration(sample: &MemorySample) -> Option<String> {
+    if let Some(frac) = sample.compressor_frac {
+        if frac >= MACOS_WARN_COMPRESSOR_CORROBORATION {
+            return Some(format!("compressor {:.0}%", frac * 100.0));
+        }
+    }
+    if let Some(frac) = sample.available_frac() {
+        if frac < AVAILABLE_FRAC_DEFER {
+            return Some(format!("available {:.0}%", frac * 100.0));
+        }
+    }
+    None
+}
+
+/// Raw (pre-hysteresis) stage for one sample, plus the honest
+/// human-readable list of the signal(s) firing — one entry per firing
+/// signal, each naming its reading. Policy and its explanation are one
+/// pass over the sample so they cannot drift apart. Absent signals
+/// contribute nothing — policy applies only to what the host actually
+/// reports; a signal below every watermark contributes no reason.
+pub(crate) fn stage_and_reasons(sample: &MemorySample) -> (CapacityStage, Vec<String>) {
     let mut stage = CapacityStage::Normal;
-    let mut worsen = |to: CapacityStage| {
+    let mut reasons: Vec<String> = Vec::new();
+    let mut fire = |to: CapacityStage, reason: String| {
         if to > stage {
             stage = to;
         }
+        reasons.push(reason);
     };
     if let Some(frac) = sample.available_frac() {
         if frac < AVAILABLE_FRAC_PARK {
-            worsen(CapacityStage::Park);
+            fire(
+                CapacityStage::Park,
+                format!("available memory {:.0}%", frac * 100.0),
+            );
         } else if frac < AVAILABLE_FRAC_DEFER {
-            worsen(CapacityStage::Defer);
+            fire(
+                CapacityStage::Defer,
+                format!("available memory {:.0}%", frac * 100.0),
+            );
         }
     }
     if let Some(level) = sample.os_pressure_level {
         if level >= MACOS_PRESSURE_PARK {
-            worsen(CapacityStage::Park);
+            fire(CapacityStage::Park, "memory pressure critical".to_string());
         } else if level >= MACOS_PRESSURE_DEFER {
-            worsen(CapacityStage::Defer);
+            // Warn alone never stages (chronic on healthy-busy Macs) —
+            // only the corroborated pair defers.
+            if let Some(corroboration) = macos_warn_corroboration(sample) {
+                fire(
+                    CapacityStage::Defer,
+                    format!("memory pressure warn + {corroboration}"),
+                );
+            }
         }
     }
     if let Some(frac) = sample.compressor_frac {
         if frac >= COMPRESSOR_FRAC_PARK {
-            worsen(CapacityStage::Park);
+            fire(
+                CapacityStage::Park,
+                format!("compressor {:.0}% of RAM", frac * 100.0),
+            );
         } else if frac >= COMPRESSOR_FRAC_DEFER {
-            worsen(CapacityStage::Defer);
+            fire(
+                CapacityStage::Defer,
+                format!("compressor {:.0}% of RAM", frac * 100.0),
+            );
         }
     }
     if let Some(some) = sample.psi_some_avg10 {
         if some >= PSI_SOME_AVG10_PARK {
-            worsen(CapacityStage::Park);
+            fire(
+                CapacityStage::Park,
+                format!("memory stall {some:.0}% (PSI some)"),
+            );
         } else if some >= PSI_SOME_AVG10_DEFER {
-            worsen(CapacityStage::Defer);
+            fire(
+                CapacityStage::Defer,
+                format!("memory stall {some:.0}% (PSI some)"),
+            );
         }
     }
     if let Some(full) = sample.psi_full_avg10 {
         if full >= PSI_FULL_AVG10_PARK {
-            worsen(CapacityStage::Park);
+            fire(
+                CapacityStage::Park,
+                format!("full memory stall {full:.0}% (PSI full)"),
+            );
         }
     }
     if let Some(load) = sample.load_percent {
         if load >= WINDOWS_LOAD_PARK {
-            worsen(CapacityStage::Park);
+            fire(CapacityStage::Park, format!("memory load {load}%"));
         } else if load >= WINDOWS_LOAD_DEFER {
-            worsen(CapacityStage::Defer);
+            fire(CapacityStage::Defer, format!("memory load {load}%"));
         }
     }
-    stage
+    (stage, reasons)
+}
+
+/// Raw stage only (the historical name; the staging-order pin and the
+/// truth-table tests key on it). Same single pass as
+/// [`stage_and_reasons`], which is what production consumes.
+#[cfg(test)]
+pub(crate) fn raw_stage(sample: &MemorySample) -> CapacityStage {
+    stage_and_reasons(sample).0
+}
+
+/// Owner knob for staging aggressiveness (`[capacity] staging` /
+/// `INTENDANT_CAPACITY_STAGING`): one coarse ceiling on what the
+/// pressure signals may stage — deliberately not per-threshold tuning.
+/// The resident-session bound, the census, and the view stay in force in
+/// every mode; `[capacity] enabled = false` remains the full off switch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum StagingMode {
+    /// Full staging: defer and park per the watermarks (the default).
+    #[default]
+    Normal,
+    /// Pressure signals cap at defer: admissions queue, nothing parks.
+    DeferOnly,
+    /// Pressure staging off: only the resident-session bound gates.
+    Off,
+}
+
+impl StagingMode {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            StagingMode::Normal => "normal",
+            StagingMode::DeferOnly => "defer-only",
+            StagingMode::Off => "off",
+        }
+    }
+}
+
+/// Resolve the staging mode: explicit config key, then the
+/// `INTENDANT_CAPACITY_STAGING` env override (the resolver is pure over
+/// the values, like [`resolve_max_resident`]; the edge reads the
+/// environment once), then the default. Unrecognized values fall through
+/// toward the default — a typo must never brick or blind the daemon.
+pub(crate) fn resolve_staging(config: Option<&str>, env: Option<&str>) -> StagingMode {
+    fn parse(value: &str) -> Option<StagingMode> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "normal" => Some(StagingMode::Normal),
+            "defer-only" | "defer_only" => Some(StagingMode::DeferOnly),
+            "off" => Some(StagingMode::Off),
+            _ => None,
+        }
+    }
+    config
+        .and_then(parse)
+        .or_else(|| env.and_then(parse))
+        .unwrap_or_default()
 }
 
 /// Stage hysteresis: worsening applies immediately; easing requires the
@@ -249,6 +370,17 @@ pub struct CapacityQueueRow {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CapacityView {
     pub stage: CapacityStage,
+    /// The honest, human-readable signal(s) behind the stage, derived at
+    /// sample time (e.g. `"memory pressure warn + compressor 18%"`).
+    /// Empty at a quiet normal; carries the easing note while the dwell
+    /// holds a stage past its signals. Frontends render these strings —
+    /// no client-side threshold knowledge.
+    #[serde(default)]
+    pub reasons: Vec<String>,
+    /// The staging mode in force (`normal` / `defer-only` / `off`) — so
+    /// a capped or disabled staging is diagnosable from the view.
+    #[serde(default = "default_view_staging")]
+    pub staging: String,
     /// False when the platform probe is unavailable or failing — rendered
     /// honestly (the stage then stays `normal` by fail-open, not by
     /// measurement).
@@ -282,6 +414,10 @@ impl CapacityView {
     }
 }
 
+fn default_view_staging() -> String {
+    StagingMode::Normal.as_str().to_string()
+}
+
 /// Outcome of an admission check at the gate.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum AdmissionCheck {
@@ -289,6 +425,9 @@ pub(crate) enum AdmissionCheck {
     /// Admissions are deferred; the caller queues or refuses per lane.
     Gate {
         stage: CapacityStage,
+        /// The view's signal reasons at the gate, for refusals that say
+        /// why (empty when only the count bound gates).
+        reasons: Vec<String>,
         bound: usize,
         resident: usize,
         queued: usize,
@@ -302,6 +441,7 @@ pub(crate) enum AdmissionCheck {
 /// absence is complete fail-open to pre-slice behavior.
 pub(crate) struct CapacityController {
     inner: std::sync::Mutex<Inner>,
+    staging: StagingMode,
 }
 
 struct Inner {
@@ -310,9 +450,18 @@ struct Inner {
 }
 
 impl CapacityController {
+    /// Test convenience: the default staging mode. Production construction
+    /// goes through [`controller_from_config`], which resolves the mode.
+    #[cfg(test)]
     pub(crate) fn new(max_resident: usize) -> Arc<Self> {
+        Self::with_staging(max_resident, StagingMode::Normal)
+    }
+
+    pub(crate) fn with_staging(max_resident: usize, staging: StagingMode) -> Arc<Self> {
         let view = CapacityView {
             stage: CapacityStage::Normal,
+            reasons: Vec::new(),
+            staging: staging.as_str().to_string(),
             probe_ok: false,
             bound: max_resident.max(1),
             resident: 0,
@@ -329,6 +478,7 @@ impl CapacityController {
                 tracker: StageTracker::default(),
                 view,
             }),
+            staging,
         })
     }
 
@@ -346,29 +496,45 @@ impl CapacityController {
     ) -> Option<CapacityView> {
         let mut inner = self.inner.lock().expect("capacity lock");
         let previous = inner.view.clone();
-        match sample {
-            Some(sample) => {
-                let stage = inner.tracker.observe(raw_stage(&sample), now);
-                if stage != inner.view.stage {
-                    inner.view.stage_since_ms = epoch_ms();
+        // Fail-open on a missing sample: no signal is not distress. The
+        // stage decays to normal through the same dwell (a mid-pressure
+        // probe outage releases backpressure rather than pinning it).
+        let (mut raw, mut reasons) = match &sample {
+            Some(sample) => stage_and_reasons(sample),
+            None => (CapacityStage::Normal, Vec::new()),
+        };
+        // The owner's staging ceiling caps what the signals may stage;
+        // the readings themselves stay honestly listed.
+        match self.staging {
+            StagingMode::Normal => {}
+            StagingMode::DeferOnly => {
+                if raw > CapacityStage::Defer {
+                    raw = CapacityStage::Defer;
+                    reasons.push("park capped at defer (staging = \"defer-only\")".to_string());
                 }
-                inner.view.stage = stage;
-                inner.view.probe_ok = true;
-                inner.view.sample = Some(sample);
             }
-            None => {
-                // Fail-open: no signal is not distress. The stage decays
-                // to normal through the same dwell (a mid-pressure probe
-                // outage releases backpressure rather than pinning it).
-                let stage = inner.tracker.observe(CapacityStage::Normal, now);
-                if stage != inner.view.stage {
-                    inner.view.stage_since_ms = epoch_ms();
-                }
-                inner.view.stage = stage;
-                inner.view.probe_ok = false;
-                inner.view.sample = None;
+            StagingMode::Off => {
+                raw = CapacityStage::Normal;
+                reasons.clear();
             }
         }
+        let stage = inner.tracker.observe(raw, now);
+        if stage > raw {
+            // The dwell is holding a stage its signals no longer call
+            // for — say so instead of showing a stage with no reason.
+            reasons.push(format!(
+                "easing — {} releases after {}s of sustained lower readings",
+                stage.as_str(),
+                EASE_DWELL.as_secs()
+            ));
+        }
+        if stage != inner.view.stage {
+            inner.view.stage_since_ms = epoch_ms();
+        }
+        inner.view.stage = stage;
+        inner.view.reasons = reasons;
+        inner.view.probe_ok = sample.is_some();
+        inner.view.sample = sample;
         inner.view.recompute_derived();
         (inner.view != previous).then(|| inner.view.clone())
     }
@@ -401,6 +567,7 @@ impl CapacityController {
         if stage >= CapacityStage::Defer || resident_now >= bound {
             AdmissionCheck::Gate {
                 stage,
+                reasons: inner.view.reasons.clone(),
                 bound,
                 resident: resident_now,
                 queued: inner.view.queued,
@@ -422,50 +589,66 @@ pub(crate) fn controller_from_config(
         return None;
     }
     let env = std::env::var("INTENDANT_CAPACITY_MAX_RESIDENT").ok();
+    let staging_env = std::env::var("INTENDANT_CAPACITY_STAGING").ok();
     let total = intendant_platform::memory::sample_memory().map(|s| s.total_bytes);
-    Some(CapacityController::new(resolve_max_resident(
-        config.max_resident_sessions,
-        env.as_deref(),
-        total,
-    )))
+    Some(CapacityController::with_staging(
+        resolve_max_resident(config.max_resident_sessions, env.as_deref(), total),
+        resolve_staging(config.staging.as_deref(), staging_env.as_deref()),
+    ))
 }
 
 /// Stable machine-checkable prefix for capacity refusals (surfaces and
 /// tests key on it, like `daemon_draining:`).
 pub(crate) const CAPACITY_REFUSAL_PREFIX: &str = "capacity_deferred:";
 
+/// Parenthetical rendering of the firing signals for refusal/queue copy:
+/// empty stays empty (count-bound gating at a quiet normal has nothing
+/// to name beyond the bound itself, which the copy already names).
+fn reasons_parenthetical(reasons: &[String]) -> String {
+    if reasons.is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", reasons.join(", "))
+    }
+}
+
 /// The honest refusal for a lane that cannot queue: names what is
-/// refused, the stage, the bound and count, and the queue depth.
+/// refused, the stage and the signal(s) behind it, the bound and count,
+/// and the queue depth.
 pub(crate) fn refusal_text(
     what: &str,
     stage: CapacityStage,
+    reasons: &[String],
     resident: usize,
     bound: usize,
     queued: usize,
 ) -> String {
     format!(
         "{CAPACITY_REFUSAL_PREFIX} {what} deferred — capacity stage is \
-         {stage} with {resident} of {bound} resident sessions and {queued} \
+         {stage}{why} with {resident} of {bound} resident sessions and {queued} \
          admission(s) queued; retry when headroom returns (watch the \
          capacity state in status)",
         stage = stage.as_str(),
+        why = reasons_parenthetical(reasons),
     )
 }
 
-/// The honest queue notice for a queued admission: names the position and
-/// the bound.
+/// The honest queue notice for a queued admission: names the position,
+/// the stage and its signal(s), and the bound.
 pub(crate) fn queued_text(
     what: &str,
     position: usize,
     stage: CapacityStage,
+    reasons: &[String],
     resident: usize,
     bound: usize,
 ) -> String {
     format!(
-        "capacity: {what} queued at position {position} — stage {stage}, \
+        "capacity: {what} queued at position {position} — stage {stage}{why}, \
          {resident} of {bound} resident sessions; it fires when headroom \
          returns",
         stage = stage.as_str(),
+        why = reasons_parenthetical(reasons),
     )
 }
 
@@ -516,7 +699,9 @@ mod tests {
     // The staging-order invariant: every park watermark sits strictly
     // inside its defer watermark, so worsening pressure always crosses
     // defer before park — admissions defer BEFORE any resident work is
-    // parked.
+    // parked. (The macOS pressure case carries its corroborating
+    // compressor: warn alone never stages at all — see the corroboration
+    // truth table below.)
     #[test]
     fn staging_order_defer_engages_before_park_per_signal() {
         let total = 16u64 * 1024 * 1024 * 1024;
@@ -535,6 +720,7 @@ mod tests {
             (
                 MemorySample {
                     os_pressure_level: Some(2),
+                    compressor_frac: Some(0.18),
                     ..sample()
                 },
                 MemorySample {
@@ -587,6 +773,290 @@ mod tests {
         assert_eq!(raw_stage(&psi_full), CapacityStage::Park);
         // A healthy sample stages nothing.
         assert_eq!(raw_stage(&sample()), CapacityStage::Normal);
+    }
+
+    // The corroboration truth table: macOS pressure-warn is chronic on
+    // healthy-busy Macs (the 2026-08-11 complaint: a workable 24 GB box
+    // refused new work on warn alone), so warn by itself NEVER stages —
+    // it defers only with a second signal (compressor past the
+    // corroboration floor, or available already under its defer
+    // watermark) — while critical still parks on its own and the
+    // standalone compressor watermarks are untouched.
+    #[test]
+    fn macos_pressure_warn_defers_only_when_corroborated() {
+        let total = 16u64 * 1024 * 1024 * 1024;
+        let warn = |compressor: Option<f64>, available: Option<f64>| MemorySample {
+            os_pressure_level: Some(2),
+            compressor_frac: compressor,
+            available_bytes: available.map(|f| frac(total, f)),
+            ..sample()
+        };
+        // Warn alone (healthy available, no compressor reading): Normal.
+        assert_eq!(raw_stage(&warn(None, Some(0.50))), CapacityStage::Normal);
+        assert_eq!(raw_stage(&warn(None, None)), CapacityStage::Normal);
+        // Warn + compressor under the corroboration floor: still Normal.
+        assert_eq!(
+            raw_stage(&warn(Some(0.14), Some(0.50))),
+            CapacityStage::Normal
+        );
+        // Warn + compressor at/above the floor (but under its own defer
+        // watermark): the corroborated pair defers.
+        assert_eq!(
+            raw_stage(&warn(Some(0.15), Some(0.50))),
+            CapacityStage::Defer
+        );
+        assert_eq!(
+            raw_stage(&warn(Some(0.18), Some(0.50))),
+            CapacityStage::Defer
+        );
+        // Warn + available already under its defer watermark: Defer.
+        assert_eq!(raw_stage(&warn(None, Some(0.08))), CapacityStage::Defer);
+        // The corroborating readings alone (no pressure signal) stage
+        // nothing: the corroboration floor is not a new solo trigger.
+        assert_eq!(
+            raw_stage(&MemorySample {
+                compressor_frac: Some(0.18),
+                ..sample()
+            }),
+            CapacityStage::Normal
+        );
+        // Level 3 sits in the warn band (>= warn, < critical): same rule.
+        assert_eq!(
+            raw_stage(&MemorySample {
+                os_pressure_level: Some(3),
+                ..sample()
+            }),
+            CapacityStage::Normal
+        );
+        assert_eq!(
+            raw_stage(&MemorySample {
+                os_pressure_level: Some(3),
+                compressor_frac: Some(0.20),
+                ..sample()
+            }),
+            CapacityStage::Defer
+        );
+        // Critical needs no corroboration: Park on its own, unchanged.
+        assert_eq!(
+            raw_stage(&MemorySample {
+                os_pressure_level: Some(4),
+                ..sample()
+            }),
+            CapacityStage::Park
+        );
+        // The standalone compressor watermarks are untouched: defer at
+        // 0.25, park at 0.35, with or without the warn reading.
+        assert_eq!(
+            raw_stage(&MemorySample {
+                compressor_frac: Some(0.26),
+                ..sample()
+            }),
+            CapacityStage::Defer
+        );
+        assert_eq!(
+            raw_stage(&warn(Some(0.36), Some(0.50))),
+            CapacityStage::Park
+        );
+        // Warn + park-level low available: available's own park wins the
+        // fold (warn corroboration never caps a worse signal).
+        assert_eq!(raw_stage(&warn(None, Some(0.04))), CapacityStage::Park);
+    }
+
+    // Reasons are the same pass as the stage: every firing signal is
+    // named with its reading, non-firing signals contribute nothing.
+    #[test]
+    fn reasons_name_each_firing_signal_with_its_reading() {
+        let total = 16u64 * 1024 * 1024 * 1024;
+        // A quiet sample: no stage, no reasons.
+        assert!(stage_and_reasons(&sample()).1.is_empty());
+        // Uncorroborated warn: no stage, no reasons (nothing fired).
+        assert!(stage_and_reasons(&MemorySample {
+            os_pressure_level: Some(2),
+            ..sample()
+        })
+        .1
+        .is_empty());
+        // The corroborated pair names both halves in one reason.
+        let (stage, reasons) = stage_and_reasons(&MemorySample {
+            os_pressure_level: Some(2),
+            compressor_frac: Some(0.18),
+            ..sample()
+        });
+        assert_eq!(stage, CapacityStage::Defer);
+        assert_eq!(reasons, vec!["memory pressure warn + compressor 18%"]);
+        // Warn corroborated by low available names the available reading.
+        let (_, reasons) = stage_and_reasons(&MemorySample {
+            os_pressure_level: Some(2),
+            available_bytes: Some(frac(total, 0.08)),
+            ..sample()
+        });
+        assert_eq!(
+            reasons,
+            vec![
+                "available memory 8%".to_string(),
+                "memory pressure warn + available 8%".to_string(),
+            ]
+        );
+        // Critical, standalone compressor, PSI, and Windows load each
+        // carry their own reading.
+        let (stage, reasons) = stage_and_reasons(&MemorySample {
+            os_pressure_level: Some(4),
+            compressor_frac: Some(0.36),
+            ..sample()
+        });
+        assert_eq!(stage, CapacityStage::Park);
+        assert_eq!(
+            reasons,
+            vec![
+                "memory pressure critical".to_string(),
+                "compressor 36% of RAM".to_string(),
+            ]
+        );
+        let (_, reasons) = stage_and_reasons(&MemorySample {
+            psi_some_avg10: Some(15.0),
+            ..sample()
+        });
+        assert_eq!(reasons, vec!["memory stall 15% (PSI some)"]);
+        let (stage, reasons) = stage_and_reasons(&MemorySample {
+            psi_some_avg10: Some(12.0),
+            psi_full_avg10: Some(6.0),
+            ..sample()
+        });
+        assert_eq!(stage, CapacityStage::Park);
+        assert_eq!(
+            reasons,
+            vec![
+                "memory stall 12% (PSI some)".to_string(),
+                "full memory stall 6% (PSI full)".to_string(),
+            ]
+        );
+        let (_, reasons) = stage_and_reasons(&MemorySample {
+            load_percent: Some(92),
+            ..sample()
+        });
+        assert_eq!(reasons, vec!["memory load 92%"]);
+    }
+
+    // The view's reasons follow the latest sample, and the ease dwell
+    // holding a stage past its signals says so instead of showing a
+    // stage with no reason.
+    #[test]
+    fn view_reasons_follow_the_sample_and_name_the_easing_dwell() {
+        let controller = CapacityController::new(8);
+        let t0 = Instant::now();
+        let pressured = MemorySample {
+            os_pressure_level: Some(2),
+            compressor_frac: Some(0.18),
+            ..sample()
+        };
+        let view = controller.observe(Some(pressured), t0).expect("changed");
+        assert_eq!(view.stage, CapacityStage::Defer);
+        assert_eq!(view.reasons, vec!["memory pressure warn + compressor 18%"]);
+        // Signals clear inside the dwell: the stage holds and the
+        // reasons carry the honest easing note.
+        let view = controller
+            .observe(Some(sample()), t0 + Duration::from_secs(5))
+            .expect("changed");
+        assert_eq!(view.stage, CapacityStage::Defer, "inside the dwell");
+        assert_eq!(
+            view.reasons,
+            vec![format!(
+                "easing — defer releases after {}s of sustained lower readings",
+                EASE_DWELL.as_secs()
+            )]
+        );
+        // Past the dwell: normal, nothing to explain.
+        let view = controller
+            .observe(Some(sample()), t0 + Duration::from_secs(5) + EASE_DWELL)
+            .expect("changed");
+        assert_eq!(view.stage, CapacityStage::Normal);
+        assert!(view.reasons.is_empty());
+    }
+
+    // The staging knob: config wins over env, env fills when the key is
+    // unset, unrecognized values fall through toward the default at
+    // every level — a typo never bricks or blinds the daemon.
+    #[test]
+    fn resolve_staging_precedence_and_lenient_fallback() {
+        assert_eq!(resolve_staging(None, None), StagingMode::Normal);
+        assert_eq!(resolve_staging(Some("normal"), None), StagingMode::Normal);
+        assert_eq!(
+            resolve_staging(Some("defer-only"), None),
+            StagingMode::DeferOnly
+        );
+        assert_eq!(
+            resolve_staging(Some("defer_only"), None),
+            StagingMode::DeferOnly
+        );
+        assert_eq!(resolve_staging(Some("off"), None), StagingMode::Off);
+        assert_eq!(resolve_staging(Some(" OFF "), None), StagingMode::Off);
+        // Config wins over env.
+        assert_eq!(
+            resolve_staging(Some("defer-only"), Some("off")),
+            StagingMode::DeferOnly
+        );
+        // Env fills when the key is unset or invalid.
+        assert_eq!(resolve_staging(None, Some("off")), StagingMode::Off);
+        assert_eq!(resolve_staging(Some("nope"), Some("off")), StagingMode::Off);
+        // Garbage everywhere reads as the default.
+        assert_eq!(resolve_staging(Some("nope"), Some("also-nope")), StagingMode::Normal);
+        assert_eq!(resolve_staging(None, Some("")), StagingMode::Normal);
+    }
+
+    // `defer-only`: pressure signals cap at defer — admissions still
+    // gate, nothing can reach the park stage — and the view says the cap
+    // fired.
+    #[test]
+    fn defer_only_staging_caps_park_at_defer() {
+        let controller = CapacityController::with_staging(8, StagingMode::DeferOnly);
+        let critical = MemorySample {
+            os_pressure_level: Some(4),
+            ..sample()
+        };
+        let view = controller
+            .observe(Some(critical), Instant::now())
+            .expect("changed");
+        assert_eq!(view.stage, CapacityStage::Defer);
+        assert_eq!(view.staging, "defer-only");
+        assert_eq!(
+            view.reasons,
+            vec![
+                "memory pressure critical".to_string(),
+                "park capped at defer (staging = \"defer-only\")".to_string(),
+            ]
+        );
+        match controller.admission_check(0) {
+            AdmissionCheck::Gate { stage, .. } => assert_eq!(stage, CapacityStage::Defer),
+            other => panic!("defer-only still gates admissions: {other:?}"),
+        }
+    }
+
+    // `off`: pressure staging disabled — the worst sample stages
+    // nothing — while the resident-session bound still gates (the full
+    // off switch remains `[capacity] enabled = false`).
+    #[test]
+    fn off_staging_ignores_pressure_but_keeps_the_count_bound() {
+        let controller = CapacityController::with_staging(2, StagingMode::Off);
+        let critical = MemorySample {
+            os_pressure_level: Some(4),
+            compressor_frac: Some(0.40),
+            ..sample()
+        };
+        let view = controller
+            .observe(Some(critical), Instant::now())
+            .expect("probe_ok flips");
+        assert_eq!(view.stage, CapacityStage::Normal);
+        assert_eq!(view.staging, "off");
+        assert!(view.reasons.is_empty());
+        assert!(view.probe_ok, "the probe still reports honestly");
+        assert_eq!(controller.admission_check(1), AdmissionCheck::Admit);
+        match controller.admission_check(2) {
+            AdmissionCheck::Gate { stage, reasons, .. } => {
+                assert_eq!(stage, CapacityStage::Normal);
+                assert!(reasons.is_empty());
+            }
+            other => panic!("the count bound still gates under off: {other:?}"),
+        }
     }
 
     #[test]
@@ -726,7 +1196,14 @@ mod tests {
         };
         controller.observe(Some(pressured), Instant::now());
         match controller.admission_check(1) {
-            AdmissionCheck::Gate { stage, .. } => assert_eq!(stage, CapacityStage::Defer),
+            AdmissionCheck::Gate { stage, reasons, .. } => {
+                assert_eq!(stage, CapacityStage::Defer);
+                assert_eq!(
+                    reasons,
+                    vec!["memory stall 15% (PSI some)"],
+                    "the gate carries the firing signal for the refusal"
+                );
+            }
             other => panic!("defer stage must gate admissions: {other:?}"),
         }
     }
@@ -758,19 +1235,28 @@ mod tests {
     }
 
     // Refusal/queue honesty: the messages name the bound, the count, the
-    // queue, and carry the stable prefix.
+    // queue, the firing signal(s), and carry the stable prefix.
     #[test]
     fn refusal_and_queue_texts_name_the_facts() {
-        let refusal = refusal_text("fork", CapacityStage::Defer, 16, 16, 3);
+        let reasons = vec!["memory pressure warn + compressor 18%".to_string()];
+        let refusal = refusal_text("fork", CapacityStage::Defer, &reasons, 16, 16, 3);
         assert!(refusal.starts_with(CAPACITY_REFUSAL_PREFIX));
         assert!(refusal.contains("16 of 16"));
         assert!(refusal.contains("3 admission(s) queued"));
-        assert!(refusal.contains("stage is defer"));
-        let queued = queued_text("session create", 4, CapacityStage::Park, 16, 16);
+        assert!(refusal.contains("stage is defer (memory pressure warn + compressor 18%)"));
+        let queued = queued_text("session create", 4, CapacityStage::Park, &reasons, 16, 16);
         assert!(queued.contains("position 4"));
         assert!(queued.contains("16 of 16"));
-        assert!(queued.contains("stage park"));
+        assert!(queued.contains("stage park (memory pressure warn + compressor 18%)"));
         assert!(queued.contains("fires when headroom returns"));
+        // Count-bound gating at a quiet normal has no signal to name:
+        // no empty parenthetical noise.
+        let refusal = refusal_text("fork", CapacityStage::Normal, &[], 16, 16, 0);
+        assert!(refusal.contains("stage is normal with 16 of 16"));
+        assert!(!refusal.contains("()"));
+        let queued = queued_text("session create", 1, CapacityStage::Normal, &[], 16, 16);
+        assert!(queued.contains("stage normal, 16 of 16"));
+        assert!(!queued.contains("()"));
     }
 
     #[test]

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -2259,10 +2259,15 @@ impl IntendantServer {
             if let Some(controller) = crate::capacity::published_capacity_controller() {
                 let view = controller.view();
                 if view.admissions_deferred {
+                    let why = if view.reasons.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" — {}", view.reasons.join(", "))
+                    };
                     return format!(
                         "ok (new session dispatched — capacity is deferring admissions \
-                         (stage {}, {} of {} resident, {} queued): it queues and fires \
-                         when headroom returns; see `capacity` in get_status)",
+                         (stage {}, {} of {} resident, {} queued{why}): it queues and \
+                         fires when headroom returns; see `capacity` in get_status)",
                         view.stage.as_str(),
                         view.resident,
                         view.bound,

--- a/src/bin/caller/project.rs
+++ b/src/bin/caller/project.rs
@@ -134,6 +134,15 @@ pub struct CapacityConfig {
     /// var overrides the derivation but not this key.
     #[serde(default)]
     pub max_resident_sessions: Option<usize>,
+    /// Staging aggressiveness — one coarse knob, deliberately not
+    /// per-threshold tuning: `"normal"` (default; defer and park per the
+    /// watermarks), `"defer-only"` (pressure signals cap at defer —
+    /// admissions queue, nothing parks), `"off"` (pressure staging
+    /// disabled; the resident-session bound still gates). Unrecognized
+    /// values read as `normal`. The `INTENDANT_CAPACITY_STAGING` env var
+    /// fills in when this key is unset.
+    #[serde(default)]
+    pub staging: Option<String>,
 }
 
 impl Default for CapacityConfig {
@@ -141,6 +150,7 @@ impl Default for CapacityConfig {
         Self {
             enabled: default_capacity_enabled(),
             max_resident_sessions: None,
+            staging: None,
         }
     }
 }

--- a/src/bin/caller/session_supervisor/capacity_gate.rs
+++ b/src/bin/caller/session_supervisor/capacity_gate.rs
@@ -98,6 +98,7 @@ impl SessionSupervisor {
                 AdmissionCheck::Admit => Decision::Pass(Box::new(msg), reserved),
                 AdmissionCheck::Gate {
                     stage,
+                    reasons,
                     bound,
                     resident,
                     ..
@@ -113,12 +114,13 @@ impl SessionSupervisor {
                     };
                     match refusing_lane {
                         Some(what) => Decision::Refuse(capacity::refusal_text(
-                            what, stage, resident, bound, queued,
+                            what, stage, &reasons, resident, bound, queued,
                         )),
                         None if queued >= capacity::ADMISSION_QUEUE_CAP => {
                             Decision::Refuse(capacity::refusal_text(
                                 "session create (admission queue full)",
                                 stage,
+                                &reasons,
                                 resident,
                                 bound,
                                 queued,
@@ -135,6 +137,7 @@ impl SessionSupervisor {
                                 "session create",
                                 position,
                                 stage,
+                                &reasons,
                                 resident,
                                 bound,
                             ))

--- a/src/bin/caller/session_supervisor/sub_agents.rs
+++ b/src/bin/caller/session_supervisor/sub_agents.rs
@@ -218,6 +218,7 @@ impl SessionSupervisor {
             let resident = self.state.lock().await.sessions.len();
             if let crate::capacity::AdmissionCheck::Gate {
                 stage,
+                reasons,
                 bound,
                 resident,
                 queued,
@@ -226,6 +227,7 @@ impl SessionSupervisor {
                 return Err(crate::capacity::refusal_text(
                     "sub-agent spawn",
                     stage,
+                    &reasons,
                     resident,
                     bound,
                     queued,

--- a/static/app.html
+++ b/static/app.html
@@ -37759,8 +37759,13 @@ function ui2CapacityChipSync() {
       : stage === 'defer'
         ? 'Memory pressure: new session admissions queue until headroom returns; resident work continues.'
         : 'Sessions are at the resident bound: new admissions queue until a slot frees.',
-    `Residents ${view.resident} of ${view.bound}.`,
   ];
+  // The daemon's own reasons strings name the firing signal(s) — the
+  // client renders them verbatim, no threshold knowledge here.
+  if (Array.isArray(view.reasons) && view.reasons.length) {
+    lines.push(`Why: ${view.reasons.join('; ')}.`);
+  }
+  lines.push(`Residents ${view.resident} of ${view.bound}.`);
   if (queued > 0) lines.push(`${queued} admission(s) queued — they fire when headroom returns.`);
   if (view.probe_ok === false) lines.push('No memory probe on this host: staging is fail-open; only the resident bound applies.');
   chip.title = lines.join(' ');
@@ -39272,7 +39277,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '89f0818a4a3c7497';
+const INTENDANT_APP_BUILD = '0c850c0554f24b9b';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {

--- a/static/app/ui2-chrome.js
+++ b/static/app/ui2-chrome.js
@@ -1041,8 +1041,13 @@ function ui2CapacityChipSync() {
       : stage === 'defer'
         ? 'Memory pressure: new session admissions queue until headroom returns; resident work continues.'
         : 'Sessions are at the resident bound: new admissions queue until a slot frees.',
-    `Residents ${view.resident} of ${view.bound}.`,
   ];
+  // The daemon's own reasons strings name the firing signal(s) — the
+  // client renders them verbatim, no threshold knowledge here.
+  if (Array.isArray(view.reasons) && view.reasons.length) {
+    lines.push(`Why: ${view.reasons.join('; ')}.`);
+  }
+  lines.push(`Residents ${view.resident} of ${view.bound}.`);
   if (queued > 0) lines.push(`${queued} admission(s) queued — they fire when headroom returns.`);
   if (view.probe_ok === false) lines.push('No memory probe on this host: staging is fail-open; only the resident bound applies.');
   chip.title = lines.join(' ');


### PR DESCRIPTION
macOS pressure-warn is chronic on healthy-busy Macs (2026-08-11: a
workable 24 GB box refused new work on warn alone), so warn no longer
enters Defer by itself: it defers only corroborated by a second signal
(compressor >= 0.15, named const with rationale, or available already
under its defer watermark). Critical still parks alone; the standalone
compressor/available/PSI/Windows watermarks, fail-open, and the ease
dwell are untouched.

The staging fold now also produces honest human-readable reasons
naming each firing signal with its reading (one pass, cannot drift):
CapacityView.reasons rides the wire to get_status, the dashboard
capacity chip tooltip, capacity refusals/queue notices, and the MCP
deferring ack — plus an easing note while the dwell holds a stage past
its signals.

New coarse owner knob [capacity] staging = normal | defer-only | off
(INTENDANT_CAPACITY_STAGING fills in when unset; invalid values fall
toward normal): defer-only caps pressure staging at defer, off disables
pressure staging while the resident bound still gates; the view names
the mode. Documented in configuration.md.
