### PR TITLE
xr: graduate — drop the dev gate

### DIFF
--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -778,8 +778,8 @@ authority surface. Today the scene is a 3D constellation backdrop with the
 working UI painted as screen-space HUD panels. Activity remains the default
 DOM control surface. The immersive WebXR direction moved to its own surface
 and chapter as of 2026-08-13 — see [XR](./xr.md): a careful spatial port of
-the regular dashboard (dev-gated entry chip behind `?xr=dev` until its first
-hardware validation), not an extension of Station's design.
+the regular dashboard (entry chip on by default for XR-capable
+browsers; `?xr=off` opts out), not an extension of Station's design.
 The dedicated
 [Station](./station.md) chapter carries the architecture, an honest
 current-state inventory, and the roadmap.

--- a/docs/src/xr.md
+++ b/docs/src/xr.md
@@ -92,11 +92,11 @@ every other frontend. Deferred deliberately: the voice composer toggle (no
 existing action seam to reuse; needs a designed one, not a hack) and
 compositor media layers (below).
 
-### Dev gate
+### Availability
 
-Until milestone 1 is validated on hardware, the entry chip is gated behind
-`?xr=dev` (same convention as `?station_panes=on`). The gate drops once the
-Quest pass confirms the experience.
+The entry chip ships on by default for any browser reporting immersive
+support (milestone 1 graduated on the owner's Quest 3, 2026-08-13);
+`?xr=off` is the opt-out escape hatch.
 
 ## Testing
 
@@ -110,7 +110,7 @@ developer loop sidesteps both:
    USB-C, accept the debug prompt.
 2. `adb reverse tcp:8765 tcp:8765` (after `adb devices` shows the headset;
    works over Wi-Fi adb after a one-time USB bootstrap).
-3. In Horizon Browser: `http://localhost:8765/?xr=dev` — localhost is a
+3. In Horizon Browser: `http://localhost:8765/` — localhost is a
    secure context, and the daemon sees a loopback client (local-presence
    lane; no cert ceremony).
 4. Tap the **XR** chip in the header. Passthrough is the default premise —

--- a/scripts/validate-dashboard.cjs
+++ b/scripts/validate-dashboard.cjs
@@ -254,7 +254,6 @@ Checks:
                               stereo frame loop (2 views), synthetic-snapshot scene build,
                               activation-by-name card select, and a captured approval dispatch
                               asserted against the dashboard's action shape (never routed to the
-                              daemon). Appends ?xr=dev to the target URL automatically
 
 Options:
   --host HOST                 Host used with --port (default: 127.0.0.1)
@@ -2294,13 +2293,6 @@ class BrowserHarness {
           { source: XR_WEBXR_SHIM_SOURCE },
           this.sessionId,
         );
