### PR TITLE
backend detection and launch resolve past the daemon's inherited PATH

### DIFF
--- a/crates/intendant-platform/src/platform.rs
+++ b/crates/intendant-platform/src/platform.rs
@@ -1544,9 +1544,10 @@ pub fn resolve_command_path(command: &str) -> Option<std::path::PathBuf> {
     resolve_command_path_in(command, std::env::var_os("PATH"))
 }
 
-/// `PATH` is injected so tests don't have to mutate process-global env
-/// (which races the parallel test runner).
-fn resolve_command_path_in(
+/// `PATH` is injected so tests (and callers composing their own
+/// resolution ladders) don't have to mutate process-global env — which
+/// races the parallel test runner.
+pub fn resolve_command_path_in(
     command: &str,
     path_var: Option<std::ffi::OsString>,
 ) -> Option<std::path::PathBuf> {
@@ -1571,6 +1572,14 @@ fn resolve_command_path_in(
         }
     }
     None
+}
+
+/// Whether an executable named `command` exists in `dir` — the per-dir
+/// probe callers use to search declared installer destinations that are
+/// not on `PATH` (Windows gets the same `PATHEXT`-style suffix handling
+/// as `PATH` resolution). Stat-only; never executes anything.
+pub fn executable_in_dir(dir: &std::path::Path, command: &str) -> Option<std::path::PathBuf> {
+    executable_candidate(&dir.join(command))
 }
 
 /// The candidate itself on Unix (a regular file with an execute bit); on
@@ -1629,9 +1638,10 @@ pub fn off_path_install_probe(command: &str) -> Option<OffPathInstall> {
     off_path_install_probe_in(command, std::env::var_os("PATH"), &home_dir())
 }
 
