### PR TITLE
installers: prebuilt-binary fast path; source build becomes the fallback

### DIFF
--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -44,7 +44,8 @@ winget or choco on Windows — announcing the exact command before it runs,
 escalating via `sudo` only where it exists and never silently, and otherwise
 stopping to name the command for you to run. Rust and the native build
 dependencies follow the same law via the per-OS setup scripts from the
-cloned tree.
+cloned tree — and the Rust toolchain is only required at all when the
+install builds from source (see below).
 
 The install ends concretely, not silently: once the daemon reports ready, the
 installer prints the dashboard's tokened loopback owner URL (`intendant ctl
@@ -65,8 +66,20 @@ stamped installer double-checks itself: it prints its release identity
 (`tag @ commit`) before doing anything else, installs exactly that released
 tree, and fails closed with `RELEASE_PIN_MISMATCH` when the checkout doesn't
 match the commit its release recorded. Everything else it executes comes from
-that verified tree, and `cargo build --locked` extends the pinning to
-dependency hashes.
+that verified tree, and on the source build `cargo build --locked` extends
+the pinning to dependency hashes.
+
+Installing a release, the script skips the source compile where the release
+publishes a prebuilt binary pair for the platform (Linux x86_64/aarch64
+`.tar.gz`, Windows `.zip` — from v0.2.0-alpha.6 on): the pair is downloaded
+from the same release and verified against its `.sha256` sidecar, and every
+asset — pair, sidecar, installer — is covered by the release's PGP-signed,
+transparency-logged manifest. No matching asset, a failed verification, or a
+binary that doesn't run on the box (old glibc, wrong arch) falls back to the
+source build; `--from-source` / `-FromSource` forces that fully
+source-verified path outright. macOS always builds from source — no paired
+unix binary asset is published for it (the packaged app carries the macOS
+binaries).
 
 Pick your rung of the trust ladder honestly:
 

