### PR TITLE
installers: build named bins; semver-aware fallback tag pick

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -47,9 +47,10 @@
 .PARAMETER Ref
     Pin the fresh clone to a tag, branch, or commit. Default: the release
     this installer was stamped with (when fetched as a release asset); an
-    unstamped copy falls back to the newest published release tag
-    (vX.Y.Z), and to the default branch head only while no release
-    exists. An explicit ref you choose skips the release-pin
+    unstamped copy falls back to the newest published release tag by
+    semver precedence (vX.Y.Z or vX.Y.Z-<prerelease> -- prerelease
+    releases count), and to the default branch head only while no
+    release exists. An explicit ref you choose skips the release-pin
     verification.
 
 .PARAMETER Service
@@ -116,6 +117,58 @@ if ($InstallerReleaseCommit) {
 $elevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()
     ).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
 
+# -- Release-tag picking --
+# Highest-precedence release tag under semver 2.0 ordering: version core
+# first, then release > prerelease, then prerelease identifiers
+# (dot-separated; numeric identifiers compare numerically and rank below
+# alphanumeric ones, alphanumeric compare ASCII-lexically, the shorter
+# identifier set loses ties). Earlier copies filtered prerelease tags out
+# entirely (and [version] cannot parse them anyway) -- but the published
+# alphas ARE the product releases (GitHub marks them Latest), so an
+# unstamped copy was silently regressing fresh installs to the stale
+# v0.1.0. Windows PowerShell 5.1 has no [semver] type, hence the
+# explicit comparer.
+function Compare-IntendantReleaseTag([string]$A, [string]$B) {
+    $coreA, $preA = ($A.Substring(1) -split '-', 2)
+    $coreB, $preB = ($B.Substring(1) -split '-', 2)
+    $numsA = $coreA -split '\.'
+    $numsB = $coreB -split '\.'
+    for ($i = 0; $i -lt 3; $i++) {
+        $d = [long]$numsA[$i] - [long]$numsB[$i]
+        if ($d -ne 0) { return [math]::Sign($d) }
+    }
+    if (-not $preA -and -not $preB) { return 0 }
+    if (-not $preA) { return 1 }   # a release outranks any prerelease of the same core
+    if (-not $preB) { return -1 }
+    $idsA = $preA -split '\.'
+    $idsB = $preB -split '\.'
+    $n = [math]::Min($idsA.Count, $idsB.Count)
+    for ($i = 0; $i -lt $n; $i++) {
+        $x = $idsA[$i]; $y = $idsB[$i]
+        $xNum = $x -match '^[0-9]+$'
+        $yNum = $y -match '^[0-9]+$'
+        if ($xNum -and $yNum) {
+            $d = [long]$x - [long]$y
+            if ($d -ne 0) { return [math]::Sign($d) }
+        } elseif ($xNum -ne $yNum) {
+            if ($xNum) { return -1 } else { return 1 }
+        } else {
+            $d = [string]::CompareOrdinal($x, $y)
+            if ($d -ne 0) { return [math]::Sign($d) }
+        }
+    }
+    return [math]::Sign($idsA.Count - $idsB.Count)
+}
+
+function Select-IntendantReleaseTag([string[]]$Tags) {
+    $best = $null
+    foreach ($tag in $Tags) {
+        if (-not $tag) { continue }
+        if ($null -eq $best -or (Compare-IntendantReleaseTag $tag $best) -gt 0) { $best = $tag }
+    }
+    return $best
+}
+
 # -- Toolchain --
 # git is needed before anything else -- the clone is how the repo's own
 # setup scripts (scripts\setup-windows.ps1) arrive, so they cannot
