### PR TITLE
mcp: the events verb - cursor long-poll over the daemon lifecycle stream

### DIFF
--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -70,7 +70,7 @@ served display/CU and shared-view set — its allowlist also names the
 browser-workspace and raw frame tools, which currently have no served
 `tools/list` definitions anywhere and are reachable only by direct call;
 `managed` (alias `managed-context`) advertises `get_status` plus the managed
-rewind/fission set; `facade` advertises only the five meta-tools of the
+rewind/fission set; `facade` advertises only the six meta-tools of the
 CLI-shaped facade (next section); `full` — or omitting `tool_profile` —
 keeps the whole
 list, and unknown profile names fall back to the `core` bootstrap set (the
@@ -82,14 +82,22 @@ hidden HTTP tools remain callable (the lazy `ctl tools call` path).
 ### The facade profile
 
 `tool_profile=facade` is the context-efficient control surface: instead of a
-typed schema per capability, it advertises five meta-tools and everything
+typed schema per capability, it advertises six meta-tools and everything
 else is discovered lazily. `inspect`, `act`, and `authorize` each execute
 one registered command per call, named as an argv array
 (`{"argv":["agenda","list","--status","open"]}`) — risk-split so MCP hosts
 can auto-allow reads and gate authority-class calls per tool. `help` renders
 the command map from the registry (families first, then per-family usage
 lines with each command's lane); `docs` lists and fetches the embedded
-operating skills. A facade call is authorized as the **resolved** command's
+operating skills. `events` is the cursor long-poll over the daemon's
+session/approval/task lifecycle stream — omit `since` to start at now,
+pass `wait_s` (≤60) to block until something happens, re-poll with the
+returned `next_cursor`, and treat `gap: true` as "resync via the read
+commands". Its cursors are opaque, bound to the minting principal, and
+invalidated by a daemon restart (the error says so); the underlying ring
+ingests only the lifecycle families the `session.inspect` read tools
+already serve, so the stream is push semantics over existing authority,
+never new authority. A facade call is authorized as the **resolved** command's
 operation against the caller's principal, at every ingress, before any side
 effect — a parse failure never dispatches, and a command invoked through the
 wrong lane is redirected to the right tool by name. Argv values are literal

--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -97,7 +97,10 @@ commands". Its cursors are opaque, bound to the minting principal, and
 invalidated by a daemon restart (the error says so); the underlying ring
 ingests only the lifecycle families the `session.inspect` read tools
 already serve, so the stream is push semantics over existing authority,
-never new authority. A facade call is authorized as the **resolved** command's
+never new authority — and delivery is session-scoped for agent-session
+callers (a supervised backend on its session-bound token sees only its
+own session's events, sessionless events withheld, matching the scoped
+approval reads). A facade call is authorized as the **resolved** command's
 operation against the caller's principal, at every ingress, before any side
 effect — a parse failure never dispatches, and a command invoked through the
 wrong lane is redirected to the right tool by name. Argv values are literal

--- a/src/bin/caller/event_ring.rs
+++ b/src/bin/caller/event_ring.rs
@@ -1,0 +1,330 @@
+//! The daemon-wide event ring: a bounded, cursor-addressed window over
+//! the control-plane bus, feeding the MCP `events` long-poll verb
+//! (docs/design-mcp-control-lane.md, M2).
+//!
+//! Shape decisions:
+//!
+//! - **Modeled on the presence event window** (`presence-core`'s
+//!   `push → seq` / `since(seq)` / `current_seq()` triple) — the one
+//!   proven cursor idiom in the tree — but daemon-wide and fed once per
+//!   process from the bus broadcast lane, next to the other
+//!   mode-independent bus folds in `startup::wiring`.
+//! - **Sequence numbers are assigned at ingest**, never inherited from
+//!   an upstream counter, and every read reports `current_seq` so a
+//!   quiet poll still advances the caller's cursor.
+//! - **The ingest allowlist is the security boundary**: the ring stores
+//!   only event families whose content the `session.inspect`-gated read
+//!   tools already serve (session/approval/task lifecycle). Families
+//!   gated by other operations — agenda, memory, displays, credentials
+//!   — and the high-rate streaming families (model deltas, agent
+//!   output, context snapshots) are never ingested, so the `events`
+//!   verb can never widen what its operation already reads.
+//! - **Loss is visible twice over**: a bus-side lag pushes a synthetic
+//!   `event_gap` entry into the ring (the dashboard WS precedent), and
+//!   a cursor that has fallen off the retained window reports
+//!   `gap: true` (the terminal scrollback precedent).
+
+use std::collections::VecDeque;
+use std::sync::Arc;
+
+use crate::event::{app_event_to_outbound, AppEvent, EventBus};
+
+/// Retained entries (count bound). Lifecycle families are low-rate, so
+/// this is minutes-to-hours of history on a busy daemon.
+const RING_CAPACITY: usize = 1024;
+/// Retained bytes (size bound): approval prompts can be large, and the
+/// ring must never become a session-transcript hoard.
+const RING_MAX_BYTES: usize = 2 * 1024 * 1024;
+
+/// One retained event: its ingest-assigned sequence number and the
+/// pre-serialized `OutboundEvent` JSON (`{"event":"…", …}`).
+#[derive(Debug, Clone)]
+pub struct RingEntry {
+    pub seq: u64,
+    pub json: String,
+}
+
+struct RingInner {
+    entries: VecDeque<RingEntry>,
+    bytes: usize,
+    next_seq: u64,
+}
+
+/// Bounded daemon-wide event window with monotonic cursors. Readers
+/// long-poll via [`EventRing::notified`] + [`EventRing::since`]; the
+/// writer is the single bus fold spawned by [`spawn_event_ring_fold`].
+pub struct EventRing {
+    inner: std::sync::Mutex<RingInner>,
+    notify: tokio::sync::Notify,
+    /// Random per-boot identity baked into cursors: the ring is
+    /// in-memory, so sequence numbers restart with the daemon — a
+    /// cursor from a previous boot must fail loudly ("daemon
+    /// restarted"), never read the wrong positions silently.
+    epoch: u64,
+}
+
+impl EventRing {
+    pub fn new() -> Self {
+        Self {
+            inner: std::sync::Mutex::new(RingInner {
+                entries: VecDeque::new(),
+                bytes: 0,
+                next_seq: 1,
+            }),
+            notify: tokio::sync::Notify::new(),
+            epoch: uuid::Uuid::new_v4().as_u128() as u64,
+        }
+    }
+
+    /// The per-boot cursor epoch.
+    pub fn epoch(&self) -> u64 {
+        self.epoch
+    }
+
+    /// Append one serialized event, assign its sequence number, evict
+    /// oldest entries past the count/byte bounds, and wake pollers.
+    pub fn push(&self, json: String) -> u64 {
+        let seq = {
+            let mut inner = self.inner.lock().expect("event ring lock");
+            let seq = inner.next_seq;
+            inner.next_seq += 1;
+            inner.bytes += json.len();
+            inner.entries.push_back(RingEntry { seq, json });
+            while inner.entries.len() > RING_CAPACITY
+                || (inner.bytes > RING_MAX_BYTES && inner.entries.len() > 1)
+            {
+                if let Some(dropped) = inner.entries.pop_front() {
+                    inner.bytes -= dropped.json.len();
+                }
+            }
+            seq
+        };
+        self.notify.notify_waiters();
+        seq
+    }
+
+    /// The highest assigned sequence number (0 = nothing ever pushed).
+    pub fn current_seq(&self) -> u64 {
+        self.inner.lock().expect("event ring lock").next_seq - 1
+    }
+
+    /// Entries with `seq > since`, capped at `max`, plus whether `since`
+    /// has fallen off the retained window (events were evicted unseen —
+    /// the caller should resync its world from the read tools).
+    pub fn since(&self, since: u64, max: usize) -> (Vec<RingEntry>, bool) {
+        let inner = self.inner.lock().expect("event ring lock");
+        let oldest_retained = inner.entries.front().map(|e| e.seq);
+        // A gap exists when events newer than the cursor were evicted:
+        // the oldest retained entry is more than one past the cursor,
+        // or everything is gone while the counter moved past it.
+        let gap = match oldest_retained {
+            Some(oldest) => since + 1 < oldest,
+            None => since < inner.next_seq - 1,
+        };
+        let events = inner
+            .entries
+            .iter()
+            .filter(|e| e.seq > since)
+            .take(max)
+            .cloned()
+            .collect();
+        (events, gap)
+    }
+
+    /// A future that resolves on the next push. Create it BEFORE
+    /// re-checking `current_seq` so a push between the check and the
+    /// await cannot be missed (the standard Notify discipline).
+    pub fn notified(&self) -> tokio::sync::futures::Notified<'_> {
+        self.notify.notified()
+    }
+}
+
+impl Default for EventRing {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Whether an [`AppEvent`] belongs in the ring: the session, approval,
+/// and task lifecycle families — exactly the content the
+/// `session.inspect`-gated read tools already serve. Everything else is
+/// deliberately absent: the streaming families would flood the window
+/// (model deltas, agent output, context snapshots), and the families
+/// gated by OTHER operations (agenda, memory, display, credential,
+/// presence) must not become readable through a `session.inspect` verb.
+pub fn app_event_rides_event_ring(event: &AppEvent) -> bool {
+    matches!(
+        event,
+        AppEvent::SessionStarted { .. }
+            | AppEvent::SessionEnded { .. }
+            | AppEvent::SessionIdentity { .. }
+            | AppEvent::SessionAttached { .. }
+            | AppEvent::StatusUpdate { .. }
+            | AppEvent::TurnStarted { .. }
+            | AppEvent::RoundComplete { .. }
+            | AppEvent::TaskComplete { .. }
+            | AppEvent::DoneSignal { .. }
+            | AppEvent::Interrupted { .. }
+            | AppEvent::ApprovalRequired { .. }
+            | AppEvent::UserQuestionRequired { .. }
+            | AppEvent::ApprovalResolved { .. }
+            | AppEvent::AutoApproved { .. }
+    )
+}
+
+/// Spawn the single bus → ring fold (mode-independent; lives next to
+/// the other daemon-wide bus listeners in `startup::wiring`). A lagged
+/// broadcast receiver records a synthetic `event_gap` entry so pollers
+/// can tell "quiet" from "you missed N events".
+pub fn spawn_event_ring_fold(
+    mut event_rx: tokio::sync::broadcast::Receiver<AppEvent>,
+    ring: Arc<EventRing>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            match event_rx.recv().await {
+                Ok(event) => {
+                    if !app_event_rides_event_ring(&event) {
+                        continue;
+                    }
+                    if let Some(outbound) = app_event_to_outbound(&event) {
+                        match serde_json::to_string(&outbound) {
+                            Ok(json) => {
+                                ring.push(json);
+                            }
+                            Err(err) => {
+                                eprintln!("[event-ring] serialize outbound event: {err}");
+                            }
+                        }
+                    }
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                    ring.push(
+                        serde_json::json!({ "event": "event_gap", "skipped": skipped }).to_string(),
+                    );
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    })
+}
+
+/// Convenience for the startup wiring: build the ring and its fold in
+/// one call.
+pub fn start_event_ring(bus: &EventBus) -> (Arc<EventRing>, tokio::task::JoinHandle<()>) {
+    let ring = Arc::new(EventRing::new());
+    let fold = spawn_event_ring_fold(bus.subscribe(), ring.clone());
+    (ring, fold)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry_seqs(entries: &[RingEntry]) -> Vec<u64> {
+        entries.iter().map(|e| e.seq).collect()
+    }
+
+    #[test]
+    fn cursors_advance_and_read_in_order() {
+        let ring = EventRing::new();
+        assert_eq!(ring.current_seq(), 0);
+        assert_eq!(ring.push("{\"event\":\"a\"}".into()), 1);
+        assert_eq!(ring.push("{\"event\":\"b\"}".into()), 2);
+        assert_eq!(ring.current_seq(), 2);
+        let (events, gap) = ring.since(0, 100);
+        assert!(!gap);
+        assert_eq!(entry_seqs(&events), vec![1, 2]);
+        let (events, gap) = ring.since(1, 100);
+        assert!(!gap);
+        assert_eq!(entry_seqs(&events), vec![2]);
+        let (events, gap) = ring.since(2, 100);
+        assert!(!gap, "a caught-up cursor is not a gap");
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn eviction_is_visible_as_a_gap() {
+        let ring = EventRing::new();
+        for i in 0..(RING_CAPACITY + 10) {
+            ring.push(format!("{{\"event\":\"e{i}\"}}"));
+        }
+        // The first 10 entries were evicted: a cursor at 0 reports the
+        // gap; a cursor at the eviction boundary does not.
+        let (events, gap) = ring.since(0, usize::MAX);
+        assert!(gap, "evicted-past cursor must report a gap");
+        assert_eq!(events.len(), RING_CAPACITY);
+        let boundary = (RING_CAPACITY as u64 + 10) - RING_CAPACITY as u64;
+        let (_, gap) = ring.since(boundary, usize::MAX);
+        assert!(!gap, "cursor at the oldest retained boundary is gapless");
+    }
+
+    #[test]
+    fn byte_bound_evicts_oldest_but_keeps_the_newest() {
+        let ring = EventRing::new();
+        let big = "x".repeat(RING_MAX_BYTES / 2);
+        ring.push(big.clone());
+        ring.push(big.clone());
+        ring.push(big);
+        let (events, gap) = ring.since(0, usize::MAX);
+        assert!(gap);
+        assert!(
+            events.len() < 3,
+            "the byte bound must have evicted something"
+        );
+        assert_eq!(
+            events.last().map(|e| e.seq),
+            Some(3),
+            "the newest entry always survives"
+        );
+    }
+
+    #[test]
+    fn max_caps_one_page() {
+        let ring = EventRing::new();
+        for i in 0..10 {
+            ring.push(format!("{{\"event\":\"e{i}\"}}"));
+        }
+        let (events, _) = ring.since(0, 3);
+        assert_eq!(entry_seqs(&events), vec![1, 2, 3]);
+    }
+
+    /// The allowlist is the security boundary: lifecycle/approval/task
+    /// families ride; streaming floods and families gated by other
+    /// operations never do (security posture of the `events` verb).
+    #[test]
+    fn ring_allowlist_excludes_floods_and_foreign_op_families() {
+        let rides = |event: &AppEvent| app_event_rides_event_ring(event);
+        assert!(rides(&AppEvent::SessionEnded {
+            session_id: "s".into(),
+            reason: "done".into(),
+            error_kind: None,
+        }));
+        assert!(rides(&AppEvent::ApprovalResolved {
+            session_id: None,
+            id: 7,
+            action: "accept".into(),
+        }));
+        assert!(!rides(&AppEvent::ModelResponseDelta {
+            session_id: Some("s".into()),
+            text: "flood".into(),
+        }));
+    }
+
+    #[tokio::test]
+    async fn notified_wakes_on_push() {
+        let ring = Arc::new(EventRing::new());
+        let notified = ring.notified();
+        let pusher = {
+            let ring = ring.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+                ring.push("{\"event\":\"wake\"}".into());
+            })
+        };
+        tokio::time::timeout(std::time::Duration::from_secs(5), notified)
+            .await
+            .expect("push must wake a parked poller");
+        pusher.await.unwrap();
+    }
+}

--- a/src/bin/caller/event_ring.rs
+++ b/src/bin/caller/event_ring.rs
@@ -116,9 +116,13 @@ impl EventRing {
         let oldest_retained = inner.entries.front().map(|e| e.seq);
         // A gap exists when events newer than the cursor were evicted:
         // the oldest retained entry is more than one past the cursor,
-        // or everything is gone while the counter moved past it.
+        // or everything is gone while the counter moved past it. The
+        // arithmetic saturates so an out-of-range cursor (callers are
+        // expected to validate first) degrades to a wrong-but-harmless
+        // answer instead of a debug overflow panic that would poison
+        // the ring's mutex for the whole daemon.
         let gap = match oldest_retained {
-            Some(oldest) => since + 1 < oldest,
+            Some(oldest) => since.saturating_add(1) < oldest,
             None => since < inner.next_seq - 1,
         };
         let events = inner
@@ -277,6 +281,18 @@ mod tests {
             Some(3),
             "the newest entry always survives"
         );
+    }
+
+    /// An out-of-range cursor must never panic inside the lock — a
+    /// debug overflow there would poison the mutex and kill the event
+    /// stream for the whole daemon (review P2). Callers validate
+    /// cursors first; the ring is merely harmless on junk.
+    #[test]
+    fn out_of_range_cursor_is_harmless() {
+        let ring = EventRing::new();
+        ring.push("{\"event\":\"a\"}".into());
+        let (events, _) = ring.since(u64::MAX, 10);
+        assert!(events.is_empty());
     }
 
     #[test]

--- a/src/bin/caller/event_ring.rs
+++ b/src/bin/caller/event_ring.rs
@@ -36,11 +36,19 @@ const RING_CAPACITY: usize = 1024;
 /// ring must never become a session-transcript hoard.
 const RING_MAX_BYTES: usize = 2 * 1024 * 1024;
 
-/// One retained event: its ingest-assigned sequence number and the
-/// pre-serialized `OutboundEvent` JSON (`{"event":"…", …}`).
+/// One retained event: its ingest-assigned sequence number, the
+/// `OutboundEvent` tag and owning session (extracted once at ingest so
+/// delivery-time filtering and session scoping never re-parse), and the
+/// pre-serialized JSON (`{"event":"…", …}`).
 #[derive(Debug, Clone)]
 pub struct RingEntry {
     pub seq: u64,
+    /// The serde tag ("session_started", …; "event_gap" for the
+    /// synthetic loss marker).
+    pub event: String,
+    /// The session the event belongs to (`None` = daemon-wide, e.g. an
+    /// approval raised outside any session).
+    pub session_id: Option<String>,
     pub json: String,
 }
 
@@ -83,13 +91,18 @@ impl EventRing {
 
     /// Append one serialized event, assign its sequence number, evict
     /// oldest entries past the count/byte bounds, and wake pollers.
-    pub fn push(&self, json: String) -> u64 {
+    pub fn push(&self, event: String, session_id: Option<String>, json: String) -> u64 {
         let seq = {
             let mut inner = self.inner.lock().expect("event ring lock");
             let seq = inner.next_seq;
             inner.next_seq += 1;
             inner.bytes += json.len();
-            inner.entries.push_back(RingEntry { seq, json });
+            inner.entries.push_back(RingEntry {
+                seq,
+                event,
+                session_id,
+                json,
+            });
             while inner.entries.len() > RING_CAPACITY
                 || (inner.bytes > RING_MAX_BYTES && inner.entries.len() > 1)
             {
@@ -192,9 +205,21 @@ pub fn spawn_event_ring_fold(
                         continue;
                     }
                     if let Some(outbound) = app_event_to_outbound(&event) {
-                        match serde_json::to_string(&outbound) {
-                            Ok(json) => {
-                                ring.push(json);
+                        match serde_json::to_value(&outbound) {
+                            Ok(value) => {
+                                // Tag and owning session are extracted
+                                // once here so delivery can name-filter
+                                // and session-scope without re-parsing.
+                                let name = value
+                                    .get("event")
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or("unknown")
+                                    .to_string();
+                                let session_id = value
+                                    .get("session_id")
+                                    .and_then(|v| v.as_str())
+                                    .map(String::from);
+                                ring.push(name, session_id, value.to_string());
                             }
                             Err(err) => {
                                 eprintln!("[event-ring] serialize outbound event: {err}");
@@ -204,6 +229,8 @@ pub fn spawn_event_ring_fold(
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
                     ring.push(
+                        "event_gap".to_string(),
+                        None,
                         serde_json::json!({ "event": "event_gap", "skipped": skipped }).to_string(),
                     );
                 }
@@ -233,8 +260,8 @@ mod tests {
     fn cursors_advance_and_read_in_order() {
         let ring = EventRing::new();
         assert_eq!(ring.current_seq(), 0);
-        assert_eq!(ring.push("{\"event\":\"a\"}".into()), 1);
-        assert_eq!(ring.push("{\"event\":\"b\"}".into()), 2);
+        assert_eq!(ring.push("a".into(), None, "{\"event\":\"a\"}".into()), 1);
+        assert_eq!(ring.push("b".into(), None, "{\"event\":\"b\"}".into()), 2);
         assert_eq!(ring.current_seq(), 2);
         let (events, gap) = ring.since(0, 100);
         assert!(!gap);
@@ -251,7 +278,7 @@ mod tests {
     fn eviction_is_visible_as_a_gap() {
         let ring = EventRing::new();
         for i in 0..(RING_CAPACITY + 10) {
-            ring.push(format!("{{\"event\":\"e{i}\"}}"));
+            ring.push("e".into(), None, format!("{{\"event\":\"e{i}\"}}"));
         }
         // The first 10 entries were evicted: a cursor at 0 reports the
         // gap; a cursor at the eviction boundary does not.
@@ -267,9 +294,9 @@ mod tests {
     fn byte_bound_evicts_oldest_but_keeps_the_newest() {
         let ring = EventRing::new();
         let big = "x".repeat(RING_MAX_BYTES / 2);
-        ring.push(big.clone());
-        ring.push(big.clone());
-        ring.push(big);
+        ring.push("big".into(), None, big.clone());
+        ring.push("big".into(), None, big.clone());
+        ring.push("big".into(), None, big);
         let (events, gap) = ring.since(0, usize::MAX);
         assert!(gap);
         assert!(
@@ -290,7 +317,7 @@ mod tests {
     #[test]
     fn out_of_range_cursor_is_harmless() {
         let ring = EventRing::new();
-        ring.push("{\"event\":\"a\"}".into());
+        ring.push("a".into(), None, "{\"event\":\"a\"}".into());
         let (events, _) = ring.since(u64::MAX, 10);
         assert!(events.is_empty());
     }
@@ -299,7 +326,7 @@ mod tests {
     fn max_caps_one_page() {
         let ring = EventRing::new();
         for i in 0..10 {
-            ring.push(format!("{{\"event\":\"e{i}\"}}"));
+            ring.push("e".into(), None, format!("{{\"event\":\"e{i}\"}}"));
         }
         let (events, _) = ring.since(0, 3);
         assert_eq!(entry_seqs(&events), vec![1, 2, 3]);
@@ -335,7 +362,7 @@ mod tests {
             let ring = ring.clone();
             tokio::spawn(async move {
                 tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-                ring.push("{\"event\":\"wake\"}".into());
+                ring.push("wake".into(), None, "{\"event\":\"wake\"}".into());
             })
         };
         tokio::time::timeout(std::time::Duration::from_secs(5), notified)

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -53,6 +53,7 @@ pub(crate) use intendant_core::error;
 pub(crate) use intendant_display as display;
 mod display_peer_ids;
 mod event;
+mod event_ring;
 mod external_agent;
 mod external_wrapper_index;
 mod file_watcher;

--- a/src/bin/caller/mcp/facade.rs
+++ b/src/bin/caller/mcp/facade.rs
@@ -630,7 +630,8 @@ pub(crate) const COMMANDS: &[CommandSpec] = &[
 ];
 
 /// The meta-tool names the facade serves.
-pub(crate) const FACADE_TOOLS: [&str; 5] = ["inspect", "act", "authorize", "help", "docs"];
+pub(crate) const FACADE_TOOLS: [&str; 6] =
+    ["inspect", "act", "authorize", "help", "docs", "events"];
 
 /// Params for the three executor meta-tools (`inspect`/`act`/`authorize`).
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -932,6 +933,10 @@ pub(crate) fn facade_gate_operation(name: &str, args: &serde_json::Value) -> Opt
         // The read-only meta surface: the command map and the embedded
         // skills corpus disclose less than get_status already does.
         "help" | "docs" => Some(PeerOperation::StatsRead),
+        // The event stream carries only session/approval/task lifecycle
+        // (the ring's ingest allowlist), i.e. what the session.inspect
+        // read tools already serve — push semantics, not new authority.
+        "events" => Some(PeerOperation::SessionInspect),
         "inspect" | "act" | "authorize" => Some(
             plan_for_meta(name, args)
                 .map(|planned| crate::mcp::mcp_tool_operation(planned.tool))
@@ -953,6 +958,7 @@ pub(crate) fn facade_tool_advertised(
 ) -> Option<bool> {
     match name {
         "help" | "docs" => Some(allowed(PeerOperation::StatsRead)),
+        "events" => Some(allowed(PeerOperation::SessionInspect)),
         "inspect" | "act" | "authorize" => Some(
             COMMANDS
                 .iter()
@@ -1332,6 +1338,7 @@ mod tests {
         };
         assert_eq!(facade_tool_advertised("help", read_only), Some(true));
         assert_eq!(facade_tool_advertised("docs", read_only), Some(true));
+        assert_eq!(facade_tool_advertised("events", read_only), Some(true));
         assert_eq!(facade_tool_advertised("inspect", read_only), Some(true));
         assert_eq!(facade_tool_advertised("act", read_only), Some(false));
         assert_eq!(facade_tool_advertised("authorize", read_only), Some(false));
@@ -1344,8 +1351,14 @@ mod tests {
             facade_tool_advertised("inspect", approvals_only),
             Some(false)
         );
+        assert_eq!(
+            facade_tool_advertised("events", approvals_only),
+            Some(false),
+            "events rides session.inspect, not the approval operation"
+        );
         let nothing = |_: Op| false;
         assert_eq!(facade_tool_advertised("help", nothing), Some(false));
+        assert_eq!(facade_tool_advertised("events", nothing), Some(false));
         assert_eq!(facade_tool_advertised("get_status", read_only), None);
     }
 

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -74,6 +74,7 @@ pub(crate) use tools_ask::{
 pub(crate) use tools_ask::unregister_pending_ask;
 mod tools_codex_cloud;
 mod tools_display;
+mod tools_events;
 mod tools_terminal;
 pub(crate) use tools_terminal::{
     TerminalCloseParams, TerminalOpenParams, TerminalReadParams, TerminalResizeParams,
@@ -676,6 +677,12 @@ impl IntendantServer {
             },
             "help" => Ok(text_tool_result(facade::render_help(&args))),
             "docs" => Ok(text_tool_result(facade::render_docs(&args))),
+            "events" => {
+                let Parameters(params) = parse_params::<tools_events::EventsParams>(args)?;
+                Ok(text_tool_result(
+                    self.events_tool(params, caller, &actor).await,
+                ))
+            }
             "get_status" => Ok(text_tool_result(
                 self.get_status_for_session(session_id, managed_context_override)
                     .await,

--- a/src/bin/caller/mcp/state.rs
+++ b/src/bin/caller/mcp/state.rs
@@ -148,6 +148,10 @@ pub struct McpAppState {
     /// `None` outside the gateway/daemon shapes (bare stdio servers) —
     /// terminal surfaces then answer "unavailable".
     pub terminal: Option<std::sync::Arc<crate::terminal::TerminalRegistry>>,
+    /// The daemon-wide event ring, for the `events` long-poll verb.
+    /// `None` outside the gateway/daemon shapes (bare stdio servers) —
+    /// the verb then answers "unavailable".
+    pub event_ring: Option<std::sync::Arc<crate::event_ring::EventRing>>,
     /// Directory for screenshot output.
     pub screenshot_dir: Option<std::path::PathBuf>,
     /// Persistent counter for screenshot filenames (avoids overwriting).
@@ -337,6 +341,7 @@ impl McpAppState {
             memory: None,
             handover: None,
             terminal: None,
+            event_ring: None,
             user_display_activation_pending: std::collections::HashMap::new(),
             display_capture_ready: HashSet::new(),
             screenshot_dir: None,

--- a/src/bin/caller/mcp/tool_gate.rs
+++ b/src/bin/caller/mcp/tool_gate.rs
@@ -231,7 +231,7 @@ pub(crate) enum ToolProfileFamily {
     Core,
     Screen,
     Managed,
-    /// The CLI-shaped meta-tool surface (`mcp/facade.rs`): five tools,
+    /// The CLI-shaped meta-tool surface (`mcp/facade.rs`): six tools,
     /// everything else discovered lazily through help/docs.
     Facade,
 }
@@ -297,7 +297,9 @@ pub(crate) fn mcp_tool_operation(name: &str) -> crate::peer::access_policy::Peer
         // guards a hypothetical ingress that skips gate-side resolution:
         // it falls to the restrictive default rather than anything
         // broader, and never authorizes the envelope as a whole.
-        "inspect" | "act" | "authorize" | "help" | "docs" => PeerOperation::RuntimeControl,
+        "inspect" | "act" | "authorize" | "help" | "docs" | "events" => {
+            PeerOperation::RuntimeControl
+        }
         // The terminal family (owner-ruled 2026-08-28: controlling agents
         // get terminal access, R2 tentatively at Operate). Reads ride
         // terminal.view; input/resize/close ride terminal.write; open is
@@ -581,6 +583,14 @@ fn build_manual_http_tool_definitions() -> Vec<serde_json::Value> {
             "docs",
             "The embedded Intendant operating skills: no argument lists them; a skill name returns its full text plus its support-file manifest; skill + file fetches one bundled support file (judgment and workflow guidance beyond command syntax).",
             crate::mcp::facade::FacadeDocsParams
+        ),
+    );
+    push(
+        "events",
+        manual_http_tool_definition!(
+            "events",
+            "Cursor long-poll over the daemon's session/approval/task lifecycle events. Omit since to start at now; pass wait_s (max 60) to block until something happens; re-poll with the returned next_cursor. gap=true means events were missed — resync via the read commands. filter is a comma-separated list of event names.",
+            crate::mcp::tools_events::EventsParams
         ),
     );
 

--- a/src/bin/caller/mcp/tools_events.rs
+++ b/src/bin/caller/mcp/tools_events.rs
@@ -12,16 +12,20 @@
 //!   fails loudly instead of silently reading wrong positions.
 //! - Cursors are PRINCIPAL-BOUND (the design-review amendment): the tag
 //!   commits to the acting principal, and a cursor minted under another
-//!   principal is refused. Visibility is uniform today (everything in
-//!   the ring is `session.inspect`-class), so the binding is
-//!   forward-compatibility for per-principal filtering, not a secrecy
-//!   boundary by itself.
+//!   principal is refused.
+//! - Delivery is SESSION-SCOPED for agent-session callers (security
+//!   review P1): a supervised backend using its session-bound MCP token
+//!   sees only its gate-bound session's events — the
+//!   `get_pending_approval_scoped` discipline — with sessionless events
+//!   failing closed; every other caller class keeps the daemon-wide
+//!   view its `session.inspect` grant already reads. Cursor positions
+//!   stay global (coarse volume metadata, not content).
 //! - `since` omitted = start at NOW: the first call returns the current
 //!   cursor (optionally waiting for the next event), never the
 //!   backlog.
 
 use super::*;
-use crate::event_ring::EventRing;
+use crate::event_ring::{EventRing, RingEntry};
 use std::sync::Arc;
 
 /// Long-poll ceiling — the `remote wait` chunk contract.
@@ -86,19 +90,37 @@ fn decode_cursor(cursor: &str) -> Option<(u64, u64, u64)> {
     Some((epoch, seq, tag))
 }
 
-/// Which delivered events a filter keeps. The `event_gap` loss marker
-/// is exempt: a filtering caller must still learn it missed events.
-fn passes_filter(json: &str, filter: &Option<Vec<String>>) -> bool {
+/// Which delivered events a name filter keeps. The `event_gap` loss
+/// marker is exempt: a filtering caller must still learn it missed
+/// events.
+fn passes_filter(entry: &RingEntry, filter: &Option<Vec<String>>) -> bool {
     let Some(names) = filter else {
         return true;
     };
-    let tag = serde_json::from_str::<serde_json::Value>(json)
-        .ok()
-        .and_then(|v| v.get("event").and_then(|e| e.as_str()).map(String::from));
-    match tag {
-        Some(tag) => tag == "event_gap" || names.iter().any(|n| n == &tag),
-        // An unparsable entry is delivered rather than silently eaten.
-        None => true,
+    entry.event == "event_gap" || names.iter().any(|n| n == &entry.event)
+}
+
+/// Session scoping at delivery (security review P1): an agent-session
+/// caller — a supervised backend using its session-bound MCP token —
+/// sees only its gate-bound session's events, mirroring
+/// `get_pending_approval_scoped`'s discipline; sessionless events fail
+/// closed for it, and a scope whose gate bound no id sees nothing.
+/// The synthetic `event_gap` loss marker is exempt — it carries no
+/// content beyond "events were missed", and a scoped caller must still
+/// learn its view lost events. Every other caller class keeps the
+/// daemon-wide view its `session.inspect` grant already reads.
+fn visible_to_scope(entry: &RingEntry, scope: &McpToolScope<'_>) -> bool {
+    match scope {
+        McpToolScope::Unrestricted => true,
+        McpToolScope::AgentSession { session_id } => {
+            if entry.event == "event_gap" {
+                return true;
+            }
+            match (entry.session_id.as_deref(), session_id) {
+                (Some(entry_session), Some(bound)) => entry_session == *bound,
+                _ => false,
+            }
+        }
     }
 }
 
@@ -173,6 +195,7 @@ impl IntendantServer {
             .clamp(1, EVENTS_PAGE_MAX);
         let wait_s = params.wait_s.unwrap_or(0).min(EVENTS_WAIT_MAX_S);
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(wait_s);
+        let scope = McpToolScope::from_actor(actor);
 
         let mut delivered: Vec<String> = Vec::new();
         let mut gap = false;
@@ -184,7 +207,7 @@ impl IntendantServer {
             gap |= gap_now;
             for entry in entries {
                 scan_seq = entry.seq;
-                if passes_filter(&entry.json, &filter) {
+                if visible_to_scope(&entry, &scope) && passes_filter(&entry, &filter) {
                     delivered.push(entry.json);
                 }
                 if delivered.len() >= max_events {
@@ -264,7 +287,7 @@ mod tests {
     #[test]
     fn cursor_validation_refuses_foreign_stale_and_future_cursors() {
         let ring = EventRing::new();
-        ring.push("{\"event\":\"a\"}".into());
+        ring.push("a".into(), None, "{\"event\":\"a\"}".into());
         let tag = 0x77;
         let ok = encode_cursor(ring.epoch(), 1, tag);
         assert_eq!(validate_cursor(&ok, &ring, tag), Ok(1));
@@ -292,9 +315,17 @@ mod tests {
         let state = crate::mcp::tests::test_state();
         let ring = Arc::new(EventRing::new());
         for i in 0..250 {
-            ring.push(format!("{{\"event\":\"session_started\",\"n\":{i}}}"));
+            ring.push(
+                "session_started".into(),
+                Some("sess-x".into()),
+                format!("{{\"event\":\"session_started\",\"n\":{i}}}"),
+            );
         }
-        ring.push("{\"event\":\"approval_required\",\"id\":9}".into());
+        ring.push(
+            "approval_required".into(),
+            Some("sess-x".into()),
+            "{\"event\":\"approval_required\",\"id\":9}".into(),
+        );
         state.write().await.event_ring = Some(ring.clone());
         let server = IntendantServer::new(state, crate::event::EventBus::new());
 
@@ -328,20 +359,120 @@ mod tests {
         );
     }
 
+    /// End-to-end session scoping through the tool (security review
+    /// P1): an agent-session caller polling the full stream receives
+    /// only its gate-bound session's events — another session's events
+    /// and sessionless approvals are withheld, while the cursor still
+    /// advances past them.
+    #[tokio::test]
+    async fn agent_session_callers_see_only_their_session_through_the_tool() {
+        let state = crate::mcp::tests::test_state();
+        let ring = Arc::new(EventRing::new());
+        ring.push(
+            "turn_started".into(),
+            Some("sess-a".into()),
+            "{\"event\":\"turn_started\",\"session_id\":\"sess-a\"}".into(),
+        );
+        ring.push(
+            "turn_started".into(),
+            Some("sess-b".into()),
+            "{\"event\":\"turn_started\",\"session_id\":\"sess-b\"}".into(),
+        );
+        ring.push(
+            "approval_required".into(),
+            None,
+            "{\"event\":\"approval_required\",\"id\":1}".into(),
+        );
+        state.write().await.event_ring = Some(ring.clone());
+        let server = IntendantServer::new(state, crate::event::EventBus::new());
+
+        let actor = crate::access::actor::ActorBinding::agent_session(
+            Some("principal:agent".into()),
+            "sess-a".into(),
+        );
+        let start = encode_cursor(
+            ring.epoch(),
+            0,
+            cursor_principal_tag(ToolCallerTrust::Scoped, &actor),
+        );
+        let result = server
+            .events_tool(
+                EventsParams {
+                    since: Some(start),
+                    wait_s: Some(0),
+                    filter: None,
+                    max_events: None,
+                },
+                ToolCallerTrust::Scoped,
+                &actor,
+            )
+            .await;
+        let parsed: serde_json::Value = serde_json::from_str(&result).expect("valid json");
+        assert_eq!(parsed["ok"], true, "{result}");
+        let events = parsed["events"].as_array().expect("events array");
+        assert_eq!(events.len(), 1, "{result}");
+        assert_eq!(events[0]["session_id"], "sess-a");
+        assert_eq!(
+            parsed["current_seq"].as_u64(),
+            Some(3),
+            "the cursor advances past withheld events"
+        );
+    }
+
+    fn entry(event: &str, session_id: Option<&str>) -> RingEntry {
+        RingEntry {
+            seq: 1,
+            event: event.to_string(),
+            session_id: session_id.map(String::from),
+            json: format!("{{\"event\":\"{event}\"}}"),
+        }
+    }
+
     /// The `event_gap` loss marker always passes a filter — a filtering
     /// caller must still learn it missed events.
     #[test]
     fn filters_keep_gap_markers_and_matching_names() {
         let filter = Some(vec!["approval_required".to_string()]);
-        assert!(passes_filter(
-            "{\"event\":\"approval_required\",\"id\":1}",
-            &filter
+        assert!(passes_filter(&entry("approval_required", None), &filter));
+        assert!(!passes_filter(&entry("session_started", None), &filter));
+        assert!(passes_filter(&entry("event_gap", None), &filter));
+        assert!(passes_filter(&entry("anything", None), &None));
+    }
+
+    /// Session scoping at delivery (security review P1): an
+    /// agent-session caller sees only its gate-bound session's events;
+    /// sessionless events fail closed, an unbound scope sees nothing,
+    /// the loss marker stays visible, and every other caller class
+    /// keeps the daemon-wide view.
+    #[test]
+    fn agent_session_scope_confines_delivery_to_the_bound_session() {
+        let mine = McpToolScope::AgentSession {
+            session_id: Some("sess-a"),
+        };
+        assert!(visible_to_scope(
+            &entry("turn_started", Some("sess-a")),
+            &mine
         ));
-        assert!(!passes_filter("{\"event\":\"session_started\"}", &filter));
-        assert!(passes_filter(
-            "{\"event\":\"event_gap\",\"skipped\":9}",
-            &filter
+        assert!(!visible_to_scope(
+            &entry("turn_started", Some("sess-b")),
+            &mine
         ));
-        assert!(passes_filter("{\"event\":\"anything\"}", &None));
+        assert!(
+            !visible_to_scope(&entry("approval_required", None), &mine),
+            "sessionless events fail closed for session-scoped callers"
+        );
+        assert!(
+            visible_to_scope(&entry("event_gap", None), &mine),
+            "the loss marker stays visible"
+        );
+        let unbound = McpToolScope::AgentSession { session_id: None };
+        assert!(
+            !visible_to_scope(&entry("turn_started", Some("sess-a")), &unbound),
+            "a scope whose gate bound no id sees nothing"
+        );
+        assert!(visible_to_scope(
+            &entry("turn_started", Some("sess-b")),
+            &McpToolScope::Unrestricted
+        ));
     }
 }

--- a/src/bin/caller/mcp/tools_events.rs
+++ b/src/bin/caller/mcp/tools_events.rs
@@ -1,0 +1,262 @@
+//! The `events` facade verb: a cursor-addressed long-poll over the
+//! daemon event ring (docs/design-mcp-control-lane.md, M2) — the
+//! transport-agnostic answer to "wait for something to happen" that
+//! `ctl` never had either. Push semantics only: the ring's ingest
+//! allowlist ([`crate::event_ring::app_event_rides_event_ring`]) keeps
+//! the stream to content the `session.inspect`-gated read tools already
+//! serve, so this verb can never widen what its operation reads.
+//!
+//! Cursor contract:
+//! - Opaque `"{epoch:x}.{seq}.{tag:x}"` strings. The epoch is the
+//!   ring's per-boot identity — a cursor from a previous daemon boot
+//!   fails loudly instead of silently reading wrong positions.
+//! - Cursors are PRINCIPAL-BOUND (the design-review amendment): the tag
+//!   commits to the acting principal, and a cursor minted under another
+//!   principal is refused. Visibility is uniform today (everything in
+//!   the ring is `session.inspect`-class), so the binding is
+//!   forward-compatibility for per-principal filtering, not a secrecy
+//!   boundary by itself.
+//! - `since` omitted = start at NOW: the first call returns the current
+//!   cursor (optionally waiting for the next event), never the
+//!   backlog.
+
+use super::*;
+use crate::event_ring::EventRing;
+use std::sync::Arc;
+
+/// Long-poll ceiling — the `remote wait` chunk contract.
+const EVENTS_WAIT_MAX_S: u64 = 60;
+const EVENTS_PAGE_DEFAULT: usize = 100;
+const EVENTS_PAGE_MAX: usize = 500;
+
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
+pub struct EventsParams {
+    /// Cursor from a previous response's `next_cursor`. Omit to start
+    /// at NOW (no backlog replay).
+    #[serde(default)]
+    pub since: Option<String>,
+    /// Seconds to wait for an event when nothing is newer than the
+    /// cursor (default 0 = return immediately; clamp 0–60). Chunk
+    /// longer waits client-side and re-poll with the returned cursor.
+    #[serde(default)]
+    pub wait_s: Option<u64>,
+    /// Comma-separated event names to keep (e.g.
+    /// "approval_required,session_ended"). Omit for all. The synthetic
+    /// `event_gap` loss marker always passes the filter.
+    #[serde(default)]
+    pub filter: Option<String>,
+    /// Max events per page (default 100, cap 500).
+    #[serde(default)]
+    pub max_events: Option<usize>,
+}
+
+/// The principal half of a cursor: root surfaces share one tag; every
+/// scoped caller commits to its bound principal id (the unattributed
+/// fallback included — same fail-closed identity the terminal actor
+/// derivation uses).
+fn cursor_principal_tag(trust: ToolCallerTrust, actor: &crate::access::actor::ActorBinding) -> u64 {
+    use std::hash::{Hash, Hasher};
+    // DefaultHasher::new() is fixed-key SipHash — stable for the life
+    // of the boot, which is exactly a cursor's validity (the epoch
+    // already invalidates cursors across restarts).
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    match trust {
+        ToolCallerTrust::OwnerSurface => "root".hash(&mut hasher),
+        ToolCallerTrust::Scoped => actor
+            .principal_id
+            .as_deref()
+            .unwrap_or("principal:unattributed")
+            .hash(&mut hasher),
+    }
+    hasher.finish()
+}
+
+fn encode_cursor(epoch: u64, seq: u64, tag: u64) -> String {
+    format!("{epoch:x}.{seq}.{tag:x}")
+}
+
+fn decode_cursor(cursor: &str) -> Option<(u64, u64, u64)> {
+    let mut parts = cursor.split('.');
+    let epoch = u64::from_str_radix(parts.next()?, 16).ok()?;
+    let seq = parts.next()?.parse::<u64>().ok()?;
+    let tag = u64::from_str_radix(parts.next()?, 16).ok()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((epoch, seq, tag))
+}
+
+/// Which delivered events a filter keeps. The `event_gap` loss marker
+/// is exempt: a filtering caller must still learn it missed events.
+fn passes_filter(json: &str, filter: &Option<Vec<String>>) -> bool {
+    let Some(names) = filter else {
+        return true;
+    };
+    let tag = serde_json::from_str::<serde_json::Value>(json)
+        .ok()
+        .and_then(|v| v.get("event").and_then(|e| e.as_str()).map(String::from));
+    match tag {
+        Some(tag) => tag == "event_gap" || names.iter().any(|n| n == &tag),
+        // An unparsable entry is delivered rather than silently eaten.
+        None => true,
+    }
+}
+
+fn events_error(message: &str) -> String {
+    serde_json::json!({ "ok": false, "error": message }).to_string()
+}
+
+impl IntendantServer {
+    pub(crate) async fn events_tool(
+        &self,
+        params: EventsParams,
+        trust: ToolCallerTrust,
+        actor: &crate::access::actor::ActorBinding,
+    ) -> String {
+        let ring: Option<Arc<EventRing>> = self.state.read().await.event_ring.clone();
+        let Some(ring) = ring else {
+            return events_error(
+                "event stream unavailable on this server shape (bare stdio --mcp has no daemon event ring)",
+            );
+        };
+        let tag = cursor_principal_tag(trust, actor);
+        let mut scan_seq = match params
+            .since
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            None => ring.current_seq(),
+            Some(cursor) => {
+                let Some((epoch, seq, cursor_tag)) = decode_cursor(cursor) else {
+                    return events_error(
+                        "invalid cursor — omit `since` to start at now and mint a fresh one",
+                    );
+                };
+                if epoch != ring.epoch() {
+                    return events_error(
+                        "cursor is from a previous daemon boot — the stream restarted; omit `since`, resync state via the read commands, and continue from the fresh cursor",
+                    );
+                }
+                if cursor_tag != tag {
+                    // Principal-bound (design-review amendment): a cursor
+                    // minted under another principal is refused.
+                    return events_error(
+                        "cursor was minted for a different principal — omit `since` to mint your own",
+                    );
+                }
+                seq
+            }
+        };
+        let filter = params.filter.as_deref().map(|f| {
+            f.split(',')
+                .map(|n| n.trim().to_string())
+                .filter(|n| !n.is_empty())
+                .collect::<Vec<_>>()
+        });
+        let max_events = params
+            .max_events
+            .unwrap_or(EVENTS_PAGE_DEFAULT)
+            .clamp(1, EVENTS_PAGE_MAX);
+        let wait_s = params.wait_s.unwrap_or(0).min(EVENTS_WAIT_MAX_S);
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(wait_s);
+
+        let mut delivered: Vec<String> = Vec::new();
+        let mut gap = false;
+        loop {
+            // Notify discipline: arm the wakeup BEFORE reading, so a
+            // push between the read and the await cannot be missed.
+            let notified = ring.notified();
+            let (entries, gap_now) = ring.since(scan_seq, max_events);
+            gap |= gap_now;
+            for entry in entries {
+                scan_seq = entry.seq;
+                if passes_filter(&entry.json, &filter) {
+                    delivered.push(entry.json);
+                }
+                if delivered.len() >= max_events {
+                    break;
+                }
+            }
+            // Return on the first delivered batch (long-poll contract),
+            // on a gap (the caller must resync), or at the deadline.
+            if !delivered.is_empty() || gap || tokio::time::Instant::now() >= deadline {
+                break;
+            }
+            if tokio::time::timeout_at(deadline, notified).await.is_err() {
+                // Lapse: fall through to one final read — an event
+                // recorded moments ago is delivered instead of being
+                // reported as a quiet timeout (the ask-tool ledger
+                // discipline).
+                let (entries, gap_now) = ring.since(scan_seq, max_events);
+                gap |= gap_now;
+                for entry in entries {
+                    scan_seq = entry.seq;
+                    if passes_filter(&entry.json, &filter) {
+                        delivered.push(entry.json);
+                    }
+                    if delivered.len() >= max_events {
+                        break;
+                    }
+                }
+                break;
+            }
+        }
+
+        let events_json = delivered.join(",");
+        format!(
+            "{{\"ok\":true,\"events\":[{events_json}],\"next_cursor\":{next_cursor},\"current_seq\":{current_seq},\"gap\":{gap}}}",
+            next_cursor =
+                serde_json::json!(encode_cursor(ring.epoch(), scan_seq, tag)),
+            current_seq = ring.current_seq(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cursors_round_trip_and_reject_malformed() {
+        let cursor = encode_cursor(0xabc, 42, 0xdef);
+        assert_eq!(decode_cursor(&cursor), Some((0xabc, 42, 0xdef)));
+        for bad in ["", "1.2", "x.2.3", "1.y.3", "1.2.z", "1.2.3.4"] {
+            assert_eq!(decode_cursor(bad), None, "{bad:?} must be refused");
+        }
+    }
+
+    /// Cursors are principal-bound: root surfaces share one tag, each
+    /// scoped principal gets its own, and the unattributed fallback is
+    /// its own identity rather than colliding with root.
+    #[test]
+    fn principal_tags_separate_root_and_principals() {
+        let unattributed = crate::access::actor::ActorBinding::unattributed();
+        let root = cursor_principal_tag(ToolCallerTrust::OwnerSurface, &unattributed);
+        let scoped_unattributed = cursor_principal_tag(ToolCallerTrust::Scoped, &unattributed);
+        assert_ne!(root, scoped_unattributed);
+        // The tag is deterministic within a boot — the same caller can
+        // reuse its cursor across calls.
+        assert_eq!(
+            root,
+            cursor_principal_tag(ToolCallerTrust::OwnerSurface, &unattributed)
+        );
+    }
+
+    /// The `event_gap` loss marker always passes a filter — a filtering
+    /// caller must still learn it missed events.
+    #[test]
+    fn filters_keep_gap_markers_and_matching_names() {
+        let filter = Some(vec!["approval_required".to_string()]);
+        assert!(passes_filter(
+            "{\"event\":\"approval_required\",\"id\":1}",
+            &filter
+        ));
+        assert!(!passes_filter("{\"event\":\"session_started\"}", &filter));
+        assert!(passes_filter(
+            "{\"event\":\"event_gap\",\"skipped\":9}",
+            &filter
+        ));
+        assert!(passes_filter("{\"event\":\"anything\"}", &None));
+    }
+}

--- a/src/bin/caller/mcp/tools_events.rs
+++ b/src/bin/caller/mcp/tools_events.rs
@@ -106,6 +106,35 @@ fn events_error(message: &str) -> String {
     serde_json::json!({ "ok": false, "error": message }).to_string()
 }
 
+/// Decode and validate a caller cursor against the live ring: shape,
+/// boot epoch, principal binding, and position. The position check
+/// matters twice over — a forged future sequence would otherwise park
+/// the poll until the counter catches up, and it must never reach the
+/// ring's arithmetic at all (review P2).
+fn validate_cursor(cursor: &str, ring: &EventRing, expected_tag: u64) -> Result<u64, &'static str> {
+    let Some((epoch, seq, tag)) = decode_cursor(cursor) else {
+        return Err("invalid cursor — omit `since` to start at now and mint a fresh one");
+    };
+    if epoch != ring.epoch() {
+        return Err(
+            "cursor is from a previous daemon boot — the stream restarted; omit `since`, resync state via the read commands, and continue from the fresh cursor",
+        );
+    }
+    if tag != expected_tag {
+        // Principal-bound (design-review amendment): a cursor minted
+        // under another principal is refused.
+        return Err("cursor was minted for a different principal — omit `since` to mint your own");
+    }
+    if seq > ring.current_seq() {
+        // Real cursors are minted from the monotonic counter, so a
+        // position ahead of it was never minted by this ring.
+        return Err(
+            "cursor is ahead of the stream — it was not minted by this ring; omit `since` to start at now",
+        );
+    }
+    Ok(seq)
+}
+
 impl IntendantServer {
     pub(crate) async fn events_tool(
         &self,
@@ -127,26 +156,10 @@ impl IntendantServer {
             .filter(|s| !s.is_empty())
         {
             None => ring.current_seq(),
-            Some(cursor) => {
-                let Some((epoch, seq, cursor_tag)) = decode_cursor(cursor) else {
-                    return events_error(
-                        "invalid cursor — omit `since` to start at now and mint a fresh one",
-                    );
-                };
-                if epoch != ring.epoch() {
-                    return events_error(
-                        "cursor is from a previous daemon boot — the stream restarted; omit `since`, resync state via the read commands, and continue from the fresh cursor",
-                    );
-                }
-                if cursor_tag != tag {
-                    // Principal-bound (design-review amendment): a cursor
-                    // minted under another principal is refused.
-                    return events_error(
-                        "cursor was minted for a different principal — omit `since` to mint your own",
-                    );
-                }
-                seq
-            }
+            Some(cursor) => match validate_cursor(cursor, &ring, tag) {
+                Ok(seq) => seq,
+                Err(message) => return events_error(message),
+            },
         };
         let filter = params.filter.as_deref().map(|f| {
             f.split(',')
@@ -178,29 +191,31 @@ impl IntendantServer {
                     break;
                 }
             }
-            // Return on the first delivered batch (long-poll contract),
-            // on a gap (the caller must resync), or at the deadline.
-            if !delivered.is_empty() || gap || tokio::time::Instant::now() >= deadline {
+            // Return on the first delivered batch (long-poll contract)
+            // or on a gap (the caller must resync).
+            if !delivered.is_empty() || gap {
+                break;
+            }
+            // A filter can reject a whole raw page while a match sits
+            // further along the buffered window — and nothing already
+            // buffered will ever fire the notify. Drain to the ring's
+            // head before considering any wait (review P2); the window
+            // is bounded, so this is at most a few pages.
+            if scan_seq < ring.current_seq() {
+                continue;
+            }
+            if tokio::time::Instant::now() >= deadline {
                 break;
             }
             if tokio::time::timeout_at(deadline, notified).await.is_err() {
-                // Lapse: fall through to one final read — an event
+                // Lapse: loop once more for a final read — an event
                 // recorded moments ago is delivered instead of being
                 // reported as a quiet timeout (the ask-tool ledger
-                // discipline).
-                let (entries, gap_now) = ring.since(scan_seq, max_events);
-                gap |= gap_now;
-                for entry in entries {
-                    scan_seq = entry.seq;
-                    if passes_filter(&entry.json, &filter) {
-                        delivered.push(entry.json);
-                    }
-                    if delivered.len() >= max_events {
-                        break;
-                    }
-                }
-                break;
+                // discipline); the deadline check above ends the loop
+                // right after it.
+                continue;
             }
+            // Woken: loop back and read from the advanced cursor.
         }
 
         let events_json = delivered.join(",");
@@ -240,6 +255,76 @@ mod tests {
         assert_eq!(
             root,
             cursor_principal_tag(ToolCallerTrust::OwnerSurface, &unattributed)
+        );
+    }
+
+    /// Every refusal branch of cursor validation, including the forged
+    /// future position (review P2 — it would park the poll and, worse,
+    /// must never reach the ring's arithmetic).
+    #[test]
+    fn cursor_validation_refuses_foreign_stale_and_future_cursors() {
+        let ring = EventRing::new();
+        ring.push("{\"event\":\"a\"}".into());
+        let tag = 0x77;
+        let ok = encode_cursor(ring.epoch(), 1, tag);
+        assert_eq!(validate_cursor(&ok, &ring, tag), Ok(1));
+        assert!(validate_cursor("garbage", &ring, tag).is_err());
+        let wrong_epoch = encode_cursor(ring.epoch().wrapping_add(1), 1, tag);
+        assert!(validate_cursor(&wrong_epoch, &ring, tag)
+            .unwrap_err()
+            .contains("previous daemon boot"));
+        let wrong_principal = encode_cursor(ring.epoch(), 1, tag + 1);
+        assert!(validate_cursor(&wrong_principal, &ring, tag)
+            .unwrap_err()
+            .contains("different principal"));
+        let future = encode_cursor(ring.epoch(), u64::MAX, tag);
+        assert!(validate_cursor(&future, &ring, tag)
+            .unwrap_err()
+            .contains("ahead of the stream"));
+    }
+
+    /// A filter that rejects whole raw pages must not park the poll
+    /// while a match already sits further along the buffered window
+    /// (review P2): with wait_s=0 the scan drains to the ring's head
+    /// and returns the buried match immediately.
+    #[tokio::test]
+    async fn filtered_polls_drain_the_buffered_window() {
+        let state = crate::mcp::tests::test_state();
+        let ring = Arc::new(EventRing::new());
+        for i in 0..250 {
+            ring.push(format!("{{\"event\":\"session_started\",\"n\":{i}}}"));
+        }
+        ring.push("{\"event\":\"approval_required\",\"id\":9}".into());
+        state.write().await.event_ring = Some(ring.clone());
+        let server = IntendantServer::new(state, crate::event::EventBus::new());
+
+        let unattributed = crate::access::actor::ActorBinding::unattributed();
+        let start = encode_cursor(
+            ring.epoch(),
+            0,
+            cursor_principal_tag(ToolCallerTrust::OwnerSurface, &unattributed),
+        );
+        let result = server
+            .events_tool(
+                EventsParams {
+                    since: Some(start),
+                    wait_s: Some(0),
+                    filter: Some("approval_required".into()),
+                    max_events: Some(10),
+                },
+                ToolCallerTrust::OwnerSurface,
+                &unattributed,
+            )
+            .await;
+        let parsed: serde_json::Value = serde_json::from_str(&result).expect("valid json");
+        assert_eq!(parsed["ok"], true, "{result}");
+        let events = parsed["events"].as_array().expect("events array");
+        assert_eq!(events.len(), 1, "{result}");
+        assert_eq!(events[0]["event"], "approval_required");
+        assert_eq!(
+            parsed["current_seq"].as_u64(),
+            Some(251),
+            "cursor drained to the head"
         );
     }
 

--- a/src/bin/caller/startup/daemon.rs
+++ b/src/bin/caller/startup/daemon.rs
@@ -60,7 +60,7 @@ pub(crate) async fn run_daemon(
     // runs — the daemon's `/mcp` gateway surface observes state through
     // `spawn_http_observation_listener`, which ignores Tick. A 1 Hz tick
     // would only wake every bus subscriber for nothing.
-    let _session_listeners = startup::wiring::spawn_session_listeners(
+    let session_listeners = startup::wiring::spawn_session_listeners(
         &bus,
         &recording_registry,
         &session_registry,
@@ -118,6 +118,7 @@ pub(crate) async fn run_daemon(
         outbound_tx.clone(),
         None, // query_ctx: the daemon serves supervised sessions, not one live agent
         None, // active_session_log: supervised children register their own logs
+        Some(session_listeners.event_ring.clone()),
     )?;
     let shared_session = gateway.shared_session.clone();
     eprintln!("{}", gateway.log_line);

--- a/src/bin/caller/startup/headless.rs
+++ b/src/bin/caller/startup/headless.rs
@@ -41,7 +41,7 @@ pub(crate) async fn run_headless_mode(
     let task = task.unwrap();
 
     let bus = EventBus::new();
-    let _session_listeners = startup::wiring::spawn_session_listeners(
+    let session_listeners = startup::wiring::spawn_session_listeners(
         &bus,
         &recording_registry,
         &session_registry,
@@ -443,6 +443,7 @@ pub(crate) async fn run_headless_mode(
             outbound_tx.clone(),
             query_ctx,
             Some(session_log.clone()),
+            Some(session_listeners.event_ring.clone()),
         )?;
         eprintln!("{}", gateway.log_line);
         headless_peer_registry = Some(gateway.peer_registry.clone());

--- a/src/bin/caller/startup/mcp_mode.rs
+++ b/src/bin/caller/startup/mcp_mode.rs
@@ -42,7 +42,7 @@ pub(crate) async fn run_mcp_mode(
     let _human_monitor =
         event::spawn_human_question_monitor(bus.clone(), human_question_path.clone());
     let _tick_handle = event::spawn_tick_timer(bus.clone(), 1000);
-    let _session_listeners = startup::wiring::spawn_session_listeners(
+    let session_listeners = startup::wiring::spawn_session_listeners(
         &bus,
         &recording_registry,
         &session_registry,
@@ -119,6 +119,7 @@ pub(crate) async fn run_mcp_mode(
             outbound_tx.clone(),
             None, // query_ctx: MCP mode has no dashboard agent-state queries
             Some(session_log.clone()),
+            Some(session_listeners.event_ring.clone()),
         )?;
         slog(&session_log, |l| l.info(&gateway.log_line));
         eprintln!("{}", gateway.log_line);

--- a/src/bin/caller/startup/wiring.rs
+++ b/src/bin/caller/startup/wiring.rs
@@ -26,14 +26,18 @@
 use crate::*;
 
 /// Handles for the session listeners every mode spawns first:
-/// the recording listener, the user-display grant/revoke listener, and
-/// the session-list cache invalidator.
+/// the recording listener, the user-display grant/revoke listener, the
+/// session-list cache invalidator, and the daemon event ring's bus fold
+/// (plus the ring itself, handed to the MCP state for the `events`
+/// long-poll verb).
 /// tokio tasks detach on drop; the struct mirrors the original
 /// keep-until-scope-end bindings.
 pub(crate) struct SessionListeners {
     pub(crate) _recording_listener: tokio::task::JoinHandle<()>,
     pub(crate) _user_display_listener: tokio::task::JoinHandle<()>,
     pub(crate) _session_list_cache_invalidator: tokio::task::JoinHandle<()>,
+    pub(crate) _event_ring_fold: tokio::task::JoinHandle<()>,
+    pub(crate) event_ring: Arc<crate::event_ring::EventRing>,
 }
 
 pub(crate) fn spawn_session_listeners(
@@ -54,10 +58,13 @@ pub(crate) fn spawn_session_listeners(
         Some(frame_registry.clone()),
     );
     let _session_list_cache_invalidator = spawn_session_list_cache_invalidator(bus.subscribe());
+    let (event_ring, _event_ring_fold) = crate::event_ring::start_event_ring(bus);
     SessionListeners {
         _recording_listener,
         _user_display_listener,
         _session_list_cache_invalidator,
+        _event_ring_fold,
+        event_ring,
     }
 }
 
@@ -250,6 +257,9 @@ pub(crate) fn spawn_mode_web_gateway(
     broadcast_tx: tokio::sync::broadcast::Sender<String>,
     query_ctx: Option<web_gateway::WebQueryCtx>,
     active_session_log: Option<SharedSessionLog>,
+    // The daemon event ring from this mode's `SessionListeners`, wired
+    // into the MCP state for the `events` long-poll verb.
+    event_ring: Option<Arc<crate::event_ring::EventRing>>,
 ) -> Result<GatewaySpawn, CallerError> {
     let mut config = web_gateway::build_config(
         project.config.presence.live_provider.as_deref(),
@@ -314,6 +324,7 @@ pub(crate) fn spawn_mode_web_gateway(
     mcp_http_state.frame_registry = Some(frame_registry.clone());
     mcp_http_state.session_registry = Some(session_registry.clone());
     mcp_http_state.peer_registry = Some(peer_registry.clone());
+    mcp_http_state.event_ring = event_ring;
     mcp_http_state.screenshot_dir = Some(log_dir.join("screenshots"));
     // The gateway shape always has an answerable frontend: a dashboard can
     // attach while an `ask_user` blocks, so asks wait instead of


### PR DESCRIPTION
M2 of the MCP control lane (docs/design-mcp-control-lane.md): an
MCP-only agent can now WAIT for things to happen instead of polling N
read commands — the transport-agnostic answer to follow/attach that ctl
never had either.

The daemon-wide event ring (event_ring.rs) is a bounded (1024 entries /
2 MiB, drop-oldest) cursor-addressed window fed once per process from
the bus broadcast lane, next to the other mode-independent bus folds.
Its ingest allowlist is the security boundary: only the session,
approval, and task lifecycle families ride — exactly the content the
session.inspect-gated read tools already serve — so the verb is push
semantics over existing authority, never new authority. The streaming
floods (model deltas, agent output, context snapshots) and the families
gated by other operations (agenda, memory, display, credential,
presence) are never ingested. Loss is visible twice over: a lagged bus
receiver records a synthetic event_gap entry, and a cursor that fell
off the window reports gap: true.

The events tool (sixth facade meta-tool, session.inspect at the gate
and in advertisement) long-polls with the remote-wait chunk contract:
wait_s clamps to 60, the Notify wakeup is armed before each read so a
push cannot be missed, and a lapsed wait does one final read before
reporting quiet (the ask-tool ledger discipline). Cursors are opaque
"{epoch}.{seq}.{tag}" strings: the epoch is the ring's per-boot
identity, so a cursor from a previous boot fails loudly instead of
silently reading wrong positions, and the tag binds the cursor to the
minting principal (the design-review amendment) — a cursor minted under
another principal is refused. since omitted starts at NOW (no backlog
replay); filter keeps named events but never suppresses the event_gap
marker.

The ring travels SessionListeners → spawn_mode_web_gateway → McpState;
bare stdio --mcp has no ring and the verb answers unavailable there
(stdio convergence is a separate open question).
