### PR TITLE
Warn on TLS-only peer pairing

### DIFF
--- a/docs/src/peer-federation.md
+++ b/docs/src/peer-federation.md
@@ -999,6 +999,12 @@ relationships, not raw endpoints. A daemon relationship has identity, a server
 certificate pin, a peer-scoped client certificate, capability metadata, and local
 policy that can later be changed or revoked.
 
+The accepting gateway must request client certificates: use the default mTLS
+mode or enable `[server.mtls]`. `[server.tls]` and `--tls` are TLS-only and
+cannot accept the peer certificate. Invite creation and request approval still
+succeed so the gateway can be fixed afterward, but Intendant warns while client
+certificate authentication is not armed.
+
 The dashboard's **Access** tab exposes peer relationship management:
 **Invitations** contains onboarding flows, **Peer Trust** shows inbound
 identities and outbound peer routes, and **Daemons** shows peer-routed targets

--- a/src/bin/caller/connect_rendezvous.rs
+++ b/src/bin/caller/connect_rendezvous.rs
@@ -2361,6 +2361,7 @@ mod tests {
         );
         let registry = Arc::new(DashboardControlRegistry::new(
             crate::web_gateway::WebGatewayConfig::default(),
+            true,
             broadcast_tx,
             crate::event::EventBus::new(),
             None,

--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -2396,9 +2396,13 @@ pub(crate) async fn api_peer_dashboard_control_signal_response(
 pub(crate) async fn api_peer_pairing_invite_response(
     id: String,
     params: Option<&serde_json::Value>,
+    runtime: &ControlRuntime,
 ) -> serde_json::Value {
     let body_text = params_body_text(params);
-    let (status, body) = crate::web_gateway::peers_pairing_invite(&body_text);
+    let (status, body) = crate::web_gateway::peers_pairing_invite(
+        &body_text,
+        runtime.peer_pairing_client_auth_armed,
+    );
     http_body_response(id, status, body, "peer pairing invite")
 }
 
@@ -2487,15 +2491,23 @@ pub(crate) async fn api_peer_pairing_requests_response_from_cert_dir(
 pub(crate) async fn api_peer_pairing_request_decision_response(
     id: String,
     params: Option<&serde_json::Value>,
+    runtime: &ControlRuntime,
 ) -> serde_json::Value {
     let cert_dir = crate::access::backend::select_backend().cert_dir();
-    api_peer_pairing_request_decision_response_from_cert_dir(id, params, &cert_dir).await
+    api_peer_pairing_request_decision_response_from_cert_dir(
+        id,
+        params,
+        &cert_dir,
+        runtime.peer_pairing_client_auth_armed,
+    )
+    .await
 }
 
 pub(crate) async fn api_peer_pairing_request_decision_response_from_cert_dir(
     id: String,
     params: Option<&serde_json::Value>,
     cert_dir: &std::path::Path,
+    peer_pairing_client_auth_armed: bool,
 ) -> serde_json::Value {
     let params = params.cloned().unwrap_or_else(|| serde_json::json!({}));
     let request_id = string_param(&params, &["request_id", "requestId", "code", "id"]);
@@ -2509,8 +2521,13 @@ pub(crate) async fn api_peer_pairing_request_decision_response_from_cert_dir(
         op
     };
     let body_text = serde_json::to_string(&params).unwrap_or_else(|_| "{}".to_string());
-    let (status, body) =
-        crate::web_gateway::peers_pairing_request_decision(cert_dir, &request_id, &op, &body_text);
+    let (status, body) = crate::web_gateway::peers_pairing_request_decision(
+        cert_dir,
+        &request_id,
+        &op,
+        &body_text,
+        peer_pairing_client_auth_armed,
+    );
     http_body_response(id, status, body, "peer access request decision")
 }
 
@@ -3876,6 +3893,7 @@ mod tests {
                 &bus,
                 None,
                 None,
+                true,
             )
             .await,
         );
@@ -3904,6 +3922,7 @@ mod tests {
                 &bus,
                 None,
                 None,
+                true,
             )
             .await,
         );
@@ -3913,6 +3932,7 @@ mod tests {
             "parity-decision".to_string(),
             Some(&serde_json::json!({"request_id": "zzz", "op": "badop"})),
             tmp.path(),
+            true,
         )
         .await;
         assert_eq!(frame["ok"], true);
@@ -3928,6 +3948,7 @@ mod tests {
             "parity-decision-missing".to_string(),
             Some(&serde_json::json!({})),
             tmp.path(),
+            true,
         )
         .await;
         assert_eq!(frame["ok"], false);
@@ -3947,6 +3968,7 @@ mod tests {
                 &bus,
                 None,
                 None,
+                true,
             )
             .await,
         );
@@ -3983,6 +4005,7 @@ mod tests {
                 &bus,
                 None,
                 Some(&registry),
+                true,
             )
             .await,
         );
