### PR TITLE
Make Xvfb allocation fail closed

### DIFF
--- a/crates/intendant-platform/src/platform.rs
+++ b/crates/intendant-platform/src/platform.rs
@@ -140,6 +140,27 @@ pub fn request_graceful_terminate(pid: u32) -> bool {
     }
 }
 
+/// Create a FIFO for Unix-only lock-file regression tests. Keeping this tiny
+/// wrapper here preserves `platform.rs` as the crate's documented unsafe
+/// island; production code never calls it.
+#[cfg(all(test, target_os = "linux"))]
+pub(crate) fn create_test_fifo(path: &std::path::Path) -> std::io::Result<()> {
+    use std::os::unix::ffi::OsStrExt as _;
+
+    let path = std::ffi::CString::new(path.as_os_str().as_bytes()).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "FIFO test path contains an interior NUL",
+        )
+    })?;
+    // SAFETY: `path` is a live NUL-terminated string and mode 0600 is valid.
+    if unsafe { libc::mkfifo(path.as_ptr(), 0o600) } == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
 /// Return the main display's dimensions on macOS, in **points** (the
 /// logical/global display coordinate space), not backing pixels.
 ///

--- a/crates/intendant-platform/src/vision.rs
+++ b/crates/intendant-platform/src/vision.rs
@@ -1,5 +1,9 @@
 use intendant_core::error::CallerError;
 #[cfg(target_os = "linux")]
+use std::io::Read as _;
+#[cfg(target_os = "linux")]
+use std::os::unix::fs::{FileTypeExt as _, OpenOptionsExt as _};
+#[cfg(target_os = "linux")]
 use std::process::Stdio;
 use tokio::process::Child;
 
@@ -12,110 +16,78 @@ pub struct DisplayConfig {
     pub height: u32,
 }
 
-// ── X11 lock file helpers (Linux only) ──────────────────────────────────────
-
-/// Read the PID from an X lock file. Returns `None` if the file can't be read or parsed.
 #[cfg(target_os = "linux")]
