### PR TITLE
docs(agenda): teach schedule timestamp precision

### DIFF
--- a/skills/intendant-agenda/SKILL.md
+++ b/skills/intendant-agenda/SKILL.md
@@ -105,7 +105,12 @@ dashboard, attributed to your session.
   `--goal` as its task (never raw actions; add `--orchestrate` for the
   orchestration shape, `--interactive` for the owner-sitting shape —
   the fired session opens with the goal as the owner's message and
-  waits for them). **Nothing fires until the owner approves the
+  waits for them). The local wall-clock form is minute-precision only
+  (`YYYY-MM-DD HH:MM` or `YYYY-MM-DDTHH:MM`); a seconds-bearing local
+  form is refused. Scripts should prefer relative `+Nm` forms, or use
+  RFC3339/epoch milliseconds when they need an exact absolute instant,
+  so computed seconds cannot abort a scheduling batch. **Nothing fires
+  until the owner approves the
   manifest**, so propose and move on; the item badges the owner's
   attention rail. Approval is the owner's act alone (dashboard or an
   owner shell) — you may propose, but never attempt `approve` or

--- a/src/bin/caller/builtin_skills.rs
+++ b/src/bin/caller/builtin_skills.rs
@@ -251,7 +251,6 @@ mod tests {
             );
         }
 
-        assert!(crate::ctl::parse_due_ms("2026-08-04 23:45").is_ok());
         assert!(crate::ctl::parse_due_ms("2026-08-04 23:45:41").is_err());
         assert!(crate::ctl::parse_due_ms("2026-08-04T23:45:41-04:00").is_ok());
     }

--- a/src/bin/caller/builtin_skills.rs
+++ b/src/bin/caller/builtin_skills.rs
@@ -231,4 +231,28 @@ mod tests {
             }
         }
     }
+
+    /// `ctl agenda schedule --at` accepts minute-precision local wall
+    /// clocks, while seconds require an offset-bearing RFC3339 instant.
+    /// Keep the shipped agenda skill aligned with that parser boundary so a
+    /// generated local timestamp cannot silently abort a scheduling batch.
+    #[test]
+    fn agenda_skill_teaches_schedule_time_precision() {
+        let agenda = embedded("intendant-agenda");
+        for needle in [
+            "minute-precision only",
+            "`YYYY-MM-DD HH:MM`",
+            "relative `+Nm` forms",
+            "RFC3339/epoch milliseconds",
+        ] {
+            assert!(
+                agenda.skill_md.contains(needle),
+                "intendant-agenda lost its schedule-time teaching {needle:?}"
+            );
+        }
+
+        assert!(crate::ctl::parse_due_ms("2026-08-04 23:45").is_ok());
+        assert!(crate::ctl::parse_due_ms("2026-08-04 23:45:41").is_err());
+        assert!(crate::ctl::parse_due_ms("2026-08-04T23:45:41-04:00").is_ok());
+    }
 }


### PR DESCRIPTION
## Summary
- document the minute-only local wall-clock form for agenda scheduling
- recommend relative, RFC3339, or epoch forms when scripts compute finer timestamps
- pin the shipped skill against the parser boundary

## Validation
- skill structure inspected; the generic Codex validator rejects the pre-existing Intendant-specific compatibility key
- cargo fmt --all -- --check
- git diff --check
- remote Rust validation pending

Agenda: 01KZDRPM8NQ064XZEP2KR244XS