### PR TITLE
kimi sign-in: complete full onboarding, expose partial state, remediate 40110

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2961,6 +2961,7 @@ dependencies = [
  "tokio-tungstenite",
  "tokio-util",
  "toml",
+ "toml_edit 0.22.27",
  "ulid",
  "unicode-normalization",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,10 @@ html2text = "0.17"
 portable-pty = "0.9"
 dotenvy = "0.15"
 toml = "0.8"
+# Format-preserving TOML editing for the Kimi onboarding-completion merge
+# (user comments/layout in ~/.kimi-code/config.toml must survive the managed
+# provider+model install). Already in the tree via toml 0.8 — same version.
+toml_edit = "0.22"
 uuid = { version = "1", features = ["v4", "serde"] }
 # Agenda item IDs: ULIDs are time-ordered, so lexicographic id order is
 # creation order — the agenda ledger's natural sort. Pure Rust.

--- a/src/bin/caller/external_agent/kimi_code/bridge.rs
+++ b/src/bin/caller/external_agent/kimi_code/bridge.rs
@@ -473,6 +473,55 @@ pub(crate) fn install_kimi_credential_if_unchanged(
     result
 }
 
+/// Seed a fresh, private ceremony home with a copy of the primary home's
+/// current credential, so `kimi login` starts with `hadToken=true`: kimi's
+/// own login then refreshes the token and re-runs its config provisioning
+/// WITHOUT a device-code round trip (its device flow is the fallback for a
+/// revoked/invalid token, in which case the ceremony proceeds interactively
+/// exactly as an unseeded one). This is what turns the sign-in ceremony into
+/// the "finish setup" lane for a signed-in-but-unonboarded home (card
+/// 01KZR9YHTX): the account holder's existing authority completes
+/// onboarding, usually with zero interaction.
+///
+/// `Ok(false)` = no primary credential exists (nothing to seed; the ceremony
+/// runs the normal device flow). The ceremony home is freshly created and
+/// owner-private before this runs, and the whole ceremony directory is
+/// deleted on every terminal ceremony state, so the copy's lifetime is the
+/// ceremony's.
+pub(crate) fn seed_kimi_ceremony_credential(
+    primary_home: &Path,
+    ceremony_home: &Path,
+) -> io::Result<bool> {
+    require_real_directory(ceremony_home, "Kimi ceremony home")?;
+    let primary_path = primary_home.join(KIMI_CREDENTIAL_PATH);
+    match fs::symlink_metadata(&primary_path) {
+        Ok(_) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error),
+    }
+    let mut credential = read_regular_credential(&primary_path, "Kimi primary credential")?;
+    let result = (|| {
+        let ceremony_path = ceremony_home.join(KIMI_CREDENTIAL_PATH);
+        let parent = ceremony_path
+            .parent()
+            .ok_or_else(|| io::Error::other("Kimi ceremony credential has no parent"))?;
+        fs::create_dir_all(parent)?;
+        require_real_directory(parent, "Kimi ceremony credential directory")?;
+        set_private_dir_permissions(parent)?;
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&ceremony_path)?;
+        file.write_all(&credential)?;
+        file.sync_all()?;
+        drop(file);
+        set_private_file_permissions(&ceremony_path)?;
+        Ok(true)
+    })();
+    credential.fill(0);
+    result
+}
+
 fn credential_digest(bytes: &[u8]) -> [u8; 32] {
     Sha256::digest(bytes).into()
 }
@@ -2343,6 +2392,39 @@ mod tests {
             fs::read(primary.join(KIMI_CREDENTIAL_PATH)).unwrap(),
             b"synthetic-new-login"
         );
+    }
+
+    #[test]
+    fn ceremony_seeding_copies_only_an_existing_primary_credential() {
+        let temp = tempfile::tempdir().unwrap();
+        let primary = temp.path().join("kimi");
+        let ceremony = temp.path().join("ceremony");
+        fs::create_dir_all(&primary).unwrap();
+        fs::create_dir_all(&ceremony).unwrap();
+
+        // Signed-out primary: nothing to seed, the device flow runs as-is.
+        assert!(!seed_kimi_ceremony_credential(&primary, &ceremony).unwrap());
+        assert!(!ceremony.join(KIMI_CREDENTIAL_PATH).exists());
+
+        fs::create_dir_all(primary.join("credentials")).unwrap();
+        fs::write(primary.join(KIMI_CREDENTIAL_PATH), b"synthetic-login").unwrap();
+        assert!(seed_kimi_ceremony_credential(&primary, &ceremony).unwrap());
+        assert_eq!(
+            fs::read(ceremony.join(KIMI_CREDENTIAL_PATH)).unwrap(),
+            b"synthetic-login"
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(ceremony.join(KIMI_CREDENTIAL_PATH))
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o077,
+                0
+            );
+        }
     }
 
     #[test]

--- a/src/bin/caller/external_agent/kimi_code/mod.rs
+++ b/src/bin/caller/external_agent/kimi_code/mod.rs
@@ -38,9 +38,6 @@ pub(crate) use self::bridge::{
     seed_kimi_ceremony_credential, sync_managed_bridges_to_primary, KimiCredentialBaseline,
     KimiCredentialInstall,
 };
