### PR TITLE
feat(agenda): surface live item pickup

### DIFF
--- a/docs/src/agenda-and-memory.md
+++ b/docs/src/agenda-and-memory.md
@@ -90,8 +90,9 @@ The supported commands are:
 - `acknowledge_answer` — explicitly record that a consumer picked up the
   current answer (`intendant ctl agenda acknowledge ID_PREFIX`); reads never
   perform this transition;
-- `annotate`, `set_blocker`, `clear_blocker`, `add_relies_on`, and
-  `remove_relies_on` — the item's thread and gates (below);
+- `annotate`, `pick_up`, `set_blocker`, `clear_blocker`, `add_relies_on`,
+  and `remove_relies_on` — the item's thread, structural live-session
+  pickup, and gates (below);
 - `propose_effect`, `approve_effect`, `revoke_effect`, and
   `withdraw_effect` for a scheduled session (withdraw takes back a
   still-unapproved proposal — the decline gesture; revoke stays the
@@ -202,6 +203,15 @@ operations in the same append-only log:
   item of any status — the thread under it. Full history folds; surfaces cap
   the render with an expander. Intake caps each note at the body limit and
   an item at 500 annotations (a pathology rail, not a budget).
+- **Live pickup** (`pick_up`; `intendant ctl agenda pickup ID_PREFIX`) is
+  accepted only from an attributed supervised agent session on an open
+  item. It folds as a structurally marked annotation; ordinary note text
+  never implies ownership. At the serving seam the daemon joins that
+  session against the live supervisor registry. While it remains live, a
+  pending approval card says the item is in progress and asks the owner to
+  confirm before starting the proposed session too. The warning is
+  advisory: it prevents accidental duplicate work without taking away the
+  owner's approval lever. A dead session leaves history but no live chip.
 - **Blockers** (`set_blocker` / `clear_blocker`) state a human criterion —
   "api access granted", "waiting on the vendor" — on an open item. **No
   machinery evaluates blockers**: no watchers, no pollers, no condition
@@ -558,6 +568,15 @@ never pending, never planned; approve on it refuses with a re-propose
 pointer). An ordinary re-propose revives the lane either way. Older
 builds skip the unknown op line whole: the proposal stays visible there
 — honest staleness, never a mangled state.
+
+**Completion moots pending review.** If an item is completed while its
+manifest is still unapproved, the `complete` fold performs the same
+view cleanup as withdrawal and appends an attributed thread note saying
+the proposal was mooted by completion. A never-fired proposal disappears
+from the effects view; fired lineage remains marked withdrawn. This is one
+durable completion event, so the lifecycle transition and its consequence
+cannot tear apart. Reopening the item does not silently resurrect the old
+proposal; scheduling again is an explicit fresh proposal.
 
 **Propose-time fireability (2026-07-30): an approvable manifest IS a
 fireable manifest.** One validator (`agenda/fireability.rs`, derived from
@@ -2071,7 +2090,8 @@ tests is the tripwire, not a refactor.
   who-line session ids, answer text on answered questions, UNCLEARED
   blocker criteria, the `part_of`/`relies_on`/`relates_to` edge lists,
   slim refs and effect state (digests included — digest-prefix search
-  keeps resolving), annotation counts, and the serving-seam flags.
+  keeps resolving), annotation counts, structurally active pickup session
+  ids, and the serving-seam flags.
   Bodies and annotation threads never ride it — the inspector fetches
   the item route. Parity with the full DTO is pinned
   (`summary_fields_derive_from_the_full_dto`).

--- a/skills/intendant-agenda/SKILL.md
+++ b/skills/intendant-agenda/SKILL.md
@@ -54,6 +54,7 @@ dashboard, attributed to your session.
 "$INTENDANT" ctl agenda schedule 01KX --goal "Sit with the owner on the release board" --at +1d --interactive   # owner-sitting: fires, opens with the goal, waits for the owner
 "$INTENDANT" ctl agenda withdraw 01KX --reason "superseded by the rewrite"   # take back a PENDING unapproved proposal (yours included); approved = owner's revoke-schedule
 "$INTENDANT" ctl agenda annotate 01KX "Tried the vendor API — still 403; evidence in run 88."
+"$INTENDANT" ctl agenda pickup 01KX   # supervised session: structurally mark live pickup before starting
 "$INTENDANT" ctl agenda attest 01KX --occurrence 98eb14c2... --outcome partial --note "3 of 5 slices landed" --ref file:$HOME/handoff.md   # fired sessions: self-report your occurrence (rider names its id)
 "$INTENDANT" ctl agenda block 01KX "gpt-live-1 available on the API (currently app-only)"
 "$INTENDANT" ctl agenda relies-on 01KX 01KY    # 01KX waits on 01KY (--remove drops the link)
@@ -173,6 +174,15 @@ dashboard, attributed to your session.
   `relies-on` draws a link to a prerequisite item; a completed
   prerequisite satisfies it automatically at read time, a retired one
   flags the dependent for review. `list --blocked` filters the gated set.
+
+- **Picking up parked work**: after choosing an existing open item to
+  handle, run `ctl agenda pickup <id>` before starting. This is a
+  structural item/session link, not prose: while your supervised session
+  is live, the dashboard shows that work is already underway beside any
+  pending Approve action and warns before starting a duplicate scheduled
+  session. Ordinary annotations never imply pickup. Completion keeps the
+  pickup in history, and automatically records an unapproved proposal as
+  mooted instead of leaving a dead Approve solicitation behind.
 
 - **Refs make items handoff units**: `ref` attaches a typed POINTER —
   a file path (digested at attach; the dashboard shows drift honestly),

