### PR TITLE
fix(core): declare Tokio macros feature

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -398,6 +398,13 @@ jobs:
       # instances PLUS the interactive agents — stacked full-suite runs
       # starved the label queue at ~55-minute waits). Push-to-main runs
       # are gone entirely (2026-07-10, the `on:` comment).
+      # Keep this as a standalone, non-test invocation: sibling packages and
+      # intendant-core's dev-dependencies enable extra Tokio features, which
+      # would hide a missing feature on the crate's direct dependency.
+      - name: cargo check (intendant-core standalone)
+        if: runner.os == 'Linux' && steps.relevance_unix.outputs.relevant != 'false' && steps.relevance_win.outputs.relevant != 'false'
+        run: cargo check -p intendant-core --lib --locked --target ${{ matrix.target }}
+
       - name: cargo check (fast path)
         if: github.event_name != 'merge_group' && runner.os != 'Linux' && steps.relevance_unix.outputs.relevant != 'false' && steps.relevance_win.outputs.relevant != 'false'
         run: |

--- a/crates/intendant-core/Cargo.toml
+++ b/crates/intendant-core/Cargo.toml
@@ -15,7 +15,9 @@ schemars = "1"
 dirs = "6"
 serde_json = "1.0"
 socket2 = "0.6"
-tokio = { version = "1.0", features = ["io-util", "net", "sync", "time"] }
+# net.rs uses select! in non-test code; keep macros direct instead of
+# relying on workspace or dev-dependency feature unification.
+tokio = { version = "1.0", features = ["io-util", "macros", "net", "sync", "time"] }
 # CallerError carries reqwest::Error in its Http variant; feature set
 # mirrors the caller's so workspace feature unification stays a no-op.
 reqwest = { version = "0.12", features = ["json", "rustls-tls", "stream", "multipart"], default-features = false }


### PR DESCRIPTION
## Summary
- declare Tokio macros as a direct intendant-core dependency feature
- add a standalone Linux CI check that prevents workspace or dev-dependency feature unification from masking missing direct features

## Validation
- cargo check -p intendant-core --lib --locked
- cargo test -p intendant-core --lib --locked (232 passed)
- actionlint .github/workflows/windows.yml
- git diff --check