### PR TITLE
Keep answered agenda questions visible until pickup

### DIFF
--- a/docs/src/agenda-and-memory.md
+++ b/docs/src/agenda-and-memory.md
@@ -87,6 +87,9 @@ The supported commands are:
 - `ask` — park a rich multi-question ask as a durable question item (below);
 - `answer` for an open question (answering also resolves it; `structured`
   optionally carries a rich-ask breakdown);
+- `acknowledge_answer` — explicitly record that a consumer picked up the
+  current answer (`intendant ctl agenda acknowledge ID_PREFIX`); reads never
+  perform this transition;
 - `annotate`, `set_blocker`, `clear_blocker`, `add_relies_on`, and
   `remove_relies_on` — the item's thread and gates (below);
 - `propose_effect`, `approve_effect`, `revoke_effect`, and
@@ -98,6 +101,13 @@ Items use monotonic ULIDs, so lexicographic order is creation order. Titles,
 bodies, tags, and due times have bounded intake. There is no destructive
 delete operation: retirement hides an item from the normal open view while
 preserving its history.
+
+Bare `intendant ctl agenda list` is the working inbox: it includes every open
+item plus answered questions still awaiting pickup. The named lifecycle
+filters remain exact (`--open` is open-only, `--done` is done-only, and so
+on). A successful live-session delivery or an explicit answer acknowledgement
+removes an answered question from the bare list without changing its `done`
+lifecycle status.
 
 A question is the durable, non-blocking counterpart to `ask_user`. Parking it
 does not stop a session. The owner can answer later, and a future session can
@@ -159,11 +169,13 @@ successor — it is recorded, not silent: the daemon appends a
 `record_ask_delivery` op (daemon-authored, like `record_occurrence`)
 marking `answer.delivered: false`, raises one info-urgency notification
 (item title only, never answer text), and the item card wears a quiet
-"answered · awaiting pickup" chip. A successful injection (or an inline
-waiter return) records `delivered: true` instead. The session-start
-agenda ritual remains the pickup path: a session that parked a question
-and died reads the reply from the item next time (reading does not flip
-the marker; only a later successful delivery does).
+"answered · awaiting pickup" chip. Plain answered questions and older
+answers with no delivery fact also remain awaiting pickup. A successful
+injection (or an inline waiter return) records `delivered: true` instead.
+The session-start agenda ritual remains the pickup path: a session that
+parked a question and died reads the reply from the item next time, then
+explicitly runs `intendant ctl agenda acknowledge ID_PREFIX`. Reading does
+not flip either the delivery marker or the acknowledgement receipt.
 
 **Dismissal is not resolution.** Skipping or denying the rail card records
 a dismissal marker (`dismissed`: verb, time, actor) and clears every

--- a/src/bin/caller/agenda/ask.rs
+++ b/src/bin/caller/agenda/ask.rs
@@ -364,6 +364,7 @@ mod tests {
             kind: None,
             structured,
             delivered: None,
+            acknowledged: None,
         }
     }
 

--- a/src/bin/caller/agenda/store.rs
+++ b/src/bin/caller/agenda/store.rs
@@ -44,13 +44,14 @@ pub(crate) enum AgendaError {
 /// preserved on disk but skipped at load (forward compatibility: a newer
 /// build's vocabulary — effects, journal curation — must not brick an older
 /// daemon's ledger).
-const KNOWN_OPS: [&str; 26] = [
+const KNOWN_OPS: [&str; 27] = [
     "add",
     "patch",
     "complete",
     "reopen",
     "retire",
     "answer",
+    "acknowledge_answer",
     "dismiss",
     "annotate",
     "set_blocker",
@@ -1691,6 +1692,34 @@ impl AgendaStore {
                         "{id} is retired — reopen it first"
                     ))),
                 }
+            }
+            AgendaCommand::AcknowledgeAnswer { id, source: _ } => {
+                let item = self.require(&id)?;
+                if item.kind != super::types::AgendaKind::Question {
+                    return Err(AgendaError::Invalid(format!(
+                        "{id} is not a question — only question answers can be acknowledged"
+                    )));
+                }
+                if item.status != AgendaStatus::Done {
+                    return Err(AgendaError::Transition(match item.status {
+                        AgendaStatus::Open => format!("{id} has not been answered yet"),
+                        AgendaStatus::Retired => format!("{id} is retired — reopen it first"),
+                        AgendaStatus::Done => unreachable!(),
+                    }));
+                }
+                let Some(answer) = item.answer.as_ref() else {
+                    return Err(AgendaError::Transition(format!(
+                        "{id} was completed without an answer to acknowledge"
+                    )));
+                };
+                if !item.answer_awaiting_pickup() {
+                    return Err(AgendaError::Transition(if answer.delivered == Some(true) {
+                        format!("{id}'s answer was already delivered")
+                    } else {
+                        format!("{id}'s answer is already acknowledged")
+                    }));
+                }
+                Ok(AgendaOp::AcknowledgeAnswer { id })
             }
             AgendaCommand::ProposeEffect {
                 id,
@@ -3806,10 +3835,50 @@ mod tests {
         ));
 
         drop(store);