--- a/src/bin/caller/agenda/handle.rs
+++ b/src/bin/caller/agenda/handle.rs
@@ -200,6 +200,24 @@ impl AgendaHandle {
         cmd: &AgendaCommand,
         actor: Option<&AgendaActor>,
     ) -> Result<(), AgendaError> {
+        if matches!(cmd, AgendaCommand::PickUp { .. }) {
+            let attributed_session = actor.is_some_and(|actor| {
+                actor.kind.as_deref() == Some("agent_session")
+                    && actor
+                        .session_id
+                        .as_deref()
+                        .is_some_and(|id| !id.trim().is_empty())
+            });
+            if attributed_session {
+                return Ok(());
+            }
+            return Err(AgendaError::SessionRequired {
+                verb: "pick_up",
+                actor: actor
+                    .and_then(|actor| actor.kind.clone())
+                    .unwrap_or_else(|| "unattributed".to_string()),
+            });
+        }
         let verb = match cmd {
             AgendaCommand::ApproveEffect { .. } => "approve_effect",
             AgendaCommand::RevokeEffect { .. } => "revoke_effect",
@@ -1184,6 +1202,25 @@ impl AgendaHandle {
         for (item, (causes, completable)) in items.iter_mut().zip(blocked_views) {
             item.blocked_on = causes;
             item.completable = completable;
+        }
+
+        // Structural live pickup decoration. The op records WHO picked
+        // the item up; the supervisor registry answers whether that
+        // session is alive NOW. Lock contention omits the claim for this
+        // read instead of serving a stale ownership bit. Closed items
+        // keep their pickup history but never advertise active work.
+        let live_sessions = crate::session_supervisor::published_live_session_registry()
+            .and_then(|registry| registry.live_wrapper_ids());
+        for item in items {
+            for note in &mut item.annotations {
+                note.live = item.status == super::types::AgendaStatus::Open
+                    && note.pickup
+                    && note.session_id.as_ref().is_some_and(|session_id| {
+                        live_sessions
+                            .as_ref()
+                            .is_some_and(|live| live.contains(session_id))
+                    });
+            }
         }
     }
 
@@ -2185,6 +2222,33 @@ mod tests {
             session_id: session.map(str::to_string),
             kind: Some(kind.to_string()),
         })
+    }
+
+    #[test]
+    fn pickup_requires_an_attributed_agent_session() {
+        let cmd = AgendaCommand::PickUp {
+            id: "01PICKUP".into(),
+            source: None,
+        };
+        assert!(AgendaHandle::authorize_command(
+            &cmd,
+            actor("agent_session", Some("sess-live")).as_ref()
+        )
+        .is_ok());
+        for denied in [
+            actor("local_process", None),
+            actor("dashboard", None),
+            actor("agent_session", None),
+            None,
+        ] {
+            assert!(matches!(
+                AgendaHandle::authorize_command(&cmd, denied.as_ref()),
+                Err(AgendaError::SessionRequired {
+                    verb: "pick_up",
+                    ..
+                })
+            ));
+        }
     }
 
     /// The steward rider's mandated proof: an agent session can propose a

--- a/src/bin/caller/agenda/reminders.rs
+++ b/src/bin/caller/agenda/reminders.rs
@@ -4499,6 +4499,8 @@ mod tests {
             session_id: None,
             kind: Some("daemon".into()),
             source: Some(super::super::types::TRIGGER_CONSUMED_SOURCE.into()),
+            pickup: false,
+            live: false,
         };
         let mut q1 = matching_question("q1", 20_000, None);
         q1.annotations.push(consumed_note(&occ(0)));
@@ -4930,6 +4932,8 @@ mod tests {
             session_id: None,
             kind: Some("daemon".into()),
             source: Some("trigger-evaluator".into()),
+            pickup: false,
+            live: false,
         });
         let mut impostor = matching_question("q-impostor", 21_000, None);
         impostor.annotations.push(AgendaAnnotation {
@@ -4939,6 +4943,8 @@ mod tests {
             session_id: Some("whoever".into()),
             kind: Some("agent_session".into()),
             source: Some("trigger-evaluator".into()),
+            pickup: false,
+            live: false,
         });
         let looped = matching_question("q-loop", 22_000, Some("sess-fired"));
 
@@ -5119,6 +5125,8 @@ mod tests {
                 session_id: None,
                 kind: Some("daemon".into()),
                 source: Some("trigger-evaluator".into()),
+                pickup: false,
+                live: false,
             });
             question
         };

