### PR TITLE
mcp: per-request SSE for held-POST verbs (M2c)

### DIFF
--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -2277,7 +2277,7 @@ response omits the header.
 | POST | `/api/peers/{peer_id}/dashboard-control-webrtc` | federation (per method/path) | own origin | bounded | Relay dashboard-control WebRTC signaling to a connected peer |
 | any | `/api/peers[/…]` | federation (per method/path) | own origin | bounded | Peers sub-router catch-all (handler-owned JSON 404/405 for unknown subpaths and undeclared methods) |
 | POST | `/api/coordinator/route` | federation (per method/path) | own origin | bounded | Capability-based task routing through the Coordinator |
-| POST | `/mcp` | MCP token | own origin | ≤ 16 MiB | MCP Streamable HTTP endpoint (JSON-RPC requests + notifications) |
+| POST | `/mcp` | MCP token | own origin | ≤ 16 MiB | MCP Streamable HTTP endpoint (JSON-RPC requests + notifications; held-POST verbs answer as per-request SSE when accepted) |
 | GET | `/mcp` | MCP token | own origin | none | MCP SSE stream (405: stateless server) |
 | DELETE | `/mcp` | MCP token | own origin | none | MCP session delete (405: stateless server) |
 <!-- gateway-route-table:end -->

--- a/src/bin/caller/gateway_routes.rs
+++ b/src/bin/caller/gateway_routes.rs
@@ -2967,7 +2967,7 @@ pub(crate) static ROUTES: &[Route] = &[
         cors: CorsPosture::OwnOrigin,
         body: BodyPolicy::Capped(MCP_BODY_CAP_BYTES),
         handler: RouteHandlerId::McpPost,
-        doc: "MCP Streamable HTTP endpoint (JSON-RPC requests + notifications)",
+        doc: "MCP Streamable HTTP endpoint (JSON-RPC requests + notifications; held-POST verbs answer as per-request SSE when accepted)",
         tunnel: None,
     },
     Route {

--- a/src/bin/caller/mcp/facade.rs
+++ b/src/bin/caller/mcp/facade.rs
@@ -1377,6 +1377,20 @@ pub(crate) fn plan_for_meta(meta: &str, args: &serde_json::Value) -> Result<Plan
     })
 }
 
+/// The underlying tool an executor call resolves to, if it resolves —
+/// argv-only, values never parsed (the [`resolve_meta_argv`]
+/// discipline), so a transport may consult it pre-dispatch (per-request
+/// SSE mode selection) at the same cost class as the gate. `None`: not
+/// an executor call, or its path does not resolve.
+pub(crate) fn facade_resolved_tool(name: &str, args: &serde_json::Value) -> Option<&'static str> {
+    match name {
+        "inspect" | "act" | "authorize" => resolve_meta_argv(name, args)
+            .ok()
+            .map(|(_, spec)| spec.tool),
+        _ => None,
+    }
+}
+
 /// The gate-side authorization resolver. `None`: not a facade tool (fall
 /// through to the fixed per-tool map). `Some(op)`: authorize this
 /// operation, then dispatch. Resolution here NEVER builds arguments

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -50,7 +50,7 @@ mod state;
 pub(crate) use state::*;
 mod facade;
 mod tool_gate;
-pub(crate) use facade::{facade_gate_operation, facade_tool_advertised};
+pub(crate) use facade::{facade_gate_operation, facade_resolved_tool, facade_tool_advertised};
 pub(crate) use tool_gate::*;
 mod tool_params;
 pub(crate) use tool_params::*;

--- a/src/bin/caller/mcp/tool_gate.rs
+++ b/src/bin/caller/mcp/tool_gate.rs
@@ -76,23 +76,30 @@ pub(crate) fn fission_tool(name: &str) -> bool {
 /// - `execute_cu_actions` — a caller-supplied action list sleeps its
 ///   `wait`/`hold_key` millisecond durations verbatim
 ///   (`computer_use.rs`), so a sequence legitimately outlives the
-///   window.
+///   window (the 60 s cloud CU round trip also rides inside it).
 /// - `peer_execute_cu_actions` — the same caller-paced actions run on
 ///   a federated peer, bounded only by `PEER_MCP_TIMEOUT` (120 s).
+/// - `events` — the long-poll chunk may sit the full
+///   `EVENTS_WAIT_MAX_S` (60 s) on a quiet stream.
+/// - `remote_command` — `op=wait` chunks clamp to the same full
+///   window (`ctl::remote`'s 1–60 s chunk contract).
 ///
-/// Deliberately not held — quick by design, with caps at or under the
-/// window: the `events` long-poll (`EVENTS_WAIT_MAX_S` = 60, pinned by
-/// the test below), the cloud CU round trip (60 s), and the codex
-/// thread-action waits (20 s). The remaining peer round trips share
-/// `PEER_MCP_TIMEOUT` as a transport bound, but they are sub-second
-/// lookups — a cap is a bound, not a hold (the `events` reading).
-pub(crate) const MCP_HELD_POST_TOOLS: [&str; 6] = [
+/// A wait capped AT the window is held, not exempt: the full wait
+/// plus gate/dispatch overhead exceeds the idle window it equals, so
+/// the first response byte loses the race on a quiet chunk.
+/// Deliberately not held — quick by design with real margin: the
+/// codex thread-action waits (20 s) and the remaining peer round
+/// trips (sub-second lookups under `PEER_MCP_TIMEOUT`'s transport
+/// bound — a bound is not a hold).
+pub(crate) const MCP_HELD_POST_TOOLS: [&str; 8] = [
     "ask_user",
     "request_user_display",
     "spawn_live_audio",
     "fission_control",
     "execute_cu_actions",
     "peer_execute_cu_actions",
+    "events",
+    "remote_command",
 ];
 
 pub(crate) fn mcp_held_post_tool(name: &str) -> bool {
@@ -1885,21 +1892,15 @@ mod tests {
         });
     }
 
-    /// The held-POST classification tracks the real tool surface: every
-    /// held name is an advertised router tool, so a rename breaks here
-    /// instead of silently downgrading the verb to the plain JSON
-    /// answer that dies at the idle timeout; and the `events` long-poll
-    /// — deliberately excluded — stays at or under the window the
-    /// exclusion assumed, so raising its cap forces reclassification.
+    /// The held-POST classification tracks the real tool surface:
+    /// every held name must resolve to a live dispatch arm, so a
+    /// rename breaks here instead of silently downgrading the verb to
+    /// the plain JSON answer that dies at the idle timeout.
     #[test]
     fn held_post_classification_tracks_the_tool_surface() {
         use crate::event::EventBus;
         use crate::mcp::tests::{test_server, test_state};
 
-        assert!(
-            crate::mcp::tools_events::EVENTS_WAIT_MAX_S <= 60,
-            "the events long-poll cap crossed the held-POST window: move `events` into MCP_HELD_POST_TOOLS"
-        );
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()

--- a/src/bin/caller/mcp/tool_gate.rs
+++ b/src/bin/caller/mcp/tool_gate.rs
@@ -55,6 +55,40 @@ pub(crate) fn fission_tool(name: &str) -> bool {
     )
 }
 
+/// The held-POST verbs: tools whose handlers can hold one `tools/call`
+/// past a ~60 s client/proxy idle window because they block on a human
+/// or on a long timer. The HTTP transport answers these as per-request
+/// SSE when the caller accepts it (`web_gateway::mcp_gate`); every
+/// other tool answers as plain JSON. The classification lives here,
+/// beside the other per-tool classifications, so a new held verb is
+/// declared once instead of mirrored into the gateway.
+///
+/// - `ask_user` — waits up to `ASK_USER_MAX_WAIT_SECS` (900 s) on the
+///   human's answer.
+/// - `request_user_display` — waits on the display-grant decision
+///   (caller-set `wait_secs`).
+/// - `spawn_live_audio` — always-consent gate
+///   (`live_audio::SPAWN_CONSENT_WAIT`, 300 s), then the voice
+///   conversation runs to its own completion.
+/// - `fission_control` — `op=wait` blocks up to 300 s
+///   (`clamp_fission_wait_timeout_s`); the quick ops answer in one
+///   frame, which the stream carries just as well.
+///
+/// Deliberately not held — capped at or under the window: the `events`
+/// long-poll (`EVENTS_WAIT_MAX_S` = 60, pinned by the test below), the
+/// cloud CU round trip (60 s), and the codex thread-action waits
+/// (20 s).
+pub(crate) const MCP_HELD_POST_TOOLS: [&str; 4] = [
+    "ask_user",
+    "request_user_display",
+    "spawn_live_audio",
+    "fission_control",
+];
+
+pub(crate) fn mcp_held_post_tool(name: &str) -> bool {
+    MCP_HELD_POST_TOOLS.contains(&name)
+}
+
 pub(crate) fn with_default_mcp_session_id(
     mut args: serde_json::Value,
     session_id: Option<&str>,
@@ -1836,6 +1870,58 @@ mod tests {
                     "router tool `{}` must declare a `\"type\": \"object\"` schema root \
                      — the stdio transport serves it verbatim",
                     tool.name
+                );
+            }
+        });
+    }
+
+    /// The held-POST classification tracks the real tool surface: every
+    /// held name is an advertised router tool, so a rename breaks here
+    /// instead of silently downgrading the verb to the plain JSON
+    /// answer that dies at the idle timeout; and the `events` long-poll
+    /// — deliberately excluded — stays at or under the window the
+    /// exclusion assumed, so raising its cap forces reclassification.
+    #[test]
+    fn held_post_classification_tracks_the_tool_surface() {
+        use crate::event::EventBus;
+        use crate::mcp::tests::{test_server, test_state};
+
+        assert!(
+            crate::mcp::tools_events::EVENTS_WAIT_MAX_S <= 60,
+            "the events long-poll cap crossed the held-POST window: move `events` into MCP_HELD_POST_TOOLS"
+        );
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let (_home, server) = test_server(test_state(), EventBus::new());
+            // Hidden-but-callable is a real category (`spawn_live_audio`
+            // and `fission_control` have dispatch arms but no listing),
+            // so no listing can be the universe: run each held name
+            // through the real dispatch with unparseable args instead. A
+            // live arm fails fast on its typed params; only a renamed or
+            // removed tool produces the unknown-tool fall-through.
+            let control = server
+                .call_tool_by_name_for_session(
+                    "definitely_not_a_tool",
+                    serde_json::json!([]),
+                    None,
+                    None,
+                )
+                .await
+                .expect_err("the unknown-tool probe must refuse");
+            assert!(
+                control.contains("Unknown tool"),
+                "the dispatch fall-through moved — reanchor this pin: {control}"
+            );
+            for held in MCP_HELD_POST_TOOLS {
+                let outcome = server
+                    .call_tool_by_name_for_session(held, serde_json::json!([]), None, None)
+                    .await;
+                assert!(
+                    !matches!(&outcome, Err(error) if error.contains("Unknown tool")),
+                    "held-POST tool `{held}` has no dispatch arm (renamed?)"
                 );
             }
         });