-pub(crate) fn read_lock_pid(lock_path: &str) -> Option<u32> {
-    let contents = std::fs::read_to_string(lock_path).ok()?;
-    contents.trim().parse().ok()
+fn lock_path_in(lock_dir: &std::path::Path, display_id: u32) -> std::path::PathBuf {
+    lock_dir.join(format!(".X{display_id}-lock"))
 }
 
-/// Check if a lock file is stale (the PID inside is no longer running).
 #[cfg(target_os = "linux")]
-pub fn is_lock_stale(lock_path: &str) -> bool {
-    match read_lock_pid(lock_path) {
-        Some(pid) => !crate::platform::process_alive(pid),
-        None => false, // can't read/parse → assume not stale
-    }
+fn socket_path_in(lock_dir: &std::path::Path, display_id: u32) -> std::path::PathBuf {
+    lock_dir.join(".X11-unix").join(format!("X{display_id}"))
 }
 
-/// Check whether the process owning a lock file is an Xvfb instance for the given display.
-/// Returns true if the process cmdline starts with "Xvfb :<id>".
-#[cfg(target_os = "linux")]
-pub fn is_our_xvfb(lock_path: &str, display_id: u32) -> bool {
-    let pid = match read_lock_pid(lock_path) {
-        Some(p) => p,
-        None => return false,
-    };
-    let cmdline_str = match crate::platform::process_cmdline(pid) {
-        Some(s) => s,
-        None => return false,
-    };
-    let expected = format!("Xvfb :{}", display_id);
-    cmdline_str.starts_with(&expected)
+fn path_entry_absent(path: &std::path::Path) -> bool {
+    matches!(
+        std::fs::symlink_metadata(path),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound
+    )
 }
 
-/// Kill the process that owns a lock file (if alive) and clean up.
+/// Whether neither an X lock nor socket directory entry exists for a display.
+/// `symlink_metadata` deliberately treats dangling symlinks as occupied.
+pub fn virtual_display_slot_is_absent(lock_dir: &std::path::Path, display_id: u32) -> bool {
+    path_entry_absent(&lock_dir.join(format!(".X{display_id}-lock")))
+        && path_entry_absent(&lock_dir.join(".X11-unix").join(format!("X{display_id}")))
+}
+
 #[cfg(target_os = "linux")]
-pub fn kill_and_reclaim(lock_path: &str, display_id: u32) {
-    let Some(pid) = read_lock_pid(lock_path) else {
-        eprintln!(
-            "[vision] refusing to reclaim X lock {} for display {}: no readable pid",
-            lock_path, display_id
-        );
-        return;
-    };
-    // Send SIGKILL via the kill command — the process is an orphaned Xvfb we're reclaiming
-    match std::process::Command::new("kill")
-        .args(["-9", &pid.to_string()])
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
+fn read_lock_pid_path(lock_path: &std::path::Path) -> Option<u32> {
+    const MAX_X_LOCK_BYTES: usize = 32;
+
+    let entry_metadata = std::fs::symlink_metadata(lock_path).ok()?;
+    if !entry_metadata.file_type().is_file()
+        || entry_metadata.len() == 0
+        || entry_metadata.len() > MAX_X_LOCK_BYTES as u64
     {
-        Ok(status) if status.success() => {
-            for _ in 0..10 {
-                if !crate::platform::process_alive(pid) {
-                    remove_stale_lock(display_id);
-                    return;
-                }
-                std::thread::sleep(std::time::Duration::from_millis(50));
-            }
-            eprintln!(
-                "[vision] kill -9 reported success for Xvfb pid {} on display {}, but process is still alive; leaving lock in place",
-                pid, display_id
-            );
-        }
-        Ok(status) => {
-            eprintln!(
-                "[vision] kill -9 failed for Xvfb pid {} on display {} with status {}; leaving lock in place",
-                pid, display_id, status
-            );
-        }
-        Err(err) => {
-            eprintln!(
-                "[vision] failed to run kill for Xvfb pid {} on display {}: {}; leaving lock in place",
-                pid, display_id, err
-            );
-        }
+        return None;
     }
+    let mut file = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(lock_path)
+        .ok()?;
+    let metadata = file.metadata().ok()?;
+    if !metadata.file_type().is_file()
+        || metadata.len() == 0
+        || metadata.len() > MAX_X_LOCK_BYTES as u64
+    {
+        return None;
+    }
+    let mut bytes = [0_u8; MAX_X_LOCK_BYTES + 1];
+    let read = file.read(&mut bytes).ok()?;
+    if read == 0 || read > MAX_X_LOCK_BYTES {
+        return None;
+    }
+    let pid = std::str::from_utf8(&bytes[..read])
+        .ok()?
+        .trim()
+        .parse::<u32>()
+        .ok()?;
+    let pid_t = libc::pid_t::try_from(pid).ok()?;
+    (pid_t > 0).then_some(pid)
 }
 
-/// Remove a stale X lock file and its socket.
 #[cfg(target_os = "linux")]
-pub fn remove_stale_lock(id: u32) {
-    let lock = format!("/tmp/.X{}-lock", id);
-    let socket = format!("/tmp/.X11-unix/X{}", id);
-    let _ = std::fs::remove_file(&lock);
-    let _ = std::fs::remove_file(&socket);
+fn xvfb_state_established(lock_dir: &std::path::Path, display_id: u32, pid: u32) -> bool {
+    read_lock_pid_path(&lock_path_in(lock_dir, display_id)) == Some(pid)
+        && std::fs::symlink_metadata(socket_path_in(lock_dir, display_id))
+            .is_ok_and(|metadata| metadata.file_type().is_socket())
 }
 
-// Non-Linux stubs — these are called from debug.rs and XvfbGuard::Drop.
-#[cfg(not(target_os = "linux"))]
-#[allow(dead_code)]
-pub fn is_lock_stale(_lock_path: &str) -> bool {
-    false
+#[cfg(target_os = "linux")]
+fn owned_xvfb_paths_are_cleared(lock_dir: &std::path::Path, display_id: u32) -> bool {
+    virtual_display_slot_is_absent(lock_dir, display_id)
 }
-#[cfg(not(target_os = "linux"))]
-#[allow(dead_code)]
-pub fn is_our_xvfb(_lock_path: &str, _display_id: u32) -> bool {
-    false
-}
-#[cfg(not(target_os = "linux"))]
-#[allow(dead_code)]
-pub fn kill_and_reclaim(_lock_path: &str, _display_id: u32) {}
-#[cfg(not(target_os = "linux"))]
-pub fn remove_stale_lock(_id: u32) {}
 
 // ── Display config ──────────────────────────────────────────────────────────
 
@@ -124,19 +96,24 @@ pub fn remove_stale_lock(_id: u32) {}
 /// Resolutions are chosen to minimize token cost while maintaining UI readability,
 /// matching each provider's internal image processing pipeline so that the Xvfb
 /// resolution = screenshot resolution = what the model sees (no scaling).
-pub fn display_config_for_provider(provider_name: &str) -> DisplayConfig {
-    let (width, height) = match provider_name {
+/// Returns `None` when every virtual-display slot is occupied.
+pub fn display_config_for_provider(provider_name: &str) -> Option<DisplayConfig> {
+    let (width, height) = display_resolution_for_provider(provider_name);
+    Some(DisplayConfig {
+        target: DisplayTarget::Virtual {
+            id: find_free_display()?,
+        },
+        width,
+        height,
+    })
+}
+
+pub fn display_resolution_for_provider(provider_name: &str) -> (u32, u32) {
+    match provider_name {
         "openai" => (1024, 768),    // 3 tiles of 512x512 → ~595 tokens
         "anthropic" => (819, 1456), // 9:16 within 1568px limit → ~1590 tokens
         "gemini" => (768, 1024),    // 2 tiles of 768x768 → ~516 tokens
         _ => (1024, 768),           // safe default
-    };
-    DisplayConfig {
-        target: DisplayTarget::Virtual {
-            id: find_free_display(),
-        },
-        width,
-        height,
     }
 }
 
@@ -155,55 +132,35 @@ const VIRTUAL_DISPLAY_END: u32 = 200;
 /// Find a free X display number, preferring :99.
 ///
 /// Strategy for each candidate display:
-/// 1. No lock file → use it
-/// 2. Lock file with dead PID → clean up and use it
-/// 3. Lock file with live Xvfb process for this display → kill and reclaim it
-///    (it's an orphan from a previous intendant session)
-/// 4. Lock file with some other live process → skip to next display
+/// 1. No lock or socket → use it
+/// 2. Any lock or socket entry → leave it untouched and skip
 #[cfg(target_os = "linux")]
-fn find_free_display() -> u32 {
+fn find_free_display() -> Option<u32> {
     find_free_display_in(std::path::Path::new("/tmp"), &[])
 }
 
-/// Lock-dir-injectable core of [`find_free_display`]. Tests pin a temp dir
-/// so the scan never probes the real X11 locks — a live :99 on a shared box
-/// (or a CI runner that also hosts a daemon) must never be examined, let
-/// alone reclaimed, by a unit test.
+/// Lock-dir-injectable core of [`find_free_display`]. Tests pin a temp dir so
+/// the scan never probes the machine's real X11 entries.
 ///
 /// `exclude` lists display numbers this process knows are live and its own
-/// (held `XvfbGuard`s, registered capture sessions). Step 3's orphan
-/// reclaim would otherwise kill them: a guard-held `:99` looks exactly like
-/// an orphaned Xvfb to the lock-file scan, so allocating a *second* display
-/// must skip it rather than reclaim it.
+/// (held `XvfbGuard`s, registered capture sessions).
 #[cfg(target_os = "linux")]
-fn find_free_display_in(lock_dir: &std::path::Path, exclude: &[u32]) -> u32 {
+fn find_free_display_in(lock_dir: &std::path::Path, exclude: &[u32]) -> Option<u32> {
     for id in PREFERRED_DISPLAY..VIRTUAL_DISPLAY_END {
         if exclude.contains(&id) {
             continue;
         }
-        let lock = lock_dir.join(format!(".X{}-lock", id));
-        if !lock.exists() {
-            return id;
-        }
-        let lock = lock.to_string_lossy();
-        // Lock file exists — check if the owning process is dead
-        if is_lock_stale(&lock) {
-            remove_stale_lock(id);
-            return id;
-        }
-        // Process is alive — reclaim if it's an orphaned Xvfb for this display
-        if is_our_xvfb(&lock, id) {
-            kill_and_reclaim(&lock, id);
-            return id;
+        if virtual_display_slot_is_absent(lock_dir, id) {
+            return Some(id);
         }
     }
-    199 // fallback
+    None
 }
 
 /// On non-Linux platforms, return 0 as a sentinel for the native display.
 #[cfg(not(target_os = "linux"))]
-fn find_free_display() -> u32 {
-    0
+fn find_free_display() -> Option<u32> {
+    Some(0)
 }
 
 /// Allocate a virtual-display config at an explicit resolution, for callers
@@ -211,22 +168,41 @@ fn find_free_display() -> u32 {
 /// pipeline (the dashboard's keyless "new virtual display" path). Same
 /// allocator as [`display_config_for_provider`], provider-independent size.
 ///
-/// `exclude` must list virtual-display numbers the caller already holds
-/// alive (guards, registered capture sessions) so the allocator never
-/// reclaims them as orphans — see [`find_free_display_in`].
-pub fn virtual_display_config(width: u32, height: u32, exclude: &[u32]) -> DisplayConfig {
+/// `exclude` must list virtual-display numbers the caller already holds alive.
+/// Returns `None` when every slot is occupied or excluded.
+pub fn virtual_display_config(width: u32, height: u32, exclude: &[u32]) -> Option<DisplayConfig> {
     #[cfg(target_os = "linux")]
-    let id = find_free_display_in(std::path::Path::new("/tmp"), exclude);
+    return virtual_display_config_in(std::path::Path::new("/tmp"), width, height, exclude);
     #[cfg(not(target_os = "linux"))]
     let id = {
         let _ = exclude;
-        find_free_display()
+        find_free_display()?
     };
-    DisplayConfig {
+    #[cfg(not(target_os = "linux"))]
+    Some(DisplayConfig {
         target: DisplayTarget::Virtual { id },
         width,
         height,
-    }
+    })
+}
+
+/// Lock-directory-injectable Linux allocator used by hermetic callers and
+/// tests. It has the same fail-closed semantics as [`virtual_display_config`]
+/// and never mutates the supplied directory.
+#[cfg(target_os = "linux")]
+#[doc(hidden)]
+pub fn virtual_display_config_in(
+    lock_dir: &std::path::Path,
+    width: u32,
+    height: u32,
+    exclude: &[u32],
+) -> Option<DisplayConfig> {
+    let id = find_free_display_in(lock_dir, exclude)?;
+    Some(DisplayConfig {
+        target: DisplayTarget::Virtual { id },
+        width,
+        height,
+    })
 }
 
 /// Whether a live X server socket exists for virtual display `:id`.
@@ -275,18 +251,74 @@ pub fn conventional_virtual_display() -> Option<u32> {
 
 // ── Xvfb guard ──────────────────────────────────────────────────────────────
 
-/// Guard that kills the Xvfb process when dropped.
-/// Cleans up the lock file and socket after killing.
+/// Guard that kills the exact child Xvfb process when dropped.
 pub struct XvfbGuard {
     child: Child,
+    #[cfg(target_os = "linux")]
     display_id: u32,
+    #[cfg(target_os = "linux")]
+    pid: u32,
+}
+
+impl XvfbGuard {
+    /// Ask this guard's exact child to exit and reap it without blocking a
+    /// runtime worker. Graceful waiting is bounded; the fallback hard-kills
+    /// only the spawned child. X lock/socket residue is never removed because
+    /// its ownership is ambiguous once the child has exited.
+    pub async fn shutdown(mut self) {
+        #[cfg(target_os = "linux")]
+        {
+            match self.child.try_wait() {
+                Ok(Some(_)) => {
+                    self.report_residual_state();
+                    return;
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    eprintln!("[vision] failed to inspect Xvfb child before shutdown: {err}");
+                    let _ = self.child.kill().await;
+                    return;
+                }
+            }
+
+            if crate::platform::request_graceful_terminate(self.pid) {
+                match tokio::time::timeout(std::time::Duration::from_millis(500), self.child.wait())
+                    .await
+                {
+                    Ok(Ok(_)) => {
+                        self.report_residual_state();
+                        return;
+                    }
+                    Ok(Err(err)) => {
+                        eprintln!("[vision] failed to reap Xvfb child after SIGTERM: {err}");
+                    }
+                    Err(_) => {}
+                }
+            }
+        }
+
+        // `Child::kill` targets this guard's exact spawned child and awaits
+        // its exit. Drop remains the nonblocking fallback if this future is
+        // cancelled before the await completes.
+        let _ = self.child.kill().await;
+    }
+
+    #[cfg(target_os = "linux")]
+    fn report_residual_state(&self) {
+        if !owned_xvfb_paths_are_cleared(std::path::Path::new("/tmp"), self.display_id) {
+            eprintln!(
+                "[vision] Xvfb exited but left state on display {}; preserving it",
+                self.display_id
+            );
+        }
+    }
 }
 
 impl Drop for XvfbGuard {
     fn drop(&mut self) {
+        // Drop cannot wait: hard-kill this guard's exact spawned child and
+        // leave reaping to Tokio. Normal async teardown calls `shutdown`.
         let _ = self.child.start_kill();
-        // Clean up lock file and socket so the display number can be reused
-        remove_stale_lock(self.display_id);
     }
 }
 
@@ -309,7 +341,7 @@ pub async fn launch_display(config: &DisplayConfig) -> Result<XvfbGuard, CallerE
     let display_arg = format!(":{}", display_id);
     let screen_arg = format!("{}x{}x24", config.width, config.height);
 
-    let child = tokio::process::Command::new("Xvfb")
+    let mut child = tokio::process::Command::new("Xvfb")
         .args([&display_arg, "-screen", "0", &screen_arg, "-ac"])
         .stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -338,6 +370,26 @@ pub async fn launch_display(config: &DisplayConfig) -> Result<XvfbGuard, CallerE
         )));
     }
 
+    if child
+        .try_wait()
+        .map_err(|err| CallerError::Config(format!("Failed to inspect Xvfb: {err}")))?
+        .is_some()
+    {
+        return Err(CallerError::Config(format!(
+            "Xvfb on display {display_arg} exited during startup"
+        )));
+    }
+    let pid = child.id().ok_or_else(|| {
+        CallerError::Config(format!(
+            "Xvfb on display {display_arg} has no observable process id"
+        ))
+    })?;
+    if !xvfb_state_established(std::path::Path::new("/tmp"), display_id, pid) {
+        return Err(CallerError::Config(format!(
+            "Xvfb on display {display_arg} did not establish its expected lock and socket"
+        )));
+    }
+
     // Preserve the user's original DISPLAY before overriding with virtual display.
     // This is used by DisplayTarget::UserSession to resolve the user's actual display.
     if std::env::var("INTENDANT_USER_DISPLAY").is_err() {
@@ -349,7 +401,11 @@ pub async fn launch_display(config: &DisplayConfig) -> Result<XvfbGuard, CallerE
     // Set DISPLAY env var so the runtime subprocess inherits it
     std::env::set_var("DISPLAY", &display_arg);
 
-    Ok(XvfbGuard { child, display_id })
+    Ok(XvfbGuard {
+        child,
+        display_id,
+        pid,
+    })
 }
 
 /// Virtual display launch is not available on non-Linux platforms.
@@ -450,80 +506,181 @@ pub fn detect_x11_display() -> Option<String> {
 mod tests {
     use super::*;
 
-    // Crate-local env lock, same role as the caller's
-    // `test_support::TEST_ENV_LOCK`: serializes env-mutating tests within
-    // this test binary. A lock cannot serialize across crates' separate
-    // test processes anyway, so crate-local is exactly as strong.
-    #[cfg(not(target_os = "macos"))]
-    static TEST_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-
     #[test]
     fn display_config_openai() {
-        let config = display_config_for_provider("openai");
-        assert_eq!(config.width, 1024);
-        assert_eq!(config.height, 768);
+        assert_eq!(display_resolution_for_provider("openai"), (1024, 768));
     }
 
     #[test]
     fn display_config_anthropic() {
-        let config = display_config_for_provider("anthropic");
-        assert_eq!(config.width, 819);
-        assert_eq!(config.height, 1456);
+        assert_eq!(display_resolution_for_provider("anthropic"), (819, 1456));
     }
 
     #[test]
     fn display_config_gemini() {
-        let config = display_config_for_provider("gemini");
-        assert_eq!(config.width, 768);
-        assert_eq!(config.height, 1024);
+        assert_eq!(display_resolution_for_provider("gemini"), (768, 1024));
     }
 
     #[test]
     fn display_config_unknown_defaults_to_openai() {
-        let config = display_config_for_provider("unknown-provider");
-        assert_eq!(config.width, 1024);
-        assert_eq!(config.height, 768);
+        assert_eq!(
+            display_resolution_for_provider("unknown-provider"),
+            (1024, 768)
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    fn test_lock_dir() -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(tmp.path().join(".X11-unix")).unwrap();
+        tmp
     }
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn find_free_display_avoids_existing() {
-        let tmp = tempfile::tempdir().unwrap();
-        // :99 is occupied by a live, non-Xvfb process (this test itself), so
-        // the scan must leave it alone and settle on :100.
-        std::fs::write(
-            tmp.path().join(".X99-lock"),
-            format!("{}\n", std::process::id()),
-        )
-        .unwrap();
-        assert_eq!(find_free_display_in(tmp.path(), &[]), 100);
+    fn exited_owned_xvfb_is_reusable_only_after_its_paths_are_gone() {
+        let tmp = test_lock_dir();
+        assert!(owned_xvfb_paths_are_cleared(tmp.path(), 99));
+
+        let lock = lock_path_in(tmp.path(), 99);
+        std::fs::write(&lock, "replacement\n").unwrap();
+        assert!(!owned_xvfb_paths_are_cleared(tmp.path(), 99));
+        assert!(lock.exists());
+
+        std::fs::remove_file(&lock).unwrap();
+        let socket = socket_path_in(tmp.path(), 99);
+        std::fs::write(&socket, b"replacement").unwrap();
+        assert!(!owned_xvfb_paths_are_cleared(tmp.path(), 99));
+        assert!(socket.exists());
     }
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn find_free_display_skips_excluded_ids_without_reclaiming() {
-        let tmp = tempfile::tempdir().unwrap();
-        // :99 has a stale lock (dead pid). Without the exclusion the scan
-        // would clean it up and hand out 99; a caller that still holds :99
-        // alive (guard, capture session) must get the next number and the
-        // lock file must survive untouched.
-        let lock = tmp.path().join(".X99-lock");
-        std::fs::write(&lock, " 1999999999\n").unwrap();
-        assert_eq!(find_free_display_in(tmp.path(), &[99]), 100);
-        assert!(lock.exists(), "excluded display's lock must not be touched");
-        assert_eq!(find_free_display_in(tmp.path(), &[99, 100, 101]), 102);
+    fn owned_xvfb_startup_requires_matching_pid_and_socket() {
+        let tmp = test_lock_dir();
+        std::fs::write(lock_path_in(tmp.path(), 99), "4201\n").unwrap();
+        let _listener =
+            std::os::unix::net::UnixListener::bind(socket_path_in(tmp.path(), 99)).unwrap();
+
+        assert!(xvfb_state_established(tmp.path(), 99, 4201));
+        assert!(!xvfb_state_established(tmp.path(), 99, 9999));
     }
 
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn unowned_lock_is_skipped_without_mutation() {
+        let tmp = test_lock_dir();
+        let lock = lock_path_in(tmp.path(), 99);
+        std::fs::write(&lock, "4101\n").unwrap();
+
+        assert_eq!(find_free_display_in(tmp.path(), &[]), Some(100));
+        assert_eq!(std::fs::read(&lock).unwrap(), b"4101\n");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn injectable_virtual_config_skips_occupied_99() {
+        let tmp = test_lock_dir();
+        let lock = lock_path_in(tmp.path(), 99);
+        std::fs::write(&lock, "foreign\n").unwrap();
+
+        let config = virtual_display_config_in(tmp.path(), 1280, 800, &[]).unwrap();
+        assert!(matches!(config.target, DisplayTarget::Virtual { id: 100 }));
+        assert_eq!(std::fs::read(lock).unwrap(), b"foreign\n");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn dangling_symlinks_are_occupied_and_untouched() {
+        let tmp = test_lock_dir();
+        let lock = lock_path_in(tmp.path(), 99);
+        let socket = socket_path_in(tmp.path(), 100);
+        std::os::unix::fs::symlink("missing-lock-target", &lock).unwrap();
+        std::os::unix::fs::symlink("missing-socket-target", &socket).unwrap();
+
+        assert_eq!(find_free_display_in(tmp.path(), &[]), Some(101));
+        assert!(std::fs::symlink_metadata(&lock)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert!(std::fs::symlink_metadata(&socket)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn fifo_lock_is_rejected_without_blocking_or_mutation() {
+        let tmp = test_lock_dir();
+        let lock = lock_path_in(tmp.path(), 99);
+        crate::platform::create_test_fifo(&lock).unwrap();
+
+        assert_eq!(read_lock_pid_path(&lock), None);
+        assert_eq!(find_free_display_in(tmp.path(), &[]), Some(100));
+        assert!(std::fs::symlink_metadata(&lock)
+            .unwrap()
+            .file_type()
+            .is_fifo());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn oversized_and_malformed_locks_are_bounded_and_untouched() {
+        let tmp = test_lock_dir();
+        let oversized_lock = lock_path_in(tmp.path(), 99);
+        let malformed_lock = lock_path_in(tmp.path(), 100);
+        std::fs::write(&oversized_lock, vec![b'7'; 4096]).unwrap();
+        std::fs::write(&malformed_lock, "not-a-pid\n").unwrap();
+
+        assert_eq!(read_lock_pid_path(&oversized_lock), None);
+        assert_eq!(read_lock_pid_path(&malformed_lock), None);
+        assert_eq!(find_free_display_in(tmp.path(), &[]), Some(101));
+        assert_eq!(std::fs::metadata(&oversized_lock).unwrap().len(), 4096);
+        assert_eq!(std::fs::read(&malformed_lock).unwrap(), b"not-a-pid\n");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn lock_pid_parser_requires_positive_pid_t_range() {
+        let tmp = test_lock_dir();
+        let lock = lock_path_in(tmp.path(), 99);
+        std::fs::write(&lock, " 42\n").unwrap();
+        assert_eq!(read_lock_pid_path(&lock), Some(42));
+        std::fs::write(&lock, "0\n").unwrap();
+        assert_eq!(read_lock_pid_path(&lock), None);
+        std::fs::write(&lock, format!("{}\n", i64::from(i32::MAX) + 1)).unwrap();
+        assert_eq!(read_lock_pid_path(&lock), None);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn exhausted_range_returns_none_without_mutation() {
+        let tmp = test_lock_dir();
+        for id in PREFERRED_DISPLAY..VIRTUAL_DISPLAY_END {
+            std::fs::write(lock_path_in(tmp.path(), id), format!("occupied-{id}\n")).unwrap();
+        }
+
+        assert_eq!(find_free_display_in(tmp.path(), &[]), None);
+        assert_eq!(
+            std::fs::read(lock_path_in(tmp.path(), PREFERRED_DISPLAY)).unwrap(),
+            b"occupied-99\n"
+        );
+        assert_eq!(
+            std::fs::read(lock_path_in(tmp.path(), VIRTUAL_DISPLAY_END - 1)).unwrap(),
+            b"occupied-199\n"
+        );
+        assert!(virtual_display_config_in(tmp.path(), 1280, 800, &[]).is_none());
+    }
+
+    #[cfg(not(target_os = "linux"))]
     #[test]
     fn virtual_display_config_carries_requested_resolution() {
-        let config = virtual_display_config(1920, 1080, &[]);
+        let config = virtual_display_config(1920, 1080, &[]).unwrap();
         assert_eq!((config.width, config.height), (1920, 1080));
         let DisplayTarget::Virtual { id } = config.target else {
             panic!("virtual_display_config must target a virtual display");
         };
-        #[cfg(target_os = "linux")]
-        assert!((99..200).contains(&id));
-        #[cfg(not(target_os = "linux"))]
         assert_eq!(id, 0);
     }
 
@@ -534,11 +691,9 @@ mod tests {
         std::fs::write(tmp.path().join("X0"), b"").unwrap();
         std::fs::write(tmp.path().join("X99"), b"").unwrap();
         std::fs::write(tmp.path().join("X250"), b"").unwrap();
-        // User-session servers (:0) and out-of-range numbers never count.
         assert!(!virtual_display_socket_exists_in(tmp.path(), 0));
         assert!(virtual_display_socket_exists_in(tmp.path(), 99));
         assert!(!virtual_display_socket_exists_in(tmp.path(), 250));
-        // In-range but no socket.
         assert!(!virtual_display_socket_exists_in(tmp.path(), 150));
     }
 
@@ -546,101 +701,5 @@ mod tests {
     #[test]
     fn virtual_display_socket_probe_is_linux_only() {
         assert!(!virtual_display_socket_exists(99));
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn is_lock_stale_nonexistent_file() {
-        assert!(!is_lock_stale("/tmp/.X_nonexistent_test-lock"));
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn stale_lock_detection_and_cleanup() {
-        // Create a lock file with a definitely-dead PID
-        let test_id = 198; // high number unlikely to conflict
-        let lock = format!("/tmp/.X{}-lock", test_id);
-        let socket_dir = "/tmp/.X11-unix";
-        let socket = format!("{}/X{}", socket_dir, test_id);
-        // Use PID 1999999999 which cannot exist
-        std::fs::write(&lock, " 1999999999\n").unwrap();
-        assert!(is_lock_stale(&lock));
-        remove_stale_lock(test_id);
-        assert!(!std::path::Path::new(&lock).exists());
-        // Clean up socket if it was created
-        let _ = std::fs::remove_file(&socket);
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn read_lock_pid_nonexistent() {
-        assert_eq!(read_lock_pid("/tmp/.X_nonexistent_test-lock"), None);
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn read_lock_pid_valid() {
-        let lock = "/tmp/.X197-test-lock";
-        std::fs::write(lock, " 12345\n").unwrap();
-        assert_eq!(read_lock_pid(lock), Some(12345));
-        let _ = std::fs::remove_file(lock);
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn is_our_xvfb_dead_pid() {
-        // Lock with dead PID — is_our_xvfb should return false (can't read cmdline)
-        let lock = "/tmp/.X197-test-lock2";
-        std::fs::write(lock, " 1999999999\n").unwrap();
-        assert!(!is_our_xvfb(lock, 197));
-        let _ = std::fs::remove_file(lock);
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn preferred_display_is_99() {
-        assert_eq!(PREFERRED_DISPLAY, 99);
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn find_free_display_prefers_99() {
-        // When :99 is free, find_free_display should return 99
-        let lock = format!("/tmp/.X{}-lock", PREFERRED_DISPLAY);
-        if !std::path::Path::new(&lock).exists() {
-            assert_eq!(find_free_display(), 99);
-        }
-        // If :99 is taken we can only assert >= 99
-        assert!(find_free_display() >= 99);
-    }
-
-    #[cfg(not(target_os = "macos"))]
-    #[test]
-    fn is_display_accessible_no_display_set() {
-        // Serialize with every other env-mutating test: this test unsets
-        // DISPLAY, and is_display_accessible() itself re-sets it as a side
-        // effect when it detects a live X socket.
-        let _guard = TEST_ENV_LOCK.blocking_lock();
-        let prev = std::env::var("DISPLAY").ok();
-        std::env::remove_var("DISPLAY");
-        // With DISPLAY unset the function deliberately probes /tmp/.X11-unix
-        // and may legitimately find (and authorize against) a real X server —
-        // on such a box "inaccessible" is simply not the true state. Only
-        // assert the no-display outcome where no socket exists (CI runners,
-        // headless boxes) — the same environment-conditional pattern as
-        // find_free_display_prefers_99 above.
-        #[cfg(not(target_os = "windows"))]
-        let have_socket = detect_x11_display().is_some();
-        #[cfg(target_os = "windows")]
-        let have_socket = false;
-        if !have_socket {
-            assert!(!is_display_accessible());
-        }
-        // Restore DISPLAY exactly; the probe may have set it as a side
-        // effect, and leaking it would perturb every later display test.
-        match prev {
-            Some(d) => std::env::set_var("DISPLAY", d),
-            None => std::env::remove_var("DISPLAY"),
-        }
     }
 }

--- a/src/bin/caller/codex_cloud_attach.rs
+++ b/src/bin/caller/codex_cloud_attach.rs
@@ -1612,6 +1612,8 @@ async fn start_worker_display_session(
     // `state` only receives the Xvfb guard, which exists on Linux alone.
     #[cfg(not(target_os = "linux"))]
     let _ = &mut *state;
+    #[cfg(target_os = "linux")]
+    let mut launched_xvfb = None;
 
     let mock_synthetic = std::env::var("INTENDANT_MOCK_DISPLAY").as_deref() == Ok("synthetic")
         && std::env::var("PROVIDER").as_deref() == Ok("mock");
@@ -1633,16 +1635,20 @@ async fn start_worker_display_session(
             let id = match existing {
                 Some(id) => id,
                 None => {
-                    let id = crate::vision::conventional_virtual_display().unwrap_or(99);
-                    let config = crate::vision::DisplayConfig {
-                        target: intendant_platform::DisplayTarget::Virtual { id },
-                        width: 1280,
-                        height: 800,
+                    let config = worker_virtual_display_config_in(std::path::Path::new("/tmp"))?;
+                    let intendant_platform::DisplayTarget::Virtual { id } = config.target else {
+                        return Err(
+                            "worker display allocator returned a non-virtual target".to_string()
+                        );
                     };
                     let guard = crate::vision::launch_display(&config)
                         .await
                         .map_err(|e| format!("launch Xvfb for the worker display: {e}"))?;
-                    state._xvfb = Some(guard);
+                    // Keep the exact-child guard local until the capture
+                    // backend and session have both started. Any startup
+                    // error before then drops it immediately instead of
+                    // leaving a failed display alive in worker state.
+                    launched_xvfb = Some(guard);
                     id
                 }
             };
@@ -1674,7 +1680,21 @@ async fn start_worker_display_session(
         .await
         .insert(display_id, Arc::clone(&session));
     state.registry = Some(registry);
+    #[cfg(target_os = "linux")]
+    {
+        state._xvfb = launched_xvfb;
+    }
     Ok((display_id, session))
+}
+
+#[cfg(target_os = "linux")]
+fn worker_virtual_display_config_in(
+    lock_dir: &std::path::Path,
+) -> Result<crate::vision::DisplayConfig, String> {
+    crate::vision::virtual_display_config_in(lock_dir, 1280, 800, &[]).ok_or_else(|| {
+        "worker display needs an unoccupied X display in the Intendant virtual-display range"
+            .to_string()
+    })
 }
 
 /// Ensure the worker display session exists, creating it on first use.
@@ -2416,6 +2436,45 @@ async fn serve_worker_frame(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn worker_allocator_skips_occupied_99_and_selects_100() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(tmp.path().join(".X11-unix")).unwrap();
+        let lock = tmp.path().join(".X99-lock");
+        std::fs::write(&lock, b"foreign\n").unwrap();
+
+        let config = worker_virtual_display_config_in(tmp.path()).unwrap();
+        assert!(matches!(
+            config.target,
+            intendant_platform::DisplayTarget::Virtual { id: 100 }
+        ));
+        assert_eq!(std::fs::read(lock).unwrap(), b"foreign\n");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn worker_allocator_propagates_exhaustion_without_launching() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(tmp.path().join(".X11-unix")).unwrap();
+        for id in 99..200 {
+            std::fs::write(tmp.path().join(format!(".X{id}-lock")), b"occupied\n").unwrap();
+        }
+
+        let error = worker_virtual_display_config_in(tmp.path())
+            .err()
+            .expect("fully occupied range must fail");
+        assert!(error.contains("unoccupied X display"), "{error}");
+        assert_eq!(
+            std::fs::read(tmp.path().join(".X99-lock")).unwrap(),
+            b"occupied\n"
+        );
+        assert_eq!(
+            std::fs::read(tmp.path().join(".X199-lock")).unwrap(),
+            b"occupied\n"
+        );
+    }
 
     #[test]
     fn tokens_are_single_use_and_expiring() {

--- a/src/bin/caller/debug.rs
+++ b/src/bin/caller/debug.rs
@@ -36,25 +36,16 @@ impl Drop for DebugScreen {
 }
 
 /// Find a free display in the 50-59 range for debug use.
-/// On non-Linux platforms the X lock file helpers are stubs, so this
-/// returns the first display in range immediately.
+/// Every lock- or socket-backed slot is skipped; this path never reclaims a
+/// live server or removes ambiguous filesystem state.
 #[allow(dead_code)]
-pub fn find_free_debug_display() -> u32 {
-    for id in DEBUG_DISPLAY_MIN..=DEBUG_DISPLAY_MAX {
-        let lock = format!("/tmp/.X{}-lock", id);
-        if !std::path::Path::new(&lock).exists() {
-            return id;
-        }
-        if vision::is_lock_stale(&lock) {
-            vision::remove_stale_lock(id);
-            return id;
-        }
-        if vision::is_our_xvfb(&lock, id) {
-            vision::kill_and_reclaim(&lock, id);
-            return id;
-        }
-    }
-    DEBUG_DISPLAY_MAX // fallback
+pub fn find_free_debug_display() -> Option<u32> {
+    find_free_debug_display_in(std::path::Path::new("/tmp"))
+}
+
+fn find_free_debug_display_in(lock_dir: &std::path::Path) -> Option<u32> {
+    (DEBUG_DISPLAY_MIN..=DEBUG_DISPLAY_MAX)
+        .find(|&id| vision::virtual_display_slot_is_absent(lock_dir, id))
 }
 
 /// Returns `<state root>/recordings/` (`~/.intendant/recordings/` by
@@ -101,7 +92,8 @@ pub async fn setup_debug_screen(web_port: u16) -> Result<DebugScreen, String> {
 /// Set up a debug screen: Xvfb + passive Firefox.
 #[cfg(target_os = "linux")]
 pub async fn setup_debug_screen(web_port: u16) -> Result<DebugScreen, String> {
-    let display_id = find_free_debug_display();
+    let display_id = find_free_debug_display()
+        .ok_or_else(|| "No safely reusable debug display in :50..:59".to_string())?;
     let config = vision::DisplayConfig {
         target: super::computer_use::DisplayTarget::Virtual { id: display_id },
         width: 1280,
@@ -277,8 +269,25 @@ mod tests {
 
     #[test]
     fn find_free_debug_display_in_range() {
-        let id = find_free_debug_display();
+        let tmp = tempfile::tempdir().unwrap();
+        let id = find_free_debug_display_in(tmp.path()).expect("empty temp range is free");
         assert!(id >= DEBUG_DISPLAY_MIN && id <= DEBUG_DISPLAY_MAX);
+    }
+
+    #[test]
+    fn find_free_debug_display_fails_closed_when_range_is_ambiguous() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sockets = tmp.path().join(".X11-unix");
+        std::fs::create_dir(&sockets).unwrap();
+        for id in DEBUG_DISPLAY_MIN..=DEBUG_DISPLAY_MAX {
+            let path = if id % 2 == 0 {
+                tmp.path().join(format!(".X{id}-lock"))
+            } else {
+                sockets.join(format!("X{id}"))
+            };
+            std::fs::write(path, b"ambiguous\n").unwrap();
+        }
+        assert_eq!(find_free_debug_display_in(tmp.path()), None);
     }
 
     #[test]

--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -739,6 +739,13 @@ pub enum AppEvent {
         reason: String,
     },
 
+    /// A virtual-display create request failed before any display lifecycle
+    /// existed. Deliberately carries no display id: consumers must never
+    /// interpret this as capture loss or tear down a registered session.
+    VirtualDisplayCreateFailed {
+        reason: String,
+    },
+
     /// The OS screen-share approval dialog has been raised on the guest
     /// desktop and we're waiting for the user to approve. The dashboard
     /// surfaces this as a banner so a remote user (e.g. via the web UI)
@@ -2592,13 +2599,14 @@ pub enum ControlMsg {
     /// that gives a claimed headless box a working display without any
     /// agent tool call. The daemon allocates the display number, launches
     /// Xvfb through the same machinery agent sessions use, registers a
-    /// capture session, and announces it with `DisplayReady`; failures
-    /// surface as `DisplayCaptureLost` with an actionable reason. The
+    /// capture session, and announces it with `DisplayReady`; pre-lifecycle
+    /// failures surface as `VirtualDisplayCreateFailed` with an actionable
+    /// reason. The
     /// created display is daemon-owned: closing its tile
     /// (`RevokeUserDisplay` on its id) destroys it, a graceful daemon exit
-    /// drops its guard, and a hard kill leaves it to the standard Xvfb
-    /// orphan-reclaim on the next allocation (signal shutdown is
-    /// `process::exit` — no `Drop`). Linux-only mechanism — other
+    /// drops its guard, and a hard kill leaves fail-closed residue that later
+    /// allocations skip (signal shutdown is `process::exit` — no `Drop`).
+    /// Linux-only mechanism — other
     /// platforms report a clear error.
     CreateVirtualDisplay {
         /// Optional resolution; defaults to 1920x1080. Values are clamped
@@ -3869,6 +3877,17 @@ pub fn app_event_to_outbound(event: &AppEvent) -> Option<crate::types::OutboundE
                 reason: reason.clone(),
             })
         }
+        AppEvent::VirtualDisplayCreateFailed { reason } => Some(OutboundEvent::LogEntry {
+            level: "error".to_string(),
+            source: "display".to_string(),
+            content: reason.clone(),
+            turn: None,
+            session_id: None,
+            user_turn_index: None,
+            user_turn_revision: None,
+            replacement_for_user_turn_index: None,
+            attachments: Vec::new(),
+        }),
         AppEvent::DisplayApprovalPending {
             display_id,
             backend,
@@ -4258,6 +4277,7 @@ fn app_event_writes_to_session_log(event: &AppEvent) -> bool {
             | AppEvent::DisplayTaken { .. }
             | AppEvent::DisplayReleased { .. }
             | AppEvent::DisplayCaptureLost { .. }
+            | AppEvent::VirtualDisplayCreateFailed { .. }
             | AppEvent::DisplayApprovalPending { .. }
             | AppEvent::SharedView { .. }
             | AppEvent::UserDisplayGranted { .. }
@@ -4508,6 +4528,9 @@ fn write_event_to_session_log(session_log: &crate::SharedSessionLog, event: &App
         }
         AppEvent::DisplayCaptureLost { display_id, reason } => {
             log.warn(&format!("Display :{} capture lost: {}", display_id, reason));
+        }
+        AppEvent::VirtualDisplayCreateFailed { reason } => {
+            log.warn(reason);
         }
         AppEvent::DisplayApprovalPending {
             display_id,
@@ -6626,6 +6649,24 @@ mod tests {
                 height: Some(800)
             }
         ));
+    }
+
+    #[test]
+    fn virtual_display_create_failure_wire_is_not_a_lifecycle_event() {
+        let outbound = app_event_to_outbound(&AppEvent::VirtualDisplayCreateFailed {
+            reason: "virtual display create failed: exhausted".to_string(),
+        })
+        .expect("create failure is visible to frontends");
+        let value = serde_json::to_value(outbound).unwrap();
+        assert_eq!(
+            value.get("event").and_then(serde_json::Value::as_str),
+            Some("log_entry")
+        );
+        assert_eq!(
+            value.get("source").and_then(serde_json::Value::as_str),
+            Some("display")
+        );
+        assert!(value.get("display_id").is_none());
     }
 
     #[test]

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -1225,7 +1225,12 @@ async fn maybe_auto_launch_xvfb(
         });
         return;
     }
-    let config = vision::display_config_for_provider(provider_name);
+    let Some(config) = vision::display_config_for_provider(provider_name) else {
+        slog(session_log, |l| {
+            l.warn("No unoccupied virtual display is available; skipping Xvfb auto-launch")
+        });
+        return;
+    };
     let trigger = if facts.has_capture_screen {
         "captureScreen"
     } else {
@@ -3075,7 +3080,8 @@ pub fn spawn_user_display_listener(
                         &mut virtual_display_guards,
                         display_id,
                         "tile closed",
-                    );
+                    )
+                    .await;
                 }
                 Ok(AppEvent::DisplayCaptureLost {
                     display_id,
@@ -3095,7 +3101,8 @@ pub fn spawn_user_display_listener(
                         &mut virtual_display_guards,
                         display_id,
                         "capture lost",
-                    );
+                    )
+                    .await;
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
                     // A missed grant/revoke/capture-loss leaves no trustworthy
@@ -3109,7 +3116,12 @@ pub fn spawn_user_display_listener(
                          closing all display sessions fail-closed"
                     );
                     let sessions = session_registry.write().await.drain();
-                    virtual_display_guards.clear();
+                    // Gracefully reap guards concurrently. Serially awaiting
+                    // each bounded shutdown here would compound the timeout
+                    // and make lag recovery itself keep falling behind.
+                    for (_, guard) in std::mem::take(&mut virtual_display_guards) {
+                        tokio::spawn(guard.shutdown());
+                    }
                     for session in sessions {
                         tokio::spawn(async move {
                             session.stop().await;

--- a/src/bin/caller/mcp/commands.rs
+++ b/src/bin/caller/mcp/commands.rs
@@ -1473,14 +1473,16 @@ pub(crate) async fn handle_control_command_mcp(
         ControlMsg::CreateVirtualDisplay { .. } => {
             // The user-display listener (spawned in every mode) owns the
             // actual work — Xvfb launch, capture session, DisplayReady /
-            // DisplayCaptureLost — by consuming this same bus event. This
-            // arm only acknowledges receipt on the MCP control surface.
+            // DisplayCaptureLost, or an id-free create-failure log entry —
+            // by consuming this same bus event. This arm only acknowledges
+            // receipt on the MCP control surface.
             emit_control_result(
                 control_tx,
                 "create_virtual_display",
                 true,
                 "virtual display creation requested — outcome arrives as \
-                 display_ready or display_capture_lost"
+                 display_ready, display_capture_lost after allocation, or an \
+                 error log_entry before a display lifecycle exists"
                     .to_string(),
                 None,
             );
@@ -1814,6 +1816,41 @@ mod tests {
                 .await
                 .is_err(),
             "standalone refusals must not forward lifecycle commands"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_virtual_display_ack_names_pre_lifecycle_failure_surface() {
+        let dir = tempdir().unwrap();
+        let state = test_state_with_log_dir(dir.path().to_path_buf());
+        let bus = EventBus::new();
+        let (control_tx, mut control_rx) = broadcast::channel::<String>(8);
+
+        let resource = handle_control_command_mcp(
+            &state,
+            &bus,
+            &Some(control_tx),
+            ControlMsg::CreateVirtualDisplay {
+                width: Some(1280),
+                height: Some(800),
+            },
+        )
+        .await;
+
+        assert_eq!(resource, Some(RESOURCE_LOGS_URI));
+        let event = timeout(Duration::from_millis(200), control_rx.recv())
+            .await
+            .expect("timed out waiting for create_virtual_display command_result")
+            .expect("broadcast recv failed");
+        let json: serde_json::Value = serde_json::from_str(&event).unwrap();
+        assert_eq!(json["event"], "command_result");
+        assert_eq!(json["action"], "create_virtual_display");
+        assert_eq!(json["ok"], true);
+        assert_eq!(
+            json["message"],
+            "virtual display creation requested — outcome arrives as display_ready, \
+             display_capture_lost after allocation, or an error log_entry before a \
+             display lifecycle exists"
         );
     }
 

--- a/src/bin/caller/mcp/events.rs
+++ b/src/bin/caller/mcp/events.rs
@@ -1047,6 +1047,9 @@ pub fn spawn_event_listener(
                             format!("Display :{} capture lost: {}", display_id, reason),
                         );
                     }
+                    AppEvent::VirtualDisplayCreateFailed { ref reason } => {
+                        s.push_log(LogLevel::Warn, reason.clone());
+                    }
                     AppEvent::DisplayApprovalPending {
                         display_id,
                         backend,

--- a/src/bin/caller/mcp/tools_display.rs
+++ b/src/bin/caller/mcp/tools_display.rs
@@ -143,16 +143,15 @@ impl IntendantServer {
     }
 
     #[tool(
-        description = "Create a daemon-owned virtual display (Xvfb) on this daemon's host and activate it for capture and streaming — it announces as display_ready to every dashboard and federated peer, survives the calling session, and dies with the daemon (closing its dashboard tile reaps it early). Linux hosts only today; other platforms report a clear error. Waits for the ready/failed outcome and returns the new display's id and geometry."
+        description = "Create a daemon-owned virtual display (Xvfb) on this daemon's host and activate it for capture and streaming — it announces as display_ready to every dashboard and federated peer and survives the calling session (closing its dashboard tile reaps it early). Linux hosts only today; other platforms report a clear error. Waits for the ready/failed outcome and returns the new display's id and geometry."
     )]
     pub(crate) async fn create_virtual_display(
         &self,
         Parameters(params): Parameters<CreateVirtualDisplayParams>,
     ) -> String {
-        // Outcome events carry only a display id, so the fresh display is
-        // recognized by not having existed before the request (the
-        // unsupported-platform failure uses a sentinel id, which is
-        // likewise never a live id).
+        // Ready events carry the allocated display id; pre-lifecycle failures
+        // have their own id-free event and therefore cannot collide with or
+        // retire any registered display session.
         let session_registry = self.state.read().await.session_registry.clone();
         let known: std::collections::HashSet<u32> =
             crate::display::enumerate_displays_with_sessions(&session_registry)
@@ -188,16 +187,15 @@ impl IntendantServer {
                          federated peers now."
                     );
                 }
-                Ok(Ok(AppEvent::DisplayCaptureLost { display_id, reason }))
-                    if !known.contains(&display_id) =>
-                {
-                    // The handler's failure reasons already carry this
-                    // prefix (virtual_display.rs phrases them for the
-                    // dashboard's capture-lost surface); only bare
-                    // reasons need it added.
+                Ok(Ok(AppEvent::VirtualDisplayCreateFailed { reason })) => {
                     if reason.starts_with("virtual display create failed") {
                         return reason;
                     }
+                    return format!("virtual display create failed: {reason}");
+                }
+                Ok(Ok(AppEvent::DisplayCaptureLost { display_id, reason }))
+                    if !known.contains(&display_id) =>
+                {
                     return format!("virtual display create failed: {reason}");
                 }
                 Ok(Ok(_)) => continue,

--- a/src/bin/caller/peer/upcast.rs
+++ b/src/bin/caller/peer/upcast.rs
@@ -1203,6 +1203,12 @@ impl AppEventUpcaster {
                 .displays
                 .lost(*display_id, Some(format!("capture_lost: {reason}"))),
 
+            AppEvent::VirtualDisplayCreateFailed { reason } => vec![log_event(
+                LogLevel::Error,
+                "display",
+                reason.clone(),
+            )],
+
             AppEvent::DisplayApprovalPending {
                 display_id: _,
                 backend,
@@ -4443,6 +4449,13 @@ mod tests {
         assert_parity(AppEvent::DisplayCaptureLost {
             display_id: 1,
             reason: "backend_crashed".into(),
+        });
+    }
+
+    #[test]
+    fn parity_virtual_display_create_failed() {
+        assert_parity(AppEvent::VirtualDisplayCreateFailed {
+            reason: "no unoccupied X display is available".into(),
         });
     }
 

--- a/src/bin/caller/presence.rs
+++ b/src/bin/caller/presence.rs
@@ -1141,6 +1141,7 @@ pub fn filter_event(event: &AppEvent, last_phase: &mut String) -> Option<Presenc
         | AppEvent::DebugScreenReady { .. }
         | AppEvent::DebugScreenTornDown { .. }
         | AppEvent::DisplayCaptureLost { .. }
+        | AppEvent::VirtualDisplayCreateFailed { .. }
         | AppEvent::DisplayApprovalPending { .. }
         // Presence sees the display via frames; per-action overlay events
         // are dashboard presentation, not narration material.

--- a/src/bin/caller/provider/mod.rs
+++ b/src/bin/caller/provider/mod.rs
@@ -1064,12 +1064,12 @@ pub fn select_cu_provider(
                 CallerError::Config("CU provider=gemini but no GEMINI_API_KEY found.".into())
             })?;
             let model = model_str.unwrap_or_else(|| "gemini-3-flash-preview".to_string());
-            let display = crate::vision::display_config_for_provider("gemini");
+            let display = crate::vision::display_resolution_for_provider("gemini");
             let ctx = resolve_context_window(&model);
             let max_out = resolve_max_output_tokens(&model);
             let mut p = GeminiProvider::new_with_tools(key, model, ctx, max_out, escalate_tools);
             p.cu_enabled = true;
-            p.cu_display = Some((display.width, display.height));
+            p.cu_display = Some(display);
             Ok(Box::new(p))
         }
         Some("anthropic") => {
@@ -1077,12 +1077,12 @@ pub fn select_cu_provider(
                 CallerError::Config("CU provider=anthropic but no ANTHROPIC_API_KEY found.".into())
             })?;
             let model = model_str.unwrap_or_else(|| "claude-haiku-4-5-20251001".to_string());
-            let display = crate::vision::display_config_for_provider("anthropic");
+            let display = crate::vision::display_resolution_for_provider("anthropic");
             let ctx = resolve_context_window(&model);
             let max_out = resolve_max_output_tokens(&model);
             let mut p = AnthropicProvider::new_with_tools(key, model, ctx, max_out, escalate_tools);
             p.cu_enabled = true;
-            p.cu_display = Some((display.width, display.height));
+            p.cu_display = Some(display);
             Ok(Box::new(p))
         }
         Some("openai") => {
@@ -1091,12 +1091,12 @@ pub fn select_cu_provider(
                 return Err(chatgpt_native_cu_error());
             }
             let model = model_str.unwrap_or_else(|| "gpt-5.4-mini".to_string());
-            let display = crate::vision::display_config_for_provider("openai");
+            let display = crate::vision::display_resolution_for_provider("openai");
             let ctx = resolve_context_window(&model);
             let max_out = resolve_max_output_tokens(&model);
             let mut p = OpenAIProvider::new_with_tools(key, model, ctx, max_out, escalate_tools);
             p.set_cu_enabled(true);
-            p.cu_display = Some((display.width, display.height));
+            p.cu_display = Some(display);
             Ok(Box::new(p))
         }
         Some(other) => Err(CallerError::Config(format!(
@@ -1111,7 +1111,7 @@ pub fn select_cu_provider(
             let chatgpt_openai_only = matches!(&openai_key, Some(OpenAIAuth::ChatGpt));
             if let Some(OpenAIAuth::ApiKey(key)) = openai_key {
                 let model = model_str.unwrap_or_else(|| "gpt-5.4-mini".to_string());
-                let display = crate::vision::display_config_for_provider("openai");
+                let display = crate::vision::display_resolution_for_provider("openai");
                 let ctx = resolve_context_window(&model);
                 let max_out = resolve_max_output_tokens(&model);
                 let mut p = OpenAIProvider::new_with_tools(
@@ -1122,27 +1122,27 @@ pub fn select_cu_provider(
                     escalate_tools,
                 );
                 p.set_cu_enabled(true);
-                p.cu_display = Some((display.width, display.height));
+                p.cu_display = Some(display);
                 Ok(Box::new(p))
             } else if let Some(key) = anthropic_key {
                 let model = model_str.unwrap_or_else(|| "claude-haiku-4-5-20251001".to_string());
-                let display = crate::vision::display_config_for_provider("anthropic");
+                let display = crate::vision::display_resolution_for_provider("anthropic");
                 let ctx = resolve_context_window(&model);
                 let max_out = resolve_max_output_tokens(&model);
                 let mut p =
                     AnthropicProvider::new_with_tools(key, model, ctx, max_out, escalate_tools);
                 p.cu_enabled = true;
-                p.cu_display = Some((display.width, display.height));
+                p.cu_display = Some(display);
                 Ok(Box::new(p))
             } else if let Some(key) = gemini_key {
                 let model = model_str.unwrap_or_else(|| "gemini-3-flash-preview".to_string());
-                let display = crate::vision::display_config_for_provider("gemini");
+                let display = crate::vision::display_resolution_for_provider("gemini");
                 let ctx = resolve_context_window(&model);
                 let max_out = resolve_max_output_tokens(&model);
                 let mut p =
                     GeminiProvider::new_with_tools(key, model, ctx, max_out, escalate_tools);
                 p.cu_enabled = true;
-                p.cu_display = Some((display.width, display.height));
+                p.cu_display = Some(display);
                 Ok(Box::new(p))
             } else {
                 if chatgpt_openai_only {

--- a/src/bin/caller/virtual_display.rs
+++ b/src/bin/caller/virtual_display.rs
@@ -5,7 +5,7 @@
 //! fleet display live from the browser". This module lets a frontend create
 //! (and destroy) an Xvfb display through the exact machinery agent sessions
 //! use: `vision::launch_display` for the process, `activate_user_display`
-//! for the capture session, `DisplayReady`/`DisplayCaptureLost` for the
+//! for the capture session, and distinct ready/create-failed events for the
 //! outcome.
 //!
 //! Ownership model: a created display is **daemon-owned** — like an
@@ -19,7 +19,7 @@
 //! loss reaps it explicitly.
 
 use crate::display;
-use crate::display_glue::{activate_user_display, report_user_display_capture_unavailable};
+use crate::display_glue::activate_user_display;
 use crate::event::{AppEvent, EventBus};
 use crate::frames;
 use crate::types::LogLevel;
@@ -30,8 +30,9 @@ use std::sync::Arc;
 
 /// Xvfb guards for dashboard-created virtual displays, keyed by display
 /// number. Owned as plain task-local state by the user-display listener —
-/// single consumer, no locking. Dropping a guard kills the Xvfb and cleans
-/// its X lock/socket.
+/// single consumer, no locking. Async teardown asks the exact child to exit;
+/// Drop hard-kills that child without waiting. Ambiguous residual X state is
+/// preserved and skipped.
 pub(crate) type VirtualDisplayGuards = HashMap<u32, vision::XvfbGuard>;
 
 /// Default resolution for a dashboard-created display. Human-facing desktop
@@ -45,11 +46,6 @@ const MIN_WIDTH: u32 = 320;
 const MIN_HEIGHT: u32 = 240;
 const MAX_WIDTH: u32 = 3840;
 const MAX_HEIGHT: u32 = 2160;
-
-/// Failure-report id for platforms where no display number is ever
-/// allocated. Must never match a real capture session: the
-/// DisplayCaptureLost handler tears down whatever session carries the id.
-const VIRTUAL_DISPLAY_UNSUPPORTED_SENTINEL: u32 = u32::MAX;
 
 /// Resolve requested dimensions: defaults for omitted axes, bounds-checked,
 /// rounded down to even (VP8 rejects odd frame dimensions).
@@ -71,8 +67,7 @@ pub(crate) fn virtual_display_dimensions(
 /// Handle `ControlMsg::CreateVirtualDisplay`: launch an Xvfb at a free
 /// display number and register its capture session so every dashboard gets
 /// a streaming tile. All failure paths report through
-/// `DisplayCaptureLost` — the dashboard surfaces that as an error toast —
-/// and never leave an unguarded Xvfb behind.
+/// `VirtualDisplayCreateFailed` and never leave an unguarded Xvfb behind.
 pub(crate) async fn create_virtual_display(
     bus: &EventBus,
     session_registry: &display::SharedSessionRegistry,
@@ -81,16 +76,10 @@ pub(crate) async fn create_virtual_display(
     width: Option<u32>,
     height: Option<u32>,
 ) {
-    // Unsupported platforms bail before any display number is chosen. The
-    // error still flows through DisplayCaptureLost (the channel dashboards
-    // and MCP callers toast), but against a sentinel id: with no allocation
-    // the natural fallback id is 0, and the DisplayCaptureLost handler
-    // tears down whatever live session matches — a failed macOS create once
-    // killed the real display-0 capture that way.
+    // Unsupported platforms bail before any display lifecycle exists.
     if !vision::virtual_displays_supported() {
-        report_user_display_capture_unavailable(
+        report_virtual_display_create_failed(
             bus,
-            VIRTUAL_DISPLAY_UNSUPPORTED_SENTINEL,
             "virtual display create failed: virtual displays are Xvfb-based and Linux-only; \
              use \"Your display\" to stream this machine's desktop instead",
         );
@@ -112,17 +101,25 @@ pub(crate) async fn create_virtual_display(
     let (width, height) = match virtual_display_dimensions(width, height) {
         Ok(dims) => dims,
         Err(reason) => {
-            // No display number was consumed; report against the display
-            // the allocator would pick so the toast is still actionable.
-            let config = vision::virtual_display_config(DEFAULT_WIDTH, DEFAULT_HEIGHT, &exclude);
-            let id = virtual_target_id(&config);
-            report_user_display_capture_unavailable(bus, id, reason);
+            report_virtual_display_create_failed(bus, reason);
             return;
         }
     };
 
-    let config = vision::virtual_display_config(width, height, &exclude);
-    let display_id = virtual_target_id(&config);
+    let Some(config) = vision::virtual_display_config(width, height, &exclude) else {
+        report_virtual_display_create_failed(
+            bus,
+            "virtual display create failed: no unoccupied X display is available",
+        );
+        return;
+    };
+    let Some(display_id) = virtual_target_id(&config) else {
+        report_virtual_display_create_failed(
+            bus,
+            "virtual display create failed: allocator returned a non-virtual target",
+        );
+        return;
+    };
 
     match vision::launch_display(&config).await {
         Ok(guard) => {
@@ -141,42 +138,47 @@ pub(crate) async fn create_virtual_display(
             // guarded Xvfb running with no tile and no way to destroy it.
             // (`get_any` for symmetry — this is lifecycle bookkeeping, not
             // an agent lookup, though virtual displays are never hidden.)
-            if session_registry.read().await.get_any(display_id).is_none()
-                && guards.remove(&display_id).is_some()
-            {
-                eprintln!("[virtual_display] :{display_id} activation failed — Xvfb reaped");
+            if session_registry.read().await.get_any(display_id).is_none() {
+                reap_virtual_display(guards, display_id, "activation failed").await;
             }
         }
         Err(e) => {
-            report_user_display_capture_unavailable(bus, display_id, create_failure_reason(&e));
+            report_virtual_display_create_failed(bus, create_failure_reason(&e));
         }
     }
 }
 
-/// Drop the guard for a dashboard-created display, killing its Xvfb and
-/// cleaning the X lock/socket. Returns whether this display was ours.
+fn report_virtual_display_create_failed(bus: &EventBus, reason: impl Into<String>) {
+    let reason = reason.into();
+    eprintln!("[virtual_display] {reason}");
+    bus.send(AppEvent::VirtualDisplayCreateFailed { reason });
+}
+
+/// Drop the guard for a dashboard-created display, stopping its exact Xvfb
+/// child while preserving any ambiguous residual X state. Returns whether
+/// this display was ours.
 /// Reaped on tile close (`UserDisplayRevoked`) and on capture loss (the
 /// Xvfb died, or activation never produced a session).
-pub(crate) fn reap_virtual_display(
+pub(crate) async fn reap_virtual_display(
     guards: &mut VirtualDisplayGuards,
     display_id: u32,
     context: &str,
 ) -> bool {
-    if guards.remove(&display_id).is_some() {
+    if let Some(guard) = guards.remove(&display_id) {
         eprintln!("[virtual_display] destroyed :{display_id} ({context})");
+        guard.shutdown().await;
         true
     } else {
         false
     }
 }
 
-fn virtual_target_id(config: &vision::DisplayConfig) -> u32 {
+fn virtual_target_id(config: &vision::DisplayConfig) -> Option<u32> {
     match config.target {
-        DisplayTarget::Virtual { id } => id,
-        // virtual_display_config always returns a Virtual target; keep a
-        // sane value if that invariant ever changes rather than panicking
-        // in the listener task.
-        DisplayTarget::UserSession => 0,
+        DisplayTarget::Virtual { id } => Some(id),
+        // `virtual_display_config` promises a virtual target. Fail closed if
+        // that invariant ever changes: display 0 may be a real user session.
+        DisplayTarget::UserSession => None,
     }
 }
 
@@ -229,11 +231,44 @@ mod tests {
         assert!(err.contains("out of range"), "{err}");
     }
 
-    #[test]
-    fn reap_is_scoped_to_created_displays() {
+    #[tokio::test]
+    async fn reap_is_scoped_to_created_displays() {
         let mut guards = VirtualDisplayGuards::new();
         // Nothing created from the dashboard: reap must refuse — agent
         // Xvfbs and user displays are not ours to kill.
-        assert!(!reap_virtual_display(&mut guards, 99, "test"));
+        assert!(!reap_virtual_display(&mut guards, 99, "test").await);
+    }
+
+    #[test]
+    fn user_session_target_never_falls_back_to_display_zero() {
+        let config = vision::DisplayConfig {
+            target: DisplayTarget::UserSession,
+            width: DEFAULT_WIDTH,
+            height: DEFAULT_HEIGHT,
+        };
+        assert_eq!(virtual_target_id(&config), None);
+    }
+
+    #[tokio::test]
+    async fn unallocated_failure_cannot_collide_with_max_display_session() {
+        let backend = Arc::new(crate::display::synthetic::SyntheticBackend::new());
+        let session = Arc::new(crate::display::DisplaySession::new(u32::MAX, backend));
+        let registry = Arc::new(tokio::sync::RwLock::new(
+            crate::display::SessionRegistry::new(),
+        ));
+        registry
+            .write()
+            .await
+            .insert(u32::MAX, Arc::clone(&session));
+        let bus = EventBus::new();
+        let mut rx = bus.subscribe();
+
+        report_virtual_display_create_failed(&bus, "virtual display create failed: exhausted");
+
+        assert!(matches!(
+            rx.recv().await.unwrap(),
+            AppEvent::VirtualDisplayCreateFailed { .. }
+        ));
+        assert!(registry.read().await.get_any(u32::MAX).is_some());
     }
 }


### PR DESCRIPTION
## Summary

- treat every existing or unreadable X lock/socket entry as occupied and fail cleanly on exhaustion
- keep Xvfb ownership in an exact-child guard with nonblocking Drop and bounded async teardown
- report pre-lifecycle creation failures without a fake display id or teardown side effects
- apply the same allocator semantics to dashboard, cloud-worker, provider, and debug paths
- preserve direct/wire peer event parity

## Verification

- cargo fmt --all -- --check
- targeted intendant-platform and caller tests
- host and Linux-target clippy/check with warnings denied
- two independent blind reviews of the exact diff
- no live Xvfb launch and no process signals during validation

## Deliberately deferred

This slice does not claim atomic scan-to-spawn reservation, process-scoped DISPLAY handling, Xauthority or -nolisten tcp hardening, create-request correlation, or a live Xvfb exercise. Those remain separate follow-up work; consumers should keep live capture disabled until that boundary is completed.