--- a/src/bin/caller/agenda/store.rs
+++ b/src/bin/caller/agenda/store.rs
@@ -19,7 +19,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 /// Command intake errors. The gateway maps `NotFound` to 404, the two
-/// rejection variants to 400, `NotPermitted` to 403; `Io` is a
+/// rejection variants to 400, authorization variants to 403; `Io` is a
 /// daemon-side 500.
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum AgendaError {
@@ -36,6 +36,12 @@ pub(crate) enum AgendaError {
          but never approve them — ask the owner to review on the dashboard"
     )]
     NotPermitted { verb: &'static str, actor: String },
+    /// Structural pickup is meaningful only when the gate can attribute
+    /// it to a supervised agent session whose liveness can be joined.
+    #[error(
+        "{verb} requires an attributed live agent session; {actor} actors cannot claim live pickup"
+    )]
+    SessionRequired { verb: &'static str, actor: String },
     #[error("agenda log I/O: {0}")]
     Io(#[from] std::io::Error),
 }
@@ -44,7 +50,7 @@ pub(crate) enum AgendaError {
 /// preserved on disk but skipped at load (forward compatibility: a newer
 /// build's vocabulary — effects, journal curation — must not brick an older
 /// daemon's ledger).
-const KNOWN_OPS: [&str; 27] = [
+const KNOWN_OPS: [&str; 28] = [
     "add",
     "patch",
     "complete",
@@ -54,6 +60,7 @@ const KNOWN_OPS: [&str; 27] = [
     "acknowledge_answer",
     "dismiss",
     "annotate",
+    "pick_up",
     "set_blocker",
     "clear_blocker",
     "add_relies_on",
@@ -1954,6 +1961,21 @@ impl AgendaStore {
                     id,
                     text: text.to_string(),
                 })
+            }
+            AgendaCommand::PickUp { id, source: _ } => {
+                let item = self.require(&id)?;
+                if item.status != AgendaStatus::Open {
+                    return Err(AgendaError::Transition(format!(
+                        "{id} is not open — only open work can be picked up"
+                    )));
+                }
+                if item.annotations.len() >= MAX_ANNOTATIONS_PER_ITEM {
+                    return Err(AgendaError::Invalid(format!(
+                        "item has {MAX_ANNOTATIONS_PER_ITEM} annotations — retire it or start \
+                         a successor item"
+                    )));
+                }
+                Ok(AgendaOp::PickUp { id })
             }
             AgendaCommand::Attest {
                 id,
@@ -5885,6 +5907,112 @@ mod tests {
         let before = store.item(&id).unwrap();
         let mut reopened = AgendaStore::open(dir.path()).unwrap();
         assert_eq!(reopened.item(&id).unwrap(), before);
+    }
+
+    /// Picking up work is a structural op, not an annotation-text
+    /// convention. Repeating it from one session refreshes the single
+    /// folded marker, while the append-only log keeps both acts.
+    #[test]
+    fn pickup_folds_one_structural_marker_per_session() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = AgendaStore::open(dir.path()).unwrap();
+        let id = store
+            .apply_command(add_cmd("picked up work"), owner(), 1000)
+            .unwrap()
+            .id;
+
+        let first = store
+            .apply_command(
+                AgendaCommand::PickUp {
+                    id: id.clone(),
+                    source: None,
+                },
+                session_actor(),
+                1001,
+            )
+            .unwrap();
+        let pickup = first.annotations.last().unwrap();
+        assert!(pickup.pickup);
+        assert!(!pickup.live, "liveness is serving-seam state, never folded");
+        assert_eq!(pickup.session_id.as_deref(), Some("sess-w1"));
+
+        let refreshed = store
+            .apply_command(
+                AgendaCommand::PickUp {
+                    id: id.clone(),
+                    source: None,
+                },
+                session_actor(),
+                1002,
+            )
+            .unwrap();
+        let pickups: Vec<_> = refreshed
+            .annotations
+            .iter()
+            .filter(|note| note.pickup)
+            .collect();
+        assert_eq!(pickups.len(), 1);
+        assert_eq!(pickups[0].at_ms, 1002);
+
+        let page = store
+            .read_ops(0, Some(&id), AGENDA_OPS_DEFAULT_LIMIT)
+            .unwrap();
+        assert_eq!(
+            page.ops
+                .iter()
+                .filter(|entry| entry["op"]["op"]["type"] == "pick_up")
+                .count(),
+            2,
+            "the raw history keeps both pickup acts"
+        );
+    }
+
+    /// Completing an item consumes a still-unapproved proposal in the
+    /// same durable fold event and leaves an attributed explanation in
+    /// the thread. Reopening never resurrects the dead solicitation.
+    #[test]
+    fn completion_moots_a_pending_unapproved_proposal() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut store = AgendaStore::open(dir.path()).unwrap();
+        let _project = with_default_project(&mut store);
+        let id = store
+            .apply_command(add_cmd("live work beat the proposal"), owner(), 1000)
+            .unwrap()
+            .id;
+        store
+            .apply_command(propose_one_shot(&id), session_actor(), 1001)
+            .unwrap();
+
+        let completed = store
+            .apply_command(
+                AgendaCommand::Complete {
+                    id: id.clone(),
+                    source: None,
+                },
+                owner(),
+                1002,
+            )
+            .unwrap();
+        assert_eq!(completed.status, AgendaStatus::Done);
+        assert!(completed.effects.is_empty());
+        let note = completed.annotations.last().unwrap();
+        assert!(note.text.contains("proposal mooted by completion"));
+        assert_eq!(note.principal.as_deref(), Some("owner"));
+
+        let reopened = store
+            .apply_command(
+                AgendaCommand::Reopen {
+                    id: id.clone(),
+                    source: None,
+                },
+                owner(),
+                1003,
+            )
+            .unwrap();
+        assert!(reopened.effects.is_empty());
+
+        let mut replayed = AgendaStore::open(dir.path()).unwrap();
+        assert_eq!(replayed.item(&id).unwrap(), reopened);
     }
 
     /// The approved side is the owner's revoke, never withdraw: the

--- a/src/bin/caller/agenda/summary.rs
+++ b/src/bin/caller/agenda/summary.rs
@@ -166,6 +166,11 @@ pub(crate) struct AgendaItemSummary {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub(crate) refs: Vec<SummaryRef>,
     pub(crate) annotations_count: u32,
+    /// Structurally recorded pickups whose sessions are live at this
+    /// serving read. The full annotation thread stays off the summary;
+    /// this tiny projection is the dashboard's duplicate-work warning.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(crate) active_pickups: Vec<SummaryPickup>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub(crate) effects: Vec<SummaryEffect>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -216,6 +221,12 @@ pub(crate) struct SummaryProvenance {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) source: Option<String>,
     pub(crate) created_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct SummaryPickup {
+    pub(crate) session_id: String,
+    pub(crate) at_ms: u64,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -486,6 +497,17 @@ fn summarize_one(all: &[AgendaItem], item: &AgendaItem, watermark: u64) -> Agend
             })
             .collect(),
         annotations_count: item.annotations.len() as u32,
+        active_pickups: item
+            .annotations
+            .iter()
+            .filter(|note| note.pickup && note.live)
+            .filter_map(|note| {
+                note.session_id.as_ref().map(|session_id| SummaryPickup {
+                    session_id: session_id.clone(),
+                    at_ms: note.at_ms,
+                })
+            })
+            .collect(),
         effects: item
             .effects
             .iter()
@@ -1090,6 +1112,39 @@ mod tests {
         let ask = resolved[0].ask.as_ref().expect("ask history marker");
         assert!(ask.questions.is_none(), "resolved ask slims to the count");
         assert_eq!(ask.questions_count, 1);
+    }
+
+    #[test]
+    fn summary_carries_only_structurally_live_pickups() {
+        let mut item = bare("01PICK", "picked up", AgendaStatus::Open);
+        let pickup = |session_id: &str, live: bool| super::super::types::AgendaAnnotation {
+            text: "picked up live by this session".into(),
+            at_ms: 42,
+            principal: None,
+            session_id: Some(session_id.into()),
+            kind: Some("agent_session".into()),
+            source: None,
+            pickup: true,
+            live,
+        };
+        item.annotations.push(pickup("sess-live", true));
+        item.annotations.push(pickup("sess-ended", false));
+        item.annotations
+            .push(super::super::types::AgendaAnnotation {
+                text: "picked up live (just prose)".into(),
+                at_ms: 43,
+                principal: None,
+                session_id: Some("sess-prose".into()),
+                kind: Some("agent_session".into()),
+                source: None,
+                pickup: false,
+                live: true,
+            });
+
+        let summary = summarize(std::slice::from_ref(&item), std::slice::from_ref(&item));
+        assert_eq!(summary[0].active_pickups.len(), 1);
+        assert_eq!(summary[0].active_pickups[0].session_id, "sess-live");
+        assert_eq!(summary[0].annotations_count, 3);
     }
 
     /// Track AS S6 pin (ruling R-AS5): the serving window is WIRE

--- a/src/bin/caller/agenda/types.rs
+++ b/src/bin/caller/agenda/types.rs
@@ -930,6 +930,17 @@ pub struct AgendaAnnotation {
     pub(crate) kind: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) source: Option<String>,
+    /// Structural pickup marker written only by the dedicated `pick_up`
+    /// op. Ordinary note text never implies ownership. Additive and
+    /// absent-on-the-wire for every historic annotation.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub(crate) pickup: bool,
+    /// Display-only liveness decoration for pickup markers. The fold
+    /// always writes `false`; the serving seam stamps it from the live
+    /// session registry, so session death clears the UI without a
+    /// synthetic ledger write.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub(crate) live: bool,
 }
 
 /// One blocker (F2 fold view): criterion text stated by whoever set it,
@@ -1394,6 +1405,15 @@ pub enum AgendaCommand {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         source: Option<String>,
     },
+    /// Record that this supervised agent session picked up an open item.
+    /// The tenant edge requires an attributed `agent_session`; the fold
+    /// stores a structural annotation so surfaces never infer pickup from
+    /// prose. Liveness is joined at serving time.
+    PickUp {
+        id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        source: Option<String>,
+    },
     /// The fired session's self-report on its occurrence (Track AO): a
     /// second axis beside the transport verdict, accepted only from a
     /// session in the occurrence's started lineage (Rider A —
@@ -1620,6 +1640,11 @@ impl AgendaItem {
                         .and_then(|run| run.session_id.as_deref()),
                 )
             }))
