### PR TITLE
Correlate virtual display creation results

### DIFF
--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -2898,6 +2898,20 @@ impl DisplaySession {
         self.frame_tx.subscribe()
     }
 
+    /// Whether the capture bridge is still live.
+    ///
+    /// This is a narrow lifecycle probe for callers that must not publish a
+    /// newly created display until capture has produced a frame and remained
+    /// alive through the readiness check. It is deliberately observational:
+    /// normal capture loss is still reported by the display event stream.
+    pub async fn capture_bridge_running(&self) -> bool {
+        self.capture_handle
+            .lock()
+            .await
+            .as_ref()
+            .is_some_and(|handle| !handle.is_finished())
+    }
+
     /// Get the most recently captured frame, or `None` if no frame yet.
     ///
     /// Marks external frame demand: repeated polls (the recording

--- a/src/bin/caller/display_glue.rs
+++ b/src/bin/caller/display_glue.rs
@@ -19,12 +19,31 @@ use crate::*;
 /// this forwarder is where its lifecycle/telemetry events become
 /// `AppEvent`s.
 pub(crate) fn display_event_forwarder(bus: EventBus) -> display::DisplayEventSender {
+    display_event_forwarder_with_generation(bus, None)
+}
+
+fn display_event_forwarder_with_generation(
+    bus: EventBus,
+    capture_generation: Option<String>,
+) -> display::DisplayEventSender {
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
     tokio::spawn(async move {
         while let Some(ev) = rx.recv().await {
             bus.send(match ev {
                 display::DisplayEvent::CaptureLost { display_id, reason } => {
-                    AppEvent::DisplayCaptureLost { display_id, reason }
+                    if let Some(capture_generation) = capture_generation.clone() {
+                        AppEvent::VirtualDisplayCaptureLost {
+                            display_id,
+                            capture_generation,
+                            reason,
+                        }
+                    } else {
+                        AppEvent::DisplayCaptureLost {
+                            display_id,
+                            capture_generation: None,
+                            reason,
+                        }
+                    }
                 }
                 display::DisplayEvent::Metrics { snapshot } => AppEvent::DisplayMetrics {
                     snapshot: *snapshot,
@@ -491,9 +510,30 @@ pub(crate) fn report_user_display_capture_unavailable(
     display_id: u32,
     reason: impl Into<String>,
 ) {
+    report_user_display_capture_unavailable_with_generation(bus, display_id, None, reason);
+}
+
+fn report_user_display_capture_unavailable_with_generation(
+    bus: &EventBus,
+    display_id: u32,
+    capture_generation: Option<String>,
+    reason: impl Into<String>,
+) {
     let reason = reason.into();
     eprintln!("[user_display] {reason}");
-    bus.send(AppEvent::DisplayCaptureLost { display_id, reason });
+    if let Some(capture_generation) = capture_generation {
+        bus.send(AppEvent::VirtualDisplayCaptureLost {
+            display_id,
+            capture_generation,
+            reason,
+        });
+    } else {
+        bus.send(AppEvent::DisplayCaptureLost {
+            display_id,
+            capture_generation: None,
+            reason,
+        });
+    }
 }
 
 /// Arm the synthetic display backend when — and only when — the headless
@@ -565,6 +605,44 @@ pub(crate) async fn activate_user_display(
     target_display_id: u32,
     agent_visible: bool,
 ) {
+    activate_user_display_inner(
+        bus,
+        session_registry,
+        frame_registry,
+        target_display_id,
+        agent_visible,
+        None,
+    )
+    .await;
+}
+
+pub(crate) async fn activate_user_display_with_capture_generation(
+    bus: &EventBus,
+    session_registry: &display::SharedSessionRegistry,
+    frame_registry: Option<std::sync::Arc<tokio::sync::RwLock<frames::FrameRegistry>>>,
+    target_display_id: u32,
+    agent_visible: bool,
+    capture_generation: String,
+) {
+    activate_user_display_inner(
+        bus,
+        session_registry,
+        frame_registry,
+        target_display_id,
+        agent_visible,
+        Some(capture_generation),
+    )
+    .await;
+}
+
+async fn activate_user_display_inner(
+    bus: &EventBus,
+    session_registry: &display::SharedSessionRegistry,
+    frame_registry: Option<std::sync::Arc<tokio::sync::RwLock<frames::FrameRegistry>>>,
+    target_display_id: u32,
+    agent_visible: bool,
+    capture_generation: Option<String>,
+) {
     let display_id: u32 = target_display_id;
 
     // Dedupe against ANY live session — a private view is still a live
@@ -605,20 +683,27 @@ pub(crate) async fn activate_user_display(
             .start(
                 30,
                 frame_registry,
-                Some(display_event_forwarder(bus.clone())),
+                Some(display_event_forwarder_with_generation(
+                    bus.clone(),
+                    capture_generation.clone(),
+                )),
             )
             .await
         {
-            report_user_display_capture_unavailable(
+            report_user_display_capture_unavailable_with_generation(
                 bus,
                 display_id,
+                capture_generation.clone(),
                 format!("synthetic display session failed: {e}"),
             );
             return;
         }
         let (width, height) = session.resolution();
         let session = Arc::new(session);
-        session.spawn_metrics_logger(Some(display_event_forwarder(bus.clone())));
+        session.spawn_metrics_logger(Some(display_event_forwarder_with_generation(
+            bus.clone(),
+            capture_generation.clone(),
+        )));
         session_registry.write().await.insert(display_id, session);
         bus.send(AppEvent::DisplayReady {
             display_id,
@@ -645,9 +730,10 @@ pub(crate) async fn activate_user_display(
         let backend = match display::x11::X11Backend::with_display(&display_str) {
             Ok(backend) => backend,
             Err(e) => {
-                report_user_display_capture_unavailable(
+                report_user_display_capture_unavailable_with_generation(
                     bus,
                     display_id,
+                    capture_generation.clone(),
                     format!("virtual display {display_str} connect failed: {e}"),
                 );
                 return;
@@ -659,20 +745,27 @@ pub(crate) async fn activate_user_display(
             .start(
                 30,
                 frame_registry.clone(),
-                Some(display_event_forwarder(bus.clone())),
+                Some(display_event_forwarder_with_generation(
+                    bus.clone(),
+                    capture_generation.clone(),
+                )),
             )
             .await
         {
-            report_user_display_capture_unavailable(
+            report_user_display_capture_unavailable_with_generation(
                 bus,
                 display_id,
+                capture_generation.clone(),
                 format!("virtual display {display_str} session failed: {e}"),
             );
             return;
         }
         let (width, height) = session.resolution();
         let session = Arc::new(session);
-        session.spawn_metrics_logger(Some(display_event_forwarder(bus.clone())));
+        session.spawn_metrics_logger(Some(display_event_forwarder_with_generation(
+            bus.clone(),
+            capture_generation.clone(),
+        )));
         session_registry.write().await.insert(display_id, session);
         bus.send(AppEvent::DisplayReady {
             display_id,

--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -241,6 +241,62 @@ pub enum CredentialReloadProgress {
     Failed { error: String },
 }
 
+/// Request-scoped terminal result for one daemon-owned virtual-display
+/// creation. This stays on the internal event bus: public display lifecycle
+/// remains `DisplayReady` / `VirtualDisplayCreateFailed`, while synchronous
+/// callers use this value to avoid consuming another concurrent request's
+/// outcome.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VirtualDisplayCreateOutcome {
+    Created {
+        display_id: u32,
+        width: u32,
+        height: u32,
+    },
+    Failed {
+        reason: String,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VirtualDisplayCreateWaitError {
+    TimedOut,
+    Closed,
+}
+
+type VirtualDisplayCreateWaiters =
+    Arc<Mutex<HashMap<String, tokio::sync::oneshot::Sender<VirtualDisplayCreateOutcome>>>>;
+
+/// RAII owner for one request-scoped terminal result. Dropping a cancelled or
+/// timed-out call removes its sender so abandoned MCP calls cannot accumulate
+/// in the daemon.
+pub struct VirtualDisplayCreateWaiter {
+    request_id: String,
+    waiters: VirtualDisplayCreateWaiters,
+    receiver: tokio::sync::oneshot::Receiver<VirtualDisplayCreateOutcome>,
+}
+
+impl VirtualDisplayCreateWaiter {
+    pub async fn wait(
+        mut self,
+        timeout_after: Duration,
+    ) -> Result<VirtualDisplayCreateOutcome, VirtualDisplayCreateWaitError> {
+        match tokio::time::timeout(timeout_after, &mut self.receiver).await {
+            Ok(Ok(outcome)) => Ok(outcome),
+            Ok(Err(_closed)) => Err(VirtualDisplayCreateWaitError::Closed),
+            Err(_elapsed) => Err(VirtualDisplayCreateWaitError::TimedOut),
+        }
+    }
+}
+
+impl Drop for VirtualDisplayCreateWaiter {
+    fn drop(&mut self) {
+        if let Ok(mut waiters) = self.waiters.lock() {
+            waiters.remove(&self.request_id);
+        }
+    }
+}
+
 /// All events flowing through the system.
 #[derive(Debug, Clone)]
 pub enum AppEvent {
@@ -2609,6 +2665,10 @@ pub enum ControlMsg {
     /// Linux-only mechanism — other
     /// platforms report a clear error.
     CreateVirtualDisplay {
+        /// Opaque per-call correlation id. Older/dashboard callers may omit
+        /// it and continue to observe only the public display lifecycle.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        request_id: Option<String>,
         /// Optional resolution; defaults to 1920x1080. Values are clamped
         /// to sane bounds and rounded down to even (VP8 requirement).
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2895,6 +2955,7 @@ pub struct EventBus {
     tx: tokio::sync::broadcast::Sender<AppEvent>,
     session_log_sinks: Arc<Mutex<Vec<tokio::sync::mpsc::UnboundedSender<SessionLogLaneItem>>>>,
     intent_sinks: Arc<Mutex<Vec<tokio::sync::mpsc::UnboundedSender<AppEvent>>>>,
+    virtual_display_create_waiters: VirtualDisplayCreateWaiters,
 }
 
 impl EventBus {
@@ -2904,7 +2965,47 @@ impl EventBus {
             tx,
             session_log_sinks: Arc::new(Mutex::new(Vec::new())),
             intent_sinks: Arc::new(Mutex::new(Vec::new())),
+            virtual_display_create_waiters: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    /// Register one lossless terminal-result channel before emitting its
+    /// corresponding create intent. Generated MCP request ids are unique; an
+    /// occupied id is rejected instead of replacing another caller's sender.
+    pub fn register_virtual_display_create_waiter(
+        &self,
+        request_id: String,
+    ) -> Result<VirtualDisplayCreateWaiter, String> {
+        let (sender, receiver) = tokio::sync::oneshot::channel();
+        let mut waiters = self
+            .virtual_display_create_waiters
+            .lock()
+            .map_err(|_| "virtual display result registry is unavailable".to_string())?;
+        if waiters.contains_key(&request_id) {
+            return Err("virtual display request id is already pending".to_string());
+        }
+        waiters.insert(request_id.clone(), sender);
+        drop(waiters);
+        Ok(VirtualDisplayCreateWaiter {
+            request_id,
+            waiters: Arc::clone(&self.virtual_display_create_waiters),
+            receiver,
+        })
+    }
+
+    /// Complete one registered request over its request-scoped lossless
+    /// channel. Returns false when the caller already timed out or cancelled.
+    pub fn complete_virtual_display_create(
+        &self,
+        request_id: &str,
+        outcome: VirtualDisplayCreateOutcome,
+    ) -> bool {
+        let sender = self
+            .virtual_display_create_waiters
+            .lock()
+            .ok()
+            .and_then(|mut waiters| waiters.remove(request_id));
+        sender.is_some_and(|sender| sender.send(outcome).is_ok())
     }
 
     pub fn send(&self, event: AppEvent) {
@@ -3035,7 +3136,9 @@ pub fn app_event_rides_intent_lane(event: &AppEvent) -> bool {
             | AppEvent::SessionIdentity { .. }
             | AppEvent::SessionRelationship { .. }
             | AppEvent::SessionEnded { .. }
+            | AppEvent::UserDisplayGranted { .. }
             | AppEvent::UserDisplayRevoked { .. }
+            | AppEvent::DisplayCaptureLost { .. }
             | AppEvent::SharedView { .. }
             | AppEvent::DisplayReady { .. }
             | AppEvent::TaskComplete { .. }
@@ -5029,6 +5132,52 @@ mod tests {
         assert!(intents.try_recv().is_err());
     }
 
+    #[tokio::test]
+    async fn intent_lane_keeps_display_lifecycle_lossless_under_broadcast_flood() {
+        let bus = EventBus::new();
+        let mut intents = bus.subscribe_intents();
+        let mut lossy = bus.subscribe();
+
+        bus.send(AppEvent::UserDisplayGranted {
+            display_id: 99,
+            agent_visible: true,
+        });
+        for _ in 0..5_000 {
+            bus.send(AppEvent::Tick);
+        }
+        bus.send(AppEvent::ControlCommand(ControlMsg::CreateVirtualDisplay {
+            request_id: Some("vdc-lossless".to_string()),
+            width: Some(1280),
+            height: Some(720),
+        }));
+        bus.send(AppEvent::DisplayCaptureLost {
+            display_id: 99,
+            reason: "test loss".to_string(),
+        });
+
+        assert!(matches!(
+            intents.recv().await,
+            Some(AppEvent::UserDisplayGranted { display_id: 99, .. })
+        ));
+        assert!(matches!(
+            intents.recv().await,
+            Some(AppEvent::ControlCommand(ControlMsg::CreateVirtualDisplay {
+                request_id: Some(request_id),
+                width: Some(1280),
+                height: Some(720),
+            })) if request_id == "vdc-lossless"
+        ));
+        assert!(matches!(
+            intents.recv().await,
+            Some(AppEvent::DisplayCaptureLost { display_id: 99, .. })
+        ));
+        assert!(intents.try_recv().is_err());
+        assert!(matches!(
+            lossy.recv().await,
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(_))
+        ));
+    }
+
     /// B5, deterministic core: the coalesce buffer concatenates per
     /// session (insertion-ordered across sessions) and one flush emits one
     /// wire line per session with the payload shape unchanged.
@@ -6635,6 +6784,7 @@ mod tests {
         assert!(matches!(
             msg,
             ControlMsg::CreateVirtualDisplay {
+                request_id: None,
                 width: None,
                 height: None
             }
@@ -6645,10 +6795,24 @@ mod tests {
         assert!(matches!(
             msg,
             ControlMsg::CreateVirtualDisplay {
+                request_id: None,
                 width: Some(1280),
                 height: Some(800)
             }
         ));
+
+        let json = r#"{"action":"create_virtual_display","request_id":"vdc-abc","width":1024,"height":768}"#;
+        let msg: ControlMsg = serde_json::from_str(json).unwrap();
+        assert!(matches!(
+            msg,
+            ControlMsg::CreateVirtualDisplay {
+                request_id: Some(ref request_id),
+                width: Some(1024),
+                height: Some(768)
+            } if request_id == "vdc-abc"
+        ));
+        let serialized = serde_json::to_value(&msg).unwrap();
+        assert_eq!(serialized["request_id"], "vdc-abc");
     }
 
     #[test]

--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -3008,6 +3008,15 @@ impl EventBus {
         sender.is_some_and(|sender| sender.send(outcome).is_ok())
     }
 
+    /// Whether an exact correlated virtual-display caller is still waiting.
+    /// A poisoned registry fails closed so queued work cannot launch an
+    /// unowned display when cancellation state is ambiguous.
+    pub fn virtual_display_create_is_pending(&self, request_id: &str) -> bool {
+        self.virtual_display_create_waiters
+            .lock()
+            .is_ok_and(|waiters| waiters.contains_key(request_id))
+    }
+
     pub fn send(&self, event: AppEvent) {
         // Every approval resolution — session registries, daemon-scoped gate
         // waiters, MCP/agenda resolvers — announces through this event, so

--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -792,7 +792,30 @@ pub enum AppEvent {
     // Display capture lost (backend crashed or portal session ended)
     DisplayCaptureLost {
         display_id: u32,
+        /// Generation of a daemon-owned virtual display when this public
+        /// retirement was validated against one. `None` for ordinary user or
+        /// agent-owned display sessions. Internal lifecycle consumers use it
+        /// to ignore a delayed retirement after an id has been reused.
+        capture_generation: Option<String>,
         reason: String,
+    },
+
+    /// Capture loss raised by a generation-bound daemon-owned virtual display.
+    /// This is internal lifecycle input: the serial display owner validates
+    /// the generation before emitting the public `DisplayCaptureLost` event.
+    VirtualDisplayCaptureLost {
+        display_id: u32,
+        capture_generation: String,
+        reason: String,
+    },
+
+    /// Asynchronous first-frame readiness result for one daemon-owned virtual
+    /// display. The slow wait never runs on the serial display-intent owner.
+    VirtualDisplayCaptureReadiness {
+        display_id: u32,
+        capture_generation: String,
+        ready: bool,
+        reason: Option<String>,
     },
 
     /// A virtual-display create request failed before any display lifecycle
@@ -3148,6 +3171,8 @@ pub fn app_event_rides_intent_lane(event: &AppEvent) -> bool {
             | AppEvent::UserDisplayGranted { .. }
             | AppEvent::UserDisplayRevoked { .. }
             | AppEvent::DisplayCaptureLost { .. }
+            | AppEvent::VirtualDisplayCaptureLost { .. }
+            | AppEvent::VirtualDisplayCaptureReadiness { .. }
             | AppEvent::SharedView { .. }
             | AppEvent::DisplayReady { .. }
             | AppEvent::TaskComplete { .. }
@@ -3983,12 +4008,12 @@ pub fn app_event_to_outbound(event: &AppEvent) -> Option<crate::types::OutboundE
             tile_snapshot_frames: snapshot.tile_snapshot_frames,
             tile_snapshot_kbps: snapshot.tile_snapshot_kbps,
         }),
-        AppEvent::DisplayCaptureLost { display_id, reason } => {
-            Some(OutboundEvent::DisplayCaptureLost {
-                display_id: *display_id,
-                reason: reason.clone(),
-            })
-        }
+        AppEvent::DisplayCaptureLost {
+            display_id, reason, ..
+        } => Some(OutboundEvent::DisplayCaptureLost {
+            display_id: *display_id,
+            reason: reason.clone(),
+        }),
         AppEvent::VirtualDisplayCreateFailed { reason } => Some(OutboundEvent::LogEntry {
             level: "error".to_string(),
             source: "display".to_string(),
@@ -4131,7 +4156,9 @@ pub fn app_event_to_outbound(event: &AppEvent) -> Option<crate::types::OutboundE
         | AppEvent::VoiceModelRerouted { .. }
         | AppEvent::LiveAudioStarted { .. }
         | AppEvent::LiveAudioProgress { .. }
-        | AppEvent::LiveAudioCompleted { .. } => None,
+        | AppEvent::LiveAudioCompleted { .. }
+        | AppEvent::VirtualDisplayCaptureLost { .. }
+        | AppEvent::VirtualDisplayCaptureReadiness { .. } => None,
     }
 }
 
@@ -4389,6 +4416,8 @@ fn app_event_writes_to_session_log(event: &AppEvent) -> bool {
             | AppEvent::DisplayTaken { .. }
             | AppEvent::DisplayReleased { .. }
             | AppEvent::DisplayCaptureLost { .. }
+            | AppEvent::VirtualDisplayCaptureLost { .. }
+            | AppEvent::VirtualDisplayCaptureReadiness { .. }
             | AppEvent::VirtualDisplayCreateFailed { .. }
             | AppEvent::DisplayApprovalPending { .. }
             | AppEvent::SharedView { .. }
@@ -4638,7 +4667,9 @@ fn write_event_to_session_log(session_log: &crate::SharedSessionLog, event: &App
         AppEvent::DisplayReleased { display_id, note } => {
             log.display_released(*display_id, note.as_deref());
         }
-        AppEvent::DisplayCaptureLost { display_id, reason } => {
+        AppEvent::DisplayCaptureLost {
+            display_id, reason, ..
+        } => {
             log.warn(&format!("Display :{} capture lost: {}", display_id, reason));
         }
         AppEvent::VirtualDisplayCreateFailed { reason } => {
@@ -5161,7 +5192,14 @@ mod tests {
         }));
         bus.send(AppEvent::DisplayCaptureLost {
             display_id: 99,
+            capture_generation: None,
             reason: "test loss".to_string(),
+        });
+        bus.send(AppEvent::VirtualDisplayCaptureReadiness {
+            display_id: 100,
+            capture_generation: "generation-1".to_string(),
+            ready: true,
+            reason: None,
         });
 
         assert!(matches!(
@@ -5179,6 +5217,15 @@ mod tests {
         assert!(matches!(
             intents.recv().await,
             Some(AppEvent::DisplayCaptureLost { display_id: 99, .. })
+        ));
+        assert!(matches!(
+            intents.recv().await,
+            Some(AppEvent::VirtualDisplayCaptureReadiness {
+                display_id: 100,
+                capture_generation,
+                ready: true,
+                reason: None,
+            }) if capture_generation == "generation-1"
         ));
         assert!(intents.try_recv().is_err());
         assert!(matches!(

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -3383,6 +3383,12 @@ pub fn spawn_user_display_listener(
                     .await;
                 }
                 AppEvent::UserDisplayRevoked { display_id, .. } => {
+                    virtual_display::fail_pending_virtual_display_create(
+                        &bus,
+                        &mut virtual_display_guards,
+                        display_id,
+                        "virtual display create was revoked before completion",
+                    );
                     deactivate_user_display(&session_registry, display_id).await;
                     // Closing the tile of a dashboard-created display IS its
                     // destroy: nothing else owns it, and leaving the Xvfb
@@ -3396,6 +3402,7 @@ pub fn spawn_user_display_listener(
                 }
                 AppEvent::DisplayCaptureLost {
                     display_id,
+                    capture_generation: None,
                     ref reason,
                 } => {
                     // Capture backend stopped unexpectedly (portal session
@@ -3412,6 +3419,47 @@ pub fn spawn_user_display_listener(
                         &mut virtual_display_guards,
                         display_id,
                         "capture lost",
+                    )
+                    .await;
+                }
+                AppEvent::DisplayCaptureLost {
+                    capture_generation: Some(_),
+                    ..
+                } => {
+                    // Generation-bound public retirements are emitted only
+                    // after the virtual-display owner has already validated
+                    // and cleaned the exact generation. Their lossless-lane
+                    // copy must not touch a replacement that reused the id.
+                }
+                AppEvent::VirtualDisplayCaptureLost {
+                    display_id,
+                    ref capture_generation,
+                    ref reason,
+                } => {
+                    virtual_display::handle_virtual_display_capture_lost(
+                        &bus,
+                        &session_registry,
+                        &mut virtual_display_guards,
+                        display_id,
+                        capture_generation,
+                        reason,
+                    )
+                    .await;
+                }
+                AppEvent::VirtualDisplayCaptureReadiness {
+                    display_id,
+                    ref capture_generation,
+                    ready,
+                    ref reason,
+                } => {
+                    virtual_display::handle_virtual_display_capture_readiness(
+                        &bus,
+                        &session_registry,
+                        &mut virtual_display_guards,
+                        display_id,
+                        capture_generation,
+                        ready,
+                        reason.clone(),
                     )
                     .await;
                 }

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -3334,7 +3334,7 @@ fn setup_fresh_conversation_with_attachments(
 /// On revoke: stop the session and remove it from the registry.
 ///
 /// Also the owner of dashboard-created virtual displays: it consumes
-/// `ControlMsg::CreateVirtualDisplay` off the bus (this task is the one
+/// `ControlMsg::CreateVirtualDisplay` off the lossless intent lane (this task is the one
 /// place with the session/frame registries the create needs), and holds
 /// their `XvfbGuard`s as task-local state — created displays die with the
 /// daemon, on tile close (revoke of their id), or on capture loss.
@@ -3344,14 +3344,19 @@ pub fn spawn_user_display_listener(
     frame_registry: Option<std::sync::Arc<tokio::sync::RwLock<frames::FrameRegistry>>>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
-        let mut rx = bus.subscribe();
+        // Every event this task acts on rides the lossless intent lane. A
+        // virtual-display create can take long enough for the best-effort
+        // broadcast ring to lap; dropping either a create request or a
+        // grant/revoke/capture-loss transition would leave the caller and
+        // display registry out of sync.
+        let mut rx = bus.subscribe_intents();
         let mut virtual_display_guards = virtual_display::VirtualDisplayGuards::new();
-        loop {
-            match rx.recv().await {
-                Ok(AppEvent::UserDisplayGranted {
+        while let Some(event) = rx.recv().await {
+            match event {
+                AppEvent::UserDisplayGranted {
                     display_id,
                     agent_visible,
-                }) => {
+                } => {
                     activate_user_display(
                         &bus,
                         &session_registry,
@@ -3361,10 +3366,11 @@ pub fn spawn_user_display_listener(
                     )
                     .await;
                 }
-                Ok(AppEvent::ControlCommand(ControlMsg::CreateVirtualDisplay {
+                AppEvent::ControlCommand(ControlMsg::CreateVirtualDisplay {
+                    request_id,
                     width,
                     height,
-                })) => {
+                }) => {
                     virtual_display::create_virtual_display(
                         &bus,
                         &session_registry,
@@ -3372,10 +3378,11 @@ pub fn spawn_user_display_listener(
                         &mut virtual_display_guards,
                         width,
                         height,
+                        request_id,
                     )
                     .await;
                 }
-                Ok(AppEvent::UserDisplayRevoked { display_id, .. }) => {
+                AppEvent::UserDisplayRevoked { display_id, .. } => {
                     deactivate_user_display(&session_registry, display_id).await;
                     // Closing the tile of a dashboard-created display IS its
                     // destroy: nothing else owns it, and leaving the Xvfb
@@ -3387,10 +3394,10 @@ pub fn spawn_user_display_listener(
                     )
                     .await;
                 }
-                Ok(AppEvent::DisplayCaptureLost {
+                AppEvent::DisplayCaptureLost {
                     display_id,
                     ref reason,
-                }) => {
+                } => {
                     // Capture backend stopped unexpectedly (portal session
                     // ended, backend crashed, etc.).  Remove the session from
                     // the registry so a re-grant creates a fresh one.
@@ -3408,31 +3415,6 @@ pub fn spawn_user_display_listener(
                     )
                     .await;
                 }
-                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
-                    // A missed grant/revoke/capture-loss leaves no trustworthy
-                    // lifecycle state. Fail closed: registry drain invokes the
-                    // synchronous input-authority observer before any stale
-                    // session can be looked up again; stop captures and Xvfb
-                    // guards outside the registry lock. The user can explicitly
-                    // re-open the displays after the event stream recovers.
-                    eprintln!(
-                        "[user_display] lifecycle listener lagged by {skipped} events; \
-                         closing all display sessions fail-closed"
-                    );
-                    let sessions = session_registry.write().await.drain();
-                    // Gracefully reap guards concurrently. Serially awaiting
-                    // each bounded shutdown here would compound the timeout
-                    // and make lag recovery itself keep falling behind.
-                    for (_, guard) in std::mem::take(&mut virtual_display_guards) {
-                        tokio::spawn(guard.shutdown());
-                    }
-                    for session in sessions {
-                        tokio::spawn(async move {
-                            session.stop().await;
-                        });
-                    }
-                }
-                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
                 _ => {}
             }
         }

--- a/src/bin/caller/mcp/commands.rs
+++ b/src/bin/caller/mcp/commands.rs
@@ -1831,6 +1831,7 @@ mod tests {
             &bus,
             &Some(control_tx),
             ControlMsg::CreateVirtualDisplay {
+                request_id: None,
                 width: Some(1280),
                 height: Some(800),
             },

--- a/src/bin/caller/mcp/events.rs
+++ b/src/bin/caller/mcp/events.rs
@@ -1040,6 +1040,7 @@ pub fn spawn_event_listener(
                     AppEvent::DisplayCaptureLost {
                         display_id,
                         ref reason,
+                        ..
                     } => {
                         s.note_display_capture_lost(display_id);
                         s.push_log(
@@ -1049,6 +1050,12 @@ pub fn spawn_event_listener(
                     }
                     AppEvent::VirtualDisplayCreateFailed { ref reason } => {
                         s.push_log(LogLevel::Warn, reason.clone());
+                    }
+                    AppEvent::VirtualDisplayCaptureLost { .. }
+                    | AppEvent::VirtualDisplayCaptureReadiness { .. } => {
+                        // Internal generation-bound lifecycle input. The
+                        // display owner emits the public retirement only
+                        // after validating the active generation.
                     }
                     AppEvent::DisplayApprovalPending {
                         display_id,

--- a/src/bin/caller/mcp/tools_display.rs
+++ b/src/bin/caller/mcp/tools_display.rs
@@ -1898,10 +1898,12 @@ mod tests {
         let timeout_waiter = bus
             .register_virtual_display_create_waiter("vdc-timeout".to_string())
             .unwrap();
+        assert!(bus.virtual_display_create_is_pending("vdc-timeout"));
         assert_eq!(
             timeout_waiter.wait(Duration::from_millis(10)).await,
             Err(crate::event::VirtualDisplayCreateWaitError::TimedOut)
         );
+        assert!(!bus.virtual_display_create_is_pending("vdc-timeout"));
         assert!(!bus.complete_virtual_display_create(
             "vdc-timeout",
             crate::event::VirtualDisplayCreateOutcome::Failed {
@@ -1912,10 +1914,12 @@ mod tests {
         let cancelled = bus
             .register_virtual_display_create_waiter("vdc-cancelled".to_string())
             .unwrap();
+        assert!(bus.virtual_display_create_is_pending("vdc-cancelled"));
         assert!(bus
             .register_virtual_display_create_waiter("vdc-cancelled".to_string())
             .is_err());
         drop(cancelled);
+        assert!(!bus.virtual_display_create_is_pending("vdc-cancelled"));
         assert!(!bus.complete_virtual_display_create(
             "vdc-cancelled",
             crate::event::VirtualDisplayCreateOutcome::Failed {

--- a/src/bin/caller/mcp/tools_display.rs
+++ b/src/bin/caller/mcp/tools_display.rs
@@ -143,74 +143,68 @@ impl IntendantServer {
     }
 
     #[tool(
-        description = "Create a daemon-owned virtual display (Xvfb) on this daemon's host and activate it for capture and streaming — it announces as display_ready to every dashboard and federated peer and survives the calling session (closing its dashboard tile reaps it early). Linux hosts only today; other platforms report a clear error. Waits for the ready/failed outcome and returns the new display's id and geometry."
+        description = "Create a daemon-owned virtual display (Xvfb) on this daemon's host and activate it for capture and streaming — it announces as display_ready to every dashboard and federated peer and survives the calling session (closing its dashboard tile reaps it early). Linux hosts only today; other platforms report a clear error. Waits for this exact request's correlated terminal result and returns JSON with request_id plus the new display id/geometry or error."
     )]
     pub(crate) async fn create_virtual_display(
         &self,
         Parameters(params): Parameters<CreateVirtualDisplayParams>,
     ) -> String {
-        // Ready events carry the allocated display id; pre-lifecycle failures
-        // have their own id-free event and therefore cannot collide with or
-        // retire any registered display session.
-        let session_registry = self.state.read().await.session_registry.clone();
-        let known: std::collections::HashSet<u32> =
-            crate::display::enumerate_displays_with_sessions(&session_registry)
-                .await
-                .into_iter()
-                .map(|d| d.id)
-                .collect();
-        let mut rx = self.bus.subscribe();
+        // Every caller receives a distinct internal terminal result. Public
+        // DisplayReady/failure events remain broadcast lifecycle signals and
+        // are deliberately not used for synchronous attribution.
+        let request_id = format!("vdc-{}", uuid::Uuid::new_v4().simple());
+        let waiter = match self
+            .bus
+            .register_virtual_display_create_waiter(request_id.clone())
+        {
+            Ok(waiter) => waiter,
+            Err(error) => {
+                return serde_json::json!({
+                    "ok": false,
+                    "request_id": request_id,
+                    "error": error
+                })
+                .to_string();
+            }
+        };
         self.bus
             .send(AppEvent::ControlCommand(ControlMsg::CreateVirtualDisplay {
+                request_id: Some(request_id.clone()),
                 width: params.width,
                 height: params.height,
             }));
-        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(20);
-        loop {
-            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-            if remaining.is_zero() {
-                return "virtual display creation requested, but no display_ready arrived \
-                        within 20s — check the daemon log (is Xvfb installed on the host?)"
-                    .to_string();
-            }
-            match tokio::time::timeout(remaining, rx.recv()).await {
-                Ok(Ok(AppEvent::DisplayReady {
-                    display_id,
-                    width,
-                    height,
-                    ..
-                })) if !known.contains(&display_id) => {
-                    return format!(
-                        "virtual display created: display_id {display_id} ({width}x{height}). \
-                         Target it as display_target \"display_{display_id}\" for screenshots \
-                         and CU actions; it is streaming to dashboards and announced to \
-                         federated peers now."
-                    );
-                }
-                Ok(Ok(AppEvent::VirtualDisplayCreateFailed { reason })) => {
-                    if reason.starts_with("virtual display create failed") {
-                        return reason;
-                    }
-                    return format!("virtual display create failed: {reason}");
-                }
-                Ok(Ok(AppEvent::DisplayCaptureLost { display_id, reason }))
-                    if !known.contains(&display_id) =>
-                {
-                    return format!("virtual display create failed: {reason}");
-                }
-                Ok(Ok(_)) => continue,
-                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => continue,
-                Ok(Err(tokio::sync::broadcast::error::RecvError::Closed)) => {
-                    return "virtual display create: the event bus closed before an outcome \
-                            arrived"
-                        .to_string();
-                }
-                Err(_elapsed) => {
-                    return "virtual display creation requested, but no display_ready arrived \
-                            within 20s — check the daemon log (is Xvfb installed on the host?)"
-                        .to_string();
-                }
-            }
+        match waiter.wait(std::time::Duration::from_secs(20)).await {
+            Ok(crate::event::VirtualDisplayCreateOutcome::Created {
+                display_id,
+                width,
+                height,
+            }) => serde_json::json!({
+                "ok": true,
+                "request_id": request_id,
+                "display_id": display_id,
+                "display_target": format!("display_{display_id}"),
+                "width": width,
+                "height": height
+            })
+            .to_string(),
+            Ok(crate::event::VirtualDisplayCreateOutcome::Failed { reason }) => serde_json::json!({
+                "ok": false,
+                "request_id": request_id,
+                "error": reason
+            })
+            .to_string(),
+            Err(crate::event::VirtualDisplayCreateWaitError::TimedOut) => serde_json::json!({
+                "ok": false,
+                "request_id": request_id,
+                "error": "virtual display creation did not return its correlated result within 20s"
+            })
+            .to_string(),
+            Err(crate::event::VirtualDisplayCreateWaitError::Closed) => serde_json::json!({
+                "ok": false,
+                "request_id": request_id,
+                "error": "virtual display event bus closed before the correlated result arrived"
+            })
+            .to_string(),
         }
     }
 
@@ -1771,6 +1765,164 @@ mod tests {
         test_session_registry_with_display, test_state, test_state_with_log_dir,
     };
     use tokio::time::{timeout, Duration};
+
+    async fn next_virtual_display_create_command(
+        rx: &mut tokio::sync::broadcast::Receiver<AppEvent>,
+    ) -> (String, Option<u32>, Option<u32>) {
+        loop {
+            match timeout(Duration::from_secs(1), rx.recv()).await {
+                Ok(Ok(AppEvent::ControlCommand(ControlMsg::CreateVirtualDisplay {
+                    request_id: Some(request_id),
+                    width,
+                    height,
+                }))) => return (request_id, width, height),
+                Ok(Ok(_)) => continue,
+                other => panic!("expected correlated create command, got {other:?}"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn concurrent_virtual_display_creates_receive_only_their_own_reversed_results() {
+        let bus = EventBus::new();
+        let mut command_rx = bus.subscribe();
+        let server = IntendantServer::new(test_state(), bus.clone());
+
+        let first_server = server.clone();
+        let first = tokio::spawn(async move {
+            first_server
+                .create_virtual_display(Parameters(CreateVirtualDisplayParams {
+                    width: Some(800),
+                    height: Some(600),
+                }))
+                .await
+        });
+        let second_server = server.clone();
+        let second = tokio::spawn(async move {
+            second_server
+                .create_virtual_display(Parameters(CreateVirtualDisplayParams {
+                    width: Some(1000),
+                    height: Some(700),
+                }))
+                .await
+        });
+
+        let mut first_id = None;
+        let mut second_id = None;
+        for _ in 0..2 {
+            let (request_id, width, height) =
+                next_virtual_display_create_command(&mut command_rx).await;
+            match (width, height) {
+                (Some(800), Some(600)) => first_id = Some(request_id),
+                (Some(1000), Some(700)) => second_id = Some(request_id),
+                other => panic!("unexpected create dimensions: {other:?}"),
+            }
+        }
+        let first_id = first_id.expect("first request id");
+        let second_id = second_id.expect("second request id");
+        assert_ne!(first_id, second_id);
+
+        // Public lifecycle traffic and an unrelated internal result are all
+        // stale for these callers and must not complete either future.
+        bus.send(AppEvent::DisplayReady {
+            display_id: 88,
+            width: 640,
+            height: 480,
+            agent_visible: true,
+        });
+        bus.send(AppEvent::VirtualDisplayCreateFailed {
+            reason: "stale public failure".to_string(),
+        });
+        assert!(!bus.complete_virtual_display_create(
+            "vdc-unrelated",
+            crate::event::VirtualDisplayCreateOutcome::Created {
+                display_id: 89,
+                width: 640,
+                height: 480,
+            },
+        ));
+        // Overflow the best-effort broadcast ring. Terminal delivery uses a
+        // separate one-shot registry and therefore cannot be displaced by
+        // high-rate unrelated daemon traffic.
+        for _ in 0..5_000 {
+            bus.send(AppEvent::Tick);
+        }
+        tokio::task::yield_now().await;
+        assert!(!first.is_finished());
+        assert!(!second.is_finished());
+
+        // Complete the second request first. The first waiter must remain
+        // pending even though it observes the same broadcast event.
+        assert!(bus.complete_virtual_display_create(
+            &second_id,
+            crate::event::VirtualDisplayCreateOutcome::Created {
+                display_id: 102,
+                width: 1000,
+                height: 700,
+            },
+        ));
+        let second_json: serde_json::Value = serde_json::from_str(
+            &timeout(Duration::from_secs(1), second)
+                .await
+                .expect("second request should complete")
+                .expect("second task should not panic"),
+        )
+        .unwrap();
+        assert_eq!(second_json["ok"], true);
+        assert_eq!(second_json["request_id"], second_id);
+        assert_eq!(second_json["display_id"], 102);
+        assert_eq!(second_json["display_target"], "display_102");
+        assert!(!first.is_finished());
+
+        assert!(bus.complete_virtual_display_create(
+            &first_id,
+            crate::event::VirtualDisplayCreateOutcome::Failed {
+                reason: "first request failed".to_string(),
+            },
+        ));
+        let first_json: serde_json::Value = serde_json::from_str(
+            &timeout(Duration::from_secs(1), first)
+                .await
+                .expect("first request should complete")
+                .expect("first task should not panic"),
+        )
+        .unwrap();
+        assert_eq!(first_json["ok"], false);
+        assert_eq!(first_json["request_id"], first_id);
+        assert_eq!(first_json["error"], "first request failed");
+    }
+
+    #[tokio::test]
+    async fn virtual_display_result_wait_is_lossless_bounded_and_cancellation_safe() {
+        let bus = EventBus::new();
+        let timeout_waiter = bus
+            .register_virtual_display_create_waiter("vdc-timeout".to_string())
+            .unwrap();
+        assert_eq!(
+            timeout_waiter.wait(Duration::from_millis(10)).await,
+            Err(crate::event::VirtualDisplayCreateWaitError::TimedOut)
+        );
+        assert!(!bus.complete_virtual_display_create(
+            "vdc-timeout",
+            crate::event::VirtualDisplayCreateOutcome::Failed {
+                reason: "too late".to_string(),
+            }
+        ));
+
+        let cancelled = bus
+            .register_virtual_display_create_waiter("vdc-cancelled".to_string())
+            .unwrap();
+        assert!(bus
+            .register_virtual_display_create_waiter("vdc-cancelled".to_string())
+            .is_err());
+        drop(cancelled);
+        assert!(!bus.complete_virtual_display_create(
+            "vdc-cancelled",
+            crate::event::VirtualDisplayCreateOutcome::Failed {
+                reason: "cancelled".to_string(),
+            }
+        ));
+    }
 
     /// A fragment unique to the user-session opt-in refusal
     /// (`computer_use::user_session_denied_message`, which both gated MCP

--- a/src/bin/caller/peer/upcast.rs
+++ b/src/bin/caller/peer/upcast.rs
@@ -1199,9 +1199,14 @@ impl AppEventUpcaster {
                 reason: note.clone(),
             }],
 
-            AppEvent::DisplayCaptureLost { display_id, reason } => self
+            AppEvent::DisplayCaptureLost {
+                display_id, reason, ..
+            } => self
                 .displays
                 .lost(*display_id, Some(format!("capture_lost: {reason}"))),
+
+            AppEvent::VirtualDisplayCaptureLost { .. }
+            | AppEvent::VirtualDisplayCaptureReadiness { .. } => Vec::new(),
 
             AppEvent::VirtualDisplayCreateFailed { reason } => vec![log_event(
                 LogLevel::Error,
@@ -3608,6 +3613,7 @@ mod tests {
         // Losing capture retires availability.
         let lost = u.upcast(&AppEvent::DisplayCaptureLost {
             display_id: 1,
+            capture_generation: None,
             reason: "backend_crashed".into(),
         });
         assert_eq!(lost.len(), 1);
@@ -4448,6 +4454,7 @@ mod tests {
     fn parity_display_capture_lost() {
         assert_parity(AppEvent::DisplayCaptureLost {
             display_id: 1,
+            capture_generation: None,
             reason: "backend_crashed".into(),
         });
     }

--- a/src/bin/caller/presence.rs
+++ b/src/bin/caller/presence.rs
@@ -1141,6 +1141,8 @@ pub fn filter_event(event: &AppEvent, last_phase: &mut String) -> Option<Presenc
         | AppEvent::DebugScreenReady { .. }
         | AppEvent::DebugScreenTornDown { .. }
         | AppEvent::DisplayCaptureLost { .. }
+        | AppEvent::VirtualDisplayCaptureLost { .. }
+        | AppEvent::VirtualDisplayCaptureReadiness { .. }
         | AppEvent::VirtualDisplayCreateFailed { .. }
         | AppEvent::DisplayApprovalPending { .. }
         // Presence sees the display via frames; per-action overlay events

--- a/src/bin/caller/virtual_display.rs
+++ b/src/bin/caller/virtual_display.rs
@@ -27,6 +27,7 @@ use crate::vision;
 use intendant_platform::DisplayTarget;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 /// Xvfb guards for dashboard-created virtual displays, keyed by display
 /// number. Owned as plain task-local state by the user-display listener —
@@ -46,6 +47,8 @@ const MIN_WIDTH: u32 = 320;
 const MIN_HEIGHT: u32 = 240;
 const MAX_WIDTH: u32 = 3840;
 const MAX_HEIGHT: u32 = 2160;
+const CAPTURE_READY_TIMEOUT: Duration = Duration::from_secs(5);
+const CAPTURE_STABILITY_WINDOW: Duration = Duration::from_millis(100);
 
 /// Resolve requested dimensions: defaults for omitted axes, bounds-checked,
 /// rounded down to even (VP8 rejects odd frame dimensions).
@@ -137,17 +140,35 @@ pub(crate) async fn create_virtual_display(
             });
             // Dashboard-created virtual displays are agent workspaces:
             // always agent-visible.
+            let capture_ready_after = Instant::now();
             activate_user_display(bus, session_registry, frame_registry, display_id, true).await;
-            // Activation failure already reported its reason; don't leave a
-            // guarded Xvfb running with no tile and no way to destroy it.
-            // (`get_any` for symmetry — this is lifecycle bookkeeping, not
-            // an agent lookup, though virtual displays are never hidden.)
-            if session_registry.read().await.get_any(display_id).is_none() {
+            // A registry row alone is not capture readiness. The capture
+            // bridge can close immediately after `start_capture` returns and
+            // queue DisplayCaptureLost behind this create intent. Require a
+            // fresh frame and a still-live bridge before completing the
+            // correlated request as Created.
+            let session = session_registry.read().await.get_any(display_id);
+            let readiness = match session.as_ref() {
+                Some(session) => {
+                    await_capture_readiness(
+                        session,
+                        capture_ready_after,
+                        CAPTURE_READY_TIMEOUT,
+                        CAPTURE_STABILITY_WINDOW,
+                    )
+                    .await
+                }
+                None => Err("display activation did not publish a capture session".to_string()),
+            };
+            if let Err(reason) = readiness {
+                if let Some(session) = session_registry.write().await.remove(display_id) {
+                    session.stop().await;
+                }
                 reap_virtual_display(guards, display_id, "activation failed").await;
                 report_virtual_display_create_failed(
                     bus,
                     request_id.as_deref(),
-                    "virtual display create failed: display activation did not publish a capture session",
+                    format!("virtual display create failed: {reason}"),
                 );
             } else if let Some(request_id) = request_id {
                 if !bus.complete_virtual_display_create(
@@ -172,6 +193,26 @@ pub(crate) async fn create_virtual_display(
             );
         }
     }
+}
+
+async fn await_capture_readiness(
+    session: &display::DisplaySession,
+    capture_ready_after: Instant,
+    timeout: Duration,
+    stability_window: Duration,
+) -> Result<(), String> {
+    session
+        .fresh_frame(capture_ready_after, timeout)
+        .await
+        .map_err(|error| format!("capture did not produce a fresh frame: {error}"))?;
+    // Give an immediately closed producer a bounded window to drive the
+    // bridge to completion before the liveness observation. A source that
+    // produced one terminal frame and then died is not a ready display.
+    tokio::time::sleep(stability_window).await;
+    if !session.capture_bridge_running().await {
+        return Err("capture bridge stopped during activation".to_string());
+    }
+    Ok(())
 }
 
 fn report_virtual_display_create_failed(
@@ -240,6 +281,66 @@ fn create_failure_reason(e: &crate::error::CallerError) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::display::{DisplayBackend, Frame, FrameFormat};
+    use intendant_core::error::CallerError;
+    use std::sync::Mutex;
+    use tokio::sync::mpsc;
+
+    struct TestCaptureBackend {
+        keep_sender_alive: bool,
+        sender: Mutex<Option<mpsc::Sender<Frame>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl DisplayBackend for TestCaptureBackend {
+        async fn start_capture(&self, _fps: u32) -> Result<mpsc::Receiver<Frame>, CallerError> {
+            let (tx, rx) = mpsc::channel(2);
+            tx.try_send(Frame {
+                data: vec![0; 640 * 480 * 4],
+                format: FrameFormat::Bgra,
+                width: 640,
+                height: 480,
+                stride: 640 * 4,
+                timestamp: Instant::now(),
+                dirty_rects: None,
+            })
+            .unwrap();
+            if self.keep_sender_alive {
+                *self.sender.lock().unwrap() = Some(tx);
+            }
+            Ok(rx)
+        }
+
+        async fn stop_capture(&self) {
+            self.sender.lock().unwrap().take();
+        }
+
+        async fn inject_input(
+            &self,
+            _event: crate::display::InputEvent,
+        ) -> Result<(), CallerError> {
+            Ok(())
+        }
+
+        fn resolution(&self) -> (u32, u32) {
+            (640, 480)
+        }
+
+        fn kind(&self) -> &'static str {
+            "virtual-display-readiness-test"
+        }
+    }
+
+    async fn started_test_session(keep_sender_alive: bool) -> display::DisplaySession {
+        let backend = Arc::new(TestCaptureBackend {
+            keep_sender_alive,
+            sender: Mutex::new(None),
+        });
+        let session = display::DisplaySession::new(199, backend);
+        session.disable_video_bank();
+        session.start(30, None, None).await.unwrap();
+        session
+    }
 
     #[test]
     fn dimensions_default_to_full_hd() {
@@ -269,6 +370,34 @@ mod tests {
         assert!(virtual_display_dimensions(None, Some(10_000)).is_err());
         let err = virtual_display_dimensions(Some(8000), Some(600)).unwrap_err();
         assert!(err.contains("out of range"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn capture_readiness_requires_a_fresh_frame_and_live_bridge() {
+        let capture_ready_after = Instant::now();
+        let failed = started_test_session(false).await;
+        let error = await_capture_readiness(
+            &failed,
+            capture_ready_after,
+            Duration::from_millis(100),
+            Duration::from_millis(20),
+        )
+        .await
+        .unwrap_err();
+        assert!(error.contains("capture bridge stopped"), "{error}");
+        failed.stop().await;
+
+        let capture_ready_after = Instant::now();
+        let healthy = started_test_session(true).await;
+        await_capture_readiness(
+            &healthy,
+            capture_ready_after,
+            Duration::from_millis(100),
+            Duration::from_millis(20),
+        )
+        .await
+        .unwrap();
+        healthy.stop().await;
     }
 
     #[tokio::test]

--- a/src/bin/caller/virtual_display.rs
+++ b/src/bin/caller/virtual_display.rs
@@ -20,7 +20,7 @@
 
 use crate::display;
 use crate::display_glue::activate_user_display;
-use crate::event::{AppEvent, EventBus};
+use crate::event::{AppEvent, EventBus, VirtualDisplayCreateOutcome};
 use crate::frames;
 use crate::types::LogLevel;
 use crate::vision;
@@ -75,11 +75,13 @@ pub(crate) async fn create_virtual_display(
     guards: &mut VirtualDisplayGuards,
     width: Option<u32>,
     height: Option<u32>,
+    request_id: Option<String>,
 ) {
     // Unsupported platforms bail before any display lifecycle exists.
     if !vision::virtual_displays_supported() {
         report_virtual_display_create_failed(
             bus,
+            request_id.as_deref(),
             "virtual display create failed: virtual displays are Xvfb-based and Linux-only; \
              use \"Your display\" to stream this machine's desktop instead",
         );
@@ -101,7 +103,7 @@ pub(crate) async fn create_virtual_display(
     let (width, height) = match virtual_display_dimensions(width, height) {
         Ok(dims) => dims,
         Err(reason) => {
-            report_virtual_display_create_failed(bus, reason);
+            report_virtual_display_create_failed(bus, request_id.as_deref(), reason);
             return;
         }
     };
@@ -109,6 +111,7 @@ pub(crate) async fn create_virtual_display(
     let Some(config) = vision::virtual_display_config(width, height, &exclude) else {
         report_virtual_display_create_failed(
             bus,
+            request_id.as_deref(),
             "virtual display create failed: no unoccupied X display is available",
         );
         return;
@@ -116,6 +119,7 @@ pub(crate) async fn create_virtual_display(
     let Some(display_id) = virtual_target_id(&config) else {
         report_virtual_display_create_failed(
             bus,
+            request_id.as_deref(),
             "virtual display create failed: allocator returned a non-virtual target",
         );
         return;
@@ -140,18 +144,54 @@ pub(crate) async fn create_virtual_display(
             // an agent lookup, though virtual displays are never hidden.)
             if session_registry.read().await.get_any(display_id).is_none() {
                 reap_virtual_display(guards, display_id, "activation failed").await;
+                report_virtual_display_create_failed(
+                    bus,
+                    request_id.as_deref(),
+                    "virtual display create failed: display activation did not publish a capture session",
+                );
+            } else if let Some(request_id) = request_id {
+                if !bus.complete_virtual_display_create(
+                    &request_id,
+                    VirtualDisplayCreateOutcome::Created {
+                        display_id,
+                        width,
+                        height,
+                    },
+                ) {
+                    eprintln!(
+                        "[virtual_display] create caller no longer waiting for request {request_id}"
+                    );
+                }
             }
         }
         Err(e) => {
-            report_virtual_display_create_failed(bus, create_failure_reason(&e));
+            report_virtual_display_create_failed(
+                bus,
+                request_id.as_deref(),
+                create_failure_reason(&e),
+            );
         }
     }
 }
 
-fn report_virtual_display_create_failed(bus: &EventBus, reason: impl Into<String>) {
+fn report_virtual_display_create_failed(
+    bus: &EventBus,
+    request_id: Option<&str>,
+    reason: impl Into<String>,
+) {
     let reason = reason.into();
     eprintln!("[virtual_display] {reason}");
-    bus.send(AppEvent::VirtualDisplayCreateFailed { reason });
+    bus.send(AppEvent::VirtualDisplayCreateFailed {
+        reason: reason.clone(),
+    });
+    if let Some(request_id) = request_id {
+        if !bus.complete_virtual_display_create(
+            request_id,
+            VirtualDisplayCreateOutcome::Failed { reason },
+        ) {
+            eprintln!("[virtual_display] create caller no longer waiting for request {request_id}");
+        }
+    }
 }
 
 /// Drop the guard for a dashboard-created display, stopping its exact Xvfb
@@ -263,12 +303,44 @@ mod tests {
         let bus = EventBus::new();
         let mut rx = bus.subscribe();
 
-        report_virtual_display_create_failed(&bus, "virtual display create failed: exhausted");
+        report_virtual_display_create_failed(
+            &bus,
+            None,
+            "virtual display create failed: exhausted",
+        );
 
         assert!(matches!(
             rx.recv().await.unwrap(),
             AppEvent::VirtualDisplayCreateFailed { .. }
         ));
         assert!(registry.read().await.get_any(u32::MAX).is_some());
+    }
+
+    #[tokio::test]
+    async fn create_failure_emits_public_lifecycle_and_exact_correlated_result() {
+        let bus = EventBus::new();
+        let mut rx = bus.subscribe();
+        let reason = "virtual display create failed: exhausted";
+        let waiter = bus
+            .register_virtual_display_create_waiter("vdc-request-a".to_string())
+            .unwrap();
+
+        report_virtual_display_create_failed(&bus, Some("vdc-request-a"), reason);
+
+        assert!(matches!(
+            rx.recv().await.unwrap(),
+            AppEvent::VirtualDisplayCreateFailed { reason: emitted } if emitted == reason
+        ));
+        assert_eq!(
+            waiter.wait(std::time::Duration::from_secs(1)).await,
+            Ok(VirtualDisplayCreateOutcome::Failed {
+                reason: reason.to_string()
+            })
+        );
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(10), rx.recv())
+                .await
+                .is_err()
+        );
     }
 }

--- a/src/bin/caller/virtual_display.rs
+++ b/src/bin/caller/virtual_display.rs
@@ -80,6 +80,16 @@ pub(crate) async fn create_virtual_display(
     height: Option<u32>,
     request_id: Option<String>,
 ) {
+    // The lossless intent lane can outlive its synchronous caller. Refuse an
+    // already-cancelled correlated request before allocating an X display;
+    // uncorrelated dashboard creates keep their legacy lifecycle behavior.
+    if let Some(request_id) = request_id.as_deref() {
+        if !bus.virtual_display_create_is_pending(request_id) {
+            eprintln!("[virtual_display] skipped cancelled create request {request_id}");
+            return;
+        }
+    }
+
     // Unsupported platforms bail before any display lifecycle exists.
     if !vision::virtual_displays_supported() {
         report_virtual_display_create_failed(
@@ -180,8 +190,12 @@ pub(crate) async fn create_virtual_display(
                     },
                 ) {
                     eprintln!(
-                        "[virtual_display] create caller no longer waiting for request {request_id}"
+                        "[virtual_display] create caller no longer waiting for request {request_id}; destroying its display"
                     );
+                    if let Some(session) = session_registry.write().await.remove(display_id) {
+                        session.stop().await;
+                    }
+                    reap_virtual_display(guards, display_id, "create caller cancelled").await;
                 }
             }
         }
@@ -398,6 +412,35 @@ mod tests {
         .await
         .unwrap();
         healthy.stop().await;
+    }
+
+    #[tokio::test]
+    async fn cancelled_correlated_request_is_skipped_before_display_lifecycle() {
+        let bus = EventBus::new();
+        let mut events = bus.subscribe();
+        let registry = Arc::new(tokio::sync::RwLock::new(
+            crate::display::SessionRegistry::new(),
+        ));
+        let mut guards = VirtualDisplayGuards::new();
+
+        create_virtual_display(
+            &bus,
+            &registry,
+            None,
+            &mut guards,
+            Some(1280),
+            Some(720),
+            Some("vdc-no-longer-pending".to_string()),
+        )
+        .await;
+
+        assert!(guards.is_empty());
+        assert!(registry.read().await.all_display_ids().is_empty());
+        assert!(
+            tokio::time::timeout(Duration::from_millis(10), events.recv())
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]

--- a/src/bin/caller/virtual_display.rs
+++ b/src/bin/caller/virtual_display.rs
@@ -19,7 +19,7 @@
 //! loss reaps it explicitly.
 
 use crate::display;
-use crate::display_glue::activate_user_display;
+use crate::display_glue::activate_user_display_with_capture_generation;
 use crate::event::{AppEvent, EventBus, VirtualDisplayCreateOutcome};
 use crate::frames;
 use crate::types::LogLevel;
@@ -34,7 +34,59 @@ use std::time::{Duration, Instant};
 /// single consumer, no locking. Async teardown asks the exact child to exit;
 /// Drop hard-kills that child without waiting. Ambiguous residual X state is
 /// preserved and skipped.
-pub(crate) type VirtualDisplayGuards = HashMap<u32, vision::XvfbGuard>;
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct VirtualDisplayOwnership {
+    capture_generation: String,
+    request_id: Option<String>,
+    width: u32,
+    height: u32,
+}
+
+pub(crate) struct VirtualDisplayGuards {
+    processes: HashMap<u32, vision::XvfbGuard>,
+    ownership: HashMap<u32, VirtualDisplayOwnership>,
+}
+
+impl VirtualDisplayGuards {
+    pub(crate) fn new() -> Self {
+        Self {
+            processes: HashMap::new(),
+            ownership: HashMap::new(),
+        }
+    }
+
+    fn keys(&self) -> impl Iterator<Item = &u32> {
+        self.ownership.keys()
+    }
+
+    fn get(&self, display_id: &u32) -> Option<&VirtualDisplayOwnership> {
+        self.ownership.get(display_id)
+    }
+
+    fn get_mut(&mut self, display_id: &u32) -> Option<&mut VirtualDisplayOwnership> {
+        self.ownership.get_mut(display_id)
+    }
+
+    fn insert(
+        &mut self,
+        display_id: u32,
+        guard: vision::XvfbGuard,
+        ownership: VirtualDisplayOwnership,
+    ) {
+        self.processes.insert(display_id, guard);
+        self.ownership.insert(display_id, ownership);
+    }
+
+    fn remove(&mut self, display_id: &u32) -> Option<vision::XvfbGuard> {
+        self.ownership.remove(display_id);
+        self.processes.remove(display_id)
+    }
+
+    #[cfg(test)]
+    fn is_empty(&self) -> bool {
+        self.processes.is_empty() && self.ownership.is_empty()
+    }
+}
 
 /// Default resolution for a dashboard-created display. Human-facing desktop
 /// default — the token-optimized provider resolutions in
@@ -69,8 +121,9 @@ pub(crate) fn virtual_display_dimensions(
 
 /// Handle `ControlMsg::CreateVirtualDisplay`: launch an Xvfb at a free
 /// display number and register its capture session so every dashboard gets
-/// a streaming tile. All failure paths report through
-/// `VirtualDisplayCreateFailed` and never leave an unguarded Xvfb behind.
+/// a streaming tile. Pre-activation failures report through
+/// `VirtualDisplayCreateFailed`; post-publication failures emit an
+/// ID-bearing `DisplayCaptureLost`. No path leaves an unguarded Xvfb behind.
 pub(crate) async fn create_virtual_display(
     bus: &EventBus,
     session_registry: &display::SharedSessionRegistry,
@@ -140,7 +193,17 @@ pub(crate) async fn create_virtual_display(
 
     match vision::launch_display(&config).await {
         Ok(guard) => {
-            guards.insert(display_id, guard);
+            let capture_generation = format!("vdcg-{}", uuid::Uuid::new_v4().simple());
+            guards.insert(
+                display_id,
+                guard,
+                VirtualDisplayOwnership {
+                    capture_generation: capture_generation.clone(),
+                    request_id,
+                    width,
+                    height,
+                },
+            );
             bus.send(AppEvent::PresenceLog {
                 message: format!(
                     "[virtual_display] created :{display_id} ({width}x{height}) from the dashboard"
@@ -151,52 +214,46 @@ pub(crate) async fn create_virtual_display(
             // Dashboard-created virtual displays are agent workspaces:
             // always agent-visible.
             let capture_ready_after = Instant::now();
-            activate_user_display(bus, session_registry, frame_registry, display_id, true).await;
-            // A registry row alone is not capture readiness. The capture
-            // bridge can close immediately after `start_capture` returns and
-            // queue DisplayCaptureLost behind this create intent. Require a
-            // fresh frame and a still-live bridge before completing the
-            // correlated request as Created.
-            let session = session_registry.read().await.get_any(display_id);
-            let readiness = match session.as_ref() {
-                Some(session) => {
-                    await_capture_readiness(
-                        session,
+            activate_user_display_with_capture_generation(
+                bus,
+                session_registry,
+                frame_registry,
+                display_id,
+                true,
+                capture_generation.clone(),
+            )
+            .await;
+            if let Some(session) = session_registry.read().await.get_any(display_id) {
+                let bus = bus.clone();
+                tokio::spawn(async move {
+                    let readiness = await_capture_readiness(
+                        &session,
                         capture_ready_after,
                         CAPTURE_READY_TIMEOUT,
                         CAPTURE_STABILITY_WINDOW,
                     )
-                    .await
-                }
-                None => Err("display activation did not publish a capture session".to_string()),
-            };
-            if let Err(reason) = readiness {
-                if let Some(session) = session_registry.write().await.remove(display_id) {
-                    session.stop().await;
-                }
-                reap_virtual_display(guards, display_id, "activation failed").await;
-                report_virtual_display_create_failed(
-                    bus,
-                    request_id.as_deref(),
-                    format!("virtual display create failed: {reason}"),
-                );
-            } else if let Some(request_id) = request_id {
-                if !bus.complete_virtual_display_create(
-                    &request_id,
-                    VirtualDisplayCreateOutcome::Created {
+                    .await;
+                    let (ready, reason) = match readiness {
+                        Ok(()) => (true, None),
+                        Err(reason) => (false, Some(reason)),
+                    };
+                    bus.send(AppEvent::VirtualDisplayCaptureReadiness {
                         display_id,
-                        width,
-                        height,
-                    },
-                ) {
-                    eprintln!(
-                        "[virtual_display] create caller no longer waiting for request {request_id}; destroying its display"
-                    );
-                    if let Some(session) = session_registry.write().await.remove(display_id) {
-                        session.stop().await;
-                    }
-                    reap_virtual_display(guards, display_id, "create caller cancelled").await;
-                }
+                        capture_generation,
+                        ready,
+                        reason,
+                    });
+                });
+            } else {
+                // Activation normally emits its own generation-bound loss.
+                // Send a redundant correlated failure so a future backend
+                // cannot strand the Xvfb by returning without a registry row
+                // or lifecycle event. Duplicate generations are idempotent.
+                bus.send(AppEvent::VirtualDisplayCaptureLost {
+                    display_id,
+                    capture_generation,
+                    reason: "display activation did not publish a capture session".to_string(),
+                });
             }
         }
         Err(e) => {
@@ -206,6 +263,147 @@ pub(crate) async fn create_virtual_display(
                 create_failure_reason(&e),
             );
         }
+    }
+}
+
+pub(crate) async fn handle_virtual_display_capture_readiness(
+    bus: &EventBus,
+    session_registry: &display::SharedSessionRegistry,
+    guards: &mut VirtualDisplayGuards,
+    display_id: u32,
+    capture_generation: &str,
+    ready: bool,
+    reason: Option<String>,
+) {
+    let Some(ownership) = guards.get(&display_id) else {
+        return;
+    };
+    if ownership.capture_generation != capture_generation {
+        eprintln!(
+            "[virtual_display] ignored stale readiness generation {capture_generation} for :{display_id}"
+        );
+        return;
+    }
+    if !ready {
+        retire_virtual_display_generation(
+            bus,
+            session_registry,
+            guards,
+            display_id,
+            capture_generation,
+            reason.as_deref().unwrap_or("capture readiness failed"),
+        )
+        .await;
+        return;
+    }
+
+    let request_id = ownership.request_id.clone();
+    let width = ownership.width;
+    let height = ownership.height;
+    let Some(request_id) = request_id else {
+        return;
+    };
+    if bus.complete_virtual_display_create(
+        &request_id,
+        VirtualDisplayCreateOutcome::Created {
+            display_id,
+            width,
+            height,
+        },
+    ) {
+        if let Some(ownership) = guards.get_mut(&display_id) {
+            if ownership.capture_generation == capture_generation {
+                ownership.request_id = None;
+            }
+        }
+    } else {
+        retire_virtual_display_generation(
+            bus,
+            session_registry,
+            guards,
+            display_id,
+            capture_generation,
+            "create caller cancelled before capture became ready",
+        )
+        .await;
+    }
+}
+
+pub(crate) async fn handle_virtual_display_capture_lost(
+    bus: &EventBus,
+    session_registry: &display::SharedSessionRegistry,
+    guards: &mut VirtualDisplayGuards,
+    display_id: u32,
+    capture_generation: &str,
+    reason: &str,
+) {
+    retire_virtual_display_generation(
+        bus,
+        session_registry,
+        guards,
+        display_id,
+        capture_generation,
+        reason,
+    )
+    .await;
+}
+
+async fn retire_virtual_display_generation(
+    bus: &EventBus,
+    session_registry: &display::SharedSessionRegistry,
+    guards: &mut VirtualDisplayGuards,
+    display_id: u32,
+    capture_generation: &str,
+    reason: &str,
+) {
+    let Some(ownership) = guards.get(&display_id) else {
+        return;
+    };
+    if ownership.capture_generation != capture_generation {
+        eprintln!(
+            "[virtual_display] ignored stale capture generation {capture_generation} for :{display_id}"
+        );
+        return;
+    }
+    let request_id = ownership.request_id.clone();
+
+    // Publish the ID-bearing retirement before freeing the id. Its intent-lane
+    // copy carries the old generation, so it cannot tear down a replacement.
+    bus.send(AppEvent::DisplayCaptureLost {
+        display_id,
+        capture_generation: Some(capture_generation.to_string()),
+        reason: reason.to_string(),
+    });
+    if let Some(session) = session_registry.write().await.remove(display_id) {
+        session.stop().await;
+    }
+    reap_virtual_display(guards, display_id, "capture unavailable").await;
+    if let Some(request_id) = request_id {
+        let _ = bus.complete_virtual_display_create(
+            &request_id,
+            VirtualDisplayCreateOutcome::Failed {
+                reason: format!("virtual display create failed: {reason}"),
+            },
+        );
+    }
+}
+
+pub(crate) fn fail_pending_virtual_display_create(
+    bus: &EventBus,
+    guards: &mut VirtualDisplayGuards,
+    display_id: u32,
+    reason: &str,
+) {
+    let request_id = guards
+        .get_mut(&display_id)
+        .and_then(|ownership| ownership.request_id.take());
+    if let Some(request_id) = request_id {
+        let _ = bus.complete_virtual_display_create(
+            &request_id,
+            VirtualDisplayCreateOutcome::Failed {
+                reason: reason.to_string(),
+            },
+        );
     }
 }
 
@@ -412,6 +610,139 @@ mod tests {
         .await
         .unwrap();
         healthy.stop().await;
+    }
+
+    #[tokio::test]
+    async fn readiness_and_loss_are_scoped_to_one_capture_generation() {
+        let bus = EventBus::new();
+        let mut events = bus.subscribe();
+        let waiter = bus
+            .register_virtual_display_create_waiter("vdc-generation-test".to_string())
+            .unwrap();
+        let session = Arc::new(started_test_session(true).await);
+        let registry = Arc::new(tokio::sync::RwLock::new(
+            crate::display::SessionRegistry::new(),
+        ));
+        registry.write().await.insert(199, Arc::clone(&session));
+        let mut guards = VirtualDisplayGuards::new();
+        guards.ownership.insert(
+            199,
+            VirtualDisplayOwnership {
+                capture_generation: "generation-current".to_string(),
+                request_id: Some("vdc-generation-test".to_string()),
+                width: 1280,
+                height: 720,
+            },
+        );
+
+        handle_virtual_display_capture_readiness(
+            &bus,
+            &registry,
+            &mut guards,
+            199,
+            "generation-current",
+            true,
+            None,
+        )
+        .await;
+        assert_eq!(
+            waiter.wait(Duration::from_millis(100)).await,
+            Ok(VirtualDisplayCreateOutcome::Created {
+                display_id: 199,
+                width: 1280,
+                height: 720,
+            })
+        );
+        assert_eq!(guards.get(&199).unwrap().request_id, None);
+
+        handle_virtual_display_capture_lost(
+            &bus,
+            &registry,
+            &mut guards,
+            199,
+            "generation-stale",
+            "stale capture stopped",
+        )
+        .await;
+        assert!(guards.get(&199).is_some());
+        assert!(registry.read().await.get_any(199).is_some());
+        assert!(
+            tokio::time::timeout(Duration::from_millis(10), events.recv())
+                .await
+                .is_err()
+        );
+
+        handle_virtual_display_capture_lost(
+            &bus,
+            &registry,
+            &mut guards,
+            199,
+            "generation-current",
+            "capture stopped",
+        )
+        .await;
+        assert!(guards.get(&199).is_none());
+        assert!(registry.read().await.get_any(199).is_none());
+        assert!(matches!(
+            events.recv().await.unwrap(),
+            AppEvent::DisplayCaptureLost {
+                display_id: 199,
+                capture_generation: Some(ref generation),
+                ref reason,
+            } if generation == "generation-current" && reason == "capture stopped"
+        ));
+    }
+
+    #[tokio::test]
+    async fn readiness_failure_publishes_retirement_and_fails_the_exact_waiter() {
+        let bus = EventBus::new();
+        let mut events = bus.subscribe();
+        let waiter = bus
+            .register_virtual_display_create_waiter("vdc-readiness-failed".to_string())
+            .unwrap();
+        let session = Arc::new(started_test_session(true).await);
+        let registry = Arc::new(tokio::sync::RwLock::new(
+            crate::display::SessionRegistry::new(),
+        ));
+        registry.write().await.insert(198, session);
+        let mut guards = VirtualDisplayGuards::new();
+        guards.ownership.insert(
+            198,
+            VirtualDisplayOwnership {
+                capture_generation: "generation-failed".to_string(),
+                request_id: Some("vdc-readiness-failed".to_string()),
+                width: 1280,
+                height: 720,
+            },
+        );
+
+        handle_virtual_display_capture_readiness(
+            &bus,
+            &registry,
+            &mut guards,
+            198,
+            "generation-failed",
+            false,
+            Some("no fresh frame".to_string()),
+        )
+        .await;
+
+        assert_eq!(
+            waiter.wait(Duration::from_millis(100)).await,
+            Ok(VirtualDisplayCreateOutcome::Failed {
+                reason: "virtual display create failed: no fresh frame".to_string(),
+            })
+        );
+        assert!(registry.read().await.get_any(198).is_none());
+        assert!(guards.get(&198).is_none());
+        assert!(matches!(
+            events.recv().await.unwrap(),
+            AppEvent::DisplayCaptureLost {
+                display_id: 198,
+                capture_generation: Some(ref generation),
+                ref reason,
+            } if generation == "generation-failed" && reason == "no fresh frame"
+        ));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Daemon-owned virtual display creation now returns only the terminal result for the exact MCP request that initiated it. This keeps the public display lifecycle unchanged while preventing concurrent callers from consuming one another's ready or failure events.\n\nThe result is machine-readable JSON, remains internal to the local event bus, and preserves older control clients that omit a request ID. Tests cover reversed concurrent completions, stale public and unrelated events, failures, timeouts, closed buses, and wire compatibility.\n\nValidation:\n- cargo test -p intendant --bins\n- cargo test -p intendant-core -p intendant-custody -p intendant-display -p intendant-platform -p owner-plane-core -p owner-plane-reducer\n- cargo test -p intendant --test e2e\n- cargo clippy --workspace -- -D warnings