### PR TITLE
mcp: protocol version negotiation + unknown-profile core fallback

### DIFF
--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -71,8 +71,9 @@ browser-workspace and raw frame tools, which currently have no served
 `tools/list` definitions anywhere and are reachable only by direct call;
 `managed` (alias `managed-context`) advertises `get_status` plus the managed
 rewind/fission set; `full` — or omitting `tool_profile` — keeps the whole
-list, and unknown profile names fail open so a typoed URL does not silently
-hide tools. Profile filtering applies to `tools/list` only —
+list, and unknown profile names fall back to the `core` bootstrap set (the
+daemon logs the unknown name, and hidden tools stay callable, so a typoed
+URL stays diagnosable without the full-list context cost). Profile filtering applies to `tools/list` only —
 hidden HTTP tools remain callable (the lazy `ctl tools call` path).
 *Authorization* is separate: see the next section.
 

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -471,8 +471,8 @@ impl IntendantServer {
             if !known_tool_profile(profile) {
                 eprintln!(
                     "[mcp] unknown tool_profile {profile:?} — advertising the core bootstrap \
-                     set (hidden tools stay callable; known profiles: full, core, codex-core, \
-                     cli, minimal, screen, display, managed, managed-context)"
+                     set (hidden tools stay callable; known profiles: {})",
+                    known_tool_profile_names()
                 );
             }
         }

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -467,6 +467,15 @@ impl IntendantServer {
             .read()
             .await
             .exposed_codex_managed_context_enabled_for(session_id, managed_context_override);
+        if let Some(profile) = tool_profile.map(str::trim).filter(|p| !p.is_empty()) {
+            if !known_tool_profile(profile) {
+                eprintln!(
+                    "[mcp] unknown tool_profile {profile:?} — advertising the core bootstrap \
+                     set (hidden tools stay callable; known profiles: full, core, codex-core, \
+                     cli, minimal, screen, display, managed, managed-context)"
+                );
+            }
+        }
         // Router tool definitions are static per process, but every call
         // used to re-serialize and ref-inline all ~50 schemas. Build the
         // unfiltered set once; per-request work is the name-keyed

--- a/src/bin/caller/mcp/tool_gate.rs
+++ b/src/bin/caller/mcp/tool_gate.rs
@@ -674,7 +674,7 @@ fn build_manual_http_tool_definitions() -> Vec<serde_json::Value> {
         "create_virtual_display",
         manual_http_tool_definition!(
             "create_virtual_display",
-            "Create an agent-owned virtual display (Xvfb) on this daemon's host and activate it for capture and streaming — it announces as display_ready to every dashboard and federated peer. Linux hosts only today; other platforms report a clear error. Waits for the ready/failed outcome and returns the new display's id and geometry.",
+            "Create a daemon-owned virtual display (Xvfb) on this daemon's host and activate it for capture and streaming — it announces as display_ready to every dashboard and federated peer, survives the calling session, and dies with the daemon (closing its dashboard tile reaps it early). Linux hosts only today; other platforms report a clear error. Waits for the ready/failed outcome and returns the new display's id and geometry.",
             CreateVirtualDisplayParams
         ),
     );

--- a/src/bin/caller/mcp/tool_gate.rs
+++ b/src/bin/caller/mcp/tool_gate.rs
@@ -210,10 +210,37 @@ pub(crate) fn tool_allowed_for_profile(
             matches!(name, "get_status")
                 || (managed_context && (managed_context_tool(name) || fission_tool(name)))
         }
-        // Unknown profiles fail open so typoed third-party URLs do not silently
-        // hide tools. Intendant-generated URLs use known profile names.
-        _ => true,
+        // Unknown profiles fall back to the `core` bootstrap set. This used
+        // to fail open to the full surface so a typoed third-party URL would
+        // not silently hide tools — but the full unfiltered list is itself
+        // the failure mode now (tens of KB of schemas swamping a session's
+        // context before any work starts), and profile shaping never gates
+        // calls: hidden tools stay callable, so `core` keeps a typo
+        // diagnosable (the standard operating set is still advertised, and
+        // the listing edge logs the unknown name) without the blowout.
+        // Intendant-generated URLs use known profile names.
+        _ => tool_allowed_for_profile(name, managed_context, Some("core")),
     }
