### PR TITLE
macos app: route window.open and external links to the system browser

### DIFF
--- a/macos-app/main.swift
+++ b/macos-app/main.swift
@@ -767,7 +767,75 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
         // stay silent; the menu item remains available.
     }
 
-    // MARK: - WKUIDelegate (JS alert/confirm/prompt)
+    // MARK: - External links (system browser)
+
+    /// Whether `url` stays inside the app's own dashboard world: the
+    /// `intendant://` proxy scheme, the wrapper's generated pages
+    /// (about:blank via loadHTMLString) and in-page content schemes, and
+    /// anything on loopback — the supervised daemon in every TLS/WS/port
+    /// shape, co-homed sibling daemons included.
+    func isDashboardOrigin(_ url: URL) -> Bool {
+        guard let scheme = url.scheme?.lowercased() else { return true }
+        if ["intendant", "about", "data", "blob", "file", "javascript"].contains(scheme) {
+            return true
+        }
+        let host = url.host?.lowercased() ?? ""
+        return host == "localhost" || host.hasSuffix(".localhost")
+            || host == "127.0.0.1" || host == "::1" || host == "[::1]"
+    }
+
+    /// Map a webview-internal URL to what the system browser should get.
+    /// `intendant://backend/...` is the proxy origin — its real address is
+    /// the supervised daemon on loopback (an explicit port in the URL
+    /// survives, so co-homed sibling links keep working; the default is
+    /// the supervised port). Pure in-page schemes yield nil (nothing a
+    /// browser could open).
+    func systemBrowserURL(for url: URL?) -> URL? {
+        guard let url = url, let scheme = url.scheme?.lowercased(), !scheme.isEmpty else {
+            return nil
+        }
+        if ["about", "data", "blob", "javascript"].contains(scheme) { return nil }
+        if scheme == "intendant" {
+            var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+            components?.scheme = launchPlan.scheme
+            components?.host = "127.0.0.1"
+            components?.port = url.port ?? port
+            return components?.url
+        }
+        return url
+    }
+
+    /// Hand a URL out of the webview to the user's default browser.
+    /// Sign-in and enrollment flows depend on the real profile (password
+    /// manager, passkeys, existing sessions) — an isolated webview window
+    /// is never the right place for them.
+    func openInSystemBrowser(_ rawURL: URL?, reason: String) {
+        guard let target = systemBrowserURL(for: rawURL) else {
+            NSLog("External open skipped (\(reason)): no browser-usable URL in \(rawURL?.absoluteString ?? "nil")")
+            return
+        }
+        NSLog("Opening in system browser (\(reason)): \(target.absoluteString)")
+        NSWorkspace.shared.open(target)
+    }
+
+    // MARK: - WKUIDelegate (popups + JS alert/confirm/prompt)
+
+    /// window.open / target=_blank from the dashboard. The app never
+    /// grows a second webview: popups are sign-in and enrollment flows
+    /// that must land in the system default browser, so the URL goes
+    /// there and nil comes back (window.open yields null). The SPA knows
+    /// this contract through the injected `__intendantAppExternalOpen`
+    /// marker and treats the null as handled instead of rendering its
+    /// popup-blocked fallback. about:blank pre-opens get nothing useful
+    /// here — under the marker the SPA skips them and opens the final
+    /// URL directly.
+    func webView(_ webView: WKWebView,
+                 createWebViewWith configuration: WKWebViewConfiguration,
+                 for navigationAction: WKNavigationAction,
+                 windowFeatures: WKWindowFeatures) -> WKWebView? {
+        openInSystemBrowser(navigationAction.request.url, reason: "popup")
+        return nil
+    }
 
     func webView(_ webView: WKWebView,
                  runJavaScriptAlertPanelWithMessage message: String,
@@ -807,6 +875,25 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
     }
 
     // MARK: - WKNavigationDelegate