+            .chain(self.annotations.iter().filter_map(|note| {
+                (note.pickup && note.live)
+                    .then_some(note.session_id.as_deref())
+                    .flatten()
+            }))
             .chain(self.refs.iter().filter_map(|r| {
                 (r.ref_type == AgendaRefType::Session).then_some(r.locator.as_str())
             }))
@@ -1667,6 +1692,7 @@ impl AgendaCommand {
             | AgendaCommand::AcknowledgeAnswer { source, .. }
             | AgendaCommand::ProposeEffect { source, .. }
             | AgendaCommand::Annotate { source, .. }
+            | AgendaCommand::PickUp { source, .. }
             | AgendaCommand::Attest { source, .. }
             | AgendaCommand::SetBlocker { source, .. }
             | AgendaCommand::ClearBlocker { source, .. }
@@ -1756,6 +1782,12 @@ pub(crate) enum AgendaOp {
     Annotate {
         id: String,
         text: String,
+    },
+    /// Structural live-session pickup. Attribution rides the envelope;
+    /// older builds preserve-skip the unknown op and therefore show no
+    /// potentially stale ownership claim.
+    PickUp {
+        id: String,
     },
     /// Blocker set (F2): `blocker_id` was minted at intake and is recorded
     /// here — replay never mints.
@@ -1923,6 +1955,7 @@ impl AgendaOp {
             | AgendaOp::AcknowledgeAnswer { id }
             | AgendaOp::Dismiss { id, .. }
             | AgendaOp::Annotate { id, .. }
+            | AgendaOp::PickUp { id }
             | AgendaOp::SetBlocker { id, .. }
             | AgendaOp::ClearBlocker { id, .. }
             | AgendaOp::AddReliesOn { id, .. }
@@ -2049,6 +2082,38 @@ pub(crate) fn apply_op(
                 session_id: actor.session_id,
                 kind: actor.kind,
                 source: rec.source.clone(),
+                pickup: false,
+                live: false,
+            });
+            item.updated_ms = at_ms;
+            None
+        }
+        AgendaOp::PickUp { id } => {
+            let Some(item) = items.get_mut(id) else {
+                return Some(format!("pick_up for unknown {id} ignored"));
+            };
+            if item.status != AgendaStatus::Open {
+                return Some(format!("pick_up on non-open {id} ignored"));
+            }
+            let actor = rec.actor.clone().unwrap_or_default();
+            let Some(session_id) = actor.session_id.clone() else {
+                return Some(format!("pick_up without a session on {id} ignored"));
+            };
+            // One folded marker per session. Re-pickup refreshes its
+            // timestamp without growing the view; the op log retains the
+            // complete history.
+            item.annotations.retain(|note| {
+                !(note.pickup && note.session_id.as_deref() == Some(session_id.as_str()))
+            });
+            item.annotations.push(AgendaAnnotation {
+                text: "picked up live by this session".to_string(),
+                at_ms,
+                principal: actor.principal,
+                session_id: Some(session_id),
+                kind: actor.kind,
+                source: rec.source.clone(),
+                pickup: true,
+                live: false,
             });
             item.updated_ms = at_ms;
             None
@@ -2310,6 +2375,45 @@ pub(crate) fn apply_op(
             };
             match item.status {
                 AgendaStatus::Open => {
+                    // Completion makes an unapproved proposal inert. Fold
+                    // that consequence into the completion itself: the
+                    // item thread names what happened, a never-fired
+                    // proposal leaves the live view, and fired lineage is
+                    // retained with a withdrawal marker. The complete op
+                    // is the durable history event; no second write can be
+                    // torn away from it.
+                    if let Some(pos) = item
+                        .effects
+                        .iter()
+                        .position(|effect| effect.approval.is_none() && effect.withdrawn.is_none())
+                    {
+                        let actor = rec.actor.clone().unwrap_or_default();
+                        let reason = "item completed before the proposal was approved";
+                        item.annotations.push(AgendaAnnotation {
+                            text: format!(
+                                "scheduled-session proposal mooted by completion — {reason}"
+                            ),
+                            at_ms,
+                            principal: actor.principal.clone(),
+                            session_id: actor.session_id.clone(),
+                            kind: actor.kind.clone(),
+                            source: rec.source.clone(),
+                            pickup: false,
+                            live: false,
+                        });
+                        if item.effects[pos].last_run.is_none() {
+                            item.effects.remove(pos);
+                        } else {
+                            item.effects[pos].withdrawn = Some(AgendaWithdrawal {
+                                at_ms,
+                                principal: actor.principal,
+                                session_id: actor.session_id,
+                                kind: actor.kind,
+                                reason: Some(reason.to_string()),
+                            });
+                            item.effects[pos].requested.clear();
+                        }
+                    }
                     item.status = AgendaStatus::Done;
                     item.completed_ms = Some(at_ms);
                     item.updated_ms = at_ms;
@@ -2484,6 +2588,8 @@ pub(crate) fn apply_op(
                 session_id: actor.session_id.clone(),
                 kind: actor.kind.clone(),
                 source: rec.source.clone(),
+                pickup: false,
+                live: false,
             });
             // Fired history is sacred: a lineage that ever ran keeps its
             // entry — manifest, last_run, attestation, streak — as

--- a/src/bin/caller/ctl.rs
+++ b/src/bin/caller/ctl.rs
@@ -2609,6 +2609,7 @@ async fn run_agenda(
             run_agenda_read_page(client, config, &raw[1..], AgendaPageKind::Occurrences).await?
         }
         "complete" | "done" => agenda_transition(client, config, "complete", &raw[1..]).await?,
+        "pickup" | "pick-up" => agenda_transition(client, config, "pick_up", &raw[1..]).await?,
         "acknowledge" | "ack" => {
             agenda_transition(client, config, "acknowledge_answer", &raw[1..]).await?
         }
@@ -6088,6 +6089,7 @@ fn help_agenda() {
   intendant ctl agenda list [--all|--open|--done|--retired] [--blocked] [--json]\n\
   intendant ctl agenda show ID_PREFIX [--json]   # ONE item, full detail — never fetches the ledger\n\
   intendant ctl agenda annotate ID_PREFIX NOTE... [--source LABEL]\n\
+  intendant ctl agenda pickup ID_PREFIX [--source LABEL]   # supervised session: mark this item as actively being handled\n\
   intendant ctl agenda attest ID_PREFIX --occurrence OCC_ID --outcome achieved|partial|blocked|abandoned\n\
       [--note TEXT] [--ref file:PATH]... [--source LABEL]   # fired session's self-report on its occurrence\n\
   intendant ctl agenda block ID_PREFIX CRITERION... [--source LABEL]\n\
@@ -6160,6 +6162,11 @@ as self-described and never becomes attribution; supervised sessions\n\
 are attributed automatically and don't need it.\n\
 \n\
 `annotate` appends an attributed note (any status — the item's thread).\n\
+`pickup` is for a supervised agent session that starts handling an OPEN\n\
+item. It records a structural item/session link (never guessed from note\n\
+text); while that session remains live, pending approval surfaces warn that\n\
+work is already underway. Repeating it from the same session just refreshes\n\
+that session's marker.\n\
 `block` states a human criterion (e.g. \"api access granted\") on an open\n\
 item; NOTHING evaluates it — the owner clears from the dashboard, or\n\
 `unblock` clears by blocker-id prefix (omit the prefix when only one is\n\

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -3572,7 +3572,7 @@ pub(crate) mod tests {
                 owner.clone(),
             )
             .unwrap();
-        handle
+        let proposed = handle
             .apply(
                 crate::agenda::AgendaCommand::ProposeEffect {
                     id: closed.id.clone(),
@@ -3588,6 +3588,15 @@ pub(crate) mod tests {
                     project_root: Some(dir.path().display().to_string()),
                     binding_refs: Vec::new(),
                     source: None,
+                },
+                owner.clone(),
+            )
+            .unwrap();
+        handle
+            .apply(
+                crate::agenda::AgendaCommand::ApproveEffect {
+                    id: closed.id.clone(),
+                    digest: proposed.effects[0].digest.clone(),
                 },
                 owner.clone(),
             )
@@ -3629,7 +3638,7 @@ pub(crate) mod tests {
             .is_empty());
         assert_eq!(body["counts"]["done"], 1);
         // S1: additive seq cursor on the bare tool response too.
-        assert_eq!(body["seq"], 3);
+        assert_eq!(body["seq"], 4);
     }
 
     /// Track AS S7: `agenda_item` resolves exact ids (always win),

--- a/src/bin/caller/mcp/tool_gate.rs
+++ b/src/bin/caller/mcp/tool_gate.rs
@@ -1627,6 +1627,7 @@ mod tests {
                     "clear_blocker",
                     "complete",
                     "patch",
+                    "pick_up",
                     "place",
                     "propose_effect",
                     "remove_part_of",

--- a/src/bin/caller/web_gateway/routes_agenda.rs
+++ b/src/bin/caller/web_gateway/routes_agenda.rs
@@ -1075,7 +1075,7 @@ mod tests {
         let done = agenda
             .apply(add("closed with body", &big_body), owner.clone())
             .unwrap();
-        agenda
+        let proposed = agenda
             .apply(
                 crate::agenda::AgendaCommand::ProposeEffect {
                     id: done.id.clone(),
@@ -1091,6 +1091,15 @@ mod tests {
                     project_root: Some(dir.path().display().to_string()),
                     binding_refs: Vec::new(),
                     source: None,
+                },
+                owner.clone(),
+            )
+            .unwrap();
+        agenda
+            .apply(
+                crate::agenda::AgendaCommand::ApproveEffect {
+                    id: done.id.clone(),
+                    digest: proposed.effects[0].digest.clone(),
                 },
                 owner.clone(),
             )
@@ -1160,9 +1169,9 @@ mod tests {
         assert_eq!(body["counts"]["done"], 1);
         assert_eq!(body["counts"]["retired"], 1);
         // S1: the bare response now also carries the fold's seq cursor —
-        // additive, and exactly the ops route's line count (6 ops here:
-        // three adds, one propose, one complete, one retire).
-        assert_eq!(body["seq"], 6);
+        // additive, and exactly the ops route's line count (7 ops here:
+        // three adds, one propose, one approve, one complete, one retire).
+        assert_eq!(body["seq"], 7);
     }
 
     /// Track AS S2: `since_seq` on the list core (HTTP `?since_seq=` and

--- a/src/bin/caller/web_gateway/routes_agenda.rs
+++ b/src/bin/caller/web_gateway/routes_agenda.rs
@@ -728,7 +728,8 @@ fn agenda_error_status(err: &crate::agenda::AgendaError) -> u16 {
     match err {
         crate::agenda::AgendaError::NotFound(_) => 404,
         crate::agenda::AgendaError::Invalid(_) | crate::agenda::AgendaError::Transition(_) => 400,
-        crate::agenda::AgendaError::NotPermitted { .. } => 403,
+        crate::agenda::AgendaError::NotPermitted { .. }
+        | crate::agenda::AgendaError::SessionRequired { .. } => 403,
         crate::agenda::AgendaError::Io(_) => 500,
     }
 }

--- a/static/app.html
+++ b/static/app.html
@@ -39429,7 +39429,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'fa352ce13cfa950f';
+const INTENDANT_APP_BUILD = 'cb6b9be0234a40d3';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -96620,6 +96620,11 @@ function agendaAdoptFullItem(full) {
   const prior = agendaFindItem(full.id);
   const row = Object.assign({}, full, {
     annotations_count: Array.isArray(full.annotations) ? full.annotations.length : 0,
+    active_pickups: Array.isArray(full.annotations)
+      ? full.annotations
+        .filter((note) => note.pickup === true && note.live === true && note.session_id)
+        .map((note) => ({ session_id: note.session_id, at_ms: note.at_ms }))
+      : [],
     blocked: full.status === 'open'
       && Array.isArray(full.blocked_on) && full.blocked_on.length > 0,
     completable: full.completable === true,
@@ -97053,6 +97058,16 @@ function agendaItemSessionIds(item) {
     if (effect.proposed_session_id) ids.push(effect.proposed_session_id);
     if (effect.last_run && effect.last_run.session_id) ids.push(effect.last_run.session_id);
   });
+  (item.active_pickups || []).forEach((pickup) => {
+    if (pickup.session_id) ids.push(pickup.session_id);
+  });
+  // Full-grain event/detail copies carry the structural marker inside
+  // annotations; summary copies carry the slim active_pickups projection.
+  (item.annotations || []).forEach((note) => {
+    if (note.pickup === true && note.live === true && note.session_id) {
+      ids.push(note.session_id);
+    }
+  });
   return ids;
 }
 
@@ -97073,13 +97088,12 @@ function agendaOnTabShown() {
 }
 
 async function agendaSendOp(params, button) {
-  // Approve-while-blocked (confirm-not-gate): every approve surface —
-  // card strips, inspector, sheet approve-now, missed-reschedule —
-  // funnels through this emitter, so the ONE named confirm lives here.
-  // Cancel sends nothing; accept proceeds — nothing ever refuses.
-  if (params && params.op === 'approve_effect'
-    && !(await agendaApproveBlockedConfirm(params))) {
-    return false;
+  // Approval advisories (live pickup, then blocked bookkeeping): every
+  // approve surface funnels through this emitter. Cancel sends nothing;
+  // accepting the warnings proceeds — neither advisory is a daemon gate.
+  if (params && params.op === 'approve_effect') {
+    if (!(await agendaApproveLivePickupConfirm(params))) return false;
+    if (!(await agendaApproveBlockedConfirm(params))) return false;
   }
   if (button) button.disabled = true;
   try {
@@ -97173,6 +97187,59 @@ function agendaLinkState(link) {
 // contract); a row that has never been summarized wears no flag.
 function agendaItemIsBlocked(item) {
   return item.blocked === true;
+}
+
+// Structural pickup is recorded by the dedicated pick_up op and stamped
+// live by the daemon's supervisor join. Never infer it from annotation
+// text: prose remains prose.
+function agendaActivePickups(item) {
+  if (!item) return [];
+  if (Array.isArray(item.active_pickups) && item.active_pickups.length) {
+    return item.active_pickups;
+  }
+  return Array.isArray(item.annotations)
+    ? item.annotations
+      .filter((note) => note.pickup === true && note.live === true && note.session_id)
+      .map((note) => ({ session_id: note.session_id, at_ms: note.at_ms }))
+    : [];
+}
+
+function agendaPickupLabel(pickup) {
+  const session = pickup && agendaSessionInfo(pickup.session_id);
+  return session && session.name
+    ? `“${session.name}”`
+    : `session ${String((pickup && pickup.session_id) || '').slice(0, 8)}`;
+}
+
+function agendaLivePickupChipHtml(item) {
+  const pickups = agendaActivePickups(item);
+  if (!pickups.length) return '';
+  const first = agendaPickupLabel(pickups[0]);
+  const more = pickups.length > 1 ? ` +${pickups.length - 1}` : '';
+  return agendaChipHtml(`in progress · ${first}${more}`, 'iris',
+    'A supervised session structurally picked up this item and is still live. Approving would start another worker; the owner can still proceed after a warning.');
+}
+
+// Duplicate-work warning, not an authority gate: the owner remains able
+// to approve, but must see the live pickup and make that choice explicitly.
+async function agendaApproveLivePickupConfirm(params) {
+  const item = agendaFindItem(params.id)
+    || (typeof agendaFullItemFor === 'function' ? agendaFullItemFor(params.id) : null);
+  const pickups = agendaActivePickups(item);
+  if (!pickups.length) return true;
+  const names = pickups.slice(0, 2).map(agendaPickupLabel).join(' and ');
+  const more = pickups.length > 2 ? ` and ${pickups.length - 2} more` : '';
+  const message = `${names}${more} already picked up this item and is still live. Approve another session anyway?`;
+  if (typeof showDashboardConfirm !== 'function') return window.confirm(message);
+  const choice = await showDashboardConfirm({
+    title: 'Work is already underway',
+    message,
+    warning: 'Approving starts the proposed scheduled session as well. The live pickup is advisory, but continuing may duplicate work.',
+    confirmLabel: 'Approve anyway',
+    cancelLabel: 'Not now',
+    danger: false,
+  });
+  return choice === true;
 }
 
 // Approve-while-blocked (advisory-plus-confirm): ONE named confirm
@@ -100388,6 +100455,7 @@ function agendaCardEffectStrip(item) {
       + (st.rec ? ` · every ${agendaCadenceLabel(st.rec.every_ms)}` : ' · once')
       + (refusal ? ` — not fireable as planned: ${refusal.reason}` : ' — needs your approval');
     actions = agendaEffectRevisionChipHtml(e)
+      + agendaLivePickupChipHtml(item)
       + agendaDigestChipHtml(e.digest, 'Approve binds exactly this manifest revision',
         agendaDigestPulseClass(e.effect_id))
       + (refusal
@@ -101947,6 +102015,7 @@ function agendaInspEffectHtml(item) {
         <span class="ag2-eff-dot"></span>
         <span class="ag2-eff-state">${escapeHtml(stateLabel)}</span>
         <span class="ag2-spacer"></span>
+        ${st.kind === 'pending' ? agendaLivePickupChipHtml(item) : ''}
         ${agendaEffectRevisionChipHtml(e)}
         ${agendaDigestChipHtml(bound ? e.approval.digest : e.digest,
     bound ? 'Your recorded approval covers exactly this manifest revision'
@@ -106670,6 +106739,7 @@ function agendaHoodOpVerb(op, envelope) {
       const source = envelope.source || op.source || '';
       return source ? `annotated · --source ${source}` : 'annotated';
     }
+    case 'pick_up': return 'picked up live';
     case 'set_blocker': return 'blocker set';
     case 'clear_blocker': return 'blocker cleared';
     case 'add_ref': return `ref attached · ${op.ref_type || 'file'}`;
@@ -106699,7 +106769,7 @@ function agendaHoodOpDot(op, known) {
   switch (String(op.type || '')) {
     case 'add': case 'reopen': case 'request_occurrence': return 'iris';
     case 'set_blocker': return 'rose';
-    case 'clear_blocker': case 'approve_effect': case 'answer': case 'acknowledge_answer': case 'complete': return 'green';
+    case 'clear_blocker': case 'approve_effect': case 'answer': case 'acknowledge_answer': case 'complete': case 'pick_up': return 'green';
     case 'add_ref': case 'remove_ref': case 'record_ask_delivery': return 'sky';
     case 'propose_effect': case 'revoke_effect': case 'withdraw_effect': return 'amber';
     case 'record_occurrence':

--- a/static/app/ui2-agenda-cards.js
+++ b/static/app/ui2-agenda-cards.js
@@ -1094,6 +1094,7 @@ function agendaCardEffectStrip(item) {
       + (st.rec ? ` · every ${agendaCadenceLabel(st.rec.every_ms)}` : ' · once')
       + (refusal ? ` — not fireable as planned: ${refusal.reason}` : ' — needs your approval');
     actions = agendaEffectRevisionChipHtml(e)
+      + agendaLivePickupChipHtml(item)
       + agendaDigestChipHtml(e.digest, 'Approve binds exactly this manifest revision',
         agendaDigestPulseClass(e.effect_id))
       + (refusal

--- a/static/app/ui2-agenda-hood.js
+++ b/static/app/ui2-agenda-hood.js
@@ -361,6 +361,7 @@ function agendaHoodOpVerb(op, envelope) {
       const source = envelope.source || op.source || '';
       return source ? `annotated · --source ${source}` : 'annotated';
     }
+    case 'pick_up': return 'picked up live';
     case 'set_blocker': return 'blocker set';
     case 'clear_blocker': return 'blocker cleared';
     case 'add_ref': return `ref attached · ${op.ref_type || 'file'}`;
@@ -390,7 +391,7 @@ function agendaHoodOpDot(op, known) {
   switch (String(op.type || '')) {
     case 'add': case 'reopen': case 'request_occurrence': return 'iris';
     case 'set_blocker': return 'rose';
-    case 'clear_blocker': case 'approve_effect': case 'answer': case 'acknowledge_answer': case 'complete': return 'green';
+    case 'clear_blocker': case 'approve_effect': case 'answer': case 'acknowledge_answer': case 'complete': case 'pick_up': return 'green';
     case 'add_ref': case 'remove_ref': case 'record_ask_delivery': return 'sky';
     case 'propose_effect': case 'revoke_effect': case 'withdraw_effect': return 'amber';
     case 'record_occurrence':

--- a/static/app/ui2-agenda-inspector.js
+++ b/static/app/ui2-agenda-inspector.js
@@ -636,6 +636,7 @@ function agendaInspEffectHtml(item) {
         <span class="ag2-eff-dot"></span>
         <span class="ag2-eff-state">${escapeHtml(stateLabel)}</span>
         <span class="ag2-spacer"></span>
+        ${st.kind === 'pending' ? agendaLivePickupChipHtml(item) : ''}
         ${agendaEffectRevisionChipHtml(e)}
         ${agendaDigestChipHtml(bound ? e.approval.digest : e.digest,
     bound ? 'Your recorded approval covers exactly this manifest revision'

--- a/static/app/ui2-agenda.js
+++ b/static/app/ui2-agenda.js
@@ -269,6 +269,11 @@ function agendaAdoptFullItem(full) {
   const prior = agendaFindItem(full.id);
   const row = Object.assign({}, full, {
     annotations_count: Array.isArray(full.annotations) ? full.annotations.length : 0,
+    active_pickups: Array.isArray(full.annotations)
+      ? full.annotations
+        .filter((note) => note.pickup === true && note.live === true && note.session_id)
+        .map((note) => ({ session_id: note.session_id, at_ms: note.at_ms }))
+      : [],
     blocked: full.status === 'open'
       && Array.isArray(full.blocked_on) && full.blocked_on.length > 0,
     completable: full.completable === true,
@@ -702,6 +707,16 @@ function agendaItemSessionIds(item) {
     if (effect.proposed_session_id) ids.push(effect.proposed_session_id);
     if (effect.last_run && effect.last_run.session_id) ids.push(effect.last_run.session_id);
   });
+  (item.active_pickups || []).forEach((pickup) => {
+    if (pickup.session_id) ids.push(pickup.session_id);
+  });
+  // Full-grain event/detail copies carry the structural marker inside
+  // annotations; summary copies carry the slim active_pickups projection.
+  (item.annotations || []).forEach((note) => {
+    if (note.pickup === true && note.live === true && note.session_id) {
+      ids.push(note.session_id);
+    }
+  });
   return ids;
 }
 
@@ -722,13 +737,12 @@ function agendaOnTabShown() {
 }
 
 async function agendaSendOp(params, button) {
-  // Approve-while-blocked (confirm-not-gate): every approve surface —
-  // card strips, inspector, sheet approve-now, missed-reschedule —
-  // funnels through this emitter, so the ONE named confirm lives here.
-  // Cancel sends nothing; accept proceeds — nothing ever refuses.
-  if (params && params.op === 'approve_effect'
-    && !(await agendaApproveBlockedConfirm(params))) {
-    return false;
+  // Approval advisories (live pickup, then blocked bookkeeping): every
+  // approve surface funnels through this emitter. Cancel sends nothing;
+  // accepting the warnings proceeds — neither advisory is a daemon gate.
+  if (params && params.op === 'approve_effect') {
+    if (!(await agendaApproveLivePickupConfirm(params))) return false;
+    if (!(await agendaApproveBlockedConfirm(params))) return false;
   }
   if (button) button.disabled = true;
   try {
@@ -822,6 +836,59 @@ function agendaLinkState(link) {
 // contract); a row that has never been summarized wears no flag.
 function agendaItemIsBlocked(item) {
   return item.blocked === true;
+}
+
+// Structural pickup is recorded by the dedicated pick_up op and stamped
+// live by the daemon's supervisor join. Never infer it from annotation
+// text: prose remains prose.
+function agendaActivePickups(item) {
+  if (!item) return [];
+  if (Array.isArray(item.active_pickups) && item.active_pickups.length) {
+    return item.active_pickups;
+  }
+  return Array.isArray(item.annotations)
+    ? item.annotations
+      .filter((note) => note.pickup === true && note.live === true && note.session_id)
+      .map((note) => ({ session_id: note.session_id, at_ms: note.at_ms }))
+    : [];
+}
+
+function agendaPickupLabel(pickup) {
+  const session = pickup && agendaSessionInfo(pickup.session_id);
+  return session && session.name
+    ? `“${session.name}”`
+    : `session ${String((pickup && pickup.session_id) || '').slice(0, 8)}`;
+}
+
+function agendaLivePickupChipHtml(item) {
+  const pickups = agendaActivePickups(item);
+  if (!pickups.length) return '';
+  const first = agendaPickupLabel(pickups[0]);
+  const more = pickups.length > 1 ? ` +${pickups.length - 1}` : '';
+  return agendaChipHtml(`in progress · ${first}${more}`, 'iris',
+    'A supervised session structurally picked up this item and is still live. Approving would start another worker; the owner can still proceed after a warning.');
+}
+
+// Duplicate-work warning, not an authority gate: the owner remains able
+// to approve, but must see the live pickup and make that choice explicitly.
+async function agendaApproveLivePickupConfirm(params) {
+  const item = agendaFindItem(params.id)
+    || (typeof agendaFullItemFor === 'function' ? agendaFullItemFor(params.id) : null);
+  const pickups = agendaActivePickups(item);
+  if (!pickups.length) return true;
+  const names = pickups.slice(0, 2).map(agendaPickupLabel).join(' and ');
+  const more = pickups.length > 2 ? ` and ${pickups.length - 2} more` : '';
+  const message = `${names}${more} already picked up this item and is still live. Approve another session anyway?`;
+  if (typeof showDashboardConfirm !== 'function') return window.confirm(message);
+  const choice = await showDashboardConfirm({
+    title: 'Work is already underway',
+    message,
+    warning: 'Approving starts the proposed scheduled session as well. The live pickup is advisory, but continuing may duplicate work.',
+    confirmLabel: 'Approve anyway',
+    cancelLabel: 'Not now',
+    danger: false,
+  });
+  return choice === true;
 }
 
 // Approve-while-blocked (advisory-plus-confirm): ONE named confirm


### PR DESCRIPTION
Summary:
- add a structural session-attributed pickup operation and live dashboard marker
- warn before approving a duplicate scheduled worker while pickup is live
- moot pending unapproved proposals during completion with an attributed history note
- update CLI, skill, docs, summary serving shape, and generated dashboard

Validation:
- seven focused agenda/store/summary/authorization tests
- JavaScript syntax checks
- dashboard assembler up-to-date
- cargo fmt --check
- git diff --check