### PR TITLE
Scope Xvfb displays to runtime children

### DIFF
--- a/crates/intendant-platform/src/display_target.rs
+++ b/crates/intendant-platform/src/display_target.rs
@@ -3,6 +3,13 @@
 
 use serde::{Deserialize, Serialize};
 
+fn user_session_display_env_from(mut read_env: impl FnMut(&str) -> Option<String>) -> String {
+    read_env("INTENDANT_USER_DISPLAY")
+        .filter(|value| !value.is_empty())
+        .or_else(|| read_env("DISPLAY").filter(|value| !value.is_empty()))
+        .unwrap_or_else(|| ":0".to_string())
+}
+
 /// Cross-platform display target. Replaces raw display numbers with a
 /// platform-agnostic enum that distinguishes between agent-managed virtual
 /// displays and the user's active session display.
@@ -29,10 +36,11 @@ impl DisplayTarget {
                     // macOS doesn't use DISPLAY for the primary display
                     String::new()
                 } else {
-                    // On Linux, try to find the login session's DISPLAY.
-                    // The caller may have overridden DISPLAY for Xvfb, so we
-                    // check INTENDANT_USER_DISPLAY first, then fall back to :0.
-                    std::env::var("INTENDANT_USER_DISPLAY").unwrap_or_else(|_| ":0".to_string())
+                    // Prefer the separately adopted login-session value. If
+                    // no adopter ran, preserve a valid ambient non-:0 X11
+                    // desktop rather than inventing :0. Xvfb launch itself
+                    // never mutates either process value.
+                    user_session_display_env_from(|key| std::env::var(key).ok())
                 }
             }
         }
@@ -71,6 +79,31 @@ impl DisplayTarget {
             Some(id) => Self::from_display_id(id),
             None => default,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn resolve(values: &[(&str, &str)]) -> String {
+        let values = values.iter().copied().collect::<BTreeMap<_, _>>();
+        user_session_display_env_from(|key| values.get(key).map(|value| (*value).to_string()))
+    }
+
+    #[test]
+    fn user_session_display_prefers_adopted_then_ambient_then_default() {
+        assert_eq!(
+            resolve(&[("INTENDANT_USER_DISPLAY", ":7"), ("DISPLAY", ":99")]),
+            ":7"
+        );
+        assert_eq!(resolve(&[("DISPLAY", ":7")]), ":7");
+        assert_eq!(resolve(&[]), ":0");
+        assert_eq!(
+            resolve(&[("INTENDANT_USER_DISPLAY", ""), ("DISPLAY", ":8")]),
+            ":8"
+        );
     }
 }
 

--- a/crates/intendant-platform/src/vision.rs
+++ b/crates/intendant-platform/src/vision.rs
@@ -261,6 +261,19 @@ pub struct XvfbGuard {
 }
 
 impl XvfbGuard {
+    /// The virtual display owned by this guard. `None` is returned on
+    /// platforms where Xvfb launch is unsupported.
+    pub fn display_id(&self) -> Option<u32> {
+        #[cfg(target_os = "linux")]
+        {
+            Some(self.display_id)
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            None
+        }
+    }
+
     /// Ask this guard's exact child to exit and reap it without blocking a
     /// runtime worker. Graceful waiting is bounded; the fallback hard-kills
     /// only the spawned child. X lock/socket residue is never removed because
@@ -327,7 +340,10 @@ impl Drop for XvfbGuard {
 /// Launch Xvfb on the given display with the given resolution.
 /// The config's target must be `DisplayTarget::Virtual`; returns
 /// `CallerError::Config` otherwise.
-/// Returns a guard that kills the process on drop.
+/// Returns a guard that kills the process on drop. The launch is scoped to
+/// the returned display and never changes the daemon's process-wide `DISPLAY`;
+/// callers must pass the display target explicitly to capture, input, and
+/// browser subprocesses.
 #[cfg(target_os = "linux")]
 pub async fn launch_display(config: &DisplayConfig) -> Result<XvfbGuard, CallerError> {
     let display_id = match config.target {
@@ -389,17 +405,6 @@ pub async fn launch_display(config: &DisplayConfig) -> Result<XvfbGuard, CallerE
             "Xvfb on display {display_arg} did not establish its expected lock and socket"
         )));
     }