+
+    /// One policy for sign-in, enrollment, and every future external
+    /// link: the dashboard main frame never navigates off its own origin
+    /// — anything else opens in the system default browser instead.
+    /// Sub-frame loads pass through untouched, as do new-window targets
+    /// (nil frame — those reach createWebViewWith above).
+    func webView(_ webView: WKWebView,
+                 decidePolicyFor navigationAction: WKNavigationAction,
+                 decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        guard let frame = navigationAction.targetFrame, frame.isMainFrame,
+              let url = navigationAction.request.url,
+              !isDashboardOrigin(url)
+        else {
+            decisionHandler(.allow)
+            return
+        }
+        decisionHandler(.cancel)
+        openInSystemBrowser(url, reason: "main-frame navigation")
+    }
 
     func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
         // macOS killed the web process (memory pressure). Restore what was
@@ -986,14 +1073,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
     /// bypass the scheme handler and need the real address), and
     /// `__intendantAppSupervisor` marks the supervisor's presence so the
     /// dashboard's update chip renders the one-click action instead of
-    /// the CLI-daemon hand-off. Re-run at update swap with the new port
+    /// the CLI-daemon hand-off. `__intendantAppExternalOpen` tells the
+    /// SPA that popups and external links are routed to the system
+    /// default browser (window.open returns null yet succeeded — see
+    /// createWebViewWith). Re-run at update swap with the new port
     /// (scripts are fixed strings, so a swap must replace them).
     func installUserScripts(_ controller: WKUserContentController, port: Int) {
         controller.removeAllUserScripts()
         let tlsLiteral = launchPlan.usesTLS ? "true" : "false"
         let portScript = WKUserScript(
             source: "window.__intendantPort = \(port); window.__intendantBackendTls = \(tlsLiteral); "
-                + "window.__intendantAppSupervisor = true;",
+                + "window.__intendantAppSupervisor = true; window.__intendantAppExternalOpen = true;",
             injectionTime: .atDocumentStart,
             forMainFrameOnly: true
         )

--- a/src/bin/caller/web_gateway/static_assets.rs
+++ b/src/bin/caller/web_gateway/static_assets.rs
@@ -1825,6 +1825,40 @@ mod tests {
         assert!(THREE_MODULE_JS.contains("Three.js Authors"));
     }
 
+    /// External-URL opener contract with the bundled macOS app: the
+    /// wrapper routes popups/external navigations to the system default
+    /// browser (sign-in needs the user's real profile), returns null from
+    /// window.open by design, and marks the capability with an injected
+    /// `__intendantAppExternalOpen`. The SPA's shared opener reads that
+    /// marker, and external window.open sites go through it so a genuinely
+    /// blocked popup renders an honest fallback instead of a silent no-op.
+    #[test]
+    fn external_url_opener_contract_is_pinned() {
+        // The shared helpers exist (foundation fragment) and read the marker.
+        assert!(APP_HTML.contains("function openExternalUrl(url)"));
+        assert!(APP_HTML.contains("function openExternalUrlOrExplain(url)"));
+        assert!(APP_HTML.contains("window.__intendantAppExternalOpen === true"));
+
+        // Agent sign-in: helper-routed open + state-driven honest fallback
+        // (state, not DOM — the 2s ceremony poll re-renders the card).
+        assert!(APP_HTML.contains("if (openExternalUrl(url)) return;"));
+        assert!(APP_HTML.contains("state.openFallback = true;"));
+        assert!(APP_HTML.contains("agent-signin-open-fallback"));
+
+        // Passkey enrollment: the gesture-preserving about:blank pre-open
+        // is skipped under the wrapper marker (it can never carry the
+        // later URL there) and the fetched URL goes through the helper.
+        assert!(APP_HTML.contains("!openExternalUrl(invitation.enrollment_url)"));
+
+        // The wrapper really injects the marker the SPA reads and carries
+        // both webview exits (popup + main-frame policy) — a rename or a
+        // dropped hook on either side fails here, not in a user's hands.
+        let wrapper = include_str!("../../../../macos-app/main.swift");
+        assert!(wrapper.contains("window.__intendantAppExternalOpen = true;"));
+        assert!(wrapper.contains("createWebViewWith configuration: WKWebViewConfiguration"));
+        assert!(wrapper.contains("decidePolicyFor navigationAction: WKNavigationAction"));
+    }
+
     #[test]
     fn live_workspace_input_is_released_before_its_surface_is_hidden() {
         fn section(start: &str, end: &str) -> &'static str {

--- a/static/app.html
+++ b/static/app.html
@@ -36715,6 +36715,47 @@ window.__ui2 = {
   enabled: ui2Enabled, icon: ui2Icon,
   theme: ui2Theme, setTheme: ui2SetTheme,
 };
+
+// ── external-URL opener ────────────────────────────────────────────────
+// window.open is not a given: the bundled macOS app's WKWebView routes
+// popups to the system default browser (sign-in flows need the user's
+// real profile — password manager, passkeys — never an isolated webview)
+// and returns null from window.open BY DESIGN; its injected
+// `__intendantAppExternalOpen` marker says "null still opened". Popup
+// blockers and older app bundles return null with no marker. Callers
+// branch on the boolean and render an honest fallback (the URL with a
+// copy affordance) instead of a silent no-op.
+function openExternalUrl(url) {
+  let popup = null;
+  try {
+    popup = window.open(url, '_blank');
+  } catch (err) {
+    popup = null;
+  }
+  if (popup) {
+    // Sever the opener by hand: the 'noopener' feature would make
+    // window.open return null even on success, hiding the outcome.
+    try { popup.opener = null; } catch (err) { /* cross-origin */ }
+    return true;
+  }
+  return window.__intendantAppExternalOpen === true;
+}
+
+// Shared fallback for call sites without their own inline URL surface:
+// copy the link and say so, or at least show it — never a silent no-op.
+function openExternalUrlOrExplain(url) {
+  if (openExternalUrl(url)) return true;
+  const link = String(url);
+  const explain = 'This view can’t open browser tabs — ';
+  if (navigator.clipboard?.writeText) {
+    navigator.clipboard.writeText(link)
+      .then(() => showControlToast?.('info', explain + 'link copied, paste it in your browser.'))
+      .catch(() => showControlToast?.('error', explain + `open ${link} in your browser.`));
+  } else {
+    showControlToast?.('error', explain + `open ${link} in your browser.`);
+  }
+  return false;
+}
 /* ── static/app/ui2-chrome.js ── */
 // ── ui-v2 chrome wiring (design-overhaul P1a) ──────────────────────────
 // Builds the nav rail's destination buttons and mirrors live state out of
@@ -39277,7 +39318,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '0c850c0554f24b9b';
+const INTENDANT_APP_BUILD = 'e81037746c5dd02d';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -42186,7 +42227,15 @@ function hostedControlRenderManagementCard() {
     if (addPasskey) {
       addPasskey.onclick = async () => {
         addPasskey.disabled = true;
-        const enrollmentWindow = window.open('about:blank', '_blank');
+        // Pre-open about:blank inside the click gesture so the popup
+        // survives blockers, then point it at the fetched URL. Skipped
+        // in the macOS app wrapper: its webview routes popups to the
+        // system browser and an about:blank pre-open can never carry
+        // the later URL — openExternalUrl below opens the real link
+        // instead (NSWorkspace needs no gesture timing).
+        const enrollmentWindow = window.__intendantAppExternalOpen === true
+          ? null
+          : window.open('about:blank', '_blank');
         if (enrollmentWindow) enrollmentWindow.opener = null;
         try {
           const label = mount.querySelector('#custom-passkey-label').value.trim();
@@ -42206,7 +42255,7 @@ function hostedControlRenderManagementCard() {
           }
           if (enrollmentWindow) {
             enrollmentWindow.location.replace(invitation.enrollment_url);
-          } else {
+          } else if (!openExternalUrl(invitation.enrollment_url)) {
             await navigator.clipboard.writeText(invitation.enrollment_url);
             showControlToast?.('info', 'Enrollment link copied. Open it before it expires.');
           }
@@ -45271,6 +45320,11 @@ function agentSigninProviderState() {
     busy: false,
     lastError: '',
     pollTimer: null,
+    // The "Open …" button could not open a tab (popup blocker, or an app
+    // wrapper predating the system-browser popup route): state, not DOM,
+    // because the 2s ceremony poll re-renders the card and would wipe an
+    // ad-hoc note. Cleared on the next ceremony start.
+    openFallback: false,
   };
 }
 const agentSigninState = {
@@ -45402,6 +45456,7 @@ async function agentSigninStart(provider) {
   // or the guard above mutes the button for the rest of the page load.
   try {
     state.lastError = '';
+    state.openFallback = false;
     renderAgentSigninSection();
     const resp = await daemonApi.request(spec.startMethod, { ...spec.startParams });
     if (resp.ok) {
@@ -46088,7 +46143,9 @@ function agentSigninProviderCard(provider) {
       openRow.className = 'vault-actions';
       openRow.appendChild(
         vaultButton(spec.openLabel, () => {
-          window.open(url, '_blank', 'noopener');
+          if (openExternalUrl(url)) return;
+          state.openFallback = true;
+          renderAgentSigninSection();
         }, { primary: true })
       );
       openRow.appendChild(
@@ -46100,6 +46157,17 @@ function agentSigninProviderCard(provider) {
         })
       );
       stepOne.appendChild(openRow);
+      if (state.openFallback) {
+        // Honest fallback when no tab opened (popup blocker, or an app
+        // wrapper predating the system-browser popup route): the link
+        // itself renders right below — point at it instead of no-oping.
+        const fallback = document.createElement('div');
+        fallback.className = 'vault-warning agent-signin-open-fallback';
+        fallback.textContent =
+          'A browser tab could not be opened from here — use Copy link ' +
+          'and open the link below in your browser.';
+        stepOne.appendChild(fallback);
+      }
       const checkNote = document.createElement('div');
       checkNote.className = 'vault-note';
       checkNote.textContent = spec.checkNote;
@@ -83682,7 +83750,7 @@ function renderAccessFleetStrip() {
       direct.title = `Open ${directUrl} — this daemon's own dashboard, no rendezvous in the loop. Works when this browser can reach it (same LAN/VPN); a self-signed daemon shows a one-time certificate warning.`;
       direct.addEventListener('click', async event => {
         event.stopPropagation();
-        window.open(await withSiblingLoopbackToken(directUrl), '_blank', 'noopener');
+        openExternalUrlOrExplain(await withSiblingLoopbackToken(directUrl));
       });
       meta.appendChild(direct);
     }
@@ -109084,7 +109152,7 @@ async function memoryProposeFromForm(button) {
       if (ev.metaKey || ev.ctrlKey || ev.shiftKey || ev.altKey || ev.button !== 0) return;
       ev.preventDefault();
       Promise.resolve(withSiblingLoopbackToken(bare)).then((url) => {
-        window.open(url, '_blank', 'noopener');
+        openExternalUrlOrExplain(url);
       });
     });
     return link;
@@ -136074,7 +136142,7 @@ function openPeerSessionExternally(s, hostId) {
     showControlToast('error', 'No reachable dashboard URL is known for this peer.');
     return;
   }
-  window.open(`${base}/#sessions`, '_blank', 'noopener');
+  if (!openExternalUrlOrExplain(`${base}/#sessions`)) return;
   const sid = String(s?.session_id || s?.resume_id || '').trim();
   if (sid) {
     showControlToast('info', `Opened ${host.label || 'peer'} dashboard — look for session ${sid.slice(0, 8)}…`);

--- a/static/app/31-ui2-foundation.js
+++ b/static/app/31-ui2-foundation.js
@@ -120,3 +120,44 @@ window.__ui2 = {
   enabled: ui2Enabled, icon: ui2Icon,
   theme: ui2Theme, setTheme: ui2SetTheme,
 };
+
+// ── external-URL opener ────────────────────────────────────────────────
+// window.open is not a given: the bundled macOS app's WKWebView routes
+// popups to the system default browser (sign-in flows need the user's
+// real profile — password manager, passkeys — never an isolated webview)
+// and returns null from window.open BY DESIGN; its injected
+// `__intendantAppExternalOpen` marker says "null still opened". Popup
+// blockers and older app bundles return null with no marker. Callers
+// branch on the boolean and render an honest fallback (the URL with a
+// copy affordance) instead of a silent no-op.
+function openExternalUrl(url) {
+  let popup = null;
+  try {
+    popup = window.open(url, '_blank');
+  } catch (err) {
+    popup = null;
+  }
+  if (popup) {
+    // Sever the opener by hand: the 'noopener' feature would make
+    // window.open return null even on success, hiding the outcome.
+    try { popup.opener = null; } catch (err) { /* cross-origin */ }
+    return true;
+  }
+  return window.__intendantAppExternalOpen === true;
+}
+
+// Shared fallback for call sites without their own inline URL surface:
+// copy the link and say so, or at least show it — never a silent no-op.
+function openExternalUrlOrExplain(url) {
+  if (openExternalUrl(url)) return true;
+  const link = String(url);
+  const explain = 'This view can’t open browser tabs — ';
+  if (navigator.clipboard?.writeText) {
+    navigator.clipboard.writeText(link)
+      .then(() => showControlToast?.('info', explain + 'link copied, paste it in your browser.'))
+      .catch(() => showControlToast?.('error', explain + `open ${link} in your browser.`));
+  } else {
+    showControlToast?.('error', explain + `open ${link} in your browser.`);
+  }
+  return false;
+}

--- a/static/app/31b-hosted-control.js
+++ b/static/app/31b-hosted-control.js
@@ -902,7 +902,15 @@ function hostedControlRenderManagementCard() {
     if (addPasskey) {
       addPasskey.onclick = async () => {
         addPasskey.disabled = true;
-        const enrollmentWindow = window.open('about:blank', '_blank');
+        // Pre-open about:blank inside the click gesture so the popup
+        // survives blockers, then point it at the fetched URL. Skipped
+        // in the macOS app wrapper: its webview routes popups to the
+        // system browser and an about:blank pre-open can never carry
+        // the later URL — openExternalUrl below opens the real link
+        // instead (NSWorkspace needs no gesture timing).
+        const enrollmentWindow = window.__intendantAppExternalOpen === true
+          ? null
+          : window.open('about:blank', '_blank');
         if (enrollmentWindow) enrollmentWindow.opener = null;
         try {
           const label = mount.querySelector('#custom-passkey-label').value.trim();
@@ -922,7 +930,7 @@ function hostedControlRenderManagementCard() {
           }
           if (enrollmentWindow) {
             enrollmentWindow.location.replace(invitation.enrollment_url);
-          } else {
+          } else if (!openExternalUrl(invitation.enrollment_url)) {
             await navigator.clipboard.writeText(invitation.enrollment_url);
             showControlToast?.('info', 'Enrollment link copied. Open it before it expires.');
           }

--- a/static/app/32-vault-custody.js
+++ b/static/app/32-vault-custody.js
@@ -1759,6 +1759,11 @@ function agentSigninProviderState() {
     busy: false,
     lastError: '',
     pollTimer: null,
+    // The "Open …" button could not open a tab (popup blocker, or an app
+    // wrapper predating the system-browser popup route): state, not DOM,
+    // because the 2s ceremony poll re-renders the card and would wipe an
+    // ad-hoc note. Cleared on the next ceremony start.
+    openFallback: false,
   };
 }
 const agentSigninState = {
@@ -1890,6 +1895,7 @@ async function agentSigninStart(provider) {
   // or the guard above mutes the button for the rest of the page load.
   try {
     state.lastError = '';
+    state.openFallback = false;
     renderAgentSigninSection();
     const resp = await daemonApi.request(spec.startMethod, { ...spec.startParams });
     if (resp.ok) {
@@ -2576,7 +2582,9 @@ function agentSigninProviderCard(provider) {
       openRow.className = 'vault-actions';
       openRow.appendChild(
         vaultButton(spec.openLabel, () => {
-          window.open(url, '_blank', 'noopener');
+          if (openExternalUrl(url)) return;
+          state.openFallback = true;
+          renderAgentSigninSection();
         }, { primary: true })
       );
       openRow.appendChild(
@@ -2588,6 +2596,17 @@ function agentSigninProviderCard(provider) {
         })
       );
       stepOne.appendChild(openRow);
+      if (state.openFallback) {
+        // Honest fallback when no tab opened (popup blocker, or an app
+        // wrapper predating the system-browser popup route): the link
+        // itself renders right below — point at it instead of no-oping.
+        const fallback = document.createElement('div');
+        fallback.className = 'vault-warning agent-signin-open-fallback';
+        fallback.textContent =
+          'A browser tab could not be opened from here — use Copy link ' +
+          'and open the link below in your browser.';
+        stepOne.appendChild(fallback);
+      }
       const checkNote = document.createElement('div');
       checkNote.className = 'vault-note';
       checkNote.textContent = spec.checkNote;

--- a/static/app/43-access-panes.js
+++ b/static/app/43-access-panes.js
@@ -830,7 +830,7 @@ function renderAccessFleetStrip() {
       direct.title = `Open ${directUrl} — this daemon's own dashboard, no rendezvous in the loop. Works when this browser can reach it (same LAN/VPN); a self-signed daemon shows a one-time certificate warning.`;
       direct.addEventListener('click', async event => {
         event.stopPropagation();
-        window.open(await withSiblingLoopbackToken(directUrl), '_blank', 'noopener');
+        openExternalUrlOrExplain(await withSiblingLoopbackToken(directUrl));
       });
       meta.appendChild(direct);
     }

--- a/static/app/56-debug-sessions.js
+++ b/static/app/56-debug-sessions.js
@@ -479,7 +479,7 @@ function openPeerSessionExternally(s, hostId) {
     showControlToast('error', 'No reachable dashboard URL is known for this peer.');
     return;
   }
-  window.open(`${base}/#sessions`, '_blank', 'noopener');
+  if (!openExternalUrlOrExplain(`${base}/#sessions`)) return;
   const sid = String(s?.session_id || s?.resume_id || '').trim();
   if (sid) {
     showControlToast('info', `Opened ${host.label || 'peer'} dashboard — look for session ${sid.slice(0, 8)}…`);

--- a/static/app/ui2-handover.js
+++ b/static/app/ui2-handover.js
@@ -1560,7 +1560,7 @@
       if (ev.metaKey || ev.ctrlKey || ev.shiftKey || ev.altKey || ev.button !== 0) return;
       ev.preventDefault();
       Promise.resolve(withSiblingLoopbackToken(bare)).then((url) => {
-        window.open(url, '_blank', 'noopener');
+        openExternalUrlOrExplain(url);
       });
     });
     return link;


### PR DESCRIPTION
The bundled app's WKWebView had no createWebViewWith hook, so every
window.open — Kimi/Claude/Codex sign-in, passkey enrollment — silently
did nothing. Sign-in must land in the system default browser (the
user's real profile: password manager, passkeys), never an isolated
webview window.

Wrapper: createWebViewWith routes popup URLs to NSWorkspace and returns
nil; a decidePolicyFor main-frame policy sends every non-dashboard
origin (not intendant:// proxy, not loopback) the same way, one policy
for all future external links; intendant:// popup URLs are rewritten to
the daemon's real loopback address. The injected
__intendantAppExternalOpen marker tells the SPA that a null window.open
still opened.

SPA: shared openExternalUrl/openExternalUrlOrExplain helpers replace
raw window.open at the external sites (agent sign-in, passkey
enrollment, fleet direct links, peer dashboard hand-off, handover
successor links). A blocked popup now renders an honest fallback —
state-driven on the sign-in card (the 2s ceremony poll re-renders it),
copy-link toast elsewhere — instead of a silent no-op. Enrollment keeps
its gesture-preserving about:blank pre-open in real browsers and skips
it under the wrapper marker, opening the fetched URL directly.

Pinned by external_url_opener_contract_is_pinned (fragments + wrapper
marker/hook parity).