--- a/src/bin/caller/mcp/tool_gate.rs
+++ b/src/bin/caller/mcp/tool_gate.rs
@@ -73,16 +73,26 @@ pub(crate) fn fission_tool(name: &str) -> bool {
 /// - `fission_control` — `op=wait` blocks up to 300 s
 ///   (`clamp_fission_wait_timeout_s`); the quick ops answer in one
 ///   frame, which the stream carries just as well.
+/// - `execute_cu_actions` — a caller-supplied action list sleeps its
+///   `wait`/`hold_key` millisecond durations verbatim
+///   (`computer_use.rs`), so a sequence legitimately outlives the
+///   window.
+/// - `peer_execute_cu_actions` — the same caller-paced actions run on
+///   a federated peer, bounded only by `PEER_MCP_TIMEOUT` (120 s).
 ///
-/// Deliberately not held — capped at or under the window: the `events`
-/// long-poll (`EVENTS_WAIT_MAX_S` = 60, pinned by the test below), the
-/// cloud CU round trip (60 s), and the codex thread-action waits
-/// (20 s).
-pub(crate) const MCP_HELD_POST_TOOLS: [&str; 4] = [
+/// Deliberately not held — quick by design, with caps at or under the
+/// window: the `events` long-poll (`EVENTS_WAIT_MAX_S` = 60, pinned by
+/// the test below), the cloud CU round trip (60 s), and the codex
+/// thread-action waits (20 s). The remaining peer round trips share
+/// `PEER_MCP_TIMEOUT` as a transport bound, but they are sub-second
+/// lookups — a cap is a bound, not a hold (the `events` reading).
+pub(crate) const MCP_HELD_POST_TOOLS: [&str; 6] = [
     "ask_user",
     "request_user_display",
     "spawn_live_audio",
     "fission_control",
+    "execute_cu_actions",
+    "peer_execute_cu_actions",
 ];
 
 pub(crate) fn mcp_held_post_tool(name: &str) -> bool {

--- a/src/bin/caller/mcp/tools_events.rs
+++ b/src/bin/caller/mcp/tools_events.rs
@@ -28,8 +28,11 @@ use super::*;
 use crate::event_ring::{EventRing, RingEntry};
 use std::sync::Arc;
 
-/// Long-poll ceiling — the `remote wait` chunk contract.
-const EVENTS_WAIT_MAX_S: u64 = 60;
+/// Long-poll ceiling — the `remote wait` chunk contract. Also the
+/// reason `events` stays out of `MCP_HELD_POST_TOOLS`: at or under this
+/// cap a call answers before a ~60 s idle window closes, so it takes
+/// plain JSON, not per-request SSE (`tool_gate` pins the pairing).
+pub(crate) const EVENTS_WAIT_MAX_S: u64 = 60;
 const EVENTS_PAGE_DEFAULT: usize = 100;
 const EVENTS_PAGE_MAX: usize = 500;
 

--- a/src/bin/caller/mcp/tools_events.rs
+++ b/src/bin/caller/mcp/tools_events.rs
@@ -28,11 +28,12 @@ use super::*;
 use crate::event_ring::{EventRing, RingEntry};
 use std::sync::Arc;
 
-/// Long-poll ceiling — the `remote wait` chunk contract. Also the
-/// reason `events` stays out of `MCP_HELD_POST_TOOLS`: at or under this
-/// cap a call answers before a ~60 s idle window closes, so it takes
-/// plain JSON, not per-request SSE (`tool_gate` pins the pairing).
-pub(crate) const EVENTS_WAIT_MAX_S: u64 = 60;
+/// Long-poll ceiling — the `remote wait` chunk contract. A chunk can
+/// sit this full window on a quiet stream, and the full wait plus
+/// dispatch overhead crosses a ~60 s idle window — which is why
+/// `events` is a held-POST verb (`MCP_HELD_POST_TOOLS`): SSE
+/// keepalives carry the quiet chunk when the client accepts them.
+const EVENTS_WAIT_MAX_S: u64 = 60;
 const EVENTS_PAGE_DEFAULT: usize = 100;
 const EVENTS_PAGE_MAX: usize = 500;
 

--- a/src/bin/caller/web_gateway/http.rs
+++ b/src/bin/caller/web_gateway/http.rs
@@ -382,6 +382,24 @@ pub(crate) fn http_header_present(header_text: &str, header_name: &str) -> bool 
     http_header_value(header_text, header_name).is_some()
 }
 
+/// Every field line of a repeatable header, in order of appearance.
+/// List-valued fields (`Accept`, `Accept-Encoding`, …) may legally
+/// arrive split across several field lines — RFC 9110 folds them into
+/// one comma-joined list — so list semantics must consult all of them;
+/// [`http_header_value`] sees only the first line and is for singleton
+/// fields.
+pub(crate) fn http_header_values<'a>(
+    header_text: &'a str,
+    header_name: &'a str,
+) -> impl Iterator<Item = &'a str> + 'a {
+    header_text.lines().skip(1).filter_map(move |line| {
+        let (name, value) = line.split_once(':')?;
+        name.trim()
+            .eq_ignore_ascii_case(header_name)
+            .then_some(value.trim())
+    })
+}
+
 /// Whether the request head's `Accept-Encoding` admits gzip (tolerant:
 /// case-insensitive header name and token, `x-gzip` alias, `;q=0` rejects).
 pub(crate) fn accept_encoding_allows_gzip(header_text: &str) -> bool {
@@ -1484,6 +1502,20 @@ pub(crate) fn extract_header_value(header_text: &str, name: &str) -> Option<Stri
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Repeatable headers fold across field lines: the plural reader
+    /// returns every occurrence in order, while the singleton reader
+    /// keeps its first-line contract.
+    #[test]
+    fn header_values_folds_repeated_field_lines() {
+        let head = "POST /mcp HTTP/1.1\r\naccept: application/json\r\nAccept: text/event-stream\r\nHost: h\r\n\r\n";
+        assert_eq!(
+            http_header_values(head, "accept").collect::<Vec<_>>(),
+            vec!["application/json", "text/event-stream"]
+        );
+        assert_eq!(http_header_value(head, "accept"), Some("application/json"));
+        assert_eq!(http_header_values(head, "x-absent").next(), None);
+    }
 
     #[test]
     fn http_response_builder_reproduces_legacy_framing_byte_for_byte() {

--- a/src/bin/caller/web_gateway/mcp_gate.rs
+++ b/src/bin/caller/web_gateway/mcp_gate.rs
@@ -608,6 +608,38 @@ pub(crate) async fn handle_mcp_http_request(
 /// waits already self-chunk under 60 s.
 const MCP_SSE_STREAMED_TOOLS: [&str; 2] = ["ask_user", "request_user_display"];
 const MCP_SSE_KEEPALIVE_SECS: u64 = 15;
+/// A progress token is a correlation handle (spec: string or integer),
+/// not a payload: reflecting it in every keepalive means an unbounded
+/// one would amplify a near-cap request into ~1 GiB over a 900 s ask
+/// (review: bound before reflecting). Oversized or non-scalar tokens
+/// downgrade to comment keepalives.
+const MCP_SSE_PROGRESS_TOKEN_MAX_BYTES: usize = 256;
+/// A keepalive write that cannot make progress within this window means
+/// the client stopped reading: stop writing (the verb still runs to its
+/// own lifecycle) instead of letting a blocked `write_all` starve the
+/// select loop that polls the call future.
+const MCP_SSE_WRITE_TIMEOUT_SECS: u64 = 10;
+
+/// RFC 9110 Accept negotiation, narrowed to the one question asked:
+/// does this header accept `text/event-stream` with a non-zero
+/// quality? A bare substring check would treat `text/event-stream;q=0`
+/// — an explicit rejection — as acceptance (review).
+fn accepts_event_stream(accept: &str) -> bool {
+    accept.split(',').any(|range| {
+        let mut parts = range.split(';');
+        let media = parts.next().unwrap_or("").trim().to_ascii_lowercase();
+        if media != "text/event-stream" {
+            return false;
+        }
+        for param in parts {
+            let param = param.trim().to_ascii_lowercase();
+            if let Some(q) = param.strip_prefix("q=") {
+                return q.trim().parse::<f32>().map(|q| q > 0.0).unwrap_or(false);
+            }
+        }
+        true
+    })
+}
 
 /// The per-request SSE decision for one `POST /mcp` body (MCP
 /// Streamable HTTP, 2026-07-28 shape: the server may answer any POST
@@ -625,8 +657,7 @@ struct McpSsePlan {
 }
 
 fn mcp_sse_plan(header_text: &str, body_text: &str) -> Option<McpSsePlan> {
-    let accepts_sse = http_header_value(header_text, "accept")
-        .is_some_and(|accept| accept.to_ascii_lowercase().contains("text/event-stream"));
+    let accepts_sse = http_header_value(header_text, "accept").is_some_and(accepts_event_stream);
     if !accepts_sse {
         return None;
     }
@@ -653,6 +684,11 @@ fn mcp_sse_plan(header_text: &str, body_text: &str) -> Option<McpSsePlan> {
     let progress_token = params
         .get("_meta")
         .and_then(|meta| meta.get("progressToken"))
+        .filter(|token| match token {
+            serde_json::Value::Number(_) => true,
+            serde_json::Value::String(s) => s.len() <= MCP_SSE_PROGRESS_TOKEN_MAX_BYTES,
+            _ => false,
+        })
         .cloned();
     Some(McpSsePlan { progress_token })
 }
@@ -774,7 +810,10 @@ pub(crate) async fn handle_mcp_post(
                 .header_segment(&mcp_cors)
                 .header("Connection", "close")
                 .into_string();
-            if stream.write_all(head.as_bytes()).await.is_err() {
+            // Flushed, not just written: over TLS a completed write can
+            // leave ciphertext buffered, and the whole point of the
+            // stream is 15 s of guaranteed WIRE activity (review).
+            if stream.write_all(head.as_bytes()).await.is_err() || stream.flush().await.is_err() {
                 finalize_http_stream(&mut stream).await;
                 return;
             }
@@ -804,12 +843,26 @@ pub(crate) async fn handle_mcp_post(
                             Some(token) => sse_progress_frame(token, ticks),
                             None => ": keepalive\n\n".to_string(),
                         };
-                        if stream.write_all(frame.as_bytes()).await.is_err() {
-                            // The client hung up. The verb still runs to
-                            // completion — plain-POST semantics, where a
-                            // disconnect is only ever noticed at the
-                            // final write — so an in-flight ask keeps
-                            // its own lifecycle.
+                        // Flush each frame (wire activity, not buffer
+                        // activity), and bound the write: a client that
+                        // stopped reading must not park this loop on a
+                        // blocked write_all — that would stop polling
+                        // the call future itself (review).
+                        let wrote = tokio::time::timeout(
+                            std::time::Duration::from_secs(MCP_SSE_WRITE_TIMEOUT_SECS),
+                            async {
+                                stream.write_all(frame.as_bytes()).await?;
+                                stream.flush().await
+                            },
+                        )
+                        .await;
+                        if !matches!(wrote, Ok(Ok(()))) {
+                            // The client hung up (or stopped reading).
+                            // The verb still runs to completion —
+                            // plain-POST semantics, where a disconnect
+                            // is only ever noticed at the final write —
+                            // so an in-flight ask keeps its own
+                            // lifecycle; we just stop writing.
                             client_gone = true;
                         }
                     }
@@ -825,6 +878,7 @@ pub(crate) async fn handle_mcp_post(
                     McpHttpOutcome::Accepted => String::new(),
                 };
                 let _ = stream.write_all(final_frame.as_bytes()).await;
+                let _ = stream.flush().await;
             }
             finalize_http_stream(&mut stream).await;
             return;
@@ -1195,6 +1249,69 @@ mod tests {
             .unwrap()
             .progress_token
             .is_none());
+        // A progress token is a bounded correlation handle, never a
+        // payload: an oversized or non-scalar token downgrades to
+        // comment keepalives instead of being reflected every 15 s.
+        let huge_token = serde_json::json!({
+            "jsonrpc": "2.0", "id": 7, "method": "tools/call",
+            "params": {
+                "name": "ask_user",
+                "arguments": { "question": "go?" },
+                "_meta": { "progressToken": "x".repeat(MCP_SSE_PROGRESS_TOKEN_MAX_BYTES + 1) },
+            },
+        })
+        .to_string();
+        assert!(
+            mcp_sse_plan(sse_headers, &huge_token)
+                .unwrap()
+                .progress_token
+                .is_none(),
+            "oversized token downgrades"
+        );
+        let object_token = serde_json::json!({
+            "jsonrpc": "2.0", "id": 8, "method": "tools/call",
+            "params": {
+                "name": "ask_user",
+                "arguments": { "question": "go?" },
+                "_meta": { "progressToken": { "not": "a scalar" } },
+            },
+        })
+        .to_string();
+        assert!(mcp_sse_plan(sse_headers, &object_token)
+            .unwrap()
+            .progress_token
+            .is_none());
+        let int_token = serde_json::json!({
+            "jsonrpc": "2.0", "id": 9, "method": "tools/call",
+            "params": {
+                "name": "ask_user",
+                "arguments": { "question": "go?" },
+                "_meta": { "progressToken": 42 },
+            },
+        })
+        .to_string();
+        assert_eq!(
+            mcp_sse_plan(sse_headers, &int_token)
+                .unwrap()
+                .progress_token,
+            Some(serde_json::json!(42))
+        );
+    }
+
+    /// Accept negotiation is media-range aware: `;q=0` is an explicit
+    /// rejection, not acceptance; non-zero qualities and the bare form
+    /// accept; other media types never match.
+    #[test]
+    fn event_stream_acceptance_honors_quality_values() {
+        assert!(accepts_event_stream("text/event-stream"));
+        assert!(accepts_event_stream("application/json, text/event-stream"));
+        assert!(accepts_event_stream("Text/Event-Stream; q=0.5"));
+        assert!(!accepts_event_stream(
+            "application/json, text/event-stream;q=0"
+        ));
+        assert!(!accepts_event_stream("text/event-stream;q=0.0"));
+        assert!(!accepts_event_stream("application/json"));
+        assert!(!accepts_event_stream("text/event-streamer"));
     }
 
     /// SSE frames follow the event-stream grammar: an event line, one

--- a/src/bin/caller/web_gateway/mcp_gate.rs
+++ b/src/bin/caller/web_gateway/mcp_gate.rs
@@ -693,6 +693,20 @@ fn mcp_sse_plan(header_text: &str, body_text: &str) -> Option<McpSsePlan> {
     Some(McpSsePlan { progress_token })
 }
 
+/// The SSE response head. `X-Accel-Buffering: no` orders nginx-family
+/// reverse proxies not to buffer the stream — a proxy that holds the
+/// 15 s frames until the request completes recreates exactly the idle
+/// silence the stream exists to prevent.
+fn sse_response_head(mcp_cors: &str) -> String {
+    HttpResponse::new("200 OK")
+        .header("Content-Type", "text/event-stream")
+        .header("Cache-Control", "no-cache")
+        .header("X-Accel-Buffering", "no")
+        .header_segment(mcp_cors)
+        .header("Connection", "close")
+        .into_string()
+}
+
 /// One SSE event frame. Compact JSON carries no raw newlines, but data
 /// lines split defensively — a newline inside a data payload would
 /// otherwise break the frame grammar.
@@ -804,19 +818,6 @@ pub(crate) async fn handle_mcp_post(
         // per-tool decision still runs inside the dispatch, and a
         // denial simply arrives as the stream's only message.
         if let Some(plan) = mcp_sse_plan(header_text, &body_text) {
-            let head = HttpResponse::new("200 OK")
-                .header("Content-Type", "text/event-stream")
-                .header("Cache-Control", "no-cache")
-                .header_segment(&mcp_cors)
-                .header("Connection", "close")
-                .into_string();
-            // Flushed, not just written: over TLS a completed write can
-            // leave ciphertext buffered, and the whole point of the
-            // stream is 15 s of guaranteed WIRE activity (review).
-            if stream.write_all(head.as_bytes()).await.is_err() || stream.flush().await.is_err() {
-                finalize_http_stream(&mut stream).await;
-                return;
-            }
             let call = handle_mcp_http_request(
                 &body_text,
                 mcp,
@@ -828,12 +829,23 @@ pub(crate) async fn handle_mcp_post(
                 &bus,
             );
             tokio::pin!(call);
+            // Establish the stream. Flushed, not just written: over TLS
+            // a completed write can leave ciphertext buffered, and the
+            // whole point of the stream is 15 s of guaranteed WIRE
+            // activity. If the head cannot be written — the client or a
+            // proxy reset between delivering the POST and reading the
+            // response — the accepted call still runs to its own
+            // completion below: plain-POST semantics never let a
+            // disconnect cancel a held verb, so only the writing is
+            // skipped.
+            let head = sse_response_head(&mcp_cors);
+            let mut client_gone =
+                stream.write_all(head.as_bytes()).await.is_err() || stream.flush().await.is_err();
             let mut keepalive =
                 tokio::time::interval(std::time::Duration::from_secs(MCP_SSE_KEEPALIVE_SECS));
             keepalive.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             keepalive.tick().await; // consume the immediate first tick
             let mut ticks = 0u64;
-            let mut client_gone = false;
             let outcome = loop {
                 tokio::select! {
                     outcome = &mut call => break outcome,
@@ -1374,6 +1386,24 @@ mod tests {
         assert_eq!(payload["method"], "notifications/progress");
         assert_eq!(payload["params"]["progressToken"], "tok-1");
         assert_eq!(payload["params"]["progress"], 3);
+    }
+
+    /// The SSE head carries the stream contract end to end: 200, the
+    /// event-stream content type, no-cache, the caller's CORS segment,
+    /// and the anti-buffering order — an nginx-family proxy that holds
+    /// the 15 s frames until completion would recreate exactly the idle
+    /// silence the stream exists to prevent.
+    #[test]
+    fn sse_response_head_defeats_proxy_buffering() {
+        let head = sse_response_head("Access-Control-Allow-Origin: https://a\r\nVary: Origin\r\n");
+        assert!(head.starts_with("HTTP/1.1 200 OK\r\n"));
+        assert!(head.contains("Content-Type: text/event-stream\r\n"));
+        assert!(head.contains("Cache-Control: no-cache\r\n"));
+        assert!(head.contains("X-Accel-Buffering: no\r\n"));
+        assert!(head.contains("Access-Control-Allow-Origin: https://a\r\n"));
+        assert!(head.contains("Vary: Origin\r\n"));
+        assert!(head.contains("Connection: close\r\n"));
+        assert!(head.ends_with("\r\n\r\n"));
     }
 
     /// The stateless `/mcp` endpoint negotiates `initialize` per spec: echo

--- a/src/bin/caller/web_gateway/mcp_gate.rs
+++ b/src/bin/caller/web_gateway/mcp_gate.rs
@@ -880,18 +880,27 @@ pub(crate) async fn handle_mcp_post(
                     }
                 }
             };
-            if !client_gone {
-                let final_frame = match outcome {
-                    McpHttpOutcome::Response(resp) => {
-                        sse_frame("message", &serde_json::to_string(&resp).unwrap_or_default())
-                    }
-                    // Unreachable for a planned tools/call request
-                    // (notifications never plan); close the stream bare.
-                    McpHttpOutcome::Accepted => String::new(),
-                };
-                let _ = stream.write_all(final_frame.as_bytes()).await;
-                let _ = stream.flush().await;
+            if client_gone {
+                // The peer already failed a bounded write, so the
+                // graceful finalizer must not run: its unbounded
+                // flush + shutdown would push into the same
+                // backpressure (rustls can still hold ciphertext from
+                // the cancelled write) and park this task long after
+                // the verb finished. Dropping the stream closes the
+                // socket without the courtesy flush the peer stopped
+                // reading anyway.
+                return;
             }
+            let final_frame = match outcome {
+                McpHttpOutcome::Response(resp) => {
+                    sse_frame("message", &serde_json::to_string(&resp).unwrap_or_default())
+                }
+                // Unreachable for a planned tools/call request
+                // (notifications never plan); close the stream bare.
+                McpHttpOutcome::Accepted => String::new(),
+            };
+            let _ = stream.write_all(final_frame.as_bytes()).await;
+            let _ = stream.flush().await;
             finalize_http_stream(&mut stream).await;
             return;
         }

--- a/src/bin/caller/web_gateway/mcp_gate.rs
+++ b/src/bin/caller/web_gateway/mcp_gate.rs
@@ -601,6 +601,87 @@ pub(crate) async fn handle_mcp_http_request(
     })
 }
 
+/// The held-POST verbs whose calls can outlive client and proxy idle
+/// timeouts (an ask waits up to 900 s on the human; a display request
+/// waits on the grant): per-request SSE keeps those responses warm.
+/// Everything shorter answers as plain JSON — `events` and the remote
+/// waits already self-chunk under 60 s.
+const MCP_SSE_STREAMED_TOOLS: [&str; 2] = ["ask_user", "request_user_display"];
+const MCP_SSE_KEEPALIVE_SECS: u64 = 15;
+
+/// The per-request SSE decision for one `POST /mcp` body (MCP
+/// Streamable HTTP, 2026-07-28 shape: the server may answer any POST
+/// as an event stream). Streams only when the client accepts
+/// `text/event-stream`, the message is a `tools/call` REQUEST (an id —
+/// notifications take their 202), and the named (or facade-resolved)
+/// tool is a held-POST verb. Argument VALUES are never parsed here —
+/// facade resolution is argv-only, the same pre-auth cost class as the
+/// gate.
+struct McpSsePlan {
+    /// The client's `_meta.progressToken`, when it sent one: keepalives
+    /// ride as `notifications/progress` events. Without it they ride as
+    /// SSE comment lines (progress notifications require the token).
+    progress_token: Option<serde_json::Value>,
+}
+
+fn mcp_sse_plan(header_text: &str, body_text: &str) -> Option<McpSsePlan> {
+    let accepts_sse = http_header_value(header_text, "accept")
+        .is_some_and(|accept| accept.to_ascii_lowercase().contains("text/event-stream"));
+    if !accepts_sse {
+        return None;
+    }
+    let msg: serde_json::Value = serde_json::from_str(body_text).ok()?;
+    if msg.get("id").is_none_or(serde_json::Value::is_null) {
+        return None;
+    }
+    if msg.get("method").and_then(serde_json::Value::as_str) != Some("tools/call") {
+        return None;
+    }
+    let params = msg.get("params")?;
+    let name = params
+        .get("name")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("");
+    if !MCP_SSE_STREAMED_TOOLS.contains(&name) {
+        static NULL_ARGS: serde_json::Value = serde_json::Value::Null;
+        let args = params.get("arguments").unwrap_or(&NULL_ARGS);
+        let tool = crate::mcp::facade_resolved_tool(name, args)?;
+        if !MCP_SSE_STREAMED_TOOLS.contains(&tool) {
+            return None;
+        }
+    }
+    let progress_token = params
+        .get("_meta")
+        .and_then(|meta| meta.get("progressToken"))
+        .cloned();
+    Some(McpSsePlan { progress_token })
+}
+
+/// One SSE event frame. Compact JSON carries no raw newlines, but data
+/// lines split defensively — a newline inside a data payload would
+/// otherwise break the frame grammar.
+fn sse_frame(event: &str, data: &str) -> String {
+    let mut out = format!("event: {event}\n");
+    for line in data.split('\n') {
+        out.push_str("data: ");
+        out.push_str(line);
+        out.push('\n');
+    }
+    out.push('\n');
+    out
+}
+
+/// A spec-shaped `notifications/progress` keepalive (progress counts
+/// ticks; no total — the held verbs have none).
+fn sse_progress_frame(token: &serde_json::Value, ticks: u64) -> String {
+    let notification = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/progress",
+        "params": { "progressToken": token, "progress": ticks },
+    });
+    sse_frame("message", &notification.to_string())
+}
+
 // Parameter count rides until a request-context bundle collapses the
 // shared per-connection arguments (open cleanup; not load-bearing).
 #[allow(clippy::too_many_arguments)]
@@ -678,6 +759,76 @@ pub(crate) async fn handle_mcp_post(
         };
         let (mcp_session_id, codex_managed_context, tool_profile) =
             mcp_context_from_request_line(request_line);
+        // Per-request SSE (Streamable HTTP): a held-POST verb whose
+        // client accepts an event stream answers as one — keepalives
+        // (progress notifications when the request carried a token)
+        // every 15 s defeat client/proxy idle timeouts, then the final
+        // JSON-RPC response closes the stream. Everything else keeps
+        // the plain-JSON leg below. Authorization is unchanged: the
+        // per-tool decision still runs inside the dispatch, and a
+        // denial simply arrives as the stream's only message.
+        if let Some(plan) = mcp_sse_plan(header_text, &body_text) {
+            let head = HttpResponse::new("200 OK")
+                .header("Content-Type", "text/event-stream")
+                .header("Cache-Control", "no-cache")
+                .header_segment(&mcp_cors)
+                .header("Connection", "close")
+                .into_string();
+            if stream.write_all(head.as_bytes()).await.is_err() {
+                finalize_http_stream(&mut stream).await;
+                return;
+            }
+            let call = handle_mcp_http_request(
+                &body_text,
+                mcp,
+                mcp_session_id.as_deref(),
+                codex_managed_context,
+                tool_profile.as_deref(),
+                &mcp_access,
+                mcp_gate_session(header_text),
+                &bus,
+            );
+            tokio::pin!(call);
+            let mut keepalive =
+                tokio::time::interval(std::time::Duration::from_secs(MCP_SSE_KEEPALIVE_SECS));
+            keepalive.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            keepalive.tick().await; // consume the immediate first tick
+            let mut ticks = 0u64;
+            let mut client_gone = false;
+            let outcome = loop {
+                tokio::select! {
+                    outcome = &mut call => break outcome,
+                    _ = keepalive.tick(), if !client_gone => {
+                        ticks += 1;
+                        let frame = match &plan.progress_token {
+                            Some(token) => sse_progress_frame(token, ticks),
+                            None => ": keepalive\n\n".to_string(),
+                        };
+                        if stream.write_all(frame.as_bytes()).await.is_err() {
+                            // The client hung up. The verb still runs to
+                            // completion — plain-POST semantics, where a
+                            // disconnect is only ever noticed at the
+                            // final write — so an in-flight ask keeps
+                            // its own lifecycle.
+                            client_gone = true;
+                        }
+                    }
+                }
+            };
+            if !client_gone {
+                let final_frame = match outcome {
+                    McpHttpOutcome::Response(resp) => {
+                        sse_frame("message", &serde_json::to_string(&resp).unwrap_or_default())
+                    }
+                    // Unreachable for a planned tools/call request
+                    // (notifications never plan); close the stream bare.
+                    McpHttpOutcome::Accepted => String::new(),
+                };
+                let _ = stream.write_all(final_frame.as_bytes()).await;
+            }
+            finalize_http_stream(&mut stream).await;
+            return;
+        }
         let outcome = handle_mcp_http_request(
             &body_text,
             mcp,
@@ -974,6 +1125,104 @@ pub(crate) fn mcp_agent_session_context(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The per-request SSE plan fires only for the exact intersection:
+    /// an event-stream-accepting client, a `tools/call` REQUEST, and a
+    /// held-POST verb (typed name or facade-resolved) — and it lifts
+    /// the client's progress token when one rides the request. Values
+    /// are never parsed: a facade call with garbage arguments still
+    /// plans by its argv alone.
+    #[test]
+    fn sse_plan_gates_on_accept_request_shape_and_held_verbs() {
+        let sse_headers =
+            "POST /mcp HTTP/1.1\r\nHost: h\r\nAccept: application/json, text/event-stream\r\n\r\n";
+        let json_headers = "POST /mcp HTTP/1.1\r\nHost: h\r\nAccept: application/json\r\n\r\n";
+        let ask = serde_json::json!({
+            "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+            "params": { "name": "ask_user", "arguments": { "question": "go?" } },
+        })
+        .to_string();
+        assert!(mcp_sse_plan(sse_headers, &ask).is_some());
+        assert!(
+            mcp_sse_plan(json_headers, &ask).is_none(),
+            "no event-stream accept, no stream"
+        );
+        // A short verb answers as plain JSON even when SSE is accepted.
+        let status = serde_json::json!({
+            "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+            "params": { "name": "get_status", "arguments": {} },
+        })
+        .to_string();
+        assert!(mcp_sse_plan(sse_headers, &status).is_none());
+        // Notifications (no id) never stream; nor do non-call methods.
+        let notification = serde_json::json!({
+            "jsonrpc": "2.0", "method": "tools/call",
+            "params": { "name": "ask_user", "arguments": {} },
+        })
+        .to_string();
+        assert!(mcp_sse_plan(sse_headers, &notification).is_none());
+        let list = serde_json::json!({
+            "jsonrpc": "2.0", "id": 3, "method": "tools/list",
+        })
+        .to_string();
+        assert!(mcp_sse_plan(sse_headers, &list).is_none());
+        // Facade resolution is argv-only: `act ["ask", ...]` streams.
+        let facade_ask = serde_json::json!({
+            "jsonrpc": "2.0", "id": 4, "method": "tools/call",
+            "params": { "name": "act", "arguments": { "argv": ["ask", "which one?"] } },
+        })
+        .to_string();
+        assert!(mcp_sse_plan(sse_headers, &facade_ask).is_some());
+        let facade_status = serde_json::json!({
+            "jsonrpc": "2.0", "id": 5, "method": "tools/call",
+            "params": { "name": "inspect", "arguments": { "argv": ["status"] } },
+        })
+        .to_string();
+        assert!(mcp_sse_plan(sse_headers, &facade_status).is_none());
+        // The progress token rides out of _meta when present.
+        let with_token = serde_json::json!({
+            "jsonrpc": "2.0", "id": 6, "method": "tools/call",
+            "params": {
+                "name": "ask_user",
+                "arguments": { "question": "go?" },
+                "_meta": { "progressToken": "tok-1" },
+            },
+        })
+        .to_string();
+        let plan = mcp_sse_plan(sse_headers, &with_token).unwrap();
+        assert_eq!(plan.progress_token, Some(serde_json::json!("tok-1")));
+        assert!(mcp_sse_plan(sse_headers, &ask)
+            .unwrap()
+            .progress_token
+            .is_none());
+    }
+
+    /// SSE frames follow the event-stream grammar: an event line, one
+    /// data line per payload line, a blank terminator; the progress
+    /// frame is a spec-shaped notifications/progress message.
+    #[test]
+    fn sse_frames_speak_the_event_stream_grammar() {
+        assert_eq!(
+            sse_frame("message", "{\"a\":1}"),
+            "event: message\ndata: {\"a\":1}\n\n"
+        );
+        assert_eq!(
+            sse_frame("message", "line1\nline2"),
+            "event: message\ndata: line1\ndata: line2\n\n"
+        );
+        let frame = sse_progress_frame(&serde_json::json!("tok-1"), 3);
+        assert!(frame.starts_with("event: message\ndata: "));
+        assert!(frame.ends_with("\n\n"));
+        let payload: serde_json::Value = serde_json::from_str(
+            frame
+                .trim_start_matches("event: message\ndata: ")
+                .trim_end(),
+        )
+        .unwrap();
+        assert_eq!(payload["method"], "notifications/progress");
+        assert_eq!(payload["params"]["progressToken"], "tok-1");
+        assert_eq!(payload["params"]["progress"], 3);
+    }
 
     /// The stateless `/mcp` endpoint negotiates `initialize` per spec: echo
     /// a requested revision it implements, otherwise answer with the newest

--- a/src/bin/caller/web_gateway/mcp_gate.rs
+++ b/src/bin/caller/web_gateway/mcp_gate.rs
@@ -445,9 +445,29 @@ pub(crate) fn negotiated_mcp_protocol_version(requested: Option<&str>) -> &'stat
         .unwrap_or(SUPPORTED_MCP_PROTOCOL_VERSIONS[0])
 }
 
+/// Parse one wire body into its JSON-RPC request, or into the
+/// `-32700` response the wire expects for malformed JSON. The POST
+/// handler parses ONCE and shares the request between the SSE
+/// decision and dispatch — a second decode of a body near the route
+/// cap would double the heaviest per-POST cost for every client
+/// whose `Accept` admits an event stream.
+pub(crate) fn parse_mcp_http_request(body: &str) -> Result<McpHttpRequest, McpHttpOutcome> {
+    serde_json::from_str(body).map_err(|e| {
+        McpHttpOutcome::Response(McpHttpResponse {
+            jsonrpc: "2.0".into(),
+            id: None,
+            result: None,
+            error: Some(McpHttpError {
+                code: -32700,
+                message: format!("Parse error: {}", e),
+            }),
+        })
+    })
+}
+
 #[allow(clippy::too_many_arguments)]
-pub(crate) async fn handle_mcp_http_request(
-    body: &str,
+pub(crate) async fn handle_mcp_parsed_request(
+    request: McpHttpRequest,
     server: &crate::mcp::IntendantServer,
     session_id: Option<&str>,
     codex_managed_context: Option<bool>,
@@ -459,21 +479,6 @@ pub(crate) async fn handle_mcp_http_request(
     gate_session: Option<String>,
     bus: &EventBus,
 ) -> McpHttpOutcome {
-    let request: McpHttpRequest = match serde_json::from_str(body) {
-        Ok(r) => r,
-        Err(e) => {
-            return McpHttpOutcome::Response(McpHttpResponse {
-                jsonrpc: "2.0".into(),
-                id: None,
-                result: None,
-                error: Some(McpHttpError {
-                    code: -32700,
-                    message: format!("Parse error: {}", e),
-                }),
-            });
-        }
-    };
-
     // JSON-RPC notifications have no `id` and expect no response body.
     // The MCP Streamable HTTP spec requires 202 Accepted for these.
     let is_notification = request.id.is_none();
@@ -638,9 +643,10 @@ fn accepts_event_stream(accept: &str) -> bool {
     })
 }
 
-/// The per-request SSE decision for one `POST /mcp` body (MCP
-/// Streamable HTTP, 2026-07-28 shape: the server may answer any POST
-/// as an event stream). Streams only when the client accepts
+/// The per-request SSE decision for one parsed `POST /mcp` request —
+/// the caller's single decode, shared with dispatch (MCP Streamable
+/// HTTP, 2026-07-28 shape: the server may answer any POST as an
+/// event stream). Streams only when the client accepts
 /// `text/event-stream`, the message is a `tools/call` REQUEST (an id —
 /// notifications take their 202), and the named (or facade-resolved)
 /// tool is a held-POST verb. Argument VALUES are never parsed here —
@@ -653,7 +659,7 @@ struct McpSsePlan {
     progress_token: Option<serde_json::Value>,
 }
 
-fn mcp_sse_plan(header_text: &str, body_text: &str) -> Option<McpSsePlan> {
+fn mcp_sse_plan(header_text: &str, request: &McpHttpRequest) -> Option<McpSsePlan> {
     // `Accept` is list-valued and may legally arrive split across
     // repeated field lines; fold every line (the parser is an ANY over
     // comma-separated ranges, so per-line ANY equals the joined list).
@@ -661,14 +667,13 @@ fn mcp_sse_plan(header_text: &str, body_text: &str) -> Option<McpSsePlan> {
     if !accepts_sse {
         return None;
     }
-    let msg: serde_json::Value = serde_json::from_str(body_text).ok()?;
-    if msg.get("id").is_none_or(serde_json::Value::is_null) {
+    if request.id.as_ref().is_none_or(|id| id.is_null()) {
         return None;
     }
-    if msg.get("method").and_then(serde_json::Value::as_str) != Some("tools/call") {
+    if request.method != "tools/call" {
         return None;
     }
-    let params = msg.get("params")?;
+    let params = request.params.as_ref()?;
     let name = params
         .get("name")
         .and_then(serde_json::Value::as_str)
@@ -816,105 +821,119 @@ pub(crate) async fn handle_mcp_post(
         // JSON-RPC response closes the stream. Everything else keeps
         // the plain-JSON leg below. Authorization is unchanged: the
         // per-tool decision still runs inside the dispatch, and a
-        // denial simply arrives as the stream's only message.
-        if let Some(plan) = mcp_sse_plan(header_text, &body_text) {
-            let call = handle_mcp_http_request(
-                &body_text,
-                mcp,
-                mcp_session_id.as_deref(),
-                codex_managed_context,
-                tool_profile.as_deref(),
-                &mcp_access,
-                mcp_gate_session(header_text),
-                &bus,
-            );
-            tokio::pin!(call);
-            // Establish the stream. Flushed, not just written: over TLS
-            // a completed write can leave ciphertext buffered, and the
-            // whole point of the stream is 15 s of guaranteed WIRE
-            // activity. If the head cannot be written — the client or a
-            // proxy reset between delivering the POST and reading the
-            // response — the accepted call still runs to its own
-            // completion below: plain-POST semantics never let a
-            // disconnect cancel a held verb, so only the writing is
-            // skipped.
-            let head = sse_response_head(&mcp_cors);
-            let mut client_gone =
-                stream.write_all(head.as_bytes()).await.is_err() || stream.flush().await.is_err();
-            let mut keepalive =
-                tokio::time::interval(std::time::Duration::from_secs(MCP_SSE_KEEPALIVE_SECS));
-            keepalive.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-            keepalive.tick().await; // consume the immediate first tick
-            let mut ticks = 0u64;
-            let outcome = loop {
-                tokio::select! {
-                    outcome = &mut call => break outcome,
-                    _ = keepalive.tick(), if !client_gone => {
-                        ticks += 1;
-                        let frame = match &plan.progress_token {
-                            Some(token) => sse_progress_frame(token, ticks),
-                            None => ": keepalive\n\n".to_string(),
-                        };
-                        // Flush each frame (wire activity, not buffer
-                        // activity), and bound the write: a client that
-                        // stopped reading must not park this loop on a
-                        // blocked write_all — that would stop polling
-                        // the call future itself (review).
-                        let wrote = tokio::time::timeout(
-                            std::time::Duration::from_secs(MCP_SSE_WRITE_TIMEOUT_SECS),
-                            async {
-                                stream.write_all(frame.as_bytes()).await?;
-                                stream.flush().await
-                            },
-                        )
-                        .await;
-                        if !matches!(wrote, Ok(Ok(()))) {
-                            // The client hung up (or stopped reading).
-                            // The verb still runs to completion —
-                            // plain-POST semantics, where a disconnect
-                            // is only ever noticed at the final write —
-                            // so an in-flight ask keeps its own
-                            // lifecycle; we just stop writing.
-                            client_gone = true;
+        // denial simply arrives as the stream's only message. The body
+        // is decoded exactly once — the SSE decision and dispatch
+        // share the parse.
+        let outcome = match parse_mcp_http_request(&body_text) {
+            Err(outcome) => outcome,
+            Ok(request) => {
+                if let Some(plan) = mcp_sse_plan(header_text, &request) {
+                    let call = handle_mcp_parsed_request(
+                        request,
+                        mcp,
+                        mcp_session_id.as_deref(),
+                        codex_managed_context,
+                        tool_profile.as_deref(),
+                        &mcp_access,
+                        mcp_gate_session(header_text),
+                        &bus,
+                    );
+                    tokio::pin!(call);
+                    // Establish the stream. Flushed, not just written:
+                    // over TLS a completed write can leave ciphertext
+                    // buffered, and the whole point of the stream is
+                    // 15 s of guaranteed WIRE activity. If the head
+                    // cannot be written — the client or a proxy reset
+                    // between delivering the POST and reading the
+                    // response — the accepted call still runs to its
+                    // own completion below: plain-POST semantics never
+                    // let a disconnect cancel a held verb, so only the
+                    // writing is skipped.
+                    let head = sse_response_head(&mcp_cors);
+                    let mut client_gone = stream.write_all(head.as_bytes()).await.is_err()
+                        || stream.flush().await.is_err();
+                    let mut keepalive = tokio::time::interval(std::time::Duration::from_secs(
+                        MCP_SSE_KEEPALIVE_SECS,
+                    ));
+                    keepalive.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+                    keepalive.tick().await; // consume the immediate first tick
+                    let mut ticks = 0u64;
+                    let outcome = loop {
+                        tokio::select! {
+                            outcome = &mut call => break outcome,
+                            _ = keepalive.tick(), if !client_gone => {
+                                ticks += 1;
+                                let frame = match &plan.progress_token {
+                                    Some(token) => sse_progress_frame(token, ticks),
+                                    None => ": keepalive\n\n".to_string(),
+                                };
+                                // Flush each frame (wire activity, not
+                                // buffer activity), and bound the
+                                // write: a client that stopped reading
+                                // must not park this loop on a blocked
+                                // write_all — that would stop polling
+                                // the call future itself (review).
+                                let wrote = tokio::time::timeout(
+                                    std::time::Duration::from_secs(MCP_SSE_WRITE_TIMEOUT_SECS),
+                                    async {
+                                        stream.write_all(frame.as_bytes()).await?;
+                                        stream.flush().await
+                                    },
+                                )
+                                .await;
+                                if !matches!(wrote, Ok(Ok(()))) {
+                                    // The client hung up (or stopped
+                                    // reading). The verb still runs to
+                                    // completion — plain-POST
+                                    // semantics, where a disconnect is
+                                    // only ever noticed at the final
+                                    // write — so an in-flight ask
+                                    // keeps its own lifecycle; we just
+                                    // stop writing.
+                                    client_gone = true;
+                                }
+                            }
                         }
+                    };
+                    if client_gone {
+                        // The peer already failed a bounded write, so
+                        // the graceful finalizer must not run: its
+                        // unbounded flush + shutdown would push into
+                        // the same backpressure (rustls can still hold
+                        // ciphertext from the cancelled write) and
+                        // park this task long after the verb finished.
+                        // Dropping the stream closes the socket
+                        // without the courtesy flush the peer stopped
+                        // reading anyway.
+                        return;
                     }
+                    let final_frame = match outcome {
+                        McpHttpOutcome::Response(resp) => {
+                            sse_frame("message", &serde_json::to_string(&resp).unwrap_or_default())
+                        }
+                        // Unreachable for a planned tools/call request
+                        // (notifications never plan); close the stream
+                        // bare.
+                        McpHttpOutcome::Accepted => String::new(),
+                    };
+                    let _ = stream.write_all(final_frame.as_bytes()).await;
+                    let _ = stream.flush().await;
+                    finalize_http_stream(&mut stream).await;
+                    return;
                 }
-            };
-            if client_gone {
-                // The peer already failed a bounded write, so the
-                // graceful finalizer must not run: its unbounded
-                // flush + shutdown would push into the same
-                // backpressure (rustls can still hold ciphertext from
-                // the cancelled write) and park this task long after
-                // the verb finished. Dropping the stream closes the
-                // socket without the courtesy flush the peer stopped
-                // reading anyway.
-                return;
+                handle_mcp_parsed_request(
+                    request,
+                    mcp,
+                    mcp_session_id.as_deref(),
+                    codex_managed_context,
+                    tool_profile.as_deref(),
+                    &mcp_access,
+                    mcp_gate_session(header_text),
+                    &bus,
+                )
+                .await
             }
-            let final_frame = match outcome {
-                McpHttpOutcome::Response(resp) => {
-                    sse_frame("message", &serde_json::to_string(&resp).unwrap_or_default())
-                }
-                // Unreachable for a planned tools/call request
-                // (notifications never plan); close the stream bare.
-                McpHttpOutcome::Accepted => String::new(),
-            };
-            let _ = stream.write_all(final_frame.as_bytes()).await;
-            let _ = stream.flush().await;
-            finalize_http_stream(&mut stream).await;
-            return;
-        }
-        let outcome = handle_mcp_http_request(
-            &body_text,
-            mcp,
-            mcp_session_id.as_deref(),
-            codex_managed_context,
-            tool_profile.as_deref(),
-            &mcp_access,
-            mcp_gate_session(header_text),
-            &bus,
-        )
-        .await;
+        };
         // Keep-alive opt-in (response leg): both shapes are self-framing
         // (Content-Length), and dispatch consumed the body under the /mcp
         // row's cap. Managed Codex/CC backends call /mcp once per tool
@@ -1201,6 +1220,45 @@ pub(crate) fn mcp_agent_session_context(
 mod tests {
     use super::*;
 
+    /// SSE-plan fixtures arrive pre-parsed, the way the production
+    /// path hands them over (one decode, shared with dispatch).
+    fn parse_req(value: serde_json::Value) -> McpHttpRequest {
+        serde_json::from_value(value).expect("test request parses")
+    }
+
+    /// Wire-shaped test entry: production parses once in
+    /// `handle_mcp_post` and hands the request to
+    /// `handle_mcp_parsed_request`; tests keep the str form so the
+    /// parse-error path is covered on the same seam the wire takes.
+    #[allow(clippy::too_many_arguments)]
+    async fn handle_mcp_http_request(
+        body: &str,
+        server: &crate::mcp::IntendantServer,
+        session_id: Option<&str>,
+        codex_managed_context: Option<bool>,
+        tool_profile: Option<&str>,
+        access: &HttpAccessContext,
+        gate_session: Option<String>,
+        bus: &EventBus,
+    ) -> McpHttpOutcome {
+        match parse_mcp_http_request(body) {
+            Ok(request) => {
+                handle_mcp_parsed_request(
+                    request,
+                    server,
+                    session_id,
+                    codex_managed_context,
+                    tool_profile,
+                    access,
+                    gate_session,
+                    bus,
+                )
+                .await
+            }
+            Err(outcome) => outcome,
+        }
+    }
+
     /// The per-request SSE plan fires only for the exact intersection:
     /// an event-stream-accepting client, a `tools/call` REQUEST, and a
     /// held-POST verb (typed name or facade-resolved) — and it lifts
@@ -1212,58 +1270,51 @@ mod tests {
         let sse_headers =
             "POST /mcp HTTP/1.1\r\nHost: h\r\nAccept: application/json, text/event-stream\r\n\r\n";
         let json_headers = "POST /mcp HTTP/1.1\r\nHost: h\r\nAccept: application/json\r\n\r\n";
-        let ask = serde_json::json!({
+        let ask = parse_req(serde_json::json!({
             "jsonrpc": "2.0", "id": 1, "method": "tools/call",
             "params": { "name": "ask_user", "arguments": { "question": "go?" } },
-        })
-        .to_string();
+        }));
         assert!(mcp_sse_plan(sse_headers, &ask).is_some());
         assert!(
             mcp_sse_plan(json_headers, &ask).is_none(),
             "no event-stream accept, no stream"
         );
         // A short verb answers as plain JSON even when SSE is accepted.
-        let status = serde_json::json!({
+        let status = parse_req(serde_json::json!({
             "jsonrpc": "2.0", "id": 2, "method": "tools/call",
             "params": { "name": "get_status", "arguments": {} },
-        })
-        .to_string();
+        }));
         assert!(mcp_sse_plan(sse_headers, &status).is_none());
         // Notifications (no id) never stream; nor do non-call methods.
-        let notification = serde_json::json!({
+        let notification = parse_req(serde_json::json!({
             "jsonrpc": "2.0", "method": "tools/call",
             "params": { "name": "ask_user", "arguments": {} },
-        })
-        .to_string();
+        }));
         assert!(mcp_sse_plan(sse_headers, &notification).is_none());
-        let list = serde_json::json!({
+        let list = parse_req(serde_json::json!({
             "jsonrpc": "2.0", "id": 3, "method": "tools/list",
-        })
-        .to_string();
+        }));
         assert!(mcp_sse_plan(sse_headers, &list).is_none());
         // Facade resolution is argv-only: `act ["ask", ...]` streams.
-        let facade_ask = serde_json::json!({
+        let facade_ask = parse_req(serde_json::json!({
             "jsonrpc": "2.0", "id": 4, "method": "tools/call",
             "params": { "name": "act", "arguments": { "argv": ["ask", "which one?"] } },
-        })
-        .to_string();
+        }));
         assert!(mcp_sse_plan(sse_headers, &facade_ask).is_some());
-        let facade_status = serde_json::json!({
+        let facade_status = parse_req(serde_json::json!({
             "jsonrpc": "2.0", "id": 5, "method": "tools/call",
             "params": { "name": "inspect", "arguments": { "argv": ["status"] } },
-        })
-        .to_string();
+        }));
         assert!(mcp_sse_plan(sse_headers, &facade_status).is_none());
         // The progress token rides out of _meta when present.
-        let with_token = serde_json::json!({
+        let with_token = parse_req(serde_json::json!({
             "jsonrpc": "2.0", "id": 6, "method": "tools/call",
             "params": {
                 "name": "ask_user",
                 "arguments": { "question": "go?" },
                 "_meta": { "progressToken": "tok-1" },
             },
-        })
-        .to_string();
+        }));
         let plan = mcp_sse_plan(sse_headers, &with_token).unwrap();
         assert_eq!(plan.progress_token, Some(serde_json::json!("tok-1")));
         assert!(mcp_sse_plan(sse_headers, &ask)
@@ -1273,15 +1324,14 @@ mod tests {
         // A progress token is a bounded correlation handle, never a
         // payload: an oversized or non-scalar token downgrades to
         // comment keepalives instead of being reflected every 15 s.
-        let huge_token = serde_json::json!({
+        let huge_token = parse_req(serde_json::json!({
             "jsonrpc": "2.0", "id": 7, "method": "tools/call",
             "params": {
                 "name": "ask_user",
                 "arguments": { "question": "go?" },
                 "_meta": { "progressToken": "x".repeat(MCP_SSE_PROGRESS_TOKEN_MAX_BYTES + 1) },
             },
-        })
-        .to_string();
+        }));
         assert!(
             mcp_sse_plan(sse_headers, &huge_token)
                 .unwrap()
@@ -1289,28 +1339,26 @@ mod tests {
                 .is_none(),
             "oversized token downgrades"
         );
-        let object_token = serde_json::json!({
+        let object_token = parse_req(serde_json::json!({
             "jsonrpc": "2.0", "id": 8, "method": "tools/call",
             "params": {
                 "name": "ask_user",
                 "arguments": { "question": "go?" },
                 "_meta": { "progressToken": { "not": "a scalar" } },
             },
-        })
-        .to_string();
+        }));
         assert!(mcp_sse_plan(sse_headers, &object_token)
             .unwrap()
             .progress_token
             .is_none());
-        let int_token = serde_json::json!({
+        let int_token = parse_req(serde_json::json!({
             "jsonrpc": "2.0", "id": 9, "method": "tools/call",
             "params": {
                 "name": "ask_user",
                 "arguments": { "question": "go?" },
                 "_meta": { "progressToken": 42 },
             },
-        })
-        .to_string();
+        }));
         assert_eq!(
             mcp_sse_plan(sse_headers, &int_token)
                 .unwrap()
@@ -1321,11 +1369,10 @@ mod tests {
         // consent-gated and long-poll tools ride the same
         // classification.
         for held in crate::mcp::MCP_HELD_POST_TOOLS {
-            let call = serde_json::json!({
+            let call = parse_req(serde_json::json!({
                 "jsonrpc": "2.0", "id": 10, "method": "tools/call",
                 "params": { "name": held, "arguments": {} },
-            })
-            .to_string();
+            }));
             assert!(
                 mcp_sse_plan(sse_headers, &call).is_some(),
                 "held verb `{held}` must stream"
@@ -1340,11 +1387,10 @@ mod tests {
     /// timeout.
     #[test]
     fn sse_selection_folds_repeated_accept_field_lines() {
-        let ask = serde_json::json!({
+        let ask = parse_req(serde_json::json!({
             "jsonrpc": "2.0", "id": 1, "method": "tools/call",
             "params": { "name": "ask_user", "arguments": { "question": "go?" } },
-        })
-        .to_string();
+        }));
         let split = "POST /mcp HTTP/1.1\r\nHost: h\r\nAccept: application/json\r\nAccept: text/event-stream\r\n\r\n";
         assert!(mcp_sse_plan(split, &ask).is_some());
         let rejected = "POST /mcp HTTP/1.1\r\nHost: h\r\nAccept: application/json\r\nAccept: text/event-stream;q=0\r\n\r\n";

--- a/src/bin/caller/web_gateway/mcp_gate.rs
+++ b/src/bin/caller/web_gateway/mcp_gate.rs
@@ -601,12 +601,9 @@ pub(crate) async fn handle_mcp_http_request(
     })
 }
 
-/// The held-POST verbs whose calls can outlive client and proxy idle
-/// timeouts (an ask waits up to 900 s on the human; a display request
-/// waits on the grant): per-request SSE keeps those responses warm.
-/// Everything shorter answers as plain JSON — `events` and the remote
-/// waits already self-chunk under 60 s.
-const MCP_SSE_STREAMED_TOOLS: [&str; 2] = ["ask_user", "request_user_display"];
+// Which verbs stream is not this gate's call: `crate::mcp` classifies
+// its held-POST tools (`mcp_held_post_tool`) beside its other per-tool
+// gates, and this file only carries the SSE mechanics.
 const MCP_SSE_KEEPALIVE_SECS: u64 = 15;
 /// A progress token is a correlation handle (spec: string or integer),
 /// not a payload: reflecting it in every keepalive means an unbounded
@@ -657,7 +654,10 @@ struct McpSsePlan {
 }
 
 fn mcp_sse_plan(header_text: &str, body_text: &str) -> Option<McpSsePlan> {
-    let accepts_sse = http_header_value(header_text, "accept").is_some_and(accepts_event_stream);
+    // `Accept` is list-valued and may legally arrive split across
+    // repeated field lines; fold every line (the parser is an ANY over
+    // comma-separated ranges, so per-line ANY equals the joined list).
+    let accepts_sse = http_header_values(header_text, "accept").any(accepts_event_stream);
     if !accepts_sse {
         return None;
     }
@@ -673,11 +673,11 @@ fn mcp_sse_plan(header_text: &str, body_text: &str) -> Option<McpSsePlan> {
         .get("name")
         .and_then(serde_json::Value::as_str)
         .unwrap_or("");
-    if !MCP_SSE_STREAMED_TOOLS.contains(&name) {
+    if !crate::mcp::mcp_held_post_tool(name) {
         static NULL_ARGS: serde_json::Value = serde_json::Value::Null;
         let args = params.get("arguments").unwrap_or(&NULL_ARGS);
         let tool = crate::mcp::facade_resolved_tool(name, args)?;
-        if !MCP_SSE_STREAMED_TOOLS.contains(&tool) {
+        if !crate::mcp::mcp_held_post_tool(tool) {
             return None;
         }
     }
@@ -1295,6 +1295,41 @@ mod tests {
                 .unwrap()
                 .progress_token,
             Some(serde_json::json!(42))
+        );
+        // Every held verb streams, not just the ask pair: the
+        // consent-gated and long-poll tools ride the same
+        // classification.
+        for held in crate::mcp::MCP_HELD_POST_TOOLS {
+            let call = serde_json::json!({
+                "jsonrpc": "2.0", "id": 10, "method": "tools/call",
+                "params": { "name": held, "arguments": {} },
+            })
+            .to_string();
+            assert!(
+                mcp_sse_plan(sse_headers, &call).is_some(),
+                "held verb `{held}` must stream"
+            );
+        }
+    }
+
+    /// `Accept` is list-valued: a client may legally split the list
+    /// across repeated field lines, and selection folds every line —
+    /// a first-line-only read would silently downgrade a compliant
+    /// held call to the plain JSON answer that dies at the idle
+    /// timeout.
+    #[test]
+    fn sse_selection_folds_repeated_accept_field_lines() {
+        let ask = serde_json::json!({
+            "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+            "params": { "name": "ask_user", "arguments": { "question": "go?" } },
+        })
+        .to_string();
+        let split = "POST /mcp HTTP/1.1\r\nHost: h\r\nAccept: application/json\r\nAccept: text/event-stream\r\n\r\n";
+        assert!(mcp_sse_plan(split, &ask).is_some());
+        let rejected = "POST /mcp HTTP/1.1\r\nHost: h\r\nAccept: application/json\r\nAccept: text/event-stream;q=0\r\n\r\n";
+        assert!(
+            mcp_sse_plan(rejected, &ask).is_none(),
+            "a q=0 rejection on a later line is still a rejection"
         );
     }
 


### PR DESCRIPTION
M2's remaining transport slice per the MCP Control Lane design (~/mcp-control-next.md): a `POST /mcp` `tools/call` whose client accepts `text/event-stream` and whose named (or facade-resolved) tool is a held-POST verb (`ask_user`, `request_user_display`) answers as a per-request SSE stream — 15 s keepalives (spec-shaped `notifications/progress` when the request carries `_meta.progressToken`) defeat client/proxy idle timeouts on waits up to 900 s, then the final JSON-RPC response closes the stream. Everything else keeps the plain-JSON leg; `GET /mcp` stays 405 (the 2026-07-28 stateless shape). Authorization unchanged: the per-tool decision runs inside dispatch; SSE mode selection is argv-only (values never parsed pre-auth, the #891 discipline).