-
-    // Preserve the user's original DISPLAY before overriding with virtual display.
-    // This is used by DisplayTarget::UserSession to resolve the user's actual display.
-    if std::env::var("INTENDANT_USER_DISPLAY").is_err() {
-        if let Ok(original) = std::env::var("DISPLAY") {
-            std::env::set_var("INTENDANT_USER_DISPLAY", &original);
-        }
-    }
-
-    // Set DISPLAY env var so the runtime subprocess inherits it
-    std::env::set_var("DISPLAY", &display_arg);
 
     Ok(XvfbGuard {
         child,

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -3569,11 +3569,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn discover_displays_no_lock_files() {
-        // This test just verifies the function doesn't panic
+    async fn discover_displays_are_sorted() {
+        // The host may legitimately have any number of display locks while
+        // this parallel test suite creates and tears down Xvfb instances.
+        // Assert the deterministic property promised by the helper instead
+        // of imposing an environment-dependent cardinality ceiling.
         let displays = Agent::discover_displays();
-        // Can't assert specific values since it depends on environment
-        assert!(displays.len() < 100); // sanity check
+        assert!(displays.windows(2).all(|pair| pair[0] <= pair[1]));
     }
 
     #[tokio::test]

--- a/src/bin/caller/agent_loop.rs
+++ b/src/bin/caller/agent_loop.rs
@@ -2383,11 +2383,16 @@ pub(crate) async fn run_agent_loop(
                 }
             }
 
-            if batch.agent_input_json.is_none() && !batch.precomputed_results.is_empty() {
+            if batch.agent_input_json.is_none()
+                && !batch.precomputed_results.is_empty()
+                && !has_cu_calls
+            {
                 continue;
             }
 
-            // If no runtime commands, just respond to tool calls with context update
+            // If no runtime commands, respond to tool calls locally. Native
+            // CU can coexist with controller-only calls, so prepare and run
+            // it here instead of dropping it at this early return.
             let Some(ref json_str) = batch.agent_input_json else {
                 empty_command_streak = 0;
                 // Respond to whatever no dedicated handler answered above
@@ -2399,6 +2404,44 @@ pub(crate) async fn run_agent_loop(
                         continue;
                     }
                     conversation.add_tool_result(call_id, tool_name, "OK — context updated.");
+                }
+                if has_cu_calls {
+                    let user_display_granted = autonomy.read().await.user_display_granted;
+                    match maybe_auto_launch_xvfb(
+                        &BatchFacts::default(),
+                        xvfb_guard,
+                        provider.name(),
+                        &session_log,
+                        user_display_granted,
+                        true,
+                    )
+                    .await
+                    {
+                        Ok(()) => {
+                            execute_cu_calls(
+                                &response.cu_calls,
+                                conversation,
+                                provider.cu_display(),
+                                xvfb_guard.as_ref().and_then(|guard| guard.display_id()),
+                                log_dir,
+                                &mut cu_action_counter,
+                                &session_log,
+                                session_registry,
+                                user_display_granted,
+                                Some(&cu_observer),
+                            )
+                            .await;
+                        }
+                        Err(display_error) => {
+                            for cu_call in &response.cu_calls {
+                                conversation.add_cu_result(
+                                    &cu_call.call_id,
+                                    &display_error,
+                                    vec![],
+                                );
+                            }
+                        }
+                    }
                 }
                 continue;
             };
@@ -2792,7 +2835,30 @@ pub(crate) async fn run_agent_loop(
 
             // Run agent
             slog(&session_log, |l| l.agent_input(&json_str));
-            maybe_auto_launch_xvfb(&batch_facts, xvfb_guard, provider.name(), &session_log).await;
+            // Read the grant before display preparation: an ambient user
+            // display is eligible only when this session owns that grant.
+            let user_display_granted = autonomy.read().await.user_display_granted;
+            if let Err(display_error) = maybe_auto_launch_xvfb(
+                &batch_facts,
+                xvfb_guard,
+                provider.name(),
+                &session_log,
+                user_display_granted,
+                has_cu_calls,
+            )
+            .await
+            {
+                for (call_id, tool_name) in &batch.call_id_names {
+                    if handled_call_ids.contains(call_id) {
+                        continue;
+                    }
+                    conversation.add_tool_result(call_id, tool_name, &display_error);
+                }
+                for cu_call in &response.cu_calls {
+                    conversation.add_cu_result(&cu_call.call_id, &display_error, vec![]);
+                }
+                continue;
+            }
             let preview = batch_facts.commands_preview.clone();
             bus.send(AppEvent::AgentStarted {
                 session_id: local_session_id.clone(),
@@ -2812,9 +2878,6 @@ pub(crate) async fn run_agent_loop(
                 });
             }
 
-            // Read the grant fresh from the autonomy guard at every runtime
-            // spawn so a mid-session grant/revoke reaches the next child.
-            let user_display_granted = autonomy.read().await.user_display_granted;
             let output = agent_runner::run_agent(
                 &json_str,
                 log_dir,
@@ -2902,29 +2965,50 @@ pub(crate) async fn run_agent_loop(
                     &response.cu_calls,
                     conversation,
                     provider.cu_display(),
+                    xvfb_guard.as_ref().and_then(|guard| guard.display_id()),
                     log_dir,
                     &mut cu_action_counter,
                     &session_log,
                     session_registry,
-                    autonomy.read().await.user_display_granted,
+                    user_display_granted,
                     Some(&cu_observer),
                 )
                 .await;
             }
         } else if has_cu_calls {
             // CU-only turn (no function tool calls)
-            execute_cu_calls(
-                &response.cu_calls,
-                conversation,
-                provider.cu_display(),
-                log_dir,
-                &mut cu_action_counter,
+            let user_display_granted = autonomy.read().await.user_display_granted;
+            match maybe_auto_launch_xvfb(
+                &BatchFacts::default(),
+                xvfb_guard,
+                provider.name(),
                 &session_log,
-                session_registry,
-                autonomy.read().await.user_display_granted,
-                Some(&cu_observer),
+                user_display_granted,
+                true,
             )
-            .await;
+            .await
+            {
+                Ok(()) => {
+                    execute_cu_calls(
+                        &response.cu_calls,
+                        conversation,
+                        provider.cu_display(),
+                        xvfb_guard.as_ref().and_then(|guard| guard.display_id()),
+                        log_dir,
+                        &mut cu_action_counter,
+                        &session_log,
+                        session_registry,
+                        user_display_granted,
+                        Some(&cu_observer),
+                    )
+                    .await;
+                }
+                Err(display_error) => {
+                    for cu_call in &response.cu_calls {
+                        conversation.add_cu_result(&cu_call.call_id, &display_error, vec![]);
+                    }
+                }
+            }
         } else {
             // --- Legacy text extraction path ---
 
@@ -3395,7 +3479,25 @@ Proceed with explicit assumptions and continue without additional questions."
 
             // Log the full JSON being sent to the agent
             slog(&session_log, |l| l.agent_input(&json_str));
-            maybe_auto_launch_xvfb(&batch_facts, xvfb_guard, provider.name(), &session_log).await;
+            // Read the grant before display preparation: an ambient user
+            // display is eligible only when this session owns that grant.
+            let user_display_granted = autonomy.read().await.user_display_granted;
+            if let Err(display_error) = maybe_auto_launch_xvfb(
+                &batch_facts,
+                xvfb_guard,
+                provider.name(),
+                &session_log,
+                user_display_granted,
+                false,
+            )
+            .await
+            {
+                conversation.add_user(
+                    MessageProvenance::SystemInjection,
+                    format!("Agent execution was not started: {display_error}"),
+                );
+                continue;
+            }
 
             let preview = batch_facts.commands_preview.clone();
             bus.send(AppEvent::AgentStarted {
@@ -3416,9 +3518,6 @@ Proceed with explicit assumptions and continue without additional questions."
                 });
             }
 
-            // Read the grant fresh from the autonomy guard at every runtime
-            // spawn so a mid-session grant/revoke reaches the next child.
-            let user_display_granted = autonomy.read().await.user_display_granted;
             let output = agent_runner::run_agent(
                 &json_str,
                 log_dir,
@@ -5023,8 +5122,10 @@ mod provenance_parity {
         let add_user_with_images = concat!(".add_", "user_with_images(");
         for (file, users, with_images) in [
             // agent_loop's 10th site is the coordination radar block
-            // (§2.1 seam, SystemInjection — consciously added, C2).
-            ("agent_loop.rs", 10usize, 2usize),
+            // (§2.1 seam, SystemInjection — consciously added, C2); the
+            // 11th reports fail-closed virtual-display preparation to the
+            // legacy text loop (SystemInjection).
+            ("agent_loop.rs", 11usize, 2usize),
             ("main.rs", 16, 1),
             ("run_modes.rs", 4, 3),
             ("display_glue.rs", 1, 2),

--- a/src/bin/caller/agent_loop.rs
+++ b/src/bin/caller/agent_loop.rs
@@ -2820,6 +2820,7 @@ pub(crate) async fn run_agent_loop(
                 log_dir,
                 &project.root,
                 user_display_granted,
+                xvfb_guard.as_ref().and_then(|guard| guard.display_id()),
                 batch_facts.has_ask_human,
                 runtime_mcp_env,
             )
@@ -3423,6 +3424,7 @@ Proceed with explicit assumptions and continue without additional questions."
                 log_dir,
                 &project.root,
                 user_display_granted,
+                xvfb_guard.as_ref().and_then(|guard| guard.display_id()),
                 batch_facts.has_ask_human,
                 runtime_mcp_env,
             )

--- a/src/bin/caller/agent_runner.rs
+++ b/src/bin/caller/agent_runner.rs
@@ -215,10 +215,18 @@ fn apply_user_display_grant_env(cmd: &mut Command, user_display_granted: bool) {
 
 /// Scope one runtime child to its session-owned Xvfb. `None` preserves the
 /// ordinary inherited/user-session display selected by the existing child
-/// environment policy.
+/// environment policy. A virtual child must not retain Wayland selection:
+/// otherwise GUI programs can ignore DISPLAY and connect to the owner's
+/// compositor through WAYLAND_DISPLAY/XDG_RUNTIME_DIR.
 fn apply_virtual_display_env(cmd: &mut Command, virtual_display_id: Option<u32>) {
     if let Some(display_id) = virtual_display_id {
         cmd.env("DISPLAY", format!(":{display_id}"));
+        #[cfg(target_os = "linux")]
+        {
+            cmd.env_remove("WAYLAND_DISPLAY");
+            cmd.env_remove("XDG_RUNTIME_DIR");
+            cmd.env("XDG_SESSION_TYPE", "x11");
+        }
     }
 }
 
@@ -868,10 +876,11 @@ async fn run_agent_inner(
     #[cfg(target_os = "linux")]
     crate::linux_display_env::apply_to_tokio_command(&mut cmd);
 
-    // A session-owned virtual display overrides only this runtime child.
-    // `launch_display` deliberately leaves the daemon-wide DISPLAY alone so
-    // concurrent sessions and browser workspaces cannot inherit each other's
-    // X servers.
+    // A session-owned virtual display overrides only this runtime child and,
+    // on Linux, removes the Wayland selection path so GUI programs cannot
+    // bypass DISPLAY. `launch_display` deliberately leaves the daemon-wide
+    // environment alone so concurrent sessions and browser workspaces cannot
+    // inherit each other's X servers.
     apply_virtual_display_env(&mut cmd, virtual_display_id);
 
     let mut child = cmd.spawn().map_err(|e| {
@@ -1444,21 +1453,70 @@ mod tests {
     fn virtual_display_env_is_child_scoped_and_optional() {
         let mut virtual_child = Command::new("true");
         virtual_child.env("DISPLAY", ":0");
+        virtual_child.env("WAYLAND_DISPLAY", "wayland-0");
+        virtual_child.env("XDG_RUNTIME_DIR", "/run/user/1000");
+        virtual_child.env("XDG_SESSION_TYPE", "wayland");
         apply_virtual_display_env(&mut virtual_child, Some(137));
-        let display = virtual_child
-            .as_std()
-            .get_envs()
-            .find(|(key, _)| *key == std::ffi::OsStr::new("DISPLAY"))
-            .and_then(|(_, value)| value)
+        let env: std::collections::HashMap<_, _> = virtual_child.as_std().get_envs().collect();
+        let display = env
+            .get(std::ffi::OsStr::new("DISPLAY"))
+            .and_then(|value| *value)
             .and_then(std::ffi::OsStr::to_str);
         assert_eq!(display, Some(":137"));
+        #[cfg(target_os = "linux")]
+        {
+            assert_eq!(
+                env.get(std::ffi::OsStr::new("WAYLAND_DISPLAY")),
+                Some(&None)
+            );
+            assert_eq!(
+                env.get(std::ffi::OsStr::new("XDG_RUNTIME_DIR")),
+                Some(&None)
+            );
+            assert_eq!(
+                env.get(std::ffi::OsStr::new("XDG_SESSION_TYPE"))
+                    .and_then(|value| *value)
+                    .and_then(std::ffi::OsStr::to_str),
+                Some("x11")
+            );
+        }
 
         let mut ordinary_child = Command::new("true");
+        ordinary_child.env("DISPLAY", ":0");
+        ordinary_child.env("WAYLAND_DISPLAY", "wayland-owner");
+        ordinary_child.env("XDG_RUNTIME_DIR", "/run/user/owner");
+        ordinary_child.env("XDG_SESSION_TYPE", "wayland");
         apply_virtual_display_env(&mut ordinary_child, None);
-        assert!(ordinary_child
-            .as_std()
-            .get_envs()
-            .all(|(key, _)| key != std::ffi::OsStr::new("DISPLAY")));
+        let ordinary_env: std::collections::HashMap<_, _> =
+            ordinary_child.as_std().get_envs().collect();
+        assert_eq!(
+            ordinary_env
+                .get(std::ffi::OsStr::new("DISPLAY"))
+                .and_then(|value| *value)
+                .and_then(std::ffi::OsStr::to_str),
+            Some(":0")
+        );
+        assert_eq!(
+            ordinary_env
+                .get(std::ffi::OsStr::new("WAYLAND_DISPLAY"))
+                .and_then(|value| *value)
+                .and_then(std::ffi::OsStr::to_str),
+            Some("wayland-owner")
+        );
+        assert_eq!(
+            ordinary_env
+                .get(std::ffi::OsStr::new("XDG_RUNTIME_DIR"))
+                .and_then(|value| *value)
+                .and_then(std::ffi::OsStr::to_str),
+            Some("/run/user/owner")
+        );
+        assert_eq!(
+            ordinary_env
+                .get(std::ffi::OsStr::new("XDG_SESSION_TYPE"))
+                .and_then(|value| *value)
+                .and_then(std::ffi::OsStr::to_str),
+            Some("wayland")
+        );
     }
 
     /// A small injected cap for the drain tests — never allocate the real

--- a/src/bin/caller/agent_runner.rs
+++ b/src/bin/caller/agent_runner.rs
@@ -213,6 +213,15 @@ fn apply_user_display_grant_env(cmd: &mut Command, user_display_granted: bool) {
     }
 }
 
+/// Scope one runtime child to its session-owned Xvfb. `None` preserves the
+/// ordinary inherited/user-session display selected by the existing child
+/// environment policy.
+fn apply_virtual_display_env(cmd: &mut Command, virtual_display_id: Option<u32>) {
+    if let Some(display_id) = virtual_display_id {
+        cmd.env("DISPLAY", format!(":{display_id}"));
+    }
+}
+
 /// Provider-credential env names scrubbed from the runtime child beyond the
 /// authoritative `provider::PROVIDER_KEY_ENV_VARS` list: adjacent
 /// conventional spellings of the same secrets that a user `.env` (loaded
@@ -600,6 +609,9 @@ fn output_with_exit_status(
 /// `user_display_granted` is the autonomy guard's grant state, read by the
 /// caller at spawn time — the runtime child observes it as
 /// `INTENDANT_USER_DISPLAY_GRANTED` on its environment.
+/// `virtual_display_id`, when present, scopes this one runtime child and all
+/// of its GUI subprocesses to that session's Xvfb without mutating the
+/// controller process environment.
 ///
 /// `has_ask_human` selects the no-timeout path for batches containing
 /// `askHuman` (which polls indefinitely for the user). The caller derives it
@@ -610,6 +622,7 @@ pub async fn run_agent(
     log_dir: &std::path::Path,
     workdir: &std::path::Path,
     user_display_granted: bool,
+    virtual_display_id: Option<u32>,
     has_ask_human: bool,
     mcp_env: Option<&RuntimeMcpEnv>,
 ) -> Result<AgentOutput, CallerError> {
@@ -663,6 +676,7 @@ pub async fn run_agent(
                 Some(workdir),
                 Some(&sandbox),
                 user_display_granted,
+                virtual_display_id,
                 has_ask_human,
                 mcp_env,
                 None,
@@ -676,6 +690,7 @@ pub async fn run_agent(
         Some(workdir),
         None,
         user_display_granted,
+        virtual_display_id,
         has_ask_human,
         mcp_env,
         None,
@@ -698,6 +713,7 @@ pub async fn run_agent_sandboxed(
         None,
         Some(sandbox),
         user_display_granted,
+        None,
         has_ask_human,
         None,
         None,
@@ -729,6 +745,7 @@ pub async fn run_install_batch(
         Some(log_dir),
         None,
         false,
+        None,
         false,
         None,
         Some(hard_timeout),
@@ -743,6 +760,7 @@ async fn run_agent_inner(
     workdir: Option<&std::path::Path>,
     sandbox: Option<&crate::sandbox::SandboxConfig>,
     user_display_granted: bool,
+    virtual_display_id: Option<u32>,
     has_ask_human: bool,
     mcp_env: Option<&RuntimeMcpEnv>,
     hard_timeout_override: Option<std::time::Duration>,
@@ -849,6 +867,12 @@ async fn run_agent_inner(
 
     #[cfg(target_os = "linux")]
     crate::linux_display_env::apply_to_tokio_command(&mut cmd);
+
+    // A session-owned virtual display overrides only this runtime child.
+    // `launch_display` deliberately leaves the daemon-wide DISPLAY alone so
+    // concurrent sessions and browser workspaces cannot inherit each other's
+    // X servers.
+    apply_virtual_display_env(&mut cmd, virtual_display_id);
 
     let mut child = cmd.spawn().map_err(|e| {
         CallerError::Agent(format!("Failed to spawn agent at {:?}: {}", agent_path, e))
@@ -1414,6 +1438,27 @@ mod tests {
                 .all(|(k, _)| k != std::ffi::OsStr::new("INTENDANT_USER_DISPLAY_GRANTED")),
             "ungranted state must not set the grant var on the child"
         );
+    }
+
+    #[test]
+    fn virtual_display_env_is_child_scoped_and_optional() {
+        let mut virtual_child = Command::new("true");
+        virtual_child.env("DISPLAY", ":0");
+        apply_virtual_display_env(&mut virtual_child, Some(137));
+        let display = virtual_child
+            .as_std()
+            .get_envs()
+            .find(|(key, _)| *key == std::ffi::OsStr::new("DISPLAY"))
+            .and_then(|(_, value)| value)
+            .and_then(std::ffi::OsStr::to_str);
+        assert_eq!(display, Some(":137"));
+
+        let mut ordinary_child = Command::new("true");
+        apply_virtual_display_env(&mut ordinary_child, None);
+        assert!(ordinary_child
+            .as_std()
+            .get_envs()
+            .all(|(key, _)| key != std::ffi::OsStr::new("DISPLAY")));
     }
 
     /// A small injected cap for the drain tests — never allocate the real

--- a/src/bin/caller/display_glue.rs
+++ b/src/bin/caller/display_glue.rs
@@ -1141,6 +1141,19 @@ pub(crate) fn resolve_cu_display_target(user_display_granted: bool) -> computer_
     }
 }
 
+/// Resolve native computer-use for one agent-loop session. A session-owned
+/// Xvfb is authoritative even when the daemon process still carries an
+/// ambient `DISPLAY` selected for a different session.
+fn resolve_cu_display_target_for_session(
+    user_display_granted: bool,
+    session_virtual_display_id: Option<u32>,
+) -> computer_use::DisplayTarget {
+    match session_virtual_display_id {
+        Some(id) => computer_use::DisplayTarget::Virtual { id },
+        None => resolve_cu_display_target(user_display_granted),
+    }
+}
+
 /// Maximum turns for an ephemeral CU task before giving up.
 pub(crate) const CU_TASK_MAX_TURNS: usize = 20;
 
@@ -1675,6 +1688,8 @@ pub(crate) async fn handle_shared_view_calls(
     }
 }
 
+/// `session_virtual_display_id`, when present, is the Xvfb owned by this
+/// agent-loop session and overrides daemon-wide display discovery.
 /// `user_display_granted` is the autonomy guard's grant state, read by the
 /// caller before dispatching the batch. `cu_observer` feeds the dashboard's
 /// live action-visualization lane (`None` disables emission).
@@ -1683,6 +1698,7 @@ pub(crate) async fn execute_cu_calls(
     cu_calls: &[computer_use::CuToolCall],
     conversation: &mut conversation::Conversation,
     cu_display: Option<(u32, u32)>,
+    session_virtual_display_id: Option<u32>,
     log_dir: &std::path::Path,
     counter: &mut u64,
     session_log: &SharedSessionLog,
@@ -1692,8 +1708,8 @@ pub(crate) async fn execute_cu_calls(
 ) {
     // Owned form for execute_actions, which wants `&Option<_>`.
     let session_registry = session_registry.cloned();
-    let display_target = if cu_display.is_some() {
-        resolve_cu_display_target(user_display_granted)
+    let display_target = if cu_display.is_some() || session_virtual_display_id.is_some() {
+        resolve_cu_display_target_for_session(user_display_granted, session_virtual_display_id)
     } else {
         // No CU display configured — resolve availability-aware, but
         // never auto-target the user's desktop from the model-driven
@@ -1822,6 +1838,24 @@ mod tests {
                 None => std::env::remove_var("DISPLAY"),
             }
         }
+    }
+
+    /// Hostile concurrency pin: daemon-wide DISPLAY may name another
+    /// session's Xvfb. The guard id threaded by the owning loop must win for
+    /// native CU regardless of ambient state or the user-display grant.
+    #[tokio::test]
+    async fn session_virtual_display_overrides_ambient_daemon_display() {
+        let _env_lock = crate::test_support::TEST_ENV_LOCK.lock().await;
+        let _display = DisplayEnvGuard::set(":99");
+
+        assert_eq!(
+            resolve_cu_display_target_for_session(false, Some(137)),
+            computer_use::DisplayTarget::Virtual { id: 137 }
+        );
+        assert_eq!(
+            resolve_cu_display_target_for_session(true, Some(138)),
+            computer_use::DisplayTarget::Virtual { id: 138 }
+        );
     }
 
     #[tokio::test]

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -1155,10 +1155,11 @@ fn encode_screenshot(result_text: &str) -> Option<Vec<conversation::ImageData>> 
 ///
 /// Detection flow:
 /// 1. Already launched (`xvfb_guard` is `Some`)? → skip
-/// 2. Current DISPLAY accessible? Yes → skip
-/// 3. Batch contains `captureScreen` or any `execAsAgent`? No → skip
+/// 2. User display is granted and current DISPLAY is accessible? Yes → skip
+/// 3. Batch contains `captureScreen`, any `execAsAgent`, or native CU? No → skip
 /// 4. Launch Xvfb and retain its id in the session-owned guard
-/// 5. On failure → log warning, let commands fail naturally
+/// 5. On failure → reject this batch so the runtime cannot discover another
+///    session's Xvfb from host-global lock files
 ///
 /// We launch on execAsAgent (not just captureScreen) because GUI applications
 /// started in early turns must share the same display that captureScreen will
@@ -1173,12 +1174,54 @@ async fn maybe_auto_launch_xvfb(
     xvfb_guard: &mut Option<vision::XvfbGuard>,
     provider_name: &str,
     session_log: &SharedSessionLog,
-) {
+    user_display_granted: bool,
+    has_cu_calls: bool,
+) -> Result<(), String> {
+    maybe_auto_launch_xvfb_with(
+        facts,
+        xvfb_guard,
+        provider_name,
+        session_log,
+        user_display_granted,
+        has_cu_calls,
+        vision::virtual_displays_supported(),
+        vision::display_config_for_provider,
+        |config| async move { vision::launch_display(&config).await },
+    )
+    .await
+}
+
+/// Injectable core of [`maybe_auto_launch_xvfb`]. The production wrapper
+/// supplies the platform allocator and launcher; tests inject hostile launch
+/// outcomes without depending on the host having (or not having) Xvfb.
+#[allow(clippy::too_many_arguments)]
+async fn maybe_auto_launch_xvfb_with<ConfigFn, LaunchFn, LaunchFuture>(
+    facts: &BatchFacts,
+    xvfb_guard: &mut Option<vision::XvfbGuard>,
+    provider_name: &str,
+    session_log: &SharedSessionLog,
+    user_display_granted: bool,
+    has_cu_calls: bool,
+    virtual_displays_supported: bool,
+    display_config_for_provider: ConfigFn,
+    launch_display: LaunchFn,
+) -> Result<(), String>
+where
+    ConfigFn: FnOnce(&str) -> Option<vision::DisplayConfig>,
+    LaunchFn: FnOnce(vision::DisplayConfig) -> LaunchFuture,
+    LaunchFuture: std::future::Future<Output = Result<vision::XvfbGuard, CallerError>>,
+{
     if xvfb_guard.is_some() {
-        return;
+        return Ok(());
     }
-    if !facts.has_capture_screen && !facts.has_exec {
-        return;
+    if !facts.has_capture_screen && !facts.has_exec && !has_cu_calls {
+        return Ok(());
+    }
+    // Xvfb is a Linux-only isolation backend. Native-display platforms keep
+    // their existing runtime-side permission handling and never treat the
+    // absence of Xvfb as a batch failure.
+    if !virtual_displays_supported {
+        return Ok(());
     }
     // Memoized accessible-display verdict: this function runs on every
     // exec/captureScreen batch, `is_display_accessible()` forks `xdpyinfo`
@@ -1193,11 +1236,11 @@ async fn maybe_auto_launch_xvfb(
     // a dead display and auto-launch could never self-heal.
     static EXISTING_DISPLAY: std::sync::Mutex<Option<(u32, u32, u32)>> =
         std::sync::Mutex::new(None);
-    {
+    if user_display_granted {
         let mut memo = EXISTING_DISPLAY.lock().unwrap_or_else(|e| e.into_inner());
         if memo.is_some() {
             if existing_display_memo_still_valid() {
-                return;
+                return Ok(());
             }
             // The memoized display died — clear and fall through to the
             // full probe so Xvfb auto-launch can recover.
@@ -1209,7 +1252,7 @@ async fn maybe_auto_launch_xvfb(
     // Don't emit DisplayReady — no DisplaySession exists, so the web dashboard
     // can't connect via WebRTC. Recording uses the legacy platform ffmpeg path
     // directly (x11grab on Linux, screencapture/image2pipe on macOS).
-    if vision::is_display_accessible() {
+    if user_display_granted && vision::is_display_accessible() {
         let default_display = if cfg!(target_os = "macos") { 0 } else { 99 };
         let display_id = std::env::var("DISPLAY")
             .ok()
@@ -1224,22 +1267,23 @@ async fn maybe_auto_launch_xvfb(
                 display_id, width, height
             ))
         });
-        return;
+        return Ok(());
     }
-    let Some(config) = vision::display_config_for_provider(provider_name) else {
-        slog(session_log, |l| {
-            l.warn("No unoccupied virtual display is available; skipping Xvfb auto-launch")
-        });
-        return;
+    let Some(config) = display_config_for_provider(provider_name) else {
+        let message = "No unoccupied virtual display is available; the batch was not executed.";
+        slog(session_log, |l| l.warn(message));
+        return Err(message.to_string());
     };
     let trigger = if facts.has_capture_screen {
         "captureScreen"
-    } else {
+    } else if facts.has_exec {
         "execAsAgent (display needed)"
+    } else {
+        "native computer use"
     };
     let virtual_id = match config.target {
         computer_use::DisplayTarget::Virtual { id } => id,
-        _ => return,
+        _ => return Err("Virtual-display allocation returned a non-virtual target.".to_string()),
     };
     slog(session_log, |l| {
         l.info(&format!(
@@ -1247,7 +1291,7 @@ async fn maybe_auto_launch_xvfb(
             virtual_id, config.width, config.height, trigger
         ))
     });
-    match vision::launch_display(&config).await {
+    match launch_display(config).await {
         Ok(guard) => {
             // Phase 1: no DisplayReady for virtual displays — no DisplaySession means no web slot.
             // The agent uses this display for CU via X11 tools directly.
@@ -1258,11 +1302,14 @@ async fn maybe_auto_launch_xvfb(
                 ))
             });
             *xvfb_guard = Some(guard);
+            Ok(())
         }
         Err(e) => {
-            slog(session_log, |l| {
-                l.warn(&format!("Failed to auto-launch Xvfb: {}", e))
-            });
+            let message = format!(
+                "Virtual display launch failed; the batch was not executed and may be retried: {e}"
+            );
+            slog(session_log, |l| l.warn(&message));
+            Err(message)
         }
     }
 }
@@ -1586,6 +1633,138 @@ mod tests {
         assert!(sock.exists());
         std::fs::remove_file(&sock).unwrap();
         assert!(!sock.exists());
+    }
+
+    /// A native-CU-only response has no runtime command batch, but it still
+    /// needs the same session-owned display. If Xvfb cannot start, fail the
+    /// preparation step and leave the guard empty rather than letting native
+    /// CU fall through to an ambient/foreign display.
+    #[tokio::test]
+    async fn cu_only_turn_rejects_hostile_xvfb_launch_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let session_log: SharedSessionLog = std::sync::Arc::new(std::sync::Mutex::new(
+            session_log::SessionLog::open(dir.path().join("session")).unwrap(),
+        ));
+        let launch_attempted = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let launch_attempted_in_hook = std::sync::Arc::clone(&launch_attempted);
+        let mut guard = None;
+
+        let result = maybe_auto_launch_xvfb_with(
+            &BatchFacts::default(),
+            &mut guard,
+            "openai",
+            &session_log,
+            false,
+            true,
+            true,
+            |_| {
+                Some(vision::DisplayConfig {
+                    target: computer_use::DisplayTarget::Virtual { id: 137 },
+                    width: 1024,
+                    height: 768,
+                })
+            },
+            move |_| {
+                launch_attempted_in_hook.store(true, std::sync::atomic::Ordering::SeqCst);
+                async {
+                    Err::<vision::XvfbGuard, _>(CallerError::Config(
+                        "hostile test: Xvfb executable unavailable".to_string(),
+                    ))
+                }
+            },
+        )
+        .await;
+
+        let error = result.expect_err("failed Xvfb launch must reject native CU");
+        assert!(launch_attempted.load(std::sync::atomic::Ordering::SeqCst));
+        assert!(error.contains("batch was not executed"), "{error}");
+        assert!(error.contains("Xvfb executable unavailable"), "{error}");
+        assert!(guard.is_none(), "a failed launch must not publish a guard");
+    }
+
+    /// macOS and Windows have no Xvfb runtime. Their native-display path must
+    /// remain available without calling the Linux allocator or launcher.
+    #[tokio::test]
+    async fn absent_virtual_display_runtime_skips_xvfb_hooks() {
+        let dir = tempfile::tempdir().unwrap();
+        let session_log: SharedSessionLog = std::sync::Arc::new(std::sync::Mutex::new(
+            session_log::SessionLog::open(dir.path().join("session")).unwrap(),
+        ));
+        let allocation_attempted = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let launch_attempted = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let allocation_attempted_in_hook = std::sync::Arc::clone(&allocation_attempted);
+        let launch_attempted_in_hook = std::sync::Arc::clone(&launch_attempted);
+        let mut guard = None;
+        let facts = BatchFacts {
+            has_exec: true,
+            ..BatchFacts::default()
+        };
+
+        let result = maybe_auto_launch_xvfb_with(
+            &facts,
+            &mut guard,
+            "openai",
+            &session_log,
+            false,
+            false,
+            false,
+            move |_| {
+                allocation_attempted_in_hook.store(true, std::sync::atomic::Ordering::SeqCst);
+                None
+            },
+            move |_| {
+                launch_attempted_in_hook.store(true, std::sync::atomic::Ordering::SeqCst);
+                async {
+                    Err::<vision::XvfbGuard, _>(CallerError::Config(
+                        "launcher must not run".to_string(),
+                    ))
+                }
+            },
+        )
+        .await;
+
+        assert_eq!(result, Ok(()));
+        assert!(!allocation_attempted.load(std::sync::atomic::Ordering::SeqCst));
+        assert!(!launch_attempted.load(std::sync::atomic::Ordering::SeqCst));
+        assert!(guard.is_none());
+    }
+
+    /// Exhausted allocation is another fail-closed no-runtime path. The
+    /// launcher must not be called with an invented/reused display id.
+    #[tokio::test]
+    async fn cu_only_turn_rejects_exhausted_virtual_display_range() {
+        let dir = tempfile::tempdir().unwrap();
+        let session_log: SharedSessionLog = std::sync::Arc::new(std::sync::Mutex::new(
+            session_log::SessionLog::open(dir.path().join("session")).unwrap(),
+        ));
+        let launch_attempted = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let launch_attempted_in_hook = std::sync::Arc::clone(&launch_attempted);
+        let mut guard = None;
+
+        let result = maybe_auto_launch_xvfb_with(
+            &BatchFacts::default(),
+            &mut guard,
+            "openai",
+            &session_log,
+            false,
+            true,
+            true,
+            |_| None,
+            move |_| {
+                launch_attempted_in_hook.store(true, std::sync::atomic::Ordering::SeqCst);
+                async {
+                    Err::<vision::XvfbGuard, _>(CallerError::Config(
+                        "launcher must not run".to_string(),
+                    ))
+                }
+            },
+        )
+        .await;
+
+        let error = result.expect_err("exhausted allocation must reject native CU");
+        assert!(error.contains("No unoccupied virtual display"), "{error}");
+        assert!(!launch_attempted.load(std::sync::atomic::Ordering::SeqCst));
+        assert!(guard.is_none());
     }
 
     /// The idle queued-steer flush synthesizes an EMPTY task envelope per

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -1157,13 +1157,14 @@ fn encode_screenshot(result_text: &str) -> Option<Vec<conversation::ImageData>> 
 /// 1. Already launched (`xvfb_guard` is `Some`)? → skip
 /// 2. Current DISPLAY accessible? Yes → skip
 /// 3. Batch contains `captureScreen` or any `execAsAgent`? No → skip
-/// 4. Launch Xvfb, store guard, set DISPLAY
+/// 4. Launch Xvfb and retain its id in the session-owned guard
 /// 5. On failure → log warning, let commands fail naturally
 ///
 /// We launch on execAsAgent (not just captureScreen) because GUI applications
 /// started in early turns must share the same display that captureScreen will
-/// later capture. Launching only on captureScreen is too late — the app would
-/// already be running on a different (or no) display.
+/// later capture. The guard's display id is applied only to this session's
+/// runtime children; launching only on captureScreen is too late — the app
+/// would already be running on a different (or no) display.
 ///
 /// `facts` carries the batch's trigger booleans, derived once per batch —
 /// this function used to re-parse the full batch JSON (twice) to answer them.


### PR DESCRIPTION
## Summary

- stop Xvfb launch from overwriting daemon-wide display state
- bind runtime children and native computer-use calls to the owning session display
- reject display-requiring batches when isolated Xvfb allocation or launch fails
- prevent virtual children from bypassing Xvfb through inherited Wayland variables
- preserve native-display behavior on platforms without Xvfb

## Verification

- full controller, Connect, and runtime bin suites
- full library and doc-test battery
- workspace clippy with warnings denied
- 55/55 end-to-end tests
- hostile allocation, launch-failure, ambient-display, and Wayland regression tests

## Deliberately deferred

Create-request correlation, browser-workspace display binding, atomic allocation, Xauthority/TCP hardening, and live Linux concurrency remain separate reviewed slices.