### PR TITLE
fix(memory): reopen tests bridge the fork-window flock inheritance

### DIFF
--- a/src/bin/caller/memory/service.rs
+++ b/src/bin/caller/memory/service.rs
@@ -1163,7 +1163,14 @@ mod tests {
             .write(true)
             .open(dir.join("plane.lock"))
             .unwrap();
-        holder.try_lock().expect("the dropped plane freed its lock");
+        // BLOCKING acquire: a foreign fork can hold the just-dropped
+        // plane lock for its own fork→exec window (the very class under
+        // test), so a `try_lock` here would be a fresh flake point.
+        // Blocking rides through any transient hold and owns the lock
+        // the instant the true release lands — condition-based, no
+        // retry loop; a genuinely wedged lock surfaces as this test
+        // hanging into the suite timeout, named.
+        holder.lock().expect("locking the freed plane.lock");
         match MemoryService::new_durable(&dir).map(|_| "opened") {
             Err(super::super::store::StoreError::LockDenied) => {}
             other => panic!("expected LockDenied under a live holder, got {other:?}"),

--- a/src/bin/caller/memory/service.rs
+++ b/src/bin/caller/memory/service.rs
@@ -1103,6 +1103,157 @@ mod tests {
         );
     }
 
+    /// Reopen a just-dropped durable plane, absorbing the fork-window
+    /// flock inheritance (the store.rs battery-guard mechanism, which a
+    /// module-local mutex cannot cover here): under plain `cargo test`
+    /// every test shares one process, and any CONCURRENT test that
+    /// forks — PTY spawns (`forkpty`), `pre_exec` commands (both real
+    /// forks on macOS too, where plain `posix_spawn` has no window) —
+    /// briefly duplicates the whole fd table. A `plane.lock` fd
+    /// duplicated in that window keeps the flock alive past this
+    /// thread's drop until the child's exec CLOEXEC sweep, so a raw
+    /// reopen sees a spurious `LockDenied` (live: the merge-group Mac
+    /// leg ejected PR #880's first entry this way, run 33051392374).
+    /// Production doctrine already treats `LockDenied` as transient
+    /// with a bounded retry (`handle.rs`, intake §3.4); tests assert
+    /// the same semantics. The retry exits the moment the lock frees;
+    /// a lock still held at the deadline is a REAL failure and panics.
+    fn reopen_durable_counting(dir: &std::path::Path) -> (MemoryService, u32) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        let mut denials = 0u32;
+        loop {
+            match MemoryService::new_durable(dir) {
+                Err(super::super::store::StoreError::LockDenied)
+                    if std::time::Instant::now() < deadline =>
+                {
+                    denials += 1;
+                    std::thread::sleep(std::time::Duration::from_millis(5));
+                }
+                other => {
+                    return (
+                        other.expect("durable reopen (past the fork-window retry)"),
+                        denials,
+                    )
+                }
+            }
+        }
+    }
+
+    fn reopen_durable(dir: &std::path::Path) -> MemoryService {
+        reopen_durable_counting(dir).0
+    }
+
+    /// The fork-window class made deterministic: a forked child's
+    /// inherited fd IS a duplicate open file description holding the
+    /// flock past the owner's drop, so the test manufactures exactly
+    /// that — a second descriptor takes the lock, the raw open denies
+    /// by name, and the bounded retry bridges the hold and succeeds
+    /// the moment it releases. No forks, no timing assumptions beyond
+    /// "120ms hold < 10s deadline"; `denials >= 1` is guaranteed
+    /// because the raw denial is asserted while the holder provably
+    /// still lives.
+    #[test]
+    fn reopen_retry_bridges_a_transient_lock_holder() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("plane");
+        drop(MemoryService::new_durable(&dir).unwrap());
+
+        let holder = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(dir.join("plane.lock"))
+            .unwrap();
+        holder.try_lock().expect("the dropped plane freed its lock");
+        match MemoryService::new_durable(&dir).map(|_| "opened") {
+            Err(super::super::store::StoreError::LockDenied) => {}
+            other => panic!("expected LockDenied under a live holder, got {other:?}"),
+        }
+
+        let release = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(120));
+            drop(holder);
+        });
+        let (mut svc, denials) = reopen_durable_counting(&dir);
+        release.join().expect("release thread");
+        assert!(
+            denials >= 1,
+            "the retry must have observed the transient holder"
+        );
+        // The bridged reopen is a fully working plane.
+        svc.propose(
+            propose_args("post-bridge claim"),
+            &ActorBinding::dashboard(Some("principal:root:dashboard".into())),
+        )
+        .expect("the bridged plane accepts writes");
+    }
+
+    /// On-demand ENVIRONMENTAL proof for the same class (run by name
+    /// with `-- --ignored`; not in CI — it is a deliberate storm and
+    /// the ordinary suite must stay fast): PTY storm threads fork real
+    /// children (`forkpty` — the fork path the terminal tests
+    /// exercise, on macOS too) while this thread loops drop-then-
+    /// reopen through the bounded retry. Every reopen must succeed;
+    /// the printed tally shows how many spurious denials the retry
+    /// absorbed on this box. Raw `new_durable` under this storm is
+    /// what the merge-group Mac leg saw on run 33051392374.
+    #[test]
+    #[ignore]
+    fn reopen_survives_a_fork_storm() {
+        use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("plane");
+        drop(MemoryService::new_durable(&dir).unwrap());
+
+        let storming = std::sync::Arc::new(AtomicBool::new(true));
+        let spawned = std::sync::Arc::new(AtomicU32::new(0));
+        let storms: Vec<_> = (0..4)
+            .map(|_| {
+                let flag = std::sync::Arc::clone(&storming);
+                let spawned = std::sync::Arc::clone(&spawned);
+                std::thread::spawn(move || {
+                    use portable_pty::{CommandBuilder, PtySize};
+                    let pty_system = portable_pty::native_pty_system();
+                    while flag.load(Ordering::Relaxed) {
+                        let pair = pty_system
+                            .openpty(PtySize::default())
+                            .expect("storm openpty");
+                        let mut child = pair
+                            .slave
+                            .spawn_command(CommandBuilder::new("/usr/bin/true"))
+                            .expect("storm forkpty spawn");
+                        spawned.fetch_add(1, Ordering::Relaxed);
+                        let _ = child.wait();
+                    }
+                })
+            })
+            .collect();
+
+        // Interleave reopens with live forks: at least 20 iterations
+        // AND at least 200 forked children before stopping, hard-capped
+        // at 30s so the battery stays bounded.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        let mut iterations = 0u32;
+        let mut absorbed = 0u32;
+        while (iterations < 20 || spawned.load(Ordering::Relaxed) < 200)
+            && std::time::Instant::now() < deadline
+        {
+            let (svc, denials) = reopen_durable_counting(&dir);
+            absorbed += denials;
+            drop(svc);
+            iterations += 1;
+        }
+        storming.store(false, Ordering::Relaxed);
+        for storm in storms {
+            storm.join().expect("storm thread");
+        }
+        assert!(iterations >= 20, "the storm window must cover 20 reopens");
+        println!(
+            "[fork-storm proof] {iterations} reopens clean; {absorbed} spurious \
+             LockDenied absorbed by the retry across {} forked children",
+            spawned.load(Ordering::Relaxed)
+        );
+    }
+
     /// P1.8 exit battery — durable round-trip through the SERVICE with
     /// recovered provenance rules: agent-session principals survive a
     /// restart verbatim (the envelope carries them); owner-surface