+}
+
+/// Whether `profile` names a defined advertisement profile. Kept beside the
+/// match in [`tool_allowed_for_profile`] — when a profile arm is added or
+/// renamed there, update this list in the same change (a unit test pins the
+/// known set, and the listing edge uses this to log unknown names before
+/// they fall back to `core`).
+pub(crate) fn known_tool_profile(profile: &str) -> bool {
+    matches!(
+        profile.trim().to_ascii_lowercase().as_str(),
+        "full"
+            | "core"
+            | "codex-core"
+            | "cli"
+            | "minimal"
+            | "screen"
+            | "display"
+            | "managed"
+            | "managed-context"
+    )
 }
 
 /// The IAM permission gate a given MCP tool call must clear.
@@ -761,6 +788,75 @@ fn build_manual_http_tool_definitions() -> Vec<serde_json::Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Unknown profiles used to fail open to the full surface; they now fall
+    /// back to the `core` bootstrap set (the full-list context blowout was
+    /// the real failure mode). Pin the fallback through the real serving
+    /// path in both managed-context states.
+    #[test]
+    fn unknown_profile_advertises_exactly_the_core_set() {
+        use crate::event::EventBus;
+        use crate::mcp::tests::{test_server, test_state};
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let (_home, server) = test_server(test_state(), EventBus::new());
+            for managed_context in [false, true] {
+                let names = |served: &serde_json::Value| -> Vec<String> {
+                    served["tools"]
+                        .as_array()
+                        .expect("tools array")
+                        .iter()
+                        .map(|t| t["name"].as_str().expect("tool name").to_string())
+                        .collect()
+                };
+                let unknown = server
+                    .list_tools_json_for_session(
+                        None,
+                        Some(managed_context),
+                        Some("no-such-profile"),
+                    )
+                    .await;
+                let core = server
+                    .list_tools_json_for_session(None, Some(managed_context), Some("core"))
+                    .await;
+                assert_eq!(
+                    names(&unknown),
+                    names(&core),
+                    "unknown profile must advertise the core set \
+                     (managed_context={managed_context})"
+                );
+            }
+        });
+    }
+
+    /// The known-profile list the listing edge logs against stays in sync
+    /// with the named arms of `tool_allowed_for_profile` — update both
+    /// together (adding a profile arm without extending this list makes the
+    /// daemon mislabel the new profile as unknown in its log line).
+    #[test]
+    fn known_tool_profile_pins_the_named_arms() {
+        for profile in [
+            "full",
+            "core",
+            "codex-core",
+            "cli",
+            "minimal",
+            "screen",
+            "display",
+            "managed",
+            "managed-context",
+            " Core ", // trimmed + case-insensitive, like the filter itself
+        ] {
+            assert!(known_tool_profile(profile), "{profile:?} must be known");
+        }
+        for profile in ["", "no-such-profile", "core2", "facade"] {
+            assert!(!known_tool_profile(profile), "{profile:?} must be unknown");
+        }
+    }
 
     #[test]
     fn codex_cloud_tools_are_full_profile_only_with_explicit_iam_classes() {
@@ -1470,8 +1566,8 @@ mod tests {
     /// lacks `"type": "object"` rejects the ENTIRE list and the session
     /// registers zero Intendant tools (the live 2026-07 `agenda_op`
     /// regression). Iterate every profile branch of
-    /// [`tool_allowed_for_profile`] (plus the no-profile and unknown-profile
-    /// fail-open surfaces) x managed-context through the real serving path
+    /// [`tool_allowed_for_profile`] (plus the no-profile default and the
+    /// unknown-profile core fallback) x managed-context through the real serving path
     /// and fail on any served schema that is not explicitly object-typed.
     #[test]
     fn every_profile_serves_only_object_typed_tool_schemas() {
@@ -1485,8 +1581,8 @@ mod tests {
         rt.block_on(async {
             let (_home, server) = test_server(test_state(), EventBus::new());
             // Every named arm of `tool_allowed_for_profile`, the profile-less
-            // default, and an unknown profile (which fails open to the full
-            // surface).
+            // default, and an unknown profile (which falls back to the core
+            // set).
             let profiles = [
                 None,
                 Some("full"),

--- a/src/bin/caller/mcp/tool_gate.rs
+++ b/src/bin/caller/mcp/tool_gate.rs
@@ -88,19 +88,24 @@ pub(crate) fn tool_allowed_for_profile(
     if !managed_context && (managed_context_tool(name) || fission_tool(name)) {
         return false;
     }
-    let Some(profile) = profile
-        .map(str::trim)
-        .filter(|profile| !profile.is_empty())
-        .map(|profile| profile.to_ascii_lowercase())
-    else {
+    let Some(profile) = profile.map(str::trim).filter(|profile| !profile.is_empty()) else {
         return true;
     };
-    match profile.as_str() {
-        "full" => true,
+    // Unknown profiles fall back to the `Core` family. This used to fail
+    // open to the full surface so a typoed third-party URL would not
+    // silently hide tools — but the full unfiltered list is itself the
+    // failure mode now (tens of KB of schemas swamping a session's context
+    // before any work starts), and profile shaping never gates calls:
+    // hidden tools stay callable, so the core set keeps a typo diagnosable
+    // (the listing edge logs unknown names via `known_tool_profile`)
+    // without the blowout. Intendant-generated URLs use known names.
+    let family = tool_profile_family(profile).unwrap_or(ToolProfileFamily::Core);
+    match family {
+        ToolProfileFamily::Full => true,
         // Codex should learn the broad Intendant surface lazily through
         // `intendant ctl --help` instead of receiving every MCP schema up front.
         // Keep the tiny always-useful status/collaboration set first-class.
-        "core" | "codex-core" | "cli" | "minimal" => {
+        ToolProfileFamily::Core => {
             matches!(
                 name,
                 "get_status"
@@ -177,7 +182,7 @@ pub(crate) fn tool_allowed_for_profile(
                 // normal turns should use them.
                 && (managed_context_tool(name) || fission_tool(name)))
         }
-        "screen" | "display" => {
+        ToolProfileFamily::Screen => {
             matches!(
                 name,
                 "get_status"
@@ -206,41 +211,61 @@ pub(crate) fn tool_allowed_for_profile(
                     | "hide_shared_view"
             ) || (managed_context && (managed_context_tool(name) || fission_tool(name)))
         }
-        "managed" | "managed-context" => {
+        ToolProfileFamily::Managed => {
             matches!(name, "get_status")
                 || (managed_context && (managed_context_tool(name) || fission_tool(name)))
         }
-        // Unknown profiles fall back to the `core` bootstrap set. This used
-        // to fail open to the full surface so a typoed third-party URL would
-        // not silently hide tools — but the full unfiltered list is itself
-        // the failure mode now (tens of KB of schemas swamping a session's
-        // context before any work starts), and profile shaping never gates
-        // calls: hidden tools stay callable, so `core` keeps a typo
-        // diagnosable (the standard operating set is still advertised, and
-        // the listing edge logs the unknown name) without the blowout.
-        // Intendant-generated URLs use known profile names.
-        _ => tool_allowed_for_profile(name, managed_context, Some("core")),
     }
 }
 
-/// Whether `profile` names a defined advertisement profile. Kept beside the
-/// match in [`tool_allowed_for_profile`] — when a profile arm is added or
-/// renamed there, update this list in the same change (a unit test pins the
-/// known set, and the listing edge uses this to log unknown names before
-/// they fall back to `core`).
+/// The advertisement-profile catalog: every recognized `tool_profile` name
+/// and the filter family it routes to. The single source behind filtering
+/// ([`tool_allowed_for_profile`] routes through [`tool_profile_family`]),
+/// recognition and the listing edge's unknown-name diagnostic
+/// ([`known_tool_profile`], [`known_tool_profile_names`]), and the profile
+/// tests — add a profile here and every consumer follows.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum ToolProfileFamily {
+    Full,
+    Core,
+    Screen,
+    Managed,
+}
+
+pub(crate) const TOOL_PROFILE_CATALOG: &[(&str, ToolProfileFamily)] = &[
+    ("full", ToolProfileFamily::Full),
+    ("core", ToolProfileFamily::Core),
+    ("codex-core", ToolProfileFamily::Core),
+    ("cli", ToolProfileFamily::Core),
+    ("minimal", ToolProfileFamily::Core),
+    ("screen", ToolProfileFamily::Screen),
+    ("display", ToolProfileFamily::Screen),
+    ("managed", ToolProfileFamily::Managed),
+    ("managed-context", ToolProfileFamily::Managed),
+];
+
+/// Case-insensitive, whitespace-tolerant catalog lookup.
+fn tool_profile_family(profile: &str) -> Option<ToolProfileFamily> {
+    let normalized = profile.trim().to_ascii_lowercase();
+    TOOL_PROFILE_CATALOG
+        .iter()
+        .find(|(name, _)| *name == normalized)
+        .map(|(_, family)| *family)
+}
+
+/// Whether `profile` names a catalog profile (the listing edge logs
+/// unknown names before they fall back to the core family).
 pub(crate) fn known_tool_profile(profile: &str) -> bool {
-    matches!(
-        profile.trim().to_ascii_lowercase().as_str(),
-        "full"
-            | "core"
-            | "codex-core"
-            | "cli"
-            | "minimal"
-            | "screen"
-            | "display"
-            | "managed"
-            | "managed-context"
-    )
+    tool_profile_family(profile).is_some()
+}
+
+/// The catalog's names, comma-joined for diagnostics.
+pub(crate) fn known_tool_profile_names() -> String {
+    TOOL_PROFILE_CATALOG
+        .iter()
+        .map(|(name, _)| *name)
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// The IAM permission gate a given MCP tool call must clear.
@@ -833,26 +858,25 @@ mod tests {
         });
     }
 
-    /// The known-profile list the listing edge logs against stays in sync
-    /// with the named arms of `tool_allowed_for_profile` — update both
-    /// together (adding a profile arm without extending this list makes the
-    /// daemon mislabel the new profile as unknown in its log line).
+    /// Recognition, filtering, and the diagnostic name list all derive from
+    /// `TOOL_PROFILE_CATALOG` — pin the catalog's own invariants instead of
+    /// a second hand-written list.
     #[test]
-    fn known_tool_profile_pins_the_named_arms() {
-        for profile in [
-            "full",
-            "core",
-            "codex-core",
-            "cli",
-            "minimal",
-            "screen",
-            "display",
-            "managed",
-            "managed-context",
-            " Core ", // trimmed + case-insensitive, like the filter itself
-        ] {
-            assert!(known_tool_profile(profile), "{profile:?} must be known");
+    fn tool_profile_catalog_drives_recognition_and_diagnostics() {
+        for (name, _) in TOOL_PROFILE_CATALOG {
+            assert!(known_tool_profile(name), "{name:?} must be known");
+            assert!(
+                known_tool_profile_names().contains(name),
+                "{name:?} must appear in the diagnostic list"
+            );
         }
+        // Lookup is trim + case-insensitive, like the filter itself.
+        assert!(known_tool_profile(" Core "));
+        // No duplicate names — a duplicate would shadow its family.
+        let mut names: Vec<&str> = TOOL_PROFILE_CATALOG.iter().map(|(n, _)| *n).collect();
+        names.sort_unstable();
+        names.dedup();
+        assert_eq!(names.len(), TOOL_PROFILE_CATALOG.len());
         for profile in ["", "no-such-profile", "core2", "facade"] {
             assert!(!known_tool_profile(profile), "{profile:?} must be unknown");
         }
@@ -1583,19 +1607,10 @@ mod tests {
             // Every named arm of `tool_allowed_for_profile`, the profile-less
             // default, and an unknown profile (which falls back to the core
             // set).
-            let profiles = [
-                None,
-                Some("full"),
-                Some("core"),
-                Some("codex-core"),
-                Some("cli"),
-                Some("minimal"),
-                Some("screen"),
-                Some("display"),
-                Some("managed"),
-                Some("managed-context"),
-                Some("unknown-profile-for-schema-pin"),
-            ];
+            let profiles = TOOL_PROFILE_CATALOG
+                .iter()
+                .map(|(name, _)| Some(*name))
+                .chain([None, Some("unknown-profile-for-schema-pin")]);
             for profile in profiles {
                 for managed_context in [false, true] {
                     let served = server

--- a/src/bin/caller/mcp/tools_display.rs
+++ b/src/bin/caller/mcp/tools_display.rs
@@ -143,7 +143,7 @@ impl IntendantServer {
     }
 
     #[tool(
-        description = "Create an agent-owned virtual display (Xvfb) on this daemon's host and activate it for capture and streaming — it announces as display_ready to every dashboard and federated peer. Linux hosts only today; other platforms report a clear error. Waits for the ready/failed outcome and returns the new display's id and geometry."
+        description = "Create a daemon-owned virtual display (Xvfb) on this daemon's host and activate it for capture and streaming — it announces as display_ready to every dashboard and federated peer, survives the calling session, and dies with the daemon (closing its dashboard tile reaps it early). Linux hosts only today; other platforms report a clear error. Waits for the ready/failed outcome and returns the new display's id and geometry."
     )]
     pub(crate) async fn create_virtual_display(
         &self,

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -242,6 +242,12 @@ pub(crate) async fn serve_http_request(
             table_posture,
             Some(crate::gateway_routes::CorsPosture::FleetOrLoopback)
         );
+        // One list for every preflight branch. MCP-Protocol-Version rides
+        // here because Streamable HTTP clients at revision 2025-06-18 send
+        // it on every post-initialize request — the app-scheme origin is a
+        // real cross-origin /mcp caller, and a preflight that omits the
+        // header would block every request after the handshake.
+        const PREFLIGHT_ALLOW_HEADERS: &str = "Content-Type, Authorization, MCP-Protocol-Version";
         let response = if own_origin_scoped {
             // Own-origin APIs (and /mcp) are same-origin (or
             // app-scheme) only; a cross-origin preflight gets
@@ -255,10 +261,7 @@ pub(crate) async fn serve_http_request(
                 Some(origin) => HttpResponse::new("204 No Content")
                     .header("Access-Control-Allow-Origin", origin)
                     .header("Access-Control-Allow-Methods", methods)
-                    .header(
-                        "Access-Control-Allow-Headers",
-                        "Content-Type, Authorization",
-                    )
+                    .header("Access-Control-Allow-Headers", PREFLIGHT_ALLOW_HEADERS)
                     .header("Access-Control-Max-Age", "86400")
                     .header("Vary", "Origin")
                     .header("Connection", "close"),
@@ -292,10 +295,7 @@ pub(crate) async fn serve_http_request(
                 Some(origin) => HttpResponse::new("204 No Content")
                     .header("Access-Control-Allow-Origin", origin)
                     .header("Access-Control-Allow-Methods", methods)
-                    .header(
-                        "Access-Control-Allow-Headers",
-                        "Content-Type, Authorization",
-                    )
+                    .header("Access-Control-Allow-Headers", PREFLIGHT_ALLOW_HEADERS)
                     .header("Access-Control-Max-Age", "86400")
                     .header("Vary", "Origin")
                     .header("Connection", "close"),
@@ -310,10 +310,7 @@ pub(crate) async fn serve_http_request(
             HttpResponse::new("204 No Content")
                 .header("Access-Control-Allow-Origin", "*")
                 .header("Access-Control-Allow-Methods", methods)
-                .header(
-                    "Access-Control-Allow-Headers",
-                    "Content-Type, Authorization",
-                )
+                .header("Access-Control-Allow-Headers", PREFLIGHT_ALLOW_HEADERS)
                 .header("Access-Control-Max-Age", "86400")
                 .header("Connection", "close")
         };

--- a/src/bin/caller/web_gateway/mcp_gate.rs
+++ b/src/bin/caller/web_gateway/mcp_gate.rs
@@ -411,7 +411,6 @@ pub(crate) fn mcp_permission_denied_result(
     })
 }
 
-#[allow(clippy::too_many_arguments)]
 /// Protocol revisions the stateless HTTP `/mcp` endpoint fully implements,
 /// newest first. A revision is listed only when every MUST that applies to a
 /// stateless, tools-only POST server is actually implemented here: 2025-03-26
@@ -437,6 +436,7 @@ pub(crate) fn negotiated_mcp_protocol_version(requested: Option<&str>) -> &'stat
         .unwrap_or(SUPPORTED_MCP_PROTOCOL_VERSIONS[0])
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn handle_mcp_http_request(
     body: &str,
     server: &crate::mcp::IntendantServer,

--- a/src/bin/caller/web_gateway/mcp_gate.rs
+++ b/src/bin/caller/web_gateway/mcp_gate.rs
@@ -412,6 +412,31 @@ pub(crate) fn mcp_permission_denied_result(
 }
 
 #[allow(clippy::too_many_arguments)]
+/// Protocol revisions the stateless HTTP `/mcp` endpoint fully implements,
+/// newest first. A revision is listed only when every MUST that applies to a
+/// stateless, tools-only POST server is actually implemented here: 2025-03-26
+/// is deliberately absent (it makes JSON-RPC batching mandatory, and this
+/// endpoint parses single-object bodies only), and newer revisions stay off
+/// until their mandatory surface (list cache metadata, `server/discover`,
+/// header routing) lands. The stdio transport negotiates separately via rmcp.
+pub(crate) const SUPPORTED_MCP_PROTOCOL_VERSIONS: [&str; 2] = ["2025-06-18", "2024-11-05"];
+
+/// Spec version negotiation for `initialize`: echo the client's requested
+/// revision when this endpoint implements it; otherwise answer with the
+/// newest implemented revision and let the client decide whether to proceed.
+/// A missing or malformed `protocolVersion` also gets the newest — tolerant
+/// reads beat guessing a caller's era wrong.
+pub(crate) fn negotiated_mcp_protocol_version(requested: Option<&str>) -> &'static str {
+    requested
+        .and_then(|req| {
+            SUPPORTED_MCP_PROTOCOL_VERSIONS
+                .iter()
+                .find(|v| **v == req)
+                .copied()
+        })
+        .unwrap_or(SUPPORTED_MCP_PROTOCOL_VERSIONS[0])
+}
+
 pub(crate) async fn handle_mcp_http_request(
     body: &str,
     server: &crate::mcp::IntendantServer,
@@ -452,8 +477,13 @@ pub(crate) async fn handle_mcp_http_request(
             if let Some(sid) = gate_session.as_deref() {
                 note_supervised_mcp_serve(bus, sid, McpServeMilestone::Initialize);
             }
+            let requested = request
+                .params
+                .as_ref()
+                .and_then(|params| params.get("protocolVersion"))
+                .and_then(serde_json::Value::as_str);
             Ok(serde_json::json!({
-                "protocolVersion": "2024-11-05",
+                "protocolVersion": negotiated_mcp_protocol_version(requested),
                 "capabilities": { "tools": {} },
                 "serverInfo": {
                     "name": "intendant",
@@ -920,6 +950,97 @@ pub(crate) fn mcp_agent_session_context(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The stateless `/mcp` endpoint negotiates `initialize` per spec: echo
+    /// a requested revision it implements, otherwise answer with the newest
+    /// it does. 2025-03-26 is deliberately not echoed (its mandatory
+    /// JSON-RPC batching is unimplemented here).
+    #[test]
+    fn initialize_negotiates_protocol_version() {
+        assert_eq!(
+            negotiated_mcp_protocol_version(Some("2025-06-18")),
+            "2025-06-18"
+        );
+        assert_eq!(
+            negotiated_mcp_protocol_version(Some("2024-11-05")),
+            "2024-11-05"
+        );
+        assert_eq!(
+            negotiated_mcp_protocol_version(Some("2025-03-26")),
+            "2025-06-18"
+        );
+        assert_eq!(
+            negotiated_mcp_protocol_version(Some("2026-07-28")),
+            "2025-06-18"
+        );
+        assert_eq!(negotiated_mcp_protocol_version(None), "2025-06-18");
+    }
+
+    /// End-to-end through `handle_mcp_http_request`: the wire response's
+    /// `protocolVersion` follows negotiation and capabilities stay
+    /// tools-only.
+    #[test]
+    fn initialize_response_negotiates_on_the_wire() {
+        use crate::event::EventBus;
+        use crate::mcp::tests::{test_server, test_state};
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let tmp = tempfile::TempDir::new().unwrap();
+            let loopback: std::net::SocketAddr = "127.0.0.1:9".parse().unwrap();
+            let request = format!(
+                "POST /mcp HTTP/1.1\r\nHost: 127.0.0.1:1\r\nx-intendant-loopback-token: {}\r\n\r\n",
+                crate::loopback_token::loopback_admission_token()
+            );
+            let access =
+                mcp_http_access_context(tmp.path(), None, None, false, false, loopback, &request)
+                    .unwrap();
+            let (_home, server) = test_server(test_state(), EventBus::new());
+            let bus = EventBus::new();
+            for (requested, expect) in [
+                ("2024-11-05", "2024-11-05"),
+                ("2025-06-18", "2025-06-18"),
+                ("2025-03-26", "2025-06-18"),
+                ("not-a-version", "2025-06-18"),
+            ] {
+                let body = serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": requested,
+                        "capabilities": {},
+                        "clientInfo": {"name": "t", "version": "0"},
+                    },
+                })
+                .to_string();
+                let outcome =
+                    handle_mcp_http_request(&body, &server, None, None, None, &access, None, &bus)
+                        .await;
+                let McpHttpOutcome::Response(resp) = outcome else {
+                    panic!("initialize must produce a response (requested {requested})");
+                };
+                let result = resp.result.expect("initialize result");
+                assert_eq!(
+                    result
+                        .get("protocolVersion")
+                        .and_then(serde_json::Value::as_str),
+                    Some(expect),
+                    "requested {requested}"
+                );
+                assert!(
+                    result
+                        .get("capabilities")
+                        .and_then(|c| c.get("tools"))
+                        .is_some(),
+                    "capabilities must stay tools-only-shaped (requested {requested})"
+                );
+            }
+        });
+    }
 
     /// The mcp_token-less loopback tail of the /mcp ladder mints
     /// `local_process` — owner posture — so it now requires the per-boot


### PR DESCRIPTION
First implementation slice of the MCP control-lane program (design: #885, `docs/design-mcp-control-lane.md`) — the M0 protocol-hygiene items that are pure wins regardless of the rest of the program.

**1. `/mcp` protocol version negotiation.** `initialize` hardcoded `2024-11-05` no matter what the client requested. It now negotiates per spec: a requested revision the endpoint implements (`2025-06-18`, `2024-11-05`) is echoed; anything else gets the newest implemented revision and the client decides. `2025-03-26` is deliberately not advertised: that revision makes JSON-RPC batching mandatory, and this endpoint parses single-object bodies only (noted in the new `SUPPORTED_MCP_PROTOCOL_VERSIONS` doc). The stdio transport already negotiates via rmcp and is untouched; the `2024-11-05` string in the codex external-agent test mock is a fixture, not wire code, and stays.

**2. Unknown `tool_profile` values fall back to `core` instead of the full surface.** Flagging this one for review attention because the old behavior was a documented deliberate decision ("typoed third-party URLs should not silently hide tools"). The reconciliation: the full unfiltered list is itself the failure mode the profiles exist to prevent (tens of KB of tool schemas swamping a session's context), profile shaping never gates calls (hidden tools stay callable), and the listing edge now logs the unknown profile name — so a typo stays diagnosable while the standard operating set is still advertised. The old comment's rationale is preserved and answered in the new comment.

Tests: negotiation unit + on-the-wire coverage; unknown-profile ≡ core pinned through the real serving path in both managed-context states; a known-profile-list pin so a future profile arm that forgets the log list fails a test; stale fail-open comments in existing tests updated.
