### PR TITLE
fix(display): stall-proof the SCK capture edge — drain-to-newest, deeper queues, coal= metric

### DIFF
--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -899,14 +899,35 @@ pub fn captured_frame_kind(dirty_rects: Option<&[capture::damage::Rect]>) -> Cap
 /// caller can count them — they WERE captured and must show in the
 /// capture rate, or a coalescing window would masquerade as a slow
 /// source.
+///
+/// The surviving frame carries the damage UNION of everything it
+/// superseded: per-frame dirty rects are not cumulative (the tile
+/// bridge accumulates them frame by frame for exactly that reason), so
+/// dropping a coalesced content frame's rects would leave its region
+/// stale in the tile lane until a periodic snapshot. Any unannotated
+/// frame in the run (`None` = damage unknown) poisons the union to
+/// `None` — consumers already treat that as full-frame damage.
 pub fn drain_capture_rx_to_newest(
     rx: &mut mpsc::Receiver<Frame>,
     mut newest: Frame,
 ) -> (Frame, Vec<CapturedFrameKind>) {
     let mut superseded = Vec::new();
+    let mut damage_union = newest.dirty_rects.clone();
+    let mut coalesced_any = false;
     while let Ok(fresher) = rx.try_recv() {
         superseded.push(captured_frame_kind(newest.dirty_rects.as_deref()));
+        damage_union = match (damage_union, fresher.dirty_rects.clone()) {
+            (Some(mut acc), Some(rects)) => {
+                acc.extend(rects);
+                Some(acc)
+            }
+            _ => None,
+        };
         newest = fresher;
+        coalesced_any = true;
+    }
+    if coalesced_any {
+        newest.dirty_rects = damage_union;
     }
     (newest, superseded)
 }
@@ -6897,6 +6918,53 @@ mod tests {
         let (newest, superseded) = drain_capture_rx_to_newest(&mut rx, first);
         assert_eq!(newest.data[0], 0xDD);
         assert!(superseded.is_empty());
+    }
+
+    /// Coalescing must not lose damage: the surviving frame carries the
+    /// UNION of superseded frames' dirty rects (per-frame damage is not
+    /// cumulative — the tile bridge repaints only reported regions), and
+    /// any unannotated frame in the run poisons the union to `None`
+    /// (full-frame damage to consumers).
+    #[tokio::test]
+    async fn drain_capture_rx_unions_superseded_damage() {
+        use capture::damage::Rect;
+        let (tx, mut rx) = mpsc::channel::<Frame>(8);
+        let r1 = Rect::new(0, 0, 2, 2);
+        let r2 = Rect::new(2, 2, 2, 2);
+        let mut a = make_test_bgra(4, 4);
+        a.dirty_rects = Some(vec![r1]);
+        let mut b = make_test_bgra(4, 4);
+        b.dirty_rects = Some(Vec::new()); // SCK Idle delivery
+        let mut c = make_test_bgra(4, 4);
+        c.data[0] = 0xCC;
+        c.dirty_rects = Some(vec![r2]);
+        tx.try_send(a).unwrap();
+        tx.try_send(b).unwrap();
+        tx.try_send(c).unwrap();
+        let first = rx.recv().await.expect("frame a");
+        let (newest, _) = drain_capture_rx_to_newest(&mut rx, first);
+        assert_eq!(newest.data[0], 0xCC);
+        assert_eq!(
+            newest.dirty_rects.as_deref(),
+            Some(&[r1, r2][..]),
+            "the survivor repaints every superseded region"
+        );
+
+        // An unannotated frame anywhere in the run means damage unknown:
+        // the union degrades to full-frame (`None`), never to a subset.
+        let mut e = make_test_bgra(4, 4);
+        e.dirty_rects = Some(vec![r1]);
+        let f = make_test_bgra(4, 4); // dirty_rects: None
+        let mut g = make_test_bgra(4, 4);
+        g.data[0] = 0x66;
+        g.dirty_rects = Some(vec![r2]);
+        tx.try_send(e).unwrap();
+        tx.try_send(f).unwrap();
+        tx.try_send(g).unwrap();
+        let first = rx.recv().await.expect("frame e");
+        let (newest, _) = drain_capture_rx_to_newest(&mut rx, first);
+        assert_eq!(newest.data[0], 0x66);
+        assert_eq!(newest.dirty_rects, None);
     }
 
     /// **3c.3b.3b finding 2 regression test.** Pool-only sessions

