### PR TITLE
fix(coordination): bound cleanup and poll noise

### DIFF
--- a/src/bin/caller/connect_rendezvous.rs
+++ b/src/bin/caller/connect_rendezvous.rs
@@ -861,6 +861,7 @@ async fn run_connect_rendezvous_client(
             status.daemon_id = Some(daemon_id.clone());
         });
     });
+    let mut poll_log = PollLogState::default();
 
     loop {
         // Track HS5 (Q9): only the lease holder speaks for this
@@ -923,6 +924,9 @@ async fn run_connect_rendezvous_client(
                 result = poll_next(&client, &base_url, &config, &daemon_id) => {
                     match result {
                         Ok(Some(event)) => {
+                            if poll_log.note_success() {
+                                eprintln!("[connect] poll recovered");
+                            }
                             if !client_epoch_is_current(epoch) {
                                 return;
                             }
@@ -946,11 +950,16 @@ async fn run_connect_rendezvous_client(
                             false
                         }
                         Ok(None) => {
+                            if poll_log.note_success() {
+                                eprintln!("[connect] poll recovered");
+                            }
                             report_dry_credentials(&client, &base_url, &config, &daemon_id).await;
                             false
                         }
                         Err(e) => {
-                            eprintln!("[connect] poll failed: {e}");
+                            if poll_log.note_failure(&e.to_string()) {
+                                eprintln!("[connect] poll failed: {e}");
+                            }
                             with_current_client_epoch(epoch, || {
                                 with_status(|status| {
                                     status.last_error = Some(format!("poll failed: {e}"));
@@ -1003,6 +1012,28 @@ async fn run_connect_rendezvous_client(
                 }
             }
         }
+    }
+}
+
+#[derive(Default)]
+struct PollLogState {
+    last_failure: Option<String>,
+}
+
+impl PollLogState {
+    /// Log only the first failure in a run, or a materially different
+    /// failure after the state changes.
+    fn note_failure(&mut self, failure: &str) -> bool {
+        if self.last_failure.as_deref() == Some(failure) {
+            return false;
+        }
+        self.last_failure = Some(failure.to_string());
+        true
+    }
+
+    /// Emit one recovery edge when a successful poll ends a failure run.
+    fn note_success(&mut self) -> bool {
+        self.last_failure.take().is_some()
     }
 }
 
@@ -2333,6 +2364,17 @@ pub(crate) fn join_url(base_url: &Url, path: &str) -> Result<Url, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn poll_log_is_edge_triggered_and_reports_recovery() {
+        let mut state = PollLogState::default();
+        assert!(state.note_failure("offline"));
+        assert!(!state.note_failure("offline"));
+        assert!(state.note_failure("timed out"));
+        assert!(state.note_success());
+        assert!(!state.note_success());
+        assert!(state.note_failure("offline"));
+    }
 
     fn note_test_fleet_zone_observation(
         response: &RegisterResponse,

--- a/src/bin/caller/coordination/gc.rs
+++ b/src/bin/caller/coordination/gc.rs
@@ -49,14 +49,11 @@ pub(crate) fn sweep_all(coordination_root: &Path, now_ms: u64) -> GcReport {
             return report;
         }
     };
-    for (n, entry) in entries.enumerate() {
-        if n >= MAX_SCAN_ENTRIES {
-            report.errors.push(format!(
-                "{}: exceeds the {MAX_SCAN_ENTRIES}-space scan bound",
-                coordination_root.display()
-            ));
-            break;
-        }
+    // The coordination root is a fleet of independently bounded spaces,
+    // not one protocol directory. Stream every child so an old fleet with
+    // more than MAX_SCAN_ENTRIES projects cannot permanently strand the
+    // tail beyond the per-kind defensive scan bound.
+    for entry in entries {
         let Ok(entry) = entry else { continue };
         let name = entry.file_name().to_string_lossy().to_string();
         if name.starts_with('.') {
@@ -311,6 +308,23 @@ mod tests {
         let report = sweep_all(&root, now + 25 * HOUR_MS);
         assert_eq!(report.spaces, 2);
         assert_eq!(report.declarations_removed, 2);
+        assert!(report.errors.is_empty(), "{:?}", report.errors);
+    }
+
+    #[test]
+    fn sweep_all_streams_past_the_per_space_scan_bound() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("coordination");
+        for i in 0..=MAX_SCAN_ENTRIES {
+            let sessions = root.join(format!("space-{i:04}")).join("sessions");
+            std::fs::create_dir_all(&sessions).unwrap();
+            std::fs::write(sessions.join(".orphan.tmp"), "partial").unwrap();
+        }
+
+        let now = crate::coordination::now_ms();
+        let report = sweep_all(&root, now + 2 * HOUR_MS);
+        assert_eq!(report.spaces, MAX_SCAN_ENTRIES + 1);
+        assert_eq!(report.tmp_removed, MAX_SCAN_ENTRIES + 1);
         assert!(report.errors.is_empty(), "{:?}", report.errors);
     }
 }

--- a/src/bin/caller/coordination/messages.rs
+++ b/src/bin/caller/coordination/messages.rs
@@ -314,7 +314,7 @@ impl MessageSpace {
         if !writer_dir.is_dir() {
             let (dirs, _) = writer_dirs(&self.dir)?;
             if dirs.len() >= MAX_WRITER_DIRS {
-                return Err(CoordinationError::WriteRefused(format!(
+                return Err(CoordinationError::CapacityReached(format!(
                     "space holds {} writer dirs; the bound is {MAX_WRITER_DIRS}",
                     dirs.len()
                 )));
@@ -324,7 +324,7 @@ impl MessageSpace {
         restrict_dir_modes(&writer_dir)?;
         let (live, _) = scan::scan_liveness_dir(&writer_dir)?;
         if live.len() >= MAX_MESSAGES_PER_WRITER {
-            return Err(CoordinationError::WriteRefused(format!(
+            return Err(CoordinationError::CapacityReached(format!(
                 "writer {RESERVED_DAEMON_WRITER:?} holds {} messages; the bound is \
                  {MAX_MESSAGES_PER_WRITER} — expiry GC must catch up first",
                 live.len()

--- a/src/bin/caller/coordination/mod.rs
+++ b/src/bin/caller/coordination/mod.rs
@@ -114,6 +114,8 @@ pub(crate) enum CoordinationError {
     WriteRefused(String),
     #[error("coordination read refused: {0}")]
     ReadRefused(String),
+    #[error("coordination capacity reached: {0}")]
+    CapacityReached(String),
     #[error("coordination io: {0}")]
     Io(String),
 }

--- a/src/bin/caller/coordination/radar.rs
+++ b/src/bin/caller/coordination/radar.rs
@@ -366,7 +366,11 @@ pub(crate) fn write_space_radar_notes(
                 ttl_s: None,
             });
             if let Err(e) = result {
+                let at_capacity = matches!(e, CoordinationError::CapacityReached(_));
                 errors.push(e.to_string());
+                if at_capacity {
+                    return errors;
+                }
             }
         }
     }
@@ -390,7 +394,11 @@ pub(crate) fn write_space_radar_notes(
             ttl_s: None,
         });
         if let Err(e) = result {
+            let at_capacity = matches!(e, CoordinationError::CapacityReached(_));
             errors.push(e.to_string());
+            if at_capacity {
+                return errors;
+            }
         }
     }
     errors
@@ -1400,6 +1408,26 @@ mod tests {
         let quiet = snap(&inputs(&[], &[], &[], &[]));
         assert!(write_space_radar_notes(&empty_dir, "empty", &quiet).is_empty());
         assert!(!empty_dir.exists(), "quiet spaces stay untouched");
+    }
+
+    #[test]
+    fn radar_note_capacity_stops_after_one_refusal() {
+        let tmp = tempfile::tempdir().unwrap();
+        let space_dir = tmp.path().join("space");
+        let daemon_dir = space_dir.join("messages/daemon");
+        std::fs::create_dir_all(&daemon_dir).unwrap();
+        for i in 0..messages::MAX_MESSAGES_PER_WRITER {
+            std::fs::write(daemon_dir.join(format!("rn-full-{i}.md")), "occupied").unwrap();
+        }
+        let decls = [
+            declaration("s-a", &["src/a.rs", "src/b.rs"], false),
+            declaration("s-b", &["src/a.rs", "src/b.rs"], false),
+        ];
+        let snapshot = snap(&inputs(&decls, &[], &[], &[]));
+
+        let errors = write_space_radar_notes(&space_dir, "test-space", &snapshot);
+        assert_eq!(errors.len(), 1, "capacity is reported once per pass");
+        assert!(errors[0].contains("capacity reached"), "{errors:?}");
     }
 
     #[test]


### PR DESCRIPTION
Summary:
- stream coordination GC across every project space while retaining per-space bounds
- stop radar capacity retries after the first refusal in a pass
- log Connect polling failures on state changes and report recovery

Validation:
- focused GC over-bound test
- focused radar capacity test
- focused Connect poll edge/recovery test
- cargo fmt --check
- git diff --check