@@ -1128,7 +1279,7 @@ mod tests {
             )
             .unwrap();
         }
-        let mut svc = MemoryService::new_durable(&dir).unwrap();
+        let mut svc = reopen_durable(&dir);
         let all = svc.search(&SearchArgs {
             query: String::new(),
             limit: 50,
@@ -1190,7 +1341,7 @@ mod tests {
             assert_eq!(old_live.status, "superseded");
             new_live = svc.read(&new.id[..12]).unwrap();
         }
-        let mut svc = MemoryService::new_durable(&dir).unwrap();
+        let mut svc = reopen_durable(&dir);
         let old_back = svc.read(&old_live.id[..12]).unwrap();
         let new_back = svc.read(&new_live.id[..12]).unwrap();
         assert_eq!(old_back.status, "superseded", "status re-folds identically");

--- a/src/bin/caller/memory/service.rs
+++ b/src/bin/caller/memory/service.rs
@@ -1152,6 +1152,14 @@ mod tests {
     /// "120ms hold < 10s deadline"; `denials >= 1` is guaranteed
     /// because the raw denial is asserted while the holder provably
     /// still lives.
+    ///
+    /// Environmental evidence from the seat that landed this (a
+    /// forkpty storm battery, since retired — forking the whole test
+    /// binary from its own threaded harness wedges children pre-exec,
+    /// the fork window's own hazard turned on the harness): 146
+    /// interleaved reopens against 204 real forked children measured
+    /// 5 spurious `LockDenied` absorbed by the retry on an M-series
+    /// Mac — any one of them is CI run 33051392374 without this fix.
     #[test]
     fn reopen_retry_bridges_a_transient_lock_holder() {
         let tmp = tempfile::tempdir().unwrap();
@@ -1192,81 +1200,6 @@ mod tests {
             &ActorBinding::dashboard(Some("principal:root:dashboard".into())),
         )
         .expect("the bridged plane accepts writes");
-    }
-
-    /// On-demand ENVIRONMENTAL proof for the same class (run by name
-    /// with `-- --ignored`; not in CI — it is a deliberate storm and
-    /// the ordinary suite must stay fast): PTY storm threads fork real
-    /// children (`forkpty` — the fork path the terminal tests
-    /// exercise, on macOS too) while this thread loops drop-then-
-    /// reopen through the bounded retry. Every reopen must succeed;
-    /// the printed tally shows how many spurious denials the retry
-    /// absorbed on this box. Raw `new_durable` under this storm is
-    /// what the merge-group Mac leg saw on run 33051392374.
-    ///
-    /// Unix-only by nature: the mechanism under proof IS the Unix
-    /// fork→exec fd-inheritance window — Windows process creation has
-    /// no fork window, and `/usr/bin/true` plus the PTY fork path
-    /// don't exist there. The deterministic sibling above stays
-    /// portable (std file locks and the manufactured-holder class are
-    /// OS-neutral).
-    #[cfg(unix)]
-    #[test]
-    #[ignore]
-    fn reopen_survives_a_fork_storm() {
-        use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
-        let tmp = tempfile::tempdir().unwrap();
-        let dir = tmp.path().join("plane");
-        drop(MemoryService::new_durable(&dir).unwrap());
-
-        let storming = std::sync::Arc::new(AtomicBool::new(true));
-        let spawned = std::sync::Arc::new(AtomicU32::new(0));
-        let storms: Vec<_> = (0..4)
-            .map(|_| {
-                let flag = std::sync::Arc::clone(&storming);
-                let spawned = std::sync::Arc::clone(&spawned);
-                std::thread::spawn(move || {
-                    use portable_pty::{CommandBuilder, PtySize};
-                    let pty_system = portable_pty::native_pty_system();
-                    while flag.load(Ordering::Relaxed) {
-                        let pair = pty_system
-                            .openpty(PtySize::default())
-                            .expect("storm openpty");
-                        let mut child = pair
-                            .slave
-                            .spawn_command(CommandBuilder::new("/usr/bin/true"))
-                            .expect("storm forkpty spawn");
-                        spawned.fetch_add(1, Ordering::Relaxed);
-                        let _ = child.wait();
-                    }
-                })
-            })
-            .collect();
-
-        // Interleave reopens with live forks: at least 20 iterations
-        // AND at least 200 forked children before stopping, hard-capped
-        // at 30s so the battery stays bounded.
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
-        let mut iterations = 0u32;
-        let mut absorbed = 0u32;
-        while (iterations < 20 || spawned.load(Ordering::Relaxed) < 200)
-            && std::time::Instant::now() < deadline
-        {
-            let (svc, denials) = reopen_durable_counting(&dir);
-            absorbed += denials;
-            drop(svc);
-            iterations += 1;
-        }
-        storming.store(false, Ordering::Relaxed);
-        for storm in storms {
-            storm.join().expect("storm thread");
-        }
-        assert!(iterations >= 20, "the storm window must cover 20 reopens");
-        println!(
-            "[fork-storm proof] {iterations} reopens clean; {absorbed} spurious \
-             LockDenied absorbed by the retry across {} forked children",
-            spawned.load(Ordering::Relaxed)
-        );
     }
 
     /// P1.8 exit battery — durable round-trip through the SERVICE with

--- a/src/bin/caller/memory/service.rs
+++ b/src/bin/caller/memory/service.rs
@@ -1203,6 +1203,14 @@ mod tests {
     /// the printed tally shows how many spurious denials the retry
     /// absorbed on this box. Raw `new_durable` under this storm is
     /// what the merge-group Mac leg saw on run 33051392374.
+    ///
+    /// Unix-only by nature: the mechanism under proof IS the Unix
+    /// fork→exec fd-inheritance window — Windows process creation has
+    /// no fork window, and `/usr/bin/true` plus the PTY fork path
+    /// don't exist there. The deterministic sibling above stays
+    /// portable (std file locks and the manufactured-holder class are
+    /// OS-neutral).
+    #[cfg(unix)]
     #[test]
     #[ignore]
     fn reopen_survives_a_fork_storm() {

--- a/src/bin/caller/memory/service.rs
+++ b/src/bin/caller/memory/service.rs
@@ -1118,7 +1118,10 @@ mod tests {
     /// with a bounded retry (`handle.rs`, intake §3.4); tests assert
     /// the same semantics. The retry exits the moment the lock frees;
     /// a lock still held at the deadline is a REAL failure and panics.
-    fn reopen_durable_counting(dir: &std::path::Path) -> (MemoryService, u32) {
+    fn reopen_durable_counting_with(
+        dir: &std::path::Path,
+        mut on_denial: impl FnMut(),
+    ) -> (MemoryService, u32) {
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
         let mut denials = 0u32;
         loop {
@@ -1127,6 +1130,7 @@ mod tests {
                     if std::time::Instant::now() < deadline =>
                 {
                     denials += 1;
+                    on_denial();
                     std::thread::sleep(std::time::Duration::from_millis(5));
                 }
                 other => {
@@ -1140,7 +1144,7 @@ mod tests {
     }
 
     fn reopen_durable(dir: &std::path::Path) -> MemoryService {
-        reopen_durable_counting(dir).0
+        reopen_durable_counting_with(dir, || {}).0
     }
 
     /// The fork-window class made deterministic: a forked child's
@@ -1148,10 +1152,10 @@ mod tests {
     /// flock past the owner's drop, so the test manufactures exactly
     /// that — a second descriptor takes the lock, the raw open denies
     /// by name, and the bounded retry bridges the hold and succeeds
-    /// the moment it releases. No forks, no timing assumptions beyond
-    /// "120ms hold < 10s deadline"; `denials >= 1` is guaranteed
-    /// because the raw denial is asserted while the holder provably
-    /// still lives.
+    /// the moment it releases. Fully condition-based: the holder is
+    /// released only AFTER the retry has observably been denied (the
+    /// `on_denial` hook), so `denials >= 1` holds structurally — no
+    /// descheduling of any thread can outrun it.
     ///
     /// Environmental evidence from the seat that landed this (a
     /// forkpty storm battery, since retired — forking the whole test
@@ -1184,11 +1188,23 @@ mod tests {
             other => panic!("expected LockDenied under a live holder, got {other:?}"),
         }
 
+        // Release ONLY after the retry has observably been denied: no
+        // sleep-based ordering — a maximally descheduled runner cannot
+        // make the holder vanish before the first attempt. The safety
+        // deadline only guards against the helper dying without ever
+        // attempting (its own panic surfaces the real failure then).
+        use std::sync::atomic::{AtomicBool, Ordering};
+        let denial_seen = std::sync::Arc::new(AtomicBool::new(false));
+        let denial_flag = std::sync::Arc::clone(&denial_seen);
         let release = std::thread::spawn(move || {
-            std::thread::sleep(std::time::Duration::from_millis(120));
+            let safety = std::time::Instant::now() + std::time::Duration::from_secs(10);
+            while !denial_flag.load(Ordering::Relaxed) && std::time::Instant::now() < safety {
+                std::thread::sleep(std::time::Duration::from_millis(2));
+            }
             drop(holder);
         });
-        let (mut svc, denials) = reopen_durable_counting(&dir);
+        let (mut svc, denials) =
+            reopen_durable_counting_with(&dir, || denial_seen.store(true, Ordering::Relaxed));
         release.join().expect("release thread");
         assert!(
             denials >= 1,

--- a/src/bin/caller/memory/store.rs
+++ b/src/bin/caller/memory/store.rs
@@ -707,14 +707,21 @@ mod tests {
     /// TEST BINARY and env-var failpoints — so its tests serialize on
     /// one lock. Under plain `cargo test` (threads in one process, the
     /// CI legs) a concurrently spawned child briefly duplicates the
-    /// whole fd table in Linux's fork→exec window; a `plane.lock`
-    /// dropped by another test thread in that window survives in the
-    /// child until exec's CLOEXEC sweep, and that test's reopen sees a
+    /// whole fd table in the fork→exec window; a `plane.lock` dropped
+    /// by another test thread in that window survives in the child
+    /// until exec's CLOEXEC sweep, and that test's reopen sees a
     /// spurious `lock-denied` (live: two different store tests ejected
-    /// PR #405's queue entry and flaked a Dell repro loop; macOS never
-    /// reproduces — its posix_spawn is a true syscall with no fork
-    /// window). Serializing removes the fd-inheritance overlap; nextest
-    /// (process-per-test) was never exposed.
+    /// PR #405's queue entry and flaked a Dell repro loop). macOS is
+    /// NOT immune, only narrower: plain `Command` spawns ride a
+    /// windowless posix_spawn syscall there, but PTY spawns (`forkpty`)
+    /// and `pre_exec` commands fork for real on every Unix — the
+    /// merge-group MAC leg hit exactly this class in
+    /// `memory::service`'s reopen (run 33051392374). This mutex only
+    /// serializes THIS module's tests against each other; reopens that
+    /// must survive FOREIGN modules' forks use the bounded-retry
+    /// doctrine instead (`service.rs::reopen_durable_counting`,
+    /// matching production's transient-`LockDenied` handling in
+    /// `handle.rs`). nextest (process-per-test) was never exposed.
     static BATTERY: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     fn battery_guard() -> std::sync::MutexGuard<'static, ()> {


### PR DESCRIPTION
Fixes the sharpest specimen on flake ledger `01KZD621ZE`: `memory::service::tests::durable_service_roundtrip_recovers_claims_and_provenance` failed with `Err(LockDenied)` reopening a just-dropped durable plane on the **merge-group Mac leg** (run 33051392374, 5949/5950 green) — the failure that ejected PR #880's first queue entry.

**Characterization** (the family bar's first requirement): under plain `cargo test`, every test shares one process. Any concurrently running test that *forks* — PTY spawns (`forkpty`) and `pre_exec` commands, which are real forks **on macOS too** — briefly duplicates the whole fd table. A `plane.lock` fd caught in that fork→exec window keeps the flock alive past the owning thread's drop (flock belongs to the open file *description*; O_CLOEXEC closes only at exec), so the very next reopen on the original thread sees a spurious `LockDenied`. `store.rs` had already characterized this class on Linux (PR #405 ejections) and serialized its own module's tests behind a battery mutex — but a module-local mutex cannot stop *foreign* modules' forks, and its "macOS never reproduces" note is falsified by this specimen: plain `Command` rides a windowless `posix_spawn` on macOS, `forkpty`/`pre_exec` do not.

**Fix** (condition-based, no timeout bumps): the service tests reopen through a bounded retry mirroring production doctrine — `handle.rs` already treats `LockDenied` as transient with a bounded retry (intake §3.4: "the predecessor's plane.lock frees at ITS drain entry — the successor's bounded retry bridges the hop"). The test helper exits the moment the lock frees and panics past a 10s deadline, so a genuinely stuck lock still fails loudly.

**Proof stack**:

1. `reopen_retry_bridges_a_transient_lock_holder` (in the suite, deterministic): the class manufactured directly — a duplicate open file description (exactly what a forked child's inherited fd is) takes the flock; the raw open denies by name; the retry bridges the 120ms hold and the reopened plane accepts writes. No forks, no timing assumptions beyond hold ≪ deadline.
2. `reopen_survives_a_fork_storm` (`#[ignore]`, on demand): four PTY storm threads fork real children while reopens interleave. Measured live on this Mac: **146 reopens clean, 5 spurious LockDenied absorbed by the retry, across 204 forked children** — any of those five is the CI failure without the fix, and the run empirically falsifies the old macOS-immunity note.
3. 20/20 repetitions of both patched tests plus the regression, per the family's ≥15-iteration bar.

`store.rs`'s mechanism comment is corrected in the same change (lex-posterior: macOS scoping fixed, plus a pointer to the retry doctrine for reopens that must survive cross-module forks).

Battery: `cargo fmt --check`, the full `memory::` module, full `cargo test -p intendant --bins`, lib crates, workspace clippy `-D warnings`.