--- a/docs/src/windows-support.md
+++ b/docs/src/windows-support.md
@@ -44,7 +44,11 @@ the `curl | sh` one-liner, from an elevated PowerShell on a fresh box:
 ```
 
 It clones the repo, runs the dependency setup below (elevated shells only),
-builds, and launches. The script is a per-release GitHub asset — stamped
+installs the release's prebuilt, sha256-verified `intendant.exe` +
+`intendant-runtime.exe` pair when the release publishes one (from
+v0.2.0-alpha.6 on; the source build remains the fallback, and `-FromSource`
+forces it — only that path needs the Rust toolchain), and launches. The
+script is a per-release GitHub asset — stamped
 with the release it installs, hash-committed to the public transparency
 log, and fail-closed (`RELEASE_PIN_MISMATCH`) when the checkout doesn't
 match its release; a rendezvous serves at most a redirect to it. Add

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -22,7 +22,11 @@
 
     Dependencies (git, rustup, VS Build Tools, NASM) are handled by
     scripts/setup-windows.ps1 from the cloned repo -- run automatically
-    when this shell is elevated, otherwise checked and reported.
+    when this shell is elevated, otherwise checked and reported. The
+    Rust toolchain is only required when building from source: a release
+    install prefers the release's prebuilt, sha256-verified
+    intendant.exe + intendant-runtime.exe pair and builds from source
+    only as the fallback (-FromSource forces the source build).
 
     The install finishes concretely: it generates the per-user dashboard
     access certificates and imports them into this user's certificate
@@ -62,6 +66,13 @@
 .PARAMETER NoRun
     Build and link only; print how to start it.
 
+.PARAMETER FromSource
+    Always build from source, skipping the prebuilt-binary fast path
+    (the fully source-verified install). Without it, installing a
+    release downloads the release's sha256-verified binary pair when
+    one is published for this platform, and builds from source
+    otherwise.
+
 .PARAMETER Repo
     Git URL to clone (default: https://github.com/intendant-dev/Intendant).
 
@@ -75,6 +86,7 @@ param(
     [string]$Ref = "",
     [switch]$Service,
     [switch]$NoRun,
+    [switch]$FromSource,
     [string]$Repo = "https://github.com/intendant-dev/Intendant",
     [string]$InstallDir = (Join-Path $HOME "intendant")
 )
@@ -272,22 +284,121 @@ if ($InstallerReleaseCommit -and $Ref -eq $InstallerReleaseTag) {
     Say "release pin verified: $Ref is commit $actualCommit"
 }
 
+# -- Binary fast path --
+# When the resolved ref IS a release tag, that release may publish the
+# prebuilt intendant.exe + intendant-runtime.exe pair
+# (Intendant-<version>-windows-x86_64.zip): downloading it replaces the
+# multi-minute source compile. The trust story is unchanged -- the
+# checkout above stays pin-verified to the release commit, and the zip
+# is sha256-verified against the .sha256 sidecar published by the same
+# release, every asset of which is PGP-signed and committed to the
+# public transparency log. -FromSource opts out and keeps the fully
+# source-verified build. Old releases without the pair, other
+# architectures, a non-GitHub -Repo, or any verification or smoke
+# failure fall back to the source build below.
+$BinaryInstall = $false
+$daemonExe = Join-Path $InstallDir "target\release\intendant.exe"
+function Get-GitHubRepoPath([string]$RepoUrl) {
+    if ($RepoUrl -match '^https://github\.com/([^/]+/[^/]+?)(\.git)?/?$') { return $Matches[1] }
+    return $null
+}
+if (-not $FromSource -and $Ref -match '^v[0-9]' -and $env:PROCESSOR_ARCHITECTURE -eq 'AMD64') {
+    $repoPath = Get-GitHubRepoPath $Repo
+    if ($repoPath) {
+        $fastAsset = "Intendant-" + $Ref.Substring(1) + "-windows-x86_64.zip"
+        $fastBase = "https://github.com/$repoPath/releases/download/$Ref"
+        $fastTmp = Join-Path $env:TEMP ("intendant-asset-" + [Guid]::NewGuid().ToString("N"))
+        New-Item -ItemType Directory -Force -Path $fastTmp | Out-Null
+        $fastZip = Join-Path $fastTmp $fastAsset
+        $fetched = $false
+        # Windows PowerShell 5.1: older .NET defaults can exclude TLS 1.2
+        # (GitHub requires it), and the IWR progress bar slows large
+        # downloads by an order of magnitude.
+        [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+        $prevProgress = $ProgressPreference
+        $ProgressPreference = 'SilentlyContinue'
+        try {
+            Say "binary fast path: fetching $fastAsset from the $Ref release"
+            Invoke-WebRequest -UseBasicParsing -Uri "$fastBase/$fastAsset" -OutFile $fastZip
+            Invoke-WebRequest -UseBasicParsing -Uri "$fastBase/$fastAsset.sha256" -OutFile "$fastZip.sha256"
+            $fetched = $true
+        } catch {
+            Say "note: no prebuilt binary pair for $Ref (releases before v0.2.0-alpha.6 ship none) -- building from source"
+        } finally {
+            $ProgressPreference = $prevProgress
+        }
+        if ($fetched) {
+            $want = ((Get-Content -LiteralPath "$fastZip.sha256" -TotalCount 1) -replace '^\s+', '' -split '\s+')[0]
+            $got = (Get-FileHash -LiteralPath $fastZip -Algorithm SHA256).Hash
+            if (-not $want -or -not ($want -ieq $got)) {
+                Say "WARNING: $fastAsset did not match its .sha256 sidecar (expected $want, got $got) -- discarding the download and building from source instead"
+            } else {
+                Say "verified $fastAsset against its .sha256 sidecar"
+                $fastReleaseDir = Join-Path $InstallDir "target\release"
+                New-Item -ItemType Directory -Force -Path $fastReleaseDir | Out-Null
+                $extracted = $false
+                try {
+                    Expand-Archive -LiteralPath $fastZip -DestinationPath $fastReleaseDir -Force
+                    $extracted = $true
+                } catch {
+                    Say "WARNING: could not extract $fastAsset ($($_.Exception.Message)) -- building from source instead"
+                }
+                if ($extracted -and (Test-Path $daemonExe) -and (Test-Path (Join-Path $fastReleaseDir "intendant-runtime.exe"))) {
+                    # Post-extract smoke: --version prints the version and
+                    # exits 0 immediately on a healthy binary; a
+                    # wrong-architecture or corrupt exe fails here.
+                    # Shielded like Get-TokenedDashboardUrl below: under
+                    # $ErrorActionPreference = "Stop", Windows PowerShell
+                    # 5.1 can escalate redirected native stderr into a
+                    # terminating error.
+                    $prevEap = $ErrorActionPreference
+                    $ErrorActionPreference = "Continue"
+                    $smokeOk = $false
+                    try {
+                        & $daemonExe --version 2>$null | Out-Null
+                        $smokeOk = ($LASTEXITCODE -eq 0)
+                    } catch {
+                        $smokeOk = $false
+                    } finally {
+                        $ErrorActionPreference = $prevEap
+                    }
+                    if ($smokeOk) {
+                        $BinaryInstall = $true
+                        Say "installed the release's prebuilt binary pair (windows-x86_64) -- the source build is skipped (-FromSource forces one)"
+                    } else {
+                        Say "WARNING: the prebuilt intendant.exe does not run on this system (wrong architecture or a corrupt download) -- removing it and building from source instead"
+                        Remove-Item -LiteralPath $daemonExe -Force -ErrorAction SilentlyContinue
+                        Remove-Item -LiteralPath (Join-Path $fastReleaseDir "intendant-runtime.exe") -Force -ErrorAction SilentlyContinue
+                    }
+                }
+            }
+        }
+        Remove-Item -LiteralPath $fastTmp -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
 # -- System dependencies --
 # setup-windows.ps1 is the dependency authority (rustup, VS Build Tools
 # C++ workload, NASM, ffmpeg, Media Foundation). It needs elevation to
-# install; unelevated we only verify and report.
+# install; unelevated we only verify and report. The Rust toolchain is
+# only REQUIRED when building from source: on the binary fast path an
+# unelevated shell without cargo is fine.
 $setup = Join-Path $InstallDir "scripts\setup-windows.ps1"
 if ($elevated -and (Test-Path $setup)) {
     Say "installing system dependencies (scripts\setup-windows.ps1 -NoBuild)"
     & $setup -NoBuild
     if ($LASTEXITCODE -ne 0) { Fail "system dependency setup failed" }
+} elseif ($BinaryInstall) {
+    Say "note: unelevated shell -- skipping dependency setup (the prebuilt binaries need no build toolchain; run scripts\setup-windows.ps1 from an elevated PowerShell later for the optional tools it manages)."
 } elseif (-not (Get-Command cargo -ErrorAction SilentlyContinue)) {
-    Fail "Rust is required. Either re-run this installer from an elevated PowerShell (it will run scripts\setup-windows.ps1 for you) or install rustup from https://rustup.rs and re-run."
+    Fail "Rust is required to build from source. Either re-run this installer from an elevated PowerShell (it will run scripts\setup-windows.ps1 for you) or install rustup from https://rustup.rs and re-run."
 } else {
     Say "note: unelevated shell -- skipping dependency setup; if the build fails on a missing native dep, run scripts\setup-windows.ps1 from an elevated PowerShell."
 }
 
 # -- Build --
+# Skipped entirely when the verified prebuilt pair is in place: only the
+# source build requires the Rust toolchain.
 # --locked: build exactly the committed Cargo.lock -- a resolution that
 # differs from what CI tested is a failure, not a fallback.
 # Named bins mirror the release lane's proven build shape (release.yml's
@@ -297,10 +408,11 @@ if ($elevated -and (Test-Path $setup)) {
 # bare workspace build would compile -- a configuration no CI leg gates --
 # while shrinking the install build. intendant-connect is the hosted
 # rendezvous service and is not part of a daemon install.
-Say "building release binaries (this takes a few minutes on a fresh box)"
-cargo build --release --locked --bin intendant --bin intendant-runtime
-if ($LASTEXITCODE -ne 0) { Fail "cargo build failed" }
-$daemonExe = Join-Path $InstallDir "target\release\intendant.exe"
+if (-not $BinaryInstall) {
+    Say "building release binaries (this takes a few minutes on a fresh box)"
+    cargo build --release --locked --bin intendant --bin intendant-runtime
+    if ($LASTEXITCODE -ne 0) { Fail "cargo build failed" }
+}
 
 # -- Dashboard access certs + Windows certificate-store import --
 # The dashboard defaults to mTLS. Generate the per-user access material

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,6 +23,10 @@ set -eu
 # fails closed on mismatch. Its own bytes are covered by the release
 # manifest committed to the transparency log, so the custody chain is
 # log -> installer bytes -> pinned commit -> the tree that gets built.
+# On the binary fast path the build is replaced by the same release's
+# prebuilt pair, sha256-verified against sidecars published by that
+# release and covered by the same logged manifest; --from-source keeps
+# the fully source-built path.
 INSTALLER_RELEASE_TAG=""
 INSTALLER_RELEASE_COMMIT=""
 
@@ -32,7 +36,7 @@ Intendant installer
 
   curl -fsSL https://github.com/intendant-dev/Intendant/releases/latest/download/install.sh | sh -s -- \
     [--service] [--connect <rendezvous-url>] \
-    [--daemon-id <id>] [--no-run]
+    [--daemon-id <id>] [--no-run] [--from-source]
 
 Options:
   --service       Keep the daemon running unattended: installs a boot
@@ -54,6 +58,11 @@ Options:
                   head only while no release exists. An explicit ref you
                   choose skips the release-pin verification.
   --no-run        Build and link only; print how to start it.
+  --from-source   Always build from source, skipping the prebuilt-binary
+                  fast path (the fully source-verified install). Without
+                  it, installing a release downloads the release's
+                  sha256-verified binary pair when one is published for
+                  this platform, and builds from source otherwise.
 
 Environment overrides:
   INTENDANT_REPO         git URL   (default: https://github.com/intendant-dev/Intendant)
@@ -69,6 +78,7 @@ DAEMON_ID="${INTENDANT_CONNECT_DAEMON_ID:-}"
 REF="${INTENDANT_REF:-}"
 RUN=1
 SERVICE=0
+FROM_SOURCE=0
 
 say() { printf '\033[1m[intendant install]\033[0m %s\n' "$*"; }
 die() { printf '\033[1;31m[intendant install]\033[0m %s\n' "$*" >&2; exit 1; }
@@ -88,6 +98,8 @@ while [ $# -gt 0 ]; do
       SERVICE=1; shift ;;
     --no-run)
       RUN=0; shift ;;
+    --from-source)
+      FROM_SOURCE=1; shift ;;
     -h|--help)
       usage
       exit 0 ;;
@@ -267,10 +279,145 @@ if [ -n "$INSTALLER_RELEASE_COMMIT" ] && [ "$REF" = "$INSTALLER_RELEASE_TAG" ]; 
   say "release pin verified: $REF is commit $ACTUAL_COMMIT"
 fi
 
+# ── Binary fast path (stage) ──
+# When the resolved ref IS a release tag, that release may publish a
+# prebuilt `intendant` + `intendant-runtime` pair for this platform
+# (Linux x86_64/aarch64: Intendant-<version>-linux-<arch>.tar.gz — a
+# tar.gz so the executable bits survive): downloading it replaces the
+# 12+ minute source compile. The trust story is unchanged — the checkout
+# above stays pin-verified to the release commit, and the pair is
+# sha256-verified against the .sha256 sidecar published by the same
+# release, every asset of which is PGP-signed and committed to the
+# public transparency log. --from-source opts out and keeps the fully
+# source-verified build. Old releases without the pair, other
+# architectures, a non-GitHub INTENDANT_REPO, or any verification
+# failure fall back to the source build. macOS stays source-built here:
+# no paired unix binary asset is published for it (the packaged app
+# bundle carries the macOS binaries).
+#
+# Staging and smoke are two phases: the pair is downloaded, verified,
+# and extracted HERE, but only run AFTER dependency setup below — on a
+# fresh box the binaries need the runtime shared libraries setup
+# installs (libvpx, pipewire, xcb) before they can execute at all.
+
+# Owner/repo path of a github.com HTTPS remote (the only host the
+# release-asset fast path can construct download URLs for); any other
+# remote returns non-zero and the caller takes the source build.
+github_repo_path() {
+  case "$1" in
+    https://github.com/*)
+      _path="${1#https://github.com/}"
+      _path="${_path%.git}"
+      _path="${_path%/}"
+      case "$_path" in
+        */*/*) return 1 ;;
+        */*) printf '%s\n' "$_path"; return 0 ;;
+        *) return 1 ;;
+      esac ;;
+    *) return 1 ;;
+  esac
+}
+
+# Lowercase sha256 of a file, via whichever tool this box has
+# (sha256sum on Linux coreutils, shasum on macOS/BSD).
+file_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}' | tr 'A-F' 'a-f'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}' | tr 'A-F' 'a-f'
+  else
+    return 1
+  fi
+}
+
+# First hex field of a `sha256sum`-format sidecar, lowercased.
+sidecar_sha256() {
+  awk 'NR==1 {print $1}' "$1" | tr 'A-F' 'a-f'
+}
+
+fetch_url() {
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL --proto '=https' --tlsv1.2 -o "$2" "$1"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q -O "$2" "$1"
+  else
+    return 1
+  fi
+}
+
+# Download <asset> (+ its .sha256 sidecar) from the release <tag> of
+# github repo <path>, verify the digest, and leave the verified file at
+# $FAST_TMP/<asset>. Non-zero = not available / failed verification; the
+# caller takes the source build. A digest MISMATCH is the loud case: the
+# download is deleted and the mismatch named.
+fetch_release_asset() {
+  _repo_path="$1"; _tag="$2"; _asset="$3"
+  _base="https://github.com/${_repo_path}/releases/download/${_tag}"
+  say "binary fast path: fetching ${_asset} from the ${_tag} release"
+  if ! fetch_url "${_base}/${_asset}" "$FAST_TMP/${_asset}"; then
+    return 1
+  fi
+  if ! fetch_url "${_base}/${_asset}.sha256" "$FAST_TMP/${_asset}.sha256"; then
+    rm -f "$FAST_TMP/${_asset}"
+    return 1
+  fi
+  _want="$(sidecar_sha256 "$FAST_TMP/${_asset}.sha256")"
+  _got="$(file_sha256 "$FAST_TMP/${_asset}")" || _got=""
+  if [ -z "$_want" ] || [ -z "$_got" ] || [ "$_want" != "$_got" ]; then
+    rm -f "$FAST_TMP/${_asset}" "$FAST_TMP/${_asset}.sha256"
+    say "WARNING: ${_asset} did not match its .sha256 sidecar (expected ${_want:-<none>}, got ${_got:-<none>}) — discarding the download and building from source instead"
+    return 1
+  fi
+  say "verified ${_asset} against its .sha256 sidecar"
+  return 0
+}
+
+stage_release_binaries() {
+  [ "$FROM_SOURCE" = "0" ] || return 1
+  [ "$PLATFORM" = "Linux" ] || return 1
+  case "$REF" in v[0-9]*) ;; *) return 1 ;; esac
+  FAST_ARCH="$(uname -m)"
+  case "$FAST_ARCH" in x86_64|aarch64) ;; *) return 1 ;; esac
+  FAST_REPO_PATH="$(github_repo_path "$REPO")" || return 1
+  FAST_ASSET="Intendant-${REF#v}-linux-${FAST_ARCH}.tar.gz"
+  FAST_TMP="$(mktemp -d)" || return 1
+  if ! fetch_release_asset "$FAST_REPO_PATH" "$REF" "$FAST_ASSET"; then
+    rm -rf "$FAST_TMP"
+    say "note: no verified prebuilt binary pair for $REF on linux-$FAST_ARCH (releases before v0.2.0-alpha.6 ship none) — building from source"
+    return 1
+  fi
+  mkdir -p "$INSTALL_DIR/target/release"
+  if ! tar -xzf "$FAST_TMP/$FAST_ASSET" -C "$INSTALL_DIR/target/release" intendant intendant-runtime; then
+    rm -f "$INSTALL_DIR/target/release/intendant" "$INSTALL_DIR/target/release/intendant-runtime"
+    rm -rf "$FAST_TMP"
+    say "WARNING: could not extract $FAST_ASSET — building from source instead"
+    return 1
+  fi
+  rm -rf "$FAST_TMP"
+  # tar preserves the executable bits; chmod defensively anyway.
+  chmod +x "$INSTALL_DIR/target/release/intendant" "$INSTALL_DIR/target/release/intendant-runtime" 2>/dev/null || true
+  return 0
+}
+
+BINARY_STAGED=0
+if stage_release_binaries; then
+  BINARY_STAGED=1
+  say "staged the release's prebuilt binary pair — it is smoke-tested after dependency setup (--from-source forces a source build)"
+fi
+
 # ── System dependencies ──
 if [ "$PLATFORM" = "Linux" ] && command -v apt-get >/dev/null 2>&1 && [ -x scripts/setup-linux.sh ]; then
-  say "installing system dependencies (scripts/setup-linux.sh)"
-  ./scripts/setup-linux.sh || die "system dependency setup failed"
+  if [ "$BINARY_STAGED" = "1" ]; then
+    # The setup run still matters on the binary path — it installs the
+    # runtime shared libraries the prebuilt binaries load (libvpx,
+    # pipewire, xcb) — but its build phase would waste the fast path, so
+    # skip exactly that with the script's own --no-build flag.
+    say "installing system dependencies (scripts/setup-linux.sh --no-build)"
+    ./scripts/setup-linux.sh --no-build || die "system dependency setup failed"
+  else
+    say "installing system dependencies (scripts/setup-linux.sh)"
+    ./scripts/setup-linux.sh || die "system dependency setup failed"
+  fi
 elif [ "$PLATFORM" = "Linux" ]; then
   say "note: no apt-get here — if the build fails on a missing native dep, install your distro's equivalents of the APT_PACKAGES list in scripts/setup-linux.sh (pkg-config, libclang, libvpx, libpipewire-0.3, libxcb + shm/randr)."
 elif [ "$PLATFORM" = "Darwin" ] && [ -x scripts/setup-macos.sh ]; then
@@ -278,26 +425,45 @@ elif [ "$PLATFORM" = "Darwin" ] && [ -x scripts/setup-macos.sh ]; then
   ./scripts/setup-macos.sh || die "system dependency setup failed"
 fi
 
-# setup-linux.sh installs rustup when cargo is missing, but into its own
-# shell — pick the env up here before insisting.
-if ! command -v cargo >/dev/null 2>&1 && [ -f "$HOME/.cargo/env" ]; then
-  . "$HOME/.cargo/env"
+# ── Binary fast path (smoke) ──
+# The staged pair must actually run here before it is trusted: an
+# old-glibc box ("GLIBC_x.y not found"), a wrong-architecture download,
+# or a corrupt file all fail --version, and the honest answer is to say
+# so, remove the pair, and build from source.
+if [ "$BINARY_STAGED" = "1" ]; then
+  if "$INSTALL_DIR/target/release/intendant" --version >/dev/null 2>&1; then
+    say "prebuilt binaries verified and working — the source build is skipped"
+  else
+    say "WARNING: the prebuilt intendant binary does not run on this system (old glibc, wrong architecture, or a corrupt download) — removing it and building from source instead"
+    rm -f "$INSTALL_DIR/target/release/intendant" "$INSTALL_DIR/target/release/intendant-runtime"
+    BINARY_STAGED=0
+  fi
 fi
-command -v cargo >/dev/null 2>&1 || die "Rust is required. Install via https://rustup.rs then re-run:
+
+# Only the source build requires the Rust toolchain: the whole block is
+# skipped when the verified prebuilt pair is in place.
+if [ "$BINARY_STAGED" = "0" ]; then
+  # setup-linux.sh installs rustup when cargo is missing, but into its own
+  # shell — pick the env up here before insisting.
+  if ! command -v cargo >/dev/null 2>&1 && [ -f "$HOME/.cargo/env" ]; then
+    . "$HOME/.cargo/env"
+  fi
+  command -v cargo >/dev/null 2>&1 || die "Rust is required. Install via https://rustup.rs then re-run:
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
 
-# ── Build ──
-# --locked: build exactly the committed Cargo.lock — a resolution that
-# differs from what CI tested is a failure, not a fallback.
-# Named bins mirror the release lane's proven build shape (release.yml's
-# binary jobs): a daemon install needs `intendant` + `intendant-runtime`
-# only, and naming them skips the wasm workspace members and
-# station-web's native graphics stack (~71 packages) that a bare
-# workspace build would compile — a configuration no CI leg gates —
-# while shrinking the install build. intendant-connect is the hosted
-# rendezvous service and is not part of a daemon install.
-say "building release binaries (this takes a few minutes on a fresh box)"
-cargo build --release --locked --bin intendant --bin intendant-runtime
+  # ── Build ──
+  # --locked: build exactly the committed Cargo.lock — a resolution that
+  # differs from what CI tested is a failure, not a fallback.
+  # Named bins mirror the release lane's proven build shape (release.yml's
+  # binary jobs): a daemon install needs `intendant` + `intendant-runtime`
+  # only, and naming them skips the wasm workspace members and
+  # station-web's native graphics stack (~71 packages) that a bare
+  # workspace build would compile — a configuration no CI leg gates —
+  # while shrinking the install build. intendant-connect is the hosted
+  # rendezvous service and is not part of a daemon install.
+  say "building release binaries (this takes a few minutes on a fresh box)"
+  cargo build --release --locked --bin intendant --bin intendant-runtime
+fi
 
 BIN_DIR="$HOME/.local/bin"
 mkdir -p "$BIN_DIR"


### PR DESCRIPTION
## What

End users installing a release stop paying the 12+ minute source compile when a verified prebuilt binary pair exists for their platform. Both install scripts gain a binary fast path, with the source build as the fallback and `--from-source` / `-FromSource` as the explicit opt-out. Builds on #852 (named-bins build + semver tag pick) and consumes the paired assets #853 added to the release lane.

Flow, same shape in both scripts:

1. After the tag is resolved and the checkout pin-verified (untouched), and only when the resolved ref is a release tag and the repo override is github.com-shaped: construct the platform asset name — Linux `Intendant-<version>-linux-<arch>.tar.gz` (arch from `uname -m`, x86_64|aarch64 only), Windows `Intendant-<version>-windows-x86_64.zip` (AMD64 only) — and download it plus its `.sha256` sidecar from the release.
2. Verify the digest (sh: compute via `sha256sum`/`shasum` and string-compare to the sidecar's first field, lowercased both sides; ps1: `Get-FileHash` vs the parsed sidecar, case-insensitive). Mismatch: loud warning naming both digests, download deleted, source build.
3. Extract the pair into `<checkout>/target/release/` so every downstream step (symlinks, user PATH, launcher, access setup, service install) works unchanged; `chmod +x` defensively on unix.
4. Smoke: the extracted controller must exit 0 on `--version` (verified in `src/bin/caller/main.rs` to print and exit immediately). Failure (old glibc, wrong arch, corrupt file): announce, remove the pair, source build.
5. Only the source path requires the Rust toolchain. install.ps1's unelevated hard-fail on missing cargo moved into the source branch; the elevated `setup-windows.ps1 -NoBuild` run keeps happening exactly where it does today. install.sh keeps the `setup-linux.sh` run on the binary path — it installs the runtime shared libraries the prebuilt binaries load (libvpx, pipewire, xcb) — but passes the script's own `--no-build` flag so its build phase doesn't waste the fast path. Staging (download+verify+extract) runs before dependency setup, the smoke after it: on a fresh box the binaries cannot even execute until those libraries exist.
6. macOS keeps the source build, with a comment saying why: no paired unix binary asset is published for it (the packaged app carries the macOS binaries).
7. Trust-story comments updated where they tell it: checkout still pin-verified to the release commit; binaries sha256-verified against sidecars from the same release, all covered by the release's PGP-signed, transparency-logged manifest; `--from-source` remains the fully source-verifying path. Old releases without paired assets (any tag <= v0.2.0-alpha.5 on Linux) take the 404 -> announce -> build fallback.

Docs: the build-step sentences in `docs/src/getting-started.md` and `docs/src/windows-support.md` updated surgically.

## Validation

- `sh -n` + `bash -n` on install.sh: clean. `LC_ALL=C grep -nP '[^\x00-\x7F]'` on install.ps1: empty (pure ASCII preserved, per the PR #790 hardening). pwsh is not installed on this dev box — instead the edited install.ps1 was ParseFile-checked under **real Windows PowerShell 5.1 (5.1.26100)** on a Windows 11 box: parse-clean (the same check `ui.rs::ps1_installer_parses` runs on the Windows CI leg).
- **Live end-to-end against the real v0.2.0-alpha.5 release:**
  - sh core (functions extracted byte-identically from the edited script): fetched `Intendant-0.2.0-alpha.5-windows-x86_64.zip` + sidecar from the release URL, sidecar parsed, sha256 verified, archive extracted, both exes present at sibling names. Run-smoke skipped there (Windows PE on macOS) and covered by:
  - the same ps1 fast-path logic executed end to end **on a real Windows 11 box**: download, verify, `Expand-Archive`, and the real smoke — `intendant.exe --version` exited 0 printing `intendant 0.2.0-alpha.5 (commit e6c792ed, ...)`; `BinaryInstall=true`.
- **Linux tar path:** a fixture tar.gz staged exactly as the release workflow stages it (two stub executables, `sha256sum`-format sidecar) driven through the shipped `stage_release_binaries`: verify -> extract -> exec-bit check -> stub smoke, all pass.
- **Fallback rehearsals, no build executed:** real 404s — `Intendant-0.2.0-alpha.5-linux-x86_64.tar.gz` (Linux pair predates alpha.6) and `Intendant-0.1.0-windows-x86_64.zip` on Windows — both reach the announced fall-back-to-source decision; corrupted download fails verification loudly and is deleted; non-GitHub `INTENDANT_REPO`/`-Repo` shapes, `--from-source`, macOS, and non-tag refs all skip straight to source.
- Both scripts grep-audited: every executable cargo/toolchain reference sits inside the source-path gate (`BINARY_STAGED=0` block / `-not $BinaryInstall` + the deps chain's source branch).
- The `bin/connect/ui.rs` static pins over both scripts (ASCII, stamp sentinels exactly once, asset URLs, git-bootstrap needles, `cargo build --release`, `"service", "install"`) re-verified by direct string check: all 23 pass; the real test suite runs in CI.