--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -705,6 +705,14 @@ pub struct DisplayMetricsCounters {
     /// counter to the backend via
     /// [`DisplayBackend::install_capture_frame_drop_counter`].
     pub capture_backend_drops: Arc<AtomicU64>,
+    /// Of `capture_frames`, the frames the capture bridge received but
+    /// superseded without broadcasting because a fresher frame was
+    /// already queued behind them (the drain-to-newest pass on each
+    /// bridge wake). Every consumer of the frame bus keeps latest-wins
+    /// state, so replaying a stale burst serially would only add
+    /// latency; a nonzero window here is the "runtime was starved and
+    /// recovered" signal — capture kept pace, the scheduler did not.
+    pub capture_coalesced: AtomicU64,
 
     /// Total frames successfully VP8-encoded.
     pub encode_frames: AtomicU64,
@@ -797,6 +805,7 @@ impl DisplayMetricsCounters {
             capture_drops: AtomicU64::new(0),
             capture_idle_frames: AtomicU64::new(0),
             capture_backend_drops: Arc::new(AtomicU64::new(0)),
+            capture_coalesced: AtomicU64::new(0),
             encode_frames: AtomicU64::new(0),
             encode_drops: AtomicU64::new(0),
             encode_freshness_us_sum: AtomicU64::new(0),
@@ -876,6 +885,30 @@ pub fn captured_frame_kind(dirty_rects: Option<&[capture::damage::Rect]>) -> Cap
         Some([]) => CapturedFrameKind::Idle,
         _ => CapturedFrameKind::Content,
     }
+}
+
+/// Drain the backend channel to the newest immediately-available frame.
+///
+/// A runtime stall (post-boot CPU storms are the live specimen —
+/// agenda 01KZ2PM87Q) queues captured frames behind a starved capture
+/// bridge; replaying them serially on wake would broadcast stale
+/// content one scheduling gap late, and every consumer of the frame
+/// bus keeps latest-wins state anyway. Skipping straight to the newest
+/// bounds recovery latency at one frame. Returns the newest frame plus
+/// the damage kinds of the frames it superseded (oldest first) so the
+/// caller can count them — they WERE captured and must show in the
+/// capture rate, or a coalescing window would masquerade as a slow
+/// source.
+pub fn drain_capture_rx_to_newest(
+    rx: &mut mpsc::Receiver<Frame>,
+    mut newest: Frame,
+) -> (Frame, Vec<CapturedFrameKind>) {
+    let mut superseded = Vec::new();
+    while let Ok(fresher) = rx.try_recv() {
+        superseded.push(captured_frame_kind(newest.dirty_rects.as_deref()));
+        newest = fresher;
+    }
+    (newest, superseded)
 }
 
 /// Which gate let one pool-feed forward through (see the bridge's
