### PR TITLE
deps: patch event-listener and h2 RustSec advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1806,11 +1806,10 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -2284,9 +2283,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Summary

- update `event-listener` from 5.4.1 to 5.4.2, fixing RUSTSEC-2026-0221
- update `h2` from 0.4.15 to 0.4.16, fixing RUSTSEC-2026-0258 discovered during verification

## Impact

The first update removes an unsound `Send`/`Sync` implementation reachable through the Linux desktop dependency graph. The second bounds empty HTTP/2 DATA-frame queuing to prevent remote memory exhaustion.

Closes #786.

## Validation

- `cargo audit`: zero vulnerabilities and zero warnings
- `cargo metadata --locked --no-deps --format-version 1`
- dependency-tree verification for `event-listener 5.4.2` and `h2 0.4.16`
- remote workspace preflight was unavailable because the provider required renewed MFA; repository CI remains authoritative