### PR TITLE
mcp: terminal tool family (M1b)

### DIFF
--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -405,7 +405,11 @@ authorities here). Output is polled with a monotonic cursor over the
 marker — and the exit status is retained so a poller that missed the
 death still learns it. Visibility is the registry's own model: root
 surfaces see every session, scoped principals see their own and shared
-ones. None of these ride the scoped profiles; they appear on
+ones. A shell spawned for a scoped principal is OS-sandboxed to the
+grant's filesystem scope and — independently, even when the grant
+carries no scope — never inherits the daemon's process environment (the
+daemon env holds provider API keys; the child env is cleared and
+rebuilt secret-free). None of these ride the scoped profiles; they appear on
 full/unprofiled listings and through the facade's `terminal` commands
 (`open` and `write` on the `authorize` lane — writing into a live shell
 is running commands).
@@ -415,7 +419,7 @@ is running commands).
 | `terminal_list` | Visible sessions: id, liveness, sharing, geometry, retained exit status. | — |
 | `terminal_open` | Open or create a shell PTY (shell-spawn class); returns the id, whether it was created, geometry, and the starting read cursor. | `terminal_id?`, `cols?`, `rows?`, `shared?` |
 | `terminal_read` | Cursor-paged output read with gap reporting, liveness, and exit status. | `terminal_id`, `cursor?`, `max_bytes?` |
-| `terminal_write` | Write to a live shell's stdin (appends a newline by default; `enter: false` for raw keystrokes). | `terminal_id`, `input`, `enter?` |
+| `terminal_write` | Write to a live shell's stdin (appends Enter — a carriage return — by default; `enter: false` for raw keystrokes). | `terminal_id`, `input`, `enter?` |
 | `terminal_resize` | Resize the PTY. | `terminal_id`, `cols`, `rows` |
 | `terminal_close` | Close the session. | `terminal_id` |
 

--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -410,7 +410,8 @@ grant's filesystem scope and — independently, even when the grant
 carries no scope — never inherits the daemon's process environment (the
 daemon env holds provider API keys; the child env is cleared and
 rebuilt secret-free, and the shell starts profile-less so rc files
-can't repopulate it). The sandbox is fixed at spawn, so a caller-owned
+can't repopulate it — a shell with no known profile-suppression mode is
+substituted by profile-less bash). The sandbox is fixed at spawn, so a caller-owned
 session whose grant scope has since changed is refused as stale by
 open-attach, reads, writes, and resizes — close it and reopen to get a
 shell under the current scope. None of these ride the scoped profiles; they appear on

--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -409,7 +409,8 @@ ones. A shell spawned for a scoped principal is OS-sandboxed to the
 grant's filesystem scope and — independently, even when the grant
 carries no scope — never inherits the daemon's process environment (the
 daemon env holds provider API keys; the child env is cleared and
-rebuilt secret-free). None of these ride the scoped profiles; they appear on
+rebuilt secret-free, and the shell starts profile-less so rc files
+can't repopulate it). None of these ride the scoped profiles; they appear on
 full/unprofiled listings and through the facade's `terminal` commands
 (`open` and `write` on the `authorize` lane — writing into a live shell
 is running commands).

--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -410,7 +410,10 @@ grant's filesystem scope and — independently, even when the grant
 carries no scope — never inherits the daemon's process environment (the
 daemon env holds provider API keys; the child env is cleared and
 rebuilt secret-free, and the shell starts profile-less so rc files
-can't repopulate it). None of these ride the scoped profiles; they appear on
+can't repopulate it). The sandbox is fixed at spawn, so a caller-owned
+session whose grant scope has since changed is refused as stale by
+open-attach, reads, writes, and resizes — close it and reopen to get a
+shell under the current scope. None of these ride the scoped profiles; they appear on
 full/unprofiled listings and through the facade's `terminal` commands
 (`open` and `write` on the `authorize` lane — writing into a live shell
 is running commands).

--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -391,6 +391,34 @@ active holder.
 | `release_browser_workspace`   | Release a workspace lease. | `workspace_id`, `holder_id?`, `note?` |
 | `close_browser_workspace`     | Close a workspace and terminate its local browser process when owned here. | `workspace_id`, `reason?` |
 
+### Terminal
+
+Request/response shell access sharing the dashboard's PTY pool — a shell
+opened over MCP is attachable from a dashboard terminal tile and vice
+versa. Reads ride `terminal.view`; input, resize, and close ride
+`terminal.write`; `terminal_open` creates the shell when absent and is
+therefore gated as `shell.spawn` structurally (the attach-vs-create split
+the dashboard tunnel frame decides statefully is simply two different
+authorities here). Output is polled with a monotonic cursor over the
+256 KiB scrollback ring; a cursor that has fallen off the window reports
+`gap: true` — the polling analogue of the push lane's dropped-output
+marker — and the exit status is retained so a poller that missed the
+death still learns it. Visibility is the registry's own model: root
+surfaces see every session, scoped principals see their own and shared
+ones. None of these ride the scoped profiles; they appear on
+full/unprofiled listings and through the facade's `terminal` commands
+(`open` and `write` on the `authorize` lane — writing into a live shell
+is running commands).
+
+| Tool | Description | Params |
+|------|-------------|--------|
+| `terminal_list` | Visible sessions: id, liveness, sharing, geometry, retained exit status. | — |
+| `terminal_open` | Open or create a shell PTY (shell-spawn class); returns the id, whether it was created, geometry, and the starting read cursor. | `terminal_id?`, `cols?`, `rows?`, `shared?` |
+| `terminal_read` | Cursor-paged output read with gap reporting, liveness, and exit status. | `terminal_id`, `cursor?`, `max_bytes?` |
+| `terminal_write` | Write to a live shell's stdin (appends a newline by default; `enter: false` for raw keystrokes). | `terminal_id`, `input`, `enter?` |
+| `terminal_resize` | Resize the PTY. | `terminal_id`, `cols`, `rows` |
+| `terminal_close` | Close the session. | `terminal_id` |
+
 ### Remote compute & Codex Cloud workers
 
 `remote_command` offloads heavy platform-neutral compilation and testing to

--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -1274,7 +1274,8 @@ pub(crate) async fn api_mcp_tool_call_response(
             // names a session on this lane, so the actor carries the
             // dashboard principal only (the `session_id` param above is
             // context selection, not identity).
-            crate::mcp::ToolCaller::from_gate(&runtime.grant.access_principal(), None),
+            crate::mcp::ToolCaller::from_gate(&runtime.grant.access_principal(), None)
+                .with_fs_scope(runtime.grant.filesystem()),
         )
         .await
     {

--- a/src/bin/caller/dashboard_control/api_transfers_fs.rs
+++ b/src/bin/caller/dashboard_control/api_transfers_fs.rs
@@ -2979,6 +2979,7 @@ mod tests {
                 "https",
             ),
             iam_state: None,
+            peer_filesystem: None,
         };
 
         let unresolvable = "00000000-0000-0000-0000-000000000000";

--- a/src/bin/caller/mcp/facade.rs
+++ b/src/bin/caller/mcp/facade.rs
@@ -512,7 +512,7 @@ pub(crate) const COMMANDS: &[CommandSpec] = &[
             "no-enter",
             "__no_enter",
             Bool,
-            "raw keystrokes, no newline"
+            "raw keystrokes, no Enter"
         )],
         help: "Write a command line (or raw input) into a live shell",
     },

--- a/src/bin/caller/mcp/facade.rs
+++ b/src/bin/caller/mcp/facade.rs
@@ -451,6 +451,93 @@ pub(crate) const COMMANDS: &[CommandSpec] = &[
         )],
         help: "Per-layer display/CU readiness diagnosis",
     },
+    // The terminal family (owner-ruled): reads on inspect; resize/close on
+    // act; open (shell.spawn) and write (command execution in a live
+    // shell) on authorize — writing into a shell IS running commands, the
+    // same class as spawning one.
+    CommandSpec {
+        path: &["terminal", "list"],
+        lane: RiskLane::Inspect,
+        tool: "terminal_list",
+        seed: "{}",
+        positionals: &[],
+        flags: &[],
+        help: "List the shell sessions visible to the caller",
+    },
+    CommandSpec {
+        path: &["terminal", "open"],
+        lane: RiskLane::Authorize,
+        tool: "terminal_open",
+        seed: "{}",
+        positionals: &[p_str("TERMINAL_ID", "terminal_id", false, false)],
+        flags: &[
+            flag!("cols", "cols", U64, "initial columns (default 120)"),
+            flag!("rows", "rows", U64, "initial rows (default 32)"),
+            flag!("shared", "shared", Bool, "visible to other principals"),
+        ],
+        help: "Open or create a shell PTY session (shell-spawn class)",
+    },
+    CommandSpec {
+        path: &["terminal", "read"],
+        lane: RiskLane::Inspect,
+        tool: "terminal_read",
+        seed: "{}",
+        positionals: &[p_str("TERMINAL_ID", "terminal_id", true, false)],
+        flags: &[
+            flag!(
+                "cursor",
+                "cursor",
+                U64,
+                "from a previous read's next_cursor"
+            ),
+            flag!(
+                "max-bytes",
+                "max_bytes",
+                U64,
+                "cap one read (default 16384)"
+            ),
+        ],
+        help: "Cursor-paged read of a shell session's output",
+    },
+    CommandSpec {
+        path: &["terminal", "write"],
+        lane: RiskLane::Authorize,
+        tool: "terminal_write",
+        seed: "{}",
+        positionals: &[
+            p_str("TERMINAL_ID", "terminal_id", true, false),
+            p_str("INPUT", "input", true, true),
+        ],
+        flags: &[flag!(
+            "no-enter",
+            "__no_enter",
+            Bool,
+            "raw keystrokes, no newline"
+        )],
+        help: "Write a command line (or raw input) into a live shell",
+    },
+    CommandSpec {
+        path: &["terminal", "resize"],
+        lane: RiskLane::Act,
+        tool: "terminal_resize",
+        seed: "{}",
+        positionals: &[
+            p_str("TERMINAL_ID", "terminal_id", true, false),
+            p_u64("COLS", "cols"),
+            p_u64("ROWS", "rows"),
+        ],
+        flags: &[],
+        help: "Resize a shell session's PTY",
+    },
+    CommandSpec {
+        path: &["terminal", "close"],
+        lane: RiskLane::Act,
+        tool: "terminal_close",
+        seed: "{}",
+        positionals: &[p_str("TERMINAL_ID", "terminal_id", true, false)],
+        flags: &[],
+        help: "Close a shell session",
+    },
     // The managed-context recovery family: under rewind-only pressure the
     // dispatcher's pressure gate admits only these (applied to the RESOLVED
     // tool — facade meta names are exempt at the envelope so recovery stays
@@ -781,6 +868,12 @@ fn build_args(spec: &CommandSpec, rest: &[String]) -> Result<serde_json::Value, 
             ));
         }
     }
