### PR TITLE
codex: preflight stale stdio mcp_servers.intendant entries before spawn

### DIFF
--- a/docs/src/external-agent-orchestration.md
+++ b/docs/src/external-agent-orchestration.md
@@ -346,6 +346,18 @@ own native capabilities where the upstream CLIs provide them.
   `sandbox_workspace_write.network_access=true` (only in `workspace-write`), and
   `sandbox_workspace_write.writable_roots=[…]`.
 
+  One shape the overrides cannot express: Codex `-c` overrides deep-merge into
+  the config table (they never replace it), so a user-global
+  `[mcp_servers.intendant]` entry declared as **stdio** (`command = …`) in the
+  Codex home `config.toml` would merge with the injected `type="http"`/`url`
+  keys into an entry Codex rejects wholesale (`JSON-RPC error -32600: url is
+  not supported for stdio`). Intendant preflights the effective Codex home
+  before spawn and fails the session with the remedy
+  (`codex mcp remove intendant`) instead of surfacing that opaque error; an
+  active `oauth:codex` lease additionally drops such an entry from the
+  `config.toml` carried into the materialized `CODEX_HOME`, which only ever
+  serves Intendant-spawned processes.
+
   Codex app-server launches in `managed_context = "managed"` also pass config
   overrides that suppress inherited user-global Codex MCP servers and plugin/app
   connectors by default. This keeps managed startup to Intendant MCP plus

--- a/src/bin/caller/credential_leases.rs
+++ b/src/bin/caller/credential_leases.rs
@@ -1180,6 +1180,11 @@ fn remove_tree_no_follow(path: &Path, canonical_boundary: &Path) -> Result<(), S
         .map_err(|error| format!("remove directory {}: {error}", canonical.display()))
 }
 
+/// Rewrite applied to a carried config's bytes before they land in a
+/// materialized home: `Some(rewritten)` to substitute, `None` to keep the
+/// original bytes.
+type CarryOverSanitizer = fn(&[u8]) -> Option<Vec<u8>>;
+
 struct MaterializationPlan {
     dir_name: &'static str,
     auth_name: &'static str,
@@ -1191,7 +1196,7 @@ struct MaterializationPlan {
     /// (`None`). The materialized home only ever serves Intendant-spawned
     /// agents, so entries that would fight the per-session launch config
     /// are dropped at the copy instead of poisoning every leased spawn.
-    carry_over_sanitizer: Option<fn(&[u8]) -> Option<Vec<u8>>>,
+    carry_over_sanitizer: Option<CarryOverSanitizer>,
     /// Message-search source label for staged transcripts.
     source: &'static str,
     /// Transcript subdirectories the agent writes under this home —

--- a/src/bin/caller/credential_leases.rs
+++ b/src/bin/caller/credential_leases.rs
@@ -1186,6 +1186,12 @@ struct MaterializationPlan {
     /// Non-secret config carried over from the agent's real home
     /// (source home, file name) so behavior is preserved.
     carry_over: Option<(PathBuf, &'static str)>,
+    /// Rewrites the carried config's bytes before they land in the
+    /// materialized home (`Some(rewritten)`), or keeps them verbatim
+    /// (`None`). The materialized home only ever serves Intendant-spawned
+    /// agents, so entries that would fight the per-session launch config
+    /// are dropped at the copy instead of poisoning every leased spawn.
+    carry_over_sanitizer: Option<fn(&[u8]) -> Option<Vec<u8>>>,
     /// Message-search source label for staged transcripts.
     source: &'static str,
     /// Transcript subdirectories the agent writes under this home —
@@ -1202,6 +1208,11 @@ fn materialization_plan(kind: &str) -> Option<MaterializationPlan> {
             auth_name: "auth.json",
             carry_over: crate::session_config::effective_codex_home()
                 .map(|home| (PathBuf::from(home), "config.toml")),
+            // A stdio-shaped `[mcp_servers.intendant]` entry in the real
+            // config would deep-merge with the per-session
+            // `-c mcp_servers.intendant.*` overrides and make every leased
+            // Codex spawn unstartable; drop it from the carried copy.
+            carry_over_sanitizer: Some(crate::external_agent::codex::sanitize_carried_codex_config),
             source: "codex",
             transcript_dirs: &["sessions", "archived_sessions"],
         }),
@@ -1209,6 +1220,7 @@ fn materialization_plan(kind: &str) -> Option<MaterializationPlan> {
             dir_name: "claude-home",
             auth_name: ".credentials.json",
             carry_over: Some((crate::platform::home_dir().join(".claude"), "settings.json")),
+            carry_over_sanitizer: None,
             source: "claude-code",
             transcript_dirs: &["projects"],
         }),
@@ -1221,6 +1233,7 @@ fn materialization_plan(kind: &str) -> Option<MaterializationPlan> {
                     .unwrap_or_else(|| crate::platform::home_dir().join(".kimi-code")),
                 "config.toml",
             )),
+            carry_over_sanitizer: None,
             source: "kimi",
             transcript_dirs: &["sessions"],
         }),
