### PR TITLE
approval rail: honest unknown-id handling, single-send, stale-card truth links

### DIFF
--- a/src/bin/caller/backend_install.rs
+++ b/src/bin/caller/backend_install.rs
@@ -451,6 +451,13 @@ async fn install_gate_waiter(
     });
 
     let resolve = |action: &str| {
+        // Record the consumption BEFORE dropping the pending entry: the
+        // session supervisor observes the same decision broadcast
+        // concurrently and checks `install_pending` then the
+        // recently-resolved register — this order leaves no window where
+        // the id is in neither and a first, legitimate decision gets
+        // misreported as stale (routing.rs `resolve_approval`).
+        crate::event::record_approval_resolved(approval_id);
         if let Ok(mut set) = pending_install_approvals().lock() {
             set.remove(&approval_id);
         }
@@ -981,6 +988,11 @@ mod tests {
         }
         assert!(!installs_dir.exists(), "a declined install never executes");
         assert!(!install_pending(approval_id), "pending entry cleared");
+        assert!(
+            crate::event::approval_recently_resolved(approval_id),
+            "the consumed id lands in the recently-resolved register, so a \
+             duplicate decision reads as benign instead of stale"
+        );
         loop {
             match tokio::time::timeout(Duration::from_secs(5), events.recv())
                 .await

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -2678,6 +2678,18 @@ pub(crate) fn cached_bootstrap_events_response_frame(
             }
         }
     }
