### PR TITLE
xr: survive the consent moment — preload wasm for activation, visible entry status

### DIFF
--- a/static/app.html
+++ b/static/app.html
@@ -32844,6 +32844,21 @@ html.ui-v2 .ui2-xr-chip[data-state="error"] {
   border-color: var(--line-2);
   opacity: .8;
 }
+
+/* Visible entry status: tooltips don't exist in a headset. */
+html.ui-v2 .ui2-xr-status {
+  margin-left: 8px;
+  font-size: 12px;
+  color: var(--text-2);
+  max-width: 42ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+html.ui-v2 .ui2-xr-status[data-state="error"] {
+  color: #E87A8B;
+}
 </style>
 <!-- ── static/app/20-shell.html ── -->
 </head>
@@ -39366,7 +39381,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '9fd138fa0abe2f7d';
+const INTENDANT_APP_BUILD = 'b3c5ab5120d90fff';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -146214,6 +146229,7 @@ async function ensureXr() {
   xrInstance.setOnSessionEnd(() => {
     xrStopSnapshotPump();
     xrSetChipState('idle', 'Enter XR');
+    xrShowStatus('', '');
   });
   await xrInstance.probeSupport();
   return xrInstance;
@@ -146280,18 +146296,54 @@ function xrStopSnapshotPump() {
   }
 }
 
+// Visible status line beside the chip. Tooltips don't exist inside a
+// headset, so entry progress and failures must be rendered text.
+function xrShowStatus(state, text) {
+  if (!xrChipEl) return;
+  let el = document.getElementById('ui2-xr-status');
+  if (!text) {
+    if (el) el.remove();
+    return;
+  }
+  if (!el) {
+    el = document.createElement('span');
+    el.id = 'ui2-xr-status';
+    el.className = 'ui2-xr-status';
+    xrChipEl.insertAdjacentElement('afterend', el);
+  }
+  el.dataset.state = state;
+  el.textContent = text;
+}
+
 async function xrEnter() {
   xrSetChipState('busy', 'Starting immersive session…');
+  xrShowStatus('busy', 'starting…');
+  // The permission dialog can take a while to be noticed in-headset; an
+  // unsettled entry is almost always the consent prompt waiting, not a
+  // hang. Say so where the operator can read it.
+  const consentHint = setTimeout(() => {
+    xrShowStatus('busy', 'waiting for the headset permission dialog — look for an Allow prompt');
+  }, 6000);
   try {
-    const inst = await ensureXr();
+    // The module is preloaded at chip mount so this click reaches
+    // requestSession while its user activation is still fresh — a slow
+    // module fetch here used to burn the activation window.
+    const inst = xrInstance || await ensureXr();
     // Passthrough-first: prefer AR on hardware that has it (Quest 3),
     // fall back to VR (Vision Pro Safari has no immersive-ar).
     const mode = xrSupport.ar ? 'immersive-ar' : 'immersive-vr';
     await inst.enter(mode);
+    clearTimeout(consentHint);
     xrStartSnapshotPump();
     xrSetChipState('active', 'Immersive session running');
+    xrShowStatus('', '');
   } catch (err) {
-    xrSetChipState('error', 'XR entry failed: ' + (err && err.message ? err.message : err));
+    clearTimeout(consentHint);
+    const detail = (err && (err.message || err.name)) || String(err);
+    xrSetChipState('error', 'XR entry failed: ' + detail);
+    // Persist the failure where a headset user can read it; clear on the
+    // next attempt instead of a timer.
+    xrShowStatus('error', 'XR entry failed: ' + detail);
     setTimeout(() => xrSetChipState('idle', 'Enter XR'), 4000);
   }
 }
@@ -146318,6 +146370,14 @@ function xrMountChip() {
   xrSupport = await xrProbeSupportLight();
   if (!xrSupport.ar && !xrSupport.vr) return;
   xrMountChip();
+  // Preload the WASM module now so the click handler reaches
+  // requestSession within its transient user-activation window — the
+  // module fetch must never sit between the tap and the session request.
+  try {
+    await ensureXr();
+  } catch (err) {
+    xrShowStatus('error', 'XR module failed to load: ' + ((err && err.message) || err));
+  }
 })();
 
 // QA facade, mirroring the stationProbe convention: the validator's

--- a/static/app/ui2-xr.css
+++ b/static/app/ui2-xr.css
@@ -46,3 +46,18 @@ html.ui-v2 .ui2-xr-chip[data-state="error"] {
   border-color: var(--line-2);
   opacity: .8;
 }