+    // The `terminal write` shape: --no-enter maps onto the tool's
+    // enter=false (a positive flag would read "submit" — the CLI-shaped
+    // negative reads better in argv).
+    if obj.remove("__no_enter").is_some() {
+        obj.insert("enter".to_string(), serde_json::Value::Bool(false));
+    }
     // The `ask` shape: repeatable --option labels become option objects.
     if let Some(options) = obj.remove("__options") {
         let labels = options.as_array().cloned().unwrap_or_default();
@@ -1045,6 +1138,7 @@ mod tests {
             Op::MemoryRead,
             Op::DisplayView,
             Op::PeerInspect,
+            Op::TerminalView,
         ];
         for spec in COMMANDS {
             let op = crate::mcp::mcp_tool_operation(spec.tool);

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -74,6 +74,11 @@ pub(crate) use tools_ask::{
 pub(crate) use tools_ask::unregister_pending_ask;
 mod tools_codex_cloud;
 mod tools_display;
+mod tools_terminal;
+pub(crate) use tools_terminal::{
+    TerminalCloseParams, TerminalOpenParams, TerminalReadParams, TerminalResizeParams,
+    TerminalWriteParams,
+};
 mod tools_managed;
 mod tools_notes;
 mod tools_remote_compute;
@@ -170,6 +175,32 @@ impl IntendantServer {
         &self,
     ) -> Option<std::sync::Arc<crate::handover::HandoverRuntime>> {
         self.state.read().await.handover.clone()
+    }
+
+    /// The gateway's shell PTY registry, when this server shape carries
+    /// one (`None` on bare stdio servers — terminal tools answer
+    /// "unavailable").
+    pub(crate) async fn terminal_registry(
+        &self,
+    ) -> Option<std::sync::Arc<crate::terminal::TerminalRegistry>> {
+        self.state.read().await.terminal.clone()
+    }
+
+    /// Sync best-effort boot wiring for the terminal registry (the
+    /// gateway's setup path is not async — same pattern as
+    /// [`Self::handover_runtime_now`]). Returns whether the handle landed;
+    /// at boot the state lock is uncontended, so a `false` is loud news.
+    pub(crate) fn set_terminal_registry_now(
+        &self,
+        registry: std::sync::Arc<crate::terminal::TerminalRegistry>,
+    ) -> bool {
+        match self.state.try_write() {
+            Ok(mut state) => {
+                state.terminal = Some(registry);
+                true
+            }
+            Err(_) => false,
+        }
     }
 
     /// Sync best-effort read for boot-time wiring in non-async spawn
@@ -937,6 +968,39 @@ impl IntendantServer {
                 let params = parse_params::<ReleaseBrowserWorkspaceParams>(args)?;
                 Ok(text_tool_result(
                     self.release_browser_workspace(params).await,
+                ))
+            }
+            "terminal_list" => Ok(text_tool_result(
+                self.terminal_list_tool(caller, &actor).await,
+            )),
+            "terminal_open" => {
+                let Parameters(params) = parse_params::<TerminalOpenParams>(args)?;
+                Ok(text_tool_result(
+                    self.terminal_open_tool(params, caller, &actor).await,
+                ))
+            }
+            "terminal_read" => {
+                let Parameters(params) = parse_params::<TerminalReadParams>(args)?;
+                Ok(text_tool_result(
+                    self.terminal_read_tool(params, caller, &actor).await,
+                ))
+            }
+            "terminal_write" => {
+                let Parameters(params) = parse_params::<TerminalWriteParams>(args)?;
+                Ok(text_tool_result(
+                    self.terminal_write_tool(params, caller, &actor).await,
+                ))
+            }
+            "terminal_resize" => {
+                let Parameters(params) = parse_params::<TerminalResizeParams>(args)?;
+                Ok(text_tool_result(
+                    self.terminal_resize_tool(params, caller, &actor).await,
+                ))
+            }
+            "terminal_close" => {
+                let Parameters(params) = parse_params::<TerminalCloseParams>(args)?;
+                Ok(text_tool_result(
+                    self.terminal_close_tool(params, caller, &actor).await,
                 ))
             }
             "list_displays" => Ok(text_tool_result(self.list_displays().await)),

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -985,19 +985,22 @@ impl IntendantServer {
             "terminal_read" => {
                 let Parameters(params) = parse_params::<TerminalReadParams>(args)?;
                 Ok(text_tool_result(
-                    self.terminal_read_tool(params, caller, &actor).await,
+                    self.terminal_read_tool(params, caller, &actor, fs_scope)
+                        .await,
                 ))
             }
             "terminal_write" => {
                 let Parameters(params) = parse_params::<TerminalWriteParams>(args)?;
                 Ok(text_tool_result(
-                    self.terminal_write_tool(params, caller, &actor).await,
+                    self.terminal_write_tool(params, caller, &actor, fs_scope)
+                        .await,
                 ))
             }
             "terminal_resize" => {
                 let Parameters(params) = parse_params::<TerminalResizeParams>(args)?;
                 Ok(text_tool_result(
-                    self.terminal_resize_tool(params, caller, &actor).await,
+                    self.terminal_resize_tool(params, caller, &actor, fs_scope)
+                        .await,
                 ))
             }
             "terminal_close" => {

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -596,6 +596,7 @@ impl IntendantServer {
         let ToolCaller {
             trust: caller,
             actor,
+            fs_scope,
         } = caller;
         fn parse_params<T: serde::de::DeserializeOwned>(
             args: serde_json::Value,
@@ -653,6 +654,7 @@ impl IntendantServer {
                         ToolCaller {
                             trust: caller,
                             actor,
+                            fs_scope,
                         },
                     ))
                     .await
@@ -976,7 +978,8 @@ impl IntendantServer {
             "terminal_open" => {
                 let Parameters(params) = parse_params::<TerminalOpenParams>(args)?;
                 Ok(text_tool_result(
-                    self.terminal_open_tool(params, caller, &actor).await,
+                    self.terminal_open_tool(params, caller, &actor, fs_scope)
+                        .await,
                 ))
             }
             "terminal_read" => {
@@ -2678,6 +2681,12 @@ impl ToolCallerTrust {
 pub struct ToolCaller {
     pub trust: ToolCallerTrust,
     pub actor: crate::access::actor::ActorBinding,
+    /// The filesystem scope sandboxing any shell this caller spawns
+    /// (`terminal_open`): `None` = unrestricted (owner surfaces and
+    /// scope-less grants — dashboard-tunnel parity). Constructors default
+    /// to the EMPTY policy — fail closed — until a gate resolves the real
+    /// scope via [`Self::with_fs_scope`].
+    pub fs_scope: Option<crate::peer::access_policy::FilesystemAccessPolicy>,
 }
 
 impl ToolCaller {
@@ -2687,6 +2696,7 @@ impl ToolCaller {
         Self {
             trust: ToolCallerTrust::Scoped,
             actor: crate::access::actor::ActorBinding::unattributed(),
+            fs_scope: Some(crate::peer::access_policy::FilesystemAccessPolicy::default()),
         }
     }
 
@@ -2701,7 +2711,21 @@ impl ToolCaller {
         Self {
             trust: ToolCallerTrust::from_principal(principal),
             actor: crate::access::actor::ActorBinding::from_principal(principal, gate_session),
+            // Fail-closed until the gate states the real scope — an
+            // ungated ToolCaller sandboxes any shell it spawns to nothing.
+            fs_scope: Some(crate::peer::access_policy::FilesystemAccessPolicy::default()),
         }
+    }
+
+    /// State the caller's resolved filesystem scope (the gate's job:
+    /// `RequestAuthority::fs_scope` on HTTP, `DashboardControlGrant::
+    /// filesystem` on the tunnel). `None` = unrestricted.
+    pub fn with_fs_scope(
+        mut self,
+        fs_scope: Option<crate::peer::access_policy::FilesystemAccessPolicy>,
+    ) -> Self {
+        self.fs_scope = fs_scope;
+        self
     }
 }
 

--- a/src/bin/caller/mcp/state.rs
+++ b/src/bin/caller/mcp/state.rs
@@ -144,6 +144,10 @@ pub struct McpAppState {
     /// scheduler-lease view, for the `scheduler_lease` status block.
     /// `None` outside the gateway/daemon shapes.
     pub handover: Option<std::sync::Arc<crate::handover::HandoverRuntime>>,
+    /// The gateway's shell PTY registry, for the terminal tool family.
+    /// `None` outside the gateway/daemon shapes (bare stdio servers) —
+    /// terminal surfaces then answer "unavailable".
+    pub terminal: Option<std::sync::Arc<crate::terminal::TerminalRegistry>>,
     /// Directory for screenshot output.
     pub screenshot_dir: Option<std::path::PathBuf>,
     /// Persistent counter for screenshot filenames (avoids overwriting).
@@ -332,6 +336,7 @@ impl McpAppState {
             agenda: None,
             memory: None,
             handover: None,
+            terminal: None,
             user_display_activation_pending: std::collections::HashMap::new(),
             display_capture_ready: HashSet::new(),
             screenshot_dir: None,

--- a/src/bin/caller/mcp/tool_gate.rs
+++ b/src/bin/caller/mcp/tool_gate.rs
@@ -298,6 +298,15 @@ pub(crate) fn mcp_tool_operation(name: &str) -> crate::peer::access_policy::Peer
         // it falls to the restrictive default rather than anything
         // broader, and never authorizes the envelope as a whole.
         "inspect" | "act" | "authorize" | "help" | "docs" => PeerOperation::RuntimeControl,
+        // The terminal family (owner-ruled 2026-08-28: controlling agents
+        // get terminal access, R2 tentatively at Operate). Reads ride
+        // terminal.view; input/resize/close ride terminal.write; open is
+        // the create-capable verb and carries shell.spawn structurally —
+        // this is the deliberate lift of the historical "no MCP tool
+        // reaches Terminal*" pin, per docs/design-mcp-control-lane.md.
+        "terminal_list" | "terminal_read" => PeerOperation::TerminalView,
+        "terminal_write" | "terminal_resize" | "terminal_close" => PeerOperation::TerminalWrite,
+        "terminal_open" => PeerOperation::ShellSpawn,
         // Daemon/agent status summaries. whoami rides here: it discloses
         // only the caller's own gate-resolved identity — strictly less than
         // get_status already reveals.
@@ -474,6 +483,60 @@ fn build_manual_http_tool_definitions() -> Vec<serde_json::Value> {
         );
         tools.push(definition);
     };
+
+    // The terminal family: request/response shell access sharing the
+    // dashboard's PTY pool. Advertised on full/unprofiled listings and
+    // reached through the facade's `terminal` commands; deliberately kept
+    // out of core/screen/managed (context rent + the remote_command
+    // precedent).
+    push(
+        "terminal_list",
+        manual_http_tool_definition!(
+            "terminal_list",
+            "List the shell sessions visible to the caller: id, liveness, sharing, geometry, retained exit status. Root surfaces see every session; scoped principals see their own and shared ones.",
+            crate::mcp::tools_terminal::TerminalListParams
+        ),
+    );
+    push(
+        "terminal_open",
+        manual_http_tool_definition!(
+            "terminal_open",
+            "Open (attach) or create a shell PTY session on this daemon. Creation is why this tool is gated as shell.spawn; attach-only workflows use terminal_list/terminal_read. Returns the id, whether it was created, geometry, and the read cursor to start polling from.",
+            crate::mcp::tools_terminal::TerminalOpenParams
+        ),
+    );
+    push(
+        "terminal_read",
+        manual_http_tool_definition!(
+            "terminal_read",
+            "Cursor-paged read of a visible shell session's output (0 = oldest retained). Returns the text, the next cursor, whether a gap fell off the 256 KiB scrollback ring, liveness, and the retained exit status. Poll after terminal_write.",
+            crate::mcp::tools_terminal::TerminalReadParams
+        ),
+    );
+    push(
+        "terminal_write",
+        manual_http_tool_definition!(
+            "terminal_write",
+            "Write input to a visible live shell session's stdin (appends a newline by default; pass enter=false for raw keystrokes). Refuses with the exit status when the shell has died.",
+            crate::mcp::tools_terminal::TerminalWriteParams
+        ),
+    );
+    push(
+        "terminal_resize",
+        manual_http_tool_definition!(
+            "terminal_resize",
+            "Resize a visible shell session's PTY.",
+            crate::mcp::tools_terminal::TerminalResizeParams
+        ),
+    );
+    push(
+        "terminal_close",
+        manual_http_tool_definition!(
+            "terminal_close",
+            "Close a visible shell session (sends end-of-input and removes it from the pool).",
+            crate::mcp::tools_terminal::TerminalCloseParams
+        ),
+    );
 
     // The facade meta-tools (`tool_profile=facade`): a CLI-shaped,
     // context-efficient control surface — three risk-lane argv executors

--- a/src/bin/caller/mcp/tool_gate.rs
+++ b/src/bin/caller/mcp/tool_gate.rs
@@ -517,7 +517,7 @@ fn build_manual_http_tool_definitions() -> Vec<serde_json::Value> {
         "terminal_write",
         manual_http_tool_definition!(
             "terminal_write",
-            "Write input to a visible live shell session's stdin (appends a newline by default; pass enter=false for raw keystrokes). Refuses with the exit status when the shell has died.",
+            "Write input to a visible live shell session's stdin (appends Enter — a carriage return — by default; pass enter=false for raw keystrokes). Refuses with the exit status when the shell has died.",
             crate::mcp::tools_terminal::TerminalWriteParams
         ),
     );

--- a/src/bin/caller/mcp/tools_display.rs
+++ b/src/bin/caller/mcp/tools_display.rs
@@ -2040,6 +2040,7 @@ mod tests {
                     ToolCaller {
                         trust: ToolCallerTrust::OwnerSurface,
                         actor: crate::access::actor::ActorBinding::unattributed(),
+                        fs_scope: None,
                     },
                 )
                 .await
@@ -2661,6 +2662,7 @@ mod tests {
                     ToolCaller {
                         trust: ToolCallerTrust::OwnerSurface,
                         actor: crate::access::actor::ActorBinding::unattributed(),
+                        fs_scope: None,
                     },
                 )
                 .await
@@ -2908,6 +2910,7 @@ mod tests {
                     ToolCaller {
                         trust: ToolCallerTrust::OwnerSurface,
                         actor: crate::access::actor::ActorBinding::unattributed(),
+                        fs_scope: None,
                     },
                 )
                 .await

--- a/src/bin/caller/mcp/tools_terminal.rs
+++ b/src/bin/caller/mcp/tools_terminal.rs
@@ -109,6 +109,27 @@ fn terminal_actor(
     }
 }
 
+/// How much of `bytes` to deliver so the page ends on a UTF-8 boundary:
+/// the whole page when it is valid or ends mid-page-invalid (binary —
+/// lossy is honest), trimmed when the tail is an INCOMPLETE multibyte
+/// sequence a later page completes. A page smaller than one sequence is
+/// delivered whole so progress is always made.
+fn utf8_page_len(bytes: &[u8]) -> usize {
+    match std::str::from_utf8(bytes) {
+        Ok(_) => bytes.len(),
+        Err(err) => {
+            if err.error_len().is_some() {
+                // Invalid sequence inside the page — not a boundary split.
+                bytes.len()
+            } else if err.valid_up_to() == 0 && !bytes.is_empty() {
+                bytes.len()
+            } else {
+                err.valid_up_to()
+            }
+        }
+    }
+}
+
 fn no_registry() -> String {
     serde_json::json!({
         "ok": false,
@@ -161,6 +182,7 @@ impl IntendantServer {
         params: TerminalOpenParams,
         trust: ToolCallerTrust,
         actor: &crate::access::actor::ActorBinding,
+        fs_scope: Option<crate::peer::access_policy::FilesystemAccessPolicy>,
     ) -> String {
         let Some(registry) = self.terminal_registry().await else {
             return no_registry();
@@ -179,7 +201,12 @@ impl IntendantServer {
             // which never spawn).
             may_spawn: true,
             shared: params.shared.unwrap_or(false),
-            scope: None,
+            // The caller's grant-resolved filesystem scope, stated by the
+            // ingress gate (dashboard-tunnel parity): a scoped grant's
+            // shell is OS-sandboxed to its roots with a cleared
+            // environment, and an ungated caller's default is the empty
+            // scope — never an unrestricted, key-bearing shell.
+            scope: fs_scope,
         };
         match registry
             .open_or_attach(
@@ -232,9 +259,18 @@ impl IntendantServer {
             .unwrap_or(TERMINAL_READ_DEFAULT_BYTES)
             .min(TERMINAL_READ_MAX_BYTES);
         let (bytes, next_cursor, gap) = session.read_since(params.cursor.unwrap_or(0), max_bytes);
+        // A multibyte UTF-8 sequence split at the page boundary must not
+        // decay into replacement characters on both pages: hold the
+        // incomplete tail back (rewinding the cursor to the boundary) so
+        // the next read re-delivers it whole. Genuinely invalid bytes
+        // mid-page (binary output) stay lossy — that is honest — and a
+        // page smaller than one sequence is delivered as-is so a tiny
+        // max_bytes still makes progress.
+        let kept = utf8_page_len(&bytes);
+        let next_cursor = next_cursor - (bytes.len() - kept) as u64;
         serde_json::json!({
             "ok": true,
-            "output": String::from_utf8_lossy(&bytes),
+            "output": String::from_utf8_lossy(&bytes[..kept]),
             "next_cursor": next_cursor,
             "gap": gap,
             "alive": session.is_alive(),
@@ -320,6 +356,28 @@ impl IntendantServer {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A multibyte sequence split at the page boundary is held back for
+    /// the next page instead of decaying into replacement characters on
+    /// both sides (review P2); binary garbage stays lossy, and a page
+    /// smaller than one sequence still makes progress.
+    #[test]
+    fn utf8_page_len_holds_back_incomplete_tails() {
+        let s = "ab\u{00e9}".as_bytes(); // 'é' = 2 bytes
+        assert_eq!(utf8_page_len(&s[..3]), 2, "split tail held back");
+        assert_eq!(utf8_page_len(s), 4, "complete page delivered whole");
+        assert_eq!(
+            utf8_page_len(&[0xff, 0x61]),
+            2,
+            "invalid mid-page stays lossy"
+        );
+        assert_eq!(
+            utf8_page_len(&s[2..3]),
+            1,
+            "sub-sequence page still progresses"
+        );
+        assert_eq!(utf8_page_len(b""), 0);
+    }
 
     #[test]
     fn scoped_actor_without_principal_owns_nothing() {

--- a/src/bin/caller/mcp/tools_terminal.rs
+++ b/src/bin/caller/mcp/tools_terminal.rs
@@ -60,7 +60,8 @@ pub struct TerminalReadParams {
     /// retained output).
     #[serde(default)]
     pub cursor: Option<u64>,
-    /// Max bytes to return (default 16384, cap 65536).
+    /// Max bytes to return (default 16384, cap 65536, floor 4 — a page
+    /// never consumes a split UTF-8 sequence).
     #[serde(default)]
     pub max_bytes: Option<usize>,
 }
@@ -110,18 +111,22 @@ fn terminal_actor(
 }
 
 /// How much of `bytes` to deliver so the page ends on a UTF-8 boundary:
-/// the whole page when it is valid or ends mid-page-invalid (binary —
-/// lossy is honest), trimmed when the tail is an INCOMPLETE multibyte
-/// sequence a later page completes. A page smaller than one sequence is
-/// delivered whole so progress is always made.
+/// the whole page when it is valid or contains a genuinely INVALID
+/// sequence (binary output — lossy is honest), trimmed to the last
+/// boundary when the tail is an INCOMPLETE sequence a later page
+/// completes. An incomplete prefix is NEVER consumed — even when that
+/// means an empty page with a parked cursor — because delivering it
+/// lossily advances past bytes the caller can then never reconstruct.
+/// Progress is guaranteed by the read floor (`max_bytes` ≥ 4, the
+/// longest UTF-8 sequence): a page that starts on a boundary and has
+/// room for a whole sequence only ever trims a tail the ring has not
+/// finished receiving yet.
 fn utf8_page_len(bytes: &[u8]) -> usize {
     match std::str::from_utf8(bytes) {
         Ok(_) => bytes.len(),
         Err(err) => {
             if err.error_len().is_some() {
                 // Invalid sequence inside the page — not a boundary split.
-                bytes.len()
-            } else if err.valid_up_to() == 0 && !bytes.is_empty() {
                 bytes.len()
             } else {
                 err.valid_up_to()
@@ -254,18 +259,19 @@ impl IntendantServer {
         else {
             return no_visible(&params.terminal_id);
         };
+        // Floor 4 (the longest UTF-8 sequence): with boundary-aligned
+        // cursors and room for a whole sequence, the boundary trim below
+        // can only hold back a tail the ring has not finished receiving.
         let max_bytes = params
             .max_bytes
             .unwrap_or(TERMINAL_READ_DEFAULT_BYTES)
-            .min(TERMINAL_READ_MAX_BYTES);
+            .clamp(4, TERMINAL_READ_MAX_BYTES);
         let (bytes, next_cursor, gap) = session.read_since(params.cursor.unwrap_or(0), max_bytes);
         // A multibyte UTF-8 sequence split at the page boundary must not
         // decay into replacement characters on both pages: hold the
         // incomplete tail back (rewinding the cursor to the boundary) so
         // the next read re-delivers it whole. Genuinely invalid bytes
-        // mid-page (binary output) stay lossy — that is honest — and a
-        // page smaller than one sequence is delivered as-is so a tiny
-        // max_bytes still makes progress.
+        // mid-page (binary output) stay lossy — that is honest.
         let kept = utf8_page_len(&bytes);
         let next_cursor = next_cursor - (bytes.len() - kept) as u64;
         serde_json::json!({
@@ -371,10 +377,13 @@ mod tests {
             2,
             "invalid mid-page stays lossy"
         );
+        // An incomplete PREFIX is never consumed — the cursor parks, and
+        // the read floor (max_bytes ≥ 4) guarantees the next page has
+        // room for the whole sequence.
         assert_eq!(
             utf8_page_len(&s[2..3]),
-            1,
-            "sub-sequence page still progresses"
+            0,
+            "incomplete prefix held, not consumed"
         );
         assert_eq!(utf8_page_len(b""), 0);
     }

--- a/src/bin/caller/mcp/tools_terminal.rs
+++ b/src/bin/caller/mcp/tools_terminal.rs
@@ -23,6 +23,7 @@
 //!   principal id degrades to a principal that owns nothing.
 
 use super::*;
+use crate::peer::access_policy::FilesystemAccessPolicy;
 use crate::terminal::{ShellSpawnPolicy, TerminalActor, TerminalKey};
 
 /// Cap on one cursor read. Big enough for a full scrollback replay in
@@ -175,6 +176,34 @@ fn no_visible(terminal_id: &str) -> String {
     .to_string()
 }
 
+/// Whether the caller's CURRENT filesystem scope still matches the one
+/// the session's shell was spawned under. The OS sandbox is fixed at
+/// spawn, so when an operator narrows (or reissues) the owning
+/// principal's scope, the old shell keeps enforcing the broader policy
+/// — the session is refused as stale rather than serving authority the
+/// grant no longer expresses (security review P1). Applies only to
+/// sessions the CALLING principal owns: a shared session another
+/// principal spawned runs under ITS owner's authority by design, and
+/// root surfaces are never scope-bound.
+fn scope_is_stale(
+    trust: ToolCallerTrust,
+    owned: bool,
+    spawn_scope: Option<&FilesystemAccessPolicy>,
+    current: Option<&FilesystemAccessPolicy>,
+) -> bool {
+    matches!(trust, ToolCallerTrust::Scoped) && owned && spawn_scope != current
+}
+
+fn stale_scope(terminal_id: &str) -> String {
+    serde_json::json!({
+        "ok": false,
+        "error": format!(
+            "your filesystem scope changed since terminal {terminal_id:?} was spawned and its sandbox still reflects the old scope — terminal_close it, then terminal_open a fresh shell under the current scope"
+        ),
+    })
+    .to_string()
+}
+
 impl IntendantServer {
     pub(crate) async fn terminal_list_tool(
         &self,
@@ -237,7 +266,7 @@ impl IntendantServer {
             // including one whose grant carries no filesystem scope)
             // gets a cleared, secret-free environment and can never read
             // the daemon's provider keys through `env`.
-            scope: fs_scope,
+            scope: fs_scope.clone(),
         };
         match registry
             .open_or_attach(
@@ -250,6 +279,21 @@ impl IntendantServer {
             .await
         {
             Ok((session, created)) => {
+                // Attaching back to your own live shell whose sandbox
+                // predates a scope change is refused up front — the
+                // handle would only meet the same staleness refusal on
+                // every read and write. (A fresh spawn is by definition
+                // under the current scope.)
+                if !created
+                    && scope_is_stale(
+                        trust,
+                        session.managed_by(&acting),
+                        session.spawn_scope(),
+                        fs_scope.as_ref(),
+                    )
+                {
+                    return stale_scope(&terminal_id);
+                }
                 // The current write high-water is the natural first
                 // cursor: a fresh open starts reading at "now".
                 let (_, cursor, _) = session.read_since(u64::MAX, 0);
@@ -274,17 +318,24 @@ impl IntendantServer {
         params: TerminalReadParams,
         trust: ToolCallerTrust,
         actor: &crate::access::actor::ActorBinding,
+        fs_scope: Option<FilesystemAccessPolicy>,
     ) -> String {
         let Some(registry) = self.terminal_registry().await else {
             return no_registry();
         };
         let key = TerminalKey::local(&params.terminal_id);
-        let Some(session) = registry
-            .get_visible(&key, &terminal_actor(trust, actor))
-            .await
-        else {
+        let acting = terminal_actor(trust, actor);
+        let Some(session) = registry.get_visible(&key, &acting).await else {
             return no_visible(&params.terminal_id);
         };
+        if scope_is_stale(
+            trust,
+            session.managed_by(&acting),
+            session.spawn_scope(),
+            fs_scope.as_ref(),
+        ) {
+            return stale_scope(&params.terminal_id);
+        }
         // Floor 4 (the longest UTF-8 sequence): with boundary-aligned
         // cursors and room for a whole sequence, the boundary trim below
         // can only hold back a tail the ring has not finished receiving.
@@ -318,17 +369,24 @@ impl IntendantServer {
         params: TerminalWriteParams,
         trust: ToolCallerTrust,
         actor: &crate::access::actor::ActorBinding,
+        fs_scope: Option<FilesystemAccessPolicy>,
     ) -> String {
         let Some(registry) = self.terminal_registry().await else {
             return no_registry();
         };
         let key = TerminalKey::local(&params.terminal_id);
-        let Some(session) = registry
-            .get_visible(&key, &terminal_actor(trust, actor))
-            .await
-        else {
+        let acting = terminal_actor(trust, actor);
+        let Some(session) = registry.get_visible(&key, &acting).await else {
             return no_visible(&params.terminal_id);
         };
+        if scope_is_stale(
+            trust,
+            session.managed_by(&acting),
+            session.spawn_scope(),
+            fs_scope.as_ref(),
+        ) {
+            return stale_scope(&params.terminal_id);
+        }
         if !session.is_alive() {
             return serde_json::json!({
                 "ok": false,
@@ -359,17 +417,24 @@ impl IntendantServer {
         params: TerminalResizeParams,
         trust: ToolCallerTrust,
         actor: &crate::access::actor::ActorBinding,
+        fs_scope: Option<FilesystemAccessPolicy>,
     ) -> String {
         let Some(registry) = self.terminal_registry().await else {
             return no_registry();
         };
         let key = TerminalKey::local(&params.terminal_id);
-        let Some(session) = registry
-            .get_visible(&key, &terminal_actor(trust, actor))
-            .await
-        else {
+        let acting = terminal_actor(trust, actor);
+        let Some(session) = registry.get_visible(&key, &acting).await else {
             return no_visible(&params.terminal_id);
         };
+        if scope_is_stale(
+            trust,
+            session.managed_by(&acting),
+            session.spawn_scope(),
+            fs_scope.as_ref(),
+        ) {
+            return stale_scope(&params.terminal_id);
+        }
         session.resize(params.cols, params.rows);
         serde_json::json!({ "ok": true, "cols": params.cols, "rows": params.rows }).to_string()
     }
@@ -436,6 +501,55 @@ mod tests {
             "incomplete prefix held, not consumed"
         );
         assert_eq!(utf8_page_len(b""), 0);
+    }
+
+    /// A caller-owned session spawned under an older filesystem scope
+    /// is refused once the grant's scope changes — the OS sandbox is
+    /// fixed at spawn and must not keep serving authority the grant no
+    /// longer expresses (security review P1). Shared sessions another
+    /// principal owns ride that owner's authority, and root surfaces
+    /// are never scope-bound.
+    #[test]
+    fn stale_scope_refuses_only_owned_scoped_mismatches() {
+        let a = FilesystemAccessPolicy {
+            read_roots: vec!["/srv/a".into()],
+            write_roots: Vec::new(),
+        };
+        let b = FilesystemAccessPolicy {
+            read_roots: vec!["/srv/b".into()],
+            write_roots: Vec::new(),
+        };
+        assert!(scope_is_stale(
+            ToolCallerTrust::Scoped,
+            true,
+            Some(&a),
+            Some(&b)
+        ));
+        assert!(
+            scope_is_stale(ToolCallerTrust::Scoped, true, None, Some(&a)),
+            "a grant gaining a scope stales the old unscoped shell"
+        );
+        assert!(scope_is_stale(
+            ToolCallerTrust::Scoped,
+            true,
+            Some(&a),
+            None
+        ));
+        assert!(!scope_is_stale(
+            ToolCallerTrust::Scoped,
+            true,
+            Some(&a),
+            Some(&a)
+        ));
+        assert!(!scope_is_stale(ToolCallerTrust::Scoped, true, None, None));
+        assert!(
+            !scope_is_stale(ToolCallerTrust::Scoped, false, Some(&a), Some(&b)),
+            "another owner's shared session rides its owner's authority"
+        );
+        assert!(
+            !scope_is_stale(ToolCallerTrust::OwnerSurface, true, Some(&a), None),
+            "root surfaces are never scope-bound"
+        );
     }
 
     /// Once the shell has exited nothing can ever complete a split

--- a/src/bin/caller/mcp/tools_terminal.rs
+++ b/src/bin/caller/mcp/tools_terminal.rs
@@ -1,0 +1,333 @@
+//! The terminal tool family: request/response shell access for MCP
+//! callers, sharing the dashboard's PTY pool (a shell opened over MCP is
+//! attachable from a dashboard terminal tile and vice versa).
+//!
+//! Deliberate shape decisions (docs/design-mcp-control-lane.md, the
+//! owner's terminal ruling):
+//!
+//! - **Per-tool operations stay honest.** The streaming tunnel's
+//!   `terminal_open` frame does a stateful "attach = terminal.view,
+//!   create = shell.spawn" split inside the handler; here the split is
+//!   structural — `terminal_open` always demands `shell.spawn` (it
+//!   creates when absent), while reads ride `terminal.view` and
+//!   input/resize/close ride `terminal.write` — so the gate-level
+//!   operation IS the tool's whole authority.
+//! - **Polling, not streaming.** Output is read with a monotonic cursor
+//!   over the scrollback ring ([`crate::terminal::Scrollback`]'s
+//!   total-bytes-written space); a cursor that fell off the 256 KiB
+//!   window reports `gap: true` — the polling analogue of the push
+//!   lane's dropped-output marker.
+//! - **Visibility is the registry's own model**: root-surface callers act
+//!   as [`TerminalActor::Root`]; every scoped caller acts as its bound
+//!   IAM principal and sees only its own and shared sessions. A missing
+//!   principal id degrades to a principal that owns nothing.
+
+use super::*;
+use crate::terminal::{ShellSpawnPolicy, TerminalActor, TerminalKey};
+
+/// Cap on one cursor read. Big enough for a full scrollback replay in
+/// four calls, small enough to keep a tool result model-sized.
+const TERMINAL_READ_MAX_BYTES: usize = 64 * 1024;
+const TERMINAL_READ_DEFAULT_BYTES: usize = 16 * 1024;
+
+/// Params for `terminal_list` (none).
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
+pub struct TerminalListParams {}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct TerminalOpenParams {
+    /// Terminal id to open or attach (creates the shell when absent).
+    /// Omit to mint a fresh id.
+    #[serde(default)]
+    pub terminal_id: Option<String>,
+    /// Initial columns (default 120).
+    #[serde(default)]
+    pub cols: Option<u16>,
+    /// Initial rows (default 32).
+    #[serde(default)]
+    pub rows: Option<u16>,
+    /// Create the shell as shared (visible to other principals). Default
+    /// false.
+    #[serde(default)]
+    pub shared: Option<bool>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct TerminalReadParams {
+    /// The terminal id.
+    pub terminal_id: String,
+    /// Cursor from a previous read's `next_cursor` (0 = from the oldest
+    /// retained output).
+    #[serde(default)]
+    pub cursor: Option<u64>,
+    /// Max bytes to return (default 16384, cap 65536).
+    #[serde(default)]
+    pub max_bytes: Option<usize>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct TerminalWriteParams {
+    /// The terminal id.
+    pub terminal_id: String,
+    /// Bytes to write to the shell's stdin, verbatim.
+    pub input: String,
+    /// Append a newline (submit the input as a command line). Default
+    /// true — pass false for raw keystrokes.
+    #[serde(default)]
+    pub enter: Option<bool>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct TerminalResizeParams {
+    /// The terminal id.
+    pub terminal_id: String,
+    pub cols: u16,
+    pub rows: u16,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct TerminalCloseParams {
+    /// The terminal id.
+    pub terminal_id: String,
+}
+
+/// Root-surface callers act as root; every scoped caller acts as its
+/// bound principal (a missing id owns nothing — fail closed, never
+/// root).
+fn terminal_actor(
+    trust: ToolCallerTrust,
+    actor: &crate::access::actor::ActorBinding,
+) -> TerminalActor {
+    match trust {
+        ToolCallerTrust::OwnerSurface => TerminalActor::Root,
+        ToolCallerTrust::Scoped => TerminalActor::Principal(
+            actor
+                .principal_id
+                .clone()
+                .unwrap_or_else(|| "principal:unattributed".to_string()),
+        ),
+    }
+}
+
+fn no_registry() -> String {
+    serde_json::json!({
+        "ok": false,
+        "error": "terminal registry unavailable on this server shape (bare stdio --mcp has no gateway PTY pool)",
+    })
+    .to_string()
+}
+
+fn no_visible(terminal_id: &str) -> String {
+    serde_json::json!({
+        "ok": false,
+        "error": format!(
+            "no visible terminal {terminal_id:?} — terminal_list enumerates yours, terminal_open creates one"
+        ),
+    })
+    .to_string()
+}
+
+impl IntendantServer {
+    pub(crate) async fn terminal_list_tool(
+        &self,
+        trust: ToolCallerTrust,
+        actor: &crate::access::actor::ActorBinding,
+    ) -> String {
+        let Some(registry) = self.terminal_registry().await else {
+            return no_registry();
+        };
+        let rows: Vec<serde_json::Value> = registry
+            .list_visible(&terminal_actor(trust, actor))
+            .await
+            .into_iter()
+            .map(|s| {
+                serde_json::json!({
+                    "terminal_id": s.key.terminal_id,
+                    "host_id": s.key.host_id,
+                    "alive": s.alive,
+                    "shared": s.shared,
+                    "can_manage": s.can_manage,
+                    "exit_status": s.exit_status,
+                    "cols": s.size.map(|(c, _)| c),
+                    "rows": s.size.map(|(_, r)| r),
+                })
+            })
+            .collect();
+        serde_json::json!({ "terminals": rows }).to_string()
+    }
+
+    pub(crate) async fn terminal_open_tool(
+        &self,
+        params: TerminalOpenParams,
+        trust: ToolCallerTrust,
+        actor: &crate::access::actor::ActorBinding,
+    ) -> String {
+        let Some(registry) = self.terminal_registry().await else {
+            return no_registry();
+        };
+        let terminal_id = params
+            .terminal_id
+            .map(|id| id.trim().to_string())
+            .filter(|id| !id.is_empty())
+            .unwrap_or_else(|| format!("mcp-{}", &uuid::Uuid::new_v4().simple().to_string()[..8]));
+        let key = TerminalKey::local(&terminal_id);
+        let acting = terminal_actor(trust, actor);
+        let policy = ShellSpawnPolicy {
+            // The gate already charged this call as shell.spawn — that is
+            // the tool's whole operation, so creation is always permitted
+            // here (attach-only callers use terminal_read/terminal_list,
+            // which never spawn).
+            may_spawn: true,
+            shared: params.shared.unwrap_or(false),
+            scope: None,
+        };
+        match registry
+            .open_or_attach(
+                key,
+                params.cols.unwrap_or(120),
+                params.rows.unwrap_or(32),
+                &acting,
+                policy,
+            )
+            .await
+        {
+            Ok((session, created)) => {
+                // The current write high-water is the natural first
+                // cursor: a fresh open starts reading at "now".
+                let (_, cursor, _) = session.read_since(u64::MAX, 0);
+                serde_json::json!({
+                    "ok": true,
+                    "terminal_id": terminal_id,
+                    "created": created,
+                    "alive": session.is_alive(),
+                    "shared": session.shared(),
+                    "cols": session.size().map(|(c, _)| c),
+                    "rows": session.size().map(|(_, r)| r),
+                    "read_cursor": cursor,
+                })
+                .to_string()
+            }
+            Err(err) => serde_json::json!({ "ok": false, "error": err.to_string() }).to_string(),
+        }
+    }
+
+    pub(crate) async fn terminal_read_tool(
+        &self,
+        params: TerminalReadParams,
+        trust: ToolCallerTrust,
+        actor: &crate::access::actor::ActorBinding,
+    ) -> String {
+        let Some(registry) = self.terminal_registry().await else {
+            return no_registry();
+        };
+        let key = TerminalKey::local(&params.terminal_id);
+        let Some(session) = registry
+            .get_visible(&key, &terminal_actor(trust, actor))
+            .await
+        else {
+            return no_visible(&params.terminal_id);
+        };
+        let max_bytes = params
+            .max_bytes
+            .unwrap_or(TERMINAL_READ_DEFAULT_BYTES)
+            .min(TERMINAL_READ_MAX_BYTES);
+        let (bytes, next_cursor, gap) = session.read_since(params.cursor.unwrap_or(0), max_bytes);
+        serde_json::json!({
+            "ok": true,
+            "output": String::from_utf8_lossy(&bytes),
+            "next_cursor": next_cursor,
+            "gap": gap,
+            "alive": session.is_alive(),
+            "exit_status": session.exit_status(),
+        })
+        .to_string()
+    }
+
+    pub(crate) async fn terminal_write_tool(
+        &self,
+        params: TerminalWriteParams,
+        trust: ToolCallerTrust,
+        actor: &crate::access::actor::ActorBinding,
+    ) -> String {
+        let Some(registry) = self.terminal_registry().await else {
+            return no_registry();
+        };
+        let key = TerminalKey::local(&params.terminal_id);
+        let Some(session) = registry
+            .get_visible(&key, &terminal_actor(trust, actor))
+            .await
+        else {
+            return no_visible(&params.terminal_id);
+        };
+        if !session.is_alive() {
+            return serde_json::json!({
+                "ok": false,
+                "error": "shell already exited",
+                "exit_status": session.exit_status(),
+            })
+            .to_string();
+        }
+        let mut input = params.input.into_bytes();
+        if params.enter.unwrap_or(true) {
+            input.push(b'\n');
+        }
+        session.write_input(&input);
+        serde_json::json!({
+            "ok": true,
+            "wrote_bytes": input.len(),
+            "hint": "poll terminal_read with your cursor for the shell's response",
+        })
+        .to_string()
+    }
+
+    pub(crate) async fn terminal_resize_tool(
+        &self,
+        params: TerminalResizeParams,
+        trust: ToolCallerTrust,
+        actor: &crate::access::actor::ActorBinding,
+    ) -> String {
+        let Some(registry) = self.terminal_registry().await else {
+            return no_registry();
+        };
+        let key = TerminalKey::local(&params.terminal_id);
+        let Some(session) = registry
+            .get_visible(&key, &terminal_actor(trust, actor))
+            .await
+        else {
+            return no_visible(&params.terminal_id);
+        };
+        session.resize(params.cols, params.rows);
+        serde_json::json!({ "ok": true, "cols": params.cols, "rows": params.rows }).to_string()
+    }
+
+    pub(crate) async fn terminal_close_tool(
+        &self,
+        params: TerminalCloseParams,
+        trust: ToolCallerTrust,
+        actor: &crate::access::actor::ActorBinding,
+    ) -> String {
+        let Some(registry) = self.terminal_registry().await else {
+            return no_registry();
+        };
+        let key = TerminalKey::local(&params.terminal_id);
+        let closed = registry
+            .close_visible(&key, &terminal_actor(trust, actor))
+            .await;
+        serde_json::json!({ "ok": closed, "closed": closed }).to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scoped_actor_without_principal_owns_nothing() {
+        let unattributed = crate::access::actor::ActorBinding::unattributed();
+        let actor = terminal_actor(ToolCallerTrust::Scoped, &unattributed);
+        match actor {
+            TerminalActor::Principal(id) => assert_eq!(id, "principal:unattributed"),
+            TerminalActor::Root => panic!("scoped caller must never derive Root"),
+        }
+    }
+}

--- a/src/bin/caller/mcp/tools_terminal.rs
+++ b/src/bin/caller/mcp/tools_terminal.rs
@@ -141,6 +141,22 @@ fn utf8_page_len(bytes: &[u8]) -> usize {
     }
 }
 
+/// [`utf8_page_len`] while the shell lives; the whole page once it has
+/// exited. A split sequence is held back only because a later page can
+/// complete it — after exit no output can ever arrive, so holding a
+/// truncated final sequence would park the cursor forever; delivering it
+/// lossily is the honest end state. (On Windows the exit flag can beat
+/// the reader thread's final drain by a moment, so a tail consumed in
+/// that window may decay into replacement characters — a one-character
+/// cost, against a permanently wedged cursor.)
+fn page_keep_len(bytes: &[u8], alive: bool) -> usize {
+    if alive {
+        utf8_page_len(bytes)
+    } else {
+        bytes.len()
+    }
+}
+
 fn no_registry() -> String {
     serde_json::json!({
         "ok": false,
@@ -278,18 +294,20 @@ impl IntendantServer {
             .clamp(4, TERMINAL_READ_MAX_BYTES);
         let (bytes, next_cursor, gap) = session.read_since(params.cursor.unwrap_or(0), max_bytes);
         // A multibyte UTF-8 sequence split at the page boundary must not
-        // decay into replacement characters on both pages: hold the
-        // incomplete tail back (rewinding the cursor to the boundary) so
-        // the next read re-delivers it whole. Genuinely invalid bytes
-        // mid-page (binary output) stay lossy — that is honest.
-        let kept = utf8_page_len(&bytes);
+        // decay into replacement characters on both pages: while the
+        // shell lives, hold the incomplete tail back (rewinding the
+        // cursor to the boundary) so the next read re-delivers it whole;
+        // once it has exited, deliver everything. Genuinely invalid
+        // bytes mid-page (binary output) stay lossy — that is honest.
+        let alive = session.is_alive();
+        let kept = page_keep_len(&bytes, alive);
         let next_cursor = next_cursor - (bytes.len() - kept) as u64;
         serde_json::json!({
             "ok": true,
             "output": String::from_utf8_lossy(&bytes[..kept]),
             "next_cursor": next_cursor,
             "gap": gap,
-            "alive": session.is_alive(),
+            "alive": alive,
             "exit_status": session.exit_status(),
         })
         .to_string()
@@ -418,6 +436,21 @@ mod tests {
             "incomplete prefix held, not consumed"
         );
         assert_eq!(utf8_page_len(b""), 0);
+    }
+
+    /// Once the shell has exited nothing can ever complete a split
+    /// sequence, so a truncated final tail is delivered lossily instead
+    /// of parking the cursor forever (review P2, round 4); while it
+    /// lives the tail is held for the page that completes it.
+    #[test]
+    fn dead_sessions_consume_split_tails() {
+        assert_eq!(page_keep_len(&[b'a', 0xc3], true), 1, "live: tail held");
+        assert_eq!(
+            page_keep_len(&[b'a', 0xc3], false),
+            2,
+            "dead: tail delivered lossily"
+        );
+        assert_eq!(page_keep_len(&[0xc3], false), 1, "dead: bare prefix too");
     }
 
     #[test]

--- a/src/bin/caller/mcp/tools_terminal.rs
+++ b/src/bin/caller/mcp/tools_terminal.rs
@@ -72,8 +72,9 @@ pub struct TerminalWriteParams {
     pub terminal_id: String,
     /// Bytes to write to the shell's stdin, verbatim.
     pub input: String,
-    /// Append a newline (submit the input as a command line). Default
-    /// true — pass false for raw keystrokes.
+    /// Append Enter (a carriage return — the key a terminal sends to
+    /// submit a command line). Default true — pass false for raw
+    /// keystrokes.
     #[serde(default)]
     pub enter: Option<bool>,
 }
@@ -110,27 +111,32 @@ fn terminal_actor(
     }
 }
 
-/// How much of `bytes` to deliver so the page ends on a UTF-8 boundary:
-/// the whole page when it is valid or contains a genuinely INVALID
-/// sequence (binary output — lossy is honest), trimmed to the last
-/// boundary when the tail is an INCOMPLETE sequence a later page
-/// completes. An incomplete prefix is NEVER consumed — even when that
+/// How much of `bytes` to deliver so the page never ends inside an
+/// INCOMPLETE UTF-8 sequence: the whole page when everything after the
+/// last genuinely INVALID sequence (binary output — lossy is honest) is
+/// valid, trimmed to the last boundary when the tail is an incomplete
+/// sequence a later page completes — invalid bytes earlier in the page
+/// don't forfeit that trim (a binary page can still end in a split
+/// character). An incomplete prefix is NEVER consumed — even when that
 /// means an empty page with a parked cursor — because delivering it
 /// lossily advances past bytes the caller can then never reconstruct.
 /// Progress is guaranteed by the read floor (`max_bytes` ≥ 4, the
-/// longest UTF-8 sequence): a page that starts on a boundary and has
-/// room for a whole sequence only ever trims a tail the ring has not
-/// finished receiving yet.
+/// longest UTF-8 sequence) plus invalid sequences always being consumed:
+/// the scan only ever holds back a tail the ring has not finished
+/// receiving yet.
 fn utf8_page_len(bytes: &[u8]) -> usize {
-    match std::str::from_utf8(bytes) {
-        Ok(_) => bytes.len(),
-        Err(err) => {
-            if err.error_len().is_some() {
-                // Invalid sequence inside the page — not a boundary split.
-                bytes.len()
-            } else {
-                err.valid_up_to()
-            }
+    // Walk the page the way the lossy decoder will: valid runs and
+    // invalid sequences are delivered; only a trailing incomplete
+    // sequence (`error_len() == None`) is held back. Each iteration
+    // resumes past the previous error, so the page is scanned once.
+    let mut offset = 0;
+    loop {
+        match std::str::from_utf8(&bytes[offset..]) {
+            Ok(_) => return bytes.len(),
+            Err(err) => match err.error_len() {
+                Some(skip) => offset += err.valid_up_to() + skip,
+                None => return offset + err.valid_up_to(),
+            },
         }
     }
 }
@@ -208,9 +214,13 @@ impl IntendantServer {
             shared: params.shared.unwrap_or(false),
             // The caller's grant-resolved filesystem scope, stated by the
             // ingress gate (dashboard-tunnel parity): a scoped grant's
-            // shell is OS-sandboxed to its roots with a cleared
-            // environment, and an ungated caller's default is the empty
-            // scope — never an unrestricted, key-bearing shell.
+            // shell is OS-sandboxed to its roots, and an ungated caller's
+            // default is the empty scope. Environment secrecy does NOT
+            // ride this scope — the registry derives it from the ACTOR,
+            // so every principal-owned spawn (every Scoped caller,
+            // including one whose grant carries no filesystem scope)
+            // gets a cleared, secret-free environment and can never read
+            // the daemon's provider keys through `env`.
             scope: fs_scope,
         };
         match registry
@@ -311,7 +321,11 @@ impl IntendantServer {
         }
         let mut input = params.input.into_bytes();
         if params.enter.unwrap_or(true) {
-            input.push(b'\n');
+            // CR, not LF: the byte the Enter key actually sends. ConPTY
+            // only submits a command line on CR (terminal.rs's PTY tests
+            // pin this), and Unix line discipline maps CR to NL on input
+            // (ICRNL), so CR is the correct submit byte everywhere.
+            input.push(b'\r');
         }
         session.write_input(&input);
         serde_json::json!({
@@ -376,6 +390,24 @@ mod tests {
             utf8_page_len(&[0xff, 0x61]),
             2,
             "invalid mid-page stays lossy"
+        );
+        // Invalid bytes EARLIER in the page must not forfeit the tail
+        // trim: the scan resumes past them and still holds back a
+        // trailing incomplete sequence (review P2, round 3).
+        assert_eq!(
+            utf8_page_len(&[0xff, b'a', b'b', 0xc3]),
+            3,
+            "split tail held back even after an invalid byte"
+        );
+        assert_eq!(
+            utf8_page_len(&[0xff, 0xc3, 0xa9]),
+            3,
+            "complete char after an invalid byte delivered whole"
+        );
+        assert_eq!(
+            utf8_page_len(&[0xff]),
+            1,
+            "a lone invalid byte still makes progress"
         );
         // An incomplete PREFIX is never consumed — the cursor parks, and
         // the read floor (max_bytes ≥ 4) guarantees the next page has

--- a/src/bin/caller/mcp/tools_whoami.rs
+++ b/src/bin/caller/mcp/tools_whoami.rs
@@ -275,6 +275,7 @@ mod tests {
             actor: crate::access::actor::ActorBinding::local_process(Some(
                 "principal:local-process".into(),
             )),
+            fs_scope: None,
         };
         let result = server
             .call_tool_by_name_as_caller("whoami", serde_json::json!({}), None, None, caller)

--- a/src/bin/caller/terminal.rs
+++ b/src/bin/caller/terminal.rs
@@ -204,11 +204,15 @@ fn scoped_shell_cwd(
         .unwrap_or_else(|| std::path::PathBuf::from("/"))
 }
 
-/// Startup args for a scoped shell. Scoped shells skip rc/profile files:
-/// `$HOME` is outside the sandbox, so a login shell would spray permission
-/// errors trying to read dotfiles it must not see.
+/// Startup args for a secret-free shell: skip rc/profile files. A scoped
+/// shell's `$HOME` is outside the sandbox, so a login shell would spray
+/// permission errors reading dotfiles it must not see; a scope-less
+/// principal shell CAN read its dotfiles, but letting profiles run would
+/// repopulate the cleared environment the moment they execute (API keys
+/// exported in `~/.zshrc` are routine) — the profile skip is what makes
+/// the env clearing in [`PtySession::spawn`] stick.
 #[cfg(unix)]
-fn scoped_shell_args(shell: &str) -> Vec<String> {
+fn secret_free_shell_args(shell: &str) -> Vec<String> {
     let name = std::path::Path::new(shell)
         .file_name()
         .and_then(|name| name.to_str())
@@ -217,6 +221,25 @@ fn scoped_shell_args(shell: &str) -> Vec<String> {
         "zsh" => vec!["-f".to_string()],
         "bash" => vec!["--noprofile".to_string(), "--norc".to_string()],
         "fish" => vec!["--no-config".to_string()],
+        _ => Vec::new(),
+    }
+}
+
+/// Windows twin of [`secret_free_shell_args`]: `-NoProfile` keeps
+/// PowerShell from running profile scripts that would repopulate the
+/// cleared environment; `/d` skips cmd.exe's AutoRun registry commands.
+/// Returns the complete startup argv for the shell, replacing the
+/// profile-enabled interactive defaults.
+#[cfg(windows)]
+fn secret_free_shell_args(shell: &str) -> Vec<String> {
+    let name = std::path::Path::new(shell)
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .unwrap_or(shell)
+        .to_ascii_lowercase();
+    match name.as_str() {
+        "powershell" | "pwsh" => vec!["-NoLogo".to_string(), "-NoProfile".to_string()],
+        "cmd" => vec!["/d".to_string()],
         _ => Vec::new(),
     }
 }
@@ -809,8 +832,10 @@ impl PtySession {
     /// principal-owned spawn (`owner` set — every non-root actor) never
     /// inherits the daemon's process environment: the daemon env holds
     /// provider API keys, so the child env is cleared and rebuilt
-    /// secret-free; only root-lane shells (the owner's own surfaces)
-    /// inherit.
+    /// secret-free and the shell starts profile-less (a login shell's rc
+    /// files would repopulate the environment before the principal ever
+    /// types); only root-lane shells (the owner's own surfaces) inherit
+    /// and get the login-style startup.
     fn spawn(
         cols: u16,
         rows: u16,
@@ -853,7 +878,16 @@ impl PtySession {
         } else {
             let build_cmd = |program: &str, args: &[String]| {
                 let mut cmd = PtyCommandBuilder::new(program);
-                cmd.args(args);
+                if owner.is_some() {
+                    // Profile-less startup, or the env clearing below is
+                    // theater: a login shell's rc files run before the
+                    // principal ever types and would repopulate the
+                    // cleared environment (API keys exported in dotfiles
+                    // are routine).
+                    cmd.args(secret_free_shell_args(program));
+                } else {
+                    cmd.args(args);
+                }
                 if let Some(ref dir) = cwd {
                     cmd.cwd(dir);
                 }
@@ -1026,7 +1060,7 @@ impl PtySession {
         #[cfg(unix)]
         {
             let (shell, _) = crate::platform::interactive_pty_shell();
-            let shell_args = scoped_shell_args(&shell);
+            let shell_args = secret_free_shell_args(&shell);
             let cwd = scoped_shell_cwd(
                 scope,
                 project_root.unwrap_or_else(|| std::path::Path::new("/")),
@@ -2400,14 +2434,32 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn scoped_shell_args_skip_rc_files_per_shell() {
-        assert_eq!(scoped_shell_args("/bin/zsh"), vec!["-f"]);
+    fn secret_free_shell_args_skip_rc_files_per_shell() {
+        assert_eq!(secret_free_shell_args("/bin/zsh"), vec!["-f"]);
         assert_eq!(
-            scoped_shell_args("/bin/bash"),
+            secret_free_shell_args("/bin/bash"),
             vec!["--noprofile", "--norc"]
         );
-        assert_eq!(scoped_shell_args("/usr/bin/fish"), vec!["--no-config"]);
-        assert!(scoped_shell_args("/bin/sh").is_empty());
+        assert_eq!(secret_free_shell_args("/usr/bin/fish"), vec!["--no-config"]);
+        assert!(secret_free_shell_args("/bin/sh").is_empty());
+    }
+
+    /// The Windows variant must disable profile/AutoRun startup for the
+    /// interactive shells [`crate::platform::interactive_pty_shell`] can
+    /// return — a profile script would repopulate the cleared environment
+    /// of a principal-owned shell (review P1, round 4).
+    #[cfg(windows)]
+    #[test]
+    fn secret_free_shell_args_disable_windows_profiles() {
+        assert_eq!(
+            secret_free_shell_args("powershell.exe"),
+            vec!["-NoLogo", "-NoProfile"]
+        );
+        assert_eq!(
+            secret_free_shell_args("C:\\Program Files\\PowerShell\\7\\pwsh.exe"),
+            vec!["-NoLogo", "-NoProfile"]
+        );
+        assert_eq!(secret_free_shell_args("cmd.exe"), vec!["/d"]);
     }
 
     #[cfg(unix)]
@@ -2445,9 +2497,22 @@ mod tests {
     async fn principal_shell_without_scope_gets_secret_free_env() {
         // The canary must be present in THIS process's environment while
         // the shell spawns to prove the child cleared it; mutate and
-        // restore under the crate-wide env lock.
+        // restore under the crate-wide env lock. The drop guard restores
+        // the variable's prior state on every exit path — declared after
+        // the lock guard so it drops (restoring) while the lock is held.
+        const CANARY: &str = "INTENDANT_TEST_ENV_CANARY";
+        struct RestoreCanary(Option<std::ffi::OsString>);
+        impl Drop for RestoreCanary {
+            fn drop(&mut self) {
+                match self.0.take() {
+                    Some(value) => std::env::set_var("INTENDANT_TEST_ENV_CANARY", value),
+                    None => std::env::remove_var("INTENDANT_TEST_ENV_CANARY"),
+                }
+            }
+        }
         let guard = crate::test_support::TEST_ENV_LOCK.lock().await;
-        std::env::set_var("INTENDANT_TEST_ENV_CANARY", "leak_9418");
+        let restore = RestoreCanary(std::env::var_os(CANARY));
+        std::env::set_var(CANARY, "leak_9418");
 
         let registry = TerminalRegistry::new(std::env::temp_dir());
         let key = TerminalKey::local("principal-env-e2e");
@@ -2467,7 +2532,7 @@ mod tests {
             .await;
         // The spawn ran synchronously inside open_or_attach, so the
         // mutation window ends here regardless of the result.
-        std::env::remove_var("INTENDANT_TEST_ENV_CANARY");
+        drop(restore);
         drop(guard);
         let (session, created) = spawned.unwrap();
         assert!(created);

--- a/src/bin/caller/terminal.rs
+++ b/src/bin/caller/terminal.rs
@@ -127,7 +127,10 @@ impl TerminalActor {
 /// a sandboxed one — the PTY child is confined to the scope's roots (plus
 /// read-only system paths) at the OS level: Landlock on Linux, a Seatbelt
 /// profile on macOS, a restricted token + temporary RESTRICTED ACEs on
-/// Windows (see win_sandbox.rs). `None` scope = today's full shell.
+/// Windows (see win_sandbox.rs). `None` scope = a filesystem-unrestricted
+/// shell; environment secrecy is a separate axis the spawn derives from
+/// the ACTOR, not from the scope — every principal-owned shell gets a
+/// cleared, secret-free environment (see [`PtySession::spawn`]).
 #[derive(Debug, Clone, Default)]
 pub struct ShellSpawnPolicy {
     pub may_spawn: bool,
@@ -218,22 +221,15 @@ fn scoped_shell_args(shell: &str) -> Vec<String> {
     }
 }
 
-/// Minimal, secret-free environment for a scoped shell. The daemon process
-/// env holds API keys and infrastructure detail; a scoped principal must
-/// not see any of it, so the child env is cleared and rebuilt. `HOME`
-/// points at the first writable root (shell history, tool caches, and
-/// dotfile writes land inside the scope instead of erroring).
+/// Minimal, secret-free environment for a shell whose spawning actor
+/// must not see the daemon's process env (API keys, infrastructure
+/// detail): the child env is cleared and rebuilt from this allowlist.
+/// `home` is where shell history, tool caches, and dotfile writes land —
+/// a sandboxed shell passes its first writable scope root (the real
+/// `$HOME` is outside the sandbox), an unsandboxed principal shell
+/// passes the real home.
 #[cfg(unix)]
-fn scoped_shell_env(
-    scope: &crate::peer::access_policy::FilesystemAccessPolicy,
-    shell: &str,
-) -> Vec<(String, String)> {
-    let home = scope
-        .write_roots
-        .first()
-        .or_else(|| scope.read_roots.first())
-        .map(|root| root.display().to_string())
-        .unwrap_or_else(|| "/tmp".to_string());
+fn secret_free_shell_env(home: String, shell: &str) -> Vec<(String, String)> {
     let path = if cfg!(target_os = "macos") {
         "/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
     } else {
@@ -263,23 +259,31 @@ fn scoped_shell_env(
     env
 }
 
-/// Windows twin of [`scoped_shell_env`]: minimal, secret-free environment
-/// for a scoped shell. `SystemRoot` and `PATHEXT` are load-bearing (process
-/// startup and DLL/command resolution break without them); the profile
-/// family (`USERPROFILE`, `APPDATA`, …) and temp point into the first
-/// writable root so PSReadLine history, tool caches, and temp files land
-/// inside the scope instead of erroring — the real profile is invisible to
-/// the restricted token anyway.
-#[cfg(windows)]
-fn windows_scoped_shell_env(
+/// [`secret_free_shell_env`] for a scoped shell: `HOME` points at the
+/// first writable root so shell history, tool caches, and dotfile writes
+/// land inside the scope instead of erroring.
+#[cfg(unix)]
+fn scoped_shell_env(
     scope: &crate::peer::access_policy::FilesystemAccessPolicy,
+    shell: &str,
 ) -> Vec<(String, String)> {
-    let profile = scope
+    let home = scope
         .write_roots
         .first()
         .or_else(|| scope.read_roots.first())
         .map(|root| root.display().to_string())
-        .unwrap_or_else(|| std::env::temp_dir().display().to_string());
+        .unwrap_or_else(|| "/tmp".to_string());
+    secret_free_shell_env(home, shell)
+}
+
+/// Windows twin of [`secret_free_shell_env`]: minimal, secret-free
+/// environment for a shell whose spawning actor must not see the daemon's
+/// process env. `SystemRoot` and `PATHEXT` are load-bearing (process
+/// startup and DLL/command resolution break without them); the profile
+/// family (`USERPROFILE`, `APPDATA`, …) and temp point into `profile` so
+/// PSReadLine history, tool caches, and temp files have somewhere to land.
+#[cfg(windows)]
+fn windows_secret_free_shell_env(profile: String) -> Vec<(String, String)> {
     let system_root = std::env::var("SystemRoot").unwrap_or_else(|_| "C:\\Windows".to_string());
     let mut env = vec![
         ("SystemRoot".to_string(), system_root.clone()),
@@ -317,6 +321,22 @@ fn windows_scoped_shell_env(
         }
     }
     env
+}
+
+/// [`windows_secret_free_shell_env`] for a scoped shell: the profile
+/// family points into the first writable root so writes land inside the
+/// scope — the real profile is invisible to the restricted token anyway.
+#[cfg(windows)]
+fn windows_scoped_shell_env(
+    scope: &crate::peer::access_policy::FilesystemAccessPolicy,
+) -> Vec<(String, String)> {
+    let profile = scope
+        .write_roots
+        .first()
+        .or_else(|| scope.read_roots.first())
+        .map(|root| root.display().to_string())
+        .unwrap_or_else(|| std::env::temp_dir().display().to_string());
+    windows_secret_free_shell_env(profile)
 }
 
 /// Read-only system baseline a scoped shell needs to be a usable shell
@@ -785,7 +805,12 @@ impl PtySession {
     /// Spawn a new shell under a fresh PTY. The shell defaults to
     /// `$SHELL`, falling back to `/bin/bash`. When `scope` is set the
     /// child is wrapped in an OS sandbox confined to the scope's roots —
-    /// see [`ShellSpawnPolicy`].
+    /// see [`ShellSpawnPolicy`]. Independently of the scope, a
+    /// principal-owned spawn (`owner` set — every non-root actor) never
+    /// inherits the daemon's process environment: the daemon env holds
+    /// provider API keys, so the child env is cleared and rebuilt
+    /// secret-free; only root-lane shells (the owner's own surfaces)
+    /// inherit.
     fn spawn(
         cols: u16,
         rows: u16,
@@ -832,8 +857,35 @@ impl PtySession {
                 if let Some(ref dir) = cwd {
                     cmd.cwd(dir);
                 }
-                // Seed TERM so xterm.js gets colors and cursor sequences.
-                cmd.env("TERM", "xterm-256color");
+                if owner.is_some() {
+                    // A principal-owned shell never inherits the daemon's
+                    // process environment, even without a filesystem
+                    // scope (scope-less grants, supervised sessions): the
+                    // daemon env holds provider API keys, and a scoped
+                    // principal reading them through `env` would cross
+                    // the runtime/controller key boundary. Secrecy and
+                    // filesystem confinement are separate axes — this
+                    // shell keeps the real home, it is only secret-free.
+                    // Root-lane shells (the owner's own terminal tabs)
+                    // inherit as before.
+                    cmd.env_clear();
+                    #[cfg(unix)]
+                    let curated = secret_free_shell_env(
+                        std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string()),
+                        program,
+                    );
+                    #[cfg(windows)]
+                    let curated = windows_secret_free_shell_env(
+                        std::env::var("USERPROFILE")
+                            .unwrap_or_else(|_| std::env::temp_dir().display().to_string()),
+                    );
+                    for (key, value) in curated {
+                        cmd.env(key, value);
+                    }
+                } else {
+                    // Seed TERM so xterm.js gets colors and cursor sequences.
+                    cmd.env("TERM", "xterm-256color");
+                }
                 // Unit-test builds point the spawned shell's HOME at a
                 // per-process scratch: interactive shells write history
                 // (~/.zsh_history, ~/.bash_history) on exit, and terminal
@@ -2380,6 +2432,56 @@ mod tests {
                 "unexpected env var {key} in scoped shell env"
             );
         }
+    }
+
+    /// A principal-owned shell with NO filesystem scope still gets a
+    /// cleared, secret-free environment: the daemon process env holds
+    /// provider API keys, and environment secrecy must not depend on a
+    /// grant happening to carry a filesystem scope (review P1). Root-lane
+    /// shells keep inheriting — every other PTY test in this module
+    /// spawns as [`TerminalActor::Root`] and exercises that side.
+    #[cfg(unix)]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn principal_shell_without_scope_gets_secret_free_env() {
+        // The canary must be present in THIS process's environment while
+        // the shell spawns to prove the child cleared it; mutate and
+        // restore under the crate-wide env lock.
+        let guard = crate::test_support::TEST_ENV_LOCK.lock().await;
+        std::env::set_var("INTENDANT_TEST_ENV_CANARY", "leak_9418");
+
+        let registry = TerminalRegistry::new(std::env::temp_dir());
+        let key = TerminalKey::local("principal-env-e2e");
+        let actor = TerminalActor::Principal("principal:client-key:envtest".to_string());
+        let spawned = registry
+            .open_or_attach(
+                key,
+                100,
+                30,
+                &actor,
+                ShellSpawnPolicy {
+                    may_spawn: true,
+                    shared: false,
+                    scope: None,
+                },
+            )
+            .await;
+        // The spawn ran synchronously inside open_or_attach, so the
+        // mutation window ends here regardless of the result.
+        std::env::remove_var("INTENDANT_TEST_ENV_CANARY");
+        drop(guard);
+        let (session, created) = spawned.unwrap();
+        assert!(created);
+
+        let mut rx = session.attach();
+        expect_output(&mut rx, None, "shell startup").await;
+        // `printenv` exits non-zero when the var is absent, so the echo
+        // fallback is the deterministic pass signal. The sentinel is
+        // quote-split in the typed command so the terminal's echo of the
+        // command line can never satisfy the check; a leaked canary
+        // prints its value, short-circuits the `||`, and the sentinel
+        // never appears (the assertion times out with the transcript).
+        session.write_input(b"printenv INTENDANT_TEST_ENV_CANARY || echo CANARY_ABSENT'_OK'\r");
+        expect_output(&mut rx, Some("CANARY_ABSENT_OK"), "daemon env cleared").await;
     }
 
     #[cfg(target_os = "macos")]

--- a/src/bin/caller/terminal.rs
+++ b/src/bin/caller/terminal.rs
@@ -418,17 +418,23 @@ fn windows_scoped_shell_env(
 
 /// Read-only system baseline a scoped shell needs to be a usable shell
 /// (binaries, libraries, config) without exposing user data. `/home`,
-/// `/root`, `/Users`, and `/proc` are deliberately absent — and so is
-/// bare `/dev`: scoped shells run as the daemon's Unix account, so a
-/// whole-`/dev` grant would let them open OTHER same-account sessions'
-/// PTYs under `/dev/pts` (reading one steals that session's
-/// keystrokes). Only ownerless device nodes are listed; the shell's own
-/// terminal rides its inherited descriptors plus `/dev/tty`, which the
-/// kernel resolves to the caller's controlling terminal and can never
-/// reach another session. (Landlock rules are additive-only — there is
-/// no way to allow `/dev` minus the PTYs, so the safe nodes are
-/// enumerated. Nested PTY allocation inside a scoped shell is
-/// deliberately unavailable.)
+/// `/root`, `/Users`, and `/proc` are deliberately absent — and so are
+/// the same-account trees a whole-directory grant would expose:
+///
+/// - bare `/dev` would let the shell open OTHER same-account sessions'
+///   PTYs under `/dev/pts` (reading one steals that session's
+///   keystrokes), so only ownerless device nodes are listed; the
+///   shell's own terminal rides its inherited descriptors plus
+///   `/dev/tty`, which the kernel resolves to the caller's controlling
+///   terminal and can never reach another session;
+/// - bare `/run` would expose `/run/secrets` mounts and plain files
+///   under `/run/user/<uid>`, so only the resolver backends
+///   `/etc/resolv.conf` can point at are listed (the Landlock applier
+///   skips paths that don't exist on this distro).
+///
+/// Landlock rules are additive-only — there is no way to allow a tree
+/// minus a subtree, so the safe entries are enumerated. Nested PTY
+/// allocation inside a scoped shell is deliberately unavailable.
 #[cfg(target_os = "linux")]
 fn scoped_shell_read_baseline() -> Vec<std::path::PathBuf> {
     [
@@ -442,7 +448,9 @@ fn scoped_shell_read_baseline() -> Vec<std::path::PathBuf> {
         "/etc",
         "/opt",
         "/nix",
-        "/run",
+        "/run/systemd/resolve",
+        "/run/resolvconf",
+        "/run/NetworkManager",
         "/dev/null",
         "/dev/zero",
         "/dev/full",
@@ -510,12 +518,9 @@ fn seatbelt_profile(
         )?);
     }
     let mut exec_paths = read_paths.clone();
-    let mut write_paths: Vec<String> = Vec::new();
-    for path in ["/dev"] {
-        write_paths.push(crate::sandbox::seatbelt_path_literal(
-            std::path::Path::new(path),
-        )?);
-    }
+    let mut write_paths: Vec<String> = vec![crate::sandbox::seatbelt_path_literal(
+        std::path::Path::new("/dev"),
+    )?];
     let scratch_canonical =
         std::fs::canonicalize(scratch).unwrap_or_else(|_| scratch.to_path_buf());
     let scratch_literal = crate::sandbox::seatbelt_path_literal(&scratch_canonical)?;
@@ -1133,11 +1138,14 @@ impl PtySession {
     ///   [`SCOPED_SHELL_POLICY_ENV`] (fail-closed when the kernel lacks
     ///   Landlock) and then execs the shell.
     /// - **macOS**: `sandbox-exec -p <generated Seatbelt profile>`.
-    /// - **Windows**: refused — no OS sandbox seam wired up yet.
-    /// Build the sandboxed shell command for a scoped spawn. The second
-    /// element is the session-private scratch directory (the shell's
-    /// whole temp world on Unix — see the baselines above); the caller
-    /// owns its lifetime and removes it when the session drops.
+    /// - **Windows**: re-exec as `--scoped-shell-exec` under a fully
+    ///   restricted token, with scope-root ACEs stamped daemon-side
+    ///   (win_sandbox.rs).
+    ///
+    /// The returned tuple's second element is the session-private
+    /// scratch directory (the shell's whole temp world on Unix — see
+    /// the baselines above); the caller owns its lifetime and removes
+    /// it when the session drops.
     fn scoped_shell_command(
         scope: &crate::peer::access_policy::FilesystemAccessPolicy,
         project_root: Option<&std::path::Path>,
@@ -2798,17 +2806,19 @@ mod tests {
     }
 
     /// The Landlock baselines must never grant the shared same-account
-    /// trees (security review P1): `/dev/pts` opens other sessions'
+    /// trees (security review P1s): `/dev/pts` opens other sessions'
     /// PTYs, `/dev/shm` and the `/tmp` trees expose other processes'
-    /// shared memory and temp files, and bare `/dev` read covers the
-    /// pts side too. The shell's own terminal lane and the ownerless
-    /// entropy devices stay.
+    /// shared memory and temp files, bare `/dev` read covers the pts
+    /// side too, and bare `/run` exposes `/run/secrets` mounts and
+    /// `/run/user/<uid>` files. The shell's own terminal lane, the
+    /// ownerless entropy devices, and the enumerated resolver backends
+    /// stay.
     #[cfg(target_os = "linux")]
     #[test]
     fn scoped_shell_baselines_exclude_shared_account_trees() {
         let read = scoped_shell_read_baseline();
         let write = scoped_shell_write_baseline();
-        for shared in ["/dev", "/dev/pts", "/dev/shm", "/tmp", "/var/tmp"] {
+        for shared in ["/dev", "/dev/pts", "/dev/shm", "/tmp", "/var/tmp", "/run"] {
             let shared = std::path::PathBuf::from(shared);
             assert!(!read.contains(&shared), "{shared:?} must not be readable");
             assert!(!write.contains(&shared), "{shared:?} must not be writable");
@@ -2819,6 +2829,10 @@ mod tests {
             assert!(write.contains(&kept), "{kept:?} is the shell's own lane");
         }
         assert!(read.contains(&std::path::PathBuf::from("/dev/urandom")));
+        assert!(
+            read.contains(&std::path::PathBuf::from("/run/systemd/resolve")),
+            "the resolv.conf backend stays enumerated"
+        );
     }
 
     /// Real end-to-end sandbox check (macOS): a scoped PTY shell can read

--- a/src/bin/caller/terminal.rs
+++ b/src/bin/caller/terminal.rs
@@ -321,8 +321,10 @@ fn secret_free_shell_env(home: String, shell: &str) -> Vec<(String, String)> {
     }
     #[cfg(target_os = "macos")]
     if let Ok(tmpdir) = std::env::var("TMPDIR") {
-        // The daemon's per-user temp dir is allowed read-write in the
-        // Seatbelt profile below.
+        // Unsandboxed principal shells keep the daemon's per-user temp
+        // dir; a SCOPED shell's TMPDIR is overridden to its private
+        // scratch in `scoped_shell_env` (the profile no longer allows
+        // the shared temp trees).
         env.push(("TMPDIR".to_string(), tmpdir));
     }
     env
@@ -330,11 +332,14 @@ fn secret_free_shell_env(home: String, shell: &str) -> Vec<(String, String)> {
 
 /// [`secret_free_shell_env`] for a scoped shell: `HOME` points at the
 /// first writable root so shell history, tool caches, and dotfile writes
-/// land inside the scope instead of erroring.
+/// land inside the scope instead of erroring, and `TMPDIR` points at the
+/// session-private `scratch` — the shell's whole temp world, since the
+/// shared same-account `/tmp` trees are no longer granted.
 #[cfg(unix)]
 fn scoped_shell_env(
     scope: &crate::peer::access_policy::FilesystemAccessPolicy,
     shell: &str,
+    scratch: &std::path::Path,
 ) -> Vec<(String, String)> {
     let home = scope
         .write_roots
@@ -342,7 +347,10 @@ fn scoped_shell_env(
         .or_else(|| scope.read_roots.first())
         .map(|root| root.display().to_string())
         .unwrap_or_else(|| "/tmp".to_string());
-    secret_free_shell_env(home, shell)
+    let mut env = secret_free_shell_env(home, shell);
+    env.retain(|(key, _)| key != "TMPDIR");
+    env.push(("TMPDIR".to_string(), scratch.display().to_string()));
+    env
 }
 
 /// Windows twin of [`secret_free_shell_env`]: minimal, secret-free
@@ -410,45 +418,78 @@ fn windows_scoped_shell_env(
 
 /// Read-only system baseline a scoped shell needs to be a usable shell
 /// (binaries, libraries, config) without exposing user data. `/home`,
-/// `/root`, `/Users`, and `/proc` are deliberately absent.
+/// `/root`, `/Users`, and `/proc` are deliberately absent — and so is
+/// bare `/dev`: scoped shells run as the daemon's Unix account, so a
+/// whole-`/dev` grant would let them open OTHER same-account sessions'
+/// PTYs under `/dev/pts` (reading one steals that session's
+/// keystrokes). Only ownerless device nodes are listed; the shell's own
+/// terminal rides its inherited descriptors plus `/dev/tty`, which the
+/// kernel resolves to the caller's controlling terminal and can never
+/// reach another session. (Landlock rules are additive-only — there is
+/// no way to allow `/dev` minus the PTYs, so the safe nodes are
+/// enumerated. Nested PTY allocation inside a scoped shell is
+/// deliberately unavailable.)
 #[cfg(target_os = "linux")]
 fn scoped_shell_read_baseline() -> Vec<std::path::PathBuf> {
     [
-        "/usr", "/bin", "/sbin", "/lib", "/lib32", "/lib64", "/libx32", "/etc", "/opt", "/nix",
-        "/run", "/dev",
+        "/usr",
+        "/bin",
+        "/sbin",
+        "/lib",
+        "/lib32",
+        "/lib64",
+        "/libx32",
+        "/etc",
+        "/opt",
+        "/nix",
+        "/run",
+        "/dev/null",
+        "/dev/zero",
+        "/dev/full",
+        "/dev/random",
+        "/dev/urandom",
+        "/dev/tty",
     ]
     .iter()
     .map(std::path::PathBuf::from)
     .collect()
 }
 
-/// Writable (read-write) baseline for a scoped shell: terminal devices and
-/// the shared scratch locations every Unix tool assumes.
+/// Writable (read-write) baseline for a scoped shell: the shell's own
+/// terminal lane only. The shared same-account trees that used to be
+/// here — `/dev/pts` (open other sessions' PTYs: inject output, consume
+/// keystrokes), `/dev/shm` and `/tmp`/`/var/tmp` (read other
+/// same-account processes' shared memory and temp files, the daemon's
+/// own included) — are deliberately absent; temp space is a
+/// session-private scratch directory the spawn creates and points
+/// `TMPDIR` at (see [`PtySession::scoped_shell_command`]).
 #[cfg(target_os = "linux")]
 fn scoped_shell_write_baseline() -> Vec<std::path::PathBuf> {
-    [
-        "/dev/null",
-        "/dev/tty",
-        "/dev/pts",
-        "/dev/shm",
-        "/tmp",
-        "/var/tmp",
-    ]
-    .iter()
-    .map(std::path::PathBuf::from)
-    .collect()
+    ["/dev/null", "/dev/tty"]
+        .iter()
+        .map(std::path::PathBuf::from)
+        .collect()
 }
 
 /// Generate the Seatbelt (sandbox-exec) profile for a scoped shell on
 /// macOS: deny-default, Apple's own dyld bootstrap rules, read-only system
 /// paths, read access on the scope's roots, write access on the write
-/// roots and scratch space. Network is allowed — the scope is a
-/// *filesystem* boundary, matching Landlock semantics on Linux. Mach
-/// lookups stay open too (uid-guarded; shells need libc services); the
-/// boundary this profile enforces is file access.
+/// roots and the session-private `scratch` directory (which replaces the
+/// shared `/tmp` trees and the daemon's `TMPDIR` — same-account temp
+/// files, the daemon's own included, are not the scope's to read).
+/// Network is allowed — the scope is a *filesystem* boundary, matching
+/// Landlock semantics on Linux. Mach lookups stay open too (uid-guarded;
+/// shells need libc services); the boundary this profile enforces is
+/// file access. `/dev` stays broadly allowed for process bootstrap, but
+/// PTY devices are denied last-match-wins: scoped shells run as the
+/// daemon's Unix account, and an open on another session's
+/// `/dev/ttysNNN` injects into or steals from that terminal — the
+/// shell's own terminal rides its inherited descriptors plus
+/// `/dev/tty`, which resolves to the controlling terminal only.
 #[cfg(target_os = "macos")]
 fn seatbelt_profile(
     scope: &crate::peer::access_policy::FilesystemAccessPolicy,
+    scratch: &std::path::Path,
 ) -> Result<String, String> {
     let mut read_paths: Vec<String> = Vec::new();
     for path in [
@@ -470,16 +511,16 @@ fn seatbelt_profile(
     }
     let mut exec_paths = read_paths.clone();
     let mut write_paths: Vec<String> = Vec::new();
-    for path in ["/dev", "/private/tmp", "/private/var/tmp"] {
+    for path in ["/dev"] {
         write_paths.push(crate::sandbox::seatbelt_path_literal(
             std::path::Path::new(path),
         )?);
     }
-    if let Ok(tmpdir) = std::env::var("TMPDIR") {
-        let canonical =
-            std::fs::canonicalize(&tmpdir).unwrap_or_else(|_| std::path::PathBuf::from(&tmpdir));
-        write_paths.push(crate::sandbox::seatbelt_path_literal(&canonical)?);
-    }
+    let scratch_canonical =
+        std::fs::canonicalize(scratch).unwrap_or_else(|_| scratch.to_path_buf());
+    let scratch_literal = crate::sandbox::seatbelt_path_literal(&scratch_canonical)?;
+    read_paths.push(scratch_literal.clone());
+    write_paths.push(scratch_literal);
     // Seatbelt matches the REAL path of a file: a rule on a symlinked root
     // (`/tmp/...`, `/var/...`, `/etc/...` on macOS) would never match, so
     // roots are canonicalized first. A root that doesn't resolve is kept
@@ -533,6 +574,7 @@ fn seatbelt_profile(
          (allow file-map-executable {exec})\n\
          (allow file-read* {read})\n\
          (allow file-write* {write})\n\
+         (deny file-read* file-write* (regex #\"^/dev/ttys\"))\n\
          {sensitive}{credential}",
         exec = subpaths(&exec_paths),
         read = subpaths(&read_paths),
@@ -874,6 +916,10 @@ pub struct PtySession {
     /// principal's CURRENT scope to refuse sessions whose sandbox no
     /// longer expresses the grant.
     spawn_scope: Option<crate::peer::access_policy::FilesystemAccessPolicy>,
+    /// Session-private temp directory of a scoped Unix shell (its
+    /// `TMPDIR`, replacing the shared same-account `/tmp` trees).
+    /// Removed on Drop.
+    scoped_scratch: Option<std::path::PathBuf>,
 }
 
 impl PtySession {
@@ -924,11 +970,24 @@ impl PtySession {
             ),
             None => None,
         };
+        let mut scoped_scratch: Option<std::path::PathBuf> = None;
+        // Any failure between scratch creation and session construction
+        // must remove the scratch dir — after construction, Drop owns it.
+        let cleanup_scratch = |scratch: &Option<std::path::PathBuf>| {
+            if let Some(scratch) = scratch {
+                let _ = std::fs::remove_dir_all(scratch);
+            }
+        };
         let child = if let Some(scope) = scope {
-            let cmd = Self::scoped_shell_command(scope, cwd.as_deref())?;
-            pair.slave
-                .spawn_command(cmd)
-                .map_err(|e| format!("spawn scoped shell: {e}"))?
+            let (cmd, scratch) = Self::scoped_shell_command(scope, cwd.as_deref())?;
+            scoped_scratch = scratch;
+            match pair.slave.spawn_command(cmd) {
+                Ok(child) => child,
+                Err(e) => {
+                    cleanup_scratch(&scoped_scratch);
+                    return Err(format!("spawn scoped shell: {e}"));
+                }
+            }
         } else {
             let build_cmd = |program: &str, args: &[String]| {
                 // For a principal-owned spawn the PROGRAM is part of the
@@ -1009,14 +1068,14 @@ impl PtySession {
         };
 
         let child_killer = child.clone_killer();
-        let reader = pair
-            .master
-            .try_clone_reader()
-            .map_err(|e| format!("clone reader: {e}"))?;
-        let writer = pair
-            .master
-            .take_writer()
-            .map_err(|e| format!("take writer: {e}"))?;
+        let reader = pair.master.try_clone_reader().map_err(|e| {
+            cleanup_scratch(&scoped_scratch);
+            format!("clone reader: {e}")
+        })?;
+        let writer = pair.master.take_writer().map_err(|e| {
+            cleanup_scratch(&scoped_scratch);
+            format!("take writer: {e}")
+        })?;
 
         let session = Arc::new(Self {
             master: StdMutex::new(pair.master),
@@ -1030,6 +1089,7 @@ impl PtySession {
             owner,
             shared: std::sync::atomic::AtomicBool::new(shared),
             spawn_scope: scope.cloned(),
+            scoped_scratch,
         });
 
         // portable_pty's reader and child wait are both blocking. On Windows,
@@ -1074,10 +1134,14 @@ impl PtySession {
     ///   Landlock) and then execs the shell.
     /// - **macOS**: `sandbox-exec -p <generated Seatbelt profile>`.
     /// - **Windows**: refused — no OS sandbox seam wired up yet.
+    /// Build the sandboxed shell command for a scoped spawn. The second
+    /// element is the session-private scratch directory (the shell's
+    /// whole temp world on Unix — see the baselines above); the caller
+    /// owns its lifetime and removes it when the session drops.
     fn scoped_shell_command(
         scope: &crate::peer::access_policy::FilesystemAccessPolicy,
         project_root: Option<&std::path::Path>,
-    ) -> Result<PtyCommandBuilder, String> {
+    ) -> Result<(PtyCommandBuilder, Option<std::path::PathBuf>), String> {
         #[cfg(windows)]
         {
             // Windows twin of the Linux wrapper: re-exec this binary as
@@ -1113,7 +1177,9 @@ impl PtySession {
                 cmd.env(key, value);
             }
             cmd.cwd(cwd);
-            return Ok(cmd);
+            // Windows temp already lands inside the scope (the profile
+            // family points there) — no shared-tree scratch to manage.
+            return Ok((cmd, None));
         }
         #[cfg(unix)]
         {
@@ -1124,9 +1190,32 @@ impl PtySession {
                 project_root.unwrap_or_else(|| std::path::Path::new("/")),
             );
 
+            #[cfg(any(target_os = "macos", target_os = "linux"))]
+            let scratch = {
+                // Session-private temp: the shared `/tmp` trees hold
+                // same-account files (other sessions', the daemon's own)
+                // that are not the scope's to read, so each scoped shell
+                // gets a fresh 0700 directory as its whole temp world —
+                // granted below, pointed at by `TMPDIR`, and removed when
+                // the session drops.
+                let scratch = std::env::temp_dir().join(format!(
+                    "intendant-scoped-{}",
+                    uuid::Uuid::new_v4().simple()
+                ));
+                std::fs::create_dir_all(&scratch)
+                    .map_err(|e| format!("create scoped scratch dir: {e}"))?;
+                let mut perms = std::fs::metadata(&scratch)
+                    .map_err(|e| format!("stat scoped scratch dir: {e}"))?
+                    .permissions();
+                std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o700);
+                std::fs::set_permissions(&scratch, perms)
+                    .map_err(|e| format!("restrict scoped scratch dir: {e}"))?;
+                scratch
+            };
+
             #[cfg(target_os = "macos")]
             let (program, args, policy_env) = {
-                let profile = seatbelt_profile(scope)?;
+                let profile = seatbelt_profile(scope, &scratch)?;
                 let mut args = vec!["-p".to_string(), profile, shell.clone()];
                 args.extend(shell_args);
                 ("/usr/bin/sandbox-exec".to_string(), args, None::<String>)
@@ -1139,8 +1228,10 @@ impl PtySession {
                 let mut read = scoped_shell_read_baseline();
                 read.extend(scope.read_roots.iter().cloned());
                 read.extend(scope.write_roots.iter().cloned());
+                read.push(scratch.clone());
                 let mut write = scoped_shell_write_baseline();
                 write.extend(scope.write_roots.iter().cloned());
+                write.push(scratch.clone());
                 let policy = serde_json::to_string(&ScopedShellPolicy { read, write })
                     .map_err(|e| format!("encode scoped shell policy: {e}"))?;
                 let mut args = vec!["--scoped-shell-exec".to_string(), shell.clone()];
@@ -1161,14 +1252,14 @@ impl PtySession {
                 let mut cmd = PtyCommandBuilder::new(program);
                 cmd.args(&args);
                 cmd.env_clear();
-                for (key, value) in scoped_shell_env(scope, &shell) {
+                for (key, value) in scoped_shell_env(scope, &shell, &scratch) {
                     cmd.env(key, value);
                 }
                 if let Some(policy) = policy_env {
                     cmd.env(SCOPED_SHELL_POLICY_ENV, policy);
                 }
                 cmd.cwd(cwd);
-                Ok(cmd)
+                Ok((cmd, Some(scratch)))
             }
         }
     }
@@ -1364,6 +1455,11 @@ impl Drop for PtySession {
         // channels signalled.
         if let Ok(hub) = self.output.lock() {
             hub.detach_all();
+        }
+        // The scoped shell's session-private temp world dies with the
+        // session (best-effort — a leftover is inert 0700 scratch).
+        if let Some(scratch) = self.scoped_scratch.take() {
+            let _ = std::fs::remove_dir_all(scratch);
         }
     }
 }
@@ -2578,12 +2674,16 @@ mod tests {
             read_roots: vec![std::path::PathBuf::from("/srv/data")],
             write_roots: vec![std::path::PathBuf::from("/srv/work")],
         };
-        let env = scoped_shell_env(&scope, "/bin/zsh");
+        let scratch = std::path::Path::new("/tmp/intendant-scoped-test");
+        let env = scoped_shell_env(&scope, "/bin/zsh", scratch);
         let get = |key: &str| env.iter().find(|(k, _)| k == key).map(|(_, v)| v.as_str());
         assert_eq!(get("HOME"), Some("/srv/work"));
         assert_eq!(get("SHELL"), Some("/bin/zsh"));
         assert!(get("TERM").is_some());
         assert!(get("PATH").is_some());
+        // The whole temp world is the session-private scratch — never
+        // the daemon's TMPDIR or the shared /tmp trees.
+        assert_eq!(get("TMPDIR"), Some("/tmp/intendant-scoped-test"));
         // Nothing beyond the fixed allowlist leaks in.
         for (key, _) in &env {
             assert!(
@@ -2669,7 +2769,8 @@ mod tests {
             read_roots: vec![std::path::PathBuf::from("/srv/spa ced/read")],
             write_roots: vec![std::path::PathBuf::from("/srv/quo\"te")],
         };
-        let profile = seatbelt_profile(&scope).unwrap();
+        let scratch = std::path::Path::new("/srv/scratch-le55");
+        let profile = seatbelt_profile(&scope, scratch).unwrap();
         assert!(profile.contains("(deny default)"));
         assert!(profile.contains("(subpath \"/srv/spa ced/read\")"));
         assert!(profile.contains("(subpath \"/srv/quo\\\"te\")"));
@@ -2679,12 +2780,45 @@ mod tests {
             .find(|line| line.starts_with("(allow file-read* "))
             .unwrap();
         assert!(read_section.contains("/srv/quo"));
+        // The session-private scratch replaces the shared temp trees
+        // (same-account files are not the scope's to read), and PTY
+        // devices are denied last-match-wins — an open on another
+        // session's /dev/ttysNNN would inject into or steal from that
+        // terminal (security review P1).
+        assert!(profile.contains("(subpath \"/srv/scratch-le55\")"));
+        assert!(!profile.contains("(subpath \"/private/tmp\")"));
+        assert!(!profile.contains("(subpath \"/private/var/tmp\")"));
+        assert!(profile.contains("(deny file-read* file-write* (regex #\"^/dev/ttys\"))"));
         // Control characters are refused outright.
         let bad = FilesystemAccessPolicy {
             read_roots: vec![std::path::PathBuf::from("/srv/evil\nprofile")],
             write_roots: Vec::new(),
         };
-        assert!(seatbelt_profile(&bad).is_err());
+        assert!(seatbelt_profile(&bad, scratch).is_err());
+    }
+
+    /// The Landlock baselines must never grant the shared same-account
+    /// trees (security review P1): `/dev/pts` opens other sessions'
+    /// PTYs, `/dev/shm` and the `/tmp` trees expose other processes'
+    /// shared memory and temp files, and bare `/dev` read covers the
+    /// pts side too. The shell's own terminal lane and the ownerless
+    /// entropy devices stay.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn scoped_shell_baselines_exclude_shared_account_trees() {
+        let read = scoped_shell_read_baseline();
+        let write = scoped_shell_write_baseline();
+        for shared in ["/dev", "/dev/pts", "/dev/shm", "/tmp", "/var/tmp"] {
+            let shared = std::path::PathBuf::from(shared);
+            assert!(!read.contains(&shared), "{shared:?} must not be readable");
+            assert!(!write.contains(&shared), "{shared:?} must not be writable");
+        }
+        for kept in ["/dev/null", "/dev/tty"] {
+            let kept = std::path::PathBuf::from(kept);
+            assert!(read.contains(&kept) || write.contains(&kept));
+            assert!(write.contains(&kept), "{kept:?} is the shell's own lane");
+        }
+        assert!(read.contains(&std::path::PathBuf::from("/dev/urandom")));
     }
 
     /// Real end-to-end sandbox check (macOS): a scoped PTY shell can read
@@ -2738,6 +2872,13 @@ mod tests {
             Some(vec![root.clone()]),
             "the spawn scope is recorded on the session"
         );
+        // The session-private temp world was created for the shell
+        // (its TMPDIR; removed when the session drops).
+        let scratch = session
+            .scoped_scratch
+            .clone()
+            .expect("a scoped spawn creates its scratch dir");
+        assert!(scratch.is_dir(), "scratch {scratch:?} must exist");
 
         let mut rx = session.attach();
 

--- a/src/bin/caller/terminal.rs
+++ b/src/bin/caller/terminal.rs
@@ -1615,6 +1615,35 @@ impl TerminalRegistry {
 mod tests {
     use super::*;
 
+    /// The polling cursor: monotonic total-bytes-written space, gap
+    /// reporting when the cursor fell off the ring, clamped forward
+    /// cursors, and `u64::MAX` as the "start at now" high-water probe.
+    #[test]
+    fn scrollback_read_since_cursor_semantics() {
+        let mut ring = Scrollback::new(8);
+        ring.push(b"abcdef");
+        let (bytes, next, gap) = ring.read_since(0, 64);
+        assert_eq!(
+            (bytes.as_slice(), next, gap),
+            (b"abcdef".as_slice(), 6, false)
+        );
+        // Paged read.
+        let (bytes, next, gap) = ring.read_since(2, 2);
+        assert_eq!((bytes.as_slice(), next, gap), (b"cd".as_slice(), 4, false));
+        // Overflow trims the front; a pre-trim cursor reports the gap and
+        // resumes at the oldest retained byte.
+        ring.push(b"ghijkl"); // written=12, retained = "efghijkl"
+        let (bytes, next, gap) = ring.read_since(2, 64);
+        assert_eq!(bytes.as_slice(), b"efghijkl");
+        assert_eq!((next, gap), (12, true));
+        // Cursor 0 means "oldest retained", never a gap.
+        let (_, _, gap) = ring.read_since(0, 64);
+        assert!(!gap);
+        // The high-water probe returns the current cursor and nothing else.
+        let (bytes, next, gap) = ring.read_since(u64::MAX, 0);
+        assert_eq!((bytes.len(), next, gap), (0, 12, false));
+    }
+
     /// Unscoped spawn-allowed policy — the pre-scoping behavior.
     fn spawn_all() -> ShellSpawnPolicy {
         ShellSpawnPolicy {

--- a/src/bin/caller/terminal.rs
+++ b/src/bin/caller/terminal.rs
@@ -211,6 +211,12 @@ fn scoped_shell_cwd(
 /// repopulate the cleared environment the moment they execute (API keys
 /// exported in `~/.zshrc` are routine) — the profile skip is what makes
 /// the env clearing in [`PtySession::spawn`] stick.
+///
+/// The empty fallback for unrecognized shells is safe only under a
+/// filesystem sandbox (the rc files are unreadable there); an
+/// UNSANDBOXED principal spawn must never trust it — it goes through
+/// [`principal_shell_program`], which substitutes a shell with a known
+/// suppression mode instead.
 #[cfg(unix)]
 fn secret_free_shell_args(shell: &str) -> Vec<String> {
     let name = std::path::Path::new(shell)
@@ -241,6 +247,46 @@ fn secret_free_shell_args(shell: &str) -> Vec<String> {
         "powershell" | "pwsh" => vec!["-NoLogo".to_string(), "-NoProfile".to_string()],
         "cmd" => vec!["/d".to_string()],
         _ => Vec::new(),
+    }
+}
+
+/// The (program, argv) actually spawned for an UNSANDBOXED
+/// principal-owned shell. Suppressing profile startup is what makes the
+/// cleared environment stick, so only shells with a KNOWN suppression
+/// mode run as themselves; anything else — tcsh reads `~/.tcshrc` on
+/// every start, and an unrecognized shell can't be audited here — is
+/// replaced by bash in `--noprofile --norc` mode. Fail closed on
+/// secrecy, not open on shell preference.
+#[cfg(unix)]
+fn principal_shell_program(shell: &str) -> (String, Vec<String>) {
+    let name = std::path::Path::new(shell)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(shell);
+    match name {
+        "zsh" | "bash" | "fish" => (shell.to_string(), secret_free_shell_args(shell)),
+        _ => (
+            "/bin/bash".to_string(),
+            vec!["--noprofile".to_string(), "--norc".to_string()],
+        ),
+    }
+}
+
+/// Windows twin of [`principal_shell_program`].
+/// [`crate::platform::interactive_pty_shell`] only ever supplies
+/// powershell or cmd here — both with known suppression — but an
+/// unexpected program still falls back to profile-less PowerShell
+/// rather than running with profiles enabled.
+#[cfg(windows)]
+fn principal_shell_program(shell: &str) -> (String, Vec<String>) {
+    let args = secret_free_shell_args(shell);
+    if args.is_empty() {
+        (
+            "powershell.exe".to_string(),
+            vec!["-NoLogo".to_string(), "-NoProfile".to_string()],
+        )
+    } else {
+        (shell.to_string(), args)
     }
 }
 
@@ -840,8 +886,10 @@ impl PtySession {
     /// provider API keys, so the child env is cleared and rebuilt
     /// secret-free and the shell starts profile-less (a login shell's rc
     /// files would repopulate the environment before the principal ever
-    /// types); only root-lane shells (the owner's own surfaces) inherit
-    /// and get the login-style startup.
+    /// types — and a shell with no known suppression mode is substituted
+    /// by profile-less bash, see [`principal_shell_program`]); only
+    /// root-lane shells (the owner's own surfaces) inherit and get the
+    /// login-style startup.
     fn spawn(
         cols: u16,
         rows: u16,
@@ -883,17 +931,20 @@ impl PtySession {
                 .map_err(|e| format!("spawn scoped shell: {e}"))?
         } else {
             let build_cmd = |program: &str, args: &[String]| {
-                let mut cmd = PtyCommandBuilder::new(program);
-                if owner.is_some() {
-                    // Profile-less startup, or the env clearing below is
-                    // theater: a login shell's rc files run before the
-                    // principal ever types and would repopulate the
-                    // cleared environment (API keys exported in dotfiles
-                    // are routine).
-                    cmd.args(secret_free_shell_args(program));
+                // For a principal-owned spawn the PROGRAM is part of the
+                // secrecy decision, not just the argv: profile-less
+                // startup is what makes the env clearing below stick (a
+                // login shell's rc files run before the principal ever
+                // types and would repopulate the environment), and a
+                // shell without a known suppression mode is substituted
+                // rather than trusted — see `principal_shell_program`.
+                let (program, args) = if owner.is_some() {
+                    principal_shell_program(program)
                 } else {
-                    cmd.args(args);
-                }
+                    (program.to_string(), args.to_vec())
+                };
+                let mut cmd = PtyCommandBuilder::new(&program);
+                cmd.args(&args);
                 if let Some(ref dir) = cwd {
                     cmd.cwd(dir);
                 }
@@ -912,7 +963,7 @@ impl PtySession {
                     #[cfg(unix)]
                     let curated = secret_free_shell_env(
                         std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string()),
-                        program,
+                        &program,
                     );
                     #[cfg(windows)]
                     let curated = windows_secret_free_shell_env(
@@ -2460,6 +2511,37 @@ mod tests {
         assert!(secret_free_shell_args("/bin/sh").is_empty());
     }
 
+    /// A shell without a known profile-suppression mode must never run
+    /// an unsandboxed principal spawn (security review P1): tcsh reads
+    /// `~/.tcshrc` on every start, so an unrecognized `$SHELL` would
+    /// repopulate the cleared environment. It is substituted by
+    /// profile-less bash instead; known shells run as themselves.
+    #[cfg(unix)]
+    #[test]
+    fn principal_shell_program_substitutes_unknown_shells() {
+        assert_eq!(
+            principal_shell_program("/bin/zsh"),
+            ("/bin/zsh".to_string(), vec!["-f".to_string()])
+        );
+        assert_eq!(
+            principal_shell_program("/opt/homebrew/bin/fish"),
+            (
+                "/opt/homebrew/bin/fish".to_string(),
+                vec!["--no-config".to_string()]
+            )
+        );
+        for exotic in ["/bin/tcsh", "/bin/csh", "/usr/local/bin/nu", "/bin/sh"] {
+            assert_eq!(
+                principal_shell_program(exotic),
+                (
+                    "/bin/bash".to_string(),
+                    vec!["--noprofile".to_string(), "--norc".to_string()]
+                ),
+                "{exotic} must be replaced by profile-less bash"
+            );
+        }
+    }
+
     /// The Windows variant must disable profile/AutoRun startup for the
     /// interactive shells [`crate::platform::interactive_pty_shell`] can
     /// return — a profile script would repopulate the cleared environment
@@ -2476,6 +2558,16 @@ mod tests {
             vec!["-NoLogo", "-NoProfile"]
         );
         assert_eq!(secret_free_shell_args("cmd.exe"), vec!["/d"]);
+        // An unexpected program falls back to profile-less PowerShell
+        // rather than running with profiles enabled.
+        assert_eq!(
+            principal_shell_program("weird.exe"),
+            (
+                "powershell.exe".to_string(),
+                vec!["-NoLogo".to_string(), "-NoProfile".to_string()]
+            )
+        );
+        assert_eq!(principal_shell_program("cmd.exe").0, "cmd.exe");
     }
 
     #[cfg(unix)]

--- a/src/bin/caller/terminal.rs
+++ b/src/bin/caller/terminal.rs
@@ -822,6 +822,12 @@ pub struct PtySession {
     /// Shared sessions are visible to (and, with terminal.write, usable
     /// by) principals other than the owner. Toggled by the owner or root.
     shared: std::sync::atomic::AtomicBool,
+    /// The filesystem scope this shell was spawned under (`None` =
+    /// unscoped). The OS sandbox is fixed at spawn and cannot be
+    /// retrofitted, so accessors compare this against the owning
+    /// principal's CURRENT scope to refuse sessions whose sandbox no
+    /// longer expresses the grant.
+    spawn_scope: Option<crate::peer::access_policy::FilesystemAccessPolicy>,
 }
 
 impl PtySession {
@@ -972,6 +978,7 @@ impl PtySession {
             scope_grants,
             owner,
             shared: std::sync::atomic::AtomicBool::new(shared),
+            spawn_scope: scope.cloned(),
         });
 
         // portable_pty's reader and child wait are both blocking. On Windows,
@@ -1261,6 +1268,15 @@ impl PtySession {
     #[allow(dead_code)]
     pub fn owner(&self) -> Option<&str> {
         self.owner.as_deref()
+    }
+
+    /// The filesystem scope this shell was spawned under (`None` =
+    /// unscoped). The OS sandbox is fixed at spawn: when the owning
+    /// principal's grant scope has since changed, accessors refuse the
+    /// session as stale — close and reopen gets a shell under the
+    /// current scope.
+    pub fn spawn_scope(&self) -> Option<&crate::peer::access_policy::FilesystemAccessPolicy> {
+        self.spawn_scope.as_ref()
     }
 
     /// Whether `actor` may see (attach to / act on) this session: root
@@ -2536,6 +2552,10 @@ mod tests {
         drop(guard);
         let (session, created) = spawned.unwrap();
         assert!(created);
+        assert!(
+            session.spawn_scope().is_none(),
+            "an unscoped spawn records no scope"
+        );
 
         let mut rx = session.attach();
         expect_output(&mut rx, None, "shell startup").await;
@@ -2621,6 +2641,11 @@ mod tests {
             .await
             .unwrap();
         assert!(created);
+        assert_eq!(
+            session.spawn_scope().map(|s| s.write_roots.clone()),
+            Some(vec![root.clone()]),
+            "the spawn scope is recorded on the session"
+        );
 
         let mut rx = session.attach();
 

--- a/src/bin/caller/terminal.rs
+++ b/src/bin/caller/terminal.rs
@@ -463,6 +463,10 @@ fn seatbelt_profile(
 struct Scrollback {
     buf: VecDeque<u8>,
     capacity: usize,
+    /// Total bytes ever pushed — the monotonic cursor space for
+    /// [`Scrollback::read_since`]. The oldest retained byte sits at
+    /// `written - buf.len()`.
+    written: u64,
 }
 
 impl Scrollback {
@@ -470,15 +474,33 @@ impl Scrollback {
         Self {
             buf: VecDeque::with_capacity(capacity.min(4096)),
             capacity,
+            written: 0,
         }
     }
 
     fn push(&mut self, data: &[u8]) {
         self.buf.extend(data.iter().copied());
+        self.written += data.len() as u64;
         if self.buf.len() > self.capacity {
             let drop = self.buf.len() - self.capacity;
             self.buf.drain(..drop);
         }
+    }
+
+    /// Cursor-paged read for request/response consumers (the MCP terminal
+    /// verbs): `cursor` is an offset in total-bytes-written space (`0` =
+    /// from the oldest retained byte). Returns the bytes from the cursor —
+    /// or from the ring start when the cursor has fallen off the 256 KiB
+    /// window — the next cursor, and whether a gap was skipped (the
+    /// polling analogue of [`OUTPUT_DROPPED_MARKER`]).
+    fn read_since(&self, cursor: u64, max_bytes: usize) -> (Vec<u8>, u64, bool) {
+        let oldest = self.written - self.buf.len() as u64;
+        let gap = cursor < oldest && cursor != 0;
+        let start = cursor.clamp(oldest, self.written);
+        let skip = (start - oldest) as usize;
+        let take = self.buf.len().saturating_sub(skip).min(max_bytes);
+        let bytes: Vec<u8> = self.buf.iter().skip(skip).take(take).copied().collect();
+        (bytes, start + take as u64, gap)
     }
 
     fn snapshot(&self) -> Vec<u8> {
@@ -706,6 +728,13 @@ impl OutputHub {
         }
     }
 
+    /// Cursor-paged passthrough for polling readers — same lock as
+    /// `attach`, so a read is atomic with respect to the reader thread's
+    /// push+fan-out.
+    fn read_since(&self, cursor: u64, max_bytes: usize) -> (Vec<u8>, u64, bool) {
+        self.scrollback.read_since(cursor, max_bytes)
+    }
+
     fn attach(&mut self, max_queued_bytes: usize) -> TerminalListener {
         let shared = Arc::new(ListenerShared::new(max_queued_bytes));
         let snapshot = self.scrollback.snapshot();
@@ -733,6 +762,10 @@ pub struct PtySession {
     child_killer: StdMutex<Box<dyn portable_pty::ChildKiller + Send + Sync>>,
     output: StdMutex<OutputHub>,
     alive: StdMutex<bool>,
+    /// The exit status, retained after death so polling readers (which
+    /// were not attached when the `Exited` event fanned out) can still
+    /// learn why the shell died.
+    exit_status: StdMutex<Option<i32>>,
     /// Windows: the refcounted RESTRICTED ACE grants for this session's
     /// scope roots. Held for the session's lifetime so overlapping scoped
     /// shells never lose a shared grant early; dropped (and the ACEs
@@ -848,6 +881,7 @@ impl PtySession {
             child_killer: StdMutex::new(child_killer),
             output: StdMutex::new(OutputHub::new(SCROLLBACK_LIMIT)),
             alive: StdMutex::new(true),
+            exit_status: StdMutex::new(None),
             #[cfg(windows)]
             scope_grants,
             owner,
@@ -1101,9 +1135,35 @@ impl PtySession {
             false
         };
         if transitioned {
+            if let Ok(mut retained) = self.exit_status.lock() {
+                *retained = Some(status);
+            }
             let mut hub = self.output.lock().unwrap_or_else(|e| e.into_inner());
             hub.fan_out_exit(status);
         }
+    }
+
+    /// The retained exit status (`None` while alive or if never observed).
+    pub fn exit_status(&self) -> Option<i32> {
+        self.exit_status.lock().ok().and_then(|guard| *guard)
+    }
+
+    /// Cursor-paged scrollback read for request/response consumers; see
+    /// [`Scrollback::read_since`] for cursor semantics. Shares `attach`'s
+    /// critical section, so it can neither lose nor duplicate a chunk
+    /// racing in from the reader thread.
+    pub fn read_since(&self, cursor: u64, max_bytes: usize) -> (Vec<u8>, u64, bool) {
+        let hub = self.output.lock().unwrap_or_else(|e| e.into_inner());
+        hub.read_since(cursor, max_bytes)
+    }
+
+    /// Current PTY geometry, when the master can report it.
+    pub fn size(&self) -> Option<(u16, u16)> {
+        self.master
+            .lock()
+            .ok()
+            .and_then(|master| master.get_size().ok())
+            .map(|size| (size.cols, size.rows))
     }
 
     pub fn shared(&self) -> bool {
@@ -1216,6 +1276,18 @@ impl Drop for UnpublishedPtyGuard {
 /// replaced it while the opener was unlocked).
 fn slot_is_current(entry: Option<&SessionSlot>, slot: &Arc<OpeningSlot>) -> bool {
     matches!(entry, Some(SessionSlot::Opening(current)) if Arc::ptr_eq(current, slot))
+}
+
+/// One row of [`TerminalRegistry::list_visible`] — the fields a polling
+/// consumer needs to pick a session and start a cursor read.
+#[derive(Debug, Clone)]
+pub struct TerminalSummary {
+    pub key: TerminalKey,
+    pub alive: bool,
+    pub shared: bool,
+    pub can_manage: bool,
+    pub exit_status: Option<i32>,
+    pub size: Option<(u16, u16)>,
 }
 
 /// Process-wide registry of live shell sessions, keyed by
@@ -1463,6 +1535,31 @@ impl TerminalRegistry {
             Some(SessionSlot::Live(session)) if session.visible_to(actor) => Some(session.clone()),
             _ => None,
         }
+    }
+
+    /// Enumerate the sessions `actor` may see, for request/response
+    /// consumers (the MCP terminal verbs — the push lanes never needed
+    /// enumeration). Reservations in flight are skipped, matching every
+    /// other read's ordering: a spawn that has not published does not
+    /// exist yet.
+    pub async fn list_visible(&self, actor: &TerminalActor) -> Vec<TerminalSummary> {
+        let sessions = self.sessions.read().await;
+        let mut out: Vec<TerminalSummary> = sessions
+            .iter()
+            .filter_map(|(key, slot)| match slot {
+                SessionSlot::Live(session) if session.visible_to(actor) => Some(TerminalSummary {
+                    key: key.clone(),
+                    alive: session.is_alive(),
+                    shared: session.shared(),
+                    can_manage: session.managed_by(actor),
+                    exit_status: session.exit_status(),
+                    size: session.size(),
+                }),
+                _ => None,
+            })
+            .collect();
+        out.sort_by(|a, b| a.key.terminal_id.cmp(&b.key.terminal_id));
+        out
     }
 
     /// Close `key` if `actor` may see it. Returns whether a session was

--- a/src/bin/caller/web_gateway/access_gates.rs
+++ b/src/bin/caller/web_gateway/access_gates.rs
@@ -1454,6 +1454,7 @@ mod tests {
             iam_state: Some(std::sync::Arc::new(
                 crate::access::iam::LocalIamState::default(),
             )),
+            peer_filesystem: None,
         };
         let root = RequestAuthority {
             principal: crate::access::iam::AccessPrincipal::root_dashboard_session(
@@ -1461,6 +1462,7 @@ mod tests {
                 "http",
             ),
             iam_state: None,
+            peer_filesystem: None,
         };
 
         let mut revoked_state = crate::access::iam::LocalIamState::default();
@@ -1485,6 +1487,7 @@ mod tests {
         let revoked = RequestAuthority {
             principal: revoked_principal,
             iam_state: Some(std::sync::Arc::new(revoked_state)),
+            peer_filesystem: None,
         };
 
         for (path, operation) in [

--- a/src/bin/caller/web_gateway/api_core.rs
+++ b/src/bin/caller/web_gateway/api_core.rs
@@ -273,6 +273,15 @@ pub(crate) struct RequestAuthority {
     /// without deep-cloning principals/grants/audit history per request
     /// or per context clone (e.g. into `spawn_blocking`).
     pub(crate) iam_state: Option<std::sync::Arc<crate::access::iam::LocalIamState>>,
+    /// The authenticated peer connection's filesystem policy — present
+    /// exactly when this authority was minted from a
+    /// `PeerConnectionIdentity`. Peer principals have no local grant, so
+    /// their filesystem scope travels with the connection identity
+    /// instead of the IAM snapshot; without this, `fs_scope` would read
+    /// a peer as unrestricted (the dashboard tunnel's `Peer` grant arm
+    /// is the parity: a peer is always `Some(policy)`, never owner-class
+    /// `None`).
+    pub(crate) peer_filesystem: Option<crate::peer::access_policy::FilesystemAccessPolicy>,
 }
 
 impl RequestAuthority {
@@ -281,8 +290,15 @@ impl RequestAuthority {
     /// owner surfaces and scope-less grants, matching the dashboard
     /// tunnel's `DashboardControlGrant::filesystem` semantics). A
     /// grant-bearing principal without a readable IAM snapshot fails
-    /// closed to the EMPTY policy, never to unrestricted.
+    /// closed to the EMPTY policy, never to unrestricted; a
+    /// peer-authenticated request always carries its identity's policy.
     pub(crate) fn fs_scope(&self) -> Option<crate::peer::access_policy::FilesystemAccessPolicy> {
+        // A peer's scope rides its connection identity — peers have no
+        // local grant, and a peer is never an unrestricted owner
+        // surface (dashboard-tunnel `Peer` arm parity).
+        if let Some(peer_fs) = &self.peer_filesystem {
+            return Some(peer_fs.clone());
+        }
         match &self.iam_state {
             Some(state) => {
                 crate::access::iam::fs_scope_for_principal(state, &self.principal).cloned()
@@ -345,9 +361,36 @@ mod tests {
                 "https",
             ),
             iam_state: None,
+            peer_filesystem: None,
         };
         let decision =
             authority.decision(crate::peer::access_policy::PeerOperation::FilesystemRead);
         assert!(decision.allowed, "{decision:?}");
+    }
+
+    /// A peer-minted authority's filesystem scope is its connection
+    /// identity's policy — never owner-class `None` (review P1, round
+    /// 5): peer principals carry no local grant, so without the carried
+    /// policy `fs_scope` would read a peer as an unrestricted surface
+    /// and a terminal-operator peer's shell would escape its roots.
+    #[test]
+    fn peer_authority_fs_scope_is_the_identity_policy_never_unrestricted() {
+        let policy = crate::peer::access_policy::FilesystemAccessPolicy {
+            read_roots: vec![std::path::PathBuf::from("/srv/peer-read")],
+            write_roots: vec![std::path::PathBuf::from("/srv/peer-work")],
+        };
+        let authority = RequestAuthority {
+            principal: crate::access::iam::AccessPrincipal::peer_daemon(
+                "fp".to_string(),
+                "peer".to_string(),
+                "terminal-operator".to_string(),
+                "peer-http",
+            ),
+            iam_state: None,
+            peer_filesystem: Some(policy.clone()),
+        };
+        let scope = authority.fs_scope().expect("peer scope must be Some");
+        assert_eq!(scope.read_roots, policy.read_roots);
+        assert_eq!(scope.write_roots, policy.write_roots);
     }
 }

--- a/src/bin/caller/web_gateway/api_core.rs
+++ b/src/bin/caller/web_gateway/api_core.rs
@@ -276,6 +276,24 @@ pub(crate) struct RequestAuthority {
 }
 
 impl RequestAuthority {
+    /// The filesystem scope on the acting principal's active grant, for
+    /// sandboxing scoped shell spawns. `None` = no scope (unrestricted —
+    /// owner surfaces and scope-less grants, matching the dashboard
+    /// tunnel's `DashboardControlGrant::filesystem` semantics). A
+    /// grant-bearing principal without a readable IAM snapshot fails
+    /// closed to the EMPTY policy, never to unrestricted.
+    pub(crate) fn fs_scope(&self) -> Option<crate::peer::access_policy::FilesystemAccessPolicy> {
+        match &self.iam_state {
+            Some(state) => {
+                crate::access::iam::fs_scope_for_principal(state, &self.principal).cloned()
+            }
+            None if self.principal.grant_id.is_some() => {
+                Some(crate::peer::access_policy::FilesystemAccessPolicy::default())
+            }
+            None => None,
+        }
+    }
+
     pub(crate) fn decision(
         &self,
         op: crate::peer::access_policy::PeerOperation,

--- a/src/bin/caller/web_gateway/listener.rs
+++ b/src/bin/caller/web_gateway/listener.rs
@@ -1078,6 +1078,16 @@ fn spawn_web_gateway_from_cert_dir_with_relay_listener(
             std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."))
         })),
     );
+    // The MCP terminal tool family shares the same pool: a shell opened
+    // over MCP is attachable from the dashboard and vice versa.
+    if let Some(server) = mcp_server.as_ref() {
+        if !server.set_terminal_registry_now(terminal_registry.clone()) {
+            eprintln!(
+                "[web_gateway] terminal registry not wired into MCP state (lock contended at \
+                 boot) — terminal tools will answer unavailable"
+            );
+        }
+    }
 
     let dashboard_presence = {
         let connect_active_presence = active_presence.clone();

--- a/src/bin/caller/web_gateway/mcp_gate.rs
+++ b/src/bin/caller/web_gateway/mcp_gate.rs
@@ -845,6 +845,7 @@ pub(crate) fn mcp_http_access_context(
                 return Ok(HttpAccessContext {
                     principal: crate::access::iam::AccessPrincipal::mcp_token_holder(transport),
                     iam_state: None,
+                    peer_filesystem: None,
                 });
             };
             mcp_agent_session_context(cert_dir, &session_id, transport, false)
@@ -889,6 +890,7 @@ pub(crate) fn mcp_http_access_context(
                     return Ok(HttpAccessContext {
                         principal,
                         iam_state: Some(state),
+                        peer_filesystem: None,
                     });
                 }
                 // A lapsed local_process grant binds and is denied by the
@@ -899,6 +901,7 @@ pub(crate) fn mcp_http_access_context(
                     return Ok(HttpAccessContext {
                         principal,
                         iam_state: Some(state),
+                        peer_filesystem: None,
                     });
                 }
                 if crate::access::iam::agent_session_scoping_present(&state) {
@@ -917,6 +920,7 @@ pub(crate) fn mcp_http_access_context(
                     transport,
                 ),
                 iam_state: None,
+                peer_filesystem: None,
             })
         }
     }
@@ -943,6 +947,7 @@ pub(crate) fn mcp_agent_session_context(
             return Ok(HttpAccessContext {
                 principal,
                 iam_state: Some(state),
+                peer_filesystem: None,
             });
         }
         if let Some(principal) = crate::access::iam::principal_for_agent_session_any_status(
@@ -951,6 +956,7 @@ pub(crate) fn mcp_agent_session_context(
             return Ok(HttpAccessContext {
                 principal,
                 iam_state: Some(state),
+                peer_filesystem: None,
             });
         }
     }
@@ -961,6 +967,7 @@ pub(crate) fn mcp_agent_session_context(
             authenticated,
         ),
         iam_state: None,
+        peer_filesystem: None,
     })
 }
 
@@ -1596,6 +1603,7 @@ mod tests {
                 true,
             ),
             iam_state: None,
+            peer_filesystem: None,
         };
 
         let initialize = r#"{"jsonrpc":"2.0","id":1,"method":"initialize"}"#;
@@ -1639,6 +1647,7 @@ mod tests {
         let dashboard_access = HttpAccessContext {
             principal: crate::access::iam::AccessPrincipal::root_dashboard_session("test", "https"),
             iam_state: None,
+            peer_filesystem: None,
         };
         handle_mcp_http_request(
             list,
@@ -1728,6 +1737,7 @@ mod tests {
                 "sess-e2e", "http", true,
             ),
             iam_state: None,
+            peer_filesystem: None,
         };
         let outcome = handle_mcp_http_request(
             &call("parked by the session"),
@@ -1753,6 +1763,7 @@ mod tests {
         let dashboard_access = HttpAccessContext {
             principal: crate::access::iam::AccessPrincipal::root_dashboard_session("test", "https"),
             iam_state: None,
+            peer_filesystem: None,
         };
         let outcome = handle_mcp_http_request(
             &call("parked by the owner"),
@@ -1822,6 +1833,7 @@ mod tests {
                             "sess-neg", "http", true,
                         ),
                     iam_state: None,
+                    peer_filesystem: None,
                 },
                 Some("sess-neg".to_string()),
             ),
@@ -1831,6 +1843,7 @@ mod tests {
                         "test", "https",
                     ),
                     iam_state: None,
+                    peer_filesystem: None,
                 },
                 None,
             ),
@@ -1840,6 +1853,7 @@ mod tests {
                         "http",
                     ),
                     iam_state: None,
+                    peer_filesystem: None,
                 },
                 None,
             ),
@@ -1847,6 +1861,7 @@ mod tests {
                 HttpAccessContext {
                     principal: impostor,
                     iam_state: None,
+                    peer_filesystem: None,
                 },
                 None,
             ),
@@ -1948,6 +1963,7 @@ mod tests {
                 "sess-e2e", "http", true,
             ),
             iam_state: None,
+            peer_filesystem: None,
         };
         let outcome = handle_mcp_http_request(
             &call("proposed by the session"),
@@ -1978,6 +1994,7 @@ mod tests {
         let dashboard_access = HttpAccessContext {
             principal: crate::access::iam::AccessPrincipal::root_dashboard_session("test", "https"),
             iam_state: None,
+            peer_filesystem: None,
         };
         let outcome = handle_mcp_http_request(
             &call("proposed by the owner"),
@@ -2034,12 +2051,14 @@ mod tests {
         let dashboard_access = HttpAccessContext {
             principal: crate::access::iam::AccessPrincipal::root_dashboard_session("test", "https"),
             iam_state: None,
+            peer_filesystem: None,
         };
         let session_access = HttpAccessContext {
             principal: crate::access::iam::AccessPrincipal::supervised_agent_session_default(
                 "sess-e2e", "http", true,
             ),
             iam_state: None,
+            peer_filesystem: None,
         };
         let rpc = |name: &str, arguments: serde_json::Value| {
             serde_json::json!({

--- a/src/bin/caller/web_gateway/mcp_gate.rs
+++ b/src/bin/caller/web_gateway/mcp_gate.rs
@@ -555,7 +555,8 @@ pub(crate) async fn handle_mcp_http_request(
                     args,
                     session_id,
                     codex_managed_context,
-                    crate::mcp::ToolCaller::from_gate(&access.principal, gate_session.clone()),
+                    crate::mcp::ToolCaller::from_gate(&access.principal, gate_session.clone())
+                        .with_fs_scope(access.fs_scope()),
                 )
                 .await
             {

--- a/src/bin/caller/web_gateway/routes_access.rs
+++ b/src/bin/caller/web_gateway/routes_access.rs
@@ -2896,6 +2896,7 @@ pub(crate) fn authority_free_http_access_context(is_tls: bool) -> HttpAccessCont
             "http"
         }),
         iam_state: None,
+        peer_filesystem: None,
     }
 }
 
@@ -2932,6 +2933,12 @@ pub(crate) fn http_access_context(
         return Ok(HttpAccessContext {
             principal: peer_identity_access_principal(identity, "peer-http"),
             iam_state: None,
+            // The peer's filesystem policy must travel with the
+            // authority: peer principals have no local grant, and
+            // dropping it here would read the peer as an unrestricted
+            // owner surface at every fs-scoped consumer (scoped shell
+            // spawns above all).
+            peer_filesystem: Some(identity.filesystem.clone()),
         });
     }
     let transport = if is_tls { "https" } else { "http" };
@@ -2941,6 +2948,7 @@ pub(crate) fn http_access_context(
         return Ok(HttpAccessContext {
             principal,
             iam_state: Some(state),
+            peer_filesystem: None,
         });
     }
     if tls_client_cert_present {
@@ -2948,6 +2956,7 @@ pub(crate) fn http_access_context(
         return Ok(HttpAccessContext {
             principal: browser_mtls_principal_for_state(&state, None, transport),
             iam_state: Some(state),
+            peer_filesystem: None,
         });
     }
     // The certless fallback is the trusted-local owner lane. Its
@@ -2964,6 +2973,7 @@ pub(crate) fn http_access_context(
             transport,
         ),
         iam_state: None,
+        peer_filesystem: None,
     })
 }
 
@@ -4128,6 +4138,33 @@ mod tests {
         );
     }
 
+    /// A peer-authenticated request's authority carries the connection
+    /// identity's filesystem policy (review P1, round 5): peer
+    /// principals have no local grant, so dropping the policy here made
+    /// `fs_scope` read the peer as an unrestricted owner surface — a
+    /// terminal-capable peer's shell would escape its configured roots.
+    #[test]
+    fn http_access_context_carries_the_peer_identity_filesystem() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let identity = PeerConnectionIdentity {
+            fingerprint: "peerfp01".to_string(),
+            label: "peer-a".to_string(),
+            profile: "terminal-operator".to_string(),
+            filesystem: crate::peer::access_policy::FilesystemAccessPolicy {
+                read_roots: vec![std::path::PathBuf::from("/srv/peer-read")],
+                write_roots: vec![std::path::PathBuf::from("/srv/peer-work")],
+            },
+            record: None,
+        };
+        let access = http_access_context(tmp.path(), Some(&identity), None, false, true, false)
+            .expect("peer identity resolves an authority");
+        let scope = access
+            .fs_scope()
+            .expect("peer authority must always carry a filesystem scope");
+        assert_eq!(scope.read_roots, identity.filesystem.read_roots);
+        assert_eq!(scope.write_roots, identity.filesystem.write_roots);
+    }
+
     #[test]
     fn browser_mtls_request_cannot_mint_generated_owner_root() {
         let tmp = tempfile::TempDir::new().unwrap();
@@ -4985,6 +5022,7 @@ mod tests {
                     "golden", "https",
                 ),
                 iam_state: None,
+                peer_filesystem: None,
             };
             let response = collect_access_handler_response(|stream| {
                 handle_access_overview(
@@ -5091,6 +5129,7 @@ mod tests {
                     "golden", "https",
                 ),
                 iam_state: None,
+                peer_filesystem: None,
             };
             let response = collect_access_handler_response(|stream| {
                 handle_access_connect_claim_code(stream, context, cors, origin)
@@ -5141,6 +5180,7 @@ mod tests {
                 "golden", "https",
             ),
             iam_state: None,
+            peer_filesystem: None,
         };
 
         // Invalid JSON: serde's wording for this exact input, derived
@@ -5229,6 +5269,7 @@ mod tests {
                     "golden", "https",
                 ),
                 iam_state: None,
+                peer_filesystem: None,
             };
             let root = dir.path().to_path_buf();
             let response = collect_access_handler_response(|stream| {
@@ -5258,6 +5299,7 @@ mod tests {
                 "golden", "https",
             ),
             iam_state: None,
+            peer_filesystem: None,
         };
 
         // Non-string tier: the validation 400 under the fleet tail.
@@ -5349,6 +5391,7 @@ mod tests {
                 "golden", "https",
             ),
             iam_state: None,
+            peer_filesystem: None,
         }
     }
 

--- a/src/bin/caller/web_gateway/routes_claude_auth.rs
+++ b/src/bin/caller/web_gateway/routes_claude_auth.rs
@@ -303,11 +303,13 @@ mod tests {
         let hosted = RequestAuthority {
             principal: hosted_principal(),
             iam_state: None,
+            peer_filesystem: None,
         };
         assert!(request_authority_is_hosted(&hosted));
         let direct = RequestAuthority {
             principal: crate::access::iam::AccessPrincipal::root_dashboard_session("test", "test"),
             iam_state: None,
+            peer_filesystem: None,
         };
         assert!(!request_authority_is_hosted(&direct));
         // With a state snapshot the central evaluator's provenance rules
@@ -317,6 +319,7 @@ mod tests {
             iam_state: Some(std::sync::Arc::new(
                 crate::access::iam::LocalIamState::default(),
             )),
+            peer_filesystem: None,
         };
         assert!(request_authority_is_hosted(&hosted_with_state));
     }

--- a/src/bin/caller/web_gateway/routes_files.rs
+++ b/src/bin/caller/web_gateway/routes_files.rs
@@ -2987,6 +2987,7 @@ mod tests {
             HttpAccessContext {
                 principal,
                 iam_state: Some(std::sync::Arc::new(state.clone())),
+                peer_filesystem: None,
             },
             state,
         )
@@ -3010,6 +3011,7 @@ mod tests {
                 "https",
             ),
             iam_state: Some(Default::default()),
+            peer_filesystem: None,
         };
         assert!(authorized_dashboard_local_file_response_blocking(
             &request(&allowed),
@@ -3057,6 +3059,7 @@ mod tests {
         let revoked = HttpAccessContext {
             principal: scoped.principal.clone(),
             iam_state: Some(std::sync::Arc::new(revoked_state)),
+            peer_filesystem: None,
         };
         assert!(authorized_dashboard_local_file_response_blocking(
             &request(&allowed),
@@ -3073,6 +3076,7 @@ mod tests {
                 "test", "loopback",
             ),
             iam_state: None,
+            peer_filesystem: None,
         };
         assert!(authorized_dashboard_local_file_response_blocking(
             &request(&secret),
@@ -3797,6 +3801,7 @@ mod tests {
                 "http",
             ),
             iam_state: None,
+            peer_filesystem: None,
         }
     }
 

--- a/src/bin/caller/web_gateway/routes_hosted_control.rs
+++ b/src/bin/caller/web_gateway/routes_hosted_control.rs
@@ -153,6 +153,7 @@ impl HostedHttpAuthority {
         HttpAccessContext {
             principal: self.verified.principal.clone(),
             iam_state: Some(Arc::clone(&self.verified.iam_state)),
+            peer_filesystem: None,
         }
     }
 

--- a/src/bin/caller/web_gateway/routes_transfers.rs
+++ b/src/bin/caller/web_gateway/routes_transfers.rs
@@ -1491,6 +1491,7 @@ mod tests {
                 "https",
             ),
             iam_state: None,
+            peer_filesystem: None,
         };
         for (op, access) in [
             (PeerOperation::FilesystemRead, TransferJobAccess::ReadSource),
@@ -1557,6 +1558,7 @@ mod tests {
                 ..crate::access::iam::AccessPrincipal::root_dashboard_session("scoped", "https")
             },
             iam_state: Some(std::sync::Arc::new(state)),
+            peer_filesystem: None,
         };
         assert!(authorize_http_transfer_access(
             &scoped,


### PR DESCRIPTION
M1b of the MCP control-lane program (design: #885; facade landed in #888): the terminal verb family, per the owner ruling that controlling agents get terminal access.

**Six tools over the existing dashboard PTY pool** — `terminal_list` / `open` / `read` / `write` / `resize` / `close`. Same `TerminalRegistry`, so a shell opened over MCP is attachable from a dashboard terminal tile and vice versa, and the registry's own visibility model applies (root surfaces see everything; scoped principals see their own and shared sessions, derived from the bound IAM principal — a missing principal id owns nothing).

**Structurally honest operations.** Where the dashboard tunnel's `terminal_open` frame decides attach-vs-create statefully inside the handler, here it is two authorities: reads ride `terminal.view`, input/resize/close ride `terminal.write`, and `terminal_open` always carries `shell.spawn` because it creates when absent. No stateful check, no operation broader than the tool.

**Polling, not streaming** — additive plumbing on `terminal.rs`: a monotonic total-bytes-written cursor over the scrollback ring with `read_since` (reports `gap: true` when the cursor fell off the 256 KiB window — the polling analogue of the push lane's dropped-output marker), sharing `attach`'s critical section; a retained exit status so a poller that missed the death still learns it; a geometry accessor; and `list_visible`, which skips in-flight spawn reservations like every other read.

**Facade rows:** `terminal list`/`read` on `inspect`; `resize`/`close` on `act`; `open`/`write` on `authorize` — writing into a live shell is running commands, the same class as spawning one. Terminal tools stay out of the scoped advertisement profiles (the `remote_command` context-rent precedent); they appear on full/unprofiled listings and through the facade.

Hosted note: nothing in this PR touches the hosted walls — `/mcp` remains excluded from the hosted-lease route set, and the R2 question ("maybe for R2", Operate-preset terminal) stays a policy decision for the M4 security review, exactly as ruled.