+    // Pending daemon-scoped approvals (sessionless `approval_required` —
+    // Vault installs, live-audio consent): the arming gates' pending sets
+    // are process memory, so this replay is how a reconnecting dashboard
+    // re-derives which approval cards still stand.
+    if let Ok(guard) = caches.daemon_approval_lines.lock() {
+        for line in guard.values() {
+            match serde_json::from_str::<serde_json::Value>(line) {
+                Ok(v) => events.push(v),
+                Err(_) => malformed.push("daemon_approval"),
+            }
+        }
+    }
     events.retain(|event| {
         serde_json::to_string(event)
             .ok()

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -1427,6 +1427,14 @@ pub struct DashboardBootstrapCaches {
     /// → serialized wire line; pruned on `session_ended`.
     pub(crate) session_state_lines:
         Arc<std::sync::Mutex<BTreeMap<String, BTreeMap<&'static str, String>>>>,
+    /// Pending DAEMON-SCOPED approvals (`approval_required` with no
+    /// session — Vault installs, live-audio consent), keyed by approval
+    /// id and replayed like the per-session lines above: their pending
+    /// sets are process memory the reconnecting dashboard must re-derive,
+    /// not mirror — a card kept client-side outlives a restarted daemon
+    /// and invites decisions for dead ids. Cleared on `approval_resolved`
+    /// (which the arming gates emit on every outcome, expiry included).
+    pub(crate) daemon_approval_lines: Arc<std::sync::Mutex<BTreeMap<u64, String>>>,
 }
 
 type DashboardPresenceFuture = Pin<Box<dyn Future<Output = ()> + Send>>;

--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -53,6 +53,73 @@ pub(crate) fn ensure_approval_id_floor(persisted: u64) {
     NEXT_APPROVAL_ID.fetch_max(persisted + 1, Ordering::Relaxed);
 }
 
+/// Bounded memory of recently consumed approval-rail ids.
+///
+/// One `ControlMsg` approval decision has several concurrent consumers: the
+/// gate that armed the id (a session's approval registry, or a daemon-scoped
+/// bus waiter — install gate, live-audio consent, MCP ask, agenda ask)
+/// resolves it, while the session supervisor's `resolve_approval` observes
+/// the same broadcast and consults the pending sets. Once the id is
+/// consumed, a *second* response for it (a dashboard double-send, a re-click,
+/// or the supervisor simply losing the broadcast race to the waiter) matches
+/// no pending set anywhere — and used to be misreported in session
+/// vocabulary ("no active managed session") to owners performing
+/// daemon-scoped acts. This register lets the fallthrough tell the benign
+/// case ("already resolved") from the genuinely stale one.
+///
+/// Ids are minted once per process ([`next_approval_id`]) and resolved at
+/// most once, so membership here is definitive consumption — never a live
+/// pending id. Injectable so bound/edge tests never churn the process-wide
+/// instance other tests read.
+#[derive(Default)]
+pub(crate) struct ApprovalResolutionMemory {
+    ids: Mutex<std::collections::VecDeque<u64>>,
+}
+
+/// Enough to outlast any realistic duplicate/race window (entries are only
+/// ever queried moments after resolution) while staying trivially bounded.
+const APPROVAL_RESOLUTION_MEMORY_CAP: usize = 128;
+
+impl ApprovalResolutionMemory {
+    pub(crate) fn record(&self, id: u64) {
+        if let Ok(mut ids) = self.ids.lock() {
+            if ids.contains(&id) {
+                return;
+            }
+            ids.push_back(id);
+            while ids.len() > APPROVAL_RESOLUTION_MEMORY_CAP {
+                ids.pop_front();
+            }
+        }
+    }
+
+    pub(crate) fn contains(&self, id: u64) -> bool {
+        self.ids
+            .lock()
+            .map(|ids| ids.contains(&id))
+            .unwrap_or(false)
+    }
+}
+
+fn approval_resolution_memory() -> &'static ApprovalResolutionMemory {
+    static MEMORY: std::sync::OnceLock<ApprovalResolutionMemory> = std::sync::OnceLock::new();
+    MEMORY.get_or_init(ApprovalResolutionMemory::default)
+}
+
+/// Record `id` as consumed. Called by the bus on every `ApprovalResolved`
+/// send (the single choke point every resolver already passes through), and
+/// directly by daemon-scoped gate waiters *before* they drop the id from
+/// their pending set — closing the window where a concurrent supervisor
+/// check would find the id in neither the pending set nor this register.
+pub(crate) fn record_approval_resolved(id: u64) {
+    approval_resolution_memory().record(id);
+}
+
+/// Whether `id` is an approval-rail id this process already resolved.
+pub(crate) fn approval_recently_resolved(id: u64) -> bool {
+    approval_resolution_memory().contains(id)
+}
+
 /// Source of a context injection item.
 ///
 /// Used by the agent loop to decide which queued injections to discard between
@@ -2823,6 +2890,14 @@ impl EventBus {
     }
 
     pub fn send(&self, event: AppEvent) {
+        // Every approval resolution — session registries, daemon-scoped gate
+        // waiters, MCP/agenda resolvers — announces through this event, so
+        // recording here keeps the recently-resolved register complete
+        // without each resolver knowing about it (see
+        // `record_approval_resolved`).
+        if let AppEvent::ApprovalResolved { id, .. } = &event {
+            record_approval_resolved(*id);
+        }
         if app_event_writes_to_session_log(&event) {
             // Stamped at the emit point so the session-log writer can
             // measure how long the item sat in the lane before it was
@@ -2856,6 +2931,11 @@ impl EventBus {
     /// SessionEnded/FileChanged) must keep using [`Self::send`] — that
     /// watcher consumes the same lane.
     pub fn send_already_persisted(&self, event: AppEvent) {
+        // Same recording as `send` — the register must see every
+        // resolution regardless of which send lane carried it.
+        if let AppEvent::ApprovalResolved { id, .. } = &event {
+            record_approval_resolved(*id);
+        }
         if app_event_rides_intent_lane(&event) {
             if let Ok(mut sinks) = self.intent_sinks.lock() {
                 sinks.retain(|sink| sink.send(event.clone()).is_ok());
@@ -7863,6 +7943,51 @@ mod tests {
         let outbound = app_event_to_outbound(&event).unwrap();
         let json = serde_json::to_string(&outbound).unwrap();
         assert!(json.contains("\"event\":\"budget_warning\""));
+    }
+
+    /// The injectable register: recording is idempotent, membership is
+    /// exact, and the bound evicts oldest-first (tested on a private
+    /// instance so the churn never touches the process-wide register other
+    /// tests read).
+    #[test]
+    fn approval_resolution_memory_records_and_bounds() {
+        let memory = ApprovalResolutionMemory::default();
+        assert!(!memory.contains(7));
+        memory.record(7);
+        memory.record(7);
+        assert!(memory.contains(7));
+
+        // Fill past the cap: the oldest entry (7) falls out, the newest
+        // survive.
+        for id in 0..APPROVAL_RESOLUTION_MEMORY_CAP as u64 {
+            memory.record(1_000_000 + id);
+        }
+        assert!(!memory.contains(7), "oldest id evicted at the bound");
+        assert!(memory.contains(1_000_000));
+        assert!(memory.contains(1_000_000 + APPROVAL_RESOLUTION_MEMORY_CAP as u64 - 1));
+    }
+
+    /// Both bus send lanes feed the process-wide register: after an
+    /// `ApprovalResolved` rides either one, the id reads as recently
+    /// resolved (fresh allocator ids so parallel tests never collide).
+    #[test]
+    fn bus_send_records_approval_resolutions() {
+        let bus = EventBus::new();
+        let via_send = next_approval_id();
+        let via_pre_logged = next_approval_id();
+        assert!(!approval_recently_resolved(via_send));
+        bus.send(AppEvent::ApprovalResolved {
+            session_id: None,
+            id: via_send,
+            action: "approve".to_string(),
+        });
+        bus.send_already_persisted(AppEvent::ApprovalResolved {
+            session_id: Some("sess-1".to_string()),
+            id: via_pre_logged,
+            action: "deny".to_string(),
+        });
+        assert!(approval_recently_resolved(via_send));
+        assert!(approval_recently_resolved(via_pre_logged));
     }
 
     #[test]

--- a/src/bin/caller/session_supervisor/routing.rs
+++ b/src/bin/caller/session_supervisor/routing.rs
@@ -4529,11 +4529,15 @@ mod tests {
             1,
             "exactly one honest 'already resolved' line: {lines:?}"
         );
-        assert_eq!(benign[0].0, "info", "the duplicate case is benign, not a warning");
+        assert_eq!(
+            benign[0].0, "info",
+            "the duplicate case is benign, not a warning"
+        );
         assert!(
-            lines.iter().all(|(_, content)| !content
-                .contains("no active managed session")
-                && !content.contains("managed session")),
+            lines.iter().all(
+                |(_, content)| !content.contains("no active managed session")
+                    && !content.contains("managed session")
+            ),
             "session vocabulary must never describe a daemon-scoped duplicate: {lines:?}"
         );
     }
@@ -4550,9 +4554,10 @@ mod tests {
         let supervisor = test_supervisor(PathBuf::from("/tmp/project"), bus.clone());
         {
             let mut state = supervisor.state.lock().await;
-            state
-                .sessions
-                .insert("sess-live".to_string(), managed_session("sess-live", "intendant"));
+            state.sessions.insert(
+                "sess-live".to_string(),
+                managed_session("sess-live", "intendant"),
+            );
         }
         let mut bus_rx = bus.subscribe();
 

--- a/src/bin/caller/session_supervisor/routing.rs
+++ b/src/bin/caller/session_supervisor/routing.rs
@@ -1661,8 +1661,24 @@ impl SessionSupervisor {
         if crate::backend_install::install_pending(approval_id) {
             return;
         }
+        // The id is nobody's pending approval. If this process already
+        // resolved it, the response is a benign duplicate (a dashboard
+        // double-send, a re-click) — or this very check lost the broadcast
+        // race to the gate's own waiter, which consumes the pending entry
+        // concurrently. Either way the human's decision took effect exactly
+        // once; say so quietly instead of falling through to a stale-id
+        // warning. Checked before any session resolution because the id may
+        // never have belonged to a session (frontends historically attach a
+        // fallback session id to daemon-scoped approvals).
+        if crate::event::approval_recently_resolved(approval_id) {
+            self.info(&format!(
+                "Approval {approval_id} was already resolved — duplicate '{action}' response \
+                 ignored"
+            ));
+            return;
+        }
         let Some(target_id) = self.resolve_target_session_id(session_id).await else {
-            self.warn("Approval response dropped: no active managed session");
+            self.warn_stale_approval_response(approval_id);
             return;
         };
         let registry = {
@@ -1676,10 +1692,7 @@ impl SessionSupervisor {
                 .map(|session| session.approval_registry.clone())
         };
         let Some(registry) = registry else {
-            self.warn(&format!(
-                "Approval response dropped: session {} is not managed by this daemon",
-                short_session(&target_id)
-            ));
+            self.warn_stale_approval_response(approval_id);
             return;
         };
         let responder = registry.lock().unwrap().remove(&approval_id);
@@ -1693,13 +1706,25 @@ impl SessionSupervisor {
                 });
             }
             None => {
-                self.warn(&format!(
-                    "Approval response dropped: id {} is not pending for session {}",
-                    approval_id,
-                    short_session(&target_id)
-                ));
+                self.warn_stale_approval_response(approval_id);
             }
         }
+    }
+
+    /// The honest terminal for an approval response whose id is pending
+    /// nowhere and was not recently resolved: the proposal expired (the
+    /// install gate's 600s wall, a question deadline), the daemon
+    /// restarted (pending sets and approval registries are process
+    /// memory), or another surface consumed it longer ago than the
+    /// recently-resolved register remembers. Deliberately free of session
+    /// vocabulary — the id may belong to a daemon-scoped act (a Vault
+    /// install, a live-audio consent), where "no active managed session"
+    /// misreports the owner's own approval as a session-routing failure.
+    fn warn_stale_approval_response(&self, approval_id: u64) {
+        self.warn(&format!(
+            "Approval {approval_id} is no longer pending — it may have expired or already been \
+             resolved; trigger the action again if it is still needed"
+        ));
     }
 }
 
@@ -4451,5 +4476,168 @@ mod tests {
             }
         }
         assert!(saw_refusal, "the refusal must be reported honestly");
+    }
+
+    /// Drain the broadcast ring into the `LogEntry` lines it carries.
+    fn drain_log_entries(
+        bus_rx: &mut tokio::sync::broadcast::Receiver<AppEvent>,
+    ) -> Vec<(String, String)> {
+        let mut lines = Vec::new();
+        while let Ok(event) = bus_rx.try_recv() {
+            if let AppEvent::LogEntry { level, content, .. } = event {
+                lines.push((level, content));
+            }
+        }
+        lines
+    }
+
+    /// The Vault-install incident pin (card 01KZQWXEEK): a duplicate
+    /// approval response — the id was consumed by a daemon-scoped gate's
+    /// waiter moments earlier (dashboard double-send, or the supervisor
+    /// losing the broadcast race) — is a benign no-op. The dashboard hears
+    /// "already resolved" at info level; the session-vocabulary warning
+    /// ("no active managed session") never fires for it.
+    #[tokio::test]
+    async fn duplicate_approval_response_is_an_honest_no_op() {
+        let bus = EventBus::new();
+        let supervisor = test_supervisor(PathBuf::from("/tmp/project"), bus.clone());
+        let approval_id = crate::event::next_approval_id();
+        // The first decision resolved a daemon-scoped gate, whose waiter
+        // announced it on this bus — the choke point that feeds the
+        // recently-resolved register.
+        bus.send(AppEvent::ApprovalResolved {
+            session_id: None,
+            id: approval_id,
+            action: "approve".to_string(),
+        });
+        let mut bus_rx = bus.subscribe();
+        supervisor
+            .resolve_approval(
+                None,
+                approval_id,
+                event::ApprovalResponse::Approve,
+                "approve",
+            )
+            .await;
+        let lines = drain_log_entries(&mut bus_rx);
+        let benign: Vec<_> = lines
+            .iter()
+            .filter(|(_, content)| content.contains("already resolved"))
+            .collect();
+        assert_eq!(
+            benign.len(),
+            1,
+            "exactly one honest 'already resolved' line: {lines:?}"
+        );
+        assert_eq!(benign[0].0, "info", "the duplicate case is benign, not a warning");
+        assert!(
+            lines.iter().all(|(_, content)| !content
+                .contains("no active managed session")
+                && !content.contains("managed session")),
+            "session vocabulary must never describe a daemon-scoped duplicate: {lines:?}"
+        );
+    }
+
+    /// An approval response whose id is pending nowhere and was never
+    /// resolved by this process (expiry past the register's memory, a
+    /// daemon restart) gets the honest neutral copy — expired/resolved,
+    /// trigger again — with no session vocabulary, on every fallthrough:
+    /// no target session, and a live managed session that does not hold
+    /// the id.
+    #[tokio::test]
+    async fn unknown_approval_response_speaks_daemon_honest_copy() {
+        let bus = EventBus::new();
+        let supervisor = test_supervisor(PathBuf::from("/tmp/project"), bus.clone());
+        {
+            let mut state = supervisor.state.lock().await;
+            state
+                .sessions
+                .insert("sess-live".to_string(), managed_session("sess-live", "intendant"));
+        }
+        let mut bus_rx = bus.subscribe();
+
+        // No session id, nothing pending anywhere.
+        let stale_daemon_scoped = crate::event::next_approval_id();
+        supervisor
+            .resolve_approval(
+                None,
+                stale_daemon_scoped,
+                event::ApprovalResponse::Approve,
+                "approve",
+            )
+            .await;
+        // A live managed session that never armed this id.
+        let stale_session_scoped = crate::event::next_approval_id();
+        supervisor
+            .resolve_approval(
+                Some("sess-live".to_string()),
+                stale_session_scoped,
+                event::ApprovalResponse::Deny,
+                "deny",
+            )
+            .await;
+
+        let lines = drain_log_entries(&mut bus_rx);
+        for id in [stale_daemon_scoped, stale_session_scoped] {
+            let matched: Vec<_> = lines
+                .iter()
+                .filter(|(_, content)| content.contains(&format!("Approval {id} ")))
+                .collect();
+            assert_eq!(matched.len(), 1, "one honest line for {id}: {lines:?}");
+            let (level, content) = matched[0];
+            assert_eq!(level, "warn");
+            assert!(
+                content.contains("no longer pending")
+                    && content.contains("may have expired or already been resolved")
+                    && content.contains("trigger the action again"),
+                "the stale copy names expiry and the remedy: {content}"
+            );
+            assert!(
+                !content.contains("session"),
+                "no session vocabulary on the stale-approval terminal: {content}"
+            );
+        }
+        assert!(
+            lines
+                .iter()
+                .all(|(_, content)| !content.contains("no active managed session")),
+            "the misleading legacy copy is gone: {lines:?}"
+        );
+    }
+
+    /// The dashboard bundle's half of the response-drop fix, pinned
+    /// daemon-side (the `spa_install_lane_renders_from_the_matrix`
+    /// pattern): the approval rail must not smuggle an unrelated session
+    /// id onto daemon-scoped approvals, must treat the tunnel RPC's
+    /// delivered ack as delivery (no "retry" invitation that mints
+    /// duplicate decisions), and must truth-link its cards — clearing on
+    /// `approval_resolved` and on transport loss, re-deriving from the
+    /// daemon's bootstrap replay.
+    #[test]
+    fn spa_approval_rail_truth_links_to_daemon_state() {
+        let app = include_str!("../../../../static/app.html");
+        for needle in [
+            // showApproval: no currentSessionFullId fallback on the session
+            // binding (the exact replacement line).
+            "pendingApprovalSessionId = sessionId || approvalSessionIds.get(String(id)) || '';",
+            // sendApproval marks tunnel-delivered decisions; the watchdog
+            // then never invites the duplicate-minting retry.
+            "markApprovalSendDelivered",
+            "delivered: false",
+            // The wire approval_resolved clears the shown approval card.
+            "approval_resolved' && d.id !== undefined && typeof pendingApprovalId",
+            // Transport loss clears local approval cards; the bootstrap
+            // replay re-derives what still stands.
+            "clearLocalApprovalCardsOnTransportLoss",
+        ] {
+            assert!(
+                app.contains(needle),
+                "the dashboard bundle lost the approval-rail truth link: {needle}"
+            );
+        }
+        assert!(
+            !app.contains("|| currentSessionFullId\n      || '';"),
+            "daemon-scoped approvals must not borrow the focused session's identity"
+        );
     }
 }

--- a/src/bin/caller/web_gateway/listener.rs
+++ b/src/bin/caller/web_gateway/listener.rs
@@ -3531,14 +3531,23 @@ mod bootstrap_cache_tests {
             id: 50,
             action: "approve".to_string(),
         });