-        // The chip is dev-gated and the gate is read at module eval, so
-        // the query param must ride the first navigation. Applied here —
-        // not at arg parse — because --launch-dashboard resolves its URL
-        // only after the temporary daemon binds a port.
-        if (!/[?&]xr=dev\b/.test(opts.url)) {
-          opts.url += (opts.url.includes('?') ? '&' : '?') + 'xr=dev';
-        }
       }
       const nav = await this.cdp.send('Page.navigate', { url: opts.url }, this.sessionId);
       if (nav.errorText) {

--- a/static/app.html
+++ b/static/app.html
@@ -39392,7 +39392,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'aa2582a1bde90f64';
+const INTENDANT_APP_BUILD = '8b8033b687910385';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -146174,11 +146174,11 @@ function handleDisplayRequestResolved(d) {
 // second brain. This fragment owns only the browser-side seam: feature
 // detection, the entry chip, lazy module load, and session entry.
 //
-// DEV GATE: until milestone 1 completes, the chip appears only with
-// `?xr=dev` in the URL (same convention as `?station_panes=on`) — the
-// scaffold's enter() intentionally rejects. Everything below is
-// boot-callback or event-driven; top level declares only lets/consts/
-// functions (deep-link TDZ rule).
+// SHIPPED DEFAULT: the chip appears on any browser reporting immersive
+// support (milestone 1 graduated on the owner's Quest 3, 2026-08-13);
+// `?xr=off` is the opt-out escape. Everything below is boot-callback or
+// event-driven; top level declares only lets/consts/functions
+// (deep-link TDZ rule).
 
 let xrWasmModule = null; // module namespace after first ensureXr()
 let xrInstance = null;   // XrWeb handle after first ensureXr()
@@ -146187,11 +146187,11 @@ let xrSupport = { ar: false, vr: false };
 let xrSnapshotTimer = null;
 let xrCaptureOnly = false; // probe mode: record actions, don't route
 
-function xrDevGateOn() {
+function xrEnabled() {
   try {
-    return new URLSearchParams(location.search).get('xr') === 'dev';
+    return new URLSearchParams(location.search).get('xr') !== 'off';
   } catch {
-    return false;
+    return true;
   }
 }
 
@@ -146393,7 +146393,7 @@ function xrMountChip() {
 }
 
 (async () => {
-  if (!xrDevGateOn()) return;
+  if (!xrEnabled()) return;
   xrSupport = await xrProbeSupportLight();
   if (!xrSupport.ar && !xrSupport.vr) return;
   xrMountChip();
@@ -146410,7 +146410,7 @@ function xrMountChip() {
 // QA facade, mirroring the stationProbe convention: the validator's
 // --xr-probe drives the surface through here.
 globalThis.xrProbe = {
-  devGate: xrDevGateOn,
+  enabled: xrEnabled,
   support: () => ({ ...xrSupport }),
   chip: () => xrChipEl,
   ensure: ensureXr,

--- a/static/app/ui2-xr.js
+++ b/static/app/ui2-xr.js
@@ -6,11 +6,11 @@
 // second brain. This fragment owns only the browser-side seam: feature
 // detection, the entry chip, lazy module load, and session entry.
 //
-// DEV GATE: until milestone 1 completes, the chip appears only with
-// `?xr=dev` in the URL (same convention as `?station_panes=on`) — the
-// scaffold's enter() intentionally rejects. Everything below is
-// boot-callback or event-driven; top level declares only lets/consts/
-// functions (deep-link TDZ rule).
+// SHIPPED DEFAULT: the chip appears on any browser reporting immersive
+// support (milestone 1 graduated on the owner's Quest 3, 2026-08-13);
+// `?xr=off` is the opt-out escape. Everything below is boot-callback or
+// event-driven; top level declares only lets/consts/functions
+// (deep-link TDZ rule).
 
 let xrWasmModule = null; // module namespace after first ensureXr()
 let xrInstance = null;   // XrWeb handle after first ensureXr()
@@ -19,11 +19,11 @@ let xrSupport = { ar: false, vr: false };
 let xrSnapshotTimer = null;
 let xrCaptureOnly = false; // probe mode: record actions, don't route
 
-function xrDevGateOn() {
+function xrEnabled() {
   try {
-    return new URLSearchParams(location.search).get('xr') === 'dev';
+    return new URLSearchParams(location.search).get('xr') !== 'off';
   } catch {
-    return false;
+    return true;
   }
 }
 
@@ -225,7 +225,7 @@ function xrMountChip() {
 }
 
 (async () => {
-  if (!xrDevGateOn()) return;
+  if (!xrEnabled()) return;
   xrSupport = await xrProbeSupportLight();
   if (!xrSupport.ar && !xrSupport.vr) return;
   xrMountChip();
@@ -242,7 +242,7 @@ function xrMountChip() {
 // QA facade, mirroring the stationProbe convention: the validator's
 // --xr-probe drives the surface through here.
 globalThis.xrProbe = {
-  devGate: xrDevGateOn,
+  enabled: xrEnabled,
   support: () => ({ ...xrSupport }),
   chip: () => xrChipEl,
   ensure: ensureXr,


### PR DESCRIPTION
Milestone 1 held up on the owner's Quest 3 (entry, passthrough shelf, ray-select with visible pointer, workbench), so the entry chip ships on by default for any browser reporting immersive support. `?xr=off` is the opt-out escape. Docs and the validator probe follow: the probe now validates the ungated default (chip from feature detection alone, no query param), and the recipes lose their `?xr=dev` suffix.

Probe (ungated): `xr probe: ok — frames=39 views=2 panels=12 texts=12 hits=5 passthrough=true action=approval/approve`