-pub(crate) use self::onboarding::{
-    ceremony_home_provisioned, complete_managed_onboarding, providers_configured,
-};
 use self::bridge::{
     choose_mcp_server_name, prepare_bridge_home, sync_bridge_home_to_primary, BridgeMcpConfig,
     CredentialRefreshMonitor,
@@ -48,6 +45,9 @@ use self::bridge::{
 use self::events::{
     child_thread_id, normalize_goal_status, question_answer_body, split_child_thread_id,
     KimiSharedState,
+};
+pub(crate) use self::onboarding::{
+    ceremony_home_provisioned, complete_managed_onboarding, providers_configured,
 };
 use self::rpc::{KimiGoalBudgetLimits, KimiRpcApi, KimiRpcModel, KimiRpcTool};
 use self::runtime::*;
@@ -3338,12 +3338,16 @@ mod tests {
         let remediated = agent.onboarding_remediated(incident()).to_string();
         assert!(remediated.contains("code 40110"), "{remediated}");
         assert!(remediated.contains("Finish setup"), "{remediated}");
-        assert!(remediated.contains("onboarding never finished"), "{remediated}");
+        assert!(
+            remediated.contains("onboarding never finished"),
+            "{remediated}"
+        );
         // No nested "External agent error:" prefixes from the rewrite.
         assert_eq!(remediated.matches("External agent error:").count(), 1);
 
         // Unrelated errors pass through untouched.
-        let unrelated = external("Kimi /sessions/session_x/prompts failed (HTTP 200, code 40001): bad");
+        let unrelated =
+            external("Kimi /sessions/session_x/prompts failed (HTTP 200, code 40001): bad");
         let passthrough = agent.onboarding_remediated(unrelated).to_string();
         assert!(!passthrough.contains("Finish setup"), "{passthrough}");
     }

--- a/src/bin/caller/external_agent/kimi_code/mod.rs
+++ b/src/bin/caller/external_agent/kimi_code/mod.rs
@@ -11,6 +11,7 @@
 
 mod bridge;
 mod events;
+mod onboarding;
 mod review;
 mod rpc;
 mod runtime;
@@ -34,7 +35,11 @@ use crate::error::CallerError;
 
 pub(crate) use self::bridge::{
     capture_kimi_credential_baseline, install_kimi_credential_if_unchanged,
-    sync_managed_bridges_to_primary, KimiCredentialBaseline, KimiCredentialInstall,
+    seed_kimi_ceremony_credential, sync_managed_bridges_to_primary, KimiCredentialBaseline,
+    KimiCredentialInstall,
+};
+pub(crate) use self::onboarding::{
+    ceremony_home_provisioned, complete_managed_onboarding, providers_configured,
 };
 use self::bridge::{
     choose_mcp_server_name, prepare_bridge_home, sync_bridge_home_to_primary, BridgeMcpConfig,
@@ -142,6 +147,10 @@ pub struct KimiCodeAgent {
         Option<crate::web_gateway::session_catalog::kimi_history::KimiTurnHorizon>,
     mcp_auth_token: Option<String>,
     mcp_session_id: Option<String>,
+    /// The user-facing Kimi data home the bridge mirrors — kept for honest
+    /// error remediation (the 40110 onboarding refusal names finish-setup
+    /// only when this home really holds a credential).
+    primary_home: Option<PathBuf>,
     bridge_home: Option<PathBuf>,
     credential_refresh: Option<CredentialRefreshMonitor>,
     review_lease: Arc<tokio::sync::Mutex<Option<KimiReviewToolLease>>>,
@@ -183,6 +192,7 @@ impl KimiCodeAgent {
             fork_expected_horizon: None,
             mcp_auth_token: None,
             mcp_session_id: None,
+            primary_home: None,
             bridge_home: None,
             credential_refresh: None,
             review_lease: Arc::new(tokio::sync::Mutex::new(None)),
@@ -398,6 +408,40 @@ impl KimiCodeAgent {
         self.launch.model.take()
     }
 
+    /// Rewrite Kimi's bare "no provider configured" onboarding refusal
+    /// (wire code 40110 — card 01KZR9YHTX) into an actionable session
+    /// error. The refusal means the home is unonboarded: kimi's `/login`
+    /// writes both the credential and the managed provider entries in
+    /// `config.toml`, and `ensureReady` kills every prompts call until a
+    /// provider exists. When a credential already exists (signed in but
+    /// unonboarded — the incident state) the remedy is the Vault card's
+    /// Finish setup, which re-runs the sign-in ceremony non-interactively
+    /// on the existing credential; otherwise it is a plain sign-in. Any
+    /// other error passes through untouched.
+    fn onboarding_remediated(&self, error: CallerError) -> CallerError {
+        if !wire::provider_onboarding_refusal(&error) {
+            return error;
+        }
+        let signed_in = self
+            .primary_home
+            .as_deref()
+            .is_some_and(|home| home.join("credentials").join("kimi-code.json").is_file());
+        let remedy = if signed_in {
+            "Kimi is signed in on this machine, but onboarding never finished: its config.toml \
+             has no provider entries, which kimi's own login normally writes. Open the Vault \
+             tab's Kimi card and use \"Finish setup\" — it completes onboarding on the existing \
+             sign-in, usually without any browser step."
+        } else {
+            "Kimi has no provider configured on this machine because it is not signed in. Sign \
+             in from the Vault tab's Kimi card; the sign-in completes onboarding."
+        };
+        let base = match &error {
+            CallerError::ExternalAgent(message) => message.clone(),
+            other => other.to_string(),
+        };
+        external(format!("{base}. {remedy}"))
+    }
+
     async fn submit_content(
         &mut self,
         thread: &AgentThread,
@@ -424,7 +468,11 @@ impl KimiCodeAgent {
         let result = self
             .api()?
             .submit_prompt(&session_id, content, Value::Object(overrides))
-            .await?;
+            .await
+            // The incident seam (card 01KZR9YHTX): an unonboarded home's
+            // very first prompts call dies with the 40110 provider refusal
+            // — surface the finish-setup remedy, never the bare wire error.
+            .map_err(|error| self.onboarding_remediated(error))?;
         let status = result
             .get("status")
             .and_then(Value::as_str)
@@ -1493,6 +1541,7 @@ impl ExternalAgent for KimiCodeAgent {
             .or_else(|| std::env::var_os("KIMI_CODE_HOME").map(PathBuf::from))
             .or_else(|| dirs::home_dir().map(|home| home.join(".kimi-code")))
             .ok_or_else(|| external("could not resolve Kimi data home"))?;
+        self.primary_home = Some(primary_home.clone());
         let identity = self
             .mcp_session_id
             .clone()
@@ -1780,7 +1829,7 @@ impl ExternalAgent for KimiCodeAgent {
                             .create_session(&working_dir, self.session_agent_config())
                             .await?
                     }
-                    None => return Err(error),
+                    None => return Err(self.onboarding_remediated(error)),
                 },
             }
         };
@@ -1823,7 +1872,7 @@ impl ExternalAgent for KimiCodeAgent {
                             .update_profile(&session_id, self.session_agent_config())
                             .await?
                     }
-                    None => return Err(error),
+                    None => return Err(self.onboarding_remediated(error)),
                 },
             };
             if let Some(names) = self.launch.allowed_tools.clone() {
@@ -3255,6 +3304,85 @@ mod tests {
         assert_eq!(agent.degradable_launch_model(&refusal), None);
         // And the launch config stops sending the dead pin.
         assert!(agent.session_agent_config().get("model").is_none());
+    }
+
+    /// The onboarding remediation (card 01KZR9YHTX): only the 40110
+    /// provider refusal is rewritten, and the remedy names Finish setup
+    /// exactly when the primary home really holds a credential.
+    #[test]
+    fn onboarding_remediation_names_finish_setup_for_a_signed_in_home() {
+        let primary = tempfile::tempdir().unwrap();
+        let mut agent = KimiCodeAgent::new("kimi".into(), launch(), None);
+        agent.primary_home = Some(primary.path().to_path_buf());
+        let incident = || {
+            external(
+                "Kimi /sessions/session_x/prompts failed (HTTP 200, code 40110): \
+                 no provider configured; complete onboarding via /login or the providers endpoint",
+            )
+        };
+
+        // Signed out: the remedy is a plain sign-in.
+        let remediated = agent.onboarding_remediated(incident()).to_string();
+        assert!(remediated.contains("code 40110"), "{remediated}");
+        assert!(remediated.contains("not signed in"), "{remediated}");
+        assert!(remediated.contains("Vault tab"), "{remediated}");
+
+        // The incident state — credential present, no providers: the
+        // remedy is the Vault card's Finish setup completion lane.
+        fs::create_dir_all(primary.path().join("credentials")).unwrap();
+        fs::write(
+            primary.path().join("credentials").join("kimi-code.json"),
+            b"{}",
+        )
+        .unwrap();
+        let remediated = agent.onboarding_remediated(incident()).to_string();
+        assert!(remediated.contains("code 40110"), "{remediated}");
+        assert!(remediated.contains("Finish setup"), "{remediated}");
+        assert!(remediated.contains("onboarding never finished"), "{remediated}");
+        // No nested "External agent error:" prefixes from the rewrite.
+        assert_eq!(remediated.matches("External agent error:").count(), 1);
+
+        // Unrelated errors pass through untouched.
+        let unrelated = external("Kimi /sessions/session_x/prompts failed (HTTP 200, code 40001): bad");
+        let passthrough = agent.onboarding_remediated(unrelated).to_string();
+        assert!(!passthrough.contains("Finish setup"), "{passthrough}");
+    }
+
+    /// The incident seam end to end: the very first prompts call against a
+    /// signed-in-but-unonboarded home returns the exact captured 40110
+    /// envelope, and the session error the supervisor surfaces names the
+    /// finish-setup remedy instead of the bare wire failure.
+    #[tokio::test]
+    async fn submit_wraps_the_40110_provider_refusal_with_finish_setup() {
+        let (origin, _requests, server) = sequential_mock_server(vec![serde_json::json!({
+            "code": 40110,
+            "msg": "no provider configured; complete onboarding via /login or the providers endpoint",
+            "data": null
+        })])
+        .await;
+        let primary = tempfile::tempdir().unwrap();
+        fs::create_dir_all(primary.path().join("credentials")).unwrap();
+        fs::write(
+            primary.path().join("credentials").join("kimi-code.json"),
+            b"{}",
+        )
+        .unwrap();
+        let mut agent = KimiCodeAgent::new("kimi".into(), launch(), None);
+        agent.primary_home = Some(primary.path().to_path_buf());
+        agent.api = Some(KimiApi::new(origin, "test-token".into()).unwrap());
+        agent.shared.set_session_id(Some("session_x".to_string()));
+
+        let thread = AgentThread {
+            thread_id: "session_x".to_string(),
+        };
+        let error = agent
+            .send_message(&thread, "hello")
+            .await
+            .expect_err("an unonboarded home must fail the prompt");
+        let message = error.to_string();
+        assert!(message.contains("code 40110"), "{message}");
+        assert!(message.contains("Finish setup"), "{message}");
+        server.await.unwrap();
     }
 
     /// The 2026-08-11 owner incident end to end: a fresh Kimi install

--- a/src/bin/caller/external_agent/kimi_code/onboarding.rs
+++ b/src/bin/caller/external_agent/kimi_code/onboarding.rs
@@ -217,10 +217,8 @@ pub(crate) fn complete_managed_onboarding(
     })?;
 
     // 1. The managed provider record.
-    root_table(&mut primary, "providers").insert(
-        MANAGED_KIMI_PROVIDER,
-        Item::Table(managed_provider.clone()),
-    );
+    root_table(&mut primary, "providers")
+        .insert(MANAGED_KIMI_PROVIDER, Item::Table(managed_provider.clone()));
 
     // 2. Drop primary managed aliases the ceremony lineup no longer carries.
     let ceremony_keys: std::collections::HashSet<&str> = ceremony_aliases
@@ -335,13 +333,17 @@ fn merge_refreshed_model_alias(existing: &Table, upstream: &Table) -> Table {
     merged
 }
 
-/// The named root table, created as an explicit table when absent. A scalar
-/// squatting on the name is replaced — the merge's sections are tables in
-/// every config kimi itself writes.
+/// The named root table, created as an implicit container when absent (the
+/// children render their own `[section.child]` headers with no bare empty
+/// `[section]` header, and re-merges stay byte-stable). A scalar squatting
+/// on the name is replaced — the merge's sections are tables in every
+/// config kimi itself writes.
 fn root_table<'a>(document: &'a mut DocumentMut, key: &str) -> &'a mut Table {
     let root = document.as_table_mut();
     if !root.get(key).is_some_and(Item::is_table) {
-        root.insert(key, Item::Table(Table::new()));
+        let mut table = Table::new();
+        table.set_implicit(true);
+        root.insert(key, Item::Table(table));
     }
     root.get_mut(key)
         .and_then(Item::as_table_mut)
@@ -468,7 +470,10 @@ display_name = "K3-256k"
     #[test]
     fn providers_configured_truth_table() {
         // Absent config: not configured (kimi's gate reads an empty table).
-        assert_eq!(providers_configured(home_with_config(None).path()), Some(false));
+        assert_eq!(
+            providers_configured(home_with_config(None).path()),
+            Some(false)
+        );
         // The incident's comment-only stub.
         assert_eq!(
             providers_configured(home_with_config(Some(STUB_CONFIG)).path()),
@@ -510,10 +515,7 @@ display_name = "K3-256k"
         ));
         // Provider record without any alias is a half-written provision.
         assert!(!ceremony_home_provisioned(
-            home_with_config(Some(
-                "[providers.\"managed:kimi-code\"]\ntype = \"kimi\"\n"
-            ))
-            .path()
+            home_with_config(Some("[providers.\"managed:kimi-code\"]\ntype = \"kimi\"\n")).path()
         ));
         assert!(ceremony_home_provisioned(
             home_with_config(Some(CEREMONY_CONFIG)).path()

--- a/src/bin/caller/external_agent/kimi_code/onboarding.rs
+++ b/src/bin/caller/external_agent/kimi_code/onboarding.rs
@@ -1,0 +1,741 @@
+//! Kimi Code onboarding state: the `config.toml` provider half of a sign-in.
+//!
+//! Kimi's own `/login` writes TWO things: the OAuth credential
+//! (`credentials/kimi-code.json`) and the managed provider + model entries in
+//! `config.toml` (`provisionManagedKimiCodeConfig` fetches the live model
+//! lineup and applies `applyManagedKimiCodeConfig`; the fresh-install stub
+//! says it outright: "Login will populate managed Kimi provider and model
+//! entries"). A home with a credential but no provider table is *signed in
+//! but unonboarded*: every session dies at the first prompts call with wire
+//! code 40110 — "no provider configured; complete onboarding via /login or
+//! the providers endpoint" (`AuthSummaryService.ensureReady`, which throws
+//! exactly when the config's provider table is empty). The 2026-08-11 owner
+//! incident (card 01KZR9YHTX) was Intendant's sign-in ceremony syncing only
+//! the credential half and discarding the provider entries the ceremony-home
+//! login had written.
+//!
+//! This module owns both halves of the fix:
+//! - [`providers_configured`] — the daemon-side mirror of `ensureReady`'s
+//!   gate, used by the ceremony's completion verdict and the dashboard's
+//!   partial-state probe.
+//! - [`complete_managed_onboarding`] — a TOML-aware merge of the managed
+//!   entries the ceremony-home login wrote into the primary home's
+//!   `config.toml`, mirroring `applyManagedKimiCodeConfig`'s ownership
+//!   semantics (verified against the kimi 0.34.0 binary): the managed
+//!   provider record, its model aliases, and the two moonshot service
+//!   entries are upstream-owned; user providers, user model aliases, user
+//!   extras inside managed aliases (`mergeRefreshedModelAlias`'s
+//!   `userExtras` + `overrides`), a preservable `default_model`, and an
+//!   existing `[thinking]` table are never clobbered.
+
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+use toml_edit::{DocumentMut, Item, Table};
+
+/// Kimi's managed OAuth provider id (`KIMI_CODE_PROVIDER_NAME` in the CLI).
+pub(crate) const MANAGED_KIMI_PROVIDER: &str = "managed:kimi-code";
+
+/// The two `[services.*]` entries `applyManagedKimiCodeConfig` writes and
+/// `applyManagedKimiCodeLogoutConfig` deletes — managed-owned, so the
+/// completion merge adopts the ceremony's copies while preserving any other
+/// service the user declared.
+const MANAGED_SERVICE_KEYS: &[&str] = &["moonshot_search", "moonshot_fetch"];
+
+/// The remote-owned model-alias fields (`MANAGED_KIMI_MODEL_FIELDS` in kimi
+/// 0.34.0's `model-alias-merge.ts`, translated to the TOML writer's
+/// snake_case). `mergeRefreshedModelAlias` keeps every OTHER key on an
+/// existing alias as a user extra (plus a user `overrides` table verbatim)
+/// and takes these from upstream only — which also drops a stale managed
+/// field the upstream no longer sends.
+const MANAGED_MODEL_FIELDS: &[&str] = &[
+    "provider",
+    "model",
+    "max_context_size",
+    "capabilities",
+    "display_name",
+    "protocol",
+    "beta_api",
+    "adaptive_thinking",
+    "support_efforts",
+    "default_effort",
+];
+
+pub(crate) fn kimi_config_path(home: &Path) -> PathBuf {
+    home.join("config.toml")
+}
+
+/// The daemon-side mirror of `AuthSummaryService.ensureReady`'s provider
+/// gate: `Some(true)` when `config.toml` declares at least one provider (any
+/// provider — a BYOK custom provider passes kimi's gate exactly like the
+/// managed one), `Some(false)` when the config is absent, empty, or has an
+/// empty provider table (the fresh-install stub), `None` when the config
+/// exists but cannot be read or parsed — unknown, not a verdict.
+pub(crate) fn providers_configured(home: &Path) -> Option<bool> {
+    let text = match fs::read_to_string(kimi_config_path(home)) {
+        Ok(text) => text,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Some(false),
+        Err(_) => return None,
+    };
+    let document = match text.parse::<DocumentMut>() {
+        Ok(document) => document,
+        Err(_) => return None,
+    };
+    Some(
+        document
+            .get("providers")
+            .and_then(Item::as_table_like)
+            .is_some_and(|providers| !providers.is_empty()),
+    )
+}
+
+/// Whether an isolated ceremony home's login finished its provisioning half:
+/// the managed provider record exists and at least one model alias points at
+/// it. This is the ceremony's completion gate — a login process that has
+/// written its credential but not yet its provider entries is still running,
+/// and promoting at that instant would recreate the incident state in the
+/// primary home.
+pub(crate) fn ceremony_home_provisioned(ceremony_home: &Path) -> bool {
+    let Ok(text) = fs::read_to_string(kimi_config_path(ceremony_home)) else {
+        return false;
+    };
+    let Ok(document) = text.parse::<DocumentMut>() else {
+        return false;
+    };
+    document
+        .get("providers")
+        .and_then(Item::as_table_like)
+        .is_some_and(|providers| providers.get(MANAGED_KIMI_PROVIDER).is_some())
+        && !managed_model_aliases(&document).is_empty()
+}
+
+/// Every `[models.<key>]` alias whose `provider` is the managed provider.
+fn managed_model_aliases(document: &DocumentMut) -> Vec<(String, Table)> {
+    let Some(models) = document.get("models").and_then(Item::as_table_like) else {
+        return Vec::new();
+    };
+    models
+        .iter()
+        .filter_map(|(key, item)| {
+            let table = as_detached_table(item)?;
+            (table.get("provider").and_then(Item::as_str) == Some(MANAGED_KIMI_PROVIDER))
+                .then(|| (key.to_string(), table))
+        })
+        .collect()
+}
+
+/// A standalone copy of a table-like item (standard or inline), losing the
+/// distinction — every table this merge adopts re-renders as a standard
+/// `[section]` table in the primary document.
+fn as_detached_table(item: &Item) -> Option<Table> {
+    match item {
+        Item::Table(table) => Some(table.clone()),
+        Item::Value(value) => value.as_inline_table().map(|inline| {
+            let mut table = inline.clone().into_table();
+            table.set_implicit(false);
+            table
+        }),
+        _ => None,
+    }
+}
+
+fn invalid_data(message: String) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message)
+}
+
+/// Merge the managed provider + model entries a completed ceremony-home login
+/// wrote into the primary home's `config.toml`, then persist it atomically
+/// with owner-private permissions.
+///
+/// The data is exactly what kimi's own provisioner fetched from the managed
+/// endpoint minutes earlier and wrote with the account's live model lineup —
+/// this merge replays that write against the primary with the same ownership
+/// boundaries kimi's own code enforces:
+/// - `providers."managed:kimi-code"`: adopted (managed-owned; kimi's logout
+///   deletes it). Every other provider is untouched.
+/// - managed model aliases: adopted per `mergeRefreshedModelAlias` — managed
+///   fields from the ceremony, user extras and a user `overrides` table
+///   preserved; primary managed aliases absent from the ceremony set are
+///   removed (kimi's stale-alias rule). Aliases on other providers are
+///   untouched.
+/// - `default_model`: preserved when kimi's `canPreserveDefaultModel` would
+///   preserve it (it names a ceremony managed alias, or an existing alias on
+///   another provider); otherwise the ceremony's selection is adopted.
+/// - `[thinking]`: adopted only when the primary has none — kimi recomputes
+///   it at login, but overriding an explicit user table from a completion
+///   merge is scarier than leaving it, and the per-session profile call
+///   sets thinking anyway.
+/// - `[services]`: the two moonshot entries adopted (managed-owned); every
+///   other service preserved.
+///
+/// A primary `config.toml` that exists but does not parse is an error, never
+/// a clobber: the file is user-owned and kimi's own login would fail its
+/// read-modify-write the same way.
+pub(crate) fn complete_managed_onboarding(
+    primary_home: &Path,
+    ceremony_home: &Path,
+) -> io::Result<()> {
+    let ceremony_text = fs::read_to_string(kimi_config_path(ceremony_home)).map_err(|error| {
+        invalid_data(format!(
+            "Kimi login finished without a readable ceremony config.toml: {error}"
+        ))
+    })?;
+    let ceremony: DocumentMut = ceremony_text.parse().map_err(|error| {
+        invalid_data(format!(
+            "Kimi login wrote an unparseable ceremony config.toml: {error}"
+        ))
+    })?;
+    let managed_provider = ceremony
+        .get("providers")
+        .and_then(Item::as_table_like)
+        .and_then(|providers| providers.get(MANAGED_KIMI_PROVIDER))
+        .and_then(as_detached_table)
+        .ok_or_else(|| {
+            invalid_data(format!(
+                "Kimi login did not write the {MANAGED_KIMI_PROVIDER} provider entry"
+            ))
+        })?;
+    let ceremony_aliases = managed_model_aliases(&ceremony);
+    if ceremony_aliases.is_empty() {
+        return Err(invalid_data(format!(
+            "Kimi login wrote no model aliases for {MANAGED_KIMI_PROVIDER}"
+        )));
+    }
+
+    let primary_path = kimi_config_path(primary_home);
+    let primary_text = match fs::read_to_string(&primary_path) {
+        Ok(text) => text,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => String::new(),
+        Err(error) => return Err(error),
+    };
+    let mut primary: DocumentMut = primary_text.parse().map_err(|error| {
+        invalid_data(format!(
+            "existing Kimi config.toml {} does not parse ({error}); refusing to rewrite it",
+            primary_path.display()
+        ))
+    })?;
+
+    // 1. The managed provider record.
+    root_table(&mut primary, "providers").insert(
+        MANAGED_KIMI_PROVIDER,
+        Item::Table(managed_provider.clone()),
+    );
+
+    // 2. Drop primary managed aliases the ceremony lineup no longer carries.
+    let ceremony_keys: std::collections::HashSet<&str> = ceremony_aliases
+        .iter()
+        .map(|(key, _)| key.as_str())
+        .collect();
+    let stale: Vec<String> = primary
+        .get("models")
+        .and_then(Item::as_table_like)
+        .map(|models| {
+            models
+                .iter()
+                .filter(|(key, item)| {
+                    !ceremony_keys.contains(key)
+                        && item
+                            .as_table_like()
+                            .and_then(|table| table.get("provider"))
+                            .and_then(Item::as_str)
+                            == Some(MANAGED_KIMI_PROVIDER)
+                })
+                .map(|(key, _)| key.to_string())
+                .collect()
+        })
+        .unwrap_or_default();
+    if let Some(models) = primary.get_mut("models").and_then(Item::as_table_like_mut) {
+        for key in &stale {
+            models.remove(key);
+        }
+    }
+
+    // 3. Adopt the ceremony aliases, preserving user extras + overrides.
+    let models = root_table(&mut primary, "models");
+    for (key, ceremony_alias) in &ceremony_aliases {
+        let merged = match models.get(key).and_then(as_detached_table) {
+            Some(existing) => merge_refreshed_model_alias(&existing, ceremony_alias),
+            None => ceremony_alias.clone(),
+        };
+        models.insert(key, Item::Table(merged));
+    }
+
+    // 4. default_model: kimi's canPreserveDefaultModel rule.
+    let current_default = primary
+        .get("default_model")
+        .and_then(Item::as_str)
+        .map(str::to_string)
+        .filter(|value| !value.is_empty());
+    let preservable = current_default.as_deref().is_some_and(|default| {
+        ceremony_keys.contains(default)
+            || primary
+                .get("models")
+                .and_then(Item::as_table_like)
+                .and_then(|models| models.get(default))
+                .and_then(Item::as_table_like)
+                .is_some_and(|alias| {
+                    alias.get("provider").and_then(Item::as_str) != Some(MANAGED_KIMI_PROVIDER)
+                })
+    });
+    if !preservable {
+        if let Some(ceremony_default) = ceremony.get("default_model").and_then(Item::as_str) {
+            primary["default_model"] = toml_edit::value(ceremony_default);
+        }
+    }
+
+    // 5. [thinking]: only when the primary has none.
+    if primary.get("thinking").is_none() {
+        if let Some(thinking) = ceremony.get("thinking").and_then(as_detached_table) {
+            primary
+                .as_table_mut()
+                .insert("thinking", Item::Table(thinking));
+        }
+    }
+
+    // 6. [services]: the two managed entries; user services preserved.
+    let ceremony_services: Vec<(&str, Table)> = MANAGED_SERVICE_KEYS
+        .iter()
+        .filter_map(|key| {
+            ceremony
+                .get("services")
+                .and_then(Item::as_table_like)
+                .and_then(|services| services.get(key))
+                .and_then(as_detached_table)
+                .map(|table| (*key, table))
+        })
+        .collect();
+    if !ceremony_services.is_empty() {
+        let services = root_table(&mut primary, "services");
+        for (key, table) in ceremony_services {
+            services.insert(key, Item::Table(table));
+        }
+    }
+
+    persist_private_config(&primary_path, primary.to_string().as_bytes())
+}
+
+/// `mergeRefreshedModelAlias` (kimi 0.34.0): user extras (existing keys
+/// outside [`MANAGED_MODEL_FIELDS`], minus `overrides`), then every upstream
+/// key, then the existing `overrides` table verbatim.
+fn merge_refreshed_model_alias(existing: &Table, upstream: &Table) -> Table {
+    let mut merged = Table::new();
+    for (key, item) in existing.iter() {
+        if key == "overrides" || MANAGED_MODEL_FIELDS.contains(&key) {
+            continue;
+        }
+        merged.insert(key, item.clone());
+    }
+    for (key, item) in upstream.iter() {
+        merged.insert(key, item.clone());
+    }
+    if let Some(overrides) = existing.get("overrides") {
+        merged.insert("overrides", overrides.clone());
+    }
+    merged
+}
+
+/// The named root table, created as an explicit table when absent. A scalar
+/// squatting on the name is replaced — the merge's sections are tables in
+/// every config kimi itself writes.
+fn root_table<'a>(document: &'a mut DocumentMut, key: &str) -> &'a mut Table {
+    let root = document.as_table_mut();
+    if !root.get(key).is_some_and(Item::is_table) {
+        root.insert(key, Item::Table(Table::new()));
+    }
+    root.get_mut(key)
+        .and_then(Item::as_table_mut)
+        .expect("just inserted a table")
+}
+
+/// Stage-and-rename the merged config with owner-private permissions, the
+/// same discipline the credential installer uses.
+fn persist_private_config(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| io::Error::other("Kimi config.toml has no parent directory"))?;
+    let (mut file, staged) = crate::file_watcher::stage_in(parent)?;
+    let staged_write = file
+        .write_all(bytes)
+        .and_then(|()| file.sync_all())
+        .and_then(|()| set_private_config_permissions(&staged));
+    drop(file);
+    if let Err(error) = staged_write {
+        let _ = fs::remove_file(&staged);
+        return Err(error);
+    }
+    if let Err(error) = crate::file_watcher::persist_staged(&staged, path) {
+        let _ = fs::remove_file(&staged);
+        return Err(error);
+    }
+    set_private_config_permissions(path)
+}
+
+#[cfg(unix)]
+fn set_private_config_permissions(path: &Path) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+}
+
+#[cfg(windows)]
+fn set_private_config_permissions(path: &Path) -> io::Result<()> {
+    crate::platform::set_owner_private_permissions(path)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn set_private_config_permissions(_path: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The fresh-install stub kimi 0.34.0 writes (181 bytes, comment-only) —
+    /// the exact primary-home state of the 2026-08-11 incident box.
+    const STUB_CONFIG: &str = "\
+# ~/.kimi-code/config.toml
+# Runtime settings for Kimi Code.
+# This file starts empty so built-in defaults can apply.
+# Login will populate managed Kimi provider and model entries.
+";
+
+    /// A login-provisioned ceremony config (shape captured live from kimi
+    /// 0.34.0's own writer on this seat's dev box).
+    const CEREMONY_CONFIG: &str = r#"default_model = "kimi-code/k3"
+
+[thinking]
+enabled = true
+effort = "high"
+
+[services.moonshot_search]
+base_url = "https://api.kimi.com/coding/v1/search"
+api_key = ""
+
+[services.moonshot_search.oauth]
+storage = "file"
+key = "oauth/kimi-code"
+
+[services.moonshot_fetch]
+base_url = "https://api.kimi.com/coding/v1/fetch"
+api_key = ""
+
+[services.moonshot_fetch.oauth]
+storage = "file"
+key = "oauth/kimi-code"
+
+[providers."managed:kimi-code"]
+type = "kimi"
+api_key = ""
+base_url = "https://api.kimi.com/coding/v1"
+
+[providers."managed:kimi-code".oauth]
+storage = "file"
+key = "oauth/kimi-code"
+
+[models."kimi-code/k3"]
+provider = "managed:kimi-code"
+model = "k3"
+max_context_size = 1048576
+capabilities = [ "thinking", "always_thinking", "image_in", "video_in", "tool_use" ]
+display_name = "K3"
+support_efforts = [ "low", "high", "max" ]
+default_effort = "high"
+
+[models."kimi-code/k3-256k"]
+provider = "managed:kimi-code"
+model = "k3-256k"
+max_context_size = 262144
+capabilities = [ "thinking", "always_thinking", "image_in", "tool_use" ]
+display_name = "K3-256k"
+"#;
+
+    fn home_with_config(config: Option<&str>) -> tempfile::TempDir {
+        let home = tempfile::tempdir().unwrap();
+        if let Some(config) = config {
+            fs::write(kimi_config_path(home.path()), config).unwrap();
+        }
+        home
+    }
+
+    fn parsed(home: &Path) -> DocumentMut {
+        fs::read_to_string(kimi_config_path(home))
+            .unwrap()
+            .parse()
+            .unwrap()
+    }
+
+    #[test]
+    fn providers_configured_truth_table() {
+        // Absent config: not configured (kimi's gate reads an empty table).
+        assert_eq!(providers_configured(home_with_config(None).path()), Some(false));
+        // The incident's comment-only stub.
+        assert_eq!(
+            providers_configured(home_with_config(Some(STUB_CONFIG)).path()),
+            Some(false)
+        );
+        // An empty declared table is still empty.
+        assert_eq!(
+            providers_configured(home_with_config(Some("[providers]\n")).path()),
+            Some(false)
+        );
+        // Any provider passes ensureReady — BYOK counts.
+        assert_eq!(
+            providers_configured(
+                home_with_config(Some("[providers.custom]\ntype = \"openai\"\n")).path()
+            ),
+            Some(true)
+        );
+        assert_eq!(
+            providers_configured(home_with_config(Some(CEREMONY_CONFIG)).path()),
+            Some(true)
+        );
+        // Unparseable is unknown, never a verdict.
+        assert_eq!(
+            providers_configured(home_with_config(Some("providers = [broken")).path()),
+            None
+        );
+    }
+
+    #[test]
+    fn ceremony_provisioning_gate_requires_managed_provider_and_alias() {
+        assert!(!ceremony_home_provisioned(home_with_config(None).path()));
+        assert!(!ceremony_home_provisioned(
+            home_with_config(Some(STUB_CONFIG)).path()
+        ));
+        // A BYOK provider does not make a LOGIN ceremony provisioned — the
+        // gate is specifically about the managed entries login writes.
+        assert!(!ceremony_home_provisioned(
+            home_with_config(Some("[providers.custom]\ntype = \"openai\"\n")).path()
+        ));
+        // Provider record without any alias is a half-written provision.
+        assert!(!ceremony_home_provisioned(
+            home_with_config(Some(
+                "[providers.\"managed:kimi-code\"]\ntype = \"kimi\"\n"
+            ))
+            .path()
+        ));
+        assert!(ceremony_home_provisioned(
+            home_with_config(Some(CEREMONY_CONFIG)).path()
+        ));
+    }
+
+    #[test]
+    fn incident_stub_primary_gains_full_managed_onboarding() {
+        let primary = home_with_config(Some(STUB_CONFIG));
+        let ceremony = home_with_config(Some(CEREMONY_CONFIG));
+        complete_managed_onboarding(primary.path(), ceremony.path()).unwrap();
+
+        assert_eq!(providers_configured(primary.path()), Some(true));
+        let text = fs::read_to_string(kimi_config_path(primary.path())).unwrap();
+        // The user-facing file keeps its comments — the merge edits, it does
+        // not regenerate.
+        assert!(text.contains("# Login will populate managed Kimi provider"));
+        let document = parsed(primary.path());
+        assert_eq!(
+            document["providers"][MANAGED_KIMI_PROVIDER]["oauth"]["key"].as_str(),
+            Some("oauth/kimi-code")
+        );
+        assert_eq!(
+            document["models"]["kimi-code/k3"]["max_context_size"].as_integer(),
+            Some(1_048_576)
+        );
+        assert_eq!(document["default_model"].as_str(), Some("kimi-code/k3"));
+        assert_eq!(document["thinking"]["enabled"].as_bool(), Some(true));
+        assert_eq!(
+            document["services"]["moonshot_fetch"]["base_url"].as_str(),
+            Some("https://api.kimi.com/coding/v1/fetch")
+        );
+    }
+
+    #[test]
+    fn absent_primary_config_is_created_whole() {
+        let primary = home_with_config(None);
+        let ceremony = home_with_config(Some(CEREMONY_CONFIG));
+        complete_managed_onboarding(primary.path(), ceremony.path()).unwrap();
+        assert_eq!(providers_configured(primary.path()), Some(true));
+        assert_eq!(
+            parsed(primary.path())["default_model"].as_str(),
+            Some("kimi-code/k3")
+        );
+    }
+
+    #[test]
+    fn user_entries_survive_the_merge_untouched() {
+        let primary = home_with_config(Some(
+            r#"# my hand-tuned setup
+default_model = "byok/gpt"
+
+[providers.byok]
+type = "openai"
+api_key = "sk-user"
+base_url = "https://example.test/v1"
+
+[models."byok/gpt"]
+provider = "byok"
+model = "gpt-test"
+max_context_size = 128000
+
+[services.my_search]
+base_url = "https://search.example.test"
+
+[thinking]
+enabled = false
+"#,
+        ));
+        let ceremony = home_with_config(Some(CEREMONY_CONFIG));
+        complete_managed_onboarding(primary.path(), ceremony.path()).unwrap();
+
+        let document = parsed(primary.path());
+        // User provider, alias, service, and comment all intact.
+        assert_eq!(
+            document["providers"]["byok"]["api_key"].as_str(),
+            Some("sk-user")
+        );
+        assert_eq!(
+            document["models"]["byok/gpt"]["model"].as_str(),
+            Some("gpt-test")
+        );
+        assert_eq!(
+            document["services"]["my_search"]["base_url"].as_str(),
+            Some("https://search.example.test")
+        );
+        let text = fs::read_to_string(kimi_config_path(primary.path())).unwrap();
+        assert!(text.contains("# my hand-tuned setup"));
+        // The preservable non-managed default_model is preserved
+        // (canPreserveDefaultModel), and the user's thinking table wins.
+        assert_eq!(document["default_model"].as_str(), Some("byok/gpt"));
+        assert_eq!(document["thinking"]["enabled"].as_bool(), Some(false));
+        // The managed lineup still landed beside the user's entries.
+        assert_eq!(
+            document["providers"][MANAGED_KIMI_PROVIDER]["type"].as_str(),
+            Some("kimi")
+        );
+        assert_eq!(
+            document["models"]["kimi-code/k3"]["display_name"].as_str(),
+            Some("K3")
+        );
+    }
+
+    #[test]
+    fn stale_managed_aliases_are_replaced_and_user_extras_kept() {
+        let primary = home_with_config(Some(
+            r#"default_model = "kimi-code/k2"
+
+[providers."managed:kimi-code"]
+type = "kimi"
+api_key = ""
+base_url = "https://api.kimi.com/coding/v1"
+
+[models."kimi-code/k2"]
+provider = "managed:kimi-code"
+model = "k2"
+max_context_size = 131072
+
+[models."kimi-code/k3"]
+provider = "managed:kimi-code"
+model = "k3"
+max_context_size = 4096
+support_efforts = [ "low" ]
+my_note = "pinned for the demo"
+
+[models."kimi-code/k3".overrides]
+temperature = 0.2
+"#,
+        ));
+        let ceremony = home_with_config(Some(CEREMONY_CONFIG));
+        complete_managed_onboarding(primary.path(), ceremony.path()).unwrap();
+
+        let document = parsed(primary.path());
+        // The retired managed alias is gone (kimi's stale-alias rule)…
+        assert!(document["models"].get("kimi-code/k2").is_none());
+        // …so the dangling default follows the ceremony's selection.
+        assert_eq!(document["default_model"].as_str(), Some("kimi-code/k3"));
+        // Managed fields refreshed from upstream.
+        assert_eq!(
+            document["models"]["kimi-code/k3"]["max_context_size"].as_integer(),
+            Some(1_048_576)
+        );
+        // User extras + overrides preserved (mergeRefreshedModelAlias).
+        assert_eq!(
+            document["models"]["kimi-code/k3"]["my_note"].as_str(),
+            Some("pinned for the demo")
+        );
+        assert_eq!(
+            document["models"]["kimi-code/k3"]["overrides"]["temperature"].as_float(),
+            Some(0.2)
+        );
+    }
+
+    #[test]
+    fn preserved_managed_default_survives_a_refresh() {
+        let primary = home_with_config(Some(
+            "default_model = \"kimi-code/k3-256k\"\n\n[thinking]\nenabled = true\n",
+        ));
+        let ceremony = home_with_config(Some(CEREMONY_CONFIG));
+        complete_managed_onboarding(primary.path(), ceremony.path()).unwrap();
+        // The existing default names a ceremony managed alias — preserved
+        // even though the ceremony selected kimi-code/k3.
+        assert_eq!(
+            parsed(primary.path())["default_model"].as_str(),
+            Some("kimi-code/k3-256k")
+        );
+    }
+
+    #[test]
+    fn unprovisioned_ceremony_home_is_an_error_and_primary_untouched() {
+        let primary = home_with_config(Some(STUB_CONFIG));
+        for ceremony_config in [
+            None,
+            Some(STUB_CONFIG),
+            // Managed provider without a single alias.
+            Some("[providers.\"managed:kimi-code\"]\ntype = \"kimi\"\n"),
+        ] {
+            let ceremony = home_with_config(ceremony_config);
+            assert!(complete_managed_onboarding(primary.path(), ceremony.path()).is_err());
+        }
+        assert_eq!(
+            fs::read_to_string(kimi_config_path(primary.path())).unwrap(),
+            STUB_CONFIG
+        );
+    }
+
+    #[test]
+    fn unparseable_primary_config_is_refused_not_rewritten() {
+        let primary = home_with_config(Some("providers = [broken"));
+        let ceremony = home_with_config(Some(CEREMONY_CONFIG));
+        let error = complete_managed_onboarding(primary.path(), ceremony.path()).unwrap_err();
+        assert!(error.to_string().contains("refusing to rewrite"), "{error}");
+        assert_eq!(
+            fs::read_to_string(kimi_config_path(primary.path())).unwrap(),
+            "providers = [broken"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn merged_config_is_owner_private() {
+        use std::os::unix::fs::PermissionsExt;
+        let primary = home_with_config(None);
+        let ceremony = home_with_config(Some(CEREMONY_CONFIG));
+        complete_managed_onboarding(primary.path(), ceremony.path()).unwrap();
+        let mode = fs::metadata(kimi_config_path(primary.path()))
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o600);
+    }
+
+    #[test]
+    fn completion_is_idempotent() {
+        let primary = home_with_config(Some(STUB_CONFIG));
+        let ceremony = home_with_config(Some(CEREMONY_CONFIG));
+        complete_managed_onboarding(primary.path(), ceremony.path()).unwrap();
+        let first = fs::read_to_string(kimi_config_path(primary.path())).unwrap();
+        complete_managed_onboarding(primary.path(), ceremony.path()).unwrap();
+        assert_eq!(
+            fs::read_to_string(kimi_config_path(primary.path())).unwrap(),
+            first
+        );
+    }
+}

--- a/src/bin/caller/external_agent/kimi_code/wire.rs
+++ b/src/bin/caller/external_agent/kimi_code/wire.rs
@@ -565,6 +565,25 @@ pub(crate) fn model_not_configured_refusal(error: &CallerError) -> bool {
     message.contains("code 50001") || lower.contains("not configured")
 }
 
+/// Whether an error from this wire is Kimi's "no provider configured"
+/// onboarding refusal (card 01KZR9YHTX — the signed-in-but-unonboarded
+/// session death). `AuthSummaryService.ensureReady` throws it whenever
+/// `config.toml`'s provider table is empty; through [`decode_response`]'s
+/// formatter the incident wire form (captured live, kimi 0.34.0,
+/// 2026-08-11) is `Kimi /sessions/…/prompts failed (HTTP 200, code 40110):
+/// no provider configured; complete onboarding via /login or the providers
+/// endpoint`. The prose match is kept as a fallback for a re-coded future
+/// build; both forms must mention a provider so an unrelated refusal never
+/// triggers the onboarding remediation.
+pub(crate) fn provider_onboarding_refusal(error: &CallerError) -> bool {
+    let message = error.to_string();
+    let lower = message.to_ascii_lowercase();
+    if !lower.contains("provider") {
+        return false;
+    }
+    message.contains("code 40110") || lower.contains("no provider configured")
+}
+
 pub(crate) fn validate_meta(value: &Value) -> Result<String, CallerError> {
     let version = value
         .get("server_version")
@@ -756,6 +775,43 @@ mod tests {
             "Kimi /sessions/sess_x/profile failed (HTTP 200, code 40909): \
              search service is not configured",
         )));
+    }
+
+    #[test]
+    fn provider_onboarding_recognizer_matches_the_incident_shape_only() {
+        // The live 2026-08-11 incident wire form (kimi 0.34.0, credentials
+        // present + the fresh-install config.toml stub), exactly as
+        // decode_response formats the captured envelope {"code":40110,
+        // "msg":"no provider configured; complete onboarding via /login or
+        // the providers endpoint","data":null}.
+        let incident = external(
+            "Kimi /sessions/session_x/prompts failed (HTTP 200, code 40110): \
+             no provider configured; complete onboarding via /login or the providers endpoint",
+        );
+        assert!(provider_onboarding_refusal(&incident));
+        // A re-coded build keeping the prose still matches.
+        let reworded = external(
+            "Kimi /sessions/session_x/prompts failed (HTTP 200, code 41234): \
+             No provider configured for this session",
+        );
+        assert!(provider_onboarding_refusal(&reworded));
+        // A future 40110 that stopped mentioning providers must not match.
+        assert!(!provider_onboarding_refusal(&external(
+            "Kimi /sessions/session_x/prompts failed (HTTP 200, code 40110): request rejected",
+        )));
+        // Unrelated provider-adjacent failures never trigger remediation.
+        assert!(!provider_onboarding_refusal(&external(
+            "Kimi /sessions/session_x/prompts failed (HTTP 200, code 40001): \
+             provider request rejected",
+        )));
+        // The model-not-configured refusal stays a disjoint recognizer
+        // (its degrade path must keep winning for 50001).
+        let model_refusal = external(
+            "Kimi /sessions/session_x/profile failed (HTTP 200, code 50001): \
+             Model \"kimi-code/k3\" is not configured in config.toml.",
+        );
+        assert!(!provider_onboarding_refusal(&model_refusal));
+        assert!(!model_not_configured_refusal(&incident));
     }
 
     #[test]