-        let store = AgendaStore::open(dir.path()).unwrap();
+        let mut store = AgendaStore::open(dir.path()).unwrap();
         let reloaded = store.get(&question.id).unwrap();
         assert_eq!(reloaded.answer.as_ref().unwrap().text, "yes, before Friday");
         assert_eq!(reloaded.status, AgendaStatus::Done);
+        assert!(reloaded.answer_awaiting_pickup());
+
+        let acknowledged = store
+            .apply_command(
+                AgendaCommand::AcknowledgeAnswer {
+                    id: question.id.clone(),
+                    source: Some("session-start".into()),
+                },
+                owner(),
+                7,
+            )
+            .unwrap();
+        assert!(!acknowledged.answer_awaiting_pickup());
+        assert_eq!(
+            acknowledged
+                .answer
+                .as_ref()
+                .unwrap()
+                .acknowledged
+                .as_ref()
+                .unwrap()
+                .principal
+                .as_deref(),
+            Some("owner")
+        );
+        assert!(matches!(
+            store.apply_command(
+                AgendaCommand::AcknowledgeAnswer {
+                    id: question.id.clone(),
+                    source: None,
+                },
+                owner(),
+                8,
+            ),
+            Err(AgendaError::Transition(_))
+        ));
+
+        drop(store);
+        let store = AgendaStore::open(dir.path()).unwrap();
+        assert!(!store.get(&question.id).unwrap().answer_awaiting_pickup());
     }
 
     /// `--source` labels: validated at intake (trimmed, bounded, never
@@ -4491,6 +4560,18 @@ mod tests {
             .record_ask_delivery(&item.id, true, Some("sess-successor".into()), 5)
             .unwrap();
         assert_eq!(flipped.answer.as_ref().unwrap().delivered, Some(true));
+        assert!(!flipped.answer_awaiting_pickup());
+        assert!(matches!(
+            store.apply_command(
+                AgendaCommand::AcknowledgeAnswer {
+                    id: item.id.clone(),
+                    source: None,
+                },
+                owner(),
+                5,
+            ),
+            Err(AgendaError::Transition(_))
+        ));
 
         // Refold from disk: the marker is durable history.
         drop(store);

--- a/src/bin/caller/agenda/summary.rs
+++ b/src/bin/caller/agenda/summary.rs
@@ -228,6 +228,10 @@ pub(crate) struct SummaryAnswer {
     pub(crate) session_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) delivered: Option<bool>,
+    /// Explicit pickup receipt. Presence suppresses the awaiting-pickup
+    /// affordance even when no live-session delivery was recorded.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) acknowledged: Option<super::types::AgendaAnswerAcknowledgement>,
     /// The structured rich-ask breakdown — answered question cards
     /// render per-question selections ungated (render-completeness law).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -432,6 +436,7 @@ fn summarize_one(all: &[AgendaItem], item: &AgendaItem, watermark: u64) -> Agend
             at_ms: answer.at_ms,
             session_id: answer.session_id.clone(),
             delivered: answer.delivered,
+            acknowledged: answer.acknowledged.clone(),
             structured: answer.structured.clone(),
         }),
         ask: item.ask.as_ref().map(|ask| SummaryAsk {

--- a/src/bin/caller/agenda/types.rs
+++ b/src/bin/caller/agenda/types.rs
@@ -152,9 +152,30 @@ pub struct AgendaAnswer {
     /// heard — surfaces render it "answered · awaiting pickup"; a later
     /// successful successor delivery flips it true. Additive: `None` on
     /// answers that predate the marker and in logs written by older
-    /// builds (no chip either way — absent data claims nothing).
+    /// builds. Such answers stay in the pickup inbox until explicitly
+    /// acknowledged; absence still makes no transport claim.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) delivered: Option<bool>,
+    /// Explicit pickup receipt written by an agenda consumer. This is
+    /// deliberately separate from `delivered`: delivery is a daemon-
+    /// observed transport fact, while acknowledgement is an attributed
+    /// act. Merely reading or listing an answer never creates this value.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) acknowledged: Option<AgendaAnswerAcknowledgement>,
+}
+
+/// Who explicitly acknowledged an answered agenda question, and when.
+/// Attribution is copied from the acknowledgement op's trusted envelope;
+/// the full append-only history remains in the op log.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgendaAnswerAcknowledgement {
+    pub(crate) at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) principal: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) kind: Option<String>,
 }
 
 /// The full Ask v2 payload carried by a parked rich question: the wire
@@ -1215,6 +1236,13 @@ pub enum AgendaCommand {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         source: Option<String>,
     },
+    /// Record that a consumer picked up the current answer. This is an
+    /// explicit write: list/show reads never acknowledge on their own.
+    AcknowledgeAnswer {
+        id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        source: Option<String>,
+    },
     /// Park a rich multi-question ask (the Ask v2 payload — same
     /// vocabulary as `ask_user`'s `questions` form: options, pick bounds,
     /// free-text policy, inline preview sources) as a durable agenda