-        assert!(m.caches.daemon_approval_lines.lock().unwrap().contains_key(&51));
+        assert!(m
+            .caches
+            .daemon_approval_lines
+            .lock()
+            .unwrap()
+            .contains_key(&51));
         m.apply(&AppEvent::ApprovalResolved {
             session_id: None,
             id: 51,
             action: "timeout".to_string(),
         });
         assert!(
-            !m.caches.daemon_approval_lines.lock().unwrap().contains_key(&51),
+            !m.caches
+                .daemon_approval_lines
+                .lock()
+                .unwrap()
+                .contains_key(&51),
             "an expired proposal must not replay as a ghost card"
         );
 

--- a/src/bin/caller/web_gateway/listener.rs
+++ b/src/bin/caller/web_gateway/listener.rs
@@ -1251,6 +1251,10 @@ fn spawn_web_gateway_from_cert_dir_with_relay_listener(
     // peer transport attaching) would otherwise never see state that last
     // changed before they connected. Pruned on session_ended.
     let session_state_lines = bootstrap_caches.session_state_lines.clone();
+    // Pending daemon-scoped approvals (no session), replayed for the same
+    // reason: the arming gates' pending sets are process memory the
+    // reconnecting dashboard must re-derive. Cleared on approval_resolved.
+    let daemon_approval_lines = bootstrap_caches.daemon_approval_lines.clone();
     // Cache display_ready JSON per display_id for late-connecting browsers.
     // Using a HashMap so multiple concurrent display sessions are all replayed.
     let display_ready_cache: Arc<Mutex<HashMap<u32, String>>> =
@@ -1594,6 +1598,7 @@ fn spawn_web_gateway_from_cert_dir_with_relay_listener(
             let attached_external_sessions = attached_external_sessions.clone();
             let last_user_display_json = last_user_display_json.clone();
             let session_state_lines = session_state_lines.clone();
+            let daemon_approval_lines = daemon_approval_lines.clone();
             let display_ready_cache = display_ready_cache.clone();
             let bootstrap_caches = bootstrap_caches.clone();
             let task_tx = task_tx.clone();
@@ -2720,6 +2725,21 @@ fn spawn_web_gateway_from_cert_dir_with_relay_listener(
                         let _ = direct_tx.send(line);
                     }
 
+                    // Re-send pending DAEMON-SCOPED approvals (no session —
+                    // Vault installs, live-audio consent): their pending
+                    // sets are process memory, so this replay is how a
+                    // reconnecting dashboard re-derives which approval
+                    // cards still stand — and after a daemon restart the
+                    // (correctly empty) cache is what keeps dead cards
+                    // dead. Cleared on approval_resolved, expiry included.
+                    let daemon_approval_replay: Vec<String> = daemon_approval_lines
+                        .lock()
+                        .map(|guard| guard.values().cloned().collect())
+                        .unwrap_or_default();
+                    for line in daemon_approval_replay {
+                        let _ = direct_tx.send(line);
+                    }
+
                     // Send cached autonomy after cached status so it wins
                     // when the latest status event is older than the user's
                     // most recent autonomy switch.
@@ -3195,12 +3215,34 @@ impl BootstrapCacheMaintainer {
             // Pending approvals/questions: the daemon-side registry survives
             // a page reload but the panel state does not — replay the ask so
             // a reconnecting operator can still answer. Cleared on
-            // ApprovalResolved below. Session-less asks were never cached by
-            // the wire sniffer (no `session_id` key on the line) — same here.
+            // ApprovalResolved below.
             E::ApprovalRequired {
                 session_id: Some(session_id),
                 ..
             } => self.cache_session_state_line("approval_required", session_id, event),
+            // Daemon-scoped approvals (no session — Vault installs,
+            // live-audio consent) get the same replay treatment in their
+            // own id-keyed cache: their arming gates hold the only pending
+            // state, and it is process memory. Bounded like the session
+            // map; ids are monotonic, so evicting the first key drops the
+            // oldest proposal.
+            E::ApprovalRequired {
+                session_id: None,
+                id,
+                ..
+            } => {
+                if let Some(line) = bootstrap_wire_line(event) {
+                    if let Ok(mut guard) = self.caches.daemon_approval_lines.lock() {
+                        guard.insert(*id, line);
+                        while guard.len() > 64 {
+                            let Some(first) = guard.keys().next().copied() else {
+                                break;
+                            };
+                            guard.remove(&first);
+                        }
+                    }
+                }
+            }
             E::UserQuestionRequired {
                 session_id: Some(session_id),
                 ..
@@ -3226,22 +3268,26 @@ impl BootstrapCacheMaintainer {
                     }
                 }
             },
-            E::ApprovalResolved {
-                session_id: Some(session_id),
-                id,
-                ..
-            } => {
-                if let Ok(mut guard) = self.caches.session_state_lines.lock() {
-                    if let Some(kinds) = guard.get_mut(session_id) {
-                        for kind in ["approval_required", "user_question"] {
-                            let matches = kinds
-                                .get(kind)
-                                .and_then(|cached| {
-                                    serde_json::from_str::<serde_json::Value>(cached).ok()
-                                })
-                                .is_some_and(|cached| cached["id"].as_u64() == Some(*id));
-                            if matches {
-                                kinds.remove(kind);
+            E::ApprovalResolved { session_id, id, .. } => {
+                // Ids are process-unique, so clearing the daemon-scoped
+                // cache by id alone is exact regardless of which lane's
+                // resolution announced it.
+                if let Ok(mut guard) = self.caches.daemon_approval_lines.lock() {
+                    guard.remove(id);
+                }
+                if let Some(session_id) = session_id {
+                    if let Ok(mut guard) = self.caches.session_state_lines.lock() {
+                        if let Some(kinds) = guard.get_mut(session_id) {
+                            for kind in ["approval_required", "user_question"] {
+                                let matches = kinds
+                                    .get(kind)
+                                    .and_then(|cached| {
+                                        serde_json::from_str::<serde_json::Value>(cached).ok()
+                                    })
+                                    .is_some_and(|cached| cached["id"].as_u64() == Some(*id));
+                                if matches {
+                                    kinds.remove(kind);
+                                }
                             }
                         }
                     }
@@ -3303,6 +3349,9 @@ impl BootstrapCacheMaintainer {
             guard.clear();
         }
         if let Ok(mut guard) = self.caches.session_state_lines.lock() {
+            guard.clear();
+        }
+        if let Ok(mut guard) = self.caches.daemon_approval_lines.lock() {
             guard.clear();
         }
     }
@@ -3448,6 +3497,67 @@ mod bootstrap_cache_tests {
         });
         assert!(
             !m.caches.session_state_lines.lock().unwrap()["s-1"].contains_key("approval_required")
+        );
+    }
+
+    /// Daemon-scoped (sessionless) pending approvals — the Vault install /
+    /// live-audio consent family — ride their own id-keyed replay cache:
+    /// cached while pending so a reconnecting dashboard re-derives the
+    /// card, cleared on ANY resolution of the id (the gates emit
+    /// `ApprovalResolved` on every outcome, expiry included), bounded
+    /// oldest-first, and swept by `clear_on_gap` like every other section.
+    #[test]
+    fn daemon_scoped_pending_approvals_replay_until_resolved() {
+        let (m, _rx) = maintainer();
+        let armed = |id: u64| AppEvent::ApprovalRequired {
+            session_id: None,
+            id,
+            command_preview: "curl -fsSL https://example.invalid | bash".to_string(),
+            category: crate::autonomy::ActionCategory::CommandExec,
+        };
+        m.apply(&armed(51));
+        {
+            let guard = m.caches.daemon_approval_lines.lock().unwrap();
+            let line = guard.get(&51).expect("sessionless approval cached");
+            let parsed: serde_json::Value = serde_json::from_str(line).unwrap();
+            assert_eq!(parsed["event"], "approval_required");
+            assert_eq!(parsed["id"], 51);
+        }
+
+        // A different id resolving leaves it pending; the matching id —
+        // sessionless or not — clears it.
+        m.apply(&AppEvent::ApprovalResolved {
+            session_id: None,
+            id: 50,
+            action: "approve".to_string(),
+        });
+        assert!(m.caches.daemon_approval_lines.lock().unwrap().contains_key(&51));
+        m.apply(&AppEvent::ApprovalResolved {
+            session_id: None,
+            id: 51,
+            action: "timeout".to_string(),
+        });
+        assert!(
+            !m.caches.daemon_approval_lines.lock().unwrap().contains_key(&51),
+            "an expired proposal must not replay as a ghost card"
+        );
+
+        // Bounded: 65 pending ids keep only the newest 64 (ids are
+        // monotonic, so the first key is the oldest).
+        for id in 100..165 {
+            m.apply(&armed(id));
+        }
+        {
+            let guard = m.caches.daemon_approval_lines.lock().unwrap();
+            assert_eq!(guard.len(), 64);
+            assert!(!guard.contains_key(&100), "oldest evicted at the bound");
+            assert!(guard.contains_key(&164));
+        }
+
+        m.clear_on_gap();
+        assert!(
+            m.caches.daemon_approval_lines.lock().unwrap().is_empty(),
+            "a lagged maintainer must not replay ghost approvals"
         );
     }
 

--- a/static/app.html
+++ b/static/app.html
@@ -39272,7 +39272,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '89f0818a4a3c7497';
+const INTENDANT_APP_BUILD = '585e937562061879';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -47778,7 +47778,13 @@ function dispatchSessionControlMsg(payload, options = {}) {
     daemonApi.request('api_session_control_msg', { message: payload }, {
       timeoutMs: options.timeoutMs || 15000,
     }).then(resp => {
-      if (resp.ok) return;
+      if (resp.ok) {
+        // Delivered ack: the daemon received and dispatched this message.
+        // Callers with at-most-once semantics (the approval rail) use it
+        // to disarm their retry paths.
+        if (typeof options.onDelivered === 'function') options.onDelivered(resp);
+        return;
+      }
       // Delivered refusals (allowlist drift the parity pins make
       // near-impossible) surface instead of silently resolving; still no
       // /ws replay — the response was delivered.
@@ -56873,6 +56879,25 @@ async function main() {
         serverMsgStep(d, 'approval_resolved', () => {
           clearPendingQuestion();
           hidePanel('question-panel');
+        });
+      }
+      // The approval card truth-link: the daemon says this id is settled
+      // (decided here or elsewhere, or its waiter expired — the install
+      // gate's 600s wall). Clear the shown card so it cannot outlive its
+      // daemon-side backing and invite a decision for a dead id; peer
+      // cards retire on peer_approval_resolved instead.
+      if (d.event === 'approval_resolved' && d.id !== undefined && typeof pendingApprovalId !== 'undefined'
+          && pendingApprovalId !== null && !pendingApprovalHostId
+          && String(pendingApprovalId) === String(d.id)) {
+        serverMsgStep(d, 'approval_resolved_panel', () => {
+          const localSend = typeof approvalSendPending !== 'undefined' && approvalSendPending
+            && approvalSendPending.id === String(d.id);
+          hidePanel('approval-panel'); // clearPendingApproval + queue pump ride inside
+          if (!localSend && typeof showControlToast === 'function') {
+            showControlToast('info', d.action === 'timeout'
+              ? 'An approval expired without a decision — trigger the action again if it is still needed'
+              : 'An approval was resolved from another surface');
+          }
         });
       }
       if (d.event === 'autonomy_changed') {
@@ -77663,10 +77688,24 @@ function beginApprovalSend(id, sessionId) {
     attnKey: attentionApprovalKeyFor(id, sessionId),
     timer: null,
     poll: null,
+    // Flipped by markApprovalSendDelivered when the decision's transport
+    // ACKS receipt (the tunnel RPC's response). The fire-and-forget /ws
+    // lane never flips it.
+    delivered: false,
   };
   pending.timer = setTimeout(() => {
     // Identity check: a later send must never be killed by this timer.
     if (approvalSendPending !== pending) return;
+    if (pending.delivered) {
+      // The daemon acked receipt of the decision; only the resolution
+      // evidence (approval_resolved et al.) is late or lost. Retire the
+      // card WITHOUT the retry invitation — a re-click here is what mints
+      // duplicate decisions ("already resolved" daemon-side). If the
+      // decision found nothing pending, the daemon says so honestly on
+      // its own lane.
+      confirmApprovalSendDelivered();
+      return;
+    }
     if (pending.poll) clearInterval(pending.poll);
     approvalSendPending = null;
     setApprovalPanelSending(false);
@@ -77694,6 +77733,35 @@ function resolveApprovalSend() {
   if (approvalSendPending.poll) clearInterval(approvalSendPending.poll);
   approvalSendPending = null;
   setApprovalPanelSending(false);
+}
+
+// The decision's transport delivered it to the daemon (tunnel RPC ack).
+// Not resolution evidence by itself — the panel keeps waiting for that —
+// but it disarms the watchdog's "may not have reached the daemon — retry"
+// path, whose invited re-click double-sends one human decision.
+function markApprovalSendDelivered(id) {
+  if (approvalSendPending && approvalSendPending.id === String(id)) {
+    approvalSendPending.delivered = true;
+  }
+}
+
+// Transport loss, not resolution (the attention set's attentionClearAll
+// contract): local approval cards drop silently — the daemon-side pending
+// registries are the truth, and the reconnect bootstrap replays whatever
+// still stands (session-scoped and daemon-scoped alike), re-opening the
+// panel through the ordinary approval_required path. Without this, cards
+// whose daemon-side backing died with the process (pending sets are
+// process memory) rendered forever and invited decisions for dead ids.
+// Peer-hosted cards stay: their truth (peerPendingApprovals) survives a
+// local transport flap and retires on peer events instead.
+function clearLocalApprovalCardsOnTransportLoss() {
+  for (let i = approvalDisplayQueue.length - 1; i >= 0; i -= 1) {
+    if (!(approvalDisplayQueue[i].hostId || '')) approvalDisplayQueue.splice(i, 1);
+  }
+  if (pendingApprovalId !== null && !pendingApprovalHostId) {
+    hidePanel('approval-panel');
+  }
+  updateApprovalPendingCount();
 }
 
 function confirmApprovalSendDelivered() {
@@ -77840,11 +77908,14 @@ function showApproval(id, command, category, sessionId, hostId) {
     // local windows; the provenance line names the peer context instead.
     pendingApprovalSessionId = sessionId || '';
   } else {
-    pendingApprovalSessionId =
-      sessionId
-      || approvalSessionIds.get(String(id))
-      || currentSessionFullId
-      || '';
+    // Only a session the approval actually CARRIED. Daemon-scoped
+    // approvals (Vault installs, live-audio consent) ride sessionless by
+    // design — borrowing the focused session's identity here aimed the
+    // decision at an unrelated session and bought session-vocabulary
+    // errors for owners performing daemon-scoped acts. Sessionless
+    // main-loop approvals need no fallback either: the daemon resolves a
+    // sessionless decision against its active session itself.
+    pendingApprovalSessionId = sessionId || approvalSessionIds.get(String(id)) || '';
     if (pendingApprovalSessionId) {
       ensureSessionWindow(pendingApprovalSessionId, { phase: 'waiting' });
       focusSessionWindow(pendingApprovalSessionId);
@@ -144109,6 +144180,15 @@ function attentionApplyEvent(d, live) {
 function attentionOnServerState(connected) {
   if (!connected) {
     attentionClearAll();
+    // The bottom-panel approval card follows the same transport-loss
+    // contract as the attention set: drop local cards silently and let
+    // the reconnect bootstrap replay what still stands — the daemon
+    // replays pending approvals (session-scoped and daemon-scoped), and
+    // a card whose daemon died with its pending set stays gone instead
+    // of rendering forever (41-session-window-actions.js).
+    if (typeof clearLocalApprovalCardsOnTransportLoss === 'function') {
+      clearLocalApprovalCardsOnTransportLoss();
+    }
     return;
   }
   // Local-WS reconnect (RC-C2): the clear dropped peer approval items,
@@ -144678,7 +144758,12 @@ window.sendApproval = function(action) {
     resolveApprovalSend();
     showControlToast('error', err?.message || 'Approval could not be sent — retry');
   };
-  const sent = dispatchSessionControlMsg(msg, { onError: failSend });
+  const sent = dispatchSessionControlMsg(msg, {
+    onError: failSend,
+    // Tunnel RPC ack: the daemon received THIS decision. Disarms the
+    // watchdog's retry invitation so one click stays one response.
+    onDelivered: () => markApprovalSendDelivered(msg.id),
+  });
   if (sent === false) failSend(new Error('Approval could not be sent — no daemon connection; retry'));
 };
 window.sendHumanResponse = function() {

--- a/static/app/32-vault-custody.js
+++ b/static/app/32-vault-custody.js
@@ -4271,7 +4271,13 @@ function dispatchSessionControlMsg(payload, options = {}) {
     daemonApi.request('api_session_control_msg', { message: payload }, {
       timeoutMs: options.timeoutMs || 15000,
     }).then(resp => {
-      if (resp.ok) return;
+      if (resp.ok) {
+        // Delivered ack: the daemon received and dispatched this message.
+        // Callers with at-most-once semantics (the approval rail) use it
+        // to disarm their retry paths.
+        if (typeof options.onDelivered === 'function') options.onDelivered(resp);
+        return;
+      }
       // Delivered refusals (allowlist drift the parity pins make
       // near-impossible) surface instead of silently resolving; still no
       // /ws replay — the response was delivered.

--- a/static/app/36-voice-wasm-init.js
+++ b/static/app/36-voice-wasm-init.js
@@ -761,6 +761,25 @@ async function main() {
           hidePanel('question-panel');
         });
       }
+      // The approval card truth-link: the daemon says this id is settled
+      // (decided here or elsewhere, or its waiter expired — the install
+      // gate's 600s wall). Clear the shown card so it cannot outlive its
+      // daemon-side backing and invite a decision for a dead id; peer
+      // cards retire on peer_approval_resolved instead.
+      if (d.event === 'approval_resolved' && d.id !== undefined && typeof pendingApprovalId !== 'undefined'
+          && pendingApprovalId !== null && !pendingApprovalHostId
+          && String(pendingApprovalId) === String(d.id)) {
+        serverMsgStep(d, 'approval_resolved_panel', () => {
+          const localSend = typeof approvalSendPending !== 'undefined' && approvalSendPending
+            && approvalSendPending.id === String(d.id);
+          hidePanel('approval-panel'); // clearPendingApproval + queue pump ride inside
+          if (!localSend && typeof showControlToast === 'function') {
+            showControlToast('info', d.action === 'timeout'
+              ? 'An approval expired without a decision — trigger the action again if it is still needed'
+              : 'An approval was resolved from another surface');
+          }
+        });
+      }
       if (d.event === 'autonomy_changed') {
         serverMsgStep(d, 'autonomy_changed', () => updateStatusBar({ autonomy: d.autonomy }));
         return;

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -4116,10 +4116,24 @@ function beginApprovalSend(id, sessionId) {
     attnKey: attentionApprovalKeyFor(id, sessionId),
     timer: null,
     poll: null,
+    // Flipped by markApprovalSendDelivered when the decision's transport
+    // ACKS receipt (the tunnel RPC's response). The fire-and-forget /ws
+    // lane never flips it.
+    delivered: false,
   };
   pending.timer = setTimeout(() => {
     // Identity check: a later send must never be killed by this timer.
     if (approvalSendPending !== pending) return;
+    if (pending.delivered) {
+      // The daemon acked receipt of the decision; only the resolution
+      // evidence (approval_resolved et al.) is late or lost. Retire the
+      // card WITHOUT the retry invitation — a re-click here is what mints
+      // duplicate decisions ("already resolved" daemon-side). If the
+      // decision found nothing pending, the daemon says so honestly on
+      // its own lane.
+      confirmApprovalSendDelivered();
+      return;
+    }
     if (pending.poll) clearInterval(pending.poll);
     approvalSendPending = null;
     setApprovalPanelSending(false);
@@ -4147,6 +4161,35 @@ function resolveApprovalSend() {
   if (approvalSendPending.poll) clearInterval(approvalSendPending.poll);
   approvalSendPending = null;
   setApprovalPanelSending(false);
+}
+
+// The decision's transport delivered it to the daemon (tunnel RPC ack).
+// Not resolution evidence by itself — the panel keeps waiting for that —
+// but it disarms the watchdog's "may not have reached the daemon — retry"
+// path, whose invited re-click double-sends one human decision.
+function markApprovalSendDelivered(id) {
+  if (approvalSendPending && approvalSendPending.id === String(id)) {
+    approvalSendPending.delivered = true;
+  }
+}
+
+// Transport loss, not resolution (the attention set's attentionClearAll
+// contract): local approval cards drop silently — the daemon-side pending
+// registries are the truth, and the reconnect bootstrap replays whatever
+// still stands (session-scoped and daemon-scoped alike), re-opening the
+// panel through the ordinary approval_required path. Without this, cards
+// whose daemon-side backing died with the process (pending sets are
+// process memory) rendered forever and invited decisions for dead ids.
+// Peer-hosted cards stay: their truth (peerPendingApprovals) survives a
+// local transport flap and retires on peer events instead.
+function clearLocalApprovalCardsOnTransportLoss() {
+  for (let i = approvalDisplayQueue.length - 1; i >= 0; i -= 1) {
+    if (!(approvalDisplayQueue[i].hostId || '')) approvalDisplayQueue.splice(i, 1);
+  }
+  if (pendingApprovalId !== null && !pendingApprovalHostId) {
+    hidePanel('approval-panel');
+  }
+  updateApprovalPendingCount();
 }
 
 function confirmApprovalSendDelivered() {
@@ -4293,11 +4336,14 @@ function showApproval(id, command, category, sessionId, hostId) {
     // local windows; the provenance line names the peer context instead.
     pendingApprovalSessionId = sessionId || '';
   } else {
-    pendingApprovalSessionId =
-      sessionId
-      || approvalSessionIds.get(String(id))
-      || currentSessionFullId
-      || '';
+    // Only a session the approval actually CARRIED. Daemon-scoped
+    // approvals (Vault installs, live-audio consent) ride sessionless by
+    // design — borrowing the focused session's identity here aimed the
+    // decision at an unrelated session and bought session-vocabulary
+    // errors for owners performing daemon-scoped acts. Sessionless
+    // main-loop approvals need no fallback either: the daemon resolves a
+    // sessionless decision against its active session itself.
+    pendingApprovalSessionId = sessionId || approvalSessionIds.get(String(id)) || '';
     if (pendingApprovalSessionId) {
       ensureSessionWindow(pendingApprovalSessionId, { phase: 'waiting' });
       focusSessionWindow(pendingApprovalSessionId);

--- a/static/app/57-attention-notifications.js
+++ b/static/app/57-attention-notifications.js
@@ -251,6 +251,15 @@ function attentionApplyEvent(d, live) {
 function attentionOnServerState(connected) {
   if (!connected) {
     attentionClearAll();
+    // The bottom-panel approval card follows the same transport-loss
+    // contract as the attention set: drop local cards silently and let
+    // the reconnect bootstrap replay what still stands — the daemon
+    // replays pending approvals (session-scoped and daemon-scoped), and
+    // a card whose daemon died with its pending set stays gone instead
+    // of rendering forever (41-session-window-actions.js).
+    if (typeof clearLocalApprovalCardsOnTransportLoss === 'function') {
+      clearLocalApprovalCardsOnTransportLoss();
+    }
     return;
   }
   // Local-WS reconnect (RC-C2): the clear dropped peer approval items,

--- a/static/app/58-shortcuts-boot.js
+++ b/static/app/58-shortcuts-boot.js
@@ -61,7 +61,12 @@ window.sendApproval = function(action) {
     resolveApprovalSend();
     showControlToast('error', err?.message || 'Approval could not be sent — retry');
   };
-  const sent = dispatchSessionControlMsg(msg, { onError: failSend });
+  const sent = dispatchSessionControlMsg(msg, {
+    onError: failSend,
+    // Tunnel RPC ack: the daemon received THIS decision. Disarms the
+    // watchdog's retry invitation so one click stays one response.
+    onDelivered: () => markApprovalSendDelivered(msg.id),
+  });
   if (sent === false) failSend(new Error('Approval could not be sent — no daemon connection; retry'));
 };
 window.sendHumanResponse = function() {


### PR DESCRIPTION
Fixes the Vault install-approval response-drop class (owner live e2e
2026-08-11): an approved install ran and succeeded, yet the owner was
toasted 'Approval response dropped: no active managed session' — a
duplicate/late decision fell through resolve_approval's four
daemon-scoped pending checks into session vocabulary.

Daemon:
- event.rs grows a bounded recently-resolved approval register fed at
  the EventBus send choke point (every resolver announces through
  ApprovalResolved) and pre-fed by the install gate waiter BEFORE it
  drops the pending entry, so a supervisor losing the broadcast race
  finds the id in one set or the other — never neither.
- resolve_approval: a recently-resolved id is a benign no-op ('already
  resolved', info); every remaining fallthrough speaks one honest
  neutral copy (expired/resolved, trigger again) with no session
  vocabulary. 'no active managed session' is gone from the approval
  path.
- Bootstrap caches gain an id-keyed daemon-scoped pending-approval
  section (sessionless approval_required — Vault installs, live-audio
  consent), replayed on /ws attach and the tunnel bootstrap, cleared on
  any ApprovalResolved (expiry included), bounded, swept by
  clear_on_gap — the reconnecting dashboard re-derives which approval
  cards still stand instead of mirroring dead ones.

Dashboard:
- showApproval no longer borrows the focused session's identity for
  sessionless approvals (the smuggled session id aimed daemon-scoped
  decisions at unrelated sessions).
- The tunnel RPC's delivered ack disarms the 5s watchdog's 'may not
  have reached the daemon — retry' invitation, whose re-click minted
  duplicate decisions; undelivered sends keep the retry path.
- approval_resolved now clears the shown approval card (decided
  elsewhere or expired — the 600s install wall), with honest copy; the
  question panel already did this.
- Transport loss drops local approval cards like the attention set and
  lets the bootstrap replay re-derive survivors; peer cards keep their
  own lifecycle.

Pinned by unit tests on the duplicate and unknown-id paths, the
bootstrap cache lifecycle, the register bound/feed, and daemon-side
needle pins on the SPA truth-link markers.
