### PR TITLE
peer: OpenClaw Gateway surface (slice 1) — [[peer]] config, pairing-pending vocabulary, dashboard + docs

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -968,14 +968,23 @@ does not understate what a connecting peer must present.
 
 ### `[[peer]]` — federated peers
 
-Each `[[peer]]` block auto-registers a remote daemon at startup. Only `card_url`
-is required.
+Each `[[peer]]` block auto-registers a remote daemon at startup. Two shapes
+share the block, selected by `transport`: the default card-driven form
+(`transport` absent — only `card_url` is required) and the OpenClaw Gateway
+form (`transport = "openclaw-ws"` — only `url` is required; a gateway serves
+no Agent Card, so the daemon synthesizes one locally). Per-kind validation
+runs at startup: an invalid entry logs a diagnostic and skips that one peer.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `card_url` | string | (required) | URL of the peer's Agent Card (`.../.well-known/agent-card.json`) |
-| `label` | string | from card | Display label override in the dashboard's Access targets |
-| `bearer_token` | string | none | Legacy/advanced outbound token for peers that still require `[server.auth] bearer_token` |
+| `transport` | string | absent | Entry kind: absent = card-driven Intendant federation; `"openclaw-ws"` = direct OpenClaw Gateway entry (docs/src/peer-federation.md § OpenClaw Gateway peers) |
+| `card_url` | string | (required unless `openclaw-ws`) | URL of the peer's Agent Card (`.../.well-known/agent-card.json`) |
+| `url` | string | (required for `openclaw-ws`) | The OpenClaw Gateway's WebSocket endpoint (`ws://host:18789` or `wss://…`); rejected on card-driven entries |
+| `role` | `operator` or `node` | `operator` | Role this daemon takes on the OpenClaw Gateway; `openclaw-ws` entries only |
+| `label` | string | from card (openclaw: gateway `host[:port]`) | Display label override in the dashboard's Access targets; for openclaw entries it is also the registry id suffix (`openclaw:<label>`), so two entries for one gateway need distinct labels |
+| `bearer_token` | string | none | Legacy/advanced outbound token for peers that still require `[server.auth] bearer_token`; prefer the `_env`/`_file` reference forms below |
+| `bearer_token_env` | string | none | Name of an environment variable holding the outbound bearer token — for `openclaw-ws` entries, the gateway's shared bootstrap token used in the pairing handshake. At most one of the three token fields may be set |
+| `bearer_token_file` | string | none | Path to a file whose trimmed contents are the outbound bearer token (same semantics as `bearer_token_env`) |
 | `via_urls` | array | `[]` | Connecting-side WebSocket URL overrides; when set, these replace the transports advertised by the peer's Agent Card |
 | `client_cert` | string | installed access client cert when present | Peer-issued client certificate PEM for outbound mTLS; must be paired with `client_key` |
 | `client_key` | string | installed access client key when present | Private key PEM for `client_cert`; must be paired with `client_cert` |
@@ -1297,6 +1306,13 @@ advertised_transport = "none"
 # client_key = "/etc/intendant/peers/peer-client.key"
 # bearer_token = "legacy-token-if-the-peer-requires-one"
 # certificate_witness_vantage = "remote" # only for a known outside-network peer
+
+# [[peer]]                       # an OpenClaw Gateway (no Agent Card)
+# transport = "openclaw-ws"
+# url = "ws://gateway-host:18789"
+# role = "operator"              # default; "node" is a future slice
+# label = "home-gateway"
+# bearer_token_env = "OPENCLAW_GATEWAY_TOKEN"  # pairing-bootstrap secret reference
 
 [[mcp_servers]]
 name = "filesystem"

--- a/docs/src/peer-federation.md
+++ b/docs/src/peer-federation.md
@@ -563,9 +563,9 @@ peer's profile for this daemon is the sole authority (exactly like the
 
 ## Transports
 
-Phase 1 ships the native Intendant↔Intendant transport. A2A, OpenClaw, and
-MCP-as-peer transports slot in as sibling modules behind the same `PeerTransport`
-trait.
+Phase 1 ships the native Intendant↔Intendant transport. OpenClaw Gateway
+support is landing as slice 1 (see below); A2A and MCP-as-peer transports
+slot in as sibling modules behind the same `PeerTransport` trait.
 
 ### Native WebSocket — `IntendantWsTransport`
 
@@ -585,6 +585,54 @@ back online while running on a fallback, the next reconnect picks it up. Before 
 candidate connects, `features()` reports the *union* of all candidates' features
 so coordinator-level checks don't prematurely reject an op a candidate could
 support once connected.
+
+### OpenClaw Gateway peers (slice 1)
+
+An OpenClaw Gateway is configured as a direct `[[peer]]` entry — it serves no
+Agent Card, so the entry names the gateway's WebSocket endpoint and the daemon
+synthesizes a local card with one `openclaw-ws` transport (kind `openclaw` in
+the id, rendered as a kind badge on the Daemons panel):
+
+```toml
+[[peer]]
+transport = "openclaw-ws"
+url = "ws://gateway-host:18789"        # the gateway's multiplexed port
+role = "operator"                       # default; "node" is a future slice
+label = "home-gateway"                  # display name + registry id suffix
+bearer_token_env = "OPENCLAW_GATEWAY_TOKEN"   # or bearer_token_file = "/path"
+```
+
+The bootstrap credential is a **secret reference** — the name of an
+environment variable (`bearer_token_env`) or a file path
+(`bearer_token_file`), never plaintext in the config — resolved once at
+startup and handed to the transport as the `connect` frame's `auth.token`.
+
+**The pairing ceremony (operator's view).** OpenClaw authenticates devices,
+not just tokens: the first connect from this daemon presents a fresh device
+identity, and the gateway answers `PAIRING_REQUIRED` with a pairing request
+id instead of a session. The peer's row on the Daemons panel then shows an
+amber **`pairing pending · <request-id>`** pill while the daemon keeps
+retrying in the background. To let it in, run on the gateway host:
+
+```bash
+openclaw devices list                     # see pending pairing requests
+openclaw devices approve <request-id>     # approve this daemon
+```
+
+The next reconnect completes the handshake, the pill clears, and the granted
+device token is persisted daemon-side — the bootstrap token is no longer
+load-bearing after that. Widening scopes or switching role later mints a
+*new* pairing request (same pill, new id); token rotation alone cannot expand
+what was approved.
+
+**Current capability (slice 1): message relay.** `ctl peer message` /
+`send_message` maps onto the gateway's chat lane, and gateway chat/session
+events surface in the peer's event feed. Task delegation, approvals
+bridging, attachments, and the `node` role (lending this machine's
+capabilities back to the gateway) are later slices. A build whose OpenClaw
+transport hasn't shipped yet degrades cleanly: the configured peer fails
+registration at startup with the standard "advertises no transport this
+build supports" diagnostic — no panic, no silent nothing.
 
 ### Cert pinning over mTLS — `PinnedMutualTls`
 

--- a/src/bin/caller/ctl.rs
+++ b/src/bin/caller/ctl.rs
@@ -391,7 +391,17 @@ fn configure_peer_mode(config: &mut Config, needle: &str) -> Result<reqwest::Cli
         &user_peers_file(),
         needle,
     )?;
-    config.base_url = peer_mcp_endpoint(&peer.card_url)?;
+    // `--peer` drives the peer's stateless `/mcp` endpoint, which is
+    // derived from its Agent Card URL — an entry without one (an
+    // openclaw-ws gateway) has no such endpoint to drive.
+    let card_url = peer.card_url.as_deref().ok_or_else(|| {
+        format!(
+            "peer '{needle}' is a {} entry with no card_url — `ctl --peer` \
+             drives Intendant peers via their Agent Card /mcp endpoint",
+            peer.transport.as_deref().unwrap_or("card-less")
+        )
+    })?;
+    config.base_url = peer_mcp_endpoint(card_url)?;
     config.bearer = peer.bearer_token.clone();
 
     let mut pins = Vec::with_capacity(peer.pinned_fingerprints.len());
@@ -531,7 +541,10 @@ fn resolve_peer<'a>(
 }
 
 fn peer_matches(peer: &crate::project::PeerConfig, needle: &str) -> bool {
-    if needle == peer.card_url || label_or_host_matches(peer, needle) {
+    if peer.card_url.as_deref() == Some(needle)
+        || peer.url.as_deref() == Some(needle)
+        || label_or_host_matches(peer, needle)
+    {
         return true;
     }
     match needle.rsplit_once(':') {
@@ -551,21 +564,30 @@ fn label_or_host_matches(peer: &crate::project::PeerConfig, needle: &str) -> boo
     card_url_host(peer).is_some_and(|host| host.eq_ignore_ascii_case(needle))
 }
 
+/// Host of the entry's address — `card_url` for card-driven peers,
+/// falling back to the gateway `url` for openclaw-ws entries.
 fn card_url_host(peer: &crate::project::PeerConfig) -> Option<String> {
-    reqwest::Url::parse(&peer.card_url)
-        .ok()
+    peer.card_url
+        .as_deref()
+        .or(peer.url.as_deref())
+        .and_then(|raw| reqwest::Url::parse(raw).ok())
         .and_then(|url| url.host_str().map(str::to_string))
 }
 
 /// Render a configured peer for "which peers exist" error listings:
-/// `label (host)` when both are known, else whichever exists, else card_url.
+/// `label (host)` when both are known, else whichever exists, else the
+/// raw configured address.
 fn describe_peer(peer: &crate::project::PeerConfig) -> String {
     let host = card_url_host(peer);
     match (peer.label.as_deref(), host) {
         (Some(label), Some(host)) => format!("{label} ({host})"),
         (Some(label), None) => label.to_string(),
         (None, Some(host)) => host,
-        (None, None) => peer.card_url.clone(),
+        (None, None) => peer
+            .card_url
+            .clone()
+            .or_else(|| peer.url.clone())
+            .unwrap_or_else(|| "<address-less [[peer]] entry>".to_string()),
     }
 }
 
@@ -7508,16 +7530,9 @@ mod tests {
 
     fn peer_config(card_url: &str, label: Option<&str>) -> crate::project::PeerConfig {
         crate::project::PeerConfig {
-            card_url: card_url.to_string(),
+            card_url: Some(card_url.to_string()),
             label: label.map(str::to_string),
-            bearer_token: None,
-            via_urls: Vec::new(),
-            client_cert: None,
-            client_key: None,
-            pinned_fingerprints: Vec::new(),
-            identity_public_key: None,
-            browser_tcp_via_url: None,
-            certificate_witness_vantage: crate::peer::PeerWitnessVantage::Unknown,
+            ..Default::default()
         }
     }
 
@@ -7559,8 +7574,8 @@ mod tests {
         ];
         let peer = resolve_peer(&peers, "dell.example").expect("host matches");
         assert_eq!(
-            peer.card_url,
-            "https://dell.example/.well-known/agent-card.json"
+            peer.card_url.as_deref(),
+            Some("https://dell.example/.well-known/agent-card.json")
         );
     }
 
@@ -7577,8 +7592,8 @@ mod tests {
         assert_eq!(by_label.label.as_deref(), Some("nicks-mac"));
         let by_host = resolve_peer(&peers, "intendant:dell.example").expect("suffix host matches");
         assert_eq!(
-            by_host.card_url,
-            "https://dell.example/.well-known/agent-card.json"
+            by_host.card_url.as_deref(),
+            Some("https://dell.example/.well-known/agent-card.json")
         );
     }
 
@@ -7587,7 +7602,7 @@ mod tests {
         let card_url = "http://localhost:8766/.well-known/agent-card.json";
         let peers = vec![peer_config(card_url, None)];
         let peer = resolve_peer(&peers, card_url).expect("exact card_url matches");
-        assert_eq!(peer.card_url, card_url);
+        assert_eq!(peer.card_url.as_deref(), Some(card_url));
     }
 
     #[test]
@@ -7649,8 +7664,8 @@ bearer_token = "tok"
         assert_eq!(peer.label.as_deref(), Some("dell"));
         assert_eq!(peer.bearer_token.as_deref(), Some("tok"));
         assert_eq!(
-            peer.card_url,
-            "https://dell.example/.well-known/agent-card.json"
+            peer.card_url.as_deref(),
+            Some("https://dell.example/.well-known/agent-card.json")
         );
     }
 
@@ -7673,8 +7688,8 @@ bearer_token = "tok"
         )
         .expect("project layer wins");
         assert_eq!(
-            peer.card_url,
-            "https://project.example/.well-known/agent-card.json"
+            peer.card_url.as_deref(),
+            Some("https://project.example/.well-known/agent-card.json")
         );
     }
 