@@ -166,17 +219,19 @@ if (Test-Path (Join-Path $InstallDir ".git")) {
             Say "installing the stamped release: $Ref"
         } else {
             # Unstamped copy: default fresh installs to the newest published
-            # release tag (vX.Y.Z only -- pre-releases and peeled refs are
-            # filtered) so even this path delivers an immutable, released
-            # tree. Falling back to the mutable default-branch head happens
-            # only while no release exists, and says so out loud. -Ref
-            # overrides either way.
+            # release tag by semver precedence so even this path delivers an
+            # immutable, released tree. Prerelease tags count (see the
+            # picker above -- the old vX.Y.Z-only filter regressed fresh
+            # installs to v0.1.0); peeled ^{} refs stay excluded by the
+            # $-anchored match. Falling back to the mutable default-branch
+            # head happens only while no release exists, and says so out
+            # loud. -Ref overrides either way.
             $tagLines = git ls-remote --tags $Repo "v*"
             if ($LASTEXITCODE -eq 0 -and $tagLines) {
-                $Ref = @($tagLines) |
-                    ForEach-Object { if ($_ -match 'refs/tags/(v\d+\.\d+(\.\d+){0,2})$') { $Matches[1] } } |
-                    Sort-Object { [version]$_.Substring(1) } |
-                    Select-Object -Last 1
+                $candidates = @(@($tagLines) | ForEach-Object {
+                    if ($_ -match 'refs/tags/(v\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?)$') { $Matches[1] }
+                })
+                $Ref = Select-IntendantReleaseTag $candidates
             }
             if ($Ref) {
                 Say "pinning to the latest release tag: $Ref (override with -Ref)"
@@ -235,8 +290,15 @@ if ($elevated -and (Test-Path $setup)) {
 # -- Build --
 # --locked: build exactly the committed Cargo.lock -- a resolution that
 # differs from what CI tested is a failure, not a fallback.
+# Named bins mirror the release lane's proven build shape (release.yml's
+# binary jobs): a daemon install needs intendant.exe +
+# intendant-runtime.exe only, and naming them skips the wasm workspace
+# members and station-web's native graphics stack (~71 packages) that a
+# bare workspace build would compile -- a configuration no CI leg gates --
+# while shrinking the install build. intendant-connect is the hosted
+# rendezvous service and is not part of a daemon install.
 Say "building release binaries (this takes a few minutes on a fresh box)"
-cargo build --release --locked
+cargo build --release --locked --bin intendant --bin intendant-runtime
 if ($LASTEXITCODE -ne 0) { Fail "cargo build failed" }
 $daemonExe = Join-Path $InstallDir "target\release\intendant.exe"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -48,10 +48,11 @@ Options:
   --ref <ref>     Pin the fresh clone to a tag, branch, or commit.
                   Default: the release this installer was stamped with
                   (when fetched as a release asset); an unstamped copy
-                  falls back to the newest published release tag (vX.Y.Z),
-                  and to the default branch head only while no release
-                  exists. An explicit ref you choose skips the
-                  release-pin verification.
+                  falls back to the newest published release tag by
+                  semver precedence (vX.Y.Z or vX.Y.Z-<prerelease> —
+                  prerelease releases count), and to the default branch
+                  head only while no release exists. An explicit ref you
+                  choose skips the release-pin verification.
   --no-run        Build and link only; print how to start it.
 
 Environment overrides:
@@ -161,6 +162,53 @@ then re-run this installer"
   command -v git >/dev/null 2>&1 || die "the install reported success but git is still not on PATH — install git yourself, then re-run this installer"
 fi
 
+# ── Release-tag picker ──
+# Reads candidate tags (vX.Y.Z or vX.Y.Z-<prerelease>) one per line and
+# prints the highest-precedence one under semver 2.0 ordering: version
+# core first, then release > prerelease, then prerelease identifiers
+# (dot-separated; numeric identifiers compare numerically and rank below
+# alphanumeric ones, alphanumeric compare ASCII-lexically, the shorter
+# identifier set loses ties). Earlier copies filtered prerelease tags out
+# entirely (and `sort -V` cannot order them per semver anyway) — but the
+# published alphas ARE the product releases (GitHub marks them Latest),
+# so an unstamped copy was silently regressing fresh installs to the
+# stale v0.1.0.
+semver_max_tag() {
+  awk '
+    function ident_cmp(x, y,   xn, yn) {
+      xn = (x ~ /^[0-9]+$/); yn = (y ~ /^[0-9]+$/)
+      if (xn && yn) { if (x + 0 == y + 0) return 0; return (x + 0 < y + 0) ? -1 : 1 }
+      if (xn != yn) return xn ? -1 : 1
+      if (x "" == y "") return 0
+      return (x "" < y "") ? -1 : 1
+    }
+    function pre_cmp(a, b,   ai, bi, na, nb, i, r) {
+      na = split(a, ai, "."); nb = split(b, bi, ".")
+      for (i = 1; i <= na && i <= nb; i++) {
+        r = ident_cmp(ai[i], bi[i]); if (r != 0) return r
+      }
+      if (na == nb) return 0
+      return (na < nb) ? -1 : 1
+    }
+    function tag_cmp(a, b,   ac, bc, ap, bp, ai, bi, i, p) {
+      ap = ""; bp = ""
+      ac = substr(a, 2); bc = substr(b, 2)
+      if ((p = index(ac, "-")) > 0) { ap = substr(ac, p + 1); ac = substr(ac, 1, p - 1) }
+      if ((p = index(bc, "-")) > 0) { bp = substr(bc, p + 1); bc = substr(bc, 1, p - 1) }
+      split(ac, ai, "."); split(bc, bi, ".")
+      for (i = 1; i <= 3; i++) {
+        if (ai[i] + 0 != bi[i] + 0) return (ai[i] + 0 < bi[i] + 0) ? -1 : 1
+      }
+      if (ap == "" && bp == "") return 0
+      if (ap == "") return 1
+      if (bp == "") return -1
+      return pre_cmp(ap, bp)
+    }
+    NR == 1 || tag_cmp($0, best) > 0 { best = $0 }
+    END { if (best != "") print best }
+  '
+}
+
 # ── Source ──
 if [ -d "$INSTALL_DIR/.git" ]; then
   [ -z "$REF" ] || die "--ref pins fresh clones only; $INSTALL_DIR already exists — check out the ref there yourself"
@@ -175,14 +223,16 @@ else
       say "installing the stamped release: $REF"
     else
       # Unstamped copy: default fresh installs to the newest published
-      # release tag (vX.Y.Z only — pre-releases and peeled refs are
-      # filtered) so even this path delivers an immutable, released tree.
+      # release tag by semver precedence so even this path delivers an
+      # immutable, released tree. Prerelease tags count (see the picker
+      # above — the old vX.Y.Z-only filter regressed fresh installs to
+      # v0.1.0); peeled ^{} refs stay excluded by the $-anchored match.
       # Falling back to the mutable default-branch head happens only while
       # no release exists, and says so out loud. --ref / INTENDANT_REF
       # override either way.
       REF="$(git ls-remote --tags "$REPO" 'v*' 2>/dev/null \
-        | sed -n 's|.*refs/tags/\(v[0-9][0-9]*\.[0-9][0-9.]*\)$|\1|p' \
-        | sort -V | tail -n 1 || true)"
+        | sed -n 's|.*refs/tags/\(v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\(-[0-9A-Za-z.-][0-9A-Za-z.-]*\)\{0,1\}\)$|\1|p' \
+        | semver_max_tag || true)"
       if [ -n "$REF" ]; then
         say "pinning to the latest release tag: $REF (override with --ref)"
       else
@@ -239,8 +289,15 @@ command -v cargo >/dev/null 2>&1 || die "Rust is required. Install via https://r
 # ── Build ──
 # --locked: build exactly the committed Cargo.lock — a resolution that
 # differs from what CI tested is a failure, not a fallback.
+# Named bins mirror the release lane's proven build shape (release.yml's
+# binary jobs): a daemon install needs `intendant` + `intendant-runtime`
+# only, and naming them skips the wasm workspace members and
+# station-web's native graphics stack (~71 packages) that a bare
+# workspace build would compile — a configuration no CI leg gates —
+# while shrinking the install build. intendant-connect is the hosted
+# rendezvous service and is not part of a daemon install.
 say "building release binaries (this takes a few minutes on a fresh box)"
-cargo build --release --locked
+cargo build --release --locked --bin intendant --bin intendant-runtime
 
 BIN_DIR="$HOME/.local/bin"
 mkdir -p "$BIN_DIR"


### PR DESCRIPTION
Two installer gaps found investigating a user's Windows installer failure, fixed in both `scripts/install.sh` and `scripts/install.ps1`:

**1. Build named bins instead of the full workspace.** Both scripts ran a bare `cargo build --release --locked` — the full native workspace, a configuration no CI leg compiles on Windows or macOS (CI's package-scoped steps exclude the wasm members). The scripts now run `cargo build --release --locked --bin intendant --bin intendant-runtime`, mirroring the release lane's proven-green build shape (`release.yml`'s binary jobs). This skips the wasm workspace members and station-web's native graphics stack (~71 packages) and shrinks end-user install time; `intendant-connect` is the hosted rendezvous service and is not part of a daemon install. Verified neither script references any other built artifact: `install.sh` symlinks only `intendant` + `intendant-runtime`, and `install.ps1`'s launcher/shortcuts/service use `intendant.exe` with the runtime resolved as its on-disk sibling.

**2. Prerelease-aware fallback tag pick.** An unstamped copy's fallback filtered tags to `vX.Y.Z` only ("pre-releases filtered" was deliberate at the time), but publishing reality inverted it: the alphas ARE the product releases on GitHub (`v0.2.0-alpha.5` is marked Latest; `v0.1.0` is marked Pre-release), so an unstamped copy silently built the stale `v0.1.0`. Both scripts now pick the highest-precedence tag under semver 2.0 ordering — version core first, then release > prerelease, then prerelease identifiers (numeric compare numerically and rank below alphanumeric, alphanumeric ASCII-lexical, shorter identifier set loses ties) — accepting `vX.Y.Z` and `vX.Y.Z-<prerelease>`, still excluding peeled `^{}` refs. The sh side is a small awk comparer; the ps1 side is an explicit PS 5.1-safe comparer (no `[semver]` type there, and `[version]` cannot parse prerelease suffixes). Help text and inline comments that still claimed "pre-releases are filtered" are updated in both scripts.

`install.ps1` remains pure ASCII (the PR #790 hardening decision).

**Validation**
- `bash -n` and `sh -n` clean; `install.ps1` parses with 0 errors under real Windows PowerShell 5.1 (verified on a Windows fleet box; `pwsh` was unavailable on the dev Mac).
- Picker fixtures exercised against the extracted, shipped functions (not copies) on macOS sh/BSD awk, Debian dash/mawk (a Linux fleet box), and Windows PowerShell 5.1 — all pass, including: {v0.1.0, v0.2.0-alpha.4, v0.2.0-alpha.5} → v0.2.0-alpha.5; {v0.1.0, v0.2.0} → v0.2.0; {v0.2.0-alpha.9, v0.2.0-alpha.10} → v0.2.0-alpha.10; {v0.2.0-alpha.5, v0.2.0} → v0.2.0; plus semver edge cases (shorter-set ties, numeric-vs-alphanumeric identifiers, rc > alpha) and peeled-ref/junk-tag exclusion on a synthetic `ls-remote` listing.
- Live-repo probe: the real tag listing now resolves to `v0.2.0-alpha.5`, matching what `releases/latest` serves.
- ASCII check on `install.ps1`: no non-ASCII bytes.
- Docs: no doc literally describes the installer's build command (`windows-support.md`'s build line describes `setup-windows.ps1`, a different script), so no doc edits ride along.
