### PR TITLE
access: the agent identity class - record, profile family, cert mint, doorbell

### DIFF
--- a/src/bin/caller/access/access_policy.rs
+++ b/src/bin/caller/access/access_policy.rs
@@ -1720,6 +1720,21 @@ pub fn write_identity_record(
     cert_dir: &Path,
     record: &PeerIdentityRecord,
 ) -> Result<(), CallerError> {
+    // Store invariant, enforced at the single raw writer so EVERY lane
+    // hits it (doorbell approval, org materialization, profile changes,
+    // future writers): the agent vocabulary never lands on a peer-class
+    // record. `profile_class` recognizes `agent-operator`, so a peer
+    // record carrying it would evaluate at the agent ceiling's
+    // operation set — a recognized wrong-lane name is not an "unknown
+    // wire profile" and gets no lenient presence-only degrade.
+    let normalized = record.profile.trim().to_ascii_lowercase();
+    if matches!(record.class, IdentityClass::Peer)
+        && AGENT_PROFILES.iter().any(|(name, _)| *name == normalized)
+    {
+        return Err(CallerError::Config(format!(
+            "profile {normalized:?} is agent-lane vocabulary and cannot be stored on a peer identity"
+        )));
+    }
     with_identity_store_lock(cert_dir, || {
         let path = identity_path(cert_dir, &record.fingerprint);
         let mut body = serde_json::to_vec_pretty(record)?;
@@ -2382,6 +2397,22 @@ mod tests {
             set_identity_profile(dir.path(), &peer_fp, AGENT_OPERATOR_PROFILE).is_err(),
             "the peer lane never accepts the agent vocabulary"
         );
+
+        // The store invariant holds at the RAW writer — the choke point
+        // every lane crosses (doorbell, org materialization, future
+        // writers): a peer-class record can never carry the agent
+        // vocabulary, however it was assembled.
+        let mut smuggled = lookup_identity(dir.path(), &peer_fp).unwrap().unwrap();
+        smuggled.profile = AGENT_OPERATOR_PROFILE.to_string();
+        assert!(
+            write_identity_record(dir.path(), &smuggled).is_err(),
+            "the raw writer must refuse agent vocabulary on a peer record"
+        );
+        // Unknown wire profiles keep their lenient contract (stored
+        // as-is, presence-only degrade) — only the RECOGNIZED
+        // wrong-lane names refuse.
+        smuggled.profile = "future-profile-from-a-newer-build".to_string();
+        assert!(write_identity_record(dir.path(), &smuggled).is_ok());
     }
 
     #[test]

--- a/src/bin/caller/access/access_policy.rs
+++ b/src/bin/caller/access/access_policy.rs
@@ -162,6 +162,31 @@ pub enum PeerIdentityStatus {
     Revoked,
 }
 
+/// Which lane an identity record authenticates into. The classes never
+/// cross: a `Peer` record resolves only through the peer-daemon lane
+/// and an `Agent` record only through the agent-client lane (the R1
+/// MCP sidecar), each resolver refusing the other class fail-closed —
+/// the record class, not the certificate, is this store's
+/// discriminator, so a credential approved for one lane can never be
+/// replayed into the other.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum IdentityClass {
+    /// A federated daemon (every record written before the agent lane
+    /// existed deserializes here — the serde default).
+    #[default]
+    Peer,
+    /// An enrolled agent-operator client: a machine principal driving
+    /// this daemon over `/mcp` under an owner-granted profile ceiling.
+    Agent,
+}
+
+impl IdentityClass {
+    pub fn is_peer(&self) -> bool {
+        matches!(self, IdentityClass::Peer)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PeerIdentityRecord {
     pub version: u8,
@@ -169,6 +194,8 @@ pub struct PeerIdentityRecord {
     pub label: String,
     pub profile: String,
     pub status: PeerIdentityStatus,
+    #[serde(default, skip_serializing_if = "IdentityClass::is_peer")]
+    pub class: IdentityClass,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub card_url: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -242,6 +269,13 @@ pub enum ProfileClass {
     /// and route it to the attachment lane; authority over the worker
     /// flows the other way (home drives the worker), never inbound.
     CloudWorker,
+    /// The R1 agent-client ceiling (the MCP sidecar lane): everything a
+    /// machine principal may hold — approvals included — short of
+    /// access administration and credential custody, the same lane rule
+    /// that caps `AdminPeer`. An enrolled agent's granted profile is
+    /// either this class or any peer-vocabulary profile (each fits
+    /// under it), chosen by the owner at approval.
+    AgentOperator,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -403,6 +437,18 @@ pub(crate) const CLOUD_WORKER_PROFILE: &str = "cloud-worker";
 pub(crate) const SYSTEM_PROFILES: &[(&str, ProfileClass)] =
     &[(CLOUD_WORKER_PROFILE, ProfileClass::CloudWorker)];
 
+/// The R1 agent-operator profile name — the ceiling class for enrolled
+/// agent clients (the MCP sidecar lane).
+pub(crate) const AGENT_OPERATOR_PROFILE: &str = "agent-operator";
+
+/// Agent-lane profiles: recognized by every enforcement path, assignable
+/// only through the AGENT enrollment ceremony — the peer paths'
+/// [`require_known_profile`] keeps rejecting them, and the dashboard
+/// picker's parity pin mirrors [`PROFILES`] alone, so nothing peer-shaped
+/// can be granted an agent class by typo.
+pub(crate) const AGENT_PROFILES: &[(&str, ProfileClass)] =
+    &[(AGENT_OPERATOR_PROFILE, ProfileClass::AgentOperator)];
+
 /// Accepted alternate spellings, each canonicalizing to a [`PROFILES`] name.
 pub(crate) const PROFILE_ALIASES: &[(&str, &str)] = &[
     ("presence", "presence-only"),
@@ -447,6 +493,7 @@ pub fn profile_class(profile: &str) -> ProfileClass {
         .or_else(|| {
             SYSTEM_PROFILES
                 .iter()
+                .chain(AGENT_PROFILES)
                 .find(|(name, _)| *name == normalized)
                 .map(|(_, class)| *class)
         })
@@ -486,6 +533,31 @@ pub fn require_known_profile(raw: &str) -> Result<String, CallerError> {
     Err(CallerError::Config(format!(
         "unknown peer profile '{normalized}'; known profiles: {known}; accepted aliases: {aliases}"
     )))
+}
+
+/// Operator-facing validation for the AGENT approval path: an enrolled
+/// agent's granted profile may be any peer-vocabulary profile (each
+/// fits under the agent-operator operation set) or `agent-operator`
+/// itself. Same loud-typo contract as [`require_known_profile`]; the
+/// peer paths never accept the agent vocabulary and vice-versa is
+/// deliberately one-way (a peer profile on an agent identity is a
+/// narrower ceiling, which is always allowed).
+pub fn require_known_agent_profile(raw: &str) -> Result<String, CallerError> {
+    let normalized = normalize_profile(raw)?;
+    if let Some((name, _)) = AGENT_PROFILES.iter().find(|(name, _)| *name == normalized) {
+        return Ok(name.to_string());
+    }
+    require_known_profile(&normalized).map_err(|_| {
+        let known = AGENT_PROFILES
+            .iter()
+            .chain(PROFILES)
+            .map(|(name, _)| *name)
+            .collect::<Vec<_>>()
+            .join(", ");
+        CallerError::Config(format!(
+            "unknown agent profile '{normalized}'; known profiles: {known}"
+        ))
+    })
 }
 
 pub fn profile_allows_operation(profile: &str, op: PeerOperation) -> bool {
@@ -536,6 +608,13 @@ pub fn profile_allows_operation(profile: &str, op: PeerOperation) -> bool {
         // key-writing route gated at Settings would hand AdminPeer
         // custody through the side door.
         AdminPeer => !matches!(op, AccessManage | CredentialsManage),
+        // The agent lane inherits the same rule for the same reason: an
+        // agent client's principal is a machine, and access
+        // administration and credential custody must stay attributable
+        // to an identified person on a user-lane surface. This is the
+        // R1 charter's ceiling — approvals and operation up to
+        // everything short of IAM/credential administration.
+        AgentOperator => !matches!(op, AccessManage | CredentialsManage),
     }
 }
 
@@ -1340,6 +1419,54 @@ pub fn write_approved_identity_expiring(
     request_id: Option<&str>,
     expires_at_unix: Option<i64>,
 ) -> Result<PeerIdentityRecord, CallerError> {
+    write_approved_identity_record(
+        cert_dir,
+        fingerprint,
+        label,
+        profile,
+        IdentityClass::Peer,
+        card_url,
+        request_id,
+        expires_at_unix,
+    )
+}
+
+/// The agent-lane writer: identical store, [`IdentityClass::Agent`]
+/// stamped, no card URL (an agent client has no daemon card). Only the
+/// agent enrollment ceremony calls this; the peer approval paths stay
+/// on the peer writers above, so the class an identity authenticates
+/// into is decided by which ceremony approved it, never by the wire.
+pub fn write_approved_agent_identity(
+    cert_dir: &Path,
+    fingerprint: &str,
+    label: &str,
+    profile: &str,
+    request_id: Option<&str>,
+    expires_at_unix: Option<i64>,
+) -> Result<PeerIdentityRecord, CallerError> {
+    write_approved_identity_record(
+        cert_dir,
+        fingerprint,
+        label,
+        profile,
+        IdentityClass::Agent,
+        None,
+        request_id,
+        expires_at_unix,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn write_approved_identity_record(
+    cert_dir: &Path,
+    fingerprint: &str,
+    label: &str,
+    profile: &str,
+    class: IdentityClass,
+    card_url: Option<&str>,
+    request_id: Option<&str>,
+    expires_at_unix: Option<i64>,
+) -> Result<PeerIdentityRecord, CallerError> {
     with_identity_store_lock(cert_dir, || {
         let fingerprint = normalize_fingerprint(fingerprint)?;
         let profile = normalize_profile(profile)?;
@@ -1349,6 +1476,7 @@ pub fn write_approved_identity_expiring(
             label: label.trim().to_string(),
             profile,
             status: PeerIdentityStatus::Approved,
+            class,
             card_url: card_url.map(str::to_string),
             request_id: request_id.map(str::to_string),
             filesystem: FilesystemAccessPolicy::default(),

--- a/src/bin/caller/access/access_policy.rs
+++ b/src/bin/caller/access/access_policy.rs
@@ -2282,6 +2282,27 @@ mod tests {
             "peer aliases resolve on the agent path too"
         );
         assert!(require_known_agent_profile("made-up").is_err());
+
+        // The dashboard's agent picker mirrors AGENT_PROFILES the way
+        // the peer picker mirrors PROFILES — same drift protection,
+        // same mechanism.
+        let app = include_str!("../../../../static/app.html");
+        let from = app
+            .find("const AGENT_PROFILE_OPTIONS = [")
+            .expect("AGENT_PROFILE_OPTIONS missing from app.html");
+        let block = &app[from..];
+        let block = &block[..block.find("\n];").expect("options block unterminated")];
+        let picker: std::collections::BTreeSet<&str> = regex::Regex::new(r"profile: '([a-z-]+)'")
+            .unwrap()
+            .captures_iter(block)
+            .map(|caps| caps.get(1).unwrap().as_str())
+            .collect();
+        let canonical: std::collections::BTreeSet<&str> =
+            AGENT_PROFILES.iter().map(|(name, _)| *name).collect();
+        assert_eq!(
+            picker, canonical,
+            "AGENT_PROFILE_OPTIONS (static/app.html) drifted from AGENT_PROFILES"
+        );
     }
 
     /// Identity records written before the agent lane existed carry no

--- a/src/bin/caller/access/access_policy.rs
+++ b/src/bin/caller/access/access_policy.rs
@@ -2225,6 +2225,106 @@ mod tests {
         );
     }
 
+    /// The agent lane's ceiling: the same custody exclusion as
+    /// peer-root — one lane rule, two lanes, so the two ceilings carry
+    /// the identical operation set — and the entire operator-assignable
+    /// peer vocabulary fits under it (any peer profile is a valid
+    /// narrower agent grant). The validators keep the vocabularies
+    /// one-way: the peer path never accepts `agent-operator`; the
+    /// agent path accepts both.
+    #[test]
+    fn agent_operator_is_the_custodyless_ceiling_with_its_own_vocabulary() {
+        assert!(profile_allows_operation(
+            AGENT_OPERATOR_PROFILE,
+            PeerOperation::Approval
+        ));
+        assert!(profile_allows_operation(
+            AGENT_OPERATOR_PROFILE,
+            PeerOperation::TerminalWrite
+        ));
+        assert!(!profile_allows_operation(
+            AGENT_OPERATOR_PROFILE,
+            PeerOperation::AccessManage
+        ));
+        assert!(!profile_allows_operation(
+            AGENT_OPERATOR_PROFILE,
+            PeerOperation::CredentialsManage
+        ));
+        assert_eq!(
+            profile_operation_permission_ids(AGENT_OPERATOR_PROFILE),
+            profile_operation_permission_ids("peer-root"),
+        );
+        for (name, _) in PROFILES {
+            assert!(
+                profile_fits_under(name, AGENT_OPERATOR_PROFILE),
+                "{name} must fit under the agent ceiling"
+            );
+        }
+        assert!(matches!(
+            profile_class(AGENT_OPERATOR_PROFILE),
+            ProfileClass::AgentOperator
+        ));
+        assert!(
+            require_known_profile(AGENT_OPERATOR_PROFILE).is_err(),
+            "the peer approval vocabulary must reject the agent profile"
+        );
+        assert_eq!(
+            require_known_agent_profile(AGENT_OPERATOR_PROFILE).unwrap(),
+            AGENT_OPERATOR_PROFILE
+        );
+        assert_eq!(
+            require_known_agent_profile("read-only-display").unwrap(),
+            "read-only-display"
+        );
+        assert_eq!(
+            require_known_agent_profile("operator").unwrap(),
+            "peer-operator",
+            "peer aliases resolve on the agent path too"
+        );
+        assert!(require_known_agent_profile("made-up").is_err());
+    }
+
+    /// Identity records written before the agent lane existed carry no
+    /// class field and must stay peers; agent records round-trip; the
+    /// peer default never serializes, so existing stores stay
+    /// byte-identical.
+    #[test]
+    fn identity_class_serde_defaults_legacy_records_to_peer() {
+        let legacy = r#"{
+            "version": 1,
+            "fingerprint": "aabb",
+            "label": "old peer",
+            "profile": "stats",
+            "status": "approved",
+            "created_at_unix": 0
+        }"#;
+        let record: PeerIdentityRecord = serde_json::from_str(legacy).unwrap();
+        assert!(matches!(record.class, IdentityClass::Peer));
+        let json = serde_json::to_string(&record).unwrap();
+        assert!(
+            !json.contains("\"class\""),
+            "the peer default must not serialize"
+        );
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let agent = write_approved_agent_identity(
+            dir.path(),
+            &"ab".repeat(32),
+            "sidecar",
+            AGENT_OPERATOR_PROFILE,
+            Some("req-1"),
+            None,
+        )
+        .unwrap();
+        assert!(matches!(agent.class, IdentityClass::Agent));
+        let read = lookup_identity(dir.path(), &"ab".repeat(32))
+            .unwrap()
+            .expect("agent record persists");
+        assert!(matches!(read.class, IdentityClass::Agent));
+        assert_eq!(read.profile, AGENT_OPERATOR_PROFILE);
+        assert!(serde_json::to_string(&read).unwrap().contains("\"agent\""));
+    }
+
     #[test]
     fn peer_signal_relays_classify_as_peer_use() {
         // Acting through a connected peer — the three signaling relays and

--- a/src/bin/caller/access/access_policy.rs
+++ b/src/bin/caller/access/access_policy.rs
@@ -1628,8 +1628,15 @@ pub fn set_identity_profile(
     profile: &str,
 ) -> Result<ProfileChange, CallerError> {
     with_identity_store_lock(cert_dir, || {
-        let profile = require_known_profile(profile)?;
         let mut record = find_identity_by_fingerprint(cert_dir, selector)?;
+        // The record's class picks the vocabulary: an agent identity
+        // may be widened back to `agent-operator` (or any peer
+        // profile), while a peer identity keeps rejecting the agent
+        // vocabulary outright.
+        let profile = match record.class {
+            IdentityClass::Peer => require_known_profile(profile)?,
+            IdentityClass::Agent => require_known_agent_profile(profile)?,
+        };
         if !matches!(record.status, PeerIdentityStatus::Approved) {
             return Err(CallerError::Config(format!(
                 "peer identity {} ({}) is revoked; approve a new pairing instead of changing its profile",
@@ -2344,6 +2351,37 @@ mod tests {
         assert!(matches!(read.class, IdentityClass::Agent));
         assert_eq!(read.profile, AGENT_OPERATOR_PROFILE);
         assert!(serde_json::to_string(&read).unwrap().contains("\"agent\""));
+    }
+
+    /// Profile changes route through the record's class: an agent
+    /// narrowed to a peer profile can be widened back to
+    /// `agent-operator`, while a peer identity keeps rejecting the
+    /// agent vocabulary outright.
+    #[test]
+    fn set_identity_profile_routes_the_vocabulary_by_class() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let agent_fp = "cd".repeat(32);
+        write_approved_agent_identity(
+            dir.path(),
+            &agent_fp,
+            "sidecar",
+            AGENT_OPERATOR_PROFILE,
+            None,
+            None,
+        )
+        .unwrap();
+        let narrowed = set_identity_profile(dir.path(), &agent_fp, "read-only-display").unwrap();
+        assert_eq!(narrowed.record.profile, "read-only-display");
+        assert!(matches!(narrowed.record.class, IdentityClass::Agent));
+        let widened = set_identity_profile(dir.path(), &agent_fp, AGENT_OPERATOR_PROFILE).unwrap();
+        assert_eq!(widened.record.profile, AGENT_OPERATOR_PROFILE);
+
+        let peer_fp = "ef".repeat(32);
+        write_approved_identity(dir.path(), &peer_fp, "peer", "stats", None, None).unwrap();
+        assert!(
+            set_identity_profile(dir.path(), &peer_fp, AGENT_OPERATOR_PROFILE).is_err(),
+            "the peer lane never accepts the agent vocabulary"
+        );
     }
 
     #[test]

--- a/src/bin/caller/access/actor.rs
+++ b/src/bin/caller/access/actor.rs
@@ -326,6 +326,25 @@ mod tests {
     /// named principal kind, the unknown-kind fallback) and asserts
     /// none reaches [`ActorKind::Daemon`] — in-process construction via
     /// [`ActorBinding::daemon`] is the only mint.
+    /// The agent lane classifies as its own kind — never `Peer`, never
+    /// a dashboard/owner class — with the gate-bound principal id
+    /// preserved for attribution.
+    #[test]
+    fn agent_client_principals_classify_as_agent() {
+        let principal = crate::access::iam::AccessPrincipal::agent_client(
+            "fp-agent",
+            "Sidecar",
+            "agent-operator",
+            "https",
+        );
+        let binding = ActorBinding::from_principal(&principal, None);
+        assert_eq!(binding.kind, ActorKind::Agent);
+        assert_eq!(
+            binding.principal_id.as_deref(),
+            Some("principal:agent-client:fp-agent")
+        );
+    }
+
     #[test]
     fn from_principal_never_mints_the_daemon_kind() {
         let loopback = crate::access::iam::AccessPrincipal::local_loopback_mcp_default("http");

--- a/src/bin/caller/access/actor.rs
+++ b/src/bin/caller/access/actor.rs
@@ -62,6 +62,12 @@ pub enum ActorKind {
     Dashboard,
     /// A federated peer daemon acting under its granted profile.
     Peer,
+    /// An enrolled agent client (the R1 MCP sidecar lane): a machine
+    /// principal driving this daemon under its granted profile.
+    /// Deliberately distinct from `Peer` — a tenant edge that admits
+    /// federated daemons has made no decision about foreign agents —
+    /// and never a dashboard/owner-surface class.
+    Agent,
     /// The daemon itself, on schedule — a daemon-internal task (the
     /// GitHub PR scanner, the agenda scheduler's write-backs, the ask
     /// resolver) writing with no session, no gate, and no human at the
@@ -92,6 +98,7 @@ impl ActorKind {
             ActorKind::LocalProcess => "local_process",
             ActorKind::Dashboard => "dashboard",
             ActorKind::Peer => "peer",
+            ActorKind::Agent => "agent",
             ActorKind::Daemon => "daemon",
             ActorKind::Unattributed => "unattributed",
         }
@@ -166,6 +173,14 @@ impl ActorBinding {
         }
     }
 
+    pub fn agent(principal_id: Option<String>) -> Self {
+        Self {
+            kind: ActorKind::Agent,
+            principal_id,
+            session_id: None,
+        }
+    }
+
     /// The daemon itself, on schedule. In-process construction only —
     /// see the [`ActorKind::Daemon`] docs; no gate can produce this and
     /// [`ActorBinding::from_principal`] must never gain an arm for it
@@ -232,6 +247,7 @@ impl ActorBinding {
             | "connect_account"
             | "" => Self::dashboard(id),
             "peer_daemon" => Self::peer(id),
+            "agent_client" => Self::agent(id),
             // Unknown principal classes stay visibly unclassified while
             // still naming the principal the gate bound. `hosted_lease`
             // lands here DELIBERATELY: the agenda and memory tenant edges

--- a/src/bin/caller/access/certs.rs
+++ b/src/bin/caller/access/certs.rs
@@ -309,6 +309,33 @@ pub fn issue_client_certificate_for_public_key(
     Ok(cert.pem())
 }
 
+/// [`issue_client_certificate_for_public_key`]'s agent-lane sibling —
+/// the R1 enrollment ceremony's cert mint. Same never-sees-the-private-key
+/// contract; the CN says `Intendant Agent`.
+pub fn issue_agent_certificate_for_public_key(
+    cert_dir: &Path,
+    label: &str,
+    public_key_pem: &str,
+) -> AccessResult<String> {
+    let ca_path = cert_dir.join(CA_CRT);
+    let key_path = cert_dir.join(CA_KEY);
+    if !ca_path.exists() || !key_path.exists() {
+        return Err(AccessError(format!(
+            "no access CA found in {} — run `intendant access setup` first",
+            cert_dir.display()
+        )));
+    }
+    let ca_pem = std::fs::read_to_string(ca_path)?;
+    let ca_key_pem = read_ca_key_pem(&key_path)?;
+    let ca_key = KeyPair::from_pem(&ca_key_pem)?;
+    let ca_issuer = issuer_from_pem(&ca_pem, ca_key)?;
+    let public_key = SubjectPublicKeyInfo::from_pem(public_key_pem)
+        .map_err(|e| AccessError(format!("parse requester public key: {e}")))?;
+    let params = agent_cert_params(label)?;
+    let cert = params.signed_by(&public_key, &ca_issuer)?;
+    Ok(cert.pem())
+}
+
 fn regenerate_server_cert(cert_dir: &Path, server_names: &ServerNames) -> AccessResult<()> {
     let ca_pem = std::fs::read_to_string(cert_dir.join(CA_CRT))?;
     let ca_key_pem = read_ca_key_pem(&cert_dir.join(CA_KEY))?;
@@ -507,11 +534,24 @@ fn generate_client_cert(
 }
 
 fn client_cert_params(label: &str) -> AccessResult<CertificateParams> {
+    client_params_with_cn(format!("Intendant Client ({label})"))
+}
+
+/// The agent-lane credential shape (R1): identical CA, key usages, and
+/// validity — only the CN names the lane, for humans reading cert
+/// dumps and store listings. Enforcement never reads the CN: which
+/// lane a certificate authenticates into is decided solely by its
+/// identity record's class.
+fn agent_cert_params(label: &str) -> AccessResult<CertificateParams> {
+    client_params_with_cn(format!("Intendant Agent ({label})"))
+}
+
+fn client_params_with_cn(common_name: String) -> AccessResult<CertificateParams> {
     let mut params =
         CertificateParams::new(vec![]).map_err(|e| AccessError(format!("client params: {e}")))?;
     params
         .distinguished_name
-        .push(DnType::CommonName, format!("Intendant Client ({label})"));
+        .push(DnType::CommonName, common_name);
     params.is_ca = IsCa::NoCa;
     params.key_usages = vec![
         KeyUsagePurpose::DigitalSignature,

--- a/src/bin/caller/access/iam.rs
+++ b/src/bin/caller/access/iam.rs
@@ -618,6 +618,46 @@ impl AccessPrincipal {
         }
     }
 
+    /// The R1 agent-client principal: an enrolled machine identity
+    /// driving this daemon over `/mcp` (the MCP sidecar lane). Its own
+    /// kind — never `peer_daemon` — so every peer-shaped code path
+    /// refuses it unless it opted in, and its own actor arm attributes
+    /// it. Authority is the granted profile alone, evaluated exactly
+    /// like a peer's (`evaluate_principal_operation`), which keeps the
+    /// lane rule airtight: no agent profile reaches `AccessManage` or
+    /// `CredentialsManage` at any grant.
+    pub fn agent_client(
+        fingerprint: impl Into<String>,
+        label: impl Into<String>,
+        profile: impl Into<String>,
+        transport: impl Into<String>,
+    ) -> Self {
+        let fingerprint = fingerprint.into();
+        let profile = profile.into();
+        let label = label.into();
+        Self {
+            id: format!("principal:agent-client:{fingerprint}"),
+            kind: "agent_client".to_string(),
+            label: if label.trim().is_empty() {
+                fingerprint.clone()
+            } else {
+                label
+            },
+            source: "peer_identity_store".to_string(),
+            role_id: format!("role:agent-profile:{profile}"),
+            grant_id: Some(format!("grant:agent-profile:{fingerprint}")),
+            transport: transport.into(),
+            peer_profile: Some(profile),
+            account: None,
+            organization: None,
+            authn: Vec::new(),
+            authn_kind: None,
+            authn_binding: None,
+            authn_origin: None,
+            hosted_connect: false,
+        }
+    }
+
     pub fn local_user_client(
         principal: &IamPrincipal,
         grant: &IamGrant,
@@ -2337,6 +2377,7 @@ pub fn overview_metadata(load: &LoadedIamState) -> Value {
     const ENFORCED_PRINCIPAL_KINDS: &[&str] = &[
         "root_session",
         "peer_daemon",
+        "agent_client",
         "human_user",
         "browser_certificate",
         "agent_session",
@@ -2365,7 +2406,7 @@ pub fn overview_metadata(load: &LoadedIamState) -> Value {
             "user_client_grants": true,
             "principal_binding": "root_peer_and_local_user_client",
             "enforced_principal_kinds": ENFORCED_PRINCIPAL_KINDS,
-            "reason": "The daemon enforces trusted owner/root dashboard sessions, approved daemon peer profiles, browser/native mTLS identities (including mTLS-bound human-user grants), supervised agent sessions, MCP token holders, and trusted local-process grants. Browser client-key and Connect-account records remain available for enrollment, fleet signatures, attribution, migration, and audit. Peer offers can verify a browser key for attribution, but no alpha request ingress admits either record kind as its controlling IAM principal. Every admitted request is still evaluated per operation."
+            "reason": "The daemon enforces trusted owner/root dashboard sessions, approved daemon peer profiles, enrolled agent clients, browser/native mTLS identities (including mTLS-bound human-user grants), supervised agent sessions, MCP token holders, and trusted local-process grants. Browser client-key and Connect-account records remain available for enrollment, fleet signatures, attribution, migration, and audit. Peer offers can verify a browser key for attribution, but no alpha request ingress admits either record kind as its controlling IAM principal. Every admitted request is still evaluated per operation."
         },
         "role_ceilings": load.state.role_ceilings.clone(),
         "hosted_origins": load.state.hosted_origins.clone(),
@@ -2533,12 +2574,17 @@ pub fn evaluate_principal_operation(
             op,
             "root dashboard session grants all operations",
         ),
-        "peer_daemon" => {
+        kind @ ("peer_daemon" | "agent_client") => {
+            let lane = if kind == "agent_client" {
+                "agent"
+            } else {
+                "peer"
+            };
             let Some(profile) = principal.peer_profile.as_deref() else {
                 return AccessDecision::denied(
                     principal,
                     op,
-                    "peer daemon principal has no profile",
+                    format!("{lane} principal has no profile"),
                 );
             };
             if crate::access::access_policy::profile_allows_operation(profile, op) {
@@ -2546,7 +2592,7 @@ pub fn evaluate_principal_operation(
                     principal,
                     op,
                     format!(
-                        "peer profile {profile} allows {}",
+                        "{lane} profile {profile} allows {}",
                         operation_permission_id(op)
                     ),
                 )
@@ -2555,7 +2601,7 @@ pub fn evaluate_principal_operation(
                     principal,
                     op,
                     format!(
-                        "peer profile {profile} does not allow {}",
+                        "{lane} profile {profile} does not allow {}",
                         operation_permission_id(op)
                     ),
                 )
@@ -2615,12 +2661,16 @@ fn evaluate_principal_operation_with_state_and_fleet_zone(
             "Connect account records are discovery metadata and never authenticate to the daemon",
         );
     }
-    if principal.hosted_connect && matches!(principal.kind.as_str(), "root_session" | "peer_daemon")
+    if principal.hosted_connect
+        && matches!(
+            principal.kind.as_str(),
+            "root_session" | "peer_daemon" | "agent_client"
+        )
     {
         return AccessDecision::denied(
             principal,
             op,
-            "hosted Connect transport can never exercise a trusted-root or peer principal",
+            "hosted Connect transport can never exercise a trusted-root, peer, or agent principal",
         );
     }
     // A composite human record may retain a browser key as audit/attribution
@@ -2651,7 +2701,10 @@ fn evaluate_principal_operation_with_state_and_fleet_zone(
             "the default build treats hosted Connect as discovery-only; hosted control is immutably disabled",
         );
     }
-    if matches!(principal.kind.as_str(), "root_session" | "peer_daemon") {
+    if matches!(
+        principal.kind.as_str(),
+        "root_session" | "peer_daemon" | "agent_client"
+    ) {
         return evaluate_principal_operation(principal, op);
     }
 

--- a/src/bin/caller/access/iam.rs
+++ b/src/bin/caller/access/iam.rs
@@ -5108,6 +5108,55 @@ mod tests {
         assert!(evaluate_principal_operation(&local, PeerOperation::AccessManage).allowed);
     }
 
+    /// The agent lane's principal is pure profile authority: never an
+    /// owner surface, approvals allowed at its ceiling, custody
+    /// unreachable at ANY profile, state evaluation short-circuits
+    /// without a grant, and hosted-Connect transport refuses it
+    /// outright — the same posture peers hold, under its own kind.
+    #[test]
+    fn agent_client_principal_is_scoped_profile_authority() {
+        use crate::access::access_policy::PeerOperation;
+
+        let principal = AccessPrincipal::agent_client(
+            "fp-agent",
+            "Sidecar",
+            crate::access::access_policy::AGENT_OPERATOR_PROFILE,
+            "https",
+        );
+        assert_eq!(principal.kind, "agent_client");
+        assert_eq!(principal.id, "principal:agent-client:fp-agent");
+        assert!(!principal.is_owner_surface());
+        assert!(evaluate_principal_operation(&principal, PeerOperation::Approval).allowed);
+        assert!(evaluate_principal_operation(&principal, PeerOperation::TerminalWrite).allowed);
+        for op in [
+            PeerOperation::AccessManage,
+            PeerOperation::CredentialsManage,
+        ] {
+            assert!(
+                !evaluate_principal_operation(&principal, op).allowed,
+                "custody must stay unreachable"
+            );
+        }
+        let state = LocalIamState::default();
+        assert!(
+            evaluate_principal_operation_with_state(&state, &principal, PeerOperation::StatsRead)
+                .allowed,
+            "profile authority needs no local IAM grant"
+        );
+        let mut hosted = principal.clone();
+        hosted.hosted_connect = true;
+        assert!(
+            !evaluate_principal_operation_with_state(&state, &hosted, PeerOperation::StatsRead)
+                .allowed,
+            "hosted Connect transport can never exercise an agent principal"
+        );
+        // A narrower granted profile caps the same way it does for
+        // peers: read-only-display never reaches approvals.
+        let narrow = AccessPrincipal::agent_client("fp2", "Narrow", "read-only-display", "https");
+        assert!(evaluate_principal_operation(&narrow, PeerOperation::DisplayView).allowed);
+        assert!(!evaluate_principal_operation(&narrow, PeerOperation::Approval).allowed);
+    }
+
     #[test]
     fn owner_surface_excludes_the_root_compatible_transport_defaults() {
         // Owner surfaces: the trusted dashboard and the documented

--- a/src/bin/caller/access/org.rs
+++ b/src/bin/caller/access/org.rs
@@ -974,6 +974,9 @@ fn plan_org_peer_grant(
         label,
         profile,
         status: pol::PeerIdentityStatus::Approved,
+        // Org grant documents materialize federated daemons only — the
+        // agent lane enrolls exclusively through its own ceremony.
+        class: pol::IdentityClass::Peer,
         card_url: existing.as_ref().and_then(|r| r.card_url.clone()),
         request_id: existing.as_ref().and_then(|r| r.request_id.clone()),
         filesystem: existing
@@ -2812,6 +2815,7 @@ mod tests {
             label: "peer".to_string(),
             profile: "session-reader".to_string(),
             status: crate::access::access_policy::PeerIdentityStatus::Approved,
+            class: crate::access::access_policy::IdentityClass::Peer,
             card_url: None,
             request_id: None,
             filesystem: Default::default(),

--- a/src/bin/caller/dashboard_control/api_transfers_fs.rs
+++ b/src/bin/caller/dashboard_control/api_transfers_fs.rs
@@ -2967,6 +2967,7 @@ mod tests {
         let bus = crate::event::EventBus::new();
         let rt = peer_runtime(&rig);
         let identity = crate::web_gateway::PeerConnectionIdentity {
+            class: crate::peer::access_policy::IdentityClass::Peer,
             fingerprint: "fp".into(),
             label: "scoped-peer".into(),
             profile: "file-operator".into(),

--- a/src/bin/caller/memory/service.rs
+++ b/src/bin/caller/memory/service.rs
@@ -340,6 +340,19 @@ impl MemoryService {
             actor.kind,
             GateActorKind::Dashboard | GateActorKind::LocalProcess
         );
+        // The agent lane (enrolled R1 agent clients) is deliberately
+        // not admitted at the memory edge in its first cut — not even
+        // propose. Which memory verbs a foreign agent principal may
+        // exercise is an owner ruling that has not been made; the peer
+        // propose admission was its own ruling and the classes are
+        // distinct by construction. Refused by name so the choice is
+        // visible, not a fall-through.
+        if matches!(actor.kind, GateActorKind::Agent) {
+            return Err(MemoryError::NotPermitted {
+                verb: verb.as_str(),
+                actor: actor.kind.as_str(),
+            });
+        }
         if owner_surface || verb == Verb::Propose {
             return Ok(());
         }
@@ -381,6 +394,13 @@ impl MemoryService {
                 }),
             ),
             GateActorKind::Peer => (ActorKind::Peer, actor.principal_id.clone()),
+            // Unreachable while `authorize_write` refuses the agent
+            // lane by name above. Kept total instead of panicking: the
+            // kernel vocabulary has no agent class yet, so a future
+            // admission ruling maps here deliberately — until then the
+            // free-form id still carries the full agent principal, so
+            // even a bug that reached this arm stays id-honest.
+            GateActorKind::Agent => (ActorKind::Peer, actor.principal_id.clone()),
         }
     }
 

--- a/src/bin/caller/memory/service.rs
+++ b/src/bin/caller/memory/service.rs
@@ -1058,6 +1058,33 @@ mod tests {
         assert_eq!(view.proposed_by.actor, "peer");
     }
 
+    /// The agent lane (enrolled R1 agent clients) is refused at the
+    /// memory edge BY NAME — not even propose — until an owner ruling
+    /// admits it. The peer propose admission was its own ruling; the
+    /// classes are distinct by construction and must not inherit each
+    /// other's admissions.
+    #[test]
+    fn agent_lane_is_refused_at_the_memory_edge() {
+        let agent = ActorBinding::agent(Some("principal:agent-client:fp".into()));
+        for verb in [
+            Verb::Propose,
+            Verb::Assert,
+            Verb::JudgeSafe,
+            Verb::JudgeFull,
+            Verb::PinSafe,
+            Verb::PinFull,
+            Verb::CurateInstruction,
+        ] {
+            match MemoryService::authorize_write(&agent, verb) {
+                Err(MemoryError::NotPermitted { verb: v, actor: a }) => {
+                    assert_eq!(v, verb.as_str());
+                    assert_eq!(a, "agent");
+                }
+                other => panic!("expected actor-not-permitted for {verb:?}, got {other:?}"),
+            }
+        }
+    }
+
     /// Ring-2 propose-only (the seam ruling's tenant-edge decision):
     /// supervised agent sessions, peers, and unattributed callers may
     /// author candidates and NOTHING else — every other write verb

--- a/src/bin/caller/peer/access_request.rs
+++ b/src/bin/caller/peer/access_request.rs
@@ -480,15 +480,6 @@ pub(crate) fn create_pending_request(
     let now = unix_timestamp();
     let expires_at_unix = now + effective_ttl_secs(config);
     let path = request_path(cert_dir, &request_id);
-    let existing = read_request_path(&path)?;
-    if let Some(existing) = &existing {
-        if !matches!(effective_status(existing), AccessRequestStatus::Pending) {
-            return Err(CallerError::Config(format!(
-                "pairing request {} is already {:?}",
-                existing.code, existing.status
-            )));
-        }
-    }
 
     let stored = StoredAccessRequest {
         version: 1,
@@ -525,21 +516,36 @@ pub(crate) fn create_pending_request(
     // surface — a replay that flips any decision input (the CLASS above
     // all: peer↔agent changes what the approval mints) would race the
     // stale view into approving something the owner never evaluated.
-    if let Some(existing) = &existing {
-        let changed = existing.class != stored.class
-            || existing.requested_profile != stored.requested_profile
-            || existing.requester_label != stored.requester_label
-            || existing.requester_card_url != stored.requester_card_url
-            || existing.requester_daemon_id != stored.requester_daemon_id
-            || existing.requester_tier != stored.requester_tier;
-        if changed {
-            return Err(CallerError::Config(format!(
-                "pairing request {} is already pending with different parameters; deny it first, then re-request",
-                existing.code
-            )));
+    // The read → compare → write span holds the authority-store lock so
+    // two concurrent first knocks cannot both read None and let the
+    // LAST writer pick the stored class.
+    crate::access::authority_store::with_lock(cert_dir, || {
+        let existing = read_request_path(&path)
+            .map_err(|error| crate::access::AccessError(error.to_string()))?;
+        if let Some(existing) = &existing {
+            if !matches!(effective_status(existing), AccessRequestStatus::Pending) {
+                return Err(crate::access::AccessError(format!(
+                    "pairing request {} is already {:?}",
+                    existing.code, existing.status
+                )));
+            }
+            let changed = existing.class != stored.class
+                || existing.requested_profile != stored.requested_profile
+                || existing.requester_label != stored.requester_label
+                || existing.requester_card_url != stored.requester_card_url
+                || existing.requester_daemon_id != stored.requester_daemon_id
+                || existing.requester_tier != stored.requester_tier;
+            if changed {
+                return Err(crate::access::AccessError(format!(
+                    "pairing request {} is already pending with different parameters; deny it first, then re-request",
+                    existing.code
+                )));
+            }
         }
-    }
-    write_request(cert_dir, &stored)?;
+        write_request(cert_dir, &stored)
+            .map_err(|error| crate::access::AccessError(error.to_string()))
+    })
+    .map_err(|error| CallerError::Config(error.to_string()))?;
     eprintln!(
         "intendant: {} access request {} from {}{}; approve with `intendant peer approve {}`",
         match stored.class {
@@ -2064,6 +2070,125 @@ mod tests {
             stored.class,
             crate::access::access_policy::IdentityClass::Agent
         ));
+    }
+
+    /// Two concurrent FIRST knocks with the same key+nonce but
+    /// divergent classes cannot split the store: the read→compare→write
+    /// span holds the authority-store lock, so exactly one lands and
+    /// the loser refuses — never a last-writer-wins class the owner
+    /// did not see.
+    #[test]
+    fn concurrent_first_knocks_cannot_split_the_class() {
+        let certs = tempfile::TempDir::new().unwrap();
+        setup_certs(certs.path());
+        for round in 0..4u32 {
+            let key = access::certs::generate_client_key_material().unwrap();
+            let nonce = format!("racenonce{round:08}");
+            let build =
+                |class: Option<crate::access::access_policy::IdentityClass>| AccessRequestCreate {
+                    version: 1,
+                    requester_label: "racer".into(),
+                    public_key_pem: key.public_key_pem.clone(),
+                    nonce: nonce.clone(),
+                    requested_profile: None,
+                    requester_card_url: None,
+                    requester_daemon_id: None,
+                    requester_daemon_sig: None,
+                    requester_daemon_sig_ts: None,
+                    dialed_origin: None,
+                    requester_tier: None,
+                    requested_class: class,
+                };
+            let card = "https://target/.well-known/agent-card.json";
+            let config = PeerAccessRequestConfig::default();
+            let barrier = std::sync::Barrier::new(2);
+            let (agent_side, peer_side) = std::thread::scope(|scope| {
+                let agent = scope.spawn(|| {
+                    barrier.wait();
+                    create_pending_request(
+                        certs.path(),
+                        build(Some(crate::access::access_policy::IdentityClass::Agent)),
+                        card.into(),
+                        Some(format!("10.0.0.{round}")),
+                        &config,
+                        None,
+                    )
+                });
+                let peer = scope.spawn(|| {
+                    barrier.wait();
+                    create_pending_request(
+                        certs.path(),
+                        build(None),
+                        card.into(),
+                        Some(format!("10.0.1.{round}")),
+                        &config,
+                        None,
+                    )
+                });
+                (agent.join().unwrap(), peer.join().unwrap())
+            });
+            let winners = usize::from(agent_side.is_ok()) + usize::from(peer_side.is_ok());
+            assert_eq!(
+                winners, 1,
+                "exactly one racing knock may land (round {round}): {agent_side:?} / {peer_side:?}"
+            );
+            let (created, expect_agent) = match (&agent_side, &peer_side) {
+                (Ok(created), Err(_)) => (created, true),
+                (Err(_), Ok(created)) => (created, false),
+                _ => unreachable!("winner count pinned above"),
+            };
+            let stored = find_request(certs.path(), &created.code).unwrap();
+            assert_eq!(
+                matches!(
+                    stored.class,
+                    crate::access::access_policy::IdentityClass::Agent
+                ),
+                expect_agent,
+                "the stored class must be the WINNER's (round {round})"
+            );
+            // Keep the store small so per-source pending limits never
+            // shape later rounds.
+            deny_request(certs.path(), &created.code).unwrap();
+        }
+    }
+
+    /// A peer-class knock that ASKS for the agent vocabulary cannot be
+    /// approved into it: the store's raw-writer invariant refuses the
+    /// wrong-lane profile even when no override is given, instead of
+    /// the wire-lenient path storing a recognized ceiling name.
+    #[test]
+    fn peer_approval_refuses_requested_agent_vocabulary() {
+        let certs = tempfile::TempDir::new().unwrap();
+        setup_certs(certs.path());
+        let key = access::certs::generate_client_key_material().unwrap();
+        let request = AccessRequestCreate {
+            version: 1,
+            requester_label: "sneaky-peer".into(),
+            public_key_pem: key.public_key_pem,
+            nonce: "peeragentnonce001".into(),
+            requested_profile: Some("agent-operator".into()),
+            requester_card_url: None,
+            requester_daemon_id: None,
+            requester_daemon_sig: None,
+            requester_daemon_sig_ts: None,
+            dialed_origin: None,
+            requester_tier: None,
+            requested_class: None,
+        };
+        let created = create_pending_request(
+            certs.path(),
+            request,
+            "https://target/.well-known/agent-card.json".into(),
+            Some("127.0.0.1".into()),
+            &PeerAccessRequestConfig::default(),
+            None,
+        )
+        .unwrap();
+        let err = approve_request(certs.path(), &created.code, None).unwrap_err();
+        assert!(
+            err.to_string().contains("agent-lane vocabulary"),
+            "peer approval must refuse the agent profile: {err}"
+        );
     }
 
     /// An agent-class knock mints the agent lane end-to-end: the

--- a/src/bin/caller/peer/access_request.rs
+++ b/src/bin/caller/peer/access_request.rs
@@ -480,8 +480,9 @@ pub(crate) fn create_pending_request(
     let now = unix_timestamp();
     let expires_at_unix = now + effective_ttl_secs(config);
     let path = request_path(cert_dir, &request_id);
-    if let Some(existing) = read_request_path(&path)? {
-        if !matches!(effective_status(&existing), AccessRequestStatus::Pending) {
+    let existing = read_request_path(&path)?;
+    if let Some(existing) = &existing {
+        if !matches!(effective_status(existing), AccessRequestStatus::Pending) {
             return Err(CallerError::Config(format!(
                 "pairing request {} is already {:?}",
                 existing.code, existing.status
@@ -518,6 +519,26 @@ pub(crate) fn create_pending_request(
         client_cert_pem: None,
         target_daemon_identity_public_key: target_identity_public_key,
     };
+    // A pending record may be re-posted idempotently (a retry), never
+    // REWRITTEN: the same key+nonce yields the same request id, and the
+    // owner may already be looking at this request on an approval
+    // surface — a replay that flips any decision input (the CLASS above
+    // all: peer↔agent changes what the approval mints) would race the
+    // stale view into approving something the owner never evaluated.
+    if let Some(existing) = &existing {
+        let changed = existing.class != stored.class
+            || existing.requested_profile != stored.requested_profile
+            || existing.requester_label != stored.requester_label
+            || existing.requester_card_url != stored.requester_card_url
+            || existing.requester_daemon_id != stored.requester_daemon_id
+            || existing.requester_tier != stored.requester_tier;
+        if changed {
+            return Err(CallerError::Config(format!(
+                "pairing request {} is already pending with different parameters; deny it first, then re-request",
+                existing.code
+            )));
+        }
+    }
     write_request(cert_dir, &stored)?;
     eprintln!(
         "intendant: {} access request {} from {}{}; approve with `intendant peer approve {}`",
@@ -1955,6 +1976,94 @@ mod tests {
             .unwrap()
             .client_cert_pem
             .contains("BEGIN CERTIFICATE"));
+    }
+
+    /// A pending record is idempotent under byte-equivalent retries
+    /// and REFUSES a replay that changes any decision input — above
+    /// all the class: the same key+nonce yields the same request id,
+    /// and a peer↔agent flip under the owner's stale approval view
+    /// would mint a lane the owner never evaluated.
+    #[test]
+    fn pending_request_replays_cannot_change_decision_inputs() {
+        let certs = tempfile::TempDir::new().unwrap();
+        setup_certs(certs.path());
+        let key = access::certs::generate_client_key_material().unwrap();
+        let build = |class: Option<crate::access::access_policy::IdentityClass>,
+                     profile: Option<&str>| AccessRequestCreate {
+            version: 1,
+            requester_label: "replayer".into(),
+            public_key_pem: key.public_key_pem.clone(),
+            nonce: "replaynonce000001".into(),
+            requested_profile: profile.map(str::to_string),
+            requester_card_url: None,
+            requester_daemon_id: None,
+            requester_daemon_sig: None,
+            requester_daemon_sig_ts: None,
+            dialed_origin: None,
+            requester_tier: None,
+            requested_class: class,
+        };
+        let card = "https://target/.well-known/agent-card.json".to_string();
+        let config = PeerAccessRequestConfig::default();
+        let created = create_pending_request(
+            certs.path(),
+            build(
+                Some(crate::access::access_policy::IdentityClass::Agent),
+                None,
+            ),
+            card.clone(),
+            Some("127.0.0.1".into()),
+            &config,
+            None,
+        )
+        .unwrap();
+        // Byte-equivalent retry: idempotent, same id.
+        let retried = create_pending_request(
+            certs.path(),
+            build(
+                Some(crate::access::access_policy::IdentityClass::Agent),
+                None,
+            ),
+            card.clone(),
+            Some("127.0.0.1".into()),
+            &config,
+            None,
+        )
+        .unwrap();
+        assert_eq!(retried.request_id, created.request_id);
+        // A class flip refuses; so does a profile flip.
+        let err = create_pending_request(
+            certs.path(),
+            build(None, None),
+            card.clone(),
+            Some("127.0.0.1".into()),
+            &config,
+            None,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("different parameters"),
+            "class flip must refuse: {err}"
+        );
+        let err = create_pending_request(
+            certs.path(),
+            build(
+                Some(crate::access::access_policy::IdentityClass::Agent),
+                Some("peer-operator"),
+            ),
+            card,
+            Some("127.0.0.1".into()),
+            &config,
+            None,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("different parameters"));
+        // The stored record still carries the ORIGINAL class.
+        let stored = find_request(certs.path(), &created.code).unwrap();
+        assert!(matches!(
+            stored.class,
+            crate::access::access_policy::IdentityClass::Agent
+        ));
     }
 
     /// An agent-class knock mints the agent lane end-to-end: the

--- a/src/bin/caller/peer/access_request.rs
+++ b/src/bin/caller/peer/access_request.rs
@@ -1542,6 +1542,7 @@ mod tests {
         let nonce = "0123456789abcdef".to_string();
         let transcript = doorbell_transcript(dialed_origin, public_key_pem, &nonce, ts);
         AccessRequestCreate {
+            requested_class: None,
             version: 1,
             requester_label: "primary".into(),
             public_key_pem: public_key_pem.to_string(),
@@ -1575,6 +1576,7 @@ mod tests {
             tier.unwrap_or(""),
         );
         AccessRequestCreate {
+            requested_class: None,
             version: 1,
             requester_label: "primary".into(),
             public_key_pem: public_key_pem.to_string(),
@@ -1829,6 +1831,7 @@ mod tests {
     fn disabled_public_access_request_config_rejects_before_creating() {
         let certs = tempfile::TempDir::new().unwrap();
         let request = AccessRequestCreate {
+            requested_class: None,
             version: 1,
             requester_label: "primary".into(),
             public_key_pem: "not checked while disabled".into(),
@@ -1878,6 +1881,7 @@ mod tests {
         setup_certs(certs.path());
         let key = access::certs::generate_client_key_material().unwrap();
         let request = AccessRequestCreate {
+            requested_class: None,
             version: 1,
             requester_label: "primary".into(),
             public_key_pem: key.public_key_pem,
@@ -1915,6 +1919,7 @@ mod tests {
         setup_certs(certs.path());
         let key = access::certs::generate_client_key_material().unwrap();
         let request = AccessRequestCreate {
+            requested_class: None,
             version: 1,
             requester_label: "primary".into(),
             public_key_pem: key.public_key_pem,
@@ -1952,12 +1957,122 @@ mod tests {
             .contains("BEGIN CERTIFICATE"));
     }
 
+    /// An agent-class knock mints the agent lane end-to-end: the
+    /// stored request carries the class, approval writes an
+    /// agent-class identity record (default profile when none was
+    /// asked), and the granted profile validates strictly against the
+    /// agent vocabulary — typos fail the approval loudly, never a
+    /// silent presence-only degrade.
+    #[test]
+    fn approve_request_mints_the_agent_lane_when_requested() {
+        let certs = tempfile::TempDir::new().unwrap();
+        setup_certs(certs.path());
+        let key = access::certs::generate_client_key_material().unwrap();
+        let request = AccessRequestCreate {
+            version: 1,
+            requester_label: "sidecar-box".into(),
+            public_key_pem: key.public_key_pem,
+            nonce: "agentnonce0000001".into(),
+            requested_profile: None,
+            requester_card_url: None,
+            requester_daemon_id: None,
+            requester_daemon_sig: None,
+            requester_daemon_sig_ts: None,
+            dialed_origin: None,
+            requester_tier: None,
+            requested_class: Some(crate::access::access_policy::IdentityClass::Agent),
+        };
+        let created = create_pending_request(
+            certs.path(),
+            request,
+            "https://target/.well-known/agent-card.json".into(),
+            Some("127.0.0.1".into()),
+            &PeerAccessRequestConfig::default(),
+            None,
+        )
+        .unwrap();
+        let approved = approve_request(certs.path(), &created.code, None).unwrap();
+        assert_eq!(
+            approved.approved_profile.as_deref(),
+            Some(crate::peer::access_policy::DEFAULT_PROFILE)
+        );
+        let cert_pem = approved.client_cert_pem.clone().unwrap();
+        let fingerprint = crate::peer::access_policy::fingerprint_pem(&cert_pem).unwrap();
+        let record = crate::peer::access_policy::lookup_identity(certs.path(), &fingerprint)
+            .unwrap()
+            .expect("approval writes the identity record");
+        assert!(matches!(
+            record.class,
+            crate::access::access_policy::IdentityClass::Agent
+        ));
+        assert_eq!(
+            record.profile,
+            crate::peer::access_policy::DEFAULT_PROFILE,
+            "an unrequested profile lands on the cautious default"
+        );
+
+        // A second agent knock: a typo'd profile fails the approval
+        // loudly; the agent ceiling itself approves.
+        let key2 = access::certs::generate_client_key_material().unwrap();
+        let request2 = AccessRequestCreate {
+            version: 1,
+            requester_label: "sidecar-two".into(),
+            public_key_pem: key2.public_key_pem,
+            nonce: "agentnonce0000002".into(),
+            requested_profile: None,
+            requester_card_url: None,
+            requester_daemon_id: None,
+            requester_daemon_sig: None,
+            requester_daemon_sig_ts: None,
+            dialed_origin: None,
+            requester_tier: None,
+            requested_class: Some(crate::access::access_policy::IdentityClass::Agent),
+        };
+        let created2 = create_pending_request(
+            certs.path(),
+            request2,
+            "https://target/.well-known/agent-card.json".into(),
+            Some("127.0.0.1".into()),
+            &PeerAccessRequestConfig::default(),
+            None,
+        )
+        .unwrap();
+        assert!(
+            approve_request(certs.path(), &created2.code, Some("no-such-profile")).is_err(),
+            "agent approvals validate strictly"
+        );
+        let approved2 = approve_request(
+            certs.path(),
+            &created2.code,
+            Some(crate::access::access_policy::AGENT_OPERATOR_PROFILE),
+        )
+        .unwrap();
+        assert_eq!(
+            approved2.approved_profile.as_deref(),
+            Some(crate::access::access_policy::AGENT_OPERATOR_PROFILE)
+        );
+        let cert2 = approved2.client_cert_pem.unwrap();
+        let fp2 = crate::peer::access_policy::fingerprint_pem(&cert2).unwrap();
+        let record2 = crate::peer::access_policy::lookup_identity(certs.path(), &fp2)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            record2.profile,
+            crate::access::access_policy::AGENT_OPERATOR_PROFILE
+        );
+        assert!(matches!(
+            record2.class,
+            crate::access::access_policy::IdentityClass::Agent
+        ));
+    }
+
     #[test]
     fn approve_request_without_profile_uses_peer_operator_default() {
         let certs = tempfile::TempDir::new().unwrap();
         setup_certs(certs.path());
         let key = access::certs::generate_client_key_material().unwrap();
         let request = AccessRequestCreate {
+            requested_class: None,
             version: 1,
             requester_label: "primary".into(),
             public_key_pem: key.public_key_pem,
@@ -1998,6 +2113,7 @@ mod tests {
         setup_certs(certs.path());
         let key = access::certs::generate_client_key_material().unwrap();
         let request = AccessRequestCreate {
+            requested_class: None,
             version: 1,
             requester_label: "primary".into(),
             public_key_pem: key.public_key_pem,
@@ -2088,6 +2204,7 @@ mod tests {
         // Target side: stamped at create, carried on the approved result.
         let requester_key = access::certs::generate_client_key_material().unwrap();
         let request = AccessRequestCreate {
+            requested_class: None,
             version: 1,
             requester_label: "primary".into(),
             public_key_pem: requester_key.public_key_pem,

--- a/src/bin/caller/peer/access_request.rs
+++ b/src/bin/caller/peer/access_request.rs
@@ -54,7 +54,8 @@ pub(crate) struct AccessRequestCreate {
     /// target, key, or ceremony. All-absent = a legacy requester
     /// (admitted, shown as an unverified caller). A target that predates
     /// these fields rejects them (`deny_unknown_fields`); the requester
-    /// retries once without and notes the downgrade.
+    /// surfaces that as a hard error — never a silent downgrade an
+    /// on-path 400 could force (see the send path).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub requester_daemon_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -71,6 +72,15 @@ pub(crate) struct AccessRequestCreate {
     /// request — it is never admitted as a bare assertion.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub requester_tier: Option<String>,
+    /// The lane this enrollment asks for: absent = a federated peer
+    /// daemon (every pre-agent requester); `agent` = an R1 agent-client
+    /// enrollment. Requester-declared by design — the class changes
+    /// what an APPROVAL mints, never what the knock may do — and a
+    /// target that predates the field rejects the request outright
+    /// (`deny_unknown_fields`), so an agent enrollment can never be
+    /// silently approved as a peer by an older daemon.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requested_class: Option<crate::access::access_policy::IdentityClass>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -156,6 +166,14 @@ pub(crate) struct StoredAccessRequest {
     pub requester_tier: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_hint: Option<String>,
+    /// The lane the requester asked to enroll into; approval mints a
+    /// certificate and identity record of exactly this class, and the
+    /// owner-facing listings say which they are approving.
+    #[serde(
+        default,
+        skip_serializing_if = "crate::access::access_policy::IdentityClass::is_peer"
+    )]
+    pub class: crate::access::access_policy::IdentityClass,
     pub target_label: String,
     pub target_card_url: String,
     pub server_cert_fingerprint: String,
@@ -199,6 +217,10 @@ pub(crate) struct InitiateAccessRequestOptions {
     pub requester_label: Option<String>,
     pub requested_profile: Option<String>,
     pub requester_card_url: Option<String>,
+    /// `Some(Agent)` = an R1 agent-client enrollment (`intendant mcp
+    /// enroll`); `None` keeps the wire field absent so peer requests
+    /// stay byte-identical to pre-agent builds.
+    pub requested_class: Option<crate::access::access_policy::IdentityClass>,
 }
 
 #[derive(Debug)]
@@ -485,6 +507,7 @@ pub(crate) fn create_pending_request(
         requester_daemon_id: verified_requester_daemon_id,
         requester_tier: verified_requester_tier,
         source_hint,
+        class: request.requested_class.unwrap_or_default(),
         target_label: target_label.clone(),
         target_card_url: target_card_url.clone(),
         server_cert_fingerprint: server_cert_fingerprint.clone(),
@@ -497,7 +520,11 @@ pub(crate) fn create_pending_request(
     };
     write_request(cert_dir, &stored)?;
     eprintln!(
-        "intendant: peer access request {} from {}{}; approve with `intendant peer approve {}`",
+        "intendant: {} access request {} from {}{}; approve with `intendant peer approve {}`",
+        match stored.class {
+            crate::access::access_policy::IdentityClass::Peer => "peer",
+            crate::access::access_policy::IdentityClass::Agent => "AGENT",
+        },
         stored.code,
         stored.requester_label,
         stored
@@ -560,21 +587,62 @@ pub(crate) fn approve_request(
         .transpose()?
         .or_else(|| stored.requested_profile.clone())
         .unwrap_or_else(|| DEFAULT_PROFILE.to_string());
-    let cert_pem = access::certs::issue_client_certificate_for_public_key(
-        cert_dir,
-        &stored.requester_label,
-        &stored.public_key_pem,
-    )
+    // Strict at the core for the new lane: an agent grant must be in
+    // the agent vocabulary (agent-operator or any peer profile, each
+    // of which fits under it) — a typo fails the approval loudly
+    // instead of storing a presence-only degrade the owner never
+    // chose. Validated BEFORE minting so the recorded approved_profile
+    // is exactly what the identity record holds.
+    let profile = match stored.class {
+        super::access_policy::IdentityClass::Peer => profile,
+        super::access_policy::IdentityClass::Agent => {
+            super::access_policy::require_known_agent_profile(&profile)?
+        }
+    };
+    // The stored class decides which lane this approval mints into —
+    // cert shape, profile vocabulary, and identity writer all switch
+    // together, so a peer request can never produce an agent identity
+    // or vice versa.
+    let cert_pem = match stored.class {
+        super::access_policy::IdentityClass::Peer => {
+            access::certs::issue_client_certificate_for_public_key(
+                cert_dir,
+                &stored.requester_label,
+                &stored.public_key_pem,
+            )
+        }
+        super::access_policy::IdentityClass::Agent => {
+            access::certs::issue_agent_certificate_for_public_key(
+                cert_dir,
+                &stored.requester_label,
+                &stored.public_key_pem,
+            )
+        }
+    }
     .map_err(|e| CallerError::Config(e.to_string()))?;
     let client_fingerprint = super::access_policy::fingerprint_pem(&cert_pem)?;
-    super::access_policy::write_approved_identity(
-        cert_dir,
-        &client_fingerprint,
-        &stored.requester_label,
-        &profile,
-        stored.requester_card_url.as_deref(),
-        Some(&stored.request_id),
-    )?;
+    match stored.class {
+        super::access_policy::IdentityClass::Peer => {
+            super::access_policy::write_approved_identity(
+                cert_dir,
+                &client_fingerprint,
+                &stored.requester_label,
+                &profile,
+                stored.requester_card_url.as_deref(),
+                Some(&stored.request_id),
+            )?;
+        }
+        super::access_policy::IdentityClass::Agent => {
+            super::access_policy::write_approved_agent_identity(
+                cert_dir,
+                &client_fingerprint,
+                &stored.requester_label,
+                &profile,
+                Some(&stored.request_id),
+                None,
+            )?;
+        }
+    }
     stored.status = AccessRequestStatus::Approved;
     stored.approved_profile = Some(profile);
     stored.approved_at_unix = Some(unix_timestamp());
@@ -631,6 +699,7 @@ pub(crate) async fn initiate_access_request(
         requester_daemon_sig_ts: None,
         dialed_origin: None,
         requester_tier: None,
+        requested_class: options.requested_class,
     };
     // Caller-ID: prove this daemon's identity over the doorbell. Best
     // effort — a box without a loadable identity still rings the bell,

--- a/src/bin/caller/peer/access_request.rs
+++ b/src/bin/caller/peer/access_request.rs
@@ -1548,6 +1548,20 @@ mod tests {
     use crate::access::certs::{ensure_certs, ServerNames};
     use crate::project::ProjectConfig;
 
+    /// Every knock in this module rides a lenient rate config: the
+    /// create limiter is process-global, so a test leaning on the
+    /// DEFAULT caps is really asserting how many knocks the tests
+    /// before it made — plain `cargo test` shares one process, which
+    /// nextest's process-per-test model hides locally. The limiter's
+    /// own test isolates itself with far-future timestamps instead.
+    fn lenient_config() -> PeerAccessRequestConfig {
+        PeerAccessRequestConfig {
+            max_creates_per_window: 4096,
+            max_creates_per_source_per_window: 256,
+            ..Default::default()
+        }
+    }
+
     fn setup_certs(dir: &Path) {
         let names = ServerNames::new(
             "127.0.0.1".parse().unwrap(),
@@ -1742,7 +1756,7 @@ mod tests {
         // card URL the request arrived on.
         let card_url = "https://target/.well-known/agent-card.json";
         let origin = "https://target";
-        let config = PeerAccessRequestConfig::default();
+        let config = lenient_config();
         let source = format!(
             "test-tier-{}-{:?}",
             unix_timestamp(),
@@ -1926,7 +1940,7 @@ mod tests {
             request,
             "https://target/.well-known/agent-card.json".into(),
             Some("127.0.0.1".into()),
-            &PeerAccessRequestConfig::default(),
+            &lenient_config(),
             None,
         )
         .unwrap();
@@ -1965,7 +1979,7 @@ mod tests {
             request,
             "https://target/.well-known/agent-card.json".into(),
             Some("127.0.0.1".into()),
-            &PeerAccessRequestConfig::default(),
+            &lenient_config(),
             None,
         )
         .unwrap();
@@ -2010,7 +2024,7 @@ mod tests {
             requested_class: class,
         };
         let card = "https://target/.well-known/agent-card.json".to_string();
-        let config = PeerAccessRequestConfig::default();
+        let config = lenient_config();
         let created = create_pending_request(
             certs.path(),
             build(
@@ -2100,7 +2114,7 @@ mod tests {
                     requested_class: class,
                 };
             let card = "https://target/.well-known/agent-card.json";
-            let config = PeerAccessRequestConfig::default();
+            let config = lenient_config();
             let barrier = std::sync::Barrier::new(2);
             let (agent_side, peer_side) = std::thread::scope(|scope| {
                 let agent = scope.spawn(|| {
@@ -2180,7 +2194,7 @@ mod tests {
             request,
             "https://target/.well-known/agent-card.json".into(),
             Some("127.0.0.1".into()),
-            &PeerAccessRequestConfig::default(),
+            &lenient_config(),
             None,
         )
         .unwrap();
@@ -2221,7 +2235,7 @@ mod tests {
             request,
             "https://target/.well-known/agent-card.json".into(),
             Some("127.0.0.1".into()),
-            &PeerAccessRequestConfig::default(),
+            &lenient_config(),
             None,
         )
         .unwrap();
@@ -2267,7 +2281,7 @@ mod tests {
             request2,
             "https://target/.well-known/agent-card.json".into(),
             Some("127.0.0.1".into()),
-            &PeerAccessRequestConfig::default(),
+            &lenient_config(),
             None,
         )
         .unwrap();
@@ -2325,7 +2339,7 @@ mod tests {
             request,
             "https://target/.well-known/agent-card.json".into(),
             Some("127.0.0.1".into()),
-            &PeerAccessRequestConfig::default(),
+            &lenient_config(),
             None,
         )
         .unwrap();
@@ -2366,7 +2380,7 @@ mod tests {
             request,
             "https://target/.well-known/agent-card.json".into(),
             Some("127.0.0.1".into()),
-            &PeerAccessRequestConfig::default(),
+            &lenient_config(),
             None,
         )
         .unwrap();
@@ -2456,7 +2470,7 @@ mod tests {
             request,
             "https://target/.well-known/agent-card.json".into(),
             None,
-            &PeerAccessRequestConfig::default(),
+            &lenient_config(),
             Some(target_key.clone()),
         )
         .unwrap();

--- a/src/bin/caller/peer/pairing.rs
+++ b/src/bin/caller/peer/pairing.rs
@@ -440,6 +440,7 @@ async fn cmd_request(args: PeerArgs) -> Result<(), CallerError> {
             requester_label: args.label,
             requested_profile: args.profile,
             requester_card_url: args.requester_card_url,
+            requested_class: None,
         },
     )
     .await?;

--- a/src/bin/caller/peer/pairing.rs
+++ b/src/bin/caller/peer/pairing.rs
@@ -484,9 +484,15 @@ fn cmd_requests() -> Result<(), CallerError> {
             None => "caller=unverified".to_string(),
         };
         println!(
-            "{}  {:?}  {}  profile={}  {}  expires={}",
+            "{}  {:?}  {}  {}  profile={}  {}  expires={}",
             request.code,
             request.status,
+            // The lane an approval mints — an owner scanning the list
+            // must see which requests are AGENT enrollments.
+            match request.class {
+                crate::access::access_policy::IdentityClass::Peer => "peer",
+                crate::access::access_policy::IdentityClass::Agent => "AGENT",
+            },
             request.requester_label,
             request
                 .requested_profile
@@ -507,8 +513,13 @@ fn cmd_approve(args: PeerArgs) -> Result<(), CallerError> {
     let request =
         crate::peer::access_request::approve_request(&cert_dir, &code, args.profile.as_deref())?;
     println!(
-        ":: approved peer access request {} for {}",
-        request.code, request.requester_label
+        ":: approved {} access request {} for {}",
+        match request.class {
+            crate::access::access_policy::IdentityClass::Peer => "peer",
+            crate::access::access_policy::IdentityClass::Agent => "AGENT",
+        },
+        request.code,
+        request.requester_label
     );
     println!(
         ":: approved profile: {}",

--- a/src/bin/caller/peer/pairing.rs
+++ b/src/bin/caller/peer/pairing.rs
@@ -589,9 +589,13 @@ fn cmd_identities() -> Result<(), CallerError> {
     }
     for identity in identities {
         println!(
-            "{}  {:?}  profile={}  label={}{}{}",
+            "{}  {:?}  {}  profile={}  label={}{}{}",
             identity.fingerprint,
             identity.status,
+            match identity.class {
+                crate::access::access_policy::IdentityClass::Peer => "peer",
+                crate::access::access_policy::IdentityClass::Agent => "AGENT",
+            },
             identity.profile,
             identity.label,
             identity

--- a/src/bin/caller/peer/transport/intendant.rs
+++ b/src/bin/caller/peer/transport/intendant.rs
@@ -131,6 +131,13 @@ type WsSink = futures_util::stream::SplitSink<WsStream, Message>;
 const CARD_FETCH_TIMEOUT: Duration = Duration::from_secs(10);
 pub const PEER_CLIENT_HEADER: &str = "x-intendant-peer";
 pub const PEER_CLIENT_HEADER_VALUE: &str = "1";
+/// The agent lane's fail-closed opt-in, sibling of `x-intendant-peer`:
+/// the R1 sidecar declares itself so an unknown certificate that
+/// CLAIMS the agent lane is refused outright instead of falling
+/// through to the browser-mTLS ladder. The header is the lane
+/// declaration; the identity record's class is the authority.
+pub const AGENT_CLIENT_HEADER: &str = "x-intendant-agent";
+pub const AGENT_CLIENT_HEADER_VALUE: &str = "1";
 
 pub struct IntendantWsTransport {
     spec: TransportSpec,

--- a/src/bin/caller/web_gateway/access_gates.rs
+++ b/src/bin/caller/web_gateway/access_gates.rs
@@ -966,6 +966,7 @@ mod tests {
         let bus = EventBus::new();
         assert!(!peer_identity_allows_ws_control(None, &control, &bus));
         let peer = PeerConnectionIdentity {
+            class: crate::peer::access_policy::IdentityClass::Peer,
             fingerprint: "peer-fingerprint".to_string(),
             label: "observer".to_string(),
             profile: "observer".to_string(),
@@ -1131,6 +1132,7 @@ mod tests {
         ));
 
         let peer = PeerConnectionIdentity {
+            class: crate::peer::access_policy::IdentityClass::Peer,
             fingerprint: "peer-fingerprint".to_string(),
             label: "trusted peer".to_string(),
             profile: "observer".to_string(),

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -372,12 +372,12 @@ pub(crate) async fn serve_http_request(
     let admitted_relay_peer = relay_peer_admission
         && base_discovery_only_ingress
         && !custom_domain_selected
-        && peer_connection_identity.as_ref().is_some_and(|identity| {
-            match identity.class {
+        && peer_connection_identity
+            .as_ref()
+            .is_some_and(|identity| match identity.class {
                 crate::peer::access_policy::IdentityClass::Peer => true,
                 crate::peer::access_policy::IdentityClass::Agent => req_path == "/mcp",
-            }
-        });
+            });
     // A custom-domain TLS name is itself a live authority decision even
     // before a passkey endpoint mints a lease. Retain that decision at the
     // transport edge now, so body reads, authority-worker awaits, and

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -364,10 +364,20 @@ pub(crate) async fn serve_http_request(
     // custom-domain (owner-name) browser lane is deliberately outside the
     // exemption: peers dial the fleet name, and the owner-name lane stays
     // lease-only in both key states.
+    // Agent-class identities (the R1 sidecar lane) ride the same knob
+    // but are admitted to `/mcp` ALONE on the relay: the sidecar needs
+    // exactly that endpoint, and the amendment that created the class
+    // scopes its relay admission to it — a peer daemon's whole-gateway
+    // admission stays exactly as it was.
     let admitted_relay_peer = relay_peer_admission
         && base_discovery_only_ingress
         && !custom_domain_selected
-        && peer_connection_identity.is_some();
+        && peer_connection_identity.as_ref().is_some_and(|identity| {
+            match identity.class {
+                crate::peer::access_policy::IdentityClass::Peer => true,
+                crate::peer::access_policy::IdentityClass::Agent => req_path == "/mcp",
+            }
+        });
     // A custom-domain TLS name is itself a live authority decision even
     // before a passkey endpoint mints a lease. Retain that decision at the
     // transport edge now, so body reads, authority-worker awaits, and

--- a/src/bin/caller/web_gateway/listener.rs
+++ b/src/bin/caller/web_gateway/listener.rs
@@ -2312,10 +2312,19 @@ fn spawn_web_gateway_from_cert_dir_with_relay_listener(
                     // Browser-enrolled certificates resolve no record and
                     // are refused byte-identically; the owner-name
                     // (custom-domain) lane stays lease-only.
+                    // Peer daemons only: the agent class (R1 sidecar)
+                    // has no relay WS admission at all — its scoped
+                    // lane is `POST /mcp`, and nothing the sidecar
+                    // does needs a socket.
                     let admitted_relay_peer_ws = config.connect.relay_peer_admission
                         && base_discovery_only_ws
                         && !custom_domain_selected
-                        && peer_connection_identity.is_some();
+                        && peer_connection_identity.as_ref().is_some_and(|identity| {
+                            matches!(
+                                identity.class,
+                                crate::peer::access_policy::IdentityClass::Peer
+                            )
+                        });
                     let hosted_ws_authority = if configured_public_ws && hosted_control.enabled() {
                         let ticket =
                             query_param(header_text.lines().next().unwrap_or(""), "hosted_ticket");

--- a/src/bin/caller/web_gateway/listener.rs
+++ b/src/bin/caller/web_gateway/listener.rs
@@ -4817,6 +4817,93 @@ mod tests {
         );
     }
 
+    /// Agent-class identities under the same admission key are scoped
+    /// to `/mcp` on the relay (the amendment that created the class):
+    /// the sidecar's endpoint is admitted, every other path keeps the
+    /// discovery-only refusal, the `/ws` upgrade is refused outright —
+    /// agents have no relay socket at all — and the direct mTLS lane
+    /// stays ordinarily profile-gated, not path-scoped.
+    #[tokio::test]
+    async fn relay_agent_admission_is_scoped_to_mcp() {
+        let mut config = WebGatewayConfig::default();
+        config.connect.relay_peer_admission = true;
+        let gw = spawn_relay_ingress_test_gateway_with_peer_auth(config).await;
+
+        let agent =
+            crate::access::certs::issue_client_identity(gw.access_dir(), "sidecar").unwrap();
+        let agent_fp = crate::peer::access_policy::fingerprint_pem(&agent.cert_pem).unwrap();
+        crate::peer::access_policy::write_approved_agent_identity(
+            gw.access_dir(),
+            &agent_fp,
+            "sidecar",
+            "agent-operator",
+            None,
+            None,
+        )
+        .unwrap();
+
+        const MCP_POST: &str = "POST /mcp HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}";
+        let via_relay_mcp = identity_request(
+            gw.gateway.relay_addr,
+            true,
+            gw.ca_der.clone(),
+            &agent,
+            false,
+            MCP_POST,
+        )
+        .await;
+        assert!(
+            !via_relay_mcp.contains(DISCOVERY_ONLY_REFUSAL),
+            "the agent lane must be admitted to /mcp through the relay: {via_relay_mcp}"
+        );
+        // This rig attaches no MCP server, so the gate's own ladder
+        // answers with ITS unavailability shape — proof the request
+        // cleared transport admission and reached the endpoint.
+        assert!(
+            via_relay_mcp.contains("MCP server not available"),
+            "the admitted call lands in the MCP gate's own ladder: {via_relay_mcp}"
+        );
+        let via_relay_config = identity_request(
+            gw.gateway.relay_addr,
+            true,
+            gw.ca_der.clone(),
+            &agent,
+            false,
+            CONFIG_REQUEST,
+        )
+        .await;
+        assert!(
+            via_relay_config.contains(DISCOVERY_ONLY_REFUSAL),
+            "everything but /mcp keeps the discovery-only refusal for agents: {via_relay_config}"
+        );
+        let via_relay_ws = identity_request(
+            gw.gateway.relay_addr,
+            true,
+            gw.ca_der.clone(),
+            &agent,
+            false,
+            WS_UPGRADE_REQUEST,
+        )
+        .await;
+        assert!(
+            via_relay_ws.contains(DISCOVERY_ONLY_REFUSAL),
+            "agents have no relay WS admission: {via_relay_ws}"
+        );
+        let via_direct_config = identity_request(
+            gw.gateway.direct_addr,
+            false,
+            gw.ca_der.clone(),
+            &agent,
+            false,
+            CONFIG_REQUEST,
+        )
+        .await;
+        assert!(
+            via_direct_config.starts_with("HTTP/1.1 200"),
+            "direct mTLS stays profile-gated, not path-scoped: {via_direct_config}"
+        );
+    }
+
     /// The `hosted_lease_is_the_only_relay_control_authority` sibling:
     /// with the admission key ON, an ACTIVE peer identity record is the
     /// only OTHER relay authority, and it lands in the EXISTING ladder —

--- a/src/bin/caller/web_gateway/peer_requests.rs
+++ b/src/bin/caller/web_gateway/peer_requests.rs
@@ -128,6 +128,10 @@ pub(crate) fn identity_summary_json(
         "fingerprint": record.fingerprint,
         "label": record.label,
         "profile": record.profile,
+        // The identity's lane — the durable management surface must
+        // keep saying whether this grant is a peer daemon or an
+        // enrolled agent client long after approval.
+        "class": record.class,
         "status": record.status,
         "active": record.is_active(now_unix),
         "card_url": record.card_url,

--- a/src/bin/caller/web_gateway/routes_access.rs
+++ b/src/bin/caller/web_gateway/routes_access.rs
@@ -3232,8 +3232,10 @@ pub(crate) fn resolve_peer_connection_identity_from_cert_dir(
             // silently reinterpret. (Header-less requests resolve by
             // the record class alone, matching the peer transport's
             // long-standing contract that the header is an opt-in.)
-            let is_agent =
-                matches!(record.class, crate::peer::access_policy::IdentityClass::Agent);
+            let is_agent = matches!(
+                record.class,
+                crate::peer::access_policy::IdentityClass::Agent
+            );
             if (peer_mode && is_agent) || (agent_mode && !is_agent) {
                 return Err((
                     403,
@@ -3320,6 +3322,7 @@ mod tests {
         let bus = EventBus::new();
         let mut events = bus.subscribe();
         let identity = PeerConnectionIdentity {
+            class: crate::peer::access_policy::IdentityClass::Peer,
             fingerprint: "peer-fingerprint".to_string(),
             label: "Peer label".to_string(),
             profile: "file-reader".to_string(),
@@ -4123,6 +4126,97 @@ mod tests {
         assert!(err.1.contains("peer identity revoked"));
     }
 
+    /// The class matrix at resolution: an agent record resolves with
+    /// its class; a lane-declaration mismatch in either direction is a
+    /// 403, never a silent reinterpretation; an unknown certificate
+    /// that declares the agent lane is refused like the peer twin.
+    #[test]
+    fn connection_identity_classes_never_cross_lanes() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let agent_fp = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        let peer_fp = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+        let bare = "GET /mcp HTTP/1.1\r\nHost: x\r\n\r\n";
+        let peer_header = "GET /mcp HTTP/1.1\r\nHost: x\r\nx-intendant-peer: 1\r\n\r\n";
+        let agent_header = "GET /mcp HTTP/1.1\r\nHost: x\r\nx-intendant-agent: 1\r\n\r\n";
+
+        // Unknown cert declaring the agent lane: refused by name.
+        let err = resolve_peer_connection_identity_from_cert_dir(
+            tmp.path(),
+            agent_header,
+            Some(agent_fp),
+        )
+        .unwrap_err();
+        assert_eq!(err.0, 403);
+        assert!(err.1.contains("unknown agent client certificate"));
+
+        crate::peer::access_policy::write_approved_agent_identity(
+            tmp.path(),
+            agent_fp,
+            "sidecar",
+            "agent-operator",
+            None,
+            None,
+        )
+        .unwrap();
+        crate::peer::access_policy::write_approved_identity(
+            tmp.path(),
+            peer_fp,
+            "peer-b",
+            "read-only-display",
+            None,
+            None,
+        )
+        .unwrap();
+
+        // The agent record resolves — headerless and with its own
+        // declaration — carrying its class.
+        for header in [bare, agent_header] {
+            let identity =
+                resolve_peer_connection_identity_from_cert_dir(tmp.path(), header, Some(agent_fp))
+                    .unwrap()
+                    .unwrap();
+            assert!(matches!(
+                identity.class,
+                crate::peer::access_policy::IdentityClass::Agent
+            ));
+            assert_eq!(identity.profile, "agent-operator");
+        }
+
+        // Lane mismatches refuse in both directions.
+        let err =
+            resolve_peer_connection_identity_from_cert_dir(tmp.path(), peer_header, Some(agent_fp))
+                .unwrap_err();
+        assert_eq!(err.0, 403);
+        assert!(err.1.contains("does not match the declared lane"));
+        let err =
+            resolve_peer_connection_identity_from_cert_dir(tmp.path(), agent_header, Some(peer_fp))
+                .unwrap_err();
+        assert_eq!(err.0, 403);
+        assert!(err.1.contains("does not match the declared lane"));
+
+        // The classed identities bind classed principals at the one
+        // choke point.
+        let agent_identity =
+            resolve_peer_connection_identity_from_cert_dir(tmp.path(), bare, Some(agent_fp))
+                .unwrap()
+                .unwrap();
+        let principal = peer_identity_access_principal(&agent_identity, "https");
+        assert_eq!(principal.kind, "agent_client");
+        let peer_identity =
+            resolve_peer_connection_identity_from_cert_dir(tmp.path(), bare, Some(peer_fp))
+                .unwrap()
+                .unwrap();
+        let principal = peer_identity_access_principal(&peer_identity, "https");
+        assert_eq!(principal.kind, "peer_daemon");
+
+        // Revoked agent records name their lane in the refusal.
+        crate::peer::access_policy::revoke_identity(tmp.path(), agent_fp).unwrap();
+        let err = resolve_peer_connection_identity_from_cert_dir(tmp.path(), bare, Some(agent_fp))
+            .unwrap_err();
+        assert_eq!(err.0, 403);
+        assert!(err.1.contains("agent identity revoked"));
+    }
+
     /// Connections without a TLS client certificate resolve as anonymous,
     /// even when the peer transport's `x-intendant-peer` header is present.
     /// Certless federation modes (`AuthRequirements::none()` on trusted
@@ -4214,6 +4308,7 @@ mod tests {
     fn http_access_context_carries_the_peer_identity_filesystem() {
         let tmp = tempfile::TempDir::new().unwrap();
         let identity = PeerConnectionIdentity {
+            class: crate::peer::access_policy::IdentityClass::Peer,
             fingerprint: "peerfp01".to_string(),
             label: "peer-a".to_string(),
             profile: "terminal-operator".to_string(),
@@ -4471,6 +4566,7 @@ mod tests {
             iam_cert_dir: None,
         };
         let peer_identity = PeerConnectionIdentity {
+            class: crate::peer::access_policy::IdentityClass::Peer,
             fingerprint: "fp".to_string(),
             label: "peer".to_string(),
             profile: "peer-root".to_string(),
@@ -4745,6 +4841,7 @@ mod tests {
             iam_cert_dir: None,
         };
         let peer_identity = PeerConnectionIdentity {
+            class: crate::peer::access_policy::IdentityClass::Peer,
             fingerprint: "fp".to_string(),
             label: "peer".to_string(),
             profile: "viewer".to_string(),

--- a/src/bin/caller/web_gateway/routes_access.rs
+++ b/src/bin/caller/web_gateway/routes_access.rs
@@ -3009,6 +3009,21 @@ pub(crate) fn dashboard_control_grant_for_client(
     trusted_local_admitted: bool,
 ) -> Result<crate::dashboard_control::DashboardControlGrant, String> {
     if let Some(identity) = identity {
+        // The agent lane has NO dashboard-control surface in its first
+        // cut: the R1 charter is `/mcp` alone, and this grant's Peer
+        // arm hardcodes the peer principal — admitting an agent here
+        // would walk it into peer-only tenant edges (memory propose)
+        // under the wrong actor class. Refused by name until an owner
+        // ruling gives agents their own grant class.
+        if matches!(
+            identity.class,
+            crate::peer::access_policy::IdentityClass::Agent
+        ) {
+            return Err(
+                "agent identities have no dashboard-control surface; the agent lane is /mcp only"
+                    .to_string(),
+            );
+        }
         return Ok(crate::dashboard_control::DashboardControlGrant::Peer {
             fingerprint: identity.fingerprint.clone(),
             label: identity.label.clone(),
@@ -4215,6 +4230,42 @@ mod tests {
             .unwrap_err();
         assert_eq!(err.0, 403);
         assert!(err.1.contains("agent identity revoked"));
+    }
+
+    /// The dashboard-control entrance is peer/user-lane only: an
+    /// agent-class identity is refused by name — the grant's Peer arm
+    /// hardcodes the peer principal, and walking an agent in would
+    /// reach peer-only tenant edges (memory propose) under the wrong
+    /// actor class. The agent lane is `/mcp` alone.
+    #[test]
+    fn dashboard_control_grant_refuses_the_agent_lane() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let agent = PeerConnectionIdentity {
+            fingerprint: "dd".repeat(32),
+            label: "sidecar".into(),
+            profile: "agent-operator".into(),
+            class: crate::peer::access_policy::IdentityClass::Agent,
+            filesystem: Default::default(),
+            record: None,
+        };
+        let err = dashboard_control_grant_for_client(tmp.path(), Some(&agent), None, true, false)
+            .unwrap_err();
+        assert!(
+            err.contains("agent identities have no dashboard-control surface"),
+            "{err}"
+        );
+        let peer = PeerConnectionIdentity {
+            fingerprint: "ee".repeat(32),
+            label: "peer".into(),
+            profile: "read-only-display".into(),
+            class: crate::peer::access_policy::IdentityClass::Peer,
+            filesystem: Default::default(),
+            record: None,
+        };
+        assert!(matches!(
+            dashboard_control_grant_for_client(tmp.path(), Some(&peer), None, true, false),
+            Ok(crate::dashboard_control::DashboardControlGrant::Peer { .. })
+        ));
     }
 
     /// Connections without a TLS client certificate resolve as anonymous,

--- a/src/bin/caller/web_gateway/routes_access.rs
+++ b/src/bin/caller/web_gateway/routes_access.rs
@@ -11,6 +11,12 @@ pub(crate) struct PeerConnectionIdentity {
     pub(crate) fingerprint: String,
     pub(crate) label: String,
     pub(crate) profile: String,
+    /// The identity record's lane (`Peer` = federated daemon, `Agent`
+    /// = enrolled R1 agent client). Every consumer that treats the two
+    /// differently BRANCHES on this — the principal binding, the relay
+    /// admission scope — so an agent credential can never ride a
+    /// peer-shaped code path by omission, and vice versa.
+    pub(crate) class: crate::peer::access_policy::IdentityClass,
     pub(crate) filesystem: crate::peer::access_policy::FilesystemAccessPolicy,
     pub(crate) record: Option<crate::peer::access_policy::PeerIdentityRecord>,
 }
@@ -3054,12 +3060,27 @@ pub(crate) fn peer_identity_access_principal(
     identity: &PeerConnectionIdentity,
     transport: &str,
 ) -> crate::access::iam::AccessPrincipal {
-    crate::access::iam::AccessPrincipal::peer_daemon(
-        identity.fingerprint.clone(),
-        identity.label.clone(),
-        identity.profile.clone(),
-        transport,
-    )
+    // The one place a resolved connection identity becomes a principal:
+    // the record class picks the principal kind, so an agent identity
+    // can never mint `peer_daemon` authority or vice versa.
+    match identity.class {
+        crate::peer::access_policy::IdentityClass::Peer => {
+            crate::access::iam::AccessPrincipal::peer_daemon(
+                identity.fingerprint.clone(),
+                identity.label.clone(),
+                identity.profile.clone(),
+                transport,
+            )
+        }
+        crate::peer::access_policy::IdentityClass::Agent => {
+            crate::access::iam::AccessPrincipal::agent_client(
+                identity.fingerprint.clone(),
+                identity.label.clone(),
+                identity.profile.clone(),
+                transport,
+            )
+        }
+    }
 }
 
 pub(crate) fn authorize_http_filesystem_access(
@@ -3153,12 +3174,27 @@ pub(crate) fn audit_peer_filesystem_access(
 }
 
 pub(crate) fn peer_client_header_present(header_text: &str) -> bool {
+    lane_header_present(
+        header_text,
+        crate::peer::transport::intendant::PEER_CLIENT_HEADER,
+        crate::peer::transport::intendant::PEER_CLIENT_HEADER_VALUE,
+    )
+}
+
+pub(crate) fn agent_client_header_present(header_text: &str) -> bool {
+    lane_header_present(
+        header_text,
+        crate::peer::transport::intendant::AGENT_CLIENT_HEADER,
+        crate::peer::transport::intendant::AGENT_CLIENT_HEADER_VALUE,
+    )
+}
+
+fn lane_header_present(header_text: &str, header: &str, expected: &str) -> bool {
     header_text.lines().any(|line| {
         let Some((name, value)) = line.split_once(':') else {
             return false;
         };
-        name.eq_ignore_ascii_case(crate::peer::transport::intendant::PEER_CLIENT_HEADER)
-            && value.trim() == crate::peer::transport::intendant::PEER_CLIENT_HEADER_VALUE
+        name.eq_ignore_ascii_case(header) && value.trim() == expected
     })
 }
 
@@ -3183,38 +3219,69 @@ pub(crate) fn resolve_peer_connection_identity_from_cert_dir(
         return Ok(None);
     };
     let peer_mode = peer_client_header_present(header_text);
+    let agent_mode = agent_client_header_present(header_text);
 
     let record = crate::peer::access_policy::lookup_identity(cert_dir, fingerprint)
         .map_err(|e| (500, serde_json::json!({"error": e.to_string()}).to_string()))?;
     let now_unix = crate::access::client_key::now_unix_ms() / 1000;
     match record {
-        Some(record) if record.is_active(now_unix) => Ok(Some(PeerConnectionIdentity {
-            fingerprint: record.fingerprint.clone(),
-            label: record.label.clone(),
-            profile: record.profile.clone(),
-            filesystem: record.filesystem.clone(),
-            record: Some(record),
-        })),
+        Some(record) if record.is_active(now_unix) => {
+            // Lane-declaration discipline: a client that DECLARES one
+            // lane while holding the other class's identity is refused
+            // outright — misconfiguration or replay, never something to
+            // silently reinterpret. (Header-less requests resolve by
+            // the record class alone, matching the peer transport's
+            // long-standing contract that the header is an opt-in.)
+            let is_agent =
+                matches!(record.class, crate::peer::access_policy::IdentityClass::Agent);
+            if (peer_mode && is_agent) || (agent_mode && !is_agent) {
+                return Err((
+                    403,
+                    serde_json::json!({
+                        "error": "identity class does not match the declared lane",
+                        "fingerprint": record.fingerprint,
+                        "label": record.label,
+                    })
+                    .to_string(),
+                ));
+            }
+            Ok(Some(PeerConnectionIdentity {
+                fingerprint: record.fingerprint.clone(),
+                label: record.label.clone(),
+                profile: record.profile.clone(),
+                class: record.class,
+                filesystem: record.filesystem.clone(),
+                record: Some(record),
+            }))
+        }
         Some(record) => Err((
             403,
             serde_json::json!({
-                "error": if matches!(
-                    record.status,
-                    crate::peer::access_policy::PeerIdentityStatus::Approved
+                "error": match (
+                    matches!(
+                        record.status,
+                        crate::peer::access_policy::PeerIdentityStatus::Approved
+                    ),
+                    matches!(record.class, crate::peer::access_policy::IdentityClass::Agent),
                 ) {
-                    "peer identity expired"
-                } else {
-                    "peer identity revoked"
+                    (true, false) => "peer identity expired",
+                    (false, false) => "peer identity revoked",
+                    (true, true) => "agent identity expired",
+                    (false, true) => "agent identity revoked",
                 },
                 "fingerprint": record.fingerprint,
                 "label": record.label,
             })
             .to_string(),
         )),
-        None if peer_mode => Err((
+        None if peer_mode || agent_mode => Err((
             403,
             serde_json::json!({
-                "error": "unknown peer client certificate",
+                "error": if agent_mode {
+                    "unknown agent client certificate"
+                } else {
+                    "unknown peer client certificate"
+                },
                 "fingerprint": fingerprint,
             })
             .to_string(),

--- a/src/bin/caller/web_gateway/routes_access.rs
+++ b/src/bin/caller/web_gateway/routes_access.rs
@@ -1446,13 +1446,31 @@ pub(crate) fn access_overview_response_value_with_identities_and_iam(
             crate::peer::access_policy::PeerIdentityStatus::Approved => "expired",
             crate::peer::access_policy::PeerIdentityStatus::Revoked => "revoked",
         };
-        let principal_id = format!("principal:inbound-peer-daemon:{fingerprint}");
-        let grant_id = format!("grant:inbound-peer:{fingerprint}:{}", identity.profile);
-        let transport_id = format!("transport:inbound-peer-mtls:{fingerprint}");
+        // The overview projects the record's class faithfully — an
+        // enrolled agent client must never read as a federated daemon
+        // on the IAM topology the owner audits (it would contradict the
+        // identity listing and misstate what the grant admits).
+        let is_agent = matches!(
+            identity.class,
+            crate::peer::access_policy::IdentityClass::Agent
+        );
+        let (principal_id, grant_id, transport_id) = if is_agent {
+            (
+                format!("principal:agent-client:{fingerprint}"),
+                format!("grant:agent-client:{fingerprint}:{}", identity.profile),
+                format!("transport:agent-client-mtls:{fingerprint}"),
+            )
+        } else {
+            (
+                format!("principal:inbound-peer-daemon:{fingerprint}"),
+                format!("grant:inbound-peer:{fingerprint}:{}", identity.profile),
+                format!("transport:inbound-peer-mtls:{fingerprint}"),
+            )
+        };
         principals.push(serde_json::json!({
             "id": principal_id.clone(),
-            "kind": "peer_daemon",
-            "kind_label": "Peer daemon",
+            "kind": if is_agent { "agent_client" } else { "peer_daemon" },
+            "kind_label": if is_agent { "Agent client" } else { "Peer daemon" },
             "label": identity.label.clone(),
             "source": "peer_access_identity",
             "target_id": local_target_id.clone(),
@@ -1464,18 +1482,18 @@ pub(crate) fn access_overview_response_value_with_identities_and_iam(
             "organization": serde_json::Value::Null,
             "authn": [{
                 "kind": "daemon_mutual_tls",
-                "label": "Daemon mTLS identity"
+                "label": if is_agent { "Agent mTLS identity" } else { "Daemon mTLS identity" }
             }]
         }));
         grants.push(serde_json::json!({
             "id": grant_id,
             "principal_id": principal_id,
             "target_id": local_target_id.clone(),
-            "kind": "inbound_daemon_peer_profile",
-            "kind_label": "Inbound daemon peer profile",
-            "policy_id": "policy:peer-profile",
-            "role": "peer_profile",
-            "role_label": "Peer profile",
+            "kind": if is_agent { "agent_client_profile" } else { "inbound_daemon_peer_profile" },
+            "kind_label": if is_agent { "Agent client profile" } else { "Inbound daemon peer profile" },
+            "policy_id": if is_agent { "policy:agent-profile" } else { "policy:peer-profile" },
+            "role": if is_agent { "agent_profile" } else { "peer_profile" },
+            "role_label": if is_agent { "Agent profile" } else { "Peer profile" },
             "profile": identity.profile.clone(),
             "transport_id": transport_id.clone(),
             "source": "peer_access_identity",
@@ -1489,8 +1507,8 @@ pub(crate) fn access_overview_response_value_with_identities_and_iam(
         }));
         transports.push(serde_json::json!({
             "id": transport_id,
-            "kind": "inbound_peer_mtls",
-            "kind_label": "Inbound peer mTLS",
+            "kind": if is_agent { "agent_client_mtls" } else { "inbound_peer_mtls" },
+            "kind_label": if is_agent { "Agent client mTLS" } else { "Inbound peer mTLS" },
             "label": identity.label.clone(),
             "status": status,
             "implementation": "daemon_mutual_tls_inbound",
@@ -3924,6 +3942,81 @@ mod tests {
                 && transport["fingerprint"].as_str() == Some(fp)
                 && transport["status"].as_str() == Some("active")),
             "inbound peer mTLS transport should be visible"
+        );
+    }
+
+    /// The IAM overview projects the record's class faithfully: an
+    /// enrolled agent client reads as `agent_client` with an
+    /// agent-profile grant and its own transport kind — never as a
+    /// federated daemon — while peer records keep their exact
+    /// historical projection beside it.
+    #[test]
+    fn access_overview_projects_agent_identities_as_agent_clients() {
+        let cert_dir = tempfile::TempDir::new().unwrap();
+        let agent_fp = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+        crate::peer::access_policy::write_approved_agent_identity(
+            cert_dir.path(),
+            agent_fp,
+            "sidecar",
+            "agent-operator",
+            Some("req-agent"),
+            None,
+        )
+        .unwrap();
+        let peer_fp = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+        crate::peer::access_policy::write_approved_identity(
+            cert_dir.path(),
+            peer_fp,
+            "peer-e",
+            "stats",
+            None,
+            None,
+        )
+        .unwrap();
+        let identities = crate::peer::access_policy::list_identities(cert_dir.path()).unwrap();
+        let agent_card = serde_json::json!({
+            "id": "local-daemon",
+            "label": "Local daemon",
+            "capabilities": [],
+        });
+        let payload =
+            access_overview_response_value_with_identities(&agent_card, None, &identities);
+
+        let principals = payload["principals"].as_array().expect("principals");
+        assert!(
+            principals.iter().any(|principal| {
+                principal["id"].as_str()
+                    == Some(format!("principal:agent-client:{agent_fp}").as_str())
+                    && principal["kind"].as_str() == Some("agent_client")
+                    && principal["kind_label"].as_str() == Some("Agent client")
+            }),
+            "agent identity must project as an agent_client principal"
+        );
+        assert!(
+            principals.iter().any(|principal| {
+                principal["id"].as_str()
+                    == Some(format!("principal:inbound-peer-daemon:{peer_fp}").as_str())
+                    && principal["kind"].as_str() == Some("peer_daemon")
+            }),
+            "peer identities keep their historical projection"
+        );
+        let grants = payload["grants"].as_array().expect("grants");
+        assert!(
+            grants.iter().any(|grant| {
+                grant["kind"].as_str() == Some("agent_client_profile")
+                    && grant["role"].as_str() == Some("agent_profile")
+                    && grant["profile"].as_str() == Some("agent-operator")
+                    && grant["status"].as_str() == Some("active")
+            }),
+            "the agent grant must carry the agent role vocabulary"
+        );
+        let transports = payload["transports"].as_array().expect("transports");
+        assert!(
+            transports.iter().any(|transport| {
+                transport["kind"].as_str() == Some("agent_client_mtls")
+                    && transport["fingerprint"].as_str() == Some(agent_fp)
+            }),
+            "the agent transport must carry its own kind"
         );
     }
 

--- a/src/bin/caller/web_gateway/routes_peers.rs
+++ b/src/bin/caller/web_gateway/routes_peers.rs
@@ -648,6 +648,7 @@ pub(crate) async fn peers_pairing_request_access(
             requester_label: req.label,
             requested_profile: req.profile,
             requester_card_url: req.requester_card_url,
+            requested_class: None,
         },
     )
     .await

--- a/src/bin/caller/web_gateway/routes_peers.rs
+++ b/src/bin/caller/web_gateway/routes_peers.rs
@@ -2998,6 +2998,7 @@ mod tests {
         );
 
         let peer_identity = PeerConnectionIdentity {
+            class: crate::peer::access_policy::IdentityClass::Peer,
             fingerprint: "abc123".to_string(),
             label: "peer-a".to_string(),
             profile: "peer-operator".to_string(),

--- a/src/bin/caller/web_gateway/routes_peers.rs
+++ b/src/bin/caller/web_gateway/routes_peers.rs
@@ -905,6 +905,9 @@ pub(crate) fn access_request_summary_json(
         "code": request.code,
         "status": request.status,
         "requester_label": request.requester_label,
+        // Which lane an approval will mint — the owner must SEE what
+        // they are approving: an agent client is not a peer daemon.
+        "class": request.class,
         "requested_profile": request.requested_profile,
         "approved_profile": request.approved_profile,
         // Present only when the claim was signed inside a verified

--- a/src/bin/caller/web_gateway/routes_transfers.rs
+++ b/src/bin/caller/web_gateway/routes_transfers.rs
@@ -1592,6 +1592,7 @@ mod tests {
         // for the fs-scoped grant and for a peer identity carrying the
         // same policy — identical decisions and wording on both.
         let peer = PeerConnectionIdentity {
+            class: crate::peer::access_policy::IdentityClass::Peer,
             fingerprint: "aabbccdd".to_string(),
             label: "peer".to_string(),
             profile: "file-operator".to_string(),

--- a/src/bin/caller/web_gateway/ws_session.rs
+++ b/src/bin/caller/web_gateway/ws_session.rs
@@ -3525,6 +3525,7 @@ mod peer_approval_attribution_tests {
 
     fn identity(label: &str) -> PeerConnectionIdentity {
         PeerConnectionIdentity {
+            class: crate::peer::access_policy::IdentityClass::Peer,
             fingerprint: "aabbccddeeff00112233".to_string(),
             label: label.to_string(),
             profile: "peer-root".to_string(),

--- a/static/app.html
+++ b/static/app.html
@@ -39429,7 +39429,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '1f343358925922eb';
+const INTENDANT_APP_BUILD = '9af1c4c4816687fa';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -123904,6 +123904,17 @@ function setDaemonPairingStatus(id, msg, kind) {
   el.className = 'daemon-pairing-status' + (kind ? ' ' + kind : '');
 }
 
+// Agent-lane profiles (mirrors the daemon's AGENT_PROFILES — pinned by
+// the same parity test that pins PEER_PROFILE_OPTIONS): offered ONLY on
+// agent-class enrollment requests, never in the peer picker.
+const AGENT_PROFILE_OPTIONS = [
+  {
+    profile: 'agent-operator',
+    label: 'Agent operator (ceiling)',
+    summary: 'Everything a machine principal may hold — approvals, sessions, terminal, displays — except access administration and credential custody. Grant a narrower peer profile below to cap further.',
+  },
+];
+
 const PEER_PROFILE_OPTIONS = [
   {
     profile: 'read-only-display',
@@ -123985,19 +123996,27 @@ function peerProfileMeta(profile) {
     'peer-daemon': 'peer-root',
   };
   const canonical = aliases[value] || value;
-  return PEER_PROFILE_OPTIONS.find(item => item.profile === canonical) || {
-    profile: canonical,
-    label: canonical || 'Presence only',
-    summary: 'Unknown profiles are treated as presence-only by this build.',
-  };
+  return PEER_PROFILE_OPTIONS.find(item => item.profile === canonical)
+    || AGENT_PROFILE_OPTIONS.find(item => item.profile === canonical)
+    || {
+      profile: canonical,
+      label: canonical || 'Presence only',
+      summary: 'Unknown profiles are treated as presence-only by this build.',
+    };
 }
 
-function renderPeerProfileOptions(selected) {
+function renderPeerProfileOptions(selected, requestClass) {
   // Mirrors the daemon's DEFAULT_PROFILE (access_policy.rs): an approval
-  // with no stated profile yields read-only-display.
+  // with no stated profile yields read-only-display. Agent-class
+  // requests additionally offer the agent ceiling — without it, a
+  // requested agent-operator would silently fall back to the first
+  // peer option and the approval would post that narrower override.
   const value = String(selected || 'read-only-display').toLowerCase();
   const selectedMeta = peerProfileMeta(value);
-  return PEER_PROFILE_OPTIONS.map(({ profile, label, summary }) => (
+  const options = requestClass === 'agent'
+    ? AGENT_PROFILE_OPTIONS.concat(PEER_PROFILE_OPTIONS)
+    : PEER_PROFILE_OPTIONS;
+  return options.map(({ profile, label, summary }) => (
     `<option value="${escapeHtml(profile)}" ${profile === selectedMeta.profile ? 'selected' : ''} title="${escapeHtml(summary)}">${escapeHtml(label)}</option>`
   )).join('');
 }
@@ -124262,7 +124281,15 @@ function renderPeerAccessRequests(requests) {
     const timing = [source, expires].filter(Boolean).join(' - ');
     const pending = status === 'pending';
     const requestedProfile = req.approved_profile || req.requested_profile || 'read-only-display';
-    const roleLabel = req.approved_profile ? 'Approved peer profile' : 'Requested peer profile';
+    // Which lane approving MINTS (the daemon's stored request class):
+    // an agent client is not a peer daemon, and the owner must see the
+    // difference before deciding. Absent = a pre-agent daemon = peer.
+    const requestClass = String(req.class || 'peer').toLowerCase();
+    const isAgentRequest = requestClass === 'agent';
+    const laneWord = isAgentRequest ? 'agent' : 'peer';
+    const roleLabel = req.approved_profile
+      ? `Approved ${laneWord} profile`
+      : `Requested ${laneWord} profile`;
     // Cross-owner tier claim (docs/src/trust-tiers.md § Where fleet
     // metadata rides): the daemon stores requester_tier only when the
     // claim was signed inside a verified caller-ID, so presence here
@@ -124298,8 +124325,11 @@ function renderPeerAccessRequests(requests) {
         ${upwardAlarm
           ? '<div class="daemon-access-request-meta daemon-access-request-warn" title="Grants flow toward disposable machines, never up. Approving would hand a disposable box authority on this integrated one — the tier bridge the doctrine warns about.">⚠ Upward grant: this is a disposable machine asking for authority on an integrated one. Approving bridges your tiers.</div>'
           : (pending && integratedTier ? '<div class="daemon-access-request-meta daemon-access-request-warn" title="Grants flow toward disposable machines, never up. If that daemon is lower-trust than this one, approving bridges your tiers — see the Trust tier card in Access.">⚠ Integrated-tier machine: approving grants a peer daemon authority here. Make sure trust flows downward.</div>' : '')}
+        ${isAgentRequest
+          ? '<div class="daemon-access-request-meta daemon-access-request-warn" title="This enrollment mints an agent-client identity — a machine principal that drives this daemon over MCP at whatever profile you grant. It is not a federated peer daemon.">🤖 AGENT enrollment: approving lets this machine operate the daemon at the granted profile.</div>'
+          : ''}
         ${timing ? `<div class="daemon-access-request-meta">${timing}</div>` : ''}
-        ${pending ? `<div class="daemon-pairing-row"><select data-access-request-profile="${escapeHtml(requestId)}">${renderPeerProfileOptions(requestedProfile)}</select></div>` : ''}
+        ${pending ? `<div class="daemon-pairing-row"><select data-access-request-profile="${escapeHtml(requestId)}">${renderPeerProfileOptions(requestedProfile, requestClass)}</select></div>` : ''}
         <div class="daemon-access-request-actions">
           <button class="approve" type="button" data-access-request-action="approve" data-request-id="${escapeHtml(requestId)}" ${pending ? '' : 'disabled'}>Approve</button>
           <button class="deny" type="button" data-access-request-action="deny" data-request-id="${escapeHtml(requestId)}" ${pending ? '' : 'disabled'}>Deny</button>

--- a/static/app.html
+++ b/static/app.html
@@ -39429,7 +39429,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '38bb26cc40b3293a';
+const INTENDANT_APP_BUILD = '821cdd1c6b3f2d3d';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -124013,11 +124013,18 @@ function renderPeerProfileOptions(selected, requestClass) {
   // peer option and the approval would post that narrower override.
   const value = String(selected || 'read-only-display').toLowerCase();
   const selectedMeta = peerProfileMeta(value);
+  // The ceiling rides LAST, and an unknown or mistyped requested
+  // profile preselects the cautious default — never whatever happens
+  // to sit first. A fail-closed request must not become the maximum
+  // grant through a typo plus the browser's first-option fallback.
   const options = requestClass === 'agent'
-    ? AGENT_PROFILE_OPTIONS.concat(PEER_PROFILE_OPTIONS)
+    ? PEER_PROFILE_OPTIONS.concat(AGENT_PROFILE_OPTIONS)
     : PEER_PROFILE_OPTIONS;
+  const effective = options.some(item => item.profile === selectedMeta.profile)
+    ? selectedMeta.profile
+    : 'read-only-display';
   return options.map(({ profile, label, summary }) => (
-    `<option value="${escapeHtml(profile)}" ${profile === selectedMeta.profile ? 'selected' : ''} title="${escapeHtml(summary)}">${escapeHtml(label)}</option>`
+    `<option value="${escapeHtml(profile)}" ${profile === effective ? 'selected' : ''} title="${escapeHtml(summary)}">${escapeHtml(label)}</option>`
   )).join('');
 }
 

--- a/static/app.html
+++ b/static/app.html
@@ -39429,7 +39429,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '9af1c4c4816687fa';
+const INTENDANT_APP_BUILD = '38bb26cc40b3293a';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -124412,19 +124412,26 @@ function renderPeerIdentities(identities) {
 
   list.innerHTML = identities.map(identity => {
     const fingerprint = String(identity.fingerprint || '');
-    const label = escapeHtml(identity.label || 'Unnamed daemon');
+    // The lane the daemon stored for this grant (absent = a record
+    // from before the agent lane = peer): the durable management
+    // surface must keep the peer/agent distinction visible.
+    const identityClass = String(identity.class || 'peer').toLowerCase();
+    const isAgent = identityClass === 'agent';
+    const label = escapeHtml(identity.label || (isAgent ? 'Unnamed agent' : 'Unnamed daemon'));
     const status = String(identity.status || 'unknown').toLowerCase();
     const role = peerProfileMeta(identity.profile || 'presence-only');
     const request = identity.request_id ? `Request ${escapeHtml(identity.request_id)}` : '';
     const card = identity.card_url ? escapeHtml(identity.card_url) : '';
     const active = status === 'approved';
+    const laneLabel = isAgent ? 'Agent profile' : 'Peer profile';
     return `
       <div class="daemon-identity-card ${escapeHtml(status)}">
         <div class="daemon-identity-head">
-          <span>${label}</span>
+          <span>${isAgent ? '🤖 ' : ''}${label}</span>
           <span class="daemon-identity-status ${escapeHtml(status)}">${escapeHtml(status)}</span>
         </div>
-        <div class="daemon-identity-role" title="Peer profile ${escapeHtml(identity.profile || 'presence-only')}">Peer profile ${escapeHtml(role.label)}</div>
+        ${isAgent ? '<div class="daemon-access-request-meta" title="An enrolled agent client: a machine principal that drives this daemon over MCP at the granted profile. Not a federated peer daemon.">agent client (MCP lane)</div>' : ''}
+        <div class="daemon-identity-role" title="${laneLabel} ${escapeHtml(identity.profile || 'presence-only')}">${laneLabel} ${escapeHtml(role.label)}</div>
         <div class="daemon-identity-profile">${escapeHtml(role.summary)}${request ? ` - ${request}` : ''}</div>
         ${card ? `<div class="daemon-identity-profile">${card}</div>` : ''}
         <div class="daemon-identity-fingerprint" title="${escapeHtml(fingerprint)}">${escapeHtml(fingerprint)}</div>

--- a/static/app.html
+++ b/static/app.html
@@ -39429,7 +39429,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '04ddfd99177d54b9';
+const INTENDANT_APP_BUILD = '1f343358925922eb';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -81796,8 +81796,8 @@ function accessOverviewModel() {
         peer_profile_grants: true,
         user_client_grants: true,
         principal_binding: 'root_peer_and_local_user_client',
-        enforced_principal_kinds: ['root_session', 'peer_daemon', 'human_user', 'browser_certificate', 'agent_session', 'local_process'],
-        reason: 'The daemon enforces trusted owner/root dashboard sessions, approved daemon peers, browser/native mTLS identities, supervised agent sessions, MCP token holders, and trusted local-process grants. Browser-key records can verify peer attribution, but neither they nor Connect-account records become the controlling IAM principal for alpha control traffic.',
+        enforced_principal_kinds: ['root_session', 'peer_daemon', 'agent_client', 'human_user', 'browser_certificate', 'agent_session', 'local_process'],
+        reason: 'The daemon enforces trusted owner/root dashboard sessions, approved daemon peers, enrolled agent clients, browser/native mTLS identities, supervised agent sessions, MCP token holders, and trusted local-process grants. Browser-key records can verify peer attribution, but neither they nor Connect-account records become the controlling IAM principal for alpha control traffic.',
       },
       role_ceilings: {
         connect_account: 'role:none',

--- a/static/app/42b-access-model.js
+++ b/static/app/42b-access-model.js
@@ -1739,8 +1739,8 @@ function accessOverviewModel() {
         peer_profile_grants: true,
         user_client_grants: true,
         principal_binding: 'root_peer_and_local_user_client',
-        enforced_principal_kinds: ['root_session', 'peer_daemon', 'human_user', 'browser_certificate', 'agent_session', 'local_process'],
-        reason: 'The daemon enforces trusted owner/root dashboard sessions, approved daemon peers, browser/native mTLS identities, supervised agent sessions, MCP token holders, and trusted local-process grants. Browser-key records can verify peer attribution, but neither they nor Connect-account records become the controlling IAM principal for alpha control traffic.',
+        enforced_principal_kinds: ['root_session', 'peer_daemon', 'agent_client', 'human_user', 'browser_certificate', 'agent_session', 'local_process'],
+        reason: 'The daemon enforces trusted owner/root dashboard sessions, approved daemon peers, enrolled agent clients, browser/native mTLS identities, supervised agent sessions, MCP token holders, and trusted local-process grants. Browser-key records can verify peer attribution, but neither they nor Connect-account records become the controlling IAM principal for alpha control traffic.',
       },
       role_ceilings: {
         connect_account: 'role:none',

--- a/static/app/52-peer-display.js
+++ b/static/app/52-peer-display.js
@@ -2477,6 +2477,17 @@ function setDaemonPairingStatus(id, msg, kind) {
   el.className = 'daemon-pairing-status' + (kind ? ' ' + kind : '');
 }
 
+// Agent-lane profiles (mirrors the daemon's AGENT_PROFILES — pinned by
+// the same parity test that pins PEER_PROFILE_OPTIONS): offered ONLY on
+// agent-class enrollment requests, never in the peer picker.
+const AGENT_PROFILE_OPTIONS = [
+  {
+    profile: 'agent-operator',
+    label: 'Agent operator (ceiling)',
+    summary: 'Everything a machine principal may hold — approvals, sessions, terminal, displays — except access administration and credential custody. Grant a narrower peer profile below to cap further.',
+  },
+];
+
 const PEER_PROFILE_OPTIONS = [
   {
     profile: 'read-only-display',
@@ -2558,19 +2569,27 @@ function peerProfileMeta(profile) {
     'peer-daemon': 'peer-root',
   };
   const canonical = aliases[value] || value;
-  return PEER_PROFILE_OPTIONS.find(item => item.profile === canonical) || {
-    profile: canonical,
-    label: canonical || 'Presence only',
-    summary: 'Unknown profiles are treated as presence-only by this build.',
-  };
+  return PEER_PROFILE_OPTIONS.find(item => item.profile === canonical)
+    || AGENT_PROFILE_OPTIONS.find(item => item.profile === canonical)
+    || {
+      profile: canonical,
+      label: canonical || 'Presence only',
+      summary: 'Unknown profiles are treated as presence-only by this build.',
+    };
 }
 
-function renderPeerProfileOptions(selected) {
+function renderPeerProfileOptions(selected, requestClass) {
   // Mirrors the daemon's DEFAULT_PROFILE (access_policy.rs): an approval
-  // with no stated profile yields read-only-display.
+  // with no stated profile yields read-only-display. Agent-class
+  // requests additionally offer the agent ceiling — without it, a
+  // requested agent-operator would silently fall back to the first
+  // peer option and the approval would post that narrower override.
   const value = String(selected || 'read-only-display').toLowerCase();
   const selectedMeta = peerProfileMeta(value);
-  return PEER_PROFILE_OPTIONS.map(({ profile, label, summary }) => (
+  const options = requestClass === 'agent'
+    ? AGENT_PROFILE_OPTIONS.concat(PEER_PROFILE_OPTIONS)
+    : PEER_PROFILE_OPTIONS;
+  return options.map(({ profile, label, summary }) => (
     `<option value="${escapeHtml(profile)}" ${profile === selectedMeta.profile ? 'selected' : ''} title="${escapeHtml(summary)}">${escapeHtml(label)}</option>`
   )).join('');
 }
@@ -2835,7 +2854,15 @@ function renderPeerAccessRequests(requests) {
     const timing = [source, expires].filter(Boolean).join(' - ');
     const pending = status === 'pending';
     const requestedProfile = req.approved_profile || req.requested_profile || 'read-only-display';
-    const roleLabel = req.approved_profile ? 'Approved peer profile' : 'Requested peer profile';
+    // Which lane approving MINTS (the daemon's stored request class):
+    // an agent client is not a peer daemon, and the owner must see the
+    // difference before deciding. Absent = a pre-agent daemon = peer.
+    const requestClass = String(req.class || 'peer').toLowerCase();
+    const isAgentRequest = requestClass === 'agent';
+    const laneWord = isAgentRequest ? 'agent' : 'peer';
+    const roleLabel = req.approved_profile
+      ? `Approved ${laneWord} profile`
+      : `Requested ${laneWord} profile`;
     // Cross-owner tier claim (docs/src/trust-tiers.md § Where fleet
     // metadata rides): the daemon stores requester_tier only when the
     // claim was signed inside a verified caller-ID, so presence here
@@ -2871,8 +2898,11 @@ function renderPeerAccessRequests(requests) {
         ${upwardAlarm
           ? '<div class="daemon-access-request-meta daemon-access-request-warn" title="Grants flow toward disposable machines, never up. Approving would hand a disposable box authority on this integrated one — the tier bridge the doctrine warns about.">⚠ Upward grant: this is a disposable machine asking for authority on an integrated one. Approving bridges your tiers.</div>'
           : (pending && integratedTier ? '<div class="daemon-access-request-meta daemon-access-request-warn" title="Grants flow toward disposable machines, never up. If that daemon is lower-trust than this one, approving bridges your tiers — see the Trust tier card in Access.">⚠ Integrated-tier machine: approving grants a peer daemon authority here. Make sure trust flows downward.</div>' : '')}
+        ${isAgentRequest
+          ? '<div class="daemon-access-request-meta daemon-access-request-warn" title="This enrollment mints an agent-client identity — a machine principal that drives this daemon over MCP at whatever profile you grant. It is not a federated peer daemon.">🤖 AGENT enrollment: approving lets this machine operate the daemon at the granted profile.</div>'
+          : ''}
         ${timing ? `<div class="daemon-access-request-meta">${timing}</div>` : ''}
-        ${pending ? `<div class="daemon-pairing-row"><select data-access-request-profile="${escapeHtml(requestId)}">${renderPeerProfileOptions(requestedProfile)}</select></div>` : ''}
+        ${pending ? `<div class="daemon-pairing-row"><select data-access-request-profile="${escapeHtml(requestId)}">${renderPeerProfileOptions(requestedProfile, requestClass)}</select></div>` : ''}
         <div class="daemon-access-request-actions">
           <button class="approve" type="button" data-access-request-action="approve" data-request-id="${escapeHtml(requestId)}" ${pending ? '' : 'disabled'}>Approve</button>
           <button class="deny" type="button" data-access-request-action="deny" data-request-id="${escapeHtml(requestId)}" ${pending ? '' : 'disabled'}>Deny</button>

--- a/static/app/52-peer-display.js
+++ b/static/app/52-peer-display.js
@@ -2985,19 +2985,26 @@ function renderPeerIdentities(identities) {
 
   list.innerHTML = identities.map(identity => {
     const fingerprint = String(identity.fingerprint || '');
-    const label = escapeHtml(identity.label || 'Unnamed daemon');
+    // The lane the daemon stored for this grant (absent = a record
+    // from before the agent lane = peer): the durable management
+    // surface must keep the peer/agent distinction visible.
+    const identityClass = String(identity.class || 'peer').toLowerCase();
+    const isAgent = identityClass === 'agent';
+    const label = escapeHtml(identity.label || (isAgent ? 'Unnamed agent' : 'Unnamed daemon'));
     const status = String(identity.status || 'unknown').toLowerCase();
     const role = peerProfileMeta(identity.profile || 'presence-only');
     const request = identity.request_id ? `Request ${escapeHtml(identity.request_id)}` : '';
     const card = identity.card_url ? escapeHtml(identity.card_url) : '';
     const active = status === 'approved';
+    const laneLabel = isAgent ? 'Agent profile' : 'Peer profile';
     return `
       <div class="daemon-identity-card ${escapeHtml(status)}">
         <div class="daemon-identity-head">
-          <span>${label}</span>
+          <span>${isAgent ? '🤖 ' : ''}${label}</span>
           <span class="daemon-identity-status ${escapeHtml(status)}">${escapeHtml(status)}</span>
         </div>
-        <div class="daemon-identity-role" title="Peer profile ${escapeHtml(identity.profile || 'presence-only')}">Peer profile ${escapeHtml(role.label)}</div>
+        ${isAgent ? '<div class="daemon-access-request-meta" title="An enrolled agent client: a machine principal that drives this daemon over MCP at the granted profile. Not a federated peer daemon.">agent client (MCP lane)</div>' : ''}
+        <div class="daemon-identity-role" title="${laneLabel} ${escapeHtml(identity.profile || 'presence-only')}">${laneLabel} ${escapeHtml(role.label)}</div>
         <div class="daemon-identity-profile">${escapeHtml(role.summary)}${request ? ` - ${request}` : ''}</div>
         ${card ? `<div class="daemon-identity-profile">${card}</div>` : ''}
         <div class="daemon-identity-fingerprint" title="${escapeHtml(fingerprint)}">${escapeHtml(fingerprint)}</div>

--- a/static/app/52-peer-display.js
+++ b/static/app/52-peer-display.js
@@ -2586,11 +2586,18 @@ function renderPeerProfileOptions(selected, requestClass) {
   // peer option and the approval would post that narrower override.
   const value = String(selected || 'read-only-display').toLowerCase();
   const selectedMeta = peerProfileMeta(value);
+  // The ceiling rides LAST, and an unknown or mistyped requested
+  // profile preselects the cautious default — never whatever happens
+  // to sit first. A fail-closed request must not become the maximum
+  // grant through a typo plus the browser's first-option fallback.
   const options = requestClass === 'agent'
-    ? AGENT_PROFILE_OPTIONS.concat(PEER_PROFILE_OPTIONS)
+    ? PEER_PROFILE_OPTIONS.concat(AGENT_PROFILE_OPTIONS)
     : PEER_PROFILE_OPTIONS;
+  const effective = options.some(item => item.profile === selectedMeta.profile)
+    ? selectedMeta.profile
+    : 'read-only-display';
   return options.map(({ profile, label, summary }) => (
-    `<option value="${escapeHtml(profile)}" ${profile === selectedMeta.profile ? 'selected' : ''} title="${escapeHtml(summary)}">${escapeHtml(label)}</option>`
+    `<option value="${escapeHtml(profile)}" ${profile === effective ? 'selected' : ''} title="${escapeHtml(summary)}">${escapeHtml(label)}</option>`
   )).join('');
 }
 


### PR DESCRIPTION
M3 PR A — the daemon side of the R1 agent lane (`~/mcp-m3-plan.md` decisions D1–D4, D7): a distinct `agent` identity class in the peer identity store, the `agent-operator` profile family, the `agent_client` principal with its own actor arm, class-checked resolution with lane-declaration discipline (`x-intendant-agent`), and relay admission scoped to `POST /mcp` for agent-class identities (peers keep whole-gateway admission byte-identically). The enrollment doorbell threads the class end to end: an agent knock against a pre-M3 daemon hard-rejects (`deny_unknown_fields`) instead of silently approving as a peer.

**Reviewer note on the "EKU/issuer separation" amendment (D1):** true EKU enforcement at resolution would need an x509 parser the codebase deliberately doesn't carry, and today NO client class is cert-distinguished — discrimination is store membership by fingerprint. The amendment's intent (no cross-lane replay) is implemented at the architecture's real discriminator: the record class, enforced at resolution (mismatched lane declarations 403), at the single principal-binding choke point (class picks the kind), and at approval (class picks cert shape, vocabulary, writer). The CN differs (`Intendant Agent (…)`) for auditability only. If a stronger cert-layer marker is wanted later, it layers on without moving any of these gates.

Trust posture, pinned by tests: `agent_client` is never an owner surface; approvals are grantable at its ceiling; `AccessManage`/`CredentialsManage` unreachable at any profile; hosted-Connect transport refuses the kind; the memory tenant edge refuses the lane by name (even propose) pending an owner ruling; legacy identity records deserialize as peers and serialize byte-identically.

PR B (the `intendant mcp enroll`/`serve` sidecar) and PR C (skill + docs) follow per the plan.