+
+/* Visible entry status: tooltips don't exist in a headset. */
+html.ui-v2 .ui2-xr-status {
+  margin-left: 8px;
+  font-size: 12px;
+  color: var(--text-2);
+  max-width: 42ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+html.ui-v2 .ui2-xr-status[data-state="error"] {
+  color: #E87A8B;
+}

--- a/static/app/ui2-xr.js
+++ b/static/app/ui2-xr.js
@@ -72,6 +72,7 @@ async function ensureXr() {
   xrInstance.setOnSessionEnd(() => {
     xrStopSnapshotPump();
     xrSetChipState('idle', 'Enter XR');
+    xrShowStatus('', '');
   });
   await xrInstance.probeSupport();
   return xrInstance;
@@ -138,18 +139,54 @@ function xrStopSnapshotPump() {
   }
 }
 
+// Visible status line beside the chip. Tooltips don't exist inside a
+// headset, so entry progress and failures must be rendered text.
+function xrShowStatus(state, text) {
+  if (!xrChipEl) return;
+  let el = document.getElementById('ui2-xr-status');
+  if (!text) {
+    if (el) el.remove();
+    return;
+  }
+  if (!el) {
+    el = document.createElement('span');
+    el.id = 'ui2-xr-status';
+    el.className = 'ui2-xr-status';
+    xrChipEl.insertAdjacentElement('afterend', el);
+  }
+  el.dataset.state = state;
+  el.textContent = text;
+}
+
 async function xrEnter() {
   xrSetChipState('busy', 'Starting immersive session…');
+  xrShowStatus('busy', 'starting…');
+  // The permission dialog can take a while to be noticed in-headset; an
+  // unsettled entry is almost always the consent prompt waiting, not a
+  // hang. Say so where the operator can read it.
+  const consentHint = setTimeout(() => {
+    xrShowStatus('busy', 'waiting for the headset permission dialog — look for an Allow prompt');
+  }, 6000);
   try {
-    const inst = await ensureXr();
+    // The module is preloaded at chip mount so this click reaches
+    // requestSession while its user activation is still fresh — a slow
+    // module fetch here used to burn the activation window.
+    const inst = xrInstance || await ensureXr();
     // Passthrough-first: prefer AR on hardware that has it (Quest 3),
     // fall back to VR (Vision Pro Safari has no immersive-ar).
     const mode = xrSupport.ar ? 'immersive-ar' : 'immersive-vr';
     await inst.enter(mode);
+    clearTimeout(consentHint);
     xrStartSnapshotPump();
     xrSetChipState('active', 'Immersive session running');
+    xrShowStatus('', '');
   } catch (err) {
-    xrSetChipState('error', 'XR entry failed: ' + (err && err.message ? err.message : err));
+    clearTimeout(consentHint);
+    const detail = (err && (err.message || err.name)) || String(err);
+    xrSetChipState('error', 'XR entry failed: ' + detail);
+    // Persist the failure where a headset user can read it; clear on the
+    // next attempt instead of a timer.
+    xrShowStatus('error', 'XR entry failed: ' + detail);
     setTimeout(() => xrSetChipState('idle', 'Enter XR'), 4000);
   }
 }
@@ -176,6 +213,14 @@ function xrMountChip() {
   xrSupport = await xrProbeSupportLight();
   if (!xrSupport.ar && !xrSupport.vr) return;
   xrMountChip();
+  // Preload the WASM module now so the click handler reaches
+  // requestSession within its transient user-activation window — the
+  // module fetch must never sit between the tap and the session request.
+  try {
+    await ensureXr();
+  } catch (err) {
+    xrShowStatus('error', 'XR module failed to load: ' + ((err && err.message) || err));
+  }
 })();
 
 // QA facade, mirroring the stationProbe convention: the validator's


### PR DESCRIPTION
Two real-device defects the headset exposed and the shim could not:

- The chip click fetched + compiled the XR wasm module before calling
  requestSession, and browsers only honor an immersive request within a
  few seconds of the tap — over a relay round-trip plus mobile wasm
  compile the transient user activation could expire. The module now
  preloads at chip mount; the tap reaches requestSession immediately.
- Entry progress and failures rendered only as chip hover tooltips,
  which do not exist inside a headset — every failure read as 'stuck in
  loading'. There is now a visible status line beside the chip; after
  six seconds of unsettled entry it names the most likely cause
  ('waiting for the headset permission dialog — look for an Allow
  prompt'), errors persist until the next attempt instead of vanishing
  on a timer, and session end clears it.

validate-dashboard --xr-probe stays green (loopback launch + live fleet
ingress).