@@ -1557,6 +1585,17 @@ pub enum AgendaCommand {
 }
 
 impl AgendaItem {
+    /// Whether the current answer still belongs in the default working
+    /// set. Successful live delivery counts as pickup; otherwise only an
+    /// explicit acknowledgement clears it. Reads never alter either fact.
+    pub(crate) fn answer_awaiting_pickup(&self) -> bool {
+        self.kind == AgendaKind::Question
+            && self.status == AgendaStatus::Done
+            && self.answer.as_ref().is_some_and(|answer| {
+                answer.delivered != Some(true) && answer.acknowledged.is_none()
+            })
+    }
+
     /// Every session id this item's attribution views reference (birth
     /// provenance, answer, effect proposals and runs, session-type refs) —
     /// the set a display surface resolves to conversations and names.
@@ -1567,6 +1606,12 @@ impl AgendaItem {
             .as_deref()
             .into_iter()
             .chain(self.answer.as_ref().and_then(|a| a.session_id.as_deref()))
+            .chain(
+                self.answer
+                    .as_ref()
+                    .and_then(|a| a.acknowledged.as_ref())
+                    .and_then(|ack| ack.session_id.as_deref()),
+            )
             .chain(self.effects.iter().flat_map(|effect| {
                 effect.proposed_session_id.as_deref().into_iter().chain(
                     effect
@@ -1619,6 +1664,7 @@ impl AgendaCommand {
             | AgendaCommand::Reopen { source, .. }
             | AgendaCommand::Retire { source, .. }
             | AgendaCommand::Answer { source, .. }
+            | AgendaCommand::AcknowledgeAnswer { source, .. }
             | AgendaCommand::ProposeEffect { source, .. }
             | AgendaCommand::Annotate { source, .. }
             | AgendaCommand::Attest { source, .. }
@@ -1690,6 +1736,12 @@ pub(crate) enum AgendaOp {
         /// and fold the text alone).
         #[serde(default, skip_serializing_if = "Option::is_none")]
         structured: Option<AgendaAskResolution>,
+    },
+    /// Attributed, explicit pickup receipt for the current answer. Older
+    /// builds skip the whole line and therefore keep the answer visible
+    /// for pickup, which is the safe forward-compatible behavior.
+    AcknowledgeAnswer {
+        id: String,
     },
     /// Dismissal marker on an open question (rail skip/deny): recorded as
     /// history, the item stays open. Older builds skip the whole line
@@ -1868,6 +1920,7 @@ impl AgendaOp {
             | AgendaOp::Reopen { id }
             | AgendaOp::Retire { id }
             | AgendaOp::Answer { id, .. }
+            | AgendaOp::AcknowledgeAnswer { id }
             | AgendaOp::Dismiss { id, .. }
             | AgendaOp::Annotate { id, .. }
             | AgendaOp::SetBlocker { id, .. }
@@ -2622,6 +2675,9 @@ pub(crate) fn apply_op(
                         // Delivery is a later fact: the supervisor's
                         // delivery arm records it as its own op.
                         delivered: None,
+                        // Pickup is also a later, explicit act. Reads do
+                        // not mutate this receipt.
+                        acknowledged: None,
                     });
                     // A reply resolves the question (an earlier dismissal
                     // is history the answer supersedes).
@@ -2635,6 +2691,35 @@ pub(crate) fn apply_op(
                     Some(format!("answer on resolved {id} ignored"))
                 }
             }
+        }
+        AgendaOp::AcknowledgeAnswer { id } => {
+            let Some(item) = items.get_mut(id) else {
+                return Some(format!("acknowledge_answer for unknown {id} ignored"));
+            };
+            if item.kind != AgendaKind::Question || item.status != AgendaStatus::Done {
+                return Some(format!(
+                    "acknowledge_answer on unanswered question {id} ignored"
+                ));
+            }
+            let Some(answer) = item.answer.as_mut() else {
+                return Some(format!(
+                    "acknowledge_answer on {id} without a current answer ignored"
+                ));
+            };
+            if answer.delivered == Some(true) || answer.acknowledged.is_some() {
+                return Some(format!(
+                    "acknowledge_answer on already picked-up {id} ignored"
+                ));
+            }
+            let actor = rec.actor.clone().unwrap_or_default();
+            answer.acknowledged = Some(AgendaAnswerAcknowledgement {
+                at_ms,
+                principal: actor.principal,
+                session_id: actor.session_id,
+                kind: actor.kind,
+            });
+            item.updated_ms = at_ms;
+            None
         }
         AgendaOp::RecordAskDelivery { id, delivered, .. } => {
             let Some(item) = items.get_mut(id) else {
@@ -3527,6 +3612,12 @@ mod tests {
         let complete: AgendaCommand =
             serde_json::from_str(r#"{"op":"complete","id":"01X"}"#).unwrap();
         assert!(matches!(complete, AgendaCommand::Complete { .. }));
+        let acknowledge: AgendaCommand =
+            serde_json::from_str(r#"{"op":"acknowledge_answer","id":"01X"}"#).unwrap();
+        assert!(matches!(
+            acknowledge,
+            AgendaCommand::AcknowledgeAnswer { .. }
+        ));
         let patch: AgendaCommand =
             serde_json::from_str(r#"{"op":"patch","id":"01X","patch":{"due_ms":null}}"#).unwrap();
         match patch {
@@ -3803,6 +3894,86 @@ mod tests {
         );
     }
 
+    /// Pickup is an explicit attributed op, not a side effect of reading.
+    /// It clears the derived inbox state without changing lifecycle or the
+    /// transport-delivery fact, and replay rejects duplicate receipts.
+    #[test]
+    fn answer_acknowledgement_folds_as_an_explicit_pickup_receipt() {
+        let mut items = BTreeMap::new();
+        apply_op(
+            &mut items,
+            &rec(
+                1,
+                AgendaOp::Add {
+                    id: "q".into(),
+                    kind: AgendaKind::Question,
+                    title: "Which grid?".into(),
+                    body: String::new(),
+                    tags: Vec::new(),
+                    due_ms: None,
+                    ask: None,
+                },
+            ),
+        );
+        apply_op(
+            &mut items,
+            &rec(
+                2,
+                AgendaOp::Answer {
+                    id: "q".into(),
+                    text: "A".into(),
+                    structured: None,
+                },
+            ),
+        );
+        assert!(items["q"].answer_awaiting_pickup());
+
+        let mut ack = rec(3, AgendaOp::AcknowledgeAnswer { id: "q".into() });
+        ack.actor = Some(AgendaActor {
+            principal: Some("principal:agent".into()),
+            session_id: Some("sess-consumer".into()),
+            kind: Some("agent_session".into()),
+        });
+        assert!(apply_op(&mut items, &ack).is_none());
+        let item = &items["q"];
+        assert_eq!(item.status, AgendaStatus::Done);
+        assert!(!item.answer_awaiting_pickup());
+        assert_eq!(item.answer.as_ref().unwrap().delivered, None);
+        let receipt = item.answer.as_ref().unwrap().acknowledged.as_ref().unwrap();
+        assert_eq!(receipt.at_ms, 3);
+        assert_eq!(receipt.session_id.as_deref(), Some("sess-consumer"));
+        assert!(item
+            .referenced_session_ids()
+            .any(|id| id == "sess-consumer"));
+        assert!(apply_op(&mut items, &ack).is_some());
+    }
+
+    #[test]
+    fn acknowledge_answer_record_line_format_is_pinned() {
+        let record = AgendaOpRecord {
+            v: 1,
+            at_ms: 11,
+            actor: Some(AgendaActor {
+                principal: Some("principal:agent".into()),
+                session_id: Some("sess-consumer".into()),
+                kind: Some("agent_session".into()),
+            }),
+            source: Some("session-start".into()),
+            op: AgendaOp::AcknowledgeAnswer {
+                id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".into(),
+            },
+        };
+        let line = serde_json::to_string(&record).unwrap();
+        assert_eq!(
+            line,
+            r#"{"v":1,"at_ms":11,"actor":{"principal":"principal:agent","session_id":"sess-consumer","kind":"agent_session"},"source":"session-start","op":{"type":"acknowledge_answer","id":"01ARZ3NDEKTSV4RRFFQ69G5FAV"}}"#
+        );
+        assert_eq!(
+            serde_json::from_str::<AgendaOpRecord>(&line).unwrap(),
+            record
+        );
+    }
+
     /// DTO forward-compat for the marker: an answer serialized by an older
     /// build (no `delivered` field) deserializes to `None`, and a `None`
     /// marker stays off the wire (the answered-item pin above carries no
@@ -3811,6 +3982,7 @@ mod tests {
     fn answer_without_delivered_field_deserializes_to_none() {
         let answer: AgendaAnswer = serde_json::from_str(r#"{"text":"A","at_ms":2}"#).unwrap();
         assert_eq!(answer.delivered, None);
+        assert_eq!(answer.acknowledged, None);
         assert!(!serde_json::to_string(&answer)
             .unwrap()
             .contains("delivered"));
@@ -3826,17 +3998,17 @@ mod tests {
     }
 
     /// The dashboard's "answered · awaiting pickup" chip renders from
-    /// exactly this DTO contract: a DONE, ask-backed item whose answer
-    /// carries `delivered === false` (absent = pre-marker history = no
-    /// chip). Pinned against the built SPA so a vocabulary change that
+    /// exactly this DTO contract: a DONE answered item without successful
+    /// delivery or an explicit acknowledgement. Pinned against the built
+    /// SPA so a vocabulary change that
     /// forgets the frontend fails here instead of shipping as drift (the
     /// derive-don't-mirror parity pattern).
     #[test]
     fn awaiting_pickup_chip_condition_is_pinned_in_app_html() {
         let app = include_str!("../../../../static/app.html");
         for marker in [
-            "item.status === 'done' && item.ask && item.answer",
-            "item.answer.delivered === false",
+            "item.status === 'done' && item.answer",
+            "item.answer.delivered !== true && !item.answer.acknowledged",
             "answered · awaiting pickup",
             "agendaChipHtml('answered · awaiting pickup', 'sky'",
         ] {

--- a/src/bin/caller/ctl.rs
+++ b/src/bin/caller/ctl.rs
@@ -2587,6 +2587,9 @@ async fn run_agenda(
             run_agenda_read_page(client, config, &raw[1..], AgendaPageKind::Occurrences).await?
         }
         "complete" | "done" => agenda_transition(client, config, "complete", &raw[1..]).await?,
+        "acknowledge" | "ack" => {
+            agenda_transition(client, config, "acknowledge_answer", &raw[1..]).await?
+        }
         "reopen" => agenda_transition(client, config, "reopen", &raw[1..]).await?,
         "retire" => agenda_transition(client, config, "retire", &raw[1..]).await?,
         "annotate" => {
@@ -3152,20 +3155,32 @@ async fn run_agenda_list(
     )?;
     let blocked_only = args.has("--blocked");
     let frontier_only = args.has("--frontier");
+    let explicit_status = ["--all", "--open", "--done", "--retired"]
+        .iter()
+        .any(|flag| args.has(flag));
+    // Bare list is the working inbox: open work plus answers that no live
+    // session received and no consumer has explicitly acknowledged. The
+    // named filters remain exact; --blocked/--frontier are open-only views.
+    let default_working_set = !explicit_status && !blocked_only && !frontier_only;
     let status = if args.has("--all") {
         None
     } else if args.has("--done") {
         Some("done")
     } else if args.has("--retired") {
         Some("retired")
-    } else {
-        // Default to the working set; --open is accepted for symmetry.
-        // --blocked implies open (blocked is derived only on open items).
+    } else if args.has("--open") || blocked_only || frontier_only {
         Some("open")
+    } else {
+        // The default working set is a union, filtered locally below.
+        None
     };
     let mut tool_args = Map::new();
     insert_string(&mut tool_args, "status", status);
-    if (config.json || config.raw) && args.one("--under").is_none() && !frontier_only {
+    if (config.json || config.raw)
+        && !default_working_set
+        && args.one("--under").is_none()
+        && !frontier_only
+    {
         let response = call_tool(client, config, "agenda_list", Value::Object(tool_args)).await?;
         return print_tool_response(response, config, None);
     }
@@ -3205,9 +3220,8 @@ async fn run_agenda_list(
     let items: Vec<&Value> = all_items
         .iter()
         .filter(|item| {
-            let item_status = item.get("status").and_then(Value::as_str).unwrap_or("");
             let id = item.get("id").and_then(Value::as_str).unwrap_or("");
-            status.is_none_or(|s| item_status == s)
+            agenda_list_status_matches(item, default_working_set, status)
                 && (!blocked_only || agenda_item_is_blocked(&all_items, item))
                 && (!frontier_only || in_frontier(item))
                 && under_subtree.as_ref().is_none_or(|s| s.contains(id))
@@ -3225,10 +3239,11 @@ async fn run_agenda_list(
         if frontier_only {
             println!("frontier empty — nothing awaits triage");
         } else {
-            match (blocked_only, status) {
-                (true, _) => println!("no blocked agenda items"),
-                (false, Some(status)) => println!("no {status} agenda items"),
-                (false, None) => println!("agenda is empty"),
+            match (blocked_only, default_working_set, status) {
+                (true, _, _) => println!("no blocked agenda items"),
+                (false, true, _) => println!("no agenda items awaiting work or pickup"),
+                (false, false, Some(status)) => println!("no {status} agenda items"),
+                (false, false, None) => println!("agenda is empty"),
             }
         }
     }
@@ -3239,8 +3254,46 @@ async fn run_agenda_list(
     let open = counts.get("open").and_then(Value::as_u64).unwrap_or(0);
     let done = counts.get("done").and_then(Value::as_u64).unwrap_or(0);
     let retired = counts.get("retired").and_then(Value::as_u64).unwrap_or(0);
-    println!("{open} open · {done} done · {retired} retired");
+    if default_working_set {
+        let awaiting = items
+            .iter()
+            .filter(|item| agenda_answer_awaiting_pickup(item))
+            .count();
+        println!("{open} open · {awaiting} awaiting pickup · {done} done · {retired} retired");
+    } else {
+        println!("{open} open · {done} done · {retired} retired");
+    }
     Ok(())
+}
+
+/// Print-time twin of the agenda item's `answer_awaiting_pickup` fold. The ctl
+/// receives JSON over MCP, so it derives the same union from the served
+/// answer facts: successful delivery OR an explicit acknowledgement
+/// consumes pickup; a read never does.
+fn agenda_answer_awaiting_pickup(item: &Value) -> bool {
+    if item.get("kind").and_then(Value::as_str) != Some("question")
+        || item.get("status").and_then(Value::as_str) != Some("done")
+    {
+        return false;
+    }
+    let Some(answer) = item.get("answer").and_then(Value::as_object) else {
+        return false;
+    };
+    answer.get("delivered").and_then(Value::as_bool) != Some(true)
+        && answer.get("acknowledged").is_none_or(Value::is_null)
+}
+
+fn agenda_list_status_matches(
+    item: &Value,
+    default_working_set: bool,
+    status: Option<&str>,
+) -> bool {
+    let item_status = item.get("status").and_then(Value::as_str).unwrap_or("");
+    if default_working_set {
+        item_status == "open" || agenda_answer_awaiting_pickup(item)
+    } else {
+        status.is_none_or(|expected| item_status == expected)
+    }
 }
 
 /// Print-time twin of the daemon's `agenda::is_blocked` derivation (the
@@ -3505,6 +3558,7 @@ fn agenda_print_item_detail(item: &Value) {
 
 fn agenda_render_row(item: &Value, blocked: bool, all_items: &[Value]) -> String {
     let field = |key: &str| item.get(key).and_then(Value::as_str).unwrap_or("");
+    let awaiting_pickup = agenda_answer_awaiting_pickup(item);
     let glyph = match (field("status"), field("kind")) {
         ("open", "question") => "?",
         ("done", _) => "✓",
@@ -3514,11 +3568,18 @@ fn agenda_render_row(item: &Value, blocked: bool, all_items: &[Value]) -> String
     let mut row = format!(
         "{glyph} {}  {:<8}  {}",
         field("id"),
-        field("kind"),
+        if field("status") == "done" && field("kind") == "question" {
+            "answered"
+        } else {
+            field("kind")
+        },
         field("title")
     );
     if blocked {
         row.push_str("  [blocked]");
+    }
+    if awaiting_pickup {
+        row.push_str("  [awaiting pickup]");
     }
     if let Some(answer) = item
         .get("answer")
@@ -3623,11 +3684,16 @@ async fn agenda_transition(
     raw: &[String],
 ) -> Result<(), String> {
     let args = parse_command_args(raw, &["--source"], &[])?;
+    let cli_verb = if op == "acknowledge_answer" {
+        "acknowledge"
+    } else {
+        op
+    };
     let id = agenda_resolve_id(
         client,
         config,
         &args,
-        &format!("agenda {op} requires an item id (a unique prefix is enough)"),
+        &format!("agenda {cli_verb} requires an item id (a unique prefix is enough)"),
     )
     .await?;
     let mut map = Map::new();
@@ -5996,6 +6062,7 @@ fn help_agenda() {
       # --consequence names what happens if the question lapses unanswered, and\n\
       # --due doubles as its expiry (when silence starts to mean the consequence)\n\
   intendant ctl agenda answer ID_PREFIX REPLY... [--source LABEL]\n\
+  intendant ctl agenda acknowledge ID_PREFIX [--source LABEL]   # explicitly consume a listed answer\n\
   intendant ctl agenda list [--all|--open|--done|--retired] [--blocked] [--json]\n\
   intendant ctl agenda show ID_PREFIX [--json]   # ONE item, full detail — never fetches the ledger\n\
   intendant ctl agenda annotate ID_PREFIX NOTE... [--source LABEL]\n\
@@ -6253,6 +6320,67 @@ mod tests {
 
     fn args(values: &[&str]) -> Vec<String> {
         values.iter().map(|value| value.to_string()).collect()
+    }
+
+    #[test]
+    fn agenda_default_working_set_includes_only_unconsumed_answers_beside_open_items() {
+        let open = serde_json::json!({"kind":"task","status":"open"});
+        let plain_answer = serde_json::json!({
+            "kind":"question", "status":"done", "answer":{"text":"A","at_ms":2}
+        });
+        let missed_delivery = serde_json::json!({
+            "kind":"question", "status":"done",
+            "answer":{"text":"A","at_ms":2,"delivered":false}
+        });
+        let delivered = serde_json::json!({
+            "kind":"question", "status":"done",
+            "answer":{"text":"A","at_ms":2,"delivered":true}
+        });
+        let acknowledged = serde_json::json!({
+            "kind":"question", "status":"done",
+            "answer":{"text":"A","at_ms":2,"acknowledged":{"at_ms":3}}
+        });
+        let completed_without_answer = serde_json::json!({"kind":"question","status":"done"});
+
+        assert!(agenda_list_status_matches(&open, true, None));
+        assert!(agenda_list_status_matches(&plain_answer, true, None));
+        assert!(agenda_list_status_matches(&missed_delivery, true, None));
+        assert!(!agenda_list_status_matches(&delivered, true, None));
+        assert!(!agenda_list_status_matches(&acknowledged, true, None));
+        assert!(!agenda_list_status_matches(
+            &completed_without_answer,
+            true,
+            None
+        ));
+
+        // Named lifecycle filters stay exact: --open never grows the
+        // answered pickup union, while --done still includes every done
+        // answer regardless of pickup state.
+        assert!(!agenda_list_status_matches(
+            &plain_answer,
+            false,
+            Some("open")
+        ));
+        assert!(agenda_list_status_matches(
+            &acknowledged,
+            false,
+            Some("done")
+        ));
+    }
+
+    #[test]
+    fn agenda_answered_row_names_kind_and_pickup_state() {
+        let item = serde_json::json!({
+            "id":"01ANSWER",
+            "kind":"question",
+            "status":"done",
+            "title":"Which grid?",
+            "answer":{"text":"Use A","at_ms":2,"delivered":false}
+        });
+        let row = agenda_render_row(&item, false, &[]);
+        assert!(row.contains("answered"), "{row}");
+        assert!(row.contains("[awaiting pickup]"), "{row}");
+        assert!(row.contains("↳ Use A"), "{row}");
     }
 
     /// The approve-while-blocked warning is NAMED (the UX rider: the

--- a/src/bin/caller/mcp/tool_gate.rs
+++ b/src/bin/caller/mcp/tool_gate.rs
@@ -1613,6 +1613,7 @@ mod tests {
             assert_eq!(
                 ops,
                 [
+                    "acknowledge_answer",
                     "add",
                     "add_part_of",
                     "add_ref",

--- a/static/app.html
+++ b/static/app.html
@@ -39401,7 +39401,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '3fe7c117fef255a1';
+const INTENDANT_APP_BUILD = 'c572e9ec211107af';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -100226,12 +100226,13 @@ function agendaCardChips(item) {
         ? `“${w.watcher_title}” picks this up ${agendaRelTime(w.due_ms)} — returns to Needs you if it can’t deliver`
         : `“${w.watcher_title}” is handling this now — returns to Needs you if it can’t deliver`));
   }
-  // Answered ask whose delivery reached no session (the daemon-recorded
-  // `delivered: false` marker; absent data claims nothing).
-  if (item.status === 'done' && item.ask && item.answer
-    && item.answer.delivered === false) {
+  // Answered question still awaiting a consumer. Successful live delivery
+  // or an explicit acknowledgement consumes pickup; merely rendering the
+  // card never does.
+  if (item.status === 'done' && item.answer
+    && item.answer.delivered !== true && !item.answer.acknowledged) {
     chips.push(agendaChipHtml('answered · awaiting pickup', 'sky',
-      'No live session heard the answer — the asker’s successor reads it at session start', true));
+      'No live session received this answer and no consumer has acknowledged it yet', true));
   }
   if (st) {
     if (st.kind === 'running') {
@@ -101724,9 +101725,12 @@ function agendaInspQuestionHtml(item) {
       rows.push(`<div class="ag2-insp-resq"><span class="ag2-restext">${escapeHtml(a.text)}</span></div>`);
     }
     const who = agendaActorLabel(a) || 'unattributed';
-    const delivery = a.delivered === false
-      ? ' · awaiting pickup — no live session heard it'
-      : a.delivered === true ? ' · delivered into the asking session' : '';
+    const acknowledgedBy = a.acknowledged ? (agendaActorLabel(a.acknowledged) || 'unattributed') : '';
+    const delivery = a.delivered === true
+      ? ' · delivered into the asking session'
+      : a.acknowledged
+        ? ` · pickup acknowledged by ${acknowledgedBy}`
+        : ' · awaiting pickup';
     const railView = item.status === 'done' && questions.length
       ? ` <button type="button" class="ag2-linkbtn" data-act="rail-view">View the rail record ›</button>`
       : '';
@@ -106595,6 +106599,11 @@ function agendaHoodAskHtml(item) {
         ? 'recorded by a daemon-authored record_ask_delivery op; one info notification raised (title only, never answer text)'
         : 'absent data claims nothing';
     chips.push(agendaChipHtml(label, tone, tip));
+    if (item.answer.acknowledged) {
+      const ack = item.answer.acknowledged;
+      chips.push(agendaChipHtml('pickup acknowledged', 'green',
+        `${agendaActorLabel(ack) || 'unattributed'} · ${agendaRelTime(ack.at_ms)}`));
+    }
   }
   if (!chips.length) return '';
   const note = item.status === 'open'
@@ -106625,6 +106634,7 @@ function agendaHoodOpVerb(op, envelope) {
     case 'reopen': return 'reopened';
     case 'retire': return 'retired — hidden, never deleted';
     case 'answer': return 'answered';
+    case 'acknowledge_answer': return 'answer pickup acknowledged';
     case 'dismiss': return `dismissed${op.action ? ` (${op.action})` : ''} — still open`;
     case 'annotate': {
       // The self-described label rides the verb (the triage mandate's
@@ -106661,7 +106671,7 @@ function agendaHoodOpDot(op, known) {
   switch (String(op.type || '')) {
     case 'add': case 'reopen': case 'request_occurrence': return 'iris';
     case 'set_blocker': return 'rose';
-    case 'clear_blocker': case 'approve_effect': case 'answer': case 'complete': return 'green';
+    case 'clear_blocker': case 'approve_effect': case 'answer': case 'acknowledge_answer': case 'complete': return 'green';
     case 'add_ref': case 'remove_ref': case 'record_ask_delivery': return 'sky';
     case 'propose_effect': case 'revoke_effect': case 'withdraw_effect': return 'amber';
     case 'record_occurrence':

--- a/static/app/ui2-agenda-cards.js
+++ b/static/app/ui2-agenda-cards.js
@@ -960,12 +960,13 @@ function agendaCardChips(item) {
         ? `“${w.watcher_title}” picks this up ${agendaRelTime(w.due_ms)} — returns to Needs you if it can’t deliver`
         : `“${w.watcher_title}” is handling this now — returns to Needs you if it can’t deliver`));
   }
-  // Answered ask whose delivery reached no session (the daemon-recorded
-  // `delivered: false` marker; absent data claims nothing).
-  if (item.status === 'done' && item.ask && item.answer
-    && item.answer.delivered === false) {
+  // Answered question still awaiting a consumer. Successful live delivery
+  // or an explicit acknowledgement consumes pickup; merely rendering the
+  // card never does.
+  if (item.status === 'done' && item.answer
+    && item.answer.delivered !== true && !item.answer.acknowledged) {
     chips.push(agendaChipHtml('answered · awaiting pickup', 'sky',
-      'No live session heard the answer — the asker’s successor reads it at session start', true));
+      'No live session received this answer and no consumer has acknowledged it yet', true));
   }
   if (st) {
     if (st.kind === 'running') {

--- a/static/app/ui2-agenda-hood.js
+++ b/static/app/ui2-agenda-hood.js
@@ -318,6 +318,11 @@ function agendaHoodAskHtml(item) {
         ? 'recorded by a daemon-authored record_ask_delivery op; one info notification raised (title only, never answer text)'
         : 'absent data claims nothing';
     chips.push(agendaChipHtml(label, tone, tip));
+    if (item.answer.acknowledged) {
+      const ack = item.answer.acknowledged;
+      chips.push(agendaChipHtml('pickup acknowledged', 'green',
+        `${agendaActorLabel(ack) || 'unattributed'} · ${agendaRelTime(ack.at_ms)}`));
+    }
   }
   if (!chips.length) return '';
   const note = item.status === 'open'
@@ -348,6 +353,7 @@ function agendaHoodOpVerb(op, envelope) {
     case 'reopen': return 'reopened';
     case 'retire': return 'retired — hidden, never deleted';
     case 'answer': return 'answered';
+    case 'acknowledge_answer': return 'answer pickup acknowledged';
     case 'dismiss': return `dismissed${op.action ? ` (${op.action})` : ''} — still open`;
     case 'annotate': {
       // The self-described label rides the verb (the triage mandate's
@@ -384,7 +390,7 @@ function agendaHoodOpDot(op, known) {
   switch (String(op.type || '')) {
     case 'add': case 'reopen': case 'request_occurrence': return 'iris';
     case 'set_blocker': return 'rose';
-    case 'clear_blocker': case 'approve_effect': case 'answer': case 'complete': return 'green';
+    case 'clear_blocker': case 'approve_effect': case 'answer': case 'acknowledge_answer': case 'complete': return 'green';
     case 'add_ref': case 'remove_ref': case 'record_ask_delivery': return 'sky';
     case 'propose_effect': case 'revoke_effect': case 'withdraw_effect': return 'amber';
     case 'record_occurrence':

--- a/static/app/ui2-agenda-inspector.js
+++ b/static/app/ui2-agenda-inspector.js
@@ -442,9 +442,12 @@ function agendaInspQuestionHtml(item) {
       rows.push(`<div class="ag2-insp-resq"><span class="ag2-restext">${escapeHtml(a.text)}</span></div>`);
     }
     const who = agendaActorLabel(a) || 'unattributed';
-    const delivery = a.delivered === false
-      ? ' · awaiting pickup — no live session heard it'
-      : a.delivered === true ? ' · delivered into the asking session' : '';
+    const acknowledgedBy = a.acknowledged ? (agendaActorLabel(a.acknowledged) || 'unattributed') : '';
+    const delivery = a.delivered === true
+      ? ' · delivered into the asking session'
+      : a.acknowledged
+        ? ` · pickup acknowledged by ${acknowledgedBy}`
+        : ' · awaiting pickup';
     const railView = item.status === 'done' && questions.length
       ? ` <button type="button" class="ag2-linkbtn" data-act="rail-view">View the rail record ›</button>`
       : '';


### PR DESCRIPTION
## What changed

- add a durable, attributed `acknowledge_answer` operation and `ctl agenda acknowledge` command
- make bare `ctl agenda list` show open work plus answered questions awaiting pickup
- keep explicit lifecycle filters such as `--open` and `--done` exact
- render answered/pickup state in the CLI and dashboard, with regenerated static assets
- document the pickup workflow and pin the wire/schema behavior with focused tests

## Why

Answering a question immediately transitions it to `done`, while the default CLI list previously requested only `open` items. If no live asking session received the answer, that reply disappeared from the next-session working view and was visible only through `--all`.

Delivery remains a daemon-observed transport fact. Pickup acknowledgement is a separate explicit write, so list and show reads never mutate agenda state.

## Impact

A bare agenda list now works as a small inbox: open items remain visible, and unanswered pickup work stays present until live delivery succeeds or a consumer explicitly acknowledges it. Existing scripts that use named lifecycle filters keep their exact semantics.

## Validation

- `cargo check -p intendant --bin intendant`
- focused fold, store, CLI, summary, delivery, and served-schema tests
- `cargo run -p app-html-assembler`
- `node scripts/validate-dashboard.cjs --check-static-scripts --app-html static/app.html`
- `git diff --check`