### PR TITLE
refactor(core): remove reqwest dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2991,7 +2991,6 @@ dependencies = [
  "dirs",
  "if-addrs",
  "presence-core",
- "reqwest",
  "schemars",
  "serde",
  "serde_json",

--- a/crates/intendant-core/Cargo.toml
+++ b/crates/intendant-core/Cargo.toml
@@ -18,9 +18,6 @@ socket2 = "0.6"
 # net.rs uses select! in non-test code; keep macros direct instead of
 # relying on workspace or dev-dependency feature unification.
 tokio = { version = "1.0", features = ["io-util", "macros", "net", "sync", "time"] }
-# CallerError carries reqwest::Error in its Http variant; feature set
-# mirrors the caller's so workspace feature unification stays a no-op.
-reqwest = { version = "0.12", features = ["json", "rustls-tls", "stream", "multipart"], default-features = false }
 # Safe cross-platform local network-interface enumeration.
 if-addrs = "0.15"
 

--- a/crates/intendant-core/src/error.rs
+++ b/crates/intendant-core/src/error.rs
@@ -13,7 +13,10 @@ pub enum CallerError {
     SubAgent(String),
     Io(std::io::Error),
     Json(serde_json::Error),
-    Http(reqwest::Error),
+    /// An HTTP-layer failure rendered at the networking boundary. Keeping
+    /// the message instead of a concrete client error lets this shared core
+    /// stay independent of any HTTP/TLS stack.
+    Http(String),
     Config(String),
     /// No usable model credential anywhere: no active lease, no browser
     /// relay, no key in the process environment or any searched `.env`.
@@ -48,6 +51,12 @@ impl fmt::Display for CallerError {
 }
 
 impl CallerError {
+    /// Preserve an HTTP client's user-facing error text without making the
+    /// core crate depend on that client's concrete error type.
+    pub fn http(error: impl fmt::Display) -> Self {
+        Self::Http(error.to_string())
+    }
+
     /// Structured class for session-end events (`error_kind` on
     /// SessionEnded): lets UIs attach an action without parsing Display
     /// prose. None for errors with no dedicated surface affordance.
@@ -70,12 +79,6 @@ impl From<std::io::Error> for CallerError {
 impl From<serde_json::Error> for CallerError {
     fn from(e: serde_json::Error) -> Self {
         CallerError::Json(e)
-    }
-}
-
-impl From<reqwest::Error> for CallerError {
-    fn from(e: reqwest::Error) -> Self {
-        CallerError::Http(e)
     }
 }
 
@@ -160,6 +163,16 @@ mod tests {
         match caller_err {
             CallerError::Json(_) => {}
             _ => panic!("expected Json variant"),
+        }
+    }
+
+    #[test]
+    fn http_error_preserves_the_transport_message() {
+        let err = CallerError::http("connection reset");
+        assert_eq!(format!("{}", err), "HTTP error: connection reset");
+        match err {
+            CallerError::Http(message) => assert_eq!(message, "connection reset"),
+            _ => panic!("expected Http variant"),
         }
     }
 

--- a/crates/intendant-core/tests/dependency_boundaries.rs
+++ b/crates/intendant-core/tests/dependency_boundaries.rs
@@ -1,0 +1,14 @@
+#[test]
+fn core_manifest_does_not_depend_on_an_http_client() {
+    let manifest: toml::Value =
+        toml::from_str(include_str!("../Cargo.toml")).expect("intendant-core Cargo.toml parses");
+    let dependencies = manifest
+        .get("dependencies")
+        .and_then(toml::Value::as_table)
+        .expect("intendant-core has a dependencies table");
+
+    assert!(
+        !dependencies.contains_key("reqwest"),
+        "intendant-core is shared by non-networking leaf crates; HTTP clients belong in their consumers"
+    );
+}

--- a/src/bin/caller/provider/mod.rs
+++ b/src/bin/caller/provider/mod.rs
@@ -65,8 +65,8 @@ async fn send_with_retry(
             // consumed. Timeouts are excluded: each attempt already waited
             // the full request timeout, so backoff-retrying them multiplies
             // a hung endpoint into `timeout × (retries+1)` of wall clock.
-            Err(e) if !e.is_timeout() => last_err = Some(CallerError::Http(e)),
-            Err(e) => return Err(CallerError::Http(e)),
+            Err(e) if !e.is_timeout() => last_err = Some(CallerError::http(e)),
+            Err(e) => return Err(CallerError::http(e)),
         }
         if attempt < max_retries {
             tokio::time::sleep(backoff_delay(attempt)).await;
@@ -452,7 +452,9 @@ impl ProviderHttpResponse {
 
     async fn json<T: serde::de::DeserializeOwned>(self) -> Result<T, CallerError> {
         match self {
-            ProviderHttpResponse::Direct(response) => Ok(response.json().await?),
+            ProviderHttpResponse::Direct(response) => {
+                response.json().await.map_err(CallerError::http)
+            }
             ProviderHttpResponse::Egress(response) => {
                 let body = response.body_text().await.map_err(CallerError::Provider)?;
                 serde_json::from_str(&body).map_err(CallerError::Json)

--- a/src/bin/caller/provider/openai.rs
+++ b/src/bin/caller/provider/openai.rs
@@ -543,7 +543,8 @@ impl ChatProvider for OpenAIProvider {
         // Parse the body once; the typed view and the raw echo-back items
         // both project from the same DOM (this used to re-tokenize the
         // full body a second time).
-        let body: serde_json::Value = serde_json::from_str(&response.text().await?)?;
+        let body: serde_json::Value =
+            serde_json::from_str(&response.text().await.map_err(CallerError::http)?)?;
         // Capture raw output items for verbatim echo-back (reasoning + function_call items)
         let raw_output = body.get("output").and_then(|o| o.as_array()).cloned();
         let resp: OpenAIResponsesResponse = serde_json::from_value(body)?;

--- a/src/bin/caller/transcription.rs
+++ b/src/bin/caller/transcription.rs
@@ -153,7 +153,8 @@ impl Transcriber for WhisperTranscriber {
             .header("Authorization", format!("Bearer {}", self.api_key))
             .multipart(form)
             .send()
-            .await?;
+            .await
+            .map_err(CallerError::http)?;
 
         if !resp.status().is_success() {
             let status = resp.status();
@@ -165,7 +166,7 @@ impl Transcriber for WhisperTranscriber {
             )));
         }
 
-        let wr: WhisperResponse = resp.json().await?;
+        let wr: WhisperResponse = resp.json().await.map_err(CallerError::http)?;
         if std::env::var("RUST_LOG").is_ok() {
             eprintln!(
                 "transcription: text={:?} language={:?} duration={:?}",


### PR DESCRIPTION
## Summary

- keep `CallerError` HTTP failures transport-neutral inside `intendant-core`
- translate concrete `reqwest::Error` values at the caller's networking boundaries
- remove the core crate's normal `reqwest` dependency and pin that boundary with a manifest regression test

This keeps the existing `HTTP error: ...` display shape while preventing non-networking leaf crates from inheriting the HTTP/TLS stack through the shared core.

## Validation

- `cargo test -p intendant-core --lib error::tests::http_error_preserves_the_transport_message --locked`
- `cargo test -p intendant-core --test dependency_boundaries --locked`
- `cargo tree -p intendant-core --edges normal --prefix none` contains no `reqwest`
- inverse dependency checks confirm `intendant-display` and `intendant-platform` no longer reach `reqwest`
- `cargo fmt --all -- --check`
- `git diff --check`

Full cross-platform workspace validation is delegated to PR and merge-queue CI.
