### PR TITLE
Fix agenda HTTP fallback query forwarding

### DIFF
--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -6290,7 +6290,27 @@ mod tests {
             let rest = &entry[at..];
             Some(rest[..rest.find('\'')?].to_string())
         }
-        let mut entries: std::collections::BTreeMap<String, (String, String)> = Default::default();
+        fn quoted_list(entry: &str, key: &str) -> Vec<String> {
+            let marker = format!("{key}: [");
+            let Some(at) = entry.find(&marker).map(|at| at + marker.len()) else {
+                return Vec::new();
+            };
+            let rest = &entry[at..];
+            let list = &rest[..rest.find(']').expect("descriptor list is unterminated")];
+            list.split(',')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(|value| {
+                    value
+                        .strip_prefix('\'')
+                        .and_then(|value| value.strip_suffix('\''))
+                        .expect("descriptor list entries must be single-quoted")
+                        .to_string()
+                })
+                .collect()
+        }
+        let mut entries: std::collections::BTreeMap<String, (String, String, Vec<String>)> =
+            Default::default();
         for line in rest[..to].lines() {
             let line = line.trim();
             if line.is_empty() || line.starts_with("//") {
@@ -6304,11 +6324,37 @@ mod tests {
                 .to_string();
             let verb = quoted(line, "verb").unwrap_or_else(|| panic!("{name}: missing verb"));
             let path = quoted(line, "path").unwrap_or_else(|| panic!("{name}: missing path"));
+            let query = quoted_list(line, "query");
             assert!(
-                entries.insert(name.clone(), (verb, path)).is_none(),
+                entries.insert(name.clone(), (verb, path, query)).is_none(),
                 "duplicate descriptor entry: {name}"
             );
         }
+
+        // Agenda windowing and archive pagination are parameters of both
+        // server lanes. Pin the HTTP descriptor's full query contract so
+        // fallback cannot silently discard a live/archive selector or page
+        // cursor while the datachannel lane keeps working.
+        let agenda_query: Vec<&str> = entries
+            .get("api_agenda_list")
+            .expect("api_agenda_list must have an HTTP twin")
+            .2
+            .iter()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(
+            agenda_query,
+            [
+                "since_seq",
+                "shape",
+                "q",
+                "window",
+                "before",
+                "before_id",
+                "limit",
+            ],
+            "api_agenda_list must forward every query parsed by the HTTP and tunnel handlers"
+        );
 
         // Coverage pin: the F1 family's twinned methods (fs + staged
         // uploads), the F2 sessions-family reads (managed-context,
@@ -6501,7 +6547,7 @@ mod tests {
         let actual: std::collections::BTreeSet<&str> = entries.keys().map(String::as_str).collect();
         assert_eq!(actual, expected, "DAEMON_API_HTTP_MAP coverage drifted");
 
-        for (method_name, (verb, template)) in &entries {
+        for (method_name, (verb, template, _query)) in &entries {
             let spec = control_method_spec(method_name).unwrap_or_else(|| {
                 panic!("{method_name}: descriptor entry has no CONTROL_ONLY_METHODS row")
             });

--- a/static/app.html
+++ b/static/app.html
@@ -39401,7 +39401,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'c80e65e25d9fb8e2';
+const INTENDANT_APP_BUILD = '3fe7c117fef255a1';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -42716,7 +42716,7 @@ const DAEMON_API_HTTP_MAP = Object.freeze({
   api_session_current_rollback: { verb: 'POST', path: '/api/session/current/rollback' },
   api_codex_cloud_workers: { verb: 'GET', path: '/api/codex-cloud/workers', query: ['refresh'] },
   api_codex_cloud_submit: { verb: 'POST', path: '/api/codex-cloud/submit' },
-  api_agenda_list: { verb: 'GET', path: '/api/agenda', query: ['since_seq', 'shape', 'q'] },
+  api_agenda_list: { verb: 'GET', path: '/api/agenda', query: ['since_seq', 'shape', 'q', 'window', 'before', 'before_id', 'limit'] },
   api_agenda_item: { verb: 'GET', path: '/api/agenda/items/{item_id}' },
   api_agenda_op: { verb: 'POST', path: '/api/agenda/op' },
   api_agenda_definitions: { verb: 'GET', path: '/api/agenda/definitions' },

--- a/static/app/32-daemon-api.js
+++ b/static/app/32-daemon-api.js
@@ -186,7 +186,7 @@ const DAEMON_API_HTTP_MAP = Object.freeze({
   api_session_current_rollback: { verb: 'POST', path: '/api/session/current/rollback' },
   api_codex_cloud_workers: { verb: 'GET', path: '/api/codex-cloud/workers', query: ['refresh'] },
   api_codex_cloud_submit: { verb: 'POST', path: '/api/codex-cloud/submit' },
-  api_agenda_list: { verb: 'GET', path: '/api/agenda', query: ['since_seq', 'shape', 'q'] },
+  api_agenda_list: { verb: 'GET', path: '/api/agenda', query: ['since_seq', 'shape', 'q', 'window', 'before', 'before_id', 'limit'] },
   api_agenda_item: { verb: 'GET', path: '/api/agenda/items/{item_id}' },
   api_agenda_op: { verb: 'POST', path: '/api/agenda/op' },
   api_agenda_definitions: { verb: 'GET', path: '/api/agenda/definitions' },


### PR DESCRIPTION
## What changed

- Forward `window`, `before`, `before_id`, and `limit` through the dashboard HTTP fallback for `api_agenda_list`.
- Extend the generated-bundle parity test to pin the complete seven-key agenda-list query contract.
- Regenerate `static/app.html`.

## Why

The datachannel tunnel already carried the live/archive window and pagination parameters, but the HTTP descriptor silently dropped four of them. Dashboards using HTTP fallback therefore lost archive window selection and paging cursors.

## Validation

- Exact JavaScript adapter URL/readback check
- `cargo fmt --all -- --check`
- `cargo test -p app-html-assembler` (29 passed)
- `cargo check -p intendant --bin intendant`
- `git diff --check`

Agenda item: `01KYX8E4CB0T91HPXA80QKMXYT`