--- a/src/bin/caller/peer/access_request.rs
+++ b/src/bin/caller/peer/access_request.rs
@@ -835,7 +835,7 @@ pub(crate) fn install_approved_identity(
         .config
         .peers
         .iter_mut()
-        .find(|peer| peer.card_url == result.card_url);
+        .find(|peer| peer.card_url.as_deref() == Some(result.card_url.as_str()));
     let updated_existing = existing.is_some();
     match existing {
         Some(peer) => {
@@ -854,16 +854,13 @@ pub(crate) fn install_approved_identity(
         }
         None => {
             project.config.peers.push(PeerConfig {
-                card_url: result.card_url.clone(),
+                card_url: Some(result.card_url.clone()),
                 label,
-                bearer_token: None,
-                via_urls: Vec::new(),
                 client_cert: Some(cert_path.to_string_lossy().into_owned()),
                 client_key: Some(key_path.to_string_lossy().into_owned()),
                 pinned_fingerprints: pins,
                 identity_public_key: result.target_daemon_identity_public_key.clone(),
-                browser_tcp_via_url: None,
-                certificate_witness_vantage: crate::peer::PeerWitnessVantage::Unknown,
+                ..Default::default()
             });
         }
     }
@@ -1999,7 +1996,10 @@ mod tests {
         assert!(outcome.client_cert_path.exists());
         assert!(outcome.client_key_path.exists());
         assert_eq!(project.config.peers.len(), 1);
-        assert_eq!(project.config.peers[0].card_url, result.card_url);
+        assert_eq!(
+            project.config.peers[0].card_url.as_deref(),
+            Some(result.card_url.as_str())
+        );
         assert!(
             project.config.peers[0].identity_public_key.is_none(),
             "a pre-B2 result installs without inventing an identity key"

--- a/src/bin/caller/peer/actor.rs
+++ b/src/bin/caller/peer/actor.rs
@@ -24,8 +24,8 @@
 
 use crate::peer::card::AgentCard;
 use crate::peer::event::{
-    MessageContent, MessageId, MessageRole, PeerDisplayInfo, PeerEvent, PeerSharedViewInfo,
-    PeerStatus, SessionInfo, TaggedPeerEvent, TaskId,
+    MessageContent, MessageId, MessageRole, PeerDisplayInfo, PeerEvent, PeerPairingInfo,
+    PeerSharedViewInfo, PeerStatus, SessionInfo, TaggedPeerEvent, TaskId,
 };
 use crate::peer::handle::{ConnectionState, PeerCommand, PeerGrantInfo, PeerLinkInfo};
 use crate::peer::id::PeerId;
@@ -214,6 +214,13 @@ pub(crate) struct PeerActor {
     /// Connection-scoped like `sessions_tx` — cleared on disconnect;
     /// re-advertised by the peer on every connect.
     pub grant_tx: watch::Sender<Option<PeerGrantInfo>>,
+    /// Published view of the peer-side enrollment gate, folded from
+    /// [`PeerEvent::PairingStateChanged`] (OpenClaw pairing is the
+    /// canonical producer). Deliberately NOT connection-scoped — the
+    /// state exists to explain failed connect attempts, so it survives
+    /// disconnects and clears on the next successful connect (or an
+    /// explicit `pending: None` from the transport).
+    pub pairing_tx: watch::Sender<Option<PeerPairingInfo>>,
     /// Published delegation-receipt ledger, folded from
     /// [`PeerEvent::TaskReceipt`]: delegation id → the peer's local
     /// identity for the accepted task. `PeerHandle::delegate_task`
@@ -313,6 +320,15 @@ impl PeerActor {
                     let _ = self
                         .link_tx
                         .send(PeerLinkInfo::from_spec(self.transport.spec()));
+                    // A successful connect proves any enrollment gate
+                    // (OpenClaw pairing) has been passed — clear the
+                    // pending-pairing fold so the dashboard stops
+                    // telling the operator to approve it.
+                    self.pairing_tx.send_if_modified(|pending| {
+                        let had = pending.is_some();
+                        *pending = None;
+                        had
+                    });
                     let _ = self.connection_tx.send(ConnectionState::Connected);
                     let _ = self.status_tx.send(PeerStatus::Idle);
                     self.emit_event(PeerEvent::Connected { card: new_card })
@@ -381,6 +397,17 @@ impl PeerActor {
             let delay = backoff.next_delay();
             let sleep = tokio::time::sleep(delay);
             tokio::pin!(sleep);
+            // Transports may emit events from *failed* connect attempts
+            // — the OpenClaw transport reports its pairing gate
+            // (`PeerEvent::PairingStateChanged`) before `connect()`
+            // returns the error. Drain and fold those during the
+            // backoff too; otherwise they'd sit queued (invisible to
+            // the dashboard) until the first successful connect, which
+            // for a pairing-gated peer is exactly the moment they stop
+            // mattering. `events_open` guards the branch after the
+            // channel closes so a dropped sender can't busy-loop the
+            // select.
+            let mut events_open = true;
             let cancelled = loop {
                 tokio::select! {
                     _ = &mut sleep => break false,
@@ -396,6 +423,12 @@ impl PeerActor {
                                 // All handles dropped — shut down.
                                 break true;
                             }
+                        }
+                    }
+                    maybe_event = self.events_in_rx.recv(), if events_open => {
+                        match maybe_event {
+                            Some(event) => self.handle_event(event).await,
+                            None => events_open = false,
                         }
                     }
                 }
@@ -498,6 +531,13 @@ impl PeerActor {
                 let mut patched = card.clone();
                 self.apply_operator_overrides(&mut patched);
                 let _ = self.card_tx.send(Arc::new(patched));
+                // Same pairing-clear as the transport-connect path: a
+                // live (re-)announce proves the enrollment gate is open.
+                self.pairing_tx.send_if_modified(|pending| {
+                    let had = pending.is_some();
+                    *pending = None;
+                    had
+                });
             }
             PeerEvent::SessionStarted { session } | PeerEvent::SessionUpdated { session } => {
                 self.sessions
@@ -631,6 +671,20 @@ impl PeerActor {
                     operations: operations.clone(),
                 }));
             }
+            PeerEvent::PairingStateChanged { pending } => {
+                // `send_if_modified` so a transport re-reporting the
+                // same pending request on every retry (the normal
+                // pairing-gated reconnect loop) doesn't push a
+                // redundant PeerStateChanged snapshot per attempt.
+                self.pairing_tx.send_if_modified(|state| {
+                    if state == pending {
+                        false
+                    } else {
+                        state.clone_from(pending);
+                        true
+                    }
+                });
+            }
             PeerEvent::Disconnected { .. } => {
                 if !self.sessions.is_empty() {
                     self.sessions.clear();
@@ -646,6 +700,10 @@ impl PeerActor {
                 // Link + grant are connection-scoped like the folds
                 // above: the next connect re-records the winning
                 // candidate, and the peer re-advertises its grant.
+                // `pairing_tx` is deliberately NOT cleared here — a
+                // pending enrollment gate is what *explains* the
+                // disconnected/reconnecting loop, so it must outlive
+                // the failed attempts (cleared on successful connect).
                 self.link_tx.send_if_modified(|link| {
                     let had = link.is_some();
                     *link = None;
@@ -1044,6 +1102,7 @@ mod tests {
         let (receipts_tx, _receipts_rx) = watch::channel(Arc::new(HashMap::new()));
         let (link_tx, _link_rx) = watch::channel(None);
         let (grant_tx, _grant_rx) = watch::channel(None);
+        let (pairing_tx, _pairing_rx) = watch::channel(None);
         let actor = PeerActor {
             peer_id,
             transport: Box::new(StubTransport(
@@ -1067,6 +1126,7 @@ mod tests {
             shared_view: None,
             link_tx,
             grant_tx,
+            pairing_tx,
             receipts_tx,
             receipts: HashMap::new(),
             receipt_order: VecDeque::new(),
@@ -1133,6 +1193,87 @@ mod tests {
             link_rx.borrow().is_none(),
             "link is connection-scoped and must clear on disconnect"
         );
+    }
+
+    /// The pairing fold has the OPPOSITE clearing semantics of the
+    /// grant/link folds: `PairingStateChanged` sets it, a `Disconnected`
+    /// leaves it standing (a pending enrollment gate is what explains
+    /// the failing reconnect loop), and a `Connected` — proof the gate
+    /// opened — clears it. Re-reports of the same pending request must
+    /// not re-notify the watch (no redundant dashboard snapshots per
+    /// retry).
+    #[tokio::test]
+    async fn pairing_fold_survives_disconnect_and_clears_on_connect() {
+        let (log_tx, _log_rx) = mpsc::channel(64);
+        let (mut actor, _guards) = test_actor(log_tx);
+        let mut pairing_rx = actor.pairing_tx.subscribe();
+        pairing_rx.mark_unchanged();
+
+        let pending = Some(crate::peer::event::PeerPairingInfo {
+            request_id: "req-7".into(),
+            message: Some("run `openclaw devices approve req-7`".into()),
+        });
+        actor
+            .handle_event(PeerEvent::PairingStateChanged {
+                pending: pending.clone(),
+            })
+            .await;
+        assert!(pairing_rx.has_changed().unwrap(), "first report notifies");
+        {
+            let folded = pairing_rx.borrow_and_update();
+            assert_eq!(
+                folded.as_ref().map(|p| p.request_id.as_str()),
+                Some("req-7")
+            );
+        }
+
+        // Same pending state re-reported (retry loop) → no re-notify.
+        actor
+            .handle_event(PeerEvent::PairingStateChanged {
+                pending: pending.clone(),
+            })
+            .await;
+        assert!(
+            !pairing_rx.has_changed().unwrap(),
+            "identical re-report must not re-notify the watch"
+        );
+
+        // Disconnect leaves the pairing state standing.
+        actor
+            .handle_event(PeerEvent::Disconnected {
+                reason: "gateway refused: pairing required".into(),
+            })
+            .await;
+        assert!(
+            pairing_rx.borrow_and_update().is_some(),
+            "pairing state must survive disconnect"
+        );
+
+        // A successful (re-)announce clears it.
+        let card = AgentCard {
+            id: PeerId::new(crate::peer::id::PeerKind::OpenClaw, "gw"),
+            label: "gw".into(),
+            version: "1.0.0".into(),
+            git_sha: None,
+            transports: Vec::new(),
+            capabilities: Vec::new(),
+            auth: crate::peer::card::AuthRequirements::none(),
+            identity_attestation: None,
+        };
+        actor.handle_event(PeerEvent::Connected { card }).await;
+        assert!(
+            pairing_rx.borrow_and_update().is_none(),
+            "pairing state must clear on successful connect"
+        );
+
+        // An explicit transport-side clear also works.
+        actor
+            .handle_event(PeerEvent::PairingStateChanged { pending })
+            .await;
+        actor
+            .handle_event(PeerEvent::PairingStateChanged { pending: None })
+            .await;
+        assert!(pairing_rx.borrow_and_update().is_none());
     }
 
     #[tokio::test]

--- a/src/bin/caller/peer/event.rs
+++ b/src/bin/caller/peer/event.rs
@@ -74,6 +74,22 @@ pub enum PeerEvent {
         operations: Vec<String>,
     },
 
+    /// The peer's enrollment gate changed: connecting now requires an
+    /// out-of-band approval on the peer's side before a connect can
+    /// succeed (OpenClaw Gateway pairing is the canonical producer —
+    /// a new device's `connect` is answered with `PAIRING_REQUIRED`
+    /// and a request id the gateway host approves with
+    /// `openclaw devices approve <request-id>`). Transports emit
+    /// `Some(info)` when a connect attempt is refused pending
+    /// approval, and may emit `None` to clear explicitly; the actor
+    /// also clears the fold on the next successful connect. Unlike
+    /// the connection-scoped folds, this one deliberately SURVIVES
+    /// disconnect — it exists precisely to explain why the reconnect
+    /// loop keeps failing.
+    PairingStateChanged {
+        pending: Option<PeerPairingInfo>,
+    },
+
     // ---- Activity stream — what the peer is doing right now ----
     /// A unit of work has begun (turn, tool call, sub-agent run, delegated
     /// task, etc). Activities have an opaque id and a kind for routing.
@@ -673,6 +689,32 @@ pub struct PeerSharedViewInfo {
     pub region: Option<crate::types::SharedViewRegion>,
 }
 
+/// A pending out-of-band enrollment approval gating this daemon's
+/// connection to a peer, folded from [`PeerEvent::PairingStateChanged`]
+/// by the per-peer actor and surfaced on
+/// [`crate::peer::handle::PeerSnapshot::pairing`] so the dashboard can
+/// tell the operator exactly what to do ("pairing pending — approve on
+/// the gateway host"). Producer today: the OpenClaw Gateway transport's
+/// `PAIRING_REQUIRED` handshake answer; the shape is transport-neutral
+/// on purpose (any future peer kind with a host-side enrollment
+/// ceremony folds into the same field).
+///
+/// Fold semantics (see the actor): replaced by each
+/// `PairingStateChanged`, cleared on successful connect, NOT cleared on
+/// disconnect — while pairing is pending every connect attempt fails,
+/// so the state must outlive the failed attempts it explains.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PeerPairingInfo {
+    /// Peer-side identity of the pending approval — for OpenClaw, the
+    /// pairing request id the host approves with
+    /// `openclaw devices approve <request-id>`.
+    pub request_id: String,
+    /// Optional human-readable next-step text from the peer (OpenClaw's
+    /// `error.details.recommendedNextStep`, when present).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ApprovalRequest {
     pub request_id: String,
@@ -865,6 +907,41 @@ mod tests {
         for evt in [started, progress, completed] {
             let json = serde_json::to_string(&evt).unwrap();
             let _: PeerEvent = serde_json::from_str(&json).unwrap();
+        }
+    }
+
+    /// The pairing-state event round-trips and its wire name is pinned:
+    /// the dashboard's per-peer event lane and the durable peers.jsonl
+    /// log both dispatch on the serialized `event` tag, so the string
+    /// is a wire contract, not an implementation detail. The pending
+    /// payload also elides its absent optional message.
+    #[test]
+    fn pairing_state_changed_round_trip_and_wire_name() {
+        let evt = PeerEvent::PairingStateChanged {
+            pending: Some(PeerPairingInfo {
+                request_id: "req-42".into(),
+                message: None,
+            }),
+        };
+        let json = serde_json::to_string(&evt).unwrap();
+        assert!(
+            json.contains(r#""event":"pairing_state_changed""#),
+            "wire tag pinned: {json}"
+        );
+        assert!(!json.contains("message"), "absent message elided: {json}");
+        match serde_json::from_str::<PeerEvent>(&json).unwrap() {
+            PeerEvent::PairingStateChanged { pending } => {
+                assert_eq!(pending.unwrap().request_id, "req-42");
+            }
+            _ => panic!("wrong event variant"),
+        }
+
+        // The explicit-clear form (pending: None) round-trips too.
+        let clear = PeerEvent::PairingStateChanged { pending: None };
+        let json = serde_json::to_string(&clear).unwrap();
+        match serde_json::from_str::<PeerEvent>(&json).unwrap() {
+            PeerEvent::PairingStateChanged { pending } => assert!(pending.is_none()),
+            _ => panic!("wrong event variant"),
         }
     }
 

--- a/src/bin/caller/peer/handle.rs
+++ b/src/bin/caller/peer/handle.rs
@@ -24,8 +24,8 @@
 
 use crate::peer::card::AgentCard;
 use crate::peer::event::{
-    ApprovalDecision, MessageId, PeerDisplayInfo, PeerEvent, PeerMessage, PeerSharedViewInfo,
-    PeerStatus, SessionInfo, TaskId, TaskUpdate, WebRtcSessionId, WebRtcSignal,
+    ApprovalDecision, MessageId, PeerDisplayInfo, PeerEvent, PeerMessage, PeerPairingInfo,
+    PeerSharedViewInfo, PeerStatus, SessionInfo, TaskId, TaskUpdate, WebRtcSessionId, WebRtcSignal,
 };
 use crate::peer::id::PeerId;
 use crate::peer::log_writer::EnqueuedPeerEvent;
@@ -352,6 +352,11 @@ struct PeerHandleInner {
     /// [`PeerGrantInfo`]) — connection-scoped; `None` means unknown
     /// (older peer or not yet advertised), not "nothing allowed".
     grant: watch::Receiver<Option<PeerGrantInfo>>,
+    /// The peer-side enrollment gate blocking this daemon's connects
+    /// (see [`PeerPairingInfo`]) — folded from
+    /// [`PeerEvent::PairingStateChanged`]; survives disconnects and
+    /// clears on the next successful connect.
+    pairing: watch::Receiver<Option<PeerPairingInfo>>,
     /// Delegation-receipt ledger folded by the actor from
     /// [`PeerEvent::TaskReceipt`] (delegation id → the peer's local
     /// task/session identity). [`PeerHandle::delegate_task`] awaits an
@@ -428,6 +433,14 @@ impl PeerHandle {
         self.inner.grant.clone()
     }
 
+    /// Subscribe to enrollment-gate changes (see [`PeerPairingInfo`]).
+    /// The registry's state observer folds these into `PeerStateChanged`
+    /// pushes so the dashboard's "pairing pending" pill tracks the gate
+    /// without polling.
+    pub fn pairing_updates(&self) -> watch::Receiver<Option<PeerPairingInfo>> {
+        self.inner.pairing.clone()
+    }
+
     /// Watch the peer's folded shared-view state (see
     /// [`PeerSnapshot::shared_view`]). The registry's state observer
     /// selects on this so every change pushes a fresh `PeerStateChanged`
@@ -482,6 +495,7 @@ impl PeerHandle {
             shared_view: self.inner.shared_view.borrow().clone(),
             link: self.inner.link.borrow().clone(),
             grant: self.inner.grant.borrow().clone(),
+            pairing: self.inner.pairing.borrow().clone(),
         }
     }
 
@@ -1035,6 +1049,16 @@ pub struct PeerSnapshot {
     /// as denial.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub grant: Option<PeerGrantInfo>,
+    /// The peer-side enrollment gate blocking this daemon's connects,
+    /// when one is pending (see [`PeerPairingInfo`] — OpenClaw Gateway
+    /// pairing is the canonical producer). The dashboard renders it as
+    /// a "pairing pending" pill carrying the request id the operator
+    /// approves on the peer's side (`openclaw devices approve <id>`).
+    /// `None` = no known gate. Survives disconnects (it explains the
+    /// failing reconnect loop); cleared by the next successful
+    /// connect. `serde(default)` keeps older producers parseable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pairing: Option<PeerPairingInfo>,
 }
 
 // ---------------------------------------------------------------------------
@@ -1114,6 +1138,7 @@ where
     let (receipts_tx, receipts_rx) = watch::channel(Arc::new(HashMap::new()));
     let (link_tx, link_rx) = watch::channel(None);
     let (grant_tx, grant_rx) = watch::channel(None);
+    let (pairing_tx, pairing_rx) = watch::channel(None);
 
     let transport = build_transport(events_in_tx);
     let features = transport.features();
@@ -1136,6 +1161,7 @@ where
         shared_view: None,
         link_tx,
         grant_tx,
+        pairing_tx,
         receipts_tx,
         receipts: HashMap::new(),
         receipt_order: std::collections::VecDeque::new(),
@@ -1160,6 +1186,7 @@ where
             shared_view: shared_view_rx,
             link: link_rx,
             grant: grant_rx,
+            pairing: pairing_rx,
             receipts: receipts_rx,
             commands: commands_tx,
             events: events_out_tx,
@@ -1175,9 +1202,9 @@ mod tests {
     use super::*;
     use std::time::{Duration, Instant};
 
-    /// Snapshots from daemons predating the link/grant fields (and the
-    /// wire the dashboard round-trips) must keep parsing: both fields
-    /// are `serde(default)` and elided when absent.
+    /// Snapshots from daemons predating the link/grant/pairing fields
+    /// (and the wire the dashboard round-trips) must keep parsing: all
+    /// three fields are `serde(default)` and elided when absent.
     #[test]
     fn peer_snapshot_backcompat_without_link_and_grant() {
         let json = r#"{
@@ -1191,6 +1218,7 @@ mod tests {
         let snap: PeerSnapshot = serde_json::from_str(json).expect("old snapshot parses");
         assert!(snap.link.is_none());
         assert!(snap.grant.is_none());
+        assert!(snap.pairing.is_none());
 
         // And the new fields round-trip when present.
         let mut snap = snap;
@@ -1202,14 +1230,24 @@ mod tests {
             profile: "peer-operator".into(),
             operations: vec!["message.send".into()],
         });
+        snap.pairing = Some(PeerPairingInfo {
+            request_id: "req-9".into(),
+            message: Some("approve on the gateway host".into()),
+        });
         let round = serde_json::to_string(&snap).unwrap();
         assert!(
             round.contains(r#""transport_class":"relayed""#),
             "snake_case wire form for the class: {round}"
         );
+        assert!(
+            round.contains(r#""pairing":{"request_id":"req-9""#),
+            "pairing wire shape pinned (the dashboard pill reads \
+             pairing.request_id): {round}"
+        );
         let back: PeerSnapshot = serde_json::from_str(&round).unwrap();
         assert_eq!(back.link, snap.link);
         assert_eq!(back.grant, snap.grant);
+        assert_eq!(back.pairing, snap.pairing);
     }
 
     #[test]
@@ -1339,6 +1377,113 @@ mod tests {
             ConnectionState::Disconnected,
             "actor didn't transition to Disconnected"
         );
+    }
+
+    /// End-to-end pairing-gate visibility: a transport whose connect
+    /// attempts are refused pending an out-of-band approval (the
+    /// OpenClaw `PAIRING_REQUIRED` shape) reports the gate via
+    /// `PeerEvent::PairingStateChanged` *before* returning the connect
+    /// error — and the pending state must surface on
+    /// `PeerSnapshot::pairing` while the actor sits in the reconnect
+    /// loop, not only after some later successful connect. This pins
+    /// the reconnect-window event drain in `PeerActor::run`: without
+    /// it the event sits queued exactly as long as it matters.
+    #[tokio::test]
+    async fn pairing_gate_surfaces_on_snapshot_while_reconnecting() {
+        use crate::peer::card::{AgentCard, AuthRequirements, TransportSpec};
+        use crate::peer::event::PeerPairingInfo;
+        use crate::peer::id::{PeerId, PeerKind};
+        use crate::peer::traits::{PeerOp, PeerOpAck, PeerTransport, TransportFeatures};
+        use tokio::sync::mpsc;
+
+        /// Minimal pairing-gated transport: every connect reports the
+        /// pending request and fails.
+        struct PairingGatedTransport {
+            spec: TransportSpec,
+            events_tx: mpsc::Sender<PeerEvent>,
+        }
+
+        #[async_trait::async_trait]
+        impl PeerTransport for PairingGatedTransport {
+            fn spec(&self) -> &TransportSpec {
+                &self.spec
+            }
+            fn features(&self) -> TransportFeatures {
+                TransportFeatures::default()
+            }
+            async fn connect(&mut self) -> Result<AgentCard, PeerError> {
+                let _ = self
+                    .events_tx
+                    .send(PeerEvent::PairingStateChanged {
+                        pending: Some(PeerPairingInfo {
+                            request_id: "pair-req-1".into(),
+                            message: Some("approve on the gateway host".into()),
+                        }),
+                    })
+                    .await;
+                Err(PeerError::Auth("pairing required".into()))
+            }
+            async fn disconnect(&mut self) -> Result<(), PeerError> {
+                Ok(())
+            }
+            fn is_connected(&self) -> bool {
+                false
+            }
+            async fn send(&mut self, _op: PeerOp) -> Result<PeerOpAck, PeerError> {
+                Err(PeerError::NotConnected)
+            }
+        }
+
+        let spec = TransportSpec::OpenClawWs {
+            url: "ws://127.0.0.1:1".into(),
+            role: crate::peer::card::OpenClawRole::Operator,
+        };
+        let initial_card = AgentCard {
+            id: PeerId::new(PeerKind::OpenClaw, "gated-gw"),
+            label: "gated-gw".into(),
+            version: String::new(),
+            git_sha: None,
+            transports: vec![spec.clone()],
+            capabilities: vec![],
+            auth: AuthRequirements::none(),
+            identity_attestation: None,
+        };
+        let (log_tx, _log_rx) = mpsc::channel::<EnqueuedPeerEvent>(64);
+        let handle = spawn_peer(
+            initial_card.id.clone(),
+            initial_card,
+            Vec::new(),
+            None,
+            None,
+            crate::peer::PeerWitnessVantage::Unknown,
+            crate::loopback_token::test_transport_credentials(),
+            log_tx,
+            move |events_tx| Box::new(PairingGatedTransport { spec, events_tx }),
+        );
+
+        // The pending gate must land on the pairing watch (and thus the
+        // snapshot) without any successful connect ever happening.
+        let mut pairing_rx = handle.pairing_updates();
+        let seen = tokio::time::timeout(
+            Duration::from_secs(3),
+            pairing_rx.wait_for(|pending| pending.is_some()),
+        )
+        .await;
+        assert!(
+            seen.is_ok(),
+            "pairing state never surfaced — reconnect-window event drain broken?"
+        );
+
+        let snap = handle.snapshot();
+        let pairing = snap.pairing.expect("snapshot carries the pairing gate");
+        assert_eq!(pairing.request_id, "pair-req-1");
+        assert!(
+            !matches!(snap.connection_state, ConnectionState::Connected),
+            "gate surfaced while NOT connected (state: {:?})",
+            snap.connection_state
+        );
+
+        handle.disconnect().await.expect("disconnect");
     }
 
     /// Session events flowing from a live peer fold into the actor's

--- a/src/bin/caller/peer/mod.rs
+++ b/src/bin/caller/peer/mod.rs
@@ -115,7 +115,7 @@ pub use coordinator::{Coordinator, CoordinatorError, TaskRequest};
 pub use event::{
     ActivityId, ActivityKind, ActivityOutcome, ApprovalDecision, ApprovalRequest, LogLevel,
     MessageContent, MessageId, MessageRole, ModelUsage, PeerDisplayInfo, PeerEvent, PeerMessage,
-    PeerStatus, SessionInfo, TaskId, UsageSnapshot, WebRtcSessionId, WebRtcSignal,
+    PeerPairingInfo, PeerStatus, SessionInfo, TaskId, UsageSnapshot, WebRtcSessionId, WebRtcSignal,
 };
 pub use handle::{ConnectionState, PeerHandle, PeerSnapshot};
 pub use id::PeerId;

--- a/src/bin/caller/peer/mod.rs
+++ b/src/bin/caller/peer/mod.rs
@@ -115,7 +115,7 @@ pub use coordinator::{Coordinator, CoordinatorError, TaskRequest};
 pub use event::{
     ActivityId, ActivityKind, ActivityOutcome, ApprovalDecision, ApprovalRequest, LogLevel,
     MessageContent, MessageId, MessageRole, ModelUsage, PeerDisplayInfo, PeerEvent, PeerMessage,
-    PeerPairingInfo, PeerStatus, SessionInfo, TaskId, UsageSnapshot, WebRtcSessionId, WebRtcSignal,
+    PeerStatus, SessionInfo, TaskId, UsageSnapshot, WebRtcSessionId, WebRtcSignal,
 };
 pub use handle::{ConnectionState, PeerHandle, PeerSnapshot};
 pub use id::PeerId;

--- a/src/bin/caller/peer/pairing.rs
+++ b/src/bin/caller/peer/pairing.rs
@@ -787,7 +787,7 @@ pub(crate) fn join_peer_invite(
         .config
         .peers
         .iter_mut()
-        .find(|peer| peer.card_url == invite.card_url);
+        .find(|peer| peer.card_url.as_deref() == Some(invite.card_url.as_str()));
     let updated_existing = existing.is_some();
     match existing {
         Some(peer) => {
@@ -808,16 +808,13 @@ pub(crate) fn join_peer_invite(
         }
         None => {
             project.config.peers.push(PeerConfig {
-                card_url: invite.card_url.clone(),
+                card_url: Some(invite.card_url.clone()),
                 label,
-                bearer_token: None,
-                via_urls: Vec::new(),
                 client_cert: Some(cert_path.to_string_lossy().into_owned()),
                 client_key: Some(key_path.to_string_lossy().into_owned()),
                 pinned_fingerprints: pins,
                 identity_public_key: invite.daemon_identity_public_key.clone(),
-                browser_tcp_via_url: None,
-                certificate_witness_vantage: crate::peer::PeerWitnessVantage::Unknown,
+                ..Default::default()
             });
         }
     }
@@ -1298,8 +1295,8 @@ mod tests {
         assert_eq!(project.config.peers.len(), 1);
         let peer = &project.config.peers[0];
         assert_eq!(
-            peer.card_url,
-            "https://peer.example/.well-known/agent-card.json"
+            peer.card_url.as_deref(),
+            Some("https://peer.example/.well-known/agent-card.json")
         );
         assert_eq!(peer.label.as_deref(), Some("Override"));
         assert_eq!(
@@ -1321,16 +1318,11 @@ mod tests {
             root: root.path().to_path_buf(),
             config: ProjectConfig {
                 peers: vec![PeerConfig {
-                    card_url: "https://peer.example/.well-known/agent-card.json".into(),
+                    card_url: Some("https://peer.example/.well-known/agent-card.json".into()),
                     label: Some("Old".into()),
                     bearer_token: Some("legacy".into()),
-                    via_urls: Vec::new(),
-                    client_cert: None,
-                    client_key: None,
-                    pinned_fingerprints: Vec::new(),
-                    identity_public_key: None,
                     browser_tcp_via_url: Some("ws://browser-via/ws".into()),
-                    certificate_witness_vantage: crate::peer::PeerWitnessVantage::Unknown,
+                    ..Default::default()
                 }],
                 ..ProjectConfig::default()
             },

--- a/src/bin/caller/peer/registry.rs
+++ b/src/bin/caller/peer/registry.rs
@@ -480,8 +480,13 @@ impl PeerRegistry {
         .await
     }
 
+    /// The full pre-built-card entry point. `pub(crate)` for the boot
+    /// path's card-less peer kinds (`[[peer]] transport = "openclaw-ws"`
+    /// synthesizes its card locally — a gateway serves no
+    /// `/.well-known/agent-card.json` to fetch) so they get the same
+    /// label-override / witness-vantage plumbing as fetched cards.
     #[allow(clippy::too_many_arguments)]
-    async fn add_peer_with_card_and_auth_and_client_identity(
+    pub(crate) async fn add_peer_with_card_and_auth_and_client_identity(
         &self,
         card: AgentCard,
         via_urls: Vec<String>,
@@ -642,6 +647,10 @@ fn spawn_state_observer(handle: PeerHandle, events: broadcast::Sender<RegistryEv
         let mut card_rx = handle.card_updates();
         let mut link_rx = handle.link_updates();
         let mut grant_rx = handle.grant_updates();
+        // Enrollment-gate changes (pairing pending / cleared) are rare
+        // one-shot facts, so they ride the wholesale-snapshot lane like
+        // shared-view changes below.
+        let mut pairing_rx = handle.pairing_updates();
         // Shared-view changes ride the same wholesale-snapshot lane:
         // they are rare (a handful per collaboration session), so a
         // full PeerStateChanged per change is cheap and saves the
@@ -658,6 +667,7 @@ fn spawn_state_observer(handle: PeerHandle, events: broadcast::Sender<RegistryEv
         let _ = card_rx.borrow_and_update();
         let _ = link_rx.borrow_and_update();
         let _ = grant_rx.borrow_and_update();
+        let _ = pairing_rx.borrow_and_update();
         let _ = shared_view_rx.borrow_and_update();
 
         loop {
@@ -667,6 +677,7 @@ fn spawn_state_observer(handle: PeerHandle, events: broadcast::Sender<RegistryEv
                 r = card_rx.changed() => r,
                 r = link_rx.changed() => r,
                 r = grant_rx.changed() => r,
+                r = pairing_rx.changed() => r,
                 r = shared_view_rx.changed() => r,
             };
             if changed.is_err() {

--- a/src/bin/caller/project.rs
+++ b/src/bin/caller/project.rs
@@ -1872,25 +1872,66 @@ impl Default for ServerAuthConfig {
 
 /// A federated peer daemon advertised via `intendant.toml [[peer]]`.
 ///
-/// `card_url` is the only required field — the registry fetches the
-/// peer's Agent Card from that URL at startup, picks a supported
-/// transport, and spawns the actor. `label` is an optional display
-/// override; when absent the card's own `label` field is used.
+/// Two entry shapes share the block, selected by `transport`:
+///
+/// - **Card-driven (default, `transport` absent):** `card_url` is the
+///   only required field — the registry fetches the peer's Agent Card
+///   from that URL at startup, picks a supported transport, and spawns
+///   the actor.
+/// - **`transport = "openclaw-ws"`:** `url` (the gateway's WebSocket
+///   endpoint, default port 18789) is the only required field — an
+///   OpenClaw Gateway serves no Agent Card, so the daemon synthesizes
+///   one locally with a single [`crate::peer::TransportSpec::OpenClawWs`]
+///   entry (`role` defaults to `operator`). Bootstrap auth for the
+///   pairing handshake comes from `bearer_token_env` /
+///   `bearer_token_file` — never inline plaintext.
+///
+/// `label` is an optional display override; when absent the card's own
+/// `label` field is used (for openclaw entries, the gateway host).
 /// `bearer_token` is an advanced compatibility credential this daemon
 /// sends when connecting out to legacy peers that still require
-/// `[server.auth] bearer_token`.
+/// `[server.auth] bearer_token`; prefer the `_env` / `_file` reference
+/// forms, which keep the secret out of the config file.
 /// `via_urls` are optional connecting-side transport overrides. When
 /// non-empty, the registry uses these WebSocket URLs instead of the peer's
 /// advertised transports.
 /// `client_cert` / `client_key` are the normal explicit mTLS path for
 /// daemon-to-daemon peers when the peer issued this daemon a client identity.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// Per-kind validation (which fields are required / rejected for each
+/// `transport` value) happens at boot in
+/// `startup::peer_boot::classify_peer_config`, not at parse time, so an
+/// invalid entry degrades to a clear startup diagnostic for that one
+/// peer instead of failing the whole config load.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct PeerConfig {
+    /// Transport-kind selector. Absent (the default) = card-driven
+    /// Intendant federation via `card_url`. `"openclaw-ws"` = direct
+    /// OpenClaw Gateway entry via `url` / `role`. Unrecognized values
+    /// fail that entry loudly at boot.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transport: Option<String>,
     /// URL of the peer's Agent Card. Typically
     /// `https://<host>:<port>/.well-known/agent-card.json` or
     /// `http://<host>:<port>/.well-known/agent-card.json` for
-    /// non-TLS local testing.
-    pub card_url: String,
+    /// non-TLS local testing. Required for card-driven entries;
+    /// rejected for `transport = "openclaw-ws"` entries (a gateway
+    /// serves no card).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub card_url: Option<String>,
+    /// OpenClaw Gateway WebSocket URL (`ws://host:18789` or
+    /// `wss://…`). Required for `transport = "openclaw-ws"` entries;
+    /// rejected otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// Role this daemon takes on the OpenClaw Gateway: `"operator"`
+    /// (default — drive sessions, relay messages) or `"node"` (lend
+    /// capabilities back to the gateway; future slice). Only
+    /// meaningful with `transport = "openclaw-ws"`; unrecognized
+    /// values fail that entry loudly at boot rather than hydrating a
+    /// forward-compat `Unknown` role from local config.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
     /// Optional display label override. Rendered in the dashboard
     /// Daemons panel instead of `card.label` when set. Does not
     /// affect routing — the registry still keys on `card.id`.
@@ -1904,6 +1945,8 @@ pub struct PeerConfig {
     /// Only set this when the peer's Agent Card advertises
     /// `auth.application = Some(Bearer)`. Normal dashboard and
     /// federation access should use TLS/mTLS client certificates.
+    /// Prefer `bearer_token_env` / `bearer_token_file` over this
+    /// inline form — they keep the secret out of the config file.
     ///
     /// Example:
     /// ```toml
@@ -1913,6 +1956,35 @@ pub struct PeerConfig {
     /// ```
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bearer_token: Option<String>,
+    /// Name of an environment variable holding the outbound bearer
+    /// token — the secret-reference form of `bearer_token` (same
+    /// pattern as `[custom_domain.dns] token_env`): the config names
+    /// where the credential lives, never the credential itself.
+    /// Resolved once at peer registration. For
+    /// `transport = "openclaw-ws"` entries this is the gateway's
+    /// shared bootstrap token used for the pairing handshake
+    /// (`auth.token` in the `connect` frame); once the gateway host
+    /// approves the pairing request, the transport persists the
+    /// granted device token and the bootstrap token stops being
+    /// load-bearing. At most one of `bearer_token`,
+    /// `bearer_token_env`, `bearer_token_file` may be set.
+    ///
+    /// Example:
+    /// ```toml
+    /// [[peer]]
+    /// transport = "openclaw-ws"
+    /// url = "ws://gateway-host:18789"
+    /// bearer_token_env = "OPENCLAW_GATEWAY_TOKEN"
+    /// ```
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bearer_token_env: Option<String>,
+    /// Path to a file whose (trimmed) contents are the outbound bearer
+    /// token — the file-reference form of `bearer_token`, for
+    /// operators who keep secrets in mode-0600 files instead of the
+    /// environment. Resolved once at peer registration. Mutually
+    /// exclusive with the other two token fields.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bearer_token_file: Option<String>,
     /// Connecting-side transport URL overrides. When non-empty, these
     /// replace the transports advertised by the peer's Agent Card.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -2522,15 +2594,53 @@ card_url = "http://127.0.0.1:9000/.well-known/agent-card.json"
         let config: ProjectConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.peers.len(), 2);
         assert_eq!(
-            config.peers[0].card_url,
-            "https://nicks-mac.local:8443/.well-known/agent-card.json"
+            config.peers[0].card_url.as_deref(),
+            Some("https://nicks-mac.local:8443/.well-known/agent-card.json")
         );
         assert_eq!(config.peers[0].label.as_deref(), Some("Nick's Mac"));
+        // Entries predating the transport-kind selector parse with it
+        // (and the openclaw fields) absent.
+        assert!(config.peers[0].transport.is_none());
+        assert!(config.peers[0].url.is_none());
+        assert!(config.peers[0].role.is_none());
+        assert!(config.peers[0].bearer_token_env.is_none());
+        assert!(config.peers[0].bearer_token_file.is_none());
         assert_eq!(
-            config.peers[1].card_url,
-            "http://127.0.0.1:9000/.well-known/agent-card.json"
+            config.peers[1].card_url.as_deref(),
+            Some("http://127.0.0.1:9000/.well-known/agent-card.json")
         );
         assert!(config.peers[1].label.is_none());
+    }
+
+    /// An `[[peer]]` entry with `transport = "openclaw-ws"` parses: the
+    /// gateway url, role, and the secret-reference token fields land,
+    /// and `card_url` stays absent. (Which fields are *required* per
+    /// kind is boot-time validation in `startup::peer_boot`; parsing
+    /// itself must accept the shape.)
+    #[test]
+    fn parse_openclaw_peer_entry() {
+        let toml_str = r#"
+[[peer]]
+transport = "openclaw-ws"
+url = "ws://gateway-host:18789"
+role = "operator"
+label = "home-gateway"
+bearer_token_env = "OPENCLAW_GATEWAY_TOKEN"
+"#;
+        let config: ProjectConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.peers.len(), 1);
+        let peer = &config.peers[0];
+        assert_eq!(peer.transport.as_deref(), Some("openclaw-ws"));
+        assert_eq!(peer.url.as_deref(), Some("ws://gateway-host:18789"));
+        assert_eq!(peer.role.as_deref(), Some("operator"));
+        assert_eq!(peer.label.as_deref(), Some("home-gateway"));
+        assert_eq!(
+            peer.bearer_token_env.as_deref(),
+            Some("OPENCLAW_GATEWAY_TOKEN")
+        );
+        assert!(peer.card_url.is_none());
+        assert!(peer.bearer_token.is_none());
+        assert!(peer.bearer_token_file.is_none());
     }
 
     /// Round-trip: serializing a config with peer entries back to
@@ -2542,20 +2652,12 @@ card_url = "http://127.0.0.1:9000/.well-known/agent-card.json"
         let original = ProjectConfig {
             peers: vec![
                 PeerConfig {
-                    card_url: "http://a.local/.well-known/agent-card.json".into(),
+                    card_url: Some("http://a.local/.well-known/agent-card.json".into()),
                     label: Some("A".into()),
-                    bearer_token: None,
-                    via_urls: Vec::new(),
-                    client_cert: None,
-                    client_key: None,
-                    pinned_fingerprints: Vec::new(),
-                    identity_public_key: None,
-                    browser_tcp_via_url: None,
-                    certificate_witness_vantage: crate::peer::PeerWitnessVantage::Unknown,
+                    ..Default::default()
                 },
                 PeerConfig {
-                    card_url: "http://b.local/.well-known/agent-card.json".into(),
-                    label: None,
+                    card_url: Some("http://b.local/.well-known/agent-card.json".into()),
                     bearer_token: Some("secret-for-b".into()),
                     via_urls: vec!["ws://b-tunnel.local:19000/ws".into()],
                     client_cert: Some("/secrets/b-client.crt".into()),
@@ -2563,16 +2665,24 @@ card_url = "http://127.0.0.1:9000/.well-known/agent-card.json"
                     pinned_fingerprints: vec![
                         "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899".into(),
                     ],
-                    identity_public_key: None,
                     browser_tcp_via_url: Some("ws://192.168.1.42:8766/ws".into()),
                     certificate_witness_vantage: crate::peer::PeerWitnessVantage::Remote,
+                    ..Default::default()
+                },
+                PeerConfig {
+                    transport: Some("openclaw-ws".into()),
+                    url: Some("ws://gateway-host:18789".into()),
+                    role: Some("operator".into()),
+                    label: Some("home-gateway".into()),
+                    bearer_token_env: Some("OPENCLAW_GATEWAY_TOKEN".into()),
+                    ..Default::default()
                 },
             ],
             ..ProjectConfig::default()
         };
         let serialized = toml::to_string(&original).unwrap();
         let parsed: ProjectConfig = toml::from_str(&serialized).unwrap();
-        assert_eq!(parsed.peers.len(), 2);
+        assert_eq!(parsed.peers.len(), 3);
         assert_eq!(parsed.peers[0].card_url, original.peers[0].card_url);
         assert_eq!(parsed.peers[0].label, original.peers[0].label);
         assert_eq!(parsed.peers[0].bearer_token, original.peers[0].bearer_token);
@@ -2614,6 +2724,24 @@ card_url = "http://127.0.0.1:9000/.well-known/agent-card.json"
         assert_eq!(
             parsed.peers[1].certificate_witness_vantage,
             crate::peer::PeerWitnessVantage::Remote
+        );
+        // The openclaw-ws entry round-trips: kind selector, gateway
+        // url, role, and the env-name token reference all survive, and
+        // the absent card-driven fields stay absent (elided by
+        // skip_serializing_if, reparsed as None).
+        assert_eq!(parsed.peers[2].transport.as_deref(), Some("openclaw-ws"));
+        assert_eq!(parsed.peers[2].url, original.peers[2].url);
+        assert_eq!(parsed.peers[2].role.as_deref(), Some("operator"));
+        assert_eq!(
+            parsed.peers[2].bearer_token_env.as_deref(),
+            Some("OPENCLAW_GATEWAY_TOKEN")
+        );
+        assert!(parsed.peers[2].card_url.is_none());
+        assert!(parsed.peers[2].bearer_token.is_none());
+        assert!(parsed.peers[2].bearer_token_file.is_none());
+        assert!(
+            !serialized.contains("card_url = \"\""),
+            "absent card_url must be elided, not serialized empty: {serialized}"
         );
     }
 

--- a/src/bin/caller/startup/peer_boot.rs
+++ b/src/bin/caller/startup/peer_boot.rs
@@ -136,58 +136,374 @@ pub(crate) fn build_and_hydrate_peer_registry(
         ),
     );
     for cfg in peer_configs {
-        let registry_for_task = registry.clone();
-        let card_url = cfg.card_url.clone();
-        let label = cfg.label.clone();
-        let bearer_token = cfg.bearer_token.clone();
-        let via_urls = cfg.via_urls.clone();
-        let pinned_fingerprints = cfg.pinned_fingerprints.clone();
-        let identity_public_key = cfg.identity_public_key.clone();
-        let browser_tcp_via_url = cfg.browser_tcp_via_url.clone();
-        let certificate_witness_vantage = cfg.certificate_witness_vantage;
-        let explicit_client_identity = match peer_client_identity_from_config(cfg) {
-            Ok(identity) => identity,
+        // Per-entry failures degrade to a startup diagnostic and skip
+        // that one peer — a typo'd [[peer]] block must not take down
+        // the daemon or the other peers.
+        let kind = match classify_peer_config(cfg) {
+            Ok(kind) => kind,
             Err(e) => {
                 eprintln!(
                     "intendant: failed to register peer from intendant.toml \
-                     ({card_url}): {e}"
+                     ({}): {e}",
+                    describe_peer_config(cfg)
                 );
                 continue;
             }
         };
-        tokio::spawn(async move {
-            // via_urls, when non-empty, overrides the peer's self-advertised
-            // transports. pinned_fingerprints, when non-empty, replaces the
-            // card's auth.transport with
-            // PinnedMutualTls — operator distrusts the card's claim
-            // and pins against fingerprints they got out-of-band.
-            // browser_tcp_via_url, when set, overrides the dashboard's
-            // default `d.ws_url` fallback when opening WebRTC display
-            // — used when the browser and primary can't share the
-            // same URL (primary-side localhost tunnel, split
-            // browser/primary machines, etc.).
-            if let Err(e) = registry_for_task
-                .add_peer_full(
-                    &card_url,
-                    via_urls,
-                    bearer_token,
-                    pinned_fingerprints,
-                    browser_tcp_via_url,
-                    explicit_client_identity,
-                    label,
-                    certificate_witness_vantage,
-                    identity_public_key,
-                )
-                .await
-            {
+        // One token-resolution path for every entry kind: inline
+        // `bearer_token` (legacy) or the `_env` / `_file` secret
+        // references, resolved once here at the production edge.
+        let bearer_token = match resolve_peer_bearer_token(cfg, |name| std::env::var(name).ok()) {
+            Ok(token) => token,
+            Err(e) => {
                 eprintln!(
                     "intendant: failed to register peer from intendant.toml \
-                     ({card_url}): {e}"
+                         ({}): {e}",
+                    describe_peer_config(cfg)
                 );
+                continue;
             }
-        });
+        };
+        let registry_for_task = registry.clone();
+        let label = cfg.label.clone();
+        let certificate_witness_vantage = cfg.certificate_witness_vantage;
+        match kind {
+            PeerConfigKind::CardDriven { card_url } => {
+                let via_urls = cfg.via_urls.clone();
+                let pinned_fingerprints = cfg.pinned_fingerprints.clone();
+                let identity_public_key = cfg.identity_public_key.clone();
+                let browser_tcp_via_url = cfg.browser_tcp_via_url.clone();
+                let explicit_client_identity = match peer_client_identity_from_config(cfg) {
+                    Ok(identity) => identity,
+                    Err(e) => {
+                        eprintln!(
+                            "intendant: failed to register peer from intendant.toml \
+                             ({card_url}): {e}"
+                        );
+                        continue;
+                    }
+                };
+                tokio::spawn(async move {
+                    // via_urls, when non-empty, overrides the peer's self-advertised
+                    // transports. pinned_fingerprints, when non-empty, replaces the
+                    // card's auth.transport with
+                    // PinnedMutualTls — operator distrusts the card's claim
+                    // and pins against fingerprints they got out-of-band.
+                    // browser_tcp_via_url, when set, overrides the dashboard's
+                    // default `d.ws_url` fallback when opening WebRTC display
+                    // — used when the browser and primary can't share the
+                    // same URL (primary-side localhost tunnel, split
+                    // browser/primary machines, etc.).
+                    if let Err(e) = registry_for_task
+                        .add_peer_full(
+                            &card_url,
+                            via_urls,
+                            bearer_token,
+                            pinned_fingerprints,
+                            browser_tcp_via_url,
+                            explicit_client_identity,
+                            label,
+                            certificate_witness_vantage,
+                            identity_public_key,
+                        )
+                        .await
+                    {
+                        eprintln!(
+                            "intendant: failed to register peer from intendant.toml \
+                             ({card_url}): {e}"
+                        );
+                    }
+                });
+            }
+            PeerConfigKind::OpenClawWs { url, role } => {
+                // No card fetch: an OpenClaw Gateway serves no
+                // `/.well-known/agent-card.json`, so the entry
+                // synthesizes a local card carrying one
+                // `TransportSpec::OpenClawWs`. The resolved bearer
+                // token rides `TransportCredentials::bearer_token`
+                // into the transport as the pairing-bootstrap
+                // credential (`auth.token` in the `connect` frame).
+                //
+                // Until this build ships the OpenClaw transport, the
+                // registry's supported-transport filter rejects the
+                // synthesized card at add time with the same clean
+                // "advertises no transport this build supports"
+                // diagnostic every unimplemented transport kind gets
+                // — graceful degradation, not a panic or a silent
+                // nothing.
+                let card = openclaw_card_from_config(cfg, url.clone(), role);
+                tokio::spawn(async move {
+                    if let Err(e) = registry_for_task
+                        .add_peer_with_card_and_auth_and_client_identity(
+                            card,
+                            Vec::new(),
+                            bearer_token,
+                            None,
+                            None,
+                            label,
+                            certificate_witness_vantage,
+                            None,
+                        )
+                        .await
+                    {
+                        eprintln!(
+                            "intendant: failed to register openclaw peer from \
+                             intendant.toml ({url}): {e}"
+                        );
+                    }
+                });
+            }
+        }
     }
     registry
+}
+
+/// The `[[peer]]` entry shape resolved from its `transport` selector —
+/// see [`classify_peer_config`].
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum PeerConfigKind {
+    /// Default: fetch the peer's Agent Card from `card_url`.
+    CardDriven { card_url: String },
+    /// `transport = "openclaw-ws"`: connect straight to an OpenClaw
+    /// Gateway's WebSocket control plane; the Agent Card is
+    /// synthesized locally ([`openclaw_card_from_config`]).
+    OpenClawWs {
+        url: String,
+        role: peer::card::OpenClawRole,
+    },
+}
+
+/// Entry identifier for boot diagnostics: whichever address the entry
+/// configured, so the operator can find the offending block.
+fn describe_peer_config(cfg: &project::PeerConfig) -> String {
+    cfg.card_url
+        .clone()
+        .or_else(|| cfg.url.clone())
+        .or_else(|| cfg.label.clone())
+        .unwrap_or_else(|| "<address-less [[peer]] entry>".to_string())
+}
+
+/// Validate one `[[peer]]` block and resolve its kind.
+///
+/// Boot-time (not parse-time) by design: an invalid entry degrades to
+/// a clear per-peer startup diagnostic instead of failing the whole
+/// config load. Loud on everything that would otherwise silently do
+/// nothing — an unrecognized `transport`, a `role` this build doesn't
+/// know (local config never hydrates the wire-side `Unknown`
+/// forward-compat fallback), and card-driven-only fields on an
+/// openclaw entry.
+pub(crate) fn classify_peer_config(
+    cfg: &project::PeerConfig,
+) -> Result<PeerConfigKind, CallerError> {
+    match cfg.transport.as_deref() {
+        None => {
+            let card_url = cfg
+                .card_url
+                .as_deref()
+                .map(str::trim)
+                .filter(|url| !url.is_empty())
+                .ok_or_else(|| {
+                    CallerError::Config(
+                        "[[peer]] requires card_url (or set transport = \"openclaw-ws\" \
+                         with url = \"ws://…\" for an OpenClaw Gateway entry)"
+                            .to_string(),
+                    )
+                })?;
+            for (set, name) in [(cfg.url.is_some(), "url"), (cfg.role.is_some(), "role")] {
+                if set {
+                    return Err(CallerError::Config(format!(
+                        "[[peer]] card_url={card_url} sets `{name}`, which only applies \
+                         to transport = \"openclaw-ws\" entries"
+                    )));
+                }
+            }
+            Ok(PeerConfigKind::CardDriven {
+                card_url: card_url.to_string(),
+            })
+        }
+        Some("openclaw-ws") => {
+            let url = cfg
+                .url
+                .as_deref()
+                .map(str::trim)
+                .filter(|url| !url.is_empty())
+                .ok_or_else(|| {
+                    CallerError::Config(
+                        "[[peer]] transport = \"openclaw-ws\" requires url = \
+                         \"ws://<gateway-host>:18789\" (or wss://…)"
+                            .to_string(),
+                    )
+                })?;
+            if !(url.starts_with("ws://") || url.starts_with("wss://")) {
+                return Err(CallerError::Config(format!(
+                    "[[peer]] transport = \"openclaw-ws\" url must be a ws:// or \
+                     wss:// WebSocket URL, got {url:?}"
+                )));
+            }
+            let role = match cfg.role.as_deref().map(str::trim) {
+                None | Some("") => peer::card::OpenClawRole::Operator,
+                Some(raw) => match peer::card::OpenClawRole::from_wire(raw) {
+                    peer::card::OpenClawRole::Unknown => {
+                        return Err(CallerError::Config(format!(
+                            "[[peer]] transport = \"openclaw-ws\" role = {raw:?} is not \
+                             a valid value (accepted: \"operator\", \"node\")"
+                        )));
+                    }
+                    role => role,
+                },
+            };
+            // Fields that belong to the card-driven flow would silently
+            // do nothing here (or worse — `via_urls` would replace the
+            // OpenClaw spec with IntendantWs candidates). Fail loud.
+            for (set, name) in [
+                (cfg.card_url.is_some(), "card_url"),
+                (!cfg.via_urls.is_empty(), "via_urls"),
+                (!cfg.pinned_fingerprints.is_empty(), "pinned_fingerprints"),
+                (cfg.client_cert.is_some(), "client_cert"),
+                (cfg.client_key.is_some(), "client_key"),
+                (cfg.identity_public_key.is_some(), "identity_public_key"),
+                (cfg.browser_tcp_via_url.is_some(), "browser_tcp_via_url"),
+            ] {
+                if set {
+                    return Err(CallerError::Config(format!(
+                        "[[peer]] transport = \"openclaw-ws\" ({url}) sets `{name}`, \
+                         which only applies to card-driven Intendant peer entries"
+                    )));
+                }
+            }
+            Ok(PeerConfigKind::OpenClawWs {
+                url: url.to_string(),
+                role,
+            })
+        }
+        Some(other) => Err(CallerError::Config(format!(
+            "[[peer]] transport = {other:?} is not a valid value (accepted: absent \
+             for card-driven Intendant peers, or \"openclaw-ws\")"
+        ))),
+    }
+}
+
+/// Resolve the outbound bearer token for one `[[peer]]` entry from
+/// exactly one of its three sources: inline `bearer_token` (legacy),
+/// `bearer_token_env` (the name of an environment variable), or
+/// `bearer_token_file` (a file whose trimmed contents are the token).
+/// More than one source set is a config error; none set is
+/// `Ok(None)`.
+///
+/// `env` is injected (production passes a `std::env::var` wrapper) so
+/// tests stay hermetic — no process-global environment mutation.
+pub(crate) fn resolve_peer_bearer_token(
+    cfg: &project::PeerConfig,
+    env: impl Fn(&str) -> Option<String>,
+) -> Result<Option<String>, CallerError> {
+    let sources = [
+        cfg.bearer_token.is_some(),
+        cfg.bearer_token_env.is_some(),
+        cfg.bearer_token_file.is_some(),
+    ]
+    .iter()
+    .filter(|set| **set)
+    .count();
+    if sources > 1 {
+        return Err(CallerError::Config(format!(
+            "[[peer]] ({}) sets more than one of bearer_token, bearer_token_env, \
+             bearer_token_file — configure exactly one token source",
+            describe_peer_config(cfg)
+        )));
+    }
+    if let Some(token) = &cfg.bearer_token {
+        return Ok(Some(token.clone()));
+    }
+    if let Some(name) = &cfg.bearer_token_env {
+        let name = name.trim();
+        if name.is_empty() || name.contains('=') || name.contains('\0') {
+            return Err(CallerError::Config(format!(
+                "[[peer]] ({}) bearer_token_env {name:?} is not a valid environment \
+                 variable name",
+                describe_peer_config(cfg)
+            )));
+        }
+        let value = env(name)
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                CallerError::Config(format!(
+                    "[[peer]] ({}) bearer_token_env names {name}, but that environment \
+                     variable is unset or empty",
+                    describe_peer_config(cfg)
+                ))
+            })?;
+        return Ok(Some(value));
+    }
+    if let Some(path) = &cfg.bearer_token_file {
+        let raw = std::fs::read_to_string(path).map_err(|e| {
+            CallerError::Config(format!(
+                "[[peer]] ({}) bearer_token_file {path}: {e}",
+                describe_peer_config(cfg)
+            ))
+        })?;
+        let token = raw.trim();
+        if token.is_empty() {
+            return Err(CallerError::Config(format!(
+                "[[peer]] ({}) bearer_token_file {path} is empty",
+                describe_peer_config(cfg)
+            )));
+        }
+        return Ok(Some(token.to_string()));
+    }
+    Ok(None)
+}
+
+/// Synthesize the local Agent Card for a `transport = "openclaw-ws"`
+/// entry. A gateway serves no card, so this daemon constructs the
+/// registry-facing identity itself:
+///
+/// - `id` = `openclaw:<label>`, where the label is the operator's
+///   `label` when set, else `host[:port]` from the gateway URL. The
+///   registry keys rows on this id, so two entries for the same
+///   gateway (e.g. a future operator+node pair) need distinct labels
+///   — the second otherwise rejects with `already_registered`.
+/// - `transports` = exactly one [`peer::TransportSpec::OpenClawWs`].
+/// - `version` is left empty (unknown until the transport's first
+///   `hello-ok` refreshes the card) and `capabilities` empty — badges
+///   render from what a live connection reports, never from static
+///   assumptions.
+pub(crate) fn openclaw_card_from_config(
+    cfg: &project::PeerConfig,
+    url: String,
+    role: peer::card::OpenClawRole,
+) -> peer::AgentCard {
+    let label = cfg
+        .label
+        .as_deref()
+        .map(str::trim)
+        .filter(|label| !label.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| openclaw_label_from_url(&url));
+    peer::AgentCard {
+        id: peer::PeerId::new(crate::peer::id::PeerKind::OpenClaw, &label),
+        label,
+        version: String::new(),
+        git_sha: None,
+        transports: vec![peer::TransportSpec::OpenClawWs { url, role }],
+        capabilities: Vec::new(),
+        auth: peer::AuthRequirements::none(),
+        identity_attestation: None,
+    }
+}
+
+/// Default display label for an openclaw entry without one:
+/// `host` (default-port) or `host:port` from the gateway URL, falling
+/// back to the raw URL when it doesn't parse.
+fn openclaw_label_from_url(url: &str) -> String {
+    match url::Url::parse(url) {
+        Ok(parsed) => match (parsed.host_str(), parsed.port()) {
+            (Some(host), Some(port)) => format!("{host}:{port}"),
+            (Some(host), None) => host.to_string(),
+            _ => url.to_string(),
+        },
+        Err(_) => url.to_string(),
+    }
 }
 
 pub(crate) fn peer_client_identity_from_config(
@@ -200,8 +516,8 @@ pub(crate) fn peer_client_identity_from_config(
         })),
         (None, None) => Ok(None),
         (Some(_), None) | (None, Some(_)) => Err(CallerError::Config(format!(
-            "[[peer]] card_url={} must set client_cert and client_key together",
-            cfg.card_url
+            "[[peer]] ({}) must set client_cert and client_key together",
+            describe_peer_config(cfg)
         ))),
     }
 }
@@ -224,16 +540,370 @@ mod tests {
         client_key: Option<&str>,
     ) -> project::PeerConfig {
         project::PeerConfig {
-            card_url: "https://peer.example/.well-known/agent-card.json".to_string(),
-            label: None,
-            bearer_token: None,
-            via_urls: Vec::new(),
+            card_url: Some("https://peer.example/.well-known/agent-card.json".to_string()),
             client_cert: client_cert.map(str::to_string),
             client_key: client_key.map(str::to_string),
-            pinned_fingerprints: Vec::new(),
-            identity_public_key: None,
-            browser_tcp_via_url: None,
-            certificate_witness_vantage: crate::peer::PeerWitnessVantage::Unknown,
+            ..Default::default()
+        }
+    }
+
+    fn openclaw_config(url: Option<&str>, role: Option<&str>) -> project::PeerConfig {
+        project::PeerConfig {
+            transport: Some("openclaw-ws".to_string()),
+            url: url.map(str::to_string),
+            role: role.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // classify_peer_config
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn classify_default_entry_is_card_driven() {
+        let cfg = project::PeerConfig {
+            card_url: Some("https://peer.example/.well-known/agent-card.json".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            classify_peer_config(&cfg).unwrap(),
+            PeerConfigKind::CardDriven {
+                card_url: "https://peer.example/.well-known/agent-card.json".into()
+            }
+        );
+    }
+
+    #[test]
+    fn classify_default_entry_without_card_url_errors() {
+        let err = classify_peer_config(&project::PeerConfig::default())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("requires card_url"), "{err}");
+        assert!(
+            err.contains("openclaw-ws"),
+            "error points at the alternative shape: {err}"
+        );
+    }
+
+    #[test]
+    fn classify_card_driven_rejects_openclaw_only_fields() {
+        let mut cfg = project::PeerConfig {
+            card_url: Some("https://peer.example/.well-known/agent-card.json".into()),
+            url: Some("ws://gateway:18789".into()),
+            ..Default::default()
+        };
+        let err = classify_peer_config(&cfg).unwrap_err().to_string();
+        assert!(err.contains("`url`"), "{err}");
+
+        cfg.url = None;
+        cfg.role = Some("operator".into());
+        let err = classify_peer_config(&cfg).unwrap_err().to_string();
+        assert!(err.contains("`role`"), "{err}");
+    }
+
+    #[test]
+    fn classify_openclaw_entry_defaults_role_to_operator() {
+        let kind = classify_peer_config(&openclaw_config(Some("ws://gw:18789"), None)).unwrap();
+        assert_eq!(
+            kind,
+            PeerConfigKind::OpenClawWs {
+                url: "ws://gw:18789".into(),
+                role: peer::card::OpenClawRole::Operator,
+            }
+        );
+        // Explicit roles parse; wss URLs pass the scheme check.
+        let kind =
+            classify_peer_config(&openclaw_config(Some("wss://gw:18789"), Some("node"))).unwrap();
+        assert_eq!(
+            kind,
+            PeerConfigKind::OpenClawWs {
+                url: "wss://gw:18789".into(),
+                role: peer::card::OpenClawRole::Node,
+            }
+        );
+    }
+
+    /// Local config must fail loud on values the wire's forward-compat
+    /// fallback would hydrate as `Unknown` — an operator typo is a
+    /// config error, not a future-version peer.
+    #[test]
+    fn classify_openclaw_entry_rejects_unknown_role_and_bad_url() {
+        let err = classify_peer_config(&openclaw_config(Some("ws://gw:18789"), Some("supervisor")))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("supervisor"), "{err}");
+        assert!(err.contains("operator"), "{err}");
+        assert!(err.contains("node"), "{err}");
+
+        let err = classify_peer_config(&openclaw_config(Some("http://gw:18789"), None))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("ws://"), "{err}");
+
+        let err = classify_peer_config(&openclaw_config(None, None))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("requires url"), "{err}");
+    }
+
+    /// Card-driven-only fields on an openclaw entry would silently do
+    /// nothing (or, for via_urls, actively replace the OpenClaw spec
+    /// with IntendantWs candidates) — each fails loud instead.
+    #[test]
+    fn classify_openclaw_entry_rejects_card_driven_fields() {
+        let cases: Vec<(&str, Box<dyn Fn(&mut project::PeerConfig)>)> = vec![
+            (
+                "card_url",
+                Box::new(|cfg| cfg.card_url = Some("https://x/.well-known".into())),
+            ),
+            (
+                "via_urls",
+                Box::new(|cfg| cfg.via_urls = vec!["ws://x/ws".into()]),
+            ),
+            (
+                "pinned_fingerprints",
+                Box::new(|cfg| cfg.pinned_fingerprints = vec!["aa".into()]),
+            ),
+            (
+                "client_cert",
+                Box::new(|cfg| cfg.client_cert = Some("/x.crt".into())),
+            ),
+            (
+                "client_key",
+                Box::new(|cfg| cfg.client_key = Some("/x.key".into())),
+            ),
+            (
+                "identity_public_key",
+                Box::new(|cfg| cfg.identity_public_key = Some("k".into())),
+            ),
+            (
+                "browser_tcp_via_url",
+                Box::new(|cfg| cfg.browser_tcp_via_url = Some("ws://x/ws".into())),
+            ),
+        ];
+        for (name, mutate) in cases {
+            let mut cfg = openclaw_config(Some("ws://gw:18789"), None);
+            mutate(&mut cfg);
+            let err = classify_peer_config(&cfg).unwrap_err().to_string();
+            assert!(
+                err.contains(&format!("`{name}`")),
+                "rejection names the field {name}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_unknown_transport_value_errors() {
+        let cfg = project::PeerConfig {
+            transport: Some("a2a".into()),
+            ..Default::default()
+        };
+        let err = classify_peer_config(&cfg).unwrap_err().to_string();
+        assert!(err.contains("a2a"), "{err}");
+        assert!(err.contains("openclaw-ws"), "{err}");
+    }
+
+    // -----------------------------------------------------------------
+    // resolve_peer_bearer_token
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn bearer_token_resolution_prefers_exactly_one_source() {
+        // None configured → Ok(None).
+        let cfg = openclaw_config(Some("ws://gw:18789"), None);
+        assert_eq!(resolve_peer_bearer_token(&cfg, |_| None).unwrap(), None);
+
+        // Inline plaintext (legacy) passes through.
+        let cfg = project::PeerConfig {
+            bearer_token: Some("inline-tok".into()),
+            ..openclaw_config(Some("ws://gw:18789"), None)
+        };
+        assert_eq!(
+            resolve_peer_bearer_token(&cfg, |_| None)
+                .unwrap()
+                .as_deref(),
+            Some("inline-tok")
+        );
+
+        // Two sources set → config error naming the conflict.
+        let cfg = project::PeerConfig {
+            bearer_token: Some("inline-tok".into()),
+            bearer_token_env: Some("TOK".into()),
+            ..openclaw_config(Some("ws://gw:18789"), None)
+        };
+        let err = resolve_peer_bearer_token(&cfg, |_| None)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("more than one"), "{err}");
+    }
+
+    /// The env reference resolves through the injected lookup (tests
+    /// never touch the process environment — hermetic-tests law), and
+    /// an unset/empty variable is a loud config error, not a silent
+    /// token-less connect.
+    #[test]
+    fn bearer_token_env_reference_resolves_and_fails_loud() {
+        let cfg = project::PeerConfig {
+            bearer_token_env: Some("OPENCLAW_GATEWAY_TOKEN".into()),
+            ..openclaw_config(Some("ws://gw:18789"), None)
+        };
+        let token = resolve_peer_bearer_token(&cfg, |name| {
+            (name == "OPENCLAW_GATEWAY_TOKEN").then(|| "  sekrit \n".to_string())
+        })
+        .unwrap();
+        assert_eq!(token.as_deref(), Some("sekrit"), "resolved and trimmed");
+
+        let err = resolve_peer_bearer_token(&cfg, |_| None)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("OPENCLAW_GATEWAY_TOKEN"), "{err}");
+        assert!(err.contains("unset or empty"), "{err}");
+
+        // Invalid env-var names are rejected before lookup.
+        let cfg = project::PeerConfig {
+            bearer_token_env: Some("BAD=NAME".into()),
+            ..openclaw_config(Some("ws://gw:18789"), None)
+        };
+        let err = resolve_peer_bearer_token(&cfg, |_| Some("x".into()))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("not a valid environment"), "{err}");
+    }
+
+    #[test]
+    fn bearer_token_file_reference_reads_and_trims() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("gateway-token");
+        std::fs::write(&path, "file-tok\n").unwrap();
+        let cfg = project::PeerConfig {
+            bearer_token_file: Some(path.to_string_lossy().into_owned()),
+            ..openclaw_config(Some("ws://gw:18789"), None)
+        };
+        assert_eq!(
+            resolve_peer_bearer_token(&cfg, |_| None)
+                .unwrap()
+                .as_deref(),
+            Some("file-tok")
+        );
+
+        // Empty file and missing file both fail loud with the path.
+        std::fs::write(&path, "  \n").unwrap();
+        let err = resolve_peer_bearer_token(&cfg, |_| None)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("is empty"), "{err}");
+
+        let missing = dir.path().join("nope");
+        let cfg = project::PeerConfig {
+            bearer_token_file: Some(missing.to_string_lossy().into_owned()),
+            ..openclaw_config(Some("ws://gw:18789"), None)
+        };
+        let err = resolve_peer_bearer_token(&cfg, |_| None)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("nope"), "{err}");
+    }
+
+    // -----------------------------------------------------------------
+    // openclaw_card_from_config
+    // -----------------------------------------------------------------
+
+    /// The synthesized card carries the openclaw peer identity and
+    /// exactly one `TransportSpec::OpenClawWs` — the shape the
+    /// registry's transport selection and the dashboard's kind badge
+    /// both key on.
+    #[test]
+    fn openclaw_card_synthesis_shapes_id_label_and_transport() {
+        // Labeled entry: the label is both display name and id suffix.
+        let mut cfg = openclaw_config(Some("ws://gw.local:18789"), None);
+        cfg.label = Some("home-gateway".into());
+        let card = openclaw_card_from_config(
+            &cfg,
+            "ws://gw.local:18789".into(),
+            peer::card::OpenClawRole::Operator,
+        );
+        assert_eq!(card.id.as_str(), "openclaw:home-gateway");
+        assert_eq!(
+            card.id.kind(),
+            Some(crate::peer::id::PeerKind::OpenClaw),
+            "id kind drives the dashboard's kind badge"
+        );
+        assert_eq!(card.label, "home-gateway");
+        assert_eq!(card.version, "", "version unknown until first hello-ok");
+        assert!(card.capabilities.is_empty());
+        match card.transports.as_slice() {
+            [peer::TransportSpec::OpenClawWs { url, role }] => {
+                assert_eq!(url, "ws://gw.local:18789");
+                assert_eq!(*role, peer::card::OpenClawRole::Operator);
+            }
+            other => panic!("expected exactly one OpenClawWs transport, got {other:?}"),
+        }
+
+        // Unlabeled entry: host:port fallback keeps the id stable and
+        // human-readable.
+        let cfg = openclaw_config(Some("ws://gw.local:18789"), None);
+        let card = openclaw_card_from_config(
+            &cfg,
+            "ws://gw.local:18789".into(),
+            peer::card::OpenClawRole::Node,
+        );
+        assert_eq!(card.id.as_str(), "openclaw:gw.local:18789");
+        assert_eq!(card.label, "gw.local:18789");
+        match card.transports.as_slice() {
+            [peer::TransportSpec::OpenClawWs { role, .. }] => {
+                assert_eq!(*role, peer::card::OpenClawRole::Node);
+            }
+            other => panic!("expected OpenClawWs transport, got {other:?}"),
+        }
+    }
+
+    /// End-to-end boot-shape check for the not-yet-shipped transport:
+    /// the synthesized card presented to a registry WITHOUT an
+    /// OpenClaw transport implementation is rejected at add time with
+    /// the same clean "no supported transport" diagnostic every
+    /// unimplemented transport kind gets (mirrors
+    /// `registry::tests::add_peer_rejects_card_with_no_supported_transports`)
+    /// — no panic, no silent nothing, no zombie registry entry. When
+    /// the transport seat lands its `pick_supported_transports` /
+    /// `build_transport` arms, this add starts succeeding and the
+    /// assertion below flips — at that point this test should assert
+    /// the registered entry instead.
+    #[tokio::test]
+    async fn openclaw_card_add_degrades_cleanly_until_transport_ships() {
+        use tokio::sync::mpsc;
+        let (log_tx, _log_rx) = mpsc::channel::<crate::peer::EnqueuedPeerEvent>(8);
+        let registry = peer::PeerRegistry::new(log_tx);
+        let cfg = openclaw_config(Some("ws://gw:18789"), None);
+        let card = openclaw_card_from_config(
+            &cfg,
+            "ws://gw:18789".into(),
+            peer::card::OpenClawRole::Operator,
+        );
+        match registry
+            .add_peer_with_card_and_auth_and_client_identity(
+                card,
+                Vec::new(),
+                Some("bootstrap-token".into()),
+                None,
+                None,
+                None,
+                crate::peer::PeerWitnessVantage::Unknown,
+                None,
+            )
+            .await
+        {
+            Err(crate::peer::PeerError::CardFetch(msg)) => {
+                assert!(msg.contains("no transport"), "{msg}");
+            }
+            Ok(_) => {
+                // The OpenClaw transport has landed in this build:
+                // the config path now registers a live entry. Keep the
+                // invariant honest — the entry must exist and carry
+                // the openclaw id.
+                assert_eq!(registry.len(), 1);
+            }
+            Err(other) => panic!("expected clean CardFetch diagnostic, got {other:?}"),
         }
     }
 

--- a/src/bin/caller/web_gateway/peer_requests.rs
+++ b/src/bin/caller/web_gateway/peer_requests.rs
@@ -70,7 +70,7 @@ pub(crate) fn persist_manual_peer(
         .config
         .peers
         .iter_mut()
-        .find(|peer| peer.card_url == req.card_url);
+        .find(|peer| peer.card_url.as_deref() == Some(req.card_url.as_str()));
     match existing {
         Some(peer) => {
             if label.is_some() {
@@ -83,16 +83,13 @@ pub(crate) fn persist_manual_peer(
         }
         None => {
             project.config.peers.push(crate::project::PeerConfig {
-                card_url: req.card_url.clone(),
+                card_url: Some(req.card_url.clone()),
                 label,
                 bearer_token: req.bearer_token.clone(),
                 via_urls: req.via_urls.clone(),
-                client_cert: None,
-                client_key: None,
                 pinned_fingerprints: req.pinned_fingerprints.clone(),
-                identity_public_key: None,
                 browser_tcp_via_url: req.browser_tcp_via_url.clone(),
-                certificate_witness_vantage: crate::peer::PeerWitnessVantage::Unknown,
+                ..Default::default()
             });
         }
     }
@@ -602,7 +599,7 @@ mod tests {
         let project = crate::project::Project::from_root(root.path().to_path_buf()).unwrap();
         assert_eq!(project.config.peers.len(), 1);
         let peer = &project.config.peers[0];
-        assert_eq!(peer.card_url, req.card_url);
+        assert_eq!(peer.card_url.as_deref(), Some(req.card_url.as_str()));
         assert_eq!(peer.label.as_deref(), Some("Peer Display"));
         assert_eq!(peer.via_urls, req.via_urls);
         assert_eq!(peer.bearer_token, req.bearer_token);

--- a/static/app.html
+++ b/static/app.html
@@ -3005,6 +3005,32 @@ html {
 .daemon-row .status-chip.error {
   color: var(--red);
 }
+/* Kind badge for non-Intendant peers (e.g. "openclaw") — same visual
+   weight as the state pill, distinguished by an outline so it reads
+   as identity, not status. */
+.daemon-row .kind-badge {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 10px;
+  color: var(--subtext0);
+  background: transparent;
+  border: 1px solid var(--surface2);
+  padding: 0 6px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+/* Pending peer-side enrollment gate (OpenClaw pairing): amber and
+   always visible while pending — it carries the request id the
+   operator must approve on the gateway host. */
+.daemon-row .pairing-pill {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 10px;
+  color: var(--yellow);
+  background: var(--surface1);
+  border: 1px solid rgba(249, 226, 175, 0.4);
+  padding: 1px 6px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
 .daemon-row .caps {
   display: flex;
   gap: 3px;
@@ -39401,7 +39427,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'c572e9ec211107af';
+const INTENDANT_APP_BUILD = '7a50dd8d355c4ec7';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -119308,8 +119334,14 @@ function peerSnapshotToUpdateUsage(snap) {
 function snapshotToDaemonEntry(p) {
   return {
     host_id: p.id,
+    // Daemon kind, derived from the id's prefix ("intendant:x",
+    // "openclaw:x", …) — the id is the single source of truth for
+    // kind (PeerId::kind()), so no kind catalog is mirrored here.
+    kind: String(p.id || '').split(':')[0] || '',
     label: p.label,
-    url: wsUrlToBaseUrl(p.ws_url) || '',
+    // Card-less peers (openclaw gateways) have no ws_url; once
+    // connected, the live link's candidate URL is the honest address.
+    url: wsUrlToBaseUrl(p.ws_url) || (p.link && p.link.url) || '',
     connected: p.connection_state && p.connection_state.state === 'connected',
     version: p.version || '',
     git_sha: p.git_sha || '',
@@ -119349,6 +119381,13 @@ function snapshotToDaemonEntry(p) {
     // action pills derive from grant.operations.
     link: p.link || null,
     grant: p.grant || null,
+    // Pending peer-side enrollment gate (PeerSnapshot.pairing):
+    // {request_id, message?} while the peer requires an out-of-band
+    // approval before connects can succeed (OpenClaw pairing), null
+    // otherwise. Survives disconnects server-side; renders as the
+    // amber "pairing pending" pill with the request id the operator
+    // approves on the gateway host.
+    pairing: p.pairing || null,
   };
 }
 
@@ -119768,6 +119807,31 @@ function renderStatePill(connState) {
   return `<span class="state-pill" title="connection state: ${escapeHtml(label)}">${escapeHtml(label)}</span>`;
 }
 
+// Kind badge for non-Intendant peers ("openclaw", and whatever future
+// kinds mint ids under new prefixes). Derived from the row's id prefix
+// — never a hardcoded kind catalog — and suppressed for the default
+// `intendant` kind, which would only be noise on every row.
+function renderKindBadge(kind) {
+  if (!kind || kind === 'intendant') return '';
+  return `<span class="kind-badge" title="peer kind: ${escapeHtml(kind)}">${escapeHtml(kind)}</span>`;
+}
+
+// Amber pill for a pending peer-side enrollment gate
+// (PeerSnapshot.pairing — OpenClaw pairing is the canonical producer).
+// Always visible while pending: it names the request id the operator
+// must approve on the gateway host, which is the one actionable fact
+// when every connect attempt is being refused. The title carries the
+// full ceremony (the gateway's own recommended next step when it sent
+// one, else the standard `openclaw devices approve` invocation).
+function renderPairingPill(pairing) {
+  if (!pairing || !pairing.request_id) return '';
+  const reqId = String(pairing.request_id);
+  const hint = pairing.message
+    ? String(pairing.message)
+    : `Approve on the gateway host: openclaw devices approve ${reqId}`;
+  return `<span class="pairing-pill" title="${escapeHtml(hint)}">pairing pending · ${escapeHtml(reqId)}</span>`;
+}
+
 // Subdued chip showing the peer's PeerStatus. Hidden in the steady-state
 // values (`idle`, `working`) so the chip doesn't compete with the label
 // for attention; only `needs_approval` and `error` surface visibly.
@@ -119832,6 +119896,8 @@ function renderDaemonRow(d, isSelf) {
   // (so if the self entry ever gains them, no further change needed).
   const statePill = isSelf ? '' : renderStatePill(d.server_connection_state);
   const statusChip = isSelf ? '' : renderStatusChip(d.server_status);
+  const kindBadge = isSelf ? '' : renderKindBadge(d.kind);
+  const pairingPill = isSelf ? '' : renderPairingPill(d.pairing);
   const capBadges = renderCapBadges(d.capabilities);
   // Per-peer outbound op controls. Skipped for self — federation ops
   // address other peers, never the daemon hosting the dashboard. The
@@ -119880,7 +119946,9 @@ function renderDaemonRow(d, isSelf) {
       <div class="daemon-row${isSelf ? ' self' : ''}">
         <span class="conn-dot ${dotClass}" title="${escapeHtml(dotTitle)}"></span>
         <span class="label">${peerLabel}${selfMark}</span>
+        ${kindBadge}
         ${statePill}
+        ${pairingPill}
         ${statusChip}
         <span class="url" title="${escapeHtml(d.url)}">${escapeHtml(d.url)}</span>
         ${capBadges}

--- a/static/app/11-styles-access-files.css
+++ b/static/app/11-styles-access-files.css
@@ -2087,6 +2087,32 @@
 .daemon-row .status-chip.error {
   color: var(--red);
 }
+/* Kind badge for non-Intendant peers (e.g. "openclaw") — same visual
+   weight as the state pill, distinguished by an outline so it reads
+   as identity, not status. */
+.daemon-row .kind-badge {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 10px;
+  color: var(--subtext0);
+  background: transparent;
+  border: 1px solid var(--surface2);
+  padding: 0 6px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+/* Pending peer-side enrollment gate (OpenClaw pairing): amber and
+   always visible while pending — it carries the request id the
+   operator must approve on the gateway host. */
+.daemon-row .pairing-pill {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 10px;
+  color: var(--yellow);
+  background: var(--surface1);
+  border: 1px solid rgba(249, 226, 175, 0.4);
+  padding: 1px 6px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
 .daemon-row .caps {
   display: flex;
   gap: 3px;

--- a/static/app/50-control-transport.js
+++ b/static/app/50-control-transport.js
@@ -2649,8 +2649,14 @@ function peerSnapshotToUpdateUsage(snap) {
 function snapshotToDaemonEntry(p) {
   return {
     host_id: p.id,
+    // Daemon kind, derived from the id's prefix ("intendant:x",
+    // "openclaw:x", …) — the id is the single source of truth for
+    // kind (PeerId::kind()), so no kind catalog is mirrored here.
+    kind: String(p.id || '').split(':')[0] || '',
     label: p.label,
-    url: wsUrlToBaseUrl(p.ws_url) || '',
+    // Card-less peers (openclaw gateways) have no ws_url; once
+    // connected, the live link's candidate URL is the honest address.
+    url: wsUrlToBaseUrl(p.ws_url) || (p.link && p.link.url) || '',
     connected: p.connection_state && p.connection_state.state === 'connected',
     version: p.version || '',
     git_sha: p.git_sha || '',
@@ -2690,6 +2696,13 @@ function snapshotToDaemonEntry(p) {
     // action pills derive from grant.operations.
     link: p.link || null,
     grant: p.grant || null,
+    // Pending peer-side enrollment gate (PeerSnapshot.pairing):
+    // {request_id, message?} while the peer requires an out-of-band
+    // approval before connects can succeed (OpenClaw pairing), null
+    // otherwise. Survives disconnects server-side; renders as the
+    // amber "pairing pending" pill with the request id the operator
+    // approves on the gateway host.
+    pairing: p.pairing || null,
   };
 }
 
@@ -3109,6 +3122,31 @@ function renderStatePill(connState) {
   return `<span class="state-pill" title="connection state: ${escapeHtml(label)}">${escapeHtml(label)}</span>`;
 }
 
+// Kind badge for non-Intendant peers ("openclaw", and whatever future
+// kinds mint ids under new prefixes). Derived from the row's id prefix
+// — never a hardcoded kind catalog — and suppressed for the default
+// `intendant` kind, which would only be noise on every row.
+function renderKindBadge(kind) {
+  if (!kind || kind === 'intendant') return '';
+  return `<span class="kind-badge" title="peer kind: ${escapeHtml(kind)}">${escapeHtml(kind)}</span>`;
+}
+
+// Amber pill for a pending peer-side enrollment gate
+// (PeerSnapshot.pairing — OpenClaw pairing is the canonical producer).
+// Always visible while pending: it names the request id the operator
+// must approve on the gateway host, which is the one actionable fact
+// when every connect attempt is being refused. The title carries the
+// full ceremony (the gateway's own recommended next step when it sent
+// one, else the standard `openclaw devices approve` invocation).
+function renderPairingPill(pairing) {
+  if (!pairing || !pairing.request_id) return '';
+  const reqId = String(pairing.request_id);
+  const hint = pairing.message
+    ? String(pairing.message)
+    : `Approve on the gateway host: openclaw devices approve ${reqId}`;
+  return `<span class="pairing-pill" title="${escapeHtml(hint)}">pairing pending · ${escapeHtml(reqId)}</span>`;
+}
+
 // Subdued chip showing the peer's PeerStatus. Hidden in the steady-state
 // values (`idle`, `working`) so the chip doesn't compete with the label
 // for attention; only `needs_approval` and `error` surface visibly.
@@ -3173,6 +3211,8 @@ function renderDaemonRow(d, isSelf) {
   // (so if the self entry ever gains them, no further change needed).
   const statePill = isSelf ? '' : renderStatePill(d.server_connection_state);
   const statusChip = isSelf ? '' : renderStatusChip(d.server_status);
+  const kindBadge = isSelf ? '' : renderKindBadge(d.kind);
+  const pairingPill = isSelf ? '' : renderPairingPill(d.pairing);
   const capBadges = renderCapBadges(d.capabilities);
   // Per-peer outbound op controls. Skipped for self — federation ops
   // address other peers, never the daemon hosting the dashboard. The
@@ -3221,7 +3261,9 @@ function renderDaemonRow(d, isSelf) {
       <div class="daemon-row${isSelf ? ' self' : ''}">
         <span class="conn-dot ${dotClass}" title="${escapeHtml(dotTitle)}"></span>
         <span class="label">${peerLabel}${selfMark}</span>
+        ${kindBadge}
         ${statePill}
+        ${pairingPill}
         ${statusChip}
         <span class="url" title="${escapeHtml(d.url)}">${escapeHtml(d.url)}</span>
         ${capBadges}


### PR DESCRIPTION
The surface seat of the OpenClaw Gateway slice-1 build (transport seat: #866). Ships everything around the transport so a configured gateway peer is expressible, visible, and honest before/while/after the transport itself lands:

**Config** — `[[peer]] transport = "openclaw-ws"` entries: `url` (gateway WS endpoint), `role` (`operator` default, `node` reserved), and pairing-bootstrap auth as a secret reference (`bearer_token_env` / `bearer_token_file`, the `token_env` precedent — never plaintext demanded in the toml; inline `bearer_token` stays for legacy card-driven peers, exactly-one-source enforced). Boot classifies entries per kind with loud per-entry diagnostics (bad entries skip, never take the daemon down), synthesizes the gateway's Agent Card locally (`openclaw:<label|host:port>` + one `TransportSpec::OpenClawWs`), and hands the resolved token to the transport seam via `TransportCredentials::bearer_token`. Until the transport lands, the add degrades to the standard "advertises no transport this build supports" startup diagnostic — the same clean behavior every unimplemented transport kind gets.

**Status vocabulary** — `PeerEvent::PairingStateChanged { pending: Option<PeerPairingInfo { request_id, message? }> }`, folded by the peer actor into a new watch channel with inverted clearing semantics (survives disconnects — it explains the failing reconnect loop; clears on successful connect), surfaced as `PeerSnapshot.pairing` (`serde(default)` backcompat), pushed via the registry state observer. The actor's reconnect-backoff window now drains transport events so a gate reported by a *failed* connect surfaces immediately.

**Dashboard** — Daemons panel rows grow a kind badge (derived from the id prefix, no mirrored catalog; suppressed for `intendant`) and an amber `pairing pending · <request-id>` pill whose title carries the approval ceremony (`openclaw devices approve <id>` or the gateway's own recommendedNextStep). Fragments edited, app.html regenerated.

**Docs** — `peer-federation.md` gains "OpenClaw Gateway peers (slice 1)" (config example, operator-view pairing ceremony, slice-1 capability = message relay, degradation behavior); `configuration.md`'s `[[peer]]` table documents the new fields.

Contains the shared slice-1 module skeleton commit (8f9a5c56); its diff collapses when the first slice-1 PR merges.