@@ -4014,6 +4037,7 @@ mod tests {
                 &bus,
                 None,
                 Some(&registry),
+                true,
             )
             .await,
         );

--- a/src/bin/caller/dashboard_control/api_sessions.rs
+++ b/src/bin/caller/dashboard_control/api_sessions.rs
@@ -502,7 +502,9 @@ pub(crate) async fn control_request_frame(
         "api_peer_dashboard_control_signal" => {
             api_peer_dashboard_control_signal_response(id, params.as_ref(), &runtime).await
         }
-        "api_peer_pairing_invite" => api_peer_pairing_invite_response(id, params.as_ref()).await,
+        "api_peer_pairing_invite" => {
+            api_peer_pairing_invite_response(id, params.as_ref(), &runtime).await
+        }
         "api_peer_pairing_join" => {
             api_peer_pairing_join_response(id, params.as_ref(), &runtime).await
         }
@@ -514,7 +516,7 @@ pub(crate) async fn control_request_frame(
         }
         "api_peer_pairing_requests" => api_peer_pairing_requests_response(id).await,
         "api_peer_pairing_request_decision" => {
-            api_peer_pairing_request_decision_response(id, params.as_ref()).await
+            api_peer_pairing_request_decision_response(id, params.as_ref(), &runtime).await
         }
         "api_peer_pairing_identities" => api_peer_pairing_identities_response(id).await,
         "api_peer_pairing_identity_revoke" => {

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -552,6 +552,7 @@ type TcpFrameSender = mpsc::Sender<Vec<u8>>;
 
 pub struct DashboardControlRegistry {
     config: crate::web_gateway::WebGatewayConfig,
+    peer_pairing_client_auth_armed: bool,
     broadcast_tx: tokio::sync::broadcast::Sender<String>,
     bus: crate::event::EventBus,
     peer_registry: Option<crate::peer::PeerRegistry>,
@@ -1619,6 +1620,7 @@ impl DashboardControlRegistry {
     #[allow(clippy::too_many_arguments)] // established internal signature: the params are distinct dependencies, not a bundle
     pub fn new(
         config: crate::web_gateway::WebGatewayConfig,
+        peer_pairing_client_auth_armed: bool,
         broadcast_tx: tokio::sync::broadcast::Sender<String>,
         bus: crate::event::EventBus,
         peer_registry: Option<crate::peer::PeerRegistry>,
@@ -1638,6 +1640,7 @@ impl DashboardControlRegistry {
     ) -> Self {
         Self {
             config,
+            peer_pairing_client_auth_armed,
             broadcast_tx,
             bus,
             peer_registry,
@@ -1737,6 +1740,7 @@ impl DashboardControlRegistry {
             session_grant,
             client_nonce,
             &self.config,
+            self.peer_pairing_client_auth_armed,
             self.broadcast_tx.clone(),
             self.bus.clone(),
             self.peer_registry.clone(),
@@ -1981,6 +1985,7 @@ impl DashboardControlPeer {
         session_grant: Option<String>,
         client_nonce: Option<String>,
         config: &crate::web_gateway::WebGatewayConfig,
+        peer_pairing_client_auth_armed: bool,
         broadcast_tx: tokio::sync::broadcast::Sender<String>,
         bus: crate::event::EventBus,
         peer_registry: Option<crate::peer::PeerRegistry>,
@@ -2098,6 +2103,7 @@ impl DashboardControlPeer {
             events_subscribed: false,
             events_sent: 0,
             response_credit_enabled: false,
+            peer_pairing_client_auth_armed,
             config: Arc::new(
                 serde_json::to_value(config).unwrap_or_else(|_| serde_json::json!({})),
             ),
@@ -2183,6 +2189,8 @@ pub(crate) struct ControlRuntime {
     events_subscribed: bool,
     events_sent: u64,
     response_credit_enabled: bool,
+    /// Live gateway truth: unlike persisted config, this includes CLI flags.
+    peer_pairing_client_auth_armed: bool,
     /// Shared, not owned: `ControlRuntime` is cloned per spawned request,
     /// and an owned tree deep-copied this multi-KB JSON every time.
     config: Arc<serde_json::Value>,
@@ -4785,6 +4793,7 @@ mod tests {
             events_subscribed: false,
             events_sent: 0,
             response_credit_enabled: false,
+            peer_pairing_client_auth_armed: true,
             config: Arc::new(serde_json::json!({"provider":"openai"})),
             agent_card: Arc::new(serde_json::json!({
                 "id": "intendant:test-daemon",

--- a/src/bin/caller/peer/pairing.rs
+++ b/src/bin/caller/peer/pairing.rs
@@ -23,6 +23,32 @@ use crate::project::{PeerConfig, Project};
 const INVITE_PREFIX: &str = "intendant-peer-v1.";
 pub(crate) const AGENT_CARD_PATH: &str = "/.well-known/agent-card.json";
 const DEFAULT_WEB_PORT: u16 = intendant_core::net::DEFAULT_GATEWAY_PORT;
+pub(crate) const PEER_CLIENT_AUTH_WARNING: &str =
+    "Peer credentials were issued, but this gateway is not accepting mTLS client certificates. Paired peers cannot connect until the daemon uses its default mTLS gateway or enables [server.mtls].";
+
+/// Whether the configured gateway can accept peer-issued client certificates.
+/// TLS-only is the one incompatible posture; native mTLS is otherwise the
+/// gateway default even when neither section is explicitly enabled.
+pub(crate) fn configured_peer_client_auth_armed(server: &crate::project::ServerConfig) -> bool {
+    server.mtls.enabled || !server.tls.enabled
+}
+
+pub(crate) fn peer_client_auth_warning(client_auth_armed: bool) -> Option<&'static str> {
+    (!client_auth_armed).then_some(PEER_CLIENT_AUTH_WARNING)
+}
+
+/// CLI pairing commands run outside the live web-gateway runtime, so they can
+/// only inspect persisted config (runtime `--tls` flags are not visible here).
+/// Failure to discover a project must never turn successful certificate
+/// issuance into a pairing failure.
+fn warn_if_configured_gateway_not_client_auth_armed() {
+    let Some(warning) = Project::detect().ok().and_then(|project| {
+        peer_client_auth_warning(configured_peer_client_auth_armed(&project.config.server))
+    }) else {
+        return;
+    };
+    eprintln!(":: WARNING: {warning}");
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PeerInvite {
@@ -365,6 +391,7 @@ fn cmd_invite(args: PeerArgs) -> Result<(), CallerError> {
     println!(":: issued peer invite for {}", invite.card_url);
     println!(":: pinned server cert fingerprint: {server_cert_fingerprint}");
     println!(":: this invite contains a client private key; paste it only to the daemon that should connect");
+    warn_if_configured_gateway_not_client_auth_armed();
     println!("{encoded}");
     Ok(())
 }
@@ -489,6 +516,7 @@ fn cmd_approve(args: PeerArgs) -> Result<(), CallerError> {
             .as_deref()
             .unwrap_or(crate::peer::access_policy::DEFAULT_PROFILE)
     );
+    warn_if_configured_gateway_not_client_auth_armed();
     Ok(())
 }
 
@@ -992,6 +1020,23 @@ mod tests {
             Vec::<String>::new(),
         )
         .unwrap()
+    }
+
+    #[test]
+    fn pairing_client_auth_posture_distinguishes_tls_only() {
+        let mut server = crate::project::ServerConfig::default();
+        assert!(configured_peer_client_auth_armed(&server));
+        assert_eq!(peer_client_auth_warning(true), None);
+
+        server.tls.enabled = true;
+        assert!(!configured_peer_client_auth_armed(&server));
+        assert_eq!(
+            peer_client_auth_warning(false),
+            Some(PEER_CLIENT_AUTH_WARNING)
+        );
+
+        server.mtls.enabled = true;
+        assert!(configured_peer_client_auth_armed(&server));
     }
 
     #[test]

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -2478,6 +2478,7 @@ pub(crate) async fn serve_http_request(
                     bus,
                     project_root,
                     peer_registry,
+                    tls_client_cert_required,
                 )
                 .await;
             }

--- a/src/bin/caller/web_gateway/listener.rs
+++ b/src/bin/caller/web_gateway/listener.rs
@@ -1127,6 +1127,7 @@ fn spawn_web_gateway_from_cert_dir_with_relay_listener(
 
     let dashboard_control = Arc::new(crate::dashboard_control::DashboardControlRegistry::new(
         config.clone(),
+        tls_client_cert_required,
         broadcast_tx.clone(),
         bus.clone(),
         peer_registry.clone(),

--- a/src/bin/caller/web_gateway/routes_peers.rs
+++ b/src/bin/caller/web_gateway/routes_peers.rs
@@ -92,6 +92,7 @@ pub(crate) async fn handle_peers_sub_router(
     bus: EventBus,
     project_root: Option<PathBuf>,
     peer_registry: Option<crate::peer::PeerRegistry>,
+    peer_pairing_client_auth_armed: bool,
 ) {
     // Extract the *path* token from the request line (the second
     // whitespace-separated word) — splitting on `/api/peers` directly
@@ -106,6 +107,7 @@ pub(crate) async fn handle_peers_sub_router(
         &bus,
         project_root.as_deref(),
         peer_registry.as_ref(),
+        peer_pairing_client_auth_armed,
     )
     .await;
     write_api_response(
@@ -153,6 +155,7 @@ pub(crate) async fn peers_sub_router_api_response(
     bus: &EventBus,
     project_root: Option<&Path>,
     peer_registry: Option<&crate::peer::PeerRegistry>,
+    peer_pairing_client_auth_armed: bool,
 ) -> ApiResponse {
     // Split path from query string. `/api/peers/eligible
     // ?capability=display` needs the query stripped before
@@ -168,7 +171,7 @@ pub(crate) async fn peers_sub_router_api_response(
     let segments: Vec<&str> = subpath.split('/').filter(|s| !s.is_empty()).collect();
 
     let (status, body) = if segments == ["pairing", "invite"] && req_method == "POST" {
-        peers_pairing_invite(body_text)
+        peers_pairing_invite(body_text, peer_pairing_client_auth_armed)
     } else if segments == ["pairing", "request-access"] && req_method == "POST" {
         peers_pairing_request_access(cert_dir, body_text).await
     } else if segments == ["pairing", "request-access", "poll"] && req_method == "POST" {
@@ -184,7 +187,13 @@ pub(crate) async fn peers_sub_router_api_response(
         && segments[1] == "requests"
         && req_method == "POST"
     {
-        peers_pairing_request_decision(cert_dir, segments[2], segments[3], body_text)
+        peers_pairing_request_decision(
+            cert_dir,
+            segments[2],
+            segments[3],
+            body_text,
+            peer_pairing_client_auth_armed,
+        )
     } else {
         match peer_registry {
             None => (
@@ -465,7 +474,10 @@ pub(crate) async fn peers_add(
 /// Handle `POST /api/peers/pairing/invite`: issue a peer-scoped mTLS
 /// client identity from this daemon's access CA and return the same
 /// encoded invite string as `intendant peer invite`.
-pub(crate) fn peers_pairing_invite(body_text: &str) -> (u16, String) {
+pub(crate) fn peers_pairing_invite(
+    body_text: &str,
+    peer_pairing_client_auth_armed: bool,
+) -> (u16, String) {
     let req: PairingInviteRequest = if body_text.trim().is_empty() {
         PairingInviteRequest::default()
     } else {
@@ -494,17 +506,19 @@ pub(crate) fn peers_pairing_invite(body_text: &str) -> (u16, String) {
         client_name: req.client_name,
         port,
     }) {
-        Ok(outcome) => (
-            200,
-            serde_json::json!({
+        Ok(outcome) => {
+            let response = serde_json::json!({
                 "invite": outcome.encoded,
                 "card_url": outcome.invite.card_url,
                 "label": outcome.invite.label,
                 "server_cert_fingerprint": outcome.server_cert_fingerprint,
                 "issued_at_unix": outcome.invite.issued_at_unix,
-            })
-            .to_string(),
-        ),
+            });
+            (
+                200,
+                pairing_response_with_client_auth_warning(response, peer_pairing_client_auth_armed),
+            )
+        }
         Err(e) => {
             let status = match &e {
                 crate::error::CallerError::Config(msg) if msg.contains("--card-url") => 400,
@@ -778,6 +792,7 @@ pub(crate) fn peers_pairing_request_decision(
     code_or_id: &str,
     op: &str,
     body_text: &str,
+    peer_pairing_client_auth_armed: bool,
 ) -> (u16, String) {
     let body: PairingAccessRequestDecision = if body_text.trim().is_empty() {
         PairingAccessRequestDecision::default()
@@ -807,12 +822,32 @@ pub(crate) fn peers_pairing_request_decision(
         }
     };
     match result {
-        Ok(request) => (200, access_request_summary_json(request).to_string()),
+        Ok(request) => {
+            let response = access_request_summary_json(request);
+            let body = if op == "approve" {
+                pairing_response_with_client_auth_warning(response, peer_pairing_client_auth_armed)
+            } else {
+                response.to_string()
+            };
+            (200, body)
+        }
         Err(e) => (
             400,
             serde_json::json!({"error": pairing_error_message(&e)}).to_string(),
         ),
     }
+}
+
+fn pairing_response_with_client_auth_warning(
+    mut response: serde_json::Value,
+    peer_pairing_client_auth_armed: bool,
+) -> String {
+    if let Some(warning) =
+        crate::peer::pairing::peer_client_auth_warning(peer_pairing_client_auth_armed)
+    {
+        response["warning"] = serde_json::Value::String(warning.to_string());
+    }
+    response.to_string()
 }
 
 pub(crate) fn peers_pairing_identities_list_from_cert_dir(cert_dir: &Path) -> (u16, String) {
@@ -3004,9 +3039,25 @@ mod tests {
 
     #[test]
     fn test_api_peers_pairing_invite_rejects_bad_json() {
-        let (status, body) = peers_pairing_invite("{not-json");
+        let (status, body) = peers_pairing_invite("{not-json", true);
         assert_eq!(status, 400);
         assert!(body.contains("invalid request body"));
+    }
+
+    #[test]
+    fn pairing_success_warning_tracks_live_client_auth_posture() {
+        let warned =
+            pairing_response_with_client_auth_warning(serde_json::json!({"ok": true}), false);
+        let warned: serde_json::Value = serde_json::from_str(&warned).unwrap();
+        assert_eq!(
+            warned["warning"],
+            crate::peer::pairing::PEER_CLIENT_AUTH_WARNING
+        );
+
+        let armed =
+            pairing_response_with_client_auth_warning(serde_json::json!({"ok": true}), true);
+        let armed: serde_json::Value = serde_json::from_str(&armed).unwrap();
+        assert!(armed.get("warning").is_none());
     }
 
     #[tokio::test]
@@ -3170,6 +3221,7 @@ mod tests {
                 EventBus::new(),
                 None,
                 registry,
+                true,
             )
             .await;
         })

--- a/src/bin/caller/web_gateway/routes_peers.rs
+++ b/src/bin/caller/web_gateway/routes_peers.rs
@@ -147,6 +147,7 @@ pub(crate) async fn handle_peers_sub_router(
 /// every registry-backed leaf returns 503 so the dashboard can render
 /// "peers unavailable" instead of the empty list that a working-but-
 /// empty registry would produce.
+#[allow(clippy::too_many_arguments)] // transport-neutral router dependencies stay explicit at this internal edge
 pub(crate) async fn peers_sub_router_api_response(
     req_method: &str,
     path_token: &str,

--- a/static/app.html
+++ b/static/app.html
@@ -3350,6 +3350,7 @@ html {
 }
 .daemon-pairing-status.error { color: var(--red); }
 .daemon-pairing-status.ok { color: var(--green); }
+.daemon-pairing-status.warn { color: var(--peach); font-weight: 600; }
 .daemon-pairing-secret {
   color: var(--yellow);
   font-size: 11px;
@@ -15631,6 +15632,7 @@ html.ui-v2 .daemon-add-row button:hover { background: var(--surface-2); border-c
 html.ui-v2 .daemon-pairing-status { font-size: 11.5px; color: var(--text-3); }
 html.ui-v2 .daemon-pairing-status.error { color: var(--rose); }
 html.ui-v2 .daemon-pairing-status.ok { color: var(--green); }
+html.ui-v2 .daemon-pairing-status.warn { color: var(--amber); font-weight: 600; }
 html.ui-v2 .daemons-status { font-size: 11.5px; color: var(--text-3); }
 html.ui-v2 .daemons-status.error { color: var(--rose); }
 html.ui-v2 .daemons-status.ok { color: var(--green); }
@@ -39427,7 +39429,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '7a50dd8d355c4ec7';
+const INTENDANT_APP_BUILD = 'fa352ce13cfa950f';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -123911,7 +123913,12 @@ async function createDaemonInvite() {
     output.value = result.invite || '';
     if (copyBtn) copyBtn.disabled = !output.value;
     const target = result.card_url ? ` for ${result.card_url}` : '';
-    setDaemonPairingStatus('daemon-invite-status', `Inbound grant invite ready${target}`, 'ok');
+    const success = `Inbound grant invite ready${target}`;
+    setDaemonPairingStatus(
+      'daemon-invite-status',
+      result.warning ? `${success}. Warning: ${result.warning}` : success,
+      result.warning ? 'warn' : 'ok'
+    );
     await loadPeerIdentities();
   } catch (e) {
     setDaemonPairingStatus('daemon-invite-status', `Request failed: ${e.message}`, 'error');
@@ -124200,10 +124207,11 @@ async function decidePeerAccessRequest(requestId, op) {
       setDaemonPairingStatus('daemon-access-requests-status', `Failed: ${result.error || resp.status}`, 'error');
       return;
     }
+    const success = op === 'approve' ? 'Granted inbound access' : 'Denied inbound access';
     setDaemonPairingStatus(
       'daemon-access-requests-status',
-      op === 'approve' ? 'Granted inbound access' : 'Denied inbound access',
-      op === 'approve' ? 'ok' : ''
+      op === 'approve' && result.warning ? `${success}. Warning: ${result.warning}` : success,
+      op === 'approve' ? (result.warning ? 'warn' : 'ok') : ''
     );
     await loadPeerAccessRequests();
     if (op === 'approve') await loadPeerIdentities();

--- a/static/app/11-styles-access-files.css
+++ b/static/app/11-styles-access-files.css
@@ -2432,6 +2432,7 @@
 }
 .daemon-pairing-status.error { color: var(--red); }
 .daemon-pairing-status.ok { color: var(--green); }
+.daemon-pairing-status.warn { color: var(--peach); font-weight: 600; }
 .daemon-pairing-secret {
   color: var(--yellow);
   font-size: 11px;

--- a/static/app/52-peer-display.js
+++ b/static/app/52-peer-display.js
@@ -2619,7 +2619,12 @@ async function createDaemonInvite() {
     output.value = result.invite || '';
     if (copyBtn) copyBtn.disabled = !output.value;
     const target = result.card_url ? ` for ${result.card_url}` : '';
-    setDaemonPairingStatus('daemon-invite-status', `Inbound grant invite ready${target}`, 'ok');
+    const success = `Inbound grant invite ready${target}`;
+    setDaemonPairingStatus(
+      'daemon-invite-status',
+      result.warning ? `${success}. Warning: ${result.warning}` : success,
+      result.warning ? 'warn' : 'ok'
+    );
     await loadPeerIdentities();
   } catch (e) {
     setDaemonPairingStatus('daemon-invite-status', `Request failed: ${e.message}`, 'error');
@@ -2908,10 +2913,11 @@ async function decidePeerAccessRequest(requestId, op) {
       setDaemonPairingStatus('daemon-access-requests-status', `Failed: ${result.error || resp.status}`, 'error');
       return;
     }
+    const success = op === 'approve' ? 'Granted inbound access' : 'Denied inbound access';
     setDaemonPairingStatus(
       'daemon-access-requests-status',
-      op === 'approve' ? 'Granted inbound access' : 'Denied inbound access',
-      op === 'approve' ? 'ok' : ''
+      op === 'approve' && result.warning ? `${success}. Warning: ${result.warning}` : success,
+      op === 'approve' ? (result.warning ? 'warn' : 'ok') : ''
     );
     await loadPeerAccessRequests();
     if (op === 'approve') await loadPeerIdentities();

--- a/static/app/ui2-access.css
+++ b/static/app/ui2-access.css
@@ -983,6 +983,7 @@ html.ui-v2 .daemon-add-row button:hover { background: var(--surface-2); border-c
 html.ui-v2 .daemon-pairing-status { font-size: 11.5px; color: var(--text-3); }
 html.ui-v2 .daemon-pairing-status.error { color: var(--rose); }
 html.ui-v2 .daemon-pairing-status.ok { color: var(--green); }
+html.ui-v2 .daemon-pairing-status.warn { color: var(--amber); font-weight: 600; }
 html.ui-v2 .daemons-status { font-size: 11.5px; color: var(--text-3); }
 html.ui-v2 .daemons-status.error { color: var(--rose); }
 html.ui-v2 .daemons-status.ok { color: var(--green); }


### PR DESCRIPTION
## Summary
- warn after CLI peer invite/approval when persisted config selects TLS-only gateway mode
- surface the same warning through HTTP and dashboard-control pairing responses using the live client-auth posture
- show the warning in the Access UI and document the mTLS prerequisite

## Tests
- `cargo check -p intendant --bin intendant --locked`
- `cargo test -p intendant --bin intendant pairing_client_auth_posture_distinguishes_tls_only --locked`
- `cargo test -p intendant --bin intendant pairing_success_warning_tracks_live_client_auth_posture --locked`
- `cargo test -p intendant --bin intendant golden_peers_sub_router_transcripts --locked`
- `node --check static/app/52-peer-display.js`
- `cargo fmt --all -- --check`
- app HTML assembler reports generated artifact up to date