@@ -1234,6 +1247,7 @@ fn materialization_plan(kind: &str) -> Option<MaterializationPlan> {
                     .unwrap_or_else(|| crate::platform::home_dir().join(".pi").join("agent")),
                 "settings.json",
             )),
+            carry_over_sanitizer: None,
             source: "pi",
             transcript_dirs: &["sessions"],
         }),
@@ -1343,7 +1357,11 @@ fn materialize_with_plan(
         validate_regular_or_absent_leaf(&target, "carried config")?;
         let source = source_home.join(config_name);
         let contents = if source != target && source.is_file() {
-            std::fs::read(&source).ok()
+            std::fs::read(&source).ok().map(|bytes| {
+                plan.carry_over_sanitizer
+                    .and_then(|sanitize| sanitize(&bytes))
+                    .unwrap_or(bytes)
+            })
         } else {
             None
         };
@@ -3247,6 +3265,7 @@ mod tests {
                 dir_name: "kimi-home",
                 auth_name: "credentials/kimi-code.json",
                 carry_over: None,
+                carry_over_sanitizer: None,
                 source: "kimi",
                 transcript_dirs: &["sessions"],
             },
@@ -3266,6 +3285,7 @@ mod tests {
                 dir_name: "pi-home",
                 auth_name: "auth.json",
                 carry_over: None,
+                carry_over_sanitizer: None,
                 source: "pi",
                 transcript_dirs: &["sessions"],
             },
@@ -3355,6 +3375,64 @@ mod tests {
         cleanup_kind("oauth:claude-code");
     }
 
+    #[test]
+    fn oauth_codex_materialization_sanitizes_stale_intendant_mcp_entry() {
+        let root = tempfile::TempDir::new().unwrap();
+        let staging = crate::lease_transcript_staging::StagingPaths {
+            staging: root.path().join("test-staging"),
+            active: root.path().join("test-active"),
+        };
+        let source_home = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            source_home.path().join("config.toml"),
+            concat!(
+                "model = \"gpt-5.6-sol\"\n\n",
+                "[mcp_servers.node_repl]\ncommand = \"node-repl\"\n\n",
+                "[mcp_servers.intendant]\n",
+                "command = \"/home/user/projects/intendant/target/release/intendant\"\n",
+                "args = [ \"--mcp\" ]\n",
+            ),
+        )
+        .unwrap();
+
+        materialize_with_plan(
+            root.path(),
+            &staging,
+            &MaterializationPlan {
+                dir_name: "codex-home",
+                auth_name: "auth.json",
+                carry_over: Some((source_home.path().to_path_buf(), "config.toml")),
+                carry_over_sanitizer: Some(
+                    crate::external_agent::codex::sanitize_carried_codex_config,
+                ),
+                source: "codex",
+                transcript_dirs: &["sessions", "archived_sessions"],
+            },
+            r#"{"tokens":{}}"#,
+        )
+        .unwrap();
+
+        let carried = root.path().join("codex-home").join("config.toml");
+        let contents = std::fs::read_to_string(&carried).unwrap();
+        let value: toml::Value = contents.parse().unwrap();
+        assert_eq!(
+            value.get("model").and_then(|v| v.as_str()),
+            Some("gpt-5.6-sol")
+        );
+        let servers = value.get("mcp_servers").unwrap().as_table().unwrap();
+        assert!(servers.contains_key("node_repl"));
+        assert!(
+            !servers.contains_key("intendant"),
+            "stale stdio intendant entry must not ride into the leased home: {contents}"
+        );
+        // Only the copy is sanitized — the source config is untouched.
+        assert!(
+            std::fs::read_to_string(source_home.path().join("config.toml"))
+                .unwrap()
+                .contains("[mcp_servers.intendant]")
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn oauth_materialization_rejects_linked_root_home_parent_and_auth_leaf() {
@@ -3422,6 +3500,7 @@ mod tests {
                 dir_name: "kimi-home",
                 auth_name: "credentials/kimi-code.json",
                 carry_over: None,
+                carry_over_sanitizer: None,
                 source: "kimi",
                 transcript_dirs: &["sessions"],
             },
@@ -3544,6 +3623,7 @@ mod tests {
             dir_name: "kimi-home",
             auth_name: "credentials/kimi-code.json",
             carry_over: None,
+            carry_over_sanitizer: None,
             source: "kimi",
             transcript_dirs: &["sessions"],
         };

--- a/src/bin/caller/external_agent/codex/mod.rs
+++ b/src/bin/caller/external_agent/codex/mod.rs
@@ -1341,6 +1341,31 @@ impl ExternalAgent for CodexAgent {
             &mut command,
             leased_codex_home.as_deref().or(self.codex_home.as_deref()),
         );
+        // Preflight the same home the child resolves (leased materialization
+        // → configured home → inherited CODEX_HOME/~/.codex): a stdio-shaped
+        // `[mcp_servers.intendant]` entry there deep-merges with the
+        // `-c mcp_servers.intendant.*` overrides above into an entry Codex
+        // rejects wholesale — surfaced only as `JSON-RPC error -32600: url
+        // is not supported for stdio` when the first thread starts. Fail
+        // before spawn with the remedy instead.
+        let preflight_home = leased_codex_home
+            .clone()
+            .or_else(|| self.codex_home.clone())
+            .or_else(|| {
+                crate::session_config::effective_codex_home().map(std::path::PathBuf::from)
+            });
+        if let Some(home) = preflight_home {
+            if let Some(stale_command) = codex_home_conflicting_intendant_stdio_command(&home) {
+                return Err(CallerError::ExternalAgent(format!(
+                    "Codex config conflict: {} declares [mcp_servers.intendant] as a stdio server \
+                     (command = {stale_command:?}). Intendant registers its session MCP server \
+                     under that name over HTTP, and Codex config overrides merge instead of \
+                     replacing, so the session cannot start. Remove the stale entry \
+                     (`codex mcp remove intendant`) and retry.",
+                    home.join("config.toml").display()
+                )));
+            }
+        }
         #[cfg(target_os = "linux")]
         crate::linux_display_env::apply_to_tokio_command(&mut command);
         if let Some(root) = &self.request_trace_root {

--- a/src/bin/caller/external_agent/codex/wire.rs
+++ b/src/bin/caller/external_agent/codex/wire.rs
@@ -150,6 +150,50 @@ pub(crate) fn codex_mcp_server_names_from_config_toml(config: &str) -> Vec<Strin
     names
 }
 
+/// The `command` of a `[mcp_servers.intendant]` entry in the Codex home
+/// config, when one exists. Such a stdio-shaped entry cannot coexist with
+/// the per-session `-c mcp_servers.intendant.{type,url}` overrides: Codex
+/// `-c` overrides deep-merge into the config table at every level (they
+/// never replace it, proven against codex-cli 0.147.0), so the merged
+/// entry keeps `command` beside `url` and Codex refuses the whole
+/// configuration — surfaced as an opaque JSON-RPC -32600 ("url is not
+/// supported for stdio") when the first thread starts. Callers detect the
+/// collision before spawn and fail with the remedy instead.
+pub(crate) fn codex_home_conflicting_intendant_stdio_command(home: &Path) -> Option<String> {
+    let config = std::fs::read_to_string(home.join("config.toml")).ok()?;
+    conflicting_intendant_stdio_command_from_config_toml(&config)
+}
+
+pub(crate) fn conflicting_intendant_stdio_command_from_config_toml(config: &str) -> Option<String> {
+    let value = config.parse::<toml::Value>().ok()?;
+    let command = value.get("mcp_servers")?.get("intendant")?.get("command")?;
+    Some(
+        command
+            .as_str()
+            .map(str::to_string)
+            .unwrap_or_else(|| command.to_string()),
+    )
+}
+
+/// Sanitize a Codex `config.toml` carried into a lease-materialized
+/// `CODEX_HOME`: `Some(rewritten)` with the stdio-shaped
+/// `[mcp_servers.intendant]` entry dropped when the config declares one,
+/// `None` (keep the original bytes) otherwise. The materialized home only
+/// ever serves Intendant-spawned Codex processes, which define the
+/// `intendant` server exclusively through per-session `-c` overrides — a
+/// carried stdio entry would deep-merge with those and make every session
+/// unstartable (see [`codex_home_conflicting_intendant_stdio_command`]).
+pub(crate) fn sanitize_carried_codex_config(bytes: &[u8]) -> Option<Vec<u8>> {
+    let config = std::str::from_utf8(bytes).ok()?;
+    conflicting_intendant_stdio_command_from_config_toml(config)?;
+    let mut value: toml::Value = config.parse().ok()?;
+    value
+        .get_mut("mcp_servers")?
+        .as_table_mut()?
+        .remove("intendant");
+    toml::to_string(&value).ok().map(String::into_bytes)
+}
+
 pub(crate) fn codex_mcp_server_disable_override(server_names: &[String]) -> Option<String> {
     if server_names.is_empty() {
         return None;
@@ -486,6 +530,106 @@ command = "asana-mcp"
                 "mcp_servers={asana-prod={enabled=false},\"linear.com\"={enabled=false},\"gmail workspace\"={enabled=false}}"
             )
         );
+    }
+
+    #[test]
+    fn conflicting_intendant_stdio_command_detects_command_shaped_entry() {
+        let config = r#"
+[mcp_servers.node_repl]
+command = "/Applications/ChatGPT.app/Contents/Resources/cua_node/bin/node_repl"
+
+[mcp_servers.intendant]
+command = "/home/user/projects/intendant/target/release/intendant"
+args = [ "--mcp" ]
+"#;
+        assert_eq!(
+            conflicting_intendant_stdio_command_from_config_toml(config).as_deref(),
+            Some("/home/user/projects/intendant/target/release/intendant")
+        );
+    }
+
+    #[test]
+    fn conflicting_intendant_stdio_command_ignores_http_shape_and_other_servers() {
+        // The sanctioned http shape deep-merges harmlessly with the
+        // per-session overrides; stdio entries under other names are
+        // unrelated servers.
+        for config in [
+            "",
+            "[mcp_servers.intendant]\ntype = \"http\"\nurl = \"http://stale.example.invalid/mcp\"\n",
+            "[mcp_servers.linear]\ncommand = \"linear-mcp\"\n",
+            "[mcp_servers.intendant]\nenabled = false\n",
+            "not valid toml [",
+        ] {
+            assert_eq!(
+                conflicting_intendant_stdio_command_from_config_toml(config),
+                None,
+                "{config:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn codex_home_conflicting_intendant_stdio_command_reads_config_from_home() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(
+            codex_home_conflicting_intendant_stdio_command(tmp.path()),
+            None
+        );
+        std::fs::write(
+            tmp.path().join("config.toml"),
+            "[mcp_servers.intendant]\ncommand = \"intendant\"\nargs = [\"--mcp\"]\n",
+        )
+        .unwrap();
+        assert_eq!(
+            codex_home_conflicting_intendant_stdio_command(tmp.path()).as_deref(),
+            Some("intendant")
+        );
+    }
+
+    #[test]
+    fn sanitize_carried_codex_config_drops_only_the_stdio_intendant_entry() {
+        let config = r#"
+model = "gpt-5.6-sol"
+
+[mcp_servers.node_repl]
+command = "node-repl"
+
+[mcp_servers.intendant]
+command = "/home/user/projects/intendant/target/release/intendant"
+args = [ "--mcp" ]
+"#;
+        let rewritten = sanitize_carried_codex_config(config.as_bytes()).expect("rewritten");
+        let value: toml::Value = std::str::from_utf8(&rewritten).unwrap().parse().unwrap();
+        assert_eq!(
+            value.get("model").and_then(|v| v.as_str()),
+            Some("gpt-5.6-sol")
+        );
+        let servers = value.get("mcp_servers").unwrap().as_table().unwrap();
+        assert!(servers.contains_key("node_repl"));
+        assert!(!servers.contains_key("intendant"));
+        // The rewrite must itself be conflict-free.
+        assert_eq!(
+            conflicting_intendant_stdio_command_from_config_toml(
+                std::str::from_utf8(&rewritten).unwrap()
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn sanitize_carried_codex_config_keeps_non_conflicting_configs_byte_identical() {
+        for config in [
+            "model = \"gpt-5.6-sol\"\n",
+            "[mcp_servers.intendant]\ntype = \"http\"\nurl = \"http://stale.example.invalid/mcp\"\n",
+            "not valid toml [",
+        ] {
+            assert_eq!(
+                sanitize_carried_codex_config(config.as_bytes()),
+                None,
+                "{config:?}"
+            );
+        }
+        assert_eq!(sanitize_carried_codex_config(&[0xff, 0xfe]), None);
     }
 
     #[test]


### PR DESCRIPTION
A supervised Codex session dies at thread start with the opaque

    External agent error: JSON-RPC error -32600: failed to load configuration:
    url is not supported for stdio in `mcp_servers.intendant`

whenever the effective Codex home's `config.toml` declares `[mcp_servers.intendant]` as a **stdio** server (`command = …`) — e.g. a leftover from hand-wiring standalone Codex at Intendant's MCP via `codex mcp add intendant -- intendant --mcp`, or such an entry synced in from another machine (observed live: a `/home/…` Linux-path entry in a Mac's `~/.codex/config.toml`).

Root cause: Codex `-c` overrides **deep-merge** into the config table at every level — they never replace it (verified against codex-cli 0.147.0: per-key overrides, whole-table `mcp_servers.intendant={…}` assignment, and the managed-mode `mcp_servers={…}` suppression override all merge). So the injected `-c mcp_servers.intendant.{type,url}` keys land *beside* the stale `command` key, and Codex rejects the merged entry wholesale. There is no `-c` shape that removes a key, so both vanilla and managed launches are unstartable on such a box.

Fix, two layers:

- **Spawn preflight** (`codex/mod.rs`): before spawning the app-server, resolve the same home the child will (leased materialization → configured home → `CODEX_HOME`/`~/.codex`) and fail with an actionable message naming the file and the remedy (`codex mcp remove intendant`) instead of Codex's -32600.
- **Lease-copy sanitization** (`credential_leases.rs`): `MaterializationPlan` gains an optional `carry_over_sanitizer`; the `oauth:codex` plan drops a stdio-shaped `[mcp_servers.intendant]` entry from the `config.toml` copied into the materialized `CODEX_HOME`. The materialized home only ever serves Intendant-spawned Codex processes, which define that server exclusively via `-c` overrides, so the entry can never be right there. The user's real config is never touched.

Detection is precise: only a `command`-bearing `intendant` entry trips it — the sanctioned `type="http"` shape and stdio entries under other names deep-merge harmlessly and are left alone.

Tests: detector shape matrix, home-file reader, sanitizer rewrite/no-op matrix (including non-UTF-8 and invalid TOML), and an end-to-end materialization test proving the carried copy is sanitized while the source stays untouched. Docs: the Codex MCP-injection section in `external-agent-orchestration.md` documents the conflict and both behaviors.