--- a/src/bin/caller/external_agent/mod.rs
+++ b/src/bin/caller/external_agent/mod.rs
@@ -1211,6 +1211,12 @@ pub struct BackendAvailability {
     /// the platform stores credentials out of stat's reach (Claude Code
     /// keeps them in the keychain on macOS), so absence proves nothing.
     pub local_login: Option<bool>,
+    /// Kimi only: `Some(true)` when the home is signed in but unonboarded —
+    /// the credential exists while `config.toml` declares no provider, so
+    /// every session dies at its first prompts call (wire code 40110) until
+    /// setup is finished. `Some(false)` = signed in and onboarded; `None` =
+    /// signed out, probe unknown, or a backend without the concept.
+    pub login_incomplete: Option<bool>,
     /// Passive, zero-additional-quota compatibility evidence for the exact
     /// configured executable artifact and current adapter contract.
     pub compatibility: protocol_watch::PassiveCompatibilityStatus,
@@ -1256,17 +1262,47 @@ fn kimi_local_login(home: &Path) -> Option<bool> {
     kimi_local_login_in(std::env::var_os("KIMI_CODE_HOME"), home)
 }
 
+fn kimi_home_in(env_kimi_home: Option<std::ffi::OsString>, home: &Path) -> PathBuf {
+    env_kimi_home
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home.join(".kimi-code"))
+}
+
 /// `KIMI_CODE_HOME` injected for hermetic tests.
 fn kimi_local_login_in(env_kimi_home: Option<std::ffi::OsString>, home: &Path) -> Option<bool> {
-    let kimi_home = env_kimi_home
-        .map(PathBuf::from)
-        .unwrap_or_else(|| home.join(".kimi-code"));
     Some(
-        kimi_home
+        kimi_home_in(env_kimi_home, home)
             .join("credentials")
             .join("kimi-code.json")
             .is_file(),
     )
+}
+
+fn kimi_login_incomplete(home: &Path) -> Option<bool> {
+    kimi_login_incomplete_in(std::env::var_os("KIMI_CODE_HOME"), home)
+}
+
+/// Whether the Kimi home is *signed in but unonboarded* — a credential
+/// exists while `config.toml` declares no provider (card 01KZR9YHTX: kimi's
+/// own `/login` writes both, so this state means onboarding never finished
+/// on this machine, and every session dies at its first prompts call with
+/// wire code 40110). `Some(true)` = finish setup; `Some(false)` = signed in
+/// and onboarded; `None` = signed out (nothing to finish — the plain
+/// sign-in copy owns that state) or the config is unreadable (unknown, not
+/// a verdict). `KIMI_CODE_HOME` injected for hermetic tests.
+fn kimi_login_incomplete_in(
+    env_kimi_home: Option<std::ffi::OsString>,
+    home: &Path,
+) -> Option<bool> {
+    let kimi_home = kimi_home_in(env_kimi_home, home);
+    if !kimi_home
+        .join("credentials")
+        .join("kimi-code.json")
+        .is_file()
+    {
+        return None;
+    }
+    kimi_code::providers_configured(&kimi_home).map(|configured| !configured)
 }
 
 fn pi_local_login(home: &Path) -> Option<bool> {
@@ -1419,6 +1455,10 @@ pub fn backend_availability(
             AgentBackend::Kimi => kimi_local_login(home),
             AgentBackend::Pi => pi_local_login(home),
         };
+        let login_incomplete = match backend {
+            AgentBackend::Kimi => kimi_login_incomplete(home),
+            _ => None,
+        };
         let (compatibility_command, compatibility_profile) = match backend {
             AgentBackend::Codex => {
                 let managed = crate::project::codex_managed_context_enabled(
@@ -1451,6 +1491,7 @@ pub fn backend_availability(
             last_used_secs,
             leased,
             local_login,
+            login_incomplete,
             compatibility,
             path_hint,
         }
@@ -1520,6 +1561,7 @@ pub fn backend_availability_json(
                     "last_used_secs": info.last_used_secs,
                     "leased": info.leased,
                     "local_login": info.local_login,
+                    "login_incomplete": info.login_incomplete,
                     "compatibility": info.compatibility,
                     "path_hint": info.path_hint,
                 })
@@ -3051,6 +3093,114 @@ mod tests {
         assert_eq!(
             pi_local_login_in(Some(alt.path().as_os_str().to_os_string()), home.path()),
             Some(false)
+        );
+    }
+
+    /// The signed-in-but-unonboarded truth table (card 01KZR9YHTX): the
+    /// incomplete verdict exists only where a credential exists, mirrors
+    /// kimi's own ensureReady provider gate, and never guesses through an
+    /// unreadable config.
+    #[test]
+    fn kimi_login_incomplete_probe_truth_table() {
+        let home = tempfile::tempdir().unwrap();
+        let kimi_home = home.path().join(".kimi-code");
+
+        // Signed out: nothing to finish, whatever the config says.
+        assert_eq!(kimi_login_incomplete_in(None, home.path()), None);
+        std::fs::create_dir_all(&kimi_home).unwrap();
+        std::fs::write(
+            kimi_home.join("config.toml"),
+            "# Login will populate managed Kimi provider and model entries.\n",
+        )
+        .unwrap();
+        assert_eq!(kimi_login_incomplete_in(None, home.path()), None);
+
+        // The incident state: credential present + the comment-only stub.
+        std::fs::create_dir_all(kimi_home.join("credentials")).unwrap();
+        std::fs::write(kimi_home.join("credentials/kimi-code.json"), b"{}").unwrap();
+        assert_eq!(kimi_login_incomplete_in(None, home.path()), Some(true));
+
+        // Credential present, config absent entirely: still unonboarded.
+        std::fs::remove_file(kimi_home.join("config.toml")).unwrap();
+        assert_eq!(kimi_login_incomplete_in(None, home.path()), Some(true));
+
+        // Any configured provider passes kimi's gate — onboarded.
+        std::fs::write(
+            kimi_home.join("config.toml"),
+            "[providers.\"managed:kimi-code\"]\ntype = \"kimi\"\n",
+        )
+        .unwrap();
+        assert_eq!(kimi_login_incomplete_in(None, home.path()), Some(false));
+
+        // Unreadable config: unknown, never a verdict.
+        std::fs::write(kimi_home.join("config.toml"), "providers = [broken").unwrap();
+        assert_eq!(kimi_login_incomplete_in(None, home.path()), None);
+
+        // KIMI_CODE_HOME redirects the probe wholesale.
+        let alt = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(alt.path().join("credentials")).unwrap();
+        std::fs::write(alt.path().join("credentials/kimi-code.json"), b"{}").unwrap();
+        assert_eq!(
+            kimi_login_incomplete_in(Some(alt.path().as_os_str().to_os_string()), home.path()),
+            Some(true)
+        );
+    }
+
+    /// The dashboard contract for the finish-setup lane: the availability
+    /// wire row carries `login_incomplete`, and the Vault card fragment
+    /// consumes it with the finish-setup affordance (needle-pinned so a
+    /// fragment rewrite that drops the state fails here instead of
+    /// shipping as drift).
+    #[test]
+    fn login_incomplete_reaches_the_availability_wire_and_vault_card() {
+        let home = tempfile::tempdir().unwrap();
+        let kimi_home = home.path().join(".kimi-code");
+        std::fs::create_dir_all(kimi_home.join("credentials")).unwrap();
+        std::fs::write(kimi_home.join("credentials/kimi-code.json"), b"{}").unwrap();
+
+        let mut config = crate::project::ExternalAgentConfig::default();
+        config.codex.command = "intendant-test-absent-codex".to_string();
+        config.claude_code.command = "intendant-test-absent-claude".to_string();
+        config.kimi.command = "intendant-test-absent-kimi".to_string();
+        config.pi.command = "intendant-test-absent-pi".to_string();
+        // The kimi probes honor KIMI_CODE_HOME; pin them to the injected
+        // home for the duration (mutate/restore under the env lock).
+        let _env = crate::test_support::TEST_ENV_LOCK.blocking_lock();
+        let saved = std::env::var_os("KIMI_CODE_HOME");
+        std::env::remove_var("KIMI_CODE_HOME");
+        let rows = backend_availability_json(&config, home.path());
+        match &saved {
+            Some(value) => std::env::set_var("KIMI_CODE_HOME", value),
+            None => std::env::remove_var("KIMI_CODE_HOME"),
+        }
+        drop(_env);
+        let kimi_row = rows
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|row| row["id"] == "kimi")
+            .unwrap();
+        assert_eq!(kimi_row["login_incomplete"], serde_json::json!(true));
+        let codex_row = rows
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|row| row["id"] == "codex")
+            .unwrap();
+        assert_eq!(codex_row["login_incomplete"], serde_json::Value::Null);
+
+        let vault_fragment = include_str!("../../../static/app/32-vault-custody.js");
+        assert!(
+            vault_fragment.contains("login_incomplete"),
+            "the Vault card must consume the availability row's login_incomplete field"
+        );
+        assert!(
+            vault_fragment.contains("Sign-in incomplete"),
+            "the Vault card must render the partial state"
+        );
+        assert!(
+            vault_fragment.contains("Finish setup"),
+            "the partial state's affordance must be the finish-setup lane"
         );
     }
 

--- a/src/bin/caller/external_agent/mod.rs
+++ b/src/bin/caller/external_agent/mod.rs
@@ -3189,7 +3189,7 @@ mod tests {
             .unwrap();
         assert_eq!(codex_row["login_incomplete"], serde_json::Value::Null);
 
-        let vault_fragment = include_str!("../../../static/app/32-vault-custody.js");
+        let vault_fragment = include_str!("../../../../static/app/32-vault-custody.js");
         assert!(
             vault_fragment.contains("login_incomplete"),
             "the Vault card must consume the availability row's login_incomplete field"

--- a/src/bin/caller/kimi_auth_ceremony.rs
+++ b/src/bin/caller/kimi_auth_ceremony.rs
@@ -18,7 +18,8 @@ use crate::auth_ceremony::{
     AuthProbe, CeremonyAccount, CeremonyPhase, Provider, StartRefusal,
 };
 use crate::external_agent::kimi_code::{
-    capture_kimi_credential_baseline, install_kimi_credential_if_unchanged, KimiCredentialBaseline,
+    capture_kimi_credential_baseline, ceremony_home_provisioned, complete_managed_onboarding,
+    install_kimi_credential_if_unchanged, seed_kimi_ceremony_credential, KimiCredentialBaseline,
     KimiCredentialInstall,
 };
 
@@ -53,7 +54,17 @@ impl CredentialPromotion {
     }
 
     /// Promote the isolated login exactly once. `Ok(None)` means the CLI has
-    /// not finished writing a valid credential yet, so the poller should retry.
+    /// not finished sign-in AND onboarding yet, so the poller should retry.
+    ///
+    /// Kimi's own `/login` writes two halves — the credential, then the
+    /// managed provider+model entries its provisioner fetches into
+    /// `config.toml` (card 01KZR9YHTX: promoting only the credential leaves
+    /// the primary home signed in but unonboarded, and every session dies at
+    /// its first prompts call with wire code 40110). Promotion therefore
+    /// waits for the ceremony home to be BOTH logged in and provisioned —
+    /// there is a real window where the credential exists and the model
+    /// fetch is still in flight — and completes by installing the credential
+    /// and then merging the managed config entries into the primary home.
     fn probe_and_promote(&self) -> Result<Option<AuthProbe>, String> {
         let mut state = self
             .inner
@@ -66,12 +77,28 @@ impl CredentialPromotion {
         else {
             return Ok(None);
         };
+        if !ceremony_home_provisioned(&state.ceremony_home) {
+            return Ok(None);
+        }
         let completed = match install_kimi_credential_if_unchanged(
             &state.primary_home,
             &state.ceremony_home,
             state.baseline,
         ) {
-            Ok(KimiCredentialInstall::Installed) => Ok(probe),
+            Ok(KimiCredentialInstall::Installed) => {
+                // The credential is in. Finish the onboarding half with the
+                // provider entries this exact login just wrote; a failure
+                // here leaves the honest partial state the Vault card
+                // renders as "Sign-in incomplete — finish setup".
+                match complete_managed_onboarding(&state.primary_home, &state.ceremony_home) {
+                    Ok(()) => Ok(probe),
+                    Err(error) => Err(format!(
+                        "Kimi signed in, but installing its provider entries into config.toml \
+                         failed ({error}); sessions will refuse to start until setup is finished \
+                         — use Finish setup on the Vault tab's Kimi card"
+                    )),
+                }
+            }
             Ok(KimiCredentialInstall::SourceChanged) => Err(
                 "Kimi credentials changed in another login, logout, or refresh while this \
                  ceremony was running; the concurrent credential was preserved"
@@ -299,7 +326,15 @@ fn spawn_ceremony_process(id: u64, command: &str, primary_home: PathBuf) -> Resu
     };
     let ceremony_home = shim_parent.join("kimi-home");
     ensure_private_ceremony_directory(&ceremony_home)?;
-    let promotion = CredentialPromotion::new(primary_home, ceremony_home.clone())?;
+    let promotion = CredentialPromotion::new(primary_home.clone(), ceremony_home.clone())?;
+    // Seed the isolated home with the current credential (when one exists):
+    // kimi's login then refreshes and re-provisions without a device-code
+    // round trip, which makes this same ceremony the "finish setup" lane for
+    // a signed-in-but-unonboarded home. Best-effort — an unreadable primary
+    // credential simply leaves the normal interactive device flow, which
+    // completes onboarding all the same. The promotion baseline was captured
+    // above, before this copy, so the concurrent-change CAS is unaffected.
+    let _ = seed_kimi_ceremony_credential(&primary_home, &ceremony_home);
 
     let pair = portable_pty::native_pty_system()
         .openpty(portable_pty::PtySize {
@@ -427,8 +462,9 @@ fn reader_thread(
             Ok(None) => {
                 manager().spawn_failed(
                     id,
-                    "Kimi login exited without producing an authenticated credential; the \
-                     previous login was preserved"
+                    "Kimi login exited without completing sign-in and onboarding (its \
+                     credential or managed provider entries never appeared); the previous \
+                     login was preserved"
                         .to_string(),
                 );
                 return;
@@ -598,13 +634,46 @@ mod tests {
         assert!(custody_refusal_for(false).is_none());
     }
 
+    /// A login-provisioned ceremony config.toml in the exact shape kimi
+    /// 0.34.0's own provisioner writes (captured live on this seat).
+    const PROVISIONED_CEREMONY_CONFIG: &str = r#"default_model = "kimi-code/k3"
+
+[providers."managed:kimi-code"]
+type = "kimi"
+api_key = ""
+base_url = "https://api.kimi.com/coding/v1"
+
+[providers."managed:kimi-code".oauth]
+storage = "file"
+key = "oauth/kimi-code"
+
+[models."kimi-code/k3"]
+provider = "managed:kimi-code"
+model = "k3"
+max_context_size = 1048576
+display_name = "K3"
+"#;
+
+    /// The two-halves promotion gate and full completion (card 01KZR9YHTX):
+    /// nothing is promoted while the ceremony home lacks a valid credential,
+    /// nothing is promoted while the login has written its credential but
+    /// not yet its provider entries (the mid-login race that used to
+    /// recreate the incident state), and completion installs BOTH the
+    /// credential and the managed config.toml entries — the ceremony-complete
+    /// verdict is credentials present AND providers configured.
     #[test]
-    fn isolated_promotion_preserves_primary_until_a_valid_login_exists() {
+    fn isolated_promotion_completes_credential_and_onboarding_halves() {
         let temp = tempfile::tempdir().unwrap();
         let primary = temp.path().join("primary");
         let ceremony = temp.path().join("ceremony");
         std::fs::create_dir_all(primary.join("credentials")).unwrap();
         std::fs::create_dir_all(ceremony.join("credentials")).unwrap();
+        // The incident's primary state: fresh-install comment-only stub.
+        std::fs::write(
+            primary.join("config.toml"),
+            "# Login will populate managed Kimi provider and model entries.\n",
+        )
+        .unwrap();
         let old = serde_json::to_vec(&serde_json::json!({
             "refresh_token": "synthetic-old"
         }))
@@ -616,14 +685,67 @@ mod tests {
         std::fs::write(credentials_path(&primary), &old).unwrap();
         let promotion = CredentialPromotion::new(primary.clone(), ceremony.clone()).unwrap();
 
+        // No ceremony credential yet.
         assert_eq!(promotion.probe_and_promote().unwrap(), None);
         assert_eq!(std::fs::read(credentials_path(&primary)).unwrap(), old);
 
+        // Credential written, provisioning still in flight: not promotable.
         std::fs::write(credentials_path(&ceremony), &new).unwrap();
+        assert_eq!(promotion.probe_and_promote().unwrap(), None);
+        assert_eq!(std::fs::read(credentials_path(&primary)).unwrap(), old);
+
+        // Provisioning lands: the promotion installs the credential AND the
+        // managed provider entries, and the primary passes the same provider
+        // gate kimi's ensureReady enforces at the prompts call.
+        std::fs::write(ceremony.join("config.toml"), PROVISIONED_CEREMONY_CONFIG).unwrap();
         assert!(promotion
             .probe_and_promote()
             .unwrap()
             .is_some_and(|probe| probe.logged_in));
         assert_eq!(std::fs::read(credentials_path(&primary)).unwrap(), new);
+        assert_eq!(
+            crate::external_agent::kimi_code::providers_configured(&primary),
+            Some(true)
+        );
+        let config = std::fs::read_to_string(primary.join("config.toml")).unwrap();
+        assert!(config.contains("[providers.\"managed:kimi-code\"]"), "{config}");
+        assert!(config.contains("[models.\"kimi-code/k3\"]"), "{config}");
+    }
+
+    /// The finish-setup lane: a primary that is already signed in (the
+    /// seeded, non-interactive relogin) but unonboarded gets its provider
+    /// entries; the concurrent-change CAS still owns the credential half.
+    #[test]
+    fn seeded_completion_onboards_a_signed_in_but_unonboarded_primary() {
+        let temp = tempfile::tempdir().unwrap();
+        let primary = temp.path().join("primary");
+        let ceremony = temp.path().join("ceremony");
+        std::fs::create_dir_all(primary.join("credentials")).unwrap();
+        let credential = serde_json::to_vec(&serde_json::json!({
+            "refresh_token": "synthetic-existing"
+        }))
+        .unwrap();
+        std::fs::write(credentials_path(&primary), &credential).unwrap();
+        let promotion = CredentialPromotion::new(primary.clone(), ceremony.clone()).unwrap();
+
+        // What spawn_ceremony_process does: seed the ceremony home from the
+        // primary so kimi's login runs its non-interactive refresh path.
+        std::fs::create_dir_all(&ceremony).unwrap();
+        assert!(
+            crate::external_agent::kimi_code::seed_kimi_ceremony_credential(&primary, &ceremony)
+                .unwrap()
+        );
+        // Login re-provisions the config; the (possibly unrotated) seeded
+        // credential plus the provisioned config complete the ceremony.
+        std::fs::write(ceremony.join("config.toml"), PROVISIONED_CEREMONY_CONFIG).unwrap();
+        assert!(promotion
+            .probe_and_promote()
+            .unwrap()
+            .is_some_and(|probe| probe.logged_in));
+        assert_eq!(std::fs::read(credentials_path(&primary)).unwrap(), credential);
+        assert_eq!(
+            crate::external_agent::kimi_code::providers_configured(&primary),
+            Some(true)
+        );
     }
 }

--- a/src/bin/caller/kimi_auth_ceremony.rs
+++ b/src/bin/caller/kimi_auth_ceremony.rs
@@ -708,7 +708,10 @@ display_name = "K3"
             Some(true)
         );
         let config = std::fs::read_to_string(primary.join("config.toml")).unwrap();
-        assert!(config.contains("[providers.\"managed:kimi-code\"]"), "{config}");
+        assert!(
+            config.contains("[providers.\"managed:kimi-code\"]"),
+            "{config}"
+        );
         assert!(config.contains("[models.\"kimi-code/k3\"]"), "{config}");
     }
 
@@ -742,7 +745,10 @@ display_name = "K3"
             .probe_and_promote()
             .unwrap()
             .is_some_and(|probe| probe.logged_in));
-        assert_eq!(std::fs::read(credentials_path(&primary)).unwrap(), credential);
+        assert_eq!(
+            std::fs::read(credentials_path(&primary)).unwrap(),
+            credential
+        );
         assert_eq!(
             crate::external_agent::kimi_code::providers_configured(&primary),
             Some(true)

--- a/static/app.html
+++ b/static/app.html
@@ -39317,7 +39317,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '3c990bcbcef90a64';
+const INTENDANT_APP_BUILD = '6d56e0405251018b';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -40199,8 +40199,11 @@ function installedExternalAgents() {
 function readyExternalAgents() {
   // "Ready" = usable with no further credential step: fueled by a
   // subscription lease, or signed in on the daemon with its own account.
+  // A signed-in backend whose onboarding never finished (login_incomplete
+  // — kimi's credential-without-providers state) is NOT ready: its
+  // sessions die at the first prompt until setup is finished.
   return installedExternalAgents().filter(
-    agent => agent.leased || agent.local_login === true
+    agent => agent.leased || (agent.local_login === true && agent.login_incomplete !== true)
   );
 }
 function applyExternalAgentAvailabilityToNewSessionPicker() {
@@ -40374,7 +40377,12 @@ function applyUnfueledExternalAgentNote(empty, { omitReady = false } = {}) {
   const installed = installedExternalAgents();
   const names = agents => joinAgentNames(agents.map(agent => agent.label || agent.id));
   const leased = installed.filter(agent => agent.leased);
-  const signedIn = installed.filter(agent => !agent.leased && agent.local_login === true);
+  const signedIn = installed.filter(
+    agent => !agent.leased && agent.local_login === true && agent.login_incomplete !== true
+  );
+  const incomplete = installed.filter(
+    agent => !agent.leased && agent.local_login === true && agent.login_incomplete === true
+  );
   const signedOut = installed.filter(agent => !agent.leased && agent.local_login === false);
   const ownLogin = installed.filter(
     agent => !agent.leased && agent.local_login !== true && agent.local_login !== false
@@ -40389,6 +40397,13 @@ function applyUnfueledExternalAgentNote(empty, { omitReady = false } = {}) {
     parts.push(signedIn.length === 1
       ? `${names(signedIn)} is signed in on the daemon and needs no fuel`
       : `${names(signedIn)} are signed in on the daemon and need no fuel`);
+  }
+  if (incomplete.length) {
+    // Signed in but unonboarded (kimi's credential-without-providers
+    // state): sessions die at their first prompt until setup finishes.
+    parts.push(incomplete.length === 1
+      ? `${names(incomplete)} is signed in but its setup never finished — use Finish setup on its Vault card`
+      : `${names(incomplete)} are signed in but their setup never finished — use Finish setup on their Vault cards`);
   }
   if (signedOut.length) {
     parts.push(signedOut.length === 1
@@ -45957,6 +45972,22 @@ function agentSigninMissingAvailability(spec) {
   return entry && entry.installed === false ? entry : null;
 }
 
+/* The signed-in-but-unonboarded partial state (today only Kimi reports it):
+   the availability row's `login_incomplete === true` means the backend's
+   credential exists while its config declares no provider — sign-in
+   finished, onboarding didn't (kimi's own login writes both), and every
+   session dies at its first prompt (wire code 40110) until setup is
+   finished. The affordance is the SAME sign-in ceremony: the daemon seeds
+   the isolated login with the existing credential, so the backend
+   re-provisions on the current account, usually with no browser step. */
+function agentSigninIncompleteAvailability(spec) {
+  if (!Array.isArray(externalAgentAvailability)) return null;
+  const entry = externalAgentAvailability.find(
+    agent => agent && agent.id === spec.sessionKind
+  );
+  return entry && entry.login_incomplete === true ? entry : null;
+}
+
 /* The approval-gated Install lane on a not-installed card. Everything
    renders from the availability row's `install` object, which the daemon
    derives from its install-command matrix (`available` + the exact
@@ -46250,6 +46281,23 @@ function agentSigninProviderCard(provider) {
       const other = AGENT_SIGNIN_PROVIDERS[busyWith]?.label || busyWith;
       note(
         `A ${other} sign-in ceremony is running — one credential ceremony at a time on this daemon.`
+      );
+      return card;
+    }
+    if (phase === 'idle' && agentSigninIncompleteAvailability(spec)) {
+      const setupChip = document.createElement('span');
+      setupChip.className = 'vault-chip warn';
+      setupChip.textContent = 'setup incomplete';
+      head.appendChild(setupChip);
+      note(
+        `Sign-in incomplete — finish setup. ${spec.label} is signed in on this machine, but ` +
+          'onboarding never finished: its config has no provider entries (the sign-in normally ' +
+          'writes them), so sessions fail at their first prompt until setup completes. Finish ' +
+          'setup completes onboarding on the existing account — usually with no browser step.',
+        'vault-warning'
+      );
+      actionsRow(
+        vaultButton('Finish setup', () => agentSigninStart(provider), { primary: true })
       );
       return card;
     }

--- a/static/app/31-init-identity-fleet.js
+++ b/static/app/31-init-identity-fleet.js
@@ -895,8 +895,11 @@ function installedExternalAgents() {
 function readyExternalAgents() {
   // "Ready" = usable with no further credential step: fueled by a
   // subscription lease, or signed in on the daemon with its own account.
+  // A signed-in backend whose onboarding never finished (login_incomplete
+  // — kimi's credential-without-providers state) is NOT ready: its
+  // sessions die at the first prompt until setup is finished.
   return installedExternalAgents().filter(
-    agent => agent.leased || agent.local_login === true
+    agent => agent.leased || (agent.local_login === true && agent.login_incomplete !== true)
   );
 }
 function applyExternalAgentAvailabilityToNewSessionPicker() {
@@ -1070,7 +1073,12 @@ function applyUnfueledExternalAgentNote(empty, { omitReady = false } = {}) {
   const installed = installedExternalAgents();
   const names = agents => joinAgentNames(agents.map(agent => agent.label || agent.id));
   const leased = installed.filter(agent => agent.leased);
-  const signedIn = installed.filter(agent => !agent.leased && agent.local_login === true);
+  const signedIn = installed.filter(
+    agent => !agent.leased && agent.local_login === true && agent.login_incomplete !== true
+  );
+  const incomplete = installed.filter(
+    agent => !agent.leased && agent.local_login === true && agent.login_incomplete === true
+  );
   const signedOut = installed.filter(agent => !agent.leased && agent.local_login === false);
   const ownLogin = installed.filter(
     agent => !agent.leased && agent.local_login !== true && agent.local_login !== false
@@ -1085,6 +1093,13 @@ function applyUnfueledExternalAgentNote(empty, { omitReady = false } = {}) {
     parts.push(signedIn.length === 1
       ? `${names(signedIn)} is signed in on the daemon and needs no fuel`
       : `${names(signedIn)} are signed in on the daemon and need no fuel`);
+  }
+  if (incomplete.length) {
+    // Signed in but unonboarded (kimi's credential-without-providers
+    // state): sessions die at their first prompt until setup finishes.
+    parts.push(incomplete.length === 1
+      ? `${names(incomplete)} is signed in but its setup never finished — use Finish setup on its Vault card`
+      : `${names(incomplete)} are signed in but their setup never finished — use Finish setup on their Vault cards`);
   }
   if (signedOut.length) {
     parts.push(signedOut.length === 1

--- a/static/app/32-vault-custody.js
+++ b/static/app/32-vault-custody.js
@@ -2260,6 +2260,22 @@ function agentSigninMissingAvailability(spec) {
   return entry && entry.installed === false ? entry : null;
 }
 
+/* The signed-in-but-unonboarded partial state (today only Kimi reports it):
+   the availability row's `login_incomplete === true` means the backend's
+   credential exists while its config declares no provider — sign-in
+   finished, onboarding didn't (kimi's own login writes both), and every
+   session dies at its first prompt (wire code 40110) until setup is
+   finished. The affordance is the SAME sign-in ceremony: the daemon seeds
+   the isolated login with the existing credential, so the backend
+   re-provisions on the current account, usually with no browser step. */
+function agentSigninIncompleteAvailability(spec) {
+  if (!Array.isArray(externalAgentAvailability)) return null;
+  const entry = externalAgentAvailability.find(
+    agent => agent && agent.id === spec.sessionKind
+  );
+  return entry && entry.login_incomplete === true ? entry : null;
+}
+
 /* The approval-gated Install lane on a not-installed card. Everything
    renders from the availability row's `install` object, which the daemon
    derives from its install-command matrix (`available` + the exact
@@ -2553,6 +2569,23 @@ function agentSigninProviderCard(provider) {
       const other = AGENT_SIGNIN_PROVIDERS[busyWith]?.label || busyWith;
       note(
         `A ${other} sign-in ceremony is running — one credential ceremony at a time on this daemon.`
+      );
+      return card;
+    }
+    if (phase === 'idle' && agentSigninIncompleteAvailability(spec)) {
+      const setupChip = document.createElement('span');
+      setupChip.className = 'vault-chip warn';
+      setupChip.textContent = 'setup incomplete';
+      head.appendChild(setupChip);
+      note(
+        `Sign-in incomplete — finish setup. ${spec.label} is signed in on this machine, but ` +
+          'onboarding never finished: its config has no provider entries (the sign-in normally ' +
+          'writes them), so sessions fail at their first prompt until setup completes. Finish ' +
+          'setup completes onboarding on the existing account — usually with no browser step.',
+        'vault-warning'
+      );
+      actionsRow(
+        vaultButton('Finish setup', () => agentSigninStart(provider), { primary: true })
       );
       return card;
     }


### PR DESCRIPTION
The Vault sign-in ceremony synced only the credential half of kimi login;
the managed provider+model entries login writes into config.toml were
discarded with the ceremony home, leaving the primary signed in but
unonboarded — every session then died at its first prompts call with wire
code 40110 (owner live e2e 2026-08-11).

- onboarding.rs: providers_configured (ensureReady's gate, daemon-side),
  ceremony_home_provisioned, and complete_managed_onboarding — a
  toml_edit merge of the ceremony home's managed entries into the primary
  config.toml mirroring applyManagedKimiCodeConfig's ownership semantics
  (verified against the kimi 0.34.0 binary): managed provider record,
  managed aliases (mergeRefreshedModelAlias: user extras + overrides
  preserved, stale aliases dropped), moonshot services, preservable
  default_model kept, user thinking table kept, comments preserved.
- ceremony: promotion now waits for BOTH halves (credential + provisioned
  ceremony config) and installs both; the ceremony home is seeded with
  the existing primary credential so kimi's own login re-provisions
  non-interactively — the same ceremony is the finish-setup lane.
- availability: login_incomplete (kimi credential-without-providers) on
  the wire row; Vault card renders 'Sign-in incomplete — finish setup'
  with a Finish setup affordance; empty-state readiness excludes the
  incomplete state.
- wire: provider_onboarding_refusal recognizer pinned to the captured
  incident envelope; create/profile/prompts seams rewrite the bare 40110
  into the finish-setup remedy (signed-in vs signed-out flavors).