-/// `PATH` and the home directory are injected so tests never read or
-/// mutate process-global state (the tests-are-hermetic convention).
-fn off_path_install_probe_in(
+/// `PATH` and the home directory are injected so tests (and callers
+/// composing their own resolution ladders) never read or mutate
+/// process-global state (the tests-are-hermetic convention).
+pub fn off_path_install_probe_in(
     command: &str,
     path_var: Option<std::ffi::OsString>,
     home: &std::path::Path,

--- a/docs/src/external-agent-orchestration.md
+++ b/docs/src/external-agent-orchestration.md
@@ -1439,7 +1439,7 @@ defaults, so a bare `[agent]` with just `default_backend` works.
 default_backend = "codex"
 
 [agent.codex]
-command          = "codex"            # binary on PATH or absolute path
+command          = "codex"            # bare name (resolved via PATH, then the known install dirs) or absolute path
 model            = "gpt-5.6-sol"      # optional; omit to use Codex's default
 approval_policy  = "on-request"       # untrusted | on-request | never
 sandbox          = "workspace-write"  # read-only | workspace-write | danger-full-access

--- a/src/bin/caller/auth_ceremony.rs
+++ b/src/bin/caller/auth_ceremony.rs
@@ -818,20 +818,34 @@ pub(crate) fn url_from_shim_log(
     None
 }
 
-/// PTY program resolution mirroring `platform::spawn_command`'s rules: on
-/// Windows a bare npm-shim name (`claude` → `claude.cmd`) needs PATHEXT
-/// resolution and a `cmd.exe /C` wrapper; everywhere else the name passes
-/// through.
-pub(crate) fn pty_program_invocation(command: &str) -> (String, Vec<String>) {
+/// PTY program resolution for a backend CLI: the shared detection/launch
+/// ladder picks the actual binary first (the daemon's PATH, then the
+/// backend's declared installer destinations, then the well-known
+/// install dirs — `external_agent::launch_program`), so a CLI that
+/// availability reports installed also signs in without PATH surgery.
+/// The platform shaping then mirrors `platform::spawn_command`'s rules:
+/// on Windows a `.cmd`/`.bat` npm shim needs a `cmd.exe /C` wrapper
+/// (CreateProcess cannot exec batch files, and portable_pty has no
+/// implicit shim); everywhere else the resolved program passes through.
+pub(crate) fn pty_program_invocation(
+    backend: &crate::external_agent::AgentBackend,
+    command: &str,
+) -> (String, Vec<String>) {
+    let program = crate::external_agent::launch_program(backend, command);
     #[cfg(windows)]
     {
-        let lower = command.to_ascii_lowercase();
-        if !(command.contains('/')
-            || command.contains('\\')
+        let lower = program.to_ascii_lowercase();
+        // A ladder-resolved (or explicitly configured) batch shim path
+        // still needs the interpreter.
+        if lower.ends_with(".cmd") || lower.ends_with(".bat") {
+            return ("cmd.exe".to_string(), vec!["/C".to_string(), program]);
+        }
+        if !(program.contains('/')
+            || program.contains('\\')
             || lower.ends_with(".exe")
             || lower.ends_with(".com"))
         {
-            if let Ok(resolved) = which::which(command) {
+            if let Ok(resolved) = which::which(&program) {
                 let ext = resolved
                     .extension()
                     .and_then(|e| e.to_str())
@@ -846,7 +860,7 @@ pub(crate) fn pty_program_invocation(command: &str) -> (String, Vec<String>) {
             }
         }
     }
-    (command.to_string(), Vec::new())
+    (program, Vec::new())
 }
 
 #[cfg(test)]

--- a/src/bin/caller/backend_install.rs
+++ b/src/bin/caller/backend_install.rs
@@ -81,33 +81,59 @@ impl InstallPlatform {
 
 /// One cell of the matrix: the official, vendor-documented install
 /// command for `backend` on `platform`, verbatim as the approval wall
-/// announces and the runtime executes it.
+/// announces and the runtime executes it — plus the destination
+/// directories that installer places the CLI's launcher in.
 pub(crate) struct InstallLane {
     pub(crate) backend: AgentBackend,
     pub(crate) platform: InstallPlatform,
     pub(crate) command: &'static str,
+    /// Where the declared installer lands the launcher: home-relative
+    /// directories (components `/`-separated; joined per component so
+    /// Windows paths come out native), in search priority order. This is
+    /// the declaration backend *detection and launch* resolve through
+    /// when the daemon's inherited `PATH` misses — the daemon commonly
+    /// boots from launchd/a service with a minimal PATH, and an installer
+    /// that patched the owner's shell rc can never reach an
+    /// already-running daemon. The narrowed genuinely-not-found PATH hint
+    /// derives its named location from the same cell.
+    pub(crate) dest_dirs: &'static [&'static str],
 }
 
-/// The matrix. Sources ([external] claims, fetched 2026-08-08):
+/// The matrix. Sources ([external] claims, fetched 2026-08-08;
+/// destination dirs re-verified against the live install scripts
+/// 2026-08-11):
 ///
 /// - **Claude Code** — code.claude.com/docs/en/setup, "Native Install
 ///   (Recommended)": `curl -fsSL https://claude.ai/install.sh | bash`
 ///   (macOS/Linux/WSL); the Windows CMD lane is the vendor's own CMD tab
 ///   (the runtime's Windows shell is `cmd.exe /C`). npm/brew/winget lanes
-///   exist but the native installer is the documented primary.
+///   exist but the native installer is the documented primary. Both
+///   lanes download the versioned binary and run its own `claude
+///   install`, which lands the launcher in `~/.local/bin`
+///   (`%USERPROFILE%\.local\bin` on Windows; versions live under
+///   `~/.claude`).
 /// - **Codex** — github.com/openai/codex README: shell installer
 ///   `curl -fsSL https://chatgpt.com/codex/install.sh | sh` (macOS/Linux)
 ///   and the vendor's own PowerShell one-liner for Windows (documented in
 ///   the exact `powershell -ExecutionPolicy ByPass -c "…"` form, which is
 ///   cmd.exe-invokable). npm (`npm install -g @openai/codex`) and
-///   `brew install --cask codex` are documented alternatives.
+///   `brew install --cask codex` are documented alternatives. install.sh
+///   symlinks the launcher into `BIN_DIR="${CODEX_INSTALL_DIR:-$HOME/.local/bin}"`
+///   (releases under `~/.codex`); install.ps1's default visible bin dir
+///   is `$env:LOCALAPPDATA\Programs\OpenAI\Codex\bin` (declared here via
+///   LOCALAPPDATA's home-relative default — a registry-redirected
+///   LOCALAPPDATA falls back to the PATH rung).
 /// - **Kimi Code** — moonshotai.github.io/kimi-code getting-started:
 ///   install script (recommended, no Node required)
 ///   `curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash`;
 ///   Windows is the vendor's `irm https://code.kimi.com/kimi-code/install.ps1 | iex`
 ///   PowerShell lane, wrapped for the runtime's cmd.exe shell the same
 ///   way the Codex vendor documents theirs. npm alternative:
-///   `npm install -g @moonshot-ai/kimi-code`.
+///   `npm install -g @moonshot-ai/kimi-code`. Both scripts default
+///   `KIMI_INSTALL_DIR` to `~/.kimi-code` and land the launcher in its
+///   `bin/` (the 2026-08-11 owner e2e incident: the installer succeeded
+///   into `~/.kimi-code/bin` and patched `~/.zshrc`, which an
+///   already-running daemon can never inherit).
 /// - **Pi** deliberately has no lane: no vendor-documented single-command
 ///   installer of the same class, so the matrix says so and no button
 ///   renders for it.
@@ -116,58 +142,98 @@ const INSTALL_MATRIX: &[InstallLane] = &[
         backend: AgentBackend::ClaudeCode,
         platform: InstallPlatform::MacOs,
         command: "curl -fsSL https://claude.ai/install.sh | bash",
+        dest_dirs: &[".local/bin"],
     },
     InstallLane {
         backend: AgentBackend::ClaudeCode,
         platform: InstallPlatform::Linux,
         command: "curl -fsSL https://claude.ai/install.sh | bash",
+        dest_dirs: &[".local/bin"],
     },
     InstallLane {
         backend: AgentBackend::ClaudeCode,
         platform: InstallPlatform::Windows,
         command: "curl -fsSL https://claude.ai/install.cmd -o install.cmd && install.cmd && del install.cmd",
+        dest_dirs: &[".local/bin"],
     },
     InstallLane {
         backend: AgentBackend::Codex,
         platform: InstallPlatform::MacOs,
         command: "curl -fsSL https://chatgpt.com/codex/install.sh | sh",
+        dest_dirs: &[".local/bin"],
     },
     InstallLane {
         backend: AgentBackend::Codex,
         platform: InstallPlatform::Linux,
         command: "curl -fsSL https://chatgpt.com/codex/install.sh | sh",
+        dest_dirs: &[".local/bin"],
     },
     InstallLane {
         backend: AgentBackend::Codex,
         platform: InstallPlatform::Windows,
         command: "powershell -ExecutionPolicy ByPass -c \"irm https://chatgpt.com/codex/install.ps1 | iex\"",
+        dest_dirs: &["AppData/Local/Programs/OpenAI/Codex/bin"],
     },
     InstallLane {
         backend: AgentBackend::Kimi,
         platform: InstallPlatform::MacOs,
         command: "curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash",
+        dest_dirs: &[".kimi-code/bin"],
     },
     InstallLane {
         backend: AgentBackend::Kimi,
         platform: InstallPlatform::Linux,
         command: "curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash",
+        dest_dirs: &[".kimi-code/bin"],
     },
     InstallLane {
         backend: AgentBackend::Kimi,
         platform: InstallPlatform::Windows,
         command: "powershell -ExecutionPolicy Bypass -c \"irm https://code.kimi.com/kimi-code/install.ps1 | iex\"",
+        dest_dirs: &[".kimi-code/bin"],
     },
 ];
 
 /// The matrix cell for (`backend`, `platform`), if declared.
+fn install_lane(backend: &AgentBackend, platform: InstallPlatform) -> Option<&'static InstallLane> {
+    INSTALL_MATRIX
+        .iter()
+        .find(|lane| lane.backend == *backend && lane.platform == platform)
+}
+
+/// The install command for (`backend`, `platform`), if declared.
 pub(crate) fn install_command(
     backend: &AgentBackend,
     platform: InstallPlatform,
 ) -> Option<&'static str> {
-    INSTALL_MATRIX
-        .iter()
-        .find(|lane| lane.backend == *backend && lane.platform == platform)
-        .map(|lane| lane.command)
+    install_lane(backend, platform).map(|lane| lane.command)
+}
+
+/// The declared installer destination directories for (`backend`,
+/// `platform`), resolved under `home`, in search priority order. Empty
+/// when the matrix has no lane (Pi, untargeted platforms). Detection and
+/// launch resolve through these when the daemon's inherited `PATH`
+/// misses; the genuinely-not-found hint names the first one. `home` is
+/// injected (tests-are-hermetic).
+pub(crate) fn declared_install_dirs(
+    backend: &AgentBackend,
+    platform: InstallPlatform,
+    home: &std::path::Path,
+) -> Vec<PathBuf> {
+    install_lane(backend, platform)
+        .map(|lane| {
+            lane.dest_dirs
+                .iter()
+                .map(|spec| {
+                    let mut dir = home.to_path_buf();
+                    for component in spec.split('/') {
+                        dir.push(component);
+                    }
+                    dir
+                })
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 /// The approval-rail preview: the backend, the EXACT command verbatim on
@@ -792,6 +858,24 @@ mod tests {
                     !command.contains('\n') && !command.contains('\r'),
                     "install commands are single-line by contract"
                 );
+                // Every lane declares where its installer lands the
+                // launcher — home-relative, so detection/launch can
+                // resolve it under any injected home.
+                assert!(
+                    !cells[0].dest_dirs.is_empty(),
+                    "{}/{} must declare its installer destination",
+                    backend.as_short_str(),
+                    platform.as_str()
+                );
+                for spec in cells[0].dest_dirs {
+                    assert!(
+                        !spec.is_empty()
+                            && !spec.starts_with('/')
+                            && !spec.starts_with('~')
+                            && !spec.contains('\\'),
+                        "dest dirs are home-relative `/`-separated specs: {spec:?}"
+                    );
+                }
             }
         }
         // Pi deliberately has no lane on any platform.
@@ -800,6 +884,53 @@ mod tests {
                 .iter()
                 .all(|lane| lane.backend != AgentBackend::Pi),
             "pi has no vendor install lane by decision — adding one belongs in the matrix comment"
+        );
+    }
+
+    /// The declared destinations match the actual install scripts'
+    /// behavior (verified 2026-08-11): kimi lands in `~/.kimi-code/bin`
+    /// everywhere (the owner-e2e incident dir), claude and codex in
+    /// `~/.local/bin` on macOS/Linux, and codex's Windows installer in
+    /// LOCALAPPDATA's `Programs\OpenAI\Codex\bin`. `declared_install_dirs`
+    /// resolves them under the injected home.
+    #[test]
+    fn declared_destinations_match_the_official_installers() {
+        let home = std::path::Path::new("test-home");
+        for platform in PLATFORMS {
+            assert_eq!(
+                declared_install_dirs(&AgentBackend::Kimi, platform, home),
+                vec![home.join(".kimi-code").join("bin")],
+                "kimi installs into ~/.kimi-code/bin on {}",
+                platform.as_str()
+            );
+            assert_eq!(
+                declared_install_dirs(&AgentBackend::ClaudeCode, platform, home),
+                vec![home.join(".local").join("bin")],
+                "claude's native installer lands in ~/.local/bin on {}",
+                platform.as_str()
+            );
+            assert!(
+                declared_install_dirs(&AgentBackend::Pi, platform, home).is_empty(),
+                "pi has no lane, so no declared destinations"
+            );
+        }
+        assert_eq!(
+            declared_install_dirs(&AgentBackend::Codex, InstallPlatform::MacOs, home),
+            vec![home.join(".local").join("bin")]
+        );
+        assert_eq!(
+            declared_install_dirs(&AgentBackend::Codex, InstallPlatform::Linux, home),
+            vec![home.join(".local").join("bin")]
+        );
+        assert_eq!(
+            declared_install_dirs(&AgentBackend::Codex, InstallPlatform::Windows, home),
+            vec![home
+                .join("AppData")
+                .join("Local")
+                .join("Programs")
+                .join("OpenAI")
+                .join("Codex")
+                .join("bin")]
         );
     }
 
@@ -1032,7 +1163,7 @@ mod tests {
             "function agentInstallSection",
             "api_external_agent_install",
             "the exact command is on the approval rail",
-            "The daemon inherited its PATH at launch",
+            "any install location the daemon checks",
             "Intendant can run its official installer here, with your approval first.",
             "log-empty-install",
         ] {

--- a/src/bin/caller/claude_auth_ceremony.rs
+++ b/src/bin/caller/claude_auth_ceremony.rs
@@ -204,7 +204,8 @@ pub(crate) fn parse_auth_status(output: &str) -> Option<AuthProbe> {
 /// Run `<command> auth status` and parse it. Blocking — called from the
 /// ceremony's reader thread only.
 fn probe_auth_status(command: &str) -> Option<AuthProbe> {
-    let (program, mut args) = pty_program_invocation(command);
+    let (program, mut args) =
+        pty_program_invocation(&crate::external_agent::AgentBackend::ClaudeCode, command);
     args.extend(["auth".to_string(), "status".to_string()]);
     let output = std::process::Command::new(program)
         .args(args)
@@ -272,7 +273,8 @@ fn spawn_ceremony_process(id: u64, command: &str) -> Result<(), String> {
         })
         .map_err(|e| format!("openpty: {e}"))?;
 
-    let (program, mut args) = pty_program_invocation(command);
+    let (program, mut args) =
+        pty_program_invocation(&crate::external_agent::AgentBackend::ClaudeCode, command);
     args.extend(["auth".to_string(), "login".to_string()]);
     // V1 is the claude.ai lane, the CLI default; passed explicitly so the
     // ceremony can never inherit a different default from a newer CLI.

--- a/src/bin/caller/codex_auth_ceremony.rs
+++ b/src/bin/caller/codex_auth_ceremony.rs
@@ -273,7 +273,8 @@ pub(crate) fn parse_login_status(exit_ok: bool, output: &str) -> AuthProbe {
 /// the ceremony's worker threads only. Both output streams feed the
 /// parser (CLI status lines have moved between them before).
 fn probe_login_status(command: &str) -> Option<AuthProbe> {
-    let (program, mut args) = pty_program_invocation(command);
+    let (program, mut args) =
+        pty_program_invocation(&crate::external_agent::AgentBackend::Codex, command);
     args.extend(["login".to_string(), "status".to_string()]);
     let output = std::process::Command::new(program)
         .args(args)
@@ -345,7 +346,8 @@ fn spawn_ceremony_process(id: u64, command: &str) -> Result<(), String> {
         })
         .map_err(|e| format!("openpty: {e}"))?;
 
-    let (program, mut args) = pty_program_invocation(command);
+    let (program, mut args) =
+        pty_program_invocation(&crate::external_agent::AgentBackend::Codex, command);
     args.extend(["login".to_string(), "--device-auth".to_string()]);
     let mut cmd = portable_pty::CommandBuilder::new(&program);
     cmd.args(&args);

--- a/src/bin/caller/codex_cloud.rs
+++ b/src/bin/caller/codex_cloud.rs
@@ -849,7 +849,10 @@ async fn run_passthrough(command: &str, args: &[String]) -> Result<(), String> {
     let mut cloud_args = vec!["cloud".to_string(), command.to_string()];
     cloud_args.extend(args.iter().cloned());
     let working_dir = codex_working_dir()?;
-    let mut child = crate::platform::spawn_command(&codex_command());
+    let mut child = crate::external_agent::spawn_backend_command(
+        &crate::external_agent::AgentBackend::Codex,
+        &codex_command(),
+    );
     let status = child
         .args(cloud_args)
         .current_dir(working_dir.path())
@@ -2544,7 +2547,12 @@ async fn run_codex_with_stdin(
     use tokio::io::AsyncWriteExt as _;
 
     let working_dir = codex_working_dir()?;
-    let mut command = crate::platform::spawn_command(program);
+    // The codex CLI through detection's resolution ladder — the daemon's
+    // inherited PATH commonly lacks the native installer's bin dir.
+    let mut command = crate::external_agent::spawn_backend_command(
+        &crate::external_agent::AgentBackend::Codex,
+        program,
+    );
     command
         .args(args)
         .current_dir(working_dir.path())

--- a/src/bin/caller/credential_watch.rs
+++ b/src/bin/caller/credential_watch.rs
@@ -599,12 +599,19 @@ pub(crate) async fn run_identity_probe(
     provider: Provider,
     command: &str,
 ) -> Result<AuthProbe, String> {
-    let (program, mut args) = crate::auth_ceremony::pty_program_invocation(command);
-    match provider {
-        Provider::Claude => args.extend(["auth".to_string(), "status".to_string()]),
-        Provider::Codex => args.extend(["login".to_string(), "status".to_string()]),
+    let (backend, probe_args) = match provider {
+        Provider::Claude => (
+            crate::external_agent::AgentBackend::ClaudeCode,
+            ["auth", "status"],
+        ),
+        Provider::Codex => (
+            crate::external_agent::AgentBackend::Codex,
+            ["login", "status"],
+        ),
         Provider::Kimi => return Err("kimi is out of scope for the credential watch".to_string()),
-    }
+    };
+    let (program, mut args) = crate::auth_ceremony::pty_program_invocation(&backend, command);
+    args.extend(probe_args.into_iter().map(String::from));
     let mut cmd = tokio::process::Command::new(program);
     cmd.args(args)
         .stdin(std::process::Stdio::null())

--- a/src/bin/caller/external_agent/claude_code.rs
+++ b/src/bin/caller/external_agent/claude_code.rs
@@ -217,7 +217,9 @@ pub(crate) enum ClaudeRewindWireCapability {
 pub(crate) fn claude_rewind_wire_capability(command: &str) -> ClaudeRewindWireCapability {
     static CACHE: std::sync::OnceLock<StdMutex<HashMap<String, (String, bool)>>> =
         std::sync::OnceLock::new();
-    let Some(fingerprint) = super::protocol_watch::executable_fingerprint(command) else {
+    let Some(fingerprint) =
+        super::protocol_watch::executable_fingerprint(&super::AgentBackend::ClaudeCode, command)
+    else {
         return ClaudeRewindWireCapability::Unknown;
     };
     let cache = CACHE.get_or_init(|| StdMutex::new(HashMap::new()));
@@ -4363,7 +4365,10 @@ impl ExternalAgent for ClaudeCodeAgent {
         }
 
         // Spawn the process
-        let mut command = crate::platform::spawn_command(&self.command);
+        // Detection's resolution ladder, not the daemon's inherited PATH:
+        // a CLI that reports installed must spawn.
+        let mut command =
+            super::spawn_backend_command(&super::AgentBackend::ClaudeCode, &self.command);
         command
             .args(&args)
             .current_dir(&config.working_dir)

--- a/src/bin/caller/external_agent/codex/mod.rs
+++ b/src/bin/caller/external_agent/codex/mod.rs
@@ -1317,7 +1317,9 @@ impl ExternalAgent for CodexAgent {
         // before launch.
         let effective_web_port = web_port.unwrap_or(8765);
         let args = self.app_server_args(effective_web_port);
-        let mut command = crate::platform::spawn_command(&self.command);
+        // Detection's resolution ladder, not the daemon's inherited PATH:
+        // a CLI that reports installed must spawn.
+        let mut command = super::spawn_backend_command(&super::AgentBackend::Codex, &self.command);
         command
             .args(&args)
             .current_dir(&config.working_dir)

--- a/src/bin/caller/external_agent/kimi_code/mod.rs
+++ b/src/bin/caller/external_agent/kimi_code/mod.rs
@@ -1523,7 +1523,12 @@ impl ExternalAgent for KimiCodeAgent {
                 KimiServerEntrypoint::ServerRun => HashSet::new(),
                 KimiServerEntrypoint::Web => capture_server_instance_baseline(&bridge_home).await?,
             };
-            let mut command = crate::platform::spawn_command(&self.command);
+            // Detection's resolution ladder, not the daemon's inherited
+            // PATH: a CLI that reports installed must spawn (the one-click
+            // installer lands in ~/.kimi-code/bin, which the running
+            // daemon's PATH never carries).
+            let mut command =
+                super::spawn_backend_command(&super::AgentBackend::Kimi, &self.command);
             command
                 .args(entrypoint.args())
                 .current_dir(&config.working_dir)

--- a/src/bin/caller/external_agent/mod.rs
+++ b/src/bin/caller/external_agent/mod.rs
@@ -1214,14 +1214,16 @@ pub struct BackendAvailability {
     /// Passive, zero-additional-quota compatibility evidence for the exact
     /// configured executable artifact and current adapter contract.
     pub compatibility: protocol_watch::PassiveCompatibilityStatus,
-    /// The honest explanation when `installed` is false but the CLI *is*
-    /// present in a well-known install directory the daemon's inherited
-    /// `PATH` does not carry (`platform::off_path_install_probe`): the
-    /// startup-only `ensure_tool_paths` augmentation cannot see a
-    /// directory the install itself created (the Windows npm-shim
-    /// footgun; a first Homebrew install on macOS), so a re-probe keeps
-    /// failing until the daemon restarts — and the payload says so
-    /// instead of serving a bare not-found.
+    /// The honest explanation for a bare-name command that is genuinely
+    /// not found: not on the daemon's PATH, not at the backend's declared
+    /// installer destination (the install matrix), and not in any
+    /// well-known install directory (`platform::off_path_install_probe`)
+    /// — detection and launch resolve through all of those, so a CLI
+    /// present in any of them reports `installed` and needs no hint or
+    /// restart. What survives here is the custom-location remedy: add
+    /// that directory to the daemon's PATH and restart. `None` when
+    /// installed, or when the configured command is an explicit path
+    /// (PATH is not the story for one exact missing file).
     pub path_hint: Option<String>,
 }
 
@@ -1280,6 +1282,89 @@ fn pi_local_login_in(env_pi_home: Option<std::ffi::OsString>, home: &Path) -> Op
     Some(pi_home.join("auth.json").is_file())
 }
 
+/// Where a backend's configured command actually lives — the one
+/// resolution ladder detection, the compatibility fingerprint, and
+/// launch all share, so "detection says installed but launch can't find
+/// it" is impossible by construction:
+///
+/// 1. the daemon's `PATH` (explicit paths are checked directly here);
+/// 2. the backend's declared installer destinations
+///    ([`crate::backend_install`]'s matrix — e.g. `~/.kimi-code/bin`,
+///    which a one-click install creates *after* the daemon inherited its
+///    PATH, so no restart can be required);
+/// 3. the generic well-known install directories the PATH-hint probe
+///    consults (`platform::off_path_install_probe` — npm shims, cargo
+///    bin, Homebrew, scoop/winget).
+///
+/// Stat-only; never executes anything. The transport edge resolves the
+/// real environment; [`resolve_backend_command_path_in`] injects it.
+pub(crate) fn resolve_backend_command_path(
+    backend: &AgentBackend,
+    command: &str,
+) -> Option<PathBuf> {
+    resolve_backend_command_path_in(
+        backend,
+        command,
+        std::env::var_os("PATH"),
+        &crate::platform::home_dir(),
+    )
+}
+
+/// `PATH` and the home directory injected (tests-are-hermetic).
+fn resolve_backend_command_path_in(
+    backend: &AgentBackend,
+    command: &str,
+    path_var: Option<std::ffi::OsString>,
+    home: &Path,
+) -> Option<PathBuf> {
+    if let Some(found) = crate::platform::resolve_command_path_in(command, path_var.clone()) {
+        return Some(found);
+    }
+    // Only bare names get the install-dir rungs: an explicit path in the
+    // config points at one exact file (the same rule as the off-PATH
+    // probe), and `~` expansion above already consulted the real home.
+    let command = command.trim();
+    if command.is_empty()
+        || command == "~"
+        || command.starts_with("~/")
+        || Path::new(command).is_absolute()
+        || Path::new(command).components().count() > 1
+    {
+        return None;
+    }
+    if let Some(platform) = crate::backend_install::InstallPlatform::current() {
+        for dir in crate::backend_install::declared_install_dirs(backend, platform, home) {
+            if let Some(found) = crate::platform::executable_in_dir(&dir, command) {
+                return Some(found);
+            }
+        }
+    }
+    crate::platform::off_path_install_probe_in(command, path_var, home).map(|hit| hit.found)
+}
+
+/// The program string a spawn should exec for `backend`'s configured
+/// `command`: the ladder-resolved absolute path when it resolves, the
+/// command verbatim when it doesn't — so the eventual spawn error stays
+/// the honest NotFound instead of this helper inventing one.
+pub(crate) fn launch_program(backend: &AgentBackend, command: &str) -> String {
+    resolve_backend_command_path(backend, command)
+        .map(|path| path.to_string_lossy().into_owned())
+        .unwrap_or_else(|| command.to_string())
+}
+
+/// Build the spawn command for a backend CLI through the shared
+/// resolution ladder — the launch half of the detection contract. All
+/// backend-process spawns (wrapper adapters, the voice app-server, the
+/// Codex Cloud CLI lane) go through here rather than handing the bare
+/// configured name to the OS, which only searches the daemon's
+/// launch-time `PATH`.
+pub(crate) fn spawn_backend_command(
+    backend: &AgentBackend,
+    command: &str,
+) -> tokio::process::Command {
+    crate::platform::spawn_command(&launch_program(backend, command))
+}
+
 /// Probe every supported backend. Stat-based (never executes the CLIs),
 /// so it is cheap enough to answer a dashboard request directly. Reads
 /// the persisted project config only — a runtime `set_codex_command`
@@ -1303,7 +1388,12 @@ pub fn backend_availability(
             AgentBackend::Kimi => agent_config.kimi.command.clone(),
             AgentBackend::Pi => agent_config.pi.command.clone(),
         };
-        let mut installed = crate::platform::resolve_command_path(&command).is_some();
+        // The same ladder launch resolves through (PATH, then the
+        // declared installer destinations, then the generic well-known
+        // install dirs): `installed` is a promise that spawning works.
+        let path_var = std::env::var_os("PATH");
+        let mut installed =
+            resolve_backend_command_path_in(&backend, &command, path_var.clone(), home).is_some();
         if !installed && backend == AgentBackend::Codex {
             // Managed sessions spawn the Intendant-aware fork instead
             // of `command`; either binary makes the backend usable.
@@ -1311,7 +1401,9 @@ pub fn backend_availability(
                 .codex
                 .managed_command
                 .as_deref()
-                .is_some_and(|cmd| crate::platform::resolve_command_path(cmd).is_some());
+                .is_some_and(|cmd| {
+                    resolve_backend_command_path_in(&backend, cmd, path_var.clone(), home).is_some()
+                });
         }
         let last_used_secs =
             crate::external_wrapper_index::wrappers_for_source(home, backend.as_short_str())
@@ -1350,7 +1442,7 @@ pub fn backend_availability(
         let path_hint = if installed {
             None
         } else {
-            path_inheritance_hint(&command)
+            path_inheritance_hint(&backend, &command, home)
         };
         BackendAvailability {
             backend,
@@ -1366,29 +1458,47 @@ pub fn backend_availability(
     .collect()
 }
 
-/// The PATH-inheritance explanation for a backend whose configured bare
-/// command failed to resolve: when the CLI actually exists in a
-/// well-known install directory the daemon's `PATH` (inherited at daemon
-/// start, augmented once by `ensure_tool_paths`) does not carry, name
-/// where it was found and the remedy — the same honest-refusal
-/// convention as the update lane's toolchain resolution. `None` when the
-/// CLI genuinely isn't anywhere we know to look (or the command is an
-/// explicit path, where PATH is not the story).
-fn path_inheritance_hint(command: &str) -> Option<String> {
-    let hit = crate::platform::off_path_install_probe(command)?;
-    Some(path_inheritance_hint_copy(command, &hit))
+/// The honest explanation for a bare-name command that is genuinely not
+/// found anywhere the daemon knows to look — the resolution ladder
+/// already searched the PATH, the backend's declared installer
+/// destination, and the generic well-known install directories, so the
+/// only surviving remedy is the custom-location one. Names the declared
+/// destination (derived from the install matrix — the same declaration
+/// resolution consults) so an owner who installed by hand knows where a
+/// no-restart pickup would have landed. `None` for explicit-path
+/// commands, where PATH is not the story: the config points at one exact
+/// missing file, and that absence is its own message.
+fn path_inheritance_hint(backend: &AgentBackend, command: &str, home: &Path) -> Option<String> {
+    let command = command.trim();
+    if command.is_empty()
+        || command == "~"
+        || command.starts_with("~/")
+        || Path::new(command).is_absolute()
+        || Path::new(command).components().count() > 1
+    {
+        return None;
+    }
+    let declared = crate::backend_install::InstallPlatform::current()
+        .map(|platform| crate::backend_install::declared_install_dirs(backend, platform, home))
+        .unwrap_or_default();
+    Some(path_inheritance_hint_copy(command, declared.first()))
 }
 
-/// Pure wording half, split from the ambient-PATH probe for hermetic
-/// tests.
-fn path_inheritance_hint_copy(command: &str, hit: &crate::platform::OffPathInstall) -> String {
+/// Pure wording half, split from the platform/home resolution for
+/// hermetic tests.
+fn path_inheritance_hint_copy(command: &str, declared_dir: Option<&PathBuf>) -> String {
+    let searched = match declared_dir {
+        Some(dir) => format!(
+            "the daemon's PATH, its installer's destination ({}), or the other well-known \
+             install directories",
+            dir.display()
+        ),
+        None => "the daemon's PATH or the well-known install directories".to_string(),
+    };
     format!(
-        "{} is installed at {}, but {} is not on the daemon's PATH (inherited when the daemon \
-         started) — restart the Intendant daemon to pick it up, or launch it from a shell where \
-         that directory is on PATH.",
-        command,
-        hit.found.display(),
-        hit.dir.display()
+        "{command} was not found on {searched}. Installs into those locations are picked up \
+         automatically — if it is installed somewhere custom, add that directory to the \
+         daemon's PATH and restart the Intendant daemon."
     )
 }
 
@@ -3030,37 +3140,265 @@ mod tests {
         }
     }
 
-    /// The PATH-inheritance hint names the found executable, the
-    /// off-PATH directory, and the restart remedy — the honest copy the
-    /// picker tooltip and the Vault card render verbatim when a fresh
-    /// install stays invisible to the daemon's boot-time PATH.
-    #[test]
-    fn path_inheritance_hint_names_found_dir_and_remedy() {
-        let hit = crate::platform::OffPathInstall {
-            found: std::path::Path::new("install-dir").join("codex"),
-            dir: std::path::PathBuf::from("install-dir"),
+    /// A test executable dropped into `dir` under the platform's
+    /// resolvable name (Windows resolution probes `.exe`).
+    fn place_executable(dir: &Path, name: &str) -> PathBuf {
+        std::fs::create_dir_all(dir).unwrap();
+        let path = if cfg!(windows) {
+            dir.join(format!("{name}.exe"))
+        } else {
+            dir.join(name)
         };
-        let copy = path_inheritance_hint_copy("codex", &hit);
-        for needle in [
-            "codex is installed at ",
-            "is not on the daemon's PATH",
-            "inherited when the daemon started",
-            "restart the Intendant daemon",
-        ] {
-            assert!(copy.contains(needle), "hint copy lost {needle:?}: {copy}");
+        std::fs::write(&path, b"#!/bin/sh\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
         }
-        // Absent commands stay hintless: the plain not-found copy is the
-        // honest message when the CLI is nowhere we know to look.
-        let missing = backend_availability(
-            &{
-                let mut config = crate::project::ExternalAgentConfig::default();
-                config.codex.command = "intendant-test-absent-codex".to_string();
-                config.codex.managed_command = None;
-                config
-            },
-            tempfile::tempdir().unwrap().path(),
+        path
+    }
+
+    /// The backend's declared installer destination on THIS platform —
+    /// tests build their fixtures through the same declaration the
+    /// ladder consults, so they hold on all three CI hosts.
+    fn declared_dir(backend: &AgentBackend, home: &Path) -> PathBuf {
+        crate::backend_install::declared_install_dirs(
+            backend,
+            crate::backend_install::InstallPlatform::current().unwrap(),
+            home,
+        )
+        .remove(0)
+    }
+
+    /// The resolution ladder, rung by rung (hermetic: PATH and home are
+    /// injected): a PATH hit wins outright; the declared installer
+    /// destination answers when PATH misses; the generic well-known
+    /// install dirs are the final rung; nothing anywhere is None.
+    #[test]
+    fn backend_resolution_ladder_path_then_declared_then_known_dirs() {
+        let home = tempfile::tempdir().unwrap();
+        let path_dir = tempfile::tempdir().unwrap();
+        let path_var = Some(path_dir.path().as_os_str().to_os_string());
+        let kimi_dir = declared_dir(&AgentBackend::Kimi, home.path());
+
+        // Rung 2: PATH misses, the declared installer destination hits —
+        // the 2026-08-11 incident shape (one-click install into
+        // ~/.kimi-code/bin, daemon PATH inherited before it existed).
+        let installed = place_executable(&kimi_dir, "intendant-test-ladder-kimi");
+        assert_eq!(
+            resolve_backend_command_path_in(
+                &AgentBackend::Kimi,
+                "intendant-test-ladder-kimi",
+                path_var.clone(),
+                home.path(),
+            ),
+            Some(installed.clone())
         );
-        assert_eq!(missing[0].path_hint, None);
+
+        // Rung 1 wins over rung 2 when both have the binary.
+        let on_path = place_executable(path_dir.path(), "intendant-test-ladder-kimi");
+        assert_eq!(
+            resolve_backend_command_path_in(
+                &AgentBackend::Kimi,
+                "intendant-test-ladder-kimi",
+                path_var.clone(),
+                home.path(),
+            ),
+            Some(on_path)
+        );
+
+        // Rung 3: a dir the generic off-PATH probe knows (cargo bin) but
+        // no matrix cell declares.
+        let cargo_bin = home.path().join(".cargo").join("bin");
+        let generic = place_executable(&cargo_bin, "intendant-test-ladder-generic");
+        assert_eq!(
+            resolve_backend_command_path_in(
+                &AgentBackend::Codex,
+                "intendant-test-ladder-generic",
+                path_var.clone(),
+                home.path(),
+            ),
+            Some(generic)
+        );
+
+        // Nowhere: genuinely not installed.
+        assert_eq!(
+            resolve_backend_command_path_in(
+                &AgentBackend::Kimi,
+                "intendant-test-ladder-absent",
+                path_var.clone(),
+                home.path(),
+            ),
+            None
+        );
+
+        // Explicit paths never get the install-dir rungs: the config
+        // points at one exact file.
+        let explicit_missing = home
+            .path()
+            .join("elsewhere")
+            .join("intendant-test-ladder-kimi");
+        assert_eq!(
+            resolve_backend_command_path_in(
+                &AgentBackend::Kimi,
+                &explicit_missing.to_string_lossy(),
+                path_var,
+                home.path(),
+            ),
+            None
+        );
+    }
+
+    /// Declared-dir hits require the execute bit — a plain file at the
+    /// destination is not an install.
+    #[cfg(unix)]
+    #[test]
+    fn backend_resolution_ladder_requires_the_execute_bit() {
+        let home = tempfile::tempdir().unwrap();
+        let kimi_dir = declared_dir(&AgentBackend::Kimi, home.path());
+        std::fs::create_dir_all(&kimi_dir).unwrap();
+        std::fs::write(kimi_dir.join("intendant-test-ladder-noexec"), b"data").unwrap();
+        assert_eq!(
+            resolve_backend_command_path_in(
+                &AgentBackend::Kimi,
+                "intendant-test-ladder-noexec",
+                None,
+                home.path(),
+            ),
+            None
+        );
+    }
+
+    /// Launch runs the binary detection found: `launch_program` is the
+    /// same ladder collapsed to a spawnable string, and the incident
+    /// shape (installed only in the declared dir) yields that exact
+    /// absolute path. Unresolvable commands pass through verbatim so the
+    /// spawn error stays the honest NotFound. Hermetic via the injected
+    /// core the public edge wraps.
+    #[test]
+    fn launch_uses_the_detection_resolved_path() {
+        let home = tempfile::tempdir().unwrap();
+        let kimi_dir = declared_dir(&AgentBackend::Kimi, home.path());
+        let installed = place_executable(&kimi_dir, "intendant-test-launch-kimi");
+
+        let detected = resolve_backend_command_path_in(
+            &AgentBackend::Kimi,
+            "intendant-test-launch-kimi",
+            None,
+            home.path(),
+        )
+        .expect("the declared dir resolves");
+        assert_eq!(
+            detected, installed,
+            "detection finds the declared-dir install"
+        );
+
+        // The launch half: same ladder, same inputs, same absolute path —
+        // detection-says-installed while launch-misses is impossible.
+        let program = resolve_backend_command_path_in(
+            &AgentBackend::Kimi,
+            "intendant-test-launch-kimi",
+            None,
+            home.path(),
+        )
+        .map(|path| path.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "intendant-test-launch-kimi".to_string());
+        assert_eq!(program, installed.to_string_lossy());
+
+        // The public edge agrees with the core on a command the real
+        // environment cannot resolve (unique name, nothing planted):
+        // verbatim passthrough.
+        assert_eq!(
+            launch_program(&AgentBackend::Kimi, "intendant-test-launch-absent"),
+            "intendant-test-launch-absent"
+        );
+    }
+
+    /// End to end through `backend_availability` (the incident pin): a
+    /// one-click install into the declared destination reports installed
+    /// on the next probe — no PATH surgery, no daemon restart — and
+    /// carries no hint. The genuinely-absent backends keep the narrowed
+    /// custom-location hint.
+    #[test]
+    fn availability_reports_declared_dir_installs_without_restart() {
+        let home = tempfile::tempdir().unwrap();
+        let kimi_dir = declared_dir(&AgentBackend::Kimi, home.path());
+        place_executable(&kimi_dir, "intendant-test-availability-kimi");
+
+        let mut config = crate::project::ExternalAgentConfig::default();
+        config.codex.command = "intendant-test-absent-codex".to_string();
+        config.codex.managed_command = None;
+        config.claude_code.command = "intendant-test-absent-claude".to_string();
+        config.kimi.command = "intendant-test-availability-kimi".to_string();
+        config.pi.command = "intendant-test-absent-pi".to_string();
+
+        let availability = backend_availability(&config, home.path());
+        let kimi = &availability[2];
+        assert_eq!(kimi.backend, AgentBackend::Kimi);
+        assert!(
+            kimi.installed,
+            "an install into the declared destination is installed NOW, not after a restart"
+        );
+        assert_eq!(kimi.path_hint, None, "installed backends carry no hint");
+
+        let codex = &availability[0];
+        assert!(!codex.installed);
+        let hint = codex
+            .path_hint
+            .as_deref()
+            .expect("bare missing commands get the hint");
+        for needle in [
+            "intendant-test-absent-codex was not found on the daemon's PATH",
+            "its installer's destination",
+            "picked up automatically",
+            "add that directory to the daemon's PATH and restart the Intendant daemon",
+        ] {
+            assert!(hint.contains(needle), "hint copy lost {needle:?}: {hint}");
+        }
+    }
+
+    /// The narrowed hint fires only where PATH is the story: bare names
+    /// get the genuinely-not-found copy (naming the declared destination
+    /// when the matrix has one), explicit paths stay hintless.
+    #[test]
+    fn path_inheritance_hint_narrows_to_genuinely_not_found() {
+        let home = tempfile::tempdir().unwrap();
+        let hint =
+            path_inheritance_hint(&AgentBackend::Kimi, "intendant-test-hint-kimi", home.path())
+                .expect("bare names get the hint");
+        assert!(
+            hint.contains(
+                &declared_dir(&AgentBackend::Kimi, home.path())
+                    .display()
+                    .to_string()
+            ),
+            "the hint names the matrix-declared destination: {hint}"
+        );
+
+        // No matrix lane (Pi): the generic wording, no destination named.
+        let pi_hint =
+            path_inheritance_hint(&AgentBackend::Pi, "intendant-test-hint-pi", home.path())
+                .expect("laneless backends still get the generic hint");
+        assert!(pi_hint.contains("the daemon's PATH or the well-known install directories"));
+        assert!(!pi_hint.contains("its installer's destination"));
+
+        // Explicit paths: PATH is not the story.
+        for explicit in [
+            home.path()
+                .join("bin")
+                .join("kimi")
+                .to_string_lossy()
+                .into_owned(),
+            "~/.kimi-code/bin/kimi".to_string(),
+            "rel/kimi".to_string(),
+            String::new(),
+        ] {
+            assert_eq!(
+                path_inheritance_hint(&AgentBackend::Kimi, &explicit, home.path()),
+                None,
+                "explicit path {explicit:?} must stay hintless"
+            );
+        }
     }
 
     #[test]

--- a/src/bin/caller/external_agent/pi.rs
+++ b/src/bin/caller/external_agent/pi.rs
@@ -507,7 +507,9 @@ impl ExternalAgent for PiAgent {
             &self.launch,
         )?;
 
-        let mut command = crate::platform::spawn_command(&self.command);
+        // Detection's resolution ladder, not the daemon's inherited PATH:
+        // a CLI that reports installed must spawn.
+        let mut command = super::spawn_backend_command(&super::AgentBackend::Pi, &self.command);
         command
             .args(&args)
             .current_dir(&config.working_dir)

--- a/src/bin/caller/external_agent/protocol_watch.rs
+++ b/src/bin/caller/external_agent/protocol_watch.rs
@@ -1538,8 +1538,16 @@ pub(crate) struct ExecutableFingerprint {
     pub(crate) digest: String,
 }
 
-pub(crate) fn executable_fingerprint(command: &str) -> Option<ExecutableFingerprint> {
-    let resolved = crate::platform::resolve_command_path(command)?;
+/// Fingerprint the executable `command` resolves to for `backend` — the
+/// same ladder detection and launch use (PATH, declared installer
+/// destinations, generic install dirs), so the `resolved_path` this
+/// carries into the compatibility payload names the binary that will
+/// actually spawn.
+pub(crate) fn executable_fingerprint(
+    backend: &AgentBackend,
+    command: &str,
+) -> Option<ExecutableFingerprint> {
+    let resolved = crate::external_agent::resolve_backend_command_path(backend, command)?;
     let canonical = std::fs::canonicalize(&resolved).unwrap_or_else(|_| resolved.clone());
     let file = std::fs::File::open(&canonical).ok()?;
     let metadata = file.metadata().ok()?;
@@ -1712,7 +1720,7 @@ impl ProtocolWatchHandle {
         profile: &str,
         command: &str,
     ) -> Option<Self> {
-        let artifact = executable_fingerprint(command)?;
+        let artifact = executable_fingerprint(&backend, command)?;
         let manifest_digest = manifest_digest(&backend);
         let profile = profile_key(profile).to_string();
         let contract_path = contract_dir(
@@ -2263,7 +2271,7 @@ pub(crate) fn passive_status_in(
     command: &str,
 ) -> PassiveCompatibilityStatus {
     let contract_digest = manifest_digest(backend);
-    let Some(artifact) = executable_fingerprint(command) else {
+    let Some(artifact) = executable_fingerprint(backend, command) else {
         return PassiveCompatibilityStatus {
             state: PassiveCompatibilityState::Unobserved,
             coverage: "passive",

--- a/src/bin/caller/kimi_auth_ceremony.rs
+++ b/src/bin/caller/kimi_auth_ceremony.rs
@@ -309,7 +309,8 @@ fn spawn_ceremony_process(id: u64, command: &str, primary_home: PathBuf) -> Resu
             pixel_height: 0,
         })
         .map_err(|error| format!("openpty: {error}"))?;
-    let (program, mut args) = pty_program_invocation(command);
+    let (program, mut args) =
+        pty_program_invocation(&crate::external_agent::AgentBackend::Kimi, command);
     args.push("login".to_string());
     let mut cmd = portable_pty::CommandBuilder::new(&program);
     cmd.args(&args);

--- a/src/bin/caller/voice_broker/app_server.rs
+++ b/src/bin/caller/voice_broker/app_server.rs
@@ -353,7 +353,12 @@ impl VoiceAppServer {
     ) -> Result<Self, String> {
         std::fs::create_dir_all(neutral_cwd)
             .map_err(|e| format!("create neutral cwd {}: {e}", neutral_cwd.display()))?;
-        let mut cmd = crate::platform::spawn_command(command);
+        // The codex CLI through detection's resolution ladder, not the
+        // daemon's inherited PATH — same contract as the wrapper spawns.
+        let mut cmd = crate::external_agent::spawn_backend_command(
+            &crate::external_agent::AgentBackend::Codex,
+            command,
+        );
         cmd.args(voice_app_server_args())
             .current_dir(neutral_cwd)
             .stdin(std::process::Stdio::piped())

--- a/static/app.html
+++ b/static/app.html
@@ -39272,7 +39272,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '89f0818a4a3c7497';
+const INTENDANT_APP_BUILD = '798ca131451bbe49';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -45808,13 +45808,16 @@ function agentInstallSection(card, spec, missing, note, actionsRow) {
   }
   if (state === 'succeeded') {
     // Still on the not-installed card after a finished install: the
-    // PATH-inheritance footgun — the daemon inherited PATH at launch, so
-    // a fresh install dir may not resolve until PATH carries it.
+    // daemon resolves through its PATH, the installer's declared
+    // destination, and the well-known install dirs — so reaching this
+    // state means the CLI landed somewhere genuinely custom. Known
+    // locations flip the card automatically on the next probe.
     const el = note(
-      'The installer finished, but the CLI still does not resolve on the ' +
-        "daemon's PATH. The daemon inherited its PATH at launch — add the " +
-        'install directory to PATH and restart the daemon, or restart your ' +
-        'terminal session, then this card will pick it up.',
+      'The installer finished, but the CLI still does not resolve — it is ' +
+        "not on the daemon's PATH, at the installer's usual destination, or " +
+        'in any install location the daemon checks (those are picked up ' +
+        'automatically, no restart needed). If it landed somewhere custom, ' +
+        "add that directory to the daemon's PATH and restart the daemon.",
       'vault-warning'
     );
     if (install.log_dir) el.title = `Full installer output: ${install.log_dir}`;
@@ -45993,11 +45996,11 @@ function agentSigninProviderCard(provider) {
         'was not found on the daemon host, so there is no account to sign ' +
         'in yet. Install it on the daemon machine, then sign in from here.'
     );
-    // PATH-inheritance honesty: the daemon found the CLI in a known
-    // install directory its inherited PATH doesn't carry (installed
-    // mid-run — the Windows npm-shim footgun). Surface the exact
-    // where-and-why instead of leaving "install it" to gaslight a user
-    // who just did.
+    // Genuinely-not-found honesty: the daemon already resolved through
+    // its PATH, the installer's declared destination, and the well-known
+    // install dirs (a CLI in any of those reports installed — no restart
+    // needed), so the surviving hint names where it looked and the
+    // custom-location remedy.
     if (missing.path_hint) note(String(missing.path_hint));
     agentInstallSection(card, spec, missing, note, actionsRow);
     return card;

--- a/static/app/32-vault-custody.js
+++ b/static/app/32-vault-custody.js
@@ -2301,13 +2301,16 @@ function agentInstallSection(card, spec, missing, note, actionsRow) {
   }
   if (state === 'succeeded') {
     // Still on the not-installed card after a finished install: the
-    // PATH-inheritance footgun — the daemon inherited PATH at launch, so
-    // a fresh install dir may not resolve until PATH carries it.
+    // daemon resolves through its PATH, the installer's declared
+    // destination, and the well-known install dirs — so reaching this
+    // state means the CLI landed somewhere genuinely custom. Known
+    // locations flip the card automatically on the next probe.
     const el = note(
-      'The installer finished, but the CLI still does not resolve on the ' +
-        "daemon's PATH. The daemon inherited its PATH at launch — add the " +
-        'install directory to PATH and restart the daemon, or restart your ' +
-        'terminal session, then this card will pick it up.',
+      'The installer finished, but the CLI still does not resolve — it is ' +
+        "not on the daemon's PATH, at the installer's usual destination, or " +
+        'in any install location the daemon checks (those are picked up ' +
+        'automatically, no restart needed). If it landed somewhere custom, ' +
+        "add that directory to the daemon's PATH and restart the daemon.",
       'vault-warning'
     );
     if (install.log_dir) el.title = `Full installer output: ${install.log_dir}`;
@@ -2486,11 +2489,11 @@ function agentSigninProviderCard(provider) {
         'was not found on the daemon host, so there is no account to sign ' +
         'in yet. Install it on the daemon machine, then sign in from here.'
     );
-    // PATH-inheritance honesty: the daemon found the CLI in a known
-    // install directory its inherited PATH doesn't carry (installed
-    // mid-run — the Windows npm-shim footgun). Surface the exact
-    // where-and-why instead of leaving "install it" to gaslight a user
-    // who just did.
+    // Genuinely-not-found honesty: the daemon already resolved through
+    // its PATH, the installer's declared destination, and the well-known
+    // install dirs (a CLI in any of those reports installed — no restart
+    // needed), so the surviving hint names where it looked and the
+    // custom-location remedy.
     if (missing.path_hint) note(String(missing.path_hint));
     agentInstallSection(card, spec, missing, note, actionsRow);
     return card;


### PR DESCRIPTION
A one-click Vault install must end with a usable backend (owner e2e
2026-08-11: the Kimi installer succeeded into ~/.kimi-code/bin, yet the
card demanded PATH surgery and a daemon restart). The install matrix now
declares each installer's destination dirs per platform (verified
against the live install scripts), and one shared resolution ladder —
PATH, then the declared destinations, then the generic well-known
install dirs the old PATH hint consulted — drives detection, the
compatibility fingerprint (resolved_path stays truthful), and every
backend spawn: wrapper adapters, sign-in ceremonies, the credential
watch probe, the voice app-server, and the Codex Cloud lane, so
detection-says-installed while launch-fails-to-find is impossible by
construction. The add-to-PATH-and-restart copy narrows to the genuinely
custom-location case; installs into known locations are picked up on the
next availability probe with no restart.
