### PR TITLE
fix(agenda): cold-read budget + dataless retry; sessions join off the reactor

### DIFF
--- a/src/bin/caller/web_gateway/routes_agenda.rs
+++ b/src/bin/caller/web_gateway/routes_agenda.rs
@@ -48,7 +48,11 @@ pub(crate) async fn agenda_list_api_response(
     // in-process consumer stay whole (ruling R-AS5).
     let next_page = crate::agenda::apply_window(&mut served, window, page, crate::agenda::now_ms())
         .map(|(before, before_id)| serde_json::json!({ "before": before, "before_id": before_id }));
-    let sessions = agenda_sessions_join(&crate::platform::home_dir(), &served);
+    let sessions = agenda_sessions_join_blocking(
+        crate::platform::home_dir(),
+        agenda_referenced_session_ids(&served),
+    )
+    .await;
     // Tier-1 PR state for the anchors this snapshot serves — the same
     // sibling discipline as `sessions`: keyed by the anchors' url-ref
     // locators, memory-only (the scanner's poll fetched it, not this
@@ -130,10 +134,11 @@ pub(crate) async fn agenda_item_api_response(
     };
     match agenda.resolve_prefix(item_id) {
         crate::agenda::AgendaPrefixResolution::One(item) => {
-            let sessions = agenda_sessions_join(
-                &crate::platform::home_dir(),
-                std::slice::from_ref(item.as_ref()),
-            );
+            let sessions = agenda_sessions_join_blocking(
+                crate::platform::home_dir(),
+                agenda_referenced_session_ids(std::slice::from_ref(item.as_ref())),
+            )
+            .await;
             let pull_requests = crate::github_pr::join::tier1()
                 .for_locators(item.refs.iter().map(|r| r.locator.as_str()));
             let mut body = serde_json::json!({
@@ -263,18 +268,63 @@ fn agenda_sessions_join(
     home: &std::path::Path,
     items: &[crate::agenda::AgendaItem],
 ) -> serde_json::Map<String, serde_json::Value> {
-    let mut out = serde_json::Map::new();
+    agenda_sessions_join_ids(home, &agenda_referenced_session_ids(items))
+}
+
+/// The join's input grain: every distinct non-empty session id the
+/// items reference, in first-mention order — cheap to collect on the
+/// async path, so the file-IO half below can move to a blocking thread
+/// without borrowing the served set.
+fn agenda_referenced_session_ids(items: &[crate::agenda::AgendaItem]) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    let mut out = Vec::new();
     for item in items {
         for recorded_id in item.referenced_session_ids() {
-            if recorded_id.is_empty() || out.contains_key(recorded_id) {
+            if recorded_id.is_empty() || !seen.insert(recorded_id.to_string()) {
                 continue;
             }
-            if let Some(entry) = agenda_session_join_entry(home, recorded_id) {
-                out.insert(recorded_id.to_string(), entry);
-            }
+            out.push(recorded_id.to_string());
         }
     }
     out
+}
+
+fn agenda_sessions_join_ids(
+    home: &std::path::Path,
+    ids: &[String],
+) -> serde_json::Map<String, serde_json::Value> {
+    let mut out = serde_json::Map::new();
+    for recorded_id in ids {
+        if out.contains_key(recorded_id) {
+            continue;
+        }
+        if let Some(entry) = agenda_session_join_entry(home, recorded_id) {
+            out.insert(recorded_id.to_string(), entry);
+        }
+    }
+    out
+}
+
+/// The sessions join on a blocking thread: per-id resolution pays real
+/// file IO (`session_meta.json` reads, wrapper-index lookups, logs-root
+/// scans on misses — 13s measured cold on a 350-open-item box), and the
+/// list/detail handlers run on tokio reactor threads. A failed join
+/// task degrades to "nothing resolved" — the join is a render
+/// convenience, never worth failing the request over.
+async fn agenda_sessions_join_blocking(
+    home: std::path::PathBuf,
+    ids: Vec<String>,
+) -> serde_json::Map<String, serde_json::Value> {
+    if ids.is_empty() {
+        return serde_json::Map::new();
+    }
+    match tokio::task::spawn_blocking(move || agenda_sessions_join_ids(&home, &ids)).await {
+        Ok(map) => map,
+        Err(e) => {
+            eprintln!("[agenda] sessions join task failed: {e}");
+            serde_json::Map::new()
+        }
+    }
 }
 
 /// The session-join resolution cache (Track AS S8, ruling Q10): the

--- a/src/bin/caller/web_gateway/routes_agenda.rs
+++ b/src/bin/caller/web_gateway/routes_agenda.rs
@@ -264,6 +264,11 @@ pub(crate) async fn handle_agenda_pr_state(
 /// wrapper index to its backend conversation even when superseded; a
 /// dangling id (log dir gone, index pruned) simply has no entry, and every
 /// surface degrades to the raw id.
+/// The item-walk + resolve composition. Production lanes call the two
+/// halves separately (ids collected on the async path, resolution on a
+/// blocking thread via [`agenda_sessions_join_blocking`]); tests join
+/// in one hop.
+#[cfg(test)]
 fn agenda_sessions_join(
     home: &std::path::Path,
     items: &[crate::agenda::AgendaItem],

--- a/static/app.html
+++ b/static/app.html
@@ -39429,7 +39429,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '6e5493ba984a654f';
+const INTENDANT_APP_BUILD = '04ddfd99177d54b9';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -96372,6 +96372,13 @@ let agendaCounts = { open: 0, done: 0, retired: 0 };
 let agendaSkippedLines = 0;
 let agendaFetchInFlight = null;
 let agendaLoadError = '';
+// Bounded in-place retry for a first load that failed with NOTHING on
+// screen (the daemon's cold session-join can outlive even the widened
+// client budget once; its server-side work continues past the abort and
+// warms the cache, so a short-delay retry lands in milliseconds). Data
+// on screen never triggers this — the heal lane owns staleness.
+let agendaRetryTimer = null;
+let agendaRetryAttempts = 0;
 // Track AS S3 — the resume cursor: the daemon's op-log line seq as of
 // the last full fetch, advanced by each `agenda_changed` (which carries
 // its producing op's seq) and by each heal. null until a response
@@ -96514,8 +96521,30 @@ const agendaQaSel = {};
 const agendaQaDrafts = {};
 const agendaQaNotes = {};
 
+function agendaCancelRetry() {
+  if (agendaRetryTimer) {
+    clearTimeout(agendaRetryTimer);
+    agendaRetryTimer = null;
+  }
+}
+
+// A dataless failed load retries itself twice (4s, then 12s) instead of
+// sitting on the error until the user clicks away and back — the cold
+// daemon keeps warming behind the failed request, so the retry is cheap.
+function agendaArmRetry() {
+  if (agendaItems !== null) return;
+  if (agendaRetryTimer || agendaRetryAttempts >= 2) return;
+  const delayMs = agendaRetryAttempts === 0 ? 4000 : 12000;
+  agendaRetryAttempts += 1;
+  agendaRetryTimer = setTimeout(() => {
+    agendaRetryTimer = null;
+    if (agendaItems === null && !agendaFetchInFlight) agendaRefresh();
+  }, delayMs);
+}
+
 async function agendaRefresh() {
   if (agendaFetchInFlight) return agendaFetchInFlight;
+  agendaCancelRetry();
   agendaFetchInFlight = (async () => {
     try {
       // Track AS S5: the list feed is SUMMARIES (titles, chips, edges,
@@ -96533,13 +96562,16 @@ async function agendaRefresh() {
         agendaSessionLookupsAttempted = new Set(
           agendaItems.flatMap(agendaItemSessionIds));
         agendaLoadError = '';
+        agendaRetryAttempts = 0;
         agendaLastFullPullAt = Date.now();
         agendaAnnounceParkedAsks();
       } else {
         agendaLoadError = (resp.body && resp.body.error) || `agenda unavailable (${resp.status})`;
+        agendaArmRetry();
       }
     } catch (e) {
       agendaLoadError = String(e && e.message || e);
+      agendaArmRetry();
     } finally {
       agendaFetchInFlight = null;
     }
@@ -118512,6 +118544,22 @@ function dashboardControlRequestTimeoutMs(method) {
     // daemon -> the relaying browser -> the provider's API -> back. Same
     // budget as the peer round trips above.
     case 'api_credential_egress_probe':
+      return 30000;
+    // Plane reads whose FIRST hit after a daemon restart folds or scans
+    // cold state: the agenda list's session join pays per-unresolved-id
+    // logs-root scans (13s measured live on a 350-open-item box before
+    // its cache warms — the generic 5s default rendered the pane's
+    // sticky "Fetch is aborted"), and the Memory/Access pane bootstraps
+    // share the cold-open class (owner-verified 2026-07-29). Warm reads
+    // answer in milliseconds, so the wide budget is only ever felt on
+    // the one cold hit.
+    case 'api_agenda_list':
+    case 'api_agenda_item':
+    case 'api_agenda_ops':
+    case 'api_agenda_occurrences':
+    case 'api_memory_search':
+    case 'api_memory_claim':
+    case 'api_access_overview':
       return 30000;
     // The control-msg trio (transport F7): interrupts, session lifecycle,
     // and dashboard actions dispatched while a busy daemon is mid-turn.

--- a/static/app/50-control-transport.js
+++ b/static/app/50-control-transport.js
@@ -1741,6 +1741,22 @@ function dashboardControlRequestTimeoutMs(method) {
     // budget as the peer round trips above.
     case 'api_credential_egress_probe':
       return 30000;
+    // Plane reads whose FIRST hit after a daemon restart folds or scans
+    // cold state: the agenda list's session join pays per-unresolved-id
+    // logs-root scans (13s measured live on a 350-open-item box before
+    // its cache warms — the generic 5s default rendered the pane's
+    // sticky "Fetch is aborted"), and the Memory/Access pane bootstraps
+    // share the cold-open class (owner-verified 2026-07-29). Warm reads
+    // answer in milliseconds, so the wide budget is only ever felt on
+    // the one cold hit.
+    case 'api_agenda_list':
+    case 'api_agenda_item':
+    case 'api_agenda_ops':
+    case 'api_agenda_occurrences':
+    case 'api_memory_search':
+    case 'api_memory_claim':
+    case 'api_access_overview':
+      return 30000;
     // The control-msg trio (transport F7): interrupts, session lifecycle,
     // and dashboard actions dispatched while a busy daemon is mid-turn.
     // The pre-facade call sites asked for 10-15 s and were silently

--- a/static/app/ui2-agenda.js
+++ b/static/app/ui2-agenda.js
@@ -21,6 +21,13 @@ let agendaCounts = { open: 0, done: 0, retired: 0 };
 let agendaSkippedLines = 0;
 let agendaFetchInFlight = null;
 let agendaLoadError = '';
+// Bounded in-place retry for a first load that failed with NOTHING on
+// screen (the daemon's cold session-join can outlive even the widened
+// client budget once; its server-side work continues past the abort and
+// warms the cache, so a short-delay retry lands in milliseconds). Data
+// on screen never triggers this — the heal lane owns staleness.
+let agendaRetryTimer = null;
+let agendaRetryAttempts = 0;
 // Track AS S3 — the resume cursor: the daemon's op-log line seq as of
 // the last full fetch, advanced by each `agenda_changed` (which carries
 // its producing op's seq) and by each heal. null until a response
@@ -163,8 +170,30 @@ const agendaQaSel = {};
 const agendaQaDrafts = {};
 const agendaQaNotes = {};
 
+function agendaCancelRetry() {
+  if (agendaRetryTimer) {
+    clearTimeout(agendaRetryTimer);
+    agendaRetryTimer = null;
+  }
+}
+
+// A dataless failed load retries itself twice (4s, then 12s) instead of
+// sitting on the error until the user clicks away and back — the cold
+// daemon keeps warming behind the failed request, so the retry is cheap.
+function agendaArmRetry() {
+  if (agendaItems !== null) return;
+  if (agendaRetryTimer || agendaRetryAttempts >= 2) return;
+  const delayMs = agendaRetryAttempts === 0 ? 4000 : 12000;
+  agendaRetryAttempts += 1;
+  agendaRetryTimer = setTimeout(() => {
+    agendaRetryTimer = null;
+    if (agendaItems === null && !agendaFetchInFlight) agendaRefresh();
+  }, delayMs);
+}
+
 async function agendaRefresh() {
   if (agendaFetchInFlight) return agendaFetchInFlight;
+  agendaCancelRetry();
   agendaFetchInFlight = (async () => {
     try {
       // Track AS S5: the list feed is SUMMARIES (titles, chips, edges,
@@ -182,13 +211,16 @@ async function agendaRefresh() {
         agendaSessionLookupsAttempted = new Set(
           agendaItems.flatMap(agendaItemSessionIds));
         agendaLoadError = '';
+        agendaRetryAttempts = 0;
         agendaLastFullPullAt = Date.now();
         agendaAnnounceParkedAsks();
       } else {
         agendaLoadError = (resp.body && resp.body.error) || `agenda unavailable (${resp.status})`;
+        agendaArmRetry();
       }
     } catch (e) {
       agendaLoadError = String(e && e.message || e);
+      agendaArmRetry();
     } finally {
       agendaFetchInFlight = null;
     }


### PR DESCRIPTION
Fixes agenda item `01KYNWXVB7` (owner-hit twice): switching to the Agenda pane showed a sticky **"Fetch is aborted"**.

**Root cause, re-verified live on current main before writing code**: the tunnel's per-method timeout table has no agenda row, so the generic 5s default governs `api_agenda_list` — and the pane's FIRST read after a daemon restart pays the cold session join (per-unresolved-id `logs`-root scans behind the Track AS S8 cache). Measured on this box (350 open items): **13.06s cold, ~10–18ms warm**. The 5s abort fires exactly on that first-open-after-restart hit; Safari renders the DOMException as "Fetch is aborted".

Two of the item's three July complaints were already fixed by Track AS (an error no longer clobbers loaded data — it renders a stale banner over last-known data; and tab re-entry refetches when the pane is dataless). This lands the remaining three legs:

1. **Client budget** (`50-control-transport.js`): a 30s cold-plane-read row for the agenda read family (`api_agenda_list`/`item`/`ops`/`occurrences`) plus the Memory/Access pane bootstraps the item's sealed evidence put in the same class (`api_memory_search`, `api_memory_claim`, `api_access_overview`). Warm reads stay milliseconds — the budget is only ever felt on the one cold hit.
2. **Dataless in-place retry** (`ui2-agenda.js`): a load that fails with nothing on screen retries itself twice (4s, then 12s) instead of sitting on the error until the user clicks away and back. The daemon keeps warming behind the aborted request, so the retry lands against warm caches. Data on screen never triggers it — the heal lane owns staleness — and any explicit refresh cancels/supersedes the retry timer.
3. **Sessions join off the reactor** (`routes_agenda.rs`): the join ran synchronously inside the async list/detail handlers, so the 13s cold join stalled a tokio reactor worker — every request and WS frame multiplexed there — not just the agenda response. Ids are collected cheaply on the async path; resolution runs under `spawn_blocking` on both lanes; a failed join task degrades to "nothing resolved", never a failed request.

Deliberately not done: pre-warming the session-join cache at boot (the cold cost is paid once and now happens off-reactor under an adequate budget; boot-time IO for a pane that may never open isn't worth it).

Battery: `cargo fmt --check`, bin type-check, `routes_agenda` unit tests, full `cargo test -p intendant --bins`, lib crates, workspace clippy `-D warnings`, `node --check` on both fragments, app.html regenerated, live cold/warm measurement on the running daemon (13.06s cold, ~10ms warm — the "before" evidence; the fix is validated by the unit battery and the timeout/retry pair sized from that measurement).