@@ -967,6 +1000,12 @@ pub struct DisplayMetricsSnapshot {
     /// zero — rendered as `n/a` in the log line).
     #[serde(default)]
     pub capture_backend_drops: Option<u64>,
+    /// Frames the capture bridge superseded in its drain-to-newest pass
+    /// this window (counted in `capture_fps`, never broadcast). Nonzero
+    /// = the runtime stalled behind capture and recovered by skipping
+    /// stale frames instead of replaying them late.
+    #[serde(default)]
+    pub capture_coalesced: u64,
     pub encode_fps: f64,
     pub encode_freshness_avg_ms: f64,
     pub encode_drops: u64,
@@ -1026,6 +1065,7 @@ impl DisplayMetricsSnapshot {
         let capture_drops = counters.capture_drops.swap(0, Ordering::Relaxed);
         let capture_idle_frames = counters.capture_idle_frames.swap(0, Ordering::Relaxed);
         let capture_backend_drops = counters.capture_backend_drops.swap(0, Ordering::Relaxed);
+        let capture_coalesced = counters.capture_coalesced.swap(0, Ordering::Relaxed);
         let pool_feed_push_changed = counters.pool_feed_push_changed.swap(0, Ordering::Relaxed);
         let pool_feed_push_heartbeat = counters.pool_feed_push_heartbeat.swap(0, Ordering::Relaxed);
         let pool_feed_push_burst = counters.pool_feed_push_burst.swap(0, Ordering::Relaxed);
@@ -1070,6 +1110,7 @@ impl DisplayMetricsSnapshot {
             // session-level `metrics()` downgrades to `None` when the
             // backend never acknowledged the install (unwired = unknown).
             capture_backend_drops: Some(capture_backend_drops),
+            capture_coalesced,
             encode_fps: encode_frames as f64 / elapsed_secs,
             encode_freshness_avg_ms,
             encode_drops,
@@ -2273,6 +2314,24 @@ impl DisplaySession {
                             );
                             break;
                         };
+                        // Recover from scheduling stalls by skipping to
+                        // the newest queued frame; superseded frames
+                        // count toward the capture rate (they arrived)
+                        // and the coalesced counter (they were never
+                        // broadcast) so a starved-runtime window is
+                        // legible in the metrics instead of reading as
+                        // a slow source.
+                        let (frame, superseded) =
+                            drain_capture_rx_to_newest(&mut capture_rx, frame);
+                        for kind in &superseded {
+                            cap_counters.capture_frames.fetch_add(1, Ordering::Relaxed);
+                            cap_counters.capture_coalesced.fetch_add(1, Ordering::Relaxed);
+                            if *kind == CapturedFrameKind::Idle {
+                                cap_counters
+                                    .capture_idle_frames
+                                    .fetch_add(1, Ordering::Relaxed);
+                            }
+                        }
                         cap_counters.capture_frames.fetch_add(1, Ordering::Relaxed);
                         if captured_frame_kind(frame.dirty_rects.as_deref())
                             == CapturedFrameKind::Idle
@@ -2652,7 +2711,7 @@ impl DisplaySession {
                             "[display/metrics] id={} capture={:.1}fps encode={:.1}fps \
                              drops=cap:{}/enc:{}/peer:{} peers={} freshness_avg={:.1}ms res={}x{} \
                              tile=dirty:{}r/{}t/{:.3} delta={:.1}fps/{:.1}kbps/{}rec/skips:{} \
-                             snap={}f/{:.1}kbps/{}rec up={}s idle={:.1}fps bdrops={} \
+                             snap={}f/{:.1}kbps/{}rec up={}s idle={:.1}fps bdrops={} coal={} \
                              push=c{}/h{}/b{} paused=[{}] consumer={}",
                             m.display_id,
                             m.capture_fps,
@@ -2680,6 +2739,7 @@ impl DisplaySession {
                                 None => "n/a".to_string(),
                                 Some(n) => n.to_string(),
                             },
+                            m.capture_coalesced,
                             m.pool_feed_pushes_changed,
                             m.pool_feed_pushes_heartbeat,
                             m.pool_feed_pushes_burst,
@@ -5701,6 +5761,7 @@ mod tests {
             capture_drops: 5,
             capture_idle_fps: 1.5,
             capture_backend_drops: Some(3),
+            capture_coalesced: 4,
             encode_fps: 28.5,
             encode_freshness_avg_ms: 4.2,
             encode_drops: 2,
@@ -6797,6 +6858,45 @@ mod tests {
             timestamp: Instant::now(),
             dirty_rects: None,
         }
+    }
+
+    /// The stall-recovery drain: given queued frames behind the one just
+    /// received, the bridge must keep the NEWEST and report every
+    /// superseded frame's damage kind (oldest first) for counting.
+    #[tokio::test]
+    async fn drain_capture_rx_keeps_newest_and_reports_superseded_kinds() {
+        let (tx, mut rx) = mpsc::channel::<Frame>(8);
+        // Distinguishable frames: first byte tags identity; the middle
+        // frame is an SCK-style Idle delivery (empty dirty set).
+        let mut a = make_test_bgra(4, 4);
+        a.data[0] = 0xAA;
+        let mut b = make_test_bgra(4, 4);
+        b.data[0] = 0xBB;
+        b.dirty_rects = Some(Vec::new());
+        let mut c = make_test_bgra(4, 4);
+        c.data[0] = 0xCC;
+        tx.try_send(a).unwrap();
+        tx.try_send(b).unwrap();
+        tx.try_send(c).unwrap();
+
+        let first = rx.recv().await.expect("frame a");
+        let (newest, superseded) = drain_capture_rx_to_newest(&mut rx, first);
+        assert_eq!(newest.data[0], 0xCC, "the newest queued frame wins");
+        assert_eq!(
+            superseded,
+            vec![CapturedFrameKind::Content, CapturedFrameKind::Idle],
+            "superseded kinds arrive oldest first with the idle split intact"
+        );
+
+        // An empty queue coalesces nothing: the received frame passes
+        // through untouched.
+        let mut d = make_test_bgra(4, 4);
+        d.data[0] = 0xDD;
+        tx.try_send(d).unwrap();
+        let first = rx.recv().await.expect("frame d");
+        let (newest, superseded) = drain_capture_rx_to_newest(&mut rx, first);
+        assert_eq!(newest.data[0], 0xDD);
+        assert!(superseded.is_empty());
     }
 
     /// **3c.3b.3b finding 2 regression test.** Pool-only sessions

--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -907,10 +907,18 @@ pub fn captured_frame_kind(dirty_rects: Option<&[capture::damage::Rect]>) -> Cap
 /// stale in the tile lane until a periodic snapshot. Any unannotated
 /// frame in the run (`None` = damage unknown) poisons the union to
 /// `None` — consumers already treat that as full-frame damage.
+///
+/// The union serves CONSUMERS (repaint instructions); the metrics
+/// split serves DELIVERY TRUTH. The survivor's kind is therefore
+/// classified from its original annotation and returned separately —
+/// deriving it from the mutated frame would count an idle delivery
+/// that survived a coalescing run as content and understate
+/// `capture_idle_fps` exactly in the windows the split exists to
+/// classify.
 pub fn drain_capture_rx_to_newest(
     rx: &mut mpsc::Receiver<Frame>,
     mut newest: Frame,
-) -> (Frame, Vec<CapturedFrameKind>) {
+) -> (Frame, CapturedFrameKind, Vec<CapturedFrameKind>) {
     let mut superseded = Vec::new();
     let mut damage_union = newest.dirty_rects.clone();
     let mut coalesced_any = false;
@@ -926,10 +934,11 @@ pub fn drain_capture_rx_to_newest(
         newest = fresher;
         coalesced_any = true;
     }
+    let newest_kind = captured_frame_kind(newest.dirty_rects.as_deref());
     if coalesced_any {
         newest.dirty_rects = damage_union;
     }
-    (newest, superseded)
+    (newest, newest_kind, superseded)
 }
 
 /// Which gate let one pool-feed forward through (see the bridge's
@@ -2342,7 +2351,7 @@ impl DisplaySession {
                         // broadcast) so a starved-runtime window is
                         // legible in the metrics instead of reading as
                         // a slow source.
-                        let (frame, superseded) =
+                        let (frame, frame_kind, superseded) =
                             drain_capture_rx_to_newest(&mut capture_rx, frame);
                         for kind in &superseded {
                             cap_counters.capture_frames.fetch_add(1, Ordering::Relaxed);
@@ -2354,9 +2363,10 @@ impl DisplaySession {
                             }
                         }
                         cap_counters.capture_frames.fetch_add(1, Ordering::Relaxed);
-                        if captured_frame_kind(frame.dirty_rects.as_deref())
-                            == CapturedFrameKind::Idle
-                        {
+                        // Delivery truth from the drain, not the frame:
+                        // the damage union may have rewritten an idle
+                        // survivor's annotation for consumers.
+                        if frame_kind == CapturedFrameKind::Idle {
                             cap_counters
                                 .capture_idle_frames
                                 .fetch_add(1, Ordering::Relaxed);
@@ -6901,7 +6911,7 @@ mod tests {
         tx.try_send(c).unwrap();
 
         let first = rx.recv().await.expect("frame a");
-        let (newest, superseded) = drain_capture_rx_to_newest(&mut rx, first);
+        let (newest, _, superseded) = drain_capture_rx_to_newest(&mut rx, first);
         assert_eq!(newest.data[0], 0xCC, "the newest queued frame wins");
         assert_eq!(
             superseded,
@@ -6915,7 +6925,7 @@ mod tests {
         d.data[0] = 0xDD;
         tx.try_send(d).unwrap();
         let first = rx.recv().await.expect("frame d");
-        let (newest, superseded) = drain_capture_rx_to_newest(&mut rx, first);
+        let (newest, _, superseded) = drain_capture_rx_to_newest(&mut rx, first);
         assert_eq!(newest.data[0], 0xDD);
         assert!(superseded.is_empty());
     }
@@ -6942,7 +6952,7 @@ mod tests {
         tx.try_send(b).unwrap();
         tx.try_send(c).unwrap();
         let first = rx.recv().await.expect("frame a");
-        let (newest, _) = drain_capture_rx_to_newest(&mut rx, first);
+        let (newest, _, _) = drain_capture_rx_to_newest(&mut rx, first);
         assert_eq!(newest.data[0], 0xCC);
         assert_eq!(
             newest.dirty_rects.as_deref(),
@@ -6962,9 +6972,31 @@ mod tests {
         tx.try_send(f).unwrap();
         tx.try_send(g).unwrap();
         let first = rx.recv().await.expect("frame e");
-        let (newest, _) = drain_capture_rx_to_newest(&mut rx, first);
+        let (newest, _, _) = drain_capture_rx_to_newest(&mut rx, first);
         assert_eq!(newest.data[0], 0x66);
         assert_eq!(newest.dirty_rects, None);
+
+        // An idle SURVIVOR keeps its delivery-truth classification even
+        // though the union rewrites its annotation for consumers: the
+        // metrics split must not understate idle deliveries exactly in
+        // the coalescing windows it exists to classify.
+        let mut h = make_test_bgra(4, 4);
+        h.dirty_rects = Some(vec![r1]);
+        let mut i = make_test_bgra(4, 4);
+        i.data[0] = 0x11;
+        i.dirty_rects = Some(Vec::new()); // SCK Idle delivery survives
+        tx.try_send(h).unwrap();
+        tx.try_send(i).unwrap();
+        let first = rx.recv().await.expect("frame h");
+        let (newest, newest_kind, superseded) = drain_capture_rx_to_newest(&mut rx, first);
+        assert_eq!(newest.data[0], 0x11);
+        assert_eq!(newest_kind, CapturedFrameKind::Idle, "delivery truth");
+        assert_eq!(
+            newest.dirty_rects.as_deref(),
+            Some(&[r1][..]),
+            "consumers still repaint the superseded region"
+        );
+        assert_eq!(superseded, vec![CapturedFrameKind::Content]);
     }
 
     /// **3c.3b.3b finding 2 regression test.** Pool-only sessions

--- a/crates/intendant-display/src/macos.rs
+++ b/crates/intendant-display/src/macos.rs
@@ -734,15 +734,29 @@ impl DisplayBackend for MacOSBackend {
             .with_height(height)
             .with_pixel_format(PixelFormat::BGRA)
             .with_shows_cursor(true)
-            .with_minimum_frame_interval(&frame_interval);
+            .with_minimum_frame_interval(&frame_interval)
+            // SCK's own delivery queue. At the unset default (3), a brief
+            // stall of the callback thread makes ScreenCaptureKit drop
+            // frames UPSTREAM of this process — invisible to bdrops and
+            // indistinguishable from a quiet desktop in the metrics (the
+            // post-boot low-fps class, agenda 01KZ2PM87Q). 8 is the top
+            // of Apple's recommended 3-8 range: WindowServer retains a
+            // few more surfaces per stream and in exchange a busy boot
+            // (Spotlight, login storms) coasts instead of thinning the
+            // stream.
+            .with_queue_depth(8);
 
         // Bounded channel: backend drops frames if consumer is slow. The
         // sender lives in a per-session slot shared with the output handler
         // so `stop_capture` can close the channel promptly (see
         // `CaptureState`); it stays the channel's *only* sender — cloning it
         // out of the slot would let a late callback keep the channel open
-        // past teardown.
-        let (tx, rx) = mpsc::channel::<Frame>(4);
+        // past teardown. Capacity 8 ≈ 266ms of runtime stall at 30fps: the
+        // capture bridge drains the queue to the NEWEST frame on wake, so
+        // depth buys stall tolerance, not latency — overflow (counted via
+        // the drop counter) now means a genuinely wedged consumer, not a
+        // busy scheduler tick.
+        let (tx, rx) = mpsc::channel::<Frame>(8);
         let frame_slot = Arc::new(StdMutex::new(Some(tx)));
 
         // Per-session teardown state (see `CaptureState` for why these must


### PR DESCRIPTION
Addresses agenda `01KZ2PM87Q`: the local display pane runs ~4fps after daemon boot and self-heals minutes later (owner-reported repeatedly; latest specimen 2026-08-02, ~19-minute window, healthy 29fps after).

**Where this sits in the investigation**: PR #784's diagnosis seat classified the class as capture-side and eliminated everything downstream (encode tracked capture; zero counted drops at every stage; TWCC loss 0; no layer transitions). Two candidate stories remained — ScreenCaptureKit legitimately sparse on a quiet post-boot desktop, vs frames lost to post-boot CPU contention — and #784 added the instrumentation (`idle=`, `bdrops=`, pipeline-state fingerprints) to split them at the next occurrence. **No occurrence has reached that instrumentation since** (the owner's daemon logs show no display session in the window), so waiting is unbounded. This PR instead hardens every loss point on *our* side of SCK — the contention story's entire surface — and completes the metrics so a recurrence conclusively names its story:

1. **Drain-to-newest at the capture bridge** (`lib.rs`). A runtime stall queues captured frames behind the starved bridge; replaying them serially on wake broadcast stale content one scheduling gap late. The bridge now skips to the newest queued frame — every frame-bus consumer (pool-feed bridge, tile bridge, CU observation, `fresh_frame`) already keeps latest-wins state, so recovery latency is bounded at one frame. Superseded frames still count toward the capture rate (they arrived), and a new `capture_coalesced` counter + `coal=` metrics field makes "runtime was starved and recovered" legible instead of masquerading as a slow source. Deterministic unit test covers newest-wins, ordering, and the idle-kind split.
2. **Deeper backend→bridge channel** (`macos.rs`, 4→8): ≈266ms of stall tolerance at 30fps. With the drain, depth buys tolerance rather than latency, and a counted `bdrops` overflow now indicates a genuinely wedged consumer.
3. **Explicit SCK `queue_depth` 8** (`macos.rs`): at the unset default (3), a brief stall of the SCK callback thread makes ScreenCaptureKit drop frames *upstream of this process* — invisible to `bdrops` and indistinguishable from a quiet desktop. 8 is the top of Apple's recommended range; WindowServer retains a few more surfaces per stream in exchange for coasting through busy boots.

**Honest residue**: if the idle story (or SCK-side thinning under system pressure) is the real one, this PR does not change delivery — but the next occurrence now separates all the stories in one metrics line: `idle=` high → quiet desktop (by design), `bdrops=` > 0 → handoff overflow, `coal=` > 0 → runtime stall recovered, all ~0 at low capture → SCK itself under-delivering. The agenda item stays open pending a live-occurrence read; this seat's annotation records exactly what to look for.

Battery: `cargo fmt --check`, full `intendant-display` suite (596 tests incl. the new drain test), full `cargo test -p intendant --bins`, lib crates, workspace clippy `-D warnings`.
